### PR TITLE
Check terminal responsivnes to be sure it's ready

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -112,6 +112,10 @@ sub x11_start_program($$$) {
         sleep 3;
     }
     send_key('ret');
+    # test responsivnes of xterm to aviod miss typing
+    if ($program =~ 'xterm') {
+        utils::ensure_ready_terminal;
+    }
     wait_still_screen unless $options->{no_wait};
     # lrunner has auto-completion feature, sometimes it causes high load while
     # typing and the following 'ret' fails to work

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -37,6 +37,7 @@ our @EXPORT = qw(
   turn_off_kde_screensaver
   random_string
   handle_login
+  ensure_ready_terminal
 );
 
 
@@ -709,6 +710,30 @@ sub handle_login {
     assert_screen "displaymanager-password-prompt";
     type_password;
     send_key "ret";
+}
+
+=head2 ensure_ready_terminal
+Make sure terminal is ready by creating file with short content
+When it's done successfuly then it's proven terminal is ready
+By default non-root user shell is expected, with argument is
+expected root shell
+=cut
+sub ensure_ready_terminal {
+    my $root        = @_;
+    my $max_retries = 10;
+    for (1 .. $max_retries) {
+        eval {
+            if ($root) {
+                assert_script_run 'echo ready > term && grep ready term && rm term';
+            }
+            else {
+                assert_script_sudo 'echo ready > term && grep ready term && rm term';
+            }
+        };
+        last unless ($@);
+        diag "terminal is not ready: $@";
+        diag "terminal is not ready. Retry: $_ of $max_retries";
+    }
 }
 
 1;

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -68,7 +68,6 @@ sub test_terminal {
     my ($self, $name) = @_;
     mouse_hide(1);
     x11_start_program($name);
-    assert_screen $name;
     $self->enter_test_text($name);
     assert_screen "test-$name-1";
     send_key 'alt-f4';


### PR DESCRIPTION
often happens that when application is started via xterm, commands are typed before xterm is ready for typing
This will check terminal responsiveness to prove terminal ready

[fail](http://argus.suse.cz/tests/2#step/x11regressions_setup/4)
[xterm test](http://10.100.12.155/tests/4821)
[root terminal test](http://10.100.12.155/tests/4822#step/consoletest_setup/9)