### PR TITLE
Add tests for libvirt-lxc and system container image

### DIFF
--- a/data/virtualization/syscontainer.xml
+++ b/data/virtualization/syscontainer.xml
@@ -1,0 +1,40 @@
+<domain type='lxc'>
+  <name>guest</name>
+  <memory unit='MiB'>256</memory>
+  <currentMemory unit='MiB'>256</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <resource>
+    <partition>/machine</partition>
+  </resource>
+  <os>
+    <type arch='x86_64'>exe</type>
+    <init>/sbin/init</init>
+  </os>
+  <clock offset='utc'/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>restart</on_crash>
+  <devices>
+    <filesystem type='mount' accessmode='passthrough'>
+      <source dir='/tmp/rootfs'/>
+      <target dir='/'/>
+    </filesystem>
+    <filesystem type='mount' accessmode='passthrough'>
+      <source dir='/etc/resolv.conf'/>
+      <target dir='/etc/resolv.conf'/>
+    </filesystem>
+    <interface type='network'>
+      <source network='default'/>
+      <ip address='192.168.122.5' family='ipv4' prefix='24'/>
+      <route address='0.0.0.0' prefix='0' gateway='192.168.122.1'/>
+    </interface>
+    <console type='pty'>
+      <target type='lxc' port='0'/>
+    </console>
+    <hostdev mode='capabilities' type='misc'>
+      <source>
+        <char>/dev/ttyS0</char>
+      </source>
+    </hostdev>
+  </devices>
+</domain>

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -64,6 +64,7 @@ our @EXPORT = qw(
   load_create_hdd_tests
   is_memtest
   is_mediacheck
+  load_syscontainer_tests
 );
 
 sub init_main {
@@ -825,6 +826,26 @@ sub is_memtest {
 
 sub is_mediacheck {
     return get_var('MEDIACHECK');
+}
+
+sub load_syscontainer_tests() {
+    return unless get_var('SYSCONTAINER_IMAGE_TEST');
+    # pre-conditions for system container tests ie. the tests are running based on preinstalled image
+    return if get_var("INSTALLONLY") || get_var("DUALBOOT") || get_var("RESCUECD");
+
+    # setup $serialdev permission and so on
+    loadtest "console/consoletest_setup";
+
+    # Install needed pieces
+    loadtest 'virtualization/libvirtlxc_setup';
+
+    # Register if possible
+    if (check_var('DISTRI', 'sle')) {
+        loadtest "console/suseconnect_scc";
+    }
+
+    # Run the actual test
+    loadtest 'virtualization/syscontainer_image_test';
 }
 
 1;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -797,6 +797,10 @@ elsif (get_var("FILESYSTEM_TEST")) {
     boot_hdd_image;
     load_filesystem_tests();
 }
+elsif (get_var("SYSCONTAINER_IMAGE_TEST")) {
+    boot_hdd_image;
+    load_syscontainer_tests();
+}
 elsif (get_var('GNUHEALTH')) {
     boot_hdd_image;
     loadtest 'gnuhealth/gnuhealth_install';

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1421,6 +1421,10 @@ elsif (get_var('Y2UITEST_NCURSES')) {
 elsif (get_var('Y2UITEST_GUI')) {
     load_yast2_gui_tests;
 }
+elsif (get_var("SYSCONTAINER_IMAGE_TEST")) {
+    boot_hdd_image;
+    load_syscontainer_tests();
+}
 elsif (get_var("WINDOWS")) {
     loadtest "installation/win10_installation";
 }

--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -21,7 +21,7 @@ use base 'y2logsstep';
 
 use testapi;
 use utils 'zypper_call';
-use version_utils 'sle_version_at_least';
+use version_utils qw(is_sle sle_version_at_least);
 use registration;
 
 sub run {
@@ -38,8 +38,10 @@ sub run {
     assert_script_run 'SUSEConnect --list-extensions';
 
     # add modules
-    foreach (split(',', $registration::SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')} . $scc_addons)) {
-        add_suseconnect_product("sle-module-" . lc($registration::SLE15_MODULES{$_}));
+    if (is_sle && sle_version_at_least('15')) {
+        foreach (split(',', $registration::SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')} . $scc_addons)) {
+            add_suseconnect_product("sle-module-" . lc($registration::SLE15_MODULES{$_}));
+        }
     }
     # check repos actually work
     zypper_call('refresh');

--- a/tests/virtualization/libvirtlxc_setup.pm
+++ b/tests/virtualization/libvirtlxc_setup.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: system containers images test setup, installing libvirt-lxc
+# Maintainer: Cédric Bosdonnat <cbosdonnat@suse.de>
+
+use base "basetest";
+use testapi;
+use utils;
+use strict;
+
+sub run() {
+    select_console 'root-console';
+
+    # Install libvirt's lxc driver
+    zypper_call('--gpg-auto-import-keys ref');
+    zypper_call('in libvirt-daemon-lxc libvirt-client libvirt-daemon-config-network');
+
+    # Make sure libvirtd is up and running with default network
+    assert_script_run('systemctl restart libvirtd');
+    assert_script_run('virsh net-start default');
+}
+
+sub test_flags() {
+    return {milestone => 1, fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/virtualization/syscontainer_image_test.pm
+++ b/tests/virtualization/syscontainer_image_test.pm
@@ -1,0 +1,89 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: tests running system containers images with libvirt-lxc
+# Maintainer: Cédric Bosdonnat <cbosdonnat@suse.de>
+
+use base "basetest";
+use testapi;
+use strict;
+
+sub run() {
+    select_console 'root-console';
+
+    return if check_var('DISTRI', 'sle') && !(get_var('SCC_REGCODE') || get_var('HDD_SCC_REGISTERED'));
+
+    # Check the repositories on the host first
+    assert_script_run("zypper lr");
+
+    my $url    = get_required_var('SYSCONTAINER_IMAGE_URL');
+    my $rootfs = '/tmp/rootfs';
+
+    # Create XML file
+    assert_script_run('curl -f ' . autoinst_url . '/data/virtualization/syscontainer.xml -o /tmp/test.xml');
+
+    if (check_var('DISTRI', 'sle')) {
+        my $scccredentials_mount
+          = '<filesystem type=\"mount\" accessmode=\"passthrough\">'
+          . '  <source dir=\"/etc/zypp/credentials.d/SCCcredentials\"/>'
+          . '  <target dir=\"/etc/zypp/credentials.d/SCCcredentials\"/>'
+          . '</filesystem>';
+        assert_script_run("sed -i -e \'s:</devices>:$scccredentials_mount</devices>:\' /tmp/test.xml");
+    }
+
+    # Setup root filesystem
+
+    #   - Unpack the image
+    my ($ext) = $url =~ /\.([^.]+)$/;
+    assert_script_run("curl -L -o syscontainer-image.tar.$ext $url");
+    assert_script_run("mkdir $rootfs");
+    assert_script_run("tar xf syscontainer-image.tar.$ext -C $rootfs");
+
+    #   - Set root password
+    assert_script_run("echo 'root:test' | chpasswd --root $rootfs");
+
+    # Create the container
+    script_run('virsh -c lxc:/// create --console /tmp/test.xml', 0);
+
+    # Check that the container actually started
+    assert_screen('syscontainer-login');
+
+    # Tests on the container
+
+    # Test login on the container
+    type_string("root\n");
+    type_password("test\n");
+
+    # Wait for the login to be done before continuing
+    assert_screen('syscontainer-prompt');
+
+    # Sort by command since we can't check the PIDs:
+    # this makes the needle more robust
+    script_run('ps -e --sort ucmd', 0);
+    assert_screen('syscontainer-procs');
+
+    # Test mounts
+    script_run('mount | sort', 0);
+    assert_screen('syscontainer-mounts');
+
+    # Test repositories
+    script_run('zypper lr');
+    assert_screen('syscontainer-repos');
+
+    # shutdown the container
+    script_run('poweroff', 0);
+    assert_screen('syscontainer-shutdown');
+}
+
+sub test_flags() {
+    return {milestone => 1, fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
libvirt-lxc can be used to run containers. This test runs a system
container image as a libvirt lxc container. This has the double
advantage to test both the image and the libvirt lxc driver.

This test is to be run by maintenance to test SLES 12 SP3+ system
container images, but could also be used for validating the
libvirt-lxc containers feature on both SLES and openSUSE.

System container images to test with can be found in: [home:cbosdonnat:branches:Virtualization:containers:images:openSUSE-Tumbleweed](https://build.opensuse.org/project/show/home:cbosdonnat:branches:Virtualization:containers:images:openSUSE-Tumbleweed)