### PR TITLE
ensure_installed: allow to retry entering the PolicyKit auth dialog

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -112,14 +112,19 @@ sub ensure_installed {
     testapi::x11_start_program("xterm");
     assert_screen('xterm-started');
     type_string("pkcon install @pkglist\n");
-    my @tags = qw/Policykit Policykit-behind-window pkcon-proceed-prompt pkcon-succeeded/;
+    my @tags = qw/Policykit Policykit-behind-window PolicyKit-retry pkcon-proceed-prompt pkcon-succeeded/;
     while (1) {
         my $ret = assert_screen(\@tags, $timeout);
-        if ( $ret->{needle}->has_tag('Policykit') ) {
+        if ( $ret->{needle}->has_tag('Policykit') ||
+             $ret->{needle}->has_tag('PolicyKit-retry')) {
             type_password;
             send_key( "ret", 1 );
             @tags = grep { $_ ne 'Policykit' } @tags;
             @tags = grep { $_ ne 'Policykit-behind-window' } @tags;
+            if ( $ret->{needle}->has_tag('PolicyKit-retry')) {
+                # Only a single retry is acceptable
+                @tags = grep { $_ ne 'PolicyKit-retry' } @tags;
+            }
             next;
         }
         if ( $ret->{needle}->has_tag('Policykit-behind-window') ) {


### PR DESCRIPTION
The needle for PolicyKit-retry should always be marked as 'workaround'

The plan is to create an additional needle with the 'Please retry' text added, and having that needle marked as 'workaround'.

In none of the multiple tests done locally could I reproduce this behvaiour of polkit not accepting my input (I can reproduce it when done using openqa isotovideo, so I will keep on trying to debug it).

