### PR TITLE
Revert "Add assert_screen typed password on boot_encrypt"

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -98,7 +98,7 @@ sub unlock_if_encrypted {
     else {
         assert_screen("encrypted-disk-password-prompt", 200);
         type_password;    # enter PW at boot
-        assert_screen 'encrypted_disk-typed_password';
+        save_screenshot;
         send_key "ret";
     }
 }


### PR DESCRIPTION
This reverts commit 94b67fc95c97f0b546b69732d015eb65640b429d.
This change causes failures in grub_test, see https://progress.opensuse.org/issues/19364
They were intrioduced by Sergio for GUI installation to assert that password was typed properly, whereas for text mode password isn't shown.
