### PR TITLE
Resolve conflict between libjpeg62-devel and libjpeg8-devel

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -156,6 +156,8 @@ sub problem_can_be_skipped {
     return 1 if $pkg =~ /^wxWidgets-3_0-nostl-devel/;
     # conflicts with split devel packages from ffmpeg (3)
     return 1 if $pkg =~ /^ffmpeg2-devel/;
+    # conflicts with libjpeg62-devel
+    return 1 if $pkg =~ /^libjpeg8-devel/;
 
     return;
 }


### PR DESCRIPTION
Fixes https://openqa.opensuse.org/tests/514750#step/install_packages/9

```
+++ PROBLEMS: +++
package libjpeg8-devel-8.0.2-36.13.x86_64 conflicts with namespace:otherproviders(libjpeg-devel) provided by libjpeg62-devel-62.1.0-36.1.x86_64
  + solution
    - do not ask to install libjpeg8-devel-8.0.2-36.13.x86_64
PCBS 'libjpeg8-devel-8.0.2-36.13.x86_64': 'package libjpeg8-devel-8.0.2-36.13.x86_64 conflicts with namespace:otherproviders(libjpeg-devel) provided by libjpeg62-devel-62.1.0-36.1.x86_64'
  + solution
    - do not ask to install libjpeg62-devel-62.1.0-36.1.x86_64
PCBS 'libjpeg62-devel-62.1.0-36.1.x86_64': 'package libjpeg8-devel-8.0.2-36.13.x86_64 conflicts with namespace:otherproviders(libjpeg-devel) provided by libjpeg62-devel-62.1.0-36.1.x86_64'
package libjpeg8-devel-32bit-8.0.2-36.13.x86_64 conflicts with jpeg-devel-32bit provided by libjpeg62-devel-32bit-62.1.0-36.1.x86_64
  + solution
    - do not ask to install libjpeg8-devel-32bit-8.0.2-36.13.x86_64
PCBS 'libjpeg8-devel-32bit-8.0.2-36.13.x86_64': 'package libjpeg8-devel-32bit-8.0.2-36.13.x86_64 conflicts with jpeg-devel-32bit provided by libjpeg62-devel-32bit-62.1.0-36.1.x86_64'
  + solution
    - do not ask to install libjpeg62-devel-32bit-62.1.0-36.1.x86_64
PCBS 'libjpeg62-devel-32bit-62.1.0-36.1.x86_64': 'package libjpeg8-devel-32bit-8.0.2-36.13.x86_64 conflicts with jpeg-devel-32bit provided by libjpeg62-devel-32bit-62.1.0-36.1.x86_64'

```

Local fix verification:

`data/lsmfip --verbose libjpeg62-turbo libjpeg-turbo libjpeg62 libjpeg62-devel libjpeg62-32bit libjpeg8-32bit libjpeg8-devel libturbojpeg0-32bit libjpeg62-devel-32bit libjpeg8 libturbojpeg0 libjpeg8-devel-32bit`