### PR TITLE
Allow to trigger 'install_all_from_repository' by defining variable

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -730,6 +730,7 @@ sub load_consoletests() {
         if (!is_staging() && sle_version_at_least('12-SP2')) {
             loadtest "console/zypper_lifecycle";
         }
+        loadtest 'console/install_all_from_repository' if get_var('INSTALL_ALL_REPO');
         loadtest "console/consoletest_finish";
     }
 }


### PR DESCRIPTION
We have the test module 'install_all_from_repository' which has been added to
the test plan explicitly for HPC testing. For generic testing it would be
useful to enable the test module without needing to change test source code.
This commit triggers the test module at the end of console tests if the
variable INSTALL_ALL_REPO is defined in the test. For a successful execution
the variable must contain a valid repository name as described in the method
description for "install_all_from_repo".