### PR TITLE
[WIP] trust untrusted key and record soft failure

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -16,6 +16,10 @@ sub run() {
             send_key_until_needlematch 'addon-dvd-list', 'tab', 10;     # jump into addon list
             send_key_until_needlematch "addon-dvd-$a",   'down', 10;    # select addon in list
             send_key 'alt-o';                                           # continue
+            if (check_screen('import-untrusted-gpg-key', 5)) {          # untrusted key pop-up, record soft fail and trust it
+                record_soft_failure;
+                send_key 'alt-t';
+            }
             my $b = uc $a;                                              # variable name is upper case
             if (get_var("BETA_$b")) {
                 assert_screen "addon-betawarning-$a", 10;


### PR DESCRIPTION
during development build it can happen that untrusted key is used, this will trust key, soft fail and continue with testing
https://openqa.suse.de/tests/174925/modules/addon_products_sle/steps/14