### PR TITLE
Add support for ppc64le in support_server

### DIFF
--- a/data/supportserver/autoyast_supportserver_ppc64le.xml
+++ b/data/supportserver/autoyast_supportserver_ppc64le.xml
@@ -1,0 +1,238 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <final_halt config:type="boolean">false</final_halt>
+      <final_reboot config:type="boolean">false</final_reboot>
+      <halt config:type="boolean">false</halt>
+      <second_stage config:type="boolean">true</second_stage>
+    </mode>
+    <proposals config:type="list"/>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">false</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">false</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">false</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">false</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">false</import_gpg_key>
+    </signature-handling>
+    <storage/>
+  </general>
+
+
+<!--  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url>http://10.0.2.1/repo/SUSE/Updates/SLE-SERVER/12/x86_64/update/</media_url>
+        <product>SuSE-Linux-Updates</product>
+        <product_dir>/</product_dir>
+	<name>Updates</name>
+      </listentry>
+    </add_on_products>
+  </add-on>
+  -->
+<!--  <http-server>
+
+    <Listen config:type="list">
+      <listentry>
+        <ADDRESS/>
+        <PORT>80</PORT>
+      </listentry>
+    </Listen>
+    <hosts config:type="list">
+      <hosts_entry>
+        <KEY>main</KEY>
+        <VALUE config:type="list">
+          <listentry>
+            <KEY>ServerName</KEY>
+            <VALUE>servername</VALUE>
+          </listentry>
+        </VALUE>
+      </hosts_entry>
+    </hosts>
+    <modules config:type="list">
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>authz_host</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>actions</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>alias</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>authz_user</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>authn_file</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>authz_groupfile</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>auth_basic</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>autoindex</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>cgi</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>dir</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>include</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>log_config</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>mime</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>negotiation</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>setenvif</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>status</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>userdir</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>asis</name>
+      </module_entry>
+      <module_entry>
+        <change>enable</change>
+        <default>1</default>
+        <name>imagemap</name>
+      </module_entry>
+    </modules>
+    <service config:type="boolean">true</service>
+    <version>2.9</version>
+  </http-server>
+-->
+  <networking>
+<!--      <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <startmode>onboot</startmode>
+      </interface>
+    </interfaces>
+    -->
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <startmode>onboot</startmode>
+      </interface>
+    </interfaces>
+
+
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">false</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+    </routing>
+  </networking>
+  <software>
+    <image/>
+    <instsource/>
+    <packages config:type="list">
+		<package>vim</package>
+		<package>apache2</package>
+		<package>dhcp-server</package>
+		<package>mc</package>
+		<package>openssh</package>
+		<package>less</package>
+		<package>nfs-client</package>
+		<package>autofs</package>
+                <package>bind</package>
+		<package>atftp</package>
+		<package>yast2-iscsi-lio-server</package>
+    </packages>
+   <patterns config:type="list">
+          <pattern>base</pattern>
+    </patterns>
+
+
+  </software>
+  <users config:type="list">
+          <user>
+                      <encrypted config:type="boolean">false</encrypted>
+                      <username>root</username>
+                      <user_password>nots3cr3t</user_password>
+          </user>
+	  <user>
+                      <encrypted config:type="boolean">false</encrypted>
+                      <username>bernhard</username>
+                      <user_password>nots3cr3t</user_password>
+          </user>
+  </users>
+
+<!--
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url>http://10.0.2.1/repo/$RCE/SLES11-SP3-Updates/sle-11-x86_64/</media_url>
+        <product>SuSE-Linux-Updates</product>
+        <product_dir>/</product_dir>
+        <name>Updates</name>
+      </listentry>
+    </add_on_products>
+  </add-on>
+-->
+
+  <runlevel>
+    <default>3</default>
+  </runlevel>
+
+</profile>

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -23,8 +23,8 @@ use utils;
 
 my $confirmed_licenses = 0;
 my $stage              = 'stage1';
-my $maxtime            = 2000;       #Max waiting time for stage 1
-my $check_time         = 50;         #Period to check screen during stage 1 and 2
+my $maxtime            = 2000 * get_var('TIMEOUT_SCALE', 1);    #Max waiting time for stage 1
+my $check_time         = 50;                                    #Period to check screen during stage 1 and 2
 
 sub accept_license {
     send_key $cmd{accept};


### PR DESCRIPTION
This patch changes:
- add support of TIMEOUT_SCALE during AutoYaST installation
- support_server die with PXE server on other architecture
  than x86_64, as syslinux is not supported
- some fixes/cleanup in the iSCSI server code

See validation and non-regression tests:
- http://moon.qa.suse.cz/tests/457
- http://moon.qa.suse.cz/tests/564
- http://moon.qa.suse.cz/tests/554