### PR TITLE
Check and close Firefox tracking protection window: poo#19926

### DIFF
--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -19,17 +19,28 @@ use testapi;
 sub start_firefox() {
     x11_start_program("firefox https://html5test.com/index.html", 6, {valid => 1});
     # makes firefox as default browser
-    assert_screen [qw(firefox_default_browser firefox_readerview_window firefox-html5test)], 120;
-    if (check_screen('firefox_default_browser', 0)) {
+    assert_screen [qw(firefox_default_browser firefox_trackinfo firefox_readerview_window firefox-html5test)], 120;
+    if (match_has_tag('firefox_default_browser')) {
         wait_screen_change {
             assert_and_click 'firefox_default_browser_yes';
         };
     }
+
+    assert_screen [qw(firefox_trackinfo firefox_readerview_window firefox-html5test)];
+    # check for and close the tracking protection window
+    if (match_has_tag('firefox_trackinfo')) {
+        wait_screen_change {
+            assert_and_click 'firefox_trackinfo';
+            assert_and_click 'firefox_titlebar';    # workaround for bsc#1046005
+        };
+    }
+
     assert_screen [qw(firefox_readerview_window firefox-html5test)];
     # workaround for reader view , it grabed the focus than mainwindow
-    if (check_screen('firefox_readerview_window', 0)) {
+    if (match_has_tag('firefox_readerview_window')) {
         wait_screen_change {
             assert_and_click 'firefox_readerview_window';
+            assert_and_click 'firefox_titlebar';    # workaround for bsc#1046005
         };
     }
     assert_screen 'firefox-html5test';


### PR DESCRIPTION
With the latest update, firefox included a mini-window with tracking protection information, which covers the matching areas on the needles.

This workaround checks for the track protection window and closes it if it finds one.

Afterwards, the test clicks the top title bar to work around bsc#1046005.

Related issue: poo#19926

The test module passes on my machine:
SP1: http://dreamyhamster.suse.cz/tests/263#step/firefox/4
SP2: http://dreamyhamster.suse.cz/tests/265#step/firefox/4

Related needles will be submitted in a separate MR.