### PR TITLE
hack for aarch64

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -276,6 +276,9 @@ sub load_boot_tests(){
     if (get_var("OFW")) {
         loadtest "installation/bootloader_ofw.pm";
     }
+    elsif (check_var("ARCH", "aarch64")) {
+        loadtest "installation/bootloader_aarch64.pm";
+    }
     elsif (get_var("UEFI")) {
         loadtest "installation/bootloader_uefi.pm";
     }

--- a/tests/installation/bootloader_aarch64.pm
+++ b/tests/installation/bootloader_aarch64.pm
@@ -1,0 +1,29 @@
+# Copyright (C) 2015 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use base "installbasetest";
+use strict;
+use testapi;
+
+sub run() {
+    my ($self) = @_;
+
+    wait_serial('The highlighted entry will be executed automatically') || die "not found";
+    wait_serial("Booting `Installation'", 70);
+}
+
+1;
+# vim: et sw=4


### PR DESCRIPTION
aarch64 uefi firmware doesn't have graphical output yet. So we can't
do anything at the bootloader except waiting for it on the serial
console.