### PR TITLE
Remove code checking for deleted needles

### DIFF
--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -28,10 +28,6 @@ sub run() {
     assert_script_run "zypper -n in yast2-packager", 90;    # make sure yast2 sw_single module installed
 
     script_run("yast2 sw_single; echo yast2-i-status-\$? > /dev/$serialdev", 0);
-    if (check_screen('workaround-bsc924042', 10)) {
-        send_key 'alt-o';
-        record_soft_failure 'bsc#924042';
-    }
     assert_screen 'empty-yast2-sw_single';
 
     # Check disk usage widget for not showing subvolumes (bsc#949945)


### PR DESCRIPTION
Needles for "RESOLVED INVALID" bug for SLES-11-SP4-Beta3 do not exist anymore.

https://openqa.suse.de/tests/619408
4987 NO matching needles for workaround-bsc924042