### PR TITLE
Mark the reason for needle unregistration

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -292,7 +292,7 @@ sub check_env {
 sub unregister_needle_tags {
     my ($tag) = @_;
     my @a = @{needle::tags($tag)};
-    for my $n (@a) { $n->unregister(); }
+    for my $n (@a) { $n->unregister($tag); }
 }
 
 1;


### PR DESCRIPTION
This can be deployed without worrying - the function ignores arguments right now