### PR TITLE
[qa_automation] Collect iptables info during qa regression testing

### DIFF
--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -28,11 +28,12 @@ sub system_status {
     my $log  = shift || "/tmp/system-status.log";
     my @klst = ("kernel", "cpuinfo", "memory", "repos", "dmesg");
     my %cmds = (
-        kernel  => "uname -a",
-        cpuinfo => "cat /proc/cpuinfo",
-        memory  => "free -m",
-        repos   => "zypper repos -u",
-        dmesg   => "dmesg"
+        kernel   => "uname -a",
+        cpuinfo  => "cat /proc/cpuinfo",
+        memory   => "free -m",
+        iptables => "iptables -L -n --line-numbers",
+        repos    => "zypper repos -u",
+        dmesg    => "dmesg"
     );
     foreach my $key (@klst) {
         my $cmd = "echo '=========> $key <=========' >> $log; ";


### PR DESCRIPTION
Also add iptables info to system-status.log file.