### PR TITLE
Fix s390x jobs stuck in shutdown until openQA job times out

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -496,7 +496,8 @@ sub load_x11regression_remote {
 }
 
 sub load_boot_tests {
-    if (get_var("ISO_MAXSIZE")) {
+    # s390x uses only remote repos
+    if (get_var("ISO_MAXSIZE") && !check_var('ARCH', 's390x')) {
         loadtest "installation/isosize";
     }
     if ((get_var("UEFI") || is_jeos()) && !check_var("BACKEND", "svirt")) {

--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -169,7 +169,7 @@ sub run {
         select_console 'installation';
     }
 
-    prepare_system_reboot if (check_var('ARCH', 's390x') || check_var('BACKEND', 'ipmi'));
+    prepare_system_shutdown;
 
     wait_screen_change {
         send_key 'alt-o';    # Reboot

--- a/tests/installation/reconnect_s390.pm
+++ b/tests/installation/reconnect_s390.pm
@@ -14,7 +14,7 @@
 use base "installbasetest";
 
 use testapi;
-use utils qw(is_sle sle_version_at_least);
+use utils;
 
 use strict;
 use warnings;
@@ -44,11 +44,6 @@ sub run {
 
     # different behaviour for z/VM and z/KVM
     if (check_var('BACKEND', 's390x')) {
-
-        # kill serial ssh connection (if it exists)
-        eval { console('iucvconn')->kill_ssh unless get_var('BOOT_EXISTING_S390', ''); };
-        diag('ignoring already shut down console') if ($@);
-
         my $r;
         eval { $r = console('x3270')->expect_3270(output_delim => $login_ready, timeout => 300); };
         if ($@) {

--- a/tests/qam-minimal/install_patterns.pm
+++ b/tests/qam-minimal/install_patterns.pm
@@ -61,7 +61,7 @@ sub run {
     my $patch_status = is_patch_needed($patch, 1);
     install_packages($patch_status) if $patch_status;
 
-    prepare_system_reboot;
+    prepare_system_shutdown;
     type_string "reboot\n";
     $self->wait_boot;
 }

--- a/tests/qam-minimal/install_update.pm
+++ b/tests/qam-minimal/install_update.pm
@@ -56,7 +56,7 @@ sub run {
 
         capture_state('between', 1);
 
-        prepare_system_reboot;
+        prepare_system_shutdown;
         type_string "reboot\n";
         $self->wait_boot;
     }

--- a/tests/qam-minimal/update_minimal.pm
+++ b/tests/qam-minimal/update_minimal.pm
@@ -38,7 +38,7 @@ sub run {
     fully_patch_system;
     capture_state('after', 1);
 
-    prepare_system_reboot;
+    prepare_system_shutdown;
     type_string "reboot\n";
     $self->wait_boot;
 }

--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -15,6 +15,7 @@ use strict;
 use warnings;
 use testapi;
 use login_console;
+use utils;
 use base "proxymode";
 
 sub reboot_and_wait_up {
@@ -31,7 +32,7 @@ sub reboot_and_wait_up {
         set_var('SERIALDEV', '');
         $serialdev = 'ttyS1';
         bmwqemu::save_vars();
-        console('root-ssh')->kill_ssh;
+        prepare_system_shutdown;
         console('sol')->disable;
         # do the activation manually - the sol can be anything normally
         select_console 'sol', await_console => 0;


### PR DESCRIPTION
Whenever the SUT is expected to disappear we need to ensure the remote
connections are terminated in before to prevent the test to be stuck.

With this change also renaming `prepare_system_reboot` to
`prepare_system_shutdown` as that is a more generic term (reboot = shutdown +
boot). Also it helps with abstraction to call `prepare_system_shutdown`
unconditionally as the method takes care internally to call appropriate
actions which may be backend specific. For the normal qemu case the function
is a no-op anyway.

Verification run: http://lord.arch/tests/7905

Related progress issue: https://progress.opensuse.org/issues/26886