### PR TITLE
reconnect_s390: Better bootup error diagnosis for zVM

### DIFF
--- a/tests/installation/boot_s390.pm
+++ b/tests/installation/boot_s390.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -27,11 +27,6 @@ sub get_to_system {
     $s3270->sequence_3270("ENTER",);
     $s3270->sequence_3270("String(\"cp i 150\")",);
     $s3270->sequence_3270("ENTER",);
-    # sometimes we need to press an additional enter which shouldn't cause
-    # problems. This is actually how mgriessmeier would also do it, just
-    # blindly hit enter key until some stuff happens.
-    $s3270->sequence_3270("ENTER",);
-
 }
 
 sub run {


### PR DESCRIPTION
More specific die messages with helpful diagnostics which bootup steps could
have been reached. Includes a workaround for bsc#1040606.

Verification run: http://lord.arch/tests/7355#step/reconnect_s390/4

Related progress issue: https://progress.opensuse.org/issues/25414