### PR TITLE
btrfs_test: Fix parted asking for user interaction on ppc64le

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -17,8 +17,8 @@ sub set_unpartitioned_disk_in_bash {
     elsif (check_var('VIRSH_VMM_FAMILY', 'hyperv') or check_var('VIRSH_VMM_FAMILY', 'vmware')) {
         $vd = 'sd';
     }
-    assert_script_run 'parted --machine -l';
-    assert_script_run 'disk=${disk:-$(parted --machine -l |& sed -n \'s@^\(/dev/' . $vd . '[ab]\):.*unknown.*$@\1@p\')}';
+    assert_script_run 'parted --script --machine -l';
+    assert_script_run 'disk=${disk:-$(parted --script --machine -l |& sed -n \'s@^\(/dev/' . $vd . '[ab]\):.*unknown.*$@\1@p\')}';
     assert_script_run 'echo $disk';
 }
 


### PR DESCRIPTION
Using the parameter '--script' in general makes sense so that no user
interaction is asked for.

Verification run: https://openqa.suse.de/tests/978798

Related progress issue: https://progress.opensuse.org/issues/19550