### PR TITLE
SLERT: remove fatal test flag from kmp_modules.pm

### DIFF
--- a/tests/rt/kmp_modules.pm
+++ b/tests/rt/kmp_modules.pm
@@ -55,10 +55,6 @@ sub run {
     reset_consoles;
 }
 
-sub test_flags {
-    return {fatal => 1};
-}
-
 1;
 
 # vim: set sw=4 et:


### PR DESCRIPTION
Test kmp_modules.pm is failing on latest alpha image for SLERT 12 SP3 due bug bsc#1060455 and return {fatal->1}; but we need to check also tests which are executed after kmp_modules test so I removed test_flags{} to be able continue from milestone snapshot taken before.

Before http://dhcp62.suse.cz/tests/2118
After http://dhcp62.suse.cz/tests/2129