### PR TITLE
reset consoles on reboot

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -86,6 +86,9 @@ sub wait_boot {
 
     assert_screen 'generic-desktop', 300;
     mouse_hide(1);
+
+    # Reset the consoles after the reboot: there is no user logged in anywhere
+    reset_consoles;
 }
 
 # 'ctrl-l' does not get queued up in buffer. If this happens to fast, the

--- a/tests/console/console_reboot.pm
+++ b/tests/console/console_reboot.pm
@@ -15,7 +15,6 @@ use utils;
 sub run() {
     become_root;
     type_string "reboot\n";
-    reset_consoles;
     wait_boot;
     select_console 'user-console';
     assert_script_sudo "chown $username /dev/$serialdev";


### PR DESCRIPTION
as we now make much more use of select_console, it needs to be ensured to reset the consoles on boot
Most tests rely on wait_boot to ensure the system is back up, so it's a good place to reset the console.