### PR TITLE
Do not check nvidia repository for SP1

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -688,7 +688,8 @@ sub validate_repos {
             # For the name of product channel, sle12 uses NVIDIA, sle12sp1 and sp2 use nVidia
             # Consider migration, use regex to match nvidia whether in upper, lower or mixed
             # Skip check AMD/ATI repo since it would be removed from sled12 and sle-we-12, see bsc#984866
-            if ($base_product eq "SLED" || $we) {
+            # Skip nvidia on sp1 due to bsc#999538 - at least for now
+            if (!check_var('VERSION', '12-SP1') && ($base_product eq "SLED" || $we)) {
                 validatelr(
                     {
                         product         => "SLE-",


### PR DESCRIPTION
The nature of bnc#999538 is unclear, but we should not block maintenance
updates until we found out. It works in manual installations