### PR TITLE
Increase STONITH timeout in HA tests

### DIFF
--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -21,12 +21,25 @@ sub run() {
         type_string "ha-cluster-init -y -s /dev/disk/by-path/ip-*-lun-0; echo ha_cluster_init=\$? > /dev/$serialdev\n";
         die "ha-cluster-init failed" unless wait_serial "ha_cluster_init=0", 60;
     }
-    #    assert_script_run "sbd -d $sbd_device -1 30 create"; #create SBD with 30s watchdog timeout
-    #    assert_script_run "sbd -d $sbd_device dump";
-    #    save_screenshot;
     upload_logs "/var/log/ha-cluster-bootstrap.log";
     type_string "crm_mon -1\n";
     save_screenshot;
+    assert_script_run "crm resource stop stonith-sbd";
+    assert_script_run "crm_mon -1";
+    assert_script_run "sbd -d $sbd_device message " . get_var("HOSTNAME") . " exit";
+    type_string "ps -A | grep sbd\n";
+    assert_script_run "sbd -d $sbd_device -1 30 -4 60 create";
+    assert_script_run "crm resource start stonith-sbd";
+    assert_script_run "systemctl restart pacemaker";
+    save_screenshot;
+    for (1 .. 5) {
+        $self->clear_and_verify_console;
+        assert_script_run "crm_mon -1";
+        if (check_screen("ha-crm-mon-" . get_var("CLUSTERNAME") . "-host1-online", 5)) {
+            last;
+        }
+    }
+    assert_screen("ha-crm-mon-" . get_var("CLUSTERNAME") . "-host1-online");
     $self->barrier_wait("CLUSTER_INITIALIZED");
     $self->barrier_wait("NODE2_JOINED");
     type_string "crm_mon -1\n";


### PR DESCRIPTION
Default timeout is 5 seconds, and it's not enough on busy openQA workers: sometimes nodes fence randomly.