### PR TITLE
Apply UEFI fix to non-standard aarch64 machine types

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -311,7 +311,7 @@ sub wait_boot {
         # booted so we have to handle that
         # because of broken firmware, bootindex doesn't work on aarch64 bsc#1022064
         push @tags, 'inst-bootmenu' if ((get_var('USBBOOT') and get_var('UEFI')) || (check_var('ARCH', 'aarch64') and get_var('UEFI')) || get_var('OFW'));
-        handle_uefi_boot_disk_workaround if (check_var('MACHINE', 'aarch64') && get_var('BOOT_HDD_IMAGE') && !$in_grub);
+        handle_uefi_boot_disk_workaround if (get_var('MACHINE') =~ qr'aarch64' && get_var('BOOT_HDD_IMAGE') && !$in_grub);
         check_screen(\@tags, $bootloader_time);
         if (match_has_tag("bootloader-shim-import-prompt")) {
             send_key "down";

--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -55,7 +55,7 @@ sub run() {
     send_key "alt-l";
     type_string "reboot\n";
 
-    $self->handle_uefi_boot_disk_workaround() if check_var('MACHINE', 'aarch64');
+    $self->handle_uefi_boot_disk_workaround() if get_var('MACHINE') =~ qr'aarch64';
     assert_screen "grub2";
     send_key 'up';
 


### PR DESCRIPTION
Use the ARCH variable instead of MACHINE to determine which architecture we
are on. This should fix the aarch64-virtio machine type and any others which
are introduced.

@okurz 