### PR TITLE
consoletest_setup: after the setup is installed, it is still a LIVECD

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -20,7 +20,7 @@ sub run() {
     assert_screen "tty4-selected", 10;
     assert_screen "text-login", 10;
     type_string "$username\n";
-    if (!get_var("LIVECD")) {
+    if (!get_var("LIVETEST")) {
         assert_screen "password-prompt", 10;
         type_password;
         type_string "\n";


### PR DESCRIPTION
testrun, but now the user has a password.

So instead of checking for LIVECD, we check for LIVETEST to not await a
password prompt.
