### PR TITLE
Introduce is_patch_needed function (poo#18734)

### DIFF
--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -17,7 +17,7 @@ use Exporter;
 use testapi;
 use utils;
 
-our @EXPORT = qw(capture_state check_automounter snap_revert);
+our @EXPORT = qw(capture_state check_automounter snap_revert is_patch_needed);
 
 sub capture_state {
     my ($state, $y2logs) = @_;
@@ -59,6 +59,16 @@ sub snap_revert {
     my ($svirt, $vm_name, $snapshot) = @_;
     my $ret = $svirt->run_cmd("virsh snapshot-revert $vm_name $snapshot --running");
     die "Snapshot revert $snapshot failed" if $ret;
+}
+
+sub is_patch_needed {
+    my $patch = shift;
+    my $install = shift // 0;
+
+    my $patch_status = script_output("zypper -n info -t patch $patch");
+    if ($patch_status =~ /Status\s*:\s+[nN]ot\s[nN]eeded/) {
+        return $install ? $patch_status : 1;
+    }
 }
 
 1;

--- a/tests/qam-minimal/install_patterns.pm
+++ b/tests/qam-minimal/install_patterns.pm
@@ -32,7 +32,7 @@ sub install_packages {
     # loop over packages in patchinfo and try installation
     foreach my $line (split(/\n/, $patch_info)) {
         if (my ($package) = $line =~ $pattern) {
-            script_run("zypper -n in $package", 700);
+            zypper_call("in $package");
             save_screenshot;
         }
     }
@@ -58,10 +58,8 @@ sub run {
     # now we have gnome installed - restore DESKTOP variable
     set_var('DESKTOP', get_var('FULL_DESKTOP'));
 
-    my $patch_status = script_output("zypper -n info -t patch $patch");
-    if ($patch_status =~ /Status\s*:\s+[Nn]ot\s[Nn]eeded/) {
-        install_packages($patch_status);
-    }
+    my $patch_status = is_patch_needed($patch, 1);
+    install_packages($patch_status) if $patch_status;
 
     prepare_system_reboot;
     type_string "reboot\n";

--- a/tests/qam-minimal/install_update.pm
+++ b/tests/qam-minimal/install_update.pm
@@ -39,10 +39,9 @@ sub run {
     zypper_call("ref");
 
     # test if is patch needed and record_info
-    my $patch_status = script_output("zypper -n info -t patch $patch");
     # record softfail on QAM_MINIMAL=small tests, or record info on others
     # if isn't patch neded, zypper call with install makes no sense
-    if ($patch_status =~ /Status\s*:\s+[nN]ot\s[nN]eeded/) {
+    if (is_patch_needed($patch)) {
         if (check_var('QAM_MINIMAL', 'small')) {
             record_soft_failure("Patch isn't needed on minimal installation poo#17412");
         }


### PR DESCRIPTION
This introduces to lib/qam.pm function is_patch_needed which returns
True or patchinfo if is patch needed on SUT.

It sets kgraft test to fail state if path isn't needed.

Plus remove old KGRAFT_TEST_REPO variable and use INCIDENT_PATCH instead
guessing patch name from incident repository