### PR TITLE
[kernel/install_ltp] Fix the "bash syntax error" problem

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -79,7 +79,7 @@ sub run {
     if ($inst_ltp =~ /git/i) {
         install_dependencies;
         # bsc#1024050 - Watch for Zombies
-        script_run('pidstat -p ALL 1 > /tmp/pidstat.txt &');
+        type_string "pidstat -p ALL 1 > /tmp/pidstat.txt &\n";
         install_from_git;
     }
     elsif ($inst_ltp =~ /repo/i) {


### PR DESCRIPTION
If this shell command is run by "script_run", openQA will add " ; echo random_string > /dev/ttyS0" behind it, causing bash syntax error. This commit replaces "script_run" with "type_string".

Example here: https://openqa.suse.de/tests/844464#step/install_ltp/18

@richiejp 