### PR TITLE
Test s390x installation in fips mode

### DIFF
--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -56,6 +56,10 @@ sub run() {
             $cmdline .= " autoyast=" . data_url(get_var('AUTOYAST')) . " ";
         }
 
+        if (get_var('FIPS')) {
+            $cmdline .= "fips=1 ";
+        }
+
         $cmdline .= specific_bootmenu_params;
 
         $svirt->change_domain_element(os => initrd  => "$img_path/$name.initrd");


### PR DESCRIPTION
Append installer boot option fips=1 if FIPS variable is set.
The fips pattern will be selected during installation and
grub will be configured to boot with fips=1.