### PR TITLE
Fix for reporting failed SLEnkins tests

### DIFF
--- a/tests/slenkins/slenkins_control.pm
+++ b/tests/slenkins/slenkins_control.pm
@@ -202,11 +202,6 @@ sub run {
           echo
         done
 
-        # Check for failures
-        echo "Checking for failed tests"
-        check-failures
-        echo
-
         # Finish log files
         echo "Finishing log files"
         finish-logs


### PR DESCRIPTION
Continue of poo#18606

This should fix a problem with reporting failed tests, eg. https://openqa.suse.de/tests/885282#step/slenkins_control/20

Tested http://dhcp209.suse.cz/tests/4148#step/slenkins_control/21
