### PR TITLE
Fix issues related to switch of x11 console to tty2 on SLE15

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -2,7 +2,7 @@ package susedistribution;
 use base 'distribution';
 use serial_terminal ();
 use strict;
-use utils qw(type_string_slow ensure_unlocked_desktop save_svirt_pty sle_version_at_least is_caasp get_root_console_tty);
+use utils qw(type_string_slow ensure_unlocked_desktop save_svirt_pty sle_version_at_least is_caasp get_root_console_tty get_x11_console_tty);
 
 # Base class implementation of distribution class necessary for testapi
 
@@ -268,7 +268,7 @@ sub init_consoles {
         $self->add_console('root-console', 'tty-console', {tty => get_root_console_tty});
         $self->add_console('user-console', 'tty-console', {tty => 4});
         $self->add_console('log-console',  'tty-console', {tty => 5});
-        $self->add_console('x11',          'tty-console', {tty => 7});
+        $self->add_console('x11',          'tty-console', {tty => get_x11_console_tty});
     }
 
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -77,6 +77,7 @@ our @EXPORT = qw(
   run_scripted_command_slow
   snapper_revert_system
   get_root_console_tty
+  get_x11_console_tty
   OPENQA_FTP_URL
 );
 
@@ -1368,11 +1369,20 @@ sub snapper_revert_system {
 =head2 get_root_console_tty
     Returns tty number used designed to be used for root-console.
     When console is not yet initialized, we cannot get it from arguments.
-    Since SLE 15 gdm is running on tty2, so we change behaviour for it and
-    openSUSE distris.
+    Since SLE 15 gdm is always running on tty7, GUI session will running
+    independently on tty2, so we change behaviour for it and openSUSE distris.
 =cut
 sub get_root_console_tty {
     return (sle_version_at_least('15') && !is_caasp) ? 6 : 2;
+}
+
+=head2 get_x11_console_tty
+    Returns tty number used designed to be used for X
+    Since SLE 15 gdm is always running on tty7, currently the main GUI session
+    is running on tty2 by default. see also: bsc#1054782
+=cut
+sub get_x11_console_tty {
+    return (sle_version_at_least('15')) ? 2 : 7;
 }
 
 1;


### PR DESCRIPTION
tty7 in SLE 15 is a constant greeting tty in gnome 3.26, X will running on tty2 by default.

  see also: poo#25608, bsc#1054782

[Verification run](http://10.67.17.30/tests/1935#step/updates_packagekit_gpk/3)
Now we can switch back to X console successfully. The failure of updates_packagekit_gpk is caused by another bug: [bsc#1060844](https://bugzilla.suse.com/show_bug.cgi?id=1060844)