### PR TITLE
Various fixes after wait_idle/sleep remove

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -389,6 +389,7 @@ sub load_consoletests_minimal {
 sub load_consoletests {
     return unless consolestep_is_applicable();
     loadtest "console/consoletest_setup";
+    loadtest "console/force_cron_run" if !is_jeos;
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/check_locked_package";
     }
@@ -406,7 +407,6 @@ sub load_consoletests {
         loadtest "console/xorg_vt";
     }
     loadtest "console/zypper_lr";
-    loadtest "console/force_cron_run" if !is_jeos;
     loadtest 'console/enable_usb_repo' if check_var('USBBOOT', 1);
     if (have_addn_repos) {
         loadtest "console/zypper_ar";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -720,6 +720,7 @@ sub load_consoletests {
         loadtest "rt/kmp_modules";
     }
     loadtest "console/consoletest_setup";
+    loadtest "console/force_cron_run" unless is_jeos;
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/check_locked_package";
     }
@@ -740,7 +741,6 @@ sub load_consoletests {
         loadtest "console/xorg_vt";
     }
     loadtest "console/zypper_lr";
-    loadtest "console/force_cron_run" unless is_jeos;
     loadtest 'console/enable_usb_repo' if check_var('USBBOOT', 1);
     if (need_clear_repos()) {
         loadtest "update/zypper_clear_repos";

--- a/tests/console/force_cron_run.pm
+++ b/tests/console/force_cron_run.pm
@@ -9,10 +9,12 @@
 
 # Summary: Avoid suprises later and run the cron jobs explicitly
 # Maintainer: Stephan Kulow <coolo@suse.de>
+# Tags: bsc#1017461
 
 use base "consoletest";
 use strict;
 use testapi;
+use utils 'assert_screen_with_soft_timeout';
 
 # check if sshd works
 sub run {
@@ -21,13 +23,15 @@ sub run {
     # show dmesg output in console during cron run
     assert_script_run "dmesg -n 7";
 
+    my $before = time;
     assert_script_run "bash -x /usr/lib/cron/run-crons", 1000;
+    record_soft_failure 'bsc#1017461 - long running btrfs cron jobs can make system unresponsive' if (time - $before) > 60;
     sleep 3;    # some head room for the load average to rise
     script_run "top; echo TOP-DONE-\$? > /dev/$serialdev", 0;
     # let the load settle
-    assert_screen 'top-load-decreased', 1000;
+    assert_screen_with_soft_timeout('top-load-decreased', soft_timeout => 30, bugref => 'bsc#1017461', timeout => 1000);
     send_key 'q';
-    wait_serial 'TOP-DONE';
+    wait_serial 'TOP-DONE' || die 'top did not quit?';
 
     # return dmesg output to normal
     assert_script_run "dmesg -n 1";

--- a/tests/installation/add_update_test_repo.pm
+++ b/tests/installation/add_update_test_repo.pm
@@ -30,7 +30,7 @@ sub run() {
     while (defined(my $maintrepo = shift @repos)) {
         next if $maintrepo =~ /^\s*$/;
         assert_screen('addon-menu-active', 60);
-        send_key 'alt-u';    # specify url
+        wait_screen_change { send_key 'alt-u' };    # specify url
         if (check_var('VERSION', '12') and check_var('VIDEOMODE', 'text')) {
             send_key 'alt-x';
         }
@@ -38,7 +38,7 @@ sub run() {
             send_key $cmd{next};
         }
         assert_screen 'addonurl-entry';
-        send_key 'alt-u';    # select URL field
+        send_key 'alt-u';                           # select URL field
         type_string $maintrepo;
         advance_installer_window('addon-products');
         # if more repos to come, add more

--- a/tests/x11regressions/shotwell/shotwell_edit.pm
+++ b/tests/x11regressions/shotwell/shotwell_edit.pm
@@ -40,8 +40,7 @@ sub run {
     assert_screen 'shotwell-remove-prompt';
     wait_screen_change { send_key 'alt-r' };
     send_key "esc";
-    wait_still_screen;
-    assert_screen 'shotwell-removed-picture';
+    assert_screen 'shotwell-removed-picture', 60;
     send_key "ctrl-q";          # Quit shotwell
 
     # Clean shotwell's library then remove the test pictures

--- a/tests/x11regressions/shotwell/shotwell_edit.pm
+++ b/tests/x11regressions/shotwell/shotwell_edit.pm
@@ -13,7 +13,6 @@
 
 
 use base "x11regressiontest";
-use base "x11regressiontest";
 use strict;
 use testapi;
 
@@ -39,7 +38,7 @@ sub run {
     assert_screen 'shotwell-crop-picture';
     send_key "shift-delete";    # Remove picture from library
     assert_screen 'shotwell-remove-prompt';
-    send_key "alt-r";
+    wait_screen_change { send_key 'alt-r' };
     send_key "esc";
     wait_still_screen;
     assert_screen 'shotwell-removed-picture';

--- a/tests/x11regressions/tracker/tracker_search_in_nautilus.pm
+++ b/tests/x11regressions/tracker/tracker_search_in_nautilus.pm
@@ -18,9 +18,10 @@ use testapi;
 sub run {
     x11_start_program("nautilus");
     wait_screen_change { send_key 'ctrl-f' };
-    type_string "newfile";
-    send_key "ret";
-    assert_screen 'gedit-launched', 3;    # should open file newfile
+    wait_screen_change { type_string 'newfile' };
+    save_screenshot;
+    send_key 'ret';
+    assert_screen 'gedit-launched';    # should open file newfile
     wait_screen_change { send_key 'alt-f4' };
     send_key "alt-f4";
 }


### PR DESCRIPTION
* tracker_search_in_nautilus: Fix missing synchronisation / too low timeout
* shotwell_edit: Fix too low timeout after wait_idle/sleep remove
* add_update_test_repo: Synchronize key presses
* force_cron_run: Track too long execution with bugref (bsc#1017461)
* Prevent early console test failures related to btrfs maintenance tasks
* shotwell_edit: Fix remove dialog action