### PR TITLE
Fix mistake in pre-install formatting DASD

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -193,7 +193,7 @@ sub run() {
     my $c = select_console('iucvconn');
 
     # we also want to test the formatting during the installation if the variable is set
-    if (!get_var("FORMAT_DASD_YAST")) {
+    if (!get_var("FORMAT_DASD_YAST") && !get_var('S390_DISK')) {
         format_dasd;
     }
 


### PR DESCRIPTION
It's not necessary to format the DASD if we install on a ZFCP disk