### PR TITLE
Revert "Use wait_boot from utils.pm instead custom system_boot"

### DIFF
--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -19,7 +19,7 @@ sub run {
     my $self = shift;
     $self->system_login();
 
-    pkcon_quit unless check_var('DESKTOP', 'textmode');
+    pkcon_quit;
 
     for my $var (qw(OS_TEST_REPO SDK_TEST_REPO)) {
         my $repo = get_var($var);
@@ -29,6 +29,7 @@ sub run {
 
     fully_patch_system;
 
+    set_var('SYSTEM_IS_PATCHED', 1);
     type_string "reboot\n";
 }
 

--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -13,7 +13,6 @@ use strict;
 use warnings;
 use File::Basename;
 use base "opensusebasetest";
-use utils;
 use testapi;
 
 sub test_run_list {
@@ -28,10 +27,26 @@ sub test_suite {
     die "you need to overload test_suite in your class";
 }
 
+# system boot & login
 sub system_login {
     my $self = shift;
-    wait_boot;
-    select_console('root-console');
+    # if we have to patch the system, we won't see the CD
+    if (!get_var('SYSTEM_IS_PATCHED')) {
+        assert_screen "inst-bootmenu";
+        send_key "ret";
+    }
+    if (get_var('OFW')) {
+        assert_screen 'ofw-boot-prompt';
+        type_string "boot disk\n";
+    }
+    assert_screen "grub2";
+    send_key "ret";
+    assert_screen "text-login", 50;
+    type_string "root\n";
+    assert_screen "password-prompt";
+    type_password;
+    type_string "\n";
+    sleep 2;
 }
 
 # Call test_run_list and write the result into /root/qaset/config


### PR DESCRIPTION
Revert it, because it cause all kernel regression test fail since build2052.
openqa.suse.de/tests/overview?distri=sle&version=12-SP2&build=2052&groupid=32