### PR TITLE
Disable gdm_session_switch on Tumbleweed

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -626,7 +626,7 @@ sub load_x11tests() {
         loadtest "x11/gnome_tweak_tool.pm";
         loadtest "x11/gnome_terminal.pm";
         loadtest "x11/gedit.pm";
-        if (check_var('VERSION', 'Tumbleweed') || check_var('VERSION', '42.2')) {
+        if (check_var('VERSION', '42.2')) {
             loadtest "x11/gdm_session_switch.pm";
         }
     }


### PR DESCRIPTION
The test relies on a lot of pre-conditions that are not met on Tumbleweed:
* SLE Session does not exist
* GNOME Shell classic is not pre-installed
* ICEWM is supposed to not be pre-installed in the end