### PR TITLE
YaST tests are interactive, don't wait for serial result

### DIFF
--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -58,7 +58,7 @@ sub run() {
     #
     # First execution (wizard-like interface)
     #
-    script_run '/sbin/yast2 dns-server';
+    script_run '/sbin/yast2 dns-server', 0;
     # Just do next-next until the last step
     assert_screen 'yast2-dns-server-step1';
     send_key 'alt-n';
@@ -77,7 +77,7 @@ sub run() {
     #
     # Second execution (tree-based interface)
     #
-    script_run '/sbin/yast2 dns-server';
+    script_run '/sbin/yast2 dns-server', 0;
     assert_screen 'yast2-service-running-enabled';
     # Stop the service
     send_key 'alt-s';
@@ -94,7 +94,7 @@ sub run() {
     #
     # Third execution (tree-based interface)
     #
-    script_run '/sbin/yast2 dns-server';
+    script_run '/sbin/yast2 dns-server', 0;
     assert_screen 'yast2-service-stopped-enabled';
     # Start the service
     send_key 'alt-s';
@@ -109,7 +109,7 @@ sub run() {
     #
     # Fourth execution (tree-based interface)
     #
-    script_run '/sbin/yast2 dns-server';
+    script_run '/sbin/yast2 dns-server', 0;
     assert_screen 'yast2-service-running-disabled';
     # Stop the service
     send_key 'alt-s';

--- a/tests/console/yast2_nfs_client.pm
+++ b/tests/console/yast2_nfs_client.pm
@@ -34,7 +34,7 @@ sub run() {
     #
     # YaST nfs-client execution
     #
-    script_run '/sbin/yast2 nfs-client';
+    script_run '/sbin/yast2 nfs-client', 0;
     assert_screen 'yast2-nfs-client-shares';
     # Open the dialog to add a connection to the share
     send_key 'alt-a';

--- a/tests/yast2_ui/yast2_snapper.pm
+++ b/tests/yast2_ui/yast2_snapper.pm
@@ -89,7 +89,7 @@ sub run() {
     script_run "cd";
 
     # Start the yast2 snapper module and wait until it is started
-    script_run "yast2 snapper";
+    script_run "yast2 snapper",              0;
     assert_screen 'yast2_snapper-snapshots', 100;
     # Make sure the test snapshot is not there
     die("Unexpected snapshot found") if (check_screen('yast2_snapper-new_snapshot', 5));


### PR DESCRIPTION
script_run per default waits for the command to return and reads
  the return value on the serial dev.

The various YaST dialogs are interactive and are further handled by
  assert_screens and keyboard navigation.