### PR TITLE
Fix typo for two evolution cases

### DIFF
--- a/tests/x11regressions/evolution/evolution_smoke.pm
+++ b/tests/x11regressions/evolution/evolution_smoke.pm
@@ -32,7 +32,7 @@ sub run() {
     mouse_hide(1);
 
     # Clean and Start Evolution
-    x11_start_program("xterm -e \"killall -9 evolution; find ~ -name evolution | xargs -rm -rf;\"");
+    x11_start_program("xterm -e \"killall -9 evolution; find ~ -name evolution | xargs rm -rf;\"");
     x11_start_program("evolution");
     if (check_screen "evolution-default-client-ask") {
         assert_and_click "evolution-default-client-agree";

--- a/tests/x11regressions/evolution/evolution_timezone_setup.pm
+++ b/tests/x11regressions/evolution/evolution_timezone_setup.pm
@@ -29,7 +29,7 @@ sub run() {
     mouse_hide(1);
 
     # Clean and Start Evolution
-    x11_start_program("xterm -e \"killall -9 evolution; find ~ -name evolution | xargs -rm -rf;\"");
+    x11_start_program("xterm -e \"killall -9 evolution; find ~ -name evolution | xargs rm -rf;\"");
     x11_start_program("evolution");
     assert_screen [qw(evolution-default-client-ask test-evolution-1)];
     if (match_has_tag "evolution-default-client-ask") {


### PR DESCRIPTION
Delete extra minus for parameter of xargs.

Failed at:  https://openqa.suse.de/tests/624711#step/evolution_timezone_setup/3

line 32 has a redundant minus for xargs:

> x11_start_program("xterm -e \"killall -9 evolution; find ~ -name evolution | xargs **-**rm -rf;\"");