### PR TITLE
improved slenkins

### DIFF
--- a/data/supportserver/dhcp/dhcpd.conf
+++ b/data/supportserver/dhcp/dhcpd.conf
@@ -7,7 +7,7 @@ subnet 10.0.2.0 netmask 255.255.255.0 {
   max-lease-time 172800;
   option domain-name "test";
   option domain-name-servers  10.0.2.1,  10.0.2.1;
-  option routers 10.0.2.1;
+  option routers 10.0.2.2;
   filename "/boot/pxelinux.0";
   next-server 10.0.2.1;
 

--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -9,7 +9,13 @@ use Exporter;
 
 use testapi;
 
-our @EXPORT = qw/get_host_resolv_conf configure_static_ip configure_default_gateway configure_static_dns/;
+our @EXPORT = qw/configure_hostname get_host_resolv_conf configure_static_ip configure_dhcp configure_default_gateway configure_static_dns/;
+
+sub configure_hostname {
+    my ($hostname) = @_;
+    type_string "echo '$hostname' > /etc/hostname\n";
+    type_string "hostname '$hostname'\n";
+}
 
 sub get_host_resolv_conf {
     my %conf;
@@ -31,6 +37,21 @@ sub configure_static_ip {
     type_string "cd /proc/sys/net/ipv4/conf\n";
     type_string "for i in *[0-9]; do ";
     type_string("echo \"STARTMODE='auto'\nBOOTPROTO='static'\nIPADDR='$ip'\" > /etc/sysconfig/network/ifcfg-\$i;");
+    type_string("done\n");
+    wait_idle(20);
+    save_screenshot;
+    type_string("rcnetwork restart\n");
+    type_string("ip addr\n");
+    type_string("cd -\n");
+    wait_idle(20);
+    save_screenshot;
+}
+
+sub configure_dhcp {
+    my () = @_;
+    type_string "cd /proc/sys/net/ipv4/conf\n";
+    type_string "for i in *[0-9]; do ";
+    type_string("echo \"STARTMODE='auto'\nBOOTPROTO='dhcp'\n\" > /etc/sysconfig/network/ifcfg-\$i;");
     type_string("done\n");
     wait_idle(20);
     save_screenshot;

--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -81,7 +81,7 @@ sub configure_static_dns {
 
 sub parse_network_configuration {
     my @networks = ('fixed');
-    @networks = split /\s*,\s*/, get_var("NETWORKS");
+    @networks = split /\s*,\s*/, get_var("NETWORKS") if get_var("NETWORKS");
     my @mac = split /\s*,\s*/, get_var("NICMAC");
     my $net_conf = {};
 

--- a/main.pm
+++ b/main.pm
@@ -647,14 +647,17 @@ sub load_applicationstests {
 }
 
 sub load_skenkins_tests {
-    if (get_var("SLENKINS_NODEFILE")) {
-        my $node = get_var("SLENKINS_NODE");
-        if ($node && $node ne 'control') {
-            loadtest "slenkins/slenkins_node.pm";
+    if (get_var("SLENKINS_CONTROL")) {
+        unless (get_var("SUPPORT_SERVER")) {
+            loadtest "slenkins/login.pm";
+            loadtest "slenkins/slenkins_control_network.pm";
         }
-        else {
-            loadtest "slenkins/slenkins_control.pm";
-        }
+        loadtest "slenkins/slenkins_control.pm";
+        return 1;
+    }
+    elsif (get_var("SLENKINS_NODE")) {
+        loadtest "slenkins/login.pm";
+        loadtest "slenkins/slenkins_node.pm";
         return 1;
     }
     return 0;
@@ -708,7 +711,9 @@ elsif (get_var("SUPPORT_SERVER")) {
     loadtest "support_server/boot.pm";
     loadtest "support_server/login.pm";
     loadtest "support_server/setup.pm";
-    loadtest "support_server/wait.pm";
+    unless (load_skenkins_tests()) {    # either run the slenkins control node or just wait for connections
+        loadtest "support_server/wait.pm";
+    }
 }
 elsif (get_var("EXTRATEST")) {
     load_boot_tests();

--- a/script/import-slenkins-testsuite.pl
+++ b/script/import-slenkins-testsuite.pl
@@ -1,0 +1,125 @@
+#!/usr/bin/perl
+
+use strict;
+use Cwd 'abs_path';
+use Data::Dump qw/dd pp/;
+
+my $template_control = pp(
+    {key => "BOOT_HDD_IMAGE", value => 1},
+
+    {key => "DESKTOP", value => "textmode"},
+
+    {key => "HDD_1", value => "supporserver.qcow2"},
+
+    {key => "NICTYPE", value => "tap"},
+
+    {key => "START_AFTER_TEST", value => "textmode"},
+
+    {key => "SUPPORT_SERVER", value => 1},
+
+    {key => "SUPPORT_SERVER_ROLES", value => "dhcp"},
+
+    {key => "SLENKINS_TESTSUITES_REPO", value => "http://download.suse.de/ibs/Devel:/SLEnkins:/testsuites/SLE_12_SP1/"},
+
+    {key => "SLENKINS_REPO", value => "http://download.suse.de/ibs/Devel:/SLEnkins/SLE_12_SP1/"},
+);
+
+my $template_node = pp(
+    {key => "BOOT_HDD_IMAGE", value => 1},
+
+    {key => "DESKTOP", value => "textmode"},
+
+    {key => "HDD_1", value => "textmode-openqa-%ARCH%.qcow2"},
+
+    {key => "NICTYPE", value => "tap"},
+
+    {key => "START_AFTER_TEST", value => "textmode"},
+
+    {key => "SLENKINS_TESTSUITES_REPO", value => "http://download.suse.de/ibs/Devel:/SLEnkins:/testsuites/SLE_12_SP1/"},
+);
+
+
+sub parse_node_file {
+    my ($fn, $project_name) = @_;
+
+    open(my $fh, '<', $fn) || die "can't open $fn: $!\n";
+    my %nodes;
+    my $node;
+    while (my $line = <$fh>) {
+        chomp $line;
+        $line =~ s/\$\{PROJECT_NAME\}/$project_name/g;
+
+        if ($line =~ /^node\s+([^\s]+)$/) {
+            $node = $1;
+            $nodes{$node} = {install => []};
+        }
+        elsif ($line =~ /^install\s/) {
+            my @pkg = split(/\s+/, $line);
+            shift @pkg;
+            push @{$nodes{$node}->{install}}, @pkg;
+        }
+        elsif ($line =~ /^\s*#/) {
+            #nothing to do
+        }
+        elsif ($line !~ /^\s*$/) {
+            print STDERR "unsupported param: $line\n";
+        }
+    }
+
+    return \%nodes;
+}
+
+sub gen_testsuites {
+    my ($node_file, $project_name, $control_pkg) = @_;
+    my @suites;
+
+    for my $node (keys %$node_file) {
+        push @suites,
+          {
+            name     => "slenkins-${project_name}-${node}",
+            settings => [eval $template_node, {key => "SLENKINS_NODE", value => "$node"}, {key => "SLENKINS_INSTALL", value => join(',', @{$node_file->{$node}{install}})},],
+          };
+    }
+
+    push @suites,
+      {
+        name     => "slenkins-${project_name}-control",
+        settings => [eval $template_control, {key => "SLENKINS_NODE", value => "control"}, {key => "SLENKINS_CONTROL", value => $control_pkg}, {key => "PARALLEL_WITH", value => join(',', map { "slenkins-${project_name}-" . $_ } keys %$node_file)},],
+      };
+
+    return @suites;
+}
+
+sub import_node_file {
+    my ($fn, $project_name, $control_pkg) = @_;
+
+    unless ($project_name) {
+        my $abs_path = abs_path($fn);
+        if ($abs_path =~ /\/var\/lib\/slenkins\/([^\/]+)\/([^\/]+)\/nodes/) {
+            $project_name = $1;
+            $control_pkg  = "$1-$2";
+        }
+        else {
+            print STDERR "Can't guess project name from path $abs_path\n";
+            exit(1);
+        }
+    }
+    my $node_file = parse_node_file($fn, $project_name);
+    return gen_testsuites($node_file, $project_name, $control_pkg);
+}
+
+my @suites;
+
+if (@ARGV == 0) {
+    print STDERR "Usage:\n\n";
+    print STDERR "import-slenkins-testsuite.pl /var/lib/slenkins/*/*/nodes >slenkins_templates\n";
+    print STDERR "load_templates --update slenkins_templates\n";
+    exit(1);
+}
+
+for my $file (@ARGV) {
+    push @suites, import_node_file($file);
+}
+
+dd {TestSuites => \@suites};
+

--- a/script/import-slenkins-testsuite.pl
+++ b/script/import-slenkins-testsuite.pl
@@ -13,7 +13,7 @@ my $template_control = pp(
 
     {key => "NICTYPE", value => "tap"},
 
-    {key => "START_AFTER_TEST", value => "textmode"},
+    {key => "START_AFTER_TEST", value => "sles12_minimal_base_create_hdd"},
 
     {key => "SUPPORT_SERVER", value => 1},
 
@@ -29,11 +29,11 @@ my $template_node = pp(
 
     {key => "DESKTOP", value => "textmode"},
 
-    {key => "HDD_1", value => "textmode-openqa-%ARCH%.qcow2"},
+    {key => "HDD_1", value => "SLES_12SP1-%ARCH%-minimal_with_sdk_installed.qcow2"},
 
     {key => "NICTYPE", value => "tap"},
 
-    {key => "START_AFTER_TEST", value => "textmode"},
+    {key => "START_AFTER_TEST", value => "sles12_minimal_base_create_hdd"},
 
     {key => "SLENKINS_TESTSUITES_REPO", value => "http://download.suse.de/ibs/Devel:/SLEnkins:/testsuites/SLE_12_SP1/"},
 );
@@ -44,19 +44,37 @@ sub parse_node_file {
 
     open(my $fh, '<', $fn) || die "can't open $fn: $!\n";
     my %nodes;
+    my %networks;
     my $node;
+    my $network;
     while (my $line = <$fh>) {
         chomp $line;
         $line =~ s/\$\{PROJECT_NAME\}/$project_name/g;
 
         if ($line =~ /^node\s+([^\s]+)$/) {
-            $node = $1;
+            $node    = $1;
+            $network = undef;
             $nodes{$node} = {install => []};
+        }
+        elsif ($line =~ /^network\s+([^\s]+)$/) {
+            $network            = $1;
+            $node               = undef;
+            $networks{$network} = {};
         }
         elsif ($line =~ /^install\s/) {
             my @pkg = split(/\s+/, $line);
             shift @pkg;
-            push @{$nodes{$node}->{install}}, @pkg;
+            push @{$nodes{$node}->{install}}, @pkg if defined $node;
+        }
+        elsif ($line =~ /^ethernet\s/) {
+            my @net = split(/\s+/, $line);
+            shift @net;
+            push @{$nodes{$node}->{networks}}, @net if defined $node;
+        }
+        elsif ($line =~ /^subnet\s/ || $line =~ /^dhcp\s/ || $line =~ /^gateway\s/) {
+            my ($param, $value) = split(/\s+/, $line);
+            $value = 0 if $value eq 'no';
+            $networks{$network}->{$param} = $value if defined $network;
         }
         elsif ($line =~ /^\s*#/) {
             #nothing to do
@@ -65,27 +83,43 @@ sub parse_node_file {
             print STDERR "unsupported param: $line\n";
         }
     }
-
-    return \%nodes;
+    return (\%nodes, \%networks);
 }
 
 sub gen_testsuites {
-    my ($node_file, $project_name, $control_pkg) = @_;
+    my ($nodes, $networks, $project_name, $control_pkg) = @_;
     my @suites;
 
-    for my $node (keys %$node_file) {
+    for my $node (keys %$nodes) {
+        my @node_net = @{$nodes->{$node}->{networks}} if $nodes->{$node}->{networks};
+        push @node_net, 'fixed' unless grep { $_ eq 'fixed' } @node_net;
         push @suites,
           {
             name     => "slenkins-${project_name}-${node}",
-            settings => [eval $template_node, {key => "SLENKINS_NODE", value => "$node"}, {key => "SLENKINS_INSTALL", value => join(',', @{$node_file->{$node}{install}})},],
+            settings => [eval $template_node, {key => "SLENKINS_NODE", value => "$node"}, {key => "SLENKINS_INSTALL", value => join(',', @{$nodes->{$node}{install}})}, {key => "NETWORKS", value => join(',', @node_net)},],
           };
     }
 
-    push @suites,
-      {
+    my $control = {
         name     => "slenkins-${project_name}-control",
-        settings => [eval $template_control, {key => "SLENKINS_NODE", value => "control"}, {key => "SLENKINS_CONTROL", value => $control_pkg}, {key => "PARALLEL_WITH", value => join(',', map { "slenkins-${project_name}-" . $_ } keys %$node_file)},],
-      };
+        settings => [eval $template_control, {key => "SLENKINS_NODE", value => "control"}, {key => "SLENKINS_CONTROL", value => $control_pkg}, {key => "PARALLEL_WITH", value => join(',', map { "slenkins-${project_name}-" . $_ } keys %$nodes)},],
+    };
+
+    my @control_net = keys %$networks;
+    push @control_net, 'fixed' unless $networks->{fixed};
+    push @{$control->{settings}}, {key => "NETWORKS", value => join(',', @control_net)};
+
+    my $i = 1;
+    for my $net (keys %$networks) {
+        my @param;
+        push @param, $net;
+        for my $p (keys %{$networks->{$net}}) {
+            push @param, "$p=" . $networks->{$net}->{$p};
+        }
+        push @{$control->{settings}}, {key => "NETWORK$i", value => join(',', @param)};
+        $i++;
+    }
+    push @suites, $control;
 
     return @suites;
 }
@@ -104,8 +138,8 @@ sub import_node_file {
             exit(1);
         }
     }
-    my $node_file = parse_node_file($fn, $project_name);
-    return gen_testsuites($node_file, $project_name, $control_pkg);
+    my ($nodes, $networks) = parse_node_file($fn, $project_name);
+    return gen_testsuites($nodes, $networks, $project_name, $control_pkg);
 }
 
 my @suites;

--- a/tests/slenkins/slenkins_control_network.pm
+++ b/tests/slenkins/slenkins_control_network.pm
@@ -16,16 +16,18 @@
 use strict;
 use base 'basetest';
 use testapi;
+use lockapi;
 use mmapi;
+use mm_network;
+use ttylogin;
 
 sub run {
     my $self = shift;
 
-    wait_for_children;
-
-    $self->result('ok');
+    configure_default_gateway;
+    configure_static_ip('10.0.2.1/24');
+    configure_static_dns(get_host_resolv_conf());
 }
-
 
 sub test_flags {
     # without anything - rollback to 'lastgood' snapshot if failed
@@ -36,3 +38,5 @@ sub test_flags {
 }
 
 1;
+
+# vim: set sw=4 et:

--- a/tests/support_server/login.pm
+++ b/tests/support_server/login.pm
@@ -21,10 +21,10 @@ sub run {
 
     if (get_var("SUPPORTSERVER_NEEDLE_LOGIN")) {
         #fallback to needle based detection, if serial console not set or not supported
-        assert_screen("autoyast-system-login-console", 30);
+        assert_screen("autoyast-system-login-console", 200);
     }
     else {
-        wait_serial("login:", 30);
+        wait_serial("login:", 200);
     }
 
     type_string "root\n";

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -17,6 +17,7 @@ use strict;
 use base 'basetest';
 use lockapi;
 use testapi;
+use mm_network;
 
 my $pxe_server_set  = 0;
 my $quemu_proxy_set = 0;
@@ -91,6 +92,9 @@ sub setup_nfs_mount {
 
 sub run {
 
+    configure_default_gateway;
+    configure_static_ip('10.0.2.1/24');
+    configure_static_dns(get_host_resolv_conf());
 
     my @server_roles = split(',|;', lc(get_var("SUPPORT_SERVER_ROLES")));
     my %server_roles = map { $_ => 1 } @server_roles;

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -66,12 +66,77 @@ sub setup_tftp_server {
     $tftp_server_set = 1;
 }
 
+sub setup_networks {
+    my $net_conf = parse_network_configuration();
+
+    for my $network (keys %$net_conf) {
+        my $server_ip = ip_in_subnet($net_conf->{$network}, 1);
+        $setup_script .= "NIC=`grep $net_conf->{$network}->{mac} /sys/class/net/*/address |cut -d / -f 5`\n";
+        $setup_script .= "cat > /etc/sysconfig/network/ifcfg-\$NIC <<EOT\n";
+        $setup_script .= "IPADDR=$server_ip\n";
+        $setup_script .= "NETMASK=$net_conf->{$network}->{subnet_mask}\n";
+        $setup_script .= "STARTMODE='auto'\n";
+        $setup_script .= "EOT\n";
+    }
+    $setup_script .= "rcnetwork restart\n";
+
+    $setup_script .= "FIXED_NIC=`grep $net_conf->{fixed}->{mac} /sys/class/net/*/address |cut -d / -f 5`\n";
+    $setup_script .= "iptables -t nat -A POSTROUTING -o \$FIXED_NIC -j MASQUERADE\n";
+    for my $network (keys %$net_conf) {
+        next if $network eq 'fixed';
+        next unless $net_conf->{$network}->{gateway};
+        "NIC=`grep $net_conf->{$network}->{mac} /sys/class/net/*/address |cut -d / -f 5`\n";
+        $setup_script .= "iptables -A FORWARD -i \$FIXED_NIC -o \$NIC -m state  --state RELATED,ESTABLISHED -j ACCEPT\n";
+        $setup_script .= "iptables -A FORWARD -i \$NIC -o \$FIXED_NIC -j ACCEPT\n";
+    }
+    $setup_script .= "echo 1 > /proc/sys/net/ipv4/ip_forward\n";
+    $setup_script .= "ip route\n";
+    $setup_script .= "ip addr\n";
+    $setup_script .= "iptables -v -L\n";
+}
+
 sub setup_dhcp_server {
     return if $dhcp_server_set;
+    my $net_conf = parse_network_configuration();
 
     $setup_script .= "rcdhcpd stop\n";
-    $setup_script .= "curl -f -v " . autoinst_url . "/data/supportserver/dhcp/dhcpd.conf  >/etc/dhcpd.conf \n";
+    $setup_script .= "cat  >/etc/dhcpd.conf <<EOT\n";
+    $setup_script .= "default-lease-time 14400;\n";
+    $setup_script .= "ddns-update-style none;\n";
+    $setup_script .= "dhcp-cache-threshold 0;\n";
+    $setup_script .= "\n";
+    for my $network (keys %$net_conf) {
+        next unless $net_conf->{$network}->{dhcp};
+        my $server_ip = ip_in_subnet($net_conf->{$network}, 1);
+        $setup_script .= "subnet $net_conf->{$network}->{subnet_ip} netmask $net_conf->{$network}->{subnet_mask} {\n";
+        $setup_script .= "  range  " . ip_in_subnet($net_conf->{$network}, 15) . "  " . ip_in_subnet($net_conf->{$network}, 100) . ";\n";
+        $setup_script .= "  default-lease-time 14400;\n";
+        $setup_script .= "  max-lease-time 172800;\n";
+        $setup_script .= "  option domain-name \"test\";\n";
+        #        $setup_script .= "  option domain-name-servers  $server_ip,  $server_ip;\n";
+        if ($net_conf->{$network}->{gateway}) {
+            if ($network eq 'fixed') {
+                $setup_script .= "  option routers 10.0.2.2;\n";
+            }
+            else {
+                $setup_script .= "  option routers $server_ip;\n";
+            }
+        }
+        $setup_script .= "  filename \"/boot/pxelinux.0\";\n";
+        $setup_script .= "  next-server $server_ip;\n";
+        $setup_script .= "}\n";
+    }
+    $setup_script .= "EOT\n";
+
     $setup_script .= "curl -f -v " . autoinst_url . "/data/supportserver/dhcp/sysconfig/dhcpd  >/etc/sysconfig/dhcpd \n";
+    $setup_script .= "NIC_LIST=\"";
+    for my $network (keys %$net_conf) {
+        next unless $net_conf->{$network}->{dhcp};
+        $setup_script .= "`grep $net_conf->{$network}->{mac} /sys/class/net/*/address |cut -d / -f 5` ";
+    }
+    $setup_script .= "\"\n";
+    $setup_script .= 'sed -i -e "s|^DHCPD_INTERFACE=.*|DHCPD_INTERFACE=\"$NIC_LIST\"|" /etc/sysconfig/dhcpd' . "\n";
+
     $setup_script .= "rcdhcpd start\n";
 
     $dhcp_server_set = 1;
@@ -99,6 +164,8 @@ sub run {
     my @server_roles = split(',|;', lc(get_var("SUPPORT_SERVER_ROLES")));
     my %server_roles = map { $_ => 1 } @server_roles;
 
+    setup_networks();
+
     if (exists $server_roles{'pxe'}) {
         setup_dhcp_server();
         setup_pxe_server();
@@ -122,10 +189,11 @@ sub run {
 
     die "no services configured, SUPPORT_SERVER_ROLES variable missing?" unless $setup_script;
 
-    script_output($setup_script);
+    print $setup_script;
+
+    script_output($setup_script, 200);
 
     #create mutexes for running services
-    wait_idle(100);
     foreach my $mutex (@mutexes) {
         mutex_create($mutex);
     }


### PR DESCRIPTION
This requires https://github.com/os-autoinst/os-autoinst/pull/312

- do not parse node files, everything is configured via variables
- import-slenkins-testsuite.pl script for importing the variables
- run control node on top of support server


I am not sure where to put the import-slenkins-testsuite.pl script, for now I put it together with the tests.

Usage:

on any machine:
1. install slenkins control packages
2. import-slenkins-testsuite.pl /var/lib/slenkins/*/*/nodes >slenkins_templates
3. copy slenkins_templates to openqa machine
on openqa machine:
4. load_templates --update slenkins_templates

