### PR TITLE
Update two libreoffice cases to fix poo#18410

### DIFF
--- a/tests/x11regressions/libreoffice/libreoffice_double_click_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_double_click_file.pm
@@ -30,19 +30,13 @@ sub run() {
     send_key "ret";
     wait_still_screen;
 
-    # double click the below qw(doc docx fodg fodp fods fodt odf odg odp ods odt pptx xlsx) to check whether can be work
+    # open test files of different formats
     for my $tag (qw(doc docx fodg fodp fods fodt odf odg odp ods odt pptx xlsx)) {
         send_key_until_needlematch("libreoffice-specified-list-$tag", "right", 50, 1);
         assert_and_dclick("libreoffice-specified-list-$tag");
         assert_screen("libreoffice-test-$tag", 90);
-        if ($tag ne 'xlsx') {
-            hold_key "alt";
-            send_key_until_needlematch("libreoffice-nautilus-window", "tab");
-            release_key "alt";
-            wait_still_screen(3);
-        }
+        send_key 'ctrl-q';
     }
-    send_key "ctrl-q";
     if (!check_screen("generic-desktop")) {
         send_key "ctrl-q";
     }

--- a/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
@@ -26,7 +26,8 @@ sub run() {
     assert_screen("welcome-to-libreoffice");
     $self->check_libreoffice_dialogs();
 
-    # open below qw(doc docx fodg fodp fods fodt odf odg odp ods odt pdf pptx xlsx) to check whether can be work
+    # open test files of different formats
+    my $i = 0;
     for my $tag (qw(doc docx fodg fodp fods fodt odf odg odp ods odt pdf pptx xlsx)) {
         send_key "ctrl-o";
         wait_still_screen 3;
@@ -35,8 +36,10 @@ sub run() {
         type_string "/home/$username/Documents/ooo-test-doc-types/test.$tag\n";
         wait_still_screen 3;
         assert_screen("libreoffice-test-$tag", 90);
+        # Close every 3 files to reduce the VM's burden
+        if ($i % 3 == 0) { send_key_until_needlematch('libreoffice-test-doc', 'alt-f4', 3, 5); }
+        $i++;
     }
-    send_key "ctrl-q";
     if (!check_screen("generic-desktop")) {
         send_key "ctrl-q";
     }


### PR DESCRIPTION
libreoffice_open_specified_file and libreoffice_double_click_file are
unreliable. It seems that the VM's performance doesn't support opening
so many test files at the same time.

- libreoffice_double_click_file
  Open a test file then close it immediately.
- libreoffice_open_specified_file
  Close every 3 files to reduce the VM's burden and test open multiple files.

  see also: poo18410

Verification test:
SP1: http://147.2.212.115/tests/554
SP2: http://147.2.212.115/tests/555
SP3: http://147.2.212.115/tests/545