### PR TITLE
Add send_key_until_needle_match

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -38,8 +38,7 @@ sub run() {
         #Numburg
         #send_key_until_needlematch "qa-net-selection-" . get_var('DISTRI') . "-" . get_var("VERSION"), 'down', 30, 3;
         #Don't use send_key_until_needlematch to pick first menu tier as dist network sources might not be ready when openQA is running tests
-        send_key 'esc';
-        assert_screen 'qa-net-boot';
+        send_key_until_needlematch 'qa-net-boot', 'esc';
 
         my $image_name = "";
         if (check_var("INSTALL_TO_OTHERS", 1)) {


### PR DESCRIPTION
- to avoid missing keys

Because of: https://openqa.suse.de/tests/999475#step/boot_from_pxe/3