### PR TITLE
Expect select disks screen on ipmi

### DIFF
--- a/tests/installation/partitioning_firstdisk.pm
+++ b/tests/installation/partitioning_firstdisk.pm
@@ -26,7 +26,8 @@ sub take_first_disk_storage_ng {
     assert_screen 'select-hard-disks-one-selected';
     send_key $cmd{next};
     # If drive is not formatted, we have select hard disks page
-    if (get_var('ISO_IN_EXTERNAL_DRIVE')) {
+    # On ipmi we always have unformatted drive
+    if (get_var('ISO_IN_EXTERNAL_DRIVE') || check_var('BACKEND', 'ipmi')) {
         assert_screen 'select-hard-disks';
         send_key $cmd{next};
     }


### PR DESCRIPTION
On ipmi we always will have one unformatted disk, so need to process
additional screen. This is not the case if we have multiple unformatted
drives.