### PR TITLE
zdup: show network config prior to start the update

### DIFF
--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -17,6 +17,10 @@ sub run() {
     my $zypper_installing        = qr/Installing: \S+/;
     my $zypper_dup_fileconflict  = qr/^File conflicts .*^Continue\? \[y/ms;
 
+    # This is just for reference to know how the network was configured prior to the update
+    script_run "ip addr show";
+    save_screenshot;
+
     # before disable we need to have cdrkit installed to get proper iso appid
     script_run "zypper -n in cdrkit-cdrtools-compat";
     # Disable all repos, so we do not need to remove one by one


### PR DESCRIPTION
This can be useful as information to have in cases like:

https://openqa.opensuse.org/tests/112674/modules/consoletest_setup/steps/6
where post the zdup there is no network...

it does not fix it, but can help with the debugging to have the info available (especially suspecting name changes of the device names)