### PR TITLE
Add console responsiveness check

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -126,6 +126,10 @@ sub x11_start_program($$$) {
             };
         }
     }
+    # test responsivnes of xterm to avoid mistyping
+    if ($program =~ 'xterm') {
+        utils::ensure_ready_console;
+    }
 }
 
 sub ensure_installed {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -39,6 +39,7 @@ our @EXPORT = qw(
   handle_login
   handle_emergency
   service_action
+  ensure_ready_console
 );
 
 
@@ -767,6 +768,33 @@ sub service_action {
         foreach my $type (@types) {
             assert_script_run "systemctl $action $name.$type";
         }
+    }
+}
+
+=head2 ensure_ready_console
+Make sure console is ready by creating file with short content
+When it's done successfuly then it's proven console is ready
+By default non-root user shell is expected, with argument is
+expected root shell
+=cut
+sub ensure_ready_console {
+    my $root        = @_;
+    my $max_retries = 10;
+    assert_screen ['console', 'xterm', 'text-logged-in-root', 'text-logged-in-user'], 60;
+    for (1 .. $max_retries) {
+        eval {
+            if ($root) {
+                assert_script_run 'echo ready > term && grep ready term && rm term';
+            }
+            else {
+                assert_script_sudo 'echo ready > term && grep ready term && rm term';
+            }
+            send_key 'ctrl-c';    # cancel mistyped console checks
+            sleep 2;              # slow down loop
+        };
+        last unless ($@);
+        diag "console is not ready: $@";
+        diag "console is not ready, Retry: $_ of $max_retries";
     }
 }
 

--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -28,6 +28,7 @@ sub run() {
     }
     type_string "$password\n";
     assert_screen "ssh-second-xterm";
+    ensure_ready_console('root');
     $self->set_standard_prompt();
     $self->enter_test_text('ssh-X-forwarding');
     assert_screen 'test-sshxterm-1';


### PR DESCRIPTION
very often xterm/console test fail because of mistyped command because console was not ready

e.g. last week two staging tests had to be restarted due to mistype
http://openqa.suse.de/tests/767294#step/sshxterm/6
http://openqa.suse.de/tests/764239#step/sshxterm/4

suse gnome root console test [1](http://10.100.12.155/tests/4999#step/sshxterm/10) [2](http://10.100.12.155/tests/4999#step/consoletest_setup/10)
suse gnome user console test [1](http://10.100.12.155/tests/4999#step/xterm/5)

opensuse kde root console test [1](http://10.100.12.155/tests/5000#step/sshxterm/10) [2](http://10.100.12.155/tests/5000#step/consoletest_setup/5)
opensuse kde user console test [1](http://10.100.12.155/tests/5000#step/xterm/5)