### PR TITLE
Split execution logic for extratest and yast2 test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -36,6 +36,7 @@ our @EXPORT = qw(
   unregister_needle_tags
   any_desktop_is_applicable
   console_is_applicable
+  boot_hdd_image
 );
 
 sub init_main {
@@ -293,4 +294,19 @@ sub unregister_needle_tags {
     for my $n (@a) { $n->unregister(); }
 }
 
+sub boot_hdd_image {
+    die unless get_var("BOOT_HDD_IMAGE");
+    if (check_var("BACKEND", "svirt")) {
+        if (check_var("ARCH", "s390x")) {
+            loadtest "installation/bootloader_zkvm";
+        }
+        else {
+            loadtest "installation/bootloader_svirt";
+        }
+    }
+    if (get_var('UEFI') && get_var('BOOTFROM')) {
+        loadtest "boot/uefi_bootmenu";
+    }
+    loadtest "boot/boot_to_desktop";
+}
 1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -3,6 +3,7 @@ use base Exporter;
 use Exporter;
 use testapi qw(check_var get_var set_var diag);
 use autotest;
+use utils;
 use strict;
 use warnings;
 
@@ -37,6 +38,7 @@ our @EXPORT = qw(
   any_desktop_is_applicable
   console_is_applicable
   boot_hdd_image
+  load_yast2_ui_tests
 );
 
 sub init_main {
@@ -309,4 +311,63 @@ sub boot_hdd_image {
     }
     loadtest "boot/boot_to_desktop";
 }
+
+sub load_yast2_ui_tests {
+    boot_hdd_image;
+    # setup $serialdev permission and so on
+    loadtest "console/consoletest_setup";
+    loadtest "console/hostname";
+    loadtest "console/check_console_font";
+    loadtest "console/zypper_lr";
+    loadtest "console/zypper_ref";
+    # start extra yast console test from here
+    loadtest "console/yast2_proxy";
+    loadtest "console/yast2_ntpclient";
+    loadtest "console/yast2_tftp";
+    loadtest "console/yast2_vnc";
+    loadtest "console/yast2_samba";
+    loadtest "console/yast2_xinetd";
+    loadtest "console/yast2_apparmor";
+    # TODO: why are the following two modules called on sle but not on opensuse?
+    # TODO: check if the following two modules also work on opensuse and delete if
+    if (check_var('DISTRI', 'sle')) {
+        loadtest "console/yast2_lan_hostname";
+        loadtest "console/yast2_nis";
+    }
+    # TODO: check if the following two modules also work on sle and delete if.
+    # yast-lan related tests do not work when using networkmanager.
+    # (Livesystem and laptops do use networkmanager)
+    if (check_var('DISTRI', 'opensuse') && !get_var("LIVETEST") && !get_var("LAPTOP")) {
+        loadtest "console/yast2_cmdline";
+        loadtest "console/yast2_dns_server";
+        loadtest "console/yast2_nfs_client";
+    }
+    loadtest "console/yast2_http";
+    loadtest "console/yast2_ftp";
+    # back to desktop
+    loadtest "console/consoletest_finish";
+    return
+      unless (!get_var("INSTALLONLY")
+        && is_desktop_installed()
+        && !get_var("DUALBOOT")
+        && !get_var("RESCUECD")
+        && get_var("Y2UITEST"));
+    # TODO: check why this was not called on opensuse
+    if (check_var('DISTRI', 'sle')) {
+        loadtest "x11/yast2_lan_restart";
+    }
+    loadtest "yast2_gui/yast2_control_center";
+    loadtest "yast2_gui/yast2_bootloader";
+    loadtest "yast2_gui/yast2_datetime";
+    loadtest "yast2_gui/yast2_firewall";
+    loadtest "yast2_gui/yast2_hostnames";
+    loadtest "yast2_gui/yast2_lang";
+    loadtest "yast2_gui/yast2_network_settings";
+    if (snapper_is_applicable()) {
+        loadtest "yast2_gui/yast2_snapper";
+    }
+    loadtest "yast2_gui/yast2_software_management";
+    loadtest "yast2_gui/yast2_users";
+}
+
 1;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -472,37 +472,31 @@ sub load_consoletests() {
 
 }
 
-sub load_yast2_gui_tests() {
-    loadtest "yast2_gui/yast2_control_center";
-    loadtest "yast2_gui/yast2_bootloader";
-    loadtest "yast2_gui/yast2_datetime";
-    loadtest "yast2_gui/yast2_firewall";
-    loadtest "yast2_gui/yast2_hostnames";
-    loadtest "yast2_gui/yast2_lang";
-    loadtest "yast2_gui/yast2_network_settings";
-    if (snapper_is_applicable()) {
-        loadtest "yast2_gui/yast2_snapper";
-    }
-    loadtest "yast2_gui/yast2_software_management";
-    loadtest "yast2_gui/yast2_users";
-}
-
 sub load_extra_tests() {
-
-    return unless get_var('EXTRATEST') || get_var('Y2UITEST');
+    # Put tests that filled the conditions below
+    # 1) you don't want to run in stagings below here
+    # 2) the application is not rely on desktop environment
+    # 3) running based on preinstalled image
+    return unless get_var('EXTRATEST');
     # pre-conditions for extra tests ie. the tests are running based on preinstalled image
     return if get_var("INSTALLONLY") || get_var("DUALBOOT") || get_var("RESCUECD");
 
     # setup $serialdev permission and so on
     loadtest "console/consoletest_setup";
     loadtest "console/hostname";
-
-    if (console_is_applicable() && get_var("EXTRATEST")) {
-        # Put tests that filled the conditions below
-        # 1) you don't want to run in stagings below here
-        # 2) the application is not rely on desktop environment
-        # 3) running based on preinstalled image
-
+    if (any_desktop_is_applicable()) {
+        if (!get_var("NOAUTOLOGIN")) {
+            loadtest "x11/multi_users_dm";
+        }
+        if (gnomestep_is_applicable() && check_var('VERSION', '42.2')) {
+            # 42.2 feature - not even on Tumbleweed
+            loadtest "x11/gdm_session_switch";
+        }
+        if (gnomestep_is_applicable()) {
+            loadtest "x11/seahorse";
+        }
+    }
+    else {
         loadtest "console/check_console_font";
         loadtest "console/zypper_lr";
         loadtest "console/zypper_ar";
@@ -548,51 +542,8 @@ sub load_extra_tests() {
         if (!check_var('ARCH', 'aarch64')) {
             loadtest "toolchain/crash";
         }
-
-        return 1;
     }
-    elsif (any_desktop_is_applicable() && get_var("Y2UITEST")) {
-        loadtest "console/zypper_lr";
-        loadtest "console/zypper_ref";
-        # start extra yast console test from here
-        loadtest "console/yast2_proxy";
-        loadtest "console/yast2_ntpclient";
-        loadtest "console/yast2_tftp";
-        loadtest "console/yast2_vnc";
-        loadtest "console/yast2_samba";
-        loadtest "console/yast2_xinetd";
-        loadtest "console/yast2_apparmor";
-        loadtest "console/yast2_http";
-        loadtest "console/yast2_ftp";
-        # yast-lan related tests do not work when using networkmanager.
-        # (Livesystem and laptops do use networkmanager)
-        if (!get_var("LIVETEST") && !get_var("LAPTOP")) {
-            loadtest "console/yast2_cmdline";
-            loadtest "console/yast2_dns_server";
-            loadtest "console/yast2_nfs_client";
-        }
-        # back to desktop
-        loadtest "console/consoletest_finish";
-        load_yast2_gui_tests();
-
-        return 1;
-    }
-    elsif (any_desktop_is_applicable() && get_var("EXTRATEST")) {
-        if (!get_var("NOAUTOLOGIN")) {
-            loadtest "x11/multi_users_dm";
-        }
-        if (gnomestep_is_applicable() && check_var('VERSION', '42.2')) {
-            # 42.2 feature - not even on Tumbleweed
-            loadtest "x11/gdm_session_switch";
-        }
-        if (gnomestep_is_applicable()) {
-            loadtest "x11/seahorse";
-        }
-        return 1;
-    }
-
-
-    return 0;
+    return 1;
 }
 
 sub load_otherDE_tests() {
@@ -906,6 +857,9 @@ elsif (get_var("RESCUESYSTEM")) {
 }
 elsif (get_var("LINUXRC")) {
     loadtest "linuxrc/system_boot";
+}
+elsif (get_var('Y2UITEST')) {
+    load_yast2_ui_tests;
 }
 elsif (get_var("SUPPORT_SERVER")) {
     loadtest "support_server/boot";

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -973,10 +973,7 @@ else {
         load_zdup_tests();
     }
     elsif (get_var("BOOT_HDD_IMAGE")) {
-        if (get_var('UEFI') && get_var('BOOTFROM')) {
-            loadtest "boot/uefi_bootmenu";
-        }
-        loadtest "boot/boot_to_desktop";
+        boot_hdd_image;
         if (get_var("ISCSI_SERVER")) {
             set_var('INSTALLONLY', 1);
             loadtest "iscsi/iscsi_server";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -691,26 +691,6 @@ sub load_consoletests() {
     }
 }
 
-sub load_yast2_gui_tests() {
-    return
-      unless (!get_var("INSTALLONLY")
-        && is_desktop_installed()
-        && !get_var("DUALBOOT")
-        && !get_var("RESCUECD")
-        && get_var("Y2UITEST"));
-    loadtest "x11/yast2_lan_restart";
-    loadtest "yast2_gui/yast2_control_center";
-    loadtest "yast2_gui/yast2_bootloader";
-    loadtest "yast2_gui/yast2_datetime";
-    loadtest "yast2_gui/yast2_firewall";
-    loadtest "yast2_gui/yast2_hostnames";
-    loadtest "yast2_gui/yast2_lang";
-    loadtest "yast2_gui/yast2_network_settings";
-    loadtest "yast2_gui/yast2_snapper";
-    loadtest "yast2_gui/yast2_software_management";
-    loadtest "yast2_gui/yast2_users";
-}
-
 sub load_extra_test () {
     # Put tests that filled the conditions below
     # 1) you don't want to run in stagings below here
@@ -1183,31 +1163,11 @@ elsif (is_kgraft) {
     loadtest "qam-kgraft/reboot_restore";
 }
 elsif (get_var("EXTRATEST")) {
-    prepare_target();
+    boot_hdd_image;
     load_extra_test();
 }
 elsif (get_var("Y2UITEST")) {
-    prepare_target();
-    # setup $serialdev permission and so on
-    loadtest "console/consoletest_setup";
-    # start extra yast console test from here
-    loadtest "console/check_console_font";
-    loadtest "console/zypper_lr";
-    loadtest "console/zypper_ref";
-    loadtest "console/yast2_proxy";
-    loadtest "console/yast2_ntpclient";
-    loadtest "console/yast2_tftp";
-    loadtest "console/yast2_vnc";
-    loadtest "console/yast2_samba";
-    loadtest "console/yast2_xinetd";
-    loadtest "console/yast2_apparmor";
-    loadtest "console/yast2_lan_hostname";
-    loadtest "console/yast2_nis";
-    loadtest "console/yast2_http";
-    loadtest "console/yast2_ftp";
-    # back to desktop
-    loadtest "console/consoletest_finish";
-    load_yast2_gui_tests();
+    load_yast2_ui_tests;
 }
 elsif (get_var("WINDOWS")) {
     loadtest "installation/win10_installation";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -968,15 +968,7 @@ sub load_fips_tests_crypt() {
 
 sub prepare_target() {
     if (get_var("BOOT_HDD_IMAGE")) {
-        if (check_var("BACKEND", "svirt")) {
-            if (check_var("ARCH", "s390x")) {
-                loadtest "installation/bootloader_zkvm";
-            }
-            else {
-                loadtest "installation/bootloader_svirt";
-            }
-        }
-        loadtest "boot/boot_to_desktop";
+        boot_hdd_image;
     }
     else {
         load_boot_tests();


### PR DESCRIPTION
- extract yast2 ncurses/gui tests to main_common to align execution logic in sle and opensuse
- align execution logic of extratest in opensuse with sle