### PR TITLE
Add lock package feature for online migration

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -136,6 +136,9 @@ sub load_autoyast_clone_tests {
 sub load_zdup_tests {
     loadtest 'installation/setup_zdup';
     loadtest 'installation/zdup';
+    if (get_var("LOCK_PACKAGE")) {
+        loadtest "console/lock_package";
+    }
     loadtest 'installation/post_zdup';
     loadtest 'boot/boot_to_desktop';
 }

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -385,6 +385,9 @@ sub load_fixup_firewall() {
 sub load_consoletests() {
     if (consolestep_is_applicable()) {
         loadtest "console/consoletest_setup";
+        if (get_var("LOCK_PACKAGE")) {
+            loadtest "console/check_locked_package";
+        }
         loadtest "console/check_console_font";
         loadtest "console/textinfo";
         loadtest "console/hostname";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -592,6 +592,9 @@ sub load_consoletests() {
             loadtest "rt/kmp_modules";
         }
         loadtest "console/consoletest_setup";
+        if (get_var("LOCK_PACKAGE")) {
+            loadtest "console/check_locked_package";
+        }
         loadtest "console/check_console_font";
         loadtest "console/textinfo";
         loadtest "console/hostname";
@@ -855,11 +858,22 @@ sub load_online_migration_tests() {
     loadtest "online_migration/sle12_online_migration/register_system";
     loadtest "online_migration/sle12_online_migration/repos_check";
     # do full/minimal update before migration
-    loadtest "online_migration/sle12_online_migration/zypper_patch"  if (get_var("FULL_UPDATE"));
-    loadtest "online_migration/sle12_online_migration/minimal_patch" if (get_var("MINIMAL_UPDATE"));
+    if (get_var("FULL_UPDATE")) {
+        loadtest "online_migration/sle12_online_migration/zypper_patch";
+    }
+    if (get_var("MINIMAL_UPDATE")) {
+        loadtest "online_migration/sle12_online_migration/minimal_patch";
+    }
     loadtest "online_migration/sle12_online_migration/pre_migration";
-    loadtest "online_migration/sle12_online_migration/yast2_migration"  if (check_var("MIGRATION_METHOD", 'yast'));
-    loadtest "online_migration/sle12_online_migration/zypper_migration" if (check_var("MIGRATION_METHOD", 'zypper'));
+    if (get_var("LOCK_PACKAGE")) {
+        loadtest "console/lock_package";
+    }
+    if (check_var("MIGRATION_METHOD", 'yast')) {
+        loadtest "online_migration/sle12_online_migration/yast2_migration";
+    }
+    if (check_var("MIGRATION_METHOD", 'zypper')) {
+        loadtest "online_migration/sle12_online_migration/zypper_migration";
+    }
     loadtest "online_migration/sle12_online_migration/post_migration";
 }
 

--- a/tests/console/check_locked_package.pm
+++ b/tests/console/check_locked_package.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: check locked package after lock package test applied
+# Maintainer: Wei Jiang <wjiang@suse.com>
+
+use base "consoletest";
+use strict;
+use testapi;
+
+sub run() {
+    select_console 'root-console';
+
+    # List each active package lock and check its version and release info
+    for my $pkg (@$lock_package::locked_pkg_info) {
+        assert_script_run "zypper ll | grep $pkg->{name}";
+        assert_script_run "rpm -q $pkg->{name} | grep $pkg->{fullname}";
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/console/lock_package.pm
+++ b/tests/console/lock_package.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: lock package test mainly used for migration testsuite - poo#17206
+# Maintainer: Wei Jiang <wjiang@suse.com>
+
+package lock_package;
+use base "consoletest";
+use strict;
+use testapi;
+
+our $locked_pkg_info = [];
+
+sub run() {
+    select_console 'root-console';
+
+    # Packages to be locked is comma-separated
+    my @pkgs = split(/,/, get_var('LOCK_PACKAGE'));
+    for my $pkg (@pkgs) {
+        # Save each package's name, version and release info to variable
+        my $fullname = script_output "rpm -q $pkg";
+        push $locked_pkg_info, {name => $pkg, fullname => $fullname};
+
+        # Add a lock for each package
+        assert_script_run "zypper al $pkg";
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
See https://progress.opensuse.org/issues/17206
This is first version of locking package, and only tested during online migration.
Would be added for offline migration later.

Verified runs:
http://147.2.207.208/tests/429
http://147.2.207.208/tests/431