### PR TITLE
Adjust tests on Leap 15 for storage NG

### DIFF
--- a/tests/installation/partitioning_lvm.pm
+++ b/tests/installation/partitioning_lvm.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 use parent qw(installation_user_settings y2logsstep);
 use testapi;
-use utils qw(sle_version_at_least is_storage_ng);
+use utils qw(sle_version_at_least is_storage_ng leap_version_at_least);
 
 sub save_logs_and_resume {
     my $self = shift;
@@ -100,11 +100,20 @@ sub run {
             assert_screen "inst-select-root-disk";
             send_key 'alt-n';
         }
-        send_key 'alt-e';
+        if (leap_version_at_least('15.0')) {
+            send_key 'alt-a';
+        }
+        else {
+            send_key 'alt-e';
+        }
         assert_screen "inst-partitioning-lvm-enabled";
         if (get_var("ENCRYPT")) {
-            send_key 'alt-a';
-
+            if (leap_version_at_least('15.0')) {
+                send_key 'alt-l';
+            }
+            else {
+                send_key 'alt-a';
+            }
             if (!get_var('ENCRYPT_ACTIVATE_EXISTING')) {
                 assert_screen 'inst-encrypt-password-prompt';
                 type_password;

--- a/tests/installation/partitioning_togglehome.pm
+++ b/tests/installation/partitioning_togglehome.pm
@@ -14,6 +14,7 @@
 use strict;
 use base "y2logsstep";
 use testapi;
+use installation_user_settings;
 use utils 'is_storage_ng';
 
 sub run {
@@ -21,6 +22,7 @@ sub run {
     if (is_storage_ng) {
         assert_screen 'partition-scheme';
         send_key $cmd{next};
+        installation_user_settings::await_password_check if get_var('ENCRYPT');
     }
     if (!check_screen 'disabledhome', 0) {
         # detect whether new (Radio Buttons) YaST behaviour


### PR DESCRIPTION
- Adapt storage NG case for leap15
- Update hotkey for leap version latest then 15
- Add simple password check for partitioning togglehome case

see POO#26864

- Related ticket: https://progress.opensuse.org/issues/26864
- Verification run: 
  *  http://10.67.17.147/tests/1696#step/partitioning_togglehome/1
  *  http://10.67.17.147/tests/1693#step/partitioning_lvm/1
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/285