### PR TITLE
Ensure we have a valid console ready after every select_console switch

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -240,7 +240,7 @@ sub wait_boot {
             select_console('root-console');
         }
         else {
-            select_console('x11');
+            select_console('x11', await_console => 0);
         }
     }
     # On Xen PV and svirt we don't see a Grub menu

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -190,15 +190,16 @@ sub script_sudo($$) {
     return;
 }
 
+# simplified but still colored prompt for better readability
 sub set_standard_prompt {
     my ($self, $user) = @_;
     $user ||= $testapi::username;
     if ($user eq 'root') {
         # set standard root prompt
-        type_string "PS1='# '\n";
+        type_string "PS1=\"\$(tput bold 2; tput setaf 1)#\$(tput sgr0) \"\n";
     }
     else {
-        type_string "PS1='\$ '\n";
+        type_string "PS1=\"\$(tput bold 2; tput setaf 1)\\\$\$(tput sgr0) \"\n";
     }
 }
 

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -420,5 +420,28 @@ sub activate_console {
     }
 }
 
+=head2 console_selected
+
+    console_selected($console [, await_console => $await_console] [, tags => $tags ]);
+
+Overrides C<select_console> callback from C<testapi>. Waits for console by
+calling assert_screen on C<tags>, by default the name of the selected console.
+
+C<await_console> is set to 1 by default. Can be set to 0 to skip the check for
+the console. Call for example
+C<select_console('root-console', await_console => 0)> if there should be no
+checking for the console to be shown. Useful when the check should or must be
+test module specific.
+
+=cut
+
+sub console_selected {
+    my ($self, $console, %args) = @_;
+    $args{await_console} //= 1;
+    $args{tags} //= $console;
+    return unless $args{await_console};
+    assert_screen($args{tags}, no_wait => 1);
+}
+
 1;
 # vim: set sw=4 et:

--- a/tests/console/consoletest_finish.pm
+++ b/tests/console/consoletest_finish.pm
@@ -42,7 +42,7 @@ sub run() {
     save_screenshot();
 
     if (!check_var("DESKTOP", "textmode")) {
-        select_console('x11');
+        select_console('x11', await_console => 0);
         ensure_unlocked_desktop;
     }
 }

--- a/tests/console/openssl_alpn.pm
+++ b/tests/console/openssl_alpn.pm
@@ -28,7 +28,8 @@ sub run() {
     select_console 'user-console';
     validate_script_output 'openssl s_client -alpn http < /dev/null', sub { m/ALPN protocol: http/ };
 
-    select_console 'root-console';
+    # the openssl server is still running so do not expect a ready prompt
+    select_console 'root-console', await_console => 0;
     send_key "ctrl-c";    # terminate `openssl s_server'
     save_screenshot;
 }

--- a/tests/installation/hostname_inst.pm
+++ b/tests/installation/hostname_inst.pm
@@ -18,7 +18,7 @@ use testapi;
 
 sub run() {
     assert_screen "before-package-selection";
-    select_console('install-shell');
+    select_console 'install-shell';
     if (my $expected_install_hostname = get_var('EXPECTED_INSTALL_HOSTNAME')) {
         # EXPECTED_INSTALL_HOSTNAME contains expected hostname YaST installer
         # got from environment (DHCP, 'hostname=' as a kernel cmd line argument
@@ -32,8 +32,7 @@ sub run() {
     # cleanup
     type_string "cd /\n";
     type_string "reset\n";
-    select_console('installation');
-    assert_screen "inst-returned-to-yast";
+    select_console 'installation';
 }
 
 1;

--- a/tests/installation/logpackages.pm
+++ b/tests/installation/logpackages.pm
@@ -28,18 +28,11 @@ sub run() {
     else {
         assert_screen 'before-package-selection', 300;
     }
-
-    #send_key "ctrl-alt-shift-x"; sleep 3;
-    select_console('install-shell');
-    # switching back from X can be slow, we have to be sure here
-    assert_screen 'inst-console';
-
+    select_console 'install-shell';
     script_run "(cat /.timestamp ; echo /.packages.initrd: ; cat /.packages.initrd) > /dev/$serialdev";
     script_run "(echo /.packages.root: ; cat /.packages.root) > /dev/$serialdev";
     save_screenshot;
-
-    select_console('installation');
-    assert_screen "inst-returned-to-yast", 15;
+    select_console 'installation';
 }
 
 1;

--- a/tests/installation/reconnect_s390.pm
+++ b/tests/installation/reconnect_s390.pm
@@ -44,7 +44,7 @@ sub run() {
     }
 
     if (!check_var('DESKTOP', 'textmode')) {
-        select_console('x11');
+        select_console('x11', await_console => 0);
     }
 }
 

--- a/tests/online_migration/sle12_online_migration/post_migration.pm
+++ b/tests/online_migration/sle12_online_migration/post_migration.pm
@@ -30,7 +30,7 @@ sub run() {
         record_soft_failure 'workaround for bsc#1013208, disable nvidia repo after migration';
     }
 
-    select_console 'x11';
+    select_console 'x11', await_console => 0;
     ensure_unlocked_desktop;
     mouse_hide(1);
     assert_screen 'generic-desktop';

--- a/tests/online_migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/online_migration/sle12_online_migration/yast2_migration.pm
@@ -22,7 +22,7 @@ sub run {
         select_console 'root-console';
     }
     else {
-        select_console 'x11';
+        select_console 'x11', await_console => 0;
         ensure_unlocked_desktop;
         mouse_hide(1);
         assert_screen 'generic-desktop';

--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -35,7 +35,7 @@ sub turn_off_screensaver() {
 # Update with GNOME PackageKit Update Viewer
 sub run() {
     my ($self) = @_;
-    select_console 'x11';
+    select_console 'x11', await_console => 0;
 
     my @updates_tags           = qw(updates_none updates_available);
     my @updates_installed_tags = qw(updates_none updates_installed-logout updates_installed-restart);

--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -25,7 +25,7 @@ sub kernel_updated {
 # Update with Plasma applet for software updates using PackageKit
 sub run() {
     my ($self) = @_;
-    select_console 'x11';
+    select_console 'x11', await_console => 0;
     turn_off_kde_screensaver;
 
     my @updates_installed_tags = qw(updates_none updates_available);

--- a/tests/x11/ImageMagick.pm
+++ b/tests/x11/ImageMagick.pm
@@ -31,7 +31,6 @@ use utils;
 
 sub run() {
     select_console "x11";
-
     x11_start_program "xterm";
 
     become_root;

--- a/tests/x11/ghostscript.pm
+++ b/tests/x11/ghostscript.pm
@@ -22,7 +22,6 @@ use utils;
 
 sub run() {
     select_console "x11";
-
     x11_start_program "xterm";
 
     # become root, disable packagekit and install all needed packages

--- a/tests/x11/wireshark.pm
+++ b/tests/x11/wireshark.pm
@@ -78,7 +78,7 @@ sub run() {
     type_string "exit\n";                     # logout
     wait_still_screen 2;
     save_screenshot();
-    select_console 'x11';
+    select_console 'x11', await_console => 0;
     assert_screen "wireshark-capturing";
 
     # set filter


### PR DESCRIPTION
Using the new callback from the 'select_console' as added by
https://github.com/os-autoinst/os-autoinst/pull/738 and
https://github.com/os-autoinst/os-autoinst/pull/740
we can replace the already existing explicit places for checking that a
console is ready after switching and do it properly every time except for the
specific cases where we do not want to check or do it differently.

Needs the corresponding os-autoinst changes as well as needle updates.

Needle changes:
* https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/334
* https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/173

Verification runs:
* sle: http://lord.arch/tests/6068
* sle maintenance: http://lord.arch/tests/6069
* tw: http://lord.arch/tests/6067

Related progress issue: https://progress.opensuse.org/issues/14826