### PR TITLE
Fix multiple time wait issues for keyboard input

### DIFF
--- a/tests/x11regressions/empathy/empathy_aim.pm
+++ b/tests/x11regressions/empathy/empathy_aim.pm
@@ -92,7 +92,8 @@ sub run {
     assert_and_click 'empathy-disable-aim-account1';
     assert_and_click 'empathy-delete-aim-account1';
     assert_screen 'empathy-confirm-aim-deletion1';
-    wait_screen_change { send_key "alt-r" };
+    send_key "alt-r";
+    wait_still_screen 2;
 
     send_key "alt-c";
 

--- a/tests/x11regressions/shotwell/shotwell_edit.pm
+++ b/tests/x11regressions/shotwell/shotwell_edit.pm
@@ -38,7 +38,8 @@ sub run {
     assert_screen 'shotwell-crop-picture';
     send_key "shift-delete";    # Remove picture from library
     assert_screen 'shotwell-remove-prompt';
-    wait_screen_change { send_key 'alt-r' };
+    send_key 'alt-r';
+    wait_still_screen 2;
     send_key "esc";
     assert_screen 'shotwell-removed-picture', 60;
     send_key "ctrl-q";          # Quit shotwell

--- a/tests/x11regressions/tracker/tracker_search_in_nautilus.pm
+++ b/tests/x11regressions/tracker/tracker_search_in_nautilus.pm
@@ -18,7 +18,8 @@ use testapi;
 sub run {
     x11_start_program("nautilus");
     wait_screen_change { send_key 'ctrl-f' };
-    wait_screen_change { type_string 'newfile' };
+    type_string 'newfile';
+    wait_still_screen 2;
     save_screenshot;
     send_key 'ret';
     assert_screen 'gedit-launched';    # should open file newfile


### PR DESCRIPTION
Fix poo#21048: Empathy, shotwell and tracker tests sometimes fail, when
is keyboard input fast. Tests were updated with wait_still_screen.

Empathy and shotwel fail, if "alt-r" is followed(very fast) by "alt-c" or "esc". It cancels removal operation for both cases. 

Tracker does search during text input (on each character). It means that screen is changed with each type letter and is detected by the test. It results in incomplete search entry and test fails.

Reproduction:
empathy: https://openqa.suse.de/tests/1158277#step/empathy_aim/36
shotwell: https://openqa.suse.de/tests/1161942#step/shotwell_edit/20
tracker: https://openqa.suse.de/tests/1162708#step/tracker_search_in_nautilus/4

Result after fix:
empathy: http://10.100.12.105/tests/1431#step/empathy_aim/36
shotwell: http://10.100.12.105/tests/1434#step/shotwell_edit/20
tracker: http://10.100.12.105/1434#step/tracker_search_in_nautilus/4


