### PR TITLE
Fix ImageMagick command not found failure

### DIFF
--- a/data/imagemagick/bg_script.sh
+++ b/data/imagemagick/bg_script.sh
@@ -960,8 +960,9 @@ FILES=("test.png" "shape.gif" "plasma_fractal2.jpg" "random.png" "tile_weave.gif
 FILES+=("sparse_bary_1.gif" "sparse_bary_2.gif" "sparse_bilin_1.gif" "sparse_bilin_2.gif")
 echo "clean-up"
 for file in "${FILES[@]}"; do
-    rm "$file"
+    rm "$file" || exit 1
     echo -n "."
 done
 echo
 echo "done"
+exit 0

--- a/tests/x11/ImageMagick.pm
+++ b/tests/x11/ImageMagick.pm
@@ -39,7 +39,11 @@ sub run() {
     type_string "exit\n";
 
     assert_script_run "wget --quiet " . data_url('imagemagick/bg_script.sh') . " -O bg_script.sh";
-    type_string "chmod +x bg_script.sh; ./bg_script.sh " . data_url('imagemagick/bg_script.sh') . " \n";
+
+    assert_script_run "chmod +x bg_script.sh";
+
+    # execute the script and direct its exit code to the serial console
+    type_string "./bg_script.sh " . data_url('imagemagick/bg_script.sh') . "; echo bg_script-\$? > /dev/$testapi::serialdev\n";
 
     assert_screen "imagemagick_test";
     send_key "alt-f4";
@@ -754,6 +758,9 @@ sub run() {
 
     assert_screen "imagemagick_tiled_hex_lines";
     send_key "alt-f4";
+
+    # waiting for the exit code of the script
+    wait_serial "bg_script-0";
 
     # clean-up
     assert_script_run "rm bg_script.sh";


### PR DESCRIPTION
The test should wait the clean-up phase of the script to complete before it starts typing. This is done by waiting for its exit code at the serial console.

https://progress.opensuse.org/issues/14908 fix possible -although not common- failure: https://openqa.suse.de/tests/639206#step/ImageMagick/250

Working example: http://rwmanosvm2.suse.cz/tests/2723