### PR TITLE
ZDUP test will boot pre-installed system

### DIFF
--- a/tests/installation/bootloader_ofw.pm
+++ b/tests/installation/bootloader_ofw.pm
@@ -11,6 +11,9 @@ sub run() {
     if (get_var("UPGRADE")) {
         send_key_until_needlematch 'inst-onupgrade', 'up';
     }
+    elsif (get_var("ZDUP")) {
+        assert_screen 'inst-onlocal';
+    }
     else {
         send_key_until_needlematch 'inst-oninstallation', 'up';
     }


### PR DESCRIPTION
https://openqa.suse.de/tests/116644/modules/bootloader_ofw/steps/6

boot instead of install for ZDUP tests