### PR TITLE
Remove SP2 update channel from autoyast profiles

### DIFF
--- a/data/autoyast_sle12sp2/bug-868614_autoinst.xml
+++ b/data/autoyast_sle12sp2/bug-868614_autoinst.xml
@@ -2,17 +2,6 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name> 
-      </listentry>
-    </add_on_products>
-  </add-on>
-
   <partitioning config:type="list">
     <drive>
       <device>/dev/sda</device>
@@ -102,12 +91,12 @@
   </timezone>
   <users config:type="list">
                 <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>  
+                   <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
                    <user_password>nots3cr3t</user_password>
                    <username>bernhard</username>
                 </user>
-                
+
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <fullname>root</fullname>

--- a/data/autoyast_sle12sp2/bug-870820_sles12.xml
+++ b/data/autoyast_sle12sp2/bug-870820_sles12.xml
@@ -8,17 +8,6 @@
 -->
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name> 
-      </listentry>
-    </add_on_products>
-  </add-on>
-
   <!-- Bootloader {{{ -->
   <bootloader>
     <global>
@@ -159,12 +148,12 @@
 	<partition>
           <mount>swap</mount>
           <size>auto</size>
-	  <partition_nr config:type="integer">2</partition_nr> 
+	  <partition_nr config:type="integer">2</partition_nr>
         </partition>
         <partition>
           <size>30%</size>
           <format config:type="boolean">false</format>
-	  <partition_nr config:type="integer">3</partition_nr> 
+	  <partition_nr config:type="integer">3</partition_nr>
         </partition>
         <partition>
           <mount>/</mount>
@@ -268,7 +257,7 @@
         systemctl enable sshd && systemctl start sshd
         ]]>
         </source>
-      </script> 
+      </script>
     </init-scripts>
   </scripts>
   <!-- }}} -->
@@ -354,12 +343,12 @@
   <!-- Users {{{ -->
   <users config:type="list">
                 <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>  
+                   <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
                    <user_password>nots3cr3t</user_password>
                    <username>bernhard</username>
                 </user>
-                
+
     <user>
       <fullname>root</fullname>
       <gid>0</gid>

--- a/data/autoyast_sle12sp2/bug-870998_installedSystem.xml
+++ b/data/autoyast_sle12sp2/bug-870998_installedSystem.xml
@@ -2,17 +2,6 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name> 
-      </listentry>
-    </add_on_products>
-  </add-on>
-
   <bootloader>
     <global>
       <boot_boot>false</boot_boot>
@@ -56,7 +45,7 @@
     </signature-handling>
   </general>
   <groups config:type="list">
-    
+
   </groups>
   <kdump>
     <add_crash_kernel config:type="boolean">true</add_crash_kernel>
@@ -101,7 +90,7 @@
     <interfaces config:type="list">
       <interface>
         <bootproto>dhcp</bootproto>
-        <device>eth0</device>        
+        <device>eth0</device>
         <startmode>onboot</startmode>
       </interface>
     </interfaces>
@@ -326,12 +315,12 @@ sed -i "s/PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_c
   </software>
   <users config:type="list">
                 <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>  
+                   <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
                    <user_password>nots3cr3t</user_password>
                    <username>bernhard</username>
                 </user>
-                
+
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <fullname>root</fullname>
@@ -347,6 +336,6 @@ sed -i "s/PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_c
       <user_password>nots3cr3t</user_password>
       <username>root</username>
     </user>
-    
+
   </users>
 </profile>

--- a/data/autoyast_sle12sp2/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle12sp2/bug-872532_ix64ph1069.xml
@@ -2,17 +2,6 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name>
-      </listentry>
-    </add_on_products>
-  </add-on>
-
   <bootloader>
     <global>
       <append> ${extra_cmdline} splash=silent quiet showopts crashkernel=164M-:82M</append>

--- a/data/autoyast_sle12sp2/bug-876411_sles12_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle12sp2/bug-876411_sles12_btrfs_h5_autoinst.xml
@@ -2,17 +2,6 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name>
-      </listentry>
-    </add_on_products>
-  </add-on>
-
 <!--
   <add-on>
     <add_on_products config:type="list">

--- a/data/autoyast_sle12sp2/bug-877438_ix64ph1029.xml
+++ b/data/autoyast_sle12sp2/bug-877438_ix64ph1029.xml
@@ -2,17 +2,6 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name> 
-      </listentry>
-    </add_on_products>
-  </add-on>
-
   <bootloader>
     <device_map config:type="list">
       <device_map_entry>
@@ -117,12 +106,12 @@
   </timezone>
   <users config:type="list">
                 <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>  
+                   <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
                    <user_password>nots3cr3t</user_password>
                    <username>bernhard</username>
                 </user>
-                
+
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <fullname>root</fullname>

--- a/data/autoyast_sle12sp2/bug-879147_autoinst.xml
+++ b/data/autoyast_sle12sp2/bug-879147_autoinst.xml
@@ -2,17 +2,6 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name> 
-      </listentry>
-    </add_on_products>
-  </add-on>
-
   <bootloader>
     <device_map config:type="list">
       <device_map_entry>
@@ -254,7 +243,7 @@
     <services config:type="list"/>
   </services-manager>
   <software>
-     
+
     <patterns config:type="list">
        <pattern>32bit</pattern>
        <pattern>Minimal</pattern>
@@ -289,12 +278,12 @@
   </user_defaults>
   <users config:type="list">
                 <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>  
+                   <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
                    <user_password>nots3cr3t</user_password>
                    <username>bernhard</username>
                 </user>
-                
+
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <fullname>root</fullname>

--- a/data/autoyast_sle12sp2/bug-881307_sles12.xml
+++ b/data/autoyast_sle12sp2/bug-881307_sles12.xml
@@ -8,17 +8,6 @@
 -->
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name> 
-      </listentry>
-    </add_on_products>
-  </add-on>
-
   <!-- Bootloader {{{ -->
   <bootloader>
     <global>
@@ -166,12 +155,12 @@
 	<partition>
           <mount>swap</mount>
           <size>auto</size>
-	  <partition_nr config:type="integer">2</partition_nr> 
+	  <partition_nr config:type="integer">2</partition_nr>
         </partition>
         <partition>
           <size>30%</size>
           <format config:type="boolean">false</format>
-	  <partition_nr config:type="integer">3</partition_nr> 
+	  <partition_nr config:type="integer">3</partition_nr>
         </partition>
         <partition>
           <mount>/</mount>
@@ -275,7 +264,7 @@
         systemctl enable sshd && systemctl start sshd
         ]]>
         </source>
-      </script> 
+      </script>
     </init-scripts>
   </scripts>
   <!-- }}} -->
@@ -362,12 +351,12 @@
   <!-- Users {{{ -->
   <users config:type="list">
                 <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>  
+                   <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
                    <user_password>nots3cr3t</user_password>
                    <username>bernhard</username>
                 </user>
-                
+
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <fullname>root</fullname>

--- a/data/autoyast_sle12sp2/bug-887126_autoinst.xml
+++ b/data/autoyast_sle12sp2/bug-887126_autoinst.xml
@@ -2,17 +2,6 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name>
-      </listentry>
-    </add_on_products>
-  </add-on>
-
   <bootloader>
     <global>
       <append> resume=/dev/sda1 splash=silent quiet crashkernel=176M-:88M  showopts</append>

--- a/data/autoyast_sle12sp2/bug-887653_autoinst_jy-snapshot.xml
+++ b/data/autoyast_sle12sp2/bug-887653_autoinst_jy-snapshot.xml
@@ -2,17 +2,6 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name> 
-      </listentry>
-    </add_on_products>
-  </add-on>
-
   <firewall>
     <enable_firewall config:type="boolean">false</enable_firewall>
     <start_firewall config:type="boolean">false</start_firewall>
@@ -168,7 +157,7 @@
 		    [ '2000'  == "`get_qa_config hamsta_multicast_port`" ]   || different=1 ;
 		    [ ''  == "`get_qa_config hamsta_multicast_dev`" ]   || different=1 ;
 		    [ '2222'  == "`get_qa_config hamsta_client_port`" ]   || different=1 ;
-	
+
 		    if [ $different -eq 1 ] ; then
 		      echo '# This file contains custom configuration, that has beed used to install'  &gt; $file;
 		      echo '# this host. If you want to use default values for next installation, '   &gt;&gt; $file;
@@ -234,12 +223,12 @@
   </timezone>
   <users config:type="list">
                 <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>  
+                   <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
                    <user_password>nots3cr3t</user_password>
                    <username>bernhard</username>
                 </user>
-                
+
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <fullname>root</fullname>

--- a/data/autoyast_sle12sp2/bug-888296_autoinst.xml
+++ b/data/autoyast_sle12sp2/bug-888296_autoinst.xml
@@ -2,17 +2,6 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name>
-      </listentry>
-    </add_on_products>
-  </add-on>
-
   <audit-laf>
     <auditd>
       <action_mail_acct>root</action_mail_acct>
@@ -63,7 +52,7 @@
     <global>
       <append> console=ttyS0,115200 resume=/dev/sda3 splash=silent quiet crashkernel=176M-:88M  showopts</append>
       <append_failsafe>showopts apm=off noresume edd=off powersaved=off nohz=off highres=off processor.max_cstate=1 nomodeset x11failsafe crashkernel=176M-:88M</append_failsafe>
-      <default>SLES 12-SP2</default>
+      <default>SLES 12-SP3</default>
       <gfxbackground>/boot/grub2/themes/SLE/background.png</gfxbackground>
       <gfxmode>auto</gfxmode>
       <gfxtheme>/boot/grub2/themes/SLE/theme.txt</gfxtheme>

--- a/data/autoyast_sle12sp2/bug-892069_r3560008.xml
+++ b/data/autoyast_sle12sp2/bug-892069_r3560008.xml
@@ -2,17 +2,6 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
 
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name> 
-      </listentry>
-    </add_on_products>
-  </add-on>
-
   <bootloader>
     <global>
       <activate>false</activate>
@@ -538,12 +527,12 @@
   </user_defaults>
   <users config:type="list">
                 <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>  
+                   <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
                    <user_password>nots3cr3t</user_password>
                    <username>bernhard</username>
                 </user>
-                
+
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <fullname>maier</fullname>

--- a/data/autoyast_sle12sp2/dns.xml
+++ b/data/autoyast_sle12sp2/dns.xml
@@ -7,17 +7,6 @@
   - custom local zones
   - reverse dns mapping
 -->
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name> 
-      </listentry>
-    </add_on_products>
-  </add-on>
-
   <bootloader>
     <device_map config:type="list">
       <device_map_entry>
@@ -70,7 +59,7 @@
       <start_multipath config:type="boolean">false</start_multipath>
     </storage>
   </general>
-  
+
 
 <dns-server>
   <allowed_interfaces config:type="list"/>
@@ -768,7 +757,7 @@
     <messages>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-    <timeout config:type="integer">7</timeout> 
+    <timeout config:type="integer">7</timeout>
     </messages>
     <warnings>
       <log config:type="boolean">true</log>
@@ -823,12 +812,12 @@
   </user_defaults>
   <users config:type="list">
                 <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>  
+                   <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
                    <user_password>nots3cr3t</user_password>
                    <username>bernhard</username>
                 </user>
-                
+
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <fullname>user</fullname>

--- a/data/autoyast_sle12sp2/ftp.xml
+++ b/data/autoyast_sle12sp2/ftp.xml
@@ -6,16 +6,6 @@
   test it via script run by autoyast_verify.pm
   - default, anonymous access configuration
 -->
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name> 
-      </listentry>
-    </add_on_products>
-  </add-on>
 
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>
@@ -88,12 +78,12 @@
   </suse_register>
   <users config:type="list">
                 <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>  
+                   <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
                    <user_password>nots3cr3t</user_password>
                    <username>bernhard</username>
                 </user>
-                
+
           <user>
                       <encrypted config:type="boolean">false</encrypted>
                       <user_password>nots3cr3t</user_password>

--- a/data/autoyast_sle12sp2/http.xml
+++ b/data/autoyast_sle12sp2/http.xml
@@ -7,17 +7,6 @@
   - http and https setup
 -->
 
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name> 
-      </listentry>
-    </add_on_products>
-  </add-on>
-
   <general>
     <ask-list config:type="list"/>
     <mode>
@@ -206,7 +195,7 @@ Tmr9shvqBQKa2NyWfUBcct9hvmlrZD6fnc9a4+3nTxv3TJRwxBUc9Q==
             <OVERHEAD>#
 # Global configuration that will be applicable for all virtual hosts, unless
 # deleted here, or overriden elswhere.
-# 
+#
 
 </OVERHEAD>
             <VALUE>"/srv/www/htdocs"</VALUE>
@@ -259,13 +248,13 @@ Tmr9shvqBQKa2NyWfUBcct9hvmlrZD6fnc9a4+3nTxv3TJRwxBUc9Q==
           <listentry>
             <KEY>Alias</KEY>
             <OVERHEAD>
-# Aliases: aliases can be added as needed (with no limit). The format is 
+# Aliases: aliases can be added as needed (with no limit). The format is
 # Alias fakename realname
 #
 # Note that if you include a trailing / on fakename then the server will
 # require it to be present in the URL.  So "/icons" isn't aliased in this
-# example, only "/icons/".  If the fakename is slash-terminated, then the 
-# realname must also be slash terminated, and if the fakename omits the 
+# example, only "/icons/".  If the fakename is slash-terminated, then the
+# realname must also be slash terminated, and if the fakename omits the
 # trailing slash, the realname must also omit it.
 #
 # We include the /icons/ alias for FancyIndexed directory listings.  If you
@@ -450,12 +439,12 @@ Tmr9shvqBQKa2NyWfUBcct9hvmlrZD6fnc9a4+3nTxv3TJRwxBUc9Q==
   </suse_register>
   <users config:type="list">
                 <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>  
+                   <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
                    <user_password>nots3cr3t</user_password>
                    <username>bernhard</username>
                 </user>
-                
+
           <user>
                       <encrypted config:type="boolean">false</encrypted>
                       <user_password>nots3cr3t</user_password>

--- a/data/autoyast_sle12sp2/lvm.xml
+++ b/data/autoyast_sle12sp2/lvm.xml
@@ -6,16 +6,6 @@
   via script run by autoyast_verify.pm
   - test of root_lv on /
 -->
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name> 
-      </listentry>
-    </add_on_products>
-  </add-on>
 
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>
@@ -90,7 +80,7 @@
     <interfaces config:type="list">
       <interface>
         <bootproto>dhcp</bootproto>
-        <device>eth0</device>        
+        <device>eth0</device>
         <startmode>onboot</startmode>
       </interface>
     </interfaces>
@@ -126,12 +116,12 @@
   </software>
   <users config:type="list">
                 <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>  
+                   <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
                    <user_password>nots3cr3t</user_password>
                    <username>bernhard</username>
                 </user>
-                
+
           <user>
                       <encrypted config:type="boolean">false</encrypted>
                       <user_password>nots3cr3t</user_password>

--- a/data/autoyast_sle12sp2/sles12_autoinst_h1_btrfs.xml
+++ b/data/autoyast_sle12sp2/sles12_autoinst_h1_btrfs.xml
@@ -8,20 +8,9 @@
   init-scripts testing
   two disk devices
   gpt partitioning with btrfs filesystem on small size partitions
-  mount by device name  
-    
--->
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name> 
-      </listentry>
-    </add_on_products>
-  </add-on>
+  mount by device name
 
+-->
   <bootloader>
     <device_map config:type="list">
       <device_map_entry>
@@ -116,7 +105,7 @@
     <dns>
       <dhcp_hostname config:type="boolean">false</dhcp_hostname>
       <dhcp_resolv config:type="boolean">false</dhcp_resolv>
-      <searchlist config:type="list"> 
+      <searchlist config:type="list">
         <search>openqa.de</search>
         <search>openqa.de</search>
       </searchlist>
@@ -124,13 +113,13 @@
     <interfaces config:type="list">
       <interface>
         <bootproto>dhcp</bootproto>
-        <device>eth0</device>        
+        <device>eth0</device>
         <startmode>onboot</startmode>
       </interface>
     </interfaces>
     <routing>
-      <ip_forward config:type="boolean">false</ip_forward> 
-      <routes config:type="list"> 
+      <ip_forward config:type="boolean">false</ip_forward>
+      <routes config:type="list">
         <route>
           <destination>default</destination>
           <device>-</device>
@@ -348,12 +337,12 @@ ls -lsa /
   </software>
   <users config:type="list">
                 <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>  
+                   <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
                    <user_password>nots3cr3t</user_password>
                    <username>bernhard</username>
                 </user>
-                
+
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <fullname>root</fullname>
@@ -368,7 +357,7 @@ ls -lsa /
       <uid>0</uid>
       <user_password>nots3cr3t</user_password>
       <username>root</username>
-    </user> 
+    </user>
   </users>
   <sysconfig config:type="list">
     <sysconfig_entry>

--- a/data/autoyast_sle12sp2/sles12_autoinst_h3_xfs.xml
+++ b/data/autoyast_sle12sp2/sles12_autoinst_h3_xfs.xml
@@ -7,19 +7,8 @@
   post-scripts testing
   two disk devices
   gpt partitioning with xfs filesystem on small size partitions
-  mount by device name   
+  mount by device name
 -->
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name> 
-      </listentry>
-    </add_on_products>
-  </add-on>
-
   <bootloader>
     <global>
       <boot_boot>false</boot_boot>
@@ -107,7 +96,7 @@
     <dns>
       <dhcp_hostname config:type="boolean">false</dhcp_hostname>
       <dhcp_resolv config:type="boolean">false</dhcp_resolv>
-      <searchlist config:type="list"> 
+      <searchlist config:type="list">
         <search>pnt.de</search>
         <search>psn.de</search>
       </searchlist>
@@ -115,13 +104,13 @@
     <interfaces config:type="list">
       <interface>
         <bootproto>dhcp</bootproto>
-        <device>eth0</device>        
+        <device>eth0</device>
         <startmode>onboot</startmode>
       </interface>
     </interfaces>
     <routing>
-      <ip_forward config:type="boolean">false</ip_forward> 
-      <routes config:type="list"> 
+      <ip_forward config:type="boolean">false</ip_forward>
+      <routes config:type="list">
         <route>
           <destination>default</destination>
           <device>-</device>
@@ -296,12 +285,12 @@ sed -i "s/PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_c
   </software>
   <users config:type="list">
                 <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>  
+                   <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
                    <user_password>nots3cr3t</user_password>
                    <username>bernhard</username>
                 </user>
-                
+
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <fullname>root</fullname>
@@ -317,10 +306,10 @@ sed -i "s/PasswordAuthentication no/PasswordAuthentication yes/" /etc/ssh/sshd_c
       <user_password>nots3cr3t</user_password>
       <username>root</username>
     </user>
-    
+
   </users>
   <groups config:type="list">
-    
+
   </groups>
   <sysconfig config:type="list">
     <sysconfig_entry>

--- a/data/autoyast_sle12sp2/sles12_autoinst_h5_btrfs_uuid.xml
+++ b/data/autoyast_sle12sp2/sles12_autoinst_h5_btrfs_uuid.xml
@@ -11,18 +11,8 @@
   large xfs partition
   sorted fstab
   mount by uuid
-    
+
 -->
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name> 
-      </listentry>
-    </add_on_products>
-  </add-on>
 
   <bootloader>
     <global>
@@ -70,7 +60,7 @@
     </storage>
   </general>
   <groups config:type="list">
-    
+
   </groups>
   <host>
     <hosts config:type="list">
@@ -126,7 +116,7 @@
     <interfaces config:type="list">
       <interface>
         <bootproto>dhcp</bootproto>
-        <device>eth0</device>        
+        <device>eth0</device>
         <startmode>onboot</startmode>
       </interface>
     </interfaces>
@@ -264,7 +254,7 @@
       </partitions>
       <use>all</use>
     </drive>
-    
+
   </partitioning>
   <scripts>
     <post-scripts config:type="list">
@@ -422,12 +412,12 @@ ls -lsa /
   </timezone>
   <users config:type="list">
                 <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>  
+                   <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
                    <user_password>nots3cr3t</user_password>
                    <username>bernhard</username>
                 </user>
-                
+
     <user>
       <encrypted config:type="boolean">false</encrypted>
       <fullname>root</fullname>
@@ -443,6 +433,6 @@ ls -lsa /
       <user_password>nots3cr3t</user_password>
       <username>root</username>
     </user>
-    
+
   </users>
 </profile>

--- a/data/autoyast_sle12sp2/tftp.xml
+++ b/data/autoyast_sle12sp2/tftp.xml
@@ -6,17 +6,6 @@
   test it via script run by autoyast_verify.pm
   - default, anonymous access configuration
 -->
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url>http://download.suse.de/ibs/SUSE:/SLE-12-SP2:/Update/standard</media_url>
-        <product>SuSE-Linux-Updates</product>
-        <product_dir>/</product_dir>
-        <name>Updates</name> 
-      </listentry>
-    </add_on_products>
-  </add-on>
-
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>
   </deploy_image>
@@ -60,12 +49,12 @@ chmod 755 /srv/tftpboot
 
   <users config:type="list">
                 <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>  
+                   <fullname>Bernhard M. Wiedemann</fullname>
                    <encrypted config:type="boolean">false</encrypted>
                    <user_password>nots3cr3t</user_password>
                    <username>bernhard</username>
                 </user>
-                
+
           <user>
                       <encrypted config:type="boolean">false</encrypted>
                       <user_password>nots3cr3t</user_password>


### PR DESCRIPTION
It's unclear why it was added - and causes possibly problems in sp3 testing