### PR TITLE
Fix install_packages for updates that remove (obsolete) packages

### DIFF
--- a/tests/console/install_packages.pm
+++ b/tests/console/install_packages.pm
@@ -29,7 +29,7 @@ sub run() {
     assert_script_run("test -s \$XDG_RUNTIME_DIR/install_packages.txt");
     # might take longer for large patches (i.e. 12 kernel flavors)
     assert_script_run("xargs --no-run-if-empty zypper -n in -l < \$XDG_RUNTIME_DIR/install_packages.txt", 800);
-    assert_script_run("xargs --no-run-if-empty rpm -q < \$XDG_RUNTIME_DIR/install_packages.txt | tee /dev/$serialdev");
+    assert_script_run("grep -Ev '^-' \$XDG_RUNTIME_DIR/install_packages.txt | xargs --no-run-if-empty rpm -q -- | tee /dev/$serialdev");
 }
 
 sub test_flags() {


### PR DESCRIPTION
Follow-up to #2277 3aaab7f:

Solver (via data/lsmfip) may return "^-PACKAGENAME" for packages
that are removed by a maintenance update, e.g. new packages
obsoleting existing ones.

xargs rpm would interpret this as command line switches, resulting
in a test fail. Add '--' to indicate end of command line switches.

In addition, do not expect packages to be installed after update
if the solver marks them as removals.

Fail seen in:
https://openqa.opensuse.org/tests/331598#step/install_packages/14