### PR TITLE
Configure NTP servers on CaaSP admin node

### DIFF
--- a/tests/casp/oci_role.pm
+++ b/tests/casp/oci_role.pm
@@ -23,8 +23,17 @@ sub run() {
     send_key_until_needlematch "system-role-$role", 'down', 2;
     send_key 'ret' if (check_var('VIDEOMODE', 'text'));
 
-    # Set dashboard url for worker
-    if ($role eq 'worker') {
+    if ($role eq 'admin') {
+        # Try without ntp servers
+        send_key 'alt-i';
+        handle_simple_pw;
+        assert_screen 'ntp-servers-missing';
+        send_key 'alt-n';
+
+        send_key 'alt-t';
+        type_string 'ns.openqa.test';
+    }
+    elsif ($role eq 'worker') {
         # Try with empty controller node
         send_key 'alt-i';
         handle_simple_pw;
@@ -36,6 +45,7 @@ sub run() {
         type_string 'dashboard-url';
         assert_screen 'dashboard-url';
     }
+    save_screenshot;
 }
 
 1;

--- a/tests/casp/one_line_checks.pm
+++ b/tests/casp/one_line_checks.pm
@@ -34,6 +34,7 @@ sub run() {
     # check if installation script was executed https://trello.com/c/PJqM8x0T
     if (check_var('SYSTEM_ROLE', 'admin')) {
         assert_script_run 'zgrep manifests/activate.sh /var/log/YaST2/y2log-1.gz';
+        assert_script_run 'grep "^server ns.openqa.test" /etc/ntp.conf';
     }
 }
 

--- a/tests/casp/services_enabled.pm
+++ b/tests/casp/services_enabled.pm
@@ -18,7 +18,7 @@ use testapi;
 
 my %services_for = (
     default => [qw(sshd cloud-init-local cloud-init cloud-config cloud-final issue-generator issue-add-ssh-keys)],
-    admin   => [qw(container-feeder docker kubelet etcd)],
+    admin   => [qw(container-feeder docker kubelet etcd ntpd)],
     worker  => [qw(container-feeder salt-minion systemd-timesyncd)],
     plain   => undef
 );


### PR DESCRIPTION
Fix for: https://openqa.suse.de/tests/896376#step/oci_install/12
Local run: http://dhcp91.suse.cz/tests/4697