### PR TITLE
Use workaround for encrypted partition on ppc64le

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -618,7 +618,8 @@ sub load_reboot_tests() {
                 loadtest "installation/boot_into_snapshot.pm";
             }
         }
-        if (get_var("ENCRYPT")) {
+        # don't run for ppc64le until https://fate.suse.com/320901 is implemented
+        if (get_var("ENCRYPT") && !check_var('ARCH', 'ppc64le')) {
             loadtest "installation/boot_encrypt.pm";
         }
         loadtest "installation/first_boot.pm";

--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -11,9 +11,14 @@
 use strict;
 use base "basetest";
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
+    if (get_var('ENCRYPT') && check_var('ARCH', 'ppc64le')) {
+        record_soft_failure 'workaround https://fate.suse.com/320901';
+        unlock_if_encrypted;
+    }
     assert_screen "grub2";
     # prevent grub2 timeout; 'esc' would be cleaner, but grub2-efi falls to the menu then
     send_key 'up';


### PR DESCRIPTION
Until https://fate.suse.com/320901 is implemented, related bug [bsc#940465](https://bugzilla.suse.com/show_bug.cgi?id=940465)

Could not fully test it due to [bsc#980108](https://bugzilla.suse.com/show_bug.cgi?id=980108) but I assume "installation/boot_encrypt.pm" is then not needed on ppc64le