### PR TITLE
fix the PXE boot on ipmi hardware

### DIFF
--- a/tests/installation/qa_net.pm
+++ b/tests/installation/qa_net.pm
@@ -14,21 +14,20 @@ sub run() {
     #send_key_until_needlematch "qa-net-selection-" . get_var('DISTRI') . "-" . get_var("VERSION"), 'down', 30, 3;
     #Don't use send_key_until_needlematch to pick first menu tier as dist network sources might not be ready when openQA is running tests
     send_key 'esc';
-    assert_screen 'qa-net-boot', 8;
+    assert_screen 'qa-net-boot';
 
     my $arch       = get_var('ARCH');
     my $type_speed = 20;
-    my $path       = "/mnt/openqa/repo/" . get_var('REPO_0') . "/boot/$arch/loader/";
-    type_string "$path/linux initrd=$path/initrd install=http://" . get_var('SUSEMIRROR') . " ", $type_speed;
+    my $path       = "/mnt/openqa/repo/" . get_var('REPO_10') . "/boot/$arch/loader";
+    my $repo = get_var('HOST') . "/assets/repo/" . get_var('REPO_10');
+    type_string "$path/linux initrd=$path/initrd install=$repo ", $type_speed;
 
     type_string "vga=791 ",                   $type_speed;
     type_string "Y2DEBUG=1 ",                 $type_speed;
     type_string "video=1024x768-16 ",         $type_speed;
     type_string "console=$serialdev,115200 ", $type_speed;    # to get crash dumps as text
     type_string "console=tty ",               $type_speed;    # to get crash dumps as text
-                                                              # for some reason we need to reset the "VNC" connection again to see the bottom - most likely because it has the odd resolution of 752x413
-    $bmwqemu::backend->relogin_vnc();
-    assert_screen 'qa-net-typed', 5;
+    assert_screen 'qa-net-typed';
 
     my $e = get_var("EXTRABOOTPARAMS");
     if ($e) {


### PR DESCRIPTION
REPO_0 no longer points to a valid installation source, but to the POOL?