### PR TITLE
yast2_data: Bump timeout of deleting testdata

### DIFF
--- a/tests/x11/yast2_snapper.pm
+++ b/tests/x11/yast2_snapper.pm
@@ -47,7 +47,7 @@ sub clean_and_quit() {
     wait_screen_change { send_key "alt-l" };
     # Wait until xterm is focussed, delete the directory and close xterm
     wait_idle;
-    script_run "rm -rf testdata";
+    script_run 'rm -rf testdata', 300;
     script_run "ls";
     type_string "exit\n";
     save_screenshot;


### PR DESCRIPTION
Fixes https://openqa.suse.de/tests/846241#step/yast2_snapper/45