### PR TITLE
Check target match with x11_start_program by default in all instances

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -167,8 +167,7 @@ sub ensure_installed {
     my $pkglist = ref $pkgs eq 'ARRAY' ? join ' ', @$pkgs : $pkgs;
     $args{timeout} //= 90;
 
-    testapi::x11_start_program("xterm");
-    assert_screen('xterm');
+    testapi::x11_start_program('xterm', target_match => 'xterm');
     testapi::assert_script_sudo("chown $testapi::username /dev/$testapi::serialdev");
     my $retries = 5;    # arbitrary
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -705,7 +705,7 @@ sub poweroff_x11 {
     }
 
     if (check_var("DESKTOP", "mate")) {
-        x11_start_program("mate-session-save --shutdown-dialog");
+        x11_start_program("mate-session-save --shutdown-dialog", valid => 0);
         send_key "ctrl-alt-delete";    # shutdown
         assert_screen 'mate_logoutdialog', 15;
         assert_and_click 'mate_shutdown_btn';

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -153,8 +153,7 @@ sub systemctl {
 }
 
 sub turn_off_kde_screensaver {
-    x11_start_program("kcmshell5 screenlocker");
-    assert_screen([qw(kde-screenlock-enabled screenlock-disabled)]);
+    x11_start_program('kcmshell5 screenlocker', target_match => [qw(kde-screenlock-enabled screenlock-disabled)]);
     if (match_has_tag('kde-screenlock-enabled')) {
         assert_and_click('kde-disable-screenlock');
     }
@@ -198,8 +197,7 @@ sub prepare_system_reboot {
 sub assert_gui_app {
     my ($application, %args) = @_;
     ensure_installed($application) if $args{install};
-    x11_start_program("$application $args{exec_param}");
-    assert_screen("test-$application-started");
+    x11_start_program("$application $args{exec_param}", target_match => "test-$application-started");
     send_key "alt-f4" unless $args{remain};
 }
 
@@ -684,18 +682,18 @@ sub poweroff_x11 {
     }
 
     if (check_var("DESKTOP", "lxde")) {
-        x11_start_program("lxsession-logout");        # opens logout dialog
-        assert_screen "logoutdialog", 20;
+        # opens logout dialog
+        x11_start_program('lxsession-logout', target_match => 'logoutdialog');
         send_key "ret";
     }
 
     if (check_var("DESKTOP", "lxqt")) {
-        x11_start_program("shutdown");                # opens logout dialog
-        assert_screen "lxqt_logoutdialog", 20;
+        # opens logout dialog
+        x11_start_program('shutdown', target_match => 'lxqt_logoutdialog');
         send_key "ret";
     }
     if (check_var("DESKTOP", "enlightenment")) {
-        send_key "ctrl-alt-delete";                   # shutdown
+        send_key "ctrl-alt-delete";    # shutdown
         assert_screen 'logoutdialog', 15;
         assert_and_click 'enlightenment_shutdown_btn';
     }
@@ -1240,14 +1238,14 @@ sub handle_logout {
     # logout
     if (check_var('DESKTOP', 'gnome') || check_var('DESKTOP', 'lxde')) {
         my $command = check_var('DESKTOP', 'gnome') ? 'gnome-session-quit' : 'lxsession-logout';
-        x11_start_program("$command");    # opens logout dialog
-        assert_screen 'logoutdialog' unless check_var('DESKTOP', 'gnome');
+        my $target_match = check_var('DESKTOP', 'gnome') ? undef : 'logoutdialog';
+        x11_start_program($command, target_match => $target_match);    # opens logout dialog
     }
     else {
         my $key = check_var('DESKTOP', 'xfce') ? 'alt-f4' : 'ctrl-alt-delete';
-        send_key_until_needlematch 'logoutdialog', "$key";    # opens logout dialog
+        send_key_until_needlematch 'logoutdialog', "$key";             # opens logout dialog
     }
-    assert_and_click 'logout-button';                         # press logout
+    assert_and_click 'logout-button';                                  # press logout
 }
 
 # Handle emergency mode

--- a/lib/virtmanager.pm
+++ b/lib/virtmanager.pm
@@ -12,7 +12,7 @@ sub launch_virtmanager {
     clean_up_desktop();
     # start a console
     # launch virt-manager in an xterm
-    x11_start_program("xterm");
+    x11_start_program('xterm');
     type_string "virt-manager", 50;
     send_key "ret";
     if (check_screen("virt-manager-auth")) {

--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -32,7 +32,7 @@ sub import_pictures {
 
     # Fetch test pictures to ~/Documents
     foreach my $picture (@$pictures) {
-        x11_start_program("wget " . autoinst_url . "/data/x11regressions/$picture -O /home/$username/Documents/$picture");
+        x11_start_program("wget " . autoinst_url . "/data/x11regressions/$picture -O /home/$username/Documents/$picture", valid => 0);
     }
 
     # Open the dialog 'Import From Folder'
@@ -56,17 +56,17 @@ sub import_pictures {
 # clean_shotwell helps to clean shotwell's library then remove the test picture.
 sub clean_shotwell {
     # Clean shotwell's database
-    x11_start_program("rm -rf /home/$username/.local/share/shotwell");
+    x11_start_program("rm -rf /home/$username/.local/share/shotwell", valid => 0);
     # Clean shotwell cache files
-    x11_start_program("rm -rf /home/$username/.cache/shotwell");
+    x11_start_program("rm -rf /home/$username/.cache/shotwell", valid => 0);
     # Remove test pictures
-    x11_start_program("rm /home/$username/Documents/shotwell_test.*");
+    x11_start_program("rm /home/$username/Documents/shotwell_test.*", valid => 0);
 }
 
 # upload libreoffice specified file into /home/$username/Documents
 sub upload_libreoffice_specified_file {
 
-    x11_start_program("xterm");
+    x11_start_program('xterm');
     assert_script_run("wget " . autoinst_url . "/data/x11regressions/ooo-test-doc-types.tar.bz2 -O /home/$username/Documents/ooo-test-doc-types.tar.bz2");
     wait_still_screen;
     type_string("cd /home/$username/Documents && ls -l");
@@ -84,7 +84,7 @@ sub upload_libreoffice_specified_file {
 # cleanup libreoffcie specified file from test vm
 sub cleanup_libreoffice_specified_file {
 
-    x11_start_program("xterm");
+    x11_start_program('xterm');
     assert_script_run("rm -rf /home/$username/Documents/ooo-test-doc-types*");
     wait_still_screen;
     type_string_slow "ls -l /home/$username/Documents";
@@ -99,8 +99,7 @@ sub cleanup_libreoffice_specified_file {
 
 # cleanup libreoffice recent open file to make sure libreoffice clean
 sub cleanup_libreoffice_recent_file {
-
-    x11_start_program("libreoffice");
+    x11_start_program('libreoffice');
     wait_still_screen 3;
     send_key "alt-f";
     if (is_tumbleweed) {
@@ -316,7 +315,7 @@ sub start_evolution {
     }
     mouse_hide(1);
     # Clean and Start Evolution
-    x11_start_program("xterm -e \"killall -9 evolution; find ~ -name evolution | xargs rm -rf;\"");
+    x11_start_program("xterm -e \"killall -9 evolution; find ~ -name evolution | xargs rm -rf;\"", valid => 0);
     x11_start_program('evolution', target_match => [qw(evolution-default-client-ask test-evolution-1)]);
     # Follow the wizard to setup mail account
     if (match_has_tag 'evolution-default-client-ask') {
@@ -509,7 +508,7 @@ sub start_firefox {
     my ($self) = @_;
     mouse_hide(1);
 
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     # Clean and Start Firefox
     type_string "killall -9 firefox;rm -rf .moz* .config/iced* .cache/iced* .local/share/gnome-shell/extensions/*; firefox > firefox.log 2>&1 &\n";
     $self->firefox_check_default;
@@ -620,7 +619,7 @@ sub setup_evolution_for_ews {
     mouse_hide(1);
 
     # Clean and Start Evolution
-    x11_start_program("xterm -e \"killall -9 evolution; find ~ -name evolution | xargs rm -rf;\"");
+    x11_start_program("xterm -e \"killall -9 evolution; find ~ -name evolution | xargs rm -rf;\"", valid => 0);
     x11_start_program('evolution', target_match => [qw(evolution-default-client-ask test-evolution-1)]);
     if (match_has_tag "evolution-default-client-ask") {
         assert_and_click "evolution-default-client-agree";
@@ -757,11 +756,11 @@ sub tomboy_logout_and_login {
     assert_screen 'generic-desktop';
 
     # open start note again and take screenshot
-    x11_start_program("tomboy note");
+    x11_start_program('tomboy note', valid => 0);
 }
 
 sub gnote_launch {
-    x11_start_program('gnote', target_match => 'gnote-first-launched');
+    x11_start_program('gnote');
     send_key_until_needlematch 'gnote-start-here-matched', 'down', 5;
 }
 
@@ -788,7 +787,7 @@ sub cleanup_gnote {
 }
 
 sub gnote_start_with_new_note {
-    x11_start_program('gnote', target_match => 'gnote-first-launched');
+    x11_start_program('gnote');
     send_key "ctrl-n";
     assert_screen 'gnote-new-note', 5;
 }
@@ -797,7 +796,7 @@ sub gnote_start_with_new_note {
 sub configure_static_ip_nm {
     my ($self, $ip) = @_;
 
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root;
     assert_script_run "nmcli connection add type ethernet con-name wired ifname eth0 ip4 '$ip' gw4 10.0.2.2";
     assert_script_run 'nmcli device disconnect eth0';

--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -1,6 +1,6 @@
 # Base class for all x11regression test
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,8 +20,7 @@ use POSIX 'strftime';
 
 # Start shotwell and handle the welcome screen, if there
 sub start_shotwell {
-    x11_start_program("shotwell");
-    assert_screen [qw(shotwell-first-launch shotwell-launched)];
+    x11_start_program('shotwell', target_match => [qw(shotwell-first-launch shotwell-launched)]);
     if (match_has_tag "shotwell-first-launch") {
         wait_screen_change { send_key "ret" };
     }
@@ -318,9 +317,8 @@ sub start_evolution {
     mouse_hide(1);
     # Clean and Start Evolution
     x11_start_program("xterm -e \"killall -9 evolution; find ~ -name evolution | xargs rm -rf;\"");
-    x11_start_program("evolution");
+    x11_start_program('evolution', target_match => [qw(evolution-default-client-ask test-evolution-1)]);
     # Follow the wizard to setup mail account
-    assert_screen [qw(evolution-default-client-ask test-evolution-1)];
     if (match_has_tag 'evolution-default-client-ask') {
         assert_and_click "evolution-default-client-agree";
         assert_screen "test-evolution-1";
@@ -511,7 +509,7 @@ sub start_firefox {
     my ($self) = @_;
     mouse_hide(1);
 
-    x11_start_program 'xterm';
+    x11_start_program('xterm', target_match => 'xterm');
     # Clean and Start Firefox
     type_string "killall -9 firefox;rm -rf .moz* .config/iced* .cache/iced* .local/share/gnome-shell/extensions/*; firefox > firefox.log 2>&1 &\n";
     $self->firefox_check_default;
@@ -623,8 +621,7 @@ sub setup_evolution_for_ews {
 
     # Clean and Start Evolution
     x11_start_program("xterm -e \"killall -9 evolution; find ~ -name evolution | xargs rm -rf;\"");
-    x11_start_program("evolution");
-    assert_screen [qw(evolution-default-client-ask test-evolution-1)];
+    x11_start_program('evolution', target_match => [qw(evolution-default-client-ask test-evolution-1)]);
     if (match_has_tag "evolution-default-client-ask") {
         assert_and_click "evolution-default-client-agree";
         assert_screen 'test-evolution-1';
@@ -764,8 +761,7 @@ sub tomboy_logout_and_login {
 }
 
 sub gnote_launch {
-    x11_start_program("gnote");
-    assert_screen "gnote-first-launched", 5;
+    x11_start_program('gnote', target_match => 'gnote-first-launched');
     send_key_until_needlematch 'gnote-start-here-matched', 'down', 5;
 }
 
@@ -792,8 +788,7 @@ sub cleanup_gnote {
 }
 
 sub gnote_start_with_new_note {
-    x11_start_program("gnote");
-    assert_screen 'gnote-first-launched', 10;
+    x11_start_program('gnote', target_match => 'gnote-first-launched');
     send_key "ctrl-n";
     assert_screen 'gnote-new-note', 5;
 }
@@ -802,8 +797,7 @@ sub gnote_start_with_new_note {
 sub configure_static_ip_nm {
     my ($self, $ip) = @_;
 
-    x11_start_program 'xterm';
-    assert_screen 'xterm';
+    x11_start_program('xterm', target_match => 'xterm');
     become_root;
     assert_script_run "nmcli connection add type ethernet con-name wired ifname eth0 ip4 '$ip' gw4 10.0.2.2";
     assert_script_run 'nmcli device disconnect eth0';

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -59,7 +59,7 @@ sub prepare_sle_classic {
 sub test_terminal {
     my ($self, $name) = @_;
     mouse_hide(1);
-    x11_start_program($name, target_match => $name);
+    x11_start_program($name);
     $self->enter_test_text($name, cmd => 1);
     assert_screen "test-$name-1";
     send_key 'alt-f4';

--- a/lib/y2x11test.pm
+++ b/lib/y2x11test.pm
@@ -28,7 +28,7 @@ sub launch_yast2_module_x11 {
     type_password;
     save_screenshot;
     send_key 'ret';
-    assert_screen $args{target_match};
+    assert_screen $args{target_match}, $args{match_timeout};
 }
 
 sub post_fail_hook {

--- a/lib/y2x11test.pm
+++ b/lib/y2x11test.pm
@@ -26,7 +26,6 @@ sub launch_yast2_module_x11 {
     die "need password definition" unless $password;
     diag 'assuming root-auth-dialog, typing password';
     type_password;
-    save_screenshot;
     send_key 'ret';
     assert_screen $args{target_match}, $args{match_timeout};
 }

--- a/tests/caasp/stack_controller.pm
+++ b/tests/caasp/stack_controller.pm
@@ -112,7 +112,7 @@ sub confirm_insecure_https {
 
 # Setup while waiting for admin dashboard installation
 sub initialize {
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
 
     # Fix permissions
     assert_script_sudo "chown $testapi::username /dev/$testapi::serialdev";

--- a/tests/caasp/stack_controller.pm
+++ b/tests/caasp/stack_controller.pm
@@ -112,8 +112,7 @@ sub confirm_insecure_https {
 
 # Setup while waiting for admin dashboard installation
 sub initialize {
-    x11_start_program "xterm";
-    assert_screen "xterm";
+    x11_start_program('xterm', target_match => 'xterm');
 
     # Fix permissions
     assert_script_sudo "chown $testapi::username /dev/$testapi::serialdev";
@@ -124,7 +123,7 @@ sub initialize {
     save_screenshot;
     send_key "ctrl-l";
     send_key 'super-up';
-    x11_start_program("firefox");
+    x11_start_program('firefox');
 }
 
 sub run {

--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests - FIPS tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -31,8 +31,7 @@ sub run {
     my $fips_password = 'openqa@SUSE';
 
     # launch firefox first and enable FIPS mode
-    x11_start_program("firefox");
-    assert_screen "firefox-launch", 90;
+    x11_start_program('firefox', target_match => 'firefox-launch', match_timeout => 90);
     send_key "alt-d";
     type_string "about:preferences#security\n";
     assert_screen "firefox-preferences-security";
@@ -60,8 +59,7 @@ sub run {
     assert_screen "generic-desktop";
 
     # launch firefox again and check FIPS mode is enabled
-    x11_start_program("firefox");
-    assert_screen "firefox-fips-password-inputfiled", 90;
+    x11_start_program('firefox', target_match => 'firefox-fips-password-inputfiled', match_timeout => 90);
     type_string $fips_password;
     send_key "ret";
     # Need click on tab area twice to make sure it is selected

--- a/tests/fixup/enable_firewall.pm
+++ b/tests/fixup/enable_firewall.pm
@@ -17,7 +17,7 @@ use testapi;
 
 sub run {
     record_soft_failure('boo#1036590') if get_var('HDDVERSION', '') =~ /openSUSE-(12.1|12.2)/;
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     assert_script_sudo('SuSEfirewall2 on');
     send_key "alt-f4";
 }

--- a/tests/fixup/enable_firewall.pm
+++ b/tests/fixup/enable_firewall.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,7 +17,7 @@ use testapi;
 
 sub run {
     record_soft_failure('boo#1036590') if get_var('HDDVERSION', '') =~ /openSUSE-(12.1|12.2)/;
-    x11_start_program('xterm');
+    x11_start_program('xterm', target_match => 'xterm');
     assert_script_sudo('SuSEfirewall2 on');
     send_key "alt-f4";
 }

--- a/tests/fixup/network_configuration.pm
+++ b/tests/fixup/network_configuration.pm
@@ -31,7 +31,7 @@ sub run {
     my $command = "mv /etc/sysconfig/network/ifcfg-eth0 /etc/sysconfig/network/ifcfg-ens4; /usr/sbin/ifup ens4";
 
     if (get_var("DESKTOP") =~ /kde|gnome/) {
-        x11_start_program('xterm', target_match => 'xterm');
+        x11_start_program('xterm');
         assert_script_sudo($command);
         send_key "alt-f4";
     }

--- a/tests/fixup/network_configuration.pm
+++ b/tests/fixup/network_configuration.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -31,7 +31,7 @@ sub run {
     my $command = "mv /etc/sysconfig/network/ifcfg-eth0 /etc/sysconfig/network/ifcfg-ens4; /usr/sbin/ifup ens4";
 
     if (get_var("DESKTOP") =~ /kde|gnome/) {
-        x11_start_program("xterm");
+        x11_start_program('xterm', target_match => 'xterm');
         assert_script_sudo($command);
         send_key "alt-f4";
     }

--- a/tests/gnuhealth/gnuhealth_setup.pm
+++ b/tests/gnuhealth/gnuhealth_setup.pm
@@ -17,7 +17,7 @@ use utils 'leap_version_at_least';
 
 sub run() {
     my ($self) = @_;
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root;
     assert_script_run 'systemctl start postgresql';
     wait_screen_change { script_run 'su postgres', 0 };

--- a/tests/gnuhealth/gnuhealth_setup.pm
+++ b/tests/gnuhealth/gnuhealth_setup.pm
@@ -17,8 +17,7 @@ use utils 'leap_version_at_least';
 
 sub run() {
     my ($self) = @_;
-    x11_start_program 'xterm';
-    assert_screen 'xterm';
+    x11_start_program('xterm', target_match => 'xterm');
     become_root;
     assert_script_run 'systemctl start postgresql';
     wait_screen_change { script_run 'su postgres', 0 };

--- a/tests/gnuhealth/tryton_preconfigure.pm
+++ b/tests/gnuhealth/tryton_preconfigure.pm
@@ -16,7 +16,7 @@ use testapi;
 use utils 'leap_version_at_least';
 
 sub run {
-    x11_start_program('tryton', target_match => 'tryton-startup');
+    x11_start_program('tryton');
     assert_and_click 'tryton-manage_profiles';
     # wait for indexing to be done
     wait_still_screen(3);

--- a/tests/gnuhealth/tryton_preconfigure.pm
+++ b/tests/gnuhealth/tryton_preconfigure.pm
@@ -16,8 +16,7 @@ use testapi;
 use utils 'leap_version_at_least';
 
 sub run {
-    x11_start_program 'tryton';
-    assert_screen 'tryton-startup';
+    x11_start_program('tryton', target_match => 'tryton-startup');
     assert_and_click 'tryton-manage_profiles';
     # wait for indexing to be done
     wait_still_screen(3);

--- a/tests/installation/addon_products_via_SCC_yast2.pm
+++ b/tests/installation/addon_products_via_SCC_yast2.pm
@@ -17,7 +17,7 @@ use testapi;
 use registration 'fill_in_registration_data';
 
 sub run {
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     # add every used addon to regurl for proxy SCC
     if (get_var('SCC_ADDONS')) {
         my @addon_proxy = ("url: http://server-" . get_var('BUILD_SLE'));

--- a/tests/installation/addon_products_via_SCC_yast2.pm
+++ b/tests/installation/addon_products_via_SCC_yast2.pm
@@ -17,7 +17,7 @@ use testapi;
 use registration 'fill_in_registration_data';
 
 sub run {
-    x11_start_program('xterm');
+    x11_start_program('xterm', target_match => 'xterm');
     # add every used addon to regurl for proxy SCC
     if (get_var('SCC_ADDONS')) {
         my @addon_proxy = ("url: http://server-" . get_var('BUILD_SLE'));
@@ -28,7 +28,7 @@ sub run {
         script_sudo "echo \"@addon_proxy.proxy.scc.suse.de\" > /etc/SUSEConnect", 0;
     }
     type_string "killall xterm\n";
-    x11_start_program("xdg-su -c '/sbin/yast2'");
+    x11_start_program("xdg-su -c '/sbin/yast2'", target_match => 'yast2-control-center-ui');
     if ($password) { type_password; send_key 'ret'; }
     send_key 'alt-y' if check_screen('packagekit-warning', 2);
     assert_screen 'yast2-control-center';

--- a/tests/installation/addon_products_yast2.pm
+++ b/tests/installation/addon_products_yast2.pm
@@ -11,7 +11,7 @@
 # Summary: add addon to SLES via DVD or URL
 # Maintainer: Jozef Pupava <jpupava@suse.com>
 
-use base qw(y2logsstep opensusebasetest);
+use base qw(y2logsstep y2x11test);
 use strict;
 use testapi;
 use utils 'reboot_x11';
@@ -21,13 +21,12 @@ sub run {
     my ($self) = @_;
     my ($addon, $uc_addon);
     my $perform_reboot;
-    x11_start_program("xdg-su -c '/sbin/yast2 add-on'");
-    if ($password) { type_password; send_key "ret"; }
-    if (check_screen 'packagekit-warning') {
-        send_key 'alt-y';    # yes
+    $self->launch_yast2_module_x11('add-on', target_match => [qw(addon-products packagekit-warning)]);
+    if (match_has_tag 'packagekit-warning') {
+        send_key 'alt-y';
+        assert_screen 'addon-products';
     }
-    assert_screen 'addon-products';
-    send_key 'alt-a';        # add add-on
+    send_key 'alt-a';    # add add-on
     if (get_var("ADDONS")) {
         # the ISO_X variables must match the ADDONS list
         my $sr_number = 0;

--- a/tests/installation/live_installation.pm
+++ b/tests/installation/live_installation.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -31,7 +31,7 @@ sub send_key_and_wait {
 
 sub run {
     # stop packagekit, root password is not needed on live system
-    x11_start_program("systemctl stop packagekit.service");
+    x11_start_program('systemctl stop packagekit.service', target_match => 'generic-desktop');
     turn_off_kde_screensaver;
     assert_and_click 'live-installation';
     assert_and_click 'maximize';

--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -21,7 +21,7 @@ sub run {
 
     $self->wait_boot(ready_time => 600);
     if (get_var('ZDUP_IN_X')) {
-        x11_start_program('xterm', target_match => 'xterm');
+        x11_start_program('xterm');
         become_root;
     }
     else {

--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -21,7 +21,7 @@ sub run {
 
     $self->wait_boot(ready_time => 600);
     if (get_var('ZDUP_IN_X')) {
-        x11_start_program('xterm');
+        x11_start_program('xterm', target_match => 'xterm');
         become_root;
     }
     else {

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,7 @@ use mm_network;
 use lockapi;
 
 sub run {
-    x11_start_program("xterm -geometry 160x45+5+5");
+    x11_start_program('xterm -geometry 160x45+5+5', target_match => 'xterm');
     type_string "gsettings set org.gnome.desktop.session idle-delay 0\n";    # disable blank scree
     become_root;
     configure_default_gateway;

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -22,7 +22,7 @@ use utils 'zypper_call';
 sub run {
     my $self = shift;
 
-    x11_start_program("xterm -geometry 160x45+5+5");
+    x11_start_program('xterm -geometry 160x45+5+5', target_match => 'xterm');
     type_string "gsettings set org.gnome.desktop.session idle-delay 0\n";    # disable blank screen
     become_root;
     configure_default_gateway;

--- a/tests/online_migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/online_migration/sle12_online_migration/yast2_migration.pm
@@ -27,7 +27,7 @@ sub run {
         mouse_hide(1);
         assert_screen 'generic-desktop';
 
-        x11_start_program('xterm', target_match => 'xterm');
+        x11_start_program('xterm');
         # set blank screen to be never for current session
         script_run("gsettings set org.gnome.desktop.session idle-delay 0");
         become_root;

--- a/tests/online_migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/online_migration/sle12_online_migration/yast2_migration.pm
@@ -1,6 +1,6 @@
 # SLE12 online migration tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -27,7 +27,7 @@ sub run {
         mouse_hide(1);
         assert_screen 'generic-desktop';
 
-        x11_start_program("xterm");
+        x11_start_program('xterm', target_match => 'xterm');
         # set blank screen to be never for current session
         script_run("gsettings set org.gnome.desktop.session idle-delay 0");
         become_root;

--- a/tests/remote/remote_controller.pm
+++ b/tests/remote/remote_controller.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -43,7 +43,7 @@ sub run {
         script_run "systemctl start SuSEfirewall2";
 
         select_console 'x11';
-        x11_start_program("xterm");
+        x11_start_program('xterm', target_match => 'xterm');
         type_string "vncviewer -fullscreen $target_ip:1\n";
         assert_screen "remote_master_password";    # wait for password prompt
         type_string "$password\n";

--- a/tests/remote/remote_controller.pm
+++ b/tests/remote/remote_controller.pm
@@ -7,13 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Rename remote installation nodes (#1588)
-#    * Rename remote installation nodes
-#    slave -> target
-#    master -> controller
-#
-#    * Enable remote installation tests for opensuse
-# G-Maintainer: Martin Kravec <kravciak@users.noreply.github.com>
+# Summary: Controller/master for remote installations
+# Tags: poo#9576
+# Maintainer: Martin Kravec <mkravec@suse.com>
 
 use base "opensusebasetest";
 use strict;
@@ -22,7 +18,6 @@ use utils;
 use mm_network;
 use lockapi;
 
-# poo#9576
 sub run {
     my $target_ip;
 
@@ -43,7 +38,7 @@ sub run {
         script_run "systemctl start SuSEfirewall2";
 
         select_console 'x11';
-        x11_start_program('xterm', target_match => 'xterm');
+        x11_start_program('xterm');
         type_string "vncviewer -fullscreen $target_ip:1\n";
         assert_screen "remote_master_password";    # wait for password prompt
         type_string "$password\n";

--- a/tests/rescuecd/rescuecd.pm
+++ b/tests/rescuecd/rescuecd.pm
@@ -22,7 +22,7 @@ sub run {
     assert_and_dclick "hd-volume";
     assert_screen "hd-mounted", 6;
 
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     script_run "cd `cat /proc/self/mounts | grep /dev/vda2 | cut -d' ' -f2`";
     script_sudo "sh -c 'cat etc/SUSE-brand > /dev/$serialdev'";
     wait_serial("VERSION = 13.1", 2) || die "Not SUSE-brand found";

--- a/tests/rescuecd/rescuecd.pm
+++ b/tests/rescuecd/rescuecd.pm
@@ -22,7 +22,7 @@ sub run {
     assert_and_dclick "hd-volume";
     assert_screen "hd-mounted", 6;
 
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     script_run "cd `cat /proc/self/mounts | grep /dev/vda2 | cut -d' ' -f2`";
     script_sudo "sh -c 'cat etc/SUSE-brand > /dev/$serialdev'";
     wait_serial("VERSION = 13.1", 2) || die "Not SUSE-brand found";

--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,8 +17,7 @@ use utils;
 
 sub turn_off_screensaver {
     # Turn off screensaver
-    x11_start_program("xterm");
-    assert_screen('xterm');
+    x11_start_program('xterm', target_match => 'xterm');
 
     # in case we rebooted
     assert_script_sudo "chown $testapi::username /dev/$testapi::serialdev";
@@ -34,11 +33,9 @@ sub turn_off_screensaver {
 
 # Update with GNOME PackageKit Update Viewer
 sub run {
-
     my ($self) = @_;
     # updates_packagekit_gpk is disabled for SLE15 because of bsc#1060844
     return record_soft_failure 'bsc#1060844' if sle_version_at_least('15') && is_sle();
-
     select_console 'x11', await_console => 0;
 
     my @updates_tags           = qw(updates_none updates_available);
@@ -47,9 +44,7 @@ sub run {
     turn_off_screensaver;
 
     while (1) {
-        x11_start_program("gpk-update-viewer");
-
-        assert_screen \@updates_tags, 100;
+        x11_start_program('gpk-update-viewer', target_match => \@updates_tags, match_timeout => 100);
         if (match_has_tag("updates_none")) {
             send_key "ret";
             return;

--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -17,7 +17,7 @@ use utils;
 
 sub turn_off_screensaver {
     # Turn off screensaver
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
 
     # in case we rebooted
     assert_script_sudo "chown $testapi::username /dev/$testapi::serialdev";

--- a/tests/virtualization/prepare_sle12.pm
+++ b/tests/virtualization/prepare_sle12.pm
@@ -33,7 +33,7 @@ sub run {
         send_key "ret";
         save_screenshot;
         # install and launch polkit
-        x11_start_program('xterm', target_match => 'xterm');
+        x11_start_program('xterm');
         become_root();
         script_run "zypper -n in polkit-gnome";
         # exit root, and be the default user
@@ -46,7 +46,7 @@ sub run {
         # auto-login has been selected for gnome
         assert_screen "virt-manager_SLE12_desktop", 520;
     }
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root;
     script_run("hostname susetest");
     script_run("echo susetest > /etc/hostname");

--- a/tests/virtualization/prepare_sle12.pm
+++ b/tests/virtualization/prepare_sle12.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE Linux GmbH
+# Copyright (C) 2014-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@ sub run {
         send_key "ret";
         save_screenshot;
         # install and launch polkit
-        x11_start_program("xterm");
+        x11_start_program('xterm', target_match => 'xterm');
         become_root();
         script_run "zypper -n in polkit-gnome";
         # exit root, and be the default user
@@ -46,7 +46,7 @@ sub run {
         # auto-login has been selected for gnome
         assert_screen "virt-manager_SLE12_desktop", 520;
     }
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     become_root;
     script_run("hostname susetest");
     script_run("echo susetest > /etc/hostname");

--- a/tests/virtualization/virt_install.pm
+++ b/tests/virtualization/virt_install.pm
@@ -16,7 +16,7 @@ use testapi;
 
 sub run {
     ensure_installed("virt-install");
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root;
     script_run("virt-install --name TESTING --memory 512 --disk none --boot cdrom --graphics vnc &");
     x11_start_program('vncviewer :0', target_match => 'virtman-sle12sp1-gnome_virt-install', match_timeout => 100);

--- a/tests/virtualization/virt_install.pm
+++ b/tests/virtualization/virt_install.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,11 +16,10 @@ use testapi;
 
 sub run {
     ensure_installed("virt-install");
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     become_root;
     script_run("virt-install --name TESTING --memory 512 --disk none --boot cdrom --graphics vnc &");
-    x11_start_program("vncviewer :0");
-    assert_screen "virtman-sle12sp1-gnome_virt-install", 100;
+    x11_start_program('vncviewer :0', target_match => 'virtman-sle12sp1-gnome_virt-install', match_timeout => 100);
     for (0 .. 2) {
         send_key "alt-f4";
     }    # closing all windows

--- a/tests/virtualization/virt_top.pm
+++ b/tests/virtualization/virt_top.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,7 +17,7 @@ use testapi;
 
 sub run {
     ensure_installed("virt-top");
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     become_root;
     script_run "/usr/bin/virt-top";
     assert_screen "virtman-sle12sp1-gnome_virt-top";

--- a/tests/virtualization/virt_top.pm
+++ b/tests/virtualization/virt_top.pm
@@ -17,7 +17,7 @@ use testapi;
 
 sub run {
     ensure_installed("virt-top");
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root;
     script_run "/usr/bin/virt-top";
     assert_screen "virtman-sle12sp1-gnome_virt-top";

--- a/tests/virtualization/virtman_install.pm
+++ b/tests/virtualization/virtman_install.pm
@@ -20,7 +20,7 @@ sub run {
     # workaround for bug:
     # Bug 948366 - "pkcon install virt-manager" report it will remove
     # the package if this command is run twice
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root();
     script_run "zypper -n in virt-manager";
     # exit root, and be the default user

--- a/tests/virtualization/virtman_install.pm
+++ b/tests/virtualization/virtman_install.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,7 +20,7 @@ sub run {
     # workaround for bug:
     # Bug 948366 - "pkcon install virt-manager" report it will remove
     # the package if this command is run twice
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     become_root();
     script_run "zypper -n in virt-manager";
     # exit root, and be the default user

--- a/tests/virtualization/virtman_networkinterface.pm
+++ b/tests/virtualization/virtman_networkinterface.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE Linux GmbH
+# Copyright (C) 2014-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -33,7 +33,7 @@ sub go_for_netif {
 
 sub checking_netif_result {
     my $volumes = shift;
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     send_key "alt-f10";
     become_root();
     type_string "ip link show";

--- a/tests/virtualization/virtman_networkinterface.pm
+++ b/tests/virtualization/virtman_networkinterface.pm
@@ -33,7 +33,7 @@ sub go_for_netif {
 
 sub checking_netif_result {
     my $volumes = shift;
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     send_key "alt-f10";
     become_root();
     type_string "ip link show";

--- a/tests/virtualization/virtman_storage.pm
+++ b/tests/virtualization/virtman_storage.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE Linux GmbH
+# Copyright (C) 2014-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -67,7 +67,7 @@ sub go_for_volume {
 
 sub create_nfs_share {
     my ($dir) = @_;
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     become_root();
     type_string "mkdir -p $dir";
     send_key "ret";
@@ -82,7 +82,7 @@ sub create_nfs_share {
 
 sub checking_storage_result {
     my $volumes = shift;
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     send_key "alt-f10";
     become_root();
     type_string "virsh -c qemu:///system pool-list";

--- a/tests/virtualization/virtman_storage.pm
+++ b/tests/virtualization/virtman_storage.pm
@@ -67,7 +67,7 @@ sub go_for_volume {
 
 sub create_nfs_share {
     my ($dir) = @_;
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root();
     type_string "mkdir -p $dir";
     send_key "ret";
@@ -82,7 +82,7 @@ sub create_nfs_share {
 
 sub checking_storage_result {
     my $volumes = shift;
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     send_key "alt-f10";
     become_root();
     type_string "virsh -c qemu:///system pool-list";

--- a/tests/virtualization/virtman_virtualnet.pm
+++ b/tests/virtualization/virtman_virtualnet.pm
@@ -23,7 +23,7 @@ use virtmanager;
 
 sub checking_vnet_result {
     my $net = shift;
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     send_key "alt-f10";
     become_root();
     type_string "virsh -c qemu:///system net-list";

--- a/tests/virtualization/virtman_virtualnet.pm
+++ b/tests/virtualization/virtman_virtualnet.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 SUSE Linux GmbH
+# Copyright (C) 2014-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,7 +23,7 @@ use virtmanager;
 
 sub checking_vnet_result {
     my $net = shift;
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     send_key "alt-f10";
     become_root();
     type_string "virsh -c qemu:///system net-list";

--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,7 +15,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     send_key "alt-f10";
     become_root;
     script_run("yast2 virtualization; echo yast2-virtualization-done-\$? > /dev/$serialdev", 0);
@@ -55,7 +55,7 @@ sub run {
     # close the xterm
     send_key "alt-f4";
     # now need to start libvirtd
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     wait_screen_change { send_key "alt-f10" };
     become_root;
     type_string "systemctl start libvirtd", 50;

--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -15,7 +15,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     send_key "alt-f10";
     become_root;
     script_run("yast2 virtualization; echo yast2-virtualization-done-\$? > /dev/$serialdev", 0);
@@ -55,7 +55,7 @@ sub run {
     # close the xterm
     send_key "alt-f4";
     # now need to start libvirtd
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     wait_screen_change { send_key "alt-f10" };
     become_root;
     type_string "systemctl start libvirtd", 50;

--- a/tests/x11/ImageMagick.pm
+++ b/tests/x11/ImageMagick.pm
@@ -31,7 +31,7 @@ use utils;
 
 sub run {
     select_console "x11";
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
 
     become_root;
     pkcon_quit;

--- a/tests/x11/ImageMagick.pm
+++ b/tests/x11/ImageMagick.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -31,7 +31,7 @@ use utils;
 
 sub run {
     select_console "x11";
-    x11_start_program "xterm";
+    x11_start_program('xterm', target_match => 'xterm');
 
     become_root;
     pkcon_quit;

--- a/tests/x11/amarok.pm
+++ b/tests/x11/amarok.pm
@@ -17,7 +17,7 @@ use testapi;
 
 sub run {
     ensure_installed("amarok");
-    x11_start_program('amarok', target_match => 'test-amarok-1');
+    x11_start_program('amarok');
     send_key "alt-y";    # use music path as collection folder
                          # a workaround for librivox authentication popup window.
                          # and don't put this after opening oga file, per video

--- a/tests/x11/amarok.pm
+++ b/tests/x11/amarok.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,8 +17,7 @@ use testapi;
 
 sub run {
     ensure_installed("amarok");
-    x11_start_program('amarok');
-    assert_screen 'test-amarok-1';
+    x11_start_program('amarok', target_match => 'test-amarok-1');
     send_key "alt-y";    # use music path as collection folder
                          # a workaround for librivox authentication popup window.
                          # and don't put this after opening oga file, per video
@@ -32,8 +31,7 @@ sub run {
     # do not playing audio file as we have not testdata if NICEVIDEO
     if (!get_var("NICEVIDEO")) {
         start_audiocapture;
-        x11_start_program("amarok -l ~/data/1d5d9dD.oga");
-        assert_screen 'test-amarok-3';
+        x11_start_program('amarok -l ~/data/1d5d9dD.oga', target_match => 'test-amarok-3');
         assert_recorded_sound('DTMF-159D');
     }
     send_key "ctrl-q";       # really quit (alt-f4 just backgrounds)

--- a/tests/x11/chrome.pm
+++ b/tests/x11/chrome.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -30,8 +30,7 @@ sub run {
 
     mouse_hide;
 
-    x11_start_program("xterm");
-    assert_screen('xterm');
+    x11_start_program('xterm', target_match => 'xterm');
 
     # install the google key first
     become_root;
@@ -48,9 +47,7 @@ sub run {
     send_key "alt-f4";
 
     # avoid async keyring popups
-    x11_start_program("google-chrome --password-store=basic");
-
-    assert_screen 'chrome-default-browser-query';
+    x11_start_program('google-chrome --password-store=basic', target_match => 'chrome-default-browser-query');
     # we like to preserve the privacy of the non-human openqa workers ;-)
     assert_and_click 'chrome-do_not_send_data' if match_has_tag 'chrome-default-browser-query-send-data';
     assert_and_click 'chrome-default-browser-query';

--- a/tests/x11/chrome.pm
+++ b/tests/x11/chrome.pm
@@ -30,7 +30,7 @@ sub run {
 
     mouse_hide;
 
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
 
     # install the google key first
     become_root;

--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,9 +22,7 @@ sub run {
     ensure_installed("chromium");
 
     # avoid async keyring popups
-    x11_start_program("chromium --password-store=basic");
-
-    assert_screen 'chromium-main-window', 50;
+    x11_start_program('chromium --password-store=basic', target_match => 'chromium-main-window', match_timeout => 50);
 
     send_key "esc";       # get rid of popup
     sleep 1;

--- a/tests/x11/desktop_mainmenu.pm
+++ b/tests/x11/desktop_mainmenu.pm
@@ -20,18 +20,19 @@ use testapi;
 sub run {
     sleep 5;
     if (check_var("DESKTOP", "lxde")) {
-        x11_start_program("lxpanelctl menu");    # or Super_L or Windows key
+        # or Super_L or Windows key
+        x11_start_program('lxpanelctl menu', target_match => 'test-desktop_mainmenu-1');
     }
     elsif (check_var("DESKTOP", "xfce")) {
         mouse_set(0, 0);
         sleep 1;
-        send_key "ctrl-esc";                     # open menu
+        send_key "ctrl-esc";    # open menu
         sleep 1;
-        send_key "up";                           # go into Applications submenu
+        send_key "up";          # go into Applications submenu
         mouse_hide(1);
     }
     else {
-        send_key "alt-f1";                       # open main menu
+        send_key "alt-f1";      # open main menu
     }
     assert_screen 'test-desktop_mainmenu-1', 20;
 

--- a/tests/x11/dolphin.pm
+++ b/tests/x11/dolphin.pm
@@ -16,8 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('dolphin');
-    assert_screen 'test-dolphin-1';
+    x11_start_program('dolphin', target_match => 'test-dolphin-1');
     send_key "alt-f4";
 }
 

--- a/tests/x11/dolphin.pm
+++ b/tests/x11/dolphin.pm
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('dolphin', target_match => 'test-dolphin-1');
+    x11_start_program('dolphin');
     send_key "alt-f4";
 }
 

--- a/tests/x11/eog.pm
+++ b/tests/x11/eog.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,7 @@ use utils;
 
 
 sub run {
-    assert_gui_app("eog", exec_param => get_var("WALLPAPER"));
+    assert_gui_app('eog', exec_param => get_var('WALLPAPER'));
 }
 
 1;

--- a/tests/x11/evolution.pm
+++ b/tests/x11/evolution.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,11 +17,10 @@ use testapi;
 use utils;
 
 sub run {
-    x11_start_program("evolution");
     my @tags = qw(test-evolution-1 evolution-default-client-ask);
     push(@tags, 'evolution-preview-release') if is_gnome_next;
+    x11_start_program('evolution', target_match => \@tags);
     my $times = scalar(@tags) - 1;
-    assert_screen \@tags;
 
     unless (match_has_tag('test-evolution-1')) {
         for (0 .. $times) {

--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -19,7 +19,7 @@ use testapi;
 
 sub start_firefox {
     my ($self) = @_;
-    x11_start_program('firefox https://html5test.com/index.html');
+    x11_start_program('firefox https://html5test.com/index.html', valid => 0);
     $self->firefox_check_default;
     $self->firefox_check_popups;
     assert_screen 'firefox-html5test';

--- a/tests/x11/gdm_session_switch.pm
+++ b/tests/x11/gdm_session_switch.pm
@@ -19,10 +19,10 @@ use utils;
 
 # Smoke test: launch some applications
 sub application_test {
-    x11_start_program('gnome-terminal', target_match => 'gnome-terminal');
+    x11_start_program('gnome-terminal');
     send_key "alt-f4";
 
-    x11_start_program('nautilus', target_match => 'test-nautilus-1');
+    x11_start_program('nautilus');
     send_key "alt-f4";
 }
 

--- a/tests/x11/gdm_session_switch.pm
+++ b/tests/x11/gdm_session_switch.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,12 +19,10 @@ use utils;
 
 # Smoke test: launch some applications
 sub application_test {
-    x11_start_program "gnome-terminal";
-    assert_screen "gnome-terminal";
+    x11_start_program('gnome-terminal', target_match => 'gnome-terminal');
     send_key "alt-f4";
 
-    x11_start_program "nautilus";
-    assert_screen "test-nautilus-1";
+    x11_start_program('nautilus', target_match => 'test-nautilus-1');
     send_key "alt-f4";
 }
 

--- a/tests/x11/gedit.pm
+++ b/tests/x11/gedit.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,8 +17,7 @@ use testapi;
 
 sub run {
     my ($self) = @_;
-    x11_start_program("gedit");
-    assert_screen 'gedit-launched';
+    x11_start_program('gedit', target_match => 'gedit-launched');
     $self->enter_test_text('gedit');
     assert_screen 'test-gedit-1';
     send_key 'alt-f4';

--- a/tests/x11/gedit.pm
+++ b/tests/x11/gedit.pm
@@ -17,7 +17,7 @@ use testapi;
 
 sub run {
     my ($self) = @_;
-    x11_start_program('gedit', target_match => 'gedit-launched');
+    x11_start_program('gedit');
     $self->enter_test_text('gedit');
     assert_screen 'test-gedit-1';
     send_key 'alt-f4';

--- a/tests/x11/ghostscript.pm
+++ b/tests/x11/ghostscript.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,7 +22,7 @@ use utils;
 
 sub run {
     select_console "x11";
-    x11_start_program "xterm";
+    x11_start_program('xterm', target_match => 'xterm');
 
     # become root, disable packagekit and install all needed packages
     become_root;

--- a/tests/x11/ghostscript.pm
+++ b/tests/x11/ghostscript.pm
@@ -22,7 +22,7 @@ use utils;
 
 sub run {
     select_console "x11";
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
 
     # become root, disable packagekit and install all needed packages
     become_root;

--- a/tests/x11/gimp.pm
+++ b/tests/x11/gimp.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,8 +17,7 @@ use testapi;
 
 sub run {
     ensure_installed("gimp");
-    x11_start_program("gimp");
-    assert_screen "test-gimp-1";
+    x11_start_program('gimp', target_match => 'test-gimp-1');
     send_key "alt-f4";    # Exit
 }
 

--- a/tests/x11/gimp.pm
+++ b/tests/x11/gimp.pm
@@ -17,7 +17,7 @@ use testapi;
 
 sub run {
     ensure_installed("gimp");
-    x11_start_program('gimp', target_match => 'test-gimp-1');
+    x11_start_program('gimp');
     send_key "alt-f4";    # Exit
 }
 

--- a/tests/x11/glxgears.pm
+++ b/tests/x11/glxgears.pm
@@ -18,7 +18,7 @@ use testapi;
 sub run {
     ensure_installed 'Mesa-demo-x';
     # 'no_wait' for still screen because glxgears will be always moving
-    x11_start_program('glxgears', no_wait => 1, target_match => 'test-glxgears-1');
+    x11_start_program('glxgears', no_wait => 1);
     send_key 'alt-f4';
 }
 

--- a/tests/x11/glxgears.pm
+++ b/tests/x11/glxgears.pm
@@ -17,8 +17,8 @@ use testapi;
 
 sub run {
     ensure_installed 'Mesa-demo-x';
-    # 'no_wait' for still screen because glxgears will be always moving
-    x11_start_program('glxgears', no_wait => 1);
+    # 'no_wait' for screen check because glxgears will be always moving
+    x11_start_program('glxgears', match_no_wait => 1);
     send_key 'alt-f4';
 }
 

--- a/tests/x11/glxgears.pm
+++ b/tests/x11/glxgears.pm
@@ -18,8 +18,7 @@ use testapi;
 sub run {
     ensure_installed 'Mesa-demo-x';
     # 'no_wait' for still screen because glxgears will be always moving
-    x11_start_program('glxgears', no_wait => 1);
-    assert_screen 'test-glxgears-1';
+    x11_start_program('glxgears', no_wait => 1, target_match => 'test-glxgears-1');
     send_key 'alt-f4';
 }
 

--- a/tests/x11/gnome_control_center.pm
+++ b/tests/x11/gnome_control_center.pm
@@ -20,7 +20,7 @@ use testapi;
 sub run {
     mouse_hide(1);
     # for timeout selection see bsc#965857
-    x11_start_program('gnome-control-center', target_match => 'gnome-control-center-started', match_timeout => 120);
+    x11_start_program('gnome-control-center', match_timeout => 120);
     if (match_has_tag('gnome-control-center-new-layout')) {
         # with GNOME 3.26, the control-center got a different layout / workflow
         type_string "about";

--- a/tests/x11/gnome_control_center.pm
+++ b/tests/x11/gnome_control_center.pm
@@ -19,8 +19,8 @@ use testapi;
 
 sub run {
     mouse_hide(1);
-    x11_start_program("gnome-control-center");
-    assert_screen "gnome-control-center-started", 120;    # for timeout selection see bsc#965857
+    # for timeout selection see bsc#965857
+    x11_start_program('gnome-control-center', target_match => 'gnome-control-center-started', match_timeout => 120);
     if (match_has_tag('gnome-control-center-new-layout')) {
         # with GNOME 3.26, the control-center got a different layout / workflow
         type_string "about";

--- a/tests/x11/gnome_terminal.pm
+++ b/tests/x11/gnome_terminal.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,8 +18,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     mouse_hide(1);
-    x11_start_program("gnome-terminal");
-    assert_screen "gnome-terminal";
+    x11_start_program('gnome-terminal', target_match => 'gnome-terminal');
     send_key "ctrl-shift-t";
     if (!check_screen "gnome-terminal-second-tab") {
         record_info('workaround', 'gnome_terminal does not open second terminal when shortcut is pressed (see bsc#999243)');

--- a/tests/x11/gnome_terminal.pm
+++ b/tests/x11/gnome_terminal.pm
@@ -18,7 +18,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     mouse_hide(1);
-    x11_start_program('gnome-terminal', target_match => 'gnome-terminal');
+    x11_start_program('gnome-terminal');
     send_key "ctrl-shift-t";
     if (!check_screen "gnome-terminal-second-tab") {
         record_info('workaround', 'gnome_terminal does not open second terminal when shortcut is pressed (see bsc#999243)');

--- a/tests/x11/gnome_tweak_tool.pm
+++ b/tests/x11/gnome_tweak_tool.pm
@@ -16,7 +16,7 @@ use testapi;
 
 sub run {
     mouse_hide(1);
-    x11_start_program('gnome-tweak-tool', target_match => 'gnome-tweak-tool-started');
+    x11_start_program('gnome-tweak-tool');
     assert_and_click "gnome-tweak-tool-fonts";
     assert_screen "gnome-tweak-tool-fonts-dialog";
     send_key "alt-f4";

--- a/tests/x11/gnome_tweak_tool.pm
+++ b/tests/x11/gnome_tweak_tool.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,8 +16,7 @@ use testapi;
 
 sub run {
     mouse_hide(1);
-    x11_start_program("gnome-tweak-tool");
-    assert_screen "gnome-tweak-tool-started";
+    x11_start_program('gnome-tweak-tool', target_match => 'gnome-tweak-tool-started');
     assert_and_click "gnome-tweak-tool-fonts";
     assert_screen "gnome-tweak-tool-fonts-dialog";
     send_key "alt-f4";

--- a/tests/x11/gnomeapps/aa_disable_updates.pm
+++ b/tests/x11/gnomeapps/aa_disable_updates.pm
@@ -16,8 +16,7 @@ use testapi;
 use utils;
 
 sub run {
-    x11_start_program 'xterm';
-    assert_screen 'xterm';
+    x11_start_program('xterm', target_match => 'xterm');
     type_string "gsettings set org.gnome.software download-updates false\n";
     save_screenshot;
     type_string "exit\n";

--- a/tests/x11/gnomeapps/aa_disable_updates.pm
+++ b/tests/x11/gnomeapps/aa_disable_updates.pm
@@ -16,7 +16,7 @@ use testapi;
 use utils;
 
 sub run {
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     type_string "gsettings set org.gnome.software download-updates false\n";
     save_screenshot;
     type_string "exit\n";

--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -21,7 +21,7 @@ sub run {
 
     # needed for viewing
     ensure_installed("yelp");
-    x11_start_program('gnucash', target_match => 'test-gnucash-1');
+    x11_start_program('gnucash');
     send_key "ctrl-h";    # open user tutorial
     assert_screen 'test-gnucash-2';
     # Leave tutorial window

--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -21,8 +21,7 @@ sub run {
 
     # needed for viewing
     ensure_installed("yelp");
-    x11_start_program("gnucash");
-    assert_screen 'test-gnucash-1';
+    x11_start_program('gnucash', target_match => 'test-gnucash-1');
     send_key "ctrl-h";    # open user tutorial
     assert_screen 'test-gnucash-2';
     # Leave tutorial window

--- a/tests/x11/hexchat.pm
+++ b/tests/x11/hexchat.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 SUSE Linux GmbH
+# Copyright (C) 2015-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -30,11 +30,10 @@ sub run {
     # may suddenly cover parts of the dialog ... o_O
     mouse_set(0, 0);
     if (my $url = get_var('XCHAT_URL')) {
-        x11_start_program("$name --url=$url");
+        x11_start_program("$name --url=$url", target_match => "$name-main-window");
     }
     else {
-        x11_start_program($name);
-        assert_screen "$name-network-select";
+        x11_start_program($name, target_match => "$name-network-select");
         type_string "freenode\n";
         assert_and_click "hexchat-nick-$username";
         send_key 'ctrl-a';

--- a/tests/x11/hexchat_ssl.pm
+++ b/tests/x11/hexchat_ssl.pm
@@ -7,12 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Case #1459498 - FIPS : hexchat_ssl
-
-# G-Summary: Add hexchat_ssl test case and fips test entry
-#    Add hexchat_ssl.pm test case was located in x11/hexchat_ssl.pm
-#    Add hexchat_ssl.pm test entry in load_fips_tests_misc() in sle/main.pm
-# G-Maintainer: Ben Chou <bchou@suse.com>
+# Summary: FIPS : hexchat_ssl
+# Maintainer: Ben Chou <bchou@suse.com>
+# Tags: testopia#1459498
 
 use base "x11test";
 use strict;
@@ -28,7 +25,7 @@ sub run {
     mouse_set(0, 0);
 
     if (my $url = get_var("XCHAT_URL")) {
-        x11_start_program("$name --url=$url");
+        x11_start_program("$name --url=$url", target_match => "$name-main-window");
     }
     else {
         x11_start_program("$name", target_match => "$name-network-select");

--- a/tests/x11/hexchat_ssl.pm
+++ b/tests/x11/hexchat_ssl.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests - FIPS tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -31,8 +31,7 @@ sub run {
         x11_start_program("$name --url=$url");
     }
     else {
-        x11_start_program("$name");
-        assert_screen "$name-network-select";
+        x11_start_program("$name", target_match => "$name-network-select");
         type_string "freenode\n";
 
         # use ssl for all servers on this network

--- a/tests/x11/inkscape.pm
+++ b/tests/x11/inkscape.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,8 +17,7 @@ use testapi;
 
 sub run {
     ensure_installed('inkscape', timeout => 300);
-    x11_start_program("inkscape");
-    assert_screen 'test-inkscape-1', 3;
+    x11_start_program('inkscape', target_match => 'test-inkscape-1');
     send_key "alt-f4";    # Exit
 }
 

--- a/tests/x11/inkscape.pm
+++ b/tests/x11/inkscape.pm
@@ -17,7 +17,7 @@ use testapi;
 
 sub run {
     ensure_installed('inkscape', timeout => 300);
-    x11_start_program('inkscape', target_match => 'test-inkscape-1');
+    x11_start_program('inkscape');
     send_key "alt-f4";    # Exit
 }
 

--- a/tests/x11/kate.pm
+++ b/tests/x11/kate.pm
@@ -19,8 +19,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     ensure_installed("kate");
-    x11_start_program('kate');
-    assert_screen 'test-kate-1';
+    x11_start_program('kate', target_match => 'test-kate-1');
 
     if (!get_var("PLASMA5")) {
         # close welcome screen

--- a/tests/x11/kate.pm
+++ b/tests/x11/kate.pm
@@ -19,7 +19,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     ensure_installed("kate");
-    x11_start_program('kate', target_match => 'test-kate-1');
+    x11_start_program('kate');
 
     if (!get_var("PLASMA5")) {
         # close welcome screen

--- a/tests/x11/khelpcenter.pm
+++ b/tests/x11/khelpcenter.pm
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('khelpcenter', target_match => 'test-khelpcenter-1');
+    x11_start_program('khelpcenter');
     send_key 'alt-f4';
 }
 

--- a/tests/x11/khelpcenter.pm
+++ b/tests/x11/khelpcenter.pm
@@ -16,8 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('khelpcenter');
-    assert_screen 'test-khelpcenter-1';
+    x11_start_program('khelpcenter', target_match => 'test-khelpcenter-1');
     send_key 'alt-f4';
 }
 

--- a/tests/x11/kontact.pm
+++ b/tests/x11/kontact.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -26,8 +26,8 @@ sub run {
     x11_start_program("echo \"[General]\" >> ~/.config/kmail2rc");
     x11_start_program("echo \"first-start=false\" >> ~/.config/kmail2rc");
 
-    x11_start_program('kontact');
     my @tags = qw(test-kontact-1 kontact-import-data-dialog kontact-window);
+    x11_start_program('kontact', target_match => \@tags);
     do {
         assert_screen \@tags;
         # kontact might ask to import data from another mailer, don't

--- a/tests/x11/kontact.pm
+++ b/tests/x11/kontact.pm
@@ -17,14 +17,14 @@ use testapi;
 
 sub run {
     # start akonadi server to avoid the self-test running when we launch kontact
-    x11_start_program('akonadictl start');
+    x11_start_program('akonadictl start', valid => 0);
 
     # Workaround: sometimes the account assistant behind of mainwindow or tips window
     # To disable it run at first time start
-    x11_start_program("echo \"[General]\" >> ~/.kde4/share/config/kmail2rc");
-    x11_start_program("echo \"first-start=false\" >> ~/.kde4/share/config/kmail2rc");
-    x11_start_program("echo \"[General]\" >> ~/.config/kmail2rc");
-    x11_start_program("echo \"first-start=false\" >> ~/.config/kmail2rc");
+    x11_start_program("echo \"[General]\" >> ~/.kde4/share/config/kmail2rc",         valid => 0);
+    x11_start_program("echo \"first-start=false\" >> ~/.kde4/share/config/kmail2rc", valid => 0);
+    x11_start_program("echo \"[General]\" >> ~/.config/kmail2rc",                    valid => 0);
+    x11_start_program("echo \"first-start=false\" >> ~/.config/kmail2rc",            valid => 0);
 
     my @tags = qw(test-kontact-1 kontact-import-data-dialog kontact-window);
     x11_start_program('kontact', target_match => \@tags);

--- a/tests/x11/mate_terminal.pm
+++ b/tests/x11/mate_terminal.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,8 +18,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     mouse_hide(1);
-    x11_start_program("mate-terminal");
-    assert_screen "mate-terminal";
+    x11_start_program('mate-terminal', target_match => 'mate-terminal');
     send_key "ctrl-shift-t";
     assert_screen "mate-terminal-second-tab";
     $self->enter_test_text('mate-terminal', cmd => 1);

--- a/tests/x11/mate_terminal.pm
+++ b/tests/x11/mate_terminal.pm
@@ -18,7 +18,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     mouse_hide(1);
-    x11_start_program('mate-terminal', target_match => 'mate-terminal');
+    x11_start_program('mate-terminal');
     send_key "ctrl-shift-t";
     assert_screen "mate-terminal-second-tab";
     $self->enter_test_text('mate-terminal', cmd => 1);

--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -71,8 +71,7 @@ sub run {
     handle_login;
     assert_screen 'generic-desktop', 60;
     # verify correct user is logged in
-    x11_start_program 'xterm';
-    assert_screen 'xterm';
+    x11_start_program('xterm', target_match => 'xterm');
     wait_still_screen;
     type_string "whoami|grep $user > /tmp/whoami.log\n";
     assert_script_sudo "grep $user /tmp/whoami.log";

--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -71,7 +71,7 @@ sub run {
     handle_login;
     assert_screen 'generic-desktop', 60;
     # verify correct user is logged in
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     wait_still_screen;
     type_string "whoami|grep $user > /tmp/whoami.log\n";
     assert_script_sudo "grep $user /tmp/whoami.log";

--- a/tests/x11/nautilus.pm
+++ b/tests/x11/nautilus.pm
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('nautilus', target_match => 'test-nautilus-1');
+    x11_start_program('nautilus');
     send_key "alt-f4";
 }
 

--- a/tests/x11/nautilus.pm
+++ b/tests/x11/nautilus.pm
@@ -1,23 +1,22 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Rework the tests layout.
-# G-Maintainer: Alberto Planas <aplanas@suse.com>
+# Summary: Test initial startup of nautilus
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "x11test";
 use strict;
 use testapi;
 
 sub run {
-    x11_start_program("nautilus");
-    assert_screen 'test-nautilus-1';
+    x11_start_program('nautilus', target_match => 'test-nautilus-1');
     send_key "alt-f4";
 }
 

--- a/tests/x11/nis_client.pm
+++ b/tests/x11/nis_client.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,7 @@ use mm_network;
 use lockapi;
 
 sub run {
-    x11_start_program("xterm -geometry 155x45+5+5");
+    x11_start_program('xterm -geometry 155x45+5+5', target_match => 'xterm');
     type_string "gsettings set org.gnome.desktop.session idle-delay 0\n";    # disable blank scree
     become_root;
     configure_default_gateway;

--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,7 +19,7 @@ use lockapi;
 use mmapi;
 
 sub run {
-    x11_start_program("xterm -geometry 155x45+5+5");
+    x11_start_program('xterm -geometry 155x45+5+5', target_match => 'xterm');
     type_string "gsettings set org.gnome.desktop.session idle-delay 0\n";    # disable blank screen
     become_root;
     configure_default_gateway;

--- a/tests/x11/oocalc.pm
+++ b/tests/x11/oocalc.pm
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('oocalc', target_match => 'test-oocalc-1');
+    x11_start_program('oocalc');
     wait_still_screen;    # extra wait because oo sometimes appears to be idle during start
     wait_screen_change { assert_and_click 'input-area-oocalc', 'left', 10 };
     type_string "Hello World!\n";

--- a/tests/x11/oocalc.pm
+++ b/tests/x11/oocalc.pm
@@ -16,9 +16,8 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('oocalc');
+    x11_start_program('oocalc', target_match => 'test-oocalc-1');
     wait_still_screen;    # extra wait because oo sometimes appears to be idle during start
-    assert_screen 'test-oocalc-1';
     wait_screen_change { assert_and_click 'input-area-oocalc', 'left', 10 };
     type_string "Hello World!\n";
     assert_screen 'test-oocalc-2';

--- a/tests/x11/ooffice.pm
+++ b/tests/x11/ooffice.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,8 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("oowriter");
-    assert_screen 'test-ooffice-1';
+    x11_start_program('oowriter', target_match => 'test-ooffice-1');
     # clicking the writing area to make sure the cursor addressed there
     wait_screen_change { assert_and_click 'ooffice-writing-area', 'left', 10 };
     type_string "Hello World!";

--- a/tests/x11/ooffice.pm
+++ b/tests/x11/ooffice.pm
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('oowriter', target_match => 'test-ooffice-1');
+    x11_start_program('oowriter');
     # clicking the writing area to make sure the cursor addressed there
     wait_screen_change { assert_and_click 'ooffice-writing-area', 'left', 10 };
     type_string "Hello World!";

--- a/tests/x11/oomath.pm
+++ b/tests/x11/oomath.pm
@@ -17,7 +17,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('oomath', target_match => 'oomath-textfield-ready');
+    x11_start_program('oomath');
     type_string "E %PHI = H %PHI\nnewline\n1 = 1";
     wait_still_screen(1);
 

--- a/tests/x11/oomath.pm
+++ b/tests/x11/oomath.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,8 +17,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("oomath");
-    assert_screen 'oomath-textfield-ready';
+    x11_start_program('oomath', target_match => 'oomath-textfield-ready');
     type_string "E %PHI = H %PHI\nnewline\n1 = 1";
     wait_still_screen(1);
 

--- a/tests/x11/plasma5_force_96dpi.pm
+++ b/tests/x11/plasma5_force_96dpi.pm
@@ -15,7 +15,8 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('kcmshell5 fonts');      # Start the fonts KCM
+    # Start the fonts KCM
+    x11_start_program('kcmshell5 fonts', target_match => 'kcm_fonts_force_dpi');
     assert_and_click 'kcm_fonts_force_dpi';    # Check force DPI checkbox (96 is preselected)
     send_key 'alt-o';                          # Save and close the dialog
 }

--- a/tests/x11/reboot_lxde.pm
+++ b/tests/x11/reboot_lxde.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,8 +19,7 @@ use utils;
 sub run {
     my ($self) = @_;
     #send_key "ctrl-alt-delete"; # does open task manager instead of reboot
-    x11_start_program "lxsession-logout";
-    assert_screen "logoutdialog", 20;
+    x11_start_program('lxsession-logout', target_match => 'logoutdialog');
     send_key "tab";    # reboot
     save_screenshot;
     send_key "ret";    # confirm

--- a/tests/x11/rhythmbox.pm
+++ b/tests/x11/rhythmbox.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,8 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("rhythmbox");
-    assert_screen 'test-rhythmbox-1';
+    x11_start_program('rhythmbox', target_match => 'test-rhythmbox-1');
     send_key "alt-f4";
 }
 

--- a/tests/x11/rhythmbox.pm
+++ b/tests/x11/rhythmbox.pm
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('rhythmbox', target_match => 'test-rhythmbox-1');
+    x11_start_program('rhythmbox');
     send_key "alt-f4";
 }
 

--- a/tests/x11/ristretto.pm
+++ b/tests/x11/ristretto.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("ristretto /usr/share/wallpapers/xfce/default.wallpaper");
+    x11_start_program("ristretto /usr/share/wallpapers/xfce/default.wallpaper", valid => 0);
     wait_screen_change { send_key "ctrl-m" };
     assert_screen 'test-ristretto-1';
     send_key "alt-f4";

--- a/tests/x11/seahorse.pm
+++ b/tests/x11/seahorse.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,8 +20,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("seahorse");
-    assert_screen 'seahorse-launched', 15;    # Seahorse main window appeared
+    x11_start_program('seahorse', target_match => 'seahorse-launched');
     send_key "ctrl-n";                                # New keyring
     assert_screen "seahorse-keyring-selector";        # Dialog "Select type to create"
     assert_and_dclick "seahorse-password-keyring";    # Selection: Password keyring

--- a/tests/x11/seahorse.pm
+++ b/tests/x11/seahorse.pm
@@ -20,7 +20,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('seahorse', target_match => 'seahorse-launched');
+    x11_start_program('seahorse');
     send_key "ctrl-n";                                # New keyring
     assert_screen "seahorse-keyring-selector";        # Dialog "Select type to create"
     assert_and_dclick "seahorse-password-keyring";    # Selection: Password keyring

--- a/tests/x11/seahorse_sshkey.pm
+++ b/tests/x11/seahorse_sshkey.pm
@@ -15,8 +15,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("seahorse");
-    assert_screen 'seahorse-launched';            # Seahorse main window appeared
+    x11_start_program('seahorse', target_match => 'seahorse-launched');
     send_key "ctrl-n";                            # New Keyring
     assert_screen 'seahorse-keyring-selector';    # Dialog "Select type to create"
     send_key_until_needlematch("seahorse-secure-shell-key", "down");    # Selected secure shell key

--- a/tests/x11/seahorse_sshkey.pm
+++ b/tests/x11/seahorse_sshkey.pm
@@ -15,7 +15,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('seahorse', target_match => 'seahorse-launched');
+    x11_start_program('seahorse');
     send_key "ctrl-n";                            # New Keyring
     assert_screen 'seahorse-keyring-selector';    # Dialog "Select type to create"
     send_key_until_needlematch("seahorse-secure-shell-key", "down");    # Selected secure shell key

--- a/tests/x11/smt.pm
+++ b/tests/x11/smt.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,8 +18,7 @@ use warnings;
 use testapi;
 
 sub run {
-    x11_start_program("xterm -geometry 150x35+5+5");
-    assert_screen('xterm');
+    x11_start_program('xterm -geometry 150x35+5+5', target_match => 'xterm');
     become_root;
 
     type_string "yast2 smt-wizard;echo yast2-smt-wizard-\$? > /dev/$serialdev\n";

--- a/tests/x11/ssh_key_check.pm
+++ b/tests/x11/ssh_key_check.pm
@@ -1,22 +1,22 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Add ssh key dialog test
+# Summary: Ssh key dialog test
 #    https://progress.opensuse.org/issues/11454 https://github.com/yast/skelcd-control-SLES/blob/d2f9a79c0681806bf02eb38c4b7c287b9d9434eb/control/control.SLES.xml#L53-L71
-# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "x11test";
 use strict;
 use testapi;
 
 sub run {
-    x11_start_program("xterm -geometry 150x45+5+5");
+    x11_start_program('xterm -geometry 150x45+5+5', target_match => 'xterm');
     become_root;
     script_run 'cd /etc/ssh';
     script_run 'touch ssh_host_key ssh_host_key.pub';    # this file must exist to trigger ssh key import

--- a/tests/x11/ssh_key_verify.pm
+++ b/tests/x11/ssh_key_verify.pm
@@ -1,15 +1,15 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Add ssh key dialog test
+# Summary: ssh key dialog test
 #    https://progress.opensuse.org/issues/11454 https://github.com/yast/skelcd-control-SLES/blob/d2f9a79c0681806bf02eb38c4b7c287b9d9434eb/control/control.SLES.xml#L53-L71
-# G-Maintainer: Jozef Pupava <jpupava@suse.com>
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
 use strict;
 use warnings;
@@ -17,7 +17,7 @@ use base "y2logsstep";
 use testapi;
 
 sub run {
-    x11_start_program("xterm -geometry 150x45+5+5");
+    x11_start_program('xterm -geometry 150x45+5+5', target_match => 'xterm');
     become_root;
     script_run 'cd /etc/ssh';
     if (get_var('SSH_KEY_IMPORT')) {

--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,8 +18,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     mouse_hide(1);
-    x11_start_program("xterm");
-    assert_screen("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     type_string("ssh -XC root\@localhost xterm\n");
     assert_screen([qw(ssh-xterm-host-key-authentication ssh-password-prompt)]);
     # if ssh asks for authentication of the key accept it

--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -18,7 +18,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     mouse_hide(1);
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     type_string("ssh -XC root\@localhost xterm\n");
     assert_screen([qw(ssh-xterm-host-key-authentication ssh-password-prompt)]);
     # if ssh asks for authentication of the key accept it

--- a/tests/x11/start_wayland_plasma5.pm
+++ b/tests/x11/start_wayland_plasma5.pm
@@ -22,8 +22,8 @@ sub run {
     ensure_installed "plasma5-session-wayland";
 
     # Workaround (part 1): use softpipe as llvmpipe crashes all the time (fdo#96953)
-    x11_start_program 'mkdir -p ~/.config/plasma-workspace/env';
-    x11_start_program "echo 'echo export GALLIUM_DRIVER=softpipe >> ~/.config/startupconfig' > ~/.config/plasma-workspace/env/softpipe.sh";
+    x11_start_program('mkdir -p ~/.config/plasma-workspace/env',                                                                            valid => 0);
+    x11_start_program("echo 'echo export GALLIUM_DRIVER=softpipe >> ~/.config/startupconfig' > ~/.config/plasma-workspace/env/softpipe.sh", valid => 0);
 
     # Log out of X session
     send_key 'super';                             # Open the application menu
@@ -46,7 +46,7 @@ sub run {
 
     # Workaround (part 2): KWin does not work with the workaround so we need to undo it
     # to allow relogins to succeed
-    x11_start_program "rm ~/.config/startupconfig";
+    x11_start_program('rm ~/.config/startupconfig', valid => 0);
 }
 
 sub test_flags {

--- a/tests/x11/stunnel.pm
+++ b/tests/x11/stunnel.pm
@@ -19,8 +19,7 @@ use utils;
 use mm_tests;
 
 sub run {
-    x11_start_program("xterm");
-    assert_screen "xterm";
+    x11_start_program('xterm', target_match => 'xterm');
     become_root;
     script_run 'cd';
     configure_static_network('10.0.2.11/24');

--- a/tests/x11/stunnel.pm
+++ b/tests/x11/stunnel.pm
@@ -19,7 +19,7 @@ use utils;
 use mm_tests;
 
 sub run {
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root;
     script_run 'cd';
     configure_static_network('10.0.2.11/24');

--- a/tests/x11/systemsettings.pm
+++ b/tests/x11/systemsettings.pm
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('systemsettings', target_match => 'test-systemsettings-1');
+    x11_start_program('systemsettings');
     send_key "alt-f4";
 }
 

--- a/tests/x11/systemsettings.pm
+++ b/tests/x11/systemsettings.pm
@@ -16,8 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('systemsettings');
-    assert_screen 'test-systemsettings-1';
+    x11_start_program('systemsettings', target_match => 'test-systemsettings-1');
     send_key "alt-f4";
 }
 

--- a/tests/x11/systemsettings5.pm
+++ b/tests/x11/systemsettings5.pm
@@ -16,8 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('systemsettings5', valid => 1);
-    assert_screen 'test-systemsettings-1';
+    x11_start_program('systemsettings5', target_match => 'test-systemsettings-1');
     send_key "alt-f4";
 }
 

--- a/tests/x11/thunar.pm
+++ b/tests/x11/thunar.pm
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("thunar");
+    x11_start_program('thunar', valid => 0);
     send_key "shift-tab";
     send_key "home";
     send_key "down";

--- a/tests/x11/thunderbird.pm
+++ b/tests/x11/thunderbird.pm
@@ -17,7 +17,7 @@ use testapi;
 
 sub run {
     ensure_installed("MozillaThunderbird");
-    x11_start_program('thunderbird', target_match => 'test-thunderbird-1');
+    x11_start_program('thunderbird');
     wait_screen_change {
         send_key "alt-f4";    # close wizard
     };

--- a/tests/x11/thunderbird.pm
+++ b/tests/x11/thunderbird.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,8 +17,7 @@ use testapi;
 
 sub run {
     ensure_installed("MozillaThunderbird");
-    x11_start_program("thunderbird");
-    assert_screen 'test-thunderbird-1';
+    x11_start_program('thunderbird', target_match => 'test-thunderbird-1');
     wait_screen_change {
         send_key "alt-f4";    # close wizard
     };

--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -34,8 +34,7 @@ sub y2snapper_create_snapshot {
 sub run {
     my $self = shift;
     # Start an xterm as root
-    x11_start_program("xterm");
-    assert_screen('xterm');
+    x11_start_program('xterm', target_match => 'xterm');
     become_root;
     script_run "cd";
 

--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -34,7 +34,7 @@ sub y2snapper_create_snapshot {
 sub run {
     my $self = shift;
     # Start an xterm as root
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root;
     script_run "cd";
 

--- a/tests/x11/vlc.pm
+++ b/tests/x11/vlc.pm
@@ -22,8 +22,7 @@ use testapi;
 
 sub run {
     ensure_installed('vlc');
-    x11_start_program("vlc --no-autoscale");
-    assert_screen "vlc-first-time-wizard";
+    x11_start_program('vlc --no-autoscale', target_match => 'vlc-first-time-wizard');
     send_key "ret";
     assert_screen "vlc-main-window";
     send_key "ctrl-l";

--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -58,15 +58,13 @@ sub run {
     x11_start_program "rt";
 
     # Start xev event watcher
-    x11_start_program "xterm";
-    assert_screen('xterm');
+    x11_start_program('xterm', target_match => 'xterm');
     send_key "super-right";
     type_string "DISPLAY=$display xev\n";
 
     # Start vncviewer (rw & ro mode) and check if changes are processed by xev
     foreach my $opt (@options) {
-        x11_start_program("vncviewer $display -SecurityTypes=VncAuth");
-        assert_screen "vnc_password_dialog", 60;
+        x11_start_program("vncviewer $display -SecurityTypes=VncAuth", target_match => 'vnc_password_dialog', match_timeout => 60);
         type_string "$opt->{pw}\n";
         assert_screen 'vncviewer-xev';
         send_key "super-left";
@@ -87,7 +85,7 @@ sub run {
     send_key "ctrl-c";
     assert_script_run "sed -i '\$d' $theme";
     select_console "x11";
-    x11_start_program "rt";
+    x11_start_program('rt', target_match => 'generic-desktop');
 }
 
 1;

--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -55,10 +55,10 @@ sub run {
 
     select_console 'x11';
     # Reload theme to hide panel text
-    x11_start_program "rt";
+    x11_start_program('rt', target_match => 'generic-desktop');
 
     # Start xev event watcher
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     send_key "super-right";
     type_string "DISPLAY=$display xev\n";
 

--- a/tests/x11/wireshark.pm
+++ b/tests/x11/wireshark.pm
@@ -36,7 +36,7 @@ use utils;
 
 sub run {
     select_console 'x11';
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root;
     pkcon_quit;
     zypper_call "in wireshark";

--- a/tests/x11/wireshark.pm
+++ b/tests/x11/wireshark.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -36,7 +36,7 @@ use utils;
 
 sub run {
     select_console 'x11';
-    x11_start_program "xterm";
+    x11_start_program('xterm', target_match => 'xterm');
     become_root;
     pkcon_quit;
     zypper_call "in wireshark";

--- a/tests/x11/x3270_ssl.pm
+++ b/tests/x11/x3270_ssl.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -46,8 +46,7 @@ sub run {
 
     select_console 'x11';
 
-    x11_start_program("xterm");
-    assert_screen("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     mouse_hide(1);
 
     #Launch x3270

--- a/tests/x11/x3270_ssl.pm
+++ b/tests/x11/x3270_ssl.pm
@@ -46,7 +46,7 @@ sub run {
 
     select_console 'x11';
 
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     mouse_hide(1);
 
     #Launch x3270

--- a/tests/x11/xfce4_terminal.pm
+++ b/tests/x11/xfce4_terminal.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     mouse_hide(1);
-    x11_start_program("xfce4-terminal");
+    x11_start_program('xfce4-terminal');
     wait_still_screen 1;
     send_key "ctrl-shift-t";
     $self->enter_test_text('xfce4-terminal', cmd => 1);

--- a/tests/x11/xfce_lightdm_logout_login.pm
+++ b/tests/x11/xfce_lightdm_logout_login.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("xfce4-session-logout");
+    x11_start_program('xfce4-session-logout', target_match => 'logoutdialog');
     send_key "alt-l";
     assert_screen 'test-xfce_lightdm_logout_login-1';
     type_password;

--- a/tests/x11/xfce_notification.pm
+++ b/tests/x11/xfce_notification.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,8 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('notify-send --expire-time=30 Test');
-    assert_screen 'test-xfce_notification-1', 5;
+    x11_start_program('notify-send --expire-time=30 Test', target_match => 'test-xfce_notification-1');
 }
 
 1;

--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -205,7 +205,7 @@ sub test_7 {
 
 sub run {
     select_console 'x11';
-    x11_start_program("xterm -geometry 155x50+5+5");
+    x11_start_program("xterm -geometry 155x50+5+5", target_match => 'xterm');
     become_root;
     # enable debug for detailed messages and easier detection of restart
     assert_script_run 'sed -i \'s/DEBUG="no"/DEBUG="yes"/\' /etc/sysconfig/network/config';

--- a/tests/x11/yast2_snapper.pm
+++ b/tests/x11/yast2_snapper.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -26,8 +26,7 @@ sub run {
     ensure_installed "yast2-snapper";
 
     # Start an xterm as root
-    x11_start_program("xterm");
-    assert_screen "xterm";
+    x11_start_program('xterm', target_match => 'xterm');
     # Disable screen lock and blank screen for current Gnome session
     if (check_var('DESKTOP', 'gnome')) {
         assert_script_run('gsettings set org.gnome.desktop.session idle-delay 0');

--- a/tests/x11/yast2_snapper.pm
+++ b/tests/x11/yast2_snapper.pm
@@ -26,7 +26,7 @@ sub run {
     ensure_installed "yast2-snapper";
 
     # Start an xterm as root
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     # Disable screen lock and blank screen for current Gnome session
     if (check_var('DESKTOP', 'gnome')) {
         assert_script_run('gsettings set org.gnome.desktop.session idle-delay 0');

--- a/tests/x11regressions/empathy/empathy_aim.pm
+++ b/tests/x11regressions/empathy/empathy_aim.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -24,9 +24,7 @@ sub run {
     my $PASSWD    = "opensuse";
 
     #x11_start_program ("xterm -e killall -9 empathy");
-    x11_start_program("empathy");
-
-    assert_screen 'empathy-accounts-discover';
+    x11_start_program('empathy', target_match => 'empathy-accounts-discover');
     send_key "alt-s";    # skip accounts discover
 
     # add one aim account- aim1

--- a/tests/x11regressions/empathy/empathy_irc.pm
+++ b/tests/x11regressions/empathy/empathy_irc.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,9 +18,7 @@ use utils;
 
 
 sub run {
-    x11_start_program("empathy");
-
-    assert_screen 'empathy-accounts-discover';
+    x11_start_program('empathy', target_match => 'empathy-accounts-discover');
     send_key "alt-s";    # skip accounts discover
 
     # choose irc account type

--- a/tests/x11regressions/evince/evince_find.pm
+++ b/tests/x11regressions/evince/evince_find.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,7 @@ use testapi;
 
 
 sub run {
-    x11_start_program("evince " . autoinst_url . "/data/x11regressions/test.pdf");
+    x11_start_program("evince " . autoinst_url . "/data/x11regressions/test.pdf", valid => 0);
 
     send_key "ctrl-f";    # show search toolbar
     assert_screen 'evince-search-toolbar', 5;

--- a/tests/x11regressions/evince/evince_open.pm
+++ b/tests/x11regressions/evince/evince_open.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,7 @@ use testapi;
 
 
 sub run {
-    x11_start_program("evince " . autoinst_url . "/data/x11regressions/test.pdf");
+    x11_start_program("evince " . autoinst_url . "/data/x11regressions/test.pdf", valid => 0);
 
     send_key "alt-f10";    # maximize window
     assert_screen 'evince-open-pdf', 5;

--- a/tests/x11regressions/evince/evince_rotate_zoom.pm
+++ b/tests/x11regressions/evince/evince_rotate_zoom.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,7 @@ use testapi;
 
 
 sub run {
-    x11_start_program("evince " . autoinst_url . "/data/x11regressions/test.pdf");
+    x11_start_program("evince " . autoinst_url . "/data/x11regressions/test.pdf", valid => 0);
 
     send_key "ctrl-left";    # rotate left
     assert_screen 'evince-rotate-left', 5;

--- a/tests/x11regressions/evince/evince_view.pm
+++ b/tests/x11regressions/evince/evince_view.pm
@@ -18,7 +18,7 @@ use testapi;
 
 
 sub run {
-    x11_start_program("evince " . autoinst_url . "/data/x11regressions/test.pdf");
+    x11_start_program("evince " . autoinst_url . "/data/x11regressions/test.pdf", valid => 0);
 
     send_key "f11";    # fullscreen mode
     assert_screen 'evince-fullscreen-mode', 5;

--- a/tests/x11regressions/firefox/firefox_gnomeshell.pm
+++ b/tests/x11regressions/firefox/firefox_gnomeshell.pm
@@ -51,7 +51,7 @@ sub run {
     # Exit
     $self->exit_firefox;
 
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     type_string "ls .local/share/gnome-shell/extensions/\n";
     assert_screen('firefox-gnomeshell-checkdir', 30);
     type_string "rm -rf .local/share/gnome-shell/extensions/*;exit\n";

--- a/tests/x11regressions/firefox/firefox_gnomeshell.pm
+++ b/tests/x11regressions/firefox/firefox_gnomeshell.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -51,7 +51,7 @@ sub run {
     # Exit
     $self->exit_firefox;
 
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     type_string "ls .local/share/gnome-shell/extensions/\n";
     assert_screen('firefox-gnomeshell-checkdir', 30);
     type_string "rm -rf .local/share/gnome-shell/extensions/*;exit\n";

--- a/tests/x11regressions/firefox/firefox_headers.pm
+++ b/tests/x11regressions/firefox/firefox_headers.pm
@@ -20,8 +20,8 @@ sub run {
     mouse_hide(1);
 
     # Clean and Start Firefox
-    x11_start_program("xterm -e \"killall -9 firefox;rm -rf .moz*\"");
-    x11_start_program("firefox");
+    x11_start_program("xterm -e \"killall -9 firefox;rm -rf .moz*\"", valid => 0);
+    x11_start_program('firefox');
     $self->firefox_check_popups;
     assert_screen('firefox-launch', 90);
 

--- a/tests/x11regressions/firefox/firefox_mhtml.pm
+++ b/tests/x11regressions/firefox/firefox_mhtml.pm
@@ -21,7 +21,7 @@ sub run {
 
 
     # Fetch mht file to shm
-    x11_start_program("wget " . autoinst_url . "/data/x11regressions/ie10.mht -O /dev/shm/ie10.mht");
+    x11_start_program("wget " . autoinst_url . "/data/x11regressions/ie10.mht -O /dev/shm/ie10.mht", valid => 0);
 
     send_key "ctrl-w";
     wait_still_screen 3;
@@ -49,7 +49,7 @@ sub run {
     # Exit and Clear
     $self->exit_firefox;
     wait_still_screen 3;
-    x11_start_program("rm /dev/shm/ie10.mht");
+    x11_start_program('rm /dev/shm/ie10.mht', valid => 0);
 }
 1;
 # vim: set sw=4 et:

--- a/tests/x11regressions/firefox/firefox_pagesaving.pm
+++ b/tests/x11regressions/firefox/firefox_pagesaving.pm
@@ -32,7 +32,7 @@ sub run {
     # Exit
     $self->exit_firefox;
 
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     send_key "ctrl-l";
     wait_still_screen 3;
     type_string "ls Downloads/\n";

--- a/tests/x11regressions/firefox/firefox_pagesaving.pm
+++ b/tests/x11regressions/firefox/firefox_pagesaving.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -32,7 +32,7 @@ sub run {
     # Exit
     $self->exit_firefox;
 
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     send_key "ctrl-l";
     wait_still_screen 3;
     type_string "ls Downloads/\n";

--- a/tests/x11regressions/firefox/firefox_passwd.pm
+++ b/tests/x11regressions/firefox/firefox_passwd.pm
@@ -42,7 +42,7 @@ sub run {
 
     #Restart firefox
     send_key "ctrl-q";
-    x11_start_program("firefox");
+    x11_start_program('firefox');
     $self->firefox_check_popups;
     assert_screen('firefox-gnome', 60);
 

--- a/tests/x11regressions/firefox/firefox_private.pm
+++ b/tests/x11regressions/firefox/firefox_private.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -33,7 +33,7 @@ sub run {
     wait_still_screen 3;
     $self->exit_firefox;
 
-    x11_start_program("firefox");
+    x11_start_program('firefox');
     $self->firefox_check_default;
     $self->firefox_check_popups;
     assert_screen('firefox-launch', 90);

--- a/tests/x11regressions/gedit/gedit_about.pm
+++ b/tests/x11regressions/gedit/gedit_about.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,7 +17,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("gedit");
+    x11_start_program('gedit', target_match => 'gedit-options-icon');
 
     # check about window
     assert_and_click 'gedit-options-icon';

--- a/tests/x11regressions/gedit/gedit_launch.pm
+++ b/tests/x11regressions/gedit/gedit_launch.pm
@@ -17,10 +17,10 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('gedit', target_match => 'gedit-launched');
+    x11_start_program('gedit');
     assert_and_click 'gedit-x-button';
 
-    x11_start_program('gedit', target_match => 'gedit-launched');
+    x11_start_program('gedit');
     send_key "ctrl-q";
 }
 

--- a/tests/x11regressions/gedit/gedit_launch.pm
+++ b/tests/x11regressions/gedit/gedit_launch.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,12 +17,10 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("gedit");
-    assert_screen 'gedit-launched', 3;
+    x11_start_program('gedit', target_match => 'gedit-launched');
     assert_and_click 'gedit-x-button';
 
-    x11_start_program("gedit");
-    assert_screen 'gedit-launched', 3;
+    x11_start_program('gedit', target_match => 'gedit-launched');
     send_key "ctrl-q";
 }
 

--- a/tests/x11regressions/gedit/gedit_save.pm
+++ b/tests/x11regressions/gedit/gedit_save.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -21,8 +21,7 @@ sub run {
     x11_start_program("wget " . autoinst_url . "/data/x11regressions/test.txt");
 
     # open test text file locally
-    x11_start_program("gedit " . "test.txt");
-    assert_screen 'gedit-file-opened';
+    x11_start_program('gedit ' . 'test.txt', target_match => 'gedit-file-opened');
 
     # delete one line
     send_key "ctrl-d";
@@ -50,8 +49,7 @@ sub run {
     wait_still_screen 3;
 
     # open saved file to validate
-    x11_start_program("gedit " . "test.txt");
-    assert_screen 'gedit-saved-file';
+    x11_start_program('gedit ' . 'test.txt', target_match => 'gedit-saved-file');
     wait_screen_change { send_key "ctrl-q"; };
 
     # clean up saved file

--- a/tests/x11regressions/gedit/gedit_save.pm
+++ b/tests/x11regressions/gedit/gedit_save.pm
@@ -18,7 +18,7 @@ use testapi;
 
 sub run {
     # download test text file from x11regression data directory
-    x11_start_program("wget " . autoinst_url . "/data/x11regressions/test.txt");
+    x11_start_program("wget " . autoinst_url . "/data/x11regressions/test.txt", valid => 0);
 
     # open test text file locally
     x11_start_program('gedit ' . 'test.txt', target_match => 'gedit-file-opened');
@@ -53,7 +53,7 @@ sub run {
     wait_screen_change { send_key "ctrl-q"; };
 
     # clean up saved file
-    x11_start_program("rm " . "test.txt");
+    x11_start_program("rm " . "test.txt", valid => 0);
 }
 
 1;

--- a/tests/x11regressions/gnomecase/application_starts_on_login.pm
+++ b/tests/x11regressions/gnomecase/application_starts_on_login.pm
@@ -139,7 +139,7 @@ sub run {
     }
     $self->alter_status_auto_save_session;
 
-    x11_start_program("firefox");
+    x11_start_program('firefox');
     wait_still_screen;
     $self->firefox_check_default;
     $self->firefox_check_popups;

--- a/tests/x11regressions/gnomecase/change_password.pm
+++ b/tests/x11regressions/gnomecase/change_password.pm
@@ -128,7 +128,7 @@ sub run {
     assert_screen "generic-desktop", 120;
 
     #restore password to original value
-    x11_start_program('gnome-terminal', target_match => 'gnome-terminal');
+    x11_start_program('gnome-terminal');
     type_string "su\n";
     assert_screen "pwd4root-terminal";
     type_password "$password\n";

--- a/tests/x11regressions/gnomecase/change_password.pm
+++ b/tests/x11regressions/gnomecase/change_password.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -128,8 +128,7 @@ sub run {
     assert_screen "generic-desktop", 120;
 
     #restore password to original value
-    x11_start_program("gnome-terminal");
-    assert_screen 'gnome-terminal';
+    x11_start_program('gnome-terminal', target_match => 'gnome-terminal');
     type_string "su\n";
     assert_screen "pwd4root-terminal";
     type_password "$password\n";

--- a/tests/x11regressions/gnomecase/gnome_classic_switch.pm
+++ b/tests/x11regressions/gnomecase/gnome_classic_switch.pm
@@ -19,12 +19,12 @@ use utils;
 # applications are called twiced
 sub application_test {
     my ($self) = @_;
-    x11_start_program('gnome-terminal', target_match => 'gnome-terminal-launched');
+    x11_start_program('gnome-terminal');
     send_key "alt-f4";
     send_key "ret";
     wait_still_screen;
 
-    x11_start_program "firefox";
+    x11_start_program('firefox');
     $self->firefox_check_default;
     $self->firefox_check_popups;
     assert_screen "firefox-gnome", 150;

--- a/tests/x11regressions/gnomecase/gnome_classic_switch.pm
+++ b/tests/x11regressions/gnomecase/gnome_classic_switch.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,8 +19,7 @@ use utils;
 # applications are called twiced
 sub application_test {
     my ($self) = @_;
-    x11_start_program "gnome-terminal";
-    assert_screen "gnome-terminal-launched";
+    x11_start_program('gnome-terminal', target_match => 'gnome-terminal-launched');
     send_key "alt-f4";
     send_key "ret";
     wait_still_screen;

--- a/tests/x11regressions/gnomecase/gnome_default_applications.pm
+++ b/tests/x11regressions/gnomecase/gnome_default_applications.pm
@@ -1,6 +1,6 @@
 # Gnome tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,7 @@ use utils;
 
 sub run {
     # Prepare test files
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
 
     my @applications = (
         ['image/jpg',           'eog.desktop'],
@@ -39,7 +39,7 @@ sub run {
 }
 
 sub clear_application_environment {
-    x11_start_program("rm -rf /home/$username/gnometest");    # Clean the test directory
+    x11_start_program("rm -rf /home/$username/gnometest", valid => 0);    # Clean the test directory
 }
 
 sub prepare_application_environment {
@@ -52,7 +52,7 @@ sub prepare_application_environment {
     assert_script_run "tar czvf /home/$username/gnometest/test.tar.gz -C /home/$username/gnometest/ test.pdf";
 
     # Open nautilus
-    x11_start_program('nautilus', target_match => 'nautilus-launched');
+    x11_start_program('nautilus');
     send_key "ctrl-l";
     type_string "/home/$username/gnometest\n";
     send_key "ret";

--- a/tests/x11regressions/gnomecase/gnome_default_applications.pm
+++ b/tests/x11regressions/gnomecase/gnome_default_applications.pm
@@ -18,8 +18,7 @@ use utils;
 
 sub run {
     # Prepare test files
-    x11_start_program("xterm");
-    assert_screen 'xterm';
+    x11_start_program('xterm', target_match => 'xterm');
 
     my @applications = (
         ['image/jpg',           'eog.desktop'],
@@ -53,8 +52,7 @@ sub prepare_application_environment {
     assert_script_run "tar czvf /home/$username/gnometest/test.tar.gz -C /home/$username/gnometest/ test.pdf";
 
     # Open nautilus
-    x11_start_program("nautilus");
-    assert_screen 'nautilus-launched', 3;
+    x11_start_program('nautilus', target_match => 'nautilus-launched');
     send_key "ctrl-l";
     type_string "/home/$username/gnometest\n";
     send_key "ret";

--- a/tests/x11regressions/gnomecase/gnome_window_switcher.pm
+++ b/tests/x11regressions/gnomecase/gnome_window_switcher.pm
@@ -16,11 +16,11 @@ use testapi;
 
 sub run {
     # Launch 3 applications
-    x11_start_program('nautilus', target_match => 'nautilus-launched');
+    x11_start_program('nautilus');
     send_key "super-h";    # Minimize the window
-    x11_start_program('gedit', target_match => 'gedit-launched');
+    x11_start_program('gedit');
     send_key "super-h";    # Minimize the window
-    x11_start_program('totem', target_match => 'test-totem-started');
+    x11_start_program('totem');
     send_key "super-h";    # Minimize the window
 
     # Switch windowns with alt+tab

--- a/tests/x11regressions/gnomecase/gnome_window_switcher.pm
+++ b/tests/x11regressions/gnomecase/gnome_window_switcher.pm
@@ -1,6 +1,6 @@
 # Gnome tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,14 +16,11 @@ use testapi;
 
 sub run {
     # Launch 3 applications
-    x11_start_program("nautilus");
-    assert_screen 'nautilus-launched';
+    x11_start_program('nautilus', target_match => 'nautilus-launched');
     send_key "super-h";    # Minimize the window
-    x11_start_program("gedit");
-    assert_screen 'gedit-launched';
+    x11_start_program('gedit', target_match => 'gedit-launched');
     send_key "super-h";    # Minimize the window
-    x11_start_program("totem");
-    assert_screen "test-totem-started";
+    x11_start_program('totem', target_match => 'test-totem-started');
     send_key "super-h";    # Minimize the window
 
     # Switch windowns with alt+tab

--- a/tests/x11regressions/gnomecase/nautilus_cut_file.pm
+++ b/tests/x11regressions/gnomecase/nautilus_cut_file.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,8 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("nautilus");
-    assert_screen 'nautilus-launched';
+    x11_start_program('nautilus', target_match => 'nautilus-launched');
     x11_start_program("touch newfile");
 
     send_key_until_needlematch 'nautilus-newfile-matched', 'right', 15;

--- a/tests/x11regressions/gnomecase/nautilus_cut_file.pm
+++ b/tests/x11regressions/gnomecase/nautilus_cut_file.pm
@@ -16,8 +16,8 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program('nautilus', target_match => 'nautilus-launched');
-    x11_start_program("touch newfile");
+    x11_start_program('nautilus');
+    x11_start_program("touch newfile", valid => 0);
 
     send_key_until_needlematch 'nautilus-newfile-matched', 'right', 15;
     send_key "ctrl-x";
@@ -30,7 +30,7 @@ sub run {
     send_key "ctrl-w";                      #close nautilus
 
     #remove the newfile, rm via cmd to avoid file moving to trash
-    x11_start_program("rm Downloads/newfile");
+    x11_start_program("rm Downloads/newfile", valid => 0);
 }
 
 1;

--- a/tests/x11regressions/gnomecase/nautilus_open_ftp.pm
+++ b/tests/x11regressions/gnomecase/nautilus_open_ftp.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/x11regressions/gnomecase/nautilus_permission.pm
+++ b/tests/x11regressions/gnomecase/nautilus_permission.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,8 +17,8 @@ use testapi;
 
 
 sub run {
-    x11_start_program("touch newfile");
-    x11_start_program("nautilus");
+    x11_start_program('touch newfile', valid => 0);
+    x11_start_program('nautilus');
     send_key_until_needlematch 'nautilus-newfile-matched', 'right', 15;
     send_key "shift-f10";
     assert_screen 'nautilus-rightkey-menu';
@@ -49,7 +49,7 @@ sub run {
 
 
     #clean: remove the created new note
-    x11_start_program("rm newfile");
+    x11_start_program('rm newfile', valid => 0);
     send_key "ctrl-w";
 }
 

--- a/tests/x11regressions/gnote/gnote_first_run.pm
+++ b/tests/x11regressions/gnote/gnote_first_run.pm
@@ -23,7 +23,7 @@ sub run {
         zypper_call('in gnote');
         select_console('x11');
     }
-    x11_start_program('gnote', target_match => 'gnote-first-launched');
+    x11_start_program('gnote');
     send_key "ctrl-w";
 }
 

--- a/tests/x11regressions/gnote/gnote_first_run.pm
+++ b/tests/x11regressions/gnote/gnote_first_run.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -23,9 +23,7 @@ sub run {
         zypper_call('in gnote');
         select_console('x11');
     }
-    x11_start_program("gnote");
-    assert_screen "gnote-first-launched", 10;
-
+    x11_start_program('gnote', target_match => 'gnote-first-launched');
     send_key "ctrl-w";
 }
 

--- a/tests/x11regressions/gnote/gnote_rename_title.pm
+++ b/tests/x11regressions/gnote/gnote_rename_title.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,8 +18,7 @@ use testapi;
 
 
 sub run {
-    x11_start_program("gnote");
-    assert_screen "gnote-first-launched", 10;
+    x11_start_program('gnote', target_match => 'gnote-first-launched');
     send_key "ctrl-n";
     assert_screen 'gnote-new-note', 5;
     send_key "up";

--- a/tests/x11regressions/gnote/gnote_rename_title.pm
+++ b/tests/x11regressions/gnote/gnote_rename_title.pm
@@ -18,7 +18,7 @@ use testapi;
 
 
 sub run {
-    x11_start_program('gnote', target_match => 'gnote-first-launched');
+    x11_start_program('gnote');
     send_key "ctrl-n";
     assert_screen 'gnote-new-note', 5;
     send_key "up";

--- a/tests/x11regressions/gnote/gnote_undo_redo.pm
+++ b/tests/x11regressions/gnote/gnote_undo_redo.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -29,8 +29,7 @@ sub undo_redo_once {
 
 sub run {
     my ($self) = @_;
-    x11_start_program("gnote");
-    assert_screen "gnote-first-launched";
+    x11_start_program('gnote', target_match => 'gnote-first-launched');
     send_key "ctrl-n";
     assert_screen 'gnote-new-note';
     type_string "opensuse\nOPENSUSE\n";

--- a/tests/x11regressions/gnote/gnote_undo_redo.pm
+++ b/tests/x11regressions/gnote/gnote_undo_redo.pm
@@ -29,7 +29,7 @@ sub undo_redo_once {
 
 sub run {
     my ($self) = @_;
-    x11_start_program('gnote', target_match => 'gnote-first-launched');
+    x11_start_program('gnote');
     send_key "ctrl-n";
     assert_screen 'gnote-new-note';
     type_string "opensuse\nOPENSUSE\n";

--- a/tests/x11regressions/groupwise/groupwise.pm
+++ b/tests/x11regressions/groupwise/groupwise.pm
@@ -27,7 +27,7 @@ sub run() {
     save_screenshot;
 
     select_console 'x11';
-    x11_start_program('groupwise', target_match => 'groupwise-groupwise-startup');
+    x11_start_program('groupwise');
     send_key "alt-f4";
 }
 

--- a/tests/x11regressions/groupwise/groupwise.pm
+++ b/tests/x11regressions/groupwise/groupwise.pm
@@ -27,8 +27,7 @@ sub run() {
     save_screenshot;
 
     select_console 'x11';
-    x11_start_program("groupwise");    # start groupwise client
-    assert_screen "groupwise-groupwise-startup";
+    x11_start_program('groupwise', target_match => 'groupwise-groupwise-startup');
     send_key "alt-f4";
 }
 

--- a/tests/x11regressions/libreoffice/libreoffice_default_theme.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_default_theme.pm
@@ -17,7 +17,7 @@ use utils;
 use strict;
 
 sub check_lo_theme {
-    x11_start_program('ooffice', target_match => 'welcome-to-libreoffice');
+    x11_start_program('ooffice');
     if (is_tumbleweed) {
         send_key 'alt-f12';
     }
@@ -40,7 +40,7 @@ sub run {
     $self->check_lo_theme;
 
     # Set LO GUI toolkit var to none
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     assert_script_run 'export OOO_FORCE_DESKTOP="none"';
     type_string "cd\n";
     clear_console;
@@ -52,7 +52,7 @@ sub run {
     $self->check_lo_theme;
 
     # Unset LO GUI toolkit var
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     assert_script_run 'unset OOO_FORCE_DESKTOP';
     send_key 'alt-f4';    # Quit xterm
 }

--- a/tests/x11regressions/libreoffice/libreoffice_default_theme.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_default_theme.pm
@@ -1,6 +1,6 @@
 # LibreOffice tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,8 +17,7 @@ use utils;
 use strict;
 
 sub check_lo_theme {
-    x11_start_program("ooffice");
-    assert_screen 'welcome-to-libreoffice';
+    x11_start_program('ooffice', target_match => 'welcome-to-libreoffice');
     if (is_tumbleweed) {
         send_key 'alt-f12';
     }
@@ -41,7 +40,7 @@ sub run {
     $self->check_lo_theme;
 
     # Set LO GUI toolkit var to none
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     assert_script_run 'export OOO_FORCE_DESKTOP="none"';
     type_string "cd\n";
     clear_console;
@@ -53,7 +52,7 @@ sub run {
     $self->check_lo_theme;
 
     # Unset LO GUI toolkit var
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     assert_script_run 'unset OOO_FORCE_DESKTOP';
     send_key 'alt-f4';    # Quit xterm
 }

--- a/tests/x11regressions/libreoffice/libreoffice_double_click_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_double_click_file.pm
@@ -21,7 +21,7 @@ sub run {
     $self->upload_libreoffice_specified_file();
 
     # open gnome file manager- nautilus for testing
-    x11_start_program('nautilus', target_match => 'nautilus-launched');
+    x11_start_program('nautilus');
     send_key_until_needlematch("nautilus-Documents-matched", "right");
     send_key "ret";
     wait_still_screen(3);

--- a/tests/x11regressions/libreoffice/libreoffice_double_click_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_double_click_file.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -21,8 +21,7 @@ sub run {
     $self->upload_libreoffice_specified_file();
 
     # open gnome file manager- nautilus for testing
-    x11_start_program("nautilus");
-    assert_screen("nautilus-launched");
+    x11_start_program('nautilus', target_match => 'nautilus-launched');
     send_key_until_needlematch("nautilus-Documents-matched", "right");
     send_key "ret";
     wait_still_screen(3);

--- a/tests/x11regressions/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_mainmenu_components.pm
@@ -1,6 +1,6 @@
 # LibreOffice tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -45,7 +45,7 @@ sub select_base_and_cleanup {
     send_key "ctrl-q";    #close base
 
     # clean the test database file
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     assert_script_run "find /home/$username -name testdatabase.odb | xargs rm";
     send_key 'alt-f4';
 }

--- a/tests/x11regressions/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_mainmenu_components.pm
@@ -45,7 +45,7 @@ sub select_base_and_cleanup {
     send_key "ctrl-q";    #close base
 
     # clean the test database file
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     assert_script_run "find /home/$username -name testdatabase.odb | xargs rm";
     send_key 'alt-f4';
 }

--- a/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
@@ -23,7 +23,7 @@ sub run {
     $self->upload_libreoffice_specified_file();
 
     # check libreoffice dialogs setting
-    x11_start_program('libreoffice', target_match => 'welcome-to-libreoffice');
+    x11_start_program('libreoffice');
     $self->check_libreoffice_dialogs();
 
     # open test files of different formats

--- a/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_open_specified_file.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -23,8 +23,7 @@ sub run {
     $self->upload_libreoffice_specified_file();
 
     # check libreoffice dialogs setting
-    x11_start_program("libreoffice");
-    assert_screen("welcome-to-libreoffice");
+    x11_start_program('libreoffice', target_match => 'welcome-to-libreoffice');
     $self->check_libreoffice_dialogs();
 
     # open test files of different formats

--- a/tests/x11regressions/libreoffice/libreoffice_recent_documents.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_recent_documents.pm
@@ -1,6 +1,6 @@
 # LibreOffice tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,8 +18,7 @@ use utils;
 
 sub run {
     # Edit file hello.odt using oowriter
-    x11_start_program("oowriter");
-    assert_screen 'test-ooffice-1';
+    x11_start_program('oowriter', target_match => 'test-ooffice-1');
     # clicking the writing area to make sure the cursor addressed there
     assert_and_click 'ooffice-writing-area', 'left', 10;
     wait_still_screen;
@@ -34,8 +33,7 @@ sub run {
 
     # Check Recent Documents
     wait_still_screen;
-    x11_start_program("oowriter");
-    assert_screen 'test-ooffice-1';
+    x11_start_program('oowriter', target_match => 'test-ooffice-1');
     send_key "alt-f";
     assert_screen 'oowriter-menus-file';
     if (is_tumbleweed) {

--- a/tests/x11regressions/libreoffice/libreoffice_recent_documents.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_recent_documents.pm
@@ -18,7 +18,7 @@ use utils;
 
 sub run {
     # Edit file hello.odt using oowriter
-    x11_start_program('oowriter', target_match => 'test-ooffice-1');
+    x11_start_program('oowriter');
     # clicking the writing area to make sure the cursor addressed there
     assert_and_click 'ooffice-writing-area', 'left', 10;
     wait_still_screen;
@@ -33,7 +33,7 @@ sub run {
 
     # Check Recent Documents
     wait_still_screen;
-    x11_start_program('oowriter', target_match => 'test-ooffice-1');
+    x11_start_program('oowriter');
     send_key "alt-f";
     assert_screen 'oowriter-menus-file';
     if (is_tumbleweed) {
@@ -56,7 +56,7 @@ sub run {
     assert_screen 'generic-desktop';
 
     # Clean test file
-    x11_start_program("rm /home/$username/Documents/hello.odt");
+    x11_start_program("rm /home/$username/Documents/hello.odt", valid => 0);
 }
 
 1;

--- a/tests/x11regressions/pidgin/clean_pidgin.pm
+++ b/tests/x11regressions/pidgin/clean_pidgin.pm
@@ -18,7 +18,7 @@ use utils 'clear_console';
 
 sub remove_pkg {
     my @packages = qw(pidgin);
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
 
     # Remove packages
     assert_script_sudo "rpm -e @packages";

--- a/tests/x11regressions/pidgin/clean_pidgin.pm
+++ b/tests/x11regressions/pidgin/clean_pidgin.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,7 @@ use utils 'clear_console';
 
 sub remove_pkg {
     my @packages = qw(pidgin);
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
 
     # Remove packages
     assert_script_sudo "rpm -e @packages";

--- a/tests/x11regressions/pidgin/pidgin_IRC.pm
+++ b/tests/x11regressions/pidgin/pidgin_IRC.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,7 +20,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     my $CHANNELNAME = "susetesting";
-    x11_start_program("pidgin");
+    x11_start_program('pidgin');
 
     # Create account
     wait_screen_change { send_key "alt-a" };

--- a/tests/x11regressions/pidgin/pidgin_aim.pm
+++ b/tests/x11regressions/pidgin/pidgin_aim.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -23,7 +23,7 @@ sub run {
     my $DOMAIN    = "aim";
     my $PASSWD    = "opensuse";
 
-    x11_start_program("pidgin");
+    x11_start_program('pidgin');
 
     # Create account
     wait_screen_change { send_key 'alt-a' };

--- a/tests/x11regressions/pidgin/prep_pidgin.pm
+++ b/tests/x11regressions/pidgin/prep_pidgin.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,8 +22,7 @@ sub pidgin_preparation {
     ensure_installed('pidgin');
 
     # Enable the showoffline
-    x11_start_program("pidgin");
-    assert_screen "pidgin-welcome";
+    x11_start_program('pidgin', target_match => 'pidgin-welcome');
     send_key "alt-c";
 
     # pidgin main winodow is hidden in tray at first run

--- a/tests/x11regressions/pidgin/prep_pidgin.pm
+++ b/tests/x11regressions/pidgin/prep_pidgin.pm
@@ -22,7 +22,7 @@ sub pidgin_preparation {
     ensure_installed('pidgin');
 
     # Enable the showoffline
-    x11_start_program('pidgin', target_match => 'pidgin-welcome');
+    x11_start_program('pidgin');
     send_key "alt-c";
 
     # pidgin main winodow is hidden in tray at first run

--- a/tests/x11regressions/piglit/piglit.pm
+++ b/tests/x11regressions/piglit/piglit.pm
@@ -33,7 +33,7 @@ sub run {
     zypper_call("in piglit", exitcode => [0, 102, 103]);
 
     select_console('x11');
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
 
     # prepare results dir
     script_run("mkdir -p /tmp/p_results");

--- a/tests/x11regressions/piglit/piglit.pm
+++ b/tests/x11regressions/piglit/piglit.pm
@@ -33,7 +33,7 @@ sub run {
     zypper_call("in piglit", exitcode => [0, 102, 103]);
 
     select_console('x11');
-    x11_start_program('xterm');
+    x11_start_program('xterm', target_match => 'xterm');
 
     # prepare results dir
     script_run("mkdir -p /tmp/p_results");

--- a/tests/x11regressions/remote_desktop/onetime_vncsession_multilogin_failed.pm
+++ b/tests/x11regressions/remote_desktop/onetime_vncsession_multilogin_failed.pm
@@ -24,8 +24,7 @@ use lockapi;
 use utils;
 
 sub start_vncviewer {
-    x11_start_program 'vncviewer 10.0.2.1:1 -Fullscreen';
-    assert_screen [qw(displaymanager vnc_certificate_warning)];
+    x11_start_program('vncviewer 10.0.2.1:1 -Fullscreen', target_match => [qw(displaymanager vnc_certificate_warning)]);
     if (match_has_tag 'vnc_certificate_warning') {
         send_key 'ret';
         assert_screen [qw(displaymanager vnc_certificate_warning-2)];
@@ -44,8 +43,7 @@ sub run {
     mutex_lock 'xvnc';
 
     # Make sure the client gets the IP address
-    x11_start_program 'xterm';
-    assert_screen 'xterm';
+    x11_start_program('xterm', target_match => 'xterm');
     become_root;
     assert_script_run 'dhclient';
     type_string "exit\n";

--- a/tests/x11regressions/remote_desktop/onetime_vncsession_multilogin_failed.pm
+++ b/tests/x11regressions/remote_desktop/onetime_vncsession_multilogin_failed.pm
@@ -43,7 +43,7 @@ sub run {
     mutex_lock 'xvnc';
 
     # Make sure the client gets the IP address
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root;
     assert_script_run 'dhclient';
     type_string "exit\n";

--- a/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_java.pm
+++ b/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_java.pm
@@ -32,8 +32,7 @@ sub run {
     mutex_lock 'xvnc';
 
     # Make sure the client gets the IP address
-    x11_start_program 'xterm';
-    assert_screen 'xterm';
+    x11_start_program('xterm', target_match => 'xterm');
     become_root;
     assert_script_run 'dhclient';
     type_string "exit\n";

--- a/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_java.pm
+++ b/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_java.pm
@@ -32,7 +32,7 @@ sub run {
     mutex_lock 'xvnc';
 
     # Make sure the client gets the IP address
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root;
     assert_script_run 'dhclient';
     type_string "exit\n";

--- a/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_tigervnc.pm
+++ b/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_tigervnc.pm
@@ -30,16 +30,14 @@ sub run {
     mutex_lock 'xvnc';
 
     # Make sure the client gets the IP address
-    x11_start_program 'xterm';
-    assert_screen 'xterm';
+    x11_start_program('xterm', target_match => 'xterm');
     become_root;
     assert_script_run 'dhclient';
     type_string "exit\n";
     send_key 'alt-f4';
 
     # Start vncviewer and login with fullscreen
-    x11_start_program 'vncviewer';
-    assert_screen 'vnc_password_dialog';
+    x11_start_program('vncviewer', target_match => 'vnc_password_dialog');
     type_string '10.0.2.1:1';
     assert_and_click 'vncviewer-options';
     assert_and_click 'vncviewer-options-screen';
@@ -55,13 +53,11 @@ sub run {
     assert_screen 'generic-desktop';
 
     # Launch gnome-terminal and nautilus remotely
-    x11_start_program 'gnome-terminal';
-    assert_screen 'gnome-terminal-launched';
+    x11_start_program('gnome-terminal', target_match => 'gnome-terminal-launched');
     send_key 'alt-f4';
     send_key 'ret';
     wait_still_screen 3;
-    x11_start_program 'nautilus';
-    assert_screen 'nautilus-launched';
+    x11_start_program('nautilus', target_match => 'nautilus-launched');
     send_key 'alt-f4';
 
     # Exit vncviewer

--- a/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_tigervnc.pm
+++ b/tests/x11regressions/remote_desktop/onetime_vncsession_xvnc_tigervnc.pm
@@ -30,7 +30,7 @@ sub run {
     mutex_lock 'xvnc';
 
     # Make sure the client gets the IP address
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root;
     assert_script_run 'dhclient';
     type_string "exit\n";
@@ -53,11 +53,11 @@ sub run {
     assert_screen 'generic-desktop';
 
     # Launch gnome-terminal and nautilus remotely
-    x11_start_program('gnome-terminal', target_match => 'gnome-terminal-launched');
+    x11_start_program('gnome-terminal');
     send_key 'alt-f4';
     send_key 'ret';
     wait_still_screen 3;
-    x11_start_program('nautilus', target_match => 'nautilus-launched');
+    x11_start_program('nautilus');
     send_key 'alt-f4';
 
     # Exit vncviewer

--- a/tests/x11regressions/remote_desktop/persistent_vncsession_xvnc.pm
+++ b/tests/x11regressions/remote_desktop/persistent_vncsession_xvnc.pm
@@ -24,8 +24,7 @@ use lockapi;
 use utils;
 
 sub start_vncviewer {
-    x11_start_program 'vncviewer 10.0.2.1:1 -Fullscreen';
-    assert_screen [qw(displaymanager vncmanager-greeter vnc_certificate_warning)];
+    x11_start_program('vncviewer 10.0.2.1:1 -Fullscreen', target_match => [qw(displaymanager vncmanager-greeter vnc_certificate_warning)]);
     if (match_has_tag 'vnc_certificate_warning') {
         send_key 'ret';
         assert_screen [qw(displaymanager vncmanager-greeter vnc_certificate_warning-2)];
@@ -58,8 +57,7 @@ sub run {
     mutex_lock 'xvnc';
 
     # Make sure the client gets the IP address
-    x11_start_program 'xterm';
-    assert_screen 'xterm';
+    x11_start_program('xterm', target_match => 'xterm');
     become_root;
     assert_script_run 'dhclient';
     type_string "exit\n";
@@ -69,8 +67,7 @@ sub run {
     $self->start_vncviewer;
     handle_login;
     assert_screen 'generic-desktop';
-    x11_start_program 'gnome-terminal';
-    assert_screen 'gnome-terminal-launched';
+    x11_start_program('gnome-terminal', target_match => 'gnome-terminal-launched');
     type_string "vncmanager-controller\n";
     assert_screen 'vncmanager-controller';
     assert_and_click 'vncmanager-controller-visibility';

--- a/tests/x11regressions/remote_desktop/persistent_vncsession_xvnc.pm
+++ b/tests/x11regressions/remote_desktop/persistent_vncsession_xvnc.pm
@@ -57,7 +57,7 @@ sub run {
     mutex_lock 'xvnc';
 
     # Make sure the client gets the IP address
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root;
     assert_script_run 'dhclient';
     type_string "exit\n";
@@ -67,7 +67,7 @@ sub run {
     $self->start_vncviewer;
     handle_login;
     assert_screen 'generic-desktop';
-    x11_start_program('gnome-terminal', target_match => 'gnome-terminal-launched');
+    x11_start_program('gnome-terminal');
     type_string "vncmanager-controller\n";
     assert_screen 'vncmanager-controller';
     assert_and_click 'vncmanager-controller-visibility';

--- a/tests/x11regressions/remote_desktop/vino_client.pm
+++ b/tests/x11regressions/remote_desktop/vino_client.pm
@@ -35,8 +35,7 @@ sub run {
     mutex_lock 'vino_server_ready';
 
     # Login to the sharing session using vinagre via vino server
-    x11_start_program 'vinagre';
-    assert_screen 'vinagre-launched';
+    x11_start_program('vinagre', target_match => 'vinagre-launched');
     assert_and_click 'vinagre-enable-shortcut1';
     assert_and_click 'vinagre-enable-shortcut2';
     send_key 'alt-f10';

--- a/tests/x11regressions/remote_desktop/vino_server.pm
+++ b/tests/x11regressions/remote_desktop/vino_server.pm
@@ -32,16 +32,14 @@ sub run {
     $self->configure_static_ip_nm('10.0.2.15/15');
 
     # Add the firewall port for VNC
-    x11_start_program 'xterm';
-    assert_screen 'xterm';
+    x11_start_program('xterm', target_match => 'xterm');
     become_root;
     assert_script_run 'yast2 firewall services add zone=EXT service=service:vnc-server';
     type_string "exit\n";
     wait_screen_change { send_key 'alt-f4' };
 
     # Activate vino server
-    x11_start_program 'gnome-control-center sharing';
-    assert_screen 'gcc-sharing';
+    x11_start_program('gnome-control-center sharing', target_match => 'gcc-sharing');
     assert_and_click 'gcc-sharing-on';
     send_key 'alt-s';
     assert_screen 'gcc-screen-sharing';

--- a/tests/x11regressions/remote_desktop/vino_server.pm
+++ b/tests/x11regressions/remote_desktop/vino_server.pm
@@ -32,7 +32,7 @@ sub run {
     $self->configure_static_ip_nm('10.0.2.15/15');
 
     # Add the firewall port for VNC
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root;
     assert_script_run 'yast2 firewall services add zone=EXT service=service:vnc-server';
     type_string "exit\n";

--- a/tests/x11regressions/remote_desktop/x11_forwarding_openssh.pm
+++ b/tests/x11regressions/remote_desktop/x11_forwarding_openssh.pm
@@ -34,8 +34,7 @@ sub run {
     mutex_unlock 'ssh';
 
     # Make sure the client gets the IP address
-    x11_start_program 'xterm';
-    assert_screen 'xterm';
+    x11_start_program('xterm', target_match => 'xterm');
     become_root;
     assert_script_run 'dhclient';
     type_string "exit\n";

--- a/tests/x11regressions/remote_desktop/x11_forwarding_openssh.pm
+++ b/tests/x11regressions/remote_desktop/x11_forwarding_openssh.pm
@@ -34,7 +34,7 @@ sub run {
     mutex_unlock 'ssh';
 
     # Make sure the client gets the IP address
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root;
     assert_script_run 'dhclient';
     type_string "exit\n";

--- a/tests/x11regressions/remote_desktop/xdmcp_gdm.pm
+++ b/tests/x11regressions/remote_desktop/xdmcp_gdm.pm
@@ -31,7 +31,7 @@ sub run {
     mutex_lock 'xdmcp';
 
     # Make sure the client gets the IP address and configure the firewall
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root;
     assert_script_run 'dhclient';
     assert_script_run 'yast2 firewall services add zone=EXT service=service:xdmcp';

--- a/tests/x11regressions/remote_desktop/xdmcp_gdm.pm
+++ b/tests/x11regressions/remote_desktop/xdmcp_gdm.pm
@@ -31,8 +31,7 @@ sub run {
     mutex_lock 'xdmcp';
 
     # Make sure the client gets the IP address and configure the firewall
-    x11_start_program 'xterm';
-    assert_screen 'xterm';
+    x11_start_program('xterm', target_match => 'xterm');
     become_root;
     assert_script_run 'dhclient';
     assert_script_run 'yast2 firewall services add zone=EXT service=service:xdmcp';

--- a/tests/x11regressions/remote_desktop/xdmcp_xdm.pm
+++ b/tests/x11regressions/remote_desktop/xdmcp_xdm.pm
@@ -29,7 +29,7 @@ sub run {
     mutex_lock 'xdmcp';
 
     # Make sure the client gets the IP address and configure the firewall
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     become_root;
     assert_script_run 'dhclient';
     assert_script_run 'yast2 firewall services add zone=EXT service=service:xdmcp';

--- a/tests/x11regressions/remote_desktop/xdmcp_xdm.pm
+++ b/tests/x11regressions/remote_desktop/xdmcp_xdm.pm
@@ -29,8 +29,7 @@ sub run {
     mutex_lock 'xdmcp';
 
     # Make sure the client gets the IP address and configure the firewall
-    x11_start_program 'xterm';
-    assert_screen 'xterm';
+    x11_start_program('xterm', target_match => 'xterm');
     become_root;
     assert_script_run 'dhclient';
     assert_script_run 'yast2 firewall services add zone=EXT service=service:xdmcp';

--- a/tests/x11regressions/shotwell/shotwell_export.pm
+++ b/tests/x11regressions/shotwell/shotwell_export.pm
@@ -1,6 +1,6 @@
 # Shotwell tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -40,7 +40,7 @@ sub run {
     wait_still_screen;
 
     # Check the exported file
-    x11_start_program("nautilus");
+    x11_start_program('nautilus');
     wait_screen_change { send_key 'ctrl-l' };
     type_string "/home/$username/Desktop\n";
     send_key "ret";

--- a/tests/x11regressions/tomboy/tomboy_AlreadyRunning.pm
+++ b/tests/x11regressions/tomboy/tomboy_AlreadyRunning.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,13 +19,11 @@ use testapi;
 
 sub run {
     # open tomboy
-    x11_start_program("tomboy note");
-    assert_screen 'test-tomboy_AlreadyRunning-1';
+    x11_start_program('tomboy note', target_match => 'test-tomboy_AlreadyRunning-1');
     send_key "alt-f4";
 
     # open again
-    x11_start_program("tomboy note");
-    assert_screen 'test-tomboy_AlreadyRunning-2';
+    x11_start_program('tomboy note', target_match => 'test-tomboy_AlreadyRunning-2');
     send_key "alt-f4";
 }
 

--- a/tests/x11regressions/tomboy/tomboy_Hotkeys.pm
+++ b/tests/x11regressions/tomboy/tomboy_Hotkeys.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,7 +20,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     # open Hotkeys sheet
-    x11_start_program("tomboy note");
+    x11_start_program('tomboy note', valid => 0);
     wait_screen_change { send_key 'alt-e' };
     send_key "p";
     send_key "right";

--- a/tests/x11regressions/tomboy/tomboy_Open.pm
+++ b/tests/x11regressions/tomboy/tomboy_Open.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,7 +20,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     # open start note and take screenshot
-    x11_start_program("tomboy note");
+    x11_start_program('tomboy note', valid => 0);
     send_key "alt-f11";
     send_key "ctrl-home";
     type_string "Rename_";

--- a/tests/x11regressions/tomboy/tomboy_Print.pm
+++ b/tests/x11regressions/tomboy/tomboy_Print.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,7 +19,7 @@ use testapi;
 
 sub run {
     # open tomboy
-    x11_start_program("tomboy note");
+    x11_start_program('tomboy note', valid => 0);
 
     # open a note and print to file
     send_key "tab";

--- a/tests/x11regressions/tomboy/tomboy_StartNoteCannotBeDeleted.pm
+++ b/tests/x11regressions/tomboy/tomboy_StartNoteCannotBeDeleted.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,7 +17,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("tomboy note");
+    x11_start_program('tomboy note', valid => 0);
 
     # select "start note", to see that start note cann't be deleted
     send_key "tab";

--- a/tests/x11regressions/tomboy/tomboy_TestFindFunctionalityInSearchAllNotes.pm
+++ b/tests/x11regressions/tomboy/tomboy_TestFindFunctionalityInSearchAllNotes.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,7 +19,7 @@ use testapi;
 
 sub run {
     # open tomboy
-    x11_start_program("tomboy note");
+    x11_start_program('tomboy note', valid => 0);
 
     # create a note
     wait_screen_change { send_key "ctrl-n" };

--- a/tests/x11regressions/tomboy/tomboy_TestUndoRedoFeature.pm
+++ b/tests/x11regressions/tomboy/tomboy_TestUndoRedoFeature.pm
@@ -19,7 +19,7 @@ use testapi;
 
 sub run {
     # open tomboy
-    x11_start_program('tomboy note');
+    x11_start_program('tomboy note', valid => 0);
 
     # create a note type something and undo it
     wait_screen_change { send_key 'ctrl-n' };
@@ -68,7 +68,7 @@ sub run {
     wait_screen_change { send_key 'alt-f4' };
 
     # Kill tomboy note
-    x11_start_program('killall tomboy');
+    x11_start_program('killall tomboy', valid => 0);
 }
 
 1;

--- a/tests/x11regressions/tomboy/tomboy_firstrun.pm
+++ b/tests/x11regressions/tomboy/tomboy_firstrun.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,7 +19,7 @@ use testapi;
 
 sub run {
     mouse_hide();
-    x11_start_program("tomboy note");
+    x11_start_program('tomboy note', valid => 0);
     while (check_screen "tomboy_command_not_found", 5) {
         wait_still_screen;
         send_key "ret";

--- a/tests/x11regressions/tracker/clean_tracker.pm
+++ b/tests/x11regressions/tracker/clean_tracker.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,7 +20,7 @@ my @filenames = qw(newfile newpl.pl);
 sub run {
     # Delete a file.
     foreach (@filenames) {
-        x11_start_program("rm -rf $_");
+        x11_start_program("rm -rf $_", target_match => 'generic-desktop');
     }
 }
 

--- a/tests/x11regressions/tracker/prep_tracker.pm
+++ b/tests/x11regressions/tracker/prep_tracker.pm
@@ -23,7 +23,7 @@ my @filenames = qw(newfile newpl.pl);
 sub run {
     # Create a file.
     foreach (@filenames) {
-        x11_start_program("touch $_");
+        x11_start_program('touch $_', target_match => 'generic-desktop');
     }
 }
 

--- a/tests/x11regressions/tracker/tracker_by_command.pm
+++ b/tests/x11regressions/tracker/tracker_by_command.pm
@@ -19,7 +19,7 @@ use utils;
 
 
 sub run {
-    x11_start_program('xterm', target_match => 'xterm');
+    x11_start_program('xterm');
     if (sle_version_at_least('12-SP2')) {
         script_run "tracker search newfile";
     }

--- a/tests/x11regressions/tracker/tracker_by_command.pm
+++ b/tests/x11regressions/tracker/tracker_by_command.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,7 +19,7 @@ use utils;
 
 
 sub run {
-    x11_start_program("xterm");
+    x11_start_program('xterm', target_match => 'xterm');
     if (sle_version_at_least('12-SP2')) {
         script_run "tracker search newfile";
     }

--- a/tests/x11regressions/tracker/tracker_info.pm
+++ b/tests/x11regressions/tracker/tracker_info.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,7 +19,7 @@ use utils;
 
 
 sub run {
-    x11_start_program("xterm");
+    x11_start_program("xterm", target_match => 'xterm');
     if (sle_version_at_least('12-SP2')) {
         script_run "tracker info newpl.pl";
     }

--- a/tests/x11regressions/tracker/tracker_info.pm
+++ b/tests/x11regressions/tracker/tracker_info.pm
@@ -19,7 +19,7 @@ use utils;
 
 
 sub run {
-    x11_start_program("xterm", target_match => 'xterm');
+    x11_start_program('xterm');
     if (sle_version_at_least('12-SP2')) {
         script_run "tracker info newpl.pl";
     }

--- a/tests/x11regressions/tracker/tracker_open_apps.pm
+++ b/tests/x11regressions/tracker/tracker_open_apps.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,8 +18,7 @@ use testapi;
 
 
 sub run {
-    x11_start_program("tracker-needle");
-    assert_screen 'tracker-needle-launched';
+    x11_start_program("tracker-needle", target_match => 'tracker-needle-launched');
     type_string "cheese";
     assert_screen 'tracker-search-cheese';
     wait_screen_change { send_key 'tab' };

--- a/tests/x11regressions/tracker/tracker_open_apps.pm
+++ b/tests/x11regressions/tracker/tracker_open_apps.pm
@@ -18,7 +18,7 @@ use testapi;
 
 
 sub run {
-    x11_start_program("tracker-needle", target_match => 'tracker-needle-launched');
+    x11_start_program('tracker-needle');
     type_string "cheese";
     assert_screen 'tracker-search-cheese';
     wait_screen_change { send_key 'tab' };

--- a/tests/x11regressions/tracker/tracker_pref_starts.pm
+++ b/tests/x11regressions/tracker/tracker_pref_starts.pm
@@ -18,7 +18,7 @@ use testapi;
 
 
 sub run {
-    x11_start_program("tracker-preferences", target_match => 'tracker_pref_launched');
+    x11_start_program('tracker-preferences');
     send_key "alt-f4";
 }
 

--- a/tests/x11regressions/tracker/tracker_pref_starts.pm
+++ b/tests/x11regressions/tracker/tracker_pref_starts.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,8 +18,7 @@ use testapi;
 
 
 sub run {
-    x11_start_program("tracker-preferences");
-    assert_screen 'tracker_pref_launched';
+    x11_start_program("tracker-preferences", target_match => 'tracker_pref_launched');
     send_key "alt-f4";
 }
 

--- a/tests/x11regressions/tracker/tracker_search_in_nautilus.pm
+++ b/tests/x11regressions/tracker/tracker_search_in_nautilus.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("nautilus");
+    x11_start_program('nautilus');
     wait_screen_change { send_key 'ctrl-f' };
     type_string 'newfile';
     wait_still_screen 2;

--- a/tests/x11regressions/tracker/tracker_searchall.pm
+++ b/tests/x11regressions/tracker/tracker_searchall.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/x11regressions/tracker/tracker_searchall.pm
+++ b/tests/x11regressions/tracker/tracker_searchall.pm
@@ -17,8 +17,7 @@ use testapi;
 use utils;
 
 sub run {
-    x11_start_program("tracker-needle");
-    assert_screen 'tracker-needle-launched';
+    x11_start_program("tracker-needle", target_match => 'tracker-needle-launched');
     if (!sle_version_at_least('12-SP2')) {
         wait_screen_change { send_key 'tab' };
         wait_screen_change { send_key 'tab' };

--- a/tests/x11regressions/tracker/tracker_starts.pm
+++ b/tests/x11regressions/tracker/tracker_starts.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/x11regressions/tracker/tracker_starts.pm
+++ b/tests/x11regressions/tracker/tracker_starts.pm
@@ -16,8 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    x11_start_program("tracker-needle");
-    assert_screen 'tracker-needle-launched';
+    x11_start_program("tracker-needle", target_match => 'tracker-needle-launched');
     send_key "alt-f4";
 }
 

--- a/tests/x11regressions/x11regressions_setup.pm
+++ b/tests/x11regressions/x11regressions_setup.pm
@@ -1,6 +1,6 @@
 # X11 regression tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,7 @@ sub run {
     #Switch to x11 console, if not selected, before trying to start xterm
     select_console('x11');
 
-    x11_start_program("xterm");
+    x11_start_program('xterm');
 
     # grant user permission to access serial port until next reboot
     script_sudo "chown $username /dev/$serialdev";

--- a/tests/yast2_gui/yast2_datetime.pm
+++ b/tests/yast2_gui/yast2_datetime.pm
@@ -20,7 +20,7 @@ use testapi;
 
 sub run {
     my $self = shift;
-    $self->launch_yast2_module_x11('timezone', target_match => [qw(yast2-datetime-ui yast2-datetime_ntp-conf)]);
+    $self->launch_yast2_module_x11('timezone', target_match => [qw(yast2-datetime-ui yast2-datetime_ntp-conf)], match_timeout => 90);
     if (match_has_tag 'yast2-datetime_ntp-conf') {
         send_key 'alt-d';
         send_key 'alt-o';

--- a/tests/yast2_gui/yast2_hostnames.pm
+++ b/tests/yast2_gui/yast2_hostnames.pm
@@ -28,7 +28,7 @@ sub run {
     #	add 1 entry to /etc/hosts and edit it later
     script_run "echo '80.92.65.530    n-tv.de ntv' >> /etc/hosts";
     select_console 'x11', await_console => 0;
-    $self->launch_yast2_module_x11('host');
+    $self->launch_yast2_module_x11('host', match_timeout => 90);
     assert_and_click "yast2_hostnames_added";
     wait_still_screen 1;
     wait_screen_change { send_key 'alt-i'; };


### PR DESCRIPTION
As checking for a screen with "assert_screen" after "x11_start_program" is the
standard action and it allows to save time because there is a target to look
for this is now the default action saving quite some time for all X11 tests.

Exceptions can still be applied, for example by specifying "valid => 0" on the
call of "x11_start_program".

Validation runs:
* SLE 12 SP1 qam-gnome: http://lord.arch/tests/7609
* SLE 15 gnome: http://lord.arch/tests/7628
* openSUSE TW yast2_gui: Verification run: http://lord.arch/tests/7644

Related needle changes:
* SLE: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/517
* openSUSE: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/272