### PR TITLE
 Handle conflict between marble-kde and marble-qt

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -146,6 +146,8 @@ sub problem_can_be_skipped {
     if ($pkg =~ /chromium-desktop-gnome/) {
         return !package_installed('gnome-session');
     }
+    # conflicts with marble-kde
+    return 1 if $pkg =~ /^marble-qt/;
     # conflicts with firebird-classic
     return 1 if $pkg =~ /firebird-superserver/;
     # conflict with julia, julia-devel, respectively


### PR DESCRIPTION
Fixes:
https://openqa.opensuse.org/tests/441723#step/install_packages/9
https://openqa.opensuse.org/tests/441721#step/install_packages/9
https://openqa.opensuse.org/tests/441722#step/install_packages/9

Signed-off-by: Jürgen Löhel <jloehel@suse.com>