### PR TITLE
Soft-fail not to forget to remove ALL_MODULES variable

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -20,7 +20,8 @@ use utils 'sle_version_at_least';
 
 sub run {
     my ($self) = shift;
-
+    # Softfail not to forget remove workaround
+    record_soft_failure('bsc#1054974') if get_var('ALL_MODULES');
     $self->sle15_workaround_broken_patterns;
     # overview-generation
     # this is almost impossible to check for real


### PR DESCRIPTION
For SLE 15 we have introduced ALL_MODULES variable, which is used as a
workaround and triggers adding all modules as addons using url. Once
this is possible using proxy SCC, we should get rid of this variable and
revert related code changes.