### PR TITLE
Increase timeout for resolving conflicts

### DIFF
--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -48,6 +48,7 @@ sub run {
                 while (!check_screen('all-conflicts-resolved-packages', 4)) {
                     assert_and_click 'package-conflict-choice';
                     send_key $cmd{ok};
+                    wait_still_screen 10;
                 }
                 send_key $cmd{accept};
 


### PR DESCRIPTION
In TW net installation resolving package conflicts takes more than 4
seconds sometimes. This commit introduces wait_still_screen call after
we press ok button. And spend less time in waiting for final screen as
expected to be there. Problem is mainly that after resolving last
conflict, screen is not there and we expect yet another conflict, but in
reality issue was already resolved.

See [poo#21778](https://progress.opensuse.org/issues/21778).
[Verification run](http://gershwin.arch.suse.de/tests/1250)