### PR TITLE
Show netdevices before yast run to track down bsc#948816

### DIFF
--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -9,6 +9,11 @@ sub run() {
 
     assert_script_sudo "zypper -n in yast2-network"; # make sure yast2 lan module installed
 
+    # those two are for debugging purposes only
+    script_run('ip a');
+    script_run('ls -alF /etc/sysconfig/network/');
+    save_screenshot;
+    
     script_sudo("/sbin/yast2 lan");
 
     my $ret = assert_screen [qw/Networkmanager_controlled yast2_lan install-susefirewall2/], 60;


### PR DESCRIPTION
Since the yast2_lan test still fails from time to time:
https://openqa.suse.de/tests/150903/modules/yast2_lan/steps/4
https://openqa.suse.de/tests/150923/modules/yast2_lan/steps/4
I hope to learn more about it by printing additional information about the netconfig.