### PR TITLE
mark the s390 bootloader test as success if it worked

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -609,6 +609,8 @@ sub run() {
     else {
         die $exception if $exception;
     }
+
+    $self->result('ok');
 }
 #>>> perltidy again from here on
 


### PR DESCRIPTION
otherwise the result is none and the overall state will never be passed