### PR TITLE
Increase timeouts for aarch64

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -41,7 +41,7 @@ sub run {
     }
 
     # aarch64 firmware 'tianocore' can take longer to load
-    my $bootloader_timeout = check_var('ARCH', 'aarch64') ? 25 : 15;
+    my $bootloader_timeout = check_var('ARCH', 'aarch64') ? 30 : 15;
     assert_screen([qw(bootloader-shim-import-prompt bootloader-grub2)], $bootloader_timeout);
     if (match_has_tag("bootloader-shim-import-prompt")) {
         send_key "down";

--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -48,6 +48,8 @@ sub run {
     my $self = shift;
     # NET isos are slow to install
     my $timeout = 2000;
+    # aarch64 can be particularily slow depending on the hardware
+    $timeout *= 2 if check_var('ARCH', 'aarch64') && get_var('MAX_JOB_TIME');
     # encryption, LVM and RAID makes it even slower
     $timeout *= 2 if (get_var('ENCRYPT') || get_var('LVM') || get_var('RAID'));
 


### PR DESCRIPTION
Some of the aarch64 workers can be a bit slower, this will allow
the tests running on those workers to run sucessfully