### PR TITLE
Disable mysql_odbc test

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -437,7 +437,6 @@ sub load_consoletests {
         loadtest "console/mysql_srv";
         loadtest "console/dns_srv";
         if (!is_staging) {
-            loadtest "console/mysql_odbc";
             if (is_leap && !leap_version_at_least('15')) {
                 loadtest "console/php5";
                 loadtest "console/php5_mysql";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -840,7 +840,6 @@ sub load_consoletests {
         }
         loadtest "console/http_srv";
         loadtest "console/mysql_srv";
-        loadtest "console/mysql_odbc";
         loadtest "console/dns_srv";
         loadtest "console/postgresql96server";
         if (sle_version_at_least('12-SP1')) {    # shibboleth-sp not available on SLES 12 GA


### PR DESCRIPTION
Test was disabled due to failure on some platforms (!x86_64), also due to
lacking of some of its components (mysql_odbc plugin) on some platforms as well