### PR TITLE
virtualization initial xen support

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -990,8 +990,12 @@ elsif (get_var("VIRT_AUTOTEST")) {
     load_boot_tests();
     load_inst_tests();
     loadtest "virt_autotest/login_console.pm";
+    if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
+        loadtest "virt_autotest/setup_console_on_host.pm";
+        loadtest "virt_autotest/reboot_and_wait_up_normal1.pm";
+    }
     loadtest "virt_autotest/install_package.pm";
-    loadtest "virt_autotest/reboot_and_wait_up_normal1.pm";
+    loadtest "virt_autotest/reboot_and_wait_up_normal2.pm";
 
     if (get_var("VIRT_PRJ1_GUEST_INSTALL")) {
         loadtest "virt_autotest/guest_installation_run.pm";
@@ -1000,6 +1004,10 @@ elsif (get_var("VIRT_AUTOTEST")) {
         loadtest "virt_autotest/host_upgrade_generate_run_file.pm";
         loadtest "virt_autotest/host_upgrade_step2_run.pm";
         loadtest "virt_autotest/reboot_and_wait_up_upgrade.pm";
+        if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
+            loadtest "virt_autotest/setup_console_on_host.pm";
+            loadtest "virt_autotest/reboot_and_wait_up_normal3.pm";
+        }
         loadtest "virt_autotest/host_upgrade_step3_run.pm";
     }
 }

--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -12,6 +12,7 @@ use warnings;
 use File::Basename;
 use base "virt_autotest_base";
 use testapi;
+use virt_utils;
 
 sub install_package() {
     my $qa_server_repo = get_var('QA_HEAD_REPO', '');
@@ -52,23 +53,6 @@ sub update_package() {
 }
 
 
-sub generate_grub() {
-    if (get_var("XEN")) {
-        assert_script_run("if ! grep -q \"GRUB_CMDLINE_XEN_DEFAULT=.*console=com1 com1=115200\" /etc/default/grub;then sed -ri 's/\(GRUB_CMDLINE_XEN_DEFAULT=.*\)\"/\\1 console=com1 com1=115200\"/' /etc/default/grub ; fi");
-
-    }
-    else {
-        assert_script_run("if ! grep -q \"GRUB_CMDLINE_LINUX_DEFAULT=.*console=ttyS1,115200.*console=tty\" /etc/default/grub;then sed -ri 's/\(GRUB_CMDLINE_LINUX_DEFAULT=.*\)\"/\\1 console=ttyS1,115200 console=tty\"/' /etc/default/grub ; fi");
-    }
-
-    upload_logs("/etc/default/grub");
-
-    my $gen_grub_cmd = "grub2-mkconfig -o /boot/grub2/grub.cfg";
-
-    assert_script_run($gen_grub_cmd, 40);
-}
-
-
 sub run() {
     my $self = shift;
 
@@ -76,7 +60,7 @@ sub run() {
 
     $self->update_package();
 
-    generate_grub;
+    setup_console_in_grub;
 }
 
 

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -13,6 +13,7 @@ use warnings;
 use File::Basename;
 use base "opensusebasetest";
 use testapi;
+use virt_utils;
 
 sub login_to_console() {
     my $timeout = shift;
@@ -25,12 +26,18 @@ sub login_to_console() {
             send_key 'ret';
         }
     }
+    else {
+        set_var("reboot_for_upgrade_step", undef);
+    }
+
     assert_screen(["displaymanager", "virttest-displaymanager"], $timeout);
+
     select_console('root-console');
 }
 
 sub run() {
     login_to_console;
+    set_serialdev;
 }
 
 sub test_flags {

--- a/tests/virt_autotest/reboot_and_wait_up_normal2.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_normal2.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+use strict;
+use warnings;
+use File::Basename;
+use testapi;
+use base "reboot_and_wait_up";
+
+sub run() {
+    my $self    = shift;
+    my $timeout = 300;
+    $self->reboot_and_wait_up($timeout);
+}
+
+sub test_flags {
+    return {important => 1};
+}
+
+1;
+

--- a/tests/virt_autotest/reboot_and_wait_up_normal3.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_normal3.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+use strict;
+use warnings;
+use File::Basename;
+use testapi;
+use base "reboot_and_wait_up";
+
+sub run() {
+    my $self    = shift;
+    my $timeout = 300;
+    $self->reboot_and_wait_up($timeout);
+}
+
+sub test_flags {
+    return {important => 1};
+}
+
+1;
+

--- a/tests/virt_autotest/setup_console_on_host.pm
+++ b/tests/virt_autotest/setup_console_on_host.pm
@@ -1,0 +1,18 @@
+package setup_console_on_host;
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use virt_utils;
+
+sub run() {
+    set_serialdev;
+    setup_console_in_grub;
+}
+
+sub test_flags {
+    return {important => 1};
+}
+
+1;
+

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -18,22 +18,47 @@ use Data::Dumper;
 use XML::Writer;
 use IO::File;
 
-our @EXPORT = qw(set_serialdev);
+our @EXPORT = qw(set_serialdev setup_console_in_grub);
 
 sub set_serialdev() {
     if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
-        my $hostReleaseInfo = script_output("cat /etc/SuSE-release");
-        if ($hostReleaseInfo =~ /VERSION = 12\nPATCHLEVEL = 2\n/m) {
+        type_string("clear\n");
+        type_string("cat /etc/SuSE-release \n");
+        save_screenshot;
+        assert_screen([qw/on_host_sles_12_sp2_or_above on_host_lower_than_sles_12_sp2/], 5);
+        if (match_has_tag("on_host_sles_12_sp2_or_above")) {
             $serialdev = "hvc0";
         }
-        else {
+        elsif (match_has_tag("on_host_lower_than_sles_12_sp2")) {
             $serialdev = "xvc0";
         }
     }
     else {
         $serialdev = "ttyS1";
     }
-    script_run("echo \"Debug info: serial dev is set to $serialdev.\"", 0);
+    type_string("echo \"Debug info: serial dev is set to $serialdev.\"\n");
+}
+
+sub setup_console_in_grub() {
+    #only support grub2
+    my $grub_default_file = "/etc/default/grub";
+    my $grub_cfg_file     = "/boot/grub2/grub.cfg";
+
+    my $cmd = "if [ -d /boot/grub2 ]; then cp $grub_default_file ${grub_default_file}.org; sed -ri '/GRUB_CMDLINE_(LINUX|XEN_DEFAULT)=/ {s/(console|com\\d+)=[^\\s\"]*//g; /LINUX=/s/\"\$/ console=$serialdev console=tty\"/;/XEN_DEFAULT=/ s/\"\$/ console=com2,115200\"/;}' $grub_default_file ; fi";
+    type_string("$cmd \n");
+    wait_idle 3;
+    save_screenshot;
+    type_string("clear; cat $grub_default_file \n");
+    wait_idle 3;
+    save_screenshot;
+
+    $cmd = "if [ -d /boot/grub2 ]; then grub2-mkconfig -o $grub_cfg_file; fi";
+    type_string("$cmd \n", 40);
+    wait_idle 3;
+    save_screenshot;
+    type_string("clear; cat $grub_cfg_file \n");
+    wait_idle 3;
+    save_screenshot;
 }
 
 1;


### PR DESCRIPTION
Support xen on host sles12sp1 and sles12sp2.

Solution:
Change serialdev of os-autoinst according to host product, which check via needle (because serial not work now)
Change grub file to set up correct serial console accordingly, hvc0 for sles12sp2 and xvc0 for sles12sp1, and use com2 for hypervisor.
Then reboot machine to take effect.