### PR TITLE
LTP: tests with warnings considered as passed

### DIFF
--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -143,6 +143,10 @@ sub parse_ltp_log {
             elsif ($1 == 32 && $tfail) {
                 say $fh 'TEST EXIT CODE IS 32 (TCONF), YET TFAIL OR TBROK WAS SEEN!';
             }
+            elsif ($1 == 4) {
+                say $fh 'Passed with warnings.';
+                $tconf = 0;
+            }
             elsif ($1 == 32) {
                 say $fh 'Test process returned TCONF (32).';
                 $tconf = 1;


### PR DESCRIPTION
as warnings shouldn't mean failure.

This fixes poo#19042.