### PR TITLE
Fill External Kubernetes API server FQDN field in Velum

### DIFF
--- a/tests/casp/stack_controller.pm
+++ b/tests/casp/stack_controller.pm
@@ -40,6 +40,8 @@ sub velum_signup {
 sub velum_certificates {
     assert_screen 'velum-certificates-page';
     for (1 .. 5) { send_key 'tab' }
+    type_string "node1.openqa.test";
+    send_key 'tab';
     type_string "SUSE";
     send_key 'tab';
     type_string "QA";


### PR DESCRIPTION
Introduced in build 0285 to fix bsc#1039437
Local run: http://dhcp91.suse.cz/tests/5178#step/stack_controller/18