### PR TITLE
Stabilize yast language module test

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -98,7 +98,7 @@ done", "binaries-with-missing-libraries.txt", {timeout => 60, noupload => 1});
     clear_console;
 
     # rpmverify problems
-    $self->save_and_upload_log("rpmverify -a | grep -v \"[S5T].* c \"", "rpmverify-problems.txt", {timeout => 300, screenshot => 1, noupload => 1});
+    $self->save_and_upload_log("rpmverify -a | grep -v \"[S5T].* c \"", "rpmverify-problems.txt", {timeout => 1200, screenshot => 1, noupload => 1});
     clear_console;
 
     # VMware specific

--- a/lib/y2x11test.pm
+++ b/lib/y2x11test.pm
@@ -18,6 +18,12 @@ sub launch_yast2_module_x11 {
     $module //= '';
     $args{target_match} //= $module ? "yast2-$module-ui" : 'yast2-ui';
     my @tags = ['root-auth-dialog', ref $args{target_match} eq 'ARRAY' ? @{$args{target_match}} : $args{target_match}];
+    # Terminate yast processes which may still run
+    if (get_var('YAST2_GUI_TERMINATE_PREVIOUS_INSTANCES')) {
+        select_console('root-console');
+        script_run('pkill -TERM -e yast2');
+        select_console('x11');
+    }
     x11_start_program("xdg-su -c '/sbin/yast2 $module'", target_match => @tags, match_timeout => $args{match_timeout});
     foreach ($args{target_match}) {
         return if match_has_tag($_);

--- a/tests/yast2_gui/yast2_lang.pm
+++ b/tests/yast2_gui/yast2_lang.pm
@@ -20,7 +20,7 @@ use testapi;
 
 sub run {
     my $self = shift;
-    $self->launch_yast2_module_x11('language', match_timeout => 60);
+    $self->launch_yast2_module_x11('language', match_timeout => 240);
 
     # check language details and change detailed locale setting
     assert_and_click 'yast2-lang_details';
@@ -34,13 +34,13 @@ sub run {
     assert_and_click 'yast2-lang_secondary-language';
     assert_screen 'yast2-lang_settings_done';
 
-    # Now it will install required language packages and exit
-    wait_screen_change { send_key 'alt-o'; };
-
     # Problem here is that sometimes installation takes longer than 10 minutes
     # And then screen saver is activated, so add this step to wake
     my $timeout = 0;
     until (check_screen 'generic-desktop' || ++$timeout > 10) {
+        # Now it will install required language packages and exit
+        # Put in the loop, because sometimes button is not pressed
+        wait_screen_change { send_key 'alt-o'; };
         sleep 60;
         send_key 'ctrl';
     }


### PR DESCRIPTION
On o3 test module fails sporadically as yast gui doesn't show up in
time frame of 60 seconds. Afterwards we also not able to collect logs as
rpm verify fails to execute in time frame of 300 seconds which blocks us
from investigating root cause of the issue.
On top of that we've added code to kill all running yast processes which
may be there from previous test modules and may affect results of the
test.

See details in [poo#26104](https://progress.opensuse.org/issues/26104).

I did many verification runs, so far there was no failure in yast2_lang test module. I will conduct more runs, to be sure that suggested changes will help stabilizing the test module:
http://g226.suse.de/tests/2415#previous
