### PR TITLE
Remove softfailure if yast2 snapper times out

### DIFF
--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -104,30 +104,16 @@ sub y2snapper_clean_and_quit {
     # Ensure yast2-snapper is not busy anymore
     wait_still_screen;
     # C'l'ose the snapper module
-    send_key "alt-l";
+    wait_screen_change { send_key "alt-l"; };
 
-    my $ret;
     if ($ncurses) {
-        $ret = wait_serial("yast2-snapper-status-0", 30);
+        wait_serial("yast2-snapper-status-0", 180) || die "yast2 snapper failed";
     }
     else {
         # Wait until root gnome terminal is focussed, delete the directory and close window
-        $ret = check_screen('root-gnome-terminal');
+        assert_screen('root-gnome-terminal', timeout => 180);
     }
 
-    if (!$ret) {
-        $self->{mute_post_fail} = 1;
-        record_soft_failure 'bsc#1032831';
-        $self->y2snapper_failure_analysis;
-        # After failure analysis done, switch back to check if yast2 snapper quit
-        if ($ncurses) {
-            select_console 'root-console';
-        }
-        else {
-            select_console 'x11', await_console => 0;
-            assert_screen 'root-gnome-terminal', 90;
-        }
-    }
     script_run 'rm -rf testdata';
     script_run "ls";
     if (!$ncurses) {

--- a/tests/console/yast2_snapper_ncurses.pm
+++ b/tests/console/yast2_snapper_ncurses.pm
@@ -17,7 +17,6 @@ use utils;
 
 sub run {
     my ($self) = @_;
-    $self->{mute_post_fail} = 0;
     select_console 'root-console';
     zypper_call('in yast2-snapper');
 
@@ -34,7 +33,6 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = @_;
-    return if $self->{mute_post_fail};
     $self->y2snapper_failure_analysis;
 }
 

--- a/tests/x11/yast2_snapper.pm
+++ b/tests/x11/yast2_snapper.pm
@@ -22,9 +22,6 @@ use utils;
 
 sub run {
     my $self = shift;
-    # for not running failure_analysis twice in case we fail inside failure_analysis
-    $self->{mute_post_fail} = 0;
-
     # Make sure yast2-snapper is installed (if not: install it)
     ensure_installed "yast2-snapper";
 
@@ -37,21 +34,19 @@ sub run {
     }
     become_root;
     script_run "cd";
-
     type_string "yast2 snapper\n";
     $self->y2snapper_new_snapshot;
 
     wait_still_screen;
     $self->y2snapper_untar_testfile;
 
-    type_string "yast2 snapper\n";
+    type_string "yast2 snapper; echo yast2-snapper-status-\$? > /dev/$serialdev\n";
     $self->y2snapper_show_changes_and_delete;
     $self->y2snapper_clean_and_quit;
 }
 
 sub post_fail_hook {
     my ($self) = @_;
-    return if $self->{mute_post_fail};
     $self->y2snapper_failure_analysis;
 }
 


### PR DESCRIPTION
We have observed sporadic issue that sometimes even yast2 snapper window
is already closed, return code is not yet provided and some activity is
still there. As a part of investigation of bsc#1032831 we have
identified, that yast2 ui tests tend to fail with timeouts and in
observed cases there was some btrfs activity. Traces of if we can see in
serial output. Same behavior is easy to reproduce if one triggers btrfs
balance and tries to start and close snapper, it takes significantly
more time than in normal scenario. Considering the fact that SUT is
usually running on hardware which satisfies minimal requirements,
timeouts are plausible. With this PR we remove workarounds and introduce
increased timeout value to have stable results. Activities regarding
possible btrfs performance regression will be performed as individual
task.