### PR TITLE
Virtualization: Extend pvusb test to support customized qa repo and guest

### DIFF
--- a/tests/virt_autotest/pvusb_run.pm
+++ b/tests/virt_autotest/pvusb_run.pm
@@ -19,8 +19,11 @@ use testapi;
 
 sub get_script_run() {
     my $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-pvusb-run";
-    my $which_usb = get_var("USB_PATTERN", "");
+    my $which_usb    = get_var("USB_PATTERN", "");
+    my $qa_repo      = get_var("QA_HEAD_REPO", "http://dist.nue.suse.com/ibs/QA:/Head/SLE-12-SP3/");
+    my $guest        = get_var("GUEST", "sles-12-sp3-64-fv-def-net");
     $pre_test_cmd = $pre_test_cmd . " -w \"" . $which_usb . "\"";
+    $pre_test_cmd = $pre_test_cmd . " -r $qa_repo -g $guest";
 
     return $pre_test_cmd;
 }


### PR DESCRIPTION
Originally inside script, the qa_repo and guest are hard coded to sles12sp2 related. Now extend it to support customized configuration.