### PR TITLE
Update two libreoffice cases to fix poo#13120

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -235,9 +235,7 @@ sub load_x11regression_firefox() {
     loadtest "x11regressions/firefox/sle12/firefox_html5";
     loadtest "x11regressions/firefox/sle12/firefox_developertool";
     loadtest "x11regressions/firefox/sle12/firefox_rss";
-    if (sle_version_at_least('12-SP2')) {    # take out these failed cases from qam test for SP1
-        loadtest "x11regressions/firefox/sle12/firefox_ssl";
-    }
+    loadtest "x11regressions/firefox/sle12/firefox_ssl";
     if (!get_var("OFW") && check_var('BACKEND', 'qemu')) {
         loadtest "x11/firefox_audio";
     }

--- a/tests/x11regressions/libreoffice/libreoffice_double_click_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_double_click_file.pm
@@ -35,8 +35,7 @@ sub run() {
     for my $tag (qw/doc docx fodg fodp fods fodt odf odg odp ods odt pptx xlsx/) {
         send_key_until_needlematch("libreoffice-specified-list-$tag", "right", 50, 1);
         assert_and_dclick("libreoffice-specified-list-$tag");
-        wait_still_screen;
-        assert_screen("libreoffice-test-$tag");
+        assert_screen("libreoffice-test-$tag", 60);
         if ($tag ne 'xlsx') {
             hold_key "alt";
             send_key_until_needlematch("libreoffice-nautilus-window", "tab");

--- a/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
@@ -33,8 +33,8 @@ sub run() {
         send_key "ctrl-l";
         save_screenshot;
         type_string "/home/$username/Documents/ooo-test-doc-types/test.$tag\n";
-        wait_still_screen;
-        assert_screen("libreoffice-test-$tag");
+        wait_still_screen 3;
+        assert_screen("libreoffice-test-$tag", 60);
     }
     send_key "ctrl-q";
     if (!check_screen("generic-desktop")) {


### PR DESCRIPTION
- Extend the default timeout of two libreoffice cases to open testing files
- Bring firefox_ssl.pm back to qam test of SP1

  see also: poo#13120#change-32796, poo#10432

Validation test: http://147.2.212.239/tests/997