### PR TITLE
Hide mouse after clicking bootstrap

### DIFF
--- a/tests/casp/stack_controller.pm
+++ b/tests/casp/stack_controller.pm
@@ -87,6 +87,7 @@ sub velum_bootstrap {
     mouse_set $x, $y;
     mouse_click;
     assert_and_click "velum-bootstrap";
+    mouse_hide;
     assert_screen "velum-botstrap-done", 300;
     assert_and_click "velum-kubeconfig";
 }


### PR DESCRIPTION
Fix for: https://openqa.suse.de/tests/1004852#step/stack_controller/34