### PR TITLE
Don't fail if network.service doesn't exist

### DIFF
--- a/tests/console/hostname.pm
+++ b/tests/console/hostname.pm
@@ -25,7 +25,7 @@ sub run() {
     # if you change hostname using `hostnamectl set-hostname`, then `hostname -f` will fail with "hostname: Name or service not known"
     # also DHCP/DNS don't know about the changed hostname, you need to send a new DHCP request to update dynamic DNS
     # yast2-network module does "NetworkService.ReloadOrRestart if Stage.normal || !Linuxrc.usessh" if hostname is changed via `yast2 lan`
-    assert_script_run "systemctl -q is-active network.service && systemctl reload-or-restart network.service";
+    assert_script_run "if systemctl -q is-active network.service; then systemctl reload-or-restart network.service; fi";
 }
 
 sub test_flags() {


### PR DESCRIPTION
If `systemctl -q is-active network.service` returns non-zero exit code, assert_script_run fails: https://openqa.opensuse.org/tests/130355/modules/hostname/steps/11