### PR TITLE
Do not schedule disable_grub_timeout on Xen PV

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -691,7 +691,8 @@ sub load_inst_tests {
     }
     if (installyaststep_is_applicable()) {
         loadtest "installation/installation_overview";
-        loadtest "installation/disable_grub_timeout";
+        # On Xen PV we don't have GRUB on VNC
+        loadtest "installation/disable_grub_timeout" unless check_var('VIRSH_VMM_TYPE', 'linux');
         if (check_var('VIDEOMODE', 'text') && check_var('BACKEND', 'ipmi')) {
             loadtest "installation/disable_grub_graphics";
         }


### PR DESCRIPTION
On Xen PV we don't have GRUB on VNC console, so there's not much use for
this test module.

Failed to boot to OS here: https://openqa.suse.de/tests/1247825
Boots to OS here: http://assam.suse.cz/tests/861