### PR TITLE
Move btrfs autocompletion to extra group and check min-dev-size output

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -485,9 +485,6 @@ sub load_consoletests() {
         loadtest "console/check_console_font.pm";
         loadtest "console/textinfo.pm";
         loadtest "console/hostname.pm";
-        if (get_var("FILESYSTEM", "btrfs") eq "btrfs") {
-            loadtest "console/btrfs_autocompletion.pm";
-        }
         if (snapper_is_applicable) {
             if (get_var("UPGRADE")) {
                 loadtest "console/upgrade_snapshots.pm";
@@ -625,6 +622,9 @@ sub load_extra_tests () {
         # start extra console tests from here
         if (!get_var("OFW") && !is_jeos) {
             loadtest "console/aplay.pm";
+        }
+        if (get_var("FILESYSTEM", "btrfs") eq "btrfs") {
+            loadtest "console/btrfs_autocompletion.pm";
         }
         loadtest "console/a2ps.pm";    # a2ps is not a ring package and thus not available in staging
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -646,9 +646,6 @@ sub load_consoletests() {
         if (get_var("SYSTEM_ROLE")) {
             loadtest "console/patterns.pm";
         }
-        if (get_var("FILESYSTEM", "btrfs") eq "btrfs") {
-            loadtest "console/btrfs_autocompletion.pm";
-        }
         if (snapper_is_applicable) {
             if (get_var("UPGRADE")) {
                 loadtest "console/upgrade_snapshots.pm";
@@ -767,6 +764,9 @@ sub load_extra_test () {
     # start extra console tests from here
     if (!get_var("OFW") && !is_jeos) {
         loadtest "console/aplay.pm";
+    }
+    if (get_var("FILESYSTEM", "btrfs") eq "btrfs") {
+        loadtest "console/btrfs_autocompletion.pm";
     }
 
     loadtest "console/command_not_found.pm";

--- a/tests/console/btrfs_autocompletion.pm
+++ b/tests/console/btrfs_autocompletion.pm
@@ -24,6 +24,8 @@ sub compare_commands {
 }
 
 sub run() {
+    select_console 'root-console';
+
     compare_commands("btrfs device stats ",                  "btrfs d\tst\t");
     compare_commands("btrfs subvolume get-default ",         "btrfs su\tg\t");
     compare_commands("btrfs filesystem usage ",              "btrfs fi\tu\t");
@@ -31,6 +33,9 @@ sub run() {
 
     # Check loading of complete function
     assert_script_run "complete | grep '_btrfs btrfs'";
+
+    # Getting minimum device size is working and returning at least 1MB
+    assert_script_run "btrfs inspect-internal min-dev-size / | grep -E '^[0-9]{6,} bytes'";
 }
 
 1;


### PR DESCRIPTION
Btrfs autocompletion test moved to extra group (poo#11448)
 - discussed in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/1489
Added test for btrfs displaying minimal possible filesystem size (poo#11440)

Tested on:
SLES: http://dhcp91.suse.cz/tests/1521
TW: http://dhcp91.suse.cz/tests/1522