### PR TITLE
Fix poo#19234: Add boot=/dev/xyz for fips_lvm_encrypt

### DIFF
--- a/tests/shutdown/grub_set_bootargs.pm
+++ b/tests/shutdown/grub_set_bootargs.pm
@@ -18,7 +18,12 @@ sub run() {
     select_console('root-console');
     script_run "source /etc/default/grub";
     script_run 'new_cmdline=`echo $GRUB_CMDLINE_LINUX_DEFAULT | sed \'s/\(^\| \)quiet\($\| \)/ /\'`';
-    script_run 'new_cmdline="$new_cmdline fips=1"' if (get_var("ENABLE_FIPS"));
+    if (get_var("ENABLE_FIPS")) {
+        script_run 'new_cmdline="$new_cmdline fips=1"';
+        if (get_var("ENCRYPT") && !get_var("FULL_LVM_ENCRYPT")) {
+            script_run 'new_cmdline="$new_cmdline boot=$(df /boot | tail -1 | cut -d" " -f1)"';
+        }
+    }
     script_run 'sed -i "s#GRUB_CMDLINE_LINUX_DEFAULT=\"[^\"]*\"#GRUB_CMDLINE_LINUX_DEFAULT=\"$new_cmdline\"#" /etc/default/grub';
     script_run 'grub2-mkconfig -o /boot/grub2/grub.cfg';
 }


### PR DESCRIPTION
According to bsc#989491, the encrypted LVM fails to boot in fips
mode because in the initial ramdisk the /boot is not populated or
mounted. Adding the "boot=/dev/somewhere" option to the kernel
line is required. It must point to the device containing "/boot",
so that the initial ramdisk can find the HMACs.