### PR TITLE
Fix welcome screen check for Tumbleweed

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -69,7 +69,7 @@ sub run {
 
     # license+lang +product (on sle15)
     # On sle 15 license is on different screen, here select the product
-    if (sle_version_at_least('15')) {
+    if (check_var('DISTRI', 'sle') && sle_version_at_least('15')) {
         assert_screen('select-product');
         my %hotkey = (
             sles   => 'u',


### PR DESCRIPTION
sle_version_at_least does not check for the distribution and always
returns true for any 'VERSION' not explicitly checked, i.e. not one of
(12, 12-SP1, 12-SP2, 12-SP3, 12-SP4, 15).