### PR TITLE
Allow to create boot menu needle by sensible timeout

### DIFF
--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -27,7 +27,7 @@ sub run() {
         return;
     }
     if (get_var("USBBOOT")) {
-        assert_screen "boot-menu";
+        assert_screen "boot-menu", 5;
         # support multiple versions of seabios, does not harm to press
         # multiple keys here: seabios<1.9: f12, seabios=>1.9: esc
         send_key((match_has_tag 'boot-menu-esc') ? 'esc' : 'f12');


### PR DESCRIPTION
See
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/1428#issuecomment-223358014
for reasoning.

The timeout was set from 1 second to default in
5e58b851 but waiting for up to 30 seconds is not actually useful here.