### PR TITLE
Do not run snapper_create in every scenario

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -601,7 +601,6 @@ sub load_consoletests() {
                 loadtest "console/installation_snapshots";
             }
             loadtest "console/snapper_undochange";
-            loadtest "console/snapper_create";
         }
         if (get_var("DESKTOP") !~ /textmode/ && !check_var("ARCH", "s390x")) {
             loadtest "console/xorg_vt";


### PR DESCRIPTION
At least for now - this needs to be discussed *and* yast2_snapper
needs to be adopted to the snapper spam created by this test

See issue https://progress.opensuse.org/issues/17082