### PR TITLE
[WIP]Add basic installation and firstboot test for text mode installation on ipmi

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1301,6 +1301,9 @@ elsif (get_var("VIRT_AUTOTEST")) {
         loadtest "virt_autotest/guest_migration_dst";
     }
 }
+elsif (get_var("VERIFY_INSTALLATION_ONLY")) {
+    prepare_target();
+}
 elsif (get_var("QAM_MINIMAL")) {
     prepare_target();
     loadtest "qam-minimal/install_update";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -645,7 +645,7 @@ sub load_inst_tests {
     # need to be able to do installations on it. The release notes
     # functionality needs to be covered by other backends
     # Skip release notes test on sle 15 if have addons
-    if (!check_var('BACKEND', 'generalhw') && !(sle_version_at_least('15') && get_var('ADDONURL'))) {
+    if (!check_var('BACKEND', 'generalhw') && !check_var('BACKEND', 'ipmi') && !(sle_version_at_least('15') && get_var('ADDONURL'))) {
         loadtest "installation/releasenotes";
     }
     if (noupdatestep_is_applicable()) {

--- a/tests/installation/partitioning_firstdisk.pm
+++ b/tests/installation/partitioning_firstdisk.pm
@@ -22,7 +22,18 @@ sub take_first_disk_storage_ng {
     return unless is_storage_ng;
     send_key $cmd{guidedsetup};    # select guided setup
     assert_screen 'select-hard-disks';
-    assert_and_click 'hard-disk-dev-sdb-selected';    # Unselect second drive
+    if (check_var('VIDEOMODE', 'text') || check_var('VIDEOMODE', 'ssh-x')) {
+        assert_screen 'hard-disk-dev-sdb-selected';
+        if (match_has_tag 'hotkey_d') {
+            send_key 'alt-d';
+        }
+        elsif (match_has_tag 'hotkey_e') {
+            send_key 'alt-e';
+        }
+    }
+    else {
+        assert_and_click 'hard-disk-dev-sdb-selected';    # Unselect second drive
+    }
     assert_screen 'select-hard-disks-one-selected';
     send_key $cmd{next};
     # If drive is not formatted, we have select hard disks page
@@ -34,8 +45,16 @@ sub take_first_disk_storage_ng {
     assert_screen 'partition-scheme';
     send_key $cmd{next};
     # select btrfs file system
-    assert_and_click 'default-root-filesystem';
-    assert_and_click "filesystem-btrfs";
+    if (check_var('VIDEOMODE', 'text') || check_var('VIDEOMODE', 'ssh-x')) {
+        assert_screen 'select-root-filesystem';
+        send_key 'alt-f';
+        send_key_until_needlematch 'filesystem-btrfs', 'down', 10, 3;
+        send_key 'ret';
+    }
+    else {
+        assert_and_click 'default-root-filesystem';
+        assert_and_click "filesystem-btrfs";
+    }
     assert_screen "btrfs-selected";
     send_key $cmd{next};
 }


### PR DESCRIPTION
Currently under function group , there is no text mode installation test(videomode=text, rather than desktop=text) on 64bit-ipmi, however this is the test we rely on for virtualization. So it is better to add such test.