### PR TITLE
Process product selection screen when installing sle 15

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -113,6 +113,16 @@ sub sle15_workaround_broken_patterns {
     }
 }
 
+sub process_unsigned_files {
+    # SLE 15 has unsigned file errors, workaround them - rbrown 04/07/2017
+    if (sle_version_at_least('15')) {
+        while (check_screen('sle-15-unsigned-file')) {
+            record_soft_failure 'bsc#1047304';
+            send_key 'alt-y';
+        }
+    }
+}
+
 # to deal with dependency issues, either work around it, or break dependency to continue with installation
 sub deal_with_dependency_issues {
     my ($self) = @_;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -537,13 +537,14 @@ sub load_inst_tests {
             loadtest "installation/disk_space_fill";
         }
     }
-    if (!sle_version_at_least('15')) {    # No registration in SLE 15 atm - rbrown 04/07/17
-        if (check_var('SCC_REGISTER', 'installation')) {
-            loadtest "installation/scc_registration";
-        }
-        else {
-            loadtest "installation/skip_registration";
-        }
+    if (sle_version_at_least('15')) {
+        loadtest "installation/select_products_sle";
+    }
+    if (check_var('SCC_REGISTER', 'installation')) {
+        loadtest "installation/scc_registration";
+    }
+    else {
+        loadtest "installation/skip_registration";
     }
     if (is_sles4sap) {
         loadtest "installation/sles4sap_product_installation_mode";

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -18,20 +18,17 @@ use utils qw(addon_license sle_version_at_least);
 use qam 'advance_installer_window';
 
 sub run {
+    my ($self) = @_;
+
     if (get_var('SKIP_INSTALLER_SCREEN', 0)) {
         advance_installer_window('inst-addon');
         set_var('SKIP_INSTALLER_SCREEN', 0);
     }
-    if (sle_version_at_least('15')) {    # SLE 15 has unsigned file errors, workaround them - rbrown 04/07/2017
-        while (check_screen('sle-15-unsigned-file')) {
-            record_soft_failure 'bsc#1047304';
-            send_key 'alt-y';
-        }
-    }
+    $self->process_unsigned_files;
     assert_screen [qw(inst-addon addon-products)];
     if (get_var("ADDONS")) {
         if (match_has_tag('inst-addon')) {
-            send_key 'alt-k';            # install with addons
+            send_key 'alt-k';    # install with addons
         }
         else {
             send_key 'alt-a';

--- a/tests/installation/select_products_sle.pm
+++ b/tests/installation/select_products_sle.pm
@@ -1,0 +1,34 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Test module is used to select product during SLE 15 installation
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
+
+use strict;
+use base "y2logsstep";
+use testapi;
+use utils qw(addon_license sle_version_at_least);
+
+sub run {
+    my ($self) = @_;
+    $self->process_unsigned_files;
+    assert_screen('select-product');
+    send_key 'alt-u';
+    assert_screen('select-product-sles');
+    send_key $cmd{next};
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Now we have working product selection screen for SLE15 and need to
select product accordingly. Additionally scc registration screen is
available now.

See [poo#23448](https://progress.opensuse.org/issues/23448)
[Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/453) (merged)
[Verification run](http://10.160.66.147/tests/1830#) (fails in next step, when adding addons, investigating why)