### PR TITLE
Use bridged network needle for YaST2 lan hostname

### DIFF
--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -61,7 +61,14 @@ sub run() {
     my $domain = "zq1.de";
 
     send_key "alt-s";    # open hostname tab
-    assert_screen "yast2_lan-hostname-tab";
+
+    # On Xen we don't have user-mode networking, just a bridged network
+    if (check_var('VIRSH_VMM_FAMILY', 'xen')) {
+        assert_screen "yast2_lan-hostname-tab_bridged-network";
+    }
+    else {
+        assert_screen "yast2_lan-hostname-tab";
+    }
     send_key "tab";
     for (1 .. 15) { send_key "backspace" }
     type_string $hostname;


### PR DESCRIPTION
POO#15740

On Xen we don't have user-mode networking, just a brigged network which
provides 'qa.suse.de' on our network and for that we need different
needle.

Needle:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/285