### PR TITLE
Change reaction on absent release notes button

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -16,11 +16,7 @@ use strict;
 use testapi;
 
 sub run() {
-
-    if (!check_screen('release-notes-button', 5)) {
-        record_soft_failure 'workaround missing release notes';
-        return;
-    }
+    assert_screen('release-notes-button', 5);
 
     # workaround for bsc#1014178
     wait_still_screen(5);


### PR DESCRIPTION
Before we record a soft failure in case there is no Release Notes button
with this commit we will just fail which looks more reasonable