### PR TITLE
yast_lan is no longer so important

### DIFF
--- a/consoletest.d/110_hostname.pm
+++ b/consoletest.d/110_hostname.pm
@@ -10,7 +10,7 @@ sub run() {
 }
 
 sub test_flags() {
-    return { 'important' => 1, 'milestone' => 1, };
+    return { 'important' => 1, 'milestone' => 1, 'fatal' => 1 };
 }
 
 1;

--- a/consoletest.d/140_yast2_lan.pm
+++ b/consoletest.d/140_yast2_lan.pm
@@ -47,10 +47,6 @@ sub run() {
     die unless wait_serial "EXIT-0", 2;
 }
 
-sub test_flags() {
-    return { 'milestone' => 1, 'fatal' => 1 };
-}
-
 1;
 
 # vim: set sw=4 et:


### PR DESCRIPTION
the hostname is set in another test, which should be fatal
