### PR TITLE
Update 2 firefox cases to fix poo#10432

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -193,8 +193,9 @@ sub load_x11regression_firefox() {
     loadtest "x11regressions/firefox/sle12/firefox_health.pm";
     loadtest "x11regressions/firefox/sle12/firefox_flashplayer.pm";
     loadtest "x11regressions/firefox/sle12/firefox_java.pm";
+    loadtest "x11regressions/firefox/sle12/firefox_pagesaving.pm";
+    loadtest "x11regressions/firefox/sle12/firefox_private.pm";
     if (sle_version_at_least('12-SP2')) {    # take out these failed cases from qam test for SP1
-        loadtest "x11regressions/firefox/sle12/firefox_pagesaving.pm";
         loadtest "x11regressions/firefox/sle12/firefox_ssl.pm";
         loadtest "x11regressions/firefox/sle12/firefox_passwd.pm";
         loadtest "x11regressions/firefox/sle12/firefox_mhtml.pm";
@@ -202,7 +203,6 @@ sub load_x11regression_firefox() {
         loadtest "x11regressions/firefox/sle12/firefox_extensions.pm";
         loadtest "x11regressions/firefox/sle12/firefox_appearance.pm";
         loadtest "x11regressions/firefox/sle12/firefox_html5.pm";
-        loadtest "x11regressions/firefox/sle12/firefox_private.pm";
         loadtest "x11regressions/firefox/sle12/firefox_developertool.pm";
         loadtest "x11regressions/firefox/sle12/firefox_gnomeshell.pm";
         loadtest "x11regressions/firefox/sle12/firefox_rss.pm";

--- a/tests/x11regressions/firefox/sle12/firefox_extcontent.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_extcontent.pm
@@ -27,7 +27,7 @@ sub run() {
     sleep 1;
     type_string $ext_link. "\n";
 
-    wait_still_screen;
+    wait_still_screen 3;
     assert_screen ['firefox-reader-view', 'firefox-extcontent-pageloaded'], 90;
     if (match_has_tag 'firefox-reader-view') {
         assert_and_click('firefox-reader-close');

--- a/tests/x11regressions/firefox/sle12/firefox_flashplayer.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_flashplayer.pm
@@ -22,7 +22,7 @@ sub run() {
     send_key "esc";
     send_key "alt-d";
     type_string "http://www.adobe.com/software/flash/about/\n";
-    wait_still_screen;
+    wait_still_screen 3;
     assert_screen ['firefox-reader-view', 'firefox-flashplayer-verify_loaded'], 90;
     if (match_has_tag 'firefox-reader-view') {
         assert_and_click('firefox-reader-close');

--- a/tests/x11regressions/firefox/sle12/firefox_java.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_java.pm
@@ -22,7 +22,7 @@ sub java_testing {
     send_key "alt-d";
     type_string "http://www.java.com/en/download/installed.jsp?detect=jre\n";
 
-    wait_still_screen;
+    wait_still_screen 3;
     assert_screen [qw(firefox-reader-view firefox-java-security oracle-cookies-handling)];
     if (match_has_tag 'firefox-reader-view') {
         assert_and_click('firefox-reader-close');

--- a/tests/x11regressions/firefox/sle12/firefox_pagesaving.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_pagesaving.pm
@@ -19,10 +19,6 @@ sub run() {
     my ($self) = @_;
     $self->start_firefox;
 
-    sleep 1;
-    x11_start_program("firefox");
-    assert_screen('firefox-launch', 90);
-
     send_key "esc";
     sleep 1;
     send_key "alt-d";

--- a/tests/x11regressions/firefox/sle12/firefox_private.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_private.pm
@@ -29,10 +29,9 @@ sub run() {
     type_string "facebook.com\n";
     assert_screen('firefox-private-facebook', 90);
 
-    sleep 1;
     send_key "alt-f4";
-    sleep 1;
-    send_key "alt-f4";
+    wait_still_screen 3;
+    $self->exit_firefox;
 
     sleep 2;
     x11_start_program("firefox");
@@ -47,7 +46,6 @@ sub run() {
 
     # Exit
     send_key "alt-f4";
-
     if (check_screen('firefox-save-and-quit', 30)) {
         # confirm "save&quit"
         send_key "ret";


### PR DESCRIPTION
- firefox_pagesaving.pm:
  firefox was launched twice, delete the second launching
- firefox_private.pm:
  fixing the closing step
- reduce the waiting time for wait_still_screen
- bring back firefox_private.pm and firefox_pagesaving.pm for qam test

  see also: poo#10432


validation on SP2: http://147.2.212.239/tests/896

validation on SP1: http://147.2.212.239/tests/898