### PR TITLE
fips_setup: drop workaround of issue bsc#982268

### DIFF
--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -20,12 +20,6 @@ sub run() {
         script_run 'sed -i \'/^GRUB_CMDLINE_LINUX_DEFAULT/s/\("\)$/ fips=1\1/\' /etc/default/grub';
         script_run 'grub2-mkconfig -o /boot/grub2/grub.cfg';
     }
-
-    # Workaround bsc#982268
-    if (!script_output "find /etc -type f -name system-fips") {
-        script_run 'touch /etc/system-fips';
-        record_soft_failure 'bsc#982268';
-    }
 }
 
 sub test_flags() {


### PR DESCRIPTION
The issue has been fixed since SLES12-SP2 Beta5. And the
file /etc/system-fips isn't required any more to setup
openssl library into the FIPS mode.