### PR TITLE
Fix poo#19480: unset SCC_REGISTER for ZDUP test

### DIFF
--- a/tests/update/patch_before_migration.pm
+++ b/tests/update/patch_before_migration.pm
@@ -57,7 +57,8 @@ sub patching_sle() {
     set_var("VIDEOMODE", '');
     # keep the value of SCC_REGISTER for offline migration tests with smt pattern or modules
     # Both of them need registration during offline migration
-    if (!is_smt_or_module_tests) { set_var("SCC_REGISTER", ''); }
+    # No registration will be done during zdup test
+    if (!is_smt_or_module_tests or get_var('ZDUP')) { set_var("SCC_REGISTER", ''); }
 }
 
 sub run() {


### PR DESCRIPTION
zypper_lr will check SCC online repo if SCC_REGISTER is set.
There is no registration during ZDUP migration test, so the
SCC_REGISTER should be unset to avoide SCC repo check.