### PR TITLE
fix issue for empathy_aim.pm

### DIFF
--- a/tests/x11regressions/empathy/empathy_aim.pm
+++ b/tests/x11regressions/empathy/empathy_aim.pm
@@ -40,7 +40,12 @@ sub run() {
     send_key "alt-d";
 
     # check status
-    assert_screen('empathy-aim-aim1-success', 30);
+    assert_screen [qw/popup-unlock-keyring empathy-aim-aim1-success/], 60;
+    if (match_has_tag("popup-unlock-keyring")) {
+        type_string "$password";
+        assert_and_click "empathy_aim-unclock-keyring";
+        assert_screen('empathy-aim-aim1-success', 30);
+    }
 
     # add another aim account- aim2
 


### PR DESCRIPTION
After setting the account information, in some environment, unlock-keyring popuped, adding code for handling this.

Test result: (local environment won't trigger failed scenario like openqa.suse.de, below result shows no regression introduced)
http://147.2.212.232/tests/525

