### PR TITLE
On triggering shutdown disable vnc stall detection

### DIFF
--- a/tests/x11/shutdown.pm
+++ b/tests/x11/shutdown.pm
@@ -128,6 +128,7 @@ sub run() {
 
     }
 
+    console->disable_vnc_stalls;
     $self->{await_shutdown} = 1;
     assert_shutdown;
 }


### PR DESCRIPTION
VNC server can go down at any time and relogin is the least we want
in this case. But we can't look away from the console, otherwise we
would not notice problems on shutdown