### PR TITLE
Remove unnecessary assert_screen and kernel parameter

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -89,7 +89,6 @@ sub run {
     type_string registration_bootloader_cmdline if check_var('SCC_REGISTER', 'installation');
 
     save_screenshot;
-    assert_screen 'qa-net-typed';
     my $e = get_var("EXTRABOOTPARAMS");
     if ($e) {
         type_string "$e ", 4;

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -82,7 +82,7 @@ sub run {
     }
 
     type_string "console=$serialdev,115200 ", $type_speed;    # to get crash dumps as text
-    if (!(check_var('BACKEND', 'ipmi') && get_var('AUTOYAST'))) {
+    if (get_var('AUTOYAST')) {
         type_string "console=tty ", $type_speed;
     }
 

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -99,7 +99,7 @@ sub run {
     save_screenshot;
 
     if (check_var('BACKEND', 'ipmi') && !get_var('AUTOYAST')) {
-        assert_screen 'sshd-server-started', 300;
+        assert_screen((check_var('VIDEOMODE', 'text') ? 'sshd' : 'vnc') . '-server-started', 60 * 3);
         select_console 'installation';
 
         # We have textmode installation via ssh and the default vnc installation so far


### PR DESCRIPTION
The assert_screen on the typed message is just to unstable because
depending on the length of several parameters the text to check can
wrap and therefore will fail. We have to rely on openQA here to type
completely. Besides that, the test will only run on IPMI so we can
remove the check for it which can result in a false-positive if both
variables are False.

**Please note:** this is how it _can_ look like if everything is fixed in this test: http://openqa.glados.qa.suse.de/tests/521
For now this only addresses how this test handles the VNC/SSH installation and will continue to fail (what is already does since months). Besides that, I've to create the "vnc-server-started" needle on OSD because the resolution on my machine is for $reasons different…