### PR TITLE
Disable releasenotes on real hardware

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -446,7 +446,12 @@ sub load_inst_tests() {
         }
         loadtest "installation/partitioning_finish.pm";
     }
-    loadtest "installation/releasenotes.pm";
+    # the VNC gadget is too unreliable to click, but we
+    # need to be able to do installations on it. The release notes
+    # functionality needs to be covered by other backends
+    if (!check_var('BACKEND', 'generalhw')) {
+        loadtest "installation/releasenotes.pm";
+    }
     if (noupdatestep_is_applicable) {
         loadtest "installation/installer_timezone.pm";
         loadtest "installation/logpackages.pm";


### PR DESCRIPTION
For SLE12 GA we need to click, but our generalhw backend is unable to do
reliable clicks (at least for now, possibly this can be fixed later), but
don't block the usage of the gadget