### PR TITLE
Avoid known issue bsc#985969 in FIPS mode

### DIFF
--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -140,7 +140,8 @@ sub run() {
                 die "IPL device was not set correctly";
             }
         }
-        $self->get_ip_address();
+        # avoid known issue in FIPS mode: bsc#985969
+        $self->get_ip_address() if (!get_var('FIPS'));
         $self->save_upload_y2logs();
         select_console 'installation';
     }


### PR DESCRIPTION
With issue bsc#985969, wicked couldn't reconfigure network
interfaces properly during installaion if fips is enabled.
The issue should only influence openQA tests since in real
world there is no need to reconfigure network at the end
of installation.