### PR TITLE
Fix kdump_and_crash test (poo#19378)

### DIFF
--- a/tests/console/kdump_and_crash.pm
+++ b/tests/console/kdump_and_crash.pm
@@ -27,7 +27,6 @@ sub run() {
     # restart to activate kdump
     script_run 'reboot', 0;
     $self->wait_boot;
-    reset_consoles;
     select_console 'root-console';
 
     # often kdump could not be enabled: bsc#1022064
@@ -35,7 +34,6 @@ sub run() {
     do_kdump;
     # wait for system's reboot
     $self->wait_boot;
-    reset_consoles;
     select_console 'root-console';
 
     # all but PPC64LE arch's vmlinux images are gzipped


### PR DESCRIPTION
http://argus.suse.cz/tests/1038

Original test in all states of kdump service returns ok --> test fails in attempt to trigger kdump generation

Now test check if is service failed because known problem ( softfail with correct bsc) and workaround by restarting service  or unknown problem --> softfail with original bsc as original test.

plus removed unneeded reset_consoles from test