### PR TITLE
Add sle12 online migration testsuite

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -966,6 +966,19 @@ sub load_feature_tests() {
     loadtest "feature/feature_console/suseconnect.pm";
 }
 
+sub load_online_migration_tests() {
+    # stop packagekit service and more
+    loadtest "online_migration/sle12_online_migration/online_migration_setup.pm";
+    loadtest "online_migration/sle12_online_migration/register_system.pm";
+    # do full update before migration
+    # otherwise yast2/zypper migration will patch a minimal update
+    loadtest "online_migration/sle12_online_migration/zypper_patch.pm" if (get_var("FULL_UPDATE"));
+    loadtest "online_migration/sle12_online_migration/pre_migration.pm";
+    loadtest "online_migration/sle12_online_migration/yast2_migration.pm"  if (check_var("MIGRATION_METHOD", 'yast'));
+    loadtest "online_migration/sle12_online_migration/zypper_migration.pm" if (check_var("MIGRATION_METHOD", 'zypper'));
+    loadtest "online_migration/sle12_online_migration/post_migration.pm";
+}
+
 sub prepare_target() {
     if (get_var("BOOT_HDD_IMAGE")) {
         loadtest "boot/boot_to_desktop.pm";
@@ -1097,15 +1110,24 @@ else {
         load_boot_tests();
         load_zdup_tests();
     }
+    elsif (get_var("ONLINE_MIGRATION")) {
+        load_boot_tests();
+        load_online_migration_tests();
+    }
     elsif (get_var("BOOT_HDD_IMAGE")) {
         if (get_var("RT_TESTS")) {
             set_var('INSTALLONLY', 1);
             loadtest "rt/boot_rt_kernel.pm";
         }
         else {
-            if (get_var("BOOT_TO_SNAPSHOT") && (snapper_is_applicable) && get_var("UPGRADE")) {
+            if (get_var("BOOT_TO_SNAPSHOT") && (snapper_is_applicable)) {
                 loadtest "boot/grub_test_snapshot.pm";
-                loadtest "boot/snapper_rollback.pm";
+                if (get_var("UPGRADE")) {
+                    loadtest "boot/snapper_rollback.pm";
+                }
+                if (get_var("MIGRATION_ROLLBACK")) {
+                    loadtest "online_migration/sle12_online_migration/snapper_rollback.pm";
+                }
             }
             else {
                 loadtest "boot/boot_to_desktop.pm";

--- a/tests/boot/grub_test_snapshot.pm
+++ b/tests/boot/grub_test_snapshot.pm
@@ -24,7 +24,8 @@ sub run() {
         send_key_until_needlematch("boot-menu-snapshot", 'down', 10, 5);
         send_key 'ret';
         # find out the before migration snapshot
-        send_key_until_needlematch("snap-before-update", 'down', 40, 5);
+        send_key_until_needlematch("snap-before-update",    'down', 40, 5) if (get_var("UPGRADE"));
+        send_key_until_needlematch("snap-before-migration", 'down', 40, 5) if (get_var("MIGRATION_ROLLBACK"));
         send_key "ret";
         # bsc#956046  check if we are in first menu-entry, or not
         if (check_screen("boot-menu-snapshot-bootmenu")) {

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -40,7 +40,7 @@ sub run() {
     }
 
     assert_screen 'inst-bootmenu', 15;
-    if (get_var('ZDUP')) {
+    if (get_var('ZDUP') || get_var("ONLINE_MIGRATION")) {
         send_key 'ret';               # boot from hard disk
         return;
     }

--- a/tests/installation/bootloader_ofw.pm
+++ b/tests/installation/bootloader_ofw.pm
@@ -24,14 +24,14 @@ sub run() {
     if (get_var("UPGRADE")) {
         send_key_until_needlematch 'inst-onupgrade', 'up';
     }
-    elsif (get_var("ZDUP")) {
+    elsif (get_var("ZDUP") || get_var("ONLINE_MIGRATION")) {
         assert_screen 'inst-onlocal';
     }
     else {
         send_key_until_needlematch 'inst-oninstallation', 'up';
     }
     if (check_var('VIDEOMODE', 'text') || get_var('NETBOOT') || get_var('AUTOYAST') || get_var('SCC_URL')) {
-        if (get_var("ZDUP")) {
+        if (get_var("ZDUP") || get_var("ONLINE_MIGRATION")) {
             send_key "down";
             send_key "ret";
         }

--- a/tests/online_migration/sle12_online_migration/online_migration_setup.pm
+++ b/tests/online_migration/sle12_online_migration/online_migration_setup.pm
@@ -1,0 +1,36 @@
+# SLE12 online migration tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    my $self = shift;
+
+    # if source system is minimal installation then boot to textmode
+    if (get_var("DESKTOP") =~ /textmode|minimalx/) {
+        wait_boot textmode => 1;
+    }
+    else {
+        wait_boot;
+    }
+    select_console 'root-console';
+
+    # stop packagekit service
+    script_run "systemctl mask packagekit.service";
+    script_run "systemctl stop packagekit.service";
+
+    type_string "chown $username /dev/$serialdev\n";
+    save_screenshot;
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/online_migration/sle12_online_migration/post_migration.pm
+++ b/tests/online_migration/sle12_online_migration/post_migration.pm
@@ -1,0 +1,39 @@
+# SLE12 online migration tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "installbasetest";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    my $self = shift;
+    select_console 'root-console';
+
+    # print repos to screen and serial console after online migration
+    wait_still_screen;
+    script_run("zypper lr -u | tee /dev/$serialdev");
+    save_screenshot;
+
+    # reboot into upgraded system after online migration
+    script_run("systemctl reboot", 0);
+    if (get_var("DESKTOP") =~ /textmode|minimalx/) {
+        wait_boot textmode => 1;
+    }
+    else {
+        wait_boot;
+    }
+}
+
+sub test_flags {
+    return {important => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/online_migration/sle12_online_migration/pre_migration.pm
+++ b/tests/online_migration/sle12_online_migration/pre_migration.pm
@@ -1,0 +1,52 @@
+# SLE12 online migration tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use strict;
+use testapi;
+
+sub set_scc_proxy_url() {
+    if (my $u = get_var('SCC_PROXY_URL')) {
+        type_string "echo 'url: $u' > /etc/SUSEConnect\n";
+    }
+    save_screenshot;
+}
+
+sub check_or_install_packages() {
+    if (get_var("FULL_UPDATE")) {
+        # if system is fully updated, all necessary packages for online migration should be installed
+        # check if the packages was installed along with update
+        my $output = script_output "rpm -qa yast2-migration zypper-migration-plugin rollback-helper";
+        if ($output !~ /yast2-migration.*?zypper-migration-plugin.*?rollback-helper/s) {
+            die "migration packages was not installed along with system update";
+        }
+    }
+    else {
+        # install necessary packages for online migration if system is not updated
+        # also update snapper to ensure rollback service work properly after migration
+        assert_script_run "zypper -n in yast2-migration zypper-migration-plugin rollback-helper snapper", 190;
+    }
+}
+
+sub run() {
+    my $self = shift;
+    select_console 'root-console';
+
+    check_or_install_packages;
+
+    # set scc proxy url here to perform online migration via scc proxy
+    set_scc_proxy_url;
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/online_migration/sle12_online_migration/register_system.pm
+++ b/tests/online_migration/sle12_online_migration/register_system.pm
@@ -1,0 +1,41 @@
+# SLE12 online migration tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use strict;
+use testapi;
+use registration;
+
+sub run() {
+    my $self = shift;
+    select_console 'root-console';
+
+    if (my $u = get_var('SCC_URL')) {
+        type_string "echo 'url: $u' > /etc/SUSEConnect\n";
+    }
+
+    # register system and addons in textmode for all archs
+    if (get_var("DESKTOP") =~ /textmode|minimalx/) {
+        yast_scc_registration;
+    }
+    else {
+        set_var("DESKTOP", 'textmode');
+        yast_scc_registration;
+        # set back to gnome mode for checking
+        # if system boot into desktop correctly after migration
+        set_var("DESKTOP", 'gnome');
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/online_migration/sle12_online_migration/snapper_rollback.pm
+++ b/tests/online_migration/sle12_online_migration/snapper_rollback.pm
@@ -1,0 +1,53 @@
+# SLE12 online migration tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use strict;
+use testapi;
+use utils;
+
+sub check_rollback_system() {
+    # first to check rollback-helper service is enabled and worked properly
+    my $output = script_output "systemctl status rollback.service";
+    if ($output !~ /enabled.*?code=exited,\sstatus=0\/SUCCESS/s) {
+        die "rollback service was failed";
+    }
+
+    # second to check if repos were rolled back to original
+    script_run("zypper lr -u | tee /dev/$serialdev");
+}
+
+sub run() {
+    my $self = shift;
+
+    # login to snapshot and perform snapper rollback
+    assert_screen 'linux-login', 200;
+    select_console 'root-console';
+    wait_still_screen;
+    script_run "snapper rollback";
+
+    # reboot into the system before online migration
+    script_run("systemctl reboot", 0);
+    if (get_var("DESKTOP") =~ /textmode|minimalx/) {
+        wait_boot textmode => 1;
+    }
+    else {
+        wait_boot;
+    }
+    select_console 'root-console';
+
+    check_rollback_system;
+}
+
+sub test_flags {
+    return {important => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/online_migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/online_migration/sle12_online_migration/yast2_migration.pm
@@ -1,0 +1,113 @@
+# SLE12 online migration tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "installbasetest";
+use strict;
+use testapi;
+
+sub run {
+    my $self = shift;
+
+    if (get_var("DESKTOP") =~ /textmode|minimalx/) {
+        select_console 'root-console';
+    }
+    else {
+        select_console 'x11';
+        x11_start_program("xterm");
+        # set blank screen to be never for current session
+        script_run("gsettings set org.gnome.desktop.session idle-delay 0");
+        become_root;
+    }
+
+    script_run("/sbin/yast2 migration; echo yast2-migration-done-\$? > /dev/$serialdev", 0);
+
+    # install minimal update before migration if not perform full update
+    if (!get_var("FULL_UPDATE")) {
+        assert_screen 'yast2-migration-onlineupdates';
+        send_key "alt-y";
+        assert_screen 'yast2-migration-updatesoverview';
+        if (get_var("DESKTOP") =~ /textmode|minimalx/) {
+            send_key "alt-a";
+        }
+        else {
+            # the shortcut key alt-a doesn't work in graphic mode
+            assert_and_click 'yast2-migration-accept-patch';
+        }
+    }
+
+    # wait for migration target after needed updates installed
+    assert_screen 'yast2-migration-target', 300;
+    send_key "alt-n";
+    # currently scc proxy update channel doesn't have content
+    if (!get_var("SCC_PROXY_URL")) {
+        assert_screen 'yast2-migration-installupdate', 200;
+        send_key "alt-y";
+    }
+    assert_screen 'yast2-migration-proposal', 60;
+
+    # disable installation repo
+    assert_screen 'recommend-to-disable';
+    if (get_var("DESKTOP") =~ /textmode|minimalx/) {
+        send_key "tab";
+        send_key_until_needlematch 'disable-repo', 'down', 3;
+        send_key "ret";
+    }
+    else {
+        assert_and_click 'disable-repo';
+    }
+    wait_still_screen;
+    send_key "alt-n";
+    assert_screen 'yast2-migration-startupgrade';
+    send_key "alt-u";
+    assert_screen "yast2-migration-upgrading";
+
+    # start migration
+    my $timeout = 3000;
+    my @tags    = qw/yast2-migration-wrongdigest yast2-migration-packagebroken yast2-migration-internal-error yast2-migration-finish/;
+    while (1) {
+        my $ret = assert_screen \@tags, $timeout;
+        if ($ret->{needle}->has_tag("yast2-migration-internal-error")) {
+            $self->result('fail');
+            send_key "alt-o";
+            save_screenshot;
+            return;
+        }
+        elsif ($ret->{needle}->has_tag("yast2-migration-packagebroken")) {
+            $self->result('fail');
+            send_key "alt-d";
+            save_screenshot;
+            send_key "alt-s";
+            return;
+        }
+        elsif ($ret->{needle}->has_tag("yast2-migration-wrongdigest")) {
+            $self->result('fail');
+            send_key "alt-a", 1;
+            save_screenshot;
+            send_key "alt-n";
+            return;
+        }
+        last if $ret->{needle}->has_tag("yast2-migration-finish");
+    }
+    send_key "alt-f";
+
+    # after migration yast may ask to reboot system
+    if (check_screen("yast2-ask-reboot", 5)) {
+        send_key "alt-c";    # cancel it and reboot in post migration step
+    }
+
+    wait_serial("yast2-migration-done-0", $timeout) || die "yast2 migration failed";
+    type_string "exit\n" if (get_var("DESKTOP") !~ /textmode|minimalx/);
+}
+
+sub test_flags() {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/online_migration/sle12_online_migration/zypper_migration.pm
+++ b/tests/online_migration/sle12_online_migration/zypper_migration.pm
@@ -1,0 +1,63 @@
+# SLE12 online migration tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use strict;
+use testapi;
+
+sub run() {
+    my $self = shift;
+    select_console 'root-console';
+
+    # precompile regexes
+    my $zypper_continue               = qr/^Continue\? \[y/m;
+    my $zypper_migration_target       = qr/\[num\/q\]/m;
+    my $zypper_disable_repos          = qr/^Disable obsolete repository/m;
+    my $zypper_migration_conflict     = qr/^Choose from above solutions by number[\s\S,]* \[1/m;
+    my $zypper_migration_error        = qr/^Abort, retry, ignore\? \[a/m;
+    my $zypper_migration_fileconflict = qr/^File conflicts .*^Continue\? \[y/ms;
+    my $zypper_migration_done         = qr/^Executing.*after online migration|^ZYPPER-DONE/m;
+
+    # start migration
+    script_run("(zypper migration;echo ZYPPER-DONE) | tee /dev/$serialdev", 0);
+    # migration process take long time
+    my $timeout          = 3000;
+    my $migration_checks = [$zypper_migration_target, $zypper_disable_repos, $zypper_continue, $zypper_migration_done, $zypper_migration_error, $zypper_migration_conflict, $zypper_migration_fileconflict];
+    my $out              = wait_serial($migration_checks, $timeout);
+    while ($out) {
+        if ($out =~ $zypper_migration_target) {
+            send_key "1";
+            send_key "ret";
+        }
+        elsif ($out =~ $zypper_disable_repos) {
+            send_key "y";
+            send_key "ret";
+        }
+        elsif ($out =~ $zypper_migration_error || $out =~ $zypper_migration_conflict || $out =~ $zypper_migration_fileconflict) {
+            $self->result('fail');
+            save_screenshot;
+            return;
+        }
+        elsif ($out =~ $zypper_continue) {
+            send_key "y";
+            send_key "ret";
+        }
+        elsif ($out =~ $zypper_migration_done) {
+            last;
+        }
+        $out = wait_serial($migration_checks, $timeout);
+    }
+}
+
+sub test_flags() {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/online_migration/sle12_online_migration/zypper_patch.pm
+++ b/tests/online_migration/sle12_online_migration/zypper_patch.pm
@@ -1,0 +1,27 @@
+# SLE12 online migration tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    my $self = shift;
+    select_console 'root-console';
+
+    fully_patch_system;
+}
+
+sub test_flags() {
+    return {important => 1};
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
sle12 online migration tests  procedure:
register against real scc on sle12 or sle12sp1 (with or without addons)
then perform online migration via proxy scc to sle12sp2 with yast2/zypper migration
after migration to check migrated system or perform migration rollback test

I did not have enough tests on my loacl server since the download speed to scc/proxy scc was really painful.
The scripts submitted here for reviews and suggestions.

And I would like to know the smt credentials which could mirror proxy scc channels if possible.
Thanks. 