### PR TITLE
Added Linuxrc test for booting the installed system

### DIFF
--- a/lib/linuxrc.pm
+++ b/lib/linuxrc.pm
@@ -1,0 +1,66 @@
+package linuxrc;
+use base "opensusebasetest";
+use testapi;
+
+#
+# Shared functionality for handling Linuxrc
+#
+
+# Waits for the Linuxrc (media) boot menu and tries to choose
+# booting from CD/DVD media. Call this right away after VM starts.
+sub wait_for_bootmenu() {
+    my $self = shift;
+
+    # Load the BIOS media selection
+    assert_screen "boot-menu", 30;
+    send_key "f12";
+    wait_still_screen 2;
+
+    my $dvd_found = 0;
+
+    # Tries to find CD/DVD entry one by one from the top.
+    for my $try (1..10) {
+        my $tag = "boot-menu-boot-device-".$try."-dvd";
+
+        if (check_screen($tag, 0)) {
+            bmwqemu::diag "DVD found at position ".$try.", tag: ".$tag;
+            $dvd_found = $try;
+            type_string $try;
+            last;
+        }
+    }
+
+    unless ($dvd_found) {
+        save_screenshot;
+        die "Cannot find DVD in boot-menu";
+    }
+
+    # Waits for booting into the media boot menu
+    assert_screen("inst-bootmenu", 30);
+}
+
+# Loads Linuxrc with given parameters. Call wait_for_bootmenu() first to
+# get into media boot menu.
+#
+# @param object
+# @param string parameters
+# @param boot selection needle, default: inst-oninstallation
+sub boot_with_parameters {
+    my $self = shift;
+    my $parameters = shift;
+    my $boot_selection = shift || "inst-oninstallation";
+
+    unless (check_screen("inst-bootmenu", 0)) {
+        die "Installation media not booted, use wait_for_bootmenu() first";
+    }
+
+    $self->bootmenu_down_to($boot_selection);
+
+    type_string $parameters;
+    save_screenshot;
+
+    send_key "ret";
+}
+
+1;
+# vim: set sw=4 et:

--- a/main.pm
+++ b/main.pm
@@ -608,6 +608,9 @@ elsif (get_var("RESCUESYSTEM")) {
     loadtest "installation/rescuesystem.pm";
     loadtest "installation/rescuesystem_validate_131.pm";
 }
+elsif (get_var("LINUXRC")) {
+    loadtest "linuxrc/system_boot.pm";
+}
 elsif (get_var("SYSAUTHTEST")) {
     load_boot_tests();
     loadtest "installation/finish_desktop.pm";

--- a/tests/linuxrc/system_boot.pm
+++ b/tests/linuxrc/system_boot.pm
@@ -1,0 +1,36 @@
+use strict;
+use base "y2logsstep";
+use testapi;
+use linuxrc;
+
+#
+# bsc#906990 [linuxrc] add "Boot Linux" to installation media
+# Added in linuxrc-5.0.44
+#
+
+sub run() {
+    my $self = shift;
+
+    $self->linuxrc::wait_for_bootmenu();
+
+    $self->linuxrc::boot_with_parameters("SystemBoot=1");
+    assert_screen("linuxrc-system_boot-select-a-system-to-boot", 60);
+
+    # Press [Enter] till the last dialog for booting appears
+    $self->key_round("linuxrc-system-boot-kernel-options", "ret", 8);
+
+    # Confirm booting
+    bmwqemu::diag "Booting the installed system now...";
+    send_key "ret", 0;
+
+    # Wait for the system to boot
+    assert_screen("displaymanager", 60);
+}
+
+sub test_flags() {
+    return { 'important' => 1, 'fatal' => 1, 'milestone' => 1 };
+}
+
+1;
+
+# vim: set sw=4 et:


### PR DESCRIPTION
- bsc#906990
- Requires linuxrc-5.0.44 and higher to be used for install media

Integrated into opensuse distri the very same way as with `RESCUESYSTEM`. Use `LINUXRC=1`.

Test result can be seen here: https://yast-openqa.suse.cz/tests/393

1. There must be an installed system that will be booted from Linxurc
2. Installation ISO must be mounted, as we load Linuxrc from that media
3. No other (especially bootloader) test can run before Linuxrc test because this test adds some special parameter before booting to Linuxrc

I've used this comand: /usr/share/openqa/script/client jobs post DISTRI=opensuse BACKEND=qemu ARCH=x86_64 BUILD=20150606 VERSION=Tumbleweed ISO=openSUSE-Tumbleweed-DVD-x86_64-Snapshot20150606-Media.iso LINUXRC=1 HDD_1=tumbleweed_minimalx.qcow2 DESKTOP=minimalx TEST=linuxrc

This test can be also called right after rebooting the system, the test itself handles different position of the CD/DVD in BIOS boot menu.

Needles are here: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/34
