### PR TITLE
CaaSP nodes are not auto-accepted anymore

### DIFF
--- a/tests/casp/stack_controller.pm
+++ b/tests/casp/stack_controller.pm
@@ -71,8 +71,13 @@ sub velum_bootstrap {
     barrier_wait "WORKERS_INSTALLED";
 
     # Staging workaround
-    if (check_screen('select-all-nodes', 3)) {
-        assert_and_click 'select-all-nodes';
+    if (check_screen('velum-bootstrap-accept-nodes', 3)) {
+        assert_and_click 'velum-bootstrap-accept-nodes';
+    }
+
+    # Staging workaround
+    if (check_screen('velum-bootstrap-select-nodes', 3)) {
+        assert_and_click 'velum-bootstrap-select-nodes';
     }
 
     # Calculate position of master node radio button


### PR DESCRIPTION
Requires: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/400
Fix for: https://openqa.suse.de/tests/1024838#step/stack_controller/32