### PR TITLE
Prevent 'consoletest_setup' to show up double

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -165,11 +165,6 @@ sub console_is_applicable() {
     return !any_desktop_is_applicable();
 }
 
-sub extratest_is_applicable() {
-    # pre-conditions for extra tests ie. the tests are running based on preinstalled image
-    return !get_var("INSTALLONLY") && !get_var("DUALBOOT") && !get_var("RESCUECD");
-}
-
 sub need_clear_repos() {
     return is_staging();
 }
@@ -457,7 +452,9 @@ sub load_yast2_gui_tests() {
 
 sub load_extra_tests() {
 
-    return unless extratest_is_applicable();
+    return unless get_var('EXTRATEST') || get_var('Y2UITEST');
+    # pre-conditions for extra tests ie. the tests are running based on preinstalled image
+    return if get_var("INSTALLONLY") || get_var("DUALBOOT") || get_var("RESCUECD");
 
     # setup $serialdev permission and so on
     loadtest "console/consoletest_setup.pm";


### PR DESCRIPTION
Observed for example in https://openqa.opensuse.org/tests/230362

consoletest_setup is scheduled twice which does not harm as only one instance
will be scheduled but it is polluting the schedule and prevents me from doing
an upcoming addition to os-autoinst to support scheduling the same module
multiple times.

Verified locally by calling isotovideo on different variations of vars.json,
e.g. with EXTRATEST=0/1, Y2UITEST=0/1