### PR TITLE
Add activate existing encrypted volume 

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -375,7 +375,7 @@ sub load_inst_tests() {
         }
     }
     if (get_var('ENCRYPT_CANCEL_EXISTING') || get_var('ENCRYPT_ACTIVATE_EXISTING')) {
-	loadtest "installation/encrypted_volume_activation.pm";
+        loadtest "installation/encrypted_volume_activation.pm";
     }
     if (get_var('MULTIPATH')) {
         loadtest "installation/multipath.pm";
@@ -444,6 +444,9 @@ sub load_inst_tests() {
             if (check_var("SLES4SAP_MODE", 'sles')) {
                 loadtest "installation/user_settings.pm";
             }    # sles4sap wizard installation doesn't have user_settings step
+        }
+        elsif (get_var('IMPORT_USER_DATA')) {
+            loadtest 'installation/user_import.pm';
         }
         else {
             loadtest "installation/user_settings.pm";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -374,6 +374,9 @@ sub load_inst_tests() {
             loadtest "installation/skip_disk_activation.pm";
         }
     }
+    if (get_var('ENCRYPT_CANCEL_EXISTING') || get_var('ENCRYPT_ACTIVATE_EXISTING')) {
+	loadtest "installation/encrypted_volume_activation.pm";
+    }
     if (get_var('MULTIPATH')) {
         loadtest "installation/multipath.pm";
     }

--- a/tests/installation/encrypted_volume_activation.pm
+++ b/tests/installation/encrypted_volume_activation.pm
@@ -1,27 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
 use base "basetest";
 use strict;
 use testapi;
 
+my $after_cancel_tags = [
+    qw/
+      encrypted_volume_activation_prompt enable-multipath scc-registration
+      /
+];
+
 sub run {
     assert_screen 'encrypted_volume_activation_prompt';
     if (get_var('ENCRYPT_CANCEL_EXISTING')) {
-	send_key 'alt-c', 5;
-	if (check_screen('encrypted_volume_activation_prompt')) {
-	    record_soft_failure 'bsc#989770';
-	    send_key 'alt-c';
-	}
-    } elsif (get_var('ENCRYPT_ACTIVATE_EXISTING')) {
-	send_key 'alt-p';
-	assert_screen 'encrypted_volume_password_prompt', 10;
-	type_password;
-	send_key 'ret';
+        send_key 'alt-c';
+        assert_screen($after_cancel_tags);
+        if (match_has_tag('encrypted_volume_activation_prompt')) {
+            record_soft_failure 'bsc#989770';
+            send_key 'alt-c';
+        }
     }
-}
-
-sub test_flags {
-    return {
-	fatal => 1
-    };
+    elsif (get_var('ENCRYPT_ACTIVATE_EXISTING')) {
+        send_key 'alt-p';
+        assert_screen 'encrypted_volume_password_prompt';
+        type_password;
+        send_key 'ret';
+    }
 }
 
 1;

--- a/tests/installation/encrypted_volume_activation.pm
+++ b/tests/installation/encrypted_volume_activation.pm
@@ -1,0 +1,27 @@
+use base "basetest";
+use strict;
+use testapi;
+
+sub run {
+    assert_screen 'encrypted_volume_activation_prompt';
+    if (get_var('ENCRYPT_CANCEL_EXISTING')) {
+	send_key 'alt-c', 5;
+	if (check_screen('encrypted_volume_activation_prompt')) {
+	    record_soft_failure 'bsc#989770';
+	    send_key 'alt-c';
+	}
+    } elsif (get_var('ENCRYPT_ACTIVATE_EXISTING')) {
+	send_key 'alt-p';
+	assert_screen 'encrypted_volume_password_prompt', 10;
+	type_password;
+	send_key 'ret';
+    }
+}
+
+sub test_flags {
+    return {
+	fatal => 1
+    };
+}
+
+1;

--- a/tests/installation/user_import.pm
+++ b/tests/installation/user_import.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use strict;
+use warnings;
+use base "y2logsstep";
+use testapi;
+
+sub run() {
+    my $self = shift;
+
+    assert_screen 'import-user-data';
+    send_key 'alt-i';
+    send_key 'alt-e';
+    assert_screen 'import-user-data-selection';
+    send_key 'alt-a';
+    assert_screen 'import-user-data-selected-user';
+    send_key $cmd{ok};
+
+    send_key $cmd{next};
+}
+
+1;


### PR DESCRIPTION
When the variable ENCRYPTED_CANCEL_EXISTING is set, it will cancel the
activate encrypted volume prompt which appears during installation to a
storage device with existing encrypted lvm volume. A workaround is
implemented for bsc#989770 which causes the activation prompt to be
displayed twice.

When the variable ENCRYPTED_ACTIVATE_EXISTING is set it will enter the
password for the existing volume to activate it.