### PR TITLE
Older versions of Leap&SLE+non-UEFI also have other hotkey

### DIFF
--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -48,14 +48,11 @@ sub run {
     save_screenshot;    # needed because shortcuts change with the navigation
 
     # Select bootloader options tab
-    if ((is_sle && !sle_version_at_least('12-SP2')) || (is_leap && !leap_version_at_least('15'))) {
-        $cmd{bootloader} = 'alt-t';    # older versions
-    }
-    elsif (is_leap) {
+    if (is_leap && check_var('VERSION', '15')) {
         $cmd{bootloader} = 'alt-l';    # leap 15
     }
     else {
-        $cmd{bootloader} = check_var('UEFI', '1') ? 'alt-t' : 'alt-r';    # rest except uefi
+        $cmd{bootloader} = check_var('UEFI', '1') ? 'alt-t' : 'alt-r';    # UEFI or non-UEFI
     }
     wait_screen_change { send_key $cmd{bootloader}; };
     assert_screen 'installation-bootloader-options';


### PR DESCRIPTION
## Ticket

- [poo#12410](https://progress.opensuse.org/issues/12410)

## Verification run

- [copland#1596#step/disable_grub_timeout/7](http://copland.arch.suse.de/tests/1596#step/disable_grub_timeout/7)