### PR TITLE
skip assert release note for WE addon

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -28,6 +28,7 @@ sub run() {
     }
     if (@addons) {
         for $a (@addons) {
+            next if ($a eq 'we');                      # https://bugzilla.suse.com/show_bug.cgi?id=931003#c17
             send_key_until_needlematch("release-notes-$a", 'right');
             send_key 'left';                           # move back to first tab
             send_key 'left';


### PR DESCRIPTION
Confirmed with Frederic that no release note for WE.