### PR TITLE
ensure_installed: do not use serialdev

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -121,7 +121,7 @@ sub ensure_installed {
 
     testapi::x11_start_program("xterm");
     assert_screen('xterm-started');
-    type_string("pkcon install @pkglist; RET=$?; echo \"\n  pkcon finished\n\"; echo \"pkcon-\${RET}-\" > /dev/$testapi::serialdev\n");
+    type_string("pkcon install @pkglist; echo \"\npkcon-\$?-\n\"\n");
     my @tags = qw/Policykit Policykit-behind-window PolicyKit-retry pkcon-proceed-prompt pkcon-finished/;
     while (1) {
         my $ret = assert_screen(\@tags, $timeout);
@@ -150,7 +150,6 @@ sub ensure_installed {
         }
         # Check if we get ANY return value from pkcon on the serial... short delay, as we might still need to catch needles
         if ( $ret->{needle}->has_tag('pkcon-finished') ) {
-            wait_serial ('pkcon-0-', 5) || die "pkcon install did not succeed";
             send_key("alt-f4");    # close xterm
             return;
         }


### PR DESCRIPTION
As pkcon does not run as root, we can't output anything to serialdev.
Change the logic to output pkcon-$?- after pkcon execution and let's match
with a needle.