### PR TITLE
Increase timeout to 20min systemd-testsuite aarch64

### DIFF
--- a/tests/console/systemd_testsuite.pm
+++ b/tests/console/systemd_testsuite.pm
@@ -31,7 +31,7 @@ sub run {
 
     # run the testsuite test scripts
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh --all 2>&1 | tee /tmp/testsuite.log', 600;
+    assert_script_run './run-tests.sh --all 2>&1 | tee /tmp/testsuite.log', 1200;
     assert_script_run 'grep "# FAIL:  0" /tmp/testsuite.log';
     assert_script_run 'grep "# ERROR: 0" /tmp/testsuite.log';
 }


### PR DESCRIPTION
The timeout of 10 minutes was not enough for aarch64 as seen here: [osd#1239526](https://openqa.suse.de/tests/1239526#step/systemd_testsuite/24)

Timeout increased to 20 minutes:
- Verification run: [copland#1630](http://copland.arch.suse.de/tests/1630#step/systemd_testsuite/26)
