### PR TITLE
Make sure name, type, and user vars are defined

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -374,6 +374,8 @@ sub activate_console {
 
     $console =~ m/^(\w+)-(console|virtio-terminal)/;
     my ($name, $user, $type) = ($1, $1, $2);
+    $name = $user //= '';
+    $type //= '';
     if ($name eq 'user') {
         $user = $testapi::username;
     }


### PR DESCRIPTION
poo#15420

For consoles like `x11`, `svirt`, `sut` and others, variables `$user`,
`$name`, and `$type` were undefined. This change makes sure they are not
undefined and no warnings get produced.

Verification run: http://assam.suse.cz/tests/5077/