### PR TITLE
Fix new BETA filter checkbox

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -84,6 +84,9 @@ sub fill_in_registration_data {
         if (check_screen("local-registration-servers", 10)) {
             send_key $cmd{ok};
         }
+        if (check_screen('scc-beta-filter-checkbox', 5)) {
+            send_key 'alt-f';    # uncheck 'Filter Out Beta Version'
+        }
         # The value of SCC_ADDONS is a list of abbreviation of addons/modules
         # Following are abbreviations defined for modules and some addons
         #


### PR DESCRIPTION
BETA addons are not shown due to filter https://openqa.suse.de/tests/490860#step/scc_registration/7

http://10.100.98.90/tests/2717#step/scc_registration/6