### PR TITLE
lxde_reboot: don't use script_sudo

### DIFF
--- a/tests/x11/reboot_lxde.pm
+++ b/tests/x11/reboot_lxde.pm
@@ -16,8 +16,11 @@ sub run() {
     wait_idle;
 
     #send_key "ctrl-alt-delete"; # does open task manager instead of reboot
-    x11_start_program("xterm");
-    script_sudo "/sbin/reboot";
+    x11_start_program "lxsession-logout";
+    assert_screen "logoutdialog", 20;
+    send_key "tab";    # reboot
+    save_screenshot;
+    send_key "ret";    # confirm
     wait_boot;
 }
 


### PR DESCRIPTION
Rather use lxsession-logout to show the logout dialog and navigate using
the keyboard to reboot and confirm.

This is the same logic as is used in reboote_xfce