### PR TITLE
Bootloader/Text mode selection: Press 'ESC' on the new video mode menu

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -217,6 +217,13 @@ sub select_bootmenu_video_mode {
         send_key "f3";
         send_key_until_needlematch("inst-textselected", "up", 5);
         send_key "ret";
+        if (match_has_tag("inst-textselected-with_colormenu")) {
+            # The video mode menu was enhanced to support various color profiles
+            # Pressing 'ret' only 'toggles' text mode on/off, but no longer closes
+            # the menu, as the user might also want to pick a color profile
+            # close the menu by pressing 'esc'
+            send_key "esc";
+        }
     }
 }
 


### PR DESCRIPTION
When selecting text-mode, the new menu no longer closes when pressing
'ret'. This is done as there is also a 'color scheme' submenu which a
user might want to pick right away too. Instead, it is now needed to
press 'ESC' to close the menu and get back to the grub menu.

We can't unconditionally press 'ESC' as in case the menu would close
directly with 'ret' (old style), the keypress would prompt grub to ask
to quit to the grub console.