### PR TITLE
backport cryptlvm test to SP1

### DIFF
--- a/tests/installation/partitioning_lvm.pm
+++ b/tests/installation/partitioning_lvm.pm
@@ -74,15 +74,20 @@ sub run() {
             $collect_logs = 1;
         }
     }
-    elsif (!get_var('ENCRYPT_ACTIVATE_EXISTING')) {    # old behaviour still needed
-        send_key "alt-l", 1;                           # enable LVM-based proposal
+    elsif (!get_var('ENCRYPT_ACTIVATE_EXISTING') or get_var('ENCRYPT_FORCE_RECOMPUTE')) {    # old behaviour still needed
+        send_key "alt-l", 1;                                                                 # enable LVM-based proposal
         if (get_var("ENCRYPT")) {
             send_key "alt-y";
-            assert_screen "inst-encrypt-password-prompt";
-            type_password;
-            send_key "tab";
-            type_password;
-            send_key "ret";
+            if (get_var('ENCRYPT_FORCE_RECOMPUTE')) {                                        # RECOMPUTE does not ask for new password
+                send_key "ret";
+            }
+            else {
+                assert_screen "inst-encrypt-password-prompt";
+                type_password;
+                send_key "tab";
+                type_password;
+                send_key "ret";
+            }
             assert_screen "partition-cryptlvm-summary";
         }
         else {


### PR DESCRIPTION
Make cryptlvm+activate_existing+force_recompute work for SP1

Force recomputing after activating existing encrypted lvm partition
does not ask for (new) password on SP1 while it does on SP2.
Working example: http://rwmanosvm2.suse.cz/tests/1985
Without this change the test fails at http://rwmanosvm2.suse.cz/tests/1970#step/partitioning_lvm/7