### PR TITLE
LTP: Don't install dmapi-devel

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -47,9 +47,9 @@ sub we_available {
 
 sub install_dependencies {
     my @deps = qw(git-core make automake autoconf gcc expect libnuma-devel libaio-devel
-      numactl flex bison dmapi-devel kernel-default-devel libopenssl-devel libselinux-devel
-      libacl-devel libtirpc-devel keyutils-devel libcap-devel net-tools psmisc acl quota curl
-      iputils);
+      numactl flex bison kernel-default-devel libopenssl-devel libselinux-devel
+      libacl-devel libtirpc-devel keyutils-devel libcap-devel net-tools psmisc acl quota
+      curl iputils);
 
     zypper_call('-t in ' . join(' ', @deps), log => 'install-deps.txt');
 


### PR DESCRIPTION
dmapi-devel was removed from SLE 15, but it's not needed anyway.

This fixes poo#24700.