### PR TITLE
[WIP] bootloader DRY

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -105,8 +105,9 @@ sub pre_bootmenu_setup {
     }
 
     if (get_var("BOOT_HDD_IMAGE")) {
-        assert_screen "grub2", 15;    # Use the same bootloader needle as in grub-test
-        send_key "ret";               # boot from hd
+        wait_for_boot_menu(bootloader_time => 15);
+        # boot default selection, assumed to be first HDD entry
+        send_key 'ret';
         return 3;
     }
     return 0;

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -362,21 +362,17 @@ sub wait_boot {
         # because of broken firmware, bootindex doesn't work on aarch64 bsc#1022064
         push @tags, 'inst-bootmenu' if ((get_var('USBBOOT') and get_var('UEFI')) || (check_var('ARCH', 'aarch64') and get_var('UEFI')) || get_var('OFW'));
         $self->handle_uefi_boot_disk_workaround if (get_var('MACHINE') =~ qr'aarch64' && get_var('BOOT_HDD_IMAGE') && !$in_grub);
-        check_screen(\@tags, $bootloader_time);
+        assert_screen(\@tags, $bootloader_time);
         if (match_has_tag("bootloader-shim-import-prompt")) {
             send_key "down";
             send_key "ret";
-            assert_screen "grub2", 15;
-        }
-        elsif (match_has_tag("migration-source-system-grub2") or match_has_tag('grub2')) {
-            send_key "ret";    # boot to source system
+            assert_screen 'grub2', 15;
         }
         elsif (get_var("LIVETEST")) {
             # prevent if one day booting livesystem is not the first entry of the boot list
             if (!match_has_tag("boot-live-" . get_var("DESKTOP"))) {
                 send_key_until_needlematch("boot-live-" . get_var("DESKTOP"), 'down', 10, 5);
             }
-            send_key "ret";
         }
         elsif (match_has_tag('inst-bootmenu')) {
             # assuming the cursor is on 'installation' by default and 'boot from
@@ -384,18 +380,9 @@ sub wait_boot {
             send_key_until_needlematch 'inst-bootmenu-boot-harddisk', 'up';
             boot_local_disk;
             assert_screen 'grub2', 15;
-            # confirm default choice
-            send_key 'ret';
         }
-        elsif (match_has_tag('encrypted-disk-password-prompt')) {
-            # unlock encrypted disk before grub
-            workaround_type_encrypted_passphrase;
-            assert_screen "grub2", 15;
-        }
-        elsif (!match_has_tag("grub2")) {
-            # check_screen timeout
-            die "needle 'grub2' not found";
-        }
+        # confirm default choice
+        send_key 'ret';
     }
 
     # On Xen we have to re-connect to serial line as Xen closed it after restart

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -409,6 +409,8 @@ sub wait_for_boot_menu {
         reset_consoles;
         $self->{in_wait_boot} = 0;
     }
+    # prevent grub2 timeout; 'esc' would be cleaner, but grub2-efi falls to the menu then
+    send_key 'up';
 }
 
 =head2 wait_boot

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -204,8 +204,7 @@ sub assert_gui_app {
 
 sub select_kernel {
     my $kernel = shift;
-
-    assert_screen ['grub2', "grub2-$kernel-selected"], 100;
+    wait_for_boot_menu(bootloader_time => 100);
     if (match_has_tag "grub2-$kernel-selected") {    # if requested kernel is selected continue
         send_key 'ret';
     }

--- a/tests/boot/grub_test_snapshot.pm
+++ b/tests/boot/grub_test_snapshot.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -9,7 +9,7 @@
 # without any warranty.
 
 # Summary: Select 'snapshot' boot option from grub menu
-# Maintainer: dmaiocchi <dmaiocchi@suse.com>
+# Maintainer: okurz <okurz@suse.de>
 
 use strict;
 use base "basetest";
@@ -20,8 +20,7 @@ sub run {
     select_console 'root-console';
     type_string "reboot\n";
     reset_consoles;
-    assert_screen 'grub2', 200;
-    stop_grub_timeout;
+    $self->wait_for_boot_menu(bootloader_time => 200);
     boot_into_snapshot;
 }
 sub test_flags {

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -43,12 +43,7 @@ sub run {
 
     # aarch64 firmware 'tianocore' can take longer to load
     my $bootloader_timeout = check_var('ARCH', 'aarch64') ? 30 : 15;
-    assert_screen([qw(bootloader-shim-import-prompt bootloader-grub2)], $bootloader_timeout);
-    if (match_has_tag("bootloader-shim-import-prompt")) {
-        send_key "down";
-        send_key "ret";
-        assert_screen "bootloader-grub2", $bootloader_timeout;
-    }
+    $self->wait_for_boot_menu(bootloader_time => $bootloader_timeout);
     if (get_var("QEMUVGA") && get_var("QEMUVGA") ne "cirrus") {
         sleep 5;
     }

--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -71,8 +71,7 @@ sub run {
     }
     workaround_type_encrypted_passphrase;
     # 60 due to rare slowness e.g. multipath poo#11908
-    assert_screen "grub2", 60;
-    stop_grub_timeout;
+    $self->wait_for_boot_menu(bootloader_time => 60);
 
     # BSC#997263 - VMware screen resolution defaults to 800x600
     # By default VMware starts with Grub2 in 640x480 mode and then boots the system to

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -27,6 +27,8 @@ sub login_to_console {
 
     # Wait for bootload for the first time.
     assert_screen([qw(grub2 grub1)], 420);
+    # boot default entry
+    send_key 'ret';
 
     if (!get_var("reboot_for_upgrade_step")) {
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {

--- a/tests/virt_autotest/proxymode_login_proxy.pm
+++ b/tests/virt_autotest/proxymode_login_proxy.pm
@@ -19,8 +19,8 @@ use testapi;
 sub run {
     assert_screen "bootloader";
     send_key "ret";
-    assert_screen "grub2", 10;
-    send_key "ret";
+    $self->wait_for_boot_menu(bootloader_time => 10);
+    send_key 'ret';
     assert_screen "displaymanager", 300;
     select_console('root-console');
 }

--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -53,11 +53,7 @@ sub run {
     # C'l'ose  the snapper module
     send_key "alt-l";
     type_string "reboot\n";
-
-    $self->handle_uefi_boot_disk_workaround() if get_var('MACHINE') =~ qr'aarch64';
-    assert_screen "grub2";
-    send_key 'up';
-
+    $self->wait_for_boot_menu(bootloader_time => 90);
     send_key_until_needlematch("boot-menu-snapshot", 'down', 10, 5);
     send_key 'ret';
 


### PR DESCRIPTION
* Use 'wait_for_boot_menu' instead of custom grub2 handling
* wait_for_boot_menu: Make sure we stop the grub timeout explicitly every time
* wait_boot: Extract wait_for_boot_menu helper
* wait_boot: Simplify the initial bootloader check with assert_screen