### PR TITLE
Enable firewall after updating openSUSE 13.1 image (boo#977659)

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -354,6 +354,14 @@ sub load_fixup_network() {
 
 }
 
+sub load_fixup_firewall() {
+    # The openSUSE 13.1 GNOME disk image has the firewall disabled
+    # Upon upgrading to a new system the service state is supposed to remain as pre-configured
+    # If the service is disabled here, we enable it here
+    return unless check_var('HDDVERSION', 'openSUSE-13.1-gnome');
+    loadtest 'fixup/enable_firewall.pm';
+}
+
 sub load_consoletests() {
     if (consolestep_is_applicable()) {
         loadtest "console/consoletest_setup.pm";
@@ -978,6 +986,7 @@ else {
         || load_slenkins_tests())
     {
         load_fixup_network();
+        load_fixup_firewall();
         load_system_update_tests();
         load_rescuecd_tests();
         load_consoletests();

--- a/tests/fixup/enable_firewall.pm
+++ b/tests/fixup/enable_firewall.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "x11test";
+use strict;
+use testapi;
+
+sub run() {
+    my $self = shift;
+
+    x11_start_program('xterm');
+    assert_script_sudo('SuSEfirewall2 on');
+    send_key "alt-f4";
+}
+
+sub test_flags() {
+    return {milestone => 1};
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Local test run: http://dimstar.ddns.net/tests/199#

Alternatively we have to change the disk image of 13.1