### PR TITLE
Workaround ppc64le disk boot

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -130,17 +130,22 @@ sub bootmenu_default_params {
             assert_screen check_var('UEFI', 1) ? 'inst-video-typed-grub2' : 'inst-video-typed', 4;
         }
 
-        if (!get_var("NICEVIDEO") && !is_jeos) {
-            type_string_very_slow "plymouth.ignore-serial-consoles ";    # make plymouth go graphical
-            type_string_very_slow "linuxrc.log=$serialdev ";             # to get linuxrc logs in serial
-            type_string_very_slow "console=$serialdev ";                 # to get crash dumps as text
-            type_string_very_slow "console=tty ";                        # to get crash dumps as text
+        if (!get_var("NICEVIDEO")) {
+            if (is_jeos) {
+                type_string_very_slow "console=$serialdev ";    # to get crash dumps as text
+                type_string_very_slow "console=tty ";           # to get crash dumps as text
+            }
+            else {
+                type_string_very_slow "plymouth.ignore-serial-consoles ";    # make plymouth go graphical
+                type_string_very_slow "linuxrc.log=$serialdev ";             # to get linuxrc logs in serial
+                type_string_very_slow "console=$serialdev ";                 # to get crash dumps as text
+                type_string_very_slow "console=tty ";                        # to get crash dumps as text
 
-            assert_screen "inst-consolesettingstyped", 30;
+                assert_screen "inst-consolesettingstyped", 30;
 
-            # Enable linuxrc core dumps https://en.opensuse.org/SDB:Linuxrc#p_linuxrccore
-            type_string_very_slow "linuxrc.core=$serialdev ";
-
+                # Enable linuxrc core dumps https://en.opensuse.org/SDB:Linuxrc#p_linuxrccore
+                type_string_very_slow "linuxrc.core=$serialdev ";
+            }
             my $e = get_var("EXTRABOOTPARAMS");
             if ($e) {
                 type_string_very_slow "$e ";

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -3,6 +3,7 @@ use base 'basetest';
 
 use testapi;
 use utils;
+use bootloader_setup 'select_bootmenu_option';
 use strict;
 
 # Base class for all openSUSE tests
@@ -152,7 +153,7 @@ sub set_standard_prompt {
     $testapi::distri->set_standard_prompt;
 }
 
-sub select_bootmenu_option {
+sub select_bootmenu_more {
     my ($self, $tag, $more) = @_;
 
     assert_screen "inst-bootmenu", 15;
@@ -214,7 +215,7 @@ sub wait_boot {
     # Reset the consoles after the reboot: there is no user logged in anywhere
     reset_consoles;
     if (get_var("OFW")) {
-        assert_screen 'bootloader', $bootloader_time;
+        select_bootmenu_option;
     }
     # reconnect s390
     elsif (check_var('ARCH', 's390x')) {

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -3,7 +3,7 @@ use base 'basetest';
 
 use testapi;
 use utils;
-use bootloader_setup 'select_bootmenu_option';
+use bootloader_setup 'boot_local_disk';
 use strict;
 
 # Base class for all openSUSE tests
@@ -215,7 +215,8 @@ sub wait_boot {
     # Reset the consoles after the reboot: there is no user logged in anywhere
     reset_consoles;
     if (get_var("OFW")) {
-        select_bootmenu_option;
+        assert_screen 'bootloader', $bootloader_time;
+        boot_local_disk;
     }
     # reconnect s390
     elsif (check_var('ARCH', 's390x')) {
@@ -277,7 +278,7 @@ sub wait_boot {
             # assuming the cursor is on 'installation' by default and 'boot from
             # harddisk' is above
             send_key_until_needlematch 'inst-bootmenu-boot-harddisk', 'up';
-            wait_screen_change { send_key 'ret' };
+            boot_local_disk;
             if (check_var('ARCH', 'aarch64') and get_var('UEFI')) {
                 record_soft_failure 'bsc#1022064';
                 assert_screen 'boot-firmware';

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -374,10 +374,7 @@ sub load_boot_tests() {
     if (get_var("ISO_MAXSIZE")) {
         loadtest "installation/isosize";
     }
-    if (get_var("OFW")) {
-        loadtest "installation/bootloader_ofw";
-    }
-    elsif ((get_var("UEFI") || is_jeos()) && !check_var("BACKEND", "svirt")) {
+    if ((get_var("UEFI") || is_jeos()) && !check_var("BACKEND", "svirt")) {
         loadtest "installation/bootloader_uefi";
     }
     elsif (check_var("BACKEND", "svirt") && !check_var("ARCH", "s390x")) {
@@ -970,9 +967,6 @@ sub load_patching_tests() {
             loadtest "installation/bootloader_zkvm";
         }
     }
-    if (get_var("OFW")) {
-        loadtest "installation/bootloader_ofw";
-    }
     loadtest 'boot/boot_to_desktop_sym';
     loadtest 'update/patch_before_migration';
     # Lock package for offline migration by Yast installer
@@ -982,7 +976,6 @@ sub load_patching_tests() {
     loadtest 'console/consoletest_finish_sym';
     loadtest 'x11/reboot_and_install';
     loadtest 'installation/bootloader_zkvm_sym' if get_var('S390_ZKVM');
-    loadtest 'installation/bootloader_ofw_sym'  if get_var('OFW');
 }
 
 sub prepare_target() {

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -1,15 +1,15 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Rework the tests layout.
-# G-Maintainer: Alberto Planas <aplanas@suse.com>
+# Summary: Bootloader to setup boot process with arguments/options
+# Maintainer: Jozef Pupava <jpupava@suse.com>
 
 use base "installbasetest";
 use strict;
@@ -26,10 +26,18 @@ sub run() {
     bootmenu_network_source;
     specific_bootmenu_params;
     registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
-    select_bootmenu_language;
-    select_bootmenu_video_mode;
-    # boot
-    send_key "ret";
+    # on ppc64le boot have to be confirmed with ctrl-x or F10
+    # and it doesn't have nice graphical menu with video and language options
+    if (!check_var('ARCH', 'ppc64le')) {
+        select_bootmenu_language;
+        select_bootmenu_video_mode;
+        # boot
+        send_key 'ret';
+    }
+    else {
+        # boot
+        send_key 'ctrl-x';
+    }
 }
 
 1;

--- a/tests/installation/bootloader_ofw_sym.pm
+++ b/tests/installation/bootloader_ofw_sym.pm
@@ -1,1 +1,0 @@
-bootloader_ofw.pm

--- a/tests/installation/mediacheck.pm
+++ b/tests/installation/mediacheck.pm
@@ -26,7 +26,7 @@ sub run {
     }
 
     ensure_shim_import;
-    $self->select_bootmenu_option('inst-onmediacheck', 1);
+    $self->select_bootmenu_more('inst-onmediacheck', 1);
 
     # the timeout is insane - but some old DVDs took almost forever, could
     # recheck with all current one and lower again

--- a/tests/installation/memtest.pm
+++ b/tests/installation/memtest.pm
@@ -20,7 +20,7 @@ sub run {
     my $self = shift;
 
     ensure_shim_import;
-    $self->select_bootmenu_option('inst-onmemtest', 1);
+    $self->select_bootmenu_more('inst-onmemtest', 1);
     assert_screen "pass-complete", 700;
     send_key "esc";
 }

--- a/tests/installation/rescuesystem.pm
+++ b/tests/installation/rescuesystem.pm
@@ -20,7 +20,7 @@ sub run {
     my $self = shift;
 
     ensure_shim_import;
-    $self->select_bootmenu_option('inst-rescuesystem', 1);
+    $self->select_bootmenu_more('inst-rescuesystem', 1);
 
     assert_screen 'keyboardmap-list', 100;
     send_key "ret";

--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -19,8 +19,8 @@ use utils;
 sub run() {
     my ($self) = @_;
 
-    $self->wait_boot(ready_time => 600);
-
+    assert_screen 'displaymanager', 500;
+    ensure_unlocked_desktop;
     if (get_var('ZDUP_IN_X')) {
         x11_start_program('xterm');
         become_root;

--- a/tests/x11/reboot_and_install.pm
+++ b/tests/x11/reboot_and_install.pm
@@ -34,7 +34,8 @@ sub run() {
     specific_bootmenu_params;
     registration_bootloader_params;
     # boot
-    send_key "ret";
+    my $key = check_var('ARCH', 'ppc64le') ? 'ctrl-x' : 'ret';
+    send_key $key;
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
[poo#18228](https://progress.opensuse.org/issues/18228) and [poo#18580](https://progress.opensuse.org/issues/18580)

[fail](https://openqa.suse.de/tests/888821#step/boot_to_desktop_sym/4)

I hopefully tested all types of migration on ppc64le, browse and ask questions.
[test x86_64](http://10.100.12.155/tests)
[test ppc64le](http://furud.arch.suse.de/tests)