### PR TITLE
Use the provided FQDN (hostname)

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -252,9 +252,7 @@ sub init_consoles {
 
             ($hostname) = $s390_params =~ /Hostname=(\S+)/;
 
-            # extract hostname from a FQDN and export it as a variable
-            my ($expected_install_hostname) = $hostname =~ /(.+?)(?=\.)/;
-            set_var("EXPECTED_INSTALL_HOSTNAME", $expected_install_hostname);
+            set_var("EXPECTED_INSTALL_HOSTNAME", $hostname);
         }
 
         if (check_var("VIDEOMODE", "text")) {    # adds console for text-based installation on s390x


### PR DESCRIPTION
On s390x backend hostname is set in FQDN form (e.g. s390x.suse.de) and
we have to stick with it as it's what `hostname` returns (i.e. not just
the 's390x' part).

http://assam.suse.cz/tests/2321/file/vars.json:
```
   "EXPECTED_INSTALL_HOSTNAME" : "s390vsl666.suse.de",
   "S390_HOST" : "666",
   "S390_NETWORK_PARAMS" : "... Hostname=s390vsl666.suse.de ...",
```