### PR TITLE
Introduce assert_gui_app

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -41,6 +41,7 @@ our @EXPORT = qw(
   handle_login
   handle_emergency
   service_action
+  assert_gui_app
 );
 
 
@@ -85,6 +86,26 @@ sub prepare_system_reboot {
     if (check_var('BACKEND', 's390x')) {
         console('iucvconn')->kill_ssh;
     }
+}
+
+# assert_gui_app (optionally installs and) starts an application, checks it started
+# and closes it again. It's the most minimalistic way to test a GUI application
+# Mandatory parameter: application: the name of the application.
+# Optional parameters are:
+#   install: boolean    => does the application have to be installed first? Especially
+#                         on live images where we want to ensure the disks are complete
+#                         the parameter should not be set to true - otherwise we might
+#                         mask the fact that the app is not on the media
+#   exec_param: string => When calling the application, pass this parameter on the command line
+#   remain: boolean    => If set to true, do not close the application when tested it is
+#                         running. This can be used if the application shall be tested further
+
+sub assert_gui_app {
+    my ($application, %args) = @_;
+    ensure_installed($application) if $args{install};
+    x11_start_program("$application $args{exec_param}");
+    assert_screen("test-$application-started");
+    send_key "alt-f4" unless $args{remain};
 }
 
 sub select_kernel {

--- a/tests/x11/eog.pm
+++ b/tests/x11/eog.pm
@@ -14,12 +14,11 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 
 sub run() {
-    x11_start_program("eog " . get_var("WALLPAPER"));
-    assert_screen 'test-eog-1';
-    send_key "alt-f4";
+    assert_gui_app("eog", exec_param => get_var("WALLPAPER"));
 }
 
 1;

--- a/tests/x11/gnome_music.pm
+++ b/tests/x11/gnome_music.pm
@@ -14,11 +14,10 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils;
 
 sub run() {
-    x11_start_program("gnome-music");
-    assert_screen 'test-gnome-music-1', 3;
-    send_key "alt-f4";
+    assert_gui_app('gnome-music');
 }
 
 1;


### PR DESCRIPTION
Most simple function to test a gui application in one command.

optionally installs, starts, asserts screen and closes app again