### PR TITLE
Uncheck option hide beta version

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -134,6 +134,10 @@ sub fill_in_registration_data {
             check_screen($modules_needle, 5);
         }
         else {
+            if (check_var('BETA', '1')) {
+                assert_screen('hide-beta-version-selected');
+                send_key('alt-i');
+            }
             assert_screen($modules_needle);
         }
         if (match_has_tag 'bsc#1056413') {


### PR DESCRIPTION
## Description

Since beta, the modules are hidden by default.

- related ticket: https://progress.opensuse.org/issues/27082
- needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/551
- verification run: http://copland.arch.suse.de/tests/1628#step/scc_registration/8