### PR TITLE
Warning for migrations with low disk space

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -374,6 +374,9 @@ sub load_inst_tests() {
     }
     if (get_var('UPGRADE')) {
         loadtest "installation/upgrade_select.pm";
+        if (check_var("UPGRADE", "LOW_SPACE")) {
+            loadtest "installation/disk_space_fill.pm";
+        }
     }
     if (get_var('SCC_REGISTER', '') eq 'installation') {
         loadtest "installation/scc_registration.pm";
@@ -463,6 +466,9 @@ sub load_inst_tests() {
     }
     if (installyaststep_is_applicable()) {
         loadtest "installation/installation_overview.pm";
+        if (check_var("UPGRADE", "LOW_SPACE")) {
+            loadtest "installation/disk_space_release.pm";
+        }
         if (ssh_key_import) {
             loadtest "installation/ssh_key_setup.pm";
         }

--- a/tests/installation/disk_space_fill.pm
+++ b/tests/installation/disk_space_fill.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use strict;
+use warnings;
+use base "y2logsstep";
+use testapi;
+
+# poo#11438
+sub run() {
+    # After mounting partitions leave only 100M available
+    select_console('install-shell');
+    my $avail = script_output "btrfs fi usage -m /mnt | awk '/Free/ {print \$3}' | cut -d'.' -f 1";
+    assert_script_run "fallocate -l " . ($avail - 100) . "m /mnt/FILL_DISK_SPACE";
+    select_console('installation');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -26,6 +26,10 @@ sub run() {
     # preserve it for the video
     wait_idle 10;
 
+    if (get_var("UPGRADE", "LOW_SPACE") ne "LOW_SPACE") {
+        assert_screen "no-packages-warning";
+    }
+
     # Check autoyast has been removed in SP2 (fate#317970)
     if (get_var("SP2ORLATER") && !check_var("INSTALL_TO_OTHERS", 1)) {
         if (check_var('VIDEOMODE', 'text')) {


### PR DESCRIPTION
fate#11438

If variable UPGRADE=LOW_SPACE is present allocate most of the disk
space before installation. Warning should be visible in installation
overview.
Then parse required size from warning message and free disk space
accordingly. Refresh overview screen and if warning message disappear
start installation.

Local run:
SP0 - http://dhcp91.suse.cz/tests/2337
SP1 - http://dhcp91.suse.cz/tests/2336

Requires:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/208