### PR TITLE
Update partitioning_raid using sendkey_until_needlematch

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -37,11 +37,7 @@ sub addpart($) {
     send_key $cmd{"donotformat"};
     send_key "tab";
 
-    while (!check_screen("partition-selected-raid-type", 1)) {
-        wait_screen_change {
-            send_key "down";
-        } || die "last item";
-    }
+    send_key_until_needlematch 'partition-selected-raid-type', 'down';
     send_key $cmd{finish};
 }
 


### PR DESCRIPTION
Related issue: https://progress.opensuse.org/issues/10228

Local verification: http://lord.arch.suse.de/tests/29

![openqa_partitioning_raid](https://cloud.githubusercontent.com/assets/1693432/12992851/385c5848-d117-11e5-863a-73b1847ba0bb.png)
