### PR TITLE
Handle new 'invalid SCC URL' pop-up

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE Linux GmbH
+# Copyright (C) 2015-2017 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -77,7 +77,7 @@ sub handle_expected_errors {
 }
 
 sub run {
-    my @needles = ("bios-boot", "autoyast-error", "reboot-after-installation", "linuxrc-install-fail");
+    my @needles = ("bios-boot", "autoyast-error", "reboot-after-installation", "linuxrc-install-fail", 'scc-invalid-url');
     push @needles, "autoyast-confirm"        if get_var("AUTOYAST_CONFIRM");
     push @needles, "autoyast-postpartscript" if get_var("USRSCR_DIALOG");
     if (get_var("AUTOYAST_LICENSE")) {
@@ -98,6 +98,9 @@ sub run {
         if (match_has_tag('autoyast-error')) {
             handle_expected_errors(iteration => $i);
             $num_errors++;
+        }
+        elsif (match_has_tag('scc-invalid-url')) {
+            die 'Fix invalid SCC reg URL https://trello.com/c/N09TRZxX/968-3-don-t-crash-on-invalid-regurl-on-linuxrc-commandline';
         }
         elsif (match_has_tag('linuxrc-install-fail')) {
             save_logs_in_linuxrc("stage1_error$i");

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -77,7 +77,7 @@ sub handle_expected_errors {
 }
 
 sub run {
-    my @needles = ("bios-boot", "autoyast-error", "reboot-after-installation", "linuxrc-install-fail", 'scc-invalid-url');
+    my @needles = ("bios-boot", "autoyast-error", "reboot-after-installation", "linuxrc-install-fail", 'scc-invalid-url', 'warning-pop-up');
     push @needles, "autoyast-confirm"        if get_var("AUTOYAST_CONFIRM");
     push @needles, "autoyast-postpartscript" if get_var("USRSCR_DIALOG");
     if (get_var("AUTOYAST_LICENSE")) {
@@ -98,6 +98,9 @@ sub run {
         if (match_has_tag('autoyast-error')) {
             handle_expected_errors(iteration => $i);
             $num_errors++;
+        }
+        elsif (match_has_tag('warning-pop-up')) {
+            die 'Check the pop-up message, it is not critical so installation would continue';
         }
         elsif (match_has_tag('scc-invalid-url')) {
             die 'Fix invalid SCC reg URL https://trello.com/c/N09TRZxX/968-3-don-t-crash-on-invalid-regurl-on-linuxrc-commandline';

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,36 +18,52 @@ use testapi;
 use utils 'ensure_fullscreen';
 
 sub run() {
-    my @welcome_tags = [qw(inst-welcome inst-welcome-confirm-self-update-server)];
-    ensure_fullscreen;
-    my $bootup_timeout = 500;
-    if (get_var("BETA")) {
-        assert_screen "inst-betawarning", $bootup_timeout;
-        send_key "ret";
-        assert_screen @welcome_tags, 10;
+    while (1) {
+        my @welcome_tags = ('inst-welcome-confirm-self-update-server', 'scc-invalid-url');
+        if (get_var('BETA')) {
+            push @welcome_tags, 'inst-betawarning';
+        }
+        else {
+            push @welcome_tags, 'inst-welcome';
+        }
+        ensure_fullscreen;
+        assert_screen \@welcome_tags, 500;
+        if (match_has_tag 'scc-invalid-url') {
+            die 'SCC reg URL is invalid' if !get_var('SCC_URL_VALID');
+            send_key 'alt-r';    # registration URL field
+            send_key_until_needlematch 'scc-invalid-url-deleted', 'backspace';
+            type_string get_var('SCC_URL_VALID');
+            wait_still_screen 2;
+            wait_screen_change { send_key 'alt-o' };    # OK
+        }
+        if (match_has_tag('inst-welcome-confirm-self-update-server')) {
+            wait_screen_change { send_key $cmd{ok} };
+        }
+        # this is needed because of race condition, there is shortly visible
+        # welcome screen before Beta pop-up
+        if (match_has_tag 'inst-betawarning') {
+            send_key 'ret';
+            assert_screen 'inst-welcome';
+            last;
+        }
+        if (match_has_tag('inst-welcome')) {
+            last;
+        }
     }
-    else {
-        assert_screen @welcome_tags, $bootup_timeout;
-    }
-    if (match_has_tag('inst-welcome-confirm-self-update-server')) {
-        wait_screen_change { send_key $cmd{ok} };
-        assert_screen 'inst-welcome';
-    }
-
     wait_idle;
     mouse_hide;
 
     # license+lang
-    if (get_var("HASLICENSE")) {
+    if (get_var('HASLICENSE')) {
         send_key $cmd{next};
-        assert_screen "license-not-accepted";
+        assert_screen 'license-not-accepted';
         send_key $cmd{ok};
         send_key $cmd{accept};    # accept license
     }
-    assert_screen "languagepicked";
+    assert_screen 'languagepicked';
     send_key $cmd{next};
-    if (!check_var('INSTLANG', 'en_US') && check_screen "langincomplete", 1) {
-        send_key "alt-f";
+    if (!check_var('INSTLANG', 'en_US') && check_screen 'langincomplete', 1) {
+        send_key 'alt-f';
     }
 }
 


### PR DESCRIPTION
https://trello.com/c/N09TRZxX/968-3-don-t-crash-on-invalid-regurl-on-linuxrc-commandline

[textmode invalid URL test](http://10.100.12.155/tests/183#step/welcome/1)
[gnome invalid URL test](http://10.100.12.155/tests/6184#step/welcome/1)

[textmode invalid URL test when SCC_URL_VALID is not defind, in some random test](http://10.100.12.155/tests/6186#step/welcome/3)

[autoyast test](http://10.100.12.155/tests/6166#step/installation/2)
[casp autoyast test - detect warning and end](http://10.100.12.155/tests/6173#step/installation/1)

[gnome test](http://10.100.12.155/tests/6185#step/welcome/1)