### PR TITLE
Adding mouse_hide in the foreach loop for drive selection

### DIFF
--- a/tests/installation/addon_products.pm
+++ b/tests/installation/addon_products.pm
@@ -35,6 +35,7 @@ sub run() {
     if ( get_var("ADDONS")) {
 
         foreach $a (split(/,/, get_var('ADDONS'))) {
+            mouse_hide;
             send_key 'alt-d';	# DVD
             send_key $cmd{"xnext"}, 1;
             assert_screen 'dvd-selector', 3;


### PR DESCRIPTION
Tests fail because the presence of the cursor over the cd/dvd-rom addon box.