### PR TITLE
[poo#19398] Add workaround for kernel messages on current tty

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -69,6 +69,9 @@ sub run() {
 
     # init
     check_console_font;
+    # Workaround to avoid kernel messages on cuurent tty console
+    # Redirect all to tty10, see poo#19398 and bsc#1011815
+    type_string "command -v klogconsole && klogconsole -r10\n";
 
     type_string "chown $username /dev/$serialdev\n";
     script_run 'echo "set -o pipefail" >> /etc/bash.bashrc.local';


### PR DESCRIPTION
In many console test we experience issues with needle matching if some
kernel messages are printed. Those issues are always sporadic as we
don't trigger any specific action which may lead to such behavior. This
workaround redirects all kernel messages to tty10 and will prevent many
issues already. If we wait for serial output it still may get disrupted
output. It also doesn't help during installation.

See poo#19398 and bsc#1011815
To see the difference, I've set loglevel for all sources to 8:
sysctl -w kernel.printk="8 8 8 8"

And called btrfs balance command which logs some kernel messages.
Here one can see unexpected "[" symbols: http://gershwin.arch.suse.de/tests/169#step/textinfo/2
And here is the run with same setup, but with klogmessage command: http://gershwin.arch.suse.de/tests/168#step/textinfo/2

This workaround is reset on reboot and should not affect any other tests. If we experience more issues we may introduce better solution when we remove console=tty from boot options in the end of installation.
