### PR TITLE
Fix experimental keys on scalar in autoyast verification script

### DIFF
--- a/data/autoyast_sle12sp2/http.sh
+++ b/data/autoyast_sle12sp2/http.sh
@@ -52,7 +52,8 @@ perl - opened <<EOP && IPTABLESRES=1
   }
   #Check if some ports were not opened but expected to be
   if (%res) {
-    print "[ERROR] Some of ports were not opened: " . keys %res . ".\n";
+    print "[ERROR] Some of ports were not opened:\n";
+    print "        " . "\$_\n" for keys %res;
     \$err=1;
   }
   exit \$err;


### PR DESCRIPTION
In error we try to print keys of the hash converting them into scalar
context which is forbidden with strict in perl 5.21, hence change now.
Hence replace with iterating over keys using for loop.

Verification run: http://gershwin.arch.suse.de/tests/564#step/autoyast_verify/7

Issue introduced by my commit here:  [PR#3201](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3201)