### PR TITLE
LTP: Add Workstation Extension repo for ntfsprogs

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -38,7 +38,7 @@ sub install_dependencies {
     my @deps = qw(git-core make automake autoconf gcc libnuma-devel libaio-devel numactl
       flex bison dmapi-devel kernel-default-devel libopenssl-devel libselinux-devel
       libacl-devel libtirpc-devel keyutils-devel libcap-devel sysstat tpm-tools
-      tpm2.0-tools);
+      tpm2.0-tools psmisc acl quota);
     if (check_var('DISTRI', 'opensuse') || try_add_workstation_addon()) {
         push @deps, 'ntfsprogs';
     }


### PR DESCRIPTION
On SLES the WE extension is required for the ntfsprogs (containing mkfs.ntfs)
package.

@pevik FYI