### PR TITLE
Fix SLE staging job schedule to select 'default' system role

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -172,6 +172,7 @@ set_var('SLE_PRODUCT', get_var('SLE_PRODUCT', 'sles'));
 if (sle_version_at_least('15')) {
     set_var('SCC_REGISTER', get_var('SCC_REGISTER', 'installation'));
     # depending on registration only limited system roles are available
+    set_var('SYSTEM_ROLE', 'default') if (!get_var('SYSTEM_ROLE') && is_staging);
     set_var('SYSTEM_ROLE', get_var('SYSTEM_ROLE', check_var('SCC_REGISTER', 'installation') ? 'default' : 'minimal'));
     # in the 'minimal' system role we can not execute many test modules
     set_var('INSTALLONLY', get_var('INSTALLONLY', check_var('SYSTEM_ROLE', 'minimal')));


### PR DESCRIPTION
Example schedule output:

```
16:08:56.2450 15696 default desktop: gnome
16:08:59.8056 15696 usingenv ADDONURL=base,desktop,serverapp,script
16:08:59.8057 15696 usingenv DESKTOP=gnome
16:08:59.8059 15696 usingenv SYSTEM_ROLE=default
16:08:59.8059 15696 usingenv SCC_REGISTER=never
16:08:59.8059 15696 usingenv SLE_PRODUCT=sles
16:08:59.8312 15696 scheduling bootloader tests/installation/bootloader.pm
16:08:59.8329 15696 scheduling welcome tests/installation/welcome.pm
16:08:59.8339 15696 scheduling accept_license tests/installation/accept_license.pm
16:08:59.8345 15696 scheduling skip_registration tests/installation/skip_registration.pm
16:08:59.8360 15696 scheduling addon_products_sle tests/installation/addon_products_sle.pm
16:08:59.8366 15696 scheduling system_role tests/installation/system_role.pm
…
16:08:59.8460 15696 scheduling first_boot tests/installation/first_boot.pm
16:08:59.8471 15696 scheduling consoletest_setup tests/console/consoletest_setup.pm
…
16:08:59.8590 15696 scheduling consoletest_finish tests/console/consoletest_finish.pm
16:08:59.8598 15696 scheduling xterm tests/x11/xterm.pm
…
16:08:59.8710 15696 scheduling shutdown tests/x11/shutdown.pm
```