### PR TITLE
serial_terminal: Export serial_term_prompt

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -17,8 +17,10 @@ use Exporter;
 use bmwqemu ();
 
 BEGIN {
-    our @EXPORT = qw($serial_term_prompt login);
+    our @EXPORT = qw(serial_term_prompt login);
 }
+
+our $serial_term_prompt;
 
 =head2 login
 
@@ -30,8 +32,10 @@ escape sequences (i.e. a single #) and changes the terminal width.
 =cut
 sub login {
     die 'Login expects two arguments' unless @_ == 2;
-    my ($user, $serial_term_prompt) = @_;
+    my $user   = shift;
     my $escseq = qr/(\e [\(\[] [\d\w]{1,2})/x;
+
+    $serial_term_prompt = shift;
 
     bmwqemu::log_call;
 
@@ -49,6 +53,10 @@ sub login {
     # TODO: Send 'tput rmam' instead/also
     assert_script_run('stty cols 2048');
     assert_script_run('echo Logged into $(tty)', $bmwqemu::default_timeout, result_title => 'vconsole_login');
+}
+
+sub serial_term_prompt {
+    return $serial_term_prompt;
 }
 
 1;

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -458,7 +458,7 @@ EOF
         }
 
         if (is_serial_terminal) {
-            wait_serial($serial_term_prompt, undef, 0, no_regex => 1);
+            wait_serial(serial_term_prompt(), undef, 0, no_regex => 1);
             type_string($cmd_text);
             wait_serial($cmd_text, undef, 0, no_regex => 1);
             type_string("\n");


### PR DESCRIPTION
The $serial_term_prompt variable was moved to the distribution object, so we
have to re-export it from serial terminal library.