### PR TITLE
virtualization: fix installation failure for sles12sp1 in Nuremberg

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -14,7 +14,7 @@ use base "opensusebasetest";
 use testapi;
 
 sub run() {
-    check_screen("virttest-bootloader", 60);
+    assert_screen([qw/virttest-bootloader qa-net-selection/], 300);
     my $image_path = "";
 
     #detect pxe location
@@ -31,12 +31,8 @@ sub run() {
 
         $image_path = get_var("HOST_IMG_URL");
     }
-    else {
+    elsif (match_has_tag("qa-net-selection")) {
         #Numburg
-        if (!match_has_tag("qa-net-selection")) {
-            assert_screen "qa-net-selection", 240;
-        }
-
         #send_key_until_needlematch "qa-net-selection-" . get_var('DISTRI') . "-" . get_var("VERSION"), 'down', 30, 3;
         #Don't use send_key_until_needlematch to pick first menu tier as dist network sources might not be ready when openQA is running tests
         send_key 'esc';

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -27,7 +27,7 @@ sub run() {
     wait_idle 10;
 
     # Check autoyast has been removed in SP2 (fate#317970)
-    if (get_var("SP2ORLATER")) {
+    if (get_var("SP2ORLATER") && !check_var("INSTALL_TO_OTHERS", 1)) {
         if (check_var('VIDEOMODE', 'text')) {
             send_key 'alt-l';
             send_key 'ret';


### PR DESCRIPTION
Fix failure for installing sles12sp1 product in sles12sp2 daily test:L
1) timeout is scaled 3 times when check_screen, so decrease timeout
2) the sles12sp2 related fates testing during installation should be disabled for tests with "INSTALL_TO_OTHERS" setting to 1.