### PR TITLE
Doing snapper test

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -483,7 +483,9 @@ sub load_yast2ui_tests() {
     loadtest "yast2_ui/yast2_hostnames.pm";
     loadtest "yast2_ui/yast2_lang.pm";
     loadtest "yast2_ui/yast2_network_settings.pm";
-    loadtest "yast2_ui/yast2_snapper.pm";
+    if (snapper_is_applicable) {
+        loadtest "yast2_ui/yast2_snapper.pm";
+    }
     loadtest "yast2_ui/yast2_software_management.pm";
     loadtest "yast2_ui/yast2_users.pm";
 }

--- a/templates
+++ b/templates
@@ -3220,6 +3220,7 @@
                       settings => [
                         { key => "DESKTOP", value => "gnome" },
                         { key => "INSTALLONLY", value => 1 },
+                        { key => "HDDSIZEGB", value => 20 },
                         { key => "STORE_HDD_1", value => "gnome_image.qcow2" },
                       ],
                     },
@@ -3229,6 +3230,7 @@
                         { key => "BOOT_HDD_IMAGE", value => 1 },
                         { key => "DESKTOP", value => "gnome" },
                         { key => "HDD_1", value => "gnome_image.qcow2" },
+                        { key => "HDDSIZEGB", value => 20 },
                         { key => "START_AFTER_TEST", value => "install-gnome-image" },
                         { key => "Y2UITEST", value => 1 },
                       ],

--- a/tests/yast2_ui/yast2_snapper.pm
+++ b/tests/yast2_ui/yast2_snapper.pm
@@ -1,13 +1,142 @@
 use base "y2x11test";
 use testapi;
 
-sub run() {
-    my $self   = shift;
-    my $module = "snapper";
+# Test for basic yast2-snapper functionality. It assumes the data of the
+# opensuse distri to be available at /home/$username/data (as granted by
+# console_setup.pm)
 
-    $self->launch_yast2_module_x11($module);
-    assert_screen "yast2-$module-ui", 30;
-    send_key "alt-f4";    # Exit
+# Helper for letting y2-snapper to create a snapper snapshot
+sub y2snapper_create_snapshot() {
+    my $self = shift;
+    my $name = shift || "Awesome Snapshot";
+    # Open the 'C'reate dialog and wait until it is there
+    send_key "alt-c";
+    assert_screen 'yast2_snapper-createsnapshotdialog', 100;
+    # Fill the form and finish by pressing the 'O'k-button
+    type_string $name;
+    sleep 2;
+    send_key "tab";
+    sleep 2;
+    send_key "tab";
+    sleep 2;
+    send_key "tab";
+    sleep 2;
+    send_key "tab";
+    sleep 2;
+    send_key "tab";
+    sleep 2;
+    type_string "a=1,b=2";
+    sleep 2;
+    send_key "alt-o";
+}
+
+# Helper for selecting the new snapshot in y2-snapper
+#
+# Called when the list has been just loaded, so the top most item is selected
+sub y2snapper_select_snapshot() {
+    my $limit = 0;    # Just in case the needles don't match at all (sh*t happens)
+
+    return 1 if (check_screen('yast2_snapper-new_snapshot_selected', 3));
+    # Return false if there is no snapshot to select
+    return 0 unless (check_screen('yast2_snapper-new_snapshot', 3));
+
+    until (check_screen('yast2_snapper-new_snapshot_selected', 5) || $limit > 20) {
+        $limit++;
+        send_key "down";
+    }
+    if (check_screen('yast2_snapper-new_snapshot_selected', 5)) {
+        return 1;
+    }
+    else {
+        return 0;
+    }
+}
+
+# Quit yast2-snapper and cleanup the mess
+sub clean_and_quit() {
+    # C'l'ose  the snapper module
+    send_key "alt-l";
+    # Wait until xterm is focussed, delete the directory and close xterm
+    wait_idle;
+    script_run "rm -rf testdata";
+    script_run "ls";
+    script_run "exit";
+    save_screenshot;
+    script_run "exit";
+}
+
+sub run() {
+    my $self = shift;
+
+    # Make sure yast2-snapper is installed (if not: install it)
+    ensure_installed "yast2-snapper";
+
+    # Start an xterm as root
+    x11_start_program("xterm");
+    wait_idle;
+    become_root;
+    script_run "cd";
+
+    # Start the yast2 snapper module and wait until it is started
+    script_run "yast2 snapper";
+    assert_screen 'yast2_snapper-snapshots', 100;
+    # Make sure the test snapshot is not there
+    die("Unexpected snapshot found") if (check_screen('yast2_snapper-new_snapshot', 5));
+
+    # Create a new snapshot
+    $self->y2snapper_create_snapshot();
+    # Make sure the snapshot is listed in the main window
+    assert_screen 'yast2_snapper-new_snapshot', 100;
+    # C'l'ose  the snapper module
+    send_key "alt-l";
+
+    # Download & untar test files
+    wait_idle;
+    script_run "tar -xzf /home/$username/data/yast2_snapper.tgz && echo tar_complete > /dev/$serialdev";
+    wait_serial('tar_complete') || die 'tar -xzf failed';
+
+    # Start the yast2 snapper module and wait until it is started
+    script_run "yast2 snapper";
+    assert_screen 'yast2_snapper-snapshots', 100;
+    # Select the new snapshot
+    unless ($self->y2snapper_select_snapshot) {
+        $self->clean_and_quit;
+        die("Failed to select the snapshot in order to show differences");
+    }
+    # Press 'S'how changes button and select both directories that have been
+    # extracted from the tarball
+    send_key "alt-s";
+    assert_screen 'yast2_snapper-collapsed_testdata', 200;
+    send_key "tab";
+    sleep 2;
+    send_key "spc";
+    sleep 2;
+    send_key "down";
+    sleep 2;
+    send_key "spc";
+    # Make sure it shows the new files from the unpacked tarball
+    assert_screen 'yast2_snapper-show_testdata', 100;
+    # Close the dialog and make sure it is closed
+    send_key "alt-c";
+    assert_screen 'yast2_snapper-new_snapshot', 100;
+
+    # Select the new snapshot
+    unless ($self->y2snapper_select_snapshot) {
+        $self->clean_and_quit;
+        die("Failed to select the snapshot in order to delete it");
+    }
+    # Dele't'e the snapshot
+    send_key "alt-t";
+    assert_screen 'yast2_snapper-confirm_delete', 100;
+    send_key "alt-y";
+    # Make sure the snapshot is not longer there
+    assert_screen 'yast2_snapper-snapshots', 100;
+    if (check_screen('yast2_snapper-new_snapshot', 5)) {
+        $self->clean_and_quit;
+        die("The snapshot is still visible after trying to delete it");
+    }
+    # Success
+    $self->clean_and_quit;
 }
 
 1;


### PR DESCRIPTION
I just realize actually we didn't have valid snapper test running for openSUSE, since we're moved most of yast2 tests to a standalone one which rely on preinstalled image, so I've 1) copied yast2_snapper test from x11 to yast2_ui, but did not remove x11 one because still require it somewhere and it runs for SLE test, so did not remove it for now, we can solve it later. 2) give HDDSIZEGB = 20 to install-gnome-image and add dummy HDDSIZEGB setting to yast2_ui_gnome. This should not effect SLE or anything else but yast2_ui module itself.