### PR TITLE
use assert_and_click for reboot

### DIFF
--- a/tests/x11/reboot_gnome_pre.pm
+++ b/tests/x11/reboot_gnome_pre.pm
@@ -7,23 +7,7 @@ sub run() {
     wait_idle;
     send_key "ctrl-alt-delete";    # reboot
     assert_screen 'logoutdialog', 15;
-    send_key "tab";
-    send_key "tab";
-    my $ret;
-    for (my $counter = 10; $counter > 0; $counter--) {
-        $ret = check_screen "logoutdialog-reboot-highlighted", 3;
-        if ( defined($ret) ) {
-            last;
-        }
-        else {
-            send_key "tab";
-        }
-    }
-    # report the failure or green
-    unless ( defined($ret) ) {
-        assert_screen "logoutdialog-reboot-highlighted", 1;
-    }
-    send_key "ret";                # confirm
+    assert_and_click 'logoutdialog-reboot-highlighted';
 
     if (get_var("SHUTDOWN_NEEDS_AUTH")) {
         assert_screen 'reboot-auth', 15;


### PR DESCRIPTION
needle 'logoutdialog-reboot-highlighted' has to be recreated as unselected.

sles12
http://10.100.98.90/tests/1657/modules/reboot_gnome_pre/steps/2
opensuse
http://10.100.98.90/tests/1660/modules/reboot_gnome_pre/steps/2