### PR TITLE
use switched release note shortcuts for SLED

### DIFF
--- a/tests/installation/sle11_releasenotes.pm
+++ b/tests/installation/sle11_releasenotes.pm
@@ -9,9 +9,9 @@ sub run(){
     if (get_var("ADDONS")) {
         if (check_screen 'release-notes-tab') {
             foreach $a (split(/,/, get_var('ADDONS'))) {
-                if ($a eq 'smt') {
+                if ($a eq 'smt' || check_var('FLAVOR', 'Desktop-DVD')) {
                     send_key 'alt-s';
-                    assert_screen "release-notes-smt";
+                    assert_screen "release-notes-$a";
                     send_key 'alt-u';
                     assert_screen "release-notes-sle";
                 }


### PR DESCRIPTION
SLED has switched shortcuts, same as SMT addon

SLED
https://openqa.suse.de/tests/92095/modules/sle11_releasenotes/steps/3
SLES
https://openqa.suse.de/tests/92088/modules/sle11_releasenotes/steps/3