### PR TITLE
Remove xen-tools-domU from packages to install due to conflict

### DIFF
--- a/tests/qam-minimal/install_patterns.pm
+++ b/tests/qam-minimal/install_patterns.pm
@@ -31,7 +31,7 @@ sub install_packages {
 
     # loop over packages in patchinfo and try installation
     foreach my $line (split(/\n/, $patch_info)) {
-        if (my ($package) = $line =~ $pattern) {
+        if (my ($package) = $line =~ $pattern and $line !~ "xen-tools-domU") {
             zypper_call("in $package");
             save_screenshot;
         }


### PR DESCRIPTION
During xen installation, there is an installation conflict between the xen-tools and xen-tools-domU packages. These packages cannot be installed together.

Upon attempting to install both packages on the same system, zypper requires the user to make a decision and resolve it manually, therefore failing on OpenQA.

This change excludes the -domU package from packages to install and only leaves xen-tools, thus avoiding the conflict.

Tests now passing on my machine:
SP2: http://dreamyhamster.suse.cz/tests/303
SP1: http://dreamyhamster.suse.cz/tests/313#step/install_patterns/32
GA: http://dreamyhamster.suse.cz/tests/314#step/install_patterns/37

Related issue: https://progress.opensuse.org/issues/18840