### PR TITLE
Fix scrolling to the end of snapshots list in user_defined_snapshot test

### DIFF
--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -43,7 +43,7 @@ sub run() {
     type_string "yast2 snapper\n";
     assert_screen 'yast2_snapper-snapshots', 100;
     # ensure the last screenshots are visible
-    send_key 'pgdn';
+    send_key 'end';
     # Make sure the test snapshot is not there
     die("Unexpected snapshot found") if (check_screen([qw(grub_comment)], 1));
 


### PR DESCRIPTION
Before user_defined_snapshot test we execute yast2_lan_restart test case
which triggers creation of many snapshots, that the list doesn't fit
without scroll. In previous implementation we were pressing pgdn button,
which doesn't scroll to the end of list to verify that test snapshot is
not there. It's questionable if we need this check at all, but with
"end" button we will navigate to the end of list.

Veriffication run: http://10.160.66.147/tests/277