### PR TITLE
sysauth tests: add the snapshot repository to zypper

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -630,6 +630,7 @@ elsif (get_var("SYSAUTHTEST")) {
     loadtest "installation/finish_desktop.pm";
     # sysauth test scenarios run in the console
     loadtest "console/consoletest_setup.pm";
+    loadtest "console/zypper_ar.pm";
     loadtest "sysauth/sssd.pm";
 }
 else {


### PR DESCRIPTION
As part of the packages are on the live image, and some need to be
installed later, there is generally an issue on version updates:
* The media contains the 'new' version checked in to the snapshot
* Other packages come from the onlnine repo, which per default is the
  published Tumbleweed repository. There, in turn, is still the old
  version published.