### PR TITLE
Fix generated autoyast profile before use

### DIFF
--- a/tests/console/yast2_clone_system.pm
+++ b/tests/console/yast2_clone_system.pm
@@ -23,12 +23,10 @@ sub run() {
     zypper_call "in autoyast2";
     assert_script_run "yast2 clone_system", 200;
 
+    # Replace unitialized email variable - bsc#1015158
+    assert_script_run 'sed -i "/server_email/ s/postmaster@/\0suse.com/" /root/autoinst.xml';
+
     # Check and upload profile for chained tests
-    assert_script_run(
-        "test -f /root/autoinst.xml",
-        timeout      => 20,
-        fail_message => 'File /root/autoinst.xml could not be found'
-    );
     upload_asset "/root/autoinst.xml";
     assert_script_run "xmllint --noout --relaxng /usr/share/YaST2/schema/autoyast/rng/profile.rng /root/autoinst.xml";
 


### PR DESCRIPTION
Checking if autoinst.xml exists is duplicit as upload_asset does that
Fixing: https://openqa.suse.de/tests/684340#step/installation/14
Local run:
 profile generation - http://dhcp91.suse.cz/tests/3429#step/yast2_clone_system/5
 installation using profile - http://dhcp91.suse.cz/tests/3430

poo#15574
bsc#1015158