### PR TITLE
Get logs if boot ends in emergency mode/dracut shell

### DIFF
--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -23,7 +23,15 @@ sub run() {
     }
 
     if (get_var("NOAUTOLOGIN") || get_var("IMPORT_USER_DATA")) {
-        assert_screen 'displaymanager', 200;
+        assert_screen [qw/displaymanager emergency-shell emergency-mode/], 200;
+        if (match_has_tag('emergency-shell')) {
+            # get emergency shell logs for bug, scp doesn't work
+            script_run "cat /run/initramfs/rdsosreport.txt > /dev/$serialdev";
+        }
+        elsif (match_has_tag('emergency-mode')) {
+            type_password;
+            send_key 'ret';
+        }
         if (get_var('DESKTOP_MINIMALX_INSTONLY')) {
             # return at the DM and log in later into desired wm
             return;


### PR DESCRIPTION
In case of emergency mode, as I have seen two different types of emergency mode, log in to export logs or export logs to ttyS0 as in that shell scp doesn't work

scp doesn't work
https://openqa.suse.de/tests/526326#step/first_boot/3
test
http://10.100.98.90/tests/3027#step/first_boot/7

login
https://openqa.suse.de/tests/526901#step/first_boot/6