### PR TITLE
Add test for fate#317701 - Do not use perl-bootloader in yast2-bootloader

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -585,6 +585,10 @@ sub load_consoletests() {
             loadtest "console/syslinux.pm";
         }
         loadtest "console/mtab.pm";
+
+        if (sle_version_at_least('12-SP2')) {
+            loadtest "console/no_perl_bootloader.pm";
+        }
         if (!get_var("NOINSTALL") && !is_desktop && (check_var("DESKTOP", "textmode"))) {
             if (!is_staging() && check_var('BACKEND', 'qemu')) {
                 # The NFS test expects the IP to be 10.0.2.15

--- a/tests/console/no_perl_bootloader.pm
+++ b/tests/console/no_perl_bootloader.pm
@@ -1,0 +1,22 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use strict;
+use testapi;
+
+# Check that there is no perl-Bootloader component in installed system
+# (fate#317701)
+sub run() {
+    select_console('user-console');
+    assert_script_run('! rpm -qi perl-Bootloader-YAML');
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
On SLE 12-SP2 or greater check that no perl-Bootloader-YAML is present in the
installed system as described as a test case in fate#317701.

Locally verified on TW where it fails because perl-Bootloader-YAML is present.

Related progress issue: https://progress.opensuse.org/issues/11436