### PR TITLE
Run redefine_svirt_domain.pm only on Xen

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1337,7 +1337,7 @@ else {
         load_boot_tests();
         loadtest "jeos/firstrun";
         loadtest "jeos/grub2_gfxmode";
-        if (check_var('BACKEND', 'svirt')) {
+        if (check_var('VIRSH_VMM_FAMILY', 'xen')) {
             loadtest "installation/redefine_svirt_domain";
         }
         loadtest "jeos/diskusage";


### PR DESCRIPTION
No other hypervizor that Xen seems to reset serial console and VNC
connections.