### PR TITLE
Revert "LTP: tests with warnings considered as passed"

### DIFF
--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -277,7 +277,7 @@ sub record_ltp_result {
         $self->{result}                   = 'fail';
         $export_details->{test}->{result} = 'TBROK';
     }
-    elsif ($results->{tfail}) {
+    elsif ($results->{tfail} || $results->{twarn}) {
         $details->{result}                = 'fail';
         $self->{result}                   = 'fail';
         $export_details->{test}->{result} = 'TFAIL';

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -176,7 +176,6 @@ sub parse_ltp_log {
             elsif ($1 == 4) {
                 say $fh 'Passed with warnings.';
                 $results->{twarn}++;
-                $results->{tpass}++;
             }
             else {
                 say $fh "Test process returned unkown none zero value ($1).";


### PR DESCRIPTION
This reverts commit 08900262dfa8aa1ebfb52bb043b624f6b14f09e9.

TWARN can point to serious failures, so it's safer to keep it as an
failure.