### PR TITLE
Change variable SCC_URL to be SMT_URL

### DIFF
--- a/tests/online_migration/sle12_online_migration/register_system.pm
+++ b/tests/online_migration/sle12_online_migration/register_system.pm
@@ -16,7 +16,10 @@ sub run() {
     my $self = shift;
     select_console 'root-console';
 
-    if (my $u = get_var('SCC_URL')) {
+    # SCC_URL was placed to medium types
+    # so set SMT_URL here if register system via smt server
+    # otherwise must register system via real SCC before online migration
+    if (my $u = get_var('SMT_URL')) {
         type_string "echo 'url: $u' > /etc/SUSEConnect\n";
     }
 


### PR DESCRIPTION
@dzedro placed SCC_URL with proxy scc to medium types

because online migration need register via real SCC before migration
use vairable SMT_URL to instead of SCC_URL to avoid register via proxy scc

if SMT_URL not set, register via default real SCC, otherwise register via smt