### PR TITLE
Put back dns_srv to staging as it was originally

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -726,13 +726,10 @@ sub load_consoletests() {
             }
             loadtest "console/http_srv";
             loadtest "console/mysql_srv";
+            loadtest "console/dns_srv";
             loadtest "console/postgresql94server";
             if (sle_version_at_least('12-SP1')) {    # shibboleth-sp not available on SLES 12 GA
                 loadtest "console/shibboleth";
-            }
-            if (!is_staging()) {
-                # Very temporary removal of this test from staging - rbrown 6 Apr 2016
-                loadtest "console/dns_srv";
             }
             if (get_var('ADDONS', '') =~ /wsm/ || get_var('SCC_ADDONS', '') =~ /wsm/) {
                 loadtest "console/pcre";


### PR DESCRIPTION
dns_srv is very stable within textmode console tests so there should be no
reason why we do not test it within staging tests as we did up to 1 year ago
and as we do for openSUSE.

See https://openqa.suse.de/tests/986929#step/dns_srv/14 for a valid run.