### PR TITLE
fix ttylogin needle match by setting correct prompt

### DIFF
--- a/tests/console/ttylogin4.pm
+++ b/tests/console/ttylogin4.pm
@@ -21,6 +21,7 @@ use ttylogin;
 
 sub run() {
     ttylogin;
+    type_string "PS1=\$\n";    # set constant shell promt
 }
 
 sub test_flags() {


### PR DESCRIPTION
https://openqa.opensuse.org/tests/102017