### PR TITLE
Prevent x11/midori being scheduled on rescue CD where we can not install it

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -530,7 +530,7 @@ sub load_x11tests {
         loadtest "x11/chromium";
     }
     if (xfcestep_is_applicable()) {
-        loadtest "x11/midori";
+        loadtest "x11/midori" unless (is_staging || is_livesystem);
         loadtest "x11/ristretto";
     }
     if (gnomestep_is_applicable()) {


### PR DESCRIPTION
Test schedule evaluation verified locally:

```
05:33:56.6816 3623 scheduling isosize tests/installation/isosize.pm
05:33:56.6842 3623 scheduling bootloader tests/installation/bootloader.pm
05:33:56.6847 3623 scheduling finish_desktop tests/installation/finish_desktop.pm
05:33:56.6861 3623 scheduling consoletest_setup tests/console/consoletest_setup.pm
05:33:56.6867 3623 scheduling force_cron_run tests/console/force_cron_run.pm
05:33:56.6872 3623 scheduling textinfo tests/console/textinfo.pm
05:33:56.6877 3623 scheduling hostname tests/console/hostname.pm
05:33:56.6883 3623 scheduling xorg_vt tests/console/xorg_vt.pm
05:33:56.6890 3623 scheduling zypper_lr tests/console/zypper_lr.pm
05:33:56.6897 3623 scheduling zypper_ar tests/console/zypper_ar.pm
05:33:56.6903 3623 scheduling zypper_ref tests/console/zypper_ref.pm
05:33:56.6908 3623 scheduling ncurses tests/console/ncurses.pm
05:33:56.6920 3623 scheduling yast2_lan tests/console/yast2_lan.pm
05:33:56.6925 3623 scheduling curl_https tests/console/curl_https.pm
05:33:56.6929 3623 scheduling glibc_i686 tests/console/glibc_i686.pm
05:33:56.6935 3623 scheduling zypper_in tests/console/zypper_in.pm
05:33:56.6944 3623 scheduling yast2_i tests/console/yast2_i.pm
05:33:56.6949 3623 scheduling vim tests/console/vim.pm
05:33:56.6954 3623 scheduling firewall_enabled tests/console/firewall_enabled.pm
05:33:56.6960 3623 scheduling sshd tests/console/sshd.pm
05:33:56.6964 3623 scheduling ssh_cleanup tests/console/ssh_cleanup.pm
05:33:56.6969 3623 scheduling mtab tests/console/mtab.pm
05:33:56.6973 3623 scheduling xfce_gnome_deps tests/console/xfce_gnome_deps.pm
05:33:56.6979 3623 scheduling consoletest_finish tests/console/consoletest_finish.pm
05:33:56.6991 3623 scheduling xfce4_terminal tests/x11/xfce4_terminal.pm
05:33:56.6995 3623 scheduling xterm tests/x11/xterm.pm
05:33:56.7277 3623 scheduling firefox tests/x11/firefox.pm
05:33:56.7282 3623 scheduling ristretto tests/x11/ristretto.pm
05:33:56.7287 3623 scheduling thunar tests/x11/thunar.pm
05:33:56.7291 3623 scheduling desktop_mainmenu tests/x11/desktop_mainmenu.pm
05:33:56.7296 3623 scheduling xfce4_appfinder tests/x11/xfce4_appfinder.pm
05:33:56.7302 3623 scheduling shutdown tests/x11/shutdown.pm
```