### PR TITLE
Skip zypper repo check for zdup module case

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -980,7 +980,7 @@ sub validate_repos_sle {
     }
 
     # Verify SLES, SLED, Addons and their online SCC sources, if SCC_REGISTER is enabled
-    if (check_var('SCC_REGISTER', 'installation')) {
+    if (check_var('SCC_REGISTER', 'installation') && !get_var('ZDUP')) {
         my ($uri, $nvidia_uri, $we);
 
         # Set uri and nvidia uri for smt registration and others (scc, proxyscc)


### PR DESCRIPTION
Skip zypper repo check for zdup module case.
zdup migration cases will do de-registration before migration, Module's repo will be disabled.
The zypper repo check will be failed with those disabled repo.

verification run http://147.2.212.225/tests/839