### PR TITLE
Add a vino case and main entry for 8 remote desktop cases

### DIFF
--- a/data/x11regressions/autoyast_remote_desktop_sle12sp2_gnome.xml
+++ b/data/x11regressions/autoyast_remote_desktop_sle12sp2_gnome.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <keyboard>
+    <keyboard_values>
+      <delay/>
+      <discaps config:type="boolean">false</discaps>
+      <numlock>bios</numlock>
+      <rate/>
+    </keyboard_values>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list"/>
+  </ntp-client>
+  <software>
+    <packages config:type="list">
+      <package>grub2</package>
+      <package>sles-release</package>
+	  <package>apache2</package>
+	  <package>dhcp-server</package>
+ 	  <package>openssh</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>Minimal</pattern>
+      <pattern>apparmor</pattern>
+      <pattern>base</pattern>
+      <pattern>documentation</pattern>
+      <pattern>gnome-basic</pattern>
+      <pattern>x11</pattern>
+    </patterns>
+  </software>
+  <networking>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <startmode>auto</startmode>
+      </interface>
+    </interfaces>
+  </networking>
+  <firewall>
+    <enable_firewall config:type="boolean">true</enable_firewall>
+    <start_firewall config:type="boolean">true</start_firewall>
+  </firewall>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Berlin</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact>-1</inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -680,5 +680,19 @@ sub gnote_start_with_new_note {
     assert_screen 'gnote-new-note', 5;
 }
 
+# Configure static ip for NetworkManager on SLED or SLE+WE
+sub configure_static_ip_nm {
+    my ($self, $ip) = @_;
+
+    x11_start_program 'xterm';
+    assert_screen 'xterm';
+    become_root;
+    assert_script_run "nmcli connection add type ethernet con-name wired ifname eth0 ip4 '$ip' gw4 10.0.2.2";
+    assert_script_run 'nmcli device disconnect eth0';
+    assert_script_run 'nmcli connection up wired ifname eth0', 60;
+    type_string "exit\n";
+    wait_screen_change { send_key 'alt-f4' };
+}
+
 1;
 # vim: set sw=4 et:

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -344,6 +344,32 @@ sub load_x11regression_other() {
     }
 }
 
+sub load_x11regression_remote() {
+    # load onetime vncsession testing
+    if (check_var('REMOTE_DESKTOP_TYPE', 'one_time_vnc')) {
+        loadtest 'x11regressions/remote_desktop/onetime_vncsession_xvnc_tigervnc';
+        loadtest 'x11regressions/remote_desktop/onetime_vncsession_xvnc_java';
+        loadtest 'x11regressions/remote_desktop/onetime_vncsession_multilogin_failed';
+    }
+    # load persistemt vncsession, x11 forwarding, xdmcp with gdm testing
+    elsif (check_var('REMOTE_DESKTOP_TYPE', 'persistent_vnc')) {
+        loadtest 'x11regressions/remote_desktop/persistent_vncsession_xvnc';
+        loadtest 'x11regressions/remote_desktop/x11_forwarding_openssh';
+        loadtest 'x11regressions/remote_desktop/xdmcp_gdm';
+    }
+    # load xdmcp with xdm testing
+    elsif (check_var('REMOTE_DESKTOP_TYPE', 'xdmcp_xdm')) {
+        loadtest 'x11regressions/remote_desktop/xdmcp_xdm';
+    }
+    # load vino testing
+    elsif (check_var('REMOTE_DESKTOP_TYPE', 'vino_server')) {
+        loadtest 'x11regressions/remote_desktop/vino_server';
+    }
+    elsif (check_var('REMOTE_DESKTOP_TYPE', 'vino_client')) {
+        loadtest 'x11regressions/remote_desktop/vino_client';
+    }
+}
+
 sub load_boot_tests() {
     if (get_var("ISO_MAXSIZE")) {
         loadtest "installation/isosize";
@@ -1000,6 +1026,10 @@ elsif (get_var("REGRESSION")) {
     elsif (check_var("REGRESSION", "other")) {
         loadtest "boot/boot_to_desktop";
         load_x11regression_other();
+    }
+    elsif (check_var('REGRESSION', 'remote')) {
+        loadtest 'boot/boot_to_desktop';
+        load_x11regression_remote();
     }
     elsif (check_var("REGRESSION", "piglit")) {
         loadtest "boot/boot_to_desktop";

--- a/tests/x11regressions/remote_desktop/vino_client.pm
+++ b/tests/x11regressions/remote_desktop/vino_client.pm
@@ -1,0 +1,61 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Remote Login: client for VNC connections with vino
+#          server: vino_server.pm
+#          client: vino_client.pm
+# Maintainer: Chingkai <qkzhu@suse.com>
+# Tags: tc#1586210
+
+use strict;
+use base 'x11regressiontest';
+use testapi;
+use lockapi;
+use mmapi;
+
+sub run() {
+    my $self = shift;
+
+    # Setup static NETWORK
+    $self->configure_static_ip_nm('10.0.2.16/15');
+
+    # Wait until target becomes ready
+    mutex_lock 'vino_server_ready';
+
+    # Login to the sharing session using vinagre via vino server
+    x11_start_program 'vinagre';
+    assert_screen 'vinagre-launched';
+    assert_and_click 'vinagre-enable-shortcut1';
+    assert_and_click 'vinagre-enable-shortcut2';
+    send_key 'alt-f10';
+    assert_screen 'vinagre-launched-maxwindow';
+    send_key 'ctrl-n';
+    send_key_until_needlematch 'vinagre-protocol-vnc', 'down';
+    assert_and_click 'vinagre-connect-host';
+    type_string '10.0.2.15';
+    wait_still_screen 3;
+    send_key 'ret';
+    assert_screen 'vinagre-auth', 60;
+    type_password;
+    wait_still_screen 3;
+    send_key 'ret';
+    assert_screen 'vinagre-gcc-sharing-activate';
+    wait_screen_change { send_key 'ctrl-w'; };    # Disconnect vinagre
+    wait_screen_change { send_key 'ctrl-q'; };    # Exit vinagre
+    save_screenshot;
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
### Add autoyast xml file for remote desktop supportserver
    
This xml file is used to generate the qcow2 image for remote desktop supportserver which will be used as:
- SLES12SP2 base OS ( vncmanager and gdm is required )
- dhcp server
- ssh server
- xvnc server
- X server with xdmcp configured

### Add a vino remote desktop case to x11regressions

This is a multi machine case for Gnome sharing (vino remote desktop) testing. We can not use supportserver or any apis in mm_networks since vino requires NetworkManager. I wrote a subroutine in x11regressiontest.pm to set static IP for NetworkManager.

### Add main entry for 8 remote desktop cases in x11regressions

- onetime_vncsession_multilogin_failed.pm
- onetime_vncsession_xvnc_java.pm
- onetime_vncsession_xvnc_tigervnc.pm
- persistent_vncsession_xvnc.pm
- vino_client.pm
- vino_server.pm
- x11_forwarding_openssh.pm
- xdmcp_gdm.pm
- xdmcp_xdm.pm
    
see also: poo#9504

Validation runs for the newly added vino cases and main entry : Please only see the green jobs

http://147.2.212.115/tests/overview?distri=sle&version=12-SP3&build=0156&groupid=60
