### PR TITLE
sshxterm: Use potential safer closing method with 'killall'

### DIFF
--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -28,12 +28,8 @@ sub run() {
     $self->set_standard_prompt();
     type_string "echo If you can see this text, ssh-X-forwarding  is working.\n";
     assert_screen 'test-sshxterm-1';
-    # close both windows
-    # make sure the previous window closed
-    wait_screen_change {
-        send_key "alt-f4";
-    }
-    send_key "alt-f4";
+    # close both windows, executed in remote session, because we can
+    type_string "killall xterm\n";
 }
 
 1;


### PR DESCRIPTION
wait_screen_change sometimes triggered on partially closed gnome terminal
causing the second 'alt-f4' command to be not directed to the second terminal
window causing a timeout waiting for the second xterm to close.
Calling "killall xterm" should be a safer approach.

I tried hard to reproduce the issue by clogging the CPUs and nice-ing the
worker process. Unfortunately the recently introduced stall detection in the
backend caused the test process to be aborted when the machine was too slow,
E.g. executing "nice -n 19 <worker>" while running "stress --cpu <cpu_nr>" and
less slowing down could not reproduce the issue. Still, "killall" should be
properly evaluated by the system and it is not the responsibility of the
sshxterm test to check if 'alt-f4' can close windows.

Related issue: https://progress.opensuse.org/issues/10646