### PR TITLE
Prevent typing too early into shell

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -405,6 +405,7 @@ sub activate_console {
         }
         assert_screen "text-logged-in-$user";
         $self->set_standard_prompt($user);
+        assert_screen $console;
 
         # On s390x 'setterm' binary is not present as there's no linux console
         if (!check_var('ARCH', 's390x')) {


### PR DESCRIPTION
This was not really causing an error but confusing screenshot. Typing before a
bash prompt becomes ready and executing that afterwards is valid behaviour but
we can wait a little bit more by waiting for the prompt to be ready which is
also what most users would do anyway.

Fixes https://openqa.suse.de/tests/832883#step/transactional_update/26