### PR TITLE
Add workaround in yast2_network_setting.pm

### DIFF
--- a/tests/yast2_gui/yast2_network_settings.pm
+++ b/tests/yast2_gui/yast2_network_settings.pm
@@ -23,7 +23,13 @@ sub run {
     my $module = "lan";
 
     $self->launch_yast2_module_x11($module);
-    assert_screen "yast2-$module-ui", 60;
+    assert_screen([qw(yast2-lan-ui yast2_still_susefirewall2)], 90);
+    if (match_has_tag('yast2_still_susefirewall2')) {
+        record_soft_failure "bsc#1059569";
+        send_key 'alt-i';
+        wait_still_screen;
+    }
+
 
     #	Global Options
     send_key 'alt-g';


### PR DESCRIPTION
- workaround for SuSEfirewall2 because of bsc#1059569
  with this workaround test can continue to be finished
- see poo ticket #25640 for details
- needles PR:
  https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/511
- reference test:  http://e13.suse.de/tests/4301