### PR TITLE
Revert "Enhance kGraft test coverage to be more close "real usage" (#…

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -139,8 +139,6 @@ sub prepare_kgraft {
     my $wanted_version = right_kversion($kversion, $pversion);
     fully_patch_system;
     install_lock_kernel($wanted_version);
-    # install released kGraft patches on top of wanted kernel
-    zypper_call('patch --with-interactive -l', exitcode => [0, 102], timeout => 700);
     type_string("reboot\n");
 }
 


### PR DESCRIPTION
…3378)"

This reverts commit f5e17a016ae187fedd7c3284d9e23c290cdbed1e.

With locked packages zypper always end with interactive mode and error
code 4