### PR TITLE
Disable updates_packagekit_gpk for SLE15

### DIFF
--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -34,6 +34,10 @@ sub turn_off_screensaver {
 
 # Update with GNOME PackageKit Update Viewer
 sub run {
+    if (sle_version_at_least('15')) {
+        record_soft_failure 'bsc#1057223';    # updates_packagekit_gpk is disabled for SLE15 because of bsc#1061243
+        return;
+    }
     my ($self) = @_;
     select_console 'x11', await_console => 0;
 


### PR DESCRIPTION
A better approach for adapting WE test.