### PR TITLE
Add workaround not to use tty2 for root console

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -2,7 +2,7 @@ package susedistribution;
 use base 'distribution';
 use serial_terminal ();
 use strict;
-use utils qw(type_string_slow ensure_unlocked_desktop save_svirt_pty);
+use utils qw(type_string_slow ensure_unlocked_desktop save_svirt_pty sle_version_at_least);
 
 # Base class implementation of distribution class necessary for testapi
 
@@ -263,10 +263,11 @@ sub init_consoles {
         $self->add_console('install-shell',  'tty-console', {tty => 2});
         $self->add_console('installation',   'tty-console', {tty => check_var('VIDEOMODE', 'text') ? 1 : 7});
         $self->add_console('install-shell2', 'tty-console', {tty => 9});
-        $self->add_console('root-console',   'tty-console', {tty => 2});
-        $self->add_console('user-console',   'tty-console', {tty => 4});
-        $self->add_console('log-console',    'tty-console', {tty => 5});
-        $self->add_console('x11',            'tty-console', {tty => 7});
+        # On SLE15 X is running on tty2 see bsc#1054782
+        $self->add_console('root-console', 'tty-console', {tty => sle_version_at_least('15') ? 6 : 2});
+        $self->add_console('user-console', 'tty-console', {tty => 4});
+        $self->add_console('log-console',  'tty-console', {tty => 5});
+        $self->add_console('x11',          'tty-console', {tty => 7});
     }
 
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1530,10 +1530,10 @@ if (get_var("CLONE_SYSTEM")) {
 
 if (get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1")) {
     if (get_var("INSTALLONLY")) {
-        loadtest "console/hostname" unless is_bridged_networking;
-        loadtest "console/force_cron_run" unless is_jeos;
         # temporary adding test modules which applies hacks for missing parts in sle15
         loadtest "console/sle15_workarounds" if sle_version_at_least('15');
+        loadtest "console/hostname" unless is_bridged_networking;
+        loadtest "console/force_cron_run" unless is_jeos;
         loadtest "shutdown/grub_set_bootargs";
         loadtest "shutdown/shutdown";
         if (check_var("BACKEND", "svirt")) {

--- a/tests/console/sle15_workarounds.pm
+++ b/tests/console/sle15_workarounds.pm
@@ -15,15 +15,21 @@
 # Summary: performing extra actions specific to sle 15 which are not available normally
 # Maintainer: Rodion Iafarov <riafarov@suse.com>
 
-use base "consoletest";
+use base qw(consoletest distribution);
 use strict;
 use testapi;
 use utils qw(zypper_call sle_version_at_least);
 
 
 sub run {
+    my $self = shift;
     return unless sle_version_at_least('15');
-    select_console 'root-console';
+    send_key('ctrl-alt-f2');
+    assert_screen(["tty2-selected", 'text-login', 'text-logged-in-root', 'generic-desktop']);
+    if (match_has_tag 'generic-desktop') {
+        record_soft_failure 'bsc#1054782';
+    }
+    select_console('root-console');
     # Kernel devel packages are not in the dev tools module, so add standard repos
     record_soft_failure('bsc#1054062');    # Once bug is resolved, this code can be removed
     zypper_call('ar http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/SUSE:SLE-15:GA.repo');


### PR DESCRIPTION
As desired change root console is not available on tty2 anymore. For
backward compatibility gnome is still running on tty7. So, it's actually
running on two terminal. Consequently we cannot use tty2 as root-console
on sle 15. We add softfailure before bug is resolved and gnome is
running on tty2.

See bsc#1054782.

[Verification run](http://10.160.66.147/tests/1860)