### PR TITLE
The incredible fix for new LibreOffice

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -511,14 +511,14 @@ sub load_x11tests(){
     if (gnomestep_is_applicable) {
         loadtest "x11/eog.pm";
     }
-    if (get_var("DESKTOP") =~ /kde|gnome/ && !is_server) {
-        loadtest "x11/ooffice.pm";
-    }
     if (!get_var("NICEVIDEO") && get_var("DESKTOP") =~ /kde|gnome/ && !is_server) {
         loadtest "x11/oomath.pm";
     }
     if (!get_var("NICEVIDEO") && get_var("DESKTOP") =~ /kde|gnome/ && !get_var("LIVECD") && !is_server) {
         loadtest "x11/oocalc.pm";
+    }
+    if (get_var("DESKTOP") =~ /kde|gnome/ && !is_server) {
+        loadtest "x11/ooffice.pm";
     }
     if (kdestep_is_applicable) {
         loadtest "x11/khelpcenter.pm";


### PR DESCRIPTION
After tried many debugging way and all temporary fix all are failed in
ooffice test with new LibreOffice, unbelievable reordering the ooffice
test to after of oomath and oocalc test does work on openqa.o.o. This
sounds quite strange, but if this does work then just define it was
the workaround. The ordering of ooffice, oocalc and oomath is not that
important actually.