### PR TITLE
Fix boot from disk in ZDUP

### DIFF
--- a/tests/installation/bootloader_ofw.pm
+++ b/tests/installation/bootloader_ofw.pm
@@ -57,6 +57,12 @@ sub run() {
     }
     save_screenshot;
     send_key "ret";
+    if (get_var("ZDUP")) {
+        wait_idle(5);
+        type_string "boot disk",15;
+        save_screenshot
+        send_key "ret";
+    }
 }
 
 1;


### PR DESCRIPTION
PowerPC doesn't have sort of bootorder, firmware tries different
deivces, in case no -boot option is specified. In case we have -boot
once=d, there will be no attempt to boot from any other device than
cdrom.

Signed-off-by: Dinar Valeev <dvaleev@suse.com>