### PR TITLE
Check registration failed messages when upgrading with SCC registration

### DIFF
--- a/tests/installation/scc_registration.pm
+++ b/tests/installation/scc_registration.pm
@@ -20,6 +20,16 @@ use testapi;
 use registration;
 
 sub run() {
+    if (get_var("SCC_EXPECT_ERROR")) {
+        while (1) {
+            if (check_screen 'registration-error') {
+                send_key 'alt-o';
+                wait_still_screen;
+                next;
+            }
+            last;
+        }
+    }
     assert_screen("scc-registration", 100);
     fill_in_registration_data;
 }


### PR DESCRIPTION
To test SMT migration pre-installed system has to be registered to prove SMT migration was successful

I think this error messages are expected and reason of using proxy SCC instead of previous real SCC registration.

e.g. http://10.100.98.90/tests/1797/modules/scc_registration/steps/1