### PR TITLE
Improve registration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -35,42 +35,22 @@ sub fill_in_registration_data {
         send_key "alt-c";        # select registration code field
         type_string get_var("SCC_REGCODE");
         save_screenshot;
-        send_key $cmd{next}, 1;
+        wait_screen_change { send_key $cmd{next} };
     }
     my @known_untrusted_keys = qw(import-trusted-gpg-key-nvidia-F5113243C66B6EAE);
     unless (get_var('SCC_REGISTER', '') =~ /addon|network/) {
         my @tags = qw(local-registration-servers registration-online-repos import-untrusted-gpg-key module-selection contacting-registration-server);
         if (get_var('SCC_URL') || get_var('SMT_URL')) {
             push @tags, 'untrusted-ca-cert';
-            if (get_var('SMT_URL')) {
-                push @tags, 'registration-12sp1-check';
-            }
         }
         while (check_screen(\@tags, 60)) {
-            if (match_has_tag("local-registration-servers")) {
-                send_key "alt-o";
-                @tags = grep { $_ ne 'local-registration-servers' } @tags;
-                next;
-            }
-            elsif (match_has_tag("import-untrusted-gpg-key")) {
+            if (match_has_tag("import-untrusted-gpg-key")) {
                 if (check_var("IMPORT_UNTRUSTED_KEY", 1) || check_screen(\@known_untrusted_keys, 0)) {
                     send_key "alt-t";    # import
                 }
                 else {
-                    send_key "alt-c";
-                    ;                    # cancel
+                    send_key "alt-c";    # cancel
                 }
-                next;
-            }
-            elsif (match_has_tag("registration-online-repos")) {
-                if (!get_var('QAM_MINIMAL')) {
-                    send_key "alt-y", 1;    # want updates
-                }
-                else {
-                    send_key $cmd{next}, 1;    # minimal dont want updates
-                }
-
-                @tags = grep { $_ ne 'registration-online-repos' } @tags;
                 next;
             }
             elsif (match_has_tag('contacting-registration-server')) {
@@ -80,31 +60,33 @@ sub fill_in_registration_data {
             }
             elsif ((get_var('SCC_URL') || get_var('SMT_URL')) && match_has_tag("untrusted-ca-cert")) {
                 record_soft_failure 'bsc#943966' if get_var('SCC_CERT');
-                send_key "alt-t", 1;
+                wait_screen_change { send_key 'alt-t' };
                 # the behavior here of smt registration on 12sp1 is a little different with
                 # 12sp0 and 12sp2, normally registration would start automatically after
                 # untrusted certification imported, but it would not on 12sp1, and we have to
                 # send next manually to start registration.
-                if (get_var('SMT_URL')) {
-                    if (check_screen('registration-12sp1-check', 5)) {
-                        send_key $cmd{next};
-                    }
-                    @tags = grep { $_ ne 'registration-12sp1-check' } @tags;
+                if (get_var('SMT_URL') && (check_var('VERSION', '12-SP1') || check_var('HDDVERSION', '12-SP1'))) {
+                    send_key $cmd{next};
                 }
                 @tags = grep { $_ ne 'untrusted-ca-cert' } @tags;
                 next;
             }
-            last;
+            elsif (match_has_tag('registration-online-repos')) {
+                if (!get_var('QAM_MINIMAL')) {
+                    send_key 'alt-y';    # want updates
+                }
+                else {
+                    send_key $cmd{next};    # minimal dont want updates
+                }
+                next;
+            }
+            elsif (match_has_tag('module-selection')) {
+                last;
+            }
         }
     }
 
-    if (check_var('SCC_REGISTER', 'installation')) {
-        if (check_screen("local-registration-servers", 10)) {
-            send_key $cmd{ok};
-        }
-        if (check_screen('scc-beta-filter-checkbox', 5)) {
-            send_key 'alt-f';    # uncheck 'Filter Out Beta Version'
-        }
+    if (check_var('SCC_REGISTER', 'installation') || check_var('SCC_REGISTER', 'console')) {
         # The value of SCC_ADDONS is a list of abbreviation of addons/modules
         # Following are abbreviations defined for modules and some addons
         #
@@ -119,8 +101,11 @@ sub fill_in_registration_data {
         # idu - IBM DLPAR Utils (ppc64le only)
         # ids - IBM DLPAR sdk (ppc64le only)
         if (get_var('SCC_ADDONS')) {
+            if (check_screen('scc-beta-filter-checkbox', 5)) {
+                send_key 'alt-f';    # uncheck 'Filter Out Beta Version'
+            }
             for my $addon (split(/,/, get_var('SCC_ADDONS', ''))) {
-                if (check_var('VIDEOMODE', 'text')) {
+                if (check_var('VIDEOMODE', 'text') || check_var('SCC_REGISTER', 'console')) {
                     # The actions of selecting scc addons have been changed on SP2 or later in textmode
                     # For online migration, we have to do registration on pre-created HDD, set a flag
                     # to distinguish the sle version of HDD and perform addons selection based on it
@@ -132,12 +117,6 @@ sub fill_in_registration_data {
                     }
                 }
                 else {
-                    # go to the top of the list before looking for the addon
-                    send_key "home";
-
-                    # move the list of addons down until the current addon is found
-                    send_key_until_needlematch "scc-module-$addon", "down";
-
                     # checkmark the requested addon
                     assert_and_click "scc-module-$addon";
                 }
@@ -150,7 +129,7 @@ sub fill_in_registration_data {
                     # wait for SCC to give us the license
                     sleep 5;
                 }
-                assert_screen("scc-addon-license-$addon");
+                assert_screen "scc-addon-license-$addon", 60;
                 addon_decline_license;
                 wait_still_screen 2;
                 send_key $cmd{next};
@@ -173,9 +152,9 @@ sub fill_in_registration_data {
                     save_screenshot;
                 }
             }
-            send_key $cmd{next};
+            wait_screen_change { send_key $cmd{next} };
             # start addons/modules registration, it needs longer time if select multiple or all addons/modules
-            while (assert_screen(['import-untrusted-gpg-key', 'yast_scc-pkgtoinstall', 'inst-addon'], 120)) {
+            while (assert_screen(['import-untrusted-gpg-key', 'yast_scc-pkgtoinstall', 'yast-scc-emptypkg', 'inst-addon'], 120)) {
                 if (match_has_tag('import-untrusted-gpg-key')) {
                     if (!check_screen(\@known_untrusted_keys, 0)) {
                         record_soft_failure 'untrusted gpg key';
@@ -186,42 +165,34 @@ sub fill_in_registration_data {
                     next;
                 }
                 elsif (match_has_tag('yast_scc-pkgtoinstall')) {
-                    # if addons where selected yast shows the software install
-                    # dialog
-                    if (get_var('SCC_ADDONS')) {
-                        assert_screen("yast_scc-pkgtoinstall");
-                        send_key "alt-a";
-
-                        while (check_screen([qw(yast_scc-license-dialog yast_scc-automatic-changes)])) {
-                            if (match_has_tag('yast_scc-license-dialog')) {
-                                send_key "alt-a";
-                                next;
-                            }
+                    # yast shows the software install dialog
+                    wait_screen_change { send_key 'alt-a' };
+                    while (
+                        assert_screen(
+                            ['yast_scc-license-dialog', 'yast_scc-automatic-changes', 'yast_scc-prompt-reboot', 'yast_scc-installation-summary'], 900
+                        ))
+                    {
+                        if (match_has_tag('yast_scc-license-dialog')) {
+                            send_key 'alt-a';
+                            next;
+                        }
+                        # yast may pop up dependencies or reboot prompt window
+                        if (match_has_tag('yast_scc-automatic-changes') or match_has_tag('unsupported-packages') or match_has_tag('yast_scc-prompt-reboot')) {
+                            send_key 'alt-o';
+                            next;
+                        }
+                        if (match_has_tag('yast_scc-installation-summary')) {
+                            send_key 'alt-f';
                             last;
-                        }
-                        send_key "alt-o";
-                        send_key 'alt-o' if check_screen('unsupported-packages', 2);
-
-                        # yast may pop up a reboot prompt window after addons installation such like ha on sle12 sp0
-                        while (assert_screen([qw(yast_scc-prompt-reboot yast_scc-installation-summary)], 900)) {
-                            if (match_has_tag('yast_scc-prompt-reboot')) {
-                                send_key "alt-o", 1;
-                                next;
-                            }
-                            elsif (match_has_tag('yast_scc-installation-summary')) {
-                                send_key "alt-f";
-                                last;
-                            }
-                        }
-                    }
-                    else {
-                        # yast would display empty pkg install screen if no addon selected on sle12 sp0
-                        # set check_screen timeout longer to ensure the screen checked in this case
-                        if (check_screen("yast-scc-emptypkg", 15)) {
-                            send_key "alt-a";
                         }
                     }
                     last;
+                }
+                # yast would display empty pkg install screen if no addon selected on sle12 sp0
+                # set check_screen timeout longer to ensure the screen checked in this case
+                elsif (match_has_tag('yast-scc-emptypkg')) {
+                    send_key 'alt-a';
+                    next;  # this could be last, but it can happen that during processing packages it looks like empty packages to install and then it will fail
                 }
                 elsif (match_has_tag('inst-addon')) {
                     # it would show Add On Product screen if scc registration correctly during installation
@@ -240,7 +211,6 @@ sub fill_in_registration_data {
     }
     else {
         if (!get_var('SCC_REGISTER', '') =~ /addon|network/) {
-            assert_screen("module-selection");
             send_key $cmd{next};
         }
     }
@@ -269,7 +239,7 @@ sub registration_bootloader_params {
     # https://www.suse.com/documentation/smt11/book_yep/data/smt_client_parameters.html
     # SCC_URL=https://smt.example.com
     if (my $url = get_var("SCC_URL") || get_var("SMT_URL")) {
-        type_string " regurl=$url/connect", $max_interval;
+        type_string " regurl=$url", $max_interval;
         if ($url = get_var("SCC_CERT")) {
             type_string " regcert=$url", $max_interval;
         }
@@ -284,22 +254,22 @@ sub yast_scc_registration {
 
     fill_in_registration_data;
 
-    my $ret = wait_serial "yast-scc-done-\\d+-", 30;
+    my $ret = wait_serial "yast-scc-done-\\d+-";
     die "yast scc failed" unless (defined $ret && $ret =~ /yast-scc-done-0-/);
 
     # To check repos validity after registration, call 'validate_repos' as needed
 }
 
 sub skip_registration {
-    send_key "alt-s", 1;    # skip SCC registration
+    wait_screen_change { send_key "alt-s" };    # skip SCC registration
     assert_screen([qw(scc-skip-reg-warning-yes scc-skip-reg-warning-ok scc-skip-reg-no-warning)]);
     if (match_has_tag('scc-skip-reg-warning-ok')) {
-        send_key "alt-o";    # confirmed skip SCC registration
+        send_key "alt-o";                       # confirmed skip SCC registration
         wait_still_screen;
         send_key $cmd{next};
     }
     elsif (match_has_tag('scc-skip-reg-warning-yes')) {
-        send_key "alt-y";    # confirmed skip SCC registration
+        send_key "alt-y";                       # confirmed skip SCC registration
     }
 }
 


### PR DESCRIPTION
https://progress.opensuse.org/issues/16588

- removed obsolete wait_idle param from send_key
- replaced 12sp1 needle check with variable check
- removed sp1 local-registration-servers, this could stay as sp1 specific,
  but It doesn't do anything except assert screen, would make sense with
  use of custom server
- moved scc-beta-filter-checkbox, is handled only with addons
- added [post registration](https://openqa.suse.de/tests/790252#step/yast_scc/5)
- removed unnecessary addon selection code
- restructured dialog handlig until installation summary screen
- removed unnecessary /connect used with fakescc
- adjusted timeouts

[tests](http://10.100.12.155/tests)