### PR TITLE
Workaround: Pass kexec=1 to installer until boo#990374 is fixed

### DIFF
--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -149,6 +149,11 @@ sub run() {
         #type_string "ZYPP_MULTICURL=0 "; sleep 2;
     }
 
+    if (check_var("FLAVOR", "NET")) {
+        type_string_slow " kexec=1";
+        record_soft_failure "boo#990374 - pass kexec to installer to use initrd from FTP";
+    }
+
     # set language last so that above typing will not depend on keyboard layout
     if (get_var("INSTLANG")) {
 


### PR DESCRIPTION

This should help around cases like https://openqa.opensuse.org/tests/227377#step/welcome/6 until the full fix can be implemented

USers getting the NET installer and right away installing it, are not affected by the issue (the net installer is formally only valid for the same repo version)