### PR TITLE
Add test flow covering automatic update of YaST installer

### DIFF
--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -254,6 +254,11 @@ sub run() {
         $args .= " withiscsi=1";
     }
 
+    if (check_var("INSTALLER_NO_SELF_UPDATE", 1)) {
+        diag "Disabling installer self update as requested by INSTALLER_NO_SELF_UPDATE=1";
+        $args .= "self_update=0";
+    }
+
     type_string_very_slow $args;
     save_screenshot;
 

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -75,6 +75,11 @@ sub prepare_parmfile() {
     # create a too long parameter ;(
     $params .= " install=ftp://openqa/" . get_var('REPO_0') . " ";
 
+    if (check_var("INSTALLER_NO_SELF_UPDATE", 1)) {
+        diag "Disabling installer self update as requested by INSTALLER_NO_SELF_UPDATE=1";
+        $params .= "self_update=0";
+    }
+
     return split_lines($params);
 }
 

--- a/tests/installation/skip_registration.pm
+++ b/tests/installation/skip_registration.pm
@@ -23,6 +23,9 @@ use utils qw/ensure_fullscreen/;
 sub run() {
     assert_screen([qw/scc-registration yast2-windowborder-corner/], 100);
     if (match_has_tag('yast2-windowborder-corner')) {
+        if (check_var("INSTALLER_NO_SELF_UPDATE", 1)) {
+            die "installer should not self-update, therefore window should not have respawned, file bug and replace this line by record_soft_failure";
+        }
         ensure_fullscreen(tag => 'yast2-windowborder-corner');
         assert_screen('scc-registration', 100);
     }


### PR DESCRIPTION
Using the bootloader parameter 'self_update=[0|1]' now both paths are covered.
'self_update=1' has been the default since automatic self updating of the
installer was introduced.

New variable:
* INSTALLER_NO_SELF_UPDATE: Set to 1 to test with disabled self-updating of
  the installer

Default bootloader implementation as well as bootloader_s390 has been adapted
to add the parameter based on the value of INSTALLER_NO_SELF_UPDATE. There are
actually many bootloader test module implementations. I decided for the
default one as well as s390 where we discovered issues when the self-updating
was first hitting tests, see f6d0515 for details. Setting bootloader
parameters should be extracted to reduced duplicated content.

Verification test runs:
* INSTALLER_NO_SELF_UPDATE=1: http://lord.arch/tests/1944, showing line
  'Disabling installer self update as requested ...' in logs
* INSTALLER_NO_SELF_UPDATE=0: http://lord.arch/tests/1943, as in before, no
  difference seen