### PR TITLE
Increase timeout of run-cron

### DIFF
--- a/tests/console/force_cron_run.pm
+++ b/tests/console/force_cron_run.pm
@@ -18,8 +18,8 @@ use testapi;
 sub run() {
     select_console 'root-console';
 
-    assert_script_run "test -x /usr/lib/cron/run-crons && bash -x /usr/lib/cron/run-crons";
-    sleep 3;    # some head room for the load to start
+    assert_script_run "test -x /usr/lib/cron/run-crons && bash -x /usr/lib/cron/run-crons", 400;
+    sleep 3;    # some head room for the load average to rise
     script_run "top; echo TOP-DONE-\$? > /dev/$serialdev", 0;
     assert_screen 'top-load-decreased',                    3000;
     send_key 'q';


### PR DESCRIPTION
It can take quite a while to do all that indexing that comes with
weekly cronjobs. Especially on real hardware with real disks

Failure https://openqa.suse.de/tests/830157#step/force_cron_run/2