### PR TITLE
Adapt SLE test plan after php5 has been dropped from SLE15

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -853,9 +853,11 @@ sub load_consoletests {
         }
         if (get_var('ADDONS', '') =~ /wsm/ || get_var('SCC_ADDONS', '') =~ /wsm/) {
             loadtest "console/pcre";
-            loadtest "console/php5";
-            loadtest "console/php5_mysql";
-            loadtest "console/php5_postgresql96";
+            if (!sle_version_at_least('15')) {
+                loadtest "console/php5";
+                loadtest "console/php5_mysql";
+                loadtest "console/php5_postgresql96";
+            }
             loadtest "console/php7";
             loadtest "console/php7_mysql";
             loadtest "console/php7_postgresql96";

--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -99,7 +99,7 @@ sub run {
     assert_screen 'http_start_apache2';       # make sure that apache2 server got started when booting
     send_key 'alt-f';                         # now finish the tests :)
     check_screen 'http_install_apache2_mods';
-    send_key 'alt-i';                         # confirm to install apache2_mod_perl, apache2_mod_php5, apache2_mod_python
+    send_key 'alt-i';                         # confirm to install apache2_mod_perl, apache2_mod_php, apache2_mod_python
 
     # if popup, confirm to enable apache2 configuratuion
     if (check_screen('http_enable_apache2', 10)) {


### PR DESCRIPTION
See https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3585 as
well.