### PR TITLE
Handle conflict between firebird-{classic,superserver}

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -146,6 +146,8 @@ sub problem_can_be_skipped {
     if ($pkg =~ /chromium-desktop-gnome/) {
         return !package_installed('gnome-session');
     }
+    # conflicts with firebird-classic
+    return 1 if $pkg =~ /firebird-superserver/;
 
     return;
 }


### PR DESCRIPTION
+++ PROBLEMS: +++
package firebird-superserver-2.5.6.27020-8.1.x86_64 conflicts with firebird-classic provided by firebird-classic-2.5.6.27020-8.1.x86_64

Fixes: https://openqa.opensuse.org/tests/352639#step/install_packages/8
Fixes: https://openqa.opensuse.org/tests/352640#step/install_packages/8
Fixes: https://openqa.opensuse.org/tests/352641#step/install_packages/8

