### PR TITLE
Use Ext4 loop device for tmp in ltp-pan

### DIFF
--- a/tests/toolchain/gcc5_C_compilation.pm
+++ b/tests/toolchain/gcc5_C_compilation.pm
@@ -18,12 +18,20 @@ sub run() {
     my $package = data_url('toolchain/ltp-full-20160510.tar.xz');
     script_run "wget $package";
     script_run 'tar xJf ltp-full-20160510.tar.xz';
+
+    # Some test cases do not play nicely with Btrfs. As we are testing
+    # syscalls and not filesystem, workaroung involving Ext4 should be OK.
+    assert_script_run 'dd if=/dev/zero of=/tmp/tmpdir.loop bs=1M count=128';
+    assert_script_run 'mkfs.ext4 -F /tmp/tmpdir.loop';
+    assert_script_run 'mkdir /tmp/tmpdir';
+    assert_script_run 'mount /tmp/tmpdir.loop /tmp/tmpdir -o loop';
+
     script_run 'pushd ltp-full-20160510';
     assert_script_run './configure 2>&1 | tee /tmp/configure.log; if [ ${PIPESTATUS[0]} -ne 0 ]; then false; fi',                            600;
     assert_script_run 'make -j$(getconf _NPROCESSORS_ONLN) all 2>&1 | tee /tmp/make_all.log; if [ ${PIPESTATUS[0]} -ne 0 ]; then false; fi', 3600;
     assert_script_run 'make install 2>&1 | tee /tmp/make_install.log; if [ ${PIPESTATUS[0]} -ne 0 ]; then false; fi',                        600;
     script_run 'pushd /opt/ltp/';
-    assert_script_run './runltp -f syscalls 2>&1 | tee /tmp/runltp.log; if [ ${PIPESTATUS[0]} -ne 0 ]; then false; fi', 2000;
+    assert_script_run './runltp -f syscalls -d /tmp/tmpdir 2>&1 | tee /tmp/runltp.log; if [ ${PIPESTATUS[0]} -ne 0 ]; then false; fi', 2000;
     save_screenshot;
     script_run 'popd';
     script_run 'popd';
@@ -36,15 +44,15 @@ sub test_flags() {
 sub post_fail_hook() {
     my $self = shift;
 
-    script_run 'cat output/*.failed';    # print which tests failed
-    script_run 'mv /opt/ltp/output/*.failed /opt/ltp/output/ltp_tests_failed.list';
-    upload_logs '/opt/ltp/output/ltp_tests_failed.list';
+    script_run 'tar cvvfJ ltp-run-outputdir.tar.xz /opt/ltp/output/';
+    upload_logs 'ltp-run-outputdir.tar.xz';
     upload_logs '/tmp/configure.log';
     upload_logs '/tmp/make_all.log';
     upload_logs '/tmp/make_install.log';
     upload_logs '/tmp/runltp.log';
     $self->export_logs();
     script_run 'cd';
+    script_run 'umount /tmp/tmpdir';
 }
 
 1;


### PR DESCRIPTION
Some test cases fail when 'tmp' directory is on Btrfs. This change adds
custom directory to LTP runner which is mounted from Ext4 loop device.

Verification run: http://assam.suse.cz/tests/2804#step/gcc5_C_compilation/23.