### PR TITLE
Open firefox from launcher instead of xterm in firefox_audio

### DIFF
--- a/tests/x11/firefox_audio.pm
+++ b/tests/x11/firefox_audio.pm
@@ -18,16 +18,18 @@ use testapi;
 
 sub run {
     my ($self) = @_;
-    $self->start_firefox();
-    send_key "ctrl-l";
-    type_string(autoinst_url . "/data/1d5d9dD.oga");
-    send_key "ret";
     start_audiocapture;
+    x11_start_program("firefox " . autoinst_url . "/data/1d5d9dD.oga");
+    $self->firefox_check_default;
+    $self->firefox_check_popups;
     assert_screen 'test-firefox_audio-1', 35;
     sleep 1;    # at least a second of silence
     assert_recorded_sound('DTMF-159D');
     send_key "alt-f4";
-    $self->exit_firefox();
+    if (check_screen('firefox-save-and-quit', 4)) {
+        # confirm "save&quit"
+        send_key "ret";
+    }
 }
 
 1;


### PR DESCRIPTION
My previous commit changed the behavior of firefox_audio to launching from xterm, rather than directly from launcher, as it did before. Having received feedback that this behavior does not follow normal customer behavior, this commit goes back to opening firefox directly from launcher.

Related issue: https://progress.opensuse.org/issues/25370

Verification run:
SLE12 SP2: http://dreamyhamster.suse.cz/tests/800#step/firefox_audio/9
SLE12 SP3: http://dreamyhamster.suse.cz/tests/799#step/firefox_audio/9

Needles: N/A (no new needles necessary)