### PR TITLE
Improve extra_test_filesystem test suite stability

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,7 @@ requires 'XML::LibXML';
 requires 'XML::Writer';
 requires 'XML::Simple';
 requires 'IO::File';
+requires 'List::Util';
 
 on 'test' => sub {
   requires 'Code::DRY';


### PR DESCRIPTION
In snapper_cleanup test we have an issue that sometimes serial output is
clogged with some irrelevant messages. See run
https://openqa.opensuse.org/tests/470908#step/snapper_cleanup/187
And then we try to compare digit with the string which gives irrelevant
error. The easiest solution will be to just grab biggest number from the
output, as space is printed in bytes.

[Verification run](http://10.160.66.147/tests/1905)