### PR TITLE
Fix snapper_thin_lvm regression after 6c95f04a (poo#19322)

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -11,6 +11,11 @@ Defines the variable C<$disk> in a bash session.
 =cut
 sub set_unpartitioned_disk_in_bash {
     assert_script_run 'disk=$(parted --machine -l |& sed -n \'s@^\(/dev/vd[ab]\):.*unknown.*$@\1@p\')';
+    assert_script_run 'echo $disk';
+}
+
+sub cleanup_partition_table {
+    assert_script_run 'wipefs --all $disk';
 }
 
 1;

--- a/tests/console/btrfs_qgroups.pm
+++ b/tests/console/btrfs_qgroups.pm
@@ -87,6 +87,7 @@ sub run() {
 
     assert_script_run "cd; umount $dest";
     assert_script_run 'btrfsck $disk';
+    $self->cleanup_partition_table;
 }
 
 1;

--- a/tests/console/btrfs_send_receive.pm
+++ b/tests/console/btrfs_send_receive.pm
@@ -69,7 +69,8 @@ sub run() {
         assert_script_run "btrfs send -p $src/snap" . ($i - 1) . " $src/snap$i | btrfs receive $dest";
         compare_data $i;
     }
-    assert_script_run("umount -fl \$disk");
+    assert_script_run 'umount -fl $disk';
+    $self->cleanup_partition_table;
 }
 
 1;


### PR DESCRIPTION
Wipe the filesystem after test modules accessing the unpartitioned disk to
make sure subsequent modules, in this case snapper_thin_lvm, can also find the
unpartitioned disk again reliably. This also prevents a potentially misleading
warning as we had in before that snapper_thin_lvm is forcefully overwriting an
existing filesystem on the disk reserved for filesystem related experiments.

Verification run: http://lord.arch/tests/6327

Related progress issue: https://progress.opensuse.org/issues/19322