### PR TITLE
Revert partially 2d1468f in bootloader_ofw.pm

### DIFF
--- a/tests/installation/bootloader_ofw.pm
+++ b/tests/installation/bootloader_ofw.pm
@@ -65,16 +65,12 @@ sub run() {
             if (check_var('VIDEOMODE', 'text')) {
                 $args .= " textmode=1";
             }
-            if (get_var("NETBOOT")) {
-                if (get_var("SUSEMIRROR")) {
-                    $args .= ' install=http://' . get_var("SUSEMIRROR");
-                }
-                else {
-                    $args .= ' kernel=1 insecure=1';
-                }
+            if (get_var("NETBOOT") && get_var("SUSEMIRROR")) {
+                $args .= ' install=http://' . get_var("SUSEMIRROR");
             }
 
             type_string_very_slow $args;
+            save_screenshot;
 
             specific_bootmenu_params;
 
@@ -83,7 +79,6 @@ sub run() {
                 save_screenshot;
             }
 
-            save_screenshot;
             registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
             send_key "ctrl-x";
         }


### PR DESCRIPTION
to remove the line for NETBOOT and not SUSEMIRROR
that is creating problem during test.

Move save_screenshot before specific_bootmenu_params
that already have one.

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>