### PR TITLE
disable_grub_timeout: Make sure the overview page is reached again at end

### DIFF
--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -64,6 +64,7 @@ sub run {
     wait_still_screen(1);
     save_screenshot;
     send_key $cmd{ok};
+    assert_screen 'installation-settings-overview-loaded';
 }
 
 1;


### PR DESCRIPTION
This should fix the many failures we see in 'start_install' which immediately
presses 'alt-i' as soon as the test module starts. As 'disable_grub_timeout'
is the one immediately before and it just presses 'alt-o' to exit the
bootloader configuration but does not check for the next screen the subsequent
'alt-i' most likely gets lost.

Related progress issue: https://progress.opensuse.org/issues/26866