### PR TITLE
Fix lightdm with NOAUTOLOGIN

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -154,11 +154,14 @@ sub wait_boot {
         assert_screen 'displaymanager', 200;
         wait_idle;
         if (get_var('DM_NEEDS_USERNAME')) {
-            type_string $username;
+            type_string "$username\n";
         }
         # log in
         #assert_screen "dm-password-input", 10;
-        send_key "ret";
+        elsif (check_var('DESKTOP', 'gnome')) {
+            # In GNOME/gdm, we do not have to enter a username, but we have to select it
+            send_key 'ret';
+        }
         assert_screen 'displaymanager-password-prompt';
         type_string $password. "\n";
     }


### PR DESCRIPTION
With commit dfcaac1, a unconditional 'ret' was sent (to select the user in gdm)
Lightdm has the user preselected in a drop down and the current focus is on the
password field. Sending 'ret' means 'login without password' - which fails.