### PR TITLE
Apply bootmenu workaround only for USBBOOT for now to prevent generic UEFI failure

### DIFF
--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -39,11 +39,11 @@ sub run() {
         assert_screen 'inst-bootmenu';
         send_key 'ret';
     }
-    elsif (get_var('UEFI', '')) {
+    elsif (get_var('UEFI') && get_var('USBBOOT')) {
         assert_screen 'inst-bootmenu';
         # assuming the cursor is on 'installation' by default and 'boot from
         # harddisk' is above
-        send_key_until_needlematch 'inst-bootmenu-boot-harddisk', 'up';
+        send_key_until_needlematch 'inst-oninstallation', 'up';
         send_key 'ret';
     }
     workaround_type_encrypted_passphrase;


### PR DESCRIPTION
Using tag of existing needles so that we do not need new needles.