### PR TITLE
Poo#18282

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -216,14 +216,8 @@ sub specific_bootmenu_params {
         $args .= " self_update=0";
     }
     elsif (my $self_update_repo = get_var("INSTALLER_SELF_UPDATE")) {
-        if ($self_update_repo eq "1") {
-            diag "Explicitly enabling installer self update";
-            $args .= " self_update=1";
-        }
-        else {
-            diag "Explicitly enabling installer self with $self_update_repo";
-            $args .= " self_update=$self_update_repo";
-        }
+        $args .= " self_update=$self_update_repo";
+        diag "Explicitly enabling installer self update with $self_update_repo";
     }
 
     if (get_var("FIPS")) {

--- a/tests/installation/bootloader_ofw.pm
+++ b/tests/installation/bootloader_ofw.pm
@@ -17,6 +17,7 @@ use strict;
 use Time::HiRes 'sleep';
 
 use testapi;
+use bootloader_setup;
 use registration;
 use utils;
 
@@ -37,7 +38,12 @@ sub run() {
         || get_var('AUTOYAST')
         || get_var('SCC_URL')
         || get_var('DUD')
-        || get_var('EXTRABOOTPARAMS'))
+        || get_var('EXTRABOOTPARAMS')
+        || get_var('FIPS')
+        || get_var('AUTOUPGRADE')
+        || get_var('INSTALLER_SELF_UPDATE')
+        || get_var('INSTALLER_NO_SELF_UPDATE')
+        || get_var('IBFT'))
     {
         if (get_var("ZDUP") || get_var("ONLINE_MIGRATION") || get_var('PATCH')) {
             send_key "down";
@@ -67,33 +73,10 @@ sub run() {
                     $args .= ' kernel=1 insecure=1';
                 }
             }
-            if (get_var("DUD")) {
-                my $dud = get_var("DUD");
-                if ($dud =~ /http:\/\/|https:\/\/|ftp:\/\//) {
-                    $args .= " dud=$dud insecure=1";
-                }
-                else {
-                    $args .= " dud=" . data_url($dud) . " insecure=1";
-                }
-            }
-            if (get_var("AUTOYAST") || get_var("AUTOUPGRADE")) {
-                my $netsetup = " ifcfg=*=dhcp";    #need this instead of netsetup as default, see bsc#932692
-                $netsetup = " " . get_var("NETWORK_INIT_PARAM")
-                  if defined get_var("NETWORK_INIT_PARAM");    #e.g netsetup=dhcp,all
-                $args .= $netsetup;
-                $args .= " autoyast=" . data_url(get_var("AUTOYAST")) . " ";
-            }
 
-            if (get_var("AUTOUPGRADE")) {
-                $args .= " autoupgrade=1";
-            }
+            type_string_very_slow $args;
 
-            type_string_slow $args;
-
-            if (get_var("FIPS")) {
-                type_string_slow ' fips=1';
-                save_screenshot;
-            }
+            specific_bootmenu_params;
 
             if (my $e = get_var("EXTRABOOTPARAMS")) {
                 type_string_very_slow " $e";


### PR DESCRIPTION
Use specific_bootmenu_params from bootloader_setup in ofw bootloader.
So all parameters set in in this function are used also in ppc64 tests.

http://furud.arch.suse.de/tests/14#step/bootloader_ofw/10
http://furud.arch.suse.de/tests/16#step/bootloader_ofw/10