### PR TITLE
sles4sap: Add support for SLES4SAP-15 (user settings, registration)

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -83,8 +83,8 @@ sub set_defaults_for_username_and_password {
         $testapi::password = '';
     }
     else {
-        if (get_var('FLAVOR', '') =~ /SAP/) {
-            $testapi::username = "root";    #in sles4sap only root user created
+        if (get_var('FLAVOR', '') =~ /SAP/ and !sle_version_at_least('15')) {
+            $testapi::username = "root";    #in sles4sap only root user created (before SLE-15)
         }
         else {
             $testapi::username = "bernhard";

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -50,8 +50,9 @@ our %SLE15_MODULES = (
 # are not preselected, to crosscheck or just recreate automatic selections
 # manually
 our %SLE15_DEFAULT_MODULES = (
-    sles => 'base,desktop,serverapp',
-    sled => 'base,desktop,productivity'
+    sles     => 'base,desktop,serverapp',
+    sled     => 'base,desktop,productivity'
+    sles4sap => 'base,desktop,serverapp,ha,sapapp',
 );
 
 sub fill_in_registration_data {

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -51,7 +51,7 @@ our %SLE15_MODULES = (
 # manually
 our %SLE15_DEFAULT_MODULES = (
     sles     => 'base,desktop,serverapp',
-    sled     => 'base,desktop,productivity'
+    sled     => 'base,desktop,productivity',
     sles4sap => 'base,desktop,serverapp,ha,sapapp',
 );
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -44,7 +44,7 @@ sub is_leanos {
 }
 
 sub is_sles4sap {
-    return get_var('FLAVOR', '') =~ /SAP/;
+    return get_var('FLAVOR', '') =~ /SAP/ || check_var('SLE_PRODUCT', 'sles4sap');
 }
 
 sub is_sles4sap_standard {
@@ -584,7 +584,7 @@ sub load_inst_tests {
         loadtest "installation/skip_registration" unless check_var('SLE_PRODUCT', 'leanos');
     }
     if (is_sles4sap) {
-        loadtest "installation/sles4sap_product_installation_mode";
+        loadtest "installation/sles4sap_product_installation_mode" unless sle_version_at_least('15');
     }
     if (get_var('MAINT_TEST_REPO')) {
         loadtest 'installation/add_update_test_repo';
@@ -666,7 +666,7 @@ sub load_inst_tests {
             loadtest "installation/logpackages";
         }
         if (is_sles4sap()) {
-            if (check_var("SLES4SAP_MODE", 'sles')) {
+            if (check_var("SLES4SAP_MODE", 'sles') or sle_version_at_least('15')) {
                 loadtest "installation/user_settings";
             }    # sles4sap wizard installation doesn't have user_settings step
         }
@@ -948,9 +948,9 @@ sub load_x11tests {
     }
     loadtest "x11/desktop_mainmenu";
     if (is_sles4sap() and !is_sles4sap_standard()) {
+        loadtest "sles4sap/patterns";
         loadtest "sles4sap/sapconf";
         loadtest "sles4sap/saptune";
-        loadtest "sles4sap/patterns";
         if (get_var('NW')) {
             loadtest "sles4sap/nw_ascs_install" if (get_var('SLES4SAP_MODE') !~ /wizard/);
             loadtest "sles4sap/netweaver_ascs";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -583,8 +583,8 @@ sub load_inst_tests {
     else {
         loadtest "installation/skip_registration" unless check_var('SLE_PRODUCT', 'leanos');
     }
-    if (is_sles4sap) {
-        loadtest "installation/sles4sap_product_installation_mode" unless sle_version_at_least('15');
+    if (is_sles4sap and !sle_version_at_least('15')) {
+        loadtest "installation/sles4sap_product_installation_mode";
     }
     if (get_var('MAINT_TEST_REPO')) {
         loadtest 'installation/add_update_test_repo';

--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -49,7 +49,7 @@ sub run {
     }
 
     # no release-notes for WE and all modules
-    my @no_relnotes = qw(we lgm asmm certm contm pcm tcm wsm hpcm ids idu phub all-packages);
+    my @no_relnotes = qw(we lgm asmm certm contm pcm tcm wsm hpcm ids idu phub all-packages sapapp);
 
     # No release-notes for basic modules on SLE 15
     if (sle_version_at_least('15') && check_var('DISTRI', 'sle')) {


### PR DESCRIPTION
- Added user_settings for SLES4SAP-15 so that tests can be performed with an unprivileged user as in SLES.
- Removed installation/sles4sap_product_installation_mode for SLES4SAP-15.
- Changed order of SLES4SAP tests so patterns are tested first