### PR TITLE
Run sysauth based on the HDD image of install-kde-image

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -604,9 +604,10 @@ elsif (get_var("RESCUESYSTEM")) {
     loadtest "installation/rescuesystem_validate_131.pm";
 }
 elsif (get_var("SYSAUTHTEST")) {
-    # sysauth test script switches to tty and run test scripts in the console
     load_boot_tests();
-    loadtest "installation/finish_desktop.pm";
+    loadtest "installation/second_boot.pm";
+    # sysauth test script switches to tty and run test scripts in the console
+    loadtest "console/consoletest_setup.pm";
     loadtest "sysauth/sssd.pm";
 }
 else {

--- a/templates
+++ b/templates
@@ -386,32 +386,6 @@
                     {
                       group_name => "openSUSE Tumbleweed",
                       machine => { name => "32bit" },
-                      prio => 50,
-                      product => {
-                        arch    => "i686",
-                        distri  => "opensuse",
-                        flavor  => "GNOME-Live",
-                        group   => "opensuse-GNOME-Live",
-                        version => "*",
-                      },
-                      test_suite => { name => "sysauth" },
-                    },
-                    {
-                      group_name => "openSUSE Tumbleweed",
-                      machine => { name => "64bit" },
-                      prio => 50,
-                      product => {
-                        arch    => "x86_64",
-                        distri  => "opensuse",
-                        flavor  => "GNOME-Live",
-                        group   => "opensuse-GNOME-Live",
-                        version => "*",
-                      },
-                      test_suite => { name => "sysauth" },
-                    },
-                    {
-                      group_name => "openSUSE Tumbleweed",
-                      machine => { name => "32bit" },
                       prio => 40,
                       product => {
                         arch    => "i686",
@@ -2477,6 +2451,32 @@
                       test_suite => { name => "update_13.2" },
                     },
                     {
+                      group_name => "openSUSE Tumbleweed",
+                      machine => { name => "64bit" },
+                      prio => 50,
+                      product => {
+                        arch    => "x86_64",
+                        distri  => "opensuse",
+                        flavor  => "DVD",
+                        group   => "opensuse-DVD",
+                        version => "*",
+                      },
+                      test_suite => { name => "install-kde-image" },
+                    },
+                    {
+                      group_name => "openSUSE Tumbleweed",
+                      machine => { name => "64bit" },
+                      prio => 50,
+                      product => {
+                        arch    => "x86_64",
+                        distri  => "opensuse",
+                        flavor  => "DVD",
+                        group   => "opensuse-DVD",
+                        version => "*",
+                      },
+                      test_suite => { name => "sysauth" },
+                    },
+                    {
                       group_name => "Staging Projects",
                       machine => { name => "ppc64le" },
                       prio => 45,
@@ -3192,11 +3192,21 @@
                       ],
                     },
                     {
+                      name => "install-kde-image",
+                      settings => [
+                        { key => "DESKTOP", value => "kde" },
+                        { key => "INSTALLONLY", value => 1 },
+                        { key => "STORE_HDD_1", value => "kde_image.qcow2" },
+                      ],
+                    },
+                    {
                       name => "sysauth",
                       settings => [
-                        { key => "DESKTOP", value => "gnome" },
-                        { key => "LIVETEST", value => 1 },
+                        { key => "DESKTOP", value => "kde" },
                         { key => "SYSAUTHTEST", value => 1 },
+                        { key => "BOOT_HDD_IMAGE", value => 1 },
+                        { key => "START_AFTER_TEST", value => "install-kde-image" },
+                        { key => "HDD_1", value => "kde_image.qcow2" },
                       ],
                     },
                     {

--- a/tests/installation/second_boot.pm
+++ b/tests/installation/second_boot.pm
@@ -1,0 +1,45 @@
+use strict;
+use base "opensusebasetest";
+use testapi;
+
+sub run() {
+    my $self = shift;
+
+    wait_idle;
+
+    if (check_var('DESKTOP', 'textmode')) {
+        assert_screen 'linux-login', 180;
+        return;
+    }
+
+    mouse_hide();
+
+    if ( get_var("NOAUTOLOGIN") ) {
+        my $ret = assert_screen 'displaymanager', 180;
+        if ( get_var('DM_NEEDS_USERNAME') ) {
+            type_string $username;
+        }
+        if ( $ret->{needle}->has_tag("sddm") ) {
+            # make sure choose plasma5 session
+            assert_and_click "sddm-sessions-list";
+            assert_and_click "sddm-sessions-plasma5";
+            assert_and_click "sddm-password-input";
+        }
+        else {
+            send_key "ret";
+            wait_idle;
+        }
+        type_string "$password";
+        send_key "ret";
+    }
+
+    assert_screen 'kde-ready', 180;
+}
+
+sub test_flags() {
+    return { 'important' => 1, 'fatal' => 1, 'milestone' => 1 };
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/tests/sysauth/sssd.pm
+++ b/tests/sysauth/sssd.pm
@@ -1,14 +1,9 @@
 use base "opensusebasetest";
 use testapi;
 
-#In the console of Live-CD system, grab the sysauthtests scripts and install the test subjects.
+# Test the integration between SSSD and its various backends - file database, LDAP, and Kerberos.
 sub run() {
-    wait_idle;
-
-    # Password-less login to tty4 on Live-CD
-    send_key "ctrl-alt-f4";
-    assert_screen "text-login", 30;
-    type_string "$username\n";
+    # Assume consoletest_setup is completed
     become_root;
 
     # Install test subjects and test scripts
@@ -27,7 +22,7 @@ sub run() {
     my @scenario_failures;
 
     foreach my $scenario (qw/local ldap ldap-inherited-groups ldap-nested-groups krb/) {
-        # Download the scenario directory
+        # Download the source code of test scenario
         script_run "cd ~/sssd && mkdir $scenario && curl -L -v ".autoinst_url."/data/sssd-tests/$scenario > $scenario/cdata";
         script_run "cd $scenario && cpio -idv < cdata && mv data/* ./; ls";
         validate_script_output "./test.sh", sub {


### PR DESCRIPTION
Use install-kde-image artefact HDD image to boot into KDE desktop, and switch to console and run sysauth tests.