### PR TITLE
Add orphaned package check after migration (poo#19606)

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -967,6 +967,7 @@ sub load_online_migration_tests() {
     if (check_var("MIGRATION_METHOD", 'zypper')) {
         loadtest "online_migration/sle12_online_migration/zypper_migration";
     }
+    loadtest "online_migration/sle12_online_migration/orphaned_packages_check";
     loadtest "online_migration/sle12_online_migration/post_migration";
 }
 

--- a/tests/online_migration/sle12_online_migration/orphaned_packages_check.pm
+++ b/tests/online_migration/sle12_online_migration/orphaned_packages_check.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Check and output orphaned packages
+# Maintainer: Wes <whdu@suse.com>
+# Tags: poo#19606
+
+use base "consoletest";
+use strict;
+use testapi;
+use utils 'zypper_call';
+
+sub run() {
+    select_console 'root-console';
+
+    #No orphaned packages list to compare currently, so we simply output the result
+    zypper_call('packages --orphaned', log => 'orphaned.log');
+    save_screenshot;
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
This is for the poo#19606 - Add “orphaned packages” information output after migration