### PR TITLE
Use reboot instead of systemctl reboot

### DIFF
--- a/tests/online_migration/sle12_online_migration/post_migration.pm
+++ b/tests/online_migration/sle12_online_migration/post_migration.pm
@@ -22,7 +22,15 @@ sub run() {
     save_screenshot;
 
     # reboot into upgraded system after online migration
-    script_run("systemctl reboot", 0);
+    if (check_var("FLAVOR", "Desktop-DVD")) {
+        record_soft_failure 'bsc#989696: [online migration] systemctl reboot hangs after migration from sled12 to sled12sp2';
+        script_run("reboot", 0);
+    }
+    else {
+        script_run("systemctl reboot", 0);
+    }
+    save_screenshot;
+
     if (get_var("DESKTOP") =~ /textmode|minimalx/) {
         wait_boot textmode => 1;
     }


### PR DESCRIPTION
System sometimes hangs at reboot after migration by using command 'systemctl reboot', like following:
https://openqa.suse.de/tests/478407#step/consoletest_setup/24
or
http://147.2.207.208/tests/1509/modules/post_migration/steps/5

Simply replace to command 'reboot' to solve it:
http://147.2.207.208/tests/1510/modules/post_migration/steps/6