### PR TITLE
Fix live CDs built by kiwi>=8

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -55,8 +55,16 @@ sub pre_bootmenu_setup {
 
 sub select_bootmenu_option {
     assert_screen 'inst-bootmenu';
+    if (get_var('LIVECD')) {
+        # live CDs might have a very short timeout of the initial bootmenu
+        # (1-2s with recent kiwi versions) so better stop the timeout
+        # immediately before checking more and having an opportunity to type
+        # more boot parameters. Send 'up' which should work also on textmode
+        # and UEFI menues.
+        send_key 'up';
+    }
     if (get_var('ZDUP') || get_var("ONLINE_MIGRATION")) {
-        send_key 'ret';               # boot from hard disk
+        send_key 'ret';    # boot from hard disk
         return 3;
     }
 


### PR DESCRIPTION
It looks like live CDs built by kiwi version 8 now have a default boot menue
timeout of only 1-2 seconds so we have no time to check screens multiple
times. This commit immediately presses a key to abort the timeout to type in
boot parameters.

Local verification run logfile:

```
…
12:03:15.6389 15066 no match 23
12:03:16.5096 15066 MATCH(bootmenu-krypton-20160731:1.00)
12:03:16.7384 15057 >>> testapi::_check_backend_response: found bootmenu-krypton-20160731, similarity 1.00 @ 196/174
12:03:16.7385 Debug: /var/lib/openqa/share/tests/opensuse/tests/installation/bootloader.pm:24 called bootloader_setup::select_bootmenu_option
12:03:16.7386 15057 <<< testapi::send_key(key='up')
12:03:17.1409 Debug: /var/lib/openqa/share/tests/opensuse/tests/installation/bootloader.pm:24 called bootloader_setup::select_bootmenu_option
12:03:17.1410 15057 <<< testapi::check_screen(mustmatch='boot-live-kde', timeout=5)
```