### PR TITLE
Extratest fixes rabbitmq, machinery, salt

### DIFF
--- a/tests/console/machinery.pm
+++ b/tests/console/machinery.pm
@@ -16,9 +16,10 @@ use testapi;
 
 sub run() {
     select_console 'root-console';
-    assert_script_run 'which OneClickInstallCLI || zypper -n in yast2-metapackage-handler',  200;
-    assert_script_run 'yes | OneClickInstallCLI http://machinery-project.org/machinery.ymp', 200;
-    validate_script_output 'machinery --help',                                               sub { m/machinery - A systems management toolkit for Linux/ }, 100;
+    assert_script_run 'which OneClickInstallCLI || zypper -n in yast2-metapackage-handler', 200;
+    my $ret_check = '[ "$?" = "141" ] || [ "$?" = "0" ]';
+    assert_script_run 'yes | OneClickInstallCLI http://machinery-project.org/machinery.ymp ; ' . $ret_check, 200;
+    validate_script_output 'machinery --help', sub { m/machinery - A systems management toolkit for Linux/ }, 100;
 }
 
 1;

--- a/tests/console/salt.pm
+++ b/tests/console/salt.pm
@@ -24,7 +24,7 @@ systemctl start salt-master
 systemctl status salt-master
 sed -i -e "s/#master: salt/master: localhost/" /etc/salt/minion
 systemctl start salt-minion
-yes | salt-key --accept-all
+yes | salt-key --accept-all ; [ "$?" = "141" ] || [ "$?" = "0" ]
 salt '*' test.ping
 systemctl stop salt-master salt-minion
 EOF


### PR DESCRIPTION
* Fix rabbitmq test with workaround (boo#1029031)
* Accept 141 as valid exit status in OneClickInstallCLI in machinery
* Accept 141 as valid exit status in salt