### PR TITLE
Remove nasty workaround for reboot_gnome_pre and instead figure out w…

### DIFF
--- a/tests/x11/reboot_gnome_pre.pm
+++ b/tests/x11/reboot_gnome_pre.pm
@@ -14,13 +14,11 @@ sub run() {
         sleep 3;
         type_password;
         sleep 3;
+        assert_and_click 'reboot-auth-typed', 2; # Extra assert_and_click (with right click) to check the correct number of characters is typed and open up the 'show text' option
+        assert_and_click 'reboot-auth-showtext'; # Click the 'Show Text' Option to enable the display of the typed text
+        assert_screen 'reboot-auth-correct-password'; # Check the password is correct
         send_key "ret";
 
-        if (check_screen('please-try-again', 3)) {
-            record_soft_failure;
-            type_password;
-            send_key "ret";
-        }
     }
 }
 


### PR DESCRIPTION
…hat we actually typed and if it's right or not

Requires 3 new needles, which haven't been made for openSUSE or SLE yet
reboot-auth-typed = the reboot-auth screen with the correct number of asterixs for the typed password
reboot-auth-showtext = the 'show text' menu option from the right click menu
reboot-auth-correct-password =  the reboot-auth screen with the password displayed in plain text - must be the correct password