### PR TITLE
Switch to x11 console as precondition for x11 tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -440,11 +440,18 @@ sub load_extra_tests() {
             loadtest 'x11/user_defined_snapshot';
         }
         elsif (check_var('DISTRI', 'opensuse')) {
-            # Setup env for x11 regression tests
-            loadtest "x11regressions/x11regressions_setup";
-            # poo#18850 java test support for firefox, run firefox before chrome
-            # as otherwise have wizard on first run to import settings from it
-            loadtest "x11regressions/firefox/firefox_java";
+            if (gnomestep_is_applicable()) {
+                # Setup env for x11 regression tests
+                loadtest "x11regressions/x11regressions_setup";
+                # poo#18850 java test support for firefox, run firefox before chrome
+                # as otherwise have wizard on first run to import settings from it
+                loadtest "x11regressions/firefox/firefox_java";
+                if (check_var('VERSION', '42.2')) {
+                    # 42.2 feature - not even on Tumbleweed
+                    loadtest "x11/gdm_session_switch";
+                }
+                loadtest "x11/seahorse";
+            }
 
             if (chromestep_is_applicable()) {
                 loadtest "x11/chrome";
@@ -452,13 +459,7 @@ sub load_extra_tests() {
             if (!get_var("NOAUTOLOGIN")) {
                 loadtest "x11/multi_users_dm";
             }
-            if (gnomestep_is_applicable()) {
-                if (check_var('VERSION', '42.2')) {
-                    # 42.2 feature - not even on Tumbleweed
-                    loadtest "x11/gdm_session_switch";
-                }
-                loadtest "x11/seahorse";
-            }
+
         }
     }
     else {

--- a/tests/x11regressions/x11regressions_setup.pm
+++ b/tests/x11regressions/x11regressions_setup.pm
@@ -15,6 +15,9 @@ use strict;
 use testapi;
 
 sub run() {
+    #Switch to x11 console, if not selected, before trying to start xterm
+    select_console('x11');
+
     x11_start_program("xterm");
 
     # grant user permission to access serial port until next reboot


### PR DESCRIPTION
In extra_tests_on_gnome we have tests for x11 which assume that we are
in x11 console, which is not always the case. For newly introduced
firefox_java tests we've added this step to x11regressions_setup test.

x11regressions_setup will also become lastgood, which is running x11 and hence tests will not fail due to switching to lastgood with text terminal.

We may think about selecting x11 console unconditionally in x11_start_program subroutine.

TW: http://gershwin.arch.suse.de/tests/276#
Leap: http://gershwin.arch.suse.de/tests/272#