### PR TITLE
Add a case of remote desktop via xdmcp_xdm to x11regressions

### DIFF
--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -253,6 +253,10 @@ sub setup_xvnc_server {
 sub setup_xdmcp_server {
     return if $xdmcp_server_set;
 
+    if (check_var('REMOTE_DESKTOP_TYPE', 'xdmcp_xdm')) {
+        script_run "sed -i -e 's|^DISPLAYMANAGER=.*|DISPLAYMANAGER=\"xdm\"|' /etc/sysconfig/displaymanager";
+        script_run "sed -i -e 's|^DEFAULT_WM=.*|DEFAULT_WM=\"icewm\"|' /etc/sysconfig/windowmanager";
+    }
     script_run 'yast2 firewall services add zone=EXT service=service:xdmcp';
     script_run "sed -i -e 's|^DISPLAYMANAGER_REMOTE_ACCESS=.*|DISPLAYMANAGER_REMOTE_ACCESS=\"yes\"|' /etc/sysconfig/displaymanager";
     script_run "sed -i -e 's|^\\[xdmcp\\]|\\[xdmcp\\]\\nMaxSessions=2|' /etc/gdm/custom.conf";

--- a/tests/x11regressions/remote_desktop/onetime_vncsession_multilogin_failed.pm
+++ b/tests/x11regressions/remote_desktop/onetime_vncsession_multilogin_failed.pm
@@ -77,7 +77,6 @@ sub run() {
     send_key 'x';
 
     mutex_unlock 'xvnc';
-    assert_screen 'generic-desktop';
 }
 
 1;

--- a/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_java.pm
+++ b/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_java.pm
@@ -76,7 +76,6 @@ sub run() {
     $self->exit_firefox;
 
     mutex_unlock 'xvnc';
-    assert_screen 'generic-desktop';
 }
 
 1;

--- a/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_tigervnc.pm
+++ b/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_tigervnc.pm
@@ -70,7 +70,6 @@ sub run() {
     send_key 'x';
 
     mutex_unlock 'xvnc';
-    assert_screen 'generic-desktop';
 }
 
 1;

--- a/tests/x11regressions/remote_desktop/persistent_vncsession_xvnc.pm
+++ b/tests/x11regressions/remote_desktop/persistent_vncsession_xvnc.pm
@@ -114,7 +114,6 @@ sub run() {
     send_key 'ret';
 
     mutex_unlock 'xvnc';
-    assert_screen 'generic-desktop';
 }
 
 1;

--- a/tests/x11regressions/remote_desktop/xdmcp_xdm.pm
+++ b/tests/x11regressions/remote_desktop/xdmcp_xdm.pm
@@ -13,16 +13,14 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
-# Summary: Remote Login: XDMCP with gdm and SLE-Classic configured
+# Summary: Remote Login: XDMCP with xdm and icewm configured
 # Maintainer: Chingkai <qkzhu@suse.com>
-# Tags: tc#1586203
+# Tags: tc#1586204
 
 use strict;
-use base 'basetest';
 use base 'x11test';
 use testapi;
 use lockapi;
-use utils;
 
 sub run() {
     # Wait for supportserver if not yet ready
@@ -39,13 +37,13 @@ sub run() {
     type_string "exit\n";
 
     # Remote access SLES via Xephyr
-    type_string "Xephyr -query 10.0.2.1 -screen 1024x768+0+0 -terminate :1\n";
-    assert_screen 'xdmcp-gdm', 90;
-    send_key 'ret';
-    assert_screen 'xdmcp-login-gdm';
+    type_string "Xephyr -query 10.0.2.1 -terminate :1\n";
+    assert_screen 'xdmcp-xdm', 90;
+    type_string "$username\n";
+    wait_still_screen 3;
     type_password;
     send_key 'ret';
-    assert_screen 'xdmcp-gdm-generic-desktop';
+    assert_screen 'xdmcp-icewm-generic-desktop';
     send_key 'alt-f4';    # Close Xephyr
     wait_still_screen 3;
     send_key 'alt-f4';    # Close xterm


### PR DESCRIPTION
SLED try to run Xephyr -query to check if you get xdm prompt on the SLES with XDMCP enabled in xdm and icewm

see also: poo#9504

Validations:
Client: http://147.2.212.115/tests/429
Server: http://147.2.212.115/tests/428
