### PR TITLE
wait_still_screen to avoid problems on login, especially xdm

### DIFF
--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -37,6 +37,7 @@ sub run() {
             return;
         }
         mouse_hide();
+        wait_still_screen;
         if (get_var('DM_NEEDS_USERNAME')) {
             type_string $username;
         }
@@ -50,7 +51,6 @@ sub run() {
             assert_and_click "sddm-password-input";
         }
         else {
-            wait_still_screen;
             send_key "ret";
             if (!check_screen "displaymanager-password-prompt") {
                 record_soft_failure;


### PR DESCRIPTION
To resolve https://progress.opensuse.org/issues/12852
and to avoid https://progress.opensuse.org/issues/13574

root cause is because a DM, especially xdm can load up while systemd is still booting other things, the wait_still_screen is a nice natural pause (plus in the case of xdm also ensures nothing is being written to the visible log on the screen)

Validation Run: https://openqa.suse.de/tests/538705#
