### PR TITLE
installation: partitioning: Fix typo 'partioning'

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -16,7 +16,7 @@ use testapi;
 # Entry test code
 sub run() {
 
-    assert_screen 'partioning-edit-proposal-button', 40;
+    assert_screen 'partitioning-edit-proposal-button', 40;
 
     if (get_var("DUALBOOT")) {
         assert_screen 'partitioning-windows', 40;


### PR DESCRIPTION
Needs needle changes:

* https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/202
* https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/100