### PR TITLE
Use wait_screen_change to avoid double press of next key

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -73,10 +73,10 @@ sub fill_in_registration_data {
             }
             elsif (match_has_tag('registration-online-repos')) {
                 if (!get_var('QAM_MINIMAL')) {
-                    send_key 'alt-y';    # want updates
+                    wait_screen_change { send_key 'alt-y' };    # want updates
                 }
                 else {
-                    send_key $cmd{next};    # minimal dont want updates
+                    wait_screen_change { send_key $cmd{next} };    # minimal dont want updates
                 }
                 next;
             }


### PR DESCRIPTION
registration-online-repos matched twice on same screen and also next have been pressed twice so installation moved one step too much. On ppc64le arch this happens nearly always.

[x86_64 fail](https://openqa.suse.de/tests/804455#step/addon_products_sle/2)
[ppc64le fail](https://openqa.suse.de/tests/804451#step/addon_products_sle/2)

Hard to reproduce as I can't simulate o.s.d load
[qam-minimal-full](http://10.100.12.155/tests/5555)
[qam-minimal](http://10.100.12.155/tests/5554)

```
10:52:09.5116 2980 >>> testapi::_handle_found_needle: found registration-online-repos-20160505, similarity 1.00 @ 340/331
10:52:09.5117 Debug: /var/lib/openqa/share/tests/sle/tests/installation/scc_registration.pm:35 called registration::fill_in_registration_data
10:52:09.5118 2980 <<< testapi::send_key(key='alt-n')
10:52:09.7132 Debug: /var/lib/openqa/share/tests/sle/tests/installation/scc_registration.pm:35 called registration::fill_in_registration_data
10:52:09.7133 2980 <<< testapi::check_screen(mustmatch=[
  'local-registration-servers',
  'registration-online-repos',
  'import-untrusted-gpg-key',
  'module-selection',
  'contacting-registration-server'
], timeout=60)
10:52:09.7328 3000 MATCH(scc_registration-local_registration_servers-texmode-20160312:0.00)
10:52:09.7479 3000 MATCH(registration-online-repos-20150902:0.00)
10:52:09.7632 3000 MATCH(registration-online-repos-20160310:0.00)
10:52:09.7780 3000 MATCH(registration-online-repos-20160501:0.85)
10:52:09.7927 3000 MATCH(registration-online-repos-20160505:1.00)
10:52:09.8200 3000 MATCH(import-untrusted-gpg-key-nvidia-F5113243C66B6EAE-20161108:0.00)
10:52:09.8337 3000 MATCH(import-untrusted-gpg-key-20160128:0.00)
10:52:09.8596 3000 MATCH(scc_registration-import-untrusted-gpg-key-20160606:0.00)
10:52:09.8913 3000 MATCH(import-untrusted-gpg-key-nvidia-text-F5113243C66B6EAE-20161018:0.00)
10:52:09.9179 3000 MATCH(import-untrusted-gpg-key-nvidia-F5113243C66B6EAE-20161019:0.00)
10:52:09.9303 3000 MATCH(module-selection-textmode-20140730:0.00)
10:52:09.9443 3000 MATCH(module-selection-20140708:0.30)
10:52:09.9583 3000 MATCH(scc_registration-contacting-registration-server-20160504:0.00)
10:52:09.9728 3000 MATCH(scc_registration-contacting-registration-server-20160505:0.00)
10:52:10.0400 2980 >>> testapi::_handle_found_needle: found registration-online-repos-20160505, similarity 1.00 @ 340/331
10:52:10.0401 Debug: /var/lib/openqa/share/tests/sle/tests/installation/scc_registration.pm:35 called registration::fill_in_registration_data
10:52:10.0402 2980 <<< testapi::send_key(key='alt-n')
```