### PR TITLE
LAMP test

### DIFF
--- a/data/console/test_mysql_connector.php
+++ b/data/console/test_mysql_connector.php
@@ -1,0 +1,10 @@
+<?php
+    mysql_connect('localhost', 'root', '');
+    mysql_select_db('openQAdb');
+    $result = mysql_query("SELECT * FROM test");
+    while($row = mysql_fetch_array($result)){
+        echo $row['entry'];
+    }
+    mysql_query("INSERT INTO test (entry) VALUE ('can php write this?')");
+?>
+

--- a/data/console/test_postgresql_connector.php
+++ b/data/console/test_postgresql_connector.php
@@ -1,0 +1,9 @@
+<?php
+    $dbconn = pg_connect("host=localhost dbname=openQAdb user=postgres password=postgres")
+              or die('Could not connect: ' . pg_last_error());
+    $result = pg_query("SELECT * FROM test");
+    while($row = pg_fetch_array($result, null, PGSQL_ASSOC)){
+        echo $row['entry'], "";
+    }
+    pg_query("INSERT INTO test (entry) VALUES ('can php write this?')") or die('Query failed: ' . pg_last_error());
+?>

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -618,9 +618,16 @@ sub load_consoletests() {
             }
             loadtest "console/http_srv.pm";
             loadtest "console/mysql_srv.pm";
+            loadtest "console/postgresql94server.pm";
+            loadtest "console/shibboleth.pm";
             if (!is_staging()) {
                 # Very temporary removal of this test from staging - rbrown 6 Apr 2016
                 loadtest "console/dns_srv.pm";
+            }
+            if (get_var('ADDONS', '') =~ /wsm/ || get_var('SCC_ADDONS', '') =~ /wsm/) {
+                loadtest "console/php5.pm";
+                loadtest "console/php5_mysql.pm";
+                loadtest "console/php5_postgresql94.pm";
             }
         }
         if (get_var("MOZILLATEST")) {

--- a/tests/console/php5.pm
+++ b/tests/console/php5.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Simple PHP5 code hosted locally
+# Maintainer: Romanos Dodopoulos <romanos.dodopoulos@suse.cz>
+
+# This test requires the Web and Scripting module on SLE. Also, it
+# should preferably be executed after the 'console/http_srv' test.
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run() {
+    my $self = shift;
+    select_console 'root-console';
+
+    # install requirements
+    zypper_call "in php5 apache2-mod_php5";
+    assert_script_run "a2enmod php5";
+
+    # configure and restart the web server
+    type_string qq{echo -e "<?php\nphpinfo()\n?>" > /srv/www/htdocs/index.php\n};
+    assert_script_run "systemctl restart apache2.service";
+
+    # test that PHP works
+    assert_script_run "curl --no-buffer http://localhost/index.php | grep \"\$(uname -s -n -r -v -m)\"";
+}
+1;

--- a/tests/console/php5_mysql.pm
+++ b/tests/console/php5_mysql.pm
@@ -1,0 +1,49 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: PHP5 code that interacts locally with MySQL
+# Maintainer: Romanos Dodopoulos <romanos.dodopoulos@suse.cz>
+
+# This tests creates a MySQL database and inserts an element. Then,
+# PHP reads the elements and writes a new one in the database. If
+# all succeed, the test passes.
+#
+# The test requires the Web and Scripting module on SLE and should be
+# executed after the 'console/http_srv', 'console/mysql_srv', and
+# 'console/php5' tests.
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run() {
+    my $self = shift;
+    select_console 'root-console';
+
+    # install requirements
+    zypper_call "in php5-mysql";
+
+    # create the 'openQAdb' database with table 'test' and insert one element 'can php read this?'
+    assert_script_run qq{mysql -u root -e "CREATE DATABASE openQAdb; USE openQAdb; CREATE TABLE test (id int NOT NULL AUTO_INCREMENT, entry varchar(255) NOT NULL, PRIMARY KEY(id)); INSERT INTO test (entry) VALUE ('can you read this?');"};
+
+    # configure the PHP code that:
+    #  1. reads table 'test' from the 'openQAdb' database
+    #  2. inserts a new element 'can php write this?' into the same table
+    type_string "wget --quiet " . data_url('console/test_mysql_connector.php') . " -O /srv/www/htdocs/test_mysql_connector.php\n";
+    assert_script_run "systemctl restart apache2.service";
+
+    # access the website and verify that it can read the database
+    assert_script_run "curl --no-buffer http://localhost/test_mysql_connector.php | grep 'can you read this?'";
+
+    # verify that PHP successfully wrote the element in the database
+    assert_script_run "mysql -u root -e 'USE openQAdb; SELECT * FROM test;' | grep 'can php write this?'";
+}
+1;

--- a/tests/console/php5_postgresql94.pm
+++ b/tests/console/php5_postgresql94.pm
@@ -1,0 +1,60 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: PHP5 code that interacts locally with PostgreSQL
+# Maintainer: Romanos Dodopoulos <romanos.dodopoulos@suse.cz>
+
+# This tests creates a PostgreSQL database and inserts an element.
+# Then, PHP reads the elements and writes a new one in the database.
+# If all succeed, the test passes.
+#
+# The test requires the Web and Scripting module on SLE and should be
+# executed after the 'console/http_srv', 'console/postgresql94', and
+# 'console/php5' tests.
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run() {
+    my $self = shift;
+    select_console 'root-console';
+
+    # install requirements
+    zypper_call "in php5-pgsql";
+
+    # configuration so that PHP can access PostgreSQL
+    # setup password
+    type_string "sudo -u postgres psql postgres\n";
+    type_string "\\password postgres\n";
+    type_string "postgres\n";
+    type_string "postgres\n";
+    type_string "\\q\n";
+    # comment out default configuration
+    assert_script_run "sed -i 's/^host/#host/g' /var/lib/pgsql/data/pg_hba.conf";
+    # allow postgres to access the db with password authentication
+    assert_script_run "echo 'host openQAdb postgres 127.0.0.1/32 password' >> /var/lib/pgsql/data/pg_hba.conf";
+    assert_script_run "echo 'host openQAdb postgres      ::1/128 password' >> /var/lib/pgsql/data/pg_hba.conf";
+    assert_script_run "systemctl restart postgresql.service";
+
+    # configure the PHP code that:
+    #  1. reads table 'test' from the 'openQAdb' database (created in 'console/postgresql94' test)
+    #  2. inserts a new element 'can php write this?' into the same table
+    type_string "wget --quiet " . data_url('console/test_postgresql_connector.php') . " -O /srv/www/htdocs/test_postgresql_connector.php\n";
+    assert_script_run "systemctl restart apache2.service";
+
+    # access the website and verify that it can read the database
+    assert_script_run "curl --no-buffer http://localhost/test_postgresql_connector.php | grep 'can you read this?'";
+
+    # verify that PHP successfully wrote the element in the database
+    assert_script_run "sudo -u postgres psql -d openQAdb -c \"SELECT * FROM test\" | grep 'can php write this?'";
+}
+1;

--- a/tests/console/shibboleth.pm
+++ b/tests/console/shibboleth.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: shibboleth-sp test
+# Maintainer: Romanos Dodopoulos <romanos.dodopoulos@suse.cz>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run() {
+    my $self = shift;
+    select_console 'root-console';
+
+    zypper_call "in shibboleth-sp";
+    type_string "a2enmod shib";
+    assert_script_run "systemctl restart apache2.service";
+
+    assert_script_run "curl --no-buffer http://localhost/Shibboleth.sso/Status | grep 'Cannot connect to shibd process'";
+
+    assert_script_run "curl --no-buffer http://localhost/Shibboleth.sso/Session | grep 'A valid session was not found.'";
+}
+1;


### PR DESCRIPTION
openQA basic test for LAMP (only locally).
Specifically, install and test basic functionality of apache2-mod_php5, php5-mysql, php5-pgsql, and shibboleth-sp.

Also, enabled the conosole/postgresql94server test in main.pm

In relation to:
https://progress.opensuse.org/issues/13176
https://progress.opensuse.org/issues/13172

Working example:
http://rwmanosvm2.suse.cz/tests/1026 (no needle required)