### PR TITLE
ensure_installed: switch back to serial dev monitoring

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -121,7 +121,7 @@ sub ensure_installed {
 
     testapi::x11_start_program("xterm");
     assert_screen('xterm-started');
-    type_string("pkcon install @pkglist; echo \"\npkcon-\$?-\n\"\n");
+    type_string("pkcon install @pkglist; RET=\$?; echo \"\n  pkcon finished\n\"; echo \"pkcon-\${RET}-\" > /dev/$testapi::serialdev\n");
     my @tags = qw/Policykit Policykit-behind-window PolicyKit-retry pkcon-proceed-prompt pkcon-finished/;
     while (1) {
         my $ret = assert_screen(\@tags, $timeout);
@@ -150,6 +150,7 @@ sub ensure_installed {
         }
         # Check if we get ANY return value from pkcon on the serial... short delay, as we might still need to catch needles
         if ( $ret->{needle}->has_tag('pkcon-finished') ) {
+            wait_serial ('pkcon-0-', 5) || die "pkcon install did not succeed";
             send_key("alt-f4");    # close xterm
             return;
         }

--- a/main.pm
+++ b/main.pm
@@ -570,6 +570,8 @@ sub load_x11tests(){
         loadtest "x11/reboot_gnome_pre.pm";
     }
     loadtest "x11/reboot.pm";
+    # After a reboot, the user no longer has access to the serial device. Restore access.
+    loadtest "x11/user-serial-access.pm";
     loadtest "x11/desktop_mainmenu.pm";
 
     if (xfcestep_is_applicable) {

--- a/tests/x11/user-serial-access.pm
+++ b/tests/x11/user-serial-access.pm
@@ -1,0 +1,19 @@
+use base "x11test";
+use testapi;
+
+sub run() {
+    my $self = shift;
+    mouse_hide(1);
+    x11_start_program("xterm");
+    sleep 2;
+    script_sudo "chown $username /dev/$serialdev";
+    assert_script_run("ls -la /dev/$serialdev");
+    send_key "alt-f4";
+}
+
+sub test_flags() {
+    return { 'important' => 1, 'milestone' => 1 };
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
After a reboot, introduce a new 'test' re-owning serialdev, so that the user keeps on having access to it.
Consrquentyly, switch ensure_installed back to using the serial dev.

This should fix installation with pkcon 1.0.7 (Which is a bit messy with output) as well as 1.0.8 (which is cleaner, but the needle method has sometimes trouble seeing the 'end of install')