### PR TITLE
grub_test: use 'up' instead of 'esc' to cancel timeout

### DIFF
--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -15,8 +15,8 @@ use testapi;
 sub run() {
     my $self = shift;
     assert_screen "grub2";
-    # prevent grub2 timeout
-    send_key 'esc';
+    # prevent grub2 timeout; 'esc' would be cleaner, but grub2-efi falls to the menu then
+    send_key 'up';
     if (get_var("BOOT_TO_SNAPSHOT")) {
         send_key_until_needlematch("boot-menu-snapshot", 'down', 10, 5);
         send_key 'ret';


### PR DESCRIPTION
grub2-efi falls to the command prompt when pressing esc, which is not what
we intend to do.

Reported as https://bugzilla.opensuse.org/show_bug.cgi?id=966701 for validation