### PR TITLE
Useless use of string in void context

### DIFF
--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -98,7 +98,7 @@ sub setup_networks {
     for my $network (keys %$net_conf) {
         next if $network eq 'fixed';
         next unless $net_conf->{$network}->{gateway};
-        "NIC=`grep $net_conf->{$network}->{mac} /sys/class/net/*/address |cut -d / -f 5`\n";
+        $setup_script .= "NIC=`grep $net_conf->{$network}->{mac} /sys/class/net/*/address |cut -d / -f 5`\n";
         $setup_script .= "iptables -A FORWARD -i \$FIXED_NIC -o \$NIC -m state  --state RELATED,ESTABLISHED -j ACCEPT\n";
         $setup_script .= "iptables -A FORWARD -i \$NIC -o \$FIXED_NIC -j ACCEPT\n";
     }


### PR DESCRIPTION
https://openqa.suse.de/tests/1144187/file/autoinst-log.txt

With env var `NIC` not being set in the loop, the last `NIC` from ifcfg
setup is used (yes, it works in most cases).