### PR TITLE
Fixes poo#17294

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -42,6 +42,7 @@ our @EXPORT = qw(
   handle_emergency
   service_action
   assert_gui_app
+  get_env_by_pattern
 );
 
 
@@ -818,6 +819,18 @@ sub service_action {
             assert_script_run "systemctl $action $name.$type";
         }
     }
+}
+
+sub get_env_by_pattern {
+    my %found;
+    foreach my $key (sort(keys %ENV)) {
+        $_ = $key;
+        if (m/\w+_TEST_REPO/) {
+            my $val = $ENV{"$key"};
+            $found{$key} = $val;
+        }
+    }
+    return %found;
 }
 
 1;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -707,6 +707,15 @@ sub load_extra_test () {
     # pre-conditions for extra tests ie. the tests are running based on preinstalled image
     return if get_var('INSTALLONLY') || get_var('DUALBOOT') || get_var('RESCUECD');
 
+    # possibility to run as part of aggregated tests
+    use List::Util qw(all);
+    my %test_repos = get_env_by_pattern("\\w+_TEST_REPO");
+    my @values     = values %test_repos;
+    if (all { length() < 1 } @values) {
+        loadtest "qa_automation/patch_and_reboot";
+        loadtest "boot/boot_to_desktop";
+    }
+
     # setup $serialdev permission and so on
     loadtest 'console/consoletest_setup';
     loadtest 'console/hostname';

--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -9,9 +9,9 @@
 #
 
 # inherit qa_run, but overwrite run
-# G-Summary: QA Automation: patch the system before running the test
-#    This is to test Test Updates for SP1 and GA
-# G-Maintainer: Stephan Kulow <coolo@suse.de>
+# Summary: QA Automation: patch the system before running the test
+#          This is to test Test Updates
+# Maintainer: Stephan Kulow <coolo@suse.de>
 
 use base "qa_run";
 use strict;
@@ -21,7 +21,14 @@ use testapi;
 
 sub run {
     my $self = shift;
-    $self->system_login();
+
+    # possibility to run as part of the aggregated tests
+    if (get_var('EXTRATEST')) {
+        select_console 'root-console';
+    }
+    else {
+        $self->system_login();
+    }
 
     pkcon_quit unless check_var('DESKTOP', 'textmode');
 


### PR DESCRIPTION
This PR makes the 'extratests' able to be run into the
'Maintenance:Test Repo'. The 'get_env_by_pattern' function
is used to make sure that any *_TEST_REPO env variable is
present and not empty.

working example: http://ultron.suse.de/tests/69