### PR TITLE
no reason to limit the screen lock going back to desktop

### DIFF
--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -58,8 +58,7 @@ sub run() {
         }
         wait_idle;
         mouse_hide(1);
-        sleep 1;
-        assert_screen 'generic-desktop', 3;
+        assert_screen 'generic-desktop';
     }
 }
 


### PR DESCRIPTION
(hopefully fixes xfce https://openqa.opensuse.org/tests/93397/modules/consoletest_finish/steps/5)