### PR TITLE
Workaround for bsc#990254 on suse.com network issues

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -27,6 +27,7 @@ our @EXPORT = qw/
   ensure_fullscreen
   ensure_shim_import
   reboot_gnome
+  assert_screen_with_soft_timeout
   /;
 
 
@@ -401,6 +402,37 @@ sub reboot_gnome {
         send_key "ret";
     }
     workaround_type_encrypted_passphrase;
+}
+
+=head2 assert_screen_with_soft_timeout
+
+  assert_screen_with_soft_timeout($mustmatch [,timeout => $timeout] [, bugref => $bugref] [,soft_timeout => $soft_timeout] [,soft_failure_reason => $soft_failure_reason]);
+
+Extending assert_screen with a soft timeout. When C<$soft_timeout> is hit, a
+soft failure is recorded with the message C<$soft_failure_reason> but
+assert_screen continues until the (hard) timeout C<$timeout> is hit. This
+makes sense when an assert screen should find a screen within a lower time but
+still should not fail and continue until the hard timeout, e.g. to discover
+performance issues.
+
+Example:
+
+  assert_screen_with_soft_timeout('registration-found', timeout => 300, soft_timeout => 60, bugref => 'bsc#123456');
+
+=cut
+sub assert_screen_with_soft_timeout {
+    my ($mustmatch, %args) = @_;
+    # as in assert_screen
+    $args{timeout}             //= 30;
+    $args{soft_timeout}        //= 0;
+    $args{soft_failure_reason} //= "$args{bugref}: needle(s) $mustmatch not found within $args{soft_timeout}";
+    if ($args{soft_timeout}) {
+        die "soft timeout has to be smaller than timeout" unless ($args{soft_timeout} < $args{timeout});
+        my $ret = check_screen $mustmatch, $args{soft_timeout};
+        return $ret if $ret;
+        record_soft_failure "$args{soft_failure_reason}";
+    }
+    return assert_screen $mustmatch, $args{timeout} - $args{soft_timeout};
 }
 
 1;

--- a/tests/installation/scc_registration.pm
+++ b/tests/installation/scc_registration.pm
@@ -18,10 +18,11 @@ use base "y2logsstep";
 
 use testapi;
 use registration;
+use utils qw/assert_screen_with_soft_timeout/;
 
 sub run() {
     if (!get_var("HDD_SCC_REGISTERED")) {
-        assert_screen("scc-registration", 100);
+        assert_screen_with_soft_timeout('scc-registration', timeout => 300, soft_timeout => 100, bugref => 'bsc#990254');
     }
     fill_in_registration_data;
 }

--- a/tests/installation/skip_registration.pm
+++ b/tests/installation/skip_registration.pm
@@ -18,16 +18,16 @@ use base "y2logsstep";
 
 use testapi;
 use registration;
-use utils qw/ensure_fullscreen/;
+use utils qw/ensure_fullscreen assert_screen_with_soft_timeout/;
 
 sub run() {
-    assert_screen([qw/scc-registration yast2-windowborder-corner/], 100);
+    assert_screen_with_soft_timeout([qw/scc-registration yast2-windowborder-corner/], timeout => 300, soft_timeout => 100, bugref => 'bsc#990254');
     if (match_has_tag('yast2-windowborder-corner')) {
         if (check_var("INSTALLER_NO_SELF_UPDATE", 1)) {
             die "installer should not self-update, therefore window should not have respawned, file bug and replace this line by record_soft_failure";
         }
         ensure_fullscreen(tag => 'yast2-windowborder-corner');
-        assert_screen('scc-registration', 100);
+        assert_screen_with_soft_timeout('scc-registration', timeout => 300, soft_timeout => 100, bugref => 'bsc#990254');
     }
     send_key "alt-s", 1;    # skip SCC registration
     if (check_screen("scc-skip-reg-warning", 10)) {


### PR DESCRIPTION
Wait longer in case of initial network access does not return within original
timeout but fail hard if it still does not work after 300 seconds.

Verification run: http://lord.arch/tests/2157