### PR TITLE
Add yast2_lan_restart.pm back to extratest for openSUSE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -369,7 +369,6 @@ sub load_yast2_ui_tests {
     loadtest "console/yast2_xinetd";
     loadtest "console/yast2_apparmor";
     loadtest "console/yast2_lan_hostname";
-    # TODO: why are the following two modules called on sle but not on opensuse?
     # TODO: check if the following two modules also work on opensuse and delete if
     if (check_var('DISTRI', 'sle')) {
         loadtest "console/yast2_nis";
@@ -457,7 +456,6 @@ sub load_extra_tests() {
             # start extra x11 tests from here
             loadtest 'x11/vnc_two_passwords';
             # TODO: check why this is not called on opensuse
-            loadtest 'x11/yast2_lan_restart';
             loadtest 'x11/user_defined_snapshot';
         }
         elsif (check_var('DISTRI', 'opensuse')) {
@@ -482,6 +480,7 @@ sub load_extra_tests() {
             }
 
         }
+        loadtest 'x11/yast2_lan_restart';
     }
     else {
         loadtest "console/zypper_lr";

--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -263,31 +263,6 @@ sub run() {
     select_special_device_tab('VLAN');
     check_network;
     del_device('VLAN');
-    diag '__________(10) Start yast2 lan -> Edit (a NIC) -> change from DHCP to static, [Next] -> [OK]__________';
-    type_string "# (10) restart\n";
-    run_yast2_lan_edit;
-    send_key 'alt-t';    # Static address
-    send_key 'alt-i';    # Select IP field
-    type_string '10.0.2.1';
-    send_key 'tab';      # Subnet mask
-    type_string '/24';
-    send_key 'tab';      # Hostname
-    type_string 'openqa';
-    save_screenshot;
-    send_key 'alt-n';    # Next
-    wait_still_screen;
-    send_key 'alt-s';    # Hostname/DNS tab
-    assert_screen 'yast2_lan_hostname_tab';
-    send_key 'alt-1';    # Name server 1
-    type_string '10.160.2.88';
-    wait_still_screen 4, 4;    # blinking cursor
-    save_screenshot;
-    send_key 'alt-u';          # Routing tab
-    assert_screen 'yast2_lan_routing_tab';
-    type_string '10.0.2.2';
-    wait_still_screen 4, 4;    # blinking cursor
-    save_screenshot;
-    check_network('restart');
     diag '__________(9) checks described in (2), (5) - (7) static configuration__________';
     type_string "# (9.2) NO restart\n";
     test_2;
@@ -297,12 +272,6 @@ sub run() {
     test_6;
     type_string "# (9.7) restart\n";
     test_7('sta0');
-    diag '__________(10) Start yast2 lan -> Edit (a NIC) -> change from static to DHCP, [Next] -> [OK]__________';
-    type_string "# (10) restart\n";
-    run_yast2_lan_edit;
-    send_key 'alt-y';    # Dynamic address
-    send_key 'alt-n';    # Next
-    check_network('restart');
     type_string "killall xterm\n";
 }
 


### PR DESCRIPTION
- yast2_lan_restart.pm: remove test part NIC DHCP static
with nameserver ip which doesn't work on openSUSE production server
- please check reference tests: 
SLES 12 SP3: http://e13.suse.de/tests/3325#step/yast2_lan_restart
openSUSE TW: http://e13.suse.de/tests/3324#step/yast2_lan_restart
openSUSE Leap: http://e13.suse.de/tests/3327#step/yast2_lan_restart
- please see related ticket for further details: https://progress.opensuse.org/issues/19922
