### PR TITLE
Install curl for sle 15

### DIFF
--- a/tests/console/sle15_workarounds.pm
+++ b/tests/console/sle15_workarounds.pm
@@ -28,6 +28,8 @@ sub run {
     record_soft_failure('bsc#1053222');    # Once bug is resolved, this code can be removed
     zypper_call('ar http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/SUSE:SLE-15:GA.repo');
     zypper_call('--gpg-auto-import-keys ref');
+    # Requested by ltp team, as curl is missing after installation
+    zypper_call('in curl');
 }
 
 1;


### PR DESCRIPTION
As another change due to missing SCC, we don't have curl installed in SUT, which is used by ltp team to upload logs. In functional job group we install curl in console_setup test suite.