### PR TITLE
ensure_installed: the keycode is not the one from the telnet interfac…

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -129,7 +129,7 @@ sub ensure_installed {
         my $ret = check_screen(\@tags, $timeout);
         last unless $ret;
         if ( $ret->{needle}->has_tag('PolicyKit-CapsOn')) {
-            send_key ( "caps_lock" );
+            send_key ( "caps" );
             @tags = grep { $_ ne 'PolicyKit-CapsOn' } @tags;
         }
         if ( $ret->{needle}->has_tag('Policykit') ||


### PR DESCRIPTION
…e to qemu, but what is defined in the backend code. It has been added there as 'caps', to be in sync with keymap_ikvm

Together with the fix on os-autoinst, this is hopefully correct now.