### PR TITLE
Add 'check_metadata' script to check metadata in tests (poo#13034)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ help:
 .PHONY: prepare
 prepare:
 	git clone git://github.com/os-autoinst/os-autoinst
-	ln -s os-autoinst/tools .
+	$(MAKE) check-links
 	cd os-autoinst && cpanm -nq --installdeps .
 	cpanm -nq --installdeps .
 
@@ -20,11 +20,15 @@ link a local working copy of 'os-autoinst' into this \
 folder or call 'make prepare' to install download a copy necessary for \
 testing" && exit 2)
 
-tools/: os-autoinst/
-	@test -e tools || ln -s os-autoinst/tools .
+tools/tidy: os-autoinst/
+	@test -e tools/tidy || ln -s ../os-autoinst/tools/tidy tools/
+	@test -e tools/absolutize || ln -s ../os-autoinst/tools/absolutize tools/
+
+tools/lib/: os-autoinst/
+	@test -e tools/lib || ln -s ../os-autoinst/tools/lib tools/
 
 .PHONY: check-links
-check-links: tools/ os-autoinst/
+check-links: tools/tidy tools/lib/ os-autoinst/
 
 .PHONY: check-links
 tidy: check-links
@@ -35,12 +39,20 @@ test-compile: check-links
 	export PERL5LIB=${PERL5LIB_} ; for f in `git ls-files "*.pm" || find . -name \*.pm|grep -v /os-autoinst/` ; do perl -c $$f 2>&1 | grep -v " OK$$" && exit 2; done ; true
 
 .PHONY: test-compile-changed
-test-compile-changed: tools/
+test-compile-changed: os-autoinst/
 	export PERL5LIB=${PERL5LIB_} ; for f in `git diff --name-only | grep '.pm'` ; do perl -c $$f 2>&1 | grep -v " OK$$" && exit 2; done ; true
+
+.PHONY: test-metadata
+test-metadata:
+	tools/check_metadata $$(git ls-files "tests/**.pm")
+
+.PHONY: test-metadata-changed
+test-metadata-changed:
+	tools/check_metadata $$(git diff --name-only | grep 'tests.*pm')
 
 .PHONY: test
 test: tidy test-compile
 
 .PHONY: perlcritic
-perlcritic: check-links
+perlcritic: tools/lib/
 	PERL5LIB=tools/lib/perlcritic:$$PERL5LIB perlcritic --quiet --gentle --include Perl::Critic::Policy::HashKeyQuote .

--- a/tools/check_metadata
+++ b/tools/check_metadata
@@ -1,0 +1,9 @@
+#!/bin/sh -e
+files="${@:?"Need files to check as argument"}"
+success=1
+for file in $files; do
+    grep -q '# Summary: .\+' $file || (echo "Missing '# Summary: <multi line summary of test>'" in $file && exit 1) || success=0
+    grep -q '# Maintainer: .\+@.\+' $file || (echo "Missing '#Maintainer: <email address>'" in $file && exit 1) || success=0
+done
+[ $success = 1 ] && echo "SUCCESS" && exit 0
+exit 1


### PR DESCRIPTION
'tools/' is now not a symlink anymore but includes one script
and symlinks to the necessary tools from os-autoinst.

Add two targets 'test-metadata' acting on all test modules and
'test-metadata-changed' only on changed files in the git repo
as for 'test-compile-changed'.

Example output:
```
Missing '# Summary: <multi line summary of test>' in tests/yast2_gui/yast2_software_management.pm
Missing '#Maintainer: <email address>' in tests/yast2_gui/yast2_software_management.pm
Missing '# Summary: <multi line summary of test>' in tests/yast2_gui/yast2_users.pm
Missing '#Maintainer: <email address>' in tests/yast2_gui/yast2_users.pm
Makefile:46: recipe for target 'test-metadata' failed
make: *** [test-metadata] Error 1
```

in case of success:
```
SUCCESS
```