### PR TITLE
Do not accept hostname from DHCP, use static one

### DIFF
--- a/tests/console/hostname.pm
+++ b/tests/console/hostname.pm
@@ -20,14 +20,19 @@ sub run() {
 
     my $hostname = get_var("HOSTNAME", 'susetest');
     assert_script_run "hostnamectl set-hostname $hostname";
-    assert_script_run "hostnamectl status|grep $hostname";
-    assert_script_run "hostname|grep $hostname";
-    # if you change hostname using `hostnamectl set-hostname`, then `hostname -f` will fail with "hostname: Name or service not known"
-    # also DHCP/DNS don't know about the changed hostname, you need to send a new DHCP request to update dynamic DNS
-    # yast2-network module does "NetworkService.ReloadOrRestart if Stage.normal || !Linuxrc.usessh" if hostname is changed via `yast2 lan`
+    assert_script_run "hostnamectl status | grep $hostname";
+    assert_script_run "hostname | grep $hostname";
     script_run "systemctl status network.service";
     save_screenshot;
+    # Do not set hostname from DHCP for a while, otherwise hostname is re-set to transient
+    # hostname on network restart, where user-mode networking is not present (i.e. brigged networks).
+    assert_script_run("sed -ie '/DHCLIENT_SET_HOSTNAME=/s/=.*/=\"no\"/' /etc/sysconfig/network/dhcp");
+    # DHCP/DNS don't know about the changed hostname, a new DHCP request should be send
+    # to update dynamic DNS. yast2-network module restarts network.service via `yast2 lan`.
     assert_script_run "if systemctl -q is-active network.service; then systemctl reload-or-restart network.service; fi";
+    script_run "systemctl status network.service";
+    save_screenshot;
+    assert_script_run("sed -ie '/DHCLIENT_SET_HOSTNAME=/s/=.*/=\"yes\"/' /etc/sysconfig/network/dhcp");
 }
 
 sub test_flags() {


### PR DESCRIPTION
POO#15740

On Xen under svirt backend we don't have user-mode networking we have
for KVM and Qemu. If networking.service is restarted (explicitly or by
system restart) on Xen the system accepts new hostname different from
the static one.

This change prevents system to set as a hostname whatever comes from
DHCP and sticks with static hostname. Otherwise yast2_lan test fails:
https://openqa.suse.de/tests/692200.

Now `hostname --fqdn` fails on all systems but that's expected as domain
name is not set.

Verification runs:
Xen:  http://assam.suse.cz/tests/4578
KVM:  http://assam.suse.cz/tests/4575
Qemu: http://assam.suse.cz/tests/4577