### PR TITLE
Factory no longer patches grub2 config

### DIFF
--- a/inst.d/020_bootloader_uefi.pm
+++ b/inst.d/020_bootloader_uefi.pm
@@ -51,18 +51,8 @@ sub run() {
     for ( 1 .. 4 ) { send_key "down"; }
     send_key "end";
     if ( $vars{NETBOOT} && $vars{SUSEMIRROR} ) {
-        my $needle = assert_screen('preselected-repo')->{needle};
-        my $keys;
-        if ( $needle->has_tag('distribution_13_repo') ) {
-            $keys = length(
-                'http://download.opensuse.org/distribution/13.1/repo/oss/');
-        }
-        elsif ( $needle->has_tag('factory_repo') ) {
-            $keys = length('http://download.opensuse.org/factory/repo/oss/');
-        }
-        for ( 1 .. $keys ) { send_key "backspace"; }
-        assert_screen('inst_left');
-        type_string "http://" . $vars{SUSEMIRROR};
+        assert_screen('no_install_url');
+        type_string "install=http://" . $vars{SUSEMIRROR};
         save_screenshot();
     }
     send_key "spc";


### PR DESCRIPTION
linuxrc has the default url now - so openqa plainly needs to overwrite it
