### PR TITLE
No need to type username in SLE11 KDE

### DIFF
--- a/tests/x11/reboot.pm
+++ b/tests/x11/reboot.pm
@@ -15,7 +15,9 @@ sub run() {
         wait_idle;
 
         # log in
-        type_string $username. "\n";
+        if (check_var('DESKTOP', 'gnome')) {
+            type_string $username. "\n";
+        }
         type_string $password. "\n";
     }
 

--- a/tests/x11/reboot.pm
+++ b/tests/x11/reboot.pm
@@ -15,7 +15,7 @@ sub run() {
         wait_idle;
 
         # log in
-        if (check_var('DESKTOP', 'gnome')) {
+        if (get_var('DM_NEEDS_USERNAME')) {
             type_string $username. "\n";
         }
         type_string $password. "\n";


### PR DESCRIPTION
Tested on SLE11
kde http://10.100.98.90/tests/328
gnome http://10.100.98.90/tests/329
SLE12
gnome http://10.100.98.90/tests/331