### PR TITLE
Restore code for KEEPHDDS and LINUXRC variables

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -897,8 +897,14 @@ sub load_slenkins_tests {
 
 # load the tests in the right order
 if (get_var("REGRESSION")) {
-    load_inst_tests();
-    load_reboot_tests();
+    if (get_var("KEEPHDDS")) {
+        load_login_tests();
+    }
+    else {
+        load_inst_tests();
+        load_reboot_tests();
+    }
+
     load_x11regresion_tests();
 }
 elsif (get_var("MEDIACHECK")) {
@@ -910,6 +916,9 @@ elsif (get_var("MEMTEST")) {
 elsif (get_var("RESCUESYSTEM")) {
     loadtest "installation/rescuesystem.pm";
     loadtest "installation/rescuesystem_validate_131.pm";
+}
+elsif (get_var("LINUXRC")) {
+    loadtest "linuxrc/system_boot.pm";
 }
 elsif (get_var("SUPPORT_SERVER")) {
     loadtest "support_server/boot.pm";

--- a/tests/linuxrc/system_boot.pm
+++ b/tests/linuxrc/system_boot.pm
@@ -1,0 +1,46 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Added Linuxrc test for booting the installed system
+#  - bsc#906990
+#  - poo#10654
+# Maintainer: Lukas Ocilka <lukas.ocilka@gmail.com>
+
+use strict;
+use base "y2logsstep";
+use testapi;
+use linuxrc;
+
+sub run() {
+    my $self = shift;
+
+    $self->linuxrc::wait_for_bootmenu();
+
+    $self->linuxrc::boot_with_parameters("SystemBoot=1");
+    assert_screen("linuxrc-system_boot-select-a-system-to-boot", 60);
+
+    # Press [Enter] till the last dialog for booting appears
+    send_key_until_needlematch "linuxrc-system-boot-kernel-options", "ret", 8;
+
+    # Confirm booting
+    diag "Booting the installed system now...";
+    send_key "ret", 0;
+
+    # Wait for the system to boot
+    assert_screen("displaymanager", 60);
+}
+
+sub test_flags() {
+    return {fatal => 1, milestone => 1};
+}
+
+1;
+
+# vim: set sw=4 et:


### PR DESCRIPTION
KEEPHDDS is debugging variable (currently unused)
LINUXRC belongs to WIP - poo#10654