### PR TITLE
Run `test-compile` target in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
     packages:
       - libdbus-1-dev
       - libssh2-1-dev
+      - parallel
 before_install:
   - eval $(curl https://travis-perl.github.io/init) --perl
   - echo "requires 'Code::DRY';" >> cpanfile

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ tidy: check-links
 
 .PHONY: test-compile
 test-compile: check-links
-	export PERL5LIB=${PERL5LIB_} ; for f in `git ls-files "*.pm" || find . -name \*.pm|grep -v /os-autoinst/` ; do perl -c $$f 2>&1 | grep -v " OK$$" && exit 2; done ; true
+	export PERL5LIB=${PERL5LIB_} ; ( git ls-files "*.pm" || find . -name \*.pm|grep -v /os-autoinst/ ) | parallel perl -c 2>&1 | grep -v " OK$$" && exit 2; true
 
 .PHONY: test-compile-changed
 test-compile-changed: os-autoinst/


### PR DESCRIPTION
New runtime requirement: GNU Parallel.

Reduces `test-compile` runtime from 4 to one minute on my 8 core system
with spinning HDD.

May not be usefull in Travis itself, but helps in manual runs
significantly.