### PR TITLE
setup_zdup: Put back 'wait_boot' after ad619f68 to fix openSUSE migration

### DIFF
--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -19,7 +19,8 @@ use utils;
 sub run() {
     my ($self) = @_;
 
-    assert_screen 'displaymanager', 500;
+    my $initial_screen = (get_var('NOAUTOLOGIN') || get_var('XDMUSED')) ? 'displaymanager' : 'generic-desktop';
+    assert_screen $initial_screen, 500;
     ensure_unlocked_desktop;
     if (get_var('ZDUP_IN_X')) {
         x11_start_program('xterm');

--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -19,9 +19,7 @@ use utils;
 sub run() {
     my ($self) = @_;
 
-    my $initial_screen = (get_var('NOAUTOLOGIN') || get_var('XDMUSED')) ? 'displaymanager' : 'generic-desktop';
-    assert_screen $initial_screen, 500;
-    ensure_unlocked_desktop;
+    $self->wait_boot(ready_time => 600);
     if (get_var('ZDUP_IN_X')) {
         x11_start_program('xterm');
         become_root;


### PR DESCRIPTION
The more generic and original approach using 'wait_boot' seems better here as
it handles openSUSE and SLE correctly in general, wastes less time as it
handles the bootloader and therefore also allows to add specific steps where
necessary e.g. for machine specific bootloader workarounds, e.g. to handle
aarch64 tianocore booting.
If there is any specific handling necessary it should probably be handled
within wait_boot and not in setup_zdup.

Local verifcation run: http://lord.arch/tests/6184

Related progress issue: https://progress.opensuse.org/issues/18996