### PR TITLE
Fix "paritioning" typo in partitioning_finish.pm

### DIFF
--- a/tests/installation/partitioning_finish.pm
+++ b/tests/installation/partitioning_finish.pm
@@ -15,7 +15,7 @@ use testapi;
 sub run() {
     wait_still_screen();
     send_key $cmd{"next"};
-    assert_screen "after-paritioning";
+    assert_screen "after-partitioning";
 }
 
 1;


### PR DESCRIPTION
See https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/64
https://progress.opensuse.org/issues/10300