### PR TITLE
Install screen for heavy_load scripts, fix setup_ltp for SLE12GA

### DIFF
--- a/tests/kernel/ltp_setup_networking.pm
+++ b/tests/kernel/ltp_setup_networking.pm
@@ -78,8 +78,10 @@ EOF
     # echo/echoes, getaddrinfo_01
     assert_script_run('sed -i \'s/^\(hosts:\s+files\s\+dns$\)/\1 myhostname/\' /etc/nsswitch.conf');
 
+    # SLE12GA uses too many old style services
+    my $action = check_var('VERSION', '12') ? "enable" : "reenable";
     foreach my $service (qw(dnsmasq finger.socket nfsserver rpcbind telnet.socket vsftpd xinetd)) {
-        assert_script_run("systemctl reenable $service");
+        systemctl($action . " " . $service);
         assert_script_run("systemctl start $service || { systemctl status --no-pager $service; journalctl -xe --no-pager; false; }");
     }
 }

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -164,6 +164,8 @@ sub update_kgraft {
         # Download HEAVY LOAD script
         assert_script_run("curl -f " . autoinst_url . "/data/qam/heavy_load.sh -o /tmp/heavy_load.sh");
 
+        # install screen command
+        zypper_call("in screen", exitcode => [0, 102, 103]);
         #run HEAVY Load script
         script_run("bash /tmp/heavy_load.sh");
         # warm up system


### PR DESCRIPTION
1) `screen` isn't part of minimal pattern
2) `systemctl reenable` command doesn't work with some old style services