### PR TITLE
wait a bit before pressing alt-i to start install

### DIFF
--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -61,6 +61,7 @@ sub run() {
         assert_screen( "inst-packageinstallationstarted", 120 );
     }
     else {
+        sleep 2;    # textmode is sometimes pressing alt-i too early
         send_key $cmd{install};
         while ( my $ret = check_screen( [qw/confirmlicense startinstall/], 5 ) ) {
             last if $ret->{needle}->has_tag("startinstall");


### PR DESCRIPTION
I see this fail very often https://openqa.suse.de/tests/149932/modules/start_install/steps/2