### PR TITLE
Adjust proxy_SCC+allmodules test suite for SLE 15

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -288,7 +288,7 @@ if (get_var('DEV_IMAGE')) {
 
 # This is workaround setting which will be removed once SCC add repos and allows adding modules
 # TODO: remove when not used anymore
-if (sle_version_at_least('15')) {
+if (sle_version_at_least('15') && !check_var('SCC_REGISTER', 'installation')) {
     my @modules;
     if (get_var('ALL_MODULES')) {
         # By default add all modules
@@ -340,8 +340,7 @@ if (sle_version_at_least('15')) {
 
 if (get_var('ENABLE_ALL_SCC_MODULES') && !get_var('SCC_MODULES')) {
     if (sle_version_at_least('15')) {
-        my $addons = 'base,script,desktop,serverapp,phub,legacy,sdk,ha';
-        $addons .= ',we' if get_var('ARCH', '') =~ /x86_64|aarch64/;
+        my $addons = 'base,script,desktop,serverapp,legacy,sdk';
         set_var('SCC_ADDONS', $addons);
         set_var('PATTERNS',   'default,asmm,pcm');
     }

--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -14,6 +14,7 @@
 use base "y2logsstep";
 use strict;
 use testapi;
+use utils 'sle_version_at_least';
 
 sub run {
     assert_screen('release-notes-button', 5);
@@ -49,6 +50,11 @@ sub run {
 
     # no release-notes for WE and all modules
     my @no_relnotes = qw(we lgm asmm certm contm pcm tcm wsm hpcm ids idu phub);
+
+    # No release-notes for basic modules on SLE 15
+    if (sle_version_at_least('15') && check_var('DISTRI', 'sle')) {
+        push @no_relnotes, qw(base script desktop serverapp legacy sdk);
+    }
 
     # no relnotes for ltss in QAM_MINIMAL
     push @no_relnotes, qw(ltss) if get_var('QAM_MINIMAL');


### PR DESCRIPTION
Now we have working proxy scc, so can use it for registration. Whereas
there are some limitations, we start with allmodules test suite to check
status of SCC and then applying solution to other solution replacing our
workaroud with ftp addons urls.

Test suite requires setting SCC_URL to following value:
SCC_URL=http://Module-SERVER-Applications-%BUILD%.Module-Development-%BUILD%.Module-Scripting-%BUILD%.Module-Legacy-%BUILD%.Module-DESKTOP-Applications-%BUILD%.Module-Basesystem-%BUILD%.Leanos-%BUILD%.proxy.scc.suse.de

Please, edit if want to include WE and HA modules.

See [poo#23492](https://progress.opensuse.org/issues/23492).
[Verification run](http://gershwin.arch.suse.de/tests/1445#)