### PR TITLE
Set BRIDGED_NETWORKING for needle identification

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -65,6 +65,8 @@ sub is_bridged_networking {
         my $vmm_family = get_required_var('VIRSH_VMM_FAMILY');
         $ret = ($vmm_family =~ /xen|vmware|hyperv/);
     }
+    # Some needles match hostname which we can't set permanently with bridge.
+    set_var('BRIDGED_NETWORKING', 1) if $ret;
     return $ret;
 }
 


### PR DESCRIPTION
Eventhough we have is_bridged_networking(), we need some information,
which we can use in needles, in which we mask hostname, which we can't
match when bridged network is in use (as it's changing all the time).

E.g.: https://openqa.suse.de/tests/958746#step/xterm/5.