### PR TITLE
Fix issue: VM has no IP address with DROP_PERSISTENT_NET_RULES

### DIFF
--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -22,7 +22,7 @@ sub run {
 
     select_console('root-console');
     if (get_var('DROP_PERSISTENT_NET_RULES')) {
-        type_string "rm -f /etc/udev/rules.d/70-persistent-net.rules /etc/sysconfig/network/ifcfg-eth*\n";
+        type_string "rm -f /etc/udev/rules.d/70-persistent-net.rules\n";
     }
 
     type_string "poweroff\n";


### PR DESCRIPTION
If VM boots from an existing HDD image, sometimes the network is
unavailable because eth0 is renamed to eth1 during system boot.

With variable DROP_PERSISTENT_NET_RULES, the issue can be fixed
by removing /etc/udev/rules.d/70-persistent-net.rules. But a new
issue is introduced that eth0 couldn't get IP address since file
/etc/sysconfig/network/ifcfg-eth0 is also removed in the existing
code.

Keep ifcfg-eth0 configuration file which is required by Wicked.