### PR TITLE
Give more time to assert migration proposal

### DIFF
--- a/tests/online_migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/online_migration/sle12_online_migration/yast2_migration.pm
@@ -57,7 +57,7 @@ sub run {
         assert_screen 'yast2-migration-installupdate', 200;
         send_key "alt-y";
     }
-    assert_screen 'yast2-migration-proposal', 60;
+    assert_screen 'yast2-migration-proposal', 200;
 
     # giva a little time to check package conflicts
     if (check_screen("yast2-migration-conflicts", 15)) {


### PR DESCRIPTION
Following tests were failed because the time was not enough, lengthen it to fix them:
 
https://openqa.suse.de/tests/524682#step/yast2_migration/19
https://openqa.suse.de/tests/524683#step/yast2_migration/18
https://openqa.suse.de/tests/524685#step/yast2_migration/21
https://openqa.suse.de/tests/524684#step/yast2_migration/20