### PR TITLE
Collect filesystem disk capacity information during installation

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -115,6 +115,15 @@ sub post_fail_hook() {
     my $self = shift;
     get_to_console;
     save_upload_y2logs;
+    if (get_var('FILESYSTEM', 'btrfs') =~ /btrfs/) {
+        assert_script_run 'btrfs filesystem df /mnt | tee /tmp/btrfs-filesystem-df-mnt.txt';
+        assert_script_run 'btrfs filesystem usage /mnt | tee /tmp/btrfs-filesystem-usage-mnt.txt';
+        upload_logs '/tmp/btrfs-filesystem-df-mnt.txt';
+        upload_logs '/tmp/btrfs-filesystem-usage-mnt.txt';
+    }
+    assert_script_run 'df -h';
+    assert_script_run 'df > /tmp/df.txt';
+    upload_logs '/tmp/df.txt';
 }
 
 1;


### PR DESCRIPTION
Further debug information collected for
https://bugzilla.suse.com/show_bug.cgi?id=1039504 especially in case of btrfs
filesystems.

Verification run: http://lord.arch/tests/6562#step/install_and_reboot/55