### PR TITLE
Add yast2_lan_host module back to openSUSE extra tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -354,10 +354,12 @@ sub load_yast2_ui_tests {
     loadtest "console/yast2_samba";
     loadtest "console/yast2_xinetd";
     loadtest "console/yast2_apparmor";
-    # TODO: why are the following two modules called on sle but not on opensuse?
-    # TODO: check if the following two modules also work on opensuse and delete if
+    loadtest "console/yast2_lan_hostname";
+
+    #   we use internal nis server for the test and it cannot be used for openSUSE tests.
     if (check_var('DISTRI', 'sle')) {
-        loadtest "console/yast2_lan_hostname";
+        #    loadtest "console/yast2_lan_hostname";
+        #	SUSE has an internal nis server, but it cannot be used for openSUSE tests.
         loadtest "console/yast2_nis";
     }
     # TODO: check if the following two modules also work on sle and delete if.


### PR DESCRIPTION
For ticket https://progress.opensuse.org/issues/19922:
Fix dismatched needle and add yast2_lan_host back to openSUSE extratest.

Please see reference test:

openSUSE TW
http://e13.suse.de/tests/3148#step/yast2_lan_hostname
status: failed but it has to do with checking dhcp config file 
"grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp | grep yes"
But it doesn't happen on my openSUSE TW, manual checking doesn't showany problem.

openSUSE Leap
http://e13.suse.de/tests/3149#step/yast2_lan_hostname
status: passed, works fine

