### PR TITLE
Log available space on hd before installing apache

### DIFF
--- a/tests/console/http_srv.pm
+++ b/tests/console/http_srv.pm
@@ -18,10 +18,10 @@ use utils;
 
 sub run() {
     select_console 'root-console';
-
+    # Log space available before installation, see poo#19834
+    script_run("df -h > /dev/$serialdev", 0);
     # Install apache2
     zypper_call("in apache2");
-
     # After installation, apache2 is disabled
     assert_script_run "systemctl show -p UnitFileState apache2.service|grep UnitFileState=disabled";
 
@@ -37,6 +37,15 @@ sub run() {
         timeout      => 90,
         fail_message => 'Could not access local apache2 instance'
     );
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    $self->SUPER::post_fail_hook;
+    select_console('log-console');
+    # Log disk usage if test failed, see poo#19834
+    script_run("df -h > /dev/$serialdev", 0);
+
 }
 
 1;


### PR DESCRIPTION
During one of the executions it was not possible to install apache due
to lack of space on the hard drive. HDD setting is set to 20GB, and
apache takes 15MB only which is not really expected. Even though it
doesn't happen often. On top of that mariadb was successfully installed
in next test case, even though it requires 150MB for installation.
Here we log disk usage in order to identify the root cause of the issue
if it reoccurs.
[Verification run](http://gershwin.arch.suse.de/tests/804)
[Progress ticket](https://progress.opensuse.org/issues/19834)