### PR TITLE
Replace sleep with wait_still_screen

### DIFF
--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -19,7 +19,7 @@ sub run() {
     my $console = select_console 'root-console';
     # cleanup
     type_string "loginctl --no-pager\n";
-    sleep 2;
+    wait_still_screen(2);
     save_screenshot();
 
     script_run "systemctl unmask packagekit.service";
@@ -32,16 +32,16 @@ sub run() {
     $console = select_console 'user-console';
 
     send_key "ctrl-c";
-    sleep 1;
+    wait_still_screen(1);
     type_string "exit\n";    # logout
     $console->reset;
-    sleep 2;
+    wait_still_screen(2);
 
     save_screenshot();
 
     if (!check_var("DESKTOP", "textmode")) {
         select_console('x11');
-        sleep 2;
+        wait_still_screen(2);
         check_screenlock;
 
         # workaround for bug 834165. Apper should not try to


### PR DESCRIPTION
sleep occasionally not working on following test:
https://openqa.suse.de/tests/412689/modules/consoletest_finish/steps/5

replace sleep as wait_still_screen.

sleep 30 at line 52 not replaced which i don't understand why it needs 30s.