### PR TITLE
Investigate YaST2 failures by looking at y2log

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -31,6 +31,7 @@ sub post_fail_hook() {
         upload_logs $fn;
     }
     save_screenshot;
+    $self->investigate_yast2_failure();
 }
 
 sub post_run_hook {

--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -105,16 +105,18 @@ sub check_and_record_dependency_problems {
 }
 
 sub save_upload_y2logs() {
+    my ($self) = shift;
     assert_script_run 'sed -i \'s/^tar \(.*$\)/tar --warning=no-file-changed -\1 || true/\' /usr/sbin/save_y2logs';
     assert_script_run "save_y2logs /tmp/y2logs.tar.bz2";
     upload_logs "/tmp/y2logs.tar.bz2";
     save_screenshot();
+    $self->investigate_yast2_failure();
 }
 
 sub post_fail_hook() {
     my $self = shift;
     get_to_console;
-    save_upload_y2logs;
+    $self->save_upload_y2logs;
     if (get_var('FILESYSTEM', 'btrfs') =~ /btrfs/) {
         assert_script_run 'btrfs filesystem df /mnt | tee /tmp/btrfs-filesystem-df-mnt.txt';
         assert_script_run 'btrfs filesystem usage /mnt | tee /tmp/btrfs-filesystem-usage-mnt.txt';


### PR DESCRIPTION
Looking into the file y2log for any failure in yast related modules could
provide a very good first guess what the problem might be without needing to
transcribe screenshot content or waiting for a user to download the archive
file, unpack it, read the right file, scroll to the end, learn the format and
find a potentialy symptom. A 'record_info' window is added to job details
based on content in the file 'badlist' or a unique string being present in
y2log.

Verification run: http://lord.arch/tests/6705

The modules in the verification run are expected to fail, they show how the
error is investigated.