### PR TITLE
Drop bootloader-ofw tag

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -213,12 +213,9 @@ sub wait_boot {
 
     # Reset the consoles after the reboot: there is no user logged in anywhere
     reset_consoles;
-
-    if (get_var("OFW")) {
-        assert_screen "bootloader-ofw", $bootloader_time;
-    }
+    assert_screen "bootloader", $bootloader_time;
     # reconnect s390
-    elsif (check_var('ARCH', 's390x')) {
+    if (check_var('ARCH', 's390x')) {
         my $login_ready = qr/Welcome to SUSE Linux Enterprise Server.*\(s390x\)/;
         if (check_var('BACKEND', 's390x')) {
 


### PR DESCRIPTION
Introduction of bootloader-ofw just produce duplicate needles.
Proper usage is define OFW variable in your tests and use
"bootloader" tag.
Fixed in terms of poo#17512