### PR TITLE
Move soft failure to SP4

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -315,7 +315,7 @@ sub workaround_type_encrypted_passphrase {
         || (check_var('ARCH', 'ppc64le')
             && (get_var('ENCRYPT') && !get_var('ENCRYPT_ACTIVATE_EXISTING') || get_var('ENCRYPT_FORCE_RECOMPUTE'))))
     {
-        record_soft_failure 'workaround https://fate.suse.com/320901' if sle_version_at_least('12-SP3');
+        record_soft_failure 'workaround https://fate.suse.com/320901' if sle_version_at_least('12-SP4');
         unlock_if_encrypted;
     }
 }


### PR DESCRIPTION
- [fate#320901](https://fate.suse.com/320901) passing crypt password from bootloader to avoid typing password twice