### PR TITLE
Increase timeout and make wait_serial die for dasdfmt

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -174,7 +174,7 @@ sub format_dasd() {
     type_string("dasdfmt -b 4096 -p /dev/dasda; echo dasdfmt-status-$?- > /dev/$serialdev\n");
     sleep 2;
     type_string("yes\n");
-    wait_serial("dasdfmt-status-0-", 900);
+    wait_serial("dasdfmt-status-0-", 900) || die "dasdfmt could not finish";
 }
 
 sub run() {

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -174,7 +174,7 @@ sub format_dasd() {
     type_string("dasdfmt -b 4096 -p /dev/dasda; echo dasdfmt-status-$?- > /dev/$serialdev\n");
     sleep 2;
     type_string("yes\n");
-    wait_serial("dasdfmt-status-0-", 900) || die "dasdfmt could not finish";
+    wait_serial("dasdfmt-status-0-", 1200) || die "dasdfmt could not finish";
 }
 
 sub run() {


### PR DESCRIPTION
Increase timeout to 20 minutes for formatting DASD, sometimes it takes longer than 15 minutes,
also make wait_serial dieing if dasdfmt doesn't finish, because otherwise it leads to unstable state of DASD.

see for example:
https://openqa.suse.de/tests/387212/modules/disk_activation/steps/8
related bsc: https://bugzilla.suse.com/show_bug.cgi?id=980145