### PR TITLE
Test case tc#1525215 FIPS:ecryptfs

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -903,6 +903,7 @@ sub load_fips_tests_misc() {
 sub load_fips_tests_crypt() {
     loadtest "console/yast2_dm_crypt.pm";
     loadtest "console/cryptsetup.pm";
+    loadtest "console/ecryptfs_fips.pm";
 }
 
 sub prepare_target() {

--- a/tests/console/ecryptfs_fips.pm
+++ b/tests/console/ecryptfs_fips.pm
@@ -1,0 +1,36 @@
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+# Test case tc#1525215 FIPS:ecryptfs
+
+use base "consoletest";
+use strict;
+use testapi;
+
+sub run() {
+    my $self = shift;
+    select_console 'root-console';
+
+    # install ecryptfs-utils
+    assert_script_run("zypper -n in ecryptfs-utils");
+    assert_script_run("rpm -q ecryptfs-utils");
+    assert_script_run("modprobe ecryptfs");
+
+    # mount ecryptfs
+    assert_script_run("mkdir .private private");
+    validate_script_output("echo -e \"1\n1\n\n\nyes\nno\n\"  | mount -t ecryptfs -o key=passphrase:passphrase_passwd=testpass ./.private ./private", sub { m/Mounted eCryptfs/ });
+
+    # touch a new file and try to write with it
+    assert_script_run("cd private && touch testfile ");
+    script_run("echo hello > testfile");
+    assert_script_run("ls");
+    validate_script_output("cat testfile",              sub { m/hello/ });
+    validate_script_output("file ../.private/testfile", sub { m/testfile: data/ });
+
+    # unmount and check the encrypt file
+    assert_script_run("cd .. && umount -l private");
+    validate_script_output("ls private", sub { m/^(?!.*testfile)/ });
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Check the ecryptfs-utils with fips enabled
Install the ecryptfs-utils and encrypt the directory.
Create a new encrypt file and try to write it.
Check the file after unmont the encrypt directory

Because of [BNC#930678](https://bugzilla.suse.com/show_bug.cgi?id=930678), it will failed with fips enabled right now.

The test result with fips disabled.
[test result of ecryptfs](http://147.2.212.197/tests/593)
