### PR TITLE
Revert "fix boot_from_pxe failure to boot into pxe edit prompt"

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -35,7 +35,7 @@ sub run() {
         #Numburg
         #send_key_until_needlematch "qa-net-selection-" . get_var('DISTRI') . "-" . get_var("VERSION"), 'down', 30, 3;
         #Don't use send_key_until_needlematch to pick first menu tier as dist network sources might not be ready when openQA is running tests
-        send_key "tab";
+        send_key 'esc';
         assert_screen 'qa-net-boot';
 
         my $image_name = "";


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#1834

pressing 'tab' shows totally different behaviour than pressing 'esc'
With 'tab' you can edit an existing pxe entry (https://openqa.suse.de/tests/584859#step/boot_from_pxe/5)
but with 'esc', and that's what we want to do, we can 'create' a temporary new entry with different sources (https://openqa.suse.de/tests/566343#step/boot_from_pxe/3)

tested manually in pxe-menu