### PR TITLE
Better track bsc#990384 with soft failure

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -23,7 +23,8 @@ sub post_fail_hook() {
         # there is a severe problem, e.g. could be bsc#985850 or bsc#990384 so
         # save more, let's hope there is enough memory for intermediate
         # storage
-        # TODO just assuming that '/dev/vda2' is the root device here, does
+        record_soft_failure 'bsc#990384';
+        # CAUTION just assuming that '/dev/vda2' is the root device here, does
         # not work for LVM setup and others but we want to debug non-LVM first
         # /dev/root is not recognized as btrfs device
         $fn = '/dev/shm/vda2_brfs_debug_tree';


### PR DESCRIPTION
So far bsc#990384 is still not resolved, it is getting critical and we did not
see any other issue causing the same symptom so it is good to track it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/os-autoinst/os-autoinst-distri-opensuse/1965)
<!-- Reviewable:end -->
