### PR TITLE
Update aide_check.pm: Increase timeout

### DIFF
--- a/tests/console/aide_check.pm
+++ b/tests/console/aide_check.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: FIPS case for aide check test
+# Summary: FIPS case for aide check test
 #    This is a new test case added for FIPS, it test the basic function of aide tools.
 #    This case will been used with SLE 12 SP2 with FIPS, and it has added to misc part of FIPS test.
 #    The case will do operation as followed
@@ -15,7 +15,7 @@
 #    2. Initialized the aide database and check
 #    3. Check the difference between datebase and file system.
 #    4. Modified the file system and run aide check again.
-# G-Maintainer: Jiawei Sun <Jiawei.sun@suse.com>
+# Maintainer: Jiawei Sun <Jiawei.sun@suse.com>
 
 use base "consoletest";
 use testapi;
@@ -25,16 +25,15 @@ use strict;
 sub run() {
     my $self = shift;
     select_console 'root-console';
-    validate_script_output "zypper -n in aide", sub { m/(Installing.*)|(.*already installed)/ };
+    assert_script_run "zypper -n in aide", 90;
     assert_script_run "cp /etc/aide.conf /etc/aide.conf.bak";
-    assert_script_run "sed -i \'s/^\\//!\\//\' /etc/aide.conf && sed -i \'s/^!\\/var\\/log/\\/var\\/log/\' /etc/aide.conf";
-    assert_script_run "aide -i";
+    assert_script_run "sed -i 's:^/:!/:g' /etc/aide.conf && sed -i 's:!/var/log:/var/log:g' /etc/aide.conf";
+    assert_script_run "aide -i", 60;
     assert_script_run "cp /var/lib/aide/aide.db.new /var/lib/aide/aide.db";
-    assert_script_run "aide --check";
+    assert_script_run "aide --check", 60;
     assert_script_run "touch /var/log/testlog";
     assert_script_run "clear";
-    script_run "aide --check";
-    assert_screen "aide_result";
+    validate_script_output "aide --check | tee", sub { m/found differences between database and filesystem/ }, 60;
     assert_script_run "mv /etc/aide.conf.bak /etc/aide.conf && rm /var/log/testlog";
 }
 


### PR DESCRIPTION
The default timeout, 30s, is sometimes not enough to
install the aide package, extend it to 90s. Also set
timeout of "aide -i" and "aide --check" commands to
be 60s to avoid test failure caused by timeout.

Replace assert_screen with validate_script_output to
check the output of "aide --check" command, which will
improve the stability of the test case.