### PR TITLE
textinfo: Don't rely on a needle,

### DIFF
--- a/tests/console/textinfo.pm
+++ b/tests/console/textinfo.pm
@@ -18,7 +18,6 @@ sub run() {
     assert_script_run("/home/$username/data/textinfo 2>&1 | tee /tmp/info.txt");
     upload_logs("/tmp/info.txt");
     upload_logs("/tmp/logs.tar.bz2");
-    assert_screen "texinfo-logs-uploaded";
 }
 
 1;


### PR DESCRIPTION
upload_logs checks the exit status of curl, this is safer than relying
on the filename