### PR TITLE
Leave the actual boot entry selection to "wait_boot"

### DIFF
--- a/tests/x11/reboot_and_install.pm
+++ b/tests/x11/reboot_and_install.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -33,9 +33,14 @@ sub run() {
     bootmenu_default_params;
     specific_bootmenu_params;
     registration_bootloader_params;
-    # boot
-    my $key = check_var('ARCH', 'ppc64le') ? 'ctrl-x' : 'ret';
-    send_key $key;
+
+    # Boot the entry unless we are in "zdup" upgrade where we expect the
+    # bootloader entry to be still shown
+    unless (get_var('ZDUP')) {
+        # boot
+        my $key = check_var('ARCH', 'ppc64le') ? 'ctrl-x' : 'ret';
+        send_key $key;
+    }
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
After "reboot_and_install" we commonly use "setup_zdup" which starts with
"wait_boot" expecting the bootloader screen so we can go into the bootloader
screen but we should not trigger the boot already in reboot_and_install.

See https://openqa.suse.de/tests/924742#step/setup_zdup/1

Related progress issue: https://progress.opensuse.org/issues/18228