### PR TITLE
Use entrypoint.sh when running `docker exec`

### DIFF
--- a/tests/casp/stack_admin.pm
+++ b/tests/casp/stack_admin.pm
@@ -37,11 +37,16 @@ sub post_run_hook {
     script_run "journalctl > journal.log";
     upload_logs "journal.log";
 
-    script_run
-      "docker exec -it \$(docker ps | grep velum-dashboard | awk '{print \$1}') bundle exec rails runner 'puts SaltEvent.all.to_json' > SaltEvents.log";
+    script_run 'velumid=$(docker ps | grep velum-dashboard | awk \'{print $1}\')';
+    my $railscmd = 'bundle exec rails';
+    if (check_var('FLAVOR', 'Staging-B-DVD')) {
+        $railscmd = "entrypoint.sh $railscmd";
+    }
+
+    script_run "docker exec -it \$velumid $railscmd runner 'puts SaltEvent.all.to_json' > SaltEvents.log";
     upload_logs "SaltEvents.log";
 
-    script_run "docker exec -it \$(docker ps | grep velum-dashboard | awk '{print \$1}') bundle exec rails runner 'puts SaltEvent.all.to_json' > Pillar.log";
+    script_run "docker exec -it \$velumid $railscmd runner 'puts Pillar.all.to_json' > Pillar.log";
     upload_logs "Pillar.log";
 }
 

--- a/tests/casp/stack_worker.pm
+++ b/tests/casp/stack_worker.pm
@@ -29,8 +29,13 @@ sub post_run_hook {
     script_run "journalctl > journal.log";
     upload_logs "journal.log";
 
-    script_run
-      "docker exec -it \$(docker ps | grep velum-dashboard | awk '{print \$1}') bundle exec rails runner 'puts SaltEvent.all.to_json' > SaltEvents.log";
+    my $railscmd = 'bundle exec rails';
+    if (check_var('FLAVOR', 'Staging-B-DVD')) {
+        $railscmd = "entrypoint.sh $railscmd";
+    }
+
+    script_run 'velumid=$(docker ps | grep velum-dashboard | awk \'{print $1}\')';
+    script_run "docker exec -it \$velumid $railscmd runner 'puts SaltEvent.all.to_json' > SaltEvents.log";
     upload_logs "SaltEvents.log";
 }
 


### PR DESCRIPTION
We now need this entrypoint.sh because it's what will load the
credentials in order for rails to be able to connect to the
database.

Required after https://github.com/kubic-project/caasp-container-manifests/pull/46 was merged.