### PR TITLE
Allow installing KOTD kernel before running ltp tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -395,6 +395,9 @@ sub maybe_load_kernel_tests {
         loadtest 'kernel/shutdown_ltp';
     }
     elsif (get_var('LTP_COMMAND_FILE')) {
+        if (get_var('INSTALL_KOTD')) {
+            loadtest 'kernel/install_kotd';
+        }
         loadtest 'kernel/boot_ltp';
         if (get_var('LTP_COMMAND_FILE') =~ m/ltp-aiodio.part[134]/) {
             loadtest 'kernel/create_junkfile_ltp';


### PR DESCRIPTION
Before running ltp tests, if INSTALL_KOTD is set, load "kernel/install_kotd" test to install latest KOTD kernel.