### PR TITLE
Fix lock package loading sequence for zdup

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -135,10 +135,10 @@ sub load_autoyast_clone_tests {
 
 sub load_zdup_tests {
     loadtest 'installation/setup_zdup';
-    loadtest 'installation/zdup';
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/lock_package";
     }
+    loadtest 'installation/zdup';
     loadtest 'installation/post_zdup';
     loadtest 'boot/boot_to_desktop';
 }


### PR DESCRIPTION
Sorry, should be this: http://147.2.207.208/tests/432