### PR TITLE
Remove needles matching wrong content

### DIFF
--- a/tests/console/yast2_apparmor.pm
+++ b/tests/console/yast2_apparmor.pm
@@ -56,11 +56,6 @@ sub run() {
     send_key 'down';
     assert_screen 'yast2_apparmor_configuration_manage_existing_profiles';
     send_key 'ret';
-    assert_screen 'yast2_apparmor_configuration_manage_existing_profiles_edit';
-    send_key 'alt-p';
-    send_key 'down';
-
-    # add a profile
     assert_screen 'yast2_apparmor_configuration_manage_existing_profiles_edit_add';
     send_key 'alt-i';
     wait_still_screen(1);


### PR DESCRIPTION
assert_screen (line 59,64) are testing that previous commands are ignored (passing sometimes, when send_key was not processed fast enough and they matched previous screen)

Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/218 
Local run: http://dhcp91.suse.cz/tests/2555