### PR TITLE
Update 2 empathy cases to workaround bsc#994988 bsc#999832

### DIFF
--- a/tests/x11regressions/empathy/empathy_aim.pm
+++ b/tests/x11regressions/empathy/empathy_aim.pm
@@ -10,6 +10,7 @@
 use base "x11regressiontest";
 use strict;
 use testapi;
+use utils;
 
 # Case 1503972 - Empathy: AIM
 
@@ -23,7 +24,7 @@ sub run() {
     #x11_start_program ("xterm -e killall -9 empathy");
     x11_start_program("empathy");
 
-    assert_screen('empathy-accounts-discover', 10);
+    assert_screen 'empathy-accounts-discover';
     send_key "alt-s";    # skip accounts discover
 
     # add one aim account- aim1
@@ -37,10 +38,14 @@ sub run() {
     type_string $USERNAME0. "@" . $DOMAIN . ".com";
     send_key "tab";
     type_string $PASSWD;
+    if (sle_version_at_least('12-SP2')) {
+        assert_and_click 'remember-password-uncheck';
+        record_soft_failure 'bsc#994988 Empathy adding account org.freedesktop.Secret.Error.IsLocked: Cannot create an item in a locked collection';
+    }
     send_key "alt-d";
 
     # check status
-    assert_screen('empathy-aim-aim1-success', 30);
+    assert_screen 'empathy-aim-aim1-success';
 
     # add another aim account- aim2
 
@@ -53,12 +58,15 @@ sub run() {
     type_string $USERNAME1. "@" . $DOMAIN . ".com";
     send_key "tab";
     type_string $PASSWD;
+    if (sle_version_at_least('12-SP2')) {
+        assert_and_click 'remember-password-uncheck';
+    }
     send_key "alt-d";
 
     # check status
-    assert_screen('empathy-aim-aim2-success', 30);
+    assert_screen 'empathy-aim-aim2-success';
     send_key "alt-c";
-    assert_screen('empathy-aim-available-status', 10);
+    assert_screen 'empathy-aim-available-status';
 
     # select the test4 account to talk
     assert_and_click 'empathy-aim-contact-list';
@@ -66,29 +74,41 @@ sub run() {
     send_key "ret";
 
     # send a message and then close the dialog
-    assert_screen('empathy-dialog-window', 20);
+    assert_screen 'empathy-dialog-window';
     type_string "test from openqa";
     send_key "ret";
-    assert_screen('empathy-aim-sent-message', 5);
+    assert_screen 'empathy-aim-sent-message';
     send_key "ctrl-w";
-    assert_screen('empathy-close-dialog', 5);
+    assert_screen 'empathy-close-dialog';
 
     # cleaning
-    send_key "f4";
+    if (sle_version_at_least('12-SP2')) {
+        assert_and_click 'empathy-menu';
+        assert_and_click 'empathy-menu-accounts';
+    }
+    else {
+        send_key "f4";
+    }
     assert_and_click 'empathy-disable-aim-account0';
     assert_and_click 'empathy-delete-aim-account0';
-    assert_screen('empathy-confirm-aim-deletion0', 5);
+    assert_screen 'empathy-confirm-aim-deletion0';
     send_key "alt-r", 1;
 
     assert_and_click 'empathy-disable-aim-account1';
     assert_and_click 'empathy-delete-aim-account1';
-    assert_screen('empathy-confirm-aim-deletion1', 5);
+    assert_screen 'empathy-confirm-aim-deletion1';
     send_key "alt-r", 1;
 
     send_key "alt-c", 1;
 
     # quit
-    send_key "ctrl-q";
+    if (sle_version_at_least('12-SP2')) {
+        assert_and_click 'empathy-menu';
+        assert_and_click 'empathy-menu-quit';
+    }
+    else {
+        send_key "ctrl-q";
+    }
 }
 1;
 # vim: set sw=4 et:

--- a/tests/x11regressions/empathy/empathy_irc.pm
+++ b/tests/x11regressions/empathy/empathy_irc.pm
@@ -10,6 +10,7 @@
 use base "x11regressiontest";
 use strict;
 use testapi;
+use utils;
 
 # Case 1478813 - Empathy: IRC
 
@@ -44,7 +45,15 @@ sub run() {
     };
 
     # join openqa channel
-    send_key "ctrl-j";
+    if (sle_version_at_least('12-SP2')) {
+        assert_and_click 'empathy-menu';
+        send_key_until_needlematch "empathy-menu-rooms", "down";
+        assert_and_click 'empathy-menu-joinrooms';
+        record_soft_failure 'bsc#999832: keyboard shortcut of empathy not working on SLED12SP2';
+    }
+    else {
+        send_key "ctrl-j";
+    }
     assert_screen 'empathy-join-room';
     type_string "openqa";
     send_key "ret";
@@ -58,7 +67,13 @@ sub run() {
     send_key "ret";
 
     # cleaning
-    send_key "f4";
+    if (sle_version_at_least('12-SP2')) {
+        assert_and_click 'empathy-menu';
+        assert_and_click 'empathy-menu-accounts';
+    }
+    else {
+        send_key "f4";
+    }
     assert_and_click 'empathy-disable-account';
     assert_and_click 'empathy-delete-account';
     assert_screen 'empathy-confirm-deletion';
@@ -69,7 +84,13 @@ sub run() {
     };
 
     # quit
-    send_key "ctrl-q";
+    if (sle_version_at_least('12-SP2')) {
+        assert_and_click 'empathy-menu';
+        assert_and_click 'empathy-menu-quit';
+    }
+    else {
+        send_key "ctrl-q";
+    }
 }
 
 1;


### PR DESCRIPTION
Testing Result: http://147.2.212.239/tests/782

- empathy_aim met a DBUS error when adding an online account, so
  I uncheck the 'Remember Password' option to workaround this bug.
- All empathy keyboard shortcut are not working on SLED12SP2, so
  I add some if branches to use mouse and click instead of shortcut.

see also: poo#13116, bsc#994988, bsc#999832