### PR TITLE
Add docker test in MicroOS

### DIFF
--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -116,6 +116,9 @@ sub load_feature_tests {
 
     # Journal errors
     loadtest 'caasp/journal_check';
+
+    # Docker
+    loadtest 'console/docker';
 }
 
 sub load_stack_tests {

--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -28,8 +28,13 @@ use strict;
 sub run {
     select_console("root-console");
 
-    # install the docker package
-    zypper_call("in docker");
+    if (check_var("DISTRI", "caasp")) {
+        # Docker should be pre-installed in MicroOS
+        die "Docker is not pre-installed." if script_run("rpm -q docker");
+    }
+    else {
+        zypper_call("in docker");
+    }
 
     # start the docker daemon
     systemctl("start docker");

--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -28,7 +28,7 @@ use strict;
 sub run {
     select_console("root-console");
 
-    if (check_var("DISTRI", "caasp")) {
+    if (is_caasp) {
         # Docker should be pre-installed in MicroOS
         die "Docker is not pre-installed." if script_run("rpm -q docker");
     }


### PR DESCRIPTION
MicroOS is an operating system optimized for running the next
generation of applications with Linux containers. Thus, running
a container-based test (e.g. docker) is mandatory.