### PR TITLE
Update ecryptfs_fips.pm: expect a failure in fips

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1036,7 +1036,7 @@ sub load_fips_tests_crypt() {
     loadtest "console/consoletest_setup";
     loadtest "console/yast2_dm_crypt";
     loadtest "console/cryptsetup";
-    loadtest "console/ecryptfs_fips";
+    loadtest "fips/ecryptfs_fips";
 }
 
 sub load_patching_tests() {

--- a/tests/fips/ecryptfs_fips.pm
+++ b/tests/fips/ecryptfs_fips.pm
@@ -33,11 +33,10 @@ sub run() {
         sub { m/Mounted eCryptfs/ });
 
     # touch a new file and try to write with it
+    # According to comment 12 of bsc#973318, ecryptfs expects a failure in fips mode
     assert_script_run("cd private && touch testfile ");
-    script_run("echo hello > testfile");
-    assert_script_run("ls");
-    validate_script_output("cat testfile",              sub { m/hello/ });
-    validate_script_output("file ../.private/testfile", sub { m/testfile: data/ });
+    validate_script_output("(echo hello > testfile) 2>&1 || true", sub { m/write error/ });
+    validate_script_output("cat testfile 2>&1 || true",            sub { m/^$|No such file or directory/ });
 
     # unmount and check the encrypt file
     assert_script_run("cd .. && umount -l private");


### PR DESCRIPTION
According to comment 12 of bsc#973318, the usage of MD5 for IV
hashing in ecryptfs excludes it from being used in FIPS mode.
The ecryptfs failure in fips therefore is expected.