### PR TITLE
Proper handling of hdds, additional repos in SUTs and import parser for SLEnkins suites

### DIFF
--- a/script/import-slenkins-testsuite.pl
+++ b/script/import-slenkins-testsuite.pl
@@ -62,7 +62,7 @@ sub parse_node_file {
         if ($line =~ /^node\s+([^\s]+)$/) {
             $node    = $1;
             $network = undef;
-            $nodes{$node} = {install => []};
+            $nodes{$node} = {install => [], repos => [], disks => []};
         }
         elsif ($line =~ /^network\s+([^\s]+)$/) {
             $network            = $1;
@@ -83,6 +83,15 @@ sub parse_node_file {
             my ($param, $value) = split(/\s+/, $line);
             $value = 0 if $value eq 'no';
             $networks{$network}->{$param} = $value if defined $network;
+        }
+        elsif ($line =~ /(^repository|^repo)\s+(http.*\.repo)$/) {
+            my @repo = split(/\s+/, $line);
+            shift @repo;
+            push @{$nodes{$node}->{repos}}, @repo if defined $node;
+        }
+        elsif ($line =~ /^disk\s+([^\s]+)$/) {
+            # Stores size info about each additional drive but it's not used yet
+            push @{$nodes{$node}->{disks}}, $1 if defined $node;
         }
         elsif ($line =~ /^\s*#/) {
             #nothing to do
@@ -106,7 +115,7 @@ sub gen_testsuites {
         push @suites,
           {
             name     => "slenkins-${project_name}-${node}",
-            settings => [eval $template_node, {key => "SLENKINS_NODE", value => "$node"}, {key => "SLENKINS_INSTALL", value => join(',', sort @{$nodes->{$node}{install}})}, {key => "NETWORKS", value => join(',', @node_net)},],
+            settings => [eval $template_node, {key => "SLENKINS_NODE", value => "$node"}, {key => "SLENKINS_INSTALL", value => join(',', sort @{$nodes->{$node}{install}})}, {key => "NETWORKS", value => join(',', @node_net)}, {key => "FOREIGN_REPOS", value => join(',', sort @{$nodes->{$node}{repos}})}, {key => "NUMDISKS", value => 1+scalar(@{$nodes->{$node}{disks}})},],
           };
     }
 

--- a/tests/slenkins/slenkins_control.pm
+++ b/tests/slenkins/slenkins_control.pm
@@ -13,8 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# G-Summary: slenkins support
-# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+# Summary: slenkins support
+# Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
 
 use strict;
 use base 'basetest';
@@ -113,8 +113,10 @@ sub run {
         my $disk_size = $settings{$p}->{HDDSIZEGB} || 10;
         my $num_disks = $settings{$p}->{NUMDISKS}  || 1;
 
-        for (my $d = 0; $d < $num_disks; $d++) {
-            $conf .= "export DISK_NAME_" . uc($node) . "_DISK$d='/dev/$disk_name" . chr(ord('a') + $d) . "'\n";
+        # In SLEnkins DISK_NAME_NODE_DISK0 is used for first additional disk /dev/vdb and so on
+        # Drive /dev/vda is always in use as bootdrive and has no dedicated variable
+        for (my $d = 0; $d < ($num_disks - 1); $d++) {
+            $conf .= "export DISK_NAME_" . uc($node) . "_DISK$d='/dev/$disk_name" . chr(ord('b') + $d) . "'\n";
             $conf .= "export DISK_SIZE_" . uc($node) . "_DISK$d='${disk_size}G'\n";
         }
         $i++;

--- a/tests/slenkins/slenkins_node.pm
+++ b/tests/slenkins/slenkins_node.pm
@@ -13,8 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# G-Summary: slenkins support
-# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+# Summary: slenkins support
+# Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
 
 use strict;
 use base 'basetest';
@@ -59,6 +59,13 @@ sub run {
 
     my $conf_script = "zypper -n --no-gpg-checks ar '" . get_var('SLENKINS_TESTSUITES_REPO') . "' slenkins_testsuites\n";
 
+    # Uses full URI with .repo extension, multiple repos separated by colon is supported
+    if (get_var('FOREIGN_REPOS')) {
+        foreach (split(/[\s,]+/, get_var('FOREIGN_REPOS'))) {
+            $conf_script .= "zypper -n --no-gpg-checks ar '" . $_ . "'\n";
+        }
+    }
+
     if (get_var('SLENKINS_INSTALL')) {
         $conf_script .= "zypper -n --no-gpg-checks in " . join(' ', split(/[\s,]+/, get_var('SLENKINS_INSTALL'))) . "\n";
     }
@@ -74,7 +81,8 @@ sub run {
         chmod 700 /root/.ssh
         chmod 600 /home/testuser/.ssh/*
         chmod 700 /home/testuser/.ssh
-        rcSuSEfirewall2 stop
+        systemctl disable SuSEfirewall2
+        systemctl stop SuSEfirewall2
         rcsshd restart
     ";
     script_output($conf_script, 100);


### PR DESCRIPTION
Changes for SLEnkins suites in openQA - needed mainly for new systemd suite.

* Proper numbering and names for drives in DISK_NAME_$node_DISK$d variable according to SLEnkins scripts.
* Introduced new variable FOREIGN_REPOS for repos with .repo extension in nodes file
* Firewall stopped and disabled by systemctl
* Script import-slenkins-testuite.pl is now able parse "repo" lines with .repo extension and "disk" lines in nodes