### PR TITLE
Disable grub timeout from the Installer

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -282,6 +282,7 @@ sub load_inst_tests {
     if (noupdatestep_is_applicable()) {
         if (get_var('PATTERNS') || get_var('PACKAGES')) {
             loadtest "installation/installation_overview_before";
+            loadtest "installation/disable_grub_timeout";
             loadtest "installation/select_patterns_and_packages";
         }
     }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -668,6 +668,7 @@ sub load_inst_tests {
             loadtest "installation/installation_overview_before";
             loadtest "installation/change_desktop";
         }
+        loadtest "installation/disable_grub_timeout";
     }
     if (get_var("UEFI") && get_var("SECUREBOOT")) {
         loadtest "installation/secure_boot";

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -1,0 +1,55 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Disable grub timeout from the Installer
+#   in order to ensure tests do not skip over it.
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.com>
+
+use strict;
+use warnings;
+use base "y2logsstep";
+use testapi;
+
+sub run {
+    my ($self) = shift;
+
+    # Verify Installation Settings overview is displayed as starting point
+    assert_screen "installation-settings-overview-loaded";
+
+    if (check_var('VIDEOMODE', 'text')) {
+        # Select section booting on Installation Settings overview on text mode
+        send_key 'alt-c';
+        assert_screen 'inst-overview-options';
+        wait_screen_change { send_key 'alt-b'; };
+    }
+    else {
+        # Select section booting on Installation Settings overview (video mode)
+        send_key_until_needlematch 'booting-section-selected', 'tab', 10;
+        assert_screen 'booting-section-selected';
+        send_key 'ret';
+    }
+
+    # Select bootloader options tab
+    wait_screen_change { send_key 'alt-r'; };
+    assert_screen 'installation-bootloader-options';
+
+    # Select Timeout dropdown box and disable
+    send_key 'alt-t';
+    type_string "-1";
+
+    # ncurses uses blocking modal dialog, so press return is needed
+    send_key 'ret' if check_var('VIDEOMODE', 'text');
+
+    wait_still_screen(1);
+    save_screenshot;
+    send_key $cmd{ok};
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
## Ticket 
https://progress.opensuse.org/issues/25658
## Needles
[sle](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/525)
[opensuse](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/276)
## Verification run
* SLE-15:
  * text mode:
    * [disabled](http://10.100.51.227/tests/108#step/disable_grub_timeout/3)
    * [grub verification](http://10.100.51.227/tests/108#step/grub_test/1)
  * graphic mode:
    * [disabled](http://10.100.51.227/tests/109#step/disable_grub_timeout/7)
    * [grub verification](http://10.100.51.227/tests/109#step/grub_test/1)
* Tumbleweed:
  * text mode:
    * [Disable](http://10.100.51.227/tests/105#step/disable_grub_timeout/3)
    * [grub verification](http://10.100.51.227/tests/105#step/grub_test/1)
  * graphic mode:
    * [Disable](http://10.100.51.227/tests/104#step/disable_grub_timeout/6)
    * [grub verification](http://10.100.51.227/tests/104#step/grub_test/1)