### PR TITLE
Remove unneeded softfail from empathy_irc after fix bsc#999832

### DIFF
--- a/tests/x11regressions/empathy/empathy_irc.pm
+++ b/tests/x11regressions/empathy/empathy_irc.pm
@@ -49,13 +49,7 @@ sub run() {
 
     # join openqa channel
     send_key "ctrl-j";
-    if (!check_screen 'empathy-join-room') {
-        record_soft_failure 'bsc#999832: keyboard shortcut of empathy not working on SLED12SP2';
-        assert_and_click 'empathy-menu';
-        send_key_until_needlematch "empathy-menu-rooms", "down";
-        assert_and_click 'empathy-menu-joinrooms';
-        assert_screen 'empathy-join-room';
-    }
+    assert_screen "empathy-join-room";
     type_string "openqa";
     send_key "ret";
 


### PR DESCRIPTION
bsc#999832 has now been fixed, the soft fail referencing this bug is no longer needed in test module empathy_irc.

Related to poo##18482.

The test module is now passing without recording the soft failure:
https://openqa.suse.de/tests/869494#step/empathy_irc/20

Amended test passing on my local OpenQA instance:
http://dreamyhamster.suse.cz/tests/159#step/empathy_irc/20