### PR TITLE
Adapt tests for Tumbleweed after php5 has been dropped

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -33,6 +33,7 @@ our @EXPORT = qw(
   is_krypton_argon
   is_kde_live
   is_leap
+  is_sle
   is_tumbleweed
   is_storage_ng
   select_kernel
@@ -289,6 +290,11 @@ sub is_leap {
     return 0 unless check_var('DISTRI', 'opensuse');
     return 1 if get_var('VERSION', '') =~ /(?:[4-9][0-9]|[0-9]{3,})\.[0-9]/;
     return get_var('VERSION') =~ /^42:S/;
+}
+
+sub is_sle {
+    return 0 unless check_var('DISTRI', 'sle');
+    return 1;
 }
 
 sub is_storage_ng {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -435,7 +435,7 @@ sub load_consoletests {
         loadtest "console/http_srv";
         loadtest "console/mysql_srv";
         loadtest "console/dns_srv";
-        if (!is_staging()) {
+        if (!is_staging() && is_leap && !leap_version_at_least('15')) {
             loadtest "console/php5";
             loadtest "console/php5_mysql";
             loadtest "console/php5_postgresql96";

--- a/tests/console/pcre.pm
+++ b/tests/console/pcre.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -24,7 +24,8 @@ sub run {
     assert_script_run "./test_pcrecpp";
     save_screenshot;
 
-    zypper_call("in php5");
+    my $php = ((is_leap && !leap_version_at_least('15')) || (is_sle && !sle_version_at_least('15'))) ? 'php5' : 'php7';
+    zypper_call("in $php");
     assert_script_run "php simple.php | grep 'matches'";
     save_screenshot;
 


### PR DESCRIPTION
The test plan has been adapted to call the php5 tests only when we have
openSUSE Leap < 15 under test or SLE. The php7 tests are triggered unchanged.

Additionally also the test module "console/pcre" had been adapted to install a
corresponding php distribution based on the distribution and version.

Verification runs:
* textmode: http://lord.arch/tests/7269
* pcre: http://lord.arch/tests/7291

Related progress issue: https://progress.opensuse.org/issues/25336