### PR TITLE
Use firefox_check_popup method in regression test suite

### DIFF
--- a/tests/x11/firefox_audio.pm
+++ b/tests/x11/firefox_audio.pm
@@ -12,20 +12,22 @@
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "x11test";
+use base "x11regressiontest";
 use strict;
 use testapi;
 
 sub run {
+    my ($self) = @_;
+    $self->start_firefox();
+    send_key "ctrl-l";
+    type_string(autoinst_url . "/data/1d5d9dD.oga");
+    send_key "ret";
     start_audiocapture;
-    x11_start_program("firefox " . autoinst_url . "/data/1d5d9dD.oga");
     assert_screen 'test-firefox_audio-1', 35;
     sleep 1;    # at least a second of silence
     assert_recorded_sound('DTMF-159D');
     send_key "alt-f4";
-    if (check_screen('firefox-save-and-quit', 4)) {
-        # confirm "save&quit"
-        send_key "ret";
-    }
+    $self->exit_firefox();
 }
 
 1;

--- a/tests/x11regressions/firefox/firefox_appearance.pm
+++ b/tests/x11regressions/firefox/firefox_appearance.pm
@@ -30,15 +30,10 @@ sub run {
     sleep 1;
     type_string "addons.mozilla.org/en-US/firefox/addon/opensuse\n";
     assert_screen('firefox-appearance-mozilla_addons', 90);
-    send_key "alt-f10";
-    wait_still_screen 3;
     assert_and_click "firefox-appearance-addto";
     assert_screen('firefox-appearance-installed', 90);
     # Undo the theme installation
     send_key "alt-u";
-
-    # Exit
-    for my $i (1 .. 2) { sleep 1; send_key "ctrl-w"; }
 
     $self->exit_firefox;
 }

--- a/tests/x11regressions/firefox/firefox_developertool.pm
+++ b/tests/x11regressions/firefox/firefox_developertool.pm
@@ -23,6 +23,7 @@ sub run {
     send_key "esc";
     send_key "alt-d";
     type_string "opensuse.org\n";
+    $self->firefox_check_popups;
     assert_screen('firefox-developertool-opensuse', 90);
     send_key "ctrl-shift-i";
     assert_screen('firefox-developertool-gerneral', 30);

--- a/tests/x11regressions/firefox/firefox_downloading.pm
+++ b/tests/x11regressions/firefox/firefox_downloading.pm
@@ -15,8 +15,8 @@ use strict;
 use base "x11regressiontest";
 use testapi;
 
-my $dl_link_01 = "http://mirrors.kernel.org/opensuse/distribution/13.2/iso/openSUSE-13.2-DVD-x86_64.iso\n";
-my $dl_link_02 = "http://mirrors.kernel.org/opensuse/distribution/13.2/iso/openSUSE-13.2-DVD-i586.iso\n";
+my $dl_link_01 = "http://mirrors.kernel.org/opensuse/distribution/leap/42.2/iso/openSUSE-Leap-42.2-DVD-x86_64.iso\n";
+my $dl_link_02 = "http://mirrors.kernel.org/opensuse/distribution/leap/42.3/iso/openSUSE-Leap-42.3-DVD-x86_64.iso\n";
 
 sub dl_location_switch {
     my ($tg) = @_;

--- a/tests/x11regressions/firefox/firefox_extcontent.pm
+++ b/tests/x11regressions/firefox/firefox_extcontent.pm
@@ -26,13 +26,9 @@ sub run {
     send_key "alt-d";
     sleep 1;
     type_string $ext_link. "\n";
+    $self->firefox_check_popups;
 
-    wait_still_screen 3;
-    assert_screen ['firefox-reader-view', 'firefox-extcontent-pageloaded'], 90;
-    if (match_has_tag 'firefox-reader-view') {
-        assert_and_click('firefox-reader-close');
-        assert_screen('firefox-extcontent-pageloaded');
-    }
+    assert_screen('firefox-extcontent-pageloaded');
 
     send_key "/";
     sleep 1;

--- a/tests/x11regressions/firefox/firefox_extensions.pm
+++ b/tests/x11regressions/firefox/firefox_extensions.pm
@@ -24,7 +24,7 @@ sub run {
     wait_still_screen 3;
     send_key "ctrl-shift-a";
     assert_screen('firefox-addons_manager', 90);
-
+    assert_and_click "firefox-extensions";
     assert_and_click "firefox-searchall-addon";
     type_string "flagfox\n";
     assert_and_click('firefox-extensions-flagfox', 'right');
@@ -32,9 +32,10 @@ sub run {
     assert_screen('firefox-extensions-flagfox_installed', 90);
 
     send_key "alt-1";
+    $self->firefox_check_popups;
     assert_screen('firefox-extensions-show_flag', 60);
 
-    send_key "alt-3";
+    send_key "alt-2";
     assert_and_click('firefox-extensions-flagfox_installed');
 
     send_key "alt-1";

--- a/tests/x11regressions/firefox/firefox_flashplayer.pm
+++ b/tests/x11regressions/firefox/firefox_flashplayer.pm
@@ -22,12 +22,8 @@ sub run {
     send_key "esc";
     send_key "alt-d";
     type_string "http://www.adobe.com/software/flash/about/\n";
-    wait_still_screen 3;
-    assert_screen ['firefox-reader-view', 'firefox-flashplayer-verify_loaded'], 90;
-    if (match_has_tag 'firefox-reader-view') {
-        assert_and_click('firefox-reader-close');
-        assert_screen('firefox-flashplayer-verify_loaded');
-    }
+    $self->firefox_check_popups;
+    assert_screen('firefox-flashplayer-verify_loaded');
 
     send_key "pgdn";
     # flashplayer dropped since sled12 sp2
@@ -37,6 +33,7 @@ sub run {
             send_key "esc";
             send_key "alt-d";
             type_string "https://www.youtube.com/watch?v=Z4j5rJQMdOU\n";
+            $self->firefox_check_popups;
             assert_screen('firefox-flashplayer-video_loaded', 90);
         }
         last;

--- a/tests/x11regressions/firefox/firefox_fullscreen.pm
+++ b/tests/x11regressions/firefox/firefox_fullscreen.pm
@@ -27,6 +27,7 @@ sub run {
     send_key "alt-d";
     sleep 1;
     type_string "file:///usr/share/w3m/w3mhelp.html\n";
+    $self->firefox_check_popups;
     assert_screen('firefox-fullscreen-page', 90);
 
     send_key "f11";

--- a/tests/x11regressions/firefox/firefox_gnomeshell.pm
+++ b/tests/x11regressions/firefox/firefox_gnomeshell.pm
@@ -29,6 +29,7 @@ sub run {
 
     send_key "alt-d";
     type_string "extensions.gnome.org\n";
+    $self->firefox_check_popups;
     assert_screen('firefox-gnomeshell-frontpage', 120);
     send_key "alt-a";
     assert_and_click "firefox-gnomeshell-allowremember";
@@ -41,11 +42,8 @@ sub run {
 
     send_key "alt-d";
     type_string "extensions.gnome.org/extension/512/wikipedia-search-provider/\n";
-    assert_screen([qw(firefox-reader-view firefox-gnomeshell-extension)], 90);
-    if (match_has_tag 'firefox-reader-view') {
-        assert_and_click('firefox-reader-close');
-        assert_screen("firefox-gnomeshell-extension");
-    }
+    $self->firefox_check_popups;
+    assert_screen "firefox-gnomeshell-extension";
     assert_and_click "firefox-gnomeshell-extension_install";
     assert_and_click "firefox-gnomeshell-extension_confirm";
     assert_screen("firefox-gnomeshell-extension_on", 60);

--- a/tests/x11regressions/firefox/firefox_headers.pm
+++ b/tests/x11regressions/firefox/firefox_headers.pm
@@ -16,17 +16,20 @@ use base "x11regressiontest";
 use testapi;
 
 sub run {
+    my ($self) = @_;
     mouse_hide(1);
 
     # Clean and Start Firefox
     x11_start_program("xterm -e \"killall -9 firefox;rm -rf .moz*\"");
     x11_start_program("firefox");
+    $self->firefox_check_popups;
     assert_screen('firefox-launch', 90);
 
     send_key "esc";
     wait_screen_change { send_key "ctrl-shift-q" };
     wait_screen_change { send_key "alt-d" };
     type_string "www.gnu.org\n";
+    $self->firefox_check_popups;
     assert_screen('firefox-headers-website', 90);
 
     send_key "down";

--- a/tests/x11regressions/firefox/firefox_html5.pm
+++ b/tests/x11regressions/firefox/firefox_html5.pm
@@ -22,6 +22,7 @@ sub run {
     send_key "esc";
     send_key "alt-d";
     type_string "youtube.com/html5\n";
+    $self->firefox_check_popups;
 
     assert_screen('firefox-html5-youtube', 90);
     send_key "pgdn";
@@ -33,6 +34,7 @@ sub run {
     send_key "esc";
     send_key "alt-d";
     type_string "youtube.com/watch?v=Z4j5rJQMdOU\n";
+    $self->firefox_check_popups;
     assert_screen('firefox-flashplayer-video_loaded', 90);
 
     # Exit

--- a/tests/x11regressions/firefox/firefox_localfiles.pm
+++ b/tests/x11regressions/firefox/firefox_localfiles.pm
@@ -22,17 +22,20 @@ sub run {
     # html
     send_key "alt-d";
     type_string "/usr/share/w3m/w3mhelp.html\n";
+    $self->firefox_check_popups;
     assert_screen('firefox-local_files-html', 60);
 
     # wav
     send_key "alt-d";
     type_string "/usr/share/sounds/alsa/test.wav\n";
+    $self->firefox_check_popups;
     assert_screen('firefox-local_files-wav', 60);
     send_key "esc";
 
     # so
     send_key "alt-d";
     type_string "/usr/lib/libnss3.so\n";
+    $self->firefox_check_popups;
     assert_screen('firefox-local_files-so', 60);
     send_key "esc";
 

--- a/tests/x11regressions/firefox/firefox_mhtml.pm
+++ b/tests/x11regressions/firefox/firefox_mhtml.pm
@@ -27,18 +27,23 @@ sub run {
     wait_still_screen 3;
     send_key "ctrl-shift-a";
     assert_screen('firefox-addons_manager', 90);
-
+    assert_and_click "firefox-extensions";
     assert_and_click "firefox-searchall-addon";
     type_string "unmht\n";
     assert_and_click('firefox-mhtml-unmht');
     for my $i (1 .. 2) { send_key "tab"; }
     send_key "spc";
+    assert_and_click('unmht_restart_now');
+    $self->firefox_check_popups;
+    assert_and_click('firefox-my-addons');
     assert_screen('firefox-mhtml-unmht_installed', 90);
 
     wait_screen_change { send_key "ctrl-w" };
+    $self->firefox_check_popups;
 
     send_key "alt-d";
     type_string "file:///dev/shm/ie10.mht\n";
+    $self->firefox_check_popups;
     assert_screen('firefox-mhtml-loadpage', 60);
 
     # Exit and Clear

--- a/tests/x11regressions/firefox/firefox_pagesaving.pm
+++ b/tests/x11regressions/firefox/firefox_pagesaving.pm
@@ -22,6 +22,8 @@ sub run {
     send_key "esc";
     send_key "alt-d";
     type_string "http://www.mozilla.org/en-US\n";
+    $self->firefox_check_popups;
+
     assert_screen('firefox-pagesaving-load', 90);
     send_key "ctrl-s";
     assert_screen 'firefox-pagesaving-saveas';

--- a/tests/x11regressions/firefox/firefox_passwd.pm
+++ b/tests/x11regressions/firefox/firefox_passwd.pm
@@ -21,7 +21,7 @@ sub run {
     mouse_hide(1);
 
     my $masterpw = "firefox_test";
-    my $mozlogin = "http://www-archive.mozilla.org/quality/browser/front-end/testcases/wallet/login.html";
+    my $mozlogin = "https://www-archive.mozilla.org/quality/browser/front-end/testcases/wallet/login.html";
 
     # Clean and Start Firefox
     $self->start_firefox;
@@ -43,11 +43,13 @@ sub run {
     #Restart firefox
     send_key "ctrl-q";
     x11_start_program("firefox");
+    $self->firefox_check_popups;
     assert_screen('firefox-gnome', 60);
 
     send_key "esc";
     send_key "alt-d";
     type_string $mozlogin. "\n";
+    $self->firefox_check_popups;
 
     assert_and_click('firefox-passwd-input_username');
     type_string "squiddy";
@@ -61,6 +63,7 @@ sub run {
     send_key "esc";
     send_key "alt-d";
     type_string $mozlogin. "\n";
+    $self->firefox_check_popups;
     assert_screen('firefox-passwd-auto_filled', 90);
 
     send_key "alt-e";

--- a/tests/x11regressions/firefox/firefox_pdf.pm
+++ b/tests/x11regressions/firefox/firefox_pdf.pm
@@ -22,6 +22,7 @@ sub run {
     send_key "esc";
     send_key "alt-d";
     type_string "http://www.gnupg.org/gph/en/manual.pdf\n";
+    $self->firefox_check_popups;
 
     assert_screen('firefox-pdf-load', 90);
 

--- a/tests/x11regressions/firefox/firefox_plugins.pm
+++ b/tests/x11regressions/firefox/firefox_plugins.pm
@@ -30,9 +30,9 @@ sub run {
     for my $i (1 .. 2) { send_key "tab"; }
     send_key "pgdn";
     assert_screen('firefox-plugins-overview_02', 60);
-
+    assert_and_click('firefox-plugins-tools');
     assert_and_click('firefox-plugins-check_update');
-    assert_screen('firefox-plugins-update_page', 60);
+    assert_screen('firefox-plugins-updates', 60);
 
     $self->exit_firefox;
 }

--- a/tests/x11regressions/firefox/firefox_private.pm
+++ b/tests/x11regressions/firefox/firefox_private.pm
@@ -22,9 +22,11 @@ sub run {
     send_key "ctrl-shift-p";
     send_key "alt-d";
     type_string "gnu.org\n";
+    $self->firefox_check_popups;
     assert_screen('firefox-private-gnu', 90);
     send_key "alt-d";
     type_string "facebook.com\n";
+    $self->firefox_check_popups;
     assert_screen('firefox-private-facebook', 90);
 
     send_key "alt-f4";
@@ -32,6 +34,8 @@ sub run {
     $self->exit_firefox;
 
     x11_start_program("firefox");
+    $self->firefox_check_default;
+    $self->firefox_check_popups;
     assert_screen('firefox-launch', 90);
 
     send_key "ctrl-h";

--- a/tests/x11regressions/firefox/firefox_rss.pm
+++ b/tests/x11regressions/firefox/firefox_rss.pm
@@ -37,6 +37,7 @@ sub run {
     send_key "esc";
     send_key "alt-d";
     type_string "https://linux.slashdot.org/\n";
+    $self->firefox_check_popups;
 
     assert_and_click "firefox-rss-button_enabled", "left", 30;
     assert_screen("firefox-rss-page", 60);

--- a/tests/x11regressions/firefox/firefox_smoke.pm
+++ b/tests/x11regressions/firefox/firefox_smoke.pm
@@ -28,6 +28,7 @@ sub run {
         send_key "alt-d";
         sleep 1;
         type_string $site. "\n";
+        $self->firefox_check_popups;
         assert_screen('firefox-topsite_' . $site, 120);
     }
 

--- a/tests/x11regressions/firefox/firefox_ssl.pm
+++ b/tests/x11regressions/firefox/firefox_ssl.pm
@@ -28,7 +28,7 @@ sub run {
 
     send_key "tab";
     send_key "ret";
-    send_key "tab";
+    for (1 .. 3) { send_key "tab"; }
     send_key "ret";
 
     assert_screen('firefox-ssl-addexception', 60);
@@ -45,11 +45,14 @@ sub run {
     send_key "alt-shift-c";
 
     sleep 1;
+    assert_and_click('firefox-ssl-certificate_table');
+
+    sleep 1;
     type_string "hong";
     send_key "down";
 
     sleep 1;
-    send_key "alt-e";
+    send_key "alt-shift-e";
 
     sleep 1;
     send_key "spc";
@@ -60,13 +63,12 @@ sub run {
     sleep 1;
     assert_and_click('firefox-ssl-certificate_servers');
 
-    send_key "pgdn";
-    send_key "pgdn";
+    for (1 .. 3) { send_key "pgdn"; }
 
     sleep 1;
     assert_screen('firefox-ssl-servers_cert', 30);
 
-    wait_screen_change { send_key "alt-f4" };
+    wait_screen_change { send_key "esc" };
     send_key "ctrl-w";
 
     send_key "alt-d";

--- a/tests/x11regressions/firefox/firefox_urlsprotocols.pm
+++ b/tests/x11regressions/firefox/firefox_urlsprotocols.pm
@@ -40,6 +40,7 @@ sub run {
         send_key "alt-d";
         sleep 1;
         type_string $sites_url{$proto} . "\n";
+        $self->firefox_check_popups;
         assert_screen('firefox-urls_protocols-' . $proto, 60);
     }
 


### PR DESCRIPTION
`firefox_check_popup` and `firefox_check_default` methods have been added into the firefox regression test suite.

Apart from that, other minor changes have been introduced, due to change of UI in firefox after the recent update (such as changes to the addon manager, where the search button is no longer available on the first tab and is instead located under the Extensions tab).

Some test modules still require some fine tuning, therefore are not yet included in this commit:
- firefox_java
- firefox_appearance
- firefox_ssl

This commit is accompanied by a bunch of new needles, which are submitted separately in their repo:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/431

Verification run:
http://dreamyhamster.suse.cz/tests/406
(The three above mentioned modules are still failing in this run, as they are still WIP.)

Related issue: poo#19926