### PR TITLE
Add entry for case upgrade_glib2_pango32bit

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -710,6 +710,11 @@ elsif (get_var("SLEPOS")) {
 elsif (get_var("ONLINE_MIGRATION")) {
     load_online_migration_tests();
 }
+elsif (get_var("UPGRADE_PANGO")) {
+    loadtest "boot/boot_to_desktop.pm";
+    loadtest "offline_migration/upgrade_glib2_pango32bit.pm";
+    loadtest "shutdown/shutdown.pm";
+}
 else {
     load_boot_tests();
     if (get_var("PROXY")) {


### PR DESCRIPTION
Testing Result:

- upgrade package: http://147.2.212.239/tests/707
- offline migration using the new SLED11 image : http://147.2.212.239/tests/682

Entry for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/1547
Migration from SLED11SP4 to SLED12SP2 is failed since libpango
dependency problem, the fix of this bug has been released to MU.
This script will update the package and create a new SLED11 image
for openQA's offline_migration test.

See also: bsc#978972