### PR TITLE
[qa_automation] Add kexec testsuite

### DIFF
--- a/tests/qa_automation/kernel_kexec.pm
+++ b/tests/qa_automation/kernel_kexec.pm
@@ -1,0 +1,53 @@
+# Copyright (C) 2016 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary:  [qa_automation] kexec testsuite
+# Maintainer: Nathan Zhao <jtzhao@suse.com>
+
+use base "qa_run";
+use strict;
+use testapi;
+
+sub run() {
+    my $self = shift;
+    $self->system_login();
+    # Copy current kernel and rename it
+    $_ = $self->qa_script_output("uname -r", 10);
+    s/-default$/-kexec/;
+    my $kernel_file = "vmlinuz-$_";
+    my $initrd_file = "initrd-$_";
+    assert_script_run("cp /boot/vmlinuz-`uname -r` /boot/$kernel_file");
+    assert_script_run("cp /boot/initrd-`uname -r` /boot/$initrd_file");
+    # kernel cmdline parameter
+    $_ = $self->qa_script_output("cat /proc/cmdline");
+    s/-default /-kexec /;
+    my $cmdline = "$_ debug";
+    # kexec -l
+    assert_script_run("kexec -l /boot/$kernel_file --initrd=/boot/$initrd_file --command-line='$cmdline'");
+    # kexec -e
+    type_string("systemctl kexec\n");
+    # wait for reboot
+    wait_idle();
+    reset_consoles();
+    select_console("root-console");
+    # Check kernel cmdline parameter
+    my $result = $self->qa_script_output("cat /proc/cmdline");
+    print "Checking kernel boot parameter...\nCurrent:  $result\nExpected: $cmdline\n";
+    if ($cmdline ne $result) {
+        die "kexec failed";
+    }
+}
+
+1;


### PR DESCRIPTION
The kexec testsuite utilizes kexec to reboot and switch  to another kernel, then check the kernel boot parameter.

pass result: http://147.2.207.102/tests/454