### PR TITLE
Fix duplicate uid for two users

### DIFF
--- a/data/autoyast_sle12sp2/bug-892069_r3560008.xml
+++ b/data/autoyast_sle12sp2/bug-892069_r3560008.xml
@@ -547,7 +547,7 @@
         <warn>7</warn>
       </password_settings>
       <shell>/bin/bash</shell>
-      <uid>1000</uid>
+      <uid>1001</uid>
       <user_password>nots3cr3t</user_password>
       <username>maier</username>
     </user>


### PR DESCRIPTION
In the profile we had same uid for two users, which resulted in failing
installation. Here we simply change bernhard uid in the profile which
make installation work.

See [poo#17366](https://progress.opensuse.org/issues/17366) and [bsc#1046010](https://bugzilla.suse.com/show_bug.cgi?id=1046010)

Verification run: http://gershwin.arch.suse.de/tests/533#