### PR TITLE
Changed URI variable match for usb device

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -616,7 +616,10 @@ sub validate_repos {
                 if (check_var("BACKEND", "ipmi") || check_var("BACKEND", "generalhw")) {
                     $uri = "http[s]*://.*suse";
                 }
-                elsif (get_var('USBBOOT')) {
+                elsif (get_var('USBBOOT') && sle_version_at_least('12-SP3')) {
+                    $uri = "hd:///.*usb-";
+                }
+                elsif (get_var('USBBOOT') && sle_version_at_least('12-SP2')) {
                     $uri = "hd:///.*usbstick";
                 }
                 elsif (check_var('ARCH', 's390x')) {


### PR DESCRIPTION
The URI for usb devices doesn't match anymore 'usbstick' on installation from usb.
Just removed the 'stick' part from the string.
Depends also on https://bugzilla.suse.com/show_bug.cgi?id=1012258
because the match need at least one enabled repo( usb source in our case).