### PR TITLE
Fix ppc64le booting on zdup (poo#18228)

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -22,6 +22,7 @@ use lockapi;
 use mm_network;
 
 our @EXPORT = qw(
+  stop_grub_timeout
   boot_local_disk
   pre_bootmenu_setup
   select_bootmenu_option
@@ -35,17 +36,32 @@ our @EXPORT = qw(
   tianocore_select_bootloader
 );
 
+# prevent grub2 timeout; 'esc' would be cleaner, but grub2-efi falls to the menu then
+sub stop_grub_timeout {
+    send_key 'up';
+}
+
 sub boot_local_disk {
     if (check_var('ARCH', 'ppc64le')) {
         # TODO use bootindex to properly boot from disk when first in boot order is cd-rom
         wait_screen_change { send_key 'ret' };
-        if (check_screen 'inst-slof', 5) {
-            # specify local disk for boot
+        assert_screen [qw(inst-slof bootloader grub2 inst-bootmenu)];
+        if (match_has_tag 'grub2') {
+            diag 'already in grub2, returning from boot_local_disk';
+            stop_grub_timeout;
+            return;
+        }
+        if (match_has_tag 'inst-slof') {
+            diag 'specifying local disk for boot from slof';
             type_string_very_slow "boot /pci\t/sc\t4";
             save_screenshot;
         }
     }
-    send_key 'ret';    # boot from hard disk
+    if (check_var('ARCH', 'aarch64') and get_var('UEFI')) {
+        record_soft_failure 'bsc#1022064';
+        assert_screen 'boot-firmware';
+    }
+    send_key 'ret';
 }
 
 sub pre_bootmenu_setup {

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -37,6 +37,7 @@ our @EXPORT = qw(
 );
 
 # prevent grub2 timeout; 'esc' would be cleaner, but grub2-efi falls to the menu then
+# 'up' also works in textmode and UEFI menues.
 sub stop_grub_timeout {
     send_key 'up';
 }
@@ -93,9 +94,8 @@ sub select_bootmenu_option {
         # live CDs might have a very short timeout of the initial bootmenu
         # (1-2s with recent kiwi versions) so better stop the timeout
         # immediately before checking more and having an opportunity to type
-        # more boot parameters. Send 'up' which should work also on textmode
-        # and UEFI menues.
-        send_key 'up';
+        # more boot parameters.
+        stop_grub_timeout;
     }
     if (get_var('ZDUP') || get_var('ONLINE_MIGRATION')) {
         boot_local_disk;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -146,12 +146,11 @@ sub assert_gui_app {
 sub select_kernel {
     my $kernel = shift;
 
-    assert_screen 'grub2', 100;
-    send_key 'up';    # stop grub2 countdown
-    if (check_screen "grub2-$kernel-selected", 2) {    # if requested kernel is selected continue
+    assert_screen ['grub2', "grub2-$kernel-selected"], 100;
+    if (match_has_tag "grub2-$kernel-selected") {    # if requested kernel is selected continue
         send_key 'ret';
     }
-    else {                                             # else go to that kernel thru grub2 advanced options
+    else {                                           # else go to that kernel thru grub2 advanced options
         send_key_until_needlematch 'grub2-advanced-options', 'down';
         send_key 'ret';
         send_key_until_needlematch "grub2-$kernel-selected", 'down';

--- a/tests/boot/grub_test_snapshot.pm
+++ b/tests/boot/grub_test_snapshot.pm
@@ -14,6 +14,7 @@
 use strict;
 use base "basetest";
 use testapi;
+use bootloader_setup 'stop_grub_timeout';
 
 sub run() {
     if (get_var('ROLLBACK_AFTER_MIGRATION')) {
@@ -27,8 +28,7 @@ sub run() {
     else {
         assert_screen "grub2";
     }
-    # prevent grub2 timeout; 'esc' would be cleaner, but grub2-efi falls to the menu then
-    send_key 'up';
+    stop_grub_timeout;
     if (get_var("BOOT_TO_SNAPSHOT")) {
         send_key_until_needlematch("boot-menu-snapshot", 'down', 10, 5);
         send_key 'ret';

--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -16,6 +16,7 @@ use strict;
 use base "basetest";
 use testapi;
 use utils;
+use bootloader_setup 'stop_grub_timeout';
 
 sub run() {
     if (get_var('LIVECD')) {
@@ -49,8 +50,7 @@ sub run() {
     workaround_type_encrypted_passphrase;
     # 60 due to rare slowness e.g. multipath poo#11908
     assert_screen "grub2", 60;
-    # prevent grub2 timeout; 'esc' would be cleaner, but grub2-efi falls to the menu then
-    send_key 'up';
+    stop_grub_timeout;
 
     # BSC#997263 - VMware screen resolution defaults to 800x600
     # By default VMware starts with Grub2 in 640x480 mode and then boots the system to

--- a/tests/x11/reboot_and_install.pm
+++ b/tests/x11/reboot_and_install.pm
@@ -34,9 +34,13 @@ sub run() {
     specific_bootmenu_params;
     registration_bootloader_params;
 
-    # Boot the entry unless we are in "zdup" upgrade where we expect the
-    # bootloader entry to be still shown
-    unless (get_var('ZDUP')) {
+    # Stop the bootloader timeout in "zdup" upgrade where we expect the
+    # bootloader entry to be still shown later on and just in case it is
+    # already shown here. In other cases select the default boot entry.
+    if (get_var('ZDUP')) {
+        send_key 'up';
+    }
+    else {
         # boot
         my $key = check_var('ARCH', 'ppc64le') ? 'ctrl-x' : 'ret';
         send_key $key;

--- a/tests/x11/reboot_and_install.pm
+++ b/tests/x11/reboot_and_install.pm
@@ -38,7 +38,7 @@ sub run() {
     # bootloader entry to be still shown later on and just in case it is
     # already shown here. In other cases select the default boot entry.
     if (get_var('ZDUP')) {
-        send_key 'up';
+        stop_grub_timeout;
     }
     else {
         # boot


### PR DESCRIPTION
Moving a bit further in the direction of using the same pre-requisites for all
machine and architecture types for "wait_boot".
Move aarch64 and ppc6le handling of screens before the inst-bootmenu or grub2
menu to the same helper method "boot_local_disk".
Explicitly checks for "grub2" tag also on ppc64le when looking for the boot
menu installed on the hard disk instead of using custom tags.

Add explicit helper function to stop grub timeout.

Needs
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/360

Local verification runs:
* [sle zdup ppc64le](http://lord.arch/tests/6225)
* [sle migration offline ppc64le](http://lord.arch/tests/6237)
* [sle zdup x86_64](http://lord.arch/tests/6236)
* [tw rescue ppc64le](http://lord.arch/tests/6234)
* [tw minimalx ppc64le](http://lord.arch/tests/6235)

Related progress issue: https://progress.opensuse.org/issues/18228