### PR TITLE
Use generic bootup problem analyze

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -226,11 +226,6 @@ sub specific_bootmenu_params {
         }
     }
 
-    if (check_var('ARCH', 'aarch64') && check_var('DISTRI', 'sle')) {
-        $args .= " plymouth=0 linuxrc.debug=trace";
-        record_soft_failure "bsc#1005313 - Unhandled level 1 translation fault";
-    }
-
     type_string_very_slow $args;
     save_screenshot;
 }

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -104,10 +104,8 @@ sub test_flags() {
 sub post_fail_hook() {
     my $self = shift;
 
-    diag 'Save memory dump for bsc#1005313';
-    if (check_var('ARCH', 'aarch64') && check_var('DISTRI', 'sle')) {
-        save_memory_dump;
-    }
+    diag 'Save memory dump to debug bootup problems, e.g. for bsc#1005313';
+    save_memory_dump;
 
     # Reveal what is behind Plymouth splash screen
     wait_screen_change {


### PR DESCRIPTION
No need for sle-aarch64 specific handling. If there are bootup problems
the memory dumps can be helpful in general.