### PR TITLE
Prevent waiting time on svirt console commands and grub

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -339,7 +339,6 @@ sub wait_boot {
                 zkvm_add_interface $svirt;
                 $svirt->define_and_start;
             }
-            save_svirt_pty;
             wait_serial($login_ready, $ready_time + 100);
             $self->rewrite_static_svirt_network_configuration();
         }

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -271,18 +271,14 @@ Also see poo#18016 for details.
 =cut
 sub rewrite_static_svirt_network_configuration {
     my ($self) = @_;
-    type_string "echo root > \$pty\n";
-    wait_serial('Password');
-    type_string "echo $testapi::password > \$pty\n";
+    type_line_svirt "root", expect => 'Password';
+    type_line_svirt "$testapi::password";
     my $virsh_guest = get_required_var('VIRSH_GUEST');
-    type_string "echo sed -i \"\\\"s:IPADDR='[0-9.]*/\\([0-9]*\\)':IPADDR='$virsh_guest/\\1':\\\" /etc/sysconfig/network/ifcfg-\*\" > \$pty\n";
+    type_line_svirt "sed -i \"\\\"s:IPADDR='[0-9.]*/\\([0-9]*\\)':IPADDR='$virsh_guest/\\1':\\\" /etc/sysconfig/network/ifcfg-\*\"", expect => '#';
     type_string "# output of current network configuration for debugging\n";
-    type_string "echo cat /etc/sysconfig/network/ifcfg-\* > \$pty\n";
-    wait_serial('#');
-    type_string "echo systemctl restart network > \$pty\n";
-    wait_serial('#');
-    type_string "echo systemctl is-active network > \$pty\n";
-    wait_serial('active');
+    type_line_svirt "cat /etc/sysconfig/network/ifcfg-\*", expect => '#';
+    type_line_svirt "systemctl restart network",           expect => '#';
+    type_line_svirt "systemctl is-active network",         expect => 'active';
 }
 
 =head2 wait_boot

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -335,7 +335,9 @@ sub wait_boot {
                 zkvm_add_interface $svirt;
                 $svirt->define_and_start;
             }
-            wait_serial($login_ready, $ready_time + 100);
+            wait_serial('GNU GRUB') || diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
+            select_console('svirt');
+            type_line_svirt '', expect => $login_ready, timeout => $ready_time + 100, fail_message => 'Could not find login prompt';
             $self->rewrite_static_svirt_network_configuration();
         }
 

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -2,8 +2,7 @@ package susedistribution;
 use base 'distribution';
 use serial_terminal ();
 use strict;
-use utils 'type_string_slow';
-use utils 'ensure_unlocked_desktop';
+use utils qw(type_string_slow ensure_unlocked_desktop save_svirt_pty);
 
 # Base class implementation of distribution class necessary for testapi
 
@@ -463,6 +462,7 @@ sub activate_console {
     }
     elsif ($console eq 'svirt') {
         $self->set_standard_prompt('root');
+        save_svirt_pty;
     }
     elsif (
         $console eq 'installation'

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -91,11 +91,9 @@ correct pty pointing to the first tty, e.g. for password entry for encrypted
 partitions and rewriting the network definition of zkvm instances
 =cut
 sub save_svirt_pty {
-    return if $svirt_pty_saved;
     my $name = console('svirt')->name;
-    type_string "export pty=`virsh dumpxml $name | grep \"console type=\" | sed \"s/'/ /g\" | awk '{ print \$5 }'`\n";
+    type_string "pty=`virsh dumpxml $name 2>/dev/null | grep \"console type=\" | sed \"s/'/ /g\" | awk '{ print \$5 }'`\n";
     type_string "echo \$pty\n";
-    $svirt_pty_saved = 1;
 }
 
 sub unlock_if_encrypted {
@@ -106,7 +104,6 @@ sub unlock_if_encrypted {
 
     if (check_var('ARCH', 's390x') && check_var('BACKEND', 'svirt')) {
         my $password = $testapi::password;
-        save_svirt_pty;
 
         # enter passphrase twice (before grub and after grub) if full disk is encrypted
         if (get_var('FULL_LVM_ENCRYPT')) {


### PR DESCRIPTION
* Explicitly confirm grub boot selection in svirt console to save some seconds
* Extract helper function for typing on svirt console and waiting for answer
* Fix wait_serial waiting on svirt commands never sent