### PR TITLE
Mark mandatory 'CASEDIR' as such

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -59,7 +59,7 @@ sub loadtest {
 
 sub load_testdir {
     my ($testsuite) = @_;
-    my $testdir = testapi::get_var("CASEDIR") . "/tests/$testsuite";
+    my $testdir = testapi::get_required_var('CASEDIR') . "/tests/$testsuite";
     map { loadtest "$testsuite/" . basename($_, '.pm') } glob("$testdir/*.pm");
 }
 

--- a/products/casp/main.pm
+++ b/products/casp/main.pm
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use testapi qw(check_var get_var set_var);
+use testapi qw(check_var get_var get_required_var set_var);
 use needle;
 use File::Basename;
 
@@ -28,7 +28,7 @@ sub cleanup_needles {
 }
 $needle::cleanuphandler = \&cleanup_needles;
 
-my $distri = testapi::get_var('CASEDIR') . '/lib/susedistribution.pm';
+my $distri = testapi::get_required_var('CASEDIR') . '/lib/susedistribution.pm';
 require $distri;
 testapi::set_distribution(susedistribution->new());
 

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -10,7 +10,7 @@
 
 use strict;
 use warnings;
-use testapi qw(check_var get_var set_var);
+use testapi qw(check_var get_var get_required_var set_var);
 use lockapi;
 use needle;
 use File::Find;
@@ -81,7 +81,7 @@ sub cleanup_needles() {
 my @time = localtime();
 set_var('WINTER_IS_THERE', 1) if ($time[4] == 11 || $time[4] == 0);
 
-my $distri = testapi::get_var("CASEDIR") . '/lib/susedistribution.pm';
+my $distri = testapi::get_required_var('CASEDIR') . '/lib/susedistribution.pm';
 require $distri;
 testapi::set_distribution(susedistribution->new());
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -108,7 +108,7 @@ sub cleanup_needles {
     }
 }
 
-my $distri = testapi::get_var("CASEDIR") . '/lib/susedistribution.pm';
+my $distri = testapi::get_required_var('CASEDIR') . '/lib/susedistribution.pm';
 require $distri;
 testapi::set_distribution(susedistribution->new());
 


### PR DESCRIPTION
This helps with more obvious error messages in case 'CASEDIR' is not defined.