### PR TITLE
Prevent yast2_lan_restart failing on other than gnome

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -480,7 +480,7 @@ sub load_extra_tests() {
             }
 
         }
-        loadtest 'x11/yast2_lan_restart';
+        loadtest 'x11/yast2_lan_restart' if check_var('DISTRI', 'gnome');
     }
     else {
         loadtest "console/zypper_lr";


### PR DESCRIPTION
See
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3264#issuecomment-315543231