### PR TITLE
Update w3m_https.pm: Visit www.google.com/ncr

### DIFF
--- a/tests/console/w3m_https.pm
+++ b/tests/console/w3m_https.pm
@@ -9,10 +9,10 @@
 
 # Case 1525204 - FIPS: w3m_https
 
-# G-Summary: Add w3m_https test case and fips test entry
+# Summary: Add w3m_https test case and fips test entry
 #    Add w3m_https.pm test case was located in console/w3m_https.pm
 #    Add w3m_https.pm test entry in load_fips_tests_web() in sle/main.pm
-# G-Maintainer: Ben Chou <bchou@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
 
 use base "consoletest";
 use strict;
@@ -25,7 +25,7 @@ sub run() {
     script_run("zypper --no-refresh se -it pattern fips");
 
     my %https_url = (
-        google => "https://www.google.com/",
+        google => "https://www.google.com/ncr",
         suse   => "https://www.suse.com/",
         OBS    => "https://build.opensuse.org/",
     );


### PR DESCRIPTION
Fix poo#20100: Avoid Getting Redirected to Country-Specific
Versions of Google, which would lead to needle mismatch in
w3m_https test.