### PR TITLE
opensuse migration then rollback and zdup fix

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -43,6 +43,7 @@ our @EXPORT = qw(
   load_yast2_ui_tests
   maybe_load_kernel_tests
   load_extra_tests
+  load_rollback_tests
 );
 
 sub init_main {
@@ -515,6 +516,16 @@ sub load_extra_tests() {
         }
     }
     return 1;
+}
+
+sub load_rollback_tests() {
+    loadtest "boot/grub_test_snapshot";
+    if (get_var('UPGRADE') || get_var('ZDUP')) {
+        loadtest "boot/snapper_rollback";
+    }
+    if (get_var('MIGRATION_ROLLBACK')) {
+        loadtest "online_migration/sle12_online_migration/snapper_rollback";
+    }
 }
 
 1;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -632,7 +632,7 @@ sub load_x11tests() {
             loadtest "x11/chrome";
         }
     }
-    # Need to skip shutdown to keep beckend alive if run rollback tests after migration
+    # Need to skip shutdown to keep backend alive if running rollback tests after migration
     unless (get_var('ROLLBACK_AFTER_MIGRATION')) {
         loadtest "x11/shutdown";
     }

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -632,8 +632,10 @@ sub load_x11tests() {
             loadtest "x11/chrome";
         }
     }
-
-    loadtest "x11/shutdown";
+    # Need to skip shutdown to keep beckend alive if run rollback tests after migration
+    unless (get_var('ROLLBACK_AFTER_MIGRATION')) {
+        loadtest "x11/shutdown";
+    }
 }
 
 sub install_online_updates {
@@ -884,6 +886,9 @@ else {
         load_rescuecd_tests();
         load_consoletests();
         load_x11tests();
+        if (get_var('ROLLBACK_AFTER_MIGRATION') && (snapper_is_applicable())) {
+            load_rollback_tests();
+        }
     }
 }
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -946,16 +946,6 @@ sub prepare_target() {
     }
 }
 
-sub load_rollback_tests() {
-    loadtest "boot/grub_test_snapshot";
-    if (get_var('UPGRADE') || get_var('ZDUP')) {
-        loadtest "boot/snapper_rollback";
-    }
-    if (get_var('MIGRATION_ROLLBACK')) {
-        loadtest "online_migration/sle12_online_migration/snapper_rollback";
-    }
-}
-
 # load the tests in the right order
 if (maybe_load_kernel_tests()) {
 }

--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -31,6 +31,14 @@ sub run() {
         # script_sudo "/sbin/init 3";
 
         select_console('root-console');
+        # Create a snapshot with specified description to do snapper rollback
+        # This action is concerned about following points:
+        # 1. Source image could be original installation or updated
+        # 2. Source image may apply patches before migration
+        # 3. Hard to assert similar snapshots in grub2
+        # 4. Menu of each snapshot is long with openSUSE leap, use short and unique description
+        # 5. Avoid rollback to snapshot without graphical target
+        assert_script_run "snapper create --type pre --cleanup-algorithm=number --print-number --userdata important=yes --description 'b_zdup migration'";
 
         # Remove the --force when this is fixed:
         # https://bugzilla.redhat.com/show_bug.cgi?id=1075131


### PR DESCRIPTION
see: https://progress.opensuse.org/issues/17836
Followed by #2587 

verified runs:
http://147.2.207.208/tests/463
http://147.2.207.208/tests/470