### PR TITLE
Prevent stress tests running way too long

### DIFF
--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -127,10 +127,10 @@ sub wait_testrun {
     my $pattern   = "TESTRUN_FINISHED-" . int(rand(999999));
     my $cmd       = "while [[ ! -f $done_file ]]; do sleep $interval; done; echo $pattern >> /dev/$serialdev";
     type_string "bash -c '$cmd' &\n";
-    # Set a extremely high timeout value for wait_serial
+    # Set a high timeout value for wait_serial
     # so that it will wait until test run finished or
     # MAX_JOB_TIME(can be set on openQA webui) reached
-    my $ret = wait_serial($pattern, 32400);
+    my $ret = wait_serial($pattern, 90 * 60);
     if ($ret) {
         return 1;
     }


### PR DESCRIPTION
Current executions of "qa_acceptance_.*stress" tests run for about one hour so
there is no need for this huge timeout anymore, e.g. see
https://openqa.suse.de/tests/411898#previous
https://openqa.suse.de/tests/411899#previous
https://openqa.suse.de/tests/411900#previous

This should prevent Build testing to never be finished, e.g. see
https://openqa.suse.de/tests/overview?distri=sle&version=12-SP2&build=1588&groupid=25