### PR TITLE
Make APPTESTS a boolean

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -143,7 +143,8 @@ if (!$options{verify}) {
                             # check if the package conflicts with one of
                             # the packages we asked to install. If so
                             # remove the other one and repeat.
-                            if ($requested{$pkg} && $pkg =~ /branding/) {
+                            if ($requested{$pkg} &&
+                                ($pkg =~ /branding/ || $p->str =~ /nothing provides this-is-only-for-build-envs/)) {
                                 print STDERR "++ skipping $pkg and retry\n";
                                 delete $requested{$pkg};
                                 next REPEAT;


### PR DESCRIPTION
main.pm is more flexible to choose which tests are needed to run
application tests or to install online updates. So don't inject that
list externally via APPTESTS but let main.pm decide based on
$INSTALL_PACKAGES