### PR TITLE
[untested] move the prompt functions into the opensusebasetest

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -55,5 +55,12 @@ sub export_captured_audio {
     upload_logs ref($self) . "-captured.wav";
 }
 
+
+# Set a simple reproducible prompt for easier needle matching without hostname
+# keep in sync with susedistribution
+sub set_standard_prompt {
+    type_string "PS1=\$\ \n";
+}
+
 1;
 # vim: set sw=4 et:

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -5,7 +5,7 @@ use strict;
 # Base class for all openSUSE tests
 
 # don't import script_run - it will overwrite script_run from distribution and create a recursion
-use testapi qw(send_key %cmd assert_screen check_screen check_var get_var type_password type_string wait_idle wait_serial mouse_hide select_console);
+use testapi qw(send_key %cmd assert_screen check_screen check_var get_var type_password type_string wait_idle wait_serial mouse_hide);
 
 sub init() {
     my ($self) = @_;
@@ -165,23 +165,9 @@ sub become_root() {
     type_string "whoami > /dev/$testapi::serialdev\n";
     wait_serial("root", 6) || die "Root prompt not there";
     type_string "cd /tmp\n";
-    set_root_prompt();
-    send_key('ctrl-l');
-}
-
-# Set a simple reproducible prompt for easier needle matching without hostname
-sub set_standard_prompt() {
-    type_string "PS1=\$\ \n";
-}
-
-# Same as 'set_standard_prompt' but for root
-sub set_root_prompt() {
+    # set standard root prompt
     type_string "PS1=\#\ \n";
-}
-
-sub select_user_console() {
-    select_console('user-console');
-    set_standard_prompt();
+    send_key('ctrl-l');
 }
 
 # initialize the consoles needed during our tests
@@ -262,6 +248,8 @@ sub activate_console {
             $self->script_run("su - $user") unless ($user eq 'root');
         }
         assert_screen "text-logged-in", 10;
+        # same prompt as in opensusebasetest - but we can't import it
+        type_string "PS1=\$\ \n";
     }
 }
 

--- a/tests/console/console_reboot.pm
+++ b/tests/console/console_reboot.pm
@@ -7,7 +7,7 @@ sub run() {
     type_string "reboot\n";
     reset_consoles;
     wait_boot;
-    select_user_console();
+    select('user-console');
     assert_script_sudo "chown $username /dev/$serialdev";
 }
 

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -16,7 +16,7 @@ sub run() {
     }
 
     # init
-    select_user_console();
+    select('user-console');
 
     script_sudo "chown $username /dev/$serialdev";
 

--- a/tests/console/sle11_consoletest_setup.pm
+++ b/tests/console/sle11_consoletest_setup.pm
@@ -26,7 +26,7 @@ sub run() {
         type_string "\n";
     }
     sleep 3;
-    set_standard_prompt();
+    $self->set_standard_prompt();
     sleep 1;
 
     script_sudo "chown $username /dev/$serialdev";

--- a/tests/console/ttylogin4.pm
+++ b/tests/console/ttylogin4.pm
@@ -19,7 +19,7 @@ use testapi;
 
 
 sub run() {
-    select_user_console();
+    select('user-console');
 }
 
 sub test_flags() {

--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -11,7 +11,7 @@ sub run() {
     type_string "$password\n";
     sleep 2;
     for (1 .. 13) { send_key "ret" }
-    set_standard_prompt();
+    $self->set_standard_prompt();
     type_string "echo If you can see this text, ssh-X-forwarding  is working.\n";
     sleep 2;
     assert_screen 'test-sshxterm-1', 3;


### PR DESCRIPTION
and call the standard_prompt function already in select_console