### PR TITLE
Make sure root console is selected in post fail hook

### DIFF
--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -18,10 +18,11 @@ sub post_run_hook {
 
 sub post_fail_hook {
     my ($self) = shift;
+    select_console('root-console');
     $self->SUPER::post_fail_hook;
 
     # Export logs after failure
-    script_run "journalctl --no-pager -b 0 > /tmp/full_journal.log";
+    assert_script_run("journalctl --no-pager -b 0 > /tmp/full_journal.log");
     upload_logs "/tmp/full_journal.log";
 }
 


### PR DESCRIPTION
When test switched to unprivileged user mode and fail we also failing to
post process the failure because post_fail_hook expect root console.
Fixed that by explicitly selecting root console.