### PR TITLE
Fix typo skenkins

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -819,7 +819,7 @@ sub load_applicationstests {
     return 1;
 }
 
-sub load_skenkins_tests {
+sub load_slenkins_tests {
     if (get_var("SLENKINS_CONTROL")) {
         unless (get_var("SUPPORT_SERVER")) {
             loadtest "slenkins/login.pm";
@@ -865,7 +865,7 @@ elsif (get_var("SUPPORT_SERVER")) {
     loadtest "support_server/boot.pm";
     loadtest "support_server/login.pm";
     loadtest "support_server/setup.pm";
-    unless (load_skenkins_tests()) {    # either run the slenkins control node or just wait for connections
+    unless (load_slenkins_tests()) {    # either run the slenkins control node or just wait for connections
         loadtest "support_server/wait.pm";
     }
 }
@@ -929,7 +929,7 @@ else {
         || load_applicationstests()
         || load_extra_tests()
         || load_otherDE_tests()
-        || load_skenkins_tests())
+        || load_slenkins_tests())
     {
         load_rescuecd_tests();
         load_consoletests();


### PR DESCRIPTION
We run SLEnkins on o.s.d but not on o3 so what is the point.