### PR TITLE
Make remote vnc installation more robust

### DIFF
--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -96,6 +96,7 @@ sub run() {
         last;
     }
 
+    # Upload logs before reboot
     if (!get_var("REMOTE_CONTROLLER")) {
         do {
             send_key 'alt-s';
@@ -107,7 +108,9 @@ sub run() {
         select_console 'installation';
         assert_screen 'rebootnow';
     }
-    send_key 'alt-o';
+    wait_screen_change {
+        send_key 'alt-o';    # Reboot
+    };
 }
 
 1;


### PR DESCRIPTION
Fixes issues when remote controller finishes before target notices
system reboot.

Local run:
http://dhcp91.suse.cz/tests/3528 - target
http://dhcp91.suse.cz/tests/3529 - controller

poo#15720