### PR TITLE
Give yast2_lan more time to install SUSEfirewall2

### DIFF
--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -44,7 +44,7 @@ sub run() {
     }
     if (match_has_tag('install-susefirewall2')) {
         send_key "alt-i";                               # install SuSEfirewall2
-        assert_screen "yast2_lan", 30;                  # check yast2_lan again after SuSEfirewall2 installed
+        assert_screen "yast2_lan", 90;                  # check yast2_lan again after SuSEfirewall2 installed
     }
 
     my $hostname = "susetest";


### PR DESCRIPTION
https://openqa.opensuse.org/tests/236831#step/yast2_lan/15 proves
that downloading software can always slow down tests