### PR TITLE
Enable FIPS after installation by ENABLE_FIPS variable

### DIFF
--- a/tests/shutdown/grub_set_bootargs.pm
+++ b/tests/shutdown/grub_set_bootargs.pm
@@ -7,8 +7,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Remove quiet kernel option
-# G-Maintainer: Dominik Heidler <dheidler@suse.de>
+# Summary: Remove quiet kernel option
+# Maintainer: Dominik Heidler <dheidler@suse.de>
 
 use strict;
 use base "y2logsstep";
@@ -18,6 +18,7 @@ sub run() {
     select_console('root-console');
     script_run "source /etc/default/grub";
     script_run 'new_cmdline=`echo $GRUB_CMDLINE_LINUX_DEFAULT | sed \'s/\(^\| \)quiet\($\| \)/ /\'`';
+    script_run 'new_cmdline="$new_cmdline fips=1"' if (get_var("ENABLE_FIPS"));
     script_run 'sed -i "s#GRUB_CMDLINE_LINUX_DEFAULT=\"[^\"]*\"#GRUB_CMDLINE_LINUX_DEFAULT=\"$new_cmdline\"#" /etc/default/grub';
     script_run 'grub2-mkconfig -o /boot/grub2/grub.cfg';
 }


### PR DESCRIPTION
Simple check of variable ENABLE_FIPS by shutdown/grub_set_bootargs.pm
Variable FIPS=1 is not used intentionally because then the installer
itself is run in FIPS mode which leads to problems with SuSEFirewall2