### PR TITLE
Remove workaround_type_encrypted_passphrase from reboot_gnome

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -486,7 +486,6 @@ sub reboot_gnome {
 
         send_key "ret";
     }
-    workaround_type_encrypted_passphrase;
 }
 
 =head2 power_action

--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -75,7 +75,6 @@ sub run() {
             }
         }
     }
-    workaround_type_encrypted_passphrase;
     # the shutdown sometimes hangs longer, so give it time
     $self->wait_boot(bootloader_time => 300);
 }


### PR DESCRIPTION
Fix poo#19618, the workaround_type_encrypted_passphrase in
reboot_gnome module is dublicate now since it has been
handled in wait_boot function.