### PR TITLE
Test curl RC4 and SEED ciphers with fips enabled

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1016,6 +1016,7 @@ sub load_fips_tests_misc() {
     loadtest "console/aide_check.pm";
     loadtest "console/journald_fss.pm";
     loadtest "x11/hexchat_ssl.pm";
+    loadtest "fips/curl_fips_rc4_seed.pm";
 }
 
 sub prepare_target() {

--- a/tests/fips/curl_fips_rc4_seed.pm
+++ b/tests/fips/curl_fips_rc4_seed.pm
@@ -1,0 +1,24 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use testapi;
+use strict;
+
+# test for curl RC4 and SEED ciphers with fips enabled
+sub run() {
+    my $self = shift;
+    select_console 'root-console';
+    script_output "curl --ciphers RC4,SEED -v https://eu.httpbin.org/get | tee";
+    validate_script_output "curl --ciphers RC4,SEED -v https://eu.httpbin.org/get 2>&1 | tee", sub { m/failed setting cipher/ };
+    validate_script_output "rpm -q curl libcurl4",                                             sub { m/curl-.*/ };
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
This is new curl test case for fips related.
Both RC4 and SEED are not approved cipher by FIPS140-2.
In a fips enabled system, it will get a failed result if run curl command
with RC4 and SEED ciphers.