### PR TITLE
Make sure to run snapper_cleanup only on oS || SLE=>12SP2

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -467,7 +467,9 @@ sub load_extra_tests() {
             loadtest "console/btrfs_autocompletion";
             if (get_var("NUMDISKS", 0) > 1) {
                 loadtest "console/btrfs_qgroups";
-                loadtest 'console/snapper_cleanup';
+                if (check_var('DISTRI', 'opensuse') || (check_var('DISTRI', 'sle') && sle_version_at_least('12-SP2'))) {
+                    loadtest 'console/snapper_cleanup';
+                }
                 if (check_var('DISTRI', 'sle') && sle_version_at_least('12-SP2')) {
                     loadtest "console/btrfs_send_receive";
                 }


### PR DESCRIPTION
Fixes regression in maintenance tests introduced by 9389f5a.

Local schedule verification:

* opensuse

```
scheduling btrfs_autocompletion tests/console/btrfs_autocompletion.pm
scheduling btrfs_qgroups tests/console/btrfs_qgroups.pm
scheduling snapper_cleanup tests/console/snapper_cleanup.pm
scheduling snapper_undochange tests/console/snapper_undochange.pm
scheduling snapper_create tests/console/snapper_create.pm
…
```

* sle 12sp3

```
scheduling btrfs_autocompletion tests/console/btrfs_autocompletion.pm
scheduling btrfs_qgroups tests/console/btrfs_qgroups.pm
scheduling snapper_cleanup tests/console/snapper_cleanup.pm
scheduling btrfs_send_receive tests/console/btrfs_send_receive.pm
scheduling snapper_undochange tests/console/snapper_undochange.pm
scheduling snapper_create tests/console/snapper_create.pm
…
```

* sle 12sp1

```
scheduling btrfs_autocompletion tests/console/btrfs_autocompletion.pm
scheduling btrfs_qgroups tests/console/btrfs_qgroups.pm
scheduling snapper_undochange tests/console/snapper_undochange.pm
scheduling snapper_create tests/console/snapper_create.pm
…
```