### PR TITLE
Revert unreviewed CaaSP 2.0 fixes that break Maintenance & Kubic

### DIFF
--- a/tests/caasp/oci_keyboard.pm
+++ b/tests/caasp/oci_keyboard.pm
@@ -17,7 +17,7 @@ use testapi;
 
 sub run {
     # Switch to UK
-    check_var('VIDEOMODE', 'text') ? send_key 'alt-y' : send_key 'alt-e';
+    send_key 'alt-e';
     send_key 'up';
     send_key 'ret' if check_var('VIDEOMODE', 'text');
 
@@ -28,7 +28,7 @@ sub run {
     for (1 .. 6) { send_key 'backspace' }
 
     # Switch to US
-    check_var('VIDEOMODE', 'text') ? send_key 'alt-y' : send_key 'alt-e';
+    send_key 'alt-e';
     send_key 'down';
     send_key 'ret' if check_var('VIDEOMODE', 'text');
 }

--- a/tests/caasp/oci_password.pm
+++ b/tests/caasp/oci_password.pm
@@ -18,7 +18,7 @@ use testapi;
 sub run {
     my ($self) = @_;
 
-    check_var('VIDEOMODE', 'text') ? send_key 'alt-a' : send_key 'alt-w';
+    send_key 'alt-a';
     $self->type_password_and_verification;
     assert_screen "rootpassword-typed";
 }

--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -29,10 +29,10 @@ sub run {
     select_console("root-console");
 
     my $images = 0;
-    if (is_caasp && check_var('FLAVOR', 'DVD') && !check_var('SYSTEM_ROLE', 'plain')) {
+    if (is_caasp) {
         # Docker should be pre-installed in MicroOS
         die "Docker is not pre-installed." if script_run("rpm -q docker");
-        # On CaaSP we have several images from day one
+        # On CaaSP se have several images from day one
         $images = 13;
     }
     else {


### PR DESCRIPTION
The changes to the oci tests are not valid for Kubic 

https://openqa.opensuse.org/tests/484470#step/oci_password/1

They will also never be valid for CaaSP1

The docker changes block a more desired PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3562

So reverting them all so the docker PR can be merged and the oci changes can be done properly.