### PR TITLE
Make updates_packagekit_kde more robust

### DIFF
--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -35,17 +35,26 @@ sub run() {
 
         # First update package manager, then packages, then bsc#992773 (2x)
         while (1) {
-            assert_and_click("updates_click-install");
+            assert_and_click('updates_click-install');
 
             # Wait until installation is done
             assert_screen \@updates_installed_tags, 3600;
-            if (match_has_tag("updates_none")) {
-                wait_still_screen;
-                if (check_screen "updates_none") {
+            # Make sure we saw the right string and the same screen or a
+            # different one
+            wait_still_screen;
+            if (match_has_tag('updates_none')) {
+                if (check_screen 'updates_none') {
                     last;
                 }
                 else {
-                    record_soft_failure 'bsc#992773';
+                    record_soft_failure 'boo#992773';
+                }
+            }
+            elsif (match_has_tag('updates_available')) {
+                # look again
+                if (check_screen 'updates_none', 0) {
+                    record_soft_failure 'boo#1041112';
+                    last;
                 }
             }
         }


### PR DESCRIPTION
Created new bug https://bugzilla.opensuse.org/show_bug.cgi?id=1041112 which
also describes the problem in detail. Along with boo#992773 which is also
still open when no updates could appear when actually there are some now we
handle the inverse case where after applying updates the applet would still
shortly show available updates when actually there are not any.

Verification runs: http://lord.arch/tests?match=fix_kde_update_tray-fixed