### PR TITLE
Fix and extend LAMP tests for PHP5 and PHP7

### DIFF
--- a/data/console/postgres_openqadb.sql
+++ b/data/console/postgres_openqadb.sql
@@ -1,0 +1,250 @@
+--
+-- PostgreSQL database cluster dump
+--
+
+SET default_transaction_read_only = off;
+
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+
+--
+-- Roles
+--
+
+CREATE ROLE postgres;
+ALTER ROLE postgres WITH SUPERUSER INHERIT CREATEROLE CREATEDB LOGIN REPLICATION;
+
+
+
+
+
+
+--
+-- Database creation
+--
+
+CREATE DATABASE "openQAdb" WITH TEMPLATE = template0 OWNER = postgres;
+REVOKE ALL ON DATABASE template1 FROM PUBLIC;
+REVOKE ALL ON DATABASE template1 FROM postgres;
+GRANT ALL ON DATABASE template1 TO postgres;
+GRANT CONNECT ON DATABASE template1 TO PUBLIC;
+
+
+\connect "openQAdb"
+
+SET default_transaction_read_only = off;
+
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: 
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
+SET search_path = public, pg_catalog;
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+--
+-- Name: test; Type: TABLE; Schema: public; Owner: postgres; Tablespace: 
+--
+
+CREATE TABLE test (
+    id integer NOT NULL,
+    entry character varying
+);
+
+
+ALTER TABLE test OWNER TO postgres;
+
+--
+-- Name: test_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE test_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE test_id_seq OWNER TO postgres;
+
+--
+-- Name: test_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE test_id_seq OWNED BY test.id;
+
+
+--
+-- Name: id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY test ALTER COLUMN id SET DEFAULT nextval('test_id_seq'::regclass);
+
+
+--
+-- Data for Name: test; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY test (id, entry) FROM stdin;
+1	openQA_test
+2	can you read this?
+\.
+
+
+--
+-- Name: test_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
+--
+
+SELECT pg_catalog.setval('test_id_seq', 2, true);
+
+
+--
+-- Name: test_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres; Tablespace: 
+--
+
+ALTER TABLE ONLY test
+    ADD CONSTRAINT test_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: public; Type: ACL; Schema: -; Owner: postgres
+--
+
+REVOKE ALL ON SCHEMA public FROM PUBLIC;
+REVOKE ALL ON SCHEMA public FROM postgres;
+GRANT ALL ON SCHEMA public TO postgres;
+GRANT ALL ON SCHEMA public TO PUBLIC;
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+\connect postgres
+
+SET default_transaction_read_only = off;
+
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+--
+-- Name: postgres; Type: COMMENT; Schema: -; Owner: postgres
+--
+
+COMMENT ON DATABASE postgres IS 'default administrative connection database';
+
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: 
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
+--
+-- Name: public; Type: ACL; Schema: -; Owner: postgres
+--
+
+REVOKE ALL ON SCHEMA public FROM PUBLIC;
+REVOKE ALL ON SCHEMA public FROM postgres;
+GRANT ALL ON SCHEMA public TO postgres;
+GRANT ALL ON SCHEMA public TO PUBLIC;
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+\connect template1
+
+SET default_transaction_read_only = off;
+
+--
+-- PostgreSQL database dump
+--
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+--
+-- Name: template1; Type: COMMENT; Schema: -; Owner: postgres
+--
+
+COMMENT ON DATABASE template1 IS 'default template for new databases';
+
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: 
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
+--
+-- Name: public; Type: ACL; Schema: -; Owner: postgres
+--
+
+REVOKE ALL ON SCHEMA public FROM PUBLIC;
+REVOKE ALL ON SCHEMA public FROM postgres;
+GRANT ALL ON SCHEMA public TO postgres;
+GRANT ALL ON SCHEMA public TO PUBLIC;
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+--
+-- PostgreSQL database cluster dump complete
+--
+

--- a/data/console/test_mysql_connector.php
+++ b/data/console/test_mysql_connector.php
@@ -1,10 +1,9 @@
 <?php
-    mysql_connect('localhost', 'root', '');
-    mysql_select_db('openQAdb');
-    $result = mysql_query("SELECT * FROM test");
-    while($row = mysql_fetch_array($result)){
+    $link = mysqli_connect('localhost', 'root', '', 'openQAdb');
+    $result = mysqli_query($link, "SELECT * FROM test");
+    while($row = mysqli_fetch_assoc($result)){
         echo $row['entry'];
     }
-    mysql_query("INSERT INTO test (entry) VALUE ('can php write this?')");
+    mysqli_query($link, "INSERT INTO test (entry) VALUE ('can php write this?')");
 ?>
 

--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -192,7 +192,7 @@ qq{mysql -u root -e "CREATE DATABASE openQAdb; USE openQAdb; CREATE TABLE test (
     # configure the PHP code that:
     #  1. reads table 'test' from the 'openQAdb' database
     #  2. inserts a new element 'can php write this?' into the same table
-    assert_script_run "wget --quiet " . data_url('console/test_mysql_connector.php') . " -O /srv/www/htdocs/test_mysql_connector.php";
+    assert_script_run "curl " . data_url('console/test_mysql_connector.php') . " -o /srv/www/htdocs/test_mysql_connector.php";
     assert_script_run "systemctl restart apache2.service";
 
     # access the website and verify that it can read the database

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -457,6 +457,12 @@ sub load_consoletests() {
             loadtest "console/http_srv";
             loadtest "console/mysql_srv";
             loadtest "console/dns_srv";
+            loadtest "console/php5";
+            loadtest "console/php5_mysql";
+            loadtest "console/php5_postgresql94";
+            loadtest "console/php7";
+            loadtest "console/php7_mysql";
+            loadtest "console/php7_postgresql94";
             if (check_var('ARCH', 'x86_64')) {
                 loadtest "console/docker";
             }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -729,9 +729,10 @@ sub load_consoletests() {
             if (get_var('ADDONS', '') =~ /wsm/ || get_var('SCC_ADDONS', '') =~ /wsm/) {
                 loadtest "console/pcre";
                 loadtest "console/php5";
-                loadtest "console/php7";
                 loadtest "console/php5_mysql";
                 loadtest "console/php5_postgresql94";
+                loadtest "console/php7";
+                loadtest "console/php7_mysql";
                 loadtest "console/php7_postgresql94";
             }
             loadtest "console/apache_ssl";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -729,6 +729,7 @@ sub load_consoletests() {
             if (get_var('ADDONS', '') =~ /wsm/ || get_var('SCC_ADDONS', '') =~ /wsm/) {
                 loadtest "console/pcre";
                 loadtest "console/php5";
+                loadtest "console/php7";
                 loadtest "console/php5_mysql";
                 loadtest "console/php5_postgresql94";
             }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -732,6 +732,7 @@ sub load_consoletests() {
                 loadtest "console/php7";
                 loadtest "console/php5_mysql";
                 loadtest "console/php5_postgresql94";
+                loadtest "console/php7_postgresql94";
             }
             loadtest "console/apache_ssl";
             loadtest "console/apache_nss";

--- a/tests/console/php5_mysql.pm
+++ b/tests/console/php5_mysql.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -12,10 +12,8 @@
 #   PHP reads the elements and writes a new one in the database. If
 #   all succeed, the test passes.
 #
-#   The test requires the Web and Scripting module on SLE and should be
-#   executed after the 'console/http_srv', 'console/mysql_srv', and
-#   'console/php5' tests.
-# Maintainer: Romanos Dodopoulos <romanos.dodopoulos@suse.cz>
+#   The test requires the Web and Scripting module on SLE
+# Maintainer: Ondřej Súkup <osukup@suse.cz>
 
 
 use base "consoletest";
@@ -23,10 +21,12 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use apachetest;
 
 sub run() {
     select_console 'root-console';
 
+    setup_apache2(mode => 'PHP5');
     # install requirements
     zypper_call "in php5-mysql";
 
@@ -37,7 +37,7 @@ qq{mysql -u root -e "CREATE DATABASE openQAdb; USE openQAdb; CREATE TABLE test (
     # configure the PHP code that:
     #  1. reads table 'test' from the 'openQAdb' database
     #  2. inserts a new element 'can php write this?' into the same table
-    type_string "wget --quiet " . data_url('console/test_mysql_connector.php') . " -O /srv/www/htdocs/test_mysql_connector.php\n";
+    assert_script_run "wget --quiet " . data_url('console/test_mysql_connector.php') . " -O /srv/www/htdocs/test_mysql_connector.php";
     assert_script_run "systemctl restart apache2.service";
 
     # access the website and verify that it can read the database

--- a/tests/console/php5_mysql.pm
+++ b/tests/console/php5_mysql.pm
@@ -28,7 +28,7 @@ sub run() {
 
     setup_apache2(mode => 'PHP5');
     # install requirements
-    zypper_call "in php5-mysql mysql";
+    zypper_call "in php5-mysql mysql sudo";
 
     assert_script_run "systemctl restart mysql", 300;
 

--- a/tests/console/php5_postgresql94.pm
+++ b/tests/console/php5_postgresql94.pm
@@ -30,7 +30,7 @@ sub run() {
     setup_apache2(mode => 'PHP5');
 
     # install requirements
-    zypper_call "in php5-pgsql postgresql94-server";
+    zypper_call "in php5-pgsql postgresql94-server sudo";
 
     # start postgresql
     assert_script_run "systemctl start postgresql";

--- a/tests/console/php7.pm
+++ b/tests/console/php7.pm
@@ -1,13 +1,13 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2017 SUSE LLC
+# Copyright © 2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Simple PHP5 code hosted locally
+# Summary: Simple PHP7 code hosted locally
 #   This test requires the Web and Scripting module on SLE.
 # Maintainer: Ondřej Súkup <osukup@suse.cz>
 
@@ -20,7 +20,7 @@ use apachetest;
 
 sub run() {
     select_console 'root-console';
-    setup_apache2(mode => 'PHP5');
-    validate_script_output('curl http://localhost/index.php', sub { /PHP Version 5/ });
+    setup_apache2(mode => 'PHP7');
+    validate_script_output('curl http://localhost/index.php', sub { /PHP Version 7/ });
 }
 1;

--- a/tests/console/php7_mysql.pm
+++ b/tests/console/php7_mysql.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: PHP5 code that interacts locally with MySQL
+# Summary: PHP7 code that interacts locally with MySQL
 #   This tests creates a MySQL database and inserts an element. Then,
 #   PHP reads the elements and writes a new one in the database. If
 #   all succeed, the test passes.
@@ -26,13 +26,12 @@ use apachetest;
 sub run() {
     select_console 'root-console';
 
-    setup_apache2(mode => 'PHP5');
+    setup_apache2(mode => 'PHP7');
     # install requirements
-    zypper_call "in php5-mysql mysql";
+    zypper_call "in php7-mysql mysql";
 
     assert_script_run "systemctl restart mysql", 300;
 
     test_mysql;
 }
-
 1;

--- a/tests/console/php7_mysql.pm
+++ b/tests/console/php7_mysql.pm
@@ -28,7 +28,7 @@ sub run() {
 
     setup_apache2(mode => 'PHP7');
     # install requirements
-    zypper_call "in php7-mysql mysql";
+    zypper_call "in php7-mysql mysql sudo";
 
     assert_script_run "systemctl restart mysql", 300;
 

--- a/tests/console/php7_postgresql94.pm
+++ b/tests/console/php7_postgresql94.pm
@@ -1,13 +1,13 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: PHP5 code that interacts locally with PostgreSQL
+# Summary: PHP7 code that interacts locally with PostgreSQL
 #   This tests creates a PostgreSQL database and inserts an element.
 #   Then, PHP reads the elements and writes a new one in the database.
 #   If all succeed, the test passes.
@@ -26,14 +26,15 @@ use apachetest;
 sub run() {
     select_console 'root-console';
 
-    # ensure apache2 + php5 installed and running
-    setup_apache2(mode => 'PHP5');
+    # ensure apache2 + php7 installed and running
+    setup_apache2(mode => 'PHP7');
 
     # install requirements
-    zypper_call "in php5-pgsql postgresql94-server";
+    zypper_call "in php7-pgsql postgresql94-server";
 
-    # start postgresql
+    # start postgresql service
     assert_script_run "systemctl start postgresql";
+
     # setup database
     setup_pgsqldb;
 

--- a/tests/console/php7_postgresql94.pm
+++ b/tests/console/php7_postgresql94.pm
@@ -30,7 +30,7 @@ sub run() {
     setup_apache2(mode => 'PHP7');
 
     # install requirements
-    zypper_call "in php7-pgsql postgresql94-server";
+    zypper_call "in php7-pgsql postgresql94-server sudo";
 
     # start postgresql service
     assert_script_run "systemctl start postgresql";

--- a/tests/console/postgresql94server.pm
+++ b/tests/console/postgresql94server.pm
@@ -1,7 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -9,12 +8,13 @@
 # without any warranty.
 
 # Summary: Postgres tests for SLE12
-# Maintainer: Romanos Dodopoulos <romanos.dodopoulos@suse.cz>
+# Maintainer:  Ondřej Súkup <osukup@suse.cz>
 
 use base "consoletest";
 use strict;
 use testapi;
 use utils;
+use apachetest;
 
 sub run() {
     select_console 'root-console';
@@ -35,17 +35,9 @@ sub run() {
         assert_script_run "systemctl show -p SubState postgresql.service | grep SubState=running";
     }
 
-    # without changing current working directory we get:
-    # 'could not change directory to "/root": Permission denied'
-    assert_script_run 'pushd /tmp';
-
-    # test basic functionality - require postgresql94
-    assert_script_run "sudo -u postgres createdb openQAdb";
-    assert_script_run "sudo -u postgres psql -d openQAdb -c \"CREATE TABLE test (id SERIAL PRIMARY KEY, entry VARCHAR)\"";
-    assert_script_run "sudo -u postgres psql -d openQAdb -c \"INSERT INTO test (entry) VALUES ('openQA_test'), ('can you read this?');\"";
-    assert_script_run "sudo -u postgres psql -d openQAdb -c \"SELECT * FROM test\" | grep \"can you read this\"";
-
-    assert_script_run 'popd';    # back to previous directory
+    # test basic functionality of postgresql94
+    setup_pgsqldb;
+    destroy_pgsqldb;
 }
 
 1;


### PR DESCRIPTION
Extend LAMP to test PHP7 , and make tests independent on test order

SLE: http://argus.suse.cz/tests/1024
openSUSE: http://argus.suse.cz/tests/1025