### PR TITLE
Test if login manager is usable with many users

### DIFF
--- a/data/create_users
+++ b/data/create_users
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+n_users="$1"
+encrypted_password="$2"
+
+for i in `seq 1 $n_users` ; do
+	num=`printf "%02d" $i`
+	useradd -m -c "User #${num}" -p "$encrypted_password" "user${i}"
+done

--- a/data/delete_users
+++ b/data/delete_users
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+n_users="$1"
+
+for i in `seq 1 $n_users` ; do
+	num=`printf "%02d" $i`
+	userdel -rf "user${i}"
+done

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -590,6 +590,9 @@ sub load_extra_test () {
     loadtest "console/consoletest_finish.pm";
 
     # start extra x11 tests from here
+    if (!get_var("NOAUTOLOGIN")) {
+        loadtest "x11/multi_users_dm.pm";
+    }
 
 }
 

--- a/products/opensuse/templates
+++ b/products/opensuse/templates
@@ -3220,6 +3220,22 @@
                       ],
                     },
                     {
+                      name => "install-xfce-image",
+                      settings => [
+                        { key => "DESKTOP", value => "xfce" },
+                        { key => "INSTALLONLY", value => 1 },
+                        { key => "STORE_HDD_1", value => "xfce_image.qcow2" },
+                      ],
+                    },
+                    {
+                      name => "install-lxde-image",
+                      settings => [
+                        { key => "DESKTOP", value => "lxde" },
+                        { key => "INSTALLONLY", value => 1 },
+                        { key => "STORE_HDD_1", value => "lxde_image.qcow2" },
+                      ],
+                    },
+                    {
                       name => "sysauth",
                       settings => [
                         { key => "DESKTOP", value => "kde" },
@@ -3256,6 +3272,36 @@
                         { key => "DESKTOP", value => "gnome" },
                         { key => "HDD_1", value => "gnome_image.qcow2" },
                         { key => "START_AFTER_TEST", value => "install-gnome-image" },
+                        { key => "EXTRATEST", value => 1 },
+                      ],
+                    },
+                    {
+                      name => "extra_tests_on_kde",
+                      settings => [
+                        { key => "BOOT_HDD_IMAGE", value => 1 },
+                        { key => "DESKTOP", value => "kde" },
+                        { key => "HDD_1", value => "kde_image.qcow2" },
+                        { key => "START_AFTER_TEST", value => "install-kde-image" },
+                        { key => "EXTRATEST", value => 1 },
+                      ],
+                    },
+                    {
+                      name => "extra_tests_on_xfce",
+                      settings => [
+                        { key => "BOOT_HDD_IMAGE", value => 1 },
+                        { key => "DESKTOP", value => "xfce" },
+                        { key => "HDD_1", value => "xfce_image.qcow2" },
+                        { key => "START_AFTER_TEST", value => "install-xfce-image" },
+                        { key => "EXTRATEST", value => 1 },
+                      ],
+                    },
+                    {
+                      name => "extra_tests_on_lxde",
+                      settings => [
+                        { key => "BOOT_HDD_IMAGE", value => 1 },
+                        { key => "DESKTOP", value => "lxde" },
+                        { key => "HDD_1", value => "lxde_image.qcow2" },
+                        { key => "START_AFTER_TEST", value => "install-lxde-image" },
                         { key => "EXTRATEST", value => 1 },
                       ],
                     },

--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -1,0 +1,59 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# This test checks if many users make the login manager hard to use
+# i.e. if it takes more than one click to access the username text field
+
+use base "x11test";
+use testapi;
+
+sub ensure_multi_user_target {
+    type_string "systemctl isolate multi-user.target\n";
+    reset_consoles;
+    wait_still_screen 10;
+    # isolating multi-user.target logs us out
+    select_console 'root-console';
+}
+
+sub ensure_graphical_target {
+    type_string "systemctl isolate graphical.target\n";
+    reset_consoles;
+}
+
+sub restart_x11 {
+    ensure_multi_user_target;
+    ensure_graphical_target;
+}
+
+sub run() {
+    my $self = shift;
+
+    my $users_to_create = 100;
+    my $encrypted_password = crypt($password, "abcsalt");
+
+    # login
+    select_console 'root-console';
+
+    # disable autologin
+    script_run "cp /etc/sysconfig/displaymanager /etc/sysconfig/displaymanager.back";
+    script_run "sed -i 's/^DISPLAYMANAGER_AUTOLOGIN.*\$/DISPLAYMANAGER_AUTOLOGIN=\"\"/' /etc/sysconfig/displaymanager";
+    script_run "/home/$username/data/create_users $users_to_create \"$encrypted_password\"";
+    restart_x11;
+
+    assert_screen "multi_users_dm";
+
+    # restore previous config
+    select_console 'root-console';
+    script_run "cp /etc/sysconfig/displaymanager.back /etc/sysconfig/displaymanager";
+    script_run "/home/$username/data/delete_users $users_to_create";
+    restart_x11;
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
https://progress.opensuse.org/issues/9694

The test will succeed for kde, gnome and lxde.
It will fail for xfce, because the xfce login manager is not very nice to use with many users.
It won't run for xdm because it's pointless.