### PR TITLE
Fix last snapshot id parsing

### DIFF
--- a/tests/console/snapper_create.pm
+++ b/tests/console/snapper_create.pm
@@ -37,9 +37,8 @@ sub run {
             assert_script_run("snapper list | tail -n1");
             for (1 .. 3) { pop @snapper_cmd; }
             if ($type eq 'pre') {
-                type_string("( snapper list | tail -n1 | awk \'{ print \$3 }\'; echo snapper-post-\$?; ) > /dev/$serialdev\n");
-                my @snap_number = split('\n', wait_serial('snapper-post-0'));
-                push @snap_numbers, substr($snap_number[0], 0, -1);    # strip \n
+                # Add last snapshot id for pre type
+                push @snap_numbers, script_output($get_last_snap_number);
             }
         }
         pop @snapper_cmd if ($type eq 'post');


### PR DESCRIPTION
Initially it looked like problem with typing, which we see a lot on
production. Whereas, in the test code we slice script output to get rid
of new line symbol in the end. Which is not there always. And using
script_output doesn't need this magic, and is used in other part of code
in same test.

See [poo#21796](https://progress.opensuse.org/issues/21796)
[Verification run](http://10.160.66.147/tests/1789#)