### PR TITLE
welcome: Ensure license-not-accepted popup vanishes before next key press

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -69,7 +69,7 @@ sub run {
     if (get_var('HASLICENSE')) {
         send_key $cmd{next};
         assert_screen 'license-not-accepted';
-        send_key $cmd{ok};
+        wait_screen_change { send_key $cmd{ok} };
         send_key $cmd{accept};    # accept license
     }
     assert_screen 'languagepicked';


### PR DESCRIPTION
See https://openqa.suse.de/tests/1120007#step/welcome/6