### PR TITLE
Remove snapper test from o3

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -507,7 +507,6 @@ sub load_extra_tests() {
         if (get_var("FILESYSTEM", "btrfs") eq "btrfs") {
             loadtest "console/btrfs_autocompletion";
             if (get_var("NUMDISKS", 0) > 1) {
-                loadtest "console/snapper_cleanup";
                 loadtest "console/btrfs_qgroups";
                 loadtest "console/btrfs_send_receive";
             }


### PR DESCRIPTION
Short term fix for #poo16254 to not block Tumbleweed
while we trying to fix #poo16254