### PR TITLE
fix script for libreoffice tc#1503827 in x11regression

### DIFF
--- a/tests/x11regressions/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_mainmenu_components.pm
@@ -55,7 +55,9 @@ sub run() {
     send_key "ctrl-q";                          #close base
 
     # clean the test database file
-    x11_start_program("rm /home/$username/Documents/testdatabase.odb");
+    x11_start_program("xterm");
+    assert_script_run "find /home/$username -name testdatabase.odb | xargs rm";
+    send_key 'alt-f4';
 
     $self->open_mainmenu();
     assert_and_click 'mainmenu-office-calc';    #open calc
@@ -93,7 +95,9 @@ sub run() {
     send_key "ctrl-q";                             #close base
 
     # clean the test database file
-    x11_start_program("rm /home/$username/Documents/testdatabase.odb");
+    x11_start_program("xterm");
+    assert_script_run "find /home/$username -name testdatabase.odb | xargs rm";
+    send_key 'alt-f4';
 
     $self->open_overview();
     type_string "calc";                            #open calc
@@ -121,6 +125,7 @@ sub run() {
     assert_screen 'overview-office-writer';
     send_key "ret";
     assert_screen 'test-ooffice-1';
+    assert_and_click 'ooffice-writing-area', 'left', 10;
     send_key "ctrl-q";                             #close writer
 }
 


### PR DESCRIPTION
Testing result:

http://147.2.212.239/tests/307

This case failed at 
https://openqa.suse.de/tests/359451/modules/libreoffice_mainmenu_components/steps/43

Because we should generate a odb test file for oobase and then delete it. oobase used to create the odb test file in directory '/home/$username/Documents' before
http://147.2.212.239/tests/262/modules/libreoffice_mainmenu_components/steps/12
but now in directory '/home/$username'
http://147.2.212.239/tests/307/modules/libreoffice_mainmenu_components/steps/12

so I adjusted the clean test file part.

