### PR TITLE
Refactor prepare_for_kdump

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -21,6 +21,39 @@ sub install_kernel_debuginfo {
     zypper_call('-v in $(rpmquery kernel-default | sed "s/kernel-default/kernel-default-debuginfo/")');
 }
 
+sub prepare_for_kdump_sle {
+    # debuginfos for kernel has to be installed from build-specific directory on FTP.
+    # To get the right directory we modify content of REPO_0 variable, e.g.:
+    # SLE-12-SP2-Server-DVD-x86_64-Build2188-Media1 -> SLE-12-SP2-SERVER-POOL-x86_64-Build2188-Media3
+    if (get_var('REPO_0')) {
+        my $sles_debug_repo = get_var('REPO_0') =~ s/(Server|Desktop)/\U$1\E/r;
+        $sles_debug_repo =~ s/DVD/POOL/;
+        $sles_debug_repo =~ s/Media1/Media3/;
+        my $url = "ftp://openqa.suse.de/$sles_debug_repo";
+        zypper_call("ar -f $url SLES-Server-Debug");
+        install_kernel_debuginfo;
+        script_run 'zypper -n rr SLES-Server-Debug';
+        return;
+    }
+    my $counter = 0;
+    if (get_var('OS_TEST_ISSUES') && get_var('OS_TEST_TEMPLATE')) {
+        # append _debug to the incident repo
+        for my $b (split(/,/, get_var('OS_TEST_ISSUES'))) {
+            next unless $b;
+            $b = join($b, split('%INCIDENTNR%', get_var('OS_TEST_TEMPLATE')));
+            $b =~ s,/$,_debug/,;
+            $counter++;
+            zypper_call("--no-gpg-check ar -f $b 'DEBUG_$counter'");
+        }
+    }
+    script_run(q{zypper mr -e $(zypper lr | awk '/Debug/ {print $1}')}, 60);
+    install_kernel_debuginfo;
+    script_run(q{zypper mr -d $(zypper lr | awk '/Debug/ {print $1}')}, 60);
+    for my $i (1 .. $counter) {
+        script_run "zypper rr DEBUG_$i";
+    }
+}
+
 sub prepare_for_kdump {
     # disable packagekitd
     pkcon_quit;
@@ -28,41 +61,24 @@ sub prepare_for_kdump {
 
     # add debuginfo channels
     if (check_var('DISTRI', 'sle')) {
-        # debuginfos for kernel has to be installed from build-specific directory on FTP.
-        # To get the right directory we modify content of REPO_0 variable, e.g.:
-        # SLE-12-SP2-Server-DVD-x86_64-Build2188-Media1 -> SLE-12-SP2-SERVER-POOL-x86_64-Build2188-Media3
-        if (get_var('REPO_0')) {
-            my $sles_debug_repo = get_var('REPO_0') =~ s/(Server|Desktop)/\U$1\E/r;
-            $sles_debug_repo =~ s/DVD/POOL/;
-            $sles_debug_repo =~ s/Media1/Media3/;
-            my $url = "ftp://openqa.suse.de/$sles_debug_repo";
-            zypper_call("ar -f $url SLES-Server-Debug");
-            install_kernel_debuginfo;
-            script_run 'zypper -n rr SLES-Server-Debug';
-        }
-        else {
-            script_run(q{zypper mr -e $(zypper lr | awk '/Debug/ {print $1}')}, 60);
-            install_kernel_debuginfo;
-            script_run(q{zypper mr -d $(zypper lr | awk '/Debug/ {print $1}')}, 60);
-        }
+        prepare_for_kdump_sle;
+        return;
     }
-    else {
-        if (get_var('REPO_0_DEBUGINFO')) {
-            my $snapshot_debuginfo_repo = get_var('REPO_0_DEBUGINFO');
-            zypper_call('ar -f ' . get_var('MIRROR_HTTP') . "-debuginfo $snapshot_debuginfo_repo");
-            install_kernel_debuginfo;
-            script_run "zypper -n rr $snapshot_debuginfo_repo";
-        }
-        else {
-            my $opensuse_debug_repos = 'repo-debug ';
-            if (!check_var('VERSION', 'Tumbleweed')) {
-                $opensuse_debug_repos .= 'repo-debug-update ';
-            }
-            zypper_call("mr -e $opensuse_debug_repos");
-            install_kernel_debuginfo;
-            zypper_call("mr -d $opensuse_debug_repos");
-        }
+
+    if (get_var('REPO_0_DEBUGINFO')) {
+        my $snapshot_debuginfo_repo = get_var('REPO_0_DEBUGINFO');
+        zypper_call('ar -f ' . get_var('MIRROR_HTTP') . "-debuginfo $snapshot_debuginfo_repo");
+        install_kernel_debuginfo;
+        script_run "zypper -n rr $snapshot_debuginfo_repo";
+        return;
     }
+    my $opensuse_debug_repos = 'repo-debug ';
+    if (!check_var('VERSION', 'Tumbleweed')) {
+        $opensuse_debug_repos .= 'repo-debug-update ';
+    }
+    zypper_call("mr -e $opensuse_debug_repos");
+    install_kernel_debuginfo;
+    zypper_call("mr -d $opensuse_debug_repos");
 }
 
 sub activate_kdump {
@@ -107,4 +123,3 @@ sub do_kdump {
 1;
 
 # vim: sw=4 et
-

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -222,8 +222,8 @@ if (check_var('DESKTOP', 'minimalx')) {
 if (is_update_test_repo_test && !get_var('MAINT_TEST_REPO')) {
     my %incidents;
     my %u_url;
-    $incidents{'OS'} = get_var('OS_TEST_ISSUES',   '');
-    $u_url{'OS'}     = get_var('OS_TEST_TEMPLATE', '');
+    $incidents{OS} = get_var('OS_TEST_ISSUES',   '');
+    $u_url{OS}     = get_var('OS_TEST_TEMPLATE', '');
 
     my @maint_repos;
     my @inclist;


### PR DESCRIPTION
If there are incidents to be tested, add _debug channels to the list of
repos before installing debuginfos

Issue https://progress.opensuse.org/issues/20056