### PR TITLE
Fix RAID on LEAP15

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -69,6 +69,7 @@ sub init_cmd {
       bootloader b
       entiredisk alt-e
       guidedsetup alt-g
+      rescandevices alt-e
     );
 
     if (check_var('INSTLANG', "de_DE")) {

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -1,15 +1,15 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2176 SUSE LLC
+# Copyright © 2012-017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: change to nicer directory structure
-# Maintainer: Bernhard M. Wiedemann <bernhard+osautoinst@lsmod.de>
+# Summary: Check initial partitioning screen and prepare optional substeps
+# Maintainer: Joachim Rauch <jrauch@suse.com>
 
 use strict;
 use warnings;
@@ -26,8 +26,14 @@ sub run {
         # Define changed shortcuts
         $cmd{donotformat} = 'alt-t';
         $cmd{addraid}     = 'alt-d';
-        $cmd{filesystem}  = 'alt-a'
+        if (check_var('DISTRI', 'opensuse')) {
+            $cmd{expertpartitioner} = 'alt-x';
+            $cmd{rescandevices}     = 'alt-c';
 
+        }
+        else {
+            $cmd{filesystem} = 'alt-a';
+        }
     }
 
     if (get_var("DUALBOOT")) {

--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -156,7 +156,7 @@ sub run {
 
     # With storage ng, we go directly to expert partitioner and invalidate configuration by rescan
     if (is_storage_ng) {
-        send_key 'alt-e';                          # Rescan devices
+        send_key $cmd{rescandevices};              # Rescan devices
         assert_screen 'rescan-devices-warning';    # Confirm rescan
         send_key 'alt-y';
         wait_still_screen;                         # Wait until rescan is done


### PR DESCRIPTION
Adapted shortcuts and created needles for RAID tests on LEAP15

Verification run:
http://10.160.65.204/tests/990

To be merged with needles:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/279