### PR TITLE
Add new test suite apache2-mod_perl

### DIFF
--- a/tests/qa_automation/userspace_apache2_mod_perl.pm
+++ b/tests/qa_automation/userspace_apache2_mod_perl.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "qa_run";
+use strict;
+use testapi;
+
+sub test_run_list() {
+    return qw(_reboot_off apache2-mod_perl);
+}
+
+sub test_suite() {
+    return 'regression';
+}
+
+sub junit_type() {
+    return 'user_regression';
+}
+
+1;
+


### PR DESCRIPTION
Hi, I'd like to add a new apache2 testsuite, which Nathan updated yesterday, into openQA test. This test was removed because of some sub testcases keep failed.