### PR TITLE
Fix booting for online migration on aarch64

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -34,6 +34,12 @@ sub run() {
         send_key "ret";
     }
 
+    # Skip to load bootloader in test of online migration on aarch64
+    # Handle aarch64 image boot by wait_boot called in setup_online_migration
+    if (get_var('ONLINE_MIGRATION') && check_var('ARCH', 'aarch64')) {
+        return;
+    }
+
     # aarch64 firmware 'tianocore' can take longer to load
     my $bootloader_timeout = check_var('ARCH', 'aarch64') ? 25 : 15;
     assert_screen([qw(bootloader-shim-import-prompt bootloader-grub2)], $bootloader_timeout);


### PR DESCRIPTION
Failed test: https://openqa.suse.de/tests/994318
See: https://progress.opensuse.org/issues/17204#note-16