### PR TITLE
Wait longer for needle with smaller counter

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -41,7 +41,7 @@ sub run() {
     if (@addons) {
         for $a (@addons) {
             next if ($a eq 'we');    # https://bugzilla.suse.com/show_bug.cgi?id=931003#c17
-            send_key_until_needlematch("release-notes-$a", 'right');
+            send_key_until_needlematch("release-notes-$a", 'right', 4, 60);
             send_key 'left';         # move back to first tab
             send_key 'left';
             send_key 'left';


### PR DESCRIPTION
there is no need to check for needle 20 (default) times when there are four keys left to get back on first tab
more time for assert screen, release notes need longer to apear when multiple add-ons are used
e.g. https://openqa.suse.de/tests/332317/modules/releasenotes/steps/2