### PR TITLE
check_gcc48_on_sdk_in_aarch64: Fix match for c++, too

### DIFF
--- a/tests/console/check_gcc48_on_sdk_in_aarch64.pm
+++ b/tests/console/check_gcc48_on_sdk_in_aarch64.pm
@@ -22,10 +22,10 @@ sub run() {
         diag "checking package $package (only binary packages)";
         script_run('zypper search -t package --details ' . $package);
         diag "checking package $package is *not* in repo \'$not_repo\'";
-        assert_script_run('! zypper search -t package --details ' . $package . ' | grep \'\<' . $package . '\>\s\+.*' . $not_repo . '\'');
+        assert_script_run('! zypper search -t package --details ' . $package . ' | grep \'\s\+' . $package . '\s\+.*' . $not_repo . '\'');
         if (get_var('ADDONS', '') =~ /sdk/) {
             diag "checking package $package *is* in repo \'$repo\'";
-            assert_script_run('zypper search -t package --details ' . $package . ' | grep \'\<' . $package . '\>\s\+.*' . $repo . '\'');
+            assert_script_run('zypper search -t package --details ' . $package . ' | grep \'\s\+' . $package . '\s\+.*' . $repo . '\'');
         }
     }
 }


### PR DESCRIPTION
Should fix https://openqa.suse.de/tests/510899#step/check_gcc48_on_sdk_in_aarch64/13