### PR TITLE
[WIP] Check typed password boot_encrypt

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -96,6 +96,7 @@ sub unlock_if_encrypted {
     else {
         assert_screen("encrypted-disk-password-prompt", 200);
         type_password;    # enter PW at boot
+        assert_screen('encrypted-disk-password-typed');
         send_key "ret";
     }
 }


### PR DESCRIPTION
Improve failure detection on password typing
- https://openqa.suse.de/tests/939061#step/first_boot/1

that still needs the new needles
- [gl#os-autoinst-needles-sles/373](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/373)