### PR TITLE
Add bsc#1058099 soft-failure for autoyast

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -136,6 +136,11 @@ sub run {
                 send_key $cmd{ok};
                 next;
             }
+            if (match_has_tag('bsc#1058099')) {
+                record_soft_failure('bsc#1058099');
+                send_key $cmd{ok};
+                next;
+            }
 
             die "Unknown popup message" unless check_screen('autoyast-known-warning', 0);
 


### PR DESCRIPTION
Same failure which we have during installation, but in case of autoyast.

Please, merge [NEEDLES](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/486).
[Verification run](http://gershwin.arch.suse.de/tests/1469).