### PR TITLE
Improve yast gui proxy test stability

### DIFF
--- a/tests/console/yast2_ftp.pm
+++ b/tests/console/yast2_ftp.pm
@@ -111,7 +111,6 @@ sub run {
 
     # yast might take a while on sle12 due to suseconfig
     die "'yast2 ftp-server' didn't exit with zero exit code in defined timeout" unless wait_serial("yast2-ftp-server-status-0", 180);
-    assert_screen 'yast2_console-finished';
 
     # let's try to run it
     assert_script_run "systemctl start vsftpd.service";


### PR DESCRIPTION
Yast ui tests are extremely unstable on leap. Whereas there are some
modules which are fragile due to the test flow. Proxy is one of them. On
of the issues here is that in previous implementation we hit buttons,
but do not verify result of our actions. And in case of bad performance
it happens that some actions were not performed as expeted. As the
result, test fails. Another issue is that it's also not clear why test
failed and what exactly went wrong.

Required needles for openSUSE are located here: [PR#238](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/238)
For SLE: [MR#426](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/426)

See [poo#20564](https://progress.opensuse.org/issues/20564).
Verification runs:
[SLE](http://10.160.66.147/tests/1284)
[TW](http://10.160.66.147/tests/1283)
[Leap](http://10.160.66.147/tests/1282)

Note: as we test stability, more runs are done here for TW and Leap, as this test module is unstable there.