### PR TITLE
Increase timeout in livecdreboot.pm due to aarch64

### DIFF
--- a/tests/installation/livecdreboot.pm
+++ b/tests/installation/livecdreboot.pm
@@ -6,7 +6,7 @@ use bmwqemu ();
 sub run() {
     my $self = shift;
     # NET isos are slow to install
-    my $timeout = 2000;
+    my $timeout = 5000;
 
     # workaround for yast popups
     my @tags = qw/rebootnow/;


### PR DESCRIPTION
AArch64 fails due to timeout, hopefully increasing $timeout to 5000 resolves issue. See https://openqa.opensuse.org/tests/52963/modules/livecdreboot/steps/21 