### PR TITLE
yast2_bootloader: Use same 'finished' needle as for yast2_i

### DIFF
--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -27,11 +27,11 @@ sub run() {
     script_run("/sbin/yast2 bootloader; echo yast2-bootloader-status-\$? > /dev/$serialdev", 0);
     assert_screen "test-yast2_bootloader-1", 300;
     send_key "alt-o";                                     # OK => Close
-    assert_screen([qw(yast2_bootloader-missing_package yast2_bootloader-finished)]);
+    assert_screen([qw(yast2_bootloader-missing_package yast2_console-finished)]);
     if (match_has_tag('yast2_bootloader-missing_package')) {
         wait_screen_change { send_key 'alt-i'; };
     }
-    assert_screen 'yast2_bootloader-finished';
+    assert_screen 'yast2_console-finished';
     wait_serial("yast2-bootloader-status-0", 150) || die "'yast2 bootloader' didn't finish";
 }
 


### PR DESCRIPTION
See https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/121 and
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/241