### PR TITLE
Fix the quoting in console tests

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -42,7 +42,7 @@ sub run() {
     # but for debugging, it's easier to check the serial file later
     my $str = "SSH-" . time;
     # login use new user account
-    script_run("ssh -v $ssh_testman\@localhost -t echo LOGIN_SUCCESSFUL; echo $str-$?- > /dev/$serialdev", 0);
+    script_run("ssh -v $ssh_testman\@localhost -t echo LOGIN_SUCCESSFUL; echo $str-\$?- > /dev/$serialdev", 0);
     assert_screen "ssh-login", 60;
     type_string "yes\n";
     assert_screen 'password-prompt';

--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -21,7 +21,7 @@ sub run() {
 
     assert_script_run "zypper -n in yast2-bootloader";    # make sure yast2 bootloader module installed
 
-    script_run("/sbin/yast2 bootloader; echo yast2-bootloader-status-$? > /dev/$serialdev", 0);
+    script_run("/sbin/yast2 bootloader; echo yast2-bootloader-status-\$? > /dev/$serialdev", 0);
     assert_screen "test-yast2_bootloader-1", 300;
     send_key "alt-o";                                     # OK => Close
     wait_serial("yast2-bootloader-status-0") || die "'yast2 bootloader' didn't finish";


### PR DESCRIPTION
Output the bash $? not the perl one