### PR TITLE
Expect installer self-update to be disabled by default

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -186,7 +186,11 @@ sub specific_bootmenu_params {
 
     if (check_var("INSTALLER_NO_SELF_UPDATE", 1)) {
         diag "Disabling installer self update as requested by INSTALLER_NO_SELF_UPDATE=1";
-        $args .= "self_update=0";
+        $args .= " self_update=0";
+    }
+    elsif (check_var("INSTALLER_SELF_UPDATE", 1)) {
+        diag "Explicitly enabling installer self update as requested by INSTALLER_SELF_UPDATE=1";
+        $args .= " self_update=1";
     }
 
     if (get_var("FIPS")) {

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -81,10 +81,6 @@ sub prepare_parmfile {
     my $instsrc = get_var('REPO_TYPE', 'ftp') . '://' . get_var('REPO_HOST', 'openqa') . '/';
     $params .= " install=" . $instsrc . $repo . " ";
 
-    if (check_var("INSTALLER_NO_SELF_UPDATE", 1)) {
-        diag "Disabling installer self update as requested by INSTALLER_NO_SELF_UPDATE=1";
-        $params .= 'self_update=0 ';
-    }
     if (get_var('UPGRADE')) {
         $params .= 'upgrade=1 ';
     }

--- a/tests/installation/skip_registration.pm
+++ b/tests/installation/skip_registration.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014,2015 SUSE Linux GmbH
+# Copyright (C) 2014-2016 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,10 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# G-Summary: split scc registration
-#    makes it more obvious if a test doesn't actually register during
-#    installation
-# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+# Summary: Explicitly skip SCC registration
+# Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
 
 use strict;
 use base "y2logsstep";
@@ -31,7 +29,12 @@ sub run() {
         if (check_var("INSTALLER_NO_SELF_UPDATE", 1)) {
             die "installer should not self-update, therefore window should not have respawned, file bug and replace this line by record_soft_failure";
         }
-        ensure_fullscreen(tag => 'yast2-windowborder-corner');
+        elsif (check_var('INSTALLER_SELF_UPDATE', 1)) {
+            ensure_fullscreen(tag => 'yast2-windowborder-corner');
+        }
+        else {
+            die "so far this should only be reached on s390x which we test only on SLE which has self-update disabled since SLE 12 SP2 GM so we should not reach here unless this is a new version of SLE which has the self-update enabled by default";
+        }
         assert_screen_with_soft_timeout('scc-registration', timeout => 300, soft_timeout => 100, bugref => 'bsc#990254');
     }
     send_key "alt-s", 1;    # skip SCC registration


### PR DESCRIPTION
Using the new variable "INSTALLER_SELF_UPDATE" the installer self-update
feature can be explicitly enabled.

Actually testing if the installer self-update is not easy and so far is only
done implicitly by assuming the window over an ssh+X installation to be not
fullscreen which we have covered so far only on s390x zVM installations. This
check is now also changed to check for the explicit enablement of installer
self-update, disabled self-update as well as providing a fallback when the
window is not fullscreen in the default case which can mean that the
self-update was set as default again which should not happen unnoticed.