### PR TITLE
Fix RAID tests if UEFI is enabled

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -232,33 +232,37 @@ sub run {
         if ($_ eq 'vdd' and get_var('UEFI')) {
             assert_screen 'partitioning_raid-disk_vdd_with_partitions-selected';
             # fold the drive tree
-            send_key 'left';
-            assert_screen 'partitioning_raid-hard_disks-unfolded';
+            # Have to press to navigate in the system view tree
+            send_key 'down' if is_storage_ng;
+            send_key_until_needlematch 'partitioning_raid-hard_disks-unfolded', 'left';
             # select first disk
             send_key 'right';
-            assert_screen 'partitioning_raid-disk_vda_with_partitions-selected';
+            send_key_until_needlematch "partitioning_raid-disk_vda-selected", "down";
             # edit first partition
             send_key 'alt-e';
             assert_screen 'partition-format';
-            # format as FAT (first choice)
+            # format as FAT (first choice) unless storage-ng
             send_key 'alt-a';
-            assert_screen 'partitioning_raid-format_fat_UEFI';
+            if (is_storage_ng) {
+                send_key 'alt-f';
+                send_key_until_needlematch 'partitioning_raid-format_fat_UEFI', 'down';
+            }
+            else {
+                assert_screen 'partitioning_raid-format_fat_UEFI';
+            }
             # mount point selection
             send_key 'alt-o';
             assert_screen 'partitioning_raid-mount_point-focused';
             # enter mount point
             type_string '/boot/efi';
             assert_screen 'partitioning_raid-mount_point_boot_efi';
-            send_key $cmd{finish};
+            send_key(is_storage_ng() ? $cmd{next} : $cmd{finish});
             assert_screen 'expert-partitioner';
-            send_key 'shift-tab';
-            send_key 'shift-tab';
-            # go to top "Hard Disks" node
-            send_key 'left';
-            assert_screen 'partitioning_raid-hard_disks-unfolded';
-            # fold the drive tree again
-            send_key 'left';
         }
+
+        # select next disk
+        send_key "shift-tab" unless is_storage_ng;
+        send_key "shift-tab" unless is_storage_ng;
     }
 
     # select RAID add

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -77,9 +77,12 @@ sub run {
     # On sle 15 license is on different screen, here select the product
     if (sle_version_at_least('15') && check_var('DISTRI', 'sle')) {
         # On s390x there will be only one product which means there is no product selection
-        # On aarch64 we also have only one product at the moment because HPC was disabled temporarily
-        # (will change and not considered as bug)
-        return if (check_var('ARCH', 's390x') or check_var('ARCH', 'aarch64'));
+        return if check_var('ARCH', 's390x');
+        # Missing HPC module on ARM, should be there according to the PRD
+        if (check_var('ARCH', 'aarch64')) {
+            record_soft_failure 'bsc#1063858';
+            return;
+        }
         assert_screen('select-product');
         my %hotkey = (
             sles     => 's',


### PR DESCRIPTION
Continuing adjusting RAID tests. An arm we use UEFI and this part of
code was not adjusted. Be aware that we don't run tests with UEFI with
openSUSE.

See [poo#25496](https://progress.opensuse.org/issues/25496) for more
details.

Please, merge 2 more [NEEDLES](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/533).

[Verification run SLE15](http://g226.suse.de/tests/2295) (Fails due to https://bugzilla.suse.com/show_bug.cgi?id=1060993)
[Verification run SLE12SP3](http://g226.suse.de/tests/2296)