### PR TITLE
Support media installation in svirt bootloader

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -238,6 +238,7 @@ sub init_consoles {
                 password => $testapi::password
             });
         $self->add_console('install-shell', 'tty-console', {tty => 2});
+        $self->add_console('installation',  'tty-console', {tty => check_var('VIDEOMODE', 'text') ? 1 : 7});
         $self->add_console('root-console',  'tty-console', {tty => 2});
         $self->add_console('user-console',  'tty-console', {tty => 4});
         $self->add_console('log-console',   'tty-console', {tty => 5});

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -306,20 +306,23 @@ sub load_boot_tests() {
     if (get_var("OFW")) {
         loadtest "installation/bootloader_ofw.pm";
     }
-    elsif (get_var("UEFI") || is_jeos) {
-        if (check_var("BACKEND", "svirt")) {
-            if (check_var("VIRSH_VMM_FAMILY", "hyperv")) {
-                loadtest "installation/bootloader_hyperv.pm";
-            }
-            else {
-                loadtest "installation/bootloader_svirt.pm";
-            }
+    elsif (check_var("BACKEND", "svirt")) {
+        if (check_var("VIRSH_VMM_FAMILY", "hyperv")) {
+            loadtest "installation/bootloader_hyperv.pm";
+        }
+        else {
+            loadtest "installation/bootloader_svirt.pm";
         }
         # TODO: rename to bootloader_grub2
         # Unless GRUB2 supports framebuffer on Xen PV (bsc#961638), grub2 tests
         # has to be skipped there.
-        if (!(check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux'))) {
-            loadtest "installation/bootloader_uefi.pm";
+        if (get_var("UEFI") || is_jeos) {
+            if (!(check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux'))) {
+                loadtest "installation/bootloader_uefi.pm";
+            }
+        }
+        else {
+            loadtest "installation/bootloader.pm";
         }
     }
     elsif (uses_qa_net_hardware()) {
@@ -463,7 +466,7 @@ sub load_inst_tests() {
         loadtest "installation/start_install.pm";
     }
     loadtest "installation/install_and_reboot.pm";
-    if (check_var('BACKEND', 'svirt')) {
+    if (check_var('BACKEND', 'svirt') and check_var('ARCH', 's390x')) {
         # on svirt we need to redefine the xml-file to boot the installed kernel
         loadtest "installation/redefine_svirt_domain.pm";
     }


### PR DESCRIPTION
Previously only FTP installation and JeOS deployment were supported for
'svirt' backend's bootloader. Now installation from ISO media is
supported as well.

This require separate PR in os-autoinst which adds cdrom support to
libvirt's XML VM descriptions.

Verification run: http://assam.suse.cz/tests/2834.
Needs: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/1755.