### PR TITLE
Do not check modules preselection when patch or upgrade

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -94,7 +94,13 @@ sub fill_in_registration_data {
 
     # Soft-failure for module preselection
     if (sle_version_at_least('15') && check_var('DISTRI', 'sle')) {
-        assert_screen("modules-preselected-" . get_required_var('SLE_PRODUCT'));
+        my $modules_needle = "modules-preselected-" . get_required_var('SLE_PRODUCT');
+        if (get_var('UPGRADE') || get_var('PATCH')) {
+            check_screen($modules_needle, 5);
+        }
+        else {
+            assert_screen($modules_needle);
+        }
         if (match_has_tag 'bsc#1056413') {
             record_soft_failure('bsc#1056413');
             # Add expected modules to select them manually, as not preselected


### PR DESCRIPTION
The problem is that for the migration scenarios we set VERSION variable
to 15, but first patch SLE 12 version, so should not verify modules
selection. Whereas we should do that during SLE 15 installation.