### PR TITLE
Give CaaSP more time to boot into rcshell

### DIFF
--- a/tests/casp/rcshell_start.pm
+++ b/tests/casp/rcshell_start.pm
@@ -15,7 +15,7 @@ use strict;
 use testapi;
 
 sub run() {
-    assert_screen 'startshell', 60;
+    assert_screen 'startshell', 120;
 }
 
 1;


### PR DESCRIPTION
Fix for: https://openqa.suse.de/tests/789837#step/rcshell_start/5