### PR TITLE
For prepare_system_for_update, increase pkcon refresh timeout to 5m

### DIFF
--- a/tests/update/prepare_system_for_update_tests.pm
+++ b/tests/update/prepare_system_for_update_tests.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016 SUSE LLC
+# Copyright (C) 2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -27,7 +27,7 @@ sub run {
     assert_script_run "chown $testapi::username /dev/$testapi::serialdev";
     assert_script_run "echo \"download.use_deltarpm = false\" >> /etc/zypp/zypp.conf";
     assert_script_run "systemctl unmask packagekit";
-    assert_script_run "pkcon refresh", 90;
+    assert_script_run "pkcon refresh", 300;
 }
 
 sub test_flags {


### PR DESCRIPTION
PackageKit is active in the GUI session and will perform various
activities. Meanwhile pkcon refresh will wait in queue, failing the
default timeout of 90s - increase to 5 minutes.

https://progress.opensuse.org/issues/23478
https://openqa.opensuse.org/tests/475405#step/prepare_system_for_update_tests/15
https://openqa.opensuse.org/tests/475401#step/prepare_system_for_update_tests/15