### PR TITLE
Register modules in the right order

### DIFF
--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -34,9 +34,8 @@ sub run {
     assert_script_run "SUSEConnect --url $scc_url -r $reg_code";
 
     # add modules
-
-    foreach (values %registration::SLE15_MODULES) {
-        assert_script_run "SUSEConnect -p sle-module-" . lc($_) . "/$version/$arch";
+    foreach (split(',', $registration::SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')})) {
+        assert_script_run "SUSEConnect -p sle-module-" . lc($registration::SLE15_MODULES{$_}) . "/$version/$arch";
     }
 }
 


### PR DESCRIPTION
There was an issue with code in PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3595 
That the modules in Hash structure are not ordered when registering. This PR tries to fix the issue.
Verification testrun:
http://f146.suse.de/tests/1704
http://f146.suse.de/tests/1705

One parameter will also be changed: DESKTOP=textmode