### PR TITLE
Extend yast2_bootloader.pm for basic functionalities tests

### DIFF
--- a/tests/yast2_gui/yast2_bootloader.pm
+++ b/tests/yast2_gui/yast2_bootloader.pm
@@ -8,11 +8,12 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Add YaST2 UI tests
+# Summary: YaST2 UI test bootloader checks boot code option, kernel parameters,
+#	graphical console, bootloader option, foreign OS and protect boot loader
 #    Make sure those yast2 modules can opened properly. We can add more
 #    feature test against each module later, it is ensure it will not crashed
 #    while launching atm.
-# G-Maintainer: Max Lin <mlin@suse.com>
+# Maintainer: Zaoliang Luo <zluo@suse.com>
 
 use base "y2x11test";
 use strict;
@@ -24,7 +25,37 @@ sub run() {
 
     $self->launch_yast2_module_x11($module);
     assert_screen "yast2-$module-ui", 120;
-    send_key "alt-o";    # OK => Exit
+
+    #	boot code options
+    assert_and_click 'yast2-bootloader_grub2';
+    assert_and_click 'yast2-bootloader_not-managed';
+    send_key 'alt-c';
+
+    #	kernel parameters and use graphical console
+    assert_and_click 'yast2-bootloader_kernel-parameters';
+    send_key 'alt-p';
+    send_key 'end';
+    assert_screen 'yast2-bootloader_use-graphical-console';
+
+    #	bootloader options and set probe foreign OS, timeout
+    assert_and_click 'yast2-bootloader_bootloader-options';
+    send_key 'alt-b';
+    send_key 'alt-t';
+    type_string '16';
+
+    #	default boot section
+    assert_and_click 'yast2-bootloader_default-boot-section';
+    assert_screen 'yast2-bootloader_defautl-boot-section_tw';
+
+    #	proctect boot loader with password
+    assert_and_click 'yast2-bootloader_protect-bootloader-with-password';
+    send_key 'alt-p';
+    type_string 'dummy-password';
+    send_key 'alt-y';
+    type_string 'dummy-password';
+
+    # OK => Exit
+    send_key "alt-o";
 }
 
 1;


### PR DESCRIPTION
Please see reference test at:
openSUSE TW
http://e13.suse.de/tests/2947

Against openSUSE Leap cannot be tested because of know issue of consoletest_finish which blocks it's following tests.

SLES 12 SP3
http://e13.suse.de/tests/2963#step/yast2_bootloader
