### PR TITLE
Increase timeout in yast tests

### DIFF
--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -26,7 +26,7 @@ sub run() {
         send_key "alt-f";
     }
     # yast might take a while on sle11 due to suseconfig
-    wait_serial("yast2-i-status-0", 40) || die "yast didn't finish";
+    wait_serial("yast2-i-status-0", 60) || die "yast didn't finish";
 
     send_key "ctrl-l";                  # clear screen to see that second update does not do any more
     script_run("rpm -e $pkgname && echo '$pkgname removed' > /dev/$serialdev");

--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -8,7 +8,7 @@ sub run() {
     my $self = shift;
     script_sudo("/sbin/yast2 lan");
 
-    my $ret = assert_screen [qw/Networkmanager_controlled yast2_lan install-susefirewall2/], 20;
+    my $ret = assert_screen [qw/Networkmanager_controlled yast2_lan install-susefirewall2/], 30;
     if ( $ret->{needle}->has_tag('Networkmanager_controlled') ) {
         send_key "ret";      # confirm networkmanager popup
         assert_screen "Networkmanager_controlled-approved";


### PR DESCRIPTION
When system is under very heavy load the current timeouts are a dash too strict..increase by a conservative amount