### PR TITLE
reneedling for regression test: gnote and gedit - pass on build 620

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -343,7 +343,9 @@ sub load_x11regression_documentation() {
         loadtest "x11regressions/evince/evince_find.pm";
         loadtest "x11regressions/gedit/gedit_launch.pm";
         loadtest "x11regressions/gedit/gedit_save.pm";
-        loadtest "x11regressions/gedit/gedit_about.pm";
+        if (not get_var("SP2ORLATER")) {
+            loadtest "x11regressions/gedit/gedit_about.pm";
+        }
         loadtest "x11regressions/libreoffice/libreoffice_mainmenu_favorites.pm";
         loadtest "x11regressions/libreoffice/libreoffice_open_specified_file.pm";
         loadtest "x11regressions/libreoffice/libreoffice_double_click_file.pm";

--- a/tests/x11regressions/gnote/gnote_link_note.pm
+++ b/tests/x11regressions/gnote/gnote_link_note.pm
@@ -33,6 +33,9 @@ sub run() {
     sleep 2;
     send_key "ret";
     send_key "down";
+    if (get_var("SP2ORLATER")) {
+        send_key "ret";
+    }
     assert_screen 'gnote-what-link-here', 5;
     send_key "esc";
     send_key "ctrl-w";      #close the note "Start Here"


### PR DESCRIPTION
(remove gnote_about from main.pm for 'about' is not support in gedit)

local running result:
http://147.2.212.232/tests/805