### PR TITLE
Make the sshd test more robust

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -35,11 +35,14 @@ sub run() {
     $self->clear_and_verify_console;
     select_console 'user-console';
 
+    # we output the exit status, but we don't care - we want to see the echo on screen
+    # but for debugging, it's easier to check the serial file later
+    my $str = "SSH-" . time;
     # login use new user account
-    script_run('ssh ' . $ssh_testman . '@localhost -t echo LOGIN_SUCCESSFUL', 0);
+    script_run("ssh $ssh_testman\@localhost -t echo LOGIN_SUCCESSFUL; echo $str-$?- > /dev/$serialdev", 0);
     assert_screen "ssh-login", 60;
     type_string "yes\n";
-    sleep 3;
+    assert_screen 'password-prompt';
     type_string "$ssh_testman_passwd\n";
     assert_screen "ssh-login-ok", 10;
 }


### PR DESCRIPTION
Instead of sleep 3 wait for the password prompt before typing.
Additionally call ssh with -v and output the exit status to
serial - for ease of debugging in case the problem persist

(Unfortunately it requires ne-needling due to ssh -v, but it's quickly
done)