### PR TITLE
Wait for system shutdown

### DIFF
--- a/tests/installation/redefine_svirt_domain.pm
+++ b/tests/installation/redefine_svirt_domain.pm
@@ -21,6 +21,7 @@ sub run() {
     # test should follow.
     if (is_jeos) {
         script_run 'poweroff', 0;
+        assert_shutdown;
     }
 
     my $svirt = console('svirt');


### PR DESCRIPTION
We should not play with potential system start before the guest is
verified to be down.

This might help mitigate POO#14618.