### PR TITLE
machinery: Ensure OneClickInstallCLI is installed

### DIFF
--- a/tests/console/machinery.pm
+++ b/tests/console/machinery.pm
@@ -13,8 +13,9 @@ use testapi;
 
 sub run() {
     select_console 'root-console';
+    assert_script_run 'which OneClickInstallCLI || zypper -n in yast2-metapackage-handler',  200;
     assert_script_run 'yes | OneClickInstallCLI http://machinery-project.org/machinery.ymp', 200;
-    validate_script_output "machinery --help", sub { m/machinery - A systems management toolkit for Linux/ }, 100;
+    validate_script_output 'machinery --help',                                               sub { m/machinery - A systems management toolkit for Linux/ }, 100;
 }
 
 1;


### PR DESCRIPTION
Fixes problems as observed in
https://openqa.opensuse.org/tests/232806#step/machinery/3

Verified locally.