### PR TITLE
CaaSP: Modified confirmation message

### DIFF
--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -59,7 +59,7 @@ sub trup_call {
 
     script_run "transactional-update $cmd", 0;
     if ($cmd =~ /ptf /) {
-        if (wait_serial "\QContinue? [y/n/? shows all options] (y):") {
+        if (wait_serial "\QContinue? [y/n/...? shows all options] (y):") {
             send_key "ret";
         }
         else {


### PR DESCRIPTION
This is respun of @kravciak's
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/2660.
I believe we actually need this change. From build 15.27 this
confirmation message changed by whatever package changed.

Fail: https://openqa.suse.de/tests/844298#step/transactional_update/11
Verification run: http://assam.suse.cz/tests/5537