### PR TITLE
x11/gnomeapps: Adjust for GNOME 3.26

### DIFF
--- a/tests/x11/gnomeapps/gnome_recipes.pm
+++ b/tests/x11/gnomeapps/gnome_recipes.pm
@@ -17,6 +17,10 @@ use utils;
 
 sub run {
     assert_gui_app('gnome-recipes');
+    # assert_gui_app pressed alt-f4 to close the app, but that might have hit only
+    # the '20th aniiversary gift' popup dialog
+    # press again alt-f4, to close the application
+    send_key('alt-f4');
 }
 
 1;

--- a/tests/x11/gnomeapps/polari.pm
+++ b/tests/x11/gnomeapps/polari.pm
@@ -17,7 +17,9 @@ use utils;
 
 sub run {
     assert_gui_app('polari');
-    # Polari asks to run in backgroun or quit on pressing alt-f4
+    # assert_gui_app pressed alt-f4, but that closed 'only' the 'welcome dialog'
+    # press once again alt-f4
+    send_key('alt-f4');
     assert_and_click('polari-quit');
 }
 


### PR DESCRIPTION
No extra / special handling done to care about versions, as x11/gnomeapps is only used in case of gnome_next - so all those apps are always 'the latest version'