### PR TITLE
Detect tianocore bootmanager selection

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -26,10 +26,8 @@ sub run() {
 
     if (get_var('DUALBOOT')) {
         # send ESC to prevent tianocore from booting from hard disk...
-        send_key_until_needlematch('tianocore-mainmenu', 'esc', 10, 5);
-        send_key "down";    # language
-        send_key "down";    # device manager
-        send_key "down";    # bootmanager
+        send_key_until_needlematch('tianocore-mainmenu',    'esc',  10, 5);
+        send_key_until_needlematch('tianocore-bootmanager', 'down', 5,  5);
         send_key "ret";
         send_key "down";    # DVD
         send_key "ret";


### PR DESCRIPTION
For some reason the order of menu entries is different in different
tianocore versions.