### PR TITLE
Fix missing console/zypper_info test for SLE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -464,6 +464,7 @@ sub load_extra_tests() {
         # dependency of git test
         loadtest "console/sshd";
         loadtest "console/zypper_ref";
+        loadtest "console/zypper_info";
         loadtest "console/update_alternatives";
         # start extra console tests from here
         if (!get_var("OFW") && !is_jeos) {
@@ -496,7 +497,6 @@ sub load_extra_tests() {
             loadtest "console/machinery";
             loadtest "console/pcre";
             loadtest "console/openqa_review";
-            loadtest "console/zypper_info";
             loadtest "console/zbar";
             loadtest "console/zypper_ar";
             loadtest "console/a2ps";    # a2ps is not a ring package and thus not available in staging

--- a/tests/console/zypper_info.pm
+++ b/tests/console/zypper_info.pm
@@ -30,21 +30,20 @@ sub run() {
     die "Missing package name. Expected: /$expected_package_name/"
       unless $info_output =~ /$expected_package_name/;
 
-    if (check_var('DISTRI', 'sle')) {
-        diag 'sle not yet supported because of missing source repos';
-        return 1;
+    if (check_var('DISTRI', 'opensuse')) {
+        # sle not yet supported because of missing source repos
+        zypper_call('mr -e repo-source');
+        zypper_call('ref');
+        $info_output = script_output 'zypper info srcpackage:htop';
+
+        $expected_header = 'Information for srcpackage htop:';
+        die "Missing info header. Expected: /$expected_header/"
+          unless $info_output =~ /$expected_header/;
+
+        $expected_package_name = 'Name *: htop';
+        die "Missing package name. Expected: /$expected_package_name/"
+          unless $info_output =~ /$expected_package_name/;
     }
-    zypper_call('mr -e repo-source');
-    zypper_call('ref');
-    $info_output = script_output 'zypper info srcpackage:htop';
-
-    $expected_header = 'Information for srcpackage htop:';
-    die "Missing info header. Expected: /$expected_header/"
-      unless $info_output =~ /$expected_header/;
-
-    $expected_package_name = 'Name *: htop';
-    die "Missing package name. Expected: /$expected_package_name/"
-      unless $info_output =~ /$expected_package_name/;
 }
 
 1;


### PR DESCRIPTION
Recover missing console/zypper_info test module for SLE after extra_tests refactoring

Progress: https://progress.opensuse.org/issues/17686
openQA instance: http://copland.arch.suse.de/tests/70