### PR TITLE
Wait for screen change after pressing key

### DIFF
--- a/tests/installation/partitioning_warnings.pm
+++ b/tests/installation/partitioning_warnings.pm
@@ -33,7 +33,7 @@ sub run() {
     # expect partition setup warning pop-ups
     while (1) {
         assert_screen ['partition-warning-too-small-for-snapshots', 'partition-warning-no-efi-boot', 'partition-warning-no-swap'];
-        send_key 'alt-y';                     # yes
+        wait_screen_change { send_key 'alt-y' };    # yes
         last if match_has_tag 'partition-warning-no-swap';
     }
 }


### PR DESCRIPTION
https://openqa.suse.de/tests/878705#step/partitioning_warnings/14
I guess this failed because loop was so fast that it catched same screen twice.
In log needles matched with same tag but video looks like the second match was
partition-warning-no-swap which ended loop despite log is showing match
partition-warning-too-small-for-snapshots twice.
Perl is so fast or qemu so slow or both simultaneously that even logs \*LIE\*!