### PR TITLE
Add new gpg test to console extratests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -499,6 +499,7 @@ sub load_extra_tests() {
         loadtest "console/wget_ipv6";
         loadtest "console/unzip";
         loadtest "console/zypper_moo";
+        loadtest "console/gpg";
         if (get_var("SYSAUTHTEST")) {
             # sysauth test scenarios run in the console
             loadtest "sysauth/sssd";

--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -1,0 +1,64 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: gpg key generation and passphrase test
+# Maintainer: Petr Cervinka <pcervinka@suse.com>
+
+use base "consoletest";
+use strict;
+use testapi;
+
+sub run() {
+    select_console 'user-console';
+
+    # Get gpg version and base on the result choose different test
+    my $gpg_version_output = script_output("gpg --version");
+    my ($gpg_version) = $gpg_version_output =~ /gpg \(GnuPG\) (\d\.\d)/;
+    # generate gpg key
+    if ($gpg_version eq "2.0") {
+        # gpg version 2.0.x
+        type_string "gpg2 --gen-key\n";
+    }
+    else {
+        # gpg version >= 2.1.x
+        type_string "gpg2 --full-generate-key\n";
+    }
+    wait_still_screen 1;
+    type_string "1\n";
+    wait_still_screen 1;
+    type_string "2048\n";
+    wait_still_screen 1;
+    type_string "0\n";
+    wait_still_screen 1;
+    type_string "y\n";
+    wait_still_screen 1;
+    type_string "Test User\n";
+    wait_still_screen 1;
+    type_string "user\@example.com\n", 1;
+    type_string "\n";
+    wait_still_screen 1;
+    save_screenshot;
+    type_string "O\n";
+
+    assert_screen("gpg-enter-passphrase");
+    # enter wrong passphrase
+    type_string "REALSECRETPHRASE\n";
+    assert_screen("gpg-incorrect-passphrase");
+    type_string "\t\n", 1;
+    # enter correct passphrase
+    type_string "R34LS3CR3TPHR4S3\n";
+    wait_still_screen 1;
+    type_string "R34LS3CR3TPHR4S3\n";
+    wait_still_screen 1;
+    # list gpg keys
+    validate_script_output("gpg --list-keys", sub { m/\[ultimate\] Test User <user\@example\.com>/ });
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
I created new gpg test for openQA, which:
- generates new key
- enters passphrase
- list keys

Test validated in private openQA instance:
Leap 42.3: http://pc-pha-base-1.suse.cz/tests/830#step/gpg/1
Tumbleweed: http://pc-pha-base-1.suse.cz/tests/832#step/gpg/1
SLE12-SP2: http://pc-pha-base-1.suse.cz/tests/831#step/gpg/1

openSUSE needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/210
SLE needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/393