### PR TITLE
Simplify qam tests and make them reusable

### DIFF
--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -17,21 +17,7 @@ use Exporter;
 use testapi;
 use utils;
 
-our @EXPORT = qw/capture_state system_login/;
-
-sub system_login {
-    wait_boot(textmode => 1);
-    if (!check_var('ARCH', 's390x')) {
-        assert_screen "text-login", 50;
-        type_string "root\n";
-        assert_screen "password-prompt", 10;
-        type_password;
-        type_string "\n";
-    }
-    sleep 2;
-
-    $testapi::distri->set_standard_prompt;
-}
+our @EXPORT = qw/capture_state/;
 
 sub capture_state {
     my ($state, $y2logs) = @_;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -45,7 +45,7 @@ sub unregister_needle_tags {
 
 sub remove_desktop_needles {
     my $desktop = shift;
-    if (!check_var("DESKTOP", $desktop)) {
+    if (!check_var("DESKTOP", $desktop) && !check_var("FULL_DESKTOP", $desktop)) {
         unregister_needle_tags("ENV-DESKTOP-$desktop");
     }
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -593,13 +593,13 @@ sub load_inst_tests() {
 }
 
 sub load_reboot_tests() {
-    if (check_var("ARCH", "s390x") and !get_var("QAM_MINIMAL")) {
+    if (check_var("ARCH", "s390x")) {
         loadtest "installation/reconnect_s390.pm";
     }
     if (uses_qa_net_hardware) {
         loadtest "boot/qa_net_boot_from_hdd.pm";
     }
-    if (installyaststep_is_applicable and !get_var("QAM_MINIMAL")) {
+    if (installyaststep_is_applicable) {
         # test makes no sense on s390 because grub2 can't be captured
         if (!check_var("ARCH", "s390x")) {
             loadtest "installation/grub_test.pm";
@@ -1089,6 +1089,12 @@ elsif (get_var("QAM_MINIMAL")) {
         loadtest "qam-minimal/install_patterns.pm";
         load_consoletests();
         load_x11tests();
+
+        # actually we are using textmode until install_patterns.pm installs the gnome pattern
+        # save DESKTOP variable here and restore it in install_patterns.pm
+        # we do this after scheduling all tests for the original DESKTOP
+        set_var('FULL_DESKTOP', get_var('DESKTOP'));
+        set_var('DESKTOP',      'textmode');
     }
 }
 elsif (get_var("EXTRATEST")) {

--- a/tests/qam-minimal/check_logs.pm
+++ b/tests/qam-minimal/check_logs.pm
@@ -15,6 +15,7 @@ use qam;
 use testapi;
 
 sub run {
+    select_console 'root-console';
     # we should get the same IP setup after every reboot, but for now
     # we can't assert this
     script_run("diff -u /tmp/ip_a_before.log /tmp/ip_a_after.log");

--- a/tests/qam-minimal/install_patterns.pm
+++ b/tests/qam-minimal/install_patterns.pm
@@ -17,6 +17,7 @@ use qam;
 use testapi;
 
 sub run {
+    select_console 'root-console';
 
     script_run("while pgrep packagekitd; do pkcon quit; sleep 1; done");
 
@@ -30,6 +31,9 @@ sub run {
     assert_script_run("systemctl set-default graphical.target");
     assert_script_run('sed -i -r "s/^DISPLAYMANAGER=\"\"/DISPLAYMANAGER=\"gdm\"/" /etc/sysconfig/displaymanager');
     assert_script_run('sed -i -r "s/^DISPLAYMANAGER_AUTOLOGIN/#DISPLAYMANAGER_AUTOLOGIN/" /etc/sysconfig/displaymanager');
+
+    # now we have gnome installed - restore DESKTOP variable
+    set_var('DESKTOP', get_var('FULL_DESKTOP'));
 
     prepare_system_reboot;
     type_string "reboot\n";

--- a/tests/qam-minimal/install_update.pm
+++ b/tests/qam-minimal/install_update.pm
@@ -17,8 +17,7 @@ use qam;
 use testapi;
 
 sub run {
-    prepare_system_reboot;
-    system_login;
+    select_console 'root-console';
 
     script_run("while pgrep packagekitd; do pkcon quit; sleep 1; done");
 
@@ -36,8 +35,10 @@ sub run {
     zypper_call(qq{in -l -y -t patch \$(zypper patches | awk -F "|" '/test-minimal/ { print \$2;}')}, [0, 102, 103]);
 
     capture_state('between', 1);
+
     prepare_system_reboot;
     type_string "reboot\n";
+    wait_boot;
 }
 
 sub test_flags {

--- a/tests/qam-minimal/update_minimal.pm
+++ b/tests/qam-minimal/update_minimal.pm
@@ -15,7 +15,7 @@ use qam;
 use testapi;
 
 sub run {
-    system_login;
+    select_console 'root-console';
 
     script_run("while pgrep packagekitd; do pkcon quit; sleep 1; done");
 
@@ -30,11 +30,7 @@ sub run {
 
     prepare_system_reboot;
     type_string "reboot\n";
-
-    reset_consoles;
-
-    # wait for the reboot
-    system_login;
+    wait_boot;
 }
 
 sub test_flags {


### PR DESCRIPTION
This needs to be tested on s390 before merge.

use standard functions for boot and console
maintain correct value of DESKTOP variable so the standard functions
work correctly