### PR TITLE
Do not track reboot_gnome problem as fail for SP1

### DIFF
--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -45,8 +45,13 @@ sub run() {
             sleep 10;    # wait 10 seconds to make authentication window disappear after successful authentication
             if (check_screen 'reboot-auth', 2) {
                 record_soft_failure 'bsc#981299';
-                send_key_until_needlematch 'generic-desktop', 'esc',             7, 10;    # close timed out authentication window
-                send_key_until_needlematch 'logoutdialog',    'ctrl-alt-delete', 7, 10;    # reboot
+                send_key_until_needlematch 'generic-desktop', 'esc', 7, 10;    # close timed out authentication window
+                if (check_var('DISTRI', 'sle') && !sle_version_at_least('12-SP2')) {
+                    # retrying does not help on SP1 - once it fails, it will always fail
+                    # so just keep it as soft failure
+                    return;
+                }
+                send_key_until_needlematch 'logoutdialog', 'ctrl-alt-delete', 7, 10;    # reboot
                 assert_and_click 'logoutdialog-reboot-highlighted';
             }
         }


### PR DESCRIPTION
For SP1 maintenance we know about this bug, but especially for SLES
the realtivly low importance of this functionality is just not justifying
the extra round the review of this failure takes.

There are other options to hide this failure, but I think an explicit
work around in the openqa test is the bet one