### PR TITLE
Move crash test after compilation tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1207,14 +1207,14 @@ if (get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1")) {
 }
 
 if (get_var("TCM") || check_var("ADDONS", "tcm")) {
-    # kdump is not supported on aarch64, see BSC#990418
-    if (!check_var('ARCH', 'aarch64')) {
-        loadtest "toolchain/crash.pm";
-    }
     loadtest "toolchain/install.pm";
     loadtest "toolchain/gcc5_fortran_compilation.pm";
     loadtest "toolchain/gcc5_C_compilation.pm";
     loadtest "toolchain/gcc5_Cpp_compilation.pm";
+    # kdump is not supported on aarch64, see BSC#990418
+    if (!check_var('ARCH', 'aarch64')) {
+        loadtest "toolchain/crash.pm";
+    }
 }
 
 1;


### PR DESCRIPTION
Before https://progress.opensuse.org/issues/13014 is fixed we can
perhaps move the problematic test to the rear and have some toolchain
coverage on s390x: https://openqa.suse.de/tests/518982.

Verification run: http://assam.suse.cz/tests/2744