### PR TITLE
Update 5 firefox addon related cases to fix poo#10432

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -200,16 +200,16 @@ sub load_x11regression_firefox() {
     loadtest "x11regressions/firefox/sle12/firefox_java.pm";
     loadtest "x11regressions/firefox/sle12/firefox_pagesaving.pm";
     loadtest "x11regressions/firefox/sle12/firefox_private.pm";
+    loadtest "x11regressions/firefox/sle12/firefox_mhtml.pm";
+    loadtest "x11regressions/firefox/sle12/firefox_plugins.pm";
+    loadtest "x11regressions/firefox/sle12/firefox_extensions.pm";
+    loadtest "x11regressions/firefox/sle12/firefox_appearance.pm";
+    loadtest "x11regressions/firefox/sle12/firefox_gnomeshell.pm";
     if (sle_version_at_least('12-SP2')) {    # take out these failed cases from qam test for SP1
         loadtest "x11regressions/firefox/sle12/firefox_ssl.pm";
         loadtest "x11regressions/firefox/sle12/firefox_passwd.pm";
-        loadtest "x11regressions/firefox/sle12/firefox_mhtml.pm";
-        loadtest "x11regressions/firefox/sle12/firefox_plugins.pm";
-        loadtest "x11regressions/firefox/sle12/firefox_extensions.pm";
-        loadtest "x11regressions/firefox/sle12/firefox_appearance.pm";
         loadtest "x11regressions/firefox/sle12/firefox_html5.pm";
         loadtest "x11regressions/firefox/sle12/firefox_developertool.pm";
-        loadtest "x11regressions/firefox/sle12/firefox_gnomeshell.pm";
         loadtest "x11regressions/firefox/sle12/firefox_rss.pm";
     }
     if (!get_var("OFW") && check_var('BACKEND', 'qemu')) {

--- a/tests/x11regressions/firefox/sle12/firefox_appearance.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_appearance.pm
@@ -19,6 +19,8 @@ sub run() {
     my ($self) = @_;
     $self->start_firefox;
 
+    send_key "ctrl-w";
+    wait_still_screen 3;
     send_key "ctrl-shift-a";
     assert_and_click('firefox-appearance-tabicon');
     assert_screen('firefox-appearance-default', 30);
@@ -29,10 +31,11 @@ sub run() {
     type_string "addons.mozilla.org/en-US/firefox/addon/opensuse\n";
     assert_screen('firefox-appearance-mozilla_addons', 90);
     send_key "alt-f10";
+    wait_still_screen 3;
     assert_and_click "firefox-appearance-addto";
-    sleep 1;
-    send_key "alt-a";
     assert_screen('firefox-appearance-installed', 90);
+    # Undo the theme installation
+    send_key "alt-u";
 
     # Exit
     for my $i (1 .. 2) { sleep 1; send_key "ctrl-w"; }

--- a/tests/x11regressions/firefox/sle12/firefox_extensions.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_extensions.pm
@@ -20,21 +20,22 @@ sub run() {
     $self->start_firefox;
 
     assert_screen('firefox-extensions-no_flag', 90);
+    send_key "ctrl-w";
+    wait_still_screen 3;
     send_key "ctrl-shift-a";
     assert_screen('firefox-addons_manager', 90);
 
-    for my $i (1 .. 2) { send_key "tab"; }
+    assert_and_click "firefox-searchall-addon";
     type_string "flagfox\n";
-    assert_and_click('firefox-extensions-flagfox');
-    for my $i (1 .. 2) { send_key "tab"; }
-    send_key "spc";
+    assert_and_click('firefox-extensions-flagfox', 'right');
+    assert_and_click('firefox-extensions-flagfox_install');
     assert_screen('firefox-extensions-flagfox_installed', 90);
 
     send_key "alt-1";
     assert_screen('firefox-extensions-show_flag', 60);
 
     sleep 1;
-    send_key "alt-2";
+    send_key "alt-3";
     assert_and_click('firefox-extensions-flagfox_installed');
 
     sleep 2;

--- a/tests/x11regressions/firefox/sle12/firefox_gnomeshell.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_gnomeshell.pm
@@ -21,6 +21,8 @@ sub run() {
     my ($self) = @_;
     $self->start_firefox;
 
+    send_key "ctrl-w";
+    wait_still_screen 3;
     send_key "ctrl-shift-a";
     assert_and_click('firefox-plugins-tabicon');
     assert_screen('firefox-gnomeshell-default', 30);
@@ -38,7 +40,11 @@ sub run() {
 
     send_key "alt-d";
     type_string "extensions.gnome.org/extension/512/wikipedia-search-provider/\n";
-    assert_screen("firefox-gnomeshell-extension", 90);
+    assert_screen([qw(firefox-reader-view firefox-gnomeshell-extension)], 90);
+    if (match_has_tag 'firefox-reader-view') {
+        assert_and_click('firefox-reader-close');
+        assert_screen("firefox-gnomeshell-extension");
+    }
     sleep 5;
     assert_and_click "firefox-gnomeshell-extension_install";
     assert_and_click "firefox-gnomeshell-extension_confirm";
@@ -46,8 +52,7 @@ sub run() {
     assert_screen("firefox-gnomeshell-extension_on", 60);
 
     # Exit
-    send_key "ctrl-w";
-    send_key "alt-f4";
+    $self->exit_firefox;
 
     sleep 2;
     x11_start_program("xterm");
@@ -55,11 +60,6 @@ sub run() {
     sleep 2;
     assert_screen('firefox-gnomeshell-checkdir', 30);
     type_string "rm -rf .local/share/gnome-shell/extensions/*;exit\n";
-
-    if (check_screen('firefox-save-and-quit', 30)) {
-        # confirm "save&quit"
-        send_key "ret";
-    }
 }
 1;
 # vim: set sw=4 et:

--- a/tests/x11regressions/firefox/sle12/firefox_mhtml.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_mhtml.pm
@@ -23,10 +23,12 @@ sub run() {
     # Fetch mht file to shm
     x11_start_program("wget " . autoinst_url . "/data/x11regressions/ie10.mht -O /dev/shm/ie10.mht");
 
+    send_key "ctrl-w";
+    wait_still_screen 3;
     send_key "ctrl-shift-a";
     assert_screen('firefox-addons_manager', 90);
 
-    for my $i (1 .. 2) { send_key "tab"; }
+    assert_and_click "firefox-searchall-addon";
     type_string "unmht\n";
     assert_and_click('firefox-mhtml-unmht');
     for my $i (1 .. 2) { send_key "tab"; }
@@ -40,13 +42,9 @@ sub run() {
     assert_screen('firefox-mhtml-loadpage', 60);
 
     # Exit and Clear
-    send_key "alt-f4";
+    $self->exit_firefox;
+    wait_still_screen 3;
     x11_start_program("rm /dev/shm/ie10.mht");
-
-    if (check_screen('firefox-save-and-quit', 30)) {
-        # confirm "save&quit"
-        send_key "ret";
-    }
 }
 1;
 # vim: set sw=4 et:

--- a/tests/x11regressions/firefox/sle12/firefox_plugins.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_plugins.pm
@@ -21,6 +21,8 @@ sub run() {
     my ($self) = @_;
     $self->start_firefox;
 
+    send_key "ctrl-w";
+    wait_still_screen 3;
     send_key "ctrl-shift-a";
     assert_and_click('firefox-addons-plugins');
     assert_screen('firefox-plugins-overview_01', 60);


### PR DESCRIPTION
Firefox has been updated to 45.4, the steps to open about:addons page
has changed. In this commit I improved 5 related cases and brought
them back to qam test:
- firefox_appearance.pm
- firefox_appearance.pm
- firefox_gnomeshell.pm
- firefox_mhtml.pm
- firefox_plugins.pm

  see also: poo#10432

needles on gitlab: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/246

validation on SP2: http://147.2.212.239/tests/914

validation on SP1: http://147.2.212.239/tests/921