### PR TITLE
Increase timeout for yast_virtualization

### DIFF
--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -20,7 +20,7 @@ sub run() {
     send_key "alt-f10";
     become_root;
     script_run("yast2 virtualization; echo yast2-virtualization-done-\$? > /dev/$serialdev", 0);
-    assert_screen "virt-sle-gnome_yast_virtualization";
+    assert_screen "virt-sle-gnome_yast_virtualization", 60;
     if (check_var("FLAVOR", "Desktop-DVD")) {
         # select everything
         send_key "alt-v";    # Virtualization client tools


### PR DESCRIPTION
The yast_virtualization test fails 1/5 times. Often this is caused
after executing 'yast2 virtualization' which might take more than
30 seconds. This seems to be just a timeout issue.

Failure example: https://openqa.suse.de/tests/724279#step/yast_virtualization/7