### PR TITLE
Install yast2 sound module explicitly on sle 15

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -270,6 +270,10 @@ sub start_printer {
 
 sub run {
     my $self = shift;
+    if (is_sle && sle_version_at_least '15') {
+        #see bsc#1062331, sound is not added to the yast2 pattern
+        ensure_installed('in yast2-sound');
+    }
     $self->launch_yast2_module_x11('', target_match => 'yast2-control-center-ui', match_timeout => 180);
 
     # search module by typing string


### PR DESCRIPTION
It was decided that on SLE15 sound yast2 module won't be installed.
See [bsc#1062331](https://bugzilla.suse.com/show_bug.cgi?id=1062331).

[Verification run](http://g226.suse.de/tests/2498#).

Note: problems with needles for interface should be solved by: [PR#3818](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3818)