### PR TITLE
Improve addon boot parameter logic

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -386,7 +386,7 @@ sub specific_bootmenu_params {
     }
 
     # For leap 42.3 we don't have addon_products screen
-    if (!addon_products_is_applicable()) {
+    if (addon_products_is_applicable() && leap_version_at_least('42.3')) {
         my $addon_url = get_var("ADDONURL");
         $addon_url =~ s/\+/,/g;
         $args .= " addon=" . $addon_url;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -264,7 +264,7 @@ sub ssh_key_import {
 }
 
 sub addon_products_is_applicable {
-    return !get_var("LIVECD") && get_var("ADDONURL") && !leap_version_at_least('42.3');
+    return !get_var("LIVECD") && get_var("ADDONURL");
 }
 
 sub remove_common_needles {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -283,7 +283,7 @@ sub load_inst_tests {
     if (installwithaddonrepos_is_applicable() && !get_var("LIVECD")) {
         loadtest "installation/setup_online_repos";
     }
-    if (addon_products_is_applicable()) {
+    if (addon_products_is_applicable() && !leap_version_at_least('42.3')) {
         loadtest "installation/addon_products";
     }
     if (noupdatestep_is_applicable() && !get_var("LIVECD") && !get_var("REMOTE_CONTROLLER")) {


### PR DESCRIPTION
In initial commit PR#3233 minor mistake in the flow was done. In case of
leap, even when ADDONURL variable is empty, we would add "addon" boot
parameter. These changes fixes this problem and also makes it more clear
what is the logic behind.