### PR TITLE
Detach DLM resource creation from OCFS2 test

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -837,6 +837,7 @@ sub load_hacluster_tests() {
     else {
         loadtest("ha/ha_cluster_join.pm");                                 #node2 joins the cluster
     }
+    loadtest("ha/dlm.pm");
     loadtest("ha/ocfs2.pm");
     loadtest("ha/crm_mon.pm");
     loadtest("ha/fencing.pm");
@@ -921,7 +922,7 @@ elsif (get_var("HACLUSTER_SUPPORT_SERVER")) {
     for my $clustername (split(/,/, get_var('CLUSTERNAME'))) {
         mutex_create("MUTEX_HA_" . $clustername . "_FINISHED");    #support server can lock _FINISHED mutex when node1 finishes
     }
-    for my $mutexname (qw(CLUSTER_INITIALIZED NODE2_JOINED OCFS2_INIT OCFS2_GROUPS_CREATED OCFS2_MKFS_DONE OCFS2_GROUP_ALTERED OCFS2_DATA_COPIED OCFS2_MD5_CHECKED BEFORE_FENCING FENCING_DONE LOGS_CHECKED)) {
+    for my $mutexname (qw(CLUSTER_INITIALIZED NODE2_JOINED OCFS2_INIT DLM_GROUPS_CREATED DLM_INIT DLM_CHECKED OCFS2_MKFS_DONE OCFS2_GROUP_ALTERED OCFS2_DATA_COPIED OCFS2_MD5_CHECKED BEFORE_FENCING FENCING_DONE LOGS_CHECKED)) {
         mutex_create("MUTEX_${mutexname}_M1");                     #barrier_create mutexes
         mutex_create("MUTEX_${mutexname}_M2");
     }

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -16,7 +16,8 @@ sub run() {
     $self->barrier_create("CLUSTER_INITIALIZED");
     $self->barrier_create("NODE2_JOINED");
     $self->barrier_create("OCFS2_INIT");
-    $self->barrier_create("OCFS2_GROUPS_CREATED");
+    $self->barrier_create("DLM_GROUPS_CREATED");
+    $self->barrier_create("DLM_CHECKED");
     $self->barrier_create("OCFS2_MKFS_DONE");
     $self->barrier_create("OCFS2_GROUP_ALTERED");
     $self->barrier_create("OCFS2_DATA_COPIED");

--- a/tests/ha/dlm.pm
+++ b/tests/ha/dlm.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "hacluster";
+use testapi;
+use autotest;
+use lockapi;
+
+sub run() {
+    my $self = shift;
+    $self->barrier_wait("DLM_INIT");
+    if ($self->is_node1) {    #node1
+        type_string "echo wait until DLM resource is created\n";
+    }
+    else {
+        type_string qq(EDITOR="sed -ie '\$ a primitive dlm ocf:pacemaker:controld op monitor interval=60 timeout=60'" crm configure edit; echo dlm_add=\$? > /dev/$serialdev\n);
+        die "create DLM resource failed" unless wait_serial "dlm_add=0", 60;
+        type_string qq(EDITOR="sed -ie '\$ a group base-group dlm'" crm configure edit; echo base_group_add=\$? > /dev/$serialdev\n);
+        die "create base-group failed" unless wait_serial "base_group_add=0", 60;
+        type_string qq(EDITOR="sed -ie '\$ a clone base-clone base-group'" crm configure edit; echo base_clone_add=\$? > /dev/$serialdev\n);
+        die "create base-clone failed" unless wait_serial "base_clone_add=0", 60;
+    }
+    $self->barrier_wait("DLM_GROUPS_CREATED");
+    type_string "ps -A | grep -q dlm_controld; echo dlm_running=\$? > /dev/$serialdev\n";
+    die "dlm_controld is not running" unless wait_serial "dlm_running=0", 60;
+    $self->barrier_wait("DLM_CHECKED");
+}
+
+1;

--- a/tests/ha/ocfs2.pm
+++ b/tests/ha/ocfs2.pm
@@ -16,18 +16,6 @@ sub run() {
     my $self            = shift;
     my $ocfs2_partition = "/dev/disk/by-path/ip-*-lun-2";
     $self->barrier_wait("OCFS2_INIT");
-    if ($self->is_node1) {    #node1
-        type_string "echo wait until DLM resource is created\n";
-    }
-    else {
-        type_string qq(EDITOR="sed -ie '\$ a primitive dlm ocf:pacemaker:controld op monitor interval=60 timeout=60'" crm configure edit; echo dlm_add=\$? > /dev/$serialdev\n);
-        die "create DLM resource failed" unless wait_serial "dlm_add=0", 60;
-        type_string qq(EDITOR="sed -ie '\$ a group base-group dlm'" crm configure edit; echo base_group_add=\$? > /dev/$serialdev\n);
-        die "create base-group failed" unless wait_serial "base_group_add=0", 60;
-        type_string qq(EDITOR="sed -ie '\$ a clone base-clone base-group'" crm configure edit; echo base_clone_add=\$? > /dev/$serialdev\n);
-        die "create base-clone failed" unless wait_serial "base_clone_add=0", 60;
-    }
-    $self->barrier_wait("OCFS2_GROUPS_CREATED");
     type_string "ps -A | grep -q dlm_controld; echo dlm_running=\$? > /dev/$serialdev\n";
     die "dlm_controld is not running" unless wait_serial "dlm_running=0", 60;
     if ($self->is_node1) {


### PR DESCRIPTION
cLVM/DRBD tests need to have DLM group created without running OCFS2 test, DLM group creation moved to ha/dlm.pm