### PR TITLE
Prevent unconditional soft fail on trusted keys

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -161,7 +161,9 @@ sub fill_in_registration_data {
             # start addons/modules registration, it needs longer time if select multiple or all addons/modules
             while (assert_screen(['import-untrusted-gpg-key', 'yast_scc-pkgtoinstall', 'inst-addon'], 120)) {
                 if (match_has_tag('import-untrusted-gpg-key')) {
-                    record_soft_failure 'untrusted gpg key';
+                    if (!check_screen([qw(import-trusted-gpg-key-nvidia-F5113243C66B6EAE)], 1)) {
+                        record_soft_failure 'untrusted gpg key';
+                    }
                     send_key 'alt-t';
                     next;
                 }


### PR DESCRIPTION
There is no use in recording soft fails without any bug references for trusted
keys. If a key is trusted or not should be decided by the existance of a
corresponding needle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/os-autoinst/os-autoinst-distri-opensuse/1911)
<!-- Reviewable:end -->
