### PR TITLE
Fix to use correct x11 tty before and after upgrading

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -36,6 +36,7 @@ our @EXPORT = qw(
   is_sle
   is_tumbleweed
   is_storage_ng
+  is_sle12_hdd_in_upgrade
   select_kernel
   type_string_slow
   type_string_very_slow
@@ -306,6 +307,10 @@ sub is_sle {
 
 sub is_storage_ng {
     return get_var('STORAGE_NG');
+}
+
+sub is_sle12_hdd_in_upgrade {
+    return get_var('UPGRADE') && !sle_version_at_least('15', version_variable => 'HDDVERSION');
 }
 
 sub type_string_slow {
@@ -1384,7 +1389,7 @@ sub get_root_console_tty {
     is running on tty2 by default. see also: bsc#1054782
 =cut
 sub get_x11_console_tty {
-    my $new_gdm = !(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15')) && !is_caasp;
+    my $new_gdm = !(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15')) && !is_sle12_hdd_in_upgrade && !is_caasp;
     return (check_var('DESKTOP', 'gnome') && get_var('NOAUTOLOGIN') && $new_gdm) ? 2 : 7;
 }
 

--- a/tests/x11/reboot_and_install.pm
+++ b/tests/x11/reboot_and_install.pm
@@ -14,7 +14,7 @@ use base "opensusebasetest";
 use strict;
 
 use testapi;
-use utils qw(power_action workaround_type_encrypted_passphrase);
+use utils qw(power_action workaround_type_encrypted_passphrase is_sle12_hdd_in_upgrade);
 use bootloader_setup;
 use registration;
 
@@ -49,6 +49,12 @@ sub run {
         # boot
         my $key = check_var('ARCH', 'ppc64le') || check_var('ARCH', 'aarch64') ? 'ctrl-x' : 'ret';
         send_key $key;
+    }
+
+    # All actions have been done e.g. fully/minimal patch on booted hdd before this step
+    # After this, the hdd would be upgraded to the target version in case of Upgrade scenario
+    if (is_sle12_hdd_in_upgrade) {
+        set_var('HDDVERSION', get_var('VERSION'));
     }
 }
 


### PR DESCRIPTION
This aims to fix: https://openqa.suse.de/tests/1213419#step/consoletest_finish_sym/18
Also see: https://progress.opensuse.org/issues/26084

verified runs:
upgrade from 12sp3 to 15: http://10.67.17.71/tests/162
sle12sp3: http://10.67.17.71/tests/157
sle15: http://10.67.17.71/tests/160