### PR TITLE
Fix yast2_dns_server.pm for send_key issue

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -381,8 +381,8 @@ sub load_yast2_ui_tests {
     # (Livesystem and laptops do use networkmanager)
     if (!get_var("LIVETEST") && !get_var("LAPTOP")) {
         if (check_var('DISTRI', 'opensuse')) {
-            # TODO: https://progress.opensuse.org/issues/20970
-            #loadtest "console/yast2_dns_server";
+            # fix the issue reported in https://progress.opensuse.org/issues/20970
+            loadtest "console/yast2_dns_server";
         }
         loadtest "console/yast2_nfs_client";
     }

--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -71,8 +71,9 @@ sub run {
     send_key 'alt-n';
     assert_screen 'yast2-dns-server-step3';
     # Enable dns server and finish
-    send_key 'alt-s';
-    wait_screen_change { send_key 'alt-f'; };
+    wait_screen_change { send_key 'alt-s' };
+    send_key 'alt-f';
+    assert_screen 'root-console';
     # The wizard-like interface still uses the old approach of always starting the service
     # while enabling it, so named should be both active and enabled
     $self->assert_running(1);
@@ -84,13 +85,13 @@ sub run {
     script_run 'yast2 dns-server', 0;
     assert_screen 'yast2-service-running-enabled';
     # Stop the service
-    send_key 'alt-s';
+    wait_screen_change { send_key 'alt-s' };
     assert_screen 'yast2-service-stopped-enabled';
     # Cancel yast2 to check the effect
-    wait_screen_change { send_key 'alt-c' };
-    if (check_screen('yast2-dns-server-quit')) {
-        wait_screen_change { send_key 'alt-y' };
-    }
+    # workaround for single send_key 'alt-c' because it doesn't work.
+    send_key_until_needlematch([qw(root-console yast2-dns-server-quit)], 'alt-c');
+    send_key 'alt-y';
+    assert_screen 'root-console', 180;
     $self->assert_running(0);
     $self->assert_enabled(1);
 
@@ -104,7 +105,8 @@ sub run {
     assert_screen 'yast2-service-running-enabled';
     # Disable the service and finish
     wait_screen_change { send_key 'alt-t' };
-    wait_screen_change { send_key 'alt-o' };
+    send_key 'alt-o';
+    assert_screen 'root-console', 180;
     $self->assert_running(1);
     $self->assert_enabled(0);
 
@@ -117,7 +119,8 @@ sub run {
     send_key 'alt-s';
     assert_screen 'yast2-service-stopped-disabled';
     # Finish
-    wait_screen_change { send_key 'alt-o' };
+    send_key 'alt-o';
+    assert_screen 'root-console', 180;
     $self->assert_running(0);
     $self->assert_enabled(0);
 }


### PR DESCRIPTION
- send_key doesn't work in some cases
- add assert_screen root-console to workaround type_string issue
- for details please see ticket: https://progress.opensuse.org/issues/20970
- add loadtest "console/yast2_dns_server"; back into lib/main_common.pm
- reference test: http://e13.suse.de/tests/4002#step/yast2_dns_server
