### PR TITLE
Set EXPECTED_INSTALL_HOSTNAME var on s390x backend

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -251,6 +251,10 @@ sub init_consoles {
             set_var("S390_NETWORK_PARAMS", $s390_params);
 
             ($hostname) = $s390_params =~ /Hostname=(\S+)/;
+
+            # extract hostname from a FQDN and export it as a variable
+            my ($expected_install_hostname) = $hostname =~ /(.+?)(?=\.)/;
+            set_var("EXPECTED_INSTALL_HOSTNAME", $expected_install_hostname);
         }
 
         if (check_var("VIDEOMODE", "text")) {    # adds console for text-based installation on s390x


### PR DESCRIPTION
With s390x backend hostname in installer and otherwise is set by
S390_NETWORK_PARAMS variable. For hostname_inst test we need
EXPECTED_INSTALL_HOSTNAME variable set to actual hostname. This
change sets EXPECTED_INSTALL_HOSTNAME variable to hostname from of
S390_NETWORK_PARAMS.

/usr/share/openqa/script/clone_job.pl --from http://openqa.suse.de
--host localhost 490017 EXTRABOOTPARAMS="ifcfg=10.0.2.99/24"
INSTALLONLY=1 S390_ZKVM=1 S390_NETWORK_PARAMS='OSAHWAddr= OSAMedium=eth
InstNetDev=osa OSAInterface=qdio HostIP=10.161.155.@S390_HOST@/20
Hostname=s390vsl@S390_HOST@.suse.de Portname=VSWNL2
Gateway=10.161.159.254 Nameserver=10.160.0.1 Domain=suse.de PortNo=0
Layer2=1 ReadChannel=0.0.0800 WriteChannel=0.0.0801
DataChannel=0.0.0802' S390_HOST=666

Verification run with slightly modified code:
http://assam.suse.cz/tests/2319/file/vars.json.

See the EXPECTED_INSTALL_HOSTNAME var.