### PR TITLE
Do not prepare the system for updates when testing DUALBOOT

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -746,7 +746,7 @@ sub install_online_updates {
 }
 
 sub load_system_update_tests {
-    return if get_var("INSTALLONLY");
+    return if get_var("INSTALLONLY") || get_var("DUALBOOT");
 
     if (guiupdates_is_applicable()) {
         loadtest "update/prepare_system_for_update_tests.pm";


### PR DESCRIPTION
The various DUALBOOT tests are there to verify that installing our
product does not accidentally destroy loading alternative systems.

(logic for updates was introduced with commit e9e80a)

This is supposed to fix test failures like: https://openqa.opensuse.org/tests/239842