### PR TITLE
Follow-up to f6ae63d for gnuhealth tests - include utils

### DIFF
--- a/tests/gnuhealth/gnuhealth_setup.pm
+++ b/tests/gnuhealth/gnuhealth_setup.pm
@@ -13,6 +13,7 @@
 use base 'x11test';
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     my ($self) = @_;

--- a/tests/gnuhealth/tryton_first_time.pm
+++ b/tests/gnuhealth/tryton_first_time.pm
@@ -13,6 +13,7 @@
 use base 'x11test';
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     if (check_var('VERSION', 'Tumbleweed') || leap_version_at_least('42.3')) {

--- a/tests/gnuhealth/tryton_preconfigure.pm
+++ b/tests/gnuhealth/tryton_preconfigure.pm
@@ -13,6 +13,7 @@
 use base 'x11test';
 use strict;
 use testapi;
+use utils;
 
 sub run() {
     x11_start_program 'tryton';


### PR DESCRIPTION
Follow-up to f6ae63d for gnuhealth tests - include utils

Fixes #3296
Fixes "Undefined subroutine &gnuhealth_setup::leap_version_at_least"
Fixes https://openqa.opensuse.org/tests/448719#step/gnuhealth_setup/1

I haven't tested it, but looks straightforward. 