### PR TITLE
Virtualization: Add virt-v2v tests that support migration from xen to kvm.

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1182,6 +1182,12 @@ elsif (get_var("VIRT_AUTOTEST")) {
     elsif (get_var("VIRT_PRJ5_PVUSB")) {
         loadtest "virt_autotest/pvusb_run";
     }
+    elsif (get_var("VIRT_PRJ6_VIRT_V2V_SRC")) {
+        loadtest "virt_autotest/virt_v2v_src";
+    }
+    elsif (get_var("VIRT_PRJ6_VIRT_V2V_DST")) {
+        loadtest "virt_autotest/virt_v2v_dst";
+    }
 }
 elsif (get_var("QAM_MINIMAL")) {
     prepare_target();

--- a/tests/virt_autotest/guest_migration_base.pm
+++ b/tests/virt_autotest/guest_migration_base.pm
@@ -17,79 +17,35 @@ use testapi;
 use mmapi;
 use Exporter 'import';
 
-our @EXPORT = qw($guest_install_prepare_keep_guest $hyper_visor $vm_disk_dir
-  $guest_os $nfs_local_dir $install_script $scenario_name
-  get_var_from_parent get_var_from_child set_hosts);
+our @EXPORT = qw($guest_install_prepare_keep_guest $hyper_visor $vm_disk_dir $guest_os $nfs_local_dir $install_script $scenario_name set_common_settings);
 
 our ($guest_install_prepare_keep_guest, $hyper_visor, $vm_disk_dir, $guest_os, $nfs_local_dir, $install_script, $scenario_name);
 
-#get the guest product
-$guest_os = get_var('GUEST_OS', 'sles-12-sp2-64-fv-def-net');
+sub set_common_settings {
+    #get the guest product
+    $guest_os = get_var('GUEST_OS', 'sles-12-sp2-64-fv-def-net');
 
-#Detect the host product version
-$scenario_name = get_var('NAME');
-$hyper_visor = ($scenario_name =~ /xen/) ? "xen" : "kvm";
+    #Detect the host product version
+    $scenario_name = get_var('NAME');
+    $hyper_visor = ($scenario_name =~ /xen/) ? "xen" : "kvm";
 
-#Setup different var on different products
-my $host_os = get_var('HOST_OS');
-if ($host_os =~ /current_build/) {
+    #Setup different var on different products
+    my $host_os = get_var('HOST_OS');
+    if ($host_os =~ /current_build/) {
 
-    $vm_disk_dir                      = "/var/lib/libvirt/images";
-    $install_script                   = "/usr/share/qa/qa_test_virtualization/virt_installos";
-    $guest_install_prepare_keep_guest = qq(sed -i '/-d -o/s/-d -o/-d -u -o/' $install_script );
-}
-
-if ($host_os =~ /sles-11/i) {
-
-    $vm_disk_dir                      = "/var/lib/$hyper_visor/images";
-    $install_script                   = "/usr/share/qa/qa_test_virtualization/installos";
-    $guest_install_prepare_keep_guest = qq(sed -i 's/INSTALL_METHOD$/& -g/' $install_script);
-    $install_script .= " standalone";
-}
-
-$nfs_local_dir = "/tmp/pesudo_mount_server";
-
-sub get_var_from_parent {
-    my ($var) = @_;
-    my $parents = get_parents();
-    #Query every parent to find the var
-    for my $job_id (@$parents) {
-        my $ref = get_job_autoinst_vars($job_id);
-        return $ref->{$var} if defined $ref->{$var};
-    }
-    return;
-}
-
-sub get_var_from_child {
-    my ($var) = @_;
-    my $child = get_children();
-    #Query every child to find the var
-    for my $job_id (keys %$child) {
-        my $ref = get_job_autoinst_vars($job_id);
-        return $ref->{$var} if defined $ref->{$var};
-    }
-    return;
-}
-
-sub set_hosts {
-    my ($self) = @_;
-    my ($target_ip, $target_name);
-    if ($scenario_name =~ /_HT/) {
-
-        $target_ip   = get_var_from_child('MY_IP');
-        $target_name = get_var_from_child('MY_NAME');
-
-    }
-    else {
-
-        $target_ip   = get_var_from_parent('MY_IP');
-        $target_name = get_var_from_parent('MY_NAME');
+        $vm_disk_dir                      = "/var/lib/libvirt/images";
+        $install_script                   = "/usr/share/qa/qa_test_virtualization/virt_installos";
+        $guest_install_prepare_keep_guest = qq(sed -i '/-d -o/s/-d -o/-d -u -o/' $install_script );
     }
 
-    $self->execute_script_run("sed -i '/$target_ip/d' /etc/hosts ;echo $target_ip $target_name >>/etc/hosts", 15);
-    my $self_ip   = get_var('MY_IP');
-    my $self_name = get_var('MY_NAME');
-    $self->execute_script_run("sed -i '/$self_ip/d' /etc/hosts ;echo $self_ip $self_name >>/etc/hosts", 15);
+    if ($host_os =~ /sles-11/i) {
 
+        $vm_disk_dir                      = "/var/lib/$hyper_visor/images";
+        $install_script                   = "/usr/share/qa/qa_test_virtualization/installos";
+        $guest_install_prepare_keep_guest = qq(sed -i 's/INSTALL_METHOD$/& -g/' $install_script);
+        $install_script .= " standalone";
+    }
+
+    $nfs_local_dir = "/tmp/pesudo_mount_server";
 }
 1;

--- a/tests/virt_autotest/guest_migration_config_virtualization_env.pm
+++ b/tests/virt_autotest/guest_migration_config_virtualization_env.pm
@@ -10,13 +10,16 @@
 # Summary: virt_autotest: Virtualization multi-machine job : Guest Migration
 # Maintainer: jerry <jtang@suse.com>
 
-use base virt_autotest_base;
+use base multi_machine_job_base;
 use strict;
 use testapi;
 use guest_migration_base;
 
 sub run() {
     my ($self) = @_;
+
+    #settle all common settings
+    set_common_settings;
 
     #Turn off the firewall
     $self->execute_script_run("SuSEfirewall2 off", 500);
@@ -36,8 +39,6 @@ sub run() {
     my $ip_out = $self->execute_script_run('ip route show|grep kernel|cut -d" " -f12|head -1', 3);
     my $name_out = $self->execute_script_run('hostname', 3);
 
-    set_var('MY_IP',   $ip_out);
-    set_var('MY_NAME', $name_out);
-    bmwqemu::save_vars();
+    $self->set_ip_and_hostname_to_var;
 }
 1;

--- a/tests/virt_autotest/guest_migration_source_install_guest.pm
+++ b/tests/virt_autotest/guest_migration_source_install_guest.pm
@@ -10,7 +10,7 @@
 # Summary: virt_autotest: Virtualization multi-machine job : Guest Migration
 # Maintainer: jerry <jtang@suse.com>
 
-use base virt_autotest_base;
+use base multi_machine_job_base;
 use strict;
 use testapi;
 use guest_migration_base;

--- a/tests/virt_autotest/guest_migration_source_migrate.pm
+++ b/tests/virt_autotest/guest_migration_source_migrate.pm
@@ -10,7 +10,7 @@
 # Summary: virt_autotest: Virtualization multi-machine job : Guest Migration
 # Maintainer: jerry <jtang@suse.com>
 
-use base virt_autotest_base;
+use base multi_machine_job_base;
 use strict;
 use testapi;
 use guest_migration_base;
@@ -42,7 +42,7 @@ sub upload_tar_log() {
 sub run() {
     my ($self) = @_;
 
-    my $target_ip = get_var_from_parent('MY_IP');
+    my $target_ip = $self->get_var_from_parent('MY_IP');
 
     my $cmd_output = $self->execute_script_run("/usr/share/qa/virtautolib/lib/guest_migrate.sh -s -d $target_ip -v $hyper_visor -u root -p novell", 3600);
 

--- a/tests/virt_autotest/guest_migration_source_nfs_setup.pm
+++ b/tests/virt_autotest/guest_migration_source_nfs_setup.pm
@@ -10,7 +10,7 @@
 # Summary: virt_autotest: Virtualization multi-machine job : Guest Migration
 # Maintainer: jerry <jtang@suse.com>
 
-use base virt_autotest_base;
+use base multi_machine_job_base;
 use strict;
 use testapi;
 use lockapi;
@@ -25,7 +25,7 @@ sub run() {
     mutex_unlock('ip_set_done');
 
     #set hosts
-    set_hosts($self);
+    $self->set_hosts('child');
 
     #Change the nfs config
     my $cmd_modify_nfs_config = q(sed -i 's/^NFSV4LEASETIME=.*$/NFSV4LEASETIME="10"/' /etc/sysconfig/nfs);

--- a/tests/virt_autotest/guest_migration_target_nfs_setup.pm
+++ b/tests/virt_autotest/guest_migration_target_nfs_setup.pm
@@ -10,7 +10,7 @@
 # Summary: virt_autotest: Virtualization multi-machine job : Guest Migration
 # Maintainer: jerry <jtang@suse.com>
 
-use base virt_autotest_base;
+use base multi_machine_job_base;
 use strict;
 use testapi;
 use lockapi;
@@ -24,18 +24,12 @@ sub run() {
     mutex_create('ip_set_done');
 
     #Manually sync the setting for child nfs address
-    my $try_times = 0;
-    while (not(my $nfs_done = get_var_from_child('NFS_DONE'))) {
+    $self->workaround_for_reverse_lock('NFS_DONE', 1800);
 
-        sleep 60;
-        die if ($try_times == 10);
-        $try_times++;
-    }
-
-    my $nfs_server = get_var_from_child('MY_IP');
+    my $nfs_server = $self->get_var_from_child('MY_IP');
 
     #Setup /etc/hosts
-    set_hosts($self);
+    $self->set_hosts('parent');
 
     #Mount the share storage
     my $cmd_mount_disk_dir = "mount -t nfs -o vers=4,nfsvers=4 $nfs_server:$nfs_local_dir $vm_disk_dir";

--- a/tests/virt_autotest/multi_machine_job_base.pm
+++ b/tests/virt_autotest/multi_machine_job_base.pm
@@ -1,0 +1,90 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: base class for virtualization multi-machine job
+# Maintainer: alice <xlai@suse.com>
+
+package multi_machine_job_base;
+use base "virt_autotest_base";
+use strict;
+use testapi;
+use mmapi;
+use Data::Dumper;
+
+sub get_var_from_parent {
+    my ($self, $var) = @_;
+    my $parents = get_parents();
+    #Query every parent to find the var
+    for my $job_id (@$parents) {
+        my $ref = get_job_autoinst_vars($job_id);
+        return $ref->{$var} if defined $ref->{$var};
+    }
+    return;
+}
+
+sub get_var_from_child {
+    my ($self, $var) = @_;
+    my $child = get_children();
+    #Query every child to find the var
+    for my $job_id (keys %$child) {
+        my $ref = get_job_autoinst_vars($job_id);
+        return $ref->{$var} if defined $ref->{$var};
+    }
+    return;
+}
+
+sub set_ip_and_hostname_to_var {
+    my $self     = shift;
+    my $ip_out   = $self->execute_script_run('ip route show|grep kernel|cut -d" " -f12|head -1', 30);
+    my $name_out = $self->execute_script_run('hostname', 10);
+
+    set_var('MY_IP',   $ip_out);
+    set_var('MY_NAME', $name_out);
+    bmwqemu::save_vars();
+}
+
+sub set_hosts {
+    my ($self, $role) = @_;
+
+    my ($target_ip, $target_name);
+
+    if ($role =~ /parent/) {
+
+        $target_ip   = $self->get_var_from_child('MY_IP');
+        $target_name = $self->get_var_from_child('MY_NAME');
+
+    }
+    else {
+
+        $target_ip   = $self->get_var_from_parent('MY_IP');
+        $target_name = $self->get_var_from_parent('MY_NAME');
+    }
+
+    $self->execute_script_run("sed -i '/$target_ip/d' /etc/hosts ;echo $target_ip $target_name >>/etc/hosts", 15);
+    my $self_ip   = get_var('MY_IP');
+    my $self_name = get_var('MY_NAME');
+    $self->execute_script_run("sed -i '/$self_ip/d' /etc/hosts ;echo $self_ip $self_name >>/etc/hosts", 15);
+
+}
+
+#mmapi mutex_lock has flaws to get lock from child in parent job
+#workaround is to do it via var, that is use var instead of lock
+sub workaround_for_reverse_lock {
+    my ($self, $var, $timeout) = @_;
+    my $try_times = 0;
+
+    while (not(my $pesudo_lock = $self->get_var_from_child("$var"))) {
+        sleep 60;
+        die if ($try_times == $timeout / 60);
+        $try_times++;
+    }
+
+}
+
+1;

--- a/tests/virt_autotest/virt_v2v_dst.pm
+++ b/tests/virt_autotest/virt_v2v_dst.pm
@@ -1,0 +1,50 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: This test verifies sle and windows guest migration from xen to kvm using virt-v2v.
+#          This is the part to run on destination host.
+# Maintainer: alice <xlai@suse.com>
+
+use base multi_machine_job_base;
+use strict;
+use testapi;
+use lockapi;
+use mmapi;
+
+sub get_script_run() {
+    my ($self) = @_;
+
+    my $src_ip   = $self->get_var_from_parent('SRC_IP');
+    my $src_user = $self->get_var_from_parent('SRC_USER');
+    my $src_pass = $self->get_var_from_parent('SRC_PASS');
+    my $guests   = get_var("GUEST_LIST");
+    our $virt_v2v_log;
+
+    my $pre_test_cmd = "/usr/share/qa/virtautolib/lib/virt_v2v_test.sh -s $src_ip -u $src_user -p $src_pass -i \"$guests\" 2>&1 | tee $virt_v2v_log";
+
+    return "$pre_test_cmd";
+}
+
+sub run() {
+    my ($self) = @_;
+
+    mutex_lock('SRC_READY_TO_START');
+    mutex_unlock('SRC_READY_TO_START');
+
+    my $timeout = get_var("MAX_JOB_TIME", "10800") - 30;
+    our $virt_v2v_log_dir = "/tmp/virt-v2v/";
+    our $virt_v2v_log     = "$virt_v2v_log_dir/virt-v2v.log";
+    my $log_dirs = "$virt_v2v_log_dir /var/log/libvirt /var/log/messages";
+
+    assert_script_run("mkdir -p $virt_v2v_log_dir");
+
+    $self->run_test($timeout, "Congratulations! All tests passed!", "no", "yes", "$log_dirs", "virt-v2v-kvm-dst-logs");
+}
+
+1;

--- a/tests/virt_autotest/virt_v2v_src.pm
+++ b/tests/virt_autotest/virt_v2v_src.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: This test verifies sle and windows guest migration from xen to kvm using virt-v2v.
+#          This is the part to run on source host.
+# Maintainer: alice <xlai@suse.com>
+
+use base multi_machine_job_base;
+use strict;
+use testapi;
+use lockapi;
+use mmapi;
+
+sub run() {
+    my ($self) = @_;
+
+    my $ip_out = $self->execute_script_run('ip route show|grep kernel|cut -d" " -f12|head -1', 30);
+    set_var('SRC_IP',   $ip_out);
+    set_var('SRC_USER', "root");
+    set_var('SRC_PASS', "nots3cr3t");
+    bmwqemu::save_vars();
+
+    $self->execute_script_run("rm -r /var/log/qa/ctcs2/* /tmp/virt-v2v/* -r", 30);
+
+    mutex_create('SRC_READY_TO_START');
+
+    wait_for_children;
+
+    script_run("xl dmesg > /tmp/xl-dmesg.log");
+    &virt_autotest_base::upload_virt_logs("/var/log/libvirt /var/log/messages /var/log/xen /var/lib/xen/dump /tmp/xl-dmesg.log", "virt-v2v-xen-src-logs");
+}
+
+1;


### PR DESCRIPTION
This is a multiple machine job, involving two hosts.

This test can verify guest migration from xen to kvm with virt-v2v tool.

Supported guests： sle , windows

Successful job link:
http://147.2.212.248/tests/620
http://147.2.212.248/tests/621