### PR TITLE
SLE 11 KDE yast2 users fix

### DIFF
--- a/tests/x11/sle11_kde_setup.pm
+++ b/tests/x11/sle11_kde_setup.pm
@@ -1,0 +1,29 @@
+use base "x11test";
+use testapi;
+
+sub run() {
+    my $self = shift;
+
+    # SLE11 KDE has enabled "find applications" feature which if doesn't recognize entered command
+    # executes some of last known executed application/command.
+    # e.g. xterm https://openqa.suse.de/tests/49520/modules/yast2_users/steps/2
+    send_key "alt-f2";  # run command window
+    assert_screen 'desktop-runner';
+    $self->key_round('run-command-settings', 'tab', 5);
+    sleep 2;
+    send_key ' ';       # enter KDE run command (KRunner) settings
+    $self->key_round('run-command-filter', 'tab', 5);
+    type_string('app'); # filter applications feature
+    $self->key_round('run-command-app-checkbox', 'tab', 5);
+    send_key ' ';       # uncheck find applications feature
+    send_key "alt-o";   # OK
+    sleep 2;
+    send_key "esc";     # close run command window
+}
+
+sub test_flags() {
+    return { 'milestone' => 1 };
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Failing https://openqa.suse.de/tests/49520/modules/yast2_users/steps/3
I tried to find some amazing solution for this and this is my solution.
tested:
Opensuse KDE
http://dzedro.qa.suse.cz/tests/859/modules/yast2_users/steps/3
SLE11 KDE
http://dzedro.qa.suse.cz/tests/857/modules/yast2_users/steps/14
SLE12 GNOME
http://dzedro.qa.suse.cz/tests/860/modules/yast2_users/steps/3