### PR TITLE
Disable kontact for 42.2 for now

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -754,7 +754,11 @@ sub load_x11tests() {
     }
     if (kdestep_is_applicable) {
         loadtest "x11/amarok.pm";
-        loadtest "x11/kontact.pm";
+        # kontact is broken currently. needs to be re-enable when we
+        # move to plasma5
+        if (!(check_var('VERSION', '42.2') || get_var('VERSION', '') =~ /^42:/)) {
+            loadtest "x11/kontact.pm";
+        }
         if (!get_var("USBBOOT")) {
             if (get_var("PLASMA5")) {
                 loadtest "x11/reboot_plasma5.pm";


### PR DESCRIPTION
kdepim4 doesn't build anymore with new cmake and kdepim5 is not in a
ring yet.