### PR TITLE
Without the setup succeeding, there is no point continuing

### DIFF
--- a/tests/x11regressions/x11regressions_setup.pm
+++ b/tests/x11regressions/x11regressions_setup.pm
@@ -29,7 +29,7 @@ sub run() {
 
 # add milestone flag to save setup in lastgood vm snapshot
 sub test_flags() {
-    return {milestone => 1};
+    return {milestone => 1, fatal => 1};
 }
 
 1;


### PR DESCRIPTION
(as the test is not even important, isotvideo continued uploading
images totally broken)

https://openqa.suse.de/tests/834235#step/x11regressions_setup/8 leading to https://openqa.suse.de/tests/834229#step/piglit/19

And as restarting the installation job won't update the HDDs in worker cache, this is a real problem