### PR TITLE
Update case 12.1 - 12.3: Also accept that predictable/persistant naming

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -31,10 +31,11 @@ sub run() {
     # Export the existing status of running tasks for future reference (fail would export it again)
     script_run "ps axf > /tmp/psaxf_consoletest_setup.log";
 
-    # openSUSE 13.2's systemd has broken rules for virtio-net, not applying predictable names (despite being configured)
+    # openSUSE 13.2's (and earlier) systemd has broken rules for virtio-net, not applying predictable names (despite being configured)
     # A maintenance update breaking networking names sounds worse than just accepting that 13.2 -> TW breaks
     # At this point, the system has been upadted, but our network interface changes name (thus we lost network connection)
-    if (check_var('HDDVERSION', "openSUSE-13.2")) {    # copy eth0 network config to ens4
+    my @old_hdds = qw/openSUSE_12.1 openSUSE_12.2 openSUSE_12.3 openSUSE_13.1 openSUSE_13.2/;
+    if (grep { check_var('HDDVERSION', $_) } @old_hdds) {    # copy eth0 network config to ens4
         script_run("cp /etc/sysconfig/network/ifcfg-eth0 /etc/sysconfig/network/ifcfg-ens4");
         script_run("/sbin/ifup ens4");
     }


### PR DESCRIPTION
for network devices did not work.

Should help with the current 12.2 update fail: https://openqa.opensuse.org/tests/124289/modules/consoletest_setup/steps/19 (after I got the installer to work again)