### PR TITLE
Update evolution_mail_ews.pm to fix address book auth failure

### DIFF
--- a/tests/x11regressions/evolution/evolution_mail_ews.pm
+++ b/tests/x11regressions/evolution/evolution_mail_ews.pm
@@ -65,7 +65,12 @@ sub run() {
     assert_screen "evolution_wizard-receiving-opts";
     assert_and_click "evolution_wizard-ews-enable-gal";
     assert_and_click "evolution_wizard-ews-fetch-abl";
-    assert_screen "evolution_wizard-ews-view-gal", 120;
+    assert_screen [qw/evolution_wizard-ews-view-gal evolution_mail-auth/], 120;
+    if (match_has_tag('evolution_mail-auth')) {
+        type_string "$mail_passwd";
+        send_key "ret";
+        assert_screen "evolution_wizard-ews-view-gal", 120;
+    }
     send_key "alt-o";
     assert_screen "evolution_wizard-account-summary";
     send_key "alt-o";


### PR DESCRIPTION
Sometimes the evolution_mail_ews.pm test case fails at step of
fetching the Global Address Book list, because it indicates
that the authentication is required but missing in test script.
Strange is the auth isn't really required for fetching the list
of address book when evolution is run in another environment.