### PR TITLE
LTP: install at and expect

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -35,8 +35,8 @@ sub try_add_workstation_addon {
 }
 
 sub install_dependencies {
-    my @deps = qw(git-core make automake autoconf gcc libnuma-devel libaio-devel numactl
-      flex bison dmapi-devel kernel-default-devel libopenssl-devel libselinux-devel
+    my @deps = qw(git-core make automake autoconf gcc expect libnuma-devel libaio-devel
+      numactl flex bison dmapi-devel kernel-default-devel libopenssl-devel libselinux-devel
       libacl-devel libtirpc-devel keyutils-devel libcap-devel net-tools sysstat
       tpm-tools tpm2.0-tools psmisc acl quota);
     if (check_var('DISTRI', 'opensuse') || try_add_workstation_addon()) {

--- a/tests/kernel/ltp_setup_networking.pm
+++ b/tests/kernel/ltp_setup_networking.pm
@@ -22,12 +22,11 @@ sub install {
     zypper_call("in iputils psmisc tcpdump", log => 'utils.log');
 
     # clients
-    zypper_call("in dhcp-client finger mrsh-rsh-compat telnet", log => 'clients.log');
+    zypper_call("in dhcp-client finger telnet", log => 'clients.log');
 
     # services
-    zypper_call("in dhcp-server dnsmasq finger-server mrsh-server munge nfs-kernel-server rdist rpcbind rsync tcpd telnet-server vsftpd xinetd",
-        log => 'services.log');
-    my $services = "dnsmasq munge mrlogind.socket mrshd.socket nfsserver rpcbind vsftpd xinetd";
+    zypper_call("in dhcp-server dnsmasq finger-server nfs-kernel-server rdist rpcbind rsync tcpd telnet-server vsftpd xinetd", log => 'services.log');
+    my $services = "dnsmasq nfsserver rpcbind vsftpd xinetd";
     assert_script_run "systemctl enable $services";
     assert_script_run "systemctl start $services";
 }
@@ -37,8 +36,6 @@ sub setup {
 
     $content = <<EOF;
 # ltp specific setup
-mrsh
-mrlogin
 pts/1
 pts/2
 pts/3
@@ -56,9 +53,6 @@ EOF
         assert_script_run 'sed -i \'s/\(disable\s*=\s\)yes/\1no/\' /etc/xinetd.d/' . $xinetd_conf;
     }
     assert_script_run 'sed -i \'s/^#\(\s*bind\s*=\)\s*$/\1 0.0.0.0/\' /etc/xinetd.conf';
-
-    # rlogin
-    assert_script_run 'echo "+" > /root/.rhosts';
 
     # ftp
     assert_script_run 'sed -i \'s/^\s*\(root\)\s*$/# \1/\' /etc/ftpusers';
@@ -91,5 +85,11 @@ sub test_flags {
 }
 
 1;
+
+=head1 Discussion
+
+See poo#16648 for disabled LTP networking related tests.
+
+=cut
 
 # vim: set sw=4 et:

--- a/tests/kernel/ltp_setup_networking.pm
+++ b/tests/kernel/ltp_setup_networking.pm
@@ -19,7 +19,7 @@ use utils;
 
 sub install {
     # utils
-    zypper_call("in expect iputils psmisc tcpdump", log => 'utils.log');
+    zypper_call("in iputils psmisc tcpdump", log => 'utils.log');
 
     # clients
     zypper_call("in dhcp-client finger mrsh-rsh-compat telnet", log => 'clients.log');


### PR DESCRIPTION
expect is needed (besides of LTP network tests) for su01 (from
admin_tools) and tpmtoken03 (from tpm_tools).
at is needed for at_allow01 and at_deny01 (from admin_tools).

+ remove RSH tests.