### PR TITLE
Workaround for live patching and validate its repos

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -523,6 +523,11 @@ sub validatelr {
     if (get_var('FLAVOR') =~ m{SAP}) {
         $version .= "-SAP";
     }
+    # Live patching and other modules are not per-service pack channel model,
+    # so use major version to validate their repos
+    if ($product eq 'SLE-Live-Patching') {
+        ($version) = $version =~ /^(\d+)/;
+    }
     # Repo is checked for enabled/disabled state. If the information about the
     # expected state is not delivered to validatelr(), we use some heuristics to
     # determine the expected state: If the installation medium is a physical
@@ -559,6 +564,10 @@ sub validate_repos {
         my @addonurl_keys = split(/,/, get_var('ADDONURL', ''));
         my $scc_addon_str = '';
         for my $scc_addon (split(/,/, get_var('SCC_ADDONS', ''))) {
+            if ($scc_addon eq 'live') {
+                $scc_addon_str .= "SLE-Live-Patching";
+                next;
+            }
             $scc_addon =~ s/geo/ha-geo/ if ($scc_addon eq 'geo');
             $scc_addon_str .= "SLE-" . uc($scc_addon) . ',';
         }


### PR DESCRIPTION
From comment https://bugzilla.suse.com/show_bug.cgi?id=985647#c19, uninstall all kgraft-patch* packages prior to migration as a workaround to solve conflict during online migration with live patching addon, and confirm that no need to reinstall kgraft after migration since it should be installed during registration.

Also add validation to check live patching repos.

Test result:
http://147.2.207.208/tests/118