### PR TITLE
Fixup network configuration when upgrading from openSUSE 13.2 (and lo…

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -344,6 +344,17 @@ sub load_reboot_tests() {
     }
 }
 
+sub load_fixup_network() {
+    # openSUSE 13.2's (and earlier) systemd has broken rules for virtio-net, not applying predictable names (despite being configured)
+    # A maintenance update breaking networking names sounds worse than just accepting that 13.2 -> TW breaks with virtio-net
+    # At this point, the system has been updated, but our network interface changed name (thus we lost network connection)
+    my @old_hdds = qw/openSUSE-12.1 openSUSE-12.2 openSUSE-12.3 openSUSE-13.1-gnome openSUSE-13.2/;
+    return unless grep { check_var('HDDVERSION', $_) } @old_hdds;
+
+    loadtest "fixup/network_configuration.pm";
+
+}
+
 sub load_consoletests() {
     if (consolestep_is_applicable()) {
         loadtest "console/consoletest_setup.pm";
@@ -949,6 +960,7 @@ else {
         || load_otherDE_tests()
         || load_slenkins_tests())
     {
+        load_fixup_network();
         load_system_update_tests();
         load_rescuecd_tests();
         load_consoletests();

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -70,15 +70,6 @@ sub run() {
     script_run "ps axf > /tmp/psaxf.log";
     script_run "cat /proc/loadavg > /tmp/loadavg_consoletest_setup.txt";
 
-    # openSUSE 13.2's (and earlier) systemd has broken rules for virtio-net, not applying predictable names (despite being configured)
-    # A maintenance update breaking networking names sounds worse than just accepting that 13.2 -> TW breaks
-    # At this point, the system has been upadted, but our network interface changes name (thus we lost network connection)
-    my @old_hdds = qw/openSUSE-12.1 openSUSE-12.2 openSUSE-12.3 openSUSE-13.1-gnome openSUSE-13.2/;
-    if (grep { check_var('HDDVERSION', $_) } @old_hdds) {    # copy eth0 network config to ens4
-        script_run("cp /etc/sysconfig/network/ifcfg-eth0 /etc/sysconfig/network/ifcfg-ens4");
-        script_run("/sbin/ifup ens4");
-    }
-
     # Just after the setup: let's see the network configuration
     script_run "ip addr show";
     save_screenshot;

--- a/tests/fixup/network_configuration.pm
+++ b/tests/fixup/network_configuration.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "x11test";
+use strict;
+use testapi;
+
+sub run() {
+    my $self = shift;
+
+    # openSUSE 13.2's (and earlier) systemd has broken rules for virtio-net, not applying predictable names (despite being configured)
+    # A maintenance update breaking networking names sounds worse than just accepting that 13.2 -> TW breaks with virtio-net
+    # At this point, the system has been updated, but our network interface changed name (thus we lost network connection)
+    my $command = "cp /etc/sysconfig/network/ifcfg-eth0 /etc/sysconfig/network/ifcfg-ens4; /usr/sbin/ifup ens4";
+
+    if (get_var("DESKTOP") =~ /kde|gnome/) {
+        x11_start_program("xterm");
+        assert_script_sudo($command);
+        send_key "alt-f4";
+    }
+    else {
+        select_console 'root-console';
+        assert_script_run($command);
+    }
+}
+
+sub test_flags() {
+    return {milestone => 1};
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
…wer)

openSUSE 13.2's (and earlier) systemd has broken rules for virtio-net,
not applying predictable names (despite being configured). A maintenance
update breaking networking names sounds worse than just accepting
that 13.2 -> TW breaks with virtio-net.

Since consoletest_setup is no longer the first thing running after the
system has been updated (it is now the check for applicable updates) this
fixup needed to be moved out of consoletest_setup in order to be started
earlier (again, asap, before nything wants to access the network)