### PR TITLE
Replace unreliable keyboard shortcut by a mouse click

### DIFF
--- a/tests/installation/partitioning_firstdisk.pm
+++ b/tests/installation/partitioning_firstdisk.pm
@@ -72,7 +72,7 @@ sub take_first_disk {
     };
     send_key 'alt-n';
 
-    assert_screen 'use-entire-disk';
+    assert_and_click 'use-entire-disk';
     wait_screen_change {
         send_key 'alt-e';
     };
@@ -82,9 +82,10 @@ sub take_first_disk {
 sub run {
     if (is_storage_ng) {
         take_first_disk_storage_ng;
-        return 1;
     }
-    take_first_disk;
+    else {
+        take_first_disk;
+    }
 }
 
 1;


### PR DESCRIPTION
https://openqa.suse.de/tests/1124996?version=15&distri=sle&flavor=Leanos-DVD&test=gnome&arch=x86_64&machine=64bit-ipmi&limit_previous=100#step/partitioning_firstdisk/3 tries hard to press `alt+e` while the shortcut is `alt+u` in reality. It then fails in the next step because no partition is big enough (caused by pressing the wrong shortcut).

We already have a needle that checks exactly for that button so why not make use of it and just click it.

The change in run() is just to make it more pretty.

_Note:_ ~Not sure if this code path is still touched somewhere. I'm pretty sure this is needed for SLE12 since it does not contain storage_ng. I'll try to run an old SLE12 job to verify this change and leave this PR as [WIP] until then.~

- Related ticket: https://progress.opensuse.org/issues/23566
- Needles: not needed
- Verification run:
  - SLE12SP3: http://openqa.glados.qa.suse.de/tests/564#step/partitioning_firstdisk/3
  - TW: http://dhcp227.suse.cz/tests/272#step/partitioning_firstdisk/2
  - SLE15: not affected

