### PR TITLE
Wait longer for reboot in reboot_gnome

### DIFF
--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -29,7 +29,8 @@ sub run() {
         send_key "ret";
 
     }
-    wait_boot;
+    # the shutdown sometimes hangs longer, so give it time
+    wait_boot bootloader_time => 300;
 }
 
 sub test_flags() {


### PR DESCRIPTION
100 seconds is often not good enough to get to grub2 as the shutdown is
waiting for something

See https://openqa.suse.de/tests/351998/modules/reboot_gnome/steps/8