### PR TITLE
tag for uploaded asset

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -75,6 +75,22 @@ sub export_logs {
 
     save_screenshot;
 
+    if ( check_var("DESKTOP", "kde") ) {
+        if ( get_var('PLASMA5') ) {
+            my $fn = '/tmp/plasma5_configs.tar.bz2';
+            my $cmd = sprintf 'tar cjf %s /home/%s/.config/*rc', $fn, $username;
+            type_string "$cmd\n";
+            upload_logs $fn;
+        }
+        else {
+            my $fn = '/tmp/kde4_configs.tar.bz2';
+            my $cmd = sprintf 'tar cjf %s /home/%s/.kde4/share/config/*rc', $fn, $username;
+            type_string "$cmd\n";
+            upload_logs $fn;
+        }
+        save_screenshot;
+    }
+
     type_string "cat /home/*/.xsession-errors* > /tmp/XSE\n";
     upload_logs "/tmp/XSE";
     save_screenshot;

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -91,6 +91,9 @@ sub export_logs {
         save_screenshot;
     }
 
+    type_string "if [ -f /etc/OPENQA_ASSET_TAG ] ; then cat /etc/OPENQA_ASSET_TAG; fi\n";
+    save_screenshot;
+
     type_string "cat /home/*/.xsession-errors* > /tmp/XSE\n";
     upload_logs "/tmp/XSE";
     save_screenshot;

--- a/main.pm
+++ b/main.pm
@@ -641,6 +641,7 @@ else {
 }
 
 if (get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1")) {
+    loadtest 'support/upload_asset_pre.pm';
     if (get_var("INSTALLONLY")) {
         loadtest "shutdown/shutdown.pm";
     }

--- a/tests/support/upload_asset_pre.pm
+++ b/tests/support/upload_asset_pre.pm
@@ -1,0 +1,48 @@
+use base "installbasetest";
+use strict;
+use testapi;
+
+sub run() {
+    my $self = shift;
+
+    # switch to console
+    send_key "ctrl-alt-f2";
+    assert_screen("text-login", 10);
+    type_string "root\n";
+    sleep 2;
+    type_password;
+    type_string "\n";
+    sleep 1;
+    save_screenshot;
+
+    # create a verify file to etc/ and add a TAG to it
+    # ie. the final uploaded asset name
+    my $asset_id;
+
+    if ( get_var("STORE_HDD_1") ) {
+        my $jobid;
+        my $jobname = get_var("NAME");
+        if ( $jobname =~ /^(\d{8})-/ ) {
+            $jobid = $1;
+        }
+        else {
+            die "can not find valid jobid from $jobname";
+        }
+        $asset_id = $jobid . "-" . get_var("STORE_HDD_1");
+    }
+    elsif ( get_var("PUBLISH_HDD_1") ) {
+        $asset_id = get_var("PUBLISH_HDD_1");
+    }
+
+    script_run "echo $asset_id > /etc/OPENQA_ASSET_TAG";
+    script_run "cat /etc/OPENQA_ASSET_TAG";
+    save_screenshot;
+
+    # switch to X
+    send_key "ctrl-alt-f7";
+    wait_idle;
+    save_screenshot;
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
upload_asset_pre just runs before shutdown, so it should be the last action before shutdown, some tests what rely on the asset(chained parent test) can check the tag at some point, or dump the tag when finish_desktop or first_boot fail.