### PR TITLE
sysauth tests: wait for zypper to finish installing

### DIFF
--- a/tests/sysauth/sssd.pm
+++ b/tests/sysauth/sssd.pm
@@ -15,6 +15,7 @@ sub run() {
     /;
     script_run "systemctl stop packagekit.service; systemctl mask packagekit.service";
     script_run "zypper -n refresh && zypper -n in @test_subjects";
+    wait_idle;
 
     script_run "cd; curl -L -v ".autoinst_url."/data/sssd-tests > sssd-tests.data && cpio -id < sssd-tests.data && mv data sssd && ls sssd";
 


### PR DESCRIPTION
That should hopefully do it... currently, as seen in test https://openqa.opensuse.org/tests/69438 it just moves on to typing the testings, even though zypp is still busy (there is another issue left, as one of the packages seems to fail to install anyway, but that's out of scope for this test)