### PR TITLE
Only activate+forced_recompute yields encrypted system

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -28,6 +28,7 @@ our @EXPORT = qw/
   kdestep_is_applicable
   consolestep_is_applicable
   rescuecdstep_is_applicable
+  bootencryptstep_is_applicable
   remove_desktop_needles
   check_env
   ssh_key_import
@@ -210,6 +211,12 @@ sub consolestep_is_applicable {
 
 sub rescuecdstep_is_applicable {
     return get_var("RESCUECD");
+}
+
+sub bootencryptstep_is_applicable {
+    # activating an existing encrypted volume but not forcing recompute does
+    # *not* yield an encrypted system, see bsc#993247 fate#321208
+    return get_var('ENCRYPT') && !(get_var('ENCRYPT_ACTIVATE_EXISTING') && !get_var('ENCRYPT_FORCE_RECOMPUTE'));
 }
 
 sub ssh_key_import {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -326,7 +326,7 @@ sub load_inst_tests() {
 sub load_reboot_tests() {
     if (installyaststep_is_applicable()) {
         loadtest "installation/grub_test.pm";
-        if (get_var("ENCRYPT")) {
+        if (bootencryptstep_is_applicable) {
             loadtest "installation/boot_encrypt.pm";
         }
         if ((snapper_is_applicable()) && get_var("BOOT_TO_SNAPSHOT")) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -512,7 +512,7 @@ sub load_reboot_tests() {
                 loadtest "installation/boot_into_snapshot.pm";
             }
         }
-        if (get_var("ENCRYPT")) {
+        if (bootencryptstep_is_applicable) {
             loadtest "installation/boot_encrypt.pm";
         }
         loadtest "installation/first_boot.pm";


### PR DESCRIPTION
Also see bsc#993247 and newly created fate#321208

Related progress issue: https://progress.opensuse.org/issues/12782