### PR TITLE
[fate#317775]: AutoYaST tests for btrfs non-default subvolumes structure

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,6 +1,7 @@
 requires 'Net::Telnet';
 requires 'File::Basename';
 requires 'Data::Dumper';
+requires 'XML::LibXML';
 requires 'XML::Writer';
 requires 'XML::Simple';
 requires 'IO::File';

--- a/data/autoyast/autoyast_btrfs.xml
+++ b/data/autoyast/autoyast_btrfs.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <storage>
+      <btrfs_set_default_subvolume_name config:type="boolean">false</btrfs_set_default_subvolume_name>
+    </storage>
+  </general>
+  <keyboard>
+    <keyboard_values>
+      <delay/>
+      <discaps config:type="boolean">false</discaps>
+      <numlock>bios</numlock>
+      <rate/>
+    </keyboard_values>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list"/>
+  </ntp-client>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/vda</device>
+      <disklabel>msdos</disklabel>
+      <enable_snapshots config:type="boolean">true</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>swap</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <resize config:type="boolean">false</resize>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>rw,relatime,space_cache</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <subvolumes config:type="list">
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+	            <path>opt</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">false</copy_on_write>
+              <path>tmp</path>
+            </listentry>
+            <listentry>
+	            <path>usr/local</path>
+            </listentry>
+          </subvolumes>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>rw,relatime,nobarrier,nodatacow</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/var/log</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
+        </partition>
+      </partitions>
+      <pesize/>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <software>
+    <packages config:type="list">
+      <package>glibc</package>
+      <package>grub2</package>
+      <package>snapper</package>
+      <package>syslinux</package>
+      <package>kdump</package>
+      <package>sles-release</package>
+      <package>kexec-tools</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>32bit</pattern>
+      <pattern>Minimal</pattern>
+      <pattern>apparmor</pattern>
+      <pattern>base</pattern>
+      <pattern>documentation</pattern>
+      <pattern>gnome-basic</pattern>
+      <pattern>x11</pattern>
+    </patterns>
+  </software>
+  <networking>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <startmode>auto</startmode>
+      </interface>
+    </interfaces>
+  </networking>
+  <firewall>
+    <enable_firewall config:type="boolean">true</enable_firewall>
+    <start_firewall config:type="boolean">true</start_firewall>
+  </firewall>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Berlin</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact>-1</inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -157,7 +157,13 @@ sub load_autoyast_tests {
     else {
         loadtest("autoyast/repos");
         loadtest("autoyast/clone");
+        if (get_var('SP3ORLATER') && check_var('FILESYSTEM', 'btrfs')) {
+            loadtest "autoyast/verify_autoinst_btrfs";
+        }
         loadtest("autoyast/logs");
+    }
+    if (get_var('SP3ORLATER') && check_var('FILESYSTEM', 'btrfs')) {
+        loadtest "autoyast/verify_btrfs";
     }
     loadtest("autoyast/autoyast_reboot");
     #    next boot in load_reboot_tests

--- a/tests/autoyast/verify_autoinst_btrfs.pm
+++ b/tests/autoyast/verify_autoinst_btrfs.pm
@@ -1,0 +1,162 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test verifies that generated autoinst.xml btrfs configuration matches
+# expected settings. Mount options and subvolume configuration are verified.
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
+
+use strict;
+use base 'basetest';
+use testapi;
+use XML::LibXML;
+
+#Xpath parser
+my $dom;
+my $xpc;
+
+sub run {
+    my $self = shift;
+    $self->result('ok');    # default result
+
+    ## Copy file content to variable
+    my $autoinst = script_output("cat /root/autoinst.xml");
+    # Init parser
+    $dom = XML::LibXML->load_xml(string => $autoinst);
+    # Init xml namespace
+    $xpc = XML::LibXML::XPathContext->new($dom);
+    $xpc->registerNs('ns', 'http://www.suse.com/1.0/yast2ns');
+
+    ### Verify mount options enable_snapshots
+    my $result_str = verify_option('//ns:partitioning/ns:drive[ns:device="/dev/vda"]/ns:enable_snapshots', 'true');
+    if ($result_str) {
+        record_info("Enable_snapshots option check failed", $result_str);
+        $self->result('fail');
+    }
+    ### Verify mount options btrfs_set_default_subvolume_name
+    my $result_str = verify_option('//ns:btrfs_set_default_subvolume_name', 'false');
+    if ($result_str) {
+        record_info("Enable_snapshots option check failed", $result_str);
+        $self->result('fail');
+    }
+
+    ### Verify mount options
+    my $result_str = verify_mount_opts("/", "rw,relatime,space_cache");
+    if ($result_str) {
+        record_info("Mount options verification failed for /", $result_str);
+        $self->result('fail');
+    }
+
+    $result_str = verify_mount_opts("/var/log", "rw,relatime,nobarrier,nodatacow");
+    if ($result_str) {
+        record_info("Mount options verification failed for /", $result_str);
+        $self->result('fail');
+    }
+
+    ### Verify subvolumes
+    $result_str = verify_subvolumes("/var/log", ());
+    if ($result_str) {
+        record_info("Subvolumes verification failed for /var/log", $result_str);
+        $self->result('fail');
+    }
+
+    ### Verify subvolumes
+    $result_str = verify_subvolumes('/', (opt => 'true', 'usr/local' => 'true', tmp => 'false'));
+    if ($result_str) {
+        record_info("Subvolumes verification failed for /", $result_str);
+        $self->result('fail');
+    }
+
+    $result_str = verify_subvolumes("/var/log", ());
+    if ($result_str) {
+        record_info("Subvolumes verification failed for /var/log", $result_str);
+        $self->result('fail');
+    }
+}
+
+sub verify_option {
+    my ($xpath, $expected_val) = @_;
+
+    my $nodeset = $xpc->findnodes($xpath);
+    for my $node ($nodeset->get_nodelist) {
+        print $node->to_literal;
+    }
+    my @nodes = $nodeset->get_nodelist;
+    ## Verify that there is node found by xpath and it's single one
+    if (scalar @nodes != 1) {
+        return "Generated autoinst.xml contains unexpected number of nodes for xpath: $xpath. Found: " . scalar @nodes . ", expected: 1.";
+    }
+    if ($nodes[0]->to_literal ne $expected_val) {
+        return "Unexpected value for xpath $xpath. Expected: $expected_val, got: $nodes[0]";
+    }
+
+    return "";
+
+}
+
+sub verify_subvolumes {
+    my ($mount_path, %subvolume_opts) = @_;
+    my $nodeset = $xpc->findnodes("//ns:partition[ns:mount=\"$mount_path\"]/ns:subvolumes/ns:listentry");
+
+    ##Verify that is no subvolumes are expected, there are no entries
+    if (!%subvolume_opts && $nodeset) {
+        return "Expected no subvolumes configured, got " . $nodeset->get_nodelist->size;
+    }
+    my @nodes = $nodeset->get_nodelist;
+
+    # Check that sets of subvolumes match expectation
+    my @exp_keys = keys %subvolume_opts;
+    if (scalar @nodes != scalar @exp_keys) {
+        return "Got unexpected number of subvolumes in autoinst.xml. Expected: " . @exp_keys . " actual: " . scalar @nodes;
+    }
+
+    # Verify copy_on_write option for subvolumes
+    for my $node (@nodes) {
+        my $expected_cow = $subvolume_opts{$node->getChildrenByTagName("path")->to_literal};
+        my $actual_cow   = $node->getChildrenByTagName("copy_on_write")->to_literal;
+        if ($expected_cow ne $actual_cow) {
+            return "Unexpected copy_on_write value for mount on path $mount_path:" . " expected $expected_cow, actual $actual_cow";
+        }
+    }
+
+    return "";
+}
+
+sub verify_mount_opts {
+    my ($mount_path, $mount_opts) = @_;
+    my $nodeset = $xpc->findnodes("//ns:partition[ns:mount=\"$mount_path\"]/ns:fstopt");
+
+    my @nodes = $nodeset->get_nodelist;
+    ## Verify that there is node found by xpath and it's single one
+    if (scalar @nodes != 1) {
+        return
+            "Generated autoinst.xml contains unexpected number of partitions with same mount path for"
+          . $mount_path
+          . "Found: "
+          . scalar @nodes
+          . ", expected: 1.";
+    }
+    ## Verify that value matches expectation
+    for my $node (@nodes) {
+        if ($node->to_literal ne $mount_opts) {
+            return " Node value doesn't match mount options for $mount_path Expected : $mount_opts; Actual: " . $node->to_literal;
+        }
+    }
+
+    return "";
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/tests/autoyast/verify_btrfs.pm
+++ b/tests/autoyast/verify_btrfs.pm
@@ -1,0 +1,78 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test verifies installation using autoyast_sle_12_btrfs.xml profile
+# configuration for btrfs partitions. Verify subvolumes stcructure, mount options
+# subvolume attributes configured in profile.
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
+
+use base 'basetest';
+use strict;
+use testapi;
+
+sub run {
+
+    ### Verify mounted drives ###
+    # Common part of regexp
+    my $common_opts = qr/rw|relatime|space_cache|subvolid=\d+/;
+
+    # Get verify mount options for root
+    validate_script_output "findmnt / -no OPTIONS", sub {
+        m/^((${common_opts}|subvol=\/\.snapshots\/1\/snapshot),?){5}/i;
+    };
+
+    # Verify configured subvolumes
+    my @subvolumes = qw(opt tmp usr/local);
+
+    foreach my $subvol (@subvolumes) {
+        validate_script_output "findmnt /$subvol -no OPTIONS", sub {
+            m/^((${common_opts}|subvol=\/${subvol}),?){5}/i;
+        };
+    }
+
+    # Get verify mount options for /var/log mount point
+    validate_script_output "findmnt /var/log -no OPTIONS", sub {
+        m/^((${common_opts}|nodatasum|nodatacow|nobarrier|subvol=\/),?){8}/i;
+    };
+
+    ### Verify list of subvolumes ###
+    my $subvol_list_cmd = "btrfs subvolume list -a";
+
+    # Verify /var/log, should return no volumes
+    validate_script_output "$subvol_list_cmd /var/log", sub { m/^$/; };
+
+    # Verify "/" mount
+    assert_script_run("$subvol_list_cmd / | grep \"path <FS_TREE>/\"");
+
+    # Verify all subvolumes
+    foreach my $subvol (@subvolumes) {
+        assert_script_run("$subvol_list_cmd / | grep \"path <FS_TREE>/$subvol\"");
+    }
+
+    # Verify snapshots subvolume
+    assert_script_run("$subvol_list_cmd / | grep \"path <FS_TREE>/.snapshots\"");
+
+    ### Verify copy on write flags for subvolumes.
+    # Use -d option to list directories as files and l option to print long
+    # attribite name. Only tmp has flag set,usr.local has no setting, by default flag is set
+    validate_script_output "lsattr -dl /tmp",       sub { m/\/tmp.*No_COW/i; };
+    validate_script_output "lsattr -dl /usr/local", sub { m/\/usr\/local.*---/i; };
+    validate_script_output "lsattr -dl /opt",       sub { m/\/opt.*---/i; };
+
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/tests/console/lock_package.pm
+++ b/tests/console/lock_package.pm
@@ -25,7 +25,7 @@ sub run() {
     for my $pkg (@pkgs) {
         # Save each package's name, version and release info to variable
         my $fullname = script_output "rpm -q $pkg";
-        push $locked_pkg_info, {name => $pkg, fullname => $fullname};
+        push @$locked_pkg_info, {name => $pkg, fullname => $fullname};
 
         # Add a lock for each package
         assert_script_run "zypper al $pkg";


### PR DESCRIPTION
Tests for autoyast clone for btrfs. Tests are using same structure as for ext4, but with additional checks of functionality, namely:
1) btrfs cloned system matches autoinst profile configuration
2) autoinst.xml is generated according to the system btrfs configuration

For execution following job properties have to be set:
AUTOYAST 	autoyast/autoyast_btrfs.xml
FILESYSTEM 	btrfs

Additionally, worker should have XML::LibXML perl module installed.
