### PR TITLE
Upload coredumps

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -74,6 +74,10 @@ sub problem_detection {
     # Segmentation faults
     $self->save_and_upload_log("coredumpctl list", "segmentation-faults-list.txt", {screenshot => 1, noupload => 1});
     $self->save_and_upload_log("coredumpctl info", "segmentation-faults-info.txt", {screenshot => 1, noupload => 1});
+    # Save core dumps
+    type_string "mkdir -p coredumps\n";
+    type_string 'awk \'/Coredump/{printf("cp %s ./coredumps/\n",$2)}\' segmentation-faults-info.txt | sh';
+    type_string "\n";
     clear_console;
 
     # Broken links


### PR DESCRIPTION
Sometimes an application will generate coredumps. This change will capture
those coredumps and make them available in the assets tab in openqa.

The coredumps will be captured as long as the test invokes the function
problem_detection in the post_fail_hook.

