### PR TITLE
choose eth0 as default network device for autoyast

### DIFF
--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -233,7 +233,7 @@ sub run() {
 
     my $args = "";
     if ( get_var("AUTOYAST") ) {
-        $args .= " netsetup=dhcp,all";
+        $args .= " netdevice=eth0 netsetup=dhcp,all";
         $args .= " autoyast=" . autoinst_url . "/data/" . get_var("AUTOYAST") . " ";
     }
     type_string $args, 13;


### PR DESCRIPTION
https://openqa.suse.de/tests/91656/modules/start_install/steps/5