### PR TITLE
Virtualization: fix for host upgrade tests

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -98,10 +98,12 @@ sub setup_console_in_grub {
           . "\&\& sed -ri '/(multiboot|module\\s*.*vmlinuz)/ "
           . "{s/(console|loglevel|log_lvl|guest_loglvl)=[^ ]*//g; "
           . "/multiboot/ s/\$/ console=com2,115200 log_lvl=all guest_loglvl=all sync_console/; "
-          . "/module\\s*.*vmlinuz/ s/\$/ console=$ipmi_console,115200 console=tty loglevel=5/;}' $grub_cfg_file";
+          . "/module\\s*.*vmlinuz/ s/\$/ console=$ipmi_console,115200 console=tty loglevel=5/;}; "
+          . "s/timeout=[0-9]*/timeout=15/g;"
+          . "' $grub_cfg_file";
         assert_script_run("$cmd");
         save_screenshot;
-        $cmd = "sed -rn '/(multiboot|module\\s*.*vmlinuz)/p' $grub_cfg_file";
+        $cmd = "sed -rn '/(multiboot|module\\s*.*vmlinuz|timeout=)/p' $grub_cfg_file";
         assert_script_run("$cmd");
     }
     elsif ($grub_ver eq "grub1") {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1277,6 +1277,7 @@ elsif (get_var("VIRT_AUTOTEST")) {
         loadtest "virt_autotest/host_upgrade_step2_run";
         loadtest "virt_autotest/reboot_and_wait_up_upgrade";
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
+            loadtest "virt_autotest/setup_xen_serial_console";
             loadtest "virt_autotest/reboot_and_wait_up_normal3";
         }
         loadtest "virt_autotest/host_upgrade_step3_run";

--- a/tests/virt_autotest/host_upgrade_step2_run.pm
+++ b/tests/virt_autotest/host_upgrade_step2_run.pm
@@ -26,7 +26,8 @@ sub get_script_run {
 
 sub run {
     my $self = shift;
-    $self->run_test(12600, "Host upgrade to .* is done. Need to reboot system", "no", "yes", "/var/log/qa/", "host-upgrade-prepAndUpgrade");
+    $self->run_test(12600, "Host upgrade to .* is done. Need to reboot system|Executing host upgrade to .* offline",
+        "no", "yes", "/var/log/qa/", "host-upgrade-prepAndUpgrade");
 }
 
 1;

--- a/tests/virt_autotest/host_upgrade_step3_run.pm
+++ b/tests/virt_autotest/host_upgrade_step3_run.pm
@@ -28,7 +28,7 @@ sub get_script_run {
 sub run {
     my $self = shift;
     repl_repo_in_sourcefile();
-    $self->run_test(5400, "Test run completed successfully", "no", "yes", "/var/log/qa/", "host-upgrade-postVerify-logs");
+    $self->run_test(5400, "Host upgrade virtualization test pass", "no", "yes", "/var/log/qa/", "host-upgrade-postVerify-logs");
 }
 
 1;

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -20,7 +20,7 @@ use ipmi_backend_utils;
 
 sub login_to_console {
     my ($self, $timeout) = @_;
-    $timeout //= 300;
+    $timeout //= 120;
 
     reset_consoles;
     select_console 'sol', await_console => 0;

--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -48,7 +48,7 @@ sub reboot_and_wait_up {
         #switch to sut console
         reset_consoles;
         #wait boot finish and relogin
-        &login_console::login_to_console($reboot_timeout);
+        login_console::login_to_console($self, $reboot_timeout);
     }
 }
 

--- a/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
@@ -18,7 +18,7 @@ use base "reboot_and_wait_up";
 
 sub run {
     my $self    = shift;
-    my $timeout = 3600;
+    my $timeout = 1200;
     set_var("reboot_for_upgrade_step", "yes");
     $self->reboot_and_wait_up($timeout);
 }

--- a/tests/virt_autotest/setup_xen_serial_console.pm
+++ b/tests/virt_autotest/setup_xen_serial_console.pm
@@ -1,24 +1,23 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-# Summary: virt_autotest: virtualization automation test in openqa, both kvm and xen supported
-# Maintainer: alice <xlai@suse.com>
+# Summary: Setup xen serial console so that ipmitool can work normally from 3rd generation openqa ipmi backend.
+# Maintainer: Alice <xlai@suse.com>
 
 use strict;
 use warnings;
 use testapi;
-use base "reboot_and_wait_up";
+use base "virt_autotest_base";
+use ipmi_backend_utils;
 
 sub run {
-    my $self    = shift;
-    my $timeout = 180;
-    $self->reboot_and_wait_up($timeout);
+    set_serial_console_on_xen if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen"));
 }
 
 sub test_flags {
@@ -26,4 +25,3 @@ sub test_flags {
 }
 
 1;
-

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -164,7 +164,7 @@ sub run_test {
 
     if ($assert_pattern) {
         unless ($script_output =~ /$assert_pattern/m) {
-            assert_script_run("grep \"$assert_pattern\" $log_dir -r || zcat /tmp/$compressed_log_name.tar.gz | grep -a \"$assert_pattern\"");
+            assert_script_run("grep -E \"$assert_pattern\" $log_dir -r || zcat /tmp/$compressed_log_name.tar.gz | grep -aE \"$assert_pattern\"");
         }
     }
 


### PR DESCRIPTION
Host upgrade tests will be fully deployed onto openqa for sle15 test. This PR fix the host upgrade issues for scenarios like sle11sp4->sle12sp3, sle12sp2->sle12sp3.