### PR TITLE
Fix packagekit updates

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -761,6 +761,7 @@ sub load_system_update_tests {
         else {
             loadtest "update/updates_packagekit_gpk.pm";
         }
+        loadtest "update/check_system_is_updated.pm";
     }
     else {
         loadtest "update/zypper_up.pm";

--- a/tests/update/check_system_is_updated.pm
+++ b/tests/update/check_system_is_updated.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "x11test";
+use strict;
+use testapi;
+
+sub run() {
+    x11_start_program("xterm");
+    assert_screen('xterm-started');
+    assert_script_sudo "chown $testapi::username /dev/$testapi::serialdev";
+    assert_script_run "pkcon refresh";
+    assert_script_run "pkcon get-updates | tee /dev/$serialdev | grep 'There are no updates'";
+    send_key "alt-f4";
+}
+
+sub test_flags() {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/update/prepare_system_for_update_tests.pm
+++ b/tests/update/prepare_system_for_update_tests.pm
@@ -24,6 +24,7 @@ sub run() {
     assert_screen('xterm-started');
     assert_script_sudo "chown $testapi::username /dev/$testapi::serialdev";
     assert_script_sudo "echo \"download.use_deltarpm = false\" >> /etc/zypp/zypp.conf";
+    assert_script_run "pkcon refresh";
     send_key "alt-f4";
 }
 


### PR DESCRIPTION
poo#13056
Check no more updates are available
Reboot after kde kernel updates

Local runs:
http://dhcp91.suse.cz/tests/2079
http://dhcp91.suse.cz/tests/2077
http://dhcp91.suse.cz/tests/2078
http://dhcp91.suse.cz/tests/2080
Required needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/94
