### PR TITLE
Modifications of SLEnkins scripts in openQA

### DIFF
--- a/tests/slenkins/slenkins_control.pm
+++ b/tests/slenkins/slenkins_control.pm
@@ -13,8 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# G-Summary: slenkins support
-# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+# Summary: slenkins support
+# Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
 
 use strict;
 use base 'basetest';
@@ -113,8 +113,10 @@ sub run {
         my $disk_size = $settings{$p}->{HDDSIZEGB} || 10;
         my $num_disks = $settings{$p}->{NUMDISKS}  || 1;
 
-        for (my $d = 0; $d < $num_disks; $d++) {
-            $conf .= "export DISK_NAME_" . uc($node) . "_DISK$d='/dev/$disk_name" . chr(ord('a') + $d) . "'\n";
+        # In SLEnkins DISK_NAME_NODE_DISK0 is used for first additional disk /dev/vdb and so on
+        # Drive /dev/vda is always in use as bootdrive and has no dedicated variable
+        for (my $d = 0; $d < ($num_disks - 1); $d++) {
+            $conf .= "export DISK_NAME_" . uc($node) . "_DISK$d='/dev/$disk_name" . chr(ord('b') + $d) . "'\n";
             $conf .= "export DISK_SIZE_" . uc($node) . "_DISK$d='${disk_size}G'\n";
         }
         $i++;

--- a/tests/slenkins/slenkins_node.pm
+++ b/tests/slenkins/slenkins_node.pm
@@ -13,8 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# G-Summary: slenkins support
-# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+# Summary: slenkins support
+# Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
 
 use strict;
 use base 'basetest';
@@ -59,6 +59,10 @@ sub run {
 
     my $conf_script = "zypper -n --no-gpg-checks ar '" . get_var('SLENKINS_TESTSUITES_REPO') . "' slenkins_testsuites\n";
 
+    # Uses full URI with .repo extension, right now multiple FOREIGN_REPO is not supported
+    if (get_var("FOREIGN_REPO")) {
+        $conf_script .= "zypper -n --no-gpg-checks ar '" . get_var('FOREIGN_REPO') . "'\n";
+    }
     if (get_var('SLENKINS_INSTALL')) {
         $conf_script .= "zypper -n --no-gpg-checks in " . join(' ', split(/[\s,]+/, get_var('SLENKINS_INSTALL'))) . "\n";
     }
@@ -74,7 +78,7 @@ sub run {
         chmod 700 /root/.ssh
         chmod 600 /home/testuser/.ssh/*
         chmod 700 /home/testuser/.ssh
-        rcSuSEfirewall2 stop
+        SuSEfirewall2 off
         rcsshd restart
     ";
     script_output($conf_script, 100);


### PR DESCRIPTION
Modifications of SLEnkins scripts in openQA:

* Proper numbering and names for drives in DISK_NAME_$node_DISK$d variable according to SLEnkins scripts
* Introduced new variable FOREIGN_REPO for .repo repos in nodes file
* Disable&stop firewall instead just stop (machine had FW enabled after reboot)

TODO: add parsing of disk and repo lines in nodes into import-slenkins-testsuite.pm