### PR TITLE
Revert accidentally removed assert_screen

### DIFF
--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -29,6 +29,8 @@ sub run() {
         wait_screen_change {
             assert_and_click 'reboot-auth-showtext';                        # Click the 'Show Text' Option to enable the display of the typed text
         };
+        # Check the password is correct
+        assert_screen 'reboot-auth-correct-password';
         # we need to kill ssh for iucvconn here,
         # because after pressing return, the system is down
         prepare_system_reboot;


### PR DESCRIPTION
'ret' is hit too soon then

https://openqa.suse.de/tests/567080#step/reboot_gnome/8