### PR TITLE
Add HDDSIZEGB key to boot_to_snapshot test

### DIFF
--- a/products/opensuse/templates
+++ b/products/opensuse/templates
@@ -3230,6 +3230,7 @@
                         { key => "BOOT_TO_SNAPSHOT", value => 1 },
                         { key => "DESKTOP", value => "textmode" },
                         { key => "INSTALLONLY", value => 1 },
+                        { key => "HDDSIZEGB", value => 40 },
                       ],
                     },
                     {


### PR DESCRIPTION
set it to 40GB to match what is already set in openQA.o.o instance
This is required to avoid error if only default 10GB
because of checking done in snapper_is_applicable function
(in lib/main_common.pm)

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>