### PR TITLE
Add assert_screen typed password on boot_encrypt

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -96,7 +96,7 @@ sub unlock_if_encrypted {
     else {
         assert_screen("encrypted-disk-password-prompt", 200);
         type_password;    # enter PW at boot
-        save_screenshot;
+        assert_screen 'encrypted_disk-typed_password';
         send_key "ret";
     }
 }


### PR DESCRIPTION
Improve failure detection on password typing
- https://openqa.suse.de/tests/939061#step/first_boot/1

that still needs the new needles
- [gl#os-autoinst-needles-sles/373](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/373)

Verification run:
- graphic prompt: http://copland.arch.suse.de/tests/488
- ofw: (not yet available)
- textmode black/white: (not yet available)
- textmode grey/green: (not yet available)