### PR TITLE
Ensure valid prompt in installation system as well (poo#19198)

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -204,13 +204,8 @@ sub script_sudo($$) {
 sub set_standard_prompt {
     my ($self, $user) = @_;
     $user ||= $testapi::username;
-    if ($user eq 'root') {
-        # set standard root prompt
-        type_string "PS1=\"\\\[\$(tput bold 2; tput setaf 1)\\\]#\\\[\$(tput sgr0)\\\] \"\n";
-    }
-    else {
-        type_string "PS1=\"\\\[\$(tput bold 2; tput setaf 1)\\\]\\\$\\\[\$(tput sgr0)\\\] \"\n";
-    }
+    my $prompt_sign = $user eq 'root' ? '#' : '$';
+    type_string "which tput 2>&1 && PS1=\"\\\[\$(tput bold 2; tput setaf 1)\\\]$prompt_sign\\\[\$(tput sgr0)\\\] \"\n";
 }
 
 sub become_root {


### PR DESCRIPTION
Related needle update:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/191

Verification run: http://lord.arch/tests/6259

Related progress issue: https://progress.opensuse.org/issues/19198