### PR TITLE
LTP: Increase timeouts and enable serial terminal for installation

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -50,7 +50,8 @@ sub run {
     my $self     = shift;
     my $inst_ltp = get_var 'INSTALL_LTP';
     wait_boot;
-    select_console('root-console');
+
+    select_console(get_var('VIRTIO_CONSOLE') ? 'root-virtio-terminal' : 'root-console');
 
     if ($inst_ltp =~ /git/i) {
         install_from_git;
@@ -64,6 +65,7 @@ sub run {
     }
     upload_logs '/root/openposix_test_list.txt';
 
+    select_console('root-console');
     type_string "reboot\n";
 }
 

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -36,8 +36,8 @@ sub install_from_git {
     assert_script_run 'cd ltp';
     assert_script_run 'make autotools';
     assert_script_run './configure --with-open-posix-testsuite --with-realtime-testsuite';
-    assert_script_run 'make -j$(getconf _NPROCESSORS_ONLN)', timeout => 360;
-    assert_script_run 'make install';
+    assert_script_run 'make -j$(getconf _NPROCESSORS_ONLN)', timeout => 1440;
+    assert_script_run 'make install',                        timeout => 360;
     assert_script_run "find ~/ltp/testcases/open_posix_testsuite/conformance/interfaces -name '*.run-test' > ~/openposix_test_list.txt";
 }
 


### PR DESCRIPTION
Increase the timeouts during installation and compilation for slower workers.