### PR TITLE
Update firefox_rss, firefox_html5 and firefox_passwd to fix poo#10432

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -209,12 +209,12 @@ sub load_x11regression_firefox() {
     loadtest "x11regressions/firefox/sle12/firefox_extensions.pm";
     loadtest "x11regressions/firefox/sle12/firefox_appearance.pm";
     loadtest "x11regressions/firefox/sle12/firefox_gnomeshell.pm";
+    loadtest "x11regressions/firefox/sle12/firefox_passwd.pm";
+    loadtest "x11regressions/firefox/sle12/firefox_html5.pm";
+    loadtest "x11regressions/firefox/sle12/firefox_developertool.pm";
+    loadtest "x11regressions/firefox/sle12/firefox_rss.pm";
     if (sle_version_at_least('12-SP2')) {    # take out these failed cases from qam test for SP1
         loadtest "x11regressions/firefox/sle12/firefox_ssl.pm";
-        loadtest "x11regressions/firefox/sle12/firefox_passwd.pm";
-        loadtest "x11regressions/firefox/sle12/firefox_html5.pm";
-        loadtest "x11regressions/firefox/sle12/firefox_developertool.pm";
-        loadtest "x11regressions/firefox/sle12/firefox_rss.pm";
     }
     if (!get_var("OFW") && check_var('BACKEND', 'qemu')) {
         loadtest "x11/firefox_audio.pm";

--- a/tests/x11regressions/firefox/sle12/firefox_html5.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_html5.pm
@@ -28,12 +28,6 @@ sub run() {
     send_key "up";
     sleep 1;
     assert_screen('firefox-html5-support', 60);
-    assert_and_click('firefox-html5-request');
-
-    assert_screen('firefox-html5-youtube', 60);
-    send_key "pgdn";
-    send_key "up";
-    assert_screen('firefox-html5-enabled', 30);
 
     sleep 1;
     send_key "esc";
@@ -42,12 +36,7 @@ sub run() {
     assert_screen('firefox-flashplayer-video_loaded', 90);
 
     # Exit
-    send_key "alt-f4";
-
-    if (check_screen('firefox-save-and-quit', 30)) {
-        # confirm "save&quit"
-        send_key "ret";
-    }
+    $self->exit_firefox;
 }
 1;
 # vim: set sw=4 et:

--- a/tests/x11regressions/firefox/sle12/firefox_passwd.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_passwd.pm
@@ -24,12 +24,11 @@ sub run() {
     my $mozlogin = "http://www-archive.mozilla.org/quality/browser/front-end/testcases/wallet/login.html";
 
     # Clean and Start Firefox
-    x11_start_program("xterm -e \"killall -9 firefox;rm -rf .moz*\"\n");
-    x11_start_program("firefox");
-    assert_screen('firefox-gnome', 90);
+    $self->start_firefox;
 
     sleep 2;
     send_key "alt-e";
+    wait_still_screen 3;
     send_key "n";
     assert_and_click('firefox-passwd-security');
 
@@ -82,25 +81,23 @@ sub run() {
     sleep 1;
     type_string $masterpw. "\n";
     sleep 1;
+    send_key "alt-shift-l";
     assert_screen('firefox-passwd-saved', 30);
 
     sleep 1;
-    send_key "alt-shift-r";    #"Remove"
+    send_key "alt-shift-a";    #"Remove"
+    wait_still_screen 3;
+    send_key "alt-y";
     sleep 1;
     send_key "alt-shift-c";
     sleep 1;
     send_key "ctrl-w";
     sleep 1;
     send_key "f5";
-    assert_screen('firefox-passwd-input_username', 90);
+    assert_screen('firefox-passwd-removed', 60);
 
     # Exit
-    send_key "alt-f4";
-
-    if (check_screen('firefox-save-and-quit', 30)) {
-        # confirm "save&quit"
-        send_key "ret";
-    }
+    $self->exit_firefox;
 }
 1;
 # vim: set sw=4 et:

--- a/tests/x11regressions/firefox/sle12/firefox_rss.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_rss.pm
@@ -19,34 +19,30 @@ sub run() {
     my ($self) = @_;
     $self->start_firefox;
 
-
     send_key "alt-v", 1;
+    wait_still_screen 3;
     send_key "t";
+    wait_still_screen 3;
     send_key "c";
 
     assert_and_click "firefox-rss-close_hint";
-    assert_and_click "firefox-click-scrollbar";
+    send_key "alt-f10";
+    wait_still_screen 3;
     assert_and_click("firefox-rss-button", "right");
 
     send_key "a";
     send_key "ctrl-w";
-    send_key "alt-f10";
     assert_screen("firefox-rss-button_disabled", 60);
 
     send_key "esc";
     send_key "alt-d";
-    type_string "www.gnu.org\n";
+    type_string "https://linux.slashdot.org/\n";
 
     assert_and_click "firefox-rss-button_enabled", "left", 30;
-    assert_screen("firefox-rss-page", 90);
+    assert_screen("firefox-rss-page", 60);
 
     # Exit
-    send_key "alt-f4";
-
-    if (check_screen('firefox-save-and-quit', 30)) {
-        # confirm "save&quit"
-        send_key "ret";
-    }
+    $self->exit_firefox;
 }
 1;
 # vim: set sw=4 et:


### PR DESCRIPTION
- firefox_html5.pm
  Firefox has been updated to 45.4 which has set the html5 player as
  default. It's unnecessary to request it as default any more.
- firefox_rss.pm
  Optimize the steps and change the testing url to slashdot since it's
  loading speed is more quick.
- firefox_passwd.pm
  Update the steps according to the new version
- Switch to use the firefox starting and quit functions
- Bring back these cases to qam test:
  firefox_passwd.pm
  firefox_rss.pm
  firefox_html5.pm
  firefox_developertool.pm

  see also: poo#10432

validation on SP2: http://147.2.212.239/tests/935

validation on SP1: http://147.2.212.239/tests/937