### PR TITLE
Make sure PS1 prompt is visible

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -473,6 +473,14 @@ sub console_selected {
     # x11 needs special handling because we can not easily know if screen is
     # locked, display manager is waiting for login, etc.
     return ensure_unlocked_desktop if $args{tags} =~ /x11/;
+    # press return twice in console to make sure that PS1 prompt is visible
+    if ($args{tags} =~ /console|shell/) {
+        if (!check_screen($args{tags})) {
+            send_key 'ret';
+            send_key 'ret';
+            record_soft_failure 'bsc#1011815';
+        }
+    }
     assert_screen($args{tags}, no_wait => 1);
 }
 


### PR DESCRIPTION
fail: https://openqa.opensuse.org/tests/408239#step/multi_users_dm/2
Betwen send key is `type_string 'test';` to better see it
tests:
http://10.100.12.155/tests/6450#step/install_and_reboot/2
http://10.100.12.155/tests/6453#step/patch_before_migration/8
http://10.100.12.155/tests/6454#step/hostname/4