### PR TITLE
Fix yast2_nfs_server test on SLE

### DIFF
--- a/tests/console/yast2_nfs_server.pm
+++ b/tests/console/yast2_nfs_server.pm
@@ -82,7 +82,8 @@ sub run() {
         assert_script_run 'mount 10.0.2.15:/ /mnt';
     }
 
-    validate_script_output "cat /mnt/file", sub { m,mounted, };
+    # Timeout of 95 seconds to account for the NFS server grace period
+    validate_script_output "cat /mnt/file", sub { m,mounted, }, 95;
     assert_script_run 'umount /mnt';
 
     if (get_var('NFSSERVER')) {


### PR DESCRIPTION
Successful test run: http://10.161.59.116/tests/602/modules/yast2_nfs_server/steps/29

- Increase timeout to include 90 second grace period
- Somehow worked on TW without this
- bsc#969515