### PR TITLE
Increase timeout for boot on zKVM

### DIFF
--- a/tests/installation/reconnect_s390.pm
+++ b/tests/installation/reconnect_s390.pm
@@ -36,7 +36,7 @@ sub run() {
         select_console('iucvconn');
     }
     else {
-        wait_serial("Welcome to SUSE Linux Enterprise Server") || die "System couldn't boot";
+        wait_serial("Welcome to SUSE Linux Enterprise Server", 300) || die "System couldn't boot";
     }
 
     if (!check_var('DESKTOP', 'textmode')) {


### PR DESCRIPTION
in some test scenarios the default timeout of 90s for wait_serial seems to
be not enough. So let's increase this to 300, like we do on zVM