### PR TITLE
Virtualization: fix grub menuentry selection unstable issue

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -99,7 +99,7 @@ sub setup_console_in_grub {
           . "{s/(console|loglevel|log_lvl|guest_loglvl)=[^ ]*//g; "
           . "/multiboot/ s/\$/ console=com2,115200 log_lvl=all guest_loglvl=all sync_console/; "
           . "/module\\s*.*vmlinuz/ s/\$/ console=$ipmi_console,115200 console=tty loglevel=5/;}; "
-          . "s/timeout=[0-9]*/timeout=15/g;"
+          . "s/timeout=[0-9]*/timeout=30/g;"
           . "' $grub_cfg_file";
         assert_script_run("$cmd");
         save_screenshot;
@@ -108,7 +108,7 @@ sub setup_console_in_grub {
     }
     elsif ($grub_ver eq "grub1") {
         $cmd
-          = "cp $grub_cfg_file ${grub_cfg_file}.org \&\&  sed -i 's/timeout [0-9]*/timeout 10/; /module \\\/boot\\\/vmlinuz/{s/console=.*,115200/console=$ipmi_console,115200/g;}' $grub_cfg_file";
+          = "cp $grub_cfg_file ${grub_cfg_file}.org \&\&  sed -i 's/timeout [0-9]*/timeout 30/; /module \\\/boot\\\/vmlinuz/{s/console=.*,115200/console=$ipmi_console,115200/g;}' $grub_cfg_file";
         assert_script_run("$cmd");
         save_screenshot;
         $cmd = "sed -rn '/module \\\/boot\\\/vmlinuz/p' $grub_cfg_file";

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -33,7 +33,7 @@ sub login_to_console {
             #send key 'up' to stop grub timer counting down, to be more robust to select xen
             send_key 'up';
             save_screenshot;
-            send_key_until_needlematch("virttest-bootmenu-xen-kernel", 'down', 10, 3);
+            send_key_until_needlematch("virttest-bootmenu-xen-kernel", 'down', 10, 5);
         }
     }
     else {

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -32,6 +32,7 @@ sub login_to_console {
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
             #send key 'up' to stop grub timer counting down, to be more robust to select xen
             send_key 'up';
+            save_screenshot;
             send_key_until_needlematch("virttest-bootmenu-xen-kernel", 'down', 10, 3);
         }
     }
@@ -39,6 +40,7 @@ sub login_to_console {
         set_var("reboot_for_upgrade_step", undef);
         set_var("after_upgrade",           "yes");
     }
+    save_screenshot;
     send_key 'ret';
 
     assert_screen(['linux-login', 'virttest-displaymanager'], $timeout);


### PR DESCRIPTION
From latest test result, some tests fail at grub menuentry selection phase. Since ipmi may respond slowly sometimes, to avoid the unstability, extend the timeout value to let send_key being responded before default boot and add debug screenshot.