### PR TITLE
Make vnc_two_passwords test more robust

### DIFF
--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -56,6 +56,7 @@ sub run() {
 
     # Start xev event watcher
     x11_start_program "xterm";
+    assert_screen('xterm');
     send_key "super-right";
     type_string "DISPLAY=:1 xev\n";
 
@@ -64,6 +65,7 @@ sub run() {
         x11_start_program("vncviewer :1 -SecurityTypes=VncAuth");
         assert_screen "vnc_password_dialog", 60;
         type_string "$opt->{pw}\n";
+        assert_screen 'vncviewer-xev';
         send_key "super-left";
         mouse_set(80, 120);
 


### PR DESCRIPTION
Requires: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/326
Local run: http://dhcp91.suse.cz/tests/4125

Fixes:
https://openqa.suse.de/tests/801676#step/vnc_two_passwords/17
https://openqa.suse.de/tests/799452#step/vnc_two_passwords/17
https://openqa.suse.de/tests/798112#step/vnc_two_passwords/14