### PR TITLE
CaaSP: Workaround for ldap cert issue for KVM-and-Xen bsc#1062717

### DIFF
--- a/tests/caasp/first_boot.pm
+++ b/tests/caasp/first_boot.pm
@@ -49,6 +49,18 @@ sub run {
         # Restart network to push hostname to dns
         if (is_caasp('VMX') && get_var('STACK_ROLE')) {
             script_run "systemctl restart network", 60;
+            # Workaround for bsc#1062717 when admin node has no fqdn hostname
+            record_soft_failure 'bsc#1062717';
+            get_var('TEST') =~ /.*-(\w+)$/;
+            my $fake_hostname = $1;
+            script_run "hostnamectl set-hostname $fake_hostname.openqa.test";
+            if (check_var('STACK_ROLE', 'admin')) {
+                script_run "rm /etc/pki/ldap.crt /etc/pki/velum.crt";
+                script_run "systemctl restart admin-node-setup.service";
+                script_run "docker rm -f \$(docker ps -f \"name=k8s_velum-dashboard\" -q)";
+                script_run "docker rm -f \$(docker ps -f \"name=k8s_openldap_velum\" -q)";
+            }
+            # End of workaround
         }
     }
 }


### PR DESCRIPTION
We are unable to get full fqdn hostname from support_server, but we need that for creating certificates. In meantime until we fix the issue we can use this workaround.