### PR TITLE
Make impress template selection window optional

### DIFF
--- a/tests/x11regressions/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_mainmenu_components.pm
@@ -74,9 +74,11 @@ sub run() {
 
     $self->open_mainmenu();
     assert_and_click 'mainmenu-office-impress';    #open impress
-    assert_screen 'ooimpress-select-a-template';
-    send_key "alt-f4";                             #close template window
-    assert_screen 'ooimpress-launched';
+    assert_screen [qw(ooimpress-select-a-template ooimpress-launched)];
+    if (match_has_tag 'ooimpress-select-a-template') {
+        send_key 'alt-f4';                         # close impress template window
+        assert_screen 'ooimpress-launched';
+    }
     send_key "ctrl-q";                             #close impress
 
     $self->open_mainmenu();
@@ -109,9 +111,11 @@ sub run() {
     type_string "impress";                         #open impress
     assert_screen 'overview-office-impress';
     send_key "ret";
-    assert_screen 'ooimpress-select-a-template';
-    send_key "alt-f4";                             #close template window
-    assert_screen 'ooimpress-launched';
+    assert_screen [qw(ooimpress-select-a-template ooimpress-launched)];
+    if (match_has_tag 'ooimpress-select-a-template') {
+        send_key 'alt-f4';                         # close impress template window
+        assert_screen 'ooimpress-launched';
+    }
     send_key "ctrl-q";                             #close impress
 
     $self->open_overview();


### PR DESCRIPTION
Fix poo#20070: Window with template selection is optional now, to don't
break tests on SLE12-SP3.
Verification:
SLE12-SP3: http://pc-pha-base-1.suse.cz/tests/877#step/libreoffice_mainmenu_components/33
SLE12-SP2: http://pc-pha-base-1.suse.cz/tests/878#step/libreoffice_mainmenu_components/33