### PR TITLE
Fix is_caasp for Tumbleweed

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -284,6 +284,9 @@ sub is_caasp {
         return get_var('FLAVOR') !~ /DVD/;    # If not DVD it's VMX
     }
     elsif ($filter =~ /^\d\.\d\+?$/) {
+        # If we use '+' it means "this or newer", which includes tumbleweed
+        return ($filter =~ /\+$/) if check_var('VERSION', 'Tumbleweed');
+
         die "Unsupported version" if get_var('VERSION') !~ /^\d\.\d?$/;
         if ($filter =~ /\+$/) {
             chop $filter;


### PR DESCRIPTION
Local run: http://dhcp91.suse.cz/tests/7240
Fix for: https://openqa.opensuse.org/tests/513780#step/oci_keyboard/2