### PR TITLE
LTP: dump memory when test freezes

### DIFF
--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -207,6 +207,7 @@ sub record_ltp_result {
         $details->{result} = 'fail';
         close $fh;
         push @{$self->{details}}, $details;
+        save_memory_dump($name);
         die "Can't continue; timed out waiting for LTP test case which may still be running or the OS may have crashed!";
     }
 


### PR DESCRIPTION
Sounds like something we would want. I assume this can be opened with crash or gdb to inspect memory and get kernel stack traces.