### PR TITLE
Fix CASP installation and feature tests

### DIFF
--- a/products/casp/main.pm
+++ b/products/casp/main.pm
@@ -75,9 +75,6 @@ sub load_inst_tests() {
     # https://trello.com/c/X5VAq8PJ/779-3-casp-installation-proposal
     loadtest 'installation/installation_overview';
 
-    # Check releasenotes button on installation proposal
-    loadtest 'installation/releasenotes';
-
     # Actual installation
     loadtest 'installation/start_install';
     loadtest 'installation/install_and_reboot';
@@ -96,7 +93,7 @@ sub load_features_after {
     loadtest 'casp/libzypp_config_sym';
     loadtest 'casp/timezone_utc_sym';
     loadtest 'casp/filesystem_ro';
-    # Check autoyast profile - poo#321764
+    # Check autoyast profile - poo#321764 - missing SCC & YaST
     # loadtest 'casp/autoyast';
 }
 
@@ -105,9 +102,10 @@ load_boot_tests;
 if (check_var('FLAVOR', 'DVD')) {
     load_features_before if get_var('FEATURES');
     load_inst_tests();
+    # Installer will go back to shell (YaST feature)
+    loadtest 'casp/rcshell_exit_sym' if get_var('FEATURES');
 }
-loadtest 'installation/first_boot';
-loadtest 'casp/login';
+loadtest 'casp/first_boot';
 
 load_features_after if get_var('FEATURES');
 

--- a/tests/casp/first_boot.pm
+++ b/tests/casp/first_boot.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Login into CASP
+# Summary: First boot and login into CASP
 # Maintainer: Martin Kravec <mkravec@suse.com>
 
 use base "opensusebasetest";
@@ -15,12 +15,16 @@ use strict;
 use testapi;
 
 sub run() {
+    if (!check_var('ARCH', 's390x')) {
+        assert_screen 'linux-login', 200;
+    }
     select_console 'root-console';
 }
 
 sub test_flags() {
-    return {fatal => 1};
+    return {fatal => 1, milestone => 1};
 }
 
 1;
+
 # vim: set sw=4 et:

--- a/tests/casp/keyboard_password.pm
+++ b/tests/casp/keyboard_password.pm
@@ -19,7 +19,6 @@ sub run() {
     my ($self) = @_;
 
     assert_screen 'keyboard-password', 120;
-
     mouse_hide;
 
     $self->type_password_and_verification;

--- a/tests/casp/libzypp_config.pm
+++ b/tests/casp/libzypp_config.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Check that zypper configuration is customized for CASP
-# poo#321764
+# fate#321764
 # Maintainer: Martin Kravec <mkravec@suse.com>
 
 use base "opensusebasetest";

--- a/tests/casp/rcshell_exit.pm
+++ b/tests/casp/rcshell_exit.pm
@@ -15,6 +15,7 @@ use strict;
 use testapi;
 
 sub run() {
+    assert_screen 'startshell';
     send_key "ctrl-d";
 }
 

--- a/tests/casp/rcshell_exit_sym.pm
+++ b/tests/casp/rcshell_exit_sym.pm
@@ -1,0 +1,1 @@
+rcshell_exit.pm


### PR DESCRIPTION
Remove release notes
Exit shell after YaST installer finishes
Optimize first_boot for CASP textmode

Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/281
Local runs:
http://dhcp91.suse.cz/tests/3490 - dvd
http://dhcp91.suse.cz/tests/3488 - features
http://dhcp91.suse.cz/tests/3489 - vmx