### PR TITLE
Virtualization: pvusb test uses PVUSB_DEVICE from worker's setting as test usb

### DIFF
--- a/tests/virt_autotest/pvusb_run.pm
+++ b/tests/virt_autotest/pvusb_run.pm
@@ -19,9 +19,12 @@ use testapi;
 
 sub get_script_run() {
     my $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-pvusb-run";
-    my $which_usb    = get_var("USB_PATTERN", "");
-    my $qa_repo      = get_var("QA_HEAD_REPO", "http://dist.nue.suse.com/ibs/QA:/Head/SLE-12-SP3/");
-    my $guest        = get_var("GUEST", "sles-12-sp3-64-fv-def-net");
+    my $which_usb = get_var("PVUSB_DEVICE", "");
+    if ($which_usb eq "") {
+        die "The PVUSB_DEVICE is not properly set in workers.ini.";
+    }
+    my $qa_repo = get_var("QA_HEAD_REPO", "http://dist.nue.suse.com/ibs/QA:/Head/SLE-12-SP3/");
+    my $guest   = get_var("GUEST",        "sles-12-sp3-64-fv-def-net");
     $pre_test_cmd = $pre_test_cmd . " -w \"" . $which_usb . "\"";
     $pre_test_cmd = $pre_test_cmd . " -r $qa_repo -g $guest";
 


### PR DESCRIPTION
Different ipmi machines have different usb device. Instead of statically setting the usb device from testsuite, with this, the device will be read from worker setting.