### PR TITLE
Add SUSEConnect command line register function

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -29,6 +29,7 @@ our @EXPORT = qw(
   registration_bootloader_params
   yast_scc_registration
   skip_registration
+  get_addon_fullname
   %SLE15_MODULES
   %SLE15_DEFAULT_MODULES
 );
@@ -385,6 +386,27 @@ sub skip_registration {
     elsif (match_has_tag('scc-skip-reg-warning-yes')) {
         send_key "alt-y";                       # confirmed skip SCC registration
     }
+}
+
+sub get_addon_fullname {
+    my ($addon) = @_;
+
+    # extensions product list
+    my %product_list = (
+        'ha'    => 'sle-ha',
+        'geo'   => 'sle-ha-geo',
+        'we'    => 'sle-we',
+        'sdk'   => 'sle-sdk',
+        'live'  => 'sle-live-patching',
+        'asmm'  => 'sle-module-adv-systems-management',
+        'contm' => 'sle-module-containers',
+        'hpcm'  => 'sle-module-hpc',
+        'lgm'   => 'sle-module-legacy',
+        'pcm'   => 'sle-module-public-cloud',
+        'tcm'   => 'sle-module-toolchain',
+        'wsm'   => 'sle-module-web-scripting',
+    );
+    return $product_list{"$addon"};
 }
 
 1;

--- a/lib/suseconnect_register.pm
+++ b/lib/suseconnect_register.pm
@@ -1,0 +1,111 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Register base product & extensions with SUSEConnect
+# Maintainer: Jiawei Sun <jwsun@suse.com>
+
+package suseconnect_register;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use testapi;
+use utils;
+use registration;
+
+
+our @EXPORT = qw (suseconnect_registration command_register is_module assert_module);
+
+sub suseconnect_registration {
+    my $product_version = get_required_var('VERSION');
+
+    # register base prodcut
+    command_register($product_version);
+    my @scc_addons = split(/,/, get_var('SCC_ADDONS', ''));
+
+    # register extensions without reg code
+    for my $addon (@scc_addons) {
+        next unless is_module($addon);
+        command_register($product_version, $addon);
+    }
+    zypper_call 'lr';
+}
+
+sub command_register {
+    my ($version, $addon, $addon_regcode) = @_;
+    my $arch = get_required_var("ARCH");
+
+    # precompile regexes
+    my $zypper_conflict = qr/^Choose from above solutions by number[\s\S,]* \[1/m;
+    my $zypper_continue = qr/^Continue\? \[y/m;
+    my $zypper_done     = qr/Run.*to list these programs|^ZYPPER-DONE/m;
+
+    if (!$addon) {
+        my $reg_code = get_required_var("SCC_REGCODE");
+        $version =~ s/\-SP/./;
+        script_run("(SUSEConnect -p SLES/$version/$arch --regcode $reg_code) | tee /dev/$serialdev", 0);
+        my $out = wait_serial($zypper_conflict, 240);
+
+        #resolve potential conflict by zypper
+        if ($out =~ $zypper_conflict) {
+            save_screenshot;
+            script_run("(zypper --no-refresh install --no-recommends -t product SLES;echo ZYPPER-DONE) | tee /dev/$serialdev", 0);
+            $out = wait_serial([$zypper_conflict, $zypper_continue, $zypper_done], 240);
+            while ($out) {
+                if ($out =~ $zypper_conflict) {
+                    send_key '1';
+                    send_key 'ret';
+                    save_screenshot;
+                }
+                elsif ($out =~ $zypper_continue) {
+                    send_key 'y';
+                    send_key 'ret';
+                    save_screenshot;
+                }
+                elsif ($out =~ $zypper_done) {
+                    save_screenshot;
+                    last;
+                }
+                $out = wait_serial([$zypper_conflict, $zypper_continue, $zypper_done], 240);
+            }
+        }
+    }
+
+    else {
+        my $addon_version = int $version;
+        my $addon_name    = get_addon_fullname("$addon");
+
+        # register extension without reg code.
+        if (!$addon_regcode) {
+            assert_script_run "SUSEConnect -p $addon_name/$addon_version/$arch";
+        }
+
+        # register extension with reg code.
+        else {
+            assert_script_run "SUSEConnect -p $addon_name/$version/$arch --regcode $addon_regcode";
+        }
+    }
+    zypper_call 'lr';
+}
+
+# check there are modules in the addon list
+sub assert_module {
+    return 1 if (get_var('SCC_ADDONS', '') =~ /asmm|contm|hpcm|lgm|pcm|tcm|wsm|idu|ids/);
+}
+
+# Return 1 if this is a module
+sub is_module {
+    my ($addon) = @_;
+    return 1 if (grep { $addon eq $_ } qw(asmm contm lgm pcm tcm wsm idu ids));
+}
+
+
+1;
+# vim: sw=4 et

--- a/tests/feature/feature_console/deregister.pm
+++ b/tests/feature/feature_console/deregister.pm
@@ -20,6 +20,8 @@ use base 'consoletest';
 use strict;
 use warnings;
 use testapi;
+use suseconnect_register;
+use registration;
 
 sub run {
     select_console 'root-console';
@@ -30,8 +32,8 @@ sub run {
     }
 
     # check if a certain module is registered, e.g. toolchain
-    my $module  = "sle-module-toolchain";
     my $abbrv   = "tcm";
+    my $module  = get_addon_fullname("$abbrv");
     my $version = get_required_var('VERSION') =~ s/([0-9]+).*/$1/r;
     my $arch    = get_required_var('ARCH');
     die "$module needs to be part of SCC_ADDONS for this test" unless check_var_array('SCC_ADDONS', $abbrv);
@@ -48,7 +50,7 @@ sub run {
     }
 
     # register the module again, check if it is successful. OR using yast_scc_registration();
-    assert_script_run "SUSEConnect -p $module/$version/$arch";
+    suseconnect_register::command_register($version, $abbrv);
     assert_script_run("SUSEConnect --status-text | grep -A 3 $module | grep \"^\\s*Registered\"", 200);
 }
 


### PR DESCRIPTION
Add command_register and get_addon_fullname function.
command_register use to register product or modules, get_addon_fullname use to get product full name by abbreviation.
Update deregister by using command_register and get_addon_fullname function

Verification run http://10.67.17.147/tests/1541#step/deregister/