### PR TITLE
Fix apache_ssl.pm: gensslcert timeout

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -54,7 +54,7 @@ sub setup_apache2 {
 
     # Create x509 certificate for this apache server
     if ($mode eq "SSL") {
-        assert_script_run 'gensslcert -n $(hostname) -C $(hostname) -e webmaster@$(hostname)', 300;
+        assert_script_run 'gensslcert -n $(hostname) -C $(hostname) -e webmaster@$(hostname)', 600;
         assert_script_run 'ls /etc/apache2/ssl.crt/$(hostname)-server.crt /etc/apache2/ssl.key/$(hostname)-server.key';
     }
 


### PR DESCRIPTION
The failure was caused by timeout of gensslcert command.
Seems it will take longer time than 300s on heavy-loaded
openQA worker. Set timeout to 600s to avoid the issue.

Related progress issue: https://progress.opensuse.org/issues/14882