### PR TITLE
Adjust RAID test for storage ng

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -23,6 +23,8 @@ sub run {
     # and set the STORAGE_NG variable so later tests know about this.
     if (match_has_tag('storage-ng')) {
         set_var('STORAGE_NG', 1);
+        # Define changed shortcuts
+        $cmd{donotformat} = 'alt-t';
     }
 
     if (get_var("DUALBOOT")) {


### PR DESCRIPTION
Functionality still doesn't fully work, but with this change we will
fail at the point where there is a bug. I've introduced changes to
proceed using different format for disk size, but if fails later because
custom size doesn't work still.

Please, do not forget to merge [NEEDLES](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/481)

See poo#23340.
Verification runs:
[SLE15](http://gershwin.arch.suse.de/tests/1424#)
[SLE12SP3](http://gershwin.arch.suse.de/tests/1429)