### PR TITLE
Fix reboot phase of autoyast test for s390

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -142,6 +142,11 @@ sub load_zdup_tests {
 sub load_autoyast_tests {
     #    init boot in load_boot_tests
     loadtest("autoyast/installation");
+    # on svirt we need to redefine the xml-file to boot the installed kernel
+    if (check_var('BACKEND', 'svirt') and check_var('ARCH', 's390x')) {
+        loadtest "installation/redefine_svirt_domain";
+        loadtest "installation/reconnect_s390";
+    }
     loadtest("autoyast/console");
     loadtest("autoyast/login");
     loadtest("autoyast/wicked");


### PR DESCRIPTION
Fix for: https://openqa.suse.de/tests/790735