### PR TITLE
Updating maintainer in wireshark test module

### DIFF
--- a/tests/x11/wireshark.pm
+++ b/tests/x11/wireshark.pm
@@ -26,7 +26,7 @@
 #   - change an option
 #   - select default profile
 #   - verify the option is not changed
-# Maintainer: Romanos Dodopoulos <romanos.dodopoulos@suse.cz>
+# Maintainer: Veronika Svecova <vsvecova@suse.cz>
 
 use base "opensusebasetest";
 use strict;


### PR DESCRIPTION
Updating the maintainer field in the wireshark test module due to Romanos no longer working for the company.