### PR TITLE
Fix potential premature evaluation of 'default_desktop'

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -164,13 +164,10 @@ sub cleanup_needles {
     }
 }
 
-diag('default desktop: ' . default_desktop);
-
 # SLE specific variables
 set_var('NOAUTOLOGIN', 1);
 set_var('HASLICENSE',  1);
 set_var('SLE_PRODUCT', get_var('SLE_PRODUCT', 'sles'));
-set_var('DESKTOP',     get_var('DESKTOP', default_desktop));
 # Always register against SCC if SLE 15
 if (sle_version_at_least('15')) {
     set_var('SCC_REGISTER', get_var('SCC_REGISTER', 'installation'));
@@ -178,7 +175,10 @@ if (sle_version_at_least('15')) {
     set_var('SYSTEM_ROLE', get_var('SYSTEM_ROLE', check_var('SCC_REGISTER', 'installation') ? 'default' : 'minimal'));
     # in the 'minimal' system role we can not execute many test modules
     set_var('INSTALLONLY', get_var('INSTALLONLY', check_var('SYSTEM_ROLE', 'minimal')));
-
+}
+diag('default desktop: ' . default_desktop);
+set_var('DESKTOP', get_var('DESKTOP', default_desktop));
+if (sle_version_at_least('15')) {
     if (check_var('ARCH', 's390x') and get_var('DESKTOP', '') =~ /gnome|minimalx/) {
         diag 'BUG: bsc#1058071 - No VNC server available in SUT, disabling X11 tests. Re-enable after bug is fixed';
         set_var('DESKTOP', 'textmode');
@@ -377,6 +377,7 @@ logcurrentenv(
       NOINSTALL UPGRADE USBBOOT ZDUP ZDUPREPOS TEXTMODE
       DISTRI NOAUTOLOGIN QEMUCPU QEMUCPUS RAIDLEVEL ENCRYPT INSTLANG
       QEMUVGA DOCRUN UEFI DVD GNOME KDE ISO ISO_MAXSIZE NETBOOT USEIMAGES
+      SYSTEM_ROLE SCC_REGISTER
       SLE_PRODUCT SPLITUSR VIDEOMODE)
 );
 


### PR DESCRIPTION
It should be safer to evaluate the default desktop after we update the system
role.

See https://openqa.suse.de/tests/1223816

Evaluated test schedule:

```
22:14:15.7358 19389 default desktop: gnome
22:14:15.7359 19389 usingenv DESKTOP=gnome
22:14:15.7359 19389 usingenv TEXTMODE=1
22:14:15.7359 19389 usingenv DISTRI=sle
22:14:15.7360 19389 usingenv NOAUTOLOGIN=1
22:14:15.7360 19389 usingenv QEMUCPU=qemu64
22:14:15.7360 19389 usingenv QEMUCPUS=1
22:14:15.7360 19389 usingenv INSTLANG=en_US
22:14:15.7360 19389 usingenv QEMUVGA=cirrus
22:14:15.7360 19389 usingenv DVD=1
22:14:15.7360 19389 usingenv GNOME=1
22:14:15.7360 19389 usingenv ISO=/var/lib/openqa/pool/18/SLE-15-Installer-DVD-x86_64-Build305.1-Media1.iso
22:14:15.7361 19389 usingenv ISO_MAXSIZE=4700372992
22:14:15.7361 19389 usingenv SYSTEM_ROLE=default
22:14:15.7361 19389 usingenv SCC_REGISTER=installation
22:14:15.7361 19389 usingenv SLE_PRODUCT=sles
22:14:15.7645 19389 scheduling isosize tests/installation/isosize.pm
22:14:15.7653 19389 scheduling bootloader tests/installation/bootloader.pm
22:14:15.7667 19389 scheduling welcome tests/installation/welcome.pm
22:14:15.7673 19389 scheduling accept_license tests/installation/accept_license.pm
22:14:15.7678 19389 scheduling scc_registration tests/installation/scc_registration.pm
22:14:15.7692 19389 scheduling addon_products_sle tests/installation/addon_products_sle.pm
22:14:15.7699 19389 scheduling system_role tests/installation/system_role.pm
22:14:15.7704 19389 scheduling partitioning tests/installation/partitioning.pm
22:14:15.7709 19389 scheduling partitioning_filesystem tests/installation/partitioning_filesystem.pm
22:14:15.7713 19389 scheduling partitioning_finish tests/installation/partitioning_finish.pm
22:14:15.7719 19389 scheduling releasenotes tests/installation/releasenotes.pm
22:14:15.7724 19389 scheduling installer_timezone tests/installation/installer_timezone.pm
22:14:15.7729 19389 scheduling hostname_inst tests/installation/hostname_inst.pm
22:14:15.7733 19389 scheduling logpackages tests/installation/logpackages.pm
22:14:15.7741 19389 scheduling user_settings tests/installation/user_settings.pm
22:14:15.7745 19389 scheduling user_settings_root tests/installation/user_settings_root.pm
22:14:15.7751 19389 scheduling installation_overview tests/installation/installation_overview.pm
22:14:15.7758 19389 scheduling disable_grub_timeout tests/installation/disable_grub_timeout.pm
22:14:15.7765 19389 scheduling start_install tests/installation/start_install.pm
22:14:15.7780 19389 scheduling install_and_reboot tests/installation/install_and_reboot.pm
22:14:15.7788 19389 scheduling grub_test tests/installation/grub_test.pm
22:14:15.7794 19389 scheduling first_boot tests/installation/first_boot.pm
```