### PR TITLE
Speedup x11_start_program

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -120,9 +120,6 @@ sub x11_start_program($$$) {
         type_string $program;
     }
     wait_still_screen(1);
-    if ($options->{terminal}) {
-        wait_screen_change { send_key 'alt-t' };
-    }
     save_screenshot;
     send_key 'ret';
     wait_still_screen unless $options->{no_wait};

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -59,8 +59,7 @@ sub prepare_sle_classic {
 sub test_terminal {
     my ($self, $name) = @_;
     mouse_hide(1);
-    x11_start_program($name);
-    assert_screen $name;
+    x11_start_program($name, 6, {target_match => $name});
     $self->enter_test_text($name, cmd => 1);
     assert_screen "test-$name-1";
     send_key 'alt-f4';

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -59,7 +59,7 @@ sub prepare_sle_classic {
 sub test_terminal {
     my ($self, $name) = @_;
     mouse_hide(1);
-    x11_start_program($name, 6, {target_match => $name});
+    x11_start_program($name, target_match => $name);
     $self->enter_test_text($name, cmd => 1);
     assert_screen "test-$name-1";
     send_key 'alt-f4';

--- a/lib/y2x11test.pm
+++ b/lib/y2x11test.pm
@@ -4,17 +4,31 @@ use strict;
 
 use testapi;
 
-sub launch_yast2_module_x11 {
-    my ($self, $module) = @_;
-    $module //= '';
+=head2 launch_yast2_module_x11
 
-    x11_start_program("xdg-su -c '/sbin/yast2 $module'");
-    if (check_screen "root-auth-dialog") {
-        if ($password) {
-            type_password;
-            wait_screen_change { send_key "ret" };
-        }
+  launch_yast2_module_x11([$module] [, target_match => $target_match] [, match_timeout => $match_timeout]);
+
+Launch a yast configuration module C<$module> or the yast control center if
+C<$module> is empty. Calls C<assert_screen> on C<$target_match>, defaults to
+C<yast2-$module-ui>. Optional C<$match_timeout> can be specified as a timeout
+on the C<assert_screen> call on C<$target_match>.
+=cut
+sub launch_yast2_module_x11 {
+    my ($self, $module, %args) = @_;
+    $module //= '';
+    $args{target_match} //= $module ? "yast2-$module-ui" : 'yast2-ui';
+    my @tags = ['root-auth-dialog', ref $args{target_match} eq 'ARRAY' ? @{$args{target_match}} : $args{target_match}];
+    x11_start_program("xdg-su -c '/sbin/yast2 $module'", 6, {target_match => @tags, match_timeout => $args{match_timeout}});
+    foreach ($args{target_match}) {
+        return if match_has_tag($_);
     }
+    die "unexpected last match" unless match_has_tag 'root-auth-dialog';
+    die "need password definition" unless $password;
+    diag 'assuming root-auth-dialog, typing password';
+    type_password;
+    save_screenshot;
+    send_key 'ret';
+    assert_screen $args{target_match};
 }
 
 sub post_fail_hook {

--- a/lib/y2x11test.pm
+++ b/lib/y2x11test.pm
@@ -18,7 +18,7 @@ sub launch_yast2_module_x11 {
     $module //= '';
     $args{target_match} //= $module ? "yast2-$module-ui" : 'yast2-ui';
     my @tags = ['root-auth-dialog', ref $args{target_match} eq 'ARRAY' ? @{$args{target_match}} : $args{target_match}];
-    x11_start_program("xdg-su -c '/sbin/yast2 $module'", 6, {target_match => @tags, match_timeout => $args{match_timeout}});
+    x11_start_program("xdg-su -c '/sbin/yast2 $module'", target_match => @tags, match_timeout => $args{match_timeout});
     foreach ($args{target_match}) {
         return if match_has_tag($_);
     }

--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -48,10 +48,6 @@ sub run {
     my $self = shift;
     # NET isos are slow to install
     my $timeout = 2000;
-    # aarch64 can be particularily slow depending on the hardware
-    $timeout *= 2 if check_var('ARCH', 'aarch64') && get_var('MAX_JOB_TIME');
-    # encryption, LVM and RAID makes it even slower
-    $timeout *= 2 if (get_var('ENCRYPT') || get_var('LVM') || get_var('RAID'));
 
     # workaround for yast popups and
     # detect "Wrong Digest" error to end test earlier
@@ -68,9 +64,13 @@ sub run {
         push(@tags, 'screenlock');
     }
     # SCC might mean we install everything from the slow internet
-    if (check_var('SCC_REGISTER', 'installation')) {
+    if (check_var('SCC_REGISTER', 'installation') && !get_var('SCC_URL')) {
         $timeout = 5500;
     }
+    # aarch64 can be particularily slow depending on the hardware
+    $timeout *= 2 if check_var('ARCH', 'aarch64') && get_var('MAX_JOB_TIME');
+    # encryption, LVM and RAID makes it even slower
+    $timeout *= 2 if (get_var('ENCRYPT') || get_var('LVM') || get_var('RAID'));
     # multipath installations seem to take longer (failed some time)
     $timeout *= 2 if check_var('MULTIPATH', 1);
     # on s390 we might need to install additional packages depending on the installation method

--- a/tests/x11/amarok.pm
+++ b/tests/x11/amarok.pm
@@ -17,7 +17,7 @@ use testapi;
 
 sub run {
     ensure_installed("amarok");
-    x11_start_program("amarok", 6, {valid => 1});
+    x11_start_program('amarok');
     assert_screen 'test-amarok-1';
     send_key "alt-y";    # use music path as collection folder
                          # a workaround for librivox authentication popup window.

--- a/tests/x11/dolphin.pm
+++ b/tests/x11/dolphin.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("dolphin", 6, {valid => 1});
+    x11_start_program('dolphin');
     assert_screen 'test-dolphin-1';
     send_key "alt-f4";
 }

--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,7 +19,7 @@ use testapi;
 
 sub start_firefox {
     my ($self) = @_;
-    x11_start_program("firefox https://html5test.com/index.html", 6, {valid => 1});
+    x11_start_program('firefox https://html5test.com/index.html');
     $self->firefox_check_default;
     $self->firefox_check_popups;
     assert_screen 'firefox-html5test';

--- a/tests/x11/glxgears.pm
+++ b/tests/x11/glxgears.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,7 @@ use testapi;
 sub run {
     ensure_installed 'Mesa-demo-x';
     # 'no_wait' for still screen because glxgears will be always moving
-    x11_start_program('glxgears', 30, {no_wait => 1});
+    x11_start_program('glxgears', no_wait => 1);
     assert_screen 'test-glxgears-1';
     send_key 'alt-f4';
 }

--- a/tests/x11/kate.pm
+++ b/tests/x11/kate.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,7 +19,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     ensure_installed("kate");
-    x11_start_program("kate", 6, {valid => 1});
+    x11_start_program('kate');
     assert_screen 'test-kate-1';
 
     if (!get_var("PLASMA5")) {

--- a/tests/x11/khelpcenter.pm
+++ b/tests/x11/khelpcenter.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("khelpcenter", 6, {valid => 1});
+    x11_start_program('khelpcenter');
     assert_screen 'test-khelpcenter-1';
     send_key 'alt-f4';
 }

--- a/tests/x11/kontact.pm
+++ b/tests/x11/kontact.pm
@@ -40,7 +40,7 @@ sub run {
     # persist consistently as a process in the background causing kontact to
     # be "restored" after a re-login/reboot causing later tests to fail. To
     # prevent this we explicitly stop the kontact background process.
-    x11_start_program('killall kontact', 6, {valid => 0});
+    x11_start_program('killall kontact', valid => 0);
 }
 
 1;

--- a/tests/x11/oocalc.pm
+++ b/tests/x11/oocalc.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("oocalc", 6, {valid => 1});
+    x11_start_program('oocalc');
     wait_still_screen;    # extra wait because oo sometimes appears to be idle during start
     assert_screen 'test-oocalc-1';
     wait_screen_change { assert_and_click 'input-area-oocalc', 'left', 10 };

--- a/tests/x11/systemsettings.pm
+++ b/tests/x11/systemsettings.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("systemsettings", 6, {valid => 1});
+    x11_start_program('systemsettings');
     assert_screen 'test-systemsettings-1';
     send_key "alt-f4";
 }

--- a/tests/x11/systemsettings5.pm
+++ b/tests/x11/systemsettings5.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("systemsettings5", 6, {valid => 1});
+    x11_start_program('systemsettings5', valid => 1);
     assert_screen 'test-systemsettings-1';
     send_key "alt-f4";
 }

--- a/tests/yast2_gui/yast2_bootloader.pm
+++ b/tests/yast2_gui/yast2_bootloader.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,11 +22,8 @@ use testapi;
 use utils 'ensure_unlocked_desktop';
 
 sub run {
-    my $self   = shift;
-    my $module = "bootloader";
-
-    $self->launch_yast2_module_x11($module);
-    assert_screen "yast2-$module-ui", 120;
+    my $self = shift;
+    $self->launch_yast2_module_x11('bootloader', match_timeout => 120);
 
     #	boot code options
     assert_and_click 'yast2-bootloader_grub2';

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -270,8 +270,7 @@ sub start_printer {
 
 sub run {
     my $self = shift;
-    $self->launch_yast2_module_x11;
-    assert_screen 'yast2-control-center-ui', timeout => 180;
+    $self->launch_yast2_module_x11('', target_match => 'yast2-control-center-ui', match_timeout => 180);
 
     # search module by typing string
     search('add');

--- a/tests/yast2_gui/yast2_datetime.pm
+++ b/tests/yast2_gui/yast2_datetime.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,11 +19,8 @@ use strict;
 use testapi;
 
 sub run {
-    my $self   = shift;
-    my $module = "timezone";
-
-    $self->launch_yast2_module_x11($module);
-    assert_screen [qw(yast2-datetime-ui yast2-datetime_ntp-conf)];
+    my $self = shift;
+    $self->launch_yast2_module_x11('timezone', target_match => [qw(yast2-datetime-ui yast2-datetime_ntp-conf)]);
     if (match_has_tag 'yast2-datetime_ntp-conf') {
         send_key 'alt-d';
         send_key 'alt-o';

--- a/tests/yast2_gui/yast2_firewall.pm
+++ b/tests/yast2_gui/yast2_firewall.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -24,8 +24,7 @@ sub run {
     zypper_call('in yast2-http-server apache2 apache2-prefork');
     select_console 'x11', await_console => 0;
 
-    $self->launch_yast2_module_x11('firewall');
-    assert_screen "yast2-firewall-ui", 60;
+    $self->launch_yast2_module_x11('firewall', match_timeout => 60);
 
     # 	enter page interfaces and change zone for network interface
     assert_and_click("yast2_firewall_config_list");

--- a/tests/yast2_gui/yast2_hostnames.pm
+++ b/tests/yast2_gui/yast2_hostnames.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -28,9 +28,7 @@ sub run {
     #	add 1 entry to /etc/hosts and edit it later
     script_run "echo '80.92.65.530    n-tv.de ntv' >> /etc/hosts";
     select_console 'x11', await_console => 0;
-
-    $self->launch_yast2_module_x11($module);
-
+    $self->launch_yast2_module_x11('host');
     assert_and_click "yast2_hostnames_added";
     wait_still_screen 1;
     wait_screen_change { send_key 'alt-i'; };

--- a/tests/yast2_gui/yast2_lang.pm
+++ b/tests/yast2_gui/yast2_lang.pm
@@ -19,11 +19,8 @@ use strict;
 use testapi;
 
 sub run {
-    my $self   = shift;
-    my $module = "language";
-
-    $self->launch_yast2_module_x11($module);
-    assert_screen "yast2-$module-ui", 60;
+    my $self = shift;
+    $self->launch_yast2_module_x11('language', match_timeout => 60);
 
     # check language details and change detailed locale setting
     assert_and_click 'yast2-lang_details';

--- a/tests/yast2_gui/yast2_network_settings.pm
+++ b/tests/yast2_gui/yast2_network_settings.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,17 +19,13 @@ use strict;
 use testapi;
 
 sub run {
-    my $self   = shift;
-    my $module = "lan";
-
-    $self->launch_yast2_module_x11($module);
-    assert_screen([qw(yast2-lan-ui yast2_still_susefirewall2)], 90);
+    my $self = shift;
+    $self->launch_yast2_module_x11('lan', match_args => [qw(yast2-lan-ui yast2_still_susefirewall2)], match_timeout => 60);
     if (match_has_tag('yast2_still_susefirewall2')) {
         record_soft_failure "bsc#1059569";
         send_key 'alt-i';
         wait_still_screen;
     }
-
 
     #	Global Options
     send_key 'alt-g';

--- a/tests/yast2_gui/yast2_software_management.pm
+++ b/tests/yast2_gui/yast2_software_management.pm
@@ -1,29 +1,23 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Add YaST2 UI tests
-#    Make sure those yast2 modules can opened properly. We can add more
-#    feature test against each module later, it is ensure it will not crashed
-#    while launching atm.
-# G-Maintainer: Max Lin <mlin@suse.com>
+# Summary: Test YaST2 module for software management
+# Maintainer: Max Lin <mlin@suse.com>
 
 use base "y2x11test";
 use strict;
 use testapi;
 
 sub run {
-    my $self   = shift;
-    my $module = "sw_single";
-
-    $self->launch_yast2_module_x11($module);
-    assert_screen "yast2-$module-ui", 120;
+    my $self = shift;
+    $self->launch_yast2_module_x11('sw_single', match_timeout => 120);
     send_key "alt-a";    # Accept => Exit
 }
 

--- a/tests/yast2_gui/yast2_users.pm
+++ b/tests/yast2_gui/yast2_users.pm
@@ -1,29 +1,23 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Add YaST2 UI tests
-#    Make sure those yast2 modules can opened properly. We can add more
-#    feature test against each module later, it is ensure it will not crashed
-#    while launching atm.
-# G-Maintainer: Max Lin <mlin@suse.com>
+# Summary: Test initial startup of users configuration YaST2 module
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "y2x11test";
 use strict;
 use testapi;
 
 sub run {
-    my $self   = shift;
-    my $module = "users";
-
-    $self->launch_yast2_module_x11($module);
-    assert_screen "yast2-$module-ui", 60;
+    my $self = shift;
+    $self->launch_yast2_module_x11('users', match_timeout => 60);
     send_key "alt-o";    # OK => Exit
 }
 


### PR DESCRIPTION
* Rewrite x11_start_program with standard hash argument
* Use new option 'target_match' on yast2_gui tests to speedup startup
* xterm: Save time with new 'target_match' option of x11_start_program
* x11_start_program: Speedup with optional check for target match
* Delete unused 'terminal' option from x11_start_program
* install_and_reboot: Cleanup timeout calculation

Before (http://lord.arch/tests/7598):

```
07:52:14.3883 29978 <<< testapi::x11_start_program(timeout=undef, options=undef)
...
07:52:26.1435 29978 >>> testapi::_handle_found_needle: found xterm-started-20150812, similarity 1.00 @ 14/49
```

-> 12s

After (validation run: http://lord.arch/tests/7601):

```
08:22:57.8516 8768 <<< testapi::x11_start_program(timeout=6, options={
  'target_match' => 'xterm'
})
...
08:23:03.4361 8768 >>> testapi::_handle_found_needle: found xterm-started-20150812, similarity 1.00 @ 14/49
```

-> 6s

So 6 seconds saved.