### PR TITLE
consoletest_setup: ensure curl is installed

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -26,6 +26,8 @@ sub run() {
     become_root;
     script_run "systemctl mask packagekit.service";
     script_run "systemctl stop packagekit.service";
+    script_run "zypper -n install curl; echo \"zypper-curl-\$?-\" > /dev/$serialdev";
+    wait_serial "zypper-curl-0-";
     script_run "exit";
 
     save_screenshot;

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -26,7 +26,7 @@ sub run() {
     become_root;
     script_run "systemctl mask packagekit.service";
     script_run "systemctl stop packagekit.service";
-    script_run "zypper -n install curl; echo \"zypper-curl-\$?-\" > /dev/$serialdev";
+    script_run "zypper -n install curl tar; echo \"zypper-curl-\$?-\" > /dev/$serialdev";
     wait_serial "zypper-curl-0-";
     script_run "exit";
 


### PR DESCRIPTION
On the minimal server pattern, curl is no longer pulled in automatically
(which makes sense). So we just install curl before actually using it.