### PR TITLE
Update libreoffice_open_specified_file to fix poo#13000

### DIFF
--- a/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
@@ -7,12 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Case 1503881 - LibreOffice: Verify LibreOffice opens specified file types correctly.
+# Summary: Case 1503881 - Verify LibreOffice opens specified file types correctly
+# Maintainer: dehai <dhkong@suse.com>
 
-# G-Summary: add libreoffice tc#1503778 and tc#1503881 script and attachment
-# G-Maintainer: dehai <dhkong@suse.com>
-
-use base "x11regressiontest";
 use base "x11regressiontest";
 use strict;
 use testapi;
@@ -30,20 +27,14 @@ sub run() {
     $self->check_libreoffice_dialogs();
 
     # open below qw/doc docx fodg fodp fods fodt odf odg odp ods odt pdf pptx xlsx/ to check whether can be work
-    send_key "alt-o";
-    send_key "ctrl-l";
-    type_string "/home/$username/Documents\n";
-    send_key "ret";
-    assert_screen("specified-file-list");
-    assert_and_click 'libreoffice-click-file-list';
     for my $tag (qw/doc docx fodg fodp fods fodt odf odg odp ods odt pdf pptx xlsx/) {
-        send_key_until_needlematch("libreoffice-specified-file-$tag", "down", 50, 1);
-        send_key "ret";
+        send_key "ctrl-o";
+        wait_still_screen 3;
+        send_key "ctrl-l";
+        save_screenshot;
+        type_string "/home/$username/Documents/ooo-test-doc-types/test.$tag\n";
         wait_still_screen;
         assert_screen("libreoffice-test-$tag");
-        if ($tag ne 'xlsx') {
-            send_key "ctrl-o";
-        }
     }
     send_key "ctrl-q";
     if (!assert_screen("generic-desktop")) {


### PR DESCRIPTION
- Adding wait_still_screen between send_key
- The former send_key_until_needlematch way to open file is too much expensive.
  We can open the file via typing it's absolute address to the address bar.

see:

before:https://openqa.suse.de/tests/621670

after:http://147.2.212.239/tests/847

  see also: poo#13000