### PR TITLE
Handle multiple firefox popups upon start: poo#19926

### DIFF
--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -18,30 +18,25 @@ use testapi;
 
 sub start_firefox() {
     x11_start_program("firefox https://html5test.com/index.html", 6, {valid => 1});
-    # makes firefox as default browser
-    assert_screen [qw(firefox_default_browser firefox_trackinfo firefox_readerview_window firefox-html5test)], 120;
-    if (match_has_tag('firefox_default_browser')) {
-        wait_screen_change {
-            assert_and_click 'firefox_default_browser_yes';
-        };
-    }
-
-    assert_screen [qw(firefox_trackinfo firefox_readerview_window firefox-html5test)];
-    # check for and close the tracking protection window
-    if (match_has_tag('firefox_trackinfo')) {
-        wait_screen_change {
-            assert_and_click 'firefox_trackinfo';
-            assert_and_click 'firefox_titlebar';    # workaround for bsc#1046005
-        };
-    }
-
-    assert_screen [qw(firefox_readerview_window firefox-html5test)];
-    # workaround for reader view , it grabed the focus than mainwindow
-    if (match_has_tag('firefox_readerview_window')) {
-        wait_screen_change {
-            assert_and_click 'firefox_readerview_window';
-            assert_and_click 'firefox_titlebar';    # workaround for bsc#1046005
-        };
+    for (1 .. 3) {
+        assert_screen [qw(firefox_default_browser firefox_trackinfo firefox_readerview_window firefox-html5test)], 120;
+        if (match_has_tag('firefox_default_browser')) {
+            wait_screen_change {
+                assert_and_click 'firefox_default_browser_yes';
+            };
+        }
+        elsif (match_has_tag('firefox_trackinfo')) {
+            wait_screen_change {
+                assert_and_click 'firefox_trackinfo';
+                assert_and_click 'firefox_titlebar';    # workaround for bsc#1046005
+            };
+        }
+        elsif (match_has_tag('firefox_readerview_window')) {
+            wait_screen_change {
+                assert_and_click 'firefox_readerview_window';
+                assert_and_click 'firefox_titlebar';    # workaround for bsc#1046005
+            };
+        }
     }
     assert_screen 'firefox-html5test';
 }


### PR DESCRIPTION
Follow up on feedback for PR#3175.

Added a for loop into the test code to account for cases where multiple pop-up windows appear after each other (default, track info, reader view).

Did not manage to trigger such a case for a verification run because the windows seem to pop up pretty randomly, but the test passed on my machine on SP3:
http://dreamyhamster.suse.cz/tests/285#step/firefox/5

Related issue: poo#19926