### PR TITLE
[WIP] Fix grub_test for cryptlvm when disable grub timeout

### DIFF
--- a/lib/caasp_controller.pm
+++ b/lib/caasp_controller.pm
@@ -41,8 +41,13 @@ sub test_flags {
 # Controller job is parent. If it fails we need to export deployment logs from child jobs
 # Without this post_fail_hook they would stop with parallel_failed result
 sub post_fail_hook {
+    # Destroy barriers and create mutexes to avoid deadlock
     barrier_destroy "WORKERS_INSTALLED";
+    mutex_create "NODES_ACCEPTED";
+    mutex_create 'VELUM_CONFIGURED';
     mutex_create "CNTRL_FINISHED";
+
+    # Wait for log export from admin node
     mutex_lock "ADMIN_LOGS_EXPORTED", get_admin_job;
 }
 

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -82,9 +82,6 @@ sub run {
     }
 
     type_string "console=$serialdev,115200 ", $type_speed;    # to get crash dumps as text
-    if (get_var('AUTOYAST')) {
-        type_string "console=tty ", $type_speed;
-    }
 
     if (check_var('SCC_REGISTER', 'installation') && !(check_var('VIRT_AUTOTEST', 1) && check_var('INSTALL_TO_OTHERS', 1))) {
         type_string registration_bootloader_cmdline;

--- a/tests/caasp/stack_bootstrap.pm
+++ b/tests/caasp/stack_bootstrap.pm
@@ -30,8 +30,8 @@ sub accept_nodes {
     # Nodes are moved from pending - minus admin & controller
     my $nodes = get_var('STACK_SIZE') - 1;
 
-    # Staging workaround for debugging salt
-    my $timeout = check_var('FLAVOR', 'Staging-B-DVD') ? 5400 : 90;
+    # Workaround for debugging salt
+    my $timeout = check_var('FLAVOR', 'DVD') ? 5400 : 90;
     assert_screen_with_soft_timeout("velum-$nodes-nodes-accepted", timeout => $timeout, soft_timeout => 45, bugref => 'bsc#1046663');
     mutex_create "NODES_ACCEPTED";
 }

--- a/tests/caasp/stack_bootstrap.pm
+++ b/tests/caasp/stack_bootstrap.pm
@@ -29,10 +29,7 @@ sub accept_nodes {
     assert_and_click 'velum-bootstrap-accept-nodes';
     # Nodes are moved from pending - minus admin & controller
     my $nodes = get_var('STACK_SIZE') - 1;
-
-    # Workaround for debugging salt
-    my $timeout = check_var('FLAVOR', 'DVD') ? 5400 : 90;
-    assert_screen_with_soft_timeout("velum-$nodes-nodes-accepted", timeout => $timeout, soft_timeout => 45, bugref => 'bsc#1046663');
+    assert_screen_with_soft_timeout("velum-$nodes-nodes-accepted", timeout => 90, soft_timeout => 45, bugref => 'bsc#1046663');
     mutex_create "NODES_ACCEPTED";
 }
 
@@ -73,7 +70,7 @@ sub bootstrap {
         assert_screen 'velum-confirm-bootstrap';
 
         # External Dashboard FQDN
-        for (1 .. 3) { send_key 'tab'; }
+        for (1 .. 4) { send_key 'tab'; }
         type_string 'admin.openqa.test';
         assert_and_click "velum-bootstrap";
     }

--- a/tests/caasp/stack_configure.pm
+++ b/tests/caasp/stack_configure.pm
@@ -15,6 +15,7 @@ use caasp_controller;
 use caasp 'get_admin_job';
 
 use strict;
+use utils 'is_caasp';
 use testapi;
 use lockapi;
 
@@ -22,9 +23,20 @@ use lockapi;
 sub velum_config {
     assert_screen 'velum-certificates-page';
 
-    # Fill generic settings
+    # Internal Dashboard FQDN/IP is pre-filled
     for (1 .. 4) { send_key 'tab' }
-    type_string "master.openqa.test";
+    if (is_caasp '1.0') {
+        # External Kubernetes API server FQDN
+        type_string "master.openqa.test";
+    }
+    else {
+        # Install Tiller
+        send_key 'tab';
+        send_key 'spc';
+    }
+
+    # Make sure next button is visible
+    send_key 'pgdn';
     assert_and_click "velum-next";
 
     assert_screen 'velum-tips-page';

--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -16,17 +16,15 @@ use strict;
 use testapi;
 use utils;
 
-# test yast2 bootloader functionality
-# https://bugzilla.novell.com/show_bug.cgi?id=610454
-
 sub run {
     select_console 'root-console';
 
-    assert_script_run "zypper -n in yast2-bootloader";    # make sure yast2 bootloader module installed
+    # make sure yast2 bootloader module is installed
+    zypper_call 'in yast2-bootloader';
 
     script_run("yast2 bootloader; echo yast2-bootloader-status-\$? > /dev/$serialdev", 0);
     assert_screen "test-yast2_bootloader-1", 300;
-    send_key "alt-o";                                     # OK => Close
+    send_key "alt-o";    # OK => Close
     assert_screen([qw(yast2_bootloader-missing_package yast2_console-finished)], 200);
     if (match_has_tag('yast2_bootloader-missing_package')) {
         wait_screen_change { send_key 'alt-i'; };

--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -73,11 +73,12 @@ sub run {
             send_key "ret";
         }
     }
-    workaround_type_encrypted_passphrase;
-    # 60 due to rare slowness e.g. multipath poo#11908
-    assert_screen "grub2", 60;
-    stop_grub_timeout;
-
+    else {
+        workaround_type_encrypted_passphrase;
+        # 60 due to rare slowness e.g. multipath poo#11908
+        assert_screen "grub2", 60;
+        stop_grub_timeout;
+    }
     # BSC#997263 - VMware screen resolution defaults to 800x600
     # By default VMware starts with Grub2 in 640x480 mode and then boots the system to
     # 800x600. To avoid that we need to reconfigure Grub's gfxmode and gfxpayload.


### PR DESCRIPTION
Fix grub_test for cryptlvm when disable grub timeout. grub screen was asserted twice, [see this job](https://openqa.suse.de/tests/1239194), so this should help to finish test properly in the desktop and at the same time, not to remove lines enclosed in the "else" statement that probably are used for some other older job.

- Related ticket: https://progress.opensuse.org/issues/25376
