### PR TITLE
Handle conflicts between ffmpeg2-devel and split -devel from ffmpeg (3)

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -154,6 +154,8 @@ sub problem_can_be_skipped {
     return 1 if $pkg =~ /^julia-compat(-devel)?/;
     # conflicts with wxWidgets-3_0-devel/
     return 1 if $pkg =~ /^wxWidgets-3_0-nostl-devel/;
+    # conflicts with split devel packages from ffmpeg (3)
+    return 1 if $pkg =~ /^ffmpeg2-devel/;
 
     return;
 }


### PR DESCRIPTION
Fixes:
https://openqa.opensuse.org/tests/480751#step/install_packages/9
https://openqa.opensuse.org/tests/480752#step/install_packages/9
https://openqa.opensuse.org/tests/480753#step/install_packages/9