### PR TITLE
[qa_automation] Switch to openqa-customized run script

### DIFF
--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -78,7 +78,7 @@ sub start_testrun {
     $self->create_qaset_config();
     assert_script_run "/usr/share/qa/qaset/qaset reset";
     my $testsuite = $self->test_suite();
-    assert_script_run "/usr/share/qa/qaset/run/$testsuite-run";
+    assert_script_run "/usr/share/qa/qaset/run/$testsuite-run.openqa";
 }
 
 # Check whether DONE file exists every $interval secs in the background


### PR DESCRIPTION
The openqa-customized run script skips adding SDK repo during testing, since openQA already added it.