### PR TITLE
svirt bootloader updates for KVM and Xen PV, HVM

### DIFF
--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -40,6 +40,18 @@ sub run() {
     assert_screen "grub2", 60;
     # prevent grub2 timeout; 'esc' would be cleaner, but grub2-efi falls to the menu then
     send_key 'up';
+
+    # BSC#997263 - VMware screen resolution defaults to 800x600
+    # By default VMware starts with Grub2 in 640x480 mode and then boots the system to
+    # 800x600. To avoid that we need to reconfigure Grub's gfxmode and gfxpayload.
+    # Permanent - system-wise - solution is in console/consoletest_setup.pm.
+    if (check_var('VIRSH_VMM_FAMILY', 'vmware')) {
+        send_key 'c';
+        type_string "gfxmode=1024x768x32; gfxpayload=1024x768x32; terminal_output console; terminal_output gfxterm\n";
+        wait_still_screen;
+        send_key 'esc';
+    }
+
     if (get_var("BOOT_TO_SNAPSHOT")) {
         send_key_until_needlematch("boot-menu-snapshot", 'down', 10, 5);
         send_key 'ret';

--- a/tests/installation/redefine_svirt_domain.pm
+++ b/tests/installation/redefine_svirt_domain.pm
@@ -15,13 +15,35 @@ sub run() {
 
     my $svirt = console('svirt');
 
-    $svirt->change_domain_element(os => initrd  => undef);
-    $svirt->change_domain_element(os => kernel  => undef);
-    $svirt->change_domain_element(os => cmdline => undef);
+    if (check_var('ARCH', 's390x') or get_var('NETBOOT')) {
+        $svirt->change_domain_element(os => initrd => undef);
+        $svirt->change_domain_element(os => kernel => undef);
+        if (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')) {
+            $svirt->change_domain_element(os => kernel => "/usr/lib/grub2/x86_64-xen/grub.xen");
+        }
+        $svirt->change_domain_element(os => cmdline => undef);
+    }
 
     $svirt->change_domain_element(on_reboot => undef);
 
+    if (!check_var('ARCH', 's390x')) {
+        $svirt->change_domain_element(on_reboot => "restart");
+    }
+
     $svirt->define_and_start;
+
+    # On svirt backend we need to re-connect to 'sut' console which got
+    # unusable after post-install shutdown. reset_consoles() makes
+    # re-connect with credentials to 'sut' console possible.
+    if (!check_var('ARCH', 's390x')) {
+        reset_consoles;
+        # If we connect to 'sut' VNC display "too early" the VNC server won't be
+        # ready we will be left with a blank screen.
+        if (check_var('VIRSH_VMM_FAMILY', 'vmware')) {
+            sleep 2;
+        }
+        select_console 'sut';
+    }
 }
 
 1;

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -63,6 +63,12 @@ sub run() {
 
     assert_screen 'linux-login';
 
+    # Without this login name and password won't get to the system. The
+    # get lost somewhere. Applies for all systems installed via svirt.
+    if (check_var('BACKEND', 'svirt') and !check_var('ARCH', 's390x')) {
+        wait_idle;
+    }
+
     select_console 'root-console';
 
     assert_script_run "useradd -m $username -c '$realname'";    # create user account


### PR DESCRIPTION
With this update 12 SP1 JeOS and SLES 12 SP2 DVD install and network
install (aka direct boot) are supported with svirt backend on KVM and
Xen (PV and HVM).

Changes:

* support for direct boot on KVM and Xen with TEXTMODE and
EXTRABOOTPARAMS.

* direct boot does not use "detached" VNC, uses the 'sut' console.

* all VMs instances under svirt backend are destroyed after installation
and redefined with consoles resetted (they tended to hang in some
cases).

* `wait_idle()` had to be added to place of first encounter with the
installed system otherwise the credential wouldn't get to console.

Jobs fail at `yast2_lan` (a network setup issue, I guess) others on
`zypper_lr` (incorrect FLAVOR). But atm I focus on installation and
first boot. I will be resolved later.

Due to https://github.com/os-autoinst/os-autoinst/issues/565 and
https://github.com/os-autoinst/os-autoinst/issues/566 graphical
installation is not possible right now (workarounds are doable,
though).

**JeOS 12 SP1**
* KVM (UEFI): http://assam.suse.cz/tests/3043
* KVM (BIOS): http://assam.suse.cz/tests/3062
* Xen HVM: http://assam.suse.cz/tests/3049
* Xen PV: http://assam.suse.cz/tests/3056

**SLES 12 SP2 RC2 - Direct boot**
* Xen PV: http://assam.suse.cz/tests/3050
* Xen HVM: http://assam.suse.cz/tests/3058
* KVM (BIOS): http://assam.suse.cz/tests/3052

**SLES 12 SP2 RC2 - DVD install (Textual YaST)**
* KVM (BIOS): http://assam.suse.cz/tests/3055
* Xen PV: http://assam.suse.cz/tests/3053
* Xen HVM: http://assam.suse.cz/tests/3054

**Broken**

**SLES 12 SP2 RC2 - DVD install (Textual YaST)**
* KVM (UEFI): http://assam.suse.cz/tests/3059

**SLES 12 SP2 RC2 - DVD install (Graphical YaST)**
* KVM (BIOS): http://assam.suse.cz/tests/3060
* KVM (UEFI): http://assam.suse.cz/tests/3061

This PR requires: https://github.com/os-autoinst/os-autoinst/pull/575.