### PR TITLE
Add regexp for a new bug found by journal_check test in casp

### DIFF
--- a/tests/casp/journal_check.pm
+++ b/tests/casp/journal_check.pm
@@ -47,6 +47,7 @@ sub run() {
         bsc_1022527 => '.*wickedd.*ni_process_reap.*blocking waitpid.*',
         bsc_1022524 => '.*rpc\.statd.*Failed to open directory sm.*',
         bsc_1022525 => '.*rpcbind.*cannot(.*open file.*rpcbind.xdr.*|.*open file.*portmap.xdr.*|.*save any registration.*)',
+        bsc_1023818 => '.*Dev dev-disk-by.*device appeared twice with different sysfs paths.*',
     };
     my $master_pattern = "(" . join('|', map { "$_" } values %$bug_pattern) . ")";
 


### PR DESCRIPTION
New bug bsc#1023818 found in CaaSP/DVD/EFI, this commit just adds a regexp into journal_check test for identifying the known bug and mark the test as "softfail".

Commit tested on my machine http://dhcp209.suse.cz/tests/1731#step/journal_check/8