### PR TITLE
Wait longer for win10 desktop at first boot

### DIFF
--- a/tests/installation/win10_installation.pm
+++ b/tests/installation/win10_installation.pm
@@ -64,7 +64,7 @@ sub run() {
     type_string 'security';
     wait_still_screen;
     send_key 'alt-n';                                                              # next
-    assert_screen 'desktop-at-first-boot', 400;
+    assert_screen 'desktop-at-first-boot', 600;
     send_key 'super';                                                              # windows menu
     wait_still_screen;
     send_key 'up';


### PR DESCRIPTION
timeout 400 is too less
https://openqa.opensuse.org/tests/227211