### PR TITLE
Add new template selection window to impress start

### DIFF
--- a/tests/x11regressions/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_mainmenu_components.pm
@@ -74,6 +74,8 @@ sub run() {
 
     $self->open_mainmenu();
     assert_and_click 'mainmenu-office-impress';    #open impress
+    assert_screen 'ooimpress-select-a-template';
+    send_key "alt-f4";                             #close template window
     assert_screen 'ooimpress-launched';
     send_key "ctrl-q";                             #close impress
 
@@ -107,6 +109,8 @@ sub run() {
     type_string "impress";                         #open impress
     assert_screen 'overview-office-impress';
     send_key "ret";
+    assert_screen 'ooimpress-select-a-template';
+    send_key "alt-f4";                             #close template window
     assert_screen 'ooimpress-launched';
     send_key "ctrl-q";                             #close impress
 


### PR DESCRIPTION
Code was updated for new needle with template selection during the impress start. 

Verification:
http://pc-pha-base-1.suse.cz/tests/848#step/libreoffice_mainmenu_components/1

Related needles:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/405