### PR TITLE
Fix ZDUP on PowerPC

### DIFF
--- a/tests/installation/bootloader_ofw.pm
+++ b/tests/installation/bootloader_ofw.pm
@@ -20,49 +20,48 @@ sub run() {
         send_key_until_needlematch 'inst-oninstallation', 'up';
     }
     if (check_var('VIDEOMODE', 'text') || get_var('NETBOOT') || get_var('AUTOYAST') || get_var('SCC_URL')) {
-        # edit menu
-        send_key "e";
-        #wait until we get to grub edit
-        wait_idle(5);
-        #go down to kernel entry
-        send_key "down";
-        send_key "down";
-        send_key "down";
-        send_key "end";
-        wait_idle(5);
-        my $args = "";
-        # load kernel manually with append
-        if (check_var('VIDEOMODE', 'text')) {
-            type_string " textmode=1", 15;
-        }
-        if ( get_var("NETBOOT") && get_var("SUSEMIRROR") ) {
-            type_string " install=http://" . get_var("SUSEMIRROR"), 15;
-        }
-        if ( get_var("AUTOYAST") || get_var("AUTOUPGRADE")) {
-            my $netsetup = " ifcfg=*=dhcp"; #need this instead of netsetup as default, see bsc#932692
-            $netsetup = " ".get_var("NETWORK_INIT_PARAM") if defined get_var("NETWORK_INIT_PARAM"); #e.g netsetup=dhcp,all
-            $netsetup = " netsetup=dhcp,all" if defined get_var("USE_NETSETUP"); #netsetup override for sle11
-            $args .= $netsetup;
-            $args .= " autoyast=" . data_url(get_var("AUTOYAST")) . " ";
-        }
+        if (get_var("ZDUP")) {
+            send_key "down";
+            send_key "ret";
+        } else {
+            # edit menu
+            send_key "e";
+            #wait until we get to grub edit
+            wait_idle(5);
+            #go down to kernel entry
+            send_key "down";
+            send_key "down";
+            send_key "down";
+            send_key "end";
+            wait_idle(5);
+            my $args = "";
+            # load kernel manually with append
+            if (check_var('VIDEOMODE', 'text')) {
+                type_string " textmode=1", 15;
+            }
+            if ( get_var("NETBOOT") && get_var("SUSEMIRROR") ) {
+                type_string " install=http://" . get_var("SUSEMIRROR"), 15;
+            }
+            if ( get_var("AUTOYAST") || get_var("AUTOUPGRADE")) {
+                my $netsetup = " ifcfg=*=dhcp"; #need this instead of netsetup as default, see bsc#932692
+                $netsetup = " ".get_var("NETWORK_INIT_PARAM") if defined get_var("NETWORK_INIT_PARAM"); #e.g netsetup=dhcp,all
+                $netsetup = " netsetup=dhcp,all" if defined get_var("USE_NETSETUP"); #netsetup override for sle11
+                $args .= $netsetup;
+                $args .= " autoyast=" . data_url(get_var("AUTOYAST")) . " ";
+            }
 
-        if ( get_var("AUTOUPGRADE")) {
-            $args .= " autoupgrade=1";
-        }
+            if ( get_var("AUTOUPGRADE")) {
+                $args .= " autoupgrade=1";
+            }
 
-        type_string $args, 13;
-        save_screenshot;
-        registration_bootloader_params;
-        send_key "ctrl-x";
+            type_string $args, 13;
+            save_screenshot;
+            registration_bootloader_params;
+            send_key "ctrl-x";
+        }
     }
     save_screenshot;
     send_key "ret";
-    if (get_var("ZDUP")) {
-        wait_idle(5);
-        type_string "boot disk",15;
-        save_screenshot
-        send_key "ret";
-    }
 }
 
 1;


### PR DESCRIPTION
Due to boot order specifics on PowerPC, we need to reboot,
in order to boot from HDD asset

Signed-off-by: Dinar Valeev <dvaleev@suse.com>