### PR TITLE
Add consoletest_setup.pm at beginning of FEATURE console tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -862,6 +862,7 @@ sub load_virtualization_tests() {
 }
 
 sub load_feature_tests() {
+    loadtest "console/consoletest_setup.pm";
     loadtest "feature/feature_console/zypper_releasever.pm";
     loadtest "feature/feature_console/suseconnect.pm";
 }


### PR DESCRIPTION
Setup console before starting FEATURE console tests to avoid
test failure caused by PackageKit is running.