### PR TITLE
gedit: Improve reliability of save-changes dialog handling

### DIFF
--- a/tests/x11/gedit.pm
+++ b/tests/x11/gedit.pm
@@ -21,7 +21,8 @@ sub run() {
     assert_screen 'gedit-launched';
     $self->enter_test_text('gedit');
     assert_screen 'test-gedit-1';
-    wait_screen_change { send_key 'alt-f4' };
+    send_key 'alt-f4';
+    assert_screen 'gedit-save-changes';
     send_key 'alt-w';
 }
 


### PR DESCRIPTION
Related openSUSE needle change:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/178

Related progress issue: https://progress.opensuse.org/issues/16216

Verification run: http://lord.arch/tests/6098