### PR TITLE
No longer load separate check_console_font test modules

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -330,7 +330,6 @@ sub load_yast2_ui_tests {
     # setup $serialdev permission and so on
     loadtest "console/consoletest_setup";
     loadtest "console/hostname";
-    loadtest "console/check_console_font";
     loadtest "console/zypper_lr";
     loadtest "console/zypper_ref";
     # start extra yast console test from here
@@ -454,7 +453,6 @@ sub load_extra_tests() {
         }
     }
     else {
-        loadtest "console/check_console_font";
         loadtest "console/zypper_lr";
         loadtest "console/openvswitch";
         # dependency of git test

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -463,7 +463,6 @@ sub load_consoletests() {
     elsif (is_staging() && get_var('UEFI') || is_gnome_next || is_krypton_argon) {
         # Stagings should test yast2-bootloader in miniuefi at least but not all
         loadtest "console/consoletest_setup";
-        loadtest "console/check_console_font";
         loadtest "console/textinfo";
         loadtest "console/hostname";
         if (!get_var("LIVETEST")) {
@@ -698,7 +697,6 @@ sub load_applicationstests {
     if (get_var('BOOT_HDD_IMAGE')) {
         @tests = (
             'console/consoletest_setup',
-            'console/check_console_font',
             'console/import_gpg_keys',
             'update/zypper_up',
             'console/install_packages',


### PR DESCRIPTION
With commit 4db5c4e516 the functionality of this test has been merged
into consoletest_setup