### PR TITLE
Reorder boot_encrypt to run after grub_test

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -420,11 +420,11 @@ sub load_inst_tests() {
 }
 
 sub load_reboot_tests() {
-    if (get_var("ENCRYPT")) {
-        loadtest "installation/boot_encrypt.pm";
-    }
     if (installyaststep_is_applicable) {
         loadtest "installation/grub_test.pm";
+        if (get_var("ENCRYPT")) {
+            loadtest "installation/boot_encrypt.pm";
+        }
         loadtest "installation/first_boot.pm";
     }
     if (is_reboot_after_installation_necessary()) {


### PR DESCRIPTION
Needed because the new grub_test has to run before boot_encrypt, as the encryption prompt happens after grub is done ;)