### PR TITLE
Readd StartXinted option to ftp autoyast profile

### DIFF
--- a/data/autoyast_sle12sp2/ftp.xml
+++ b/data/autoyast_sle12sp2/ftp.xml
@@ -39,6 +39,7 @@
     <SSLv2>NO</SSLv2>
     <SSLv3>NO</SSLv3>
     <StartDaemon>2</StartDaemon>
+    <StartXinetd>YES</StartXinetd>
     <TLS>YES</TLS>
     <Umask/>
     <UmaskAnon>022</UmaskAnon>


### PR DESCRIPTION
After discussion with autoyast team in commit
2fff9863946e96b78bbdb9b533faef6d450812b9 we have removed this option, as
it was not really used in the yast code. However, it is required
according ot the comment #3 in bsc#1047232. So we introduce it back.
Documentation for this option is already merged and will be available to
the customers, as was missing previously which was the reason to remove
it.
No verification run provided as test fails. Whereas, see the comment #3 in [bsc#1047232](https://bugzilla.suse.com/show_bug.cgi?id=1047232)