### PR TITLE
Do not pass systemctl status through $PAGER

### DIFF
--- a/tests/console/hostname.pm
+++ b/tests/console/hostname.pm
@@ -25,7 +25,7 @@ sub run() {
     # if you change hostname using `hostnamectl set-hostname`, then `hostname -f` will fail with "hostname: Name or service not known"
     # also DHCP/DNS don't know about the changed hostname, you need to send a new DHCP request to update dynamic DNS
     # yast2-network module does "NetworkService.ReloadOrRestart if Stage.normal || !Linuxrc.usessh" if hostname is changed via `yast2 lan`
-    script_run "systemctl status network.service";
+    script_run "systemctl --no-pager status network.service";
     save_screenshot;
     assert_script_run "if systemctl -q is-active network.service; then systemctl reload-or-restart network.service; fi";
 }


### PR DESCRIPTION
systemd 232 seems to call $PAGER more often, especially when there are warnings in the output.

