### PR TITLE
Esc to hide Plymouth after timeout in first_boot

### DIFF
--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -101,6 +101,10 @@ sub test_flags() {
 sub post_fail_hook() {
     my $self = shift;
 
+    # Reveal what is behind Plymouth splash screen
+    send_key 'esc';
+    save_screenshot;
+
     $self->export_logs();
 }
 

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -102,9 +102,9 @@ sub post_fail_hook() {
     my $self = shift;
 
     # Reveal what is behind Plymouth splash screen
-    send_key 'esc';
-    save_screenshot;
-
+    wait_screen_change {
+        send_key 'esc';
+    };
     $self->export_logs();
 }
 


### PR DESCRIPTION
https://progress.opensuse.org/issues/13136

In case Plymouth screen is still showing, send ESC key to hopefully reveal what is behind it. To my knowledge this should not interfere with export_logs except that it will cause some programs to move on from their present state in some cases.