### PR TITLE
yast2_firewall: Bump timeout in zypper_call

### DIFF
--- a/tests/yast2_gui/yast2_firewall.pm
+++ b/tests/yast2_gui/yast2_firewall.pm
@@ -21,7 +21,7 @@ sub run {
     my $self = shift;
 
     select_console 'root-console';
-    zypper_call('in yast2-http-server apache2 apache2-prefork');
+    zypper_call('in yast2-http-server apache2 apache2-prefork', timeout => 300);
     select_console 'x11', await_console => 0;
 
     $self->launch_yast2_module_x11('firewall', match_timeout => 60);


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/25634