### PR TITLE
Fix boot on non-aarch64 UEFI in case BOOTFROM is not set, only BOOT_HDD_IMAGE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -340,7 +340,7 @@ sub boot_hdd_image {
             loadtest "installation/bootloader_svirt";
         }
     }
-    if (get_var('UEFI') && get_var('BOOTFROM')) {
+    if (get_var('UEFI') && (get_var('BOOTFROM') || get_var('BOOT_HDD_IMAGE'))) {
         loadtest "boot/uefi_bootmenu";
     }
     loadtest "boot/boot_to_desktop";

--- a/tests/boot/uefi_bootmenu.pm
+++ b/tests/boot/uefi_bootmenu.pm
@@ -18,6 +18,10 @@ use utils;
 use bootloader_setup;
 
 sub run {
+    my ($self) = @_;
+    # because of broken firmware, bootindex doesn't work on aarch64 bsc#1022064
+    # selecting a workaround is handled in boot/boot_to_desktop
+    return if (get_var('MACHINE') =~ qr'aarch64' && get_var('BOOT_HDD_IMAGE'));
     tianocore_select_bootloader;
     if (check_var('BOOTFROM', 'd')) {
         send_key_until_needlematch('tianocore-bootmanager-dvd', 'down', 5, 1);


### PR DESCRIPTION
Verification run: http://lord.arch/tests/7253

Related progress issue: https://progress.opensuse.org/issues/15100