### PR TITLE
Add prefix for image url in  boot_from_pxe

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -43,9 +43,11 @@ sub run {
             $image_name = get_var("REPO_0");
         }
 
-        my $arch = get_var('ARCH');
-        my $path = "/mnt/openqa/repo/${image_name}/boot/${arch}/loader";
-        my $repo = get_required_var('OPENQA_URL') . "/assets/repo/${image_name}";
+        my $arch       = get_var('ARCH');
+        my $path       = "/mnt/openqa/repo/${image_name}/boot/${arch}/loader";
+        my $openqa_url = get_required_var('OPENQA_URL');
+        $openqa_url = 'http://' . $openqa_url unless $openqa_url =~ /http:\/\//;
+        my $repo = $openqa_url . "/assets/repo/${image_name}";
         $image_path = "$path/linux initrd=$path/initrd install=$repo";
     }
 


### PR DESCRIPTION
On openqa.suse.de, the OPENQA_URL used to be http://openqa.suse.de, but now it is openqa.suse.de, missing "http://", but this will lead to boot_from_pxe failure that can not find installation repo. So this PR will add the prefix if missing.