### PR TITLE
Prevent kontact comming up again after reboot

### DIFF
--- a/tests/x11/kontact.pm
+++ b/tests/x11/kontact.pm
@@ -36,6 +36,11 @@ sub run() {
         wait_screen_change { send_key 'alt-c' } if match_has_tag('test-kontact-1');
     } until (match_has_tag('kontact-window'));
     send_key 'ctrl-q';
+    # Since gcc7 used for packages within openSUSE Factory kontact seems to
+    # persist consistently as a process in the background causing kontact to
+    # be "restored" after a re-login/reboot causing later tests to fail. To
+    # prevent this we explicitly stop the kontact background process.
+    x11_start_program('killall kontact', valid => 0);
 }
 
 1;


### PR DESCRIPTION
From discussions with the KDE team the behaviour which was previously random
but now in current staging:C very consistently kontact can persist in the
background as a process. After re-login/reboot the application would be
started which is not expected in our tests. This behaviour seems to be
consistent now with the move to gcc7.

For more discussion around this also see
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/2962

Verification run: http://lord.arch/tests/6331