### PR TITLE
Fix reboot workaround on svirt backend

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -109,8 +109,8 @@ sub wait_boot {
             reset_consoles;
         }
     }
-    # On Xen PV we don't see a Grub menu
-    elsif (!(check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux'))) {
+    # On Xen PV and svirt we don't see a Grub menu
+    elsif (!(check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux') && check_var('BACKEND', 'svirt'))) {
         my @tags = ('grub2');
         push @tags, 'bootloader-shim-import-prompt'   if get_var('UEFI');
         push @tags, 'boot-live-' . get_var('DESKTOP') if get_var('LIVETEST');    # LIVETEST won't to do installation and no grub2 menu show up

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -76,6 +76,9 @@ sub wait_boot {
     my $bootloader_time = $args{bootloader_time} // 100;
     my $textmode        = $args{textmode};
 
+    # Reset the consoles after the reboot: there is no user logged in anywhere
+    reset_consoles;
+
     if (get_var("OFW")) {
         assert_screen "bootloader-ofw", $bootloader_time;
     }
@@ -92,7 +95,6 @@ sub wait_boot {
             # give the system time to have routes up
             # and start serial grab again
             sleep 30;
-            reset_consoles;
             select_console('iucvconn');
         }
         else {
@@ -102,11 +104,9 @@ sub wait_boot {
         # on z/(K)VM we need to re-select a console
         if ($textmode || check_var('DESKTOP', 'textmode')) {
             select_console('root-console');
-            reset_consoles;
         }
         else {
             select_console('x11');
-            reset_consoles;
         }
     }
     # On Xen PV and svirt we don't see a Grub menu
@@ -143,7 +143,6 @@ sub wait_boot {
 
     if ($textmode || check_var('DESKTOP', 'textmode')) {
         assert_screen 'linux-login', 200;
-        reset_consoles;
         return;
     }
 
@@ -167,9 +166,6 @@ sub wait_boot {
 
     assert_screen 'generic-desktop', 300;
     mouse_hide(1);
-
-    # Reset the consoles after the reboot: there is no user logged in anywhere
-    reset_consoles;
 }
 
 # 'ctrl-l' does not get queued up in buffer. If this happens to fast, the

--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -40,12 +40,15 @@ sub run() {
 
         send_key "ret";
 
-        wait_still_screen 8, 8;    # wait 8 seconds to make authentication window disappear after successful authentication
-        if (check_screen 'reboot-auth', 2) {
-            record_soft_failure 'bsc#981299';
-            send_key_until_needlematch 'generic-desktop', 'esc',             7, 10;    # close timed out authentication window
-            send_key_until_needlematch 'logoutdialog',    'ctrl-alt-delete', 7, 10;    # reboot
-            assert_and_click 'logoutdialog-reboot-highlighted';
+        # run only on qemu backend, e.g. svirt backend is fast enough to reboot properly
+        if (check_var('BACKEND', 'qemu')) {
+            sleep 10;    # wait 10 seconds to make authentication window disappear after successful authentication
+            if (check_screen 'reboot-auth', 2) {
+                record_soft_failure 'bsc#981299';
+                send_key_until_needlematch 'generic-desktop', 'esc',             7, 10;    # close timed out authentication window
+                send_key_until_needlematch 'logoutdialog',    'ctrl-alt-delete', 7, 10;    # reboot
+                assert_and_click 'logoutdialog-reboot-highlighted';
+            }
         }
     }
     workaround_type_encrypted_passphrase;


### PR DESCRIPTION
failing s390x test with workaround https://openqa.suse.de/tests/610873#step/reboot_gnome/21