### PR TITLE
Improve partition warning handling soft-fail

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -121,7 +121,9 @@ sub run {
             # Softfail only on sle, as timeout is there on CaaSP
             if (check_var('DISTRI', 'sle') && check_screen('warning-partition-reduced', 0)) {
                 # See poo#19978, no timeout on partition warning, hence need to click OK button to soft-fail
-                record_soft_failure('bsc#1045470');
+                record_info('bsc#1045470',
+                        "There is no timeout on sle for reduced partition screen by default.\n"
+                      . "But there is timeout on CaaSP and if explicitly defined in profile. See bsc#1045470 for details.");
                 send_key_until_needlematch 'create-partition-plans-finished', $cmd{ok};
                 next;
             }


### PR DESCRIPTION
When we have introduced this soft-fail I was not aware that in some
profiles we have warning timeout configured explicitly, meaning we have
timeout on reduced partition screen. However, test will soft-fail with
bug reference that timeout is not shown. This commit improves behavior
and soft-fails only if there is no timeout, which we check with
wait_screen_change function call.

Here are two verification runs:
[run with timeout](http://gershwin.arch.suse.de/tests/741#step/installation/5)
[run without timeout](http://gershwin.arch.suse.de/tests/739#live)