### PR TITLE
Extend yast_datetime.pm for map and location

### DIFF
--- a/tests/yast2_gui/yast2_datetime.pm
+++ b/tests/yast2_gui/yast2_datetime.pm
@@ -30,6 +30,11 @@ sub run() {
     }
     assert_screen 'yast2-timezone-ui', 60;
 
+    # check map and location, other settings can be added later
+    assert_and_click 'yast2-datetime_map';
+    assert_and_click 'yast2-datetime_location';
+    assert_screen 'yast2-timezone-ui', 60;
+
     # OK => Exit
     send_key "alt-o";
 }


### PR DESCRIPTION
Please see my reference test:
openSUSE TW
http://e13.suse.de/tests/2961#step/yast2_datetime

SLES 12 SP3
http://e13.suse.de/tests/2962#step/yast2_datetime

openSUSE Leap cannot be tested because consoletest_finish blocks it's following tests. 