### PR TITLE
consoletest: show network configuration

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -31,6 +31,10 @@ sub run() {
     # Export the existing status of running tasks for future reference (fail would export it again)
     script_run "ps axf > /tmp/psaxf_consoletest_setup.log";
 
+    # Just after the setup: let's see the network configuration
+    script_run "ip addr show";
+    save_screenshot;
+
     # Stop packagekit
     script_run "systemctl mask packagekit.service";
     script_run "systemctl stop packagekit.service";


### PR DESCRIPTION
This is especially interesting in zypper dup cases: we show the network config prior to starting dup - if we show it again at this point, it can help in showing network device name changes happening

See for example https://bugzilla.opensuse.org/show_bug.cgi?id=960669