### PR TITLE
Add screenlock check and fix tty not appear after booting snapshot

### DIFF
--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -10,6 +10,7 @@
 
 use base "opensusebasetest";
 use testapi;
+use utils;
 use strict;
 
 sub run() {
@@ -41,35 +42,7 @@ sub run() {
     if (!check_var("DESKTOP", "textmode")) {
         select_console('x11');
         sleep 2;
-        send_key "backspace";    # deactivate blanking
-        if (check_screen("screenlock")) {
-            if (check_var("DESKTOP", "gnome")) {
-                send_key "esc";
-                unless (get_var("LIVETEST")) {
-                    send_key "ctrl";    # show gnome screen lock in sle 11
-
-                    # it is possible for GNOME not yet to ask for a password
-                    # switching to tty1 then back to 7, where GNOME runs, withing five minutes
-                    # does not lock with a password - in most cases we take long enough, but some
-                    # console tests are just too quick
-                    if (check_screen "gnome-screenlock-password") {
-                        type_password;
-                        send_key "ret";
-                    }
-                }
-            }
-            elsif (check_var("DESKTOP", "minimalx")) {
-                type_string "$username";
-                save_screenshot();
-                send_key "ret";
-                type_password;
-                send_key "ret";
-            }
-            else {
-                type_password;
-                send_key "ret";
-            }
-        }
+        check_screenlock;
 
         # workaround for bug 834165. Apper should not try to
         # refresh repos when the console is not active:

--- a/tests/online_migration/sle12_online_migration/snapper_rollback.pm
+++ b/tests/online_migration/sle12_online_migration/snapper_rollback.pm
@@ -26,8 +26,16 @@ sub check_rollback_system() {
 sub run() {
     my $self = shift;
 
-    # login to snapshot and perform snapper rollback
-    assert_screen 'linux-login', 200;
+    # login to before online migration snapshot
+    # tty would not appear quite often after booting snapshot
+    # it is a known bug bsc#980337
+    # in this case select tty1 first then select root console
+    if (!check_screen('linux-login', 200)) {
+        record_soft_failure 'bsc#980337';
+        send_key "ctrl-alt-f1";
+        assert_screen 'tty1-selected';
+    }
+
     select_console 'root-console';
     wait_still_screen;
     script_run "snapper rollback";

--- a/tests/online_migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/online_migration/sle12_online_migration/yast2_migration.pm
@@ -10,6 +10,7 @@
 use base "installbasetest";
 use strict;
 use testapi;
+use utils;
 
 sub run {
     my $self = shift;
@@ -19,6 +20,11 @@ sub run {
     }
     else {
         select_console 'x11';
+        wait_still_screen;
+        check_screenlock;
+        mouse_hide(1);
+        assert_screen 'generic-desktop';
+
         x11_start_program("xterm");
         # set blank screen to be never for current session
         script_run("gsettings set org.gnome.desktop.session idle-delay 0");


### PR DESCRIPTION
Add screenlock check after zypper patch to fix following issue:
https://openqa.suse.de/tests/407214/modules/yast2_migration/steps/7

Fix tty not appear after booting snapshot
after booting snapshot, tty should appear like this test:
https://openqa.suse.de/tests/394644/modules/snapper_rollback/steps/1

but tty often not appear after booting snapshot like following tests: 
https://openqa.suse.de/tests/399597/modules/snapper_rollback/steps/1
https://openqa.suse.de/tests/407209/modules/snapper_rollback/steps/1

in this case manually switch to tty1 would be successful:
https://openqa.suse.de/tests/399597/modules/consoletest_setup/steps/2

also the message on failure screens are various and hard to needle, do not assert them and check correct linux-login screen only.