### PR TITLE
Exclude select_producs_sle module on sle staging

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -531,7 +531,7 @@ sub load_inst_tests {
             loadtest "installation/disk_space_fill";
         }
     }
-    if (sle_version_at_least('15')) {
+    if (sle_version_at_least('15') && !is_staging) {
         loadtest "installation/select_products_sle";
     }
     if (check_var('SCC_REGISTER', 'installation')) {


### PR DESCRIPTION
Staging Y fails at the moment because there is no product selection
page. As of now we will exclude it to fail tests in same point where it
would fail in other tests on osd.

See [poo#23340](https://progress.opensuse.org/issues/23340).
After this change we also expose new issues, see [verification run](http://10.163.10.54/tests/1901#step/installation_overview/25).