### PR TITLE
Use ISO images where available

### DIFF
--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -109,19 +109,20 @@ sub run() {
             });
     }
 
-    my $isodir = '/var/lib/openqa/share/factory/iso';
-    # In JeOS and netinstall we don't have ISO media, for the rest we have to attach it.
-    if (!get_var('NETBOOT') and !is_jeos() and !get_var('HDD_1')) {
-        my $isofile = get_required_var('ISO');
-        my $isopath = copy_image($isofile, $isodir);
-        $svirt->add_disk(
-            {
-                cdrom     => 1,
-                file      => ($vmm_family eq 'vmware') ? basename($isopath) : $isopath,
-                dev_id    => 'b',
-                bootorder => 2
-            });
-
+    # Add cdrom devices where required
+    if (get_var('ISO') || get_var('ISO_1')) {
+        my $isodir = '/var/lib/openqa/share/factory/iso';
+        if (get_var('ISO')) {
+            my $isofile = get_var('ISO');
+            my $isopath = copy_image($isofile, $isodir);
+            $svirt->add_disk(
+                {
+                    cdrom     => 1,
+                    file      => ($vmm_family eq 'vmware') ? basename($isopath) : $isopath,
+                    dev_id    => 'b',
+                    bootorder => 2
+                });
+        }
         # Add addon media (if present at all)
         my $dev_id = 'c';
         foreach my $n (1 .. 9) {


### PR DESCRIPTION
Previously ISO images were added only for jobs without HDD_1 variable
set, now there are added if they are defined be it VM deployed from
HDD_1 or installed from ISO.

Be it change in Xen on the VM host or fallout from PR#2612 and
os-autoinst/PR#742, Xen is refusing images in ISO format being added as
hard disks, from now on they are added as cdroms.

Verification runs:
* Xen HVM: http://assam.suse.cz/tests/5528
* Xen PV: http://assam.suse.cz/tests/5530