### PR TITLE
yast2_dns_server: Fix regression introduced by c704c10e

### DIFF
--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -25,10 +25,10 @@ sub assert_running() {
     my $running = shift;
 
     if ($running) {
-        assert_script_run 'systemctl is-active named | grep -E "^active"';
+        assert_script_run '(systemctl is-active named || true) | grep -E "^active"';
     }
     else {
-        assert_script_run 'systemctl is-active named | grep -E "^(inactive|unknown)"';
+        assert_script_run '(systemctl is-active named || true) | grep -E "^(inactive|unknown)"';
     }
 }
 
@@ -38,10 +38,10 @@ sub assert_enabled() {
     my $enabled = shift;
 
     if ($enabled) {
-        assert_script_run 'systemctl is-enabled named | grep enabled';
+        assert_script_run 'systemctl is-enabled named';
     }
     else {
-        assert_script_run 'systemctl is-enabled named | grep disabled';
+        assert_script_run '! systemctl is-enabled named';
     }
 }
 

--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -113,8 +113,8 @@ sub run() {
     #
     # Fourth execution (tree-based interface)
     #
-    script_run 'yast2 dns-server', 0;
-    assert_screen 'yast2-service-running-disabled';
+    script_run 'yast2 dns-server',                  0;
+    assert_screen 'yast2-service-running-disabled', 90;
     # Stop the service
     send_key 'alt-s';
     assert_screen 'yast2-service-stopped-disabled';


### PR DESCRIPTION
Related needle PR: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/205

Verification run: http://lord.arch/tests/6481