### PR TITLE
Move focus to Yast if distribution has BETA=0

### DIFF
--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -87,6 +87,7 @@ sub run() {
     if (   !get_var("LIVECD")
         && !get_var("NICEVIDEO")
         && !get_var("UPGRADE")
+        && !get_var("SLES4SAP_MODE")
         && !check_var('VIDEOMODE', 'text'))
     {
         my $counter = 10;

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -30,6 +30,7 @@ sub run() {
 
     # license+lang
     if (get_var("HASLICENSE")) {
+        mouse_click 'left';    # if there was no beta warning, focus is not in yast and send_key doesn't work
         send_key $cmd{next};
         assert_screen "license-not-accepted";
         send_key $cmd{ok};


### PR DESCRIPTION
SLES4SAP doesn't show beta warning, and send_key $smd{next}; doesn't work in the installation (there is no way to switch focus to the Yast via keyboard, only mouse_click helps).
Sample test run: http://ix64sap002.qa.suse.de/tests/394/modules/welcome/steps/1