### PR TITLE
Do not schedule hostname_inst on REMOTE_CONTROLLER

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -436,7 +436,7 @@ sub load_inst_tests() {
         loadtest "installation/installer_timezone.pm";
         # the test should run only in scenarios, where installed
         # system is not being tested (e.g. INSTALLONLY etc.)
-        if (!consolestep_is_applicable()) {
+        if (!consolestep_is_applicable() and !get_var("REMOTE_CONTROLLER")) {
             loadtest "installation/hostname_inst.pm";
         }
         if (!get_var("REMOTE_CONTROLLER")) {


### PR DESCRIPTION
https://openqa.suse.de/tests/498044

`hostname_inst` test can't be run on REMOTE_CONTROLLER as it's just a
controller for "slave" VNC session, not the target system. On the
"slave" it's not applicable as well (it's not being executed there
anyway).