### PR TITLE
Make screenshot of typed password on boot_encrypt

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -96,6 +96,7 @@ sub unlock_if_encrypted {
     else {
         assert_screen("encrypted-disk-password-prompt", 200);
         type_password;    # enter PW at boot
+        save_screenshot;
         send_key "ret";
     }
 }


### PR DESCRIPTION
Verification run:
- http://copland.arch.suse.de/tests/487#step/boot_encrypt/2