### PR TITLE
Use postgresql94server_sle11.pm for SLE11

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -509,7 +509,7 @@ sub load_consoletests() {
         }
         loadtest "console/postgresql94.pm";
         if (is_server) {
-            loadtest "console/postgresql94server.pm";
+            loadtest "console/postgresql94server_sle11.pm";
         }
         loadtest "console/consoletest_finish.pm";
     }


### PR DESCRIPTION
The postgresql94server test was renamed to *_sle11.pm