### PR TITLE
Click the reader view notification window before open the help window

### DIFF
--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -4,6 +4,10 @@ use testapi;
 
 sub start_firefox() {
     x11_start_program("firefox https://html5test.com/index.html", 6, { valid => 1 } );
+    # workaround for reader view , it grabed the focus than mainwindow
+    if ( check_screen('firefox_readerview_window', 30) ) {
+        assert_and_click 'firefox_readerview_window';
+    }
     assert_screen 'test-firefox-1', 35;
 }
 


### PR DESCRIPTION
The reader view window grabed the focus on GNOME, click it make the focus back to mainwindow before doing next step.