### PR TITLE
setup_zdup: reaching a login prompt in 15s is certainly nice, but not al...

### DIFF
--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -28,7 +28,7 @@ sub run() {
     # login, again : )
     assert_screen "grub2", 10; # boot menu appears
     send_key "ret";
-    assert_screen "linux-login", 15; # login prompt appears
+    assert_screen "linux-login", 30; # login prompt appears
     type_string "$username\n";
     sleep 2;
     type_password;


### PR DESCRIPTION
...ways reaslistic - give it 30s to reach the text login

As is seen in https://openqa.opensuse.org/tests/39193 : the video shows that the boot is still going on; so we are really just too quickly reaching conclusion of failure
