### PR TITLE
Fix first_boot.pm for booting up in textmode

### DIFF
--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -28,8 +28,9 @@ sub run {
     }
 
     if (get_var("NOAUTOLOGIN") || get_var("IMPORT_USER_DATA")) {
-        assert_screen [qw(displaymanager emergency-shell emergency-mode)], $boot_timeout;
+        assert_screen [qw(displaymanager emergency-shell emergency-mode text-login)], $boot_timeout;
         handle_emergency if (match_has_tag('emergency-shell') or match_has_tag('emergency-mode'));
+        return if (match_has_tag('text-login'));
         handle_login;
     }
 


### PR DESCRIPTION
- the issue https://openqa.suse.de/tests/1196768#step/first_boot
  shows that booting up in textmode is not covered
- add text-login to assert_screen
- see poo#23814 for more details
- reference test http://e13.suse.de/tests/4370#step/first_boot