### PR TITLE
Fixes for PTF confirmation and unitialized values problems

### DIFF
--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -41,15 +41,20 @@ sub process_reboot {
 sub trup_call {
     my $cmd = shift;
     my $check = shift // 1;
-    $cmd .= "; echo trup-\$?- > /dev/$serialdev" if $check;
+    $cmd .= " > /dev/$serialdev";
+    $cmd .= " ; echo trup-\$?- > /dev/$serialdev" if $check;
 
     save_screenshot;
     send_key "ctrl-l";
 
     script_run "transactional-update $cmd", 0;
     if ($cmd =~ /ptf /) {
-        assert_screen "dialog_yes_no";
-        type_string "y\n";
+        if (wait_serial "\QContinue? [y/n/? shows all options] (y):") {
+            send_key "ret";
+        }
+        else {
+            die "Confirmation dialog not shown";
+        }
     }
     wait_serial 'trup-0-' if $check;
 }

--- a/tests/casp/transactional_update.pm
+++ b/tests/casp/transactional_update.pm
@@ -35,13 +35,13 @@ sub check_package {
 
 # Reboot and check that mounted snapshot differ if we expect the change
 sub check_reboot_changes {
-    my $nochange = shift;
+    my $change = shift // 1;
 
     my $svbf = script_output 'mount | grep "on / " | grep -o "subvolid=.*snapshot"';
     process_reboot 1;
     my $svaf = script_output 'mount | grep "on / " | grep -o "subvolid=.*snapshot"';
 
-    die "Unexpected snapshot $svbf : $svaf is mounted" unless ($svbf eq $svaf) == $nochange;
+    die "Expected change:$change, but before:$svbf - after:$svaf mounted" if ($svbf eq $svaf) == $change;
 }
 
 sub run() {
@@ -65,7 +65,7 @@ sub run() {
 
     # System should be up to date - no changes expected
     trup_call 'cleanup up';
-    check_reboot_changes 1;
+    check_reboot_changes 0;
 
     # Remove PTF - snapshot #3
     trup_call 'ptf remove update-test-security';


### PR DESCRIPTION
Confirmation without needles:
  https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/315
Unitialized value warning:
  http://dhcp91.suse.cz/tests/4046/file/autoinst-log.txt
Rebootmgr etcd test:
  http://dhcp91.suse.cz/tests/4057#step/rebootmgr/72

Local runs:
http://dhcp91.suse.cz/tests/4061 - DVD
http://dhcp91.suse.cz/tests/4059 - VMX
