### PR TITLE
Wait for screen change before matching next license

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -13,8 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# G-Summary: renamed autoyast/system.pm to installation.pm
-# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+# Summary: Autoyast installation
+# Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
 
 use strict;
 use base 'basetest';
@@ -25,8 +25,11 @@ my $confirmed_licenses = 0;
 
 sub accept_license {
     send_key $cmd{accept};
-    send_key $cmd{next};
     $confirmed_licenses++;
+    # Prevent from matching previous license
+    wait_screen_change {
+        send_key $cmd{next};
+    };
 }
 
 sub save_logs_and_continue {


### PR DESCRIPTION
Fix for: https://openqa.suse.de/tests/620393#step/installation/3
Local run: http://dhcp91.suse.cz/tests/2863
Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/235