### PR TITLE
Force 1024x768 after reboot

### DIFF
--- a/tests/jeos/grub2_gfxmode.pm
+++ b/tests/jeos/grub2_gfxmode.pm
@@ -16,7 +16,13 @@ use strict;
 use testapi;
 
 sub run {
-    assert_script_run("sed -ie '/GFXPAYLOAD_LINUX=/s/=.*/=1024x768/' /etc/default/grub && grub2-mkconfig -o /boot/grub2/grub.cfg");
+    if (check_var('UEFI', '1')) {
+        assert_script_run("sed -ie '/GRUB_GFXMODE=/s/=.*/=1024x768/' /etc/default/grub && grub2-mkconfig -o /boot/grub2/grub.cfg");
+        # workaround kiwi quirk bnc#968270, bnc#968264
+        assert_script_run("rm -rf /boot/efi/EFI; sed -ie 's/which/echo/' /usr/sbin/shim-install && shim-install");
+    } else {
+        assert_script_run("sed -ie '/GFXPAYLOAD_LINUX=/s/=.*/=1024x768/' /etc/default/grub && grub2-mkconfig -o /boot/grub2/grub.cfg");
+    }
 }
 
 sub test_flags() {


### PR DESCRIPTION
As explained in commit d75924cf3d18eafb5ff8be372064654ea32b9e82 we need
to make grub come up in 1024x768 to get the proper resolution when kms
is not used.

We also need to reset the EFI boot partition to work around how KIWI
does things and a bug in shim-install.

https://bugzilla.suse.com/show_bug.cgi?id=968270
https://bugzilla.suse.com/show_bug.cgi?id=968264