### PR TITLE
Enhance docker test coverage

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -512,8 +512,11 @@ sub load_extra_tests {
             loadtest "console/a2ps";    # a2ps is not a ring package and thus not available in staging
             loadtest "console/weechat";
             loadtest "console/nano";
-            if (check_var('ARCH', 'x86_64')) {
-                loadtest "console/docker";
+        }
+        if (check_var('ARCH', 'x86_64')) {
+            loadtest "console/docker";
+            if (check_var('DISTRI', 'sle')) {
+                loadtest "console/sle2docker";
             }
         }
         loadtest "console/git";

--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -1,46 +1,110 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Test docker installation and basic usage
+# Summary: Test docker installation and extended usage
 #    Cover the following aspects of docker:
 #      * package can be installed
 #      * daemon can be started
+#      * images can be searched on the Docker Hub
 #      * images can be pulled from the Docker Hub
-#      * containers can be spawned
+#      * containers can be spawned, started on background, stopped, deleted
+#      * images can be deleted
 #      * network is working inside of the containers
-# G-Maintainer: Flavio Castelli <fcastelli@suse.com>
+# Maintainer: Petr Cervinka <pcervinka@suse.com>, Flavio Castelli <fcastelli@suse.com>
+
 
 use base "consoletest";
 use testapi;
+use utils;
 use strict;
 
 sub run {
-    select_console 'root-console';
+    select_console("root-console");
 
     # install the docker package
-    assert_script_run "zypper -n in docker", 200;
+    zypper_call("in docker");
 
     # start the docker daemon
-    assert_script_run "systemctl start docker", 200;
+    systemctl("start docker");
 
-    # pull the alpine image
-    # increase timeout, on systems using devicemapper as storage backend docker's initialization can take some time
-    assert_script_run "docker pull alpine", 300;
+    # check status of docker daemon
+    systemctl("status docker");
 
-    # make sure we can actually start a container
-    script_run "docker run --rm alpine echo 'hello_from_container' > /dev/$serialdev", 0;
-    die "cannot start container" unless wait_serial "hello_from_container", 200;
+    # get docker infor after installation and check number of images, should be 0
+    validate_script_output("docker info", sub { m/Images\: 0/ });
 
-    # make sure we can actually start a container
-    script_run "docker run --rm alpine wget http://google.com && echo 'container_network_works' > /dev/$serialdev", 0;
-    die "network does not work inside of the container" unless wait_serial "container_network_works", 200;
+    # do search for openSUSE
+    validate_script_output("docker search  --no-trunc opensuse", sub { m/This project contains the stable releases of the openSUSE distribution/ });
+
+    # pull minimalistic alpine image
+    # https://store.docker.com/images/alpine
+    assert_script_run("docker pull alpine", 300);
+
+    # check number of images, should be 1
+    validate_script_output("docker info", sub { m/Images\: 1/ });
+
+    # pull hello-world image, typical docker demo image
+    # https://store.docker.com/images/hello-world
+    assert_script_run("docker pull hello-world", 300);
+
+    # check number of images, should be 2
+    validate_script_output("docker info", sub { m/Images\: 2/ });
+
+    # run hello-world
+    validate_script_output("docker run hello-world", sub { m/Hello from Docker/ });
+
+    # run hello world from alpine
+    validate_script_output("docker run alpine /bin/echo Hello world", sub { m/Hello world/ });
+
+    # check number of containers, should be 2
+    validate_script_output("docker info", sub { m/Containers\: 2/ });
+
+    # run hello world from alpine and delete container
+    validate_script_output("docker run --rm alpine /bin/echo Hello world", sub { m/Hello world/ });
+
+    # check number of containers, still should be 2
+    validate_script_output("docker info", sub { m/Containers\: 2/ });
+
+    # list docker images
+    validate_script_output("docker images", sub { m/alpine/ });
+
+    # run alpine container on background and get back its id
+    my ($container_id) = script_output("docker run -d -t -i alpine /bin/sh") =~ /(.+)/;
+
+    # check number of running containers, should be 1
+    validate_script_output("docker info", sub { m/Running\: 1/ });
+
+    # check number of running containers, should be 1
+    validate_script_output("docker ps --no-trunc -q", sub { m/${container_id}/ });
+
+    # stop running container
+    assert_script_run("docker stop ${container_id}");
+
+    # check number of running containers, should be 0
+    validate_script_output("docker info", sub { m/Running\: 0/ });
+
+    # network test
+    script_run("docker run --rm alpine wget http://google.com && echo 'container_network_works' > /dev/$serialdev", 0);
+    die("network does not work inside of the container") unless wait_serial("container_network_works", 200);
+
+    # remove all containers
+    assert_script_run("docker rm \$(docker ps -a -q)");
+
+    # check number of containers, should be 0
+    validate_script_output("docker info", sub { m/Containers\: 0/ });
+
+    # remove all images
+    assert_script_run("docker rmi --force \$(docker images -a -q)");
+
+    # check number of images, should be 0
+    validate_script_output("docker info", sub { m/Images\: 0/ });
 }
 
 1;

--- a/tests/console/sle2docker.pm
+++ b/tests/console/sle2docker.pm
@@ -1,0 +1,49 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test sle2docker installation and  usage
+#    Cover the following aspects of sle2docker:
+#      * package and sle docker image can be installed
+#      * images can be listed, activated
+#      * sle docker container is able to run
+# Maintainer: Petr Cervinka <pcervinka@suse.com>
+
+
+use base "consoletest";
+use testapi;
+use utils;
+use strict;
+
+sub run {
+    select_console('root-console');
+
+    # install sle2docker and sle docker image
+    zypper_call("in sle2docker sles12sp2-docker-image");
+
+    # list images and check that sles image is available
+    validate_script_output("sle2docker list", sub { m/sles12sp2-docker/ });
+
+    # activate images
+    assert_script_run("sle2docker activate --all");
+
+    # check that number of images visible to docker was increased
+    validate_script_output("docker info", sub { m/Images\: 2/ });
+
+    # run hello world from sles and delete container
+    validate_script_output("docker  run --rm  suse/sles12sp2 /bin/echo Hello world", sub { m/Hello world/ });
+
+    # delete sle images
+    assert_script_run("docker rmi --force \$(docker images -a  | grep suse | grep -v latest | awk {'print \$3'})");
+
+    # recheck number of images
+    validate_script_output("docker info", sub { m/Images\: 0/ });
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Enhance poo#20094: Docker tests were made available also for SLE, not
just for openSUSE. Number of docker tests was increased to cover
regressions. New sle2docker tests were created for SLE.
Verification:
* openSUSE-TW
  http://10.100.12.105/tests/1246#step/docker/1
* SLE12-SP2
  http://10.100.12.105/tests/1244#step/docker/1
  http://10.100.12.105/tests/1244#step/sle2docker/1
* SLE12-SP3
  http://10.100.12.105/tests/1245#step/docker/1
  http://10.100.12.105/tests/1245#step/sle2docker/1