### PR TITLE
Use type_string for background process

### DIFF
--- a/tests/toolchain/gcc5_C_compilation.pm
+++ b/tests/toolchain/gcc5_C_compilation.pm
@@ -19,7 +19,7 @@ sub run() {
     my $self = shift;
 
     script_run 'zypper -v -n in sysstat';
-    script_run('pidstat -p ALL 1 > /tmp/pidstat.txt &');
+    type_string 'pidstat -p ALL 1 > /tmp/pidstat.txt &';
 
     # Fixes https://github.com/linux-test-project/ltp/issues/91
     script_run 'wget ' . data_url('toolchain/794b46d9.patch');


### PR DESCRIPTION
Fails here:
https://openqa.suse.de/tests/837552#step/gcc5_Cpp_compilation/3