### PR TITLE
Create VM snapshot after JeOS is deployed

### DIFF
--- a/tests/jeos/grub2_gfxmode.pm
+++ b/tests/jeos/grub2_gfxmode.pm
@@ -41,7 +41,7 @@ sub run {
 }
 
 sub test_flags() {
-    return {fatal => 1};
+    return {fatal => 1, milestone => 1};
 }
 
 1;


### PR DESCRIPTION
Previously `sccreg` after `mount_by_label`'s fail run immediatelly after
without reverting to snapshot because there was not snapshot created.

Now if e.g. `mount_by_label` test fails, next test (`sccreg`) starts
from snapshot made in `grub2_gfxmode` test.

```
10:18:01.1733 6194 # Test died:
Mount is by path, UUID or PARTUUID and hence invalid at
/var/lib/openqa/share/tests/sle-12-SP1/tests/jeos/mount_by_label.pm line
28.
test mount_by_label died at /usr/lib/os-autoinst/basetest.pm line 296.
10:18:01.1741 6194 Loading a VM snapshot lastgood
...
10:18:11.5225 6194 ||| starting sccreg tests/jeos/sccreg.pm at
2016-09-16 10:18:11
```

Before: http://assam.suse.cz/tests/3411#step/sccreg/1
After: http://assam.suse.cz/tests/3410#step/sccreg/1