### PR TITLE
serial_terminal: Try to prevent ANSI codes in log output

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -51,7 +51,7 @@ sub login {
     type_string(qq/PS1="$serial_term_prompt"\n/);
     wait_serial(qr/PS1="$serial_term_prompt"/);
     # TODO: Send 'tput rmam' instead/also
-    assert_script_run('stty cols 2048');
+    assert_script_run('export TERM=dumb; stty cols 2048');
     assert_script_run('echo Logged into $(tty)', $bmwqemu::default_timeout, result_title => 'vconsole_login');
 }
 


### PR DESCRIPTION
Set the terminal capabilities to 'dumb' which prevents programs like GCC from
outputing ANSI colour codes making the serial log unreadable.