### PR TITLE
[poo#16996] Fix installation sequence for leap 42.3 maintenance

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -24,20 +24,6 @@ use main_common;
 
 init_main();
 
-sub is_tumbleweed {
-    # Tumbleweed and its stagings
-    return 0 unless check_var('DISTRI', 'opensuse');
-    return 1 if check_var('VERSION', 'Tumbleweed');
-    return get_var('VERSION') =~ /^Staging:/;
-}
-
-sub is_leap {
-    # Leap and its stagings
-    return 0 unless check_var('DISTRI', 'opensuse');
-    return 1 if get_var('VERSION', '') =~ /(?:[4-9][0-9]|[0-9]{3,})\.[0-9]/;
-    return get_var('VERSION') =~ /^42:S/;
-}
-
 sub cleanup_needles() {
     remove_common_needles;
     if (!get_var("LIVECD")) {
@@ -295,7 +281,7 @@ sub load_inst_tests() {
     if (installwithaddonrepos_is_applicable() && !get_var("LIVECD")) {
         loadtest "installation/setup_online_repos";
     }
-    if (!get_var("LIVECD") && get_var("ADDONURL")) {
+    if (!get_var("LIVECD") && get_var("ADDONURL") && !(leap_version_at_least('42.3') && check_var('FLAVOR', 'Maintenance'))) {
         loadtest "installation/addon_products";
     }
     if (noupdatestep_is_applicable() && !get_var("LIVECD") && !get_var("REMOTE_CONTROLLER")) {


### PR DESCRIPTION
Recently we have created new tests for Leap 42.3 for maintenance and
updates. Existing tests are failing as expect addon_products step which
is no longer there after setting up online repos. For maintenance flavor
this step is excluded for leap 42.3. As we change naming convention, we
may need to adjust version check in future. For 42.2 addon_products step
is required.

Progress tocket [poo#16996](https://progress.opensuse.org/issues/16996)
Verification runs:
http://gershwin.arch.suse.de/tests/329
http://gershwin.arch.suse.de/tests/330
