### PR TITLE
Add support for iSCSI server in support server

### DIFF
--- a/data/supportserver/autoyast_supportserver.xml
+++ b/data/supportserver/autoyast_supportserver.xml
@@ -191,13 +191,14 @@
 		<package>apache2</package>
 		<package>dhcp-server</package>
 		<package>mc</package>
-		<package>syslinux</package> -->
+		<package>syslinux</package>
  		<package>openssh</package>
 		<package>less</package>
 		<package>nfs-client</package>
 		<package>autofs</package>
                 <package>bind</package>
-		<package>atftp</package> 
+		<package>atftp</package>
+		<package>yast2-iscsi-lio-server</package>
     </packages>
    <patterns config:type="list">
           <pattern>base</pattern>


### PR DESCRIPTION
For the HA (partial) rewrite of openQA tests, we need to use the
official support server functionality. But iSCSI server function
is missing. So, this commit add it.