### PR TITLE
Update 3 firefox cases to fix Reader View issue

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -191,10 +191,10 @@ sub load_x11regression_firefox() {
     loadtest "x11regressions/firefox/sle12/firefox_changesaving.pm";
     loadtest "x11regressions/firefox/sle12/firefox_fullscreen.pm";
     loadtest "x11regressions/firefox/sle12/firefox_health.pm";
+    loadtest "x11regressions/firefox/sle12/firefox_flashplayer.pm";
+    loadtest "x11regressions/firefox/sle12/firefox_java.pm";
     if (sle_version_at_least('12-SP2')) {    # take out these failed cases from qam test for SP1
-        loadtest "x11regressions/firefox/sle12/firefox_java.pm";
         loadtest "x11regressions/firefox/sle12/firefox_pagesaving.pm";
-        loadtest "x11regressions/firefox/sle12/firefox_flashplayer.pm";
         loadtest "x11regressions/firefox/sle12/firefox_ssl.pm";
         loadtest "x11regressions/firefox/sle12/firefox_passwd.pm";
         loadtest "x11regressions/firefox/sle12/firefox_mhtml.pm";

--- a/tests/x11regressions/firefox/sle12/firefox_extcontent.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_extcontent.pm
@@ -27,12 +27,13 @@ sub run() {
     sleep 1;
     type_string $ext_link. "\n";
 
-    assert_screen ['firefox-extcontent-reader', 'firefox-extcontent-pageloaded'], 90;
-    if (match_has_tag 'firefox-extcontent-reader') {
-        assert_and_click('firefox-extcontent-reader', 'left', 5, 0.2);
+    wait_still_screen;
+    assert_screen ['firefox-reader-view', 'firefox-extcontent-pageloaded'], 90;
+    if (match_has_tag 'firefox-reader-view') {
+        assert_and_click('firefox-reader-close');
+        assert_screen('firefox-extcontent-pageloaded');
     }
 
-    assert_screen('firefox-extcontent-pageloaded', 90);
     send_key "/";
     sleep 1;
     type_string "license.tar.gz\n";

--- a/tests/x11regressions/firefox/sle12/firefox_flashplayer.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_flashplayer.pm
@@ -22,7 +22,12 @@ sub run() {
     send_key "esc";
     send_key "alt-d";
     type_string "http://www.adobe.com/software/flash/about/\n";
-    assert_screen('firefox-flashplayer-verify_loaded', 90);
+    wait_still_screen;
+    assert_screen ['firefox-reader-view', 'firefox-flashplayer-verify_loaded'], 90;
+    if (match_has_tag 'firefox-reader-view') {
+        assert_and_click('firefox-reader-close');
+        assert_screen('firefox-flashplayer-verify_loaded');
+    }
 
     send_key "pgdn";
     # flashplayer dropped since sled12 sp2

--- a/tests/x11regressions/firefox/sle12/firefox_java.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_java.pm
@@ -22,9 +22,10 @@ sub java_testing {
     send_key "alt-d";
     type_string "http://www.java.com/en/download/installed.jsp?detect=jre\n";
 
-    assert_screen [qw(firefox-extcontent-reader firefox-java-security oracle-cookies-handling)];
-    if (match_has_tag 'firefox-extcontent-reader') {
-        assert_and_click('firefox-extcontent-reader');
+    wait_still_screen;
+    assert_screen [qw(firefox-reader-view firefox-java-security oracle-cookies-handling)];
+    if (match_has_tag 'firefox-reader-view') {
+        assert_and_click('firefox-reader-close');
         assert_screen [qw(firefox-java-security oracle-cookies-handling)];
     }
     assert_screen [qw(firefox-java-security oracle-cookies-handling)];


### PR DESCRIPTION
Reader View is a Firefox feature that strips away all of a website's clutter so you can focus on what you're reading. The popup message box in the address bar has blocked our cases for a while, we have to close the popup box before the test.

- improve the closing step by adding a new needle for
  - firefox_extcontent.pm
  - firefox_flashplayer.pm
  - firefox_java.pm

- bring back firefox_flashplayer.pm and firefox_java.pm for qam test

  see also: poo#10432

validation on SP2: http://147.2.212.239/tests/887

validation on SP1: http://147.2.212.239/tests/886