### PR TITLE
Fix installation grub test ppc64le

### DIFF
--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -59,6 +59,10 @@ sub run {
     }
 
     if (get_var("STORAGE_NG") && get_var("ENCRYPT")) {
+        # bootloader timeout is disable so hit 'ret' is needed
+        assert_screen 'grub2';
+        send_key 'ret';
+
         my @tags = ();
         for (my $disk = 0; $disk < get_var("NUMDISKS", 1); $disk++) {
             push @tags, "grub-encrypted-disk$disk-password-prompt";


### PR DESCRIPTION
### Progress ticket
https://progress.opensuse.org/issues/25376

### Comments
Before searching for needles related with the passphrase, we can assert grub2 screen and hit **ret** key due to now grub timeout is disabled.

[Last occurence of this issue in openQA](https://openqa.suse.de/tests/1235830?distri=sle&version=15&flavor=Installer-DVD&arch=ppc64le&machine=ppc64le&test=cryptlvm&limit_previous=400#step/grub_test/3)