### PR TITLE
Verify sblim-sfcb successfully starts post upgrade

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -695,6 +695,9 @@ sub load_consoletests() {
         loadtest "console/yast2_i";
         loadtest "console/yast2_bootloader";
         loadtest "console/vim";
+        if (check_var('UPGRADE', '1')) {
+            loadtest "console/sblim_sfcb";
+        }
         if (!is_staging()) {
             loadtest "console/firewall_enabled";
         }

--- a/tests/console/sblim_sfcb.pm
+++ b/tests/console/sblim_sfcb.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test if sfcbd has been migrated properly during the
+#          upgrade and still starts
+# Maintainer: Adam Majer <amajer@suse.de>
+
+use base "consoletest";
+use strict;
+use testapi;
+
+sub run() {
+    assert_script_run 'rpm -qi sblim-sfcb';
+    assert_script_run 'systemctl start sblim-sfcb.service';
+    # FIXME: check if this service actually works, but this will do for now
+    sleep 10;
+    if (script_run('systemctl status sblim-sfcb.service | grep "Failed to load"') == 0) {
+        record_soft_failure('Migration went wrong and services were not unregistered - bnc#1041885');
+    }
+    assert_script_run 'systemctl status sblim-sfcb.service';
+    assert_script_run 'systemctl show -p ActiveState sblim-sfcb.service | grep ActiveState=active';
+}
+1;


### PR DESCRIPTION
cmpi-provider-register script attempts to determine if sblim-sfcb
service is installed by detecting a link to the service start
symlink. Unfortunatelly, the name of the service was renamed in
SP1 resulting in cmpi-provider-register not restarting sfcb. Fixing
the naming issue resulted in the cmpi-provider-register from
working completely, which is a regression of 874811

These tests attempt to detect such a regression in the future.

See bnc#1041885 and bnc#874811