### PR TITLE
Detect Server/Desktop for maintenance flavours

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -90,11 +90,11 @@ sub cleanup_needles() {
 }
 
 sub is_server() {
-    return check_var('FLAVOR', 'Server-DVD') || check_var('FLAVOR', 'Server-MINI');
+    return check_var('FLAVOR', '') =~ /^Server/;
 }
 
 sub is_desktop() {
-    return check_var('FLAVOR', 'Desktop-DVD') || check_var('FLAVOR', 'Desktop-MINI');
+    return check_var('FLAVOR', '') =~ /^Desktop/;
 }
 
 sub is_jeos() {


### PR DESCRIPTION
SLE 12 Maintenance testing will require at least a similar setup to openSUSE, with different flavours for UpdateTest (testing unreleased updates), Updates (testing released updates), and Maintenance (testing individual incidents)

in openSUSE these are implemented  as different flavours of openSUSE used by the qam-openqa-tool

This is a good idea and we want the same in SLE, especially during the latter part of product testing where we will want to test maintenance updates while new versions of products are still being built - the existing method could lead to clashes leading to jobs being rescheduled needlessly and confusingly.

However SLE already has different flavours which dramatically impact the test flow, such as Server and Desktop, used throughout the main.pm in the `is_server` and `is_desktop` functions

This PR preserves the existing SLE 12 behaviour while expanding it so we can have flavours such as UpdateTest-Server-DVD which will go through the `is_server` main.pm route, and UpdateTest-Desktop-DVD which will go through the `is_desktop` main.pm route

This approach has the side benefit of being more consistent with how `is_jeos` is detected

With the PR we'll be able to run actual useful UpdateTest runs on openqa.suse.de for SLE 12 SP1 and possibly GA also. 