### PR TITLE
No need to assert release-notes-sle twice

### DIFF
--- a/tests/installation/sle11_releasenotes.pm
+++ b/tests/installation/sle11_releasenotes.pm
@@ -6,7 +6,6 @@ sub run(){
     my $self=shift;
 
     assert_screen 'release-notes', 100; # suseconfig run
-
     if (get_var("ADDONS")) {
         if (check_screen 'release-notes-tab') {
             foreach $a (split(/,/, get_var('ADDONS'))) {
@@ -23,8 +22,6 @@ sub run(){
                     assert_screen "release-notes-sle";
                 }
             }
-            send_key 'alt-s';
-            assert_screen "release-notes-sle";
         }
         else {
             foreach $a (split(/,/, get_var('ADDONS'))) {
@@ -50,7 +47,6 @@ sub run(){
     else {
         assert_screen "release-notes-sle";
     }
-
     send_key $cmd{'next'};
 }
 


### PR DESCRIPTION
If there is tab then foreach will take care of all release notes, it's waste to assert_screen release-notes-sle again

gnome
http://10.100.98.90/tests/774/modules/sle11_releasenotes/steps/1
SDK
http://10.100.98.90/tests/775/modules/sle11_releasenotes/steps/1
SMT
http://10.100.98.90/tests/779/modules/sle11_releasenotes/steps/1
SMT update
http://10.100.98.90/tests/781/modules/sle11_releasenotes/steps/1
update
http://10.100.98.90/tests/778/modules/sle11_releasenotes/steps/1