### PR TITLE
Export logs when fail

### DIFF
--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -43,9 +43,15 @@ sub run() {
     wait_boot bootloader_time => 300;
 }
 
+sub post_fail_hook {
+    my $self = shift;
+    $self->export_logs;
+}
+
 sub test_flags() {
     return {important => 1, milestone => 1};
 }
+
 1;
 
 # vim: set sw=4 et:


### PR DESCRIPTION
Make it simple and just wait instead of overengineering
https://openqa.suse.de/tests/569357#step/reboot_gnome/8