### PR TITLE
Fix autoyast installations where timeout does not trigger screen_change

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -119,10 +119,9 @@ sub run {
         }
         elsif (match_has_tag('warning-pop-up')) {
             die "Unknown popup message" unless check_screen('autoyast-known-warning', 0);
-            # Die if there is no timeout
-            die 'Popup message without timeout' unless wait_screen_change(undef, 5);
+
             # Wait until popup disappears
-            sleep 3 while check_screen('autoyast-known-warning', 0);
+            die "Popup message without timeout" unless wait_screen_change { sleep 11 };
         }
         elsif (match_has_tag('scc-invalid-url')) {
             die 'Fix invalid SCC reg URL https://trello.com/c/N09TRZxX/968-3-don-t-crash-on-invalid-regurl-on-linuxrc-commandline';


### PR DESCRIPTION
Local run: http://dhcp91.suse.cz/tests/6303#step/installation/3
Fix for: https://openqa.suse.de/tests/1019076#step/installation/6

Broken by: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3068