### PR TITLE
Don't rely on keyboard shortcuts to disable the kde screenlocker

### DIFF
--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -24,7 +24,10 @@ sub kernel_updated {
 
 sub turn_off_screensaver() {
     x11_start_program("kcmshell5 screenlocker");
-    send_key("alt-l");
+    assert_screen([qw/kde-screenlock-enabled screenlock-disabled/]);
+    if (match_has_tag('kde-screenlock-enabled')) {
+        assert_and_click('kde-disable-screenlock');
+    }
     assert_screen 'screenlock-disabled';
     send_key("alt-o");
 }


### PR DESCRIPTION
The Shortcut changes between varios Plasma versions