### PR TITLE
Fix autoyast_verify.pm for missing curl

### DIFF
--- a/tests/autoyast/autoyast_verify.pm
+++ b/tests/autoyast/autoyast_verify.pm
@@ -21,6 +21,7 @@ use strict;
 use base 'basetest';
 use testapi;
 use lockapi;
+use utils "zypper_call";
 
 sub expected_failures {
     # Function is used to sof-fail known issues. As long as we use generic
@@ -36,7 +37,8 @@ sub run {
     my $self = shift;
     $self->result('fail');    # default result
     my $success = 0;
-
+    # make sure that curl has been installed
+    zypper_call("in curl", timeout => 180);
     #wait for supportserver if not yet ready
     my $roles_r = get_var_array('SUPPORT_SERVER_ROLES');
     foreach my $role (@$roles_r) {


### PR DESCRIPTION
- ticket: https://progress.opensuse.org/issues/25390
- add zypper_call "in curl";
- reference test: http://e13.suse.de/tests/4182#step/autoyast_verify
