### PR TITLE
Disable check for low disk space warning

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -26,10 +26,6 @@ sub run() {
     # preserve it for the video
     wait_idle 10;
 
-    if (get_var("UPGRADE", "LOW_SPACE") ne "LOW_SPACE") {
-        assert_screen "no-packages-warning";
-    }
-
     # Check autoyast has been removed in SP2 (fate#317970)
     if (get_var("SP2ORLATER") && !check_var("INSTALL_TO_OTHERS", 1)) {
         if (check_var('VIDEOMODE', 'text')) {


### PR DESCRIPTION
Disable check until proper workflow is explained waiting for reply in
bsc#987813.
Check will be later moved to start_install.pm as there are
workarounds for package conflicts, which have to be applied first.