### PR TITLE
utils: add leap_staging_version_in_settings method to cope with the staging version naming

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -510,6 +510,18 @@ sub sle_version_at_least {
     die "unsupported SLE $version_variable $version in check";
 }
 
+# To cope with staging version naming and this method should only be used
+# to leap_version_at_least. This method returns 1 if it is a valid staging
+# naming or the version is matched to the one in settings.
+sub leap_staging_version_in_settings {
+    my ($version_variable, $version) = @_;
+    return 0 unless is_leap;
+
+    my $version_in_settings = get_var($version_variable, '');
+    return 1 if ($version_in_settings =~ /$version:(Core|S):?[:\w]*/ || $version_in_settings eq $version);
+    return 0;
+}
+
 # Method has to be extended similarly to sle_version_at_least once we know
 # version naming convention as of now, we only add versions which we see in
 # test. If one will use function and it dies, please extend function accordingly.
@@ -521,15 +533,15 @@ sub leap_version_at_least {
     my $version_variable = $args{version_variable} // 'VERSION';
 
     if ($version eq '42.2') {
-        return check_var($version_variable, $version) || leap_version_at_least('42.3', version_variable => $version_variable);
+        return leap_staging_version_in_settings($version_variable, $version) || leap_version_at_least('42.3', version_variable => $version_variable);
     }
 
     if ($version eq '42.3') {
-        return check_var($version_variable, $version) || leap_version_at_least('15.0', version_variable => $version_variable);
+        return leap_staging_version_in_settings($version_variable, $version) || leap_version_at_least('15.0', version_variable => $version_variable);
     }
 
     if ($version eq '15.0') {
-        return check_var($version_variable, $version);
+        return leap_staging_version_in_settings($version_variable, $version);
     }
     # Die to point out that function has to be extended
     die "Unsupported Leap version $version_variable $version in check";


### PR DESCRIPTION
Add leap_staging_version_in_settings method which would checks is it a valid staging version naming or the version is matched to the one in settings.

The failed case: https://openqa.opensuse.org/tests/524386
The version variable in settings is `15.0:S:C` thus leap_version_at_least('15.0') does not work at all in the staging testing.