### PR TITLE
Fix the name of the test_flags function to make tests fatal

### DIFF
--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -41,7 +41,7 @@ sub run {
     type_string "reboot\n";
 }
 
-sub flags {
+sub test_flags {
     return {fatal => 1};
 }
 

--- a/tests/qam-minimal/check_logs.pm
+++ b/tests/qam-minimal/check_logs.pm
@@ -23,7 +23,7 @@ sub run {
     assert_script_run("cmp -s /tmp/ip_r_before.log /tmp/ip_r_after.log");
 }
 
-sub flags {
+sub test_flags {
     return {fatal => 1};
 }
 

--- a/tests/qam-minimal/install_patterns.pm
+++ b/tests/qam-minimal/install_patterns.pm
@@ -40,7 +40,7 @@ sub run {
     wait_boot;
 }
 
-sub flags {
+sub test_flags {
     return {fatal => 1};
 }
 

--- a/tests/qam-minimal/install_update.pm
+++ b/tests/qam-minimal/install_update.pm
@@ -39,7 +39,7 @@ sub run {
     type_string "reboot\n";
 }
 
-sub flags {
+sub test_flags {
     return {fatal => 1};
 }
 

--- a/tests/qam-minimal/update_minimal.pm
+++ b/tests/qam-minimal/update_minimal.pm
@@ -41,7 +41,7 @@ sub run {
     type_string "reboot\n";
 }
 
-sub flags {
+sub test_flags {
     return {fatal => 1};
 }
 


### PR DESCRIPTION
Noticed in install_patterns rolling back

