### PR TITLE
Explicitly install fips pattern and /etc/system-fips

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -924,18 +924,22 @@ elsif (get_var("SUPPORT_SERVER")) {
 elsif (get_var("FIPS_TS")) {
     if (check_var("FIPS_TS", "setup")) {
         prepare_target();
+        # Setup system into fips mode
+        loadtest "fips/fips_setup.pm";
+        # Turn off packagekit and etc
+        loadtest "console/consoletest_setup.pm";
     }
-    elsif (check_var("FIPS_TS", "core")) {
+    else {
         loadtest "boot/boot_to_desktop.pm";
-        load_fips_tests_core;
-    }
-    elsif (check_var("FIPS_TS", "web")) {
-        loadtest "boot/boot_to_desktop.pm";
-        load_fips_tests_web;
-    }
-    elsif (check_var("FIPS_TS", "misc")) {
-        loadtest "boot/boot_to_desktop.pm";
-        load_fips_tests_misc;
+        if (check_var("FIPS_TS", "core")) {
+            load_fips_tests_core;
+        }
+        elsif (check_var("FIPS_TS", "web")) {
+            load_fips_tests_web;
+        }
+        elsif (check_var("FIPS_TS", "misc")) {
+            load_fips_tests_misc;
+        }
     }
 }
 elsif (get_var("HACLUSTER_SUPPORT_SERVER")) {

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -1,0 +1,32 @@
+# SUSE's FIPS tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use testapi;
+use strict;
+
+# Install fips pattern and update grub.cfg to boot with fips=1
+sub run() {
+    select_console 'root-console';
+
+    if (!script_output "grep 'fips=1' /proc/cmdline | tee") {
+        script_run 'zypper -n install --type pattern fips', 300;
+        script_run 'sed -i \'/^GRUB_CMDLINE_LINUX_DEFAULT/s/\("\)$/ fips=1\1/\' /etc/default/grub';
+        script_run 'grub2-mkconfig -o /boot/grub2/grub.cfg';
+    }
+
+    # Workaround bsc#982268
+    if (!script_output "find /etc -type f -name system-fips") {
+        script_run 'touch /etc/system-fips';
+        record_soft_failure 'bsc#982268';
+    }
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
This is the workaround for issues bsc#985969 and bsc#982268

Due to bsc#985969, openQA fails to setup network interfaces at
the end of OS installation with variable FIPS=1. Workaround is
not perform installation with FIPS=1, but install fips pattern
later by zypper.

Due to bsc#982268, openssl couldn't enter fips mode even the
system is booted with fips=1. Workaround is create the file
/etc/system-fips manually.

This workround should be removed when the issues been fixed.