### PR TITLE
Add hostname.pm to load_extra_tests

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -506,6 +506,7 @@ sub load_extra_tests() {
 
     # setup $serialdev permission and so on
     loadtest "console/consoletest_setup.pm";
+    loadtest "console/hostname.pm";
 
     if (console_is_applicable() && get_var("EXTRATEST")) {
         # Put tests that filled the conditions below


### PR DESCRIPTION
We should set the host name to 'susetest' for cases in extra tests.

gdm_session_switch is failed at: https://openqa.opensuse.org/tests/281487#step/gdm_session_switch/14

It is previous behind hostname.pm so the host name is set to 'susetest'. But now in extra_tests_on_gnome the host name is not set.

  see also: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/1941