### PR TITLE
Fix registration in patch before migration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -110,7 +110,7 @@ sub fill_in_registration_data {
                     # The actions of selecting scc addons have been changed on SP2 or later in textmode
                     # For online migration, we have to do registration on pre-created HDD, set a flag
                     # to distinguish the sle version of HDD and perform addons selection based on it
-                    if (get_var('ONLINE_MIGRATION')) {
+                    if (get_var('ONLINE_MIGRATION') || get_var('PATCH')) {
                         select_addons_in_textmode($addon, get_var('HDD_SP2ORLATER'));
                     }
                     else {

--- a/tests/update/patch_before_migration.pm
+++ b/tests/update/patch_before_migration.pm
@@ -24,7 +24,10 @@ sub system_prepare() {
 sub patching_sle() {
     set_var("VIDEOMODE",    'text');
     set_var("SCC_REGISTER", 'installation');
-    set_var("SP2ORLATER",   '0') if get_var('HDDVERSION', '12');
+    # remember we perform registration on pre-created HDD images
+    if (sle_version_at_least('12-SP2', version_variable => 'HDDVERSION')) {
+        set_var('HDD_SP2ORLATER', 1);
+    }
 
     # stop packagekit service
     script_run "systemctl mask packagekit.service";


### PR DESCRIPTION
Aim to fix registration with addons in cases of patch hdd before migration:
https://openqa.suse.de/tests/846507

Verified runs:
sp2: http://147.2.207.208/tests/471
sp1: http://147.2.207.208/tests/472