### PR TITLE
minimal+base+sdk+proxy_SCC-postreg for SLE15

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -29,6 +29,18 @@ our @EXPORT = qw(
   registration_bootloader_params
   yast_scc_registration
   skip_registration
+  SLE15_MODULES
+);
+
+# We already have needles with names which are different we would use here
+# As it's only workaround, better not to create another set of needles.
+our %SLE15_MODULES = (
+    base      => 'Basesystem',
+    sdk       => 'Development-Tools',
+    desktop   => 'Desktop-Applications',
+    legacy    => 'Legacy',
+    script    => 'Scripting',
+    serverapp => 'Server-Applications'
 );
 
 sub fill_in_registration_data {

--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -1,0 +1,44 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Do the registration against SCC after installation
+# Maintainer: Yi Xu <yxu@suse.de>
+
+use strict;
+use base 'y2logsstep';
+
+use testapi;
+use utils 'sle_version_at_least';
+use registration;
+
+sub run {
+    return if get_var('HDD_SCC_REGISTERED');
+    my $version  = get_required_var('VERSION');
+    my $arch     = get_required_var('ARCH');
+    my $reg_code = get_required_var('SCC_REGCODE');
+    my $scc_url  = get_required_var('SCC_URL');
+
+    select_console 'root-console';
+    assert_script_run "SUSEConnect --url $scc_url -r $reg_code";
+
+    # add modules
+
+    foreach (values %registration::SLE15_MODULES) {
+        assert_script_run "SUSEConnect -p sle-module-" . lc($_) . "/$version/$arch";
+    }
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Post registration using suseconnect or yast. Solution for https://progress.opensuse.org/issues/19566
For testrun:  /usr/share/openqa/script/clone_job.pl --from https://openqa.suse.de 1192670 USE_SUSECONNECT=0  TEST=minimal+base+sdk+proxy_SCC-postreg  HDD_1=SLES-15-x86_64-280.1_unregistered.qcow2 BOOT_HDD_IMAGE=1  EXTRATEST=1 SCC_REGISTER=console INSTALLONLY=0

So following variables have to be set:
BOOT_HDD_IMAGE=1
EXTRATEST=1
SCC_REGISTER=console
USE_SUSECONNECT=0/1 depending if we want to use yast for registration or suseconnect tool.