### PR TITLE
svirt: support boot from image

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -398,6 +398,9 @@ sub activate_console {
             $self->script_run("setterm -blank 0");
         }
     }
+    elsif ($console eq 'svirt') {
+        $self->set_standard_prompt('root');
+    }
 }
 
 1;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -930,6 +930,9 @@ sub load_fips_tests_crypt() {
 
 sub prepare_target() {
     if (get_var("BOOT_HDD_IMAGE")) {
+        if (check_var("BACKEND", "svirt")) {
+            loadtest "installation/bootloader_svirt.pm";
+        }
         loadtest "boot/boot_to_desktop.pm";
     }
     else {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1230,6 +1230,9 @@ if (get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1")) {
         loadtest "console/hostname.pm";
         loadtest "shutdown/grub_set_bootargs.pm";
         loadtest "shutdown/shutdown.pm";
+        if (check_var("BACKEND", "svirt")) {
+            loadtest "shutdown/svirt_upload_assets.pm";
+        }
     }
 }
 

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -190,6 +190,11 @@ sub run() {
         $ifacecfg{type} = 'bridge';
         $ifacecfg{source} = {bridge => get_var('VMWARE_BRIDGE', 'VM Network')};
     }
+    elsif ($vmm_family eq 'kvm') {
+        $ifacecfg{type} = 'user';
+        # This is the default MAC address for user mode networking; same in qemu backend
+        $ifacecfg{mac} = {address => '52:54:00:12:34:56'};
+    }
     else {
         # We can use bridge or network as a base for network interface. Network named 'default'
         # happens to be omnipresent on workstations, bridges (br0, ...) on servers. If both 'default'

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -129,10 +129,19 @@ sub run() {
         }
     }
 
-    # using 'virtio' devices may prevent loosing key strokes
-    if ($vmm_family eq 'kvm') {
-        $svirt->add_input({type => 'mouse',    bus => "virtio"});
-        $svirt->add_input({type => 'keyboard', bus => "virtio"});
+    # We need to use 'tablet' as a pointer device, i.e. a device
+    # with absolute axis. That needs to be explicitely configured
+    # on KVM and Xen HVM only. VMware and Xen PV add pointer
+    # device with absolute axis by default.
+    if (($vmm_family eq 'kvm') or ($vmm_family eq 'xen' and $vmm_type eq 'hvm')) {
+        if ($vmm_family eq 'kvm') {
+            $svirt->add_input({type => 'tablet',   bus => 'virtio'});
+            $svirt->add_input({type => 'keyboard', bus => 'virtio'});
+        }
+        elsif ($vmm_family eq 'xen' and $vmm_type eq 'hvm') {
+            $svirt->add_input({type => 'tablet',   bus => 'usb'});
+            $svirt->add_input({type => 'keyboard', bus => 'ps2'});
+        }
     }
 
     my $console_target_type;

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -98,8 +98,7 @@ sub run() {
     }
 
     # In JeOS and netinstall we don't have ISO media, for the rest we have to attach it.
-    if (!get_var('NETBOOT') and !is_jeos()) {
-        # Add installation media
+    if (!get_var('NETBOOT') and !is_jeos() and !get_var('HDD_1')) {
         my $isofile = get_required_var('ISO');
         if ($vmm_family eq 'vmware') {
             $isofile = basename($isofile);

--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -30,7 +30,11 @@ sub run() {
         send_key "alt-e";    # open release notes window
     }
     else {
-        if (check_var('VIDEOMODE', 'text')) {
+        # In text mode we can't click anything. On Xen PV we don't have
+        # correct exis coordinates, so we miss the button: POO#13536.
+        if (check_var('VIDEOMODE', 'text')
+            or (check_var('VIRSH_VMM_FAMILY', 'xen') and check_var('VIRSH_VMM_TYPE', 'linux')))
+        {
             send_key "alt-l";    # open release notes window
         }
         else {

--- a/tests/shutdown/svirt_upload_assets.pm
+++ b/tests/shutdown/svirt_upload_assets.pm
@@ -31,7 +31,7 @@ sub run() {
         if (($format ne 'raw') and ($format ne 'qcow2')) {
             next;
         }
-        push @toextract, {name => $name, format => $format};
+        push @toextract, {name => $name, format => $format, svirt_name => $svirt->name};
     }
     for my $asset (@toextract) {
         extract_assets($asset);
@@ -45,7 +45,7 @@ sub extract_assets {
     my $format = $args->{format};
 
     type_string("clear\n");
-    my $svirt_img_name = "/var/lib/libvirt/images/openQA-SUT-" . get_var('VIRSH_INSTANCE', 1) . ".img";
+    my $svirt_img_name = "/var/lib/libvirt/images/" . $args->{svirt_name} . ".img";
     type_string("test -e $svirt_img_name && echo 'OK'\n");
     assert_screen('svirt-asset-upload-hdd-image-exists');
 

--- a/tests/shutdown/svirt_upload_assets.pm
+++ b/tests/shutdown/svirt_upload_assets.pm
@@ -1,0 +1,63 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: upload svirt assets
+# Maintainer: Michal Nowak <mnowak@suse.com>
+
+use base "installbasetest";
+use strict;
+use warnings;
+use testapi;
+
+sub run() {
+    my $self = shift;
+
+    # connect to VIRSH_HOSTNAME screen and upload asset from there
+    my $svirt = select_console('svirt');
+
+    # mark hard disks for upload if test finished
+    my @toextract;
+    for my $i (1 .. get_var('NUMDISKS')) {
+        my $name = get_var("PUBLISH_HDD_$i");
+        next unless $name;
+        $name =~ /\.([[:alnum:]]+)$/;
+        my $format = $1;
+        if (($format ne 'raw') and ($format ne 'qcow2')) {
+            next;
+        }
+        push @toextract, {name => $name, format => $format};
+    }
+    for my $asset (@toextract) {
+        extract_assets($asset);
+    }
+}
+
+sub extract_assets {
+    my ($args) = @_;
+
+    my $name   = $args->{name};
+    my $format = $args->{format};
+
+    type_string("clear\n");
+    my $svirt_img_name = "/var/lib/libvirt/images/openQA-SUT-" . get_var('VIRSH_INSTANCE', 1) . ".img";
+    type_string("test -e $svirt_img_name && echo 'OK'\n");
+    assert_screen('svirt-asset-upload-hdd-image-exists');
+
+    my $cmd = "nice ionice qemu-img convert -p -O $format $svirt_img_name /var/lib/libvirt/images/$name";
+    if (get_var('QEMU_COMPRESS_QCOW2')) {
+        $cmd .= " -c";
+    }
+    type_string("$cmd && echo 'OK'\n");
+    assert_screen('svirt-asset-upload-hdd-image-converted', 300);
+
+    upload_asset("/var/lib/libvirt/images/$name", 1, 1);
+    assert_screen('svirt-asset-upload-hdd-image-uploaded', 1000);
+}
+
+1;


### PR DESCRIPTION
Bare bone verification run: http://assam.suse.cz/tests/4047:

```
  'args' => [
              {
                'size' => '20G',
                'file' => '/var/lib/openqa/share/factory/hdd/SLES-12-SP2-x86_64-Build2184-gnome.qcow2'
              }
            ],
  'console' => 'svirt',
  'function' => 'add_disk'
...
13:23:04.4437 484 Command executed: virsh  define /var/lib/libvirt/images/openQA-SUT-10.xml
13:23:04.5966 484 Command's stdout:
Domain openQA-SUT-10 defined from /var/lib/libvirt/images/openQA-SUT-10.xml


13:23:04.7354 484 Command executed: virsh  start openQA-SUT-10
13:23:05.4843 484 Command's stdout:
Domain openQA-SUT-10 started
```
