### PR TITLE
Use explicit needle tag for iscsi disk activation

### DIFF
--- a/tests/installation/iscsi_configuration.pm
+++ b/tests/installation/iscsi_configuration.pm
@@ -18,7 +18,7 @@ sub run() {
     send_key 'alt-i';    # iBFT tab
     assert_screen 'iscsi-ibft';
     send_key 'alt-o';    # OK
-    assert_screen 'disk-activation';
+    assert_screen 'disk-activation-iscsi';
     send_key 'alt-n';    # next
 }
 


### PR DESCRIPTION
I have been too fast and didn't look 6 lines lower ... #1313 

Don’t make Perl guess what you mean when you can be explicit.