### PR TITLE
Add tests for weechat and nano

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -497,6 +497,7 @@ sub load_extra_tests() {
             loadtest "console/zypper_ar";
             loadtest "console/a2ps";    # a2ps is not a ring package and thus not available in staging
             loadtest "console/weechat";
+            loadtest "console/nano";
         }
         loadtest "console/git";
         loadtest "console/java";

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -496,6 +496,7 @@ sub load_extra_tests() {
             loadtest "console/zbar";
             loadtest "console/zypper_ar";
             loadtest "console/a2ps";    # a2ps is not a ring package and thus not available in staging
+            loadtest "console/weechat";
         }
         loadtest "console/git";
         loadtest "console/java";

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -394,6 +394,22 @@ sub wait_boot {
     $self->{in_wait_boot} = 0;
 }
 
+sub enter_test_text {
+    my ($self, $name, %args) = @_;
+    $name       //= 'your program';
+    $args{cmd}  //= 0;
+    $args{slow} //= 0;
+    for (1 .. 13) { send_key 'ret' }
+    my $text = "If you can see this text $name is working.\n";
+    $text = 'echo ' . $text if $args{cmd};
+    if ($args{slow}) {
+        type_string_slow $text;
+    }
+    else {
+        type_string $text;
+    }
+}
+
 # useful post_fail_hook for any module that calls wait_boot
 #
 # we could use the same approach in all cases of boot/reboot/shutdown in case

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -56,22 +56,6 @@ sub prepare_sle_classic {
     assert_screen "desktop-sle-classic", 120;
 }
 
-sub enter_test_text {
-    my ($self, $name, %args) = @_;
-    $name       //= 'your program';
-    $args{cmd}  //= 0;
-    $args{slow} //= 0;
-    for (1 .. 13) { send_key 'ret' }
-    my $text = "If you can see this text $name is working.\n";
-    $text = 'echo ' . $text if $args{cmd};
-    if ($args{slow}) {
-        type_string_slow $text;
-    }
-    else {
-        type_string $text;
-    }
-}
-
 sub test_terminal {
     my ($self, $name) = @_;
     mouse_hide(1);

--- a/tests/console/nano.pm
+++ b/tests/console/nano.pm
@@ -1,0 +1,38 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Test nano editor
+# Maintainer: Oliver Kurz <okurz@suse.de>
+
+use base 'consoletest';
+use strict;
+use testapi;
+use utils 'zypper_call';
+
+sub run() {
+    my ($self) = @_;
+    select_console('root-console');
+    zypper_call('in nano');
+    script_run("nano; echo nano-status-\$? > /dev/$serialdev", 0);
+    $self->enter_test_text('nano');
+    assert_screen('nano');
+    wait_screen_change { send_key 'ctrl-x' };
+    send_key 'n';
+    wait_serial("nano-status-0") || die "'nano' could not finish successfully";
+}
+
+1;
+# vim: set sw=4 et:
+

--- a/tests/console/weechat.pm
+++ b/tests/console/weechat.pm
@@ -1,0 +1,36 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Test basic weechat start and stop
+# Maintainer: Oliver Kurz <okurz@suse.de>
+
+use base 'consoletest';
+use strict;
+use testapi;
+use utils 'zypper_call';
+
+sub run() {
+    select_console('root-console');
+    zypper_call('in weechat');
+    select_console('user-console');
+    script_run("weechat; echo weechat-status-\$? > /dev/$serialdev", 0);
+    assert_screen('weechat');
+    type_string("/quit\n");
+    wait_serial("weechat-status-0") || die "'weechat' could not finish successfully";
+}
+
+1;
+# vim: set sw=4 et:
+


### PR DESCRIPTION
* Add simple nano test
  See https://lists.opensuse.org/opensuse-factory/2017-05/msg00313.html
  Related needle change: os-autoinst/os-autoinst-needles-opensuse#195
  Verification run: http://lord.arch/tests/6313
* Add simple weechat test
  See https://lists.opensuse.org/opensuse-factory/2017-05/msg00299.html
  Verification run: http://lord.arch/tests/6312