### PR TITLE
firefox_java module: Placing the Verify Java version button click before the security check

### DIFF
--- a/tests/x11regressions/firefox/sle12/firefox_java.pm
+++ b/tests/x11regressions/firefox/sle12/firefox_java.pm
@@ -26,6 +26,10 @@ sub java_testing {
     if (check_screen 'firefox-reader-view') {
         assert_and_click('firefox-reader-close');
     }
+
+    # Click the "Verify Java version" button
+    assert_and_click "firefox-java-verifyversion";
+
     check_screen([qw(firefox-java-security oracle-cookies-handling)]);
     if (match_has_tag 'firefox-java-security') {
         assert_and_click('firefox-java-securityrun');
@@ -35,8 +39,6 @@ sub java_testing {
     if (match_has_tag "oracle-cookies-handling") {
         assert_and_click "firefox-java-agree-and-proceed";
     }
-    #Click the "Verify Java version" button
-    assert_and_click "firefox-java-verifyversion";
 }
 
 sub run() {


### PR DESCRIPTION
In the firefox_java module, the click on the Verify Java version button occurred after the security check part, which eventually caused the test to fail:
https://openqa.suse.de/tests/831928#step/firefox_java/21

This commit moves clicking the Verify button before the firefox-java-security check.

Passing now on my local OpenQA instance: http://dreamyhamster.suse.cz/tests/147#step/firefox_java/18

Related to poo#17898