### PR TITLE
Stabilize yast2_ui tests on openSUSE

### DIFF
--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -14,6 +14,7 @@
 use base "console_yasttest";
 use strict;
 use testapi;
+use utils "zypper_call";
 
 # Test "yast2 dhcp-server" functionality
 # Ensure that all combinations of running/stopped and active/inactive
@@ -54,7 +55,7 @@ sub run {
     select_console 'root-console';
 
     # Make sure packages are installed
-    assert_script_run 'zypper -n in yast2-dns-server bind SuSEfirewall2';
+    zypper_call('in yast2-dns-server bind SuSEfirewall2', timeout => 180);
     # Let's pretend this is the first execution (could not be the case if
     # yast2_cmdline was executed before)
     script_run 'rm /var/lib/YaST2/dns_server';
@@ -71,7 +72,7 @@ sub run {
     assert_screen 'yast2-dns-server-step3';
     # Enable dns server and finish
     send_key 'alt-s';
-    send_key 'alt-f';
+    wait_screen_change { send_key 'alt-f'; };
     wait_idle;
     # The wizard-like interface still uses the old approach of always starting the service
     # while enabling it, so named should be both active and enabled

--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -24,9 +24,9 @@ sub run {
     script_run("yast2 http-server; echo yast2-http-server-status-\$? > /dev/$serialdev", 0);
     assert_screen 'http-server', 60;    # check page "Initializing HTTP Server Configuration"
     wait_still_screen 1;
-    send_key 'alt-i';                               # make sure that apache2, apache2-prefork packages needs to be installed
-    assert_screen 'http_server_wizard';             # check http server wizard (1/5) -- Network Device Selection
-    wait_still_screen 1;
+    send_key 'alt-i';                   # make sure that apache2, apache2-prefork packages needs to be installed
+    assert_screen 'http_server_wizard', 120;    # check http server wizard (1/5) -- Network Device Selection
+    wait_still_screen;
     send_key 'alt-n';                               # go to http server wizard (1/5) -- Network Device Selection
     assert_screen 'http_server_modules';            # check modules and enable php, perl, python before go to next step
     wait_still_screen 1;
@@ -50,51 +50,56 @@ sub run {
     send_key 'left';
     type_string "/new_dir";
     assert_screen 'http_new_dir_created';           # check new dir got created successfully
-    send_key 'alt-o';
-    wait_still_screen;
-    send_key 'alt-n';                               # now go to http server wizard (4/5)--virtual hosts
-    assert_screen 'http_add_host';                  # check the page (4/5) is open and ready for adding a new virtual host
+    wait_screen_change { send_key 'alt-o'; };
+    # Sometimes we don't get to the next page after first key press
+    # As part of poo#20668 we introduce this workaround to have reliable tests
+    # Go to http server wizard (4/5)--virtual hosts and check page (4/5 )is open
+    send_key 'alt-n';    # now
+    unless (check_screen 'http_add_host') {
+        send_key 'alt-n';
+    }
+    assert_screen 'http_add_host';            # check the page (4/5) is open and ready for adding a new virtual host
     wait_still_screen 1;
     send_key 'alt-a';
-    assert_screen 'http_new_host_info';             # check new host information page got open to edit
+    assert_screen 'http_new_host_info';       # check new host information page got open to edit
     wait_still_screen 1;
     send_key 'alt-e';
-    type_string "/srv/www/htdocs/new_dir";          # give path for server contents root
+    type_string "/srv/www/htdocs/new_dir";    # give path for server contents root
     wait_still_screen 1;
     send_key 'alt-s';
-    type_string 'localhost';                        # give server name
+    type_string 'localhost';                  # give server name
     send_key 'alt-a';
-    type_string 'admin@localhost';                  # give admin e-mail
-    send_key 'alt-g';                               # check change virtual host later
-    assert_screen 'http_ip_addresses';              # check all adresses is selected
-    send_key 'alt-o';                               # close and go back to previous page
-    assert_screen 'http_previous_page';             # check the previous page for nex step
+    type_string 'admin@localhost';            # give admin e-mail
+    send_key 'alt-g';                         # check change virtual host later
+    assert_screen 'http_ip_addresses';        # check all adresses is selected
+    send_key 'alt-o';                         # close and go back to previous page
+    assert_screen 'http_previous_page';       # check the previous page for nex step
     send_key 'alt-n';
-    assert_screen 'http_create_new_dir';            # confirm to create the new directory
+    assert_screen 'http_create_new_dir';      # confirm to create the new directory
     send_key 'alt-y';
-    assert_screen 'http_host_details';              # check virtual host details
-    send_key 'alt-a';                               # enable CGI
+    assert_screen 'http_host_details';        # check virtual host details
+    send_key 'alt-a';                         # enable CGI
     wait_still_screen 1;
-    send_key 'alt-w';                               # open page CGI directory
-    assert_screen 'http_cgi_directory';             # check CGI directory -- to be continued...
-    send_key 'alt-d';                               # enable detailed view
-    assert_screen 'http_detailed_view';             # check permissions, user, group
-    send_key 'alt-o';                               # close page cgi directory and go back to previous page
-    assert_screen 'http_details_changed';           # now give here directory index
+    send_key 'alt-w';                         # open page CGI directory
+    assert_screen 'http_cgi_directory';       # check CGI directory -- to be continued...
+    send_key 'alt-d';                         # enable detailed view
+    assert_screen 'http_detailed_view';       # check permissions, user, group
+    send_key 'alt-o';                         # close page cgi directory and go back to previous page
+    assert_screen 'http_details_changed';     # now give here directory index
     wait_still_screen 1;
     send_key 'alt-d';
-    type_string "http_virtual_01";                  # index name
+    type_string "http_virtual_01";            # index name
     send_key 'alt-p';
-    assert_screen 'http_all_details';               # check all details added
-    send_key 'alt-n';                               # go to page http server wizard (4/5) and confirm with next
-    assert_screen 'http_vitual_host_page';          # check wizard page (4/5)
-    send_key 'alt-n';                               # go to http server wizard (5/5) --summary
-    assert_screen 'http_summary';                   # check the summary page and go to select start apache2 sever when booting
+    assert_screen 'http_all_details';         # check all details added
+    send_key 'alt-n';                         # go to page http server wizard (4/5) and confirm with next
+    assert_screen 'http_vitual_host_page';    # check wizard page (4/5)
+    send_key 'alt-n';                         # go to http server wizard (5/5) --summary
+    assert_screen 'http_summary';             # check the summary page and go to select start apache2 sever when booting
     send_key 'alt-t';
-    assert_screen 'http_start_apache2';             # make sure that apache2 server got started when booting
-    send_key 'alt-f';                               # now finish the tests :)
+    assert_screen 'http_start_apache2';       # make sure that apache2 server got started when booting
+    send_key 'alt-f';                         # now finish the tests :)
     check_screen 'http_install_apache2_mods';
-    send_key 'alt-i';                               # confirm to install apache2_mod_perl, apache2_mod_php5, apache2_mod_python
+    send_key 'alt-i';                         # confirm to install apache2_mod_perl, apache2_mod_php5, apache2_mod_python
 
     # if popup, confirm to enable apache2 configuratuion
     if (check_screen('http_enable_apache2', 10)) {

--- a/tests/console/yast2_lan_hostname.pm
+++ b/tests/console/yast2_lan_hostname.pm
@@ -24,12 +24,12 @@ sub hostname_via_dhcp {
     send_key "alt-s";    # open hostname tab
     assert_screen "yast2_lan-hostname-tab";
     for (1 .. 4) { send_key 'tab' }    # go to roll-down list
-    send_key 'down';                   # open roll-down list
-    for (1 .. 3) { send_key 'up' }     # go on top of list
+    wait_screen_change { send_key 'down'; };    # open roll-down list
+    for (1 .. 3) { send_key 'up' }              # go on top of list
     send_key_until_needlematch "yast2_lan-hostname-DHCP-$dhcp", 'down';
-    send_key 'spc';                     # pick selected option
-    send_key 'alt-o';                   # OK=>Save&Exit
-    assert_screen 'console-visible';    # yast module exited
+    wait_screen_change { send_key 'spc'; };     # pick selected option
+    send_key 'alt-o';                           # OK=>Save&Exit
+    assert_screen 'console-visible';            # yast module exited
     wait_still_screen;
     if ($dhcp eq 'no') {
         assert_script_run 'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp|grep no';
@@ -40,6 +40,8 @@ sub hostname_via_dhcp {
         assert_script_run 'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp|grep no';
     }
     elsif ($dhcp eq 'yes-any') {
+        # sometimes settings not yep
+        sleep 60;
         assert_script_run 'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp|grep yes';
     }
 }

--- a/tests/console/yast2_nfs_client.pm
+++ b/tests/console/yast2_nfs_client.pm
@@ -16,7 +16,7 @@
 use base "console_yasttest";
 use strict;
 use testapi;
-
+use utils "zypper_call";
 
 sub run {
     #
@@ -27,7 +27,7 @@ sub run {
     assert_script_run 'sed -i \'5i# test comment\' /etc/fstab';
     assert_script_run 'cat /etc/fstab > fstab_before';
     # Make sure packages are installed
-    assert_script_run 'zypper -n in yast2-nfs-client nfs-client nfs-kernel-server';
+    zypper_call('in yast2-nfs-client nfs-client nfs-kernel-server', timeout => 180);
     # Prepare the test file structure
     assert_script_run 'mkdir -p /tmp/nfs/server';
     assert_script_run 'echo "It worked" > /tmp/nfs/server/file.txt';
@@ -52,8 +52,8 @@ sub run {
     send_key 'alt-m';
     type_string '/tmp/nfs/client';
     # Save the new connection and close YaST
-    send_key 'alt-o';
-    send_key 'alt-o';
+    wait_screen_change { send_key 'alt-o'; };
+    wait_screen_change { send_key 'alt-o'; };
     wait_idle;
 
     #

--- a/tests/console/yast2_ntpclient.pm
+++ b/tests/console/yast2_ntpclient.pm
@@ -13,36 +13,39 @@
 use strict;
 use base "console_yasttest";
 use testapi;
+use utils qw(type_string_slow zypper_call);
 
 sub run {
     select_console 'root-console';
-
+    # Test often fails due to info kernel messages disrupting screen
+    # Decrease logging level to warning to avoid this
+    assert_script_run "dmesg -n 4";
     # check network at first
     assert_script_run("if ! systemctl -q is-active network; then systemctl -q start network; fi");
 
     # install squid package at first
-    assert_script_run("zypper -n -q in yast2-ntp-client");
+    zypper_call("in yast2-ntp-client", timeout => 180);
 
     # start NTP configuration
     script_run("yast2 ntp-client; echo yast2-ntp-client-status-\$? > /dev/$serialdev", 0);
 
     # check Advanced NTP Configuration is opened
-    assert_screen 'yast2_ntp-client_configuration';
+    assert_screen 'yast2_ntp-client_configuration', 90;
 
     # use Synchronize without daemon
     send_key 'alt-y';
     assert_screen 'yast2_ntp-client_synchronize_without_daemon';
 
     # check Runtime Configuration Policy
-    send_key 'alt-r';
+    wait_screen_change { send_key 'alt-r'; };
     send_key 'up';
     assert_screen 'yast2_ntp-client_runtime_config_up';
     send_key 'down';
-    send_key 'ret';
+    wait_screen_change { send_key 'ret'; };
 
     # change Interval of Synchronization
     send_key 'alt-n';
-    for (1 .. 5) { send_key 'down'; }
+    type_string_slow "1\n";
 
     # check new interval of synchronization time
     assert_screen 'yast2_ntp-client_new_interval';
@@ -53,8 +56,7 @@ sub run {
     # check page new sychronization
     assert_screen 'yast2_ntp-client_new_synchronization';
     # select type of synchronization: server, then go next
-    send_key 'alt-p';
-    send_key 'alt-s';
+    send_key_until_needlematch 'yast2_ntp-client_sync_server', 'alt-s';
     send_key 'alt-n';
 
     # check NTP Server is displayed for changes
@@ -63,7 +65,7 @@ sub run {
     # select public ntp server
     send_key 'alt-s';
     assert_screen 'yast2_ntp-client_ntp_server_public';
-    send_key 'down';
+    wait_screen_change { send_key 'down'; };
     send_key 'ret';
 
     # check public ntp server is showing up and select UK
@@ -71,7 +73,7 @@ sub run {
     send_key 'alt-u';
     assert_screen 'yast2_ntp-client_public_ntp_country';
     send_key_until_needlematch 'yast2_ntp-client_country_uk', 'up';
-    send_key 'ret';
+    wait_screen_change { send_key 'ret'; };
     send_key 'alt-s';
     assert_screen 'yast2_ntp-client_public_ntp_server_uk';
     send_key 'ret';
@@ -98,16 +100,20 @@ sub run {
     type_string 'ntpclient.log';
     assert_screen 'yast2_ntp-client_new_file_name';
     send_key 'alt-o';
+    assert_screen 'yast2_ntp-client_display_log';
+    wait_still_screen 1;
     send_key 'alt-c';
-
+    # Assert that we are back to configuration page
+    assert_screen 'yast2_ntp-client_configuration';
+    wait_still_screen 1;
     # finish ntp client configuration after help page got opened
     send_key 'alt-h';
-    assert_screen 'yast2_ntp-client_help';
+    assert_screen 'yast2_ntp-client_help', 60;
+    wait_screen_change { send_key 'alt-o'; };
+    # Press ok to finish configuration
+    wait_screen_change { send_key 'alt-o'; };
 
-    send_key 'alt-o';
-    send_key 'alt-o';
-
-    wait_serial('yast2-ntp-client-status-0', 60);
+    wait_serial('yast2-ntp-client-status-0', 180);
 
     # add NTPD_FORCE_SYNC_ON_STARTUP=yes into /etc/ntp.conf, ntpd should start up at once
     script_run("echo NTPD_FORCE_SYNC_ON_STARTUP=yes >> /etc/ntp.conf");

--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -21,7 +21,7 @@ sub run {
     # check network at first
     assert_script_run("if ! systemctl -q is-active network; then systemctl -q start network; fi");
     # install local ldap server
-    zypper_call("in yast2-auth-server yast2-ldap openldap2 openldap2-client krb5-server krb5-client tdb-tools");
+    zypper_call("in yast2-auth-server yast2-ldap openldap2 openldap2-client krb5-server krb5-client tdb-tools", timeout => 240);
 
     script_run("yast2 auth-server; echo yast2-auth-server-status-\$? > /dev/$serialdev ", 0);
     # check ldap server configuration started

--- a/tests/console/yast2_tftp.pm
+++ b/tests/console/yast2_tftp.pm
@@ -18,7 +18,7 @@ use utils;
 sub run {
     select_console 'root-console';
 
-    zypper_call("in tftp yast2-tftp-server");
+    zypper_call("in tftp yast2-tftp-server", timeout => 240);
 
     script_run("yast2 tftp-server; echo yast2-tftp-server-status-\$? > /dev/$serialdev", 0);
     assert_screen 'yast2_tftp-server_configuration';
@@ -63,9 +63,8 @@ sub run {
     assert_screen 'yast2_tftp_create_new_directory';
     send_key 'alt-y';        # approve creation of new directory
 
-    # wait 60 seconds for yast2 tftp configuration got completed.
-    wait_serial("yast2-tftp-server-status-0") || die "'yast2 tftp-server' failed";
-    assert_screen 'yast2_console-finished';
+    # wait for yast2 tftp configuration completion
+    wait_serial("yast2-tftp-server-status-0", 180) || die "'yast2 tftp-server' failed";
 
     # create a test file for tftp server
     my $server_string = 'This is a QA tftp server';

--- a/tests/console/yast2_xinetd.pm
+++ b/tests/console/yast2_xinetd.pm
@@ -13,7 +13,7 @@
 use strict;
 use base "console_yasttest";
 use testapi;
-
+use utils "zypper_call";
 
 
 sub run {
@@ -22,7 +22,7 @@ sub run {
     # check network at first
     assert_script_run("if ! systemctl -q is-active network; then systemctl -q start network; fi");
     # install xinetd at first
-    assert_script_run("/usr/bin/zypper -n -q in xinetd");
+    zypper_call("in xinetd", timeout => 180);
 
     script_run("yast2 xinetd; echo yast2-xinetd-status-\$? > /dev/$serialdev", 0);
 
@@ -59,7 +59,7 @@ sub run {
     send_key 'alt-d';
     wait_still_screen 1;
     assert_screen 'yast2_xinetd_cannot_delete_again';
-    send_key 'alt-o';
+    wait_screen_change { send_key 'alt-o'; };
 
     # add a service
     send_key 'alt-a';
@@ -78,10 +78,10 @@ sub run {
     wait_still_screen 1;
 
     # close xinetd with finish
-    send_key 'alt-f';
+    wait_screen_change { send_key 'alt-f'; };
 
     # wait till xinetd got closed
-    wait_serial('yast2-xinetd-status-0', 60) || die "'yast2 xinetd' didn't finish";
+    wait_serial('yast2-xinetd-status-0', 180) || die "'yast2 xinetd' didn't finish";
 
     # check xinetd configuration
     assert_script_run("systemctl show -p ActiveState xinetd.service | grep ActiveState=active");

--- a/tests/yast2_gui/yast2_bootloader.pm
+++ b/tests/yast2_gui/yast2_bootloader.pm
@@ -18,6 +18,8 @@
 use base "y2x11test";
 use strict;
 use testapi;
+# TO be removed!!!
+use utils 'ensure_unlocked_desktop';
 
 sub run {
     my $self   = shift;
@@ -29,6 +31,7 @@ sub run {
     #	boot code options
     assert_and_click 'yast2-bootloader_grub2';
     assert_and_click 'yast2-bootloader_not-managed';
+    assert_screen 'yast2-bootloader_not-managed_warning';
     send_key 'alt-c';
 
     #	kernel parameters and use graphical console

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -47,6 +47,7 @@ sub start_addon_products {
 }
 
 sub start_add_system_extensions_or_modules {
+    search '';    # call with empty string to simply clean the field
     assert_and_click 'yast2_control-center_add-system-extensions-or-modules';
     assert_screen 'yast2_control-center_registration', timeout => 180;
     send_key 'alt-r';
@@ -287,7 +288,6 @@ sub run {
     start_software_repositories;
     start_printer;
     start_sound;
-    start_fonts;
     start_sysconfig_editor;
     start_partitioner;
     start_vpn_gateway;

--- a/tests/yast2_gui/yast2_firewall.pm
+++ b/tests/yast2_gui/yast2_firewall.pm
@@ -25,7 +25,7 @@ sub run {
     select_console 'x11', await_console => 0;
 
     $self->launch_yast2_module_x11('firewall');
-    assert_screen "yast2-firewall-ui", 30;
+    assert_screen "yast2-firewall-ui", 60;
 
     # 	enter page interfaces and change zone for network interface
     assert_and_click("yast2_firewall_config_list");
@@ -33,11 +33,14 @@ sub run {
     assert_and_click("yast2_firewall_interface_zone_change");
     wait_still_screen(2);
     assert_and_click("yast2_firewall_interface_no-zone_assigned");
+    wait_still_screen 1;
     wait_screen_change {
         send_key "down";
         send_key "ret"
     };
+    wait_still_screen 1;
     send_key "alt-o";
+    assert_screen "yast2_firewall_interfaces";
 
     # 	enter page Allowed Services and make  some changes
     assert_and_click("yast2_firewall_allowed-services");
@@ -48,7 +51,8 @@ sub run {
 
     #	enter page Broadcast and disable logging broadcast packets
     assert_and_click("yast2_firewall_broadcast");
-    send_key "alt-l";
+    wait_still_screen 1;
+    wait_screen_change { send_key "alt-l"; };
     send_key "alt-o";
     assert_screen "yast2_firewall_broadcast_no-logging";
 
@@ -59,6 +63,8 @@ sub run {
 
     #	enter page Custom Rules and check ui
     assert_and_click("yast2_firewall_custom-rules");
+    # verify Custom Rules page is displayed
+    assert_screen("yast2_firewall_custom-rules-loaded");
     send_key "alt-a";
     assert_screen "yast2_firewall_add-new-allowing-rules";
     send_key "alt-c";

--- a/tests/yast2_gui/yast2_hostnames.pm
+++ b/tests/yast2_gui/yast2_hostnames.pm
@@ -17,6 +17,8 @@
 use base "y2x11test";
 use strict;
 use testapi;
+use utils 'type_string_slow';
+
 
 sub run {
     my $self   = shift;
@@ -30,17 +32,26 @@ sub run {
     $self->launch_yast2_module_x11($module);
 
     assert_and_click "yast2_hostnames_added";
-    send_key 'alt-i';
+    wait_still_screen 1;
+    wait_screen_change { send_key 'alt-i'; };
     send_key 'alt-t';
     type_string 'download-srv';
+    wait_still_screen 1;
     send_key 'alt-h';
     type_string 'download.opensuse.org';
+    wait_still_screen 1;
     send_key 'alt-i';
-    type_string '195.135.221.134';
+    type_string_slow '195.135.221.134';
     assert_and_click 'yast2_hostnames_changed_ok';
     assert_screen "yast2-$module-ui", 30;
     #	OK => Exit
-    send_key "alt-o";
+    wait_screen_change { send_key "alt-o"; };
+}
+
+# override for base class to allow a longer timeout for package installation
+# before returning to desktop
+sub post_run_hook {
+    assert_screen 'generic-desktop', 600;
 }
 
 1;

--- a/tests/yast2_gui/yast2_lang.pm
+++ b/tests/yast2_gui/yast2_lang.pm
@@ -38,7 +38,15 @@ sub run {
     assert_screen 'yast2-lang_settings_done';
 
     # Now it will install required language packages and exit
-    send_key 'alt-o';
+    wait_screen_change { send_key 'alt-o'; };
+
+    # Problem here is that sometimes installation takes longer than 10 minutes
+    # And then screen saver is activated, so add this step to wake
+    my $timeout = 0;
+    until (check_screen 'generic-desktop' || ++$timeout > 10) {
+        sleep 60;
+        send_key 'ctrl';
+    }
 }
 
 # override for base class to allow a longer timeout for package installation


### PR DESCRIPTION
Now I've changed approach to intoroducing changes to multiple tests in
one run according to my findings on the runs. Process reminds a bit
pluging holes in a sinking boat with fingers. On top of that chances
to spot new potential issue are higher when tests are executed as a
suite and not separately.

Please, be aware that one of the main points is to make test suite
reliable even though we compromise some extra checks.

See poo#19922 and all blocking tasks.

Needles for SLE: [MR#430](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/430)
Needles for openSUSE: [PR#245](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/245)

Verification runs:
[TW](http://10.160.66.147/tests/1692)
[SLE](http://10.160.66.147/tests/1660)
[Leap](http://10.160.66.147/tests/1679)
