### PR TITLE
Add support for booting images on aarch64

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -28,6 +28,7 @@ our @EXPORT = qw(
   specific_bootmenu_params
   select_bootmenu_video_mode
   select_bootmenu_language
+  tianocore_enter_menu
   tianocore_select_bootloader
 );
 
@@ -355,10 +356,15 @@ sub select_bootmenu_language {
     }
 }
 
-sub tianocore_select_bootloader {
+sub tianocore_enter_menu {
     # press F2 and be quick about it
-    send_key_until_needlematch('tianocore-mainmenu',    'f2',   15, 1);
-    send_key_until_needlematch('tianocore-bootmanager', 'down', 5,  5);
+    send_key_until_needlematch('tianocore-mainmenu', 'f2', 15, 1);
+}
+
+
+sub tianocore_select_bootloader {
+    tianocore_enter_menu;
+    send_key_until_needlematch('tianocore-bootmanager', 'down', 5, 5);
     send_key 'ret';
 }
 


### PR DESCRIPTION
There seems to be problem in firmware or how we set up our virtual machines.
As this issue persists for a year now this commit adds support to instruct
the tianocore boot menue to boot the EFI file which is installed on disk.
This works when using `wait_boot`.

Necessary needles have been created for SLE already.

Verification run: https://openqa.suse.de/tests/907589

Related progress issue: https://progress.opensuse.org/issues/11948