### PR TITLE
CaaSP: Scale up screen resolution on Xen PV

### DIFF
--- a/tests/casp/first_boot.pm
+++ b/tests/casp/first_boot.pm
@@ -38,7 +38,7 @@ sub run {
         select_console 'root-console';
 
         # On Hyper-V we need to add special framebuffer provisions
-        if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
+        if (check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('VIRSH_VMM_TYPE', 'linux')) {
             set_framebuffer_resolution;
             assert_script_run 'transactional-update grub.cfg';
             process_reboot 1;

--- a/tests/casp/transactional_update.pm
+++ b/tests/casp/transactional_update.pm
@@ -69,11 +69,12 @@ sub run {
     check_reboot_changes;
     check_package;
 
-    # Revert to first snapshot that we created. On Hyper-V we need to modify GRUB
-    # to add special framebuffer provision; as it involves and additional snapshot
-    # magic numbers below have to be altered there.
+    # Revert to first snapshot we created. On Hyper-V and Xen PV we modified GRUB to add
+    # special framebuffer provisions to scale down, and scale up, respectively, the
+    # hypervizor's native screen resolution. As it involved an additional snapshot, magic
+    # snapshot numbers below have to be altered properly.
     my $snap;
-    if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
+    if (check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('VIRSH_VMM_TYPE', 'linux')) {
         $snap = is_casp('VMX') ? 3 : 4;
     }
     else {


### PR DESCRIPTION
Correct: http://assam.suse.cz/tests/163#step/transactional_update/29
Wrong: https://openqa.suse.de/tests/1077396#step/transactional_update/28