### PR TITLE
Evolution use local servers

### DIFF
--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -139,13 +139,30 @@ sub check_libreoffice_dialogs() {
 # get email account information for Evolution test cases
 sub getconfig_emailaccount {
     my ($self) = @_;
-    my $url = "http://jupiter.bej.suse.com/openqa/password.conf";
+    my $local_config = << 'END_LOCAL_CONFIG';
+[internal_account_A]
+user = admin 
+mailbox = admin@localhost
+passwd = password123
+recvport =995
+imapport =993
+recvServer = localhost
+sendServer = localhost
+sendport =25
 
-
-    my $file = get($url);
+[internal_account_B]
+user = nimda
+mailbox = nimda@localhost
+passwd = password123
+recvport =995
+imapport =993
+recvServer = localhost
+sendServer = localhost
+sendport =25 
+END_LOCAL_CONFIG
 
     my $config = Config::Tiny->new;
-    $config = Config::Tiny->read_string($file);
+    $config = Config::Tiny->read_string($local_config);
 
     return $config;
 
@@ -420,7 +437,8 @@ sub setup_mail_account {
     };
     sleep 1;
     type_string "$mail_user";
-    $self->evolution_add_self_signed_ca($account);
+    send_key $self->{next};
+    send_key "ret";
     assert_screen "evolution_wizard-account-summary";
     send_key $self->{next};
     if (sle_version_at_least('12-SP2')) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -357,11 +357,14 @@ sub load_x11regression_message() {
         loadtest "x11regressions/empathy/empathy_aim";
         loadtest "x11regressions/empathy/empathy_irc";
         loadtest "x11regressions/evolution/evolution_smoke";
-        loadtest "x11regressions/evolution/evolution_mail_imap";
-        loadtest "x11regressions/evolution/evolution_mail_pop";
-        loadtest "x11regressions/evolution/evolution_timezone_setup";
-        loadtest "x11regressions/evolution/evolution_meeting_imap";
-        loadtest "x11regressions/evolution/evolution_meeting_pop";
+        loadtest "x11regressions/evolution/evolution_prepare_servers";
+        if (get_var("VERSION") =~ /12/) {
+            loadtest "x11regressions/evolution/evolution_mail_imap";
+            loadtest "x11regressions/evolution/evolution_mail_pop";
+            loadtest "x11regressions/evolution/evolution_timezone_setup";
+            loadtest "x11regressions/evolution/evolution_meeting_imap";
+            loadtest "x11regressions/evolution/evolution_meeting_pop";
+        }
     }
     if (get_var("DESKTOP") =~ /kde|gnome/) {
         loadtest "x11regressions/pidgin/prep_pidgin";

--- a/tests/x11regressions/evolution/evolution_prepare_servers.pm
+++ b/tests/x11regressions/evolution/evolution_prepare_servers.pm
@@ -1,0 +1,81 @@
+# Evolution tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Setup dovecot and postfix servers as backend for evolution
+# Maintainer: Petr Cervinka <pcervinka@suse.com>
+
+use strict;
+use base "x11regressiontest";
+use testapi;
+use utils;
+
+sub run() {
+    # check for the SLE version, die if not supported
+    # dovecot repository must be ajusted for versions > 12 to run full
+    # evolution imap/pop tests
+    die 'not supported SLE version' if not get_var('VERSION') =~ /12/;
+
+    select_console('root-console');
+    pkcon_quit;
+
+    # add SLES repository and install dovecot
+    zypper_call("ar http://download.suse.de/ibs/SUSE:/SLE-12:/Update/standard/ sle_server_repo");
+    zypper_call("--gpg-auto-import-keys ref");
+    zypper_call("in dovecot", exitcode => [0, 102, 103]);
+    save_screenshot;
+
+    # configure dovecot
+    assert_script_run "sed -i -e 's/#mail_location =/mail_location = mbox:~\\/mail:INBOX=\\/var\\/mail\\/%u/g' /etc/dovecot/conf.d/10-mail.conf";
+    assert_script_run "sed -i -e 's/#mail_access_groups =/mail_access_groups = mail/g' /etc/dovecot/conf.d/10-mail.conf";
+    assert_script_run "sed -i -e 's/#ssl_cert =/ssl_cert =/g' /etc/dovecot/conf.d/10-ssl.conf";
+    assert_script_run "sed -i -e 's/#ssl_key =/ssl_key =/g' /etc/dovecot/conf.d/10-ssl.conf";
+    assert_script_run "sed -i -e 's/auth_mechanisms = plain/auth_mechanisms = plain login/g' /etc/dovecot/conf.d/10-auth.conf";
+    assert_script_run "sed -i -e '96,98 s/#//g' /etc/dovecot/conf.d/10-master.conf";
+
+    # generate default certificate for dovecot and postfix
+    assert_script_run "cd /usr/share/doc/packages/dovecot;./mkcert.sh";
+
+    # configure postfix
+    assert_script_run "postconf -e 'smtpd_use_tls = yes'";
+    assert_script_run "postconf -e 'smtpd_tls_key_file = /etc/ssl/private/dovecot.pem'";
+    assert_script_run "postconf -e 'smtpd_tls_cert_file = /etc/ssl/private/dovecot.crt'";
+    assert_script_run "sed -i -e 's/#tlsmgr/tlsmgr/g' /etc/postfix/master.cf";
+    assert_script_run "postconf -e 'smtpd_sasl_auth_enable = yes'";
+    assert_script_run "postconf -e 'smtpd_sasl_path = private/auth'";
+    assert_script_run "postconf -e 'smtpd_sasl_type = dovecot'";
+
+    # start/restart services
+    assert_script_run "systemctl start dovecot";
+    assert_script_run "systemctl restart postfix";
+
+    # create test users
+    assert_script_run "useradd -m admin";
+    script_run "passwd admin", 0;    # set user's password
+    type_password "password123";
+    send_key 'ret';
+    type_password "password123";
+    send_key 'ret';
+
+    assert_script_run "useradd -m nimda";
+    script_run "passwd nimda", 0;    # set user's password
+    type_password "password123";
+    send_key 'ret';
+    type_password "password123";
+    send_key 'ret';
+    save_screenshot;
+
+    select_console 'x11';
+}
+
+sub test_flags() {
+    return {milestone => 1};         # add milestone flag to save setup in lastgood VM snapshot
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Fix poo#19320: Local imap/pop3, smtp servers were setup for evolution
tests. The dependency on the company infrastructure located in APAC
region was removed.

Several evolution tests (evolution_mail_imap, evolution_mail_pop, evolution_timezone_setup, evolution_meeting_imap and evolution_meeting_pop) fail from time time, because of usage of remote infrastructure.

Dovecot and postfix servers were setup as local backends
Dovecot is not part of the SLED, SLE repository was added.

Verification:
SLED12-SP3: http://10.100.12.105/tests/1016#
SLED12-SP2: http://10.100.12.105/tests/1013#

It should cover these progress issues:
19320,18772,19054,15134,17596,18266

