### PR TITLE
Port test suite regression-other to Tumbleweed

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -50,6 +50,7 @@ our @EXPORT = qw(
   load_wicked_tests
   load_iso_in_external_tests
   load_x11regression_documentation
+  load_x11regression_other
   load_security_tests_core
   load_security_tests_web
   load_security_tests_misc
@@ -633,6 +634,33 @@ sub load_x11regression_documentation {
     loadtest "x11regressions/libreoffice/libreoffice_default_theme";
     loadtest "x11regressions/libreoffice/libreoffice_open_specified_file";
     loadtest "x11regressions/libreoffice/libreoffice_double_click_file";
+}
+
+sub load_x11regression_other {
+    if (check_var("DESKTOP", "gnome")) {
+        loadtest "x11regressions/brasero/brasero_launch";
+        loadtest "x11/gnomeapps/gnome_documents";
+        loadtest "x11regressions/totem/totem_launch";
+    }
+    if (check_var('DISTRI', 'sle') && sle_version_at_least('12-SP2')) {
+        loadtest "x11regressions/shotwell/shotwell_import";
+        loadtest "x11regressions/shotwell/shotwell_edit";
+        loadtest "x11regressions/shotwell/shotwell_export";
+        loadtest "virtualization/yast_virtualization";
+        loadtest "virtualization/virtman_view";
+    }
+    if (get_var("DESKTOP") =~ /kde|gnome/) {
+        loadtest "x11regressions/tracker/prep_tracker";
+        loadtest "x11regressions/tracker/tracker_starts";
+        loadtest "x11regressions/tracker/tracker_searchall";
+        loadtest "x11regressions/tracker/tracker_pref_starts";
+        loadtest "x11regressions/tracker/tracker_open_apps";
+        loadtest "x11regressions/tracker/tracker_by_command";
+        loadtest "x11regressions/tracker/tracker_info";
+        loadtest "x11regressions/tracker/tracker_search_in_nautilus";
+        loadtest "x11regressions/tracker/tracker_mainmenu";
+        loadtest "x11regressions/tracker/clean_tracker";
+    }
 }
 
 # Move fips testsuites to main_common to apply to SLE_FIPS + openSUSE

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -763,6 +763,10 @@ elsif (get_var("REGRESSION")) {
         loadtest "boot/boot_to_desktop";
         load_x11regression_documentation();
     }
+    elsif (check_var("REGRESSION", "other")) {
+        loadtest "boot/boot_to_desktop";
+        load_x11regression_other();
+    }
 }
 elsif (get_var("MEDIACHECK")) {
     loadtest "installation/mediacheck";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -465,28 +465,6 @@ sub load_x11regression_message {
     }
 }
 
-sub load_x11regression_other {
-    if (check_var("DESKTOP", "gnome")) {
-        loadtest "x11regressions/shotwell/shotwell_import";
-        loadtest "x11regressions/shotwell/shotwell_edit";
-        loadtest "x11regressions/shotwell/shotwell_export";
-        loadtest "virtualization/yast_virtualization";
-        loadtest "virtualization/virtman_view";
-    }
-    if (get_var("DESKTOP") =~ /kde|gnome/) {
-        loadtest "x11regressions/tracker/prep_tracker";
-        loadtest "x11regressions/tracker/tracker_starts";
-        loadtest "x11regressions/tracker/tracker_searchall";
-        loadtest "x11regressions/tracker/tracker_pref_starts";
-        loadtest "x11regressions/tracker/tracker_open_apps";
-        loadtest "x11regressions/tracker/tracker_by_command";
-        loadtest "x11regressions/tracker/tracker_info";
-        loadtest "x11regressions/tracker/tracker_search_in_nautilus";
-        loadtest "x11regressions/tracker/tracker_mainmenu";
-        loadtest "x11regressions/tracker/clean_tracker";
-    }
-}
-
 sub load_x11regression_remote {
     # load onetime vncsession testing
     if (check_var('REMOTE_DESKTOP_TYPE', 'one_time_vnc')) {

--- a/tests/x11regressions/brasero/brasero_launch.pm
+++ b/tests/x11regressions/brasero/brasero_launch.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Brasero launch and about
+# Maintainer: Grace Wang <gwang@suse.com>
+
+use base "x11regressiontest";
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    assert_gui_app('brasero', install => 1, remain => 1);
+
+    # check about window
+    send_key 'alt-h';
+    wait_still_screen 3;
+    send_key 'a';
+    assert_screen 'brasero-help-about';
+    send_key 'alt-f4';
+    wait_still_screen 3;
+    send_key 'alt-f4';
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11regressions/totem/totem_launch.pm
+++ b/tests/x11regressions/totem/totem_launch.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Totem launch
+# Maintainer: Grace Wang <gwang@suse.com>
+
+use base "x11regressiontest";
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    assert_gui_app('totem');
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
- Extract load_x11regression_other to main_common
- Update main.pm for both SLE and openSUSE
- Add 2 new test cases cover basic testing for brasero and totem
- Enable 1 test case for gnome-documents
- Port 10 tracker cases to Tumbleweed
- We should also add testsuite of regression-other to o3:
  BOOTFROM=c
  DESKTOP=gnome
  HDD_1=%DISTRI%-%VERSION%-%BUILD%-%ARCH%_for_regression.qcow2
  REGRESSION=other
  START_AFTER_TEST=regression-installation

  See also poo#23906

SLE results can be found: http://10.67.17.21/tests/69#
TW results can be found: http://10.67.17.21/tests/72#