### PR TITLE
Add suport for arch !x86_64

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -438,6 +438,7 @@ sub load_consoletests {
         loadtest "console/mysql_srv";
         loadtest "console/dns_srv";
         if (!is_staging) {
+            loadtest "console/mysql_odbc";
             if (is_leap && !leap_version_at_least('15.0')) {
                 loadtest "console/php5";
                 loadtest "console/php5_mysql";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -847,9 +847,12 @@ sub load_consoletests {
         }
         loadtest "console/http_srv";
         loadtest "console/mysql_srv";
+        if (sle_version_at_least('12-SP2') && (!is_staging)) {    # MyODBC-unixODBC not available on < SP2
+            loadtest "console/mysql_odbc";
+        }
         loadtest "console/dns_srv";
         loadtest "console/postgresql96server";
-        if (sle_version_at_least('12-SP1')) {    # shibboleth-sp not available on SLES 12 GA
+        if (sle_version_at_least('12-SP1')) {                     # shibboleth-sp not available on SLES 12 GA
             loadtest "console/shibboleth";
         }
         if (get_var('ADDONS', '') =~ /wsm/ || get_var('SCC_ADDONS', '') =~ /wsm/) {

--- a/tests/console/mysql_odbc.pm
+++ b/tests/console/mysql_odbc.pm
@@ -38,8 +38,8 @@ sub setup {
     # write odbcinst.ini
     assert_script_run "echo [myodbc_mysql] > /etc/unixODBC/odbcinst.ini";
     assert_script_run "echo Description=ODBC for MySQL >> /etc/unixODBC/odbcinst.ini";
-    assert_script_run "echo Driver=/usr/lib64/libmyodbc5.so >> /etc/unixODBC/odbcinst.ini";
-    assert_script_run "echo Setup=/usr/lib64/unixODBC/libodbcmyS.so >> /etc/unixODBC/odbcinst.ini";
+    assert_script_run 'echo Driver=$(rpm --eval "%_libdir")/libmyodbc5.so >> /etc/unixODBC/odbcinst.ini';
+    assert_script_run 'echo Setup=$(rpm --eval "%_libdir")/libodbcmyS.so >> /etc/unixODBC/odbcinst.ini';
     assert_script_run "echo UsageCount=2 >> /etc/unixODBC/odbcinst.ini";
 
     # create the 'odbcTEST' database with table 'test' and insert one element


### PR DESCRIPTION
Add workaround on mysql_odbc.pm to check arch and set lib dir during setup

Add workaround on main.pm to run test only if not staging and distro (sles) is newer than
sles12sp2

Tests could be seen on (might be unavailable sometimes):
http://miurasan.ddns.net/tests/598 (sles12-sp2 x86_64)
http://miurasan.ddns.net/tests/601 (tumbleweed i586)
http://miurasan.ddns.net/tests/601 (tumbleweed x86_64)

Fixes poo#13170

Shibboleth comment changed only because of warnings from tidy