### PR TITLE
Fix yast ftp-server test

### DIFF
--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -1,13 +1,16 @@
 package consoletest;
 use base "opensusebasetest";
+
 use strict;
+use testapi;
 
-# Base class for all openSUSE tests
-
-use testapi ();
+# Base class for all openSUSE console tests
 
 sub post_run_hook {
     my ($self) = @_;
+
+    # start next test in home directory
+    type_string "cd\n";
 
     # clear screen to make screen content ready for next test
     $self->clear_and_verify_console;


### PR DESCRIPTION
Test was failing on:
    bsc#975538 - dsa cerfiticate is ignored - added bug reference
    bsc#694167 - using rsa certificate with dsa_cert_file option - fixed

Also resetting to home directory after console test finishes, as btrfs_send_receive (for example) ends at read-only snapshot.

Local runs:
 - http://dhcp91.suse.cz/tests/2508 - SLES - gnome
 - http://dhcp91.suse.cz/tests/2509 - SLES - sles+extratests
 - http://dhcp91.suse.cz/tests/2510 - TW (kde)