### PR TITLE
Change links for firefox downloading test

### DIFF
--- a/tests/x11regressions/firefox/sle12/firefox_downloading.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_downloading.pm
@@ -15,8 +15,8 @@ use strict;
 use base "x11regressiontest";
 use testapi;
 
-my $dl_link_01 = "http://download.opensuse.org/distribution/13.2/iso/openSUSE-13.2-DVD-x86_64.iso\n";
-my $dl_link_02 = "http://download.opensuse.org/distribution/13.2/iso/openSUSE-13.2-DVD-i586.iso\n";
+my $dl_link_01 = "http://mirrors1.kernel.org/opensuse/distribution/13.2/iso/openSUSE-13.2-DVD-x86_64.iso\n";
+my $dl_link_02 = "http://mirrors1.kernel.org/opensuse/distribution/13.2/iso/openSUSE-13.2-DVD-i586.iso\n";
 
 sub dl_location_switch {
     my ($tg) = @_;


### PR DESCRIPTION
i suppose the download speed is too fast that make disk writing busy:
https://openqa.suse.de/tests/635345#step/firefox_downloading/10