### PR TITLE
Prevent console messages interfering with string comparison

### DIFF
--- a/tests/console/unzip.pm
+++ b/tests/console/unzip.pm
@@ -22,31 +22,32 @@ use strict;
 use testapi;
 
 sub run() {
-
     # Preparation
-    select_console "root-console";
-    assert_script_run "mkdir -p /tmp/unzip-test/";
+    select_console 'root-console';
+    assert_script_run 'mkdir -p /tmp/unzip-test/';
 
     # 1. Unzip (basic usage)
-    assert_script_run "wget --quiet " . data_url('console/test_unzip.zip') . " -O /tmp/unzip-test/archive.zip";
-    assert_script_run "cd /tmp/unzip-test; unzip archive.zip";
-    my $entries = script_output("ls -l /tmp/unzip-test/ | wc -l");
-    die "Extract produced too few values: $entries instead of 7" unless ($entries eq "7");
+    assert_script_run 'wget --quiet ' . data_url('console/test_unzip.zip') . ' -O /tmp/unzip-test/archive.zip';
+    assert_script_run 'cd /tmp/unzip-test; unzip archive.zip';
+
+    my $entries = script_output('ls -l /tmp/unzip-test/ | wc -l');
+    die "Extract produced too few values: $entries instead of 7" unless ($entries =~ /^7$/);
+
     # Go one step further and verify the md5sum of each file
-    assert_script_run "wget --quiet " . data_url('console/checklist.md5') . " -O /tmp/unzip-test/checklist.md5";
-    assert_script_run "md5sum -c /tmp/unzip-test/checklist.md5";
+    assert_script_run 'wget --quiet ' . data_url('console/checklist.md5') . ' -O /tmp/unzip-test/checklist.md5';
+    assert_script_run 'md5sum -c /tmp/unzip-test/checklist.md5';
 
     # 2. Unzip into a new directory
-    assert_script_run "cd /tmp/unzip-test/ ; unzip -d extract/ /tmp/unzip-test/archive.zip";
-    $entries = script_output("ls -l /tmp/unzip-test/extract/ | wc -l");
-    die "Extract produced too few values: $entries instead of 6" unless ($entries eq "6");
+    assert_script_run 'cd /tmp/unzip-test/ ; unzip -d extract/ /tmp/unzip-test/archive.zip';
+    $entries = script_output('ls -l /tmp/unzip-test/extract/ | wc -l');
+    die "Extract produced too few values: $entries instead of 6" unless ($entries =~ /^6$/);
     # Go one step further and verify the md5sum in extract folder of each file.
-    assert_script_run "cp /tmp/unzip-test/archive.zip /tmp/unzip-test/extract/archive.zip";
+    assert_script_run 'cp /tmp/unzip-test/archive.zip /tmp/unzip-test/extract/archive.zip';
     assert_script_run "sed -Ei 'sXunzip-testXunzip-test/extractXg' /tmp/unzip-test/checklist.md5";
-    assert_script_run "md5sum -c /tmp/unzip-test/checklist.md5";
+    assert_script_run 'md5sum -c /tmp/unzip-test/checklist.md5';
 
     # 3. Test the credibility of the zip archive
-    assert_script_run "cd /tmp/unzip-test/ ; unzip -tq archive.zip";
+    assert_script_run 'cd /tmp/unzip-test/ ; unzip -tq archive.zip';
 }
 
 1;


### PR DESCRIPTION
Fixes a problem observed while refactoring and reworking extra tests where
'<bunch of console messages>6' would not equal '6' so we better do whole-line
comparison.