### PR TITLE
Fix the system role selection to stay "default" for all-packages-iso

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -164,6 +164,10 @@ sub cleanup_needles {
     }
 }
 
+sub is_desktop_module_available {
+    return check_var('SCC_REGISTER', 'installation') || check_var_array('ADDONS', 'all-packages') || check_var_array('WORKAROUND_MODULES', 'desktop');
+}
+
 # SLE specific variables
 set_var('NOAUTOLOGIN', 1);
 set_var('HASLICENSE',  1);
@@ -172,8 +176,7 @@ set_var('SLE_PRODUCT', get_var('SLE_PRODUCT', 'sles'));
 if (sle_version_at_least('15')) {
     set_var('SCC_REGISTER', get_var('SCC_REGISTER', 'installation'));
     # depending on registration only limited system roles are available
-    set_var('SYSTEM_ROLE', 'default') if (!get_var('SYSTEM_ROLE') && is_staging);
-    set_var('SYSTEM_ROLE', get_var('SYSTEM_ROLE', check_var('SCC_REGISTER', 'installation') ? 'default' : 'minimal'));
+    set_var('SYSTEM_ROLE', get_var('SYSTEM_ROLE', is_desktop_module_available() ? 'default' : 'minimal'));
     # in the 'minimal' system role we can not execute many test modules
     set_var('INSTALLONLY', get_var('INSTALLONLY', check_var('SYSTEM_ROLE', 'minimal')));
 }


### PR DESCRIPTION
Previously we already set back the system role to stay "default" for the
staging tests by checking for "is_staging" explicitly. Instead what we should
do is check for the desktop module being available when we either registered
or we use the "all-packages" addon value or we supply the "desktop" module
over "WORKAROUND_MODULES".

Schedule output:

* all-packages-iso:

```
08:20:18.0060 13195 default desktop: gnome
08:20:18.0061 13195 usingenv DESKTOP=gnome
08:20:18.0064 13195 usingenv SYSTEM_ROLE=default
08:20:18.0065 13195 usingenv SCC_REGISTER=
08:20:18.0065 13195 usingenv SLE_PRODUCT=sles
08:20:18.0309 13195 scheduling isosize tests/installation/isosize.pm
08:20:18.0317 13195 scheduling bootloader tests/installation/bootloader.pm
08:20:18.0336 13195 scheduling welcome tests/installation/welcome.pm
08:20:18.0345 13195 scheduling accept_license tests/installation/accept_license.pm
08:20:18.0350 13195 scheduling skip_registration tests/installation/skip_registration.pm
08:20:18.0365 13195 scheduling addon_products_sle tests/installation/addon_products_sle.pm
08:20:18.0371 13195 scheduling system_role tests/installation/system_role.pm
08:20:18.0376 13195 scheduling partitioning tests/installation/partitioning.pm
08:20:18.0380 13195 scheduling partitioning_finish tests/installation/partitioning_finish.pm
08:20:18.0387 13195 scheduling releasenotes tests/installation/releasenotes.pm
08:20:18.0392 13195 scheduling installer_timezone tests/installation/installer_timezone.pm
08:20:18.0397 13195 scheduling logpackages tests/installation/logpackages.pm
08:20:18.0404 13195 scheduling user_settings tests/installation/user_settings.pm
08:20:18.0408 13195 scheduling user_settings_root tests/installation/user_settings_root.pm
08:20:18.0416 13195 scheduling installation_overview tests/installation/installation_overview.pm
08:20:18.0422 13195 scheduling disable_grub_timeout tests/installation/disable_grub_timeout.pm
08:20:18.0429 13195 scheduling start_install tests/installation/start_install.pm
08:20:18.0444 13195 scheduling install_and_reboot tests/installation/install_and_reboot.pm
08:20:18.0452 13195 scheduling grub_test tests/installation/grub_test.pm
08:20:18.0459 13195 scheduling first_boot tests/installation/first_boot.pm
08:20:18.0469 13195 scheduling consoletest_setup tests/console/consoletest_setup.pm
…
08:20:18.0604 13195 scheduling consoletest_finish tests/console/consoletest_finish.pm
08:20:18.0612 13195 scheduling xterm tests/x11/xterm.pm
…
08:20:18.0734 13195 scheduling shutdown tests/x11/shutdown.pm
```

I crosschecked the schedules of other scenarios as well, e.g. "staging",
"unregistered", "registered" as well as explicit change of "DESKTOP" when the
variable is supplied from outside.

Related progress issue: https://progress.opensuse.org/issues/27002