### PR TITLE
[qa_automation] Fix kernel_kexec.pm for ppc64le architecture

### DIFF
--- a/tests/qa_automation/kernel_kexec.pm
+++ b/tests/qa_automation/kernel_kexec.pm
@@ -28,7 +28,7 @@ sub run() {
     s/-default$/-kexec/;
     my $kernel_file = "vmlinuz-$_";
     my $initrd_file = "initrd-$_";
-    assert_script_run("cp /boot/vmlinuz-`uname -r` /boot/$kernel_file");
+    assert_script_run("cp /boot/vmlinu*-`uname -r` /boot/$kernel_file");
     assert_script_run("cp /boot/initrd-`uname -r` /boot/$initrd_file");
     # kernel cmdline parameter
     $_ = $self->qa_script_output("cat /proc/cmdline");


### PR DESCRIPTION
Kernel files on ppc64le are named as vmlinux-xxx instead of vmlinuz-xxx.