### PR TITLE
wait longer till previously used repo appears

### DIFF
--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -16,7 +16,7 @@ sub run() {
     # hardware detection can take a while
     assert_screen "select-for-update", 100;
     send_key $cmd{"next"}, 1;
-    assert_screen "remove-repository", 30;
+    assert_screen "remove-repository", 100;
     send_key $cmd{"next"}, 1;
     if (check_var('DISTRI', 'opensuse')) {
         if (check_screen('network-not-configured', 5)) {


### PR DESCRIPTION
very often is this step slower and fails
SLES:
https://openqa.suse.de/tests/140759/modules/upgrade_select/steps/2
https://openqa.suse.de/tests/140760/modules/upgrade_select/steps/2
SLED:
https://openqa.suse.de/tests/140726/modules/upgrade_select/steps/2
https://openqa.suse.de/tests/140718/modules/upgrade_select/steps/2