### PR TITLE
[poo#12322] Verify installation settings overview is loaded

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -21,7 +21,7 @@ sub run() {
 
     # overview-generation
     # this is almost impossible to check for real
-    assert_screen "inst-overview";
+    assert_screen "installation-settings-overview-loaded";
     if (get_var("XEN")) {
         assert_screen "inst-xen-pattern";
     }

--- a/tests/installation/installation_overview_before.pm
+++ b/tests/installation/installation_overview_before.pm
@@ -21,7 +21,11 @@ sub run() {
 
     # overview-generation
     # this is almost impossible to check for real
-    assert_screen "inst-overview";
+    # See poo#12322. Prevent checks before overview is fully loaded
+    # 'inst-overview' needle is used in many places and sometimes includes only
+    # parts which are there while overview is still loading. This check has to be
+    # performed only once, as state of buttons can be different
+    assert_screen "installation-settings-overview-loaded";
 
     # preserve it for the video
     wait_idle 10;


### PR DESCRIPTION
During execution on slow system loading of overview may take time,
whereas we start pressing tab key until get to the software section. It
is in the top, and if we press tab couple of times before, we won't be
able to reach software section in 20 presses for some installations.
For that we've added new check before selecting software label, which indicates that overview content was loaded.

Has to merged along with needles:
[SLE needles MR#395] (https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/395)
[TW/Leap needles PR#213] (https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/213)
[Progress ticket] (https://progress.opensuse.org/issues/12322)

Note: changes may have side effects on execution as we cannot run all testsuites locally.

Verification runs which demonstrate different scenarios:
SLE: 
- http://gershwin.arch.suse.de/tests/280
- http://gershwin.arch.suse.de/tests/286
- http://gershwin.arch.suse.de/tests/293

TW: http://gershwin.arch.suse.de/tests/287
Leap: http://gershwin.arch.suse.de/tests/288
