### PR TITLE
Fix the regex in curl_https test againsti curl 7.48.0 update

### DIFF
--- a/tests/console/curl_https.pm
+++ b/tests/console/curl_https.pm
@@ -14,7 +14,7 @@ use testapi;
 # test for bug https://bugzilla.novell.com/show_bug.cgi?id=598574
 sub run() {
     select_console 'user-console';
-    validate_script_output('curl -v https://eu.httpbin.org/get 2>&1', sub { m,subjectAltName: eu.httpbin.org matched, });
+    validate_script_output('curl -v https://eu.httpbin.org/get 2>&1', sub { m,subjectAltName:[\w\s]+["]?eu.httpbin.org["]? matched, });
 }
 
 1;


### PR DESCRIPTION
Newer curl changing the output of subjectAltName to

*  subjectAltName: host "eu.httpbin.org" matched cert's "*.httpbin.org"

the regex in the curl_https have to update.

see https://openqa.opensuse.org/tests/137164/modules/curl_https/steps/7 and this regex should backward compatible(I supposed).