### PR TITLE
SCC post registration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -22,7 +22,7 @@ use strict;
 
 use testapi;
 
-our @EXPORT = qw/fill_in_registration_data registration_bootloader_params/;
+our @EXPORT = qw/fill_in_registration_data registration_bootloader_params yast_scc_registration/;
 
 sub fill_in_registration_data {
 
@@ -123,6 +123,18 @@ sub registration_bootloader_params
         }
         save_screenshot;
     }
+}
+
+sub yast_scc_registration {
+
+    script_run "yast2 scc; echo yast-scc-done-\$? > /dev/$serialdev";
+    assert_screen 'scc-registration', 30;
+
+    fill_in_registration_data;
+
+    wait_serial('yast-scc-done-0') || die 'yast scc failed';
+    script_run 'zypper lr';
+    assert_screen 'scc-repos-listed';
 }
 
 1;

--- a/tests/console/zypper_ar_scc.pm
+++ b/tests/console/zypper_ar_scc.pm
@@ -26,14 +26,7 @@ sub run() {
     if (my $u = get_var('SCC_URL')) {
         type_string "echo 'url: $u' > /etc/SUSEConnect\n";
     }
-    type_string "yast scc; echo yast-scc-done-\$? > /dev/$serialdev\n";
-    assert_screen( "scc-registration", 30 );
-
-    fill_in_registration_data;
-
-    wait_serial("yast-scc-done-0") || die "yast scc failed";
-    type_string "zypper lr\n";
-    assert_screen "scc-repos-listed";
+    yast_scc_registration;
 
     type_string "exit\n";
 }

--- a/tests/x11/scc_postregistration.pm
+++ b/tests/x11/scc_postregistration.pm
@@ -1,0 +1,18 @@
+use base "x11test";
+use testapi;
+use registration;
+
+sub run() {
+    my $self = shift;
+
+    x11_start_program('xterm -geometry 160x45+5+5');
+    become_root;
+    assert_script_run 'mv /etc/zypp/credentials.d /etc/zypp/repos.d /etc/zypp/services.d /tmp';  # move existing registration data to /tmp
+    yast_scc_registration;
+    assert_script_run 'cp -nrp /tmp/credentials.d /tmp/repos.d /tmp/services.d /etc/zypp/';  # copy previous repo to /etc/zypp/
+    send_key 'alt-f4';  # exit xterm
+}
+
+1;
+
+# vim: set sw=4 et:


### PR DESCRIPTION
Changed tab to alt-c, tab doesn't work for post registration,
because email field has shortcut alt-m, not alt-e for installation registration.