### PR TITLE
Groupwise start test

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -398,6 +398,7 @@ sub load_x11regression_message {
         loadtest "x11regressions/evolution/evolution_timezone_setup";
         loadtest "x11regressions/evolution/evolution_meeting_imap";
         loadtest "x11regressions/evolution/evolution_meeting_pop";
+        loadtest "x11regressions/groupwise/groupwise";
     }
     if (get_var("DESKTOP") =~ /kde|gnome/) {
         loadtest "x11regressions/pidgin/prep_pidgin";

--- a/tests/x11regressions/groupwise/groupwise.pm
+++ b/tests/x11regressions/groupwise/groupwise.pm
@@ -1,0 +1,36 @@
+# Groupwise tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Groupwise client check
+# Maintainer: Petr Cervinka <pcervinka@suse.com>
+
+use strict;
+use base "x11regressiontest";
+use testapi;
+use utils;
+
+sub run() {
+    select_console('root-console');
+    pkcon_quit;
+
+    # add repository and install groupwise
+    zypper_call("ar http://download.suse.de/ibs/SUSE:/Factory:/Head:/Internal/standard/ groupwise_repo");
+    zypper_call("--gpg-auto-import-keys ref");
+    zypper_call("in novell-groupwise-gwclient", exitcode => [0, 102, 103]);
+    zypper_call("rr groupwise_repo");
+    save_screenshot;
+
+    select_console 'x11';
+    x11_start_program("groupwise");    # start groupwise client
+    assert_screen "groupwise-groupwise-startup";
+    send_key "alt-f4";
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
New test poo#20092: Implement basic groupwise start to catch situation
with possible crash bsc#1045340.

Verification: http://10.100.12.105/tests/1067#step/groupwise/1
Needle: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/424