### PR TITLE
Alice/use new set var to reload needle

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1240,6 +1240,13 @@ elsif (get_var("XFSTESTS")) {
     }
 }
 elsif (get_var("VIRT_AUTOTEST")) {
+    if (get_var('REPO_0_TO_INSTALL', '')) {
+        #Before host installation starts, swtich to version REPO_0_TO_INSTALL if it is set
+        #Save VERSION TO TARGET_DEVELOPING_VERSION
+        set_var('TARGET_DEVELOPING_VERSION', get_var('VERSION'));
+        #Switch to VERSION_TO_INSTALL
+        set_var('VERSION', get_var('VERSION_TO_INSTALL'));
+    }
     if (get_var("PROXY_MODE")) {
         loadtest "virt_autotest/proxymode_login_proxy";
         loadtest "virt_autotest/proxymode_init_pxe_install";
@@ -1271,6 +1278,10 @@ elsif (get_var("VIRT_AUTOTEST")) {
     elsif (get_var("VIRT_PRJ2_HOST_UPGRADE")) {
         loadtest "virt_autotest/host_upgrade_generate_run_file";
         loadtest "virt_autotest/host_upgrade_step2_run";
+        if (get_var('REPO_0_TO_INSTALL', '')) {
+            #After host upgrade, switch to version TARGET_DEVELOPING_VERSION and reload needles
+            loadtest "virt_autotest/switch_version_and_reload_needle";
+        }
         loadtest "virt_autotest/reboot_and_wait_up_upgrade";
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
             loadtest "virt_autotest/setup_xen_serial_console";

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -89,7 +89,7 @@ sub run {
     assert_screen 'qa-net-typed';
     my $e = get_var("EXTRABOOTPARAMS");
     if ($e) {
-        type_string "$e ", 4;
+        type_string " $e ", 4;
         save_screenshot;
     }
     send_key 'ret';

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -33,14 +33,13 @@ sub login_to_console {
             #send key 'up' to stop grub timer counting down, to be more robust to select xen
             send_key 'up';
             send_key_until_needlematch("virttest-bootmenu-xen-kernel", 'down', 10, 3);
-            send_key 'ret';
         }
     }
     else {
         set_var("reboot_for_upgrade_step", undef);
         set_var("after_upgrade",           "yes");
-        send_key 'ret';
     }
+    send_key 'ret';
 
     assert_screen(['linux-login', 'virttest-displaymanager'], $timeout);
 

--- a/tests/virt_autotest/switch_version_and_reload_needle.pm
+++ b/tests/virt_autotest/switch_version_and_reload_needle.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: This test changes the VERSION to TARGET_DEVELOPING_VERSION and reload needles.
+#          This test should be loaded after host upgrade.
+#          It needs to be wrapped in test because
+#          set_var with reload_needles option needs to be run in test files rather than main.pm,
+# Maintainer: xlai@suse.com
+
+
+use strict;
+use warnings;
+use base "virt_autotest_base";
+use testapi;
+
+sub run {
+    #switch VERSION TO TARGET_DEVELOPING_VERSION
+    set_var('VERSION', get_required_var('TARGET_DEVELOPING_VERSION'), reload_needles => 1);
+}
+
+1;
+

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -27,7 +27,14 @@ use virt_autotest_base;
 our @EXPORT = qw(repl_repo_in_sourcefile);
 
 sub get_version_for_daily_build_guest {
-    my $version = lc(get_var("VERSION"));
+    my $version = '';
+    if (get_var('REPO_0_TO_INSTALL', '')) {
+        $version = get_var('TARGET_DEVELOPING_VERSION', '');
+    }
+    else {
+        $version = get_var("VERSION", '');
+    }
+    $version = lc($version);
     if ($version !~ /sp/m) {
         $version = $version . "-fcs";
     }


### PR DESCRIPTION
Virtualization tests need to switch VERSION inside a single test , and reload needles accordingly. This meant to work cooperatively with the new set_var which provide the capability to reload_needle, see https://progress.opensuse.org/issues/25504.

Verification job link:
http://10.67.18.220/tests/422

Host/guest upgrade tests are not verified yet, because of bug bsc#1058252.