### PR TITLE
UEFI boot partition on raid1

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -64,6 +64,12 @@ sub run() {
             }
         }
     }
+
+    if (check_screen('inst-overview-bootloader-warning', 0)) {
+        record_soft_failure 'bsc#1024409';
+        send_key 'alt-i';    #install
+        assert_screen 'inst-overview-error-found';
+    }
 }
 
 1;

--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -81,6 +81,7 @@ sub run() {
     else {
         sleep 2;    # textmode is sometimes pressing alt-i too early
         send_key $cmd{install};
+        wait_screen_change { send_key 'alt-o' } if match_has_tag('inst-overview-error-found', 0);
         while (check_screen([qw(confirmlicense startinstall)], 5)) {
             last if match_has_tag("startinstall");
             send_key $cmd{acceptlicense}, 1;


### PR DESCRIPTION
Testcase changed in order to meet the requirements from FATE- https://fate.suse.com/314829
This is just one change, the second change will make sure that system can boot if one disk is removed.
Bug related - https://bugzilla.suse.com/show_bug.cgi?id=1024409
Some runnings:
http://markeb.arch.suse.de/tests/17
http://markeb.arch.suse.de/tests/48