### PR TITLE
Logout after traffic generation in wireshark test

### DIFF
--- a/tests/x11/wireshark.pm
+++ b/tests/x11/wireshark.pm
@@ -75,6 +75,9 @@ sub run() {
     wait_still_screen 2;
     assert_script_run "dig www.suse.com A";
     assert_script_run "host www.suse.com";    # check for valid IP address
+    type_string "exit\n";                     # logout
+    wait_still_screen 2;
+    save_screenshot();
     select_console 'x11';
     assert_screen "wireshark-capturing";
 


### PR DESCRIPTION
This prevents multi users logged shown on authentication dialog which leads to unmatch the current needle.
Fix following installation and migration tests with WE addon:
https://openqa.suse.de/tests/714014#step/reboot_gnome/5
https://openqa.suse.de/tests/713329#step/reboot_gnome/5
https://openqa.suse.de/tests/714014#step/reboot_gnome/5