### PR TITLE
Do not look for non-existing productivity release notes

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -53,7 +53,7 @@ sub run {
 
     # No release-notes for basic modules on SLE 15
     if (sle_version_at_least('15') && check_var('DISTRI', 'sle')) {
-        push @no_relnotes, qw(base script desktop serverapp legacy sdk);
+        push @no_relnotes, qw(base script desktop productivity serverapp legacy sdk);
     }
 
     # no relnotes for ltss in QAM_MINIMAL


### PR DESCRIPTION
See https://openqa.suse.de/tests/1236483#step/releasenotes/10

Related progress issue: https://progress.opensuse.org/issues/26952