### PR TITLE
Upload logs once consoletest_finish test failed

### DIFF
--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -56,6 +56,12 @@ sub run() {
     }
 }
 
+sub post_fail_hook() {
+    my $self = shift;
+
+    $self->export_logs();
+}
+
 sub test_flags() {
     return {milestone => 1, fatal => 1};
 }


### PR DESCRIPTION
As it's an milestone and fatal test, if it's test failed it should uploading logs.