### PR TITLE
Always reboot to ensure a properly working updated system (bsc#989696)

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -33,6 +33,7 @@ our @EXPORT = qw/
   addon_decline_license
   addon_license
   validate_repos
+  setup_online_migration
   /;
 
 
@@ -721,6 +722,24 @@ sub validate_repos {
                 });
         }
     }
+}
+
+sub setup_online_migration {
+    # if source system is minimal installation then boot to textmode
+    wait_boot textmode => !is_desktop_installed;
+    select_console 'root-console';
+
+    # stop packagekit service
+    script_run "systemctl mask packagekit.service";
+    script_run "systemctl stop packagekit.service";
+
+    type_string "chown $username /dev/$serialdev\n";
+
+    # enable Y2DEBUG all time
+    type_string "echo 'export Y2DEBUG=1' >> /etc/bash.bashrc.local\n";
+    script_run "source /etc/bash.bashrc.local";
+
+    save_screenshot;
 }
 
 1;

--- a/tests/online_migration/sle12_online_migration/online_migration_setup.pm
+++ b/tests/online_migration/sle12_online_migration/online_migration_setup.pm
@@ -13,23 +13,7 @@ use testapi;
 use utils;
 
 sub run() {
-    my $self = shift;
-
-    # if source system is minimal installation then boot to textmode
-    wait_boot textmode => !is_desktop_installed;
-    select_console 'root-console';
-
-    # stop packagekit service
-    script_run "systemctl mask packagekit.service";
-    script_run "systemctl stop packagekit.service";
-
-    type_string "chown $username /dev/$serialdev\n";
-
-    # enable Y2DEBUG all time
-    type_string "echo 'export Y2DEBUG=1' >> /etc/bash.bashrc.local\n";
-    script_run "source /etc/bash.bashrc.local";
-
-    save_screenshot;
+    setup_online_migration;
 }
 
 1;

--- a/tests/online_migration/sle12_online_migration/zypper_patch.pm
+++ b/tests/online_migration/sle12_online_migration/zypper_patch.pm
@@ -17,6 +17,8 @@ sub run() {
     select_console 'root-console';
 
     fully_patch_system;
+    type_string "reboot\n";
+    setup_online_migration;
 }
 
 sub test_flags() {


### PR DESCRIPTION
In case of online migration in bsc#989696 we hit the case that the migrated
system does not boot. The old SLE 12 GA kernel version was suspected to be the
case. `zypper patch` would pull in an updated kernel but it is never applied
as there is no reboot between the `zypper patch` call and the whole step of
online migration.