### PR TITLE
[URGENT] Virtualization: code enhancement to make test more robust over ipmi and bug fix

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -43,6 +43,7 @@ our @EXPORT = qw(
   workaround_type_encrypted_passphrase
   ensure_unlocked_desktop
   sle_version_at_least
+  install_to_other_at_least
   ensure_fullscreen
   ensure_shim_import
   reboot_gnome
@@ -395,6 +396,25 @@ sub sle_version_at_least {
           && !check_var($version_variable, '13');
     }
     die "unsupported SLE $version_variable $version in check";
+}
+
+#Check the real version of the test machine is at least some value, rather than the VERSION variable
+#It is for version checking for tests with variable "INSTALL_TO_OTHERS".
+sub install_to_other_at_least {
+    my $version = shift;
+
+    if (!check_var("INSTALL_TO_OTHERS", "1")) {
+        return 0;
+    }
+
+    #setup the var for real VERSION
+    my $real_installed_version = get_var("REPO_0_TO_INSTALL");
+    $real_installed_version =~ /.*SLES?-(\d+-SP\d+)-.*/m;
+    $real_installed_version = $1;
+    set_var("REAL_INSTALLED_VERSION", $real_installed_version);
+    bmwqemu::save_vars();
+
+    return sle_version_at_least($version, version_variable => "REAL_INSTALLED_VERSION");
 }
 
 sub ensure_fullscreen {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -465,11 +465,14 @@ sub load_inst_tests() {
     }
     loadtest "installation/addon_products_sle";
     if (noupdatestep_is_applicable()) {
+        #system_role selection during installation was added as a new feature since sles12sp2
+        #so system_role.pm should be loaded for all tests that actually install to versions over sles12sp2
+        #no matter with or without INSTALL_TO_OTHERS tag
         if (   check_var('ARCH', 'x86_64')
             && sle_version_at_least('12-SP2')
             && is_server()
             && (!is_sles4sap() || is_sles4sap_standard())
-            && install_this_version())
+            && (install_this_version() || install_to_other_at_least('12-SP2')))
         {
             loadtest "installation/system_role";
         }

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -35,6 +35,8 @@ sub login_to_console() {
     assert_screen([qw(grub2 grub1)], 120);
     if (!get_var("reboot_for_upgrade_step")) {
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
+            #send key 'up' to stop grub timer counting down, to be more robust to select xen
+            send_key 'up';
             send_key_until_needlematch("virttest-bootmenu-xen-kernel", 'down', 10, 1);
             send_key 'ret';
         }


### PR DESCRIPTION
Changes:
  *) change login_console script to let grub menuentry selection for xen more stable, by sending a key 'down' to grub to stop timer counting down
  *) let system_role test show up for sles12sp2 host installation in sles12sp3+ milestone test
      Currently system_role.pm is not properly loaded for those test installing host to sles12sp2 in sles12sp3 release test, so change code to detect not only those installed to the test release, but also those with INSTALL_TO_OTHERS.


Verification link:
login_console grub enhancement:
http://147.2.212.135/tests/1017
http://147.2.212.135/tests/1016

system_role loading:
http://147.2.212.135/tests/1033
http://147.2.212.135/tests/1032