### PR TITLE
sssd: Ensure psmisc is also installed in textmode installs

### DIFF
--- a/tests/sysauth/sssd.pm
+++ b/tests/sysauth/sssd.pm
@@ -25,6 +25,9 @@ sub run() {
       krb5 krb5-client krb5-server krb5-plugin-kdb-ldap
       /;
     script_run "systemctl stop packagekit.service; systemctl mask packagekit.service";
+    if (check_var('DESKTOP', 'textmode')) {    # sssd test suite depends on killall, which is part of psmisc (enhanced_base pattern)
+        assert_script_run "zypper -n in psmisc";
+    }
     script_run "zypper -n refresh && zypper -n in @test_subjects";
     wait_idle;
 


### PR DESCRIPTION

The absence of psmisc is responsible for the failures seen in sysauth/sssd since we moved the test to be textmode based

https://openqa.opensuse.org/tests/225367#step/sssd/29

(cleanup of the previous test run failed, sssd was not terminated)