### PR TITLE
LTP: Increase timeout for build configuration

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -59,7 +59,7 @@ sub install_from_git {
     assert_script_run("git clone $url --depth 1" . $tag, timeout => 360);
     assert_script_run 'cd ltp';
     assert_script_run 'make autotools';
-    assert_script_run './configure --with-open-posix-testsuite --with-realtime-testsuite';
+    assert_script_run('./configure --with-open-posix-testsuite --with-realtime-testsuite', timeout => 300);
     assert_script_run 'make -j$(getconf _NPROCESSORS_ONLN)', timeout => 1440;
     assert_script_run 'make install',                        timeout => 360;
     assert_script_run "find ~/ltp/testcases/open_posix_testsuite/conformance/interfaces -name '*.run-test' > ~/openposix_test_list.txt";


### PR DESCRIPTION
Usually it only takes 10-20 seconds to run the configure script. Yet it has
timed out. I have not seen the configure script fail for any other
reason, so I have increased the timeout by an order of magnitude.