### PR TITLE
parted: never prompt for user intervention

### DIFF
--- a/tests/console/gpt_ptable.pm
+++ b/tests/console/gpt_ptable.pm
@@ -1,19 +1,15 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: refactor jeos tests a bit
-#    - simplyfy by using assert_script_run instead of
-#      validate_script_output
-#    - move some of the more generic ones to console/
-#    - make vim test actually run vim
-# G-Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+# Summary: Verify that disks have a GPT partition label
+# Maintainer: Michal Nowak <mnowak@suse.com>
 
 use base "consoletest";
 use strict;
@@ -21,7 +17,7 @@ use testapi;
 
 # verify that the disks have a gpt partition label
 sub run() {
-    assert_script_run("parted -ml | grep '^/dev/.*:gpt:'", fail_message => 'no gpt partition table found');
+    assert_script_run("parted -mls | grep '^/dev/.*:gpt:'", fail_message => 'no gpt partition table found');
 }
 
 1;


### PR DESCRIPTION
Sometimes a supposedly broken GPT header is claimed and `parted` stops
with a question wrt to a "fix". `-s` will prevent the question.

See bsc#1029712 for why such problems are not going to be fixed.