### PR TITLE
Give more time to against slow downloading and installing

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -315,7 +315,7 @@ sub fully_patch_system {
     # first run, possible update of packager -- exit code 103
     zypper_call('patch --with-interactive -l', exitcode => [0, 102, 103]);
     # second run, full system update
-    zypper_call('patch --with-interactive -l', exitcode => [0, 102], timeout => 2500);
+    zypper_call('patch --with-interactive -l', exitcode => [0, 102], timeout => 3500);
 }
 
 sub workaround_type_encrypted_passphrase {


### PR DESCRIPTION
Sometimes zypper fully patch failed due to occasionally slow downloading or installing like following tests:
https://openqa.suse.de/tests/525106#step/zypper_patch/3
https://openqa.suse.de/tests/525297#step/zypper_patch/3
Give more time to avoid this kind failure.