### PR TITLE
Poo#19230 Stabilize patch before migration tests on PPC by typing slowly

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -21,7 +21,7 @@ use Exporter;
 use strict;
 
 use testapi;
-use utils qw(addon_decline_license assert_screen_with_soft_timeout);
+use utils qw(addon_decline_license assert_screen_with_soft_timeout type_string_slow);
 
 our @EXPORT = qw(fill_in_registration_data registration_bootloader_params yast_scc_registration skip_registration);
 
@@ -262,8 +262,15 @@ sub registration_bootloader_params {
 }
 
 sub yast_scc_registration {
-
-    type_string "yast2 scc; echo yast-scc-done-\$?- > /dev/$serialdev\n";
+    my ($type_slow) = @_;
+    my $yast_scc_cmd = "yast2 scc; echo yast-scc-done-\$?- > /dev/$serialdev\n";
+    #Due to ninja keys on PPC, may be required to type command slowlier, see poo#19230
+    if ($type_slow) {
+        type_string_slow $yast_scc_cmd;
+    }
+    else {
+        type_string $yast_scc_cmd;
+    }
     assert_screen_with_soft_timeout(
         'scc-registration',
         timeout      => 90,

--- a/tests/update/patch_before_migration.pm
+++ b/tests/update/patch_before_migration.pm
@@ -22,16 +22,16 @@ sub is_smt_or_module_tests {
 sub system_prepare() {
     select_console 'root-console';
     type_string "chown $username /dev/$serialdev\n";
-    type_string "echo 'export Y2DEBUG=1' >> /etc/bash.bashrc.local\n";
+    type_string "echo ' export Y2DEBUG = 1 ' >> /etc/bash.bashrc.local\n";
     script_run "source /etc/bash.bashrc.local";
 }
 
 sub patching_sle() {
-    set_var("VIDEOMODE",    'text');
-    set_var("SCC_REGISTER", 'installation');
+    set_var("VIDEOMODE",    ' text ');
+    set_var("SCC_REGISTER", ' installation ');
     # remember we perform registration on pre-created HDD images
-    if (sle_version_at_least('12-SP2', version_variable => 'HDDVERSION')) {
-        set_var('HDD_SP2ORLATER', 1);
+    if (sle_version_at_least(' 12 -SP2 ', version_variable => ' HDDVERSION ')) {
+        set_var(' HDD_SP2ORLATER ', 1);
     }
 
     # stop packagekit service
@@ -40,18 +40,18 @@ sub patching_sle() {
 
     assert_script_run("zypper lr && zypper mr --disable --all");
     save_screenshot;
-    yast_scc_registration();
-    assert_script_run('zypper lr -d');
+    yast_scc_registration(check_var("ARCH", "ppc64le"));    #See poo#19230, pass true to type slowly
+    assert_script_run(' zypper lr -d ');
 
-    if (get_var('MINIMAL_UPDATE')) {
-        minimal_patch_system(version_variable => 'HDDVERSION');
+    if (get_var(' MINIMAL_UPDATE ')) {
+        minimal_patch_system(version_variable => ' HDDVERSION ');
     }
 
-    if (get_var('FULL_UPDATE')) {
+    if (get_var(' FULL_UPDATE ')) {
         fully_patch_system();
     }
 
-    de_register(version_variable => 'HDDVERSION');
+    de_register(version_variable => ' HDDVERSION ');
     remove_ltss;
     assert_script_run("zypper mr --enable --all");
     set_var("VIDEOMODE", '');


### PR DESCRIPTION
In couple of runs redirection key was not properly typed, in other runs shift key was still pressed and wrong serial device was used. Issue occurs only on PowerPC and is not reproducible in every run. By typing unstable command slower we should gain more stability.

Progress ticket: https://progress.opensuse.org/issues/19230
Verification run: http://10.160.66.147/tests/216#step/patch_before_migration/16