### PR TITLE
send_key alt-e only for installation

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -21,7 +21,9 @@ sub run(){
         }
     }
     send_key 'alt-o';   # exit release notes window
-    send_key 'alt-e';   # select region as previous selected
+    if (!get_var("UPGRADE")) {
+        send_key 'alt-e';   # select timezone region as previously selected
+    }
 }
 
 1;


### PR DESCRIPTION
update is failing because of alt-e, alt-e is needed for text mode installation.
https://openqa.suse.de/tests/97025/modules/installation_overview/steps/2