### PR TITLE
Fix regression_gnome issue

### DIFF
--- a/tests/x11regressions/gnomecase/gnome_default_applications.pm
+++ b/tests/x11regressions/gnomecase/gnome_default_applications.pm
@@ -64,8 +64,6 @@ sub run() {
     assert_screen 'gnomecase-defaultapps-firefoxopen';
     send_key "alt-f4";                                     #close firefox
     wait_still_screen;
-    send_key "ret";
-    wait_still_screen;
     send_key "ctrl-w";                                     #close nautilus
 
     # Clean the test directory


### PR DESCRIPTION
  - gnome_default_applications - which only have one tab to close
  - o.s.d failure: https://openqa.suse.de/tests/507705#step/gnome_default_applications/32