### PR TITLE
setup_online_repos: Use send_key_until_match

### DIFF
--- a/tests/installation/setup_online_repos.pm
+++ b/tests/installation/setup_online_repos.pm
@@ -25,7 +25,7 @@ sub run() {
 
     # move the cursor to repos lists
     if (check_var("VIDEOMODE", "text")) {
-        send_key 'alt-l';
+        send_key_until_needlematch 'setup_online_repos-repos-list', 'tab';
     }
     else {
         send_key 'alt-i';


### PR DESCRIPTION
42.2 uses a different shortcut and we have no other mean in
text mode. To avoid using VERSION use tab key