### PR TITLE
Fix locked 'x11' console for vnc_two_passwords

### DIFF
--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -62,8 +62,10 @@ sub run() {
     send_key 'ret';
     send_key_until_needlematch("snap-bootloader-comment", 'down', 10, 5);
     save_screenshot;
-    send_key 'ret';
-    if (!check_screen([qw(tty-selected displaymanager, 60)])) { record_soft_failure 'bsc#980337'; }
+    wait_screen_change { send_key 'ret' };
+    # boot into the snapshot
+    $self->wait_boot(textmode => 1);
+    # request reboot again to ensure we will end up in the original system
     send_key 'ctrl-alt-delete';
     $self->wait_boot;
 }

--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -13,6 +13,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils 'ensure_unlocked_desktop';
 
 my @options = ({pw => "full_access_pw", change => 1}, {pw => "view_only_pw", change => 0});
 my $theme = "/usr/share/gnome-shell/theme/gnome-classic.css";
@@ -50,7 +51,9 @@ sub run() {
     assert_script_run "echo \"#panel .panel-button { color: transparent; }\" >> $theme";
     start_vnc_server;
 
-    select_console "x11";
+    select_console 'x11', await_console => 0;
+    ensure_unlocked_desktop;
+
     # Reload theme to hide panel text
     x11_start_program "rt";
 


### PR DESCRIPTION
`select_console 'x11'` previously expected an "x11" needle to show up which it
did sometimes when the screen content was not really updated but the session
was already locked. The tests would get stuck in this case. This commit fixes
this by calling `ensure_unlocked_desktop` explicitly.

Verification run: http://lord.arch/tests/6129

Related progress issue: https://progress.opensuse.org/issues/18352