### PR TITLE
Fix tests to run extra tests on s390x

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -522,8 +522,8 @@ sub load_extra_tests {
         loadtest "console/zypper_info";
         loadtest "console/update_alternatives";
         # start extra console tests from here
-        # Audio device is not supported on ppc64le, JeOS, and Xen PV
-        if (!get_var("OFW") && !is_jeos && !check_var('VIRSH_VMM_FAMILY', 'xen')) {
+        # Audio device is not supported on ppc64le, s390x, JeOS, and Xen PV
+        if (!get_var("OFW") && !is_jeos && !check_var('VIRSH_VMM_FAMILY', 'xen') && ! check_var('ARCH', 's390x')) {
             loadtest "console/aplay";
         }
         loadtest "console/command_not_found";

--- a/tests/console/openvswitch.pm
+++ b/tests/console/openvswitch.pm
@@ -27,7 +27,7 @@ use utils;
 sub run {
     select_console 'root-console';
 
-    zypper_call('in openvswitch-switch iputils', timeout => 200);
+    zypper_call('in openvswitch-switch iputils', timeout => 300);
 
     # Start the openvswitch daemon
     assert_script_run "systemctl start openvswitch", 200;


### PR DESCRIPTION
In order to enable extra tests on s390x we have introduced changes in
infrastructure, whereas there were 2 issues which are test problems.
aplay fails as there is no sound card available, hence we should not
test it. openvswitch installation took longer than timeout, but tests
works normally.
Note: vnc is not available after installation on s390x, hence no x11
tests will succeed.

See [poo#13216](https://progress.opensuse.org/issues/13216) for details.
[Verification run](http://g226.suse.de/tests/2483#). Fails due to [bsc#1064686](https://bugzilla.suse.com/show_bug.cgi?id=1064686).