### PR TITLE
[poo#15306] Release lifecycle data for Toolchain Module

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -9,7 +9,7 @@
 # without any warranty.
 use strict;
 use warnings;
-use testapi qw(check_var get_var get_required_var set_var);
+use testapi qw(check_var get_var get_required_var set_var check_var_array);
 use lockapi;
 use needle;
 use File::Find;
@@ -778,6 +778,9 @@ sub load_consoletests() {
         }
         if (!is_staging() && sle_version_at_least('12-SP2')) {
             loadtest "console/zypper_lifecycle";
+            if (check_var_array('SCC_ADDONS', 'tcm')) {
+                loadtest "console/zypper_lifecycle_toolchain";
+            }
         }
         loadtest 'console/install_all_from_repository' if get_var('INSTALL_ALL_REPO');
         loadtest "console/consoletest_finish";

--- a/tests/console/zypper_lifecycle_toolchain.pm
+++ b/tests/console/zypper_lifecycle_toolchain.pm
@@ -1,0 +1,56 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: test for 'zypper lifecycle' for toolchain module
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
+# Tags: fate#32205
+
+use base "consoletest";
+use strict;
+use testapi;
+
+sub run() {
+    my %expiration = (
+        gcc5      => 'Now',
+        libada5   => 'Now',
+        gcc6      => '2024-10-30',
+        libada6   => '2024-10-30',
+        toolchain => '2024-10-30'
+    );
+
+    select_console 'root-console';
+    # Get gcc packages, ignore conflicting gcc6-ada and libada6 packages
+    my $gcc_packages
+      = script_output "zypper se -ur SLE-Module-Toolchain12-Updates -t package | awk '{print \$2}' | sed '1,/|/d' | grep -vE '(gcc6-ada|libada6)'", 300;
+    # Create list by removing blank symbols and new lines
+    $gcc_packages =~ s/(\R|\s)+/ /g;
+    # Install gcc packages
+    zypper_call("in $gcc_packages");
+    # Get lifecycle information for installed toolchain packages
+    my $output = script_output "zypper lifecycle $gcc_packages", 300;
+    diag($output);
+    # Verify that for gcc5 "now" is shown as expiration date, for gcc6 C<$expected_date>
+    for my $package (split(/ /, $gcc_packages)) {
+        while (my ($package_regexp, $expected_date) = each %expiration) {
+            if ($package =~ m/.*$package_regexp.*/ && $output !~ m/.*\Q$package\E\s*$expected_date.*/) {
+                die("For toolchain module $package expected $expected_date as expiration date, lifecycle output:\n $output");
+            }
+        }
+    }
+
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
See fate#322050 and poo#15306. Detailed test case can be found in fate
ticket. We already test zypper lifecycle command, but it's required to
extend existing tests and perform tests which are specific for the
module. Here we implement test for toolchain module packages. Test is
executed in the test suite where toolchain module is already installed.

Verification run: http://gershwin.arch.suse.de/tests/204
Progress ticket: https://progress.opensuse.org/issues/15306
Fate ticket: https://fate.suse.com/322050