### PR TITLE
bootloader_s390: Calculate zVM RAM from variable to DRY

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -100,7 +100,7 @@ EO_frickin_boot_parms
         eval {
             # Define memory to behave the same way as other archs
             # and to have the same configuration through all s390 guests
-            $s3270->sequence_3270("String(\"DEFINE STORAGE 1G\")", "ENTER",);
+            $s3270->sequence_3270('String("DEFINE STORAGE ' . get_var('QEMURAM', 1024) . 'M") ', "ENTER",);
 
             # ensure that we are in cms mode before executing qaboot
             $s3270->sequence_3270("String(\"#cp i cms\")", "ENTER", "ENTER", "ENTER", "ENTER",);


### PR DESCRIPTION
Local verification run: http://lord.arch/tests/1105

The calculated RAM amount is the same as in before as can be seen in the logfile:

```
14:18:07.7291 <<< backend::console_proxy::__ANON__(wrapped_call={
  'args' => [ 
              'String("DEFINE STORAGE 1G") ',
              'ENTER'
            ],
  'function' => 'sequence_3270',
  'console' => 'x3270'
})
```

@Soulofdestiny, @sysrich 