### PR TITLE
Fix yast2 scc failure

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -137,7 +137,7 @@ sub registration_bootloader_params {
 
 sub yast_scc_registration {
 
-    assert_script_run "yast2 scc";
+    type_string "yast2 scc; echo yast-scc-done-\$?- > /dev/$serialdev\n";
     assert_screen 'scc-registration', 30;
 
     fill_in_registration_data;


### PR DESCRIPTION
yast scc was always failed:

https://openqa.suse.de/tests/318490/modules/yast_scc/steps/2

wait_serial could not get return unless yast2 scc exit
using type_string to instead of assert_script_run