### PR TITLE
Verify mouse on first partition if PowerPC RAID tests

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -299,6 +299,12 @@ sub run {
         assert_screen 'partitioning_raid-menu_add_raid';
         setraidlevel(1);
         assert_screen 'partitioning_raid-raid_1-selected';
+        if (get_var('OFW')) {
+            # verify that start at first partition for PowerPC
+            send_key 'down';
+            send_key 'up';
+            assert_screen 'partitioning_raid-devices_first_partition';
+        }
         addraid(2);
 
         assert_screen 'partition-format';


### PR DESCRIPTION
when starting to select the MD1 partitions

For unknown reason the RAID* tests are starting to fail
with bad selection of two first partitions.
But requesting down/up keys is sufficient to resolve the problem.

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>

This need the needle from https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/262