### PR TITLE
Improve empathy_irc test

### DIFF
--- a/tests/x11regressions/empathy/empathy_irc.pm
+++ b/tests/x11regressions/empathy/empathy_irc.pm
@@ -32,6 +32,7 @@ sub run() {
 
     # select freenode irc network
     assert_and_click 'empathy-irc-network';
+    assert_screen 'empathy-irc-network-choose';
     type_string "freenode";
     assert_screen 'empathy-irc-freenode';
     wait_screen_change {
@@ -48,16 +49,14 @@ sub run() {
     };
 
     # join openqa channel
-    if (sle_version_at_least('12-SP2')) {
+    send_key "ctrl-j";
+    if (!check_screen 'empathy-join-room') {
+        record_soft_failure 'bsc#999832: keyboard shortcut of empathy not working on SLED12SP2';
         assert_and_click 'empathy-menu';
         send_key_until_needlematch "empathy-menu-rooms", "down";
         assert_and_click 'empathy-menu-joinrooms';
-        record_soft_failure 'bsc#999832: keyboard shortcut of empathy not working on SLED12SP2';
+        assert_screen 'empathy-join-room';
     }
-    else {
-        send_key "ctrl-j";
-    }
-    assert_screen 'empathy-join-room';
     type_string "openqa";
     send_key "ret";
 
@@ -70,12 +69,10 @@ sub run() {
     send_key "ret";
 
     # cleaning
-    if (sle_version_at_least('12-SP2')) {
+    send_key "f4";
+    if (!check_screen 'empathy-disable-account') {
         assert_and_click 'empathy-menu';
         assert_and_click 'empathy-menu-accounts';
-    }
-    else {
-        send_key "f4";
     }
     assert_and_click 'empathy-disable-account';
     assert_and_click 'empathy-delete-account';
@@ -87,12 +84,11 @@ sub run() {
     };
 
     # quit
-    if (sle_version_at_least('12-SP2')) {
+    send_key "ctrl-q";
+    wait_still_screen 3;
+    if (check_screen 'empathy-menu', 0) {
         assert_and_click 'empathy-menu';
         assert_and_click 'empathy-menu-quit';
-    }
-    else {
-        send_key "ctrl-q";
     }
 }
 


### PR DESCRIPTION
The empathy_irc test expects that shortcuts fail on SLE12-SP2 and succeed on other version. However, the test should record a soft failure when the test actually fails and not based on the version. Also the workarounds are now used in previous versions as well, since the shortcuts might fail occasionally (openQA lag?).

needles: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/2244
( EDIT - correct link: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/278 )

Working examples:
SP1 - http://rwmanosvm1.suse.cz/tests/188
SP2 - http://rwmanosvm1.suse.cz/tests/187