### PR TITLE
Set YaST install window back to fullscreen to workaround bsc#985055

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -24,6 +24,7 @@ our @EXPORT = qw/
   workaround_type_encrypted_passphrase
   check_screenlock
   sle_version_at_least
+  ensure_fullscreen
   /;
 
 
@@ -347,6 +348,17 @@ sub sle_version_at_least {
     }
 
     die "unsupported SLE VERSION $version in check";
+}
+
+sub ensure_fullscreen {
+    my (%args) = @_;
+    $args{tag} //= 'yast2-windowborder';
+    # for ssh-X using our window manager we need to handle windows explicitly
+    if (check_var('VIDEOMODE', 'ssh-x')) {
+        assert_screen($args{tag});
+        my $console = select_console("installation");
+        $console->fullscreen({window_name => 'YaST2*'});
+    }
 }
 
 1;

--- a/tests/installation/skip_registration.pm
+++ b/tests/installation/skip_registration.pm
@@ -18,9 +18,14 @@ use base "y2logsstep";
 
 use testapi;
 use registration;
+use utils qw/ensure_fullscreen/;
 
 sub run() {
-    assert_screen("scc-registration", 100);
+    assert_screen([qw/scc-registration yast2-windowborder-corner/], 100);
+    if (match_has_tag('yast2-windowborder-corner')) {
+        ensure_fullscreen(tag => 'yast2-windowborder-corner');
+        assert_screen('scc-registration', 100);
+    }
     send_key "alt-s", 1;    # skip SCC registration
     if (check_screen("scc-skip-reg-warning", 10)) {
         if (check_screen("ok-button", 10)) {

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -12,15 +12,7 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
-
-sub ensure_fullscreen {
-    # for ssh-X using our window manager we need to handle windows explicitly
-    if (check_var('VIDEOMODE', 'ssh-x')) {
-        assert_screen('yast2-windowborder');
-        my $console = select_console("installation");
-        $console->fullscreen({window_name => 'YaST2*'});
-    }
-}
+use utils qw/ensure_fullscreen/;
 
 sub run() {
     my $self = shift;


### PR DESCRIPTION
YaST installer has a new feature to apply online updates during installation.
This happens at start of our test module "skip_registration". It was observed
as the YaST installer application window actually restarts. It seems this is
only observed in our s390 zVM based ssh+X scenario - at least so far. This
change sets the new window to fullscreen, too

As the previous detection of YaST window border explicitly tries to match on a
foreground dialog window a new needle was created which also works on the
single window attached right to the corner of the window manager we use for
s390x based tests.

SLE needle PR:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/158

Related progress issue: poo#12348