### PR TITLE
reboot disambiguation

### DIFF
--- a/tests/autoyast/autoyast_reboot.pm
+++ b/tests/autoyast/autoyast_reboot.pm
@@ -25,7 +25,8 @@ sub run {
     type_string("shutdown -r now\n");
 
 #obsoletes installation/autoyast_reboot.pm
-    assert_screen( "autoyast-boot", 900 );
+    assert_screen( "bios-boot", 900 );
+    assert_screen( "autoyast-boot", 20 );
 
 
 

--- a/tests/autoyast/system.pm
+++ b/tests/autoyast/system.pm
@@ -42,7 +42,7 @@ sub run {
     # wait for bootloader to appear
     my $ret;
 
-    my @needles = ("autoyast-boot", "autoyast-error", "reboot-after-installation");
+    my @needles = ("bios-boot", "autoyast-error", "reboot-after-installation");
 
     push @needles, "autoyast-confirm" if get_var("AUTOYAST_CONFIRM");
     push @needles, "autoyast-postpartscript" if get_var("USRSCR_DIALOG");
@@ -61,7 +61,7 @@ sub run {
 
         #repeat until timeout or login screen
         if ( defined $ret ) {
-           last if $ret->{needle}->has_tag("autoyast-boot") || $ret->{needle}->has_tag("reboot-after-installation");
+           last if $ret->{needle}->has_tag("bios-boot") || $ret->{needle}->has_tag("reboot-after-installation");
  
            if ( $ret->{needle}->has_tag('autoyast-error') ) {
               send_key "alt-s"; #stop


### PR DESCRIPTION
 - fixed tag check that was causing mismatch in tap based workflow
