### PR TITLE
fix issue in regresion splitting:

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -983,13 +983,6 @@ if (get_var("REGRESSION")) {
         loadtest "boot/boot_to_desktop.pm";
         load_x11regression_other();
     }
-    elsif (check_var("REGRESSION", "test")) {
-        loadtest "boot/boot_to_desktop.pm";
-        loadtest "x11regressions/x11regressions_setup.pm";
-        loadtest "console/hostname.pm";
-        loadtest "shutdown/grub_set_bootargs.pm";
-        loadtest "shutdown/shutdown.pm";
-    }
 }
 elsif (get_var("FEATURE")) {
     prepare_target();

--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -20,7 +20,7 @@ sub run() {
 }
 
 sub test_flags() {
-    return {fatal => 1};
+    return {fatal => 1, milestone => 1};    # add milestone flag to save setup in lastgood vm snapshot
 }
 
 1;


### PR DESCRIPTION
-add milestone flag in the boot_from_desktop.pm
-remove regression_test from main.pm

Notes:
In irc we got agree to make two tiny update: 
1. boot_to_desktop.om should be milestone
2. add x11regression_setup.pm in all the regression_* test 
to make sure: not only test case could boot from the lastgood vm image, but also assert_script_run could be used.

After a thought, I believe include x11regression_setup.pm in regression_installation(as I did) which will save the base-image-4-regression for further regression_* test to use is enough.

settings in x11regression_setup.pm still take effect even though reboot system (refer the file : )

While if further update still be required, I will check it timely.