### PR TITLE
CaaSP: fix for using correct 'x11' tty

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1382,7 +1382,7 @@ sub get_root_console_tty {
     is running on tty2 by default. see also: bsc#1054782
 =cut
 sub get_x11_console_tty {
-    my $new_gdm = !(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15'));
+    my $new_gdm = !(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15')) && !is_caasp;
     return (check_var('DESKTOP', 'gnome') && get_var('NOAUTOLOGIN') && $new_gdm) ? 2 : 7;
 }
 


### PR DESCRIPTION
Commit https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3649 broke selection of tty for x11 in CaaSP-controller test

CaaSP-controller test is basically SLE12_SP2 support_server but with DISTRI=caasp, DESKTOP=gnome, NOAUTOLOGIN=1 set ---> $new_gdm = True

and it returns **2** but it should be **7**

So I added one more condition which should fix that.

We need this change for GMC testing of CaaSP2.0

CaaSP tested here http://dhcp62.suse.cz/tests/2272
