### PR TITLE
Fix poo#19682: failed to launch fips tests on s390x

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -944,6 +944,7 @@ sub load_online_migration_tests() {
 }
 
 sub load_fips_tests_core() {
+    loadtest "console/consoletest_setup";
     loadtest "fips/openssl/openssl_fips_alglist";
     loadtest "fips/openssl/openssl_fips_hash";
     loadtest "fips/openssl/openssl_fips_cipher";
@@ -959,6 +960,7 @@ sub load_fips_tests_core() {
 }
 
 sub load_fips_tests_web() {
+    loadtest "console/consoletest_setup";
     loadtest "console/curl_https";
     loadtest "console/wget_https";
     loadtest "console/w3m_https";
@@ -970,6 +972,7 @@ sub load_fips_tests_web() {
 }
 
 sub load_fips_tests_misc() {
+    loadtest "console/consoletest_setup";
     loadtest "console/aide_check";
     loadtest "console/journald_fss";
     loadtest "fips/curl_fips_rc4_seed";
@@ -979,6 +982,7 @@ sub load_fips_tests_misc() {
 }
 
 sub load_fips_tests_crypt() {
+    loadtest "console/consoletest_setup";
     loadtest "console/yast2_dm_crypt";
     loadtest "console/cryptsetup";
     loadtest "console/ecryptfs_fips";
@@ -1089,31 +1093,25 @@ elsif (get_var("SLEPOS")) {
     load_slepos_tests();
 }
 elsif (get_var("FIPS_TS")) {
+    prepare_target();
     if (check_var("FIPS_TS", "setup")) {
-        prepare_target();
         # Setup system into fips mode
         loadtest "fips/fips_setup";
     }
     elsif (check_var("FIPS_TS", "fipsenv")) {
-        prepare_target();
         loadtest "fips/openssl/openssl_fips_env";
     }
-    else {
-        loadtest "boot/boot_to_desktop";
-        # Turn off packagekit, setup $serialdev permission and etc
-        loadtest "console/consoletest_setup";
-        if (check_var("FIPS_TS", "core")) {
-            load_fips_tests_core;
-        }
-        elsif (check_var("FIPS_TS", "web")) {
-            load_fips_tests_web;
-        }
-        elsif (check_var("FIPS_TS", "misc")) {
-            load_fips_tests_misc;
-        }
-        elsif (check_var("FIPS_TS", "crypt")) {
-            load_fips_tests_crypt;
-        }
+    elsif (check_var("FIPS_TS", "core")) {
+        load_fips_tests_core;
+    }
+    elsif (check_var("FIPS_TS", "web")) {
+        load_fips_tests_web;
+    }
+    elsif (check_var("FIPS_TS", "misc")) {
+        load_fips_tests_misc;
+    }
+    elsif (check_var("FIPS_TS", "crypt")) {
+        load_fips_tests_crypt;
     }
 }
 elsif (get_var("HACLUSTER_SUPPORT_SERVER")) {


### PR DESCRIPTION
The fips tests can't be launched on s390x machine because the
bootloader module is not loaded before boot_to_desktop.
Also move the fips tests subroutines to lib/main_common.pm
for cleanup.