### PR TITLE
smt: 'smt-sync' involving repo update might take longer than 3 minutes

### DIFF
--- a/tests/x11/smt.pm
+++ b/tests/x11/smt.pm
@@ -48,7 +48,7 @@ sub run() {
         send_key 'alt-n';
         wait_serial("yast2-smt-wizard-0", 200) || die 'smt wizard failed';
     }
-    assert_script_run 'smt-sync', 200;
+    assert_script_run 'smt-sync', 600;
     assert_script_run 'smt-repos';
     type_string "killall xterm\n";
 }


### PR DESCRIPTION
See https://openqa.suse.de/tests/537511#step/smt/18