### PR TITLE
Proper wait for password prompt

### DIFF
--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -39,8 +39,12 @@ sub run() {
             assert_and_click "sddm-password-input";
         }
         else {
+            wait_still_screen;
             send_key "ret";
-            wait_idle;
+            if (!check_screen "displaymanager-password-prompt") {
+                record_soft_failure;
+                assert_screen "displaymanager-password-prompt";
+            }
         }
         type_string "$password";
         send_key "ret";


### PR DESCRIPTION
wait_idle is un-effective because system is idle and password field need some
time to be active after return is pressed e.g.
https://openqa.suse.de/tests/385825/modules/first_boot/steps/5