### PR TITLE
Run bsc#1061829 workaround only on QEMU

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -76,11 +76,14 @@ sub run {
     die "passwd failed" unless (defined $ret && $ret =~ /$str-0-/);
 
     # Workaround for bsc#1061829 - Ethernet device is missing configuration
-    record_soft_failure 'bsc#1061829 - Ethernet device is missing configuration';
-    assert_script_run "eth=\$(ip link | grep '^2:' | awk '{ print \$2 }' | tr -d ':')";
-    assert_script_run 'cp -v /etc/sysconfig/network/ifcfg-eth0 /etc/sysconfig/network/ifcfg-$eth';
-    assert_script_run 'systemctl restart wicked.service';
-    assert_script_run 'ip addr';
+    # Does apply only to KVM.
+    if (check_var('BACKEND', 'qemu')) {
+        record_soft_failure 'bsc#1061829 - Ethernet device is missing configuration';
+        assert_script_run "eth=\$(ip link | grep '^2:' | awk '{ print \$2 }' | tr -d ':')";
+        assert_script_run 'cp -v /etc/sysconfig/network/ifcfg-eth0 /etc/sysconfig/network/ifcfg-$eth';
+        assert_script_run 'systemctl restart wicked.service';
+        assert_script_run 'ip addr';
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
Both Xens, & Hyper-V are defaulting to `eth0` and thus working.