### PR TITLE
Use type_string instead script_run

### DIFF
--- a/tests/rt/kmp_modules.pm
+++ b/tests/rt/kmp_modules.pm
@@ -55,9 +55,9 @@ sub run() {
     script_run 'sed -i s\'/^allow_unsupported_modules 0/allow_unsupported_modules 1/\' /etc/modprobe.d/10-unsupported-modules.conf';
     # install kmp packages
     assert_script_run 'zypper -n in *-kmp-rt *-kmp-compute', 500;
-    script_run 'reboot';
+    type_string "reboot\n";
     kmp_module('compute');
-    script_run 'reboot';
+    type_string "reboot\n";
     kmp_module('rt');
     type_string "exit\n";
 }


### PR DESCRIPTION
there is no need to wait_idle, otherwise test will miss the boot https://openqa.suse.de/tests/191314/modules/kmp_modules/steps/17