### PR TITLE
Virtualization: Add serial console setting for xen

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -18,7 +18,7 @@ use strict;
 use warnings;
 use testapi;
 
-our @EXPORT = qw(use_ssh_serial_console);
+our @EXPORT = qw(use_ssh_serial_console set_serial_console_on_xen);
 
 #With the new ipmi backend, we only use the root-ssh console when the SUT boot up,
 #and no longer setup the real serial console for either kvm or xen.
@@ -34,6 +34,151 @@ sub use_ssh_serial_console() {
     set_var('SERIALDEV', 'sshserial');
     bmwqemu::save_vars();
 }
+
+my $grub_ver;
+
+sub get_dom0_serialdev() {
+    my $root_dir = shift;
+    $root_dir //= '/';
+
+    my $dom0_serialdev;
+
+    script_run("clear");
+    script_run("cat ${root_dir}/etc/SuSE-release");
+    save_screenshot;
+    assert_screen([qw(on_host_sles_12_sp2_or_above on_host_lower_than_sles_12_sp2)]);
+
+    if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
+        if (match_has_tag("on_host_sles_12_sp2_or_above")) {
+            $dom0_serialdev = "hvc0";
+        }
+        elsif (match_has_tag("on_host_lower_than_sles_12_sp2")) {
+            $dom0_serialdev = "xvc0";
+        }
+    }
+    else {
+        $dom0_serialdev = 'ttyS1';
+    }
+
+    if (match_has_tag("grub1")) {
+        $grub_ver = "grub1";
+    }
+    else {
+        $grub_ver = "grub2";
+    }
+
+    type_string("echo \"Debug info: hypervisor serial dev should be $dom0_serialdev. Grub version is $grub_ver.\"\n");
+
+    return $dom0_serialdev;
+}
+
+sub setup_console_in_grub {
+    my ($ipmi_console, $root_dir) = @_;
+    $ipmi_console //= $serialdev;
+    $root_dir //= '/';
+
+    #set grub config file
+    my $grub_cfg_file;
+    if ($grub_ver eq "grub2") {
+        $grub_cfg_file = "${root_dir}/boot/grub2/grub.cfg";
+    }
+    elsif ($grub_ver eq "grub1") {
+        $grub_cfg_file = "${root_dir}/boot/grub/menu.lst";
+    }
+    else {
+        die "The grub version is not supported!";
+    }
+
+    #setup serial console for xen
+    my $cmd;
+    if ($grub_ver eq "grub2") {
+        #grub2
+        $cmd
+          = "cp $grub_cfg_file ${grub_cfg_file}.org \&\& sed -ri '/(multiboot|module\\s*.*vmlinuz)/ {s/(console|loglevel|log_lvl|guest_loglvl)=[^ ]*//g; /multiboot/ s/\$/ console=com2,115200 log_lvl=all guest_loglvl=all/; /module\\s*.*vmlinuz/ s/\$/ console=$ipmi_console,115200 console=tty loglevel=5/;}' $grub_cfg_file";
+        assert_script_run("$cmd");
+        save_screenshot;
+        $cmd = "sed -rn '/(multiboot|module\\s*.*vmlinuz)/p' $grub_cfg_file";
+        assert_script_run("$cmd");
+    }
+    elsif ($grub_ver eq "grub1") {
+        $cmd
+          = "cp $grub_cfg_file ${grub_cfg_file}.org \&\&  sed -i 's/timeout [0-9]*/timeout 10/; /module \\\/boot\\\/vmlinuz/{s/console=.*,115200/console=$ipmi_console,115200/g;}' $grub_cfg_file";
+        assert_script_run("$cmd");
+        save_screenshot;
+        $cmd = "sed -rn '/module \\\/boot\\\/vmlinuz/p' $grub_cfg_file";
+        assert_script_run("$cmd");
+    }
+    else {
+        die "Not supported grub version!";
+    }
+    save_screenshot;
+    upload_logs("$grub_cfg_file");
+}
+
+sub mount_installation_disk() {
+    my ($installation_disk, $mount_point) = @_;
+
+    #default from yast installation
+    $installation_disk //= "/dev/sda2";
+    $mount_point       //= "/mnt";
+
+    #mount
+    assert_script_run("mkdir -p $mount_point");
+    assert_script_run("mount $installation_disk $mount_point");
+    assert_script_run("ls ${mount_point}/boot");
+}
+
+sub umount_installation_disk() {
+    my $mount_point = shift;
+
+    #default from yast installation
+    $mount_point //= "/mnt";
+
+    #umount
+    assert_script_run("umount -l $mount_point");
+    assert_script_run("ls $mount_point");
+}
+
+sub get_installation_partition() {
+    my $partition = script_output("fdisk -l | grep \"^\/dev\/sda\.\*\\\*\" | cut -d ' ' -f 1");
+    return $partition;
+}
+
+#Usage:
+#For post installation, use set_serial_console_on_xen directly
+#For during installation, use set_serial_console_on_xen("/mnt")
+#For custom usage, use set_serial_console_on_xen($mount_point, $installation_disk)
+sub set_serial_console_on_xen() {
+    my ($mount_point, $installation_disk) = @_;
+
+    #prepare accessible grub
+    my $root_dir;
+    if ($mount_point ne "") {
+        #when mount point is not empty, needs to mount installation disk
+        if ($installation_disk eq "") {
+            #search for the real installation partition on the first disk, which is selected by yast in ipmi installation
+            $installation_disk = &get_installation_partition;
+        }
+        #mount partition
+        assert_script_run("cd /");
+        &mount_installation_disk("$installation_disk", "$mount_point");
+        $root_dir = $mount_point;
+    }
+    else {
+        $root_dir = "/";
+    }
+
+    #set up xen serial console
+    my $ipmi_console = &get_dom0_serialdev("$root_dir");
+    &setup_console_in_grub($ipmi_console, $root_dir);
+
+    #cleanup mount
+    if ($mount_point ne "") {
+        assert_script_run("cd /");
+        &umount_installation_disk("$mount_point");
+    }
+}
+
 
 1;
 

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -20,18 +20,12 @@ sub run() {
     if (check_var('BACKEND', 'ipmi')) {
         select_console 'sol', await_console => 0;
     }
-    assert_screen([qw(virttest-bootloader qa-net-selection)], 300);
+    assert_screen([qw(virttest-pxe-menu qa-net-selection)], 300);
     my $image_path = "";
 
     #detect pxe location
-    if (match_has_tag("virttest-bootloader")) {
+    if (match_has_tag("virttest-pxe-menu")) {
         #BeiJing
-        # Wait the second screen for ipmi bootloader
-        send_key_until_needlematch "virttest-boot-into-pxe", "f12", 3, 60;
-
-        # Wait pxe management screen
-        send_key_until_needlematch "virttest-pxe-menu", "f12", 200, 1;
-
         # Login to command line of pxe management
         send_key_until_needlematch "virttest-pxe-edit-prompt", "esc", 60, 1;
 

--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -149,6 +149,8 @@ sub run() {
         # we require ssh installation anyway
         if (check_var('BACKEND', 'ipmi')) {
             use_ssh_serial_console;
+            # set serial console for xen
+            &set_serial_console_on_xen("/mnt") if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen"));
         }
         else {
             # avoid known issue in FIPS mode: bsc#985969

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -16,6 +16,7 @@ use warnings;
 use testapi;
 use base "virt_autotest_base";
 use virt_utils;
+use ipmi_backend_utils;
 
 sub update_package() {
     my $self           = shift;
@@ -42,6 +43,7 @@ sub update_package() {
 sub run() {
     my $self = shift;
     $self->update_package();
+    set_serial_console_on_xen if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen"));
     repl_repo_in_sourcefile();
 }
 


### PR DESCRIPTION
What it solves:
Currently all sles12sp3 xen tests fail on openqa.suse.de at login_console step, this is because xen serial console is not properly set , however ipmitool kind of relies on serial console output. So on the third generation ipmi backend, xen serial console should always be well set.

This code support settting up xen serial console both during installation and after installation.

Also beijing pxe server is different from nuremburg, so also update boot_from_pxe code for beijing test server/machines.

Successful job link:
http://147.2.212.149/tests/128

