### PR TITLE
desktop-mainmenu: wait_idle before attempting to move on in all deskt…

### DIFF
--- a/tests/x11/desktop_mainmenu.pm
+++ b/tests/x11/desktop_mainmenu.pm
@@ -4,6 +4,7 @@ use testapi;
 
 sub run() {
     my $self = shift;
+    wait_idle;
     if ( check_var("DESKTOP", "lxde") ) {
         x11_start_program("lxpanelctl menu");    # or Super_L or Windows key
     }
@@ -16,7 +17,6 @@ sub run() {
         mouse_hide(1);
     }
     else {
-        wait_idle;
         send_key "alt-f1";                        # open main menu
     }
     assert_screen 'test-desktop_mainmenu-1', 20;


### PR DESCRIPTION
…op cases

This potentially helps us in cases like
https://openqa.opensuse.org/tests/95323/modules/desktop_mainmenu/steps/1

where xfce obviously was not ready and even the mouse_set(0,0) was not executed... in the end we seem to lose a key-stroke 'up', not showing the menu.

Compared to an earlier successful run https://openqa.opensuse.org/tests/94160/modules/desktop_mainmenu/steps/1 the menu is visible top left (so mouse_set(0,0 worked).

This makes me believe that actually waiting for the system to be idle before clicking around might be a good way.

for anything non-XFCE/LXDE, this is already being done (move from the else block out, to apply to all desktops)