### PR TITLE
Fix/update partition warnings

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -264,6 +264,9 @@ sub load_inst_tests() {
             loadtest "installation/partitioning_lvm";
         }
         if (get_var("FILESYSTEM")) {
+            if (get_var('PARTITIONING_WARNINGS')) {
+                loadtest 'installation/partitioning_warnings';
+            }
             loadtest "installation/partitioning_filesystem";
         }
         if (get_var("TOGGLEHOME")) {

--- a/tests/installation/partitioning_warnings.pm
+++ b/tests/installation/partitioning_warnings.pm
@@ -31,11 +31,14 @@ sub run() {
     assert_screen 'expert-partitioner';
     send_key $cmd{accept};
     # expect partition setup warning pop-ups
-    while (1) {
-        assert_screen ['partition-warning-too-small-for-snapshots', 'partition-warning-no-efi-boot', 'partition-warning-no-swap'];
+    assert_screen 'partition-warning-too-small-for-snapshots';
+    wait_screen_change { send_key 'alt-y' };    # yes
+    if (get_var('UEFI')) {
+        assert_screen 'partition-warning-no-efi-boot';
         wait_screen_change { send_key 'alt-y' };    # yes
-        last if match_has_tag 'partition-warning-no-swap';
     }
+    assert_screen 'partition-warning-no-swap';
+    wait_screen_change { send_key 'alt-y' };        # yes
 }
 
 1;


### PR DESCRIPTION
Test passing when 'too small partition for snapshots' message is expected, but missing
http://10.100.12.155/tests/7007#step/partitioning_warnings/12

Failing test when expected message is missing
http://10.100.12.155/tests/7008#step/partitioning_warnings/13

Passing test with all expected warnings
http://10.100.12.155/tests/7009#step/partitioning_warnings/12