### PR TITLE
VLC: Click the play button

### DIFF
--- a/tests/x11/vlc.pm
+++ b/tests/x11/vlc.pm
@@ -30,8 +30,7 @@ sub run() {
     assert_screen "vlc-network-window";
     send_key "backspace";
     type_string autoinst_url . "/data/Big_Buck_Bunny_8_seconds_bird_clip.ogv";
-    send_key "alt-p";
-    send_key "ret";
+    assert_and_click "vlc-play_button";
     assert_screen "vlc-done-playing";
     send_key "ctrl-q";
 }


### PR DESCRIPTION
ALT-P is double occupied inside the application (the play button itself as well as
'Play' inside the drop down of said button.

Let's do the same in the test as users would do and click the button