### PR TITLE
slenkins now requires two repos

### DIFF
--- a/tests/slenkins/slenkins_control.pm
+++ b/tests/slenkins/slenkins_control.pm
@@ -58,7 +58,8 @@ sub run {
         chmod 600 /root/.ssh/*
         chmod 700 /root/.ssh
 
-        zypper -n --no-gpg-checks ar " . get_var('SLENKINS_REPO') . " slenkins
+        zypper -n --no-gpg-checks ar '" . get_var('SLENKINS_TESTSUITES_REPO') . "' slenkins_testsuites
+        zypper -n --no-gpg-checks ar '" . get_var('SLENKINS_REPO') . "' slenkins
 
         # slenkins-engine-tests is required for /usr/lib/slenkins/lib/slenkins-functions.sh below
         zypper -n --no-gpg-checks in " . get_var('SLENKINS_CONTROL') . " slenkins-engine-tests

--- a/tests/slenkins/slenkins_node.pm
+++ b/tests/slenkins/slenkins_node.pm
@@ -42,7 +42,7 @@ sub run {
                 configure_default_gateway;
                 configure_static_ip("10.0.2.$ip_num/24");
                 configure_static_dns(get_host_resolv_conf());
-                script_output("zypper -n --no-gpg-checks ar " . get_var('SLENKINS_REPO') . " slenkins", 100);
+                script_output("zypper -n --no-gpg-checks ar '" . get_var('SLENKINS_TESTSUITES_REPO') . "' slenkins_testsuites", 100);
                 $configured = 1;
             }
             $ip_num++;


### PR DESCRIPTION
Slenkins packages are now split to two separate repos.
The nodes require SLEnkins:testsuites and the control machine requires both SLEnkins and SLEnkins:testsuites.
