### PR TITLE
Do not load x11_login when autologin is disabled

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -584,7 +584,7 @@ sub load_mate_tests() {
 sub load_x11tests() {
     return unless (!get_var("INSTALLONLY") && is_desktop_installed() && !get_var("DUALBOOT") && !get_var("RESCUECD"));
 
-    if (get_var("NOAUTOLOGIN") || get_var("XDMUSED")) {
+    if (get_var("XDMUSED")) {
         loadtest "x11/x11_login.pm";
     }
     if (guiupdates_is_applicable()) {


### PR DESCRIPTION
Even though the system requires a login, there are other spots already
taking care of this when not using xdm (e.g first_boot logs the user in
when NOAUTOLOGIN is defined).