### PR TITLE
Use rpm command instead of zypper to install kotd kernels

### DIFF
--- a/tests/kernel/install_kotd.pm
+++ b/tests/kernel/install_kotd.pm
@@ -14,19 +14,89 @@ use base "opensusebasetest";
 use utils;
 use testapi;
 
-# Add kotd repo
-sub add_repos {
-    my $url = get_required_var("INSTALL_KOTD");
-    if ($url =~ /^[\w.]+-[\w.]+$/) {
-        $url = "http://download.suse.de/ibs/Devel:/Kernel:/$url/standard/";
+=head2 grub_version
+
+    grub_version();
+
+If grub2 is installed, return 2; otherwise, return 1.
+
+=cut
+
+sub grub_version {
+    my $ret = script_run('rpm -q grub2');
+    if ($ret == 0) {
+        return 2;
     }
-    zypper_call("--no-gpg-check ar -f '$url' kotd", timeout => 600);
-    zypper_call("--gpg-auto-import-keys ref",       timeout => 1200);
+    return 1;
 }
 
-# Install kotd kernel and reboot
-sub install_from_repo {
-    zypper_call("install --oldpackage --from kotd kernel-default", timeout => 1200);
+
+=head2 download_kernel
+
+  download_kernel($url, $package);
+
+Download package $package from $url with wget and save it to /tmp. C<die> if wget returns non-zero value.
+
+=cut
+
+sub download_kernel {
+    my ($url, $package) = @_;
+    my $kernel = script_output("curl -sk '$url' | grep -oP '$package-[\\d.]+.*?\\.rpm' | head -n1");
+    my $file   = "/tmp/$kernel";
+    if (substr($url, -1) ne '/') {
+        $url = "$url/$kernel";
+    }
+    else {
+        $url = "$url$kernel";
+    }
+    assert_script_run("wget -O '$file' '$url'", timeout => 600);
+    return $file;
+}
+
+=head2 install_kernel
+
+  install_kernel($file);
+
+Install kernel file $file with rpm command and C<die> if it returns non-zero value.
+
+=cut
+
+sub install_kernel {
+    my $file = shift;
+    assert_script_run("rpm -i --nodeps --oldpackage --nosignature '$file'", timeout => 120);
+}
+
+# Set KOTD kernel as default boot option
+=head2 set_default
+
+  set_default($file);
+
+Set $file as the default boot option.
+
+=cut
+
+sub set_default {
+    my $file = shift;
+    my $cmd  = <<'END';
+#!/bin/bash
+rpm -q grub2 &> /dev/null
+if [[ $? -eq 0 ]]; then
+    grub_conf='/boot/grub2/grub.cfg'
+else
+    grub_conf='/boot/grub/menu.lst'
+fi
+
+id=$(echo "$1" | awk -F. '{print $(NF-2)}')
+vmlinuz=$(find /boot -name "vmlinuz-*$id*")
+old_version=$(uname -r)
+new_version=$(basename "$vmlinuz" | sed -e 's/vmlinuz-//g')
+sed -ie "s/$old_version/$new_version/g" "$grub_conf"
+END
+    my $script = "set_default.sh";
+    open my $fh, ">", 'current_script' or croak("Could not open file. $!");
+    print $fh $cmd;
+    close $fh;
+    assert_script_run("curl -sfv '" . autoinst_url("/current_script") . "' | bash -xs '$file'");
 }
 
 sub run {
@@ -38,8 +108,20 @@ sub run {
     else {
         select_console('root-console');
     }
-    add_repos;
-    install_from_repo;
+
+    my $url = get_required_var("INSTALL_KOTD");
+    if ($url =~ /^[\w.]+-[\w.]+$/) {
+        my $arch = get_required_var("ARCH");
+        $url = "http://download.suse.de/ibs/Devel:/Kernel:/$url/standard/$arch/";
+    }
+
+    if (grub_version() == 1) {
+        my $file = download_kernel($url, 'kernel-default-base');
+        install_kernel($file);
+    }
+    my $file = download_kernel($url, "kernel-default");
+    install_kernel($file);
+    set_default($file);
 
     select_console('root-console');
     type_string "reboot\n";


### PR DESCRIPTION
After discussing with Michal Marek, we decided to SLE12 SP2 to test all the SLE12 kotd kernels, including GA, SP1, SP2, SP3. To achieve this, rpm must be used instead of zypper. Besides, the kotd kernel must be configured  as the default boot option in grub configuration files.

Test result: http://147.2.207.102/tests/1046#step/install_kotd/38