### PR TITLE
Remove workaround_type_encrypted_passphrase from reboot_gnome

### DIFF
--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -20,7 +20,6 @@ sub run() {
     my ($self) = @_;
     # 'keepconsole => 1' is workaround for bsc#1044072
     power_action('reboot', keepconsole => 1);
-    workaround_type_encrypted_passphrase;
     $self->wait_boot(bootloader_time => 300);
 }
 


### PR DESCRIPTION
It's duplicate action since workaround_type_encrypted_passphrase
has been included in wait_boot function. Remove it from the
reboot_gnome.pm to avoid boot failure in lvm_full_encrypt test