### PR TITLE
user_defined_snapshot: Handle aarch64 specific uefi workaround

### DIFF
--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -55,6 +55,7 @@ sub run() {
     send_key "alt-l";
     type_string "reboot\n";
 
+    $self->handle_uefi_boot_disk_workaround() if (check_var('MACHINE', 'aarch64') && get_var('BOOT_HDD_IMAGE'));
     assert_screen "grub2";
     send_key 'up';
 


### PR DESCRIPTION
Allows to execute gnome extra tests on aarch64 where we need the workaround
for booting from the disk image.