### PR TITLE
add systemd testsuite

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -811,6 +811,7 @@ sub load_consoletests() {
         }
         loadtest "console/apache_ssl";
         loadtest "console/apache_nss";
+        loadtest 'console/systemd_testsuite' if sle_version_at_least('12-SP2');
     }
     if (check_var("DESKTOP", "xfce")) {
         loadtest "console/xfce_gnome_deps";

--- a/tests/console/systemd_testsuite.pm
+++ b/tests/console/systemd_testsuite.pm
@@ -1,0 +1,55 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Run testsuite included in systemd sources
+# Maintainer: Thomas Blume <tblume@suse.com>
+
+use base "consoletest";
+use warnings;
+use strict;
+use testapi;
+use utils;
+
+sub run() {
+    # install systemd testsuite
+    select_console 'root-console';
+    if (check_var('VERSION', '12-SP2')) {
+        zypper_call('ar http://download.suse.de/ibs/QA:/SLE12SP2/update/ systemd-testrepo');
+    }
+
+    elsif (check_var('VERSION', '12-SP3')) {
+        zypper_call('ar http://download.suse.de/ibs/QA:/SLE12SP3/update/ systemd-testrepo');
+    }
+    else {
+        my $version = get_var('VERSION');
+        my $distri  = get_var('DISTRI');
+        die "systemd testsuite tests not supported for $distri version $version";
+    }
+
+    zypper_call('--gpg-auto-import-keys ref');
+    zypper_call('in systemd-testsuite');
+
+    # run the testsuite test scripts
+    assert_script_run('cd /var/opt/systemd-tests; ./run-tests.sh --all 2>&1 | tee /tmp/testsuite.log', 300);
+    assert_screen('systemd-testsuite-result');
+
+    #cleanup
+    zypper_call('rm systemd-testsuite');
+}
+
+
+sub post_fail_hook {
+    my ($self) = shift;
+    $self->SUPER::post_fail_hook;
+    assert_script_run('cp /tmp/testsuite.log /var/opt/systemd-tests/logs; tar cjf systemd-testsuite-logs.tar.bz2 logs');
+    upload_logs('systemd-testsuite-logs.tar.bz2');
+}
+
+
+1;


### PR DESCRIPTION
add systemd testsuite to console tests
add call for systemd testsuite to sle/main.pm

needles at: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/440

example testrun integration test:
http://emerson/tests/224

example testrun stand-alone test:
http://emerson/tests/223