### PR TITLE
poweroff_x11: GNOME: click poweroff instead of using return key

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -632,7 +632,7 @@ sub poweroff_x11 {
     if (check_var("DESKTOP", "gnome")) {
         send_key "ctrl-alt-delete";
         assert_screen 'logoutdialog', 15;
-        send_key "ret";    # confirm shutdown
+        assert_and_click 'gnome-shell_shutdown_btn';
 
         if (get_var("SHUTDOWN_NEEDS_AUTH")) {
             assert_screen 'shutdown-auth', 15;


### PR DESCRIPTION
This aligns with how KDE/SDDM is performing the shutdown. Additionally,
there were cases observed where the keyboard focus is not correct at
every instance of pressing ctrl-alt-del.

smoke-test: http://dimstar.internet-box.ch:81/tests/456