### PR TITLE
Update tests for gnuhealth version 3.2

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -780,6 +780,7 @@ elsif (get_var("FILESYSTEM_TEST")) {
 elsif (get_var('GNUHEALTH')) {
     boot_hdd_image;
     loadtest 'gnuhealth/gnuhealth_install';
+    loadtest 'gnuhealth/gnuhealth_setup';
     loadtest 'gnuhealth/tryton_install';
     loadtest 'gnuhealth/tryton_preconfigure';
     loadtest 'gnuhealth/tryton_first_time';

--- a/tests/gnuhealth/gnuhealth_install.pm
+++ b/tests/gnuhealth/gnuhealth_install.pm
@@ -17,27 +17,6 @@ use testapi;
 sub run() {
     my ($self) = @_;
     ensure_installed 'gnuhealth';
-    x11_start_program 'xterm';
-    assert_screen 'xterm';
-    become_root;
-    assert_script_run 'systemctl start postgresql';
-    wait_screen_change { script_run 'su postgres', 0 };
-    script_run 'sed -i -e \'s/\(local.*all.*all.*\)md5/\1trust/g\' /var/lib/pgsql/data/pg_hba.conf', 0;
-    script_run 'psql -c "CREATE USER tryton WITH CREATEDB;"',                                        0;
-    wait_screen_change { send_key 'ctrl-d' };
-    assert_script_run 'systemctl restart postgresql';
-    # generate the crypted password as described in /etc/tryton/trytond.conf
-    # but with no randomness for easier testing and preventing a stray '/' to
-    # destroy the sed call
-    script_run 'pw=$(python -c \'import getpass,crypt; print(crypt.crypt(getpass.getpass(), str(123456789)))\')', 0;
-    wait_still_screen(1);
-    type_string "susetesting\n";
-    assert_script_run 'sed -i -e "s/^.*super_pwd.*\$/super_pwd = ${pw}/g" /etc/tryton/trytond.conf';
-    assert_script_run 'systemctl start trytond';
-    # exit from root session
-    send_key 'ctrl-d';
-    # exit xterm
-    send_key 'ctrl-d';
 }
 
 sub test_flags() {

--- a/tests/gnuhealth/gnuhealth_setup.pm
+++ b/tests/gnuhealth/gnuhealth_setup.pm
@@ -1,0 +1,54 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Initial setup of gnuhealth, e.g. database
+# Maintainer: Oliver Kurz <okurz@suse.de>
+
+use base 'x11test';
+use strict;
+use testapi;
+
+sub run() {
+    my ($self) = @_;
+    x11_start_program 'xterm';
+    assert_screen 'xterm';
+    become_root;
+    assert_script_run 'systemctl start postgresql';
+    wait_screen_change { script_run 'su postgres', 0 };
+    script_run 'sed -i -e \'s/\(\(local\|host\).*all.*all.*\)\(md5\|ident\)/\1trust/g\' /var/lib/pgsql/data/pg_hba.conf', 0;
+    script_run 'psql -c "CREATE USER tryton WITH CREATEDB;"',                                                             0;
+    if (check_var('VERSION', 'Tumbleweed') || leap_version_at_least('42.3')) {
+        script_run 'createdb gnuhealth --encoding=\'UTF8\' --owner=tryton', 0;
+    }
+    script_run 'exit', 0;
+    assert_script_run 'systemctl restart postgresql';
+    # generate the crypted password as described in /etc/tryton/trytond.conf
+    # but with no randomness for easier testing and preventing a stray '/' to
+    # destroy the sed call
+    script_run 'pw=$(python -c \'import getpass,crypt; print(crypt.crypt(getpass.getpass(), str(123456789)))\')', 0;
+    wait_still_screen(1);
+    type_string "susetesting\n";
+    assert_script_run 'sed -i -e "s/^.*super_pwd.*\$/super_pwd = ${pw}/g" /etc/tryton/trytond.conf';
+    if (check_var('VERSION', 'Tumbleweed') || leap_version_at_least('42.3')) {
+        assert_script_run 'echo susetesting > /tmp/pw';
+        assert_script_run 'sudo -u tryton env TRYTONPASSFILE=/tmp/pw trytond-admin -c /etc/tryton/trytond.conf --all -d gnuhealth --password', 600;
+    }
+    assert_script_run 'systemctl start trytond';
+    # exit from root session
+    send_key 'ctrl-d';
+    # exit xterm
+    send_key 'ctrl-d';
+}
+
+sub test_flags() {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/gnuhealth/tryton_first_time.pm
+++ b/tests/gnuhealth/tryton_first_time.pm
@@ -15,7 +15,14 @@ use strict;
 use testapi;
 
 sub run() {
-    send_key_until_needlematch 'tryton-login_password', 'tab';
+    if (check_var('VERSION', 'Tumbleweed') || leap_version_at_least('42.3')) {
+        wait_screen_change { send_key 'tab' };
+        send_key 'ret';
+        assert_screen 'tryton-login_password';
+    }
+    else {
+        send_key_until_needlematch 'tryton-login_password', 'tab';
+    }
     type_string "susetesting\n";
     assert_screen 'tryton-module_configuration_wizard_start';
     send_key 'ret';

--- a/tests/gnuhealth/tryton_preconfigure.pm
+++ b/tests/gnuhealth/tryton_preconfigure.pm
@@ -25,21 +25,28 @@ sub run() {
     send_key_until_needlematch 'tryton-manage_profiles-host_textfield_selected', 'tab';
     type_string 'localhost';
     send_key 'tab';
-    # button 'create' should appear, weird GUI behaviour
-    assert_and_click 'tryton-manage_profiles-create_database';
-    # tryton server password
-    type_string 'susetesting';
-    send_key 'tab';
-    # database name
-    type_string 'gnuhealth_demo';
-    send_key 'tab';
-    send_key 'tab';
-    # admin password
-    type_string 'susetesting';
-    send_key 'tab';
-    type_string 'susetesting';
-    # wait for create button to be active
-    assert_and_click 'tryton-manage_profiles-create_database-create';
+    if (check_var('VERSION', 'Tumbleweed') || leap_version_at_least('42.3')) {
+        assert_screen 'tryton-manage_profiles-database_selected';
+        type_string 'admin';
+    }
+    else {
+        # button 'create' should appear, weird GUI behaviour
+        assert_and_click 'tryton-manage_profiles-create_database';
+        # tryton server password
+        type_string 'susetesting';
+        send_key 'tab';
+        # database name
+        type_string 'gnuhealth_demo';
+        send_key 'tab';
+        send_key 'tab';
+        # admin password
+        type_string 'susetesting';
+        send_key 'tab';
+        type_string 'susetesting';
+        # wait for create button to be active
+        assert_and_click 'tryton-manage_profiles-create_database-create';
+
+    }
     # back to profiles menue
     assert_screen 'tryton-manage_profiles-add', 300;
     send_key 'ret';


### PR DESCRIPTION
The workflow of gnuhealth changed significantly with the new version 3.2 which
we have in openSUSE Tumbleweed and openSUSE Leap 42.3 now. Because of security
concerns trytond does not allow the creation of the database from the tryton
client GUI anymore but these steps have to be done manually in before. As the
setup therefore become more complicated a new test module 'gnuhealth_setup' is
extracted.

Corresponding needle PR:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/229

Verification runs:
* new needles created in interactive mode: http://lord.arch/tests/6822
* Full run: http://lord.arch/tests/6823

Related progress issue: https://progress.opensuse.org/issues/20340