### PR TITLE
Add a stress test newburn 1 hour version to kernel test

### DIFF
--- a/tests/qa_automation/kernel_newburn_1h.pm
+++ b/tests/qa_automation/kernel_newburn_1h.pm
@@ -1,0 +1,35 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: A stress test from qa_test_newburn(QA:Head), this is one hour version.
+# Maintainer: Yong Sun <yosun@suse.com>
+
+use base "qa_run";
+use strict;
+use testapi;
+
+sub test_run_list {
+    return qw(_reboot_off newburn_1h);
+}
+
+sub test_suite {
+    return 'kernel';
+}
+
+sub junit_type {
+    return 'kernel_regression';
+}
+
+1;


### PR DESCRIPTION
Add a 1 hour version newburn test for kernel job group.
The original newburn need to run 36 hours, so it didn't added into openqa. This commit add an 1 hour version newburn to cover some compiler code coverage, and it can make basic stress test.