### PR TITLE
Fix #2240

### DIFF
--- a/tests/qam-kgraft/reboot_restore.pm
+++ b/tests/qam-kgraft/reboot_restore.pm
@@ -49,12 +49,12 @@ sub run() {
 
     script_run("ssh-keygen -R qadb2.suse.de");
     assert_script_run(
-        qq{/usr/share/qa/tools/remote_qa_db_report.pl
-                         -L
-                         -b
-                         -T openqa
-                         -c "`uname -r -v` `kgr -v patches | grep -B2 RPM | head -n1`"
-                         -t patch:"$rrid"
+        qq{/usr/share/qa/tools/remote_qa_db_report.pl \\
+                         -L \\
+                         -b \\
+                         -T openqa \\
+                         -c "`uname -r -v` `kgr -v patches | grep -B2 RPM | head -n1`" \\
+                         -t patch:"$rrid" \\
                          &> /tmp/submission.log }, 1800
     );
     script_run("cat /tmp/submission.log");


### PR DESCRIPTION
The multi-line command to submit logs to qadb is not interpreted as multi-
line. Adding backslashes to fix this.

See: https://openqa.suse.de/tests/718102/file/video.ogv  (Time: 08:51)