### PR TITLE
Replace unnecessary wait_idle with assert_screen

### DIFF
--- a/tests/x11/yast2_snapper.pm
+++ b/tests/x11/yast2_snapper.pm
@@ -62,7 +62,7 @@ sub run() {
 
     # Start an xterm as root
     x11_start_program("xterm");
-    wait_idle;
+    assert_screen "xterm";
     become_root;
     script_run "cd";
 


### PR DESCRIPTION
Because of wait_idle description:
It's wasting a lot of time and should be avoided as such. Take it as last resort if there is nothing else you can assert on.