### PR TITLE
 Remove workaround for dependency issues and missing patterns

### DIFF
--- a/lib/installsummarystep.pm
+++ b/lib/installsummarystep.pm
@@ -2,7 +2,6 @@ package installsummarystep;
 use base "y2logsstep";
 use testapi;
 use strict;
-use utils 'sle_version_at_least';
 
 
 sub accept3rdparty {
@@ -28,9 +27,7 @@ sub accept_changes_with_3rd_party_repos {
         send_key $cmd{ok};
         accept3rdparty;
     }
-    if (sle_version_at_least '15') {
-        $self->sle15_workaround_broken_patterns;
-    }
+
     assert_screen 'inst-overview';
 }
 

--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -102,15 +102,6 @@ sub break_dependency {
     }
 }
 
-sub sle15_workaround_broken_patterns {
-    return unless sle_version_at_least('15');
-    # SLE 15 has pattern errors, workaround them - rbrown 04/07/2017
-    while (check_screen('sle-15-failed-to-select-pattern', (check_var('ARCH', 'aarch64') ? 10 : 2))) {
-        record_soft_failure 'bsc#1047327';
-        send_key 'alt-o';
-    }
-}
-
 sub process_unsigned_files {
     my ($self, $expected_screens) = @_;
     # SLE 15 has unsigned file errors, workaround them - rbrown 04/07/2017
@@ -173,7 +164,6 @@ sub deal_with_dependency_issues {
         record_soft_failure 'bsc#1047337';
         send_key 'alt-o';                      # OK
     }
-    sle15_workaround_broken_patterns;
     sleep 2;
 
     if (check_screen('dependency-issue-fixed', 0)) {

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -20,6 +20,12 @@ use qam 'advance_installer_window';
 sub run {
     my ($self) = @_;
 
+    # Softfail not to forget remove workaround
+    # TODO: Remove once fixed for SLE15
+    if (get_var('ALL_MODULES') || get_var('WORKAROUND_MODULES')) {
+        record_soft_failure('bsc#1054974');
+    }
+
     if (get_var('SKIP_INSTALLER_SCREEN', 0)) {
         advance_installer_window('inst-addon');
         set_var('SKIP_INSTALLER_SCREEN', 0);

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -25,9 +25,6 @@ sub run {
     # this is almost impossible to check for real
     assert_screen "installation-settings-overview-loaded";
 
-    $self->sle15_workaround_broken_patterns;
-    $self->deal_with_dependency_issues;
-
     if (get_var("XEN")) {
         assert_screen "inst-xen-pattern";
     }
@@ -61,13 +58,7 @@ sub run {
         assert_screen 'autoyast_removed';
     }
 
-    if (check_screen('manual-intervention', 0)) {
-        $self->deal_with_dependency_issues;
-    }
-
-    $self->sle15_workaround_broken_patterns;    # Pattern warnings appear after dependancy resolution also;
-
-    my $need_ssh = check_var('ARCH', 's390x');  # s390x always needs SSH
+    my $need_ssh = check_var('ARCH', 's390x');    # s390x always needs SSH
     $need_ssh = 1 if check_var('BACKEND', 'ipmi');    # we better be able to login
 
     if (!get_var('UPGRADE') && $need_ssh) {

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -20,8 +20,7 @@ use utils 'sle_version_at_least';
 
 sub run {
     my ($self) = shift;
-    # Softfail not to forget remove workaround
-    record_soft_failure('bsc#1054974') if get_var('ALL_MODULES');
+
     # overview-generation
     # this is almost impossible to check for real
     assert_screen "installation-settings-overview-loaded";

--- a/tests/installation/installation_overview_before.pm
+++ b/tests/installation/installation_overview_before.pm
@@ -18,8 +18,6 @@ use testapi;
 
 sub run {
     my ($self) = @_;
-    $self->sle15_workaround_broken_patterns;
-
     # overview-generation
     # this is almost impossible to check for real
     # See poo#12322. Prevent checks before overview is fully loaded
@@ -27,10 +25,6 @@ sub run {
     # parts which are there while overview is still loading. This check has to be
     # performed only once, as state of buttons can be different
     assert_screen "installation-settings-overview-loaded";
-
-    if (check_screen 'manual-intervention') {
-        $self->deal_with_dependency_issues;
-    }
 }
 
 1;

--- a/tests/installation/select_patterns_and_packages.pm
+++ b/tests/installation/select_patterns_and_packages.pm
@@ -55,8 +55,6 @@ sub check12qtbug {
 sub gotopatterns {
     my ($self) = @_;
 
-    $self->deal_with_dependency_issues;
-
     if (check_var('VIDEOMODE', 'text')) {
         wait_still_screen;
         send_key 'alt-c';
@@ -86,8 +84,7 @@ sub package_action {
     my ($self, $unblock) = @_;
     my $operation;
     my $packages = $unblock ? get_var('INSTALLATION_BLOCKED') : get_var('PACKAGES');
-    # Workaround for sle 15. Version check is performed inside of the method
-    $self->sle15_workaround_broken_patterns;
+
     if (get_var('PACKAGES')) {
         if (check_var('VIDEOMODE', 'text')) {
             send_key 'alt-f';
@@ -141,8 +138,7 @@ sub package_action {
         send_key 'alt-o';
         accept3rdparty;
     }
-    # Workaround for sle 15. Version check is performed inside of the method
-    $self->sle15_workaround_broken_patterns;
+
     if (get_var('INSTALLATION_BLOCKED') && $secondrun) {
         record_soft_failure 'bsc#1029660';
         assert_screen 'inst-overview-blocked';


### PR DESCRIPTION
Now issues with dependencies should not appear anymore and hence we
should not soft-fail them. Point here is that original bug was created
for leanOS. If we test SLES, we should create relevant bug. To resolve
original issue, we add modules which are expected to be in installation.

We still continue adding modules manually instead of using SCC
functionality, recently we have introduced another variable to add
specific modules only. We also move it to addon_products_sle test
module where behavior has workaround applied.

[Verification run](http://gershwin.arch.suse.de/tests/1376#settings).
See [poo#23938](https://progress.opensuse.org/issues/23938).
