### PR TITLE
Do not run the releasenotes test on SP0 and SP1

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -66,6 +66,10 @@ sub is_staging () {
     return get_var('STAGING');
 }
 
+sub is_released_product() {
+    return check_var('VERSION', '12') || check_var('VERSION', '12-SP1');
+}
+
 sub cleanup_needles() {
     remove_desktop_needles("lxde");
     remove_desktop_needles("kde");
@@ -115,7 +119,6 @@ sub cleanup_needles() {
         unregister_needle_tags('ENV-OFW-1');
     }
 }
-
 
 #assert_screen "inst-bootmenu",12; # wait for welcome animation to finish
 
@@ -443,7 +446,11 @@ sub load_inst_tests() {
         }
         loadtest "installation/partitioning_finish.pm";
     }
-    loadtest "installation/releasenotes.pm";
+    if (!is_released_product) {
+        # the releasenotes for released products are not so interesting to verify
+        # and SP0 has no way to trigger the dialog without tabbing like mad (fixed in SP1)
+        loadtest "installation/releasenotes.pm";
+    }
     if (noupdatestep_is_applicable && !get_var("LIVECD")) {
         loadtest "installation/installer_timezone.pm";
     }


### PR DESCRIPTION
It would require a completely different code path for SP0 and the test
is pointless to what we want to test in maintenance