### PR TITLE
Get rid of all wait_idle and superfluous sleep calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ test-merge:
 	  FILES=$$(git diff --name-only FETCH_HEAD `git merge-base FETCH_HEAD master 2>/dev/null` | grep 'tests.*pm') ;\
 	  for file in $$FILES; do if test -f $$file; then \
 	    tools/check_metadata $$file || touch failed; \
+	    git grep wait_idle $$file && touch failed; \
 	    ${PERLCRITIC} $$file || touch failed ;\
 	  fi ; done; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,12 @@ test-merge:
 test-dry:
 	export PERL5LIB=${PERL5LIB_} ; tools/detect_code_dups
 
+.PHONY: test-no-wait_idle
+test-no-wait_idle:
+	@! git grep wait_idle lib/ tests/
+
 .PHONY: test
-test: tidy test-compile test-merge test-dry
+test: tidy test-compile test-merge test-dry test-no-wait_idle
 
 PERLCRITIC=PERL5LIB=tools/lib/perlcritic:$$PERL5LIB perlcritic --quiet --gentle --include Perl::Critic::Policy::HashKeyQuote --include Perl::Critic::Policy::ConsistentQuoteLikeWords
 

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -329,8 +329,6 @@ sub bootmenu_network_source {
                 type_string_slow " nameserver=" . join(",", @$dns);
                 type_string_slow " $remote=1 ${remote}password=$password";
             }
-            #type_string "ZYPP_ARIA2C=0 "; sleep 9;
-            #type_string "ZYPP_MULTICURL=0 "; sleep 2;
         }
     }
 
@@ -511,9 +509,6 @@ sub select_bootmenu_language {
             for (1 .. abs($n)) {
                 send_key($n < 0 ? "up" : "down");
             }
-
-            # TODO: add needles for some often tested
-            sleep 2;
             send_key "ret";
         }
     }

--- a/lib/kgrafttest.pm
+++ b/lib/kgrafttest.pm
@@ -18,8 +18,7 @@ sub post_fail_hook {
     my $snapshot_before = get_var('KGRAFT_SNAPSHOT_BEFORE');
     my $name            = get_var('VIRSH_GUESTNAME');
     save_screenshot;
-    send_key('ctrl-c');
-    sleep 2;
+    wait_screen_change { send_key 'ctrl-c' };
     capture_state("fail");
 
     #reconnect to svirt backend and revert to snapshot before update

--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -52,7 +52,6 @@ sub configure_static_ip {
     save_screenshot;
     assert_script_run "rcnetwork restart";
     assert_script_run "ip addr";
-    wait_idle(20);
     save_screenshot;
 }
 
@@ -66,11 +65,9 @@ sub configure_dhcp {
     type_string "NIC=`grep \$MAC /sys/class/net/*/address |cut -d / -f 5`;";
     type_string("echo \"STARTMODE='auto'\nBOOTPROTO='dhcp'\n\" > /etc/sysconfig/network/ifcfg-\$NIC;");
     type_string("done\n");
-    wait_idle(20);
     save_screenshot;
     type_string("rcnetwork restart\n");
     type_string("ip addr\n");
-    wait_idle(20);
     save_screenshot;
 }
 

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -428,13 +428,6 @@ sub wait_boot {
         handle_emergency if (match_has_tag('emergency-shell') or match_has_tag('emergency-mode'));
 
         reset_consoles;
-
-        # Without this login name and password won't get to the system. They get
-        # lost somewhere. Applies for all systems installed via svirt, but zKVM.
-        if (check_var('BACKEND', 'svirt') and !check_var('ARCH', 's390x')) {
-            wait_idle;
-        }
-
         $self->{in_wait_boot} = 0;
         return;
     }
@@ -445,7 +438,6 @@ sub wait_boot {
         assert_screen [qw(displaymanager emergency-shell emergency-mode)], $ready_time;
         handle_emergency if (match_has_tag('emergency-shell') or match_has_tag('emergency-mode'));
 
-        wait_idle;
         if (get_var('DM_NEEDS_USERNAME')) {
             type_string "$username\n";
         }

--- a/lib/proxymode.pm
+++ b/lib/proxymode.pm
@@ -90,7 +90,6 @@ sub start_nc_on_slave {
     my ($self) = @_;
     # Create nc connection on root console
     type_string "mkfifo /dev/$SLAVE_SERIALDEV\n";
-    sleep 2;
     type_string "tail -f /dev/$SLAVE_SERIALDEV | nc -l 1234 &\n";
     save_screenshot;
     save_org_serialdev();
@@ -105,7 +104,6 @@ sub con_nc_on_proxy {
     my $proxy_serialdev = get_var("PROXY_SERIALDEV", "ttyS0");
 
     type_string "nc ${test_machine} 1234 |tee /dev/" . $proxy_serialdev . "\n";
-    sleep 3;
     save_screenshot;
 }
 

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -174,7 +174,6 @@ sub fill_in_registration_data {
                         assert_and_click "scc-code-field-$addon";
                     }
                     type_string $regcode;
-                    sleep 1;
                     save_screenshot;
                 }
             }

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -162,7 +162,7 @@ sub ensure_installed {
         last if (match_has_tag('pkcon-finished'));
         if (match_has_tag('Policykit')) {
             type_password;
-            send_key("ret", 1);
+            send_key 'ret';
             @tags = grep { $_ ne 'Policykit' } @tags;
             @tags = grep { $_ ne 'Policykit-behind-window' } @tags;
             next;

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -8,7 +8,7 @@ use utils qw(type_string_slow ensure_unlocked_desktop save_svirt_pty);
 
 # don't import script_run - it will overwrite script_run from distribution and create a recursion
 use testapi qw(send_key %cmd assert_screen check_screen check_var get_var save_screenshot
-  match_has_tag set_var type_password type_string wait_idle wait_serial
+  match_has_tag set_var type_password type_string wait_serial
   mouse_hide send_key_until_needlematch record_info
   wait_still_screen wait_screen_change get_required_var diag);
 

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -168,8 +168,7 @@ sub ensure_installed {
             next;
         }
         if (match_has_tag('Policykit-behind-window')) {
-            send_key("alt-tab");
-            sleep 3;
+            wait_screen_change { send_key 'alt-tab' };
             next;
         }
         if (match_has_tag('pkcon-proceed-prompt')) {
@@ -399,8 +398,7 @@ sub activate_console {
             # LIVE CDa do not run inst-consoles as started by inst-linux (it's regular live run, auto-starting yast live installer)
             assert_screen "text-login", 10;
             # login as root, who does not have a password on Live-CDs
-            type_string "root\n";
-            sleep 1;
+            wait_screen_change { type_string "root\n" };
         }
         else {
             # on s390x we need to login here by providing a password

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -633,26 +633,25 @@ sub poweroff_x11 {
             send_key "alt-f4";    # opens log out popup after all windows closed
         }
         assert_screen 'logoutdialog';
-        type_string "\t\t";       # select shutdown
-        sleep 1;
+        wait_screen_change { type_string "\t\t" };    # select shutdown
 
         # assert_screen 'test-shutdown-1', 3;
         type_string "\n";
     }
 
     if (check_var("DESKTOP", "lxde")) {
-        x11_start_program("lxsession-logout");    # opens logout dialog
+        x11_start_program("lxsession-logout");        # opens logout dialog
         assert_screen "logoutdialog", 20;
         send_key "ret";
     }
 
     if (check_var("DESKTOP", "lxqt")) {
-        x11_start_program("shutdown");            # opens logout dialog
+        x11_start_program("shutdown");                # opens logout dialog
         assert_screen "lxqt_logoutdialog", 20;
         send_key "ret";
     }
     if (check_var("DESKTOP", "enlightenment")) {
-        send_key "ctrl-alt-delete";               # shutdown
+        send_key "ctrl-alt-delete";                   # shutdown
         assert_screen 'logoutdialog', 15;
         assert_and_click 'enlightenment_shutdown_btn';
     }

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -201,8 +201,7 @@ sub select_kernel {
             type_string $username;
         }
         else {
-            send_key 'ret';
-            wait_idle;
+            wait_screen_change { send_key 'ret' };
         }
         type_password;
         send_key 'ret';
@@ -633,8 +632,7 @@ sub poweroff_x11 {
         for (1 .. 5) {
             send_key "alt-f4";    # opens log out popup after all windows closed
         }
-        wait_idle;
-        assert_screen 'logoutdialog', 15;
+        assert_screen 'logoutdialog';
         type_string "\t\t";       # select shutdown
         sleep 1;
 

--- a/lib/virtmanager.pm
+++ b/lib/virtmanager.pm
@@ -13,14 +13,11 @@ sub launch_virtmanager {
     # start a console
     # launch virt-manager in an xterm
     x11_start_program("xterm");
-    wait_idle;
     type_string "virt-manager", 50;
     send_key "ret";
-    wait_idle;
     if (check_screen("virt-manager-auth")) {
         type_password;
         send_key "ret";
-        wait_idle;
     }
     save_screenshot;
 }
@@ -470,15 +467,13 @@ sub delete_netinterface {
 sub create_netinterface {
     my $netif = shift;
     # go to the "+" button
-    wait_idle;
     for (1 .. 7) {
         send_key "tab", 10;
     }
     # press it
-    send_key "spc", 1;
+    wait_screen_change { send_key 'spc' };
     # step 1
     # be sure to be at the first value (bridge)
-    wait_idle;
     for (1 .. 4) {
         send_key "up", 20;
     }
@@ -627,8 +622,7 @@ sub create_guest {
     }
     save_screenshot;
     # go to step2
-    send_key "alt-f";
-    wait_idle;
+    wait_screen_change { send_key "alt-f" };
     # step 2: media installation
     send_key "alt-f", 10;
     # step 3: Mem and CPU

--- a/lib/virtmanager.pm
+++ b/lib/virtmanager.pm
@@ -37,11 +37,8 @@ sub connection_details {
     my ($tab) = @_;
     # connection details
     wait_screen_change { send_key "alt-e" };
-    sleep 1;
     # be sure return has been done
     send_key "ret";
-    sleep 1;
-    # send_key "ret";
     if (get_var("DESKTOP") !~ /icewm/) {
         assert_screen "virtman-sle12-gnome_details", 40;
     }
@@ -51,7 +48,6 @@ sub connection_details {
     # be sure to be on a tab
     for (1 .. 4) {
         send_key "tab";
-        #sleep 1;
     }
     # need to send X "right" key to go to the correct tab
     # network interface = 3
@@ -71,7 +67,6 @@ sub connection_details {
     }
     for (1 .. $count) {
         send_key "right";
-        sleep 1;
     }
 }
 
@@ -98,9 +93,6 @@ sub create_vnet {
     # got to "+"
     # i know assert_and_click could be used
     #    for (1 .. 6) {
-    #	send_key "tab";
-    #        #sleep 1;
-    #   }
     #send_key "spc";
     assert_and_click "SLE12_virt-manager_vnet_plus";
 
@@ -114,11 +106,9 @@ sub create_vnet {
     # got to enable_ipv4
     wait_screen_change { send_key "tab" };
     if ($vnet->{ipv4}{active} eq "true") {
-        send_key "tab";
-        sleep 1;
+        wait_screen_change { send_key "tab" };
         type_string $vnet->{ipv4}{network};
-        send_key "tab";
-        sleep 1;
+        wait_screen_change { send_key "tab" };
         if ($vnet->{ipv4}{dhcpv4}{active} eq "true") {
             send_key "tab";
             type_string $vnet->{ipv4}{dhcpv4}{start};
@@ -128,17 +118,14 @@ sub create_vnet {
         else {
             # disable
             send_key "spc";
-            sleep 1;
         }
         send_key "tab";
         if ($vnet->{ipv4}{staticrouteipv4}{active} eq "true") {
-            send_key "spc";
-            sleep 1;
+            wait_screen_change { send_key "spc" };
             send_key "tab";
             type_string $vnet->{ipv4}{staticrouteipv4}{tonet};
             send_key "tab";
             type_string $vnet->{ipv4}{staticrouteipv4}{viagw};
-            sleep 1;
         }
         # if not staticrouteipv4 we can go next
     }
@@ -150,17 +137,13 @@ sub create_vnet {
     wait_screen_change { send_key "alt-f" };
     # step 3
     if ($vnet->{ipv6}{active} eq "true") {
-        send_key "tab";
-        send_key "spc";
-        sleep 1;
-        send_key "tab";
-        sleep 1;
+        wait_screen_change { send_key "tab" };
+        wait_screen_change { send_key "spc" };
+        wait_screen_change { send_key "tab" };
         type_string $vnet->{ipv6}{network};
-        send_key "tab";
-        sleep 1;
+        wait_screen_change { send_key "tab" };
         if ($vnet->{ipv6}{dhcpv6}{active} eq "true") {
-            send_key "spc";
-            sleep 1;
+            wait_screen_change { send_key "spc" };
             send_key "tab";
             type_string $vnet->{ipv6}{dhcpv6}{start};
             send_key "tab";
@@ -168,8 +151,7 @@ sub create_vnet {
         }
         send_key "tab";
         if ($vnet->{ipv4}{staticrouteipv6}{active} eq "true") {
-            send_key "spc";
-            sleep 1;
+            wait_screen_change { send_key "spc" };
             send_key "tab";
             type_string $vnet->{ipv6}{staticrouteipv6}{tonet};
             send_key "tab";
@@ -226,8 +208,7 @@ sub loop_down {
 sub valid_step {
     # quick function to valid a step
     # validate step with forward
-    send_key "alt-f";
-    sleep 1;
+    wait_screen_change { send_key "alt-f" };
     # be sure that there is no error, or remove them from screen
     save_screenshot;
     for (1 .. 4) { send_key "esc"; }
@@ -249,7 +230,6 @@ sub create_new_pool {
     # got to the "+"
     for (1 .. 8) {
         send_key "tab";
-        #sleep 1;
     }
     send_key "spc";
     # step 1
@@ -450,12 +430,9 @@ sub delete_netinterface {
     send_key "esc";
     # lets go to an interface now
     send_key "tab";
-    sleep 1;
     send_key "down";
-    sleep 1;
-    for (1 .. 7) { send_key "tab"; sleep 1; }
+    for (1 .. 7) { send_key "tab"; }
     send_key "spc";
-    sleep 1;
     save_screenshot;
     send_key "alt-y";
     # close virt-manager
@@ -492,8 +469,7 @@ sub create_netinterface {
     # step 2
     # there is no name for ethernet or vlan
     if ($netif->{type} ne "ethernet" && $netif->{type} ne "vlan") {
-        send_key "tab";
-        sleep 1;
+        wait_screen_change { send_key "tab" };
         type_string $netif->{name}, 50;
     }
     send_key "tab";
@@ -514,12 +490,10 @@ sub create_netinterface {
     send_key "tab";
     #go to IPsettings
     send_key "ret";
-    sleep 1;
     if ($netif->{ipsetting}{copy}{active} eq "true") {
         send_key "tab";
         send_key "up";
         send_key "alt-o";
-        sleep 1;
     }
     elsif ($netif->{ipsetting}{manually}{active} eq "true") {
         # default selection
@@ -529,31 +503,22 @@ sub create_netinterface {
         }
         elsif ($netif->{ipsetting}{manually}{ipv4}{mode} eq "static") {
             send_key "tab";
-            sleep 1;
             send_key "tab";
-            sleep 1;
             send_key "tab";
             send_key "down";
-            sleep 1;
             send_key "tab";
             type_string $netif->{ipsetting}{manually}{ipv4}{address}, 50;
             send_key "tab";
-            sleep 1;
             type_string $netif->{ipsetting}{manually}{ipv4}{gateway}, 50;
         }
         elsif ($netif->{ipsetting}{manually}{ipv4}{mode} eq "noconf") {
             send_key "tab";
-            sleep 1;
             send_key "tab";
-            sleep 1;
             send_key "down";
-            sleep 1;
             send_key "down";
-            sleep 1;
         }
         save_screenshot;
         send_key "alt-o";
-        sleep 1;
     }
     # next step for ethernet is interface selection, there is no other conf
     if ($netif->{type} ne "ethernet") {
@@ -568,7 +533,6 @@ sub create_netinterface {
         }
         save_screenshot;
         send_key "alt-o";
-        sleep 1;
     }
     if ($netif->{type} eq "vlan") {
         type_string $netif->{vlantag}, 50;
@@ -643,7 +607,6 @@ sub create_guest {
     create_new_volume($newvolume);
     save_screenshot;
     # choose this volume and press alt-v
-    #send_key "tab"; sleep 1;
     if (get_var("DESKTOP") !~ /icewm/) {
         assert_and_click "virtman-sle12-gnome_choose_volume";
     }

--- a/lib/virtmanager.pm
+++ b/lib/virtmanager.pm
@@ -36,10 +36,10 @@ sub clean_up_desktop {
 sub connection_details {
     my ($tab) = @_;
     # connection details
-    send_key "alt-e", 1;
+    wait_screen_change { send_key "alt-e" };
     sleep 1;
     # be sure return has been done
-    send_key "ret", 1;
+    send_key "ret";
     sleep 1;
     # send_key "ret";
     if (get_var("DESKTOP") !~ /icewm/) {
@@ -108,11 +108,11 @@ sub create_vnet {
     # go to text
     type_string $vnet->{name}, 30;
     save_screenshot;
-    send_key "ret", 10;
+    send_key "ret";
     # step 2
     save_screenshot;
     # got to enable_ipv4
-    send_key "tab", 1;
+    wait_screen_change { send_key "tab" };
     if ($vnet->{ipv4}{active} eq "true") {
         send_key "tab";
         sleep 1;
@@ -144,10 +144,10 @@ sub create_vnet {
     }
     else {
         # disable IPV4
-        send_key "spc", 10;
+        send_key "spc";
     }
     save_screenshot;
-    send_key "alt-f", 10;
+    wait_screen_change { send_key "alt-f" };
     # step 3
     if ($vnet->{ipv6}{active} eq "true") {
         send_key "tab";
@@ -177,16 +177,16 @@ sub create_vnet {
         }
     }
     save_screenshot;
-    send_key "alt-f", 1;
+    wait_screen_change { send_key "alt-f" };
     # step 4
     if ($vnet->{vnet}{isolatedvnet}{active} eq "true") {
         send_key "alt-i";
-        send_key "tab", 1;
+        send_key "tab";
     }
     elsif ($vnet->{vnet}{fwdphysical}{active} eq "true") {
-        send_key "tab",  1;
-        send_key "down", 1;
-        send_key "tab",  1;
+        wait_screen_change { send_key "tab" };
+        wait_screen_change { send_key "down" };
+        wait_screen_change { send_key "tab" };
         # we only support ANY now
         if ($vnet->{vnet}{fwdphysical}{destination} eq "any") {
             # sending tab will go to "mode"
@@ -196,7 +196,7 @@ sub create_vnet {
             send_key "tab";
         }
         elsif ($vnet->{vnet}{fwdphysical}{mode} eq "routed") {
-            send_key "down", 1;
+            wait_screen_change { send_key "down" };
         }
     }
     # go to enable ipv6 routing
@@ -206,8 +206,7 @@ sub create_vnet {
     }
     save_screenshot;
     # go to next
-    send_key "tab", 1;
-    sleep 1;
+    wait_screen_change { send_key "tab" };
     if ($vnet->{vnetl}{DNSdomainname} ne "") {
         type_string $vnet->{vnet}{DNSdomainname};
     }
@@ -265,26 +264,26 @@ sub create_new_pool {
     }
     elsif ($pool->{data}{type} eq "disk") {
         loop_down("1");
-        send_key "alt-f", 1;
-        send_key "tab",   1;
+        wait_screen_change { send_key "alt-f" };
+        wait_screen_change { send_key "tab" };
         type_string $pool->{data}{target_path}, 50;
-        send_key "tab", 1;
-        send_key "tab", 1;
+        wait_screen_change { send_key 'tab' };
+        wait_screen_change { send_key 'tab' };
         type_string $pool->{data}{source_path}, 50;
-        send_key "tab", 1;
-        send_key "tab", 1;
+        wait_screen_change { send_key 'tab' };
+        wait_screen_change { send_key 'tab' };
         if ($pool->{data}{buildpool} eq "true") {
-            send_key "spc", 1;
+            wait_screen_change { send_key 'spc' };
         }
         valid_step();
     }
     elsif ($pool->{data}{type} eq "fs") {
         loop_down("2");
-        send_key "alt-f", 1;
-        send_key "tab",   1;
+        wait_screen_change { send_key 'alt-f' };
+        wait_screen_change { send_key 'tab' };
         type_string $pool->{data}{target_path}, 50;
-        send_key "tab", 1;
-        send_key "tab", 1;
+        wait_screen_change { send_key 'tab' };
+        wait_screen_change { send_key 'tab' };
         type_string $pool->{data}{source_path}, 50;
         valid_step();
     }
@@ -295,32 +294,32 @@ sub create_new_pool {
     }
     elsif ($pool->{data}{type} eq "iscsi") {
         loop_down("4");
-        send_key "alt-f", 1;
-        send_key "tab",   1;
+        send_key "alt-f";
+        send_key "tab";
         type_string $pool->{data}{target_path};
         send_key "tab";
-        send_key "tab", 1;
+        send_key "tab";
         type_string $pool->{data}{hostname}, 50;
-        send_key "tab", 1;
+        send_key "tab";
         type_string $pool->{data}{IQNsource}, 50;
-        send_key "tab", 1;
+        send_key "tab";
         if ($pool->{data}{initiator}{activate} eq "true") {
             send_key "spc";
-            send_key "tab", 1;
+            send_key "tab";
             type_string $pool->{data}{initiator}{name};
         }
         valid_step();
     }
     elsif ($pool->{data}{type} eq "logical") {
         loop_down("5");
-        send_key "alt-f", 1;
-        send_key "tab",   1;
+        send_key "alt-f";
+        send_key "tab";
         type_string $pool->{data}{target_path}, 50;
-        send_key "tab", 1;
-        send_key "tab", 1;
+        send_key "tab";
+        send_key "tab";
         type_string $pool->{data}{source_path}, 50;
-        send_key "tab", 1;
-        send_key "tab", 1;
+        send_key "tab";
+        send_key "tab";
         if ($pool->{data}{buildpool} eq "true") {
             send_key "spc";
         }
@@ -328,30 +327,30 @@ sub create_new_pool {
     }
     elsif ($pool->{data}{type} eq "mpath") {
         loop_down("6");
-        send_key "alt-f", 1;
-        send_key "tab",   1;
+        send_key "alt-f";
+        send_key "tab";
         type_string $pool->{data}{target_path}, 50;
         valid_step();
     }
     elsif ($pool->{data}{type} eq "netfs") {
         loop_down("7");
-        send_key "alt-f", 1;
-        send_key "tab",   1;
+        send_key "alt-f";
+        send_key "tab";
         type_string $pool->{data}{target_path}, 50;
         send_key "tab";
-        send_key "tab", 1;
+        send_key "tab";
         type_string $pool->{data}{hostname}, 50;
-        send_key "tab", 1;
+        send_key "tab";
         type_string $pool->{data}{source_path}, 50;
         valid_step();
     }
     elsif ($pool->{data}{type} eq "scsi") {
         loop_down("8");
-        send_key "alt-f", 1;
-        send_key "tab",   1;
+        send_key "alt-f";
+        send_key "tab";
         type_string $pool->{data}{target_path}, 50;
-        send_key "tab", 1;
-        send_key "tab", 1;
+        send_key "tab";
+        send_key "tab";
         type_string $pool->{data}{source_path}, 50;
         valid_step();
     }
@@ -374,10 +373,10 @@ sub create_new_volume {
     }
     else {
         # old version of virt-manager provide shortcut...
-        send_key "alt-n", 1;
+        send_key "alt-n";
     }
     type_string $volume->{name}, 20;
-    send_key "tab", 10;
+    send_key "tab";
     # default is qcow2 go to the upper selection
     for (1 .. 4) { send_key "up"; }
     # order is: qcow2, raw, cow, qcow, qed, vmdk, vpc, vdi
@@ -403,12 +402,12 @@ sub create_new_volume {
         $index_down = $index + 2;
         loop_down($index_down);
         if ($volume->{backingstore} ne "") {
-            send_key "tab", 10;
-            send_key "spc", 10;
-            send_key "tab", 10;
+            send_key "tab";
+            send_key "spc";
+            send_key "tab";
             type_string $volume->{backingstore}, 50;
         }
-        else { send_key "tab", 1; }
+        else { send_key "tab"; }
     }
     elsif ($volume->{format} eq "qed") {
         $index_down = $index + 3;
@@ -426,19 +425,19 @@ sub create_new_volume {
         $index_down = $index + 6;
         loop_down($index_down);
     }
-    send_key "tab", 1;
+    send_key "tab";
     type_string $volume->{maxcapacity}, 50;
     if ($volume->{format} ne "qcow2") {
-        send_key "tab", 1;
+        send_key "tab";
         type_string $volume->{allocation};
     }
     # alt-f is used for format also! duplicate shortcut....
-    send_key "alt-f", 4;
-    #    send_key "alt-f", 4;
-    #send_key "ret", 4;
+    send_key "alt-f";
+    #    send_key "alt-f";
+    #send_key "ret";
     save_screenshot;
     # close error windows in case of....
-    #send_key "alt-c", 1;
+    #send_key "alt-c";
 }
 
 sub delete_netinterface {
@@ -468,14 +467,14 @@ sub create_netinterface {
     my $netif = shift;
     # go to the "+" button
     for (1 .. 7) {
-        send_key "tab", 10;
+        send_key "tab";
     }
     # press it
     wait_screen_change { send_key 'spc' };
     # step 1
     # be sure to be at the first value (bridge)
     for (1 .. 4) {
-        send_key "up", 20;
+        send_key "up";
     }
     if ($netif->{type} eq "bridge") {
         print "nothing to do\n";
@@ -489,7 +488,7 @@ sub create_netinterface {
     elsif ($netif->{type} eq "vlan") {
         loop_down("3");
     }
-    send_key "alt-f", 1;
+    send_key "alt-f";
     # step 2
     # there is no name for ethernet or vlan
     if ($netif->{type} ne "ethernet" && $netif->{type} ne "vlan") {
@@ -497,29 +496,28 @@ sub create_netinterface {
         sleep 1;
         type_string $netif->{name}, 50;
     }
-    send_key "tab", 1;
+    send_key "tab";
     if ($netif->{startmode} eq "none") {
         print "default choice\n";
     }
     elsif ($netif->{startmode} eq "onboot") {
-        send_key "down", 1;
+        send_key "down";
     }
     elsif ($netif->{startmode} eq "hotplug") {
         send_key "down";
-        send_key "down", 1;
+        send_key "down";
     }
-    send_key "tab", 1;
+    send_key "tab";
     if ($netif->{activenow} eq "true") {
-        send_key "spc", 1;
+        send_key "spc";
     }
-    send_key "tab", 1;
+    send_key "tab";
     #go to IPsettings
     send_key "ret";
     sleep 1;
     if ($netif->{ipsetting}{copy}{active} eq "true") {
-        # FIXME
-        send_key "tab", 10;
-        send_key "up",  10;
+        send_key "tab";
+        send_key "up";
         send_key "alt-o";
         sleep 1;
     }
@@ -559,17 +557,17 @@ sub create_netinterface {
     }
     # next step for ethernet is interface selection, there is no other conf
     if ($netif->{type} ne "ethernet") {
-        send_key "tab", 10;
+        send_key "tab";
     }
     if ($netif->{type} eq "bridge") {
-        send_key "ret", 10;
+        send_key "ret";
         type_string $netif->{ipsetting}{bridgesettings}{fwddelay}, 50;
         if ($netif->{ipsetting}{bridgesettings}{stp} eq "true") {
             send_key "tab";
             send_key "ret";
         }
         save_screenshot;
-        send_key "alt-o", 1;
+        send_key "alt-o";
         sleep 1;
     }
     if ($netif->{type} eq "vlan") {
@@ -580,7 +578,7 @@ sub create_netinterface {
         # FIXME
         print "not yet implemented\n";
     }
-    send_key "tab", 10;
+    send_key "tab";
     save_screenshot;
     if ($netif->{interface} eq "lo") {
         send_key "spc";
@@ -588,9 +586,9 @@ sub create_netinterface {
     elsif ($netif->{interface} eq "other") {
         send_key "down";
         send_key "down";
-        send_key "spc", 1;
+        send_key "spc";
     }
-    send_key "alt-f", 30;
+    send_key "alt-f";
     if ($netif->{type} ne "vlan" && $netif->{type} ne "bond") {
         # bridge/ethernet can take time to be up; waiting 35sec more
         save_screenshot;
@@ -606,7 +604,7 @@ sub create_guest {
     my $guest = shift;
     # create using virt-install
     send_key "alt-f";
-    send_key "n", 10;
+    send_key "n";
     # step 1: method
     if ($guest->{method} eq "cdrom") {
         print "nothing to do\n";
@@ -624,17 +622,17 @@ sub create_guest {
     # go to step2
     wait_screen_change { send_key "alt-f" };
     # step 2: media installation
-    send_key "alt-f", 10;
+    send_key "alt-f";
     # step 3: Mem and CPU
-    send_key "tab", 10;
+    send_key "tab";
     type_string $guest->{memory}, 50;
-    send_key "tab", 10;
+    send_key "tab";
     type_string $guest->{cpu}, 50;
     save_screenshot;
-    send_key "alt-f", 10;
+    send_key "alt-f";
     # step 4: storage
-    send_key "alt-m", 10;
-    send_key "alt-w", 10;
+    send_key "alt-m";
+    send_key "alt-w";
 
     my $newvolume = {
         name        => "guest",
@@ -653,12 +651,12 @@ sub create_guest {
         assert_and_click "virtman_choose_volume";
     }
     # go to last step
-    send_key "alt-f", 10;
+    send_key "alt-f";
     # step 5: last conf
-    send_key "tab", 10;
+    send_key "tab";
     type_string $guest->{name}, 50;
     # be sure to be in "customize"
-    send_key "tab", 10;
+    send_key "tab";
     if ($guest->{custom} eq "true") {
         send_key "alt-u";
     }
@@ -668,7 +666,7 @@ sub create_guest {
         send_key "spc";
         send_key "tab";
         # unselect and select FIXED MAC
-        send_key "alt-m", 10;
+        send_key "alt-m";
         send_key "alt-m";
         send_key "tab";
         # enter custom mac
@@ -679,10 +677,10 @@ sub create_guest {
     if ($guest->{custom} eq "true") {
         send_key "tab";
         send_key "tab";
-        send_key "tab", 10;
+        send_key "tab";
         for (1 .. 11) {
             # parse all options
-            send_key "down", 10;
+            send_key "down";
         }
         save_screenshot;
         send_key "up";

--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -229,8 +229,7 @@ sub send_meeting_request {
     #create new meeting
     send_key "shift-ctrl-e";
     assert_screen "evolution_mail-compse_meeting", 30;
-    send_key "alt-a";
-    sleep 2;
+    wait_screen_change { send_key 'alt-a' };
     type_string "$mail_box";
     send_key "alt-s";
     if (sle_version_at_least('12-SP2')) {
@@ -303,8 +302,7 @@ sub start_evolution {
     wait_screen_change {
         send_key "alt-a";
     };
-    type_string "$mail_box";
-    sleep 1;
+    wait_screen_change { type_string "$mail_box" };
     save_screenshot();
 
     # skip server look up for localhost email address
@@ -439,10 +437,7 @@ sub setup_mail_account {
     assert_and_click "evolution_wizard-sending-setauthtype";
     send_key_until_needlematch "evolution_wizard-sending-authtype", "down", 5, 3;
     send_key "ret";
-    wait_screen_change {
-        send_key "alt-n";
-    };
-    sleep 1;
+    wait_screen_change { send_key 'alt-n' };
     type_string "$mail_user";
     send_key $self->{next};
     send_key "ret";
@@ -610,7 +605,6 @@ sub setup_evolution_for_ews {
         send_key "alt-a";
     };
     type_string "$mailbox";
-    sleep 1;
     save_screenshot();
 
     send_key "alt-o";
@@ -704,14 +698,10 @@ sub evolution_send_message {
 }
 
 sub pidgin_remove_account {
-    send_key "ctrl-a";
-    sleep 2;
-    send_key "right";
-    sleep 2;
-    send_key "ret";
-    sleep 2;
-    send_key "alt-d";
-    sleep 2;
+    wait_screen_change { send_key "ctrl-a" };
+    wait_screen_change { send_key "right" };
+    wait_screen_change { send_key "ret" };
+    wait_screen_change { send_key "alt-d" };
     send_key "alt-d";
 }
 
@@ -719,17 +709,14 @@ sub tomboy_logout_and_login {
     wait_screen_change { send_key 'alt-f4' };
 
     # logout
-    send_key "alt-f2";
-    sleep 1;
+    wait_screen_change { send_key "alt-f2" };
     type_string "gnome-session-quit --logout --force\n";
     wait_still_screen;
 
     # login
     send_key "ret";
-    sleep 2;
     wait_still_screen;
     type_password();
-    sleep 2;
     send_key "ret";
     assert_screen 'generic-desktop';
 

--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -722,8 +722,7 @@ sub tomboy_logout_and_login {
     send_key "alt-f2";
     sleep 1;
     type_string "gnome-session-quit --logout --force\n";
-    sleep 20;
-    wait_idle;
+    wait_still_screen;
 
     # login
     send_key "ret";
@@ -732,8 +731,7 @@ sub tomboy_logout_and_login {
     type_password();
     sleep 2;
     send_key "ret";
-    sleep 20;
-    wait_idle;
+    assert_screen 'generic-desktop';
 
     # open start note again and take screenshot
     x11_start_program("tomboy note");

--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -36,13 +36,10 @@ sub get_to_console {
     my $ret = check_screen(\@tags, 5);
     if ($ret && match_has_tag("linuxrc-repo-not-found")) {    # KVM only
         send_key "ctrl-alt-f9";
-        wait_idle;
         assert_screen "inst-console";
         type_string "blkid\n";
         save_screenshot();
-        send_key "ctrl-alt-f3";
-        wait_idle;
-        sleep 1;
+        wait_screen_change { send_key 'ctrl-alt-f3' };
         save_screenshot();
     }
     elsif ($ret) {

--- a/lib/y2x11test.pm
+++ b/lib/y2x11test.pm
@@ -12,7 +12,7 @@ sub launch_yast2_module_x11 {
     if (check_screen "root-auth-dialog") {
         if ($password) {
             type_password;
-            send_key "ret", 1;
+            wait_screen_change { send_key "ret" };
         }
     }
 }

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -74,9 +74,8 @@ sub handle_expected_errors {
     send_key "alt-s";    #stop
     $self->save_and_upload_yastlogs("_expected_error$i");
     $i++;
-    send_key "tab";      #continue
-    send_key "ret";
-    wait_idle(5);
+    wait_screen_change { send_key 'tab' };    #continue
+    wait_screen_change { send_key 'ret' };
 }
 
 sub verify_timeout_and_check_screen {
@@ -145,9 +144,8 @@ sub run {
 
             assert_screen("startinstall", 20);
 
-            send_key "tab";
-            send_key "ret";
-            wait_idle(5);
+            wait_screen_change { send_key 'tab' };
+            wait_screen_change { send_key 'ret' };
             @needles = grep { $_ ne 'autoyast-confirm' } @needles;
             $confirmed = 1;
         }

--- a/tests/autoyast/login.pm
+++ b/tests/autoyast/login.pm
@@ -30,9 +30,7 @@ sub run {
         use_ssh_serial_console;
     }
     assert_script_run 'echo "checking serial port"';
-    wait_idle(10);
     type_string "cat /proc/cmdline\n";
-    wait_idle(10);
     save_screenshot;
     $self->result('ok');
 }

--- a/tests/autoyast/logs.pm
+++ b/tests/autoyast/logs.pm
@@ -33,12 +33,8 @@ sub run {
     type_string
 "tar cjf /tmp/logs.tar.bz2 --exclude=/etc/{brltty,udev/hwdb.bin} --exclude=/var/log/{YaST2,zypp,{pbl,zypper}.log} /var/{log,adm/autoinstall} /run/systemd/system/ /usr/lib/systemd/system/ /boot/grub2/{device.map,grub{.cfg,env}} /etc/\n";
     upload_logs "/tmp/logs.tar.bz2";
-
-    #on high load, wait_idle is not enough
     type_string "echo UPLOADFINISH >/dev/$serialdev\n";
     wait_serial("UPLOADFINISH", 200);
-
-    wait_idle(30);
     save_screenshot;
 }
 

--- a/tests/autoyast/pxe_boot.pm
+++ b/tests/autoyast/pxe_boot.pm
@@ -61,8 +61,7 @@ sub run {
     if (get_var("EXTRA_BOOT_ARG")) {
         type_string_very_slow(' ' . get_var("EXTRA_BOOT_ARG"));
     }
-
-    sleep 3;
+    wait_still_screen(3);
     save_screenshot;
     send_key "ret";
 

--- a/tests/autoyast/wicked.pm
+++ b/tests/autoyast/wicked.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE Linux GmbH
+# Copyright (C) 2015-2016 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,15 +13,14 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# G-Summary: wicked script for more logs if eth0 is not up
-# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+# Summary: wicked script for more logs if eth0 is not up
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
 use strict;
 use base 'basetest';
 use testapi;
 
 sub run {
-
     # https://en.opensuse.org/openSUSE:Bugreport_wicked
     type_string "systemctl status wickedd.service\n";
     type_string "echo `wicked show all |cut -d ' ' -f 1` END | tee /dev/$serialdev\n";
@@ -49,7 +48,6 @@ sub run {
         save_screenshot;
         # collect the configuration
         type_string "wicked show-config > /tmp/wicked/config-dump.log\n";
-        sleep 5;
         # collect the status
         type_string "wicked ifstatus --verbose all > /tmp/wicked/status.log\n";
         type_string "journalctl -b -o short-precise > /tmp/wicked/wicked.log\n";

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -18,13 +18,6 @@ use strict;
 
 sub run {
     my $self = shift;
-
-    # Without this login name and password won't get to the system. They get
-    # lost somewhere. Applies for all systems installed via svirt, but zKVM.
-    if (check_var('BACKEND', 'svirt') and !check_var('ARCH', 's390x')) {
-        wait_idle;
-    }
-
     # let's see how it looks at the beginning
     save_screenshot;
 
@@ -58,8 +51,7 @@ sub run {
                 assert_and_click "sddm-password-input";
             }
             else {
-                send_key "ret";
-                wait_idle;
+                wait_screen_change { send_key 'ret' };
             }
             type_string "$password";
             send_key "ret";

--- a/tests/console/yast2_dm_crypt.pm
+++ b/tests/console/yast2_dm_crypt.pm
@@ -62,7 +62,6 @@ sub run {
     assert_screen "yast2-cryptfile-summary";
     send_key "alt-f";
     assert_screen "yast2-cryptfile-creation";
-    wait_idle;
 
     wait_serial('yast2-disk-status-0') || die "'yast2 disk' didn't finish";
 

--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -73,7 +73,6 @@ sub run {
     # Enable dns server and finish
     send_key 'alt-s';
     wait_screen_change { send_key 'alt-f'; };
-    wait_idle;
     # The wizard-like interface still uses the old approach of always starting the service
     # while enabling it, so named should be both active and enabled
     $self->assert_running(1);
@@ -88,11 +87,10 @@ sub run {
     send_key 'alt-s';
     assert_screen 'yast2-service-stopped-enabled';
     # Cancel yast2 to check the effect
-    send_key 'alt-c';
+    wait_screen_change { send_key 'alt-c' };
     if (check_screen('yast2-dns-server-quit')) {
-        send_key 'alt-y';
+        wait_screen_change { send_key 'alt-y' };
     }
-    wait_idle;
     $self->assert_running(0);
     $self->assert_enabled(1);
 
@@ -105,9 +103,8 @@ sub run {
     send_key 'alt-s';
     assert_screen 'yast2-service-running-enabled';
     # Disable the service and finish
-    send_key 'alt-t';
-    send_key 'alt-o';
-    wait_idle;
+    wait_screen_change { send_key 'alt-t' };
+    wait_screen_change { send_key 'alt-o' };
     $self->assert_running(1);
     $self->assert_enabled(0);
 
@@ -120,8 +117,7 @@ sub run {
     send_key 'alt-s';
     assert_screen 'yast2-service-stopped-disabled';
     # Finish
-    send_key 'alt-o';
-    wait_idle;
+    wait_screen_change { send_key 'alt-o' };
     $self->assert_running(0);
     $self->assert_enabled(0);
 }

--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -67,7 +67,7 @@ sub run {
         type_string("$pkgname\n");
         assert_screen "$pkgname-selected-for-install", 10;
     }
-    send_key "alt-a", 1;     # accept
+    send_key "alt-a";        # accept
 
     # Whether summary is shown depends on PKGMGR_ACTION_AT_EXIT in /etc/sysconfig/yast2
     until (get_var('YAST_SW_NO_SUMMARY')) {

--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -47,7 +47,7 @@ sub run {
 
     script_sudo("yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev", 0);
 
-    assert_screen [qw(Networkmanager_controlled yast2_lan install-susefirewall2 dhcp-popup)], 60;
+    assert_screen [qw(Networkmanager_controlled yast2_lan install-susefirewall2 dhcp-popup)], 120;
     handle_dhcp_popup;
     if (match_has_tag('Networkmanager_controlled')) {
         handle_Networkmanager_controlled;

--- a/tests/console/yast2_nfs_client.pm
+++ b/tests/console/yast2_nfs_client.pm
@@ -52,9 +52,8 @@ sub run {
     send_key 'alt-m';
     type_string '/tmp/nfs/client';
     # Save the new connection and close YaST
-    wait_screen_change { send_key 'alt-o'; };
-    wait_screen_change { send_key 'alt-o'; };
-    wait_idle;
+    wait_screen_change { send_key 'alt-o' };
+    wait_screen_change { send_key 'alt-o' };
 
     #
     # Check the result

--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -23,7 +23,7 @@ sub run {
     type_string "ha-cluster-join -yc " . get_var("HACLUSTERJOIN") . "\n";
     assert_screen "ha-cluster-join-password";
     type_password;
-    send_key("ret", 1);
+    send_key 'ret';
     wait_still_screen;
     script_run "crm_mon -1";
     save_screenshot;

--- a/tests/installation/addon_products.pm
+++ b/tests/installation/addon_products.pm
@@ -60,9 +60,7 @@ sub run {
             else {
                 assert_screen "addon-license-$a";
             }
-            sleep 2;
-            send_key 'alt-y';    # yes, agree
-            sleep 2;
+            wait_screen_change { send_key 'alt-y' };    # yes, agree
             send_key $cmd{next};
             assert_screen 'addon-list';
             if ((split(/,/, get_var('ADDONS')))[-1] ne $a) {

--- a/tests/installation/addon_products.pm
+++ b/tests/installation/addon_products.pm
@@ -19,8 +19,8 @@ sub run {
     if (check_screen('network-setup', 10)) {    # won't appear for NET installs
         send_key $cmd{next};                    # use network
         assert_screen 'dhcp-network';
-        send_key 'alt-d', 2;                    # DHCP
-        send_key 'alt-o', 2;                    # OK
+        wait_screen_change { send_key 'alt-d' };    # DHCP
+        send_key 'alt-o';                           # OK
     }
 
     assert_screen 'addon-selection';
@@ -29,25 +29,25 @@ sub run {
 
         # FIXME: do the same as sle here
         foreach my $url (split(/\+/, get_var("ADDONURL"))) {
-            send_key "alt-a";                   # Add another
-            send_key $cmd{xnext}, 1;            # Specify URL (default)
+            send_key "alt-a";                       # Add another
+            wait_screen_change { send_key $cmd{xnext} };    # Specify URL (default)
             type_string $url;
-            send_key $cmd{next}, 1;
-            if (get_var("ADDONURL") !~ m{/update/}) {    # update is already trusted, so would trigger "delete"
+            wait_screen_change { send_key $cmd{next} };
+            if (get_var("ADDONURL") !~ m{/update/}) {       # update is already trusted, so would trigger "delete"
                 send_key "alt-i";
                 assert_screen 'import-untrusted-gpg-key-598D0E63B3FD7E48';
-                send_key "alt-t", 1;                     # confirm import (trust) key
+                send_key "alt-t";                           # confirm import (trust) key
             }
         }
         assert_screen 'addon-selection';
-        send_key $cmd{next}, 1;                          # done
+        wait_screen_change { send_key $cmd{next} };         # done
     }
 
     if (get_var("ADDONS")) {
 
         for my $a (split(/,/, get_var('ADDONS'))) {
-            send_key 'alt-d';                            # DVD
-            send_key $cmd{xnext}, 1;
+            send_key 'alt-d';                               # DVD
+            send_key $cmd{xnext};
             assert_screen 'dvd-selector';
             send_key_until_needlematch 'addon-dvd-list', 'tab';
             send_key_until_needlematch "addon-dvd-$a",   'down';

--- a/tests/installation/addon_products_yast2.pm
+++ b/tests/installation/addon_products_yast2.pm
@@ -24,7 +24,7 @@ sub run {
         send_key 'alt-y';    # yes
     }
     assert_screen 'addon-products';
-    send_key 'alt-a', 2;     # add add-on
+    send_key 'alt-a';        # add add-on
     if (get_var("ADDONS")) {
         # the ISO_X variables must match the ADDONS list
         my $sr_number = 0;
@@ -42,8 +42,8 @@ sub run {
                 send_key $cmd{next};
             }
             else {
-                send_key 'alt-v', 3;    # DVD
-                send_key $cmd{next}, 3;
+                wait_screen_change { send_key 'alt-v' };    # DVD
+                send_key $cmd{next};
                 assert_screen 'dvd-selector',                        3;
                 send_key_until_needlematch 'addon-dvd-list',         'tab', 5;      # jump into addon list
                 send_key_until_needlematch "addon-dvd-sr$sr_number", 'down', 10;    # select addon in list
@@ -61,13 +61,13 @@ sub run {
             else {
                 assert_screen "addon-license-$addon";
             }
-            send_key 'alt-a', 2;                                                    # yes, agree
-            send_key $cmd{next}, 2;
+            wait_screen_change { send_key 'alt-a' };                                # yes, agree
+            send_key $cmd{next};
             assert_screen 'addon-yast2-patterns';
             send_key_until_needlematch 'addon-yast2-view-selected', 'alt-v', 10;
             send_key 'spc';                                                         # open view menu
-            send_key 'alt-r', 1;
-            send_key 'alt-r', 1;                                                    # go to repositories
+            wait_screen_change { send_key 'alt-r' };
+            wait_screen_change { send_key 'alt-r' };                                # go to repositories
             send_key 'ret';                                                         # open repositories tab
             assert_screen "addon-yast2-repo-$addon";
             send_key 'alt-a';                                                       # accept
@@ -81,7 +81,7 @@ sub run {
                 send_key 'alt-o';                                                   # OK
             }
             assert_screen "addon-installation-report";
-            send_key 'alt-f', 2;                                                    # finish
+            send_key 'alt-f';                                                       # finish
             assert_screen 'scc-registration';
             if (get_var('SCC_REGISTER')) {
                 fill_in_registration_data;
@@ -94,27 +94,27 @@ sub run {
                     save_screenshot;
                     send_key $cmd{next};
                 }
-                assert_screen 'addon-products',                     60;
-                send_key "tab",                                     1;              # select addon-products-$addon
+                assert_screen 'addon-products', 60;
+                wait_screen_change { send_key "tab" };                              # select addon-products-$addon
                 send_key "pgup",                                    1;
                 send_key_until_needlematch "addon-products-$addon", 'down';
             }
             else {
                 skip_registration;
                 if (check_screen("scc-skip-base-system-reg-warning")) {
-                    send_key "alt-y", 1;                                            # confirmed skip SCC registration
+                    wait_screen_change { send_key "alt-y" };                        # confirmed skip SCC registration
                 }
             }
             if ((split(/,/, get_var('ADDONS')))[-1] ne $addon) {                    # if $addon is not first from all ADDONS
-                send_key 'alt-a', 2;                                                # add another add-on
+                send_key 'alt-a';                                                   # add another add-on
             }
             else {
-                send_key 'alt-o', 2;                                                # ok continue
+                send_key 'alt-o';                                                   # ok continue
             }
         }
     }
     else {
-        send_key 'alt-n', 2;                                                        # done
+        send_key 'alt-n';                                                           # done
     }
 }
 

--- a/tests/installation/bootloader_ofw.pm
+++ b/tests/installation/bootloader_ofw.pm
@@ -51,15 +51,13 @@ sub run {
         }
         else {
             # edit menu
-            send_key "e";
+            wait_screen_change { send_key "e" };
             #wait until we get to grub edit
-            wait_idle(5);
             #go down to kernel entry
             send_key "down";
             send_key "down";
             send_key "down";
-            send_key "end";
-            wait_idle(5);
+            wait_screen_change { send_key "end" };
             my $args = "";
             # load kernel manually with append
             if (check_var('VIDEOMODE', 'text')) {

--- a/tests/installation/installation_mode.pm
+++ b/tests/installation/installation_mode.pm
@@ -18,7 +18,7 @@ use testapi;
 
 sub run {
     # autoconf phase
-    # includes downloads, so wait_idle is bad.
+    # includes downloads
     assert_screen [qw(partitioning-edit-proposal-button inst-instmode)], 120;
     if (match_has_tag("partitioning-edit-proposal-button")) {
         # new desktop selection workflow

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -38,9 +38,6 @@ sub run {
         assert_screen "inst-xen-pattern";
     }
 
-    # preserve it for the video
-    wait_idle 10;
-
     # Check autoyast has been removed in SP2 (fate#317970)
     if (get_var("SP2ORLATER") && !check_var("INSTALL_TO_OTHERS", 1)) {
         if (check_var('VIDEOMODE', 'text')) {

--- a/tests/installation/installation_overview_before.pm
+++ b/tests/installation/installation_overview_before.pm
@@ -27,9 +27,6 @@ sub run {
     # performed only once, as state of buttons can be different
     assert_screen "installation-settings-overview-loaded";
 
-    # preserve it for the video
-    wait_idle 10;
-
     if (match_has_tag 'manual-intervention') {
         $self->deal_with_dependency_issues;
     }

--- a/tests/installation/partitioning_lvm.pm
+++ b/tests/installation/partitioning_lvm.pm
@@ -76,7 +76,7 @@ sub run {
         }
     }
     elsif (!get_var('ENCRYPT_ACTIVATE_EXISTING')) {    # old behaviour still needed
-        send_key "alt-l", 1;                           # enable LVM-based proposal
+        wait_screen_change { send_key "alt-l" };       # enable LVM-based proposal
         if (get_var("ENCRYPT")) {
             send_key "alt-y";
             assert_screen "inst-encrypt-password-prompt";

--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -83,8 +83,7 @@ sub addraid {
     assert_screen 'partition-role';
     send_key "alt-o";    # Operating System
 
-    send_key $cmd{next};
-    wait_idle 3;
+    wait_screen_change { send_key $cmd{next} };
 }
 
 sub setraidlevel {
@@ -135,9 +134,8 @@ sub set_lvm {
     send_key "alt-o";    # Operating System
     send_key $cmd{next};
 
-    # keep deafult to mount as root and btrfs
-    send_key $cmd{finish};
-    wait_idle 4;
+    # keep default to mount as root and btrfs
+    wait_screen_change { send_key $cmd{finish} };
 }
 
 sub run {
@@ -338,7 +336,6 @@ sub run {
     # LVM on top of raid if needed
     if (get_var("LVM")) {
         set_lvm();
-        wait_idle 3;
         save_screenshot;
     }
 

--- a/tests/installation/partitioning_splitusr.pm
+++ b/tests/installation/partitioning_splitusr.pm
@@ -30,7 +30,6 @@ sub run {
     wait_screen_change { send_key 'alt-i' };    # Resize
     send_key "alt-u";                           # Custom
     type_string "1.5G";
-    sleep 2;
     send_key "ret";
 
     # add /usr

--- a/tests/installation/partitioning_splitusr.pm
+++ b/tests/installation/partitioning_splitusr.pm
@@ -16,10 +16,10 @@ use strict;
 use testapi;
 
 sub run {
-    send_key "alt-e", 1;    # Edit
-                            # select vda2
+    send_key "alt-e";    # Edit
+                         # select vda2
     send_key "right";
-    send_key "down";        # only works with multiple HDDs
+    send_key "down";     # only works with multiple HDDs
     send_key "right";
     send_key "down";
     send_key "tab";
@@ -27,11 +27,11 @@ sub run {
     send_key "down";
 
     #send_key "right"; send_key "down"; send_key "down";
-    send_key "alt-i", 1;    # Resize
-    send_key "alt-u";       # Custom
+    wait_screen_change { send_key 'alt-i' };    # Resize
+    send_key "alt-u";                           # Custom
     type_string "1.5G";
     sleep 2;
-    send_key "ret", 1;
+    send_key "ret";
 
     # add /usr
     wait_screen_change { send_key $cmd{addpart} };
@@ -49,7 +49,7 @@ sub run {
     assert_screen "partition-splitusr-submitted-usr";
     send_key $cmd{finish};
     assert_screen "partition-splitusr-finished";
-    send_key $cmd{accept}, 1;
+    wait_screen_change { send_key $cmd{accept} };
     send_key "alt-y";        # Quit the warning window
 }
 

--- a/tests/installation/partitioning_splitusr.pm
+++ b/tests/installation/partitioning_splitusr.pm
@@ -34,10 +34,8 @@ sub run {
     send_key "ret", 1;
 
     # add /usr
-    send_key $cmd{addpart};
-    wait_idle 4;
-    send_key $cmd{next};
-    wait_idle 3;
+    wait_screen_change { send_key $cmd{addpart} };
+    wait_screen_change { send_key $cmd{next} };
     for (1 .. 10) {
         send_key "backspace";
     }
@@ -45,8 +43,7 @@ sub run {
     send_key $cmd{next};
     assert_screen 'partition-role';
     send_key "alt-o";    # Operating System
-    send_key $cmd{next};
-    wait_idle 5;
+    wait_screen_change { send_key $cmd{next} };
     send_key "alt-m";        # Mount Point
     type_string "/usr\b";    # Backspace to break bad completion to /usr/local
     assert_screen "partition-splitusr-submitted-usr";

--- a/tests/installation/post_zdup.pm
+++ b/tests/installation/post_zdup.pm
@@ -24,8 +24,6 @@ sub run {
     # Remove the --force when this is fixed:
     # https://bugzilla.redhat.com/show_bug.cgi?id=1075131
     script_run("systemctl set-default --force graphical.target");
-    sleep 5;
-
     save_screenshot;
 
     # switch to root-console (in case we are in X)

--- a/tests/installation/secure_boot.pm
+++ b/tests/installation/secure_boot.pm
@@ -22,13 +22,11 @@ sub run {
     $cmd{bootloader} = "alt-b" if check_var('VIDEOMODE', "text");
     send_key $cmd{change};        # Change
     send_key $cmd{bootloader};    # Bootloader
-    sleep 4;
 
     # Is secure boot enabled?
     assert_screen "bootloader-secureboot-enabled";
-    send_key $cmd{accept};        # Accept
-    sleep 2;
-    send_key "alt-o";             # cOntinue
+    wait_screen_change { send_key $cmd{accept} };    # Accept
+    send_key "alt-o";                                # cOntinue
 }
 
 1;

--- a/tests/installation/secure_boot.pm
+++ b/tests/installation/secure_boot.pm
@@ -29,7 +29,6 @@ sub run {
     send_key $cmd{accept};        # Accept
     sleep 2;
     send_key "alt-o";             # cOntinue
-    wait_idle;
 }
 
 1;

--- a/tests/installation/skip_disk_activation.pm
+++ b/tests/installation/skip_disk_activation.pm
@@ -16,10 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    record_soft_failure 'we should not have it';
-    sleep 3;
-    send_key $cmd{next};
-    sleep 5;
+    wait_screen_change { send_key $cmd{next} };
 }
 
 1;

--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -35,7 +35,7 @@ sub run {
 
         while (match_has_tag("startupdate-conflict") || match_has_tag("license-popup")) {
             if (match_has_tag("startupdate-conflict")) {
-                send_key $cmd{ok}, 1;
+                send_key $cmd{ok};
 
                 while (!check_screen('packages-section-selected', 2)) {
                     send_key 'tab';
@@ -46,21 +46,21 @@ sub run {
 
                 while (!check_screen('all-conflicts-resolved-packages', 4)) {
                     assert_and_click 'package-conflict-choice';
-                    send_key $cmd{ok}, 1;
+                    send_key $cmd{ok};
                 }
-                send_key $cmd{accept}, 1;
+                send_key $cmd{accept};
 
                 while (check_screen('license-popup', 2)) {
-                    send_key $cmd{accept}, 1;
+                    send_key $cmd{accept};
                 }
                 assert_screen "automatic-changes";
-                send_key $cmd{continue}, 1;
+                send_key $cmd{continue};
 
                 send_key $cmd{update};
                 sleep 1;
             }
             if (match_has_tag("license-popup")) {
-                send_key $cmd{accept}, 1;
+                send_key $cmd{accept};
             }
             assert_screen [qw(startupdate startupdate-conflict license-popup)], 5;
         }
@@ -88,7 +88,7 @@ sub run {
         wait_screen_change { send_key 'alt-o' } if match_has_tag('inst-overview-error-found', 0);
         while (check_screen([qw(confirmlicense startinstall)], 5)) {
             last if match_has_tag("startinstall");
-            send_key $cmd{acceptlicense}, 1;
+            send_key $cmd{acceptlicense};
         }
         assert_screen "startinstall";
 

--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -27,9 +27,9 @@ sub run {
 
     # hardware detection and waiting for updates from suse.com can take a while
     assert_screen_with_soft_timeout('select-for-update', timeout => 500, soft_timeout => 100, bugref => 'bsc#1028774');
-    send_key $cmd{next}, 1;
+    send_key $cmd{next};
     assert_screen "remove-repository", 240;
-    send_key $cmd{next}, 1;
+    send_key $cmd{next};
 }
 
 1;

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -62,9 +62,8 @@ sub run {
         wait_screen_change { send_key 'ret' };
     }
     assert_screen 'inst-welcome';
-
-    wait_idle;
     mouse_hide;
+    wait_still_screen(3);
 
     # license+lang
     if (get_var('HASLICENSE')) {

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -63,13 +63,6 @@ sub run {
     }
 
     assert_screen 'linux-login';
-
-    # Without this login name and password won't get to the system. They get
-    # lost somewhere. Applies for all systems installed via svirt, but zKVM.
-    if (check_var('BACKEND', 'svirt') and !check_var('ARCH', 's390x')) {
-        wait_idle;
-    }
-
     select_console 'root-console';
 
     assert_script_run "useradd -m $username -c '$realname'";    # create user account

--- a/tests/linuxrc/system_boot.pm
+++ b/tests/linuxrc/system_boot.pm
@@ -31,7 +31,7 @@ sub run {
 
     # Confirm booting
     diag "Booting the installed system now...";
-    send_key "ret", 0;
+    send_key "ret";
 
     # Wait for the system to boot
     assert_screen("displaymanager", 60);

--- a/tests/online_migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/online_migration/sle12_online_migration/yast2_migration.pm
@@ -201,7 +201,7 @@ sub run {
         }
         elsif (match_has_tag("yast2-migration-wrongdigest")) {
             $self->result('fail');
-            send_key "alt-a", 1;
+            send_key "alt-a";
             save_screenshot;
             send_key "alt-n";
             return;

--- a/tests/qa_automation/kernel_kexec.pm
+++ b/tests/qa_automation/kernel_kexec.pm
@@ -41,7 +41,6 @@ sub run {
     # kexec -e
     type_string("systemctl kexec\n");
     # wait for reboot
-    wait_idle();
     reset_consoles();
     select_console("root-console");
     # Check kernel cmdline parameter

--- a/tests/sysauth/sssd.pm
+++ b/tests/sysauth/sssd.pm
@@ -32,8 +32,6 @@ sub run {
         assert_script_run "zypper -n in psmisc";
     }
     script_run "zypper -n refresh && zypper -n in @test_subjects";
-    wait_idle;
-
     script_run "cd; curl -L -v " . autoinst_url . "/data/sssd-tests > sssd-tests.data && cpio -id < sssd-tests.data && mv data sssd && ls sssd";
 
     # The test scenarios are now ready to run

--- a/tests/virt_autotest/guest_migration_dst.pm
+++ b/tests/virt_autotest/guest_migration_dst.pm
@@ -36,9 +36,7 @@ sub run {
     my $pre_test_cmd = "/usr/share/qa/virtautolib/lib/guest_migrate.sh " . $args;
     type_string("$pre_test_cmd \n");
     save_screenshot;
-    sleep 10;
     send_key("ctrl-c");
-    sleep 3;
     save_screenshot;
     #workaround end
 

--- a/tests/virt_autotest/guest_migration_source_install_guest.pm
+++ b/tests/virt_autotest/guest_migration_source_install_guest.pm
@@ -26,8 +26,5 @@ sub run {
         $self->execute_script_run("$install_script $guest", 3600);
         save_screenshot;
     }
-
-    sleep 5;
-
 }
 1;

--- a/tests/virt_autotest/proxymode_init_pxe_install.pm
+++ b/tests/virt_autotest/proxymode_init_pxe_install.pm
@@ -28,7 +28,6 @@ sub run {
     $self->connect_slave($ipmi_machine);
     $self->restart_host($ipmi_machine);
     assert_screen "proxy_virttest-pxe", 300;
-    wait_idle 3;
     send_key_until_needlematch "proxy_virttest-pxe-edit-prompt", "esc", 10, 5;
     wait_still_screen 5;
     # Execute installation command on pxe management cmd console

--- a/tests/virt_autotest/proxymode_login_proxy.pm
+++ b/tests/virt_autotest/proxymode_login_proxy.pm
@@ -23,7 +23,6 @@ sub run {
     send_key "ret";
     assert_screen "displaymanager", 300;
     select_console('root-console');
-    sleep 2;
 }
 
 sub test_flags {

--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -22,7 +22,6 @@ sub reboot_and_wait_up {
     my $reboot_timeout = shift;
 
     if (get_var("PROXY_MODE")) {
-        wait_idle 1;
         select_console('root-console');
         my $test_machine = get_var("TEST_MACHINE");
         $self->reboot($test_machine, $reboot_timeout);

--- a/tests/virtualization/installation.pm
+++ b/tests/virtualization/installation.pm
@@ -96,7 +96,6 @@ sub run {
     send_key "alt-i",                          1;
     assert_screen "SLE12_install_in_progress", 10;
     # reboot !
-    wait_idle 530;
 }
 
 sub test_flags {

--- a/tests/virtualization/installation.pm
+++ b/tests/virtualization/installation.pm
@@ -23,77 +23,77 @@ use testapi;
 sub run {
     if (get_var("BETA") =~ /beta/) {
         assert_screen "SLE12_beta", 120;
-        send_key "alt-o",           1;
+        send_key "alt-o";
     }
 
     # accept Licence
     assert_screen "SLE12_acceptlicence", 120;
-    send_key "alt-a",                    1;
-    send_key "alt-n",                    1;
+    send_key "alt-a";
+    send_key "alt-n";
 
     # Skip registration
-    send_key "alt-s", 1;
-    send_key "alt-y", 1;
+    send_key "alt-s";
+    send_key "alt-y";
 
     # No external repository
-    send_key "alt-n", 3;
+    send_key "alt-n";
     save_screenshot;
 
     # don't use btrfs, switch to ext4
     assert_screen "SLE12_partition_ext4", 20;
-    send_key "alt-d",                     1;
-    send_key "alt-f",                     1;
-    send_key "down",                      1;
-    send_key "alt-o",                     1;
-    send_key "alt-n",                     1;
+    send_key "alt-d";
+    send_key "alt-f";
+    send_key "down";
+    send_key "alt-o";
+    send_key "alt-n";
 
     # timezone default (NY)
-    send_key "alt-n", 1;
+    send_key "alt-n";
     save_screenshot;
 
     # user
     type_string $username, 2;
-    #    send_key "alt-u", 1;
+    #    send_key "alt-u";
     #    type_string "linux", 2;
-    send_key "alt-p", 1;
+    send_key "alt-p";
     type_string $password;
-    send_key "alt-o", 1;
+    send_key "alt-o";
     type_string $password;
-    send_key "alt-s", 2;
-    send_key "alt-a", 2;
-    send_key "alt-n", 2;
-    send_key "alt-y", 2;
+    send_key "alt-s";
+    send_key "alt-a";
+    send_key "alt-n";
+    send_key "alt-y";
 
     # install setting go to software selection
     assert_screen "SLE12_software_selection", 20;
-    send_key "tab",                           3;
-    send_key "tab",                           3;
-    send_key "ret",                           3;
+    send_key "tab";
+    send_key "tab";
+    send_key "ret";
 
     # remove doc and apparmor, add kvm
     assert_screen "SLE12_pre_selection", 20;
-    send_key "tab",                      3;
+    send_key "tab";
     # remove doc
-    send_key "down", 3;
-    send_key "spc",  2;
+    send_key "down";
+    send_key "spc";
     # remove apparmor
-    for (1 .. 3) { send_key "down", 3; }
-    send_key "spc", 2;
+    for (1 .. 3) { send_key "down"; }
+    send_key "spc";
     # select KVM
-    for (1 .. 3) { send_key "down", 3; }
-    send_key "spc", 2;
+    for (1 .. 3) { send_key "down"; }
+    send_key "spc";
     if (get_var("DESKTOP") =~ /icewm/) {
         # remove Gnome desktop
-        for (1 .. 3) { send_key "down", 3; }
-        send_key "spc", 2;
+        for (1 .. 3) { send_key "down"; }
+        send_key "spc";
     }
     save_screenshot;
-    send_key "alt-o", 1;
+    send_key "alt-o";
 
     # Launch the intallation
-    assert_screen "SLE12_goforinstall",        20;
-    send_key "alt-i",                          1;
-    send_key "alt-i",                          1;
+    assert_screen "SLE12_goforinstall", 20;
+    send_key "alt-i";
+    send_key "alt-i";
     assert_screen "SLE12_install_in_progress", 10;
     # reboot !
 }

--- a/tests/virtualization/prepare_sle12.pm
+++ b/tests/virtualization/prepare_sle12.pm
@@ -28,9 +28,9 @@ sub run {
         send_key "ret";
         assert_screen "SLE12_login", 520;
         type_string "linux";
-        send_key "ret", 1;
+        wait_screen_change { send_key "ret" };
         type_string $password;
-        send_key "ret", 1;
+        send_key "ret";
         save_screenshot;
         # install and launch polkit
         x11_start_program("xterm");

--- a/tests/virtualization/prepare_sle12.pm
+++ b/tests/virtualization/prepare_sle12.pm
@@ -22,6 +22,7 @@ use testapi;
 use virtmanager;
 
 sub run {
+    my ($self) = @_;
     # login and preparation of the system
     if (get_var("DESKTOP") =~ /icewm/) {
         send_key "ret";
@@ -46,11 +47,9 @@ sub run {
         assert_screen "virt-manager_SLE12_desktop", 520;
     }
     x11_start_program("xterm");
-    wait_idle;
     become_root;
     script_run("hostname susetest");
     script_run("echo susetest > /etc/hostname");
-    wait_idle;
 
     send_key "alt-f4";
 }

--- a/tests/virtualization/virt_install.pm
+++ b/tests/virtualization/virt_install.pm
@@ -17,11 +17,9 @@ use testapi;
 sub run {
     ensure_installed("virt-install");
     x11_start_program("xterm");
-    wait_idle;
     become_root;
     script_run("virt-install --name TESTING --memory 512 --disk none --boot cdrom --graphics vnc &");
     x11_start_program("vncviewer :0");
-    wait_idle;
     assert_screen "virtman-sle12sp1-gnome_virt-install", 100;
     for (0 .. 2) {
         send_key "alt-f4";

--- a/tests/virtualization/virt_top.pm
+++ b/tests/virtualization/virt_top.pm
@@ -18,10 +18,8 @@ use testapi;
 sub run {
     ensure_installed("virt-top");
     x11_start_program("xterm");
-    wait_idle;
     become_root;
     script_run "/usr/bin/virt-top";
-    wait_idle;
     assert_screen "virtman-sle12sp1-gnome_virt-top";
     send_key "alt-f4";
 }

--- a/tests/virtualization/virtman_networkinterface.pm
+++ b/tests/virtualization/virtman_networkinterface.pm
@@ -34,18 +34,16 @@ sub go_for_netif {
 sub checking_netif_result {
     my $volumes = shift;
     x11_start_program("xterm");
-    wait_idle;
     send_key "alt-f10";
     become_root();
     type_string "ip link show";
     send_key "ret";
-    wait_idle;
     save_screenshot;
     if (get_var("DESKTOP") !~ /icewm/) {
-        assert_screen "virtman-sle12-gnome_netifcheck", 20;
+        assert_screen "virtman-sle12-gnome_netifcheck";
     }
     else {
-        assert_screen "virtman_netifcheck", 20;
+        assert_screen "virtman_netifcheck";
     }
 }
 

--- a/tests/virtualization/virtman_storage.pm
+++ b/tests/virtualization/virtman_storage.pm
@@ -61,7 +61,6 @@ sub go_for_volume {
         # all other previous declaration are OK
         $newvolume->{name}   = "VOL" . $poolnb . "_" . $format;
         $newvolume->{format} = $format;
-        wait_idle;
         create_new_volume($newvolume);
     }
 }
@@ -69,7 +68,6 @@ sub go_for_volume {
 sub create_nfs_share {
     my ($dir) = @_;
     x11_start_program("xterm");
-    wait_idle;
     become_root();
     type_string "mkdir -p $dir";
     send_key "ret";
@@ -78,7 +76,6 @@ sub create_nfs_share {
     type_string "systemctl restart nfsserver.service";
     send_key "ret";
     type_string "exportfs\n";
-    wait_idle;
     type_string "exit";
     send_key "ret";
 }
@@ -86,15 +83,13 @@ sub create_nfs_share {
 sub checking_storage_result {
     my $volumes = shift;
     x11_start_program("xterm");
-    wait_idle;
     send_key "alt-f10";
     become_root();
     type_string "virsh -c qemu:///system pool-list";
     send_key "ret";
     foreach my $vol (@$volumes) {
         type_string "virsh -c qemu:///system vol-list $vol";
-        send_key "ret";
-        wait_idle;
+        wait_screen_change { send_key 'ret' };
     }
     save_screenshot;
     if (get_var("DESKTOP") !~ /icewm/) {

--- a/tests/virtualization/virtman_storage.pm
+++ b/tests/virtualization/virtman_storage.pm
@@ -52,9 +52,9 @@ sub go_for_volume {
     launch_virtmanager();
     connection_details("storage");
     # got to pool
-    send_key "tab", 1;
+    wait_screen_change { send_key "tab" };
     for (0 .. $poolnb) {
-        send_key "down", 1;
+        wait_screen_change { send_key "down" };
     }
     # do all other format available
     foreach my $format (@formats) {

--- a/tests/virtualization/virtman_view.pm
+++ b/tests/virtualization/virtman_view.pm
@@ -27,7 +27,7 @@ sub run {
     # go to preferences
     send_key "alt-e";
     wait_still_screen;
-    send_key "p", 1;
+    wait_screen_change { send_key "p" };
     # go to polling
     send_key "right";
     for (1 .. 3) { send_key "tab"; }
@@ -50,8 +50,8 @@ sub run {
     sleep 1;
 
     # go to view now
-    send_key "alt-v", 1;
-    send_key "right", 1;
+    wait_screen_change { send_key "alt-v" };
+    wait_screen_change { send_key "right" };
     # activate everything
     for (1 .. 4) {
         send_key "down";

--- a/tests/virtualization/virtman_virtualnet.pm
+++ b/tests/virtualization/virtman_virtualnet.pm
@@ -30,7 +30,7 @@ sub checking_vnet_result {
     send_key "ret";
     foreach my $vnet (@$net) {
         type_string "virsh -c qemu:///system net-info $vnet";
-        send_key "ret", 1;
+        send_key "ret";
     }
     if (get_var("DESKTOP") !~ /icewm/) {
         assert_screen "virtman-sle12-sp1-gnome_vnetcheck";

--- a/tests/virtualization/virtman_virtualnet.pm
+++ b/tests/virtualization/virtman_virtualnet.pm
@@ -24,7 +24,6 @@ use virtmanager;
 sub checking_vnet_result {
     my $net = shift;
     x11_start_program("xterm");
-    wait_idle;
     send_key "alt-f10";
     become_root();
     type_string "virsh -c qemu:///system net-list";
@@ -33,12 +32,11 @@ sub checking_vnet_result {
         type_string "virsh -c qemu:///system net-info $vnet";
         send_key "ret", 1;
     }
-    wait_idle;
     if (get_var("DESKTOP") !~ /icewm/) {
-        assert_screen "virtman-sle12-sp1-gnome_vnetcheck", 20;
+        assert_screen "virtman-sle12-sp1-gnome_vnetcheck";
     }
     else {
-        assert_screen "virtman_vnetcheck", 20;
+        assert_screen "virtman_vnetcheck";
     }
 }
 

--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -16,7 +16,6 @@ use testapi;
 
 sub run {
     x11_start_program("xterm");
-    wait_idle;
     send_key "alt-f10";
     become_root;
     script_run("yast2 virtualization; echo yast2-virtualization-done-\$? > /dev/$serialdev", 0);
@@ -57,12 +56,10 @@ sub run {
     send_key "alt-f4";
     # now need to start libvirtd
     x11_start_program("xterm");
-    send_key "alt-f10";
-    wait_idle;
+    wait_screen_change { send_key "alt-f10" };
     become_root;
     type_string "systemctl start libvirtd", 50;
-    send_key "ret";
-    wait_idle;
+    wait_screen_change { send_key "ret" };
     type_string "systemctl status libvirtd", 50;
     send_key "ret";
     save_screenshot;

--- a/tests/x11/banshee.pm
+++ b/tests/x11/banshee.pm
@@ -20,7 +20,6 @@ sub run {
     assert_screen 'test-banshee-1', 3;
     send_key "ctrl-q";    # really quit (alt-f4 just backgrounds)
     send_key "alt-f4";
-    wait_idle;
 }
 
 sub ocr_checklist {

--- a/tests/x11/desktop_mainmenu.pm
+++ b/tests/x11/desktop_mainmenu.pm
@@ -18,7 +18,6 @@ use testapi;
 
 
 sub run {
-    wait_idle;
     if (check_var("DESKTOP", "lxde")) {
         x11_start_program("lxpanelctl menu");    # or Super_L or Windows key
     }

--- a/tests/x11/oocalc.pm
+++ b/tests/x11/oocalc.pm
@@ -17,16 +17,13 @@ use testapi;
 
 sub run {
     x11_start_program("oocalc", 6, {valid => 1});
-    sleep 2;
     wait_still_screen;    # extra wait because oo sometimes appears to be idle during start
-    assert_screen 'test-oocalc-1', 3;
+    assert_screen 'test-oocalc-1';
     wait_screen_change { assert_and_click 'input-area-oocalc', 'left', 10 };
     type_string "Hello World!\n";
-    sleep 2;
-    assert_screen 'test-oocalc-2', 3;
+    assert_screen 'test-oocalc-2';
     send_key "alt-f4";
-    sleep 2;
-    assert_screen 'test-oocalc-3', 3;
+    assert_screen 'test-oocalc-3';
     assert_and_click 'dont-save-libreoffice-btn';    # _Don't save
 }
 

--- a/tests/x11/oocalc.pm
+++ b/tests/x11/oocalc.pm
@@ -20,8 +20,7 @@ sub run {
     sleep 2;
     wait_still_screen;    # extra wait because oo sometimes appears to be idle during start
     assert_screen 'test-oocalc-1', 3;
-    assert_and_click 'input-area-oocalc', 'left', 10;
-    wait_idle 10;
+    wait_screen_change { assert_and_click 'input-area-oocalc', 'left', 10 };
     type_string "Hello World!\n";
     sleep 2;
     assert_screen 'test-oocalc-2', 3;

--- a/tests/x11/ooffice.pm
+++ b/tests/x11/ooffice.pm
@@ -19,8 +19,7 @@ sub run {
     x11_start_program("oowriter");
     assert_screen 'test-ooffice-1';
     # clicking the writing area to make sure the cursor addressed there
-    assert_and_click 'ooffice-writing-area', 'left', 10;
-    wait_idle 10;
+    wait_screen_change { assert_and_click 'ooffice-writing-area', 'left', 10 };
     type_string "Hello World!";
     assert_screen 'test-ooffice-2';
     send_key "alt-f4";

--- a/tests/x11/reboot_icewm.pm
+++ b/tests/x11/reboot_icewm.pm
@@ -18,7 +18,6 @@ use utils;
 
 sub run {
     my ($self) = @_;
-    wait_idle;
     send_key "ctrl-alt-delete";    # reboot
     assert_screen 'logoutdialog', 15;
     assert_and_click 'logoutdialog-reboot-highlighted';

--- a/tests/x11/reboot_kde.pm
+++ b/tests/x11/reboot_kde.pm
@@ -18,7 +18,6 @@ use utils;
 
 sub run {
     my ($self) = @_;
-    wait_idle;
     send_key "ctrl-alt-delete";    # reboot
     assert_screen 'logoutdialog', 15;
     send_key "tab";

--- a/tests/x11/reboot_lxde.pm
+++ b/tests/x11/reboot_lxde.pm
@@ -18,8 +18,6 @@ use utils;
 
 sub run {
     my ($self) = @_;
-    wait_idle;
-
     #send_key "ctrl-alt-delete"; # does open task manager instead of reboot
     x11_start_program "lxsession-logout";
     assert_screen "logoutdialog", 20;

--- a/tests/x11/reboot_plasma5.pm
+++ b/tests/x11/reboot_plasma5.pm
@@ -18,7 +18,6 @@ use utils;
 
 sub run {
     my ($self) = @_;
-    wait_idle;
     send_key "ctrl-alt-delete";    # reboot
     assert_screen 'logoutdialog', 15;
     assert_and_click 'sddm_reboot_option_btn';

--- a/tests/x11/reboot_xfce.pm
+++ b/tests/x11/reboot_xfce.pm
@@ -18,7 +18,6 @@ use utils;
 
 sub run {
     my ($self) = @_;
-    wait_idle;
     send_key "alt-f4";    # open logout dialog
     assert_screen 'logoutdialog', 15;
     send_key "tab";       # reboot

--- a/tests/x11/rhythmbox.pm
+++ b/tests/x11/rhythmbox.pm
@@ -19,7 +19,6 @@ sub run {
     x11_start_program("rhythmbox");
     assert_screen 'test-rhythmbox-1';
     send_key "alt-f4";
-    wait_idle;
 }
 
 1;

--- a/tests/x11/thunar.pm
+++ b/tests/x11/thunar.pm
@@ -17,7 +17,6 @@ use testapi;
 
 sub run {
     x11_start_program("thunar");
-    sleep 10;
     send_key "shift-tab";
     send_key "home";
     send_key "down";

--- a/tests/x11/x11_login.pm
+++ b/tests/x11/x11_login.pm
@@ -19,7 +19,6 @@ sub run {
     type_string $username. "\n";
     sleep 1;
     type_string $password. "\n";
-    wait_idle;
 }
 
 1;

--- a/tests/x11/xfce4_appfinder.pm
+++ b/tests/x11/xfce4_appfinder.pm
@@ -1,33 +1,29 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Rework the tests layout.
-# G-Maintainer: Alberto Planas <aplanas@suse.com>
+# Summary: Test xfce4-appfinder, auto-completion and starting xfce4-about
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
-use base "x11test";
+use base 'x11test';
 use strict;
 use testapi;
 
-# test xfce4-appfinder, auto-completion and starting xfce4-about
 
-# this part contains the steps to run this test
 sub run {
     send_key "alt-f2";
-    sleep 2;
     send_key "down";
     type_string "about\n";
     assert_screen 'test-xfce4_appfinder-1';
     send_key "ret";
     assert_screen 'test-xfce4_appfinder-2';
     send_key "alt-f4";
-    sleep 2;
 }
 
 1;

--- a/tests/x11/xfce_lightdm_logout_login.pm
+++ b/tests/x11/xfce_lightdm_logout_login.pm
@@ -23,10 +23,8 @@ sub run {
     send_key "ret";
     assert_screen 'generic-desktop';
     mouse_set(100, 100);
-    sleep 1;
     for (1 .. 4) {
         mouse_hide;
-        sleep 3;
         check_screen('mouse-cursor', 1) || return;
     }
     die "mouse cursor still visible";

--- a/tests/x11regressions/empathy/empathy_aim.pm
+++ b/tests/x11regressions/empathy/empathy_aim.pm
@@ -87,14 +87,14 @@ sub run {
     assert_and_click 'empathy-disable-aim-account0';
     assert_and_click 'empathy-delete-aim-account0';
     assert_screen 'empathy-confirm-aim-deletion0';
-    send_key "alt-r", 1;
+    send_key "alt-r";
 
     assert_and_click 'empathy-disable-aim-account1';
     assert_and_click 'empathy-delete-aim-account1';
     assert_screen 'empathy-confirm-aim-deletion1';
-    send_key "alt-r", 1;
+    wait_screen_change { send_key "alt-r" };
 
-    send_key "alt-c", 1;
+    send_key "alt-c";
 
     # quit
     if (sle_version_at_least('12-SP2')) {

--- a/tests/x11regressions/evince/evince_find.pm
+++ b/tests/x11regressions/evince/evince_find.pm
@@ -36,7 +36,7 @@ sub run {
     }
     assert_screen 'evince-search-1stresult', 5;
 
-    send_key "esc", 1;
+    wait_screen_change { send_key "esc" };
     send_key "ctrl-w";
 }
 

--- a/tests/x11regressions/evolution/evolution_mail_ews.pm
+++ b/tests/x11regressions/evolution/evolution_mail_ews.pm
@@ -64,7 +64,6 @@ sub run {
 
     # Exit
     send_key "ctrl-q";
-    wait_idle;
 }
 
 1;

--- a/tests/x11regressions/evolution/evolution_smoke.pm
+++ b/tests/x11regressions/evolution/evolution_smoke.pm
@@ -54,7 +54,6 @@ sub run {
 
     # Exit
     send_key "ctrl-q";
-    wait_idle;
 }
 
 1;

--- a/tests/x11regressions/evolution/evolution_task_ews.pm
+++ b/tests/x11regressions/evolution/evolution_task_ews.pm
@@ -69,7 +69,6 @@ sub run {
 
     # Exit
     send_key "ctrl-q";
-    wait_idle;
 }
 
 1;

--- a/tests/x11regressions/firefox/firefox_developertool.pm
+++ b/tests/x11regressions/firefox/firefox_developertool.pm
@@ -21,26 +21,15 @@ sub run {
     $self->start_firefox;
 
     send_key "esc";
-    sleep 1;
     send_key "alt-d";
-    sleep 1;
     type_string "opensuse.org\n";
     assert_screen('firefox-developertool-opensuse', 90);
-
-    sleep 2;
     send_key "ctrl-shift-i";
     assert_screen('firefox-developertool-gerneral', 30);
-    sleep 2;
     assert_and_click "firefox-developertool-click_element";
-    sleep 1;
     assert_and_click "firefox-developertool-check_element";
-
-    sleep 2;
     assert_screen("firefox-developertool-element", 30);
-
-    sleep 1;
     assert_and_click "firefox-developertool-console_button";
-    sleep 1;
     send_key "f5";
     assert_screen("firefox-developertool-console_contents", 30);
 

--- a/tests/x11regressions/firefox/firefox_extensions.pm
+++ b/tests/x11regressions/firefox/firefox_extensions.pm
@@ -34,11 +34,9 @@ sub run {
     send_key "alt-1";
     assert_screen('firefox-extensions-show_flag', 60);
 
-    sleep 1;
     send_key "alt-3";
     assert_and_click('firefox-extensions-flagfox_installed');
 
-    sleep 2;
     send_key "alt-1";
     assert_screen('firefox-extensions-no_flag', 90);
 

--- a/tests/x11regressions/firefox/firefox_gnomeshell.pm
+++ b/tests/x11regressions/firefox/firefox_gnomeshell.pm
@@ -28,7 +28,6 @@ sub run {
     assert_screen('firefox-gnomeshell-default', 30);
 
     send_key "alt-d";
-    sleep 1;
     type_string "extensions.gnome.org\n";
     assert_screen('firefox-gnomeshell-frontpage', 120);
     send_key "alt-a";
@@ -47,19 +46,15 @@ sub run {
         assert_and_click('firefox-reader-close');
         assert_screen("firefox-gnomeshell-extension");
     }
-    sleep 5;
     assert_and_click "firefox-gnomeshell-extension_install";
     assert_and_click "firefox-gnomeshell-extension_confirm";
-    sleep 10;
     assert_screen("firefox-gnomeshell-extension_on", 60);
 
     # Exit
     $self->exit_firefox;
 
-    sleep 2;
     x11_start_program("xterm");
     type_string "ls .local/share/gnome-shell/extensions/\n";
-    sleep 2;
     assert_screen('firefox-gnomeshell-checkdir', 30);
     type_string "rm -rf .local/share/gnome-shell/extensions/*;exit\n";
 }

--- a/tests/x11regressions/firefox/firefox_headers.pm
+++ b/tests/x11regressions/firefox/firefox_headers.pm
@@ -24,8 +24,8 @@ sub run {
     assert_screen('firefox-launch', 90);
 
     send_key "esc";
-    send_key "ctrl-shift-q", 1;
-    send_key "alt-d",        1;
+    wait_screen_change { send_key "ctrl-shift-q" };
+    wait_screen_change { send_key "alt-d" };
     type_string "www.gnu.org\n";
     assert_screen('firefox-headers-website', 90);
 

--- a/tests/x11regressions/firefox/firefox_headers.pm
+++ b/tests/x11regressions/firefox/firefox_headers.pm
@@ -29,7 +29,6 @@ sub run {
     type_string "www.gnu.org\n";
     assert_screen('firefox-headers-website', 90);
 
-    sleep 10;
     send_key "down";
     assert_screen('firefox-headers-first_item', 50);
 

--- a/tests/x11regressions/firefox/firefox_java.pm
+++ b/tests/x11regressions/firefox/firefox_java.pm
@@ -16,9 +16,7 @@ use base "x11regressiontest";
 use testapi;
 
 sub java_testing {
-    sleep 1;
     send_key "ctrl-t";
-    sleep 2;
     send_key "alt-d";
     type_string "http://www.java.com/en/download/installed.jsp?detect=jre\n";
 
@@ -59,31 +57,25 @@ sub run {
     if (check_var('DISTRI', 'sle')) {
         assert_and_click('firefox-logo');
     }
-    sleep 1;
     send_key "ctrl-shift-a";
 
     assert_screen("firefox-java-addonsmanager");
     #Required only on opensuse's FF, on sle search is available from "Get Add-ons"
     if (check_var('DISTRI', 'opensuse')) {
         assert_and_click('firefox-java-extensions');
-        sleep 1;
     }
 
     send_key "/";
-    sleep 1;
     type_string "iced\n";
 
     #Focus to "Available Add-ons"
     assert_and_click "firefox-java-myaddons";
 
     #Focus to "Ask to Activate"
-    sleep 1;
     assert_and_click "firefox-java-asktoactivate";
 
     #Focus to "Never Activate"
-    sleep 1;
     send_key "up";
-    sleep 1;
     send_key "ret";
 
     assert_screen("firefox-java-neveractive");
@@ -94,7 +86,7 @@ sub run {
     send_key "ctrl-w";
 
     #Focus to "Always Activate"
-    for my $i (1 .. 2) { sleep 1; send_key "down"; }
+    for my $i (1 .. 2) { send_key "down"; }
     assert_screen("firefox-java-active", 60);
 
     java_testing();

--- a/tests/x11regressions/firefox/firefox_mhtml.pm
+++ b/tests/x11regressions/firefox/firefox_mhtml.pm
@@ -35,7 +35,7 @@ sub run {
     send_key "spc";
     assert_screen('firefox-mhtml-unmht_installed', 90);
 
-    send_key "ctrl-w", 1;
+    wait_screen_change { send_key "ctrl-w" };
 
     send_key "alt-d";
     type_string "file:///dev/shm/ie10.mht\n";

--- a/tests/x11regressions/firefox/firefox_pagesaving.pm
+++ b/tests/x11regressions/firefox/firefox_pagesaving.pm
@@ -20,18 +20,12 @@ sub run {
     $self->start_firefox;
 
     send_key "esc";
-    sleep 1;
     send_key "alt-d";
-    sleep 1;
     type_string "http://www.mozilla.org/en-US\n";
-
     assert_screen('firefox-pagesaving-load', 90);
-
     send_key "ctrl-s";
     assert_screen 'firefox-pagesaving-saveas';
-
     send_key "alt-s";
-    sleep 5;
 
     # Exit
     $self->exit_firefox;

--- a/tests/x11regressions/firefox/firefox_passwd.pm
+++ b/tests/x11regressions/firefox/firefox_passwd.pm
@@ -26,13 +26,11 @@ sub run {
     # Clean and Start Firefox
     $self->start_firefox;
 
-    sleep 2;
     send_key "alt-e";
     wait_still_screen 3;
     send_key "n";
     assert_and_click('firefox-passwd-security');
 
-    sleep 1;
     send_key "alt-shift-u";
 
     assert_screen('firefox-passwd-master_setting', 30);
@@ -40,18 +38,15 @@ sub run {
     type_string $masterpw;
     send_key "tab";
     type_string $masterpw;
-    for my $i (1 .. 3) { sleep 1; send_key "ret"; }
+    for my $i (1 .. 3) { send_key "ret"; }
 
     #Restart firefox
-    sleep 1;
     send_key "ctrl-q";
-    sleep 3;
     x11_start_program("firefox");
     assert_screen('firefox-gnome', 60);
 
     send_key "esc";
     send_key "alt-d";
-    sleep 1;
     type_string $mozlogin. "\n";
 
     assert_and_click('firefox-passwd-input_username');
@@ -59,40 +54,29 @@ sub run {
     send_key "tab";
     type_string "calamari";
     send_key "ret";
-    sleep 2;
     assert_and_click('firefox-passwd-confirm_remember');
     assert_screen('firefox-passwd-confirm_master_pw', 30);
     type_string $masterpw. "\n";
 
-    sleep 1;
     send_key "esc";
     send_key "alt-d";
     type_string $mozlogin. "\n";
     assert_screen('firefox-passwd-auto_filled', 90);
 
-    sleep 1;
     send_key "alt-e";
     send_key "n";    #Preferences
-    sleep 1;
     assert_and_click('firefox-passwd-security');
     send_key "alt-shift-p";    #"Saved Passwords..."
-    sleep 1;
     send_key "alt-shift-p";    #"Show Passwords"
-    sleep 1;
     type_string $masterpw. "\n";
-    sleep 1;
     send_key "alt-shift-l";
     assert_screen('firefox-passwd-saved', 30);
 
-    sleep 1;
     send_key "alt-shift-a";    #"Remove"
     wait_still_screen 3;
     send_key "alt-y";
-    sleep 1;
     send_key "alt-shift-c";
-    sleep 1;
     send_key "ctrl-w";
-    sleep 1;
     send_key "f5";
     assert_screen('firefox-passwd-removed', 60);
 

--- a/tests/x11regressions/firefox/firefox_private.pm
+++ b/tests/x11regressions/firefox/firefox_private.pm
@@ -20,8 +20,6 @@ sub run {
     $self->start_firefox;
 
     send_key "ctrl-shift-p";
-    sleep 5;
-
     send_key "alt-d";
     type_string "gnu.org\n";
     assert_screen('firefox-private-gnu', 90);
@@ -33,15 +31,12 @@ sub run {
     wait_still_screen 3;
     $self->exit_firefox;
 
-    sleep 2;
     x11_start_program("firefox");
     assert_screen('firefox-launch', 90);
 
     send_key "ctrl-h";
     assert_and_click('firefox-private-checktoday');
     assert_screen('firefox-private-checkhistory', 60);
-
-    sleep 1;
     send_key "alt-f4";
 
     # Exit

--- a/tests/x11regressions/firefox/firefox_rss.pm
+++ b/tests/x11regressions/firefox/firefox_rss.pm
@@ -19,7 +19,7 @@ sub run {
     my ($self) = @_;
     $self->start_firefox;
 
-    send_key "alt-v", 1;
+    send_key "alt-v";
     wait_still_screen 3;
     send_key "t";
     wait_still_screen 3;

--- a/tests/x11regressions/firefox/firefox_ssl.pm
+++ b/tests/x11regressions/firefox/firefox_ssl.pm
@@ -37,7 +37,7 @@ sub run {
     assert_screen('firefox-ssl-loadpage', 60);
 
     send_key "alt-e";
-    send_key "n", 1;
+    send_key "n";
 
     assert_and_click('firefox-ssl-preference_advanced');
     assert_and_click('firefox-ssl-advanced_certificate');
@@ -66,7 +66,7 @@ sub run {
     sleep 1;
     assert_screen('firefox-ssl-servers_cert', 30);
 
-    send_key "alt-f4", 1;
+    wait_screen_change { send_key "alt-f4" };
     send_key "ctrl-w";
 
     send_key "alt-d";

--- a/tests/x11regressions/gnomecase/change_password.pm
+++ b/tests/x11regressions/gnomecase/change_password.pm
@@ -44,7 +44,6 @@ sub logout_and_login {
 
 sub reboot_system {
     my ($self) = @_;
-    wait_idle;
     send_key "ctrl-alt-delete";    #reboot
     assert_screen 'logoutdialog', 15;
     assert_and_click 'logoutdialog-reboot-highlighted';

--- a/tests/x11regressions/gnomecase/gnome_default_applications.pm
+++ b/tests/x11regressions/gnomecase/gnome_default_applications.pm
@@ -35,7 +35,6 @@ sub run {
     send_key "ctrl-l";
     type_string "/home/$username/gnometest\n";
     send_key "ret";
-    sleep 5;
     assert_screen 'gnomecase-defaultapps-nautilus';
 
     # Open test files with default applications

--- a/tests/x11regressions/gnomecase/nautilus_cut_file.pm
+++ b/tests/x11regressions/gnomecase/nautilus_cut_file.pm
@@ -21,14 +21,11 @@ sub run {
     x11_start_program("touch newfile");
 
     send_key_until_needlematch 'nautilus-newfile-matched', 'right', 15;
-    sleep 2;
     send_key "ctrl-x";
     send_key_until_needlematch 'nautilus-Downloads-matched', 'left', 5;
     send_key "ret";
-    sleep 2;
     send_key "ctrl-v";    #paste to dir ~/Downloads
     assert_screen "nautilus-newfile-moved";
-    sleep 2;
     send_key "alt-up";                      #back to home dir from ~/Downloads
     assert_screen 'nautilus-no-newfile';    #assure newfile moved
     send_key "ctrl-w";                      #close nautilus

--- a/tests/x11regressions/gnomecase/nautilus_permission.pm
+++ b/tests/x11regressions/gnomecase/nautilus_permission.pm
@@ -25,32 +25,24 @@ sub run {
     send_key "r";    #choose properties
     assert_screen 'nautilus-properties';
     send_key "up";       #move focus onto tab
-    sleep 2;
     send_key "right";    #move to tab Permissions
     for (1 .. 4) { send_key "tab" }
     send_key "ret";
     assert_screen 'nautilus-access-permission';
     send_key "down";
-    sleep 1;
     send_key "ret";
-    sleep 1;
     send_key "tab";
-    sleep 1;
     send_key "ret";
     assert_screen 'nautilus-access-permission';
     send_key "down";
-    sleep 1;
     send_key "ret";
-    sleep 1;
-    send_key "esc";    #close the dialog
-    sleep 1;
-    #reopen the properties menu to check if the changes kept
+    send_key "esc";      #close the dialog
+                         #reopen the properties menu to check if the changes kept
     send_key "shift-f10";
     assert_screen 'nautilus-rightkey-menu';
-    send_key "r";      #choose properties
+    send_key "r";        #choose properties
     assert_screen 'nautilus-properties';
     send_key "up";       #move focus onto tab
-    sleep 2;
     send_key "right";    #move to tab Permissions
     assert_screen 'nautilus-permissions-changed';
     send_key "esc";      #close the dialog

--- a/tests/x11regressions/gnote/gnote_rename_title.pm
+++ b/tests/x11regressions/gnote/gnote_rename_title.pm
@@ -26,16 +26,11 @@ sub run {
     send_key "up";
     type_string "new title-opensuse\n";
     send_key "ctrl-tab";    #jump to toolbar
-    sleep 2;
     send_key "ret";         #back to all notes interface
-    sleep 5;                #it needs seconds to refresh title
     send_key_until_needlematch 'gnote-new-note-title-matched', 'down', 6;
     send_key "delete";
-    sleep 2;
     send_key "tab";
-    sleep 2;
     send_key "ret";
-    sleep 2;
     send_key "ctrl-w";
 }
 

--- a/tests/x11regressions/gnote/gnote_search_all.pm
+++ b/tests/x11regressions/gnote/gnote_search_all.pm
@@ -21,7 +21,6 @@ sub run {
     x11_start_program("gnote");
     assert_screen "gnote-first-launched", 10;
     send_key "ctrl-f";
-    sleep 2;
     type_string "welcome";
     assert_screen 'gnote-search-welcome', 5;
 

--- a/tests/x11regressions/gnote/gnote_search_body.pm
+++ b/tests/x11regressions/gnote/gnote_search_body.pm
@@ -22,9 +22,7 @@ sub run {
     assert_screen "gnote-first-launched", 5;
     send_key_until_needlematch 'gnote-start-here-matched', 'down', 5;
     send_key "ret";
-    sleep 2;
     send_key "ctrl-f";
-    sleep 2;
     type_string "and";
     assert_screen 'gnote-search-body-and', 5;
 

--- a/tests/x11regressions/gnote/gnote_search_title.pm
+++ b/tests/x11regressions/gnote/gnote_search_title.pm
@@ -21,9 +21,7 @@ sub run {
     assert_screen "gnote-first-launched", 5;
     send_key_until_needlematch 'gnote-start-here-matched', 'down', 5;
     send_key "ret";
-    sleep 2;
     send_key "ctrl-f";
-    sleep 2;
     type_string "here";
     assert_screen 'gnote-search-title-here', 5;
 

--- a/tests/x11regressions/gnote/gnote_undo_redo.pm
+++ b/tests/x11regressions/gnote/gnote_undo_redo.pm
@@ -22,7 +22,6 @@ sub undo_redo_once {
     send_key "ctrl-z";    #undo
     assert_screen 'gnote-new-note', 5;
     send_key "ctrl-shift-z";    #redo
-    sleep 2;
     send_key "left";            #unselect text
     assert_screen 'gnote-new-note-1', 5;
 }
@@ -38,7 +37,6 @@ sub run {
 
     #assure undo and redo take effect after save note and re-enter note
     send_key "ctrl-tab";    #jump to toolbar
-    sleep 2;
     send_key "ret";         #back to all notes interface
     send_key_until_needlematch 'gnote-new-note-matched', 'down', 6;
     send_key "ret";
@@ -46,13 +44,10 @@ sub run {
 
     #clean: remove the created new note
     send_key "ctrl-tab";    #jump to toolbar
-    sleep 2;
     send_key "ret";         #back to all notes interface
     send_key_until_needlematch 'gnote-new-note-matched', 'down', 6;
     send_key "delete";
-    sleep 2;
     send_key "tab";
-    sleep 2;
     send_key "ret";
     assert_screen "gnote-first-launched", 5;
     send_key "ctrl-w";

--- a/tests/x11regressions/pidgin/clean_pidgin.pm
+++ b/tests/x11regressions/pidgin/clean_pidgin.pm
@@ -14,26 +14,18 @@
 use base "x11regressiontest";
 use strict;
 use testapi;
+use utils 'clear_console';
 
 sub remove_pkg {
     my @packages = qw(pidgin);
     x11_start_program("xterm");
 
     # Remove packages
-    type_string "xdg-su -c 'rpm -e @packages'\n";
-    sleep 3;
-    if ($password) {
-        type_password;
-        send_key "ret";
-    }
-    sleep 30;    # give time to uninstall
-    type_string "clear\n";
-    sleep 2;
+    assert_script_sudo "rpm -e @packages";
+    clear_console;
     type_string "rpm -qa @packages\n";
     assert_screen "pidgin-pkg-removed";    #make sure pkgs removed.
-
     type_string "exit\n";
-    sleep 2;
 }
 
 sub run {

--- a/tests/x11regressions/pidgin/pidgin_IRC.pm
+++ b/tests/x11regressions/pidgin/pidgin_IRC.pm
@@ -23,32 +23,25 @@ sub run {
     x11_start_program("pidgin");
 
     # Create account
-    send_key "alt-a";
-    sleep 2;
-    send_key "spc";
-    sleep 2;
+    wait_screen_change { send_key "alt-a" };
+    wait_screen_change { send_key "spc" };
 
     # Choose Protocol "IRC"
     send_key_until_needlematch 'pidgin-protocol-irc', 'down';
-    send_key "ret";
-    sleep 2;
-    send_key "alt-u";
-    sleep 1;
-    type_string "$CHANNELNAME";
-    sleep 2;
-    send_key "alt-a";
+    wait_screen_change { send_key "ret" };
+    wait_screen_change { send_key "alt-u" };
+    wait_screen_change { type_string "$CHANNELNAME" };
+    wait_screen_change { send_key "alt-a" };
 
     # Should create IRC account
     assert_screen 'pidgin-irc-account';
 
     # Close account manager
-    send_key "ctrl-a";
-    sleep 2;
-    send_key "alt-c";
-    sleep 15;    # need time to connect server
+    wait_screen_change { send_key "ctrl-a" };
+    wait_screen_change { send_key "alt-c" };
 
     # Warning of spoofing ip may appear
-    if (check_screen("pidgin-spoofing-ip", 10)) {
+    if (check_screen("pidgin-spoofing-ip")) {
         wait_screen_change {
             send_key "alt-tab";
         };
@@ -58,11 +51,8 @@ sub run {
     }
 
     # Join a chat
-    send_key "ctrl-c";
-    sleep 2;
-
-    type_string "#sledtesting";
-    sleep 2;
+    wait_screen_change { send_key "ctrl-c" };
+    wait_screen_change { type_string "#sledtesting" };
     send_key "alt-j";
 
     # Should open sledtesting channel
@@ -72,8 +62,7 @@ sub run {
     send_key "alt-tab";
     type_string "Hello from openQA\n";
     assert_screen 'pidgin-irc-msgsent';
-    send_key "ctrl-w";
-    sleep 2;
+    wait_screen_change { send_key "ctrl-w" };
 
     # Cleaning
     $self->pidgin_remove_account;
@@ -82,10 +71,8 @@ sub run {
     assert_screen 'pidgin-welcome';
 
     # Exit
-    send_key "alt-c";
-    sleep 2;
+    wait_screen_change { send_key "alt-c" };
     send_key "ctrl-q";
-    sleep 2;
 }
 
 1;

--- a/tests/x11regressions/pidgin/pidgin_aim.pm
+++ b/tests/x11regressions/pidgin/pidgin_aim.pm
@@ -26,74 +26,50 @@ sub run {
     x11_start_program("pidgin");
 
     # Create account
-    send_key "alt-a";
-    sleep 2;
-    send_key "spc";
-    sleep 2;
-
+    wait_screen_change { send_key 'alt-a' };
+    wait_screen_change { send_key 'spc' };
     send_key_until_needlematch 'pidgin-protocol-aim', 'down';
-    send_key "ret";
-    sleep 2;
-    send_key "alt-u";
-    sleep 1;
-
+    wait_screen_change { send_key 'ret' };
+    wait_screen_change { send_key 'alt-u' };
     type_string $USERNAME. "@" . $DOMAIN . ".com";
-    sleep 2;
-    send_key "alt-p";
-    sleep 1;
+    wait_still_screen(1);
+    wait_screen_change { send_key 'alt-p' };
     type_string $PASSWD;
-    sleep 2;
-    send_key "alt-a";
+    wait_screen_change { send_key "alt-a" };
 
     # Should create AIM account 1
     assert_screen 'pidgin-aim-account1';
 
     # Create another account
-    send_key "ctrl-a";
-    sleep 2;
-    send_key "alt-a";
-    sleep 2;
-    send_key "alt-u";
-    sleep 1;
-    type_string $USERNAME1. "@" . $DOMAIN . ".com";
-    sleep 2;
-    send_key "alt-p";
-    sleep 1;
-    type_string "$PASSWD";
-    sleep 2;
-    send_key "alt-a";
-    sleep 15;    # wait until account2 online
-
+    wait_screen_change { send_key 'ctrl-a' };
+    wait_screen_change { send_key 'alt-a' };
+    wait_screen_change { send_key 'alt-u' };
+    wait_screen_change { type_string $USERNAME1. "@" . $DOMAIN . ".com" };
+    wait_screen_change { send_key "alt-p" };
+    wait_screen_change { type_string "$PASSWD" };
+    wait_screen_change { send_key "alt-a" };
     # Should have AIM accounts 1 and 2
     assert_screen 'pidgin-aim-account2';
 
     # Close account manager
-    send_key "ctrl-a";
-    sleep 2;
-    send_key "alt-c";
-    sleep 2;
+    wait_screen_change { send_key "ctrl-a" };
+    wait_screen_change { send_key "alt-c" };
 
     # Open a chat
-    send_key "tab";
-    sleep 2;
+    wait_screen_change { send_key "tab" };
     send_key_until_needlematch 'pidgin-aim-online-buddy', 'down';
-    sleep 2;
-    send_key "ret";
-    sleep 2;
+    wait_screen_change { send_key "ret" };
     type_string "hello world!\n";
 
     # Should see "hello world!" in screen.
     assert_screen 'pidgin-aim-sentmsg';
     send_key "ctrl-tab";
     assert_screen 'pidgin-aim-receivedmsg';
-    sleep 2;
 
     # Cleaning
     # Close the conversation
+    wait_screen_change { send_key "ctrl-w" };
     send_key "ctrl-w";
-    sleep 2;
-    send_key "ctrl-w";
-    sleep 2;
 
     # Remove both accounts
     for (1 .. 2) {
@@ -104,10 +80,8 @@ sub run {
     assert_screen 'pidgin-welcome';
 
     # Exit
-    send_key "alt-c";
-    sleep 2;
+    wait_screen_change { send_key "alt-c" };
     send_key "ctrl-q";
-    sleep 2;
 }
 
 1;

--- a/tests/x11regressions/shotwell/shotwell_edit.pm
+++ b/tests/x11regressions/shotwell/shotwell_edit.pm
@@ -40,7 +40,6 @@ sub run {
     send_key "shift-delete";    # Remove picture from library
     assert_screen 'shotwell-remove-prompt';
     send_key "alt-r";
-    sleep 2;
     send_key "esc";
     wait_still_screen;
     assert_screen 'shotwell-removed-picture';

--- a/tests/x11regressions/shotwell/shotwell_export.pm
+++ b/tests/x11regressions/shotwell/shotwell_export.pm
@@ -42,7 +42,7 @@ sub run {
 
     # Check the exported file
     x11_start_program("nautilus");
-    send_key "ctrl-l", 1;
+    wait_screen_change { send_key 'ctrl-l' };
     type_string "/home/$username/Desktop\n";
     send_key "ret";
     assert_screen 'shotwell-exported-file';

--- a/tests/x11regressions/tomboy/tomboy_AlreadyRunning.pm
+++ b/tests/x11regressions/tomboy/tomboy_AlreadyRunning.pm
@@ -21,16 +21,12 @@ sub run {
     # open tomboy
     x11_start_program("tomboy note");
     assert_screen 'test-tomboy_AlreadyRunning-1';
-    sleep 2;
     send_key "alt-f4";
-    sleep 2;
 
     # open again
     x11_start_program("tomboy note");
     assert_screen 'test-tomboy_AlreadyRunning-2';
-    sleep 2;
     send_key "alt-f4";
-    sleep 2;
 }
 
 1;

--- a/tests/x11regressions/tomboy/tomboy_AlreadyRunning.pm
+++ b/tests/x11regressions/tomboy/tomboy_AlreadyRunning.pm
@@ -20,16 +20,14 @@ use testapi;
 sub run {
     # open tomboy
     x11_start_program("tomboy note");
-    wait_idle;
-    assert_screen 'test-tomboy_AlreadyRunning-1', 3;
+    assert_screen 'test-tomboy_AlreadyRunning-1';
     sleep 2;
     send_key "alt-f4";
     sleep 2;
 
     # open again
     x11_start_program("tomboy note");
-    wait_idle;
-    assert_screen 'test-tomboy_AlreadyRunning-2', 3;
+    assert_screen 'test-tomboy_AlreadyRunning-2';
     sleep 2;
     send_key "alt-f4";
     sleep 2;

--- a/tests/x11regressions/tomboy/tomboy_Hotkeys.pm
+++ b/tests/x11regressions/tomboy/tomboy_Hotkeys.pm
@@ -23,9 +23,7 @@ sub run {
     x11_start_program("tomboy note");
     wait_screen_change { send_key 'alt-e' };
     send_key "p";
-    sleep 1;
     send_key "right";
-    sleep 1;
 
     # set Hotkeys
     for (1 .. 4) {
@@ -33,7 +31,6 @@ sub run {
     }
     type_string "<Alt>F10\t<Alt>F9";
     assert_screen 'test-tomboy_Hotkeys-1', 3;
-    sleep 2;
     wait_screen_change { send_key 'esc' };
 
     $self->tomboy_logout_and_login;
@@ -41,59 +38,35 @@ sub run {
     # test hotkeys
     send_key "alt-f12";
     assert_screen 'test-tomboy_Hotkeys-2';
-    sleep 1;
     send_key "esc";
-    sleep 2;
 
     send_key "alt-f11";
-    sleep 1;
     send_key "up";
-    sleep 1;
     assert_screen 'test-tomboy_Hotkeys-3';
-    sleep 1;
     send_key "ctrl-w";
-    sleep 2;
 
     send_key "alt-f10";
     assert_screen 'test-tomboy_Hotkeys-4';
-    sleep 1;
     send_key "alt-t";
-    sleep 3;
     send_key "esc";
-    sleep 1;
     send_key "right";
-    sleep 1;
     send_key "right";
-    sleep 1;
     send_key "right";
-    sleep 1;
     send_key "ret";
-    sleep 3;
     send_key "alt-d";
-    sleep 2;
 
     send_key "alt-f9";
-    sleep 2;
     type_string "sssss\n";
-    sleep 1;
     assert_screen 'test-tomboy_Hotkeys-5', 3;
-    sleep 1;
     send_key "ctrl-a";
-    sleep 1;
     send_key "delete";
-    sleep 1;
 
     # to check all hotkeys
     send_key "alt-e";
-    sleep 1;
     send_key "p";
-    sleep 1;
     send_key "right";
-    sleep 1;
     assert_screen 'test-tomboy_Hotkeys-6', 3;
-    sleep 1;
     send_key "esc";
-    sleep 2;
     send_key "alt-f4";
 }
 

--- a/tests/x11regressions/tomboy/tomboy_Hotkeys.pm
+++ b/tests/x11regressions/tomboy/tomboy_Hotkeys.pm
@@ -40,9 +40,7 @@ sub run {
 
     # test hotkeys
     send_key "alt-f12";
-    sleep 1;
-    wait_idle;
-    assert_screen 'test-tomboy_Hotkeys-2', 3;
+    assert_screen 'test-tomboy_Hotkeys-2';
     sleep 1;
     send_key "esc";
     sleep 2;
@@ -51,16 +49,13 @@ sub run {
     sleep 1;
     send_key "up";
     sleep 1;
-    wait_idle;
-    assert_screen 'test-tomboy_Hotkeys-3', 3;
+    assert_screen 'test-tomboy_Hotkeys-3';
     sleep 1;
     send_key "ctrl-w";
     sleep 2;
 
     send_key "alt-f10";
-    sleep 10;
-    wait_idle;
-    assert_screen 'test-tomboy_Hotkeys-4', 3;
+    assert_screen 'test-tomboy_Hotkeys-4';
     sleep 1;
     send_key "alt-t";
     sleep 3;

--- a/tests/x11regressions/tomboy/tomboy_Open.pm
+++ b/tests/x11regressions/tomboy/tomboy_Open.pm
@@ -22,34 +22,24 @@ sub run {
     # open start note and take screenshot
     x11_start_program("tomboy note");
     send_key "alt-f11";
-    sleep 2;
     send_key "ctrl-home";
-    sleep 2;
     type_string "Rename_";
-    sleep 1;
     wait_screen_change { send_key 'ctrl-w' };
 
     # Check hotkey for open "start here" still works
     send_key "alt-fll";
-    sleep 2;
     wait_still_screen;
     check_screen "tomboy_open_0", 5;
 
     send_key "shift-up";
-    sleep 2;
     send_key "delete";
-    sleep 2;
     send_key "ctrl-w";
-    sleep 2;
     $self->tomboy_logout_and_login;
 
     send_key "alt-f11";
-    sleep 2;
     send_key "up";
-    sleep 1;
     check_screen "tomboy_open_1", 5;
     send_key "ctrl-w";
-    sleep 2;
     send_key "alt-f4";
 }
 

--- a/tests/x11regressions/tomboy/tomboy_Open.pm
+++ b/tests/x11regressions/tomboy/tomboy_Open.pm
@@ -27,8 +27,7 @@ sub run {
     sleep 2;
     type_string "Rename_";
     sleep 1;
-    send_key "ctrl-w";
-    wait_idle;
+    wait_screen_change { send_key 'ctrl-w' };
 
     # Check hotkey for open "start here" still works
     send_key "alt-fll";

--- a/tests/x11regressions/tomboy/tomboy_Print.pm
+++ b/tests/x11regressions/tomboy/tomboy_Print.pm
@@ -23,28 +23,15 @@ sub run {
 
     # open a note and print to file
     send_key "tab";
-    sleep 1;
     send_key "down";
-    sleep 1;
     send_key "ret";
-    sleep 3;
     send_key "ctrl-p";
-    sleep 3;
     send_key "tab";
-    sleep 1;
     send_key "alt-v";
-    sleep 5;    #FIXME Print to file failed in this version, so just replace with preview.
-                #send_key "alt-p"; sleep 2; #FIXME
-                #send_key "alt-r"; sleep 5; #FIXME
-
     assert_screen 'test-tomboy_Print-1';
-    sleep 2;
     send_key "ctrl-w";
-    sleep 2;
     send_key "ctrl-w";
-    sleep 2;
     send_key "alt-f4";
-    sleep 2;
 }
 
 1;

--- a/tests/x11regressions/tomboy/tomboy_Print.pm
+++ b/tests/x11regressions/tomboy/tomboy_Print.pm
@@ -37,8 +37,7 @@ sub run {
                 #send_key "alt-p"; sleep 2; #FIXME
                 #send_key "alt-r"; sleep 5; #FIXME
 
-    wait_idle;
-    assert_screen 'test-tomboy_Print-1', 3;
+    assert_screen 'test-tomboy_Print-1';
     sleep 2;
     send_key "ctrl-w";
     sleep 2;
@@ -46,7 +45,6 @@ sub run {
     sleep 2;
     send_key "alt-f4";
     sleep 2;
-    wait_idle;
 }
 
 1;

--- a/tests/x11regressions/tomboy/tomboy_StartNoteCannotBeDeleted.pm
+++ b/tests/x11regressions/tomboy/tomboy_StartNoteCannotBeDeleted.pm
@@ -21,31 +21,19 @@ sub run {
 
     # select "start note", to see that start note cann't be deleted
     send_key "tab";
-    sleep 2;
     send_key "down";
-    sleep 2;
     send_key "down";
-    sleep 2;
     send_key "ret";
-    sleep 2;
     check_screen "tomboy_delete_0";    # to see if the delete buttom is avaiable
-    sleep 2;
 
     # press the delete button
     send_key "alt-t";
-    sleep 2;
     send_key "esc";
-    sleep 2;
     send_key "right";
-    sleep 2;
     send_key "right";
-    sleep 2;
     send_key "right";
-    sleep 2;
     send_key "ret";
-    sleep 2;
     send_key "ret";
-    sleep 2;
     wait_still_screen;
 
     send_key "alt-c";
@@ -56,7 +44,6 @@ sub run {
     check_screen "tomboy_delete_1", 5;    # to see if start note still there
     send_key "tab";                       # move the cursor back to text.
     send_key "alt-f4";
-    sleep 2;
 }
 
 1;

--- a/tests/x11regressions/tomboy/tomboy_StartNoteCannotBeDeleted.pm
+++ b/tests/x11regressions/tomboy/tomboy_StartNoteCannotBeDeleted.pm
@@ -28,8 +28,7 @@ sub run {
     sleep 2;
     send_key "ret";
     sleep 2;
-    wait_idle;
-    check_screen "tomboy_delete_0", 5;    # to see if the delete buttom is avaiable
+    check_screen "tomboy_delete_0";    # to see if the delete buttom is avaiable
     sleep 2;
 
     # press the delete button
@@ -58,7 +57,6 @@ sub run {
     send_key "tab";                       # move the cursor back to text.
     send_key "alt-f4";
     sleep 2;
-    wait_idle;
 }
 
 1;

--- a/tests/x11regressions/tomboy/tomboy_TestFindFunctionalityInSearchAllNotes.pm
+++ b/tests/x11regressions/tomboy/tomboy_TestFindFunctionalityInSearchAllNotes.pm
@@ -26,8 +26,7 @@ sub run {
     sleep 2;
     type_string "hehe";
     sleep 1;
-    send_key "alt-f4";
-    wait_idle;
+    wait_screen_change { send_key 'alt-f4' };
 
     send_key "alt-f9";
     sleep 2;
@@ -35,8 +34,7 @@ sub run {
     sleep 1;
     assert_screen 'test-tomboy_TestFindFunctionalityInSearchAllNotes-1', 3;
     sleep 2;
-    send_key "alt-f4";
-    wait_idle;
+    wait_screen_change { send_key 'alt-f4' };
 
     # test Edit->preferences
     send_key "alt-f9";
@@ -49,8 +47,7 @@ sub run {
     sleep 2;
     send_key "alt-f4";
     sleep 1;
-    send_key "alt-f4";
-    wait_idle;
+    wait_screen_change { send_key 'alt-f4' };
 
     # test Help->Contents
     send_key "alt-f9";
@@ -63,8 +60,7 @@ sub run {
     sleep 2;
     send_key "alt-f4";
     sleep 1;
-    send_key "alt-f4";
-    wait_idle;
+    wait_screen_change { send_key 'alt-f4' };
 
     # test Help-> About
     send_key "alt-f9";
@@ -76,8 +72,7 @@ sub run {
     sleep 2;
     send_key "alt-f4";
     sleep 1;
-    send_key "alt-f4";
-    wait_idle;
+    wait_screen_change { send_key 'alt-f4' };
 
     # test File->Close
     send_key "alt-f";
@@ -96,8 +91,7 @@ sub run {
     sleep 1;
     send_key "alt-d";
     sleep 1;
-    send_key "alt-f4";
-    wait_idle;
+    wait_screen_change { send_key 'alt-f4' };
 }
 
 1;

--- a/tests/x11regressions/tomboy/tomboy_TestFindFunctionalityInSearchAllNotes.pm
+++ b/tests/x11regressions/tomboy/tomboy_TestFindFunctionalityInSearchAllNotes.pm
@@ -22,75 +22,50 @@ sub run {
     x11_start_program("tomboy note");
 
     # create a note
-    send_key "ctrl-n";
-    sleep 2;
+    wait_screen_change { send_key "ctrl-n" };
     type_string "hehe";
-    sleep 1;
+    save_screenshot;
     wait_screen_change { send_key 'alt-f4' };
 
-    send_key "alt-f9";
-    sleep 2;
+    wait_screen_change { send_key "alt-f9" };
     type_string "hehe";
-    sleep 1;
-    assert_screen 'test-tomboy_TestFindFunctionalityInSearchAllNotes-1', 3;
-    sleep 2;
+    assert_screen 'test-tomboy_TestFindFunctionalityInSearchAllNotes-1';
     wait_screen_change { send_key 'alt-f4' };
 
     # test Edit->preferences
     send_key "alt-f9";
-    sleep 2;
     send_key "alt-e";
-    sleep 1;
     send_key "p";
-    sleep 1;
-    assert_screen 'test-tomboy_TestFindFunctionalityInSearchAllNotes-2', 3;
-    sleep 2;
+    assert_screen 'test-tomboy_TestFindFunctionalityInSearchAllNotes-2';
     send_key "alt-f4";
-    sleep 1;
     wait_screen_change { send_key 'alt-f4' };
 
     # test Help->Contents
     send_key "alt-f9";
-    sleep 2;
     send_key "alt-h";
-    sleep 1;
     send_key "c";
-    sleep 1;
-    assert_screen 'test-tomboy_TestFindFunctionalityInSearchAllNotes-3', 3;
-    sleep 2;
+    assert_screen 'test-tomboy_TestFindFunctionalityInSearchAllNotes-3';
     send_key "alt-f4";
-    sleep 1;
     wait_screen_change { send_key 'alt-f4' };
 
     # test Help-> About
     send_key "alt-f9";
-    sleep 2;
     send_key "alt-h";
     send_key "a";
-    sleep 1;
-    assert_screen 'test-tomboy_TestFindFunctionalityInSearchAllNotes-4', 3;
-    sleep 2;
+    assert_screen 'test-tomboy_TestFindFunctionalityInSearchAllNotes-4';
     send_key "alt-f4";
-    sleep 1;
     wait_screen_change { send_key 'alt-f4' };
 
     # test File->Close
     send_key "alt-f";
-    sleep 1;
     send_key "c";
-    sleep 1;
-    assert_screen 'test-tomboy_TestFindFunctionalityInSearchAllNotes-5', 3;
-    sleep 2;
+    assert_screen 'test-tomboy_TestFindFunctionalityInSearchAllNotes-5';
 
     # delete the created note
     send_key "alt-f9";
-    sleep 1;
     send_key "up";
-    sleep 1;
     send_key "delete";
-    sleep 1;
     send_key "alt-d";
-    sleep 1;
     wait_screen_change { send_key 'alt-f4' };
 }
 

--- a/tests/x11regressions/tomboy/tomboy_checkinstall.pm
+++ b/tests/x11regressions/tomboy/tomboy_checkinstall.pm
@@ -18,12 +18,7 @@ use testapi;
 
 sub run {
     mouse_hide();
-    sleep 60;
     ensure_installed("tomboy");
-    send_key "ret";
-    sleep 90;
-    send_key "esc";
-    sleep 5;
 }
 
 1;

--- a/tests/x11regressions/tomboy/tomboy_checkinstall.pm
+++ b/tests/x11regressions/tomboy/tomboy_checkinstall.pm
@@ -19,13 +19,11 @@ use testapi;
 sub run {
     mouse_hide();
     sleep 60;
-    wait_idle;
     ensure_installed("tomboy");
     send_key "ret";
     sleep 90;
     send_key "esc";
     sleep 5;
-    wait_idle;
 }
 
 1;

--- a/tests/x11regressions/tomboy/tomboy_firstrun.pm
+++ b/tests/x11regressions/tomboy/tomboy_firstrun.pm
@@ -36,7 +36,6 @@ sub run {
     sleep 3;
     send_key "alt-f4";
     sleep 7;
-    wait_idle;
 }
 
 1;

--- a/tests/x11regressions/tomboy/tomboy_firstrun.pm
+++ b/tests/x11regressions/tomboy/tomboy_firstrun.pm
@@ -21,21 +21,16 @@ sub run {
     mouse_hide();
     x11_start_program("tomboy note");
     while (check_screen "tomboy_command_not_found", 5) {
-        sleep 30;
+        wait_still_screen;
         send_key "ret";
-        sleep 1;
     }
-    sleep 1;
+    wait_still_screen(3);
 
     # open the menu
     send_key "alt-f12";
-    sleep 2;
     check_screen "tomboy_menu", 5;
-    sleep 2;
-    send_key "esc";
-    sleep 3;
+    wait_screen_change { send_key 'esc' };
     send_key "alt-f4";
-    sleep 7;
 }
 
 1;

--- a/tests/x11regressions/tracker/clean_tracker.pm
+++ b/tests/x11regressions/tracker/clean_tracker.pm
@@ -23,7 +23,6 @@ sub run {
         x11_start_program("rm -rf $_");
         sleep 2;
     }
-    wait_idle;
 }
 
 1;

--- a/tests/x11regressions/tracker/clean_tracker.pm
+++ b/tests/x11regressions/tracker/clean_tracker.pm
@@ -21,7 +21,6 @@ sub run {
     # Delete a file.
     foreach (@filenames) {
         x11_start_program("rm -rf $_");
-        sleep 2;
     }
 }
 

--- a/tests/x11regressions/tracker/prep_tracker.pm
+++ b/tests/x11regressions/tracker/prep_tracker.pm
@@ -26,7 +26,6 @@ sub run {
         x11_start_program("touch $_");
         sleep 2;
     }
-    wait_idle;
 }
 
 sub test_flags {

--- a/tests/x11regressions/tracker/prep_tracker.pm
+++ b/tests/x11regressions/tracker/prep_tracker.pm
@@ -24,7 +24,6 @@ sub run {
     # Create a file.
     foreach (@filenames) {
         x11_start_program("touch $_");
-        sleep 2;
     }
 }
 

--- a/tests/x11regressions/tracker/tracker_info.pm
+++ b/tests/x11regressions/tracker/tracker_info.pm
@@ -26,10 +26,8 @@ sub run {
     else {
         script_run "tracker-info newpl.pl";
     }
-    sleep 5;
     assert_screen 'tracker-info-newpl';
     send_key "alt-f4";
-    sleep 2;    # close xterm
 }
 
 1;

--- a/tests/x11regressions/tracker/tracker_open_apps.pm
+++ b/tests/x11regressions/tracker/tracker_open_apps.pm
@@ -19,11 +19,8 @@ use testapi;
 
 sub run {
     x11_start_program("tracker-needle");
-    sleep 2;
-    wait_idle;    # extra wait because oo sometimes appears to be idle during start
     assert_screen 'tracker-needle-launched';
     type_string "cheese";
-    sleep 8;
     assert_screen 'tracker-search-cheese';
     sleep 2;
     send_key "tab";
@@ -32,7 +29,6 @@ sub run {
     sleep 2;
     send_key "ret";
     sleep 2;
-    wait_idle;
     assert_screen 'cheese-launched';
     send_key "alt-f4";
     sleep 2;    #close cheese

--- a/tests/x11regressions/tracker/tracker_open_apps.pm
+++ b/tests/x11regressions/tracker/tracker_open_apps.pm
@@ -22,16 +22,11 @@ sub run {
     assert_screen 'tracker-needle-launched';
     type_string "cheese";
     assert_screen 'tracker-search-cheese';
-    sleep 2;
-    send_key "tab";
-    sleep 2;
-    send_key "down";
-    sleep 2;
+    wait_screen_change { send_key 'tab' };
+    wait_screen_change { send_key 'down' };
     send_key "ret";
-    sleep 2;
     assert_screen 'cheese-launched';
-    send_key "alt-f4";
-    sleep 2;    #close cheese
+    wait_screen_change { send_key 'alt-f4' };
     send_key "alt-f4";
 }
 

--- a/tests/x11regressions/tracker/tracker_pref_starts.pm
+++ b/tests/x11regressions/tracker/tracker_pref_starts.pm
@@ -19,8 +19,6 @@ use testapi;
 
 sub run {
     x11_start_program("tracker-preferences");
-    sleep 2;
-    wait_idle;
     assert_screen 'tracker_pref_launched';
     send_key "alt-f4";
 }

--- a/tests/x11regressions/tracker/tracker_search_in_nautilus.pm
+++ b/tests/x11regressions/tracker/tracker_search_in_nautilus.pm
@@ -17,18 +17,11 @@ use testapi;
 
 sub run {
     x11_start_program("nautilus");
-    wait_idle;
-    send_key "ctrl-f";
-    sleep 2;
+    wait_screen_change { send_key 'ctrl-f' };
     type_string "newfile";
-    wait_idle;
     send_key "ret";
-    wait_idle;
     assert_screen 'gedit-launched', 3;    # should open file newfile
-    send_key "alt-f4";
-    sleep 2;                              #close gedit
-
-    # close nautilus
+    wait_screen_change { send_key 'alt-f4' };
     send_key "alt-f4";
 }
 

--- a/tests/x11regressions/tracker/tracker_searchall.pm
+++ b/tests/x11regressions/tracker/tracker_searchall.pm
@@ -18,22 +18,16 @@ use utils;
 
 sub run {
     x11_start_program("tracker-needle");
-    sleep 2;
-    wait_idle;
     assert_screen 'tracker-needle-launched';
     if (!sle_version_at_least('12-SP2')) {
-        send_key "tab";
-        wait_idle;
-        send_key "tab";
-        wait_idle;
-        send_key "right";
-        wait_idle;
-        send_key "ret";
+        wait_screen_change { send_key 'tab' };
+        wait_screen_change { send_key 'tab' };
+        wait_screen_change { send_key 'right' };
+        wait_screen_change { send_key 'ret' };
         #switch to search input field
         for (1 .. 4) { send_key "right" }
     }
     type_string "newfile";
-    sleep 5;
     assert_screen 'tracker-search-result';
     send_key "alt-f4";
 }

--- a/tests/x11regressions/tracker/tracker_starts.pm
+++ b/tests/x11regressions/tracker/tracker_starts.pm
@@ -17,8 +17,6 @@ use testapi;
 
 sub run {
     x11_start_program("tracker-needle");
-    sleep 2;
-    wait_idle;
     assert_screen 'tracker-needle-launched';
     send_key "alt-f4";
 }


### PR DESCRIPTION
Verification runs:
* btrfs standard SLE@zkvm: http://lord.arch/tests/7078
* textmode@zkvm: http://lord.arch/tests/7080
* migration_offline_sle12sp1_ltss+allpatterns_fullupdate@zkvm: http://lord.arch/tests/7100
* RAID6@x86_64: http://lord.arch/tests/7104
* krypton live: http://lord.arch/tests/7108
* extra_tests_on_gnome: http://lord.arch/tests/7110
* kde: http://lord.arch/tests/7109
* regression-other SLE: http://lord.arch/tests/7112

All failures in the verification runs are unrelated fails to click or the same
problems that have been observed in production as well.

Related progress issue: https://progress.opensuse.org/issues/5830