### PR TITLE
Add some custom die message to assert_script_run

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -52,7 +52,7 @@ sub run_yast_cli_test {
     script_run("if [ -d t ]; then echo -n 'run'; else echo -n 'skip'; fi > /dev/$serialdev", 0);
     my $action = wait_serial(['run', 'skip'], 10);
     if ($action eq 'run') {
-        assert_script_run 'prove';
+        assert_script_run('prove', fail_msg => 'yast cli tests failed');
     }
 
     script_run 'popd';

--- a/tests/console/gpt_ptable.pm
+++ b/tests/console/gpt_ptable.pm
@@ -14,7 +14,7 @@ use testapi;
 
 # verify that the disks have a gpt partition label
 sub run() {
-    assert_script_run "parted -ml | grep '^/dev/.*:gpt:'";
+    assert_script_run("parted -ml | grep '^/dev/.*:gpt:'", fail_msg => 'no gpt partition table found');
 }
 
 1;

--- a/tests/console/http_srv.pm
+++ b/tests/console/http_srv.pm
@@ -30,7 +30,7 @@ sub run() {
 
     # verify httpd serves index.html
     type_string "echo Lorem ipsum dolor sit amet > /srv/www/htdocs/index.html\n";
-    assert_script_run "curl -f http://localhost/ | grep 'Lorem ipsum dolor sit amet'";
+    assert_script_run("curl -f http://localhost/ | grep 'Lorem ipsum dolor sit amet'", fail_msg => 'Could not access local apache2 instance');
 }
 
 1;

--- a/tests/console/import_gpg_keys.pm
+++ b/tests/console/import_gpg_keys.pm
@@ -22,7 +22,7 @@ sub run() {
     select_console 'root-console';
 
     if (my $keys = get_var("IMPORT_GPG_KEYS")) {
-        assert_script_run("rpm --import ~$username/data/$keys");
+        assert_script_run("rpm --import ~$username/data/$keys", fail_msg => 'Failed to import GPG keys');
     }
 }
 

--- a/tests/console/kdump_disabled.pm
+++ b/tests/console/kdump_disabled.pm
@@ -13,7 +13,7 @@ use strict;
 use testapi;
 
 sub run() {
-    assert_script_run("grep ^0 /sys/kernel/kexec_crash_loaded");
+    assert_script_run("grep ^0 /sys/kernel/kexec_crash_loaded", fail_msg => 'kdump should be disabled');
 }
 
 1;

--- a/tests/console/snapper_undochange.pm
+++ b/tests/console/snapper_undochange.pm
@@ -28,7 +28,7 @@ sub run() {
 
     # Restore snapfile
     script_run "snapper undochange $snapaf..$snapbf $snapfile";
-    assert_script_run "test -f $snapfile", 10;
+    assert_script_run("test -f $snapfile", timeout => 10, fail_msg => "File $snapfile could not be found");
 
     assert_screen 'snapper_undochange', 3;
 }

--- a/tests/console/yast2_clone_system.pm
+++ b/tests/console/yast2_clone_system.pm
@@ -27,7 +27,7 @@ sub run() {
         $n_error++;
     }
 
-    assert_script_run "test -f /root/autoinst.xml", 20;
+    assert_script_run("test -f /root/autoinst.xml", timeout => 20, fail_msg => 'File /root/autoinst.xml could not be found');
     upload_asset "/root/autoinst.xml";
 }
 

--- a/tests/rt/kmp_modules.pm
+++ b/tests/rt/kmp_modules.pm
@@ -20,7 +20,7 @@ sub kmp_module {
     assert_screen 'generic-desktop';
     select_console 'root-console';
     # check if kernel is proper $kernel
-    assert_script_run "uname -r|grep $kernel";
+    assert_script_run("uname -r|grep $kernel", 90, "Expected kernel $kernel not found");
     # get bash script
     my $package = data_url('modprobe_kmp_modules.sh');
     script_run "wget $package";
@@ -36,7 +36,7 @@ sub kmp_module {
 =cut
     script_run 'chmod +x modprobe_kmp_modules.sh';
     # run script printed above, modprobe kmp-compute and kmp-rt modules
-    assert_script_run "./modprobe_kmp_modules.sh $kernel";
+    assert_script_run("./modprobe_kmp_modules.sh $kernel", 90, 'Failed to load modules');
     reset_consoles;
 }
 

--- a/tests/toolchain/gcc5_fortran_compilation.pm
+++ b/tests/toolchain/gcc5_fortran_compilation.pm
@@ -34,7 +34,7 @@ sub run() {
     # Test
     assert_script_run './driver_run|tee /tmp/test.log', 300;
 
-    assert_script_run '! grep " [1-9][0-9]* TESTS FAILED" *.res';
+    assert_script_run('! grep " [1-9][0-9]* TESTS FAILED" *.res', fail_msg => 'fortran tests failed');
 
     save_screenshot;
 }


### PR DESCRIPTION
Since https://github.com/os-autoinst/os-autoinst/pull/430
os-autoinst supports an optional, custom error message on die in
assert_script_run. As assert_script_run ignores additional arguments in older
version this should be a backward compatible addition.

Not all assert_script_run calls have been changed but only the locations where
a failure of assert_script_run might have a non-obvious cause to the reviewer
of test failures.

No further tests than just "make test" have been conducted.