### PR TITLE
Fix ISO_IN_EXTERNAL test

### DIFF
--- a/tests/console/copy_iso_to_external_drive.pm
+++ b/tests/console/copy_iso_to_external_drive.pm
@@ -42,6 +42,8 @@ sub run {
 
 sub post_run_hook {
     #prepare environment for next test
+    type_string "logout\n";
+    assert_screen "text-login";
     select_console "x11";
 }
 


### PR DESCRIPTION
Fixed the problem when rebooting to the installation.

Verification runs:
[TW](http://10.160.65.204/tests/489) 

[SLES](http://10.160.65.204/tests/490)

The following settings have to be set in the set suite:
ISO_IN_EXTERNAL_DRIVE=1
SSH_KEY_IMPORT=0
NUMDISKS=2
BOOTFROM=d

Contrary to the initial commit do **not** touch SHUTDOWN_NEEDS_AUTH