### PR TITLE
Enable DNS on slenkins control node

### DIFF
--- a/script/import-slenkins-testsuite.pl
+++ b/script/import-slenkins-testsuite.pl
@@ -19,7 +19,7 @@ my $template_control = pp(
 
     {key => "SUPPORT_SERVER", value => 1},
 
-    {key => "SUPPORT_SERVER_ROLES", value => "dhcp"},
+    {key => "SUPPORT_SERVER_ROLES", value => "dhcp,dns"},
 
     #   this is a part of support server configuration
     #    {key => "SLENKINS_TESTSUITES_REPO", value => "http://download.suse.de/ibs/Devel:/SLEnkins:/testsuites/SLE_12_SP1/"},

--- a/tests/slenkins/slenkins_node.pm
+++ b/tests/slenkins/slenkins_node.pm
@@ -46,7 +46,13 @@ sub run {
     mutex_unlock('dhcp');
     configure_dhcp();
 
-    configure_static_dns(get_host_resolv_conf());
+    if ($control_settings->{"SUPPORT_SERVER_ROLES"} !~ /\bdns\b/) {
+        # dns on control node (supportserver) is not configured
+        # -> use external dns
+        configure_static_dns(get_host_resolv_conf());
+    }
+    # else use the supportserver dns configured via dhcp
+
     my $conf_script = "zypper -n --no-gpg-checks ar '" . get_var('SLENKINS_TESTSUITES_REPO') . "' slenkins_testsuites\n";
 
     if (get_var('SLENKINS_INSTALL')) {


### PR DESCRIPTION
This makes the SUT hostnames resolvable so hostname -f works.
It fixes slenkins-qa_test_subversion.
