### PR TITLE
Fix poo#17636

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -56,9 +56,11 @@ sub post_fail_hook {
     # system might be stuck on bootup showing only splash screen so we press
     # esc to show console logs
     send_key 'esc';
-    $self->SUPER::post_fail_hook;
+    select_console('install-shell');
     # in case we could not even reach the installer welcome screen and logs
     # could not be collected on the serial output:
+    $self->save_upload_y2logs;
+    $self->get_ip_address;
     upload_logs '/var/log/linuxrc.log';
 }
 


### PR DESCRIPTION
Fix the issue that test fails in welcome post_fail_hook expecting
password prompt but bash is already logged in