### PR TITLE
CASP login test should be fatal

### DIFF
--- a/tests/casp/login.pm
+++ b/tests/casp/login.pm
@@ -18,5 +18,9 @@ sub run() {
     select_console 'root-console';
 }
 
+sub test_flags() {
+    return {fatal => 1};
+}
+
 1;
 # vim: set sw=4 et:


### PR DESCRIPTION
I think fatal is more proper than important for login test. Test should not softfail with this problem.