### PR TITLE
gnome-control-center: use assert_and click instead of typing enter to…

### DIFF
--- a/tests/x11/gnome_control_center.pm
+++ b/tests/x11/gnome_control_center.pm
@@ -12,7 +12,7 @@ sub run() {
     assert_screen "gnome-control-center-started", 10;
     type_string "details";
     assert_screen "gnome-control-center-details-typed", 5;
-    send_key "ret";
+    assert_and_click "gnome-control-center-details";
     assert_screen 'test-gnome_control_center-1', 3;
     send_key "alt-f4";
 }


### PR DESCRIPTION
… launch the details panel

That should hopefully give us more reliable test results than what we see for g-c-c at the moment