### PR TITLE
Reset console status after triggering boot

### DIFF
--- a/tests/autoyast/autoyast_reboot.pm
+++ b/tests/autoyast/autoyast_reboot.pm
@@ -22,6 +22,7 @@ use testapi;
 
 sub run {
     type_string("shutdown -r now\n");
+    reset_consoles;
 
     #obsoletes installation/autoyast_reboot.pm
     assert_screen("bios-boot",     900);

--- a/tests/installation/boot_into_snapshot.pm
+++ b/tests/installation/boot_into_snapshot.pm
@@ -43,6 +43,7 @@ sub run() {
         }
     }
     script_run("systemctl reboot", 0);
+    reset_consoles;
 }
 
 sub test_flags() {


### PR DESCRIPTION
I tested this with http://dimstar.ddns.net/tests/2 (boot_to_snapshot) - this test is a clone of https://openqa.opensuse.org/tests/333209 which failed to switch to TTY1 after the reboot