### PR TITLE
Configure ddns on support server

### DIFF
--- a/data/supportserver/named/2.0.10.in-addr.arpa.zone
+++ b/data/supportserver/named/2.0.10.in-addr.arpa.zone
@@ -1,0 +1,11 @@
+$TTL 3600
+@          IN   SOA     ns.openqa.test.  ns.openqa.test. (
+                                2016020901   ; serial number
+                                1200          ; refresh
+                                600          ; retry
+                                7D        ; expire
+                                3600       ) ; minimum TTL
+@          NS      ns.openqa.test.
+
+$ORIGIN 2.0.10.in-addr.arpa.
+1          PTR     ns.openqa.test.

--- a/data/supportserver/named/openqa.test.zone
+++ b/data/supportserver/named/openqa.test.zone
@@ -1,0 +1,11 @@
+$TTL 3600
+$ORIGIN openqa.test.
+@          IN   SOA     ns.openqa.test.  ns.openqa.test. (
+                                2016020901   ; serial number
+                                1200          ; refresh
+                                600          ; retry
+                                7D        ; expire
+                                3600       ) ; minimum TTL
+@          NS      ns.openqa.test.
+ns         IN      A       10.0.2.1
+

--- a/data/supportserver/named/openqa.zones
+++ b/data/supportserver/named/openqa.zones
@@ -1,0 +1,11 @@
+zone "openqa.test" IN {
+  type master;
+  file "master/openqa.test.zone";
+  allow-update { 127.0.0.1; };
+};
+
+zone "2.0.10.in-addr.arpa" IN {
+  type master;
+  file "master/2.0.10.in-addr.arpa.zone";
+  allow-update { 127.0.0.1; };
+};


### PR DESCRIPTION
With this configuration the DNS on support server can resolve hostnames of DHCP clients.
It simplifies writing of multimachine tests.

So far it supports only the 10.0.2.0/24 range.