### PR TITLE
Fix warning in autoinst-log.txt

### DIFF
--- a/tests/installation/upgrade_select_opensuse.pm
+++ b/tests/installation/upgrade_select_opensuse.pm
@@ -17,9 +17,7 @@ use testapi;
 
 # Check that installer does not freeze when pressing next
 sub check_bsc997635 {
-    my $ret = wait_screen_change {
-        send_key $cmd{next};
-    }, 10;
+    my $ret = wait_screen_change(sub { send_key $cmd{next}; }, 10);
     if (!$ret) {
         record_soft_failure 'bsc#997635';
         sleep 30;

--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -23,7 +23,7 @@ sub assert_and_click_until_screen_change {
     my $i = 0;
 
     for (; $i < $repeat; $i++) {
-        wait_screen_change { assert_and_click $mustmatch; }, $wait_change;
+        wait_screen_change(sub { assert_and_click $mustmatch }, $wait_change);
         last unless check_screen($mustmatch, 0);
     }
 


### PR DESCRIPTION
Remove warning from **autoinst-log.txt**

* Warning message: Useless use of private variable in void context
* Test modules: reboot_gnome, upgrade_select_opensuse
* Verification run:
  * For openSUSE update [copland#518](http://copland.arch.suse.de/tests/518)
  * For SLE [copland#519](http://copland.arch.suse.de/tests/519)