### PR TITLE
assert text login instead of sleep

### DIFF
--- a/tests/installation/reboot_eject_cd.pm
+++ b/tests/installation/reboot_eject_cd.pm
@@ -7,7 +7,7 @@ sub run() {
 
     # Eject the DVD
     send_key "ctrl-alt-f3";
-    sleep 4;
+    assert_screen('text-login');
     send_key "ctrl-alt-delete";
 
     # Bug in 13.1?


### PR DESCRIPTION
- fix 'none' result and thus failing the test