### PR TITLE
Workaround for bsc#1060174: send_key "accept license" multiple times

### DIFF
--- a/tests/installation/accept_license.pm
+++ b/tests/installation/accept_license.pm
@@ -36,6 +36,14 @@ sub run {
     }
     $self->verify_license_has_to_be_accepted;
     send_key $cmd{next};
+    # workaround for bsc#1059317, multiple times clicking accept license
+    my $count = 5;
+    while (check_screen('license-not-accepted', 3) && $count >= 1) {
+        record_soft_failure 'bsc#1059317';
+        $self->verify_license_has_to_be_accepted;
+        send_key $cmd{next};
+        $count--;
+    }
 }
 
 1;


### PR DESCRIPTION
A solution for https://progress.opensuse.org/issues/26000
If send_key "accept" failed, try some more times.
I could verify it on x86_64: http://f146.suse.de/tests/1458
Can someone please verify it on aarch64? @okurz  @rwx788 