### PR TITLE
Add firefox pop up check method

### DIFF
--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -13,51 +13,20 @@
 
 package firefox;
 use base "x11test";
+use base "x11regressiontest";
 use strict;
 use testapi;
 
 sub start_firefox {
     my ($self) = @_;
     x11_start_program("firefox https://html5test.com/index.html", 6, {valid => 1});
-    $self->check_firefox_default;
-    $self->check_firefox_popups;
+    $self->firefox_check_default;
+    $self->firefox_check_popups;
     assert_screen 'firefox-html5test';
 }
 
-sub check_firefox_default {
-    # Set firefox as default browser if asked
-    assert_screen [qw(firefox_default_browser firefox_trackinfo firefox_readerview_window firefox-html5test)], 120;
-    if (match_has_tag('firefox_default_browser')) {
-        wait_screen_change {
-            assert_and_click 'firefox_default_browser_yes';
-        };
-    }
-}
-
-sub check_firefox_popups {
-    # Check whether there are any pop up windows and handle them one by one
-    for (1 .. 2) {
-        wait_still_screen;
-        assert_screen [qw(firefox_trackinfo firefox_readerview_window firefox-html5test)], 60;
-        # Handle the tracking protection pop up
-        if (match_has_tag('firefox_trackinfo')) {
-            wait_screen_change {
-                assert_and_click 'firefox_trackinfo';
-                assert_and_click 'firefox_titlebar';    # workaround for bsc#1046005
-            };
-        }
-        # Handle the reader view pop up
-        elsif (match_has_tag('firefox_readerview_window')) {
-            wait_screen_change {
-                assert_and_click 'firefox_readerview_window';
-                assert_and_click 'firefox_titlebar';    # workaround for bsc#1046005
-            };
-        }
-    }
-}
-
-sub run {
-    my $self = shift;
+sub run() {
+    my ($self) = shift;
     mouse_hide(1);
     $self->start_firefox();
     send_key "alt-h";

--- a/tests/x11regressions/gnomecase/application_starts_on_login.pm
+++ b/tests/x11regressions/gnomecase/application_starts_on_login.pm
@@ -105,6 +105,7 @@ sub run {
     send_key "alt-f4";
 
     logout_and_login;
+    $self->firefox_check_popups;
     assert_screen "firefox-gnome", 90;
     send_key "alt-f4";
     wait_still_screen;
@@ -134,8 +135,11 @@ sub run {
 
     x11_start_program("firefox");
     wait_still_screen;
+    $self->firefox_check_default;
+    $self->firefox_check_popups;
     assert_screen "firefox-gnome", 90;
     logout_and_login;
+    $self->firefox_check_popups;
     assert_screen "firefox-gnome", 90;
     send_key "alt-f4";
     wait_still_screen;

--- a/tests/x11regressions/gnomecase/gnome_classic_switch.pm
+++ b/tests/x11regressions/gnomecase/gnome_classic_switch.pm
@@ -18,6 +18,7 @@ use utils;
 
 # applications are called twiced
 sub application_test {
+    my ($self) = @_;
     x11_start_program "gnome-terminal";
     assert_screen "gnome-terminal-launched";
     send_key "alt-f4";
@@ -25,6 +26,8 @@ sub application_test {
     wait_still_screen;
 
     x11_start_program "firefox";
+    $self->firefox_check_default;
+    $self->firefox_check_popups;
     assert_screen "firefox-gnome", 150;
     send_key "alt-f4";
     wait_still_screen;


### PR DESCRIPTION
Following up on PR#3202, I have added `firefox_check_default` and `firefox_check_popups` methods into the x11regressiontest library, so they can be reused for firefox regression testing.

To make the subroutines more generic and usable in different scenarios, I have used a new needle tag `firefox_clean`, which is used to check that firefox has no pop up windows left open. Needles are submitted separately.

Related MR with needles:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/409

I have used these methods in `application_starts_on_login` and `gnome_classic_switch` test modules and the test passed locally:
http://dreamyhamster.suse.cz/tests/353#step/application_starts_on_login/110
http://dreamyhamster.suse.cz/tests/353#step/gnome_classic_switch/47

I am currently also testing them for use in the QAM firefox regression test suite; a separate PR will follow for this.

Related issue: https://progress.opensuse.org/issues/19926