### PR TITLE
Get CPU and RAM information

### DIFF
--- a/tests/toolchain/install.pm
+++ b/tests/toolchain/install.pm
@@ -38,6 +38,9 @@ sub run() {
     }
     script_run 'export CC=/usr/bin/gcc-5';
     script_run 'export CXX=/usr/bin/g++-5';
+    script_run 'lscpu';
+    script_run 'free -m';
+    save_screenshot;
 }
 
 sub test_flags() {


### PR DESCRIPTION
Toolchain test have been made (timeouts) for 4 CPUs and 4096 RAM on x86_64, can be different on another architectures, this information can be important