### PR TITLE
Add yast2_ftp and yast2_http tests to opensuse extratests

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -596,6 +596,8 @@ sub load_extra_tests () {
             loadtest "sysauth/sssd.pm";
         }
         loadtest "console/command_not_found.pm";
+        loadtest "console/yast2_http.pm";
+        loadtest "console/yast2_ftp.pm";
 
         # finished console test and back to desktop
         loadtest "console/consoletest_finish.pm";


### PR DESCRIPTION
Add new yast2_http and yast2_ftp tests to openSUSE Extratests

@Zaoliang - please feel free to do this in any future pull requests for the tests you're working on - it's always nice to have openSUSE's test coverage expand aligned with SLE's :)