### PR TITLE
Remove variable expansion from sle12+support server

### DIFF
--- a/data/autoyast_sle12sp2/init_script.sh
+++ b/data/autoyast_sle12sp2/init_script.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+set -x
+echo "This is an AutoYaST init script test logfile" >/var/log/autoyast_init_script.log || exit 1
+exit 0

--- a/data/autoyast_sle12sp2/sles12.xml
+++ b/data/autoyast_sle12sp2/sles12.xml
@@ -1,0 +1,878 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <bootloader>
+    <device_map config:type="list">
+      <device_map_entry>
+        <firmware>hd0</firmware>
+        <linux>/dev/vda</linux>
+      </device_map_entry>
+    </device_map>
+    <global>
+      <activate>true</activate>
+      <default>openSUSE 13.1</default>
+      <generic_mbr>true</generic_mbr>
+      <lines_cache_id>2</lines_cache_id>
+      <timeout config:type="integer">8</timeout>
+      <append>elevator=noop</append>
+    </global>
+    <loader_type>grub2</loader_type>
+    <sections config:type="list">
+      <section>
+        <append>resume=/dev/vda1 splash=silent quiet showopts</append>
+        <image>/boot/vmlinuz-3.11.3-1-desktop</image>
+        <lines_cache_id>0</lines_cache_id>
+        <menuentry>openSUSE 13.1</menuentry>
+        <name>openSUSE 13.1</name>
+        <root>/dev/vda2</root>
+        <type>image</type>
+        <usage>Linux</usage>
+      </section>
+      <section>
+        <append>showopts apm=off noresume nosmp maxcpus=0 edd=off powersaved=off nohz=off highres=off processor.max_cstate=1 nomodeset x11failsafe</append>
+        <image>(hd0,1)/boot/vmlinuz-2.6.37.1-1.2-default</image>
+        <initrd>(hd0,1)/boot/initrd-2.6.37.1-1.2-default</initrd>
+        <lines_cache_id>1</lines_cache_id>
+        <name>Failsafe -- openSUSE 11.4 - 2.6.37.1-1.2</name>
+        <original_name>failsafe</original_name>
+        <root>/dev/vda2</root>
+        <type>image</type>
+      </section>
+    </sections>
+  </bootloader>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel config:type="list">
+      <listentry>72M,low</listentry>
+      <listentry>32M,high</listentry>
+    </crash_kernel>
+    <general>
+      <KDUMP_COMMANDLINE/>
+      <KDUMP_COMMANDLINE_APPEND/>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>10</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_KERNELVER/>
+      <KDUMP_NOTIFICATION_CC/>
+      <KDUMP_NOTIFICATION_TO/>
+      <KDUMP_SAVEDIR>/var/crash</KDUMP_SAVEDIR>
+      <KDUMP_SMTP_PASSWORD/>
+      <KDUMP_SMTP_SERVER/>
+      <KDUMP_SMTP_USER/>
+      <KDUMP_TRANSFER/>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+      <KEXEC_OPTIONS/>
+    </general>
+  </kdump>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <ntp_sync_time_before_installation>ntp.suse.de</ntp_sync_time_before_installation>
+    </mode>
+    <signature-handling>
+      <accept_unknown_gpg_key>
+        <all config:type="boolean">true</all>
+      </accept_unknown_gpg_key>
+    </signature-handling>
+  </general>
+
+  <scripts>
+
+    <pre-scripts config:type="list">
+      <script>
+        <filename>1_prescript.sh</filename>
+        <interpreter>shell</interpreter>
+        <location/>
+        <feedback config:type="boolean">false</feedback>
+        <feedback_type>error</feedback_type>
+        <source><![CDATA[#!/bin/sh
+BASE='/root/userscripts'
+STR="1:prescript:"
+ST='clean'
+RES=`fdisk -l | grep -E '^/dev/vda'`
+if [ -n "$RES" ];then
+   STR=$STR'partition already defined:'
+   ST='exist'
+else
+   STR=$STR'not yet mounted:'
+fi
+STR=$STR$ST
+mkdir $BASE
+echo $STR
+echo $STR > $BASE/userscr.log
+#cp /tmp/1_prescript.sh $BASE
+        ]]></source>
+      </script>
+      <script>
+        <filename>1b_prescript_remote.sh</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[#!/bin/sh
+STR="1b:prescript-remote:ok"
+BASE='/root/userscripts'
+echo $STR
+echo $STR >> $BASE/userscr.log
+        ]]></source>
+        <feedback config:type="boolean">false</feedback>
+	<feedback_type>error</feedback_type>
+      </script>
+    </pre-scripts>
+
+    <post-scripts config:type="list">
+      <script>
+        <filename>yast_clone.sh</filename>
+        <interpreter>shell</interpreter>
+        <location/>
+        <feedback config:type="boolean">false</feedback>
+        <source><![CDATA[#!/bin/sh
+mv /var/run/zypp.pid /var/run/zypp.sav
+test -f /root/autoinst.xml && rm /root/autoinst.xml
+yast clone_system
+mv /var/run/zypp.sav /var/run/zypp.pid
+        ]]></source>
+      </script>
+      <script>
+        <filename>post-script.sh</filename>
+        <interpreter>shell</interpreter>
+        <location/>
+        <feedback config:type="boolean">false</feedback>
+        <source><![CDATA[#!/bin/sh
+chmod 755 /srv/tftpboot
+        ]]></source>
+      </script>
+      <script>
+        <filename>4_post.sh</filename>
+        <interpreter>shell</interpreter>
+        <location/>
+        <feedback config:type="boolean">false</feedback>
+	<feedback_type>error</feedback_type>
+        <source><![CDATA[#!/bin/sh
+STR="4:postinstall:"
+ST='ok'
+BASE='/root/userscripts'
+if [ -e /rebootflag ];then
+  STR=$STR' no final reboot!:'
+  ST='fail'
+else
+  STR=$STR'reboot detected:'
+fi
+STR=$STR$ST
+echo $STR
+echo $STR >> $BASE/userscr.log
+#cp /tmp/4_post.sh $BASE
+ls -l $BASE
+        ]]></source>
+        <network_needed config:type="boolean">false</network_needed>
+      </script>
+    </post-scripts>
+
+    <postpartitioning-scripts config:type="list">
+      <script>
+        <filename>2_postpartitioning.sh</filename>
+        <interpreter>shell</interpreter>
+        <location/>
+        <feedback config:type="boolean">false</feedback>
+	<feedback_type>error</feedback_type>
+        <source><![CDATA[#!/bin/sh
+STR="2:postpartitioning:"
+ST='ok'
+BASE='/root/userscripts'
+RES=`df -T /dev/vda2 | grep -E '^/dev' | sed -r 's@.*\s+(.*)$@\1@'`
+STR=$STR"sda2 mounted on "$RES":"
+if [ "$RES" != '/mnt' ];then
+   STR=$STR"invalid mountpoint!:"
+   ST='fail'
+fi
+RES=`chroot /mnt rpm -qa | wc -l`
+STR=$STR"rpm count "$RES":"
+if [ "$RES" -ne '0' ];then
+   STR=$STR' rpms already installed!:'
+   ST='fail'
+fi
+STR=$STR$ST
+echo $STR
+echo $STR >> $BASE/userscr.log
+#cp /tmp/2_postpartitioning.sh $BASE
+        ]]></source>
+      </script>
+    </postpartitioning-scripts>
+
+    <chroot-scripts config:type="list">
+      <script>
+        <filename>3_chroot.sh</filename>
+        <interpreter>shell</interpreter>
+        <location/>
+        <feedback config:type="boolean">false</feedback>
+	<feedback_type>error</feedback_type>
+        <source><![CDATA[#!/bin/sh
+STR="3:chroot:"
+ST='ok'
+BASE='/root/userscripts'
+if chroot /mnt rpm -q glibc ;then
+  STR=$STR' glibc installed:'
+else
+  STR=$STR' glibc not installed!:'
+  ST='fail'
+fi
+STR=$STR$ST
+echo $STR
+echo $STR >> $BASE/userscr.log
+touch /rebootflag
+#cp /tmp/3_chroot.sh $BASE
+ls -l $BASE
+mv $BASE /mnt/$BASE
+ls -l /mnt/$BASE
+        ]]></source>
+      <chrooted config:type="boolean">false</chrooted>
+
+      </script>
+    </chroot-scripts>
+
+    <init-scripts config:type="list">
+      <script>
+        <filename>init_download.sh</filename>
+        <interpreter>shell</interpreter>
+        <location><![CDATA[http://10.0.2.1/data/autoyast_sle12sp2/init_script.sh]]></location>
+      </script>
+      <script>
+        <filename>init_ssh.sh</filename>
+        <chrooted config:type="boolean">true</chrooted>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+  chkconfig sshd on
+  rcsshd start
+]]></source>
+      </script>
+      <script>
+        <filename>5_post.sh</filename>
+        <interpreter>shell</interpreter>
+        <location/>
+        <feedback config:type="boolean">false</feedback>
+        <feedback_type>error</feedback_type>
+        <source><![CDATA[#!/bin/sh
+      STR="5:init:"
+      PARENT='/usr/lib/YaST2/bin/autoyast-initscripts.sh'
+      BASE='/root/userscripts'
+      PPIDNAME=`ps -p $PPID -fh -o cmd`
+      STR=$STR"started by: $PPID = $PPIDNAME:"
+      BPPIDNAME=`echo "$PPIDNAME" | sed -r s'@^(.*)\s@@'`
+      ST='ok'
+      if [ "$PARENT" != "$BPPIDNAME" ];then
+        STR=$STR':incorrect parent:'
+        ST='fail'
+      else
+        STR=$STR':parent correct:'
+      fi
+      STR=$STR$ST
+      echo $STR
+      echo $STR >> $BASE/userscr.log
+      ls -l $BASE
+      ]]></source>
+        <network_needed config:type="boolean">false</network_needed>
+      </script>
+
+    </init-scripts>
+  </scripts>
+
+<dns-server>
+  <allowed_interfaces config:type="list"/>
+  <chroot>1</chroot>
+  <logging config:type="list"/>
+  <options config:type="list">
+    <option>
+      <key>directory</key>
+      <value>"/var/lib/named"</value>
+    </option>
+    <option>
+      <key>disable-empty-zone</key>
+      <value>"1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.IP6.ARPA"</value>
+    </option>
+    <option>
+      <key>dump-file</key>
+      <value>"/var/log/named_dump.db"</value>
+    </option>
+    <option>
+      <key>include</key>
+      <value>"/etc/named.d/forwarders.conf"</value>
+    </option>
+    <option>
+      <key>listen-on-v6</key>
+      <value>{ any; }</value>
+    </option>
+    <option>
+      <key>managed-keys-directory</key>
+      <value>"/var/lib/named/dyn/"</value>
+    </option>
+    <option>
+      <key>notify</key>
+      <value>no</value>
+    </option>
+    <option>
+      <key>statistics-file</key>
+      <value>"/var/log/named.stats"</value>
+    </option>
+    <option>
+      <key>forwarders</key>
+      <value/>
+    </option>
+  </options>
+  <start_service>1</start_service>
+  <use_ldap>0</use_ldap>
+  <zones config:type="list">
+    <listentry>
+      <file>root.hint</file>
+      <options config:type="list">
+	<option>
+	  <key>type</key>
+	  <value>hint</value>
+	</option>
+	<option>
+	  <key>file</key>
+	  <value>"root.hint"</value>
+	</option>
+      </options>
+      <type>hint</type>
+      <zone>.</zone>
+    </listentry>
+    <listentry>
+      <file>localhost.zone</file>
+      <options config:type="list">
+	<option>
+	  <key>type</key>
+	  <value>master</value>
+	</option>
+	<option>
+	  <key>file</key>
+	  <value>"localhost.zone"</value>
+	</option>
+      </options>
+      <records config:type="list">
+	<listentry>
+	  <key>localhost.</key>
+	  <type>NS</type>
+	  <value>@</value>
+	</listentry>
+	<listentry>
+	  <key>localhost.</key>
+	  <type>A</type>
+	  <value>127.0.0.1</value>
+	</listentry>
+	<listentry>
+	  <key>cx01</key>
+	  <type>A</type>
+	  <value>127.0.0.10</value>
+	</listentry>
+	<listentry>
+	  <key>cx01</key>
+	  <type>AAAA</type>
+	  <value>::1</value>
+	</listentry>
+      </records>
+      <soa>
+	<expiry>6W</expiry>
+	<mail>root</mail>
+	<minimum>1W</minimum>
+	<refresh>2D</refresh>
+	<retry>4H</retry>
+	<serial>42</serial>
+	<server>@</server>
+	<zone>@</zone>
+      </soa>
+      <this_zone_had_NS_record_at_start>1</this_zone_had_NS_record_at_start>
+      <ttl>1W</ttl>
+      <type>master</type>
+      <zone>localhost</zone>
+    </listentry>
+    <listentry>
+      <file>127.0.0.zone</file>
+      <options config:type="list">
+	<option>
+	  <key>type</key>
+	  <value>master</value>
+	</option>
+	<option>
+	  <key>file</key>
+	  <value>"127.0.0.zone"</value>
+	</option>
+      </options>
+      <records config:type="list">
+	<listentry>
+	  <key>0.0.127.in-addr.arpa.</key>
+	  <type>NS</type>
+	  <value>localhost.</value>
+	</listentry>
+	<listentry>
+	  <key>1</key>
+	  <type>PTR</type>
+	  <value>localhost.</value>
+	</listentry>
+      </records>
+      <soa>
+	<expiry>6W</expiry>
+	<mail>root.localhost.</mail>
+	<minimum>1W</minimum>
+	<refresh>2D</refresh>
+	<retry>4H</retry>
+	<serial>42</serial>
+	<server>localhost.</server>
+	<zone>@</zone>
+      </soa>
+      <this_zone_had_NS_record_at_start>1</this_zone_had_NS_record_at_start>
+      <ttl>1W</ttl>
+      <type>master</type>
+      <zone>0.0.127.in-addr.arpa</zone>
+    </listentry>
+    <listentry>
+      <file>127.0.0.zone</file>
+      <options config:type="list">
+	<option>
+	  <key>type</key>
+	  <value>master</value>
+	</option>
+	<option>
+	  <key>file</key>
+	  <value>"127.0.0.zone"</value>
+	</option>
+      </options>
+      <records config:type="list">
+	<listentry>
+	  <key>0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa.</key>
+	  <type>NS</type>
+	  <value>localhost.</value>
+	</listentry>
+	<listentry>
+	  <key>1</key>
+	  <type>PTR</type>
+	  <value>localhost.</value>
+	</listentry>
+      </records>
+      <soa>
+	<expiry>6W</expiry>
+	<mail>root.localhost.</mail>
+	<minimum>1W</minimum>
+	<refresh>2D</refresh>
+	<retry>4H</retry>
+	<serial>42</serial>
+	<server>localhost.</server>
+	<zone>@</zone>
+      </soa>
+      <this_zone_had_NS_record_at_start>1</this_zone_had_NS_record_at_start>
+      <ttl>1W</ttl>
+      <type>master</type>
+      <zone>0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa</zone>
+    </listentry>
+    <listentry>
+      <file>master/openqa.local</file>
+      <options config:type="list">
+	<option>
+	  <key>allow-transfer</key>
+	  <value>{ any; }</value>
+	</option>
+	<option>
+	  <key>file</key>
+	  <value>"master/openqa.local"</value>
+	</option>
+	<option>
+	  <key>type</key>
+	  <value>master</value>
+	</option>
+      </options>
+      <records config:type="list">
+	<listentry>
+	  <key>openqa.local.</key>
+	  <type>NS</type>
+	  <value>dns</value>
+	</listentry>
+	<listentry>
+	  <key>dns</key>
+	  <type>A</type>
+	  <value>127.0.0.1</value>
+	</listentry>
+	<listentry>
+	  <key>qahost</key>
+	  <type>A</type>
+	  <value>172.16.0.1</value>
+	</listentry>
+	<listentry>
+	  <key>cr01</key>
+	  <type>A</type>
+	  <value>172.16.0.10</value>
+	</listentry>
+	<listentry>
+	  <key>cr02</key>
+	  <type>A</type>
+	  <value>172.16.0.11</value>
+	</listentry>
+	<listentry>
+	  <key>crA</key>
+	  <type>CNAME</type>
+	  <value>cr02</value>
+	</listentry>
+	<listentry>
+	  <key>cr03</key>
+	  <type>A</type>
+	  <value>172.16.0.12</value>
+	</listentry>
+	<listentry>
+	  <key>crb</key>
+	  <type>CNAME</type>
+	  <value>cr01</value>
+	</listentry>
+	<listentry>
+	  <key>crA2</key>
+	  <type>CNAME</type>
+	  <value>crA</value>
+	</listentry>
+	<listentry>
+	  <key>crA3</key>
+	  <type>CNAME</type>
+	  <value>crA2</value>
+	</listentry>
+	<listentry>
+	  <key>crx</key>
+	  <type>CNAME</type>
+	  <value>crA</value>
+	</listentry>
+      </records>
+      <soa>
+	<expiry>1w</expiry>
+	<mail>root</mail>
+	<minimum>1d</minimum>
+	<refresh>3h</refresh>
+	<retry>1h</retry>
+	<serial>2014092500</serial>
+	<server>@</server>
+	<zone>@</zone>
+      </soa>
+      <this_zone_had_NS_record_at_start>1</this_zone_had_NS_record_at_start>
+      <ttl>2d</ttl>
+      <type>master</type>
+      <zone>openqa.local</zone>
+    </listentry>
+    <listentry>
+      <file>master/0.16.172.in-addr.arpa</file>
+      <options config:type="list">
+	<option>
+	  <key>allow-transfer</key>
+	  <value>{ any; }</value>
+	</option>
+	<option>
+	  <key>file</key>
+	  <value>"master/0.16.172.in-addr.arpa"</value>
+	</option>
+	<option>
+	  <key>type</key>
+	  <value>master</value>
+	</option>
+      </options>
+      <records config:type="list">
+	<listentry>
+	  <key>0.16.172.in-addr.arpa.</key>
+	  <type>NS</type>
+	  <value>dns.openqa.local.</value>
+	</listentry>
+	<listentry>
+	  <key>1.0.16.172.in-addr.arpa.</key>
+	  <type>PTR</type>
+	  <value>qahost.</value>
+	</listentry>
+	<listentry>
+	  <key>10.0.16.172.in-addr.arpa.</key>
+	  <type>PTR</type>
+	  <value>cr01.openqa.local.</value>
+	</listentry>
+	<listentry>
+	  <key>11.0.16.172.in-addr.arpa.</key>
+	  <type>PTR</type>
+	  <value>cr02.openqa.local.</value>
+	</listentry>
+	<listentry>
+	  <key>12.0.16.172.in-addr.arpa.</key>
+	  <type>PTR</type>
+	  <value>cr03.openqa.local.</value>
+	</listentry>
+      </records>
+      <soa>
+	<expiry>1W</expiry>
+	<mail>1341414.</mail>
+	<minimum>1D</minimum>
+	<refresh>3H</refresh>
+	<retry>1H</retry>
+	<serial>2014092500</serial>
+	<server>xtest.</server>
+	<zone>@</zone>
+      </soa>
+      <this_zone_had_NS_record_at_start>1</this_zone_had_NS_record_at_start>
+      <ttl>2D</ttl>
+      <type>master</type>
+      <zone>0.16.172.in-addr.arpa</zone>
+    </listentry>
+  </zones>
+</dns-server>
+
+
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id></dhclient_client_id>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>vagrantup.com</domain>
+      <hostname>vagrant-sles12</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <searchlist config:type="list">
+        <search>vagrantup.com</search>
+      </searchlist>
+      <write_hostname config:type="boolean">true</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <name>82540EM Gigabit Ethernet Controller</name>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+  </networking>
+  <tftp-server>
+    <start_tftpd config:type="boolean">true</start_tftpd>
+    <tftp_directory>/srv/tftpboot</tftp_directory>
+  </tftp-server>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/vda</device>
+      <disklabel>msdos</disklabel>
+      <enable_snapshots config:type="boolean">true</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>swap</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>auto</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">3</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>500G</size>
+          <subvolumes config:type="list">
+            <listentry>boot/grub2/i386-pc</listentry>
+            <listentry>boot/grub2/x86_64-efi</listentry>
+            <listentry>home</listentry>
+            <listentry>opt</listentry>
+            <listentry>srv</listentry>
+            <listentry>tmp</listentry>
+            <listentry>usr/local</listentry>
+            <listentry>var/crash</listentry>
+            <listentry>var/lib/mailman</listentry>
+            <listentry>var/lib/named</listentry>
+            <listentry>var/log</listentry>
+            <listentry>var/opt</listentry>
+            <listentry>var/spool</listentry>
+            <listentry>var/tmp</listentry>
+            <listentry> <!-- subvolume not created by default -->
+              <path>var/lib/nocow</path>
+              <copy_on_write config:type="boolean">false</copy_on_write>
+            </listentry>
+            <listentry> <!-- redefine a subvolume created as nocow by default -->
+              <path>var/lib/pgsql</path>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+            </listentry>
+          </subvolumes>
+        </partition>
+      </partitions>
+      <pesize/>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <!-- We expect error messages during installation. We will 'grep' for them. -->
+      <timeout config:type="integer">5</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">5</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <!-- We expect warnings during installation. We will 'grep' for them. -->
+      <timeout config:type="integer">5</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">5</timeout>
+    </yesno_messages>
+  </report>
+  <software>
+    <install_recommended config:type="boolean">false</install_recommended>
+    <packages config:type="list">
+      <package>aaa_base</package>
+      <package>bash</package>
+      <package>coreutils</package>
+      <package>cracklib-dict-full</package>
+      <package>device-mapper</package>
+      <package>e2fsprogs</package>
+      <package>elfutils</package>
+      <package>filesystem</package>
+      <package>gcc</package>
+      <package>glibc</package>
+      <package>grub2</package>
+      <package>initviocons</package>
+      <package>insserv</package>
+      <package>iputils</package>
+      <package>kbd</package>
+      <package>kernel-default</package>
+      <package>less</package>
+      <package>libxml2-tools</package>
+      <package>login</package>
+      <package>mkinitrd</package>
+      <package>module-init-tools</package>
+      <package>ncurses-utils</package>
+      <package>openssh</package>
+      <package>pam</package>
+      <package>pam-modules</package>
+      <package>procps</package>
+      <package>pwdutils</package>
+      <package>rpcbind</package>
+      <package>rpm</package>
+      <package>sudo</package>
+      <package>sysconfig</package>
+      <package>tar</package>
+      <package>timezone</package>
+      <package>vim</package>
+      <package>vim-base</package>
+      <package>w3m</package>
+      <package>zypper</package>
+      <package>rsync</package>
+      <package>ca-certificates-mozilla</package>
+      <package>glibc-locale</package>
+      <package>yast2-kdump</package>
+      <package>yast2-network</package>
+      <package>yast2-users</package>
+      <package>cronie</package>
+      <package>xinetd</package>
+      <package>tftp</package>
+      <package>bind</package>
+      <package>SuSEfirewall2</package>
+    </packages>
+    <post-packages config:type="list">
+      <package>bind</package>
+      <package>dummy-package</package>
+    </post-packages>
+    <patterns config:type="list">
+      <pattern>Minimal</pattern>
+      <pattern>base</pattern>
+    </patterns>
+    <remove-packages config:type="list">
+      <package>libyui-gtk-pkg5</package>
+      <package>libyui-gtk5</package>
+      <package>Mesa</package>
+      <package>libcairo2</package>
+      <package>libgtk-3-0</package>
+      <package>gtk3-tools</package>
+      <package>libpango-1_0-0</package>
+      <package>libcairo-gobject2</package>
+      <package>pango-tools</package>
+      <package>subversion</package>
+      <package>tk</package>
+      <package>libXft2</package>
+      <package>libtool</package>
+      <package>fontconfig</package>
+      <package>gitk</package>
+      <package>git-gui</package>
+    </remove-packages>
+  </software>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>vagrant</fullname>
+      <gid>100</gid>
+      <home>/home/vagrant</home>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>vagrant</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>suse</fullname>
+      <gid>100</gid>
+      <home>/home/suse</home>
+      <shell>/bin/bash</shell>
+      <uid>1001</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>suse</username>
+      <authorized_keys config:type="list">
+        <authorized_key>Tunnel="0" ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKLt1vnW2vTJpBp3VK91rFsBvpY97NljsVLdgUrlPbZ/L51FerQQ+djQ/ivDASQjO+567nMGqfYGFA/De1EGMMEoeShza67qjNi14L1HBGgVojaNajMR/NI2d1kDyvsgRy7D7FT5UGGUNT0dlcSD3b85zwgHeYLidgcGIoKeRi7HpVDOOTyhwUv4sq3ubrPCWARgPeOLdVFa9clC8PTZdxSeKp4jpNjIHEyREPin2Un1luCIPWrOYyym7aRJEPopCEqBA9HvfwpbuwBI5F0uIWZgSQLfpwW86599fBo/PvMDa96DpxH1VlzJlAIHQsMkMHbsCazPNC0++Kp5ZVERiH vagrant@localhost.net</authorized_key>
+        <authorized_key>non valid ssh key</authorized_key>
+      </authorized_keys>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+
+  <install>
+     <init>
+       <info_file>
+<![CDATA[
+#
+# Do not remove the following line:
+# start_linuxrc_conf
+#
+textmode: 1
+linuxrc.debug=1
+
+# end_linuxrc_conf
+# Do not remove the above comment
+#
+]]>
+      </info_file>
+    </init>
+  </install>
+  <unsupported>
+    <comment>This is a dummy and also unsupported section</comment>
+  </unsupported>
+
+  <sshd>
+    <comment>This is an obsolete section</comment>
+  </sshd>
+
+  <!-- check bsc#991001 -->
+  <language>
+    <language>POSIX</language>
+  </language>
+</profile>


### PR DESCRIPTION
For autoyast test we don't use full functionality of aytests framework,
and variables are not get expanded. Hence as a temporary solution we
create profile copy with hardcoded url to the script which is available
on support server. Both were copied from original aytests repo:
https://github.com/yast/aytests-tests/tree/master/aytests

This is temporary solution, we should get rid of two copies of same
files.

Changes also require setting AUTOYAST variable to autoyast_sle12sp2/sles12.xml in the test suite once merged.

Progress ticket: [poo#17366](https://progress.opensuse.org/issues/17366)
Verification run: http://gershwin.arch.suse.de/tests/521#