### PR TITLE
Moved snapper_cleanup test to run before btrfs qgroup test

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -681,9 +681,9 @@ sub load_extra_test () {
     if (get_var("FILESYSTEM", "btrfs") eq "btrfs") {
         loadtest "console/btrfs_autocompletion.pm";
         if (get_var("NUMDISKS", 0) > 1) {
+            loadtest "console/snapper_cleanup.pm";
             loadtest "console/btrfs_qgroups.pm";
             loadtest "console/btrfs_send_receive.pm";
-            loadtest "console/snapper_cleanup.pm";
         }
     }
 


### PR DESCRIPTION
Moved test snapper_cleanup before "btrfs qgroup" because the quota was too small and the test failed to run with the error: dd failed to open 'data': Read only file system" 