### PR TITLE
Soft-fail role selection if product is leanos

### DIFF
--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -18,7 +18,7 @@ use utils 'sle_version_at_least';
 sub assert_system_role {
     # Still initializing the system at this point, can take some time
     assert_screen 'system-role-default-system', 180;
-
+    record_soft_failure('bsc#1055071') if (get_required_var('SLE_PRODUCT') eq 'leanos');
     # Pick System Role; poo#16650
     if (check_var('SYSTEM_ROLE', 'kvm')) {
         send_key 'alt-k';


### PR DESCRIPTION
According to PRD role selection should not be there for leanOS, so add
soft-failure. See [bsc#1055071](https://bugzilla.suse.com/show_bug.cgi?id=1055071)