### PR TITLE
Add one more precompile regexes for dup conflict

### DIFF
--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -8,6 +8,7 @@ sub run() {
     # precompile regexes
     my $zypper_dup_continue = qr/^Continue\? \[y/m;
     my $zypper_dup_conflict = qr/^Choose from above solutions by number or cancel \[1/m;
+    my $zypper_dup_more_conflict = qr/^Choose from above solutions by number or skip, retry or cancel \[1/m;
     my $zypper_dup_notifications = qr/^View the notifications now\? \[y/m;
     my $zypper_dup_error = qr/^Abort, retry, ignore\? \[a/m;
     my $zypper_dup_finish = qr/^There are some running programs that might use files/m;
@@ -56,7 +57,7 @@ sub run() {
 
     $out = wait_serial([$zypper_dup_continue, $zypper_dup_conflict, $zypper_dup_error], 240);
     while($out) {
-        if ($out =~ $zypper_dup_conflict) {
+        if ($out =~ $zypper_dup_conflict || $out =~ $zypper_dup_more_conflict) {
             send_key '1', 1;
             send_key 'ret', 1;
         }


### PR DESCRIPTION
If found more than 1 problem, the prompt text is:
Choose from above solutions by number or skip, retry or cancel [1/2/3/s/r/c] (c):

ref. https://openqa.opensuse.org/tests/63160/modules/zdup/steps/2