### PR TITLE
Rework snapper --no-dbus tests

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -27,5 +27,45 @@ sub cleanup_partition_table {
     assert_script_run 'wipefs --force --all $disk';
 }
 
+=head2 snapper_nodbus_setup
+
+In `snapper --no-dbus` test we need DBus to be disabled on SLES12SP3 and Leap 42.3
+systemd allows DBus to be disabled. On Tumbleweed this is not possible and the simplest
+way to get DBus-less environment is to enter rescue.target via systemctl.
+=cut
+sub snapper_nodbus_setup {
+    my ($self) = @_;
+    if (script_run('! systemctl is-active dbus')) {
+        script_run('systemctl rescue', 0);
+        assert_screen('emergency-shell', 10);
+        type_password;
+        send_key 'ret';
+        $self->set_standard_prompt('root');
+        assert_screen 'root-console';
+    }
+}
+
+=head2 snapper_nodbus_restore
+
+Restore environment to default.target. Console root-console has to be reset, because
+move from rescue to default target, logs us out. Die if DBus is active at this point,
+it means that DBus got activated somehow, thus invalidated `snapper --no-dbus` testing.
+=cut
+sub snapper_nodbus_restore {
+    if (script_run('systemctl is-active dbus')) {
+        script_run('systemctl default', 0);
+        assert_screen 'tty2-selected';
+        console('root-console')->reset;
+        select_console 'root-console';
+    }
+    else {
+        die 'DBus service ought not to be active (but is)';
+    }
+}
+
+sub post_fail_hook {
+    upload_logs('/var/log/snapper.log');
+}
+
 1;
 # vim: set sw=4 et:

--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -7,9 +7,10 @@ use testapi;
 =head2 unpartitioned_disk_in_bash
 
 Choose the disk without a partition table for btrfs experiments.
-Defines the variable C<$disk> in a bash session.
+Defines the variable C<$disk> in a bash session, which defaults to
+'/dev/*b' drive (i.e. /dev/{vd,xvd,sd}b) be it blank or used before.
 =cut
-sub set_unpartitioned_disk_in_bash {
+sub set_playground_disk_in_bash {
     my $vd = 'vd';    # KVM
     if (check_var('VIRSH_VMM_FAMILY', 'xen')) {
         $vd = 'xvd';
@@ -18,7 +19,7 @@ sub set_unpartitioned_disk_in_bash {
         $vd = 'sd';
     }
     assert_script_run 'parted --script --machine -l';
-    assert_script_run 'disk=${disk:-$(parted --script --machine -l |& sed -n \'s@^\(/dev/' . $vd . '[ab]\):.*unknown.*$@\1@p\')}';
+    assert_script_run 'disk=${disk:-$(parted --script --machine -l |& sed -n \'s@^\(/dev/' . $vd . 'b\):.*$@\1@p\')}';
     assert_script_run 'echo $disk';
 }
 

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -545,7 +545,9 @@ sub load_filesystem_tests() {
     }
     loadtest 'console/snapper_undochange';
     loadtest 'console/snapper_create';
-    if (check_var('DISTRI', 'sle')) {
+    if (   (check_var('DISTRI', 'sle') && sle_version_at_least('12-SP3'))
+        || (check_var('DISTRI', 'opensuse') && (check_var('VERSION', '42.3') || check_var('VERSION', 'Tumbleweed'))))
+    {
         loadtest 'console/snapper_thin_lvm';
     }
 }

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -152,7 +152,8 @@ sub export_logs {
 
 # Set a simple reproducible prompt for easier needle matching without hostname
 sub set_standard_prompt {
-    $testapi::distri->set_standard_prompt;
+    my ($self, $user) = @_;
+    $testapi::distri->set_standard_prompt($user);
 }
 
 sub select_bootmenu_more {

--- a/tests/console/btrfs_qgroups.pm
+++ b/tests/console/btrfs_qgroups.pm
@@ -25,7 +25,7 @@ sub run() {
 
     # Set up
     assert_script_run "mkdir $dest";
-    $self->set_unpartitioned_disk_in_bash;
+    $self->set_playground_disk_in_bash;
     assert_script_run "mkfs.btrfs -f \$disk && mount \$disk $dest && cd $dest";
     assert_script_run "btrfs quota enable .";
 

--- a/tests/console/btrfs_send_receive.pm
+++ b/tests/console/btrfs_send_receive.pm
@@ -51,7 +51,7 @@ sub run() {
     assert_script_run "mkdir $src";
     assert_script_run "btrfs subvolume create $src/sv";
     assert_script_run "mkdir $dest";
-    $self->set_unpartitioned_disk_in_bash;
+    $self->set_playground_disk_in_bash;
     assert_script_run "mkfs.btrfs -f \$disk && mount \$disk $dest";
     #make sure that pax is installed
     zypper_call('in -C pax');

--- a/tests/console/snapper_cleanup.pm
+++ b/tests/console/snapper_cleanup.pm
@@ -13,11 +13,10 @@
 use base "consoletest";
 use strict;
 use testapi;
-use utils qw(service_action clear_console);
+use utils 'clear_console';
 
 sub snapper_cleanup {
-    my ($snapper)       = @_;
-    my $snaps_numb      = "$snapper list | grep number | wc -l";
+    my $snaps_numb      = "snapper list | grep number | wc -l";
     my $btrfs_fs_usage  = "btrfs filesystem usage / --raw";
     my $fs_size         = script_output("$btrfs_fs_usage | sed -n '2p' | awk -F ' ' '{print\$3}'");
     my $used_space      = script_output("$btrfs_fs_usage | sed -n '6p' | awk -F ' ' '{print\$2}'");
@@ -27,17 +26,17 @@ sub snapper_cleanup {
     # we want to fill up disk enough so that snapper cleanup triggers
     my $scratch_size_gb = 6;
     my $fill_space      = 'dd if=/dev/urandom of=data bs=1M count=1024';
-    my $snap_create     = "$snapper create --cleanup number --command '$fill_space'";
+    my $snap_create     = "snapper create --cleanup number --command '$fill_space'";
     assert_script_run "btrfs filesystem show --mbytes /";
 
     for (1 .. $scratch_size_gb / 2) { assert_script_run("$snap_create", 500); }
 
     script_run "echo There are `$snaps_numb` snapshots BEFORE cleanup";
-    assert_script_run("$snapper cleanup number");    # cleanup created snapshots
+    assert_script_run("snapper cleanup number");    # cleanup created snapshots
     assert_script_run("btrfs quota rescan -w /", 15);
     script_run "echo There are `$snaps_numb` snapshots AFTER cleanup";
     assert_script_run("btrfs qgroup show -pcre /", 3);
-    assert_script_run("$snapper list");
+    assert_script_run("snapper list");
     clear_console;
     script_output("$btrfs_fs_usage | sed -n '7p' | awk -F ' ' '{print\$3}'");
 
@@ -52,33 +51,32 @@ sub snapper_cleanup {
     }
 }
 
-sub run() {
+sub run {
     select_console 'root-console';
 
-    my @snapper_runs = 'snapper';
-    push @snapper_runs, 'snapper --no-dbus' if get_var('SNAPPER_NODBUS');
-
-    foreach my $snapper (@snapper_runs) {
-        service_action('dbus', {type => ['socket', 'service'], action => ['stop', 'mask']}) if ($snapper =~ /dbus/);
-
-        if (get_var("UPGRADE") || get_var("AUTOUPGRADE") && !get_var("BOOT_TO_SNAPSHOT")) {
-            assert_script_run "$snapper setup-quota";
-            assert_script_run "$snapper set-config NUMBER_LIMIT=2-10 NUMBER_LIMIT_IMPORTANT=4-10";
-        }
-
-        assert_script_run("$snapper get-config");    # get initial cfg
-        assert_script_run("$snapper list");          # get initial list of snap's
-        assert_script_run("$snapper set-config NUMBER_MIN_AGE=0");
-        assert_script_run("btrfs qgroup show -pc /", 3);
-
-        # We need to run snapper at least couple of times to ensure it cleans up properly
-        # '4' is an arbitrary value proven by test
-        for (1 .. 4) { snapper_cleanup($snapper); }
-
-        assert_script_run("$snapper set-config NUMBER_MIN_AGE=1800");
-
-        service_action('dbus', {type => ['socket', 'service'], action => ['unmask', 'start']}) if ($snapper =~ /dbus/);
+    if (get_var("UPGRADE") || get_var("AUTOUPGRADE") && !get_var("BOOT_TO_SNAPSHOT")) {
+        assert_script_run "snapper setup-quota";
+        assert_script_run "snapper set-config NUMBER_LIMIT=2-10 NUMBER_LIMIT_IMPORTANT=4-10";
     }
+
+    assert_script_run("snapper get-config");    # get initial cfg
+    assert_script_run("snapper list");          # get initial list of snap's
+    assert_script_run("snapper set-config NUMBER_MIN_AGE=0");
+    assert_script_run("btrfs qgroup show -pc /", 3);
+
+    # We need to run snapper at least couple of times to ensure it cleans up properly
+    # '4' is an arbitrary value proven by test
+    for (1 .. 4) { snapper_cleanup; }
+
+    assert_script_run("snapper set-config NUMBER_MIN_AGE=1800");
+}
+
+
+sub post_fail_hook {
+    my ($self) = @_;
+    upload_logs('/var/log/snapper.log');
 }
 
 1;
+
+# vim: set sw=4 et:

--- a/tests/console/snapper_create.pm
+++ b/tests/console/snapper_create.pm
@@ -15,52 +15,44 @@ use base "consoletest";
 use testapi;
 use utils;
 
-sub run() {
+sub run {
     select_console 'root-console';
 
-    my @snapper_runs = 'snapper';
-    push @snapper_runs, 'snapper --no-dbus' if get_var('SNAPPER_NODBUS');
-
-    foreach my $snapper (@snapper_runs) {
-        my $get_last_snap_number = "$snapper list | tail -n1 | awk '{ print \$3 }'";
-        service_action('dbus', {type => ['socket', 'service'], action => ['stop', 'mask']}) if ($snapper =~ /dbus/);
-        my @snapper_cmd = "$snapper create";
-        my @snap_numbers;
-        my $first_snap_to_delete;
-        foreach my $type ('single', 'command', 'pre', 'post') {
-            my $type_arg = "--type $type";
-            $type_arg = "--command \"$snapper list | tail -n1\"" if ($type eq 'command');
-            push @snapper_cmd, $type_arg;
-            foreach my $cleanup_algorithm ('number', 'timeline', 'empty-pre-post') {
-                push @snapper_cmd, '--pre-number ' . pop @snap_numbers if ($type eq 'post');
-                push @snapper_cmd, "--cleanup-algorithm $cleanup_algorithm";
-                my $description = "type=$type,cleanup_algorithm=$cleanup_algorithm";
-                push @snapper_cmd, "--print-number --description \"$description\"";
-                push @snapper_cmd, "--userdata \"$description\"";
-                assert_script_run(join ' ', @snapper_cmd);
-                $first_snap_to_delete = script_output($get_last_snap_number) unless $first_snap_to_delete;
-                assert_script_run("$snapper list | tail -n1");
-                for (1 .. 3) { pop @snapper_cmd; }
-                if ($type eq 'pre') {
-                    type_string("( $snapper list | tail -n1 | awk \'{ print \$3 }\'; echo snapper-post-\$?; ) > /dev/$serialdev\n");
-                    my @snap_number = split('\n', wait_serial('snapper-post-0'));
-                    push @snap_numbers, substr($snap_number[0], 0, -1);    # strip \n
-                }
+    my $get_last_snap_number = "snapper list | tail -n1 | awk '{ print \$3 }'";
+    my @snapper_cmd          = "snapper create";
+    my @snap_numbers;
+    my $first_snap_to_delete;
+    foreach my $type ('single', 'command', 'pre', 'post') {
+        my $type_arg = "--type $type";
+        $type_arg = "--command \"snapper list | tail -n1\"" if ($type eq 'command');
+        push @snapper_cmd, $type_arg;
+        foreach my $cleanup_algorithm ('number', 'timeline', 'empty-pre-post') {
+            push @snapper_cmd, '--pre-number ' . pop @snap_numbers if ($type eq 'post');
+            push @snapper_cmd, "--cleanup-algorithm $cleanup_algorithm";
+            my $description = "type=$type,cleanup_algorithm=$cleanup_algorithm";
+            push @snapper_cmd, "--print-number --description \"$description\"";
+            push @snapper_cmd, "--userdata \"$description\"";
+            assert_script_run(join ' ', @snapper_cmd);
+            $first_snap_to_delete = script_output($get_last_snap_number) unless $first_snap_to_delete;
+            assert_script_run("snapper list | tail -n1");
+            for (1 .. 3) { pop @snapper_cmd; }
+            if ($type eq 'pre') {
+                type_string("( snapper list | tail -n1 | awk \'{ print \$3 }\'; echo snapper-post-\$?; ) > /dev/$serialdev\n");
+                my @snap_number = split('\n', wait_serial('snapper-post-0'));
+                push @snap_numbers, substr($snap_number[0], 0, -1);    # strip \n
             }
-            pop @snapper_cmd if ($type eq 'post');
-            pop @snapper_cmd;
         }
-        service_action('dbus', {type => ['socket', 'service'], action => ['unmask', 'start']}) if ($snapper =~ /dbus/);
-        assert_script_run("$snapper list");
-        # Delete all those snapshots we just created so other tests are not confused
-        assert_script_run("$snapper delete --sync $first_snap_to_delete-" . script_output($get_last_snap_number));
-        assert_script_run("$snapper list");
+        pop @snapper_cmd if ($type eq 'post');
+        pop @snapper_cmd;
     }
+    assert_script_run("snapper list");
+    # Delete all those snapshots we just created so other tests are not confused
+    assert_script_run("snapper delete --sync $first_snap_to_delete-" . script_output($get_last_snap_number));
+    assert_script_run("snapper list");
 }
 
-sub post_fail_hook() {
+sub post_fail_hook {
     my ($self) = @_;
-
     upload_logs('/var/log/snapper.log');
 }
 

--- a/tests/console/snapper_thin_lvm.pm
+++ b/tests/console/snapper_thin_lvm.pm
@@ -14,9 +14,8 @@
 use base 'btrfs_test';
 use testapi;
 use strict;
-use utils 'service_action';
 
-sub run() {
+sub run {
     my ($self) = @_;
     select_console 'root-console';
 
@@ -64,12 +63,13 @@ sub run() {
         assert_script_run "umount $mnt_thin";
         assert_script_run "rm -rf $mnt_thin_snapshot $mnt_thin";
         assert_script_run 'vgremove -f test';
-        assert_script_run 'echo -e "g\np\nw" | fdisk $disk';
+        $self->cleanup_partition_table;
         assert_script_run 'lsblk';
 
-        service_action('dbus', {type => ['socket', 'service'], action => ['unmask', 'start']}) if ($snapper =~ /dbus/);
+        $self->snapper_nodbus_restore if $snapper =~ /dbus/;
     }
 }
 
 1;
+
 # vim: set sw=4 et:

--- a/tests/console/snapper_thin_lvm.pm
+++ b/tests/console/snapper_thin_lvm.pm
@@ -25,9 +25,10 @@ sub run() {
     my $mnt_thin          = '/mnt/thin';
     my $mnt_thin_snapshot = $mnt_thin . '-snapshot';
 
-    $self->set_unpartitioned_disk_in_bash;
     foreach my $snapper (@snapper_runs) {
-        service_action('dbus', {type => ['socket', 'service'], action => ['stop', 'mask']}) if ($snapper =~ /dbus/);
+        $self->snapper_nodbus_setup if $snapper =~ /dbus/;
+
+        $self->set_playground_disk_in_bash;
 
         # Create partition on unpartitioned
         assert_script_run 'echo -e "g\nn\n\n\n\nt\n8e\np\nw" | fdisk $disk';

--- a/tests/console/snapper_undochange.pm
+++ b/tests/console/snapper_undochange.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2015-2016 SUSE LLC
+# Copyright © 2015-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -10,12 +10,12 @@
 # Summary: Check that snapper can revert file changes between snapshots
 # Maintainer: mkravec <mkravec@suse.com>
 
-use base "consoletest";
+use base "btrfs_test";
 use strict;
 use testapi;
-use utils 'service_action';
 
 sub run() {
+    my ($self) = @_;
     select_console 'root-console';
 
     my $snapfile     = '/root/snapfile';
@@ -23,31 +23,27 @@ sub run() {
     push @snapper_runs, 'snapper --no-dbus' if get_var('SNAPPER_NODBUS');
 
     foreach my $snapper (@snapper_runs) {
-        service_action('dbus', {type => ['socket', 'service'], action => ['stop', 'mask']}) if ($snapper =~ /dbus/);
+        $self->snapper_nodbus_setup if $snapper =~ /dbus/;
 
-        my $snapbf = script_output "$snapper create -p -d 'before undochange test'", 90;
+        assert_script_run "snapbf=`$snapper create -p -d 'before undochange test'`", 90;
         script_run "date > $snapfile";
-        my $snapaf = script_output "$snapper create -p -d 'after undochange test'", 90;
+        assert_script_run "snapaf=`$snapper create -p -d 'after undochange test'`", 90;
 
         # Delete snapfile
-        script_run "$snapper undochange $snapbf..$snapaf $snapfile", 90;
+        script_run "$snapper undochange \$snapbf..\$snapaf $snapfile", 90;
         script_run("test -f $snapfile || echo \"snap-ba-ok\" > /dev/$serialdev", 0);
-        wait_serial("snap-ba-ok", 30) || die "Snapper undochange $snapbf..$snapaf failed";
+        wait_serial("snap-ba-ok", 30) || die "Snapper undochange failed";
 
         # Restore snapfile
-        script_run "$snapper undochange $snapaf..$snapbf $snapfile", 90;
+        script_run "$snapper undochange \$snapaf..\$snapbf $snapfile", 90;
         assert_script_run("test -f $snapfile", timeout => 10, fail_message => "File $snapfile could not be found");
 
         assert_screen 'snapper_undochange';
-        service_action('dbus', {type => ['socket', 'service'], action => ['unmask', 'start']}) if ($snapper =~ /dbus/);
         assert_script_run "rm $snapfile";
+        $self->snapper_nodbus_restore if $snapper =~ /dbus/;
     }
 }
 
-sub post_fail_hook() {
-    my ($self) = @_;
-
-    upload_logs('/var/log/snapper.log');
-}
-
 1;
+
+# vim: set sw=4 et:


### PR DESCRIPTION
https://progress.opensuse.org/issues/19804

`snapper --no-dbus` should be run in more sane environment & made SLE15-ready.

Verification runs:
* Build0277 of opensuse-42.3-DVD.x86_64	extra_test_filesystem@64bit: http://assam.suse.cz/tests/6446
* Build0432 of sle-12-SP3-Server-DVD.x86_64	extra_test_filesystem@64bit: http://assam.suse.cz/tests/6443
* Build20170610 of opensuse-Tumbleweed-DVD.x86_64	extra_test_filesystem@64bit: http://assam.suse.cz/tests/6444