### PR TITLE
don't use snapper test for sle11 migration

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -137,6 +137,9 @@ if ( !is_desktop ) {
 if ( check_var( 'DESKTOP', 'minimalx' ) ) {
     set_var("XDMUSED", 1);
 }
+if (get_var('HDD_1') =~ /\D*-11-\S*/) {
+    set_var('FILESYSTEM', 'ext4');
+}
 
 unless (get_var('PACKAGETOINSTALL')) {
     set_var("PACKAGETOINSTALL", "x3270");


### PR DESCRIPTION
snapper tests in sle11migration  tests are failing because of ext4 file system in sle11
e.g. https://openqa.suse.de/tests/113923/modules/upgrade_snapshots/steps/3