### PR TITLE
Enable low space upgrade test on opensuse

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -252,6 +252,9 @@ sub load_inst_tests() {
     }
     if (!get_var("LIVECD") && get_var("UPGRADE")) {
         loadtest "installation/upgrade_select.pm";
+        if (check_var("UPGRADE", "LOW_SPACE")) {
+            loadtest "installation/disk_space_fill.pm";
+        }
         loadtest "installation/upgrade_select_opensuse.pm";
     }
     if (noupdatestep_is_applicable() && get_var("LIVECD")) {
@@ -309,6 +312,9 @@ sub load_inst_tests() {
     }
     if (installyaststep_is_applicable()) {
         loadtest "installation/installation_overview.pm";
+        if (check_var("UPGRADE", "LOW_SPACE")) {
+            loadtest "installation/disk_space_release.pm";
+        }
         if (ssh_key_import) {
             loadtest "installation/ssh_key_setup.pm";
         }

--- a/tests/installation/disk_space_release.pm
+++ b/tests/installation/disk_space_release.pm
@@ -36,7 +36,8 @@ sub run() {
     }
     select_console('installation');
     send_key "alt-b";
-    send_key "alt-n";
+    wait_still_screen;
+    send_key_until_needlematch "inst-overview", "alt-n", 3, 30;
     assert_screen "no-packages-warning";
 }
 

--- a/tests/installation/upgrade_select_opensuse.pm
+++ b/tests/installation/upgrade_select_opensuse.pm
@@ -12,6 +12,14 @@ use strict;
 use base "y2logsstep";
 use testapi;
 
+# Check that installer does not freeze when pressing next
+sub check_bsc997635 {
+    if (!wait_screen_change { send_key $cmd{next} }, 10) {
+        record_soft_failure 'bsc#997635';
+        sleep 30;
+    }
+}
+
 sub run() {
     # offline DVD upgrade may not have network (boo#995771)
     if (!check_var("FLAVOR", "NET") && check_screen('network-not-configured')) {
@@ -29,8 +37,8 @@ sub run() {
         }
         # Bug 881107 - there is 2nd license agreement screen in openSUSE upgrade
         # http://bugzilla.opensuse.org/show_bug.cgi?id=881107
-        if (check_screen('upgrade-license-agreement', 10)) {
-            send_key 'alt-n';
+        if (check_screen('upgrade-license-agreement')) {
+            check_bsc997635;
         }
     }
 


### PR DESCRIPTION
Includes workaround for bsc#997635
Requires: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/106

TW - http://dhcp91.suse.cz/tests/2446 - update_Leap_42.1_gnome
42.2 - http://dhcp91.suse.cz/tests/2449 - update_Leap_42.1_gnome
SP0 - http://dhcp91.suse.cz/tests/2448
SP1 - http://dhcp91.suse.cz/tests/2447

I will not schedule test yet, we need to wait until functionality is ready