### PR TITLE
Incerase timeout for installation of kernel debuginfo package

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -18,7 +18,7 @@ our @EXPORT = qw(install_kernel_debuginfo prepare_for_kdump activate_kdump kdump
 
 sub install_kernel_debuginfo {
     assert_script_run 'zypper ref', 300;
-    zypper_call('-v in $(rpmquery kernel-default | sed "s/kernel-default/kernel-default-debuginfo/")');
+    zypper_call('-v in $(rpmquery kernel-default | sed "s/kernel-default/kernel-default-debuginfo/")', timeout => 1400);
 }
 
 sub prepare_for_kdump_sle {


### PR DESCRIPTION
Kernel debuginfo has over 0.5GB (packed), so on saturated network can
take very long time to download and install it