### PR TITLE
[WIP] Simplify YaST2 GUI tests - needs rebase and conflict fixing

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -5,7 +5,7 @@ use strict;
 use utils 'type_string_slow';
 use utils 'ensure_unlocked_desktop';
 
-# Base class for all openSUSE tests
+# Base class implementation of distribution class necessary for testapi
 
 # don't import script_run - it will overwrite script_run from distribution and create a recursion
 use testapi qw(send_key %cmd assert_screen check_screen check_var get_var save_screenshot

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -2,8 +2,6 @@
 package x11test;
 use base "opensusebasetest";
 
-# Base class for all openSUSE tests
-
 use strict;
 use testapi;
 use utils 'type_string_slow';

--- a/lib/y2x11test.pm
+++ b/lib/y2x11test.pm
@@ -17,26 +17,13 @@ sub launch_yast2_module_x11 {
     }
 }
 
-sub save_upload_y2logs() {
-    assert_script_run "save_y2logs /tmp/y2logs.tar.bz2";
-    upload_logs "/tmp/y2logs.tar.bz2";
-}
-
 sub post_fail_hook() {
     my ($self) = shift;
-    $self->export_kde_logs;
-
-    type_string "cat /home/*/.xsession-errors* > /tmp/XSE\n";
-    upload_logs "/tmp/XSE";
-
-    save_upload_y2logs;
-
+    $self->export_logs;
     save_screenshot;
 }
 
 sub post_run_hook {
-    my ($self) = @_;
-
     assert_screen('generic-desktop');
 }
 

--- a/lib/y2x11test.pm
+++ b/lib/y2x11test.pm
@@ -2,8 +2,6 @@ package y2x11test;
 use base "opensusebasetest";
 use strict;
 
-# Base class for all openSUSE tests
-
 use testapi;
 
 sub launch_yast2_module_x11 {

--- a/lib/y2x11test.pm
+++ b/lib/y2x11test.pm
@@ -5,15 +5,19 @@ use strict;
 use testapi;
 
 sub launch_yast2_module_x11 {
-    my ($self, $module) = @_;
+    my ($self, $module, %args) = @_;
     $module //= '';
+    my $tag = $args{tag} // "yast2-$module-ui";
+    my $timeout = $args{timeout} // 30;
 
     x11_start_program("xdg-su -c '/sbin/yast2 $module'");
-    if (check_screen "root-auth-dialog") {
+    assert_screen ['root-auth-dialog', $tag], $timeout;
+    if (match_has_tag 'root-auth-dialog') {
         if ($password) {
             type_password;
-            send_key "ret", 1;
+            send_key 'ret';
         }
+        assert_screen $tag, $timeout;
     }
 }
 

--- a/tests/yast2_gui/yast2_bootloader.pm
+++ b/tests/yast2_gui/yast2_bootloader.pm
@@ -1,18 +1,15 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Add YaST2 UI tests
-#    Make sure those yast2 modules can opened properly. We can add more
-#    feature test against each module later, it is ensure it will not crashed
-#    while launching atm.
-# G-Maintainer: Max Lin <mlin@suse.com>
+# Summary: YaST2 bootloader module test
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "y2x11test";
 use strict;
@@ -20,10 +17,7 @@ use testapi;
 
 sub run() {
     my $self   = shift;
-    my $module = "bootloader";
-
-    $self->launch_yast2_module_x11($module);
-    assert_screen "yast2-$module-ui", 120;
+    $self->launch_yast2_module_x11('bootloader');
     send_key "alt-o";    # OK => Exit
 }
 

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -653,8 +653,7 @@ sub run() {
         select_console 'x11', await_console => 0;
     }
 
-    $self->launch_yast2_module_x11;
-    assert_screen 'yast2-control-center-ui';
+    $self->launch_yast2_module_x11('', tag => 'yast2-control-center-ui');
 
     # search module by typing string
     search('add');

--- a/tests/yast2_gui/yast2_datetime.pm
+++ b/tests/yast2_gui/yast2_datetime.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,9 +20,7 @@ use testapi;
 
 sub run() {
     my $self   = shift;
-    my $module = "timezone";
-
-    $self->launch_yast2_module_x11($module);
+    $self->launch_yast2_module_x11('timezone', timeout => 60);
     assert_screen [qw(yast2-datetime-ui yast2-datetime_ntp-conf)];
     if (match_has_tag 'yast2-datetime_ntp-conf') {
         send_key 'alt-d';

--- a/tests/yast2_gui/yast2_firewall.pm
+++ b/tests/yast2_gui/yast2_firewall.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,13 +19,10 @@ use utils;
 
 sub run() {
     my $self = shift;
-
     select_console 'root-console';
     zypper_call('in yast2-http-server apache2 apache2-prefork');
     select_console 'x11', await_console => 0;
-
     $self->launch_yast2_module_x11('firewall');
-    assert_screen "yast2-firewall-ui", 30;
 
     # 	enter page interfaces and change zone for network interface
     assert_and_click("yast2_firewall_config_list");

--- a/tests/yast2_gui/yast2_hostnames.pm
+++ b/tests/yast2_gui/yast2_hostnames.pm
@@ -1,18 +1,16 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Add YaST2 UI tests
-#    Make sure those yast2 modules can opened properly. We can add more
-#    feature test against each module later, it is ensure it will not crashed
-#    while launching atm.
-# G-Maintainer: Max Lin <mlin@suse.com>
+# Summary: YaST2 GUI test for 'host'
+#    Simple launch test
+# Maintainer: Max Lin <mlin@suse.com>
 
 use base "y2x11test";
 use strict;
@@ -20,10 +18,7 @@ use testapi;
 
 sub run() {
     my $self   = shift;
-    my $module = "host";
-
-    $self->launch_yast2_module_x11($module);
-    assert_screen "yast2-$module-ui", 30;
+    $self->launch_yast2_module_x11('host');
     send_key "alt-o";    # OK => Exit
 }
 

--- a/tests/yast2_gui/yast2_lang.pm
+++ b/tests/yast2_gui/yast2_lang.pm
@@ -1,18 +1,16 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Add YaST2 UI tests
-#    Make sure those yast2 modules can opened properly. We can add more
-#    feature test against each module later, it is ensure it will not crashed
-#    while launching atm.
-# G-Maintainer: Max Lin <mlin@suse.com>
+# Summary: YaST2 GUI test for 'language'
+#    Simple launch test
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "y2x11test";
 use strict;
@@ -20,10 +18,7 @@ use testapi;
 
 sub run() {
     my $self   = shift;
-    my $module = "language";
-
-    $self->launch_yast2_module_x11($module);
-    assert_screen "yast2-$module-ui", 60;
+    $self->launch_yast2_module_x11('language', timeout => 60);
     send_key "alt-o";    # OK => Exit
 }
 

--- a/tests/yast2_gui/yast2_network_settings.pm
+++ b/tests/yast2_gui/yast2_network_settings.pm
@@ -1,18 +1,16 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Add YaST2 UI tests
-#    Make sure those yast2 modules can opened properly. We can add more
-#    feature test against each module later, it is ensure it will not crashed
-#    while launching atm.
-# G-Maintainer: Max Lin <mlin@suse.com>
+# Summary: YaST2 GUI test for 'lan'
+#    Simple launch test
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "y2x11test";
 use strict;
@@ -20,10 +18,7 @@ use testapi;
 
 sub run() {
     my $self   = shift;
-    my $module = "lan";
-
-    $self->launch_yast2_module_x11($module);
-    assert_screen "yast2-$module-ui", 60;
+    $self->launch_yast2_module_x11('lan', timeout => 60);
     send_key "alt-o";    # OK => Exit
 }
 

--- a/tests/yast2_gui/yast2_software_management.pm
+++ b/tests/yast2_gui/yast2_software_management.pm
@@ -1,18 +1,16 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Add YaST2 UI tests
-#    Make sure those yast2 modules can opened properly. We can add more
-#    feature test against each module later, it is ensure it will not crashed
-#    while launching atm.
-# G-Maintainer: Max Lin <mlin@suse.com>
+# Summary: YaST2 GUI test for 'sw_single'
+#    Simple launch test
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "y2x11test";
 use strict;
@@ -20,10 +18,7 @@ use testapi;
 
 sub run() {
     my $self   = shift;
-    my $module = "sw_single";
-
-    $self->launch_yast2_module_x11($module);
-    assert_screen "yast2-$module-ui", 120;
+    $self->launch_yast2_module_x11('sw_single', timeout => 120);
     send_key "alt-a";    # Accept => Exit
 }
 

--- a/tests/yast2_gui/yast2_users.pm
+++ b/tests/yast2_gui/yast2_users.pm
@@ -1,18 +1,16 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Add YaST2 UI tests
-#    Make sure those yast2 modules can opened properly. We can add more
-#    feature test against each module later, it is ensure it will not crashed
-#    while launching atm.
-# G-Maintainer: Max Lin <mlin@suse.com>
+# Summary: YaST2 users GUI
+#  Simple launch test
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "y2x11test";
 use strict;
@@ -20,10 +18,7 @@ use testapi;
 
 sub run() {
     my $self   = shift;
-    my $module = "users";
-
-    $self->launch_yast2_module_x11($module);
-    assert_screen "yast2-$module-ui", 60;
+    $self->launch_yast2_module_x11('users', timeout => 60);
     send_key "alt-o";    # OK => Exit
 }
 


### PR DESCRIPTION
All YaST2 GUI tests assert one initial startup screen. The tag name already
follows a common scheme so we can assert on that screen in
'launch_yast2_module_x11' already when looking for alternatives.

Getting rid of the wait_idle call in 'launch_yast2_module_x11'.

Updating test summary and maintainer where not done yet based on auto-generated
content.

Verification run: http://lord.arch/tests/6243