### PR TITLE
main.pm: do not run mysql_odbc test on Tumbleweed Staging

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -435,12 +435,14 @@ sub load_consoletests {
         }
         loadtest "console/http_srv";
         loadtest "console/mysql_srv";
-        loadtest "console/mysql_odbc";
         loadtest "console/dns_srv";
-        if (!is_staging() && is_leap && !leap_version_at_least('15')) {
-            loadtest "console/php5";
-            loadtest "console/php5_mysql";
-            loadtest "console/php5_postgresql96";
+        if (!is_staging) {
+            loadtest "console/mysql_odbc";
+            if (is_leap && !leap_version_at_least('15')) {
+                loadtest "console/php5";
+                loadtest "console/php5_mysql";
+                loadtest "console/php5_postgresql96";
+            }
         }
         loadtest "console/php7";
         loadtest "console/php7_mysql";


### PR DESCRIPTION
MyODBC-unixODBC and unixODBC are not ring package which is not available to test them on Staging Project.

Regression from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3567