### PR TITLE
Fix prepboot fs type selection

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -111,7 +111,10 @@ sub addpart {
     }
     if ($args{fsid}) {                            # $args{fsid} will describe needle tag below
         send_key 'alt-i';                         # select File system ID
-        send_key_until_needlematch "partition-selected-$args{fsid}-type", 'down';
+
+        # Due to bsc#1062465 cannot go from top to bottom on storage-ng
+        send_key 'end';
+        send_key_until_needlematch "partition-selected-$args{fsid}-type", 'up';
     }
     if ($args{mount}) {
         send_key 'alt-m';
@@ -122,7 +125,7 @@ sub addpart {
         assert_screen 'partition-lvm-encrypt';
         send_key $cmd{next};
         assert_screen 'partition-lvm-password-prompt';
-        send_key 'alt-e';                         # select password field
+        send_key 'alt-e';    # select password field
         type_password;
         send_key 'tab';
         type_password;


### PR DESCRIPTION
The initial problem is that we go through the list from default postiion
and not from the top or either bottom, so prep boot fs type could not be
selected. Another issue is with fs types which miss id and installer
crashes, to work this issue around we go from the bottom of the list and
not from the top.

See [poo#25460](https://progress.opensuse.org/issues/25460).
Please, merge [NEEDLES](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/545). 
[Verification run](http://gershwin.arch.suse.de/tests/64#step/partitioning_warnings/28), be aware that this run is on x86_64 worker, where we've triggered same behavior as on ppc64le.
