### PR TITLE
Simplify pkcon retry to not retry on success

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -128,11 +128,12 @@ sub ensure_installed {
     testapi::assert_script_sudo("chown $testapi::username /dev/$testapi::serialdev");
     my $retries = 5;    # arbitrary
     $self->script_run("for i in {1..$retries} ; do pkcon install @pkglist && break ; done ; RET=\$?; echo \"\n  pkcon finished\n\"; echo \"pkcon-\${RET}-\" > /dev/$testapi::serialdev", 0);
-    my @tags = qw/Policykit Policykit-behind-window pkcon-proceed-prompt/;
+    my @tags = qw/Policykit Policykit-behind-window pkcon-proceed-prompt pkcon-finished/;
     while (1) {
         last unless @tags;
         my $ret = check_screen(\@tags, $timeout);
         last unless $ret;
+        last if (match_has_tag('pkcon-finished'));
         if (match_has_tag('Policykit')) {
             type_password;
             send_key("ret", 1);

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -127,34 +127,31 @@ sub ensure_installed {
     assert_screen('xterm-started');
     testapi::assert_script_sudo("chown $testapi::username /dev/$testapi::serialdev");
     my $retries = 5;    # arbitrary
-  RETRY: for (1 .. $retries) {
-        $self->script_run("pkcon install @pkglist; RET=\$?; echo \"\n  pkcon finished\n\"; echo \"pkcon-\${RET}-\" > /dev/$testapi::serialdev", 0);
-        my @tags = qw/Policykit Policykit-behind-window pkcon-proceed-prompt/;
-        while (1) {
-            last unless @tags;
-            my $ret = check_screen(\@tags, $timeout);
-            last RETRY unless $ret;
-            if (match_has_tag('Policykit')) {
-                type_password;
-                send_key("ret", 1);
-                @tags = grep { $_ ne 'Policykit' } @tags;
-                @tags = grep { $_ ne 'Policykit-behind-window' } @tags;
-                next;
-            }
-            if (match_has_tag('Policykit-behind-window')) {
-                send_key("alt-tab");
-                sleep 3;
-                next;
-            }
-            if (match_has_tag('pkcon-proceed-prompt')) {
-                send_key("y");
-                send_key("ret");
-                @tags = grep { $_ ne 'pkcon-proceed-prompt' } @tags;
-                next;
-            }
+    $self->script_run("for i in {1..$retries} ; do pkcon install @pkglist && break ; done ; RET=\$?; echo \"\n  pkcon finished\n\"; echo \"pkcon-\${RET}-\" > /dev/$testapi::serialdev", 0);
+    my @tags = qw/Policykit Policykit-behind-window pkcon-proceed-prompt/;
+    while (1) {
+        last unless @tags;
+        my $ret = check_screen(\@tags, $timeout);
+        last unless $ret;
+        if (match_has_tag('Policykit')) {
+            type_password;
+            send_key("ret", 1);
+            @tags = grep { $_ ne 'Policykit' } @tags;
+            @tags = grep { $_ ne 'Policykit-behind-window' } @tags;
+            next;
+        }
+        if (match_has_tag('Policykit-behind-window')) {
+            send_key("alt-tab");
+            sleep 3;
+            next;
+        }
+        if (match_has_tag('pkcon-proceed-prompt')) {
+            send_key("y");
+            send_key("ret");
+            @tags = grep { $_ ne 'pkcon-proceed-prompt' } @tags;
+            next;
         }
     }
-
     wait_serial('pkcon-0-', 27) || die "pkcon install did not succeed";
     send_key("alt-f4");    # close xterm
 }


### PR DESCRIPTION
Retrying in an outside perl for-loop nested with while is complicated and I
failed because it would actually not abort after success but continue trying
to install 5 times which is not causing anything to fail but a waste of time
and annoying. Using a simple for loop within bash should be much simpler to
grasp and works with early abort :-)

Verification run: http://lord.arch/tests/2097