### PR TITLE
Fix package version in update repository

### DIFF
--- a/tests/casp/transactional_update.pm
+++ b/tests/casp/transactional_update.pm
@@ -61,7 +61,7 @@ sub run() {
     assert_script_run 'zypper ar utt.repo';
     trup_call 'reboot cleanup up';
     check_reboot_changes;
-    check_package '5.4.2';
+    check_package '5.30.1';
 
     # System should be up to date - no changes expected
     trup_call 'cleanup up';


### PR DESCRIPTION
Update repository was rebuild because of bsc#1034900

Fix for: https://openqa.suse.de/tests/888678#step/transactional_update/71