### PR TITLE
Add kernel regression test memeat and memtester

### DIFF
--- a/tests/qa_automation/acceptance_fs_stress.pm
+++ b/tests/qa_automation/acceptance_fs_stress.pm
@@ -1,3 +1,18 @@
+# Copyright (C) 2015 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
 use base "qa_run";
 use testapi;
 

--- a/tests/qa_automation/acceptance_fs_stress.pm
+++ b/tests/qa_automation/acceptance_fs_stress.pm
@@ -1,0 +1,17 @@
+use base "qa_run";
+use testapi;
+
+sub test_run_list() {
+    return qw(_reboot_off fs_stress);
+}
+
+sub junit_type() {
+    return 'stress_validation';
+}
+
+sub test_suite() {
+    return 'acceptance';
+}
+
+1;
+

--- a/tests/qa_automation/acceptance_process_stress.pm
+++ b/tests/qa_automation/acceptance_process_stress.pm
@@ -1,3 +1,18 @@
+# Copyright (C) 2015 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
 use base "qa_run";
 use testapi;
 

--- a/tests/qa_automation/acceptance_process_stress.pm
+++ b/tests/qa_automation/acceptance_process_stress.pm
@@ -1,0 +1,17 @@
+use base "qa_run";
+use testapi;
+
+sub test_run_list() {
+    return qw(_reboot_off process_stress);
+}
+
+sub junit_type() {
+    return 'stress_validation';
+}
+
+sub test_suite() {
+    return 'acceptance';
+}
+
+1;
+

--- a/tests/qa_automation/acceptance_sched_stress.pm
+++ b/tests/qa_automation/acceptance_sched_stress.pm
@@ -1,3 +1,18 @@
+# Copyright (C) 2015 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
 use base "qa_run";
 use testapi;
 

--- a/tests/qa_automation/acceptance_sched_stress.pm
+++ b/tests/qa_automation/acceptance_sched_stress.pm
@@ -1,0 +1,17 @@
+use base "qa_run";
+use testapi;
+
+sub test_run_list() {
+    return qw(_reboot_off sched_stress);
+}
+
+sub junit_type() {
+    return 'stress_validation';
+}
+
+sub test_suite() {
+    return 'acceptance';
+}
+
+1;
+

--- a/tests/qa_automation/kernel_memeat.pm
+++ b/tests/qa_automation/kernel_memeat.pm
@@ -2,15 +2,15 @@ use base "qa_run";
 use testapi;
 
 sub test_run_list() {
-        return qw(_reboot_off memeat);
+    return qw(_reboot_off memeat);
 }
 
 sub test_suite() {
-        return 'kernel';
+    return 'kernel';
 }
 
 sub junit_type() {
-        return 'kernel_regression';
+    return 'kernel_regression';
 }
 
 1;

--- a/tests/qa_automation/kernel_memeat.pm
+++ b/tests/qa_automation/kernel_memeat.pm
@@ -1,3 +1,18 @@
+# Copyright (C) 2015 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
 use base "qa_run";
 use testapi;
 

--- a/tests/qa_automation/kernel_memeat.pm
+++ b/tests/qa_automation/kernel_memeat.pm
@@ -1,0 +1,16 @@
+use base "qa_run";
+use testapi;
+
+sub test_run_list() {
+        return qw(_reboot_off memeat);
+}
+
+sub test_suite() {
+        return 'kernel';
+}
+
+sub junit_type() {
+        return 'kernel_regression';
+}
+
+1;

--- a/tests/qa_automation/kernel_memtester.pm
+++ b/tests/qa_automation/kernel_memtester.pm
@@ -1,3 +1,18 @@
+# Copyright (C) 2015 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
 use base "qa_run";
 use testapi;
 

--- a/tests/qa_automation/kernel_memtester.pm
+++ b/tests/qa_automation/kernel_memtester.pm
@@ -2,16 +2,15 @@ use base "qa_run";
 use testapi;
 
 sub test_run_list() {
-        return qw(_reboot_off memtester);
+    return qw(_reboot_off memtester);
 }
 
 sub test_suite() {
-        return 'kernel';
+    return 'kernel';
 }
 
 sub junit_type() {
-        return 'kernel_regression';
+    return 'kernel_regression';
 }
 
 1;
-

--- a/tests/qa_automation/kernel_memtester.pm
+++ b/tests/qa_automation/kernel_memtester.pm
@@ -1,0 +1,17 @@
+use base "qa_run";
+use testapi;
+
+sub test_run_list() {
+        return qw(_reboot_off memtester);
+}
+
+sub test_suite() {
+        return 'kernel';
+}
+
+sub junit_type() {
+        return 'kernel_regression';
+}
+
+1;
+

--- a/tests/qa_automation/userspace_1.pm
+++ b/tests/qa_automation/userspace_1.pm
@@ -1,3 +1,18 @@
+# Copyright (C) 2015 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
 use base "qa_run";
 use testapi;
 

--- a/tests/qa_automation/userspace_2.pm
+++ b/tests/qa_automation/userspace_2.pm
@@ -1,3 +1,18 @@
+# Copyright (C) 2015 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
 use base "qa_run";
 use testapi;
 

--- a/tests/qa_automation/userspace_3.pm
+++ b/tests/qa_automation/userspace_3.pm
@@ -1,3 +1,18 @@
+# Copyright (C) 2015 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
 use base "qa_run";
 use testapi;
 

--- a/tests/qa_automation/userspace_4.pm
+++ b/tests/qa_automation/userspace_4.pm
@@ -1,3 +1,18 @@
+# Copyright (C) 2015 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
 use base "qa_run";
 use testapi;
 


### PR DESCRIPTION
I add two stable testcases for kernel regression test. memeat need around 10min, and memtester need around half hour to run. Both of them are tested in local server in Beijing successfully. I suggest to add these two test into openqa.suse.de test envirorment for new build test.