### PR TITLE
Enlightenment: close window using alt-f4

### DIFF
--- a/tests/x11/terminology.pm
+++ b/tests/x11/terminology.pm
@@ -19,7 +19,7 @@ sub run() {
     for (1 .. 13) { send_key "ret" }
     type_string "echo If you can see this text terminology is working.\n";
     assert_screen 'test-terminology-1';
-    send_key "ctrl-alt-x";    # This will need to be fixed - even Enlightenment should use alt-f4, boo#983953
+    send_key "alt-f4";
 }
 
 1;


### PR DESCRIPTION
boo#983953 has been fixed - and we have no product where we test Englightenment where this fix is not included (or should be, in case Leap will gain this test)

As such, it is safe to simply switch the keyboard shortcut to what was expected to be there from the beginning on.