### PR TITLE
s390: Work around broken disk_formatting during installation

### DIFF
--- a/tests/installation/partitioning_filesystem.pm
+++ b/tests/installation/partitioning_filesystem.pm
@@ -35,6 +35,12 @@ sub run {
         }
     }
     if (is_storage_ng) {
+        # On s390x due to workaround we don't format drive, so select disks screen appears there
+        # Using check_screen not to break test when bug is fixed
+        if (get_var('FORMAT_DASD_YAST') && check_screen('select-hard-disks', 5)) {
+            record_soft_failure('bsc#1055871');
+            send_key $cmd{next};
+        }
         assert_screen 'partition-scheme';
         send_key $cmd{next};
     }


### PR DESCRIPTION
For disk_activation test suite we use cmd tool to get same behavior
which doesn't work within installer due to bsc#1055871
So as workaround, format the disk nevertheless, even if it should be formatted within YaST