### PR TITLE
Add post_fail_hook for online_migration_setup

### DIFF
--- a/tests/online_migration/sle12_online_migration/online_migration_setup.pm
+++ b/tests/online_migration/sle12_online_migration/online_migration_setup.pm
@@ -24,5 +24,20 @@ sub test_flags() {
     return {fatal => 1, important => 1};
 }
 
+sub post_fail_hook {
+    my ($self) = @_;
+
+    # Show the console log if stuck on the plymouth splash screen
+    wait_screen_change {
+        send_key 'esc';
+    };
+
+    # Try to login to tty console
+    select_console 'root-console' unless (match_has_tag('emergency-shell') or match_has_tag('emergency-mode'));
+
+    # Save logs if succeed to access a console
+    $self->SUPER::post_fail_hook;
+}
+
 1;
 # vim: set sw=4 et:


### PR DESCRIPTION
Fix poo#17638: online_migration_setup should use some error
investigation like e.g. first_boot, reboot_gnome, etc.