### PR TITLE
Fix FIPS test failures due to script_output update

### DIFF
--- a/tests/console/aide_check.pm
+++ b/tests/console/aide_check.pm
@@ -22,7 +22,7 @@ use testapi;
 use strict;
 
 # test for basic function of aide. Check different between aide.db and file system
-sub run() {
+sub run {
     my $self = shift;
     select_console 'root-console';
     assert_script_run "zypper -n in aide", 90;
@@ -33,11 +33,11 @@ sub run() {
     assert_script_run "aide --check", 60;
     assert_script_run "touch /var/log/testlog";
     assert_script_run "clear";
-    validate_script_output "aide --check | tee", sub { m/found differences between database and filesystem/ }, 60;
+    validate_script_output "aide --check || true", sub { m/found differences between database and filesystem/ }, 60;
     assert_script_run "mv /etc/aide.conf.bak /etc/aide.conf && rm /var/log/testlog";
 }
 
-sub test_flags() {
+sub test_flags {
     return {important => 1};
 }
 

--- a/tests/fips/curl_fips_rc4_seed.pm
+++ b/tests/fips/curl_fips_rc4_seed.pm
@@ -7,27 +7,26 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Test curl RC4 and SEED ciphers with fips enabled
+# Summary: Test curl RC4 and SEED ciphers with fips enabled
 #    This is new curl test case for fips related.
 #    Both RC4 and SEED are not approved cipher by FIPS140-2.
 #    In a fips enabled system, it will get a failed result if run curl command
 #    with RC4 and SEED ciphers.
-# G-Maintainer: Jiawei Sun <JiaWei.Sun@suse.com>
+# Maintainer: Jiawei Sun <JiaWei.Sun@suse.com>
 
 use base "consoletest";
 use testapi;
 use strict;
 
 # test for curl RC4 and SEED ciphers with fips enabled
-sub run() {
+sub run {
     my $self = shift;
     select_console 'root-console';
-    script_output "curl --ciphers RC4,SEED -v https://eu.httpbin.org/get | tee";
-    validate_script_output "curl --ciphers RC4,SEED -v https://eu.httpbin.org/get 2>&1 | tee", sub { m/failed setting cipher/ };
-    validate_script_output "rpm -q curl libcurl4",                                             sub { m/curl-.*/ };
+    validate_script_output "curl --ciphers RC4,SEED -v https://eu.httpbin.org/get 2>&1 || true", sub { m/failed setting cipher/ };
+    validate_script_output "rpm -q curl libcurl4",                                               sub { m/curl-.*/ };
 }
 
-sub test_flags() {
+sub test_flags {
     return {important => 1};
 }
 

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -7,31 +7,36 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Setup system work into fips mode
+# Summary: Setup system work into fips mode
 #    Install fips pattern and update grub.cfg with fips=1
 #
 #    Also include workaround of bsc#982268:
 #    Due to bsc#982268, openssl couldn't enter fips mode even the
 #    system is booted with fips=1. Workaround is create the file
 #    /etc/system-fips manually.
-# G-Maintainer: Qingming Su <qingming.su@suse.com>
+# Maintainer: Qingming Su <qingming.su@suse.com>
 
 use base "consoletest";
 use testapi;
 use strict;
 
 # Install fips pattern and update grub.cfg to boot with fips=1
-sub run() {
+sub run {
     select_console 'root-console';
 
-    if (!script_output "grep 'fips=1' /proc/cmdline | tee") {
-        script_run 'zypper -n install --type pattern fips', 300;
-        script_run 'sed -i \'/^GRUB_CMDLINE_LINUX_DEFAULT/s/\("\)$/ fips=1\1/\' /etc/default/grub';
-        script_run 'grub2-mkconfig -o /boot/grub2/grub.cfg';
-    }
+    my $setup_script = "
+    grep 'fips=1' /proc/cmdline && exit 0
+    zypper -n install --type pattern fips
+    sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT/s/\\(\"\\)\$/ fips=1\\1/' /etc/default/grub
+    grub2-mkconfig -o /boot/grub2/grub.cfg
+    grep 'fips=1' /boot/grub2/grub.cfg
+    ";
+
+    print $setup_script;
+    script_output($setup_script, 300);
 }
 
-sub test_flags() {
+sub test_flags {
     return {important => 1};
 }
 

--- a/tests/fips/openssh/openssh_fips.pm
+++ b/tests/fips/openssh/openssh_fips.pm
@@ -23,7 +23,7 @@ use base "consoletest";
 use strict;
 use testapi;
 
-sub run() {
+sub run {
     select_console 'root-console';
 
     # Verify MD5 is disabled in fips mode, no need to login
@@ -39,10 +39,10 @@ sub run() {
       sub { m/Unknown mac type|no matching MAC found/ };
 
     # Verify ssh doesn't support DSA public key in fips mode
-    validate_script_output 'ssh-keygen -t dsa -f ~/.ssh/id_dsa -P "" 2>&1 | tee', sub { m/Key type dsa not alowed in FIPS mode/ };
+    validate_script_output 'ssh-keygen -t dsa -f ~/.ssh/id_dsa -P "" 2>&1 || true', sub { m/Key type dsa not alowed in FIPS mode/ };
 }
 
-sub test_flags() {
+sub test_flags {
     return {important => 1};
 }
 

--- a/tests/fips/openssl/openssl_fips_alglist.pm
+++ b/tests/fips/openssl/openssl_fips_alglist.pm
@@ -15,30 +15,30 @@ use base "consoletest";
 use testapi;
 use strict;
 
-sub run() {
+sub run {
     select_console 'root-console';
 
     # List cipher algorithms in fips mode:
     # only AES and DES3 are approved
     validate_script_output
-      'echo -n "Invalid Cipher: "; openssl list-cipher-algorithms | grep -vE "AES|aes|DES3|des3|DES-EDE" | wc -l',
+      "echo -n 'Invalid Cipher: '; openssl list-cipher-algorithms | sed -e '/AES/d' -e '/aes/d' -e '/DES3/d' -e '/des3/d' -e '/DES-EDE/d' | wc -l",
       sub { m/^Invalid Cipher: 0$/ };
 
     # List message digest algorithms in fips mode:
     # only SHA1 and SHA2 (224, 256, 384, 512) are approved
     # Note: DSA is short of DSA-SHA1, so it is also valid item
     validate_script_output
-      'echo -n "Invalid Hash: "; openssl list-message-digest-algorithms | grep -vE "SHA1|SHA224|SHA256|SHA384|SHA512|DSA" | wc -l',
+"echo -n 'Invalid Hash: '; openssl list-message-digest-algorithms | sed -e '/SHA1/d' -e '/SHA224/d' -e '/SHA256/d' -e '/SHA384/d' -e '/SHA512/d' -e '/DSA/d' | wc -l",
       sub { m/^Invalid Hash: 0$/ };
 
     # List public key algorithms in fips mode:
     # only RSA, DSA, ECDSA, EC DH, CMAC and HMAC are approved
     validate_script_output
-      'echo -n "Invalid Pubkey: "; openssl list-public-key-algorithms | grep ^Name | grep -vE "RSA|rsa|DSA|dsa|EC|DH|HMAC|CMAC" | wc -l',
+"echo -n 'Invalid Pubkey: '; openssl list-public-key-algorithms | grep '^Name' | sed -e '/RSA/d' -e '/rsa/d' -e '/DSA/d' -e '/dsa/d' -e '/EC/d' -e '/DH/d' -e '/HMAC/d' -e '/CMAC/d' | wc -l",
       sub { m/^Invalid Pubkey: 0$/ };
 }
 
-sub test_flags() {
+sub test_flags {
     return {important => 1};
 }
 

--- a/tests/fips/openssl/openssl_fips_cipher.pm
+++ b/tests/fips/openssl/openssl_fips_cipher.pm
@@ -16,7 +16,7 @@ use testapi;
 use strict;
 use utils;
 
-sub run() {
+sub run {
     select_console 'root-console';
 
     my $enc_passwd = "pass1234";
@@ -44,14 +44,14 @@ sub run() {
     }
     for my $cipher (@invalid_cipher) {
         validate_script_output
-          "openssl enc -$cipher -e -in $file_raw -out $file_enc -k $enc_passwd -md $hash_alg 2>&1 | tee",
+          "openssl enc -$cipher -e -in $file_raw -out $file_enc -k $enc_passwd -md $hash_alg 2>&1 || true",
           sub { m/disabled for fips|unknown option/ };
     }
 
     script_run 'cd - && rm -rf fips-test';
 }
 
-sub test_flags() {
+sub test_flags {
     return {important => 1};
 }
 

--- a/tests/fips/openssl/openssl_fips_hash.pm
+++ b/tests/fips/openssl/openssl_fips_hash.pm
@@ -10,17 +10,17 @@
 # Test description: In fips mode, openssl only works with the FIPS
 # approved HASH algorithms: SHA1 and SHA2 (224, 256, 384, 512)
 
-# G-Summary: Add Hash and Cipher test cases for openssl-fips
+# Summary: Add Hash and Cipher test cases for openssl-fips
 #    A new test suite is created for FIPS_TS, named "core", which will
 #    contain all the basic test cases for fips verificaton. Just like
 #    the cases to verify opessl hash, cipher, or public key algorithms
-# G-Maintainer: Qingming Su <qingming.su@suse.com>
+# Maintainer: Qingming Su <qingming.su@suse.com>
 
 use base "consoletest";
 use testapi;
 use strict;
 
-sub run() {
+sub run {
     select_console 'root-console';
 
     my $tmp_file = "/tmp/hello.txt";
@@ -37,13 +37,13 @@ sub run() {
     # With non-approved HASH algorithms, openssl will report failure
     my @invalid_hash = ("md4", "md5", "mdc2", "ripemd160", "whirlpool", "sha");
     for my $hash (@invalid_hash) {
-        validate_script_output "openssl dgst -$hash $tmp_file 2>&1 | tee", sub { m/disabled for fips|unknown option/ };
+        validate_script_output "openssl dgst -$hash $tmp_file 2>&1 || true", sub { m/disabled for fips|unknown option/ };
     }
 
     script_run 'rm -f $tmp_file';
 }
 
-sub test_flags() {
+sub test_flags {
     return {important => 1};
 }
 


### PR DESCRIPTION
Resolve the issue that some FIPS test cases are failed after
script_output function in testapi.pm been updated with:
  /bin/bash -eox pipefail $run_script