### PR TITLE
[WIP] Packagekit updates

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -253,7 +253,7 @@ sub gnomestep_is_applicable() {
 }
 
 sub guiupdates_is_applicable() {
-    return get_var("DESKTOP") =~ /gnome|kde/;
+    return get_var("DESKTOP") =~ /gnome|kde|xfce|lxde/;
 }
 
 sub lxdestep_is_applicable() {
@@ -667,20 +667,25 @@ sub load_x11tests() {
         loadtest "x11/awesome_xterm.pm";
         return;
     }
-
+    if (guiupdates_is_applicable) {
+        if (check_var("DESKTOP", "kde")) {
+            loadtest "x11/updates_packagekit_kde.pm";
+        }
+        else {
+            loadtest "x11/updates_packagekit_gpk.pm";
+        }
+    }
     if (xfcestep_is_applicable) {
         loadtest "x11/xfce4_terminal.pm";
     }
     loadtest "x11/xterm.pm";
     loadtest "x11/sshxterm.pm" unless get_var("LIVETEST");
     if (gnomestep_is_applicable) {
-        loadtest "x11/updates_gnome.pm";
         loadtest "x11/gnome_control_center.pm";
         loadtest "x11/gnome_terminal.pm";
         loadtest "x11/gedit.pm";
     }
     if (kdestep_is_applicable) {
-        loadtest "x11/updates_kde.pm";
         loadtest "x11/kate.pm";
     }
     loadtest "x11/firefox.pm";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -807,7 +807,7 @@ sub load_x11tests() {
     loadtest "x11/xterm.pm";
     loadtest "x11/sshxterm.pm";
     if (gnomestep_is_applicable) {
-        loadtest "x11/updates_gnome.pm";
+        loadtest "x11/updates_packagekit_gpk.pm";
         loadtest "x11/gnome_control_center.pm";
         loadtest "x11/gnome_terminal.pm";
         loadtest "x11/gedit.pm";

--- a/tests/x11/updates_packagekit_kde.pm
+++ b/tests/x11/updates_packagekit_kde.pm
@@ -18,6 +18,7 @@ sub pre_run_hook() {
     send_key("alt-o");
 }
 
+# Update with Plasma applet for software updates using PackageKit
 sub run() {
     my @updates_installed_tags = qw/updates_none updates_available/;
 


### PR DESCRIPTION
Use packagekit application for updates on desktop installation instead of zypper up.
https://progress.opensuse.org/issues/9492

Depends on:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/74