### PR TITLE
yast2_dns_server: Bump timeout for service startup

### DIFF
--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -26,7 +26,7 @@ sub assert_running {
     my $running = shift;
 
     if ($running) {
-        assert_script_run '(systemctl is-active named || true) | grep -E "^active"';
+        assert_script_run '(systemctl is-active named || true) | grep -E "^active"', timeout => 300;
     }
     else {
         assert_script_run '(systemctl is-active named || true) | grep -E "^(inactive|unknown)"';


### PR DESCRIPTION
See https://openqa.opensuse.org/tests/460306

Related progress issue: https://progress.opensuse.org/issues/20970