### PR TITLE
Add mm-test of mariadb ssl connection

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -702,20 +702,25 @@ sub load_applicationstests {
     # adjust $pos below if you modify the position of
     # consoletest_finish!
     if (get_var('BOOT_HDD_IMAGE')) {
-        @tests = (
-            'console/consoletest_setup',
-            'console/import_gpg_keys',
-            'update/zypper_up',
-            'console/install_packages',
-            'console/zypper_add_repos',
-            'console/qam_zypper_patch',
-            'console/qam_verify_package_install',
-            'console/console_reboot',
-            # position -2
-            'console/consoletest_finish',
-            # position -1
-            'x11/shutdown'
-        );
+        if (get_var('MM_CLIENT')) {
+            @tests = split(/,/, get_var('APPTESTS'));
+        }
+        else {
+            @tests = (
+                'console/consoletest_setup',
+                'console/import_gpg_keys',
+                'update/zypper_up',
+                'console/install_packages',
+                'console/zypper_add_repos',
+                'console/qam_zypper_patch',
+                'console/qam_verify_package_install',
+                'console/console_reboot',
+                # position -2
+                'console/consoletest_finish',
+                # position -1
+                'x11/shutdown'
+            );
+        }
     }
     else {
         @tests = (
@@ -843,6 +848,10 @@ elsif (get_var("ISO_IN_EXTERNAL_DRIVE")) {
     load_iso_in_external_tests();
     load_inst_tests();
     load_reboot_tests();
+}
+elsif (get_var('MM_CLIENT')) {
+    boot_hdd_image;
+    load_applicationstests;
 }
 else {
     if (get_var("LIVETEST") || get_var('LIVE_INSTALLATION')) {

--- a/tests/console/mariadb.pm
+++ b/tests/console/mariadb.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: client part of mariadb ssl connection test
+# Maintainer: Wei Jiang <wjiang@suse.com>
+# Tags: TC1595192
+
+use base "consoletest";
+use strict;
+use testapi;
+use lockapi;
+use utils;
+use mm_tests;
+
+sub run {
+    select_console 'root-console';
+    configure_static_network('10.0.2.11/24');
+    zypper_call('in mariadb-client');
+
+    mutex_lock('mariadb');
+    mutex_unlock('mariadb');
+
+    type_string_slow "mysql --ssl --host=10.0.2.1 --user=root --password\n";
+    assert_screen 'mariadb-monitor-password';
+    type_string_slow "suse\n";
+    # Give more time to authenticate and open the db server
+    assert_screen 'mariadb-monitor-opened', 60;
+    type_string_slow "quit\n";
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/support_server/wait.pm
+++ b/tests/support_server/wait.pm
@@ -13,8 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# G-Summary: supportserver and supportserver generator implementation
-# G-Maintainer: Pavel Sladek <psladek@suse.com>
+# Summary: supportserver and supportserver generator implementation
+# Maintainer: Pavel Sladek <psladek@suse.com>
 
 use strict;
 use base 'basetest';
@@ -33,6 +33,11 @@ sub run {
     my @server_roles = split(',|;', lc(get_var("SUPPORT_SERVER_ROLES")));
     my %server_roles = map { $_ => 1 } @server_roles;
 
+    # No messages file in openSUSE which use journal by default
+    # Write journal log to /var/log/messages for openSUSE
+    if (check_var('DISTRI', 'opensuse')) {
+        script_run 'journalctl -b -x > /var/log/messages', 90;
+    }
     my $log_cmd = "tar cjf /tmp/logs.tar.bz2 /var/log/messages ";
     if (exists $server_roles{qemuproxy} || exists $server_roles{aytest}) {
         $log_cmd .= "/var/log/apache2 ";


### PR DESCRIPTION
See: https://progress.opensuse.org/issues/23348

Verified runs:
sle-fips:
http://10.67.17.71/tests/2
http://10.67.17.71/tests/3
tumbleweed:
http://10.67.17.71/tests/21
http://10.67.17.71/tests/22

Needle:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/458