### PR TITLE
Start firewall and apache before testing ports

### DIFF
--- a/data/autoyast_sle12sp2/http.sh
+++ b/data/autoyast_sle12sp2/http.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-set -e -x
+HO=`hostname`
+
+SuSEfirewall2 start
+rcapache2 start
 
 HTTPTEST=/var/log/test-http.txt
 HTTPSTEST=/var/log/test-https.txt
@@ -8,9 +11,9 @@ HTTPRES=0
 
 echo test > /srv/www/htdocs/test.txt
 echo "[DEBUG] http test:"
-curl -s -S http://localhost/test.txt 2>&1 | tee $HTTPTEST
+curl -s -S http://$HO/test.txt 2>&1 | tee $HTTPTEST
 echo "[DEBUG] https -k test:"
-curl -s -S -k https://localhost/test.txt 2>&1 | tee $HTTPSTEST
+curl -s -S -k https://$HO/test.txt 2>&1 | tee $HTTPSTEST
 
 diff -u /srv/www/htdocs/test.txt $HTTPTEST && diff -u $HTTPTEST $HTTPSTEST && HTTPRES=1 || echo "[ERROR] HTTP/HTTPS test failed"
 


### PR DESCRIPTION
In the test we verify open ports in firewall rules, whereas we don't have some of them added to iptables
before we start the firewall service.
This part is also adjusted according to the http.sh script located in
aytests. It cannot be reused as of now, as fails to verify ports. Hence
we have our local copy and back merge this script to aytests.

No bug in product, hence expect to be green.

This ticket is related to [poo#17934](https://progress.opensuse.org/issues/17934)
Verification run: http://gershwin.arch.suse.de/tests/579