### PR TITLE
Weak password dialog should be displayed only once in CaaSP

### DIFF
--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -1,0 +1,30 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+package caasp;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use warnings;
+use testapi;
+
+our @EXPORT = qw(handle_simple_pw);
+
+# Weak password warning should be displayed only once - bsc#1025835
+sub handle_simple_pw {
+    return if get_var 'SIMPLE_PW_CONFIRMED';
+
+    assert_screen 'inst-userpasswdtoosimple';
+    send_key 'alt-y';
+    set_var 'SIMPLE_PW_CONFIRMED', 1;
+}
+
+1;

--- a/tests/casp/oci_install.pm
+++ b/tests/casp/oci_install.pm
@@ -14,13 +14,13 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
+use caasp;
 
 sub run() {
     send_key $cmd{install};
 
     # Accept simple password
-    assert_screen 'inst-userpasswdtoosimple';
-    send_key 'ret';
+    handle_simple_pw;
 
     # Accept update repositories during installation
     if (check_var('REGISTER', 'installation')) {

--- a/tests/casp/oci_role.pm
+++ b/tests/casp/oci_role.pm
@@ -12,7 +12,7 @@
 
 use strict;
 use base "y2logsstep";
-use utils;
+use caasp;
 use testapi;
 
 sub run() {
@@ -27,8 +27,7 @@ sub run() {
     if ($role eq 'worker') {
         # Try with empty controller node
         send_key 'alt-i';
-        assert_screen 'inst-userpasswdtoosimple';
-        send_key 'alt-y';
+        handle_simple_pw;
         assert_screen 'controller-node-invalid';
         send_key 'alt-o';
 


### PR DESCRIPTION
Fix for: https://openqa.suse.de/tests/783842#step/oci_install/2

Local runs:
http://dhcp91.suse.cz/tests/3975 - admin
http://dhcp91.suse.cz/tests/3977 - worker