### PR TITLE
Press Return when choosing CaaSP role in textmode

### DIFF
--- a/tests/casp/oci_role.pm
+++ b/tests/casp/oci_role.pm
@@ -21,6 +21,7 @@ sub run() {
     # Select proper role
     send_key 'alt-s';
     send_key_until_needlematch "system-role-$role", 'down', 2;
+    send_key 'ret' if (check_var('VIDEOMODE', 'text'));
 
     # Set dashboard url for worker
     if ($role eq 'worker') {


### PR DESCRIPTION
Needed for CaaSP textmode installation. 

* PR for needles https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/313
* sample output http://dhcp209.suse.cz/tests/3162