### PR TITLE
Disable screensaver in live KDE session (installer)

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -33,6 +33,7 @@ our @EXPORT = qw/
   addon_license
   validate_repos
   setup_online_migration
+  turn_off_kde_screensaver
   /;
 
 
@@ -54,6 +55,16 @@ sub unlock_if_encrypted {
     assert_screen("encrypted-disk-password-prompt", 200);
     type_password;    # enter PW at boot
     send_key "ret";
+}
+
+sub turn_off_kde_screensaver() {
+    x11_start_program("kcmshell5 screenlocker");
+    assert_screen([qw/kde-screenlock-enabled screenlock-disabled/]);
+    if (match_has_tag('kde-screenlock-enabled')) {
+        assert_and_click('kde-disable-screenlock');
+    }
+    assert_screen 'screenlock-disabled';
+    send_key("alt-o");
 }
 
 # makes sure bootloader appears and then boots to desktop resp text

--- a/tests/installation/live_installation.pm
+++ b/tests/installation/live_installation.pm
@@ -23,6 +23,7 @@
 
 use base "installbasetest";
 use testapi;
+use utils;
 use strict;
 
 sub send_key_and_wait {
@@ -33,6 +34,7 @@ sub send_key_and_wait {
 }
 
 sub run() {
+    turn_off_kde_screensaver;
     assert_and_click 'live-installation';
     assert_and_click 'maximize';
     mouse_hide;

--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -22,20 +22,10 @@ sub kernel_updated {
     return script_run "rpm -q --last kernel-default | head -1 | grep $current";
 }
 
-sub turn_off_screensaver() {
-    x11_start_program("kcmshell5 screenlocker");
-    assert_screen([qw/kde-screenlock-enabled screenlock-disabled/]);
-    if (match_has_tag('kde-screenlock-enabled')) {
-        assert_and_click('kde-disable-screenlock');
-    }
-    assert_screen 'screenlock-disabled';
-    send_key("alt-o");
-}
-
 # Update with Plasma applet for software updates using PackageKit
 sub run() {
     select_console 'x11';
-    turn_off_screensaver;
+    turn_off_kde_screensaver;
 
     my @updates_installed_tags = qw/updates_none updates_available/;
     assert_screen [qw/updates_available-tray tray-without-updates-available/];


### PR DESCRIPTION
Make the turn_off_screensaver from the earleir packagekit-kde test into a public utils function and disable the screensaver before launching the installer