### PR TITLE
waitidle before send keys to change option

### DIFF
--- a/inst.d/068_user_settings.pm
+++ b/inst.d/068_user_settings.pm
@@ -22,6 +22,7 @@ sub run() {
         sendautotype("$password\t");
     }
     waitforneedle( "inst-userinfostyped", 5 );
+    waitidle 6;
     if ( $ENV{NOAUTOLOGIN} ) {
         sendkey $cmd{"noautologin"};
         waitforneedle( "autologindisabled", 5 );


### PR DESCRIPTION
when I creating needles against new yast theme, I see sendkey $cmd{"noautologin"} sent but sometimes it doesn't applied that seems due to system busy, just give a idle timer before send keys. 
