### PR TITLE
size comparsion fix

### DIFF
--- a/tests/jeos/diskusage.pm
+++ b/tests/jeos/diskusage.pm
@@ -9,8 +9,9 @@ sub run() {
     my $datamax    = get_var("BTRFS_MAXDATASIZE");
 
     script_run "echo btrfs-data=\$(btrfs filesystem df -b / | grep Data | sed -n -e 's/^.*used=//p') | tee -a /dev/$serialdev"; # spit out only the part of the btrfs filesystem size we're interested in
-    my $datasize = wait_serial 'btrfs-data=\d+' =~ m/(\d\S*)$/; # https://xkcd.com/208/
+    my $datasize = wait_serial('btrfs-data=\d+\S+'); # https://xkcd.com/208/
     die "failed to get btrfs-data size" unless (defined $datasize); # shouldn't ever happen, bet just incase it does
+    $datasize = substr $datasize, 11;
     
     if ( $datasize > $datamax ) {
         $result = 'fail';


### PR DESCRIPTION
skip the name btrfs-data=, compare only number.
log:
Argument "btrfs-data=606920704\r\n" isn't numeric in numeric gt (>) at /var/lib/openqa/share/tests/sle-12/tests/jeos/diskusage.pm line 15.