### PR TITLE
Fix change desktop with SYSTEM_ROLE

### DIFF
--- a/tests/installation/change_desktop.pm
+++ b/tests/installation/change_desktop.pm
@@ -60,20 +60,24 @@ sub change_desktop() {
         send_key_until_needlematch 'patterns-list-selected', 'tab', 10;
     }
 
-    if (!check_var('DESKTOP', 'gnome')) {
-        send_key_until_needlematch 'gnome-selected', 'down', 10;
-        wait_screen_change { send_key ' '; };
+    if (get_var('SYSTEM_ROLE')) {
+        assert_screen "desktop-unselected";
     }
-    if (check_var('DESKTOP', 'kde')) {
-        send_key_until_needlematch 'kde-unselected', 'down', 10;
-        wait_screen_change { send_key ' '; };
+    else {
+        if (!check_var('DESKTOP', 'gnome')) {
+            send_key_until_needlematch 'gnome-selected', 'down', 10;
+            wait_screen_change { send_key ' '; };
+        }
+        if (check_var('DESKTOP', 'kde')) {
+            send_key_until_needlematch 'kde-unselected', 'down', 10;
+            wait_screen_change { send_key ' '; };
+        }
+        if (check_var('DESKTOP', 'textmode')) {
+            send_key_until_needlematch 'x11-selected', 'down', 10;
+            wait_screen_change { send_key ' '; };
+        }
+        assert_screen "desktop-selected";
     }
-    if (check_var('DESKTOP', 'textmode')) {
-        send_key_until_needlematch 'x11-selected', 'down', 10;
-        wait_screen_change { send_key ' '; };
-    }
-
-    assert_screen "desktop-selected";
 
     if (check_var('VIDEOMODE', 'text')) {
         send_key 'alt-a';    # accept


### PR DESCRIPTION
SYSTEM_ROLE uses KVM Virtualication Host role, which will unselect all desktop enviroment and by default gnome was expected to be selected so test with SYSTEM_ROLE failed e.g. https://openqa.suse.de/tests/471354#step/change_desktop/20