### PR TITLE
Prevent check console font not failing under slow echo

### DIFF
--- a/tests/console/check_console_font.pm
+++ b/tests/console/check_console_font.pm
@@ -23,7 +23,8 @@ use testapi;
 
 sub run() {
 
-    type_string "echo Jeder wackere Bayer vertilgt bequem zwo Pfund Kalbshaxen. 0123456789\n";
+    # Ensure the echo of input actually happened by using assert_script_run
+    assert_script_run "echo Jeder wackere Bayer vertilgt bequem zwo Pfund Kalbshaxen. 0123456789";
     if (check_screen "broken-console-font", 5) {
         assert_script_sudo("/usr/lib/systemd/systemd-vconsole-setup");
     }


### PR DESCRIPTION
Fixes potentially broken fonts in situation where the echo to the screen did
not complete unless the timeout of the follow up 'check_screen' hits.

Elaborated and cross-checked with rbrown.

Situation where this can help although the font is actually correct in this situation:
![broken](https://cloud.githubusercontent.com/assets/1693432/12456704/5112a054-bfa1-11e5-96df-d7e473a3ae41.png)

Verified in local test:
![fixed](https://cloud.githubusercontent.com/assets/1693432/12456728/6869df74-bfa1-11e5-9ea7-b3ba811c3743.png)
