### PR TITLE
LTP: fix run_ltp for non-networking tests

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -27,6 +27,9 @@ sub run {
     }
 
     assert_script_run('export LTPROOT=/opt/ltp; export TMPDIR=/tmp PATH=$LTPROOT/testcases/bin:$PATH');
+
+    # setup for LTP networking tests
+    assert_script_run("export PASSWD='$testapi::password'");
 }
 
 sub test_flags {

--- a/tests/kernel/ltp_setup_networking.pm
+++ b/tests/kernel/ltp_setup_networking.pm
@@ -17,7 +17,7 @@ use base 'opensusebasetest';
 use testapi;
 use utils;
 
-sub install_services {
+sub install {
     # utils
     zypper_call("in expect iputils net-tools-deprecated telnet", log => 1);
 
@@ -32,8 +32,7 @@ sub install_services {
     }
 }
 
-sub setup_env_variables {
-    my $conf_file = '/root/env-variables.sh';    # TODO: remove duplicity with run_ltp.pm
+sub setup {
     my $content;
 
     $content = <<EOF;
@@ -63,21 +62,13 @@ EOF
     # nfs
     assert_script_run 'echo \'/ *(rw,no_root_squash,sync)\' >> /etc/exports';
     assert_script_run 'exportfs';
-
-    # variables for run_ltp.pm
-    $content = <<EOF;
-export PASSWD='$testapi::password'
-export TST_USE_NETNS=1
-EOF
-    assert_script_run "echo \"$content\" > $conf_file";
-    upload_logs $conf_file;
 }
 
 # poo#14402
 sub run {
     select_console(get_var('VIRTIO_CONSOLE') ? 'root-virtio-terminal' : 'root-console');
-    install_services;
-    setup_env_variables;
+    install;
+    setup;
 }
 
 sub test_flags {

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -242,15 +242,10 @@ sub run {
     my ($self) = @_;
     my $cmd_file = get_var 'LTP_COMMAND_FILE';
     die 'Need LTP_COMMAND_FILE to know which tests to run' unless $cmd_file;
-    my $conf_file   = '/root/env-variables.sh';                 # TODO: remove duplicity with ltp_setup_networking.pm
     my $cmd_pattern = get_var('LTP_COMMAND_PATTERN') || '.*';
     my $cmd_exclude = get_var('LTP_COMMAND_EXCLUDE') || '$^';
-    my $timeout     = get_var('LTP_TIMEOUT') || 900;
+    my $timeout     = get_var('LTP_TIMEOUT')         || 900;
     my $is_posix    = $cmd_file =~ m/^\s*openposix\s*$/i;
-
-    if ($conf_file) {
-        assert_script_run(". '$conf_file'");
-    }
 
     my @tests;
     if ($is_posix) {


### PR DESCRIPTION
+ removed TST_USE_NETNS variable (not needed)

This is a regression from:
2543482d LTP: add setup module for networking tests