### PR TITLE
Do not attempt to find a input box on the GNOME screenlocker

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -351,7 +351,6 @@ sub ensure_unlocked_desktop {
         unless (get_var("LIVETEST")) {
             send_key "ctrl";    # show gnome screen lock in sle 11
             assert_screen([qw/gnome-screenlock-password screenlock/]);
-            assert_and_click "displaymanager-password-prompt";
             type_password;
             send_key "ret";
         }


### PR DESCRIPTION
The screenlocker can currently be identified in two states:
* shield up: there is a password prompt abailable and clicking might work
* shield down: the case most users will find the system when returning. The
  clock is shown and our tests account for this already.

In both cases, the user can 'just start typing the password'; if the shield
was down, it lifts and no keypress is being lost (as long as the password does
not start with a space, this is true; space, esc and enter are treated specially
to only lift the shield but are not forwarded to be part of the password).