### PR TITLE
Fix boot to snapshot after introduction of disable_grub_timeout

### DIFF
--- a/tests/installation/boot_into_snapshot.pm
+++ b/tests/installation/boot_into_snapshot.pm
@@ -21,6 +21,7 @@ use testapi;
 use base "opensusebasetest";
 
 sub run {
+    my ($self) = @_;
     assert_screen 'linux-login', 200;
     select_console 'root-console';
     # 1)
@@ -48,6 +49,7 @@ sub run {
     assert_script_run('snapper --iso list | tail -n 1 | grep \'|\s*|\s*|\s*$\'', fail_message => 'last snapshot should not be cleaned up but is not-important');
     script_run("systemctl reboot", 0);
     reset_consoles;
+    $self->wait_boot;
 }
 
 sub test_flags {


### PR DESCRIPTION
- first_boot failed because the test disable_grub_timeout before
  disabled timeout for boot:
  https://openqa.opensuse.org/tests/508146#step/first_boot
- see poo#26898 for more details
- add wait_boot at end of boot_into_snapshot.pm to make sure
  linux login appears for sure.
-  reference test: http://e13.suse.de/tests/4464