### PR TITLE
Simplify and speed up zypper_ref test

### DIFF
--- a/tests/console/zypper_ref.pm
+++ b/tests/console/zypper_ref.pm
@@ -18,11 +18,11 @@ sub run() {
 
     script_run("zypper ref; echo zypper-ref-\$? > /dev/$serialdev", 0);
     # don't trust graphic driver repo
-    if (check_screen("new-repo-need-key", 20)) {
+    assert_screen([qw/new-repo-need-key zypper_ref/]);
+    if (match_has_tag('new-repo-need-key')) {
         type_string "r\n";
     }
     wait_serial("zypper-ref-0") || die "zypper ref failed";
-    assert_screen("zypper_ref");
 }
 
 sub test_flags() {


### PR DESCRIPTION
Using assert_screen on all expected variants helps us to not need to tune the
timeout on a check_screen to save time.

local verification: ![openqa_local_test_zypper_ref](https://cloud.githubusercontent.com/assets/1693432/12729515/766b4358-c927-11e5-9bff-b9525e4e0594.png)
