### PR TITLE
LTP: Add junkfile for aiodio tests

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -941,6 +941,9 @@ elsif (get_var('INSTALL_LTP')) {
 }
 elsif (get_var('LTP_COMMAND_FILE')) {
     loadtest 'kernel/boot_ltp';
+    if (get_var('LTP_COMMAND_FILE') =~ m/ltp-aiodio.part[134]/) {
+        loadtest 'kernel/create_junkfile_ltp';
+    }
     loadtest 'kernel/run_ltp';
 }
 elsif (get_var('VIRTIO_CONSOLE_TEST')) {

--- a/tests/kernel/create_junkfile_ltp.pm
+++ b/tests/kernel/create_junkfile_ltp.pm
@@ -1,0 +1,48 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Creates some files for the aiodio tests, see ltp/testscripts/ltp-aiodio.sh
+# Maintainer: Richard Palethorpe <rpalethorpe@suse.com>
+
+use 5.018;
+use warnings;
+use base 'opensusebasetest';
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    my $pdir   = '$TMPDIR/aiodio.$$';
+    my $dir    = '$TMPDIR/aiodio';
+
+    assert_script_run("mkdir -p $pdir/junkdir $dir");
+    assert_script_run("dd if=/dev/urandom of=$pdir/junkfile oflag=sync bs=1M count=26");
+    upload_logs("$pdir/junkfile", failok => 1);
+    for my $f (['f', '8K'], ['1', '4K'], ['2', '1K'], ['3', '512']) {
+        assert_script_run("dd if=$pdir/junkfile of=$pdir/ff$f->[0] bs=$f->[1] conv=block,sync");
+    }
+    for my $f ([2, '2K'], [3, '1K'], [4, '512'], [5, '4K']) {
+        assert_script_run("dd if=$pdir/junkfile of=$dir/file$f->[0] bs=$f->[1] conv=block,sync");
+    }
+}
+
+sub test_flags {
+    return {
+        fatal     => 1,
+        milestone => 1
+    };
+}
+
+=head1 Configuration
+
+This test module is activated when LTP_COMMAND_FILE is set to one of the aiodio
+tests.
+
+=cut
+
+1;

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -255,6 +255,8 @@ sub run {
         @tests = $self->parse_runfile($cmd_file, $cmd_pattern, $cmd_exclude);
     }
 
+    assert_script_run('cd /opt/ltp/testcases/bin');
+
     for my $test (@tests) {
         my $fin_msg    = "### TEST $test->{name} COMPLETE >>> ";
         my $cmd_text   = qq($test->{command}; echo "$fin_msg\$?");


### PR DESCRIPTION
This gets the aiodio tests running which is better than not running them.

Verification:
http://10.100.51.181:8080/tests/640
http://10.100.51.181:8080/tests/636
http://10.100.51.181:8080/tests/641
http://10.100.51.181:8080/tests/643

@metan-ucw