### PR TITLE
Virtualization: change assert pattern to tell test result for guest upgrade test

### DIFF
--- a/tests/virt_autotest/guest_upgrade_run.pm
+++ b/tests/virt_autotest/guest_upgrade_run.pm
@@ -34,7 +34,7 @@ sub run {
     my $self = shift;
     my $timeout = get_var("MAX_TEST_TIME", "36000") + 10;
     script_run("echo \"Debug info: max_test_time is $timeout\"");
-    $self->run_test($timeout, "Test run completed successfully", "no", "yes", "/var/log/qa/", "guest-upgrade-logs");
+    $self->run_test($timeout, "guest_upgrade_test ... ... PASSED", "no", "yes", "/var/log/qa/", "guest-upgrade-logs");
 }
 
 sub test_flags {


### PR DESCRIPTION
Original used pattern to check test result failed or successful is not correct. It showed up even when test failed.
So switched to use more accurate one.