### PR TITLE
adding ghostscript and gv tests

### DIFF
--- a/data/ghostscript/ghostscript_ps2pdf.sh
+++ b/data/ghostscript/ghostscript_ps2pdf.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Add ghostscript test 
+#    This test downloads a script that converts all the .ps images in 
+#    the examples to .pdf files. If one (or more) were not converted
+#    then a file called failed is created and the test fails. Also it
+#    will display one of the generated PDFs to see if gv works.
+# Maintainer: Dario Abatianni <dabatianni@suse.de>
+
+tempfolder="ghostscript_test"
+log="ghostscript.log"
+failed="/tmp/ghostscript_failed"
+reference="alphabet.pdf"
+
+mkdir $tempfolder
+cd $tempfolder
+
+# timestamp the start of the logfile
+date > $log
+
+# run through all of the example *.ps files in the ghostscript folder
+version=`gs --version`
+for i in `find /usr/share/ghostscript/$version/examples/*.ps -type f`
+do
+  # convert all *.ps files to *.pdf files in the current temporary folder
+  echo Running ps2pdf $i ... >> $log
+
+  # in case converting of one file fails, add a "failed" marker file
+  ps2pdf $i 2>> $log || touch $failed
+done
+
+# timestamp the end of the logfile
+date >> $log
+
+# list the final files (for reference on the screenshot)
+ls -l .
+cd -
+
+# check if our gv reference pdf is there, exit if not
+test -f $tempfolder/$reference || exit 2
+
+# move the logfile and the reference one folder down
+mv $tempfolder/$log $tempfolder/$reference .
+
+# clean up temporary folder
+rm -f $tempfolder/*
+rmdir $tempfolder
+

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -770,6 +770,7 @@ sub load_x11tests() {
             loadtest "x11/eog.pm";
             loadtest "x11/rhythmbox.pm";
             loadtest "x11/ImageMagick.pm";
+            loadtest "x11/ghostscript.pm";
         }
         if (get_var('DESKTOP') =~ /kde|gnome/) {
             loadtest "x11/ooffice.pm";

--- a/tests/x11/ghostscript.pm
+++ b/tests/x11/ghostscript.pm
@@ -1,0 +1,70 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Add ghostscript test
+#    This test downloads a script that converts all the .ps images in
+#    the examples to .pdf files. If one (or more) were not converted
+#    then a file called failed is created and the test fails. Also it
+#    will display one of the generated PDFs to see if gv works.
+# Maintainer: Dario Abatianni <dabatianni@suse.de>
+
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run() {
+    select_console "x11";
+
+    x11_start_program "xterm";
+
+    # become root, disable packagekit and install all needed packages
+    become_root;
+    pkcon_quit;
+    zypper_call "in ghostscript ghostscript-x11 gv";
+    type_string "exit\n";
+
+    my $gs_script = "ghostscript_ps2pdf.sh";
+    my $gs_log    = "ghostscript.log";
+    my $gs_failed = "/tmp/ghostscript_failed";
+    my $reference = "alphabet.pdf";
+
+    # download ghostscript converter script and test if download succeeded
+    assert_script_run "wget " . data_url("ghostscript/$gs_script");
+    assert_script_run "test -f $gs_script";
+    assert_script_run "test -s $gs_script";
+
+    # convert example *.ps files to *.pdf
+    assert_script_run "sh ./$gs_script";
+
+    # show the resulting logfile onthe screen for reference and upload logs
+    script_run "cat $gs_log";
+    upload_logs $gs_log;
+
+    # check if there was an error during the pdf generation
+    assert_script_run "test ! -f $gs_failed";
+
+    # display one reference pdf on screen and check if it looks correct
+    script_run "gv $reference", 0;
+    assert_screen "ghostview_alphabet";
+
+    # close gv
+    send_key "alt-f4";
+    wait_still_screen;
+
+    # cleanup temporary files
+    script_run "rm -f $gs_log $reference";
+
+    # close xterm
+    send_key "alt-f4";
+}
+
+1;
+


### PR DESCRIPTION
Summary: Add ghostscript test 
This test downloads a script that converts all the .ps images in 
the examples to .pdf files. If one (or more) were not converted
then a file called failed is created and the test fails. Also it
will display one of the generated PDFs to see if gv works.

Sample:
http://froh.qam.suse.de/tests/59