### PR TITLE
Fix still busy filesystem on wipefs in some occassions

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -10,12 +10,13 @@ Choose the disk without a partition table for btrfs experiments.
 Defines the variable C<$disk> in a bash session.
 =cut
 sub set_unpartitioned_disk_in_bash {
-    assert_script_run 'disk=$(parted --machine -l |& sed -n \'s@^\(/dev/vd[ab]\):.*unknown.*$@\1@p\')';
+    assert_script_run 'parted --machine -l';
+    assert_script_run 'disk=${disk:-$(parted --machine -l |& sed -n \'s@^\(/dev/vd[ab]\):.*unknown.*$@\1@p\')}';
     assert_script_run 'echo $disk';
 }
 
 sub cleanup_partition_table {
-    assert_script_run 'wipefs --all $disk';
+    assert_script_run 'wipefs --force --all $disk';
 }
 
 1;

--- a/tests/console/btrfs_send_receive.pm
+++ b/tests/console/btrfs_send_receive.pm
@@ -69,7 +69,7 @@ sub run() {
         assert_script_run "btrfs send -p $src/snap" . ($i - 1) . " $src/snap$i | btrfs receive $dest";
         compare_data $i;
     }
-    assert_script_run 'umount $disk', 600;
+    assert_script_run 'umount -l $disk';
     $self->cleanup_partition_table;
 }
 


### PR DESCRIPTION
Not using a lazy unmount could work in some cases but in most it would still
fail because the filesystem is busy from the previous filesystem experiments.
So we instead force the wiping of the filesystem. Also later in other test
modules when the disk variable is still there we reuse it. It must be the same
disk anyway. This way if the disk looks still like used or not unpartitioned
it's forcefully overwritten as a last resort.

This is a followup to
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/2964

Verification run: http://lord.arch/tests/6418

Related progress issue: https://progress.opensuse.org/issues/19370