### PR TITLE
Increase timeout in installation to be robust on slow workers

### DIFF
--- a/tests/installation/installation_overview_before.pm
+++ b/tests/installation/installation_overview_before.pm
@@ -18,7 +18,8 @@ sub run() {
 
     # overview-generation
     # this is almost impossible to check for real
-    assert_screen "inst-overview";
+    # it can take a long time until everything is computed
+    assert_screen "inst-overview", 120;
 
     # preserve it for the video
     wait_idle 10;

--- a/tests/installation/livecdreboot.pm
+++ b/tests/installation/livecdreboot.pm
@@ -15,8 +15,8 @@ use bmwqemu ();
 
 sub run() {
     my $self = shift;
-    # NET isos are slow to install
-    my $timeout = 2000;
+    # NET isos are slow to install, slow machines will take long to install
+    my $timeout = 4000;
 
     # workaround for yast popups
     my @tags = qw/rebootnow/;


### PR DESCRIPTION
Verified to fix installation on my openqa test instance with slow IO.

Should fix https://progress.opensuse.org/issues/10136