### PR TITLE
support_server: add a mutex to notify that is is ready

### DIFF
--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -17,41 +17,45 @@ use lockapi;
 use mmapi;
 
 sub run {
-    # Number of node is a mandatory variable!
-    my $num_nodes = get_required_var('HA_NUM_NODES');
+    for my $cluster_infos (split(/,/, get_required_var('CLUSTER_INFOS'))) {
+        # The CLUSTER_INFOS variable for support_server also contains the number of node
+        my ($cluster_name, $num_nodes) = split(/:/, $cluster_infos);
 
-    # Initialize all barrier locks for each cluster
-    for my $clustername (split(/,/, get_var('CLUSTER_NAME'))) {
+        # Number of node is a mandatory variable!
+        if ($num_nodes lt '2') {
+            die "A valid number of nodes is mandatory";
+        }
+
         # BARRIER_HA_ needs to also wait the support-server
-        barrier_create('BARRIER_HA_' . $clustername,                 $num_nodes + 1);
-        barrier_create('CLUSTER_INITIALIZED_' . $clustername,        $num_nodes);
-        barrier_create('NODE_JOINED_' . $clustername,                $num_nodes);
-        barrier_create('DLM_INIT_' . $clustername,                   $num_nodes);
-        barrier_create('DLM_GROUPS_CREATED_' . $clustername,         $num_nodes);
-        barrier_create('DLM_CHECKED_' . $clustername,                $num_nodes);
-        barrier_create('DRBD_INIT_' . $clustername,                  $num_nodes);
-        barrier_create('DRBD_CHECK_DEVICE_NODE_02_' . $clustername,  $num_nodes);
-        barrier_create('DRBD_CREATE_DEVICE_NODE_01_' . $clustername, $num_nodes);
-        barrier_create('DRBD_DOWN_DONE_' . $clustername,             $num_nodes);
-        barrier_create('DRBD_MIGRATION_DONE_' . $clustername,        $num_nodes);
-        barrier_create('DRBD_RES_CREATED_' . $clustername,           $num_nodes);
-        barrier_create('DRBD_SETUP_DONE_' . $clustername,            $num_nodes);
-        barrier_create('OCFS2_INIT_' . $clustername,                 $num_nodes);
-        barrier_create('OCFS2_MKFS_DONE_' . $clustername,            $num_nodes);
-        barrier_create('OCFS2_GROUP_ADDED_' . $clustername,          $num_nodes);
-        barrier_create('OCFS2_DATA_COPIED_' . $clustername,          $num_nodes);
-        barrier_create('OCFS2_MD5_CHECKED_' . $clustername,          $num_nodes);
-        barrier_create('BEFORE_FENCING_' . $clustername,             $num_nodes);
-        barrier_create('FENCING_DONE_' . $clustername,               $num_nodes);
-        barrier_create('LOGS_CHECKED_' . $clustername,               $num_nodes);
-        barrier_create('CLVM_INIT_' . $clustername,                  $num_nodes);
-        barrier_create('CLVM_RESOURCE_CREATED_' . $clustername,      $num_nodes);
-        barrier_create('CLVM_PV_VG_LV_CREATED_' . $clustername,      $num_nodes);
-        barrier_create('CLVM_VG_RESOURCE_CREATED_' . $clustername,   $num_nodes);
-        barrier_create('CLVM_RW_CHECKED_' . $clustername,            $num_nodes);
-        barrier_create('CLVM_MD5SUM_' . $clustername,                $num_nodes);
-        barrier_create('MON_INIT_' . $clustername,                   $num_nodes);
-        barrier_create('MON_CHECKED_' . $clustername,                $num_nodes);
+        barrier_create('BARRIER_HA_' . $cluster_name,                 $num_nodes + 1);
+        barrier_create('CLUSTER_INITIALIZED_' . $cluster_name,        $num_nodes);
+        barrier_create('NODE_JOINED_' . $cluster_name,                $num_nodes);
+        barrier_create('DLM_INIT_' . $cluster_name,                   $num_nodes);
+        barrier_create('DLM_GROUPS_CREATED_' . $cluster_name,         $num_nodes);
+        barrier_create('DLM_CHECKED_' . $cluster_name,                $num_nodes);
+        barrier_create('DRBD_INIT_' . $cluster_name,                  $num_nodes);
+        barrier_create('DRBD_CHECK_DEVICE_NODE_02_' . $cluster_name,  $num_nodes);
+        barrier_create('DRBD_CREATE_DEVICE_NODE_01_' . $cluster_name, $num_nodes);
+        barrier_create('DRBD_DOWN_DONE_' . $cluster_name,             $num_nodes);
+        barrier_create('DRBD_MIGRATION_DONE_' . $cluster_name,        $num_nodes);
+        barrier_create('DRBD_RES_CREATED_' . $cluster_name,           $num_nodes);
+        barrier_create('DRBD_SETUP_DONE_' . $cluster_name,            $num_nodes);
+        barrier_create('OCFS2_INIT_' . $cluster_name,                 $num_nodes);
+        barrier_create('OCFS2_MKFS_DONE_' . $cluster_name,            $num_nodes);
+        barrier_create('OCFS2_GROUP_ADDED_' . $cluster_name,          $num_nodes);
+        barrier_create('OCFS2_DATA_COPIED_' . $cluster_name,          $num_nodes);
+        barrier_create('OCFS2_MD5_CHECKED_' . $cluster_name,          $num_nodes);
+        barrier_create('BEFORE_FENCING_' . $cluster_name,             $num_nodes);
+        barrier_create('FENCING_DONE_' . $cluster_name,               $num_nodes);
+        barrier_create('LOGS_CHECKED_' . $cluster_name,               $num_nodes);
+        barrier_create('CLVM_INIT_' . $cluster_name,                  $num_nodes);
+        barrier_create('CLVM_RESOURCE_CREATED_' . $cluster_name,      $num_nodes);
+        barrier_create('CLVM_PV_VG_LV_CREATED_' . $cluster_name,      $num_nodes);
+        barrier_create('CLVM_VG_RESOURCE_CREATED_' . $cluster_name,   $num_nodes);
+        barrier_create('CLVM_RW_CHECKED_' . $cluster_name,            $num_nodes);
+        barrier_create('CLVM_MD5SUM_' . $cluster_name,                $num_nodes);
+        barrier_create('MON_INIT_' . $cluster_name,                   $num_nodes);
+        barrier_create('MON_CHECKED_' . $cluster_name,                $num_nodes);
     }
 
     # Wait for all children to start
@@ -59,8 +63,10 @@ sub run {
     wait_for_children_to_start;
 
     # To synchronize all nodes (including  the support server)
-    for my $clustername (split(/,/, get_var('CLUSTER_NAME'))) {
-        barrier_wait('BARRIER_HA_' . $clustername);
+    for my $cluster_infos (split(/,/, get_var('CLUSTER_INFOS'))) {
+        # The CLUSTER_INFOS variable for support_server also contains the number of node
+        my ($cluster_name, $num_nodes) = split(/:/, $cluster_infos);
+        barrier_wait('BARRIER_HA_' . $cluster_name);
     }
 }
 

--- a/tests/ha/wait_support_server.pm
+++ b/tests/ha/wait_support_server.pm
@@ -18,9 +18,11 @@ use mmapi;
 
 sub run {
     # Support server takes time to complete setup, so we need to wait (a little!) before
-    my $wait_time = 600;
-    diag "Waiting $wait_time seconds for support server to complete setup...";
-    sleep $wait_time;
+    diag "Waiting for support server to complete setup...";
+
+    # Wait for the support_server to finish
+    mutex_lock('support_server_ready');
+    mutex_unlock('support_server_ready');
 
     # Now we can wait for barrier to synchronize nodes
     barrier_wait('BARRIER_HA_' . get_var('CLUSTER_NAME'));

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -15,6 +15,7 @@ use base "installbasetest";
 use strict;
 
 use testapi;
+use lockapi;
 use bootloader_setup;
 use registration;
 
@@ -27,6 +28,15 @@ sub run {
     specific_bootmenu_params;
     specific_caasp_params;
     registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
+    # if a support_server is used, we need to wait for him to finish its initialization
+    # and we need to do it *before* starting the OS, as a DHCP request can happen too early
+    if (check_var('USE_SUPPORT_SERVER', 1)) {
+        diag "Waiting for support server to complete setup...";
+
+        # we use mutex to do this
+        mutex_lock('support_server_ready');
+        mutex_unlock('support_server_ready');
+    }
     # on ppc64le boot have to be confirmed with ctrl-x or F10
     # and it doesn't have nice graphical menu with video and language options
     if (!check_var('ARCH', 'ppc64le')) {

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -500,10 +500,13 @@ sub run {
     script_output($setup_script, 200);
     assert_script_run "SuSEfirewall2 stop" if $disable_firewall;
 
-    #create mutexes for running services
+    # Create mutexes for running services
     foreach my $mutex (@mutexes) {
         mutex_create($mutex);
     }
+
+    # Create a *last* mutex to signal that support_server initialization is done
+    mutex_create('support_server_ready');
 }
 
 sub test_flags {


### PR DESCRIPTION
To fix sporadic failed of VM installation using a support_server, mainly due to creation time, a lock need to be added.
Mutexes for roles provided by the support_server already exists, but a more generic mutex may be needed to be sure that the whole support_server is ready.

So, this PR do:
- Fix sporadic failed of VM installation by adding the 'support_server_ready' mutex
- Modify 'installation' tests to use the new mutex if needed with the 'USE_SUPPORT_SERVER' variable
- Modify 'ha' tests to use the new mutex, no need to wait anymore for an arbitrary time!

See these tests for the PR validation:
http://moon.qa.suse.cz/tests/229
http://moon.qa.suse.cz/tests/230