### PR TITLE
Increase timeout for multi users when restart gnome

### DIFF
--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -52,7 +52,7 @@ sub run {
     restart_x11;
 
     # login created user
-    assert_screen 'multi_users_dm';
+    assert_screen 'multi_users_dm', 180;    # gnome loading takes long sometimes
     wait_still_screen;
     if (check_var('DESKTOP', 'gnome')) {
         send_key_until_needlematch('user#01_selected', 'up', 5, 3);    # select created user #01


### PR DESCRIPTION
In production, gnome sometimes doesn't start using default timeout.
Seems that issue is reproducible only on workers with high load. Changes
to functional part of the logic were already applied.

See [poo#25446](https://progress.opensuse.org/issues/25446).

As we were not able to reproduce issue locally, we used TIMEOUT_SCALE variable to see if this can resolve it: https://openqa.opensuse.org/tests/501491# (here needle is missing due to recently introduced changes to x11_program_start.