### PR TITLE
virt-autotest : Add proxymode support for using physical machine

### DIFF
--- a/lib/proxymode.pm
+++ b/lib/proxymode.pm
@@ -1,0 +1,131 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+package proxymode;
+# Summary: proxymode: The basic lib for using proxy mode to connect or operation with physical machine
+# Maintainer: John <xgwang@suse.com>
+
+use base 'basetest';
+use testapi;
+use strict;
+
+our $SLAVE_SERIALDEV = 'proxyserial';
+
+sub switch_power {
+    my ($ipmi_machine, $ipmi_user, $ipmi_pass, $ipmi_status) = @_;
+    $ipmi_pass   //= 'ADMIN';
+    $ipmi_user   //= 'ADMIN';
+    $ipmi_status //= 'off';
+    die "Variable ipmi_machine is invalid in function restart_host!" unless $ipmi_machine;
+    my $ipmitool = "ipmitool -H " . $ipmi_machine . " -U " . $ipmi_user . " -P " . $ipmi_pass . " -I lanplus ";
+    script_run($ipmitool . 'chassis power ' . $ipmi_status, 20);
+    while (1) {
+        my $stdout = script_output($ipmitool . 'chassis power status', 20);
+        last if $stdout =~ m/is $ipmi_status/;
+        die "Failure on running IPMITOOL:" . $stdout if $stdout =~ m/Error/;
+        script_run($ipmitool . 'chassis power ' . $ipmi_status, 20);
+        sleep(2);
+    }
+}
+
+sub restart_host {
+    my ($self, $ipmi_machine, $ipmi_user, $ipmi_pass) = @_;
+    select_console 'log-console';
+    switch_power($ipmi_machine, $ipmi_user, $ipmi_pass, 'off');
+    switch_power($ipmi_machine, $ipmi_user, $ipmi_pass, 'on');
+    wait_idle 10;
+    save_screenshot;
+    select_console 'root-console';
+}
+
+sub connect_slave {
+    my ($self, $ipmi_machine, $ipmi_user, $ipmi_pass) = @_;
+    $ipmi_user //= 'ADMIN';
+    $ipmi_pass //= 'ADMIN';
+    die "Variable ipmi_machine is invalid in function connect_slave!" unless $ipmi_machine;
+    script_run("clear");
+    type_string("ipmitool -H " . $ipmi_machine . " -U " . $ipmi_user . " -P " . $ipmi_pass . " -I lanplus sol activate", 20);
+    send_key 'ret';
+    send_key 'ret';
+    save_screenshot;
+}
+
+sub check_prompt_for_boot {
+    my ($self, $timeout) = @_;
+    $timeout //= 5000;
+    assert_screen("autoyast-system-login-console", $timeout);
+    type_string "root\n";
+    wait_still_screen(2);
+    type_password;
+    send_key "ret";
+    assert_screen("text-logged-in-root");
+    type_string("clear;ip a\n");
+}
+
+sub save_org_serialdev {
+    if (!get_var("PROXY_SERIALDEV")) {
+        set_var("PROXY_SERIALDEV", $serialdev);
+    }
+}
+
+sub get_org_serialdev {
+    return get_var("PROXY_SERIALDEV", "ttyS0");
+}
+
+sub resume_org_serialdev {
+    $serialdev = get_org_serialdev();
+}
+
+sub set_serialdev {
+    $serialdev = $SLAVE_SERIALDEV;
+}
+
+sub start_nc_on_slave {
+    my ($self) = @_;
+    # Create nc connection on root console
+    type_string "mkfifo /dev/$SLAVE_SERIALDEV\n";
+    sleep 2;
+    type_string "tail -f /dev/$SLAVE_SERIALDEV | nc -l 1234 &\n";
+    save_screenshot;
+    save_org_serialdev();
+}
+
+sub con_nc_on_proxy {
+    my ($self, $test_machine, $console) = @_;
+    wait_still_screen(2);
+    send_key "ctrl-c";
+    send_key "ctrl-c";
+
+    my $proxy_serialdev = get_var("PROXY_SERIALDEV", "ttyS0");
+
+    type_string "nc ${test_machine} 1234 |tee /dev/" . $proxy_serialdev . "\n";
+    sleep 3;
+    save_screenshot;
+}
+
+sub reset_curr_serialdev {
+    my ($self) = @_;
+    set_serialdev();
+    my $pattern = 'NC_CONNECTION_TEST-' . int(rand(999999));
+    type_string "echo $pattern |tee /dev/$serialdev\n";
+    die "Failed to build the connection between slave machine and proxy machine!" unless wait_serial($pattern, 10);
+    save_screenshot;
+}
+
+sub redirect_serial {
+    my ($self, $test_machine) = @_;
+    die "The variable test_machine should not be empty!" unless $test_machine;
+    $self->start_nc_on_slave();
+    select_console 'log-console';
+    $self->con_nc_on_proxy($test_machine);
+    select_console "root-console";
+    $self->reset_curr_serialdev();
+}
+1;
+

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1082,16 +1082,33 @@ elsif (get_var("QA_TESTSET")) {
     loadtest "qa_automation/" . get_var("QA_TESTSET");
 }
 elsif (get_var("VIRT_AUTOTEST")) {
-    load_boot_tests();
-    load_inst_tests();
-    loadtest "virt_autotest/login_console";
-    if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
+    if (get_var("PROXY_MODE")) {
+        loadtest "virt_autotest/proxymode_login_proxy";
+        loadtest "virt_autotest/proxymode_init_pxe_install";
+        loadtest "virt_autotest/proxymode_redirect_serial1";
+        loadtest "virt_autotest/install_package";
+        if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
+            loadtest "virt_autotest/setup_console_on_host";
+            loadtest "virt_autotest/reboot_and_wait_up_normal1";
+            loadtest "virt_autotest/proxymode_redirect_serial2";
+        }
+        loadtest "virt_autotest/update_package";
         loadtest "virt_autotest/setup_console_on_host1";
-        loadtest "virt_autotest/reboot_and_wait_up_normal1";
+        loadtest "virt_autotest/reboot_and_wait_up_normal2";
+        loadtest "virt_autotest/proxymode_redirect_serial3";
     }
-    loadtest "virt_autotest/install_package";
-    loadtest "virt_autotest/reboot_and_wait_up_normal2";
-
+    else {
+        load_boot_tests();
+        load_inst_tests();
+        loadtest "virt_autotest/login_console";
+        if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
+            loadtest "virt_autotest/setup_console_on_host1";
+            loadtest "virt_autotest/reboot_and_wait_up_normal1";
+        }
+        loadtest "virt_autotest/install_package";
+        loadtest "virt_autotest/update_package";
+        loadtest "virt_autotest/reboot_and_wait_up_normal2";
+    }
     if (get_var("VIRT_PRJ1_GUEST_INSTALL")) {
         loadtest "virt_autotest/guest_installation_run";
     }

--- a/tests/virt_autotest/host_upgrade_base.pm
+++ b/tests/virt_autotest/host_upgrade_base.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 #
 package host_upgrade_base;
-# Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# Summary: host_upgrade_base: Geting prefix part of command line for running case host upgrade project.
 # Maintainer: alice <xlai@suse.com>
 
 use strict;

--- a/tests/virt_autotest/host_upgrade_step3_run.pm
+++ b/tests/virt_autotest/host_upgrade_step3_run.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-# Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm and xen support fully
+# Summary: host_upgrade_step3_run : Get the second stage script name for host upgrade test.
 #          This test verifies virtualization host upgrade test result.
 # Maintainer: alice <xlai@suse.com>
 

--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -12,10 +12,8 @@
 
 use strict;
 use warnings;
-use File::Basename;
 use base "virt_autotest_base";
 use testapi;
-use virt_utils;
 
 sub install_package() {
     my $qa_server_repo = get_var('QA_HEAD_REPO', '');
@@ -26,51 +24,24 @@ sub install_package() {
     else {
         die "There is no qa server repo defined variable QA_HEAD_REPO\n";
     }
+    assert_script_run("zypper --non-interactive --gpg-auto-import-keys ref", 180);
 
-    assert_script_run("zypper --non-interactive --gpg-auto-import-keys ref", 90);
-    assert_script_run("zypper --non-interactive -n in qa_lib_virtauto",      1800);
+    assert_script_run("zypper --non-interactive -n in qa_lib_virtauto", 1800);
+
+    if (get_var("PROXY_MODE")) {
+        if (get_var("XEN")) {
+            assert_script_run("zypper --non-interactive -n in -t pattern xen_server", 1800);
+        }
+    }
 }
-
-sub update_package() {
-    my $self           = shift;
-    my $test_type      = get_var('TEST_TYPE', 'Milestone');
-    my $update_pkg_cmd = "source /usr/share/qa/virtautolib/lib/virtlib;update_virt_rpms";
-    if ($test_type eq 'Milestone') {
-        $update_pkg_cmd = $update_pkg_cmd . " off on off";
-    }
-    else {
-        $update_pkg_cmd = $update_pkg_cmd . " off off on";
-    }
-
-    $update_pkg_cmd = $update_pkg_cmd . " 2>&1 | tee /tmp/update_virt_rpms.log ";
-
-    my $ret = $self->execute_script_run($update_pkg_cmd, 7200);
-    save_screenshot;
-
-    upload_logs("/tmp/update_virt_rpms.log");
-
-    if ($ret !~ /Need to reboot system to make the rpms work/m) {
-        die " Update virt rpms fail, going to terminate following test!";
-    }
-
-}
-
 
 sub run() {
-    my $self = shift;
-
     install_package;
-
-    $self->update_package();
-
-    setup_console_in_grub;
-
-    repl_repo_in_sourcefile();
 }
 
 
 sub test_flags {
-    return {important => 1};
+    return {fatal => 1};
 }
 
 1;

--- a/tests/virt_autotest/proxymode_conn_slave.pm
+++ b/tests/virt_autotest/proxymode_conn_slave.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: proxymode_conn_slave: Connect physical machine through proxy machine.
+# Maintainer: John <xgwang@suse.com>
+
+use strict;
+use warnings;
+use testapi;
+use base "proxymode";
+
+sub run() {
+    my $self         = shift;
+    my $ipmi_machine = get_var("IPMI_HOSTNAME");
+    die "There is no ipmi ip address defined variable IPMI_HOSTNAME" unless $ipmi_machine;
+    $self->connect_slave($ipmi_machine);
+    $self->restart_host($ipmi_machine);
+    assert_screen "proxy_virttest-pxe", 600;
+    send_key 'ret';
+    $self->check_prompt_for_boot();
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+

--- a/tests/virt_autotest/proxymode_init_pxe_install.pm
+++ b/tests/virt_autotest/proxymode_init_pxe_install.pm
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: proxymode_init_pxe_install: Initialize pxe and start to install special product
+# Maintainer: John <xgwang@suse.com>
+
+use strict;
+use warnings;
+use testapi;
+use base "proxymode";
+
+sub run() {
+    my $self         = shift;
+    my $ipmi_machine = get_var("IPMI_HOSTNAME");
+    my $autoyast     = get_var("AUTOYAST_FILE");
+    my $image_path   = get_var("HOST_IMG_URL");
+
+    die "There is no ipmi ip address defined variable IPMI_HOSTNAME"       unless $ipmi_machine;
+    die "There is no re-install product cmd defined variable HOST_IMG_URL" unless $image_path;
+    die "There is no autoyase file defined variable AUTOYAST_FILE"         unless $autoyast;
+    ## Login to command line of pxe management
+    $self->connect_slave($ipmi_machine);
+    $self->restart_host($ipmi_machine);
+    assert_screen "proxy_virttest-pxe", 300;
+    wait_idle 3;
+    send_key_until_needlematch "proxy_virttest-pxe-edit-prompt", "esc", 10, 5;
+    wait_still_screen 5;
+    # Execute installation command on pxe management cmd console
+    my $type_speed = 20;
+    type_string ${image_path} . " ", $type_speed;
+    type_string "console=ttyS1,115200 ", $type_speed;
+    type_string "console=tty ",          $type_speed;
+    type_string "autoyast=" . $autoyast, $type_speed;
+    wait_still_screen 5;
+    send_key 'ret';
+    save_screenshot;
+    $self->check_prompt_for_boot();
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+

--- a/tests/virt_autotest/proxymode_login_proxy.pm
+++ b/tests/virt_autotest/proxymode_login_proxy.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: proxymode_login_proxy: Login to Physical machine thru Proxy machine with ipmitool.
+# Maintainer: John <xgwang@suse.com>
+
+use strict;
+use warnings;
+use File::Basename;
+use base "opensusebasetest";
+use testapi;
+
+sub run() {
+    assert_screen "bootloader";
+    send_key "ret";
+    assert_screen "grub2", 10;
+    send_key "ret";
+    assert_screen "displaymanager", 300;
+    select_console('root-console');
+    sleep 2;
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+

--- a/tests/virt_autotest/proxymode_redirect_serial1.pm
+++ b/tests/virt_autotest/proxymode_redirect_serial1.pm
@@ -1,0 +1,27 @@
+## SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: proxymode_redirect_serial1: Setup a channel which redirects Physical machine serial output to Proxy machine standard output.
+# Maintainer: John <xgwang@suse.com>
+
+use strict;
+use testapi;
+use base "proxymode";
+sub run {
+    my $self         = shift;
+    my $test_machine = get_var("TEST_MACHINE");
+    $self->redirect_serial($test_machine);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+

--- a/tests/virt_autotest/proxymode_redirect_serial2.pm
+++ b/tests/virt_autotest/proxymode_redirect_serial2.pm
@@ -1,0 +1,27 @@
+## SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: proxymode_redirect_serial2: Setup a channel which redirects Physical machine serial output to Proxy machine standard output.
+# Maintainer: John <xgwang@suse.com>
+
+use strict;
+use testapi;
+use base "proxymode";
+sub run {
+    my $self         = shift;
+    my $test_machine = get_var("TEST_MACHINE");
+    $self->redirect_serial($test_machine);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+

--- a/tests/virt_autotest/proxymode_redirect_serial3.pm
+++ b/tests/virt_autotest/proxymode_redirect_serial3.pm
@@ -1,0 +1,27 @@
+## SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: proxymode_redirect_serial3: Setup a channel which redirects Physical machine serial output to Proxy machine standard output.
+# Maintainer: John <xgwang@suse.com>
+
+use strict;
+use testapi;
+use base "proxymode";
+sub run {
+    my $self         = shift;
+    my $test_machine = get_var("TEST_MACHINE");
+    $self->redirect_serial($test_machine);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+

--- a/tests/virt_autotest/reboot_and_wait_up_normal1.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_normal1.pm
@@ -12,18 +12,17 @@
 
 use strict;
 use warnings;
-use File::Basename;
 use testapi;
 use base "reboot_and_wait_up";
 
 sub run() {
     my $self    = shift;
-    my $timeout = 300;
+    my $timeout = 600;
     $self->reboot_and_wait_up($timeout);
 }
 
 sub test_flags {
-    return {important => 1};
+    return {fatal => 1};
 }
 
 1;

--- a/tests/virt_autotest/reboot_and_wait_up_normal2.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_normal2.pm
@@ -12,18 +12,17 @@
 
 use strict;
 use warnings;
-use File::Basename;
 use testapi;
 use base "reboot_and_wait_up";
 
 sub run() {
     my $self    = shift;
-    my $timeout = 300;
+    my $timeout = 600;
     $self->reboot_and_wait_up($timeout);
 }
 
 sub test_flags {
-    return {important => 1};
+    return {fatal => 1};
 }
 
 1;

--- a/tests/virt_autotest/reboot_and_wait_up_normal3.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_normal3.pm
@@ -12,18 +12,17 @@
 
 use strict;
 use warnings;
-use File::Basename;
 use testapi;
 use base "reboot_and_wait_up";
 
 sub run() {
     my $self    = shift;
-    my $timeout = 300;
+    my $timeout = 600;
     $self->reboot_and_wait_up($timeout);
 }
 
 sub test_flags {
-    return {important => 1};
+    return {fatal => 1};
 }
 
 1;

--- a/tests/virt_autotest/setup_console_on_host.pm
+++ b/tests/virt_autotest/setup_console_on_host.pm
@@ -1,19 +1,18 @@
-# Summary: virtualization initial xen support (#1575)
-# Maintainer: xiao li ai <xlai@suse.com>
+# Summary: setup_console_on_host: Re-set serial port and update serial info to kernel option.
+# Maintainer: alice <xlai@suse.com>
 
 use strict;
 use warnings;
-use base "opensusebasetest";
+use base "proxymode";
 use testapi;
 use virt_utils;
 
 sub run() {
-    set_serialdev;
-    setup_console_in_grub;
+    resetup_console();
 }
 
 sub test_flags {
-    return {important => 1};
+    return {fatal => 1};
 }
 
 1;

--- a/tests/virt_autotest/setup_console_on_host1.pm
+++ b/tests/virt_autotest/setup_console_on_host1.pm
@@ -1,19 +1,19 @@
-# Summary: virtualization: modification for adding prj2 host upgrade xen case
+# Summary: setup_console_on_host1: Re-set serial port and update serial info to kernel option.
 # Maintainer: alice <xlai@suse.com>
 
 use strict;
 use warnings;
-use base "opensusebasetest";
+use base "proxymode";
 use testapi;
 use virt_utils;
 
 sub run() {
-    set_serialdev;
-    setup_console_in_grub;
+    my $self = shift;
+    resetup_console();
 }
 
 sub test_flags {
-    return {important => 1};
+    return {fatal => 1};
 }
 
 1;

--- a/tests/virt_autotest/setup_console_on_host2.pm
+++ b/tests/virt_autotest/setup_console_on_host2.pm
@@ -1,19 +1,19 @@
-# Summary: virtualization: modification for adding prj2 host upgrade xen case
+# Summary: setup_console_on_host2: Re-set serial port and update serial info to kernel option.
 # Maintainer: alice <xlai@suse.com>
 
 use strict;
 use warnings;
-use base "opensusebasetest";
+use base "proxymode";
 use testapi;
 use virt_utils;
 
 sub run() {
-    set_serialdev;
-    setup_console_in_grub;
+    my $self = shift;
+    resetup_console();
 }
 
 sub test_flags {
-    return {important => 1};
+    return {fatal => 1};
 }
 
 1;

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -1,0 +1,57 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+package update_package;
+# Summary: update_package: Update all packages and use real repo as guest installation source before test.
+# Maintainer: John <xgwang@suse.com>
+
+use strict;
+use warnings;
+use testapi;
+use base "virt_autotest_base";
+use virt_utils;
+
+sub update_package() {
+    my $self           = shift;
+    my $test_type      = get_var('TEST_TYPE', 'Milestone');
+    my $update_pkg_cmd = "source /usr/share/qa/virtautolib/lib/virtlib;update_virt_rpms";
+    my $ret;
+    if ($test_type eq 'Milestone') {
+        $update_pkg_cmd = $update_pkg_cmd . " off on off";
+    }
+    else {
+        $update_pkg_cmd = $update_pkg_cmd . " off off on";
+    }
+
+    $update_pkg_cmd = $update_pkg_cmd . " 2>&1 | tee /tmp/update_virt_rpms.log ";
+    $ret = $self->execute_script_run($update_pkg_cmd, 7200);
+    upload_logs("/tmp/update_virt_rpms.log");
+    save_screenshot;
+    if ($ret !~ /Need to reboot system to make the rpms work/m) {
+        die " Update virt rpms fail, going to terminate following test!";
+    }
+
+}
+
+sub run() {
+    my $self = shift;
+    $self->update_package();
+    if (!get_var("PROXY_MODE")) {
+        setup_console_in_grub();
+    }
+    repl_repo_in_sourcefile();
+}
+
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+


### PR DESCRIPTION
*Existing Issue:
- The ipmi mode only support SUPERMICRO machine with ikvm firmware.
- The ipmi mode now is not very stable.

*Goal:
- Create a new mode which can support more various physical machine with ipmi , not only supermicro machine.
- Add the proxy mode as extension or backup of ipmi mode for using physical machine to do test.

*Terms:
- Proxy machine : The machine is qemu vm which is created by openqa
- Slave machine : The physical machine.

*Policy:
- Using proxy machine as a agency to control physical machine to finish test

*Problems:
- Comparing with ipmi mode , we need to solve following problems.
1.Using proxy to connect/control slave machine
2.Redirect serial port from slave machine to proxy machine.

*Solution:
- Problem 1: Using ipmitoll as interactive medium to connect slave machine.
- Problem 2: Using *nc to redirect special file descriptor of slave machine to standard serial port of proxy machine, make all output in slave machine be redirected to serial port of proxy machine.

*Usage:
- use proxymode_login_proxy.pm to login to proxy machine
- use proxymode_conn_slave.pm to connect to slave machine (take ipmitool as communication medium)
- use proxymode_redirect_serial1.pm to redirect #serial port from slave to proxy machine. (Create nc between slave and proxy)

*Sample:
- I finished guest installation test of virtualization using this method, http://147.2.212.248/tests/407 , http://147.2.212.248/tests/406

*Test
- Regression test of ipmi mode: http://147.2.212.248/tests/442  http://147.2.212.248/tests/433
- Prj1 test of proxy mode : http://147.2.212.248/tests/431 http://147.2.212.248/tests/430