### PR TITLE
setup_online_repos: Ensure initialized online repos before continuing

### DIFF
--- a/tests/installation/setup_online_repos.pm
+++ b/tests/installation/setup_online_repos.pm
@@ -74,6 +74,9 @@ sub run() {
             last unless check_screen 'import-untrusted-gpg-key-598D0E63B3FD7E48';
         }
     }
+    # make sure we are done with the setup and arrived at the next screen
+    # which can take some time as this involves network traffic
+    assert_screen 'before-package-selection', 300;
 }
 
 1;


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/13072