### PR TITLE
LTP: Wait for the terminal prompt to appear before typing

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -17,8 +17,22 @@ use Exporter;
 use bmwqemu ();
 
 BEGIN {
-    our @EXPORT = qw(login);
+    our @EXPORT = qw($serial_term_prompt login);
 }
+
+=head2 serial_term_prompt
+
+   wait_serial($serial_term_prompt);
+
+A simple undecorated prompt for serial terminals. ANSI escape characters only
+serve to create log noise in most tests which use the serial terminal, so
+don't use them here. Also avoid using characters which have special meaning in
+a regex. Note that our common prompt character '#' denotes a comment in a
+regex with '/z' on the end, but if you are using /z you will need to wrap the
+prompt in \Q and \E anyway otherwise the whitespace will be ignored.
+
+=cut
+our $serial_term_prompt = '# ';
 
 =head2 login
 
@@ -44,9 +58,8 @@ sub login {
     type_password;
     type_string("\n");
     wait_serial(qr/$escseq* \w+:~\s\# $escseq* \s*$/x);
-    # TODO: use distribution::set_standard_prompt
-    type_string(qq/PS1="# "\n/);
-    wait_serial(qr/PS1="# "\s+# $/);
+    type_string(qq/PS1="$serial_term_prompt"\n/);
+    wait_serial(qr/PS1="$serial_term_prompt"\s+# $/);
     # TODO: Send 'tput rmam' instead/also
     assert_script_run('stty cols 2048');
     assert_script_run('echo Logged into $(tty)', $bmwqemu::default_timeout, result_title => 'vconsole_login');

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -19,6 +19,7 @@ use utils;
 use Time::HiRes qw(clock_gettime CLOCK_MONOTONIC);
 use File::Basename 'basename';
 use JSON;
+use serial_terminal;
 require bmwqemu;
 
 sub start_result {
@@ -458,6 +459,7 @@ EOF
         }
 
         if (is_serial_terminal) {
+            wait_serial($serial_term_prompt, undef, 0, no_regex => 1);
             type_string($cmd_text);
             wait_serial($cmd_text, undef, 0, no_regex => 1);
             type_string("\n");


### PR DESCRIPTION
I suspect Bash drops I/O data on rare occasions because we are sending input
too early. If true then we need to wait for the prompt to appear before
sending data.

Also we may accidentally send data to the STDIN of the echo program if we are
very quick. I don't think echo reads STDIN, but it's possible that the data
will get dropped when echo closes, depending on how the shell handles STDIO
for its children.

If this stops some of the random failures then we may need to do it for all
script_run calls. This makes the output from the LTP look even worse, but it
is more important that the tests are run.

Requires os-autoinst PR: os-autoinst/os-autoinst#772