### PR TITLE
Use default timeout for boot-menu

### DIFF
--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -27,7 +27,7 @@ sub run() {
         return;
     }
     if (get_var("USBBOOT")) {
-        assert_screen "boot-menu", 1;
+        assert_screen "boot-menu";
         # support multiple versions of seabios, does not harm to press
         # multiple keys here: seabios<1.9: f12, seabios=>1.9: esc
         send_key((match_has_tag 'boot-menu-esc') ? 'esc' : 'f12');


### PR DESCRIPTION
Should fix https://progress.opensuse.org/issues/12122

If 5 seconds are not enough, then boot menu timeout can be increased.
https://github.com/dzedro/os-autoinst/blob/master/backend/qemu.pm#L557