### PR TITLE
Virtualization: compose correct guest pattern when replacing guest repo with daily build

### DIFF
--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -26,9 +26,17 @@ use virt_autotest_base;
 
 our @EXPORT = qw(repl_repo_in_sourcefile);
 
+sub get_version_for_daily_build_guest {
+    my $version = lc(get_var("VERSION"));
+    if ($version !~ /sp/m) {
+        $version = $version . "-fcs";
+    }
+    return $version;
+}
+
 sub repl_repo_in_sourcefile {
     # Replace the daily build repo as guest installation resource in source file (like source.cn; source.de ..)
-    my $veritem = "source.http.sles-" . lc(get_var("VERSION")) . "-64";
+    my $veritem = "source.http.sles-" . get_version_for_daily_build_guest . "-64";
     if (get_var("REPO_0")) {
         my $location = &virt_autotest_base::execute_script_run("", "perl /usr/share/qa/tools/location_detect_impl.pl", 60);
         $location =~ s/[\r\n]+$//;
@@ -37,7 +45,7 @@ sub repl_repo_in_sourcefile {
         my $shell_cmd
           = "if grep $veritem $soucefile >> /dev/null;then sed -i \"s#$veritem=.*#$veritem=$newrepo#\" $soucefile;else echo \"$veritem=$newrepo\" >> $soucefile;fi";
         assert_script_run($shell_cmd);
-        assert_script_run("cat $soucefile");
+        assert_script_run("grep \"$veritem\" $soucefile");
     }
     else {
         print "Do not need to change resource for $veritem item\n";


### PR DESCRIPTION
Openqa version has two kinds, for big release like sle15, it is 15, while for spacks, it looks like 12-SP3. However for guest pattern used in virtualization automation, it should be like sles-15-fcs and sles-15-sp1. So this code converts VERSION to correct guest pattern.

Verification link:
http://10.67.18.202/tests/351#step/update_package/7