### PR TITLE
openSUSE: No longer test xchat

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -777,7 +777,6 @@ sub load_x11tests() {
         && !system_is_livesystem)
     {
         loadtest "x11/gnucash.pm";
-        loadtest "x11/xchat.pm";
         loadtest "x11/hexchat.pm";
         loadtest "x11/vlc.pm";
         # chrome pulls in lsb which creates /media (bug#915562),


### PR DESCRIPTION
Xchat has been removed in favor of hexchat in openSUSE

> osc log -D openSUSE:Factory xchat
r38 | dimstar_suse | 2016-03-29 07:55:04 | 03b3708f1cc825d53a7398ecfeddd192 | 2.8.8 | rq376752