### PR TITLE
Ensure systemd knows of the service it checks with is-active

### DIFF
--- a/tests/console/hostname.pm
+++ b/tests/console/hostname.pm
@@ -25,6 +25,8 @@ sub run() {
     # if you change hostname using `hostnamectl set-hostname`, then `hostname -f` will fail with "hostname: Name or service not known"
     # also DHCP/DNS don't know about the changed hostname, you need to send a new DHCP request to update dynamic DNS
     # yast2-network module does "NetworkService.ReloadOrRestart if Stage.normal || !Linuxrc.usessh" if hostname is changed via `yast2 lan`
+    script_run "systemctl status network.service";
+    save_screenshot;
     assert_script_run "if systemctl -q is-active network.service; then systemctl reload-or-restart network.service; fi";
 }
 


### PR DESCRIPTION
We seem to be running in strange timing issues where
  systemctl is-active network.service
an return either 'unknown' or 'activating'. Both results have an
exit code 3, which stops the reload command.

By first querying the actual status, systemd seems to catch up with
reality and allowing to properly query it using is-active afterward.

I see this together with #1164 as solution

* This change ensure the status can properly be queried by is-active
* #1164 takes care of not failing when the service itself is not enabled / known
