### PR TITLE
Restructuring HA tests

### DIFF
--- a/tests/ha/ha_preparation.pm
+++ b/tests/ha/ha_preparation.pm
@@ -78,7 +78,15 @@ sub run() {
         rebootvm "$i";
     }
     sleep 120; # give them all time to reboot
-    for my $i ( 1 .. 3 ) {
+    #FIXME - quick hack
+    type_string "ssh 10.0.2.16 -l root\n";
+    sleep 10;
+    type_string "nots3cr3t\n";
+    sleep 10;
+    check_screen 'ha-ssh-login', 40; #should be assert
+    send_key 'ctrl-l';
+    send_key 'ctrl-pgdn';
+    for my $i ( 2.. 3 ) { #should be 1-3, see above FIXME
         connectssh "$i";
         send_key 'ctrl-pgdn';
     }

--- a/tests/ha/ha_preparation.pm
+++ b/tests/ha/ha_preparation.pm
@@ -35,6 +35,8 @@ sub fixvmnetwork($) {
     sleep 5;
     type_string "/etc/init.d/network restart\n";
     sleep 10;
+    type_string "chkconfig sshd on\n";
+    sleep 5;
     type_string "exit\n";
     send_key 'f8'; #screen check
     send_key 'down'; #screen check

--- a/tests/ha/ha_preparation.pm
+++ b/tests/ha/ha_preparation.pm
@@ -1,0 +1,109 @@
+use base "installbasetest";
+use testapi;
+use autotest;
+
+sub connectssh($) {
+    my ($nodenum) = @_;
+    my $nodeip = 5+$nodenum; 
+    type_string "ssh 10.0.2.1$nodeip -l root\n";
+    sleep 10;
+    type_string "nots3cr3t\n";
+    sleep 10;
+    check_screen 'ha-ssh-login', 40; #should be assert
+    send_key 'ctrl-l';
+}
+
+sub startvm($) {
+    my ($nodenum) = @_;
+    my $nodemac = 6+$nodenum;
+    type_string "su -c 'qemu-kvm -m 1024 -vga cirrus -drive file=node$nodenum.img,id=hd1 -cdrom /dev/sr0 -drive if=scsi,id=addon_1,file=/dev/sr1,media=cdrom -drive if=scsi,id=addon_2,file=/dev/sr2,media=cdrom -drive if=scsi,id=addon_3,file=/dev/sr3,media=cdrom -vnc :9$nodenum,share=force-shared -netdev bridge,id=hn0 -device virtio-net,netdev=hn0,mac=52:54:00:12:34:5$nodemac &'\n";
+    sleep 5;
+    type_string "nots3cr3t\n";
+    sleep 5;
+    send_key 'ctrl-l';
+}
+
+sub fixvmnetwork($) {
+    my ($nodenum) = @_;
+    type_string "vncviewer localhost:9$nodenum -shared -fullscreen\n"; #screen check
+    check_screen 'vm-login', 40; #screen check
+    type_string "root\n";
+    sleep 5;
+    type_string "nots3cr3t\n";
+    sleep 5;
+    type_string "sed -i 's/eth0/eth1/g' /etc/sysconfig/network/ifcfg-*\n";
+    sleep 5;
+    type_string "/etc/init.d/network restart\n";
+    sleep 5;
+    send_key 'f8'; #screen check
+    send_key 'down'; #screen check
+    send_key 'ret'; #screen check
+    sleep 5;
+    send_key 'ctrl-l';
+}
+
+sub run() {
+    # TODO - Make this your snapshot,  this is where you want to restart every time you need to re-run HA validation
+    type_string "cp node1.img node2.img && cp node1.img node3.img\n"; #copy disk image two new imgs
+    assert_screen 'ha-copy-finished', 500;
+    for my $i ( 1 .. 3 ) {
+        startvm "$i";
+    }
+    sleep 120; # give them all time to boot up
+    for my $i ( 2 .. 3 ) {
+        fixvmnetwork "$i";
+    }
+    for my $i ( 1 .. 3 ) {
+        connectssh "$i";
+        send_key 'ctrl-pgdn';
+    }
+    send_key 'ctrl-alt-g';
+    type_string "zypper -n in yast2-iscsi-client open-iscsi\n";
+    sleep 60; # Give it some time to do the install
+    type_string "echo '10.0.2.16    node1' >> /etc/hosts\n";
+    type_string "echo '10.0.2.17    node2' >> /etc/hosts\n";
+    type_string "echo '10.0.2.18    node3' >> /etc/hosts\n";
+    send_key 'shift-ctrl-alt-g';
+    type_string "echo 'InitiatorName=iqn.1996-04.de.suse:01:8f4aff8c879' > /etc/iscsi/initiatorname.iscsi\n";
+    type_string "echo 'node1' > /etc/hostname\n";
+    type_string "echo 'node1' > /etc/HOSTNAME\n";
+    type_string "hostname node1\n";
+    send_key 'ctrl-pgdn';
+    type_string "echo 'InitiatorName=iqn.1996-04.de.suse:01:8f4aff8c878' > /etc/iscsi/initiatorname.iscsi\n";
+    type_string "echo 'node2' > /etc/hostname\n";
+    type_string "echo 'node2' > /etc/HOSTNAME\n";
+    type_string "hostname node2\n";
+    send_key 'ctrl-pgdn';
+    type_string "echo 'InitiatorName=iqn.1996-04.de.suse:01:8f4aff8c877' > /etc/iscsi/initiatorname.iscsi\n";
+    type_string "echo 'node3' > /etc/hostname\n";
+    type_string "echo 'node3' > /etc/HOSTNAME\n";
+    type_string "hostname node3\n";
+    send_key 'ctrl-pgup';
+    send_key 'ctrl-pgup';
+    send_key 'ctrl-alt-g';
+    type_string "yast iscsi-client\n";
+    assert_screen 'yast-iscsi-client-loaded';
+    send_key 'alt-b';
+    send_key 'alt-v';
+    assert_screen 'yast-iscsi-discovered-targets';
+    send_key 'alt-d';
+    assert_screen 'yast-iscsi-initiator-discovery';
+    send_key 'alt-i';
+    type_string '10.0.2.15';
+    send_key 'alt-n';
+    assert_screen 'yast-iscsi-discovered-targets';
+    send_key 'alt-l';
+    assert_screen 'yast-iscsi-initiator-login';
+    send_key 'alt-s';
+    send_key 'down';
+    send_key 'down';
+    send_key 'ret';
+    send_key 'alt-n';
+    assert_screen 'yast-iscsi-discovered-targets';
+    send_key 'alt-o';
+    sleep 5;
+    send_key 'ctrl-l';
+    assert_screen 'proxy-terminator-clean';
+}
+
+1;

--- a/tests/ha/ha_preparation.pm
+++ b/tests/ha/ha_preparation.pm
@@ -34,12 +34,31 @@ sub fixvmnetwork($) {
     type_string "sed -i 's/eth0/eth1/g' /etc/sysconfig/network/ifcfg-*\n";
     sleep 5;
     type_string "/etc/init.d/network restart\n";
-    sleep 5;
+    sleep 10;
+    type_string "exit\n";
     send_key 'f8'; #screen check
     send_key 'down'; #screen check
     send_key 'ret'; #screen check
     sleep 5;
     send_key 'ctrl-l';
+}
+
+sub rebootvm($) {
+my ($nodenum) = @_;
+    type_string "vncviewer localhost:9$nodenum -shared -fullscreen\n"; #screen check
+    check_screen 'vm-login', 40; #screen check
+    type_string "root\n";
+    sleep 5;
+    type_string "nots3cr3t\n";
+    sleep 5;
+    type_string "init 6\n";
+    send_key 'f8'; #screen check
+    send_key 'down'; #screen check
+    send_key 'ret'; #screen check
+    sleep 5;
+    send_key 'ctrl-l';
+}
+
 }
 
 sub run() {
@@ -53,6 +72,10 @@ sub run() {
     for my $i ( 2 .. 3 ) {
         fixvmnetwork "$i";
     }
+    for my $i ( 1 .. 3 ) {
+        rebootvm "$i";
+    }
+    sleep 120; # give them all time to reboot
     for my $i ( 1 .. 3 ) {
         connectssh "$i";
         send_key 'ctrl-pgdn';

--- a/tests/ha/ha_preparation.pm
+++ b/tests/ha/ha_preparation.pm
@@ -103,30 +103,6 @@ sub run() {
     type_string "hostname node3\n";
     send_key 'ctrl-pgup';
     send_key 'ctrl-pgup';
-    send_key 'ctrl-alt-g';
-    type_string "yast iscsi-client\n";
-    assert_screen 'yast-iscsi-client-loaded';
-    send_key 'alt-b';
-    send_key 'alt-v';
-    assert_screen 'yast-iscsi-discovered-targets';
-    send_key 'alt-d';
-    assert_screen 'yast-iscsi-initiator-discovery';
-    send_key 'alt-i';
-    type_string '10.0.2.15';
-    send_key 'alt-n';
-    assert_screen 'yast-iscsi-discovered-targets';
-    send_key 'alt-l';
-    assert_screen 'yast-iscsi-initiator-login';
-    send_key 'alt-s';
-    send_key 'down';
-    send_key 'down';
-    send_key 'ret';
-    send_key 'alt-n';
-    assert_screen 'yast-iscsi-discovered-targets';
-    send_key 'alt-o';
-    sleep 5;
-    send_key 'ctrl-l';
-    assert_screen 'proxy-terminator-clean';
 }
 
 1;

--- a/tests/ha/ha_preparation.pm
+++ b/tests/ha/ha_preparation.pm
@@ -7,6 +7,8 @@ sub connectssh($) {
     my $nodeip = 5+$nodenum; 
     type_string "ssh 10.0.2.1$nodeip -l root\n";
     sleep 10;
+    type_string "yes\n";
+    sleep 10;
     type_string "nots3cr3t\n";
     sleep 10;
     check_screen 'ha-ssh-login', 40; #should be assert
@@ -35,8 +37,6 @@ sub fixvmnetwork($) {
     sleep 5;
     type_string "/etc/init.d/network restart\n";
     sleep 10;
-    type_string "chkconfig sshd on\n";
-    sleep 5;
     type_string "exit\n";
     send_key 'f8'; #screen check
     send_key 'down'; #screen check
@@ -52,6 +52,8 @@ my ($nodenum) = @_;
     type_string "root\n";
     sleep 5;
     type_string "nots3cr3t\n";
+    sleep 5;
+    type_string "chkconfig sshd on\n";
     sleep 5;
     type_string "init 6\n";
     send_key 'f8'; #screen check

--- a/tests/ha/ha_preparation.pm
+++ b/tests/ha/ha_preparation.pm
@@ -59,8 +59,6 @@ my ($nodenum) = @_;
     send_key 'ctrl-l';
 }
 
-}
-
 sub run() {
     # TODO - Make this your snapshot,  this is where you want to restart every time you need to re-run HA validation
     type_string "cp node1.img node2.img && cp node1.img node3.img\n"; #copy disk image two new imgs

--- a/tests/ha/ha_vm_shutdown.pm
+++ b/tests/ha/ha_vm_shutdown.pm
@@ -1,0 +1,13 @@
+use base "installbasetest";
+use testapi;
+use autotest;
+
+sub run() {
+    assert_screen 'linux-login', 200;
+    type_string "init 0\n"; #shutdown VM
+    check_screen 'proxy-terminal',30;
+    send_key 'ctrl-l';
+    sleep 60; #Give it 60 seconds to shut down the VM
+}
+
+1;

--- a/tests/ha/hawk.pm
+++ b/tests/ha/hawk.pm
@@ -12,7 +12,8 @@ sub run() {
     #assert_and_click 'firefox-add-exception';
     send_key 'tab';
     send_key 'ret';
-    assert_and_click 'firefox-confirm-exception';
+    #assert_and_click 'firefox-confirm-exception';
+    send_key 'alt-c';
     assert_screen 'hawk-login';
     assert_and_click 'hawk-username';
     type_string 'hacluster';

--- a/tests/ha/iscsi_config.pm
+++ b/tests/ha/iscsi_config.pm
@@ -3,31 +3,6 @@ use testapi;
 use autotest;
 
 sub run() {
-    if (check_var('DESKTOP', 'textmode')) {
-        assert_screen 'linux-login', 200;
-    }
-    type_string "zypper -n in yast2-iscsi-client open-iscsi\n";
-    sleep 60; # Give it some time to do the install
-    type_string "echo '10.0.2.16    node1' >> /etc/hosts\n";
-    type_string "echo '10.0.2.17    node2' >> /etc/hosts\n";
-    type_string "echo '10.0.2.18    node3' >> /etc/hosts\n";
-    send_key 'shift-ctrl-alt-g';
-    type_string "echo 'InitiatorName=iqn.1996-04.de.suse:01:8f4aff8c879' > /etc/iscsi/initiatorname.iscsi\n";
-    type_string "echo 'node1' > /etc/hostname\n";
-    type_string "echo 'node1' > /etc/HOSTNAME\n";
-    type_string "hostname node1\n";
-    send_key 'ctrl-pgdn';
-    type_string "echo 'InitiatorName=iqn.1996-04.de.suse:01:8f4aff8c878' > /etc/iscsi/initiatorname.iscsi\n";
-    type_string "echo 'node2' > /etc/hostname\n";
-    type_string "echo 'node2' > /etc/HOSTNAME\n";
-    type_string "hostname node2\n";
-    send_key 'ctrl-pgdn';
-    type_string "echo 'InitiatorName=iqn.1996-04.de.suse:01:8f4aff8c877' > /etc/iscsi/initiatorname.iscsi\n";
-    type_string "echo 'node3' > /etc/hostname\n";
-    type_string "echo 'node3' > /etc/HOSTNAME\n";
-    type_string "hostname node3\n";
-    send_key 'ctrl-pgup';
-    send_key 'ctrl-pgup';
     send_key 'ctrl-alt-g';
     type_string "yast iscsi-client\n";
     assert_screen 'yast-iscsi-client-loaded';

--- a/tests/installation/proxy_init.pm
+++ b/tests/installation/proxy_init.pm
@@ -20,6 +20,7 @@ sub createhavm($) {
     script_run "qemu-img create -f qcow2 node$nodenum.img 10G";
     my $nodemac = 6+$nodenum;
     type_string "su -c 'qemu-kvm -m 1024 -vga cirrus -drive file=node$nodenum.img,id=hd1 -cdrom /dev/sr0 -drive if=scsi,id=addon_1,file=/dev/sr1,media=cdrom -drive if=scsi,id=addon_2,file=/dev/sr2,media=cdrom -drive if=scsi,id=addon_3,file=/dev/sr3,media=cdrom -vnc :9$nodenum,share=force-shared -netdev bridge,id=hn0 -device virtio-net,netdev=hn0,mac=52:54:00:12:34:5$nodemac &'\n";
+    sleep 5;
     type_string "nots3cr3t\n";
     sleep 5;
     type_string "vncviewer localhost:9$nodenum -shared -fullscreen\n";
@@ -43,7 +44,7 @@ sub run() {
     assert_screen 'proxy-terminator-started';
     send_key 'ctrl-pgup';
     send_key 'ctrl-pgup';
-    for my $i ( 1 .. 3 ) {
+    for my $i ( 1 .. 1 ) { #FIXME - Reduced to one to do cloning instead
         createhavm "$i";
     }
 }

--- a/tests/installation/proxy_init.pm
+++ b/tests/installation/proxy_init.pm
@@ -15,7 +15,7 @@ sub key_round($$) {
     }
 }
 
-sub createhavm($) {
+sub createvm($) {
     my ($nodenum) = @_;
     script_run "qemu-img create -f qcow2 node$nodenum.img 10G";
     my $nodemac = 6+$nodenum;
@@ -44,9 +44,7 @@ sub run() {
     assert_screen 'proxy-terminator-started';
     send_key 'ctrl-pgup';
     send_key 'ctrl-pgup';
-    for my $i ( 1 .. 1 ) { #FIXME - Reduced to one to do cloning instead
-        createhavm "$i";
-    }
+    createvm "1"; # only need one VM now
 }
 
 1;

--- a/tests/installation/proxy_ssh.pm
+++ b/tests/installation/proxy_ssh.pm
@@ -16,11 +16,11 @@ sub starthainstall($) {
 
 sub run() {
     assert_screen 'proxy-terminator-clean';
-    for my $i ( 1 .. 3 ) {
+    for my $i ( 1 .. 1 ) { #FIXME - Reduced to one to do cloning instead
         starthainstall "$i";
-        send_key 'ctrl-pgdn';
+        #send_key 'ctrl-pgdn'; #FIXME - Removed as no longer installing in parralel
     }
-    send_key 'ctrl-alt-g'; #group all tabs together (changed in the vm from meta-g default)
+    #send_key 'ctrl-alt-g'; #group all tabs together (changed in the vm from meta-g default) #FIXME - Removed as no longer installing in parralel
 }
 
 1;

--- a/tests/installation/proxy_ssh.pm
+++ b/tests/installation/proxy_ssh.pm
@@ -2,7 +2,7 @@ use base "installbasetest";
 use strict;
 use testapi;
 
-sub starthainstall($) {
+sub startsshinstall($) {
     my ($nodenum) = @_;
     my $nodeip = 5+$nodenum;
     type_string "ssh 10.0.2.1$nodeip -l root\n";
@@ -16,11 +16,7 @@ sub starthainstall($) {
 
 sub run() {
     assert_screen 'proxy-terminator-clean';
-    for my $i ( 1 .. 1 ) { #FIXME - Reduced to one to do cloning instead
-        starthainstall "$i";
-        #send_key 'ctrl-pgdn'; #FIXME - Removed as no longer installing in parralel
-    }
-    #send_key 'ctrl-alt-g'; #group all tabs together (changed in the vm from meta-g default) #FIXME - Removed as no longer installing in parralel
+    startsshinstall "1"; # only need one VM now
 }
 
 1;

--- a/tests/installation/proxy_start_2nd_stage.pm
+++ b/tests/installation/proxy_start_2nd_stage.pm
@@ -2,7 +2,7 @@ use base "installbasetest";
 use strict;
 use testapi;
 
-sub reconnecthainstall($) {
+sub reconnectsshinstall($) {
     my ($nodenum) = @_;
     my $nodeip = 5+$nodenum;
     type_string "ssh 10.0.2.1$nodeip -l root\n";
@@ -15,12 +15,7 @@ sub reconnecthainstall($) {
 
 sub run() {
     sleep 240; #500 is too long, seems to shut down the VMs
-    #send_key 'shift-ctrl-alt-g'; #FIXME - Removed as no longer installing in parralel
-    for my $i ( 1 .. 1 ) { #FIXME - Reduced to one to do cloning instead
-        reconnecthainstall "$i";
-        #send_key 'ctrl-pgdn'; #FIXME - Removed as no longer installing in parralel
-    }
-    #send_key 'ctrl-alt-g'; #FIXME - Removed as no longer installing in parralel
+    reconnecthainstall "1";
 }
 
 1;

--- a/tests/installation/proxy_start_2nd_stage.pm
+++ b/tests/installation/proxy_start_2nd_stage.pm
@@ -15,7 +15,7 @@ sub reconnectsshinstall($) {
 
 sub run() {
     sleep 240; #500 is too long, seems to shut down the VMs
-    reconnecthainstall "1";
+    reconnectsshinstall "1";
 }
 
 1;

--- a/tests/installation/proxy_start_2nd_stage.pm
+++ b/tests/installation/proxy_start_2nd_stage.pm
@@ -15,12 +15,12 @@ sub reconnecthainstall($) {
 
 sub run() {
     sleep 240; #500 is too long, seems to shut down the VMs
-    send_key 'shift-ctrl-alt-g';
-     for my $i ( 1 .. 3 ) {
+    #send_key 'shift-ctrl-alt-g'; #FIXME - Removed as no longer installing in parralel
+    for my $i ( 1 .. 1 ) { #FIXME - Reduced to one to do cloning instead
         reconnecthainstall "$i";
-        send_key 'ctrl-pgdn';
+        #send_key 'ctrl-pgdn'; #FIXME - Removed as no longer installing in parralel
     }
-    send_key 'ctrl-alt-g';
+    #send_key 'ctrl-alt-g'; #FIXME - Removed as no longer installing in parralel
 }
 
 1;

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -14,7 +14,8 @@ sub run() {
     else {
         assert_screen "inst-welcome", 500;
     }
-
+    
+    wait_idle;
     # animated cursor wastes disk space, so it is moved to bottom right corner
     mouse_hide;
 


### PR DESCRIPTION
I've reworked the entire HA test suite, in order to squish reliability issues, and make the 'proxy' concept more flexible in the long run (the reworking there represents preparation for using it for SSH and VNC tests on real hardware)

For HA this means no more parralel installation, it makes one VM, installs once, clones the VM, fixes the carnage that causes, and carries on

In theory, this should be snapshotable just before the Clone, which if it works will make me a very happy person for developing future HA tests

I'm pushing this without a full test on my dev machine (it's late/early), but I'm reasnobly confident it reflects at least the direction of travel if not perfect implementation for HA Validation