### PR TITLE
Wrap assert_screen with !is_serial_terminal()

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -9,7 +9,7 @@ use strict;
 use testapi qw(send_key %cmd assert_screen check_screen check_var get_var save_screenshot
   match_has_tag set_var type_password type_string wait_idle wait_serial
   mouse_hide send_key_until_needlematch record_soft_failure
-  wait_still_screen wait_screen_change);
+  wait_still_screen wait_screen_change is_serial_terminal);
 
 
 sub handle_password_prompt {
@@ -439,8 +439,9 @@ sub console_selected {
     my ($self, $console, %args) = @_;
     $args{await_console} //= 1;
     $args{tags} //= $console;
-    return unless $args{await_console};
-    assert_screen($args{tags}, no_wait => 1);
+    if ($args{await_console} && !is_serial_terminal()) {
+        assert_screen($args{tags}, no_wait => 1);
+    }
 }
 
 1;


### PR DESCRIPTION
Any time assert_screen is used in a common code path for all consoles, we
should check that the console is not a serial terminal.

The alternative to this change is to make await_console 'opt-in' which Oliver is working on. Although there is no harm in making both changes as in the future all text consoles could potentially be a serial terminal on some platforms. Also await_console could be implemented for virtio terminal if necessary.

@okurz @coolo 