### PR TITLE
LTP: Write results to JSON file

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -79,12 +79,15 @@ sub install_from_git {
     script_run 'export CREATE_ENTRIES=1';
     assert_script_run 'make install', timeout => 360;
     assert_script_run "find ~/ltp/testcases/open_posix_testsuite/conformance/interfaces -name '*.run-test' > ~/openposix_test_list.txt";
+    # It is a shallow clone so 'git describe' won't work
+    script_run 'git log -1 --pretty=format:"git %h" > /opt/ltp_version';
 }
 
 sub install_from_repo {
     zypper_call 'in qa_test_ltp';
     zypper_call('in ntfsprogs') if we_available;
     assert_script_run q(find ${LTPROOT:-/opt/ltp}/testcases/bin/openposix/conformance/interfaces/ -name '*.run-test' > ~/openposix_test_list.txt);
+    script_run 'rpm -q qa_test_ltp > /opt/ltp_version';
 }
 
 sub run {


### PR DESCRIPTION
We already do some parsing of the LTP log in OpenQA, so we can use the result
of that parsing to also write out a structured JSON file with test results in it.

Output may look something like
```
{
   "format" : "result_array:v1",
   "results" : [
      {
         "environment" : {
            "harness" : "SUSE OpenQA",
            "libc" : "",
            "kernel" : "",
            "product" : "sle:12-SP3",
            "revision" : "0344",
            "arch" : "qemu_x86_64"
         },
         "test" : {
            "duration" : 0.00689668099221308,
            "log" : "\r\nabs01       1  TPASS  :  Test passed\r\nabs01       2  TPASS  :  Test passed\r\nabs01       3  TPASS  :  Test passed\r\n### TEST abs01 COMPLETE >>> 0"
         },
         "pass" : "true",
         "test_fqn" : "LTP:math:abs01"
      },
      {
         "test" : {
            "duration" : 0.00675127700378653,
            "log" : "\r\natof01      1  TPASS  :  Test passed\r\natof01      2  TPASS  :  Test passed\r\natof01      3  TPASS  :  Test passed\r\natof01      4  TPASS  :  Test passed\r\n### TEST atof01 COMPLETE >>> 0"
         },
         "environment" : {
            "kernel" : "",
            "libc" : "",
            "harness" : "SUSE OpenQA",
            "product" : "sle:12-SP3",
            "revision" : "0344",
            "arch" : "qemu_x86_64"
         },
         "pass" : "true",
         "test_fqn" : "LTP:math:atof01"
      },
  ]
}
```

This is suitable for being dumped straight into a key-value store like Redis (which has JSON values) or a document store like CouchDB. Alternatively it could be parsed and put into an SQL database. The structure is explained in the code, line 210.

https://progress.opensuse.org/issues/19104

@mimi1vx 