### PR TITLE
Slow down string typing in the UEFI shell

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -94,12 +94,12 @@ sub run() {
     # }
 
     if (check_var('VIDEOMODE', "text")) {
-        type_string "textmode=1 ";
+        type_string "textmode=1 ", 15;
     }
 
     type_string " \\\n";    # changed the line before typing video params
                             # https://wiki.archlinux.org/index.php/Kernel_Mode_Setting#Forcing_modes_and_EDID
-    type_string "Y2DEBUG=1 ";
+    type_string "Y2DEBUG=1 ", 15;
     if (check_var('ARCH', 'i586') || check_var('ARCH', 'x86_64')) {
         type_string "vga=791 ";
         type_string "video=1024x768-16 ", 13;


### PR DESCRIPTION
On aarch64, we're injecting keys via the USB keyboard emulation, which
is rather slow and has a short queue of 16 bytes only (which is ~ 4
keystrokes I think).