### PR TITLE
Make curl fail on some HTTP errors

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -47,7 +47,7 @@ sub run() {
     save_screenshot;
     clear_console;
 
-    assert_script_run "curl -L -v " . autoinst_url('/data') . " > test.data";
+    assert_script_run "curl -L -v -f " . autoinst_url('/data') . " > test.data";
     assert_script_run " cpio -id < test.data";
     script_run "ls -al data";
 

--- a/tests/console/sle11_consoletest_setup.pm
+++ b/tests/console/sle11_consoletest_setup.pm
@@ -48,7 +48,7 @@ sub run() {
     save_screenshot;
     clear_console;
 
-    assert_script_run("curl -L -v " . autoinst_url . "/data > test.data");
+    assert_script_run("curl -L -v -f " . autoinst_url . "/data > test.data");
     assert_script_run " cpio -id < test.data";
     script_run "ls -al data";
 


### PR DESCRIPTION
Although consoletest_setup.pm uses assert_script_run() to check
the result of the curl command, it's actually useless since curl
would fail silently. Add "-f" to make curl to return 22 when it
fails to fetch the file.

Signed-off-by: Gary Lin <glin@suse.com>