### PR TITLE
Fix next button hotkey for kde-live installation

### DIFF
--- a/tests/installation/installer_timezone.pm
+++ b/tests/installation/installer_timezone.pm
@@ -1,23 +1,30 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: change to nicer directory structure
-# G-Maintainer: Bernhard M. Wiedemann <bernhard+osautoinst lsmod de>
+# Summary: Verify timezone settings page and proceed to next page
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
 
 use strict;
 use base "y2logsstep";
 use testapi;
+use main_common "noupdatestep_is_applicable";
 
 sub run() {
     assert_screen "inst-timezone", 125 || die 'no timezone';
-    send_key $cmd{next};
+    # Different hotkey on kde live distri
+    if (noupdatestep_is_applicable() && get_var("LIVECD")) {
+        send_key "alt-x";
+    }
+    else {
+        send_key $cmd{next};
+    }
 }
 
 1;

--- a/tests/installation/livecd_network_settings.pm
+++ b/tests/installation/livecd_network_settings.pm
@@ -18,7 +18,8 @@ use testapi;
 
 sub run() {
     assert_screen 'inst-network_settings-livecd';
-    send_key $cmd{next};
+    # For network settings we have different shortcut, see discussion under bsc#1045798
+    send_key 'alt-x';
 }
 
 1;


### PR DESCRIPTION
In the wizard on TW instead of usual alt-n key combo for next page we got alt-x. See [bsc#1045798](https://bugzilla.opensuse.org/show_bug.cgi?id=1045798) for justification. Issue appears only on kde_live installation as we have additional page with network settings there. Test is not used for sle, so distrii check hasn't been added.

Verification run: http://gershwin.arch.suse.de/tests/571
New needles for partitioner are following [PR#220](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/220).