### PR TITLE
Search for docker based on provides, not arbitrary package name

### DIFF
--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -30,7 +30,7 @@ sub run {
 
     if (is_caasp && check_var('FLAVOR', 'DVD') && !check_var('SYSTEM_ROLE', 'plain')) {
         # Docker should be pre-installed in MicroOS
-        die "Docker is not pre-installed." if script_run("rpm -q docker");
+        die "Docker is not pre-installed." if script_run("zypper se -x --provides -i docker | grep docker");
     }
     else {
         zypper_call("in docker");


### PR DESCRIPTION
Docker will be a package who's name will change a lot over time, with the possibility of alternatives in the not so distant future - search for an installed package that provides docker, not a package with the name docker.