### PR TITLE
Add DRBD test to HA testsuite

### DIFF
--- a/data/ha/drbd9.conf.template
+++ b/data/ha/drbd9.conf.template
@@ -1,0 +1,22 @@
+resource r0 {
+   disk {
+      resync-rate 10M;
+   }
+   connection-mesh {
+	hosts 1b009 1b010;
+   }
+   on 1b009 {
+      address   10.162.30.9:7788;
+      device    /dev/drbd0 ;
+      disk      /dev/vdb1;
+      meta-disk internal;
+      node-id 0;
+   }
+   on 1b010 {
+      address   10.162.30.10:7788;
+      device    /dev/drbd0 ;
+      disk      /dev/vdb1;
+      meta-disk internal;
+      node-id 1;
+   }
+}

--- a/data/ha/drbd9.crm.config
+++ b/data/ha/drbd9.crm.config
@@ -1,0 +1,6 @@
+primitive drbd-data ocf:linbit:drbd \
+	params drbd_resource=r0 drbdconf="/etc/drbd.conf" \
+	op monitor interval=29s role=Master \
+	op monitor interval=31s role=Slave
+ms ms-drbd-data drbd-data \
+	meta master-max=1 master-node-max=1 clone-max=2 clone-node-max=1 notify=true

--- a/data/ha/drbd9.r0.res.template
+++ b/data/ha/drbd9.r0.res.template
@@ -1,0 +1,19 @@
+resource r0 { 
+  device /dev/drbd0; 
+  disk "/dev/vdb"; 
+  meta-disk internal; 
+  on host1 { 
+    address  ADDR1:7788; 
+    node-id 0; 
+  }
+  on host2 { 
+    address ADDR2:7788; 
+    node-id 1; 
+  }
+  disk {
+    resync-rate 10M; 
+  }
+  connection-mesh { 
+    hosts host1 host2;
+  }
+}

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -862,6 +862,7 @@ sub load_hacluster_tests() {
         loadtest("ha/dlm");
         loadtest("ha/clvm");
         loadtest("ha/ocfs2");
+        loadtest("ha/drbd");
         loadtest("ha/crm_mon");
         loadtest("ha/fencing");
         if (!get_var("HACLUSTERJOIN")) {                     #node1 will be fenced

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -26,6 +26,12 @@ sub run() {
         barrier_create("DLM_INIT_" . $clustername,                 2);
         barrier_create("DLM_GROUPS_CREATED_" . $clustername,       2);
         barrier_create("DLM_CHECKED_" . $clustername,              2);
+        barrier_create("DRBD_INIT_" . $clustername,                2);
+        barrier_create("DRBD_CHECKED_" . $clustername,             2);
+        barrier_create("DRBD_CHECK_DEVICE_HOST2_" . $clustername,  2);
+        barrier_create("DRBD_CREATE_DEVICE_HOST1_" . $clustername, 2);
+        barrier_create("DRBD_SETUP_DONE_" . $clustername,          2);
+        barrier_create("DRBD_MIGRATIONDONE_" . $clustername,       2);
         barrier_create("OCFS2_INIT_" . $clustername,               2);
         barrier_create("OCFS2_MKFS_DONE_" . $clustername,          2);
         barrier_create("OCFS2_GROUP_ALTERED_" . $clustername,      2);

--- a/tests/ha/drbd.pm
+++ b/tests/ha/drbd.pm
@@ -1,0 +1,81 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: DRBD OpenQA test
+# Add two new VARIABLES DRBD_LUN0 and DRBD_LUN1
+# Create DRBD Device
+# Create crm ressource
+# Check resource migration
+# Check multistate status
+# Maintainer: Haris Sehic <hsehic@suse.com>
+
+use base "hacluster";
+use strict;
+use testapi;
+use autotest;
+use lockapi;
+
+sub run() {
+    my $self    = shift;
+    my $lun0    = get_var("DRBD_LUN0");
+    my $lun1    = get_var("DRBD_LUN1");
+    my $host1ip = script_output("host -t A host1 | cut -d' ' -f4");
+    my $host2ip = script_output("host -t A host2 | cut -d' ' -f4");
+
+    barrier_wait("DRBD_INIT_" . $self->cluster_name);
+    assert_script_run q(awk -e '{print;}/startup {/{print "wfc-timeout 100;\ndegr-wfc-timeout 120;"};' /etc/drbd.d/global_common.conf >/tmp/global_common.conf && mv /tmp/global_common.conf /etc/drbd.d/global_common.conf);
+    assert_script_run "curl -f -v " . autoinst_url . "/data/ha/drbd9.r0.res.template -o /etc/drbd.d/r0.res";
+    assert_script_run q(sed -i 's/ADDR1/) . $host1ip . q(/' /etc/drbd.d/r0.res);
+    assert_script_run q(sed -i 's/ADDR2/) . $host2ip . q(/' /etc/drbd.d/r0.res);
+    save_screenshot;
+    assert_script_run "drbdadm create-md r0";
+    assert_script_run "drbdadm up r0";
+    barrier_wait("DRBD_CREATE_DEVICE_HOST1_" . $self->cluster_name);
+    if ($self->is_node1) {
+        assert_script_run "drbdadm primary --force r0";
+        assert_script_run "drbdadm status r0";
+        # run assert_script_run timeout 240 during the long assert_script_run drbd sync
+        assert_script_run q(while ! `drbdadm status r0 | grep -q "peer-disk:UpToDate"`; do sleep 10; drbdadm status r0;  done), 240;
+    }
+    else {
+        type_string "echo wait until drbd device is created\n";
+    }
+    save_screenshot;
+    barrier_wait("DRBD_CHECK_DEVICE_HOST2_" . $self->cluster_name);
+    if ($self->is_node1) {
+        type_string "echo wait until drbd status is set\n";
+    }
+    else {
+        assert_script_run "drbdadm status r0";
+        # run assert_script_run timeout 240 during the long assert_script_run drbd sync
+        assert_script_run q(while ! `drbdadm status r0 | grep -q "peer-disk:UpToDate"`; do sleep 10;drbdadm status r0; done), 240;
+    }
+    save_screenshot;
+    barrier_wait("DRBD_SETUP_DONE_" . $self->cluster_name);
+    if ($self->is_node1) {
+        assert_script_run "curl -f -v " . autoinst_url . "/data/ha/drbd9.crm.config -o /tmp/r0.crm";
+        assert_script_run "crm configure load update /tmp/r0.crm";
+        # check for result
+        assert_script_run "crm resource status ms-drbd-data | grep 'host1 Master'";
+    }
+    save_screenshot;
+    barrier_wait("DRBD_CHECKED_" . $self->cluster_name);
+    if ($self->is_node1) {
+        #do nothing
+    }
+    else {
+        assert_script_run "crm resource migrate ms-drbd-data host2";
+        # check the migration / timeout 240 sec it takes some time to update
+        assert_script_run q(while ! `drbdadm status r0 | grep -q "r0 role:Primary"`; do sleep 10; drbdadm status r0;  done), 240;
+        assert_script_run "crm resource status ms-drbd-data | grep 'host2 Master'";
+    }
+    barrier_wait("DRBD_MIGRATIONDONE_" . $self->cluster_name);
+}
+
+1;


### PR DESCRIPTION
According to http://ix64hae1001.qa.suse.de/tests/536 this DRBD testcase works
Testcase includes two new Variables DRBD_LUN0 and DRBD_LUN1
Test_suite hacluster-alpha-node1 and hacluster-alpha-node2 extended by NUMDISKS=2 and HDDSIZEGB_2=5

Testcase includes creating, configuring and testing DRBD9 on two cluster nodes 