### PR TITLE
Enable Y2DEBUG and fix behaviors for zypper migration

### DIFF
--- a/tests/online_migration/sle12_online_migration/online_migration_setup.pm
+++ b/tests/online_migration/sle12_online_migration/online_migration_setup.pm
@@ -29,6 +29,11 @@ sub run() {
     script_run "systemctl stop packagekit.service";
 
     type_string "chown $username /dev/$serialdev\n";
+
+    # enable Y2DEBUG all time
+    type_string "echo 'export Y2DEBUG=1' >> /etc/profile\n";
+    script_run "source /etc/profile";
+
     save_screenshot;
 }
 

--- a/tests/online_migration/sle12_online_migration/zypper_migration.pm
+++ b/tests/online_migration/sle12_online_migration/zypper_migration.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-use base "consoletest";
+use base "installbasetest";
 use strict;
 use testapi;
 
@@ -23,12 +23,14 @@ sub run() {
     my $zypper_migration_error        = qr/^Abort, retry, ignore\? \[a/m;
     my $zypper_migration_fileconflict = qr/^File conflicts .*^Continue\? \[y/ms;
     my $zypper_migration_done         = qr/^Executing.*after online migration|^ZYPPER-DONE/m;
+    my $zypper_migration_notification = qr/^View the notifications now\? \[y/m;
+    my $zypper_migration_failed       = qr/^Migration failed/m;
 
     # start migration
     script_run("(zypper migration;echo ZYPPER-DONE) | tee /dev/$serialdev", 0);
     # migration process take long time
     my $timeout          = 3000;
-    my $migration_checks = [$zypper_migration_target, $zypper_disable_repos, $zypper_continue, $zypper_migration_done, $zypper_migration_error, $zypper_migration_conflict, $zypper_migration_fileconflict];
+    my $migration_checks = [$zypper_migration_target, $zypper_disable_repos, $zypper_continue, $zypper_migration_done, $zypper_migration_error, $zypper_migration_conflict, $zypper_migration_fileconflict, $zypper_migration_notification, $zypper_migration_failed];
     my $out              = wait_serial($migration_checks, $timeout);
     while ($out) {
         if ($out =~ $zypper_migration_target) {
@@ -39,13 +41,17 @@ sub run() {
             send_key "y";
             send_key "ret";
         }
-        elsif ($out =~ $zypper_migration_error || $out =~ $zypper_migration_conflict || $out =~ $zypper_migration_fileconflict) {
+        elsif ($out =~ $zypper_migration_error || $out =~ $zypper_migration_conflict || $out =~ $zypper_migration_fileconflict || $out =~ $zypper_migration_failed) {
             $self->result('fail');
             save_screenshot;
             return;
         }
         elsif ($out =~ $zypper_continue) {
             send_key "y";
+            send_key "ret";
+        }
+        elsif ($out =~ $zypper_migration_notification) {
+            send_key "n";    #do not view package update notification by default
             send_key "ret";
         }
         elsif ($out =~ $zypper_migration_done) {


### PR DESCRIPTION
Set Y2DEBUG=1 for better debugging requested by bsc#989489
https://openqa.suse.de/tests/487120#step/yast2_migration/39

Fix package update notification viewing:
https://openqa.suse.de/tests/485212#step/zypper_migration/5
Verified test:
http://147.2.207.208/tests/1559/modules/zypper_migration/steps/11