### PR TITLE
upgrade test

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -152,7 +152,7 @@ sub script_sudo($$) {
     my ($self, $prog, $wait) = @_;
 
     send_key 'ctrl-l';
-    type_string "su -c '$prog'\n";
+    type_string "su -c \'$prog\'\n";
     if (!get_var("LIVETEST")) {
         assert_screen 'password-prompt';
         type_password;

--- a/main.pm
+++ b/main.pm
@@ -394,13 +394,13 @@ sub load_rescuecd_tests() {
 
 sub load_zdup_tests() {
     if (get_var('ZDUP_IN_X')) {
-        loadtest "installation/setup_zdup_keepX.pm";
+        loadtest 'installation/setup_zdup_keepX.pm';
     }
     else {
-        loadtest "installation/setup_zdup.pm";
+        loadtest 'installation/setup_zdup.pm';
     }
-    loadtest "installation/zdup.pm";
-    loadtest "installation/post_zdup.pm";
+    loadtest 'installation/zdup.pm';
+    loadtest 'installation/post_zdup.pm';
 }
 
 sub load_consoletests() {

--- a/main.pm
+++ b/main.pm
@@ -145,6 +145,11 @@ if ( check_var( 'DESKTOP', 'minimalx' ) ) {
     set_var('DM_NEEDS_USERNAME', 1);
 }
 
+# ZDUP_IN_X imply ZDUP
+if ( get_var('ZDUP_IN_X')) {
+    set_var('ZDUP', 1);
+}
+
 $needle::cleanuphandler = \&cleanup_needles;
 
 bmwqemu::save_vars(); # update variables
@@ -388,7 +393,12 @@ sub load_rescuecd_tests() {
 }
 
 sub load_zdup_tests() {
-    loadtest "installation/setup_zdup.pm";
+    if (get_var('ZDUP_IN_X')) {
+        loadtest "installation/setup_zdup_keepX.pm";
+    }
+    else {
+        loadtest "installation/setup_zdup.pm";
+    }
     loadtest "installation/zdup.pm";
     loadtest "installation/post_zdup.pm";
 }
@@ -606,6 +616,12 @@ else {
     load_rescuecd_tests();
     load_consoletests();
     load_x11tests();
+}
+
+if (get_var('STORE_ASSET')) {
+    # store resulting hdd as job asset
+    # this only creates link, actual upload is done after qemu stops
+    upload_image(1, get_var('STORE_ASSET'), 'assets_public');
 }
 
 1;

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -20,11 +20,13 @@ sub run() {
     }
 
     assert_screen "inst-bootmenu", 15;
-    if ( get_var("ZDUP") ) {
-        eject_cd;
-        power('reset');
-        sleep 10;
-        send_key "ret";    # boot
+    if (get_var('ZDUP')) {
+        if (get_var('SUSEMIRROR') || get_var('ZDUPREPOS')) {
+            eject_cd;
+            power('reset');
+            sleep 10;
+        }
+        send_key 'ret';    # boot
         return;
     }
 

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -22,10 +22,13 @@ sub run() {
         sleep 5;
     }
     if ( get_var("ZDUP") ) {
-        eject_cd;
-        power('reset');
-        sleep 10;
-        send_key "ret";    # boot
+        # if SUSEMIRROR nor ZDUPREPOS are specified, we are ZDUPing from new ISO
+        if (get_var('SUSEMIRROR') || get_var('ZDUPREPOS')) {
+            eject_cd;
+            power('reset');
+            sleep 10;
+        }
+        send_key 'ret';    # boot
         return;
     }
 

--- a/tests/installation/post_zdup.pm
+++ b/tests/installation/post_zdup.pm
@@ -14,6 +14,9 @@ sub run() {
 
     save_screenshot;
 
+    # switch to tty3 (in case we are in X)
+    send_key "ctrl-alt-f3";
+    assert_screen "text-login", 5;
     # Reboot after dup
     send_key "ctrl-alt-delete";
     assert_screen "grub2", 50;

--- a/tests/installation/setup_zdup_keepX.pm
+++ b/tests/installation/setup_zdup_keepX.pm
@@ -1,0 +1,20 @@
+use base "installbasetest";
+use strict;
+use testapi;
+
+sub run() {
+    # wait booted
+    assert_screen 'generic-desktop', 200;
+
+    x11_start_program('xterm');
+    become_root;
+
+    type_string "PS1=\$\n";    # set constant shell promt
+    sleep 1;
+
+    # Disable console screensaver
+    script_run("setterm -blank 0");
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -1,12 +1,41 @@
 use base "installbasetest";
 use strict;
 use testapi;
+use experimental 'smartmatch';
 
 sub run() {
     my $self = shift;
 
+    # precompile regexes
+    my $zypper_dup_continue = qr/^Continue\? \[y/m;
+    my $zypper_dup_conflict = qr/^Choose from above solutions by number or cancel \[1/m;
+    my $zypper_dup_notifications = qr/^View the notifications now\? \[y/m;
+    my $zypper_dup_error = qr/^Abort, retry, ignore\? \[a/m;
+    my $zypper_dup_finish = qr/^There are some running programs that might use files/m;
+    my $zypper_packagekit = qr/^Tell PackageKit to quit\?/m;
+    my $zypper_packagekit_again = qr/^Try again\?/m;
+    my $zypper_repo_disabled = qr/^Repository '\S+' has been successfully disabled./m;
+    my $zypper_installing = qr/Installing: \S+/;
+
     # Disable all repos, so we do not need to remove one by one
-    script_run("zypper modifyrepo --all --disable");
+    # beware PackageKit!
+    script_run("zypper modifyrepo --all --disable | tee /dev/$serialdev");
+    my $out = wait_serial([$zypper_packagekit, $zypper_repo_disabled], 120);
+    while($out) {
+        if ($out ~~ [$zypper_packagekit, $zypper_packagekit_again]) {
+            send_key 'y';
+            send_key 'ret';
+        }
+        elsif ($out =~ $zypper_repo_disabled) {
+            last;
+        }
+        $out = wait_serial([$zypper_repo_disabled, $zypper_packagekit_again, $zypper_packagekit], 120);
+    }
+    unless ($out) {
+        save_screenshot;
+        $self->result('fail');
+        return;
+    }
 
     my $defaultrepo;
     if (get_var('SUSEMIRROR')) {
@@ -24,34 +53,61 @@ sub run() {
     }
     script_run("zypper --gpg-auto-import-keys refresh");
 
-    script_run("zypper dup -l");
+    script_run("zypper dup -l | tee /dev/$serialdev");
 
-    my $ret = assert_screen [qw/zypper-dup-continue zypper-dup-conflict/], 10;
-    while ( $ret->{needle}->has_tag("zypper-dup-conflict") ) {
-        send_key "1", 1;
-        send_key "ret", 1;
-        $ret = assert_screen [qw/zypper-dup-continue zypper-dup-conflict/], 5;
-    }
-
-    if ( $ret->{needle}->has_tag("zypper-dup-continue") ) {
-        send_key "y", 1;
-        send_key "ret", 1;
-    }
-
-    my @tags = qw/zypper-dup-retrieving zypper-dup-installing zypper-view-notifications zypper-post-scripts zypper-dup-agreeing/;
-    $ret = assert_screen \@tags, 5;
-    while ( defined($ret) ) {
-        last if check_screen [qw/zypper-dup-error zypper-dup-finish/];
-        if ( $ret->{needle}->has_tag("zypper-view-notifications") ) {
-            send_key "n", 1; # do not show notifications
-            send_key "ret", 1;
+    $out = wait_serial([$zypper_dup_continue, $zypper_dup_conflict, $zypper_dup_error], 240);
+    while($out) {
+        if ($out =~ $zypper_dup_conflict) {
+            send_key '1', 1;
+            send_key 'ret', 1;
         }
-        send_key "shift", 1;
-        sleep 10;
-        $ret = assert_screen \@tags, 10;
+        elsif ($out =~ $zypper_dup_continue) {
+            save_screenshot;
+            # confirm zypper dup continue
+            send_key 'y', 1;
+            send_key 'ret', 1;
+            last;
+        }
+        elsif ($out =~ $zypper_dup_error) {
+            save_screenshot;
+            $self->result('fail');
+            return;
+        }
+        $out = wait_serial([$zypper_dup_continue, $zypper_dup_conflict, $zypper_dup_error], 120);
+    }
+    unless($out) {
+        save_screenshot;
+        $self->result('fail');
+        return;
+    }
+
+    # wait for zypper dup finish, accept failures in meantime
+    $out = wait_serial([$zypper_dup_finish, $zypper_installing, $zypper_dup_notifications, $zypper_dup_error], 120);
+    while ($out) {
+        if ($out =~ $zypper_dup_notifications) {
+            send_key 'n', 1; # do not show notifications
+            send_key 'ret', 1;
+        }
+        elsif ($out =~ $zypper_dup_error) {
+            $self->result('fail');
+            save_screenshot;
+            return;
+        }
+        elsif ($out =~ $zypper_dup_finish) {
+            last;
+        }
+        else {
+            # probably to avoid hitting black screen on video
+            send_key 'shift', 1;
+        }
+        $out = wait_serial([$zypper_dup_finish, $zypper_installing, $zypper_dup_notifications, $zypper_dup_error], 120);
     }
 
     assert_screen "zypper-dup-finish", 2;
+}
+
+sub test_flags() {
+    return { 'fatal' => 1, 'important' => 1 };
 }
 
 1;

--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -4,10 +4,18 @@ use testapi;
 
 sub run() {
     my $self = shift;
-    my $defaultrepo = "http://" . get_var("SUSEMIRROR");
 
     # Disable all repos, so we do not need to remove one by one
     script_run("zypper modifyrepo --all --disable");
+
+    my $defaultrepo;
+    if (get_var('SUSEMIRROR')) {
+        $defaultrepo = "http://" . get_var("SUSEMIRROR");
+    }
+    else {
+        # SUSEMIRROR not set, zdup from attached ISO
+        $defaultrepo = 'dvd:///';
+    }
 
     my $nr = 1;
     foreach my $r ( split( /\+/, get_var("ZDUPREPOS", $defaultrepo) ) ) {


### PR DESCRIPTION
Mini how to:
- select test A (preferably one that install from scratch) and add STORE_ASSET variable to it. This will upload resulting HDD as job asset
- select (or create new) another test B and when at least one generated asset exists, set test B as chained parent to test A. This makes sure that test B use asset generated in previous run of test A
- set ZDUP or ZDUP_IN_X to test B to perform upgrade

- this use serial output and enhanced ( https://github.com/os-autoinst/os-autoinst/pull/250 ) wait_serial instead of plain needle matching