### PR TITLE
Test ALPN in openssl in extra & FIPS from 12SP2 on

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -545,7 +545,6 @@ sub load_consoletests() {
         if (need_clear_repos()) {
             loadtest "update/zypper_clear_repos.pm";
         }
-        loadtest "console/openssl_alpn.pm";
         #have SCC repo for SLE product
         if (have_scc_repos()) {
             loadtest "console/yast_scc.pm";
@@ -654,6 +653,9 @@ sub load_extra_test () {
     # setup $serialdev permission and so on
     loadtest "console/consoletest_setup.pm";
     loadtest "console/check_console_font.pm";
+    if (sle_version_at_least('12-SP2')) {
+        loadtest "console/openssl_alpn.pm";
+    }
     loadtest "console/zypper_lr.pm";
     loadtest "console/zypper_ref.pm";
     loadtest "console/update_alternatives.pm";
@@ -878,6 +880,9 @@ sub load_fips_tests_core() {
     loadtest "fips/openssl/openssl_fips_cipher.pm";
     loadtest "fips/openssl/openssl_pubkey_rsa.pm";
     loadtest "fips/openssl/openssl_pubkey_dsa.pm";
+    if (sle_version_at_least('12-SP2')) {
+        loadtest "console/openssl_alpn.pm";
+    }
     loadtest "console/sshd.pm";
     loadtest "console/ssh_pubkey.pm";
     loadtest "fips/openssh/openssh_fips.pm";

--- a/tests/console/openssl_alpn.pm
+++ b/tests/console/openssl_alpn.pm
@@ -10,15 +10,18 @@
 use base "consoletest";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     # FATE#320292 - Application-Layer Protocol Negotiation (ALPN) support for openssl
+
     select_console 'root-console';
 
     assert_script_run 'openssl req -newkey rsa:2048 -nodes -keyout domain.key -x509 -days 365 -out domain.crt -subj "/C=CZ/L=Prague/O=SUSE/CN=alpn.suse.cz"';
 
+    clear_console;
     type_string "openssl s_server -key domain.key -cert domain.crt -alpn http\n";
-    save_screenshot;
+    assert_screen "openssl-s_server-alpn-accept-connections";
 
     select_console 'user-console';
     validate_script_output 'openssl s_client -alpn http < /dev/null', sub { m/ALPN protocol: http/ };


### PR DESCRIPTION
ALPN in openssl is a SLE 12-SP2+ feature. Run the test from 12-SP2 on in
extra tests and FIPS.