### PR TITLE
Make ftp tests more stable

### DIFF
--- a/tests/console/yast2_ftp.pm
+++ b/tests/console/yast2_ftp.pm
@@ -13,12 +13,13 @@
 use strict;
 use base "console_yasttest";
 use testapi;
+use utils qw(type_string_slow zypper_call);
 
 sub run() {
     select_console 'root-console';
 
     # install vsftps
-    assert_script_run("zypper -n -q in vsftpd yast2-ftp-server");
+    zypper_call("-q in vsftpd yast2-ftp-server");
 
     # bsc#694167
     # create RSA certificate for ftp server at first which can be used for SSL configuration
@@ -26,108 +27,91 @@ sub run() {
 
     # create DSA certificate for ftp server at first which can be used for SSL configuration
     script_run("openssl dsaparam -out dsaparam.pem 1024");
-    type_string("openssl req -x509 -nodes -days 365 -newkey dsa:dsaparam.pem -keyout /etc/vsftpd.pem -out /etc/vsftpd.pem\n");
+    type_string_slow("openssl req -x509 -nodes -days 365 -newkey dsa:dsaparam.pem \\\n"
+          . "-subj '/C=DE/ST=Bayern/L=Nuremberg/O=Suse/OU=QA/CN=localhost/emailAddress=admin\@localhost' \\\n"
+          . "-keyout /etc/vsftpd.pem -out /etc/vsftpd.pem\n");
 
-    sleep 2;
-    type_string "DE\n";
-    type_string "bayern\n";
-    type_string "nuremberg\n";
-    type_string "SUSE\n";
-    type_string "QA\n";
-    type_string "localhost\n";
-    type_string "admin\@localhost\n";
+    assert_script_run("`[[ -e /etc/vsftpd.pem ]]`");    # check vsftpd.pem is created
 
-    assert_script_run("ls -l /etc/vsftpd.pem");    # check vsftpd.pem is created
-
-    # start yast2 apache2 configuration
-    script_run("yast2 ftp-server; echo yast2-ftp-server-status-\$? > /dev/$serialdev", 0);
-    assert_screen 'ftp-server';                    # check ftp server configuration page
-    send_key 'alt-w';                              # make sure ftp start-up when booting
-    check_screen 'ftp_server_when_booting';        # check service start when booting
+    # start yast2 ftp configuration
+    type_string "yast2 ftp-server; echo yast2-ftp-server-status-\$? > /dev/$serialdev\n";
+    assert_screen 'ftp-server';                         # check ftp server configuration page
+    send_key 'alt-w';                                   # make sure ftp start-up when booting
+    assert_screen 'ftp_server_when_booting';            # check service start when booting
 
     # General
-    send_key_until_needlematch 'yast2_ftp_start-up_selected', 'shift-tab';
-    wait_still_screen 1;
-    send_key 'down';
-    wait_still_screen 1;
-    send_key 'ret';                                # enter page General
-    assert_screen 'ftp_welcome_mesage';            # check welcome message for add strings
-    send_key 'alt-w';                              # select welcome message to edit
-    for (1 .. 20) { send_key 'backspace'; }        # delete existing welcome strings
-    type_string 'This is QA FTP server, welcome!'; # type new welcome text
-    assert_screen 'ftp_welcome_message_added';     # check new welcome text
-    send_key 'alt-u';                              # select umask for anounymous
-    type_string '0022';                            # set 755
-    send_key 'alt-s';                              # select umask for authenticated users
-    type_string '0022';                            # set 755
-    assert_screen 'ftp_umask_value';               # check umask value
-    send_key 'alt-y';                              # give a new directory for anonymous users
-    for (1 .. 20) { send_key 'backspace'; }
+    send_key_until_needlematch 'yast2_ftp_start-up_selected', 'tab';
+    wait_screen_change { send_key 'down' };
+    wait_screen_change { send_key 'ret' };              # enter page General
+
+    assert_screen 'yast2_tftp_general_selected';
+    assert_screen 'ftp_welcome_mesage';                 # check welcome message for add strings
+    send_key 'alt-w';                                   # select welcome message to edit
+    send_key_until_needlematch 'yast2_tftp_empty_welcome_message', 'backspace';    # delete existing welcome strings
+    type_string 'This is QA FTP server, welcome!';                                 # type new welcome text
+    assert_screen 'ftp_welcome_message_added';                                     # check new welcome text
+    send_key 'alt-u';                                                              # select umask for anounymous
+    type_string '0022';                                                            # set 755
+    send_key 'alt-s';                                                              # select umask for authenticated users
+    type_string '0022';                                                            # set 755
+    assert_screen 'ftp_umask_value';                                               # check umask value
+    wait_screen_change { send_key 'alt-y' };                                       # give a new directory for anonymous users
+    send_key_until_needlematch 'yast2_tftp_empty_anon_dir', 'backspace';
     type_string '/srv/ftp/anonymous';
-    send_key 'alt-t';                              # give a new directory for authenticated users
+    send_key 'alt-t';                                                              # give a new directory for authenticated users
     wait_still_screen 1;
     type_string '/srv/ftp/authenticated';
-    assert_screen 'yast2_ftp_general_directories';    # check new directories for ftp users
+    assert_screen 'yast2_ftp_general_directories';                                 # check new directories for ftp users
     send_key 'alt-o';
     assert_screen 'yast2_ftp_directory_browse';
     send_key 'alt-c';
 
     # Performance
     send_key_until_needlematch 'yast2_tftp_general_selected', 'shift-tab';
-    send_key 'down';
-    wait_still_screen 1;
-    send_key 'ret';
-    wait_still_screen 1;
+    wait_screen_change { send_key 'down' };
+    wait_screen_change { send_key 'ret' };
     send_key 'alt-m';
-    for (1 .. 5) { send_key 'down'; }
-    send_key 'alt-e';    # change max client for one IP
-    for (1 .. 4) { send_key 'up'; }
-    send_key 'alt-x';    # change max clients to 20
-    for (1 .. 11) { send_key 'up'; }
-    send_key 'alt-l';    # change local max rate to 100 kb/s
-    for (1 .. 20) { send_key 'up'; }
-    send_key 'alt-r';    # change anonymous max rate to 50 kb/s
-    for (1 .. 10) { send_key 'up'; }
-    assert_screen 'yast2_ftp_performance-settings';    # check performance settings
+    type_string_slow "10\n";
+    send_key 'alt-e';                                                              # change max client for one IP
+    type_string_slow "7\n";
+    send_key 'alt-x';                                                              # change max clients to 20
+    type_string_slow "20\n";
+    send_key 'alt-l';                                                              # change local max rate to 100 kb/s
+    type_string_slow "100\n";
+    send_key 'alt-r';                                                              # change anonymous max rate to 50 kb/s
+    type_string_slow "50\n";
+    assert_screen 'yast2_ftp_performance-settings';                                # check performance settings
 
     # Authentication
     send_key_until_needlematch 'yast2_tftp_performance_selected', 'shift-tab';
-    send_key 'down';
-    wait_still_screen 1;
-    send_key 'ret';
-    wait_still_screen 1;
+    wait_screen_change { send_key 'down' };
+    wait_screen_change { send_key 'ret' };
     send_key 'alt-e';
     assert_screen 'yast2_ftp_authentication_enabled';
-    send_key 'alt-y';
-    wait_still_screen 1;
-    send_key 'alt-s';
-    send_key 'alt-s';                              # disable creating directories
-    assert_screen 'yast2_ftp_anonymous_upload';    # check upload settings
+    wait_screen_change { send_key 'alt-y' };
+    send_key_until_needlematch 'yast2_tftp_anon_create_dir_disabled', 'alt-s';     # disable creating directories
+    assert_screen 'yast2_ftp_anonymous_upload';                                    # check upload settings
 
     # Expert Settings
     send_key_until_needlematch 'yast2_tftp_authentication_selected', 'shift-tab';
-    send_key 'down';
-    wait_still_screen 1;
+    wait_screen_change { send_key 'down' };
     send_key 'ret';
-    wait_still_screen 1;
-    assert_screen 'yast2_ftp_create_upload_dir_confirm';    # confirm to create upload directory
-    send_key 'alt-y';
-    wait_still_screen 1;
-    send_key 'alt-m';
-    for (1 .. 4) { send_key 'down'; }
-    send_key 'alt-a';
-    for (1 .. 4) { send_key 'up'; }
-    send_key 'alt-l';                                       # enable SSL
-    assert_screen 'yast2_ftp_expert_settings';              # check passive mode value and enable SSL
-    send_key 'alt-s';                                       # give path for DSA certificate
+    assert_screen 'yast2_ftp_create_upload_dir_confirm';                           # confirm to create upload directory
+    wait_screen_change { send_key 'alt-y' };
+    wait_screen_change { send_key 'alt-m' };
+    type_string_slow "30000\n";
+    wait_screen_change { send_key 'alt-a' };
+    type_string_slow "30100\n";
+    wait_screen_change { send_key 'alt-l' };                                       # enable SSL
+    assert_screen 'yast2_ftp_expert_settings';                                     # check passive mode value and enable SSL
+    wait_screen_change { send_key 'alt-s' };                                       # give path for DSA certificate
     type_string '/etc/vsftpd.pem';
-    send_key 'alt-p';                                       # open port in firewall
-    wait_still_screen 1;
-    send_key 'alt-f';                                       # done and close the configuration page now
-
+    wait_screen_change { send_key 'alt-p' };                                       # open port in firewall
+    send_key 'alt-f';                                                              # done and close the configuration page now
 
     # yast might take a while on sle12 due to suseconfig
-    wait_serial("yast2-ftp-server-status-0", 60) || die "'yast2 ftp-server' didn't finish";
+    die "'yast2 ftp-server' didn't exit with zero exit code in defined timeout" unless wait_serial("yast2-ftp-server-status-0", 180);
+    assert_screen 'yast2_console-finished';
 
     # let's try to run it
     assert_script_run "systemctl start vsftpd.service";


### PR DESCRIPTION
Initial issue is that ftp tests are unstable on Leap. With introduced
changes we want to make it more stable. This is achieved by performing
checks that screen has changed after pressing certain key, etc. Problem
appears only on Leap, for SLE and TW tests are stable. The main issue
is that it's hard to say when ftp wizard has finished it's work.
Previously we used serial output to wait for, whereas 60 seconds timeout
isn't always enough. So main change here to fix tests is increase of
timeout, but to assert that console appeared.

See [poo#20204](https://progress.opensuse.org/issues/20204).
Requires needles merge: [PR#227](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/227)

Verification run:
http://gershwin.arch.suse.de/tests/870#

Note: test was executed 15 times on rather box with only 2 cores in parallel with other tests. We may wait for other tests improvement from ticket https://progress.opensuse.org/issues/19922 to merge all together and test in dev job group, as tests are not executed with leap due to instability of the results.