### PR TITLE
Update pidgin cases to workaround bsc#984969

### DIFF
--- a/tests/x11regressions/pidgin/clean_pidgin.pm
+++ b/tests/x11regressions/pidgin/clean_pidgin.pm
@@ -15,7 +15,7 @@ use testapi;
 # Cleaning for testing pidgin
 sub remove_pkg() {
     my $self     = shift;
-    my @packages = qw/pidgin pidgin-otr/;
+    my @packages = qw/pidgin/;
     x11_start_program("xterm");
 
     # Remove packages
@@ -29,7 +29,7 @@ sub remove_pkg() {
     type_string "clear\n";
     sleep 2;
     type_string "rpm -qa @packages\n";
-    assert_screen "pidgin-pkg-removed", 10;    #make sure pkgs removed.
+    assert_screen "pidgin-pkg-removed";    #make sure pkgs removed.
 
     type_string "exit\n";
     sleep 2;

--- a/tests/x11regressions/pidgin/pidgin_IRC.pm
+++ b/tests/x11regressions/pidgin/pidgin_IRC.pm
@@ -35,7 +35,7 @@ sub run() {
     send_key "alt-a";
 
     # Should create IRC account
-    assert_screen 'pidgin-irc-account', 3;
+    assert_screen 'pidgin-irc-account';
 
     # Close account manager
     send_key "ctrl-a";
@@ -62,12 +62,12 @@ sub run() {
     send_key "alt-j";
 
     # Should open sledtesting channel
-    assert_screen 'pidgin-irc-sledtesting', 3;
+    assert_screen 'pidgin-irc-sledtesting';
 
     # Send a message
     send_key "alt-tab";
     type_string "Hello from openQA\n";
-    assert_screen 'pidgin-irc-msgsent', 3;
+    assert_screen 'pidgin-irc-msgsent';
     send_key "ctrl-w";
     sleep 2;
 
@@ -83,7 +83,7 @@ sub run() {
     send_key "alt-d";
 
     # Should not have any account and show welcome window
-    assert_screen 'pidgin-welcome', 3;
+    assert_screen 'pidgin-welcome';
 
     # Exit
     send_key "alt-c";

--- a/tests/x11regressions/pidgin/pidgin_aim.pm
+++ b/tests/x11regressions/pidgin/pidgin_aim.pm
@@ -44,7 +44,7 @@ sub run() {
     send_key "alt-a";
 
     # Should create AIM account 1
-    assert_screen 'pidgin-aim-account1', 3;
+    assert_screen 'pidgin-aim-account1';
 
     # Create another account
     send_key "ctrl-a";
@@ -63,7 +63,7 @@ sub run() {
     sleep 15;    # wait until account2 online
 
     # Should have AIM accounts 1 and 2
-    assert_screen 'pidgin-aim-account2', 3;
+    assert_screen 'pidgin-aim-account2';
 
     # Close account manager
     send_key "ctrl-a";
@@ -81,9 +81,9 @@ sub run() {
     type_string "hello world!\n";
 
     # Should see "hello world!" in screen.
-    assert_screen 'pidgin-aim-sentmsg', 3;
+    assert_screen 'pidgin-aim-sentmsg';
     send_key "ctrl-tab";
-    assert_screen 'pidgin-aim-receivedmsg', 3;
+    assert_screen 'pidgin-aim-receivedmsg';
     sleep 2;
 
     # Cleaning
@@ -117,7 +117,7 @@ sub run() {
     send_key "alt-d";
 
     # Should not have any account
-    assert_screen 'pidgin-welcome', 3;
+    assert_screen 'pidgin-welcome';
 
     # Exit
     send_key "alt-c";

--- a/tests/x11regressions/pidgin/prep_pidgin.pm
+++ b/tests/x11regressions/pidgin/prep_pidgin.pm
@@ -11,59 +11,58 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 # Preparation for testing pidgin
 sub pidgin_preparation() {
     my $self = shift;
     mouse_hide(1);
-    my @packages = qw/pidgin pidgin-otr/;
+    my @packages = qw/pidgin/;
 
     # Install packages
-    x11_start_program("xterm");
-    type_string "xdg-su -c 'zypper -n in @packages'\n";
-    sleep 3;
-    if ($password) {
-        type_password;
-        send_key "ret";
-    }
-    sleep 60;            # give time to install
-    type_string "\n";    # prevent the screensaver...
-                         # make sure pkgs installed
-    type_string "clear;rpm -qa @packages\n";
-    assert_screen "pidgin-pkg-installed", 10;
+    ensure_installed(@packages);
 
     # Enable the showoffline
-    type_string "pidgin\n";
-    assert_screen "pidgin-welcome", 10;
+    x11_start_program("pidgin");
+    assert_screen "pidgin-welcome";
     send_key "alt-c";
-    sleep 1;
 
     # pidgin main winodow is hidden in tray at first run
     # need to show up the main window
-    send_key "super-m";
-    sleep 1;
-    send_key "ret";
-    sleep 1;
+    if (sle_version_at_least('12-SP2')) {
+        hold_key "ctrl-alt";
+        send_key "tab";
+        wait_still_screen;
+        send_key "tab";
+        wait_still_screen;
+        send_key "tab";
+        assert_screen "status-icons";
+        release_key "ctrl-alt";
+        assert_and_click "status-icons-pidgin";
+    }
+    else {
+        send_key "super-m";
+        wait_still_screen;
+        send_key "ret";
+        wait_still_screen;
+    }
 
     # check showoffline status is off
     send_key "alt-b";
-    sleep 1;
+    wait_still_screen;
     send_key "o";
-    sleep 1;
-    assert_screen "pidgin-showoffline-off", 10;
+    assert_screen "pidgin-showoffline-off";
     # enable showoffline
     send_key "o";
+    wait_still_screen;
     # check showoffline status is on
     send_key "alt-b";
-    sleep 1;
+    wait_still_screen;
     send_key "o";
-    assert_screen "pidgin-showoffline-on", 10;
+    assert_screen "pidgin-showoffline-on";
     send_key "esc";
 
-    send_key "ctrl-q";       # quit pidgin
-    sleep 1;
-    type_string "exit\n";    # close xterm
-    sleep 2;
+    send_key "ctrl-q";    # quit pidgin
 }
 
 sub run() {


### PR DESCRIPTION
Pidgin tests always failed in ['regression message' ](https://openqa.suse.de/tests/448565#step/prep_pidgin/5)testsuite after
SLED12 SP2 Alpha3 in openQA since bsc#984969 - pidgin take too long time
to probe pidgin-otr.so. Currently our automation test hasn't covered
pidgin-otr, so I drop it from the pre installed list in pre_pidgin.pm

 - Drop pidgin-otr in pre_pidgin.pm and clean_pidgin.pm
 - Use ensure_installed instead of xdg-su... to install package
 - Add if (sle_version_at_least('12-SP2')) branches to handle pidgin's
   new behavior in Gnome 320
 - Use wait_still_screen instead of sleep x seconds
 - Delete assert_screen's parameter(default timeout is enough)

See also: bsc#984969

Testing Result:
http://147.2.212.239/tests/649