### PR TITLE
Check that xterm started before typing

### DIFF
--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -19,6 +19,7 @@ sub run() {
     my ($self) = @_;
     mouse_hide(1);
     x11_start_program("xterm");
+    assert_screen("xterm");
     type_string("ssh -XC root\@localhost xterm\n");
     assert_screen([qw(ssh-xterm-host-key-authentication ssh-password-prompt)]);
     # if ssh asks for authentication of the key accept it


### PR DESCRIPTION
Fix for: https://openqa.suse.de/tests/747424#step/sshxterm/8