### PR TITLE
Switch to correct pty in textmode after save_logs_and_continue

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -35,8 +35,7 @@ sub accept_license {
 sub save_logs_and_continue {
     my $name = shift;
     # save logs and continue
-    send_key "ctrl-alt-f2";
-    send_key "alt-f2";
+    select_console 'install-shell';
     sleep 5;
     wait_idle(5);
     assert_screen ["inst-console"];
@@ -54,7 +53,7 @@ sub save_logs_and_continue {
     upload_logs "/tmp/y2logs-$name.tar.bz2";
     save_screenshot;
     clear_console;
-    send_key "alt-f7";
+    select_console 'installation';
     wait_idle(5);
 }
 


### PR DESCRIPTION
Fix for textmode autoinst installation mainly for CaaSP but should work elsewhere.

If any known problem of autoinst profile occurs then the script can save y2logs and continue installation by switching into correct pty using select_console values 'install-shell' and 'installation' from lib/susedistribution.pm.

textmode: http://dhcp209.suse.cz/tests/3257
gui (i didn't broke it): http://dhcp209.suse.cz/tests/3258

PR for needle: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/314