### PR TITLE
Add test for command-not-found tool

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -562,6 +562,8 @@ sub load_extra_test () {
     }
     loadtest "console/a2ps.pm";    # a2ps is not a ring package and thus not available in staging
 
+    loadtest "console/command_not_found.pm";
+
     # finished console test and back to desktop
     loadtest "console/consoletest_finish.pm";
 

--- a/tests/console/command_not_found.pm
+++ b/tests/console/command_not_found.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use testapi;
+
+# test for regression of bug http://bugzilla.suse.com/show_bug.cgi?id=952496
+sub run() {
+    # permissions don't matter
+
+    my $not_installed_pkg = "xosview";
+    assert_script_run("cnf $not_installed_pkg 2>&1 | tee /dev/stderr | grep -q \"zypper install $not_installed_pkg\"");
+    save_screenshot;
+}
+
+sub test_flags() {
+    return {important => 1};
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
To catch regressions for http://bugzilla.suse.com/show_bug.cgi?id=952496

https://progress.opensuse.org/issues/9684