### PR TITLE
Add wait to fix keyboard input

### DIFF
--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -263,6 +263,7 @@ sub send_meeting_request {
     send_key "shift-ctrl-e";
     assert_screen "evolution_mail-compse_meeting", 30;
     wait_screen_change { send_key 'alt-a' };
+    wait_still_screen;
     type_string "$mail_box";
     send_key "alt-s";
     if (sle_version_at_least('12-SP2')) {


### PR DESCRIPTION
Fix poo#21048: Email address is not sometimes typed correctly. Wait
before keyboard input solves the situation.

Incorrect behavior (address is mda@localhost):
https://openqa.suse.de/tests/1156423#step/evolution_meeting_imap/47

Fixed behavior (address is nimda@localhost):
http://10.100.12.105/tests/1411#step/evolution_meeting_imap/47