### PR TITLE
Revert "Boot from HDD with UEFI under svirt backend"

### DIFF
--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -37,7 +37,7 @@ sub run() {
         assert_screen 'inst-bootmenu';
         send_key 'ret';
     }
-    elsif (get_var('UEFI') && (get_var('USBBOOT') || check_var('BACKEND', 'svirt'))) {
+    elsif (get_var('UEFI') && get_var('USBBOOT')) {
         assert_screen 'inst-bootmenu';
         # assuming the cursor is on 'installation' by default and 'boot from
         # harddisk' is above


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#2264
This is actually not needed, if we don't destroy & undefine the VM after installation as we did in `installation/redefine_svirt_domain.pm` (see #2281).