### PR TITLE
Make kexec=1 workaround configurable

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -158,7 +158,7 @@ sub bootmenu_network_source {
         #type_string "ZYPP_MULTICURL=0 "; sleep 2;
     }
 
-    if (check_var("FLAVOR", "NET")) {
+    if (check_var("LINUXRC_KEXEC", "1")) {
         type_string_slow " kexec=1";
         record_soft_failure "boo#990374 - pass kexec to installer to use initrd from FTP";
     }
@@ -189,6 +189,11 @@ sub specific_bootmenu_params {
 
     if (get_var("FIPS")) {
         $args .= " fips=1";
+    }
+
+    if (check_var("LINUXRC_KEXEC", "1")) {
+        $args .= " kexec=1";
+        record_soft_failure "boo#990374 - pass kexec to installer to use initrd from FTP";
     }
 
     type_string_very_slow $args;

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -14,6 +14,7 @@ use strict;
 use Time::HiRes qw(sleep);
 
 use testapi;
+use bootloader_setup;
 use registration;
 use utils;
 
@@ -147,18 +148,7 @@ sub run() {
 
     #type_string_slow 'kiwidebug=1 ';
 
-    my $args = "";
-    if (get_var("AUTOYAST")) {
-        $args .= " ifcfg=*=dhcp ";
-        $args .= "autoyast=" . autoinst_url . "/data/" . get_var("AUTOYAST") . " ";
-    }
-    type_string_slow $args;
-    save_screenshot;
-
-    if (get_var("FIPS")) {
-        type_string_slow ' fips=1';
-        save_screenshot;
-    }
+    specific_bootmenu_params;
 
     registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
 


### PR DESCRIPTION
The workaround is not desirable for most tests, only for very
specific use cases like the TW->TW upgrade.