### PR TITLE
Fix main_common not including set_var

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1,7 +1,7 @@
 package main_common;
 use base Exporter;
 use Exporter;
-use testapi qw/check_var get_var diag/;
+use testapi qw/check_var get_var set_var diag/;
 use autotest;
 use strict;
 use warnings;


### PR DESCRIPTION
Looks like I didn't test an execution path where INSTLANG is not set.