### PR TITLE
Work bsc#1058099 around to register against proxy SCC

### DIFF
--- a/tests/console/sle15_workarounds.pm
+++ b/tests/console/sle15_workarounds.pm
@@ -32,13 +32,10 @@ sub run {
     select_console('root-console');
     # Stop packagekit
     pkcon_quit;
-    # Kernel devel packages are not in the dev tools module, so add standard repos
-    record_soft_failure('bsc#1054062');    # Once bug is resolved, this code can be removed
-    zypper_call('ar http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/SUSE:SLE-15:GA.repo');
-    zypper_call('--gpg-auto-import-keys ref');
-    # Requested by ltp team, as curl is missing after installation
-    record_soft_failure('bsc#1053837');    # Once bug is resolved, this code can be removed
-    zypper_call('in curl');
+    if (script_run('test -f /etc/products.d/baseproduct')) {
+        record_soft_failure('bsc#1049164');
+        assert_script_run('ln -s /etc/products.d/SLES.prod /etc/products.d/baseproduct');
+    }
 }
 
 1;

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -30,7 +30,8 @@ sub run {
     else {
         push @welcome_tags, 'inst-welcome';
     }
-
+    # Add tag for soft-failure on SLE 15
+    push @welcome_tags, 'no-product-found-on-scc' if sle_version_at_least('15');
     ensure_fullscreen;
 
     # Process expected pop-up windows and exit when welcome/beta_war is shown or too many iterations
@@ -53,6 +54,11 @@ sub run {
             next;
         }
         if (match_has_tag 'inst-welcome-confirm-self-update-server') {
+            wait_screen_change { send_key $cmd{ok} };
+            next;
+        }
+        if (match_has_tag 'no-product-found-on-scc') {
+            record_soft_failure 'bsc#1056413';
             wait_screen_change { send_key $cmd{ok} };
             next;
         }


### PR DESCRIPTION
Problem is that before we select product, it's considered to be leanOS,
which we cannot register against SCC. With regurl, seems that we are
trying to do so. Which leads to an error, which we don't expect to be
resolved soon. This issue replicates on multiple architectures.

After that we should disable 'ALL_MODULES' and 'WORKAROUND_MODULES' settings from mediums and test suites.

Please, merge [NEEDLES](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/484).
See [poo#23492](https://progress.opensuse.org/issues/23492).

[Verification run](http://gershwin.arch.suse.de/tests/1466).