### PR TITLE
Rewrite qa_run.pm for kernel regression testing

### DIFF
--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -14,56 +14,21 @@ use warnings;
 use base "opensusebasetest";
 use testapi;
 
-sub create_qaset_config() {
-    my $self = shift;
-    my @list = $self->test_run_list();
-    return unless @list;
-    assert_script_run "echo 'SQ_TEST_RUN_LIST=(\n " . join("\n ", @list) . "\n )' > /root/qaset/config";
-}
-
-sub test_run_list() {
+sub test_run_list {
     return ();
 }
 
-sub junit_type() {
+sub junit_type {
     die "you need to overload junit_type in your class";
 }
 
-sub test_suite() {
+sub test_suite {
     die "you need to overload test_suite in your class";
 }
 
-sub wait_testrun {
-    my ($interval) = @_;
-    $interval = 300 unless defined $interval;
-
-    my $done_file = '/var/log/qaset/control/DONE';
-    while (1) {
-        my $pattern = "TESTRUN_FINISHED-" . int(rand(999999));
-        type_string "sleep 0.1 ; [[ -f $done_file ]] && echo '$pattern' | tee /dev/$serialdev\n";
-        my $ret = wait_serial($pattern, $interval);
-        if ($ret) {
-            return 1;
-        }
-    }
-    return 0;
-}
-
-sub qa_upload_logs {
-    my ($dir, $pattern) = @_;
-    my $output = script_output("find '$dir' -type f -name '$pattern'", 300);
-    my @log_files = split("\n", $output);
-    # upload logs
-    foreach my $log_file (@log_files) {
-        $log_file =~ s/^\s+|\s+$//g;
-        upload_logs($log_file);
-    }
-}
-
-# qa_testset_automation validation test
-sub run() {
+# system boot & login
+sub system_login {
     my $self = shift;
-    # system boot & login
     assert_screen "inst-bootmenu", 30;
     send_key "ret";
     assert_screen "grub2", 15;
@@ -74,26 +39,89 @@ sub run() {
     type_password;
     type_string "\n";
     sleep 2;
-    # Repo & Package
-    assert_script_run "zypper --no-gpg-check -n ar -f " . get_var('QA_HEAD_REPO') . " qa_ibs";
+}
+
+# Call test_run_list and write the result into /root/qaset/config
+sub create_qaset_config {
+    my $self = shift;
+    my @list = $self->test_run_list();
+    return unless @list;
+    assert_script_run("mkdir -p /root/qaset");
+    my $testsuites = "\n\t" . join("\n\t", @list) . "\n";
+    assert_script_run("echo 'SQ_TEST_RUN_LIST=($testsuites)' > /root/qaset/config");
+}
+
+# Add qa head repo for kernel testing
+# 
+# If QA_SERVER_REPO is set, remove all existing zypper repos
+# and 
+sub prepare_repos {
+    my $self            = shift;
+    my $qa_server_repo  = get_var('QA_SERVER_REPO', '');
+    if ($qa_server_repo) {
+        # Remove all existing repos and add QA_SERVER_REPO
+        my $rm_repos = "declare -i n=`zypper repos | wc -l`-2; for ((i=0; i<\$n; i++)); do zypper rr 1; done; unset n; unset i";
+        assert_script_run($rm_repos, 300);
+        assert_script_run("zypper --no-gpg-check -n ar -f '$qa_server_repo' server-repo");
+    }
+    assert_script_run "zypper --no-gpg-check -n ar -f '" . get_var('QA_HEAD_REPO') . "' qa-ibs";
     assert_script_run "zypper --gpg-auto-import-keys ref";
     assert_script_run "zypper -n in qa_testset_automation";
-    assert_script_run "mkdir /root/qaset";
+}
+
+# Create qaset/config file, reset qaset, and start testrun
+sub start_testrun {
+    my $self = shift;
     $self->create_qaset_config();
-    # Start testrun
-    assert_script_run("/usr/share/qa/qaset/qaset reset");
+    assert_script_run "/usr/share/qa/qaset/qaset reset";
     my $testsuite = $self->test_suite();
     assert_script_run "/usr/share/qa/qaset/run/$testsuite-run";
-    # Wait for testrun to finish
-    my $interval = 300;
-    unless (wait_testrun($interval)) {
+}
+
+# Check whether DONE file exists every $interval secs in the background
+sub wait_testrun {
+    my ($self, $interval) = @_;
+    $interval = 30 unless defined $interval;
+    my $done_file   = '/var/log/qaset/control/DONE';
+    my $pattern     = "TESTRUN_FINISHED-" . int(rand(999999));
+    my $cmd         = "while [[ ! -f $done_file ]]; do sleep $interval; done; echo $pattern >> /dev/$serialdev";
+    type_string "bash -c '$cmd' &\n";
+    # Set a extremely high timeout value for wait_serial
+    # so that it will wait until test run finished or 
+    # MAX_JOB_TIME(can be set on openQA webui) reached
+    my $ret = wait_serial($pattern, 3600 * 240);
+    if ($ret) {
+        return 1;
+    }
+    return 0;
+}
+
+# Upload all log tarballs in /var/log/qaset/log
+sub qa_upload_logs {
+    my ($self, $dir, $pattern) = @_;
+    my $output = script_output("find '$dir' -type f -name '$pattern'", 120);
+    my @log_files = split("\n", $output);
+    # upload logs
+    foreach my $log_file (@log_files) {
+        $log_file =~ s/^\s+|\s+$//g;
+        upload_logs $log_file;
+    }
+}
+
+# qa_testset_automation validation test
+sub run() {
+    my $self = shift;
+    $self->system_login();
+    $self->prepare_repos();
+    assert_script_run "zypper repos -u";    # Show all repos for debugging
+    $self->start_testrun();
+    unless ($self->wait_testrun()) {
         die "Test run didn't finish";
     }
-    # Print the QADB link
+
     type_string "grep -E \"http://.*/submission.php.*submission_id=[0-9]+\"  /var/log/qaset/submission/submission-*.log " . "| awk -F\": \"  '{print \$2}' | tee -a /dev/$serialdev\n";
-    # Upload log tarballs
-    qa_upload_logs('/var/log/qaset/log', '*.tar.*');
-    # junit log
+    $self->qa_upload_logs('/var/log/qaset/log', '*.tar.*');
+
     my $junit_type = $self->junit_type();
     assert_script_run "/usr/share/qa/qaset/bin/junit_xml_gen.py /var/log/qaset/log -s /var/log/qaset/submission -o /tmp/junit.xml -n '$junit_type'";
     parse_junit_log("/tmp/junit.xml");

--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -51,13 +51,11 @@ sub create_qaset_config {
     assert_script_run("echo 'SQ_TEST_RUN_LIST=($testsuites)' > /root/qaset/config");
 }
 
-# Add qa head repo for kernel testing
-# 
-# If QA_SERVER_REPO is set, remove all existing zypper repos
-# and 
+# Add qa head repo for kernel testing. If QA_SERVER_REPO is set,
+# remove all existing zypper repos first
 sub prepare_repos {
-    my $self            = shift;
-    my $qa_server_repo  = get_var('QA_SERVER_REPO', '');
+    my $self = shift;
+    my $qa_server_repo = get_var('QA_SERVER_REPO', '');
     if ($qa_server_repo) {
         # Remove all existing repos and add QA_SERVER_REPO
         my $rm_repos = "declare -i n=`zypper repos | wc -l`-2; for ((i=0; i<\$n; i++)); do zypper rr 1; done; unset n; unset i";
@@ -82,12 +80,12 @@ sub start_testrun {
 sub wait_testrun {
     my ($self, $interval) = @_;
     $interval = 30 unless defined $interval;
-    my $done_file   = '/var/log/qaset/control/DONE';
-    my $pattern     = "TESTRUN_FINISHED-" . int(rand(999999));
-    my $cmd         = "while [[ ! -f $done_file ]]; do sleep $interval; done; echo $pattern >> /dev/$serialdev";
+    my $done_file = '/var/log/qaset/control/DONE';
+    my $pattern   = "TESTRUN_FINISHED-" . int(rand(999999));
+    my $cmd       = "while [[ ! -f $done_file ]]; do sleep $interval; done; echo $pattern >> /dev/$serialdev";
     type_string "bash -c '$cmd' &\n";
     # Set a extremely high timeout value for wait_serial
-    # so that it will wait until test run finished or 
+    # so that it will wait until test run finished or
     # MAX_JOB_TIME(can be set on openQA webui) reached
     my $ret = wait_serial($pattern, 3600 * 240);
     if ($ret) {

--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -35,7 +35,7 @@ sub test_suite() {
 
 sub wait_testrun {
     my ($interval) = @_;
-    $interval = 120 unless defined $interval;
+    $interval = 300 unless defined $interval;
 
     my $done_file = '/var/log/qaset/control/DONE';
     while (1) {
@@ -51,7 +51,7 @@ sub wait_testrun {
 
 sub qa_upload_logs {
     my ($dir, $pattern) = @_;
-    my $output = script_output("find '$dir' -type f -name '$pattern'", 120);
+    my $output = script_output("find '$dir' -type f -name '$pattern'", 300);
     my @log_files = split("\n", $output);
     # upload logs
     foreach my $log_file (@log_files) {
@@ -85,7 +85,7 @@ sub run() {
     my $testsuite = $self->test_suite();
     assert_script_run "/usr/share/qa/qaset/run/$testsuite-run";
     # Wait for testrun to finish
-    my $interval = 120;
+    my $interval = 300;
     unless (wait_testrun($interval)) {
         die "Test run didn't finish";
     }

--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -7,8 +7,10 @@
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
-
+#
 package qa_run;
+use strict;
+use warnings;
 use base "opensusebasetest";
 use testapi;
 
@@ -31,71 +33,69 @@ sub test_suite() {
     die "you need to overload test_suite in your class";
 }
 
+sub wait_testrun {
+    my ($interval) = @_;
+    $interval = 120 unless defined $interval;
+
+    my $done_file = '/var/log/qaset/control/DONE';
+    while (1) {
+        my $pattern = "TESTRUN_FINISHED-" . int(rand(999999));
+        type_string "sleep 0.1 ; [[ -f $done_file ]] && echo '$pattern' | tee /dev/$serialdev\n";
+        my $ret = wait_serial($pattern, $interval);
+        if ($ret) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+sub qa_upload_logs {
+    my ($dir, $pattern) = @_;
+    my $output = script_output("find '$dir' -type f -name '$pattern'", 120);
+    my @log_files = split("\n", $output);
+    # upload logs
+    foreach my $log_file (@log_files) {
+        $log_file =~ s/^\s+|\s+$//g;
+        upload_logs($log_file);
+    }
+}
+
 # qa_testset_automation validation test
 sub run() {
     my $self = shift;
-
+    # system boot & login
     assert_screen "inst-bootmenu", 30;
-    send_key "ret";    # boot
-
+    send_key "ret";
     assert_screen "grub2", 15;
     send_key "ret";
-
     assert_screen "text-login", 50;
     type_string "root\n";
     assert_screen "password-prompt", 10;
     type_password;
     type_string "\n";
-    sleep 1;
-
-    # Add Repo - http://dist.nue.suse.com/ibs/QA:/Head/SLE-12-SP1/
+    sleep 2;
+    # Repo & Package
     assert_script_run "zypper --no-gpg-check -n ar -f " . get_var('QA_HEAD_REPO') . " qa_ibs";
-
-    # refresh repo
-    assert_script_run "zypper --gpg-auto-import-keys ref -r qa_ibs";
-
-    # Install - zypper in qa_testset_automation
+    assert_script_run "zypper --gpg-auto-import-keys ref";
     assert_script_run "zypper -n in qa_testset_automation";
-
     assert_script_run "mkdir /root/qaset";
     $self->create_qaset_config();
-
-    # Trigger run script
+    # Start testrun
+    assert_script_run("/usr/share/qa/qaset/qaset reset");
     my $testsuite = $self->test_suite();
     assert_script_run "/usr/share/qa/qaset/run/$testsuite-run";
-
-    # This tests creates 2 screens 1 Main screen, 1 screen for specific test/module
-    # Monitor - Connect to Main Screen
-    type_string "screen -r `screen -ls | grep $testsuite | cut -d\".\" -f1`\n";
-
-    # When finished, the screen will terminate
-    for (1 .. 60) {
-        if (check_screen [qw/qa_screen_done qa_error/], 120) {
-            if (match_has_tag('qa_error')) {
-                die "run failed";
-            }
-            last;
-        }
-        else {
-            # change the screen periodically to avoid standstill detection for long running tests
-            my $time = time;
-            type_string "$time\n";
-        }
+    # Wait for testrun to finish
+    my $interval = 120;
+    unless (wait_testrun($interval)) {
+        die "Test run didn't finish";
     }
-    # output the QADB link
+    # Print the QADB link
     type_string "grep -E \"http://.*/submission.php.*submission_id=[0-9]+\"  /var/log/qaset/submission/submission-*.log " . "| awk -F\": \"  '{print \$2}' | tee -a /dev/$serialdev\n";
-
-    # can't use upload_log, so do a loop version of it
-    assert_script_run "cd /var/log/qaset/log; for i in *.bz2; do curl --form upload=\@\$i " . autoinst_url() . "/uploadlog/`basename \$i`; done";
-
-    # QA DB upload happens for each module
-    # qa_testset_automation remove the oldlogs, we create it back here for junit collecting information
-    assert_script_run "mkdir /var/log/qa/oldlogs; cd /var/log/qa/oldlogs; for i in /var/log/qaset/log/*.bz2; do tar -xjvf \$i; done";
-
-    # test junit
+    # Upload log tarballs
+    qa_upload_logs('/var/log/qaset/log', '*.tar.*');
+    # junit log
     my $junit_type = $self->junit_type();
     assert_script_run "/usr/share/qa/qaset/bin/junit_xml_gen.py /var/log/qaset/log -s /var/log/qaset/submission -o /tmp/junit.xml -n '$junit_type'";
-    assert_script_run "ls -l /tmp/";
     parse_junit_log("/tmp/junit.xml");
 }
 


### PR DESCRIPTION
Designed a new mechanism to detect whether the test run has finished. Instead of needles, the new qa_run.pm checks if /var/log/qaset/control/DONE exists using shell script.

Besides, I've also fixed the timeout issue of uploading log files by uploading them one by one. 