### PR TITLE
[WIP] Use more strict 'assert_screen_change' where possible

### DIFF
--- a/lib/installation_user_settings.pm
+++ b/lib/installation_user_settings.pm
@@ -17,7 +17,7 @@ use testapi;
 
 sub type_password_and_verification {
     for (1 .. 2) {
-        wait_screen_change { type_string "$password\t" };
+        assert_screen_change { type_string "$password\t" };
     }
 }
 

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -180,7 +180,7 @@ sub fill_in_registration_data {
                     if (!check_screen(\@known_untrusted_keys, 0)) {
                         record_soft_failure 'untrusted gpg key';
                     }
-                    wait_screen_change {
+                    assert_screen_change {
                         send_key 'alt-t';
                     };
                     next;

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -9,7 +9,7 @@ use strict;
 use testapi qw(send_key %cmd assert_screen check_screen check_var get_var
   match_has_tag set_var type_password type_string wait_idle wait_serial
   mouse_hide send_key_until_needlematch record_soft_failure
-  wait_still_screen wait_screen_change);
+  wait_still_screen assert_screen_change);
 
 
 sub handle_password_prompt {
@@ -120,7 +120,7 @@ sub x11_start_program($$$) {
     if ($options->{valid}) {
         for (1 .. 3) {
             last unless check_screen "desktop-runner-border", 2;
-            wait_screen_change {
+            assert_screen_change {
                 send_key "ret";
             };
         }

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -268,7 +268,7 @@ sub ensure_unlocked_desktop {
             last;            # desktop is uncloked, mission accomplished
         }
         if (match_has_tag 'screenlock') {
-            wait_screen_change {
+            assert_screen_change {
                 send_key 'esc';    # end screenlock
             };
         }

--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -32,7 +32,7 @@ sub import_pictures {
     }
 
     # Open the dialog 'Import From Folder'
-    wait_screen_change {
+    assert_screen_change {
         send_key "ctrl-i";
     };
     assert_screen 'shotwell-importing';
@@ -66,7 +66,7 @@ sub upload_libreoffice_specified_file() {
     wait_still_screen;
     type_string("cd /home/$username/Documents && ls -l");
     send_key "ret";
-    wait_screen_change {
+    assert_screen_change {
         assert_screen("libreoffice-find-tar-file");
         type_string("tar -xjvf ooo-test-doc-types.tar.bz2");
         send_key "ret";
@@ -84,7 +84,7 @@ sub cleanup_libreoffice_specified_file() {
     wait_still_screen;
     type_string("ls -l /home/$username/Documents");
     send_key "ret";
-    wait_screen_change {
+    assert_screen_change {
         assert_screen("libreoffice-find-no-tar-file");
     };
     wait_still_screen;
@@ -283,11 +283,11 @@ sub start_evolution {
     assert_screen "evolution_wizard-restore-backup";
     send_key $self->{next};
     assert_screen "evolution_wizard-identity";
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-e";
     };
     type_string "SUSE Test";
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-a";
     };
     type_string "$mail_box";
@@ -315,15 +315,15 @@ sub setup_mail_account {
     }
 
     assert_screen "evolution_wizard-receiving";
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-t";
     };
     send_key "ret";
     send_key_until_needlematch "evolution_wizard-receiving-$proto", "down", 10, 3;
-    wait_screen_change {
+    assert_screen_change {
         send_key "ret";
     };
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-s";
     };
     type_string "$mail_recvServer";
@@ -331,7 +331,7 @@ sub setup_mail_account {
         #No need set receive port with POP
     }
     elsif ($proto eq 'imap') {
-        wait_screen_change {
+        assert_screen_change {
             send_key "alt-p";
         };
         type_string "$mail_recvport";
@@ -339,16 +339,16 @@ sub setup_mail_account {
     else {
         die "Unsupported protocol: $proto";
     }
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-n";
     };
     type_string "$mail_user";
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-m";
     };
     send_key "ret";
     send_key_until_needlematch "evolution_wizard-receiving-ssl", "down", 5, 3;
-    wait_screen_change {
+    assert_screen_change {
         send_key "ret";
     };
     # add self-signed CA with internal account
@@ -356,7 +356,7 @@ sub setup_mail_account {
         assert_and_click "evolution_wizard-receiving-checkauthtype";
         assert_screen "evolution_mail_meeting_trust_ca";
         send_key "alt-a";
-        wait_screen_change {
+        assert_screen_change {
             send_key $self->{next};
             send_key "ret";
         }
@@ -376,27 +376,27 @@ sub setup_mail_account {
 
     #setup sending protocol as smtp
     assert_screen "evolution_wizard-sending";
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-t";
     };
     send_key "ret";
     save_screenshot;
     send_key_until_needlematch "evolution_wizard-sending-smtp", "down", 5, 3;
-    wait_screen_change {
+    assert_screen_change {
         send_key "ret";
     };
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-s";
     };
     type_string "$mail_sendServer";
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-p";
     };
     type_string "$mail_sendport";
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-v";
     };
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-m";
     };
     send_key "ret";
@@ -404,7 +404,7 @@ sub setup_mail_account {
     send_key "ret";
 
     #Known issue: hot key 'alt-y' doesn't work
-    #wait_screen_change {
+    #assert_screen_change {
     #   send_key "alt-y";
     #};
     #send_key "ret";
@@ -414,7 +414,7 @@ sub setup_mail_account {
     assert_and_click "evolution_wizard-sending-setauthtype";
     send_key_until_needlematch "evolution_wizard-sending-authtype", "down", 5, 3;
     send_key "ret";
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-n";
     };
     sleep 1;
@@ -424,7 +424,7 @@ sub setup_mail_account {
         assert_and_click "evolution_wizard-sending-checkauthtype";
         assert_screen "evolution_mail_meeting_trust_ca";
         send_key "alt-a";
-        wait_screen_change {
+        assert_screen_change {
             send_key $self->{next};
             send_key "ret";
         }
@@ -537,11 +537,11 @@ sub setup_evolution_for_ews {
     assert_screen "evolution_wizard-restore-backup";
     send_key "alt-o";
     assert_screen "evolution_wizard-identity";
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-e";
     };
     type_string "SUSE Test";
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-a";
     };
     type_string "$mailbox";
@@ -555,7 +555,7 @@ sub setup_evolution_for_ews {
         assert_screen 'evolution_wizard-receiving';
     }
 
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-t";
     };
     send_key "ret";
@@ -613,7 +613,7 @@ sub evolution_send_message {
     assert_screen "evolution_mail-compose-message";
     assert_and_click "evolution_mail-message-to";
     type_string "$mailbox";
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-u";
     };
     wait_still_screen;

--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -56,7 +56,7 @@ sub get_to_console() {
 # to workaround dep issues
 sub record_dependency_issues {
     while (check_screen 'dependancy-issue', 5) {
-        wait_screen_change {
+        assert_screen_change {
             if (check_var('VIDEOMODE', 'text')) {
                 send_key 'alt-s';
             }
@@ -64,7 +64,7 @@ sub record_dependency_issues {
                 send_key 'alt-1';
             }
         };
-        wait_screen_change {
+        assert_screen_change {
             send_key 'spc';
         };
         send_key 'alt-o';
@@ -91,7 +91,7 @@ sub check_and_record_dependency_problems {
 
     if (get_var("WORKAROUND_DEPS")) {
         $self->record_dependency_issues;
-        wait_screen_change {
+        assert_screen_change {
             send_key 'alt-a';
         };
         send_key 'alt-o';

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -27,7 +27,7 @@ sub accept_license {
     send_key $cmd{accept};
     $confirmed_licenses++;
     # Prevent from matching previous license
-    wait_screen_change {
+    assert_screen_change {
         send_key $cmd{next};
     };
 }

--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -29,7 +29,7 @@ sub run() {
     send_key "alt-o";                                     # OK => Close
     assert_screen([qw(yast2_bootloader-missing_package yast2_console-finished)], 200);
     if (match_has_tag('yast2_bootloader-missing_package')) {
-        wait_screen_change { send_key 'alt-i'; };
+        assert_screen_change { send_key 'alt-i'; };
     }
     assert_screen 'yast2_console-finished', 200;
     wait_serial("yast2-bootloader-status-0") || die "'yast2 bootloader' didn't finish";

--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -79,10 +79,10 @@ sub run() {
         assert_screen(\@tags, 60);
         # automatic changes for manual selections
         if (match_has_tag('yast2-sw-packages-autoselected') or match_has_tag('yast2-sw_automatic-changes')) {
-            wait_screen_change { send_key 'alt-o' };
+            assert_screen_change { send_key 'alt-o' };
         }
         elsif (match_has_tag('yast2-sw_shows_summary')) {
-            wait_screen_change { send_key 'alt-f' };
+            assert_screen_change { send_key 'alt-f' };
         }
     } until (match_has_tag('yast2_console-finished'));
 

--- a/tests/console/yast2_nis.pm
+++ b/tests/console/yast2_nis.pm
@@ -20,7 +20,7 @@ sub run() {
     script_run "zypper -n in yast2-nis-client";    # make sure yast client module installed
     type_string "yast2 nis\n";
     assert_screen 'nis-client';
-    wait_screen_change { send_key 'alt-u' };
+    assert_screen_change { send_key 'alt-u' };
     send_key 'alt-m';
     assert_screen 'nis-client-automounter-enabled';    # this checks if nis and automounter got really enabled
     send_key 'alt-i';                                  # enter Nis domain for enter string suse.de
@@ -29,20 +29,20 @@ sub run() {
     type_string "10.162.0.1";
     send_key 'alt-t';                                  # open port in firewall
     assert_screen 'open_port_in_firewall';             # check the port is open
-    wait_screen_change { send_key 'alt-p' };           # check Netconfif NIS Policy
+    assert_screen_change { send_key 'alt-p' };         # check Netconfif NIS Policy
     send_key 'up';
-    wait_screen_change { send_key 'ret' };
+    assert_screen_change { send_key 'ret' };
     assert_screen 'only-manual-changes';               # check the needle
     send_key 'alt-p';                                  # enter Netconfif NIS Policy again for custom policy
-    wait_screen_change { send_key 'down' };
+    assert_screen_change { send_key 'down' };
     send_key 'ret';
-    wait_screen_change { send_key 'alt-x' };           # check Expert...
-    wait_screen_change { send_key 'alt-b' };
+    assert_screen_change { send_key 'alt-x' };         # check Expert...
+    assert_screen_change { send_key 'alt-b' };
     assert_screen 'expert_settings';                   # check the needle enable Broken server
     send_key 'alt-y';
-    wait_screen_change { type_string "-c" };           # only checks if the config file has syntax errors and exits
+    assert_screen_change { type_string "-c" };         # only checks if the config file has syntax errors and exits
     send_key 'alt-o';
-    wait_screen_change { send_key 'alt-s' };           # enter NFS configuration...
+    assert_screen_change { send_key 'alt-s' };         # enter NFS configuration...
     assert_screen 'nfs-client-configuration';          # add nfs settings
     send_key 'alt-a';
     assert_screen 'nfs-server-hostname';               # check that type string is sucessful
@@ -54,10 +54,10 @@ sub run() {
     type_string "/mounts_local";
     send_key 'alt-o';
     assert_screen 'nfs_server_added';                  # check Mount point
-    wait_screen_change { send_key 'alt-t' };           # go back to nfs configuration and delete configuration created before
+    assert_screen_change { send_key 'alt-t' };         # go back to nfs configuration and delete configuration created before
     assert_screen 'nis_server_delete';                 # confirm to delete configuration
     send_key 'alt-y';
-    wait_screen_change { send_key 'alt-o' };
+    assert_screen_change { send_key 'alt-o' };
     send_key 'alt-f';                                  # close the dialog...
     assert_screen 'nis_server_not_found';              # check error message for 'nis server not found'
     send_key 'alt-o';                                  # close it now even when config is not valid

--- a/tests/installation/change_desktop.pm
+++ b/tests/installation/change_desktop.pm
@@ -69,15 +69,15 @@ sub change_desktop() {
     else {
         if (!check_var('DESKTOP', 'gnome')) {
             send_key_until_needlematch 'gnome-selected', 'down', 10;
-            wait_screen_change { send_key ' '; };
+            assert_screen_change { send_key ' '; };
         }
         if (check_var('DESKTOP', 'kde')) {
             send_key_until_needlematch 'kde-unselected', 'down', 10;
-            wait_screen_change { send_key ' '; };
+            assert_screen_change { send_key ' '; };
         }
         if (check_var('DESKTOP', 'textmode')) {
             send_key_until_needlematch 'x11-selected', 'down', 10;
-            wait_screen_change { send_key ' '; };
+            assert_screen_change { send_key ' '; };
         }
         assert_screen "desktop-selected";
     }

--- a/tests/installation/encrypted_volume_activation.pm
+++ b/tests/installation/encrypted_volume_activation.pm
@@ -32,7 +32,7 @@ my $after_cancel_tags = [
 sub run {
     assert_screen 'encrypted_volume_activation_prompt';
     if (get_var('ENCRYPT_CANCEL_EXISTING')) {
-        wait_screen_change { send_key 'alt-c'; };
+        assert_screen_change { send_key 'alt-c'; };
         assert_screen($after_cancel_tags);
         if (match_has_tag('encrypted_volume_activation_prompt')) {
             record_soft_failure 'bsc#989770';

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -108,7 +108,7 @@ sub post_fail_hook() {
     save_memory_dump;
 
     # Reveal what is behind Plymouth splash screen
-    wait_screen_change {
+    assert_screen_change {
         send_key 'esc';
     };
     $self->export_logs();

--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -108,7 +108,7 @@ sub run() {
         select_console 'installation';
         assert_screen 'rebootnow';
     }
-    wait_screen_change {
+    assert_screen_change {
         send_key 'alt-o';    # Reboot
     };
 

--- a/tests/installation/livecd_network_settings.pm
+++ b/tests/installation/livecd_network_settings.pm
@@ -22,10 +22,10 @@ sub run() {
     # wait for key import dialog during initialization
     assert_screen 'import-untrusted-gpg-key-B88B2FD43DBDC284', 120;
     # 'T'rust
-    wait_screen_change { send_key 'alt-t'; };
+    assert_screen_change { send_key 'alt-t'; };
     # LIVECD installer assumes online repos at this point
     wait_still_screen;
-    wait_screen_change { send_key $cmd{next}; };
+    assert_screen_change { send_key $cmd{next}; };
 }
 
 1;

--- a/tests/installation/partitioning_firstdisk.pm
+++ b/tests/installation/partitioning_firstdisk.pm
@@ -23,13 +23,13 @@ sub run() {
     send_key $cmd{createpartsetup};
     assert_screen 'prepare-hard-disk';
 
-    wait_screen_change {
+    assert_screen_change {
         send_key 'alt-1';
     };
     send_key 'alt-n';
 
     assert_screen 'use-entire-disk';
-    wait_screen_change {
+    assert_screen_change {
         send_key 'alt-e';
     };
     send_key $cmd{next};

--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -59,7 +59,7 @@ sub addraid {
     # add
     send_key $cmd{add};
     wait_still_screen;
-    wait_screen_change {
+    assert_screen_change {
         send_key $cmd{next};
     };
 

--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -77,15 +77,15 @@ sub run() {
 
     # exit release notes window
     if (check_var('VIDEOMODE', 'text')) {
-        wait_screen_change { send_key 'alt-o'; };
+        assert_screen_change { send_key 'alt-o'; };
     }
     else {
         assert_screen([qw(release-notes-sle-ok-button release-notes-sle-close-button)]);
         if (match_has_tag('release-notes-sle-ok-button')) {
-            wait_screen_change { send_key 'alt-o' };
+            assert_screen_change { send_key 'alt-o' };
         }
         else {
-            wait_screen_change { send_key 'alt-c'; };
+            assert_screen_change { send_key 'alt-c'; };
         }
     }
     if (!get_var("UPGRADE")) {

--- a/tests/installation/select_patterns.pm
+++ b/tests/installation/select_patterns.pm
@@ -26,7 +26,7 @@ sub accept3rdparty {
     while (check_screen([qw(3rdpartylicense automatic-changes inst-overview)], 15)) {
         last if match_has_tag("automatic-changes");
         last if match_has_tag("inst-overview");
-        wait_screen_change {
+        assert_screen_change {
             send_key $cmd{acceptlicense};
         };
     }
@@ -106,7 +106,7 @@ sub run {
             next;
         }
         if ($needs_to_be_selected && !$selected) {
-            wait_screen_change {
+            assert_screen_change {
                 send_key ' ';
             };
             assert_screen 'current-pattern-selected', 5;

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -30,7 +30,7 @@ sub run() {
         assert_screen @welcome_tags, $bootup_timeout;
     }
     if (match_has_tag('inst-welcome-confirm-self-update-server')) {
-        wait_screen_change { send_key $cmd{ok} };
+        assert_screen_change { send_key $cmd{ok} };
         assert_screen 'inst-welcome';
     }
 

--- a/tests/toolchain/crash.pm
+++ b/tests/toolchain/crash.pm
@@ -66,10 +66,10 @@ sub run() {
     do {
         assert_screen \@tags, 300;
         # enable kdump if it is not already
-        wait_screen_change { send_key 'alt-u' } if match_has_tag('yast2-kdump-disabled');
-        wait_screen_change { send_key 'alt-o' } if match_has_tag('yast2-kdump-enabled');
-        wait_screen_change { send_key 'alt-o' } if match_has_tag('yast2-kdump-restart-info');
-        wait_screen_change { send_key 'alt-i' } if match_has_tag('yast2-missing_package');
+        assert_screen_change { send_key 'alt-u' } if match_has_tag('yast2-kdump-disabled');
+        assert_screen_change { send_key 'alt-o' } if match_has_tag('yast2-kdump-enabled');
+        assert_screen_change { send_key 'alt-o' } if match_has_tag('yast2-kdump-restart-info');
+        assert_screen_change { send_key 'alt-i' } if match_has_tag('yast2-missing_package');
     } until (match_has_tag('yast2_console-finished'));
     script_run 'reboot', 0;
     $self->wait_boot;

--- a/tests/virtualization/virtman_view.pm
+++ b/tests/virtualization/virtman_view.pm
@@ -34,7 +34,7 @@ sub run {
     for (1 .. 3) { send_key "tab"; }
     save_screenshot;
     # activate disk I/O
-    wait_screen_change {
+    assert_screen_change {
         send_key "spc";
     };
     send_key "tab";
@@ -68,14 +68,14 @@ sub run {
         assert_screen "virtman-viewcheck", 30;
     }
     # close every open windows
-    wait_screen_change {
+    assert_screen_change {
         send_key "esc";
     };
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-f";
     };
     wait_still_screen;
-    wait_screen_change {
+    assert_screen_change {
         send_key "q";
     };
     # close the xterm

--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -21,14 +21,14 @@ sub start_firefox() {
     # makes firefox as default browser
     assert_screen [qw(firefox_default_browser firefox_readerview_window firefox-html5test)], 120;
     if (check_screen('firefox_default_browser', 0)) {
-        wait_screen_change {
+        assert_screen_change {
             assert_and_click 'firefox_default_browser_yes';
         };
     }
     assert_screen [qw(firefox_readerview_window firefox-html5test)];
     # workaround for reader view , it grabed the focus than mainwindow
     if (check_screen('firefox_readerview_window', 0)) {
-        wait_screen_change {
+        assert_screen_change {
             assert_and_click 'firefox_readerview_window';
         };
     }

--- a/tests/x11/gedit.pm
+++ b/tests/x11/gedit.pm
@@ -21,7 +21,7 @@ sub run() {
     assert_screen 'gedit-launched';
     $self->enter_test_text('gedit');
     assert_screen 'test-gedit-1';
-    wait_screen_change { send_key 'alt-f4' };
+    assert_screen_change { send_key 'alt-f4' };
     send_key 'alt-w';
 }
 

--- a/tests/x11/kontact.pm
+++ b/tests/x11/kontact.pm
@@ -31,7 +31,7 @@ sub run() {
     do {
         assert_screen \@tags;
         # kontact might ask to import data from another mailer, don't
-        wait_screen_change { send_key 'alt-n' } if match_has_tag('kontact-import-data-dialog');
+        assert_screen_change { send_key 'alt-n' } if match_has_tag('kontact-import-data-dialog');
     } until (match_has_tag('test-kontact-1'));
     send_key 'alt-c';    # KF5-based account assistant ignores alt-f4
     assert_screen 'kontact-window';

--- a/tests/x11/oomath.pm
+++ b/tests/x11/oomath.pm
@@ -26,9 +26,9 @@ sub run() {
     send_key "shift-left";
     send_key "2";
     # undo produces "12" instead of "1"
-    wait_screen_change { send_key "ctrl-z" };
+    assert_screen_change { send_key "ctrl-z" };
     assert_screen 'test-oomath-1', 3;
-    wait_screen_change { send_key "alt-f4" };
+    assert_screen_change { send_key "alt-f4" };
     assert_screen 'oomath-prompt', 5;
     assert_and_click 'dont-save-libreoffice-btn';    # _Don't save
 }

--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -27,11 +27,11 @@ sub run() {
         wait_still_screen;
         type_string $testapi::password, max_interval => 5;
         wait_still_screen;
-        wait_screen_change {
+        assert_screen_change {
             # Extra assert_and_click (with right click) to check the correct number of characters is typed and open up the 'show text' option
             assert_and_click 'reboot-auth-typed', 'right';
         };
-        wait_screen_change {
+        assert_screen_change {
             # Click the 'Show Text' Option to enable the display of the typed text
             assert_and_click 'reboot-auth-showtext';
         };

--- a/tests/x11/ristretto.pm
+++ b/tests/x11/ristretto.pm
@@ -17,7 +17,7 @@ use testapi;
 
 sub run() {
     x11_start_program("ristretto /usr/share/wallpapers/xfce/default.wallpaper");
-    wait_screen_change { send_key "ctrl-m" };
+    assert_screen_change { send_key "ctrl-m" };
     assert_screen 'test-ristretto-1';
     send_key "alt-f4";
 }

--- a/tests/x11/thunderbird.pm
+++ b/tests/x11/thunderbird.pm
@@ -19,7 +19,7 @@ sub run() {
     ensure_installed("MozillaThunderbird");
     x11_start_program("thunderbird");
     assert_screen 'test-thunderbird-1';
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-f4";    # close wizard
     };
     send_key "alt-f4";        # close prog

--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -19,7 +19,7 @@ my $theme = "/usr/share/gnome-shell/theme/gnome-classic.css";
 
 sub type_and_wait {
     type_string shift;
-    wait_screen_change {
+    assert_screen_change {
         type_string "\n";
     };
 }
@@ -45,7 +45,7 @@ sub start_vnc_server {
 # poo#11794
 sub run() {
     select_console "root-console";
-    # Hide panel buttons so wait_screen_change ignores clock change
+    # Hide panel buttons so assert_screen_change ignores clock change
     assert_script_run "echo \"#panel .panel-button { color: transparent; }\" >> $theme";
     start_vnc_server;
 

--- a/tests/x11/xfce4_terminal.pm
+++ b/tests/x11/xfce4_terminal.pm
@@ -23,7 +23,7 @@ sub run() {
     send_key "ctrl-shift-t";
     $self->enter_test_text('xfce4-terminal');
     assert_screen 'test-xfce4_terminal-1';
-    wait_screen_change { send_key 'alt-f4' };
+    assert_screen_change { send_key 'alt-f4' };
     # confirm close of multi-tab window
     send_key 'alt-w';
 }

--- a/tests/x11/yast2_snapper.pm
+++ b/tests/x11/yast2_snapper.pm
@@ -29,11 +29,11 @@ sub y2snapper_create_snapshot() {
     assert_screen 'yast2_snapper-createsnapshotdialog', 100;
     # Fill the form and finish by pressing the 'O'k-button
     type_string $name;
-    wait_screen_change { send_key "tab" };
-    wait_screen_change { send_key "tab" };
-    wait_screen_change { send_key "tab" };
-    wait_screen_change { send_key "tab" };
-    wait_screen_change { send_key "tab" };
+    assert_screen_change { send_key "tab" };
+    assert_screen_change { send_key "tab" };
+    assert_screen_change { send_key "tab" };
+    assert_screen_change { send_key "tab" };
+    assert_screen_change { send_key "tab" };
     type_string "a=1,b=2";
     save_screenshot;
     send_key "alt-o";
@@ -44,7 +44,7 @@ sub clean_and_quit() {
     # Ensure yast2-snapper is not busy anymore
     wait_still_screen;
     # C'l'ose  the snapper module
-    wait_screen_change { send_key "alt-l" };
+    assert_screen_change { send_key "alt-l" };
     # Wait until xterm is focussed, delete the directory and close xterm
     wait_idle;
     script_run "rm -rf testdata";
@@ -90,22 +90,22 @@ sub run() {
     type_string "yast2 snapper\n";
     assert_screen 'yast2_snapper-snapshots', 100;
     send_key_until_needlematch([qw(yast2_snapper-new_snapshot yast2_snapper-new_snapshot_selected)], 'pgdn');
-    wait_screen_change { send_key 'end' };
+    assert_screen_change { send_key 'end' };
     send_key_until_needlematch('yast2_snapper-new_snapshot_selected', 'up');
     # Press 'S'how changes button and select both directories that have been
     # extracted from the tarball
     send_key "alt-s";
     assert_screen 'yast2_snapper-collapsed_testdata', 200;
-    wait_screen_change { send_key "tab" };
-    wait_screen_change { send_key "spc" };
+    assert_screen_change { send_key "tab" };
+    assert_screen_change { send_key "spc" };
     send_key "down";
-    wait_screen_change { send_key "spc" };
+    assert_screen_change { send_key "spc" };
     # Make sure it shows the new files from the unpacked tarball
     assert_screen 'yast2_snapper-show_testdata', 100;
     # Close the dialog and make sure it is closed
     send_key "alt-c";
     send_key_until_needlematch([qw(yast2_snapper-new_snapshot yast2_snapper-new_snapshot_selected)], 'pgdn');
-    wait_screen_change { send_key 'end' };
+    assert_screen_change { send_key 'end' };
     send_key_until_needlematch('yast2_snapper-new_snapshot_selected', 'up');
     # Dele't'e the snapshot
     send_key "alt-t";

--- a/tests/x11regressions/empathy/empathy_irc.pm
+++ b/tests/x11regressions/empathy/empathy_irc.pm
@@ -34,7 +34,7 @@ sub run() {
     assert_screen 'empathy-irc-network-choose';
     type_string "freenode";
     assert_screen 'empathy-irc-freenode';
-    wait_screen_change {
+    assert_screen_change {
         send_key "ret";
     };
     send_key "tab";
@@ -43,7 +43,7 @@ sub run() {
     type_string "openqa-$rstr";
     send_key "alt-d";
     assert_screen 'empathy-irc-account-added';
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-c";
     };
 
@@ -78,7 +78,7 @@ sub run() {
     assert_screen 'empathy-confirm-deletion';
     send_key "alt-r";
     assert_screen 'empathy-account-deleted';
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-c";
     };
 

--- a/tests/x11regressions/evolution/evolution_mail_ews.pm
+++ b/tests/x11regressions/evolution/evolution_mail_ews.pm
@@ -27,7 +27,7 @@ sub run() {
     assert_screen "evolution_mail-compose-message";
     assert_and_click "evolution_mail-message-to";
     type_string "$mailbox";
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-u";
     };
     type_string "Testing";
@@ -40,7 +40,7 @@ sub run() {
     }
 
     send_key_until_needlematch "evolution_mail-notification", "f12", 10, 10;
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-w";
     };
     send_key "ret";
@@ -51,7 +51,7 @@ sub run() {
     assert_screen "evolution_mail-ready";
     assert_screen "evolution_mail-message-info";
     # Delete the message and expunge the deleted item
-    wait_screen_change {
+    assert_screen_change {
         send_key "ctrl-d";
     };
     save_screenshot();

--- a/tests/x11regressions/evolution/evolution_smoke.pm
+++ b/tests/x11regressions/evolution/evolution_smoke.pm
@@ -43,12 +43,12 @@ sub run() {
     assert_screen "evolution_mail-max-window";
 
     # Help
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-h";
     };
     send_key "a";
     assert_screen "evolution_about";
-    wait_screen_change {
+    assert_screen_change {
         send_key "esc";
     };
 

--- a/tests/x11regressions/firefox/sle12/firefox_changesaving.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_changesaving.pm
@@ -22,16 +22,16 @@ sub run() {
 
     $self->start_firefox;
 
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-tab";    #Switch to xterm
     };
     type_string "$changesaving_checktimestamp > dfa\n";
 
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-tab";    #Switch to firefox
     };
 
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-e";
     };
     send_key "n";
@@ -41,10 +41,10 @@ sub run() {
     send_key "down";           #Show a blank page
     assert_screen('firefox-changesaving-showblankpage', 30);
 
-    wait_screen_change {
+    assert_screen_change {
         send_key "ctrl-w";
     };
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-tab";    #Switch to xterm
     };
     type_string "$changesaving_checktimestamp > dfb\n";
@@ -54,7 +54,7 @@ sub run() {
     assert_screen('firefox-changesaving-diffresult', 30);
     type_string "rm df*\n", 1;    #Clear
 
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-tab";       #Switch to xterm
     };
 

--- a/tests/x11regressions/firefox/sle12/firefox_downloading.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_downloading.pm
@@ -20,7 +20,7 @@ my $dl_link_02 = "http://mirrors1.kernel.org/opensuse/distribution/13.2/iso/open
 
 sub dl_location_switch {
     my ($tg) = @_;
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-e";
     };
     send_key "n";
@@ -111,7 +111,7 @@ sub run() {
 
     # Retry
     send_key "ret";
-    wait_still_screen 2;    # extra wait for subsequent command execution, wait_screen_change sometimes works not well
+    wait_still_screen 2;    # extra wait for subsequent command execution, assert_screen_change sometimes works not well
     send_key "shift-f10";
     assert_screen 'firefox-downloading-resumed';
     send_key "esc";

--- a/tests/x11regressions/firefox/sle12/firefox_emaillink.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_emaillink.pm
@@ -64,7 +64,7 @@ sub run() {
     assert_screen('firefox-email_link-settings_sending');
     send_key "alt-s";    #Server
     type_string "smtp.suse.com";
-    wait_screen_change {
+    assert_screen_change {
         send_key $next_key;
     };
 
@@ -80,7 +80,7 @@ sub run() {
     send_key "alt-a";
 
     assert_screen('firefox-email_link-send');
-    wait_screen_change {
+    assert_screen_change {
         send_key "esc";
     };
 

--- a/tests/x11regressions/gedit/gedit_about.pm
+++ b/tests/x11regressions/gedit/gedit_about.pm
@@ -20,7 +20,7 @@ sub run() {
     x11_start_program("gedit");
 
     # check about window
-    wait_screen_change {
+    assert_screen_change {
         send_key "alt-h";
     };
     send_key "a";
@@ -33,7 +33,7 @@ sub run() {
     assert_and_click 'gedit-about-link';
     # give a little time to open and load website
     assert_screen 'gedit-open-firefox', 60;
-    wait_screen_change {
+    assert_screen_change {
         send_key "ctrl-q";
     };
 

--- a/tests/x11regressions/gedit/gedit_save.pm
+++ b/tests/x11regressions/gedit/gedit_save.pm
@@ -45,13 +45,13 @@ sub run() {
     sleep 1;
 
     # save and quit
-    wait_screen_change { send_key "ctrl-s"; };
+    assert_screen_change { send_key "ctrl-s"; };
     send_key "ctrl-q";
 
     # open saved file to validate
     x11_start_program("gedit " . "test.txt");
     assert_screen 'gedit-saved-file', 3;
-    wait_screen_change { send_key "ctrl-q"; };
+    assert_screen_change { send_key "ctrl-q"; };
 
     # clean up saved file
     x11_start_program("rm " . "test.txt");

--- a/tests/x11regressions/libreoffice/libreoffice_pyuno_bridge.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_pyuno_bridge.pm
@@ -27,7 +27,7 @@ sub run() {
 
     #Open LibreOffice
     send_key "alt-f2";
-    wait_screen_change {
+    assert_screen_change {
         type_string "libreoffice --writer";
         send_key "ret";
     };

--- a/tests/x11regressions/pidgin/pidgin_IRC.pm
+++ b/tests/x11regressions/pidgin/pidgin_IRC.pm
@@ -48,10 +48,10 @@ sub run() {
 
     # Warning of spoofing ip may appear
     if (check_screen("pidgin-spoofing-ip", 10)) {
-        wait_screen_change {
+        assert_screen_change {
             send_key "alt-tab";
         };
-        wait_screen_change {
+        assert_screen_change {
             send_key "ctrl-w";    # close it
         };
     }

--- a/tests/x11regressions/shotwell/shotwell_import.pm
+++ b/tests/x11regressions/shotwell/shotwell_import.pm
@@ -23,7 +23,7 @@ sub run() {
 
     x11_start_program("shotwell");
     assert_screen 'shotwell-first-launch';
-    wait_screen_change { send_key "ret"; };
+    assert_screen_change { send_key "ret"; };
 
     # Import two test pictures into the library
     $self->import_pictures(\@pictures);


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst/pull/689 added a new function to
the testapi 'assert_screen_change' which should be used wherever there is no
explicit checking of the return value of 'wait_screen_change'.

Leaving alone the occurences of 'wait_screen_change' where the return code
is checked.

Verification run: http://lord.arch/tests/5552