### PR TITLE
Dynamically adjust the schedule according to available system roles on SLE15

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -94,7 +94,7 @@ sub default_desktop {
     return 'gnome' if get_var('ADDONURL', '') =~ /(desktop|server)/;
     return 'textmode' if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'));
     return 'gnome' if check_var_array('ADDONS', 'all-packages');
-    return (get_var('SCC_REGISTER') && !check_var('SCC_REGISTER', 'installation')) ? 'textmode' : 'gnome';
+    return (!get_var('SCC_REGISTER') || !check_var('SCC_REGISTER', 'installation')) ? 'textmode' : 'gnome';
 }
 
 sub cleanup_needles {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -174,7 +174,12 @@ set_var('DESKTOP',     get_var('DESKTOP', default_desktop));
 # Always register against SCC if SLE 15
 if (sle_version_at_least('15')) {
     set_var('SCC_REGISTER', get_var('SCC_REGISTER', 'installation'));
+    # depending on registration only limited system roles are available
+    set_var('SYSTEM_ROLE', get_var('SYSTEM_ROLE', check_var('SCC_REGISTER', 'installation') ? 'default' : 'minimal'));
+    # in the 'minimal' system role we can not execute many test modules
+    set_var('INSTALLONLY', get_var('INSTALLONLY', check_var('SYSTEM_ROLE', 'minimal')));
 }
+
 
 # Set serial console for Xen PV
 if (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')) {
@@ -756,7 +761,7 @@ sub load_consoletests {
     }
     loadtest "console/textinfo";
     loadtest "console/hostname" unless is_bridged_networking;
-    if (get_var("SYSTEM_ROLE")) {
+    if (get_var('SYSTEM_ROLE', '') =~ /kvm|xen/) {
         loadtest "console/patterns";
     }
     if (snapper_is_applicable()) {

--- a/tests/console/patterns.pm
+++ b/tests/console/patterns.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -21,10 +21,8 @@ sub run {
 
     # System roles are defined in config.xml. Currently the role 'kvm host'
     # defines kvm_server as an additional pattern, xen_server defines 'xen host'.
-    my $pattern_name = 'kvm_server';
-    if (check_var('SYSTEM_ROLE', 'xen')) {
-        $pattern_name = 'xen_server';
-    }
+    die "Only kvm|xen roles are supported" unless get_var('SYSTEM_ROLE', '') =~ /kvm|xen/;
+    my $pattern_name = get_required_var('SYSTEM_ROLE') . '_server';
     assert_script_run("zypper patterns -i | grep $pattern_name");
 }
 


### PR DESCRIPTION
Depending on registration within the installation system roles can be
available or not. This commit sets the system role if not overridden depending
on registration during installation. As for 'minimal', e.g. as used in the
test suite "skip_registration", only a minor subset of packages are available
the test variable "INSTALLONLY" is implicitly set.

Test schedule for default test scenario, registered, desktop overridden as textmode:

```
09:52:31.4243 12545 default desktop: gnome
09:52:31.4245 12545 usingenv DESKTOP=textmode
09:52:31.4245 12545 usingenv LVM=1
09:52:31.4246 12545 usingenv TEXTMODE=1
09:52:31.4246 12545 usingenv DISTRI=sle
09:52:31.4246 12545 usingenv NOAUTOLOGIN=1
09:52:31.4246 12545 usingenv QEMUCPU=qemu64
09:52:31.4247 12545 usingenv QEMUCPUS=1
09:52:31.4247 12545 usingenv ENCRYPT=1
09:52:31.4247 12545 usingenv INSTLANG=en_US
09:52:31.4247 12545 usingenv QEMUVGA=cirrus
09:52:31.4247 12545 usingenv DVD=1
09:52:31.4248 12545 usingenv GNOME=1
09:52:31.4248 12545 usingenv ISO=/var/lib/openqa/share/factory/iso/SLE-15-Server-DVD-x86_64-Build2140-Media1.iso
09:52:31.4248 12545 usingenv ISO_MAXSIZE=4700372992
09:52:31.4248 12545 usingenv SLE_PRODUCT=sles
09:52:31.4641 12545 scheduling isosize tests/installation/isosize.pm
09:52:31.4654 12545 scheduling bootloader tests/installation/bootloader.pm
09:52:31.4680 12545 scheduling welcome tests/installation/welcome.pm
09:52:31.4688 12545 scheduling accept_license tests/installation/accept_license.pm
09:52:31.4695 12545 scheduling scc_registration tests/installation/scc_registration.pm
09:52:31.4710 12545 scheduling addon_products_sle tests/installation/addon_products_sle.pm
09:52:31.4716 12545 scheduling system_role tests/installation/system_role.pm
09:52:31.4721 12545 scheduling partitioning tests/installation/partitioning.pm
09:52:31.4730 12545 scheduling partitioning_lvm tests/installation/partitioning_lvm.pm
09:52:31.4734 12545 scheduling partitioning_finish tests/installation/partitioning_finish.pm
09:52:31.4741 12545 scheduling releasenotes tests/installation/releasenotes.pm
09:52:31.4745 12545 scheduling installer_timezone tests/installation/installer_timezone.pm
09:52:31.4750 12545 scheduling logpackages tests/installation/logpackages.pm
09:52:31.4755 12545 scheduling user_settings tests/installation/user_settings.pm
09:52:31.4770 12545 scheduling user_settings_root tests/installation/user_settings_root.pm
09:52:31.4785 12545 scheduling installation_overview_before tests/installation/installation_overview_before.pm
09:52:31.4795 12545 scheduling change_desktop tests/installation/change_desktop.pm
09:52:31.4801 12545 scheduling disable_grub_timeout tests/installation/disable_grub_timeout.pm
09:52:31.4807 12545 scheduling installation_overview tests/installation/installation_overview.pm
09:52:31.4814 12545 scheduling start_install tests/installation/start_install.pm
09:52:31.4835 12545 scheduling install_and_reboot tests/installation/install_and_reboot.pm
09:52:31.4850 12545 scheduling grub_test tests/installation/grub_test.pm
09:52:31.4858 12545 scheduling boot_encrypt tests/installation/boot_encrypt.pm
09:52:31.4869 12545 scheduling first_boot tests/installation/first_boot.pm
09:52:31.4885 12545 scheduling consoletest_setup tests/console/consoletest_setup.pm
…
09:52:31.5146 12545 scheduling consoletest_finish tests/console/consoletest_finish.pm
```

Unregistered default:

```
09:52:31.0670 12531 default desktop: textmode
09:52:31.0677 12531 usingenv DESKTOP=textmode
09:52:31.0677 12531 usingenv LVM=1
09:52:31.0678 12531 usingenv TEXTMODE=1
09:52:31.0679 12531 usingenv DISTRI=sle
09:52:31.0679 12531 usingenv NOAUTOLOGIN=1
09:52:31.0680 12531 usingenv QEMUCPU=qemu64
09:52:31.0681 12531 usingenv QEMUCPUS=1
09:52:31.0681 12531 usingenv ENCRYPT=1
09:52:31.0682 12531 usingenv INSTLANG=en_US
09:52:31.0683 12531 usingenv QEMUVGA=cirrus
09:52:31.0683 12531 usingenv DVD=1
09:52:31.0684 12531 usingenv GNOME=1
09:52:31.0685 12531 usingenv ISO=/var/lib/openqa/share/factory/iso/SLE-15-Server-DVD-x86_64-Build2140-Media1.iso
09:52:31.0685 12531 usingenv ISO_MAXSIZE=4700372992
09:52:31.0686 12531 usingenv SLE_PRODUCT=sles
09:52:31.0956 12531 scheduling isosize tests/installation/isosize.pm
09:52:31.0964 12531 scheduling bootloader tests/installation/bootloader.pm
09:52:31.0978 12531 scheduling welcome tests/installation/welcome.pm
09:52:31.0982 12531 scheduling accept_license tests/installation/accept_license.pm
09:52:31.0988 12531 scheduling skip_registration tests/installation/skip_registration.pm
09:52:31.1003 12531 scheduling addon_products_sle tests/installation/addon_products_sle.pm
09:52:31.1008 12531 scheduling system_role tests/installation/system_role.pm
09:52:31.1013 12531 scheduling partitioning tests/installation/partitioning.pm
09:52:31.1022 12531 scheduling partitioning_lvm tests/installation/partitioning_lvm.pm
09:52:31.1026 12531 scheduling partitioning_finish tests/installation/partitioning_finish.pm
09:52:31.1033 12531 scheduling releasenotes tests/installation/releasenotes.pm
09:52:31.1037 12531 scheduling installer_timezone tests/installation/installer_timezone.pm
09:52:31.1043 12531 scheduling hostname_inst tests/installation/hostname_inst.pm
09:52:31.1049 12531 scheduling logpackages tests/installation/logpackages.pm
09:52:31.1054 12531 scheduling user_settings tests/installation/user_settings.pm
09:52:31.1059 12531 scheduling user_settings_root tests/installation/user_settings_root.pm
09:52:31.1065 12531 scheduling disable_grub_timeout tests/installation/disable_grub_timeout.pm
09:52:31.1071 12531 scheduling installation_overview tests/installation/installation_overview.pm
09:52:31.1079 12531 scheduling start_install tests/installation/start_install.pm
09:52:31.1094 12531 scheduling install_and_reboot tests/installation/install_and_reboot.pm
09:52:31.1102 12531 scheduling grub_test tests/installation/grub_test.pm
09:52:31.1106 12531 scheduling boot_encrypt tests/installation/boot_encrypt.pm
09:52:31.1113 12531 scheduling first_boot tests/installation/first_boot.pm
09:52:31.1122 12531 scheduling sle15_workarounds tests/console/sle15_workarounds.pm
09:52:31.1127 12531 scheduling hostname tests/console/hostname.pm
09:52:31.1132 12531 scheduling force_cron_run tests/console/force_cron_run.pm
09:52:31.1137 12531 scheduling grub_set_bootargs tests/shutdown/grub_set_bootargs.pm
09:52:31.1141 12531 scheduling shutdown tests/shutdown/shutdown.pm
```

Registered installation with explicit selection of role 'minimal':

```
09:52:31.8207 12554 default desktop: textmode
09:52:31.8209 12554 usingenv DESKTOP=textmode
09:52:31.8209 12554 usingenv LVM=1
09:52:31.8209 12554 usingenv TEXTMODE=1
09:52:31.8209 12554 usingenv DISTRI=sle
09:52:31.8210 12554 usingenv NOAUTOLOGIN=1
09:52:31.8210 12554 usingenv QEMUCPU=qemu64
09:52:31.8210 12554 usingenv QEMUCPUS=1
09:52:31.8210 12554 usingenv ENCRYPT=1
09:52:31.8211 12554 usingenv INSTLANG=en_US
09:52:31.8211 12554 usingenv QEMUVGA=cirrus
09:52:31.8211 12554 usingenv DVD=1
09:52:31.8212 12554 usingenv GNOME=1
09:52:31.8212 12554 usingenv ISO=/var/lib/openqa/share/factory/iso/SLE-15-Server-DVD-x86_64-Build2140-Media1.iso
09:52:31.8212 12554 usingenv ISO_MAXSIZE=4700372992
09:52:31.8212 12554 usingenv SLE_PRODUCT=sles
09:52:31.8512 12554 scheduling isosize tests/installation/isosize.pm
09:52:31.8520 12554 scheduling bootloader tests/installation/bootloader.pm
09:52:31.8535 12554 scheduling welcome tests/installation/welcome.pm
09:52:31.8540 12554 scheduling accept_license tests/installation/accept_license.pm
09:52:31.8545 12554 scheduling scc_registration tests/installation/scc_registration.pm
09:52:31.8560 12554 scheduling addon_products_sle tests/installation/addon_products_sle.pm
09:52:31.8566 12554 scheduling system_role tests/installation/system_role.pm
09:52:31.8570 12554 scheduling partitioning tests/installation/partitioning.pm
09:52:31.8580 12554 scheduling partitioning_lvm tests/installation/partitioning_lvm.pm
09:52:31.8584 12554 scheduling partitioning_finish tests/installation/partitioning_finish.pm
09:52:31.8590 12554 scheduling releasenotes tests/installation/releasenotes.pm
09:52:31.8595 12554 scheduling installer_timezone tests/installation/installer_timezone.pm
09:52:31.8600 12554 scheduling hostname_inst tests/installation/hostname_inst.pm
09:52:31.8604 12554 scheduling logpackages tests/installation/logpackages.pm
09:52:31.8609 12554 scheduling user_settings tests/installation/user_settings.pm
09:52:31.8613 12554 scheduling user_settings_root tests/installation/user_settings_root.pm
09:52:31.8620 12554 scheduling disable_grub_timeout tests/installation/disable_grub_timeout.pm
09:52:31.8626 12554 scheduling installation_overview tests/installation/installation_overview.pm
09:52:31.8632 12554 scheduling start_install tests/installation/start_install.pm
09:52:31.8648 12554 scheduling install_and_reboot tests/installation/install_and_reboot.pm
09:52:31.8656 12554 scheduling grub_test tests/installation/grub_test.pm
09:52:31.8660 12554 scheduling boot_encrypt tests/installation/boot_encrypt.pm
09:52:31.8666 12554 scheduling first_boot tests/installation/first_boot.pm
09:52:31.8675 12554 scheduling sle15_workarounds tests/console/sle15_workarounds.pm
09:52:31.8679 12554 scheduling hostname tests/console/hostname.pm
09:52:31.8684 12554 scheduling force_cron_run tests/console/force_cron_run.pm
09:52:31.8689 12554 scheduling grub_set_bootargs tests/shutdown/grub_set_bootargs.pm
09:52:31.8693 12554 scheduling shutdown tests/shutdown/shutdown.pm
```

Related progress issue: https://progress.opensuse.org/issues/26038