### PR TITLE
Fix the test failure in zypper_releasever.pm

### DIFF
--- a/tests/feature/feature_console/zypper_releasever.pm
+++ b/tests/feature/feature_console/zypper_releasever.pm
@@ -27,7 +27,7 @@ sub run() {
     my $zypper_pk_block = qr/^Tell PackageKit to quit\?/m;
 
     # Add a test repo with $releasever var being used in its name
-    script_run "zypper ar -n '${dist}\${releasever_major}\${releasever_minor:+SP\$releasever_minor}' -d dir:/tmp $test_repo 2>&1 | tee /dev/$serialdev";
+    script_run "zypper ar -n '${dist}\${releasever_major}\${releasever_minor:+SP\$releasever_minor}' -d dir:/tmp $test_repo 2>&1 | tee /dev/$serialdev", 0;
 
     my $out = wait_serial [$zypper_ar_ok, $zypper_pk_block];
     if ($out =~ $zypper_pk_block) {
@@ -41,7 +41,7 @@ sub run() {
         $repo_alias =~ s/\./SP/;
         my $str = qr/^Name *: *${repo_alias} */m;
 
-        script_run "zypper --releasever=$ver lr $test_repo | tee /dev/$serialdev";
+        script_run "zypper --releasever=$ver lr $test_repo | tee /dev/$serialdev", 0;
         if (!wait_serial $str) {
             remove_repo $test_repo;
             die "zypper returns incorrect repo name";


### PR DESCRIPTION
Replace some script_run with type_string since we want to check
the command output by wait_serial later. With script_run, the
output will be used to check whether the command is finished,
then later wait_serial will get nothing and raise test failure.