### PR TITLE
Prevent gnome race cond in ensure_unlocked_desktop

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -361,35 +361,58 @@ sub workaround_type_encrypted_passphrase {
 
 # if stay under tty console for long time, then check
 # screen lock is necessary when switch back to x11
+# returns without login if any of the tags in param matches
 sub ensure_unlocked_desktop {
-    my ($tags) = @_;
-    $tags //= [qw/generic-desktop/];
-    # deactivate blanking
-    send_key "backspace";
-    # the screenlock can take some time to show up when it is already
-    # triggered
-    wait_still_screen(10);
+    my ($extra_tags) = @_;
+    $extra_tags //= [];
+
+    # try to stop screenlocker / blanking
+    send_key "esc";
+
+    # prevent the still running screen lock from consuming next key press
+    wait_still_screen(1);
+
+    my $tags = [];
+    if (check_var('DESKTOP', 'gnome')) {
+        # gnome might show the old 'generic desktop' screen although that is
+        # just a left over in the framebuffer but actually the screen is
+        # already locked so we have to try something else to check
+        # responsiveness.
+        # open run command prompt (if screen isn't locked)
+        send_key "alt-f2";
+        push @$tags, 'desktop-runner';
+    }
+    else {
+        push @$tags, 'generic-desktop';
+    }
+
+    # wait for run prompt or screen locker
+    push @$tags, @$extra_tags;
     push @$tags, 'screenlock';
+    push @$tags, 'gnome-screenlock-password';
     assert_screen($tags);
-    if (!match_has_tag 'screenlock') {
+
+    if (match_has_tag 'desktop-runner' or match_has_tag 'generic-desktop') {
         # ensure screen is not immediately locked after checking
+        # also close command run prompt
         send_key 'esc';
+        assert_screen([qw/generic-desktop/]);
         return;
+    }
+    for my $tag (@$extra_tags) {
+        if (match_has_tag $tag) {
+            # caller provided tag matched
+            # caller needs to deal with it
+            return;
+        }
     }
     if (check_var("DESKTOP", "gnome")) {
         send_key "esc";
         unless (get_var("LIVETEST")) {
             send_key "ctrl";    # show gnome screen lock in sle 11
-
-            # it is possible for GNOME not yet to ask for a password
-            # switching to tty1 then back to 7, where GNOME runs, withing five minutes
-            # does not lock with a password - in most cases we take long enough, but some
-            # console tests are just too quick
-            assert_screen([qw/gnome-screenlock-password generic-desktop/]);
-            if (match_has_tag('gnome-screenlock-password')) {
-                type_password;
-                send_key "ret";
-            }
+            assert_screen([qw/gnome-screenlock-password screenlock/]);
+            type_password;
+            send_key "ret";
         }
     }
     elsif (check_var("DESKTOP", "minimalx")) {

--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -8,8 +8,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Rework the tests layout.
-# G-Maintainer: Alberto Planas <aplanas@suse.com>
+# Summary: Cleanup and switch (back) to X11
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "opensusebasetest";
 use testapi;
@@ -44,7 +44,7 @@ sub run() {
 
     if (!check_var("DESKTOP", "textmode")) {
         select_console('x11');
-        ensure_unlocked_desktop [qw/displaymanager generic-desktop/];
+        ensure_unlocked_desktop [qw/displaymanager/];
         if (get_var("DESKTOP_MINIMALX_INSTONLY")) {
             # Desired wm was just installed and needs x11_login
             assert_screen 'displaymanager', 200;


### PR DESCRIPTION
Make sure that the VM is responsive.

See also: https://progress.opensuse.org/issues/14064

Tested with opensuse-minimalx and sles-gnome.