### PR TITLE
Updates: Allow to set YAST_SW_NO_SUMMARY as part of the job template

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -135,7 +135,9 @@ if ( check_var( 'DESKTOP', 'minimalx' ) ) {
 # openSUSE specific variables
 set_var("PACKAGETOINSTALL", "xdelta");
 set_var("WALLPAPER", '/usr/share/wallpapers/openSUSEdefault/contents/images/1280x1024.jpg');
-set_var("YAST_SW_NO_SUMMARY", 1) if get_var('UPGRADE') || get_var("ZDUP");
+if ( !defined get_var( "YAST_SW_NO_SUMMARY" ) ) {
+    set_var("YAST_SW_NO_SUMMARY", 1) if get_var('UPGRADE') || get_var("ZDUP");
+}
 
 # set KDE and GNOME, ...
 set_var(uc(get_var('DESKTOP')), 1);


### PR DESCRIPTION
Until openSUSE 13.2, the default was to not show a summary after
installing packages. So it was correct to inject YAST_SW_NO_SUMMARY=1
into the upgraded systems. On 13.2, the default was changed and we can
no longer just inject it.

So the idea is to have the job template set it to 0 for the 13.2 update
case and keep the logic for the older cases.