### PR TITLE
LTP: Use named argument for memory dump

### DIFF
--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -207,7 +207,7 @@ sub record_ltp_result {
         $details->{result} = 'fail';
         close $fh;
         push @{$self->{details}}, $details;
-        save_memory_dump($name);
+        save_memory_dump(filename => $name);
         die "Can't continue; timed out waiting for LTP test case which may still be running or the OS may have crashed!";
     }
 


### PR DESCRIPTION
Save memory dump only uses named arguments.