### PR TITLE
LTP: networking: use ss instead of netstat

### DIFF
--- a/tests/kernel/ltp_setup_networking.pm
+++ b/tests/kernel/ltp_setup_networking.pm
@@ -19,7 +19,7 @@ use utils;
 
 sub install {
     # utils
-    zypper_call("in expect iputils net-tools-deprecated psmisc tcpdump telnet", log => 'utils.log');
+    zypper_call("in expect iputils net-tools-deprecated psmisc tcpdump telnet util-linux", log => 'utils.log');
 
     # clients
     zypper_call("in dhcp-client finger mrsh-rsh-compat telnet", log => 'clients.log');

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -266,7 +266,6 @@ sub run {
         );
 
         script_run('ps axf');
-        script_run('netstat -ap');
 
         # emulate /opt/ltp/testscripts/network.sh
         assert_script_run('TST_TOTAL=1 TCID="network_settings"; . test_net.sh; export TCID= TST_LIB_LOADED=');

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -266,6 +266,7 @@ sub run {
         );
 
         script_run('ps axf');
+        script_run('ss -ltunp | column -t');
 
         # emulate /opt/ltp/testscripts/network.sh
         assert_script_run('TST_TOTAL=1 TCID="network_settings"; . test_net.sh; export TCID= TST_LIB_LOADED=');


### PR DESCRIPTION
Display only listening TCP and UDP sockets (enough for diagnostics).

NOTE: `column -t` hack is needed (see http://unix.stackexchange.com/questions/252744/ss-linux-socket-statistics-utility-output-format)