### PR TITLE
Timeout fixes for upgrades and windows dual-boot

### DIFF
--- a/lib/windows_utils.pm
+++ b/lib/windows_utils.pm
@@ -37,7 +37,7 @@ sub wait_boot_windows {
     type_password;
     send_key 'ret';    # press shutdown button
 
-    assert_screen 'windows-desktop';
+    assert_screen 'windows-desktop', 120;
 }
 
 1;

--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -69,7 +69,7 @@ sub run() {
             send_key 'alt-n';
             record_soft_failure 'error bootloader preupdate';
         }
-        assert_screen "inst-packageinstallationstarted";
+        assert_screen "inst-packageinstallationstarted", 120;
 
         # view installation details
         send_key $cmd{instdetails};

--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -28,7 +28,7 @@ sub run() {
     # hardware detection and waiting for updates from suse.com can take a while
     assert_screen_with_soft_timeout('select-for-update', timeout => 500, soft_timeout => 100, bugref => 'bsc#990254');
     send_key $cmd{next}, 1;
-    assert_screen "remove-repository", 100;
+    assert_screen "remove-repository", 240;
     send_key $cmd{next}, 1;
 }
 


### PR DESCRIPTION
On TW we see timeout issue on upgrade test recently, eg. https://openqa.opensuse.org/tests/331326#step/start_install/25 , https://openqa.opensuse.org/tests/331327#step/upgrade_select/3,  https://openqa.opensuse.org/tests/331325#step/start_install/25, etc.

For windows dual-boot failure, see https://openqa.opensuse.org/tests/331418#step/boot_windows/8