### PR TITLE
Do not load zypper_lr on sle 15 as part of console tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -500,7 +500,7 @@ sub load_extra_tests {
         loadtest 'x11/yast2_lan_restart' if check_var('DISTRI', 'gnome');
     }
     else {
-        loadtest "console/zypper_lr";
+        loadtest "console/zypper_lr_validate";
         loadtest "console/openvswitch";
         # dependency of git test
         loadtest "console/sshd";

--- a/tests/console/zypper_lr_validate.pm
+++ b/tests/console/zypper_lr_validate.pm
@@ -1,23 +1,25 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2016 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Only do very basic zypper lr test and show repos for easy investigation
-# Maintainer: Rodion Iafarov <riafarov@suse.com>
+# Summary: Validate SLE zypper repositories
+# Maintainer: Michal Nowak <mnowak@suse.com>
 
 use base "consoletest";
 use strict;
 use testapi;
-use utils 'zypper_call';
+use utils;
 
 sub run {
+    # ZYPPER_LR is needed for inconsistent migration, test would fail looking for deactivated addon
+    set_var 'ZYPPER_LR', 1;
     select_console 'root-console';
-    assert_script_run "zypper lr --uri | tee /dev/$serialdev";
+    validate_repos;
 }
 
 1;


### PR DESCRIPTION
zypper_lr test module takes 1 hour for execution on SLE 15. And we don't
need full validation in every run of console tests. So we execute
validation part only for extra tests and in all other scenarios we
simply list all repos to simplify investigation.