### PR TITLE
Fix bootloader test with BOOT_HDD_IMAGE

### DIFF
--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -32,14 +32,15 @@ sub run() {
         send_key(2 + get_var("NUMDISKS"));
     }
 
-    assert_screen "inst-bootmenu", 15;
-    if (get_var('ZDUP')) {
-        send_key 'ret';    # boot from hard disk
+    if (get_var('BOOT_HDD_IMAGE')) {
+        assert_screen 'grub2', 15;    # Use the same bootloader needle as in grub-test
+        send_key 'ret';               # boot from hd
         return;
     }
 
-    if (get_var("BOOT_HDD_IMAGE")) {
-        send_key "ret";    # boot from hd
+    assert_screen 'inst-bootmenu', 15;
+    if (get_var('ZDUP')) {
+        send_key 'ret';               # boot from hard disk
         return;
     }
 


### PR DESCRIPTION
In case of tests running with BOOT_HDD_IMAGE, we default to boot directly
from the disk, without first booting the DVD. Test for the grub2 bootloader
to appear before checking for the DVD installer bootloader.