### PR TITLE
Fix firefox java test for leap

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -440,6 +440,12 @@ sub load_extra_tests() {
             loadtest 'x11/user_defined_snapshot';
         }
         elsif (check_var('DISTRI', 'opensuse')) {
+            # Setup env for x11 regression tests
+            loadtest "x11regressions/x11regressions_setup";
+            # poo#18850 java test support for firefox, run firefox before chrome
+            # as otherwise have wizard on first run to import settings from it
+            loadtest "x11regressions/firefox/firefox_java";
+
             if (chromestep_is_applicable()) {
                 loadtest "x11/chrome";
             }
@@ -452,10 +458,6 @@ sub load_extra_tests() {
                     loadtest "x11/gdm_session_switch";
                 }
                 loadtest "x11/seahorse";
-                # Setup env for x11 regression tests
-                loadtest "x11regressions/x11regressions_setup";
-                # poo#18850 java test support for firefox
-                loadtest "x11regressions/firefox/firefox_java";
             }
         }
     }


### PR DESCRIPTION
In the test suite for extra tests on gnome we have chromium tests, which
were executed before firefox, which means that on first start ff tries
to import settings from chromium and test fails due to unexpected
window. Easiest solution is to schedule firefox tests before chrome as
it's already preinstalled in SUT.

NOTE: please merge needles for the tests, as will fail on Leap otherwise: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/211

Progress ticket: https://progress.opensuse.org/issues/19858
Verification run TW: http://gershwin.arch.suse.de/tests/245
Verification run Leap: http://gershwin.arch.suse.de/tests/246

Has to be merged with new needles for leap which didn't match in verification run: 
