### PR TITLE
Fix autoyast removed test

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -32,11 +32,8 @@ sub run() {
             send_key 'alt-l';
             send_key 'ret';
             send_key 'tab';
+            send_key 'end';
         }
-        else {
-            send_key_until_needlematch 'packages-section-selected', 'tab';
-        }
-        send_key 'end';
         assert_screen 'autoyast_removed';
     }
 


### PR DESCRIPTION
Requires: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/167
Local runs:
gnome: http://dhcp91.suse.cz/tests/1729#step/installation_overview/2
migration: http://dhcp91.suse.cz/tests/1727#step/installation_overview/2
textmode: http://dhcp91.suse.cz/tests/1730#step/installation_overview/2