### PR TITLE
Adjust yast2 tests to check exit code

### DIFF
--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -20,10 +20,10 @@ sub run() {
 
     assert_script_run "zypper -n in yast2-bootloader";    # make sure yast2 bootloader module installed
 
-    script_run("/sbin/yast2 bootloader; echo YBL-$? > /dev/$serialdev", 0);
+    script_run("/sbin/yast2 bootloader; echo yast2-bootloader-status-$? > /dev/$serialdev", 0);
     assert_screen "test-yast2_bootloader-1", 300;
     send_key "alt-o";                                     # OK => Close
-    die "yastootloader failed" unless wait_serial "YBL-0";
+    wait_serial("yast2-bootloader-status-0") || die "'yast2 bootloader' didn't finish";
 }
 
 1;

--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -88,7 +88,7 @@ sub run() {
     }
 
     # yast might take a while on sle11 due to suseconfig
-    wait_serial("yast2-i-status-0", 60) || die "yast didn't finish";
+    wait_serial("yast2-i-status-0", 60) || die "'yast2 sw_single' didn't finish";
 
     clear_console;                           # clear screen to see that second update does not do any more
     assert_script_run("rpm -e $pkgname");    # erase $pkgname

--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -8,6 +8,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+
 use base "console_yasttest";
 use testapi;
 use utils;
@@ -26,7 +27,7 @@ sub run() {
     script_run('ls -alF /etc/sysconfig/network/');
     save_screenshot;
 
-    script_sudo("/sbin/yast2 lan", 0);
+    script_sudo("/sbin/yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev", 0);
 
     assert_screen [qw/Networkmanager_controlled yast2_lan install-susefirewall2/], 60;
     if (match_has_tag('Networkmanager_controlled')) {
@@ -37,7 +38,7 @@ sub run() {
             # SLED11...
             send_key 'alt-y';
         }
-        assert_screen 'yast2-lan-exited', 30;
+        wait_serial("yast2-lan-status-0", 60) || die "'yast2 lan' didn't finish";
         return;                                         # don't change any settings
     }
     if (match_has_tag('install-susefirewall2')) {
@@ -59,7 +60,7 @@ sub run() {
     assert_screen 'test-yast2_lan-1';
 
     send_key "alt-o";                                   # OK=>Save&Exit
-    assert_screen 'yast2-lan-exited', 90;
+    wait_serial("yast2-lan-status-0", 90) || die "'yast2 lan' didn't finish";
 
     clear_console;
     script_run('echo $?');


### PR DESCRIPTION
Adapted the behaviour of yast2_lan to the behaviour of other yast tests for checking exit code
e.g. script_run with output to serialdev and read the status from there

Improved and unified error messages in case of failing