### PR TITLE
Do not run php7 console test in Staging

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -460,9 +460,11 @@ sub load_consoletests() {
             loadtest "console/php5";
             loadtest "console/php5_mysql";
             loadtest "console/php5_postgresql94";
-            loadtest "console/php7";
-            loadtest "console/php7_mysql";
-            loadtest "console/php7_postgresql94";
+            if (!is_staging()) {
+                loadtest "console/php7";
+                loadtest "console/php7_mysql";
+                loadtest "console/php7_postgresql94";
+            }
         }
         if (check_var("DESKTOP", "xfce")) {
             loadtest "console/xfce_gnome_deps";


### PR DESCRIPTION
During enabling textmode test on Staging test group, realized some console test is not valid to test on Staging due to they aren't part of staging test dvd, after discussed, I've changed  staging2 dvd a bit and openqa should skip php7 test if staging.

ref. https://openqa.opensuse.org/tests/415264