### PR TITLE
Add 2 seconds wait_idle

### DIFF
--- a/tests/installation/addon_products.pm
+++ b/tests/installation/addon_products.pm
@@ -8,8 +8,8 @@ sub run() {
     if ( check_screen('network-setup', 10)) { # won't appear for NET installs
         send_key $cmd{"next"};    # use network
         assert_screen 'dhcp-network';
-        send_key 'alt-d'; # DHCP
-        send_key "alt-o", 2;        # OK
+        send_key 'alt-d', 2;    # DHCP
+        send_key 'alt-o', 2;    # OK
     }
     my $repo = 0;
     $repo++ if get_var("DUD");


### PR DESCRIPTION
Lot of tests fail, installation doesn't move after alt-o is sent, maybe 2 second wait_idle will help ?
https://openqa.suse.de/tests/18366/modules/addon_products/steps/3