### PR TITLE
Autoyast profile for autoupgrading sles12GM and sles12SP1 to sles12SP2

### DIFF
--- a/data/autoyast_sle12/autoyast_up_gnome_sle12.xml
+++ b/data/autoyast_sle12/autoyast_up_gnome_sle12.xml
@@ -1,0 +1,31 @@
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+<deploy_image>
+<image_installation config:type="boolean">false</image_installation>
+</deploy_image>
+<general>
+<ask-list config:type="list"/>
+<mode>
+<confirm config:type="boolean">false</confirm>
+<final_halt config:type="boolean">false</final_halt>
+<final_reboot config:type="boolean">false</final_reboot>
+<halt config:type="boolean">false</halt>
+<second_stage config:type="boolean">false</second_stage>
+</mode>
+<proposals config:type="list"/>
+<signature-handling>
+<accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+<accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+<accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+<accept_unsigned_file config:type="boolean">false</accept_unsigned_file>
+<accept_verification_failed config:type="boolean">false</accept_verification_failed>
+<import_gpg_key config:type="boolean">true</import_gpg_key>
+</signature-handling>
+<storage/>
+</general>
+<groups config:type="list"/>
+<login_settings/>
+<upgrade>
+<only_installed_packages config:type="boolean">true</only_installed_packages>
+<stop_on_solver_conflict config:type="boolean">true</stop_on_solver_conflict>
+</upgrade>
+</profile>

--- a/products/opensuse/templates
+++ b/products/opensuse/templates
@@ -2477,19 +2477,6 @@
                       test_suite => { name => "install-kde-image" },
                     },
                     {
-                      group_name => "openSUSE Tumbleweed",
-                      machine => { name => "64bit" },
-                      prio => 50,
-                      product => {
-                        arch    => "x86_64",
-                        distri  => "opensuse",
-                        flavor  => "DVD",
-                        group   => "opensuse-DVD",
-                        version => "*",
-                      },
-                      test_suite => { name => "sysauth" },
-                    },
-                    {
                       group_name => "Staging Projects",
                       machine => { name => "ppc64le" },
                       prio => 45,
@@ -3236,16 +3223,6 @@
                       ],
                     },
                     {
-                      name => "sysauth",
-                      settings => [
-                        { key => "DESKTOP", value => "kde" },
-                        { key => "SYSAUTHTEST", value => 1 },
-                        { key => "BOOT_HDD_IMAGE", value => 1 },
-                        { key => "START_AFTER_TEST", value => "install-kde-image" },
-                        { key => "HDD_1", value => "kde_image.qcow2" },
-                      ],
-                    },
-                    {
                       name => "install-gnome-image",
                       settings => [
                         { key => "DESKTOP", value => "gnome" },
@@ -3273,6 +3250,7 @@
                         { key => "HDD_1", value => "gnome_image.qcow2" },
                         { key => "START_AFTER_TEST", value => "install-gnome-image" },
                         { key => "EXTRATEST", value => 1 },
+                        { key => "SYSAUTHTEST", value => 1 },
                       ],
                     },
                     {
@@ -3283,6 +3261,7 @@
                         { key => "HDD_1", value => "kde_image.qcow2" },
                         { key => "START_AFTER_TEST", value => "install-kde-image" },
                         { key => "EXTRATEST", value => 1 },
+                        { key => "SYSAUTHTEST", value => 1 },
                       ],
                     },
                     {
@@ -3293,6 +3272,7 @@
                         { key => "HDD_1", value => "xfce_image.qcow2" },
                         { key => "START_AFTER_TEST", value => "install-xfce-image" },
                         { key => "EXTRATEST", value => 1 },
+                        { key => "SYSAUTHTEST", value => 1 },
                       ],
                     },
                     {
@@ -3303,6 +3283,7 @@
                         { key => "HDD_1", value => "lxde_image.qcow2" },
                         { key => "START_AFTER_TEST", value => "install-lxde-image" },
                         { key => "EXTRATEST", value => 1 },
+                        { key => "SYSAUTHTEST", value => 1 },
                       ],
                     },
                     {

--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -175,7 +175,7 @@ sub run() {
 
     # JUnit xml report
     my $junit_type = $self->junit_type();
-    assert_script_run "/usr/share/qa/qaset/bin/junit_xml_gen.py /var/log/qaset/log -s /var/log/qaset/submission -o /tmp/junit.xml -n '$junit_type'";
+    assert_script_run "/usr/share/qa/qaset/bin/junit_xml_gen.py -n '$junit_type' -d -o /tmp/junit.xml /var/log/qaset";
     parse_junit_log("/tmp/junit.xml");
 }
 


### PR DESCRIPTION
Please create two new testsuites named "autoupgrade_sle12_sp0" and "autoupgrade_sle12_sp1"
-   autoupgrade_sle12_sp0 test specific vars:
        HDD_1=SLES-12-gnome-x86_64.img
        AUTOYAST=autoyast_up_gnome_sle12.xml
-   autoupgrade_sle12_sp1 test specific vars:
        HDD_1=SLES-12SP1-x86_64.qcow2
        AUTOYAST=autoyast_up_gnome_sle12.xml

Examples: 
sles12GM to sles12sp1GM - http://crocodile.qa.suse.cz/tests/2182
sles12sp1GM to sles12sp2 - http://crocodile.qa.suse.cz/tests/2293