### PR TITLE
Set password on CaaSP workers for log export

### DIFF
--- a/tests/casp/stack_admin.pm
+++ b/tests/casp/stack_admin.pm
@@ -28,7 +28,7 @@ sub run {
     # Wait in loop until velum is available until controller node can connect
     my $timeout   = 240;
     my $starttime = time;
-    while (script_run 'curl -kI https://localhost | grep velum') {
+    while (script_run 'curl -kLI localhost | grep velum') {
         my $timerun = time - $starttime;
         if ($timerun < $timeout) {
             sleep 15;

--- a/tests/casp/stack_controller.pm
+++ b/tests/casp/stack_controller.pm
@@ -59,6 +59,7 @@ sub velum_bootstrap {
     # Nodes are moved from pending - minus admin & controller
     my $nodes = get_var('STACK_SIZE') - 2;
     assert_screen_with_soft_timeout("velum-$nodes-nodes-accepted", timeout => 90, soft_timeout => 15, bugref => 'bsc#1046663');
+    mutex_create "NODES_ACCEPTED";
 
     # Select all nodes for bootstrap
     assert_and_click 'velum-bootstrap-select-nodes';

--- a/tests/casp/stack_worker.pm
+++ b/tests/casp/stack_worker.pm
@@ -23,8 +23,8 @@ sub run {
 }
 
 sub post_run_hook {
-    # Workers installed using autoyast have no password - bsc#1030876
-    return if get_var('AUTOYAST');
+    # Password is set later on autoyast nodes
+    select_console('root-console') if get_var('AUTOYAST');
 
     script_run "journalctl > journal.log", 90;
     upload_logs "journal.log";


### PR DESCRIPTION
CaaSP workers installed with autoyast have no root password. With this change we will set password for all workers using salt after accepting them to cluster. Logs can be exported after that from all nodes.

Minor improvement is also test for redirection to https

Local run: http://dhcp91.suse.cz/tests/6679#step/stack_worker/3
 - failed on local openqa issue after successful login