### PR TITLE
Working test for Software Raid partitioning

### DIFF
--- a/tests/installation/select_patterns.pm
+++ b/tests/installation/select_patterns.pm
@@ -5,7 +5,7 @@ use testapi;
 sub key_round($$) {
     my ($tag, $key) = @_;
 
-    my $counter = 10;
+    my $counter = 15;
     while ( !check_screen( $tag, 1 ) ) {
         send_key $key;
         if (!$counter--) {


### PR DESCRIPTION
Works for for all raid levels and filesystems

$counter for keyround in select_patterns increased to 15 to cover the fact it needs more keypresses when YaST expertmode is triggered by 4 present disks.