### PR TITLE
Prevent "sshboy" ssh test user to leak into loaded snapshots

### DIFF
--- a/tests/console/ssh_cleanup.pm
+++ b/tests/console/ssh_cleanup.pm
@@ -17,5 +17,9 @@ sub run {
     assert_script_run('getent passwd sshboy > /dev/null && userdel -fr sshboy');
 }
 
+sub test_flags {
+    return {milestone => 1};
+}
+
 1;
 # vim: set sw=4 et:

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -54,9 +54,5 @@ sub run {
     assert_screen "ssh-login-ok";
 }
 
-sub test_flags {
-    return {milestone => 1};
-}
-
 1;
 # vim: set sw=4 et:


### PR DESCRIPTION
Move snapshot milestone from sshd to ssh_cleanup so that a intermediate test
module failure does not load again the state of a virtual machine with the ssh
test user "sshboy" disrupting later tests, for example with a display manager.

Validation run: http://lord.arch/tests/7617

Related progress issue: https://progress.opensuse.org/issues/25836