### PR TITLE
test autoyast error dialogs

### DIFF
--- a/data/autoyast_sle12/autoyast_error.xml
+++ b/data/autoyast_sle12/autoyast_error.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+
+
+<!-- the purpose of this autoyast file is to test the error dialog in stage 1 and 2
+     the errors are not fatal so the installation can continue after confirmation
+-->
+
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <report>
+    <messages>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+      <log config:type="boolean">true</log>
+    </messages>
+    <errors>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+      <log config:type="boolean">true</log>
+    </errors>
+    <warnings>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+      <log config:type="boolean">true</log>
+    </warnings>
+  </report>
+
+<!-- stage 2 error - script output -->
+
+  <scripts>
+    <post-scripts config:type="list">
+      <script>
+        <source>
+<![CDATA[ echo Post-install script error dialog
+]]>
+        </source>
+        <feedback config:type="boolean">true</feedback>
+        <feedback_type>error</feedback_type>
+      </script>
+    </post-scripts>
+  </scripts>
+
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url><![CDATA[dvd:///?devices=/dev/sr0]]></media_url>
+        <product_dir>/</product_dir>
+      </listentry>
+    </add_on_products>
+  </add-on>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <keyboard>
+    <keyboard_values>
+      <delay/>
+      <discaps config:type="boolean">false</discaps>
+      <numlock>bios</numlock>
+      <rate/>
+    </keyboard_values>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <software>
+    <packages config:type="list">
+
+<!-- stage 1 error - missing package -->
+
+      <package>nonexistent-package</package>
+
+
+      <package>perl-Bootloader-YAML</package>
+      <package>glibc</package>
+      <package>grub2</package>
+      <package>snapper</package>
+      <package>syslinux</package>
+      <package>kdump</package>
+      <package>sles-release</package>
+      <package>sle-sdk-release</package>
+      <package>kexec-tools</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>32bit</pattern>
+      <pattern>Minimal</pattern>
+      <pattern>apparmor</pattern>
+      <pattern>base</pattern>
+      <pattern>documentation</pattern>
+      <pattern>gnome-basic</pattern>
+      <pattern>x11</pattern>
+    </patterns>
+  </software>
+  <networking>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <startmode>auto</startmode>
+      </interface>
+    </interfaces>
+  </networking>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Berlin</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact>-1</inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>


### PR DESCRIPTION
The main purpose of this test is to exercise the error dialog needles to be sure that the autoyast error handling and uploading logs works ok in both stage1 and stage2. 