### PR TITLE
Regression tests are too expensive if they export logs

### DIFF
--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -441,6 +441,8 @@ sub setup_pop {
     assert_screen "evolution_mail-max-window";
 }
 
+sub post_fail_hook() {
+}
 
 1;
 # vim: set sw=4 et:


### PR DESCRIPTION
We're generally not interested in most of the logs gathered from the
base class - and firefox test can easily run 3 hours, mainly uploading
logs