### PR TITLE
Extend worker role test for CaaSP

### DIFF
--- a/products/casp/main.pm
+++ b/products/casp/main.pm
@@ -90,6 +90,7 @@ sub load_feature_tests {
     loadtest 'casp/libzypp_config';
     loadtest 'casp/timezone_utc';
     loadtest 'casp/filesystem_ro';
+    loadtest 'casp/one_line_checks';
     loadtest 'casp/nfs_client' if get_var('NFS_SHARE');
     loadtest 'casp/journal_check';
 }

--- a/tests/casp/oci_role.pm
+++ b/tests/casp/oci_role.pm
@@ -24,6 +24,14 @@ sub run() {
 
     # Set dashboard url for worker
     if ($role eq 'worker') {
+        # Try with empty controller node
+        send_key 'alt-i';
+        assert_screen 'inst-userpasswdtoosimple';
+        send_key 'alt-y';
+        assert_screen 'controller-node-invalid';
+        send_key 'alt-o';
+
+        # Fill controller node information
         send_key 'alt-c';
         type_string 'dashboard-url';
         assert_screen 'dashboard-url';

--- a/tests/casp/one_line_checks.pm
+++ b/tests/casp/one_line_checks.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Run simple checks after installation
+# Maintainer: Martin Kravec <mkravec@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+
+sub run() {
+    if (check_var('SYSTEM_ROLE', 'worker')) {
+        # poo#16574
+        # Should be replaced by actually connecting to admin node when it's implemented
+        assert_script_run "grep \"master: 'dashboard-url'\" /etc/salt/minion.d/master.conf";
+    }
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
- try installting without setting controller node url.
- test that salt configuration was modified

poo#16574

Required needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/310
Local run: http://dhcp91.suse.cz/tests/3882