### PR TITLE
Drop hostname test in SLE11

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -452,7 +452,6 @@ sub load_consoletests() {
     if (consolestep_is_applicable) {
         loadtest "console/sle11_consoletest_setup.pm";
         loadtest "console/textinfo.pm";
-        loadtest "console/hostname.pm";
         if (get_var("DESKTOP") !~ /textmode/) {
             loadtest "console/xorg_vt.pm";
         }


### PR DESCRIPTION
The hostname already sets while installation ie. write into /etc/HOSTNAME, and yast2_lan did a check again. Since hostname test for openSUSE will move to using hostnamectl in order to ensure it writes
hostname to /etc/hostname, and hostnamectl doesn't exist on SLE11, drop this test then.