### PR TITLE
Add test for fips related environment variables

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1072,6 +1072,10 @@ elsif (get_var("FIPS_TS")) {
         # Setup system into fips mode
         loadtest "fips/fips_setup";
     }
+    elsif (check_var("FIPS_TS", "fipsenv")) {
+        prepare_target();
+        loadtest "fips/openssl/openssl_fips_env";
+    }
     else {
         loadtest "boot/boot_to_desktop";
         # Turn off packagekit, setup $serialdev permission and etc

--- a/tests/fips/openssl/openssl_fips_env.pm
+++ b/tests/fips/openssl/openssl_fips_env.pm
@@ -1,0 +1,41 @@
+# openssl fips test
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Test variables: OPENSSL_FIPS and OPENSSL_FORCE_FIPS_MODE
+# OPENSSL_FIPS=1: put the openssl CLI into FIPS mode
+# OPENSSL_FORCE_FIPS_MODE=1: put the openssl library into FIPS mode
+# Maintainer: Qingming Su <qingming.su@suse.com>
+
+use base "consoletest";
+use testapi;
+use strict;
+
+sub validate_fips {
+    validate_script_output "openssl dgst -md5 /tmp/hello.txt 2>&1 || true", sub { m/disabled for fips|unknown option/ };
+}
+
+sub run {
+    select_console 'root-console';
+
+    # Prepare temp file for testing
+    assert_script_run "echo Hello > /tmp/hello.txt";
+
+    # Verify variable OPENSSL_FIPS
+    type_string "export OPENSSL_FIPS=1\n";
+    validate_fips;
+
+    # Verify variable OPENSSL_FORCE_FIPS_MODE
+    type_string "unset OPENSSL_FIPS; export OPENSSL_FORCE_FIPS_MODE=1\n";
+    validate_fips;
+
+    script_run 'rm -f /tmp/hello.txt';
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Intead of enforcing the whole system into FIPS mode with kernel
parameter fips=1, single module can be put into FIPS mode with
special environment variables, i.e. OPENSSL_FIPS=1