### PR TITLE
Add support for new SLE15 system roles 'textmode' and 'minimal'

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -29,7 +29,8 @@ our @EXPORT = qw(
   registration_bootloader_params
   yast_scc_registration
   skip_registration
-  SLE15_MODULES
+  %SLE15_MODULES
+  %SLE15_DEFAULT_MODULES
 );
 
 # We already have needles with names which are different we would use here
@@ -41,6 +42,14 @@ our %SLE15_MODULES = (
     legacy    => 'Legacy',
     script    => 'Scripting',
     serverapp => 'Server-Applications'
+);
+
+# The expected modules of a default installation per product. Use them if they
+# are not preselected, to crosscheck or just recreate automatic selections
+# manually
+our %SLE15_DEFAULT_MODULES = (
+    sles => 'base,script,desktop,serverapp',
+    sled => 'base,script,desktop'
 );
 
 sub fill_in_registration_data {
@@ -128,11 +137,7 @@ sub fill_in_registration_data {
         if (match_has_tag 'bsc#1056413') {
             record_soft_failure('bsc#1056413');
             # Add expected modules to select them manually, as not preselected
-            my %addons = (
-                sles => 'base,script,desktop,serverapp',
-                sled => 'base,script,desktop'
-            );
-            my $addons = $addons{get_required_var('SLE_PRODUCT')} . (get_var('SCC_ADDONS') ? ',' . get_var('SCC_ADDONS') : '');
+            my $addons = $SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')} . (get_var('SCC_ADDONS') ? ',' . get_var('SCC_ADDONS') : '');
             set_var('SCC_ADDONS', $addons);
         }
     }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -92,6 +92,7 @@ sub default_desktop {
     return 'gnome' if get_var('BASE_VERSION', '') =~ /^12/;
     # In sle15 we add repos manually to make a workaround of missing SCC, gnome will be installed as default system.
     return 'gnome' if get_var('ADDONURL', '') =~ /(desktop|server)/;
+    return 'gnome' if check_var_array('ADDONS', 'all-packages');
     return (get_var('SCC_REGISTER') && !check_var('SCC_REGISTER', 'installation')) ? 'textmode' : 'gnome';
 }
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -92,6 +92,7 @@ sub default_desktop {
     return 'gnome' if get_var('BASE_VERSION', '') =~ /^12/;
     # In sle15 we add repos manually to make a workaround of missing SCC, gnome will be installed as default system.
     return 'gnome' if get_var('ADDONURL', '') =~ /(desktop|server)/;
+    return 'textmode' if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'));
     return 'gnome' if check_var_array('ADDONS', 'all-packages');
     return (get_var('SCC_REGISTER') && !check_var('SCC_REGISTER', 'installation')) ? 'textmode' : 'gnome';
 }

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -16,6 +16,38 @@ use base "y2logsstep";
 use testapi;
 use utils qw(addon_license sle_version_at_least);
 use qam 'advance_installer_window';
+use registration '%SLE15_DEFAULT_MODULES';
+
+sub handle_all_packages_medium {
+    assert_screen 'addon-products-all_packages';
+    send_key 'alt-s';
+    # We could reuse SCC_MODULES or another list. For now just hardcode what
+    # corresponds to the selected SLE15 product because the "all packages"
+    # addon medium and feature of installer is only available for SLE >= 15
+    # anyway
+    foreach (split(/,/, $SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')})) {
+        send_key 'home';
+        send_key_until_needlematch "addon-products-all_packages-$_-highlighted", 'down';
+        send_key 'spc';
+    }
+    send_key $cmd{next};
+}
+
+sub handle_addon {
+    my ($addon) = @_;
+    return handle_all_packages_medium if $addon eq 'all-packages';
+    addon_license($addon);
+    # might involve some network lookup of products, licenses, etc.
+    assert_screen 'addon-products', 90;
+    send_key "tab";    # select addon-products-$addon
+    wait_still_screen 10;
+    if (check_var('VIDEOMODE', 'text')) {    # textmode need more tabs, depends on add-on count
+        send_key_until_needlematch "addon-list-selected", 'tab';
+    }
+    send_key "pgup";
+    wait_still_screen 2;
+    send_key_until_needlematch "addon-products-$addon", 'down';
+}
 
 sub run {
     my ($self) = @_;
@@ -27,12 +59,7 @@ sub run {
     $self->process_unsigned_files([qw(inst-addon addon-products)]);
     assert_screen [qw(inst-addon addon-products)];
     if (get_var("ADDONS")) {
-        if (match_has_tag('inst-addon')) {
-            send_key 'alt-k';    # install with addons
-        }
-        else {
-            send_key 'alt-a';
-        }
+        send_key match_has_tag('inst-addon') ? 'alt-k' : 'alt-a';
         # the ISO_X variables must match the ADDONS list
         my $sr_number = 0;
         for my $addon (split(/,/, get_var('ADDONS'))) {
@@ -44,17 +71,7 @@ sub run {
             send_key_until_needlematch 'addon-dvd-list',         'tab',  5;     # jump into addon list
             send_key_until_needlematch "addon-dvd-sr$sr_number", 'down', 10;    # select addon in list
             send_key 'alt-o';                                                   # continue
-            addon_license($addon);
-            # might involve some network lookup of products, licenses, etc.
-            assert_screen 'addon-products', 90;
-            send_key "tab";                                                     # select addon-products-$addon
-            wait_still_screen 10;
-            if (check_var('VIDEOMODE', 'text')) {                               # textmode need more tabs, depends on add-on count
-                send_key_until_needlematch "addon-list-selected", 'tab';
-            }
-            send_key "pgup";
-            wait_still_screen 2;
-            send_key_until_needlematch "addon-products-$addon", 'down';
+            handle_addon($addon);
             if ((split(/,/, get_var('ADDONS')))[-1] ne $addon) {                # if $addon is not first from all ADDONS
                 send_key 'alt-a';                                               # add another add-on
             }

--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -49,7 +49,7 @@ sub run {
     }
 
     # no release-notes for WE and all modules
-    my @no_relnotes = qw(we lgm asmm certm contm pcm tcm wsm hpcm ids idu phub);
+    my @no_relnotes = qw(we lgm asmm certm contm pcm tcm wsm hpcm ids idu phub all-packages);
 
     # No release-notes for basic modules on SLE 15
     if (sle_version_at_least('15') && check_var('DISTRI', 'sle')) {

--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -1,33 +1,45 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Check system role selection screen. Added in SLE 12 SP2
+# Summary: Check system role selection screen or select system role. Added in SLE 12 SP2
 # Maintainer: Jozef Pupava <jpupava@suse.com>
+# Tags: poo#16650, poo#25850
 
 use strict;
 use base "y2logsstep";
 use testapi;
 use utils 'sle_version_at_least';
 
+
+my %role_hotkey = (
+    default  => 's',    # sles with gnome
+    textmode => 't',
+    minimal  => 'm',
+    kvm      => 'k',
+    xen      => 'x',
+);
+
+sub change_system_role {
+    my ($system_role) = @_;
+    send_key 'alt-' . $role_hotkey{$system_role};
+    assert_screen "system-role-$system_role-selected";
+    # every system role other than default will end up in textmode
+    set_var('DESKTOP', 'textmode');
+}
+
 sub assert_system_role {
     # Still initializing the system at this point, can take some time
     assert_screen 'system-role-default-system', 180;
-    # Pick System Role; poo#16650
-    if (check_var('SYSTEM_ROLE', 'kvm')) {
-        send_key 'alt-k';
-        assert_screen 'system-role-kvm-virthost';
+    my $system_role = get_var('SYSTEM_ROLE', 'default');
+    if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default')) {
+        change_system_role($system_role);
     }
-    elsif (check_var('SYSTEM_ROLE', 'xen')) {
-        send_key 'alt-x';
-        assert_screen 'system-role-xen-virthost';
-    }
-
     send_key $cmd{next};
 }
 


### PR DESCRIPTION
Based on the existing test variable 'SYSTEM_ROLE' we can explicitly select the
new SLE15 system roles 'textmode' or 'minimal' as well as the existant ones.
As this also influences the initial bootup target the 'default_desktop' method
is updated accordingly.

Verification local, see screenshots:

textmode:
![openqa_feature_system_role_textmode](https://user-images.githubusercontent.com/1693432/31596393-942e2d82-b242-11e7-9751-97f1baddec40.png)

minimal:
![openqa_feature_system_role_minimal](https://user-images.githubusercontent.com/1693432/31596396-9a32f10e-b242-11e7-851b-122cd129af8a.png)

Related SLE needles MR:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/527

Related progress issues:

* minimal: https://progress.opensuse.org/issues/26038
* textmode: https://progress.opensuse.org/issues/26042