### PR TITLE
Improve check_screen login for unsigned file popups

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -114,12 +114,19 @@ sub sle15_workaround_broken_patterns {
 }
 
 sub process_unsigned_files {
+    my ($self, $expected_screens) = @_;
     # SLE 15 has unsigned file errors, workaround them - rbrown 04/07/2017
-    if (sle_version_at_least('15')) {
-        while (check_screen('sle-15-unsigned-file')) {
+    return unless (sle_version_at_least('15'));
+    my $counter = 0;
+    while ($counter++ < 5) {
+        if (check_screen 'sle-15-unsigned-file', 0) {
             record_soft_failure 'bsc#1047304';
             send_key 'alt-y';
         }
+        elsif (check_screen $expected_screens, 0) {
+            last;
+        }
+        wait_still_screen;
     }
 }
 

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -24,7 +24,7 @@ sub run {
         advance_installer_window('inst-addon');
         set_var('SKIP_INSTALLER_SCREEN', 0);
     }
-    $self->process_unsigned_files;
+    $self->process_unsigned_files([qw(inst-addon addon-products)]);
     assert_screen [qw(inst-addon addon-products)];
     if (get_var("ADDONS")) {
         if (match_has_tag('inst-addon')) {

--- a/tests/installation/select_products_sle.pm
+++ b/tests/installation/select_products_sle.pm
@@ -19,11 +19,10 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use utils qw(addon_license sle_version_at_least);
 
 sub run {
     my ($self) = @_;
-    $self->process_unsigned_files;
+    $self->process_unsigned_files('select-product');
     assert_screen('select-product');
     send_key 'alt-u';
     assert_screen('select-product-sles');


### PR DESCRIPTION
With old logic we wait default timeout (30s) even popup doesn't occur.
With these changes we won't wait this long. I've verified that needles
which match expectation won't match if popup is there.

See [poo#23448](https://progress.opensuse.org/issues/23448).
[Verification run](http://10.160.66.147/tests/1840#)