### PR TITLE
Move SLE specific serialdev init to SLE's main.pm

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -124,6 +124,16 @@ unless (get_var("DESKTOP")) {
 set_var('NOAUTOLOGIN', 1);
 set_var('HASLICENSE',  1);
 
+# Set serial console for Xen PV
+if (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')) {
+    if (sle_version_at_least('12-SP2')) {
+        set_var('SERIALDEV', 'hvc0');
+    }
+    else {
+        set_var('SERIALDEV', 'xvc0');
+    }
+}
+
 if (sle_version_at_least('12-SP2')) {
     set_var('SP2ORLATER', 1);
 }


### PR DESCRIPTION
POO#15756

Requires: https://github.com/os-autoinst/os-autoinst/pull/685
Verification run: http://assam.suse.cz/tests/4581

Move SLE specific code from testapi.pm to main.pm. Also use /dev/hvc0
for 12-SP2 on, /dev/xvc0 for the rest.