### PR TITLE
Fix prompt again - do not being a veriable

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -59,7 +59,7 @@ sub export_captured_audio {
 # Set a simple reproducible prompt for easier needle matching without hostname
 # keep in sync with susedistribution
 sub set_standard_prompt {
-    type_string "PS1='$ '\n";
+    type_string "PS1='\$ '\n";
 }
 
 1;

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -293,7 +293,7 @@ sub activate_console {
         }
         assert_screen "text-logged-in", 10;
         # same prompt as in opensusebasetest - but we can't import it
-        type_string "PS1=\$\ \n";
+        type_string "PS1='\$ '\n";
     }
 }
 

--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -35,7 +35,7 @@ sub run() {
         select_console('root-console');
     }
 
-    script_run "PS1=\$";    # set constant shell promt
+    $self->set_standard_prompt();
 
     # Disable console screensaver
     assert_script_run("setterm -blank 0");


### PR DESCRIPTION
Put $ inside of double quotes without escape character
it is being a variable in Perl.