### PR TITLE
Remove ugly ctrl-c press from test flow

### DIFF
--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -34,7 +34,6 @@ sub run() {
 
     $console = select_console 'user-console';
 
-    send_key "ctrl-c";
     wait_still_screen(1);
     type_string "exit\n";    # logout
     $console->reset;


### PR DESCRIPTION
Remove ugly ctrl-c press from test flow
Ticket: https://progress.opensuse.org/issues/14834
Test: http://10.160.67.147/tests/68#step/consoletest_finish/6