### PR TITLE
wait_boot returns before running "reset_consoles" in text mode

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -56,6 +56,7 @@ sub wait_boot {
 
     if ($textmode || check_var('DESKTOP', 'textmode')) {
         assert_screen 'linux-login', 200;
+        reset_consoles;
         return;
     }
 


### PR DESCRIPTION
Cause of: https://openqa.suse.de/tests/194729/modules/console_reboot/steps/1/src