### PR TITLE
Workaround for yast2 crash while tests running on openQA

### DIFF
--- a/tests/console/yast2_xinetd.pm
+++ b/tests/console/yast2_xinetd.pm
@@ -27,7 +27,11 @@ sub run {
     script_run("yast2 xinetd; echo yast2-xinetd-status-\$? > /dev/$serialdev", 0);
 
     # check xinetd network configuration got started
-    assert_screen 'yast2_xinetd_startup', 90;
+    assert_screen([qw(yast2_xinetd_startup yast2_xinetd_core-dumped)]), 90;
+    if (match_has_tag('yast2_xinetd_core-dumped')) {
+        # softfail when yast2 crashed and throws core dumped message
+        record_soft_failure "bsc#1049433";
+    }
 
     # enable xinetd
     send_key 'alt-l';


### PR DESCRIPTION
- add record_soft_failure "bsc#1049433"
- please see also ticket for further information:
  https://progress.opensuse.org/issues/23616