### PR TITLE
Test Recommended dependency installation (FATE#318099)

### DIFF
--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -3,11 +3,13 @@ use testapi;
 
 sub run() {
     my $self    = shift;
-    my $pkgname = 'yast2-buildtools';
-    my $recommended = 'cmake';
+    my $pkgname     = get_var("PACKAGETOINSTALL_RECOMMENDER", "yast2-nfs-client");
+    my $recommended = get_var("PACKAGETOINSTALL_RECOMMENDED", "nfs-client");
 
     become_root();
     type_string "PS1=\"# \"\n";
+
+    assert_script_run "zypper -n rm $pkgname $recommended";
 
     assert_script_run "zypper -n in yast2-packager"; # make sure yast2 sw_single module installed
 

--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -3,7 +3,8 @@ use testapi;
 
 sub run() {
     my $self    = shift;
-    my $pkgname = get_var("PACKAGETOINSTALL");
+    my $pkgname = 'yast2-buildtools';
+    my $recommended = 'cmake';
 
     become_root();
     type_string "PS1=\"# \"\n";
@@ -11,16 +12,39 @@ sub run() {
     assert_script_run "zypper -n in yast2-packager"; # make sure yast2 sw_single module installed
 
     script_run("/sbin/yast2 sw_single; echo yast2-i-status-\$? > /dev/$serialdev");
-    if (check_screen('workaround-bsc924042')) {
+    if (check_screen('workaround-bsc924042', 10)) {
         send_key 'alt-o';
         record_soft_failure;
     }
     assert_screen 'empty-yast2-sw_single';
+
+    # Testcase according to https://fate.suse.com/318099
+    # UC1:
+    # Select a certain package, check that another gets selected/installed
     type_string("$pkgname\n");
     sleep 3;
     send_key "spc";    # select for install
-    sleep 1;
-    assert_screen "package-$pkgname-selected-for-install", 3;
+    assert_screen "$pkgname-selected-for-install", 5;
+
+    send_key "alt-p"; # go to search box again
+    for ( 1 .. length($pkgname) ) { send_key "backspace" }
+    type_string("$recommended\n");
+    assert_screen "$recommended-selected-for-install", 10;
+
+    # UC2b:
+    # Given that package is not installed,
+    # uncheck Dependencies/Install Recommended Packages,
+    # select the package, verify that recommended package is NOT selected
+    send_key "alt-d"; # Menu "Dependencies"
+    assert_screen 'yast2-sw_install_recommended_packages_enabled', 60;
+    send_key "alt-r"; # Submenu Install Recommended Packages
+
+    assert_screen "$recommended-not-selected-for-install", 5;
+    send_key "alt-p"; # go to search box again
+    for ( 1 .. length($recommended) ) { send_key "backspace" }
+    type_string("$pkgname\n");
+    assert_screen "$pkgname-selected-for-install", 10;
+
     send_key "alt-a", 1;    # accept
     # Upgrade tests and the old distributions eg. SLE11 doesn't shows the summary
     unless ( get_var("YAST_SW_NO_SUMMARY") ) {


### PR DESCRIPTION
A followup to #657, where the involved packages should be present in all tested distros: openSUSE, SLE, Ring 1.