### PR TITLE
disable console/installation_snapshots on sle12

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -546,7 +546,7 @@ sub load_consoletests() {
             if (get_var("UPGRADE")) {
                 loadtest "console/upgrade_snapshots.pm";
             }
-            elsif (!get_var("ZDUP")) {    # zypper doesn't do upgrade or installation snapshots
+            elsif (!get_var("ZDUP") and !check_var('VERSION', '12')) {    # zypper and sle12 doesn't do upgrade or installation snapshots
                 loadtest "console/installation_snapshots.pm";
             }
             loadtest "console/snapper_undochange.pm";


### PR DESCRIPTION
SLE12 doesn't create installation snapshot --> this test always fail