### PR TITLE
LTP: Try to install GCC 32-bit binaries

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -47,7 +47,11 @@ sub install_dependencies {
     }
     zypper_call('in ' . join(' ', @deps), log => 'install-deps.txt');
 
-    script_run('zypper -n in net-tools-deprecated');
+    my @maybe_deps = qw(net-tools-deprecated gcc-32bit);
+
+    for my $dep (@maybe_deps) {
+        script_run('zypper -n in ' . $dep);
+    }
 }
 
 sub install_from_git {


### PR DESCRIPTION
Soon LTP will support -m32 (32-bit compat mode) for individual tests so we
need to install the 32-bit library binaries and headers for glibc and
GCC. Instead of listing all the necessary libs, we can just install
gcc-32bit. If gcc-32bit is missing we do not want to fail here, the LTP build
system will deal with it and we will get TCONF for the effected tests.

@pevik 