### PR TITLE
Bootloader/Text mode selection: use send_key_until_needlematch

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -215,10 +215,7 @@ sub specific_bootmenu_params {
 sub select_bootmenu_video_mode {
     if (check_var("VIDEOMODE", "text")) {
         send_key "f3";
-        for (1 .. 2) {
-            send_key "up";
-        }
-        assert_screen "inst-textselected";
+        send_key_until_needlematch("inst-textselected", "up", 5);
         send_key "ret";
     }
 }


### PR DESCRIPTION
With the introduction of color profiles for YaST (low visibility enhancements),
text mode is no longer the 2nd last item in the menu. Instead of pressing 'up'
a specific amount of time, use send_key_until_needlematch to find the right
entry to press enter on.

https://progress.opensuse.org/issues/14392