### PR TITLE
CaaSP cluster deployment with KVM images

### DIFF
--- a/products/casp/main.pm
+++ b/products/casp/main.pm
@@ -138,7 +138,7 @@ if (get_var('STACK_ROLE')) {
     }
     else {
         load_boot_tests;
-        load_inst_tests;
+        load_inst_tests if is_casp('DVD');
         loadtest 'casp/first_boot';
     }
     load_stack_tests;

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -119,6 +119,7 @@ sub run() {
     type_string " \\\n";    # changed the line before typing video params
     bootmenu_default_params;
     specific_bootmenu_params;
+    specific_caasp_params;
 
     # JeOS and CaaSP are never deployed with Linuxrc involved,
     # so 'regurl' does not apply there.


### PR DESCRIPTION
Local run: http://dhcp91.suse.cz/tests/overview?distri=casp&version=1.0&build=21.17&groupid=25