### PR TITLE
Make release notes work for network add-on

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -18,7 +18,8 @@ sub run() {
         record_soft_failure 'workaround missing release notes';
         return;
     }
-    my @addons = split(/,/, get_var('ADDONS', ''));
+    my $addons = get_var('ADDONS', get_var('ADDONURL', ''));
+    my @addons = split(/,/, $addons);
     if (check_var('SCC_REGISTER', 'installation')) {
         push @addons, split(/,/, get_var('SCC_ADDONS', ''));
     }


### PR DESCRIPTION
network add-on test uses variable ADDONURL istead of ADDONS https://openqa.suse.de/tests/210220/modules/releasenotes/steps/1
tested:
http://10.100.98.90/tests/938/modules/releasenotes/steps/1