### PR TITLE
Fix text mode installation partition disk issues

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -645,7 +645,7 @@ sub load_inst_tests {
     # need to be able to do installations on it. The release notes
     # functionality needs to be covered by other backends
     # Skip release notes test on sle 15 if have addons
-    if (!check_var('BACKEND', 'generalhw') && !(sle_version_at_least('15') && get_var('ADDONURL'))) {
+    if (!check_var('BACKEND', 'generalhw') && !check_var('BACKEND', 'ipmi') && !(sle_version_at_least('15') && get_var('ADDONURL'))) {
         loadtest "installation/releasenotes";
     }
     if (noupdatestep_is_applicable()) {

--- a/tests/installation/partitioning_firstdisk.pm
+++ b/tests/installation/partitioning_firstdisk.pm
@@ -22,7 +22,18 @@ sub take_first_disk_storage_ng {
     return unless is_storage_ng;
     send_key $cmd{guidedsetup};    # select guided setup
     assert_screen 'select-hard-disks';
-    assert_and_click 'hard-disk-dev-sdb-selected';    # Unselect second drive
+    if (check_var('VIDEOMODE', 'text')) {
+        assert_screen 'hard-disk-dev-sdb-selected';
+        if (match_has_tag 'hotkey_d') {
+            send_key 'alt-d';
+        }
+        elsif (match_has_tag 'hotkey_e') {
+            send_key 'alt-e';
+        }
+    }
+    else {
+        assert_and_click 'hard-disk-dev-sdb-selected';    # Unselect second drive
+    }
     assert_screen 'select-hard-disks-one-selected';
     send_key $cmd{next};
     # If drive is not formatted, we have select hard disks page
@@ -34,8 +45,16 @@ sub take_first_disk_storage_ng {
     assert_screen 'partition-scheme';
     send_key $cmd{next};
     # select btrfs file system
-    assert_and_click 'default-root-filesystem';
-    assert_and_click "filesystem-btrfs";
+    if (check_var('VIDEOMODE', 'text')) {
+        assert_screen 'select-root-filesystem';
+        send_key 'alt-f';
+        send_key_until_needlematch 'filesystem-btrfs', 'down', 10, 3;
+        send_key 'ret';
+    }
+    else {
+        assert_and_click 'default-root-filesystem';
+        assert_and_click "filesystem-btrfs";
+    }
     assert_screen "btrfs-selected";
     send_key $cmd{next};
 }


### PR DESCRIPTION
In sle15 installation, partitioning for text mode installation usually fails. One reason is that assert_and_click is not supported on text mode, so rewrite relevant behaviors for text mode installation. Another reason is that releasenote.pm should not be run after parition_finish.pm, so add ipmi condition check when loading the test.

Failed tests:
https://openqa.suse.de/tests/1177878

Relatively adding needles PR(need merge):
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/492/diffs

Verification test:
http://10.67.18.202/tests/305