### PR TITLE
Virtualization: workaround for broken serial on xen during reboot

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -94,7 +94,11 @@ sub setup_console_in_grub {
     if ($grub_ver eq "grub2") {
         #grub2
         $cmd
-          = "cp $grub_cfg_file ${grub_cfg_file}.org \&\& sed -ri '/(multiboot|module\\s*.*vmlinuz)/ {s/(console|loglevel|log_lvl|guest_loglvl)=[^ ]*//g; /multiboot/ s/\$/ console=com2,115200 log_lvl=all guest_loglvl=all/; /module\\s*.*vmlinuz/ s/\$/ console=$ipmi_console,115200 console=tty loglevel=5/;}' $grub_cfg_file";
+          = "cp $grub_cfg_file ${grub_cfg_file}.org "
+          . "\&\& sed -ri '/(multiboot|module\\s*.*vmlinuz)/ "
+          . "{s/(console|loglevel|log_lvl|guest_loglvl)=[^ ]*//g; "
+          . "/multiboot/ s/\$/ console=com2,115200 log_lvl=all guest_loglvl=all sync_console/; "
+          . "/module\\s*.*vmlinuz/ s/\$/ console=$ipmi_console,115200 console=tty loglevel=5/;}' $grub_cfg_file";
         assert_script_run("$cmd");
         save_screenshot;
         $cmd = "sed -rn '/(multiboot|module\\s*.*vmlinuz)/p' $grub_cfg_file";
@@ -148,7 +152,7 @@ sub get_installation_partition() {
 #For post installation, use set_serial_console_on_xen directly
 #For during installation, use set_serial_console_on_xen("/mnt")
 #For custom usage, use set_serial_console_on_xen($mount_point, $installation_disk)
-sub set_serial_console_on_xen() {
+sub set_serial_console_on_xen {
     my ($mount_point, $installation_disk) = @_;
 
     #prepare accessible grub

--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -150,7 +150,7 @@ sub run() {
         if (check_var('BACKEND', 'ipmi')) {
             use_ssh_serial_console;
             # set serial console for xen
-            &set_serial_console_on_xen("/mnt") if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen"));
+            set_serial_console_on_xen("/mnt") if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen"));
         }
         else {
             # avoid known issue in FIPS mode: bsc#985969


### PR DESCRIPTION
From the sles12sp3 gmc test result, 3 jobs fail because bug  1037937, which reports that xen serail sometimes breaks after allocating console ring. Developer recommend this workaround. I made several test locally, it works fine. So push it.