### PR TITLE
Fix uninitialized value

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -254,7 +254,7 @@ sub have_addn_repos() {
 }
 
 sub we_is_applicable() {
-    return is_server && get_var("ADDONS") =~ /we/;
+    return is_server && get_var("ADDONS", "") =~ /we/;
 }
 
 sub loadtest($) {


### PR DESCRIPTION
https://openqa.suse.de/tests/209945/file/autoinst-log.txt
Use of uninitialized value in pattern match (m//) at /var/lib/openqa/share/tests/sle/main.pm line 257.