### PR TITLE
Do not check bootmenu if on UEFI

### DIFF
--- a/tests/installation/mediacheck.pm
+++ b/tests/installation/mediacheck.pm
@@ -20,8 +20,10 @@ use bootloader_setup qw/pre_bootmenu_setup/;
 sub run {
     my $self = shift;
 
-    # handle mediacheck for usb boot
-    return if pre_bootmenu_setup == 3;
+    # handle mediacheck for usb boot if non-uefi
+    if (!get_var("UEFI")) {
+        return if pre_bootmenu_setup == 3;
+    }
 
     ensure_shim_import;
     $self->select_bootmenu_option('inst-onmediacheck', 1);


### PR DESCRIPTION
Don't need to selecting on the bootmenu if UEBBOOT+UEFI, in the uefi environment the first screen always are MOK or say OVMF can found it.

https://openqa.opensuse.org/tests/299688