### PR TITLE
Prevent timeout on slow yast2_i startup

### DIFF
--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -28,7 +28,7 @@ sub run() {
     assert_script_run "zypper -n in yast2-packager", 90;    # make sure yast2 sw_single module installed
 
     script_run("yast2 sw_single; echo yast2-i-status-\$? > /dev/$serialdev", 0);
-    assert_screen 'empty-yast2-sw_single';
+    assert_screen 'empty-yast2-sw_single', 90;
 
     # Check disk usage widget for not showing subvolumes (bsc#949945)
     # on SLE12SP0 hidden subvolume isn't supported


### PR DESCRIPTION
See https://openqa.suse.de/tests/619408#step/yast2_i/5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/os-autoinst/os-autoinst-distri-opensuse/1986)
<!-- Reviewable:end -->
