### PR TITLE
Wireshark, remove 'exit' without console reset

### DIFF
--- a/tests/x11/wireshark.pm
+++ b/tests/x11/wireshark.pm
@@ -75,9 +75,6 @@ sub run {
     select_console 'root-console';
     assert_script_run "dig www.suse.com A";
     assert_script_run "host www.suse.com";    # check for valid IP address
-    type_string "exit\n";                     # logout
-    wait_still_screen 2;
-    save_screenshot();
     select_console 'x11', await_console => 0;
     assert_screen "wireshark-capturing";
 


### PR DESCRIPTION
Exiting virtual console without reseting it make openQA unable to login
to it once needed:
https://openqa.suse.de/tests/1060715#step/reboot_gnome/2

Removing the 'exit' as well as some other code, which I believe should
just support the 'exit', and is now of no use.