### PR TITLE
Add KNOWN_ISSUE feature to xfstests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1217,6 +1217,9 @@ elsif (get_var("QA_TESTSET")) {
 elsif (get_var("XFSTESTS")) {
     loadtest "qa_automation/xfstests_prepare_boot";
     loadtest "qa_automation/xfstests_prepare_testsuite";
+    if (get_var("XFSTESTS_KNOWN_ISSUE")) {
+        loadtest "qa_automation/xfstests_prepare_issue_case";
+    }
     loadtest "qa_automation/xfstests_prepare_env";
     loadtest "qa_automation/xfstests_run_generic";
     loadtest "qa_automation/xfstests_run_shared";
@@ -1228,6 +1231,9 @@ elsif (get_var("XFSTESTS")) {
     }
     elsif (check_var("TEST_FS_TYPE", "ext4")) {
         loadtest "qa_automation/xfstests_run_ext4";
+    }
+    if (get_var("XFSTESTS_KNOWN_ISSUE")) {
+        loadtest "qa_automation/xfstests_run_issue_case";
     }
 }
 elsif (get_var("VIRT_AUTOTEST")) {

--- a/tests/qa_automation/xfstests_prepare_issue_case.pm
+++ b/tests/qa_automation/xfstests_prepare_issue_case.pm
@@ -1,0 +1,41 @@
+# Copyright © 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary:  xfstests testsuite
+# Use the latest xfstests testsuite from upstream to make file system test
+# Maintainer: Yong Sun <yosun@suse.com>
+
+use base "xfstests_install";
+use base "xfstests_device";
+use strict;
+use testapi;
+
+sub run {
+    my $self = shift;
+    assert_script_run("mkdir -p /tmp/issue_case/{generic,shared,xfs,btrfs,ext4}");
+    my @blst = split(/,/, get_var('XFSTESTS_KNOWN_ISSUE', ''));
+    foreach my $case (@blst) {
+        if ($case =~ /^-/) {
+            $case = substr($case, 1);
+            script_run("rm ./tests/$case");
+        }
+        else {
+            script_run("mv ./tests/$case /tmp/issue_case/$case");
+        }
+    }
+    script_run("ls /tmp/issue_case/*/");
+}
+
+1;

--- a/tests/qa_automation/xfstests_run_issue_case.pm
+++ b/tests/qa_automation/xfstests_run_issue_case.pm
@@ -1,0 +1,40 @@
+# Copyright © 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary:  xfstests testsuite
+# Use the latest xfstests testsuite from upstream to make file system test
+# Maintainer: Yong Sun <yosun@suse.com>
+
+use base "xfstests_install";
+use base "xfstests_device";
+use base "xfstests_logs";
+use strict;
+use testapi;
+
+sub run() {
+    my $self = shift;
+    my @blst = split(/,/, get_var('XFSTESTS_KNOWN_ISSUE', ''));
+    foreach my $case (@blst) {
+        if ($case !~ /^-/) {
+            script_run("mv /tmp/issue_case/$case ./tests/$case");
+            script_run("./check $case", 60 * 60 * 1);
+        }
+    }
+
+    # Upload all log tarballs in ./results/
+    $self->log_upload();
+}
+
+1;


### PR DESCRIPTION
New feature:
xfstests don't support blacklist, this KNOWN ISSUE feature just like blacklist but more. 
It'll remove set case at first, and run them before whole tests finished. I add two steps xfstests_prepare_issue_case and xfstests_run_issue_case.
It can help to: 1) system hang by known issue a long time for nothing 2) give a reasonable short timeout to those known-issue-test to check if it get fixed in each build.

Parameter change:
Add XFSTESTS_KNOWN_ISSUE: e.g. can be set as XFSTESTS_KNOWN_ISSUE=generic/002,generic/003, different tests split by ",".
If you don't want some case run at all, add a "-" in front of it. e.g. XFSTESTS_KNOWN_ISSUE=generic/002,generic/003,-generic/004,-generic/005  then generic/004 and 005 will not run.

Test:
http://147.2.207.102/tests/1118

In this test I set XFSTESTS_KNOWN_ISSUE with generic/002,generic/003
1) Check in following link, those two test were not run 
http://147.2.207.102/tests/1118#step/xfstests_run_generic/1
2) Those two test ran separate in the last step: http://147.2.207.102/tests/1118#step/xfstests_run_issue_case/7