### PR TITLE
Remove unnecessary kernel parameter

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -82,9 +82,6 @@ sub run {
     }
 
     type_string "console=$serialdev,115200 ", $type_speed;    # to get crash dumps as text
-    if (get_var('AUTOYAST')) {
-        type_string "console=tty ", $type_speed;
-    }
 
     if (check_var('SCC_REGISTER', 'installation') && !(check_var('VIRT_AUTOTEST', 1) && check_var('INSTALL_TO_OTHERS', 1))) {
         type_string registration_bootloader_cmdline;


### PR DESCRIPTION
Follow up of f75f53aaffc986b248764f31b158206f503a739c; I mixed up the logical statement here which results in typing console=tty if the variable AUTOYAST is set. This results in a broken test for virtualization:
https://openqa.suse.de/tests/1238337#step/boot_from_pxe/6

https://openqa.suse.de/tests/1226759#step/boot_from_pxe/7 is how it looked before f75f53aaffc986b248764f31b158206f503a739c (and with this PR merged).

Long story, short: With `console=tty` set we lose Serial-Over-Lan output from linuxrc/yast. This output is mandatory to see if the VNC-server/SSH-server got started. Since there is no known case where we actually need `console=tty`, @alice-suse and me decided to remove this statement completely to fix virtualization tests as well as SLE functional ones.

Excerpt from IRC:
```
> 09:34 <xlai> nsinger: morning!
> 09:35 <xlai> nsinger: I saw you made a commit to openqa test code, i do not quite understand what it fixes. 
> 09:35 <xlai> commit f75f53aaffc986b248764f31b158206f503a739c
> 09:35 <xlai> Author: Nick Singer <nsinger@suse.de>
> 09:35 <xlai> Date:   Mon Oct 23 09:11:14 2017 +0200
> 09:35 <xlai>     Remove problematic kernel parameter
> 09:35 <xlai>     
> 09:35 <xlai>     This test will only run on IPMI and fails there if you add console=tty
> 09:35 <xlai>     because then the installer renders eventual error messages on a tty
> 09:35 <xlai>     which is not visible over SOL.
> 09:37 <xlai> The orginal logic is if    it is ipmi test and with autoyast, then do not type "console=tty" . Because if types, sol will not get installation process and return to openqa. But with your commit, of course it fails , see https://openqa.suse.de/tests/1238337
> 09:37 <c4y> openQA: sle-15-Installer-DVD-x86_64-Build321.5-gi-guest_developing-on-
> 09:39 <xlai> nsinger, can you explain a little more what you want to fix and then i can make a fix and not block what you originally wnat to fix
> 09:51 <nsinger> xlai: interesting that your test fails now. This commit fixed https://openqa.suse.de/tests/1236127#step/boot_from_pxe/6  which never saw the "your vnc is now running" message
> 09:52 <xlai> nsinger: for all ipmi tests, we do not use vnc in installation
> 09:53 <xlai> nsinger: ipmi tests installation is based on textmode
> 09:55 <xlai> nsinger, sorry, I should say all ipmi textmode tests , rather ipmi tests
> 09:56 <nsinger> xlai: true but also in textmode we swallow this message if console=tty. Just compare: https://openqa.suse.de/tests/1226913 (just the journal) to https://openqa.suse.de/tests/1236188#step/boot_from_pxe/6 (<- here the real yast message is showing)
> 10:00 <nsinger> xlai: your previous if-statement always added "console=tty" if AUTOYAST!=1 because boot_from_pxe only runs on hosts with BACKEND=ipmi
> 10:01 <xlai> nsinger, No, the original code does not add that for autoyast ipmi test
> 10:01 <nsinger> xlai: let's ask you the other way around. Do you have _any_ usecase for console=tty in your tests? If not, we should just remove it completey (the whole statement)
> 10:03 <xlai> nsinger: this is the autoyast installation job that original pass without typing "console=tty", https://openqa.suse.de/tests/1226759#step/boot_from_pxe/7
> 10:04 <xlai> nsinger, it seems all our virtualization test works fine without console=tty, but i do not know how other groups
> 10:10 <nsinger> xlai: then i'd say the proper fix is to remove that if-statement completely
> 10:12 <xlai> nsinger: I think so, remove typing "console=tty" completely. But how that works for video mode (vnc case) may need to be verified first.
> 10:13 <nsinger> xlai: we already verified it by the two ipmi-tests i intended to fix (see links above)
```