### PR TITLE
Accept license during zypper migration

### DIFF
--- a/tests/online_migration/sle12_online_migration/zypper_migration.pm
+++ b/tests/online_migration/sle12_online_migration/zypper_migration.pm
@@ -29,15 +29,16 @@ sub run() {
     my $zypper_migration_done         = qr/^Executing.*after online migration|^ZYPPER-DONE/m;
     my $zypper_migration_notification = qr/^View the notifications now\? \[y/m;
     my $zypper_migration_failed       = qr/^Migration failed/m;
+    my $zypper_migration_license      = qr/Do you agree with the terms of the license\? \[y/m;
 
     # start migration
     script_run("(zypper migration;echo ZYPPER-DONE) | tee /dev/$serialdev", 0);
     # migration process take long time
     my $timeout          = 7200;
     my $migration_checks = [
-        $zypper_migration_target,       $zypper_disable_repos,          $zypper_continue,
-        $zypper_migration_done,         $zypper_migration_error,        $zypper_migration_conflict,
-        $zypper_migration_fileconflict, $zypper_migration_notification, $zypper_migration_failed
+        $zypper_migration_target, $zypper_disable_repos,      $zypper_continue,               $zypper_migration_done,
+        $zypper_migration_error,  $zypper_migration_conflict, $zypper_migration_fileconflict, $zypper_migration_notification,
+        $zypper_migration_failed, $zypper_migration_license
     ];
     my $out = wait_serial($migration_checks, $timeout);
     while ($out) {
@@ -65,6 +66,11 @@ sub run() {
         }
         elsif ($out =~ $zypper_continue) {
             send_key "y";
+            send_key "ret";
+        }
+        elsif ($out =~ $zypper_migration_license) {
+            type_string "yes";
+            save_screenshot;
             send_key "ret";
         }
         elsif ($out =~ $zypper_migration_notification) {


### PR DESCRIPTION
zypper migration failed in the latest build with license agreement waiting to accept:
https://openqa.suse.de/tests/1020608
https://openqa.suse.de/tests/1020618

See: https://progress.opensuse.org/issues/20034