### PR TITLE
merge from sle

### DIFF
--- a/inst.d/020_bootloader.pm
+++ b/inst.d/020_bootloader.pm
@@ -99,6 +99,7 @@ sub run() {
 
     assert_screen "inst-video-typed", 13;
     if ( !$vars{NICEVIDEO} ) {
+        type_string "plymouth.ignore-serial-consoles ", 4; # make plymouth go graphical
         type_string "console=ttyS0 ", 4;    # to get crash dumps as text
         type_string "console=tty ",   4;    # to get crash dumps as text
         assert_screen "inst-consolesettingstyped", 30;
@@ -254,7 +255,7 @@ sub run() {
 
     my $args = "";
     if ( $vars{AUTOYAST} ) {
-        $args .= " netsetup=dhcp,all";
+        $args .= " ifcfg=*=dhcp";
         $args .= " autoyast=http://$vars{OPENQA_HOSTNAME}/test-data/$vars{DISTRI}/data/$vars{AUTOYAST} ";
     }
     type_string $args, 13;
@@ -271,6 +272,11 @@ init 5
 exit
 " );
 
+    }
+
+    if ($vars{FIPS}) {
+        type_string " fips=1", 13;
+        save_screenshot;
     }
 
     # boot

--- a/inst.d/020_bootloader_uefi.pm
+++ b/inst.d/020_bootloader_uefi.pm
@@ -82,15 +82,13 @@ sub run() {
     assert_screen "inst-video-typed-grub2", 13;
 
     if ( !$vars{NICEVIDEO} ) {
-        sleep 15;
+        type_string "plymouth.ignore-serial-consoles ", 7; # make plymouth go graphical
         type_string "console=ttyS0 ";    # to get crash dumps as text
-        sleep 15;
         type_string "console=tty ";      # to get crash dumps as text
         my $e = $vars{EXTRABOOTPARAMS};
 
         #	if($vars{RAIDLEVEL}) {$e="linuxrc=trace"}
-        if ($e) { sleep 10; type_string "$e "; }
-        sleep 15;                          # workaround slow gfxboot drawing 662991
+        if ($e) { type_string "$e "; }
     }
 
     #type_string "kiwidebug=1 ";
@@ -103,7 +101,7 @@ sub run() {
     }
     my $args = "";
     if ( $vars{AUTOYAST} ) {
-        $args .= " netsetup=dhcp,all autoyast=http://$vars{OPENQA_HOSTNAME}/test-data/$vars{DISTRI}/data/$vars{AUTOYAST} ";
+        $args .= " ifcfg=*=dhcp autoyast=http://$vars{OPENQA_HOSTNAME}/test-data/$vars{DISTRI}/data/$vars{AUTOYAST} ";
     }
     type_string $args;
     save_screenshot;


### PR DESCRIPTION
- pass plymouth.ignore-serial-consoles to show graphical boot splash
  even when there is a serial console
- fix netsetup parameters for autoyast
- add optional fips mode
- remove the sleeps in UEFI, works without now
