### PR TITLE
Test switching keyboard layout

### DIFF
--- a/products/casp/main.pm
+++ b/products/casp/main.pm
@@ -61,9 +61,10 @@ sub load_boot_tests() {
 sub load_inst_tests() {
     loadtest 'casp/oci_overview';
 
+    # Check keyboard layout
+    loadtest 'casp/oci_keyboard';
     # Register system
     loadtest 'casp/oci_register' if check_var('REGISTER', 'installation');
-
     # Set root password
     loadtest 'casp/oci_password';
     # Set system Role

--- a/tests/casp/oci_keyboard.pm
+++ b/tests/casp/oci_keyboard.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Change keyboard layout
+# Maintainer: Martin Kravec <mkravec@suse.com>
+
+use strict;
+use warnings;
+use base "y2logsstep";
+use testapi;
+
+sub run() {
+    # Switch to UK
+    send_key 'alt-e';
+    send_key 'up';
+
+    # Check that UK layout is active
+    send_key 'alt-g';
+    type_string '~@#\"|';    # writes ¬"£#@~
+    assert_screen 'keyboard-layout-uk';
+    send_key 'ctrl-a';
+    send_key 'delete';
+
+    # Switch to US
+    send_key 'alt-e';
+    send_key 'down';
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Required needles:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/319

Local run:
http://dhcp91.suse.cz/tests/4069#step/oci_keyboard/1

Requested in:
https://trello.com/c/P9uQmLRA/869-3-caasp-do-not-trigger-password-check-in-case-of-changing-keyboard-layout