### PR TITLE
Put assert_screen before $cmd{install}

### DIFF
--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -85,7 +85,8 @@ sub run {
         assert_screen("inst-packageinstallationstarted", $started_timeout);
     }
     else {
-        sleep 2;    # textmode is sometimes pressing alt-i too early
+        # We need to wait for the Installer to get ready
+        assert_screen 'installation-settings-overview-loaded';
         send_key $cmd{install};
         wait_screen_change { send_key 'alt-o' } if match_has_tag('inst-overview-error-found', 0);
         while (check_screen([qw(confirmlicense startinstall)], 5)) {


### PR DESCRIPTION
On slow systems it may happen that 'alt-i' won't get to YaST at the
right time, because screen is still refreshing (atm after
grub changes).

Fails here: http://assam.suse.cz/tests/722#step/start_install/3
Passes here: http://assam.suse.cz/tests/724#step/start_install/1