### PR TITLE
Xen System Role

### DIFF
--- a/tests/console/patterns.pm
+++ b/tests/console/patterns.pm
@@ -9,9 +9,9 @@
 
 # Summary: Test pattern selection for system role 'kvm host'
 # Maintainer: Christopher Hofmann <cwh@suse.de>
-# Tags: fate#317481
+# Tags: fate#317481 poo#16650
 
-use base "consoletest";
+use base 'consoletest';
 use strict;
 use testapi;
 use utils;
@@ -19,13 +19,12 @@ use utils;
 sub run() {
     select_console 'root-console';
 
-    # System roles are defined in config.xml.
-    # Currently the role 'kvm host' defines kvm_server as an additional pattern.
+    # System roles are defined in config.xml. Currently the role 'kvm host'
+    # defines kvm_server as an additional pattern, xen_server defines 'xen host'.
     my $pattern_name = 'kvm_server';
-
-    # List the installed patterns and grep for $pattern_name as defined above.
-    # grep's exit status will be 1 if it is not found and therefore
-    # assert_script_run() will fail.
+    if (check_var('SYSTEM_ROLE', 'xen')) {
+        $pattern_name = 'xen_server';
+    }
     assert_script_run("zypper patterns -i | grep $pattern_name");
 }
 

--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -18,9 +18,14 @@ sub run() {
     # Still initializing the system at this point, can take some time
     assert_screen 'system-role-default-system', 180;
 
-    if (get_var("SYSTEM_ROLE")) {
+    # Pick System Role; poo#16650
+    if (check_var('SYSTEM_ROLE', 'kvm')) {
         send_key 'alt-k';
         assert_screen 'system-role-kvm-virthost';
+    }
+    elsif (check_var('SYSTEM_ROLE', 'xen')) {
+        send_key 'alt-x';
+        assert_screen 'system-role-xen-virthost';
     }
 
     send_key $cmd{next};


### PR DESCRIPTION
poo#16650 poo#15738

Test suite `textmode+xen_server_role` was added, will be activated in
it's group after merge.

Verification runs:
* KVM: http://assam.suse.cz/tests/5065
* Xen: http://assam.suse.cz/tests/5069

Associated needle: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/305