### PR TITLE
Verify sle version with sle_version_at_least

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -535,7 +535,7 @@ sub load_inst_tests {
             loadtest "installation/disk_space_fill";
         }
     }
-    if (!check_var('VERSION', '15')) {    # No registration in SLE 15 atm - rbrown 04/07/17
+    if (!sle_version_at_least('15')) {    # No registration in SLE 15 atm - rbrown 04/07/17
         if (check_var('SCC_REGISTER', 'installation')) {
             loadtest "installation/scc_registration";
         }
@@ -559,7 +559,7 @@ sub load_inst_tests {
             && is_server()
             && (!is_sles4sap() || is_sles4sap_standard())
             && (install_this_version() || install_to_other_at_least('12-SP2'))
-            || check_var('VERSION', '15'))    # SLE 15 will always show the system role
+            || sle_version_at_least('15'))    # SLE 15 will always show the system role
         {
             loadtest "installation/system_role";
         }

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -14,7 +14,7 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use utils 'addon_license';
+use utils qw(addon_license sle_version_at_least);
 use qam 'advance_installer_window';
 
 sub run {
@@ -22,7 +22,7 @@ sub run {
         advance_installer_window('inst-addon');
         set_var('SKIP_INSTALLER_SCREEN', 0);
     }
-    if (check_var('VERSION', '15')) {    # SLE 15 has unsigned file errors, workaround them - rbrown 04/07/2017
+    if (sle_version_at_least('15')) {    # SLE 15 has unsigned file errors, workaround them - rbrown 04/07/2017
         while (check_screen('sle-15-unsigned-file')) {
             record_soft_failure 'bsc#1047304';
             send_key 'alt-y';

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -15,9 +15,10 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
+use utils 'sle_version_at_least';
 
 sub sle15_workaround_broken_patterns {
-    if (check_var('VERSION', '15')) {    # SLE 15 has pattern errors, workaround them - rbrown 04/07/2017
+    if (sle_version_at_least('15')) {    # SLE 15 has pattern errors, workaround them - rbrown 04/07/2017
         while (check_screen('sle-15-failed-to-select-pattern', 2)) {
             record_soft_failure 'bsc#1047327';
             send_key 'alt-o';

--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -15,6 +15,7 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
+use utils 'sle_version_at_least';
 
 sub check_bsc982138 {
     if (check_screen('installation-details-view-remaining-time-gt2h', 5)) {
@@ -94,7 +95,7 @@ sub run {
 
         # confirm
         send_key $cmd{install};
-        if (check_var('VERSION', '15')) {    # SLE 15 has unsigned file errors, workaround them - rbrown 04/07/2017
+        if (sle_version_at_least('15')) {    # SLE 15 has unsigned file errors, workaround them - rbrown 04/07/2017
             while (check_screen([qw(sle-15-unsigned-file workaround_no_checksum_found)])) {
                 record_soft_failure 'bsc#1047304';
                 send_key 'alt-y';

--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -13,6 +13,7 @@
 use strict;
 use base "y2logsstep";
 use testapi;
+use utils 'sle_version_at_least';
 
 sub assert_system_role {
     # Still initializing the system at this point, can take some time
@@ -36,7 +37,7 @@ sub assert_system_role_with_workaround_sle15_aarch64_missing_system_role {
     # When the workaround is no more needed, execute on `sub run` only the function `sub assert_system_role`
     wait_still_screen;
     # SLE 15 will always show the system role
-    if (check_var('VERSION', '15') && check_var('ARCH', 'aarch64')) {
+    if (sle_version_at_least('15') && check_var('ARCH', 'aarch64')) {
         assert_screen 'partitioning-edit-proposal-button';
         record_soft_failure 'bsc#1049297 - missing system role';
     }


### PR DESCRIPTION
Our general assumption is that changes applied to the latest version
will be applicable to the next version as well. When we use check_var
method, we compare against single version, and even code would work with
next major release, it won't use this execution path and it will be
required to change every usage. sle_version_at_least provides more
flexibility and provide version number comparison logic in single place.

See [poo#20582](https://progress.opensuse.org/issues/20582)
[Verification run](http://gershwin.arch.suse.de/tests/1214#)
