### PR TITLE
Value of HDD_1 variable changed in import-slenkins-testsuite.pl

### DIFF
--- a/script/import-slenkins-testsuite.pl
+++ b/script/import-slenkins-testsuite.pl
@@ -35,7 +35,7 @@ my $template_node = pp(
 
     {key => "ISO_1", value => "SLE-%VERSION%-SDK-DVD-%ARCH%-Build%BUILD_SDK%-Media1.iso"},
 
-    {key => "HDD_1", value => "SLES-%VERSION%-%ARCH%-minimal_with_sdk_installed.qcow2"},
+    {key => "HDD_1", value => "SLES-%VERSION%-%ARCH%-%BUILD%-minimal_with_sdk%BUILD_SDK%_installed.qcow2"},
 
     {key => "NICTYPE", value => "tap"},
 


### PR DESCRIPTION
Due adding new groups for maintenance there was a need to modify HDD_1 variable for all SLEnkins nodes test suites. This change is now incorporated in import-slenkins-testsuite.pl script for importing SLEnkins suites into openQA.