### PR TITLE
Proper hdds numbering, additional repos in SUTs and modified import parser for SLEnkins poo#14534

### DIFF
--- a/tests/slenkins/slenkins_control.pm
+++ b/tests/slenkins/slenkins_control.pm
@@ -13,8 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# G-Summary: slenkins support
-# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+# Summary: slenkins support
+# Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
 
 use strict;
 use base 'basetest';
@@ -113,8 +113,10 @@ sub run {
         my $disk_size = $settings{$p}->{HDDSIZEGB} || 10;
         my $num_disks = $settings{$p}->{NUMDISKS}  || 1;
 
-        for (my $d = 0; $d < $num_disks; $d++) {
-            $conf .= "export DISK_NAME_" . uc($node) . "_DISK$d='/dev/$disk_name" . chr(ord('a') + $d) . "'\n";
+        # In SLEnkins DISK_NAME_NODE_DISK0 is used for first additional disk /dev/vdb and so on
+        # Drive /dev/vda is always in use as bootdrive and has no dedicated variable
+        for (my $d = 0; $d < ($num_disks - 1); $d++) {
+            $conf .= "export DISK_NAME_" . uc($node) . "_DISK$d='/dev/$disk_name" . chr(ord('b') + $d) . "'\n";
             $conf .= "export DISK_SIZE_" . uc($node) . "_DISK$d='${disk_size}G'\n";
         }
         $i++;

--- a/tests/slenkins/slenkins_node.pm
+++ b/tests/slenkins/slenkins_node.pm
@@ -13,8 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# G-Summary: slenkins support
-# G-Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
+# Summary: slenkins support
+# Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
 
 use strict;
 use base 'basetest';
@@ -59,6 +59,13 @@ sub run {
 
     my $conf_script = "zypper -n --no-gpg-checks ar '" . get_var('SLENKINS_TESTSUITES_REPO') . "' slenkins_testsuites\n";
 
+    # Uses full URI with .repo extension, multiple repos separated by colon is supported
+    if (get_var('FOREIGN_REPOS')) {
+        foreach (split(/[\s,]+/, get_var('FOREIGN_REPOS'))) {
+            $conf_script .= "zypper -n --no-gpg-checks ar '" . $_ . "'\n";
+        }
+    }
+
     if (get_var('SLENKINS_INSTALL')) {
         $conf_script .= "zypper -n --no-gpg-checks in " . join(' ', split(/[\s,]+/, get_var('SLENKINS_INSTALL'))) . "\n";
     }
@@ -74,7 +81,8 @@ sub run {
         chmod 700 /root/.ssh
         chmod 600 /home/testuser/.ssh/*
         chmod 700 /home/testuser/.ssh
-        rcSuSEfirewall2 stop
+        systemctl disable SuSEfirewall2
+        systemctl stop SuSEfirewall2
         rcsshd restart
     ";
     script_output($conf_script, 100);


### PR DESCRIPTION
Changes for SLEnkins suites in openQA - needed mainly for new systemd suite:
* Proper numbering and names for drives in DISK_NAME_$node_DISK$d variable according to SLEnkins scripts.
* Introduced new variable FOREIGN_REPOS for repos with .repo extension in nodes file
* Firewall stopped and disabled by systemctl
* Script import-slenkins-testuite.pl is now able to parse "repository/repo" lines with .repo extension as well as "disk" lines in nodes file