### PR TITLE
Fix poo#19242: Enter password before grub for full lvm encrypt

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -303,6 +303,7 @@ sub wait_boot {
         push @tags, 'bootloader-shim-import-prompt'   if get_var('UEFI');
         push @tags, 'boot-live-' . get_var('DESKTOP') if get_var('LIVETEST');    # LIVETEST won't to do installation and no grub2 menu show up
         push @tags, 'bootloader'                      if get_var('OFW');
+        push @tags, 'encrypted-disk-password-prompt'  if get_var('ENCRYPT');
         if (get_var('ONLINE_MIGRATION')) {
             push @tags, 'migration-source-system-grub2';
         }
@@ -336,6 +337,11 @@ sub wait_boot {
             assert_screen 'grub2', 15;
             # confirm default choice
             send_key 'ret';
+        }
+        elsif (match_has_tag('encrypted-disk-password-prompt')) {
+            # unlock encrypted disk before grub
+            workaround_type_encrypted_passphrase;
+            assert_screen "grub2", 15;
         }
         elsif (!match_has_tag("grub2")) {
             # check_screen timeout


### PR DESCRIPTION
For full encrypted LVM partitions, the password should be typed
twice: before grub and after grub. It has been implemented in
installation test, but first password is missing in wait_boot
when boot from an existing hdd image.