### PR TITLE
[WIP] Snapper_rollback fix for iso

### DIFF
--- a/tests/boot/boot_to_console.pm
+++ b/tests/boot/boot_to_console.pm
@@ -14,8 +14,7 @@ use testapi;
 use Time::HiRes qw(sleep);
 
 sub run() {
-    assert_screen "inst-bootmenu", 30;
-    sleep 2;
+    assert_screen "inst-bootmenu";
     send_key "ret";    # boot
 
     assert_screen "grub2", 15;

--- a/tests/boot/grub_test_snapshot.pm
+++ b/tests/boot/grub_test_snapshot.pm
@@ -14,6 +14,9 @@ use testapi;
 
 sub run() {
     my $self = shift;
+
+    assert_screen "inst-bootmenu";
+    send_key "ret";    # boot
     assert_screen "grub2";
     # prevent grub2 timeout; 'esc' would be cleaner, but grub2-efi falls to the menu then
     send_key 'up';


### PR DESCRIPTION
I was assuming that the production systems could boot from hdd_directly without passing by iso.

So i regarding the other tests in production, this should fix the broken test.

I didn't tested. PR for Review 