### PR TITLE
Fix mediacheck and rescuesystem with shim import

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -25,6 +25,7 @@ our @EXPORT = qw/
   check_screenlock
   sle_version_at_least
   ensure_fullscreen
+  ensure_shim_import
   /;
 
 
@@ -364,6 +365,16 @@ sub ensure_fullscreen {
         assert_screen($args{tag});
         my $console = select_console("installation");
         $console->fullscreen({window_name => 'YaST2*'});
+    }
+}
+
+sub ensure_shim_import {
+    my (%args) = @_;
+    $args{tags} //= [qw/inst-bootmenu bootloader-shim-import-prompt/];
+    assert_screen($args{tags}, 15);
+    if (match_has_tag("bootloader-shim-import-prompt")) {
+        send_key "down";
+        send_key "ret";
     }
 }
 

--- a/tests/installation/mediacheck.pm
+++ b/tests/installation/mediacheck.pm
@@ -11,10 +11,12 @@
 use base "opensusebasetest";
 use strict;
 use testapi;
+use utils qw/ensure_shim_import/;
 
 sub run {
     my $self = shift;
 
+    ensure_shim_import;
     $self->select_bootmenu_option('inst-onmediacheck', 1);
 
     # the timeout is insane - but SLE11 DVDs take almost forever

--- a/tests/installation/mediacheck.pm
+++ b/tests/installation/mediacheck.pm
@@ -18,8 +18,11 @@ sub run {
     $self->select_bootmenu_option('inst-onmediacheck', 1);
 
     # the timeout is insane - but SLE11 DVDs take almost forever
-    assert_screen "mediacheck-ok", 3600;
+    assert_screen [qw/mediacheck-ok mediacheck-checksum-wrong/], 3600;
     send_key "ret";
+    if (match_has_tag('mediacheck-checksum-wrong')) {
+        die "Checksum reported as wrong";
+    }
 }
 
 sub test_flags() {

--- a/tests/installation/memtest.pm
+++ b/tests/installation/memtest.pm
@@ -11,15 +11,12 @@
 use base "opensusebasetest";
 use strict;
 use testapi;
+use utils qw/ensure_shim_import/;
 
 sub run {
     my $self = shift;
 
-    assert_screen([qw/inst-bootmenu bootloader-shim-import-prompt/], 15);
-    if (match_has_tag("bootloader-shim-import-prompt")) {
-        send_key "down";
-        send_key "ret";
-    }
+    ensure_shim_import;
     $self->select_bootmenu_option('inst-onmemtest', 1);
     assert_screen "pass-complete", 700;
     send_key "esc";

--- a/tests/installation/rescuesystem.pm
+++ b/tests/installation/rescuesystem.pm
@@ -11,10 +11,12 @@
 use base "opensusebasetest";
 use strict;
 use testapi;
+use utils qw/ensure_shim_import/;
 
 sub run {
     my $self = shift;
 
+    ensure_shim_import;
     $self->select_bootmenu_option('inst-rescuesystem', 1);
 
     if (check_screen "keyboardmap-list", 100) {


### PR DESCRIPTION
Should fix Leap42.2 mediacheck and rescuesystem tests.

Needs needles:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/88

Verification run: http://lord.arch/tests/1988