### PR TITLE
reconnect_s390: Make reboot more robust

### DIFF
--- a/tests/installation/reconnect_s390.pm
+++ b/tests/installation/reconnect_s390.pm
@@ -18,6 +18,8 @@ use warnings;
 sub run() {
     my $self = shift;
 
+    my $login_ready = qr/Welcome to SUSE Linux Enterprise Server.*\(tty/;
+
     # different behaviour for z/VM and z/KVM
     if (check_var('BACKEND', 's390x')) {
 
@@ -27,7 +29,7 @@ sub run() {
 
         # 'wait_serial' implementation for x3270
         console('x3270')->expect_3270(
-            output_delim => qr/Welcome to SUSE Linux Enterprise Server/,
+            output_delim => $login_ready,
             timeout      => 300
         );
 
@@ -37,7 +39,7 @@ sub run() {
         select_console('iucvconn');
     }
     else {
-        wait_serial("Welcome to SUSE Linux Enterprise Server", 300) || die "System couldn't boot";
+        wait_serial($login_ready, 300) || die "System couldn't boot";
     }
 
     if (!check_var('DESKTOP', 'textmode')) {


### PR DESCRIPTION
Since kernel-parameter 'quiet' was removed, some tests failed because
wait_serial matched to early

related poo: https://progress.opensuse.org/issues/13014
local verfication: http://opeth.suse.de/tests/3099