### PR TITLE
Fix disable_grub_timeout shortcut and change_desktop behavior with 'default' SYSTEM_ROLE

### DIFF
--- a/tests/installation/change_desktop.pm
+++ b/tests/installation/change_desktop.pm
@@ -47,7 +47,7 @@ sub change_desktop {
     }
     send_key_until_needlematch 'patterns-list-selected', 'tab', 10;
 
-    if (get_var('SYSTEM_ROLE')) {
+    if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default')) {
         assert_screen "desktop-unselected";
     }
     else {

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -39,8 +39,8 @@ sub run {
     # Select bootloader options tab
     $cmd{bootloader} = 'alt-r';    # Value for most products
     if (check_var('DISTRI', 'sle')) {
-        if (!sle_version_at_least('12-SP2')) {
-            $cmd{bootloader} = 'alt-t';    # SLE-12 GA & SLE-SP1 use 'alt-t
+        if (!sle_version_at_least('12-SP2') || sle_version_at_least('15')) {
+            $cmd{bootloader} = 'alt-t';    # SLE-12 GA & SLE-SP1 & SLE15 use 'alt-t
         }
     }
     elsif (!is_tumbleweed) {


### PR DESCRIPTION
disable_grub_timeout:     Shortcut is alt-t on SLE15

change_desktop:  After changes in main.pm for sle, we define SYSTEM_ROLE as default and  expect no desktop selected in patterns, which is not true.

[Verification run](http://g226.suse.de/tests/2313#)
