### PR TITLE
Fix operator precedence issue

### DIFF
--- a/tests/console/yast2_clone_system.pm
+++ b/tests/console/yast2_clone_system.pm
@@ -28,7 +28,7 @@ sub run() {
 
     # Check and upload profile for chained tests
     upload_asset "/root/autoinst.xml";
-    if (script_run 'xmllint --noout --relaxng /usr/share/YaST2/schema/autoyast/rng/profile.rng /root/autoinst.xml' ne 0) {
+    if (script_run 'xmllint --noout --relaxng /usr/share/YaST2/schema/autoyast/rng/profile.rng /root/autoinst.xml') {
         record_soft_failure 'bsc#1013047';
     }
 


### PR DESCRIPTION
If return value from bash is not 0, which means true in perl then record_soft_fail

Currently script_run is called with 1 boolean parameter - "script_run ('xmllint..' ne 0)", without an actual script.

Fix for: https://openqa.opensuse.org/tests/338155#step/yast2_clone_system/11
Local run: http://dhcp91.suse.cz/tests/3648