### PR TITLE
Timezone check moved to one_line_checks

### DIFF
--- a/products/casp/main.pm
+++ b/products/casp/main.pm
@@ -79,7 +79,7 @@ sub load_inst_tests() {
 sub load_rcshell_tests {
     loadtest 'casp/rcshell_start';
     loadtest 'casp/libzypp_config';
-    loadtest 'casp/timezone_utc';
+    loadtest 'casp/one_line_checks';
 }
 
 # Feature tests after installation finishes


### PR DESCRIPTION
Fix for: https://openqa.suse.de/tests/790711
Local run: http://dhcp91.suse.cz/tests/4018