### PR TITLE
Soft-fail partition warning in autoyast test

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -118,6 +118,12 @@ sub run {
             $num_errors++;
         }
         elsif (match_has_tag('warning-pop-up')) {
+            if (check_screen('warning-partition-reduced', 0)) {
+                # See poo#19978, no timeout on partition warning, hence need to click OK button to soft-fail
+                record_soft_failure('bsc#1045470');
+                send_key $cmd{ok};
+                next;
+            }
             die "Unknown popup message" unless check_screen('autoyast-known-warning', 0);
             # Die if there is no timeout
             die 'Popup message without timeout' unless wait_screen_change(undef, 5);


### PR DESCRIPTION
We expect partition warning, as available space on hdd is less than we
have in autoyast profile, whereas there is no timeout on warning screen.
This change presses ok button when such warning is shown.

Has to be merged along with needles changes: [MR#399](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/399)

See [poo#19978](https://progress.opensuse.org/issues/19978) and [bsc#1045470](https://bugzilla.suse.com/show_bug.cgi?id=1045470)

Verification run: http://gershwin.arch.suse.de/tests/418