### PR TITLE
Remove assert_screen "yast2_control-center_remote-administration_display-manager-warning"

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -328,8 +328,6 @@ sub run() {
     assert_and_click "yast2_control-center_remote-administration";
     assert_screen "yast2_control-center_remote-administration_ok", 60;
     send_key "alt-o";
-    assert_screen "yast2_control-center_remote-administration_display-manager-warning";
-    send_key "alt-o";
     assert_screen 'yast2-control-center-ui';
 
     #   start Samba Server


### PR DESCRIPTION
I've checked https://openqa.suse.de/tests/852009 for test results.
I found that the needle "yast2_control-center_remote-administration_display-manager-warning" is not needed anymore. This leads to the failure. 
