### PR TITLE
Give vnc more time to start

### DIFF
--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -61,7 +61,7 @@ sub run() {
     # Start vncviewer (rw & ro mode) and check if changes are processed by xev
     foreach my $opt (@options) {
         x11_start_program("vncviewer :1 -SecurityTypes=VncAuth");
-        assert_screen "vnc_password_dialog";
+        assert_screen "vnc_password_dialog", 60;
         type_string "$opt->{pw}\n";
         send_key "super-left";
         mouse_set(80, 120);


### PR DESCRIPTION
Fix for: https://openqa.suse.de/tests/728652#step/vnc_two_passwords/18