### PR TITLE
Fix regression in ad619f68 always expecting 'displaymanager'

### DIFF
--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -19,7 +19,8 @@ use utils;
 sub run() {
     my ($self) = @_;
 
-    assert_screen 'displaymanager', 500;
+    my $initial_screen = (get_var('NOAUTOLOGIN') || get_var('XDMUSED')) ? 'displaymanager' : 'generic-desktop';
+    assert_screen $initial_screen, 500;
     ensure_unlocked_desktop;
     if (get_var('ZDUP_IN_X')) {
         x11_start_program('xterm');


### PR DESCRIPTION
In before we had the more generic wait_boot method. Now, when we want to
explicitly check for the display manager (or desktop) to be present we need to
care about the different configurations, e.g. autologin.

Related progress issue: https://progress.opensuse.org/issues/18996