### PR TITLE
Use zypper_call in consoletest_setup to increase timeout

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -88,7 +88,7 @@ sub run() {
     # Let's uninstall 'the pattern' (no packages affected) in order to be able to install stuff
     script_run 'rpm -qi patterns-openSUSE-minimal_base-conflicts && zypper -n rm patterns-openSUSE-minimal_base-conflicts';
     # Install curl and tar in order to get the test data
-    assert_script_run "zypper -n install curl tar";
+    zypper_call 'install curl tar';
 
     # upload_logs requires curl, but we wanted the initial state of the system
     upload_logs "/tmp/psaxf.log";


### PR DESCRIPTION
Fixes https://openqa.opensuse.org/tests/382319#step/consoletest_setup/32