### PR TITLE
Update 3 libreoffice cases to fix unstable failure

### DIFF
--- a/tests/x11regressions/libreoffice/libreoffice_double_click_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_double_click_file.pm
@@ -35,28 +35,17 @@ sub run() {
     for my $tag (qw/doc docx fodg fodp fods fodt odf odg odp ods odt pptx xlsx/) {
         send_key_until_needlematch("libreoffice-specified-list-$tag", "right", 50, 1);
         assert_and_dclick("libreoffice-specified-list-$tag");
-        assert_screen("libreoffice-test-$tag", 60);
+        assert_screen("libreoffice-test-$tag", 90);
         if ($tag ne 'xlsx') {
             hold_key "alt";
             send_key_until_needlematch("libreoffice-nautilus-window", "tab");
             release_key "alt";
         }
     }
-    wait_screen_change {
-        # close libreoffice
+    send_key "ctrl-q";
+    if (!check_screen("generic-desktop")) {
         send_key "ctrl-q";
-    };
-    wait_still_screen;
-    hold_key "alt";
-    send_key "tab";
-    assert_screen("libreoffice-nautilus-window");
-    release_key "alt";
-    wait_still_screen;
-    wait_screen_change {
-        # close nautilus
-        send_key "alt-f4";
-    };
-    assert_screen("generic-desktop");
+    }
 
     #clean up
     $self->cleanup_libreoffice_recent_file();

--- a/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
@@ -34,7 +34,7 @@ sub run() {
         save_screenshot;
         type_string "/home/$username/Documents/ooo-test-doc-types/test.$tag\n";
         wait_still_screen 3;
-        assert_screen("libreoffice-test-$tag", 60);
+        assert_screen("libreoffice-test-$tag", 90);
     }
     send_key "ctrl-q";
     if (!check_screen("generic-desktop")) {

--- a/tests/x11regressions/libreoffice/libreoffice_recent_documents.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_recent_documents.pm
@@ -45,7 +45,9 @@ sub run() {
     send_key "ret";
     assert_screen 'test-ooffice-1';
 
-    send_key "ctrl-q";    # Quit oowriter
+    # Quit oowriter
+    assert_and_click 'ooffice-writing-area', 'left', 10;
+    send_key "ctrl-q";
 
     assert_screen 'generic-desktop';
 


### PR DESCRIPTION
- Extend the open testing file timeout of two libreoffice cases to 90s
- Add assert_and_click for recent_documents.pm to make sure oowriter has focus
- Improve the closing part for libreoffice_double_click_file

  see also: poo#13120

Validation run: http://147.2.212.239/tests/999