### PR TITLE
Handle conflict between julia,-devel and julia-compat,-devel

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -148,6 +148,8 @@ sub problem_can_be_skipped {
     }
     # conflicts with firebird-classic
     return 1 if $pkg =~ /firebird-superserver/;
+    # conflict with julia, julia-devel, respectively
+    return 1 if $pkg =~ /^julia-compat(-devel)?/;
 
     return;
 }


### PR DESCRIPTION
`julia-compat` conflicts with `otherproviders(julia)` which is `julia`, similarly for `julia-compat-devel`.

Fixes:
https://openqa.opensuse.org/tests/377713#step/install_packages/9
https://openqa.opensuse.org/tests/377714#step/install_packages/9
https://openqa.opensuse.org/tests/377715#step/install_packages/9
https://openqa.opensuse.org/tests/377723#step/install_packages/9
https://openqa.opensuse.org/tests/377724#step/install_packages/9
https://openqa.opensuse.org/tests/377725#step/install_packages/9