### PR TITLE
Do not load accept_license test module on staging

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -566,8 +566,8 @@ sub load_inst_tests {
             loadtest "installation/disk_space_fill";
         }
     }
-    if (sle_version_at_least('15')) {
-        loadtest "installation/select_products_sle" unless is_staging;
+    if (sle_version_at_least('15') && !is_staging()) {
+        loadtest "installation/select_products_sle";
         loadtest "installation/accept_license" if get_var('HASLICENSE');
     }
     if (check_var('SCC_REGISTER', 'installation')) {


### PR DESCRIPTION
Now in our build of SLE 15 we have license agreement shown after product
selection. On staging we don't have product selection and license
agreement is shown on welcome screen as before.

See https://openqa.suse.de/tests/1140379#