### PR TITLE
Drops xfce_notification test

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -567,7 +567,6 @@ sub load_x11tests(){
 
     if (xfcestep_is_applicable) {
         loadtest "x11/xfce4_appfinder.pm";
-        loadtest "x11/xfce_notification.pm";
         if (!( get_var("FLAVOR") eq 'Rescue-CD' )) {
             loadtest "x11/xfce_lightdm_logout_login.pm";
         }


### PR DESCRIPTION
It looks like never been successful tested, or no long time doesn't work, and seems no one care it. The reason is the the usage of --expire-time option doesn't like what we looking for, the OSD always shows 5 secs then fade out, 5 secs is really too short for send "ret" key, wait idle, and then assert_screen.