### PR TITLE
Adjust partitioning_firstdisk test module for storage_ng

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -68,6 +68,7 @@ sub init_cmd {
       package p
       bootloader b
       entiredisk alt-e
+      guidedsetup alt-g
     );
 
     if (check_var('INSTLANG', "de_DE")) {

--- a/tests/installation/partitioning_filesystem.pm
+++ b/tests/installation/partitioning_filesystem.pm
@@ -44,7 +44,7 @@ sub run {
     # select filesystem
     assert_and_click "filesystem-$fs";
     assert_screen "$fs-selected";
-    send_key(is_storage_ng() ? 'alt-n' : 'alt-o');
+    send_key(is_storage_ng() ? $cmd{next} : 'alt-o');
 
     # make sure we're back from the popup
     assert_screen 'edit-proposal-settings';

--- a/tests/installation/partitioning_firstdisk.pm
+++ b/tests/installation/partitioning_firstdisk.pm
@@ -7,18 +7,34 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: New test to take the first disk
+# Summary: New test to take the first disk
 #    Otherwise the partitioning proposal will use a free disk, which makes
 #    rebooting a game of chance on real hardware
-# G-Maintainer: Stephan Kulow <coolo@suse.de>
+# Maintainer: Stephan Kulow <coolo@suse.de>
 
 use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
+use utils 'is_storage_ng';
 
-sub run {
+sub take_first_disk_storage_ng {
+    return unless is_storage_ng;
+    send_key $cmd{guidedsetup};    # select guided setup
+    assert_screen 'select-hard-disks';
+    send_key 'alt-e';              # Unselect second drive
+    assert_screen 'select-hard-disks-one-selected';
+    send_key $cmd{next};
+    assert_screen 'partition-scheme';
+    send_key $cmd{next};
+    # select btrfs file system
+    assert_and_click 'default-root-filesystem';
+    assert_and_click "filesystem-btrfs";
+    assert_screen "btrfs-selected";
+    send_key $cmd{next};
+}
 
+sub take_first_disk {
     # create partitioning
     send_key $cmd{createpartsetup};
     assert_screen 'prepare-hard-disk';
@@ -33,6 +49,14 @@ sub run {
         send_key 'alt-e';
     };
     send_key $cmd{next};
+}
+
+sub run {
+    if (is_storage_ng) {
+        take_first_disk_storage_ng;
+        return 1;
+    }
+    take_first_disk;
 }
 
 1;


### PR DESCRIPTION
With storage ng we have new flow for guided setup, so test module has to
be adjusted. We have ipmi specific test suite which requires to select
only one disk for installation. Flow of the interface has been changed with
storage ng.

Please, merge [NEEDLES](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/470)
See [poo#23340](https://progress.opensuse.org/issues/23340).

Verification run was done using normal worker (not ipmi), using multiple drives and modifying main.pm:
http://10.160.66.147/tests/1993

