### PR TITLE
Add more log in xfstests, and reduce wait time

### DIFF
--- a/tests/qa_automation/xfstests_install.pm
+++ b/tests/qa_automation/xfstests_install.pm
@@ -81,6 +81,10 @@ sub prepare_env {
     assert_script_run("export SCRATCH_DIR=/mnt/scratch");
     assert_script_run("export SCRATCH_DEV=" . $scratch_partition, 10);
     assert_script_run("export SCRATCH_MNT=/mnt/scratch");
+
+    #to get more useful logs
+    assert_script_run("dmesg -n 7");
+    assert_script_run("systemctl stop cron");
 }
 
 1;

--- a/tests/qa_automation/xfstests_run.pm
+++ b/tests/qa_automation/xfstests_run.pm
@@ -41,7 +41,7 @@ sub run() {
     script_run("sed -i \"s/hostname -s/hostname/\" ./common/rc");
     script_run("sed -i \"s/hostname -s/hostname/\" ./common/config");
 
-    script_run("./check", 60 * 60 * 6);
+    script_run("./check", 60 * 60 * 5);
 
     # Upload all log tarballs in ./results/
     $self->log_upload();


### PR DESCRIPTION
- Show more log during test. It's mainly to shows more information when stuck happened like btrfs/130
- Reduce waiting time from 6 hours to 5 hours, because osd has better performance than my server.

http://147.2.207.102/tests/1082
Test is still running, but it already shows the Call trace log for btrfs/130