### PR TITLE
virtualization: fix test prj2_host_upgrade_sles12sp1_to_sles12sp2_kvm failure when check result.

### DIFF
--- a/tests/virt_autotest/host_upgrade_step1_run.pm
+++ b/tests/virt_autotest/host_upgrade_step1_run.pm
@@ -22,7 +22,7 @@ sub get_script_run() {
 
 sub run() {
     my $self = shift;
-    $self->run_test(5400, "Test run completed successfully", "no", "yes", "/var/log/qa/ctcs2/", "host-upgrade-updateVirtRpms");
+    $self->run_test(5400, "Test run completed successfully", "no", "yes", "/var/log/qa/", "host-upgrade-updateVirtRpms");
 }
 1;
 

--- a/tests/virt_autotest/host_upgrade_step2_run.pm
+++ b/tests/virt_autotest/host_upgrade_step2_run.pm
@@ -23,7 +23,7 @@ sub get_script_run() {
 
 sub run() {
     my $self = shift;
-    $self->run_test(36000, "Host upgrade to .* is done. Need to reboot system", "no", "yes", "/var/log/qa/ctcs2/", "host-upgrade-prepAndUpgrade");
+    $self->run_test(36000, "Host upgrade to .* is done. Need to reboot system", "no", "yes", "/var/log/qa/", "host-upgrade-prepAndUpgrade");
 }
 
 1;

--- a/tests/virt_autotest/host_upgrade_step3_run.pm
+++ b/tests/virt_autotest/host_upgrade_step3_run.pm
@@ -22,7 +22,7 @@ sub get_script_run() {
 
 sub run() {
     my $self = shift;
-    $self->run_test(5400, "Test run completed successfully", "no", "yes", "/var/log/qa/ctcs2/", "host-upgrade-postVerify-logs");
+    $self->run_test(5400, "Test run completed successfully", "no", "yes", "/var/log/qa/", "host-upgrade-postVerify-logs");
 }
 
 1;


### PR DESCRIPTION
root cause: when ctcs2 log is successfully uploaded, contents under /var/log/qa/ctcs2 will be moved to /var/log/qa/oldlogs/, so grep patterns in that directory will fail.