### PR TITLE
Use slow bootloader typing consistently in all instances

### DIFF
--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -15,32 +15,7 @@ use Time::HiRes qw(sleep);
 
 use testapi;
 use registration;
-
-# arbitrary slow typing speed, also see bootloader_uefi
-use constant SLOW_TYPING_SPEED => 13;
-
-# type even slower towards the end to ensure no keybuffer overflow even
-# when scrolling within the boot command line to prevent character
-# mangling
-use constant SLOWER_TYPING_SPEED => 4;
-
-sub type_string_slow {
-    my ($string) = @_;
-
-    type_string $string, SLOW_TYPING_SPEED;
-}
-
-sub type_string_slower {
-    my ($string) = @_;
-
-    type_string $string, SLOWER_TYPING_SPEED;
-
-    # the bootloader prompt line is very delicate with typing especially when
-    # scrolling. We are typing very slow but this could still pose problems
-    # when the worker host is utilized so better wait until the string is
-    # displayed before continuing
-    wait_still_screen 1;
-}
+use utils;
 
 # hint: press shift-f10 trice for highest debug level
 sub run() {
@@ -97,14 +72,14 @@ sub run() {
 
     assert_screen "inst-video-typed", 4;
     if (!get_var("NICEVIDEO")) {
-        type_string_slower "plymouth.ignore-serial-consoles ";    # make plymouth go graphical
-        type_string_slower "linuxrc.log=$serialdev ";             #to get linuxrc logs in serial
-        type_string_slower "console=$serialdev ";                 # to get crash dumps as text
-        type_string_slower "console=tty ";                        # to get crash dumps as text
+        type_string_very_slow "plymouth.ignore-serial-consoles ";    # make plymouth go graphical
+        type_string_very_slow "linuxrc.log=$serialdev ";             #to get linuxrc logs in serial
+        type_string_very_slow "console=$serialdev ";                 # to get crash dumps as text
+        type_string_very_slow "console=tty ";                        # to get crash dumps as text
         assert_screen "inst-consolesettingstyped", 30;
         my $e = get_var("EXTRABOOTPARAMS");
         if ($e) {
-            type_string_slower "$e ";
+            type_string_very_slow "$e ";
             save_screenshot;
         }
     }
@@ -262,15 +237,15 @@ sub run() {
         $args .= " autoupgrade=1";
     }
 
-    type_string_slower $args;
+    type_string_very_slow $args;
     save_screenshot;
 
     if (get_var("FIPS")) {
-        type_string_slower " fips=1";
+        type_string_very_slow " fips=1";
         save_screenshot;
     }
 
-    registration_bootloader_params(SLOWER_TYPING_SPEED);
+    registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
 
     # boot
     send_key "ret";

--- a/tests/installation/bootloader_ofw.pm
+++ b/tests/installation/bootloader_ofw.pm
@@ -15,6 +15,7 @@ use Time::HiRes qw(sleep);
 
 use testapi;
 use registration;
+use utils;
 
 # hint: press shift-f10 trice for highest debug level
 sub run() {
@@ -48,10 +49,10 @@ sub run() {
             my $args = "";
             # load kernel manually with append
             if (check_var('VIDEOMODE', 'text')) {
-                type_string " textmode=1", 15;
+                type_string_slow ' textmode=1';
             }
             if (get_var("NETBOOT") && get_var("SUSEMIRROR")) {
-                type_string " install=http://" . get_var("SUSEMIRROR"), 15;
+                type_string_slow ' install=http://' . get_var("SUSEMIRROR");
             }
             if (get_var("AUTOYAST") || get_var("AUTOUPGRADE")) {
                 my $netsetup = " ifcfg=*=dhcp";    #need this instead of netsetup as default, see bsc#932692
@@ -65,15 +66,15 @@ sub run() {
                 $args .= " autoupgrade=1";
             }
 
-            type_string $args, 13;
+            type_string_slow $args;
 
             if (get_var("FIPS")) {
-                type_string " fips=1", 13;
+                type_string_slow ' fips=1';
                 save_screenshot;
             }
 
             save_screenshot;
-            registration_bootloader_params;
+            registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
             send_key "ctrl-x";
         }
     }

--- a/tests/installation/bootloader_ofw_yaboot.pm
+++ b/tests/installation/bootloader_ofw_yaboot.pm
@@ -11,13 +11,14 @@
 use base "installbasetest";
 use strict;
 use testapi;
+use utils;
 use Time::HiRes qw(sleep);
 
 # hint: press shift-f10 trice for highest debug level
 sub run() {
     assert_screen "bootloader-ofw-yaboot", 15;
     if (check_var('VIDEOMODE', 'text')) {
-        type_string "install textmode=1", 15;
+        type_string_slow 'install textmode=1';
     }
     send_key "ret";
 }

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -91,13 +91,9 @@ sub run() {
     for (1 .. 4) { send_key "down"; }
     send_key "end";
 
-    # USB kbd in raw mode is rather slow and QEMU only buffers 16 bytes, so
-    # we need to type very slowly to not lose keypresses.
-    my $slow_typing_speed = 13;
-
     if (get_var("NETBOOT") && get_var("SUSEMIRROR")) {
         assert_screen('no_install_url');
-        type_string " install=http://" . get_var("SUSEMIRROR"), $slow_typing_speed;
+        type_string_slow " install=http://" . get_var("SUSEMIRROR");
         save_screenshot();
     }
     send_key "spc";
@@ -107,52 +103,52 @@ sub run() {
     # }
 
     if (check_var('VIDEOMODE', "text")) {
-        type_string "textmode=1 ", $slow_typing_speed;
+        type_string_slow "textmode=1 ";
     }
 
     type_string " \\\n";    # changed the line before typing video params
                             # https://wiki.archlinux.org/index.php/Kernel_Mode_Setting#Forcing_modes_and_EDID
-    type_string "Y2DEBUG=1 ", $slow_typing_speed;
+    type_string_slow 'Y2DEBUG=1 ';
     if (!is_jeos && (check_var('ARCH', 'i586') || check_var('ARCH', 'x86_64'))) {
-        type_string "vga=791 ";
-        type_string "video=1024x768-16 ", $slow_typing_speed;
+        type_string_slow 'vga=791 ';
+        type_string_slow 'video=1024x768-16 ';
 
         # not needed anymore atm as cirrus has 1024 as default now:
         # https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=121a6a17439b000b9699c3fa876636db20fa4107
         #type_string "drm_kms_helper.edid_firmware=edid/1024x768.bin ";
-        assert_screen "inst-video-typed-grub2", $slow_typing_speed;
+        assert_screen "inst-video-typed-grub2";
     }
 
     if (!get_var("NICEVIDEO") && !is_jeos) {
-        type_string "plymouth.ignore-serial-consoles ", $slow_typing_speed;    # make plymouth go graphical
-        type_string "linuxrc.log=$serialdev ",          $slow_typing_speed;    # to get linuxrc logs in serial
-        type_string " \\\n";                                                   # changed the line before typing video params
-        type_string "console=$serialdev ",         $slow_typing_speed;         # to get crash dumps as text
-        type_string "console=tty ",                $slow_typing_speed;         # to get crash dumps as text
+        type_string_slow "plymouth.ignore-serial-consoles ";    # make plymouth go graphical
+        type_string_slow "linuxrc.log=$serialdev ";             # to get linuxrc logs in serial
+        type_string " \\\n";                                    # changed the line before typing video params
+        type_string_slow "console=$serialdev ";                 # to get crash dumps as text
+        type_string_slow "console=tty ";                        # to get crash dumps as text
         assert_screen "inst-consolesettingstyped", 10;
         my $e = get_var("EXTRABOOTPARAMS");
         if ($e) {
-            type_string "$e ", 4;
+            type_string_very_slow "$e ";
             save_screenshot;
         }
     }
 
-    #type_string "kiwidebug=1 ", $slow_typing_speed;
+    #type_string_slow 'kiwidebug=1 ';
 
     my $args = "";
     if (get_var("AUTOYAST")) {
         $args .= " ifcfg=*=dhcp ";
         $args .= "autoyast=" . autoinst_url . "/data/" . get_var("AUTOYAST") . " ";
     }
-    type_string $args, $slow_typing_speed;
+    type_string_slow $args;
     save_screenshot;
 
     if (get_var("FIPS")) {
-        type_string " fips=1", $slow_typing_speed;
+        type_string_slow ' fips=1';
         save_screenshot;
     }
 
-    registration_bootloader_params;
+    registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
 
     # boot
     send_key "f10";


### PR DESCRIPTION
Rework existing bootloader files to use the same approach for slow typing.
Actual typing speeds have been adjusted where deemed useful, e.g. from "15" to
"13" to use a common value. The registration parameters are now consistently
typed slower to ensure the long URL is typed slower and safer. This change
will make the code consistent, could help with uefi and ofw related problems
although none have been observed lately and only increases the test time by an
tiny amount if at all.