### PR TITLE
Wait longer for grub2 screen

### DIFF
--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -22,7 +22,8 @@ sub run() {
         send_key 'ret';
     }
     workaround_type_encrypted_passphrase;
-    assert_screen "grub2";
+    # 60 due to rare slowness e.g. multipath poo#11908
+    assert_screen "grub2", 60;
     # prevent grub2 timeout; 'esc' would be cleaner, but grub2-efi falls to the menu then
     send_key 'up';
     if (get_var("BOOT_TO_SNAPSHOT")) {


### PR DESCRIPTION
poo#11908

I would ignore this tidy fail because it's wrong in this case
It would put comment line 26 on same level as comment on line 25