### PR TITLE
Fix disable timeout in SLE-12-GA,SLE-12-SP1&LEAP

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -282,9 +282,9 @@ sub load_inst_tests {
     if (noupdatestep_is_applicable()) {
         if (get_var('PATTERNS') || get_var('PACKAGES')) {
             loadtest "installation/installation_overview_before";
-            loadtest "installation/disable_grub_timeout";
             loadtest "installation/select_patterns_and_packages";
         }
+        loadtest "installation/disable_grub_timeout";
     }
     if (get_var("UEFI") && get_var("SECUREBOOT")) {
         loadtest "installation/secure_boot";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -670,7 +670,6 @@ sub load_inst_tests {
             loadtest "installation/installation_overview_before";
             loadtest "installation/change_desktop";
         }
-        loadtest "installation/disable_grub_timeout";
     }
     if (get_var("UEFI") && get_var("SECUREBOOT")) {
         loadtest "installation/secure_boot";
@@ -681,6 +680,7 @@ sub load_inst_tests {
     }
     if (installyaststep_is_applicable()) {
         loadtest "installation/installation_overview";
+        loadtest "installation/disable_grub_timeout";
         if (check_var('VIDEOMODE', 'text') && check_var('BACKEND', 'ipmi')) {
             loadtest "installation/disable_grub_graphics";
         }

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -25,7 +25,7 @@ sub run {
 
     if (check_var('VIDEOMODE', 'text')) {
         # Select section booting on Installation Settings overview on text mode
-        send_key 'alt-c';
+        send_key $cmd{change};
         assert_screen 'inst-overview-options';
         wait_screen_change { send_key 'alt-b'; };
     }
@@ -37,21 +37,24 @@ sub run {
     }
 
     # Select bootloader options tab
-    # older sle version use 'alt-t;
-    my $shortcut = 'alt-r';
+    $cmd{bootloader} = 'alt-r';    # Value for most products
     if (check_var('DISTRI', 'sle')) {
         if (!sle_version_at_least('12-SP2')) {
-            $shortcut = 'alt-t';
+            $cmd{bootloader} = 'alt-t';    # SLE-12 GA & SLE-SP1 use 'alt-t
         }
     }
-    # openSUSE all supported distributions use 'alt-r'
-    wait_screen_change { send_key $shortcut; };
-
+    elsif (!is_tumbleweed) {
+        $cmd{bootloader} = 'alt-l';        #openSUSE LEAP uses 'alt-l'
+    }
+    wait_screen_change { send_key $cmd{bootloader}; };
     assert_screen 'installation-bootloader-options';
 
     # Select Timeout dropdown box and disable
     send_key 'alt-t';
-    type_string "-1";
+    my $timeout = "-1";
+    # SLE-12 GA only accepts positive integers in range [0,300]
+    $timeout = "60" if !(sle_version_at_least('12-SP1'));
+    type_string $timeout;
 
     # ncurses uses blocking modal dialog, so press return is needed
     send_key 'ret' if check_var('VIDEOMODE', 'text');


### PR DESCRIPTION
Fixed several issues for other products:
- Test included in more test scenarios.
- **SLE 12 GA**: Fixed problem related with the range accepted for Timeout [0,300]. Instead of -1, for this product version is typed 60 seconds.
- **SLE 12 SP1**: missing needles.
- **Opensuse Leap**: different shortcut to access tab & corresponding needles.

## Ticket 
https://progress.opensuse.org/issues/25658
## Needles
[openSUSE](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/280)
[SLE](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/534)
## Verification run
* [SLE 12 GA](http://10.100.51.227/tests/169#step/disable_grub_timeout/8)
* [SLE 12 SP1](http://10.100.51.227/tests/168#step/disable_grub_timeout/8)
* [LEAP text](http://10.100.51.227/tests/164#step/disable_grub_timeout/4) & [LEAP graphic](http://10.100.51.227/tests/165#step/disable_grub_timeout/7)
