### PR TITLE
Fix the broken network in autoyast stage 2

### DIFF
--- a/data/autoyast_sle12sp2/bug-888296_autoinst.xml
+++ b/data/autoyast_sle12sp2/bug-888296_autoinst.xml
@@ -1197,7 +1197,6 @@
       </interface>
     </interfaces>
     <ipv6 config:type="boolean">true</ipv6>
-    <keep_install_network config:type="boolean">false</keep_install_network>
     <managed config:type="boolean">false</managed>
     <routing>
       <ipv4_forward config:type="boolean">false</ipv4_forward>


### PR DESCRIPTION
This change in the AY profile fixes a broken stage 2 installation.
The profile was most likely generated with SP1 and the test only ever worked because of a bug in autoyast which was present until SP2 (first paragraph in https://github.com/yast/yast-autoinstallation/blob/master/doc/network_scenarios.md) and caused yast to ignore "keep_install_network". Since this bug was fixed, the installer in stage 2 was not any longer capable of connecting to the network.

Since the change in the behavior is already documented and also kind of addressed in https://www.suse.com/es-es/support/kb/doc/?id=7018401 IMHO we don't have to worry about costumers who still use such a profile.

Verification is that the job is capable of reaching this step: http://openqa.glados.qa.suse.de/tests/164#step/installation/11