### PR TITLE
Separate systemsettings test for KDE4-based and KF5-based

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -168,7 +168,8 @@ if (check_var('DESKTOP', 'minimalx')) {
 }
 
 # now Plasma 5 is default KDE desktop
-if (check_var('DESKTOP', 'kde')) {
+# openSUSE version less than or equal to 13.2 have to set KDE4 variable as 1
+if (check_var('DESKTOP', 'kde') && !get_var('KDE4')) {
     set_var("PLASMA5", 1);
 }
 
@@ -619,7 +620,12 @@ sub load_x11tests() {
     }
     if (kdestep_is_applicable) {
         loadtest "x11/khelpcenter.pm";
-        loadtest "x11/systemsettings.pm";
+        if (get_var("PLASMA5")) {
+            loadtest "x11/systemsettings5.pm";
+        }
+        else {
+            loadtest "x11/systemsettings.pm";
+        }
         loadtest "x11/dolphin.pm";
     }
     if (snapper_is_applicable) {

--- a/tests/x11/systemsettings5.pm
+++ b/tests/x11/systemsettings5.pm
@@ -1,0 +1,22 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "x11test";
+use testapi;
+
+sub run() {
+    my $self = shift;
+    x11_start_program("systemsettings5", 6, {valid => 1});
+    assert_screen 'test-systemsettings-1';
+    send_key "alt-f4";
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
In update test, there might have old KDE4 systemsettings as another candidate in krunner via auto-completion, therefore, separate systemsettings test to systemsettings(KDE4-based) and systemsettings5(KF5-based) test.
    
openSUSE version less than or equal to 13.2 have to set KDE4 variable as 1, thus PLASMA5 variable won't be sets.