### PR TITLE
assert_and_click works with workaround in backend

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -37,13 +37,8 @@ sub run() {
         send_key "alt-e";    # open release notes window
     }
     else {
-        # In text mode we can't click anything. On Xen PV we don't have
-        # correct exis coordinates, so we miss the button: POO#13536.
-        if (
-            check_var('VIDEOMODE', 'text')
-            or (    check_var('VIRSH_VMM_FAMILY', 'xen')
-                and check_var('VIRSH_VMM_TYPE', 'linux')))
-        {
+        # In text mode we can't click anything.
+        if (check_var('VIDEOMODE', 'text')) {
             send_key "alt-l";    # open release notes window
         }
         else {


### PR DESCRIPTION
POO#13536

`assert_and_click()` now should work on Xen PV with a resolution hack in
os-autoinst.

Related to: https://github.com/os-autoinst/os-autoinst/pull/699