### PR TITLE
export_logs: also export systemctl messages

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -46,6 +46,14 @@ sub export_logs {
     type_string "ps axf > /tmp/psaxf.log\n";
     upload_logs "/tmp/psaxf.log";
     save_screenshot;
+
+    type_string "systemctl list-unit-files > /tmp/systemctl_unit-files.log\n";
+    upload_logs "/tmp/systemctl_unit-files.log";
+    type_string "systemctl status > /tmp/systemctl_status.log\n";
+    upload_logs "/tmp/systemctl_status.log";
+    type_string "systemctl > /tmp/systemctl.log\n";
+    upload_logs "/tmp/systemctl.log";
+    save_screenshot;
 }
 
 sub export_captured_audio {


### PR DESCRIPTION
More debug logs needed to get to the bottom of the first_boot issue seen in GNOME.

We seem to have two things enabled that try to catch X..

especially interesting in the journal of a failed case is:
display-manager[740]: Starting service gdm..done comes WAY after X died already (huh? gdm should be starting X)

but there also figures
systemd[1]: Started X Display Manager.
in the log, which is not in the successful boot cases..

so, with systemctl I hope to find out what services we have 'enabled' in the failed case.. and hopefully find some more reason for this.