### PR TITLE
Fix module selection in scc+all_modules on sle15

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -114,6 +114,13 @@ sub fill_in_registration_data {
                 }
             }
             my @scc_addons = split(/,/, get_var('SCC_ADDONS', ''));
+
+            # Workaround for boo#1056047
+            if (!(check_screen 'scc_module-phub')) {
+                record_soft_failure 'boo#1056047';
+                #find and remove phub
+                @scc_addons = grep { !/phub/ } @scc_addons;
+            }
             for my $addon (@scc_addons) {
                 if (check_var('VIDEOMODE', 'text') || check_var('SCC_REGISTER', 'console')) {
                     # The actions of selecting scc addons have been changed on SP2 or later in textmode

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -314,11 +314,17 @@ if (get_var('ALL_MODULES') && sle_version_at_least('15')) {
 }
 
 if (get_var('ENABLE_ALL_SCC_MODULES') && !get_var('SCC_MODULES')) {
-    if (check_var('ARCH', 'aarch64')) {
-        set_var('SCC_ADDONS', 'pcm,tcm');
+    if (sle_version_at_least('15')) {
+        # let's start with what corresponds to server
+        set_var('SCC_ADDONS', 'base,script,desktop,serverapp,phub');
     }
     else {
-        set_var('SCC_ADDONS', 'phub,asmm,contm,lgm,pcm,tcm,wsm');
+        if (check_var('ARCH', 'aarch64')) {
+            set_var('SCC_ADDONS', 'pcm,tcm');
+        }
+        else {
+            set_var('SCC_ADDONS', 'phub,asmm,contm,lgm,pcm,tcm,wsm');
+        }
     }
 }
 


### PR DESCRIPTION
Fixed the module selection for SLES15 and added a workaround for
boo#1056047 which causes now a softfail

Verification run:
http://10.160.65.204/tests/525

Needles were already merged on GitLab

Set ENABLE_ALL_SCC_MODULES=1