### PR TITLE
Enable snapper_cleanup test in o3

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -467,8 +467,8 @@ sub load_extra_tests() {
             loadtest "console/btrfs_autocompletion";
             if (get_var("NUMDISKS", 0) > 1) {
                 loadtest "console/btrfs_qgroups";
+                loadtest 'console/snapper_cleanup';
                 if (check_var('DISTRI', 'sle') && sle_version_at_least('12-SP2')) {
-                    loadtest 'console/snapper_cleanup';
                     loadtest "console/btrfs_send_receive";
                 }
             }


### PR DESCRIPTION
Proof run http://kimball.arch.suse.de/tests/308