### PR TITLE
Revert "Fix issues related to switch of x11 console to tty2 on SLE15"

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -2,7 +2,7 @@ package susedistribution;
 use base 'distribution';
 use serial_terminal ();
 use strict;
-use utils qw(type_string_slow ensure_unlocked_desktop save_svirt_pty sle_version_at_least is_caasp get_root_console_tty get_x11_console_tty);
+use utils qw(type_string_slow ensure_unlocked_desktop save_svirt_pty sle_version_at_least is_caasp get_root_console_tty);
 
 # Base class implementation of distribution class necessary for testapi
 
@@ -268,7 +268,7 @@ sub init_consoles {
         $self->add_console('root-console', 'tty-console', {tty => get_root_console_tty});
         $self->add_console('user-console', 'tty-console', {tty => 4});
         $self->add_console('log-console',  'tty-console', {tty => 5});
-        $self->add_console('x11',          'tty-console', {tty => get_x11_console_tty});
+        $self->add_console('x11',          'tty-console', {tty => 7});
     }
 
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -77,7 +77,6 @@ our @EXPORT = qw(
   run_scripted_command_slow
   snapper_revert_system
   get_root_console_tty
-  get_x11_console_tty
   OPENQA_FTP_URL
 );
 
@@ -1369,20 +1368,11 @@ sub snapper_revert_system {
 =head2 get_root_console_tty
     Returns tty number used designed to be used for root-console.
     When console is not yet initialized, we cannot get it from arguments.
-    Since SLE 15 gdm is always running on tty7, GUI session will running
-    independently on tty2, so we change behaviour for it and openSUSE distris.
+    Since SLE 15 gdm is running on tty2, so we change behaviour for it and
+    openSUSE distris.
 =cut
 sub get_root_console_tty {
     return (sle_version_at_least('15') && !is_caasp) ? 6 : 2;
-}
-
-=head2 get_x11_console_tty
-    Returns tty number used designed to be used for X
-    Since SLE 15 gdm is always running on tty7, currently the main GUI session
-    is running on tty2 by default. see also: bsc#1054782
-=cut
-sub get_x11_console_tty {
-    return (sle_version_at_least('15')) ? 2 : 7;
 }
 
 1;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#3645

This is a much more general issue that simply *cannot* be fixed this way!
The VT the graphical session ends up depends on a lot more factors:
* The display manager in use (xdm, gdm, sddm, lightdm)
* The VT allocation algorithm (sddm starts at 7, gdm at 1, etc.)
* The VTs currently in use (root-console, user-console, etc.)
* The display server (X can reuse the server, but wayland might not, so a different VT is used)

None of those are looked at here so this is broken. Also see the various discussions about this issue on other wayland-related topics.

it's all not so easy. Problem is that init_consoles is called before we know all the parameters which define the product so the check as proposed checking desktop and the value of NOAUTOLOGIN also will not work at this time.