### PR TITLE
Implement poweroff part go through icewm

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -599,7 +599,15 @@ sub poweroff_x11 {
         assert_and_click 'mate_shutdown_btn';
     }
 
-    if (get_var("DESKTOP") =~ m/minimalx|textmode/) {
+    if (check_var("DESKTOP", "minimalx")) {
+        send_key "ctrl-alt-delete";    # logout dialog
+        assert_screen 'logoutdialog', 10;
+        send_key "alt-d";              # shut_d_own
+        assert_screen 'logout-confirm-dialog', 10;
+        send_key "alt-o";              # _o_k
+    }
+
+    if (get_var("DESKTOP") =~ /textmode/) {
         power('off');
     }
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -607,10 +607,6 @@ sub poweroff_x11 {
         send_key "alt-o";              # _o_k
     }
 
-    if (get_var("DESKTOP") =~ /textmode/) {
-        power('off');
-    }
-
     if (check_var('BACKEND', 's390x')) {
         # make sure SUT shut down correctly
         console('x3270')->expect_3270(


### PR DESCRIPTION
according to https://openqa.opensuse.org/tests/421551 failure, the previous reboot/shutdown change had switch the console to x11 before shutdown on minimalx scenario, however ``power('off')`` inside of poweroff_x11 does not work on minimalx, I think it never tested ``power('off')`` on minimalx in the past, therefore here implemented poweroff steps on icewm like the others X11 tests did. Also remove textmode part from poweroff_x11, it's not x11 scenario and seems never be used.

Verification run: https://openqa.opensuse.org/tests/421784