### PR TITLE
install os-autoinst dependencies for travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: perl # prevent it from using perlbrew which does not support threads
 perl:
-  - "5.18-thr"
+  - "5.18-extras"
 before_install:
   - eval $(curl https://travis-perl.github.io/init) --perl
 install:
   - perlbrew list
   - cpanm -nq JSON Data::Dump
   - git clone git://github.com/os-autoinst/os-autoinst
+  - cpanm -nq `cat os-autoinst/DEPENDENCIES.txt`
 script:
   - make test
 sudo: false


### PR DESCRIPTION
- without them some tests fail compiling (eg. mmapi requires Mojo::UA)
- there is no 5.18-thr perl in travis-ci, use 5.18-extras for threads