### PR TITLE
Add Hyper-V svirt tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help:
 prepare:
 	git clone git://github.com/os-autoinst/os-autoinst
 	ln -s os-autoinst/tools .
-	ln -s os-autoinst/cpanfile .
+	cd os-autoinst && cpanm -nq --installdeps .
 	cpanm -nq --installdeps .
 
 .PHONY: check-links

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,1 @@
+requires 'Net::Telnet';

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -443,7 +443,12 @@ sub load_boot_tests() {
     }
     elsif (get_var("UEFI") || is_jeos) {
         if (check_var("BACKEND", "svirt")) {
-            loadtest "installation/bootloader_svirt.pm";
+            if (check_var("VIRSH_VMM_FAMILY", "hyperv")) {
+                loadtest "installation/bootloader_hyperv.pm";
+            }
+            else {
+                loadtest "installation/bootloader_svirt.pm";
+            }
         }
         # TODO: rename to bootloader_grub2
         # Unless GRUB2 supports framebuffer on Xen PV (bsc#961638), grub2 tests

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -19,10 +19,16 @@ sub run() {
     # let's see how it looks at the beginning
     save_screenshot;
 
+    # Special keys like Ctrl-Alt-Fx does not work on Hyper-V atm. Alt-Fx however do.
+    my $tty1_key = 'ctrl-alt-f1';
+    if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
+        $tty1_key = 'alt-f1';
+    }
+
     if (!check_var('ARCH', 's390x')) {
         # verify there is a text console on tty1
         for (1 .. 6) {
-            send_key 'ctrl-alt-f1';
+            send_key $tty1_key;
             if (check_screen("tty1-selected", 5)) {
                 last;
             }
@@ -52,7 +58,7 @@ sub run() {
             }
             type_string "$password";
             send_key "ret";
-            send_key_until_needlematch "tty1-selected", "ctrl-alt-f1", 6, 5;
+            send_key_until_needlematch "tty1-selected", $tty1_key, 6, 5;
         }
     }
 

--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -1,0 +1,118 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "installbasetest";
+
+use testapi;
+use utils;
+
+use strict;
+use warnings;
+
+use File::Basename;
+use Net::Telnet ();
+
+sub run() {
+
+    my $self = shift;
+
+    my $svirt = select_console('svirt');
+    my $name  = $svirt->name;
+
+    my $file = basename(get_var('HDD_1'));
+
+    if (is_jeos) {
+        type_string "mkdir -p ~/.vnc/\n";
+        type_string "vncpasswd -f <<<$testapi::password > ~/.vnc/passwd\n";
+        type_string "chmod 600 ~/.vnc/passwd\n";
+        type_string "pkill -f \"Xvnc :1\"; pkill -9 -f \"Xvnc :1\"\n";
+        type_string "Xvnc :1 -geometry 1024x768 -pn -rfbauth ~/.vnc/passwd &\n";
+
+        my $ps   = "powershell -Command";
+        my $wait = "";
+
+        my ($t, $winserver, @winver, @vmguid);
+
+        $t = new Net::Telnet(Timeout => 60);
+
+        $t->open(get_var('HYPERV_SERVER'));
+        $t->login(get_var('HYPERV_USERNAME'), get_var('HYPERV_PASSWORD'));
+
+        # This is the expected shell prompt: '$ ' otherwise cmd() will timeout.
+        # * in Bash: PS1='$ ' in ~/.bash_profile
+        # * as a CMD.exe: set user var PROMPT to $$$S
+        $t->prompt('/\$ /i');
+
+        @winver = $t->cmd("cmd /C ver");
+
+        if (grep { /Microsoft Windows \[Version 6.1.*\]/ } @winver) {
+            $wait      = "-Wait";
+            $winserver = 2008;
+        }
+        elsif (grep { /Microsoft Windows \[Version 6.3.*\]/ } @winver) {
+            $winserver = 2012;
+        }
+        elsif (grep { /Microsoft Windows \[Version 10.0.*\]/ } @winver) {
+            $winserver = 2016;
+        }
+        else {
+            die "Unsupported version: @winver";
+        }
+
+        $t->cmd("$ps Get-VM");
+        # It fails on WS 2008 R2 for Stopped VMs
+        $t->cmd("$ps Stop-VM -Force $name $wait");
+        $t->cmd("$ps Remove-VM -Force $name");
+        if ($winserver eq "2008") {
+            $t->cmd("$ps New-VM -Name $name");
+            $t->cmd("$ps Add-VMNic -VM $name (Select-VMSwitch)");
+            $t->cmd("$ps Add-VMDisk -VM $name -ControllerID 0 -Lun 0 $file");
+            $t->cmd("$ps Set-VMSerialPort -VM $name -PortNumber 1 -Connection '\\\\.\\pipe\\$name'");
+            @vmguid = $t->cmd("$ps (Get-VM -VMName $name).name");
+        }
+        elsif ($winserver eq "2012") {
+            $t->cmd("$ps New-VM -Name $name -VHDPath $file -SwitchName *");
+            $t->cmd("$ps Set-VMComPort -VMName $name -Number 1 -Path '\\\\.\\pipe\\$name'");
+            @vmguid = $t->cmd("$ps (Get-VM -VMName $name).id.guid");
+        }
+        elsif ($winserver eq "2016") {
+            $t->cmd("$ps New-VM -Name $name -VHDPath $file -SwitchName \\*");
+            $t->cmd("$ps Set-VMComPort -VMName $name -Number 1 -Path '\\\\.\\pipe\\$name'");
+            @vmguid = $t->cmd("$ps \\(Get-VM -VMName $name\\).id.guid");
+        }
+
+        # remove stray whitespace characters
+        @vmguid = map { join(' ', split(' ')) } @vmguid;
+        # find a GUID like this 52eac3c0-da62-4054-bf6a-ad99bdb07f82 in the array
+        until (grep { m/([A-Fa-f0-9]{8}[\-][A-Fa-f0-9]{4}[\-][A-Fa-f0-9]{4}[\-][A-Fa-f0-9]{4}[\-]([A-Fa-f0-9]){12})/gi } $vmguid[0]) {
+            shift(@vmguid);
+        }
+        # remove telnet transfer remnants
+        $vmguid[0] =~ s/[^[:print:]]+//;
+
+        # xfreerdp should be run with fullscreen option (/f) so the needle match but
+        # due to bug https://github.com/FreeRDP/FreeRDP/issues/3362 on WS 2008 R2 we
+        # have to start xfreerdp without the /f option and toggle to fullscreen later.
+        # Typing this string takes so long that we miss grub menu at all...
+        type_string "DISPLAY=:1 xfreerdp /u:" . get_var('HYPERV_USERNAME') . " /p:'" . get_var('HYPERV_PASSWORD') . "' /v:" . get_var('HYPERV_SERVER') . " /cert-ignore /jpeg /jpeg-quality:100 /fast-path:1 /bpp:32 /vmconnect:$vmguid[0]";
+
+        $t->cmd("$ps Start-VM $name $wait");
+        $t->close;
+
+        # ...so we execute the command right after VMs starts.
+        type_string "\n";
+
+        # attach to console (a TCP port on HYPERV_SERVER)
+        $svirt->attach_to_running;
+
+        select_console('sut');
+    }
+}
+
+1;

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -108,6 +108,9 @@ sub run() {
     type_string " \\\n";    # changed the line before typing video params
                             # https://wiki.archlinux.org/index.php/Kernel_Mode_Setting#Forcing_modes_and_EDID
     type_string_slow 'Y2DEBUG=1 ';
+    if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
+        type_string " video=hyperv_fb:1024x768";
+    }
     if (!is_jeos && (check_var('ARCH', 'i586') || check_var('ARCH', 'x86_64'))) {
         type_string_slow 'vga=791 ';
         type_string_slow 'video=1024x768-16 ';
@@ -152,6 +155,14 @@ sub run() {
     # boot
     send_key "f10";
 
+    # This is a workaround for xfreerdp connected to Windows Server 2008 R2.
+    # See issue https://github.com/FreeRDP/FreeRDP/issues/3362.
+    # xfreerdp is started in window-mode (i.e. non-fullscreen), now when
+    # all resolution changes (by Hyper-V BIOS, Grub) were done we should
+    # switch to fullscreen so needles match.
+    if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
+        send_key("ctrl-alt-ret");
+    }
 }
 
 1;

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -13,7 +13,7 @@ use strict;
 use testapi;
 
 sub select_locale {
-    assert_screen 'jeos-locale', 60;
+    assert_screen 'jeos-locale', 120;
     my $lang = get_var("INSTLANG", 'us');
     send_key_until_needlematch "jeos-system-locale-$lang", 'e', 50;
     send_key 'ret';

--- a/tests/jeos/grub2_gfxmode.pm
+++ b/tests/jeos/grub2_gfxmode.pm
@@ -17,12 +17,21 @@ use testapi;
 
 sub run {
     if (check_var('UEFI', '1')) {
-        assert_script_run("sed -ie '/GRUB_GFXMODE=/s/=.*/=1024x768/' /etc/default/grub && grub2-mkconfig -o /boot/grub2/grub.cfg");
-        # workaround kiwi quirk bnc#968270, bnc#968264
-        assert_script_run("rm -rf /boot/efi/EFI; sed -ie 's/which/echo/' /usr/sbin/shim-install && shim-install");
+        assert_script_run("sed -ie '/GRUB_GFXMODE=/s/=.*/=1024x768/' /etc/default/grub");
     }
     else {
-        assert_script_run("sed -ie '/GFXPAYLOAD_LINUX=/s/=.*/=1024x768/' /etc/default/grub && grub2-mkconfig -o /boot/grub2/grub.cfg");
+        assert_script_run("sed -ie '/GFXPAYLOAD_LINUX=/s/=.*/=1024x768/' /etc/default/grub");
+    }
+
+    if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
+        assert_script_run("sed -ie '/GRUB_CMDLINE_LINUX_DEFAULT=/s/\"\$/ video=hyperv_fb:1024x768\"/' /etc/default/grub");
+    }
+
+    assert_script_run("grub2-mkconfig -o /boot/grub2/grub.cfg");
+
+    if (check_var('UEFI', '1')) {
+        # workaround kiwi quirk bnc#968270, bnc#968264
+        assert_script_run("rm -rf /boot/efi/EFI; sed -ie 's/which/echo/' /usr/sbin/shim-install && shim-install");
     }
 }
 

--- a/tests/jeos/root_fs_size.pm
+++ b/tests/jeos/root_fs_size.pm
@@ -13,7 +13,11 @@ use strict;
 use testapi;
 
 sub run() {
-    validate_script_output "df --output=size -BG / | sed 1d | tr -d ' '", sub { /^24G$/ }
+    my $expected_size = "24G";
+    if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
+        $expected_size = "30G";
+    }
+    validate_script_output "df --output=size -BG / | sed 1d | tr -d ' '", sub { /^$expected_size$/ }
 }
 
 1;


### PR DESCRIPTION
This bootloader setups Hyper-V VM:

1. Connects to VIRSH_HOST via SSH,
2. starts a VNC server there, VNC server starts RDP connection to a VM on
HYPERV_SERVER via xfreerdp,
3. openQA connects to the VNC server.

Server requirements:

* Windows Server 2008 R2, 2012 R2, or 2016 (TP5) - a Datacenter edition,
* Hyper-V and RDP roles are installed,
* telnet server (WS 2008 R2 and 2012 R2 contain terminal service, 2016
  does not and e.g. telnetd from Cygwin has to be installed),
* program which enables VM's serial port for connection from outside
  (Hyper-V enables serial port as a Windows named pipe \\.\pipe\NAME),
  e.g. "Named Pipe TCP Proxy Utility" (which is not a scriptable, it's
  an GUI app...),
* open ports in firewall, perhaps add above program as an exception to
  the firewall,
* WS 2008 R2 requires Powershell and "PowerShell management Library for
  Hyper-V" (http://pshyperv.codeplex.com)

Intermediary VIRSH_HOST requirements:

* sshd, vnserver, xauth,
* FreeRDP before commit 9c7b7ab otherwise /vmconnect option won't work,
  see https://github.com/FreeRDP/FreeRDP/issues/2421,

Caveats:

* FreeRDP does not work for Windows Server 2016 (TP5), see
  https://github.com/FreeRDP/FreeRDP/issues/3325,
* FreeRDP has to be in it's old version, see above,
* so far VM in RDP connection which is displayed by a VNC server on
  VIRSH_HOST is not getting "System Keys" (e.g. Alt-F2 for console
  change), which looks similar to me as when vncviewer is running without
  "-FullScreen -FullscreenSystemKeys" options.