### PR TITLE
Fix autoyast_reboot due to disable timeout

### DIFF
--- a/tests/autoyast/autoyast_reboot.pm
+++ b/tests/autoyast/autoyast_reboot.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2016 SUSE LLC
+# Copyright (C) 2015-2017 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -29,9 +29,6 @@ sub run {
 
     if (check_var("BOOTFROM", "d")) {
         assert_screen("inst-bootmenu", 60);
-    }
-    else {
-        assert_screen 'grub2';
     }
 }
 


### PR DESCRIPTION
## Progress ticket
https://progress.opensuse.org/issues/26978
## Verification run
http://10.100.51.227/tests/266#
## Needles
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/283

Issue seen in my local machine after fixing autoyast_installation test: [previous build](http://10.100.51.227/tests/265#step/autoyast_reboot/5)