### PR TITLE
Assert also login screen on ensure_unlocked_desktop

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -391,7 +391,7 @@ sub ensure_unlocked_desktop {
         if ((match_has_tag 'displaymanager-password-prompt') || (match_has_tag 'gnome-screenlock-password')) {
             if ($password ne '') {
                 type_password;
-                assert_screen 'locked_screen-typed_password';
+                assert_screen [qw(locked_screen-typed_password login_screen-typed_password)];
             }
             send_key 'ret';
         }


### PR DESCRIPTION
## Issue

- [osd#1081380#step/console/7](https://openqa.suse.de/tests/1081380#step/console/7)


## Verification run

- [copland#1282](http://copland.arch.suse.de/tests/1282) (running)


## Needles

- Needle created through needle editor on osd [gl#os-autoinst-needles-sles#af1d6cd341c0cdad2333e585b3dbc9df7d23cfa8](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/commit/af1d6cd341c0cdad2333e585b3dbc9df7d23cfa8)
- Fix tag name through needle editor on osd [gl#os-autoinst-needles-sles#4705fa1cf899c2ad54f37e4f60750d310ce0e876](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/commit/4705fa1cf899c2ad54f37e4f60750d310ce0e876)