### PR TITLE
Fix issue with already booted s390-guest

### DIFF
--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -16,7 +16,9 @@ sub run() {
     my $self = shift;
 
     if (check_var('DESKTOP', 'textmode') || get_var('BOOT_TO_SNAPSHOT')) {
-        assert_screen 'linux-login', 200;
+        if (!check_var('ARCH', 's390x')) {
+            assert_screen 'linux-login', 200;
+        }
         return;
     }
 


### PR DESCRIPTION
We don't need a linux-login, since we are already logged on after reconnect_s390