### PR TITLE
Fix lightdm check: hide the mouse after coming back to desktop

### DIFF
--- a/tests/x11/xfce_lightdm_logout_login.pm
+++ b/tests/x11/xfce_lightdm_logout_login.pm
@@ -14,19 +14,19 @@ use testapi;
 
 # log out, check lightdm-gtk-greeter and log in again
 
-# this part contains the steps to run this test
 sub run() {
     my $self = shift;
     x11_start_program("xfce4-session-logout");
     send_key "alt-l";
     assert_screen 'test-xfce_lightdm_logout_login-1', 13;
-    mouse_hide();
     type_password;
     send_key "ret";
+    assert_screen 'generic-desktop';
+    mouse_hide;
 }
 
 sub test_flags() {
-    return {important => 1};
+    return {important => 1, milestone => 1};
 }
 
 1;


### PR DESCRIPTION
Fixes https://openqa.opensuse.org/tests/236012#step/inkscape/1