### PR TITLE
Fix yast2_ntpclient.pm

### DIFF
--- a/tests/console/yast2_ntpclient.pm
+++ b/tests/console/yast2_ntpclient.pm
@@ -120,8 +120,13 @@ sub run() {
 
     wait_serial('yast2-ntp-client-status-0', 60);
 
+
+    # add NTPD_FORCE_SYNC_ON_STARTUP=yes into /etc/ntp.conf, ntpd should start up at once
+    script_run("echo NTPD_FORCE_SYNC_ON_STARTUP=yes >> /etc/ntp.conf");
+    script_run("systemctl restart ntpd.service");
+
     # check NTP synchronization
-    assert_script_run('/usr/bin/timedatectl | grep "NTP synchronized: yes"');
+    assert_script_run("systemctl show -p ActiveState ntpd.service | grep ActiveState=active");
 
 }
 1;


### PR DESCRIPTION
/usr/bin/timedatectl is not realiable for detecting host time synchronization with server, it delivers sometimes wrong status even when ntpd was stopped.
Fix includes NTPD_FORCE_SYNC_ON_STARTUP and check ntpd.service instead of timedatactl.

Please take a look at http://e13.suse.de/tests/956
