### PR TITLE
LTP: networking: Don't install rdist package, install wget

### DIFF
--- a/tests/kernel/ltp_setup_networking.pm
+++ b/tests/kernel/ltp_setup_networking.pm
@@ -19,13 +19,13 @@ use utils;
 
 sub install {
     # utils
-    zypper_call('in iputils psmisc tcpdump', log => 'utils.log');
+    zypper_call('in wget iputils psmisc tcpdump', log => 'utils.log');
 
     # clients
     zypper_call('in dhcp-client finger telnet', log => 'clients.log');
 
     # services
-    zypper_call('in dhcp-server dnsmasq finger-server nfs-kernel-server rdist rpcbind rsync tcpd telnet-server vsftpd xinetd', log => 'services.log');
+    zypper_call('in dhcp-server dnsmasq finger-server nfs-kernel-server rpcbind rsync tcpd telnet-server vsftpd xinetd', log => 'services.log');
 }
 
 sub setup {


### PR DESCRIPTION
It's not available for SLE 15 Leanos and testing rdist is not much
valuable anyway.
wget in not installed by default on SLE 15 Leanos.