### PR TITLE
Fix o.s.d issue - Maintenance job group

### DIFF
--- a/tests/x11regressions/gnomecase/application_starts_on_login.pm
+++ b/tests/x11regressions/gnomecase/application_starts_on_login.pm
@@ -116,6 +116,11 @@ sub run() {
     logout_and_login;
     assert_screen "firefox-gnome", 90;
     send_key "alt-f4";
+    wait_still_screen;
+    if (check_screen("firefox-gnome")) {
+        send_key "alt-f4";
+    }
+    assert_screen "generic-desktop";
 
     #remove firefox from startup application
     tweak_startupapp_menu;
@@ -143,6 +148,10 @@ sub run() {
     logout_and_login;
     assert_screen "firefox-gnome", 90;
     send_key "alt-f4";
+    wait_still_screen;
+    if (check_screen("firefox-gnome")) {
+        send_key "alt-f4";
+    }
 
     if (get_var("SP2ORLATER")) {
         restore_status_auto_save_session;


### PR DESCRIPTION
Firefox doesn't want to close in application_starts_on_login -  add check point
https://openqa.suse.de/tests/497657#step/application_starts_on_login/49