### PR TITLE
PostgreSQL workaround for bsc#1060639 & List extensions in SUSEConnect

### DIFF
--- a/tests/console/postgresql96server.pm
+++ b/tests/console/postgresql96server.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Postgres tests for SLE12
-# Maintainer:  Ondřej Súkup <osukup@suse.cz>
+# Maintainer: Ondřej Súkup <osukup@suse.cz>
 
 use base "consoletest";
 use strict;
@@ -27,7 +27,12 @@ sub run {
 
     # check the status
     assert_script_run 'systemctl show -p ActiveState postgresql.service | grep ActiveState=active';
-    assert_script_run 'systemctl show -p SubState postgresql.service | grep SubState=running';
+    if (is_sle && sle_version_at_least('15')) {
+        record_soft_failure 'Workaround for bsc#1060639: postgresql96 server service exits with "active (exited)"';
+    }
+    else {
+        assert_script_run 'systemctl show -p SubState postgresql.service | grep SubState=running';
+    }
 
     # test basic functionality of postgresql
     setup_pgsqldb;

--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -36,6 +36,7 @@ sub run {
 
     select_console 'root-console';
     assert_script_run "SUSEConnect --url $scc_url -r $reg_code";
+    assert_script_run 'SUSEConnect --list-extensions';
 
     # add modules
     foreach (split(',', $registration::SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')} . $scc_addons)) {


### PR DESCRIPTION
@yxususe I added one command to list extensions, so we know what we are presented with: http://assam.suse.cz/tests/700#step/suseconnect_scc/4
@SergioAtSUSE I added PostgreSQL workaround http://assam.suse.cz/tests/700#step/postgresql96server/9 about which you are talking about in bsc#1060639. I actually think 1-2 weeks is a long enough time for such a workaround to be of value.