### PR TITLE
yast2_clone_system: Bump timeout

### DIFF
--- a/tests/console/yast2_clone_system.pm
+++ b/tests/console/yast2_clone_system.pm
@@ -24,10 +24,11 @@ sub run() {
     script_run("yast2 clone_system; echo yast2-clone-system-status-\$? > /dev/$serialdev", 0);
 
     # workaround for bsc#1013605
-    assert_screen([qw(dhcp-popup yast2_console-finished)], 200);
+    my $timeout = 600;
+    assert_screen([qw(dhcp-popup yast2_console-finished)], $timeout);
     if (match_has_tag('dhcp-popup')) {
         wait_screen_change { send_key 'alt-o' };
-        assert_screen 'yast2_console-finished', 200;
+        assert_screen 'yast2_console-finished', $timeout;
     }
     wait_serial('yast2-clone-system-status-0') || die "'yast2 clone_system' didn't finish";
 


### PR DESCRIPTION
See https://openqa.suse.de/tests/797639#step/yast2_clone_system/6