### PR TITLE
SLE-15 support SLEnkins openQA wrapper, VIRTIO_CONSOLE can be used

### DIFF
--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -66,8 +66,8 @@ sub configure_dhcp {
     type_string("echo \"STARTMODE='auto'\nBOOTPROTO='dhcp'\n\" > /etc/sysconfig/network/ifcfg-\$NIC;");
     type_string("done\n");
     save_screenshot;
-    type_string("rcnetwork restart\n");
-    type_string("ip addr\n");
+    assert_script_run "rcnetwork restart";
+    assert_script_run "ip addr";
     save_screenshot;
 }
 

--- a/tests/slenkins/login.pm
+++ b/tests/slenkins/login.pm
@@ -21,7 +21,7 @@ use base 'basetest';
 use testapi;
 
 sub run {
-    select_console('root-console');
+    select_console(get_var('VIRTIO_CONSOLE') ? 'root-virtio-terminal' : 'root-console');
 }
 
 sub test_flags {

--- a/tests/slenkins/slenkins_node.pm
+++ b/tests/slenkins/slenkins_node.pm
@@ -86,9 +86,9 @@ sub run {
         chmod 700 /root/.ssh
         chmod 600 /home/testuser/.ssh/*
         chmod 700 /home/testuser/.ssh
-        systemctl disable SuSEfirewall2
-        systemctl stop SuSEfirewall2
-        rcsshd restart
+        systemctl disable SuSEfirewall2 || true # SLE-15 doesn't have SuSEfirewall2 pkgs anymore
+        systemctl stop SuSEfirewall2 || true    # SLE-15 doesn't have SuSEfirewall2 pkgs anymore
+        systemctl restart sshd
     ";
     script_output($conf_script, 100);
 

--- a/tests/support_server/login.pm
+++ b/tests/support_server/login.pm
@@ -30,8 +30,7 @@ sub run {
 
     # the supportserver image can be different version than the currently tested system
     # so try to login without use of needles
-    select_console 'root-console';
-
+    select_console(get_var('VIRTIO_CONSOLE') ? 'root-virtio-terminal' : 'root-console');
 }
 
 sub test_flags {


### PR DESCRIPTION
This commit brings support for SLE-15 in SLEnkins openQA wrapper and it is backward compatible with SLE-12.

In addition VIRTIO_CONSOLE=1 can be used - testing is bit faster then. 

Tested on SLE-15 LeanOS http://dhcp62.suse.cz/tests/1634#step/1_default_autogenerated/2 (test is failing because "yast2 firewall" module not available.

Tested on SLE-12-SP3 as well http://dhcp62.suse.cz/tests/1352#step/1_default_autogenerated/2

Complete support for SLE-15 would need working test "create_hdd_minimal_base+sdk" and few modification for slenkins-* tests:
* VIRTIO_CONSOLE=1 (maybe even NOVIDEO=1 which is kind of useless over serial)
* remove ISO_1 (replaced by ADDONURL_SDK in create_hdd_minimal_base+sdk - repo is added in image already)
* modification of HDD_1 value
* modification of START_AFTER_TEST=create_hdd_minimal_base+sdk
