### PR TITLE
Skip assert ids release note

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -52,7 +52,7 @@ sub run() {
     }
 
     # no release-notes for WE and all modules
-    my @no_relnotes = qw(we lgm asmm certm contm pcm tcm wsm hpcm);
+    my @no_relnotes = qw(we lgm asmm certm contm pcm tcm wsm hpcm ids idu);
 
     # no relnotes for ltss in QAM_MINIMAL
     push @no_relnotes, qw(ltss) if get_var('QAM_MINIMAL');


### PR DESCRIPTION
There are release notes for IBM-ids and IBM-idu, skipped needle assert
[POO#19170](https://progress.opensuse.org/issues/19170)
