### PR TITLE
Custom network init not only for autoyast or autoupgrade

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -165,13 +165,15 @@ sub bootmenu_network_source {
 }
 
 sub specific_bootmenu_params {
-    my $args = "";
+    my $args     = "";
+    my $netsetup = "";
     if (get_var("AUTOYAST") || get_var("AUTOUPGRADE") && get_var("AUTOUPGRADE") ne 'local') {
-        my $netsetup = " ifcfg=*=dhcp";    #need this instead of netsetup as default, see bsc#932692
+        $netsetup = get_var("NETWORK_INIT_PARAM", "ifcfg=*=dhcp");    #need this instead of netsetup as default, see bsc#932692
+        $args .= " $netsetup autoyast=" . data_url(get_var("AUTOYAST")) . " ";
+    }
+    else {
         $netsetup = " " . get_var("NETWORK_INIT_PARAM") if defined get_var("NETWORK_INIT_PARAM");    #e.g netsetup=dhcp,all
-        $netsetup = " netsetup=dhcp,all" if defined get_var("USE_NETSETUP");                         #netsetup override for sle11
         $args .= $netsetup;
-        $args .= " autoyast=" . data_url(get_var("AUTOYAST")) . " ";
     }
 
     if (get_var("AUTOUPGRADE")) {

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -13,6 +13,9 @@ use testapi;
 use utils;
 use strict;
 
+# Summary: console test pre setup, stoping and disabling packagekit, install curl and tar to get logs and so on
+# Maintainer: Oliver Kurz <okurz@suse.de>
+
 sub run() {
     my $self = shift;
 
@@ -98,6 +101,12 @@ sub run() {
         assert_script_run("sed -ie '/GFXMODE=/s/=.*/=1024x768x32/' /etc/default/grub");
         assert_script_run("sed -ie '/GFXPAYLOAD_LINUX=/s/=.*/=1024x768x32/' /etc/default/grub");
         assert_script_run("grub2-mkconfig -o /boot/grub2/grub.cfg");
+    }
+
+    # https://fate.suse.com/320347 https://bugzilla.suse.com/show_bug.cgi?id=988157
+    if (check_var('NETWORK_INIT_PARAM', 'ifcfg=eth0=dhcp')) {
+        # grep all also compressed files e.g. y2log-1.gz
+        assert_script_run 'less /var/log/YaST2/y2log*|grep "Automatic DHCP configuration not started - an interface is already configured"';
     }
 
     save_screenshot;


### PR DESCRIPTION
Custom network setup can be now used with any test

minimal+base+custom_init
http://10.100.98.90/tests/3490
autoupgrade_sle12_ga
http://10.100.98.90/tests/3491