### PR TITLE
Minor fix in yast2_nfs_client

### DIFF
--- a/tests/console/yast2_nfs_client.pm
+++ b/tests/console/yast2_nfs_client.pm
@@ -18,7 +18,7 @@ sub run() {
     assert_script_run 'mkdir -p /tmp/nfs/server';
     assert_script_run 'echo "It worked" > /tmp/nfs/server/file.txt';
     # Serve the share
-    assert_script_run 'echo /tmp/nfs/server *(ro) >> /etc/exports';
+    assert_script_run 'echo "/tmp/nfs/server *(ro)" >> /etc/exports';
     assert_script_run 'systemctl start nfs-server';
 
     #


### PR DESCRIPTION
I was trying to fix this until I found out it was not broken, it's simply that the fix has not made it into oS:42 yet.
https://openqa.opensuse.org/tests/80504/modules/yast2_nfs_client/steps/11

In the process I at least added some missing quotes (everything seems to work without them, but it's screaming for problems in the future).