### PR TITLE
Add a metadata boilerplate to every test

### DIFF
--- a/tests/autoyast/autoyast_reboot.pm
+++ b/tests/autoyast/autoyast_reboot.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: merge of sles11sp4 autoyast test, base commit
+# G-Maintainer: Pavel Sladek <psladek@suse.cz>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/autoyast/autoyast_verify.pm
+++ b/tests/autoyast/autoyast_verify.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: merge of sles11sp4 autoyast test, base commit
+# G-Maintainer: Pavel Sladek <psladek@suse.cz>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/autoyast/clone.pm
+++ b/tests/autoyast/clone.pm
@@ -13,6 +13,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: autoyast cleanup
+#    - split repos.pm into separater tests
+#    - changed order of tests, run the specific tests in autoyast_verify
+#      earlier
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/autoyast/console.pm
+++ b/tests/autoyast/console.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: merge of sles11sp4 autoyast test, base commit
+# G-Maintainer: Pavel Sladek <psladek@suse.cz>
+
 use strict;
 use base 'y2logsstep';
 use testapi;

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: renamed autoyast/system.pm to installation.pm
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/autoyast/login.pm
+++ b/tests/autoyast/login.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: merge of sles11sp4 autoyast test, base commit
+# G-Maintainer: Pavel Sladek <psladek@suse.cz>
+
 use strict;
 use base 'y2logsstep';
 use testapi;

--- a/tests/autoyast/logs.pm
+++ b/tests/autoyast/logs.pm
@@ -13,6 +13,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: autoyast cleanup
+#    - split repos.pm into separater tests
+#    - changed order of tests, run the specific tests in autoyast_verify
+#      earlier
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/autoyast/pxe_boot.pm
+++ b/tests/autoyast/pxe_boot.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: merge of sles11sp4 autoyast test, base commit
+# G-Maintainer: Pavel Sladek <psladek@suse.cz>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/autoyast/repos.pm
+++ b/tests/autoyast/repos.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: merge of sles11sp4 autoyast test, base commit
+# G-Maintainer: Pavel Sladek <psladek@suse.cz>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/autoyast/wicked.pm
+++ b/tests/autoyast/wicked.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: wicked script for more logs if eth0 is not up
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
+# G-Summary: virtualization: merge pxe boot process of Nuremberg and Beijing; simplify and reuse code for reboot_and_login process; rebase the virt_utils package
+# G-Maintainer: alice <xlai@suse.com>
+
 use strict;
 use warnings;
 use File::Basename;

--- a/tests/boot/boot_to_console.pm
+++ b/tests/boot/boot_to_console.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: sle11 online migration testsuite
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "basetest";
 use strict;
 use testapi;

--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: boot from existing image to desktop
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "basetest";
 use strict;
 use testapi;

--- a/tests/boot/grub_test_snapshot.pm
+++ b/tests/boot/grub_test_snapshot.pm
@@ -8,6 +8,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Enable Snapper-Rollback on HDD special Image.
+#    Enable test-workflow on Main
+# G-Maintainer: dmaiocchi <dmaiocchi@suse.com>
+
 use strict;
 use base "basetest";
 use testapi;

--- a/tests/boot/qa_net_boot_from_hdd.pm
+++ b/tests/boot/qa_net_boot_from_hdd.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Let real hardware boot to BIOS and PXE menu before grub_test
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "basetest";
 use strict;
 use testapi;

--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -11,6 +11,10 @@
 # test a rollback (as a backup) situation after system has migrated. (e.g from Sles12 to sp2)
 # we make snapper rollback and  go back to downgraded system,
 
+# G-Summary: Enable Snapper-Rollback on HDD special Image.
+#    Enable test-workflow on Main
+# G-Maintainer: dmaiocchi <dmaiocchi@suse.com>
+
 use base "consoletest";
 use testapi;
 use utils;

--- a/tests/boot/uefi_bootmenu.pm
+++ b/tests/boot/uefi_bootmenu.pm
@@ -7,6 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Select UEFI boot device in BIOS
+#    OVMF doesn't honor the -boot XX setting of qemu so we have to manually enter the boot manager in the BIOS
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "basetest";
 use strict;
 use testapi;

--- a/tests/console/a2ps.pm
+++ b/tests/console/a2ps.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: a2ps test based on: https://progress.opensuse.org/issues/9472
+# G-Maintainer: Dumitru Gutu <dgutu@suse.com>
+
 use strict;
 use base "consoletest";
 use testapi;

--- a/tests/console/acpi.pm
+++ b/tests/console/acpi.pm
@@ -7,6 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Test acpi loading with acpi=force parameterpoo#11798
+#    In acpi mode devicetree directory exists, but is empty..
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/add_yast_head.pm
+++ b/tests/console/add_yast_head.pm
@@ -8,6 +8,15 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add two tests useful only in the yast branch
+#     * The plan is to create a yast branch of main.pm (like it's already
+#       done for sle2)
+#     * The goal of that branch is to make fast and easy to run single
+#       jobs to test a specific feature (probably still under development)
+#     * This two tests can be used to ensure that the last code generated
+#       by the YaST team is being used during the execution of the job.
+# G-Maintainer: Ancor Gonzalez Sosa <ancor@suse.de>
+
 use base "consoletest";
 use testapi;
 use strict;

--- a/tests/console/aide_check.pm
+++ b/tests/console/aide_check.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: FIPS case for aide check test
+#    This is a new test case added for FIPS, it test the basic function of aide tools.
+#    This case will been used with SLE 12 SP2 with FIPS, and it has added to misc part of FIPS test.
+#    The case will do operation as followed
+#    1. Install aide if it has not been installed.
+#    2. Initialized the aide database and check
+#    3. Check the difference between datebase and file system.
+#    4. Modified the file system and run aide check again.
+# G-Maintainer: Jiawei Sun <Jiawei.sun@suse.com>
+
 use base "consoletest";
 use testapi;
 use strict;

--- a/tests/console/aplay.pm
+++ b/tests/console/aplay.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use testapi;
 use strict;

--- a/tests/console/autoyast_removed.pm
+++ b/tests/console/autoyast_removed.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Confirm autoyast creation is removed from installation overviewResolves poo#11442
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/btrfs_autocompletion.pm
+++ b/tests/console/btrfs_autocompletion.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Bash autocompletion for btrfs
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/btrfs_qgroups.pm
+++ b/tests/console/btrfs_qgroups.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Btrfs quota group improvements poo#11446
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/btrfs_send_receive.pm
+++ b/tests/console/btrfs_send_receive.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Btrfs send & receive snapshots
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/check_console_font.pm
+++ b/tests/console/check_console_font.pm
@@ -18,6 +18,11 @@
 # console font, we need to call systemd-vconsole-setup to workaround
 # that
 
+# G-Summary: check for broken console font
+#    cause soft fail if console font is broken, then fix it by calling
+#    systemd-vconsole-setup.
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "consoletest";
 use testapi;
 use utils;

--- a/tests/console/check_gcc48_on_sdk_in_aarch64.pm
+++ b/tests/console/check_gcc48_on_sdk_in_aarch64.pm
@@ -7,6 +7,13 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add test for fate#320678 - GCC 4.8 on SDK in aarch64
+#    Locally verified with Tumbleweed which fails because the package does not
+#    exist as expected.
+#
+#    Related progress issue: https://progress.opensuse.org/issues/11804
+# G-Maintainer: Oliver Kurz <okurz@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/command_not_found.pm
+++ b/tests/console/command_not_found.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add test for command-not-found tool
+# G-Maintainer: Dominik Heidler <dheidler@suse.de>
+
 use base "consoletest";
 use testapi;
 use strict;

--- a/tests/console/console_reboot.pm
+++ b/tests/console/console_reboot.pm
@@ -8,6 +8,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: console reboot test
+#    refactor common reboot and encrypt unlock functions to utils.pm
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "consoletest";
 use testapi;
 use utils;

--- a/tests/console/console_shutdown.pm
+++ b/tests/console/console_shutdown.pm
@@ -14,6 +14,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: shutdown console test
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use strict;
 use base 'basetest';    # don' use consoletest to avoid post run hook
 use testapi;

--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "opensusebasetest";
 use testapi;
 use utils;

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use testapi;
 use utils;

--- a/tests/console/cryptsetup.pm
+++ b/tests/console/cryptsetup.pm
@@ -9,6 +9,13 @@
 
 # Case 1528909  - FIPS: cryptsetup
 
+# G-Summary: Test cryptsetup in FIPS mode
+#    Related test case:Case 1528909  - FIPS: cryptsetup
+#    https://bugzilla.suse.com/tr_show_case.cgi?case_id=1528909
+#    This case is verify the command of cryptsetup whether can be work in FIPS mode
+#    Local openQA validation running: http://147.2.212.179/tests/330
+# G-Maintainer: dehai <dhkong@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/curl_https.pm
+++ b/tests/console/curl_https.pm
@@ -8,6 +8,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: consoletests: add a new curl_https test
+#    Ensure curl is able to successfully connect to a https site
+#    (www.opensuse.org) without certificate errors.
+# G-Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
 use base "consoletest";
 use testapi;
 use strict;

--- a/tests/console/curl_ipv6.pm
+++ b/tests/console/curl_ipv6.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use testapi;
 use strict;

--- a/tests/console/dns_srv.pm
+++ b/tests/console/dns_srv.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Very simple, needle free, bind server test
+# G-Maintainer: sysrich <RBrownCCB@opensuse.org>
+
 use strict;
 use base "consoletest";
 use testapi;

--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -8,6 +8,15 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Test docker installation and basic usage
+#    Cover the following aspects of docker:
+#      * package can be installed
+#      * daemon can be started
+#      * images can be pulled from the Docker Hub
+#      * containers can be spawned
+#      * network is working inside of the containers
+# G-Maintainer: Flavio Castelli <fcastelli@suse.com>
+
 use base "consoletest";
 use testapi;
 use strict;

--- a/tests/console/ecryptfs_fips.pm
+++ b/tests/console/ecryptfs_fips.pm
@@ -3,6 +3,13 @@
 # without any warranty.
 # Test case tc#1525215 FIPS:ecryptfs
 
+# G-Summary: Test case tc#1525215 FIPS:ecryptfs
+#    Check the ecryptfs-utils with fips enabled
+#    Install the ecryptfs-utils and encrypt the directory.
+#    Create a new encrypt file and try to write it.
+#    Check the file after unmont the encrypt directory
+# G-Maintainer: Jiawei Sun <JiaWei.Sun@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/firewall_enabled.pm
+++ b/tests/console/firewall_enabled.pm
@@ -8,6 +8,13 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: refactor jeos tests a bit
+#    - simplyfy by using assert_script_run instead of
+#      validate_script_output
+#    - move some of the more generic ones to console/
+#    - make vim test actually run vim
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/console/glibc_i686.pm
+++ b/tests/console/glibc_i686.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use testapi;
 use strict;

--- a/tests/console/gpt_ptable.pm
+++ b/tests/console/gpt_ptable.pm
@@ -8,6 +8,13 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: refactor jeos tests a bit
+#    - simplyfy by using assert_script_run instead of
+#      validate_script_output
+#    - move some of the more generic ones to console/
+#    - make vim test actually run vim
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/hostname.pm
+++ b/tests/console/hostname.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/http_srv.pm
+++ b/tests/console/http_srv.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add two server tests.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use strict;
 use base "consoletest";
 use testapi;

--- a/tests/console/import_gpg_keys.pm
+++ b/tests/console/import_gpg_keys.pm
@@ -14,6 +14,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: test to import gpg keys
+#    openSUSE maintenance updates in testing are signed by a different key,
+#    so that key needs to be imported manually
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/install_otherDE_pattern.pm
+++ b/tests/console/install_otherDE_pattern.pm
@@ -7,6 +7,12 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add Framework to test other Desktop Environments
+#    Non-Primary desktop environments are generally installed by means
+#    of a pattern. For those tests, we assume a minimal-X based installation
+#    where the pattern is being installed on top.
+# G-Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/install_packages.pm
+++ b/tests/console/install_packages.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: new test that installs configured packages
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/install_windowmanager.pm
+++ b/tests/console/install_windowmanager.pm
@@ -1,3 +1,9 @@
+# G-Summary: Add test for awesome window manager
+#    Based on "minimalx" installation.
+#
+#    Related issue: https://progress.opensuse.org/issues/9522
+# G-Maintainer: Dominik Heidler <dheidler@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/install_yast_head.pm
+++ b/tests/console/install_yast_head.pm
@@ -8,6 +8,15 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add two tests useful only in the yast branch
+#     * The plan is to create a yast branch of main.pm (like it's already
+#       done for sle2)
+#     * The goal of that branch is to make fast and easy to run single
+#       jobs to test a specific feature (probably still under development)
+#     * This two tests can be used to ensure that the last code generated
+#       by the YaST team is being used during the execution of the job.
+# G-Maintainer: Ancor Gonzalez Sosa <ancor@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/installation_snapshots.pm
+++ b/tests/console/installation_snapshots.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Test for the snapshot created after installation (fate#317973)
+# G-Maintainer: Ancor Gonzalez Sosa <ancor@suse.de>
+
 use base 'consoletest';
 use strict;
 use testapi;

--- a/tests/console/journald_fss.pm
+++ b/tests/console/journald_fss.pm
@@ -9,6 +9,13 @@
 
 # Case 1560070  - FIPS: systemd journald FSS
 
+# G-Summary: Add Case 1463314-FIPS:systemd-journald test
+#    Systemd depend on libgcrypt for journald's FSS(Forward Secure Sealing) function
+#    It is only needed to test journald's key generation and verification function
+#    Verify key should be generated,as well as a QR code
+#    No failed messages output
+# G-Maintainer: dehai <dhkong@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/kdump_disabled.pm
+++ b/tests/console/kdump_disabled.pm
@@ -8,6 +8,13 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: refactor jeos tests a bit
+#    - simplyfy by using assert_script_run instead of
+#      validate_script_output
+#    - move some of the more generic ones to console/
+#    - make vim test actually run vim
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/machinery.pm
+++ b/tests/console/machinery.pm
@@ -7,6 +7,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add simple machinery test thanks to greygoo (#1592)
+#    Obsoletes https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/1059
+#    brought up to current state of tests.
+# G-Maintainer: Oliver Kurz <okurz@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/mozmill_setup.pm
+++ b/tests/console/mozmill_setup.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/mtab.pm
+++ b/tests/console/mtab.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/mysql_srv.pm
+++ b/tests/console/mysql_srv.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add two server tests.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use strict;
 use base "consoletest";
 use testapi;

--- a/tests/console/no_perl_bootloader.pm
+++ b/tests/console/no_perl_bootloader.pm
@@ -7,6 +7,17 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add test for fate#317701 - Do not use perl-bootloader in yast2-bootloader (#1571)
+#    On SLE 12-SP2 or greater check that no perl-Bootloader-YAML is present in the
+#    installed system as described as a test case in fate#317701.
+#
+#    Locally verified on TW where it fails because perl-Bootloader-YAML is present.
+#
+#    Verification run: http://lord.arch/tests/2057
+#
+#    Related progress issue: https://progress.opensuse.org/issues/11436
+# G-Maintainer: Oliver Kurz <okurz@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/openssl_alpn.pm
+++ b/tests/console/openssl_alpn.pm
@@ -7,6 +7,13 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Test ALPN support in openssl
+#    FATE#320292 - Application-Layer Protocol Negotiation (ALPN) support for
+#    openssl. Also PR#11800.
+#
+#    Verification run: http://assam.suse.cz/tests/2514#step/openssl_alpn/1.
+# G-Maintainer: Michal Nowak <mnowak@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/openvswitch.pm
+++ b/tests/console/openvswitch.pm
@@ -7,6 +7,19 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: tests: console: Add openvswitch openQA test
+#    Add a basic openvswitch test. This test does the following
+#
+#    - Installs openvswitch
+#    - Starts the systemd service unit
+#    - Executes a few basic openvswitch commands
+#    - Makes use of network namespaces and OpenFlow rules to test basic
+#    connectivity between veth pairs and OvS switches connected via
+#    patch ports.
+#
+#    Signed-off-by: Markos Chandras <mchandras@suse.de>
+# G-Maintainer: Markos Chandras <mchandras@suse.de>
+
 use base "consoletest";
 use testapi;
 use strict;

--- a/tests/console/patterns.pm
+++ b/tests/console/patterns.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Test pattern selection for system role 'kvm host' (fate#317481)
+# G-Maintainer: Christopher Hofmann <cwh@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/postgresql94.pm
+++ b/tests/console/postgresql94.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Postgres tests for 11SP4
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/postgresql94server.pm
+++ b/tests/console/postgresql94server.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Postgres tests for 11SP4
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/postgresql94server_sle11.pm
+++ b/tests/console/postgresql94server_sle11.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Postgres tests for 11SP4
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/qam_verify_package_install.pm
+++ b/tests/console/qam_verify_package_install.pm
@@ -14,6 +14,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: test to verify installed packages
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/qam_zypper_patch.pm
+++ b/tests/console/qam_zypper_patch.pm
@@ -14,6 +14,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: zypper patch for maintenance
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/rabbitmq.pm
+++ b/tests/console/rabbitmq.pm
@@ -7,6 +7,14 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add rabbitmq test suite
+#    Based on https://www.rabbitmq.com/tutorials/tutorial-one-python.html
+#
+#    Solely added because someone added "rabbitmq" to the Leap42.2 test plan :-)
+#
+#    Local verification done.
+# G-Maintainer: Oliver Kurz <okurz@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/rails.pm
+++ b/tests/console/rails.pm
@@ -7,6 +7,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add rails test
+#    As coolo wrote, 'nough said. Had it make it work though, his IRC notes
+#    had syntax errors ;-)
+# G-Maintainer: Oliver Kurz <okurz@suse.de>
+
 use strict;
 use base "consoletest";
 use testapi;

--- a/tests/console/rt_devel_packages.pm
+++ b/tests/console/rt_devel_packages.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: RT tests
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/console/rt_is_realtime.pm
+++ b/tests/console/rt_is_realtime.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: RT tests
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/console/rt_peak_pci.pm
+++ b/tests/console/rt_peak_pci.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: RT tests
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/console/rt_preempt_test.pm
+++ b/tests/console/rt_preempt_test.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: RT tests
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/console/salt.pm
+++ b/tests/console/salt.pm
@@ -7,6 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add basic salt test suite
+#    Local verification done.
+# G-Maintainer: Oliver Kurz <okurz@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/sle11_consoletest_setup.pm
+++ b/tests/console/sle11_consoletest_setup.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: sle 11 without systemd consoletest setup
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/sle11_ncc_checkrepos.pm
+++ b/tests/console/sle11_ncc_checkrepos.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: sle11 ncc testsuite
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/snapper_cleanup.pm
+++ b/tests/console/snapper_cleanup.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Snapper cleanup test based on FATE#312751
+# G-Maintainer: Dumitru Gutu <dgutu@suse.com>
+
 use base "consoletest";
 use strict;
 use utils;

--- a/tests/console/snapper_undochange.pm
+++ b/tests/console/snapper_undochange.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: snapper_undochange console test
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/sntp.pm
+++ b/tests/console/sntp.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/ssh_pubkey.pm
+++ b/tests/console/ssh_pubkey.pm
@@ -7,6 +7,19 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add openssh test cases for FIPS testing
+#    Test Case 1525228: FIPS: openssh
+#
+#    Involve the existing openssh test case: sshd.pm
+#
+#    Create new case ssh_pubkey.pm to test public key
+#
+#    Create new case openssh_fips.pm to verify that
+#    openssh will refuse to work with any non-approved
+#    algorithm in fips mode, just like blowfish cipher
+#    or MD5 hash.
+# G-Maintainer: Qingming Su <qingming.su@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/sshd_running.pm
+++ b/tests/console/sshd_running.pm
@@ -8,6 +8,13 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: refactor jeos tests a bit
+#    - simplyfy by using assert_script_run instead of
+#      validate_script_output
+#    - move some of the more generic ones to console/
+#    - make vim test actually run vim
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/sshfs.pm
+++ b/tests/console/sshfs.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/syslinux.pm
+++ b/tests/console/syslinux.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/textinfo.pm
+++ b/tests/console/textinfo.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/ttylogin4.pm
+++ b/tests/console/ttylogin4.pm
@@ -14,6 +14,10 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: test that logs in on the console without running consoletest_setup
+#    useful to prepare patched disk images that will consoletest_setup later
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/update_alternatives.pm
+++ b/tests/console/update_alternatives.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: console/update_alternatives test for bsc#969171
+# G-Maintainer: Ondřej Súkup <osukup@suse.cz>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/upgrade_snapshots.pm
+++ b/tests/console/upgrade_snapshots.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add test for the snapshots created during upgrade
+# G-Maintainer: Imobach González Sosa <igonzalezsosa@suse.com>
+
 use base 'consoletest';
 use strict;
 use testapi;

--- a/tests/console/vim.pm
+++ b/tests/console/vim.pm
@@ -8,6 +8,13 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: refactor jeos tests a bit
+#    - simplyfy by using assert_script_run instead of
+#      validate_script_output
+#    - move some of the more generic ones to console/
+#    - make vim test actually run vim
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/w3m_https.pm
+++ b/tests/console/w3m_https.pm
@@ -9,6 +9,11 @@
 
 # Case 1525204 - FIPS: w3m_https
 
+# G-Summary: Add w3m_https test case and fips test entry
+#    Add w3m_https.pm test case was located in console/w3m_https.pm
+#    Add w3m_https.pm test entry in load_fips_tests_web() in sle/main.pm
+# G-Maintainer: Ben Chou <bchou@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/wget_https.pm
+++ b/tests/console/wget_https.pm
@@ -9,6 +9,11 @@
 
 # Case 1461937 - FIPS: wget
 
+# G-Summary: Add Case 1461937-FIPS: wget and modify main.pm
+#    Need enable FIPS environment before test this script.
+#    Impact the openssl module
+# G-Maintainer: dehai <dhkong@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/wget_ipv6.pm
+++ b/tests/console/wget_ipv6.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/xfce_gnome_deps.pm
+++ b/tests/console/xfce_gnome_deps.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/xorg_vt.pm
+++ b/tests/console/xorg_vt.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/yast2_apparmor.pm
+++ b/tests/console/yast2_apparmor.pm
@@ -7,6 +7,12 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add yast2_apparmor.pm
+#    common yast module was missing in openqa tests
+#
+#    Verification run: http://e13.suse.de/tests/1086
+# G-Maintainer: Zaoliang Luo <zluo@suse.de>
+
 use strict;
 use base "consoletest";
 use testapi;

--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "console_yasttest";
 use strict;
 use testapi;

--- a/tests/console/yast2_clone_system.pm
+++ b/tests/console/yast2_clone_system.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: clone system and use the autoyast file in chained tests
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use base "console_yasttest";
 use strict;
 use testapi;

--- a/tests/console/yast2_cmdline.pm
+++ b/tests/console/yast2_cmdline.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Support for the new tests for yast command line
+# G-Maintainer: Ancor Gonzalez Sosa <ancor@suse.de>
+
 use base "console_yasttest";
 use strict;
 use testapi;

--- a/tests/console/yast2_dm_crypt.pm
+++ b/tests/console/yast2_dm_crypt.pm
@@ -9,6 +9,9 @@
 
 # Case 1525213 - FIPS: dm-crypt
 
+# G-Summary: Add dm crypt test for fips
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "console_yasttest";
 use strict;
 use testapi;

--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: New test for yast2-dns-server (service management)
+# G-Maintainer: Ancor Gonzalez Sosa <ancor@suse.de>
+
 use base "console_yasttest";
 use strict;
 use testapi;

--- a/tests/console/yast2_ftp.pm
+++ b/tests/console/yast2_ftp.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add yast2_ftp
+# G-Maintainer: Zaoliang Luo <zluo@suse.de>
+
 use strict;
 use base "consoletest";
 use testapi;

--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add test yast2_http
+# G-Maintainer: Zaoliang Luo <zluo@suse.de>
+
 use strict;
 use base "consoletest";
 use testapi;

--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "console_yasttest";
 use strict;
 use testapi;

--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -9,6 +9,9 @@
 # without any warranty.
 
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "console_yasttest";
 use strict;
 use testapi;

--- a/tests/console/yast2_nfs_client.pm
+++ b/tests/console/yast2_nfs_client.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: yast2_nfs_client module
+# G-Maintainer: Ancor Gonzalez Sosa <ancor@suse.de>
+
 use base "console_yasttest";
 use strict;
 use testapi;

--- a/tests/console/yast2_nfs_server.pm
+++ b/tests/console/yast2_nfs_server.pm
@@ -7,6 +7,15 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add new yast2_nfs_server test
+#    This tests "yast2 nfs-server" by creating an NFS share,
+#    writing a file to it and validating that the file is accessible
+#    after mounting.
+#    It can also be used as a server in an "/ on NFS" test scenario.
+#    In this case, NFSSERVER has to be 1, the server is accessible as
+#    10.0.2.1 and it provides a mutex "nfs_ready".
+# G-Maintainer: Fabian Vogt <fvogt@suse.com>
+
 use strict;
 use base "console_yasttest";
 use utils;

--- a/tests/console/yast2_nis.pm
+++ b/tests/console/yast2_nis.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add yast2-nis.pm
+# G-Maintainer: Zaoliang Luo <zluo@suse.de>
+
 use strict;
 use base "console_yasttest";
 use testapi;

--- a/tests/console/yast2_ntpclient.pm
+++ b/tests/console/yast2_ntpclient.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add yast2_ntpclient test
+# G-Maintainer: Zaoliang Luo <zluo@suse.de>
+
 use strict;
 use base "consoletest";
 use testapi;

--- a/tests/console/yast2_proxy.pm
+++ b/tests/console/yast2_proxy.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add yast2_proxy
+# G-Maintainer: Zaoliang Luo <zluo@suse.de>
+
 use strict;
 use base "consoletest";
 use testapi;

--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add yast2_samba.pm
+# G-Maintainer: Zaoliang Luo <zluo@suse.de>
+
 use strict;
 use base "consoletest";
 use testapi;

--- a/tests/console/yast2_tftp.pm
+++ b/tests/console/yast2_tftp.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add yast2_tftp.pm
+# G-Maintainer: Zaoliang Luo <zluo@suse.de>
+
 use strict;
 use base "consoletest";
 use testapi;

--- a/tests/console/yast2_vnc.pm
+++ b/tests/console/yast2_vnc.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add yast2_vnc.pm
+# G-Maintainer: Zaoliang Luo <zluo@suse.de>
+
 use strict;
 use base "consoletest";
 use testapi;

--- a/tests/console/yast2_xinetd.pm
+++ b/tests/console/yast2_xinetd.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add test case yast2_xinetd
+# G-Maintainer: Zaoliang Luo <zluo@suse.de>
+
 use strict;
 use base "consoletest";
 use testapi;

--- a/tests/console/yast_scc.pm
+++ b/tests/console/yast_scc.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: harmorize zypper_ref between SLE and openSUSE
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use strict;
 use base "consoletest";
 

--- a/tests/console/zbar.pm
+++ b/tests/console/zbar.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Test zbar to be able to decode a qr code
+# G-Maintainer: Oliver Kurz <okurz@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/zypper_add_repos.pm
+++ b/tests/console/zypper_add_repos.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: new test that adds configured repositories
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/zypper_ar.pm
+++ b/tests/console/zypper_ar.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: harmorize zypper_ref between SLE and openSUSE
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/zypper_disable_deltarpm.pm
+++ b/tests/console/zypper_disable_deltarpm.pm
@@ -14,6 +14,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: test to disable deltarpm
+#    installing all online updates takes too long if deltarpm is on and our
+#    line is powerful enough to download full rpms.
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/zypper_in.pm
+++ b/tests/console/zypper_in.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -7,6 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add test for fate#320597 'zypper lifecycle'
+#    Verification run: http://lord.arch/tests/2449
+# G-Maintainer: Oliver Kurz <okurz@suse.de>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/zypper_lr.pm
+++ b/tests/console/zypper_lr.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: harmorize zypper_ref between SLE and openSUSE
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/console/zypper_ref.pm
+++ b/tests/console/zypper_ref.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/feature/feature_console/suseconnect.pm
+++ b/tests/feature/feature_console/suseconnect.pm
@@ -9,6 +9,10 @@
 
 # Case #1480023 : [316585] Drop suseRegister
 
+# G-Summary: Add load feature tests entry and Feature #1480023
+#    Feature Test : #1480023 : [316585] Drop suseRegister
+# G-Maintainer: Ben Chou <bchou@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/feature/feature_console/zypper_crit_sec_fix_only.pm
+++ b/tests/feature/feature_console/zypper_crit_sec_fix_only.pm
@@ -10,6 +10,11 @@
 # Feature #318760: Update critical security fixes only
 # Test Case #1480288: Test Feature: Update critical security fixes only
 
+# G-Summary: Test zypper can update critical security fixes only
+#    Add test case for feature #1480288: Update critical
+#    security fixes only.
+# G-Maintainer: Qingming Su <qingming.su@suse.com>
+
 use base "consoletest";
 use testapi;
 use registration;

--- a/tests/feature/feature_console/zypper_releasever.pm
+++ b/tests/feature/feature_console/zypper_releasever.pm
@@ -10,6 +10,10 @@
 # Feature #318354: [ECO] zypper: more advanced $releasever handling
 # Test case #1480297: zypper: more advanced $releasever handling
 
+# G-Summary: Add feature test case #1480297
+#    Test Feature 318354: zypper: more advanced $releasever handling
+# G-Maintainer: Qingming Su <qingming.su@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/fips/curl_fips_rc4_seed.pm
+++ b/tests/fips/curl_fips_rc4_seed.pm
@@ -7,6 +7,13 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Test curl RC4 and SEED ciphers with fips enabled
+#    This is new curl test case for fips related.
+#    Both RC4 and SEED are not approved cipher by FIPS140-2.
+#    In a fips enabled system, it will get a failed result if run curl command
+#    with RC4 and SEED ciphers.
+# G-Maintainer: Jiawei Sun <JiaWei.Sun@suse.com>
+
 use base "consoletest";
 use testapi;
 use strict;

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -7,6 +7,15 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Setup system work into fips mode
+#    Install fips pattern and update grub.cfg with fips=1
+#
+#    Also include workaround of bsc#982268:
+#    Due to bsc#982268, openssl couldn't enter fips mode even the
+#    system is booted with fips=1. Workaround is create the file
+#    /etc/system-fips manually.
+# G-Maintainer: Qingming Su <qingming.su@suse.com>
+
 use base "consoletest";
 use testapi;
 use strict;

--- a/tests/fips/openssh/openssh_fips.pm
+++ b/tests/fips/openssh/openssh_fips.pm
@@ -7,6 +7,19 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add openssh test cases for FIPS testing
+#    Test Case 1525228: FIPS: openssh
+#
+#    Involve the existing openssh test case: sshd.pm
+#
+#    Create new case ssh_pubkey.pm to test public key
+#
+#    Create new case openssh_fips.pm to verify that
+#    openssh will refuse to work with any non-approved
+#    algorithm in fips mode, just like blowfish cipher
+#    or MD5 hash.
+# G-Maintainer: Qingming Su <qingming.su@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/fips/openssl/openssl_fips_alglist.pm
+++ b/tests/fips/openssl/openssl_fips_alglist.pm
@@ -10,6 +10,12 @@
 # Test description: When working in fips mode, openssl should only
 # list the FIPS approved cryptographic functions
 
+# G-Summary: Add Hash and Cipher test cases for openssl-fips
+#    A new test suite is created for FIPS_TS, named "core", which will
+#    contain all the basic test cases for fips verificaton. Just like
+#    the cases to verify opessl hash, cipher, or public key algorithms
+# G-Maintainer: Qingming Su <qingming.su@suse.com>
+
 use base "consoletest";
 use testapi;
 use strict;

--- a/tests/fips/openssl/openssl_fips_cipher.pm
+++ b/tests/fips/openssl/openssl_fips_cipher.pm
@@ -10,6 +10,12 @@
 # Test description: In fips mode, openssl only works with the FIPS
 # approved Cihper algorithms: AES and DES3
 
+# G-Summary: Add Hash and Cipher test cases for openssl-fips
+#    A new test suite is created for FIPS_TS, named "core", which will
+#    contain all the basic test cases for fips verificaton. Just like
+#    the cases to verify opessl hash, cipher, or public key algorithms
+# G-Maintainer: Qingming Su <qingming.su@suse.com>
+
 use base "consoletest";
 use testapi;
 use strict;

--- a/tests/fips/openssl/openssl_fips_hash.pm
+++ b/tests/fips/openssl/openssl_fips_hash.pm
@@ -10,6 +10,12 @@
 # Test description: In fips mode, openssl only works with the FIPS
 # approved HASH algorithms: SHA1 and SHA2 (224, 256, 384, 512)
 
+# G-Summary: Add Hash and Cipher test cases for openssl-fips
+#    A new test suite is created for FIPS_TS, named "core", which will
+#    contain all the basic test cases for fips verificaton. Just like
+#    the cases to verify opessl hash, cipher, or public key algorithms
+# G-Maintainer: Qingming Su <qingming.su@suse.com>
+
 use base "consoletest";
 use testapi;
 use strict;

--- a/tests/fips/openssl/openssl_pubkey_dsa.pm
+++ b/tests/fips/openssl/openssl_pubkey_dsa.pm
@@ -11,6 +11,14 @@
 # and succeed to sign/verify message.
 # According to FIPS 186-4, approved DSA key sizes: 1024/2048/3072
 
+# G-Summary: Add RSA/DSA public key tests for openssl-fips
+#    For RSA public key, test 2048/3072/4096 bits key pair generation,
+#    file encrypt/decrypt and message signing/verification.
+#
+#    For DSA public key, test 1024/2048/3072 bits key pair generation,
+#    and message signing/verification.
+# G-Maintainer: Qingming Su <qingming.su@suse.com>
+
 use base "consoletest";
 use testapi;
 use strict;

--- a/tests/fips/openssl/openssl_pubkey_rsa.pm
+++ b/tests/fips/openssl/openssl_pubkey_rsa.pm
@@ -11,6 +11,14 @@
 # and succeed to encrypt/decrypt/sign/verify message.
 # According to FIPS 186-2, approved RSA key sizes: 2048/3072/4096
 
+# G-Summary: Add RSA/DSA public key tests for openssl-fips
+#    For RSA public key, test 2048/3072/4096 bits key pair generation,
+#    file encrypt/decrypt and message signing/verification.
+#
+#    For DSA public key, test 1024/2048/3072 bits key pair generation,
+#    and message signing/verification.
+# G-Maintainer: Qingming Su <qingming.su@suse.com>
+
 use base "consoletest";
 use testapi;
 use strict;

--- a/tests/fixup/enable_firewall.pm
+++ b/tests/fixup/enable_firewall.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Enable firewall after updating openSUSE 13.1 image (boo#977659)
+# G-Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/fixup/network_configuration.pm
+++ b/tests/fixup/network_configuration.pm
@@ -7,6 +7,18 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Fixup network configuration when upgrading from openSUSE 13.2 (and lower)
+#    openSUSE 13.2's (and earlier) systemd has broken rules for virtio-net,
+#    not applying predictable names (despite being configured). A maintenance
+#    update breaking networking names sounds worse than just accepting
+#    that 13.2 -> TW breaks with virtio-net.
+#
+#    Since consoletest_setup is no longer the first thing running after the
+#    system has been updated (it is now the check for applicable updates) this
+#    fixup needed to be moved out of consoletest_setup in order to be started
+#    earlier (again, asap, before nything wants to access the network)
+# G-Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add HA tests
+#    - boot ha_support_server with dhcp/dns/ntp/iscsi services
+#    - configure ntp/iscsi/watchdog on nodes
+#    - create/join cluster using ha_cluster_init/join
+#    - create shared OCFS2 and check that it's really shared
+#    - check cluster status using crm_mon
+#    - fence a node and check that it's really fenced
+#    - grep /var/log to find segfaults at the end
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use base "hacluster";
 use strict;
 use testapi;

--- a/tests/ha/check_logs.pm
+++ b/tests/ha/check_logs.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add HA tests
+#    - boot ha_support_server with dhcp/dns/ntp/iscsi services
+#    - configure ntp/iscsi/watchdog on nodes
+#    - create/join cluster using ha_cluster_init/join
+#    - create shared OCFS2 and check that it's really shared
+#    - check cluster status using crm_mon
+#    - fence a node and check that it's really fenced
+#    - grep /var/log to find segfaults at the end
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use base "hacluster";
 use strict;
 use testapi;

--- a/tests/ha/clvm.pm
+++ b/tests/ha/clvm.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add cLVM test
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use base "hacluster";
 use strict;
 use testapi;

--- a/tests/ha/crm_mon.pm
+++ b/tests/ha/crm_mon.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add HA tests
+#    - boot ha_support_server with dhcp/dns/ntp/iscsi services
+#    - configure ntp/iscsi/watchdog on nodes
+#    - create/join cluster using ha_cluster_init/join
+#    - create shared OCFS2 and check that it's really shared
+#    - check cluster status using crm_mon
+#    - fence a node and check that it's really fenced
+#    - grep /var/log to find segfaults at the end
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use base "hacluster";
 use strict;
 use testapi;

--- a/tests/ha/cts.pm
+++ b/tests/ha/cts.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add pacemaker-cts test
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use base "hacluster";
 use testapi;
 use autotest;

--- a/tests/ha/dlm.pm
+++ b/tests/ha/dlm.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Detach DLM resource creation from OCFS2 test
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use base "hacluster";
 use strict;
 use testapi;

--- a/tests/ha/fencing.pm
+++ b/tests/ha/fencing.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Initial HA Validation Tests
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use base "hacluster";
 use strict;
 use testapi;

--- a/tests/ha/fencing_boot.pm
+++ b/tests/ha/fencing_boot.pm
@@ -1,1 +1,114 @@
-../installation/first_boot.pm
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# G-Summary: Add HA tests
+#    - boot ha_support_server with dhcp/dns/ntp/iscsi services
+#    - configure ntp/iscsi/watchdog on nodes
+#    - create/join cluster using ha_cluster_init/join
+#    - create shared OCFS2 and check that it's really shared
+#    - check cluster status using crm_mon
+#    - fence a node and check that it's really fenced
+#    - grep /var/log to find segfaults at the end
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
+use strict;
+use base "y2logsstep";
+use testapi;
+
+sub handle_login {
+    if (get_var('DESKTOP_MINIMALX_INSTONLY')) {
+        # return at the DM and log in later into desired wm
+        return;
+    }
+    mouse_hide();
+    wait_still_screen;
+    if (get_var('DM_NEEDS_USERNAME')) {
+        type_string $username;
+    }
+    if (match_has_tag("sddm")) {
+        # make sure choose plasma5 session
+        assert_and_click "sddm-sessions-list";
+        assert_and_click "sddm-sessions-plasma5";
+        assert_and_click "sddm-password-input";
+    }
+    else {
+        send_key "ret";
+        if (!check_screen "displaymanager-password-prompt") {
+            record_soft_failure;
+            assert_screen "displaymanager-password-prompt";
+        }
+    }
+    type_string "$password";
+    send_key "ret";
+}
+
+sub run() {
+    my $self = shift;
+
+    if (check_var('DESKTOP', 'textmode') || get_var('BOOT_TO_SNAPSHOT')) {
+        if (!check_var('ARCH', 's390x')) {
+            assert_screen 'linux-login', 200;
+        }
+        return;
+    }
+
+    if (get_var("NOAUTOLOGIN") || get_var("IMPORT_USER_DATA")) {
+        assert_screen [qw/displaymanager emergency-shell emergency-mode/], 200;
+        if (match_has_tag('emergency-shell')) {
+            # get emergency shell logs for bug, scp doesn't work
+            script_run "cat /run/initramfs/rdsosreport.txt > /dev/$serialdev";
+        }
+        elsif (match_has_tag('emergency-mode')) {
+            type_password;
+            send_key 'ret';
+        }
+        handle_login;
+    }
+
+    my @tags = qw/generic-desktop/;
+    if (check_var('DESKTOP', 'kde') && get_var('VERSION', '') =~ /^1[23]/) {
+        push(@tags, 'kde-greeter');
+    }
+    # GNOME and KDE get into screenlock after 5 minutes without activities.
+    # using multiple check intervals here then we can get the wrong desktop
+    # screenshot at least in case desktop screenshot changed, otherwise we get
+    # the screenlock screenshot.
+    my $timeout        = 600;
+    my $check_interval = 30;
+    while ($timeout > $check_interval) {
+        my $ret = check_screen \@tags, $check_interval;
+        last if $ret;
+        $timeout -= $check_interval;
+    }
+    # the last check after previous intervals must be fatal
+    assert_screen \@tags, $check_interval;
+    if (match_has_tag('kde-greeter')) {
+        send_key "esc";
+        assert_screen 'generic-desktop';
+    }
+}
+
+sub test_flags() {
+    return {fatal => 1, milestone => 1};
+}
+
+sub post_fail_hook() {
+    my $self = shift;
+
+    # Reveal what is behind Plymouth splash screen
+    wait_screen_change {
+        send_key 'esc';
+    };
+    $self->export_logs();
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/tests/ha/fencing_consoletest_setup.pm
+++ b/tests/ha/fencing_consoletest_setup.pm
@@ -1,1 +1,137 @@
-../console/consoletest_setup.pm
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# G-Summary: Add HA tests
+#    - boot ha_support_server with dhcp/dns/ntp/iscsi services
+#    - configure ntp/iscsi/watchdog on nodes
+#    - create/join cluster using ha_cluster_init/join
+#    - create shared OCFS2 and check that it's really shared
+#    - check cluster status using crm_mon
+#    - fence a node and check that it's really fenced
+#    - grep /var/log to find segfaults at the end
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
+use base "consoletest";
+use testapi;
+use utils;
+use strict;
+
+sub run() {
+    my $self = shift;
+
+    # Without this login name and password won't get to the system. The
+    # get lost somewhere. Applies for all systems installed via svirt.
+    if (check_var('BACKEND', 'svirt') and !check_var('ARCH', 's390x')) {
+        wait_idle;
+    }
+
+    # let's see how it looks at the beginning
+    save_screenshot;
+
+    # Special keys like Ctrl-Alt-Fx does not work on Hyper-V atm. Alt-Fx however do.
+    my $tty1_key = 'ctrl-alt-f1';
+    if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
+        $tty1_key = 'alt-f1';
+    }
+
+    if (!check_var('ARCH', 's390x')) {
+        # verify there is a text console on tty1
+        for (1 .. 6) {
+            send_key $tty1_key;
+            if (check_screen("tty1-selected", 5)) {
+                last;
+            }
+        }
+        if (!check_screen "tty1-selected", 5) {    #workaround for bsc#977007
+            record_soft_failure "unable to switch to the text mode";
+            send_key 'ctrl-alt-backspace';         #kill X and log in again
+            send_key 'ctrl-alt-backspace';
+            assert_screen 'displaymanager', 200;    #copy from installation/first_boot.pm
+            if (get_var('DESKTOP_MINIMALX_INSTONLY')) {
+                # return at the DM and log in later into desired wm
+                return;
+            }
+            mouse_hide();
+            if (get_var('DM_NEEDS_USERNAME')) {
+                type_string $username;
+            }
+            if (match_has_tag("sddm")) {
+                # make sure choose plasma5 session
+                assert_and_click "sddm-sessions-list";
+                assert_and_click "sddm-sessions-plasma5";
+                assert_and_click "sddm-password-input";
+            }
+            else {
+                send_key "ret";
+                wait_idle;
+            }
+            type_string "$password";
+            send_key "ret";
+            send_key_until_needlematch "tty1-selected", $tty1_key, 6, 5;
+        }
+    }
+
+    # init
+    select_console 'root-console';
+
+    type_string "chown $username /dev/$serialdev\n";
+    # Export the existing status of running tasks and system load for future reference (fail would export it again)
+    script_run "ps axf > /tmp/psaxf.log";
+    script_run "cat /proc/loadavg > /tmp/loadavg_consoletest_setup.txt";
+
+    # Just after the setup: let's see the network configuration
+    script_run "ip addr show";
+    save_screenshot;
+
+    # Stop packagekit
+    script_run "systemctl mask packagekit.service";
+    script_run "systemctl stop packagekit.service";
+    # Installing a minimal system gives a pattern conflicting with anything not minimal
+    # Let's uninstall 'the pattern' (no packages affected) in order to be able to install stuff
+    script_run 'rpm -qi patterns-openSUSE-minimal_base-conflicts && zypper -n rm patterns-openSUSE-minimal_base-conflicts';
+    # Install curl and tar in order to get the test data
+    assert_script_run "zypper -n install curl tar";
+
+    # upload_logs requires curl, but we wanted the initial state of the system
+    upload_logs "/tmp/psaxf.log";
+    upload_logs "/tmp/loadavg_consoletest_setup.txt";
+
+    # BSC#997263 - VMware screen resolution defaults to 800x600
+    if (check_var('VIRSH_VMM_FAMILY', 'vmware')) {
+        assert_script_run("sed -ie '/GFXMODE=/s/=.*/=1024x768x32/' /etc/default/grub");
+        assert_script_run("sed -ie '/GFXPAYLOAD_LINUX=/s/=.*/=1024x768x32/' /etc/default/grub");
+        assert_script_run("grub2-mkconfig -o /boot/grub2/grub.cfg");
+    }
+
+    save_screenshot;
+
+    $self->clear_and_verify_console;
+
+    select_console 'user-console';
+
+    assert_script_run "curl -L -v -f " . autoinst_url('/data') . " > test.data";
+    assert_script_run " cpio -id < test.data";
+    script_run "ls -al data";
+
+    save_screenshot;
+}
+
+sub post_fail_hook() {
+    my $self = shift;
+
+    $self->export_logs();
+}
+
+sub test_flags() {
+    return {milestone => 1, fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/ha/firewall_disable.pm
+++ b/tests/ha/firewall_disable.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add HA tests
+#    - boot ha_support_server with dhcp/dns/ntp/iscsi services
+#    - configure ntp/iscsi/watchdog on nodes
+#    - create/join cluster using ha_cluster_init/join
+#    - create shared OCFS2 and check that it's really shared
+#    - check cluster status using crm_mon
+#    - fence a node and check that it's really fenced
+#    - grep /var/log to find segfaults at the end
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use base "hacluster";
 use strict;
 use testapi;

--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add HA tests
+#    - boot ha_support_server with dhcp/dns/ntp/iscsi services
+#    - configure ntp/iscsi/watchdog on nodes
+#    - create/join cluster using ha_cluster_init/join
+#    - create shared OCFS2 and check that it's really shared
+#    - check cluster status using crm_mon
+#    - fence a node and check that it's really fenced
+#    - grep /var/log to find segfaults at the end
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use base "hacluster";
 use strict;
 use testapi;

--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add HA tests
+#    - boot ha_support_server with dhcp/dns/ntp/iscsi services
+#    - configure ntp/iscsi/watchdog on nodes
+#    - create/join cluster using ha_cluster_init/join
+#    - create shared OCFS2 and check that it's really shared
+#    - check cluster status using crm_mon
+#    - fence a node and check that it's really fenced
+#    - grep /var/log to find segfaults at the end
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use base "hacluster";
 use strict;
 use testapi;

--- a/tests/ha/ha_cts_support_server.pm
+++ b/tests/ha/ha_cts_support_server.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add pacemaker-cts test
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use base "basetest";
 use strict;
 use testapi;

--- a/tests/ha/ha_support_server.pm
+++ b/tests/ha/ha_support_server.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add HA tests
+#    - boot ha_support_server with dhcp/dns/ntp/iscsi services
+#    - configure ntp/iscsi/watchdog on nodes
+#    - create/join cluster using ha_cluster_init/join
+#    - create shared OCFS2 and check that it's really shared
+#    - check cluster status using crm_mon
+#    - fence a node and check that it's really fenced
+#    - grep /var/log to find segfaults at the end
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use base "basetest";
 use strict;
 use testapi;

--- a/tests/ha/iscsi_client.pm
+++ b/tests/ha/iscsi_client.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add HA tests
+#    - boot ha_support_server with dhcp/dns/ntp/iscsi services
+#    - configure ntp/iscsi/watchdog on nodes
+#    - create/join cluster using ha_cluster_init/join
+#    - create shared OCFS2 and check that it's really shared
+#    - check cluster status using crm_mon
+#    - fence a node and check that it's really fenced
+#    - grep /var/log to find segfaults at the end
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use base "hacluster";
 use strict;
 use testapi;

--- a/tests/ha/ntp_client.pm
+++ b/tests/ha/ntp_client.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add HA tests
+#    - boot ha_support_server with dhcp/dns/ntp/iscsi services
+#    - configure ntp/iscsi/watchdog on nodes
+#    - create/join cluster using ha_cluster_init/join
+#    - create shared OCFS2 and check that it's really shared
+#    - check cluster status using crm_mon
+#    - fence a node and check that it's really fenced
+#    - grep /var/log to find segfaults at the end
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use base "hacluster";
 use strict;
 use testapi;

--- a/tests/ha/ocfs2.pm
+++ b/tests/ha/ocfs2.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Initial HA Validation Tests
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use base "hacluster";
 use strict;
 use testapi;

--- a/tests/ha/watchdog.pm
+++ b/tests/ha/watchdog.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add HA tests
+#    - boot ha_support_server with dhcp/dns/ntp/iscsi services
+#    - configure ntp/iscsi/watchdog on nodes
+#    - create/join cluster using ha_cluster_init/join
+#    - create shared OCFS2 and check that it's really shared
+#    - check cluster status using crm_mon
+#    - fence a node and check that it's really fenced
+#    - grep /var/log to find segfaults at the end
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use base "hacluster";
 use strict;
 use testapi;

--- a/tests/hpc/cpuid.pm
+++ b/tests/hpc/cpuid.pm
@@ -8,6 +8,15 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: HPC_Module: Add test for cpuid
+#    https://fate.suse.com/319512
+#
+#    At the moment this test is in a pretty undefined state, since it's not clarified yet,
+#    what needs to be tested exactly
+#
+#    For now, it only shows the output of 'cpuid' and prints it to the serialdev
+# G-Maintainer: soulofdestiny <mgriessmeier@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/hpc/install.pm
+++ b/tests/hpc/install.pm
@@ -8,6 +8,13 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: HPC_Module: standard installation
+#    This test is as simple as it can be at the moment, since we are at the very
+#    beginning of HPC testing
+#    It only adds the repo and installs the four important packages to check if there are any
+#    dependency issues
+# G-Maintainer: soulofdestiny <mgriessmeier@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/hpc/rasdaemon.pm
+++ b/tests/hpc/rasdaemon.pm
@@ -8,6 +8,15 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: HPC_Module: Add test for rasdaemon package
+#    https://fate.suse.com/318824
+#
+#    This tests the rasdaemon package from the HPC module
+#
+#    At the moment, it follows a very small testcase described in fate, which injects
+#    memory errors and see if rasdaemon is able to detect it
+# G-Maintainer: soulofdestiny <mgriessmeier@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/installation/add_update_test_repo.pm
+++ b/tests/installation/add_update_test_repo.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Support installation testing of SLE 12 with untested maint updates
+# G-Maintainer: sysrich <sysrich@linux.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/addon_products.pm
+++ b/tests/installation/addon_products.pm
@@ -8,6 +8,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: restructure opensuse install test code
+#    this splits monolitic yast1b and yast2 modules
+#    into finer grained single-task modules
+# G-Maintainer: Bernhard M. Wiedemann <bernhard+osautoinst lsmod de>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: rename sle's version of addon_products step
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/addon_products_yast2.pm
+++ b/tests/installation/addon_products_yast2.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add addon to SLES via DVD or URL
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/autoyast_reboot.pm
+++ b/tests/installation/autoyast_reboot.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: more autoyast fixes
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/boot_encrypt.pm
+++ b/tests/installation/boot_encrypt.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: splited wait_encrypt_prompt being a single step; harmonized once wait_encrypt_prompt obsoleted
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use strict;
 use base "installbasetest";
 use utils;

--- a/tests/installation/boot_into_snapshot.pm
+++ b/tests/installation/boot_into_snapshot.pm
@@ -14,6 +14,11 @@
 #  before_upgrade and after upgrade are not identical. test is made
 #  by checking the /etc/os-release, this is compatible also for openSUSE-TW (2)
 
+# G-Summary: Add new test boot_into_snapshot
+#    Main for opensuse changed. boot_into_snapshot test ronly snapshot
+#    Test needed for testing the snapper rollback functionality.
+# G-Maintainer: dmaiocchi <dmaiocchi@suse.com>
+
 use strict;
 use testapi;
 use base "y2logsstep";

--- a/tests/installation/boot_s390.pm
+++ b/tests/installation/boot_s390.pm
@@ -7,6 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add feature to boot into existing s390x zvm guest
+#    Verification run: http://lord.arch/tests/2064
+# G-Maintainer: Oliver Kurz <okurz@suse.de>
+
 use base "installbasetest";
 
 use testapi;

--- a/tests/installation/boot_windows.pm
+++ b/tests/installation/boot_windows.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "installbasetest";
 use strict;
 

--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -7,6 +7,44 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add Hyper-V libvirt tests
+#    This bootloader setups Hyper-V VM:
+#
+#    1. Connects to VIRSH_HOST via SSH,
+#    2. starts a VNC server there,
+#    3. RDP connection to a VM on HYPERV_SERVER via xfreerdp is created,
+#    4. openQA connects to the VNC server.
+#
+#    Server requirements:
+#
+#    * Windows Server 2008 R2, 2012 R2, or 2016 (TP5) - a Datacenter edition,
+#    * Hyper-V and RDP roles are installed,
+#    * telnet server (WS 2008 R2 and 2012 R2 contain telnet service, WS 2016
+#      does not and e.g. telnetd from Cygwin has to be installed),
+#    * program which enables VM's serial port for connection from outside
+#      (Hyper-V enables serial port as a Windows named pipe \\.\pipe\NAME),
+#      e.g. "Named Pipe TCP Proxy Utility" (which is not a scriptable, it's
+#      an GUI app...),
+#    * open ports in firewall, perhaps add above program as an exception to
+#      the firewall,
+#    * WS 2008 R2 requires Powershell and "PowerShell management Library for
+#      Hyper-V" (http://pshyperv.codeplex.com).
+#
+#    Intermediary VIRSH_HOST requirements:
+#
+#    * sshd, VNC server,
+#    * FreeRDP where https://github.com/FreeRDP/FreeRDP/issues/2421 is
+#      fixed.
+#
+#    Caveats:
+#
+#    * FreeRDP does not work for Windows Server 2016 (TP5), see
+#      https://github.com/FreeRDP/FreeRDP/issues/3325,
+#    * so far VM in RDP connection which is displayed by a VNC server on
+#      VIRSH_HOST is not getting "System Keys" (e.g. Ctrl- Alt-F2 for console
+#      change).
+# G-Maintainer: Michal Nowak <mnowak@suse.com>
+
 use base "installbasetest";
 
 use testapi;

--- a/tests/installation/bootloader_ofw.pm
+++ b/tests/installation/bootloader_ofw.pm
@@ -8,6 +8,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add first PowerPC test
+#    Signed-off-by: Dinar Valeev <dvaleev@suse.com>
+# G-Maintainer: Dinar Valeev <dvaleev@suse.com>
+
 use base "installbasetest";
 use strict;
 

--- a/tests/installation/bootloader_ofw_yaboot.pm
+++ b/tests/installation/bootloader_ofw_yaboot.pm
@@ -8,6 +8,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add yaboot test
+#    Signed-off-by: Dinar Valeev <dvaleev@suse.com>
+# G-Maintainer: Dinar Valeev <dvaleev@suse.com>
+
 use base "installbasetest";
 use strict;
 use testapi;

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add get_to_yast.pm, rename to bootloader_s390.pm
+# G-Maintainer: Susanne Oberhauser <froh@suse.com>
+
 use base "installbasetest";
 
 use testapi;

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add svirt bootloader (JeOS, and FTP install)
+# G-Maintainer: Michal Nowak <mnowak@suse.com>
+
 use base "installbasetest";
 use strict;
 use warnings;

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "installbasetest";
 use strict;
 

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: an experimental bootloader using virsh over ssh
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "installbasetest";
 
 use testapi;

--- a/tests/installation/change_desktop.pm
+++ b/tests/installation/change_desktop.pm
@@ -9,6 +9,9 @@
 # without any warranty.
 
 package change_desktop;
+# G-Summary: [OOP]Change desktop for sle12 & sle11
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/check_medium.pm
+++ b/tests/installation/check_medium.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add some SLE11 tests for consistency in the branches
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/disk_activation.pm
+++ b/tests/installation/disk_activation.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: s390 DASD Disk activation test
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/disk_space_fill.pm
+++ b/tests/installation/disk_space_fill.pm
@@ -7,6 +7,17 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Warning for migrations with low disk spacefate#11438
+#
+#    If variable UPGRADE=LOW_SPACE is present allocate most of the disk
+#    space before installation. Warning should be visible in installation
+#    overview.
+#
+#    Then parse required size from warning message and free disk space
+#    accordingly. Refresh overview screen and if warning message disappear
+#    start installation.
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/disk_space_release.pm
+++ b/tests/installation/disk_space_release.pm
@@ -7,6 +7,17 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Warning for migrations with low disk spacefate#11438
+#
+#    If variable UPGRADE=LOW_SPACE is present allocate most of the disk
+#    space before installation. Warning should be visible in installation
+#    overview.
+#
+#    Then parse required size from warning message and free disk space
+#    accordingly. Refresh overview screen and if warning message disappear
+#    start installation.
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/dud_addon.pm
+++ b/tests/installation/dud_addon.pm
@@ -7,6 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Addon added via dud
+#    https://trello.com/c/h7DzsthA/647-3-sle-12-sp2-p1-992608-add-ons-added-via-add-on-products-xml-are-lost-after-self-update
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/encrypted_volume_activation.pm
+++ b/tests/installation/encrypted_volume_activation.pm
@@ -7,6 +7,17 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Create new test module encrypted volume activation
+#    When the variable ENCRYPTED_CANCEL_EXISTING is set, it will cancel the
+#    activate encrypted volume prompt which appears during installation to a
+#    storage device with existing encrypted lvm volume. A workaround is
+#    implemented for bsc#989770 which causes the activation prompt to be
+#    displayed twice.
+#
+#    When the variable ENCRYPTED_ACTIVATE_EXISTING is set it will enter the
+#    password for the existing volume to activate it.
+# G-Maintainer: Richard Palethorpe <rpalethorpe@suse.com>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/finish_desktop.pm
+++ b/tests/installation/finish_desktop.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: move all inst/$DESKTOP.pm into one global 999_finish_desktop and runthe tests from start.pl
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "installbasetest";
 use testapi;
 use strict;

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: renamed 091_second_stage to 091_first_boot
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/good_buttons.pm
+++ b/tests/installation/good_buttons.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add a button bar test
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -8,6 +8,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rename livecdreboot, moved grub code in grub_test.pm
+#    Livecdreboot test name was unclear, renamed it in to install_and_reboot.
+#    The code concerning grub test has moved to new test grub_test.pm
+#    Main pm adapted for the new grub_test.pm
+#    In first_boot.pm added get_var(boot_into_snapshot) for assert linux-terminal,
+#    since after booting on snapshot, only a terminal interface is given, not GUI.
+#
+#    Issues on progress: 9716,10286,10164
+# G-Maintainer: dmaiocchi <dmaiocchi@suse.com>
+
 use strict;
 use base "basetest";
 use testapi;

--- a/tests/installation/hostname_inst.pm
+++ b/tests/installation/hostname_inst.pm
@@ -7,6 +7,50 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Hostname in YaST Installer is set properly
+#    PR#11456 (FATE#319639)
+#
+#    This test makes sure that correct hostname is set during installation.
+#    Basicly if no hostname comes from environment (DHCP), it's set to
+#    "install".
+#
+#    Test cases covered (and to be implemented in openQA):
+#
+#    Test1
+#    Start installation without additional param on kernel cmd line.
+#    Check whether hostname 'install' is set
+#    /usr/share/openqa/script/clone_job.pl --from http://openqa.suse.de
+#    --host localhost 490017 INSTALLONLY=1
+#    http://assam.suse.cz/tests/2313#step/hostname_inst/5
+#
+#    Test2
+#    Start installation with ifcfg=..., means set up a static network (without
+#    dhcp).
+#    Check whether hostname 'install' is set.
+#    /usr/share/openqa/script/clone_job.pl --from http://openqa.suse.de
+#    --host localhost 490017 EXTRABOOTPARAMS="ifcfg=10.0.2.99/24"
+#    INSTALLONLY=1
+#    http://assam.suse.cz/tests/2317#step/hostname_inst/5
+#
+#    Test3
+#    Start qemu with `-netdev user,hostname=myhostname`. Start installation
+#    ifcfg=*=dhcp.
+#    Check whether hostname is set to 'myhostname'.
+#    /usr/share/openqa/script/clone_job.pl --from http://openqa.suse.de
+#    --host localhost 490017 EXTRABOOTPARAMS="ifcfg=*=dhcp"
+#    EXPECTED_INSTALL_HOSTNAME=myhostname
+#    NICTYPE_USER_OPTIONS="hostname=myhostname" INSTALLONLY=1
+#    http://assam.suse.cz/tests/2316#step/hostname_inst/5
+#
+#    Test4
+#    Start installation with `hostname=myhostname` on kernel cmd line. Check
+#    whether hostname is set to 'myhostname'.
+#    /usr/share/openqa/script/clone_job.pl --from http://openqa.suse.de
+#    --host localhost 490017 EXTRABOOTPARAMS="hostname=myhostname"
+#    EXPECTED_INSTALL_HOSTNAME=myhostname INSTALLONLY=1
+#    http://assam.suse.cz/tests/2312#step/hostname_inst/5
+# G-Maintainer: Michal Nowak <mnowak@suse.com>
+
 use base "y2logsstep";
 use strict;
 use warnings;

--- a/tests/installation/inst_mediacheck.pm
+++ b/tests/installation/inst_mediacheck.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: work on improving the delta between openSUSE and sle
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -8,6 +8,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rename livecdreboot, moved grub code in grub_test.pm
+#    Livecdreboot test name was unclear, renamed it in to install_and_reboot.
+#    The code concerning grub test has moved to new test grub_test.pm
+#    Main pm adapted for the new grub_test.pm
+#    In first_boot.pm added get_var(boot_into_snapshot) for assert linux-terminal,
+#    since after booting on snapshot, only a terminal interface is given, not GUI.
+#
+#    Issues on progress: 9716,10286,10164
+# G-Maintainer: dmaiocchi <dmaiocchi@suse.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/installation_enlargeswap.pm
+++ b/tests/installation/installation_enlargeswap.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add test to check enlarge swap for suspend
+# G-Maintainer: Zaoliang Luo <zluo@e13.suse.de>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/installation_mode.pm
+++ b/tests/installation/installation_mode.pm
@@ -8,6 +8,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: restructure opensuse install test code
+#    this splits monolitic yast1b and yast2 modules
+#    into finer grained single-task modules
+# G-Maintainer: Bernhard M. Wiedemann <bernhard+osautoinst lsmod de>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -8,6 +8,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: restructure opensuse install test code
+#    this splits monolitic yast1b and yast2 modules
+#    into finer grained single-task modules
+# G-Maintainer: Bernhard M. Wiedemann <bernhard+osautoinst lsmod de>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/installation_overview_before.pm
+++ b/tests/installation/installation_overview_before.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Check installation overview befoer and after any pattern change
+# G-Maintainer: sysrich <sysrich@linux.com>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/installcheck.pm
+++ b/tests/installation/installcheck.pm
@@ -7,6 +7,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: New test to run installcheck on ISO
+#    I'm reusing the support server image to get an install check log - to be
+#    added to big staging projects with many changes
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/installation/installer_desktopselection.pm
+++ b/tests/installation/installer_desktopselection.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: change to nicer directory structure
+# G-Maintainer: Bernhard M. Wiedemann <bernhard+osautoinst lsmod de>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/installer_timezone.pm
+++ b/tests/installation/installer_timezone.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: change to nicer directory structure
+# G-Maintainer: Bernhard M. Wiedemann <bernhard+osautoinst lsmod de>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/iscsi_configuration.pm
+++ b/tests/installation/iscsi_configuration.pm
@@ -7,6 +7,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Configuration of iSCSI installation
+#    check if iBFT is present
+#    select iSCSI disk to install system on
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/isosize.pm
+++ b/tests/installation/isosize.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/installation/live_installation.pm
+++ b/tests/installation/live_installation.pm
@@ -7,6 +7,20 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add test for live installer based on Kde-Live
+#    The live installer was missing for some time from the media and the left overs
+#    in tests showed to be out of date. Changing all necessary references to ensure
+#    the live medium can be booted, the net installer can be run from the plasma
+#    session and the installed Tumbleweed system boots correctly. In the process an
+#    issue with the live installer has been found and is worked around while
+#    recording a reference to the bug.
+#
+#    Adds new variable 'LIVE_INSTALLATION'. 'LIVETEST' must not be set but only
+#    'LIVECD'.
+#
+#    Verification run: http://lord.arch/tests/3043
+# G-Maintainer: Oliver Kurz <okurz@suse.de>
+
 use base "installbasetest";
 use testapi;
 use strict;

--- a/tests/installation/livecd_network_settings.pm
+++ b/tests/installation/livecd_network_settings.pm
@@ -7,6 +7,20 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add test for live installer based on Kde-Live
+#    The live installer was missing for some time from the media and the left overs
+#    in tests showed to be out of date. Changing all necessary references to ensure
+#    the live medium can be booted, the net installer can be run from the plasma
+#    session and the installed Tumbleweed system boots correctly. In the process an
+#    issue with the live installer has been found and is worked around while
+#    recording a reference to the bug.
+#
+#    Adds new variable 'LIVE_INSTALLATION'. 'LIVETEST' must not be set but only
+#    'LIVECD'.
+#
+#    Verification run: http://lord.arch/tests/3043
+# G-Maintainer: Oliver Kurz <okurz@suse.de>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/logpackages.pm
+++ b/tests/installation/logpackages.pm
@@ -8,6 +8,12 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: write instsys and initrd package lists to log
+#    this allows to better check and compare versions
+#    to find what might have introduced a bug
+#    or if the new version with a proposed fix is already included.
+# G-Maintainer: Bernhard M. Wiedemann <bernhard+osautoinst lsmod de>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/mediacheck.pm
+++ b/tests/installation/mediacheck.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/installation/mediacheck_yaboot.pm
+++ b/tests/installation/mediacheck_yaboot.pm
@@ -8,6 +8,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add bootting mediacheck from yaboot
+#    Signed-off-by: Dinar Valeev <dvaleev@suse.com>
+# G-Maintainer: Dinar Valeev <dvaleev@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/installation/memtest.pm
+++ b/tests/installation/memtest.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Refactor mediacheck and memtest tests.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/installation/mouse_hide.pm
+++ b/tests/installation/mouse_hide.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Test to see if mouse is hidden - to be run before/as part of installation_mode
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use base "opensusebasetest";
 use testapi;
 use strict;

--- a/tests/installation/multipath.pm
+++ b/tests/installation/multipath.pm
@@ -8,6 +8,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Enable multipath test
+#    Signed-off-by: Dinar Valeev <dvaleev@suse.com>
+# G-Maintainer: Dinar Valeev <dvaleev@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: change to nicer directory structure
+# G-Maintainer: Bernhard M. Wiedemann <bernhard+osautoinst lsmod de>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/partitioning_filesystem.pm
+++ b/tests/installation/partitioning_filesystem.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Refactor partitioning test to handle all supported filesystems - needles present already
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/partitioning_finish.pm
+++ b/tests/installation/partitioning_finish.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/partitioning_firstdisk.pm
+++ b/tests/installation/partitioning_firstdisk.pm
@@ -7,6 +7,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: New test to take the first disk
+#    Otherwise the partitioning proposal will use a free disk, which makes
+#    rebooting a game of chance on real hardware
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/partitioning_iscsi.pm
+++ b/tests/installation/partitioning_iscsi.pm
@@ -7,6 +7,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Configuration of iSCSI installation
+#    check if iBFT is present
+#    select iSCSI disk to install system on
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/partitioning_lvm.pm
+++ b/tests/installation/partitioning_lvm.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split the paritioning monster into smaller pieces
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/partitioning_raid_sle11.pm
+++ b/tests/installation/partitioning_raid_sle11.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Half finished sle11 partitioning software raidtest
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/partitioning_resize_root.pm
+++ b/tests/installation/partitioning_resize_root.pm
@@ -12,6 +12,24 @@
 # Maintainer: okurz@suse.de
 # Tags: bsc#989976, bsc#1000165
 
+# G-Summary: Add test to resize the root volume of a LVM
+#    Verification test for bsc#989976, bsc#1000165.
+#
+#    The installer by default selects a root volume of maximum 40GB regardless of
+#    the available space. If the user resizes the volume, the btrfs subvolumes are
+#    not shown (although they are still created). This test verifies the subvolumes
+#    are present after resizing the root volume. The home volume is disabled
+#    (TOGGLEHOME=1) to actually provide the space for the root volume. Otherwise the
+#    available space would all be consumed by the home volume.
+#
+#    Triggered with variables:
+#    * TOGGLEHOME=1
+#    * RESIZE_ROOT_VOLUME=1
+#    * HDDSIZEGB=50
+#
+#    Local verification run: http://lord.arch/tests/4961
+# G-Maintainer: Oliver Kurz <okurz@suse.de>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/partitioning_sle11.pm
+++ b/tests/installation/partitioning_sle11.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add some SLE11 tests for consistency in the branches
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/partitioning_sle11_desktop_sdk.pm
+++ b/tests/installation/partitioning_sle11_desktop_sdk.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Urgent partioning fix for SLED 11 SP4 GMC
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/partitioning_splitusr.pm
+++ b/tests/installation/partitioning_splitusr.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/partitioning_togglehome.pm
+++ b/tests/installation/partitioning_togglehome.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split the paritioning monster into smaller pieces
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/post_zdup.pm
+++ b/tests/installation/post_zdup.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "installbasetest";
 use strict;
 use testapi;

--- a/tests/installation/proxy_boot.pm
+++ b/tests/installation/proxy_boot.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Initial HA Validation Tests
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use base "installbasetest";
 use strict;
 use testapi;

--- a/tests/installation/proxy_init.pm
+++ b/tests/installation/proxy_init.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Restructure HA tests for resilience, maintainability, and awesomeness
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use base "installbasetest";
 use strict;
 use testapi;

--- a/tests/installation/proxy_ssh.pm
+++ b/tests/installation/proxy_ssh.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Restructure HA tests for resilience, maintainability, and awesomeness
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use base "installbasetest";
 use strict;
 use testapi;

--- a/tests/installation/proxy_start_2nd_stage.pm
+++ b/tests/installation/proxy_start_2nd_stage.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Restructure HA tests for resilience, maintainability, and awesomeness
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use base "installbasetest";
 use strict;
 use testapi;

--- a/tests/installation/reboot_after_install.pm
+++ b/tests/installation/reboot_after_install.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add random reboot after install
+# G-Maintainer: Bernhard M. Wiedemann <bernhard+osautoinst lsmod de>
+
 use base "installbasetest";
 use strict;
 use testapi;

--- a/tests/installation/reboot_eject_cd.pm
+++ b/tests/installation/reboot_eject_cd.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: splited wait_encrypt_prompt being a single step; harmonized once wait_encrypt_prompt obsoleted
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/reconnect_s390.pm
+++ b/tests/installation/reconnect_s390.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: added functionality for reconnecting s390-consoles after reboot
+# G-Maintainer: Matthias Grießmeier <mgriessmeier@suse.de>
+
 use base "installbasetest";
 
 use testapi;

--- a/tests/installation/redefine_svirt_domain.pm
+++ b/tests/installation/redefine_svirt_domain.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Split the svirt redefine to another test
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "installbasetest";
 use strict;
 use testapi;

--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: SLE12 release notes
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/rescuesystem.pm
+++ b/tests/installation/rescuesystem.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add Rescue System test.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/installation/rescuesystem_validate_131.pm
+++ b/tests/installation/rescuesystem_validate_131.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split the rescuesystem test to allow overwriting the validation
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/installation/rescuesystem_validate_sle.pm
+++ b/tests/installation/rescuesystem_validate_sle.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Validate any SLES image not only one version
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/installation/rescuesystem_yaboot.pm
+++ b/tests/installation/rescuesystem_yaboot.pm
@@ -8,6 +8,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add bootting rescue from yaboot
+#    Signed-off-by: Dinar Valeev <dvaleev@suse.com>
+# G-Maintainer: Dinar Valeev <dvaleev@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/installation/scc_registration.pm
+++ b/tests/installation/scc_registration.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: work on improving the delta between openSUSE and sle
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use strict;
 use base "y2logsstep";
 

--- a/tests/installation/secure_boot.pm
+++ b/tests/installation/secure_boot.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add secure boot test. Add SECUREBOOT variable.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/select_patterns.pm
+++ b/tests/installation/select_patterns.pm
@@ -8,6 +8,15 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: adding a test that selects given PATTERNS
+#    You can pass
+#    PATTERNS=minimal,base or
+#    PATTERNS=all to select all of them
+#
+#    For this you need to have needles that provide pattern-base,pattern-minimal...
+#    additional to the on-pattern tag
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/select_patterns_sle11.pm
+++ b/tests/installation/select_patterns_sle11.pm
@@ -8,6 +8,15 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: adding a test that selects given PATTERNS
+#    You can pass
+#    PATTERNS=minimal,base or
+#    PATTERNS=all to select all of them
+#
+#    For this you need to have needles that provide pattern-base,pattern-minimal...
+#    additional to the on-pattern tag
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/server_base_scenario.pm
+++ b/tests/installation/server_base_scenario.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add some SLE11 tests for consistency in the branches
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/installation/setup_online_repos.pm
+++ b/tests/installation/setup_online_repos.pm
@@ -8,6 +8,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: New test: test installation with update repos
+#    Basically for Leap only. https://progress.opensuse.org/issues/9620
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "installbasetest";
 use strict;
 use testapi;

--- a/tests/installation/skip_disk_activation.pm
+++ b/tests/installation/skip_disk_activation.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: an experimental bootloader using virsh over ssh
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/skip_registration.pm
+++ b/tests/installation/skip_registration.pm
@@ -13,6 +13,11 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: split scc registration
+#    makes it more obvious if a test doesn't actually register during
+#    installation
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use strict;
 use base "y2logsstep";
 

--- a/tests/installation/sle11_hardware_config.pm
+++ b/tests/installation/sle11_hardware_config.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: prepare some more tests for sle11
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/sle11_install_finish.pm
+++ b/tests/installation/sle11_install_finish.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: prepare some more tests for sle11
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/sle11_ncc.pm
+++ b/tests/installation/sle11_ncc.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: prepare some more tests for sle11
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/sle11_network.pm
+++ b/tests/installation/sle11_network.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: prepare some more tests for sle11
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/sle11_online_update.pm
+++ b/tests/installation/sle11_online_update.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: sle11 ncc testsuite
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/sle11_releasenotes.pm
+++ b/tests/installation/sle11_releasenotes.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: prepare some more tests for sle11
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/sle11_service.pm
+++ b/tests/installation/sle11_service.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: prepare some more tests for sle11
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/sle11_skip_ncc.pm
+++ b/tests/installation/sle11_skip_ncc.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: prepare some more tests for sle11
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/sle11_user_authentication_method.pm
+++ b/tests/installation/sle11_user_authentication_method.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: prepare some more tests for sle11
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/sle11_wait_for_2nd_stage.pm
+++ b/tests/installation/sle11_wait_for_2nd_stage.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add an explicit wait for 2nd stage step in sle11
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/installation/sles4sap_product_installation_mode.pm
+++ b/tests/installation/sles4sap_product_installation_mode.pm
@@ -1,4 +1,7 @@
 #!/usr/bin/perl -w
+# G-Summary: Add SLES4SAP tests
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/sles4sap_wizard.pm
+++ b/tests/installation/sles4sap_wizard.pm
@@ -1,4 +1,7 @@
 #!/usr/bin/perl -w
+# G-Summary: Add SLES4SAP tests
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/sles4sap_wizard_nw.pm
+++ b/tests/installation/sles4sap_wizard_nw.pm
@@ -1,4 +1,7 @@
 #!/usr/bin/perl -w
+# G-Summary: Add SLES4SAP tests
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/sles4sap_wizard_swpm.pm
+++ b/tests/installation/sles4sap_wizard_swpm.pm
@@ -1,4 +1,7 @@
 #!/usr/bin/perl -w
+# G-Summary: Add SLES4SAP tests
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/sles4sap_wizard_trex.pm
+++ b/tests/installation/sles4sap_wizard_trex.pm
@@ -1,4 +1,7 @@
 #!/usr/bin/perl -w
+# G-Summary: Add SLES4SAP tests
+# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/smt_configuration.pm
+++ b/tests/installation/smt_configuration.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: installation + SMT addon
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/ssh_key_setup.pm
+++ b/tests/installation/ssh_key_setup.pm
@@ -7,6 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add ssh key dialog test
+#    https://progress.opensuse.org/issues/11454 https://github.com/yast/skelcd-control-SLES/blob/d2f9a79c0681806bf02eb38c4b7c287b9d9434eb/control/control.SLES.xml#L53-L71
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -8,6 +8,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: restructure opensuse install test code
+#    this splits monolitic yast1b and yast2 modules
+#    into finer grained single-task modules
+# G-Maintainer: Bernhard M. Wiedemann <bernhard+osautoinst lsmod de>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add new SP2 feature (System role)
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/upgrade_select_opensuse.pm
+++ b/tests/installation/upgrade_select_opensuse.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Split openSUSE specific part from upgrade_select
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/upgrade_select_sle11.pm
+++ b/tests/installation/upgrade_select_sle11.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: fix upgrade for sle11 and tidy
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/installation/user_import.pm
+++ b/tests/installation/user_import.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Use existing encrypted volume and import users
+#    When ENCRYPT_ACTIVATE_EXISTING is set, check that the existing volumes
+#    have been detected and included in the default partitioning volume. If
+#    not, issue soft failure bsc#989750 and rerun partition proposal without asserting
+#    for new password prompts.
+#
+#    Added IMPORT_USER_DATA which when set, user_import.pm is loaded to
+#    import old users rather than configure new ones.
+# G-Maintainer: Richard Palethorpe <rpalethorpe@suse.com>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/user_settings.pm
+++ b/tests/installation/user_settings.pm
@@ -8,6 +8,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: restructure opensuse install test code
+#    this splits monolitic yast1b and yast2 modules
+#    into finer grained single-task modules
+# G-Maintainer: Bernhard M. Wiedemann <bernhard+osautoinst lsmod de>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/user_settings_root.pm
+++ b/tests/installation/user_settings_root.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split the root user setup in a 2nd test
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split & unify opensuse install scripts part1
+# G-Maintainer: Bernhard M. Wiedemann <bernhard+osautoinst lsmod de>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/installation/win10_firstboot.pm
+++ b/tests/installation/win10_firstboot.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Split Windows 10 test
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "installbasetest";
 use strict;
 

--- a/tests/installation/win10_installation.pm
+++ b/tests/installation/win10_installation.pm
@@ -7,6 +7,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Windows 10 installation test module
+#    modiffied (only win10 drivers) iso from https://fedoraproject.org/wiki/Windows_Virtio_Drivers is needed
+#    Works only with CDMODEL=ide-cd and QEMUCPU=host or core2duo (maybe other but not qemu64)
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "installbasetest";
 use strict;
 

--- a/tests/installation/win10_reboot.pm
+++ b/tests/installation/win10_reboot.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add separate windows reboot test
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "installbasetest";
 use strict;
 

--- a/tests/installation/win10_shutdown.pm
+++ b/tests/installation/win10_shutdown.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Split Windows 10 test
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "installbasetest";
 use strict;
 

--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "installbasetest";
 use strict;
 use testapi;

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -7,6 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Test suite for iSCSI server and client
+#    Multimachine testsuites, server test creates iscsi target and client test uses it
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -7,6 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Test suite for iSCSI server and client
+#    Multimachine testsuites, server test creates iscsi target and client test uses it
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/jeos/diskusage.pm
+++ b/tests/jeos/diskusage.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: First commit of JeOS firstrun, diskusage, sccreg, and imgsize tests
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: First commit of JeOS firstrun, diskusage, sccreg, and imgsize tests
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/jeos/grub2_gfxmode.pm
+++ b/tests/jeos/grub2_gfxmode.pm
@@ -11,6 +11,11 @@
 # 1024x768 of the cirrus kms driver doesn't help us. We need to
 # manually configure grub to tell the kernel what mode to use.
 
+# G-Summary: set gfxplayload for grub
+#    JeOS doesn't inherit the gfx settings from the first boot so we need
+#    to adjust the grub config manually to survive reboots.
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/jeos/mount_by_label.pm
+++ b/tests/jeos/mount_by_label.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: jeos tests
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/jeos/root_fs_size.pm
+++ b/tests/jeos/root_fs_size.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: jeos tests
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/jeos/sccreg.pm
+++ b/tests/jeos/sccreg.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: First commit of JeOS firstrun, diskusage, sccreg, and imgsize tests
+# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/linuxrc/system_boot.pm
+++ b/tests/linuxrc/system_boot.pm
@@ -8,6 +8,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Added Linuxrc test for booting the installed system
+#    - bsc#906990
+#    - Requires linuxrc-5.0.44 and higher to be used for install media
+# G-Maintainer: Lukas Ocilka <lukas.ocilka@gmail.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/login/boot.pm
+++ b/tests/login/boot.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Modification for main.pm and login without install script. Need to set REGRESSION and KEEPHDDS to enable it
+# G-Maintainer: nick wang <nwang@suse.com>
+
 use base "basetest";
 use strict;
 use testapi;

--- a/tests/offline_migration/upgrade_glib2_pango32bit.pm
+++ b/tests/offline_migration/upgrade_glib2_pango32bit.pm
@@ -7,6 +7,15 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add case upgrade_glib2_pango32bit to fix bsc#978972
+#    Migration from SLED11SP4 to SLED12SP2 is failed since libpango
+#    dependency problem, the fix of this bug has been released to MU.
+#    This script will update the package and create a new SLED11 image
+#    for openQA's offline_migration test.
+#
+#    See also: bsc#978972
+# G-Maintainer: Chingkai <qkzhu@suse.com>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/online_migration/sle11/add_beta_repos.pm
+++ b/tests/online_migration/sle11/add_beta_repos.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: sle11 online migration testsuite
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/online_migration/sle11/check_upload_repos.pm
+++ b/tests/online_migration/sle11/check_upload_repos.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: sle11 online migration testsuite
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/online_migration/sle11/reboot_to_console.pm
+++ b/tests/online_migration/sle11/reboot_to_console.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: sle11 online migration testsuite
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "basetest";
 use strict;
 use testapi;

--- a/tests/online_migration/sle11/yast2_online_update.pm
+++ b/tests/online_migration/sle11/yast2_online_update.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: sle11 online migration testsuite
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/online_migration/sle11/yast2_wagon.pm
+++ b/tests/online_migration/sle11/yast2_wagon.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: sle11 online migration testsuite
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/online_migration/sle12_online_migration/online_migration_setup.pm
+++ b/tests/online_migration/sle12_online_migration/online_migration_setup.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add sle12 online migration testsuite
+#    Fixes follow up by the comments
+#
+#    Apply fully patch system function
+#
+#    Fix typo and remove redundant comment
+#
+#    Remove a unnecessary line
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/online_migration/sle12_online_migration/post_migration.pm
+++ b/tests/online_migration/sle12_online_migration/post_migration.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add sle12 online migration testsuite
+#    Fixes follow up by the comments
+#
+#    Apply fully patch system function
+#
+#    Fix typo and remove redundant comment
+#
+#    Remove a unnecessary line
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "installbasetest";
 use strict;
 use testapi;

--- a/tests/online_migration/sle12_online_migration/pre_migration.pm
+++ b/tests/online_migration/sle12_online_migration/pre_migration.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add sle12 online migration testsuite
+#    Fixes follow up by the comments
+#
+#    Apply fully patch system function
+#
+#    Fix typo and remove redundant comment
+#
+#    Remove a unnecessary line
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/online_migration/sle12_online_migration/register_system.pm
+++ b/tests/online_migration/sle12_online_migration/register_system.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add sle12 online migration testsuite
+#    Fixes follow up by the comments
+#
+#    Apply fully patch system function
+#
+#    Fix typo and remove redundant comment
+#
+#    Remove a unnecessary line
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/online_migration/sle12_online_migration/repos_check.pm
+++ b/tests/online_migration/sle12_online_migration/repos_check.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add compatibility to check smt and nvidia repos
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/online_migration/sle12_online_migration/snapper_rollback.pm
+++ b/tests/online_migration/sle12_online_migration/snapper_rollback.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add sle12 online migration testsuite
+#    Fixes follow up by the comments
+#
+#    Apply fully patch system function
+#
+#    Fix typo and remove redundant comment
+#
+#    Remove a unnecessary line
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/online_migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/online_migration/sle12_online_migration/yast2_migration.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add sle12 online migration testsuite
+#    Fixes follow up by the comments
+#
+#    Apply fully patch system function
+#
+#    Fix typo and remove redundant comment
+#
+#    Remove a unnecessary line
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "y2logsstep";
 use strict;
 use testapi;

--- a/tests/online_migration/sle12_online_migration/zypper_migration.pm
+++ b/tests/online_migration/sle12_online_migration/zypper_migration.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add sle12 online migration testsuite
+#    Fixes follow up by the comments
+#
+#    Apply fully patch system function
+#
+#    Fix typo and remove redundant comment
+#
+#    Remove a unnecessary line
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "installbasetest";
 use strict;
 use testapi;

--- a/tests/online_migration/sle12_online_migration/zypper_patch.pm
+++ b/tests/online_migration/sle12_online_migration/zypper_patch.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add sle12 online migration testsuite
+#    Fixes follow up by the comments
+#
+#    Apply fully patch system function
+#
+#    Fix typo and remove redundant comment
+#
+#    Remove a unnecessary line
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/qa_automation/acceptance.pm
+++ b/tests/qa_automation/acceptance.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Second upload of qa_automation/acceptance.pm
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/acceptance_fs_stress.pm
+++ b/tests/qa_automation/acceptance_fs_stress.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: splite acceptance test into three to avoid timeout issue
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/acceptance_process_stress.pm
+++ b/tests/qa_automation/acceptance_process_stress.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: splite acceptance test into three to avoid timeout issue
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/acceptance_sched_stress.pm
+++ b/tests/qa_automation/acceptance_sched_stress.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: splite acceptance test into three to avoid timeout issue
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_autotest.pm
+++ b/tests/qa_automation/kernel_autotest.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add autotest tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_libhugetlbfs.pm
+++ b/tests/qa_automation/kernel_libhugetlbfs.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: Add 4 more kernel regression testsuits
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_lmbench.pm
+++ b/tests/qa_automation/kernel_lmbench.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: Add 4 more kernel regression testsuits
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_aio_stress.pm
+++ b/tests/qa_automation/kernel_ltp_aio_stress.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_aiodio.pm
+++ b/tests/qa_automation/kernel_ltp_aiodio.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_commands.pm
+++ b/tests/qa_automation/kernel_ltp_commands.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_connectors.pm
+++ b/tests/qa_automation/kernel_ltp_connectors.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: Add four new ltp subtest to regression test
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_containers.pm
+++ b/tests/qa_automation/kernel_ltp_containers.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_controllers.pm
+++ b/tests/qa_automation/kernel_ltp_controllers.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_dio.pm
+++ b/tests/qa_automation/kernel_ltp_dio.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_fcntl_locktests.pm
+++ b/tests/qa_automation/kernel_ltp_fcntl_locktests.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: Add four new ltp subtest to regression test
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_filecaps.pm
+++ b/tests/qa_automation/kernel_ltp_filecaps.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: Add four new ltp subtest to regression test
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_fs.pm
+++ b/tests/qa_automation/kernel_ltp_fs.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_fs_perms_simple.pm
+++ b/tests/qa_automation/kernel_ltp_fs_perms_simple.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_fstests.pm
+++ b/tests/qa_automation/kernel_ltp_fstests.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_fsx.pm
+++ b/tests/qa_automation/kernel_ltp_fsx.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_hugetlb.pm
+++ b/tests/qa_automation/kernel_ltp_hugetlb.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: Add four new ltp subtest to regression test
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_input.pm
+++ b/tests/qa_automation/kernel_ltp_input.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_ipc.pm
+++ b/tests/qa_automation/kernel_ltp_ipc.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_kernel_misc.pm
+++ b/tests/qa_automation/kernel_ltp_kernel_misc.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_leapsec.pm
+++ b/tests/qa_automation/kernel_ltp_leapsec.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_math.pm
+++ b/tests/qa_automation/kernel_ltp_math.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_mm.pm
+++ b/tests/qa_automation/kernel_ltp_mm.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_openposix.pm
+++ b/tests/qa_automation/kernel_ltp_openposix.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_pipes.pm
+++ b/tests/qa_automation/kernel_ltp_pipes.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_pty.pm
+++ b/tests/qa_automation/kernel_ltp_pty.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_quickhit.pm
+++ b/tests/qa_automation/kernel_ltp_quickhit.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_sched.pm
+++ b/tests/qa_automation/kernel_ltp_sched.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_syscalls.pm
+++ b/tests/qa_automation/kernel_ltp_syscalls.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_ltp_timers.pm
+++ b/tests/qa_automation/kernel_ltp_timers.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: [qa_automation] Add ltp tests
+# G-Maintainer: Nathan Zhao <jtzhao@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_lvm2_120.pm
+++ b/tests/qa_automation/kernel_lvm2_120.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: Add 4 more kernel regression testsuits
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_lynis.pm
+++ b/tests/qa_automation/kernel_lynis.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: Add 4 more kernel regression testsuits
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_memeat.pm
+++ b/tests/qa_automation/kernel_memeat.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: Add kernel regression test memeat and memtester
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/kernel_memtester.pm
+++ b/tests/qa_automation/kernel_memtester.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: Add kernel regression test memeat and memtester
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -9,6 +9,10 @@
 #
 
 # inherit qa_run, but overwrite run
+# G-Summary: QA Automation: patch the system before running the test
+#    This is to test Test Updates for SP1 and GA
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "qa_run";
 use strict;
 use warnings;

--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -9,6 +9,9 @@
 # without any warranty.
 #
 package qa_run;
+# G-Summary: remove code duplication by sharing the code in a base class
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use strict;
 use warnings;
 use File::Basename;

--- a/tests/qa_automation/userspace_apache2_mod_perl.pm
+++ b/tests/qa_automation/userspace_apache2_mod_perl.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add new testsuite apache-mod_perl
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_apparmor.pm
+++ b/tests/qa_automation/userspace_apparmor.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_apparmor_profiles.pm
+++ b/tests/qa_automation/userspace_apparmor_profiles.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_bind.pm
+++ b/tests/qa_automation/userspace_bind.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_bzip2.pm
+++ b/tests/qa_automation/userspace_bzip2.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_coreutils.pm
+++ b/tests/qa_automation/userspace_coreutils.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_cpio.pm
+++ b/tests/qa_automation/userspace_cpio.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_cracklib.pm
+++ b/tests/qa_automation/userspace_cracklib.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_findutils.pm
+++ b/tests/qa_automation/userspace_findutils.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_gzip.pm
+++ b/tests/qa_automation/userspace_gzip.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_indent.pm
+++ b/tests/qa_automation/userspace_indent.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_net_snmp.pm
+++ b/tests/qa_automation/userspace_net_snmp.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_nfs.pm
+++ b/tests/qa_automation/userspace_nfs.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_nfs_v4.pm
+++ b/tests/qa_automation/userspace_nfs_v4.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_openssh.pm
+++ b/tests/qa_automation/userspace_openssh.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_openssl.pm
+++ b/tests/qa_automation/userspace_openssl.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_php5.pm
+++ b/tests/qa_automation/userspace_php5.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_postfix.pm
+++ b/tests/qa_automation/userspace_postfix.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_sharutils.pm
+++ b/tests/qa_automation/userspace_sharutils.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qa_automation/userspace_systemd.pm
+++ b/tests/qa_automation/userspace_systemd.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: split userspace into pieces for easy review.
+# G-Maintainer: Yong Sun <yosun@suse.com>
+
 use base "qa_run";
 use strict;
 use testapi;

--- a/tests/qam-kgraft/reboot_restore.pm
+++ b/tests/qam-kgraft/reboot_restore.pm
@@ -8,6 +8,9 @@
 # without any warranty.#
 
 
+# G-Summary: Live Patching regression testsuite
+# G-Maintainer: Ondřej Súkup <osukup@suse.cz>
+
 use base 'opensusebasetest';
 use testapi;
 use qam;

--- a/tests/qam-kgraft/regressions_tests.pm
+++ b/tests/qam-kgraft/regressions_tests.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Live Patching regression testsuite
+# G-Maintainer: Ondřej Súkup <osukup@suse.cz>
+
 use base 'opensusebasetest';
 use testapi;
 use qam;

--- a/tests/qam-kgraft/update_kgraft.pm
+++ b/tests/qam-kgraft/update_kgraft.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Live Patching regression testsuite
+# G-Maintainer: Ondřej Súkup <osukup@suse.cz>
+
 use base 'opensusebasetest';
 use testapi;
 use qam;

--- a/tests/qam-minimal/check_logs.pm
+++ b/tests/qam-minimal/check_logs.pm
@@ -7,6 +7,15 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: QAM Minimal test in openQA
+#    it prepares minimal instalation, boot it, install tested incident , try
+#    reboot and update system with all released updates.
+#
+#    with QAM_MINIMAL=full it also installs gnome-basic, base, apparmor and
+#    x11 patterns and reboot system to graphical login + start console and
+#    x11 tests
+# G-Maintainer: Ondřej Súkup <osukup@suse.cz>
+
 use base "consoletest";
 
 use strict;

--- a/tests/qam-minimal/install_patterns.pm
+++ b/tests/qam-minimal/install_patterns.pm
@@ -8,6 +8,15 @@
 # without any warranty.
 
 
+# G-Summary: QAM Minimal test in openQA
+#    it prepares minimal instalation, boot it, install tested incident , try
+#    reboot and update system with all released updates.
+#
+#    with QAM_MINIMAL=full it also installs gnome-basic, base, apparmor and
+#    x11 patterns and reboot system to graphical login + start console and
+#    x11 tests
+# G-Maintainer: Ondřej Súkup <osukup@suse.cz>
+
 use base "basetest";
 
 use strict;

--- a/tests/qam-minimal/install_update.pm
+++ b/tests/qam-minimal/install_update.pm
@@ -8,6 +8,15 @@
 # without any warranty.
 
 
+# G-Summary: QAM Minimal test in openQA
+#    it prepares minimal instalation, boot it, install tested incident , try
+#    reboot and update system with all released updates.
+#
+#    with QAM_MINIMAL=full it also installs gnome-basic, base, apparmor and
+#    x11 patterns and reboot system to graphical login + start console and
+#    x11 tests
+# G-Maintainer: Ondřej Súkup <osukup@suse.cz>
+
 use base "basetest";
 
 use strict;

--- a/tests/qam-minimal/update_minimal.pm
+++ b/tests/qam-minimal/update_minimal.pm
@@ -7,6 +7,15 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: QAM Minimal test in openQA
+#    it prepares minimal instalation, boot it, install tested incident , try
+#    reboot and update system with all released updates.
+#
+#    with QAM_MINIMAL=full it also installs gnome-basic, base, apparmor and
+#    x11 patterns and reboot system to graphical login + start console and
+#    x11 tests
+# G-Maintainer: Ondřej Súkup <osukup@suse.cz>
+
 use strict;
 use base "basetest";
 

--- a/tests/remote/remote_controller.pm
+++ b/tests/remote/remote_controller.pm
@@ -7,6 +7,14 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rename remote installation nodes (#1588)
+#    * Rename remote installation nodes
+#    slave -> target
+#    master -> controller
+#
+#    * Enable remote installation tests for opensuse
+# G-Maintainer: Martin Kravec <kravciak@users.noreply.github.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/remote/remote_target.pm
+++ b/tests/remote/remote_target.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Remote ssh & vnc installation
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/rescuecd/rescuecd.pm
+++ b/tests/rescuecd/rescuecd.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add RESCUECD test.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "rescuecdstep";
 use strict;
 use testapi;

--- a/tests/rt/kmp_modules.pm
+++ b/tests/rt/kmp_modules.pm
@@ -8,6 +8,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: RT tests
+#    test kmp modules & boot RT kernel script for further automated and regression RT tests
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/shutdown/grub_set_bootargs.pm
+++ b/tests/shutdown/grub_set_bootargs.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Remove quiet kernel option
+# G-Maintainer: Dominik Heidler <dheidler@suse.de>
+
 use strict;
 use base "y2logsstep";
 use testapi;

--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -14,6 +14,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: support for saving and loading of hdd image
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/slenkins/login.pm
+++ b/tests/slenkins/login.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: fixed login for slenkins tests
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/slenkins/slenkins_control.pm
+++ b/tests/slenkins/slenkins_control.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: slenkins support
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/slenkins/slenkins_control_network.pm
+++ b/tests/slenkins/slenkins_control_network.pm
@@ -13,6 +13,12 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: improved slenkins
+#    - do not parse node files, everything is configured via variables
+#    - import-slenkins-testsuite.pl script for importing the variables
+#    - run control node on support server
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/slenkins/slenkins_node.pm
+++ b/tests/slenkins/slenkins_node.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: slenkins support
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/slepos/boot_image.pm
+++ b/tests/slepos/boot_image.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Basic SLEPOS test
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use base "basetest";
 use testapi;
 use utils;

--- a/tests/slepos/build_images_kiwi.pm
+++ b/tests/slepos/build_images_kiwi.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Basic SLEPOS test
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use base "basetest";
 use testapi;
 use utils;

--- a/tests/slepos/build_offline_image_kiwi.pm
+++ b/tests/slepos/build_offline_image_kiwi.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Basic SLEPOS test
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use base "basetest";
 use testapi;
 use utils;

--- a/tests/slepos/prepare.pm
+++ b/tests/slepos/prepare.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Basic SLEPOS test
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use base "basetest";
 use testapi;
 use utils;

--- a/tests/slepos/register_images.pm
+++ b/tests/slepos/register_images.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Basic SLEPOS test
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use base "basetest";
 use testapi;
 use utils;

--- a/tests/slepos/run_posInitAdminserver.pm
+++ b/tests/slepos/run_posInitAdminserver.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Basic SLEPOS test
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use base "basetest";
 use testapi;
 use utils;

--- a/tests/slepos/run_posInitBranchserver.pm
+++ b/tests/slepos/run_posInitBranchserver.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Basic SLEPOS test
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use base "basetest";
 use testapi;
 use utils;

--- a/tests/slepos/run_possyncimages.pm
+++ b/tests/slepos/run_possyncimages.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Basic SLEPOS test
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use base "basetest";
 use testapi;
 use utils;

--- a/tests/slepos/use_smt_for_kiwi.pm
+++ b/tests/slepos/use_smt_for_kiwi.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Basic SLEPOS test
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use base "basetest";
 use testapi;
 use utils;

--- a/tests/slepos/wait.pm
+++ b/tests/slepos/wait.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Basic SLEPOS test
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/slepos/zypper_add_repo.pm
+++ b/tests/slepos/zypper_add_repo.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Basic SLEPOS test
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use base "basetest";
 use testapi;
 use utils;

--- a/tests/slepos/zypper_install_adminserver.pm
+++ b/tests/slepos/zypper_install_adminserver.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Basic SLEPOS test
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use base "basetest";
 use testapi;
 use utils;

--- a/tests/slepos/zypper_install_branchserver.pm
+++ b/tests/slepos/zypper_install_branchserver.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Basic SLEPOS test
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use base "basetest";
 use testapi;
 use utils;

--- a/tests/slepos/zypper_install_imageserver.pm
+++ b/tests/slepos/zypper_install_imageserver.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Basic SLEPOS test
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use base "basetest";
 use testapi;
 use utils;

--- a/tests/support_server/boot.pm
+++ b/tests/support_server/boot.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: supportserver and supportserver generator implementation
+# G-Maintainer: Pavel Sladek <psladek@suse.com>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/support_server/configure.pm
+++ b/tests/support_server/configure.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: configure support server repos during image building
+# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/support_server/login.pm
+++ b/tests/support_server/login.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: supportserver and supportserver generator implementation
+# G-Maintainer: Pavel Sladek <psladek@suse.com>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: supportserver and supportserver generator implementation
+# G-Maintainer: Pavel Sladek <psladek@suse.com>
+
 use strict;
 use base 'basetest';
 use lockapi;

--- a/tests/support_server/wait.pm
+++ b/tests/support_server/wait.pm
@@ -13,6 +13,9 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+# G-Summary: supportserver and supportserver generator implementation
+# G-Maintainer: Pavel Sladek <psladek@suse.com>
+
 use strict;
 use base 'basetest';
 use testapi;

--- a/tests/sysauth/sssd.pm
+++ b/tests/sysauth/sssd.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Run tests in the console of a live Gnome CD system, against SSSD and its LDAP, Kerberos backends.
+# G-Maintainer: HouzuoGuo <guohouzuo@gmail.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/toolchain/crash.pm
+++ b/tests/toolchain/crash.pm
@@ -7,6 +7,32 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Run 'crash' utility on a kernel memory dump
+#    Upstream kernel commit 8244062ef1 (v4.5), which got ingerited by SLE
+#    from 11-SP4 to 12-SP2 fixed handling of /proc/kallsyms. This change
+#    affected 'crash' utility, among other utilities.
+#
+#    Without
+#    https://github.com/crash-utility/crash/commit/098cdab16dfa6a85e9dad2cad604dee14ee15f66
+#    commit (v7.1.5) 'crash' crashed with:
+#
+#      crash: invalid structure member offset: module_num_symtab
+#             FILE: kernel.c  LINE: 3421  FUNCTION: module_init()
+#
+#      [./crash] error trace: 472bde => 4e09e7 => 52a6ea => 52a679
+#
+#        52a679: OFFSET_verify.part.24+73
+#        52a6ea: OFFSET_verify+42
+#        4e09e7: module_init+1255
+#        472bde: main_loop+238
+#
+#    https://bugzilla.suse.com/show_bug.cgi?id=977306
+#    https://fate.suse.com/320844
+#
+#    This test enables kdump, dumps kernel memory and runs 'crash' on the
+#    dump.
+# G-Maintainer: Michal Nowak <mnowak@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/toolchain/gcc5_C_compilation.pm
+++ b/tests/toolchain/gcc5_C_compilation.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Toolchain module tests
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/toolchain/gcc5_Cpp_compilation.pm
+++ b/tests/toolchain/gcc5_Cpp_compilation.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Toolchain module tests
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/toolchain/gcc5_fortran_compilation.pm
+++ b/tests/toolchain/gcc5_fortran_compilation.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Fortran test for SLE Toolchain Module's GCC5
+# G-Maintainer: Michal Nowak <mnowak@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/toolchain/install.pm
+++ b/tests/toolchain/install.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Toolchain module tests
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/update/check_system_is_updated.pm
+++ b/tests/update/check_system_is_updated.pm
@@ -7,6 +7,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Fix packagekit updatespoo#13056
+#    Check no more updates are available
+#    Reboot after kde kernel updates
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/update/prepare_system_for_update_tests.pm
+++ b/tests/update/prepare_system_for_update_tests.pm
@@ -14,6 +14,11 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: Update the system before testing
+#    For this attach an update category between first_boot and console tests and
+#    reboot in case the update applet requested so
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -7,6 +7,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Update the system before testing
+#    For this attach an update category between first_boot and console tests and
+#    reboot in case the update applet requested so
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -7,6 +7,15 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Packagekit updates
+#    Used Updaters:
+#    gpk-update-viewer - gnome & xfce & lxde
+#    plasma-pk-updates - kde
+#
+#    Change:
+#    assert_and_click replaced with keyboard shortcuts for ipmi test
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use base "x11test";
 use strict;
 use utils;

--- a/tests/update/zypper_clear_repos.pm
+++ b/tests/update/zypper_clear_repos.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Clear unneed repos before updating for Staging Project
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use base "consoletest";
 use strict;
 use testapi;

--- a/tests/update/zypper_up.pm
+++ b/tests/update/zypper_up.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "console_yasttest";
 use strict;
 use testapi;

--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
+# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# G-Maintainer: alice <xlai@suse.com>
+
 use base "virt_autotest_base";
 use testapi;
 

--- a/tests/virt_autotest/host_upgrade_base.pm
+++ b/tests/virt_autotest/host_upgrade_base.pm
@@ -8,6 +8,9 @@
 # without any warranty.
 #
 package host_upgrade_base;
+# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# G-Maintainer: alice <xlai@suse.com>
+
 use strict;
 use warnings;
 use base "virt_autotest_base";

--- a/tests/virt_autotest/host_upgrade_generate_run_file.pm
+++ b/tests/virt_autotest/host_upgrade_generate_run_file.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
+# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# G-Maintainer: alice <xlai@suse.com>
+
 use base "host_upgrade_base";
 #use virt_utils qw(set_serialdev);
 use testapi;

--- a/tests/virt_autotest/host_upgrade_step1_run.pm
+++ b/tests/virt_autotest/host_upgrade_step1_run.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
+# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# G-Maintainer: alice <xlai@suse.com>
+
 use base "host_upgrade_base";
 use testapi;
 use strict;

--- a/tests/virt_autotest/host_upgrade_step2_run.pm
+++ b/tests/virt_autotest/host_upgrade_step2_run.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
+# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# G-Maintainer: alice <xlai@suse.com>
+
 use base "host_upgrade_base";
 #use virt_utils qw(set_serialdev);
 use testapi;

--- a/tests/virt_autotest/host_upgrade_step3_run.pm
+++ b/tests/virt_autotest/host_upgrade_step3_run.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
+# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# G-Maintainer: alice <xlai@suse.com>
+
 use base "host_upgrade_base";
 use testapi;
 use virt_utils;

--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
+# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# G-Maintainer: alice <xlai@suse.com>
+
 use strict;
 use warnings;
 use File::Basename;

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -8,6 +8,9 @@
 # without any warranty.
 #
 package login_console;
+# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# G-Maintainer: alice <xlai@suse.com>
+
 use strict;
 use warnings;
 use File::Basename;

--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -8,6 +8,9 @@
 # without any warranty.
 #
 package reboot_and_wait_up;
+# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# G-Maintainer: alice <xlai@suse.com>
+
 use strict;
 use warnings;
 use File::Basename;

--- a/tests/virt_autotest/reboot_and_wait_up_normal1.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_normal1.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
+# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# G-Maintainer: alice <xlai@suse.com>
+
 use strict;
 use warnings;
 use File::Basename;

--- a/tests/virt_autotest/reboot_and_wait_up_normal2.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_normal2.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
+# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# G-Maintainer: alice <xlai@suse.com>
+
 use strict;
 use warnings;
 use File::Basename;

--- a/tests/virt_autotest/reboot_and_wait_up_normal3.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_normal3.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
+# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# G-Maintainer: alice <xlai@suse.com>
+
 use strict;
 use warnings;
 use File::Basename;

--- a/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
+# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# G-Maintainer: alice <xlai@suse.com>
+
 use strict;
 use warnings;
 use File::Basename;

--- a/tests/virt_autotest/setup_console_on_host.pm
+++ b/tests/virt_autotest/setup_console_on_host.pm
@@ -1,3 +1,6 @@
+# G-Summary: virtualization initial xen support (#1575)
+# G-Maintainer: xiao li ai <xlai@suse.com>
+
 use strict;
 use warnings;
 use base "opensusebasetest";

--- a/tests/virt_autotest/setup_console_on_host1.pm
+++ b/tests/virt_autotest/setup_console_on_host1.pm
@@ -1,3 +1,6 @@
+# G-Summary: virtualization: modification for adding prj2 host upgrade xen case
+# G-Maintainer: alice <xlai@suse.com>
+
 use strict;
 use warnings;
 use base "opensusebasetest";

--- a/tests/virt_autotest/setup_console_on_host2.pm
+++ b/tests/virt_autotest/setup_console_on_host2.pm
@@ -1,3 +1,6 @@
+# G-Summary: virtualization: modification for adding prj2 host upgrade xen case
+# G-Maintainer: alice <xlai@suse.com>
+
 use strict;
 use warnings;
 use base "opensusebasetest";

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -8,6 +8,9 @@
 # without any warranty.
 #
 package virt_autotest_base;
+# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# G-Maintainer: alice <xlai@suse.com>
+
 use strict;
 use warnings;
 use File::Basename;

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -8,6 +8,9 @@
 # without any warranty.
 #
 package virt_utils;
+# G-Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# G-Maintainer: alice <xlai@suse.com>
+
 use base Exporter;
 use Exporter;
 use strict;

--- a/tests/virtualization/boot.pm
+++ b/tests/virtualization/boot.pm
@@ -14,6 +14,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: - add the virtualization test suite- add a load_virtualization_tests call
+# G-Maintainer: aginies <aginies@suse.com>
+
 use base "basetest";
 use strict;
 use testapi;

--- a/tests/virtualization/installation.pm
+++ b/tests/virtualization/installation.pm
@@ -14,6 +14,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: - add the virtualization test suite- add a load_virtualization_tests call
+# G-Maintainer: aginies <aginies@suse.com>
+
 use base "basetest";
 use strict;
 use testapi;

--- a/tests/virtualization/prepare_sle12.pm
+++ b/tests/virtualization/prepare_sle12.pm
@@ -14,6 +14,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: - add the virtualization test suite- add a load_virtualization_tests call
+# G-Maintainer: aginies <aginies@suse.com>
+
 use base "basetest";
 use strict;
 use testapi;

--- a/tests/virtualization/virt_install.pm
+++ b/tests/virtualization/virt_install.pm
@@ -1,3 +1,6 @@
+# G-Summary: - add the virtualization test suite- add a load_virtualization_tests call
+# G-Maintainer: aginies <aginies@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/virtualization/virt_top.pm
+++ b/tests/virtualization/virt_top.pm
@@ -1,3 +1,6 @@
+# G-Summary: - add the virtualization test suite- add a load_virtualization_tests call
+# G-Maintainer: aginies <aginies@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/virtualization/virtman_create_guest.pm
+++ b/tests/virtualization/virtman_create_guest.pm
@@ -14,6 +14,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: - add the virtualization test suite- add a load_virtualization_tests call
+# G-Maintainer: aginies <aginies@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/virtualization/virtman_install.pm
+++ b/tests/virtualization/virtman_install.pm
@@ -1,3 +1,6 @@
+# G-Summary: - add the virtualization test suite- add a load_virtualization_tests call
+# G-Maintainer: aginies <aginies@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/virtualization/virtman_networkinterface.pm
+++ b/tests/virtualization/virtman_networkinterface.pm
@@ -14,6 +14,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: - add the virtualization test suite- add a load_virtualization_tests call
+# G-Maintainer: aginies <aginies@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/virtualization/virtman_storage.pm
+++ b/tests/virtualization/virtman_storage.pm
@@ -14,6 +14,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: - add the virtualization test suite- add a load_virtualization_tests call
+# G-Maintainer: aginies <aginies@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/virtualization/virtman_view.pm
+++ b/tests/virtualization/virtman_view.pm
@@ -14,6 +14,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: - add the virtualization test suite- add a load_virtualization_tests call
+# G-Maintainer: aginies <aginies@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/virtualization/virtman_virtualnet.pm
+++ b/tests/virtualization/virtman_virtualnet.pm
@@ -14,6 +14,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: - add the virtualization test suite- add a load_virtualization_tests call
+# G-Maintainer: aginies <aginies@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -1,3 +1,6 @@
+# G-Summary: - add the virtualization test suite- add a load_virtualization_tests call
+# G-Maintainer: aginies <aginies@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/amarok.pm
+++ b/tests/x11/amarok.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/application_browser.pm
+++ b/tests/x11/application_browser.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/awesome_menu.pm
+++ b/tests/x11/awesome_menu.pm
@@ -1,3 +1,9 @@
+# G-Summary: Add test for awesome window manager
+#    Based on "minimalx" installation.
+#
+#    Related issue: https://progress.opensuse.org/issues/9522
+# G-Maintainer: Dominik Heidler <dheidler@suse.de>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/awesome_reconfigure_openqa.pm
+++ b/tests/x11/awesome_reconfigure_openqa.pm
@@ -7,6 +7,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Other Desktop Environments: Awesome Window Manager
+#    This test has been migrated from a pure-standalone, full test to
+#    be integrated into the new DE/WM Framework
+# G-Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/awesome_xterm.pm
+++ b/tests/x11/awesome_xterm.pm
@@ -1,3 +1,9 @@
+# G-Summary: Add test for awesome window manager
+#    Based on "minimalx" installation.
+#
+#    Related issue: https://progress.opensuse.org/issues/9522
+# G-Maintainer: Dominik Heidler <dheidler@suse.de>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/banshee.pm
+++ b/tests/x11/banshee.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: work on improving the delta between openSUSE and sle
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "basetest";
 use strict;
 use testapi;

--- a/tests/x11/chrome.pm
+++ b/tests/x11/chrome.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: GOOGLE Chrome: attempt to install and run google chrome
+# G-Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add chromium test
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/desktop_mainmenu.pm
+++ b/tests/x11/desktop_mainmenu.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/dolphin.pm
+++ b/tests/x11/dolphin.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/enlightenment_first_start.pm
+++ b/tests/x11/enlightenment_first_start.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Other Desktop Environments: Enlightenment
+# G-Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/enlightenment_reconfigure_openqa.pm
+++ b/tests/x11/enlightenment_reconfigure_openqa.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Other Desktop Environments: Enlightenment
+# G-Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/eog.pm
+++ b/tests/x11/eog.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/evolution.pm
+++ b/tests/x11/evolution.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -9,6 +9,9 @@
 # without any warranty.
 
 package firefox;
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/firefox_audio.pm
+++ b/tests/x11/firefox_audio.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/firefox_nss.pm
+++ b/tests/x11/firefox_nss.pm
@@ -9,6 +9,9 @@
 
 # Case #1560076 - FIPS: Firefox Mozilla NSS
 
+# G-Summary: Add fips firefox nss test
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/firefox_stress.pm
+++ b/tests/x11/firefox_stress.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/gdm_session_switch.pm
+++ b/tests/x11/gdm_session_switch.pm
@@ -7,6 +7,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add a case for gdm session switch
+#    openSUSE has shipped SLE-Classic since Leap 42.2, this case will test
+#    gdm session switch among sle-classic, gnome-classic, icewm and gnome.
+# G-Maintainer: Chingkai Chu <chuchingkai@gmail.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/gedit.pm
+++ b/tests/x11/gedit.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/gimp.pm
+++ b/tests/x11/gimp.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/glxgears.pm
+++ b/tests/x11/glxgears.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/gnome_control_center.pm
+++ b/tests/x11/gnome_control_center.pm
@@ -8,6 +8,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: test: add test for gnome-control-center
+#    Identify bugs like https://bugzilla.suse.com/show_bug.cgi?id=897687
+#    earlier.
+# G-Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/gnome_music.pm
+++ b/tests/x11/gnome_music.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add gnome_music test; move rhythmbox test to obsoleted
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/gnome_terminal.pm
+++ b/tests/x11/gnome_terminal.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/gnome_tweak_tool.pm
+++ b/tests/x11/gnome_tweak_tool.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: GNOME Tweak Tool
+# G-Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/hexchat.pm
+++ b/tests/x11/hexchat.pm
@@ -14,6 +14,10 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: support both hexchat and xchat in one test
+#    xchat and hexchat are similar enough to not duplicate code
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/hexchat_ssl.pm
+++ b/tests/x11/hexchat_ssl.pm
@@ -9,6 +9,11 @@
 
 # Case #1459498 - FIPS : hexchat_ssl
 
+# G-Summary: Add hexchat_ssl test case and fips test entry
+#    Add hexchat_ssl.pm test case was located in x11/hexchat_ssl.pm
+#    Add hexchat_ssl.pm test entry in load_fips_tests_misc() in sle/main.pm
+# G-Maintainer: Ben Chou <bchou@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/imagemagick.pm
+++ b/tests/x11/imagemagick.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/inkscape.pm
+++ b/tests/x11/inkscape.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/kate.pm
+++ b/tests/x11/kate.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/khelpcenter.pm
+++ b/tests/x11/khelpcenter.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/kontact.pm
+++ b/tests/x11/kontact.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/lxqt_reconfigure_openqa.pm
+++ b/tests/x11/lxqt_reconfigure_openqa.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Other Desktop Environments: LXQt
+# G-Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/mate_reconfigure_openqa.pm
+++ b/tests/x11/mate_reconfigure_openqa.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Other Desktop Environments: Mate
+# G-Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/mate_terminal.pm
+++ b/tests/x11/mate_terminal.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Other Desktop Environments: Mate
+# G-Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/mozmill_run.pm
+++ b/tests/x11/mozmill_run.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -10,6 +10,10 @@
 # This test checks if many users make the login manager hard to use
 # i.e. if it takes more than one click to access the username text field
 
+# G-Summary: Test if login manager is usable with many users
+#    Progress Issue #9694
+# G-Maintainer: Dominik Heidler <dheidler@suse.de>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/nautilus.pm
+++ b/tests/x11/nautilus.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/nis_client.pm
+++ b/tests/x11/nis_client.pm
@@ -7,6 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: NIS server-client test
+#    https://progress.opensuse.org/issues/9900
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -7,6 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: NIS server-client test
+#    https://progress.opensuse.org/issues/9900
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/oocalc.pm
+++ b/tests/x11/oocalc.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/ooffice.pm
+++ b/tests/x11/ooffice.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/oomath.pm
+++ b/tests/x11/oomath.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/reboot_and_install.pm
+++ b/tests/x11/reboot_and_install.pm
@@ -7,6 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add ssh key dialog test
+#    https://progress.opensuse.org/issues/11454 https://github.com/yast/skelcd-control-SLES/blob/d2f9a79c0681806bf02eb38c4b7c287b9d9434eb/control/control.SLES.xml#L53-L71
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "opensusebasetest";
 use strict;
 

--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: rename reboot_*_pre to reboot_* - the reboot.pm just contained one line
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/x11/reboot_gnome_sle11.pm
+++ b/tests/x11/reboot_gnome_sle11.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: rename reboot_*_pre to reboot_* - the reboot.pm just contained one line
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/x11/reboot_icewm.pm
+++ b/tests/x11/reboot_icewm.pm
@@ -8,6 +8,12 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add Framework to test other Desktop Environments
+#    Non-Primary desktop environments are generally installed by means
+#    of a pattern. For those tests, we assume a minimal-X based installation
+#    where the pattern is being installed on top.
+# G-Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/x11/reboot_kde.pm
+++ b/tests/x11/reboot_kde.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: rename reboot_*_pre to reboot_* - the reboot.pm just contained one line
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/x11/reboot_lxde.pm
+++ b/tests/x11/reboot_lxde.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: rename reboot_*_pre to reboot_* - the reboot.pm just contained one line
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/x11/reboot_plasma5.pm
+++ b/tests/x11/reboot_plasma5.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: rename reboot_*_pre to reboot_* - the reboot.pm just contained one line
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/x11/reboot_xfce.pm
+++ b/tests/x11/reboot_xfce.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: rename reboot_*_pre to reboot_* - the reboot.pm just contained one line
+# G-Maintainer: Stephan Kulow <coolo@suse.de>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/x11/rhythmbox.pm
+++ b/tests/x11/rhythmbox.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/ristretto.pm
+++ b/tests/x11/ristretto.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/seahorse.pm
+++ b/tests/x11/seahorse.pm
@@ -7,6 +7,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: New test: Seahorse
+#    Serves two purposes:
+#    * Tests seahorse (GNOME Keyring frontend)
+#    * As a side effect, it initializes the keyring so that other
+#      tests running later can access an existing keyring (e.g. chromium &
+#      chrome). This allows us not having to handle special cases there for
+#      creating new keyring databases (Which, potentially, every application
+#      could be asking for).
+# G-Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/shutdown.pm
+++ b/tests/x11/shutdown.pm
@@ -11,6 +11,9 @@
 # we need the package here for shutdown_sle11 to inherit it
 package shutdown;
 # don't use x11test, the end of this is not a desktop
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "opensusebasetest";
 use strict;
 use testapi;

--- a/tests/x11/shutdown_sle11.pm
+++ b/tests/x11/shutdown_sle11.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Create sle 11 shutdown script
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use strict;
 
 # work around for broken base in perl < 5.20

--- a/tests/x11/sle11_firefox.pm
+++ b/tests/x11/sle11_firefox.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: SLE11 firefox with KDE has to accept "default browser check"
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "firefox";
 use strict;
 use testapi;

--- a/tests/x11/sle11_kde_setup.pm
+++ b/tests/x11/sle11_kde_setup.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: SLE11 KDE setup, turn off find app feature
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/smt.pm
+++ b/tests/x11/smt.pm
@@ -7,6 +7,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add smt configuration test
+#    test installation and upgrade with smt pattern, basic configuration via
+#    smt-wizard and validation with smt-repos smt-sync return value
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "x11test";
 use testapi;
 

--- a/tests/x11/ssh_key_check.pm
+++ b/tests/x11/ssh_key_check.pm
@@ -7,6 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add ssh key dialog test
+#    https://progress.opensuse.org/issues/11454 https://github.com/yast/skelcd-control-SLES/blob/d2f9a79c0681806bf02eb38c4b7c287b9d9434eb/control/control.SLES.xml#L53-L71
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/ssh_key_verify.pm
+++ b/tests/x11/ssh_key_verify.pm
@@ -7,6 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add ssh key dialog test
+#    https://progress.opensuse.org/issues/11454 https://github.com/yast/skelcd-control-SLES/blob/d2f9a79c0681806bf02eb38c4b7c287b9d9434eb/control/control.SLES.xml#L53-L71
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use strict;
 use warnings;
 use base "y2logsstep";

--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/systemsettings.pm
+++ b/tests/x11/systemsettings.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/systemsettings5.pm
+++ b/tests/x11/systemsettings5.pm
@@ -8,6 +8,16 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Separate systemsettings test for KDE4-based and KF5-based
+#    In update test, there might have old KDE4 systemsettings as another
+#    candidate in krunner via auto-completion, therefore, separate
+#    systemsettings test to systemsettings(KDE4-based) and
+#    systemsettings5(KF5-based) test.
+#
+#    openSUSE version less than or equal to 13.2 have to set KDE4 variable as
+#    1, thus PLASMA5 variable won't be sets.
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/terminology.pm
+++ b/tests/x11/terminology.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Other Desktop Environments: Enlightenment
+# G-Maintainer: Dominique Leuenberger <dimstar@opensuse.org>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/thunar.pm
+++ b/tests/x11/thunar.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/thunderbird.pm
+++ b/tests/x11/thunderbird.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/vlc.pm
+++ b/tests/x11/vlc.pm
@@ -14,6 +14,10 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: vlc test
+#    plays some free video file
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: VNC Secondary viewonly passwordpoo#11794
+# G-Maintainer: mkravec <mkravec@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/x11_login.pm
+++ b/tests/x11/x11_login.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/xchat.pm
+++ b/tests/x11/xchat.pm
@@ -14,6 +14,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+# G-Summary: xchat test
+# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/xfce4_appfinder.pm
+++ b/tests/x11/xfce4_appfinder.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/xfce4_terminal.pm
+++ b/tests/x11/xfce4_terminal.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/xfce_lightdm_logout_login.pm
+++ b/tests/x11/xfce_lightdm_logout_login.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/xfce_notification.pm
+++ b/tests/x11/xfce_notification.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/xterm.pm
+++ b/tests/x11/xterm.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -7,6 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Feature 318787
+#    YaST logic on Network Restart while no config changes were made https://progress.opensuse.org/issues/11450
+# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/yast2_snapper.pm
+++ b/tests/x11/yast2_snapper.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Test for yast2-snapper
+# G-Maintainer: Ancor Gonzalez Sosa <ancor@suse.de>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11/yast2_users.pm
+++ b/tests/x11/yast2_users.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Rework the tests layout.
+# G-Maintainer: Alberto Planas <aplanas@suse.com>
+
 use base "x11test";
 use strict;
 use testapi;

--- a/tests/x11regressions/ImageMagick.pm
+++ b/tests/x11regressions/ImageMagick.pm
@@ -23,6 +23,22 @@
 # time-consuming (more than two hours in a specific case, while this
 # test can finish in less than 20 minutes).
 
+# G-Summary: Add ImageMagick test
+#    This test creates, displays, and evaluates 200+ images utilizing
+#    various convertion options of ImageMagick.
+#
+#    The examined examples were taken from:
+#    https://www.imagemagick.org/Usage/canvas/ (Aug 2016)
+#
+#    A set of preloaded images and a script are required as input. This
+#    test generates multiple new images and evaluates the output. Some
+#    of the new images are converted from the preloaded images, while
+#    others are drawn from scratch. The preloaded script contains all
+#    the executed commands because typing them appeared to be extremely
+#    time-consuming (more than two hours in a specific case, while this
+#    test can finish in less than 20 minutes).
+# G-Maintainer: Romanos Dodopoulos <rdodopoulos@novell.com>
+
 use base "x11test";
 use strict;
 use warnings;

--- a/tests/x11regressions/empathy/empathy_aim.pm
+++ b/tests/x11regressions/empathy/empathy_aim.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: openqa script for tc#1503972
+# G-Maintainer: dehai <dhkong@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/empathy/empathy_irc.pm
+++ b/tests/x11regressions/empathy/empathy_irc.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add empathy irc regression test
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/evince/evince_find.pm
+++ b/tests/x11regressions/evince/evince_find.pm
@@ -8,6 +8,14 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add evince regression testsuite
+#    add x11regressions test data
+#
+#    add gedit regression testsuite
+#
+#    remove unnecessary sleeps
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/evince/evince_open.pm
+++ b/tests/x11regressions/evince/evince_open.pm
@@ -8,6 +8,14 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add evince regression testsuite
+#    add x11regressions test data
+#
+#    add gedit regression testsuite
+#
+#    remove unnecessary sleeps
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/evince/evince_rotate_zoom.pm
+++ b/tests/x11regressions/evince/evince_rotate_zoom.pm
@@ -8,6 +8,14 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add evince regression testsuite
+#    add x11regressions test data
+#
+#    add gedit regression testsuite
+#
+#    remove unnecessary sleeps
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/evince/evince_view.pm
+++ b/tests/x11regressions/evince/evince_view.pm
@@ -8,6 +8,14 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add evince regression testsuite
+#    add x11regressions test data
+#
+#    add gedit regression testsuite
+#
+#    remove unnecessary sleeps
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/evolution/evolution_mail_ews.pm
+++ b/tests/x11regressions/evolution/evolution_mail_ews.pm
@@ -9,6 +9,12 @@
 
 # Test Case #1503965: Evolution: Setup MS Exchange account
 
+# G-Summary: Add three test cases for Evolution
+#    evolution_smoke: Case #1503857: Evolution setup assistant
+#    evolution_mail_imap: Case #1503768: send and receive email via IMAP
+#    evolution_mail_ews: Case #1503965: Setup MS Exchange account
+# G-Maintainer: Qingming Su <qingming.su@suse.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/evolution/evolution_mail_imap.pm
+++ b/tests/x11regressions/evolution/evolution_mail_imap.pm
@@ -9,6 +9,12 @@
 
 # Test Case #1503768: Evolution: send and receive email via IMAP
 
+# G-Summary: Add three test cases for Evolution
+#    evolution_smoke: Case #1503857: Evolution setup assistant
+#    evolution_mail_imap: Case #1503768: send and receive email via IMAP
+#    evolution_mail_ews: Case #1503965: Setup MS Exchange account
+# G-Maintainer: Qingming Su <qingming.su@suse.com>
+
 use strict;
 #use base "x11test";
 use base "x11regressiontest";

--- a/tests/x11regressions/evolution/evolution_mail_pop.pm
+++ b/tests/x11regressions/evolution/evolution_mail_pop.pm
@@ -9,6 +9,9 @@
 
 # Test Case #1503919 - Evolution: send and receive email via POP
 
+# G-Summary: add scripts and entry for evolution tc#1503919 in x11regression
+# G-Maintainer: Chingkai <qkzhu@suse.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/evolution/evolution_meeting_imap.pm
+++ b/tests/x11regressions/evolution/evolution_meeting_imap.pm
@@ -8,6 +8,11 @@
 # without any warranty.
 
 # Test Case tc#1503817 evolution imap meeting test
+# G-Summary: tc# 1503817: Evolution: Imap Meeting
+#    This is used for tc# 1503817, Send the meeting request by evolution and the
+#    receiver will get the meeting request with imap protocol.
+# G-Maintainer: Jiawei Sun <JiaWei.Sun@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/evolution/evolution_meeting_pop.pm
+++ b/tests/x11regressions/evolution/evolution_meeting_pop.pm
@@ -9,6 +9,13 @@
 
 # Test Case #1503976 Pop Meeting
 
+# G-Summary: Test Case #1503976 Pop Meeting
+#    This case is used for tc#1503976, send the meeting request by evolution and the
+#    receiver will get the meeting request with POP3 protocol.
+#    Add send_meeting_request to x11regression lib
+#    Reduce costing time of imap meeting and pop meeting
+# G-Maintainer: Jiawei Sun <JiaWei.Sun@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use warnings;

--- a/tests/x11regressions/evolution/evolution_smoke.pm
+++ b/tests/x11regressions/evolution/evolution_smoke.pm
@@ -9,6 +9,12 @@
 
 # Test Case #1503857 - Evolution: First time launch and setup assistant
 
+# G-Summary: Add three test cases for Evolution
+#    evolution_smoke: Case #1503857: Evolution setup assistant
+#    evolution_mail_imap: Case #1503768: send and receive email via IMAP
+#    evolution_mail_ews: Case #1503965: Setup MS Exchange account
+# G-Maintainer: Qingming Su <qingming.su@suse.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/evolution/evolution_task_ews.pm
+++ b/tests/x11regressions/evolution/evolution_task_ews.pm
@@ -9,6 +9,9 @@
 
 # Test Case #1503757: Evolution:Send MS task
 
+# G-Summary: openqa script for tc#1503757: evolution_task_ews
+# G-Maintainer: xiaojun <xjin@suse.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/evolution/evolution_timezone_setup.pm
+++ b/tests/x11regressions/evolution/evolution_timezone_setup.pm
@@ -9,6 +9,9 @@
 
 #testcase 5255-1503908:Evolution: setup timezone
 
+# G-Summary: updated openqa script and entry for tc#1503908: evolution_timezone_setup
+# G-Maintainer: xiaojun <xjin@suse.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_autocomplete.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_autocomplete.pm
@@ -20,6 +20,9 @@
 # test-firefox_autocomplete-1
 # firefox_autocomplete-testpage, firefox_autocomplete-testpage_filled
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_bookmark.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_bookmark.pm
@@ -9,6 +9,9 @@
 # without any warranty.
 
 # auther xjin
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use base "x11regressiontest";
 use testapi;
 use strict;

--- a/tests/x11regressions/firefox/sle11/firefox_bookmarks.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_bookmarks.pm
@@ -22,6 +22,9 @@
 # test-firefox_bookmarks-delete
 # test-firefox_bookmarks-edit01, test-firefox_bookmarks-edit02, test-firefox_bookmarks-edit03
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_contentmenu.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_contentmenu.pm
@@ -14,6 +14,9 @@
 # Case:     1248972
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_help.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_help.pm
@@ -15,6 +15,9 @@
 # Description:    Test firefox help
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_home_page.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_home_page.pm
@@ -14,6 +14,9 @@
 # Case:        1248977
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_https.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_https.pm
@@ -14,6 +14,9 @@
 # Case:        1248985
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_importssl.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_importssl.pm
@@ -14,6 +14,9 @@
 # Case:        1248994
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_java.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_java.pm
@@ -20,6 +20,9 @@
 # test-firefox_java-1, test-firefox_java-2, test-firefox_java-3
 # test-firefox_java-java_warning
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_launch.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_launch.pm
@@ -16,6 +16,9 @@
 # This case is available only when you run firefox the first time
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_loadie6.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_loadie6.pm
@@ -14,6 +14,9 @@
 # Case:        1248988
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_localpage.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_localpage.pm
@@ -20,6 +20,9 @@
 # test-firefox-openfile-1
 # test-firefox_lcoalpage-1
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_menu.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_menu.pm
@@ -14,6 +14,9 @@
 # Case:     1248944
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_mhtml.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_mhtml.pm
@@ -21,6 +21,9 @@
 # test-firefox-openfile-1
 # test-firefox_mhtml-1, test-firefox_mhtml-2
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_newwindow.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_newwindow.pm
@@ -15,6 +15,9 @@
 # Description:    open new window and open link in new window
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_page_control.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_page_control.pm
@@ -14,6 +14,9 @@
 # Case:        1248975
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_password_i.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_password_i.pm
@@ -14,6 +14,9 @@
 # Case:        1248984
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_print.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_print.pm
@@ -19,6 +19,9 @@
 #3.Print the page and check the hard copy output.
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_printing.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_printing.pm
@@ -52,6 +52,9 @@
 # Note: Mozilla printing test main page:
 #       http://www-archive.mozilla.org/quality/browser/front-end/testcases/printing/
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_printing_images.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_printing_images.pm
@@ -25,6 +25,9 @@
 # Note: Mozilla printing test main page:
 #       http://www-archive.mozilla.org/quality/browser/front-end/testcases/printing/
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_remember_passwd.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_remember_passwd.pm
@@ -21,6 +21,9 @@
 #5.Click any history
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_search.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_search.pm
@@ -14,6 +14,9 @@
 # Case:        1248978
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_sendlink.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_sendlink.pm
@@ -20,6 +20,9 @@
 # test-firefox_sendlink-1, test-firefox_sendlink-2, test-firefox_sendlink-3
 # test-firefox_sendlink-unstable_warning
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_sidebar.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_sidebar.pm
@@ -21,6 +21,9 @@
 #5.Click any history
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_tab.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_tab.pm
@@ -24,6 +24,9 @@
 # NOTE: Some actions in this case can not be implemented.
 # For example, click and drag. So they are not included.
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_topsite.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_topsite.pm
@@ -15,6 +15,9 @@
 # Description:    test some top websites and then check the history
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_url.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_url.pm
@@ -21,6 +21,9 @@
 # test-firefox_url-wikipedia-1, test-firefox_url-wikipedia-2
 # test-firefox_url-googlemaps-1, test-firefox_url-googlemaps-2
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle11/firefox_urlprotocols.pm
+++ b/tests/x11regressions/firefox/sle11/firefox_urlprotocols.pm
@@ -14,6 +14,9 @@
 # Case:        1248989
 ##################################################
 
+# G-Summary: Restore SLE11 cases to sub-directory, remove main.pm lines because no openSUSE cases.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_appearance.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_appearance.pm
@@ -10,6 +10,9 @@
 
 # Case#1479190: Firefox: Add-ons - Appearance
 
+# G-Summary: Added 13 new scripts. Minor changes for some old scripts to run better together.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_changesaving.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_changesaving.pm
@@ -10,6 +10,9 @@
 
 # Case#1436111: Firefox: Preferences Change Saving
 
+# G-Summary: Added new cases, change firefox_emaillink.pm
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_developertool.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_developertool.pm
@@ -10,6 +10,9 @@
 
 # Case#1479522: Firefox: Web Developer Tools
 
+# G-Summary: Added 13 new scripts. Minor changes for some old scripts to run better together.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_downloading.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_downloading.pm
@@ -10,6 +10,9 @@
 
 # Case#1436106: Firefox: Downloading
 
+# G-Summary: Add some modified/merged test cases
+# G-Maintainer: wnereiz <wnereiz@github>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_emaillink.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_emaillink.pm
@@ -10,6 +10,9 @@
 
 # Case#1436117 Firefox: Email Link
 
+# G-Summary: Add some modified/merged test cases
+# G-Maintainer: wnereiz <wnereiz@github>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_extcontent.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_extcontent.pm
@@ -10,6 +10,9 @@
 
 # Case#1436064: Firefox: Externally handled content
 
+# G-Summary: Added new cases, change firefox_emaillink.pm
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_extensions.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_extensions.pm
@@ -10,6 +10,9 @@
 
 # Case#1479189: Firefox: Add-ons - Extensions
 
+# G-Summary: Added 13 new scripts. Minor changes for some old scripts to run better together.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_flashplayer.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_flashplayer.pm
@@ -10,6 +10,9 @@
 
 # Case#1436061: Firefox: Flash Player
 
+# G-Summary: Added new cases, change firefox_emaillink.pm
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_fullscreen.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_fullscreen.pm
@@ -10,6 +10,9 @@
 
 # Case#1479413: Firefox: Full Screen Browsing
 
+# G-Summary: Added 13 new scripts. Minor changes for some old scripts to run better together.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_gnomeshell.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_gnomeshell.pm
@@ -10,6 +10,9 @@
 
 # Case#1479556: Firefox: Gnome Shell Integration
 
+# G-Summary: Added 13 new scripts. Minor changes for some old scripts to run better together.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_headers.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_headers.pm
@@ -10,6 +10,9 @@
 
 # Case#1436066: Firefox: HTTP Headers
 
+# G-Summary: Added new cases, change firefox_emaillink.pm
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_health.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_health.pm
@@ -10,6 +10,9 @@
 
 # Case#1479504: Firefox: Health Report
 
+# G-Summary: Added 13 new scripts. Minor changes for some old scripts to run better together.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_html5.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_html5.pm
@@ -10,6 +10,9 @@
 
 # Case#1479221: Firefox: HTML5 Video
 
+# G-Summary: Added 13 new scripts. Minor changes for some old scripts to run better together.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_java.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_java.pm
@@ -10,6 +10,9 @@
 
 # Case#1436069: Firefox: Java Plugin (IcedTea-Web)
 
+# G-Summary: Added new cases, change firefox_emaillink.pm
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_localfiles.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_localfiles.pm
@@ -10,6 +10,9 @@
 
 # Case#1436075 Firefox: Open local file with various types
 
+# G-Summary: Add some modified/merged test cases
+# G-Maintainer: wnereiz <wnereiz@github>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_mhtml.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_mhtml.pm
@@ -10,6 +10,9 @@
 
 # Case#1436084: Firefox: Open IE MHTML Files
 
+# G-Summary: Added 13 new scripts. Minor changes for some old scripts to run better together.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_pagesaving.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_pagesaving.pm
@@ -10,6 +10,9 @@
 
 # Case#1436102: Firefox: Page Saving
 
+# G-Summary: Added new cases, change firefox_emaillink.pm
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_passwd.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_passwd.pm
@@ -10,6 +10,9 @@
 
 # Case#1436079: Firefox: Password Management
 
+# G-Summary: Added 13 new scripts. Minor changes for some old scripts to run better together.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_pdf.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_pdf.pm
@@ -10,6 +10,9 @@
 
 # Case#1436081: Firefox: Build-in PDF Viewer
 
+# G-Summary: Added new cases, change firefox_emaillink.pm
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_plugins.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_plugins.pm
@@ -10,6 +10,9 @@
 
 # Case#1479188: Firefox: Add-ons - Plugins
 
+# G-Summary: Added 13 new scripts. Minor changes for some old scripts to run better together.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_private.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_private.pm
@@ -10,6 +10,9 @@
 
 # Case#1479412: Firefox: Private Browsing
 
+# G-Summary: Added 13 new scripts. Minor changes for some old scripts to run better together.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_rss.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_rss.pm
@@ -10,6 +10,9 @@
 
 # Case#1479557: Firefox: RSS Button
 
+# G-Summary: Added 13 new scripts. Minor changes for some old scripts to run better together.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_smoke.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_smoke.pm
@@ -10,6 +10,9 @@
 
 # Case#1479153 Firefox: Smoke Test
 
+# G-Summary: Add some modified/merged test cases
+# G-Maintainer: wnereiz <wnereiz@github>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_ssl.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_ssl.pm
@@ -10,6 +10,9 @@
 
 # Case#1436067: Firefox: SSL Certificate
 
+# G-Summary: Added 13 new scripts. Minor changes for some old scripts to run better together.
+# G-Maintainer: wnereiz <wnereiz@gmail.com>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/firefox/sle12/firefox_urlsprotocols.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_urlsprotocols.pm
@@ -10,6 +10,9 @@
 
 # Case#1436118 Firefox: URLs with various protocols
 
+# G-Summary: Add some modified/merged test cases
+# G-Maintainer: wnereiz <wnereiz@github>
+
 use strict;
 use base "x11regressiontest";
 use testapi;

--- a/tests/x11regressions/gedit/gedit_about.pm
+++ b/tests/x11regressions/gedit/gedit_about.pm
@@ -8,6 +8,14 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add evince regression testsuite
+#    add x11regressions test data
+#
+#    add gedit regression testsuite
+#
+#    remove unnecessary sleeps
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gedit/gedit_launch.pm
+++ b/tests/x11regressions/gedit/gedit_launch.pm
@@ -8,6 +8,14 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add evince regression testsuite
+#    add x11regressions test data
+#
+#    add gedit regression testsuite
+#
+#    remove unnecessary sleeps
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gedit/gedit_save.pm
+++ b/tests/x11regressions/gedit/gedit_save.pm
@@ -8,6 +8,14 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add evince regression testsuite
+#    add x11regressions test data
+#
+#    add gedit regression testsuite
+#
+#    remove unnecessary sleeps
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnomecase/application_starts_on_login.pm
+++ b/tests/x11regressions/gnomecase/application_starts_on_login.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: openqa script for regression tc#1503973
+# G-Maintainer: xiaojun <xjin@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnomecase/change_password.pm
+++ b/tests/x11regressions/gnomecase/change_password.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: openqa script and entry for tc#1503803 tc#1503905; entry for tc#1503973
+# G-Maintainer: xiaojun <xjin@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnomecase/gnome_classic_switch.pm
+++ b/tests/x11regressions/gnomecase/gnome_classic_switch.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: openqa script and entry for tc#1503849:gnome:gnome-classic switch
+# G-Maintainer: xiaojun <xjin@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnomecase/gnome_default_applications.pm
+++ b/tests/x11regressions/gnomecase/gnome_default_applications.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add script for tc#1503753 tc#1503894
+# G-Maintainer: Chingkai <qkzhu@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnomecase/gnome_window_switcher.pm
+++ b/tests/x11regressions/gnomecase/gnome_window_switcher.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add scripts and entry for gnomecases tc#1503968 in x11regression
+# G-Maintainer: Chingkai <qkzhu@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnomecase/login_test.pm
+++ b/tests/x11regressions/gnomecase/login_test.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: openqa script and entry for tc#1503803 tc#1503905; entry for tc#1503973
+# G-Maintainer: xiaojun <xjin@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnomecase/nautilus_cut_file.pm
+++ b/tests/x11regressions/gnomecase/nautilus_cut_file.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: x11regressions: add nautilus scripts
+# G-Maintainer: Xudong Zhang <xdzhang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnomecase/nautilus_open_ftp.pm
+++ b/tests/x11regressions/gnomecase/nautilus_open_ftp.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: x11regressions: add nautilus scripts
+# G-Maintainer: Xudong Zhang <xdzhang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnomecase/nautilus_permission.pm
+++ b/tests/x11regressions/gnomecase/nautilus_permission.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: x11regressions: add nautilus scripts
+# G-Maintainer: Xudong Zhang <xdzhang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnote/gnote_edit_format.pm
+++ b/tests/x11regressions/gnote/gnote_edit_format.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: x11regressions: add test scripts for gnote
+# G-Maintainer: Xudong Zhang <xdzhang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnote/gnote_first_run.pm
+++ b/tests/x11regressions/gnote/gnote_first_run.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: x11regressions: add test scripts for gnote
+# G-Maintainer: Xudong Zhang <xdzhang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnote/gnote_link_note.pm
+++ b/tests/x11regressions/gnote/gnote_link_note.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: x11regressions: add test scripts for gnote
+# G-Maintainer: Xudong Zhang <xdzhang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnote/gnote_rename_title.pm
+++ b/tests/x11regressions/gnote/gnote_rename_title.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: x11regressions: add test scripts for gnote
+# G-Maintainer: Xudong Zhang <xdzhang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnote/gnote_search_all.pm
+++ b/tests/x11regressions/gnote/gnote_search_all.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: x11regressions: add test scripts for gnote
+# G-Maintainer: Xudong Zhang <xdzhang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnote/gnote_search_body.pm
+++ b/tests/x11regressions/gnote/gnote_search_body.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: x11regressions: add test scripts for gnote
+# G-Maintainer: Xudong Zhang <xdzhang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnote/gnote_search_title.pm
+++ b/tests/x11regressions/gnote/gnote_search_title.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add script for tc#1503753 tc#1503894
+# G-Maintainer: Chingkai <qkzhu@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/gnote/gnote_undo_redo.pm
+++ b/tests/x11regressions/gnote/gnote_undo_redo.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: x11regressions: add test scripts for gnote
+# G-Maintainer: Xudong Zhang <xdzhang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/libreoffice/libreoffice_default_theme.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_default_theme.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add scripts for libreoffice tc#1503783 tc#1503789 in x11regression
+# G-Maintainer: Chingkai <qkzhu@suse.com>
+
 use base "x11regressiontest";
 use testapi;
 use utils;

--- a/tests/x11regressions/libreoffice/libreoffice_double_click_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_double_click_file.pm
@@ -9,6 +9,9 @@
 
 # Case 1503778  - LibreOffice: Open supported file types by double click.
 
+# G-Summary: add libreoffice tc#1503778 and tc#1503881 script and attachment
+# G-Maintainer: dehai <dhkong@suse.com>
+
 use base "x11regressiontest";
 use base "x11regressiontest";
 use strict;

--- a/tests/x11regressions/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_mainmenu_components.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add a libreoffice tc#1503827 for x11regression
+# G-Maintainer: Chingkai <qkzhu@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/libreoffice/libreoffice_mainmenu_favorites.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_mainmenu_favorites.pm
@@ -9,6 +9,9 @@
 
 # Case 1503906 - LibreOffice: Favorite Documents link in Computer menu.
 
+# G-Summary: add libreoffice tc#1503906 script
+# G-Maintainer: dehai <dhkong@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
@@ -9,6 +9,9 @@
 
 # Case 1503881 - LibreOffice: Verify LibreOffice opens specified file types correctly.
 
+# G-Summary: add libreoffice tc#1503778 and tc#1503881 script and attachment
+# G-Maintainer: dehai <dhkong@suse.com>
+
 use base "x11regressiontest";
 use base "x11regressiontest";
 use strict;

--- a/tests/x11regressions/libreoffice/libreoffice_pyuno_bridge.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_pyuno_bridge.pm
@@ -9,6 +9,10 @@
 
 # Case 1503978  - LibreOffice: pyuno bridge.
 
+# G-Summary: Add test case for TC#150378
+#    Update use base of libreoffice_pyuno_bridge.pm
+# G-Maintainer: Jiawei Sun <JiaWei.Sun@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/libreoffice/libreoffice_recent_documents.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_recent_documents.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add scripts for libreoffice tc#1503783 tc#1503789 in x11regression
+# G-Maintainer: Chingkai <qkzhu@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/pidgin/clean_pidgin.pm
+++ b/tests/x11regressions/pidgin/clean_pidgin.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: First commit for pidgin cases. These cases should be test under good network condition.Otherwise,will be failed by timeout.
+# G-Maintainer: nick wang <nwang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/pidgin/pidgin_IRC.pm
+++ b/tests/x11regressions/pidgin/pidgin_IRC.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: First commit for pidgin cases. These cases should be test under good network condition.Otherwise,will be failed by timeout.
+# G-Maintainer: nick wang <nwang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/pidgin/pidgin_aim.pm
+++ b/tests/x11regressions/pidgin/pidgin_aim.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: First commit for pidgin cases. These cases should be test under good network condition.Otherwise,will be failed by timeout.
+# G-Maintainer: nick wang <nwang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/pidgin/prep_pidgin.pm
+++ b/tests/x11regressions/pidgin/prep_pidgin.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: First commit for pidgin cases. These cases should be test under good network condition.Otherwise,will be failed by timeout.
+# G-Maintainer: nick wang <nwang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/shotwell/shotwell_edit.pm
+++ b/tests/x11regressions/shotwell/shotwell_edit.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add 3 shotwell cases to x11regression
+# G-Maintainer: Chingkai <qkzhu@suse.com>
+
 use base "x11regressiontest";
 use base "x11regressiontest";
 use strict;

--- a/tests/x11regressions/shotwell/shotwell_export.pm
+++ b/tests/x11regressions/shotwell/shotwell_export.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add 3 shotwell cases to x11regression
+# G-Maintainer: Chingkai <qkzhu@suse.com>
+
 use base "x11regressiontest";
 use base "x11regressiontest";
 use strict;

--- a/tests/x11regressions/shotwell/shotwell_import.pm
+++ b/tests/x11regressions/shotwell/shotwell_import.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add 3 shotwell cases to x11regression
+# G-Maintainer: Chingkai <qkzhu@suse.com>
+
 use base "x11regressiontest";
 use base "x11regressiontest";
 use strict;

--- a/tests/x11regressions/tomboy/tomboy_AlreadyRunning.pm
+++ b/tests/x11regressions/tomboy/tomboy_AlreadyRunning.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add some new script
+# G-Maintainer: root <root@linux-t9vu.site>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tomboy/tomboy_Hotkeys.pm
+++ b/tests/x11regressions/tomboy/tomboy_Hotkeys.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add some new script
+# G-Maintainer: root <root@linux-t9vu.site>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tomboy/tomboy_Open.pm
+++ b/tests/x11regressions/tomboy/tomboy_Open.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add some new script
+# G-Maintainer: root <root@linux-t9vu.site>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tomboy/tomboy_Print.pm
+++ b/tests/x11regressions/tomboy/tomboy_Print.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add some new script
+# G-Maintainer: root <root@linux-t9vu.site>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tomboy/tomboy_StartNoteCannotBeDeleted.pm
+++ b/tests/x11regressions/tomboy/tomboy_StartNoteCannotBeDeleted.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add some new script
+# G-Maintainer: root <root@linux-t9vu.site>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tomboy/tomboy_TestFindFunctionalityInSearchAllNotes.pm
+++ b/tests/x11regressions/tomboy/tomboy_TestFindFunctionalityInSearchAllNotes.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Modify some by Weihua's comments, and add two news
+# G-Maintainer: Sero Sun <yosun@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tomboy/tomboy_TestUndoRedoFeature.pm
+++ b/tests/x11regressions/tomboy/tomboy_TestUndoRedoFeature.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Modify some by Weihua's comments, and add two news
+# G-Maintainer: Sero Sun <yosun@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tomboy/tomboy_checkinstall.pm
+++ b/tests/x11regressions/tomboy/tomboy_checkinstall.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add some new script
+# G-Maintainer: root <root@linux-t9vu.site>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tomboy/tomboy_firstrun.pm
+++ b/tests/x11regressions/tomboy/tomboy_firstrun.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add tomboy.d
+# G-Maintainer: SeroSun <sunyong0511@gmail.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tracker/clean_tracker.pm
+++ b/tests/x11regressions/tracker/clean_tracker.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: First commit for tracker cases. Still need to modify main.pm to make it work.
+# G-Maintainer: nick wang <nwang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tracker/prep_tracker.pm
+++ b/tests/x11regressions/tracker/prep_tracker.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: First commit for tracker cases. Still need to modify main.pm to make it work.
+# G-Maintainer: nick wang <nwang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tracker/tracker_by_command.pm
+++ b/tests/x11regressions/tracker/tracker_by_command.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: First commit for tracker cases. Still need to modify main.pm to make it work.
+# G-Maintainer: nick wang <nwang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tracker/tracker_info.pm
+++ b/tests/x11regressions/tracker/tracker_info.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: First commit for tracker cases. Still need to modify main.pm to make it work.
+# G-Maintainer: nick wang <nwang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tracker/tracker_mainmenu.pm
+++ b/tests/x11regressions/tracker/tracker_mainmenu.pm
@@ -7,6 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: add tracker main menu test case to x11regression
+# G-Maintainer: Chingkai Chu <qkzhu@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tracker/tracker_open_apps.pm
+++ b/tests/x11regressions/tracker/tracker_open_apps.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: First commit for tracker cases. Still need to modify main.pm to make it work.
+# G-Maintainer: nick wang <nwang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tracker/tracker_pref_starts.pm
+++ b/tests/x11regressions/tracker/tracker_pref_starts.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: First commit for tracker cases. Still need to modify main.pm to make it work.
+# G-Maintainer: nick wang <nwang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tracker/tracker_search_in_nautilus.pm
+++ b/tests/x11regressions/tracker/tracker_search_in_nautilus.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: First commit for tracker cases. Still need to modify main.pm to make it work.
+# G-Maintainer: nick wang <nwang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tracker/tracker_searchall.pm
+++ b/tests/x11regressions/tracker/tracker_searchall.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: First commit for tracker cases. Still need to modify main.pm to make it work.
+# G-Maintainer: nick wang <nwang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/tracker/tracker_starts.pm
+++ b/tests/x11regressions/tracker/tracker_starts.pm
@@ -8,6 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: First commit for tracker cases. Still need to modify main.pm to make it work.
+# G-Maintainer: nick wang <nwang@suse.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/x11regressions/x11regressions_setup.pm
+++ b/tests/x11regressions/x11regressions_setup.pm
@@ -7,6 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add common setup for x11regression tests
+#     - grant user permission to access serial port
+# G-Maintainer: mitiao <mitiao@gmail.com>
+
 use base "x11regressiontest";
 use strict;
 use testapi;

--- a/tests/yast2_gui/yast2_bootloader.pm
+++ b/tests/yast2_gui/yast2_bootloader.pm
@@ -8,6 +8,12 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add YaST2 UI tests
+#    Make sure those yast2 modules can opened properly. We can add more
+#    feature test against each module later, it is ensure it will not crashed
+#    while launching atm.
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use base "y2x11test";
 use strict;
 use testapi;

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -8,6 +8,12 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add YaST2 UI tests
+#    Make sure those yast2 modules can opened properly. We can add more
+#    feature test against each module later, it is ensure it will not crashed
+#    while launching atm.
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use base "y2x11test";
 use strict;
 use testapi;

--- a/tests/yast2_gui/yast2_datetime.pm
+++ b/tests/yast2_gui/yast2_datetime.pm
@@ -8,6 +8,12 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add YaST2 UI tests
+#    Make sure those yast2 modules can opened properly. We can add more
+#    feature test against each module later, it is ensure it will not crashed
+#    while launching atm.
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use base "y2x11test";
 use strict;
 use testapi;

--- a/tests/yast2_gui/yast2_firewall.pm
+++ b/tests/yast2_gui/yast2_firewall.pm
@@ -8,6 +8,12 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add YaST2 UI tests
+#    Make sure those yast2 modules can opened properly. We can add more
+#    feature test against each module later, it is ensure it will not crashed
+#    while launching atm.
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use base "y2x11test";
 use strict;
 use testapi;

--- a/tests/yast2_gui/yast2_hostnames.pm
+++ b/tests/yast2_gui/yast2_hostnames.pm
@@ -8,6 +8,12 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add YaST2 UI tests
+#    Make sure those yast2 modules can opened properly. We can add more
+#    feature test against each module later, it is ensure it will not crashed
+#    while launching atm.
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use base "y2x11test";
 use strict;
 use testapi;

--- a/tests/yast2_gui/yast2_lang.pm
+++ b/tests/yast2_gui/yast2_lang.pm
@@ -8,6 +8,12 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add YaST2 UI tests
+#    Make sure those yast2 modules can opened properly. We can add more
+#    feature test against each module later, it is ensure it will not crashed
+#    while launching atm.
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use base "y2x11test";
 use strict;
 use testapi;

--- a/tests/yast2_gui/yast2_network_settings.pm
+++ b/tests/yast2_gui/yast2_network_settings.pm
@@ -8,6 +8,12 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add YaST2 UI tests
+#    Make sure those yast2 modules can opened properly. We can add more
+#    feature test against each module later, it is ensure it will not crashed
+#    while launching atm.
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use base "y2x11test";
 use strict;
 use testapi;

--- a/tests/yast2_gui/yast2_snapper.pm
+++ b/tests/yast2_gui/yast2_snapper.pm
@@ -8,6 +8,12 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add YaST2 UI tests
+#    Make sure those yast2 modules can opened properly. We can add more
+#    feature test against each module later, it is ensure it will not crashed
+#    while launching atm.
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use base "y2x11test";
 use strict;
 use testapi;

--- a/tests/yast2_gui/yast2_software_management.pm
+++ b/tests/yast2_gui/yast2_software_management.pm
@@ -8,6 +8,12 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add YaST2 UI tests
+#    Make sure those yast2 modules can opened properly. We can add more
+#    feature test against each module later, it is ensure it will not crashed
+#    while launching atm.
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use base "y2x11test";
 use strict;
 use testapi;

--- a/tests/yast2_gui/yast2_users.pm
+++ b/tests/yast2_gui/yast2_users.pm
@@ -8,6 +8,12 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+# G-Summary: Add YaST2 UI tests
+#    Make sure those yast2 modules can opened properly. We can add more
+#    feature test against each module later, it is ensure it will not crashed
+#    while launching atm.
+# G-Maintainer: Max Lin <mlin@suse.com>
+
 use base "y2x11test";
 use strict;
 use testapi;


### PR DESCRIPTION
This is extracted from git and often enough nonsense - or duplicating
infos already present in the file. But if we want to enforce a policy
on having this information in the file, we need to make it easy for
contributors to see how it's supposed to look like.

So I add G-Summary and G-Maintainer, that the next contributor to the
test needs to adapt to be Summary if correct - or change the text while
at it.