### PR TITLE
Add Case 1463314-FIPS:systemd-journald test

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1031,6 +1031,7 @@ sub load_fips_tests_web() {
 
 sub load_fips_tests_misc() {
     loadtest "console/aide_check.pm";
+    loadtest "console/journald_fss.pm";
 }
 
 sub prepare_target() {

--- a/tests/console/journald_fss.pm
+++ b/tests/console/journald_fss.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Case 1463314  - FIPS: systemd
+
+use base "consoletest";
+use strict;
+use testapi;
+
+sub run() {
+
+    select_console "root-console";
+    assert_script_run("echo 'Seal=yes' >> /etc/systemd/journald.conf");
+    assert_script_run("mkdir -p /var/log/journal");
+    assert_script_run("systemctl restart systemd-journald.service");
+    assert_script_run("journalctl --setup-keys");
+    assert_screen("journalctl-qr");
+    assert_script_run("journalctl --setup-keys --force | tee /tmp/key");
+    assert_script_run("journalctl --verify --verify-key=`cat /tmp/key`");
+    assert_script_run("rm -f /tmp/key");
+}
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Systemd depend on libgcrypt for journald's FSS(Forward Secure Sealing) function
It is only needed to test journald's key generation and verification function
Verify key should be generated,as well as a QR code
No failed messages output