### PR TITLE
Improve stability for the s390 bootloader

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -86,6 +86,14 @@ sub get_to_yast() {
     # qboot
     my $ftp_server = get_var('OPENQA_HOSTNAME') or die;
     my $dir_with_suse_ins = get_var('REPO_0');
+
+    # ensure that we are in cms mode before executing qaboot
+    $s3270->sequence_3270("String(\"#cp i cms\")", "ENTER", "ENTER", "ENTER", "ENTER",);
+    $r = $s3270->expect_3270(
+        output_delim => qr/CMS/,
+        timeout      => 20
+    ) || die "Could not initialize CMS";
+
     $s3270->sequence_3270("String(\"qaboot openqa.suse.de $dir_with_suse_ins\")", "ENTER", "Wait(InputField)",);
 
     ##############################

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -174,7 +174,7 @@ sub format_dasd() {
     assert_script_run("dasd_configure 0.0.0150 1");
 
     # make sure that there is a dasda device
-    assert_script_run("lsdasd | tee /dev/$serialdev");
+    assert_script_run("lsdasd");
     assert_screen("ensure-dasd-exists");
 
     # format dasda (this can take up to 20 minutes depending on disk size)


### PR DESCRIPTION
In recent runs we saw many little things to stumble over in the booting process of s390
Due to that, I did some changes in the bootloader_s390

  * make qaboot more stable with ensuring that the z/VM guest is in CMS mode before executing qaboot
    (poo#12182)

  * make dasdfmt more stable, because it fails from time to time with writing to serial
    (poo#12106)
 
  * general cleanup of the code
