### PR TITLE
Make ssh X-forward password typing robust

### DIFF
--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -16,19 +16,24 @@ sub run() {
     mouse_hide(1);
     x11_start_program("xterm");
     script_run("ssh -XC root\@localhost xterm");
-    type_string "yes\n";
-    wait_idle 6;
+    assert_screen([qw/ssh-xterm-host-key-authentication ssh-password-prompt/]);
+    # if ssh asks for authentication of the key accept it
+    if (match_has_tag('ssh-xterm-host-key-authentication')) {
+        type_string "yes\n";
+        assert_screen "ssh-password-prompt";
+    }
     type_string "$password\n";
-    sleep 2;
+    assert_screen "ssh-second-xterm";
     for (1 .. 13) { send_key "ret" }
     $self->set_standard_prompt();
     type_string "echo If you can see this text, ssh-X-forwarding  is working.\n";
-    sleep 2;
-    assert_screen 'test-sshxterm-1', 3;
+    assert_screen 'test-sshxterm-1';
+    # close both windows
+    # make sure the previous window closed
+    wait_screen_change {
+        send_key "alt-f4";
+    }
     send_key "alt-f4";
-    sleep 1;
-    send_key "alt-f4";
-    sleep 2;
 }
 
 1;


### PR DESCRIPTION
- Add additional needle checks to accept the host key if it was not already
   accepted in before
 - Make sure the password prompt is shown before starting to type

 - Make sure the second xterm window is shown not to yield a false negative
matching on the test pattern blindly typed into the first window when no actual
ssh connection could be established

Fixes https://progress.opensuse.org/issues/5346

screenshot of host key authentication needle matching:
![openqa_sshxterm_hostkey_authentication_prompt](https://cloud.githubusercontent.com/assets/1693432/12551761/0425b0b8-c36d-11e5-991c-98b4b69e2085.png)

screenshot of password prompt needle matching:
![openqa_sshxterm_password_prompt](https://cloud.githubusercontent.com/assets/1693432/12551763/04427658-c36d-11e5-8747-359e430856ce.png)

local verification of sshxterm:
![openqa_sshxterm_verification](https://cloud.githubusercontent.com/assets/1693432/12551764/0445671e-c36d-11e5-94c5-88ea263adc58.png)