### PR TITLE
Add an explicit run of the cron jobs

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -403,6 +403,7 @@ sub load_consoletests() {
             loadtest "console/xorg_vt";
         }
         loadtest "console/zypper_lr";
+        loadtest "console/force_cron_run";
         loadtest 'console/enable_usb_repo' if check_var('USBBOOT', 1);
         if (have_addn_repos) {
             loadtest "console/zypper_ar";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -620,6 +620,7 @@ sub load_consoletests() {
             loadtest "console/xorg_vt";
         }
         loadtest "console/zypper_lr";
+        loadtest "console/force_cron_run";
         loadtest 'console/enable_usb_repo' if check_var('USBBOOT', 1);
         if (need_clear_repos()) {
             loadtest "update/zypper_clear_repos";

--- a/tests/console/force_cron_run.pm
+++ b/tests/console/force_cron_run.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Avoid suprises later and run the cron jobs explicitly
+# Maintainer: Stephan Kulow <coolo@suse.de>
+
+use base "consoletest";
+use strict;
+use testapi;
+
+# check if sshd works
+sub run() {
+    select_console 'root-console';
+
+    assert_script_run "test -x /usr/lib/cron/run-crons && bash -x /usr/lib/cron/run-crons";
+    sleep 3;    # some head room for the load to start
+    script_run "top; echo TOP-DONE-\$? > /dev/$serialdev", 0;
+    assert_screen 'top-load-decreased',                    3000;
+    send_key 'q';
+    wait_serial 'TOP-DONE';
+}
+
+sub test_flags() {
+    return {milestone => 1, fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Our data shows pretty clear that the tests type much more unreliable
around the time the first cron.weekly is called (*/15) - and it's
believed that the btrfs maintenance is killing responsiveness
as described in boo#1017461 (and others). So better run these
cron jobs at a given time to avoid random tests becoming unreproducible