### PR TITLE
Add delay to HA support server job

### DIFF
--- a/tests/ha/ha_support_server.pm
+++ b/tests/ha/ha_support_server.pm
@@ -26,6 +26,7 @@ sub run() {
     type_string "if `dig \@localhost srv1.bravo.ha-test.qa.suse.de +short | grep -q 172.16.0.17`; then echo dns2_okay > /dev/$serialdev; fi\n";
     wait_serial("dns2_okay") || die "support server cannot resolve DNS2";
     type_string "exit\n";
+    sleep 300;    #sometimes node jobs started with several minutes delay, support server shouldn't finish until jobs are started
     for my $clustername (split(/,/, get_var('CLUSTERNAME'))) {    #wait until all jobs are done
         mutex_lock("MUTEX_HA_" . $clustername . "_FINISHED");
     }


### PR DESCRIPTION
[Last HA tests](http://openqa.suse.de/tests/overview?groupid=27&build=0247@1422&distri=sle&version=12-SP2) were failed because HA jobs were not started at the same time.
[support server job](http://openqa.suse.de/tests/351671/file/autoinst-log.txt): start time: 2016-04-19 07:01:20, end time: 2016-04-19 07:02:52
[node1 job](https://openqa.suse.de/tests/351672/file/autoinst-log.txt): start time: 2016-04-19 07:02:53
[node2 job](https://openqa.suse.de/tests/351673/file/autoinst-log.txt): start time: 2016-04-19 07:05:42

Standalone support server job finishes in less than two minutes, and if node jobs don't start within this period, they fail. 300 s delay will prolong support server job life.