### PR TITLE
Fix 'ctrl-l being missed when executed before completion of previous command

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -2,13 +2,17 @@ package opensusebasetest;
 use base 'basetest';
 
 use testapi;
+use utils;
 
 # Base class for all openSUSE tests
 
+
+# Additional to backend testapi 'clear-console' we do a needle match to ensure
+# continuation only after verification
 sub clear_and_verify_console {
     my ($self) = @_;
 
-    send_key "ctrl-l";
+    clear_console;
     assert_screen('cleared-console');
 
 }

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -148,7 +148,7 @@ sub ensure_installed {
 sub script_sudo($$) {
     my ($self, $prog, $wait) = @_;
 
-    send_key 'ctrl-l';
+    type_string "clear\n";
     type_string "su -c \'$prog\'\n";
     if (!get_var("LIVETEST")) {
         assert_screen 'password-prompt';
@@ -178,7 +178,7 @@ sub become_root {
     wait_serial("root", 6) || die "Root prompt not there";
     type_string "cd /tmp\n";
     $self->set_standard_prompt('root');
-    send_key('ctrl-l');
+    type_string "clear\n";
 }
 
 # initialize the consoles needed during our tests

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -7,7 +7,7 @@ use strict;
 
 use testapi;
 
-our @EXPORT = qw/wait_boot unlock_if_encrypted/;
+our @EXPORT = qw/unlock_if_encrypted wait_boot clear_console/;
 
 sub unlock_if_encrypted {
 
@@ -86,6 +86,12 @@ sub wait_boot {
 
     assert_screen 'generic-desktop', 300;
     mouse_hide(1);
+}
+
+# 'ctrl-l' does not get queued up in buffer. If this happens to fast, the
+# screen would not be cleared
+sub clear_console {
+    type_string "clear\n";
 }
 
 1;

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -16,6 +16,7 @@
 use strict;
 use base 'basetest';
 use testapi;
+use utils;
 
 sub save_logs_and_continue {
     my $name = shift;
@@ -28,7 +29,7 @@ sub save_logs_and_continue {
     type_string "save_y2logs /tmp/y2logs-$name.tar.bz2\n";
     upload_logs "/tmp/y2logs-$name.tar.bz2";
     save_screenshot;
-    send_key "ctrl-l";
+    clear_console;
     send_key "alt-f7";
     wait_idle(5);
 }

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -10,6 +10,7 @@
 
 use base "consoletest";
 use testapi;
+use utils;
 
 
 sub run() {
@@ -47,7 +48,7 @@ sub run() {
     script_run "exit";
 
     save_screenshot;
-    send_key "ctrl-l";
+    clear_console;
 
     script_run("curl -L -v " . autoinst_url('/data') . " > test.data; echo \"curl-\$?\" > /dev/$serialdev");
     wait_serial("curl-0", 10) || die 'curl failed';

--- a/tests/console/installation_snapshots.pm
+++ b/tests/console/installation_snapshots.pm
@@ -10,6 +10,7 @@
 
 use base 'consoletest';
 use testapi;
+use utils;
 
 # fate#317973: Create initial snapshot at the end of installation/update
 # bnc#935923: Cleanup and consistent naming for snapshots made during installation
@@ -25,7 +26,7 @@ sub run() {
     $pattern = 'single\s*(\|[^|]*){4}\s*\|\s*number\s*\|\s*Initial Status\s*\|\s*important=yes' if get_var('JEOS');
     wait_serial($pattern, 5) || die 'installation snapshot test failed';
     script_run('exit');
-    send_key 'ctrl-l';
+    clear_console;
 }
 
 sub test_flags() {

--- a/tests/console/mozmill_setup.pm
+++ b/tests/console/mozmill_setup.pm
@@ -10,6 +10,7 @@
 
 use base "consoletest";
 use testapi;
+use utils;
 
 # http://mozmill-crowd.blargon7.com/#/functional/reports
 
@@ -17,7 +18,7 @@ sub run() {
     my $self = shift;
     script_sudo("zypper -n in gcc python-devel python-pip mercurial curlftpfs");
     assert_screen 'test-mozmill_setup-1', 3;
-    send_key "ctrl-l";
+    clear_console;
 
     #script_sudo("pip install mozmill mercurial");
     script_sudo("pip install mozmill mercurial");
@@ -26,7 +27,7 @@ sub run() {
     sleep 5;
     wait_idle 50;
     assert_screen 'test-mozmill_setup-2', 3;
-    send_key "ctrl-l";
+    clear_console;
     script_run("cd /tmp");    # dont use home to not confuse dolphin test
     script_run("wget -q openqa.opensuse.org/opensuse/qatests/qa_mozmill_setup.sh");
     local $bmwqemu::timesidleneeded = 3;

--- a/tests/console/sle11_consoletest_setup.pm
+++ b/tests/console/sle11_consoletest_setup.pm
@@ -10,6 +10,7 @@
 
 use base "consoletest";
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
@@ -46,7 +47,7 @@ sub run() {
     script_run "exit";
 
     save_screenshot;
-    send_key "ctrl-l";
+    clear_console;
 
     script_run("curl -L -v " . autoinst_url . "/data > test.data; echo \"curl-\$?\" > /dev/$serialdev");
     wait_serial("curl-0", 10) || die 'curl failed';

--- a/tests/console/sntp.pm
+++ b/tests/console/sntp.pm
@@ -10,6 +10,7 @@
 
 use base "consoletest";
 use testapi;
+use utils;
 
 # for https://bugzilla.novell.com/show_bug.cgi?id=657626
 sub run() {
@@ -18,7 +19,7 @@ sub run() {
     script_sudo("perl qa_ntp.pl");
     wait_idle 90;
     assert_screen 'test-sntp-1', 3;
-    send_key "ctrl-l";    # clear screen
+    clear_console;
     script_run('echo sntp returned $?');
     assert_screen 'test-sntp-2', 3;
 }

--- a/tests/console/upgrade_snapshots.pm
+++ b/tests/console/upgrade_snapshots.pm
@@ -10,6 +10,7 @@
 
 use base 'consoletest';
 use testapi;
+use utils;
 
 # fate#317900: Create snapshot before starting Upgrade
 
@@ -25,7 +26,7 @@ sub run() {
     wait_serial('post\s*(\|[^|]*){4}\s*\|\s*number\s*\|\s*after update\s*\|\s*important=yes', 5) || die 'upgrade snapshots test failed';
 
     script_run('exit');
-    send_key 'ctrl-l';
+    clear_console;
 }
 
 sub test_flags() {

--- a/tests/console/xorg_vt.pm
+++ b/tests/console/xorg_vt.pm
@@ -10,11 +10,12 @@
 
 use base "consoletest";
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
 
-    send_key "ctrl-l";
+    clear_console;
     script_run('ps -ef | grep bin/X');
     assert_screen("xorg-tty7");    # suppose used terminal is tty7
 }

--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -10,6 +10,7 @@
 
 use base "console_yasttest";
 use testapi;
+use utils;
 
 # test yast2 bootloader functionality
 # https://bugzilla.novell.com/show_bug.cgi?id=610454
@@ -23,7 +24,7 @@ sub run() {
     my $ret = assert_screen "test-yast2_bootloader-1", 300;
     send_key "alt-o";                                      # OK => Close
     assert_screen 'exited-bootloader', 150;
-    send_key "ctrl-l";
+    clear_console;
     script_run("echo \"EXIT-\$?\" > /dev/$serialdev");
     die unless wait_serial "EXIT-0", 2;
     script_run('rpm -q hwinfo');

--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -10,6 +10,7 @@
 
 use base "console_yasttest";
 use testapi;
+use utils;
 
 sub run() {
     my $self        = shift;
@@ -73,7 +74,7 @@ sub run() {
     # yast might take a while on sle11 due to suseconfig
     wait_serial("yast2-i-status-0", 60) || die "yast didn't finish";
 
-    send_key "ctrl-l";                       # clear screen to see that second update does not do any more
+    clear_console;                           # clear screen to see that second update does not do any more
     assert_script_run("rpm -e $pkgname");    # erase $pkgname
     script_run("echo mark yast test");       # avoid zpper needle
     script_run("rpm -q $pkgname");

--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -10,6 +10,7 @@
 
 use base "console_yasttest";
 use testapi;
+use utils;
 
 # test yast2 lan functionality
 # https://bugzilla.novell.com/show_bug.cgi?id=600576
@@ -59,12 +60,12 @@ sub run() {
     send_key "alt-o";                                   # OK=>Save&Exit
     assert_screen 'yast2-lan-exited', 90;
 
-    send_key "ctrl-l";                                  # clear screen
+    clear_console;
     script_run('echo $?');
     script_run('hostname');
     assert_screen 'test-yast2_lan-2';
 
-    send_key "ctrl-l";                                  # clear screen
+    clear_console;
     script_run('ip -o a s');
     script_run('ip r s');
     script_run('getent ahosts ' . get_var("OPENQA_HOSTNAME"));

--- a/tests/console/zypper_in.pm
+++ b/tests/console/zypper_in.pm
@@ -10,6 +10,7 @@
 
 use base "consoletest";
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
@@ -19,7 +20,7 @@ sub run() {
 
     my $pkgname = get_var("PACKAGETOINSTALL");
     assert_script_run("zypper -n in screen $pkgname");
-    send_key "ctrl-l";    # clear screen to see that second update does not do any more
+    clear_console;    # clear screen to see that second update does not do any more
     assert_script_run("rpm -e $pkgname");
     script_run("rpm -q $pkgname");
     script_run('exit');

--- a/tests/console/zypper_up.pm
+++ b/tests/console/zypper_up.pm
@@ -10,6 +10,7 @@
 
 use base "consoletest";
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
@@ -30,7 +31,7 @@ sub run() {
 
     # XXX: does this below make any sense? what if updates got
     # published meanwhile?
-    send_key "ctrl-l";    # clear screen to see that second update does not do any more
+    clear_console;    # clear screen to see that second update does not do any more
     assert_script_run("zypper -n -q patch");
 
     script_run('exit');

--- a/tests/ha/cluster_init.pm
+++ b/tests/ha/cluster_init.pm
@@ -10,6 +10,7 @@
 
 use base "installbasetest";
 use testapi;
+use utils;
 use autotest;
 
 sub run() {
@@ -18,7 +19,7 @@ sub run() {
     assert_screen 'cluster-init', 60;
     type_string "crm status\n";
     assert_screen 'cluster-status';
-    send_key 'ctrl-l';
+    clear_console;
 }
 
 1;

--- a/tests/ha/cluster_join.pm
+++ b/tests/ha/cluster_join.pm
@@ -10,6 +10,7 @@
 
 use base "installbasetest";
 use testapi;
+use utils;
 use autotest;
 
 sub joincluster() {
@@ -28,7 +29,7 @@ sub joincluster() {
         upload_logs "/root/hbreport.tar.bz2";
         save_screenshot();
     }
-    send_key 'ctrl-l';
+    clear_console;
 }
 
 sub run() {

--- a/tests/ha/corosync.pm
+++ b/tests/ha/corosync.pm
@@ -10,13 +10,14 @@
 
 use base "installbasetest";
 use testapi;
+use utils;
 use autotest;
 
 sub run() {
     for my $i (1 .. 3) {
         type_string "crm status\n";
         assert_screen 'cluster-status';
-        send_key 'ctrl-l';
+        clear_console;
         send_key 'ctrl-pgdn';
     }
 }

--- a/tests/ha/fencing.pm
+++ b/tests/ha/fencing.pm
@@ -10,6 +10,7 @@
 
 use base "installbasetest";
 use testapi;
+use utils;
 use autotest;
 
 sub run() {
@@ -20,20 +21,20 @@ sub run() {
     type_string "crm status\n";
     assert_screen 'cluster-node-down';
     sleep 240;
-    send_key 'ctrl-l';
+    clear_console;
     type_string "crm status\n";
     assert_screen 'cluster-node-returned';
-    send_key 'ctrl-l';
+    clear_console;
     send_key 'ctrl-pgdn';
     send_key 'ret';
     type_string "ssh 10.0.2.17 -l root\n";
     sleep 10;
     type_string "nots3cr3t\n";
     sleep 10;
-    send_key 'ctrl-l';
+    clear_console;
     type_string "crm status\n";
     assert_screen 'cluster-status';
-    send_key 'ctrl-l';
+    clear_console;
     send_key 'ctrl-pgup';
 }
 

--- a/tests/ha/ha_preparation.pm
+++ b/tests/ha/ha_preparation.pm
@@ -10,6 +10,7 @@
 
 use base "installbasetest";
 use testapi;
+use utils;
 use autotest;
 
 sub connectssh($) {
@@ -22,7 +23,7 @@ sub connectssh($) {
     type_string "nots3cr3t\n";
     sleep 10;
     check_screen 'ha-ssh-login', 40;    #should be assert
-    send_key 'ctrl-l';
+    clear_console;
 }
 
 sub startvm($) {
@@ -32,7 +33,7 @@ sub startvm($) {
     sleep 5;
     type_string "nots3cr3t\n";
     sleep 5;
-    send_key 'ctrl-l';
+    clear_console;
 }
 
 sub fixvmnetwork($) {
@@ -52,7 +53,7 @@ sub fixvmnetwork($) {
     send_key 'down';
     send_key 'ret';
     sleep 5;
-    send_key 'ctrl-l';
+    clear_console;
 }
 
 sub rebootvm($) {
@@ -68,7 +69,7 @@ sub rebootvm($) {
     send_key 'down';
     send_key 'ret';
     sleep 5;
-    send_key 'ctrl-l';
+    clear_console;
 }
 
 sub checkboot($) {
@@ -79,7 +80,7 @@ sub checkboot($) {
     send_key 'down';
     send_key 'ret';
     sleep 5;
-    send_key 'ctrl-l';
+    clear_console;
 }
 
 sub run() {

--- a/tests/ha/sle11_cluster_init.pm
+++ b/tests/ha/sle11_cluster_init.pm
@@ -10,6 +10,7 @@
 
 use base "installbasetest";
 use testapi;
+use utils;
 use autotest;
 use lockapi;
 
@@ -19,7 +20,7 @@ sub run() {
         assert_screen 'cluster-init', 60;
         type_string "crm status\n";
         assert_screen 'cluster-status';
-        send_key 'ctrl-l';
+        clear_console;
         mutex_create('cluster-init');
     }
     else {
@@ -40,7 +41,7 @@ sub run() {
             type_string "tailf /var/log/messages\n";    # Probably redundant, remove if not needed
             save_screenshot();
         }
-        send_key 'ctrl-l';
+        clear_console;
     }
 }
 

--- a/tests/installation/post_zdup.pm
+++ b/tests/installation/post_zdup.pm
@@ -14,7 +14,7 @@ use testapi;
 use utils;
 
 sub run() {
-    send_key "ctrl-l", 1;
+    clear_console;
 
     # Print zypper repos
     script_run("zypper lr -d");

--- a/tests/installation/proxy_init.pm
+++ b/tests/installation/proxy_init.pm
@@ -11,6 +11,7 @@
 use base "installbasetest";
 use strict;
 use testapi;
+use utils;
 
 sub createvm($) {
     my ($self, $nodenum) = @_;
@@ -32,7 +33,7 @@ sub createvm($) {
     send_key 'f8',                    1;
     send_key 'down',                  1;
     send_key 'ret',                   1;
-    send_key 'ctrl-l',                1;
+    clear_console;
 }
 
 sub run() {

--- a/tests/installation/proxy_start_2nd_stage.pm
+++ b/tests/installation/proxy_start_2nd_stage.pm
@@ -11,6 +11,7 @@
 use base "installbasetest";
 use strict;
 use testapi;
+use utils;
 
 sub reconnectsshinstall($) {
     my ($nodenum) = @_;
@@ -31,7 +32,7 @@ sub waitfor2ndstage($) {
     send_key 'down',                1;
     send_key 'ret',                 1;
     sleep 5;
-    send_key 'ctrl-l', 1;
+    clear_console;
 }
 
 sub run() {

--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -21,9 +21,9 @@ sub run() {
     x11_start_program("chromium");
 
     assert_screen 'chromium-main-window', 50;
-    send_key "esc";    # get rid of popup
+    send_key "esc";       # get rid of popup
     sleep 1;
-    send_key "ctrl-l";
+    send_key "ctrl-l";    # select text in address bar
     sleep 1;
     type_string "about:\n";
     assert_screen 'chromium-about', 15;

--- a/tests/x11/xterm.pm
+++ b/tests/x11/xterm.pm
@@ -10,6 +10,7 @@
 
 use base "x11test";
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
@@ -17,8 +18,8 @@ sub run() {
     x11_start_program("xterm");
     sleep 2;
     type_string "cd\n";
-    sleep 1;              # go to $HOME (for KDE)
-    send_key "ctrl-l";    # clear
+    sleep 1;    # go to $HOME (for KDE)
+    clear_console;
     for (1 .. 13) { send_key "ret" }
     type_string "echo If you can see this text xterm is working.\n";
     sleep 2;


### PR DESCRIPTION
This should fix some flaky tests depending on machine execution performance.

Replace all occurences of 'ctrl-l' to clear the screen in a console with
'clear\n' in form of the new helper function 'clear_console()' as 'ctrl-l' is
not buffered in the keybuffer whereas 'clear\n' is executed after the previous
command returns to the prompt.

Tested locally with "console-consoletest_setup" and following on x86_64. No
test of "ha" or similar has been done.

Alternative or complementary to
os-autoinst#923

Related issue:
https://progress.opensuse.org/issues/10138