### PR TITLE
Add softfail for dns autoyast test

### DIFF
--- a/data/autoyast_sle12sp2/dns.sh
+++ b/data/autoyast_sle12sp2/dns.sh
@@ -4,6 +4,13 @@ set -e -x
 systemctl start named
 nslookup cr01.openqa.local 127.0.0.1
 nslookup 172.16.0.10 127.0.0.1
-nslookup 127.0.0.1 127.0.0.1
-nslookup localhost 127.0.0.1 
+nslookup localhost 127.0.0.1
+# Ignore result as known issue bsc#1046605
+result=$(nslookup 127.0.0.1 127.0.0.1 || true)
+if [[ $result == *"** server can't find 1.0.0.127.in-addr.arpa: SERVFAIL"* ]]; then
+   echo "Expected error, see bsc#1046605: $result";
+else
+  return 1;
+fi
+
 echo "AUTOYAST OK"

--- a/tests/autoyast/autoyast_verify.pm
+++ b/tests/autoyast/autoyast_verify.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE Linux GmbH
+# Copyright (C) 2015-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -12,14 +12,25 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
-
-# G-Summary: merge of sles11sp4 autoyast test, base commit
-# G-Maintainer: Pavel Sladek <psladek@suse.cz>
+#
+# Summary: common framework to run verification scripts for systems
+#          installed with autoyast
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
 
 use strict;
 use base 'basetest';
 use testapi;
 use lockapi;
+
+sub expected_failures {
+    # Function is used to sof-fail known issues. As long as we use generic
+    # framework here, we need to perform additional checks to identify
+    # particular test case based on script url
+    my ($script_output) = @_;
+    if ($script_output =~ /bsc#1046605/) {
+        record_soft_failure('bsc#1046605');
+    }
+}
 
 sub run {
     my $self = shift;
@@ -89,6 +100,8 @@ sub run {
         ./verify.sh
         ');
         $success = 1 if $res =~ /AUTOYAST OK/;
+        # Soft-fail known bugs
+        expected_failures($res);
     }
 
     save_screenshot;


### PR DESCRIPTION
One of the reverse zones is not configured properly with given autoyast
profile which is a bug. Unfortunately, there is no chance that it gets
fixed in sp3, but should work in sle15. As we don't want to forget about
this issue, we don't exclude this check, but introduce soft-failure.

[Progress ticket](https://progress.opensuse.org/issues/17366)
[Verification run](http://gershwin.arch.suse.de/tests/707#step/autoyast_verify/8)