### PR TITLE
Update onetime_vncsession_xvnc_java.pm to fix poo#20124

### DIFF
--- a/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_java.pm
+++ b/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_java.pm
@@ -45,14 +45,10 @@ sub run() {
     send_key 'alt-d';
     type_string "10.0.2.1:5801\n";
     assert_screen 'firefox-ssl-untrusted';
-    send_key 'tab';
-    send_key 'ret';
-    send_key 'tab';
-    send_key 'ret';
+    assert_and_click 'firefox-ssl-untrusted-advanced';
+    assert_and_click 'firefox-ssl-addexception-button';
     assert_screen 'firefox-ssl-addexception', 60;
     send_key 'alt-c';
-    wait_still_screen 3;
-    send_key 'alt-f10';
     assert_and_click 'xvnc-firefox-activate-IcedTea';
     assert_and_click 'xvnc-firefox-IcedTea-allow';
     assert_screen 'xvnc-firefox-certification-warning';


### PR DESCRIPTION
Firefox has been updated to the new version, I changed the steps
to add security exception.

  see also: poo#20124

Validation test: http://147.2.212.222/tests/722