### PR TITLE
Add new PXE boot specific tag and unload needles

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -121,6 +121,13 @@ sub cleanup_needles {
     else {
         unregister_needle_tags('ENV-OFW-1');
     }
+
+    if (get_var('PXEBOOT')) {
+        unregister_needle_tags('ENV-PXEBOOT-0');
+    }
+    else {
+        unregister_needle_tags('ENV-PXEBOOT-1');
+    }
 }
 
 my $distri = testapi::get_required_var('CASEDIR') . '/lib/susedistribution.pm';


### PR DESCRIPTION
As we have a lot of needles, we use ENV- tags to unregister irrelevant
needles in order to improve mathing performance. While fixing autoyast
tests we got another grub menu needle, which is specific to pxe_menu
boot. Here is tiny improvement to unload not used needles for other
tests.

Needles improvement that uses new logic can be merged using [MR#408](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/408)