### PR TITLE
Make sure the cron jobs don't interfere with extratests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1312,6 +1312,7 @@ if (get_var("CLONE_SYSTEM")) {
 if (get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1")) {
     if (get_var("INSTALLONLY")) {
         loadtest "console/hostname";
+        loadtest "console/force_cron_run";
         loadtest "shutdown/grub_set_bootargs";
         loadtest "shutdown/shutdown";
         if (check_var("BACKEND", "svirt")) {


### PR DESCRIPTION
The btrfs maintenance can be very annoying - especially if
testing btrfs features at around the time they kick in,
e.g. https://openqa.suse.de/tests/835137#step/btrfs_qgroups/4