### PR TITLE
Exclude non-existant applications from test on kde-live

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -28,8 +28,9 @@ our @EXPORT = qw(
   clear_console
   is_jeos
   is_casp
-  is_gnome_next
   is_krypton_argon
+  is_kde_live
+  is_gnome_next
   select_kernel
   type_string_slow
   type_string_very_slow
@@ -195,6 +196,10 @@ sub is_jeos() {
 
 sub is_krypton_argon {
     return get_var('FLAVOR') =~ /(Krypton|Argon)/;
+}
+
+sub is_kde_live {
+    return get_var('FLAVOR') =~ /KDE-Live/;
 }
 
 sub is_gnome_next {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -532,8 +532,9 @@ sub load_x11tests() {
     if (kdestep_is_applicable()) {
         loadtest "x11/kate";
     }
-    loadtest "x11/firefox";
-    if (!get_var("OFW") && check_var('BACKEND', 'qemu')) {
+    # no firefox on KDE-Live # boo#1022499
+    loadtest "x11/firefox" unless is_kde_live;
+    if (!get_var("OFW") && check_var('BACKEND', 'qemu') && !is_kde_live) {
         loadtest "x11/firefox_audio";
     }
     if (gnomestep_is_applicable() && !(get_var("LIVECD") || is_server)) {
@@ -552,7 +553,7 @@ sub load_x11tests() {
         loadtest "x11/oomath";
         loadtest "x11/oocalc";
     }
-    if (get_var("DESKTOP") =~ /kde|gnome/ && !is_server && !is_krypton_argon && !is_gnome_next) {
+    if (get_var("DESKTOP") =~ /kde|gnome/ && !is_server && !is_kde_live && !is_krypton_argon && !is_gnome_next) {
         loadtest "x11/ooffice";
     }
     if (kdestep_is_applicable()) {


### PR DESCRIPTION
Firefox is not on KDE-Live and will not return soon, see
https://bugzilla.suse.com/show_bug.cgi?id=1022499