### PR TITLE
Split xfstests into groups, and change trigger to main.pm

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1212,6 +1212,22 @@ elsif (get_var("QA_TESTSET")) {
     }
     loadtest "qa_automation/" . get_var("QA_TESTSET");
 }
+elsif (get_var("XFSTESTS")) {
+    loadtest "qa_automation/xfstests_prepare_boot";
+    loadtest "qa_automation/xfstests_prepare_testsuite";
+    loadtest "qa_automation/xfstests_prepare_env";
+    loadtest "qa_automation/xfstests_run_generic";
+    loadtest "qa_automation/xfstests_run_shared";
+    if (check_var("TEST_FS_TYPE", "xfs")) {
+        loadtest "qa_automation/xfstests_run_xfs";
+    }
+    elsif (check_var("TEST_FS_TYPE", "btrfs")) {
+        loadtest "qa_automation/xfstests_run_btrfs";
+    }
+    elsif (check_var("TEST_FS_TYPE", "ext4")) {
+        loadtest "qa_automation/xfstests_run_ext4";
+    }
+}
 elsif (get_var("VIRT_AUTOTEST")) {
     if (get_var("PROXY_MODE")) {
         loadtest "virt_autotest/proxymode_login_proxy";

--- a/tests/qa_automation/xfstests_logs.pm
+++ b/tests/qa_automation/xfstests_logs.pm
@@ -22,6 +22,7 @@ sub log_upload {
     my $tarball = "/tmp/qaset-xfstests-results.tar.bz2";
     assert_script_run("tar jcvf " . $tarball . " ./results/");
     upload_logs($tarball);
+    assert_script_run("rm -rf ./results/*");
 }
 
 1;

--- a/tests/qa_automation/xfstests_prepare_boot.pm
+++ b/tests/qa_automation/xfstests_prepare_boot.pm
@@ -1,0 +1,32 @@
+# Copyright © 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary:  xfstests testsuite
+# Use the latest xfstests testsuite from upstream to make file system test
+# Maintainer: Yong Sun <yosun@suse.com>
+
+use base "xfstests_install";
+use base "xfstests_device";
+use strict;
+use testapi;
+
+sub run {
+    my $self = shift;
+
+    $self->system_login();
+    $self->prepare_repo();
+}
+
+1;

--- a/tests/qa_automation/xfstests_prepare_env.pm
+++ b/tests/qa_automation/xfstests_prepare_env.pm
@@ -1,0 +1,39 @@
+# Copyright © 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary:  xfstests testsuite
+# Use the latest xfstests testsuite from upstream to make file system test
+# Maintainer: Yong Sun <yosun@suse.com>
+
+use base "xfstests_install";
+use base "xfstests_device";
+use strict;
+use testapi;
+
+sub run {
+    my $self = shift;
+
+    #Split /home into many partitions
+    my ($test_partition, $scratch_partition, $test_fs_type) = $self->dev_create_partition();
+
+    #Prepare envirorment and all parameters before run test
+    $self->prepare_env($test_partition, $scratch_partition);
+
+    #Modify obsoleted "hostname -s" to "hostname" in ./common/rc and ./common/config
+    script_run("sed -i \"s/hostname -s/hostname/\" ./common/rc");
+    script_run("sed -i \"s/hostname -s/hostname/\" ./common/config");
+}
+
+1;

--- a/tests/qa_automation/xfstests_prepare_testsuite.pm
+++ b/tests/qa_automation/xfstests_prepare_testsuite.pm
@@ -1,0 +1,32 @@
+# Copyright © 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary:  xfstests testsuite
+# Use the latest xfstests testsuite from upstream to make file system test
+# Maintainer: Yong Sun <yosun@suse.com>
+
+use base "xfstests_install";
+use base "xfstests_device";
+use strict;
+use testapi;
+
+sub run {
+    my $self = shift;
+
+    #Install xfstests test package
+    $self->prepare_testpackage();
+}
+
+1;

--- a/tests/qa_automation/xfstests_run_btrfs.pm
+++ b/tests/qa_automation/xfstests_run_btrfs.pm
@@ -1,0 +1,34 @@
+# Copyright © 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary:  xfstests testsuite
+# Use the latest xfstests testsuite from upstream to make file system test
+# Maintainer: Yong Sun <yosun@suse.com>
+
+use base "xfstests_install";
+use base "xfstests_device";
+use base "xfstests_logs";
+use strict;
+use testapi;
+
+sub run {
+    my $self = shift;
+    script_run("./check btrfs/???", 60 * 60 * 3);
+
+    # Upload all log tarballs in ./results/
+    $self->log_upload();
+}
+
+1;

--- a/tests/qa_automation/xfstests_run_ext4.pm
+++ b/tests/qa_automation/xfstests_run_ext4.pm
@@ -1,0 +1,34 @@
+# Copyright © 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary:  xfstests testsuite
+# Use the latest xfstests testsuite from upstream to make file system test
+# Maintainer: Yong Sun <yosun@suse.com>
+
+use base "xfstests_install";
+use base "xfstests_device";
+use base "xfstests_logs";
+use strict;
+use testapi;
+
+sub run {
+    my $self = shift;
+    script_run("./check ext4/???", 60 * 60 * 2);
+
+    # Upload all log tarballs in ./results/
+    $self->log_upload();
+}
+
+1;

--- a/tests/qa_automation/xfstests_run_generic.pm
+++ b/tests/qa_automation/xfstests_run_generic.pm
@@ -1,0 +1,34 @@
+# Copyright © 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary:  xfstests testsuite
+# Use the latest xfstests testsuite from upstream to make file system test
+# Maintainer: Yong Sun <yosun@suse.com>
+
+use base "xfstests_install";
+use base "xfstests_device";
+use base "xfstests_logs";
+use strict;
+use testapi;
+
+sub run {
+    my $self = shift;
+    script_run("./check generic/???", 60 * 60 * 3);
+
+    # Upload all log tarballs in ./results/
+    $self->log_upload();
+}
+
+1;

--- a/tests/qa_automation/xfstests_run_shared.pm
+++ b/tests/qa_automation/xfstests_run_shared.pm
@@ -25,23 +25,7 @@ use testapi;
 
 sub run {
     my $self = shift;
-    $self->system_login();
-    $self->prepare_repo();
-
-    #Split /home into many partitions
-    my ($test_partition, $scratch_partition, $test_fs_type) = $self->dev_create_partition();
-
-    #Install xfstests test package
-    $self->prepare_testpackage();
-
-    #Prepare envirorment and all parameters before run test
-    $self->prepare_env($test_partition, $scratch_partition);
-
-    #Modify obsoleted "hostname -s" to "hostname" in ./common/rc and ./common/config
-    script_run("sed -i \"s/hostname -s/hostname/\" ./common/rc");
-    script_run("sed -i \"s/hostname -s/hostname/\" ./common/config");
-
-    script_run("./check", 60 * 60 * 5);
+    script_run("./check shared/???", 60 * 60 * 1);
 
     # Upload all log tarballs in ./results/
     $self->log_upload();

--- a/tests/qa_automation/xfstests_run_xfs.pm
+++ b/tests/qa_automation/xfstests_run_xfs.pm
@@ -1,0 +1,34 @@
+# Copyright © 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary:  xfstests testsuite
+# Use the latest xfstests testsuite from upstream to make file system test
+# Maintainer: Yong Sun <yosun@suse.com>
+
+use base "xfstests_install";
+use base "xfstests_device";
+use base "xfstests_logs";
+use strict;
+use testapi;
+
+sub run {
+    my $self = shift;
+    script_run("./check xfs/???", 60 * 60 * 3);
+
+    # Upload all log tarballs in ./results/
+    $self->log_upload();
+}
+
+1;


### PR DESCRIPTION
Code Changs:
- Split xfstests into groups: generic, share, xfs/btrfs. And delete the useless xfstests_run.pm
- Make testresult more clear to reviewers, then change to use main.pm to trigger tests. Use parameter XFSTESTS=1 to trigger xfstests related tests, and use TEST_FS_TYPE to define test xfs or btrfs.
- Prepare script start with xfstests_prepare*; Run script start with xfstests_run*; others script are modules.

Configure change:
- Remove QA_TESTSET
- Add XFSTESTS=1

Test: 
http://147.2.207.102/tests/1100