### PR TITLE
Restart to prevent potential screen disruptions

### DIFF
--- a/tests/toolchain/crash.pm
+++ b/tests/toolchain/crash.pm
@@ -54,6 +54,11 @@ sub run() {
         assert_script_run "zypper -n mr -d $opensuse_debug_repos";
     }
 
+    # restart to get rid of potential screen disruptions from previous test
+    script_run 'reboot', 0;
+    wait_boot;
+    select_console 'root-console';
+
     # activate kdump
     script_run 'yast2 kdump', 0;
     if (check_screen 'yast2-kdump-disabled') {


### PR DESCRIPTION
In commit 77fd9df9da855be752d23070e66974eb6bf3874a I forgot to add
restart before YaST - on PPC it may fail because the screen may be
distorted from previous test's remnants.