### PR TITLE
Adjust bootmenu helper for PowerPC

### DIFF
--- a/tests/installation/mediacheck.pm
+++ b/tests/installation/mediacheck.pm
@@ -7,7 +7,12 @@ sub run {
 
     assert_screen "inst-bootmenu", 15;
 
-    $self->bootmenu_down_to('inst-onmediacheck');
+    if (get_var('OFW')) {
+        $self->key_round('inst-onmediacheck', 'up');
+    } else {
+       $self->bootmenu_down_to('inst-onmediacheck');
+    }
+
     send_key "ret";
     # the timeout is insane - but SLE11 DVDs take almost forever
     assert_screen "mediacheck-ok", 3600;

--- a/tests/installation/rescuesystem.pm
+++ b/tests/installation/rescuesystem.pm
@@ -7,7 +7,11 @@ sub run {
 
     assert_screen "inst-bootmenu", 15;
 
-    $self->bootmenu_down_to('inst-rescuesystem');
+    if (get_var('OFW')) {
+        $self->key_round('inst-rescuesystem', 'up');
+    } else {
+       $self->bootmenu_down_to('inst-rescuesystem');
+    }
     send_key "ret";
 
     if ( check_screen "keyboardmap-list", 100 ) {


### PR DESCRIPTION
On grub2 powerpc our default boot entry is the last one. Lets go up in
that case.