### PR TITLE
WIP: Fix poo#20182.

### DIFF
--- a/tests/installation/add_update_test_repo.pm
+++ b/tests/installation/add_update_test_repo.pm
@@ -33,7 +33,12 @@ sub run() {
         send_key $cmd{next};
         assert_screen 'addon-products';
         # if more repos to come, add more
-        send_key 'alt-a' if @repos;
+        if (@repos) {
+            send_key 'alt-a';
+            until (check_screen('addon-menu-active', 5)) {
+                send_key 'alt-a';
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Unfortuanetly sometimes SUT get only ALT key instead Alt-A. So
wait_screen_change isn't usable for test because is changed highlighted
button but not activates needed action.

http://quasar.suse.cz/tests/5  --> se white blocks in test