### PR TITLE
Replace geo addon name to its product name

### DIFF
--- a/tests/console/zypper_lr.pm
+++ b/tests/console/zypper_lr.pm
@@ -60,8 +60,9 @@ sub run() {
         my @addons_keys   = split(/,/, get_var('ADDONS',   ''));
         my @addonurl_keys = split(/,/, get_var('ADDONURL', ''));
         my $scc_addon_str = '';
-        foreach (split(/,/, get_var('SCC_ADDONS', ''))) {
-            $scc_addon_str .= "SLE-" . uc($_) . ',';
+        for my $scc_addon (split(/,/, get_var('SCC_ADDONS', ''))) {
+            $scc_addon =~ s/geo/ha-geo/ if ($scc_addon eq 'geo');
+            $scc_addon_str .= "SLE-" . uc($scc_addon) . ',';
         }
         my @scc_addons_keys = split(/,/, $scc_addon_str);
         @h_addons{@addons_keys}         = ();


### PR DESCRIPTION
We usually use 'geo' as scc addon name in tests. To verify its scc online source, we have to replace 'geo' to product name 'ha-geo'.
failed test:
https://openqa.suse.de/tests/524243#step/zypper_lr/24
verified test:
http://147.2.207.208/tests/73#step/zypper_lr/39
