### PR TITLE
Do not add DHCLIENT_SET_HOSTNAME=yes to ifcfg-eth0

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -169,7 +169,12 @@ sub specific_bootmenu_params {
     my $args     = "";
     my $netsetup = "";
     if (get_var("AUTOYAST") || get_var("AUTOUPGRADE") && get_var("AUTOUPGRADE") ne 'local') {
-        $netsetup = get_var("NETWORK_INIT_PARAM", "ifcfg=*=dhcp");    #need this instead of netsetup as default, see bsc#932692
+        # We need to use 'ifcfg=*=dhcp' instead of 'netsetup=dhcp' as a default
+        # due to BSC#932692 (SLE-12). 'SetHostname=0' has to be set because autoyast
+        # profile has DHCLIENT_SET_HOSTNAME="yes" in /etc/sysconfig/network/dhcp,
+        # 'ifcfg=*=dhcp' sets this variable in ifcfg-eth0 as well and we can't
+        # have them both as it's not deterministic.
+        $netsetup = get_var("NETWORK_INIT_PARAM", "ifcfg=*=dhcp SetHostname=0");
         $args .= " $netsetup autoyast=" . data_url(get_var("AUTOYAST")) . " ";
     }
     else {


### PR DESCRIPTION
POO#15684

By default system has DHCLIENT_SET_HOSTNAME=yes in
/etc/sysconfig/network/dhcp, autoyast file out of such system has it set
as well. If we install system from autoyast file with ifcfg=*=dhcp (or
netsetup=dhcp) - and we have to use it as installation from local media
may not set networking, which we need to download autoyast profile from
server - DHCLIENT_SET_HOSTNAME=yes is set in
/etc/sysconfig/network/ifcfg-eth0 but that is not deterministic
(https://github.com/yast/yast-network/pull/461).

Verification run: http://assam.suse.cz/tests/4637