### PR TITLE
Cowardly increase timeout for autoyast reboot

### DIFF
--- a/tests/autoyast/autoyast_reboot.pm
+++ b/tests/autoyast/autoyast_reboot.pm
@@ -25,7 +25,7 @@ sub run {
     reset_consoles;
 
     assert_screen("bios-boot",  900);
-    assert_screen("bootloader", 20);
+    assert_screen("bootloader", 30);
 
     if (check_var("BOOTFROM", "d")) {
         assert_screen("inst-bootmenu", 60);


### PR DESCRIPTION
It happened once on one of the workers that we didn't get boot menu
before the timeout. Test uses support server, so these workers are under
load there. Worth mentioning that test uses pxe boot and doesn't perform
any additional actions, so 10 seconds are spent there just waiting.
After performing 3 runs locally on 2 core machine, I was not able to
replicate original issue.

[Local run](http://gershwin.arch.suse.de/tests/612)
[Progress ticket](https://progress.opensuse.org/issues/20278)