### PR TITLE
Fix screenlock detection when it takes some time to lock

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -330,7 +330,11 @@ sub workaround_type_encrypted_passphrase {
 sub ensure_unlocked_desktop {
     my ($tags) = @_;
     $tags //= [qw/generic-desktop/];
-    send_key "backspace";    # deactivate blanking
+    # deactivate blanking
+    send_key "backspace";
+    # the screenlock can take some time to show up when it is already
+    # triggered
+    wait_still_screen(10);
     push @$tags, 'screenlock';
     assert_screen($tags);
     if (!match_has_tag 'screenlock') {

--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -41,7 +41,6 @@ sub run() {
 
     if (!check_var("DESKTOP", "textmode")) {
         select_console('x11');
-        wait_still_screen(2);
         ensure_unlocked_desktop [qw/displaymanager generic-desktop/];
         if (get_var("DESKTOP_MINIMALX_INSTONLY")) {
             # Desired wm was just installed and needs x11_login

--- a/tests/online_migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/online_migration/sle12_online_migration/yast2_migration.pm
@@ -20,7 +20,6 @@ sub run {
     }
     else {
         select_console 'x11';
-        wait_still_screen;
         ensure_unlocked_desktop;
         mouse_hide(1);
         assert_screen 'generic-desktop';


### PR DESCRIPTION
After switching back to the graphical console the screenlock may take some
time to actually show up. If the screen check happens too fast, a logged in
session is detected but the system is not responsive until the lockscreen
shows up which has to be unlocked, hence the addition of the wait_still_screen
within the unlock method. Therefore also we don't need any wait_still_screen
in before.

Verification runs:
 * http://lord.arch/tests/3828#step/consoletest_finish/7 when the screen is
   locked after some seconds
 * http://lord.arch/tests/3829#step/consoletest_finish/7 when the lockscreen
   shows up but is in grace period where no password needs to be entered, yet

Related progress issue: https://progress.opensuse.org/issues/13258