### PR TITLE
Handle changes in evolution 3.26

### DIFF
--- a/tests/x11/evolution.pm
+++ b/tests/x11/evolution.pm
@@ -36,6 +36,8 @@ sub run {
         }
         assert_screen 'test-evolution-1';
     }
+    # Evolution 3.26 launches the main window before the new account assistant - alt-f4 closes it
+    send_key "alt-f4" if match_has_tag('evolution-mainwindow-launched');
     send_key "ctrl-q";            # really quit (alt-f4 just backgrounds)
     send_key "alt-f4";
 }


### PR DESCRIPTION
Prior to Evolution 3.26, the 'new account' assistant was launched
unconditionally. Since 3.26, it only starts when the 'Mail' register
is being accessed (which is the default register selected when
starting evolution without parameters, like for example -c calendar)

So, newly, the main window starts up, the Mail register is auto-selected
and then the 'new account' assistant launches.

This requires now that, once we cancel the new-account assistant, that
we have to properly handle to close the Evolution main window too.