### PR TITLE
Disable force_cron_run module on JeOS

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -402,7 +402,7 @@ sub load_consoletests() {
             loadtest "console/xorg_vt";
         }
         loadtest "console/zypper_lr";
-        loadtest "console/force_cron_run";
+        loadtest "console/force_cron_run" if !is_jeos;
         loadtest 'console/enable_usb_repo' if check_var('USBBOOT', 1);
         if (have_addn_repos) {
             loadtest "console/zypper_ar";

--- a/tests/console/force_cron_run.pm
+++ b/tests/console/force_cron_run.pm
@@ -18,7 +18,7 @@ use testapi;
 sub run() {
     select_console 'root-console';
 
-    assert_script_run "test -x /usr/lib/cron/run-crons && bash -x /usr/lib/cron/run-crons", 1000;
+    assert_script_run "bash -x /usr/lib/cron/run-crons", 1000;
     sleep 3;    # some head room for the load average to rise
     script_run "top; echo TOP-DONE-\$? > /dev/$serialdev", 0;
     # let the load settle


### PR DESCRIPTION
JeOS does not have cron installed, so the test fails.

Before: https://openqa.opensuse.org/tests/375959#step/force_cron_run/5
After: https://tortuga.suse.de/tests/1873