### PR TITLE
Make prove fails in yast_cli_test obvious

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -54,7 +54,7 @@ sub run_yast_cli_test {
     script_run("if [ -d t ]; then echo -n 'run'; else echo -n 'skip'; fi > /dev/$serialdev", 0);
     my $action = wait_serial(['run', 'skip'], 10);
     if ($action eq 'run') {
-        assert_script_run('prove', timeout => 90, fail_message => 'yast cli tests failed');
+        assert_script_run('prove -v', timeout => 90, fail_message => 'yast cli tests failed');
     }
 
     script_run 'popd';


### PR DESCRIPTION
Related to http://bugzilla.suse.com/show_bug.cgi?id=1031279