### PR TITLE
Add test for installation from external iso

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -403,6 +403,10 @@ sub specific_bootmenu_params {
         $args .= " addon=" . $addon_url;
     }
 
+    if (check_var('ISO_IN_EXTERNAL_DRIVE',1)) {
+        $args .= "install=hd:/?device=vdb1/install.iso";
+    }
+
     if (check_var('ARCH', 's390x')) {
         return $args;
     }

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -403,8 +403,8 @@ sub specific_bootmenu_params {
         $args .= " addon=" . $addon_url;
     }
 
-    if (check_var('ISO_IN_EXTERNAL_DRIVE',1)) {
-        $args .= "install=hd:/?device=vdb1/install.iso";
+    if (get_var('ISO_IN_EXTERNAL_DRIVE')) {
+        $args .= " install=hd:/install.iso";
     }
 
     if (check_var('ARCH', 's390x')) {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -48,6 +48,7 @@ our @EXPORT = qw(
   load_rollback_tests
   load_filesystem_tests
   load_wicked_tests
+  load_iso_in_external_tests
 );
 
 sub init_main {
@@ -582,6 +583,12 @@ sub load_filesystem_tests {
 sub load_wicked_tests {
     loadtest "console/wicked_before_test";
     loadtest "console/wicked_basic";
+}
+
+sub load_iso_in_external_tests {
+    loadtest "boot/boot_to_desktop";
+    loadtest "console/copy_iso_to_external_drive";
+    loadtest "x11/reboot_and_install";
 }
 
 1;

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -67,6 +67,7 @@ sub init_cmd {
       software s
       package p
       bootloader b
+      entiredisk alt-e
     );
 
     if (check_var('INSTLANG', "de_DE")) {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -257,6 +257,9 @@ sub load_inst_tests {
             loadtest "installation/livecd_network_settings";
         }
         loadtest "installation/partitioning";
+        if (get_var("ISO_IN_EXTERNAL_DRIVE")) {
+            loadtest "installation/partitioning_choose_disk";
+        }
         if (defined(get_var("RAIDLEVEL"))) {
             loadtest "installation/partitioning_raid";
         }
@@ -835,6 +838,11 @@ elsif (ssh_key_import) {
     load_reboot_tests();
     # verify previous defined ssh keys
     loadtest "x11/ssh_key_verify";
+}
+elsif (get_var("ISO_IN_EXTERNAL_DRIVE")) {
+    load_iso_in_external_tests();
+    load_inst_tests();
+    load_reboot_tests();
 }
 else {
     if (get_var("LIVETEST") || get_var('LIVE_INSTALLATION')) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1383,7 +1383,9 @@ elsif (ssh_key_import) {
 }
 elsif (get_var('ISO_IN_EXTERNAL_DRIVE')) {
     loadtest "boot/boot_to_desktop";
-    loadtest 'console/copy_iso_to_external_drive';
+    loadtest "console/copy_iso_to_external_drive";
+    loadtest 'x11/reboot_and_install';
+    #load_boot_tests();
     load_inst_tests();
     load_reboot_tests();
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -608,6 +608,9 @@ sub load_inst_tests {
         if (uses_qa_net_hardware()) {
             loadtest "installation/partitioning_firstdisk";
         }
+        if (get_var("ISO_IN_EXTERNAL_DRIVE")) {
+            loadtest "installation/partitioning_choose_disk";
+        }
         loadtest "installation/partitioning_finish";
     }
     # the VNC gadget is too unreliable to click, but we
@@ -1382,10 +1385,7 @@ elsif (ssh_key_import) {
     loadtest "x11/ssh_key_verify";
 }
 elsif (get_var('ISO_IN_EXTERNAL_DRIVE')) {
-    loadtest "boot/boot_to_desktop";
-    loadtest "console/copy_iso_to_external_drive";
-    loadtest 'x11/reboot_and_install';
-    #load_boot_tests();
+    load_iso_in_external_tests();
     load_inst_tests();
     load_reboot_tests();
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1381,6 +1381,12 @@ elsif (ssh_key_import) {
     # verify previous defined ssh keys
     loadtest "x11/ssh_key_verify";
 }
+elsif (get_var('ISO_IN_EXTERNAL_DRIVE')) {
+    loadtest "boot/boot_to_desktop";
+    loadtest 'console/copy_iso_to_external_drive';
+    load_inst_tests();
+    load_reboot_tests();
+}
 elsif (get_var('HPC')) {
     if (check_var('HPC', 'install')) {
         load_boot_tests();

--- a/tests/console/copy_iso_to_external_drive.pm
+++ b/tests/console/copy_iso_to_external_drive.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Copy the installation ISO to an external drive
+#    test for bug boo#1040749
+# Maintainer: Sergio Lindo Mansilla <slindomansilla@suse.com>
+
+use base "x11test";
+use strict;
+use testapi;
+
+sub run() {
+    select_console 'user-console';
+    # select_console 'root-console';
+
+    script_run "mount | tee /dev/$serialdev";
+    # TODO
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/console/copy_iso_to_external_drive.pm
+++ b/tests/console/copy_iso_to_external_drive.pm
@@ -11,16 +11,35 @@
 #    test for bug boo#1040749
 # Maintainer: Sergio Lindo Mansilla <slindomansilla@suse.com>
 
-use base "x11test";
+use base 'btrfs_test';
 use strict;
 use testapi;
 
 sub run() {
-    select_console 'user-console';
-    # select_console 'root-console';
+    my ($self) = @_;
 
-    script_run "mount | tee /dev/$serialdev";
-    # TODO
+    #select_console 'user-console';
+    select_console 'root-console';
+
+    type_string "mount | tee /dev/$serialdev\n";
+
+    # choose unpartioned disk and set <$disk> shell variable
+    $self->set_unpartitioned_disk_in_bash;
+
+    #partition HDD2
+    assert_script_run "parted \$disk mklabel gpt";
+    assert_script_run "parted -a opt \$disk mkpart primary ext4 0% 100%";
+    assert_script_run "mkfs.ext4 \$disk'1'";
+
+    #mount HDD2
+    assert_script_run "mount \$disk'1' /mnt";
+
+    #copy iso from DVD to HDD2
+    assert_script_run "dd if=/dev/dvd of=/mnt/install.iso" , 3000;
+
+    #check if copy worked
+    assert_script_run "` [[ -s /mnt/install.iso  ]]`";
+    select_console "x11";
 }
 
 1;

--- a/tests/console/copy_iso_to_external_drive.pm
+++ b/tests/console/copy_iso_to_external_drive.pm
@@ -8,37 +8,40 @@
 # without any warranty.
 
 # Summary: Copy the installation ISO to an external drive
-#    test for bug boo#1040749
-# Maintainer: Sergio Lindo Mansilla <slindomansilla@suse.com>
+# Maintainer: Joachim Rauch <jrauch@suse.com>
+# Tags: boo#1040749
 
 use base 'btrfs_test';
 use strict;
 use testapi;
 
-sub run() {
+sub run {
     my ($self) = @_;
 
-    #select_console 'user-console';
     select_console 'root-console';
 
-    type_string "mount | tee /dev/$serialdev\n";
-
     # choose unpartioned disk and set <$disk> shell variable
-    $self->set_unpartitioned_disk_in_bash;
-
+    $self->set_playground_disk;
+    my $disk = get_var('PLAYGROUNDDISK');
     #partition HDD2
-    assert_script_run "parted \$disk mklabel gpt";
-    assert_script_run "parted -a opt \$disk mkpart primary ext4 0% 100%";
-    assert_script_run "mkfs.ext4 \$disk'1'";
+    assert_script_run "echo Disk: $disk";
+    assert_script_run "parted $disk mklabel gpt",                       240;
+    assert_script_run "parted -a opt $disk mkpart primary ext4 0% 50%", 240;
+    my $partition = $disk . "1";
+    assert_script_run "mkfs.ext4 $partition", 240;
 
     #mount HDD2
-    assert_script_run "mount \$disk'1' /mnt";
+    assert_script_run "mount $partition /mnt";
 
     #copy iso from DVD to HDD2
-    assert_script_run "dd if=/dev/dvd of=/mnt/install.iso" , 3000;
+    assert_script_run 'dd if=/dev/dvd of=/mnt/install.iso', 3000;
 
     #check if copy worked
-    assert_script_run "` [[ -s /mnt/install.iso  ]]`";
+    assert_script_run '[[ $(md5sum /dev/dvd | awk \'{print $1}\') == $(md5sum /mnt/install.iso | awk \'{print $1}\') ]]';
+}
+
+sub post_run_hook {
+    #prepare environment for next test
     select_console "x11";
 }
 

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2176 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,9 +16,7 @@ use warnings;
 use base "y2logsstep";
 use testapi;
 
-# Entry test code
 sub run {
-
     assert_screen 'partitioning-edit-proposal-button', 40;
 
     # Storage NG introduces a new partitioning dialog. We detect this by the existence of the "Guided Setup" button
@@ -30,7 +28,6 @@ sub run {
     if (get_var("DUALBOOT")) {
         assert_screen 'partitioning-windows', 40;
     }
-
 }
 
 1;

--- a/tests/installation/partitioning_choose_disk.pm
+++ b/tests/installation/partitioning_choose_disk.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright ©2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Ensure primary disk is selected for partitioning, e.g. for multi-drive setups
+# Maintainer: Joachim Rauch <jrauch@suse.com>
+
+use strict;
+use warnings;
+use base "y2logsstep";
+use testapi;
+
+sub run {
+    save_screenshot;
+    send_key "$cmd{createpartsetup}";    #create partition setup
+    save_screenshot;
+    send_key 'alt-1';                    #use disk 1
+    save_screenshot;
+    wait_screen_change { send_key "$cmd{next}"; };
+    send_key "$cmd{entiredisk}";         #use entire disk
+    save_screenshot;
+    wait_screen_change { send_key "$cmd{next}"; };
+    save_screenshot;
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Added necessary boot parameter to lib/bootloader_setup
Added copy_iso_to_external_drive which clones the iso from dvd
to the second HDD in the SUT
Added verify_and_preape install which checks for the iso and
provides the necessary transisiton to X needed for the
reboot_and_install test
Added a routine in the partitioning test to choose the first hdd
in SUT as target for the installation

Issue:
https://progress.opensuse.org/issues/19510

Verification run:

SLE: http://10.160.65.204/tests/465
TW:  http://10.160.65.204/tests/TODO


Test SUITE to detect bugs like [this](https://bugzilla.opensuse.org/show_bug.cgi?id=1040749)

Settings:
- ISO_IN_EXTERNAL_DRIVE=1
- SHUTDOWN_NEEDS_AUTH=1
- IMPORT_SSH_KEYS=0
- NUMDISKS=2
- BOOTFROM=d

