### PR TITLE
Remove workaround btrfs quota on same file

### DIFF
--- a/tests/console/btrfs_qgroups.pm
+++ b/tests/console/btrfs_qgroups.pm
@@ -71,7 +71,7 @@ sub run() {
     # Check for bsc#993841
     assert_script_run "btrfs subvolume create e";
     assert_script_run "btrfs qgroup limit 50m e .";
-    assert_script_run "! for c in {1..40}; do dd if=/dev/zero bs=1M count=40 of=e/file; done";
+    assert_script_run "for c in {1..40}; do dd if=/dev/zero bs=1M count=40 of=e/file; done";
     script_run "sync";
     assert_script_run("rm e/file", fail_message => 'bsc#993841');
 


### PR DESCRIPTION
Related to https://bugzilla.suse.com/show_bug.cgi?id=1032274

Since the bug [bsc#1019614](https://bugzilla.suse.com/show_bug.cgi?id=1019614) is fixed, the test fails because the command doesn't show the "expected" error code.