### PR TITLE
Use common logs upload hook in yast2 GUI tests as well

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -5,7 +5,7 @@ use strict;
 use utils 'type_string_slow';
 use utils 'ensure_unlocked_desktop';
 
-# Base class for all openSUSE tests
+# Base class implementation of distribution class necessary for testapi
 
 # don't import script_run - it will overwrite script_run from distribution and create a recursion
 use testapi qw(send_key %cmd assert_screen check_screen check_var get_var save_screenshot

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -2,8 +2,6 @@
 package x11test;
 use base "opensusebasetest";
 
-# Base class for all openSUSE tests
-
 use strict;
 use testapi;
 use utils 'type_string_slow';

--- a/lib/y2x11test.pm
+++ b/lib/y2x11test.pm
@@ -17,26 +17,13 @@ sub launch_yast2_module_x11 {
     }
 }
 
-sub save_upload_y2logs() {
-    assert_script_run "save_y2logs /tmp/y2logs.tar.bz2";
-    upload_logs "/tmp/y2logs.tar.bz2";
-}
-
 sub post_fail_hook() {
     my ($self) = shift;
-    $self->export_kde_logs;
-
-    type_string "cat /home/*/.xsession-errors* > /tmp/XSE\n";
-    upload_logs "/tmp/XSE";
-
-    save_upload_y2logs;
-
+    $self->export_logs;
     save_screenshot;
 }
 
 sub post_run_hook {
-    my ($self) = @_;
-
     assert_screen('generic-desktop');
 }
 

--- a/lib/y2x11test.pm
+++ b/lib/y2x11test.pm
@@ -2,8 +2,6 @@ package y2x11test;
 use base "opensusebasetest";
 use strict;
 
-# Base class for all openSUSE tests
-
 use testapi;
 
 sub launch_yast2_module_x11 {


### PR DESCRIPTION
No need to do something special here and replicate the logic. This fixes
misleading error messages in case the .xsession-errors files do not exist as
well as provide more information, e.g. about the state of systemd controlled
jobs.