### PR TITLE
Add test for openqa-review

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -537,6 +537,7 @@ sub load_extra_tests() {
         loadtest "console/curl_ipv6";
         loadtest "console/wget_ipv6";
         loadtest "console/unzip";
+        loadtest "console/openqa_review";
 
         # finished console test and back to desktop
         loadtest "console/consoletest_finish";

--- a/tests/console/openqa_review.pm
+++ b/tests/console/openqa_review.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test openqa-review can be started (with runtime dependencies)
+# Maintainer: Oliver Kurz <okurz@suse.de>
+
+use base "consoletest";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    zypper_call('in python-openqa_review');
+    assert_script_run 'openqa-review --help';
+}
+
+1;


### PR DESCRIPTION
Verification run: http://lord.arch/tests/5647#step/openqa_review/5

The verification run shows an expected problem because of underspecified
requirements in the spec file of openqa-review therefore the test is working
as expected.