### PR TITLE
[WIP] Adjust tests for extra screen when disk is not formatted

### DIFF
--- a/tests/installation/partitioning_filesystem.pm
+++ b/tests/installation/partitioning_filesystem.pm
@@ -35,6 +35,12 @@ sub run {
         }
     }
     if (is_storage_ng) {
+        # On s390x due to workaround we don't format drive, so select disks screen appears there
+        # Using check_screen not to break test when bug is fixed
+        if (get_var('FORMAT_DASD_YAST') && check_screen('select-hard-disks', 5)) {
+            record_soft_failure('bsc#1055871');
+            send_key $cmd{next};
+        }
         assert_screen 'partition-scheme';
         send_key $cmd{next};
     }


### PR DESCRIPTION
For disk_activation test suite on we use cmd tool to get same behavior
which doesn't work within installer yet. With s390x-zVM-vswitch-l2
worker we have variable FORMAT_DASD_YAST set to 1 to trigger this
behavior.
This leads to new screen during installation, which we need to process.

Cannot provide verification run, as specific worker.