### PR TITLE
Fix issues related to switch of root-console to tty6

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -3,6 +3,7 @@ use base 'consoletest';
 
 use strict;
 use testapi;
+use utils 'get_root_console_tty';
 
 =head2 set_playground_disk
 
@@ -56,7 +57,8 @@ it means that DBus got activated somehow, thus invalidated `snapper --no-dbus` t
 sub snapper_nodbus_restore {
     if (script_run('systemctl is-active dbus')) {
         script_run('systemctl default', 0);
-        assert_screen 'tty2-selected';
+        my $tty = get_root_console_tty;
+        assert_screen "tty$tty-selected";
         console('root-console')->reset;
         select_console 'root-console';
     }

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -2,7 +2,7 @@ package susedistribution;
 use base 'distribution';
 use serial_terminal ();
 use strict;
-use utils qw(type_string_slow ensure_unlocked_desktop save_svirt_pty sle_version_at_least is_caasp);
+use utils qw(type_string_slow ensure_unlocked_desktop save_svirt_pty sle_version_at_least is_caasp get_root_console_tty);
 
 # Base class implementation of distribution class necessary for testapi
 
@@ -264,7 +264,7 @@ sub init_consoles {
         $self->add_console('installation',   'tty-console', {tty => check_var('VIDEOMODE', 'text') ? 1 : 7});
         $self->add_console('install-shell2', 'tty-console', {tty => 9});
         # On SLE15 X is running on tty2 see bsc#1054782
-        $self->add_console('root-console', 'tty-console', {tty => (sle_version_at_least('15') && !is_caasp) ? 6 : 2});
+        $self->add_console('root-console', 'tty-console', {tty => get_root_console_tty});
         $self->add_console('user-console', 'tty-console', {tty => 4});
         $self->add_console('log-console',  'tty-console', {tty => 5});
         $self->add_console('x11',          'tty-console', {tty => 7});
@@ -437,7 +437,7 @@ sub activate_console {
         }
         else {
             my $nr = 4;
-            $nr = 2 if ($name eq 'root');
+            $nr = get_root_console_tty if ($name eq 'root');
             $nr = 5 if ($name eq 'log');
             my @tags = ("tty$nr-selected", "text-logged-in-$user", "text-login");
             # s390 zkvm uses a remote ssh session which is root by default so

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -74,6 +74,7 @@ our @EXPORT = qw(
   install_all_from_repo
   run_scripted_command_slow
   snapper_revert_system
+  get_root_console_tty
 );
 
 
@@ -1311,6 +1312,16 @@ sub snapper_revert_system {
     power_action('reboot', textmode => 1);
     $self->wait_boot;
     select_console 'root-console';
+}
+
+=head2 get_root_console_tty
+    Returns tty number used designed to be used for root-console.
+    When console is not yet initialized, we cannot get it from arguments.
+    Since SLE 15 gdm is running on tty2, so we change behaviour for it and
+    openSUSE distris.
+=cut
+sub get_root_console_tty {
+    return (sle_version_at_least('15') && !is_caasp) ? 6 : 2;
 }
 
 1;


### PR DESCRIPTION
In SLE15 gdm is now running on tty2, so we use tty6 for it. Not to
diverge openSUSE tests, we use same strategy, as TW should correspond to
SLE 15 from functionality perspective.

See [poo#23548](https://progress.opensuse.org/issues/23548).
[Verification run](http://localhost/tests/1874).

NOTE: please merge needles [PR#255](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/255)