### PR TITLE
Upload also wicked logs when network interface is down

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -3,6 +3,7 @@ use base 'basetest';
 
 use testapi;
 use utils;
+use mm_network;
 use strict;
 
 # Base class for all openSUSE tests
@@ -30,11 +31,63 @@ sub save_and_upload_log {
     save_screenshot if $args->{screenshot};
 }
 
+sub export_wicked_logs {
+    my $self = shift;
+
+    # https://en.opensuse.org/openSUSE:Bugreport_wicked
+    type_string "systemctl status wickedd.service\n";
+    type_string "echo `wicked show all |cut -d ' ' -f 1` END | tee /dev/$serialdev\n";
+    my $iflist = wait_serial("END", 10);
+    $iflist =~ s/\bEND\b//g;
+    $iflist =~ s/\blo\b//g;
+    $iflist =~ s/^\s*//g;
+    $iflist =~ s/\s*$//g;
+
+    my $up = 1;
+    for my $if (split(/\s+/, $iflist)) {
+        type_string "wicked show '$if' |head -n1|awk '{print\$2}'| tee /dev/$serialdev\n";
+        $up = 0 if !wait_serial("up", 10);
+    }
+    if (!$up) {
+        type_string "mkdir /tmp/wicked\n";
+        # enable debugging
+        type_string "perl -i -lpe 's{^(WICKED_DEBUG)=.*}{\$1=\"all\"};s{^(WICKED_LOG_LEVEL)=.*}{\$1=\"debug\"}' /etc/sysconfig/network/config\n";
+        type_string "egrep \"WICKED_DEBUG|WICKED_LOG_LEVEL\" /etc/sysconfig/network/config\n";
+        # restart the daemons
+        type_string "systemctl restart wickedd\n";
+        save_screenshot;
+        # reapply the config
+        type_string "wicked --debug all ifup all\n";
+        save_screenshot;
+        # collect the configuration
+        type_string "wicked show-config > /tmp/wicked/config-dump.log\n";
+        sleep 5;
+        # collect the status
+        type_string "wicked ifstatus --verbose all > /tmp/wicked/status.log\n";
+        type_string "journalctl -b -o short-precise > /tmp/wicked/wicked.log\n";
+        type_string "ip addr show > /tmp/wicked/ip_addr.log\n";
+        type_string "ip route show table all > /tmp/wicked/routes.log\n";
+        # collect network information
+        type_string "hwinfo --netcard > /tmp/wicked/hwinfo-netcard.log\n";
+        # setup static network, if network interface is down, to be able upload logs.
+        configure_default_gateway;
+        configure_static_ip('10.0.2.1/24');
+        configure_static_dns(get_host_resolv_conf());
+        type_string "tar -czf /tmp/wicked_logs.tgz /etc/sysconfig/network /tmp/wicked\n";
+        upload_logs "/tmp/wicked_logs.tgz";
+        save_screenshot;
+    }
+}
+
 sub export_logs {
     my $self = shift;
 
     select_console 'root-console';
     save_screenshot;
+
+    # check if wicked is installed and turn on debug, get all needed wicked logs if network interface is down
+    my $wicked_installed = script_run 'rpm -q wicked';
+    export_wicked_logs if $wicked_installed;
 
     save_and_upload_log('cat /proc/loadavg', '/tmp/loadavg',     {screenshot => 1});
     save_and_upload_log('journalctl -b',     '/tmp/journal.log', {screenshot => 1});

--- a/tests/autoyast/wicked.pm
+++ b/tests/autoyast/wicked.pm
@@ -14,50 +14,13 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 use strict;
-use base 'basetest';
+use base 'consoletest';
 use testapi;
 
 sub run {
+    my $self = shift;
 
-    # https://en.opensuse.org/openSUSE:Bugreport_wicked
-    type_string "systemctl status wickedd.service\n";
-    type_string "echo `wicked show all |cut -d ' ' -f 1` END | tee /dev/$serialdev\n";
-    my $iflist = wait_serial("END", 10);
-    $iflist =~ s/\bEND\b//g;
-    $iflist =~ s/\blo\b//g;
-    $iflist =~ s/^\s*//g;
-    $iflist =~ s/\s*$//g;
-
-    my $up = 1;
-    for my $if (split(/\s+/, $iflist)) {
-        type_string "wicked show '$if' |head -n1|awk '{print\$2}'| tee /dev/$serialdev\n";
-        $up = 0 if !wait_serial("up", 10);
-    }
-    if (!$up) {
-        type_string "mkdir /tmp/wicked\n";
-        # enable debugging
-        type_string "perl -i -lpe 's{^(WICKED_DEBUG)=.*}{\$1=\"all\"};s{^(WICKED_LOG_LEVEL)=.*}{\$1=\"debug\"}' /etc/sysconfig/network/config\n";
-        type_string "egrep \"WICKED_DEBUG|WICKED_LOG_LEVEL\" /etc/sysconfig/network/config\n";
-        # restart the daemons
-        type_string "systemctl restart wickedd\n";
-        save_screenshot;
-        # reapply the config
-        type_string "wicked --debug all ifup all\n";
-        save_screenshot;
-        # collect the configuration
-        type_string "wicked show-config > /tmp/wicked/config-dump.log\n";
-        sleep 5;
-        # collect the status
-        type_string "wicked ifstatus --verbose all > /tmp/wicked/status.log\n";
-        type_string "journalctl -b -o short-precise > /tmp/wicked/wicked.log\n";
-        type_string "ip addr show > /tmp/wicked/ip_addr.log\n";
-        type_string "ip route show table all > /tmp/wicked/routes.log\n";
-        # collect network information
-        type_string "hwinfo --netcard > /tmp/wicked/hwinfo-netcard.log\n";
-        type_string "tar -czf /tmp/wicked_logs.tgz /etc/sysconfig/network /tmp/wicked\n";
-        upload_logs "/tmp/wicked_logs.tgz";
-        save_screenshot;
-    }
+    $self->export_logs();
 }
 
 1;


### PR DESCRIPTION
I guess it's useful here, to upload any log at all https://openqa.suse.de/tests/391792/modules/consoletest_setup/steps/22

would look like:
http://10.100.98.90/tests/1906