### PR TITLE
Make the update more reliable by doing what we can in text console

### DIFF
--- a/tests/update/check_system_is_updated.pm
+++ b/tests/update/check_system_is_updated.pm
@@ -7,22 +7,18 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Fix packagekit updatespoo#13056
-#    Check no more updates are available
-#    Reboot after kde kernel updates
-# G-Maintainer: mkravec <mkravec@suse.com>
+# Summary: Check no more updates are available
+# Maintainer: mkravec <mkravec@suse.com>
 
-use base "x11test";
+use base "consoletest";
 use strict;
 use testapi;
 
 sub run() {
-    x11_start_program("xterm");
-    assert_screen('xterm-started');
-    assert_script_sudo "chown $testapi::username /dev/$testapi::serialdev";
+    select_console 'root-console';
+    assert_script_run "chown $testapi::username /dev/$testapi::serialdev";
     assert_script_run "pkcon refresh";
     assert_script_run "pkcon get-updates | tee /dev/$serialdev | grep 'There are no updates'";
-    send_key "alt-f4";
 }
 
 sub test_flags() {

--- a/tests/update/prepare_system_for_update_tests.pm
+++ b/tests/update/prepare_system_for_update_tests.pm
@@ -14,25 +14,20 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-# G-Summary: Update the system before testing
-#    For this attach an update category between first_boot and console tests and
-#    reboot in case the update applet requested so
-# G-Maintainer: Stephan Kulow <coolo@suse.de>
+# Summary: Prepare system for actual desktop specific updates
+# Maintainer: Stephan Kulow <coolo@suse.de>
 
-use base "x11test";
+use base "consoletest";
 use strict;
 use testapi;
 use utils;
 
 sub run() {
-    select_console 'x11';
+    select_console 'root-console';
 
-    x11_start_program("xterm");
-    assert_screen('xterm-started');
-    assert_script_sudo "chown $testapi::username /dev/$testapi::serialdev";
-    assert_script_sudo "echo \"download.use_deltarpm = false\" >> /etc/zypp/zypp.conf";
+    assert_script_run "chown $testapi::username /dev/$testapi::serialdev";
+    assert_script_run "echo \"download.use_deltarpm = false\" >> /etc/zypp/zypp.conf";
     assert_script_run "pkcon refresh";
-    send_key "alt-f4";
 }
 
 sub test_flags() {

--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -7,10 +7,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Update the system before testing
-#    For this attach an update category between first_boot and console tests and
-#    reboot in case the update applet requested so
-# G-Maintainer: Stephan Kulow <coolo@suse.de>
+# Summary: PackageKit update using gpk
+# Maintainer: Stephan Kulow <coolo@suse.de>
 
 use base "x11test";
 use strict;
@@ -36,6 +34,8 @@ sub turn_off_screensaver() {
 
 # Update with GNOME PackageKit Update Viewer
 sub run() {
+    select_console 'x11';
+
     my @updates_tags           = qw/updates_none updates_available/;
     my @updates_installed_tags = qw/updates_none updates_installed-logout updates_installed-restart/;
 

--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -7,14 +7,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Packagekit updates
-#    Used Updaters:
-#    gpk-update-viewer - gnome & xfce & lxde
-#    plasma-pk-updates - kde
-#
-#    Change:
-#    assert_and_click replaced with keyboard shortcuts for ipmi test
-# G-Maintainer: mkravec <mkravec@suse.com>
+# Summary: Packagekit updates using kde applet
+# Maintainer: mkravec <mkravec@suse.com>
 
 use base "x11test";
 use strict;
@@ -31,15 +25,19 @@ sub kernel_updated {
 sub turn_off_screensaver() {
     x11_start_program("kcmshell5 screenlocker");
     send_key("alt-l");
+    assert_screen 'screenlock-disabled';
     send_key("alt-o");
 }
 
 # Update with Plasma applet for software updates using PackageKit
 sub run() {
+    select_console 'x11';
     turn_off_screensaver;
 
     my @updates_installed_tags = qw/updates_none updates_available/;
-    if (check_screen("updates_available-tray")) {
+    assert_screen 'updates_available-tray';
+    assert_screen [qw/updates_available-tray updates_none/];
+    if (match_has_tag 'updates_available-tray') {
         assert_and_click("updates_available-tray");
 
         # First update package manager, then packages, then bsc#992773 (2x)


### PR DESCRIPTION
The update is pretty fragile - as the system is not yet updated,
but we have to test 42.1 updates as that's what users do too

Before: https://openqa.opensuse.org/tests/278076#previous (one out of 20 succeed)
After: https://tortuga.suse.de/tests/552#