### PR TITLE
Honor textmode setting for PowerPC bootloader

### DIFF
--- a/tests/installation/bootloader_ofw.pm
+++ b/tests/installation/bootloader_ofw.pm
@@ -9,7 +9,18 @@ sub run() {
     send_key "up";
     send_key "up";
     send_key "up";
-    send_key "ret";
+    if (check_var('VIDEOMODE', 'text')) {
+       send_key "e";
+       send_key "down";
+       send_key "down";
+       send_key "down";
+       send_key "end";
+       type_string " textmode=1", 15;
+       send_key "ctrl-x";
+    }
+    else {
+       send_key "ret";
+    }
 }
 
 1;

--- a/tests/installation/bootloader_ofw_yaboot.pm
+++ b/tests/installation/bootloader_ofw_yaboot.pm
@@ -6,6 +6,9 @@ use Time::HiRes qw(sleep);
 # hint: press shift-f10 trice for highest debug level
 sub run() {
     assert_screen "bootloader-ofw-yaboot", 15;
+    if (check_var('VIDEOMODE', 'text')) {
+       type_string "install textmode=1", 15;
+    }
     send_key "ret";
 }
 


### PR DESCRIPTION
In case VIDEOMODE is text we need to pass appropriate options to linux

Signed-off-by: Dinar Valeev <dvaleev@suse.com>