### PR TITLE
first_boot: Do not press RETURN if the DM does not require a username…

### DIFF
--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -23,9 +23,12 @@ sub handle_login {
     mouse_hide();
     wait_still_screen;
     if (get_var('DM_NEEDS_USERNAME')) {
-        type_string $username;
+        type_string "$username\n";
     }
-    send_key "ret";
+    if (check_var('DESKTOP', 'gnome')) {
+        # In GNOME/gdm, we do not have to enter a username, but we have to select it
+        send_key 'ret';
+    }
     assert_screen "displaymanager-password-prompt";
     type_string "$password";
     send_key "ret";

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -8,8 +8,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: renamed 091_second_stage to 091_first_boot
-# G-Maintainer: Max Lin <mlin@suse.com>
+# Summary: Special handling to get to the desktop the first time after
+#          the installation has been completed (either find the desktop after
+#          auto-login or handle the login screen to reach the desktop)
+# Maintainer: Max Lin <mlin@suse.com>
 
 use strict;
 use base "y2logsstep";


### PR DESCRIPTION
… (input or selection)

The DMs react all a bit different to user input. An overview of the ones used in openSUSE:

 * xdm: requires typing username & password
 * gdm: requires to 'select the user' from the list (ret does that) then type password
 * sddm: user is pre-selected: only type password (initial input field)
 * lightdm: user is pre-selected: only password (initial input field) needs to be typed

For the cases where the password input field is preselected, hitting RET means 'login without password', so is not the right thing
For xdm, hitting 'ret' means to move from 'username' to the 'password' field
for gdm, 'ret' means 'select default user', then ask for the password

Should actually fix the fallout from 
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/1864

(there are quite a few variations, especially also with SLE)