### PR TITLE
Add timeout for installing package

### DIFF
--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -18,7 +18,7 @@ sub run() {
     send_key "alt-a", 1;    # accept
     # Upgrade tests and the old distributions eg. SLE11 doesn't shows the summary
     unless ( get_var("YAST_SW_NO_SUMMARY") ) {
-        assert_screen 'yast2-sw_shows_summary', 3;
+        assert_screen 'yast2-sw_shows_summary', 30;
         send_key "alt-f";
     }
     # yast might take a while on sle11 due to suseconfig


### PR DESCRIPTION
3 seconds is insane for some package, eg. x3270 need some more time to execute reconfigure_fonts script, add time out to 30 seconds.