### PR TITLE
Revert "Configure the serial line console on s390x"

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -243,13 +243,6 @@ sub init_consoles {
                 port     => 5901,
                 password => $testapi::password
             });
-        $self->add_console(
-            'iucvconn',
-            'ssh-iucvconn',
-            {
-                hostname => $hostname,
-                password => $testapi::password
-            });
 
         $self->add_console(
             'install-shell',


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#1178

this still breaks s390 tests unless the new serial behaviour is implemented...