### PR TITLE
login_test: Give rebooting GNOME more time

### DIFF
--- a/tests/x11regressions/gnomecase/login_test.pm
+++ b/tests/x11regressions/gnomecase/login_test.pm
@@ -32,7 +32,7 @@ sub run () {
     my $ov = get_var('NOAUTOLOGIN');
     set_var('NOAUTOLOGIN', '');
     reboot_gnome;
-    wait_boot;
+    wait_boot bootloader_time => 300;
     set_var('NOAUTOLOGIN', $ov);
     $self->auto_login_alter;
 }


### PR DESCRIPTION
Fixing https://openqa.suse.de/tests/638998#step/login_test/12 