### PR TITLE
Fix regression_gnome issue

### DIFF
--- a/tests/x11regressions/gnomecase/application_starts_on_login.pm
+++ b/tests/x11regressions/gnomecase/application_starts_on_login.pm
@@ -117,9 +117,8 @@ sub run() {
     assert_screen "firefox-gnome", 90;
     send_key "alt-f4";
     wait_still_screen;
-    if (check_screen("firefox-gnome")) {
-        send_key "alt-f4";
-    }
+    send_key "ret";
+    wait_still_screen;
     assert_screen "generic-desktop";
 
     #remove firefox from startup application
@@ -149,9 +148,8 @@ sub run() {
     assert_screen "firefox-gnome", 90;
     send_key "alt-f4";
     wait_still_screen;
-    if (check_screen("firefox-gnome")) {
-        send_key "alt-f4";
-    }
+    send_key "ret";
+    wait_still_screen;
 
     if (get_var("SP2ORLATER")) {
         restore_status_auto_save_session;

--- a/tests/x11regressions/gnomecase/gnome_default_applications.pm
+++ b/tests/x11regressions/gnomecase/gnome_default_applications.pm
@@ -64,6 +64,8 @@ sub run() {
     assert_screen 'gnomecase-defaultapps-firefoxopen';
     send_key "alt-f4";                                     #close firefox
     wait_still_screen;
+    send_key "ret";
+    wait_still_screen;
     send_key "ctrl-w";                                     #close nautilus
 
     # Clean the test directory


### PR DESCRIPTION
Due to initially launched firefox got more than one tab compared with before, then close firefox need confirm - 'ret' applied
