### PR TITLE
Fix user#01 selection on gnome

### DIFF
--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -54,8 +54,11 @@ sub run {
     # login created user
     assert_screen 'multi_users_dm';
     wait_still_screen;
-    if (check_var('DESKTOP', 'gnome') || check_var('DESKTOP', 'xfce')) {
-        send_key 'down';    # select created user #01
+    if (check_var('DESKTOP', 'gnome')) {
+        send_key_until_needlematch('user#01_selected', 'up', 5, 3);    # select created user #01
+    }
+    elsif (check_var('DESKTOP', 'xfce')) {
+        send_key 'down';                                               # select created user #01
     }
     elsif (check_var('DESKTOP', 'kde')) {
         for (1 .. 6) {


### PR DESCRIPTION
On gnome when having many users created, not the first user in the list
is selected, as mouse cursor is in the middle of the screen. Clicking
doesn't work, as list gets scrolled when pointer is moved, as a result
we click wrong user, so using up key. Whereas, to select user correctly
needle has 100% match level, as matches other users with 97% accuracy.

Please, do not forget to merge [NEEDLES](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/271).

See [poo#25446](https://progress.opensuse.org/issues/25446).
[Verification run](http://gershwin.arch.suse.de/tests/1500) Fails in the shutdown for unknown reason.
