### PR TITLE
clone system and use the autoyast file in chained tests

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -483,6 +483,9 @@ sub load_consoletests() {
         if (check_var("DESKTOP", "xfce")) {
             loadtest "console/xfce_gnome_deps.pm";
         }
+        if (get_var("CLONE_SYSTEM")) {
+            loadtest "console/yast2_clone_system.pm";
+        }
         loadtest "console/consoletest_finish.pm";
     }
 }

--- a/tests/console/yast2_clone_system.pm
+++ b/tests/console/yast2_clone_system.pm
@@ -1,0 +1,29 @@
+use base "console_yasttest";
+use testapi;
+
+sub run() {
+    my $self    = shift;
+
+    become_root();
+    type_string "PS1=\"# \"\n";
+
+    type_string("rm -f /root/autoinst.xml ; zypper -n in autoyast2 ; yast2 clone_system ; echo FINISHED >/dev/$serialdev\n");
+    my $n_error = 0;
+    while ($n_error < 5 && !wait_serial("FINISHED", 200)) {
+        # try to confirm error dialogs and continue
+        $self->result('fail');
+        save_screenshot;
+        send_key "ret";
+        $n_error++;
+    }
+
+    type_string("test -f /root/autoinst.xml && echo CLONED >/dev/$serialdev\n");
+    die "autoinst.xml was not created" if !wait_serial("CLONED", 20);
+
+    upload_asset "/root/autoinst.xml";
+
+    type_string "exit\n";
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -237,7 +237,7 @@ sub run() {
         $netsetup = " ".get_var("NETWORK_INIT_PARAM") if defined get_var("NETWORK_INIT_PARAM"); #e.g netsetup=dhcp,all
         $netsetup = " netsetup=dhcp,all" if defined get_var("USE_NETSETUP"); #netsetup override for sle11
         $args .= $netsetup;
-        $args .= " autoyast=" . autoinst_url . "/data/" . get_var("AUTOYAST") . " ";
+        $args .= " autoyast=" . data_url(get_var("AUTOYAST")) . " ";
     }
 
     if ( get_var("AUTOUPGRADE")) {


### PR DESCRIPTION
A job can clone the system and upload autoinst.xml as an asset with
CLONE_SYSTEM=1

This asset can be used for installation of chained job:
ASSET_1=autoinst.xml
AUTOYAST=ASSET_1
START_AFTER_TEST=<the first job>
