### PR TITLE
Change kernel-version regex to be more permissive

### DIFF
--- a/tests/qam-kgraft/reboot_restore.pm
+++ b/tests/qam-kgraft/reboot_restore.pm
@@ -67,7 +67,7 @@ sub run() {
     save_screenshot;
 
     script_run("basename /boot/initrd-\$(uname -r) | sed s_initrd-__g | sed s_-default__g > /dev/$serialdev", 0);
-    my ($kver) = wait_serial(qr/^\d\.\d+\.\d+-\d+(?:\.\d+|)/) =~ /(^\d\.\d+\.\d+-\d+(?:\.\d+|))\s/;
+    my ($kver) = wait_serial(qr/(^[\d.-]+)-.+\s/) =~ /(^[\d.-]+)-.+\s/;
 
     script_run("lsinitrd /boot/initrd-$kver-xen | grep patch");
     save_screenshot;


### PR DESCRIPTION
The kernel version got longer by one block which causes the sed statement
to not match. This commit makes the regex more permissive.

Attention: This will not work for kernel-rt, because it has "rt" in the
version number but since there are no live patches for this flavour it is
only a minor concern.