### PR TITLE
[do not merge] Add yast-users tests

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -447,6 +447,7 @@ sub load_consoletests() {
         }
         loadtest "console/zypper_ref.pm";
         loadtest "console/yast2_lan.pm";
+        loadtest "console/yast2_users.pm";
         loadtest "console/curl_https.pm";
         if (!get_var("OFW")) {
             loadtest "console/aplay.pm";

--- a/tests/console/yast2_users.pm
+++ b/tests/console/yast2_users.pm
@@ -7,9 +7,9 @@ sub add_user() {
     type_string "Test user";
     assert_screen "yast2_users-username";
     send_key "alt-p";
-    type_string "nots3cr3t.";
+    type_password "nots3cr3t.";
     send_key "tab";
-    type_string "nots3cr3t.";
+    type_password "nots3cr3t.";
     send_key "alt-o";
     assert_screen "yast2_users-disable_autologin";
     send_key "alt-n";
@@ -34,9 +34,9 @@ sub remove_user() {
 }
 
 sub add_passwordless_user() {
-    script_run "pam-config -a --unix-nullok";
-    script_run "useradd test -c 'Test user'";
-    script_run "passwd -d test";
+    assert_script_run "pam-config -a --unix-nullok";
+    assert_script_run "useradd test -c 'Test user'";
+    assert_script_run "passwd -d test";
 }
 
 sub edit_passwordless_user() {
@@ -46,12 +46,12 @@ sub edit_passwordless_user() {
 }
 
 sub remove_passwordless_user() {
-    script_run "pam-config -d --unix-nullok";
-    script_run "userdel test";
+    assert_script_run "pam-config -d --unix-nullok";
+    assert_script_run "userdel test";
 }
 
 sub start_yast2_users() {
-    script_run "yast2 users";
+    assert_script_run "yast2 users";
     assert_screen "yast2_users-users";
 }
 

--- a/tests/console/yast2_users.pm
+++ b/tests/console/yast2_users.pm
@@ -1,0 +1,84 @@
+use base "console_yasttest";
+use testapi;
+
+sub add_user() {
+    send_key "alt-a";
+    assert_screen "yast2_users-add_user";
+    type_string "Test user";
+    assert_screen "yast2_users-username";
+    send_key "alt-p";
+    type_string "nots3cr3t.";
+    send_key "tab";
+    type_string "nots3cr3t.";
+    send_key "alt-o";
+    assert_screen "yast2_users-disable_autologin";
+    send_key "alt-n";
+    assert_screen "yast2_users-testuser";
+}
+
+sub edit_user() {
+    send_key "alt-i";
+    assert_screen "yast2_users-edit_testuser";
+    send_key "alt-f";
+    sleep 1;
+    type_string " #1";
+    send_key "alt-o";
+    assert_screen "yast2_users-edited_testuser";
+}
+
+sub remove_user() {
+    send_key "alt-t";
+    assert_screen "yast2_users-confirm_delete";
+    send_key "alt-y";
+    assert_screen "yast2_users-users";
+}
+
+sub add_passwordless_user() {
+    script_run "pam-config -a --unix-nullok";
+    script_run "useradd test -c 'Test user'";
+    script_run "passwd -d test";
+}
+
+sub edit_passwordless_user() {
+    send_key "down";
+    sleep 1;
+    edit_user;
+}
+
+sub remove_passwordless_user() {
+    script_run "pam-config -d --unix-nullok";
+    script_run "userdel test";
+}
+
+sub start_yast2_users() {
+    script_run "yast2 users";
+    assert_screen "yast2_users-users";
+}
+
+sub run() {
+    become_root;
+
+    # Start yast2 users
+    start_yast2_users;
+
+    # Basic tests
+    add_user;
+    edit_user;
+    remove_user;
+    send_key "alt-o"; # Exit yast2 users
+
+    # Password-less users
+    send_key "ctrl-l"; # Clear screen
+    add_passwordless_user;
+    start_yast2_users;
+    edit_passwordless_user;
+    send_key "alt-o"; # Exit yast2 users
+    remove_passwordless_user;
+
+    # Exit
+    send_key "ctrl-l"; # Clear screen
+    script_run "exit"
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/console/yast2_users.pm
+++ b/tests/console/yast2_users.pm
@@ -7,9 +7,9 @@ sub add_user() {
     type_string "Test user";
     assert_screen "yast2_users-username";
     send_key "alt-p";
-    type_password "nots3cr3t.";
+    type_password;
     send_key "tab";
-    type_password "nots3cr3t.";
+    type_password;
     send_key "alt-o";
     assert_screen "yast2_users-disable_autologin";
     send_key "alt-n";


### PR DESCRIPTION
Add some basic tests about yast2-users (create, edit and delete users). It contains a test about fixed bug [bsc#928607](https://bugzilla.suse.com/show_bug.cgi?id=928607) so I guess it should not be merged until yast2-users 3.1.39 is available on TW.

Anyway, feedback is welcome.

Thanks.