### PR TITLE
Prevent 'sshboy' messing up unrelated tests

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -420,6 +420,7 @@ sub load_consoletests() {
             loadtest "console/sshd_running.pm";
         }
         loadtest "console/sshd.pm";
+        loadtest "console/ssh_cleanup.pm";
         if (!get_var("LIVETEST") && !is_staging()) {
             # in live we don't have a password for root so ssh doesn't
             # work anyways, and except staging_core image, the rest of

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -599,6 +599,7 @@ sub load_consoletests() {
             loadtest "console/rt_preempt_test.pm";
         }
         loadtest "console/sshd.pm";
+        loadtest "console/ssh_cleanup.pm";
         if (get_var("BIGTEST")) {
             loadtest "console/sntp.pm";
             loadtest "console/curl_ipv6.pm";
@@ -898,6 +899,7 @@ sub load_fips_tests_core() {
     }
     loadtest "console/sshd.pm";
     loadtest "console/ssh_pubkey.pm";
+    loadtest "console/ssh_cleanup.pm";
     loadtest "fips/openssh/openssh_fips.pm";
 }
 

--- a/tests/console/ssh_cleanup.pm
+++ b/tests/console/ssh_cleanup.pm
@@ -1,0 +1,21 @@
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use base "consoletest";
+use strict;
+use testapi;
+
+# Summary: Cleanup ssh test user to prevent the user showing up in
+#  displaymanager and confusing other tests
+# Maintainer: okurz@suse.de
+sub run() {
+    select_console 'root-console';
+    assert_script_run('getent passwd sshboy > /dev/null && userdel -fr sshboy');
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
The user sshboy is created by the sshd test module and used only in sshd
itself and ssh_pubkey (FIPS) for now. To prevent confusion of reviewers and
unrelated tests (e.g. log into displaymanager) the user is removed in its own
test module regardless if the sshd test module failed or passed in before.