### PR TITLE
Restrict properly ppc64le encryption workaround

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -324,7 +324,7 @@ sub fully_patch_system {
 }
 
 sub workaround_type_encrypted_passphrase {
-    if (get_var('ENCRYPT') && check_var('ARCH', 'ppc64le')) {
+    if (check_var('ARCH', 'ppc64le') && (get_var('ENCRYPT') || get_var('ENCRYPT_FORCE_RECOMPUTE') || !(get_var('ENCRYPT_ACTIVATE_EXISTING') && get_var('ENCRYPT_CANCEL_EXISTING')))) {
         record_soft_failure 'workaround https://fate.suse.com/320901';
         unlock_if_encrypted;
     }


### PR DESCRIPTION
https://progress.opensuse.org/issues/12782

one of issues:
https://openqa.suse.de/tests/594606#step/grub_test/10