### PR TITLE
New test for yast2-nfs-client and reactivation of yast tests

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -404,6 +404,7 @@ sub load_consoletests() {
 # The yast tests are not really ready for production - they break in staging tests
 #        loadtest "console/yast2_cmdline.pm";
 #        loadtest "console/yast2_dns_server.pm";
+        loadtest "console/yast2_nfs_client.pm";
         if (snapper_is_applicable) {
             if (get_var("UPGRADE")) {
                 loadtest "console/upgrade_snapshots.pm";

--- a/main.pm
+++ b/main.pm
@@ -401,9 +401,8 @@ sub load_consoletests() {
         loadtest "console/consoletest_setup.pm";
         loadtest "console/textinfo.pm";
         loadtest "console/hostname.pm";
-# The yast tests are not really ready for production - they break in staging tests
-#        loadtest "console/yast2_cmdline.pm";
-#        loadtest "console/yast2_dns_server.pm";
+        loadtest "console/yast2_cmdline.pm";
+        loadtest "console/yast2_dns_server.pm";
         loadtest "console/yast2_nfs_client.pm";
         if (snapper_is_applicable) {
             if (get_var("UPGRADE")) {

--- a/tests/console/yast2_nfs_client.pm
+++ b/tests/console/yast2_nfs_client.pm
@@ -1,0 +1,57 @@
+use base "console_yasttest";
+use testapi;
+
+# Test "yast2 nfs-client" functionality
+# Ensures that it works with the current version of nfs-client (it got broken
+# with the conversion from init.d to systemd services)
+
+sub run() {
+    my $self = shift;
+
+    #
+    # Preparation
+    #
+    become_root;
+    # Make sure packages are installed
+    assert_script_run 'zypper -n in yast2-nfs-client nfs-client nfs-kernel-server';
+    # Prepare the test file structure
+    assert_script_run 'mkdir -p /tmp/nfs/server';
+    assert_script_run 'echo "It worked" > /tmp/nfs/server/file.txt';
+    # Serve the share
+    assert_script_run 'echo /tmp/nfs/server *(ro) >> /etc/exports';
+    assert_script_run 'systemctl start nfs-server';
+
+    #
+    # YaST nfs-client execution
+    #
+    script_run '/sbin/yast2 nfs-client';
+    assert_screen 'yast2-nfs-client-shares';
+    # Open the dialog to add a connection to the share
+    send_key 'alt-a';
+    assert_screen 'yast2-nfs-client-add';
+    type_string 'localhost';
+    # Explore the available shares and select the only available one
+    send_key 'alt-e';
+    assert_screen 'yast2-nfs-client-exported';
+    send_key 'alt-o';
+    # Set the local mount point
+    send_key 'alt-m';
+    type_string '/tmp/nfs/client';
+    # Save the new connection and close YaST
+    send_key 'alt-o';
+    send_key 'alt-o';
+    wait_idle;
+
+    #
+    # Check the result
+    #
+    script_run "cat /tmp/nfs/client/file.txt > /dev/$serialdev";
+    wait_serial('It worked', 10);
+
+    # Exit from root
+    script_run 'exit';
+}
+
+1;
+
+# vim: set sw=4 et:


### PR DESCRIPTION
Depends on https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/42

Verified that the new test and also the disabled tests are already working in Tumbleweed (they were disabled because I merged them too fast and they broke staging).