### PR TITLE
Move execution of mysql_odbc to extra_tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -567,6 +567,10 @@ sub load_extra_tests {
         loadtest "console/zypper_moo";
         loadtest "console/gpg";
         loadtest "console/shells";
+        # MyODBC-unixODBC not available on < SP2 and sle 15
+        if (sle_version_at_least('12-SP2') && !(sle_version_at_least('15'))) {
+            loadtest "console/mysql_odbc";
+        }
         if (get_var("SYSAUTHTEST")) {
             # sysauth test scenarios run in the console
             loadtest "sysauth/sssd";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -847,7 +847,6 @@ sub load_consoletests {
     loadtest "console/sshd";
     loadtest "console/ssh_cleanup";
     loadtest "console/mtab";
-
     if (is_new_installation && sle_version_at_least('12-SP2')) {
         loadtest "console/no_perl_bootloader";
     }
@@ -858,12 +857,9 @@ sub load_consoletests {
         }
         loadtest "console/http_srv";
         loadtest "console/mysql_srv";
-        if (sle_version_at_least('12-SP2') && (!is_staging)) {    # MyODBC-unixODBC not available on < SP2
-            loadtest "console/mysql_odbc";
-        }
         loadtest "console/dns_srv";
         loadtest "console/postgresql96server";
-        if (sle_version_at_least('12-SP1')) {                     # shibboleth-sp not available on SLES 12 GA
+        if (sle_version_at_least('12-SP1')) {    # shibboleth-sp not available on SLES 12 GA
             loadtest "console/shibboleth";
         }
         if (get_var('ADDONS', '') =~ /wsm/ || get_var('SCC_ADDONS', '') =~ /wsm/) {


### PR DESCRIPTION
mysql_odbc test requires package MyODBC-unixODBC which is available only on SDK.

Remove mysql_odbc test from main.pm and add mysql_odbc on main_common to run
inside load_extra_tests function.

Fixes poo#27080 - [qam] test fails in mysql_odbc.

Fix tidy complaints about white spaces on shibboleth comments.