### PR TITLE
For SLE15 SLED is not a flavor anymore but a product

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -34,7 +34,7 @@ sub is_server {
 }
 
 sub is_desktop {
-    return get_var('FLAVOR', '') =~ /^Desktop/;
+    return get_var('FLAVOR', '') =~ /^Desktop/ || check_var('SLE_PRODUCT', 'sled');
 }
 
 sub is_leanos {


### PR DESCRIPTION
This will fix the wrong expectation about a shutdown authentication dialog on
SLED 15.

Related progress issue: https://progress.opensuse.org/issues/25992