### PR TITLE
Disable skip_disk_activation test for SP2

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -410,7 +410,7 @@ sub load_inst_tests() {
         if (check_var('BACKEND', 's390x')) {
             loadtest "installation/disk_activation.pm";
         }
-        else {
+        elsif (!check_var('VERSION', '12-SP2')) {
             loadtest "installation/skip_disk_activation.pm";
         }
     }


### PR DESCRIPTION
Since there is nothing to skip in SP2, disable skip_disk_activation