### PR TITLE
Add hostname on active IP for FQDN hostname

### DIFF
--- a/tests/console/hostname.pm
+++ b/tests/console/hostname.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,10 +18,16 @@ use testapi;
 sub run() {
     select_console 'root-console';
 
-    my $hostname = get_var("HOSTNAME", 'susetest');
+    my $hostname = get_var('HOSTNAME', 'susetest');
+    my $domain = check_var('DISTRI', 'opensuse') ? 'openqa.opensuse.org' : 'openqa.suse.de';
+    # create entry in /etc/hosts for FQDN hostname
+    assert_script_run 'interface=`awk \'{print$6}\' /proc/net/arp|uniq|tail -n1`';
+    assert_script_run 'ip=`ip a|grep $interface|grep inet|awk -F\' *|/\' \'{print$3}\'`';
+    assert_script_run "echo \"\$ip $hostname.$domain $hostname\" >> /etc/hosts";
+    assert_script_run 'cat /etc/hosts';
     assert_script_run "hostnamectl set-hostname $hostname";
     assert_script_run "hostnamectl status|grep $hostname";
-    assert_script_run "hostname|grep $hostname";
+    assert_script_run "hostname -f|grep $hostname";
     # if you change hostname using `hostnamectl set-hostname`, then `hostname -f` will fail with "hostname: Name or service not known"
     # also DHCP/DNS don't know about the changed hostname, you need to send a new DHCP request to update dynamic DNS
     # yast2-network module does "NetworkService.ReloadOrRestart if Stage.normal || !Linuxrc.usessh" if hostname is changed via `yast2 lan`


### PR DESCRIPTION
This will get active network interface from arp table
In /etc/hosts will be added valid FQDN hostname entry to IP from active interface

e.g. SUMA test need FQDN hostname
[http://sleposbuilder.suse.cz/tests/260#step/init/5](http://10.100.2.56/tests/260#step/init/5)
[http://sleposbuilder.suse.cz/tests/248#step/init/10](http://10.100.2.56/tests/248#step/init/10)

[test](http://10.100.12.155/tests/6709#step/hostname/21)