### PR TITLE
Improve yast2 http gui test stability

### DIFF
--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -22,71 +22,85 @@ sub run {
     # install http server
     assert_script_run("/usr/bin/zypper -n -q in yast2-http-server");
     script_run("yast2 http-server; echo yast2-http-server-status-\$? > /dev/$serialdev", 0);
-    assert_screen 'http-server';              # check page "Initializing HTTP Server Configuration"
-    send_key 'alt-i';                         # make sure that apache2, apache2-prefork packages needs to be installed
-    assert_screen 'http_server_wizard';       # check http server wizard (1/5) -- Network Device Selection
-    send_key 'alt-n';                         # go to http server wizard (1/5) -- Network Device Selection
-    assert_screen 'http_server_modules';      # check modules and enable php, perl, python before go to next step
+    assert_screen 'http-server', 60;    # check page "Initializing HTTP Server Configuration"
+    wait_still_screen 1;
+    send_key 'alt-i';                               # make sure that apache2, apache2-prefork packages needs to be installed
+    assert_screen 'http_server_wizard';             # check http server wizard (1/5) -- Network Device Selection
+    wait_still_screen 1;
+    send_key 'alt-n';                               # go to http server wizard (1/5) -- Network Device Selection
+    assert_screen 'http_server_modules';            # check modules and enable php, perl, python before go to next step
+    wait_still_screen 1;
     send_key 'alt-p';
+    assert_screen 'http_modules_enabled_php';       # check php module enabled
     send_key 'alt-e';
+    assert_screen 'http_modules_enabled_perl';      # check perl module enabled
     send_key 'alt-y';
-    assert_screen 'http_modules_enabled';     # check 3 modules enabled
+    assert_screen 'http_modules_enabled_python';    # check python module enabled
+    wait_still_screen 1;
     send_key 'alt-n';
-    assert_screen 'http_default_host';        # check http server wizard (3/5) -- default host
-    send_key 'down';                          # select Directory for change
-    assert_screen 'http_new_directory';       # give a new directory
-    send_key 'alt-i';                         # open page dir configuration
-    assert_screen 'http_htdocs_new_dir';      # check dir configuration page ready for change directory
+    assert_screen 'http_default_host';              # check http server wizard (3/5) -- default host
+    wait_still_screen 1;
+    send_key 'down';                                # select Directory for change
+    assert_screen 'http_new_directory';             # give a new directory
+    wait_still_screen 1;
+    send_key 'alt-i';                               # open page dir configuration
+    assert_screen 'http_htdocs_new_dir';            # check dir configuration page ready for change directory
+    wait_still_screen 1;
     send_key 'alt-d';
     send_key 'left';
     type_string "/new_dir";
-    assert_screen 'http_new_dir_created';     # check new dir got created successfully
+    assert_screen 'http_new_dir_created';           # check new dir got created successfully
     send_key 'alt-o';
     wait_still_screen;
-    send_key 'alt-n';                         # now go to http server wizard (4/5)--virtual hosts
-    assert_screen 'http_add_host';            # check the page (4/5) is open and ready for adding a new virtual host
+    send_key 'alt-n';                               # now go to http server wizard (4/5)--virtual hosts
+    assert_screen 'http_add_host';                  # check the page (4/5) is open and ready for adding a new virtual host
+    wait_still_screen 1;
     send_key 'alt-a';
-    assert_screen 'http_new_host_info';       # check new host information page got open to edit
+    assert_screen 'http_new_host_info';             # check new host information page got open to edit
+    wait_still_screen 1;
     send_key 'alt-e';
-    type_string "/srv/www/htdocs/new_dir";    # give path for server contents root
+    type_string "/srv/www/htdocs/new_dir";          # give path for server contents root
+    wait_still_screen 1;
     send_key 'alt-s';
-    type_string 'localhost';                  # give server name
+    type_string 'localhost';                        # give server name
     send_key 'alt-a';
-    type_string 'admin@localhost';            # give admin e-mail
-    send_key 'alt-g';                         # check change virtual host later
-    assert_screen 'http_ip_addresses';        # check all adresses is selected
-    send_key 'alt-o';                         # close and go back to previous page
-    assert_screen 'http_previous_page';       # check the previous page for nex step
+    type_string 'admin@localhost';                  # give admin e-mail
+    send_key 'alt-g';                               # check change virtual host later
+    assert_screen 'http_ip_addresses';              # check all adresses is selected
+    send_key 'alt-o';                               # close and go back to previous page
+    assert_screen 'http_previous_page';             # check the previous page for nex step
     send_key 'alt-n';
-    assert_screen 'http_create_new_dir';      # confirm to create the new directory
+    assert_screen 'http_create_new_dir';            # confirm to create the new directory
     send_key 'alt-y';
-    assert_screen 'http_host_details';        # check virtual host details
-    send_key 'alt-a';                         # enable CGI
-    send_key 'alt-w';                         # open page CGI directory
-    assert_screen 'http_cgi_directory';       # check CGI directory -- to be continued...
-    send_key 'alt-d';                         # enable detailed view
-    assert_screen 'http_detailed_view';       # check permissions, user, group
-    send_key 'alt-o';                         # close page cgi directory and go back to previous page
-    assert_screen 'http_details_changed';     # now give here directory index
+    assert_screen 'http_host_details';              # check virtual host details
+    send_key 'alt-a';                               # enable CGI
+    wait_still_screen 1;
+    send_key 'alt-w';                               # open page CGI directory
+    assert_screen 'http_cgi_directory';             # check CGI directory -- to be continued...
+    send_key 'alt-d';                               # enable detailed view
+    assert_screen 'http_detailed_view';             # check permissions, user, group
+    send_key 'alt-o';                               # close page cgi directory and go back to previous page
+    assert_screen 'http_details_changed';           # now give here directory index
+    wait_still_screen 1;
     send_key 'alt-d';
-    type_string "http_virtual_01";            # index name
+    type_string "http_virtual_01";                  # index name
     send_key 'alt-p';
-    assert_screen 'http_all_details';         # check all details added
-    send_key 'alt-n';                         # go to page http server wizard (4/5) and confirm with next
-    assert_screen 'http_vitual_host_page';    # check wizard page (4/5)
-    send_key 'alt-n';                         # go to http server wizard (5/5) --summary
-    assert_screen 'http_summary';             # check the summary page and go to select start apache2 sever when booting
+    assert_screen 'http_all_details';               # check all details added
+    send_key 'alt-n';                               # go to page http server wizard (4/5) and confirm with next
+    assert_screen 'http_vitual_host_page';          # check wizard page (4/5)
+    send_key 'alt-n';                               # go to http server wizard (5/5) --summary
+    assert_screen 'http_summary';                   # check the summary page and go to select start apache2 sever when booting
     send_key 'alt-t';
-    assert_screen 'http_start_apache2';       # make sure that apache2 server got started when booting
-    send_key 'alt-f';                         # now finish the tests :)
+    assert_screen 'http_start_apache2';             # make sure that apache2 server got started when booting
+    send_key 'alt-f';                               # now finish the tests :)
     check_screen 'http_install_apache2_mods';
-    send_key 'alt-i';                         # confirm to install apache2_mod_perl, apache2_mod_php5, apache2_mod_python
+    send_key 'alt-i';                               # confirm to install apache2_mod_perl, apache2_mod_php5, apache2_mod_python
 
     # if popup, confirm to enable apache2 configuratuion
     if (check_screen('http_enable_apache2', 10)) {
-        send_key 'alt-o';
+        wait_screen_change { send_key 'alt-o'; };
     }
-    wait_serial("yast2-http-server-status-0", 60) || die "'yast2 http-server' didn't finish";
+    wait_serial("yast2-http-server-status-0", 180) || die "'yast2 http-server' didn't finish";
 }
 1;
 


### PR DESCRIPTION
Test is extremely unstable on leap. Adding more waiting for still screen
and increasing timeout in points where test fails on production helps to
mitigate the issue. After introducing suggested changes, I was able to
get 10+ successful runs in the row.

See [poo#20640](https://progress.opensuse.org/issues/20640).
Related needles: [PR#242](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/242)
[MR#428](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/428)
Verification runs: 
[Leap](http://10.160.66.147/tests/1263)
[TW](http://10.160.66.147/tests/1264)
[SLE](http://10.160.66.147/tests/1265)
