### PR TITLE
Skip grub_test on remote installation

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1326,7 +1326,7 @@ else {
     elsif (get_var("REMOTE_TARGET")) {
         load_boot_tests();
         loadtest "remote/remote_target";
-        load_reboot_tests();
+        loadtest "installation/first_boot";
     }
     elsif (is_jeos) {
         load_boot_tests();


### PR DESCRIPTION
Parent job can take longer to finish and release the lock. Grub passes
timeout in the meantime and related assert_screen fails.

poo#15720

Local run: http://dhcp91.suse.cz/tests/3696