### PR TITLE
Fix yast2_i test

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -221,22 +221,16 @@ sub yast_scc_registration {
             last;
         }
         send_key "alt-o";
-        # Upgrade tests and the old distributions eg. SLE11 don't
-        # show the summary
-        if (get_var("YAST_SW_NO_SUMMARY")) {
-            $timeout = 900;    # installation of an addon may take long
-        }
-        else {
-            # yast may pop up a reboot prompt window after addons installation such like ha on sle12 sp0
-            while (assert_screen([qw/yast_scc-prompt-reboot yast_scc-installation-summary/], 900)) {
-                if (match_has_tag('yast_scc-prompt-reboot')) {
-                    send_key "alt-o", 1;
-                    next;
-                }
-                elsif (match_has_tag('yast_scc-installation-summary')) {
-                    send_key "alt-f";
-                    last;
-                }
+
+        # yast may pop up a reboot prompt window after addons installation such like ha on sle12 sp0
+        while (assert_screen([qw/yast_scc-prompt-reboot yast_scc-installation-summary/], 900)) {
+            if (match_has_tag('yast_scc-prompt-reboot')) {
+                send_key "alt-o", 1;
+                next;
+            }
+            elsif (match_has_tag('yast_scc-installation-summary')) {
+                send_key "alt-f";
+                last;
             }
         }
     }

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -105,9 +105,6 @@ if (check_var('DESKTOP', 'minimalx') || get_var('DESKTOP_MINIMALX_INSTONLY')) {
 set_var('LEAP', get_var('VERSION', '') =~ /(?:[4-9][0-9]|[0-9]{3,})\.[0-9]/);
 set_var("PACKAGETOINSTALL", "xdelta");
 set_var("WALLPAPER",        '/usr/share/wallpapers/openSUSEdefault/contents/images/1280x1024.jpg');
-if (!defined get_var("YAST_SW_NO_SUMMARY")) {
-    set_var("YAST_SW_NO_SUMMARY", 1) if get_var('UPGRADE') || get_var("ZDUP");
-}
 
 # set KDE and GNOME, ...
 set_var(uc(get_var('DESKTOP')), 1);

--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -8,8 +8,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Rework the tests layout.
-# G-Maintainer: Alberto Planas <aplanas@suse.com>
+# Summary: Install packages using yast2.
+# Maintainer: Martin Kravec <mkravec@suse.com>
 
 use base "console_yasttest";
 use strict;
@@ -27,7 +27,7 @@ sub run() {
 
     assert_script_run "zypper -n in yast2-packager", 90;    # make sure yast2 sw_single module installed
 
-    script_run("/sbin/yast2 sw_single; echo yast2-i-status-\$? > /dev/$serialdev", 0);
+    script_run("yast2 sw_single; echo yast2-i-status-\$? > /dev/$serialdev", 0);
     if (check_screen('workaround-bsc924042', 10)) {
         send_key 'alt-o';
         record_soft_failure 'bsc#924042';
@@ -81,18 +81,14 @@ sub run() {
         send_key 'alt-o';
     }
 
+    if (check_screen('yast2-sw_automatic-changes', 10)) {
+        send_key 'alt-o';
+    }
+
     # Whether summary is shown depends on PKGMGR_ACTION_AT_EXIT in /etc/sysconfig/yast2
-    # We actually can never be sure how this is set, so let's just check:
-    while (check_screen(['yast2-sw_shows_summary', 'yast2-sw_automatic-changes'], 10)) {
-        if (match_has_tag('yast2-sw_automatic-changes')) {
-            send_key 'alt-o';
-            next;
-        }
-        if (match_has_tag('yast2-sw_shows_summary')) {
-            send_key 'alt-f';
-            record_soft_failure if get_var("YAST_SW_NO_SUMMARY");
-        }
-        last;
+    unless (get_var("YAST_SW_NO_SUMMARY")) {
+        assert_screen 'yast2-sw_shows_summary';
+        send_key 'alt-f';
     }
 
     # yast might take a while on sle11 due to suseconfig


### PR DESCRIPTION
If yast2-sw_shows_summary is not matched then test skips alt-f command
but expects yast to finish. Default timeout should help.

Also removed soft_fail, as it depends only on static variable from test
setup and it produces soft_fail where it should not.

Fix for: https://openqa.suse.de/tests/600708#step/yast2_i/17
Invalid soft_fail: https://openqa.opensuse.org/tests/272298#step/yast2_i/16
Local runs:
http://dhcp91.suse.cz/tests/2698
http://dhcp91.suse.cz/tests/2697