### PR TITLE
Add assert_screen before processing license screen on SLE15

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -595,7 +595,7 @@ sub load_inst_tests {
     }
     if (sle_version_at_least('15')) {
         loadtest "installation/select_products_sle" unless is_staging;
-        loadtest "installation/accept_license";
+        loadtest "installation/accept_license" if get_var('HASLICENSE');
     }
     if (check_var('SCC_REGISTER', 'installation')) {
         loadtest "installation/scc_registration";

--- a/tests/installation/accept_license.pm
+++ b/tests/installation/accept_license.pm
@@ -23,6 +23,7 @@ use testapi;
 
 sub run {
     my ($self) = @_;
+    assert_screen 'license-agreement';
     $self->verify_license_has_to_be_accepted;
     send_key $cmd{next};
 }


### PR DESCRIPTION
In text mode there is an issue that we press Next button too early,
before screen is loaded. We added assertion of the screen to avoid
such a scenario.

See [poo#23736](https://progress.opensuse.org/issues/)
Please, merge set of [NEEDLES](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/473)

Verification runs:
[textmode](http://10.160.66.147/tests/2000)
[x11](http://10.160.66.147/tests/2001)