### PR TITLE
Registration tests for CaaSP

### DIFF
--- a/products/casp/main.pm
+++ b/products/casp/main.pm
@@ -60,6 +60,9 @@ sub load_boot_tests() {
 sub load_inst_tests() {
     loadtest 'casp/oci_overview';
 
+    # Register system
+    loadtest 'casp/oci_register' if check_var('REGISTER', 'installation');
+
     # Set root password
     loadtest 'casp/oci_password';
     # Set system Role
@@ -110,6 +113,11 @@ if (check_var('FLAVOR', 'DVD')) {
     }
 }
 loadtest 'casp/first_boot';
+
+# ==== Extra tests run after installation  ====
+if (get_var('REGISTER')) {
+    loadtest 'casp/register_and_check';
+}
 
 if (get_var('EXTRA', '') =~ /FEATURES/) {
     load_feature_tests;

--- a/tests/casp/oci_install.pm
+++ b/tests/casp/oci_install.pm
@@ -22,6 +22,12 @@ sub run() {
     assert_screen 'inst-userpasswdtoosimple';
     send_key 'ret';
 
+    # Accept update repositories during installation
+    if (check_var('REGISTER', 'installation')) {
+        assert_screen 'registration-online-repos';
+        send_key "alt-y";
+    }
+
     # Confirm installation start
     assert_screen "startinstall";
     send_key $cmd{install};

--- a/tests/casp/oci_register.pm
+++ b/tests/casp/oci_register.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Type in registration information
+# Maintainer: Martin Kravec <mkravec@suse.com>
+
+use strict;
+use base "y2logsstep";
+use testapi;
+
+sub run() {
+    send_key 'alt-g';
+    type_string get_var('REGCODE');
+
+    save_screenshot;
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/casp/register_and_check.pm
+++ b/tests/casp/register_and_check.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Register system and check if registration was succesful
+#  Can be also registered during installation
+# Maintainer: Martin Kravec <mkravec@suse.com>
+
+use strict;
+use base "opensusebasetest";
+use testapi;
+
+sub run() {
+    my $regcode = get_var 'REGCODE';
+    if (check_var('REGISTER', 'suseconnect')) {
+        assert_script_run "SUSEConnect --regcode $regcode";
+    }
+
+    # Check that registration was succeeded
+    assert_script_run 'SUSEConnect --status-text | grep -o "Status: ACTIVE"';
+    assert_script_run 'test -f /etc/zypp/credentials.d/SCCcredentials';
+    # validate_repos; - needs modifications for CaaSP
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Registration tests are scheduled according to variable:
REGISTER=[installation|suseconnect]

Registration code is set in "media" setup in openqa in variable:
REGCODE

poo#16388

Local runs:
 - http://dhcp91.suse.cz/tests/3872 - VMX - suseconnect
 - http://dhcp91.suse.cz/tests/3871 - DVD - suseconnect
 - http://dhcp91.suse.cz/tests/3870 - DVD - installation