### PR TITLE
Increment install timeout.

### DIFF
--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -17,7 +17,7 @@ use bmwqemu ();
 sub run() {
     my $self = shift;
     # NET isos are slow to install
-    my $timeout = 2000;
+    my $timeout = 3000;
 
     # workaround for yast popups
     my @tags = qw/rebootnow/;


### PR DESCRIPTION
Installation on aarch64 fails, because the timeout is reached. Increment the timeout to fix this.

https://openqa.opensuse.org/tests/178398/modules/install_and_reboot/steps/21
https://openqa.opensuse.org/tests/178396/modules/install_and_reboot/steps/21