### PR TITLE
Get rid of REPO_SLES_DEBUG, visual glitches fixes

### DIFF
--- a/tests/toolchain/crash.pm
+++ b/tests/toolchain/crash.pm
@@ -16,46 +16,20 @@ use testapi;
 use utils;
 
 sub install_kernel_debuginfo {
+    # list installed kernels
+    assert_script_run 'rpmquery -a kernel-default*';
     # kernel debug symbols are huge, this can take a while
-    assert_script_run 'zypper ref; zypper -n -v in kernel-default-base-debuginfo kernel-default-debuginfo', 1200;
+    assert_script_run 'zypper ref; zypper -n -v in kernel-default-debuginfo', 1200;
 }
 
 sub run() {
     select_console('root-console');
 
-    script_run 'zypper -n in yast2-kdump kdump crash';
-
-    script_run 'yast2 kdump', 0;
-
-    # It seems that `toolchain/gcc5_Cpp_compilation.pm` spits some visual artifacts
-    # (https://openqa.suse.de/tests/522356/file/video.ogv) which prevent needle match.
-    # It's not enough to wait, we have to refresh the screen before check_screen or
-    # assert_screen.
-    wait_still_screen(20, 60);
-    send_key 'ctrl-l';    # refresh the screen
-
-    if (check_screen 'yast2-kdump-disabled') {
-        send_key 'alt-u';    # enable kdump
-    }
-
-    send_key 'ctrl-l';       # refresh the screen
-    assert_screen 'yast2-kdump-enabled';
-    send_key 'alt-o';        # OK
-
-    send_key 'ctrl-l';       # refresh the screen
-    if (check_screen 'yast2-kdump-restart-info') {
-        send_key 'alt-o';    # OK
-    }
-
-    # activate kdump
-    wait_still_screen(10, 30);
-    script_run 'reboot', 0;
-    wait_boot;
-    select_console 'root-console';
-
     # disable packagekitd
     script_run 'systemctl mask packagekit.service';
     script_run 'systemctl stop packagekit.service';
+
+    script_run 'zypper -n in yast2-kdump kdump crash';
 
     # add debuginfo channels
     if (check_var('DISTRI', 'sle')) {
@@ -74,6 +48,25 @@ sub run() {
         assert_script_run "zypper -n mr -d $opensuse_debug_repos";
     }
 
+    # activate kdump
+    script_run 'yast2 kdump', 0;
+    if (check_screen 'yast2-kdump-disabled') {
+        send_key 'alt-u';    # enable kdump
+    }
+
+    assert_screen 'yast2-kdump-enabled';
+    send_key 'alt-o';        # OK
+
+    if (check_screen 'yast2-kdump-restart-info') {
+        send_key 'alt-o';    # OK
+    }
+
+    wait_still_screen(10, 30);
+    script_run 'reboot', 0;
+    wait_boot;
+    select_console 'root-console';
+
+    # make sure kdump is enabled after reboot
     validate_script_output "yast2 kdump show 2>&1", sub { m/Kdump is enabled/ }, 90;
 
     # get dump
@@ -83,8 +76,9 @@ sub run() {
     wait_boot;
     select_console 'root-console';
 
+    # all but PPC64LE arch's vmlinux images are gzipped
     my $suffix = check_var('ARCH', 'ppc64le') ? '' : '.gz';
-    my $crash_cmd = 'echo exit | crash `ls -1t /var/crash/*/vmcore | head -n1` /boot/vmlinux-`uname -r`' . $suffix;
+    my $crash_cmd = "echo exit | crash `ls -1t /var/crash/*/vmcore | head -n1` /boot/vmlinux-`uname -r`$suffix";
     assert_script_run "$crash_cmd";
     validate_script_output "$crash_cmd", sub { m/PANIC/ };
 }

--- a/tests/toolchain/crash.pm
+++ b/tests/toolchain/crash.pm
@@ -33,7 +33,13 @@ sub run() {
 
     # add debuginfo channels
     if (check_var('DISTRI', 'sle')) {
-        my $url = "ftp://openqa.suse.de/" . get_required_var('REPO_SLES_DEBUG');
+        # debuginfos for kernel has to be installed from build-specific directory on FTP.
+        # To get the right directory we modify content of REPO_0 variable, e.g.:
+        #   SLE-12-SP2-Server-DVD-x86_64-Build2188-Media1 -> SLE-12-SP2-SERVER-POOL-x86_64-Build2188-Media3
+        my $sles_debug_repo = get_var('REPO_0') =~ s/(Server|Desktop)/\U$1\E/r;
+        $sles_debug_repo =~ s/DVD/POOL/;
+        $sles_debug_repo =~ s/Media1/Media3/;
+        my $url = "ftp://openqa.suse.de/$sles_debug_repo";
         assert_script_run "zypper ar -f $url SLES-Server-Debug";
         install_kernel_debuginfo;
         script_run 'zypper -n rr SLES-Server-Debug';


### PR DESCRIPTION
Getting rid of `REPO_SLES_DEBUG` as it's not provided by rsync.pl
the information can be extracted from `REPO_0` var as well.
Also removing 'screen-cleaning' because of previous test's
esses' random writes to TTY; reboot will rule them out.

Verification run: http://assam.suse.cz/tests/4057.