### PR TITLE
Add post_fail_hook to install_patterns tests

### DIFF
--- a/tests/qam-minimal/install_patterns.pm
+++ b/tests/qam-minimal/install_patterns.pm
@@ -44,4 +44,9 @@ sub test_flags {
     return {fatal => 1};
 }
 
+sub post_fail_hook {
+    assert_script_run "save_y2logs /tmp/y2logs-fail.tar.bz2";
+    upload_logs "/tmp/y2logs-fail.tar.bz2";
+}
+
 1;


### PR DESCRIPTION
wee need capture zypper.log and other related files in https://openqa.suse.de/tests/391197/modules/install_patterns/steps/10