### PR TITLE
Enable yast2_dns_server.pm, yast2_samba.pm again

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -375,22 +375,20 @@ sub load_yast2_ui_tests {
     loadtest "console/yast2_tftp";
     loadtest "console/yast2_vnc";
     # TODO https://progress.opensuse.org/issues/20200
-    #loadtest "console/yast2_samba";
+    # softfail record #bsc1049433 for samba and xinetd
+    loadtest "console/yast2_samba";
     loadtest "console/yast2_xinetd";
     loadtest "console/yast2_apparmor";
     loadtest "console/yast2_lan_hostname";
-    # TODO: check if the following two modules also work on opensuse and delete if
+    # internal nis server in suse network is used, but this is not possible for
+    # openqa.opensuse.org
     if (check_var('DISTRI', 'sle')) {
         loadtest "console/yast2_nis";
     }
-    # TODO: check if the following two modules also work on sle and delete if.
     # yast-lan related tests do not work when using networkmanager.
     # (Livesystem and laptops do use networkmanager)
     if (!get_var("LIVETEST") && !get_var("LAPTOP")) {
-        if (check_var('DISTRI', 'opensuse')) {
-            # fix the issue reported in https://progress.opensuse.org/issues/20970
-            loadtest "console/yast2_dns_server";
-        }
+        loadtest "console/yast2_dns_server";
         loadtest "console/yast2_nfs_client";
     }
     loadtest "console/yast2_http";

--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -14,7 +14,7 @@
 use base "console_yasttest";
 use strict;
 use testapi;
-use utils "zypper_call";
+use utils;
 
 # Test "yast2 dhcp-server" functionality
 # Ensure that all combinations of running/stopped and active/inactive
@@ -55,7 +55,8 @@ sub run {
     select_console 'root-console';
 
     # Make sure packages are installed
-    zypper_call('in yast2-dns-server bind SuSEfirewall2', timeout => 180);
+    my $firewall_package = ((is_sle && is_sle_version_at_least('15')) || (is_leap && is_leap_version_at_least('15'))) ? 'firewalld' : 'SuSEfirewall2';
+    zypper_call("in yast2-dns-server bind $firewall_package", timeout => 180);
     # Let's pretend this is the first execution (could not be the case if
     # yast2_cmdline was executed before)
     script_run 'rm /var/lib/YaST2/dns_server';


### PR DESCRIPTION
- enable yast2_dns_server, yast2_samba in main_common.pm
- update TODO information in main_common.pm
- see ticket for details: https://progress.opensuse.org/issues/19922
- reference test: http://e13.suse.de/tests/4188