### PR TITLE
Fix disable_grub_timeout with consistent "assert_screen" and "send_key_until_needle_match" for all cases (all products, modes, etc.)

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -296,8 +296,7 @@ sub is_tumbleweed {
 sub is_leap {
     # Leap and its stagings
     return 0 unless check_var('DISTRI', 'opensuse');
-    return 1 if get_var('VERSION', '') =~ /(?:[4-9][0-9]|[0-9]{3,})\.[0-9]/;
-    return get_var('VERSION') =~ /^42:S/;
+    return 1 if get_var('VERSION', '') =~ /[0-9]{2,}\.[0-9]/;
 }
 
 sub is_sle {
@@ -518,10 +517,10 @@ sub leap_version_at_least {
     }
 
     if ($version eq '42.3') {
-        return check_var($version_variable, $version) || leap_version_at_least('15', version_variable => $version_variable);
+        return check_var($version_variable, $version) || leap_version_at_least('15.0', version_variable => $version_variable);
     }
 
-    if ($version eq '15') {
+    if ($version eq '15.0') {
         return check_var($version_variable, $version);
     }
     # Die to point out that function has to be extended
@@ -1393,7 +1392,7 @@ sub get_root_console_tty {
     is running on tty2 by default. see also: bsc#1054782
 =cut
 sub get_x11_console_tty {
-    my $new_gdm = !(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15')) && !is_sle12_hdd_in_upgrade && !is_caasp;
+    my $new_gdm = !(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15.0')) && !is_sle12_hdd_in_upgrade && !is_caasp;
     return (check_var('DESKTOP', 'gnome') && get_var('NOAUTOLOGIN') && $new_gdm) ? 2 : 7;
 }
 

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -284,8 +284,7 @@ sub load_inst_tests {
             loadtest "installation/installation_overview_before";
             loadtest "installation/select_patterns_and_packages";
         }
-        # breaks leap 15 https://progress.opensuse.org/issues/26936
-        #loadtest "installation/disable_grub_timeout";
+        loadtest "installation/disable_grub_timeout";
     }
     if (get_var("UEFI") && get_var("SECUREBOOT")) {
         loadtest "installation/secure_boot";

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -439,7 +439,7 @@ sub load_consoletests {
         loadtest "console/mysql_srv";
         loadtest "console/dns_srv";
         if (!is_staging) {
-            if (is_leap && !leap_version_at_least('15')) {
+            if (is_leap && !leap_version_at_least('15.0')) {
                 loadtest "console/php5";
                 loadtest "console/php5_mysql";
                 loadtest "console/php5_postgresql96";

--- a/tests/console/firewall_enabled.pm
+++ b/tests/console/firewall_enabled.pm
@@ -18,7 +18,7 @@ use testapi;
 use utils;
 
 sub run {
-    if ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15'))) {
+    if ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0'))) {
         if (script_run('firewallctl state')) {
             record_soft_failure('bsc#1054977');
         }

--- a/tests/console/pcre.pm
+++ b/tests/console/pcre.pm
@@ -24,7 +24,7 @@ sub run {
     assert_script_run "./test_pcrecpp";
     save_screenshot;
 
-    my $php = ((is_leap && !leap_version_at_least('15')) || (is_sle && !sle_version_at_least('15'))) ? 'php5' : 'php7';
+    my $php = ((is_leap && !leap_version_at_least('15')) || (is_sle && !sle_version_at_least('15.0'))) ? 'php5' : 'php7';
     zypper_call("in $php");
     assert_script_run "php simple.php | grep 'matches'";
     save_screenshot;

--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -55,7 +55,7 @@ sub run {
     select_console 'root-console';
 
     # Make sure packages are installed
-    my $firewall_package = ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15'))) ? 'firewalld' : 'SuSEfirewall2';
+    my $firewall_package = ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0'))) ? 'firewalld' : 'SuSEfirewall2';
     zypper_call("in yast2-dns-server bind $firewall_package", timeout => 180);
     # Let's pretend this is the first execution (could not be the case if
     # yast2_cmdline was executed before)

--- a/tests/console/yast2_vnc.pm
+++ b/tests/console/yast2_vnc.pm
@@ -25,7 +25,7 @@ sub run {
     # install components to test plus dependencies for checking
     my $packages = 'vncmanager xorg-x11';
     # netstat is deprecated in newer versions, use 'ss' instead
-    my $use_nettools = (is_sle && !sle_version_at_least('15')) || (is_leap && !leap_version_at_least('15'));
+    my $use_nettools = (is_sle && !sle_version_at_least('15')) || (is_leap && !leap_version_at_least('15.0'));
     $packages .= ' net-tools' if $use_nettools;
     zypper_call("in $packages");
 

--- a/tests/installation/addon_products.pm
+++ b/tests/installation/addon_products.pm
@@ -30,23 +30,24 @@ sub run {
         # FIXME: do the same as sle here
         foreach my $url (split(/\+/, get_var("ADDONURL"))) {
             send_key "alt-a";                       # Add another
-            wait_screen_change { send_key $cmd{xnext} };    # Specify URL (default)
+            send_key $cmd{xnext};                   # Specify URL (default)
+            wait_still_screen(1);
             type_string $url;
             wait_screen_change { send_key $cmd{next} };
-            if (get_var("ADDONURL") !~ m{/update/}) {       # update is already trusted, so would trigger "delete"
+            if (get_var("ADDONURL") !~ m{/update/}) {    # update is already trusted, so would trigger "delete"
                 send_key "alt-i";
                 assert_screen 'import-untrusted-gpg-key-598D0E63B3FD7E48';
-                send_key "alt-t";                           # confirm import (trust) key
+                send_key "alt-t";                        # confirm import (trust) key
             }
         }
         assert_screen 'addon-selection';
-        wait_screen_change { send_key $cmd{next} };         # done
+        wait_screen_change { send_key $cmd{next} };      # done
     }
 
     if (get_var("ADDONS")) {
 
         for my $a (split(/,/, get_var('ADDONS'))) {
-            send_key 'alt-d';                               # DVD
+            send_key 'alt-d';                            # DVD
             send_key $cmd{xnext};
             assert_screen 'dvd-selector';
             send_key_until_needlematch 'addon-dvd-list', 'tab';

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -36,7 +36,7 @@ sub run {
         # Select section booting on Installation Settings overview on text mode
         send_key $cmd{change};
         assert_screen 'inst-overview-options';
-        wait_screen_change { send_key 'alt-b'; };
+        send_key 'alt-b';
     }
     else {
         # Select section booting on Installation Settings overview (video mode)
@@ -44,32 +44,12 @@ sub run {
         assert_screen 'booting-section-selected';
         send_key 'ret';
     }
-
-    save_screenshot;    # needed because shortcuts change with the navigation
-
-    # Select bootloader options tab
-    if ((is_sle && !sle_version_at_least('12-SP2')) || (is_leap && !leap_version_at_least('15.0'))) {
-        $cmd{bootloader} = 'alt-t';    # older versions
-    }
-    elsif (is_leap) {
-        $cmd{bootloader} = 'alt-l';    # leap 15
-    }
-    else {
-        $cmd{bootloader} = check_var('UEFI', '1') ? 'alt-t' : 'alt-r';    # rest except uefi
-    }
-    wait_screen_change { send_key $cmd{bootloader}; };
-    if (!check_screen('installation-bootloader-options', 0)) {
-        record_info('Workaround',
-                'We tried our best but could not find a fitting hotkey to reach the bootloader options. Would have typed \''
-              . $cmd{bootloader}
-              . '\', aborting (see poo#25658)');
-        send_key $cmd{cancel};
-        wait_still_screen(2);
-        send_key 'esc';
-        assert_screen 'installation-settings-overview-loaded';
-        return;
-    }
-
+    assert_screen([qw(inst-bootloader-settings inst-bootloader-settings-first_tab_highlighted)]);
+    # Depending on an optional button "release notes" we need to press "tab"
+    # to go to the first tab
+    send_key 'tab' unless match_has_tag 'inst-bootloader-settings-first_tab_highlighted';
+    send_key_until_needlematch 'inst-bootloader-options-highlighted', 'right';
+    assert_screen 'installation-bootloader-options';
     # Select Timeout dropdown box and disable
     send_key 'alt-t';
     my $timeout = "-1";

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -48,7 +48,7 @@ sub run {
     save_screenshot;    # needed because shortcuts change with the navigation
 
     # Select bootloader options tab
-    if ((is_sle && !sle_version_at_least('12-SP2')) || (is_leap && !leap_version_at_least('15'))) {
+    if ((is_sle && !sle_version_at_least('12-SP2')) || (is_leap && !leap_version_at_least('15.0'))) {
         $cmd{bootloader} = 'alt-t';    # older versions
     }
     elsif (is_leap) {

--- a/tests/x11regressions/gnomecase/application_starts_on_login.pm
+++ b/tests/x11regressions/gnomecase/application_starts_on_login.pm
@@ -41,7 +41,7 @@ sub alter_status_auto_save_session {
     my ($self) = @_;
     $self->start_dconf;
     # Old behavior for non SLE15 or non TW
-    if (!sle_version_at_least('15') && !leap_version_at_least('15')) {
+    if (!sle_version_at_least('15') && !leap_version_at_least('15.0')) {
         send_key_until_needlematch "dconf-org", "down";
         assert_and_click "unfold";
         send_key_until_needlematch "dconf-org-gnome", "down";

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -22,7 +22,7 @@ use utils;
 sub search {
     my ($name) = @_;
     # with the gtk interface we have to click as there is no shortcut
-    if ((is_sle && !sle_version_at_least('15')) || (is_leap && !leap_version_at_least('15'))) {
+    if ((is_sle && !sle_version_at_least('15')) || (is_leap && !leap_version_at_least('15.0'))) {
         assert_screen([qw(yast2_control-center_search_clear yast2_control-center_search)], no_wait => 1);
         if (match_has_tag 'yast2_control-center_search') {
             assert_and_click 'yast2_control-center_search';


### PR DESCRIPTION
This fixes the test module for all currently supported products independant of
any hotkey for enabling the tabs which proved unreliable.

Also ensure bootloader settings page is finished loading with an explicit
assert_screen. Before next keypress we should be explicit and look for a
needle.

This solves problems as observed in
http://lord.arch/tests/7750#step/disable_grub_timeout/3

Verification runs:
* SLE 12 GA GUI 64bit: http://lord.arch/tests/7819
* SLE 12 GA GUI uefi: http://lord.arch/tests/7825
* SLE 12 SP1 textmode: http://lord.arch/tests/7828
* SLE 12 SP1 GUI: http://lord.arch/tests/7813
* SLE 12 SP3 GUI: http://lord.arch/tests/7824
* SLE 12 SP3 GUI SLED: http://lord.arch/tests/7823
* SLE 12 SP3 GUI uefi: http://lord.arch/tests/7814
* SLE 15 textmode: http://lord.arch/tests/7822
* SLE 15 GUI (minimal-x): http://lord.arch/tests/7821
* SLE 15 GUI: http://lord.arch/tests/7820
* openSUSE Leap 42.2 GUI 64bit-2G: http://lord.arch/tests/7831, http://lord.arch/tests/7815
* openSUSE Leap 42.2 textmode 64bit-2G: http://lord.arch/tests/7854
* openSUSE Leap 42.3 GUI 64bit-2G: http://lord.arch/tests/7817
* openSUSE Leap 42.3 textmode 64bit: http://lord.arch/tests/7827
* openSUSE Leap 15.0 textmode 64bit: http://lord.arch/tests/7852
* openSUSE Leap 15.0 GUI staging (minimal-x): http://lord.arch/tests/7835
* openSUSE Leap 15.0 GUI 64bit: http://lord.arch/tests/7833
* openSUSE Leap 15.0 GUI gnome 64bit: http://lord.arch/tests/7847
* openSUSE Tumbleweed textmode 64bit: http://lord.arch/tests/7853
* openSUSE Tumbleweed GUI 64bit: http://lord.arch/tests/7836

Related progress issue: https://progress.opensuse.org/issues/25658

* SLE needles PR: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/541
* openSUSE needles PR: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/282