### PR TITLE
remove boot_encrypt from sle11 install workflow

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -422,9 +422,6 @@ sub load_inst_tests() {
 
 sub load_reboot_tests() {
 
-    if (get_var("ENCRYPT")) {
-        loadtest "installation/boot_encrypt.pm";
-    }
     if (installyaststep_is_applicable) {
         loadtest "installation/first_boot.pm";
     }


### PR DESCRIPTION
unlocking the encrpyted partition is already done in
installation/sle11_wait_for_2nd_stage.pm