### PR TITLE
Support new desktop selection workflow

### DIFF
--- a/tests/installation/installation_mode.pm
+++ b/tests/installation/installation_mode.pm
@@ -19,7 +19,12 @@ use testapi;
 sub run() {
     # autoconf phase
     # includes downloads, so wait_idle is bad.
-    assert_screen "inst-instmode", 120;
+    assert_screen [qw(partitioning-edit-proposal-button inst-instmode)], 120;
+    if (match_has_tag("partitioning-edit-proposal-button")) {
+        # new desktop selection workflow
+        set_var('NEW_DESKTOP_SELECTION', 1);
+        return;
+    }
 
     if (get_var("UPGRADE")) {
         send_key "alt-u";    # Include Add-On Products

--- a/tests/installation/installer_desktopselection.pm
+++ b/tests/installation/installer_desktopselection.pm
@@ -16,8 +16,19 @@ use base "y2logsstep";
 use testapi;
 
 sub run() {
+    my $install_patterns = '';
     assert_screen 'desktop-selection';
     my $d = get_var('DESKTOP');
+
+    if (get_var('NEW_DESKTOP_SELECTION')) {
+        # select computer role
+        if ($d ne 'kde' && $d ne 'gnome' && $d ne 'textmode') {
+            $d = 'custom';
+        }
+        if ($d eq 'custom') {
+            $install_patterns = 'x11' if get_var('DESKTOP') eq 'minimalx';
+        }
+    }
     if ($d ne 'kde' && $d ne 'gnome') {
         # up to 42.1 textmode was below 'other'
         if (!($d eq 'textmode' && check_screen 'has-server-selection', 2)) {
@@ -34,6 +45,15 @@ sub run() {
     }
     assert_screen "$d-selected";
     send_key $cmd{next};
+
+    if (get_var('NEW_DESKTOP_SELECTION') && $d eq 'custom') {
+        assert_screen "pattern-selection";
+        for my $p (split(/,/, $install_patterns)) {
+            assert_and_click "pattern-$p";
+            assert_and_click "pattern-$p-selected";
+        }
+        send_key $cmd{ok};
+    }
 }
 
 1;

--- a/tests/installation/logpackages.pm
+++ b/tests/installation/logpackages.pm
@@ -22,7 +22,12 @@ use testapi;
 sub run() {
     # the waiting might take long in case of online update repos being
     # initialized before that screen
-    assert_screen 'before-package-selection', 300;
+    if (get_var('NEW_DESKTOP_SELECTION')) {
+        assert_screen 'before-role-selection', 300;
+    }
+    else {
+        assert_screen 'before-package-selection', 300;
+    }
 
     #send_key "ctrl-alt-shift-x"; sleep 3;
     select_console('install-shell');


### PR DESCRIPTION
Corresponding change for new desktop selection workflow, new desktop selection workflow is about selecting computer role, "Other" now called "Custom", in the custom mode, user have to select pattern
themselves. Add-on source option doesn't have a owned page now.

Tested: gnome, kde, minimalx, cryptlvm, RAID0

Verification run: http://147.2.211.148/tests/overview?build=485.9&distri=opensuse&version=Staging:F&groupid=14 and http://147.2.211.148/tests/overview?build=643.9&distri=opensuse&version=Staging:F&groupid=14

Note that, this is mainly for staging period test, after new desktop selection workflow merged into main project, more fixes is required for openqa test as there are more tests for main product. And this does not harm old style workflow, see http://147.2.211.148/tests/469 .