### PR TITLE
Don't install packages if there's nothing to do

### DIFF
--- a/tests/console/install_packages.pm
+++ b/tests/console/install_packages.pm
@@ -18,7 +18,7 @@ sub run() {
 
     assert_script_run("zypper -n in -l perl-solv");
     assert_script_run("~$username/data/lsmfip --verbose $packages > \$XDG_RUNTIME_DIR/install_packages.txt");
-    assert_script_run("xargs zypper -n in -l < \$XDG_RUNTIME_DIR/install_packages.txt");
+    assert_script_run("xargs --no-run-if-empty zypper -n in -l < \$XDG_RUNTIME_DIR/install_packages.txt");
     assert_script_run("rpm -q $packages | tee /dev/$serialdev");
 }
 


### PR DESCRIPTION
Sometimes all packages are already installed. Don't run zypper in
that case.