### PR TITLE
Fix ftp test for autoyast regression

### DIFF
--- a/data/autoyast_sle12sp2/ftp.sh
+++ b/data/autoyast_sle12sp2/ftp.sh
@@ -1,9 +1,12 @@
-#!/bin/bash
-
-set -e -x
-
+#!/bin/sh -ex
+#create test file for upload
 echo test > test.txt
-curl -T test.txt ftp://localhost/ --user anonymous:anystring
-curl ftp://localhost/test.txt > test2.txt
+#create dirs and set permissions required for anonymous upload
+mkdir -p /tmp/ftp/incoming
+chmod a-w /tmp/ftp
+chmod a+rw /tmp/ftp/incoming
+
+curl -T test.txt ftp://localhost/incoming/ --user anonymous:anystring
+curl ftp://localhost/incoming/test.txt > test2.txt
 
 diff -u test.txt test2.txt && echo "AUTOYAST OK"

--- a/data/autoyast_sle12sp2/ftp.xml
+++ b/data/autoyast_sle12sp2/ftp.xml
@@ -1,12 +1,7 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-<!--
-  sets up an ftp server,
-  test it via script run by autoyast_verify.pm
-  - default, anonymous access configuration
--->
-
+  <!--  sets up an ftp server,  test it via script run by autoyast_verify.pm  - default, anonymous access configuration-->
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>
   </deploy_image>
@@ -16,7 +11,7 @@
     </mode>
   </general>
   <networking>
-      <keep_install_network config:type="boolean">true</keep_install_network>
+    <keep_install_network config:type="boolean">true</keep_install_network>
   </networking>
   <ftp-server>
     <AnonAuthen>2</AnonAuthen>
@@ -27,9 +22,9 @@
     <Banner>Welcome message</Banner>
     <CertFile/>
     <ChrootEnable>NO</ChrootEnable>
-    <EnableUpload>NO</EnableUpload>
+    <EnableUpload>YES</EnableUpload>
     <FTPUser>ftp</FTPUser>
-    <FtpDirAnon>/tmp</FtpDirAnon>
+    <FtpDirAnon>/tmp/ftp</FtpDirAnon>
     <FtpDirLocal/>
     <GuestUser/>
     <LocalMaxRate>0</LocalMaxRate>
@@ -38,16 +33,15 @@
     <MaxIdleTime>15</MaxIdleTime>
     <PasMaxPort>40500</PasMaxPort>
     <PasMinPort>40000</PasMinPort>
-    <PassiveMode>NO</PassiveMode>
+    <PassiveMode>YES</PassiveMode>
     <SSL>0</SSL>
     <SSLEnable>NO</SSLEnable>
     <SSLv2>NO</SSLv2>
     <SSLv3>NO</SSLv3>
-    <StartDaemon>0</StartDaemon>
-    <StartXinetd>YES</StartXinetd>
+    <StartDaemon>2</StartDaemon>
     <TLS>YES</TLS>
     <Umask/>
-    <UmaskAnon/>
+    <UmaskAnon>022</UmaskAnon>
     <UmaskLocal/>
     <VerboseLogging>NO</VerboseLogging>
     <VirtualUser>NO</VirtualUser>
@@ -77,18 +71,16 @@
     <do_registration config:type="boolean">false</do_registration>
   </suse_register>
   <users config:type="list">
-                <user>
-                   <fullname>Bernhard M. Wiedemann</fullname>
-                   <encrypted config:type="boolean">false</encrypted>
-                   <user_password>nots3cr3t</user_password>
-                   <username>bernhard</username>
-                </user>
-
-          <user>
-                      <encrypted config:type="boolean">false</encrypted>
-                      <user_password>nots3cr3t</user_password>
-                      <username>root</username>
-          </user>
+    <user>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
   </users>
-
 </profile>


### PR DESCRIPTION
This test was never working. There is part which will get fixed in
[bsc#1047232](https://bugzilla.suse.com/show_bug.cgi?id=1047232), another part is to perform upload as anonymous user. For
that proper permissions have to be set. For example, write operation has
to be forbidden on anon_root directory, but is allowed on
subdirectories. Which makes it impossible to upload to root ftp
directory as anonymous user. Additionally, we introduce changes to
creation mask of files uploaded by anonym in order to be able to
download it afterwords.

Test verified manually, after setting "listen=NO" in vsftpd.conf file.
After fix is there, test should work smoothly.

NOTE: changes are in profile are only in following settings: 
```
<UmaskAnon>022</UmaskAnon>
<StartDaemon>2</StartDaemon>
```

where StartDaemon is reverting [commit](https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/1eb21868c56dd0df8fe11e8ab9d841c01c1a0031)

Other is just formatting fix.