### PR TITLE
Update exit statement of Yast registration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -202,7 +202,7 @@ sub fill_in_registration_data {
                 # set check_screen timeout longer to ensure the screen checked in this case
                 elsif (match_has_tag('yast-scc-emptypkg')) {
                     send_key 'alt-a';
-                    next;  # this could be last, but it can happen that during processing packages it looks like empty packages to install and then it will fail
+                    last;    # The needle of empty packages has been update more specific, no need to enter determine statement again.
                 }
                 elsif (match_has_tag('inst-addon')) {
                     # it would show Add On Product screen if scc registration correctly during installation


### PR DESCRIPTION
The needle of yast-scc-emptypkg has update more specific, no need to
enter the determine statement again.
Enter the determine will cause infinite wait, and the case will be failed after time out