### PR TITLE
LTP: fix installing package providing ifconfig

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -37,7 +37,7 @@ sub try_add_workstation_addon {
 sub install_dependencies {
     my @deps = qw(git-core make automake autoconf gcc libnuma-devel libaio-devel numactl
       flex bison dmapi-devel kernel-default-devel libopenssl-devel libselinux-devel
-      libacl-devel libtirpc-devel keyutils-devel libcap-devel net-tools-deprecated sysstat
+      libacl-devel libtirpc-devel keyutils-devel libcap-devel net-tools sysstat
       tpm-tools tpm2.0-tools psmisc acl quota);
     if (check_var('DISTRI', 'opensuse') || try_add_workstation_addon()) {
         push @deps, 'ntfsprogs';
@@ -46,6 +46,8 @@ sub install_dependencies {
         record_soft_failure 'Need Workstation Extension for ntfsprogs; poo#15652';
     }
     zypper_call('in ' . join(' ', @deps), log => 'install-deps.txt');
+
+    script_run('zypper -n in net-tools-deprecated');
 }
 
 sub install_from_git {


### PR DESCRIPTION
ifconfig is provided by net-tools (old distros) or in
net-tools-deprecated (since April 2014).

This fixes regression which breaks SLE testing introduced in:
ad77a2f5 LTP: install net-tools-deprecated package for tests
2543482d LTP: add setup module for networking tests