### PR TITLE
Fix some script_run usage

### DIFF
--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -15,7 +15,7 @@ sub run() {
     my $self = shift;
     mouse_hide(1);
     x11_start_program("xterm");
-    script_run("ssh -XC root\@localhost xterm");
+    type_string("ssh -XC root\@localhost xterm\n");
     assert_screen([qw/ssh-xterm-host-key-authentication ssh-password-prompt/]);
     # if ssh asks for authentication of the key accept it
     if (match_has_tag('ssh-xterm-host-key-authentication')) {

--- a/tests/x11/yast2_snapper.pm
+++ b/tests/x11/yast2_snapper.pm
@@ -88,7 +88,7 @@ sub run() {
     script_run "cd";
 
     # Start the yast2 snapper module and wait until it is started
-    script_run "yast2 snapper";
+    type_string "yast2 snapper\n";
     assert_screen 'yast2_snapper-snapshots', 100;
     # Make sure the test snapshot is not there
     die("Unexpected snapshot found") if (check_screen('yast2_snapper-new_snapshot', 5));
@@ -105,7 +105,7 @@ sub run() {
     assert_script_run "tar -xzf /home/$username/data/yast2_snapper.tgz";
 
     # Start the yast2 snapper module and wait until it is started
-    script_run "yast2 snapper";
+    type_string "yast2 snapper\n";
     assert_screen 'yast2_snapper-snapshots', 100;
     # Select the new snapshot
     unless ($self->y2snapper_select_snapshot) {


### PR DESCRIPTION
script_run can't be used on applications that do not just fire and terminate
simply use type_string for those cases and rely on all the logic in the tests
later on to decide if the execution worked