### PR TITLE
GRE tunnel support by MTU change in support server

### DIFF
--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -85,6 +85,8 @@ sub setup_networks {
         $setup_script .= "IPADDR=$server_ip\n";
         $setup_script .= "NETMASK=$net_conf->{$network}->{subnet_mask}\n";
         $setup_script .= "STARTMODE='auto'\n";
+        # TCP cannot pass GRE tunnel with default MTU value 1500 in combination of DF flag set in L3 for ovs bridge
+        $setup_script .= "MTU='1458'\n";
         $setup_script .= "EOT\n";
     }
     $setup_script .= "rcnetwork restart\n";
@@ -160,6 +162,8 @@ sub setup_dhcp_server {
         $setup_script .= "  range  " . ip_in_subnet($net_conf->{$network}, 15) . "  " . ip_in_subnet($net_conf->{$network}, 100) . ";\n";
         $setup_script .= "  default-lease-time 14400;\n";
         $setup_script .= "  max-lease-time 172800;\n";
+        # dhcp clients have to use MTU 1458 to be able pass GRE Tunnel
+        $setup_script .= "  option interface-mtu 1458;\n";
         $setup_script .= "  option domain-name \"openqa.test\";\n";
         if ($dns) {
             $setup_script .= "  option domain-name-servers  $server_ip,  $server_ip;\n";


### PR DESCRIPTION
This commit fixes an issue with TCP communication over GRE tunnel used in ovs bridge and multimachine tests which uses support_server.

There are two changes:
1) set MTU='1458' by ifcfg-eth0 for support server
2) set MTU 1458 by dhcp mtu advertisement in dhcpd.conf for clients

Problem was that by default VMs inside bridge had default MTU 1500 which cannot pass over GRE tunnel because GRE itself has some consumption in addition.

I determined the proposed MTU value by command # **ping -M do -s 1430 <host>** and it is maximum allowed value (1458 = 1430+ICMP consumption). BTW the same MTU value is used even in VMs inside OpenStack Cloud - it also uses ovs+gre.

The lowered value of MTU=1458 should be harmless even for tests out of GRE tunnel (but using support_server)

More reading about the problem: https://specs.openstack.org/openstack/neutron-specs/specs/kilo/mtu-selection-and-advertisement.html

tested:
* dhcp62.suse.cz/tests/640 (controller at dhcp62) 
* dhcp209.suse.cz/tests/642 (admin on dhcp209)
dhcp62 and dhcp209 connected by ovs+GRE

poo#17776