### PR TITLE
WIP - general approach for test cases fate#319639

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -542,6 +542,9 @@ sub load_inst_tests() {
     }
     if (noupdatestep_is_applicable) {
         loadtest "installation/installer_timezone.pm";
+	if (!consolestep_is_applicable) {
+	    loadtest "installation/hostname_inst.pm";
+	}
         if (!get_var("REMOTE_MASTER")) {
             loadtest "installation/logpackages.pm";
         }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -542,9 +542,9 @@ sub load_inst_tests() {
     }
     if (noupdatestep_is_applicable) {
         loadtest "installation/installer_timezone.pm";
-	if (!consolestep_is_applicable) {
-	    loadtest "installation/hostname_inst.pm";
-	}
+        if (!consolestep_is_applicable) {
+            loadtest "installation/hostname_inst.pm";
+        }
         if (!get_var("REMOTE_MASTER")) {
             loadtest "installation/logpackages.pm";
         }

--- a/tests/installation/hostname_inst.pm
+++ b/tests/installation/hostname_inst.pm
@@ -15,9 +15,9 @@ use testapi;
 sub run() {
     my $self = shift;
     assert_screen "before-package-selection";
-    
+
     select_console('install-shell');
-    
+
     if (get_var('HOSTNAME')) {
         assert_script_run 'test $(hostname) == "myhost"';
     }

--- a/tests/installation/hostname_inst.pm
+++ b/tests/installation/hostname_inst.pm
@@ -1,7 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2016 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/installation/hostname_inst.pm
+++ b/tests/installation/hostname_inst.pm
@@ -16,15 +16,14 @@ use testapi;
 sub run() {
     my $self = shift;
     assert_screen "before-package-selection";
-
-    #send_key "ctrl-alt-shift-x"; sleep 3;
+    
     select_console('install-shell');
     
     if (get_var('HOSTNAME')) {
-        assert_script_run 'test $(hostname) == "myhost"'
+        assert_script_run 'test $(hostname) == "myhost"';
     }
     else {
-        assert_script_run 'test $(hostname) == "install"'
+        assert_script_run 'test $(hostname) == "install"';
     }
 
     save_screenshot;

--- a/tests/installation/hostname_inst.pm
+++ b/tests/installation/hostname_inst.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use strict;
+use warnings;
+use base "y2logsstep";
+use testapi;
+
+sub run() {
+    my $self = shift;
+    assert_screen "before-package-selection";
+
+    #send_key "ctrl-alt-shift-x"; sleep 3;
+    select_console('install-shell');
+    
+    if (get_var('HOSTNAME')) {
+        assert_script_run 'test $(hostname) == "myhost"'
+    }
+    else {
+        assert_script_run 'test $(hostname) == "install"'
+    }
+
+    save_screenshot;
+
+    select_console('installation');
+    assert_screen "inst-returned-to-yast", 15;
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Test cases for feature: https://fate.suse.com/319639

WIP - general approach

Related openQA action:
https://progress.opensuse.org/issues/11456

Related YaST team scrum PBI:
https://trello.com/c/dwbIW3ke/348-3-sle-12-sp2-p9b-m-automatic-test-case-for-feature-319639-set-hostname-in-installer-properly

We have considered to implement these test cases:  

Test1:
    start installation without additional param on kernel cmd line
    check whether hostname 'install' is set

Test2:
    start installation with ifcfg=<static IP>, means set up a static network (without dhcp)
    check whether hostname 'install' is set

Test3:
    start qemu with -netdev user,hostname=<myhostname1>
    start installation ifcfg=*=dhcp
    check whether hostname is set to 'myhostname1'

Test4:
    start installation with hostname=<myhostname2> on kernel cmd line
    check whether hostname is set to 'myhostname2'

Covered test cases in hostname_inst.pm: Test1 Test2 Test4
Test3 is more complicated, needs to set param for qemu (dhcp hostname) or multi machine setup.

Idea is (discussed with Oliver Kurz) to create a new testsuite which ends after checking the
hostname in inst-sys (not yet implemented in this pull request).

Start this testsuite 3 (4) times with different settings.

Test1:
/usr/share/openqa/script/clone_job.pl --from localhost 240 DISTRI=gs
Test2:
/usr/share/openqa/script/clone_job.pl --from localhost 240 DISTRI=gs   EXTRABOOTPARAMS="ifcfg=10.0.2.99/24"
Test4:
/usr/share/openqa/script/clone_job.pl --from localhost 240 DISTRI=gs   EXTRABOOTPARAMS="hostname=myhost" HOSTNAME=1

