### PR TITLE
Add common setup for x11regression tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -276,6 +276,7 @@ sub loadtest($) {
 }
 
 sub load_x11regresion_tests() {
+    loadtest "x11regressions/x11regressions_setup.pm";
     loadtest "x11regressions/firefox/sle12/firefox_smoke.pm";
     loadtest "x11regressions/firefox/sle12/firefox_localfiles.pm";
     loadtest "x11regressions/firefox/sle12/firefox_emaillink.pm";

--- a/tests/x11regressions/x11regressions_setup.pm
+++ b/tests/x11regressions/x11regressions_setup.pm
@@ -1,0 +1,36 @@
+# X11 regression tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "x11test";
+use strict;
+use testapi;
+
+sub run() {
+    my $self = shift;
+
+    x11_start_program("xterm");
+
+    # grant permission for default user to access serial port
+    type_string "xdg-su -c 'chown $username /dev/$serialdev'\n";
+    wait_still_screen;
+
+    if ($password) {
+        type_password;
+        send_key "ret";
+    }
+
+    wait_still_screen;
+    save_screenshot;
+
+    # quit xterm
+    type_string "exit\n";
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
This step put after installation and before all actural x11 regression tests which aims to setup some common configurations, such like granting user permission to access serial port or more in future.

It will fix the following wait_serial error and permit user to execute assert_script_run or script_run without permission issue.
https://openqa.suse.de/tests/296558/modules/tracker_info/steps/4