### PR TITLE
Remove unused variable

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -148,9 +148,6 @@ if (get_var('HDD_1') =~ /\D*-11-\S*/) {
 unless (get_var('PACKAGETOINSTALL')) {
     set_var("PACKAGETOINSTALL", "x3270");
 }
-unless (get_var('PACKAGETOINSTALLWITHRECOMMENDS')) {
-    set_var("PACKAGETOINSTALLWITHRECOMMENDS", "dasher");
-}
 set_var("WALLPAPER", '/usr/share/wallpapers/SLEdefault/contents/images/1280x1024.jpg');
 
 # set KDE and GNOME, ...


### PR DESCRIPTION
#677 was merged too fast. Now that #657 has been superseded  by #686, this variable makes no sense anymore (we use the same package in every distro).