### PR TITLE
Fix poo#20782: Don't install devel packages

### DIFF
--- a/tests/qam-minimal/install_patterns.pm
+++ b/tests/qam-minimal/install_patterns.pm
@@ -31,7 +31,7 @@ sub install_packages {
 
     # loop over packages in patchinfo and try installation
     foreach my $line (split(/\n/, $patch_info)) {
-        if (my ($package) = $line =~ $pattern and $line !~ "xen-tools-domU") {
+        if (my ($package) = $line =~ $pattern and $line !~ "xen-tools-domU" and $line !~ "-devel") {
             zypper_call("in $package");
             save_screenshot;
         }


### PR DESCRIPTION
Devel packages shouldn't be installed in qam-minimal-full  and install_pattern test.

Failure reproduction:
https://openqa.suse.de/tests/1081390
http://10.100.12.105/tests/1185#step/install_patterns/1

Verification after fix:
http://10.100.12.105/tests/1186#step/install_patterns/1
http://10.100.12.105/tests/1187#step/install_patterns/1