### PR TITLE
Use mutexes instead of barriers

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -518,9 +518,10 @@ sub specific_caasp_params {
         mutex_lock 'dhcp';
         mutex_unlock 'dhcp';
     }
-    # Wait for admin node installation on workers
+    # Wait until admin node genarates autoyast profile
     if (check_var 'STACK_ROLE', 'worker') {
-        barrier_wait 'VELUM_STARTED';
+        mutex_lock "VELUM_CONFIGURED";
+        mutex_unlock "VELUM_CONFIGURED";
     }
 }
 

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -126,23 +126,19 @@ sub load_stack_tests {
     loadtest "caasp/stack_" . get_var('STACK_ROLE');
 }
 
-# Init barriers on on controller node startup
-# Have to be done here because grub2 needle times out on supportserver
-sub stack_barriers_init {
-    my $children = get_children;
-    my $jobs     = 1 + keys %$children;
+# Init cluster variables
+sub stack_init {
+    my $children   = get_children;
+    my $stack_size = keys %$children;
 
-    barrier_create("VELUM_STARTED",     $jobs);        # Velum node is ready
-    barrier_create("WORKERS_INSTALLED", $jobs - 1);    # Nodes are installed
-    barrier_create("CNTRL_FINISHED",    $jobs);        # We are finished with testing
-
-    set_var "STACK_SIZE", $jobs;
+    barrier_create("WORKERS_INSTALLED", $stack_size);
+    set_var "STACK_SIZE", $stack_size;
 }
 
 if (get_var('STACK_ROLE')) {
     # ==== CaaSP tests ====
     if (check_var 'STACK_ROLE', 'controller') {
-        stack_barriers_init;
+        stack_init;
         loadtest "support_server/login";
         loadtest "support_server/setup";
     }

--- a/tests/caasp/stack_worker.pm
+++ b/tests/caasp/stack_worker.pm
@@ -18,8 +18,10 @@ use lockapi;
 sub run {
     # Notify others that installation finished
     barrier_wait "WORKERS_INSTALLED";
+
     # Wait until controller node finishes
-    barrier_wait "CNTRL_FINISHED";
+    mutex_lock "CNTRL_FINISHED";
+    mutex_unlock "CNTRL_FINISHED";
 }
 
 sub post_run_hook {


### PR DESCRIPTION
Barriers are useful when waiting for multiple nodes to reach some state. When waiting for single node to reach desired state mutexes are prefered.

This PR should make whole testsuite fail faster in case of single node failure.

Local runs:
1.0 - http://dhcp91.suse.cz/tests/7266
2.0 - http://dhcp91.suse.cz/tests/7245
Kubic - http://dhcp91.suse.cz/tests/7282