### PR TITLE
Fix restrict properly ppc64le encryption workaround

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -353,7 +353,7 @@ sub fully_patch_system {
 }
 
 sub workaround_type_encrypted_passphrase {
-    if (check_var('ARCH', 'ppc64le') && (get_var('ENCRYPT') || get_var('ENCRYPT_FORCE_RECOMPUTE') || !(get_var('ENCRYPT_ACTIVATE_EXISTING') && get_var('ENCRYPT_CANCEL_EXISTING')))) {
+    if (check_var('ARCH', 'ppc64le') && (get_var('ENCRYPT') && !get_var('ENCRYPT_ACTIVATE_EXISTING') || get_var('ENCRYPT_FORCE_RECOMPUTE'))) {
         record_soft_failure 'workaround https://fate.suse.com/320901';
         unlock_if_encrypted;
     }

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -354,7 +354,7 @@ sub fully_patch_system {
 
 sub workaround_type_encrypted_passphrase {
     if (check_var('ARCH', 'ppc64le') && (get_var('ENCRYPT') && !get_var('ENCRYPT_ACTIVATE_EXISTING') || get_var('ENCRYPT_FORCE_RECOMPUTE'))) {
-        record_soft_failure 'workaround https://fate.suse.com/320901';
+        record_soft_failure 'workaround https://fate.suse.com/320901' if sle_version_at_least('12-SP3');
         unlock_if_encrypted;
     }
 }


### PR DESCRIPTION
```
Test                                        Passphrase  Variables
cryptlvm                                    yes         ENCRYPT
cryptlvm+activate_existing                  no          ENCRYPT ENCRYPT_ACTIVATE_EXISTING
cryptlvm+activate_existing+force_recompute  yes         ENCRYPT ENCRYPT_ACTIVATE_EXISTING ENCRYPT_FORCE_RECOMPUTE
cryptlvm+activate_existing+import_users     no          ENCRYPT ENCRYPT_ACTIVATE_EXISTING
```

tested behavior with x86_64 as I don't have ppc64le worker
I used check_var('ARCH', 'x86_64') instead check_var('ARCH', 'ppc64le'), just imagine it's ppc64le and focus on grub_test ;)

[cryptlvm](http://10.100.51.177/tests/3551)
[cryptlvm+activate_existing+force_recompute](http://10.100.51.177/tests/3550)
[cryptlvm+activate_existing](http://10.100.51.177/tests/3547)
[cryptlvm+activate_existing+import_users](http://10.100.51.177/tests/3549)