### PR TITLE
Fix s390x test crash in reconnect_s390 in VNC stall detection

### DIFF
--- a/tests/installation/reconnect_s390.pm
+++ b/tests/installation/reconnect_s390.pm
@@ -27,6 +27,7 @@ sub run() {
         # kill serial ssh connection (if it exists)
         eval { console('iucvconn')->kill_ssh unless get_var('BOOT_EXISTING_S390', ''); };
         diag('ignoring already shut down console') if ($@);
+        console('installation')->disable_vnc_stalls;
 
         # 'wait_serial' implementation for x3270
         console('x3270')->expect_3270(


### PR DESCRIPTION
The VNC console must be disabled when triggering reboot.

Verification run: http://lord.arch/tests/6622

Related progress issues:
* https://progress.opensuse.org/issues/16488
* https://progress.opensuse.org/issues/19262