### PR TITLE
Make xterm test more robust

### DIFF
--- a/tests/x11/xterm.pm
+++ b/tests/x11/xterm.pm
@@ -11,20 +11,14 @@
 use base "x11test";
 use strict;
 use testapi;
-use utils;
 
 sub run() {
-    my $self = shift;
     mouse_hide(1);
     x11_start_program("xterm");
-    sleep 2;
-    type_string "cd\n";
-    sleep 1;    # go to $HOME (for KDE)
-    clear_console;
+    assert_screen('xterm-started');
     for (1 .. 13) { send_key "ret" }
     type_string "echo If you can see this text xterm is working.\n";
-    sleep 2;
-    assert_screen 'test-xterm-1', 3;
+    assert_screen 'test-xterm-1';
     send_key "alt-f4";
 }
 


### PR DESCRIPTION
Fixing poo#13708
Local run:
SLES: http://dhcp91.suse.cz/tests/2475 (gnome)
TW: http://dhcp91.suse.cz/tests/2476 (kde)