### PR TITLE
Adjust tests for sle 15 welcome screen

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -195,6 +195,16 @@ sub deal_with_dependency_issues {
     }
 }
 
+sub verify_license_has_to_be_accepted {
+    # license+lang
+    if (get_var('HASLICENSE')) {
+        send_key $cmd{next};
+        assert_screen 'license-not-accepted';
+        wait_screen_change { send_key $cmd{ok} };
+        send_key $cmd{accept};    # accept license
+    }
+}
+
 sub save_upload_y2logs {
     my ($self) = shift;
     assert_script_run 'sed -i \'s/^tar \(.*$\)/tar --warning=no-file-changed -\1 || true/\' /usr/sbin/save_y2logs';

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -593,8 +593,9 @@ sub load_inst_tests {
             loadtest "installation/disk_space_fill";
         }
     }
-    if (sle_version_at_least('15') && !is_staging) {
-        loadtest "installation/select_products_sle";
+    if (sle_version_at_least('15')) {
+        loadtest "installation/select_products_sle" unless is_staging;
+        loadtest "installation/accept_license";
     }
     if (check_var('SCC_REGISTER', 'installation')) {
         loadtest "installation/scc_registration";

--- a/tests/installation/accept_license.pm
+++ b/tests/installation/accept_license.pm
@@ -1,0 +1,31 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Test module is used to accept license during SLE 15 installation
+#          Should be improved to be more product specific
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
+
+use strict;
+use base "y2logsstep";
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->verify_license_has_to_be_accepted;
+    send_key $cmd{next};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -15,9 +15,10 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
-use utils 'ensure_fullscreen';
+use utils qw(ensure_fullscreen sle_version_at_least);
 
 sub run {
+    my ($self) = @_;
     my $iterations;
 
     my @welcome_tags = ('inst-welcome-confirm-self-update-server', 'scc-invalid-url');
@@ -66,12 +67,11 @@ sub run {
     wait_still_screen(3);
 
     # license+lang
-    if (get_var('HASLICENSE')) {
-        send_key $cmd{next};
-        assert_screen 'license-not-accepted';
-        wait_screen_change { send_key $cmd{ok} };
-        send_key $cmd{accept};    # accept license
+    # On sle 15 license is on different screen
+    unless (sle_version_at_least('15')) {
+        $self->verify_license_has_to_be_accepted;
     }
+
     assert_screen 'languagepicked';
     send_key $cmd{next};
     if (!check_var('INSTLANG', 'en_US') && check_screen 'langincomplete', 1) {


### PR DESCRIPTION
With new architecture we show license after product is selected. Hence,
it cannot be shown before this step. This adjusts flow for SLE15.

Note, this already will fix major part of failing tests, but not all.
[NEEDLES](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/471)

[Verification run](http://10.160.66.147/tests/1997#)