### PR TITLE
Print scc/smt reops of source products to serial

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -249,8 +249,13 @@ sub yast_scc_registration {
     my $ret = wait_serial "yast-scc-done-\\d+-", $timeout;
     die "yast scc failed" unless (defined $ret && $ret =~ /yast-scc-done-0-/);
 
-    script_run 'zypper lr';
-    assert_screen 'scc-repos-listed';
+    if (get_var('ONLINE_MIGRATION')) {
+        script_run("zypper lr -u | tee /dev/$serialdev");
+    }
+    else {
+        script_run 'zypper lr';
+        assert_screen 'scc-repos-listed';
+    }
 }
 
 1;


### PR DESCRIPTION
Since we have plenty of source products with various addon
combinations need to be registered via scc or smt before
online migration, it is not possible to assert theri repo list
to check validity.
like this example:
https://openqa.suse.de/tests/527871#step/register_system/34

Currently print scc/smt repos after registration to serial and
it is easy to read and check by viewing result from wait_serial.
It is a temporary solution to check scc/smt repos in case of
online migration testing during RC1 phrase.

We already have zypper_lr.pm to check repos validity for installed
and migrated system, I will do some extra works in RC2 phrase to
recall it to check repo validity for source system registered via
scc and smt.