### PR TITLE
[qa_automation] Fix userspace_apache2_mod_perl.pm

### DIFF
--- a/tests/qa_automation/userspace_apache2_mod_perl.pm
+++ b/tests/qa_automation/userspace_apache2_mod_perl.pm
@@ -13,7 +13,7 @@ use strict;
 use testapi;
 
 sub test_run_list() {
-    return qw(_reboot_off apache2-mod_perl);
+    return qw(_reboot_off apache2_mod_perl);
 }
 
 sub test_suite() {


### PR DESCRIPTION
Since the automation framework doesn't support "-" inside testsuite names, apache2-mod_perl has been renamed to apache2_mod_perl.