### PR TITLE
textinfo: sort rpm output of all packages

### DIFF
--- a/data/textinfo
+++ b/data/textinfo
@@ -31,7 +31,7 @@ du /var/log/messages
 ps ax 
 
 systemctl --no-pager --full
-rpm -qa
+rpm -qa | sort
 
 journalctl -a --no-full -m > /var/log/journal.dump
 


### PR DESCRIPTION
When one actually needs this list to compare things, it's really helpful to have the info sorted.