### PR TITLE
Uninstall minimal-base-conflicts if present

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -24,10 +24,14 @@ sub run() {
     script_sudo "chown $username /dev/$serialdev";
 
     become_root;
+    # Stop packagekit
     script_run "systemctl mask packagekit.service";
     script_run "systemctl stop packagekit.service";
-    script_run "zypper -n install curl tar; echo \"zypper-curl-\$?-\" > /dev/$serialdev";
-    wait_serial "zypper-curl-0-";
+    # Installing a minimal system gives a pattern conflicting with anything not minimal
+    # Let's uninstall 'the pattern' (no packages affected) in order to be able to install stuff
+    assert_script_run "zypper -n rm patterns-openSUSE-minimal_base-conflicts";
+    # Install curl and tar in order to get the test data
+    assert_script_run "zypper -n install curl tar";
     script_run "exit";
 
     save_screenshot;

--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -6,10 +6,6 @@ sub run() {
 
     become_root;
 
-    # Installing a minimal system gives a pattern conflicting with anything not minimal
-    # Let's uninstall 'the pattern' (no packages affected) in order to be able to install docker
-    script_run "zypper -n rm patterns-openSUSE-minimal_base-conflicts && echo 'patterns-openSUSE-minimal_base-conflicts removed' > /dev/$serialdev";
-
     # install the docker package
     script_run "zypper -n in docker && echo 'docker_installed' > /dev/$serialdev";
     die "docker install failed" unless wait_serial "docker_installed", 200;


### PR DESCRIPTION
Working tests
http://yast-openqa.suse.cz/tests/5 (textmode, not longer affected)
http://yast-openqa.suse.cz/tests/6 (kde, still works)