### PR TITLE
Replace DEFAULT_WALLPAPER variable with WALLPAPER variable

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -135,7 +135,7 @@ if ( check_var( 'DESKTOP', 'minimalx' ) ) {
 # openSUSE specific variables
 set_var("SUSEMIRROR", "download.opensuse.org/factory") unless get_var('SUSEMIRROR');
 set_var("PACKAGETOINSTALL", "xdelta");
-set_var("DEFAULT_WALLPAPER", 'openSUSEdefault');
+set_var("WALLPAPER", '/usr/share/wallpapers/openSUSEdefault/contents/images/1280x1024.jpg');
 set_var("YAST_SW_NO_SUMMARY", 1) if get_var('UPGRADE') || get_var("ZDUP");
 
 # set KDE and GNOME, ...

--- a/tests/x11/eog.pm
+++ b/tests/x11/eog.pm
@@ -8,7 +8,7 @@ use testapi;
 # this part contains the steps to run this test
 sub run() {
     my $self = shift;
-    x11_start_program("eog /usr/share/wallpapers/" . get_var("DEFAULT_WALLPAPER") . "/contents/images/1280x1024.jpg");
+    x11_start_program("eog " . get_var("WALLPAPER"));
     sleep 2;
     assert_screen 'test-eog-1', 3;
     sleep 2;


### PR DESCRIPTION
With this variable rename, a full path for wallpaper is used for eog test.