### PR TITLE
Fix hexchat_ssl.pm failure: SSL is already on

### DIFF
--- a/tests/x11/hexchat_ssl.pm
+++ b/tests/x11/hexchat_ssl.pm
@@ -32,7 +32,10 @@ sub run() {
 
         # use ssl for all servers on this network
         assert_and_click "$name-edit-button";
-        assert_and_click "$name-use-ssl-button";
+        assert_screen ["$name-use-ssl-button", "$name-ssl-on"];
+        if (!match_has_tag("$name-ssl-on")) {
+            assert_and_click "$name-use-ssl-button";
+        }
         assert_and_click "$name-close-button";
 
         assert_and_click "$name-connect-button";


### PR DESCRIPTION
Fix hexchat test failure caused by package update:
No need to explicitly enable SSL if it is already
enabled as default setting.