### PR TITLE
Use specific_bootmenu_params from bootloader_setup on s390x arch

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -187,22 +187,24 @@ sub bootmenu_network_source {
 }
 
 sub specific_bootmenu_params {
-    my $args     = "";
-    my $netsetup = "";
-    if (get_var("AUTOYAST") || get_var("AUTOUPGRADE") && get_var("AUTOUPGRADE") ne 'local') {
-        # We need to use 'ifcfg=*=dhcp' instead of 'netsetup=dhcp' as a default
-        # due to BSC#932692 (SLE-12). 'SetHostname=0' has to be set because autoyast
-        # profile has DHCLIENT_SET_HOSTNAME="yes" in /etc/sysconfig/network/dhcp,
-        # 'ifcfg=*=dhcp' sets this variable in ifcfg-eth0 as well and we can't
-        # have them both as it's not deterministic.
-        $netsetup = get_var("NETWORK_INIT_PARAM", "ifcfg=*=dhcp SetHostname=0");
-        $args .= " $netsetup autoyast=" . data_url(get_var("AUTOYAST")) . " ";
-    }
-    else {
-        $netsetup = " " . get_var("NETWORK_INIT_PARAM") if defined get_var("NETWORK_INIT_PARAM");    #e.g netsetup=dhcp,all
-        $args .= $netsetup;
-    }
+    my $args = "";
 
+    if (!check_var('ARCH', 's390x')) {
+        my $netsetup = "";
+        if (get_var("AUTOYAST") || get_var("AUTOUPGRADE") && get_var("AUTOUPGRADE") ne 'local') {
+            # We need to use 'ifcfg=*=dhcp' instead of 'netsetup=dhcp' as a default
+            # due to BSC#932692 (SLE-12). 'SetHostname=0' has to be set because autoyast
+            # profile has DHCLIENT_SET_HOSTNAME="yes" in /etc/sysconfig/network/dhcp,
+            # 'ifcfg=*=dhcp' sets this variable in ifcfg-eth0 as well and we can't
+            # have them both as it's not deterministic.
+            $netsetup = get_var("NETWORK_INIT_PARAM", "ifcfg=*=dhcp SetHostname=0");
+            $args .= " $netsetup autoyast=" . data_url(get_var("AUTOYAST")) . " ";
+        }
+        else {
+            $netsetup = " " . get_var("NETWORK_INIT_PARAM") if defined get_var("NETWORK_INIT_PARAM");    #e.g netsetup=dhcp,all
+            $args .= $netsetup;
+        }
+    }
     if (get_var("AUTOUPGRADE")) {
         $args .= " autoupgrade=1";
     }
@@ -239,8 +241,13 @@ sub specific_bootmenu_params {
         }
     }
 
-    type_string_very_slow $args;
-    save_screenshot;
+    if (check_var('ARCH', 's390x')) {
+        return $args;
+    }
+    else {
+        type_string_very_slow $args;
+        save_screenshot;
+    }
 }
 
 sub select_bootmenu_video_mode {

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -20,6 +20,8 @@ use strict;
 use warnings;
 use English;
 
+use bootloader_setup;
+
 # try to find the 2 longest lines that are below beyond the limit
 # collapsing the lines - we have a limit of 10 lines
 sub try_merge_lines {
@@ -87,6 +89,9 @@ sub prepare_parmfile {
     if (get_var('UPGRADE')) {
         $params .= 'upgrade=1 ';
     }
+
+    $params .= specific_bootmenu_params;
+
     if (check_var('SCC_REGISTER', 'installation')) {
         if (get_var('SCC_URL')) {
             my $regurl = get_var('SCC_URL');

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -18,6 +18,7 @@ use File::Basename 'basename';
 
 use strict;
 use warnings;
+use bootloader_setup;
 
 
 sub run() {
@@ -54,6 +55,8 @@ sub run() {
         if (get_var('AUTOYAST')) {
             $cmdline .= " autoyast=" . data_url(get_var('AUTOYAST')) . " ";
         }
+
+        $cmdline .= specific_bootmenu_params;
 
         $svirt->change_domain_element(os => initrd  => "$img_path/$name.initrd");
         $svirt->change_domain_element(os => kernel  => "$img_path/$name.kernel");


### PR DESCRIPTION
(poo#18282)

Note - DUD and INSTALLER_SELF_UPDATE url must be shorter than 52
characters for s390x parmfile