### PR TITLE
Longer timeout for zypper ref command.

### DIFF
--- a/tests/console/zypper_ref.pm
+++ b/tests/console/zypper_ref.pm
@@ -20,7 +20,7 @@ sub run() {
 
     script_run("zypper ref; echo zypper-ref-\$? > /dev/$serialdev", 0);
     # don't trust graphic driver repo
-    assert_screen([qw(new-repo-need-key zypper_ref)]);
+    assert_screen([qw(new-repo-need-key zypper_ref)], timeout => 300);
     if (match_has_tag('new-repo-need-key')) {
         type_string "r\n";
     }


### PR DESCRIPTION
On systems registered to official SCC with more repositories refresh can
take longer time

trying fix https://openqa.suse.de/tests/971414#step/zypper_ref/3