### PR TITLE
Do not run on 's390x', support extra params on PPC

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -251,8 +251,6 @@ sub init_consoles {
             set_var("S390_NETWORK_PARAMS", $s390_params);
 
             ($hostname) = $s390_params =~ /Hostname=(\S+)/;
-
-            set_var("EXPECTED_INSTALL_HOSTNAME", $hostname);
         }
 
         if (check_var("VIDEOMODE", "text")) {    # adds console for text-based installation on s390x

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -440,7 +440,7 @@ sub load_inst_tests() {
         loadtest "installation/installer_timezone.pm";
         # the test should run only in scenarios, where installed
         # system is not being tested (e.g. INSTALLONLY etc.)
-        if (!consolestep_is_applicable() and !get_var("REMOTE_CONTROLLER")) {
+        if (!consolestep_is_applicable() and !get_var("REMOTE_CONTROLLER") and !check_var('BACKEND', 's390x')) {
             loadtest "installation/hostname_inst.pm";
         }
         if (!get_var("REMOTE_CONTROLLER")) {

--- a/tests/installation/bootloader_ofw.pm
+++ b/tests/installation/bootloader_ofw.pm
@@ -73,6 +73,11 @@ sub run() {
                 save_screenshot;
             }
 
+            if (my $e = get_var("EXTRABOOTPARAMS")) {
+                type_string_very_slow " $e";
+                save_screenshot;
+            }
+
             save_screenshot;
             registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
             send_key "ctrl-x";


### PR DESCRIPTION
The test tests nothing on 's390x' backend, just that the expected
hostname was set (and this is not the point of the test).

EXTRABOOTPARAMS is now supported on PPC.

Should fix: https://openqa.suse.de/tests/502321#step/hostname_inst/5.