### PR TITLE
Send down key to the right pattern instead of assert_and_click

### DIFF
--- a/tests/installation/installer_desktopselection.pm
+++ b/tests/installation/installer_desktopselection.pm
@@ -41,9 +41,9 @@ sub run() {
     if (get_var('NEW_DESKTOP_SELECTION') && $d eq 'custom') {
         assert_screen "pattern-selection";
         my $de = get_var('DESKTOP');
-        assert_and_click "pattern-$de";
-        assert_and_click "pattern-$de-selected";
-        save_screenshot;
+        send_key_until_needlematch "pattern-$de-selected", 'down';
+        send_key 'spc';
+        assert_screen "pattern-$de-checked";
         send_key $cmd{ok};
     }
 }


### PR DESCRIPTION
With splits patterns, now "Base technologies" group is in the very first on the list rather than "Graphical environment", send down key to scroll down the list until on the right pattern.

http://147.2.211.148/tests/501

Note that: will create ``patterns-$de-checked`` needle on o3 directly after this got merged.