### PR TITLE
Create xfstests in openQA

### DIFF
--- a/tests/qa_automation/xfstests_device.pm
+++ b/tests/qa_automation/xfstests_device.pm
@@ -1,0 +1,120 @@
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+package xfstests_device;
+# Summary:  Device prepare related base class for xfstests_run
+# Maintainer: Yong Sun <yosun@suse.com>
+
+use strict;
+use warnings;
+use File::Basename;
+use base "opensusebasetest";
+use utils;
+use testapi qw(is_serial_terminal :DEFAULT);
+
+# Create test partition and scratch partition, and make FS in them
+sub dev_create_partition() {
+    my $self = shift;
+    my $test_fs_type = get_var('TEST_FS_TYPE', '');
+    unless ($test_fs_type) {
+        $test_fs_type = "xfs";
+        print "warning: TEST_FS_TYPE not configured, test defaultly set it to xfs.";
+    }
+    assert_script_run("parted -l -m 2>&1");
+    my $cmd               = "parted -l -m 2>&1| awk -F \':\' \'{if(\$5 == \"xfs\") print \$1}\'";
+    my $test_partition_id = script_output($cmd, 10);
+    my $test_partition    = "/dev/vda" . $test_partition_id;
+
+    # seperate xfs partition(/home) into two same size xfs
+    $cmd = "parted -l -m 2>&1| awk -F \':\' \'{if(\$5 == \"xfs\") print \$2}\'";
+    my $partition_begin = script_output($cmd, 10);
+    my $extendpartition_begin = $partition_begin;
+    $cmd = "parted -l -m 2>&1| awk -F \':\' \'{if(\$5 == \"xfs\") print \$3}\'";
+    my $partition_end       = script_output($cmd, 10);
+    my $extendpartition_end = $partition_end;
+    my $partition_cut_point = $self->get_cut_point($partition_begin, $partition_end, 2);
+    assert_script_run("umount " . $test_partition);
+    type_string "parted /dev/vda\n";
+    type_string "rm " . $test_partition_id . "\n", 5;
+    type_string "mkpart extended " . $partition_begin . " " . $partition_end . "\n", 5;
+    type_string "mkpart logical " . $test_fs_type . " " . $partition_begin . " " . $partition_cut_point . "\n", 5;
+    type_string "mkpart logical " . $test_fs_type . " " . $partition_cut_point . " " . $partition_end . "\n",   5;
+    #Following line for this: The resulting partition is not properly aligned for best performance.Ignore/Cancel?
+    type_string "Ignore\n";
+    type_string "quit\n";
+    $cmd = "parted -l -m 2>&1| awk -F \':\' \'{if(\$2 == \"$extendpartition_begin\" && \$3 != \"$extendpartition_end\") print \$1}\'";
+
+    # reset test partition number, because sometimes this id changed after mkpart
+    $test_partition_id = script_output($cmd, 10);
+    $test_partition = "/dev/vda" . $test_partition_id;
+
+    type_string "parted -l -m\n", 5;
+    my $scratch_partition_id = $test_partition_id + 1;
+    my $scratch_partition    = "/dev/vda" . $scratch_partition_id;
+
+    assert_script_run("mkfs." . $test_fs_type . " -f " . $test_partition);
+    assert_script_run("mkfs." . $test_fs_type . " -f " . $scratch_partition);
+
+    $self->dev_update_fstab($test_partition, $scratch_partition, $test_fs_type);
+    return ($test_partition, $scratch_partition, $test_fs_type);
+}
+
+# get_cut_point(begin, end, dev_num): find the suitable cut point between begin and end, and return the first cut point, unit: Mbit
+#   e.g. get_cut_point(21.1MB, 33.1MB, 6) will return 23.1
+sub get_cut_point() {
+    my $self = shift;
+    my ($begin, $end, $dev_num) = @_;
+    print "begin = $begin, end = $end, test and scratch device number = $dev_num\n";
+    unless ($dev_num =~ /[2-9]|[1-9]\d+/) {
+        die "The setting Device Number is $dev_num. It's not available, or not biger than 1\n";
+    }
+    if ($begin eq $end) {
+        die "No space for new partition, begin and end are same.\n";
+    }
+    $begin = $self->str_to_mb($begin);
+    $end   = $self->str_to_mb($end);
+    $begin + (1.0 * ($end - $begin) / $dev_num);
+}
+
+# str_to_mb(string): Change string to number, unit: Mbit, e.g: 2GB -> 2000
+sub str_to_mb() {
+    my $self = shift;
+    my $str  = shift;
+    print "str = $str\n";
+    my $result = "";
+    if ($str =~ /(\d+(\.\d+)?)kB/) {
+        print "result = $1\n";
+        $result = $1 / 1024;
+    }
+    elsif ($str =~ /(\d+(\.\d+)?)MB/) {
+        print "result = $1\n";
+        $result = $1;
+    }
+    elsif ($str =~ /(\d+(\.\d+)?)GB/) {
+        print "result = $1\n";
+        $result = $1 * 1024;
+    }
+    else {
+        die "Input not available in str_to_mb().";
+    }
+}
+
+# dev_update_fstab(test_partition, scratch_partition, test_fs_type): Add new partition into /etc/fstab, to solve problem when mount them
+sub dev_update_fstab() {
+    my $self = shift;
+    my ($test_partition, $scratch_partition, $test_fs_type) = @_;
+    assert_script_run("cat /etc/fstab");
+    my $cmd = "blkid " . $test_partition . " 2>&1| awk -F \'\"\' \'{print \$2}\'";
+    my $test_uuid = script_output($cmd, 10);
+    $cmd = "blkid " . $scratch_partition . " 2>&1| awk -F \'\"\' \'{print \$2}\'";
+    my $scratch_uuid = script_output($cmd, 10);
+    assert_script_run("sed -i '/home/d' /etc/fstab");
+    assert_script_run("sed -i '\$aUUID=$test_uuid /mnt/test " . $test_fs_type . " defaults 1 2' /etc/fstab");
+    assert_script_run("sed -i '\$aUUID=$scratch_uuid /mnt/scratch " . $test_fs_type . " defaults 1 2' /etc/fstab");
+    assert_script_run("cat /etc/fstab");
+}
+1;

--- a/tests/qa_automation/xfstests_install.pm
+++ b/tests/qa_automation/xfstests_install.pm
@@ -1,0 +1,86 @@
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+package xfstests_install;
+# Summary:  Package install and envirorment prepare related base class for xfstests_run
+# Maintainer: Yong Sun <yosun@suse.com>
+
+use strict;
+use warnings;
+use File::Basename;
+use base "opensusebasetest";
+use utils;
+use testapi qw(is_serial_terminal :DEFAULT);
+
+sub system_login {
+    my $self = shift;
+    $self->wait_boot;
+    if (get_var('VIRTIO_CONSOLE')) {
+        select_console('root-virtio-terminal');
+    }
+    else {
+        select_console('root-console');
+    }
+}
+
+# Add and refresh repos
+sub prepare_repo {
+    my $self           = shift;
+    my $qa_server_repo = get_var('QA_SERVER_REPO', '');
+    my $qa_sdk_repo    = get_var('QA_SDK_REPO', '');
+    pkcon_quit;
+    if ($qa_server_repo) {
+        # Remove all existing repos and add QA_SERVER_REPO
+        script_run('for ((i = $(zypper lr| tail -n+5 |wc -l); i >= 1; i-- )); do zypper -n rr $i; done; unset i', 300);
+        zypper_call("--no-gpg-check ar -f '$qa_server_repo' server-repo");
+        # Add QA_SDK_REPO if need
+        if ($qa_sdk_repo) {
+            zypper_call("--no-gpg-check ar -f '$qa_sdk_repo' sle-sdk");
+        }
+    }
+    my $qa_web_repo = get_var('QA_WEB_REPO', '');
+    if ($qa_web_repo) {
+        zypper_call("--no-gpg-check ar -f '$qa_web_repo' qa-web");
+    }
+    # sometimes updates.suse.com is busy, so we need to wait for possiblye retries
+    zypper_call("--gpg-auto-import-keys ref");
+}
+
+# Install xfstests from upstream git repo
+sub prepare_testpackage {
+    my $self = shift;
+    assert_script_run("cd /root/");
+    assert_script_run("zypper ref", 60);
+    assert_script_run(
+"zypper -n in git e2fsprogs automake gcc libuuid1 quota attr make xfsprogs libgdbm4 gawk uuid-runtime acl bc dump indent libtool lvm2 psmisc sed xfsdump libacl-devel libattr-devel libaio-devel libuuid-devel openssl-devel xfsprogs-devel",
+        60 * 10
+    );
+    assert_script_run("git clone git://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git", 60 * 10);
+    assert_script_run("cd xfstests-dev");
+    assert_script_run("make",         60 * 10);
+    assert_script_run("make install", 60 * 5);
+}
+
+# Prepare envirorment and all parameters for running xfstests (e.g. test_partition format as /dev/vda2)
+sub prepare_env {
+    my $self = shift;
+    my ($test_partition, $scratch_partition) = @_;
+    print("xfstests_install: test partition is $test_partition, scratch partition is $scratch_partition \n");
+    assert_script_run("useradd fsgqa");
+    assert_script_run("mkdir /home/fsgqa");
+    assert_script_run("groupadd fsgqa");
+    assert_script_run("usermod -g fsgqa fsgqa");
+    assert_script_run("mkdir /mnt/test /mnt/scratch");
+    assert_script_run("mount " . $test_partition . " /mnt/test");
+    assert_script_run("export TEST_DIR=/mnt/test");
+    assert_script_run("export TEST_DEV=" . $test_partition, 10);
+    assert_script_run("export SCRATCH_DIR=/mnt/scratch");
+    assert_script_run("export SCRATCH_DEV=" . $scratch_partition, 10);
+    assert_script_run("export SCRATCH_MNT=/mnt/scratch");
+}
+
+1;

--- a/tests/qa_automation/xfstests_logs.pm
+++ b/tests/qa_automation/xfstests_logs.pm
@@ -1,0 +1,27 @@
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+package xfstests_logs;
+# Summary:  Log upload and analysis related base class for xfstests_run
+# Maintainer: Yong Sun <yosun@suse.com>
+
+use strict;
+use warnings;
+use File::Basename;
+use base "opensusebasetest";
+use utils;
+use testapi qw(is_serial_terminal :DEFAULT);
+
+# Upload all log tarballs in ./results/
+sub log_upload() {
+    my $self    = shift;
+    my $tarball = "/tmp/qaset-xfstests-results.tar.bz2";
+    assert_script_run("tar jcvf " . $tarball . " ./results/");
+    upload_logs($tarball);
+}
+
+1;

--- a/tests/qa_automation/xfstests_run.pm
+++ b/tests/qa_automation/xfstests_run.pm
@@ -1,0 +1,50 @@
+# Copyright © 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary:  xfstests testsuite
+# Use the latest xfstests testsuite from upstream to make file system test
+# Maintainer: Yong Sun <yosun@suse.com>
+
+use base "xfstests_install";
+use base "xfstests_device";
+use base "xfstests_logs";
+use strict;
+use testapi;
+
+sub run() {
+    my $self = shift;
+    $self->system_login();
+    $self->prepare_repo();
+
+    #Split /home into many partitions
+    my ($test_partition, $scratch_partition, $test_fs_type) = $self->dev_create_partition();
+
+    #Install xfstests test package
+    $self->prepare_testpackage();
+
+    #Prepare envirorment and all parameters before run test
+    $self->prepare_env($test_partition, $scratch_partition);
+
+    #Modify obsoleted "hostname -s" to "hostname" in ./common/rc and ./common/config
+    script_run("sed -i \"s/hostname -s/hostname/\" ./common/rc");
+    script_run("sed -i \"s/hostname -s/hostname/\" ./common/config");
+
+    script_run("./check", 60 * 60 * 6);
+
+    # Upload all log tarballs in ./results/
+    $self->log_upload();
+}
+
+1;


### PR DESCRIPTION
The first version of xfstests in openQA.
- It follow the native upstream version of xfstests directly.
- It now only support test xfs, will include all the other filesystem in next version. (btrfs, ext4...)
- It requires /home partition exist, so please enable TOGGLEHOME=0
- The run process will split in the future. Now it need 3 and half hours(as my test) to run the default xfs test (including generic, share and xfs)

http://147.2.207.102/tests/1066