### PR TITLE
virtualization: replace type_string with script_run for stable type_string behavior

### DIFF
--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -17,7 +17,7 @@ use virt_utils;
 sub install_package() {
     my $qa_server_repo = get_var('QA_HEAD_REPO', '');
     if ($qa_server_repo) {
-        type_string "zypper --non-interactive rr server-repo\n";
+        script_run "zypper --non-interactive rr server-repo";
         assert_script_run("zypper --non-interactive --no-gpg-check -n ar -f '$qa_server_repo' server-repo");
     }
     else {

--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -19,10 +19,13 @@ sub reboot_and_wait_up() {
     my $self           = shift;
     my $reboot_timeout = shift;
 
+    wait_idle 1;
     select_console('root-console');
+    wait_idle 1;
     type_string("/sbin/reboot\n");
+    wait_idle 1;
     reset_consoles;
-    sleep 2;
+    wait_idle 1;
     &login_console::login_to_console($reboot_timeout);
 
 }

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -103,7 +103,7 @@ sub execute_script_run($$) {
 sub push_junit_log($) {
     my ($self, $junit_content) = @_;
 
-    type_string "echo \'$junit_content\' > /tmp/output.xml\n";
+    script_run "echo \'$junit_content\' > /tmp/output.xml";
     parse_junit_log("/tmp/output.xml");
 }
 

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -24,8 +24,8 @@ our @EXPORT = qw(set_serialdev setup_console_in_grub repl_repo_in_sourcefile);
 
 sub set_serialdev() {
     if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
-        type_string("clear\n");
-        type_string("cat /etc/SuSE-release \n");
+        script_run("clear");
+        script_run("cat /etc/SuSE-release");
         save_screenshot;
         assert_screen([qw/on_host_sles_12_sp2_or_above on_host_lower_than_sles_12_sp2/], 5);
         if (match_has_tag("on_host_sles_12_sp2_or_above")) {
@@ -38,7 +38,7 @@ sub set_serialdev() {
     else {
         $serialdev = "ttyS1";
     }
-    type_string("echo \"Debug info: serial dev is set to $serialdev.\"\n");
+    script_run("echo \"Debug info: serial dev is set to $serialdev.\"");
 }
 
 sub setup_console_in_grub() {
@@ -47,18 +47,18 @@ sub setup_console_in_grub() {
     my $grub_cfg_file     = "/boot/grub2/grub.cfg";
 
     my $cmd = "if [ -d /boot/grub2 ]; then cp $grub_default_file ${grub_default_file}.org; sed -ri '/GRUB_CMDLINE_(LINUX|LINUX_DEFAULT|XEN_DEFAULT)=/ {s/(console|com\\d+)=[^ \"]*//g; /LINUX=/s/\"\$/ console=$serialdev,115200 console=tty\"/;/XEN_DEFAULT=/ s/\"\$/ console=com2,115200\"/;}' $grub_default_file ; fi";
-    type_string("$cmd \n");
+    script_run("$cmd");
     wait_idle 3;
     save_screenshot;
-    type_string("clear; cat $grub_default_file \n");
+    script_run("clear; cat $grub_default_file");
     wait_idle 3;
     save_screenshot;
 
     $cmd = "if [ -d /boot/grub2 ]; then grub2-mkconfig -o $grub_cfg_file; fi";
-    type_string("$cmd \n", 40);
+    script_run("$cmd", 40);
     wait_idle 3;
     save_screenshot;
-    type_string("clear; cat $grub_cfg_file \n");
+    script_run("clear; cat $grub_cfg_file");
     wait_idle 3;
     save_screenshot;
 }


### PR DESCRIPTION
IPMI keyboard driver does not perform stablelly if another type_string is sent before the original type_string finishes its real command running, so use script_run instead to wait it finish.