### PR TITLE
Add entry for FIPS test suites in main.pm

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -996,6 +996,10 @@ sub load_online_migration_tests() {
     loadtest "online_migration/sle12_online_migration/post_migration.pm";
 }
 
+sub load_fips_tests_web() {
+    loadtest "console/curl_https.pm";
+}
+
 sub prepare_target() {
     if (get_var("BOOT_HDD_IMAGE")) {
         loadtest "boot/boot_to_desktop.pm";
@@ -1065,6 +1069,15 @@ elsif (get_var("SUPPORT_SERVER")) {
     loadtest "support_server/setup.pm";
     unless (load_slenkins_tests()) {
         loadtest "support_server/wait.pm";
+    }
+}
+elsif (get_var("FIPS_TS")) {
+    if (check_var("FIPS_TS", "setup")) {
+        prepare_target();
+    }
+    elsif (check_var("FIPS_TS", "web")) {
+        loadtest "boot/boot_to_desktop.pm";
+        load_fips_tests_web;
     }
 }
 elsif (get_var("HACLUSTER_SUPPORT_SERVER")) {


### PR DESCRIPTION
The "FIPS setup" test suite is the basic one to make the image
for FIPS tests afterwards. The setup test suite must be run with
FIPS=1 variable to make sure the FIPS pattern is enabled during
image installation. And other FIPS test suites should be run upon
the generated image.