### PR TITLE
Add openssh test cases for FIPS testing

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -831,6 +831,9 @@ sub load_fips_tests_core() {
     loadtest "fips/openssl/openssl_fips_alglist.pm";
     loadtest "fips/openssl/openssl_fips_hash.pm";
     loadtest "fips/openssl/openssl_fips_cipher.pm";
+    loadtest "console/sshd.pm";
+    loadtest "console/ssh_pubkey.pm";
+    loadtest "fips/openssh/openssh_fips.pm";
 }
 
 sub load_fips_tests_web() {

--- a/tests/console/ssh_pubkey.pm
+++ b/tests/console/ssh_pubkey.pm
@@ -1,0 +1,39 @@
+# SUSE's openssh tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use strict;
+use testapi;
+
+# check if sshd works with public key
+sub run() {
+    select_console 'user-console';
+
+    # Assume user "sshboy" has been created in sshd.pm test script
+    my $ssh_testman        = "sshboy";
+    my $ssh_testman_passwd = "let3me2in1";
+
+    # Remove existing public keys and create new one
+    script_run("rm -f ~/.ssh/id_*; ssh-keygen -t rsa -f ~/.ssh/id_rsa -P ''", 0);
+    assert_screen "ssh-keygen-ok", 60;
+
+    # Copy public key to target user's ~/.ssh/authorized_keys
+    script_run("ssh-keygen -R localhost; ssh-copy-id -i ~/.ssh/id_rsa.pub $ssh_testman\@localhost", 0);
+    assert_screen "ssh-login", 60;
+    type_string "yes\n";
+    assert_screen 'password-prompt';
+    type_string "$ssh_testman_passwd\n";
+
+    # Verify ssh without password
+    script_run("ssh -v $ssh_testman\@localhost -t echo LOGIN_SUCCESSFUL", 0);
+    assert_screen "ssh-login-ok";
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/fips/openssh/openssh_fips.pm
+++ b/tests/fips/openssh/openssh_fips.pm
@@ -1,0 +1,31 @@
+# SUSE's openssh fips tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use strict;
+use testapi;
+
+sub run() {
+    select_console 'root-console';
+
+    # Verify MD5 is disabled in fips mode, no need to login
+    validate_script_output 'expect -c "spawn ssh -v -o StrictHostKeyChecking=no localhost; expect -re \[Pp\]assword; send badpass\n; exit 0"', sub { m/MD5 not allowed in FIPS 140-2 mode, using SHA/ };
+
+    # Verify ssh doesn't work with non-approved cipher in fips mode
+    validate_script_output 'expect -c "spawn ssh -v -c blowfish localhost; expect EOF; exit 0"', sub { m/Unknown cipher type|no matching cipher found/ };
+
+    # Verify ssh doesn't work with non-approved hash in fips mode
+    validate_script_output 'expect -c "spawn ssh -v -m hmac-md5 localhost; expect EOF; exit 0"', sub { m/Unknown mac type|no matching mac found/ };
+
+    # Verify ssh doesn't support DSA public key in fips mode
+    validate_script_output 'ssh-keygen -t dsa -f ~/.ssh/id_dsa -P "" 2>&1 | tee', sub { m/Key type dsa not alowed in FIPS mode/ };
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Involve the existing openssh test case: sshd.pm

Create new case ssh_pubkey.pm to test public key

Create new case openssh_fips.pm to verify that
openssh will refuse to work with any non-approved
algorithm in fips mode, just like blowfish cipher
or MD5 hash.