### PR TITLE
bootloader: there is no variable RESCUECD, so let's check the FLAVOR to ...

### DIFF
--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -28,12 +28,6 @@ sub run() {
         return;
     }
 
-    # type_string "kiwidebug=1 ";
-
-    if ( get_var("RESCUECD") ) {
-        send_key "ret";    # boot
-        return;
-    }
 
     if (get_var("UPGRADE")) {
         $self->bootmenu_down_to('inst-onupgrade');


### PR DESCRIPTION
That should hopefully help in identifying that we just have to boot there... or any other, better way to identify this being a Rescue-CD?
