### PR TITLE
Don't type and check typed password for kde live

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -372,8 +372,10 @@ sub ensure_unlocked_desktop {
             send_key 'ret';
         }
         if ((match_has_tag 'displaymanager-password-prompt') || (match_has_tag 'gnome-screenlock-password')) {
-            type_password;
-            assert_screen 'locked_screen-typed_password';
+            if ($password ne '') {
+                type_password;
+                assert_screen 'locked_screen-typed_password';
+            }
             send_key 'ret';
         }
         if (match_has_tag 'generic-desktop') {


### PR DESCRIPTION
## Issue

KDE Live uses no password
[o3#453105#step/consoletest_finish/13](https://openqa.opensuse.org/tests/453105#step/consoletest_finish/13)

## Verification run

- [copland#1110](http://copland.arch.suse.de/tests/1110)
- [copland#1109](http://copland.arch.suse.de/tests/1109)