### PR TITLE
command-not-found: Explicitly select user-console

### DIFF
--- a/tests/console/command_not_found.pm
+++ b/tests/console/command_not_found.pm
@@ -14,7 +14,8 @@ use strict;
 
 # test for regression of bug http://bugzilla.suse.com/show_bug.cgi?id=952496
 sub run() {
-    # permissions don't matter
+    # select user-console; for one we want to be sure cnf works for a user, 2nd assert_script_run does not work in root-console
+    select_console 'user-console';
 
     if (check_var('DESKTOP', 'textmode')) {    # command-not-found is part of the enhanced_base pattern, missing in textmode
         assert_script_sudo "zypper -n in command-not-found";


### PR DESCRIPTION
The usage of assert_script_sudo does not reliably work on root-console (yet)
as there is no password prompt.
By switching to the user-console first we no longer depend on where the
previous test left us and can in plus be sure to test command-not-found as user