### PR TITLE
Do not wait for autologin to disable itself in case of NOAUTOLOGIN

### DIFF
--- a/tests/installation/user_settings.pm
+++ b/tests/installation/user_settings.pm
@@ -25,7 +25,7 @@ sub run() {
     send_key "tab";
     $self->type_password_and_verification;
     assert_screen "inst-userinfostyped";
-    if (get_var("NOAUTOLOGIN") && !check_screen('autologindisabled')) {
+    if (get_var("NOAUTOLOGIN") && !check_screen('autologindisabled', timeout => 0)) {
         send_key $cmd{noautologin};
         assert_screen "autologindisabled";
     }


### PR DESCRIPTION
If autologin is enabled, it will stay enabled until manually changed.

Signed-off-by: Stefan Brüns <stefan.bruens@rwth-aachen.de>