### PR TITLE
Send 'up' key in order to prevent grub2 timeout before boot_snapshot entry found

### DIFF
--- a/tests/installation/livecdreboot.pm
+++ b/tests/installation/livecdreboot.pm
@@ -71,6 +71,7 @@ sub run() {
     # yet long enough to make sense to even have the test.
     my $ret = check_screen "grub2", 30;
     if (defined($ret)) {
+        send_key 'up';    # prevent grub2 timeout
         if (get_var("BOOT_TO_SNAPSHOT")) {
             send_key_until_needlematch("boot-menu-snapshot", 'down', 10, 5);
             send_key 'ret';


### PR DESCRIPTION
https://openqa.opensuse.org/tests/115224/modules/livecdreboot/steps/7