### PR TITLE
Package functions for migration tests

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -1,0 +1,89 @@
+# Copyright (C) 2017 SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package migration;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+
+use testapi;
+use utils;
+use registration;
+
+our @EXPORT = qw(
+  setup_online_migration
+  register_system_in_textmode
+  de_register
+);
+
+sub setup_online_migration {
+    my ($self) = @_;
+    # if source system is minimal installation then boot to textmode
+    # we don't care about source system start time because our SUT is upgraded one
+    $self->wait_boot(textmode => !is_desktop_installed, ready_time => 600);
+    select_console 'root-console';
+
+    # stop packagekit service
+    script_run "systemctl mask packagekit.service";
+    script_run "systemctl stop packagekit.service";
+
+    type_string "chown $username /dev/$serialdev\n";
+
+    # enable Y2DEBUG all time
+    type_string "echo 'export Y2DEBUG=1' >> /etc/bash.bashrc.local\n";
+    script_run "source /etc/bash.bashrc.local";
+
+    save_screenshot;
+}
+
+sub register_system_in_textmode {
+    # SCC_URL was placed to medium types
+    # so set SMT_URL here if register system via smt server
+    # otherwise must register system via real SCC before online migration
+    if (my $u = get_var('SMT_URL')) {
+        type_string "echo 'url: $u' > /etc/SUSEConnect\n";
+    }
+
+    # register system and addons in textmode for all archs
+    set_var("VIDEOMODE", 'text');
+    if (sle_version_at_least('12-SP2', version_variable => 'HDDVERSION')) {
+        set_var('HDD_SP2ORLATER', 1);
+    }
+    yast_scc_registration;
+}
+
+sub de_register {
+    my (%args) = @_;
+    $args{version_variable} //= 'VERSION';
+    if (sle_version_at_least('12-SP1', version_variable => $args{version_variable})) {
+        assert_script_run('SUSEConnect -d --cleanup');
+        my $output = script_output 'SUSEConnect -s';
+        die "System is still registered" unless $output =~ /Not Registered/;
+        save_screenshot;
+    }
+    else {
+        assert_script_run("zypper removeservice `zypper services --show-enabled-only --sort-by-name | awk {'print\$5'} | sed -n '1,2!p'`");
+        assert_script_run('rm /etc/zypp/credentials.d/* /etc/SUSEConnect');
+        my $output = script_output 'SUSEConnect -s';
+        die "System is still registered" unless $output =~ /Not Registered/;
+        save_screenshot;
+    }
+}
+
+1;
+
+# vim: sw=4 et

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -53,7 +53,6 @@ our @EXPORT = qw(
   addon_decline_license
   addon_license
   validate_repos
-  setup_online_migration
   turn_off_kde_screensaver
   random_string
   handle_login
@@ -805,26 +804,6 @@ sub validate_repos {
     if (check_var('DISTRI', 'sle') and !get_var('STAGING') and sle_version_at_least('12-SP1')) {
         validate_repos_sle($version);
     }
-}
-
-sub setup_online_migration {
-    my ($self) = @_;
-    # if source system is minimal installation then boot to textmode
-    # we don't care about source system start time because our SUT is upgraded one
-    $self->wait_boot(textmode => !is_desktop_installed, ready_time => 600);
-    select_console 'root-console';
-
-    # stop packagekit service
-    script_run "systemctl mask packagekit.service";
-    script_run "systemctl stop packagekit.service";
-
-    type_string "chown $username /dev/$serialdev\n";
-
-    # enable Y2DEBUG all time
-    type_string "echo 'export Y2DEBUG=1' >> /etc/bash.bashrc.local\n";
-    script_run "source /etc/bash.bashrc.local";
-
-    save_screenshot;
 }
 
 sub random_string {

--- a/tests/online_migration/sle12_online_migration/online_migration_setup.pm
+++ b/tests/online_migration/sle12_online_migration/online_migration_setup.pm
@@ -13,7 +13,7 @@
 use base "consoletest";
 use strict;
 use testapi;
-use utils;
+use migration;
 
 sub run() {
     my ($self) = @_;

--- a/tests/online_migration/sle12_online_migration/register_system.pm
+++ b/tests/online_migration/sle12_online_migration/register_system.pm
@@ -13,25 +13,11 @@
 use base "console_yasttest";
 use strict;
 use testapi;
-use registration;
-use utils;
+use migration;
 
 sub run() {
     select_console 'root-console';
-
-    # SCC_URL was placed to medium types
-    # so set SMT_URL here if register system via smt server
-    # otherwise must register system via real SCC before online migration
-    if (my $u = get_var('SMT_URL')) {
-        type_string "echo 'url: $u' > /etc/SUSEConnect\n";
-    }
-
-    # register system and addons in textmode for all archs
-    set_var("VIDEOMODE", 'text');
-    if (sle_version_at_least('12-SP2', version_variable => 'HDDVERSION')) {
-        set_var('HDD_SP2ORLATER', 1);
-    }
-    yast_scc_registration;
+    register_system_in_textmode;
 }
 
 sub test_flags {

--- a/tests/online_migration/sle12_online_migration/zypper_patch.pm
+++ b/tests/online_migration/sle12_online_migration/zypper_patch.pm
@@ -14,6 +14,7 @@ use base "consoletest";
 use strict;
 use testapi;
 use utils;
+use migration;
 
 sub run() {
     my ($self) = @_;

--- a/tests/update/patch_before_migration.pm
+++ b/tests/update/patch_before_migration.pm
@@ -12,6 +12,7 @@ use base "consoletest";
 use strict;
 use testapi;
 use utils;
+use migration;
 use registration;
 
 sub is_smt_or_module_tests {
@@ -49,20 +50,7 @@ sub patching_sle() {
     if (get_var('FULL_UPDATE')) {
         fully_patch_system();
     }
-
-    if (sle_version_at_least('12-SP1', version_variable => 'HDDVERSION')) {
-        assert_script_run('SUSEConnect -d --cleanup');
-        my $output = script_output 'SUSEConnect -s';
-        die "System is still registered" unless $output =~ /Not Registered/;
-        save_screenshot;
-    }
-    else {
-        assert_script_run("zypper removeservice `zypper services --show-enabled-only --sort-by-name | awk {'print\$5'} | sed -n '1,2!p'`");
-        assert_script_run('rm /etc/zypp/credentials.d/* /etc/SUSEConnect');
-        my $output = script_output 'SUSEConnect -s';
-        die "System is still registered" unless $output =~ /Not Registered/;
-        save_screenshot;
-    }
+    de_register(version_variable => 'HDDVERSION');
     assert_script_run("zypper mr --enable --all");
     set_var("VIDEOMODE", '');
     # keep the value of SCC_REGISTER for offline migration tests with smt pattern or modules


### PR DESCRIPTION
For better reuse of migration functions
Verified runs:
online: http://147.2.207.208/tests/491
offline: http://147.2.207.208/tests/494
(ignore ltss and timeout in runs)