### PR TITLE
toolchain: Configuring and compiling can take way longer

### DIFF
--- a/tests/toolchain/gcc5_C_compilation.pm
+++ b/tests/toolchain/gcc5_C_compilation.pm
@@ -19,9 +19,9 @@ sub run() {
     script_run "wget $package";
     script_run 'tar jxf ltp-full-20150420.tar.bz2';
     script_run 'cd ltp-full-20150420';
-    assert_script_run './configure --with-open-posix-testsuite|tee /tmp/configure.log', 100;
-    assert_script_run 'make all|tee /tmp/make_all.log',                                 800;
-    assert_script_run 'make install|tee /tmp/make_install.log',                         400;
+    assert_script_run './configure --with-open-posix-testsuite|tee /tmp/configure.log', 600;
+    assert_script_run 'make all|tee /tmp/make_all.log',                                 3600;
+    assert_script_run 'make install|tee /tmp/make_install.log',                         600;
     script_run 'cd /opt/ltp/';
     assert_script_run './runltp -f syscalls|tee /tmp/runltp.log', 2000;
     script_run 'cat output/*.failed';    # print what tests failed

--- a/tests/toolchain/gcc5_Cpp_compilation.pm
+++ b/tests/toolchain/gcc5_Cpp_compilation.pm
@@ -24,7 +24,7 @@ sub run() {
     script_run 'mkdir llvm-3.6.2.src/tools/clang';
     script_run 'mv cfe-3.6.2.src/* llvm-3.6.2.src/tools/clang/';
     script_run 'cd llvm-3.6.2.src';
-    assert_script_run './configure --disable-bindings|tee /tmp/configure.log', 100;
+    assert_script_run './configure --disable-bindings|tee /tmp/configure.log', 600;
     assert_script_run 'make -j$(getconf _NPROCESSORS_ONLN)|tee /tmp/make.log', 4000;
     script_run 'cd tools/clang';
     assert_script_run 'make test|tee /tmp/make_test.log', 500;


### PR DESCRIPTION
Should fix issues as in
https://openqa.suse.de/tests/487089

In general configuring and compiling time scales a lot with performance of the
underlying platform. The test is mainly not about performance and openQA is
not well suited to test this so the timeout values should be way less
restrictive and only a last resort. For the sake of simplicity the same robust
value is used independant of architecture or platform as we don't really have
reliable performance figures which are only architecture but not worker
specific.

Related progress issue: https://progress.opensuse.org/issues/12896