### PR TITLE
Sleep as workaround before typing in editor/xterm (poo#17442)

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -70,7 +70,13 @@ sub test_terminal {
     x11_start_program($name);
     assert_screen $name;
     $self->enter_test_text($name);
-    assert_screen "test-$name-1";
+    unless (check_screen "test-$name-1") {
+        record_soft_failure 'poo#17442 workaround for too early typing, remove after ticket fixed';
+        # We really should not use sleeps but too many keys have gone missing
+        sleep 1;
+        # let's try again
+        assert_screen "test-$name-1";
+    }
     send_key 'alt-f4';
 }
 


### PR DESCRIPTION
I really do not like the sleep and want to get rid of it again but I do not
see a better choice as a workaround. `wait_still_screen` does not work because
of blinking cursor, `wait_screen_change` does also not apply because we have
an `assert_screen` just in before. `wait_idle` should be avoided, no choices
left.