### PR TITLE
Remove double login

### DIFF
--- a/tests/autoyast/login.pm
+++ b/tests/autoyast/login.pm
@@ -29,13 +29,6 @@ sub run {
         #use console based on ssh to avoid unstable ipmi
         use_ssh_serial_console;
     }
-    else {
-        type_string "root\n";
-        sleep 10;
-        type_password;
-        send_key "ret";
-        sleep 10;
-    }
     assert_script_run 'echo "checking serial port"';
     wait_idle(10);
     type_string "cat /proc/cmdline\n";


### PR DESCRIPTION
Fixed Issue 20192 where the test would try to login to an
already logged in console.
Removed code part which logs in since the test only runs after
'console' test which logs in.

Issue:
https://progress.opensuse.org/issues/20192

Verification:
http://pinky.arch.suse.de/tests/54#step/login/2