### PR TITLE
Check responsiveness not only on gnome

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -249,7 +249,7 @@ sub ensure_unlocked_desktop {
         }
         if (match_has_tag 'generic-desktop') {
             send_key 'esc';
-            if (check_var('DESKTOP', 'gnome')) {
+            if (!check_var('DESKTOP', 'minimalx')) {
                 # gnome might show the old 'generic desktop' screen although that is
                 # just a left over in the framebuffer but actually the screen is
                 # already locked so we have to try something else to check


### PR DESCRIPTION
Only exclude minimalx, there alt-f2 doesn't work and screenlock is not activated automatically

[KDE fail](http://10.100.12.155/tests/4545#step/xterm/9)
[KDE pass](http://10.100.12.155/tests/4551#step/consoletest_finish/9)
[minimalx](http://10.100.12.155/tests/4550#step/consoletest_finish/9)
