### PR TITLE
Add 4 more kernel regression testsuits

### DIFF
--- a/tests/qa_automation/kernel_libhugetlbfs.pm
+++ b/tests/qa_automation/kernel_libhugetlbfs.pm
@@ -1,0 +1,31 @@
+# Copyright (C) 2016 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use base "qa_run";
+use testapi;
+
+sub test_run_list() {
+    return qw(_reboot_off libhugetlbfs);
+}
+
+sub test_suite() {
+    return 'kernel';
+}
+
+sub junit_type() {
+    return 'kernel_regression';
+}
+
+1;

--- a/tests/qa_automation/kernel_lmbench.pm
+++ b/tests/qa_automation/kernel_lmbench.pm
@@ -1,0 +1,31 @@
+# Copyright (C) 2016 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use base "qa_run";
+use testapi;
+
+sub test_run_list() {
+    return qw(_reboot_off lmbench);
+}
+
+sub test_suite() {
+    return 'kernel';
+}
+
+sub junit_type() {
+    return 'kernel_regression';
+}
+
+1;

--- a/tests/qa_automation/kernel_lvm2_120.pm
+++ b/tests/qa_automation/kernel_lvm2_120.pm
@@ -1,0 +1,31 @@
+# Copyright (C) 2016 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use base "qa_run";
+use testapi;
+
+sub test_run_list() {
+    return qw(_reboot_off lvm2_2_02_120);
+}
+
+sub test_suite() {
+    return 'kernel';
+}
+
+sub junit_type() {
+    return 'kernel_regression';
+}
+
+1;

--- a/tests/qa_automation/kernel_lynis.pm
+++ b/tests/qa_automation/kernel_lynis.pm
@@ -1,0 +1,31 @@
+# Copyright (C) 2016 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use base "qa_run";
+use testapi;
+
+sub test_run_list() {
+    return qw(_reboot_off lynis);
+}
+
+sub test_suite() {
+    return 'kernel';
+}
+
+sub junit_type() {
+    return 'kernel_regression';
+}
+
+1;


### PR DESCRIPTION
Add following 4 testcases into kernel-regression test list, and the run time their need (all of them not take a lot of time):
libhugetlbfs 24s
lmbench 23m6s
lvm2 24m24s
lynis 5m3s
