### PR TITLE
Introduce softfails for known issues for autoyast

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -126,6 +126,20 @@ sub run {
                 send_key_until_needlematch 'create-partition-plans-finished', $cmd{ok};
                 next;
             }
+            if (match_has_tag('bsc#1055034') || match_has_tag('bsc#1054895')) {
+                record_soft_failure('bsc#1055034');
+                if (check_screen 'bsc#1054895', 0) {
+                    record_soft_failure('bsc#1054895');
+                }
+                send_key $cmd{ok};
+                next;
+            }
+            if (match_has_tag('bsc#1056356')) {
+                record_soft_failure('bsc#1056356');
+                send_key $cmd{ok};
+                next;
+            }
+
             die "Unknown popup message" unless check_screen('autoyast-known-warning', 0);
 
             # Wait until popup disappears


### PR DESCRIPTION
For the normal installation we work around issues with packages and
problems with patterns. Same issues apply for autoyast installation. To
get valualble results with other issues we need to click Ok button to
proceed with installation.

See [poo#23736](https://progress.opensuse.org/issues/23736).
Please, merge [NEEDLES](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/467).

[Verification run](http://10.160.66.147/tests/1985#live)