### PR TITLE
Redefine libvirt JeOS domain as soon as possible

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -143,6 +143,14 @@ sub wait_boot {
 
     if ($textmode || check_var('DESKTOP', 'textmode')) {
         assert_screen 'linux-login', 200;
+        reset_consoles;
+
+        # Without this login name and password won't get to the system. They get
+        # lost somewhere. Applies for all systems installed via svirt, but zKVM.
+        if (check_var('BACKEND', 'svirt') and !check_var('ARCH', 's390x')) {
+            wait_idle;
+        }
+
         return;
     }
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1185,6 +1185,9 @@ else {
         load_boot_tests();
         loadtest "jeos/firstrun.pm";
         loadtest "jeos/grub2_gfxmode.pm";
+        if (check_var('BACKEND', 'svirt')) {
+            loadtest "installation/redefine_svirt_domain.pm";
+        }
         loadtest "jeos/diskusage.pm";
         loadtest "jeos/root_fs_size.pm";
         loadtest "jeos/mount_by_label.pm";

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -8,8 +8,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Rework the tests layout.
-# G-Maintainer: Alberto Planas <aplanas@suse.com>
+# Summary: Prepare console for console tests
+# Maintainer: Oliver Kurz <okurz@suse.com>
 
 use base "consoletest";
 use testapi;
@@ -22,8 +22,8 @@ use strict;
 sub run() {
     my $self = shift;
 
-    # Without this login name and password won't get to the system. The
-    # get lost somewhere. Applies for all systems installed via svirt.
+    # Without this login name and password won't get to the system. They get
+    # lost somewhere. Applies for all systems installed via svirt, but zKVM.
     if (check_var('BACKEND', 'svirt') and !check_var('ARCH', 's390x')) {
         wait_idle;
     }

--- a/tests/installation/redefine_svirt_domain.pm
+++ b/tests/installation/redefine_svirt_domain.pm
@@ -7,14 +7,21 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Split the svirt redefine to another test
-# G-Maintainer: Stephan Kulow <coolo@suse.de>
+# Summary: libvirt domains need to be redefined after installation
+# to restart properly
+# Maintainer: Michal Nowak <mnowak@suse.com>
 
 use base "installbasetest";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
+    # Now we need to redefine libvirt domain; installation/redefine_svirt_domain
+    # test should follow.
+    if (is_jeos) {
+        script_run 'poweroff', 0;
+    }
 
     my $svirt = console('svirt');
 
@@ -47,6 +54,20 @@ sub run() {
         }
         select_console 'sut';
     }
+
+    if (is_jeos) {
+        wait_boot;
+        if (check_var('BACKEND', 'svirt') and !check_var('ARCH', 's390x')) {
+            wait_idle;
+        }
+        select_console 'root-console';
+    }
+}
+
+sub test_flags() {
+    # on JeOS this is the time for first snapshot as system is deployed
+    # and it's libvirt XML domain set to restart properly
+    return {fatal => 1, milestone => is_jeos ? 1 : 0};
 }
 
 1;

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -8,8 +8,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: First commit of JeOS firstrun, diskusage, sccreg, and imgsize tests
-# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+# Summary: Configure JeOS
+# Maintainer: Michal Nowak <mnowak@suse.com>
 
 use base "opensusebasetest";
 use strict;
@@ -66,8 +66,8 @@ sub run() {
 
     assert_screen 'linux-login';
 
-    # Without this login name and password won't get to the system. The
-    # get lost somewhere. Applies for all systems installed via svirt.
+    # Without this login name and password won't get to the system. They get
+    # lost somewhere. Applies for all systems installed via svirt, but zKVM.
     if (check_var('BACKEND', 'svirt') and !check_var('ARCH', 's390x')) {
         wait_idle;
     }

--- a/tests/jeos/grub2_gfxmode.pm
+++ b/tests/jeos/grub2_gfxmode.pm
@@ -11,10 +11,10 @@
 # 1024x768 of the cirrus kms driver doesn't help us. We need to
 # manually configure grub to tell the kernel what mode to use.
 
-# G-Summary: set gfxplayload for grub
+# Summary: set gfxplayload for grub
 #    JeOS doesn't inherit the gfx settings from the first boot so we need
 #    to adjust the grub config manually to survive reboots.
-# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+# Maintainer: Michal Nowak <mnowak@suse.com>
 
 use base "opensusebasetest";
 use strict;
@@ -46,7 +46,7 @@ sub run {
 }
 
 sub test_flags() {
-    return {fatal => 1, milestone => 1};
+    return {fatal => 1};
 }
 
 1;


### PR DESCRIPTION
To support restarts on JeOS with svirt backend
(https://openqa.suse.de/tests/599136) libvirt domain needs to be
redefined as it's done for YaST installations. Couple of
`wait_idle()`'s need to be added as well.

Verification run: http://assam.suse.cz/tests/3442.