### PR TITLE
Add addon= param for leap 42.3

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -20,6 +20,7 @@ use testapi;
 use utils;
 use lockapi;
 use mm_network;
+use main_common "addon_products_is_applicable";
 
 our @EXPORT = qw(
   stop_grub_timeout
@@ -335,6 +336,13 @@ sub specific_bootmenu_params {
         else {
             $args .= " dud=" . data_url($dud) . " insecure=1";
         }
+    }
+
+    # For leap 42.3 we don't have addon_products screen
+    if (!addon_products_is_applicable()) {
+        my $addon_url = get_var("ADDONURL");
+        $addon_url =~ s/\+/,/g;
+        $args .= " addon=" . $addon_url;
     }
 
     if (check_var('ARCH', 's390x')) {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -33,6 +33,7 @@ our @EXPORT = qw(
   consolestep_is_applicable
   rescuecdstep_is_applicable
   bootencryptstep_is_applicable
+  addon_products_is_applicable
   remove_common_needles
   remove_desktop_needles
   check_env
@@ -260,6 +261,10 @@ sub rescuecdstep_is_applicable {
 
 sub ssh_key_import {
     return get_var("SSH_KEY_IMPORT") || get_var("SSH_KEY_DO_NOT_IMPORT");
+}
+
+sub addon_products_is_applicable {
+    return !get_var("LIVECD") && get_var("ADDONURL") && !leap_version_at_least('42.3');
 }
 
 sub remove_common_needles {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -284,7 +284,7 @@ sub load_inst_tests() {
     if (installwithaddonrepos_is_applicable() && !get_var("LIVECD")) {
         loadtest "installation/setup_online_repos";
     }
-    if (!get_var("LIVECD") && get_var("ADDONURL") && !(leap_version_at_least('42.3') && check_var('FLAVOR', 'Maintenance'))) {
+    if (addon_products_is_applicable()) {
         loadtest "installation/addon_products";
     }
     if (noupdatestep_is_applicable() && !get_var("LIVECD") && !get_var("REMOTE_CONTROLLER")) {


### PR DESCRIPTION
As a fix for 42.3 maintenance tests:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3118 we
have identified that addon_products step is not in installer anymore.
Whereas for many tests we need to add addon url. Designed way now is to
pass it using addon= boot option. It's allowed to pass comma separated urls.

NOTE: This functionality is broken as of now, but once is there can test and merge.