### PR TITLE
firefox_audio: Go back to calling firefox with direct URL to prevent mistyping

### DIFF
--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -520,7 +520,9 @@ sub firefox_check_default {
 sub firefox_check_popups {
     # Check whether there are any pop up windows and handle them one by one
     for (1 .. 2) {
-        wait_still_screen;
+        # wait for any popup to showup but not expect a too long still time
+        # because of dynamic openSUSE start page background logo
+        wait_still_screen(1);
         assert_screen [qw(firefox_trackinfo firefox_readerview_window firefox_clean)], 60;
         # handle the tracking protection pop up
         if (match_has_tag('firefox_trackinfo')) {

--- a/tests/x11/firefox_audio.pm
+++ b/tests/x11/firefox_audio.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -9,6 +9,9 @@
 # without any warranty.
 
 # Summary: Test audio playback in firefox
+#  Depending on if firefox has been started in before firefox might behave
+#  different but should always show the play controls which the test is
+#  looking for.
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "x11test";
@@ -18,17 +21,13 @@ use testapi;
 
 sub run {
     my ($self) = @_;
-    $self->start_firefox();
-    send_key "ctrl-l";
-    wait_still_screen(1);
-    type_string(autoinst_url . "/data/1d5d9dD.oga");
-    send_key "ret";
     start_audiocapture;
-    assert_screen 'test-firefox_audio-1', 35;
+    x11_start_program('firefox ' . data_url('1d5d9dD.oga'), target_match => 'test-firefox_audio-1', match_timeout => 35);
     sleep 1;    # at least a second of silence
     assert_recorded_sound('DTMF-159D');
-    send_key "alt-f4";
-    $self->exit_firefox();
+    send_key 'alt-f4';
+    assert_screen([qw(firefox-save-and-quit generic-desktop)]);
+    send_key 'ret' if match_has_tag 'firefox-save-and-quit';
 }
 
 1;


### PR DESCRIPTION
This test module is about testing audio playback and should not try to do
anything else. With the recent rewrite we introduced a slow down, an increase
of complexity and also the problem that by typing into the address bar a
complex URL characters can go missing. Most likely the reason for that is that
firefox makes suggestions after the first character is typed so in many cases
the second character, which is 't' of 'http' has gone missing.

Verification run: http://lord.arch/tests/8035#step/firefox_audio/3

Related progress issue: https://progress.opensuse.org/issues/25654