### PR TITLE
zypper_lifecycle: Do not rely on date as getting date is non-atomic

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -46,9 +46,7 @@ sub run() {
     assert_script_run 'zypper lifecycle --help';
     assert_script_run('zypper lifecycle --days 1', timeout => 30, fail_message => 'All packages supported tomorrow');
     $output = script_output 'zypper lifecycle --days 0';
-    my $today = qx{date --iso-8601};
-    chomp($today);
-    die "'end of support' line not found" unless $output =~ /No (products|packages).*before $today/;
+    die "'end of support' line not found" unless $output =~ /No (products|packages).*before/;
     assert_script_run('zypper lifecycle --days 9999', timeout => 30, fail_message => 'No package should be supported for more than 20 years');
     $output = script_output 'zypper lifecycle --days 9999';
     die "Product 'end of support' line not found" unless $output =~ /^Product end of support before/;


### PR DESCRIPTION
The  being evaluated on the worker and not the SUT is suspect to timezone
differences, e.g. see
https://openqa.suse.de/tests/506437#step/zypper_lifecycle/29, where this
fails. But even when we would get the time from the SUT and then compare it
against the zypper lifecycle output we could hit the day boundary. It is
better to not try to parse the date at all.