### PR TITLE
Support select_console() in svirt properly

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -201,7 +201,27 @@ sub init_consoles {
         $self->add_console('user-console',  'tty-console', {tty => 4});
         $self->add_console('x11',           'tty-console', {tty => 7});
     }
-    if (check_var('BACKEND', 'svirt') || check_var('BACKEND', 's390x')) {
+
+    # JeOS via svirt backend
+    if (get_var('JEOS') && check_var('BACKEND', 'svirt')) {
+        my $hostname = get_var('VIRSH_GUEST');
+
+        $self->add_console(
+            'sut',
+            'vnc-base',
+            {
+                hostname => $hostname,
+                port     => 5901,
+                password => $testapi::password
+            });
+        $self->add_console('install-shell', 'tty-console', {tty => 2});
+        $self->add_console('root-console',  'tty-console', {tty => 2});
+        $self->add_console('user-console',  'tty-console', {tty => 4});
+        $self->add_console('x11',           'tty-console', {tty => 7});
+    }
+
+    # non-JeOS tests via svirt and s390x backends
+    if (!get_var('JEOS') && (check_var('BACKEND', 'svirt') || check_var('BACKEND', 's390x'))) {
         my $hostname = get_var('VIRSH_GUEST');
 
         if (check_var('BACKEND', 's390x')) {
@@ -302,7 +322,7 @@ sub activate_console {
         $user = $testapi::username if $user eq 'user';
 
         # different handling for svirt and s390 backend
-        if (!check_var('BACKEND', 's390x') && !check_var('BACKEND', 'svirt')) {
+        if (!check_var('BACKEND', 's390x') && (check_var('BACKEND', 'svirt') && get_var('JEOS'))) {
             my $nr = 4;
             $nr = 2 if ($user eq 'root');
             # we need to wait more than five seconds here to pass the idle timeout in

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -30,6 +30,11 @@ sub run() {
     my $name  = $svirt->name;
     my $repo;
 
+    my $xenconsole = "xvc0";
+    if (check_var("VERSION", "12-SP2")) {
+        $xenconsole = "hvc0";    # on 12-SP2 we use pvops, thus /dev/hvc0
+    }
+
     if (!is_jeos) {
         my $cmdline = get_var('VIRSH_CMDLINE') . " ";
 
@@ -49,7 +54,7 @@ sub run() {
         $cmdline .= "sshpassword=$testapi::password ";
 
         if ($vmm_family eq 'xen' && $vmm_type eq 'linux') {
-            $cmdline .= "xenfb.video=4,1024,768 console=hvc0 ";
+            $cmdline .= "xenfb.video=4,1024,768 console=$xenconsole console=tty0 ";
         }
         else {
             $cmdline .= "console=ttyS0 ";
@@ -146,7 +151,7 @@ sub run() {
     # select_console does not select TTY in traditional sense, but
     # connects to a guest VNC session
     if (is_jeos) {
-        select_console('installation');
+        select_console('sut');
     }
     else {
         if (check_var("VIDEOMODE", "text")) {


### PR DESCRIPTION
This commit adds consoles for JeOS deployments. 'sut' console is the VNC
console of VM guest, rest is generic TTYs which leverage console
activation in activate_console().