### PR TITLE
yast2_dns_server: the yast module requires SuSEfirewall2 to be installed

### DIFF
--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -37,7 +37,7 @@ sub run() {
     #
     become_root;
     # Make sure packages are installed
-    assert_script_run 'zypper -n in yast2-dns-server bind';
+    assert_script_run 'zypper -n in yast2-dns-server bind SuSEfirewall2';
     # Let's pretend this is the first execution (could not be the case if
     # yast2_cmdline was executed before)
     script_run 'rm /var/lib/YaST2/dns_server';


### PR DESCRIPTION
If the package is not there, YaST will ask to install it, but breaking the predicted workflow.

See for example: https://openqa.opensuse.org/tests/75944/modules/yast2_dns_server/steps/6

