### PR TITLE
Use basic password store in chrome and chromium

### DIFF
--- a/tests/x11/chrome.pm
+++ b/tests/x11/chrome.pm
@@ -46,22 +46,19 @@ sub run() {
     # closing xterm
     send_key "alt-f4";
 
-    x11_start_program("google-chrome");
+    # avoid async keyring popups
+    x11_start_program("google-chrome --password-store=basic");
 
     assert_and_click 'chrome-default-browser-query';
 
-    handle_keyring 'google-chrome-main-window', 50;
+    assert_screen 'google-chrome-main-window', 50;
 
     send_key "ctrl-l";
     sleep 1;
     type_string "about:\n";
-    handle_keyring 'google-chrome-about', 15;
+    assert_screen 'google-chrome-about', 15;
 
     send_key "alt-f4";
-
-    # check kwallet and cancel it
-    # 1 => enable, 0 => cancel
-    handle_kwallet(0);
 }
 
 1;

--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -23,27 +23,24 @@ sub run() {
 
     ensure_installed("chromium");
 
-    x11_start_program("chromium");
+    # avoid async keyring popups
+    x11_start_program("chromium --password-store=basic");
 
-    handle_keyring 'chromium-main-window', 50;
+    assert_screen 'chromium-main-window', 50;
 
     send_key "esc";       # get rid of popup
     sleep 1;
     send_key "ctrl-l";    # select text in address bar
     sleep 1;
     type_string "about:\n";
-    handle_keyring 'chromium-about', 15;
+    assert_screen 'chromium-about', 15;
 
     send_key "ctrl-l";
     sleep 1;
     type_string "https://html5test.com/index.html\n";
-    handle_keyring 'chromium-html5test', 30;
+    assert_screen 'chromium-html5test', 30;
 
     send_key "alt-f4";
-
-    # check kwallet and cancel it
-    # 1 => enable, 0 => cancel
-    handle_kwallet(0);
 }
 
 1;


### PR DESCRIPTION
Handling the popups of gnome-keyring appearing at random places
has proven to make the test too unreliable. So just don't test this,
but test chromium basic functionality.