### PR TITLE
Add possibility to test LVM build on top of RAID

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -56,12 +56,10 @@ sub addraid($;$) {
     }
     send_key $cmd{"next"};
     assert_screen 'partition-role', 6;
-    if ($step == 3 and get_var("LVM"))
-    {
+    if ($step == 3 and get_var("LVM")) {
       send_key "alt-a";    # Raw Volume
     }
-    else
-    {
+    else {
       send_key "alt-o";    # Operating System
     }
     send_key $cmd{"next"};
@@ -221,8 +219,7 @@ sub run() {
     wait_idle 3;
 
     # LVM on top of raid if needed
-    if (get_var("LVM"))
-    {
+    if (get_var("LVM")) {
         set_lvm();
     }
 
@@ -234,12 +231,10 @@ sub run() {
         send_key 'alt-y';
     }
 
-    if (get_var("LVM"))
-    {
+    if (get_var("LVM")) {
       assert_screen 'acceptedpartitioningraidlvm', 6;
     }
-    else
-    {
+    else {
       assert_screen 'acceptedpartitioning', 6;
     }
 }

--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -56,8 +56,16 @@ sub addraid($;$) {
     }
     send_key $cmd{"next"};
     assert_screen 'partition-role', 6;
-    send_key "alt-o";    # Operating System
+    if ($step == 3 and get_var("LVM"))
+    {
+      send_key "alt-a";    # Raw Volume
+    }
+    else
+    {
+      send_key "alt-o";    # Operating System
+    }
     send_key $cmd{"next"};
+
     wait_idle 3;
 }
 
@@ -68,6 +76,46 @@ sub setraidlevel($) {
 
     send_key "alt-i";    # move to RAID name input field
     send_key "tab";      # skip RAID name input field
+}
+
+sub set_lvm() {
+    send_key "shift-tab";
+    # select LVM
+    send_key "down";
+
+    # create volume group
+    send_key "alt-d";
+    send_key "down";
+    send_key "ret";
+
+    assert_screen 'lvmsetupraid', 6;
+    # add all unformated lvm devices
+    send_key "alt-d";
+
+    # set volume name
+    send_key "alt-v";
+    type_string "root";
+
+    send_key $cmd{"finish"};
+
+    # create logical volume
+    send_key "alt-d";
+    send_key "down";
+    send_key "down";
+    send_key "ret";
+
+    # create normal volume with name root
+    type_string "root";
+    send_key $cmd{"next"};
+
+    # keep default
+    send_key $cmd{"next"};
+
+    send_key "alt-o";    # Operating System
+    send_key $cmd{"next"};
+
+    # keep deafult to mount as root and btrfs
+    send_key $cmd{finish};
 }
 
 sub run() {
@@ -172,6 +220,12 @@ sub run() {
     send_key $cmd{"finish"};
     wait_idle 3;
 
+    # LVM on top of raid if needed
+    if (get_var("LVM"))
+    {
+        set_lvm();
+    }
+
     # done
     send_key $cmd{"accept"};
 
@@ -179,7 +233,15 @@ sub run() {
     if ( check_screen 'subvolumes-shadowed', 5 ) {
         send_key 'alt-y';
     }
-    assert_screen 'acceptedpartitioning', 6;
+
+    if (get_var("LVM"))
+    {
+      assert_screen 'acceptedpartitioningraidlvm', 6;
+    }
+    else
+    {
+      assert_screen 'acceptedpartitioning', 6;
+    }
 }
 
 


### PR DESCRIPTION
It have two main benefits:

1) real test case based on customer bug report
2) it test LVM creation in expert partitioner, as LVM enabled itself
only set custom proposal option, but this test create it manually in
expert partitioner

I also have needless for SLE12SP1, but I do not feel openqa confident enough to create robust enough needles, so I prefer if some operator with more experiences can create it

Fix for bug in yast is already deployed, so should not break staging.

Running example with SLE12SP1 is available at YaST instance of openqa: https://yast-openqa.suse.cz/tests/116