### PR TITLE
Setup hostname during installation

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -432,6 +432,7 @@ sub load_inst_tests() {
     if (get_var('UPGRADE')) {
         loadtest "installation/upgrade_select.pm";
     }
+    loadtest "installation/network_configuration.pm";
     if (get_var('SCC_REGISTER', '') eq 'installation') {
         loadtest "installation/scc_registration.pm";
     }
@@ -562,7 +563,6 @@ sub load_consoletests() {
         loadtest "console/consoletest_setup.pm";
         loadtest "console/check_console_font.pm";
         loadtest "console/textinfo.pm";
-        loadtest "console/hostname.pm";
         if (snapper_is_applicable) {
             if (get_var("UPGRADE")) {
                 loadtest "console/upgrade_snapshots.pm";
@@ -1026,7 +1026,6 @@ else {
 
 if (get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1")) {
     if (get_var("INSTALLONLY")) {
-        loadtest "console/hostname.pm";
         loadtest "shutdown/grub_set_bootargs.pm";
         loadtest "shutdown/shutdown.pm";
     }

--- a/tests/installation/network_configuration.pm
+++ b/tests/installation/network_configuration.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright Â© 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use strict;
+use base 'y2logsstep';
+use testapi;
+
+sub run() {
+
+    assert_screen 'scc-registration', 100;
+    send_key 'alt-w';    # press network configuration button
+    assert_screen 'installation-network-settings';
+    send_key 'alt-s';    # select Hostname/DNS tab
+    if (!check_screen 'installation-network-settings-hostname-susetest', 5) {
+        send_key 'alt-t';    # select hostname field
+        type_string 'susetest';
+    }
+    sleep 1;
+    save_screenshot;
+    send_key 'alt-n';        # next
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
It will fix ipmi https://progress.opensuse.org/issues/11638

I named it network_configuration despite it's actual purpose is to change hostname, maybe in future it will be used also for network setup instead of dhcp