### PR TITLE
s390x doesn't need login to console

### DIFF
--- a/tests/toolchain/install.pm
+++ b/tests/toolchain/install.pm
@@ -5,13 +5,15 @@ use testapi;
 sub run() {
     my $self = shift;
 
-    send_key 'ctrl-alt-f4';
-    assert_screen 'tty4-selected';
-    assert_screen 'text-login';
-    type_string "root\n";
-    assert_screen 'password-prompt', 10;
-    type_password;
-    send_key 'ret';
+    if (!check_var('ARCH', 's390x')) {
+        send_key 'ctrl-alt-f4';
+        assert_screen 'tty4-selected';
+        assert_screen 'text-login';
+        type_string "root\n";
+        assert_screen 'password-prompt', 10;
+        type_password;
+        send_key 'ret';
+    }
     assert_screen 'text-logged-in';
     # disable packagekitd
     script_run 'systemctl mask packagekit.service';


### PR DESCRIPTION
failing s390x https://openqa.suse.de/tests/132032/modules/install/steps/2