### PR TITLE
Prevent post_fail_hook stuck in user/root-console

### DIFF
--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -4,7 +4,7 @@ use base "opensusebasetest";
 use strict;
 use testapi;
 
-# Base class for all openSUSE console tests
+# Base class for all console tests
 
 sub post_run_hook {
     my ($self) = @_;
@@ -18,7 +18,7 @@ sub post_run_hook {
 
 sub post_fail_hook {
     my ($self) = shift;
-    select_console('root-console');
+    select_console('log-console');
     $self->SUPER::post_fail_hook;
 
     # Export logs after failure


### PR DESCRIPTION
Using the log-console in all consoles tests by default we can gather logs in
cases the user or root console is occupied and a process is stuck there.

http://lord.arch/tests/6488#step/sshd/12 shows the problem.

Validation run: http://lord.arch/tests/6490#step/sshd/5