### PR TITLE
Install parted for xfstests, because SLE15 doesn't installed it as default

### DIFF
--- a/tests/qa_automation/xfstests_install.pm
+++ b/tests/qa_automation/xfstests_install.pm
@@ -56,7 +56,7 @@ sub prepare_testpackage {
     assert_script_run("cd /root/");
     assert_script_run("zypper ref", 60);
     assert_script_run(
-"zypper -n in git e2fsprogs automake gcc libuuid1 quota attr make xfsprogs libgdbm4 gawk uuid-runtime acl bc dump indent libtool lvm2 psmisc sed xfsdump libacl-devel libattr-devel libaio-devel libuuid-devel openssl-devel xfsprogs-devel",
+"zypper -n in git e2fsprogs automake gcc libuuid1 quota attr make xfsprogs libgdbm4 gawk uuid-runtime acl bc dump indent libtool lvm2 psmisc sed xfsdump libacl-devel libattr-devel libaio-devel libuuid-devel openssl-devel xfsprogs-devel parted",
         60 * 10
     );
     assert_script_run("git clone git://git.kernel.org/pub/scm/fs/xfs/xfstests-dev.git", 60 * 10);


### PR DESCRIPTION
Add one package "parted" in prepare stage. It used to default installed in SLE12, but not in SLE15.
This package is necessary in xfstests test to prepare test device.

This package is in module basesystem:
linux-zes4:~/xfstests-dev # zypper se -s parted
Loading repository data...
Reading installed packages...

S  | Name         | Type       | Version | Arch   | Repository
---+--------------+------------+---------+--------+-----------
i  | libparted0   | package    | 3.2-4.1 | s390x  | Basesystem
i+ | parted       | package    | 3.2-4.1 | s390x  | Basesystem
   | parted       | srcpackage | 3.2-4.1 | noarch | Basesystem
   | parted-devel | package    | 3.2-4.1 | s390x  | Basesystem
