### PR TITLE
Adding wait_still_screen to make sure test goes right way

### DIFF
--- a/tests/x11regressions/libreoffice/libreoffice_double_click_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_double_click_file.pm
@@ -11,7 +11,6 @@
 # Maintainer: dehai <dhkong@suse.com>
 
 use base "x11regressiontest";
-use base "x11regressiontest";
 use strict;
 use testapi;
 
@@ -40,6 +39,7 @@ sub run() {
             hold_key "alt";
             send_key_until_needlematch("libreoffice-nautilus-window", "tab");
             release_key "alt";
+            wait_still_screen(3);
         }
     }
     send_key "ctrl-q";


### PR DESCRIPTION
A wait_still_screen step has been added into the libreoffice_double_click_file module.

Context:
The test opens nautilus and wants to loop through a list of document files of various types to check that they open without problems.
After checking the first one on the list (.doc), it wants to return back to nautilus (alt-tab) and proceed to the next document file (.docx).
However, the alt key seems to get released in a wrong moment; the test does not return to nautilus and instead stays in the .doc file (looks like tab has been pressed a couple more times), so the test cannot continue and fails.

Failed test: https://openqa.suse.de/tests/815852#step/libreoffice_double_click_file/87

The amended test went through fine on my local openQA instance (however it will need to be re-assessed in production to see how much of a help it is in an environment with higher workload):
http://dreamyhamster.suse.cz/tests/141#step/libreoffice_double_click_file/33

Related to poo#17758

Also, duplicate base reference has been removed from the test.