### PR TITLE
fix boot_from_pxe failure to boot into pxe edit prompt

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -35,7 +35,7 @@ sub run() {
         #Numburg
         #send_key_until_needlematch "qa-net-selection-" . get_var('DISTRI') . "-" . get_var("VERSION"), 'down', 30, 3;
         #Don't use send_key_until_needlematch to pick first menu tier as dist network sources might not be ready when openQA is running tests
-        send_key 'esc';
+        send_key "tab";
         assert_screen 'qa-net-boot';
 
         my $image_name = "";


### PR DESCRIPTION
I do not know when the pxe boot process changes. Originally sending 'esc' can go to pxe boot process, but from the latest build result, it does not. Oliver suggests to use "tab", so change the code accordingly. 