### PR TITLE
Skip server look up for localhost email address

### DIFF
--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -306,6 +306,13 @@ sub start_evolution {
     type_string "$mail_box";
     sleep 1;
     save_screenshot();
+
+    # skip server look up for localhost email address
+    if ($mail_box =~ /localhost/) {
+        record_soft_failure 'bsc#1049387 - Evolution Skip lookup button sometimes doesn\'t work';
+        assert_and_click "evolution-mail-skip-look-up-checkbox";
+        save_screenshot();
+    }
     send_key $self->{next};
 }
 


### PR DESCRIPTION
poo#19320:  Skip server look up for localhost email address in Evolution mail to avoid bug bsc#1049387.

Needle:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/436

General verification:
SP2: http://10.100.12.105/tests/1160
SP3: http://10.100.12.105/tests/1161

Specific verification for aim.com (checkbox is not changed):
http://10.100.12.105/tests/1160#step/evolution_smoke/10
Specific verification for localhost (checkbox is clicked):
http://10.100.12.105/tests/1160#step/evolution_mail_imap/13



