### PR TITLE
Revert "Add assert_screen typed password on boot_encrypt"

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -98,7 +98,7 @@ sub unlock_if_encrypted {
     else {
         assert_screen("encrypted-disk-password-prompt", 200);
         type_password;    # enter PW at boot
-        assert_screen 'encrypted_disk-typed_password';
+        save_screenshot;
         send_key "ret";
     }
 }


### PR DESCRIPTION
This reverts commit 94b67fc95c97f0b546b69732d015eb65640b429d.

I thought I could fix the issue asserting the screenshot, but I changed a function that is used by several modules and my changes are causing some false positives.
I will work on a proper solution that only affects the module 'boot_encrypt'. Until then, my changes should be reverted.