### PR TITLE
Install expect where needed

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -30,7 +30,7 @@ sub setup_apache2 {
         $mode = "NSSFIPS";
     }
     if ($mode =~ m/NSS/) {
-        push @packages, qw(apache2-mod_nss mozilla-nss-tools);
+        push @packages, qw(apache2-mod_nss mozilla-nss-tools expect);
     }
 
     # Make sure the packages are installed


### PR DESCRIPTION
https://openqa.suse.de/tests/856509#step/apache_nss/28

We don't have it on JeOS by default.