### PR TITLE
Support leap_version_at_least('15')

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -497,6 +497,10 @@ sub leap_version_at_least {
     }
 
     if ($version eq '42.3') {
+        return check_var($version_variable, $version) || leap_version_at_least('15', version_variable => $version_variable);
+    }
+
+    if ($version eq '15') {
         return check_var($version_variable, $version);
     }
     # Die to point out that function has to be extended


### PR DESCRIPTION
Follow-up to fd586d8: Support leap_version_at_least('15')

Fix `Unsupported Leap version VERSION 15 in check at /var/lib/openqa/cache/openqa1-opensuse/tests/opensuse/products/opensuse/../../lib/utils.pm line 503`

Fixes #3585
Fixes https://openqa.opensuse.org/tests/489010
Fixes https://openqa.opensuse.org/tests/489011
Fixes https://openqa.opensuse.org/tests/489012
Fixes https://openqa.opensuse.org/tests/489014
Fixes https://openqa.opensuse.org/tests/489015
Fixes https://openqa.opensuse.org/tests/489016
Related to https://progress.opensuse.org/issues/25336