### PR TITLE
Fix login_test occasional failure

### DIFF
--- a/tests/x11regressions/gnomecase/login_test.pm
+++ b/tests/x11regressions/gnomecase/login_test.pm
@@ -7,8 +7,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: openqa script and entry for tc#1503803 tc#1503905; entry for tc#1503973
-# G-Maintainer: xiaojun <xjin@suse.com>
+# Summary: openqa script and entry for tc#1503803 tc#1503905; entry for tc#1503973
+# Maintainer: xiaojun <xjin@suse.com>
 
 use base "x11regressiontest";
 use strict;
@@ -23,6 +23,7 @@ sub auto_login_alter {
     send_key "super";
     wait_still_screen;
     type_string "settings", 1;    #Use '1' to give gnome-shell enough time to search settings module; Otherwise slow worker will cause failed result.
+    wait_still_screen;
     assert_and_click "settings";
     assert_screen "gnome-settings";
     type_string "users";


### PR DESCRIPTION
The login_test types 'settings' in the overview of gnome and selects
it with assert_and_click. Although a delay is already set in
typing, it is not adequate. Recent test failed because the assert
happened before the full string was typed. So a 'wait_still_screen'
after typing fixes this issue.

Failed test: https://openqa.suse.de/tests/624848#step/login_test/2