### PR TITLE
Add start_shotwell() function and use it in shotwell test group

### DIFF
--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -18,6 +18,15 @@ use testapi;
 use utils;
 use POSIX 'strftime';
 
+# Start shotwell and handle the welcome screen, if there
+sub start_shotwell {
+    x11_start_program("shotwell");
+    assert_screen [qw(shotwell-first-launch shotwell-launched)];
+    if (match_has_tag "shotwell-first-launch") {
+        wait_screen_change { send_key "ret" };
+    }
+}
+
 # import_pictures helps shotwell to import test pictures into shotwell's library.
 sub import_pictures {
     my ($self, $pictures) = @_;
@@ -49,7 +58,8 @@ sub import_pictures {
 sub clean_shotwell {
     # Clean shotwell's database
     x11_start_program("rm -rf /home/$username/.local/share/shotwell");
-
+    # Clean shotwell cache files
+    x11_start_program("rm -rf /home/$username/.cache/shotwell");
     # Remove test pictures
     x11_start_program("rm /home/$username/Documents/shotwell_test.*");
 }

--- a/tests/x11regressions/shotwell/shotwell_edit.pm
+++ b/tests/x11regressions/shotwell/shotwell_edit.pm
@@ -20,8 +20,8 @@ sub run {
     my $self     = shift;
     my @pictures = qw(shotwell_test.jpg shotwell_test.png);
 
-    x11_start_program("shotwell");
-    assert_screen 'shotwell-launched';
+    # Open shotwell
+    $self->start_shotwell();
 
     # Import two test pictures into the library
     $self->import_pictures(\@pictures);

--- a/tests/x11regressions/shotwell/shotwell_export.pm
+++ b/tests/x11regressions/shotwell/shotwell_export.pm
@@ -12,7 +12,6 @@
 # Tags: tc#1503754
 
 use base "x11regressiontest";
-use base "x11regressiontest";
 use strict;
 use testapi;
 
@@ -20,8 +19,8 @@ sub run {
     my $self     = shift;
     my @pictures = qw(shotwell_test.jpg shotwell_test.png);
 
-    x11_start_program("shotwell");
-    assert_screen 'shotwell-launched';
+    # Open shotwell
+    $self->start_shotwell;
 
     # Import two test pictures into the library
     $self->import_pictures(\@pictures);
@@ -30,7 +29,7 @@ sub run {
     send_key "alt-home";
     send_key "ctrl-shift-e";
     assert_screen 'shotwell-export-prompt';
-    send_key "alt-f";    # Choose jepg format to export
+    send_key "alt-f";    # Choose jpeg format to export
     send_key "down";
     assert_screen 'shotwell-export-jepg';
     send_key "alt-o";
@@ -50,7 +49,6 @@ sub run {
 
     # Clean shotwell's library then remove the test pictures
     $self->clean_shotwell();
-    x11_start_program("rm /home/$username/Desktop/shotwell_test.jpg");
 }
 
 1;

--- a/tests/x11regressions/shotwell/shotwell_import.pm
+++ b/tests/x11regressions/shotwell/shotwell_import.pm
@@ -11,7 +11,6 @@
 # Maintainer: Chingkai <qkzhu@suse.com>
 
 use base "x11regressiontest";
-use base "x11regressiontest";
 use strict;
 use testapi;
 
@@ -21,9 +20,7 @@ sub run {
     my $self     = shift;
     my @pictures = qw(shotwell_test.jpg shotwell_test.png);
 
-    x11_start_program("shotwell");
-    assert_screen 'shotwell-first-launch';
-    wait_screen_change { send_key "ret"; };
+    $self->start_shotwell();
 
     # Import two test pictures into the library
     $self->import_pictures(\@pictures);


### PR DESCRIPTION
This commit removes the code to start shotwell out of the individual shotwell* tests and instead adds a `start_shotwell()` function into the x11regression library, in accordance with the DRY principle. The function starts the application and subsequently checks whether there is a welcome window pop up, in order to prevent failures when the state is restored from the last good snapshot.

Verification run:
SLED12 SP2: http://dreamyhamster.suse.cz/tests/746
SLED12 SP3: http://dreamyhamster.suse.cz/tests/744
In both runs, the `shotwell_edit` module fails due to another issue (21048), however, the following module, `shotwell_export`, runs fine.

Related issue: https://progress.opensuse.org/issues/21052
Needles MR: Not applicable - no new needles were necessary.

Context:
The shotwell test group contains 3 test modules. Upon opening the application, the first module (`shotwell_import`) handles the first-launch window and closes it, while the next two modules (`shotwell_edit` and `shotwell_export`) do not expect the welcome window any more and merely assert that the application is launched.

However, if any of the previous modules fail, the SUT state is restored to the last anchored snapshot, which in this case is right after `boot_to_desktop`, therefore the next shotwell* module after the failure behaves again as first launch and the welcome window appears again.