### PR TITLE
Pick bootloader_zkvm on s390x instead of svirt one

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -306,7 +306,7 @@ sub load_boot_tests() {
     elsif (get_var("UEFI") || is_jeos) {
         loadtest "installation/bootloader_uefi.pm";
     }
-    elsif (check_var("BACKEND", "svirt")) {
+    elsif (check_var("BACKEND", "svirt") && !check_var("ARCH", "s390x")) {
         if (check_var("VIRSH_VMM_FAMILY", "hyperv")) {
             loadtest "installation/bootloader_hyperv.pm";
         }


### PR DESCRIPTION
Commit 5fe1f66aa6b02b23ae6db9278132d600e0df83bd inadvertly changed
bootloader for zkvm, it run bootloader_svirt instead. This change
reverts this behavior.