### PR TITLE
Use boot_encrypt test also for ppc64le

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -618,8 +618,7 @@ sub load_reboot_tests() {
                 loadtest "installation/boot_into_snapshot.pm";
             }
         }
-        # don't run for ppc64le until https://fate.suse.com/320901 is implemented
-        if (get_var("ENCRYPT") && !check_var('ARCH', 'ppc64le')) {
+        if (get_var("ENCRYPT")) {
             loadtest "installation/boot_encrypt.pm";
         }
         loadtest "installation/first_boot.pm";


### PR DESCRIPTION
My assumption was wrong in #1422, of course there is second passphrase prompt ...

https://openqa.suse.de/tests/409021