### PR TITLE
Fix parsing of docker image/container ID

### DIFF
--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -94,10 +94,10 @@ sub run {
     die("network does not work inside of the container") unless wait_serial("container_network_works", 200);
 
     # remove all containers related to alpine and hello-world
-    assert_script_run("docker rm \$(docker ps -a | grep 'alpine:$alpine_image_version\\|hello-world' | awk '{print \$1}')");
+    assert_script_run("docker rm \$(docker ps -a | grep 'alpine\\|hello-world' | awk '{print \$1}')");
 
     # Remove the alpine and hello-world images
-    assert_script_run("docker images | grep 'alpine:$alpine_image_version\\|hello-world' | awk '{print \$1}' | xargs docker rmi");
+    assert_script_run("docker images | grep 'alpine\\|hello-world' | awk '{print \$3}' | xargs docker rmi");
 
 }
 


### PR DESCRIPTION
Fix poo#25926: Container ID was not parsed correctly in `docker images`
output. Images weren't deleted properly. Fix will also delete all alpine
containers/images (not only specific version).

Test left not deleted docker images and following test sle2docker failed.

Failure: 
* incorrect image deletion: https://openqa.suse.de/tests/1204168#step/docker/102
* sle2docker failure: https://openqa.suse.de/tests/1204168#step/sle2docker/21

Verification:
* correct image deletion: http://10.100.12.105/tests/1503#step/docker/102
* not failing sle2docker: http://10.100.12.105/tests/1503#step/sle2docker/1