### PR TITLE
Add regurl as SCC_URL in boot_from_pxe.pm

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -15,6 +15,7 @@ use warnings;
 use File::Basename;
 use base "opensusebasetest";
 use testapi;
+use registration;
 
 sub run {
     if (check_var('BACKEND', 'ipmi')) {
@@ -84,6 +85,8 @@ sub run {
     if (!(check_var('BACKEND', 'ipmi') && get_var('AUTOYAST'))) {
         type_string "console=tty ", $type_speed;
     }
+
+    type_string registration_bootloader_cmdline if check_var('SCC_REGISTER', 'installation');
 
     save_screenshot;
     assert_screen 'qa-net-typed';


### PR DESCRIPTION
For physical machine pxe installation, by default scc url is the official one, scc.suse.com, however for sle15, it is not updated for every daily build, so need to use proxy scc instead.

Verification link:
http://10.67.18.220/tests/415#step/boot_from_pxe/5

From the job, it is verified that scc registration used proxy scc, and module selection is successful, also system_role can be shown completely which is not in official scc. 
However I did not manage to see full installation pass, because it needs too much extra effort to make all other test files pass (new needle or bug), which will be handled separately.