### PR TITLE
INSTALLONLY should not apply updates

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -163,6 +163,14 @@ sub installwithaddonrepos_is_applicable() {
     return get_var("HAVE_ADDON_REPOS") && !get_var("UPGRADE") && !get_var("NET");
 }
 
+sub updates_is_applicable() {
+    # we don't want live systems to run out of memory or virtual disk space.
+    # Applying updates on a live system would not be persistent anyway.
+    # Also, applying updates on BOOT_TO_SNAPSHOT is useless.
+    # Also, updates on INSTALLONLY do not match the meaning
+    return !get_var('INSTALLONLY') && !get_var('BOOT_TO_SNAPSHOT') && !get_var('DUALBOOT') && !get_var('UPGRADE') && !is_livesystem;
+}
+
 sub guiupdates_is_applicable() {
     return get_var("DESKTOP") =~ /gnome|kde|xfce|lxde/ && !check_var("FLAVOR", "Rescue-CD");
 }
@@ -765,15 +773,7 @@ sub install_online_updates {
 }
 
 sub load_system_update_tests {
-    # we don't want live systems to run out of memory or virtual disk space.
-    # Applying updates on a live system would not be persistent anyway
-    # Applying updates on BOOT_TO_SNAPSHOT is useless.
-    return if get_var("BOOT_TO_SNAPSHOT") || get_var("DUALBOOT") || get_var("UPGRADE") || is_livesystem;
-    # Infamous boot order issue on UEFI+USBBOOT leads a kernel reboot failed to
-    # boot into HDD but USB again. Since uefi@usbboot is INSTALLONLY test and
-    # will not generate the asset image, just don't applying updates on it.
-    return if get_var("UEFI") && get_var("USBBOOT");
-
+    return unless updates_is_applicable;
     if (need_clear_repos) {
         loadtest "update/zypper_clear_repos";
     }


### PR DESCRIPTION
Applying updates and also testing this is a good idea but the "install only"
jobs are not the correct location.

An update notification like in
https://openqa.opensuse.org/tests/332430#step/consoletest_finish/11
could be better fixed by needles which either explicitly accept the update
notification or mask it so that it does not matter because we should not care
at the state of "install only" if there are any updates or not.

Any job using INSTALLYONLY should test only if the SUT can boot correctly.
That is especially true for tests stating BOOT_TO_SNAPSHOT which boots into a
snapshot that is read-only. Trying to apply updates does not make sense after
booting into a read-only snapshot.

This reverts commit 40a89e4be9f0367a3c051d869d6586cfeacae73a.

Verification runs:

* kde @ TW: http://lord.arch/tests/5592
* gnome-image @ Leap 42.3: http://lord.arch/tests/5593
* gnome-gdm @ Leap 42.3: http://lord.arch/tests/5594
* gnome maintenance @ Leap 42.2: http://lord.arch/tests/5595

Related progress issue: https://progress.opensuse.org/issues/16018