### PR TITLE
Fix locked 'x11' console handling for x11 tests

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -3,6 +3,7 @@ use base 'distribution';
 use serial_terminal ();
 use strict;
 use utils 'type_string_slow';
+use utils 'ensure_unlocked_desktop';
 
 # Base class for all openSUSE tests
 
@@ -450,6 +451,9 @@ sub console_selected {
     $args{ignore}        //= qr{sut|root-virtio-terminal|iucvconn|svirt};
     return unless $args{await_console};
     return if $args{tags} =~ $args{ignore};
+    # x11 needs special handling because we can not easily know if screen is
+    # locked, display manager is waiting for login, etc.
+    return ensure_unlocked_desktop if $args{tags} =~ /x11/;
     assert_screen($args{tags}, no_wait => 1);
 }
 

--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -51,9 +51,7 @@ sub run() {
     assert_script_run "echo \"#panel .panel-button { color: transparent; }\" >> $theme";
     start_vnc_server;
 
-    select_console 'x11', await_console => 0;
-    ensure_unlocked_desktop;
-
+    select_console 'x11';
     # Reload theme to hide panel text
     x11_start_program "rt";
 


### PR DESCRIPTION
`select_console 'x11'` previously expected an "x11" needle to show up which it
did sometimes when the screen content was not really updated but the session
was already locked. The tests would get stuck in this case. This commit fixes
this by calling `ensure_unlocked_desktop` in the "console_selected" callback
when expecting "x11".

In case there are problems with that approach in specific test modules we can
call `select_console 'x11', no_wait => 1`.

Verification runs:
 * SLE: http://lord.arch/tests/6129
 * SLE maintenance: http://lord.arch/tests/6136
 * openSUSE Leap 42.3 awesome: http://lord.arch/tests/6135
 
Related progress issue: https://progress.opensuse.org/issues/18352