### PR TITLE
Send key when window about missing pkg appears

### DIFF
--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -27,6 +27,11 @@ sub run() {
     script_run("/sbin/yast2 bootloader; echo yast2-bootloader-status-\$? > /dev/$serialdev", 0);
     assert_screen "test-yast2_bootloader-1", 300;
     send_key "alt-o";                                     # OK => Close
+    assert_screen([qw(yast2_bootloader-missing_package yast2_bootloader-finished)]);
+    if (match_has_tag('yast2_bootloader-missing_package')) {
+        wait_screen_change { send_key 'alt-i'; };
+    }
+    assert_screen 'yast2_bootloader-finished';
     wait_serial("yast2-bootloader-status-0", 150) || die "'yast2 bootloader' didn't finish";
 }
 


### PR DESCRIPTION
Fix the soft-failure when yast2_bootloader gets a window about missing package kexec-tools.
The change in test will send keystrokes only if this window will appear.
Tests:
migration_offline_sled11_sp4
migration_offline_sled11_sp4+sdk
migration_offline_sled11_sp4_kde
