### PR TITLE
Fix ltp network net.tcp_cmds tests

### DIFF
--- a/tests/kernel/ltp_setup_networking.pm
+++ b/tests/kernel/ltp_setup_networking.pm
@@ -71,6 +71,9 @@ EOF
 
     # dhcpd
     assert_script_run 'touch /var/lib/dhcp/db/dhcpd.leases /var/lib/dhcp6/db/dhcpd6.leases';
+
+    # echo/echoes, getaddrinfo_01
+    assert_script_run 'sed -i \'s/^\(hosts:\s+files\s\+dns$\)/\1 myhostname/\' /etc/nsswitch.conf';
 }
 
 # poo#14402

--- a/tests/kernel/ltp_setup_networking.pm
+++ b/tests/kernel/ltp_setup_networking.pm
@@ -70,7 +70,7 @@ EOF
     assert_script_run 'which ping6 >/dev/null 2>&1 || ln -s `which ping` /usr/local/bin/ping6';
 
     # dhcpd
-    assert_script_run 'touch /var/lib/dhcp6/db/dhcpd6.leases';
+    assert_script_run 'touch /var/lib/dhcp/db/dhcpd.leases /var/lib/dhcp6/db/dhcpd6.leases';
 }
 
 # poo#14402

--- a/tests/kernel/ltp_setup_networking.pm
+++ b/tests/kernel/ltp_setup_networking.pm
@@ -19,7 +19,7 @@ use utils;
 
 sub install {
     # utils
-    zypper_call("in expect iputils psmisc tcpdump telnet", log => 'utils.log');
+    zypper_call("in expect iputils psmisc tcpdump", log => 'utils.log');
 
     # clients
     zypper_call("in dhcp-client finger mrsh-rsh-compat telnet", log => 'clients.log');

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -286,10 +286,10 @@ sub run {
         my $fin_msg    = "### TEST $test->{name} COMPLETE >>> ";
         my $cmd_text   = qq($test->{command}; echo "$fin_msg\$?");
         my $start_time = thetime();
-        my $set_rhost  = $is_network && $test->{command} =~ m/^finger01|ftp01|rcp01|rdist01|rsh01/;
+        my $set_rhost  = $is_network && $test->{command} =~ m/^finger01|ftp01|rcp01|rdist01|rlogin01|rpc01|rpcinfo01|rsh01|telnet01/;
 
         if ($set_rhost) {
-            assert_script_run(q(export RHOST='localhost'));
+            assert_script_run(q(export RHOST='127.0.0.1'));
         }
 
         if (is_serial_terminal) {

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -269,10 +269,17 @@ sub run {
         script_run('ps axf');
         script_run('netstat -ap');
 
+        script_run('cat /etc/resolv.conf');
+        script_run('cat /etc/nsswitch.conf');
+        script_run('cat /etc/hosts');
+
         # emulate /opt/ltp/testscripts/network.sh
         assert_script_run('TST_TOTAL=1 TCID="network_settings"; . test_net.sh; export TCID= TST_LIB_LOADED=');
 
         script_run('env');
+
+        script_run('ip addr');
+        script_run('ip route');
     }
 
     for my $test (@tests) {


### PR DESCRIPTION
Most of the tests are fixed, rlogin and telnet needs to be disabled.