### PR TITLE
Port testsuite regression-gnome to Tumbleweed

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -50,6 +50,7 @@ our @EXPORT = qw(
   load_wicked_tests
   load_iso_in_external_tests
   load_x11regression_documentation
+  load_x11regression_gnome
   load_x11regression_other
   load_security_tests_core
   load_security_tests_web
@@ -634,6 +635,21 @@ sub load_x11regression_documentation {
     loadtest "x11regressions/libreoffice/libreoffice_default_theme";
     loadtest "x11regressions/libreoffice/libreoffice_open_specified_file";
     loadtest "x11regressions/libreoffice/libreoffice_double_click_file";
+}
+
+sub load_x11regression_gnome {
+    return unless check_var('DESKTOP', 'gnome');
+    loadtest "x11regressions/gnomecase/nautilus_cut_file";
+    loadtest "x11regressions/gnomecase/nautilus_permission";
+    loadtest "x11regressions/gnomecase/nautilus_open_ftp";
+    loadtest "x11regressions/gnomecase/application_starts_on_login";
+    loadtest "x11regressions/gnomecase/change_password";
+    loadtest "x11regressions/gnomecase/login_test";
+    if (check_var('DISTRI', 'sle') && sle_version_at_least('12-SP1')) {
+        loadtest "x11regressions/gnomecase/gnome_classic_switch";
+    }
+    loadtest "x11regressions/gnomecase/gnome_default_applications";
+    loadtest "x11regressions/gnomecase/gnome_window_switcher";
 }
 
 sub load_x11regression_other {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -750,6 +750,7 @@ elsif (get_var("WICKED")) {
 }
 elsif (get_var("REGRESSION")) {
     if (check_var("REGRESSION", "installation")) {
+        set_var('NOAUTOLOGIN', 1);
         load_boot_tests();
         load_inst_tests();
         load_reboot_tests();
@@ -762,6 +763,10 @@ elsif (get_var("REGRESSION")) {
     elsif (check_var("REGRESSION", "documentation")) {
         loadtest "boot/boot_to_desktop";
         load_x11regression_documentation();
+    }
+    elsif (check_var("REGRESSION", "gnome")) {
+        loadtest "boot/boot_to_desktop";
+        load_x11regression_gnome();
     }
     elsif (check_var("REGRESSION", "other")) {
         loadtest "boot/boot_to_desktop";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -431,20 +431,6 @@ sub load_x11regression_firefox {
     }
 }
 
-sub load_x11regression_gnome {
-    if (check_var("DESKTOP", "gnome")) {
-        loadtest "x11regressions/gnomecase/nautilus_cut_file";
-        loadtest "x11regressions/gnomecase/nautilus_permission";
-        loadtest "x11regressions/gnomecase/nautilus_open_ftp";
-        loadtest "x11regressions/gnomecase/application_starts_on_login";
-        loadtest "x11regressions/gnomecase/change_password";
-        loadtest "x11regressions/gnomecase/login_test";
-        loadtest "x11regressions/gnomecase/gnome_classic_switch";
-        loadtest "x11regressions/gnomecase/gnome_default_applications";
-        loadtest "x11regressions/gnomecase/gnome_window_switcher";
-    }
-}
-
 sub load_x11regression_message {
     if (check_var("DESKTOP", "gnome")) {
         loadtest "x11regressions/empathy/empathy_aim";

--- a/tests/x11regressions/gnomecase/application_starts_on_login.pm
+++ b/tests/x11regressions/gnomecase/application_starts_on_login.pm
@@ -13,6 +13,7 @@
 use base "x11regressiontest";
 use strict;
 use testapi;
+use utils;
 
 sub tweak_startupapp_menu {
     my ($self) = @_;
@@ -23,19 +24,6 @@ sub tweak_startupapp_menu {
     assert_screen "tweak-tool";
     # increase the default timeout - the switching can be slow
     send_key_until_needlematch "tweak-startapp", "down", 10, 2;
-}
-
-sub logout_and_login {
-    assert_and_click "system-indicator";
-    assert_and_click "user-logout-sector";
-    assert_and_click "logout-system";
-    wait_still_screen;
-    send_key "ret";
-    assert_screen "displaymanager";
-    send_key "ret";
-    assert_screen "originUser-login-dm";
-    type_password;
-    send_key "ret";
 }
 
 sub start_dconf {
@@ -52,13 +40,22 @@ sub start_dconf {
 sub alter_status_auto_save_session {
     my ($self) = @_;
     $self->start_dconf;
-    send_key_until_needlematch "dconf-org", "down";
-    assert_and_click "unfold";
-    send_key_until_needlematch "dconf-org-gnome", "down";
-    assert_and_click "unfold";
-    send_key_until_needlematch "dconf-gnome-evolution", "down";
-    assert_and_click "scroll-down";    #this step aim to work around screen not scroll down automate issue
-    send_key_until_needlematch "gnome-session", "down";
+    # Old behavior for non SLE15 or non TW
+    if (!sle_version_at_least('15') && !leap_version_at_least('15')) {
+        send_key_until_needlematch "dconf-org", "down";
+        assert_and_click "unfold";
+        send_key_until_needlematch "dconf-org-gnome", "down";
+        assert_and_click "unfold";
+        send_key_until_needlematch "dconf-gnome-evolution", "down";
+        assert_and_click "scroll-down";    #this step aim to work around screen not scroll down automate issue
+        send_key_until_needlematch "gnome-session", "down";
+    }
+    # New behavior for SLE15 and TW
+    else {
+        send_key 'ctrl-f';
+        assert_screen 'dconf-search-bar';
+        type_string "auto-save-session\n";
+    }
     assert_and_click "auto-save-session";
     if (check_screen("changing-scheme-popup")) {
         assert_and_click "auto-save-session-alter-use-default";
@@ -73,7 +70,7 @@ sub alter_status_auto_save_session {
 sub restore_status_auto_save_session {
     my ($self) = @_;
     $self->start_dconf;
-    assert_and_click "auto-save-session";
+    assert_and_click "auto-save-session" unless (sle_version_at_least('15'));
     assert_and_click "auto-save-session-alter-use-default";
     assert_and_click "auto-save-session-apply";
     send_key "alt-f4";
@@ -88,7 +85,7 @@ sub run {
     $self->tweak_startupapp_menu;
     assert_and_click "tweak-startapp-add";
     assert_screen "tweak-startapp-applist";
-    if (get_var("SP2ORLATER")) {
+    if (sle_version_at_least('12-SP2')) {
         assert_and_click "startupApp-searching";
         wait_still_screen;
         assert_screen "focused-on-search";
@@ -104,7 +101,8 @@ sub run {
     wait_still_screen;
     send_key "alt-f4";
 
-    logout_and_login;
+    handle_logout;
+    handle_login;
     $self->firefox_check_popups;
     assert_screen "firefox-gnome", 90;
     send_key "alt-f4";
@@ -122,7 +120,8 @@ sub run {
     send_key "alt-f4";
     assert_screen "generic-desktop";
 
-    logout_and_login;
+    handle_logout;
+    handle_login;
     assert_screen "generic-desktop";
 
     #set auto-save-session;
@@ -131,6 +130,13 @@ sub run {
     ##auto-save-session functionality has been abandoned;
     ##current status: just firefox works
     ##so in the future will consider remove openqa code for this session
+    # Install dconf-editor for TW
+    if (check_var('VERSION', 'Tumbleweed')) {
+        select_console('root-console');
+        pkcon_quit;
+        zypper_call('in dconf-editor');
+        select_console('x11');
+    }
     $self->alter_status_auto_save_session;
 
     x11_start_program("firefox");
@@ -138,7 +144,8 @@ sub run {
     $self->firefox_check_default;
     $self->firefox_check_popups;
     assert_screen "firefox-gnome", 90;
-    logout_and_login;
+    handle_logout;
+    handle_login;
     $self->firefox_check_popups;
     assert_screen "firefox-gnome", 90;
     send_key "alt-f4";
@@ -146,7 +153,7 @@ sub run {
     send_key "ret";
     wait_still_screen;
 
-    if (get_var("SP2ORLATER")) {
+    if (sle_version_at_least('12-SP2')) {
         $self->restore_status_auto_save_session;
     }
     else {

--- a/tests/x11regressions/gnomecase/change_password.pm
+++ b/tests/x11regressions/gnomecase/change_password.pm
@@ -32,25 +32,19 @@ sub lock_screen {
 }
 
 sub logout_and_login {
-    assert_and_click "system-indicator";
-    assert_and_click "user-logout-sector";
-    assert_and_click "logout-system";
-    send_key "ret";
-    assert_screen "displaymanager";
-    send_key "ret";
-    type_string "$newpwd\n";
+    handle_logout;
+    assert_screen 'displaymanager';
+    mouse_hide();
+    wait_still_screen;
+    send_key 'ret';
+    assert_screen 'displaymanager-password-prompt', no_wait => 1;
+    type_password "$newpwd\n";
     assert_screen "generic-desktop";
 }
 
 sub reboot_system {
     my ($self) = @_;
-    send_key "ctrl-alt-delete";    #reboot
-    assert_screen 'logoutdialog', 15;
-    assert_and_click 'logoutdialog-reboot-highlighted';
-    if (check_screen("reboot-auth", 5)) {
-        type_password;
-        assert_and_click "authenticate";
-    }
+    reboot_x11;
     $self->{await_reboot} = 1;
     assert_screen "displaymanager", 200;
     $self->{await_reboot} = 0;
@@ -79,7 +73,7 @@ sub change_pwd {
     wait_still_screen;
     type_string $newpwd;
     wait_still_screen;
-    send_key "alt-v";
+    send_key 'tab';
     wait_still_screen;
     type_string $newpwd;
     assert_screen "actived-change-password";
@@ -94,7 +88,7 @@ sub add_user {
     assert_and_click "set-password-option";
     send_key "alt-p";
     type_string $pwd4newUser;
-    send_key "alt-v";
+    send_key 'tab';
     type_string $pwd4newUser;
     assert_screen "actived-add-user";
     send_key "alt-a";
@@ -115,6 +109,7 @@ sub run {
     lock_screen;
     logout_and_login;
     $self->reboot_system;
+
     #swtich to new added user then switch back
     switch_user;
     send_key "esc";
@@ -123,17 +118,18 @@ sub run {
     send_key "ret";
     assert_screen "testUser-login-dm";
     type_string "$pwd4newUser\n";
-    assert_screen "generic-desktop", 60;
+    assert_screen "generic-desktop", 120;
     switch_user;
     send_key "esc";
     assert_screen "displaymanager";
     send_key "ret";
     assert_screen "originUser-login-dm";
     type_string "$newpwd\n";
-    assert_screen "generic-desktop", 60;
+    assert_screen "generic-desktop", 120;
 
     #restore password to original value
     x11_start_program("gnome-terminal");
+    assert_screen 'gnome-terminal';
     type_string "su\n";
     assert_screen "pwd4root-terminal";
     type_password "$password\n";

--- a/tests/x11regressions/gnomecase/gnome_default_applications.pm
+++ b/tests/x11regressions/gnomecase/gnome_default_applications.pm
@@ -14,6 +14,7 @@
 use base "x11regressiontest";
 use strict;
 use testapi;
+use utils;
 
 sub run {
     # Prepare test files
@@ -62,43 +63,49 @@ sub prepare_application_environment {
 
 sub open_default_apps {
     # Open test files with default applications
-    assert_and_dclick "gnomecase-defaultapps-jpgfile";     #open jpg
+    assert_and_dclick "gnomecase-defaultapps-jpgfile";    #open jpg
     assert_screen 'gnomecase-defaultapps-jpgopen';
-    send_key "ctrl-w";                                     #close eog
+    send_key "ctrl-w";                                    #close eog
     wait_still_screen;
-    assert_and_dclick "gnomecase-defaultapps-pngfile";     #open png
+    assert_and_dclick "gnomecase-defaultapps-pngfile";    #open png
     assert_screen 'gnomecase-defaultapps-pngopen';
-    send_key "ctrl-w";                                     #close eog
+    send_key "ctrl-w";                                    #close eog
     wait_still_screen;
-    assert_and_dclick "gnomecase-defaultapps-pdffile";     #open pdf
+    assert_and_dclick "gnomecase-defaultapps-pdffile";    #open pdf
     wait_still_screen;
     send_key "super-up";
     assert_screen 'evince-open-pdf';
-    send_key "ctrl-w";                                     #close evince
+    send_key "ctrl-w";                                    #close evince
     wait_still_screen;
-    assert_and_dclick "gnomecase-defaultapps-bz2file";     #open bzip
+    assert_and_dclick "gnomecase-defaultapps-bz2file";    #open bzip
     assert_screen 'gnomecase-defaultapps-bz2open';
-    send_key "ctrl-w";                                     #close fileroller
+    send_key "ctrl-w" unless sle_version_at_least('15');    #close fileroller
     wait_still_screen;
-    assert_and_dclick "gnomecase-defaultapps-gzfile";      #open gzip
+    assert_and_dclick "gnomecase-defaultapps-gzfile";       #open gzip
     assert_screen 'gnomecase-defaultapps-gzopen';
-    send_key "ctrl-w";                                     #close fileroller
+    send_key "ctrl-w" unless sle_version_at_least('15');    #close fileroller
     wait_still_screen;
-    assert_and_dclick "gnomecase-defaultapps-htmlfile";    #open html
+    assert_and_dclick "gnomecase-defaultapps-htmlfile";     #open html
     assert_screen 'gnomecase-defaultapps-firefoxopen';
-    send_key "alt-f4";                                     #close firefox
+    send_key "alt-f4";                                      #close firefox
     wait_still_screen;
-    send_key "ctrl-w";                                     #close nautilus
+    send_key "ctrl-w";                                      #close nautilus
 }
 
 # For each element, will check if the mimetype will open with the correct application
 sub check_default_apps {
     my @apps = @_;
 
-    my $default = 1;
-    my @message = ();
+    my $default    = 1;
+    my $returnCode = 1;
+    my @message    = ();
     for my $app (@apps) {
-        my $returnCode = script_run("[ '$app->[1]' == \$(gvfs-mime --query '$app->[0]' |  awk 'NR==1{print \$NF}' | sed 's/[[:space:]]//' ) ]");
+        if (sle_version_at_least('15')) {
+            $returnCode = script_run("[ '$app->[1]' == \$(gio mime '$app->[0]' |  awk 'NR==1{print \$NF}' | sed 's/[[:space:]]//' ) ]");
+        }
+        else {
+            $returnCode = script_run("[ '$app->[1]' == \$(gvfs-mime --query '$app->[0]' |  awk 'NR==1{print \$NF}' | sed 's/[[:space:]]//' ) ]");
+        }
         if ($returnCode) {
             push @message, "The mimetype $app->[0] should open with $app->[1]";
             $default = 0;

--- a/tests/x11regressions/gnomecase/gnome_window_switcher.pm
+++ b/tests/x11regressions/gnomecase/gnome_window_switcher.pm
@@ -22,8 +22,8 @@ sub run {
     x11_start_program("gedit");
     assert_screen 'gedit-launched';
     send_key "super-h";    # Minimize the window
-    x11_start_program("gnote");
-    assert_screen "gnote-first-launched";
+    x11_start_program("totem");
+    assert_screen "test-totem-started";
     send_key "super-h";    # Minimize the window
 
     # Switch windowns with alt+tab
@@ -33,7 +33,7 @@ sub run {
     send_key "tab";
     assert_screen "alt-tab-nautilus";
     send_key "tab";
-    assert_screen "alt-tab-gnote";
+    assert_screen "alt-tab-totem";
     release_key "alt";
 
     # Close the 3 applications

--- a/tests/x11regressions/gnomecase/nautilus_open_ftp.pm
+++ b/tests/x11regressions/gnomecase/nautilus_open_ftp.pm
@@ -33,7 +33,8 @@ sub run {
     send_key 'shift-f10';
     assert_screen 'nautilus-ftp-rightkey-menu';
     # unmount ftp
-    wait_screen_change { send_key 'u' };
+    send_key 'alt-u';
+    assert_screen 'nautilus-launched';
     send_key 'ctrl-w';
 }
 


### PR DESCRIPTION
- Extract load_x11regression_gnome to main_common
- Update main.pm of SLE and openSUSE
- Set NOAUTOLOGIN=1 for regression-installation
- Update 5 cases since TW uses the newer version
- We should also add testsuite of regression-gnome to o3:
  BOOTFROM=c, DESKTOP=gnome,
  HDD_1=openSUSE-%VERSION%-%BUILD%-%ARCH%_for_regression.qcow2,
  REGRESSION=gnome, START_AFTER_TEST=regression-installation

  see also: poo#23884

Validation test: http://10.67.17.30/tests/1908