### PR TITLE
Virtualization: code enhancement in installation/install_and_reboot

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -5,7 +5,8 @@ use strict;
 
 sub use_wicked() {
     script_run "cd /proc/sys/net/ipv4/conf";
-    script_run "for i in *[0-9]; do echo BOOTPROTO=dhcp > /etc/sysconfig/network/ifcfg-\$i; wicked --debug all ifup \$i; done";
+    script_run("for i in *[0-9]; do echo BOOTPROTO=dhcp > /etc/sysconfig/network/ifcfg-\$i; wicked --debug all ifup \$i; done", 300);
+    save_screenshot;
 }
 
 sub use_ifconfig() {

--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -115,7 +115,7 @@ sub run() {
     if (!get_var("REMOTE_CONTROLLER")) {
         do {
             send_key 'alt-s';
-        } until (wait_still_screen(3, 4));
+        } until (wait_still_screen(3, 4, 99));
         select_console 'install-shell';
 
         # check for right boot-device on s390x (zVM, DASD ONLY)


### PR DESCRIPTION
Installation subtest install_and_reboot is a main script that usually meet failures when running on ipmi. Change code to be more stable.

 Main changes:
      1) increase similarity level in wait_still_screen to ensure the installation process is really stopped
      2) increase timeout for wicked command to ensure this command really finish before the next start

Verification link:
http://147.2.212.135/tests/1057