### PR TITLE
Use CaaSP2 style YaST shortcuts in Kubic also

### DIFF
--- a/tests/caasp/oci_keyboard.pm
+++ b/tests/caasp/oci_keyboard.pm
@@ -17,7 +17,7 @@ use testapi;
 
 sub run {
     # Switch to UK keyboard
-    if (check_var('VERSION', '2.0')) {
+    if (!check_var('VERSION', '1.0')) {
         check_var('VIDEOMODE', 'text') ? send_key 'alt-y' : send_key 'alt-e';
     }
     else {
@@ -33,7 +33,7 @@ sub run {
     for (1 .. 6) { send_key 'backspace' }
 
     # Switch back to US keyboard
-    if (check_var('VERSION', '2.0')) {
+    if (!check_var('VERSION', '1.0')) {
         check_var('VIDEOMODE', 'text') ? send_key 'alt-y' : send_key 'alt-e';
     }
     else {

--- a/tests/caasp/oci_password.pm
+++ b/tests/caasp/oci_password.pm
@@ -18,7 +18,7 @@ use testapi;
 sub run {
     my ($self) = @_;
 
-    if (check_var('VERSION', '2.0')) {
+    if (!check_var('VERSION', '1.0')) {
         check_var('VIDEOMODE', 'text') ? send_key 'alt-a' : send_key 'alt-w';
     }
     else {


### PR DESCRIPTION
Kubic now has the same yast2-caasp as CaaSP 2.0

Therefore the current workarounds of 'If Version = 2.0' will now actually prevent Kubic from passing

Therefore changing them (as @drpaneas suggested) to be "If !Version = 1.0" to still preserve CaaSP 1 behaviour for SUSE QAM but leave CaaSP 2.0 and Kubic / 3 using the new behaviour