### PR TITLE
Add load_testdir function

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1,5 +1,6 @@
 package main_common;
 use base Exporter;
+use File::Basename;
 use Exporter;
 use testapi qw(check_var get_var set_var diag);
 use autotest;
@@ -10,6 +11,7 @@ use warnings;
 our @EXPORT = qw(
   init_main
   loadtest
+  load_testdir
   set_defaults_for_username_and_password
   setup_env
   logcurrentenv
@@ -51,6 +53,12 @@ sub init_main {
 sub loadtest {
     my ($test) = @_;
     autotest::loadtest("tests/$test.pm");
+}
+
+sub load_testdir {
+    my ($testsuite) = @_;
+    my $testdir = testapi::get_var("CASEDIR") . "/tests/$testsuite";
+    map { loadtest "$testsuite/" . basename($_, '.pm') } glob("$testdir/*.pm");
 }
 
 sub set_defaults_for_username_and_password {


### PR DESCRIPTION
Instead of having to explicitly list <n> specialized tests for a
scenario it can be beneficial to have those auto-loaded if found in a
specific directory.

This allows for example to group EXTRA TESTS into a specific directory
and adding new ones only takes a new file to land there

I'm currently preparing a larger set of 'GNOME Apps' tests to be tested as GNOME EXTRATESTS and GNOME Next Live (and it already spotted a broken app) based on load_testdir; but that will come in the future, having the capability in place for others to consume does not have to wait imho