### PR TITLE
Fix pull request #2223

### DIFF
--- a/tests/qam-kgraft/reboot_restore.pm
+++ b/tests/qam-kgraft/reboot_restore.pm
@@ -65,7 +65,7 @@ sub run() {
     script_run("cat /tmp/lsboot");
     save_screenshot;
 
-    script_run("basename /boot/initrd-\$(uname -r) | sed s_initrd-__g | sed s_-default__g > /dev/$serialdev", 0);
+    script_run("basename /boot/initrd-\$(uname -r) | sed s_initrd-__g > /dev/$serialdev", 0);
     my ($kver) = wait_serial(qr/(^[\d.-]+)-.+\s/) =~ /(^[\d.-]+)-.+\s/;
 
     script_run("lsinitrd /boot/initrd-$kver-xen | grep patch");


### PR DESCRIPTION
The regex introduced in pull request #2223 [1] was created under the
assumption that the kernel-flavour wouldn't be cut off.
This commit removes the sed-invocation that cuts off the flavour.

[1] https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/2223