### PR TITLE
Fix regular expression of install_kotd.pm and increase timeout

### DIFF
--- a/tests/kernel/install_kotd.pm
+++ b/tests/kernel/install_kotd.pm
@@ -49,7 +49,7 @@ sub download_kernel {
     else {
         $url = "$url$kernel";
     }
-    assert_script_run("wget -O '$file' '$url'", timeout => 600);
+    assert_script_run("wget -O '$file' '$url'", timeout => 1800);
     return $file;
 }
 
@@ -110,7 +110,7 @@ sub run {
     }
 
     my $url = get_required_var("INSTALL_KOTD");
-    if ($url =~ /^[\w.]+-[\w.]+$/) {
+    if ($url !~ /^https?:\/\//) {
         my $arch = get_required_var("ARCH");
         $url = "http://download.suse.de/ibs/Devel:/Kernel:/$url/standard/$arch/";
     }


### PR DESCRIPTION
The previous regular expression failed to match patterns like "SLE12-SP1-LTSS". This patch fixes this problem: https://openqa.suse.de/tests/1021185#step/install_kotd/18

Besides, I've also increased the timeout of downloading kernel files, since sometimes the internet connection becomes real slow.

Tested here: http://147.2.207.102/tests/1059#