### PR TITLE
remove skipping of RT add-on SCC reg key prompt

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -88,7 +88,7 @@ sub fill_in_registration_data {
             for $addon (split(/,/, get_var('SCC_ADDONS', ''))) {
                 $uc_addon = uc $addon;    # change to uppercase to match variable
                 if (my $regcode = get_var("SCC_REGCODE_$uc_addon")) {
-                    next if ($addon =~ /sdk|rt/);    # bsc#956726
+                    next if ($addon =~ /sdk/);
                     if (check_var('DESKTOP', 'textmode')) {
                         send_key_until_needlematch "scc-code-field-$addon", 'tab';
                     }


### PR DESCRIPTION
I excluded also RT addon, to don't wait for SCC reg code prompt because of bug bsc#956726, it shouldn't be fixed in SP1, but it is fixed and RT add-on is asking for reg code
Have to remove it now otherwise test will fail. https://openqa.suse.de/tests/169036/modules/scc_registration/steps/7