### PR TITLE
Reset consoles when rebooting into snapshot

### DIFF
--- a/tests/boot/grub_test_snapshot.pm
+++ b/tests/boot/grub_test_snapshot.pm
@@ -21,6 +21,7 @@ sub run() {
         set_var('BOOT_TO_SNAPSHOT', 1);
         select_console 'root-console';
         type_string "reboot\n";
+        reset_consoles;
         assert_screen 'grub2', 200;
     }
     else {

--- a/tests/online_migration/sle12_online_migration/snapper_rollback.pm
+++ b/tests/online_migration/sle12_online_migration/snapper_rollback.pm
@@ -40,11 +40,11 @@ sub run() {
     }
 
     select_console 'root-console';
-    wait_still_screen;
     script_run "snapper rollback";
 
     # reboot into the system before online migration
     script_run("systemctl reboot", 0);
+    reset_consoles;
     $self->wait_boot(textmode => !is_desktop_installed);
     select_console 'root-console';
 


### PR DESCRIPTION
All snapper rollback tests were failed.
No idea about the failure of select root-console after booting into snapshot:
https://openqa.suse.de/tests/837775#step/snapper_rollback/4
https://openqa.suse.de/tests/837764#step/snapper_rollback/3
https://openqa.suse.de/tests/837680#step/snapper_rollback/3

Verified runs work with log console:
http://147.2.207.208/tests/448#step/snapper_rollback/5
http://147.2.207.208/tests/442#step/snapper_rollback/5 