### PR TITLE
Accept not-implemented fate#321208 as a given

### DIFF
--- a/tests/installation/boot_encrypt.pm
+++ b/tests/installation/boot_encrypt.pm
@@ -8,8 +8,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: splited wait_encrypt_prompt being a single step; harmonized once wait_encrypt_prompt obsoleted
-# G-Maintainer: Max Lin <mlin@suse.com>
+# Summary: Unlock encrypted partitions during bootup
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
 use strict;
 use base "installbasetest";
@@ -17,7 +17,7 @@ use utils;
 use testapi qw/get_var record_soft_failure/;
 
 sub run() {
-    if (get_var('ENCRYPT_ACTIVATE_EXISTING') && !get_var('ENCRYPT_FORCE_RECOMPUTE')) {
+    if (get_var('ENCRYPT_ACTIVATE_EXISTING') and !get_var('ENCRYPT_FORCE_RECOMPUTE') and (sle_version_at_least('12-SP4') or sle_version_at_least('13'))) {
         record_soft_failure('bsc#993247 fate#321208: activating existing encrypted volume does *not* yield an encrypted system if not forcing');
         return;
     }

--- a/tests/installation/partitioning_lvm.pm
+++ b/tests/installation/partitioning_lvm.pm
@@ -40,7 +40,7 @@ sub run() {
             record_soft_failure 'bsc#989750';
             $collect_logs = 1;
         }
-        elsif (match_has_tag('partitioning-encrypt-ignored-existing')) {
+        elsif (match_has_tag('partitioning-encrypt-ignored-existing') and (sle_version_at_least('12-SP4') or sle_version_at_least('13'))) {
             record_soft_failure 'bsc#993247 https://fate.suse.com/321208';
             $collect_logs = 1;
         }


### PR DESCRIPTION
The feature request fate#321208 was not included in evaluation for the SLE 12
SP3 feature funnel so that behaviour is not going to change anytime soon. We
have to accept the current behaviour as is and not record a soft failure.