### PR TITLE
fix firefox_java.pm

### DIFF
--- a/tests/x11regressions/firefox/sle12/firefox_java.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_java.pm
@@ -23,6 +23,9 @@ sub run() {
         sleep 2;
         send_key "alt-d";
         type_string "http://www.java.com/en/download/installed.jsp?detect=jre\n";
+        if (check_screen("oracle-cookies-handling", 30)) {
+            assert_and_click "firefox-java-agree-and-proceed";
+        }
     }
 
     # Clean and Start Firefox

--- a/tests/x11regressions/gnomecase/change_password.pm
+++ b/tests/x11regressions/gnomecase/change_password.pm
@@ -50,6 +50,7 @@ sub reboot_system {
     }
     assert_screen "displaymanager", 200;
     send_key "ret";
+    wait_still_screen;
     type_string "$password";
     send_key "ret";
     assert_screen "generic-desktop";
@@ -93,8 +94,11 @@ sub change_pwd {
 
 sub add_user {
     assert_and_click "add-user";
-    send_key "alt-f";
     type_string "$newUser";
+    unless (assert_screen("input-username-test")) {
+        send_key "alt-f";
+        type_string "$newUser";
+    }
     assert_and_click "set-password-option";
     send_key "alt-p";
     type_string "$pwd4newUser";


### PR DESCRIPTION
 Add exceptional scenario handling: in some environment, oracle-cookie handing window will pop up, if so we should process with it.

Local test result: (failed scenario in openqa.suse.de not triggered in local, below result verified no regression introduced)
http://147.2.212.232/tests/511
http://147.2.212.232/tests/545