### PR TITLE
Wait for the last welcome message on s390x console

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -69,10 +69,11 @@ sub wait_boot {
     }
     # reconnect s390
     elsif (check_var('ARCH', 's390x')) {
+        my $login_ready = qr/Welcome to SUSE Linux Enterprise Server.*\(s390x\)/;
         if (check_var('BACKEND', 's390x')) {
 
             console('x3270')->expect_3270(
-                output_delim => qr/Welcome to SUSE Linux Enterprise Server/,
+                output_delim => $login_ready,
                 timeout      => 300
             );
 
@@ -83,7 +84,7 @@ sub wait_boot {
             select_console('iucvconn');
         }
         else {
-            wait_serial("Welcome to SUSE Linux Enterprise Server");
+            wait_serial($login_ready, 300);
         }
 
         # on z/(K)VM we need to re-select a console


### PR DESCRIPTION
POO#13698

Should fix: https://openqa.suse.de/tests/558463#step/crash/7.

This change mirrors changes in `installation/reconnect_s390` as in commit a6b0405e6e06fb4b04e3fd82850b08cb172f76b6 and commit 825dd5672f92457b8ad3c32d390052bfb962899. Untested.