### PR TITLE
Replace workaround for bsc#1061838 with #1064834

### DIFF
--- a/tests/console/force_cron_run.pm
+++ b/tests/console/force_cron_run.pm
@@ -29,8 +29,8 @@ sub settle_load {
 sub run {
     select_console 'root-console';
 
-    if (script_run 'grep -w mail /etc/group') {
-        record_soft_failure 'bsc#1061838 - Group "mail" not found';
+    if (script_run('rpmquery --whatprovides smtp_daemon')) {
+        record_soft_failure 'bsc#1064834 - run-crons fails with: "Could not find suitable mailer."';
         return;
     }
 


### PR DESCRIPTION
bsc#1061838 is now fixed, but bsc#1064834 is still present.

Verification runs:
JeOS: http://assam.suse.cz/tests/747
SLES: http://assam.suse.cz/tests/749