### PR TITLE
Record softfail on presence of bsc#982138

### DIFF
--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -95,6 +95,9 @@ sub run() {
             last if check_screen 'installation-details-view', 5;
         }
         assert_screen 'installation-details-view';
+        if (check_screen('installation-details-view-remaining-time-gt2h', 5)) {
+            record_soft_failure 'bsc#982138: Remaining time estimation during installation shows >2h most of the time';
+        }
         if (get_var("DVD") && !get_var("NOIMAGES")) {
             if (check_var('DESKTOP', 'kde')) {
                 assert_screen 'kde-imagesused', 500;


### PR DESCRIPTION
Needs a needle with tag 'installation-details-view-remaining-time-gt2h'
matching on the remaining time estimation with content '>2:00:00'.

e.g. see 9f10a66 in os-autoinst-needles-sles

Related issue: https://progress.opensuse.org/issues/12162

Verification test run: http://lord.arch/tests/255