### PR TITLE
Skip already enabled kdump

### DIFF
--- a/tests/toolchain/crash.pm
+++ b/tests/toolchain/crash.pm
@@ -19,14 +19,16 @@ sub run() {
 
     script_run 'yast2 kdump', 0;
 
-    assert_screen 'yast2-kdump-disabled';
-    send_key 'alt-u';    # enable kdump
+    if (check_screen 'yast2-kdump-disabled') {
+        send_key 'alt-u';    # enable kdump
+    }
 
     assert_screen 'yast2-kdump-enabled';
-    send_key 'alt-o';    # OK
+    send_key 'alt-o';        # OK
 
-    assert_screen 'yast2-kdump-restart-info';
-    send_key 'alt-o';    # OK
+    if (check_screen 'yast2-kdump-restart-info') {
+        send_key 'alt-o';    # OK
+    }
 
     # activate kdump
     script_run 'reboot', 0;


### PR DESCRIPTION
If kdump is already enabled the test would fail because it would expect kdump being disabled (e.g. here: https://openqa.suse.de/tests/445896#step/crash/8 kdump is enabled after installation but the test failed from another reason).

New needle required: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/157 https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/79.

Verification run: http://assam.suse.cz/tests/1528.