### PR TITLE
Update evolution_timezone_setup to fix poo#13118

### DIFF
--- a/tests/x11regressions/evolution/evolution_timezone_setup.pm
+++ b/tests/x11regressions/evolution/evolution_timezone_setup.pm
@@ -9,31 +9,38 @@
 
 #testcase 5255-1503908:Evolution: setup timezone
 
-# G-Summary: updated openqa script and entry for tc#1503908: evolution_timezone_setup
-# G-Maintainer: xiaojun <xjin@suse.com>
+# Summary: tc#1503908: evolution_timezone_setup
+# Maintainer: Chingkai <qkzhu@suse.com>
 
 use strict;
 use base "x11regressiontest";
 use testapi;
+use utils;
 
 sub run() {
     my $mailbox     = 'nooops_test3@aim.com';
     my $mail_passwd = 'opensuse';
+    my $next_key    = 'alt-o';
+
+    if (sle_version_at_least('12-SP2')) {
+        $next_key = "alt-n";
+    }
 
     mouse_hide(1);
 
     # Clean and Start Evolution
     x11_start_program("xterm -e \"killall -9 evolution; find ~ -name evolution | xargs -rm -rf;\"");
     x11_start_program("evolution");
-    if (check_screen "evolution-default-client-ask") {
+    assert_screen [qw(evolution-default-client-ask test-evolution-1)];
+    if (match_has_tag "evolution-default-client-ask") {
         assert_and_click "evolution-default-client-agree";
+        assert_screen 'test-evolution-1';
     }
 
     # Follow the wizard to complete the first launch steps
-    assert_screen "test-evolution-1";
-    send_key "alt-o";
+    send_key $next_key;
     assert_screen "evolution_wizard-restore-backup";
-    send_key "alt-o";
+    send_key $next_key;
     assert_screen "evolution_wizard-identity";
     send_key "alt-e";
     type_string "SUSE Test";
@@ -43,19 +50,20 @@ sub run() {
     sleep 1;
     save_screenshot();
 
-    send_key "alt-o";
-    if (check_screen "evolution_wizard-skip-lookup") {
+    send_key $next_key;
+    assert_screen [qw(evolution_wizard-skip-lookup evolution_wizard-receiving)];
+    if (match_has_tag "evolution_wizard-skip-lookup") {
         send_key "alt-s";
+        assert_screen 'evolution_wizard-receiving';
     }
 
-    assert_screen "evolution_wizard-receiving";
     send_key "alt-t";
     send_key "ret";
     send_key_until_needlematch "evolution_wizard-receiving-none", "up";
     send_key "ret";
     wait_still_screen;
 
-    send_key "alt-o";
+    send_key $next_key;
     wait_still_screen;
     assert_screen "evolution_wizard-sending";
     send_key "alt-t";
@@ -63,11 +71,16 @@ sub run() {
     send_key_until_needlematch "evolution_wizard-sending-sendmail", "down";
     send_key "ret";
     wait_still_screen;
-    send_key "alt-o";
+    send_key $next_key;
     wait_still_screen;
 
     assert_screen "evolution_wizard-account-summary";
-    send_key "alt-o";
+    if (sle_version_at_least('12-SP2')) {
+        assert_and_click "evolution-option-next";
+    }
+    else {
+        send_key $next_key;
+    }
     assert_screen "evolution_wizard-done";
     send_key "alt-a";
     if (check_screen "evolution_mail-init-window") {
@@ -87,7 +100,14 @@ sub run() {
     assert_screen "evolution-selectA-timezone";
     assert_and_click "mercator-projection";
     assert_screen "mercator-zoomed-in";
-    assert_and_click "time-zone-selection";
+    if (sle_version_at_least('12-SP2')) {
+        send_key "alt-s";
+        wait_still_screen 3;
+        send_key "ret";
+    }
+    else {
+        assert_and_click "time-zone-selection";
+    }
     send_key_until_needlematch("timezone-asia-shanghai", "up") || send_key_until_needlematch("timezone-asia-shanghai", "down");
     send_key "ret";
     assert_screen "asia-shanghai-timezone-setup";


### PR DESCRIPTION
validation run: http://147.2.212.239/tests/854

- The 'Continue' button of evolution setup wizard of this case has changed to
  'Next' on SLED12SP2.
- Change check_screen to match_has_tag to save time.

  see also: poo#13118