### PR TITLE
autoyast console selection improvement

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -247,6 +247,7 @@ sub init_consoles {
     if (get_var('BACKEND', '') =~ /qemu|ipmi|generalhw/ || (check_var('BACKEND', 'svirt') && !get_var('S390_ZKVM'))) {
         $self->add_console('install-shell',  'tty-console', {tty => 2});
         $self->add_console('installation',   'tty-console', {tty => check_var('VIDEOMODE', 'text') ? 1 : 7});
+        $self->add_console('install-shell2', 'tty-console', {tty => 9});
         $self->add_console('root-console',   'tty-console', {tty => 2});
         $self->add_console('user-console',   'tty-console', {tty => 4});
         $self->add_console('log-console',    'tty-console', {tty => 5});

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -229,15 +229,6 @@ sub init_consoles {
         $self->add_console('root-virtio-terminal', 'virtio-terminal', {});
     }
 
-    if (check_var('BACKEND', 'qemu') || check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'generalhw')) {
-        $self->add_console('install-shell', 'tty-console', {tty => 2});
-        $self->add_console('installation',  'tty-console', {tty => check_var('VIDEOMODE', 'text') ? 1 : 7});
-        $self->add_console('root-console',  'tty-console', {tty => 2});
-        $self->add_console('user-console',  'tty-console', {tty => 4});
-        $self->add_console('log-console',   'tty-console', {tty => 5});
-        $self->add_console('x11',           'tty-console', {tty => 7});
-    }
-
     # svirt backend, except s390x ARCH
     if (!get_var('S390_ZKVM') and check_var('BACKEND', 'svirt')) {
         my $hostname = get_var('VIRSH_GUEST');
@@ -251,12 +242,15 @@ sub init_consoles {
                 port     => $port,
                 password => $testapi::password
             });
-        $self->add_console('install-shell', 'tty-console', {tty => 2});
-        $self->add_console('installation',  'tty-console', {tty => check_var('VIDEOMODE', 'text') ? 1 : 7});
-        $self->add_console('root-console',  'tty-console', {tty => 2});
-        $self->add_console('user-console',  'tty-console', {tty => 4});
-        $self->add_console('log-console',   'tty-console', {tty => 5});
-        $self->add_console('x11',           'tty-console', {tty => 7});
+    }
+
+    if (get_var('BACKEND', '') =~ /qemu|ipmi|generalhw/ || (check_var('BACKEND', 'svirt') && !get_var('S390_ZKVM'))) {
+        $self->add_console('install-shell',  'tty-console', {tty => 2});
+        $self->add_console('installation',   'tty-console', {tty => check_var('VIDEOMODE', 'text') ? 1 : 7});
+        $self->add_console('root-console',   'tty-console', {tty => 2});
+        $self->add_console('user-console',   'tty-console', {tty => 4});
+        $self->add_console('log-console',    'tty-console', {tty => 5});
+        $self->add_console('x11',            'tty-console', {tty => 7});
     }
 
     if (check_var('BACKEND', 's390x') || get_var('S390_ZKVM')) {

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -36,7 +36,6 @@ sub save_logs_and_continue {
     my $name = shift;
     # save logs and continue
     select_console 'install-shell';
-    assert_screen ["inst-console"];
 
     # the network may be down with keep_install_network=false
     # use static ip in that case

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -55,11 +55,7 @@ sub save_logs_and_continue {
 
 sub save_logs_in_linuxrc {
     my $name = shift;
-    # tty9 is available in linuxrc
-    send_key "ctrl-alt-f9";
-    send_key "alt-f9";
-    sleep 5;
-    assert_screen ["inst-console"];
+    select_console 'install-shell2', tags => 'install-shell';
 
     # save_y2logs is not present
     assert_script_run "tar czf /tmp/logs-$name.tar.bz2 /var/log";


### PR DESCRIPTION
* Replace custom linuxrc shell tty9 selection with console
* DRY on consoles initialization
* Delete redundant assert_screen after self-checking select_console