### PR TITLE
snapper: delete snapshot spam

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -600,7 +600,6 @@ sub load_consoletests() {
             elsif (!get_var("ZDUP") and !check_var('VERSION', '12')) {    # zypper and sle12 doesn't do upgrade or installation snapshots
                 loadtest "console/installation_snapshots";
             }
-            loadtest "console/snapper_undochange";
         }
         if (get_var("DESKTOP") !~ /textmode/ && !check_var("ARCH", "s390x")) {
             loadtest "console/xorg_vt";
@@ -732,6 +731,8 @@ sub load_extra_test () {
                 loadtest 'console/btrfs_send_receive';
             }
         }
+        loadtest 'console/snapper_undochange';
+        loadtest 'console/snapper_create';
         loadtest 'console/snapper_thin_lvm';
         loadtest 'console/command_not_found';
         loadtest 'console/openvswitch';

--- a/tests/console/btrfs_send_receive.pm
+++ b/tests/console/btrfs_send_receive.pm
@@ -67,6 +67,7 @@ sub run() {
         assert_script_run "btrfs send -p $src/snap" . ($i - 1) . " $src/snap$i | btrfs receive $dest";
         compare_data $i;
     }
+    assert_script_run("umount -fl /dev/vdb");
 }
 
 sub test_flags() {


### PR DESCRIPTION
Should fix problems with `yast2_snapper` test introduced in PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/2377.
Verification runs: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/2453/commits/27db4e3b14343af236e27e67f8877f4baf3f3916.