### PR TITLE
Wait for correct screen then press key

### DIFF
--- a/tests/installation/addon_products_yast2.pm
+++ b/tests/installation/addon_products_yast2.pm
@@ -63,6 +63,7 @@ sub run() {
             }
             send_key 'alt-a', 2;                                                    # yes, agree
             send_key $cmd{next}, 2;
+            assert_screen 'addon-yast2-patterns';
             send_key_until_needlematch 'addon-yast2-view-selected', 'alt-v', 10;
             send_key 'spc';                                                         # open view menu
             send_key 'alt-r', 1;


### PR DESCRIPTION
alt-v is pressed before corresponding button is present then it can fail

[fail](https://openqa.suse.de/tests/658064#step/addon_products_yast2/27)
[fixed](http://10.100.12.155/tests/4065#step/addon_products_yast2/15)