### PR TITLE
Adjustments due to GUI change after update to wireshark 2.2.6

### DIFF
--- a/tests/x11/wireshark.pm
+++ b/tests/x11/wireshark.pm
@@ -130,16 +130,14 @@ sub run() {
     #   Profile test   #
     ####################
     # Create new 'openQA' profile.
-    assert_and_click "wireshark-edit";
-    assert_and_click "wireshark-edit-profiles";
+    send_key "ctrl-shift-a";
     assert_screen "wireshark-profiles";
     assert_and_click "wireshark-profiles-new";
     type_string "openQA\n";
     assert_screen "wireshark-fullscreen";
 
     # Unselect the display of the Protocol in the UI.
-    assert_and_click "wireshark-edit";
-    assert_and_click "wireshark-edit-preferences";
+    send_key "ctrl-shift-p";
     assert_screen "wireshark-preferences";
     assert_and_click "wireshark-preferences-columns";
     assert_screen "wireshark-preferences-columns-protocol-displayed";
@@ -151,15 +149,13 @@ sub run() {
     assert_screen "wireshark-fullscreen";
 
     # Change back to the Default profile.
-    assert_and_click "wireshark-edit";
-    assert_and_click "wireshark-edit-profiles";
+    send_key "ctrl-shift-a";
     assert_screen "wireshark-profiles";
     assert_and_dclick "wireshark-profiles-default";
     assert_screen "wireshark-fullscreen";
 
     # Verify that the Protocol is properly displayed.
-    assert_and_click "wireshark-edit";
-    assert_and_click "wireshark-edit-preferences";
+    send_key "ctrl-shift-p";
     assert_screen "wireshark-preferences";
     assert_and_click "wireshark-preferences-columns";
     assert_screen [qw(wireshark-preferences-columns-protocol-displayed wireshark-preferences-columns-protocol-not-displayed)];


### PR DESCRIPTION
After an update to wireshark 2.2.6, the graphical environment has slightly changed, with fonts rendering differently. In SLE12SP1, some of the option items the test needs to reach used to be easily clickable, but now are outside of the visible part of the screen. Instead of cluttering the test code with moving the cursor further down in the menu, I opted for using the keyboard shortcuts to reach the required options.

The wireshark module is now passing on my local openQA instance:
SLE12SP1: http://dreamyhamster.suse.cz/tests/185#step/wireshark/21
SLE12SP2: http://dreamyhamster.suse.cz/tests/188#step/wireshark/19

The related needles had already been merged:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/353

Related progress issue: poo#17954