### PR TITLE
utils: sle_version_at_least: do not fallback to true if VERSION is no…

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -450,8 +450,13 @@ sub sle_version_at_least {
     my ($version, %args) = @_;
     my $version_variable = $args{version_variable} // 'VERSION';
 
+    if ($version eq '12') {
+        return check_var($version_variable, '12');
+    }
+
     if ($version eq '12-SP1') {
-        return !check_var($version_variable, '12');
+        return sle_version_at_least('12', version_variable => $version_variable)
+          && !check_var($version_variable, '12');
     }
 
     if ($version eq '12-SP2') {


### PR DESCRIPTION
…t known

Instead of falling back to TRUE if 'VERSION' is not in the list of known SLE
Versions, fall back to false.

if tested against Tumbleweed for example, sle_version_at_least('15') would return
true, even though this is not the intention