### PR TITLE
Use xen-kbdfront.ptr_size on Xen PV

### DIFF
--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -51,7 +51,7 @@ sub run() {
                 $cmdline .= "xenfb.video=4,1024,768 ";
             }
             else {
-                $cmdline .= "xen-fbfront.video=32,1024,768 ";
+                $cmdline .= 'xen-fbfront.video=32,1024,768 xen-kbdfront.ptr_size=1024,768 ';
             }
             $cmdline .= "console=$xenconsole console=tty ";
         }
@@ -293,13 +293,13 @@ sub run() {
         type_string "echo -en '\\033[K' > \$pty\n";                         # end of line
         type_string "echo -en ' $cmdline' > \$pty\n";
         if (sle_version_at_least('12-SP2') or is_casp) {
-            type_string "echo -en ' xen-fbfront.video=32,1024,768' > \$pty\n";    # set kernel framebuffer
+            type_string "echo -en ' xen-fbfront.video=32,1024,768 xen-kbdfront.ptr_size=1024,768 ' > \$pty\n";    # set kernel framebuffer
         }
         else {
-            type_string "echo -en ' xenfb.video=4,1024,768' > \$pty\n";           # set kernel framebuffer
+            type_string "echo -en ' xenfb.video=4,1024,768' > \$pty\n";                                           # set kernel framebuffer
         }
 
-        type_string "echo -en '\\x18' > \$pty\n";                                 # send Ctrl-x to boot guest kernel
+        type_string "echo -en '\\x18' > \$pty\n";                                                                 # send Ctrl-x to boot guest kernel
         save_screenshot;
     }
 

--- a/tests/jeos/grub2_gfxmode.pm
+++ b/tests/jeos/grub2_gfxmode.pm
@@ -37,7 +37,7 @@ sub run {
         $video = "video=hyperv_fb:1024x768";
     }
     elsif (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')) {
-        $video = 'xen-fbfront.video=32,1024,768';
+        $video = 'xen-fbfront.video=32,1024,768 xen-kbdfront.ptr_size=1024,768 ';
     }
 
     if ($video) {


### PR DESCRIPTION
Thanks to solved bsc#1020616 we are now able to place pointer to
expected x/y axis via `xen-kbdfront.ptr_size` kernel option. Supersedes
https://github.com/os-autoinst/os-autoinst/pull/699.