### PR TITLE
Add Hash and Cipher test cases for openssl-fips

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1011,6 +1011,12 @@ sub load_online_migration_tests() {
     loadtest "online_migration/sle12_online_migration/post_migration.pm";
 }
 
+sub load_fips_tests_core() {
+    loadtest "fips/openssl/openssl_fips_alglist.pm";
+    loadtest "fips/openssl/openssl_fips_hash.pm";
+    loadtest "fips/openssl/openssl_fips_cipher.pm";
+}
+
 sub load_fips_tests_web() {
     loadtest "console/curl_https.pm";
 }
@@ -1089,6 +1095,10 @@ elsif (get_var("SUPPORT_SERVER")) {
 elsif (get_var("FIPS_TS")) {
     if (check_var("FIPS_TS", "setup")) {
         prepare_target();
+    }
+    elsif (check_var("FIPS_TS", "core")) {
+        loadtest "boot/boot_to_desktop.pm";
+        load_fips_tests_core;
     }
     elsif (check_var("FIPS_TS", "web")) {
         loadtest "boot/boot_to_desktop.pm";

--- a/tests/fips/openssl/openssl_fips_alglist.pm
+++ b/tests/fips/openssl/openssl_fips_alglist.pm
@@ -1,0 +1,35 @@
+# openssl fips test
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Test description: When working in fips mode, openssl should only
+# list the FIPS approved cryptographic functions
+
+use base "consoletest";
+use testapi;
+use strict;
+
+sub run() {
+    select_console 'root-console';
+
+    # List cipher algorithms in fips mode:
+    # only AES and DES3 are approved
+    validate_script_output 'echo -n "Invalid Cipher: "; openssl list-cipher-algorithms | grep -vE "AES|aes|DES3|des3|DES-EDE" | wc -l', sub { m/^Invalid Cipher: 0$/ };
+
+    # List message digest algorithms in fips mode:
+    # only SHA1 and SHA2 (224, 256, 384, 512) are approved
+    # Note: DSA is short of DSA-SHA1, so it is also valid item
+    validate_script_output 'echo -n "Invalid Hash: "; openssl list-message-digest-algorithms | grep -vE "SHA1|SHA224|SHA256|SHA384|SHA512|DSA" | wc -l', sub { m/^Invalid Hash: 0$/ };
+
+    # List public key algorithms in fips mode:
+    # only RSA, DSA, ECDSA, EC DH, CMAC and HMAC are approved
+    validate_script_output 'echo -n "Invalid Pubkey: "; openssl list-public-key-algorithms | grep ^Name | grep -vE "RSA|rsa|DSA|dsa|EC|DH|HMAC|CMAC" | wc -l', sub { m/^Invalid Pubkey: 0$/ };
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/fips/openssl/openssl_fips_cipher.pm
+++ b/tests/fips/openssl/openssl_fips_cipher.pm
@@ -1,0 +1,48 @@
+# openssl fips test
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Test description: In fips mode, openssl only works with the FIPS
+# approved Cihper algorithms: AES and DES3
+
+use base "consoletest";
+use testapi;
+use strict;
+
+sub run() {
+    select_console 'root-console';
+
+    my $enc_passwd = "pass1234";
+    my $hash_alg   = "sha256";
+    my $file_raw   = "hello.txt";
+    my $file_enc   = "hello.txt.enc";
+    my $file_dec   = "hello.txt.tmp";
+
+    # Prepare temp directory and file for testing
+    assert_script_run "mkdir fips-test && cd fips-test && echo Hello > $file_raw";
+
+    # With FIPS approved Cipher algorithms, openssl should work
+    my @approved_cipher = ("aes128", "aes192", "aes256", "des3");
+    for my $cipher (@approved_cipher) {
+        assert_script_run "openssl enc -$cipher -e -in $file_raw -out $file_enc -k $enc_passwd -md $hash_alg";
+        assert_script_run "openssl enc -$cipher -d -in $file_enc -out $file_dec -k $enc_passwd -md $hash_alg";
+        validate_script_output "cat $file_dec", sub { m/^Hello$/ };
+        script_run "rm -f $file_enc $file_dec";
+    }
+
+    # With FIPS non-approved Cipher algorithms, openssl shall report failure
+    my @invalid_cipher = ("bf", "cast5", "rc4", "seed", "des", "desx");
+    for my $cipher (@invalid_cipher) {
+        validate_script_output "openssl enc -$cipher -e -in $file_raw -out $file_enc -k $enc_passwd -md $hash_alg 2>&1 | tee", sub { m/disabled for fips|unknown option/ };
+    }
+
+    script_run 'cd - && rm -rf fips-test';
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/fips/openssl/openssl_fips_hash.pm
+++ b/tests/fips/openssl/openssl_fips_hash.pm
@@ -1,0 +1,41 @@
+# openssl fips test
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Test description: In fips mode, openssl only works with the FIPS
+# approved HASH algorithms: SHA1 and SHA2 (224, 256, 384, 512)
+
+use base "consoletest";
+use testapi;
+use strict;
+
+sub run() {
+    select_console 'root-console';
+
+    my $tmp_file = "/tmp/hello.txt";
+
+    # Prepare temp file for testing
+    assert_script_run "echo Hello > $tmp_file";
+
+    # With FIPS approved HASH algorithms, openssl should work
+    my @approved_hash = ("sha1", "sha224", "sha256", "sha384", "sha512");
+    for my $hash (@approved_hash) {
+        assert_script_run "openssl dgst -$hash $tmp_file";
+    }
+
+    # With non-approved HASH algorithms, openssl will report failure
+    my @invalid_hash = ("md4", "md5", "mdc2", "ripemd160", "whirlpool", "sha");
+    for my $hash (@invalid_hash) {
+        validate_script_output "openssl dgst -$hash $tmp_file 2>&1 | tee", sub { m/disabled for fips|unknown option/ };
+    }
+
+    script_run 'rm -f $tmp_file';
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
A new test suite is created for FIPS_TS, named "core", which will
contain all the basic test cases for fips verificaton. Just like
the cases to verify opessl hash, cipher, or public key algorithms