### PR TITLE
Confirm autoyast creation is removed from installation overview

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -641,6 +641,9 @@ sub load_extra_test () {
     if (!get_var("OFW") && !is_jeos()) {
         loadtest "console/aplay.pm";
     }
+    if (get_var("SP2ORLATER")) {
+        loadtest "console/autoyast_removed.pm";
+    }
     if (get_var("FILESYSTEM", "btrfs") eq "btrfs") {
         loadtest "console/btrfs_autocompletion.pm";
     }

--- a/tests/console/autoyast_removed.pm
+++ b/tests/console/autoyast_removed.pm
@@ -1,0 +1,21 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use strict;
+use testapi;
+
+# Check autoyast has been removed in SP2 (fate#317970)
+sub run() {
+    select_console("root-console");
+    assert_script_run("[ ! -f /root/autoinst.xml ]");
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -26,6 +26,20 @@ sub run() {
     # preserve it for the video
     wait_idle 10;
 
+    # Check autoyast has been removed in SP2 (fate#317970)
+    if (get_var("SP2ORLATER")) {
+        if (check_var('VIDEOMODE', 'text')) {
+            send_key 'alt-l';
+            send_key 'ret';
+            send_key 'tab';
+        }
+        else {
+            send_key_until_needlematch 'packages-section-selected', 'tab';
+        }
+        send_key 'end';
+        assert_screen 'autoyast_removed';
+    }
+
     # check for dependency issues, if found, drill down to software selection, take a screenshot, then die
     if (check_screen("inst-overview-dep-warning", 1)) {
         record_soft_failure 'dependency warning';


### PR DESCRIPTION
Resolves poo#11442
Depends on https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/166