### PR TITLE
Increase shutdown timer for PowerPC gnome test

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -754,6 +754,10 @@ sub power_action {
             record_soft_failure('bsc#1055462');
             $shutdown_timeout *= 3;
         }
+        if (get_var("OFW") && check_var('DISTRI', 'opensuse') && check_var('DESKTOP', 'gnome') && get_var('PUBLISH_HDD_1')) {
+            $shutdown_timeout *= 3;
+            record_soft_failure("boo#1057637 shutdown_timeout increased to $shutdown_timeout (s) expecting to complete.");
+        }
         assert_shutdown($shutdown_timeout) if $action eq 'poweroff';
         reset_consoles;
     }


### PR DESCRIPTION
Increase shutdown timer as bypass boo#1057637
    
    for some instances of "create_hdd_gnome" test
    that do not shutdown in less than 60s.
https://openqa.opensuse.org/tests/477562#step/shutdown/7
https://openqa.opensuse.org/tests/461120#step/shutdown/7

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>