### PR TITLE
don't add vga= and video= on JeOS

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -105,7 +105,7 @@ sub run() {
     type_string " \\\n";    # changed the line before typing video params
                             # https://wiki.archlinux.org/index.php/Kernel_Mode_Setting#Forcing_modes_and_EDID
     type_string "Y2DEBUG=1 ", $slow_typing_speed;
-    if (check_var('ARCH', 'i586') || check_var('ARCH', 'x86_64')) {
+    if (!get_var('JEOS') && (check_var('ARCH', 'i586') || check_var('ARCH', 'x86_64'))) {
         type_string "vga=791 ";
         type_string "video=1024x768-16 ", $slow_typing_speed;
 

--- a/tests/jeos/grub2_gfxmode.pm
+++ b/tests/jeos/grub2_gfxmode.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# JeOS with kernel-default-base doesn't use kms, so the default mode
+# 1024x768 of the cirrus kms driver doesn't help us. We need to
+# manually configure grub to tell the kernel what mode to use.
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+
+sub run {
+    assert_script_run("sed -ie '/GFXPAYLOAD_LINUX=/s/=.*/=1024x768/' /etc/default/grub && grub2-mkconfig -o /boot/grub2/grub.cfg");
+}
+
+sub test_flags() {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
JeOS uses kernel-default-base and that lacks kms. For some reason colors
are wrong when passing vga and not using kms
(https://bugzilla.suse.com/show_bug.cgi?id=963952)
Maybe we don't need vga= at all anymore as we change gfxpayload?