### PR TITLE
Fix power_action call within 'console_reboot' after 265658e3

### DIFF
--- a/tests/console/console_reboot.pm
+++ b/tests/console/console_reboot.pm
@@ -19,8 +19,7 @@ use strict;
 
 sub run() {
     my ($self) = @_;
-    select_console 'root-console';
-    power_action('reboot');
+    power_action('reboot', textmode => 1);
     $self->wait_boot;
     select_console 'root-console';
     assert_script_run "chown $username /dev/$serialdev";


### PR DESCRIPTION
Within the test module 'console_reboot' we want to explicitly call a reboot
command from a text terminal even though we have an X11 session available.
This commit adds an option to power_action to explicitly select the
behaviour regardless of the value of the DESKTOP variable which still defines
the default.

Also correcting the comment to correctly describe the different modes as well
as fix some language issues.

As 'power_action' internally selects the correct console we can get rid of the
redundant call in console_reboot itself which was in conflict with the
previous behaviour anyway. After switching to the root-console, power_action
would switch back to the x11 console and eventually fail there. See
https://openqa.opensuse.org/tests/423083#step/console_reboot/10 for the
corresponding failure that is fixed.

Verification run: http://lord.arch/tests/6673

Related progress issue: https://progress.opensuse.org/issues/19880