### PR TITLE
Improved zypper_lifecycle test

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -14,23 +14,13 @@ use testapi;
 
 our $date_re = qr/[0-9]{4}-[0-9]{2}-[0-9]{2}/;
 
-sub check_package_lifecycle {
-    my ($package) = @_;
-    my $output = script_output 'zypper lifecycle ' . $package, 300;
-    # https://github.com/nadvornik/zypper-lifecycle/blob/master/test-data/SLES.lifecycle
-    # says it should be
-    #  /$package\s*[0-9.*-]\+\s[0-9]{4}-[0-9]{2}-[0-9]{2}/;
-    # but it's actually
-    die "$package lifecycle entry incorrect" unless $output =~ /$package-\S+\s+$date_re/;
-}
-
 sub run() {
     diag('fate#320597: Introduce \'zypper lifecycle\' to provide information about life cycle of individual products and packages');
     select_console 'user-console';
-    my $output = script_output 'zypper lifecycle', 300;
-    die "Missing header line"                                        unless $output =~ /Product end of support/;
-    die "All packages within base distribution should have same EOL" unless $output =~ /No packages with end of support different from product./;
-    die "Missing link to lifecycle page"                             unless $output =~ qr{\*\) See https://www.suse.com/lifecycle for latest information};
+    my $overview = script_output 'zypper lifecycle', 300;
+    die "Missing header line"                                        unless $overview =~ /Product end of support/;
+    die "All packages within base distribution should have same EOL" unless $overview =~ /No packages with end of support different from product./;
+    die "Missing link to lifecycle page"                             unless $overview =~ qr{\*\) See https://www.suse.com/lifecycle for latest information};
     # Compare to test data from
     # https://github.com/nadvornik/zypper-lifecycle/blob/master/test-data/SLES.lifecycle
     # from https://fate.suse.com/320597
@@ -39,8 +29,52 @@ sub run() {
     #
     # 3. verify that "zypper lifecycle" shows correct package eol based on the
     # data from step 2
-    map { check_package_lifecycle $_ } qw/aaa_base kernel-default/;
+    my $prod     = script_output "basename `readlink /etc/products.d/baseproduct ` .prod";
+    my $package  = 'aaa_base';
+    my $testdate = '2020-02-03';
+    # backup and create our lifecycle data with known content
+    select_console 'root-console';
+    assert_script_run "
+    if [ -f /var/lib/lifecycle/data/$prod.lifecycle ] ; then
+        mv /var/lib/lifecycle/data/$prod.lifecycle /var/lib/lifecycle/data/$prod.lifecycle.orig
+    fi
+    mkdir -p /var/lib/lifecycle/data
+    echo '$package, *, $testdate' > /var/lib/lifecycle/data/$prod.lifecycle";
+    # verify eol from lifecycle data
+    select_console 'user-console';
+    my $output = script_output "zypper lifecycle $package", 300;
+    die "$package lifecycle entry incorrect:$output" unless $output =~ /$package-\S+\s+$testdate/;
+
+    # delete lifecycle data - package eol should default to product eol
+    select_console 'root-console';
+    assert_script_run "rm -f /var/lib/lifecycle/data/$prod.lifecycle";
+
+    # get product eol
+    my $product_name = script_output "grep '<summary>' /etc/products.d/$prod.prod";
+    $product_name =~ s/.*<summary>([^<]*)<\/summary>.*/$1/;
+
+    my $product_eol;
+    for my $l (split /\n/, $overview) {
+        if ($l =~ /$product_name\s*(\S*)/) {
+            $product_eol = $1;
+            last;
+        }
+    }
+    die "baseproduct eol not found in overview" unless $product_eol;
+
+    select_console 'user-console';
+    # verify that package eol defaults to product eol
+    $output = script_output "zypper lifecycle $package", 300;
+    die "$package lifecycle entry incorrect:'$output', expected: '/$package-\\S+\\s+$product_eol'" unless $output =~ /$package-\S+\s+$product_eol/;
+
+    # restore original data, if any
+    select_console 'root-console';
+    assert_script_run "
+    if [ -f /var/lib/lifecycle/data/$prod.lifecycle.orig ] ; then
+        mv /var/lib/lifecycle/data/$prod.lifecycle.orig mv /var/lib/lifecycle/data/$prod.lifecycle
+    fi";
     #
+    select_console 'user-console';
     # 4. verify that "zypper lifecycle --days N" and "zypper lifecycle --date
     # D" shows correct results
     assert_script_run 'zypper lifecycle --help';
@@ -49,9 +83,10 @@ sub run() {
     die "'end of support' line not found" unless $output =~ /No (products|packages).*before/;
     assert_script_run('zypper lifecycle --days 9999', timeout => 300, fail_message => 'No package should be supported for more than 20 years');
     $output = script_output 'zypper lifecycle --days 9999', 300;
-    die "Product 'end of support' line not found" unless $output =~ /^Product end of support before/;
-    my $product_version = get_required_var('VERSION') =~ s/-/ /r;
-    die "Current product should not be supported anymore" unless $output =~ /SUSE Linux Enterprise.*$product_version.*$date_re/;
+    # bsc#999537 c8
+    # die "Product 'end of support' line not found" unless $output =~ /^Product end of support before/;
+    # my $product_version = get_required_var('VERSION') =~ s/-/ /r;
+    # die "Current product should not be supported anymore" unless $output =~ /SUSE Linux Enterprise.*$product_version.*$date_re/;
     assert_script_run('zypper lifecycle --date $(date --iso-8601)', timeout => 300, fail_message => 'All packages should be supported as of today');
 }
 


### PR DESCRIPTION
Test package eol with and without package-specific data.

I found a problem with dates after codestream eol - bsc#999537 c8. Correct  behavior is still discussed. The test for it is commented out for now.