### PR TITLE
Do not run yast2_nfs_server on JeOS

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -445,8 +445,8 @@ sub load_consoletests() {
             loadtest "console/sshfs";
         }
         loadtest "console/mtab";
-        if (!get_var("NOINSTALL") && !get_var("LIVETEST") && (check_var("DESKTOP", "textmode")) && !is_jeos) {
-            if (check_var('BACKEND', 'qemu')) {
+        if (!get_var("NOINSTALL") && !get_var("LIVETEST") && (check_var("DESKTOP", "textmode"))) {
+            if (check_var('BACKEND', 'qemu') && !is_jeos) {
                 # The NFS test expects the IP to be 10.0.2.15
                 loadtest "console/yast2_nfs_server";
             }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -672,7 +672,7 @@ sub load_consoletests() {
             loadtest "console/no_perl_bootloader";
         }
         if (!get_var("NOINSTALL") && !is_desktop && (check_var("DESKTOP", "textmode"))) {
-            if (!is_staging() && check_var('BACKEND', 'qemu')) {
+            if (!is_staging() && check_var('BACKEND', 'qemu') && !is_jeos) {
                 # The NFS test expects the IP to be 10.0.2.15
                 loadtest "console/yast2_nfs_server";
             }


### PR DESCRIPTION
poo#18218

In commit afbf12eb8556f7f977d8f5a30f8ba0365e321e04 I removed much more
tests than intended. Fixing that for openSUSE and providing the change
for SLE as well.