### PR TITLE
Add a collection of GNOME Application tests

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -675,6 +675,7 @@ sub load_x11tests() {
         if (!get_var("USBBOOT")) {
             loadtest "x11/reboot_gnome";
         }
+        load_testdir('x11/gnomeapps') if is_gnome_next;
     }
     loadtest "x11/desktop_mainmenu";
 

--- a/tests/x11/gnomeapps/aa_disable_updates.pm
+++ b/tests/x11/gnomeapps/aa_disable_updates.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Disable GNOME Software wanting to auto-update the system
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    x11_start_program 'xterm';
+    assert_screen 'xterm';
+    type_string "gsettings set org.gnome.software download-updates false\n";
+    save_screenshot;
+    type_string "exit\n";
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/aisleriot.pm
+++ b/tests/x11/gnomeapps/aisleriot.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Aisleriot - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('sol');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/baobab.pm
+++ b/tests/x11/gnomeapps/baobab.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Disk Usage Analyzer - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('baobab');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/cheese.pm
+++ b/tests/x11/gnomeapps/cheese.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Cheese - WebCam Analyzer - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('cheese');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/dconf_editor.pm
+++ b/tests/x11/gnomeapps/dconf_editor.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME dconf editor - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('dconf-editor');
+    # assert_gui_app tries to terminate the app by pressing alt-f4
+    # for dconf-editor, this only closes the "Warning dialog"
+    # After that we expect the dconf-main window, which we again
+    # terminate with alt-f4
+    assert_screen('dconf-editor-mainwindow');
+    send_key('alt-f4');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/epiphany.pm
+++ b/tests/x11/gnomeapps/epiphany.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Epiphany - Web browser - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('epiphany');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/file_roller.pm
+++ b/tests/x11/gnomeapps/file_roller.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: file-roller - archive manager - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('file-roller');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_2048.pm
+++ b/tests/x11/gnomeapps/gnome_2048.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME 2048 - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-2048');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_books.pm
+++ b/tests/x11/gnomeapps/gnome_books.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Books - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-books');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_builder.pm
+++ b/tests/x11/gnomeapps/gnome_builder.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Builder - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-builder');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_calculator.pm
+++ b/tests/x11/gnomeapps/gnome_calculator.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Calculator - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-calculator');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_calendar.pm
+++ b/tests/x11/gnomeapps/gnome_calendar.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Calendar - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-calendar');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_characters.pm
+++ b/tests/x11/gnomeapps/gnome_characters.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Characters - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-characters');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_clocks.pm
+++ b/tests/x11/gnomeapps/gnome_clocks.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Clocks - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-clocks');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_contacts.pm
+++ b/tests/x11/gnomeapps/gnome_contacts.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Contacts - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-contacts');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_dictionary.pm
+++ b/tests/x11/gnomeapps/gnome_dictionary.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Dictionary - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-dictionary');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_documents.pm
+++ b/tests/x11/gnomeapps/gnome_documents.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Documents - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-documents');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_font_viewer.pm
+++ b/tests/x11/gnomeapps/gnome_font_viewer.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Font viewer - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-font-viewer');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_games.pm
+++ b/tests/x11/gnomeapps/gnome_games.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Games - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-games');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_logs.pm
+++ b/tests/x11/gnomeapps/gnome_logs.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Logs - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-logs');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_maps.pm
+++ b/tests/x11/gnomeapps/gnome_maps.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Maps minimal test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-maps');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_multi_writer.pm
+++ b/tests/x11/gnomeapps/gnome_multi_writer.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME MultiWriter - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-multi-writer');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_news.pm
+++ b/tests/x11/gnomeapps/gnome_news.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME News - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-news');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_photos.pm
+++ b/tests/x11/gnomeapps/gnome_photos.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Photos - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-photos');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_recipes.pm
+++ b/tests/x11/gnomeapps/gnome_recipes.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Weather - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-recipes');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_screenshot.pm
+++ b/tests/x11/gnomeapps/gnome_screenshot.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Screenshot - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-screenshot', exec_param => "-i");
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_system_monitor.pm
+++ b/tests/x11/gnomeapps/gnome_system_monitor.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME System Monitor - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-system-monitor');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_taquin.pm
+++ b/tests/x11/gnomeapps/gnome_taquin.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Taquin - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-taquin');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_todo.pm
+++ b/tests/x11/gnomeapps/gnome_todo.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Todo - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-todo');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/gnome_weather.pm
+++ b/tests/x11/gnomeapps/gnome_weather.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Weather - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('gnome-weather');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/polari.pm
+++ b/tests/x11/gnomeapps/polari.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME IRC (polari) - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('polari');
+    # Polari asks to run in backgroun or quit on pressing alt-f4
+    assert_and_click('polari-quit');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/gnomeapps/vinagre.pm
+++ b/tests/x11/gnomeapps/vinagre.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: GNOME Weather - Minimal Test
+# Maintainer: Dominique Leuenberger <dimstar@suse.de>>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    assert_gui_app('vinagre');
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
The tests are currently enabled on GNOME Next Live media, but would
make sense also on the regular distro's GNOME EXTRA test suite

for GNOME's EXTRA Test though I will need to set some of the applications having to install, as they are not all present on a default openSUSE install - but they are all supposed to be on the GNOME Next media

smoetest run: http://dimstar.ddns.net/tests/289#