### PR TITLE
xfce_lightdm: Make the test unimportant

### DIFF
--- a/tests/x11/xfce_lightdm_logout_login.pm
+++ b/tests/x11/xfce_lightdm_logout_login.pm
@@ -22,16 +22,20 @@ sub run() {
     type_password;
     send_key "ret";
     assert_screen 'generic-desktop';
+    mouse_set(100, 100);
+    sleep 1;
     for (1 .. 4) {
         mouse_hide;
-        check_screen('mouse-cursor', 5) || return;
+        sleep 3;
+        check_screen('mouse-cursor', 1) || return;
     }
     die "mouse cursor still visible";
-
 }
 
 sub test_flags() {
-    return {important => 1, milestone => 1};
+    # as long as we don't understand the failure in mouse_hide we should rather not
+    # rely on this test. The problem can't be reproduced outside of openqa
+    return {important => 0, milestone => 1};
 }
 
 1;


### PR DESCRIPTION
- sleep some between the mouse_hides
- try a "random" mouse set before the mouse_hide calls
- remove important flag

Reference: https://tortuga.suse.de/tests/394#step/xfce_lightdm_logout_login/6