### PR TITLE
Adjust boot image creation with repos on sle 15

### DIFF
--- a/lib/installsummarystep.pm
+++ b/lib/installsummarystep.pm
@@ -2,6 +2,7 @@ package installsummarystep;
 use base "y2logsstep";
 use testapi;
 use strict;
+use utils 'sle_version_at_least';
 
 
 sub accept3rdparty {
@@ -16,6 +17,7 @@ sub accept3rdparty {
 }
 
 sub accept_changes_with_3rd_party_repos {
+    my ($self) = @_;
     if (check_var('VIDEOMODE', 'text')) {
         send_key $cmd{accept};
         accept3rdparty;
@@ -25,6 +27,9 @@ sub accept_changes_with_3rd_party_repos {
     else {
         send_key $cmd{ok};
         accept3rdparty;
+    }
+    if (sle_version_at_least '15') {
+        $self->sle15_workaround_broken_patterns;
     }
     assert_screen 'inst-overview';
 }

--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -57,7 +57,7 @@ sub get_to_console {
 
 # to workaround dependency issues
 sub workaround_dependency_issues {
-    assert_screen 'dependency-issue';
+    return unless sle_version_at_least('15') && check_screen 'dependency-issue', 10;
 
     if (check_var('VIDEOMODE', 'text')) {
         while (check_screen('dependency-issue', 5)) {
@@ -80,7 +80,7 @@ sub workaround_dependency_issues {
 
 # to break dependency issues
 sub break_dependency {
-    assert_screen 'dependency-issue';
+    return unless sle_version_at_least('15') && check_screen 'dependency-issue', 10;
 
     if (check_var('VIDEOMODE', 'text')) {
         while (check_screen('dependency-issue-text', 5)) {    # repeat it untill all dependency issues are resolved
@@ -173,6 +173,10 @@ sub deal_with_dependency_issues {
 
     if (check_screen([qw(accept-licence automatic-changes unsupported-packages error-with-patterns sle-15-failed-to-select-pattern)], 2)) {
         goto DO_CHECKS;
+    }
+    # In text mode dependency issues may occur again after resolving them
+    if (check_screen 'manual-intervention') {
+        $self->deal_with_dependency_issues;
     }
 }
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -12,7 +12,7 @@ use warnings;
 use testapi qw(check_var get_var get_required_var set_var check_var_array);
 use lockapi;
 use needle;
-use utils 'is_hyperv_in_gui';
+use utils qw(is_hyperv_in_gui sle_version_at_least);
 use File::Find;
 use File::Basename;
 
@@ -603,7 +603,8 @@ sub load_inst_tests {
     # the VNC gadget is too unreliable to click, but we
     # need to be able to do installations on it. The release notes
     # functionality needs to be covered by other backends
-    if (!check_var('BACKEND', 'generalhw')) {
+    # Skip release notes test on sle 15 if have addons
+    if (!check_var('BACKEND', 'generalhw') && !(sle_version_at_least('15') && get_var('ADDONURL'))) {
         loadtest "installation/releasenotes";
     }
     if (noupdatestep_is_applicable()) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -85,9 +85,11 @@ sub default_desktop {
         if (get_var('BASE_VERSION', '') =~ /^12/) {
             return 'gnome';
         }
-        else {
-            return 'textmode';
+        # In sle15 we add repos manually to make a workaround of missing SCC, gnome will be installed as default system.
+        if (get_var('ADDONURL') =~ /(desktop|server)/) {
+            return 'gnome';
         }
+        return 'textmode';
     }
 }
 

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -51,7 +51,7 @@ sub run {
             # might involve some network lookup of products, licenses, etc.
             assert_screen 'addon-products', 90;
             send_key "tab";                                                     # select addon-products-$addon
-            wait_still_screen 2;
+            wait_still_screen 10;
             if (check_var('VIDEOMODE', 'text')) {                               # textmode need more tabs, depends on add-on count
                 send_key_until_needlematch "addon-list-selected", 'tab';
             }
@@ -96,6 +96,7 @@ sub run {
                 send_key 'alt-t';
             }
             send_key "tab";                                                     # select addon-products-$addon
+            wait_still_screen 10;                                               # wait until repo is added and list is initialized
             if (check_var('VIDEOMODE', 'text')) {                               # textmode need more tabs, depends on add-on count
                 send_key_until_needlematch "addon-list-selected", 'tab';
             }

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -26,7 +26,7 @@ sub run {
     # this is almost impossible to check for real
     assert_screen "installation-settings-overview-loaded";
 
-    $self->sle15_workaround_broken_patterns;
+    $self->deal_with_dependency_issues;
 
     if (get_var("XEN")) {
         assert_screen "inst-xen-pattern";

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -17,23 +17,16 @@ use base "y2logsstep";
 use testapi;
 use utils 'sle_version_at_least';
 
-sub sle15_workaround_broken_patterns {
-    if (sle_version_at_least('15')) {    # SLE 15 has pattern errors, workaround them - rbrown 04/07/2017
-        while (check_screen('sle-15-failed-to-select-pattern', 2)) {
-            record_soft_failure 'bsc#1047327';
-            send_key 'alt-o';
-        }
-    }
-}
 
 sub run {
     my ($self) = shift;
 
+    $self->sle15_workaround_broken_patterns;
     # overview-generation
     # this is almost impossible to check for real
     assert_screen "installation-settings-overview-loaded";
 
-    sle15_workaround_broken_patterns;
+    $self->sle15_workaround_broken_patterns;
 
     if (get_var("XEN")) {
         assert_screen "inst-xen-pattern";
@@ -57,9 +50,9 @@ sub run {
         $self->deal_with_dependency_issues;
     }
 
-    sle15_workaround_broken_patterns;    # Pattern warnings appear after dependancy resolution also;
+    $self->sle15_workaround_broken_patterns;    # Pattern warnings appear after dependancy resolution also;
 
-    my $need_ssh = check_var('ARCH', 's390x');    # s390x always needs SSH
+    my $need_ssh = check_var('ARCH', 's390x');  # s390x always needs SSH
     $need_ssh = 1 if check_var('BACKEND', 'ipmi');    # we better be able to login
 
     if (!get_var('UPGRADE') && $need_ssh) {

--- a/tests/installation/installation_overview_before.pm
+++ b/tests/installation/installation_overview_before.pm
@@ -19,6 +19,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     $self->sle15_workaround_broken_patterns;
+
     # overview-generation
     # this is almost impossible to check for real
     # See poo#12322. Prevent checks before overview is fully loaded
@@ -27,9 +28,7 @@ sub run {
     # performed only once, as state of buttons can be different
     assert_screen "installation-settings-overview-loaded";
 
-    $self->sle15_workaround_broken_patterns;
-
-    if (match_has_tag 'manual-intervention') {
+    if (check_screen 'manual-intervention') {
         $self->deal_with_dependency_issues;
     }
 }

--- a/tests/installation/installation_overview_before.pm
+++ b/tests/installation/installation_overview_before.pm
@@ -18,7 +18,7 @@ use testapi;
 
 sub run {
     my ($self) = @_;
-
+    $self->sle15_workaround_broken_patterns;
     # overview-generation
     # this is almost impossible to check for real
     # See poo#12322. Prevent checks before overview is fully loaded
@@ -26,6 +26,8 @@ sub run {
     # parts which are there while overview is still loading. This check has to be
     # performed only once, as state of buttons can be different
     assert_screen "installation-settings-overview-loaded";
+
+    $self->sle15_workaround_broken_patterns;
 
     if (match_has_tag 'manual-intervention') {
         $self->deal_with_dependency_issues;

--- a/tests/installation/select_patterns_and_packages.pm
+++ b/tests/installation/select_patterns_and_packages.pm
@@ -194,7 +194,7 @@ sub run {
                 };
                 assert_screen 'current-pattern-selected', 5;
             }
-
+            $self->workaround_dependency_issues;
             # stick to the default patterns
             if (get_var('PATTERNS', '') =~ /default/) {
                 $needs_to_be_selected = $selected;

--- a/tests/installation/select_patterns_and_packages.pm
+++ b/tests/installation/select_patterns_and_packages.pm
@@ -53,7 +53,10 @@ sub check12qtbug {
 }
 
 sub gotopatterns {
-    my $self = @_;
+    my ($self) = @_;
+
+    $self->deal_with_dependency_issues;
+
     if (check_var('VIDEOMODE', 'text')) {
         wait_still_screen;
         send_key 'alt-c';
@@ -63,13 +66,6 @@ sub gotopatterns {
     else {
         send_key_until_needlematch 'packages-section-selected', 'tab';
         send_key 'ret';
-    }
-
-    if (check_screen('dependency-issue', 5) && get_var("WORKAROUND_DEPS")) {
-        $self->workaround_dependency_issues;
-    }
-    if (check_screen('dependency-issue', 0) && get_var("BREAK_DEPS")) {
-        $self->break_dependency;
     }
 
     assert_screen 'pattern_selector';
@@ -87,9 +83,11 @@ sub gotopatterns {
 }
 
 sub package_action {
-    my $unblock = @_;
+    my ($self, $unblock) = @_;
     my $operation;
     my $packages = $unblock ? get_var('INSTALLATION_BLOCKED') : get_var('PACKAGES');
+    # Workaround for sle 15. Version check is performed inside of the method
+    $self->sle15_workaround_broken_patterns;
     if (get_var('PACKAGES')) {
         if (check_var('VIDEOMODE', 'text')) {
             send_key 'alt-f';
@@ -143,6 +141,8 @@ sub package_action {
         send_key 'alt-o';
         accept3rdparty;
     }
+    # Workaround for sle 15. Version check is performed inside of the method
+    $self->sle15_workaround_broken_patterns;
     if (get_var('INSTALLATION_BLOCKED') && $secondrun) {
         record_soft_failure 'bsc#1029660';
         assert_screen 'inst-overview-blocked';
@@ -157,9 +157,9 @@ sub package_action {
 }
 
 sub run {
-    my $self = shift;
+    my ($self) = @_;
 
-    gotopatterns;
+    $self->gotopatterns;
     if (get_var('PATTERNS')) {
         my %wanted_patterns;
         for my $p (split(/,/, get_var('PATTERNS'))) {
@@ -207,13 +207,13 @@ sub run {
             check12qtbug;
         }
     }
-    package_action;
+    $self->package_action;
     $secondrun++;
-    gotopatterns;
-    package_action;
+    $self->gotopatterns;
+    $self->package_action;
     $secondrun--;
-    gotopatterns;
-    package_action('unblock');
+    $self->gotopatterns;
+    $self->package_action('unblock');
 }
 
 1;


### PR DESCRIPTION
We already have a method to workaround broken patterns, whereas in some
scenarios we have installation_overview_before where we just assert
overview screen.
As a temporary solution we will add repos manually before we get scc.
Whereas, it should not affect test code, as this part is done using test
suite configuration. This PR mainly contains changes to workaround known
installation issues. We also exclude release notes test on sle 15 as it doesn't
work properly with addons and there will be no such a thing visible in
future.


See [poo#20824](https://progress.opensuse.org/issues/20824) and [poo#20984](https://progress.opensuse.org/issues/20984)

NOTE: all workaround take place only on sle15, hence won't affect other versions.

This change is partly included in [PR#3353](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3353).
Verification runs: 
[SLE15 minimal base + SDK](http://10.160.66.147/tests/1779)
[SLE15 text mode create hdd](http://10.160.66.147/tests/1769)
[SLE12 SP3 minimal base + SDK](http://10.160.66.147/tests/1731)

[Needles MR#442](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/442) - already merged
[Needles MR#443](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/443) - needs merge.