### PR TITLE
Close the terminal after snapshots tests

### DIFF
--- a/tests/console/installation_snapshots.pm
+++ b/tests/console/installation_snapshots.pm
@@ -6,6 +6,7 @@ sub run() {
     script_run("snapper list | tee /dev/$serialdev");
     # Check if the snapshot called 'after installation' is there
     wait_serial("after installation", 5);
+    script_run("exit");
 }
 
 sub test_flags() {

--- a/tests/console/upgrade_snapshots.pm
+++ b/tests/console/upgrade_snapshots.pm
@@ -7,6 +7,7 @@ sub run() {
     # Check if the snapshots called 'before upgrade' and 'after upgrade' are
     # there.
     wait_serial(qr/before upgrade.*(\n.*)+after upgrade/, 5);
+    script_run("exit");
 }
 
 sub test_flags() {


### PR DESCRIPTION
Add the missing 'exit' after snapshots tests.