### PR TITLE
show fstab in textinfo

### DIFF
--- a/data/textinfo
+++ b/data/textinfo
@@ -6,6 +6,8 @@ lsmod
 
 free
 
+cat /etc/fstab
+
 mount
 
 /usr/sbin/btrfs filesystem df /


### PR DESCRIPTION
with JeOS we currently have a problem where kiwi creates /etc/fstab
differently than yast. So it's useful to know how it looks like
exactly to debug follow up problems.