### PR TITLE
Fix kontact config file path

### DIFF
--- a/tests/x11/kontact.pm
+++ b/tests/x11/kontact.pm
@@ -24,6 +24,8 @@ sub run() {
     # To disable it run at first time start
     x11_start_program("echo \"[General]\" >> ~/.kde4/share/config/kmail2rc");
     x11_start_program("echo \"first-start=false\" >> ~/.kde4/share/config/kmail2rc");
+    x11_start_program("echo \"[General]\" >> ~/.config/kmail2rc");
+    x11_start_program("echo \"first-start=false\" >> ~/.config/kmail2rc");
 
     x11_start_program("kontact", 6, {valid => 1});
 


### PR DESCRIPTION
This lets kontact5 behave correctly as if it's not the first run,
fixing boo#1036736