### PR TITLE
textinfo: /var/log/messages might not exist

### DIFF
--- a/data/textinfo
+++ b/data/textinfo
@@ -16,7 +16,7 @@ rpm -qa 'kernel-*'
 grep DISPLAYMANAGER /etc/sysconfig/displaymanager
 grep DEFAULT /etc/sysconfig/windowmanager
 ls -l /etc/ntp*
-du /var/log/messages
+[ -f /var/log/messages ] && du /var/log/messages
 ps ax
 systemctl --no-pager --full
 rpm -qa | sort


### PR DESCRIPTION
Fixes https://openqa.opensuse.org/tests/377914#step/textinfo/4