### PR TITLE
Do not verify repositories on SLE 12 GM

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -549,7 +549,7 @@ sub validate_repos {
     script_run "clear";
     assert_script_run "zypper lr -d | tee /dev/$serialdev";
 
-    if (check_var('DISTRI', 'sle') and !get_var('STAGING')) {
+    if (check_var('DISTRI', 'sle') and !get_var('STAGING') and sle_version_at_least('12-SP1')) {
         script_run "clear";
 
         # On SLE we follow "SLE Channels Checking Table"


### PR DESCRIPTION
There are repositories on SLE 12 GM no one added support for:
https://openqa.suse.de/tests/621675#step/zypper_lr/19. Disabling 12 GM
in the "meantime".