### PR TITLE
Don't look for repo from deactivated add-on

### DIFF
--- a/tests/console/zypper_lr.pm
+++ b/tests/console/zypper_lr.pm
@@ -16,6 +16,8 @@ use testapi;
 use utils;
 
 sub run() {
+    # ZYPPER_LR is needed for inconsistent migration, test would fail looking for deactivated addon
+    set_var 'ZYPPER_LR';
     select_console 'root-console';
     validate_repos;
 }


### PR DESCRIPTION
Forgotten to commit in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/2939

fail https://openqa.suse.de/tests/1002527#step/zypper_lr/22
test is not looking for removed/deactivated add-on http://10.100.12.155/tests/6445#step/zypper_lr/30