### PR TITLE
More robust yast2_snapper module

### DIFF
--- a/tests/x11/yast2_snapper.pm
+++ b/tests/x11/yast2_snapper.pm
@@ -41,8 +41,8 @@ sub y2snapper_select_snapshot() {
     return 0 unless (check_screen('yast2_snapper-new_snapshot', 3));
 
     until (check_screen('yast2_snapper-new_snapshot_selected', 5) || $limit > 20) {
-      $limit++;
-      send_key "down";
+        $limit++;
+        send_key "down";
     }
     if (check_screen('yast2_snapper-new_snapshot_selected', 5)) {
         return 1;
@@ -80,10 +80,7 @@ sub run() {
     script_run "yast2 snapper";
     assert_screen 'yast2_snapper-snapshots', 100;
     # Make sure the test snapshot is not there
-    if (check_screen('yast2_snapper-new_snapshot', 5)) {
-      $self->result('fail');
-      return;
-    }
+    die("Unexpected snapshot found") if (check_screen('yast2_snapper-new_snapshot', 5));
 
     # Create a new snapshot
     $self->y2snapper_create_snapshot();
@@ -102,9 +99,8 @@ sub run() {
     assert_screen 'yast2_snapper-snapshots', 100;
     # Select the new snapshot
     unless ($self->y2snapper_select_snapshot) {
-      $self->result('fail');
-      $self->clean_and_quit;
-      return;
+        $self->clean_and_quit;
+        die("Failed to select the snapshot in order to show differences");
     }
     # Press 'S'how changes button and select both directories that have been
     # extracted from the tarball
@@ -125,9 +121,8 @@ sub run() {
 
     # Select the new snapshot
     unless ($self->y2snapper_select_snapshot) {
-      $self->result('fail');
-      $self->clean_and_quit;
-      return;
+        $self->clean_and_quit;
+        die("Failed to select the snapshot in order to delete it");
     }
     # Dele't'e the snapshot
     send_key "alt-t";
@@ -136,9 +131,10 @@ sub run() {
     # Make sure the snapshot is not longer there
     assert_screen 'yast2_snapper-snapshots', 100;
     if (check_screen('yast2_snapper-new_snapshot', 5)) {
-      $self->result('fail');
+        $self->clean_and_quit;
+        die("The snapshot is still visible after trying to delete it");
     }
-
+    # Success
     $self->clean_and_quit;
 }
 

--- a/tests/x11/yast2_snapper.pm
+++ b/tests/x11/yast2_snapper.pm
@@ -29,43 +29,87 @@ sub y2snapper_create_snapshot() {
     sleep 2;
     send_key "alt-o";
 }
+
+# Helper for selecting the new snapshot in y2-snapper
+#
+# Called when the list has been just loaded, so the top most item is selected
+sub y2snapper_select_snapshot() {
+    my $limit = 0; # Just in case the needles don't match at all (sh*t happens)
+
+    return 1 if (check_screen('yast2_snapper-new_snapshot_selected', 3));
+    # Return false if there is no snapshot to select
+    return 0 unless (check_screen('yast2_snapper-new_snapshot', 3));
+
+    until (check_screen('yast2_snapper-new_snapshot_selected', 5) || $limit > 20) {
+      $limit++;
+      send_key "down";
+    }
+    if (check_screen('yast2_snapper-new_snapshot_selected', 5)) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+# Quit yast2-snapper and cleanup the mess
+sub clean_and_quit() {
+    # C'l'ose  the snapper module
+    send_key "alt-l";
+    # Wait until xterm is focussed, delete the directory and close xterm
+    wait_idle;
+    script_run "rm -rf testdata";
+    script_run "ls";
+    script_run "exit";
+    save_screenshot;
+    script_run "exit";
+}
+
 sub run() {
     my $self = shift;
+
     # Make sure yast2-snapper is installed (if not: install it)
     ensure_installed "yast2-snapper";
+
     # Start an xterm as root
     x11_start_program("xterm");
     wait_idle;
     become_root;
     script_run "cd";
+
     # Start the yast2 snapper module and wait until it is started
     script_run "yast2 snapper";
-    assert_screen 'yast2_snapper-no_new_snapshot', 100;
+    assert_screen 'yast2_snapper-snapshots', 100;
+    # Make sure the test snapshot is not there
+    if (check_screen('yast2_snapper-new_snapshot', 5)) {
+      $self->result('fail');
+      return;
+    }
+
     # Create a new snapshot
     $self->y2snapper_create_snapshot();
     # Make sure the snapshot is listed in the main window
     assert_screen 'yast2_snapper-new_snapshot', 100;
     # C'l'ose  the snapper module
     send_key "alt-l";
+
     # Download & untar test files
     wait_idle;
     script_run "tar -xzf /home/$username/data/yast2_snapper.tgz && echo tar_complete > /dev/$serialdev";
     wait_serial('tar_complete') || die 'tar -xzf failed';
+
     # Start the yast2 snapper module and wait until it is started
     script_run "yast2 snapper";
-    # Make sure the snapper module is started
-    assert_screen 'yast2_snapper-new_snapshot', 100;
+    assert_screen 'yast2_snapper-snapshots', 100;
     # Select the new snapshot
-    send_key "down";
-    sleep 2;
-    send_key "down";
-    sleep 2;
-    send_key "down";
-    sleep 2;
+    unless ($self->y2snapper_select_snapshot) {
+      $self->result('fail');
+      $self->clean_and_quit;
+      return;
+    }
     # Press 'S'how changes button and select both directories that have been
     # extracted from the tarball
     send_key "alt-s";
-    assert_screen 'yast2_snapper-collapsed_testdata', 100;
+    assert_screen 'yast2_snapper-collapsed_testdata', 200;
     send_key "tab";
     sleep 2;
     send_key "spc";
@@ -78,27 +122,24 @@ sub run() {
     # Close the dialog and make sure it is closed
     send_key "alt-c";
     assert_screen 'yast2_snapper-new_snapshot', 100;
+
     # Select the new snapshot
-    send_key "down";
-    sleep 2;
-    send_key "down";
-    sleep 2;
-    send_key "down";
-    sleep 2;
+    unless ($self->y2snapper_select_snapshot) {
+      $self->result('fail');
+      $self->clean_and_quit;
+      return;
+    }
     # Dele't'e the snapshot
     send_key "alt-t";
     assert_screen 'yast2_snapper-confirm_delete', 100;
     send_key "alt-y";
-    assert_screen 'yast2_snapper-no_new_snapshot', 100;
-    # C'l'ose  the snapper module
-    send_key "alt-l";
-    # Wait until xterm is focussed, delete the directory and close xterm
-    wait_idle;
-    script_run "rm -rf testdata";
-    script_run "ls";
-    script_run "exit";
-    save_screenshot;
-    script_run "exit";
+    # Make sure the snapshot is not longer there
+    assert_screen 'yast2_snapper-snapshots', 100;
+    if (check_screen('yast2_snapper-new_snapshot', 5)) {
+      $self->result('fail');
+    }
+
+    $self->clean_and_quit;
 }
 
 1;


### PR DESCRIPTION
Goes together with https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/36

The previous version assumed a fixed number of snapshots. but the number of snapshots actually depends on the steps performed before calling yast2-snapper.  Examples:
https://yast-openqa.suse.cz/tests/416
https://yast-openqa.suse.cz/tests/420
https://yast-openqa.suse.cz/tests/419