### PR TITLE
be careful with missing parenthesis

### DIFF
--- a/consoletest.d/010_consoletest_setup.pm
+++ b/consoletest.d/010_consoletest_setup.pm
@@ -19,8 +19,11 @@ sub run() {
     #type_string 'PS1=\$\ '."\n"; # qemu-0.12.4 can not do backslash yet. http://permalink.gmane.org/gmane.comp.emulators.qemu/71856
 
     script_sudo("chown $username /dev/$serialdev");
-    script_run("curl -sf http://$vars{OPENQA_HOSTNAME}/tests/$vars{TEST_ID}/data | cpio -id ; echo \"cpio-\$?\"> /dev/$serialdev");
-    wait_serial "cpio-0", 10 || die;
+    
+    script_run("curl -v http://$vars{OPENQA_HOSTNAME}/tests/$vars{TEST_ID}/data > test.data; echo \"curl-\$?\" > /dev/$serialdev");
+    wait_serial("curl-0", 10) || die 'curl failed';
+    script_run(" cpio -id < test.data; echo \"cpio-\$?\"> /dev/$serialdev");
+    wait_serial("cpio-0", 10) || die 'cpio failed';
     script_run("ls -al data");
 
     save_screenshot;

--- a/consoletest.d/120_zypper_ref.pm
+++ b/consoletest.d/120_zypper_ref.pm
@@ -38,7 +38,7 @@ sub run() {
     script_run("while pgrep packagekitd; do sleep 1; done");
     save_screenshot;
     script_run("zypper ref && echo 'worked' > /dev/$serialdev");
-    wait_serial "worked", 10 || die "zypper failed";
+    wait_serial("worked", 10) || die "zypper failed";
     assert_screen("zypper_ref");
     type_string "exit\n";
 }

--- a/consoletest.d/880_xfce_gnome_deps.pm
+++ b/consoletest.d/880_xfce_gnome_deps.pm
@@ -16,7 +16,7 @@ sub run() {
     script_run('rpm -qa "*nautilus*|*gnome*" | sort | tee /tmp/xfce-gnome-deps');
     script_sudo('mv /tmp/xfce-gnome-deps /var/log');
     script_run("echo 'gnome_deps_ok' >  /dev/ttyS0");
-    wait_serial 'gnome_deps_ok', 5;
+    wait_serial('gnome_deps_ok', 5);
 
 }
 


### PR DESCRIPTION
wait_serial 'hallo', 5 || die;

_looks_ like dying if wait_serial fails. But indeed, the die is never
evaluated as 5 || die is 5
