### PR TITLE
use zypper_call to run zypper commands

### DIFF
--- a/tests/console/http_srv.pm
+++ b/tests/console/http_srv.pm
@@ -11,6 +11,7 @@
 use strict;
 use base "consoletest";
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
@@ -18,7 +19,7 @@ sub run() {
     select_console 'root-console';
 
     # Install apache2
-    assert_script_run "zypper -n -q in apache2";
+    zypper_call("in apache2");
 
     # After installation, apache2 is disabled
     assert_script_run "systemctl show -p UnitFileState apache2.service|grep UnitFileState=disabled";

--- a/tests/console/mysql_srv.pm
+++ b/tests/console/mysql_srv.pm
@@ -11,14 +11,15 @@
 use strict;
 use base "consoletest";
 use testapi;
+use utils;
 
 sub run() {
     my $self = shift;
 
     select_console 'root-console';
 
-    # Install apache2
-    script_run "zypper -n -q in mysql", 10;
+    # Install mysql
+    zypper_call("in mysql");
 
     # After installation, mysql is disabled
     script_run "systemctl status mysql.service | tee /dev/$serialdev -", 0;


### PR DESCRIPTION
The mysql_srv test calls zypper with a low timeout value. This often produces -not fatal- failures (for example, rwmanosvm2.suse.cz/tests/635#step/mysql_srv/2 ).

It seems safer to take advantage of the 'zypper_call' function. In this case, the script doesn't need to "worry" about the timeout value and could benefit from further development of that function (e.g., timeout depending on zypper command). However, it will require the utils library.