### PR TITLE
Look for problems in the system

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -25,20 +25,92 @@ sub post_run_hook {
 
 sub save_and_upload_log {
     my ($cmd, $file, $args) = @_;
-    script_run "$cmd > $file";
-    upload_logs $file;
+    script_run("$cmd | tee $file", $args->{timeout});
+    upload_logs($file) unless $args->{noupload};
     save_screenshot if $args->{screenshot};
 }
 
-sub export_logs {
+sub problem_detection {
     my $self = shift;
 
+    type_string "pushd \$(mktemp -d)\n";
+
+    # Slowest services
+    save_and_upload_log("systemd-analyze blame", "systemd-analyze-blame.txt", {noupload => 1});
+    clear_console;
+
+    # Generate and upload SVG out of `systemd-analyze plot'
+    save_and_upload_log('systemd-analyze plot', "systemd-analyze-plot.svg", {noupload => 1});
+    clear_console;
+
+    # Failed system services
+    save_and_upload_log('systemctl --all --state=failed', "failed-system-services.txt", {screenshot => 1, noupload => 1});
+    clear_console;
+
+    # Unapplied configuration files
+    save_and_upload_log("find /* -name '*.rpmnew'", "unapplied-configuration-files.txt", {screenshot => 1, noupload => 1});
+    clear_console;
+
+    # Errors, warnings, exceptions, and crashes mentioned in dmesg
+    save_and_upload_log("dmesg | grep -i 'error\\|warn\\|exception\\|crash'", "dmesg-errors.txt", {screenshot => 1, noupload => 1});
+    clear_console;
+
+    # Errors in journal
+    save_and_upload_log("journalctl --no-pager -p 'err'", "journalctl-errors.txt", {screenshot => 1, noupload => 1});
+    clear_console;
+
+    # Tracebacks in journal
+    save_and_upload_log('journalctl | grep -i traceback', "journalctl-tracebacks.txt", {screenshot => 1, noupload => 1});
+    clear_console;
+
+    # Segmentation faults
+    save_and_upload_log("coredumpctl list", "segmentation-faults-list.txt", {screenshot => 1, noupload => 1});
+    save_and_upload_log("coredumpctl info", "segmentation-faults-info.txt", {screenshot => 1, noupload => 1});
+    clear_console;
+
+    # Broken links
+    save_and_upload_log("find / -type d \\( -path /proc -o -path /run -o -path /.snapshots -o -path /var \\) -prune -o -xtype l -exec ls -l --color=always {} \\; -exec rpmquery -f {} \\;", "broken-symlinks.txt", {screenshot => 1, noupload => 1});
+    clear_console;
+
+    # Binaries with missing libraries
+    save_and_upload_log("
+IFS=:
+for path in \$PATH; do
+    for bin in \$path/*; do
+        ldd \$bin 2> /dev/null | grep 'not found' && echo -n Affected binary: \$bin 'from ' && rpmquery -f \$bin
+    done
+done", "binaries-with-missing-libraries.txt", {timeout => 60, noupload => 1});
+    clear_console;
+
+    # rpmverify problems
+    save_and_upload_log("rpmverify -a | grep -v \"[S5T].* c \"", "rpmverify-problems.txt", {timeout => 60, screenshot => 1, noupload => 1});
+    clear_console;
+
+    # VMware specific
+    if (check_var('VIRSH_VMM_FAMILY', 'vmware')) {
+        save_and_upload_log('systemctl status vmtoolsd vgauthd', "vmware-services.txt", {screenshot => 1, noupload => 1});
+        clear_console;
+    }
+
+    script_run 'tar cvvJf problem_detection_logs.tar.xz *';
+    upload_logs('problem_detection_logs.tar.xz');
+    type_string "popd\n";
+}
+
+sub export_logs {
     select_console 'root-console';
     save_screenshot;
+
+    problem_detection;
 
     save_and_upload_log('cat /proc/loadavg', '/tmp/loadavg.txt', {screenshot => 1});
     save_and_upload_log('journalctl -b',     '/tmp/journal.log', {screenshot => 1});
     save_and_upload_log('ps axf',            '/tmp/psaxf.log',   {screenshot => 1});
+
+    # Just after the setup: let's see the network configuration
+    save_and_upload_log("ip addr show", "/tmp/ip-addr-show.log");
+
+    save_screenshot;
 
     # check whether xorg logs is exists in user's home, if yes, upload xorg logs from user's
     # home instead of /var/log


### PR DESCRIPTION
POO#11930

This new sub problem_detection() detects problems in the installed
system and uploads log to worker. Currently it looks into systemd
journal, coredumpctl, systemctl et all for core dumps, signs of python
traceback, general problems in the journal etc. (Other proposals
welcome.)

I implemented POO#11930 not as an enhancement to textinfo.pm test but as
a function which might be called from different places (installed system
and even installer itself), and multiple times. Atm I execute it from
`console/consoletest_setup.pm` and `x11/shutdown.pm`. Problem of current
approach is that it adds 5-6 minutes to the test suite per execution.

Verification run: http://assam.suse.cz/tests/2678#downloads.