### PR TITLE
Change base for snapper tests to get more logs

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -66,7 +66,12 @@ sub snapper_nodbus_restore {
 }
 
 sub post_fail_hook {
+    my ($self) = shift;
+    select_console('log-console');
+    $self->SUPER::post_fail_hook;
+
     upload_logs('/var/log/snapper.log');
+    $self->export_logs;
 }
 
 1;

--- a/tests/console/btrfs_autocompletion.pm
+++ b/tests/console/btrfs_autocompletion.pm
@@ -10,7 +10,7 @@
 # Summary: Bash autocompletion for btrfs
 # Maintainer: mkravec <mkravec@suse.com>
 
-use base "consoletest";
+use base 'btrfs_test';
 use strict;
 use testapi;
 

--- a/tests/console/snapper_cleanup.pm
+++ b/tests/console/snapper_cleanup.pm
@@ -10,7 +10,7 @@
 # Summary: Snapper cleanup test based on FATE#312751
 # Maintainer: Dumitru Gutu <dgutu@suse.com>
 
-use base "consoletest";
+use base 'btrfs_test';
 use strict;
 use testapi;
 use utils 'clear_console';
@@ -69,12 +69,6 @@ sub run {
     for (1 .. 4) { snapper_cleanup; }
 
     assert_script_run("snapper set-config NUMBER_MIN_AGE=1800");
-}
-
-
-sub post_fail_hook {
-    my ($self) = @_;
-    upload_logs('/var/log/snapper.log');
 }
 
 1;

--- a/tests/console/snapper_create.pm
+++ b/tests/console/snapper_create.pm
@@ -11,7 +11,7 @@
 # Maintainer: Michal Nowak <mnowak@suse.com>
 
 use strict;
-use base "consoletest";
+use base 'btrfs_test';
 use testapi;
 use utils;
 
@@ -49,11 +49,6 @@ sub run {
     # Delete all those snapshots we just created so other tests are not confused
     assert_script_run("snapper delete --sync $first_snap_to_delete-" . script_output($get_last_snap_number));
     assert_script_run("snapper list");
-}
-
-sub post_fail_hook {
-    my ($self) = @_;
-    upload_logs('/var/log/snapper.log');
 }
 
 1;

--- a/tests/console/snapper_undochange.pm
+++ b/tests/console/snapper_undochange.pm
@@ -10,7 +10,7 @@
 # Summary: Check that snapper can revert file changes between snapshots
 # Maintainer: mkravec <mkravec@suse.com>
 
-use base "btrfs_test";
+use base 'btrfs_test';
 use strict;
 use testapi;
 


### PR DESCRIPTION
Need to get more logs to report `snapper cleanup number`'s "Illegal
snapshot":
https://openqa.opensuse.org/tests/426254#step/snapper_cleanup/172.

Feeds `btrfs_test`'s `post_fail_hook` from 'consoletest'.

`post_fail_hook` kicks in after artificial `assert_script_run 'fail';`:
* SLES: http://assam.suse.cz/tests/41
* Leap 42.3: http://assam.suse.cz/tests/39
* Tumbleweed: http://assam.suse.cz/tests/40