### PR TITLE
Fix installation timeout on encrypted system

### DIFF
--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -40,6 +40,8 @@ sub run() {
     my $self = shift;
     # NET isos are slow to install
     my $timeout = 2000;
+    # and encryption makes it even slower
+    $timeout *= 2 if get_var('ENCRYPT');
 
     # workaround for yast popups and
     # detect "Wrong Digest" error to end test earlier


### PR DESCRIPTION
See https://openqa.suse.de/tests/890914#step/install_and_reboot/21 as an
example.