### PR TITLE
modify&add yast_virtualization virtman_view to run in regression_others group

### DIFF
--- a/lib/virtmanager.pm
+++ b/lib/virtmanager.pm
@@ -15,9 +15,11 @@ sub launch_virtmanager() {
     type_string "virt-manager", 50;
     send_key "ret";
     wait_idle;
-    type_password;
-    send_key "ret";
-    wait_idle;
+    if (check_screen("virt-manager-auth")) {
+        type_password;
+        send_key "ret";
+        wait_idle;
+    }
     save_screenshot;
 }
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -401,6 +401,8 @@ sub load_x11regression_other() {
         loadtest "x11regressions/shotwell/shotwell_import.pm";
         loadtest "x11regressions/shotwell/shotwell_edit.pm";
         loadtest "x11regressions/shotwell/shotwell_export.pm";
+        loadtest "virtualization/yast_virtualization.pm";
+        loadtest "virtualization/virtman_view.pm";
     }
     if (get_var("DESKTOP") =~ /kde|gnome/) {
         loadtest "x11regressions/tracker/prep_tracker.pm";

--- a/tests/virtualization/virtman_view.pm
+++ b/tests/virtualization/virtman_view.pm
@@ -24,6 +24,7 @@ sub run {
     launch_virtmanager();
     # go to preferences
     send_key "alt-e";
+    wait_still_screen;
     send_key "p", 1;
     # go to polling
     send_key "right";

--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -8,15 +8,21 @@ sub run() {
     wait_idle;
     send_key "alt-f10";
     become_root;
-    script_run "yast2 virtualization";
-    wait_idle;
-    assert_screen "virt-sle12sp1-gnome_yast_virtualization", 50;
-    # select everything
-    send_key "alt-x", 10;    # XEN Server
-    send_key "alt-e", 10;    # Xen tools
-    send_key "alt-k", 10;    # KVM Server
-    send_key "alt-v", 10;    # KVM tools
-    send_key "alt-l", 10;    # libvirt-lxc
+    script_run("/sbin/yast2 virtualization; echo yast2-virtualization-done-\$? > /dev/$serialdev", 0);
+    assert_screen "virt-sle-gnome_yast_virtualization";
+    if (check_var("FLAVOR", "Desktop-DVD")) {
+        # select everything
+        send_key "alt-v";    # Virtualization client tools
+        send_key "alt-l";    # libvirt-lxc
+    }
+    else {
+        # select everything
+        send_key "alt-x";    # XEN Server
+        send_key "alt-e";    # Xen tools
+        send_key "alt-k";    # KVM Server
+        send_key "alt-v";    # KVM tools
+        send_key "alt-l";    # libvirt-lxc
+    }
 
     # launch the installation
     send_key "alt-a";
@@ -28,12 +34,14 @@ sub run() {
     if (get_var("STANDALONEVT")) {
         assert_screen "virt-sle12sp1-gnome_yast_virtualization_OK", 200;
     }
-    else {
-        assert_screen "virt-sle12sp1-gnome_yast_virtualization_bridge", 200;
+    if (check_screen("virt-sle12sp1-gnome_yast_virtualization_bridge", 120)) {
         # select yes
         send_key "alt-y";
     }
+
+    assert_screen "virt-sle-gnome_yast_virtualization_installed", 60;
     send_key "alt-o";
+    wait_serial("yast2-virtualization-done-0", 200) || die "yast2 virtualization failed";
     # close the xterm
     send_key "alt-f4";
     # now need to start libvirtd


### PR DESCRIPTION
Testing Result:

- on SLED: http://147.2.212.239/tests/482

- on SLES: http://147.2.212.239/tests/481

This commit is based on Antoine's commit (https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/9ef5cae), since we want to see how virt-manager and virt-viewer works in SLE Desktop SP2 as a graphic client. But on SLE Desktop,we do not provide host qemu packages.

So at last I only modified 2 cases :
- yast_virtualization
- virtman_view
to run in SLED and added them to regression_others， and my modification won't influence the tests on SLES.