### PR TITLE
Process untrusted key on leap maintenance distri

### DIFF
--- a/tests/installation/installer_desktopselection.pm
+++ b/tests/installation/installer_desktopselection.pm
@@ -13,7 +13,9 @@
 
 use strict;
 use base "y2logsstep";
+use main_common "addon_products_is_applicable";
 use testapi;
+use utils "leap_version_at_least";
 
 sub run {
     assert_screen 'desktop-selection';
@@ -51,6 +53,14 @@ sub run {
         send_key_until_needlematch "$d-selected", 'tab';                       # select correct field to match needle
     }
     send_key $cmd{next};
+
+    # On leap 42.3 we don't have addon products page, and provide urls as addon
+    # as boot parameter. Trusting gpg key is the done after we click next
+    # on Desktop selection screen
+    if (addon_products_is_applicable() && leap_version_at_least('42.3')) {
+        assert_screen 'import-untrusted-gpg-key-598D0E63B3FD7E48';
+        send_key "alt-t";    # confirm import (trust) key
+    }
 
     if (get_var('NEW_DESKTOP_SELECTION') && $d eq 'custom') {
         assert_screen "pattern-selection";


### PR DESCRIPTION
On leap 42.3 maintenance do not have addon products screen. So, we put
addon urls as boot parameter. It lead to next problem that we have
untrusted gpg key and now have this step after Next button is clicked on
desktop selection screen. Existing needles are reused. Not much common
code can be extracted from addon_products test module.

[poo#16996](https://progress.opensuse.org/issues/16996)
Verification runs:
http://gershwin.arch.suse.de/tests/898
http://gershwin.arch.suse.de/tests/899