### PR TITLE
Update 2 x11regression cases

### DIFF
--- a/tests/x11regressions/firefox/sle12/firefox_emaillink.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_emaillink.pm
@@ -13,8 +13,16 @@
 use strict;
 use base "x11regressiontest";
 use testapi;
+use utils;
 
 sub run() {
+    my $self     = shift;
+    my $next_key = "alt-o";
+
+    if (sle_version_at_least('12-SP2')) {
+        $next_key = "alt-n";
+    }
+
     mouse_hide(1);
 
     # Clean and Start Firefox
@@ -27,15 +35,15 @@ sub run() {
     send_key "e";
     assert_screen('firefox-email_link-welcome', 90);
 
-    send_key "alt-o";
+    send_key $next_key;
 
     sleep 1;
-    send_key "alt-o";
+    send_key $next_key;
 
     sleep 1;
     send_key "alt-a";
     type_string 'test@suse.com';
-    send_key "alt-o";
+    send_key $next_key;
 
     sleep 1;
     send_key "alt-s";    #Skip
@@ -45,18 +53,28 @@ sub run() {
     type_string "imap.suse.com";
     send_key "alt-n";    #Username
     type_string "test";
-    send_key "alt-o";
-
-    sleep 1;
-    send_key "alt-o";
+    if (sle_version_at_least('12-SP2')) {
+        assert_and_click "evolution-option-next";
+        wait_still_screen;
+        assert_and_click "evolution-option-next";
+    }
+    else {
+        send_key $next_key;
+        wait_still_screen;
+        send_key $next_key;
+    }
 
     assert_screen('firefox-email_link-settings_sending', 30);
     send_key "alt-s";    #Server
     type_string "smtp.suse.com";
-    send_key "alt-o";
+    send_key $next_key;
 
-    sleep 1;
-    send_key "alt-o";
+    if (sle_version_at_least('12-SP2')) {
+        assert_and_click "evolution-option-next";
+    }
+    else {
+        send_key $next_key;
+    }
 
     sleep 1;
     send_key "alt-a";

--- a/tests/x11regressions/gnomecase/gnome_classic_switch.pm
+++ b/tests/x11regressions/gnomecase/gnome_classic_switch.pm
@@ -39,6 +39,7 @@ sub application_test {
     x11_start_program "firefox";
     assert_screen "firefox-gnome", 150;
     send_key "alt-f4";
+    wait_still_screen;
     send_key "ret";
     wait_still_screen;
 }


### PR DESCRIPTION
Testing Result:  http://147.2.212.239/tests/811

- firefox_emaillink:
  The 'Continue' button of evolution setup wizard of this case has changed
  to 'Next' on SLED12SP2.
- gnome_classic_switch:
  Adding a wait_still_screen between two send_key operation.

  see also: poo#13946, poo#13944