### PR TITLE
Add post_fail_hook from x11/shutdown.pm to shutdown/shutdown.pm

### DIFF
--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -36,6 +36,14 @@ sub test_flags {
     return {fatal => 1};
 }
 
+sub post_fail_hook {
+    my ($self) = @_;
+    # In case plymouth splash shows up and the shutdown is blocked, show
+    # console logs - save screen of console (plymouth splash screen in disabled at boottime)
+    send_key('esc');
+    save_screenshot;
+}
+
 1;
 
 # vim: set sw=4 et:


### PR DESCRIPTION
Just a simple copy & paste from x11/shutdown.pm to show at least the systemd-output in case of a hanging system. Unfortunately I was not able to reuse the hook from x11/shutdown directly (by using e.g. perls Exporter) but had to copy the code over.

I hope we can unify both modules in the future but for now this should be a suitable workaround.

- Related ticket: https://progress.opensuse.org/issues/16520
- Needles: not needed
- Verification run: any run where x11/shutdown.pm triggered
