### PR TITLE
Add a case for gdm session switch

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -626,6 +626,9 @@ sub load_x11tests() {
         loadtest "x11/gnome_tweak_tool.pm";
         loadtest "x11/gnome_terminal.pm";
         loadtest "x11/gedit.pm";
+        if (check_var('VERSION', 'Tumbleweed') || check_var('VERSION', '42.2')) {
+            loadtest "x11/gdm_session_switch.pm";
+        }
     }
     if (kdestep_is_applicable()) {
         loadtest "x11/kate.pm";

--- a/tests/x11/gdm_session_switch.pm
+++ b/tests/x11/gdm_session_switch.pm
@@ -1,0 +1,96 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "x11regressiontest";
+use strict;
+use testapi;
+use utils;
+
+# logout and switch window-manager
+sub switch_wm {
+    mouse_set(1000, 30);
+    assert_and_click "system-indicator";
+    assert_and_click "user-logout-sector";
+    assert_and_click "logout-system";
+    assert_screen "logout-dialogue";
+    send_key "ret";
+    assert_screen "displaymanager";
+    send_key "ret";
+    assert_screen "originUser-login-dm";
+    type_string "$password";
+}
+
+# Smoke test: launch some applications
+sub application_test {
+    x11_start_program "gnome-terminal";
+    assert_screen "gnome-terminal";
+    send_key "alt-f4";
+
+    x11_start_program "nautilus";
+    assert_screen "test-nautilus-1";
+    send_key "alt-f4";
+}
+
+sub run () {
+    my $self = shift;
+
+    # Log out and switch to GNOME Classic
+    assert_screen "generic-desktop";
+    switch_wm;
+    assert_and_click "displaymanager-settings";
+    assert_and_click "dm-gnome-classic";
+    send_key "ret";
+    assert_screen "desktop-gnome-classic", 120;
+    application_test;
+
+    # Log out and switch to SLE Classic
+    switch_wm;
+    assert_and_click "displaymanager-settings";
+    assert_and_click "dm-sle-classic";
+    send_key "ret";
+    assert_screen "desktop-sle-classic", 120;
+    application_test;
+
+    # Log out and switch to icewm
+    switch_wm;
+    assert_and_click "displaymanager-settings";
+    assert_and_click "dm-icewm";
+    send_key "ret";
+    assert_screen "desktop-icewm", 120;
+    # Smoke test: launch some applications
+    send_key "super-spc";
+    wait_still_screen;
+    type_string "gnome-terminal\n";
+    assert_screen "gnome-terminal";
+    send_key "alt-f4";
+    send_key "super-spc";
+    wait_still_screen;
+    type_string "nautilus\n";
+    assert_screen "test-nautilus-1";
+    send_key "alt-f4";
+    wait_still_screen;
+
+    # Log out and switch back to GNOME(default)
+    send_key "ctrl-alt-delete";
+    assert_screen "icewm-session-dialog";
+    send_key "alt-l";
+    wait_still_screen;
+    send_key "alt-o";
+    assert_screen "displaymanager";
+    send_key "ret";
+    assert_screen "originUser-login-dm";
+    type_string "$password";
+    assert_and_click "displaymanager-settings";
+    assert_and_click "dm-gnome";
+    send_key "ret";
+    assert_screen "generic-desktop", 120;
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Testing Result:
http://147.2.212.239/tests/767

openSUSE has shipped SLE-Classic since Leap 42.2, this case will test
gdm session switch among sle-classic, gnome-classic, icewm and gnome.