### PR TITLE
consoletests: add a new curl_https test

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -410,6 +410,7 @@ sub load_consoletests() {
         }
         loadtest "console/zypper_ref.pm";
         loadtest "console/yast2_lan.pm";
+        loadtest "console/curl_https.pm";
         if (!get_var("OFW")) {
             loadtest "console/aplay.pm";
             loadtest "console/glibc_i686.pm";

--- a/tests/console/curl_https.pm
+++ b/tests/console/curl_https.pm
@@ -1,0 +1,12 @@
+use base "consoletest";
+use testapi;
+
+# test for bug https://bugzilla.novell.com/show_bug.cgi?id=598574
+sub run() {
+    my $self = shift;
+    validate_script_output('curl -v https://www.opensuse.org',
+                           sub { m,Location: http://www.opensuse.org/en/, });
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Ensure curl is able to successfully connect to a https site
(www.opensuse.org) without certificate errors.