### PR TITLE
final release notes for sle12

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -5,21 +5,34 @@ use testapi;
 sub run(){
     my $self=shift;
 
-    if (check_var('VIDEOMODE', 'text')) {
-        send_key "alt-l";   # open release notes window
-        send_key 'alt-s';   # jump to first tab
-    }
-    else {
-        assert_and_click 'release-notes-button';    # open release notes window
-        assert_and_click 'release-notes-tab-sle';   # click on first SLES tab
-    }
-    assert_screen 'release-notes-sle';  # SLE release notes
     if (get_var("ADDONS")) {
+        if (check_var('VIDEOMODE', 'text')) {
+            send_key "alt-l";   # open release notes window
+            send_key 'alt-s';   # jump to first tab
+        }
+        else {
+            assert_and_click 'release-notes-button';    # open release notes window
+            assert_and_click 'release-notes-tab-sle';   # click on first SLES tab
+        }
+        assert_screen 'release-notes-sle';  # SLE release notes
         foreach $a (split(/,/, get_var('ADDONS'))) {
             send_key 'alt-s';   # jump to first tab
             send_key_until_needlematch("release-notes-tab-$a", 'right');
         }
     }
+    else {
+        if (check_var('VIDEOMODE', 'text')) {
+            send_key "alt-l";   # open release notes window
+        }
+        else {
+            assert_and_click 'release-notes-button';    # open release notes window
+        }
+        assert_screen 'release-notes-sle';  # SLE release notes
+        if (check_screen 'release-notes-tab') {
+            record_soft_failure;    # https://bugzilla.suse.com/show_bug.cgi?id=935599
+        }
+    }
+
     send_key 'alt-o';   # exit release notes window
     if (!get_var("UPGRADE")) {
         send_key 'alt-e';   # select timezone region as previously selected


### PR DESCRIPTION
thx to @lnussel 
this should be final sle12 release notes, I didn't think and worked with buggy double release notes [bnc935599](https://bugzilla.suse.com/show_bug.cgi?id=935599) added soft fail for tabs without addons

gnome
http://10.100.98.90/tests/1108
textmode
http://10.100.98.90/tests/1109