### PR TITLE
Improve timing when reconnecting to VNC on XEN

### DIFF
--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -35,6 +35,7 @@ sub process_reboot {
     reset_consoles;
     # We have to re-connect *after* the restart on xen
     if (check_var('VIRSH_VMM_FAMILY', 'xen')) {
+        assert_screen 'black';
         sleep 4;
         select_console 'sut';
         console('svirt')->attach_to_running({stop_vm => 1});


### PR DESCRIPTION
Test should wait for https://openqa.suse.de/tests/806966#step/transactional_update/20 to disappear before starting timer.

Requires: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/330
Fixes: https://openqa.suse.de/tests/814588