### PR TITLE
Soft-fail missing licenses for extensions on SLE 15

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -836,6 +836,11 @@ sub addon_license {
     push @tags, (get_var("BETA_$uc_addon") ? "addon-betawarning-$addon" : "addon-license-$addon");
   license: {
         do {
+            # Soft-fail on SLE-15 if license is not there.
+            if (sle_version_at_least('15') && !check_screen \@tags) {
+                record_soft_failure 'bsc#1057223';
+                return;
+            }
             assert_screen \@tags;
             if (match_has_tag('import-untrusted-gpg-key')) {
                 record_soft_failure 'untrusted gpg key';


### PR DESCRIPTION
On SLE 15 we don't have licenses for extensions when added manually yet.
This commit adds soft failure with required reference for sle 15 only.

See [poo#23504](https://progress.opensuse.org/issues/23504).

Please, merge [NEEDLE](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/478).

[Verification run](http://gershwin.arch.suse.de/tests/1372).