### PR TITLE
Changing whait time in autoyast_reboot.pm to 5900

### DIFF
--- a/tests/installation/autoyast_reboot.pm
+++ b/tests/installation/autoyast_reboot.pm
@@ -5,7 +5,12 @@ use testapi;
 sub run() {
     my $self = shift;
 
-    assert_screen( "grub2", 900 );
+    if (get_var("AUTOUPGRADE")) {
+	 assert_screen( "grub2", 5900 );
+    }
+    else {
+	assert_screen( "grub2", 900 );
+    }
 }
 
 1;


### PR DESCRIPTION
Changing whati time in autoyast_reboot.pm to 5900 to allow upgrade to finish in time for further autoyast tests with addons.