### PR TITLE
Move iputils package from setup network to install LTP

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -48,14 +48,15 @@ sub we_available {
 sub install_dependencies {
     my @deps = qw(git-core make automake autoconf gcc expect libnuma-devel libaio-devel
       numactl flex bison dmapi-devel kernel-default-devel libopenssl-devel libselinux-devel
-      libacl-devel libtirpc-devel keyutils-devel libcap-devel net-tools psmisc acl quota curl);
+      libacl-devel libtirpc-devel keyutils-devel libcap-devel net-tools psmisc acl quota curl
+      iputils);
 
     zypper_call('-t in ' . join(' ', @deps), log => 'install-deps.txt');
 
     my @maybe_deps = qw(net-tools-deprecated gcc-32bit sysstat tpm-tools ntfsprogs);
 
     for my $dep (@maybe_deps) {
-        script_run('zypper -n -t in ' . $dep);
+        script_run('zypper -n -t in ' . $dep . ' | tee');
     }
 }
 

--- a/tests/kernel/ltp_setup_networking.pm
+++ b/tests/kernel/ltp_setup_networking.pm
@@ -19,7 +19,7 @@ use utils;
 
 sub install {
     # utils
-    zypper_call('in wget iptables iputils psmisc tcpdump', log => 'utils.log');
+    zypper_call('in wget iptables psmisc tcpdump', log => 'utils.log');
 
     # clients
     zypper_call('in dhcp-client finger telnet', log => 'clients.log');


### PR DESCRIPTION
Some tests in controllers need the ping utility, so iputils is a dependency of
more than just the networking component.

Also pipe zypper into tee to stop it from printing ANSI characters even when
terminal is set to dumb (https://bugzilla.opensuse.org/show_bug.cgi?id=1055315).

@pevik 