### PR TITLE
Extend yast2_network_settings.pm for following basic configurations

### DIFF
--- a/tests/yast2_gui/yast2_network_settings.pm
+++ b/tests/yast2_gui/yast2_network_settings.pm
@@ -8,11 +8,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Add YaST2 UI tests
+# Summary: yast2_network_settings.pm checks Global options, Overview, Hostname/DNS, Routing
 #    Make sure those yast2 modules can opened properly. We can add more
 #    feature test against each module later, it is ensure it will not crashed
 #    while launching atm.
-# G-Maintainer: Max Lin <mlin@suse.com>
+# Maintainer: Zaoliang Luo <zluo@suse.com>
 
 use base "y2x11test";
 use strict;
@@ -24,7 +24,47 @@ sub run() {
 
     $self->launch_yast2_module_x11($module);
     assert_screen "yast2-$module-ui", 60;
-    send_key "alt-o";    # OK => Exit
+
+    #	Global Options
+    send_key 'alt-g';
+    assert_screen 'yast2-network-settings_global-options';
+    assert_screen 'yast2-network-settings_global-options_wicked-service';
+    #	set dhcp client Identifier
+    send_key 'alt-i';
+    if (check_var('DISTRI', 'sle')) {
+        type_string 'sle-host';
+    }
+    elsif (check_var('DISTRI', 'opensuse')) {
+        type_string 'opensuse-host';
+    }
+
+    #	Overview, add a bridge
+    send_key 'alt-v';
+    assert_screen 'yast2-network-settings_overview';
+    send_key 'alt-a';
+    assert_and_click 'yast2-network-settings_overview_hardware-dialog_device-type';
+    assert_and_click 'yast2-network-settings_overview_hardware-dialog_device-type_bridge';
+    send_key 'alt-n';
+    assert_screen 'yast2-network-settings_overview_network-card-setup';
+    send_key 'alt-y';
+    assert_screen 'yast2-network-settings_overview_network-card-setup_dynamic-add';
+    send_key 'alt-n';
+
+    #	Hostname/DNS, set hostname via dhcp, yes for br0
+    send_key 'alt-s';
+    assert_screen 'yast2-network-settings_hostname-dns';
+    assert_and_click 'yast2-network-settings_hostname-dns_set-via-dhcp';
+    assert_and_click 'yast2-network-settings_hostname-dns_br0';
+
+    #	Routing, enable Forwarding
+    send_key 'alt-u';
+    assert_screen 'yast2-network-settings_routing';
+    assert_and_click 'yast2-network-settings_routing_ipv4';
+    assert_and_click 'yast2-network-settings_routing_ipv6';
+
+    #	Save network setting and it can take long time, exit
+    send_key "alt-o";
+    wait_still_screen(60);
 }
 
 1;


### PR DESCRIPTION
 - Global Options
 - Overview, add a bridge device
 - Hostname/DNS, set hostname via dhcp
 - Routing, enable Forwarding
 - Save configuration changes

SLES 12 SP3: http://e13.suse.de/tests/3023#step/yast2_network_settings
openSUSE TW: http://e13.suse.de/tests/3036#step/yast2_network_settings
openSUSE Leap: http://e13.suse.de/tests/3030#step/yast2_network_settings

 Related PRs for needles: 
SLES 12 SP3: 
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/376
openSUSE TW, Leap
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/193

