### PR TITLE
Add test case for login with only root user exists poo#19168

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1088,6 +1088,14 @@ sub handle_login {
     assert_screen 'displaymanager';    # wait for DM, then try to login
     mouse_hide();
     wait_still_screen;
+    if (get_var('ROOTONLY')) {
+        if (check_screen 'displaymanager-username-notlisted', 10) {
+            record_soft_failure 'bgo#731320/boo#1047262 "not listed" Login screen for root user is not intuitive';
+            assert_and_click 'displaymanager-username-notlisted';
+            wait_still_screen 3;
+        }
+        type_string "root\n";
+    }
     if (get_var('DM_NEEDS_USERNAME')) {
         type_string "$username\n";
     }

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -298,7 +298,7 @@ sub load_inst_tests() {
         else {
             loadtest "installation/user_settings";
         }
-        if (get_var("DOCRUN") || get_var("IMPORT_USER_DATA")) {    # root user
+        if (get_var("DOCRUN") || get_var("IMPORT_USER_DATA") || get_var("ROOTONLY")) {    # root user
             loadtest "installation/user_settings_root";
         }
     }

--- a/tests/installation/user_settings.pm
+++ b/tests/installation/user_settings.pm
@@ -19,25 +19,32 @@ use testapi;
 sub run() {
     my ($self) = @_;
     assert_screen "inst-usersetup";
-    type_string $realname;
-    send_key "tab";
-
-    send_key "tab";
-    $self->type_password_and_verification;
-    assert_screen "inst-userinfostyped";
-    if (get_var("NOAUTOLOGIN") && !check_screen('autologindisabled', timeout => 0)) {
-        send_key $cmd{noautologin};
-        assert_screen "autologindisabled";
+    if (get_var 'ROOTONLY') {
+        send_key 'alt-s';
+        assert_screen 'inst-rootonly-selected';
+        # done user setup
+        send_key $cmd{next};
     }
-    if (get_var("DOCRUN")) {
-        send_key $cmd{otherrootpw};
-        assert_screen "rootpwdisabled";
-    }
+    else {
+        type_string $realname;
+        send_key "tab";
 
-    # done user setup
-    send_key $cmd{next};
-    $self->await_password_check;
+        send_key "tab";
+        $self->type_password_and_verification;
+        assert_screen "inst-userinfostyped";
+        if (get_var("NOAUTOLOGIN") && !check_screen('autologindisabled', timeout => 0)) {
+            send_key $cmd{noautologin};
+            assert_screen "autologindisabled";
+        }
+        if (get_var("DOCRUN")) {
+            send_key $cmd{otherrootpw};
+            assert_screen "rootpwdisabled";
+        }
+
+        # done user setup
+        send_key $cmd{next};
+        $self->await_password_check;
+    }
 }
-
 1;
 # vim: set sw=4 et:


### PR DESCRIPTION
- Add ROOTONLY case for both SLE and openSUSE
- This case will only create root user during the installation
- set DESKTOP=gnome, INSTALLONLY=1, NOAUTOLOGIN=1, ROOTONLY=1 for openSUSE
- set DESKTOP=gnome, INSTALLONLY=1, ROOTONLY=1 for SLE
- Record soft failure for openSUSE

    see also: poo#19168, bgo#731320, boo#1047262

Validation test for SLE: http://147.2.212.222/tests/714
Validation test for openSUSE: http://147.2.212.222/tests/713