### PR TITLE
Fix PS1 variable to prevent overwriting on overly long lines

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -197,10 +197,10 @@ sub set_standard_prompt {
     $user ||= $testapi::username;
     if ($user eq 'root') {
         # set standard root prompt
-        type_string "PS1=\"\$(tput bold 2; tput setaf 1)#\$(tput sgr0) \"\n";
+        type_string "PS1=\"\\\[\$(tput bold 2; tput setaf 1)\\\]#\\\[\$(tput sgr0)\\\] \"\n";
     }
     else {
-        type_string "PS1=\"\$(tput bold 2; tput setaf 1)\\\$\$(tput sgr0) \"\n";
+        type_string "PS1=\"\\\[\$(tput bold 2; tput setaf 1)\\\]\\\$\\\[\$(tput sgr0)\\\] \"\n";
     }
 }
 


### PR DESCRIPTION
On very long lines the content of the line would be overwritten as soon as the
end of the horizontal space was reached. For example on "upload_logs" the
start of the line gets overwritten.

Verification run: http://lord.arch/tests/6125#step/consoletest_setup/33