### PR TITLE
Use HTTP without SSL for html5test to avoid expired certificate error

### DIFF
--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -35,7 +35,7 @@ sub run {
 
     send_key "ctrl-l";
     sleep 1;
-    type_string "https://html5test.com/index.html\n";
+    type_string "http://html5test.com/index.html\n";
     assert_screen 'chromium-html5test', 30;
 
     send_key "alt-f4";

--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -19,7 +19,7 @@ use testapi;
 
 sub start_firefox {
     my ($self) = @_;
-    x11_start_program("firefox https://html5test.com/index.html", 6, {valid => 1});
+    x11_start_program("firefox http://html5test.com/index.html", 6, {valid => 1});
     $self->firefox_check_default;
     $self->firefox_check_popups;
     assert_screen 'firefox-html5test';


### PR DESCRIPTION
Currently html5test.com loads a resource from a page with an expired
SSL certificate, causing test failures. This changes the URL to use http
without SSL to workaround that, but it will require new needles as they
include the URL and security badge.

Verification run: http://lagarto.suse.de/tests/78#step/firefox/13