### PR TITLE
Add test modules needed for Plasma on Wayland testing

### DIFF
--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -508,14 +508,19 @@ sub firefox_check_popups {
         # handle the tracking protection pop up
         if (match_has_tag('firefox_trackinfo')) {
             wait_screen_change { assert_and_click 'firefox_trackinfo'; };
-            # workaround for bsc#1046005
-            wait_screen_change { assert_and_click 'firefox_titlebar'; };
         }
         # handle the reader view pop up
         elsif (match_has_tag('firefox_readerview_window')) {
             wait_screen_change { assert_and_click 'firefox_readerview_window'; };
-            # workaround for bsc#1046005
-            wait_screen_change { assert_and_click 'firefox_titlebar'; };
+        }
+
+        if (match_has_tag('firefox_trackinfo') or match_has_tag('firefox_readerview_window')) {
+            # bsc#1046005 does not seem to affect KDE and as the workaround sometimes results in
+            # accidentially moving the firefox window around, skip it.
+            if (!check_var("DESKTOP", "kde")) {
+                # workaround for bsc#1046005
+                wait_screen_change { assert_and_click 'firefox_titlebar' };
+            }
         }
     }
 }

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -516,6 +516,10 @@ sub load_x11tests {
     if (get_var("XDMUSED")) {
         loadtest "x11/x11_login";
     }
+    if (kdestep_is_applicable() && get_var("WAYLAND")) {
+        loadtest "x11/plasma5_force_96dpi";
+        loadtest "x11/start_wayland_plasma5";
+    }
     if (xfcestep_is_applicable()) {
         loadtest "x11/xfce4_terminal";
     }

--- a/tests/x11/plasma5_force_96dpi.pm
+++ b/tests/x11/plasma5_force_96dpi.pm
@@ -1,0 +1,24 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Force the font DPI to 96, needed for Wayland
+# Maintainer: Fabian Vogt <fvogt@suse.com>
+
+use base 'x11test';
+use strict;
+use testapi;
+
+sub run {
+    x11_start_program('kcmshell5 fonts');      # Start the fonts KCM
+    assert_and_click 'kcm_fonts_force_dpi';    # Check force DPI checkbox (96 is preselected)
+    send_key 'alt-o';                          # Save and close the dialog
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/start_wayland_plasma5.pm
+++ b/tests/x11/start_wayland_plasma5.pm
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Prepare for wayland and log out of X11 and into wayland
+# Maintainer: Fabian Vogt <fvogt@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+
+    # Make sure everything necessary is installed
+    ensure_installed "plasma5-session-wayland";
+
+    # Workaround: use softpipe as llvmpipe crashes all the time (fdo#96953)
+    x11_start_program 'mkdir -p ~/.config/plasma-workspace/env';
+    x11_start_program "echo 'echo export GALLIUM_DRIVER=softpipe >> ~/.config/startupconfig' > ~/.config/plasma-workspace/env/softpipe.sh";
+
+    # Log out of X session
+    send_key 'super';                             # Open the application menu
+    assert_and_click 'plasma_logout_btn';         # Click on the logout button
+    assert_and_click 'plasma_overlay_confirm';    # Confirm logout
+
+    # Now we're in sddm
+    assert_and_click 'sddm_desktopsession';            # Open session selection box
+    assert_and_click 'sddm_session_plasma_wayland';    # Select Plasma 5 (Wayland) session
+
+    # Log in as usual
+    type_password;
+    send_key 'ret';
+
+    # Wait until logged in
+    assert_screen 'generic-desktop', 60;
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;
+
+# vim: set sw=4 et:


### PR DESCRIPTION
To use this, a machine with ```QEMUVGA=virtio``` is needed. For the krypton-live-wayland test to succeed, 1024MiB of RAM are not enough anymore, so ```QEMURAM=2048``` is necessary.
To enable the X11 tests to run in a wayland session, set ```WAYLAND=1```.

Two workarounds:
------------------------

The assert_and_click for the firefox titlebar causes the window to get dragged around on the screen for some reason. I found that the assert_and_click is not necessary for the test to succeed, but I'm not sure which conditional is the right one. I guess it might be necessary only on GNOME.

The ```GALLIUM_DRIVER``` workaround is needed to prevent krunner segfaulting with software rendering with llvmpipe. It's an upstream issue, likely in Mesa. Unfortunately it can't be set globally as softpipe is not suitable for use with KWin, so the workaround is a bit more complex.

Known issues:
-------------------

* Shutdown and reboot do not work (product issue): http://lagarto.suse.de/tests/25#step/reboot_plasma5/3
* Wrong keyboard input in oowrite (happens only sometimes): http://lagarto.suse.de/tests/22#step/ooffice/8

Verification runs:
----------------------

Krypton Live DVD: http://lagarto.suse.de/tests/25

Normal TW installation: http://lagarto.suse.de/tests/22 (More needles, but still running: http://lagarto.suse.de/tests/27)