### PR TITLE
Fix sysauth failures in Factory and 42.2 beta

### DIFF
--- a/data/sssd-tests/krb/test.sh
+++ b/data/sssd-tests/krb/test.sh
@@ -17,7 +17,7 @@ mkdir -p /tmp/ldap-sssdtest &&
 cp ldap.crt /tmp/ldap-sssdtest.cacrt &&
 cp ldap.crt /tmp/ldap-sssdtest.crt &&
 cp ldap.key /tmp/ldap-sssdtest.key &&
-/usr/sbin/slapd -h 'ldap:///' -f slapd.conf &&
+$SLAPD -h 'ldap:///' -f slapd.conf &&
 ldapadd -x -D 'cn=root,dc=ldapdom,dc=net' -wpass -f db.ldif &> /dev/null &&
 ldappasswd -x -D 'cn=root,dc=ldapdom,dc=net' -wpass -spass 'cn=krbkdc,dc=ldapdom,dc=net' &&
 ldappasswd -x -D 'cn=root,dc=ldapdom,dc=net' -wpass -spass 'cn=krbadm,dc=ldapdom,dc=net' || test_abort 'Failed to prepare LDAP server'
@@ -38,6 +38,10 @@ systemctl unmask krb5kdc kadmind &&
 systemctl start krb5kdc kadmind &&
 kadmin.local -r LDAPDOM.NET -q 'addprinc -x dn="uid=testuser1,ou=UnixUser,dc=ldapdom,dc=net" -pw goodpass testuser1' &> /dev/null &&
 kadmin.local -r LDAPDOM.NET -q 'addprinc -x dn="uid=testuser2,ou=UnixUser,dc=ldapdom,dc=net" -pw goodpass testuser2' &> /dev/null || test_abort 'Failed to create Kerberos principles'
+# SSSD's PAM responder now has trouble reading user password in version 1.14
+# Workaround is discussed in https://lists.fedorahosted.org/archives/list/sssd-users@lists.fedorahosted.org/thread/D3C2DDA7EDIEPZLSWXE53TFY4GGAICRN/
+kadmin.local -r LDAPDOM.NET -q 'modprinc +requires_preauth testuser1' &> /dev/null &&
+kadmin.local -r LDAPDOM.NET -q 'modprinc +requires_preauth testuser2' &> /dev/null &&
 
 test_case 'Start SSSD'
 sssd -f -c sssd.conf || test_fatal 'Failed to start SSSD'

--- a/data/sssd-tests/ldap-nested-groups/test.sh
+++ b/data/sssd-tests/ldap-nested-groups/test.sh
@@ -14,7 +14,7 @@ mkdir -p /tmp/ldap-sssdtest &&
 cp ldap.crt /tmp/ldap-sssdtest.cacrt &&
 cp ldap.crt /tmp/ldap-sssdtest.crt &&
 cp ldap.key /tmp/ldap-sssdtest.key &&
-/usr/sbin/slapd -h 'ldap:///' -f slapd.conf &&
+$SLAPD -h 'ldap:///' -f slapd.conf &&
 sleep 2 &&
 ldapadd -x -D 'cn=root,dc=ldapdom,dc=net' -wpass -f db.ldif &> /dev/null || test_abort 'Failed to prepare LDAP server'
 

--- a/data/sssd-tests/ldap-no-auth/test.sh
+++ b/data/sssd-tests/ldap-no-auth/test.sh
@@ -14,7 +14,7 @@ mkdir -p /tmp/ldap-sssdtest &&
 cp ldap.crt /tmp/ldap-sssdtest.cacrt &&
 cp ldap.crt /tmp/ldap-sssdtest.crt &&
 cp ldap.key /tmp/ldap-sssdtest.key &&
-/usr/sbin/slapd -h 'ldap:///' -f slapd.conf &&
+$SLAPD -h 'ldap:///' -f slapd.conf &&
 sleep 2 &&
 ldapadd -x -D 'cn=root,dc=ldapdom,dc=net' -wpass -f db.ldif &> /dev/null || test_abort 'Failed to prepare LDAP server'
 

--- a/data/sssd-tests/ldap/test.sh
+++ b/data/sssd-tests/ldap/test.sh
@@ -14,7 +14,7 @@ mkdir -p /tmp/ldap-sssdtest &&
 cp ldap.crt /tmp/ldap-sssdtest.cacrt &&
 cp ldap.crt /tmp/ldap-sssdtest.crt &&
 cp ldap.key /tmp/ldap-sssdtest.key &&
-/usr/sbin/slapd -h 'ldap:///' -f slapd.conf &&
+$SLAPD -h 'ldap:///' -f slapd.conf &&
 sleep 2 &&
 ldapadd -x -D 'cn=root,dc=ldapdom,dc=net' -wpass -f db.ldif &> /dev/null || test_abort 'Failed to prepare LDAP server'
 

--- a/data/sssd-tests/testincl.sh
+++ b/data/sssd-tests/testincl.sh
@@ -1,6 +1,9 @@
 # Common features for SSSD testing scenarios
 # Please only use these functions in test case sub-directory
 
+SLAPD="/usr/sbin/slapd"
+[ ! -e "$SLAPD" ] && SLAPD=/usr/lib/openldap/slapd
+
 SSS_RELATED_UNITS='nscd.service nscd.socket krb5kdc.service kadmind.service sssd.service slapd.service'
 
 # Comprehensive list of system-wide configuration files touched by test cases


### PR DESCRIPTION
LDAP binary is now looked for in two locations to cater for the difference between
Leap and Factory.
Enable pre-authentication for users in Kerberos to fix a failure arised with
SSSD 1.14 upgrade. This should fix bsc#990375.