### PR TITLE
fix install_packages fails with uninstallable packages

### DIFF
--- a/tests/console/install_packages.pm
+++ b/tests/console/install_packages.pm
@@ -1,15 +1,15 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: new test that installs configured packages
-# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+# Summary: new test that installs configured packages
+# Maintainer: Stephan Kulow <coolo@suse.com>
 
 use base "consoletest";
 use strict;
@@ -29,7 +29,7 @@ sub run() {
     assert_script_run("test -s \$XDG_RUNTIME_DIR/install_packages.txt");
     # might take longer for large patches (i.e. 12 kernel flavors)
     assert_script_run("xargs --no-run-if-empty zypper -n in -l < \$XDG_RUNTIME_DIR/install_packages.txt", 800);
-    assert_script_run("rpm -q $packages | tee /dev/$serialdev");
+    assert_script_run("xargs --no-run-if-empty rpm -q < \$XDG_RUNTIME_DIR/install_packages.txt | tee /dev/$serialdev");
 }
 
 sub test_flags() {


### PR DESCRIPTION
install_packages fails for uninstallable packags. lsmfip already
filters some correctly, however the final rpm command errors out on
missing pacakges, as the list comes from INSTALL_PACKAGES

Use the list filtered to lsmfip for rpm -q as well.