### PR TITLE
Revert workaround for bsc#963008 on s390

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -61,13 +61,6 @@ sub run() {
             send_key 'ret';
             assert_screen 'ssh-open';
         }
-
-        record_soft_failure 'bsc#963008';
-        if (!check_screen('firewall-disabled', 5)) {
-            send_key_until_needlematch 'firewall-enabled-selected', 'tab';
-            send_key 'ret';
-            assert_screen 'firewall-disabled';
-        }
     }
 }
 


### PR DESCRIPTION
bsc#963008 was fixed, so we can enable the firewall by default