### PR TITLE
Disable hostname_inst test on bridged networks

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -642,9 +642,11 @@ sub load_inst_tests {
         loadtest "installation/installer_timezone";
         # the test should run only in scenarios, where installed
         # system is not being tested (e.g. INSTALLONLY etc.)
+        # The test also won't work reliably when network is bridged (non-s390x svirt).
         if (    !consolestep_is_applicable()
             and !get_var("REMOTE_CONTROLLER")
             and !is_hyperv_in_gui
+            and !is_bridged_networking
             and !check_var('BACKEND', 's390x')
             and sle_version_at_least('12-SP2'))
         {


### PR DESCRIPTION
Fails here: https://openqa.suse.de/tests/1195266#step/hostname_inst/9

Hostname on bridged networks on svirt are known to be far from what's
expected everywhere else. Disabling the test.

Verification run: http://assam.suse.cz/tests/584