### PR TITLE
kdump: Use assert_script_run with longer timeout

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -17,7 +17,7 @@ use utils;
 our @EXPORT = qw(install_kernel_debuginfo prepare_for_kdump activate_kdump kdump_is_active do_kdump);
 
 sub install_kernel_debuginfo {
-    script_run 'zypper ref';
+    assert_script_run 'zypper ref', 300;
     zypper_call('-v in $(rpmquery kernel-default | sed "s/kernel-default/kernel-default-debuginfo/")');
 }
 

--- a/tests/console/kdump_and_crash.pm
+++ b/tests/console/kdump_and_crash.pm
@@ -10,7 +10,6 @@
 # Summary: Run 'crash' utility on a kernel memory dump
 # Maintainer: Michal Nowak <mnowak@suse.com>, Yi Xu <yxu@suse.com>
 
-use base "opensusebasetest";
 use base "console_yasttest";
 use strict;
 use testapi;


### PR DESCRIPTION
Trying to fix https://openqa.suse.de/tests/957760#step/kdump_and_crash/9
With maintenance repo a zypper ref takes longer