### PR TITLE
Add test_flags fatal=1,milestone to grub_test

### DIFF
--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -32,5 +32,9 @@ sub run() {
     # avoid timeout for booting to HDD
     send_key 'ret';
 }
+sub test_flags() {
+    return {fatal => 1};
+}
+
 1;
 # vim: set sw=4 et:


### PR DESCRIPTION
Since this test is important,stop the test if something go wrong.