### PR TITLE
Reboot at the end of zypper_migration

### DIFF
--- a/tests/online_migration/sle12_online_migration/zypper_migration.pm
+++ b/tests/online_migration/sle12_online_migration/zypper_migration.pm
@@ -64,6 +64,10 @@ sub run() {
         }
         $out = wait_serial($migration_checks, $timeout);
     }
+    script_run("systemctl reboot", 0);
+
+    # sometimes reboot takes longer time after online migration, give more time
+    wait_boot(bootloader_time => 300);
 }
 
 sub test_flags() {


### PR DESCRIPTION
In order to resolve https://bugzilla.suse.com/show_bug.cgi?id=1001684, was caused by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/1863/files

Patch zypper_migration to act like yast2_migration and reboot at the end of the migration