### PR TITLE
Accept disabled firewall on older openSUSE versions as given

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -378,7 +378,11 @@ sub load_fixup_firewall() {
     # The openSUSE 13.1 GNOME disk image has the firewall disabled
     # Upon upgrading to a new system the service state is supposed to remain as pre-configured
     # If the service is disabled here, we enable it here
-    return unless check_var('HDDVERSION', 'openSUSE-13.1-gnome');
+    # For the older openSUSE base images we also see a problem with the
+    # firewall being disabled since
+    # https://build.opensuse.org/request/show/483163
+    # which seems to be in openSUSE Tumbleweed since 20170413
+    return unless get_var('HDDVERSION', '') =~ /openSUSE-(12.1|12.2|13.1-gnome)/;
     loadtest 'fixup/enable_firewall';
 }
 

--- a/tests/fixup/enable_firewall.pm
+++ b/tests/fixup/enable_firewall.pm
@@ -16,6 +16,7 @@ use strict;
 use testapi;
 
 sub run() {
+    record_soft_failure('boo#1036590') if get_var('HDDVERSION', '') =~ /openSUSE-(12.1|12.2)/;
     x11_start_program('xterm');
     assert_script_sudo('SuSEfirewall2 on');
     send_key "alt-f4";


### PR DESCRIPTION
Since https://build.opensuse.org/request/show/483163 was accepted it seems the
firewall is disabled after upgrade from openSUSE 12.1 and openSUSE 12.2 to
current openSUSE Tumbleweed. We just accept this for the unsupported older
base image versions and enable the firewall after the upgrade like we already
do for openSUSE 13.1.

Related progress issue: https://progress.opensuse.org/issues/18578

Verification run: http://lord.arch/tests/6161#step/firewall_enabled/1