### PR TITLE
Virtualization: resetup serial console setting for kvm tests

### DIFF
--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -42,7 +42,7 @@ sub update_package() {
 sub run() {
     my $self = shift;
     $self->update_package();
-    if (!get_var("PROXY_MODE") && (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen"))) {
+    if (!get_var("PROXY_MODE")) {
         resetup_console;
     }
     repl_repo_in_sourcefile();


### PR DESCRIPTION
Serial console needs to be resetup for kvm after updating package which may change grub files.