### PR TITLE
Set new keyboard shortcuts for libyui-qt >= 2.46.16

### DIFF
--- a/tests/installation/installer_desktopselection.pm
+++ b/tests/installation/installer_desktopselection.pm
@@ -4,7 +4,7 @@ use base "y2logsstep";
 use testapi;
 
 sub run() {
-    my %desktopkeys = ( kde => "k", gnome => "g", xfce => "x", lxde => "l", minimalx => "m", textmode => "i" );
+    my %desktopkeys = ( kde => "k", gnome => "g", xfce => "f", lxde => "x", minimalx => "m", textmode => "i" );
     assert_screen "desktop-selection", 30;
     my $d = get_var("DESKTOP");
     my $key = "alt-$desktopkeys{$d}";


### PR DESCRIPTION
Release Notes was added as a global shortcut, occupying 'l', thus moving
LXDE to X and XFCE to F.