### PR TITLE
Poo#19398 Improve comment why have console=tty as boot parameter

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -127,6 +127,15 @@ sub bootmenu_type_extra_boot_params {
     }
 }
 
+sub bootmenu_type_console_params {
+    # To get crash dumps as text
+    type_string_very_slow "console=$serialdev ";
+
+    # See bsc#1011815, last console set as boot parameter is linked to /dev/console
+    # and doesn't work if set to serial device.
+    type_string_very_slow "console=tty ";
+}
+
 sub bootmenu_default_params {
     if (check_var('ARCH', 'ppc64le')) {
         # edit menu, wait until we get to grub edit
@@ -159,14 +168,12 @@ sub bootmenu_default_params {
 
         if (!get_var("NICEVIDEO")) {
             if (is_jeos) {
-                type_string_very_slow "console=$serialdev ";    # to get crash dumps as text
-                type_string_very_slow "console=tty ";           # to get crash dumps as text
+                bootmenu_type_console_params;
             }
             else {
                 type_string_very_slow "plymouth.ignore-serial-consoles ";    # make plymouth go graphical
-                type_string_very_slow "linuxrc.log=$serialdev ";             # to get linuxrc logs in serial
-                type_string_very_slow "console=$serialdev ";                 # to get crash dumps as text
-                type_string_very_slow "console=tty ";                        # to get crash dumps as text
+                type_string_very_slow "linuxrc.log=$serialdev ";
+                bootmenu_type_console_params;
 
                 assert_screen "inst-consolesettingstyped", 30;
 


### PR DESCRIPTION
See poo#19398 and bsc#1011815. The problem is that sometimes kernel messages are printed to active console and prevent needles from matching. We already redirect kernel messages to serial device and do not need them on tty, whereas installation cannot start without tty defined as system console, hence we only can workaround this by either:
1) reducing loglevel
2) using klogconsole
3) changing grub config on installed system

As it's only nice to have, we leave it as it is, and change the tests only if it becomes critical issue.

Verification run: http://gershwin.arch.suse.de/tests/61#step/bootloader/5
Progress ticket: https://progress.opensuse.org/issues/19398