### PR TITLE
Aarch64 and JeOS should use UEFI bootloader

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -303,6 +303,9 @@ sub load_boot_tests() {
     if (get_var("OFW")) {
         loadtest "installation/bootloader_ofw.pm";
     }
+    elsif (get_var("UEFI") || is_jeos) {
+        loadtest "installation/bootloader_uefi.pm";
+    }
     elsif (check_var("BACKEND", "svirt")) {
         if (check_var("VIRSH_VMM_FAMILY", "hyperv")) {
             loadtest "installation/bootloader_hyperv.pm";


### PR DESCRIPTION
Commit 5fe1f66aa6b02b23ae6db9278132d600e0df83bd errorneously removed `bootloader_uefi` from aarch64 and jeos (both use UEFI=1) chain. This commit readds it to it's former place in `main.pm`.