### PR TITLE
Validate output with validate_script_output instead of needling

### DIFF
--- a/tests/console/a2ps.pm
+++ b/tests/console/a2ps.pm
@@ -1,16 +1,18 @@
 use strict;
 use base "consoletest";
 use testapi;
-
-# a2ps is available by default only in openSUSE*
+use ttylogin;
 
 sub run() {
     become_root;
+    assert_script_run("systemctl stop packagekit.service");
     assert_script_run("zypper -n in a2ps");
-    assert_script_run("curl https://www.suse.com -o /tmp/suse.html");
-    assert_script_run("a2ps -o /tmp/suse.ps /tmp/suse.html");
-    assert_screen "a2ps_saved";
+    assert_script_run("curl https://www.suse.com > /tmp/suse.html");
+    validate_script_output "a2ps -o /tmp/suse.ps /tmp/suse.html 2>&1", sub { m/saved into the file/ }, 3;
     script_run('exit');
 }
 
 1;
+
+#vim: set sw=4 et:
+


### PR DESCRIPTION
Based on https://progress.opensuse.org/issues/9660