### PR TITLE
Add save_screenshot in addraid fct for debug

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -71,6 +71,7 @@ sub addraid {
     # add
     send_key $cmd{add};
     wait_still_screen;
+    save_screenshot;
     wait_screen_change {
         send_key $cmd{next};
     };


### PR DESCRIPTION
to show potential bad devices selections on RAID* tests.
for investigation RAID0 test for PowerPC failure TW Snapshot 20170823:

The remaining devices for MD2 has 3 disks witg 298MB and 1 with 101MB
while expecting 4 disks of same size.
https://openqa.opensuse.org/tests/474201#step/partitioning_raid/163

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>