### PR TITLE
Select product only for sle

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -69,7 +69,7 @@ sub run {
 
     # license+lang +product (on sle15)
     # On sle 15 license is on different screen, here select the product
-    if (sle_version_at_least('15')) {
+    if (sle_version_at_least('15') && check_var('DISTRI', 'sle')) {
         assert_screen('select-product');
         my %hotkey = (
             sles   => 'u',


### PR DESCRIPTION
Our favorite function sle_version_at_least returns true for all non sle
distributions. Point is that we expect all changes in SLE to be in TW or
Leap. This commit skips selecting product if not sle.

See [poo#24708](https://progress.opensuse.org/issues/24708)
[Verification run](http://gershwin.arch.suse.de/tests/1377#)