### PR TITLE
Workaround for boo#1019090, bnc#1014602

### DIFF
--- a/tests/console/java.pm
+++ b/tests/console/java.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -8,7 +8,7 @@
 # without any warranty.
 # Description: Basic Java test
 # Summary: It installs every Java version which is available into
-#	   the repositories and then it performs a series of basic
+#          the repositories and then it performs a series of basic
 #          tests, such as verifying the version, compile and run
 #          the Hello World program
 # Maintainer: Panos Georgiadis <pgeorgiadis@suse.com>
@@ -20,7 +20,46 @@ use utils;
 use base "consoletest";
 sub run() {
     select_console 'root-console';
-    zypper_call "in java-*";
+
+    # Make sure that PackageKit is not running
+    pkcon_quit;
+
+    # Capture the return code value of the following scenarios
+    my $bootstrap_pkg_rt       = zypper_call("se java-*bootstrap",  exitcode => [0, 104]);
+    my $bootstrap_conflicts_rt = zypper_call("in --dry-run java-*", exitcode => [0, 4]);
+
+    # logs / debugging purposes
+    diag "checking variable: bootstrap_pkg_rt = $bootstrap_pkg_rt";
+    diag "checking variable: bootstrap_conflicts_rt = $bootstrap_conflicts_rt";
+
+    if (check_var("DISTRI", "sle")) {
+        zypper_call "in java-*";
+    }
+
+    if (check_var("DISTRI", "opensuse")) {
+        if ($bootstrap_pkg_rt == 0) {
+            diag "There are java bootstrap packages available to be installed";
+            print "There are java bootstrap packages available to be installed\n";
+            if ($bootstrap_conflicts_rt == 0) {
+                diag "There is no conflict installing the java bootstrap packages";
+                print "There is no conflict installing the java bootstrap packages\n";
+                zypper_call "in java-*";
+            }
+            else {
+                diag "There are conflicts with the installation of java bootstrap packages";
+                print "There are conflicts with the installation of java bootstrap packages\n";
+                record_soft_failure 'boo#1019090';
+                # Workaround: install java-* except from the problematic bootstrap packages
+                zypper_call "in `(zypper se java-* | grep -v bootstrap | grep -v 'i ' | awk '{print \$2}' | sed -n -E -e '/java/,\$ p')`";
+            }
+        }
+        else {
+            diag "There are no java bootstrap packages";
+            print "There are no java bootstrap packages\n";
+            zypper_call "in java-*";
+        }
+    }
+
     assert_script_run "wget --quiet " . data_url('console/test_java.sh');
     assert_script_run 'chmod +x test_java.sh';
     assert_script_run './test_java.sh';


### PR DESCRIPTION
boo#1019090: do not install 'java-bootstrap' packages, as they
conflict with java on Leap42.2

bnc#1014602: java 1.7.0 is reported by java when having ibm-java 1.7.1
installed. This behavior is expected and acceptable according to IBM.

Also only fail the test for 'javac' if the -devel package should be
installed (SDK available) but it's not.