### PR TITLE
fix rescue cd tests:

### DIFF
--- a/tests.d/x11/xfce_lightdm_logout_login.pm
+++ b/tests.d/x11/xfce_lightdm_logout_login.pm
@@ -2,6 +2,11 @@ use base "xfcestep";
 use strict;
 use bmwqemu;
 
+sub is_applicable {
+    my $self = shift;
+    return $self->SUPER::is_applicable && !( $vars{FLAVOR} eq 'Rescue-CD' );
+}
+
 # log out, check lightdm-gtk-greeter and log in again
 
 # this part contains the steps to run this test

--- a/x11test.d/410_chromium.pm
+++ b/x11test.d/410_chromium.pm
@@ -3,7 +3,7 @@ use bmwqemu;
 
 sub is_applicable {
     my $self = shift;
-    return $self->SUPER::is_applicable && !( $vars{FLAVOR} =~ /^Staging2?[\-]DVD$/ );
+    return $self->SUPER::is_applicable && !( $vars{FLAVOR} =~ /^Staging2?[\-]DVD$/ || $vars{FLAVOR} eq 'Rescue-CD' );
 }
 
 sub run() {


### PR DESCRIPTION
- don't run chromium test on rescue cd - no PackageKit
- don't logout of xfce - too much hassle
