### PR TITLE
svirt: Don't remove what's being soon downloaded

### DIFF
--- a/tests/shutdown/svirt_upload_assets.pm
+++ b/tests/shutdown/svirt_upload_assets.pm
@@ -38,10 +38,6 @@ sub extract_assets {
     # on your own - hence the following assert_screen().
     upload_asset("$image_storage/$name", 1, 1);
     assert_screen('svirt-asset-upload-hdd-image-uploaded', 1000);
-
-    # clean up on s390pb
-    type_string("rm -f $image_storage/$name && echo OK\n");
-    assert_screen('svirt-image-cleaned-up');
 }
 
 sub run() {


### PR DESCRIPTION
Currently we have only one Xen VM host. On this host we create Xen HVM &
PV QCOW2 images for later use, but we don't have to remove it, as we
eventually download them soon again for extra_test* test suites.

@Soulofdestiny Does it affect any of zKVM tests? Can't find evidence, that it's used anywhere by Xen.