### PR TITLE
Re-login for Plasma 5

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -453,7 +453,12 @@ sub load_x11tests(){
     return unless (!get_var("INSTALLONLY") && get_var("DESKTOP") !~ /textmode|minimalx/ && !get_var("DUALBOOT") && !get_var("RESCUECD"));
 
     if ( get_var("NOAUTOLOGIN") || get_var("XDMUSED") ) {
-        loadtest "x11/x11_login.pm";
+        if ( get_var("PLASMA5") ) {
+            loadtest "x11/plasma5_logout_in.pm";
+        }
+        else {
+            loadtest "x11/x11_login.pm";
+        }
     }
     if (xfcestep_is_applicable) {
         loadtest "x11/xfce_close_hint_popup.pm";

--- a/tests/x11/plasma5_logout_in.pm
+++ b/tests/x11/plasma5_logout_in.pm
@@ -1,0 +1,34 @@
+use base "x11test";
+use testapi;
+
+sub run() {
+    my $self = shift;
+
+    if ( !check_screen('sddm', 10) ) {
+        # make sure back to login screen
+        send_key "ctrl-alt-delete";    # logout dialog
+        assert_screen 'logoutdialog', 15;
+        assert_and_click 'sddm_logout_btn';
+    }
+
+    mouse_hide();
+
+    # log in
+    assert_screen 'displaymanager', 20;
+    # make sure choose plasma5 session
+    assert_and_click "sddm-sessions-list";
+    assert_and_click "sddm-sessions-plasma5";
+    assert_and_click "sddm-password-input";
+
+    type_string "$password";
+    send_key "ret";
+
+    assert_screen 'generic-desktop', 20;
+}
+
+sub test_flags() {
+    return { 'milestone' => 1 };
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/x11_login.pm
+++ b/tests/x11/x11_login.pm
@@ -5,10 +5,12 @@ sub run() {
     my $self = shift;
 
     # log in
-    type_string $username. "\n";
-    sleep 1;
-    type_string $password. "\n";
-    wait_idle;
+    type_string $username;
+    send_key "ret";
+    type_string "$password";
+    send_key "ret";
+
+    assert_screen 'generic-desktop', 20;
 }
 
 1;


### PR DESCRIPTION
Currently Plasma 5 can not handle hostname change in a desktop session,
otherwise krunner or desktop applications will not reponse. Thus a
re-login is needed if we did hostname change during console test.

Set it milestone due to we need to update lastgood for such case.