### PR TITLE
Make zfcp test more stable

### DIFF
--- a/tests/installation/disk_activation.pm
+++ b/tests/installation/disk_activation.pm
@@ -23,9 +23,11 @@ sub run {
         assert_screen 'zfcp-add-device';
         send_key 'alt-g';                    # get wwpn's
         assert_screen 'zfcp-wwpn';
-        sleep 3;
-        send_key 'alt-t';                    # get lun
-        send_key 'alt-t';                    # do it twice
+
+        # it's very hard to guess how long this takes...
+        while (check_screen('zfcp-lun-not-found', '2')) {
+            send_key 'alt-t';                # get lun
+        }
         assert_screen 'zfcp-lun';
         send_key 'alt-n';
 
@@ -37,39 +39,39 @@ sub run {
         send_key 'alt-n';
         sleep 5;
     }
-    else {                                   # use default DASD as install disk
+    else {    # use default DASD as install disk
         assert_screen 'disk-activation', 15;
-        send_key 'alt-d';                    # configure DASD disk
+        send_key 'alt-d';    # configure DASD disk
         assert_screen 'dasd-disk-management';
 
         # we need to type backspace to delete the content of the input field in textmode
         if (check_var("VIDEOMODE", "text")) {
-            send_key 'alt-m';                # minimum channel ID
+            send_key 'alt-m';    # minimum channel ID
             for (1 .. 9) { send_key "backspace"; }
             type_string '0.0.0150';
-            send_key 'alt-x';                # maximum channel ID
+            send_key 'alt-x';    # maximum channel ID
             for (1 .. 9) { send_key "backspace"; }
             type_string '0.0.0150';
-            send_key 'alt-f';                # filter button
+            send_key 'alt-f';    # filter button
             assert_screen 'dasd-unselected';
-            send_key 'alt-s';                # select all
+            send_key 'alt-s';    # select all
             assert_screen 'dasd-selected';
-            send_key 'alt-a';                # perform action button
+            send_key 'alt-a';    # perform action button
             assert_screen 'action-list';
-            send_key 'alt-a';                # activate
+            send_key 'alt-a';    # activate
         }
         else {
-            send_key 'alt-m';                # minimum channel ID
+            send_key 'alt-m';    # minimum channel ID
             type_string '0.0.0150';
-            send_key 'alt-x';                # maximum channel ID
+            send_key 'alt-x';    # maximum channel ID
             type_string '0.0.0150';
-            send_key 'alt-f';                # filter button
+            send_key 'alt-f';    # filter button
             assert_screen 'dasd-unselected';
-            send_key 'alt-s';                # select all
+            send_key 'alt-s';    # select all
             assert_screen 'dasd-selected';
-            send_key 'alt-a';                # perform action button
+            send_key 'alt-a';    # perform action button
             assert_screen 'action-list';
-            send_key 'a';                    # activate
+            send_key 'a';        # activate
         }
 
         if (check_screen 'dasd-format-device') {    # format device pop-up


### PR DESCRIPTION
We see sporadic fails in the activation of zfcp discs when requesting the LUNs
It takes between 1 and 10 seconds to retrieve it, sometimes we need to press the shortcut again
so let's just press the shortcut until the LUN pops up to avoid this