### PR TITLE
Avoid unnecessary console switch in x11/shutdown

### DIFF
--- a/tests/x11/shutdown.pm
+++ b/tests/x11/shutdown.pm
@@ -29,7 +29,7 @@ sub run {
         type_string("exit\n");
     }
     $self->{await_shutdown} = 0;
-    power_action('poweroff');
+    power_action('poweroff', keepconsole => 1);
     $self->{await_shutdown} = 1;
 }
 


### PR DESCRIPTION
This shouldn't have any effect on already passing tests, but will fix the failures in x11/shutdown in Plasma Wayland sessions: https://openqa.opensuse.org/tests/460363#step/shutdown/11

Long background story
------------------------------

While X11 sessions get started on VT 7, this is not the case for Wayland, where the next free console (VT1 is used by getty, VT7 by the sddm greeter -> VT2 by default) is used.
So when power_action does a `select_console 'x11'`, it switches to the console where sddm is running and presses 'ctrl-alt-delete', resulting in an immediate reboot. Simply changing the VT number of the 'x11' console in susedistribution.pm depending on the `WAYLAND` variable does not work as the wayland tests currently start in a X11 session before switching to a Wayland session. It is also not possible to change the `WAYLAND` variable dynamically during the test as the VT numbers are configured only once on startup.

So all in all this needs some more discussion and thoughts how to handle this properly.

For now this can be worked around by not switching the console in this test, which is AFAICS unnecessary anyways.

Verification run: http://lagarto.suse.de/tests/77