### PR TITLE
Test des-ede is invalid cipher in openssl-fips

### DIFF
--- a/tests/fips/openssl/openssl_fips_cipher.pm
+++ b/tests/fips/openssl/openssl_fips_cipher.pm
@@ -13,6 +13,7 @@
 use base "consoletest";
 use testapi;
 use strict;
+use utils;
 
 sub run() {
     select_console 'root-console';
@@ -37,6 +38,9 @@ sub run() {
 
     # With FIPS non-approved Cipher algorithms, openssl shall report failure
     my @invalid_cipher = ("bf", "cast5", "rc4", "seed", "des", "desx");
+    if (sle_version_at_least('12-SP2')) {
+        push @invalid_cipher, "des-ede";
+    }
     for my $cipher (@invalid_cipher) {
         validate_script_output "openssl enc -$cipher -e -in $file_raw -out $file_enc -k $enc_passwd -md $hash_alg 2>&1 | tee", sub { m/disabled for fips|unknown option/ };
     }


### PR DESCRIPTION
The Two-key TDEA Encryption, known as des-ede in openssl, was once
approved algorithm by FIPS, but according to NIST.SP.800-131Ar1
specification, it is disallowed after 2015. So, now it becames
non-approved cipher and shouldn't work in FIPS mode.