### PR TITLE
Support for the new tests for yast command line

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -51,7 +51,7 @@ sub run_yast_cli_test {
       script_run "# Skip running 'prove'";
     }
 
-    script_run "cd ..";
+    script_run 'cd ..';
     script_run "rm -rf $repo";
 }
 

--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -47,8 +47,6 @@ sub run_yast_cli_test {
     $action = wait_serial(['run', 'skip'], 10);
     if ($action eq 'run') {
       assert_script_run 'prove';
-    } else {
-      script_run "# Skip running 'prove'";
     }
 
     script_run 'cd ..';

--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -46,7 +46,8 @@ sub run_yast_cli_test {
     script_run("if [ -d t ]; then echo 'run' | tee /dev/$serialdev; fi");
     assert_script_run 'prove' if wait_serial 'run', 10;
 
-    script_run "cd .."
+    script_run "cd ..";
+    script_run "rm -rf $repo";
 }
 
 1;

--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -30,5 +30,24 @@ sub post_run_hook {
     $self->clear_and_verify_console;
 }
 
+# Executes the command line tests from a yast repository (in master or in the
+# given optional branch) using prove
+sub run_yast_cli_test {
+    my ($self, $repo, $branch) = @_;
+    my $action;
+
+    script_run "git clone https://github.com/yast/$repo.git";
+    script_run "cd $repo";
+
+    if ($branch) {
+        script_run "git checkout $branch";
+    }
+    # Run 'prove' only if there is a directory called t
+    script_run("if [ -d t ]; then echo 'run' | tee /dev/$serialdev; fi");
+    assert_script_run 'prove' if wait_serial 'run', 10;
+
+    script_run "cd .."
+}
+
 1;
 # vim: set sw=4 et:

--- a/main.pm
+++ b/main.pm
@@ -429,6 +429,7 @@ sub load_consoletests() {
         loadtest "console/consoletest_setup.pm";
         loadtest "console/textinfo.pm";
         loadtest "console/hostname.pm";
+        loadtest "console/yast2_cmdline.pm";
         if (snapper_is_applicable) {
             loadtest "console/snapper_snapshots.pm";
             if (get_var("UPGRADE")) {

--- a/tests/console/yast2_cmdline.pm
+++ b/tests/console/yast2_cmdline.pm
@@ -14,7 +14,7 @@ sub run() {
     $self->run_yast_cli_test('yast-dns-server');
 
     # Exit from root
-    script_run "exit";
+    script_run 'exit';
 }
 
 1;

--- a/tests/console/yast2_cmdline.pm
+++ b/tests/console/yast2_cmdline.pm
@@ -6,10 +6,15 @@ sub run() {
 
     become_root();
     # Install git
-    script_run "zypper -n install git-core; echo \"zypper-git-\$?-\" > /dev/$serialdev";
-    wait_serial "zypper-git-0-";
+    assert_script_run 'zypper -n install git-core';
 
+    # Run all the existing YaST CLI tests
     $self->run_yast_cli_test('yast-network');
+    assert_script_run 'zypper -n install bind yast2-dns-server';
+    $self->run_yast_cli_test('yast-dns-server');
+
+    # Exit from root
+    script_run "exit";
 }
 
 1;

--- a/tests/console/yast2_cmdline.pm
+++ b/tests/console/yast2_cmdline.pm
@@ -1,0 +1,16 @@
+use base "console_yasttest";
+use testapi;
+
+sub run() {
+    my $self = shift;
+
+    become_root();
+    # Install git
+    script_run "zypper -n install git-core; echo \"zypper-git-\$?-\" > /dev/$serialdev";
+    wait_serial "zypper-git-0-";
+
+    $self->run_yast_cli_test('yast-network');
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Goes together with https://github.com/yast/yast-network/pull/322 

This does not include the test main.pm. That's intentional for the time being.