### PR TITLE
reconnect_s390: Fix broken regexp for zVM

### DIFF
--- a/tests/installation/reconnect_s390.pm
+++ b/tests/installation/reconnect_s390.pm
@@ -18,7 +18,7 @@ use warnings;
 sub run() {
     my $self = shift;
 
-    my $login_ready = qr/Welcome to SUSE Linux Enterprise Server.*\(tty/;
+    my $login_ready = qr/Welcome to SUSE Linux Enterprise Server.*\(s390x\)/;
 
     # different behaviour for z/VM and z/KVM
     if (check_var('BACKEND', 's390x')) {


### PR DESCRIPTION
the previous fix for zKVM unfortunately broke zVM installation