### PR TITLE
bootloader_s390: Always show debug regardless of result

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -172,9 +172,9 @@ EO_frickin_boot_parms
 }
 
 sub show_debug() {
-    script_run "ps auxf";
+    type_string "ps auxf\n";
     save_screenshot;
-    script_run "dmesg";
+    type_string "dmesg\n";
     save_screenshot;
 }
 
@@ -193,13 +193,15 @@ sub format_dasd() {
 
     # make sure that there is a dasda device
     $r = script_run("lsdasd");
-    show_debug() and die "dasd_configure died with exit code $r" unless ($r && $r == 1);
-
     assert_screen("ensure-dasd-exists");
+    # always calling debug output, trying to help with poo#12596
+    show_debug();
+    die "dasd_configure died with exit code $r" unless (defined($r) && $r == 0);
 
     # format dasda (this can take up to 20 minutes depending on disk size)
     $r = script_run("echo yes | dasdfmt -b 4096 -p /dev/dasda", 1200);
-    show_debug() and die "dasdfmt died with exit code $r" unless ($r && $r == 1);
+    show_debug();
+    die "dasdfmt died with exit code $r" unless (defined($r) && $r == 0);
 }
 
 sub run() {


### PR DESCRIPTION
This allows easier comparison of "good" and "bad" state. Also changing
"script_run" within show_debug() to type_string to not rely on a potentially
broken serial port which we want to debug.

The assumption about return code of script_run was wrong. Of course it does
return the exit code of the executed script, not a perl true/false value.