### PR TITLE
Changed time before assert screen mediacheck test

### DIFF
--- a/tests/installation/mediacheck.pm
+++ b/tests/installation/mediacheck.pm
@@ -10,7 +10,7 @@ sub run {
     $self->bootmenu_down_to('inst-onmediacheck');
     send_key "ret";
     # the timeout is insane - but SLE11 DVDs take almost forever
-    assert_screen "mediacheck-ok", 1000;
+    assert_screen "mediacheck-ok", 1600;
     send_key "ret";
 }
 


### PR DESCRIPTION
Proposing to change the assert time, as it was observed that test is failing because the machine was under heavy load  while running the mediacheck test.