### PR TITLE
redirect curl's stderr to stdout

### DIFF
--- a/tests/console/curl_https.pm
+++ b/tests/console/curl_https.pm
@@ -4,7 +4,7 @@ use testapi;
 # test for bug https://bugzilla.novell.com/show_bug.cgi?id=598574
 sub run() {
     my $self = shift;
-    validate_script_output('curl -v https://www.opensuse.org',
+    validate_script_output('curl -v https://www.opensuse.org 2>&1',
                            sub { m,Location: http://www.opensuse.org/en/, });
 }
 


### PR DESCRIPTION
curl writes output to stderr, we need those output for string matching