### PR TITLE
Test create_autoyast for CaaSP

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,4 +2,5 @@ requires 'Net::Telnet';
 requires 'File::Basename';
 requires 'Data::Dumper';
 requires 'XML::Writer';
+requires 'XML::Simple';
 requires 'IO::File';

--- a/products/casp/main.pm
+++ b/products/casp/main.pm
@@ -86,6 +86,7 @@ sub load_rcshell_tests {
 # Feature tests after installation finishes
 sub load_feature_tests {
     # Feature tests
+    loadtest 'casp/create_autoyast';
     loadtest 'casp/libzypp_config';
     loadtest 'casp/filesystem_ro';
     loadtest 'casp/services_enabled';

--- a/tests/casp/create_autoyast.pm
+++ b/tests/casp/create_autoyast.pm
@@ -1,0 +1,63 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test for generating worker autoinst profile for CaaSP poo#17174
+# Maintainer: Tomas Hehejik <thehejik@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+use caasp;
+use XML::Simple;
+
+sub run() {
+    my $self = shift;
+
+    my $salt_master   = 'fake-salt-master.com';
+    my $smt_url       = 'http://fake.smt.com';
+    my $regcode       = 'fake-reg-code';
+    my $reg_email     = 'fake@fake.com';
+    my $autoinst_file = '/root/autoinst.xml';
+
+    # Generate autoyast profile using all possible arguments with fake values
+    my $autoinst_with_args = script_output("create_autoyast_profile --salt-master $salt_master --smt-url $smt_url --regcode $regcode --reg-email $reg_email");
+
+    my $xml  = XML::Simple->new;
+    my $data = $xml->XMLin($autoinst_with_args);
+
+    # Check for salt_master value in XML
+    unless ($data->{scripts}{'chroot-scripts'}{script}{source} =~ /$salt_master/) {
+        $self->write_detail_output("salt-master missing", "Value $salt_master for salt-master missing in xml", "fail");
+    }
+
+    # Check for smt_url value in XML
+    unless ($data->{suse_register}{reg_server} =~ /$smt_url/) {
+        $self->write_detail_output("reg-server missing", "Value $smt_url for reg-server missing in xml", "fail");
+    }
+
+    # Check for regcode value in XML
+    unless ($data->{suse_register}{reg_code} =~ /$regcode/) {
+        $self->write_detail_output("regcode missing", "Value $regcode for regcode missing in xml", "fail");
+    }
+
+    # Check for reg_email value in XML
+    unless ($data->{suse_register}{email} =~ /$reg_email/) {
+        $self->write_detail_output("reg-email missing", "Value $reg_email for reg-email missing in xml", "fail");
+    }
+
+    # Generate generic autoinst.xml without using additional args
+    script_output("create_autoyast_profile -o $autoinst_file");
+    upload_asset $autoinst_file;
+}
+
+sub test_flags() {
+    return {important => 1};
+}
+
+1;

--- a/tests/casp/journal_check.pm
+++ b/tests/casp/journal_check.pm
@@ -13,32 +13,7 @@
 use base "opensusebasetest";
 use strict;
 use testapi;
-
-sub write_detail_output {
-    my ($self, $title, $output, $result) = @_;
-
-    $result =~ /^(ok|fail|softfail)$/ || die "Result value: $result not allowed.";
-
-    my $filename = $self->next_resultname('txt');
-    my $detail   = {
-        title  => $title,
-        result => $result,
-        text   => $filename,
-    };
-    push @{$self->{details}}, $detail;
-
-    open my $fh, '>', bmwqemu::result_dir() . "/$filename";
-    print $fh $output;
-    close $fh;
-
-    # Set overall result for the job
-    if ($result eq 'fail') {
-        $self->{result} = $result;
-    }
-    elsif ($result eq 'ok') {
-        $self->{result} ||= $result;
-    }
-}
+use caasp;
 
 sub run() {
     my ($self) = @_;


### PR DESCRIPTION
This PR consists of two commits:
- Move custom function write_detail_output() into lib/caasp.pm
Function write_detail_output() used in journal_check.pm was moved into lib/caasp.pm for it's general availability for other tests/files. Later it could be replaced by record_info() function but right now the function seems to be broken, see poo#17462.
- create_autoyast.pm test for caasp
New test for caasp for generating  caasp worker's autoinst xml profile. It introduces new dependency on XML::Simple for checking autoinst.xml content. The library should be available on openqa workers because yast2 depends on the package "perl-XML-Simple".

Test generating the autoinst.xml profile: http://dhcp209.suse.cz/tests/3446
Test installing according to generated autoinst.xml profile: http://dhcp209.suse.cz/tests/3447