### PR TITLE
Don't flag gdm_session_switch important

### DIFF
--- a/tests/x11/gdm_session_switch.pm
+++ b/tests/x11/gdm_session_switch.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-use base "x11regressiontest";
+use base "x11test";
 use strict;
 use testapi;
 use utils;
@@ -38,8 +38,6 @@ sub application_test {
 }
 
 sub run () {
-    my $self = shift;
-
     # Log out and switch to GNOME Classic
     assert_screen "generic-desktop";
     switch_wm;


### PR DESCRIPTION
Broken for Leap currently:
https://bugzilla.suse.com/show_bug.cgi?id=999655