### PR TITLE
Port testsuite regression-documentation to Tumbleweed

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -49,6 +49,7 @@ our @EXPORT = qw(
   load_filesystem_tests
   load_wicked_tests
   load_iso_in_external_tests
+  load_x11regression_documentation
 );
 
 sub init_main {
@@ -592,6 +593,36 @@ sub load_iso_in_external_tests {
     loadtest "boot/boot_to_desktop";
     loadtest "console/copy_iso_to_external_drive";
     loadtest "x11/reboot_and_install";
+}
+
+sub load_x11regression_documentation {
+    if (check_var("DESKTOP", "gnome")) {
+        loadtest "x11regressions/gnote/gnote_first_run";
+        loadtest "x11regressions/gnote/gnote_link_note";
+        loadtest "x11regressions/gnote/gnote_rename_title";
+        loadtest "x11regressions/gnote/gnote_undo_redo";
+        loadtest "x11regressions/gnote/gnote_edit_format";
+        loadtest "x11regressions/gnote/gnote_search_all";
+        loadtest "x11regressions/gnote/gnote_search_body";
+        loadtest "x11regressions/gnote/gnote_search_title";
+        loadtest "x11regressions/evince/evince_open";
+        loadtest "x11regressions/evince/evince_view";
+        loadtest "x11regressions/evince/evince_rotate_zoom";
+        loadtest "x11regressions/evince/evince_find";
+        loadtest "x11regressions/gedit/gedit_launch";
+        loadtest "x11regressions/gedit/gedit_save";
+        loadtest "x11regressions/gedit/gedit_about";
+        if (!is_tumbleweed) {
+            loadtest "x11regressions/libreoffice/libreoffice_mainmenu_favorites";
+            loadtest "x11regressions/evolution/evolution_prepare_servers";
+            loadtest "x11regressions/libreoffice/libreoffice_pyuno_bridge";
+        }
+        loadtest "x11regressions/libreoffice/libreoffice_mainmenu_components";
+        loadtest "x11regressions/libreoffice/libreoffice_recent_documents";
+        loadtest "x11regressions/libreoffice/libreoffice_default_theme";
+        loadtest "x11regressions/libreoffice/libreoffice_open_specified_file";
+        loadtest "x11regressions/libreoffice/libreoffice_double_click_file";
+    }
 }
 
 1;

--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -78,7 +78,7 @@ sub cleanup_libreoffice_specified_file {
     x11_start_program("xterm");
     assert_script_run("rm -rf /home/$username/Documents/ooo-test-doc-types*");
     wait_still_screen;
-    type_string("ls -l /home/$username/Documents");
+    type_string_slow "ls -l /home/$username/Documents";
     send_key "ret";
     wait_screen_change {
         assert_screen("libreoffice-find-no-tar-file");
@@ -92,8 +92,16 @@ sub cleanup_libreoffice_specified_file {
 sub cleanup_libreoffice_recent_file {
 
     x11_start_program("libreoffice");
+    wait_still_screen 3;
     send_key "alt-f";
-    send_key "alt-u";
+    if (is_tumbleweed) {
+        send_key 'down';
+        wait_still_screen 3;
+        send_key 'u';
+    }
+    else {
+        send_key "alt-u";
+    }
     assert_screen("libreoffice-recent-documents");
     send_key_until_needlematch("libreoffice-clear-list", "down");
     send_key "ret";
@@ -102,36 +110,51 @@ sub cleanup_libreoffice_recent_file {
 
 }
 
+sub open_libreoffice_options {
+    if (is_tumbleweed) {
+        send_key 'alt-f12';
+    }
+    else {
+        send_key "alt-t";
+        wait_still_screen 3;
+        send_key "alt-o";
+    }
+}
+
 # check libreoffice dialog windows setting- "gnome dialog" or "libreoffice dialog"
 sub check_libreoffice_dialogs {
+    my ($self) = shift;
 
     # make sure libreoffice dialog option is disabled status
-    send_key "alt-t";
-    send_key "alt-o";
+    $self->open_libreoffice_options;
+
     assert_screen("ooffice-tools-options");
     send_key_until_needlematch('libreoffice-options-general', 'down');
     assert_screen("libreoffice-general-dialogs-disabled");
     send_key "alt-o";
+    wait_still_screen 3;
     send_key "alt-o";
     assert_screen("libreoffice-gnome-dialogs");
     send_key "alt-c";
+    wait_still_screen 3;
 
     # enable libreoffice dialog
-    send_key "alt-t";
-    send_key "alt-o";
+    $self->open_libreoffice_options;
     assert_screen("libreoffice-options-general");
     send_key "alt-u";
     assert_screen("libreoffice-general-dialogs-enabled");
     send_key "alt-o";
+    wait_still_screen 3;
     send_key "alt-o";
     assert_screen("libreoffice-specific-dialogs");
     send_key "alt-c";
+    wait_still_screen 3;
 
     # restore the default setting
-    send_key "alt-t";
-    send_key "alt-o";
+    $self->open_libreoffice_options;
     assert_screen("libreoffice-options-general");
     send_key "alt-u";
+    wait_still_screen 3;
     send_key "alt-o";
 
 }
@@ -749,8 +772,7 @@ sub gnote_search_and_close {
 
 # remove the created new note
 sub cleanup_gnote {
-    wait_screen_change { send_key 'ctrl-tab' };    #jump to toolbar
-    send_key 'ret';                                #back to all notes interface
+    send_key 'esc';    #back to all notes interface
     send_key_until_needlematch 'gnote-new-note-matched', 'down', 6;
     wait_screen_change { send_key 'delete' };
     wait_screen_change { send_key 'tab' };

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -759,6 +759,10 @@ elsif (get_var("REGRESSION")) {
         loadtest "shutdown/grub_set_bootargs";
         loadtest "shutdown/shutdown";
     }
+    elsif (check_var("REGRESSION", "documentation")) {
+        loadtest "boot/boot_to_desktop";
+        load_x11regression_documentation();
+    }
 }
 elsif (get_var("MEDIACHECK")) {
     loadtest "installation/mediacheck";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -416,36 +416,6 @@ sub load_x11regression_gnome {
     }
 }
 
-sub load_x11regression_documentation {
-    if (check_var("DESKTOP", "gnome")) {
-        loadtest "x11regressions/gnote/gnote_first_run";
-        loadtest "x11regressions/gnote/gnote_link_note";
-        loadtest "x11regressions/gnote/gnote_rename_title";
-        loadtest "x11regressions/gnote/gnote_undo_redo";
-        loadtest "x11regressions/gnote/gnote_edit_format";
-        loadtest "x11regressions/gnote/gnote_search_all";
-        loadtest "x11regressions/gnote/gnote_search_body";
-        loadtest "x11regressions/gnote/gnote_search_title";
-        loadtest "x11regressions/evince/evince_open";
-        loadtest "x11regressions/evince/evince_view";
-        loadtest "x11regressions/evince/evince_rotate_zoom";
-        loadtest "x11regressions/evince/evince_find";
-        loadtest "x11regressions/gedit/gedit_launch";
-        loadtest "x11regressions/gedit/gedit_save";
-        if (not get_var("SP2ORLATER")) {
-            loadtest "x11regressions/gedit/gedit_about";
-        }
-        loadtest "x11regressions/libreoffice/libreoffice_mainmenu_favorites";
-        loadtest "x11regressions/libreoffice/libreoffice_mainmenu_components";
-        loadtest "x11regressions/libreoffice/libreoffice_recent_documents";
-        loadtest "x11regressions/libreoffice/libreoffice_default_theme";
-        loadtest "x11regressions/evolution/evolution_prepare_servers";
-        loadtest "x11regressions/libreoffice/libreoffice_pyuno_bridge";
-        loadtest "x11regressions/libreoffice/libreoffice_open_specified_file";
-        loadtest "x11regressions/libreoffice/libreoffice_double_click_file";
-    }
-}
-
 sub load_x11regression_message {
     if (check_var("DESKTOP", "gnome")) {
         loadtest "x11regressions/empathy/empathy_aim";

--- a/tests/x11regressions/gedit/gedit_about.pm
+++ b/tests/x11regressions/gedit/gedit_about.pm
@@ -20,30 +20,15 @@ sub run {
     x11_start_program("gedit");
 
     # check about window
-    wait_screen_change {
-        send_key "alt-h";
-    };
-    send_key "a";
+    assert_and_click 'gedit-options-icon';
+    assert_and_click 'gedit-options-about';
     assert_screen 'gedit-help-about';
 
-    # check license
-    assert_screen 'gedit-about-license';
-
-    # check website link
-    assert_and_click 'gedit-about-link';
-    # give a little time to open and load website
-    assert_screen 'gedit-open-firefox', 60;
-    wait_screen_change {
-        send_key "ctrl-q";
-    };
-
     # check credits
-    send_key "alt-r";
-    assert_screen 'gedit-about-credits';
-    send_key "alt-r";    # close credit
+    assert_and_click 'gedit-about-credits';
+    assert_screen 'gedit-about-authors';
 
-    assert_screen 'gedit-about-license';
-    send_key "alt-c";    # close about
+    send_key "esc";    # close about
     assert_screen 'gedit-launched';
     send_key "ctrl-q";
 }

--- a/tests/x11regressions/gedit/gedit_save.pm
+++ b/tests/x11regressions/gedit/gedit_save.pm
@@ -47,10 +47,11 @@ sub run {
     # save and quit
     wait_screen_change { send_key "ctrl-s"; };
     send_key "ctrl-q";
+    wait_still_screen 3;
 
     # open saved file to validate
     x11_start_program("gedit " . "test.txt");
-    assert_screen 'gedit-saved-file', 3;
+    assert_screen 'gedit-saved-file';
     wait_screen_change { send_key "ctrl-q"; };
 
     # clean up saved file

--- a/tests/x11regressions/gnote/gnote_first_run.pm
+++ b/tests/x11regressions/gnote/gnote_first_run.pm
@@ -14,12 +14,24 @@
 use base "x11regressiontest";
 use strict;
 use testapi;
+use utils;
 
 sub run {
+    if (is_tumbleweed) {
+        select_console('root-console');
+        pkcon_quit;
+        zypper_call('in gnote');
+        select_console('x11');
+    }
     x11_start_program("gnote");
     assert_screen "gnote-first-launched", 10;
 
     send_key "ctrl-w";
+}
+
+# add milestone flag to save gnote installation in lastgood vm snapshot
+sub test_flags {
+    return {milestone => 1} if (is_tumbleweed);
 }
 
 1;

--- a/tests/x11regressions/gnote/gnote_link_note.pm
+++ b/tests/x11regressions/gnote/gnote_link_note.pm
@@ -15,6 +15,7 @@
 use base 'x11regressiontest';
 use strict;
 use testapi;
+use utils;
 
 
 sub run {
@@ -32,13 +33,13 @@ sub run {
     };
     wait_screen_change { send_key 'ret' };
     wait_screen_change { send_key 'down' };
-    if (get_var('SP2ORLATER')) {
+    if (get_var('SP2ORLATER') || is_tumbleweed) {
         wait_screen_change { send_key 'ret' };
     }
     assert_screen 'gnote-what-link-here';
     wait_screen_change { send_key 'esc' };
     #close the note "Start Here"
-    wait_screen_change { send_key 'ctrl-w' };
+    wait_screen_change { send_key 'ctrl-w' } if (!is_tumbleweed);
     $self->cleanup_gnote;
 }
 

--- a/tests/x11regressions/gnote/gnote_undo_redo.pm
+++ b/tests/x11regressions/gnote/gnote_undo_redo.pm
@@ -18,20 +18,21 @@ use testapi;
 
 
 sub undo_redo_once {
-    assert_screen 'gnote-new-note-1', 5;
+    assert_screen 'gnote-new-note-1';
     send_key "ctrl-z";    #undo
-    assert_screen 'gnote-new-note', 5;
+    assert_screen 'gnote-new-note';
     send_key "ctrl-shift-z";    #redo
+    wait_still_screen 3;
     send_key "left";            #unselect text
-    assert_screen 'gnote-new-note-1', 5;
+    assert_screen 'gnote-new-note-1';
 }
 
 sub run {
     my ($self) = @_;
     x11_start_program("gnote");
-    assert_screen "gnote-first-launched", 10;
+    assert_screen "gnote-first-launched";
     send_key "ctrl-n";
-    assert_screen 'gnote-new-note', 5;
+    assert_screen 'gnote-new-note';
     type_string "opensuse\nOPENSUSE\n";
     $self->undo_redo_once;
 
@@ -39,6 +40,7 @@ sub run {
     send_key "ctrl-tab";    #jump to toolbar
     send_key "ret";         #back to all notes interface
     send_key_until_needlematch 'gnote-new-note-matched', 'down', 6;
+    wait_still_screen 3;
     send_key "ret";
     $self->undo_redo_once;
 
@@ -49,7 +51,7 @@ sub run {
     send_key "delete";
     send_key "tab";
     send_key "ret";
-    assert_screen "gnote-first-launched", 5;
+    assert_screen "gnote-first-launched";
     send_key "ctrl-w";
 }
 

--- a/tests/x11regressions/libreoffice/libreoffice_default_theme.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_default_theme.pm
@@ -16,18 +16,29 @@ use testapi;
 use utils;
 use strict;
 
-
-sub run {
-    # Check LO default theme on standard GUI toolkit var
+sub check_lo_theme {
     x11_start_program("ooffice");
     assert_screen 'welcome-to-libreoffice';
-    send_key "alt-t";
-    assert_screen 'ooffice-menus-tools';
-    send_key "o";
+    if (is_tumbleweed) {
+        send_key 'alt-f12';
+    }
+    else {
+        send_key "alt-t";
+        assert_screen 'ooffice-menus-tools';
+        send_key "o";
+    }
     assert_screen 'ooffice-tools-options';
     send_key_until_needlematch 'ooffice-tools-options-view', 'down';
     send_key "esc";
+    wait_still_screen 3;
     send_key "ctrl-q";    # Quit LO
+}
+
+sub run {
+    my $self = shift;
+
+    # Check LO default theme on standard GUI toolkit var
+    $self->check_lo_theme;
 
     # Set LO GUI toolkit var to none
     x11_start_program("xterm");
@@ -39,16 +50,7 @@ sub run {
     send_key 'alt-f4';    # Quit xterm
 
     # Check LO default theme on none standard GUI toolkit var
-    x11_start_program("ooffice");
-    assert_screen 'welcome-to-libreoffice';
-    send_key "alt-t";
-    assert_screen 'ooffice-menus-tools';
-    send_key "o";
-    assert_screen 'ooffice-tools-options';
-    send_key_until_needlematch 'ooffice-tools-options-view', 'down';
-    send_key "esc";
-    wait_still_screen;
-    send_key "ctrl-q";    # Quit LO
+    $self->check_lo_theme;
 
     # Unset LO GUI toolkit var
     x11_start_program("xterm");

--- a/tests/x11regressions/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_mainmenu_components.pm
@@ -13,12 +13,13 @@
 use base "x11regressiontest";
 use strict;
 use testapi;
+use utils;
 
 # open desktop mainmenu and click office
 sub open_mainmenu {
     my $self = shift;
 
-    wait_still_screen;
+    wait_still_screen 3;
     send_key "alt-f1";
     assert_screen 'test-desktop_mainmenu-1';
     assert_and_click 'mainmenu-office';
@@ -27,7 +28,7 @@ sub open_mainmenu {
 
 # enter 'Activities overview'
 sub open_overview {
-    wait_still_screen;
+    wait_still_screen 3;
     send_key "super";
     assert_screen 'tracker-mainmenu-launched';
 }
@@ -52,79 +53,80 @@ sub select_base_and_cleanup {
 sub run {
     my $self = shift;
 
-    # launch components from mainmenu
-    $self->open_mainmenu();
-    assert_and_click 'mainmenu-office-lo';    #open lo
-    assert_screen 'welcome-to-libreoffice';
-    send_key "ctrl-q";                        #close lo
+    if (!is_tumbleweed) {
+        # launch components from mainmenu
+        $self->open_mainmenu();
+        assert_and_click 'mainmenu-office-lo';    #open lo
+        assert_screen 'welcome-to-libreoffice';
+        send_key "ctrl-q";                        #close lo
 
-    $self->open_mainmenu();
-    assert_and_click 'mainmenu-office-base';    #open base
-    select_base_and_cleanup;
+        $self->open_mainmenu();
+        assert_and_click 'mainmenu-office-base';    #open base
+        select_base_and_cleanup;
 
-    $self->open_mainmenu();
-    assert_and_click 'mainmenu-office-calc';    #open calc
-    assert_screen 'test-oocalc-1';
-    send_key "ctrl-q";                          #close calc
+        $self->open_mainmenu();
+        assert_and_click 'mainmenu-office-calc';    #open calc
+        assert_screen 'test-oocalc-1';
+        send_key "ctrl-q";                          #close calc
 
-    $self->open_mainmenu();
-    assert_and_click 'mainmenu-office-draw';    #open draw
-    assert_screen 'oodraw-launched';
-    send_key "ctrl-q";                          #close draw
+        $self->open_mainmenu();
+        assert_and_click 'mainmenu-office-draw';    #open draw
+        assert_screen 'oodraw-launched';
+        send_key "ctrl-q";                          #close draw
 
-    $self->open_mainmenu();
-    assert_and_click 'mainmenu-office-impress';    #open impress
-    assert_screen [qw(ooimpress-select-a-template ooimpress-launched)];
-    if (match_has_tag 'ooimpress-select-a-template') {
-        send_key 'alt-f4';                         # close impress template window
-        assert_screen 'ooimpress-launched';
+        $self->open_mainmenu();
+        assert_and_click 'mainmenu-office-impress';    #open impress
+        assert_screen [qw(ooimpress-select-a-template ooimpress-launched)];
+        if (match_has_tag 'ooimpress-select-a-template') {
+            send_key 'alt-f4';                         # close impress template window
+            assert_screen 'ooimpress-launched';
+        }
+        send_key "ctrl-q";                             #close impress
+
+        $self->open_mainmenu();
+        assert_and_click 'mainmenu-office-writer';     #open writer
+        assert_screen 'test-ooffice-1';
+        send_key "ctrl-q";                             #close writer
     }
-    send_key "ctrl-q";                             #close impress
-
-    $self->open_mainmenu();
-    assert_and_click 'mainmenu-office-writer';     #open writer
-    assert_screen 'test-ooffice-1';
-    send_key "ctrl-q";                             #close writer
 
     # launch components from Activities overview
     $self->open_overview();
-    type_string "base";                            #open base
+    type_string "base";                                #open base
     assert_screen 'overview-office-base';
     send_key "ret";
     select_base_and_cleanup;
 
     $self->open_overview();
-    type_string "calc";                            #open calc
-    assert_screen 'overview-office-calc';
-    send_key "ret";
+    type_string "calc";                                #open calc
+    assert_and_click 'overview-office-calc';
     assert_screen 'test-oocalc-1';
-    send_key "ctrl-q";                             #close calc
+    send_key "ctrl-q";                                 #close calc
 
     $self->open_overview();
-    type_string "draw";                            #open draw
+    type_string "draw";                                #open draw
     assert_screen 'overview-office-draw';
     send_key "ret";
     assert_screen 'oodraw-launched';
-    send_key "ctrl-q";                             #close draw
+    send_key "ctrl-q";                                 #close draw
 
     $self->open_overview();
-    type_string "impress";                         #open impress
+    type_string "impress";                             #open impress
     assert_screen 'overview-office-impress';
     send_key "ret";
     assert_screen [qw(ooimpress-select-a-template ooimpress-launched)];
     if (match_has_tag 'ooimpress-select-a-template') {
-        send_key 'alt-f4';                         # close impress template window
+        send_key 'alt-f4';                             # close impress template window
         assert_screen 'ooimpress-launched';
     }
-    send_key "ctrl-q";                             #close impress
+    send_key "ctrl-q";                                 #close impress
 
     $self->open_overview();
-    type_string "writer";                          #open writer
+    type_string "writer";                              #open writer
     assert_screen 'overview-office-writer';
     send_key "ret";
     assert_screen 'test-ooffice-1';
     assert_and_click 'ooffice-writing-area', 'left', 10;
-    send_key "ctrl-q";                             #close writer
+    send_key "ctrl-q";                                 #close writer
 }
 
 1;

--- a/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
@@ -13,6 +13,7 @@
 use base "x11regressiontest";
 use strict;
 use testapi;
+use utils;
 
 sub run {
     my $self = shift;
@@ -33,11 +34,11 @@ sub run {
         wait_still_screen 3;
         send_key "ctrl-l";
         save_screenshot;
-        type_string "/home/$username/Documents/ooo-test-doc-types/test.$tag\n";
+        type_string_slow "/home/$username/Documents/ooo-test-doc-types/test.$tag\n";
         wait_still_screen 3;
-        assert_screen("libreoffice-test-$tag", 90);
+        assert_screen("libreoffice-test-$tag", 120);
         # Close every 3 files to reduce the VM's burden
-        if ($i % 3 == 0) { send_key_until_needlematch('libreoffice-test-doc', 'alt-f4', 3, 5); }
+        if ($i % 3 == 0) { send_key_until_needlematch('libreoffice-test-doc', 'alt-f4', 5, 10); }
         $i++;
     }
     if (!check_screen("generic-desktop")) {

--- a/tests/x11regressions/libreoffice/libreoffice_recent_documents.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_recent_documents.pm
@@ -14,6 +14,7 @@
 use base "x11regressiontest";
 use strict;
 use testapi;
+use utils;
 
 sub run {
     # Edit file hello.odt using oowriter
@@ -37,7 +38,14 @@ sub run {
     assert_screen 'test-ooffice-1';
     send_key "alt-f";
     assert_screen 'oowriter-menus-file';
-    send_key "ctrl-u";
+    if (is_tumbleweed) {
+        send_key 'down';
+        wait_still_screen 3;
+        send_key 'u';
+    }
+    else {
+        send_key "ctrl-u";
+    }
     assert_screen 'oowriter-menus-file-recentDucuments';
     send_key_until_needlematch("libreoffice-clear-list", "down");
     send_key "ret";


### PR DESCRIPTION
- Extract load_x11regression_documentation to main_common
- Update main.pm of SLE and openSUSE
- Update 9 cases including gedit, gnote, libreoffice since TW uses the newer version
- We should also add testsuite of regression-documentation to o3:
  BOOTFROM=c, DESKTOP=gnome,
  HDD_1=openSUSE-%VERSION%-%BUILD%-%ARCH%_for_regression.qcow2,
  REGRESSION=documentation, START_AFTER_TEST=regression-installation

  see also: poo#23780

Validation Test: http://10.67.17.30/tests/970