### PR TITLE
Don't use script_run to reboot

### DIFF
--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -38,7 +38,7 @@ sub run() {
             script_run("systemctl set-default --force multi-user.target");
         }
         # The CD was ejected in the bootloader test
-        script_run("/sbin/reboot");
+        type_string("/sbin/reboot\n");
 
         reset_consoles;
         wait_boot textmode => 1;


### PR DESCRIPTION
script_run expects the command to return echoes stuff to the serial to know
when it's done.

Calling reboot suppresses the following echo to the serial, thus making the monitor fail.