### PR TITLE
Use wait_screen_change for all setraidlevel keys

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -90,7 +90,7 @@ sub addraid {
 sub setraidlevel {
     my ($level) = @_;
     my %entry = (0 => 0, 1 => 1, 5 => 5, 6 => 6, 10 => 'g');
-    send_key "alt-$entry{$level}";
+    wait_screen_change { send_key "alt-$entry{$level}"; };
 
     wait_screen_change { send_key "alt-i"; };    # move to RAID name input field
     wait_screen_change { send_key "tab"; };      # skip RAID name input field


### PR DESCRIPTION
Latest attempt of fix for poo#18444 - Make partitioning_raid test compatible with UEFI on aarch64

Now all send_key() within setraidlevel are enveloped in wait_screen_change. At least It shouldn't brake anything else.

Tested on x86_64: http://dhcp209.suse.cz/tests/4190