### PR TITLE
Enable boot of zKVM images with static network configuration on other hosts

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -35,6 +35,7 @@ our @EXPORT = qw(
   select_kernel
   type_string_slow
   type_string_very_slow
+  save_svirt_pty
   unlock_if_encrypted
   prepare_system_reboot
   get_netboot_mirror
@@ -82,6 +83,21 @@ use constant SLOW_TYPING_SPEED => 13;
 # mangling
 use constant VERY_SLOW_TYPING_SPEED => 4;
 
+my $svirt_pty_saved = 0;
+
+=head2 save_svirt_pty
+save the pty device within the svirt shell session so that we can refer to the
+correct pty pointing to the first tty, e.g. for password entry for encrypted
+partitions and rewriting the network definition of zkvm instances
+=cut
+sub save_svirt_pty {
+    return if $svirt_pty_saved;
+    my $name = console('svirt')->name;
+    type_string "export pty=`virsh dumpxml $name | grep \"console type=\" | sed \"s/'/ /g\" | awk '{ print \$5 }'`\n";
+    type_string "echo \$pty\n";
+    $svirt_pty_saved = 1;
+}
+
 sub unlock_if_encrypted {
     my (%args) = @_;
     $args{check_typed_password} //= 0;
@@ -90,12 +106,7 @@ sub unlock_if_encrypted {
 
     if (check_var('ARCH', 's390x') && check_var('BACKEND', 'svirt')) {
         my $password = $testapi::password;
-        my $svirt    = select_console('svirt');
-        my $name     = $svirt->name;
-        $svirt->suspend;
-        type_string "export pty=`virsh dumpxml $name | grep \"console type=\" | sed \"s/'/ /g\" | awk '{ print \$5 }'`\n";
-        type_string "echo \$pty\n";
-        $svirt->resume;
+        save_svirt_pty;
 
         # enter passphrase twice (before grub and after grub) if full disk is encrypted
         if (get_var('FULL_LVM_ENCRYPT')) {


### PR DESCRIPTION
Rewrite the static network configuration of generated disk images for zkvm
with a static wicked network configuration on bootup over the virsh console so
that we can use the image on other hosts as well.

Verification run: http://lord.arch/tests/7076

Related progress issue: https://progress.opensuse.org/issues/18016