### PR TITLE
Fix smt migration with SCC registered pre-installed image

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -26,14 +26,16 @@ our @EXPORT = qw/fill_in_registration_data registration_bootloader_params yast_s
 
 sub fill_in_registration_data {
     my ($addon, $uc_addon);
-    send_key "alt-m";        # select email field if yast2 add-on
-    send_key "alt-e";        # select email field if installation
-    send_key "backspace";    # delete m or e
-    type_string get_var("SCC_EMAIL");
-    send_key "alt-c";        # select registration code field
-    type_string get_var("SCC_REGCODE");
-    save_screenshot;
-    send_key "alt-n", 1;
+    if (!get_var("HDD_SCC_REGISTERED")) {
+        send_key "alt-m";        # select email field if yast2 add-on
+        send_key "alt-e";        # select email field if installation
+        send_key "backspace";    # delete m or e
+        type_string get_var("SCC_EMAIL");
+        send_key "alt-c";        # select registration code field
+        type_string get_var("SCC_REGCODE");
+        save_screenshot;
+        send_key "alt-n", 1;
+    }
     unless (get_var('SCC_REGISTER', '') =~ /addon|network/) {
         my @tags = qw/local-registration-servers registration-online-repos import-untrusted-gpg-key module-selection contacting-registration-server/;
         push @tags, 'untrusted-ca-cert' if get_var('SCC_URL');

--- a/tests/installation/scc_registration.pm
+++ b/tests/installation/scc_registration.pm
@@ -20,17 +20,9 @@ use testapi;
 use registration;
 
 sub run() {
-    if (get_var("SCC_EXPECT_ERROR")) {
-        while (1) {
-            if (check_screen 'registration-error') {
-                send_key 'alt-o';
-                wait_still_screen;
-                next;
-            }
-            last;
-        }
+    if (!get_var("HDD_SCC_REGISTERED")) {
+        assert_screen("scc-registration", 100);
     }
-    assert_screen("scc-registration", 100);
     fill_in_registration_data;
 }
 


### PR DESCRIPTION
I have no idea what changed, but now registration within smt migration works like a charm.
http://10.100.98.90/tests/1897