### PR TITLE
Fix Y2DEBUG enabled in terminal

### DIFF
--- a/tests/online_migration/sle12_online_migration/online_migration_setup.pm
+++ b/tests/online_migration/sle12_online_migration/online_migration_setup.pm
@@ -26,8 +26,8 @@ sub run() {
     type_string "chown $username /dev/$serialdev\n";
 
     # enable Y2DEBUG all time
-    type_string "echo 'export Y2DEBUG=1' >> /etc/profile\n";
-    script_run "source /etc/profile";
+    type_string "echo 'export Y2DEBUG=1' >> /etc/bash.bashrc.local\n";
+    script_run "source /etc/bash.bashrc.local";
 
     save_screenshot;
 }


### PR DESCRIPTION
/etc/profile is invoked only for login shells,
new sourced command in profile won't be effective
in a new opened terminal(such like xterm) unless
start it as a login shell.
Also the changes in /etc/profile will be lost
during system upgrade, use /etc/bash.bashrc.local
to instead of it.
verified result:
http://147.2.207.208/tests/1562/modules/yast2_migration/steps/10