### PR TITLE
Add yast2_lan_hostname.pm back to extratest for openSUSE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -368,10 +368,10 @@ sub load_yast2_ui_tests {
     loadtest "console/yast2_samba";
     loadtest "console/yast2_xinetd";
     loadtest "console/yast2_apparmor";
+    loadtest "console/yast2_lan_hostname";
     # TODO: why are the following two modules called on sle but not on opensuse?
     # TODO: check if the following two modules also work on opensuse and delete if
     if (check_var('DISTRI', 'sle')) {
-        loadtest "console/yast2_lan_hostname";
         loadtest "console/yast2_nis";
     }
     # TODO: check if the following two modules also work on sle and delete if.

--- a/tests/console/yast2_lan_hostname.pm
+++ b/tests/console/yast2_lan_hostname.pm
@@ -50,7 +50,6 @@ sub run() {
     hostname_via_dhcp('no');
     hostname_via_dhcp('yes-eth0');
     hostname_via_dhcp('yes-any');
-    select_console 'user-console';
 }
 
 sub post_fail_hook() {


### PR DESCRIPTION
- remove "select user-console" in yast2_lan_hostname.pm which causes
test failure on openSUSE TW. There is no need to swith to user-console.
- please see ticket https://progress.opensuse.org/issues/19922 for other details
- please see my reference test: http://e13.suse.de/tests/3309#step/yast2_lan_hostname

