### PR TITLE
Add test for 'zypper info' on binary package

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -723,6 +723,7 @@ sub load_extra_test () {
         loadtest 'console/check_console_font';
         loadtest 'console/zypper_lr';
         loadtest 'console/zypper_ref';
+        loadtest "console/zypper_info";
         loadtest 'console/update_alternatives';
         # start extra console tests from here
         if (!get_var('OFW') && !is_jeos()) {

--- a/tests/console/zypper_info.pm
+++ b/tests/console/zypper_info.pm
@@ -20,15 +20,29 @@ use utils;
 sub run() {
     select_console 'root-console';
 
-    zypper_call('mr -e repo-source');
-    zypper_call('ref');
-    my $info_output = script_output 'zypper info srcpackage:htop';
+    my $info_output = script_output 'zypper info vim';
 
-    my $expected_header = 'Information for srcpackage htop:';
+    my $expected_header = 'Information for package vim:';
     die "Missing info header. Expected: /$expected_header/"
       unless $info_output =~ /$expected_header/;
 
-    my $expected_package_name = 'Name                  : htop';
+    my $expected_package_name = 'Name *: vim';
+    die "Missing package name. Expected: /$expected_package_name/"
+      unless $info_output =~ /$expected_package_name/;
+
+    if (check_var('DISTRI', 'sle')) {
+        diag 'sle not yet supported because of missing source repos';
+        return 1;
+    }
+    zypper_call('mr -e repo-source');
+    zypper_call('ref');
+    $info_output = script_output 'zypper info srcpackage:htop';
+
+    $expected_header = 'Information for srcpackage htop:';
+    die "Missing info header. Expected: /$expected_header/"
+      unless $info_output =~ /$expected_header/;
+
+    $expected_package_name = 'Name *: htop';
     die "Missing package name. Expected: /$expected_package_name/"
       unless $info_output =~ /$expected_package_name/;
 }


### PR DESCRIPTION
- Load test module console/zypper_info in extra_tests for sle tests
- Improve regexp with variable amount of spaces
- Execute zypper info on src-pkg only under openSUSE

Progress: https://progress.opensuse.org/issues/15932

My openQA instance
opensuse: http://copland.arch.suse.de/tests/40
sle: http://copland.arch.suse.de/tests/41