### PR TITLE
Fix timeout for missing pattern warning on AARCH64

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -105,7 +105,7 @@ sub break_dependency {
 sub sle15_workaround_broken_patterns {
     return unless sle_version_at_least('15');
     # SLE 15 has pattern errors, workaround them - rbrown 04/07/2017
-    while (check_screen('sle-15-failed-to-select-pattern', 2)) {
+    while (check_screen('sle-15-failed-to-select-pattern', (check_var('ARCH', 'aarch64') ? 10 : 2))) {
         record_soft_failure 'bsc#1047327';
         send_key 'alt-o';
     }


### PR DESCRIPTION
Increased the timeout for pressing ok on the missing pattern warning
on AARCH64.

Poo:
https://progress.opensuse.org/issues/23890

Someone with an ARM worker please verify this