### PR TITLE
Workaround for bsc#1013208 in yast2 migration

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -722,11 +722,15 @@ sub validate_repos {
             # Consider migration, use regex to match nvidia whether in upper, lower or mixed
             # Skip check AMD/ATI repo since it would be removed from sled12 and sle-we-12, see bsc#984866
             if ($base_product eq "SLED" || $we) {
+                # Show the softfail information here
+                if (check_var('SOFTFAIL', 'bsc#1013208')) {
+                    record_soft_failure 'workaround for bsc#1013208, nvidia repo was disabled after migration';
+                }
                 validatelr(
                     {
                         product         => "SLE-",
                         product_channel => 'GA-Desktop-[nN][vV][iI][dD][iI][aA]-Driver',
-                        enabled_repo    => "Yes",
+                        enabled_repo    => (check_var('SOFTFAIL', 'bsc#1013208')) ? "No" : "Yes",
                         uri             => $nvidia_uri,
                         version         => $version
                     });

--- a/tests/online_migration/sle12_online_migration/post_migration.pm
+++ b/tests/online_migration/sle12_online_migration/post_migration.pm
@@ -7,15 +7,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Add sle12 online migration testsuite
-#    Fixes follow up by the comments
-#
-#    Apply fully patch system function
-#
-#    Fix typo and remove redundant comment
-#
-#    Remove a unnecessary line
-# G-Maintainer: mitiao <mitiao@gmail.com>
+# Summary: sle12 online migration testsuite
+# Maintainer: mitiao <mitiao@gmail.com>
 
 use base "installbasetest";
 use strict;
@@ -30,6 +23,13 @@ sub run() {
     wait_still_screen;
     script_run("zypper lr -u | tee /dev/$serialdev");
     save_screenshot;
+
+    # nvidia repo is always updated by scc during migration
+    # we have to disable it after migration if find workaround
+    if (check_var('SOFTFAIL', 'bsc#1013208')) {
+        assert_script_run "zypper mr -d \$(zypper lr | grep -i nvidia | cut -d \' \' -f 1)";
+        record_soft_failure 'workaround for bsc#1013208, disable nvidia repo after migration';
+    }
 
     select_console 'x11';
     ensure_unlocked_desktop;

--- a/tests/online_migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/online_migration/sle12_online_migration/yast2_migration.pm
@@ -59,8 +59,14 @@ sub run {
         assert_screen 'yast2-migration-installupdate', 200;
         send_key "alt-y";
     }
-    assert_screen 'yast2-migration-proposal', 200;
-
+    # workaround for bsc#1013208
+    assert_screen ['yast2-migration-proposal', 'yast2-migration-nvidia_sp3_cannot_load'], 200;
+    if (match_has_tag 'yast2-migration-nvidia_sp3_cannot_load') {
+        send_key "alt-s";
+        record_soft_failure 'bsc#1013208: [online migration] nvidia repo is not ready for SLE12 SP3, skip it';
+        set_var('SOFTFAIL', 'bsc#1013208');
+        assert_screen 'yast2-migration-proposal';
+    }
     # giva a little time to check package conflicts
     if (check_screen("yast2-migration-conflicts", 15)) {
         if (!is_desktop_installed()) {


### PR DESCRIPTION
The nvidia repo is not ready for SLE12 SP3, we could skip it by yast2 migration as workaround.
Verified result:
http://147.2.207.208/tests/339