### PR TITLE
Increase timeout for shutdown for sle 15 with gnome

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -748,7 +748,13 @@ sub power_action {
         assert_shutdown_and_restore_system($action);
     }
     else {
-        assert_shutdown if $action eq 'poweroff';
+        # Shutdown takes longer than 60 seconds on SLE 15
+        my $shutdown_timeout = 60;
+        if (sle_version_at_least('15') && check_var('DISTRI', 'sle') && check_var('DESKTOP', 'gnome')) {
+            record_soft_failure('bsc#1055462');
+            $shutdown_timeout *= 3;
+        }
+        assert_shutdown($shutdown_timeout) if $action eq 'poweroff';
         reset_consoles;
     }
 }

--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -206,17 +206,18 @@ sub save_upload_y2logs {
 
 sub post_fail_hook {
     my $self = shift;
-    # get_to_console;
-    # $self->save_upload_y2logs;
-    # if (get_var('FILESYSTEM', 'btrfs') =~ /btrfs/) {
-    #     assert_script_run 'btrfs filesystem df /mnt | tee /tmp/btrfs-filesystem-df-mnt.txt';
-    #     assert_script_run 'btrfs filesystem usage /mnt | tee /tmp/btrfs-filesystem-usage-mnt.txt';
-    #     upload_logs '/tmp/btrfs-filesystem-df-mnt.txt';
-    #     upload_logs '/tmp/btrfs-filesystem-usage-mnt.txt';
-    # }
-    # assert_script_run 'df -h';
-    # assert_script_run 'df > /tmp/df.txt';
-    # upload_logs '/tmp/df.txt';
+    get_to_console;
+    $self->save_upload_y2logs;
+    if (get_var('FILESYSTEM', 'btrfs') =~ /btrfs/) {
+        assert_script_run 'btrfs filesystem df /mnt | tee /tmp/btrfs-filesystem-df-mnt.txt';
+        assert_script_run 'btrfs filesystem usage /mnt | tee /tmp/btrfs-filesystem-usage-mnt.txt';
+        upload_logs '/tmp/btrfs-filesystem-df-mnt.txt';
+        upload_logs '/tmp/btrfs-filesystem-usage-mnt.txt';
+    }
+    assert_script_run 'df -h';
+    assert_script_run 'df > /tmp/df.txt';
+    upload_logs '/tmp/df.txt';
+
 }
 
 1;


### PR DESCRIPTION
Shutdown test fails because SLE is not able to shutdown in 60 seconds
when using gnome. This commit add failure, so test suite which creates
hdd with pre-installed gnome still succeeds.

See [poo#23402](https://progress.opensuse.org/issues/23402) and [bsc#1055462](https://bugzilla.suse.com/show_bug.cgi?id=1055462).

[Verification run](http://10.160.66.147/tests/1972#)