### PR TITLE
installer_timezone: Try weird combinations for 'next' shortcut

### DIFF
--- a/tests/installation/installer_timezone.pm
+++ b/tests/installation/installer_timezone.pm
@@ -14,7 +14,14 @@ use testapi;
 
 sub run() {
     assert_screen "inst-timezone", 125 || die 'no timezone';
-    send_key get_var('LIVECD') ? 'alt-x' : $cmd{next};
+    if (get_var('LIVECD')) {
+        # on live cd we might get weird combinations assigned, even if the ISO
+        # does not change, it behaves different
+        send_key "alt-$_" foreach (('x', 't'));
+    }
+    else {
+        send_key $cmd{next};
+    }
 }
 
 1;


### PR DESCRIPTION
On lord.arch 'alt-x' is necessary instead of default 'alt-n' but when running
over openqa.opensuse.org it is 'alt-t' even though it is the same DVD image.

Verification run: http://lord.arch/tests/3086