### PR TITLE
Adjust test for storage ng

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -14,6 +14,7 @@ use Exporter;
 
 use strict;
 use testapi;
+use utils 'is_storage_ng';
 
 our @EXPORT = qw(wipe_existing_partitions addpart addlv);
 
@@ -24,14 +25,33 @@ my %role = qw(
   raw alt-a
 );
 
+sub wipe_existing_partitions_storage_ng {
+    send_key_until_needlematch "expert-partitioner-hard-disks", 'right';
+    wait_still_screen 2;
+    # Remove partition
+    send_key 'alt-d';
+    # Confirm in pop-up
+    assert_screen "delete-all-partitions-confirm";
+    send_key 'alt-t';
+    # Verify removed
+    send_key_until_needlematch "expert-partitioner-vda", 'right';
+    assert_screen 'expert-partitioner-unpartitioned';
+}
+
 sub wipe_existing_partitions {
     assert_screen('release-notes-button');
     send_key match_has_tag('bsc#1054478') ? 'alt-x' : $cmd{expertpartitioner};
     assert_screen 'expert-partitioner';
     wait_still_screen;
+    #Use storage ng
+    if (is_storage_ng) {
+        wipe_existing_partitions_storage_ng;
+        return;
+    }
     for (1 .. 4) {
         send_key 'right';    # select vda hard disk
     }
+
     # empty disk partitions by creating new partition table
     send_key 'alt-x';        # expert menu
     send_key 'down';
@@ -50,12 +70,23 @@ sub addpart {
     my (%args) = @_;
     assert_screen 'expert-partitioner';
     send_key $cmd{addpart};
-    unless (get_var('UEFI') || check_var('BACKEND', 's390x')) {    # partitioning type does not appear when GPT disk used, GPT is default for UEFI
+    # partitioning type does not appear when GPT disk used, GPT is default for UEFI
+    # also doesn't appear with storage-ng
+    if (is_storage_ng && check_screen 'partition-size', 0) {
+        record_soft_failure 'bsc#1055743';
+    }
+    unless (get_var('UEFI') || check_var('BACKEND', 's390x') || is_storage_ng) {
         assert_screen 'partitioning-type';
         send_key $cmd{next};
     }
     assert_screen 'partition-size';
     if ($args{size}) {
+        if (is_storage_ng) {
+            # maximum size is selected by default
+            send_key 'alt-c';
+            assert_screen 'partition-custom-size-selected';
+            send_key 'alt-s';
+        }
         for (1 .. 10) {
             send_key 'backspace';
         }
@@ -72,12 +103,14 @@ sub addpart {
             send_key 'alt-u';
         }
         else {
+            send_key 'alt-a' if is_storage_ng;    # Select to format partition, not selected by default
+            wait_still_screen 1;
             send_key 'alt-s';
             send_key_until_needlematch "partition-selected-$args{format}-type", 'down';
         }
     }
-    if ($args{fsid}) {    # $args{fsid} will describe needle tag below
-        send_key 'alt-i';    # select File system ID
+    if ($args{fsid}) {                            # $args{fsid} will describe needle tag below
+        send_key 'alt-i';                         # select File system ID
         send_key_until_needlematch "partition-selected-$args{fsid}-type", 'down';
     }
     if ($args{mount}) {
@@ -89,12 +122,12 @@ sub addpart {
         assert_screen 'partition-lvm-encrypt';
         send_key $cmd{next};
         assert_screen 'partition-lvm-password-prompt';
-        send_key 'alt-e';    # select password field
+        send_key 'alt-e';                         # select password field
         type_password;
         send_key 'tab';
         type_password;
     }
-    send_key $cmd{finish};
+    send_key((is_storage_ng) ? $cmd{next} : $cmd{finish});
 }
 
 sub addlv {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -34,6 +34,7 @@ our @EXPORT = qw(
   is_kde_live
   is_leap
   is_tumbleweed
+  is_storage_ng
   select_kernel
   type_string_slow
   type_string_very_slow
@@ -284,6 +285,10 @@ sub is_leap {
     return 0 unless check_var('DISTRI', 'opensuse');
     return 1 if get_var('VERSION', '') =~ /(?:[4-9][0-9]|[0-9]{3,})\.[0-9]/;
     return get_var('VERSION') =~ /^42:S/;
+}
+
+sub is_storage_ng {
+    return get_var('STORAGE_NG');
 }
 
 sub type_string_slow {

--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -206,17 +206,17 @@ sub save_upload_y2logs {
 
 sub post_fail_hook {
     my $self = shift;
-    get_to_console;
-    $self->save_upload_y2logs;
-    if (get_var('FILESYSTEM', 'btrfs') =~ /btrfs/) {
-        assert_script_run 'btrfs filesystem df /mnt | tee /tmp/btrfs-filesystem-df-mnt.txt';
-        assert_script_run 'btrfs filesystem usage /mnt | tee /tmp/btrfs-filesystem-usage-mnt.txt';
-        upload_logs '/tmp/btrfs-filesystem-df-mnt.txt';
-        upload_logs '/tmp/btrfs-filesystem-usage-mnt.txt';
-    }
-    assert_script_run 'df -h';
-    assert_script_run 'df > /tmp/df.txt';
-    upload_logs '/tmp/df.txt';
+    # get_to_console;
+    # $self->save_upload_y2logs;
+    # if (get_var('FILESYSTEM', 'btrfs') =~ /btrfs/) {
+    #     assert_script_run 'btrfs filesystem df /mnt | tee /tmp/btrfs-filesystem-df-mnt.txt';
+    #     assert_script_run 'btrfs filesystem usage /mnt | tee /tmp/btrfs-filesystem-usage-mnt.txt';
+    #     upload_logs '/tmp/btrfs-filesystem-df-mnt.txt';
+    #     upload_logs '/tmp/btrfs-filesystem-usage-mnt.txt';
+    # }
+    # assert_script_run 'df -h';
+    # assert_script_run 'df > /tmp/df.txt';
+    # upload_logs '/tmp/df.txt';
 }
 
 1;

--- a/tests/installation/partitioning_filesystem.pm
+++ b/tests/installation/partitioning_filesystem.pm
@@ -14,6 +14,7 @@
 use strict;
 use base "y2logsstep";
 use testapi;
+use utils 'is_storage_ng';
 
 sub run {
 
@@ -23,8 +24,19 @@ sub run {
     assert_and_click 'edit-proposal-settings';
 
     if (get_var('PARTITIONING_WARNINGS')) {
-        assert_screen 'proposal-will-overwrite-manual-changes';
-        send_key 'alt-y';
+        if (is_storage_ng) {
+            assert_screen 'partition-scheme';
+            # No warnings with storage ng stack
+            record_soft_failure 'bsc#1055756';
+        }
+        else {
+            assert_screen 'proposal-will-overwrite-manual-changes';
+            send_key 'alt-y';
+        }
+    }
+    if (is_storage_ng) {
+        assert_screen 'partition-scheme';
+        send_key $cmd{next};
     }
     # select the combo box
     assert_and_click 'default-root-filesystem';
@@ -32,7 +44,7 @@ sub run {
     # select filesystem
     assert_and_click "filesystem-$fs";
     assert_screen "$fs-selected";
-    assert_and_click 'ok-button';
+    send_key(is_storage_ng() ? 'alt-n' : 'alt-o');
 
     # make sure we're back from the popup
     assert_screen 'edit-proposal-settings';

--- a/tests/installation/partitioning_lvm.pm
+++ b/tests/installation/partitioning_lvm.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 use parent qw(installation_user_settings y2logsstep);
 use testapi;
-use utils 'sle_version_at_least';
+use utils qw(sle_version_at_least is_storage_ng);
 
 sub save_logs_and_resume {
     my $self = shift;
@@ -53,7 +53,7 @@ sub run {
 
     # Storage NG introduces a new partitioning dialog. partitioning.pm detects this by the existence of the "Guided Setup" button
     # and sets the STORAGE_NG variable. This button uses a new hotkey.
-    if (get_var("STORAGE_NG")) {
+    if (is_storage_ng) {
         send_key "alt-g";
     }
     else {
@@ -87,7 +87,7 @@ sub run {
             $collect_logs = 1;
         }
     }
-    elsif (get_var("STORAGE_NG")) {
+    elsif (is_storage_ng) {
         if ($numdisks <= 1) {
             die "Guided workflow does not skip disk selection when only one disk!"
               unless match_has_tag('inst-partitioning-scheme');

--- a/tests/installation/partitioning_togglehome.pm
+++ b/tests/installation/partitioning_togglehome.pm
@@ -14,16 +14,21 @@
 use strict;
 use base "y2logsstep";
 use testapi;
+use utils 'is_storage_ng';
 
 sub run {
-    wait_screen_change { send_key 'alt-d' };    # open proposal settings
+    wait_screen_change { send_key(is_storage_ng() ? 'alt-g' : 'alt-d') };    # open proposal settings
+    if (is_storage_ng) {
+        assert_screen 'partition-scheme';
+        send_key $cmd{next};
+    }
     if (!check_screen 'disabledhome', 0) {
         # detect whether new (Radio Buttons) YaST behaviour
         my $new_radio_buttons = check_screen('inst-partition-radio-buttons', 0);
         send_key $new_radio_buttons ? 'alt-r' : 'alt-p';
     }
     assert_screen 'disabledhome';
-    send_key 'alt-o';                           # close proposal settings
+    send_key(is_storage_ng() ? 'alt-n' : 'alt-o');                           # finish editing settings
 }
 
 1;


### PR DESCRIPTION
New yast storage stack is merged to SLE 15 and tests need to be
adjusted accordingly. Some changes were already applied to opensuse by cwh42.
Now we need to adjust more for SLE15.

Please, merge [NEEDLES](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/465) also.
See [poo#23340](https://progress.opensuse.org/issues/23340).

Fixes btrfs test only: http://10.160.66.147/tests/1914#
and btrfs_warnings:  http://10.160.66.147/tests/1933#

For partitioning_lvm code was adjusted, so only needles have to be merged, commit only replaces get_var with is_storage_ng:
http://10.160.66.147/tests/1940#

partitioning_togglehome module is also fixed now:
http://10.160.66.147/tests/1957

NOTE: as of now changes can be merged, later additional changes will be included in the same PR, check WIP label.