### PR TITLE
Split extra test

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -787,6 +787,10 @@ elsif (get_var("MEDIACHECK")) {
 elsif (get_var("MEMTEST")) {
     loadtest "installation/memtest";
 }
+elsif (get_var("FILESYSTEM_TEST")) {
+    boot_hdd_image;
+    load_filesystem_tests();
+}
 elsif (get_var("RESCUESYSTEM")) {
     loadtest "installation/rescuesystem";
     loadtest "installation/rescuesystem_validate_131";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1235,6 +1235,10 @@ elsif (get_var("EXTRATEST")) {
     }
     load_extra_tests();
 }
+elsif (get_var("FILESYSTEM_TEST")) {
+    boot_hdd_image;
+    load_filesystem_tests();
+}
 elsif (get_var("Y2UITEST")) {
     load_yast2_ui_tests;
 }


### PR DESCRIPTION
As we discussed here: https://progress.opensuse.org/issues/17768, extra tests will be splitted into extra tests and filesystem tests, in order to reduce the overall run time. Here are several testruns:

Testrun on SLE, filesystem tests: http://f146.suse.de/tests/334
Testrun on SLE, extra tests: http://f146.suse.de/tests/332
Testrun on openSUSE, filesystem tests: http://f146.suse.de/tests/336
Testrun on openSUSE, extra tests: http://f146.suse.de/tests/338