### PR TITLE
Unregister from SCC after worker finishes

### DIFF
--- a/postrun.pm
+++ b/postrun.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+use strict;
+use warnings;
+use testapi;
+use LWP::UserAgent;
+
+# poo#11518 - deregister system after job finishes
+if (get_var("SCC_DEREGISTER")) {
+    diag "de-registration from SCC";
+
+    my @credentials = split /\r\n/, get_var("SCC_DEREGISTER");
+
+    my $ua = LWP::UserAgent->new;
+    $ua->credentials('scc.suse.com:443', 'SCC Connect API', $credentials[0], $credentials[1]);
+    my $response = $ua->delete('https://scc.suse.com/connect/systems');
+
+    if (!$response->is_success) {
+        die $response->status_line;
+    }
+}
+else {
+    diag "de-registration not needed";
+}
+
+1;

--- a/tests/jeos/sccreg.pm
+++ b/tests/jeos/sccreg.pm
@@ -8,12 +8,13 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: First commit of JeOS firstrun, diskusage, sccreg, and imgsize tests
-# G-Maintainer: Richard Brown <rbrownccb@opensuse.org>
+# Summary: Register JeOS using SUSEConnect
+# Maintainer: Richard Brown <rbrownccb@opensuse.org>
 
 use base "opensusebasetest";
 use strict;
 use testapi;
+use registration;
 
 sub run() {
     my $sccmail = get_var("SCC_EMAIL");
@@ -21,6 +22,7 @@ sub run() {
     my $url     = get_var('SCC_URL', 'https://scc.suse.com');
 
     assert_script_run "SUSEConnect --url=$url -e $sccmail -r $scccode";
+    setup_unregister_hook;
 }
 
 sub test_flags() {


### PR DESCRIPTION
https://progress.opensuse.org/issues/11518

We need to consider canceled & failed jobs, so de-registration must be
performed from worker. It needs username & password that are generated
during registration and exported into SCC_DEREGISTER variable.
    
Worker unregister from scc using by calling SCC url with:
DELETE /connect/systems

There is a short window between system registration and set_var("SCC_DEREGISTER"), when system would not unregister.

Tested by:
- Following logs in /var/lib/openqa/pool/<worker>/autoinst-log.txt
- By canceling jobs before/during/after registration or finishing them
- Checking that SCC keys are removed from scc.suse.com (Alpha Keys)

After successful job:
 SLES: http://dhcp91.suse.cz/tests/2772
 JeOS: http://dhcp91.suse.cz/tests/2771

Job canceled:
 QAM SLES-12-GA: http://dhcp91.suse.cz/tests/2778
 SLES: http://dhcp91.suse.cz/tests/2774
 JeOS: http://dhcp91.suse.cz/tests/2773