### PR TITLE
use dhcp for supportserver generator

### DIFF
--- a/data/supportserver/autoyast_supportserver.xml
+++ b/data/supportserver/autoyast_supportserver.xml
@@ -168,9 +168,8 @@
     -->
     <interfaces config:type="list">
       <interface>
-	<bootproto>static</bootproto>
-        <ipaddr>10.0.2.1/24</ipaddr>        
-        <device>eth0</device>        
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
         <startmode>onboot</startmode>
       </interface>
     </interfaces>


### PR DESCRIPTION
The static address worked only with autoinst_url 10.0.2.2.
For autoinst_url in external network it is better to use dhcp which sets up routing correctly.