### PR TITLE
Replace 'check_screenlock' by 'ensure_unlocked_desktop'

### DIFF
--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -42,7 +42,7 @@ sub run() {
     if (!check_var("DESKTOP", "textmode")) {
         select_console('x11');
         wait_still_screen(2);
-        check_screenlock [qw/displaymanager generic-desktop/];
+        ensure_unlocked_desktop [qw/displaymanager generic-desktop/];
         if (get_var("DESKTOP_MINIMALX_INSTONLY")) {
             # Desired wm was just installed and needs x11_login
             assert_screen 'displaymanager', 200;

--- a/tests/online_migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/online_migration/sle12_online_migration/yast2_migration.pm
@@ -21,7 +21,7 @@ sub run {
     else {
         select_console 'x11';
         wait_still_screen;
-        check_screenlock;
+        ensure_unlocked_desktop;
         mouse_hide(1);
         assert_screen 'generic-desktop';
 


### PR DESCRIPTION
Ensure the screen stays unlocked and not only check. Otherwise the screen
might lock immediately after checking.

Verification run: http://lord.arch/tests/3098

Related progress issue: https://progress.opensuse.org/issues/13258