### PR TITLE
sle: Add salt test call to console_tests

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -123,8 +123,10 @@ sub fill_in_registration_data {
                     send_key "spc";
                 }
                 else {
-                    assert_and_click "scc-module-$addon";
+                    wait_still_screen(1);
+                    wait_screen_change { assert_and_click "scc-module-$addon" };
                 }
+                save_screenshot;
             }
             send_key $cmd{next};    # all addons selected
             for my $addon (split(/,/, get_var('SCC_ADDONS', ''))) {

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -118,7 +118,7 @@ sub fill_in_registration_data {
         # ids - IBM DLPAR sdk (ppc64le only)
         if (get_var('SCC_ADDONS')) {
             for my $addon (split(/,/, get_var('SCC_ADDONS', ''))) {
-                if (check_var('DESKTOP', 'textmode')) {
+                if (check_var('VIDEOMODE', 'text')) {
                     send_key_until_needlematch "scc-module-$addon", 'tab';
                     send_key "spc";
                 }

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -102,6 +102,7 @@ sub fill_in_registration_data {
         }
         if (check_screen('scc-beta-filter-checkbox', 5)) {
             send_key 'alt-f';    # uncheck 'Filter Out Beta Version'
+            send_key 'tab';      # go to module selection screen
         }
         # The value of SCC_ADDONS is a list of abbreviation of addons/modules
         # Following are abbreviations defined for modules and some addons
@@ -119,7 +120,7 @@ sub fill_in_registration_data {
         if (get_var('SCC_ADDONS')) {
             for my $addon (split(/,/, get_var('SCC_ADDONS', ''))) {
                 if (check_var('VIDEOMODE', 'text')) {
-                    send_key_until_needlematch "scc-module-$addon", 'tab';
+                    send_key_until_needlematch "scc-module-$addon", 'down';
                     send_key "spc";
                 }
                 else {

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -157,9 +157,9 @@ sub fill_in_registration_data {
                     type_string $regcode;
                     sleep 1;
                     save_screenshot;
+                    send_key $cmd{next} if check_var('VIDEOMODE', 'text');
                 }
             }
-            send_key $cmd{next};
             # start addons/modules registration, it needs longer time if select multiple or all addons/modules
             while (assert_screen(['import-untrusted-gpg-key', 'yast_scc-pkgtoinstall', 'inst-addon'], 120)) {
                 if (match_has_tag('import-untrusted-gpg-key')) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -634,6 +634,9 @@ sub load_consoletests() {
         if (check_var('ARCH', 'aarch64') and sle_version_at_least('12-SP2')) {
             loadtest "console/check_gcc48_on_sdk_in_aarch64.pm";
         }
+        if (get_var('SALT') and sle_version_at_least('12-SP2')) {
+            loadtest "console/salt.pm";
+        }
         if (!is_staging() && sle_version_at_least('12-SP2')) {
             loadtest "console/zypper_lifecycle.pm";
         }

--- a/products/sle/templates
+++ b/products/sle/templates
@@ -261,6 +261,13 @@
                         { key => "RESIZE_ROOT_VOLUME", value => 1 },
                         { key => "HDDSIZEGB", value => "50" },
                       ],
+                    },
+                    {
+                      name => "salt",
+                      settings => [
+                        { key => "SCC_ADDONS", value => "asmm" },
+                        { key => "SALT", value => 1 },
+                      ],
                     }
                   ],
 }

--- a/tests/console/salt.pm
+++ b/tests/console/salt.pm
@@ -7,6 +7,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# Summary: Test installation of salt-master as well as salt-minion on same
+#  machine. Test simple operation with loopback.
+# Maintainer: okurz@suse.de
+# Tags: fate#318875, fate#320919
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -28,7 +28,7 @@ sub run() {
     }
 
     wait_idle;
-    mouse_hide;
+    mouse_hide(1);
 
     # license+lang
     if (get_var("HASLICENSE")) {


### PR DESCRIPTION
Add existing salt test module to sle main.pm. It can only work when the *asmm* module is activated and should succeed as soon as the *asmm* module includes salt.

One open question is why `lib/registration.pm` is pressing 'alt-n' two times. I had to disable the second call to enable asmm during graphical installation using (proxy-)SCC

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/os-autoinst/os-autoinst-distri-opensuse/1653)
<!-- Reviewable:end -->
