### PR TITLE
Add support for SLEnkins nodes repo variables

### DIFF
--- a/tests/slenkins/slenkins_node.pm
+++ b/tests/slenkins/slenkins_node.pm
@@ -59,10 +59,16 @@ sub run {
 
     my $conf_script = "zypper -n --no-gpg-checks ar '" . get_var('SLENKINS_TESTSUITES_REPO') . "' slenkins_testsuites\n";
 
-    # Uses full URI with .repo extension, multiple repos separated by colon is supported
+    my $i = 0;
     if (get_var('FOREIGN_REPOS')) {
         foreach (split(/[\s,]+/, get_var('FOREIGN_REPOS'))) {
-            $conf_script .= "zypper -n --no-gpg-checks ar '" . $_ . "'\n";
+            if ($_ =~ /^http.*\.repo$/) {
+                $conf_script .= "zypper -n --no-gpg-checks ar '" . $_ . "'\n";
+            }
+            else {
+                $conf_script .= "zypper -n --no-gpg-checks ar '" . $_ . "' REPO_$i" . "\n";
+                $i++;
+            }
         }
     }
 


### PR DESCRIPTION
- import-slenkins-testsuite.pl now parses channels.conf from SLEnkins for adding repositories into SUTs
- import-slenkins-testsuite.pl modified to use new group_name "Slenkins" and version "12-SP3"
- slenkins_node.pl is now able to use repos from $FOREIGN_REPOS variable with or without .repo extension

see poo#14686 for details