### PR TITLE
Fix evolution_smoke and change_password

### DIFF
--- a/tests/x11regressions/evolution/evolution_smoke.pm
+++ b/tests/x11regressions/evolution/evolution_smoke.pm
@@ -12,10 +12,16 @@
 use strict;
 use base "x11regressiontest";
 use testapi;
+use utils;
 
 sub run() {
     my $mailbox     = 'nooops_test3@aim.com';
     my $mail_passwd = 'opensuse';
+    my $next_key    = "alt-o";
+
+    if (sle_version_at_least('12-SP2')) {
+        $next_key = "alt-n";
+    }
 
     mouse_hide(1);
 
@@ -28,9 +34,9 @@ sub run() {
 
     # Follow the wizard to setup mail account
     assert_screen "test-evolution-1";
-    send_key "alt-o";
+    send_key $next_key;
     assert_screen "evolution_wizard-restore-backup";
-    send_key "alt-o";
+    send_key $next_key;
     assert_screen "evolution_wizard-identity";
     wait_screen_change {
         send_key "alt-e";
@@ -43,9 +49,14 @@ sub run() {
     sleep 1;
     save_screenshot();
 
-    send_key "alt-o";
+    send_key $next_key;
     assert_screen "evolution_wizard-account-summary", 60;
-    send_key "alt-o";
+    if (sle_version_at_least('12-SP2')) {
+        assert_and_click "evolution-option-next";
+    }
+    else {
+        send_key $next_key;
+    }
     assert_screen "evolution_wizard-done";
     send_key "alt-a";
     assert_screen "evolution_mail-auth";

--- a/tests/x11regressions/gnomecase/change_password.pm
+++ b/tests/x11regressions/gnomecase/change_password.pm
@@ -81,12 +81,19 @@ sub unlock_user_settings {
 
 sub change_pwd {
     send_key "alt-p";
+    wait_still_screen;
     send_key "ret";
+    wait_still_screen;
     send_key "alt-p";
+    wait_still_screen;
     type_string "$rootpwd";
+    wait_still_screen;
     send_key "alt-n";
+    wait_still_screen;
     type_string "$newpwd";
+    wait_still_screen;
     send_key "alt-v";
+    wait_still_screen;
     type_string "$newpwd";
     assert_screen "actived-change-password";
     send_key "alt-a";


### PR DESCRIPTION
Testing Result: http://147.2.212.239/tests/818

- evolution_smoke:
  The 'Continue' button of evolution setup wizard of this case has
  changed to 'Next' on SLED12SP2.
- change_password:
  This case is rather unstable, we should add some interval between
  the type_string and send_key.

  see also: poo#13118, poo#13968