### PR TITLE
Use explicit needle tag for iscsi disk activation

### DIFF
--- a/tests/installation/iscsi_configuration.pm
+++ b/tests/installation/iscsi_configuration.pm
@@ -12,7 +12,7 @@ use base "y2logsstep";
 use testapi;
 
 sub run() {
-    assert_screen 'disk-activation';
+    assert_screen 'disk-activation-iscsi';
     send_key 'alt-i';    # configure iscsi disk
     assert_screen 'iscsi-overview', 100;
     send_key 'alt-i';    # iBFT tab


### PR DESCRIPTION
avoid collision with DASD
https://openqa.suse.de/tests/373107/modules/iscsi_configuration/steps/3

"Don’t make Perl guess what you mean when you can be explicit."
