### PR TITLE
Collect linuxrc core dumps and logs if available

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -77,12 +77,15 @@ sub select_bootmenu_option {
 
 sub bootmenu_default_params {
     # https://wiki.archlinux.org/index.php/Kernel_Mode_Setting#Forcing_modes_and_EDID
+    if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
+        type_string " video=hyperv_fb:1024x768";
+    }
     type_string "vga=791 ";
     type_string "Y2DEBUG=1 ";
     type_string_slow "video=1024x768-16 ";
 
-    assert_screen "inst-video-typed", 4;
-    if (!get_var("NICEVIDEO")) {
+    assert_screen check_var('UEFI', 1) ? 'inst-video-typed-grub2' : 'inst-video-typed', 4;
+    if (!get_var("NICEVIDEO") && !is_jeos) {
         type_string_very_slow "plymouth.ignore-serial-consoles ";    # make plymouth go graphical
         type_string_very_slow "linuxrc.log=$serialdev ";             # to get linuxrc logs in serial
         type_string_very_slow "console=$serialdev ";                 # to get crash dumps as text

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -90,6 +90,10 @@ sub bootmenu_default_params {
         type_string_very_slow "linuxrc.log=$serialdev ";             # to get linuxrc logs in serial
         type_string_very_slow "console=$serialdev ";                 # to get crash dumps as text
         type_string_very_slow "console=tty ";                        # to get crash dumps as text
+
+        # Enable linuxrc core dumps https://en.opensuse.org/SDB:Linuxrc#p_linuxrccore
+        type_string_very_slow "linuxrc.core=$serialdev ";
+
         assert_screen "inst-consolesettingstyped", 30;
         my $e = get_var("EXTRABOOTPARAMS");
         if ($e) {

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -118,36 +118,7 @@ sub run() {
 
     type_string " \\\n";    # changed the line before typing video params
                             # https://wiki.archlinux.org/index.php/Kernel_Mode_Setting#Forcing_modes_and_EDID
-    type_string_slow 'Y2DEBUG=1 ';
-    if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
-        type_string " video=hyperv_fb:1024x768";
-    }
-    if (!is_jeos && (check_var('ARCH', 'i586') || check_var('ARCH', 'x86_64'))) {
-        type_string_slow 'vga=791 ';
-        type_string_slow 'video=1024x768-16 ';
-
-        # not needed anymore atm as cirrus has 1024 as default now:
-        # https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=121a6a17439b000b9699c3fa876636db20fa4107
-        #type_string "drm_kms_helper.edid_firmware=edid/1024x768.bin ";
-        assert_screen "inst-video-typed-grub2";
-    }
-
-    if (!get_var("NICEVIDEO") && !is_jeos) {
-        type_string_slow "plymouth.ignore-serial-consoles ";    # make plymouth go graphical
-        type_string_slow "linuxrc.log=$serialdev ";             # to get linuxrc logs in serial
-        type_string " \\\n";                                    # changed the line before typing video params
-        type_string_slow "console=$serialdev ";                 # to get crash dumps as text
-        type_string_slow "console=tty ";                        # to get crash dumps as text
-        assert_screen "inst-consolesettingstyped", 10;
-        my $e = get_var("EXTRABOOTPARAMS");
-        if ($e) {
-            type_string_very_slow "$e ";
-            save_screenshot;
-        }
-    }
-
-    #type_string_slow 'kiwidebug=1 ';
-
+    bootmenu_default_params;
     specific_bootmenu_params;
 
     registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -20,13 +20,14 @@ use utils 'ensure_fullscreen';
 sub run() {
     my @welcome_tags = [qw(inst-welcome inst-welcome-confirm-self-update-server)];
     ensure_fullscreen;
+    my $bootup_timeout = 500;
     if (get_var("BETA")) {
-        assert_screen "inst-betawarning", 500;
+        assert_screen "inst-betawarning", $bootup_timeout;
         send_key "ret";
         assert_screen @welcome_tags, 10;
     }
     else {
-        assert_screen @welcome_tags, 500;
+        assert_screen @welcome_tags, $bootup_timeout;
     }
     if (match_has_tag('inst-welcome-confirm-self-update-server')) {
         wait_screen_change { send_key $cmd{ok} };

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -51,5 +51,16 @@ sub run() {
     }
 }
 
+sub post_fail_hook {
+    my ($self) = @_;
+    # system might be stuck on bootup showing only splash screen so we press
+    # esc to show console logs
+    send_key 'esc';
+    $self->SUPER::post_fail_hook;
+    # in case we could not even reach the installer welcome screen and logs
+    # could not be collected on the serial output:
+    upload_logs '/var/log/linuxrc.log';
+}
+
 1;
 # vim: set sw=4 et:


### PR DESCRIPTION
linuxrc core dumps have been added after a discussion in
https://bugzilla.suse.com/show_bug.cgi?id=1010505#c9 as described on
https://en.opensuse.org/SDB:Linuxrc#p_linuxrccore
If they are available the should be collected to the serial log and can be
decoded using uudecode so that we can debug problems during bootup of the
installer system, e.g. as happened in bsc#1010505.

Local verification runs:
* TW uefi: http://lord.arch/tests/5521
* SLE: http://lord.arch/tests/5523

Related progress issue: https://progress.opensuse.org/issues/13896