### PR TITLE
Update journald_fss.pm: Add journalctl --rotate

### DIFF
--- a/tests/console/journald_fss.pm
+++ b/tests/console/journald_fss.pm
@@ -25,6 +25,7 @@ sub run() {
 
     # Setup keys
     assert_script_run("journalctl --interval=30s --setup-keys | tee /tmp/key");
+    assert_script_run("journalctl --rotate");
 
     # Verify the journal with valid verification key
     assert_script_run('key=$(cat /tmp/key); echo "Verify with key: $key"; journalctl --verify --verify-key=$key');


### PR DESCRIPTION
According to comment 2 of bsc#991836, "journalctl --rotate" is
required after creating the keys.