### PR TITLE
Use multi ISOs as repos for zdup migration

### DIFF
--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -88,8 +88,11 @@ sub run() {
                        esac
                        done
                        [ -z \$dev ] || echo \"found dev \$dev with label \$label\"";
-            # if that fails, e.g. if volume descriptor too long, just try /dev/sr0
-            $defaultrepo = "dvd:/?devices=\${dev:-/dev/sr0}";
+            # get all attached ISOs including addons' as zdup dup repos
+            my $srx = script_output("ls -al /dev/disk/by-label | grep -E /sr[0-9]+ | wc -l");
+            for my $n (0 .. $srx - 1) {
+                $defaultrepo .= "dvd:/?devices=\${dev:-/dev/sr$n}+";
+            }
         }
     }
 


### PR DESCRIPTION
poo#17946
SLE zdup migration commonly use attached ISO as repo to do dist upgrade.
Get all attached ISOs including addons' as repos to do dist upgrade for zdup migration with addons.

Verified runs:
http://147.2.207.208/tests/452
http://147.2.207.208/tests/453
http://147.2.207.208/tests/455