### PR TITLE
Update zypper_crit_sec_fix_only.pm: register sle

### DIFF
--- a/tests/feature/feature_console/zypper_crit_sec_fix_only.pm
+++ b/tests/feature/feature_console/zypper_crit_sec_fix_only.pm
@@ -27,7 +27,8 @@ sub run {
         script_run "SUSEConnect --status | tee /dev/$serialdev", 0;
         my $out = wait_serial [$not_registered, $registered];
         if ($out =~ $not_registered) {
-            die "The test can only be run on registered system\n";
+            set_var 'SCC_REGISTER', 'console';
+            yast_scc_registration;
         }
     }
 


### PR DESCRIPTION
Fix poo#20366: Register sle image if it isn't already registered,
because the test can only be run on registered system.