### PR TITLE
textinfo: Do not fail if there is no /etc/fstab

### DIFF
--- a/data/textinfo
+++ b/data/textinfo
@@ -3,7 +3,7 @@
 uname -a
 lsmod
 free
-cat /etc/fstab
+cat /etc/fstab || echo "no /etc/fstab found"
 mount
 mount | grep -q '/ type btrfs' && /usr/sbin/btrfs filesystem df /
 df -h


### PR DESCRIPTION
The importance of /etc/fstab is decreasing and kiwi 9.11, since the switch
to dracut for the boot process, no longer adds an /etc/fstab file to the
Live images. Instead of failing when the file is not found, make a specific
output about the fact.