### PR TITLE
Add simple machinery test thanks to greygoo

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -495,6 +495,7 @@ sub load_extra_tests() {
         loadtest "console/rabbitmq.pm";
         loadtest "console/salt.pm";
         loadtest "console/rails.pm";
+        loadtest "console/machinery.pm";
 
         # finished console test and back to desktop
         loadtest "console/consoletest_finish.pm";

--- a/tests/console/machinery.pm
+++ b/tests/console/machinery.pm
@@ -1,0 +1,21 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use strict;
+use testapi;
+
+sub run() {
+    select_console 'root-console';
+    assert_script_run 'yes | OneClickInstallCLI http://machinery-project.org/machinery.ymp', 200;
+    validate_script_output "machinery --help", sub { m/machinery - A systems management toolkit for Linux/ }, 100;
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Obsoletes https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/1059
brought up to current state of tests.