### PR TITLE
add some sleep for reboot

### DIFF
--- a/tests/x11/reboot_gnome_pre.pm
+++ b/tests/x11/reboot_gnome_pre.pm
@@ -27,8 +27,9 @@ sub run() {
 
     if (get_var("SHUTDOWN_NEEDS_AUTH")) {
         assert_screen 'reboot-auth', 15;
-        sleep 1;
+        sleep 3;
         type_password;
+        sleep 3;
         send_key "ret";
 
         if (check_screen('please-try-again', 3)) {


### PR DESCRIPTION
If this change doesn't work I will revert it.
Migration tests reboots are failing, password must be good and I don;t see any reason why it should fail eg. gnome test is green
On my local openQA migration test is green