### PR TITLE
Default ssh keys must exist to trigger import

### DIFF
--- a/tests/x11/ssh_key_check.pm
+++ b/tests/x11/ssh_key_check.pm
@@ -15,6 +15,7 @@ sub run() {
     x11_start_program("xterm -geometry 150x45+5+5");
     become_root;
     script_run 'cd /etc/ssh';
+    script_run 'touch ssh_host_key ssh_host_key.pub';    # this file must exist to trigger ssh key import
     script_run 'echo "SSHHOSTKEYFILE" | tee /etc/ssh/*key*';
     script_run 'echo "SSHHOSTPUBKEYFILE" | tee /etc/ssh/*key.pub*';
     script_run "cat /etc/ssh/*key* | tee /dev/$serialdev";


### PR DESCRIPTION
import ssh host key link is present only when /etc/ssh/ssh_host_key and /etc/ssh/ssh_host_key.pub exist

do not import ssh key
http://10.100.98.90/tests/3066
import ssh key
http://10.100.98.90/tests/3067