### PR TITLE
Wait longer for iscsi client

### DIFF
--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -25,7 +25,7 @@ sub run() {
     configure_static_ip('10.0.2.3/24');
     configure_static_dns(get_host_resolv_conf());
     type_string "yast2 iscsi-client\n";
-    assert_screen 'iscsi-client', 60;
+    assert_screen 'iscsi-client', 180;
     mutex_lock('iscsi_ready');                                               # wait for server setup
     send_key "alt-i";                                                        # go to initiator name field
     wait_still_screen(2, 10);


### PR DESCRIPTION
avoid sporadic test failures due to timeout, iscsi client didn't start in time

https://openqa.suse.de/tests/768259#step/iscsi_client/27