### PR TITLE
Load desktop before running SSSD test suite in text console

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -582,6 +582,7 @@ elsif (get_var("RESCUESYSTEM")) {
 elsif (get_var("SYSAUTHTEST")) {
     # sysauth test script switches to tty and run test scripts in the console
     load_boot_tests();
+    loadtest "installation/finish_desktop.pm";
     loadtest "sysauth/sssd.pm";
 }
 else {

--- a/tests/sysauth/sssd.pm
+++ b/tests/sysauth/sssd.pm
@@ -7,7 +7,7 @@ sub run() {
 
     # Password-less login to tty4 on Live-CD
     send_key "ctrl-alt-f4";
-    assert_screen "text-login", 10;
+    assert_screen "text-login", 30;
     type_string "$username\n";
     become_root;
 


### PR DESCRIPTION
And improve tolerance to a slow text console.