### PR TITLE
Update evolution and libreoffice case to fix poo#13118 poo#13000

### DIFF
--- a/tests/x11regressions/evolution/evolution_timezone_setup.pm
+++ b/tests/x11regressions/evolution/evolution_timezone_setup.pm
@@ -37,14 +37,10 @@ sub run() {
     assert_screen "evolution-selectA-timezone";
     assert_and_click "mercator-projection";
     assert_screen "mercator-zoomed-in";
-    if (sle_version_at_least('12-SP2')) {
-        send_key "alt-s";
-        wait_still_screen 3;
-        send_key "ret";
-    }
-    else {
-        assert_and_click "time-zone-selection";
-    }
+    # Change timezone to Shanghai
+    send_key "alt-s";
+    wait_still_screen 3;
+    send_key "ret";
     send_key_until_needlematch("timezone-asia-shanghai", "up") || send_key_until_needlematch("timezone-asia-shanghai", "down");
     send_key "ret";
     assert_screen "asia-shanghai-timezone-setup";

--- a/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
@@ -37,7 +37,7 @@ sub run() {
         assert_screen("libreoffice-test-$tag");
     }
     send_key "ctrl-q";
-    if (!assert_screen("generic-desktop")) {
+    if (!check_screen("generic-desktop")) {
         send_key "ctrl-q";
     }
 


### PR DESCRIPTION
Failed at: https://openqa.suse.de/tests/626482#step/evolution_timezone_setup/82

Failed at:https://openqa.suse.de/tests/626472#step/libreoffice_open_specified_file/54

- evolution_timezone_setup: Enter timezone drop-down menu using
  shortcut instead of assert_and_click
- libreoffice_open_specified_file: Change assert_screen to check_screen

  see also: poo#13118, poo#13000

validation run SP1: http://147.2.212.239/tests/863

validation run SP2: http://147.2.212.239/tests/858