### PR TITLE
Add offline migration capability on aarch64

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -233,6 +233,7 @@ sub export_kde_logs {
 # Our aarch64 setup fails to boot properly from an installed hard disk so
 # point the firmware boot manager to the right file.
 sub handle_uefi_boot_disk_workaround {
+    my ($self) = @_;
     record_soft_failure 'bsc#1022064';
     tianocore_enter_menu;
     send_key_until_needlematch 'tianocore-boot_maintenance_manager', 'down', 5, 5;
@@ -330,7 +331,7 @@ sub wait_boot {
         # booted so we have to handle that
         # because of broken firmware, bootindex doesn't work on aarch64 bsc#1022064
         push @tags, 'inst-bootmenu' if ((get_var('USBBOOT') and get_var('UEFI')) || (check_var('ARCH', 'aarch64') and get_var('UEFI')) || get_var('OFW'));
-        handle_uefi_boot_disk_workaround if (get_var('MACHINE') =~ qr'aarch64' && get_var('BOOT_HDD_IMAGE') && !$in_grub);
+        $self->handle_uefi_boot_disk_workaround if (get_var('MACHINE') =~ qr'aarch64' && get_var('BOOT_HDD_IMAGE') && !$in_grub);
         check_screen(\@tags, $bootloader_time);
         if (match_has_tag("bootloader-shim-import-prompt")) {
             send_key "down";

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -80,49 +80,7 @@ sub run() {
         }
     }
 
-    # assume bios+grub+anim already waited in start.sh
-    # in grub2 it's tricky to set the screen resolution
-    send_key "e";
-    if (is_jeos) {
-        for (1 .. 3) { send_key "down"; }
-        send_key "end";
-        # delete "800x600"
-        for (1 .. 7) { send_key "backspace"; }
-    }
-    else {
-        for (1 .. 2) { send_key "down"; }
-        send_key "end";
-        # delete "keep" word
-        for (1 .. 4) { send_key "backspace"; }
-    }
-    # hardcoded the value of gfxpayload to 1024x768
-    type_string "1024x768";
-    assert_screen "gfxpayload_changed", 10;
-    # back to the entry position
-    send_key "home";
-    for (1 .. 2) { send_key "up"; }
-    if (is_jeos) {
-        send_key "up";
-    }
-    sleep 5;
-    for (1 .. 4) { send_key "down"; }
-    send_key "end";
-
-    if (get_var("NETBOOT")) {
-        type_string_slow " install=" . get_netboot_mirror;
-        save_screenshot();
-    }
-    send_key "spc";
-
-    # if(get_var("PROMO")) {
-    #     for(1..2) {send_key "down";} # select KDE Live
-    # }
-
-    if (check_var('VIDEOMODE', "text")) {
-        type_string_slow "textmode=1 ";
-    }
-
-    type_string " \\\n";    # changed the line before typing video params
+    uefi_bootmenu_params;
     bootmenu_default_params;
     specific_bootmenu_params;
     specific_caasp_params;

--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -13,12 +13,14 @@
 # Maintainer: Martin Kravec <mkravec@suse.com>
 
 use strict;
-use base "basetest";
+use base "opensusebasetest";
 use testapi;
 use utils;
 use bootloader_setup qw(stop_grub_timeout boot_into_snapshot);
 
 sub run() {
+    my ($self) = @_;
+
     if (get_var('LIVECD')) {
         mouse_hide;
         wait_still_screen;
@@ -38,7 +40,15 @@ sub run() {
         if (check_var("AUTOUPGRADE") && check_var("PATCH")) {
             assert_screen 'grub2';
         }
-        send_key 'ret';
+        # use firmware boot manager of aarch64 to boot upgraded system
+        if (check_var('ARCH', 'aarch64') && get_var('UPGRADE')) {
+            send_key_until_needlematch 'inst-bootmenu-boot-harddisk', 'up';
+            send_key 'ret';
+            $self->handle_uefi_boot_disk_workaround;
+        }
+        else {
+            send_key 'ret';
+        }
     }
     elsif (get_var('UEFI') && get_var('USBBOOT')) {
         assert_screen 'inst-bootmenu';

--- a/tests/x11/reboot_and_install.pm
+++ b/tests/x11/reboot_and_install.pm
@@ -31,6 +31,10 @@ sub run() {
     # are coming from old systems here it is unlikely the reboot time
     # increases
     return if select_bootmenu_option(300) == 3;
+    # set uefi bootmenu parameters properly for aarch64, such like gfxpayload and so on
+    if (check_var('ARCH', 'aarch64')) {
+        uefi_bootmenu_params;
+    }
     bootmenu_default_params;
     specific_bootmenu_params;
     registration_bootloader_params;
@@ -43,7 +47,7 @@ sub run() {
     }
     else {
         # boot
-        my $key = check_var('ARCH', 'ppc64le') ? 'ctrl-x' : 'ret';
+        my $key = check_var('ARCH', 'ppc64le') || check_var('ARCH', 'aarch64') ? 'ctrl-x' : 'ret';
         send_key $key;
     }
 }


### PR DESCRIPTION
See: https://progress.opensuse.org/issues/20216

Verified runs:
aarch64 offline: http://147.2.207.208/tests/637
aarch64 install: http://147.2.207.208/tests/638
x86_64 offline: http://147.2.207.208/tests/639
x86_64 uefi install: http://147.2.207.208/tests/640
