### PR TITLE
Output PackageKit's updates list

### DIFF
--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -48,7 +48,7 @@ sub run() {
     # Check no more updates are available after gui updater
     select_console "root-console";
     assert_script_run "pkcon refresh";
-    assert_script_run "pkcon get-updates | grep \"There are no updates\"";
+    assert_script_run "pkcon get-updates | tee /dev/$serialdev | grep \"There are no updates\"";
     select_console "x11";
 }
 


### PR DESCRIPTION
Output PackageKit's updates list to serial as well.

the interesting thing we seen now is https://openqa.opensuse.org/tests/240488#step/updates_packagekit_kde/13 failure

it's a 42.1-to-staging-update test, updater icon does not in the tray as expected, but after pkcon refresh, PK found something need to update.. we have to output PK's update list then...