### PR TITLE
reboot: also livetest systems have a reboot confiured

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -546,9 +546,7 @@ sub load_x11tests(){
         loadtest "x11/evolution.pm" unless (check_var("FLAVOR", "Server-DVD"));
         loadtest "x11/reboot_gnome_pre.pm";
     }
-    if (!get_var("LIVETEST")) {
-        loadtest "x11/reboot.pm";
-    }
+    loadtest "x11/reboot.pm";
     loadtest "x11/desktop_mainmenu.pm";
 
     if (xfcestep_is_applicable) {


### PR DESCRIPTION
From what I've seen, all live tests seem to have the reboot_pre stage, but then reboot itself is excluded from the actual test - which, in turn, is needed to align the timing when the desktop is back up ready.