### PR TITLE
avoid a race in the glibc test

### DIFF
--- a/tests/console/glibc_i686.pm
+++ b/tests/console/glibc_i686.pm
@@ -3,9 +3,7 @@ use testapi;
 
 # this part contains the steps to run this test
 sub run() {
-    my $self = shift;
-    script_run("clear");
-    script_sudo("zypper -n in -C libc.so.6");
+    assert_script_sudo("zypper -n in -C libc.so.6");
     script_run("/lib/libc.so.*");
     assert_screen 'test-glibc_i686-1', 100;
 }


### PR DESCRIPTION
we need to wait for zypper to finish before typing - or we don't
get a clear needle