### PR TITLE
gnome-control-center: wait 2s between search and confirmation

### DIFF
--- a/tests.d/x11/gnome_control_center.pm
+++ b/tests.d/x11/gnome_control_center.pm
@@ -9,7 +9,10 @@ sub run() {
     my $self = shift;
     mouse_hide(1);
     x11_start_program("gnome-control-center");
-    type_string "details\n";
+    type_string "details";
+    # Workaround a glitch in gnome-control-center: if we hit enter to soon, the search reappears
+    sleep 2;
+    send_key "ret";
     assert_screen 'test-gnome_control_center-1', 3;
     send_key "alt-f4";
 }


### PR DESCRIPTION
It's just that, a workaround. Once upstream makes the search cancellable by launching a panel, this will be reverted again (when we no longer run tests for any of the GNOME versions having this issue)
