### PR TITLE
Fix lsmfip script to install packages *and* update

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -94,6 +94,7 @@ while (my $name = shift @ARGV) {
 
 my $pool = solv::Pool->new();
 $pool->setarch();
+$pool->set_debuglevel(0);
 
 my $cachedir = '/var/cache/zypp/solv';
 for my $repo (glob("$cachedir/*")) {
@@ -125,7 +126,8 @@ if (!$options{verify}) {
             for my $s ($sel->solvables()) {
                 print STDERR "-> $s->{name}-$s->{evr}.$s->{arch}\n" if $options{verbose};
             }
-            push @jobs, $sel->jobs($solv::Job::SOLVER_INSTALL|$solv::Job::SOLVER_UPDATE);
+            push @jobs, $sel->jobs($solv::Job::SOLVER_INSTALL);
+            push @jobs, $sel->jobs($solv::Job::SOLVER_UPDATE);
         }
 
         my @problems = $solver->solve(\@jobs);

--- a/tests/console/install_packages.pm
+++ b/tests/console/install_packages.pm
@@ -19,6 +19,9 @@ sub run() {
 
     assert_script_run("zypper -n in -l perl-solv");
     assert_script_run("~$username/data/lsmfip --verbose $packages > \$XDG_RUNTIME_DIR/install_packages.txt");
+    # make sure we install at least one package - otherwise this test is pointless
+    # better have it fail and let a reviewer check the reason
+    assert_script_run("test -s \$XDG_RUNTIME_DIR/install_packages.txt");
     assert_script_run("xargs --no-run-if-empty zypper -n in -l < \$XDG_RUNTIME_DIR/install_packages.txt");
     assert_script_run("rpm -q $packages | tee /dev/$serialdev");
 }


### PR DESCRIPTION
Job type flags can't be |ed - they can be customized with
SOLVER flags only

