### PR TITLE
Select UEFI boot device in BIOS

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -856,6 +856,9 @@ else {
         load_zdup_tests();
     }
     elsif (get_var("BOOT_HDD_IMAGE")) {
+        if (get_var('UEFI') && get_var('BOOTFROM')) {
+            loadtest "boot/uefi_bootmenu.pm";
+        }
         loadtest "boot/boot_to_desktop.pm";
         if (get_var("ISCSI_SERVER")) {
             set_var('INSTALLONLY', 1);

--- a/tests/boot/uefi_bootmenu.pm
+++ b/tests/boot/uefi_bootmenu.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "basetest";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    send_key_until_needlematch("ovmf-mainscreen", 'delete', 5, 1);
+    send_key 'down';
+    send_key 'down';    # boot manager
+    send_key 'ret';
+    if (check_var('BOOTFROM', 'd')) {
+        send_key_until_needlematch("ovmf-boot-DVD", 'down', 5, 1);
+    }
+    elsif (check_var('BOOTFROM', 'c')) {
+        send_key_until_needlematch("ovmf-boot-HDD", 'down', 5, 1);
+    }
+    else {
+        die "BOOTFROM value not supported";
+    }
+    send_key 'ret';
+}
+
+sub test_flags() {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
OVMF doesn't honor the -boot XX setting of qemu so we have to manually enter the boot manager in the BIOS