### PR TITLE
Set playground disk as a test instead of bash var

### DIFF
--- a/tests/console/btrfs_qgroups.pm
+++ b/tests/console/btrfs_qgroups.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -25,8 +25,9 @@ sub run() {
 
     # Set up
     assert_script_run "mkdir $dest";
-    $self->set_playground_disk_in_bash;
-    assert_script_run "mkfs.btrfs -f \$disk && mount \$disk $dest && cd $dest";
+    $self->set_playground_disk;
+    my $disk = get_required_var('PLAYGROUNDDISK');
+    assert_script_run "mkfs.btrfs -f $disk && mount $disk $dest && cd $dest";
     assert_script_run "btrfs quota enable .";
 
     # Create subvolumes, qgroups, assigns and limits
@@ -86,7 +87,7 @@ sub run() {
     assert_script_run 'rm e/file_*';
 
     assert_script_run "cd; umount $dest";
-    assert_script_run 'btrfsck $disk';
+    assert_script_run "btrfsck $disk";
     $self->cleanup_partition_table;
 }
 

--- a/tests/console/btrfs_send_receive.pm
+++ b/tests/console/btrfs_send_receive.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -51,8 +51,9 @@ sub run() {
     assert_script_run "mkdir $src";
     assert_script_run "btrfs subvolume create $src/sv";
     assert_script_run "mkdir $dest";
-    $self->set_playground_disk_in_bash;
-    assert_script_run "mkfs.btrfs -f \$disk && mount \$disk $dest";
+    $self->set_playground_disk;
+    my $disk = get_required_var('PLAYGROUNDDISK');
+    assert_script_run "mkfs.btrfs -f $disk && mount $disk $dest";
     #make sure that pax is installed
     zypper_call('in -C pax');
 
@@ -69,7 +70,7 @@ sub run() {
         assert_script_run "btrfs send -p $src/snap" . ($i - 1) . " $src/snap$i | btrfs receive $dest";
         compare_data $i;
     }
-    assert_script_run 'umount -l $disk';
+    assert_script_run "umount -l $disk";
     $self->cleanup_partition_table;
 }
 

--- a/tests/console/snapper_thin_lvm.pm
+++ b/tests/console/snapper_thin_lvm.pm
@@ -27,14 +27,15 @@ sub run {
     foreach my $snapper (@snapper_runs) {
         $self->snapper_nodbus_setup if $snapper =~ /dbus/;
 
-        $self->set_playground_disk_in_bash;
+        $self->set_playground_disk;
+        my $disk = get_required_var('PLAYGROUNDDISK');
 
         # Create partition on unpartitioned
-        assert_script_run 'echo -e "g\nn\n\n\n\nt\n8e\np\nw" | fdisk $disk';
+        assert_script_run 'echo -e "g\nn\n\n\n\nt\n8e\np\nw" | fdisk ' . $disk;
         assert_script_run 'lsblk';
 
         # Create a volume group named 'test'
-        assert_script_run 'vgcreate test ${disk}1';
+        assert_script_run "vgcreate test ${disk}1";
         # Follow guide at https://lizards.opensuse.org/2012/07/25/snapper-lvm/
         assert_script_run 'lvcreate --thin test/pool --size 3G';
         assert_script_run 'lvcreate --thin test/pool --virtualsize 5G --name thin';


### PR DESCRIPTION
Fixes https://openqa.suse.de/tests/1007823#step/btrfs_qgroups/12.

`unpartitioned_disk_in_bash` was setting `$disk` variable in bash
environment to secondary disk device, which we could use for filesystem
testing. New `set_playground_disk` function sets `PLAYGROUNDDISK`
variable to test environment, to be set only once, when the disk is
believed to be free from partition table.

http://assam.suse.cz/tests/8