### PR TITLE
Virtualization: sle11 support enhancement

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -21,8 +21,18 @@ use virt_utils;
 sub login_to_console() {
     my $timeout = shift;
     $timeout //= 300;
+
+    #setup needle tag
+    my $displaymanager_tag = "displaymanager";
+    if (check_var("INSTALL_TO_SLE11", "yes")) {
+        $displaymanager_tag = "displaymanager-sle11";
+    }
+    if (check_var("reboot_for_upgrade_step", "yes") || check_var("after_upgrade", "yes")) {
+        $displaymanager_tag = "displaymanager";
+    }
+
     # Wait for bootload for the first time.
-    assert_screen([qw(grub2 grub)], 120);
+    assert_screen([qw(grub2 grub1)], 120);
     if (!get_var("reboot_for_upgrade_step")) {
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
             send_key_until_needlematch("virttest-bootmenu-xen-kernel", 'down', 10, 1);
@@ -31,9 +41,10 @@ sub login_to_console() {
     }
     else {
         set_var("reboot_for_upgrade_step", undef);
+        set_var("after_upgrade",           "yes");
     }
 
-    assert_screen(["displaymanager", "virttest-displaymanager"], $timeout);
+    assert_screen(["$displaymanager_tag", "virttest-displaymanager"], $timeout);
 
     select_console('root-console');
 }


### PR DESCRIPTION
Changes:
* use different displaymanager tag to distinguish sle11 and sle12
* use grub1 to stand for grub of sle11, instead of grub

This request works cooperatively with needle request https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/328

Verification link
http://147.2.212.135/tests/948
http://147.2.212.135/tests/946
http://147.2.212.135/tests/952