### PR TITLE
svirt: disable_vnc_stalls on the right console

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -231,7 +231,8 @@ sub init_consoles {
     # avoid complex boolean logic by setting interim variables
     if (check_var('BACKEND', 'svirt')) {
         if (check_var('ARCH', 's390x')) {
-            set_var('S390_ZKVM', 1);
+            set_var('S390_ZKVM',         1);
+            set_var('SVIRT_VNC_CONSOLE', 'x11');
         }
     }
 
@@ -252,6 +253,7 @@ sub init_consoles {
                 port     => $port,
                 password => $testapi::password
             });
+        set_var('SVIRT_VNC_CONSOLE', 'sut');
     }
 
     if (get_var('BACKEND', '') =~ /qemu|ipmi|generalhw/ || (check_var('BACKEND', 'svirt') && !get_var('S390_ZKVM'))) {

--- a/tests/x11/shutdown.pm
+++ b/tests/x11/shutdown.pm
@@ -129,7 +129,8 @@ sub run() {
     }
 
     if (check_var('BACKEND', 'svirt')) {
-        console('x11')->disable_vnc_stalls;
+        my $con = get_required_var('SVIRT_VNC_CONSOLE');
+        console($con)->disable_vnc_stalls;
     }
     $self->{await_shutdown} = 1;
     assert_shutdown;


### PR DESCRIPTION
`sut` is the `x11` console of non-zKVM svirt tests.

Fails here: https://openqa.suse.de/tests/938272#step/shutdown/19