### PR TITLE
Fix slow startup of VLC playback again on aarch64

### DIFF
--- a/tests/x11/vlc.pm
+++ b/tests/x11/vlc.pm
@@ -35,7 +35,7 @@ sub run {
     assert_and_click "vlc-play_button";
     # The video is actually 23 seconds long so give a bit of headroom for
     # startup
-    assert_screen "vlc-done-playing", 40;
+    assert_screen "vlc-done-playing", 90;
     send_key "ctrl-q";
 }
 


### PR DESCRIPTION
See https://openqa.opensuse.org/tests/473434

Verification run: https://openqa.opensuse.org/tests/475139