### PR TITLE
fixup! add travis CI syntax checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-language: perl
+language: c # prevent it from using perlbrew which does not support threads
 install:
+  - sudo apt-get -y install libdata-dump-perl libjson-perl
   - git clone git://github.com/os-autoinst/os-autoinst
-  - cpanm -nq Data::Dump
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 test:
-	export PERL5LIB='../..:os-autoinst:lib' ; for f in `find . -name \*.pm` ; do perl -c $$f 2>&1 | grep -v " OK$$" && exit 2; done ; true
+	export PERL5LIB='../..:os-autoinst:lib' ; for f in `find . -name \*.pm|grep -v /os-autoinst/` ; do perl -c $$f 2>&1 | grep -v " OK$$" && exit 2; done ; true


### PR DESCRIPTION
grep -v /os-autoinst/ is needed to avoid testing code that is not part of this git repo
