### PR TITLE
Replace hotkey usages for some screens in kde live

### DIFF
--- a/tests/installation/installer_timezone.pm
+++ b/tests/installation/installer_timezone.pm
@@ -18,9 +18,9 @@ use main_common "noupdatestep_is_applicable";
 
 sub run() {
     assert_screen "inst-timezone", 125 || die 'no timezone';
-    # Different hotkey on kde live distri
+    # Unpredictable hotkey on kde live distri, click button. See bsc#1045798
     if (noupdatestep_is_applicable() && get_var("LIVECD")) {
-        send_key "alt-x";
+        assert_and_click 'next-button';
     }
     else {
         send_key $cmd{next};

--- a/tests/installation/livecd_network_settings.pm
+++ b/tests/installation/livecd_network_settings.pm
@@ -18,8 +18,8 @@ use testapi;
 
 sub run() {
     assert_screen 'inst-network_settings-livecd';
-    # For network settings we have different shortcut, see discussion under bsc#1045798
-    send_key 'alt-x';
+    # Unpredictable hotkey on kde live distri, click button. See bsc#1045798
+    assert_and_click 'next-button';
 }
 
 1;


### PR DESCRIPTION
Initial problem was that some Next buttons got new shortcuts, in the end
we have identified that they are different in 2 runs of same
distribution running on different workers. If user goes back, next
button may also change it's shortcut.
So far it happens only on timezone settings page and network settings
page which is kde live specific.

Has to be merged along with new [needle](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/225)
[Verification run](http://gershwin.arch.suse.de/tests/603)
[Progress ticket](https://progress.opensuse.org/issues/17934) 