### PR TITLE
Add quotation mark for expected_install_hostname

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -440,7 +440,7 @@ sub load_inst_tests() {
         loadtest "installation/installer_timezone.pm";
         # the test should run only in scenarios, where installed
         # system is not being tested (e.g. INSTALLONLY etc.)
-        if (!consolestep_is_applicable() and !get_var("REMOTE_CONTROLLER") and !check_var('BACKEND', 's390x')) {
+        if (!consolestep_is_applicable() and !get_var("REMOTE_CONTROLLER") and !check_var('BACKEND', 's390x') and sle_version_at_least('12-SP2')) {
             loadtest "installation/hostname_inst.pm";
         }
         if (!get_var("REMOTE_CONTROLLER")) {

--- a/tests/installation/hostname_inst.pm
+++ b/tests/installation/hostname_inst.pm
@@ -22,7 +22,7 @@ sub run() {
     if (my $expected_install_hostname = get_var('EXPECTED_INSTALL_HOSTNAME')) {
         # EXPECTED_INSTALL_HOSTNAME contains expected hostname YaST installer
         # got from environment (DHCP, 'hostname=' as a kernel cmd line argument
-        assert_script_run "test \"\$(hostname)\" == $expected_install_hostname";
+        assert_script_run "test \"\$(hostname)\" == \"$expected_install_hostname\"";
     }
     else {
         # 'install' is the default hostname if no hostname is get from environment


### PR DESCRIPTION
failed test:
https://openqa.suse.de/tests/509613#step/hostname_inst/3

verified result:
http://147.2.207.208/tests/56#step/hostname_inst/3