### PR TITLE
Disable smt test as will be replace by rmt

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -49,7 +49,8 @@ sub is_sles4sap_standard {
 }
 
 sub is_smt {
-    return (get_var("PATTERNS", '') || get_var('HDD_1', '')) =~ /smt/;
+    # Smt is replaced with rmt in SLE 15, see bsc#1061291
+    return ((get_var("PATTERNS", '') || get_var('HDD_1', '')) =~ /smt/) && !sle_version_at_least('15');
 }
 
 sub is_kgraft {


### PR DESCRIPTION
smt is dropped, no sense to run smt test module for SLE 15, hence do not
load. We also need new tests for rmt, see
[poo#25800](https://progress.opensuse.org/issues/25800).

[Verification run](http://gershwin.arch.suse.de/tests/1506#).