### PR TITLE
Refactor encryption workaround for ppc64le

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -21,6 +21,7 @@ our @EXPORT = qw/
   get_netboot_mirror
   zypper_call
   fully_patch_system
+  workaround_type_encrypted_passphrase
   /;
 
 
@@ -283,6 +284,14 @@ sub fully_patch_system {
     # second run, full system update
     zypper_call('patch --with-interactive -l', [0, 102], 2500);
 }
+
+sub workaround_type_encrypted_passphrase {
+    if (get_var('ENCRYPT') && check_var('ARCH', 'ppc64le')) {
+        record_soft_failure 'workaround https://fate.suse.com/320901';
+        unlock_if_encrypted;
+    }
+}
+
 1;
 
 # vim: sw=4 et

--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -15,10 +15,7 @@ use utils;
 
 sub run() {
     my $self = shift;
-    if (get_var('ENCRYPT') && check_var('ARCH', 'ppc64le')) {
-        record_soft_failure 'workaround https://fate.suse.com/320901';
-        unlock_if_encrypted;
-    }
+    workaround_type_encrypted_passphrase;
     assert_screen "grub2";
     # prevent grub2 timeout; 'esc' would be cleaner, but grub2-efi falls to the menu then
     send_key 'up';

--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -35,6 +35,7 @@ sub run() {
         send_key "ret";
 
     }
+    workaround_type_encrypted_passphrase;
     # the shutdown sometimes hangs longer, so give it time
     wait_boot bootloader_time => 300;
 }


### PR DESCRIPTION
Until https://fate.suse.com/320901 is implemented, related bug https://bugzilla.suse.com/show_bug.cgi?id=940465

https://openqa.suse.de/tests/409021/modules/reboot_gnome/steps/11