### PR TITLE
for reboot_pre we don't want the generic desktop at the end,

### DIFF
--- a/tests/x11/reboot_gnome_pre.pm
+++ b/tests/x11/reboot_gnome_pre.pm
@@ -1,4 +1,4 @@
-use base "x11test";
+use base "opensusebasetest";
 use testapi;
 
 sub run() {

--- a/tests/x11/reboot_kde_pre.pm
+++ b/tests/x11/reboot_kde_pre.pm
@@ -1,4 +1,4 @@
-use base "x11test";
+use base "opensusebasetest";
 use testapi;
 
 sub run() {

--- a/tests/x11/reboot_lxde_pre.pm
+++ b/tests/x11/reboot_lxde_pre.pm
@@ -1,4 +1,4 @@
-use base "x11test";
+use base "opensusebasetest";
 use testapi;
 
 sub run() {

--- a/tests/x11/reboot_xfce_pre.pm
+++ b/tests/x11/reboot_xfce_pre.pm
@@ -1,4 +1,4 @@
-use base "x11test";
+use base "opensusebasetest";
 use testapi;
 
 sub run() {


### PR DESCRIPTION
so we should not inherit x11test
