### PR TITLE
Skip rebooting when running a LIVECD

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -569,12 +569,12 @@ sub load_x11tests {
     }
     if (xfcestep_is_applicable()) {
         loadtest "x11/thunar";
-        if (!get_var("USBBOOT")) {
+        if (!get_var("USBBOOT") && !is_livesystem) {
             loadtest "x11/reboot_xfce";
         }
     }
     if (lxdestep_is_applicable()) {
-        if (!get_var("USBBOOT")) {
+        if (!get_var("USBBOOT") && !is_livesystem) {
             loadtest "x11/reboot_lxde";
         }
     }
@@ -584,7 +584,7 @@ sub load_x11tests {
             loadtest "x11/amarok";
         }
         loadtest "x11/kontact" unless is_kde_live;
-        if (!get_var("USBBOOT")) {
+        if (!get_var("USBBOOT") && !is_livesystem) {
             if (get_var("PLASMA5")) {
                 loadtest "x11/reboot_plasma5";
             }
@@ -597,7 +597,7 @@ sub load_x11tests {
         loadtest "x11/nautilus" unless get_var("LIVECD");
         loadtest "x11/gnome_music";
         loadtest "x11/evolution" unless is_server;
-        if (!get_var("USBBOOT")) {
+        if (!get_var("USBBOOT") && !is_livesystem) {
             loadtest "x11/reboot_gnome";
         }
         load_testdir('x11/gnomeapps') if is_gnome_next;


### PR DESCRIPTION
It does not make much sense to reboot a livecd, as it will lose all
memory of the previous start. This saves a lot of time, as live cd
startup is quite slow. That shutdown works is still tested by
the shutdown module at the end of the test.

Verification run: http://tortuga.suse.de/tests/1914#