### PR TITLE
New hotkey for SLE-15

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -13,9 +13,9 @@
 
 use strict;
 use warnings;
-use base "y2logsstep";
+use base 'y2logsstep';
 use testapi;
-use utils 'is_storage_ng';
+use utils qw(is_storage_ng sle_version_at_least);
 use partition_setup 'wipe_existing_partitions';
 
 # add a new primary partition
@@ -100,7 +100,12 @@ sub addraid {
 
 sub setraidlevel {
     my ($level) = @_;
-    my %entry = (0 => 0, 1 => 1, 5 => 5, 6 => 6, 10 => 'g');
+    my %entry = (
+        0  => 0,
+        1  => 1,
+        5  => 5,
+        6  => 6,
+        10 => (sle_version_at_least('15') ? 'o' : 'g'));
     wait_screen_change { send_key "alt-$entry{$level}"; };
 
     wait_screen_change { send_key "alt-i"; };    # move to RAID name input field


### PR DESCRIPTION
## Observation

The hotkey for SLE-15 assigned to RAID 10 is **o**

- Seen on RAID0 Test: https://openqa.suse.de/tests/1224762#step/partitioning_raid/187
- Seen on RAID10 Test: https://openqa.suse.de/tests/1225408#step/partitioning_raid/191

On the others version is still **g**

- Seen on Leap 42.3 https://openqa.opensuse.org/tests/451709#step/partitioning_raid/133
- Seen on Leap 15 https://openqa.opensuse.org/tests/507775#step/partitioning_raid/292
- Seen on Tumbleweed https://openqa.opensuse.org/tests/506983#step/partitioning_raid/145
- Seen on SLE 12-SP3 https://openqa.suse.de/tests/1058279#step/partitioning_raid/133


## Verification run

- <del>http://copland.arch.suse.de/tests/1590#step/partitioning_raid/221</del> (outdated)


## Needles

- https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/538


## Ticket

- https://progress.opensuse.org/issues/25496