### PR TITLE
Pick the right vmlinux and don't run on aarch64

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -486,7 +486,10 @@ sub load_extra_tests() {
         # finished console test and back to desktop
         loadtest "console/consoletest_finish.pm";
 
-        loadtest "toolchain/crash.pm";
+        # kdump is not supported on aarch64, see BSC#990418
+        if (!check_var('ARCH', 'aarch64')) {
+            loadtest "toolchain/crash.pm";
+        }
 
         return 1;
     }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1130,7 +1130,10 @@ if (get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1")) {
 }
 
 if (get_var("TCM") || check_var("ADDONS", "tcm")) {
-    loadtest "toolchain/crash.pm";
+    # kdump is not supported on aarch64, see BSC#990418
+    if (!check_var('ARCH', 'aarch64')) {
+        loadtest "toolchain/crash.pm";
+    }
     loadtest "toolchain/install.pm";
     loadtest "toolchain/gcc5_fortran_compilation.pm";
     loadtest "toolchain/gcc5_C_compilation.pm";

--- a/tests/toolchain/crash.pm
+++ b/tests/toolchain/crash.pm
@@ -67,7 +67,8 @@ sub run() {
     wait_boot;
     select_console 'root-console';
 
-    my $crash_cmd = 'echo exit | crash `ls -1t /var/crash/*/vmcore | head -n1` /boot/vmlinux-`uname -r`.gz';
+    my $suffix = check_var('ARCH', 'ppc64le') ? '' : '.gz';
+    my $crash_cmd = 'echo exit | crash `ls -1t /var/crash/*/vmcore | head -n1` /boot/vmlinux-`uname -r`' . $suffix;
     assert_script_run "$crash_cmd";
     validate_script_output "$crash_cmd", sub { m/PANIC/ };
 }


### PR DESCRIPTION
kdump on aarch64 is not supported, so the test should not be run there,
see BSC#990418.

On ppc64le there's no /boot/vmlinux-###.gz file, we need to stick to
/boot/vmlinux-###.