### PR TITLE
Some fixes for online migration test

### DIFF
--- a/tests/online_migration/sle12_online_migration/pre_migration.pm
+++ b/tests/online_migration/sle12_online_migration/pre_migration.pm
@@ -24,7 +24,8 @@ sub check_or_install_packages() {
         # check if the packages was installed along with update
         my $output = script_output "rpm -qa yast2-migration zypper-migration-plugin rollback-helper | sort";
         if ($output !~ /rollback-helper.*?yast2-migration.*?zypper-migration-plugin/s) {
-            die "migration packages was not installed along with system update";
+            record_soft_failure 'bsc#982150: migration packages were not installed along with system update. Installing missed package to continue the test';
+            assert_script_run "zypper -n in yast2-migration zypper-migration-plugin rollback-helper snapper", 190;
         }
     }
     else {
@@ -42,6 +43,9 @@ sub run() {
 
     # set scc proxy url here to perform online migration via scc proxy
     set_scc_proxy_url;
+
+    # disable installation repos before online migration
+    assert_script_run "zypper mr -d -l";
 }
 
 sub test_flags {

--- a/tests/online_migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/online_migration/sle12_online_migration/yast2_migration.pm
@@ -57,17 +57,14 @@ sub run {
     }
     assert_screen 'yast2-migration-proposal', 60;
 
-    # disable installation repo
-    assert_screen 'recommend-to-disable';
-    if (get_var("DESKTOP") =~ /textmode|minimalx/) {
-        send_key "tab";
-        send_key_until_needlematch 'disable-repo', 'down', 3;
+    # giva a little time to check package conflicts
+    if (check_screen("yast2-migration-conflicts", 15)) {
+        send_key_until_needlematch 'migration-proposal-packages', 'tab', 3;
         send_key "ret";
+        save_screenshot;
+        $self->result('fail');
+        return;
     }
-    else {
-        assert_and_click 'disable-repo';
-    }
-    wait_still_screen;
     send_key "alt-n";
     assert_screen 'yast2-migration-startupgrade';
     send_key "alt-u";


### PR DESCRIPTION
Record soft failure for checking migration packages
known bug #bsc982158 and continue the tests on 12sp1
https://openqa.suse.de/tests/443377#step/pre_migration/8

Disable installation repos before migration
reduce the difficulty to disable multiple installation repos in yast2 migration
https://openqa.suse.de/tests/443372#step/yast2_migration/18

Check package conflicts on migration proposal
if package conflicts in migration proposal, show the details of conflict and set fail 