### PR TITLE
Tune up/remove too strict assert_screen timeouts - see PR Comment

### DIFF
--- a/tests/console/install_yast_head.pm
+++ b/tests/console/install_yast_head.pm
@@ -84,7 +84,7 @@ sub run() {
         $out = wait_serial([$zypper_dup_finish, $zypper_installing, $zypper_dup_notifications, $zypper_dup_error, $zypper_dup_fileconflict], 240);
     }
 
-    assert_screen "zypper-dup-finish", 2;
+    assert_screen "zypper-dup-finish";
     script_run("exit");
 }
 

--- a/tests/installation/addon_products.pm
+++ b/tests/installation/addon_products.pm
@@ -38,7 +38,7 @@ sub run() {
                 send_key "alt-t", 1;                     # confirm import (trust) key
             }
         }
-        assert_screen 'test-addon_product-1', 3;
+        assert_screen 'test-addon_product-1';
         send_key $cmd{"next"}, 1;                        # done
     }
 
@@ -47,17 +47,17 @@ sub run() {
         foreach $a (split(/,/, get_var('ADDONS'))) {
             send_key 'alt-d';                            # DVD
             send_key $cmd{"xnext"}, 1;
-            assert_screen 'dvd-selector',                3;
+            assert_screen 'dvd-selector';
             send_key_until_needlematch 'addon-dvd-list', 'tab';
             send_key_until_needlematch "addon-dvd-$a",   'down';
             send_key 'alt-o';
             if (get_var("BETA")) {
-                assert_screen "addon-betawarning-$a", 10;
+                assert_screen "addon-betawarning-$a";
                 send_key "ret";
-                assert_screen "addon-license-beta", 10;
+                assert_screen "addon-license-beta";
             }
             else {
-                assert_screen "addon-license-$a", 10;
+                assert_screen "addon-license-$a";
             }
             sleep 2;
             send_key 'alt-y';    # yes, agree
@@ -66,7 +66,7 @@ sub run() {
             assert_screen 'addon-list';
             if ((split(/,/, get_var('ADDONS')))[-1] ne $a) {
                 send_key 'alt-a';
-                assert_screen 'addon-selection', 15;
+                assert_screen 'addon-selection';
             }
 
         }

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -19,20 +19,20 @@ sub run() {
     if (get_var("ADDONS")) {
         send_key 'alt-k', 3;    # install with addons
         foreach $a (split(/,/, get_var('ADDONS'))) {
-            send_key 'alt-d',                            3;             # DVD
-            send_key 'alt-n',                            3;
-            assert_screen 'dvd-selector',                3;
-            send_key_until_needlematch 'addon-dvd-list', 'tab', 10;     # jump into addon list
+            send_key 'alt-d', 3;    # DVD
+            send_key 'alt-n', 3;
+            assert_screen 'dvd-selector';
+            send_key_until_needlematch 'addon-dvd-list', 'tab',  10;    # jump into addon list
             send_key_until_needlematch "addon-dvd-$a",   'down', 10;    # select addon in list
             send_key 'alt-o';                                           # continue
             my $b = uc $a;                                              # variable name is upper case
             if (get_var("BETA_$b")) {
-                assert_screen "addon-betawarning-$a", 10;
+                assert_screen "addon-betawarning-$a";
                 send_key "ret";
-                assert_screen "addon-license-beta", 10;
+                assert_screen "addon-license-beta";
             }
             else {
-                assert_screen "addon-license-$a", 10;
+                assert_screen "addon-license-$a";
             }
             sleep 2;
             send_key 'alt-a';                                           # yes, agree
@@ -41,22 +41,22 @@ sub run() {
             assert_screen 'addon-list';
             if ((split(/,/, get_var('ADDONS')))[-1] ne $a) {
                 send_key 'alt-a';
-                assert_screen 'addon-selection', 15;
+                assert_screen 'addon-selection';
             }
         }
-        assert_screen 'addon-list', 5;
-        send_key 'alt-n',           3;                                  # done
+        assert_screen 'addon-list';
+        send_key 'alt-n', 3;                                            # done
     }
     elsif (get_var("ADDONURL")) {
         send_key 'alt-k';                                               # install with addons
         send_key 'alt-u';                                               # specify url
         send_key 'alt-n';
-        assert_screen 'addonurl-entry', 3;
+        assert_screen 'addonurl-entry';
         type_string get_var("ADDONURL");
         send_key 'alt-e';                                               # name
         type_string "incident0";
         send_key 'alt-n';
-        assert_screen 'addonproduct-selection', 3;
+        assert_screen 'addonproduct-selection';
         send_key 'alt-n';
     }
     else {

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -60,7 +60,7 @@ sub run() {
         for (1 .. 2) {
             send_key "up";
         }
-        assert_screen "inst-textselected", 5;
+        assert_screen "inst-textselected";
         send_key "ret";
     }
 
@@ -86,11 +86,11 @@ sub run() {
     # set HTTP-source to not use factory-snapshot
     if (get_var("NETBOOT")) {
         send_key "f4";
-        assert_screen "inst-instsourcemenu", 4;
+        assert_screen "inst-instsourcemenu";
         # select a net installation source (http, ftp, nfs, smb) by using send_key_until_needlematch
         send_key_until_needlematch 'inst-instsourcemenu-' . get_var('INSTALL_SOURCE', 'http'), 'down';
         send_key "ret";
-        assert_screen "inst-instsourcedialog-" . get_var('INSTALL_SOURCE', 'http'), 4;
+        assert_screen "inst-instsourcedialog-" . get_var('INSTALL_SOURCE', 'http');
 
         my $mirroraddr = "";
         my $mirrorpath = "/factory";
@@ -129,7 +129,7 @@ sub run() {
         # add a interval to prevent typo
         type_string $mirrorpath, 4;
 
-        assert_screen "inst-mirror_is_setup", 2;
+        assert_screen "inst-mirror_is_setup";
         send_key "ret";
 
         # HTTP-proxy
@@ -141,7 +141,7 @@ sub run() {
             }
             send_key "ret";
             type_string "$proxyhost\t$proxyport\n";
-            assert_screen "inst-proxy_is_setup", 2;
+            assert_screen "inst-proxy_is_setup";
 
             # add boot parameters
             # ZYPP... enables proxy caching
@@ -228,7 +228,7 @@ sub run() {
         if ($n && $n != $en_us) {
             $n -= $en_us;
             send_key "f2";
-            assert_screen "inst-languagemenu", 6;
+            assert_screen "inst-languagemenu";
             for (1 .. abs($n)) {
                 send_key($n < 0 ? "up" : "down");
             }

--- a/tests/installation/change_desktop.pm
+++ b/tests/installation/change_desktop.pm
@@ -28,7 +28,7 @@ sub change_desktop() {
     # ncurses offers a faster way
     if (check_var('VIDEOMODE', 'text')) {
         send_key 'alt-c';
-        assert_screen 'inst-overview-options', 3;
+        assert_screen 'inst-overview-options';
         send_key 'alt-s';
     }
     else {
@@ -73,19 +73,19 @@ sub change_desktop() {
         wait_screen_change { send_key ' '; };
     }
 
-    assert_screen "desktop-selected", 5;
+    assert_screen "desktop-selected";
 
     if (check_var('VIDEOMODE', 'text')) {
         send_key 'alt-a';    # accept
         accept3rdparty;
-        assert_screen 'automatic-changes', 4;
+        assert_screen 'automatic-changes';
         send_key 'alt-o';    # OK
     }
     else {
         send_key 'alt-o';    # OK
         accept3rdparty;
     }
-    assert_screen 'inst-overview', 15;
+    assert_screen 'inst-overview';
 
 }
 

--- a/tests/installation/installation_mode.pm
+++ b/tests/installation/installation_mode.pm
@@ -22,7 +22,7 @@ sub run() {
 
     if (get_var("UPGRADE")) {
         send_key "alt-u";    # Include Add-On Products
-        assert_screen "upgrade-selected", 2;
+        assert_screen "upgrade-selected";
     }
 
     if (get_var("HAVE_ADDON_REPOS")) {

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -18,9 +18,9 @@ sub run() {
 
     # overview-generation
     # this is almost impossible to check for real
-    assert_screen "inst-overview", 15;
+    assert_screen "inst-overview";
     if (get_var("XEN")) {
-        assert_screen "inst-xen-pattern", 5;
+        assert_screen "inst-xen-pattern";
     }
 
     # preserve it for the video
@@ -31,7 +31,7 @@ sub run() {
         record_soft_failure;
         if (check_var('VIDEOMODE', 'text')) {
             send_key 'alt-c';
-            assert_screen 'inst-overview-options', 3;
+            assert_screen 'inst-overview-options';
             send_key 'alt-s';
         }
         else {
@@ -52,9 +52,9 @@ sub run() {
                 send_key 'spc',   3;
                 send_key 'alt-o', 3;
             }
-            send_key 'alt-a',                           3;
-            send_key 'alt-o',                           3;
-            assert_screen "inst-overview-after-depfix", 15;    # Make sure you're back on the inst-overview before doing anything else
+            send_key 'alt-a', 3;
+            send_key 'alt-o', 3;
+            assert_screen "inst-overview-after-depfix";    # Make sure you're back on the inst-overview before doing anything else
         }
         else {
             save_screenshot;
@@ -62,7 +62,7 @@ sub run() {
         }
     }
 
-    if (check_var('BACKEND', 's390x')) {                       # s390x always needs SSH
+    if (check_var('BACKEND', 's390x')) {                   # s390x always needs SSH
         if (!check_screen('ssh-open', 5)) {
             send_key_until_needlematch 'ssh-blocked-selected', 'tab';
             send_key 'ret';

--- a/tests/installation/installation_overview_before.pm
+++ b/tests/installation/installation_overview_before.pm
@@ -18,7 +18,7 @@ sub run() {
 
     # overview-generation
     # this is almost impossible to check for real
-    assert_screen "inst-overview", 15;
+    assert_screen "inst-overview";
 
     # preserve it for the video
     wait_idle 10;
@@ -28,7 +28,7 @@ sub run() {
         record_soft_failure;
         if (check_var('VIDEOMODE', 'text')) {
             send_key 'alt-c';
-            assert_screen 'inst-overview-options', 3;
+            assert_screen 'inst-overview-options';
             send_key 'alt-s';
         }
         else {
@@ -49,9 +49,9 @@ sub run() {
                 send_key 'spc',   3;
                 send_key 'alt-o', 3;
             }
-            send_key 'alt-a',                           3;
-            send_key 'alt-o',                           3;
-            assert_screen "inst-overview-after-depfix", 15;    # Make sure you're back on the inst-overview before doing anything else
+            send_key 'alt-a', 3;
+            send_key 'alt-o', 3;
+            assert_screen "inst-overview-after-depfix";    # Make sure you're back on the inst-overview before doing anything else
         }
         else {
             save_screenshot;

--- a/tests/installation/installer_desktopselection.pm
+++ b/tests/installation/installer_desktopselection.pm
@@ -14,7 +14,7 @@ use testapi;
 
 sub run() {
     my %desktopkeys = (kde => "k", gnome => "g", xfce => "x", lxde => "l", minimalx => "m", textmode => "i");
-    assert_screen "desktop-selection", 30;
+    assert_screen "desktop-selection";
     my $d   = get_var("DESKTOP");
     my $key = "alt-$desktopkeys{$d}";
     if ($d eq "kde") {
@@ -23,7 +23,7 @@ sub run() {
     }
     elsif ($d eq "gnome") {
         send_key $key;
-        assert_screen "gnome-selected", 3;
+        assert_screen "gnome-selected";
     }
     else {    # lower selection level
         send_key "alt-o";    #TODO translate

--- a/tests/installation/partitioning_lvm.pm
+++ b/tests/installation/partitioning_lvm.pm
@@ -26,11 +26,11 @@ sub run() {
         type_password;
         send_key "tab";
         type_password;
-        send_key "ret",                             1;
-        assert_screen "partition-cryptlvm-summary", 3;
+        send_key "ret", 1;
+        assert_screen "partition-cryptlvm-summary";
     }
     else {
-        assert_screen "partition-lvm-summary", 3;
+        assert_screen "partition-lvm-summary";
     }
     wait_idle 5;
     send_key "alt-o";

--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -17,23 +17,23 @@ use testapi;
 #   $type == 3 => 0xFD Linux RAID
 sub addpart($) {
     my ($size) = @_;
-    assert_screen "expert-partitioner", 10;
+    assert_screen "expert-partitioner";
     send_key $cmd{addpart};
-    assert_screen "partitioning-type", 5;
+    assert_screen "partitioning-type";
     send_key $cmd{"next"};
 
-    assert_screen "partition-size", 5;
+    assert_screen "partition-size";
 
     for (1 .. 10) {
         send_key "backspace";
     }
     type_string $size . "mb";
-    assert_screen "partition-size", 3;
+    assert_screen "partition-size";
     send_key $cmd{"next"};
-    assert_screen 'partition-role', 6;
+    assert_screen 'partition-role';
     send_key "alt-a";    # Raw Volume
     send_key $cmd{"next"};
-    assert_screen 'partition-format', 8;
+    assert_screen 'partition-format';
     send_key $cmd{"donotformat"};
     send_key "tab";
 
@@ -66,7 +66,7 @@ sub addraid($;$) {
         type_string "\t$chunksize";
     }
     send_key $cmd{"next"};
-    assert_screen 'partition-role', 6;
+    assert_screen 'partition-role';
     if ($step == 3 and get_var("LVM")) {
         send_key "alt-a";    # Raw Volume
     }
@@ -97,14 +97,14 @@ sub set_lvm() {
     send_key "down";
     send_key "ret";
 
-    assert_screen 'lvmsetupraid', 6;
+    assert_screen 'lvmsetupraid';
     # add all unformated lvm devices
     send_key "alt-d";
 
     # set volume name
     send_key "alt-v";
     type_string "root";
-    assert_screen 'volumegroup-name-root', 5;
+    assert_screen 'volumegroup-name-root';
 
     send_key $cmd{"finish"}, 1;
 
@@ -116,7 +116,7 @@ sub set_lvm() {
 
     # create normal volume with name root
     type_string "root";
-    assert_screen 'volume-name-root', 5;
+    assert_screen 'volume-name-root';
     send_key $cmd{"next"};
 
     # keep default
@@ -134,33 +134,33 @@ sub run() {
 
     # create partitioning
     send_key $cmd{createpartsetup};
-    assert_screen 'createpartsetup', 3;
+    assert_screen 'createpartsetup';
 
     # user defined
     send_key $cmd{custompart};
     send_key $cmd{"next"}, 1;
-    assert_screen 'custompart', 9;
+    assert_screen 'custompart';
 
     send_key "tab";
     send_key "down";    # select disks
     if (get_var("OFW")) {    ## no RAID /boot partition for ppc
         send_key 'alt-p';
-        assert_screen 'partitioning-type', 5;
+        assert_screen 'partitioning-type';
         send_key 'alt-n';
-        assert_screen 'partitioning-size', 5;
+        assert_screen 'partitioning-size';
         send_key 'ctrl-a';
         type_string "200 MB";
         send_key 'alt-n';
-        assert_screen 'partition-role', 6;
+        assert_screen 'partition-role';
         send_key "alt-a";    # Raw Volume
         send_key 'alt-n';
-        assert_screen 'partition-format', 5;
+        assert_screen 'partition-format';
         send_key 'alt-d';
         send_key 'alt-i';
         send_key_until_needlematch 'filesystem-prep', 'down';
         send_key 'ret';
         send_key 'alt-f';
-        assert_screen 'custompart', 9;
+        assert_screen 'custompart';
         send_key 'alt-s';
         send_key 'right';
         send_key 'down';     #should select first disk'
@@ -176,7 +176,7 @@ sub run() {
         addpart(300);        # boot
         addpart(8000);       # root
         addpart(100);        # swap
-        assert_screen 'raid-partition', 15;
+        assert_screen 'raid-partition';
 
         # select next disk
         send_key "shift-tab";
@@ -243,10 +243,10 @@ sub run() {
     }
 
     if (get_var("LVM")) {
-        assert_screen 'acceptedpartitioningraidlvm', 6;
+        assert_screen 'acceptedpartitioningraidlvm';
     }
     else {
-        assert_screen 'acceptedpartitioning', 6;
+        assert_screen 'acceptedpartitioning';
     }
 }
 

--- a/tests/installation/partitioning_raid_sle11.pm
+++ b/tests/installation/partitioning_raid_sle11.pm
@@ -44,7 +44,7 @@ sub addraid($) {
     }
 
     send_key $cmd{"next"};
-    assert_screen 'partition-role', 6;
+    assert_screen 'partition-role';
     send_key "alt-o";    # Operating System
     send_key $cmd{"next"};
     wait_idle 3;
@@ -60,25 +60,25 @@ sub setraidlevel($) {
 sub run() {
     my ($self) = @_;
 
-    assert_screen 'inst-overview', 10;
+    assert_screen 'inst-overview';
     send_key $cmd{change};
     send_key 'p';    # partitioning
 
-    assert_screen 'preparing-disk', 5;
+    assert_screen 'preparing-disk';
     send_key 'alt-c';
     send_key $cmd{"next"};
-    assert_screen 'expert-partitioning', 5;
+    assert_screen 'expert-partitioning';
     send_key 'down';
     send_key 'down';
     if (get_var("OFW")) {    ## no RAID /boot partition for ppc
         send_key 'alt-p';
-        assert_screen 'add-partition', 5;
+        assert_screen 'add-partition';
         send_key 'alt-n';
-        assert_screen 'add-partition-size', 5;
+        assert_screen 'add-partition-size';
         send_key 'ctrl-a';
         type_string "200 MB";
         send_key 'alt-n';
-        assert_screen 'add-partition-type', 5;
+        assert_screen 'add-partition-type';
         send_key 'alt-d';
         send_key 'alt-i';
         my $prep_counter = 20;
@@ -90,7 +90,7 @@ sub run() {
             die "looping for too long/PReP not found" if (!$ret || $prep_counter-- == 0);
             if (check_screen("filesystem-prep", 1)) {
                 send_key 'ret';
-                assert_screen('expert-partitioning', 5);
+                assert_screen('expert-partitioning');
                 last;
             }
         }
@@ -107,50 +107,50 @@ sub run() {
 
     for (1 .. 4) {
         send_key 'alt-d';
-        assert_screen 'add-partition', 5;
+        assert_screen 'add-partition';
         send_key 'alt-n';
-        assert_screen 'add-partition-size', 5;
+        assert_screen 'add-partition-size';
         send_key 'ctrl-a';
         type_string "1 GB";
         send_key 'alt-n';
-        assert_screen 'add-partition-type', 5;
+        assert_screen 'add-partition-type';
         send_key 'alt-d';    #Do not format partition
         send_key 'alt-i';    #Filesystem ID
         send_key 'down';
         send_key 'down';
         send_key 'down';     #Linux RAID System Type
         send_key 'alt-f';
-        assert_screen('expert-partitioning', 5);
+        assert_screen('expert-partitioning');
 
         send_key 'alt-d';
-        assert_screen 'add-partition', 5;
+        assert_screen 'add-partition';
         send_key 'alt-n';
-        assert_screen 'add-partition-size', 5;
+        assert_screen 'add-partition-size';
         send_key 'ctrl-a';
         type_string "300 MB";
         send_key 'alt-n';
-        assert_screen 'add-partition-type', 5;
+        assert_screen 'add-partition-type';
         send_key 'alt-d';    #Do not format partition
         send_key 'alt-i';    #Filesystem ID
         send_key 'down';
         send_key 'down';
         send_key 'down';     #Linux RAID System Type
         send_key 'alt-f';
-        assert_screen('expert-partitioning', 5);
+        assert_screen('expert-partitioning');
 
         send_key 'alt-d';
-        assert_screen 'add-partition', 5;
+        assert_screen 'add-partition';
         send_key 'alt-n';
-        assert_screen 'add-partition-size', 5;
+        assert_screen 'add-partition-size';
         send_key 'alt-n';
-        assert_screen 'add-partition-type', 5;
+        assert_screen 'add-partition-type';
         send_key 'alt-d';    #Do not format partition
         send_key 'alt-i';    #Filesystem ID
         send_key 'down';
         send_key 'down';
         send_key 'down';     #Linux RAID System Type
         send_key 'alt-f';
-        assert_screen('expert-partitioning', 5);
+        assert_screen('expert-partitioning');
 
         # select next disk
         send_key "shift-tab";
@@ -161,7 +161,7 @@ sub run() {
 
     # select RAID add for /
     send_key 'alt-i';
-    assert_screen('add-raid', 5);
+    assert_screen('add-raid');
     setraidlevel(get_var("RAIDLEVEL"));
     send_key_until_needlematch 'raid-devices-selected', 'tab';
     send_key "down";
@@ -179,7 +179,7 @@ sub run() {
     wait_idle 3;
 
     send_key $cmd{"next"};
-    assert_screen 'add-partition-type', 6;
+    assert_screen 'add-partition-type';
     if (get_var("FILESYSTEM")) {
         send_key 'alt-s';    #goto filesystem list
         send_key ' ';        #open filesystem list
@@ -210,7 +210,7 @@ sub run() {
 
     # select RAID add for /boot
     send_key 'alt-i';
-    assert_screen('add-raid', 5);
+    assert_screen('add-raid');
     setraidlevel(1);    # RAID 1 for /boot
     send_key_until_needlematch 'raid-devices-selected', 'tab';
     send_key "down";    # start at the 300MB partition
@@ -227,7 +227,7 @@ sub run() {
     wait_idle 3;
 
     send_key $cmd{"next"};
-    assert_screen 'add-partition-type', 6;
+    assert_screen 'add-partition-type';
     send_key 'alt-m';    #goto mount point
     type_string "/boot";
     send_key 'alt-f';
@@ -235,7 +235,7 @@ sub run() {
 
     # select RAID add for swap
     send_key 'alt-i';
-    assert_screen('add-raid', 5);
+    assert_screen('add-raid');
     setraidlevel(0);     # RAID 0 for swap
     send_key_until_needlematch 'raid-devices-selected', 'tab';
     send_key "spc";      # only 4 partitions left
@@ -250,7 +250,7 @@ sub run() {
     wait_idle 3;
 
     send_key $cmd{"next"};
-    assert_screen 'add-partition-type', 6;
+    assert_screen 'add-partition-type';
     send_key 'alt-s';    #goto filesystem list
     send_key ' ';        #open filesystem list
     send_key 'home';     #go to top of the list
@@ -266,7 +266,7 @@ sub run() {
         if (check_screen("filesystem-swap", 1)) {
             send_key 'ret';
             send_key 'alt-f';
-            assert_screen('expert-partitioning', 5);
+            assert_screen('expert-partitioning');
             last;
         }
     }
@@ -277,19 +277,19 @@ sub run() {
     if (check_screen 'subvolumes-shadowed', 5) {
         send_key 'alt-y';
     }
-    assert_screen 'acceptedpartitioning', 6;
+    assert_screen 'acceptedpartitioning';
 
     if (!get_var("OFW")) {
         #Bootloader needs to be installed to MBR
         send_key 'alt-c';
         send_key 'b';
-        assert_screen 'bootloader-settings', 6;
+        assert_screen 'bootloader-settings';
         send_key 'alt-l';
-        assert_screen 'bootloader-installation-settings', 6;
+        assert_screen 'bootloader-installation-settings';
         send_key 'alt-m';
         send_key 'alt-o';
     }
-    assert_screen "inst-overview", 15;
+    assert_screen "inst-overview";
 }
 
 

--- a/tests/installation/partitioning_sle11.pm
+++ b/tests/installation/partitioning_sle11.pm
@@ -15,16 +15,16 @@ use testapi;
 sub run() {
     my $self = shift;
 
-    assert_screen 'inst-overview', 10;
+    assert_screen 'inst-overview';
     send_key $cmd{change};
     send_key 'p';    # partitioning
 
     if (get_var('LVM')) {
-        assert_screen 'preparing-disk', 5;
+        assert_screen 'preparing-disk';
         send_key 'alt-1';
         send_key $cmd{"next"};
-        assert_screen 'preparing-disk-installing', 5;
-        send_key 'alt-l',                          1;    #to use lvm
+        assert_screen 'preparing-disk-installing';
+        send_key 'alt-l', 1;    #to use lvm
         if (get_var('ENCRYPT')) {
             send_key "alt-y", 1;
             assert_screen "inst-encrypt-password-prompt";
@@ -34,27 +34,27 @@ sub run() {
             send_key "ret", 1;
         }
         send_key $cmd{"next"};
-        assert_screen 'inst-overview', 30;
+        assert_screen 'inst-overview';
     }
 
     if (check_var("FILESYSTEM", "btrfs") || get_var("BOO910346")) {
-        assert_screen 'preparing-disk', 5;
+        assert_screen 'preparing-disk';
         send_key 'alt-1';
         send_key $cmd{"next"};
-        assert_screen 'preparing-disk-installing', 5;
+        assert_screen 'preparing-disk-installing';
         send_key 'alt-u';    #to use btrfs
         send_key $cmd{"next"};
-        assert_screen 'inst-overview', 30;
+        assert_screen 'inst-overview';
     }
 
     if (!check_var("FILESYSTEM", "btrfs") && get_var("BOO910346")) {
 
         send_key $cmd{change};
         send_key 'p';        # partitioning
-        assert_screen 'preparing-disk', 5;
+        assert_screen 'preparing-disk';
         send_key 'alt-c';
         send_key $cmd{"next"};
-        assert_screen 'expert-partitioning', 5;
+        assert_screen 'expert-partitioning';
         send_key 'down';
         send_key 'down';
         send_key 'right';
@@ -63,9 +63,9 @@ sub run() {
         send_key 'down';     #should be boot
         send_key 'down';     #should be swap
         send_key 'down';     #should be root partition
-        assert_screen 'on-root-partition', 5;
+        assert_screen 'on-root-partition';
         send_key 'alt-e';    #got to actually edit
-        assert_screen 'editing-root-partition', 5;
+        assert_screen 'editing-root-partition';
         send_key 'alt-s';    #goto filesystem list
         send_key ' ';        #open filesystem list
         send_key 'home';     #go to top of the list
@@ -84,7 +84,7 @@ sub run() {
                 send_key 'ret';
                 send_key 'alt-f';
                 send_key 'alt-a';
-                assert_screen('inst-overview', 30);
+                assert_screen('inst-overview');
                 last;
             }
         }
@@ -92,23 +92,23 @@ sub run() {
 
     if (!check_var("FILESYSTEM", "btrfs") && !get_var("BOO910346") && !get_var('LVM')) {
 
-        assert_screen 'preparing-disk', 5;
+        assert_screen 'preparing-disk';
         send_key 'alt-c';
         send_key $cmd{"next"};
-        assert_screen 'expert-partitioning', 5;
+        assert_screen 'expert-partitioning';
         send_key 'down';
         send_key 'down';
         send_key 'right';
         send_key 'down';    #should select first disk'
         if (get_var("OFW")) {
             send_key 'alt-d';
-            assert_screen 'add-partition', 5;
+            assert_screen 'add-partition';
             send_key 'alt-n';
-            assert_screen 'add-partition-size', 5;
+            assert_screen 'add-partition-size';
             send_key 'ctrl-a';
             type_string "200 MB";
             send_key 'alt-n';
-            assert_screen 'add-partition-type', 5;
+            assert_screen 'add-partition-type';
             send_key 'alt-d';    # goto nonfs types
             send_key 'alt-i';
             my $prep_counter = 20;
@@ -119,19 +119,19 @@ sub run() {
                 die "looping for too long/PReP not found" if (!$ret || $prep_counter-- == 0);
                 if (check_screen("filesystem-prep", 1)) {
                     send_key 'ret';
-                    assert_screen('expert-partitioning', 5);
+                    assert_screen('expert-partitioning');
                     last;
                 }
             }
         }
         send_key 'alt-d';
-        assert_screen 'add-partition', 5;
+        assert_screen 'add-partition';
         send_key 'alt-n';
-        assert_screen 'add-partition-size', 5;
+        assert_screen 'add-partition-size';
         send_key 'ctrl-a';
         type_string "1 GB";
         send_key 'alt-n';
-        assert_screen 'add-partition-type', 5;
+        assert_screen 'add-partition-type';
         send_key 'alt-s';    #goto filesystem list
         send_key ' ';        #open filesystem list
         send_key 'home';     #go to top of the list
@@ -146,30 +146,30 @@ sub run() {
             if (check_screen("filesystem-swap", 1)) {
                 send_key 'ret';
                 send_key 'alt-f';
-                assert_screen('expert-partitioning', 5);
+                assert_screen('expert-partitioning');
                 last;
             }
         }
 
         send_key 'alt-d';
-        assert_screen 'add-partition', 5;
+        assert_screen 'add-partition';
         send_key 'alt-n';
-        assert_screen 'add-partition-size', 5;
+        assert_screen 'add-partition-size';
         send_key 'ctrl-a';
         type_string "300 MB";
         send_key 'alt-n';
-        assert_screen 'add-partition-type', 5;
+        assert_screen 'add-partition-type';
         send_key 'alt-m';    #goto mount point
         type_string "/boot";
         send_key 'alt-f';
-        assert_screen('expert-partitioning', 5);
+        assert_screen('expert-partitioning');
 
         send_key 'alt-d';
-        assert_screen 'add-partition', 5;
+        assert_screen 'add-partition';
         send_key 'alt-n';
-        assert_screen 'add-partition-size', 5;
+        assert_screen 'add-partition-size';
         send_key 'alt-n';
-        assert_screen 'add-partition-type', 5;
+        assert_screen 'add-partition-type';
         send_key 'alt-s';    #goto filesystem list
         send_key ' ';        #open filesystem list
         send_key 'home';     #go to top of the list
@@ -187,13 +187,13 @@ sub run() {
             if (check_screen("filesystem-$fs", 1)) {
                 send_key 'ret';
                 send_key 'alt-f';
-                assert_screen('expert-partitioning', 5);
+                assert_screen('expert-partitioning');
                 last;
             }
         }
 
         send_key 'alt-a';
-        assert_screen('inst-overview', 30);
+        assert_screen('inst-overview');
     }
 }
 

--- a/tests/installation/partitioning_sle11_desktop_sdk.pm
+++ b/tests/installation/partitioning_sle11_desktop_sdk.pm
@@ -15,26 +15,26 @@ use testapi;
 sub run() {
     my $self = shift;
 
-    assert_screen 'inst-overview', 10;
+    assert_screen 'inst-overview';
     send_key $cmd{change};
     send_key 'p';    # partitioning
 
-    assert_screen 'preparing-disk', 5;
+    assert_screen 'preparing-disk';
     send_key 'alt-c';
     send_key $cmd{"next"};
-    assert_screen 'expert-partitioning', 5;
+    assert_screen 'expert-partitioning';
     send_key 'down';
     send_key 'down';
     send_key 'right';
     send_key 'down';    #should select first disk'
     send_key 'alt-d';
-    assert_screen 'add-partition', 5;
+    assert_screen 'add-partition';
     send_key 'alt-n';
-    assert_screen 'add-partition-size', 5;
+    assert_screen 'add-partition-size';
     send_key 'ctrl-a';
     type_string "1 GB";
     send_key 'alt-n';
-    assert_screen 'add-partition-type', 5;
+    assert_screen 'add-partition-type';
     send_key 'alt-s';    #goto filesystem list
     send_key ' ';        #open filesystem list
     send_key 'home';     #go to top of the list
@@ -49,23 +49,23 @@ sub run() {
         if (check_screen("filesystem-swap", 1)) {
             send_key 'ret';
             send_key 'alt-f';
-            assert_screen('expert-partitioning', 5);
+            assert_screen('expert-partitioning');
             last;
         }
     }
 
     send_key 'alt-d';
-    assert_screen 'add-partition', 5;
+    assert_screen 'add-partition';
     send_key 'alt-n';
-    assert_screen 'add-partition-size', 5;
+    assert_screen 'add-partition-size';
     send_key 'ctrl-m';
     send_key 'alt-n';
-    assert_screen 'add-partition-type', 5;
+    assert_screen 'add-partition-type';
     send_key 'alt-f';
-    assert_screen('expert-partitioning', 5);
+    assert_screen('expert-partitioning');
 
     send_key 'alt-a';
-    assert_screen('inst-overview', 30);
+    assert_screen('inst-overview');
 
 }
 

--- a/tests/installation/partitioning_splitusr.pm
+++ b/tests/installation/partitioning_splitusr.pm
@@ -40,15 +40,15 @@ sub run() {
     }
     type_string "5.0G";
     send_key $cmd{"next"};
-    assert_screen 'partition-role', 6;
+    assert_screen 'partition-role';
     send_key "alt-o";    # Operating System
     send_key $cmd{"next"};
     wait_idle 5;
     send_key "alt-m";        # Mount Point
     type_string "/usr\b";    # Backspace to break bad completion to /usr/local
-    assert_screen "partition-splitusr-submitted-usr", 3;
+    assert_screen "partition-splitusr-submitted-usr";
     send_key $cmd{"finish"};
-    assert_screen "partition-splitusr-finished", 3;
+    assert_screen "partition-splitusr-finished";
     send_key $cmd{"accept"}, 1;
     send_key "alt-y";        # Quit the warning window
 }

--- a/tests/installation/partitioning_togglehome.pm
+++ b/tests/installation/partitioning_togglehome.pm
@@ -17,7 +17,7 @@ sub run() {
     send_key 'alt-d';
     $closedialog = 1;
     $homekey     = 'alt-p';
-    assert_screen "partition-proposals-window", 5;
+    assert_screen "partition-proposals-window";
     send_key $homekey;
     for (1 .. 3) {
         if (!check_screen "disabledhome", 8) {
@@ -27,7 +27,7 @@ sub run() {
             last;
         }
     }
-    assert_screen "disabledhome", 5;
+    assert_screen "disabledhome";
     if ($closedialog) {
         send_key 'alt-o';
         $closedialog = 0;

--- a/tests/installation/post_zdup.pm
+++ b/tests/installation/post_zdup.pm
@@ -33,7 +33,7 @@ sub run() {
     # TODO: why not just script_run 'root' ?
     # switch to tty3 (in case we are in X)
     send_key "ctrl-alt-f3";
-    assert_screen "text-login", 5;
+    assert_screen "text-login";
     # Reboot after dup
     send_key "ctrl-alt-delete";
 

--- a/tests/installation/rescuesystem.pm
+++ b/tests/installation/rescuesystem.pm
@@ -25,13 +25,13 @@ sub run {
     }
 
     # Login as root (no password)
-    assert_screen "rescuesystem-login", 20;
+    assert_screen "rescuesystem-login";
     type_string "root\n";
 
     # Clean the screen
     sleep 1;
     type_string "reset\n";
-    assert_screen "rescuesystem-prompt", 4;
+    assert_screen "rescuesystem-prompt";
 }
 
 sub test_flags() {

--- a/tests/installation/rescuesystem_yaboot.pm
+++ b/tests/installation/rescuesystem_yaboot.pm
@@ -34,7 +34,7 @@ sub run {
     # Clean the screen
     sleep 1;
     type_string "reset\n";
-    assert_screen "rescuesystem-prompt", 4;
+    assert_screen "rescuesystem-prompt";
 }
 
 sub test_flags() {

--- a/tests/installation/secure_boot.pm
+++ b/tests/installation/secure_boot.pm
@@ -25,7 +25,7 @@ sub run() {
     sleep 4;
 
     # Is secure boot enabled?
-    assert_screen "bootloader-secureboot-enabled", 5;
+    assert_screen "bootloader-secureboot-enabled";
     send_key $cmd{accept};        # Accept
     sleep 2;
     send_key "alt-o";             # cOntinue

--- a/tests/installation/select_patterns.pm
+++ b/tests/installation/select_patterns.pm
@@ -34,7 +34,7 @@ sub run {
 
     if (check_var('VIDEOMODE', 'text')) {
         send_key 'alt-c';
-        assert_screen 'inst-overview-options', 3;
+        assert_screen 'inst-overview-options';
         send_key 'alt-s';
     }
     else {
@@ -60,12 +60,12 @@ sub run {
         send_key 'alt-f';
         for (1 .. 4) { send_key 'up'; }
         send_key 'ret';
-        assert_screen 'patterns-list-selected', 5;
+        assert_screen 'patterns-list-selected';
     }
     else {
         send_key 'tab';
-        send_key ' ',                           2;
-        assert_screen 'patterns-list-selected', 5;
+        send_key ' ', 2;
+        assert_screen 'patterns-list-selected';
     }
 
     my %wanted_patterns;
@@ -97,11 +97,11 @@ sub run {
             wait_screen_change {
                 send_key ' ';
             };
-            assert_screen 'current-pattern-selected', 2;
+            assert_screen 'current-pattern-selected', 5;
         }
         elsif (!$needs_to_be_selected && $selected) {
             send_key ' ';
-            assert_screen [qw(current-pattern-unselected current-pattern-autoselected)], 3;
+            assert_screen [qw(current-pattern-unselected current-pattern-autoselected)], 8;
         }
         movedownelseend;
     }
@@ -109,14 +109,14 @@ sub run {
     if (check_var('VIDEOMODE', 'text')) {
         send_key 'alt-a';    # accept
         accept3rdparty;
-        assert_screen 'automatic-changes', 4;
+        assert_screen 'automatic-changes';
         send_key 'alt-o';    # OK
     }
     else {
         send_key 'alt-o';
         accept3rdparty;
     }
-    assert_screen 'inst-overview', 15;
+    assert_screen 'inst-overview';
 }
 
 1;

--- a/tests/installation/select_patterns_sle11.pm
+++ b/tests/installation/select_patterns_sle11.pm
@@ -26,7 +26,7 @@ sub run {
 
     if (check_var('VIDEOMODE', 'text')) {
         send_key 'alt-c';
-        assert_screen 'inst-overview-options', 3;
+        assert_screen 'inst-overview-options';
         send_key 'alt-s';
     }
     else {
@@ -52,7 +52,7 @@ sub run {
         send_key 'alt-f';
         for (1 .. 4) { send_key 'up'; }
         send_key 'ret';
-        assert_screen 'patterns-list-selected', 5;
+        assert_screen 'patterns-list-selected';
         send_key 'tab';
     }
     else {
@@ -96,25 +96,25 @@ sub run {
             wait_screen_change {
                 send_key ' ';
             };
-            assert_screen 'current-pattern-selected', 2;
+            assert_screen 'current-pattern-selected', 5;
         }
         elsif (!$needs_to_be_selected && $selected) {
             send_key ' ';
-            assert_screen [qw(current-pattern-unselected current-pattern-autoselected)], 3;
+            assert_screen [qw(current-pattern-unselected current-pattern-autoselected)], 8;
         }
     }
 
     if (check_var('VIDEOMODE', 'text')) {
         send_key 'alt-a';    # accept
         accept3rdparty;
-        assert_screen 'automatic-changes', 4;
+        assert_screen 'automatic-changes';
         send_key 'alt-o';    # OK
     }
     else {
         send_key 'alt-o';
         accept3rdparty;
     }
-    assert_screen 'inst-overview', 15;
+    assert_screen 'inst-overview';
 }
 
 

--- a/tests/installation/sle11_network.pm
+++ b/tests/installation/sle11_network.pm
@@ -29,7 +29,7 @@ sub run() {
         for (1 .. 10) { send_key 'backspace'; }
         type_string "zq1.de";
 
-        assert_screen 'hostname-typed', 4;
+        assert_screen 'hostname-typed';
         send_key $cmd{next};
 
         # network conf

--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -31,7 +31,7 @@ sub run() {
                 }
 
                 assert_and_click 'packages-section-selected';
-                assert_screen "package-conflict", 20;
+                assert_screen "package-conflict";
 
                 while (!check_screen('all-conflicts-resolved-packages', 4)) {
                     assert_and_click 'package-conflict-choice';
@@ -42,7 +42,7 @@ sub run() {
                 while (check_screen('license-popup', 2)) {
                     send_key $cmd{"accept"}, 1;
                 }
-                assert_screen "automatic-changes", 5;
+                assert_screen "automatic-changes";
                 send_key $cmd{"continue"}, 1;
 
                 send_key $cmd{update};
@@ -95,7 +95,7 @@ sub run() {
                 last if $ret->{needle}->has_tag("installation-details-view");
 
                 # intention to let this test fail
-                assert_screen 'installation-details-view', 1
+                assert_screen 'installation-details-view'
                   if $ret->{needle}->has_tag("grub2");
             }
             send_key $cmd{instdetails};

--- a/tests/installation/upgrade_select_sle11.pm
+++ b/tests/installation/upgrade_select_sle11.pm
@@ -27,7 +27,7 @@ sub run() {
     # hardware detection can take a while
     assert_screen "select-for-update", 100;
     send_key $cmd{"next"}, 1;
-    assert_screen 'previously-used-repositories', 5;
+    assert_screen 'previously-used-repositories';
     if (!check_var('ADDONS', 'smt')) {
         send_key $cmd{"next"}, 1;
     }
@@ -53,17 +53,17 @@ sub run() {
             else {
                 send_key 'alt-d';                                              # DVD
                 send_key $cmd{"xnext"}, 1;
-                assert_screen 'dvd-selector',                3;
-                send_key_until_needlematch 'addon-dvd-list', 'tab', 10;
+                assert_screen 'dvd-selector';
+                send_key_until_needlematch 'addon-dvd-list', 'tab',  10;
                 send_key_until_needlematch "addon-dvd-$a",   'down', 10;
                 send_key 'alt-o';
                 if (get_var("BETA")) {
-                    assert_screen "addon-betawarning-$a", 10;
+                    assert_screen "addon-betawarning-$a";
                     send_key "ret";
-                    assert_screen "addon-license-beta", 10;
+                    assert_screen "addon-license-beta";
                 }
                 else {
-                    assert_screen "addon-license-$a", 10;
+                    assert_screen "addon-license-$a";
                 }
                 sleep 2;
                 send_key 'alt-y';    # yes, agree
@@ -77,7 +77,7 @@ sub run() {
             }
         }
         if (!check_var('ADDONS', 'smt')) {    # no add-on list for SMT
-            assert_screen 'addon-list', 5;
+            assert_screen 'addon-list';
             send_key $cmd{"next"}, 1;
         }
     }
@@ -85,7 +85,7 @@ sub run() {
         send_key $cmd{"next"}, 1;
     }
 
-    assert_screen "update-installation-overview", 15;
+    assert_screen "update-installation-overview";
 }
 
 1;

--- a/tests/installation/user_settings.pm
+++ b/tests/installation/user_settings.pm
@@ -17,7 +17,7 @@ sub run() {
     my $self = shift;
 
     # user setup
-    assert_screen "inst-usersetup", 10;
+    assert_screen "inst-usersetup";
     type_string $realname;
     send_key "tab";
 
@@ -26,14 +26,14 @@ sub run() {
     for (1 .. 2) {
         type_string "$password\t";
     }
-    assert_screen "inst-userinfostyped", 10;
+    assert_screen "inst-userinfostyped";
     if (get_var("NOAUTOLOGIN") && !check_screen('autologindisabled')) {
         send_key $cmd{"noautologin"};
-        assert_screen "autologindisabled", 5;
+        assert_screen "autologindisabled";
     }
     if (get_var("DOCRUN")) {
         send_key $cmd{"otherrootpw"};
-        assert_screen "rootpwdisabled", 5;
+        assert_screen "rootpwdisabled";
     }
 
     # done user setup

--- a/tests/installation/user_settings_root.pm
+++ b/tests/installation/user_settings_root.pm
@@ -16,12 +16,12 @@ use testapi;
 sub run() {
     my $self = shift;
 
-    assert_screen "inst-rootpassword", 6;
+    assert_screen "inst-rootpassword";
     for (1 .. 2) {
         type_string "$password\t";
         sleep 1;
     }
-    assert_screen "rootpassword-typed", 3;
+    assert_screen "rootpassword-typed";
     send_key $cmd{"next"};
 
     # PW too easy (cracklib)

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -32,7 +32,7 @@ sub run() {
     if (get_var("HASLICENSE")) {
         send_key $cmd{"accept"};    # accept license
     }
-    assert_screen "languagepicked", 2;
+    assert_screen "languagepicked";
     send_key $cmd{"next"};
     if (!check_var('INSTLANG', 'en_US') && check_screen "langincomplete", 1) {
         send_key "alt-f";

--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -171,7 +171,7 @@ sub run() {
         $out = wait_serial([$zypper_dup_finish, $zypper_installing, $zypper_dup_notifications, $zypper_dup_error], 240);
     }
 
-    assert_screen "zypper-dup-finish", 2;
+    assert_screen "zypper-dup-finish";
 }
 
 sub test_flags() {


### PR DESCRIPTION
This pull request is to remove/change the explicit timeout for many yast/installation assert_screens

I reviewed each of these manually before deciding how to handle it, as a general rule of thumb I applied the following principles

Any assert_screen which is effectively being used as a "Checkpoint" of the installation workflow (ie "the product must show this screen, or else fail") has had it's timeout removed - If the screen doesn't show immediately, I feel there is no harm in giving YaST and/or the system under test a little time to get there, and timeouts <5 seconds have a habit of being flakey

Any assert_screen which is embedded in a reused sub or a loop was given extra attention to make sure the impact on the test performance was not going to be dramatic. In the case of the partitioning tests, I decided the explicit timeouts needed to be removed for the same reasons as the rest - each assert_screen is basically a checkpoint and we cannot be sure that YaST will always get there within 5 seconds.
In the case of pattern/software selection the timeouts have been increased slightly, but still kept 'strict' as the assert_screens are used somewhat more creatively and I didn't want to dramatically slow down that test.

My focus has been on tests which included assert_screens with a timeout <5 (which have an unsurprising correlation with many of our most 'flakey' tests), but when I reviewed those files I checked every assert_screen to apply these same principles to it.

Assuming this PR goes well, I expect we might want to do the same in more test modules.