### PR TITLE
Wait for screen change in setraidlevel poo#18444

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -92,8 +92,8 @@ sub setraidlevel {
     my %entry = (0 => 0, 1 => 1, 5 => 5, 6 => 6, 10 => 'g');
     send_key "alt-$entry{$level}";
 
-    send_key "alt-i";    # move to RAID name input field
-    send_key "tab";      # skip RAID name input field
+    wait_screen_change { send_key "alt-i"; };    # move to RAID name input field
+    wait_screen_change { send_key "tab"; };      # skip RAID name input field
 }
 
 sub set_lvm() {


### PR DESCRIPTION
When selecting wanted RAID level some keystrokes (eg. Tab) are ignored on xgene2 and mustang3 workers (seattle6 works fine) and then the test is failing, see https://openqa.suse.de/tests/881471#step/partitioning_raid/130

This commit is adding a wait between keystrokes and hopefully will fix that issue - it works correctly on x86_64 http://dhcp209.suse.cz/tests/4084 but I didn't test on aarch64.

Unfortunately I don't find a better solution for it because wait_screen_change() will probably not match flashing cursor which is the only change in the screen.