### PR TITLE
Make sure the input focus is in the password input field on DMs

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -349,23 +349,26 @@ sub ensure_unlocked_desktop {
             return;
         }
     }
+    # start to unlocking the screenlock
     if (check_var("DESKTOP", "gnome")) {
         send_key "esc";
         unless (get_var("LIVETEST")) {
             send_key "ctrl";    # show gnome screen lock in sle 11
             assert_screen([qw/gnome-screenlock-password screenlock/]);
+            assert_and_click "displaymanager-password-prompt";
             type_password;
             send_key "ret";
         }
     }
-    elsif (check_var("DESKTOP", "minimalx")) {
-        type_string "$username";
-        save_screenshot();
-        send_key "ret";
-        type_password;
-        send_key "ret";
-    }
     else {
+        if (check_var("DESKTOP", "minimalx")) {
+            type_string "$username";
+            save_screenshot();
+            send_key "ret";
+        }
+        # clicked the password input field on all DMs
+        # make sure the input cursor is in the input field
+        assert_and_click "displaymanager-password-prompt";
         type_password;
         send_key "ret";
     }


### PR DESCRIPTION
Make sure the input cursor is in the password input field. Otherwise some DM fails to input the password if pressed specific key before typing password, eg. sddm.

Note that, I didn't change GNOME screenlock part actually, I'm not very understood that unlocking code for SLE11.

the openQA test failure https://openqa.opensuse.org/tests/280998