### PR TITLE
Fixed redundant check for yast having finished

### DIFF
--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -25,7 +25,6 @@ sub run() {
     script_run("/sbin/yast2 bootloader; echo YBL-$? > /dev/$serialdev", 0);
     my $ret = assert_screen "test-yast2_bootloader-1", 300;
     send_key "alt-o";                                     # OK => Close
-    assert_screen 'exited-bootloader', 150;
     die "yastootloader failed" unless wait_serial "YBL-0";
 
     type_string "exit\n";

--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -16,14 +16,12 @@ use utils;
 # https://bugzilla.novell.com/show_bug.cgi?id=610454
 
 sub run() {
-    my $self = shift;
-
     become_root;
 
     assert_script_run "zypper -n in yast2-bootloader";    # make sure yast2 bootloader module installed
 
     script_run("/sbin/yast2 bootloader; echo YBL-$? > /dev/$serialdev", 0);
-    my $ret = assert_screen "test-yast2_bootloader-1", 300;
+    assert_screen "test-yast2_bootloader-1", 300;
     send_key "alt-o";                                     # OK => Close
     die "yastootloader failed" unless wait_serial "YBL-0";
 


### PR DESCRIPTION
This fixes https://openqa.opensuse.org/tests/116074/modules/yast2_bootloader/steps/10
IMO
```assert_screen 'exited-bootloader'```
is a redundancy since the following line
```die "yastootloader failed" unless wait_serial "YBL-0";```
already assures that yast properly exited.
So we can omit the need of another needle that obviously needs maintenance.