### PR TITLE
Maxing the ffox window in test due to altered graphics plugin page

### DIFF
--- a/tests/x11regressions/firefox/sle12/firefox_gnomeshell.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_gnomeshell.pm
@@ -34,6 +34,8 @@ sub run() {
     send_key "alt-a";
     assert_and_click "firefox-gnomeshell-allowremember";
     assert_and_click "firefox-gnomeshell-check_installed";
+    # Maximize the window to ensure all relevant parts are in the viewable area
+    send_key("super-up");
     assert_screen("firefox-gnomeshell-installed", 90);
     send_key "pgdn";
     assert_screen("firefox-gnomeshell-installed_02", 90);


### PR DESCRIPTION
Due to altered graphics on the firefox plugin page (sliders to enable/disable plugins were moved to the right side of the page), sle12/firefox_gnomeshell test was failing.

Test was altered to maximize the firefox window, in order to make the sliders visible in the window area.