### PR TITLE
susedistribution: Fix loading within consoletests from qemu snapshots

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -373,20 +373,17 @@ sub activate_console {
             $nr = 5 if ($name eq 'log');
             # we need to wait more than five seconds here to pass the idle timeout in
             # case the system is still booting (https://bugzilla.novell.com/show_bug.cgi?id=895602)
-            assert_screen "tty$nr-selected", 60;
-
-            assert_screen "text-login";
-            type_string "$user\n";
-            if (!get_var("LIVETEST")) {
-                assert_screen "password-prompt";
-                type_password;
-                send_key('ret');
+            assert_screen(["tty$nr-selected", "text-logged-in-$user", "text-login"], 60);
+            if (match_has_tag("tty$nr-selected") or match_has_tag("text-login")) {
+                type_string "$user\n";
+                if (!get_var("LIVETEST")) {
+                    assert_screen "password-prompt";
+                    type_password;
+                    send_key('ret');
+                }
             }
         }
-        # check if $user is not logged in try to login two times
-        if (!check_screen("text-logged-in-$user")) {
-            send_key_until_needlematch "text-logged-in-$user", "ret", 2, 5;
-        }
+        assert_screen "text-logged-in-$user";
         $self->set_standard_prompt($user);
         # Disable console screensaver
         $self->script_run("setterm -blank 0");


### PR DESCRIPTION
Add back what was working before we reworked the console handling.

There should not be a check_screen with no alternative so I am removing the
check for a second return to be pressed in case a user is not logged in.
This is just a waste of time and should not be necessary at all.

Now checking for already logged in shell, i.e. starting with the single '$' as
prompt. Needs updated needles.

Local verification done in the two cases of loading from snapshot when the
session is already logged in as well as when booting a clean machine where the
login is still necessary.

Verification screenshot in case of continue from snapshot:
![openqa_continue_from_snapshot](https://cloud.githubusercontent.com/assets/1693432/17026641/0d93eb8a-4f61-11e6-8d54-7c61d982f6a6.png)
The test module continues successfully and fails later for different reason

Related progress issue: https://progress.opensuse.org/issues/10484
