### PR TITLE
Rely less on serial console and snapper's CLI API

### DIFF
--- a/tests/console/installation_snapshots.pm
+++ b/tests/console/installation_snapshots.pm
@@ -1,14 +1,14 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Check initial snapper snapshots after installation
+# Summary: Check post-installation snapshot
 # Maintainer: Oliver Kurz <okurz@suse.de>
 # Tags: fate#317973, bsc#935923
 
@@ -20,30 +20,25 @@ use utils;
 sub run {
     select_console 'root-console';
 
-    script_run("snapper list | tee /dev/$serialdev", 0);
     # Check if the corresponding snapshot is there
-    my ($snapshot_name, $snapshot_type);
-
+    my ($snapshot_desc, $snapshot_type);
     if (is_jeos) {
-        $snapshot_name = 'Initial Status';
+        $snapshot_desc = 'Initial Status';
         $snapshot_type = 'single';
     }
     elsif (get_var('AUTOUPGRADE')) {
-        $snapshot_name = 'before update';
-        $snapshot_type = 'pre';
+        $snapshot_desc = 'before update';
+        $snapshot_type = 'pre-post';
     }
     elsif (get_var('ONLINE_MIGRATION')) {
-        $snapshot_name = 'before online migration';
-        $snapshot_type = 'pre';
+        $snapshot_desc = 'before online migration';
+        $snapshot_type = 'pre-post';
     }
     else {
-        $snapshot_name = 'after installation';
+        $snapshot_desc = 'after installation';
         $snapshot_type = 'single';
     }
-
-    my $pattern = $snapshot_type . '\s*(\|[^|]*){4}\s*\|\s*number\s*\|\s*' . $snapshot_name . '\s*\|\s*important=yes';
-
-    wait_serial($pattern, 90) || die "$snapshot_name snapshot test failed";
+    assert_script_run("snapper list --type $snapshot_type | grep '$snapshot_desc.*important=yes'");
 }
 
 1;


### PR DESCRIPTION
On Hyper-V we have inherently unreliable serial console, limiting the
amount of data we send to it makes tests on Hyper-V reliable.

As `snapper` does not have a snapshot query tool we have to use CLI
"API" but we perhaps don't have to rely that much on it's current
format.

Fails here:
https://openqa.suse.de/tests/1242169#step/installation_snapshots/3

Validation run on SLE15:
http://assam.suse.cz/tests/754#step/installation_snapshots/2

I'd like to validate in other situations but JeOS is broken wrt
snapshots and other test suites I was not able to find in OSD.