### PR TITLE
Yast CLI tests: Drop the git approach - use src packages.

### DIFF
--- a/tests/console/yast2_cmdline.pm
+++ b/tests/console/yast2_cmdline.pm
@@ -5,13 +5,15 @@ sub run() {
     my $self = shift;
 
     become_root();
-    # Install git
-    assert_script_run 'zypper -n install git-core';
+    # Install test requirement
+    assert_script_run 'zypper -n in rpm-build';
 
-    # Run all the existing YaST CLI tests
-    $self->run_yast_cli_test('yast-network');
-    assert_script_run 'zypper -n install bind yast2-dns-server';
-    $self->run_yast_cli_test('yast-dns-server');
+    # Enable source repo
+    assert_script_run 'zypper mr -e repo-source';
+
+    # Run YaST CLI tests
+    $self->run_yast_cli_test('yast2-network');
+    $self->run_yast_cli_test('yast2-dns-server');
 
     # Exit from root
     script_run 'exit';


### PR DESCRIPTION
As a followup to the discussion among @aaannz @ancorgs @DimStar77 and @mvidner here:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/614
I tried to fix the raised objections by replacing the 'git clone' approach by
- Installing the src-rpm using 'zypper si' (does also install build deps)
  So we can be sure that the test fits the package version
- Run 'rpmbuild -bp' to untar and apply the patches (if any)
- cd into the build dir and run the CLI tests

I am not yet sure if this will work on SLE, too, since I guess rpm-build will not be available there.
