### PR TITLE
more time to wait for encrypted disk password

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -16,7 +16,7 @@ sub clear_and_verify_console {
 sub pass_disk_encrypt_check {
     my ($self) = @_;
 
-    assert_screen("encrypted-disk-password-prompt");
+    assert_screen("encrypted-disk-password-prompt", 200);
     type_password;    # enter PW at boot
     send_key "ret";
 }


### PR DESCRIPTION
Failing cryptlvm tests:
https://openqa.suse.de/tests/48402/modules/reboot/steps/5
https://openqa.suse.de/tests/48411/modules/reboot/steps/5
https://openqa.suse.de/tests/48398/modules/reboot/steps/5