### PR TITLE
Fixed release notes issue in case of sdk addon

### DIFF
--- a/tests/installation/sle11_releasenotes.pm
+++ b/tests/installation/sle11_releasenotes.pm
@@ -29,14 +29,19 @@ sub run(){
             send_key 'alt-s';
             assert_screen "release-notes-sle";
         }
+        elsif (check_screen 'release-notes-sle') {	# same release notes for sdk 
+			assert_screen "release-notes-sle";
+		}
         else {
             foreach $a (split(/,/, get_var('ADDONS'))) {
-                send_key 'alt-p';
-                send_key ' ';
-                send_key 'pgup';
-                key_round "release-notes-list-$a", 'down';
-                send_key 'ret';
-                assert_screen "release-notes-$a";
+                if ($a ne "sdk") {	# sdk has no releasenotes
+                    send_key 'alt-p';
+                    send_key ' ';
+                    send_key 'pgup';
+                    key_round "release-notes-list-$a", 'down';
+                    send_key 'ret';
+                    assert_screen "release-notes-$a";
+                }
             }
             send_key 'alt-p';
             send_key ' ';


### PR DESCRIPTION

![release-notes-list-sles-20150204](https://cloud.githubusercontent.com/assets/9447312/6276360/893f62c8-b886-11e4-8fcb-b8583e6dc759.png)
SDK addon has no release notes, I'm not sure if it's legit, I added code to use release-notes-sle in case of single SDK addon and ignore SDK in case of release-notes-list.
Tested with testsuites:
gnome       http://10.100.98.90/tests/43
update_sle11_sp3       http://10.100.98.90/tests/44
update_sle11_sp3_sdk      http://10.100.98.90/tests/50
update_sle11_sp3_ha        http://10.100.98.90/tests/52
update_sle11_sp3_sdk_ha_geo      http://10.100.98.90/tests/51