### PR TITLE
Replace shortcut with click to unselect drive

### DIFF
--- a/tests/installation/partitioning_firstdisk.pm
+++ b/tests/installation/partitioning_firstdisk.pm
@@ -22,7 +22,7 @@ sub take_first_disk_storage_ng {
     return unless is_storage_ng;
     send_key $cmd{guidedsetup};    # select guided setup
     assert_screen 'select-hard-disks';
-    send_key 'alt-e';              # Unselect second drive
+    assert_and_click 'hard-disk-dev-sdb-selected';    # Unselect second drive
     assert_screen 'select-hard-disks-one-selected';
     send_key $cmd{next};
     assert_screen 'partition-scheme';


### PR DESCRIPTION
For ipmi installation, so un-select drive we've used key shortcut,
however it was different in local run with normal installation but 2
drives. So replace it with assert_and_click to be independent from
changes of shortcuts. Needle was created using webui needle editor.