### PR TITLE
Virtualization Guest Migration Test

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1097,6 +1097,16 @@ elsif (get_var("VIRT_AUTOTEST")) {
         }
         loadtest "virt_autotest/host_upgrade_step3_run";
     }
+    elsif (get_var("VIRT_PRJ3_GUEST_MIGRATION_SOURCE")) {
+        loadtest "virt_autotest/guest_migration_config_virtualization_env";
+        loadtest "virt_autotest/guest_migration_source_nfs_setup";
+        loadtest "virt_autotest/guest_migration_source_install_guest";
+        loadtest "virt_autotest/guest_migration_source_migrate";
+    }
+    elsif (get_var("VIRT_PRJ3_GUEST_MIGRATION_TARGET")) {
+        loadtest "virt_autotest/guest_migration_config_virtualization_env";
+        loadtest "virt_autotest/guest_migration_target_nfs_setup";
+    }
     elsif (get_var("VIRT_PRJ4_GUEST_UPGRADE")) {
         loadtest "virt_autotest/guest_upgrade_run";
     }

--- a/tests/virt_autotest/guest_migration_base.pm
+++ b/tests/virt_autotest/guest_migration_base.pm
@@ -1,0 +1,93 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: virt_autotest: Virtualization multi-machine job : Guest Migration
+# Maintainer: jerry <jtang@suse.com>
+
+package guest_migration_base;
+use base "opensusebasetest";
+use strict;
+use testapi;
+use mmapi;
+use Exporter qw(import);
+
+our @EXPORT = qw($guest_install_prepare_keep_guest $hyper_visor $vm_disk_dir $guest_os $nfs_local_dir $install_script $scenario_name get_var_from_parent get_var_from_child set_hosts);
+
+our ($guest_install_prepare_keep_guest, $hyper_visor, $vm_disk_dir, $guest_os, $nfs_local_dir, $install_script, $scenario_name);
+
+#get the guest product
+$guest_os = get_var('GUEST_OS', 'sles-12-sp2-64-fv-def-net');
+
+#Detect the host product version
+$scenario_name = get_var('NAME');
+$hyper_visor = ($scenario_name =~ /xen/) ? "xen" : "kvm";
+
+#Setup different var on different products
+my $host_os = get_var('HOST_OS');
+if ($host_os =~ /current_build/) {
+
+    $vm_disk_dir                      = "/var/lib/libvirt/images";
+    $install_script                   = "/usr/share/qa/qa_test_virtualization/virt_installos";
+    $guest_install_prepare_keep_guest = qq(sed -i '/-d -o/s/-d -o/-d -u -o/' $install_script );
+}
+
+if ($host_os =~ /sles-11/i) {
+
+    $vm_disk_dir                      = "/var/lib/$hyper_visor/images";
+    $install_script                   = "/usr/share/qa/qa_test_virtualization/installos";
+    $guest_install_prepare_keep_guest = qq(sed -i 's/INSTALL_METHOD$/& -g/' $install_script);
+    $install_script .= " standalone";
+}
+
+$nfs_local_dir = "/tmp/pesudo_mount_server";
+
+sub get_var_from_parent {
+    my ($var) = @_;
+    my $parents = get_parents();
+    #Query every parent to find the var
+    for my $job_id (@$parents) {
+        my $ref = get_job_autoinst_vars($job_id);
+        return $ref->{$var} if defined $ref->{$var};
+    }
+    return;
+}
+
+sub get_var_from_child {
+    my ($var) = @_;
+    my $child = get_children();
+    #Query every child to find the var
+    for my $job_id (keys %$child) {
+        my $ref = get_job_autoinst_vars($job_id);
+        return $ref->{$var} if defined $ref->{$var};
+    }
+    return;
+}
+
+sub set_hosts {
+    my ($self) = @_;
+    my ($target_ip, $target_name);
+    if ($scenario_name =~ /_HT/) {
+
+        $target_ip   = get_var_from_child('MY_IP');
+        $target_name = get_var_from_child('MY_NAME');
+
+    }
+    else {
+
+        $target_ip   = get_var_from_parent('MY_IP');
+        $target_name = get_var_from_parent('MY_NAME');
+    }
+
+    $self->execute_script_run("sed -i '/$target_ip/d' /etc/hosts ;echo $target_ip $target_name >>/etc/hosts", 15);
+    my $self_ip   = get_var('MY_IP');
+    my $self_name = get_var('MY_NAME');
+    $self->execute_script_run("sed -i '/$self_ip/d' /etc/hosts ;echo $self_ip $self_name >>/etc/hosts", 15);
+
+}
+1;

--- a/tests/virt_autotest/guest_migration_config_virtualization_env.pm
+++ b/tests/virt_autotest/guest_migration_config_virtualization_env.pm
@@ -1,0 +1,43 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: virt_autotest: Virtualization multi-machine job : Guest Migration
+# Maintainer: jerry <jtang@suse.com>
+
+use base virt_autotest_base;
+use strict;
+use testapi;
+use guest_migration_base;
+
+sub run() {
+    my ($self) = @_;
+
+    #Turn off the firewall
+    $self->execute_script_run("SuSEfirewall2 off", 500);
+
+    #Create disk backup directory
+    $self->execute_script_run("[ -d /tmp/pesudo_mount_server ] || mkdir -p /tmp/pesudo_mount_server", 500);
+
+    #Change the config file for hyper_visor
+    if ($hyper_visor =~ /xen/) {
+        $self->execute_script_run("source /usr/share/qa/virtautolib/lib/virtlib;changeXendConfig", 500);
+    }
+    else {
+        $self->execute_script_run("source /usr/share/qa/virtautolib/lib/virtlib;changeLibvirtConfig", 500);
+    }
+
+    #Query and save the ip addres
+    my $ip_out = $self->execute_script_run('ip route show|grep kernel|cut -d" " -f12|head -1', 3);
+    my $name_out = $self->execute_script_run('hostname', 3);
+
+    set_var('MY_IP',   $ip_out);
+    set_var('MY_NAME', $name_out);
+    bmwqemu::save_vars();
+}
+1;

--- a/tests/virt_autotest/guest_migration_source_install_guest.pm
+++ b/tests/virt_autotest/guest_migration_source_install_guest.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: virt_autotest: Virtualization multi-machine job : Guest Migration
+# Maintainer: jerry <jtang@suse.com>
+
+use base virt_autotest_base;
+use strict;
+use testapi;
+use guest_migration_base;
+
+sub run() {
+    my ($self) = @_;
+
+    #Keep the guest after succeed install
+    $self->execute_script_run($guest_install_prepare_keep_guest, 500);
+
+    #perform the installation
+    for my $guest (split(",", $guest_os)) {
+        $self->execute_script_run("$install_script $guest", 3600);
+        save_screenshot;
+    }
+
+    sleep 5;
+
+}
+1;

--- a/tests/virt_autotest/guest_migration_source_migrate.pm
+++ b/tests/virt_autotest/guest_migration_source_migrate.pm
@@ -1,0 +1,62 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: virt_autotest: Virtualization multi-machine job : Guest Migration
+# Maintainer: jerry <jtang@suse.com>
+
+use base virt_autotest_base;
+use strict;
+use testapi;
+use guest_migration_base;
+
+sub analyzeResult {
+    my ($self, $text) = @_;
+    my $result;
+    if ($text =~ /----------\s+reason(.*----------\s+\S+)/s) {
+        my $rough_result = $1;
+        foreach (split("\n", $rough_result)) {
+            if ($_ =~ /(.*)\s+----------\s+(pass|fail)/) {
+                my ($case_name, $case_result) = ($1, $2);
+                $result->{$case_name}{status} = "PASSED" if ($case_result =~ /pass/);
+                $result->{$case_name}{status} = "FAILED" if ($case_result =~ /fail/);
+                $result->{$case_name}{time}   = 1;
+            }
+        }
+    }
+    return $result;
+}
+
+sub upload_tar_log() {
+    my ($self, $log_dir, $log_tar_name) = @_;
+    my $full_log_tar_name = "/tmp/$log_tar_name.tar.gz";
+    script_run("tar zcf $full_log_tar_name $log_dir", 60);
+    upload_logs "$full_log_tar_name";
+}
+
+sub run() {
+    my ($self) = @_;
+
+    my $target_ip = get_var_from_parent('MY_IP');
+
+    my $cmd_output = $self->execute_script_run("/usr/share/qa/virtautolib/lib/guest_migrate.sh -s -d $target_ip -v $hyper_visor -u root -p novell", 3600);
+
+    #Upload logs
+    $self->upload_tar_log("/tmp/prj3_migrate_admin_log",                        "prj3_migrate_admin_log");
+    $self->upload_tar_log("/var/log/libvirt",                                   "libvirt");
+    $self->upload_tar_log("/tmp/prj3_guest_migration/vm_backup/vm-config-xmls", "vm-config-xmls");
+
+    #Parser result
+    $self->{product_name} = "Guest_Migration";
+    $self->{package_name} = "Guest Migration Result";
+    $self->add_junit_log($cmd_output);
+}
+
+
+
+1;

--- a/tests/virt_autotest/guest_migration_source_nfs_setup.pm
+++ b/tests/virt_autotest/guest_migration_source_nfs_setup.pm
@@ -1,0 +1,58 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: virt_autotest: Virtualization multi-machine job : Guest Migration
+# Maintainer: jerry <jtang@suse.com>
+
+use base virt_autotest_base;
+use strict;
+use testapi;
+use lockapi;
+use mmapi;
+use guest_migration_base;
+
+sub run() {
+    my ($self) = @_;
+
+    #Sync the setup for ip address
+    mutex_lock('ip_set_done');
+    mutex_unlock('ip_set_done');
+
+    #set hosts
+    set_hosts($self);
+
+    #Change the nfs config
+    my $cmd_modify_nfs_config = q(sed -i 's/^NFSV4LEASETIME=.*$/NFSV4LEASETIME="10"/' /etc/sysconfig/nfs);
+    $self->execute_script_run($cmd_modify_nfs_config, 500);
+
+    my $nfs_server        = get_var('MY_IP');
+    my $cmd_write_exports = qq(echo "$nfs_local_dir *(rw,sync,no_root_squash,no_subtree_check)" >/etc/exports);
+    $self->execute_script_run($cmd_write_exports, 500);
+
+    #Restart the nfs service
+    $self->execute_script_run("rcnfsserver restart", 500);
+    set_var('NFS_DONE', 1);
+    bmwqemu::save_vars();
+
+    #Mount the share storage
+    my $cmd_mount_disk_dir = qq(mount -t nfs -o vers=4,nfsvers=4 $nfs_server:$nfs_local_dir $vm_disk_dir);
+    $self->execute_script_run($cmd_mount_disk_dir, 500);
+    mutex_lock('nfs_done');
+    mutex_unlock('nfs_done');
+
+    #Sync the bridge setting
+    mutex_lock('bridge_done');
+    mutex_unlock('bridge_done');
+
+    #Sync the vm clean
+    mutex_lock('clean_vm_done');
+    mutex_unlock('clean_vm_done');
+}
+
+1;

--- a/tests/virt_autotest/guest_migration_target_nfs_setup.pm
+++ b/tests/virt_autotest/guest_migration_target_nfs_setup.pm
@@ -1,0 +1,65 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: virt_autotest: Virtualization multi-machine job : Guest Migration
+# Maintainer: jerry <jtang@suse.com>
+
+use base virt_autotest_base;
+use strict;
+use testapi;
+use lockapi;
+use mmapi;
+use guest_migration_base;
+
+sub run() {
+    my ($self) = @_;
+
+    #Sync the setting for ip address
+    mutex_create('ip_set_done');
+
+    #Manually sync the setting for child nfs address
+    my $try_times = 0;
+    while (not(my $nfs_done = get_var_from_child('NFS_DONE'))) {
+
+        sleep 60;
+        die if ($try_times == 10);
+        $try_times++;
+    }
+
+    my $nfs_server = get_var_from_child('MY_IP');
+
+    #Setup /etc/hosts
+    set_hosts($self);
+
+    #Mount the share storage
+    my $cmd_mount_disk_dir = "mount -t nfs -o vers=4,nfsvers=4 $nfs_server:$nfs_local_dir $vm_disk_dir";
+    $self->execute_script_run($cmd_mount_disk_dir, 500);
+    save_screenshot;
+    mutex_create('nfs_done');
+    save_screenshot;
+
+    #Clean the VM
+    my $cmd_clean_vm = q(virsh list --all|awk 'NR>2{print $2}'|sed '$d'|xargs -i virsh undefine {});
+    $self->execute_script_run($cmd_clean_vm, 500);
+
+
+    #Setup the bridge
+    $self->execute_script_run('bash /usr/share/qa/qa_test_virtualization/shared/standalone', 500);
+    mutex_create('bridge_done');
+    save_screenshot;
+
+    #Clean the VM
+    $self->execute_script_run($cmd_clean_vm, 500);
+    mutex_create('clean_vm_done');
+    save_screenshot;
+
+    wait_for_children;
+}
+
+1;

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -95,7 +95,7 @@ sub execute_script_run {
 
     if ($ret) {
         save_screenshot;
-        $ret =~ s/$pattern//g;
+        $ret =~ s/[\r\n]+$pattern[\r\n]+//g;
         return $ret;
     }
     else {


### PR DESCRIPTION
Vitualization Multi-machine job  :  Guest Migration
We have 2 role : 
 1.The source host , which will migrate to guest to the target host.
 2.The target host, wich will take the guest from source host.

In this test: 
  "Target host" play the parent role.
  "Source host"  play the child role.

we should invoke the child to let the schedule trigger the parent.

Migration step (S stand for source host, T stand for target host) : 
1. both S and T perform the  os installation 
2  both S and T perform the RPM update
3  both S and T switch the hyper viser (option)
4  both S and T setup the virtualization Migration preparation .
5  S setup nfs  ,   T sync the nfs setup .
6  S and T mount share nfs.
7  S install the GUEST
8  S do the Migration 



