### PR TITLE
LTP: Increase shutdown timeout to 1800 (30 mins)

### DIFF
--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -18,7 +18,7 @@ use utils;
 
 sub run {
     type_string "poweroff\n";
-    assert_shutdown;
+    assert_shutdown 1800;
 }
 
 sub test_flags {


### PR DESCRIPTION
The poweroff job in systemd has a timeout of 30 minutes on Tumbleweed. This
may seem excessive, but on the other hand I have never seen shutdown fail on
the LTP tests except due to a service being slow to exit. This results in a
cascade of failures, which we badly want to avoid.

Either we can put this here or in os-autoinst. I can only say how it effects the LTP though.

@mimi1vx 