### PR TITLE
Add yast_nfs_client back to SLE extratest

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -363,9 +363,11 @@ sub load_yast2_ui_tests {
     # TODO: check if the following two modules also work on sle and delete if.
     # yast-lan related tests do not work when using networkmanager.
     # (Livesystem and laptops do use networkmanager)
-    if (check_var('DISTRI', 'opensuse') && !get_var("LIVETEST") && !get_var("LAPTOP")) {
-        loadtest "console/yast2_cmdline";
-        loadtest "console/yast2_dns_server";
+    if (!get_var("LIVETEST") && !get_var("LAPTOP")) {
+        if (check_var('DISTRI', 'opensuse')) {
+            loadtest "console/yast2_cmdline";
+            loadtest "console/yast2_dns_server";
+        }
         loadtest "console/yast2_nfs_client";
     }
     loadtest "console/yast2_http";


### PR DESCRIPTION
For ticket https://progress.opensuse.org/issues/19922.
Add yast_nfs_client back to SLE extratest
My reference test against SLE:
http://e13.suse.de/tests/3153#step/yast2_nfs_client

Please check and merge my PR of needles which are required as well:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/398
