### PR TITLE
Completely ignore FAKE_SCC entries to not fool installer

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -152,17 +152,6 @@ if (check_var('DESKTOP', 'minimalx')) {
     set_var('DM_NEEDS_USERNAME', 1);
 }
 
-# use Fake SCC regcodes if none provided
-if (!get_var('SCC_REGCODE') && get_var('FAKE_SCC_REGCODE')) {
-    my @copy_vars = qw/REGCODE EMAIL URL CERT/;
-    for my $i (map { uc } split(/,/, get_var('SCC_ADDONS', ''))) {
-        push @copy_vars, "REGCODE_$i" if get_var("FAKE_SCC_REGCODE_$i");
-    }
-    for my $i (@copy_vars) {
-        set_var("SCC_$i", get_var("FAKE_SCC_$i")) unless get_var("SCC_$i");
-    }
-}
-
 $needle::cleanuphandler = \&cleanup_needles;
 
 # dump other important ENV:


### PR DESCRIPTION
Should fix issues like
https://openqa.suse.de/tests/511949#step/skip_registration/3

We do not use fake SCC anymore but as the regurl is still filled and as the
installer now tries to reach the SCC server and does more consistency checks
now the installation fails because openqa.suse.de is not really what could be
expected from an SCC.

Related to bsc#992506.

Local verification run: http://lord.arch/tests/2892