### PR TITLE
Remove dlm and ocfs2 kmp install workaround

### DIFF
--- a/tests/ha/dlm.pm
+++ b/tests/ha/dlm.pm
@@ -17,11 +17,7 @@ sub run() {
     my $self = shift;
     $self->barrier_wait("DLM_INIT");
     type_string "rpm -q dlm-kmp-default; echo dlm_kmp_default_installed=\$? > /dev/$serialdev\n";
-    if (!wait_serial "dlm_kmp_default_installed=0") {    #workaround for bsc#976634
-        record_soft_failure "dlm-kmp-default is not installed";
-        assert_script_run "zypper in -y dlm-kmp-default";
-    }
-    if ($self->is_node1) {                               #node1
+    if ($self->is_node1) {    #node1
         type_string "echo wait until DLM resource is created\n";
     }
     else {

--- a/tests/ha/ocfs2.pm
+++ b/tests/ha/ocfs2.pm
@@ -17,11 +17,6 @@ sub run() {
     my $self            = shift;
     my $ocfs2_partition = "/dev/disk/by-path/ip-*-lun-2";
     $self->barrier_wait("OCFS2_INIT");
-    type_string "rpm -q ocfs2-kmp-default; echo ocfs2_kmp_default_installed=\$? > /dev/$serialdev\n";
-    if (!wait_serial "ocfs2_kmp_default_installed=0") {    #workaround for bsc#976634
-        record_soft_failure "ocfs2-kmp-default is not installed";
-        assert_script_run "zypper in -y ocfs2-kmp-default";
-    }
     type_string "ps -A | grep -q dlm_controld; echo dlm_running=\$? > /dev/$serialdev\n";
     die "dlm_controld is not running" unless wait_serial "dlm_running=0", 60;
     if ($self->is_node1) {


### PR DESCRIPTION
I really, really, don't like the idea of having tests softfail when working around basic stuff like installing core packages that are part of the product, so this PR removes the workaround that installs kmps that should be installed as part of the basic HA install.