### PR TITLE
Use ocf:heartbeat:clvm instead of ocf:lvm2:clvmd

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -181,6 +181,10 @@ unless (get_var('INSTLANG')) {
 set_var('NOAUTOLOGIN', 1);
 set_var('HASLICENSE',  1);
 
+if (version_at_least('12-SP2')) {
+    set_var('SP2ORLATER', 1);
+}
+
 if (!get_var('NETBOOT')) {
     set_var('DVD', 1);
 }


### PR DESCRIPTION
Since sle12-sp2 we recommend to use clvmd.ocf from upstream

sample test run: http://ix64sap002.qa.suse.de/tests/432