### PR TITLE
rails: Ensure subshell spawned process can be killed

### DIFF
--- a/tests/console/rails.pm
+++ b/tests/console/rails.pm
@@ -19,7 +19,7 @@ rails new -B mycoolapp
 cd mycoolapp
 (rails server &)
 for i in {1..100} ; do sleep 0.1; curl -s http://localhost:3000 | grep "Welcome" && break ; done
-kill %1'
+pkill -f "rails server"
 EOF
     assert_script_run($_) foreach (split /\n/, $cmd);
 }


### PR DESCRIPTION
Should fix https://openqa.opensuse.org/tests/245011#step/rails/11

Verification run: http://lord.arch/tests/3109