### PR TITLE
Workaround missing release notes on SLE 15 s390x images (bsc#1054478)

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -17,6 +17,7 @@ use testapi;
 
 sub run {
     assert_screen('release-notes-button', 5);
+    return if match_has_tag('bsc#1054478');
 
     # workaround for bsc#1014178
     wait_still_screen(5);


### PR DESCRIPTION
Verification run: http://lord.arch/tests/7163#step/releasenotes/1