### PR TITLE
Revert "LTP: networking: Define interfaces to fix multicast tests"

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -30,7 +30,7 @@ sub run {
     assert_script_run('export LTPROOT=/opt/ltp; export LTP_COLORIZE_OUTPUT=n TMPDIR=/tmp PATH=$LTPROOT/testcases/bin:$PATH');
 
     # setup for LTP networking tests
-    assert_script_run("export PASSWD='$testapi::password' LHOST_IFACES=ens4 RHOST_IFACES=ens4");
+    assert_script_run("export PASSWD='$testapi::password'");
 
     my $block_dev = get_var('LTP_BIG_DEV');
     if ($block_dev && get_var('NUMDISKS') > 1) {

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -290,7 +290,10 @@ sub run {
         script_run('ip route');
         script_run('ip -6 route');
 
-        script_run('ping -c 2 8.8.8.8');
+        script_run('ping -c 2 $IPV4_NETWORK.$LHOST_IPV4_HOST');
+        script_run('ping -c 2 $IPV4_NETWORK.$RHOST_IPV4_HOST');
+        script_run('ping6 -c 2 $IPV6_NETWORK:$LHOST_IPV6_HOST');
+        script_run('ping6 -c 2 $IPV6_NETWORK:$RHOST_IPV6_HOST');
     }
 
     for my $test (@tests) {


### PR DESCRIPTION
This reverts commit 9a5a8694fc0d022f010bfcd3a068ab5684745e63.

This is reverted as it requires to setup variables also for network
namespaces based testing and does not solve problems with ping to
multicast address.