### PR TITLE
Revert "Disk 'b' always the secondary disk for tests"

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -7,10 +7,9 @@ use testapi;
 =head2 unpartitioned_disk_in_bash
 
 Choose the disk without a partition table for btrfs experiments.
-Defines the variable C<$disk> in a bash session, which defaults to
-'/dev/*b' drive (i.e. /dev/{vd,xvd,sd}b) be it blank or used before.
+Defines the variable C<$disk> in a bash session.
 =cut
-sub set_playground_disk_in_bash {
+sub set_unpartitioned_disk_in_bash {
     my $vd = 'vd';    # KVM
     if (check_var('VIRSH_VMM_FAMILY', 'xen')) {
         $vd = 'xvd';
@@ -19,7 +18,7 @@ sub set_playground_disk_in_bash {
         $vd = 'sd';
     }
     assert_script_run 'parted --script --machine -l';
-    assert_script_run 'disk=${disk:-$(parted --script --machine -l |& sed -n \'s@^\(/dev/' . $vd . 'b\):.*$@\1@p\')}';
+    assert_script_run 'disk=${disk:-$(parted --script --machine -l |& sed -n \'s@^\(/dev/' . $vd . '[ab]\):.*unknown.*$@\1@p\')}';
     assert_script_run 'echo $disk';
 }
 

--- a/tests/console/btrfs_qgroups.pm
+++ b/tests/console/btrfs_qgroups.pm
@@ -25,7 +25,7 @@ sub run() {
 
     # Set up
     assert_script_run "mkdir $dest";
-    $self->set_playground_disk_in_bash;
+    $self->set_unpartitioned_disk_in_bash;
     assert_script_run "mkfs.btrfs -f \$disk && mount \$disk $dest && cd $dest";
     assert_script_run "btrfs quota enable .";
 

--- a/tests/console/btrfs_send_receive.pm
+++ b/tests/console/btrfs_send_receive.pm
@@ -51,7 +51,7 @@ sub run() {
     assert_script_run "mkdir $src";
     assert_script_run "btrfs subvolume create $src/sv";
     assert_script_run "mkdir $dest";
-    $self->set_playground_disk_in_bash;
+    $self->set_unpartitioned_disk_in_bash;
     assert_script_run "mkfs.btrfs -f \$disk && mount \$disk $dest";
     #make sure that pax is installed
     zypper_call('in -C pax');

--- a/tests/console/snapper_thin_lvm.pm
+++ b/tests/console/snapper_thin_lvm.pm
@@ -24,10 +24,10 @@ sub run {
     my $mnt_thin          = '/mnt/thin';
     my $mnt_thin_snapshot = $mnt_thin . '-snapshot';
 
+    $self->set_unpartitioned_disk_in_bash;
     foreach my $snapper (@snapper_runs) {
         $self->snapper_nodbus_setup if $snapper =~ /dbus/;
 
-        $self->set_playground_disk_in_bash;
 
         # Create partition on unpartitioned
         assert_script_run 'echo -e "g\nn\n\n\n\nt\n8e\np\nw" | fdisk $disk';


### PR DESCRIPTION
This reverts commit ed7370942b9fa894aa9404e2c7ef07f9e5ec5325.

See https://openqa.suse.de/tests/1007823#step/btrfs_qgroups/12