### PR TITLE
Virtualization: fix guest installation tool selection

### DIFF
--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -18,11 +18,11 @@ use testapi;
 sub get_script_run {
     my $prd_version = script_output("cat /etc/issue");
     my $pre_test_cmd;
-    if ($prd_version =~ m/SUSE Linux Enterprise Server 12/) {
-        $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-virt_install_withopt-run";
+    if ($prd_version =~ m/SUSE Linux Enterprise Server 11/) {
+        $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-standalone-run";
     }
     else {
-        $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-standalone-run";
+        $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-virt_install_withopt-run";
     }
 
     my $guest_pattern = get_var('GUEST_PATTERN', 'sles-12-sp2-64-[p|f]v-def-net');


### PR DESCRIPTION
Guest installation run file chooses virtualization tool to do guest installation. There is a bug for sle15 product tool selection, which should use virt-install, but it uses vm-install. So change code to that only sle11 use vm-install.others use virt-install.