### PR TITLE
Add workaround for missing src repos in SLE15

### DIFF
--- a/tests/console/zypper_info.pm
+++ b/tests/console/zypper_info.pm
@@ -68,11 +68,16 @@ sub run {
         $cmd = "mr -e repo-source";
     }
 
-    zypper_call($cmd);
+    zypper_call($cmd) unless (is_sle && sle_version_at_least('15'));
     zypper_call("ref");
 
     # check for zypper info
     test_package_output;
+
+    if (is_sle && sle_version_at_least('15')) {
+        record_soft_failure('no source repo for SLE15 available boo#1059680');
+        return;
+    }
 
     if (sle_version_at_least('12-SP2') || check_var('DISTRI', 'opensuse')) {
         test_srcpackage_output;


### PR DESCRIPTION
Added a workaround for the missing source repos
Now skips the source package test on SLE15

Verification run:
http://10.160.65.204/tests/658

Progress issue:
https://progress.opensuse.org/issues/25396