### PR TITLE
Virtualization: testsuite changes to adjust to the new ipmi backend

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+package ipmi_backend_utils;
+# Summary: This file provides fundamental utilities related with the ipmi backend from test view,
+#          like switching consoles between ssh and ipmi supported
+# Maintainer: alice <xlai@suse.com>
+
+use base Exporter;
+use Exporter;
+use strict;
+use warnings;
+use testapi;
+
+our @EXPORT = qw(use_ssh_serial_console);
+
+#With the new ipmi backend, we only use the root-ssh console when the SUT boot up,
+#and no longer setup the real serial console for either kvm or xen.
+#When needs reboot, we will switch back to sut console which relies on ipmi.
+#We will mostly rely on ikvm to continue the test flow.
+#TODO: we need the serial output to debug issues in reboot, coolo will help add it.
+
+#use it after SUT boot finish, as it requires ssh connection to SUT to interact with SUT, including window and serial console
+sub use_ssh_serial_console() {
+    console('sol')->disable;
+    select_console('root-ssh');
+    $serialdev = 'sshserial';
+    set_var('SERIALDEV', 'sshserial');
+    bmwqemu::save_vars();
+}
+
+1;
+

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1163,10 +1163,6 @@ elsif (get_var("VIRT_AUTOTEST")) {
             load_inst_tests();
             loadtest "virt_autotest/login_console";
         }
-        if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
-            loadtest "virt_autotest/setup_console_on_host1";
-            loadtest "virt_autotest/reboot_and_wait_up_normal1";
-        }
         loadtest "virt_autotest/install_package";
         loadtest "virt_autotest/update_package";
         loadtest "virt_autotest/reboot_and_wait_up_normal2";
@@ -1179,7 +1175,6 @@ elsif (get_var("VIRT_AUTOTEST")) {
         loadtest "virt_autotest/host_upgrade_step2_run";
         loadtest "virt_autotest/reboot_and_wait_up_upgrade";
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
-            loadtest "virt_autotest/setup_console_on_host2";
             loadtest "virt_autotest/reboot_and_wait_up_normal3";
         }
         loadtest "virt_autotest/host_upgrade_step3_run";

--- a/tests/autoyast/login.pm
+++ b/tests/autoyast/login.pm
@@ -19,16 +19,23 @@
 use strict;
 use base 'y2logsstep';
 use testapi;
+use ipmi_backend_utils;
 
 sub run {
     my $self = shift;
     assert_screen("autoyast-system-login-console", 20);
     $self->result('fail');    # default result
-    type_string "root\n";
-    sleep 10;
-    type_password;
-    send_key "ret";
-    sleep 10;
+    if (check_var('BACKEND', 'ipmi')) {
+        #use console based on ssh to avoid unstable ipmi
+        use_ssh_serial_console;
+    }
+    else {
+        type_string "root\n";
+        sleep 10;
+        type_password;
+        send_key "ret";
+        sleep 10;
+    }
     assert_script_run 'echo "checking serial port"';
     wait_idle(10);
     type_string "cat /proc/cmdline\n";

--- a/tests/installation/installer_desktopselection.pm
+++ b/tests/installation/installer_desktopselection.pm
@@ -19,6 +19,12 @@ sub run() {
     assert_screen 'desktop-selection';
     my $d = get_var('DESKTOP');
 
+    # this error pop-up is present only on TW now
+    if (check_var('VERSION', 'Tumbleweed')) {
+        send_key $cmd{next};
+        assert_screen 'desktop-not-selected';
+        send_key $cmd{ok};
+    }
     if (get_var('NEW_DESKTOP_SELECTION')) {
         # select computer role
         if ($d ne 'kde' && $d ne 'gnome' && $d ne 'textmode') {
@@ -36,6 +42,12 @@ sub run() {
     send_key 'spc';                                                            # Select the desktop
 
     assert_screen "$d-selected";
+    if (check_var('VERSION', 'Tumbleweed')) {
+        send_key 'alt-o';                                                      # configure online repos
+        assert_screen 'repo-list';
+        send_key 'alt-c';                                                      # cancel
+        assert_screen 'desktop-selection';
+    }
     send_key $cmd{next};
 
     if (get_var('NEW_DESKTOP_SELECTION') && $d eq 'custom') {

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -16,7 +16,7 @@ use warnings;
 use File::Basename;
 use base "opensusebasetest";
 use testapi;
-use virt_utils;
+use ipmi_backend_utils;
 
 sub login_to_console() {
     my ($self, $timeout) = @_;
@@ -39,16 +39,13 @@ sub login_to_console() {
 
     assert_screen(['linux-login', 'virttest-displaymanager'], $timeout);
 
-    console('sol')->disable;
-    select_console('root-ssh');
-    $serialdev = 'sshserial';
-    set_var('SERIALDEV', 'sshserial');
+    #use console based on ssh to avoid unstable ipmi
+    use_ssh_serial_console;
 }
 
 sub run() {
     my $self = shift;
     $self->login_to_console;
-    set_serialdev;
 }
 
 1;

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -42,9 +42,6 @@ sub update_package() {
 sub run() {
     my $self = shift;
     $self->update_package();
-    if (!get_var("PROXY_MODE")) {
-        resetup_console;
-    }
     repl_repo_in_sourcefile();
 }
 


### PR DESCRIPTION
To avoid the unstable ipmi, we use the new ipmi backend. With it, in test, during reboot or installation we can use sut console which relies on ipmi,  and after system boot up, we can use the root-ssh console which relies on ssh.