### PR TITLE
Fix condition to load thunderbird test

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -616,7 +616,7 @@ sub load_x11tests() {
     if (bigx11step_is_applicable()) {
         loadtest "x11/firefox_stress.pm";
     }
-    if (gnomestep_is_applicable() && !get_var("LIVECD") || !is_server) {
+    if (gnomestep_is_applicable() && !(get_var("LIVECD") || is_server)) {
         loadtest "x11/thunderbird.pm";
     }
     if (get_var("MOZILLATEST")) {


### PR DESCRIPTION
That should help not loading the thunderbird test on the rescue CD for example.

there, LIVECD is set to 1, but is_server is not true.. so the original condition was obviously not meant to be like that