### PR TITLE
Keyboard selection for all CaaSP flavors

### DIFF
--- a/tests/caasp/oci_keyboard.pm
+++ b/tests/caasp/oci_keyboard.pm
@@ -16,8 +16,13 @@ use base "y2logsstep";
 use testapi;
 
 sub run {
-    # Switch to UK
-    send_key 'alt-e';
+    # Switch to UK keyboard
+    if (check_var('VERSION', '2.0')) {
+        check_var('VIDEOMODE', 'text') ? send_key 'alt-y' : send_key 'alt-e';
+    }
+    else {
+        send_key 'alt-e';
+    }
     send_key 'up';
     send_key 'ret' if check_var('VIDEOMODE', 'text');
 
@@ -27,8 +32,13 @@ sub run {
     assert_screen 'keyboard-layout-uk';
     for (1 .. 6) { send_key 'backspace' }
 
-    # Switch to US
-    send_key 'alt-e';
+    # Switch back to US keyboard
+    if (check_var('VERSION', '2.0')) {
+        check_var('VIDEOMODE', 'text') ? send_key 'alt-y' : send_key 'alt-e';
+    }
+    else {
+        send_key 'alt-e';
+    }
     send_key 'down';
     send_key 'ret' if check_var('VIDEOMODE', 'text');
 }


### PR DESCRIPTION
Fixes: https://openqa.suse.de/tests/1170040#step/oci_keyboard/2

@drpaneas @thehejik @sysrich 