### PR TITLE
Keep Tumbleweed needles in Staging:* tests

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -67,7 +67,7 @@ sub cleanup_needles() {
     if (!get_var('LEAP')) {
         unregister_needle_tags('ENV-LEAP-1');
     }
-    if (!check_var('VERSION', 'Tumbleweed')) {
+    if (!get_var('VERSION') =~ /Tumbleweed|Staging:[A-Z]/) {
         unregister_needle_tags('ENV-VERSION-Tumbleweed');
     }
     for my $flavor (qw/Krypton Krypton-Live/) {


### PR DESCRIPTION
The Staging tests for Tumbleweed all have as VERSION = Staging:<LETTER>; as they are actually TW tests, the TW needles should still apply.

The Leap tests are not affected: they report VERSION = 42:S:LETTER (similar change might be needed there though to retain the 42.x needles).

Not: this PR did not have any local test run

