### PR TITLE
[poo#19684] Add wait for snaps list in user_defined_snapshot

### DIFF
--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -61,6 +61,10 @@ sub run() {
 
     send_key_until_needlematch("boot-menu-snapshot", 'down', 10, 5);
     send_key 'ret';
+
+    # On slow VMs we press down key before snapshots list is on screen
+    wait_screen_change { assert_screen 'boot-menu-snapshots-list' };
+
     send_key_until_needlematch("snap-bootloader-comment", 'down', 10, 5);
     save_screenshot;
     wait_screen_change { send_key 'ret' };


### PR DESCRIPTION
In user_defined_snapshots tests we press down key until match needle
with required snapshot, whereas on slow system we start pressing down
key before the list is even shown. It results in unexpected initial
position of cursor in the list and we go only one direction.
In this commit we verify that screen was changed and that snapshots list
is currently shown. Needles for aarch/x86 and PPC are added.

Progress ticket: https://progress.opensuse.org/issues/19684
Verification run x86: http://gershwin.arch.suse.de/tests/175
Verification run ppc: http://10.160.66.147/tests/258#
Needles merge request: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/392

NOTE: For powerPC we have another issue at the moment which is a bug: https://bugzilla.suse.com/show_bug.cgi?id=1033758 
However, changes are introduced for the step where we select snapshot.