### PR TITLE
Support installation testing of SLE 12 with untested maint updates

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -402,6 +402,9 @@ sub load_inst_tests() {
         else {
             loadtest "installation/skip_registration.pm";
         }
+        if (get_var('MAINT_TEST_REPO')) {
+            loadtest 'installation/add_update_test_repo.pm';
+        }
         loadtest "installation/addon_products_sle.pm";
     }
     if (noupdatestep_is_applicable && get_var("LIVECD")) {

--- a/tests/installation/add_update_test_repo.pm
+++ b/tests/installation/add_update_test_repo.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use strict;
+use base "y2logsstep";
+use testapi;
+
+sub run() {
+    my $self = shift;
+    assert_screen 'inst-addon';
+    send_key 'alt-k';    # install with a maint update repo
+    foreach my $maintrepo (split(/,/, get_var('MAINT_TEST_REPO'))) {
+        assert_screen 'addon-menu-active';
+        send_key 'alt-u';    # specify url
+        send_key 'alt-n';
+        assert_screen 'addonurl-entry';
+        send_key 'alt-u';    # select URL field
+        type_string "$maintrepo";
+        send_key 'alt-n';
+        assert_screen 'addon-products';
+        if ((split(/,/, get_var('MAINT_TEST_REPO')))[-1] ne $maintrepo) {    # if $maintrepo is not first from all maint test repos
+            send_key 'alt-a';                                                # add another repo
+        }
+    }
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -15,12 +15,18 @@ use testapi;
 sub run() {
     my $self = shift;
 
-    assert_screen 'inst-addon';
+    assert_screen [qw/inst-addon addon-products/];
     if (get_var("ADDONS")) {
-        send_key 'alt-k', 3;    # install with addons
+        if (match_has_tag('inst-addon')) {
+            send_key 'alt-k';    # install with addons
+        }
+        else {
+            send_key 'alt-a';
+        }
         foreach my $addon (split(/,/, get_var('ADDONS'))) {
+            assert_screen 'addon-menu-active';
             send_key 'alt-d', 3;    # DVD
-            send_key 'alt-n', 3;
+            send_key 'alt-n';
             assert_screen 'dvd-selector';
             send_key_until_needlematch 'addon-dvd-list',   'tab',  10;    # jump into addon list
             send_key_until_needlematch "addon-dvd-$addon", 'down', 10;    # select addon in list
@@ -50,16 +56,22 @@ sub run() {
             send_key "pgup",                                    1;
             send_key_until_needlematch "addon-products-$addon", 'down';
             if ((split(/,/, get_var('ADDONS')))[-1] ne $addon) {          # if $addon is not first from all ADDONS
-                send_key 'alt-a', 2;                                      # add another add-on
+                send_key 'alt-a';                                         # add another add-on
             }
             else {
-                send_key 'alt-n', 2;                                      # next
+                send_key 'alt-n';                                         # next
             }
         }
     }
     elsif (get_var("ADDONURL")) {
-        send_key 'alt-k';                                                 # install with addons
+        if (match_has_tag('inst-addon')) {
+            send_key 'alt-k';                                             # install with addons
+        }
+        else {
+            send_key 'alt-a';
+        }
         foreach my $addon (split(/,/, get_var('ADDONURL'))) {
+            assert_screen 'addon-menu-active';
             my $uc_addon = uc $addon;                                     # varibale name is upper case
             send_key 'alt-u';                                             # specify url
             send_key 'alt-n';
@@ -67,7 +79,7 @@ sub run() {
             type_string get_var("ADDONURL_$uc_addon");                    # repo URL
             send_key 'alt-e';                                             # repo name
             type_string "$addon" . "_repo";
-            send_key 'alt-n', 2;
+            send_key 'alt-n';
             assert_screen 'addon-products';
             send_key "tab", 1;                                            # select addon-products-$addon
             if (check_var('VIDEOMODE', 'text')) {                         # textmode need more tabs, depends on add-on count
@@ -76,10 +88,10 @@ sub run() {
             send_key "pgup",                                    1;
             send_key_until_needlematch "addon-products-$addon", 'down';
             if ((split(/,/, get_var('ADDONURL')))[-1] ne $addon) {        # if $addon is not first from all ADDONS
-                send_key 'alt-a', 2;                                      # add another add-on
+                send_key 'alt-a';                                         # add another add-on
             }
             else {
-                send_key 'alt-n', 2;                                      # next
+                send_key 'alt-n';                                         # next
             }
         }
     }


### PR DESCRIPTION
Based on experiments seen here https://openqa.suse.de/tests/284315 (hotfixes that made this possible since reverted) this PR allows jobs that will install SLE 12 with the latest released and untested maint updates

Test suites in the DB require the following vars
(new) MAINT_TEST_REPO - the full URL of the build service repo containing untested maintenance updates
SCC_REGISTER = installation
SCC_EMAIL
SCC_REGCODE

Besides that, should work with whatever scenarios we pick - tested with just default so far.

Needles all already exist, most inherited from the addon_products_sle module which runs afterwards

This is running before addon_products_sle because addon_products_sle assumes it is in charge of going to the next step in the flow, and it's way harder to make this take over that role given it's conditional nature.