### PR TITLE
Support seabios version 1.9 and later

### DIFF
--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -28,7 +28,9 @@ sub run() {
     }
     if (get_var("USBBOOT")) {
         assert_screen "boot-menu", 1;
-        send_key "f12";
+        # support multiple versions of seabios, does not harm to press
+        # multiple keys here: seabios<1.9: f12, seabios=>1.9: esc
+        send_key((match_has_tag 'boot-menu-esc') ? 'esc' : 'f12');
         assert_screen "boot-menu-usb", 4;
         send_key(2 + get_var("NUMDISKS"));
     }


### PR DESCRIPTION
Fixes issues like
https://openqa.suse.de/tests/404286/modules/bootloader/steps/2
where the bootloader does not accept "f12" anymore where esc is expected.

Verification run for SLE seabios v1.8: http://lord.arch/tests/250

Needs new needle for seabios >= 1.9 with tag 'boot-menu-esc'