### PR TITLE
Skip firefox_audio test on Rescue-CDs

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -540,7 +540,7 @@ sub load_x11tests() {
     }
     # no firefox on KDE-Live # boo#1022499
     loadtest "x11/firefox" unless is_kde_live;
-    if (!get_var("OFW") && check_var('BACKEND', 'qemu') && !is_kde_live) {
+    if (!get_var("OFW") && check_var('BACKEND', 'qemu') && !check_var('FLAVOR', 'Rescue-CD') && !is_kde_live) {
         loadtest "x11/firefox_audio";
     }
     if (gnomestep_is_applicable() && !(get_var("LIVECD") || is_server)) {


### PR DESCRIPTION
Space is getting more and more of an issue on the rescue CDs - and providing
multimedia capabilities is not high on the list for the Rescue disk.

We rather sacrifice a few MB of sound drivers from the kernel to get usable
recovery tools on the media - as a consequence, we can't successfully test
audio in firefox though.