### PR TITLE
Type ADDONURL in the URL field, Reponame can be blank, autofilled

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -76,10 +76,9 @@ sub run() {
             send_key 'alt-u';                                             # specify url
             send_key 'alt-n';
             assert_screen 'addonurl-entry';
-            type_string get_var("ADDONURL_$uc_addon");                    # repo URL
-            send_key 'alt-e';                                             # repo name
-            type_string "$addon" . "_repo";
-            send_key 'alt-n';
+            send_key 'alt-u';                                             # select URL field
+            type_string "$addon";                                         # repo URL
+            send_key 'alt-n', 2;
             assert_screen 'addon-products';
             send_key "tab", 1;                                            # select addon-products-$addon
             if (check_var('VIDEOMODE', 'text')) {                         # textmode need more tabs, depends on add-on count


### PR DESCRIPTION
Was playing around with the ADDONURL variable, turns out that YaST in openSUSE and SLE don't work the way this code was written

This PR fixes that :)

Repo name field is not needed as yast autopopulates it if only a URL is provided