### PR TITLE
btrfs_test: Try to avoid a busy filesystem when trying to wipe

### DIFF
--- a/tests/console/btrfs_send_receive.pm
+++ b/tests/console/btrfs_send_receive.pm
@@ -69,7 +69,7 @@ sub run() {
         assert_script_run "btrfs send -p $src/snap" . ($i - 1) . " $src/snap$i | btrfs receive $dest";
         compare_data $i;
     }
-    assert_script_run 'umount -fl $disk';
+    assert_script_run 'umount $disk', 600;
     $self->cleanup_partition_table;
 }
 


### PR DESCRIPTION
Using '--force' on unmount would only make sense for NFS, '--lazy' would
cleanup references after unmount but keep the device busy so get rid of these
options, be explicit about the cleanup and wait longer if necessary.

Related progress issue: https://progress.opensuse.org/issues/19370