### PR TITLE
Another take on boot parameter typing

### DIFF
--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -16,15 +16,35 @@ use Time::HiRes qw(sleep);
 use testapi;
 use registration;
 
+# arbitrary slow typing speed, also see bootloader_uefi
+use constant SLOW_TYPING_SPEED => 13;
+
+# type even slower towards the end to ensure no keybuffer overflow even
+# when scrolling within the boot command line to prevent character
+# mangling
+use constant SLOWER_TYPING_SPEED => 4;
+
+sub type_string_slow {
+    my ($string) = @_;
+
+    type_string $string, SLOW_TYPING_SPEED;
+}
+
+sub type_string_slower {
+    my ($string) = @_;
+
+    type_string $string, SLOWER_TYPING_SPEED;
+
+    # the bootloader prompt line is very delicate with typing especially when
+    # scrolling. We are typing very slow but this could still pose problems
+    # when the worker host is utilized so better wait until the string is
+    # displayed before continuing
+    wait_still_screen 1;
+}
+
 # hint: press shift-f10 trice for highest debug level
 sub run() {
     my ($self) = @_;
-    # arbitrary slow typing speed, also see bootloader_uefi
-    my $slow_typing_speed = 13;
-    # type even slower towards the end to ensure no keybuffer overflow even
-    # when scrolling within the boot command line to prevent character
-    # mangling
-    my $slower_typing_speed = 4;
 
     if (get_var("IPXE")) {
         sleep 60;
@@ -73,18 +93,18 @@ sub run() {
     # https://wiki.archlinux.org/index.php/Kernel_Mode_Setting#Forcing_modes_and_EDID
     type_string "vga=791 ";
     type_string "Y2DEBUG=1 ";
-    type_string "video=1024x768-16 ", $slow_typing_speed;
+    type_string_slow "video=1024x768-16 ";
 
-    assert_screen "inst-video-typed", $slow_typing_speed;
+    assert_screen "inst-video-typed", 4;
     if (!get_var("NICEVIDEO")) {
-        type_string "plymouth.ignore-serial-consoles ", $slower_typing_speed;    # make plymouth go graphical
-        type_string "linuxrc.log=$serialdev ",          $slower_typing_speed;    #to get linuxrc logs in serial
-        type_string "console=$serialdev ",              $slower_typing_speed;    # to get crash dumps as text
-        type_string "console=tty ",                     $slower_typing_speed;    # to get crash dumps as text
-        assert_screen "inst-consolesettingstyped",      30;
+        type_string_slower "plymouth.ignore-serial-consoles ";    # make plymouth go graphical
+        type_string_slower "linuxrc.log=$serialdev ";             #to get linuxrc logs in serial
+        type_string_slower "console=$serialdev ";                 # to get crash dumps as text
+        type_string_slower "console=tty ";                        # to get crash dumps as text
+        assert_screen "inst-consolesettingstyped", 30;
         my $e = get_var("EXTRABOOTPARAMS");
         if ($e) {
-            type_string "$e ", $slower_typing_speed;
+            type_string_slower "$e ";
             save_screenshot;
         }
     }
@@ -242,15 +262,15 @@ sub run() {
         $args .= " autoupgrade=1";
     }
 
-    type_string $args, $slower_typing_speed;
+    type_string_slower $args;
     save_screenshot;
 
     if (get_var("FIPS")) {
-        type_string " fips=1", $slower_typing_speed;
+        type_string_slower " fips=1";
         save_screenshot;
     }
 
-    registration_bootloader_params($slower_typing_speed);
+    registration_bootloader_params(SLOWER_TYPING_SPEED);
 
     # boot
     send_key "ret";


### PR DESCRIPTION
Previous attempts to ensure boot parameters are typed slow enough were
conducted in e43f1e4d but depending on worker load this could still fail even
though slower typing was used. This change additionally waits for still
screens after individual string segments when doing "slower typing" to ensure
the keybuffer is flushed before continuing with the next string.

Helper methods are extracted. They could be used also in other bootloader test
implementations if applicable.

The problem was reproduced by running the worker with "nice -n 4" and hogging
all cpus with "stress" causing mangled characters. Verification with the same
parameters was successful.

The typing could still fail if too long strings are used when typing and
verification has only been done with one execution path.

Related issue: https://progress.opensuse.org/issues/10740

Fixes issue as seen in
http://lord.arch/tests/49/modules/bootloader/steps/10

![canvas](https://cloud.githubusercontent.com/assets/1693432/13177786/9ee64fa6-d71b-11e5-9620-4080ed72aa4a.png)

Verification run
http://lord.arch/tests/67