### PR TITLE
Match bootloader params for ppc64le

### DIFF
--- a/tests/installation/bootloader_ofw.pm
+++ b/tests/installation/bootloader_ofw.pm
@@ -35,7 +35,7 @@ sub run() {
     if (   check_var('VIDEOMODE', 'text')
         || get_var('NETBOOT')
         || get_var('AUTOYAST')
-        || get_var('SCC_URL') && !get_var('PATCH')
+        || get_var('SCC_URL')
         || get_var('DUD')
         || get_var('EXTRABOOTPARAMS'))
     {


### PR DESCRIPTION
Since I have a ppc worker I can do testing faster on this arch so I pretty sure that we don't need this condition here in order to boot the hdd and patch. After removing this it will boot the grub from hdd.