### PR TITLE
Add xvnc, ssh to supportserver roles and 4 remote desktop cases to x11regressions

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1038,7 +1038,6 @@ elsif (get_var("INSTALLCHECK")) {
     loadtest "installation/installcheck";
 }
 elsif (get_var("SUPPORT_SERVER")) {
-    loadtest "support_server/boot";
     loadtest "support_server/login";
     loadtest "support_server/setup";
     unless (load_slenkins_tests()) {

--- a/tests/support_server/login.pm
+++ b/tests/support_server/login.pm
@@ -13,34 +13,24 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# G-Summary: supportserver and supportserver generator implementation
-# G-Maintainer: Pavel Sladek <psladek@suse.com>
+# Summary: Boot and login to the supportserver qcow2 image
+# Maintainer: Pavel Sladek <psladek@suse.com>
 
 use strict;
 use base 'basetest';
+use base 'opensusebasetest';
 use testapi;
+use utils;
 
 sub run {
+    my ($self) = @_;
+    # we have some tests that waits for dvd boot menu timeout and boot from hdd
+    # - the timeout here must cover it
+    $self->wait_boot(bootloader_time => 80, textmode => !is_desktop_installed);
+
     # the supportserver image can be different version than the currently tested system
     # so try to login without use of needles
-    #
-    if (get_var("SUPPORTSERVER_NEEDLE_LOGIN")) {
-        #fallback to needle based detection, if serial console not set or not supported
-        assert_screen("autoyast-system-login-console", 200);
-    }
-    else {
-        wait_serial("login:", 200);
-    }
-
-    type_string "root\n";
-    sleep 1;
-    wait_idle(10);
-    type_password;
-    type_string "\n";
-
-    type_string "echo LOK >/dev/$serialdev";
-    send_key "ret";
-    wait_serial("LOK", 100);
+    select_console 'root-console';
 
 }
 

--- a/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_java.pm
+++ b/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_java.pm
@@ -1,0 +1,83 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Remote Login: One-time VNC Session with Jave applet and xvnc
+# Maintainer: Chingkai <qkzhu@suse.com>
+# Tags: tc#1586207
+
+use strict;
+use base 'basetest';
+use base 'x11regressiontest';
+use testapi;
+use lockapi;
+
+sub run() {
+    my $self = shift;
+
+    # Wait for supportserver if not yet ready
+    mutex_lock 'dhcp';
+    mutex_unlock 'dhcp';
+    mutex_lock 'xvnc';
+
+    # Make sure the client gets the IP address
+    x11_start_program 'xterm';
+    assert_screen 'xterm';
+    become_root;
+    assert_script_run 'dhclient';
+    type_string "exit\n";
+    send_key 'alt-f4';
+
+    # Start firefox
+    $self->start_firefox;
+    send_key 'esc';
+    send_key 'alt-d';
+    type_string "10.0.2.1:5801\n";
+    assert_screen 'firefox-ssl-untrusted';
+    send_key 'tab';
+    send_key 'ret';
+    send_key 'tab';
+    send_key 'ret';
+    assert_screen 'firefox-ssl-addexception', 60;
+    send_key 'alt-c';
+    wait_still_screen 3;
+    send_key 'alt-f10';
+    assert_and_click 'xvnc-firefox-activate-IcedTea';
+    assert_and_click 'xvnc-firefox-IcedTea-allow';
+    assert_screen 'xvnc-firefox-certification-warning';
+    assert_and_click 'xvnc-firefox-trust-ca';
+    assert_screen 'firefox-java-security';
+    assert_and_click 'firefox-java-securityrun';
+    assert_screen 'xvnc-firefox-verification-warning';
+    send_key 'ret';
+    assert_and_click [qw(xvnc-firefox-certification-warning2 xvnc-firefox-dm)];
+    if (match_has_tag 'xvnc-firefox-certification-warning2') {
+        send_key 'ret';
+        assert_and_click 'xvnc-firefox-dm';
+    }
+    send_key 'ret';
+    assert_screen 'xvnc-firefox-login-dm';
+    type_password;
+    send_key 'ret';
+    assert_screen 'xvnc-firefox-generic-desktop';
+
+    # Exit firefox
+    $self->exit_firefox;
+
+    mutex_unlock 'xvnc';
+    assert_screen 'generic-desktop';
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_tigervnc.pm
+++ b/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_tigervnc.pm
@@ -1,0 +1,77 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Remote Login: One-time VNC Session with tigervnc and xvnc
+# Maintainer: Chingkai <qkzhu@suse.com>
+# Tags: tc#1586206
+
+use strict;
+use base 'basetest';
+use testapi;
+use lockapi;
+use utils;
+
+sub run() {
+    #wait for supportserver if not yet ready
+    mutex_lock 'dhcp';
+    mutex_unlock 'dhcp';
+    mutex_lock 'xvnc';
+
+    # Make sure the client gets the IP address
+    x11_start_program 'xterm';
+    assert_screen 'xterm';
+    become_root;
+    assert_script_run 'dhclient';
+    type_string "exit\n";
+    send_key 'alt-f4';
+
+    # Start vncviewer and login with fullscreen
+    x11_start_program 'vncviewer';
+    assert_screen 'vnc_password_dialog';
+    type_string '10.0.2.1:1';
+    assert_and_click 'vncviewer-options';
+    assert_and_click 'vncviewer-options-screen';
+    assert_and_click 'vncviewer-options-fullscreen';
+    assert_and_click 'vncviewer-options-ok';
+    wait_still_screen 3;
+    send_key 'ret';
+    assert_screen 'vnc_certificate_warning';
+    send_key 'ret';
+    assert_screen 'vnc_certificate_warning-2';
+    send_key 'ret';
+    handle_login;
+    assert_screen 'generic-desktop';
+
+    # Launch gnome-terminal and nautilus remotely
+    x11_start_program 'gnome-terminal';
+    assert_screen 'gnome-terminal-launched';
+    send_key 'alt-f4';
+    send_key 'ret';
+    wait_still_screen 3;
+    x11_start_program 'nautilus';
+    assert_screen 'nautilus-launched';
+    send_key 'alt-f4';
+
+    # Exit vncviewer
+    send_key 'f8';
+    assert_screen 'vncviewer-menu';
+    send_key 'x';
+
+    mutex_unlock 'xvnc';
+    assert_screen 'generic-desktop';
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11regressions/remote_desktop/persistent_vncsession_xvnc.pm
+++ b/tests/x11regressions/remote_desktop/persistent_vncsession_xvnc.pm
@@ -1,0 +1,121 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Remote Login: Persistent VNC Session with tigervnc and xvnc
+# Maintainer: Chingkai <qkzhu@suse.com>
+# Tags: tc#1586209
+
+use strict;
+use base 'basetest';
+use testapi;
+use lockapi;
+use utils;
+
+sub start_vncviewer {
+    x11_start_program 'vncviewer 10.0.2.1:1 -Fullscreen';
+    assert_screen [qw(displaymanager vncmanager-greeter vnc_certificate_warning)];
+    if (match_has_tag 'vnc_certificate_warning') {
+        send_key 'ret';
+        assert_screen [qw(displaymanager vncmanager-greeter vnc_certificate_warning-2)];
+        if (match_has_tag 'vnc_certificate_warning-2') {
+            send_key 'ret';
+        }
+    }
+}
+
+sub vncviewer_login_presession {
+    assert_screen 'vncmanager-greeter';
+    assert_and_click 'vncmanager-greeter-presession';
+    assert_screen 'vncmanager-greeter-login';
+    type_string "$username";
+    wait_still_screen 2;
+    send_key 'tab';
+    wait_still_screen 2;
+    type_password;
+    wait_still_screen 2;
+    send_key 'ret';
+    assert_screen 'gnome-terminal-launched';
+}
+
+sub run() {
+    my $self = shift;
+
+    # Wait for supportserver if not yet ready
+    mutex_lock 'dhcp';
+    mutex_unlock 'dhcp';
+    mutex_lock 'xvnc';
+
+    # Make sure the client gets the IP address
+    x11_start_program 'xterm';
+    assert_screen 'xterm';
+    become_root;
+    assert_script_run 'dhclient';
+    type_string "exit\n";
+    send_key 'alt-f4';
+
+    # First time login and configure the visibility
+    $self->start_vncviewer;
+    handle_login;
+    assert_screen 'generic-desktop';
+    x11_start_program 'gnome-terminal';
+    assert_screen 'gnome-terminal-launched';
+    type_string "vncmanager-controller\n";
+    assert_screen 'vncmanager-controller';
+    assert_and_click 'vncmanager-controller-visibility';
+    assert_and_click 'vncmanager-controller-sharing';
+    send_key 'alt-o';
+    type_string "clear\n";
+
+    # Exit the vncviewer
+    send_key 'f8';
+    assert_screen 'vncviewer-menu';
+    send_key 'x';
+    assert_screen 'generic-desktop';
+
+    # Re-login to the previous session
+    $self->start_vncviewer;
+    $self->vncviewer_login_presession;
+
+    # Minimize the vncviewer
+    send_key 'f8';
+    assert_screen 'vncviewer-menu';
+    send_key 'z';
+
+    # Login to the sharing session using another vncviewer
+    $self->start_vncviewer;
+    $self->vncviewer_login_presession;
+    # Exit the sharing session
+    send_key 'f8';
+    assert_screen 'vncviewer-menu';
+    send_key 'x';
+
+    # Terminate the minimized session
+    hold_key 'alt';
+    send_key_until_needlematch('vncviewer-minimize', 'tab');
+    release_key 'alt';
+    send_key 'alt-f4';
+    mouse_set(1000, 30);
+    assert_and_click 'system-indicator';
+    assert_and_click 'user-logout-sector';
+    assert_and_click 'logout-system';
+    assert_screen 'logout-dialogue';
+    send_key 'ret';
+
+    mutex_unlock 'xvnc';
+    assert_screen 'generic-desktop';
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11regressions/remote_desktop/x11_forwarding_openssh.pm
+++ b/tests/x11regressions/remote_desktop/x11_forwarding_openssh.pm
@@ -1,0 +1,70 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Remote Login: X11 forwarding over OpenSSH
+# Maintainer: Chingkai <qkzhu@suse.com>
+# Tags: tc#1586202
+
+use strict;
+use base 'basetest';
+use base 'x11test';
+use testapi;
+use lockapi;
+use utils;
+
+sub run() {
+    my $self = shift;
+
+    # Wait for supportserver if not yet ready
+    mutex_lock 'dhcp';
+    mutex_unlock 'dhcp';
+    mutex_lock 'ssh';
+    mutex_unlock 'ssh';
+
+    # Make sure the client gets the IP address
+    x11_start_program 'xterm';
+    assert_screen 'xterm';
+    become_root;
+    assert_script_run 'dhclient';
+    type_string "exit\n";
+
+    # ssh login
+    my $str = 'SSH-' . time;
+    type_string "ssh -X root\@10.0.2.1\n";
+    assert_screen 'ssh-login', 60;
+    type_string "yes\n";
+    assert_screen 'password-prompt', 60;
+    type_string "$password\n";
+    assert_screen 'ssh-login-ok';
+
+    $self->set_standard_prompt();
+    $self->enter_test_text('ssh-X-forwarding');
+    assert_screen 'test-sshxterm-1';
+
+    # Launch gedit and gnome control center remotely
+    type_string "gedit /etc/issue\n";
+    assert_screen 'x11-forwarding-gedit';
+    send_key 'alt-f4';
+    wait_still_screen 3;
+    type_string "gnome-control-center info\n";
+    assert_screen 'x11-forwarding-gccinfo';
+    send_key 'alt-f4';
+    wait_still_screen 3;
+    send_key 'alt-f4';
+    assert_screen 'generic-desktop';
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
## Update supportserver boot, login and add xvnc, ssh to supportserver roles

- We are going to implement remote desktop testing in poo#9504 which needs:
    * SLES12SP2+gnome(gdm/vino...is necessary) supportserver qcow2 image
    * one time session xvnc server
    * persistent session xvnc server
    * ssh server for X11 forwarding
    * vino server
    * XDMCP with gdm and SLE-Classic configured
    * XDMCP with xdm and icewm configured
    * xrdp server
  supportserver is a good choice for Remote Desktop testing, but we have to
  update the login part and add the needed server roles in setup.pm.
- We used to use boot.pm and login.pm to boot into the supportserver image and
  it only supports console login. boot.pm is dropped in this commit and login.pm
  is updated by using wait_boot which supports both console and graphical login.
- Adding xvnc server role which supports both onetime VNC session and persistent
  VNC session, the VNC type is configured by variable in testsuits:
  REMOTE_DESKTOP_TYPE = persistent_vnc
  REMOTE_DESKTOP_TYPE = one_time_vnc

## Add 4 remote desktop cases for x11regressions

- onetime_vncsession_xvnc_java.pm
  Remote Login: One-time VNC Session with Jave applet and xvnc
- onetime_vncsession_xvnc_tigervnc.pm
  Remote Login: One-time VNC Session with tigervnc and xvnc
- persistent_vncsession_xvnc.pm
  Remote Login: Persistent VNC Session with tigervnc and xvnc
- x11_forwarding_openssh.pm
  Remote Login: X11 forwarding over OpenSSH

see also: https://progress.opensuse.org/issues/9504

Validation runs:
remote-desktop-client1: http://147.2.212.167/tests/298
remote-desktop-supportserver1: http://147.2.212.167/tests/296
remote-desktop-client2: http://147.2.212.167/tests/299
remote-desktop-supportserver2: http://147.2.212.167/tests/297
supportserver regression test: http://147.2.212.167/tests/295
