### PR TITLE
Add milestone flag to save x11regression setup

### DIFF
--- a/tests/x11regressions/x11regressions_setup.pm
+++ b/tests/x11regressions/x11regressions_setup.pm
@@ -26,5 +26,10 @@ sub run() {
     type_string "exit\n";
 }
 
+# add milestone flag to save setup in lastgood vm snapshot
+sub test_flags() {
+    return {milestone => 1};
+}
+
 1;
 # vim: set sw=4 et:


### PR DESCRIPTION
All setups will be saved in lastgood vm snapshot
If some tests failed, the setups would be still
effective after loading lastgood vm snapshot

Test result:
http://147.2.207.208/tests/981