### PR TITLE
Plus 60 secs for installing boot loader

### DIFF
--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -9,7 +9,7 @@ sub run() {
     script_sudo("/sbin/yast2 bootloader");
     my $ret = assert_screen "test-yast2_bootloader-1", 300;
     send_key "alt-o";     # OK => Close
-    assert_screen 'exited-bootloader', 90;
+    assert_screen 'exited-bootloader', 150;
     send_key "ctrl-l";
     script_run("echo \"EXIT-\$?\" > /dev/$serialdev");
     die unless wait_serial "EXIT-0", 2;


### PR DESCRIPTION
sometimes happens eg. https://openqa.opensuse.org/tests/64523/modules/yast2_bootloader/steps/4
didn't see the error in y2logs, thus increasing the timeout then...