### PR TITLE
Add message to record_soft_failure

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -58,8 +58,7 @@ sub fill_in_registration_data {
                 next;
             }
             elsif (get_var('SCC_URL') && match_has_tag("untrusted-ca-cert")) {
-                # bsc#943966
-                record_soft_failure if get_var('SCC_CERT');
+                record_soft_failure 'bsc#943966' if get_var('SCC_CERT');
                 send_key "alt-t", 1;        # trust
                 @tags = grep { $_ ne 'untrusted-ca-cert' } @tags;
                 next;
@@ -102,7 +101,7 @@ sub fill_in_registration_data {
             }
             send_key 'alt-n', 2;
             if (check_screen('import-untrusted-gpg-key', 10)) {
-                record_soft_failure;
+                record_soft_failure 'untrusted gpg key';
                 send_key 'alt-t', 2;
             }
             sleep 20;    # scc registration need some time

--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -77,7 +77,7 @@ sub run() {
         # workaround for bug 834165. Apper should not try to
         # refresh repos when the console is not active:
         if (get_var("DESKTOP", '') eq 'kde' && check_screen "apper-refresh-popup-bnc834165") {
-            record_soft_failure;
+            record_soft_failure 'bsc#834165';
             send_key 'alt-c';
             sleep 30;
         }

--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -26,7 +26,7 @@ sub run() {
     script_run("/sbin/yast2 sw_single; echo yast2-i-status-\$? > /dev/$serialdev", 0);
     if (check_screen('workaround-bsc924042', 10)) {
         send_key 'alt-o';
-        record_soft_failure;
+        record_soft_failure 'bsc#924042';
     }
     assert_screen 'empty-yast2-sw_single';
 

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -26,7 +26,7 @@ sub run() {
             send_key_until_needlematch "addon-dvd-$addon", 'down', 10;    # select addon in list
             send_key 'alt-o';                                             # continue
             if (check_screen('import-untrusted-gpg-key', 10)) {           # workaround untrusted key pop-up, record soft fail and trust it
-                record_soft_failure;
+                record_soft_failure 'untrusted gpg key';
                 send_key 'alt-t';
             }
             my $uc_addon = uc $addon;                                     # variable name is upper case

--- a/tests/installation/addon_products_yast2.pm
+++ b/tests/installation/addon_products_yast2.pm
@@ -63,7 +63,7 @@ sub run() {
             assert_screen 'automatic-changes';
             send_key 'alt-o';                                                      # OK
             if (check_screen 'unsupported-packages', 5) {
-                record_soft_failure;
+                record_soft_failure 'unsupported packages';
                 send_key 'alt-o';
             }
             if (check_screen 'addon-installation-pop-up', 100) {                   # e.g. RT reboot to activate new kernel

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -28,7 +28,7 @@ sub run() {
 
     # check for dependency issues, if found, drill down to software selection, take a screenshot, then die
     if (check_screen("inst-overview-dep-warning", 1)) {
-        record_soft_failure;
+        record_soft_failure 'dependency warning';
         if (check_var('VIDEOMODE', 'text')) {
             send_key 'alt-c';
             assert_screen 'inst-overview-options';
@@ -62,8 +62,7 @@ sub run() {
             assert_screen 'ssh-open';
         }
 
-        # Workaround for bsc#963008
-        record_soft_failure;
+        record_soft_failure 'bsc#963008';
         if (!check_screen('firewall-disabled', 5)) {
             send_key_until_needlematch 'firewall-enabled-selected', 'tab';
             send_key 'ret';

--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -14,23 +14,23 @@ use testapi;
 
 sub run() {
 
-    if (!check_screen('release-notes-button', 5)) {    # workaround missing release notes
-        record_soft_failure;
+    if (!check_screen('release-notes-button', 5)) {
+        record_soft_failure 'workaround missing release notes';
         return;
     }
     my @addons = split(/,/, get_var('ADDONS', ''));
     if (check_var('SCC_REGISTER', 'installation')) {
         push @addons, split(/,/, get_var('SCC_ADDONS', ''));
     }
-    send_key "alt-l", 2;                               # open release notes window
+    send_key "alt-l", 2;    # open release notes window
     if (check_var('VIDEOMODE', 'text')) {
-        send_key 'tab';                                # select tab area
+        send_key 'tab';     # select tab area
     }
     if (@addons) {
         for $a (@addons) {
-            next if ($a eq 'we');                      # https://bugzilla.suse.com/show_bug.cgi?id=931003#c17
+            next if ($a eq 'we');    # https://bugzilla.suse.com/show_bug.cgi?id=931003#c17
             send_key_until_needlematch("release-notes-$a", 'right');
-            send_key 'left';                           # move back to first tab
+            send_key 'left';         # move back to first tab
             send_key 'left';
             send_key 'left';
             send_key 'left';
@@ -38,7 +38,7 @@ sub run() {
         send_key_until_needlematch("release-notes-sle", 'right');
     }
     else {
-        assert_screen 'release-notes-sle';             # SLE release notes
+        assert_screen 'release-notes-sle';    # SLE release notes
     }
     # exit release notes window
     if (check_var('VIDEOMODE', 'text')) {
@@ -48,7 +48,7 @@ sub run() {
         send_key 'alt-c';
     }
     if (!get_var("UPGRADE")) {
-        send_key 'alt-e';                              # select timezone region as previously selected
+        send_key 'alt-e';                     # select timezone region as previously selected
     }
 }
 

--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -51,9 +51,8 @@ sub run() {
     # Disable console screensaver
     assert_script_run("setterm -blank 0");
 
-    # bnc#949188. kernel panic on 13.2
     if (get_var('HDD_1', '') =~ /opensuse-13\.2/) {
-        record_soft_failure;
+        record_soft_failure 'bsc#949188, kernel panic on 13.2';
         assert_script_run("zypper -n rm apparmor-abstractions");
     }
 }

--- a/tests/installation/skip_disk_activation.pm
+++ b/tests/installation/skip_disk_activation.pm
@@ -15,8 +15,7 @@ use testapi;
 sub run {
     my $self = shift;
 
-    # we should not have it
-    record_soft_failure;
+    record_soft_failure 'we should not have it';
     sleep 3;
     send_key 'alt-n';    # next
     sleep 5;

--- a/tests/installation/sle11_network.pm
+++ b/tests/installation/sle11_network.pm
@@ -35,14 +35,14 @@ sub run() {
         # network conf
         assert_screen 'network-config-done', 40;    # longwait Net|DSL|Modem
         if (check_screen 'workaround-boo914288') {
-            record_soft_failure;
+            record_soft_failure 'boo#914288';
         }
         send_key $cmd{next};
     }
 
     assert_screen 'test-internet-connection', 60;
     if (check_screen 'workaround-boo913722') {
-        record_soft_failure;
+        record_soft_failure 'boo#913722';
     }
     send_key $cmd{next};
 
@@ -50,7 +50,7 @@ sub run() {
     if (get_var("BETA")) {
         if (check_screen 'server-side-error', 90) {
             send_key "alt-o";
-            record_soft_failure;
+            record_soft_failure 'server-side-error';
         }
     }
     elsif (check_screen 'server-side-error', 90) {

--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -60,7 +60,7 @@ sub run() {
 
         if (check_screen('ERROR-bootloader_preupdate', 3)) {
             send_key 'alt-n';
-            record_soft_failure;
+            record_soft_failure 'error bootloader preupdate';
         }
         assert_screen "inst-packageinstallationstarted";
 

--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -33,7 +33,7 @@ sub run() {
             send_key 'alt-n';
             if (check_screen('ERROR-cannot-download-repositories')) {
                 send_key 'alt-o';
-                record_soft_failure;
+                record_soft_failure 'error can not download repositories';
             }
         }
         if (check_screen('list-of-online-repositories', 10)) {
@@ -45,14 +45,14 @@ sub run() {
         # (remove after the bug is closed)
         if (check_screen('upgrade-li-cense-agreement', 10)) {
             send_key 'alt-n';
-            record_soft_failure;
+            record_soft_failure 'boo#881107';
         }
         if (check_screen('beta-warning', 10)) {
             send_key 'alt-o';
         }
         if (check_screen('installed-product-incompatible', 10)) {
             send_key 'alt-o';    # C&ontinue
-            record_soft_failure;
+            record_soft_failure 'installed product incompatible';
         }
 
         assert_screen "update-installation-overview", 15;

--- a/tests/installation/upgrade_select_sle11.pm
+++ b/tests/installation/upgrade_select_sle11.pm
@@ -46,8 +46,8 @@ sub run() {
                     send_key 'alt-d';                                          # DHCP
                     send_key "alt-o", 2;                                       # OK
                 }
-                record_soft_failure                                            # https://bugzilla.suse.com/show_bug.cgi?id=928895
-                  assert_screen 'correct-media';                               # Correct media request
+                record_soft_failure 'bsc#928895';
+                assert_screen 'correct-media';                                 # Correct media request
                 send_key "alt-o", 2;                                           # OK
             }
             else {

--- a/tests/installation/user_settings.pm
+++ b/tests/installation/user_settings.pm
@@ -45,7 +45,7 @@ sub run() {
         send_key "ret";
     }
     else {
-        record_soft_failure;
+        record_soft_failure 'bsc#937012';
     }
 }
 

--- a/tests/installation/user_settings_root.pm
+++ b/tests/installation/user_settings_root.pm
@@ -25,12 +25,11 @@ sub run() {
     send_key $cmd{"next"};
 
     # PW too easy (cracklib)
-    # If check_screen added to workaround bsc#937012
     if (check_screen('inst-userpasswdtoosimple', 13)) {
         send_key "ret";
     }
     else {
-        record_soft_failure;
+        record_soft_failure 'bsc#937012';
     }
 }
 

--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -101,7 +101,7 @@ sub run() {
     while ($out) {
         if ($out =~ $zypper_dup_conflict) {
             if (get_var("WORKAROUND_DEPS")) {
-                record_soft_failure;
+                record_soft_failure 'workaround dependencies';
                 send_key '1';
                 send_key 'ret';
             }


### PR DESCRIPTION
The os-autoinst testapi supports optional explanation messages for
record_soft_failure since os-autoinst commit
e47004bc5b320912ca36132a14a501b8d0424eee