### PR TITLE
Add extra logging before reboot with gnome

### DIFF
--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -18,6 +18,19 @@ use utils;
 
 sub run() {
     my ($self) = @_;
+    if (check_var('DISTRI', 'sle')) {
+        # Increase logging level for bsc#1000599
+        select_console("root-console");
+        # Long string, hence type slowly
+        type_string_slow "sed -i 's|\\(/usr/lib/gnome-settings-daemon-3.0/gnome-settings-daemon\\)|\\1 --debug|g'"
+          . " /usr/lib/gnome-settings-daemon-3.0/gnome-settings-daemon-localeexec\n";
+        type_string_slow "sed -i 's|\\(/usr/lib/gnome-settings-daemon-3.0/gnome-settings-daemon-localeexec\\)|systemd-cat \\1|g'"
+          . " /etc/xdg/autostart/gnome-settings-daemon.desktop\n";
+        # Restart gnome to apply changes to services
+        assert_script_run "systemctl restart xdm";
+        # After restarting gnome need to login again
+        handle_login;
+    }
     # 'keepconsole => 1' is workaround for bsc#1044072
     power_action('reboot', keepconsole => 1);
 


### PR DESCRIPTION
In [bsc#100059](https://bugzilla.suse.com/show_bug.cgi?id=1000599) we have an issue that logout dialog does not appear after
pressing ctrl-alt-delete keys. This issue is not easy to reproduce, and
now it mainly occurs on power and aarch. We were requested to provide
extra logs. I've tried to use shared ppc workers, but was not able to
reach reboot_gnome test as it fails before. After discussion we've
decided to introduce these steps in production and revert them as soon
as we have logs.
After increasing logging level for services, we also restart xdm and
then need to login again.

Note:

[Progress ticket](https://progress.opensuse.org/issues/20344)
[Verification run](http://gershwin.arch.suse.de/tests/689)