### PR TITLE
bootloader_s390: Robustness improvements for lsdasd

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -174,12 +174,11 @@ sub format_dasd() {
     assert_script_run("dasd_configure 0.0.0150 1");
 
     # make sure that there is a dasda device
-    assert_script_run("lsdasd");
+    script_run("lsdasd", 0);
     assert_screen("ensure-dasd-exists");
 
     # format dasda (this can take up to 20 minutes depending on disk size)
-    type_string("echo yes | dasdfmt -b 4096 -p /dev/dasda; echo dasdfmt-status-$?- > /dev/$serialdev\n");
-    wait_serial("dasdfmt-status-0-", 1200) || die "dasdfmt could not finish";
+    assert_script_run("echo yes | dasdfmt -b 4096 -p /dev/dasda", 1200, 'dasdfmt could not finish');
 }
 
 sub run() {


### PR DESCRIPTION
* Improve robustness of dasd commands

Related issues: https://progress.opensuse.org/issues/10584, https://progress.opensuse.org/issues/12106

Verification test run(s): http://lord.arch/tests/389 through http://lord.arch/tests/488, i.e. 100 runs. Out of these, two failed: http://lord.arch/tests/484 and http://lord.arch/tests/446, both because the download did not succeed during 7 retries.