### PR TITLE
Enable uefi support for caasp

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -89,7 +89,9 @@ sub bootmenu_default_params {
         type_string " video=hyperv_fb:1024x768";
     }
     type_string_slow "Y2DEBUG=1 ";
-    if (!is_jeos && (check_var('ARCH', 'i586') || check_var('ARCH', 'x86_64'))) {
+
+    # gfxpayload variable replaced vga option in grub2
+    if (!is_jeos && !is_casp && (check_var('ARCH', 'i586') || check_var('ARCH', 'x86_64'))) {
         type_string "vga=791 ";
         type_string_slow "video=1024x768-16 ";
         assert_screen check_var('UEFI', 1) ? 'inst-video-typed-grub2' : 'inst-video-typed', 4;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -128,8 +128,16 @@ sub is_jeos() {
     return get_var('FLAVOR', '') =~ /^JeOS/;
 }
 
-sub is_casp() {
-    return check_var('DISTRI', 'casp');
+# Check if distribution is CASP
+# If argument is passed then flavor has to match (universal VMX keyword)
+sub is_casp {
+    my $flavor = shift;
+    return 0 unless check_var('DISTRI', 'casp');
+    return 1 unless $flavor;
+
+    # There is one DVD and multiple VMX (for KVM/XEN/VMware/Cloud) flavors
+    return !check_var('FLAVOR', 'DVD') if $flavor eq 'VMX';
+    return check_var('FLAVOR', $flavor);
 }
 
 sub type_string_slow {

--- a/products/casp/main.pm
+++ b/products/casp/main.pm
@@ -39,13 +39,20 @@ if (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')
 
 sub load_boot_tests() {
     if (check_var('FLAVOR', 'DVD')) {
-        loadtest 'installation/bootloader';
+        if (get_var("UEFI")) {
+            loadtest 'installation/bootloader_uefi';
+        }
+        else {
+            loadtest 'installation/bootloader';
+        }
     }
     else {
         if (check_var("BACKEND", "svirt")) {
             loadtest "installation/bootloader_svirt";
         }
-        loadtest 'boot/boot_to_desktop';
+        else {
+            loadtest 'installation/bootloader_uefi';
+        }
     }
 }
 

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -69,7 +69,7 @@ sub run() {
         if (get_var("PROMO") || get_var('LIVETEST')) {
             send_key_until_needlematch("boot-live-" . get_var("DESKTOP"), 'down', 10, 5);
         }
-        elsif (!is_jeos) {
+        elsif (!is_jeos && !is_casp('VMX')) {
             send_key_until_needlematch('inst-oninstallation', 'down', 10, 5);
         }
     }

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -117,7 +117,6 @@ sub run() {
     }
 
     type_string " \\\n";    # changed the line before typing video params
-                            # https://wiki.archlinux.org/index.php/Kernel_Mode_Setting#Forcing_modes_and_EDID
     bootmenu_default_params;
     specific_bootmenu_params;
 


### PR DESCRIPTION
Extend is_casp to accpet $flavor argument

poo#15874

Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/295

Local run:
http://dhcp91.suse.cz/tests/3717 VMX
http://dhcp91.suse.cz/tests/3718 VMX+UEFI
http://dhcp91.suse.cz/tests/3676 DVD
http://dhcp91.suse.cz/tests/3672 DVD+UEFI
