### PR TITLE
Run yaboot test on Power for SLE11

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -297,7 +297,7 @@ sub load_boot_tests(){
         loadtest "installation/isosize.pm";
     }
     if (get_var("OFW")) {
-        loadtest "installation/bootloader_ofw.pm";
+        loadtest "installation/bootloader_ofw_yaboot.pm";
     }
     elsif (get_var("UEFI")) {
         loadtest "installation/bootloader_uefi.pm";


### PR DESCRIPTION
SLES11 have yaboot as a bootloader.

Signed-off-by: Dinar Valeev <dvaleev@suse.com>