### PR TITLE
Add ethtool to tools in ltp_setup_networking test

### DIFF
--- a/tests/kernel/ltp_setup_networking.pm
+++ b/tests/kernel/ltp_setup_networking.pm
@@ -19,7 +19,7 @@ use utils;
 
 sub install {
     # utils
-    zypper_call('in wget iptables psmisc tcpdump', log => 'utils.log');
+    zypper_call('in wget iptables psmisc tcpdump ethtool', log => 'utils.log');
 
     # clients
     zypper_call('in dhcp-client telnet', log => 'clients.log');


### PR DESCRIPTION
`ethtool` is needed in ltp_net_features testsuite for some tests

- Verification run: http://quasar.suse.cz/tests/1152
