### PR TITLE
LTP: Prevent race condition by sending ret after read

### DIFF
--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -293,8 +293,9 @@ sub run {
         }
 
         if (is_serial_terminal) {
-            type_string("$cmd_text\n");
+            type_string($cmd_text);
             wait_serial($cmd_text, undef, 0, no_regex => 1);
+            type_string("\n");
         }
         else {
             type_string("($cmd_text) | tee /dev/$serialdev\n");


### PR DESCRIPTION
If os-autoinst pauses between `type_string` and `wait_serial`, but the SUT is able to
run, then the SUT's output will be consumed by the wrong call to
`wait_serial`. We avoid this by sending return after consuming the command echo
so that the command will only be run just before, or during the correct call
to `wait_serial`.

https://progress.opensuse.org/issues/16320