### PR TITLE
no workarounds for broken deps in slenkins

### DIFF
--- a/tests/slenkins/slenkins_control.pm
+++ b/tests/slenkins/slenkins_control.pm
@@ -60,8 +60,8 @@ sub run {
 
         zypper -n --no-gpg-checks ar " . get_var('SLENKINS_REPO') . " slenkins
 
-        #FIXME: the extra packages are workarounds for broken deps
-        zypper -n --no-gpg-checks in " . get_var('SLENKINS_CONTROL') . " susetest-python python-twopence slenkins-tests twopence-shell-client slenkins-utils
+        # slenkins-engine-tests is required for /usr/lib/slenkins/lib/slenkins-functions.sh below
+        zypper -n --no-gpg-checks in " . get_var('SLENKINS_CONTROL') . " slenkins-engine-tests
     ", 100);
 
     for my $n (@nodes) {


### PR DESCRIPTION
Some packages in slenkins repo were renamed recently so the workarounds no longer work.
Most of the dependencies seems to be fixed now.