### PR TITLE
Update test for enlightenment

### DIFF
--- a/tests/x11/enlightenment_first_start.pm
+++ b/tests/x11/enlightenment_first_start.pm
@@ -17,8 +17,6 @@ use utils;
 
 sub run() {
     mouse_hide();
-    assert_and_click "enlightenment_language_english";
-    assert_and_click "enlightenment_assistant_next";
     assert_and_click "enlightenment_keyboard_english";
     assert_and_click "enlightenment_assistant_next";
     assert_and_click "enlightenment_profile_selection";


### PR DESCRIPTION
- It does no longer show 'language' selection

### Needles
- [gh#os-autoinst-needles-opensuse/221](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/221)

### Verification run
- http://copland.arch.suse.de/tests/955