### PR TITLE
Prepend 'tests/' to test path only if not present

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -282,7 +282,10 @@ sub system_is_livesystem() {
 
 sub loadtest($) {
     my ($test) = @_;
-    autotest::loadtest("tests/$test");
+    unless ($test =~ m,^tests/,) {
+        $test = "tests/$test";
+    }
+    autotest::loadtest($test);
 }
 
 sub load_x11regresion_tests() {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -272,7 +272,10 @@ sub uses_qa_net_hardware() {
 
 sub loadtest($) {
     my ($test) = @_;
-    autotest::loadtest("tests/$test");
+    unless ($test =~ m,^tests/,) {
+        $test = "tests/$test";
+    }
+    autotest::loadtest($test);
 }
 
 sub load_x11regresion_tests() {


### PR DESCRIPTION
related to https://github.com/os-autoinst/os-autoinst/pull/474