### PR TITLE
Test pattern selection for system role 'kvm host' (fate#317481)

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -657,6 +657,9 @@ sub load_consoletests() {
         loadtest "console/check_console_font.pm";
         loadtest "console/textinfo.pm";
         loadtest "console/hostname.pm";
+        if (get_var("SYSTEM_ROLE")) {
+            loadtest "console/patterns.pm";
+        }
         if (snapper_is_applicable) {
             if (get_var("UPGRADE")) {
                 loadtest "console/upgrade_snapshots.pm";

--- a/tests/console/patterns.pm
+++ b/tests/console/patterns.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    my $self = shift;
+    select_console 'root-console';
+
+    # System roles are defined in config.xml.
+    # Currently the role 'kvm host' defines kvm_server as an additional pattern.
+    my $pattern_name = 'kvm_server';
+
+    # List the installed patterns and grep for $pattern_name as defined above.
+    # grep's exit status will be 1 if it is not found and therefore
+    # assert_script_run() will fail.
+    assert_script_run("zypper patterns -i | grep $pattern_name");
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -13,7 +13,13 @@ use testapi;
 
 sub run() {
     assert_screen 'system-role-default-system';
-    send_key 'alt-n';    # next
+
+    if (get_var("SYSTEM_ROLE")) {
+        send_key 'alt-k';
+        assert_screen 'system-role-kvm-virthost';
+    }
+
+    send_key 'alt-n';	#next
 }
 
 1;


### PR DESCRIPTION
According to the current config.xml the system roles only affect the pattern selection. There is no change in the partitioning since the default system also does not propose a separate home partition.
So the test boils down to just check the installed system for the additional patterns: kvm_server for role kvm host. xen_server for role xen host.
I am just checking one of the roles: kvm host.

To enable the test in openQA just set the additional parameter SYSTEM_ROLE to a true value. Then the system role is switched during installation and the additional 'pattern' test is scheduled as a console test.

Needles are here:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/143