### PR TITLE
Libreoffice-Math is not available on LIVECD tests (space constraints)

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -636,10 +636,8 @@ sub load_x11tests() {
     if (gnomestep_is_applicable()) {
         loadtest "x11/eog.pm";
     }
-    if (get_var("DESKTOP") =~ /kde|gnome/ && !is_server) {
-        loadtest "x11/oomath.pm";
-    }
     if (get_var("DESKTOP") =~ /kde|gnome/ && !get_var("LIVECD") && !is_server) {
+        loadtest "x11/oomath.pm";
         loadtest "x11/oocalc.pm";
     }
     if (get_var("DESKTOP") =~ /kde|gnome/ && !is_server) {


### PR DESCRIPTION
No reason to test oomath on live CDs - they explode by size and oomath is not on it (on GNOME, lowriter and calc are there - on KDE, nothing of LO is there)