### PR TITLE
Add new repo channel for Salt into import-slenkins-testsuite.pl

### DIFF
--- a/script/import-slenkins-testsuite.pl
+++ b/script/import-slenkins-testsuite.pl
@@ -67,6 +67,7 @@ sub parse_channels {
         GALAXY           => "Galaxy",
         RUBYEXTENSIONS   => "RubyExtensions",
         NETWORKUTILITIES => "NetworkUtilities",
+        SALT             => "Salt",
     );
 
     my $channel_name  = $repo_table{$repo_var};


### PR DESCRIPTION
New Salt repo channel added into /etc/slenkins/channels.conf - most probably it will not be used in openQA but still...