### PR TITLE
zypper_lifecycle: Prevent product regex matching on other lines

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -79,7 +79,7 @@ sub run {
     # get product eol
     my $product_file = "/etc/products.d/$prod.prod";
     my $product_name = script_output "grep '<summary>' $product_file";
-    $product_name =~ s/.*<summary>([^<]*)<\/summary>.*/$1/ || die "no product name found in $product_file";
+    $product_name =~ s/.*<summary>([^<]*)<\/summary>.*/$1/s || die "no product name found in $product_file";
     record_info('Product found', "Product found in overview: $product_name");
 
     my $product_eol;


### PR DESCRIPTION
script_output can return the output from the serial port covering multiple
lines with output which has not been expected. This change makes the regex
replacement more robust by getting rid of any other content in all lines only
leaving the product to match.

Related progress issue: https://progress.opensuse.org/issues/26080