### PR TITLE
Split qa_run to use test modules to boot into image

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -332,13 +332,6 @@ sub wait_boot {
             select_console('iucvconn');
         }
         else {
-            if (get_var('QA_TESTSET') && check_var('BACKEND', 'svirt')) {
-                my $svirt = select_console('svirt');
-                zkvm_add_disk $svirt;
-                zkvm_add_pty $svirt;
-                zkvm_add_interface $svirt;
-                $svirt->define_and_start;
-            }
             wait_serial('GNU GRUB') || diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
             select_console('svirt');
             save_svirt_pty;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1201,6 +1201,7 @@ elsif (get_var("HA_CLUSTER")) {
     load_ha_cluster_tests();
 }
 elsif (get_var("QA_TESTSET")) {
+    boot_hdd_image;
     if (get_var('INSTALL_KOTD')) {
         loadtest 'kernel/install_kotd';
     }

--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -46,8 +46,6 @@ sub system_status {
 
 
 sub system_login {
-    my $self = shift;
-    $self->wait_boot;
     if (get_var('VIRTIO_CONSOLE')) {
         select_console('root-virtio-terminal');
     }
@@ -158,4 +156,3 @@ sub run {
 }
 
 1;
-


### PR DESCRIPTION
In qa_run we have booting login implemented there which diverses from
how we run tests normally. It works fine in simple scenarios, but in
case of s390x we had issues before. To fix them we have applied couple
of workarounds which were specific for these tests.

Now we would like to reuse logic we already have and then trigger stress
tests.

Verification run for s390x: http://g226.suse.de/tests/2104 (fails because of missing dependency, which is another issue)
Verification run for x86_64: http://g226.suse.de/tests/2118 (I've decreased timeout here, just to prove that it works).

See [poo#19362](https://progress.opensuse.org/issues/19362).