### PR TITLE
Modules do not have release notes

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -40,9 +40,10 @@ sub run() {
     }
     if (@addons) {
         for my $a (@addons) {
-            next if ($a eq 'we');    # https://bugzilla.suse.com/show_bug.cgi?id=931003#c17
+            # no release-notes for WE and all modules
+            next if grep { $a eq $_ } qw(we lgm asmm certm contm pcm tcm wsm);
             send_key_until_needlematch("release-notes-$a", 'right', 4, 60);
-            send_key 'left';         # move back to first tab
+            send_key 'left';     # move back to first tab
             send_key 'left';
             send_key 'left';
             send_key 'left';


### PR DESCRIPTION
While installing the Web and Scripting Module (WSM), openQA fails with
'NO matching needles for release-notes-wsm'. However, this should be
skipped because there is not release note for WSM.

Also, I removed the bugzilla link because this is a comment in a
RESOLVED bug which does not add a lot of information. From what I
understood there is no release note for WE.