### PR TITLE
The extra online repositories dialog has been removed

### DIFF
--- a/tests/installation/livecd_network_settings.pm
+++ b/tests/installation/livecd_network_settings.pm
@@ -19,9 +19,6 @@ use testapi;
 sub run() {
     assert_screen 'inst-network_settings-livecd';
     send_key $cmd{next};
-    # LIVECD installer assumes online repos at this point
-    wait_still_screen;
-    wait_screen_change { send_key $cmd{next}; };
 }
 
 1;


### PR DESCRIPTION
This fixes the issue in the Tumbleweed Live installation, see https://openqa.opensuse.org/tests/377450#

The extra online repositories dialog has been removed, now it is part of the desktop selection dialog. See e.g. https://openqa.opensuse.org/tests/377467#step/installer_desktopselection/1, there is a new *Configure On-line Repositories* button.

The extra *Next* button click causes the workflow to go one more dialog further and this breaks the screen assertion in the next test.

Note: This change is designed for Tumbleweed only, if the same code is used for testing some older distribution we would need to check the `NEW_DESKTOP_SELECTION` variable.

Note2: I haven't actually executed the updated test and I'm not familiar with openQA testing, please check it thoroughly, esp. in relation to the other tests.