### PR TITLE
Use tag displaymanager instead generic-desktop

### DIFF
--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -4,7 +4,12 @@ use testapi;
 
 sub run() {
     # wait booted
-    assert_screen 'generic-desktop', 200;
+    if (get_var("NOAUTOLOGIN")) {
+        assert_screen 'displaymanager', 200;
+    }
+    else {
+        assert_screen 'generic-desktop', 200;
+    }
 
     # log into text console
     send_key "ctrl-alt-f4";


### PR DESCRIPTION
as first screen after boot withou autologin matches displaymanager

ref. installation/first_boot.pm:
https://openqa.suse.de/tests/36260/modules/first_boot/steps/1