### PR TITLE
Add case for local autoyast profile /root/autoupg.xml

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -166,7 +166,7 @@ sub bootmenu_network_source {
 
 sub specific_bootmenu_params {
     my $args = "";
-    if (get_var("AUTOYAST") || get_var("AUTOUPGRADE")) {
+    if (get_var("AUTOYAST") || get_var("AUTOUPGRADE") && get_var("AUTOUPGRADE") ne 'local') {
         my $netsetup = " ifcfg=*=dhcp";    #need this instead of netsetup as default, see bsc#932692
         $netsetup = " " . get_var("NETWORK_INIT_PARAM") if defined get_var("NETWORK_INIT_PARAM");    #e.g netsetup=dhcp,all
         $netsetup = " netsetup=dhcp,all" if defined get_var("USE_NETSETUP");                         #netsetup override for sle11

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1130,7 +1130,7 @@ elsif (ssh_key_import) {
     loadtest "x11/ssh_key_verify.pm";
 }
 else {
-    if (get_var("AUTOYAST")) {
+    if (get_var("AUTOYAST") || get_var("AUTOUPGRADE")) {
         load_boot_tests();
         load_autoyast_tests();
         load_reboot_tests();


### PR DESCRIPTION
Autoupgrade profile can be located on local disk instead of defining it via linuxrc
https://www.suse.com/documentation/sles-12/book_sle_deployment/data/sec_update_auto_run.html

test
http://10.100.98.90/tests/3110#step/bootloader/6