### PR TITLE
Fix installcheck, rescue mode & co. on Xen & Hyper-V and align svirt booting with QEMU

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -31,6 +31,7 @@ our @EXPORT = qw(
   select_bootmenu_option
   uefi_bootmenu_params
   bootmenu_default_params
+  type_hyperv_fb_video_resolution
   bootmenu_network_source
   specific_bootmenu_params
   specific_caasp_params
@@ -200,6 +201,12 @@ sub uefi_bootmenu_params {
     type_string " \\\n";    # changed the line before typing video params
 }
 
+# Returns kernel framebuffer configuration we have to
+# explicitly set on Hyper-V to get 1024x768 resolution.
+sub type_hyperv_fb_video_resolution {
+    type_string_slow ' video=hyperv_fb:1024x768 ';
+}
+
 sub bootmenu_default_params {
     if (check_var('ARCH', 'ppc64le')) {
         # edit menu, wait until we get to grub edit
@@ -248,7 +255,7 @@ sub bootmenu_default_params {
     # Default namescheme 'by-id' for devices is broken on Hyper-V (bsc#1029303),
     # we have to use something else.
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
-        type_string_slow 'video=hyperv_fb:1024x768 ';
+        type_hyperv_fb_video_resolution;
         type_string_slow 'namescheme=by-label ' unless is_jeos or is_caasp;
     }
 }

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1,7 +1,7 @@
 package opensusebasetest;
 use base 'basetest';
 
-use bootloader_setup qw(boot_local_disk tianocore_enter_menu zkvm_add_disk zkvm_add_pty zkvm_add_interface);
+use bootloader_setup qw(boot_local_disk tianocore_enter_menu zkvm_add_disk zkvm_add_pty zkvm_add_interface type_hyperv_fb_video_resolution);
 use testapi;
 use strict;
 use utils;
@@ -197,17 +197,20 @@ sub select_bootmenu_more {
     else {
         send_key_until_needlematch($tag, 'down', 10, 5);
     }
-    if (get_var('MACHINE', '') =~ /aarch64/) {
-        # newer versions of qemu on arch automatically add 'console=ttyS0' so
-        # we would end up nowhere. Setting console parameter explicitly
-        # See https://bugzilla.suse.com/show_bug.cgi?id=1032335 for details
+    if (get_var('UEFI')) {
         send_key 'e';
         send_key 'down' for (1 .. 4);
         send_key 'end';
-        type_string_slow ' console=tty1';
+        # newer versions of qemu on arch automatically add 'console=ttyS0' so
+        # we would end up nowhere. Setting console parameter explicitly
+        # See https://bugzilla.suse.com/show_bug.cgi?id=1032335 for details
+        type_string_slow ' console=tty1' if get_var('MACHINE', '') =~ /aarch64/;
+        # Hyper-V defaults to 1280x1024, we need to fix it here
+        type_hyperv_fb_video_resolution if check_var('VIRSH_VMM_FAMILY', 'hyperv');
         send_key 'f10';
     }
     else {
+        type_hyperv_fb_video_resolution if check_var('VIRSH_VMM_FAMILY', 'hyperv');
         send_key 'ret';
     }
 }

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -607,6 +607,8 @@ sub assert_shutdown_and_restore_system {
     assert_shutdown;
     if ($action eq 'reboot') {
         reset_consoles;
+        # Set disk as a primary boot device
+        console('svirt')->change_domain_element(os => boot => {dev => 'hd'});
         console('svirt')->define_and_start;
         select_console($vnc_console);
     }

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -38,6 +38,10 @@ our @EXPORT = qw(
   is_tumbleweed
   is_storage_ng
   is_sle12_hdd_in_upgrade
+  is_installcheck
+  is_memtest
+  is_mediacheck
+  is_rescuesystem
   select_kernel
   type_string_slow
   type_string_very_slow
@@ -268,6 +272,22 @@ sub is_kde_live {
 
 sub is_gnome_next {
     return get_var('FLAVOR', '') =~ /Gnome-Live/;
+}
+
+sub is_installcheck {
+    return get_var('INSTALLCHECK');
+}
+
+sub is_memtest {
+    return get_var('MEMTEST');
+}
+
+sub is_mediacheck {
+    return get_var('MEDIACHECK');
+}
+
+sub is_rescuesystem {
+    return get_var('RESCUESYSTEM');
 }
 
 # Check if distribution is CaaSP or Kubic with optional filter:

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -781,10 +781,10 @@ elsif (get_var("REGRESSION")) {
         load_x11regression_other();
     }
 }
-elsif (get_var("MEDIACHECK")) {
+elsif (is_mediacheck) {
     loadtest "installation/mediacheck";
 }
-elsif (get_var("MEMTEST")) {
+elsif (is_memtest) {
     loadtest "installation/memtest";
 }
 elsif (get_var("FILESYSTEM_TEST")) {
@@ -800,7 +800,7 @@ elsif (get_var('GNUHEALTH')) {
     loadtest 'gnuhealth/tryton_first_time';
 }
 
-elsif (get_var("RESCUESYSTEM")) {
+elsif (is_rescuesystem) {
     loadtest "installation/rescuesystem";
     loadtest "installation/rescuesystem_validate_131";
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1182,6 +1182,12 @@ elsif (get_var("RESCUESYSTEM")) {
     loadtest "installation/rescuesystem_validate_sle";
 }
 elsif (get_var("INSTALLCHECK")) {
+    if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
+        loadtest "installation/bootloader_hyperv";
+    }
+    else {
+        loadtest "installation/bootloader_svirt";
+    }
     loadtest "installation/rescuesystem";
     loadtest "installation/installcheck";
 }

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -284,30 +284,32 @@ sub run {
     # sets framebuffer (this is a GRUB2's limitation bsc#961638).
     if ($vmm_family eq 'xen' and $vmm_type eq 'linux' and !get_var('NETBOOT')) {
         $svirt->suspend;
-        my $cmdline = "";
-        if (check_var('VIDEOMODE', 'text')) {
-            $cmdline .= "textmode=1 ";
-        }
-        if (get_var('EXTRABOOTPARAMS')) {
-            $cmdline .= get_var('EXTRABOOTPARAMS') . " ";
-        }
+        my $cmdline = '';
+        $cmdline .= 'textmode=1 ' if check_var('VIDEOMODE', 'text');
+        $cmdline .= 'rescue=1 ' if is_installcheck || is_rescuesystem;    # rescue mode
+        $cmdline .= get_var('EXTRABOOTPARAMS') . ' ';
         type_string "export pty=`virsh dumpxml $name | grep \"console type=\" | sed \"s/'/ /g\" | awk '{ print \$5 }'`\n";
         type_string "echo \$pty\n";
         $svirt->resume;
-        wait_serial("Press enter to boot the selected OS", 10) || die "Can't get to Grub";
-        type_string "echo e > \$pty\n";    # edit
+        wait_serial("Press enter to boot the selected OS", 10) || die "Can't get to GRUB";
+        # Do not boot OS from disk
+        if (get_var('ISO') && get_var('HDD_1') && !is_jeos && !is_caasp) {
+            type_string "echo -en '\\033[B' > \$pty\n";                   # key down
+        }
+        type_string "echo e > \$pty\n";                                   # edit
 
         if (is_jeos or is_caasp) {
             for (1 .. 4) { type_string "echo -en '\\033[B' > \$pty\n"; }    # four-times key down
         }
         else {
+            $cmdline .= 'linemode=0';                                       # workaround for bsc#1066919
             for (1 .. 2) { type_string "echo -en '\\033[B' > \$pty\n"; }    # four-times key down
         }
         type_string "echo -en '\\033[K' > \$pty\n";                         # end of line
         type_string "echo -en ' $cmdline' > \$pty\n";
         if (sle_version_at_least('12-SP2') or is_caasp) {
             type_string "echo -en ' xen-fbfront.video=32,1024,768 xen-kbdfront.ptr_size=1024,768 ' > \$pty\n";    # set kernel framebuffer
-            type_string "echo -en ' console=hvc console=tty' > \$pty\n";                                          # set consoles
+            type_string "echo -en ' console=hvc console=tty ' > \$pty\n";                                         # set consoles
         }
         else {
             type_string "echo -en ' xenfb.video=4,1024,768' > \$pty\n";                                           # set kernel framebuffer

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -82,13 +82,13 @@ sub run {
     my $dev_id = 'b';
     # In JeOS we have the disk, we just need to deploy it, for the rest
     # - installs from network and ISO media - we have to create it.
+    $svirt->change_domain_element(os => boot => {dev => 'hd'});
     if (my $hddfile = get_var('HDD_1')) {
         my $hddpath = copy_image($hddfile, $hdddir);
         $svirt->add_disk(
             {
                 file => ($vmm_family eq 'vmware') ? basename($hddpath) : $hddpath,
                 dev_id      => 'a',
-                bootorder   => 1,
                 backingfile => 1
             });
         foreach my $n (2 .. get_var('NUMDISKS')) {
@@ -115,10 +115,9 @@ sub run {
     else {
         $svirt->add_disk(
             {
-                size      => $size_i . 'G',
-                create    => 1,
-                dev_id    => 'a',
-                bootorder => 1
+                size   => $size_i . 'G',
+                create => 1,
+                dev_id => 'a'
             });
     }
 
@@ -130,12 +129,12 @@ sub run {
             my $isopath = copy_image($isofile, $isodir);
             $svirt->add_disk(
                 {
-                    cdrom     => 1,
-                    file      => ($vmm_family eq 'vmware') ? basename($isopath) : $isopath,
-                    dev_id    => $dev_id,
-                    bootorder => 2
+                    cdrom  => 1,
+                    file   => ($vmm_family eq 'vmware') ? basename($isopath) : $isopath,
+                    dev_id => $dev_id
                 });
             $dev_id = chr((ord $dev_id) + 1);    # return next letter in alphabet
+            $svirt->change_domain_element(os => boot => {dev => 'cdrom'});
         }
         # Add addon media (if present at all)
         foreach my $n (1 .. 9) {

--- a/tests/installation/installcheck.pm
+++ b/tests/installation/installcheck.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,7 +17,9 @@ use strict;
 use testapi;
 
 sub run {
-    assert_script_run "mount /dev/sr0 /mnt";
+    # Xen PV does not emulate CDROM, treats everything as block device
+    my $cddev = check_var('VIRSH_VMM_TYPE', 'linux') ? 'xvdc2' : 'sr0';
+    assert_script_run "mount -o ro /dev/$cddev /mnt";
     assert_script_run 'cd /tmp; rpm2cpio $(find /mnt -name libsolv-tools*.rpm) | cpio -dium';
     assert_script_run 'export PATH=/tmp/usr/bin:$PATH; usr/bin/repo2solv.sh /mnt > /tmp/solv';
     script_run 'installcheck ' . get_var("ARCH") . ' /tmp/solv > /tmp/installcheck.log 2>&1 && touch /tmp/WORKED';

--- a/tests/installation/memtest.pm
+++ b/tests/installation/memtest.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -21,7 +21,7 @@ sub run {
 
     ensure_shim_import;
     $self->select_bootmenu_more('inst-onmemtest', 1);
-    assert_screen "pass-complete", 700;
+    assert_screen "pass-complete", check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 1100 : 700;
     send_key "esc";
 }
 

--- a/tests/installation/rescuesystem.pm
+++ b/tests/installation/rescuesystem.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,8 +19,12 @@ use utils 'ensure_shim_import';
 sub run {
     my $self = shift;
 
-    ensure_shim_import;
-    $self->select_bootmenu_more('inst-rescuesystem', 1);
+    # We can't see inst-sys on Xen PV, bootloader_svirt
+    # does the job to get us into rescue mode.
+    unless (check_var('VIRSH_VMM_TYPE', 'linux')) {
+        ensure_shim_import;
+        $self->select_bootmenu_more('inst-rescuesystem', 1);
+    }
 
     assert_screen 'keyboardmap-list', 100;
     send_key "ret";

--- a/tests/installation/rescuesystem_validate_sle.pm
+++ b/tests/installation/rescuesystem_validate_sle.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,9 @@ use strict;
 use testapi;
 
 sub run {
-    type_string "mount /dev/vda2 /mnt && cat /mnt/etc/SuSE-release > /dev/$serialdev\n";
+    my $hdddev = check_var('VIRSH_VMM_FAMILY', 'xen') ? 'xvda2' : 'vda2';
+    assert_script_run "mount /dev/$hdddev /mnt";
+    type_string "cat /mnt/etc/SuSE-release > /dev/$serialdev\n";
     wait_serial("SUSE Linux Enterprise Server", 10) || die "Not SLES found";
 }
 


### PR DESCRIPTION
Validation runs:
* Tumbleweed QEMU `mediacheck`: http://assam.suse.cz/tests/855
* SLES Xen PV `installcheck`: http://assam.suse.cz/tests/858
* SLES Xen HVM `installcheck`: http://assam.suse.cz/tests/857
* SLES Xen HVM `ext4`: http://assam.suse.cz/tests/856
* SLES Hyper-V `mediacheck`: http://assam.suse.cz/tests/859
* SLES Xen HVM `memtest`: http://assam.suse.cz/tests/860