### PR TITLE
Remove pidstat data gathering

### DIFF
--- a/tests/toolchain/gcc5_C_compilation.pm
+++ b/tests/toolchain/gcc5_C_compilation.pm
@@ -18,9 +18,6 @@ use testapi;
 sub run() {
     my $self = shift;
 
-    script_run 'zypper -v -n in sysstat';
-    assert_script_run '(pidstat -p ALL 1 > /tmp/pidstat.txt &)';
-
     # Fixes https://github.com/linux-test-project/ltp/issues/91
     script_run 'wget ' . data_url('toolchain/794b46d9.patch');
     script_run 'wget ' . data_url('toolchain/ltp-full-20170116.tar.xz');
@@ -61,10 +58,6 @@ sub run() {
 sub post_fail_hook() {
     my $self = shift;
 
-    script_run('kill %1');
-    script_run('xz /tmp/pidstat.txt');
-    upload_logs('/tmp/pidstat.txt.xz');
-    record_soft_failure 'bsc#1024050';
     script_run 'tar cvvfJ ltp-run-outputdir.tar.xz /opt/ltp/output/';
     upload_logs 'ltp-run-outputdir.tar.xz';
     upload_logs '/tmp/configure.log';

--- a/tests/toolchain/gcc5_Cpp_compilation.pm
+++ b/tests/toolchain/gcc5_Cpp_compilation.pm
@@ -18,8 +18,7 @@ use testapi;
 sub run() {
     my $self = shift;
 
-    script_run 'zypper -v -n in cmake sysstat';
-    assert_script_run '(pidstat -p ALL 1 > /tmp/pidstat.txt &)';
+    script_run 'zypper -v -n in cmake';
     my $package = data_url('toolchain/llvm-3.8.1.src.tar.xz');
     script_run "wget $package";
     $package = data_url('toolchain/cfe-3.8.1.src.tar.xz');
@@ -64,10 +63,6 @@ sub run() {
 sub post_fail_hook() {
     my $self = shift;
 
-    script_run('kill %1');
-    script_run('xz /tmp/pidstat.txt');
-    upload_logs('/tmp/pidstat.txt.xz');
-    record_soft_failure 'bsc#1024050';
     $self->export_logs();
     upload_logs '/tmp/configure.log';
     upload_logs '/tmp/make.log';


### PR DESCRIPTION
https://progress.opensuse.org/issues/18206#note-4

The bug hasn't been seen for a month, since btrfs quota workaround.
Supersedes https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/2784.