### PR TITLE
Use proper condition structure to fix ppc64le RAID tests

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -164,7 +164,7 @@ sub run() {
         send_key 'down';     #should select first disk'
         wait_idle 5;
     }
-    if (get_var('UEFI')) {
+    elsif (get_var('UEFI')) {
         send_key 'alt-p';
         assert_screen 'partitioning-size';
         send_key 'ctrl-a';
@@ -186,7 +186,6 @@ sub run() {
         send_key 'down';     # should select first disk'
         wait_idle 5;
     }
-
     else {
         send_key "right";    # unfold disks
         send_key "down";     # select first disk


### PR DESCRIPTION
RAID test on ppc64le are failing because there is if condition for OFW and then another separate condition for UEFI with else, this else is doing another send key right + down
and then in System view is selected vda1 [1] instead of vda [2]

[1] https://openqa.suse.de/tests/332512/modules/partitioning_raid/steps/15
[2] https://openqa.suse.de/tests/332514/modules/partitioning_raid/steps/9
