### PR TITLE
Add yast2_lan_restart.pm back to extratest for openSUSE TW/LEAP

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -444,7 +444,6 @@ sub load_extra_tests() {
             # start extra x11 tests from here
             loadtest 'x11/vnc_two_passwords';
             # TODO: check why this is not called on opensuse
-            loadtest 'x11/yast2_lan_restart';
             loadtest 'x11/user_defined_snapshot';
         }
         elsif (check_var('DISTRI', 'opensuse')) {
@@ -469,6 +468,7 @@ sub load_extra_tests() {
             }
 
         }
+        loadtest 'x11/yast2_lan_restart';
     }
     else {
         loadtest "console/zypper_lr";


### PR DESCRIPTION
- add yast_lan_restart back to extratest/yast2_gui test for openSUSE TW and Leap
- for details please see ticket: https://progress.opensuse.org/issues/19922

Please see my reference tests: 
openSUSE TW - http://e13.suse.de/tests/3259
openSUSE Leap - http://e13.suse.de/tests/3252

