### PR TITLE
For crashes in toolchain/crash we need YaST logs

### DIFF
--- a/tests/toolchain/crash.pm
+++ b/tests/toolchain/crash.pm
@@ -10,7 +10,7 @@
 # Summary: Run 'crash' utility on a kernel memory dump
 # Maintainer: Michal Nowak <mnowak@suse.com>
 
-use base "opensusebasetest";
+use base "console_yasttest";
 use strict;
 use testapi;
 use utils;


### PR DESCRIPTION
In fails like https://openqa.suse.de/tests/871474#step/crash/47 we need
more information, especially y2log log.