### PR TITLE
Get group name from the group of serial port

### DIFF
--- a/tests/x11regressions/x11regressions_setup.pm
+++ b/tests/x11regressions/x11regressions_setup.pm
@@ -20,7 +20,7 @@ sub run() {
     script_sudo "chown $username /dev/$serialdev";
 
     # get permanent user permission to access serial port even if reboot
-    script_sudo "gpasswd -a $username tty";
+    script_sudo "gpasswd -a $username \$(ls -l /dev/$serialdev | awk \"{print \\\$4}\")";
 
     # quit xterm
     type_string "exit\n";


### PR DESCRIPTION
Still failed even add user into 'tty' group
https://openqa.suse.de/tests/321774/modules/gnome_default_applications/steps/3

So remove fixed group name and get it based on the output of ls -l /dev/ttyS0 in openqa instance
Test result:
http://147.2.207.208/tests/933