### PR TITLE
Add make to qa_test_klp

### DIFF
--- a/tests/kernel/qa_test_klp.pm
+++ b/tests/kernel/qa_test_klp.pm
@@ -30,7 +30,7 @@ sub run {
         assert_script_run("SUSEConnect -p sle-sdk/" . $version . "/" . $arch);
     }
 
-    zypper_call('in -l git gcc kernel-devel');
+    zypper_call('in -l git gcc kernel-devel make');
 
     assert_script_run('git clone ' . $git_repo);
 


### PR DESCRIPTION
`make` isn't pulled on SLE12 SP0/1 by default.