### PR TITLE
Virtualization: three fixes about xen console/regurl/QA repo

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -44,7 +44,7 @@ sub get_dom0_serialdev {
     my $dom0_serialdev;
 
     script_run("clear");
-    script_run("cat ${root_dir}/etc/SuSE-release");
+    script_run("cat ${root_dir}/etc/SuSE-release || cat ${root_dir}/etc/os-release");
     save_screenshot;
     assert_screen([qw(on_host_sles_12_sp2_or_above on_host_lower_than_sles_12_sp2)]);
 

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -86,7 +86,9 @@ sub run {
         type_string "console=tty ", $type_speed;
     }
 
-    type_string registration_bootloader_cmdline if check_var('SCC_REGISTER', 'installation');
+    if (check_var('SCC_REGISTER', 'installation') && !(check_var('VIRT_AUTOTEST', 1) && check_var('INSTALL_TO_OTHERS', 1))) {
+        type_string registration_bootloader_cmdline;
+    }
 
     save_screenshot;
     my $e = get_var("EXTRABOOTPARAMS");

--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -17,13 +17,15 @@ use testapi;
 
 sub install_package {
     my $qa_server_repo = get_var('QA_HEAD_REPO', '');
-    if ($qa_server_repo) {
-        script_run "zypper --non-interactive rr server-repo";
-        assert_script_run("zypper --non-interactive --no-gpg-check -n ar -f '$qa_server_repo' server-repo");
+    if ($qa_server_repo eq '') {
+        #default repo according to version if not set from testsuite
+        $qa_server_repo = 'http://dist.nue.suse.com/ibs/QA:/Head/SLE-' . get_var('VERSION');
+        set_var('QA_HEAD_REPO', $qa_server_repo);
+        bmwqemu::save_vars();
     }
-    else {
-        die "There is no qa server repo defined variable QA_HEAD_REPO\n";
-    }
+    script_run "zypper --non-interactive rr server-repo";
+    assert_script_run("zypper --non-interactive --no-gpg-check -n ar -f '$qa_server_repo' server-repo");
+
     #workaround for dependency on xmlstarlet for qa_lib_virtauto on sles11sp4 and sles12sp1
     my $repo_0_to_install = get_var("REPO_0_TO_INSTALL", '');
     my $dependency_repo = '';


### PR DESCRIPTION
From the latest build 321.5 virtualization result, tests fail mainly for three reasons, so add fixes separately.
1 sle15 xen host installation failed at serial console setting
 solution:
     check /etc/os-release when /etc/SuSE-release is fully  deprecated
2 sle15 installer medium has no QA repo setting, which we require
 solution:
   set QA repo according to VERSION inside script
3 regurl and regsec does not fit to non-sle15 installation and make repo refresh fail
 solution:
  do not add regurl when boot from pxe for non-sle15 product(11sp4/12sp1/2/3 host installation), which is the original way in sle12sp3 release testing
  update repo are added inside scripts and do upgrade accordingly, which is already implemented in our test script

Verification job:
verify solution 1:
http://10.67.18.220/tests/458
verify solution 2:
http://10.67.18.220/tests/449#step/install_package/3
verify solution 3
http://10.67.18.220/tests/448