### PR TITLE
[poo#19202] Move docker test to extra tests in text mode

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -488,6 +488,9 @@ sub load_extra_tests() {
             loadtest "console/a2ps";    # a2ps is not a ring package and thus not available in staging
             loadtest "console/weechat";
             loadtest "console/nano";
+            if (check_var('ARCH', 'x86_64')) {
+                loadtest "console/docker";
+            }
         }
         loadtest "console/git";
         loadtest "console/java";

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -463,9 +463,6 @@ sub load_consoletests() {
             loadtest "console/php7";
             loadtest "console/php7_mysql";
             loadtest "console/php7_postgresql94";
-            if (check_var('ARCH', 'x86_64')) {
-                loadtest "console/docker";
-            }
         }
         if (check_var("DESKTOP", "xfce")) {
             loadtest "console/xfce_gnome_deps";


### PR DESCRIPTION
According to ticket https://progress.opensuse.org/issues/19202 docker is not relevant test for text mode as is optional. We rely on docker registry which may be not available, whereas we cannot have image locally, only if we build it from scratch. Another solution may be local docker registry, which requires more efforts and maintenance.

Verification run: http://gershwin.arch.suse.de/tests/3