### PR TITLE
 Support boot from Xen PV image 

### DIFF
--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -1,30 +1,35 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: boot from existing image to desktop
+# Summary: Boot from existing image to desktop
 # Maintainer: mitiao <mitiao@gmail.com>
 
-use base "opensusebasetest";
+use base 'opensusebasetest';
 use strict;
 use testapi;
-use utils;
 
 sub run() {
     my ($self) = @_;
-    # we have some tests that waits for dvd boot menu timeout and boot from hdd
-    # - the timeout here must cover it
-    $self->wait_boot(bootloader_time => 80);
+    # We have tests that boot from HDD and wait for DVD boot menu's timeout, so
+    # the timeout here must cover it. UEFI DVD adds some 60 seconds on top.
+    my $timeout = get_var('UEFI') ? 140 : 80;
+    if (check_var('VIRSH_VMM_TYPE', 'linux')) {
+        wait_serial("Welcome to SUSE Linux", $timeout) || die "System did not boot in $timeout seconds.";
+    }
+    else {
+        $self->wait_boot(bootloader_time => $timeout);
+    }
 }
 
 sub test_flags() {
-    return {fatal => 1, milestone => 1};    # add milestone flag to save setup in lastgood vm snapshot
+    return {fatal => 1, milestone => 1};    # add milestone flag to save setup in lastgood VM snapshot
 }
 
 1;


### PR DESCRIPTION
On Xen PV we don't have GRUB so `wait_boot` makes only a little sense.
Instead wait for "Welcome to SUSE Linux" banner.

Also various changes:
* typos,
* support UEFI DVD timeout, and
* removed `use utils` as `wait_boot` moved elsewhere.