### PR TITLE
Soft-fail if aplay doesn't match expected record

### DIFF
--- a/tests/console/aplay.pm
+++ b/tests/console/aplay.pm
@@ -1,15 +1,14 @@
 # SUSE's openQA tests
 #
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Rework the tests layout.
-# G-Maintainer: Alberto Planas <aplanas@suse.com>
+# Summary: Test audio using aplay.
+# Maintainer: Rodion Iafarov <aplanas@suse.com>
 
 use base "consoletest";
 use testapi;
@@ -41,7 +40,11 @@ EOS
 
     start_audiocapture;
     assert_script_run("aplay ~/data/1d5d9dD.wav");
-    assert_recorded_sound('DTMF-159D');
+    # aplay is extremely unstable due to bsc#1048271, we don't want to invest
+    # time in rerunning it, if it fails, so instead of assert, simply soft-fail
+    unless (check_recorded_sound 'DTMF-159D') {
+        record_soft_failure 'bsc#1048271';
+    }
 }
 
 1;


### PR DESCRIPTION
We have unstable aplay test, which fails due to the bsc#1048271 once in
a while. We cannot work it around with needles, as pattern is different
event if match level is 60%. In order to soft-fail this test module, we
introduce check_recorded_sound method, which doesn't fail the test, but
returns match result.

See [poo#26860](https://progress.opensuse.org/issues/26860).
Please, do not merge unless https://github.com/os-autoinst/os-autoinst/pull/873 is merged and deployed on osd and o3, as requires new method.

Verification run with failing scenario: http://g226.suse.de/tests/10#