### PR TITLE
Adapt "default_desktop" for SLE15 after SCC can be used

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -85,7 +85,7 @@ sub default_desktop {
     return 'gnome' if get_var('BASE_VERSION', '') =~ /^12/;
     # In sle15 we add repos manually to make a workaround of missing SCC, gnome will be installed as default system.
     return 'gnome' if get_var('ADDONURL', '') =~ /(desktop|server)/;
-    return (check_var('VIDEOMODE', 'text') || check_var('SLE_PRODUCT', 'leanos')) ? 'textmode' : 'gnome';
+    return (get_var('SCC_REGISTER') && !check_var('SCC_REGISTER', 'installation')) ? 'textmode' : 'gnome';
 }
 
 sub cleanup_needles {


### PR DESCRIPTION
With recent product changes the default desktop of SLE15 depends on the
selection of modules during installation. The availability of modules depends
on registration. The product selection of "leanos" is not a valid choice
anymore so we can safely remove that as well.

Verification run: http://lord.arch.suse.de/t7276

Related progress issue: https://progress.opensuse.org/issues/25282