### PR TITLE
Fix staging and adjust tests for new welcome screen

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -6,6 +6,7 @@ requires 'XML::Writer';
 requires 'XML::Simple';
 requires 'IO::File';
 requires 'List::Util';
+requires 'LWP::Simple';
 
 on 'test' => sub {
   requires 'Code::DRY';

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -67,9 +67,22 @@ sub run {
     mouse_hide;
     wait_still_screen(3);
 
-    # license+lang
-    # On sle 15 license is on different screen
-    if (!sle_version_at_least('15') || is_staging()) {
+    # license+lang +product (on sle15)
+    # On sle 15 license is on different screen, here select the product
+    if (sle_version_at_least('15')) {
+        if (check_var('STAGING', 'Y')) {
+            assert_screen('select-product');
+            my %hotkey = (
+                sles   => 'u',
+                sled   => 'i',
+                leanos => 's'
+            );
+            my $product = get_required_var('SLE_PRODUCT');
+            send_key 'alt-' . $hotkey{$product};
+            assert_screen('select-product-' . $product);
+        }
+    }
+    else {
         $self->verify_license_has_to_be_accepted;
     }
 


### PR DESCRIPTION
For staging we don't want to add all modules, as we do in
openQA Functional. This change allows to define short names of
modules to be added. E.g. ALL_MODULES=base,serverapp
In case of value '1', behavior remains same.

Another change for staging contains product selection on welcome screen and not
on separate screen as it was before. It's relevant for staging Y only at the moment,
but we can enable it for production once change is there.

After merge we need to update cron job setup to trigger sle15_sp0_staging profile.

[Verification run staging Y](http://gershwin.arch.suse.de/tests/1368)
[Verification run production](http://gershwin.arch.suse.de/tests/1365)
Please, merge the [NEEDLE](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/476).
