### PR TITLE
Add standard repo for sle 15 in the end of installation

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1508,6 +1508,8 @@ if (get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1")) {
     if (get_var("INSTALLONLY")) {
         loadtest "console/hostname" unless is_bridged_networking;
         loadtest "console/force_cron_run" unless is_jeos;
+        # temporary adding test modules which applies hacks for missing parts in sle15
+        loadtest "console/sle15_workarounds" if sle_version_at_least('15');
         loadtest "shutdown/grub_set_bootargs";
         loadtest "shutdown/shutdown";
         if (check_var("BACKEND", "svirt")) {

--- a/tests/console/sle15_workarounds.pm
+++ b/tests/console/sle15_workarounds.pm
@@ -1,0 +1,34 @@
+# Copyright (C) 2014-2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+# Summary: performing extra actions specific to sle 15 which are not available normally
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
+
+use base "consoletest";
+use strict;
+use testapi;
+use utils qw(zypper_call sle_version_at_least);
+
+
+sub run {
+    return unless sle_version_at_least('15');
+    select_console 'root-console';
+    # Kernel devel packages are not in the dev tools module, so add standard repos
+    record_soft_failure('bsc#1053222');    # Once bug is resolved, this code can be removed
+    zypper_call('ar http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/SUSE:SLE-15:GA.repo');
+    zypper_call('--gpg-auto-import-keys ref');
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -36,8 +36,8 @@ sub assert_system_role_with_workaround_sle15_aarch64_missing_system_role {
     # Workaround for bsc#1049297
     # When the workaround is no more needed, execute on `sub run` only the function `sub assert_system_role`
     wait_still_screen;
-    # SLE 15 will always show the system role
-    if (sle_version_at_least('15') && check_var('ARCH', 'aarch64')) {
+    # SLE 15 will always show the system role. Occurs on arm and ppc
+    if (sle_version_at_least('15') && get_var('ARCH') =~ /aarch64|ppc64le/) {
         assert_screen 'partitioning-edit-proposal-button';
         record_soft_failure 'bsc#1049297 - missing system role';
     }


### PR DESCRIPTION
Part of implemented workaround didn't work well as expected kernel dev
packages are not available in dev-tools module. To resolve this issue we
now add this repo manually using zypper call, as due to [bsc#1053222](https://bugzilla.suse.com/show_bug.cgi?id=1053222) this doesn't work on add on products page.

See [poo#20984](https://progress.opensuse.org/issues/20984).
[Verification run](http://10.160.66.147/tests/1801)