### PR TITLE
oomath: Explicitly check that oomath is ready for input

### DIFF
--- a/tests/x11/oomath.pm
+++ b/tests/x11/oomath.pm
@@ -19,8 +19,7 @@ use testapi;
 sub run() {
     my $self = shift;
     x11_start_program("oomath");
-    # give oomath some time to be reactive on key input
-    wait_still_screen(3);
+    assert_screen 'oomath-textfield-ready';
     type_string "E %PHI = H %PHI\nnewline\n1 = 1";
     wait_still_screen(1);
 


### PR DESCRIPTION
See https://openqa.opensuse.org/tests/302567#step/oomath/3

Local verification run: http://lord.arch/tests/5378