### PR TITLE
yast2_xinetd: Bump timeout for initial startup

### DIFF
--- a/tests/console/yast2_xinetd.pm
+++ b/tests/console/yast2_xinetd.pm
@@ -27,7 +27,7 @@ sub run() {
     script_run("yast2 xinetd; echo yast2-xinetd-status-\$? > /dev/$serialdev", 0);
 
     # check xinetd network configuration got started
-    assert_screen 'yast2_xinetd_startup';
+    assert_screen 'yast2_xinetd_startup', 90;
 
     # enable xinetd
     send_key 'alt-l';


### PR DESCRIPTION
See https://openqa.opensuse.org/tests/409286#step/yast2_xinetd/7