### PR TITLE
Add support for multiple CDROMs in svirt backend

### DIFF
--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -8,8 +8,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: an experimental bootloader using virsh over ssh
-# G-Maintainer: Stephan Kulow <coolo@suse.de>
+# Summary: zKVM bootloader
+# Maintainer: Matthias Grießmeier <mgriessmeier@suse.de>
 
 use base "installbasetest";
 
@@ -55,7 +55,7 @@ sub run() {
     # For some tests we need more than the default 4GB
     my $size_i = get_var('HDDSIZEGB') || '4';
 
-    $svirt->add_disk({size => $size_i . "G", create => 1});
+    $svirt->add_disk({size => $size_i . "G", create => 1, dev_id => 'a'});
     # need that for s390
     $svirt->add_pty({pty_dev => 'console', pty_dev_type => 'pty', target_type => 'sclp', target_port => '0'});
 


### PR DESCRIPTION
With this addons on media should be now supported.

Device name and boot order are now determined by test not backend.

Requires: https://github.com/os-autoinst/os-autoinst/pull/608

Verification runs:
* Xen PV: http://assam.suse.cz/tests/3458 (BSC#1003263)
* Xen HVM: http://assam.suse.cz/tests/3456
* KVM: http://assam.suse.cz/tests/3457