### PR TITLE
Handle cookie consent in firefox_rss

### DIFF
--- a/tests/x11regressions/firefox/firefox_rss.pm
+++ b/tests/x11regressions/firefox/firefox_rss.pm
@@ -38,6 +38,7 @@ sub run {
     send_key "alt-d";
     type_string "https://linux.slashdot.org/\n";
     $self->firefox_check_popups;
+    assert_and_click("slashdot-cookies-agree") if check_screen("slashdot-cookies", 0);
 
     assert_and_click "firefox-rss-button_enabled", "left", 30;
     assert_screen("firefox-rss-page", 60);


### PR DESCRIPTION
firefox_rss subscribes to a feed of content on https://linux.slashdot.org/, however, the website has recently started asking the user to explicitly agree to its use of cookies. This change adds the check for the cookie consent window and closes it when it appears.

Related issue: https://progress.opensuse.org/issues/25690

Related needles: Created directly via OpenQA needle editor:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/commit/18b71b27cb96141fbd5a4b661bc04d6db1cd582d
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/commit/6bf15365a2cbeecdcbab0662578a18442cd8f7eb

Verification run:
SLE12 SP2: http://dreamyhamster.suse.cz/tests/800#step/firefox_rss/21
SLE12 SP3: http://dreamyhamster.suse.cz/tests/799#step/firefox_rss/21

Note: The cookie dialog appears to be geographically dependent and does not appear when accessing the site from the Prague location, therefore it has not been possible to reproduce this behavior on a CZ-based machine.