### PR TITLE
Ensure password prompt with blinking cursor is found

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -326,7 +326,7 @@ sub wait_boot {
             # In GNOME/gdm, we do not have to enter a username, but we have to select it
             send_key 'ret';
         }
-        assert_screen 'displaymanager-password-prompt';
+        assert_screen 'displaymanager-password-prompt', no_wait => 1;
         type_password $password. "\n";
     }
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -296,7 +296,7 @@ sub workaround_type_encrypted_passphrase {
 sub ensure_unlocked_desktop {
     my $counter = 10;
     while ($counter--) {
-        assert_screen [qw/displaymanager displaymanager-password-prompt generic-desktop screenlock gnome-screenlock-password/];
+        assert_screen [qw(displaymanager displaymanager-password-prompt generic-desktop screenlock gnome-screenlock-password)], no_wait => 1;
         if (match_has_tag 'displaymanager') {
             if (check_var('DESKTOP', 'minimalx')) {
                 type_string "$username";
@@ -775,7 +775,7 @@ sub handle_login {
         # DMs in condition above have to select user
         send_key 'ret';
     }
-    assert_screen "displaymanager-password-prompt";
+    assert_screen 'displaymanager-password-prompt', no_wait => 1;
     type_password;
     send_key "ret";
 }


### PR DESCRIPTION
Fixes https://openqa.opensuse.org/tests/370454#step/user_gui_login/9

Verification run: http://lord.arch.suse.de/tests/6077