### PR TITLE
There is little use in the final assert_screen in sshfs

### DIFF
--- a/tests/console/sshfs.pm
+++ b/tests/console/sshfs.pm
@@ -13,9 +13,8 @@ use testapi;
 
 sub run() {
     my $self = shift;
-    become_root();
-    script_run("zypper -n in sshfs");
-    wait_still_screen(12, 90);
+    become_root;
+    assert_script_run("zypper -n in sshfs");
     script_run('cd /var/tmp ; mkdir mnt ; sshfs localhost:/ mnt', 0);
     assert_screen "accept-ssh-host-key";
     type_string "yes\n";    # trust ssh host key
@@ -24,16 +23,15 @@ sub run() {
     send_key "ret";
     assert_screen 'sshfs-accepted';
     script_run('cd mnt/tmp');
-    script_run("zypper -n in xdelta");
-    script_run("rpm -e xdelta");
+    assert_script_run("zypper -n in xdelta");
+    assert_script_run("rpm -e xdelta");
     script_run('cd /tmp');
 
     # we need to umount that otherwise root is considered logged in!
-    script_run("umount /var/tmp/mnt");
+    assert_script_run("umount /var/tmp/mnt");
 
     # become user again
     type_string "exit\n";
-    assert_screen 'test-sshfs-1';
 }
 
 1;


### PR DESCRIPTION
Console tests clear and verify the console anyway and all commands
better check their exit status directly