### PR TITLE
Force cron run also for desktop regression tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -947,6 +947,7 @@ elsif (get_var("REGRESSION")) {
         load_reboot_tests();
         loadtest "x11regressions/x11regressions_setup";
         loadtest "console/hostname";
+        loadtest "console/force_cron_run";
         loadtest "shutdown/grub_set_bootargs";
         loadtest "shutdown/shutdown";
     }


### PR DESCRIPTION
We had this problem of regression tests becoming unresponsive at random
times, but meanwhile I know: it's not random, it's */15