### PR TITLE
[WIP] Increase timeout for collecting logs

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -201,7 +201,7 @@ sub verify_license_has_to_be_accepted {
 sub save_upload_y2logs {
     my ($self) = shift;
     assert_script_run 'sed -i \'s/^tar \(.*$\)/tar --warning=no-file-changed -\1 || true/\' /usr/sbin/save_y2logs';
-    assert_script_run "save_y2logs /tmp/y2logs.tar.bz2";
+    assert_script_run "save_y2logs /tmp/y2logs.tar.bz2", 180;
     upload_logs "/tmp/y2logs.tar.bz2";
     save_screenshot();
     $self->investigate_yast2_failure();


### PR DESCRIPTION
In arm collecting yast logs may take longer than 90 seconds, which is
default timeout for assert_script_run now.

See [poo#25394](https://progress.opensuse.org/issues/25394).

No verification run, fixing arm worker.