### PR TITLE
firefox_audio: detect mistyped URL and give it a 2nd try

### DIFF
--- a/tests/x11/firefox_audio.pm
+++ b/tests/x11/firefox_audio.pm
@@ -21,6 +21,11 @@ sub run {
     $self->start_firefox();
     send_key "ctrl-l";
     type_string(autoinst_url . "/data/1d5d9dD.oga");
+    if (check_screen('firefox_audio_mistyped_url')) {
+        record_soft_failure('poo25654 - URL mistyped; retrying');
+        send_key "ctrl-l";
+        type_string(autoinst_url . "/data/1d5d9dD.oga");
+    }
     send_key "ret";
     start_audiocapture;
     assert_screen 'test-firefox_audio-1', 35;


### PR DESCRIPTION
Very frequently, the address is being mistyped for firefox_audio
(htp:// instead of http://); try to detect this, record a softfailure
and make a 2nd attempt.

https://progress.opensuse.org/issues/25654
