### PR TITLE
Soft fail updates_packagekit_gpk for SLE15

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -889,9 +889,7 @@ sub load_x11tests {
     loadtest "x11/xterm";
     loadtest "x11/sshxterm";
     if (gnomestep_is_applicable()) {
-        if (!sle_version_at_least('15') && !(is_staging)) {
-            loadtest "update/updates_packagekit_gpk";    # updates_packagekit_gpk is disabled for SLE15 because of bsc#1061243
-        }
+        loadtest "update/updates_packagekit_gpk" unless is_staging;
         loadtest "x11/gnome_control_center";
         loadtest "x11/gnome_terminal";
         loadtest "x11/gedit";

--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -34,6 +34,10 @@ sub turn_off_screensaver {
 
 # Update with GNOME PackageKit Update Viewer
 sub run {
+    if (sle_version_at_least('15')) {
+        record_soft_failure 'bsc#1057223';    # updates_packagekit_gpk is disabled for SLE15 because of bsc#1061243
+        return;
+    }
     my ($self) = @_;
     select_console 'x11', await_console => 0;
 


### PR DESCRIPTION
As @okurz suggested in another PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3643, changing the approach into softfail test module updates_packagekit_gpk for SLE15.