### PR TITLE
Adding a part to click a button into the firefox_java module

### DIFF
--- a/tests/x11regressions/firefox/sle12/firefox_java.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_java.pm
@@ -35,6 +35,8 @@ sub java_testing {
     if (match_has_tag "oracle-cookies-handling") {
         assert_and_click "firefox-java-agree-and-proceed";
     }
+    #Click the "Verify Java version" button
+    assert_and_click "firefox-java-verifyversion";
 }
 
 sub run() {


### PR DESCRIPTION
To verify the Java version on java.com, the site now requires the user to click a button before the check is performed.

A part has been added into the test to assert the screen and click the button, along with the relevant comment.

Failed result: https://openqa.suse.de/tests/804484#step/firefox_java/13
Passing now on my OpenQA instance: http://dreamyhamster.suse.cz/tests/136#step/firefox_java/11

A new needle to accompany the test has also been submitted: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/320