### PR TITLE
Workaround yast2 gui gtk issue because of bsc#1062733

### DIFF
--- a/lib/y2x11test.pm
+++ b/lib/y2x11test.pm
@@ -1,7 +1,7 @@
 package y2x11test;
 use base "opensusebasetest";
 use strict;
-
+use utils;
 use testapi;
 
 =head2 launch_yast2_module_x11
@@ -24,7 +24,12 @@ sub launch_yast2_module_x11 {
         script_run('pkill -TERM -e yast2');
         select_console('x11');
     }
-    x11_start_program("xdg-su -c '/sbin/yast2 $module'", target_match => @tags, match_timeout => $args{match_timeout});
+    my $yast2_args = '';
+    if (is_sle && sle_version_at_least('15')) {
+        record_soft_failure 'bsc#1062733';
+        $yast2_args = '--qt';
+    }
+    x11_start_program("xdg-su -c '/sbin/yast2 $yast2_args $module'", target_match => @tags, match_timeout => $args{match_timeout});
     foreach ($args{target_match}) {
         return if match_has_tag($_);
     }


### PR DESCRIPTION
- add yast2_args --qt in /lib/y2x11test.pm to ensure that
   yast2 can be started up in qt gui
- reference test:
   http://e13.suse.de/tests/4481#step/yast2_control_center
- see poo#27046 for more details