### PR TITLE
Replace mutexes to barriers in HA cluster tests

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -7,8 +7,6 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# temporary implementation of barrier_create and barrier_wait functions, they work only for two nodes (with HOSTNAME set to "host1" and "host2")
-
 package hacluster;
 use base "opensusebasetest";
 use testapi;
@@ -24,29 +22,8 @@ sub is_node2 {
     return (get_var("HOSTNAME") eq "host2");
 }
 
-sub barrier_wait {
-    my $self         = shift;
-    my $barrier_name = shift;
-    if (is_node1) {
-        mutex_unlock("MUTEX_${barrier_name}_M1");
-        mutex_lock("MUTEX_${barrier_name}_M2");
-    }
-    if (is_node2) {
-        mutex_unlock("MUTEX_${barrier_name}_M2");
-        mutex_lock("MUTEX_${barrier_name}_M1");
-    }
-}
-
-sub barrier_create {
-    my $self         = shift;
-    my $barrier_name = shift;
-    if (is_node1) {    #mutex_create now moved to main.pm as workaround
-        mutex_lock("MUTEX_${barrier_name}_M1");
-    }
-    if (is_node2) {
-        #        mutex_create("MUTEX_${barrier_name}_M2");
-        mutex_lock("MUTEX_${barrier_name}_M2");
-    }
+sub cluster_name {
+    return get_var("CLUSTERNAME");
 }
 
 sub post_run_hook {

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -11,30 +11,39 @@ use base "hacluster";
 use strict;
 use testapi;
 use lockapi;
+use mmapi;
 
 sub run() {
     my $self = shift;
 
-    $self->barrier_create("CLUSTER_INITIALIZED");
-    $self->barrier_create("NODE2_JOINED");
-    $self->barrier_create("OCFS2_INIT");
-    $self->barrier_create("DLM_GROUPS_CREATED");
-    $self->barrier_create("DLM_CHECKED");
-    $self->barrier_create("OCFS2_MKFS_DONE");
-    $self->barrier_create("OCFS2_GROUP_ALTERED");
-    $self->barrier_create("OCFS2_DATA_COPIED");
-    $self->barrier_create("OCFS2_MD5_CHECKED");
-    $self->barrier_create("BEFORE_FENCING");
-    $self->barrier_create("FENCING_DONE");
-    $self->barrier_create("LOGS_CHECKED");
-    $self->barrier_create("CLVM_INIT");
-    $self->barrier_create("CLVM_RESOURCE_CREATED");
-    $self->barrier_create("CLVM_PV_VG_LV_CREATED");
-    $self->barrier_create("CLVM_VG_RESOURCE_CREATED");
-    $self->barrier_create("CLVM_RW_CHECKED");
-    $self->barrier_create("CLVM_MD5SUM");
-    $self->barrier_create("PACEMAKER_CTS_INSTALLED");
-    $self->barrier_create("PACEMAKER_CTS_FINISHED");
+    for my $clustername (split(/,/, get_var('CLUSTERNAME'))) {
+        barrier_create("BARRIER_HA_" . $clustername,               3);
+        barrier_create("CLUSTER_INITIALIZED_" . $clustername,      2);
+        barrier_create("NODE2_JOINED_" . $clustername,             2);
+        barrier_create("DLM_INIT_" . $clustername,                 2);
+        barrier_create("DLM_GROUPS_CREATED_" . $clustername,       2);
+        barrier_create("DLM_CHECKED_" . $clustername,              2);
+        barrier_create("OCFS2_INIT_" . $clustername,               2);
+        barrier_create("OCFS2_MKFS_DONE_" . $clustername,          2);
+        barrier_create("OCFS2_GROUP_ALTERED_" . $clustername,      2);
+        barrier_create("OCFS2_DATA_COPIED_" . $clustername,        2);
+        barrier_create("OCFS2_MD5_CHECKED_" . $clustername,        2);
+        barrier_create("BEFORE_FENCING_" . $clustername,           2);
+        barrier_create("FENCING_DONE_" . $clustername,             2);
+        barrier_create("LOGS_CHECKED_" . $clustername,             2);
+        barrier_create("CLVM_INIT_" . $clustername,                2);
+        barrier_create("CLVM_RESOURCE_CREATED_" . $clustername,    2);
+        barrier_create("CLVM_PV_VG_LV_CREATED_" . $clustername,    2);
+        barrier_create("CLVM_VG_RESOURCE_CREATED_" . $clustername, 2);
+        barrier_create("CLVM_RW_CHECKED_" . $clustername,          2);
+        barrier_create("CLVM_MD5SUM_" . $clustername,              2);
+        #    barrier_create("PACEMAKER_CTS_INSTALLED_" . $clustername, 2);
+        #    barrier_create("PACEMAKER_CTS_FINISHED_" . $clustername, 2);
+    }
+    wait_for_children_to_start;
+    for my $clustername (split(/,/, get_var('CLUSTERNAME'))) {
+        barrier_wait("BARRIER_HA_" . $clustername);
+    }
 }
 
 sub test_flags {

--- a/tests/ha/check_logs.pm
+++ b/tests/ha/check_logs.pm
@@ -15,17 +15,14 @@ use lockapi;
 
 sub run() {
     my $self = shift;
-    $self->barrier_wait("FENCING_DONE");
+    barrier_wait("FENCING_DONE_" . $self->cluster_name);
     select_console 'root-console';
 
     script_run "hb_report -f 2014 hb_report", 120;
     upload_logs "hb_report.tar.bz2";
     type_string "echo segfaults=`grep -sR segfault /var/log | wc -l` > /dev/$serialdev\n";
     die "segfault occured" unless wait_serial "segfaults=0", 60;
-    $self->barrier_wait("LOGS_CHECKED");
-    if ($self->is_node1) {    #node1
-        mutex_unlock("MUTEX_HA_" . get_var("CLUSTERNAME") . "_FINISHED");    # release support_server
-    }
+    barrier_wait("LOGS_CHECKED_" . $self->cluster_name);
 }
 
 sub test_flags {

--- a/tests/ha/dlm.pm
+++ b/tests/ha/dlm.pm
@@ -15,7 +15,7 @@ use lockapi;
 
 sub run() {
     my $self = shift;
-    $self->barrier_wait("DLM_INIT");
+    barrier_wait("DLM_INIT_" . $self->cluster_name);
     type_string "rpm -q dlm-kmp-default; echo dlm_kmp_default_installed=\$? > /dev/$serialdev\n";
     if ($self->is_node1) {    #node1
         type_string "echo wait until DLM resource is created\n";
@@ -28,10 +28,10 @@ sub run() {
         type_string qq(EDITOR="sed -ie '\$ a clone base-clone base-group'" crm configure edit; echo base_clone_add=\$? > /dev/$serialdev\n);
         die "create base-clone failed" unless wait_serial "base_clone_add=0", 60;
     }
-    $self->barrier_wait("DLM_GROUPS_CREATED");
+    barrier_wait("DLM_GROUPS_CREATED_" . $self->cluster_name);
     type_string "ps -A | grep -q dlm_controld; echo dlm_running=\$? > /dev/$serialdev\n";
     die "dlm_controld is not running" unless wait_serial "dlm_running=0", 60;
-    $self->barrier_wait("DLM_CHECKED");
+    barrier_wait("DLM_CHECKED_" . $self->cluster_name);
 }
 
 1;

--- a/tests/ha/fencing.pm
+++ b/tests/ha/fencing.pm
@@ -15,7 +15,7 @@ use lockapi;
 
 sub run() {
     my $self = shift;
-    $self->barrier_wait("BEFORE_FENCING");
+    barrier_wait("BEFORE_FENCING_" . $self->cluster_name);
     if ($self->is_node1) {
         reset_consoles;
     }

--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -40,8 +40,8 @@ sub run() {
         }
     }
     assert_screen("ha-crm-mon-" . get_var("CLUSTERNAME") . "-host1-online");
-    $self->barrier_wait("CLUSTER_INITIALIZED");
-    $self->barrier_wait("NODE2_JOINED");
+    barrier_wait("CLUSTER_INITIALIZED_" . $self->cluster_name);
+    barrier_wait("NODE2_JOINED_" . $self->cluster_name);
     type_string "crm_mon -1\n";
     save_screenshot;
 }

--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -15,7 +15,7 @@ use lockapi;
 
 sub run() {
     my $self = shift;
-    $self->barrier_wait("CLUSTER_INITIALIZED");
+    barrier_wait("CLUSTER_INITIALIZED_" . $self->cluster_name);
     script_run "ping -c1 " . get_var("HACLUSTERJOIN");
     type_string "ha-cluster-join -yc " . get_var("HACLUSTERJOIN") . "\n";
     assert_screen "ha-cluster-join-password";
@@ -24,7 +24,7 @@ sub run() {
     wait_still_screen;
     script_run "crm_mon -1";
     save_screenshot;
-    $self->barrier_wait("NODE2_JOINED");
+    barrier_wait("NODE2_JOINED_" . $self->cluster_name);
 }
 
 sub test_flags {

--- a/tests/ha/ha_support_server.pm
+++ b/tests/ha/ha_support_server.pm
@@ -14,16 +14,17 @@ use lockapi;
 use mmapi;
 
 sub run() {
-    wait_for_children_to_start;
-    for my $clustername (split(/,/, get_var('CLUSTERNAME'))) {
-        mutex_unlock("MUTEX_HA_" . $clustername . "_NODE1_WAIT");    #start node1 and node2 jobs
-        mutex_unlock("MUTEX_HA_" . $clustername . "_NODE2_WAIT");
-    }
+    #    for my $clustername (split(/,/, get_var('CLUSTERNAME'))) {
+    #        mutex_unlock("MUTEX_HA_" . $clustername . "_NODE1_WAIT");    #start node1 and node2 jobs
+    #        mutex_unlock("MUTEX_HA_" . $clustername . "_NODE2_WAIT");
+    #    }
     # wait for bootup
     assert_screen "tty1-selected", 600;
     type_string "root\n";
     assert_screen "password-prompt";
     type_string "susetesting\n";
+    type_string "ip a\n";
+    type_string "ip route\n";
     type_string "if `ip a | grep -q '172.16.0.1/28'`; then echo ip1_okay > /dev/$serialdev; fi\n";
     wait_serial("ip1_okay") || die "support server doesn't have IP1";
     type_string "if `ip a | grep -q '172.16.0.17/28'`; then echo ip2_okay > /dev/$serialdev; fi\n";

--- a/tests/ha/ocfs2.pm
+++ b/tests/ha/ocfs2.pm
@@ -16,7 +16,7 @@ use lockapi;
 sub run() {
     my $self            = shift;
     my $ocfs2_partition = "/dev/disk/by-path/ip-*-lun-2";
-    $self->barrier_wait("OCFS2_INIT");
+    barrier_wait("OCFS2_INIT_" . $self->cluster_name);
     type_string "ps -A | grep -q dlm_controld; echo dlm_running=\$? > /dev/$serialdev\n";
     die "dlm_controld is not running" unless wait_serial "dlm_running=0", 60;
     if ($self->is_node1) {
@@ -26,7 +26,7 @@ sub run() {
     else {
         type_string "echo wait until OCFS2 is formatted\n";
     }
-    $self->barrier_wait("OCFS2_MKFS_DONE");
+    barrier_wait("OCFS2_MKFS_DONE_" . $self->cluster_name);
     if ($self->is_node1) {
         type_string "echo wait until OCFS2 resource is created\n";
     }
@@ -36,7 +36,7 @@ sub run() {
         type_string qq(EDITOR="sed -ie 's/group base-group dlm/group base-group dlm ocfs2-1/'" crm configure edit; echo base_group_alter=\$? > /dev/$serialdev\n);
         die "adding ocfs2-1 to base-group failed" unless wait_serial "base_group_alter=0", 60;
     }
-    $self->barrier_wait("OCFS2_GROUP_ALTERED");
+    barrier_wait("OCFS2_GROUP_ALTERED_" . $self->cluster_name);
     if ($self->is_node1) {
         type_string "cp -r /usr/bin/ /srv/ocfs2; echo copy_success=\$? > /dev/$serialdev\n";
         die "copying files to /srv/ocfs2 failed" unless wait_serial "copy_success=0", 60;
@@ -46,7 +46,7 @@ sub run() {
     else {
         type_string "echo wait until OCFS2 is filled with data\n";
     }
-    $self->barrier_wait("OCFS2_DATA_COPIED");
+    barrier_wait("OCFS2_DATA_COPIED_" . $self->cluster_name);
     if ($self->is_node1) {
         type_string "echo wait until OCFS2 content is checked\n";
     }
@@ -56,7 +56,7 @@ sub run() {
         type_string "diff out out_node2; echo md5sums_diff=\$? > /dev/$serialdev\n";
         die "md5sums are different on different nodes" unless wait_serial "md5sums_diff=0", 60;
     }
-    $self->barrier_wait("OCFS2_MD5_CHECKED");
+    barrier_wait("OCFS2_MD5_CHECKED_" . $self->cluster_name);
 }
 
 1;


### PR DESCRIPTION
New lockapi has barriers included in https://github.com/os-autoinst/os-autoinst/pull/579,
to support this all fake barriers implemented in lib/hacluster.pm were replaced to the new API.
This will allow more sophisticated HA tests with multinodes clusters.

Sample test run:
http://ix64sap002.qa.suse.de/tests/overview?groupid=1&distri=sle&build=0444_2145&version=12-SP2