### PR TITLE
Add rollback test after migration

### DIFF
--- a/tests/boot/grub_test_snapshot.pm
+++ b/tests/boot/grub_test_snapshot.pm
@@ -16,14 +16,23 @@ use base "basetest";
 use testapi;
 
 sub run() {
-    assert_screen "grub2";
+    if (get_var('ROLLBACK_AFTER_MIGRATION')) {
+        # set BOOT_TO_SNAPSHOT here rather than in main.pm to prevent conflict with existing snapshot tests
+        set_var('BOOT_TO_SNAPSHOT', 1);
+        select_console 'root-console';
+        type_string "reboot\n";
+        assert_screen 'grub2', 200;
+    }
+    else {
+        assert_screen "grub2";
+    }
     # prevent grub2 timeout; 'esc' would be cleaner, but grub2-efi falls to the menu then
     send_key 'up';
     if (get_var("BOOT_TO_SNAPSHOT")) {
         send_key_until_needlematch("boot-menu-snapshot", 'down', 10, 5);
         send_key 'ret';
         # find out the before migration snapshot
-        send_key_until_needlematch("snap-before-update",    'down', 40, 5) if (get_var("UPGRADE"));
+        send_key_until_needlematch("snap-before-update", 'down', 40, 5) if (get_var("UPGRADE") || get_var("ZDUP"));
         send_key_until_needlematch("snap-before-migration", 'down', 40, 5) if (get_var("MIGRATION_ROLLBACK"));
         send_key "ret";
         # bsc#956046  check if we are in first menu-entry, or not


### PR DESCRIPTION
poo#17836
Introduce a new var ROLLBACK_AFTER_MIGRATION to implement migraiton and its rollback in 1 testcase and control the workflow.
It would not break existing relevant tests and retain 2 tests mode for migration and rollback.
Also add rollback test for ZDUP migration.

Verified run:
offline migration and rollback: http://147.2.207.208/tests/440
online migration and rollback: http://147.2.207.208/tests/442
zdup migration and rollback: http://147.2.207.208/tests/447
boot_to_snapshot: http://147.2.207.208/tests/443
rollback from hdd image: http://147.2.207.208/tests/444