### PR TITLE
Fix password being typed too eagerly in postgresql tests

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -160,10 +160,15 @@ sub test_pgsql {
     # configuration so that PHP can access PostgreSQL
     # setup password
     type_string "sudo -u postgres psql postgres\n";
+    wait_still_screen(1);
     type_string "\\password postgres\n";
+    wait_still_screen(1);
     type_string "postgres\n";
+    wait_still_screen(1);
     type_string "postgres\n";
+    wait_still_screen(1);
     type_string "\\q\n";
+    wait_still_screen(1);
     # comment out default configuration
     assert_script_run "sed -i 's/^host/#host/g' /var/lib/pgsql/data/pg_hba.conf";
     # allow postgres to access the db with password authentication


### PR DESCRIPTION
Verification run: http://lord.arch/tests/6343

Related progress issue: https://progress.opensuse.org/issues/19336