### PR TITLE
Prevent check_screenlock waiting too long until screen is really locked

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -107,7 +107,7 @@ sub wait_boot {
             send_key "ret";
             assert_screen "grub2", 15;
         }
-        elsif (match_has_tag("migration-source-system-grub2")) {
+        elsif (match_has_tag("migration-source-system-grub2") or match_has_tag('grub2')) {
             send_key "ret";                                                      # boot to source system
         }
         elsif (get_var("LIVETEST")) {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -309,8 +309,12 @@ sub workaround_type_encrypted_passphrase {
 # if stay under tty console for long time, then check
 # screen lock is necessary when switch back to x11
 sub check_screenlock {
+    my ($tags) = @_;
+    $tags //= [qw/generic-desktop/];
     send_key "backspace";    # deactivate blanking
-    if (check_screen("screenlock")) {
+    push $tags, 'screenlock';
+    if (check_screen($tags)) {
+        return unless match_has_tag 'screenlock';
         if (check_var("DESKTOP", "gnome")) {
             send_key "esc";
             unless (get_var("LIVETEST")) {

--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -43,15 +43,6 @@ sub run() {
         select_console('x11');
         wait_still_screen(2);
         check_screenlock;
-
-        # workaround for bug 834165. Apper should not try to
-        # refresh repos when the console is not active:
-        if (get_var("DESKTOP", '') eq 'kde' && check_screen "apper-refresh-popup-bnc834165") {
-            record_soft_failure 'bsc#834165';
-            send_key 'alt-c';
-            sleep 30;
-        }
-        wait_idle;
         if (get_var("DESKTOP_MINIMALX_INSTONLY")) {
             # Desired wm was just installed and needs x11_login
             assert_screen 'displaymanager', 200;

--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -42,7 +42,7 @@ sub run() {
     if (!check_var("DESKTOP", "textmode")) {
         select_console('x11');
         wait_still_screen(2);
-        check_screenlock;
+        check_screenlock [qw/displaymanager generic-desktop/];
         if (get_var("DESKTOP_MINIMALX_INSTONLY")) {
             # Desired wm was just installed and needs x11_login
             assert_screen 'displaymanager', 200;


### PR DESCRIPTION
Fixes https://progress.opensuse.org/issues/12628

Output from local verification run:

* with unlocked screen:

```
16:49:10.2521 Debug: /var/lib/openqa/share/tests/opensuse/tests/console/consoletest_finish.pm:54 called utils::check_screenlock
16:49:10.2522 9119 <<< testapi::check_screen(mustmatch=[
  'displaymanager',
  'generic-desktop',
  'screenlock'
], timeout=30)
16:49:10.6960 9121 MATCH(consoletest_finish-gnome-TW-20151222:1.00)
16:49:11.3354 9119 >>> testapi::_check_backend_response: found consoletest_finish-gnome-TW-20151222, similarity 1.00 @ 0/0
```

* with locked screen:

```
16:25:59.8190 Debug: /var/lib/openqa/share/tests/opensuse/tests/console/consoletest_finish.pm:54 called utils::check_screenlock
16:25:59.8192 3991 <<< testapi::check_screen(mustmatch=[
  'displaymanager',
  'generic-desktop',
  'screenlock'
], timeout=30)
16:26:01.6312 3994 MATCH(screenlock-gnome-20160106:1.00)
16:26:02.9291 3991 >>> testapi::_check_backend_response: found screenlock-gnome-20160106, similarity 1.00 @ 503/320
16:26:02.9292 Debug: /var/lib/openqa/share/tests/opensuse/tests/console/consoletest_finish.pm:54 called utils::check_screenlock
16:26:02.9293 3991 <<< testapi::send_key(key='esc')
16:26:03.1305 Debug: /var/lib/openqa/share/tests/opensuse/tests/console/consoletest_finish.pm:54 called utils::check_screenlock
16:26:03.1306 3991 <<< testapi::send_key(key='ctrl')
16:26:03.3314 Debug: /var/lib/openqa/share/tests/opensuse/tests/console/consoletest_finish.pm:54 called utils::check_screenlock
16:26:03.3316 3991 <<< testapi::check_screen(mustmatch='gnome-screenlock-password', timeout=30)
...
```

Verification run: http://lord.arch/tests/2156