### PR TITLE
Fix autoyast installation for disabling grub timeout

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -213,10 +213,13 @@ sub run {
     check_screen \@needles, $check_time;
     until (match_has_tag 'reboot-after-installation') {
         #Verify timeout and continue if there was a match
-        next unless verify_timeout_and_check_screen(($timer += $check_time), [qw(reboot-after-installation autoyast-postinstall-error)]);
+        next unless verify_timeout_and_check_screen(($timer += $check_time), [qw(reboot-after-installation autoyast-postinstall-error autoyast-boot)]);
         if (match_has_tag('autoyast-postinstall-error')) {
             $self->handle_expected_errors(iteration => $i);
             $num_errors++;
+        }
+        elsif (match_has_tag('autoyast-boot')) {
+            send_key 'ret';    # grub timeout is disable, so press any key is needed to pass the grub
         }
     }
 


### PR DESCRIPTION
## Progress ticket
https://progress.opensuse.org/issues/26978
## Running verification
http://10.100.51.227/tests/263#step/installation/9

## Comments
Including 'ret' key in both stages should solve the issue.

bootloader is not included as exit condition of any of both stages in the test, as we want to end the test with gnome desktop.
Problem with hitting 'ret' only on first stage present in [previous pull request](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3795) seen in [this job](https://openqa.opensuse.org/tests/513659#step/installation/14):
 - Local machine: only works on local because is going faster and does not match bios needle and instead it matches the bootloader needle, in turn hitting 'ret' and going to stage 2 and finds the desktop successfully.
 - Prod: on production matches bios first and exists first stage without possibility to hit 'ret' in second stage.