### PR TITLE
Fix poo#18474: Send more keys to match ssh-blocked-selected

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -58,7 +58,7 @@ sub run() {
                 send_key 'alt-o';
             }
             else {
-                send_key_until_needlematch 'ssh-blocked-selected', 'tab';
+                send_key_until_needlematch 'ssh-blocked-selected', 'tab', 25;
                 send_key 'ret';
                 send_key_until_needlematch 'ssh-open', 'tab';
             }


### PR DESCRIPTION
The default counts of send_key_until_needlematch is 20, which is
not engouth to match ssh-blocked-selected needle when all patterns
are selected for installation.