### PR TITLE
Remove useless wait_still_screen

### DIFF
--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -499,8 +499,6 @@ sub start_gnome_settings {
     send_key "super";
     wait_still_screen;
     type_string "settings";
-    # give gnome-shell time to digest the input
-    wait_still_screen 2;
     assert_and_click "settings";
     assert_screen "gnome-settings";
 }


### PR DESCRIPTION
Depends on https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/331

- [poo#14838](https://progress.opensuse.org/issues/14838)
- [openQA:copland#98:needle_1](http://copland.arch.suse.de/tests/98#step/change_password/2)
- [openQA:copland#98:needle_2](http://copland.arch.suse.de/tests/98#step/change_password/3)