### PR TITLE
Do not re-create VM domain after installation

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -537,7 +537,7 @@ sub load_inst_tests() {
         loadtest "installation/start_install";
     }
     loadtest "installation/install_and_reboot";
-    if (check_var('BACKEND', 'svirt')) {
+    if (check_var('BACKEND', 'svirt') and check_var('ARCH', 's390x')) {
         # on svirt we need to redefine the xml-file to boot the installed kernel
         loadtest "installation/redefine_svirt_domain";
     }

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -68,10 +68,6 @@ sub run() {
         $svirt->change_domain_element(os => cmdline => $cmdline);
     }
 
-    # After installation we need to redefine the domain, so the next
-    # boot loads installed kernel and initrd.
-    $svirt->change_domain_element(on_reboot => 'destroy');
-
     my $size_i = get_var('HDDSIZEGB', '24');
     # In JeOS we have the disk, we just need to deploy it, for the rest
     # - installs from network and ISO media - we have to create it.

--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -111,6 +111,16 @@ sub run() {
     wait_screen_change {
         send_key 'alt-o';    # Reboot
     };
+
+    if (check_var('VIRSH_VMM_FAMILY', 'xen')) {
+        reset_consoles;
+        # VNC connection to SUT (the 'sut' console) is terminated on Xen via svirt
+        # backend and we have to re-connect *after* the restart, otherwise we end up
+        # with stalled VNC connection. The tricky part is to know *when* the system
+        # is already booting.
+        sleep 7;
+        select_console 'sut';
+    }
 }
 
 1;


### PR DESCRIPTION
POO#15784

The aproach with installing SUT, destroying it, and re-creating it with
the installed image does not produce reliable results, frequent VNC
stalls.

On KVM it's just fine to wait after installation for the new system to
boot, on Xen - as the VNC connection is closed after restart by host -
we have to find the right moment when the SUT is booting.

Verification run on KVM, Xen HVM, and Xen PV respectivly:
http://assam.suse.cz/tests/4616
http://assam.suse.cz/tests/4626
http://assam.suse.cz/tests/4627