### PR TITLE
Update and revert registration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -117,6 +117,10 @@ sub fill_in_registration_data {
                     }
                 }
                 else {
+                    # go to the top of the list before looking for the addon
+                    send_key "home";
+                    # move the list of addons down until the current addon is found
+                    send_key_until_needlematch "scc-module-$addon", "down";
                     # checkmark the requested addon
                     assert_and_click "scc-module-$addon";
                 }

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -86,7 +86,7 @@ sub fill_in_registration_data {
         }
     }
 
-    if (check_var('SCC_REGISTER', 'installation') || check_var('SCC_REGISTER', 'console')) {
+    if (check_var('SCC_REGISTER', 'installation') || check_var('SCC_REGISTER', 'yast') || check_var('SCC_REGISTER', 'console')) {
         # The value of SCC_ADDONS is a list of abbreviation of addons/modules
         # Following are abbreviations defined for modules and some addons
         #


### PR DESCRIPTION
Fix failing [fail1](https://openqa.suse.de/tests/801892#step/zypper_lr/12) and [fail2](https://openqa.suse.de/tests/800808#step/scc_registration/8)

[test1](http://10.100.12.155/tests/5536#step/zypper_lr/9)
[test2](http://10.100.12.155/tests/5539)