### PR TITLE
Added sleep after ctrl-f to gnote test

### DIFF
--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -729,6 +729,24 @@ sub tomboy_logout_and_login {
     x11_start_program("tomboy note");
 }
 
+sub gnote_launch {
+    x11_start_program("gnote");
+    assert_screen "gnote-first-launched", 5;
+    send_key_until_needlematch 'gnote-start-here-matched', 'down', 5;
+}
+
+sub gnote_search_and_close {
+    my ($self, $string, $needle) = @_;
+
+    send_key "ctrl-f";
+    # The gnote interface is slow. So we can't start immediately searching. We need to wait
+    wait_still_screen(2);
+    type_string $string;
+    assert_screen $needle, 5;
+
+    send_key "ctrl-w";
+}
+
 # remove the created new note
 sub cleanup_gnote {
     wait_screen_change { send_key 'ctrl-tab' };    #jump to toolbar

--- a/tests/x11regressions/gnote/gnote_search_all.pm
+++ b/tests/x11regressions/gnote/gnote_search_all.pm
@@ -18,13 +18,9 @@ use testapi;
 
 
 sub run {
-    x11_start_program("gnote");
-    assert_screen "gnote-first-launched", 10;
-    send_key "ctrl-f";
-    type_string "welcome";
-    assert_screen 'gnote-search-welcome', 5;
-
-    send_key "ctrl-w";
+    my ($self) = @_;
+    $self->gnote_launch();
+    $self->gnote_search_and_close('welcome', 'gnote-search-welcome');
 }
 
 1;

--- a/tests/x11regressions/gnote/gnote_search_body.pm
+++ b/tests/x11regressions/gnote/gnote_search_body.pm
@@ -18,15 +18,10 @@ use testapi;
 
 
 sub run {
-    x11_start_program("gnote");
-    assert_screen "gnote-first-launched", 5;
-    send_key_until_needlematch 'gnote-start-here-matched', 'down', 5;
+    my ($self) = @_;
+    $self->gnote_launch();
     send_key "ret";
-    send_key "ctrl-f";
-    type_string "and";
-    assert_screen 'gnote-search-body-and', 5;
-
-    send_key "ctrl-w";
+    $self->gnote_search_and_close('and', 'gnote-search-body-and');
 }
 
 1;

--- a/tests/x11regressions/gnote/gnote_search_title.pm
+++ b/tests/x11regressions/gnote/gnote_search_title.pm
@@ -1,6 +1,7 @@
 # Gnote tests
 #
 # Copyright © 2016 SUSE LLC
+
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,15 +18,10 @@ use testapi;
 
 
 sub run {
-    x11_start_program("gnote");
-    assert_screen "gnote-first-launched", 5;
-    send_key_until_needlematch 'gnote-start-here-matched', 'down', 5;
+    my ($self) = @_;
+    $self->gnote_launch();
     send_key "ret";
-    send_key "ctrl-f";
-    type_string "here";
-    assert_screen 'gnote-search-title-here', 5;
-
-    send_key "ctrl-w";
+    $self->gnote_search_and_close('here', 'gnote-search-title-here');
 }
 
 1;


### PR DESCRIPTION

This is related to this:
https://progress.opensuse.org/issues/21048#note-9

Just added a sleep between the ctrl-f and the start of the typing.

Before:
https://openqa.suse.de/tests/1110688

After:
http://tragicbox.suse.cz/tests/91