### PR TITLE
[qa_automation] Remove wait_boot from kexec test

### DIFF
--- a/tests/qa_automation/kernel_kexec.pm
+++ b/tests/qa_automation/kernel_kexec.pm
@@ -22,7 +22,6 @@ use testapi;
 
 sub run {
     my $self = shift;
-    $self->wait_boot;
     select_console('root-console');
     # Copy current kernel and rename it
     $_ = script_output("uname -r", 120);


### PR DESCRIPTION
Remove wait_boot since all qa tests use boot_hdd_image now.