### PR TITLE
LTP: install net-tools-deprecated package for tests

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -37,8 +37,8 @@ sub try_add_workstation_addon {
 sub install_dependencies {
     my @deps = qw(git-core make automake autoconf gcc libnuma-devel libaio-devel numactl
       flex bison dmapi-devel kernel-default-devel libopenssl-devel libselinux-devel
-      libacl-devel libtirpc-devel keyutils-devel libcap-devel sysstat tpm-tools
-      tpm2.0-tools psmisc acl quota);
+      libacl-devel libtirpc-devel keyutils-devel libcap-devel net-tools-deprecated sysstat
+      tpm-tools tpm2.0-tools psmisc acl quota);
     if (check_var('DISTRI', 'opensuse') || try_add_workstation_addon()) {
         push @deps, 'ntfsprogs';
     }

--- a/tests/kernel/ltp_setup_networking.pm
+++ b/tests/kernel/ltp_setup_networking.pm
@@ -19,7 +19,7 @@ use utils;
 
 sub install {
     # utils
-    zypper_call("in expect iputils net-tools-deprecated psmisc tcpdump telnet", log => 'utils.log');
+    zypper_call("in expect iputils psmisc tcpdump telnet", log => 'utils.log');
 
     # clients
     zypper_call("in dhcp-client finger mrsh-rsh-compat telnet", log => 'clients.log');


### PR DESCRIPTION
Tests in runtest/containers require ifconfig.

See: https://openqa.opensuse.org/tests/333124#step/run_ltp/166