### PR TITLE
Make installation_overview spot YaST's warning of dependency issues and ...

### DIFF
--- a/tests/installation/addon_products.pm
+++ b/tests/installation/addon_products.pm
@@ -55,8 +55,8 @@ sub run() {
             key_round 'addon-dvd-list', 'tab';
             key_round "addon-dvd-$a", 'down';
             send_key 'alt-o';
-            #Remove '&& ($a ne "sdk")' when boo912256 is fixed, remove '&& ($a ne "geo")' when boo912300 is fixed
-            if (get_var("BETA") && ($a ne "sdk") && ($a ne "geo")) {
+            # remove '&& ($a ne "geo")' when boo912300 is fixed
+            if (get_var("BETA") && ($a ne "geo")) {
                 assert_screen "addon-betawarning-$a", 10;
                 send_key "ret";
                 assert_screen "addon-license-beta", 10;

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -3,6 +3,19 @@ use strict;
 use base "y2logsstep";
 use testapi;
 
+sub key_round($$) {
+    my ($tag, $key) = @_;
+
+    my $counter = 15;
+    while ( !check_screen( $tag, 1 ) ) {
+        send_key $key;
+        if (!$counter--) {
+            # DIE!
+            assert_screen $tag, 1;
+        }
+    }
+}
+
 sub run() {
 
     # overview-generation
@@ -11,6 +24,25 @@ sub run() {
 
     # preserve it for the video
     wait_idle 10;
+    
+    # check for dependancy issues, if found, drill down to software selection, take a screenshot, then die
+    if (check_screen("inst-overview-dep-warning",1)){
+       
+        if (check_var('VIDEOMODE', 'text')) {
+            send_key 'alt-c';
+            assert_screen 'inst-overview-options', 3;
+            send_key 'alt-s';
+        }
+        else {
+            key_round 'packages-section-selected', 'tab';
+            send_key 'ret';
+        }
+        
+        assert_screen 'pattern_selector';
+        send_key 'alt-o';
+        assert_screen 'dependancy-issue', 5;
+        die "Dependency Warning Detected"
+    }
 }
 
 1;

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -25,7 +25,7 @@ sub run() {
     # preserve it for the video
     wait_idle 10;
     
-    # check for dependancy issues, if found, drill down to software selection, take a screenshot, then die
+    # check for dependency issues, if found, drill down to software selection, take a screenshot, then die
     if (check_screen("inst-overview-dep-warning",1)){
        
         if (check_var('VIDEOMODE', 'text')) {


### PR DESCRIPTION
...drill down/provide extra info if they appear (good for dependency bug reports..and we've had a lot of these with SLE11 already)