### PR TITLE
yast2_i: use zypper -n -i (ignore unknown packages)

### DIFF
--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -19,7 +19,7 @@ sub run() {
 
     select_console 'root-console';
 
-    assert_script_run "zypper -n rm $pkgname $recommended", 90;
+    assert_script_run "zypper -n -i rm $pkgname $recommended", 90;
 
     assert_script_run "zypper -n in yast2-packager", 90;    # make sure yast2 sw_single module installed
 


### PR DESCRIPTION
The purpose of the zypper call is to ensure that all packages listed are
removed from the system. In some cases, packages are not installed and
not available in the limited set of repositories, resulting in zypper
abortnig the task instead of removing the remaining packages.

Using zypper -i ignores the unknown packages and performs the task on
the remaining set.

This only makes sense for openQA on package removal - installations we have
to take care of in a better way