### PR TITLE
Introduce new test variable EXIT_AFTER_START_INSTALL to shorten some scenarios

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -330,6 +330,7 @@ sub load_inst_tests {
         }
         loadtest "installation/start_install";
     }
+    return 1 if get_var('EXIT_AFTER_START_INSTALL');
     loadtest "installation/install_and_reboot";
 }
 
@@ -897,6 +898,7 @@ else {
     else {
         load_boot_tests();
         load_inst_tests();
+        return 1 if get_var('EXIT_AFTER_START_INSTALL');
         load_reboot_tests();
     }
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -664,6 +664,7 @@ sub load_inst_tests {
         }
         loadtest "installation/start_install";
     }
+    return 1 if get_var('EXIT_AFTER_START_INSTALL');
     loadtest "installation/install_and_reboot";
     if (check_var('BACKEND', 'svirt') and check_var('ARCH', 's390x')) {
         # on svirt we need to redefine the xml-file to boot the installed kernel
@@ -1497,6 +1498,7 @@ else {
         else {
             load_boot_tests();
             load_inst_tests();
+            return 1 if get_var('EXIT_AFTER_START_INSTALL');
             load_reboot_tests();
         }
     }


### PR DESCRIPTION
There are some scenarios where we only test the installer workflow but do not need to conduct the full package installation. To reduce test maintenance and reduce the load because of high I/O during actual package installation a new test variable EXIT_AFTER_START_INSTALL is introduced, similar to INSTALLONLY.

Tested locally for both openSUSE as well as SLE.

Example schedule output:

```
isosize tests/installation/isosize.pm
bootloader tests/installation/bootloader.pm
welcome tests/installation/welcome.pm
encrypted_volume_activation tests/installation/encrypted_volume_activation.pm
installation_mode tests/installation/installation_mode.pm
partitioning tests/installation/partitioning.pm
partitioning_lvm tests/installation/partitioning_lvm.pm
partitioning_finish tests/installation/partitioning_finish.pm
installer_timezone tests/installation/installer_timezone.pm
logpackages tests/installation/logpackages.pm
installer_desktopselection tests/installation/installer_desktopselection.pm
user_settings tests/installation/user_settings.pm
installation_overview tests/installation/installation_overview.pm
start_install tests/installation/start_install.pm
```