### PR TITLE
Add helper function assert_screen_with_soft_timeout

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -24,6 +24,7 @@ our @EXPORT = qw/
   workaround_type_encrypted_passphrase
   check_screenlock
   sle_version_at_least
+  assert_screen_with_soft_timeout
   /;
 
 
@@ -347,6 +348,33 @@ sub sle_version_at_least {
     }
 
     die "unsupported SLE VERSION $version in check";
+}
+
+=head2 assert_screen_with_soft_timeout
+
+  assert_screen($mustmatch [,timeout => $timeout] [,soft_timeout => $soft_timeout] [,soft_failure_reason => $soft_failure_reason]);
+
+Extending assert_screen with a soft timeout. When C<$soft_timeout> is hit, a
+soft failure is recorded with the message C<$soft_failure_reason> but
+assert_screen continues until the (hard) timeout C<$timeout> is hit. This
+makes sense when an assert screen should find a screen within a lower time but
+still should not fail and continue until the hard timeout, e.g. to discover
+performance issues.
+
+=cut
+sub assert_screen_with_soft_timeout {
+    my ($mustmatch, %args) = @_;
+    print "in assert_screen_with_soft_timeout\n";
+    $args{timeout}             //= 30;                                                            # as in assert_screen
+    $args{soft_timeout}        //= 0;
+    $args{soft_failure_reason} //= "needle(s) $mustmatch not found within $args{soft_timeout}";
+    if ($args{soft_timeout}) {
+        die "soft timeout has to be smaller than timeout" unless ($args{soft_timeout} < $args{timeout});
+        my $ret = check_screen $mustmatch, $args{soft_timeout};
+        return $ret if $ret;
+        record_soft_failure "needle(s) $mustmatch not found within $args{soft_timeout}";
+    }
+    return assert_screen $mustmatch, $args{timeout} - $args{soft_timeout};
 }
 
 1;

--- a/tests/console/aplay.pm
+++ b/tests/console/aplay.pm
@@ -32,7 +32,7 @@ EOS
     assert_script_run('set_default_volume -f');
 
     script_run('alsamixer', 0);
-    assert_screen 'test-aplay-2', 3;
+    assert_screen_with_soft_timeout('test-aplay-2', soft_timeout => 3);
     send_key "esc";
     $self->clear_and_verify_console;
 

--- a/tests/console/curl_ipv6.pm
+++ b/tests/console/curl_ipv6.pm
@@ -10,6 +10,7 @@
 
 use base "consoletest";
 use testapi;
+use utils;
 use strict;
 
 # test for bug https://bugzilla.novell.com/show_bug.cgi?id=598574
@@ -17,10 +18,10 @@ sub run() {
     my $self = shift;
     script_run('curl www3.zq1.de/test.txt');
     sleep 2;
-    assert_screen 'test-curl_ipv6-1', 3;
+    assert_screen_with_soft_timeout('test-curl_ipv6-1', soft_timeout => 3);
     script_run('rpm -q curl libcurl4');
     sleep 2;
-    assert_screen 'test-curl_ipv6-2', 3;
+    assert_screen_with_soft_timeout('test-curl_ipv6-2', soft_timeout => 3);
 }
 
 1;

--- a/tests/console/mozmill_setup.pm
+++ b/tests/console/mozmill_setup.pm
@@ -18,7 +18,7 @@ use utils;
 sub run() {
     my $self = shift;
     script_sudo("zypper -n in gcc python-devel python-pip mercurial curlftpfs");
-    assert_screen 'test-mozmill_setup-1', 3;
+    assert_screen_with_soft_timeout('test-mozmill_setup-1', soft_timeout => 3);
     clear_console;
 
     #script_sudo("pip install mozmill mercurial");
@@ -27,7 +27,7 @@ sub run() {
     #script_sudo("pip install mozmill==1.5.3 mercurial");
     sleep 5;
     wait_idle 50;
-    assert_screen 'test-mozmill_setup-2', 3;
+    assert_screen_with_soft_timeout('test-mozmill_setup-2', soft_timeout => 3);
     clear_console;
     script_run("cd /tmp");    # dont use home to not confuse dolphin test
     script_run("wget -q openqa.opensuse.org/opensuse/qatests/qa_mozmill_setup.sh");

--- a/tests/console/mtab.pm
+++ b/tests/console/mtab.pm
@@ -11,11 +11,12 @@
 use base "consoletest";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     select_console 'user-console';
     script_run('test -L /etc/mtab && echo OK || echo fail');
-    assert_screen "test-mtab-1", 3;
+    assert_screen_with_soft_timeout("test-mtab-1", soft_timeout => 3);
     script_run('cat /etc/mtab');
     save_screenshot;
 }

--- a/tests/console/mysql_srv.pm
+++ b/tests/console/mysql_srv.pm
@@ -11,6 +11,7 @@
 use strict;
 use base "consoletest";
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
@@ -29,7 +30,7 @@ sub run() {
     script_run "systemctl status mysql.service | tee /dev/$serialdev -", 0;
     wait_serial(".*Syntax error.*", 2, 1) || die "have error while starting mysql";
 
-    assert_screen 'test-mysql_srv-1', 3;
+    assert_screen_with_soft_timeout('test-mysql_srv-1', soft_timeout => 3);
 }
 
 1;

--- a/tests/console/sle11_consoletest_setup.pm
+++ b/tests/console/sle11_consoletest_setup.pm
@@ -21,18 +21,18 @@ sub run() {
 
     # verify there is a text console on tty1
     send_key "ctrl-alt-f1";
-    assert_screen "tty1-selected", 15;
+    assert_screen_with_soft_timeout("tty1-selected", soft_timeout => 15);
 
     # init
     # log into text console
     send_key "ctrl-alt-f4";
     # we need to wait more than five seconds here to pass the idle timeout in
     # case the system is still booting (https://bugzilla.novell.com/show_bug.cgi?id=895602)
-    assert_screen "tty4-selected", 10;
-    assert_screen "text-login",    10;
+    assert_screen_with_soft_timeout("tty4-selected", soft_timeout => 10);
+    assert_screen "text-login", 10;
     type_string "$username\n";
     if (!get_var("LIVETEST")) {
-        assert_screen "password-prompt", 10;
+        assert_screen_with_soft_timeout("password-prompt", soft_timeout => 10);
         type_password;
         type_string "\n";
     }

--- a/tests/console/snapper_undochange.pm
+++ b/tests/console/snapper_undochange.pm
@@ -11,6 +11,7 @@
 use base "consoletest";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     select_console 'root-console';
@@ -30,7 +31,7 @@ sub run() {
     script_run "snapper undochange $snapaf..$snapbf $snapfile";
     assert_script_run "test -f $snapfile", 10;
 
-    assert_screen 'snapper_undochange', 3;
+    assert_screen_with_soft_timeout('snapper_undochange', soft_timeout => 3);
 }
 
 sub test_flags() {

--- a/tests/console/sntp.pm
+++ b/tests/console/sntp.pm
@@ -19,10 +19,10 @@ sub run() {
     script_run("cd /tmp ; wget -q openqa.opensuse.org/opensuse/qatests/qa_ntp.pl");
     script_sudo("perl qa_ntp.pl");
     wait_idle 90;
-    assert_screen 'test-sntp-1', 3;
+    assert_screen_with_soft_timeout('test-sntp-1', soft_timeout => 3);
     clear_console;
     script_run('echo sntp returned $?');
-    assert_screen 'test-sntp-2', 3;
+    assert_screen_with_soft_timeout('test-sntp-2', soft_timeout => 3);
 }
 
 1;

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -11,6 +11,7 @@
 use base "consoletest";
 use strict;
 use testapi;
+use utils;
 
 # check if sshd works
 sub run() {
@@ -47,7 +48,7 @@ sub run() {
     type_string "yes\n";
     assert_screen 'password-prompt';
     type_string "$ssh_testman_passwd\n";
-    assert_screen "ssh-login-ok", 10;
+    assert_screen_with_soft_timeout("ssh-login-ok", soft_timeout => 10);
 }
 
 sub test_flags() {

--- a/tests/console/syslinux.pm
+++ b/tests/console/syslinux.pm
@@ -11,6 +11,7 @@
 use base "consoletest";
 use strict;
 use testapi;
+use utils;
 
 # for https://bugzilla.novell.com/show_bug.cgi?id=679459
 
@@ -19,7 +20,7 @@ sub run() {
     script_run("cd /tmp ; wget -q openqa.opensuse.org/opensuse/qatests/qa_syslinux.sh");
     $self->clear_and_verify_console;
     script_sudo("sh -x qa_syslinux.sh");
-    assert_screen 'test-syslinux-1', 3;
+    assert_screen_with_soft_timeout('test-syslinux-1', soft_timeout => 3);
 }
 
 1;

--- a/tests/console/wget_ipv6.pm
+++ b/tests/console/wget_ipv6.pm
@@ -11,6 +11,7 @@
 use base "consoletest";
 use strict;
 use testapi;
+use utils;
 
 # test for equivalent of bug https://bugzilla.novell.com/show_bug.cgi?id=598574
 sub run() {
@@ -18,7 +19,7 @@ sub run() {
     select_console 'user-console';
     script_run('rpm -q wget');
     script_run('wget -O- -q www3.zq1.de/test.txt');
-    assert_screen 'test-wget_ipv6-1', 3;
+    assert_screen_with_soft_timeout('test-wget_ipv6-1', soft_timeout => 3);
 }
 
 1;

--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -49,13 +49,13 @@ sub run() {
     type_string("$pkgname\n");
     sleep 3;
     send_key "+";    # select for install
-    assert_screen "$pkgname-selected-for-install", 5;
+    assert_screen_with_soft_timeout("$pkgname-selected-for-install", soft_timeout => 5);
 
     if (!check_var('VERSION', '12')) {    #this functionality isn't avivable in SLE12SP0
         send_key "alt-p";                 # go to search box again
         for (1 .. length($pkgname)) { send_key "backspace" }
         type_string("$recommended\n");
-        assert_screen "$recommended-selected-for-install", 10;
+        assert_screen_with_soft_timeout("$recommended-selected-for-install", soft_timeout => 10);
 
         # UC2b:
         # Given that package is not installed,
@@ -65,11 +65,11 @@ sub run() {
         assert_screen 'yast2-sw_install_recommended_packages_enabled', 60;
         send_key "alt-r";    # Submenu Install Recommended Packages
 
-        assert_screen "$recommended-not-selected-for-install", 5;
+        assert_screen_with_soft_timeout("$recommended-not-selected-for-install", soft_timeout => 5);
         send_key "alt-p";    # go to search box again
         for (1 .. length($recommended)) { send_key "backspace" }
         type_string("$pkgname\n");
-        assert_screen "$pkgname-selected-for-install", 10;
+        assert_screen_with_soft_timeout("$pkgname-selected-for-install", soft_timeout => 10);
     }
     send_key "alt-a", 1;     # accept
 

--- a/tests/x11/amarok.pm
+++ b/tests/x11/amarok.pm
@@ -11,12 +11,13 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
     ensure_installed("amarok");
     x11_start_program("amarok", 6, {valid => 1});
-    assert_screen 'test-amarok-1', 3;
+    assert_screen_with_soft_timeout('test-amarok-1', soft_timeout => 3);
     send_key "alt-y";    # use music path as collection folder
                          # a workaround for librivox authentication popup window.
                          # and don't put this after opening oga file, per video
@@ -25,12 +26,12 @@ sub run() {
     if (check_screen "librivox-authentication", 40) {
         send_key "alt-c";    # cancel librivox certificate
     }
-    assert_screen 'test-amarok-2', 3;
+    assert_screen_with_soft_timeout('test-amarok-2', soft_timeout => 3);
     # do not playing audio file as we have not testdata if NICEVIDEO
     if (!get_var("NICEVIDEO")) {
         start_audiocapture;
         x11_start_program("amarok -l ~/data/1d5d9dD.oga");
-        assert_screen 'test-amarok-3', 10;
+        assert_screen_with_soft_timeout('test-amarok-3', soft_timeout => 10);
         assert_recorded_sound('DTMF-159D');
     }
     send_key "ctrl-q";       # really quit (alt-f4 just backgrounds)

--- a/tests/x11/application_browser.pm
+++ b/tests/x11/application_browser.pm
@@ -11,11 +11,12 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
     x11_start_program("application-browser");
-    assert_screen 'test-application_browser-1', 3;
+    assert_screen_with_soft_timeout('test-application_browser-1', soft_timeout => 3);
     send_key "alt-f4";
     wait_idle;
 }

--- a/tests/x11/awesome_menu.pm
+++ b/tests/x11/awesome_menu.pm
@@ -1,11 +1,12 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
     send_key "super-w";
-    assert_screen 'test-awesome-menu-1', 3;
+    assert_screen_with_soft_timeout('test-awesome-menu-1', soft_timeout => 3);
     send_key "esc";
 }
 

--- a/tests/x11/awesome_xterm.pm
+++ b/tests/x11/awesome_xterm.pm
@@ -1,17 +1,18 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
     send_key "super-r";
     type_string "xterm\n";
-    assert_screen 'awesome_xterm_icon', 10;
+    assert_screen_with_soft_timeout('awesome_xterm_icon', soft_timeout => 10);
     type_string "clear\n";
     my $arbitrary_newlines = 13;
     for (1 .. $arbitrary_newlines) { send_key "ret" }
     type_string "echo If you can see this text xterm is working.\n";
-    assert_screen 'test-xterm-1', 5;
+    assert_screen_with_soft_timeout('test-xterm-1', soft_timeout => 5);
     send_key "super-shift-c";
 }
 

--- a/tests/x11/banshee.pm
+++ b/tests/x11/banshee.pm
@@ -11,11 +11,12 @@
 use base "basetest";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
     x11_start_program("banshee");
-    assert_screen 'test-banshee-1', 3;
+    assert_screen_with_soft_timeout('test-banshee-1', soft_timeout => 3);
     send_key "ctrl-q";    # really quit (alt-f4 just backgrounds)
     send_key "alt-f4";
     wait_idle;

--- a/tests/x11/chrome.pm
+++ b/tests/x11/chrome.pm
@@ -50,7 +50,7 @@ sub run() {
     send_key "ctrl-l";
     sleep 1;
     type_string "about:\n";
-    assert_screen 'google-chrome-about', 15;
+    assert_screen_with_soft_timeout('google-chrome-about', soft_timeout => 15);
 
     send_key "alt-f4";
 

--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -28,7 +28,7 @@ sub run() {
     send_key "ctrl-l";    # select text in address bar
     sleep 1;
     type_string "about:\n";
-    assert_screen 'chromium-about', 15;
+    assert_screen_with_soft_timeout('chromium-about', soft_timeout => 15);
 
     send_key "ctrl-l";
     sleep 1;

--- a/tests/x11/desktop_mainmenu.pm
+++ b/tests/x11/desktop_mainmenu.pm
@@ -11,6 +11,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 
 sub run() {
@@ -30,7 +31,7 @@ sub run() {
     else {
         send_key "alt-f1";                       # open main menu
     }
-    assert_screen 'test-desktop_mainmenu-1', 20;
+    assert_screen_with_soft_timeout('test-desktop_mainmenu-1', soft_timeout => 20);
 
     send_key "esc";
 }

--- a/tests/x11/dolphin.pm
+++ b/tests/x11/dolphin.pm
@@ -11,11 +11,12 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
     x11_start_program("dolphin", 6, {valid => 1});
-    assert_screen 'test-dolphin-1', 3;
+    assert_screen_with_soft_timeout('test-dolphin-1', soft_timeout => 3);
     send_key "alt-f4";
     sleep 2;
 }

--- a/tests/x11/eog.pm
+++ b/tests/x11/eog.pm
@@ -11,6 +11,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 # test eye of gnome image viewer
 
@@ -20,7 +21,7 @@ sub run() {
     my $self = shift;
     x11_start_program("eog " . get_var("WALLPAPER"));
     sleep 2;
-    assert_screen 'test-eog-1', 3;
+    assert_screen_with_soft_timeout('test-eog-1', soft_timeout => 3);
     sleep 2;
     send_key "alt-f4";
     sleep 2;

--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -12,6 +12,7 @@ package firefox;
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub start_firefox() {
     x11_start_program("firefox https://html5test.com/index.html", 6, {valid => 1});
@@ -31,13 +32,13 @@ sub run() {
     mouse_hide(1);
     $self->start_firefox();
     send_key "alt-h";
-    assert_screen 'firefox-help-menu', 10;
+    assert_screen_with_soft_timeout('firefox-help-menu', soft_timeout => 10);
     send_key "a";
-    assert_screen 'test-firefox-3', 10;
+    assert_screen_with_soft_timeout('test-firefox-3', soft_timeout => 10);
 
     # close About
     send_key "alt-f4";
-    assert_screen 'test-firefox-1', 3;
+    assert_screen_with_soft_timeout('test-firefox-1', soft_timeout => 3);
 
     send_key "alt-f4";
     if (check_screen('firefox-save-and-quit', 4)) {

--- a/tests/x11/firefox_stress.pm
+++ b/tests/x11/firefox_stress.pm
@@ -11,6 +11,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 my @sites = qw(en.opensuse.org www.slashdot.com www.freshmeat.net www.microsoft.com www.yahoo.com www.ibm.com www.hp.com www.intel.com www.amd.com www.asus.com www.gigabyte.com fractal.webhop.net openqa.opensuse.org http://openqa.opensuse.org/images/openqaqr.png http://openqa.opensuse.org/opensuse/permanent/video/openSUSE-DVD-x86_64-Build0039-nice3.ogv http://openqa.opensuse.org/opensuse/qatests/ER3_020_cut.webm software.opensuse.org about:memory);
 
@@ -29,12 +30,12 @@ sub open_tab {
 sub run() {
     my $self = shift;
     x11_start_program("firefox");
-    assert_screen 'test-firefox_stress-1', 3;
+    assert_screen_with_soft_timeout('test-firefox_stress-1', soft_timeout => 3);
     foreach my $site (@sites) {
         open_tab($site);
-        if ($site =~ m/openqa/) { assert_screen 'test-firefox_stress-2', 3; }
+        if ($site =~ m/openqa/) { assert_screen_with_soft_timeout('test-firefox_stress-2', soft_timeout => 3); }
     }
-    assert_screen 'test-firefox_stress-3', 3;
+    assert_screen_with_soft_timeout('test-firefox_stress-3', soft_timeout => 3);
     send_key "alt-f4";
     sleep 2;
     send_key "ret";    # confirm "save&quit"
@@ -42,7 +43,7 @@ sub run() {
 
     # re-open to see how long it takes to open all tabs together
     x11_start_program("firefox");
-    assert_screen 'test-firefox_stress-4', 3;
+    assert_screen_with_soft_timeout('test-firefox_stress-4', soft_timeout => 3);
     send_key "alt-f4";
     sleep 2;
     send_key "ret";    # confirm "save&quit"

--- a/tests/x11/gedit.pm
+++ b/tests/x11/gedit.pm
@@ -11,6 +11,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 # test gedit text editor
 
@@ -22,7 +23,7 @@ sub run() {
     sleep 2;
     type_string "If you can see this text gedit is working.\n";
     sleep 2;
-    assert_screen 'test-gedit-1', 3;
+    assert_screen_with_soft_timeout('test-gedit-1', soft_timeout => 3);
     sleep 2;
     send_key "alt-f4";
     sleep 2;

--- a/tests/x11/gimp.pm
+++ b/tests/x11/gimp.pm
@@ -11,13 +11,14 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 # XXX TODO - is using KDE variable here
 sub run() {
     my $self = shift;
     ensure_installed("gimp");
     x11_start_program("gimp");
-    assert_screen "test-gimp-1", 20;
+    assert_screen_with_soft_timeout("test-gimp-1", soft_timeout => 20);
     send_key "alt-f4";    # Exit
 }
 

--- a/tests/x11/glxgears.pm
+++ b/tests/x11/glxgears.pm
@@ -11,12 +11,13 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
     ensure_installed("Mesa-demo-x");
     x11_start_program("glxgears");
-    assert_screen 'test-glxgears-1', 3;
+    assert_screen_with_soft_timeout('test-glxgears-1', soft_timeout => 3);
     send_key "alt-f4";
 }
 

--- a/tests/x11/gnome_control_center.pm
+++ b/tests/x11/gnome_control_center.pm
@@ -11,6 +11,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 # test gnome-control-center, with panel (boo#897687)
 
@@ -21,9 +22,9 @@ sub run() {
     x11_start_program("gnome-control-center");
     assert_screen "gnome-control-center-started", 60;    # for timeout selection see bsc#965857
     type_string "details";
-    assert_screen "gnome-control-center-details-typed", 5;
+    assert_screen_with_soft_timeout("gnome-control-center-details-typed", soft_timeout => 5);
     assert_and_click "gnome-control-center-details";
-    assert_screen 'test-gnome_control_center-1', 3;
+    assert_screen_with_soft_timeout('test-gnome_control_center-1', soft_timeout => 3);
     send_key "alt-f4";
 }
 

--- a/tests/x11/gnome_music.pm
+++ b/tests/x11/gnome_music.pm
@@ -11,11 +11,12 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
     x11_start_program("gnome-music");
-    assert_screen 'test-gnome-music-1', 3;
+    assert_screen_with_soft_timeout('test-gnome-music-1', soft_timeout => 3);
     send_key "alt-f4";
 }
 

--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -11,6 +11,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
@@ -20,10 +21,10 @@ sub run() {
     # needed for viewing
     ensure_installed("yelp");
     x11_start_program("gnucash");
-    assert_screen 'test-gnucash-1', 3;
+    assert_screen_with_soft_timeout('test-gnucash-1', soft_timeout => 3);
     send_key "ctrl-h";    # open user tutorial
     wait_idle 5;
-    assert_screen 'test-gnucash-2', 3;
+    assert_screen_with_soft_timeout('test-gnucash-2', soft_timeout => 3);
     send_key "alt-f4";    # Leave tutorial window
                           # Leave tips windows for GNOME case
     if (check_var("DESKTOP", "gnome") || get_var("DESKTOP") eq "xfce") { sleep 3; send_key "alt-c"; }

--- a/tests/x11/imagemagick.pm
+++ b/tests/x11/imagemagick.pm
@@ -11,6 +11,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 # for https://bugzilla.novell.com/show_bug.cgi?id=717871
 
@@ -23,7 +24,7 @@ sub run() {
     for (1 .. 3) {
         send_key "spc";
         sleep 3;
-        assert_screen 'test-imagemagick-1', 3;
+        assert_screen_with_soft_timeout('test-imagemagick-1', soft_timeout => 3);
     }
     send_key "alt-f4";    # close display
     send_key "alt-f4";    # close xterm

--- a/tests/x11/inkscape.pm
+++ b/tests/x11/inkscape.pm
@@ -11,12 +11,13 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
     ensure_installed("inkscape");
     x11_start_program("inkscape");
-    assert_screen 'test-inkscape-1', 3;
+    assert_screen_with_soft_timeout('test-inkscape-1', soft_timeout => 3);
     send_key "alt-f4";    # Exit
 }
 

--- a/tests/x11/kate.pm
+++ b/tests/x11/kate.pm
@@ -11,6 +11,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 # test kde text editor
 
@@ -19,7 +20,7 @@ sub run() {
     my $self = shift;
     ensure_installed("kate");
     x11_start_program("kate", 6, {valid => 1});
-    assert_screen 'test-kate-1', 10;
+    assert_screen_with_soft_timeout('test-kate-1', soft_timeout => 10);
 
     if (!get_var("PLASMA5")) {
         # close welcome screen
@@ -27,9 +28,9 @@ sub run() {
         sleep 2;
     }
     type_string "If you can see this text kate is working.\n";
-    assert_screen 'test-kate-2', 5;
+    assert_screen_with_soft_timeout('test-kate-2', soft_timeout => 5);
     send_key "ctrl-q";
-    assert_screen 'test-kate-3', 5;
+    assert_screen_with_soft_timeout('test-kate-3', soft_timeout => 5);
     send_key "alt-d";    # discard
 }
 

--- a/tests/x11/khelpcenter.pm
+++ b/tests/x11/khelpcenter.pm
@@ -11,15 +11,16 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
     x11_start_program("khelpcenter", 6, {valid => 1});
     if (get_var("LIVETEST")) {
-        assert_screen 'test-khelpcenter-1', 15;
+        assert_screen_with_soft_timeout('test-khelpcenter-1', soft_timeout => 15);
     }
     else {
-        assert_screen 'test-khelpcenter-1', 3;
+        assert_screen_with_soft_timeout('test-khelpcenter-1', soft_timeout => 3);
     }
     send_key "alt-f4";
     sleep 2;

--- a/tests/x11/kontact.pm
+++ b/tests/x11/kontact.pm
@@ -11,6 +11,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
@@ -31,9 +32,9 @@ sub run() {
         send_key "alt-n";    # Don't
     }
 
-    assert_screen "test-kontact-1", 20;    # tips window or assistant
-    send_key "alt-c";                      # KF5-based account assistant ignores alt-f4
-    assert_screen "kontact-window", 3;
+    assert_screen_with_soft_timeout("test-kontact-1", soft_timeout => 20);    # tips window or assistant
+    send_key "alt-c";                                                         # KF5-based account assistant ignores alt-f4
+    assert_screen_with_soft_timeout("kontact-window", soft_timeout => 3);
     send_key "alt-f4";
 }
 

--- a/tests/x11/mozmill_run.pm
+++ b/tests/x11/mozmill_run.pm
@@ -11,6 +11,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 # for https://bugzilla.novell.com/show_bug.cgi?id=657626
 
@@ -27,7 +28,7 @@ sub run() {
         send_key "shift";    # avoid blank/screensaver
         last if wait_serial "mozmill testrun finished", 120;
     }
-    assert_screen 'test-mozmill_run-1', 3;
+    assert_screen_with_soft_timeout('test-mozmill_run-1', soft_timeout => 3);
     send_key "alt-f4";
 }
 

--- a/tests/x11/nautilus.pm
+++ b/tests/x11/nautilus.pm
@@ -11,11 +11,12 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
     x11_start_program("nautilus");
-    assert_screen 'test-nautilus-1', 3;
+    assert_screen_with_soft_timeout('test-nautilus-1', soft_timeout => 3);
     send_key "alt-f4";
     sleep 2;
 }

--- a/tests/x11/oocalc.pm
+++ b/tests/x11/oocalc.pm
@@ -11,21 +11,22 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
     x11_start_program("oocalc", 6, {valid => 1});
     sleep 2;
     wait_still_screen;    # extra wait because oo sometimes appears to be idle during start
-    assert_screen 'test-oocalc-1', 3;
+    assert_screen_with_soft_timeout('test-oocalc-1', soft_timeout => 3);
     assert_and_click 'input-area-oocalc', 'left', 10;
     wait_idle 10;
     type_string "Hello World!\n";
     sleep 2;
-    assert_screen 'test-oocalc-2', 3;
+    assert_screen_with_soft_timeout('test-oocalc-2', soft_timeout => 3);
     send_key "alt-f4";
     sleep 2;
-    assert_screen 'test-oocalc-3', 3;
+    assert_screen_with_soft_timeout('test-oocalc-3', soft_timeout => 3);
     assert_and_click 'dont-save-libreoffice-btn';    # _Don't save
 }
 

--- a/tests/x11/ooffice.pm
+++ b/tests/x11/ooffice.pm
@@ -11,18 +11,19 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
     x11_start_program("oowriter");
-    assert_screen 'test-ooffice-1', 30;
+    assert_screen 'test-ooffice-1';
     # clicking the writing area to make sure the cursor addressed there
     assert_and_click 'ooffice-writing-area', 'left', 10;
     wait_idle 10;
     type_string "Hello World!";
-    assert_screen 'test-ooffice-2', 5;
+    assert_screen_with_soft_timeout('test-ooffice-2', soft_timeout => 5);
     send_key "alt-f4";
-    assert_screen "ooffice-save-prompt", 8;
+    assert_screen_with_soft_timeout("ooffice-save-prompt", soft_timeout => 8);
     assert_and_click 'dont-save-libreoffice-btn';    # _Don't save
 }
 

--- a/tests/x11/oomath.pm
+++ b/tests/x11/oomath.pm
@@ -11,6 +11,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 # test for bug https://bugs.freedesktop.org/show_bug.cgi?id=42301
 
@@ -25,9 +26,9 @@ sub run() {
     send_key "2";
     send_key "ctrl-z";    # undo produces "12" instead of "1"
     sleep 3;
-    assert_screen 'test-oomath-1', 3;
+    assert_screen_with_soft_timeout('test-oomath-1', soft_timeout => 3);
     send_key "alt-f4";
-    assert_screen 'oomath-prompt', 5;
+    assert_screen_with_soft_timeout('oomath-prompt', soft_timeout => 5);
     assert_and_click 'dont-save-libreoffice-btn';    # _Don't save
 }
 

--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -16,11 +16,11 @@ use utils;
 sub run() {
     wait_idle;
     send_key "ctrl-alt-delete";    # reboot
-    assert_screen 'logoutdialog', 15;
+    assert_screen_with_soft_timeout('logoutdialog', soft_timeout => 15);
     assert_and_click 'logoutdialog-reboot-highlighted';
 
     if (get_var("SHUTDOWN_NEEDS_AUTH")) {
-        assert_screen 'reboot-auth', 15;
+        assert_screen_with_soft_timeout('reboot-auth', soft_timeout => 15);
         sleep 3;
         type_password;
         sleep 3;

--- a/tests/x11/reboot_gnome_sle11.pm
+++ b/tests/x11/reboot_gnome_sle11.pm
@@ -22,7 +22,7 @@ sub run() {
     }
 
     send_key "ret";                                                 # press shutdown button
-    assert_screen "logoutdialog", 15;
+    assert_screen_with_soft_timeout("logoutdialog", soft_timeout => 15);
     send_key "tab";
     my $ret;
     for (my $counter = 10; $counter > 0; $counter--) {
@@ -36,12 +36,12 @@ sub run() {
     }
     # report the failure or green
     unless (defined($ret)) {
-        assert_screen "logoutdialog-reboot-highlighted", 1;
+        assert_screen_with_soft_timeout("logoutdialog-reboot-highlighted", soft_timeout => 1);
     }
     send_key "ret";    # confirm
 
     if (get_var("SHUTDOWN_NEEDS_AUTH")) {
-        assert_screen 'reboot-auth', 15;
+        assert_screen_with_soft_timeout('reboot-auth', soft_timeout => 15);
         type_password;
         send_key "ret";
     }

--- a/tests/x11/reboot_kde.pm
+++ b/tests/x11/reboot_kde.pm
@@ -16,7 +16,7 @@ use utils;
 sub run() {
     wait_idle;
     send_key "ctrl-alt-delete";    # reboot
-    assert_screen 'logoutdialog', 15;
+    assert_screen_with_soft_timeout('logoutdialog', soft_timeout => 15);
     send_key "tab";
     send_key "tab";
     my $ret;
@@ -31,12 +31,12 @@ sub run() {
     }
     # report the failure or green
     unless (defined($ret)) {
-        assert_screen "logoutdialog-reboot-highlighted", 1;
+        assert_screen_with_soft_timeout("logoutdialog-reboot-highlighted", soft_timeout => 1);
     }
     send_key "ret";    # confirm
 
     if (get_var("SHUTDOWN_NEEDS_AUTH")) {
-        assert_screen 'reboot-auth', 15;
+        assert_screen_with_soft_timeout('reboot-auth', soft_timeout => 15);
         type_password;
         send_key "ret";
     }

--- a/tests/x11/reboot_lxde.pm
+++ b/tests/x11/reboot_lxde.pm
@@ -18,7 +18,7 @@ sub run() {
 
     #send_key "ctrl-alt-delete"; # does open task manager instead of reboot
     x11_start_program "lxsession-logout";
-    assert_screen "logoutdialog", 20;
+    assert_screen_with_soft_timeout("logoutdialog", soft_timeout => 20);
     send_key "tab";    # reboot
     save_screenshot;
     send_key "ret";    # confirm

--- a/tests/x11/reboot_plasma5.pm
+++ b/tests/x11/reboot_plasma5.pm
@@ -16,7 +16,7 @@ use utils;
 sub run() {
     wait_idle;
     send_key "ctrl-alt-delete";    # reboot
-    assert_screen 'logoutdialog', 15;
+    assert_screen_with_soft_timeout('logoutdialog', soft_timeout => 15);
     assert_and_click 'sddm_reboot_option_btn';
     # sometimes not reliable, since if clicked the background
     # color of button should changed, thus check and click again
@@ -26,7 +26,7 @@ sub run() {
     assert_and_click 'sddm_reboot_btn';
 
     if (get_var("SHUTDOWN_NEEDS_AUTH")) {
-        assert_screen 'reboot-auth', 15;
+        assert_screen_with_soft_timeout('reboot-auth', soft_timeout => 15);
         type_password;
         send_key "ret";
     }

--- a/tests/x11/reboot_xfce.pm
+++ b/tests/x11/reboot_xfce.pm
@@ -16,7 +16,7 @@ use utils;
 sub run() {
     wait_idle;
     send_key "alt-f4";    # open logout dialog
-    assert_screen 'logoutdialog', 15;
+    assert_screen_with_soft_timeout('logoutdialog', soft_timeout => 15);
     send_key "tab";       # reboot
     save_screenshot;
     send_key "ret";       # confirm

--- a/tests/x11/rhythmbox.pm
+++ b/tests/x11/rhythmbox.pm
@@ -11,11 +11,12 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
     x11_start_program("rhythmbox");
-    assert_screen 'test-rhythmbox-1', 15;
+    assert_screen_with_soft_timeout('test-rhythmbox-1', soft_timeout => 15);
     send_key "alt-f4";
     wait_idle;
 }

--- a/tests/x11/ristretto.pm
+++ b/tests/x11/ristretto.pm
@@ -11,6 +11,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 # test ristretto and open the default wallpaper
 
@@ -20,7 +21,7 @@ sub run() {
     x11_start_program("ristretto /usr/share/wallpapers/xfce/default.wallpaper");
     send_key "ctrl-m";
     sleep 2;
-    assert_screen 'test-ristretto-1', 3;
+    assert_screen_with_soft_timeout('test-ristretto-1', soft_timeout => 3);
     send_key "alt-f4";
     sleep 2;
 }

--- a/tests/x11/shutdown.pm
+++ b/tests/x11/shutdown.pm
@@ -27,7 +27,7 @@ sub run() {
 
     if (check_var("DESKTOP", "kde")) {
         send_key "ctrl-alt-delete";    # shutdown
-        assert_screen 'logoutdialog', 15;
+        assert_screen_with_soft_timeout('logoutdialog', soft_timeout => 15);
 
         if (get_var("PLASMA5")) {
             assert_and_click 'sddm_shutdown_option_btn';
@@ -40,18 +40,18 @@ sub run() {
         }
         else {
             type_string "\t";
-            assert_screen "kde-turn-off-selected", 2;
+            assert_screen_with_soft_timeout("kde-turn-off-selected", soft_timeout => 2);
             type_string "\n";
         }
     }
 
     if (check_var("DESKTOP", "gnome")) {
         $self->trigger_shutdown_gnome_button();
-        assert_screen 'logoutdialog', 15;
+        assert_screen_with_soft_timeout('logoutdialog', soft_timeout => 15);
         send_key "ret";    # confirm shutdown
 
         if (get_var("SHUTDOWN_NEEDS_AUTH")) {
-            assert_screen 'shutdown-auth', 15;
+            assert_screen_with_soft_timeout('shutdown-auth', soft_timeout => 15);
             type_password;
 
             # we need to kill all open ssh connections before the system shuts down
@@ -65,17 +65,17 @@ sub run() {
             send_key "alt-f4";    # opens log out popup after all windows closed
         }
         wait_idle;
-        assert_screen 'logoutdialog', 15;
+        assert_screen_with_soft_timeout('logoutdialog', soft_timeout => 15);
         type_string "\t\t";       # select shutdown
         sleep 1;
 
-        # assert_screen 'test-shutdown-1', 3;
+        # assert_screen_with_soft_timeout('test-shutdown-1', soft_timeout => 3);
         type_string "\n";
     }
 
     if (check_var("DESKTOP", "lxde")) {
         x11_start_program("lxsession-logout");    # opens logout dialog
-        assert_screen "logoutdialog", 20;
+        assert_screen_with_soft_timeout("logoutdialog", soft_timeout => 20);
         send_key "ret";
     }
 

--- a/tests/x11/systemsettings.pm
+++ b/tests/x11/systemsettings.pm
@@ -11,15 +11,16 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
     x11_start_program("systemsettings", 6, {valid => 1});
     if (get_var("LIVETEST")) {
-        assert_screen 'test-systemsettings-1', 15;
+        assert_screen_with_soft_timeout('test-systemsettings-1', soft_timeout => 15);
     }
     else {
-        assert_screen 'test-systemsettings-1', 3;
+        assert_screen_with_soft_timeout('test-systemsettings-1', soft_timeout => 3);
     }
     send_key "alt-f4";
     sleep 2;

--- a/tests/x11/thunar.pm
+++ b/tests/x11/thunar.pm
@@ -11,6 +11,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 # test thunar and open the root directory
 
@@ -22,7 +23,7 @@ sub run() {
     send_key "shift-tab";
     send_key "home";
     send_key "down";
-    assert_screen 'test-thunar-1', 3;
+    assert_screen_with_soft_timeout('test-thunar-1', soft_timeout => 3);
     send_key "alt-f4";
     sleep 2;
 }

--- a/tests/x11/thunderbird.pm
+++ b/tests/x11/thunderbird.pm
@@ -11,12 +11,13 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
     ensure_installed("MozillaThunderbird");
     x11_start_program("thunderbird");
-    assert_screen 'test-thunderbird-1', 3;
+    assert_screen_with_soft_timeout('test-thunderbird-1', soft_timeout => 3);
     wait_screen_change {
         send_key "alt-f4";    # close wizzard
     };

--- a/tests/x11/xfce4_terminal.pm
+++ b/tests/x11/xfce4_terminal.pm
@@ -11,6 +11,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 # test xfce4-terminal
 
@@ -24,7 +25,7 @@ sub run() {
     for (1 .. 13) { send_key "ret" }
     type_string "echo If you can see this text xfce4-terminal is working.\n";
     sleep 2;
-    assert_screen 'test-xfce4_terminal-1', 3;
+    assert_screen_with_soft_timeout('test-xfce4_terminal-1', soft_timeout => 3);
     send_key "alt-f4";
     sleep 2;
     send_key "alt-w";

--- a/tests/x11/xfce_lightdm_logout_login.pm
+++ b/tests/x11/xfce_lightdm_logout_login.pm
@@ -11,6 +11,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 # log out, check lightdm-gtk-greeter and log in again
 
@@ -19,7 +20,7 @@ sub run() {
     my $self = shift;
     x11_start_program("xfce4-session-logout");
     send_key "alt-l";
-    assert_screen 'test-xfce_lightdm_logout_login-1', 13;
+    assert_screen_with_soft_timeout('test-xfce_lightdm_logout_login-1', soft_timeout => 13);
     mouse_hide();
     type_password;
     send_key "ret";

--- a/tests/x11/xfce_notification.pm
+++ b/tests/x11/xfce_notification.pm
@@ -11,6 +11,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 # test xfce4-notifyd with a notification
 
@@ -18,7 +19,7 @@ use testapi;
 sub run() {
     my $self = shift;
     x11_start_program('notify-send --expire-time=30 Test');
-    assert_screen 'test-xfce_notification-1', 5;
+    assert_screen_with_soft_timeout('test-xfce_notification-1', soft_timeout => 5);
 }
 
 1;

--- a/tests/x11/xterm.pm
+++ b/tests/x11/xterm.pm
@@ -24,7 +24,7 @@ sub run() {
     for (1 .. 13) { send_key "ret" }
     type_string "echo If you can see this text xterm is working.\n";
     sleep 2;
-    assert_screen 'test-xterm-1', 3;
+    assert_screen_with_soft_timeout('test-xterm-1', soft_timeout => 3);
     send_key "alt-f4";
 }
 


### PR DESCRIPTION
Change all occurences of assert_screen within console and x11 tests with a
timeout of less than the default (30s) to use a "soft timeout" first with the
old timeout value and then, if the soft timeout is hit, continue up to the
full timeout. See description of assert_screen_with_soft_timeout for details.

This should help in occassions where a module failure is more often than not
regarded as a "flaky issue" and not cared about but the job is simply cloned
to retry.

Related issue: https://progress.opensuse.org/issues/12110

Verification test run: http://lord.arch/tests/366