### PR TITLE
Factory snapshot removed

### DIFF
--- a/tests/console/installation_snapshots.pm
+++ b/tests/console/installation_snapshots.pm
@@ -27,7 +27,7 @@ sub run() {
     my ($snapshot_name, $snapshot_type);
 
     if (is_jeos) {
-        $snapshot_name = 'Factory status';
+        $snapshot_name = 'Initial Status';
         $snapshot_type = 'single';
     }
     elsif (get_var('AUTOUPGRADE')) {


### PR DESCRIPTION
Behaviour changed in bsc#986589
Factory status was renamed to Intermediate status and is not used (not working yet). Important snapshot in JeOS is Initial status.