### PR TITLE
Do not run 'register_and_check' for controller

### DIFF
--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -167,7 +167,9 @@ else {
 }
 
 # ==== Extra tests run after installation  ====
-if (get_var('REGISTER')) {
+# REGISTER = 'suseconnect' -> Registers with SCC after the installation
+# REGISTER = 'installation' -> Registers with SCC during the installation
+if (get_var('REGISTER') && !check_var('STACK_ROLE', 'controller')) {
     loadtest 'caasp/register_and_check';
 }
 


### PR DESCRIPTION
The controller node is not part of the CaaSP cluster but it is
used as a helpful mechanism, acting as dhcp, dns and ntp server.
It also operates on SLES 12 SP2, which is irrelevant to MicroOS.
As result, the SCC registration against CaaSP fails for obvious
reasons and brings the whole testsuite into pieces.

This PR removes the 'register_and_check' from the controller
and also fixes the `CaaSP DVD Deployment` when the `REGISTER`
variable is set to `installation` string value.