### PR TITLE
Reboot after fully patched for offline migration

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -25,18 +25,15 @@ use utils;
 use registration;
 
 our @EXPORT = qw(
-  setup_online_migration
+  setup_migration
   register_system_in_textmode
   de_register
   remove_ltss
   disable_installation_repos
 );
 
-sub setup_online_migration {
+sub setup_migration {
     my ($self) = @_;
-    # if source system is minimal installation then boot to textmode
-    # we don't care about source system start time because our SUT is upgraded one
-    $self->wait_boot(textmode => !is_desktop_installed, ready_time => 600);
     select_console 'root-console';
 
     # stop packagekit service

--- a/tests/online_migration/sle12_online_migration/online_migration_setup.pm
+++ b/tests/online_migration/sle12_online_migration/online_migration_setup.pm
@@ -12,12 +12,17 @@
 
 use base "consoletest";
 use strict;
+use utils;
 use testapi;
 use migration;
 
 sub run() {
     my ($self) = @_;
-    $self->setup_online_migration;
+
+    # if source system is minimal installation then boot to textmode
+    # we don't care about source system start time because our SUT is upgraded one
+    $self->wait_boot(textmode => !is_desktop_installed, ready_time => 600);
+    $self->setup_migration;
 }
 
 sub test_flags() {


### PR DESCRIPTION
Set this action to be consistent with online migration.
Also it fixes the issue of switching back from tty to x11 on 12sp2 aarch64:
https://openqa.suse.de/tests/1019332/modules/consoletest_finish_sym/steps/18
See: https://progress.opensuse.org/issues/20040#note-3

Verified runs:
offline x86_64: http://147.2.207.208/tests/606
offline aarch64: http://147.2.207.208/tests/619#step/consoletest_finish_sym/19
online: http://147.2.207.208/tests/615