### PR TITLE
No longer check for snapshot removal

### DIFF
--- a/tests/x11/yast2_snapper.pm
+++ b/tests/x11/yast2_snapper.pm
@@ -8,8 +8,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Test for yast2-snapper
-# G-Maintainer: Ancor Gonzalez Sosa <ancor@suse.de>
+# Summary: Test for yast2-snapper
+# Maintainer: Ancor Gonzalez Sosa <ancor@suse.de>
 
 use base "x11test";
 use strict;
@@ -110,21 +110,6 @@ sub run() {
     send_key "alt-t";
     assert_screen 'yast2_snapper-confirm_delete', 100;
     send_key "alt-y";
-    # Make sure the snapshot is not longer there
-    assert_screen [qw/yast2_snapper-snapshots yast2_snapper-new_snapshot yast2_snapper-new_snapshot_selected/], 100;
-    if (match_has_tag('yast2_snapper-new_snapshot') or match_has_tag('yast2_snapper-new_snapshot_selected')) {
-        diag 'new snapshot found despite requested for deletion, waiting a bit more';
-        # In old versions the test was so slow that the issue has never
-        # been seen: Deleting a snapshot on at least SP1 does not happen
-        # immediately but takes 1-2 seconds. That's why after deletion
-        # it's still there which is detected now in the new faster version
-        # of the test. On a second look it should really be gone
-        record_soft_failure 'bsc#992192' if sle_version_at_least('12-SP2');
-        wait_still_screen;
-        if (check_screen([qw/yast2_snapper-new_snapshot yast2_snapper-new_snapshot_selected/])) {
-            die("The snapshot is still visible after trying to delete it and waiting a bit");
-        }
-    }
     $self->clean_and_quit;
 }
 


### PR DESCRIPTION
As bsc#992192 was closed as a WONTFIX, there is no point testing whether or not the snapshot has been removed with a graphical check.