### PR TITLE
Revert "SLE12 partner to PR #891 - Merge at the same time please"

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -483,7 +483,6 @@ sub load_consoletests() {
         loadtest "console/consoletest_setup.pm";
         loadtest "console/check_console_font.pm";
         loadtest "console/textinfo.pm";
-        loadtest "console/ay_profilecheck.pm";
         loadtest "console/hostname.pm";
         if (snapper_is_applicable) {
             if (get_var("UPGRADE")) {


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#929 because ay_profilecheck.pm has been removed