### PR TITLE
installation mode & upgrade select fix

### DIFF
--- a/tests/installation/installation_mode.pm
+++ b/tests/installation/installation_mode.pm
@@ -16,7 +16,8 @@ sub run() {
     }
 
     if ( get_var("ADDONURL") || get_var("ADDONS") ) {
-        if (!check_var('ADDONS', 'smt')) {  # no include for SMT add-on bnc928895
+        # Don't include add-on from separate media for SMT upgrade bnc928895
+        unless (get_var("UPGRADE") && check_var('ADDONS', 'smt')) {
             send_key "alt-c";    # Include Add-On Products
             assert_screen "addonproduct-included", 10;
         }

--- a/tests/installation/upgrade_select_sle11.pm
+++ b/tests/installation/upgrade_select_sle11.pm
@@ -70,6 +70,9 @@ sub run() {
             send_key $cmd{"next"}, 1;
         }
     }
+    else {
+        send_key $cmd{"next"}, 1;
+    }
 
     assert_screen "update-installation-overview", 15;
 }


### PR DESCRIPTION
My SMT PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/432
broke sle11 smt installation and upgrade select.

Tested:
SMT
http://10.100.98.90/tests/760

update
http://10.100.98.90/tests/762

update SMT
http://10.100.98.90/tests/762

update SDK
http://10.100.98.90/tests/763

SDK
http://10.100.98.90/tests/770

GNOME
http://10.100.98.90/tests/771