### PR TITLE
Better place for ImageMagick test in main.pm

### DIFF
--- a/data/imagemagick/bg_script.sh
+++ b/data/imagemagick/bg_script.sh
@@ -11,6 +11,8 @@ function cme {
     eog "$2"
 }
 
+convert --version
+
 wget --quiet "${1/bg_script.sh/test.png}"            -O test.png
 cme test.png 1.png
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -281,9 +281,6 @@ sub load_x11regression_other() {
         loadtest "x11regressions/shotwell/shotwell_export.pm";
         loadtest "virtualization/yast_virtualization.pm";
         loadtest "virtualization/virtman_view.pm";
-        if (get_var('ADDONS', '') =~ /sdk/ && check_var("VERSION", "12-SP1")) {
-            loadtest "x11regressions/ImageMagick.pm";
-        }
     }
     if (get_var("DESKTOP") =~ /kde|gnome/) {
         loadtest "x11regressions/tracker/prep_tracker.pm";
@@ -753,6 +750,7 @@ sub load_x11tests() {
         if (gnomestep_is_applicable()) {
             loadtest "x11/eog.pm";
             loadtest "x11/rhythmbox.pm";
+            loadtest "x11/ImageMagick.pm";
         }
         if (get_var('DESKTOP') =~ /kde|gnome/) {
             loadtest "x11/ooffice.pm";

--- a/tests/x11/ImageMagick.pm
+++ b/tests/x11/ImageMagick.pm
@@ -7,23 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# ImageMagick test
-# ----------------
-# This test creates, displays, and evaluates 200+ images utilizing
-# various convertion options of ImageMagick.
-#
-# The examined examples were taken from:
-# https://www.imagemagick.org/Usage/canvas/ (Aug 2016)
-#
-# A set of preloaded images and a script are required as input. This
-# test generates multiple new images and evaluates the output. Some
-# of the new images are converted from the preloaded images, while
-# others are drawn from scratch. The preloaded script contains all
-# the executed commands because typing them appeared to be extremely
-# time-consuming (more than two hours in a specific case, while this
-# test can finish in less than 20 minutes).
-
-# G-Summary: Add ImageMagick test
+# Summary: Add ImageMagick test
 #    This test creates, displays, and evaluates 200+ images utilizing
 #    various convertion options of ImageMagick.
 #
@@ -35,9 +19,8 @@
 #    of the new images are converted from the preloaded images, while
 #    others are drawn from scratch. The preloaded script contains all
 #    the executed commands because typing them appeared to be extremely
-#    time-consuming (more than two hours in a specific case, while this
-#    test can finish in less than 20 minutes).
-# G-Maintainer: Romanos Dodopoulos <rdodopoulos@novell.com>
+#    time-consuming.
+# Maintainer: Romanos Dodopoulos <romanos.dodopoulos@suse.cz>
 
 use base "x11test";
 use strict;


### PR DESCRIPTION
At the moment, the ImageMagick test is never triggered. Since eog is
used in the test, it can be triggered right after the 'eog' test. In
addition, the SDK should be installed. Finally, this is tested only
on SLE12-SP1.

Now, the ImageMagick test will be included in the qam-gnome testsuite
in openqa.suse.de.

Working example: http://rwmanosvm2.suse.cz/tests/1384

Please feel free to suggest a better way to check for SDK than:
`if ((get_var('ADDONS', '') =~ /sdk/ || get_var('SCC_ADDONS', '') =~ /sdk/ || get_var('BUILD_SDK'))`