### PR TITLE
WIP: Add check for cleanup of old rootfs after rollback

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -348,11 +348,8 @@ sub load_reboot_tests() {
         if (get_var('ENCRYPT')) {
             loadtest "installation/boot_encrypt";
         }
-        if ((snapper_is_applicable()) && get_var("BOOT_TO_SNAPSHOT")) {
-            loadtest "installation/boot_into_snapshot";
-            if (get_var("UPGRADE")) {
-                loadtest "installation/snapper_rollback";
-            }
+        if ((snapper_is_applicable()) && get_var("BOOT_TO_SNAPSHOT") && get_var('UPGRADE')) {
+            loadtest "installation/snapper_rollback";
         }
         loadtest "installation/first_boot";
     }
@@ -830,6 +827,10 @@ elsif (ssh_key_import) {
     load_reboot_tests();
     # verify previous defined ssh keys
     loadtest "x11/ssh_key_verify";
+}
+elsif ((snapper_is_applicable()) && get_var("BOOT_TO_SNAPSHOT")) {
+    loadtest "installation/grub_test";
+    loadtest "installation/boot_into_snapshot";
 }
 else {
     if (get_var("LIVETEST") || get_var('LIVE_INSTALLATION')) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -619,10 +619,10 @@ sub load_reboot_tests() {
     if (installyaststep_is_applicable()) {
         # test makes no sense on s390 because grub2 can't be captured
         if (!(check_var("ARCH", "s390x") or (check_var('VIRSH_VMM_FAMILY', 'xen') and check_var('VIRSH_VMM_TYPE', 'linux')))) {
-            loadtest "installation/grub_test";
             if ((snapper_is_applicable()) && get_var("BOOT_TO_SNAPSHOT")) {
                 loadtest "installation/boot_into_snapshot";
             }
+            loadtest "installation/grub_test";
         }
         if (get_var('ENCRYPT')) {
             loadtest "installation/boot_encrypt";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -70,6 +70,16 @@ sub is_bridged_networking {
     return $ret;
 }
 
+sub grub_test_is_applicable {
+  # test makes no sense on s390 because grub2 can't be captured
+  return !(check_var("ARCH", "s390x") or (check_var('VIRSH_VMM_FAMILY', 'xen') and check_var('VIRSH_VMM_TYPE', 'linux'));
+}
+
+sub boot_to_snapshot_is_applicable {
+  # for snapshots we need the availability of snapper and also we need a grub menue where a test can be selected
+  return snapper_is_applicable() && get_var("BOOT_TO_SNAPSHOT") && grub_test_is_applicable);
+}
+
 sub cleanup_needles {
     remove_common_needles;
     if ((get_var('VERSION', '') ne '12') && (get_var('BASE_VERSION', '') ne '12')) {
@@ -617,10 +627,7 @@ sub load_reboot_tests() {
         loadtest "boot/qa_net_boot_from_hdd";
     }
     if (installyaststep_is_applicable()) {
-        # test makes no sense on s390 because grub2 can't be captured
-        if (!(check_var("ARCH", "s390x") or (check_var('VIRSH_VMM_FAMILY', 'xen') and check_var('VIRSH_VMM_TYPE', 'linux')))) {
-            loadtest "installation/grub_test";
-        }
+        loadtest 'installation/grub_test' if grub_test_is_applicable;
         if (get_var('ENCRYPT')) {
             loadtest "installation/boot_encrypt";
             # reconnect after installation/boot_encrypt
@@ -1245,7 +1252,8 @@ elsif (get_var("FILESYSTEM_TEST")) {
     }
     load_filesystem_tests();
 }
-elsif (snapper_is_applicable() && get_var("BOOT_TO_SNAPSHOT") && (!(check_var("ARCH", "s390x") or (check_var('VIRSH_VMM_FAMILY', 'xen') and check_var('VIRSH_VMM_TYPE', 'linux'))))) {
+#elsif (boot_to_snapshot_is_applicable && !all_upgrade_variables_and_such) {
+elsif (boot_to_snapshot_is_applicable) {
     loadtest "installation/grub_test";
     loadtest "installation/boot_into_snapshot";
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -619,9 +619,6 @@ sub load_reboot_tests() {
     if (installyaststep_is_applicable()) {
         # test makes no sense on s390 because grub2 can't be captured
         if (!(check_var("ARCH", "s390x") or (check_var('VIRSH_VMM_FAMILY', 'xen') and check_var('VIRSH_VMM_TYPE', 'linux')))) {
-            if ((snapper_is_applicable()) && get_var("BOOT_TO_SNAPSHOT")) {
-                loadtest "installation/boot_into_snapshot";
-            }
             loadtest "installation/grub_test";
         }
         if (get_var('ENCRYPT')) {
@@ -1247,6 +1244,10 @@ elsif (get_var("FILESYSTEM_TEST")) {
         loadtest "qa_automation/patch_and_reboot";
     }
     load_filesystem_tests();
+}
+elsif (snapper_is_applicable() && get_var("BOOT_TO_SNAPSHOT") && (!(check_var("ARCH", "s390x") or (check_var('VIRSH_VMM_FAMILY', 'xen') and check_var('VIRSH_VMM_TYPE', 'linux'))))) {
+    loadtest "installation/grub_test";
+    loadtest "installation/boot_into_snapshot";
 }
 elsif (get_var("Y2UITEST")) {
     load_yast2_ui_tests;

--- a/tests/installation/boot_into_snapshot.pm
+++ b/tests/installation/boot_into_snapshot.pm
@@ -38,11 +38,9 @@ sub run() {
             die "OS_VERSION after Rollback matches OS_VERSION before Rollback";
         }
     }
-    if (get_var('CHECK_SNAPPER_ROLLBACK_CLEANUP')) {
-        assert_script_run('snapper rollback');
-        assert_script_run('snapper --iso list');
-        assert_screen('snapper-autocleanup');
-    }
+    assert_script_run('snapper rollback');
+    assert_script_run('snapper --iso list');
+    sleep 3600;
     script_run("systemctl reboot", 0);
     reset_consoles;
 }

--- a/tests/installation/boot_into_snapshot.pm
+++ b/tests/installation/boot_into_snapshot.pm
@@ -26,7 +26,7 @@ sub run() {
     # 1)
     assert_script_run('touch NOWRITE;test ! -f NOWRITE');
     # 1b) just debugging infos
-    assert_script_run("snapper list");
+    assert_script_run("snapper --iso list");
     assert_script_run("cat /etc/os-release");
     if (get_var("UPGRADE")) {
         # if we made a migration, the version should be for example opensuse before migr. 42.1 > 42.2
@@ -37,6 +37,11 @@ sub run() {
         if ($OS_VERSION eq $OLD_OS_VERSION) {
             die "OS_VERSION after Rollback matches OS_VERSION before Rollback";
         }
+    }
+    if (get_var('CHECK_SNAPPER_ROLLBACK_CLEANUP')) {
+        assert_script_run('snapper rollback');
+        assert_script_run('snapper --iso list');
+        assert_screen('snapper-autocleanup');
     }
     script_run("systemctl reboot", 0);
     reset_consoles;


### PR DESCRIPTION
1. Cover fate#321773: Cleanup of old rootfs after rollback
with test
2. Change boot_to_snapshot tests from run after installation
to boot from snapshot