### PR TITLE
Use more explicit "boot_to_desktop" as last step of post_zdup

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -463,6 +463,7 @@ sub load_zdup_tests() {
     loadtest 'installation/setup_zdup.pm';
     loadtest 'installation/zdup.pm';
     loadtest 'installation/post_zdup.pm';
+    loadtest 'boot/boot_to_desktop.pm';
 }
 
 sub load_consoletests() {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -637,6 +637,7 @@ sub load_zdup_tests() {
     loadtest "installation/setup_zdup.pm";
     loadtest "installation/zdup.pm";
     loadtest "installation/post_zdup.pm";
+    loadtest 'boot/boot_to_desktop.pm';
 }
 
 sub load_consoletests() {

--- a/tests/installation/post_zdup.pm
+++ b/tests/installation/post_zdup.pm
@@ -36,8 +36,6 @@ sub run() {
     assert_screen "text-login";
     # Reboot after dup
     send_key "ctrl-alt-delete";
-
-    wait_boot;
 }
 
 1;


### PR DESCRIPTION
The migration and upgrade tests are expected to reach a fully working desktop
session which was handled by "wait_boot". As we recently failed tests a lot
in this state even though the issue had nothing to do with the migration or
upgrade itself this should be made more explicit by using the test step called
"boot_to_desktop" to resemble this.

Verification run: http://lord.arch/tests/158

## Example screenshots:
### finished:
![openqa_boot_to_desktop_finished](https://cloud.githubusercontent.com/assets/1693432/15482353/6e99e85e-212f-11e6-80ef-86ed97988ae3.png)
### running:
![openqa_boot_to_desktop_running](https://cloud.githubusercontent.com/assets/1693432/15482354/6e9d0e26-212f-11e6-84ce-22579a7c9282.png)
