### PR TITLE
Move logout/login to non-fatal test

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -36,6 +36,7 @@ our @EXPORT = qw(
   setup_online_migration
   turn_off_kde_screensaver
   random_string
+  handle_login
 );
 
 
@@ -674,6 +675,22 @@ sub random_string {
     $length //= 4;
     my @chars = ('A' .. 'Z', 'a' .. 'z', 0 .. 9);
     return join '', map { @chars[rand @chars] } 1 .. $length;
+}
+
+sub handle_login {
+    assert_screen 'displaymanager';    # wait for DM, then try to login
+    mouse_hide();
+    wait_still_screen;
+    if (get_var('DM_NEEDS_USERNAME')) {
+        type_string "$username\n";
+    }
+    if (check_var('DESKTOP', 'gnome') || (check_var('DESKTOP', 'lxde') && check_var('VERSION', '42.1'))) {
+        # DMs in condition above have to select user
+        send_key 'ret';
+    }
+    assert_screen "displaymanager-password-prompt";
+    type_password;
+    send_key "ret";
 }
 
 1;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -626,6 +626,7 @@ sub load_mate_tests() {
 sub load_x11tests() {
     return unless (!get_var("INSTALLONLY") && is_desktop_installed() && !get_var("DUALBOOT") && !get_var("RESCUECD"));
 
+    loadtest "x11/user_gui_login" unless get_var("LIVETEST") || get_var("NOAUTOLOGIN");
     if (get_var("XDMUSED")) {
         loadtest "x11/x11_login";
     }

--- a/tests/x11/user_gui_login.pm
+++ b/tests/x11/user_gui_login.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Login as user test https://progress.opensuse.org/issues/13306
+# Maintainer: Jozef Pupava <jpupava@suse.com>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils 'handle_login';
+
+sub run() {
+    # hide mouse for clean logout needles
+    mouse_hide();
+    # logout
+    if (check_var('DESKTOP', 'gnome') || check_var('DESKTOP', 'lxde')) {
+        my $command = check_var('DESKTOP', 'gnome') ? 'gnome-session-quit' : 'lxsession-logout';
+        x11_start_program("$command");    # opens logout dialog
+        assert_screen 'logoutdialog' unless check_var('DESKTOP', 'gnome');
+    }
+    else {
+        my $key = check_var('DESKTOP', 'xfce') ? 'alt-f4' : 'ctrl-alt-delete';
+        send_key_until_needlematch 'logoutdialog', "$key";    # opens logout dialog
+    }
+    assert_and_click 'logout-button';                         # press logout
+    handle_login;
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
I would like to hear opinion on line 23, I guess DM_NEEDS_USERNAME is behavior from past, but today we have lot of DMs on many versions, checking for user prompt is more convenient than setting DM_NEEDS_USERNAME on every test

[update_13.2](http://10.100.12.155/tests/4634#step/first_boot/9)