### PR TITLE
Use common value for all bootloader related typing slowdowns

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -82,9 +82,14 @@ sub run() {
     sleep 5;
     for (1 .. 4) { send_key "down"; }
     send_key "end";
+
+    # USB kbd in raw mode is rather slow and QEMU only buffers 16 bytes, so
+    # we need to type very slowly to not lose keypresses.
+    my $slow_typing_speed = 13;
+
     if (get_var("NETBOOT") && get_var("SUSEMIRROR")) {
         assert_screen('no_install_url');
-        type_string " install=http://" . get_var("SUSEMIRROR"), 15;
+        type_string " install=http://" . get_var("SUSEMIRROR"), $slow_typing_speed;
         save_screenshot();
     }
     send_key "spc";
@@ -94,28 +99,28 @@ sub run() {
     # }
 
     if (check_var('VIDEOMODE', "text")) {
-        type_string "textmode=1 ", 15;
+        type_string "textmode=1 ", $slow_typing_speed;
     }
 
     type_string " \\\n";    # changed the line before typing video params
                             # https://wiki.archlinux.org/index.php/Kernel_Mode_Setting#Forcing_modes_and_EDID
-    type_string "Y2DEBUG=1 ", 15;
+    type_string "Y2DEBUG=1 ", $slow_typing_speed;
     if (check_var('ARCH', 'i586') || check_var('ARCH', 'x86_64')) {
         type_string "vga=791 ";
-        type_string "video=1024x768-16 ", 13;
+        type_string "video=1024x768-16 ", $slow_typing_speed;
 
         # not needed anymore atm as cirrus has 1024 as default now:
         # https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=121a6a17439b000b9699c3fa876636db20fa4107
         #type_string "drm_kms_helper.edid_firmware=edid/1024x768.bin ";
-        assert_screen "inst-video-typed-grub2", 13;
+        assert_screen "inst-video-typed-grub2", $slow_typing_speed;
     }
 
     if (!get_var("NICEVIDEO") && !get_var('JEOS')) {
-        type_string "plymouth.ignore-serial-consoles ", 15;    # make plymouth go graphical
-        type_string "linuxrc.log=$serialdev ",          4;     #to get linuxrc logs in serial
-        type_string " \\\n";                                   # changed the line before typing video params
-        type_string "console=$serialdev ",         15;         # to get crash dumps as text
-        type_string "console=tty ",                15;         # to get crash dumps as text
+        type_string "plymouth.ignore-serial-consoles ", $slow_typing_speed;    # make plymouth go graphical
+        type_string "linuxrc.log=$serialdev ",          $slow_typing_speed;    # to get linuxrc logs in serial
+        type_string " \\\n";                                                   # changed the line before typing video params
+        type_string "console=$serialdev ",         $slow_typing_speed;         # to get crash dumps as text
+        type_string "console=tty ",                $slow_typing_speed;         # to get crash dumps as text
         assert_screen "inst-consolesettingstyped", 10;
         my $e = get_var("EXTRABOOTPARAMS");
         if ($e) {
@@ -124,18 +129,18 @@ sub run() {
         }
     }
 
-    #type_string "kiwidebug=1 ";
+    #type_string "kiwidebug=1 ", $slow_typing_speed;
 
     my $args = "";
     if (get_var("AUTOYAST")) {
         $args .= " ifcfg=*=dhcp ";
         $args .= "autoyast=" . autoinst_url . "/data/" . get_var("AUTOYAST") . " ";
     }
-    type_string $args, 13;
+    type_string $args, $slow_typing_speed;
     save_screenshot;
 
     if (get_var("FIPS")) {
-        type_string " fips=1", 13;
+        type_string " fips=1", $slow_typing_speed;
         save_screenshot;
     }
 


### PR DESCRIPTION
Also adds a comment explaining the rationale.