### PR TITLE
Reconnect serial line on Xen after reboot

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -335,6 +335,11 @@ sub wait_boot {
         }
     }
 
+    # On Xen we have to re-connect to serial line as Xen closed it after restart
+    if (check_var('VIRSH_VMM_FAMILY', 'xen')) {
+        console('svirt')->attach_to_running;
+    }
+
     # on s390x svirt is encryption unlocked with workaround_type_encrypted_passphrase before this wait_boot
     unlock_if_encrypted if !get_var('S390_ZKVM');
 


### PR DESCRIPTION
Fails here: https://openqa.suse.de/tests/918106#step/console_reboot/8
Verification run: http://assam.suse.cz/tests/5781#step/console_reboot/10