### PR TITLE
Do not soft-fail on partition warning CaaSP

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -118,7 +118,8 @@ sub run {
             $num_errors++;
         }
         elsif (match_has_tag('warning-pop-up')) {
-            if (check_screen('warning-partition-reduced', 0)) {
+            # Softfail only on sle, as timeout is there on CaaSP
+            if (check_var('DISTRI', 'sle') && check_screen('warning-partition-reduced', 0)) {
                 # See poo#19978, no timeout on partition warning, hence need to click OK button to soft-fail
                 record_soft_failure('bsc#1045470');
                 send_key $cmd{ok};


### PR DESCRIPTION
As part of [#3150](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3150) we added soft fail for partiotion warning because on SLE there is no timeout on it. Whereas, for CaaSP warning shown as expected with timeout. Add check to soft-fail only on SLE.