### PR TITLE
Add rails test

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -490,6 +490,7 @@ sub load_extra_tests() {
         loadtest "console/openvswitch.pm";
         loadtest "console/rabbitmq.pm";
         loadtest "console/salt.pm";
+        loadtest "console/rails.pm";
 
         # finished console test and back to desktop
         loadtest "console/consoletest_finish.pm";

--- a/tests/console/rails.pm
+++ b/tests/console/rails.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use strict;
+use base "consoletest";
+use testapi;
+
+sub run() {
+    select_console 'root-console';
+    my $cmd = <<'EOF';
+zypper -n in -C "rubygem(rails)"
+rails new -B mycoolapp
+cd mycoolapp
+(rails server &)
+for i in {1..100} ; do sleep 0.1; curl -s http://localhost:3000 | grep "Welcome" && break ; done
+kill %1'
+EOF
+    assert_script_run($_) foreach (split /\n/, $cmd);
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
As coolo wrote, 'nough said. Had it make it work though, his IRC notes
had syntax errors ;-)

Fails with

```
# Could not find gem 'web-console (~> 2.0)' in any of the gem sources listed in your Gemfile or available on this machine.
Run `bundle install` to install missing gems.
```
on my local Tumbleweed. That's what you wanted, right?