### PR TITLE
Give yast bootloader more time to generate initrd

### DIFF
--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -27,12 +27,12 @@ sub run() {
     script_run("yast2 bootloader; echo yast2-bootloader-status-\$? > /dev/$serialdev", 0);
     assert_screen "test-yast2_bootloader-1", 300;
     send_key "alt-o";                                     # OK => Close
-    assert_screen([qw(yast2_bootloader-missing_package yast2_console-finished)], 150);
+    assert_screen([qw(yast2_bootloader-missing_package yast2_console-finished)], 200);
     if (match_has_tag('yast2_bootloader-missing_package')) {
         wait_screen_change { send_key 'alt-i'; };
     }
-    assert_screen 'yast2_console-finished', 150;
-    wait_serial("yast2-bootloader-status-0", 150) || die "'yast2 bootloader' didn't finish";
+    assert_screen 'yast2_console-finished', 200;
+    wait_serial("yast2-bootloader-status-0") || die "'yast2 bootloader' didn't finish";
 }
 
 1;


### PR DESCRIPTION
Extend timeouts for assert_screen.

Use default timeout for wait_serial because we are waiting in assert_screen.

Fix for: https://openqa.suse.de/tests/646953#step/yast2_bootloader/6