### PR TITLE
Update firefox_urlsprotocols to workaround bsc#1004573 for SP3

### DIFF
--- a/tests/x11regressions/firefox/sle12/firefox_urlsprotocols.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_urlsprotocols.pm
@@ -14,6 +14,7 @@
 use strict;
 use base "x11regressiontest";
 use testapi;
+use utils;
 
 sub run() {
     my ($self) = @_;
@@ -27,7 +28,7 @@ sub run() {
         local => "file:///usr/share/w3m/w3mhelp.html"
     );
 
-    if (check_var('VERSION', '12-SP2')) {
+    if (sle_version_at_least('12-SP2')) {
         record_soft_failure 'bsc#1004573';
     }
     else {


### PR DESCRIPTION
failed at:  https://openqa.suse.de/tests/669142#step/firefox_urlsprotocols/10

Validation run for SP3: http://147.2.212.239/tests/1007 