### PR TITLE
Fix scc_register for wsm addon

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -123,6 +123,11 @@ sub fill_in_registration_data {
                     send_key "spc";
                 }
                 else {
+                    # move the later modules into screen. for this the variable
+                    # needs to be sorted
+                    if (!check_screen("scc-module-$addon", 0)) {
+                        send_key 'down';
+                    }
                     assert_and_click "scc-module-$addon";
                 }
             }


### PR DESCRIPTION
SP2 has just too many modules - so we need to scroll.

Fixing https://openqa.suse.de/tests/632008#step/scc_registration/10