### PR TITLE
QAM Minimal test in openQA

### DIFF
--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -1,0 +1,49 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+package qam;
+
+use strict;
+
+use base "Exporter";
+use Exporter;
+
+use testapi;
+use utils;
+
+our @EXPORT = qw/capture_state system_login/;
+
+sub system_login {
+    wait_boot(textmode => 1);
+    assert_screen "text-login", 50;
+    type_string "root\n";
+    assert_screen "password-prompt", 10;
+    type_password;
+    type_string "\n";
+    sleep 2;
+
+    $testapi::distri->set_standard_prompt;
+}
+
+sub capture_state {
+    my ($state, $y2logs) = @_;
+    if ($y2logs) {    #save y2logs if needed
+        assert_script_run "save_y2logs /tmp/y2logs_$state.tar.bz2";
+        upload_logs "/tmp/y2logs_$state.tar.bz2";
+        save_screenshot();
+    }
+    script_run("ip a | tee /tmp/ip_a_$state.log");
+    upload_logs("/tmp/ip_a_$state.log");
+    save_screenshot();
+    script_run("ip r | tee /tmp/ip_r_$state.log");
+    upload_logs("/tmp/ip_r_$state.log");
+    save_screenshot();
+}
+
+1;

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -53,7 +53,13 @@ sub fill_in_registration_data {
                 next;
             }
             elsif (match_has_tag("registration-online-repos")) {
-                send_key "alt-y", 1;        # want updates
+                if (!get_var('QAM_MINIMAL')) {
+                    send_key "alt-y", 1;    # want updates
+                }
+                else {
+                    send_key "alt-n", 1;    # minimal dont want updates
+                }
+
                 @tags = grep { $_ ne 'registration-online-repos' } @tags;
                 next;
             }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -503,7 +503,7 @@ sub load_reboot_tests() {
     if (uses_qa_net_hardware) {
         loadtest "boot/qa_net_boot_from_hdd.pm";
     }
-    if (installyaststep_is_applicable) {
+    if (installyaststep_is_applicable and !get_var("QAM_MINIMAL")) {
         # test makes no sense on s390 because grub2 can't be captured
         if (!check_var("ARCH", "s390x")) {
             loadtest "installation/grub_test.pm";
@@ -926,6 +926,17 @@ elsif (get_var("QA_TESTSET")) {
         loadtest "qa_automation/patch_and_reboot.pm";
     }
     loadtest "qa_automation/" . get_var("QA_TESTSET") . ".pm";
+}
+elsif (get_var("QAM_MINIMAL")) {
+    prepare_target();
+    loadtest "qam-minimal/install_update.pm";
+    loadtest "qam-minimal/update_minimal.pm";
+    loadtest "qam-minimal/check_logs.pm";
+    if (check_var("QAM_MINIMAL", 'full')) {
+        loadtest "qam-minimal/install_patterns.pm";
+        load_consoletests();
+        load_x11tests();
+    }
 }
 elsif (get_var("EXTRATEST")) {
     prepare_target();

--- a/tests/qam-minimal/check_logs.pm
+++ b/tests/qam-minimal/check_logs.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+#package install_update;
+
+use base "consoletest";
+
+use strict;
+
+use qam;
+use testapi;
+
+sub run {
+    system_login;
+
+    assert_script_run("cmp -s /tmp/ip_a_before.log /tmp/ip_a_after.log");
+    assert_script_run("cmp -s /tmp/ip_r_before.log /tmp/ip_r_after.log");
+}
+
+sub flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/qam-minimal/install_patterns.pm
+++ b/tests/qam-minimal/install_patterns.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+#package install_update;
+
+use base "basetest";
+
+use strict;
+
+use qam;
+use testapi;
+use utils;
+
+sub run {
+
+    script_run("while pgrep packagekitd; do pkcon quit; sleep 1; done");
+
+    assert_script_run("zypper ref");
+
+    script_run("zypper pt");
+    save_screenshot;
+
+    script_run("zypper -n in -t pattern base x11 gnome-basic apparmor; echo 'installed-patterns-\$?' > /dev/$serialdev", 0);
+
+    my $ret = wait_serial "installed-patterns-\?-", 1500;
+    $ret =~ /installed-patterns-(\d+)/;
+    die "zypper failed with code $1" unless $1 == 0 || $1 == 102;
+
+    assert_script_run("systemctl set-default graphical.target");
+    assert_script_run('sed -i -r "s/^DISPLAYMANAGER=\"\"/DISPLAYMANAGER=\"gdm\"/" /etc/sysconfig/displaymanager');
+    assert_script_run('sed -i -r "s/^DISPLAYMANAGER_AUTOLOGIN/#DISPLAYMANAGER_AUTOLOGIN/" /etc/sysconfig/displaymanager');
+
+    type_string "reboot\n";
+    wait_boot;
+}
+
+sub flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/qam-minimal/install_update.pm
+++ b/tests/qam-minimal/install_update.pm
@@ -1,0 +1,46 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+
+use base "basetest";
+
+use strict;
+
+use qam;
+use testapi;
+
+sub run {
+    system_login;
+
+    script_run("while pgrep packagekitd; do pkcon quit; sleep 1; done");
+
+    if (!get_var('MINIMAL_TEST_REPO')) {
+        die "no repository with update";
+    }
+
+    capture_state('before');
+
+    my $repo = get_var('MINIMAL_TEST_REPO');
+    assert_script_run("zypper -n ar -f '$repo' test-minimal");
+
+    assert_script_run("zypper ref");
+    script_run("zypper -n patch -r test-minimal ; echo 'worked-patch-\$?-' > /dev/$serialdev", 0);
+    my $ret = wait_serial "worked-patch-\?-", 700;
+    $ret =~ /worked-patch-(\d+)/;
+    die "zypper failed with code $1" unless $1 == 0 || $1 == 102 || $1 == 103;
+
+    capture_state('between', 1);
+    type_string "reboot\n";
+}
+
+sub flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/qam-minimal/update_minimal.pm
+++ b/tests/qam-minimal/update_minimal.pm
@@ -1,0 +1,48 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use strict;
+use base "basetest";
+
+use qam;
+use testapi;
+
+sub run {
+    system_login;
+
+    script_run("while pgrep packagekitd; do pkcon quit; sleep 1; done");
+
+    capture_state('between-after');
+
+    assert_script_run("zypper -n lr | grep test-minimal");
+
+    assert_script_run("zypper ref");
+
+    script_run("zypper -n patch --with-interactive -l; echo 'worked-patch-\$?' > /dev/$serialdev", 0);
+
+    my $ret = wait_serial "worked-patch-\?-", 700;
+    $ret =~ /worked-patch-(\d+)/;
+    die "zypper failed with code $1" unless $1 == 0 || $1 == 102 || $1 == 103;
+
+    script_run("zypper -n patch --with-interactive -l; echo 'worked-2-patch-\$?-' > /dev/$serialdev", 0);    # first one might only have installed "update-test-affects-package-manager"
+    $ret = wait_serial "worked-2-patch-\?-", 1500;
+    $ret =~ /worked-2-patch-(\d+)/;
+    die "zypper failed with code $1" unless $1 == 0 || $1 == 102;
+
+    capture_state('after', 1);
+
+    set_var('SYSTEM_IS_UPDATED', 1);
+    type_string "reboot\n";
+}
+
+sub flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
it prepares minimal instalation, boot it, install tested incident , try
reboot and update system with all released updates.

with QAM_MINIMAL=full it also installs gnome-basic, base, apparmor and
x11 patterns and reboot system to graphical login + start console and
x11 tests