### PR TITLE
Get rid of explicit sleeps in gnome terminal test

### DIFF
--- a/tests/x11/gnome_terminal.pm
+++ b/tests/x11/gnome_terminal.pm
@@ -12,22 +12,17 @@ use base "x11test";
 use strict;
 use testapi;
 
-# test gnome-terminal
-
-# this part contains the steps to run this test
 sub run() {
     my $self = shift;
     mouse_hide(1);
     x11_start_program("gnome-terminal");
-    sleep 10;
+    assert_screen "gnome-terminal";
     send_key "ctrl-shift-t";
+    assert_screen "gnome-terminal-second-tab";
     for (1 .. 13) { send_key "ret" }
     type_string "echo If you can see this text gnome-terminal is working.\n";
-    sleep 2;
-    assert_screen 'test-gnome_terminal-1', 3;
-    sleep 2;
+    assert_screen 'test-gnome_terminal-1';
     send_key "alt-f4";
-    sleep 2;
 }
 
 1;


### PR DESCRIPTION
SLE verification job: http://lord.arch.suse.de/tests/93
TW verification job: http://lord.arch.suse.de/tests/152

![openqa_local_test_gnome_terminal](https://cloud.githubusercontent.com/assets/1693432/15319106/84c0ded6-1c29-11e6-9389-750e7684123a.png)

TW needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/69
SLE needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/132