### PR TITLE
Fix ftp autoyast profile

### DIFF
--- a/data/autoyast_sle12sp2/ftp.xml
+++ b/data/autoyast_sle12sp2/ftp.xml
@@ -43,7 +43,7 @@
     <SSLEnable>NO</SSLEnable>
     <SSLv2>NO</SSLv2>
     <SSLv3>NO</SSLv3>
-    <StartDaemon>2</StartDaemon>
+    <StartDaemon>0</StartDaemon>
     <StartXinetd>YES</StartXinetd>
     <TLS>YES</TLS>
     <Umask/>


### PR DESCRIPTION
poo#17366
xinetd and vsftpd were fighting for same port as both were configured to start

fail: https://openqa.suse.de/tests/1026186#step/autoyast_verify/7
test: My multimachine is broken, but I tested it manually http://paste.opensuse.org/91262fb0