### PR TITLE
Use more robust assert_script_run to fix 'rpm -q'

### DIFF
--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -98,8 +98,7 @@ sub run() {
     clear_console;                           # clear screen to see that second update does not do any more
     assert_script_run("rpm -e $pkgname");    # erase $pkgname
     script_run("echo mark yast test", 0);    # avoid zpper needle
-    script_run("rpm -q $pkgname",     0);
-    assert_screen("yast-package-$pkgname-not-installed", 1);
+    assert_script_run("! rpm -q $pkgname");
 }
 
 1;

--- a/tests/console/zypper_in.pm
+++ b/tests/console/zypper_in.pm
@@ -23,8 +23,7 @@ sub run() {
     assert_script_run("zypper -n in screen $pkgname");
     clear_console;    # clear screen to see that second update does not do any more
     assert_script_run("rpm -e $pkgname");
-    script_run("rpm -q $pkgname", 0);
-    assert_screen "package-$pkgname-not-installed", 5;
+    assert_script_run("! rpm -q $pkgname");
 }
 
 1;


### PR DESCRIPTION
'assert_screen' was used with a very delicate timeout of just 1 second causing
failures like https://openqa.suse.de/tests/389855/modules/yast2_i/steps/20

Verification test run: http://lord.arch/tests/149

Related progress issue: https://progress.opensuse.org/issues/12020