### PR TITLE
Revert "Use bridged network needle for YaST2 ..."

### DIFF
--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -61,14 +61,7 @@ sub run() {
     my $domain = "zq1.de";
 
     send_key "alt-s";    # open hostname tab
-
-    # On Xen we don't have user-mode networking, just a bridged network
-    if (check_var('VIRSH_VMM_FAMILY', 'xen')) {
-        assert_screen "yast2_lan-hostname-tab_bridged-network";
-    }
-    else {
-        assert_screen "yast2_lan-hostname-tab";
-    }
+    assert_screen "yast2_lan-hostname-tab";
     send_key "tab";
     for (1 .. 15) { send_key "backspace" }
     type_string $hostname;


### PR DESCRIPTION
This reverts commit ba9bd8b04c461df416286a72dde23d550f363cfa.

Since `redefine_svirt_domain.pm` is not used anymore, networking on Xen
behaves the same as on user-mode networking.

Verification run: http://assam.suse.cz/tests/4700#step/yast2_lan/12
Needle: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/288