### PR TITLE
export_logs: produce the output of ps axf and export it

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -42,6 +42,10 @@ sub export_logs {
     type_string "cat /var/log/X* > /tmp/Xlogs\n";
     upload_logs "/tmp/Xlogs";
     save_screenshot;
+
+    type_string "ps axf > /tmp/psaxf.log\n";
+    upload_logs "/tmp/psaxf.log";
+    save_screenshot;
 }
 
 sub export_captured_audio {


### PR DESCRIPTION
This should hopefully help debug what might be locking TTY7 in case we
can't start X (https://bugzilla.opensuse.org/show_bug.cgi?id=939594)