### PR TITLE
Readd get_x11_console_tty supporting all current variants (#3645)

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -2,7 +2,7 @@ package susedistribution;
 use base 'distribution';
 use serial_terminal ();
 use strict;
-use utils qw(type_string_slow ensure_unlocked_desktop save_svirt_pty sle_version_at_least is_caasp get_root_console_tty);
+use utils qw(type_string_slow ensure_unlocked_desktop save_svirt_pty sle_version_at_least is_caasp get_root_console_tty get_x11_console_tty);
 
 # Base class implementation of distribution class necessary for testapi
 
@@ -265,10 +265,11 @@ sub init_consoles {
         $self->add_console('installation',   'tty-console', {tty => check_var('VIDEOMODE', 'text') ? 1 : 7});
         $self->add_console('install-shell2', 'tty-console', {tty => 9});
         # On SLE15 X is running on tty2 see bsc#1054782
-        $self->add_console('root-console', 'tty-console', {tty => get_root_console_tty});
-        $self->add_console('user-console', 'tty-console', {tty => 4});
-        $self->add_console('log-console',  'tty-console', {tty => 5});
-        $self->add_console('x11',          'tty-console', {tty => 7});
+        $self->add_console('root-console',   'tty-console', {tty => get_root_console_tty});
+        $self->add_console('user-console',   'tty-console', {tty => 4});
+        $self->add_console('log-console',    'tty-console', {tty => 5});
+        $self->add_console('displaymanager', 'tty-console', {tty => 7});
+        $self->add_console('x11',            'tty-console', {tty => get_x11_console_tty});
     }
 
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -77,6 +77,7 @@ our @EXPORT = qw(
   run_scripted_command_slow
   snapper_revert_system
   get_root_console_tty
+  get_x11_console_tty
   OPENQA_FTP_URL
 );
 
@@ -1373,6 +1374,16 @@ sub snapper_revert_system {
 =cut
 sub get_root_console_tty {
     return (sle_version_at_least('15') && !is_caasp) ? 6 : 2;
+}
+
+=head2 get_x11_console_tty
+    Returns tty number used designed to be used for X
+    Since SLE 15 gdm is always running on tty7, currently the main GUI session
+    is running on tty2 by default. see also: bsc#1054782
+=cut
+sub get_x11_console_tty {
+    my $new_gdm = !(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15'));
+    return (check_var('DESKTOP', 'gnome') && get_var('NOAUTOLOGIN') && $new_gdm) ? 2 : 7;
 }
 
 1;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -155,10 +155,6 @@ sub cleanup_needles {
     }
 }
 
-my $distri = testapi::get_required_var('CASEDIR') . '/lib/susedistribution.pm';
-require $distri;
-testapi::set_distribution(susedistribution->new());
-
 diag('default desktop: ' . default_desktop);
 
 # SLE specific variables
@@ -1080,6 +1076,10 @@ sub prepare_target {
         load_reboot_tests();
     }
 }
+
+my $distri = testapi::get_required_var('CASEDIR') . '/lib/susedistribution.pm';
+require $distri;
+testapi::set_distribution(susedistribution->new());
 
 # load the tests in the right order
 if (maybe_load_kernel_tests()) {


### PR DESCRIPTION
I moved the distribution initialization to make sure the variables evaluated
in init_consoles calling get_root_console_tty already regard the updated
defaults, for example the value for default desktop.

This does not consider a display manager different then the default for a
certain desktop as well as other potential impacts but the approach is proven
to work for now.

Validation runs:
* SLE15 gnome: http://lord.arch/tests/7577
* SLE15 icewm: http://lord.arch/tests/7564
* Leap 42.3 QAM icewm: http://lord.arch/tests/7562
* Tumbleweed gnome: http://lord.arch/tests/7563