### PR TITLE
Do not run 'setterm' on s390x

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -388,8 +388,12 @@ sub activate_console {
         }
         assert_screen "text-logged-in-$user";
         $self->set_standard_prompt($user);
-        # Disable console screensaver
-        $self->script_run("setterm -blank 0");
+
+        # On s390x 'setterm' binary is not present as there's no linux console
+        if (!check_var('ARCH', 's390x')) {
+            # Disable console screensaver
+            $self->script_run("setterm -blank 0");
+        }
     }
 }
 


### PR DESCRIPTION
On s390x there's no `setterm` binary as there's no linux console proper. We should not run `setterm -blank 0` in ssh-xterm anyways. Avoids: http://opeth.suse.de/tests/3648#step/consoletest_setup/3.