### PR TITLE
Increase shutdown timer from 60 to 120s

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -703,7 +703,12 @@ sub power_action {
         assert_shutdown_and_restore_system($action);
     }
     else {
-        assert_shutdown if $action eq 'poweroff';
+        if ($action eq 'poweroff') {
+            # switch to console to view log
+            # interesting in case of hang.
+            wait_screen_change(sub { send_key 'ctrl-alt-f2'; }, 1);
+            assert_shutdown 120;
+        }
         reset_consoles;
     }
 }


### PR DESCRIPTION
and switch from X to console session
to display potential message why shutdown do not complete.

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>

try to understand  why test hang on shutdown for Leap 42.3:
https://openqa.opensuse.org/tests/445498#step/shutdown/5