### PR TITLE
Fix too fast typing in kate

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -70,13 +70,7 @@ sub test_terminal {
     x11_start_program($name);
     assert_screen $name;
     $self->enter_test_text($name);
-    unless (check_screen "test-$name-1") {
-        record_soft_failure 'poo#17442 workaround for too early typing, remove after ticket fixed';
-        # We really should not use sleeps but too many keys have gone missing
-        sleep 1;
-        # let's try again
-        assert_screen "test-$name-1";
-    }
+    assert_screen "test-$name-1";
     send_key 'alt-f4';
 }
 

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -58,10 +58,13 @@ sub prepare_sle_classic {
 }
 
 sub enter_test_text {
-    my ($self, $name) = @_;
+    my ($self, $name, %args) = @_;
     $name //= 'your program';
-    for (1 .. 13) { send_key "ret" }
-    type_string "echo If you can see this text $name is working.\n";
+    $args{cmd} //= 0;
+    for (1 .. 13) { send_key 'ret' }
+    my $text = "If you can see this text $name is working.\n";
+    $text = 'echo ' . $text if $args{cmd};
+    type_string $text;
 }
 
 sub test_terminal {
@@ -69,7 +72,7 @@ sub test_terminal {
     mouse_hide(1);
     x11_start_program($name);
     assert_screen $name;
-    $self->enter_test_text($name);
+    $self->enter_test_text($name, cmd => 1);
     assert_screen "test-$name-1";
     send_key 'alt-f4';
 }

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -6,6 +6,7 @@ use base "opensusebasetest";
 
 use strict;
 use testapi;
+use utils 'type_string_slow';
 
 sub post_fail_hook() {
     my ($self) = shift;
@@ -59,12 +60,18 @@ sub prepare_sle_classic {
 
 sub enter_test_text {
     my ($self, $name, %args) = @_;
-    $name //= 'your program';
-    $args{cmd} //= 0;
+    $name       //= 'your program';
+    $args{cmd}  //= 0;
+    $args{slow} //= 0;
     for (1 .. 13) { send_key 'ret' }
     my $text = "If you can see this text $name is working.\n";
     $text = 'echo ' . $text if $args{cmd};
-    type_string $text;
+    if ($args{slow}) {
+        type_string_slow $text;
+    }
+    else {
+        type_string $text;
+    }
 }
 
 sub test_terminal {

--- a/tests/x11/gnome_terminal.pm
+++ b/tests/x11/gnome_terminal.pm
@@ -24,7 +24,7 @@ sub run() {
     if (!check_screen "gnome-terminal-second-tab") {
         record_soft_failure 'bsc#999243';
     }
-    $self->enter_test_text('gnome-terminal');
+    $self->enter_test_text('gnome-terminal', cmd => 1);
     assert_screen 'test-gnome_terminal-1';
     send_key 'alt-f4';
 }

--- a/tests/x11/kate.pm
+++ b/tests/x11/kate.pm
@@ -17,19 +17,21 @@ use strict;
 use testapi;
 
 sub run() {
+    my ($self) = @_;
     ensure_installed("kate");
     x11_start_program("kate", 6, {valid => 1});
-    assert_screen 'test-kate-1', 10;
+    assert_screen 'test-kate-1';
 
     if (!get_var("PLASMA5")) {
         # close welcome screen
-        send_key 'alt-c';
-        sleep 2;
+        wait_screen_change { send_key 'alt-c' };
     }
-    type_string "If you can see this text kate is working.\n";
-    assert_screen 'test-kate-2', 5;
+    # type slow as kate can garble up text when typing with the super natural
+    # standard speed
+    $self->enter_test_text('kate', slow => 1);
+    assert_screen 'test-kate-2';
     send_key "ctrl-q";
-    assert_screen 'test-kate-3', 5;
+    assert_screen 'test-kate-3';
     send_key "alt-d";    # discard
 }
 

--- a/tests/x11/mate_terminal.pm
+++ b/tests/x11/mate_terminal.pm
@@ -22,7 +22,7 @@ sub run() {
     assert_screen "mate-terminal";
     send_key "ctrl-shift-t";
     assert_screen "mate-terminal-second-tab";
-    $self->enter_test_text('mate-terminal');
+    $self->enter_test_text('mate-terminal', cmd => 1);
     assert_screen 'test-mate_terminal-1';
     send_key "alt-f4";
 }

--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -30,7 +30,7 @@ sub run() {
     type_string "$password\n";
     assert_screen "ssh-second-xterm";
     $self->set_standard_prompt();
-    $self->enter_test_text('ssh-X-forwarding');
+    $self->enter_test_text('ssh-X-forwarding', cmd => 1);
     assert_screen 'test-sshxterm-1';
     # close both windows, executed in remote session, because we can
     type_string "killall xterm\n";

--- a/tests/x11/xfce4_terminal.pm
+++ b/tests/x11/xfce4_terminal.pm
@@ -21,7 +21,7 @@ sub run() {
     x11_start_program("xfce4-terminal");
     wait_still_screen 1;
     send_key "ctrl-shift-t";
-    $self->enter_test_text('xfce4-terminal');
+    $self->enter_test_text('xfce4-terminal', cmd => 1);
     assert_screen 'test-xfce4_terminal-1';
     wait_screen_change { send_key 'alt-f4' };
     # confirm close of multi-tab window

--- a/tests/x11regressions/remote_desktop/x11_forwarding_openssh.pm
+++ b/tests/x11regressions/remote_desktop/x11_forwarding_openssh.pm
@@ -50,7 +50,7 @@ sub run() {
     assert_screen 'ssh-login-ok';
 
     $self->set_standard_prompt();
-    $self->enter_test_text('ssh-X-forwarding');
+    $self->enter_test_text('ssh-X-forwarding', cmd => 1);
     assert_screen 'test-sshxterm-1';
 
     # Launch gedit and gnome control center remotely


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/18200

Verification run: http://lord.arch/tests/6159#step/kate/21