### PR TITLE
Add gnuhealth tests

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -794,6 +794,9 @@ elsif (get_var("FILESYSTEM_TEST")) {
 elsif (get_var('GNUHEALTH')) {
     boot_hdd_image;
     loadtest 'gnuhealth/gnuhealth_install';
+    loadtest 'gnuhealth/tryton_install';
+    loadtest 'gnuhealth/tryton_preconfigure';
+    loadtest 'gnuhealth/tryton_first_time';
 }
 
 elsif (get_var("RESCUESYSTEM")) {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -791,6 +791,11 @@ elsif (get_var("FILESYSTEM_TEST")) {
     boot_hdd_image;
     load_filesystem_tests();
 }
+elsif (get_var('GNUHEALTH')) {
+    boot_hdd_image;
+    loadtest 'gnuhealth/gnuhealth_install';
+}
+
 elsif (get_var("RESCUESYSTEM")) {
     loadtest "installation/rescuesystem";
     loadtest "installation/rescuesystem_validate_131";

--- a/tests/gnuhealth/README
+++ b/tests/gnuhealth/README
@@ -1,0 +1,3 @@
+test suite for gnuhealth
+
+contact for gnuhealth related questions: axel.braun@gmx.de, github: coogor

--- a/tests/gnuhealth/gnuhealth_install.pm
+++ b/tests/gnuhealth/gnuhealth_install.pm
@@ -40,5 +40,9 @@ sub run() {
     send_key 'ctrl-d';
 }
 
+sub test_flags() {
+    return {fatal => 1};
+}
+
 1;
 # vim: set sw=4 et:

--- a/tests/gnuhealth/gnuhealth_install.pm
+++ b/tests/gnuhealth/gnuhealth_install.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: gnuhealth stack installation
+# Maintainer: Oliver Kurz <okurz@suse.de>
+
+use base 'x11test';
+use strict;
+use testapi;
+
+sub run() {
+    my ($self) = @_;
+    ensure_installed 'gnuhealth';
+    x11_start_program 'xterm';
+    assert_screen 'xterm';
+    become_root;
+    assert_script_run 'systemctl start postgresql';
+    wait_screen_change { script_run 'su postgres', 0 };
+    script_run 'sed -i -e \'s/\(local.*all.*all.*\)md5/\1trust/g\' /var/lib/pgsql/data/pg_hba.conf', 0;
+    script_run 'psql -c "CREATE USER tryton WITH CREATEDB;"',                                        0;
+    wait_screen_change { send_key 'ctrl-d' };
+    assert_script_run 'systemctl restart postgresql';
+    # generate the crypted password as described in /etc/tryton/trytond.conf
+    script_run
+'pw=$(python -c \'import getpass,crypt,random,string; print crypt.crypt(getpass.getpass(), "".join(random.sample(string.ascii_letters + string.digits, 8)))\')',
+      0;
+    wait_still_screen(1);
+    type_string "susetesting\n";
+    assert_script_run 'sed -i -e "s/^.*super_pwd.*\$/super_pwd = ${pw}/g" /etc/tryton/trytond.conf';
+    assert_script_run 'systemctl start trytond';
+    # exit from root session
+    send_key 'ctrl-d';
+    # exit xterm
+    send_key 'ctrl-d';
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/gnuhealth/tryton_first_time.pm
+++ b/tests/gnuhealth/tryton_first_time.pm
@@ -1,0 +1,42 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: first time startup for admin user for gnuhealth tryton
+# Maintainer: Oliver Kurz <okurz@suse.de>
+
+use base 'x11test';
+use strict;
+use testapi;
+
+sub run() {
+    send_key_until_needlematch 'tryton-login_password', 'tab';
+    type_string "susetesting\n";
+    assert_screen 'tryton-module_configuration_wizard_start';
+    send_key 'ret';
+    assert_screen 'tryton-module_configuration_wizard-add_users-welcome';
+    send_key 'ret';
+    assert_screen 'tryton-module_configuration_wizard-add_users_dialog';
+    # let's not add a user for now
+    wait_screen_change { send_key 'alt-o' };
+    wait_screen_change { send_key 'alt-e' };
+    wait_screen_change { send_key 'alt-n' };
+    send_key 'alt-o';
+    assert_screen 'tryton-admin_view', 300;
+}
+
+sub test_flags() {
+    return {fatal => 1};
+}
+
+# overwrite the base class check for a clean desktop
+sub post_run_hook {
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/gnuhealth/tryton_install.pm
+++ b/tests/gnuhealth/tryton_install.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: gnuhealth tryton client installation and startup
+# Maintainer: Oliver Kurz <okurz@suse.de>
+
+use base 'x11test';
+use strict;
+use testapi;
+
+sub run() {
+    my ($self) = @_;
+    ensure_installed 'tryton';
+}
+
+sub test_flags() {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/gnuhealth/tryton_preconfigure.pm
+++ b/tests/gnuhealth/tryton_preconfigure.pm
@@ -1,0 +1,59 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: first time administration and setup work for gnuhealth tryton
+# Maintainer: Oliver Kurz <okurz@suse.de>
+
+use base 'x11test';
+use strict;
+use testapi;
+
+sub run() {
+    x11_start_program 'tryton';
+    assert_screen 'tryton-startup';
+    assert_and_click 'tryton-manage_profiles';
+    # wait for indexing to be done
+    wait_still_screen(3);
+    assert_and_click 'tryton-manage_profiles-add';
+    type_string 'localhost';
+    send_key_until_needlematch 'tryton-manage_profiles-host_textfield_selected', 'tab';
+    type_string 'localhost';
+    send_key 'tab';
+    # button 'create' should appear, weird GUI behaviour
+    assert_and_click 'tryton-manage_profiles-create_database';
+    # tryton server password
+    type_string 'susetesting';
+    send_key 'tab';
+    # database name
+    type_string 'gnuhealth_demo';
+    send_key 'tab';
+    send_key 'tab';
+    # admin password
+    type_string 'susetesting';
+    send_key 'tab';
+    type_string 'susetesting';
+    # wait for create button to be active
+    assert_and_click 'tryton-manage_profiles-create_database-create';
+    # back to profiles menue
+    assert_screen 'tryton-manage_profiles-add', 300;
+    send_key 'ret';
+    # back to login dialog
+    assert_screen 'tryton-startup';
+}
+
+sub test_flags() {
+    return {fatal => 1};
+}
+
+# overwrite the base class check for a clean desktop
+sub post_run_hook {
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
* Add more modules for gnuhealth tests
* Add simple gnuhealth installation test

Test plan enabled by variable `GNUHEALTH=1`. After merge I will create a test suite on o3 and trigger the tests accordingly in job groups where they are shown to work. Currently the installation of gnuhealth on openSUSE Tumbleweed fails as can also be seen in the package installation test on
https://build.opensuse.org/package/show/home:okurz:branches:Application:ERP:Tryton:Factory/test-gnuhealth because of "nothing provides python2-pycha needed by python2-relatorio". openSUSE Leap 42.2 works, 42.3 will be confirmed after merge.

Related needles PR: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/204

Verification run: local
![screenshot_20170528_144620](https://cloud.githubusercontent.com/assets/1693432/26528856/733ded4e-43b4-11e7-9812-756c50058a0c.png)