### PR TITLE
memtest: Add support for shim import on UEFI setup

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -25,12 +25,12 @@ sub run() {
         sleep 60;
         return;
     }
-    check_screen([qw/bootloader-shim-import-prompt bootloader-grub2/], 15);
+    assert_screen([qw/bootloader-shim-import-prompt bootloader-grub2/], 15);
     if (match_has_tag("bootloader-shim-import-prompt")) {
         send_key "down";
         send_key "ret";
+        assert_screen "bootloader-grub2", 15;
     }
-    assert_screen "bootloader-grub2", 15;
     if (get_var("QEMUVGA") && get_var("QEMUVGA") ne "cirrus") {
         sleep 5;
     }

--- a/tests/installation/memtest.pm
+++ b/tests/installation/memtest.pm
@@ -15,6 +15,11 @@ use testapi;
 sub run {
     my $self = shift;
 
+    assert_screen([qw/inst-bootmenu bootloader-shim-import-prompt/], 15);
+    if (match_has_tag("bootloader-shim-import-prompt")) {
+        send_key "down";
+        send_key "ret";
+    }
     $self->select_bootmenu_option('inst-onmemtest', 1);
     assert_screen "pass-complete", 700;
     send_key "esc";


### PR DESCRIPTION
Verification run: http://lord.arch/tests/1951 (success blocked by bsc#989859)