### PR TITLE
SMT addon has opposite shortcuts as other addons

### DIFF
--- a/tests/installation/sle11_releasenotes.pm
+++ b/tests/installation/sle11_releasenotes.pm
@@ -10,8 +10,18 @@ sub run(){
     if (get_var("ADDONS")) {
         if (check_screen 'release-notes-tab') {
             foreach $a (split(/,/, get_var('ADDONS'))) {
-                send_key 'alt-u';
-                assert_screen "release-notes-$a";
+                if ($a eq 'smt') {
+                    send_key 'alt-s';
+                    assert_screen "release-notes-smt";
+                    send_key 'alt-u';
+                    assert_screen "release-notes-sle";
+                }
+                else {
+                    send_key 'alt-u';
+                    assert_screen "release-notes-$a";
+                    send_key 'alt-s';
+                    assert_screen "release-notes-sle";
+                }
             }
             send_key 'alt-s';
             assert_screen "release-notes-sle";


### PR DESCRIPTION
I spoke with YaST colleague Ladislav Slezak, shortcuts are dynamicaly assigned so it's not possible to fix.
ref.
http://10.100.98.90/tests/430

btw I tried to rebase my previous web commit and deleted whole branch ><