### PR TITLE
Fix poo#18774

### DIFF
--- a/data/console/test_java.sh
+++ b/data/console/test_java.sh
@@ -108,15 +108,17 @@ test_java_alternatives () {
 test_javac_alternatives () {
     list_all_javac_alternatives
 #    java_versions=$(cat $LIST_ALL_INSTALLED_VERSIONS | wc -l)
-    javac_versions=$(rpm -qa | grep java | grep devel | wc -l)
+    javac_versions=$(rpm -qa | grep java | grep devel | grep -v debuginfo | wc -l)
     javac_alternatives=$(cat $LIST_ALL_JAVAC_ALTERNATIVES | wc -l)
     if [ $javac_versions -eq $javac_alternatives ]; then
 	echo "javac: PASS"
     else
 	echo "javac: FAIL"
         echo "Debug:"
-        echo "Number of java versions: $java_versions and number of javac_alternatives $javac_alternatives"
+        echo "Number of java versions: $javac_versions and number of javac_alternatives $javac_alternatives"
         echo
+        echo "List all javac_versions"
+        rpm -qa | grep java | grep devel | grep -v debuginfo
         echo "List all javac alternatives"
         cat $LIST_ALL_JAVAC_ALTERNATIVES
 	exit 1


### PR DESCRIPTION
Fixes the check between `javac` and `javac alternatives`.
Improve debugging experience by adding more verbose output in case of failure.

I tested it in the same system as https://openqa.suse.de/tests/898280#step/java/17 and it fixes the problem:

AFTER THE FIX
=============

```
----------------------------
Find installed Java versions
----------------------------
java-1_8_0-openjdk
java-1_7_0-openjdk
java-1_8_0-ibm
java-1_7_1-ibm

------------------------------------------------------
Test if there's an alternative per Java, Devel, Plugin
------------------------------------------------------
java: PASS
javac: PASS
javaplugin: PASS

---------------------------------------------------------------------------------------
Set java/javac/plugin update alternative for each Java version, compile/run Hello World
---------------------------------------------------------------------------------------
java-1_8_0-openjdk:
update-alternatives: using /usr/lib64/jvm/jre-1.8.0-openjdk/bin/java to provide /usr/bin/java (java) in manual mode
update-alternatives: using /usr/lib64/jvm/java-1.8.0-openjdk/bin/javac to provide /usr/bin/javac (javac) in manual mode
check linked java version: PASS
check linked javac version: PASS
Java Compiler: PASS
Java runtime: PASS

java-1_7_0-openjdk:
update-alternatives: using /usr/lib64/jvm/jre-1.7.0-openjdk/bin/java to provide /usr/bin/java (java) in manual mode
update-alternatives: using /usr/lib64/jvm/java-1.7.0-openjdk/bin/javac to provide /usr/bin/javac (javac) in manual mode
check linked java version: PASS
check linked javac version: PASS
Java Compiler: PASS
Java runtime: PASS

java-1_8_0-ibm:
update-alternatives: using /usr/lib64/jvm/jre-1.8.0-ibm/bin/java to provide /usr/bin/java (java) in manual mode
update-alternatives: using /usr/lib64/jvm/java-1.8.0-ibm/bin/javac to provide /usr/bin/javac (javac) in manual mode
update-alternatives: using /usr/lib64/jvm/java-1.8.0-ibm-1.8.0/jre/lib/amd64//libnpjp2.so to provide /usr/lib64/browser-plugins/javaplugin.so (javaplugin) in manual mode
check linked java version: PASS
check linked javac version: PASS
Java Compiler: PASS
Java runtime: PASS

java-1_7_1-ibm:
update-alternatives: using /usr/lib64/jvm/jre-1.7.1-ibm/bin/java to provide /usr/bin/java (java) in manual mode
update-alternatives: using /usr/lib64/jvm/java-1.7.1-ibm/bin/javac to provide /usr/bin/javac (javac) in manual mode
update-alternatives: using /usr/lib64/jvm/java-1.7.1-ibm-1.7.1/jre/lib/amd64//libnpjp2.so to provide /usr/lib64/browser-plugins/javaplugin.so (javaplugin) in manual mode
check linked java version: OK./test_java.sh: line 168: INFO: linked java is: 1.7.0 which is normal according to bnc#1014602: command not found
check linked javac version: OK./test_java.sh: line 168: INFO: linked javac is: 1.7.0 which is normal according to bnc#1014602: command not found
Java Compiler: PASS
Java runtime: PASS
```