### PR TITLE
The initial version of virtualization automation test for openqa with kvm support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ check-links: tools/ os-autoinst/
 
 .PHONY: test-compile
 test-compile: check-links
-	export PERL5LIB="../..:os-autoinst:lib:tests/installation:tests/x11:tests/qa_automation:$$PERL5LIB" ; for f in `git ls-files "*.pm" || find . -name \*.pm|grep -v /os-autoinst/` ; do perl -c $$f 2>&1 | grep -v " OK$$" && exit 2; done ; true
+	export PERL5LIB="../..:os-autoinst:lib:tests/installation:tests/x11:tests/qa_automation:tests/virt_autotest:$$PERL5LIB" ; for f in `git ls-files "*.pm" || find . -name \*.pm|grep -v /os-autoinst/` ; do perl -c $$f 2>&1 | grep -v " OK$$" && exit 2; done ; true
 
 .PHONY: check-links
 tidy: check-links

--- a/cpanfile
+++ b/cpanfile
@@ -1,1 +1,5 @@
 requires 'Net::Telnet';
+requires 'File::Basename';
+requires 'Data::Dumper';
+requires 'XML::Writer';
+requires 'IO::File';

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -329,7 +329,12 @@ sub load_boot_tests() {
         }
     }
     elsif (uses_qa_net_hardware()) {
-        loadtest "installation/qa_net.pm";
+        if (get_var("BEIJING")) {
+            loadtest "virt_autotest/init_pxe_install.pm";
+        }
+        else {
+            loadtest "installation/qa_net.pm";
+        }
     }
     elsif (check_var("ARCH", "s390x")) {
         if (check_var('BACKEND', 's390x')) {
@@ -347,6 +352,10 @@ sub load_boot_tests() {
     else {
         loadtest "installation/bootloader.pm";
     }
+}
+
+sub install_this_version {
+    return !check_var('INSTALL_TO_OTHERS', 1);
 }
 
 sub load_inst_tests() {
@@ -382,7 +391,7 @@ sub load_inst_tests() {
     }
     loadtest "installation/addon_products_sle.pm";
     if (noupdatestep_is_applicable()) {
-        if (check_var('ARCH', 'x86_64') && sle_version_at_least('12-SP2') && is_server() && (!is_sles4sap() || is_sles4sap_standard())) {
+        if (check_var('ARCH', 'x86_64') && sle_version_at_least('12-SP2') && is_server() && (!is_sles4sap() || is_sles4sap_standard()) && install_this_version()) {
             loadtest "installation/system_role.pm";
         }
         loadtest "installation/partitioning.pm";
@@ -978,6 +987,23 @@ elsif (get_var("QA_TESTSET")) {
         loadtest "qa_automation/patch_and_reboot.pm";
     }
     loadtest "qa_automation/" . get_var("QA_TESTSET") . ".pm";
+}
+elsif (get_var("VIRT_AUTOTEST")) {
+    load_boot_tests();
+    load_inst_tests();
+    loadtest "virt_autotest/login_console.pm";
+    loadtest "virt_autotest/install_package.pm";
+    loadtest "virt_autotest/reboot_and_wait_up_normal1.pm";
+
+    if (get_var("VIRT_PRJ1_GUEST_INSTALL")) {
+        loadtest "virt_autotest/guest_installation_run.pm";
+    }
+    elsif (get_var("VIRT_PRJ2_HOST_UPGRADE")) {
+        loadtest "virt_autotest/host_upgrade_generate_run_file.pm";
+        loadtest "virt_autotest/host_upgrade_step2_run.pm";
+        loadtest "virt_autotest/reboot_and_wait_up_upgrade.pm";
+        loadtest "virt_autotest/host_upgrade_step3_run.pm";
+    }
 }
 elsif (get_var("QAM_MINIMAL")) {
     prepare_target();

--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -1,0 +1,59 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+use base "virt_autotest_base";
+use testapi;
+
+sub get_script_run() {
+    my $prd_version = script_output("cat /etc/issue");
+    my $pre_test_cmd;
+    if ($prd_version =~ m/SUSE Linux Enterprise Server 12/) {
+        $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-virt_install_withopt-run";
+    }
+    else {
+        $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-standalone-run";
+    }
+
+    $guest_pattern = get_var('GUEST_PATTERN', 'sles-12-sp2-64-[p|f]v-def-net');
+    $parallel_num  = get_var("PARALLEL_NUM",  "2");
+    $pre_test_cmd  = $pre_test_cmd . " -f " . $guest_pattern . " -n " . $parallel_num . " -r ";
+
+    return $pre_test_cmd;
+}
+
+sub analyzeResult($) {
+    my ($self, $text) = @_;
+    my $result;
+    $text =~ /Test in progress(.*)Test run complete/s;
+    my $rough_result = $1;
+    foreach (split("\n", $rough_result)) {
+        if ($_ =~ /(\S+)\s+\.{3}\s+\.{3}\s+(PASSED|FAILED)\s+\((\S+)\)/g) {
+            $result->{$1}{"status"} = $2;
+            $result->{$1}{"time"}   = $3;
+        }
+    }
+    return $result;
+}
+
+sub run() {
+    my $self = shift;
+
+    $self->{"product_tested_on"} = "SLES-12-SP2";
+    $self->{"product_name"}      = "GuestIn_stallation";
+    $self->{"package_name"}      = "Guest Installation Test";
+
+    $self->run_test(7600, "", "yes");
+}
+
+sub test_flags {
+    return {important => 1};
+}
+
+1;
+

--- a/tests/virt_autotest/host_upgrade_base.pm
+++ b/tests/virt_autotest/host_upgrade_base.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+package host_upgrade_base;
+use strict;
+use warnings;
+use base "virt_autotest_base";
+use testapi;
+
+sub get_test_name_prefix() {
+    my $test_name_prefix = "";
+
+    my $mode       = get_var("TEST_MODE",       "");
+    my $hypervisor = get_var("HOST_HYPERVISOR", "");
+    my $base       = get_var("BASE_PRODUCT",    "");    #EXAMPLE, sles-11-sp3
+    my $upgrade    = get_var("UPGRADE_PRODUCT", "");    #EXAMPLE, sles-12-sp2
+
+    $base =~ s/-//g;
+    $upgrade =~ s/-//g;
+
+    $test_name_prefix = "/usr/share/qa/tools/test-VH-Upgrade-$mode-$hypervisor-$base-$upgrade";
+
+    return "$test_name_prefix";
+}
+
+1;
+

--- a/tests/virt_autotest/host_upgrade_generate_run_file.pm
+++ b/tests/virt_autotest/host_upgrade_generate_run_file.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+use base "host_upgrade_base";
+#use virt_utils qw(set_serialdev);
+use testapi;
+
+sub get_script_run() {
+    my $pre_test_cmd;
+
+    my $mode         = get_var("TEST_MODE",       "");
+    my $hypervisor   = get_var("HOST_HYPERVISOR", "");
+    my $base         = get_var("BASE_PRODUCT",    "");    #EXAMPLE, sles-11-sp3
+    my $upgrade      = get_var("UPGRADE_PRODUCT", "");    #EXAMPLE, sles-12-sp2
+    my $upgrade_repo = get_var("UPGRADE_REPO",    "");
+    my $guest_list   = get_var("GUEST_LIST",      "");
+
+    $pre_test_cmd = "/usr/share/qa/tools/_generate_vh-update_tests.sh";
+    $pre_test_cmd .= " -m $mode";
+    $pre_test_cmd .= " -v $hypervisor";
+    $pre_test_cmd .= " -b $base";
+    $pre_test_cmd .= " -u $upgrade";
+    $pre_test_cmd .= " -r $upgrade_repo";
+    $pre_test_cmd .= " -i $guest_list";
+
+    return "$pre_test_cmd";
+}
+
+sub run() {
+    my $self = shift;
+    $self->run_test(180, "Generated test run file");
+}
+
+1;
+

--- a/tests/virt_autotest/host_upgrade_step1_run.pm
+++ b/tests/virt_autotest/host_upgrade_step1_run.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+use base "host_upgrade_base";
+use testapi;
+use strict;
+
+sub get_script_run() {
+    my $self = shift;
+
+    my $pre_test_cmd = $self->get_test_name_prefix;
+    $pre_test_cmd .= "-run 01";
+
+    return "$pre_test_cmd";
+}
+
+sub run() {
+    my $self = shift;
+    $self->run_test(5400, "Test run completed successfully", "no", "yes", "/var/log/qa/ctcs2/", "host-upgrade-updateVirtRpms");
+}
+1;
+

--- a/tests/virt_autotest/host_upgrade_step2_run.pm
+++ b/tests/virt_autotest/host_upgrade_step2_run.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+use base "host_upgrade_base";
+#use virt_utils qw(set_serialdev);
+use testapi;
+use strict;
+
+sub get_script_run() {
+    my $self = shift;
+
+    my $pre_test_cmd = $self->get_test_name_prefix;
+    $pre_test_cmd .= "-run 02";
+
+    return "$pre_test_cmd";
+}
+
+sub run() {
+    my $self = shift;
+    $self->run_test(36000, "Host upgrade to .* is done. Need to reboot system", "no", "yes", "/var/log/qa/ctcs2/", "host-upgrade-prepAndUpgrade");
+}
+
+1;
+

--- a/tests/virt_autotest/host_upgrade_step3_run.pm
+++ b/tests/virt_autotest/host_upgrade_step3_run.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+use base "host_upgrade_base";
+use testapi;
+use strict;
+
+sub get_script_run() {
+    my $self = shift;
+
+    my $pre_test_cmd = $self->get_test_name_prefix;
+    $pre_test_cmd .= "-run 03";
+
+    return "$pre_test_cmd";
+}
+
+sub run() {
+    my $self = shift;
+    $self->run_test(5400, "Test run completed successfully", "no", "yes", "/var/log/qa/ctcs2/", "host-upgrade-postVerify-logs");
+}
+
+1;
+

--- a/tests/virt_autotest/init_pxe_install.pm
+++ b/tests/virt_autotest/init_pxe_install.pm
@@ -1,0 +1,53 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+use strict;
+use warnings;
+use File::Basename;
+use base "opensusebasetest";
+use testapi;
+
+sub run() {
+    # Wait initial screen for ipmi bootloader
+    assert_screen "virttest-bootloader", 60;
+
+    # Wait the second screen for ipmi bootloader
+    send_key_until_needlematch "virttest-boot-into-pxe", "f12", 3, 60;
+
+    # Wait pxe management screen
+    send_key_until_needlematch "virttest-pxe-menu", "f12", 200, 1;
+
+    # Login to command line of pxe management
+    send_key_until_needlematch "virttest-pxe-edit-prompt", "esc", 60, 1;
+
+    # Execute installation command on pxe management cmd console
+    my $type_speed = 20;
+    my $image_path = get_var("HOST_IMG_URL");
+
+    type_string ${image_path} . " ", $type_speed;
+    type_string "vga=791 ",   $type_speed;
+    type_string "Y2DEBUG=1 ", $type_speed;
+    if (check_var("INSTALL_TO_OTHERS", 1)) {
+        type_string "video=1024x768-16 ", $type_speed;
+    }
+    else {
+        type_string "xvideo=1024x768 ", $type_speed;
+    }
+    type_string "console=ttyS1,115200 ", $type_speed;    # to get crash dumps as text
+    type_string "console=tty ",          $type_speed;
+    send_key 'ret';
+    save_screenshot;
+}
+
+sub test_flags {
+    return {important => 1};
+}
+
+1;
+

--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -1,0 +1,88 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+use strict;
+use warnings;
+use File::Basename;
+use base "virt_autotest_base";
+use testapi;
+
+sub install_package() {
+    my $qa_server_repo = get_var('QA_HEAD_REPO', '');
+    if ($qa_server_repo) {
+        type_string "zypper --non-interactive rr server-repo\n";
+        assert_script_run("zypper --non-interactive --no-gpg-check -n ar -f '$qa_server_repo' server-repo");
+    }
+    else {
+        die "There is no qa server repo defined variable QA_HEAD_REPO\n";
+    }
+
+    assert_script_run("zypper --non-interactive --gpg-auto-import-keys ref", 90);
+    assert_script_run("zypper --non-interactive -n in qa_lib_virtauto",      1800);
+}
+
+sub update_package() {
+    my $self           = shift;
+    my $test_type      = get_var('TEST_TYPE', 'Milestone');
+    my $update_pkg_cmd = "source /usr/share/qa/virtautolib/lib/virtlib;update_virt_rpms";
+    if ($test_type eq 'Milestone') {
+        $update_pkg_cmd = $update_pkg_cmd . " off on off";
+    }
+    else {
+        $update_pkg_cmd = $update_pkg_cmd . " off off on";
+    }
+
+    $update_pkg_cmd = $update_pkg_cmd . " 2>&1 | tee /tmp/update_virt_rpms.log ";
+
+    my $ret = $self->execute_script_run($update_pkg_cmd, 7200);
+    save_screenshot;
+
+    upload_logs("/tmp/update_virt_rpms.log");
+
+    if ($ret !~ /Need to reboot system to make the rpms work/m) {
+        die " Update virt rpms fail, going to terminate following test!";
+    }
+
+}
+
+
+sub generate_grub() {
+    if (get_var("XEN")) {
+        assert_script_run("if ! grep -q \"GRUB_CMDLINE_XEN_DEFAULT=.*console=com1 com1=115200\" /etc/default/grub;then sed -ri 's/\(GRUB_CMDLINE_XEN_DEFAULT=.*\)\"/\\1 console=com1 com1=115200\"/' /etc/default/grub ; fi");
+
+    }
+    else {
+        assert_script_run("if ! grep -q \"GRUB_CMDLINE_LINUX_DEFAULT=.*console=ttyS1,115200.*console=tty\" /etc/default/grub;then sed -ri 's/\(GRUB_CMDLINE_LINUX_DEFAULT=.*\)\"/\\1 console=ttyS1,115200 console=tty\"/' /etc/default/grub ; fi");
+    }
+
+    upload_logs("/etc/default/grub");
+
+    my $gen_grub_cmd = "grub2-mkconfig -o /boot/grub2/grub.cfg";
+
+    assert_script_run($gen_grub_cmd, 40);
+}
+
+
+sub run() {
+    my $self = shift;
+
+    install_package;
+
+    $self->update_package();
+
+    generate_grub;
+}
+
+
+sub test_flags {
+    return {important => 1};
+}
+
+1;
+

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+
+use strict;
+use warnings;
+use File::Basename;
+use base "opensusebasetest";
+use testapi;
+
+sub run() {
+    # Wait for bootload for the first time.
+    assert_screen "grub2", 120;
+    if (get_var("XEN")) {
+        send_key_until_needlematch("bootmenu-xen-kernel", 'down', 10, 1);
+        send_key 'ret';
+    }
+
+    assert_screen(["generic-destop", "generic-destop-virt", "displaymanager"], 300);
+    select_console('root-console');
+    sleep 3;
+}
+
+sub test_flags {
+    return {important => 1};
+}
+
+1;
+

--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+package reboot_and_wait_up;
+use strict;
+use warnings;
+use File::Basename;
+use base "opensusebasetest";
+use testapi;
+
+sub reboot_and_wait_up() {
+    my $self           = shift;
+    my $reboot_timeout = shift;
+
+    select_console('root-console');
+    type_string("/sbin/reboot\n");
+    reset_consoles;
+    sleep 2;
+    #add switch xen kernel
+    assert_screen "grub2", 120;
+    if (!get_var("reboot_for_upgrade_step")) {
+        if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
+            send_key_until_needlematch("bootmenu-xen-kernel", 'down', 10, 1);
+            send_key 'ret';
+        }
+    }
+    assert_screen(["displaymanager", "virttest-displaymanager"], $reboot_timeout);
+    select_console('root-console');
+
+}
+
+1;
+

--- a/tests/virt_autotest/reboot_and_wait_up_normal1.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_normal1.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+use strict;
+use warnings;
+use File::Basename;
+use testapi;
+use base "reboot_and_wait_up";
+
+sub run() {
+    my $self    = shift;
+    my $timeout = 300;
+    $self->reboot_and_wait_up($timeout);
+}
+
+sub test_flags {
+    return {important => 1};
+}
+
+1;
+

--- a/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+use strict;
+use warnings;
+use File::Basename;
+use testapi;
+use base "reboot_and_wait_up";
+
+sub run() {
+    my $self    = shift;
+    my $timeout = 3600;
+    set_var("reboot_for_upgrade_step", "yes");
+    $self->reboot_and_wait_up($timeout);
+}
+
+sub test_flags {
+    return {important => 1};
+}
+
+1;
+

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -1,0 +1,161 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+package virt_autotest_base;
+use strict;
+use warnings;
+use File::Basename;
+use base "opensusebasetest";
+use testapi;
+
+use Data::Dumper;
+use XML::Writer;
+use IO::File;
+
+sub analyzeResult() {
+    die "You need to overload analyzeResult in your class";
+}
+
+sub get_script_run() {
+    die "You need to overload this func in your class";
+}
+
+sub generateXML($) {
+    my ($self, $data) = @_;
+
+    $self->{"product_tested_on"} = "Product";
+    $self->{"product_name"}      = "Project Name";
+    $self->{"package_name"}      = "Package Name";
+
+    print Dumper($data);
+    my %my_hash = %$data;
+
+    my $case_num = scalar(keys %my_hash);
+    my $case_status;
+    my $xml_result;
+    my $pass_nums = 0;
+    my $fail_nums = 0;
+    my $writer    = new XML::Writer(DATA_MODE => 'true', DATA_INDENT => 2, OUTPUT => 'self');
+
+    foreach my $item (keys(%my_hash)) {
+        if ($my_hash{$item}->{"status"} =~ m/PASSED/) {
+            $pass_nums += 1;
+        }
+        else {
+            $fail_nums += 1;
+        }
+    }
+    my $count = $pass_nums + $fail_nums;
+    $writer->startTag('testsuites', "error" => "0", "failures" => "$fail_nums", "name" => $self->{"product_name"}, "skipped" => "0", "tests" => "$count", "time" => "");
+    $writer->startTag('testsuite', "error" => "0", "failures" => "$fail_nums", "hostname" => "`hostname`", "id" => "0", "name" => $self->{"product_tested_on"}, "package" => $self->{"package_name"}, "skipped" => "0", "tests" => $case_num, "time" => "", "timestamp" => "2016-02-16T02:50:00");
+
+    foreach my $item (keys(%my_hash)) {
+        if ($my_hash{$item}->{"status"} =~ m/PASSED/) {
+            $case_status = "success";
+        }
+        else {
+            $case_status = "failure";
+        }
+
+        $writer->startTag('testcase', 'classname' => $item, 'name' => $item, "status" => $case_status, 'time' => $my_hash{$item}->{"time"});
+        $writer->startTag('system-err');
+        $writer->characters("None");
+        $writer->endTag('system-err');
+
+        $writer->startTag('system-out');
+        $writer->characters($my_hash{$item}->{"time"});
+        $writer->endTag('system-out');
+
+        $writer->endTag('testcase');
+    }
+
+    $writer->endTag('testsuite');
+    $writer->endTag('testsuites');
+
+    $writer->end();
+    $writer->to_string();
+}
+
+sub execute_script_run($$) {
+    my ($self, $cmd, $timeout) = @_;
+    my $pattern = "CMD_FINISHED-" . int(rand(999999));
+
+    if (!$timeout) {
+        $timeout = 10;
+    }
+
+    type_string "(" . $cmd . "; echo $pattern) 2>&1 | tee -a /dev/$serialdev\n";
+    my $ret = wait_serial($pattern, $timeout);
+
+    save_screenshot;
+
+    if ($ret) {
+        $ret =~ s/$pattern//g;
+        return $ret;
+    }
+    else {
+        die "Timeout due to cmd run :[" . $cmd . "]\n";
+    }
+
+}
+
+sub push_junit_log($) {
+    my ($self, $junit_content) = @_;
+
+    type_string "echo \'$junit_content\' > /tmp/output.xml\n";
+    parse_junit_log("/tmp/output.xml");
+}
+
+sub run_test() {
+    my ($self, $timeout, $assert_pattern, $add_junit_log_flag, $upload_virt_log_flag, $log_dir, $compressed_log_name) = @_;
+    if (!$timeout) {
+        $timeout = 300;
+    }
+
+    my $test_cmd = $self->get_script_run();
+    my $script_output = $self->execute_script_run($test_cmd, $timeout);
+
+    if ($add_junit_log_flag eq "yes") {
+        $self->add_junit_log($script_output);
+    }
+
+    if ($upload_virt_log_flag eq "yes") {
+        upload_virt_logs($log_dir, $compressed_log_name);
+    }
+
+    if ($assert_pattern) {
+        unless ($script_output =~ /$assert_pattern/m) {
+            assert_script_run("grep \"$assert_pattern\" $log_dir -r || zcat /tmp/$compressed_log_name.tar.gz | grep -a \"$assert_pattern\"");
+        }
+    }
+
+}
+
+sub add_junit_log() {
+    my ($self, $job_output) = @_;
+
+    # Parse test result and generate junit file
+    my $tc_result  = $self->analyzeResult($job_output);
+    my $xml_result = $self->generateXML($tc_result);
+    # Upload and parse junit file.
+    $self->push_junit_log($xml_result);
+
+}
+
+sub upload_virt_logs() {
+    my ($log_dir, $compressed_log_name) = @_;
+
+    my $full_compressed_log_name = "/tmp/$compressed_log_name.tar";
+    script_run("tar cvf $full_compressed_log_name $log_dir; gzip -f $full_compressed_log_name; rm $log_dir -r", 60);
+    upload_logs "$full_compressed_log_name.gz";
+
+}
+
+1;
+

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+package virt_utils;
+use strict;
+use warnings;
+use File::Basename;
+use base "opensusebasetest";
+use testapi;
+use Exporter;
+use Data::Dumper;
+use XML::Writer;
+use IO::File;
+
+our @EXPORT = qw(set_serialdev);
+
+sub set_serialdev() {
+    if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
+        my $hostReleaseInfo = script_output("cat /etc/SuSE-release");
+        if ($hostReleaseInfo =~ /VERSION = 12\nPATCHLEVEL = 2\n/m) {
+            $serialdev = "hvc0";
+        }
+        else {
+            $serialdev = "xvc0";
+        }
+    }
+    else {
+        $serialdev = "ttyS1";
+    }
+}
+
+1;
+


### PR DESCRIPTION
Supported scenarios:
1)guest installation test on sles12sp1 and sles12sp2, kvm
2)host upgrade test from sles12sp1 to sles12sp2 , kvm

We finally made a test of this pull request based on the latest openqa code when the network recovered early this week.

Note: xen is not fully supported yet, blocked because console device changes from /dev/ttyS1 to /dev/hvc0 or /dev/xvc0, but openqa backend sets to only ttyS1. We made a fix to set it dynamically, but not verified yet.