### PR TITLE
Add sle15_workarounds.pm for testsuite create_hdd_sled_gnome

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1093,6 +1093,8 @@ elsif (get_var("REGRESSION")) {
         load_inst_tests();
         load_reboot_tests();
         loadtest "x11regressions/x11regressions_setup";
+        # temporary adding test modules which applies hacks for missing parts in sle15
+        loadtest "console/sle15_workarounds" if sle_version_at_least('15');
         loadtest "console/hostname" unless is_bridged_networking;
         loadtest "console/force_cron_run" unless is_jeos;
         loadtest "shutdown/grub_set_bootargs";


### PR DESCRIPTION
We will replace testsuite regression-installation with create_hdd_sled_gnome in
SLED 15, this commit will schedule sle15_workarounds.pm for the testsuite.

  [Validation test](http://10.67.17.30/tests/1940) (The failure of shutdown.pm was caused by a known issue)

  see also: [poo#23886](https://progress.opensuse.org/issues/23886)