### PR TITLE
[beta2 needed]Virtualization: replace guest autoyast addons with daily build modules repo

### DIFF
--- a/tests/virt_autotest/host_upgrade_step3_run.pm
+++ b/tests/virt_autotest/host_upgrade_step3_run.pm
@@ -27,7 +27,7 @@ sub get_script_run {
 
 sub run {
     my $self = shift;
-    repl_repo_in_sourcefile();
+    update_guest_configurations_with_daily_build();
     $self->run_test(5400, "Host upgrade virtualization test pass", "no", "yes", "/var/log/qa/", "host-upgrade-postVerify-logs");
 }
 

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -44,7 +44,7 @@ sub run {
     my $self = shift;
     $self->update_package();
     set_serial_console_on_xen if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen"));
-    repl_repo_in_sourcefile();
+    update_guest_configurations_with_daily_build();
 }
 
 

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -24,7 +24,7 @@ use IO::File;
 use proxymode;
 use virt_autotest_base;
 
-our @EXPORT = qw(repl_repo_in_sourcefile);
+our @EXPORT = qw(update_guest_configurations_with_daily_build);
 
 sub get_version_for_daily_build_guest {
     my $version = '';
@@ -57,6 +57,28 @@ sub repl_repo_in_sourcefile {
     else {
         print "Do not need to change resource for $veritem item\n";
     }
+}
+
+sub repl_guest_autoyast_addon_with_daily_build_module {
+    #replace the addons url in guest autoyast file in qa_lib_virtauto-data with the daily build module repos
+    my $version = get_version_for_daily_build_guest;
+    $version =~ s/-/\//;
+    my $autoyast_root_dir = "/usr/share/qa/virtautolib/data/autoinstallation/sles/" . $version . "/";
+    my $command
+      = "for file in \`find $autoyast_root_dir -type f\`;do "
+      . "sed -ri 's#^.*(Basesystem|Desktop-Applications|Legacy|Server-Applications|Development-Tools).*\$#"
+      . "<media_url>http://openqa.suse.de/assets/repo/SLE-15-Module-\\1-POOL-x86_64-Build"
+      . get_required_var('BUILD')
+      . "-Media1/</media_url>#' \$file;done";
+    assert_script_run($command);
+    save_screenshot;
+    assert_script_run("grep media_url $autoyast_root_dir/* -r");
+    save_screenshot;
+}
+
+sub update_guest_configurations_with_daily_build {
+    repl_repo_in_sourcefile;
+    repl_guest_autoyast_addon_with_daily_build_module;
 }
 
 1;


### PR DESCRIPTION
Virtualization guest installation uses autoyast way which use addons for all necessary modules, like base/server-ap/desktop-app/legacy/develop-tool. The autoyast is fixed to be the latest repo for sle15. It is ok for milestone testing. However for openqa daily build test, we need to replace them with the daily build module repos.

Verification job:
10.67.18.220/tests/474#step/update_package/35