### PR TITLE
Get rid of 'scripting' module; only enable last module; workaround for reboot_gnome; enable productivity module for SLED

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -49,8 +49,8 @@ our %SLE15_MODULES = (
 # are not preselected, to crosscheck or just recreate automatic selections
 # manually
 our %SLE15_DEFAULT_MODULES = (
-    sles => 'base,script,desktop,serverapp',
-    sled => 'base,script,desktop'
+    sles => 'base,desktop,serverapp',
+    sled => 'base,desktop'
 );
 
 sub fill_in_registration_data {

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -37,12 +37,13 @@ our @EXPORT = qw(
 # We already have needles with names which are different we would use here
 # As it's only workaround, better not to create another set of needles.
 our %SLE15_MODULES = (
-    base      => 'Basesystem',
-    sdk       => 'Development-Tools',
-    desktop   => 'Desktop-Applications',
-    legacy    => 'Legacy',
-    script    => 'Scripting',
-    serverapp => 'Server-Applications'
+    base         => 'Basesystem',
+    sdk          => 'Development-Tools',
+    desktop      => 'Desktop-Applications',
+    productivity => 'Desktop-Productivity',
+    legacy       => 'Legacy',
+    script       => 'Scripting',
+    serverapp    => 'Server-Applications'
 );
 
 # The expected modules of a default installation per product. Use them if they
@@ -50,7 +51,7 @@ our %SLE15_MODULES = (
 # manually
 our %SLE15_DEFAULT_MODULES = (
     sles => 'base,desktop,serverapp',
-    sled => 'base,desktop'
+    sled => 'base,desktop,productivity'
 );
 
 sub fill_in_registration_data {

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -195,6 +195,7 @@ sub fill_in_registration_data {
                     assert_and_click "scc-module-$addon";
                 }
             }
+            save_screenshot;
             # go back and forward, checked checkboxes have to remember state poo#17840
             if (check_var('SCC_REGISTER', 'yast')) {
                 wait_screen_change { send_key 'alt-b' };

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -137,8 +137,8 @@ sub fill_in_registration_data {
         }
         if (match_has_tag 'bsc#1056413') {
             record_soft_failure('bsc#1056413');
-            # Add expected modules to select them manually, as not preselected
-            my $addons = $SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')} . (get_var('SCC_ADDONS') ? ',' . get_var('SCC_ADDONS') : '');
+            # Activate the last of the expected modules to select them manually, as not preselected but at least dependencies are handled
+            my $addons = (split(/,/, $SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')}))[-1] . (get_var('SCC_ADDONS') ? ',' . get_var('SCC_ADDONS') : '');
             set_var('SCC_ADDONS', $addons);
         }
     }

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -608,20 +608,25 @@ sub reboot_x11 {
         record_soft_failure 'poo#19082' if ($repetitions > 0);
 
         if (get_var("SHUTDOWN_NEEDS_AUTH")) {
-            assert_screen 'reboot-auth';
-            wait_still_screen(3);                                               # 981299#c41
-            type_string $testapi::password, max_interval => 5;
-            wait_still_screen(3);                                               # 981299#c41
-            wait_screen_change {
-                # Extra assert_and_click (with right click) to check the correct number of characters is typed and open up the 'show text' option
-                assert_and_click 'reboot-auth-typed', 'right';
-            };
-            wait_screen_change {
-                # Click the 'Show Text' Option to enable the display of the typed text
-                assert_and_click 'reboot-auth-showtext';
-            };
-            # Check the password is correct
-            assert_screen 'reboot-auth-correct-password';
+            if (check_screen('shutdown-auth', 15)) {
+                wait_still_screen(3);                                           # 981299#c41
+                type_string $testapi::password, max_interval => 5;
+                wait_still_screen(3);                                           # 981299#c41
+                wait_screen_change {
+                    # Extra assert_and_click (with right click) to check the correct number of characters is typed and open up the 'show text' option
+                    assert_and_click 'reboot-auth-typed', 'right';
+                };
+                wait_screen_change {
+                    # Click the 'Show Text' Option to enable the display of the typed text
+                    assert_and_click 'reboot-auth-showtext';
+                };
+                # Check the password is correct
+                assert_screen 'reboot-auth-correct-password';
+            }
+            else {
+                record_soft_failure 'bsc#1062788';
+            }
+
             # we need to kill ssh for iucvconn here,
             # because after pressing return, the system is down
             prepare_system_reboot;


### PR DESCRIPTION
* lib/registration: Do not unneeded SLE 15 module "scripting"
* lib/registration: Adapt SLE15 module enablement to automatic requirement resolution
* lib/registration: Ensure the last enable module is also shown in screenshot
* Add workaround in reboot_x11 for bsc#1062788