### PR TITLE
test other Desktop Environments

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -654,6 +654,23 @@ sub load_extra_tests () {
     return 0;
 }
 
+sub load_otherDE_tests() {
+    if (get_var("DE_PATTERN")) {
+        my $de = get_var("DE_PATTERN");
+        loadtest "console/consoletest_setup.pm";
+        loadtest "console/hostname.pm";
+        loadtest "console/zypper_clear_repos.pm";
+        loadtest "console/install_otherDE_pattern.pm";
+        loadtest "console/consoletest_finish.pm";
+        loadtest "x11/${de}_reconfigure_openqa.pm";
+        loadtest "x11/reboot_icewm.pm";
+        # here comes the actual desktop specific test
+        loadtest "x11/shutdown.pm";
+        return 1;
+    }
+    return 0;
+}
+
 sub load_x11tests() {
     return unless (!get_var("INSTALLONLY") && get_var("DESKTOP") !~ /textmode|minimalx/ && !get_var("DUALBOOT") && !get_var("RESCUECD"));
 
@@ -1010,6 +1027,7 @@ else {
     unless (install_online_updates()
         || load_applicationstests()
         || load_extra_tests()
+        || load_otherDE_tests()
         || load_skenkins_tests())
     {
         load_rescuecd_tests();

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -99,6 +99,9 @@ sub cleanup_needles() {
     if (!check_var("VIDEOMODE", "text")) {
         unregister_needle_tags("ENV-VIDEOMODE-text");
     }
+    if (!check_var("DE_PATTERN", "enlightenment")) {
+        remove_desktop_needles("enlightenment");
+    }
     if (get_var("INSTLANG") && get_var("INSTLANG") ne "en_US") {
         unregister_needle_tags("ENV-INSTLANG-en_US");
     }
@@ -665,10 +668,16 @@ sub load_otherDE_tests() {
         loadtest "x11/${de}_reconfigure_openqa.pm";
         loadtest "x11/reboot_icewm.pm";
         # here comes the actual desktop specific test
+        if ($de =~ /^enlightenment$/) { load_enlightenment_tests(); }
         loadtest "x11/shutdown.pm";
         return 1;
     }
     return 0;
+}
+
+sub load_enlightenment_tests() {
+    loadtest "x11/enlightenment_first_start.pm";
+    loadtest "x11/terminology.pm";
 }
 
 sub load_x11tests() {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -24,7 +24,7 @@ our %valueranges = (
     DOCRUN             => [0, 1],
 
     #   BTRFS=>[0,1],
-    DESKTOP => [qw(kde gnome xfce lxde minimalx textmode awesome)],
+    DESKTOP => [qw(kde gnome xfce lxde minimalx textmode)],
 
     #   ROOTFS=>[qw(ext3 xfs jfs btrfs reiserfs)],
     VIDEOMODE => ["", "text"],
@@ -84,7 +84,6 @@ sub cleanup_needles() {
     remove_desktop_needles("kde");
     remove_desktop_needles("gnome");
     remove_desktop_needles("xfce");
-    remove_desktop_needles("awesome");
     if (!get_var("DESKTOP_MINIMALX_INSTONLY")) {
         remove_desktop_needles("minimalx");
     }
@@ -107,6 +106,9 @@ sub cleanup_needles() {
     }
     if (!check_var("DE_PATTERN", "enlightenment")) {
         remove_desktop_needles("enlightenment");
+    }
+    if (!check_var("DE_PATTERN", "awesome")) {
+        remove_desktop_needles("awesome");
     }
     if (get_var("INSTLANG") && get_var("INSTLANG") ne "en_US") {
         unregister_needle_tags("ENV-INSTLANG-en_US");
@@ -674,6 +676,7 @@ sub load_otherDE_tests() {
         loadtest "x11/${de}_reconfigure_openqa.pm";
         loadtest "x11/reboot_icewm.pm";
         # here comes the actual desktop specific test
+        if ($de =~ /^awesome$/)       { load_awesome_tests(); }
         if ($de =~ /^enlightenment$/) { load_enlightenment_tests(); }
         if ($de =~ /^mate$/)          { load_mate_tests(); }
         if ($de =~ /^lxqt$/)          { load_lxqt_tests(); }
@@ -681,6 +684,11 @@ sub load_otherDE_tests() {
         return 1;
     }
     return 0;
+}
+
+sub load_awesome_tests() {
+    loadtest "x11/awesome_menu.pm";
+    loadtest "x11/awesome_xterm.pm";
 }
 
 sub load_enlightenment_tests() {
@@ -700,13 +708,6 @@ sub load_x11tests() {
 
     if (get_var("NOAUTOLOGIN") || get_var("XDMUSED")) {
         loadtest "x11/x11_login.pm";
-    }
-    # testing awesome should be considered special, not execute other tests
-    # afterwards, just make sure the basics work
-    if (check_var("DESKTOP", "awesome")) {
-        loadtest "x11/awesome_menu.pm";
-        loadtest "x11/awesome_xterm.pm";
-        return;
     }
     if (guiupdates_is_applicable) {
         if (check_var("DESKTOP", "kde")) {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -99,6 +99,9 @@ sub cleanup_needles() {
     if (!check_var("VIDEOMODE", "text")) {
         unregister_needle_tags("ENV-VIDEOMODE-text");
     }
+    if (!check_var("DE_PATTERN", "mate")) {
+        remove_desktop_needles("mate");
+    }
     if (!check_var("DE_PATTERN", "enlightenment")) {
         remove_desktop_needles("enlightenment");
     }
@@ -669,6 +672,7 @@ sub load_otherDE_tests() {
         loadtest "x11/reboot_icewm.pm";
         # here comes the actual desktop specific test
         if ($de =~ /^enlightenment$/) { load_enlightenment_tests(); }
+        if ($de =~ /^mate$/)          { load_mate_tests(); }
         loadtest "x11/shutdown.pm";
         return 1;
     }
@@ -678,6 +682,10 @@ sub load_otherDE_tests() {
 sub load_enlightenment_tests() {
     loadtest "x11/enlightenment_first_start.pm";
     loadtest "x11/terminology.pm";
+}
+
+sub load_mate_tests() {
+    loadtest "x11/mate_terminal.pm";
 }
 
 sub load_x11tests() {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -102,6 +102,9 @@ sub cleanup_needles() {
     if (!check_var("DE_PATTERN", "mate")) {
         remove_desktop_needles("mate");
     }
+    if (!check_var("DE_PATTERN", "lxqt")) {
+        remove_desktop_needles("lxqt");
+    }
     if (!check_var("DE_PATTERN", "enlightenment")) {
         remove_desktop_needles("enlightenment");
     }
@@ -673,6 +676,7 @@ sub load_otherDE_tests() {
         # here comes the actual desktop specific test
         if ($de =~ /^enlightenment$/) { load_enlightenment_tests(); }
         if ($de =~ /^mate$/)          { load_mate_tests(); }
+        if ($de =~ /^lxqt$/)          { load_lxqt_tests(); }
         loadtest "x11/shutdown.pm";
         return 1;
     }
@@ -682,6 +686,9 @@ sub load_otherDE_tests() {
 sub load_enlightenment_tests() {
     loadtest "x11/enlightenment_first_start.pm";
     loadtest "x11/terminology.pm";
+}
+
+sub load_lxqt_tests() {
 }
 
 sub load_mate_tests() {

--- a/tests/console/install_otherDE_pattern.pm
+++ b/tests/console/install_otherDE_pattern.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    my $self = shift;
+    select_console 'root-console';
+
+    script_run("zypper lr -d | tee /dev/$serialdev");
+
+    my $pattern   = get_var("DE_PATTERN");
+    my $zypp_type = "pattern";
+    if (check_var("DE_IS_PKG", 1)) {
+        $zypp_type = "package";
+    }
+    assert_script_run("zypper -n in -t $zypp_type $pattern", 600);
+
+    # Toggle the default window manager
+    assert_script_run("sed -i 's/DEFAULT_WM=.*/DEFAULT_WM=\"${pattern}\"/' /etc/sysconfig/windowmanager");
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/awesome_reconfigure_openqa.pm
+++ b/tests/x11/awesome_reconfigure_openqa.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    my $self = shift;
+
+    set_var('DESKTOP', 'awesome');
+    $self->result('ok');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/enlightenment_first_start.pm
+++ b/tests/x11/enlightenment_first_start.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    my $self = shift;
+    mouse_hide();
+    assert_and_click "enlightenment_profile_selection";
+    assert_and_click "enlightenment_assistant_next";
+    assert_and_click "enlightenment_profile_size";
+    assert_and_click "enlightenment_assistant_next";
+    assert_screen "enlightenment_windowfocus";
+    assert_and_click "enlightenment_assistant_next";
+    assert_screen "enlightenment_compositing";
+    assert_and_click "enlightenment_assistant_next";
+    assert_screen "enlightenment_generic_desktop";
+}
+
+sub test_flags() {
+    return {milestone => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/enlightenment_reconfigure_openqa.pm
+++ b/tests/x11/enlightenment_reconfigure_openqa.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    my $self = shift;
+
+    set_var('DESKTOP', 'enlightenment');
+    $self->result('ok');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/lxqt_reconfigure_openqa.pm
+++ b/tests/x11/lxqt_reconfigure_openqa.pm
@@ -1,0 +1,24 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    my $self = shift;
+
+    set_var("DESKTOP", "lxqt");
+
+    $self->result('ok');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/mate_reconfigure_openqa.pm
+++ b/tests/x11/mate_reconfigure_openqa.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    my $self = shift;
+
+    # Next time we boot we are no longer minimalx based, but mate based
+    set_var('DESKTOP', 'mate');
+
+    # mate uses lightdm as window manager, which has the user preselected
+    set_var('DISPLAYMANAGER',    'lightdm');
+    set_var('DM_NEEDS_USERNAME', 0);
+
+    $self->result('ok');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/mate_terminal.pm
+++ b/tests/x11/mate_terminal.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "x11test";
+use strict;
+use testapi;
+
+sub run() {
+    my $self = shift;
+    mouse_hide(1);
+    x11_start_program("mate-terminal");
+    assert_screen "mate-terminal";
+    send_key "ctrl-shift-t";
+    assert_screen "mate-terminal-second-tab";
+    for (1 .. 13) { send_key "ret" }
+    type_string "echo If you can see this text mate-terminal is working.\n";
+    assert_screen 'test-mate_terminal-1';
+    send_key "alt-f4";
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/reboot_icewm.pm
+++ b/tests/x11/reboot_icewm.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    wait_idle;
+    send_key "ctrl-alt-delete";    # reboot
+    assert_screen 'logoutdialog', 15;
+    assert_and_click 'logoutdialog-reboot-highlighted';
+    assert_screen 'icewm_confirm_logout';    # Confirm logout, Logout will close all active applications. Proceed?
+    send_key 'alt-o';
+
+    wait_boot;
+}
+
+sub test_flags() {
+    return {important => 1, milestone => 1};
+}
+1;
+
+# vim: set sw=4 et:

--- a/tests/x11/shutdown.pm
+++ b/tests/x11/shutdown.pm
@@ -79,6 +79,11 @@ sub run() {
         send_key "ret";
     }
 
+    if (check_var("DESKTOP", "lxqt")) {
+        x11_start_program("shutdown");            # opens logout dialog
+        assert_screen "lxqt_logoutdialog", 20;
+        send_key "ret";
+    }
     if (check_var("DESKTOP", "enlightenment")) {
         send_key "ctrl-alt-delete";               # shutdown
         assert_screen 'logoutdialog', 15;

--- a/tests/x11/shutdown.pm
+++ b/tests/x11/shutdown.pm
@@ -79,6 +79,12 @@ sub run() {
         send_key "ret";
     }
 
+    if (check_var("DESKTOP", "enlightenment")) {
+        send_key "ctrl-alt-delete";               # shutdown
+        assert_screen 'logoutdialog', 15;
+        assert_and_click 'enlightenment_shutdown_btn';
+    }
+
     if (get_var("DESKTOP") =~ m/minimalx|textmode/) {
         power('off');
     }

--- a/tests/x11/shutdown.pm
+++ b/tests/x11/shutdown.pm
@@ -97,7 +97,7 @@ sub run() {
         assert_and_click 'mate_shutdown_btn';
     }
 
-    if (get_var("DESKTOP") =~ m/minimalx|textmode/) {
+    if (get_var("DESKTOP") =~ m/minimalx|textmode|awesome/) {
         power('off');
     }
 

--- a/tests/x11/shutdown.pm
+++ b/tests/x11/shutdown.pm
@@ -85,6 +85,13 @@ sub run() {
         assert_and_click 'enlightenment_shutdown_btn';
     }
 
+    if (check_var("DESKTOP", "mate")) {
+        x11_start_program("mate-session-save --shutdown-dialog");
+        send_key "ctrl-alt-delete";               # shutdown
+        assert_screen 'mate_logoutdialog', 15;
+        assert_and_click 'mate_shutdown_btn';
+    }
+
     if (get_var("DESKTOP") =~ m/minimalx|textmode/) {
         power('off');
     }

--- a/tests/x11/terminology.pm
+++ b/tests/x11/terminology.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "x11test";
+use strict;
+use testapi;
+
+sub run() {
+    my $self = shift;
+    mouse_hide(1);
+    x11_start_program("terminology");
+    assert_screen "terminology";
+    for (1 .. 13) { send_key "ret" }
+    type_string "echo If you can see this text terminology is working.\n";
+    assert_screen 'test-terminology-1';
+    send_key "ctrl-alt-x";    # This will need to be fixed - even Enlightenment should use alt-f4, boo#983953
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
This collection of commits allows to setup tests for

* Enlightenment
* LXQt
* Mate

All tests are up to the point that they start a session and shut down again. At least maintainers of 2 of those DEs expressed interest to extend it with more tests.

There is also a pullreq with needles in order to not having to create them all again.

Those three DEs ran on my local openQA instance, based on TW Snapshot 0605