### PR TITLE
Show plymouth debug messages during boot

### DIFF
--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -8,15 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Rename livecdreboot, moved grub code in grub_test.pm
-#    Livecdreboot test name was unclear, renamed it in to install_and_reboot.
-#    The code concerning grub test has moved to new test grub_test.pm
-#    Main pm adapted for the new grub_test.pm
-#    In first_boot.pm added get_var(boot_into_snapshot) for assert linux-terminal,
-#    since after booting on snapshot, only a terminal interface is given, not GUI.
-#
-#    Issues on progress: 9716,10286,10164
-# G-Maintainer: dmaiocchi <dmaiocchi@suse.com>
+# Summary: Handle grub menu after reboot
+# Tags: poo#9716, poo#10286, poo#10164
+# Maintainer: Martin Kravec <mkravec@suse.com>
 
 use strict;
 use base "basetest";
@@ -83,8 +77,26 @@ sub run() {
     if (get_var("XEN")) {
         send_key_until_needlematch("bootmenu-xen-kernel", 'down', 10, 5);
     }
-    # avoid timeout for booting to HDD
-    send_key 'ret';
+    if (check_var('ARCH', 'aarch64') && check_var('DISTRI', 'sle') && get_var('PLYMOUTH_DEBUG')) {
+        record_soft_failure "Running with plymouth:debug to catch bsc#995310";
+
+        send_key 'e';
+        # Move to end of kernel boot parameters line
+        send_key_until_needlematch "linux-line", "down";
+        send_key "end";
+
+        # remove "splash=silent quiet showopts"
+        assert_screen "linux-line-matched";
+        for (1 .. 28) { send_key "backspace" }
+        type_string 'plymouth:debug';
+
+        save_screenshot;
+        send_key 'ctrl-x';
+    }
+    else {
+        # avoid timeout for booting to HDD
+        send_key 'ret';
+    }
 }
 
 sub test_flags() {


### PR DESCRIPTION
This shoud provide more information to resolve bsc#995310

Local run: http://dhcp91.suse.cz/tests/3065
Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/249