### PR TITLE
Revert "Add yast2_lan_restart.pm back to extratest for openSUSE TW/LEAP"

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -452,6 +452,7 @@ sub load_extra_tests() {
             # start extra x11 tests from here
             loadtest 'x11/vnc_two_passwords';
             # TODO: check why this is not called on opensuse
+            loadtest 'x11/yast2_lan_restart';
             loadtest 'x11/user_defined_snapshot';
         }
         elsif (check_var('DISTRI', 'opensuse')) {
@@ -476,7 +477,6 @@ sub load_extra_tests() {
             }
 
         }
-        loadtest 'x11/yast2_lan_restart';
     }
     else {
         loadtest "console/zypper_lr";


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#3236

Unfortunately the test failed on o3 both for [Tumbleweed](https://openqa.opensuse.org/tests/442033#step/yast2_lan_restart/255) as well as [Leap](https://openqa.opensuse.org/tests/442027#step/yast2_lan_restart/255) which does not seem to be related to missing needles but that dig can't reach suse.com. Maybe that is not reachable from the o3 network? Please check.