### PR TITLE
On minimal installations installing glibc-32bit

### DIFF
--- a/tests/console/glibc_i686.pm
+++ b/tests/console/glibc_i686.pm
@@ -16,7 +16,7 @@ use strict;
 sub run() {
     select_console 'root-console';
 
-    assert_script_run("zypper -n in -C libc.so.6", 100);
+    assert_script_run("zypper -n in -C libc.so.6", 500);
 
     # select user console for our needles to match
     select_console 'user-console';


### PR DESCRIPTION
can take longer than 100s, see
https://openqa.suse.de/tests/496796#step/glibc_i686/1