### PR TITLE
Fix remote installation mutex issue

### DIFF
--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -55,10 +55,7 @@ sub run() {
         last;
     }
 
-    if (get_var("REMOTE_MASTER")) {
-        mutex_create("installation_finished");
-    }
-    else {
+    if (!get_var("REMOTE_MASTER")) {
         send_key 'alt-s';        # Stop the reboot countdown
         select_console 'install-shell';
         $self->get_ip_address();

--- a/tests/remote/remote_master.pm
+++ b/tests/remote/remote_master.pm
@@ -14,6 +14,7 @@ use utils;
 use mm_network;
 use lockapi;
 
+# poo#9576
 sub run() {
     my $slave_ip;
 

--- a/tests/remote/remote_slave.pm
+++ b/tests/remote/remote_slave.pm
@@ -13,15 +13,14 @@ use testapi;
 use lockapi;
 use mmapi;
 
+# poo#9576
 sub run() {
-    # there is only one child
-    my $children = get_children();
-    my $child_id = (keys %$children)[0];
-
+    # Notice MASTER system is ready for installation
     assert_screen "remote_slave_ready", 200;
-
     mutex_create "installation_ready";
-    mutex_lock('installation_finished', $child_id);
+
+    # Wait until MASTER finishes installing the system
+    wait_for_children;
 }
 
 sub test_flags {


### PR DESCRIPTION
Fixes problem where child creates lock and exit before parent has a change to process it:
  cause_of_death='mutex lock 'installation_finished': lock owner already finished'
Local runs:
  http://dhcp91.suse.cz/tests/overview?distri=sle&version=12-SP2&build=1988&groupid=3