### PR TITLE
Enable ADDONS and ADDONURL variables use together

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -28,7 +28,8 @@ sub run() {
         for my $addon (split(/,/, get_var('ADDONS'))) {
             $sr_number++;
             assert_screen 'addon-menu-active';
-            send_key 'alt-d', 3;    # DVD
+            send_key 'alt-d';    # DVD
+            wait_still_screen, 3;
             send_key 'alt-n';
             assert_screen 'dvd-selector';
             send_key_until_needlematch 'addon-dvd-list',         'tab',  10;    # jump into addon list
@@ -47,26 +48,25 @@ sub run() {
             else {
                 assert_screen "addon-license-$addon";
             }
-            sleep 2;
+            wait_still_screen, 2;
             send_key 'alt-a';                                                   # yes, agree
-            sleep 2;
+            wait_still_screen, 2;
             send_key 'alt-n';                                                   # next
             assert_screen 'addon-products';
-            send_key "tab", 1;                                                  # select addon-products-$addon
+            send_key "tab";                                                     # select addon-products-$addon
+            wait_still_screen, 2;
             if (check_var('VIDEOMODE', 'text')) {                               # textmode need more tabs, depends on add-on count
                 send_key_until_needlematch "addon-list-selected", 'tab';
             }
-            send_key "pgup",                                    1;
+            send_key "pgup";
+            wait_still_screen, 2;
             send_key_until_needlematch "addon-products-$addon", 'down';
             if ((split(/,/, get_var('ADDONS')))[-1] ne $addon) {                # if $addon is not first from all ADDONS
                 send_key 'alt-a';                                               # add another add-on
             }
-            else {
-                send_key 'alt-n';                                               # next
-            }
         }
     }
-    elsif (get_var("ADDONURL")) {
+    if (get_var("ADDONURL")) {
         if (match_has_tag('inst-addon')) {
             send_key 'alt-k';                                                   # install with addons
         }
@@ -82,24 +82,35 @@ sub run() {
             send_key 'alt-u';                                                   # select URL field
             type_string get_var("ADDONURL_$uc_addon");                          # repo URL
             send_key 'alt-n';
+            if (get_var("ADDONS")) {
+                if (get_var("BETA_$uc_addon")) {
+                    assert_screen "addon-betawarning-$addon";
+                    send_key "ret";
+                    assert_screen "addon-license-beta";
+                }
+                else {
+                    assert_screen "addon-license-$addon";
+                }
+                wait_still_screen, 2;
+                send_key 'alt-a';                                               # yes, agree
+                wait_still_screen, 2;
+                send_key 'alt-n';                                               # next
+            }
             assert_screen 'addon-products', 90;
             send_key "tab";                                                     # select addon-products-$addon
             if (check_var('VIDEOMODE', 'text')) {                               # textmode need more tabs, depends on add-on count
                 send_key_until_needlematch "addon-list-selected", 'tab';
             }
-            send_key "pgup",                                    1;
+            send_key "pgup";
+            wait_still_screen, 2;
             send_key_until_needlematch "addon-products-$addon", 'down';
             if ((split(/,/, get_var('ADDONURL')))[-1] ne $addon) {              # if $addon is not first from all ADDONS
                 send_key 'alt-a';                                               # add another add-on
             }
-            else {
-                send_key 'alt-n';                                               # next
-            }
         }
     }
-    else {
-        send_key 'alt-n', 3;                                                    # done
-    }
+    send_key 'alt-n';                                                           # next
+    wait_still_screen, 5;
 }
 
 1;


### PR DESCRIPTION
So far we could use either ADDONS variable or ADDONURL variable but not
together. Now is possible to combine those variables together: e.g. one
addon in ADDONS (i.e. installed from medium) and another one from
ADDONURL (i.e. installed from URI source).

I had to copy this chunk of code from ADDONS if-clause to ADDONURL
if-clause because when media and URI addon installations are combined
YaST presents License for addon installation from ADDONURL (which it did
not before):

```
if (get_var("ADDONS")) {
    if (get_var("BETA_$uc_addon")) {
        assert_screen "addon-betawarning-$addon";
        send_key "ret";
        assert_screen "addon-license-beta";
    }
    else {
        assert_screen "addon-license-$addon";
    }
    sleep 2;
    send_key 'alt-a';
    sleep 2;
    send_key 'alt-n';
}
```
Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/160.
Verification run: http://assam.suse.cz/tests/1666#step/addon_products_sle/25.