### PR TITLE
Create svirt VMs where BACKEND is set to svirt

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -505,6 +505,7 @@ sub load_svirt_boot_tests {
 }
 
 sub load_svirt_vm_setup_tests {
+    return unless check_var('BACKEND', 'svirt');
     if (check_var("VIRSH_VMM_FAMILY", "hyperv")) {
         loadtest "installation/bootloader_hyperv";
     }


### PR DESCRIPTION
Fails here: https://openqa.suse.de/tests/1249950
Regression from: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3883
Validation runs:
* http://assam.suse.cz/tests/864
* http://assam.suse.cz/tests/867