### PR TITLE
Make loadavg log readable in browser

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -36,7 +36,7 @@ sub export_logs {
     select_console 'root-console';
     save_screenshot;
 
-    save_and_upload_log('cat /proc/loadavg', '/tmp/loadavg',     {screenshot => 1});
+    save_and_upload_log('cat /proc/loadavg', '/tmp/loadavg.txt', {screenshot => 1});
     save_and_upload_log('journalctl -b',     '/tmp/journal.log', {screenshot => 1});
     save_and_upload_log('ps axf',            '/tmp/psaxf.log',   {screenshot => 1});
 

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -68,7 +68,7 @@ sub run() {
     type_string "chown $username /dev/$serialdev\n";
     # Export the existing status of running tasks and system load for future reference (fail would export it again)
     script_run "ps axf > /tmp/psaxf.log";
-    script_run "cat /proc/loadavg > /tmp/loadavg_consoletest_setup";
+    script_run "cat /proc/loadavg > /tmp/loadavg_consoletest_setup.txt";
 
     # openSUSE 13.2's (and earlier) systemd has broken rules for virtio-net, not applying predictable names (despite being configured)
     # A maintenance update breaking networking names sounds worse than just accepting that 13.2 -> TW breaks
@@ -94,7 +94,7 @@ sub run() {
 
     # upload_logs requires curl, but we wanted the initial state of the system
     upload_logs "/tmp/psaxf.log";
-    upload_logs "/tmp/loadavg_consoletest_setup";
+    upload_logs "/tmp/loadavg_consoletest_setup.txt";
     save_screenshot;
 
     $self->clear_and_verify_console;


### PR DESCRIPTION
Prevents browsers trying to offer "loadavg" as binary file.