### PR TITLE
Overload post fail hook for yast2 snapper

### DIFF
--- a/tests/x11/yast2_snapper.pm
+++ b/tests/x11/yast2_snapper.pm
@@ -127,5 +127,16 @@ sub run() {
     $self->clean_and_quit;
 }
 
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->export_kde_logs;
+    $self->export_logs;
+
+    # Upload y2log for analysis if yast2 snapper fails
+    assert_script_run "save_y2logs /tmp/y2logs.tar.bz2";
+    upload_logs "/tmp/y2logs.tar.bz2";
+    save_screenshot;
+}
+
 1;
 # vim: set sw=4 et:


### PR DESCRIPTION
Upload all logs including y2log if yast2_snapper fails, it aims to check following failure:
https://openqa.suse.de/tests/672456#step/yast2_snapper/45

verified result:
http://147.2.207.208/tests/364#downloads