### PR TITLE
Fix textinfo for non-btrfs

### DIFF
--- a/data/textinfo
+++ b/data/textinfo
@@ -5,7 +5,7 @@ lsmod
 free
 cat /etc/fstab
 mount
-/usr/sbin/btrfs filesystem df /
+mount | grep -q '/ type btrfs' && /usr/sbin/btrfs filesystem df /
 df -h
 ip -o a s
 ip r s


### PR DESCRIPTION
Fixes https://openqa.opensuse.org/tests/377898#step/textinfo/4