### PR TITLE
pkcon_quit is only for less than SLE12SP2

### DIFF
--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -52,7 +52,9 @@ sub create_qaset_config {
 sub prepare_repos {
     my $self           = shift;
     my $qa_server_repo = get_var('QA_SERVER_REPO');
-    pkcon_quit;
+    unless (sle_version_at_least('12-SP2')) {
+        pkcon_quit;
+    }
     if ($qa_server_repo) {
         # Remove all existing repos and add QA_SERVER_REPO
         script_run('for i in {1..$(zypper lr| tail -n+3 |wc -l)}; do zypper -n rr $i; done; unset i', 300);


### PR DESCRIPTION
pkcon_quit masked packagekit at the very beginning of test, it cause systemd can't test packagekit without unmask it(and it can't test the initial status of packagekit as well). As workaround pkcon_quit is for SLES12SP1 and less version, I add a condition to avoid the influence  to SLE12SP2. Or if there is any powerful command than sle_version_at_least to avoid the influence by pkcon_quit in following SLE13.