### PR TITLE
Check typed password before pressing return

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -367,6 +367,7 @@ sub ensure_unlocked_desktop {
         }
         if ((match_has_tag 'displaymanager-password-prompt') || (match_has_tag 'gnome-screenlock-password')) {
             type_password;
+            assert_screen 'locked_screen-typed_password';
             send_key 'ret';
         }
         if (match_has_tag 'generic-desktop') {


### PR DESCRIPTION
### Description

That might avoid the enter key to be pressed too early and be detected wrong. By asserting that the password is typed.


### Issue

[poo#19094](https://progress.opensuse.org/issues/19094)


### Verification run

- Tumbleweed [copland#1024#step/consoletest_finish/13](http://copland.arch.suse.de/tests/1024#step/consoletest_finish/13)
- Leap 42.3 [copland#1023#step/consoletest_finish/15](http://copland.arch.suse.de/tests/1023#step/consoletest_finish/15)
- Leap 42.2 [copland#1028#step/consoletest_finish/13](http://copland.arch.suse.de/tests/1028#step/consoletest_finish/13)
- SLE 12 SP3 [copland#1029#step/consoletest_finish/13](http://copland.arch.suse.de/tests/1029#step/consoletest_finish/13)


### Needles

- [gh#os-autoinst-needles-opensuse/228](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/228)
- [gh#os-autoinst-needles-sles/422](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/422)