### PR TITLE
Wait after key press

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -76,9 +76,10 @@ sub run {
             send_key 'alt-u';                                                   # specify url
             send_key $cmd{next};
             assert_screen 'addonurl-entry';
-            send_key 'alt-u';                                                   # select URL field
-            type_string get_var("ADDONURL_$uc_addon");                          # repo URL
+            send_key 'alt-u';                             # select URL field
+            type_string get_var("ADDONURL_$uc_addon");    # repo URL
             send_key $cmd{next};
+            wait_still_screen;                            # wait after key is pressed, e.g. 'addon-products' can apper shortly before initialization
             my @tags = ('addon-products', "addon-betawarning-$addon", "addon-license-$addon", 'import-untrusted-gpg-key');
             assert_screen(\@tags, 90);
             if (match_has_tag("addon-betawarning-$addon") or match_has_tag("addon-license-$addon")) {
@@ -87,7 +88,7 @@ sub run {
                     assert_screen "addon-license-beta";
                 }
                 wait_still_screen 2;
-                send_key 'alt-a';                                               # yes, agree
+                send_key 'alt-a';                         # yes, agree
                 wait_still_screen 2;
                 send_key $cmd{next};
                 assert_screen 'addon-products', 90;
@@ -95,16 +96,16 @@ sub run {
             elsif (match_has_tag('import-untrusted-gpg-key')) {
                 send_key 'alt-t';
             }
-            send_key "tab";                                                     # select addon-products-$addon
-            wait_still_screen 10;                                               # wait until repo is added and list is initialized
-            if (check_var('VIDEOMODE', 'text')) {                               # textmode need more tabs, depends on add-on count
+            send_key "tab";                               # select addon-products-$addon
+            wait_still_screen 10;                         # wait until repo is added and list is initialized
+            if (check_var('VIDEOMODE', 'text')) {         # textmode need more tabs, depends on add-on count
                 send_key_until_needlematch "addon-list-selected", 'tab';
             }
             send_key "pgup";
             wait_still_screen 2;
             send_key_until_needlematch "addon-products-$addon", 'down';
-            if ((split(/,/, get_var('ADDONURL')))[-1] ne $addon) {              # if $addon is not first from all ADDONS
-                send_key 'alt-a';                                               # add another add-on
+            if ((split(/,/, get_var('ADDONURL')))[-1] ne $addon) {    # if $addon is not first from all ADDONS
+                send_key 'alt-a';                                     # add another add-on
             }
         }
     }


### PR DESCRIPTION
poo#23326

addon-products needle appeared shortly and matched, then initialization started so first 2-3 lines were hidden behind initialization and could not match

fail: https://openqa.suse.de/tests/1103394#step/addon_products_sle/27