### PR TITLE
Fix the group name of serial port

### DIFF
--- a/tests/x11regressions/x11regressions_setup.pm
+++ b/tests/x11regressions/x11regressions_setup.pm
@@ -20,7 +20,7 @@ sub run() {
     script_sudo "chown $username /dev/$serialdev";
 
     # get permanent user permission to access serial port even if reboot
-    script_sudo "gpasswd -a $username dialout";
+    script_sudo "gpasswd -a $username tty";
 
     # quit xterm
     type_string "exit\n";


### PR DESCRIPTION
In openQA instance the group of serial ports is 'tty'. 