### PR TITLE
Exclude yast2_nfs_server from JeOS

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -445,7 +445,7 @@ sub load_consoletests() {
             loadtest "console/sshfs";
         }
         loadtest "console/mtab";
-        if (!get_var("NOINSTALL") && !get_var("LIVETEST") && (check_var("DESKTOP", "textmode"))) {
+        if (!get_var("NOINSTALL") && !get_var("LIVETEST") && (check_var("DESKTOP", "textmode")) && !is_jeos) {
             if (check_var('BACKEND', 'qemu')) {
                 # The NFS test expects the IP to be 10.0.2.15
                 loadtest "console/yast2_nfs_server";


### PR DESCRIPTION
poo#18218

On JeOS (kernel-default-base) we don't have `nfsd` kernel module.

@Vogtinator 