### PR TITLE
Test gnome-keyring with secure shell key creation

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -732,6 +732,7 @@ sub load_security_tests_misc {
     # appropriate for other arches.
     loadtest "x11/hexchat_ssl" if (check_var('ARCH', 'x86_64'));
     loadtest "x11/x3270_ssl";
+    loadtest "x11/seahorse_sshkey";
 }
 
 sub load_security_tests_crypt {

--- a/tests/x11/seahorse_sshkey.pm
+++ b/tests/x11/seahorse_sshkey.pm
@@ -1,0 +1,40 @@
+# SUSE's gnome-keyring tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Test add new secure shell key with gnome-keyring
+# Maintainer: Jiawei Sun <jiawei.sun@suse.com>
+
+use base "x11test";
+use strict;
+use testapi;
+
+sub run {
+    x11_start_program("seahorse");
+    assert_screen 'seahorse-launched';            # Seahorse main window appeared
+    send_key "ctrl-n";                            # New Keyring
+    assert_screen 'seahorse-keyring-selector';    # Dialog "Select type to create"
+    send_key_until_needlematch("seahorse-secure-shell-key", "down");    # Selected secure shell key
+    send_key 'ret';
+    assert_screen 'seahorse-new-sshkey';                                # Dialog : "Add password; New ssh key"
+    send_key 'alt-d';
+    type_string "Keyring test";                                         # Name of new ssh key
+    send_key 'alt-j';                                                   # Just Create ssh key without setup
+    assert_screen 'seahorse-sshkey-passphrase';                         # sshkey passphrase
+    type_password;
+    send_key 'ret';
+    assert_screen 'seahorse-sshkey-passphrase-retype';                  # sshkey passphrase retype
+    type_password;
+    send_key 'ret';
+    assert_and_click "seahorse-sshkey-list";                            # check the sshkey list
+    assert_screen "seahorse-display-sshkey";                            # verify the new ssh key has been added to the keyring
+    send_key "alt-f4";                                                  # close seahorse
+}
+
+1;
+# vim: set sw=6 et:


### PR DESCRIPTION
Setup and create a new ssh key with seahorese, and check if it has been save to the keyring.
This case can be running both with & without fips enable.
Verification run http://10.67.17.147/tests/1568