### PR TITLE
Do not need to add module name, rely on upload_file now

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -12,7 +12,7 @@ sub post_fail_hook() {
     select_console 'root-console';
     save_screenshot;
 
-    my $fn = sprintf '/tmp/y2logs-%s.tar.bz2', ref $self;
+    my $fn = '/tmp/y2logs.tar.bz2';
     type_string "save_y2logs $fn\n";
     upload_logs $fn;
     save_screenshot;


### PR DESCRIPTION
handle the rename and avoiding overwritten in upload_file https://github.com/os-autoinst/os-autoinst/pull/406