### PR TITLE
Revert "bootloader: check bootmenu needle for different seabios"

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -37,7 +37,7 @@ sub pre_bootmenu_setup {
         return 3;
     }
     if (get_var("USBBOOT")) {
-        assert_screen([qw/boot-menu boot-menu-esc/], 5);
+        assert_screen "boot-menu", 5;
         # support multiple versions of seabios, does not harm to press
         # multiple keys here: seabios<1.9: f12, seabios=>1.9: esc
         send_key((match_has_tag 'boot-menu-esc') ? 'esc' : 'f12');


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#2166
as discussed, use only one tag for the different versions of seabios and change the needle

see https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/266