### PR TITLE
Adjust the x11 VT number when switching to wayland in start_wayland_plasma5

### DIFF
--- a/tests/x11/start_wayland_plasma5.pm
+++ b/tests/x11/start_wayland_plasma5.pm
@@ -40,6 +40,9 @@ sub run {
 
     # Wait until logged in
     assert_screen 'generic-desktop', 60;
+
+    # We're now in a wayland session, which is in a different VT
+    console('x11')->{args}->{tty} = 3;
 }
 
 sub test_flags {


### PR DESCRIPTION
For a Wayland session, sddm cannot reuse the greeter VT (tty7) as it is in
use by the X server, so it does the VT allocation itself. It queries the
kernel for the first free one and uses it. tty1 and tty2 are allocated during
consoletest_setup, so it is very likely to use tty3.

IMO a awful hack (directly modifying properties of a global variable), but @okurz recommended it and there does not seem to be a better way currently.

Verification run: http://lagarto.suse.de/tests/91 (without the keepconsole changes in shutdown.pm)