### PR TITLE
The logging fixes for GNOME

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -38,7 +38,6 @@ sub export_logs {
 
     save_and_upload_log('cat /proc/loadavg', '/tmp/loadavg',     {screenshot => 1});
     save_and_upload_log('journalctl -b',     '/tmp/journal.log', {screenshot => 1});
-    save_and_upload_log('cat /var/log/X*',   '/tmp/Xlogs.log',   {screenshot => 1});
     save_and_upload_log('ps axf',            '/tmp/psaxf.log',   {screenshot => 1});
 
     my @xse_files = glob('/home/*/.xsession-errors*');
@@ -47,6 +46,14 @@ sub export_logs {
         #if does not have .xsession-errors existence probably it was combined in jounalctl
         save_and_upload_log('cat /home/*/.xsession-errors*', '/tmp/XSE.log', {screenshot => 1});
         last;
+    }
+
+    my $xorg_log_path = '/home/*/.local/share/xorg';
+    if (-d $xorg_log_path) {
+        save_and_upload_log("cat $xorg_log_path/X*", '/tmp/Xlogs.log', {screenshot => 1});
+    }
+    else {
+        save_and_upload_log('cat /var/log/X*', '/tmp/Xlogs.log', {screenshot => 1});
     }
 
     save_and_upload_log('systemctl list-unit-files', '/tmp/systemctl_unit-files.log');

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -36,11 +36,18 @@ sub export_logs {
     select_console 'root-console';
     save_screenshot;
 
-    save_and_upload_log('cat /proc/loadavg',             '/tmp/loadavg',     {screenshot => 1});
-    save_and_upload_log('cat /home/*/.xsession-errors*', '/tmp/XSE.log',     {screenshot => 1});
-    save_and_upload_log('journalctl -b',                 '/tmp/journal.log', {screenshot => 1});
-    save_and_upload_log('cat /var/log/X*',               '/tmp/Xlogs.log',   {screenshot => 1});
-    save_and_upload_log('ps axf',                        '/tmp/psaxf.log',   {screenshot => 1});
+    save_and_upload_log('cat /proc/loadavg', '/tmp/loadavg',     {screenshot => 1});
+    save_and_upload_log('journalctl -b',     '/tmp/journal.log', {screenshot => 1});
+    save_and_upload_log('cat /var/log/X*',   '/tmp/Xlogs.log',   {screenshot => 1});
+    save_and_upload_log('ps axf',            '/tmp/psaxf.log',   {screenshot => 1});
+
+    my @xse_files = glob('/home/*/.xsession-errors*');
+    for my $file (@xse_files) {
+        next if -z $file;
+        #if does not have .xsession-errors existence probably it was combined in jounalctl
+        save_and_upload_log('cat /home/*/.xsession-errors*', '/tmp/XSE.log', {screenshot => 1});
+        last;
+    }
 
     save_and_upload_log('systemctl list-unit-files', '/tmp/systemctl_unit-files.log');
     save_and_upload_log('systemctl status',          '/tmp/systemctl_status.log');


### PR DESCRIPTION
1) don't upload empty ```.xsessions-errors```, eg. it was combined in journal if GNOME
2) Xlogs now are under user's home ie. ```/home/*/.local/share/xorg``` for GNOME, upload xlogs from new path instead.