### PR TITLE
SLES4SAP-15 new OS Edition Screen & Updates to SLES4SAP tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -84,8 +84,8 @@ sub set_defaults_for_username_and_password {
         $testapi::password = '';
     }
     else {
-        if (get_var('FLAVOR', '') =~ /SAP/ and !sle_version_at_least('15')) {
-            $testapi::username = "root";    #in sles4sap only root user created (before SLE-15)
+        if (get_var('FLAVOR', '') =~ /SAP/) {
+            $testapi::username = "root";    #in sles4sap only root user created
         }
         else {
             $testapi::username = "bernhard";

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1276,7 +1276,7 @@ sub handle_login {
         }
         type_string "root\n";
     }
-    if (get_var('DM_NEEDS_USERNAME')) {
+    if (get_var('DM_NEEDS_USERNAME') and !get_var('ROOTONLY')) {
         type_string "$username\n";
     }
     if (check_var('DESKTOP', 'gnome') || (check_var('DESKTOP', 'lxde') && check_var('VERSION', '42.1'))) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -609,7 +609,7 @@ sub load_inst_tests {
         {
             loadtest "installation/system_role";
         }
-        if (is_sles4sap()) {
+        if (is_sles4sap() and sle_version_at_least('15')) {
             loadtest "installation/sles4sap_product_installation_mode";
         }
         loadtest "installation/partitioning";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -609,6 +609,9 @@ sub load_inst_tests {
         {
             loadtest "installation/system_role";
         }
+        if (is_sles4sap()) {
+            loadtest "installation/sles4sap_product_installation_mode";
+        }
         loadtest "installation/partitioning";
         if (defined(get_var("RAIDLEVEL"))) {
             loadtest "installation/partitioning_raid";
@@ -672,7 +675,7 @@ sub load_inst_tests {
             loadtest "installation/logpackages";
         }
         if (is_sles4sap()) {
-            if (check_var("SLES4SAP_MODE", 'sles') or sle_version_at_least('15')) {
+            if (is_sles4sap_standard()) {
                 loadtest "installation/user_settings";
             }    # sles4sap wizard installation doesn't have user_settings step
         }

--- a/tests/installation/sles4sap_product_installation_mode.pm
+++ b/tests/installation/sles4sap_product_installation_mode.pm
@@ -5,6 +5,7 @@
 use strict;
 use base "y2logsstep";
 use testapi;
+use utils qw(sle_version_at_least);
 
 sub run {
     if (sle_version_at_least('15')) {

--- a/tests/installation/sles4sap_product_installation_mode.pm
+++ b/tests/installation/sles4sap_product_installation_mode.pm
@@ -1,22 +1,30 @@
 #!/usr/bin/perl -w
-# G-Summary: Add SLES4SAP tests
-# G-Maintainer: Denis Zyuzin <dzyuzin@suse.com>
+# Summary: Handle "Choose Operation System Edition" screen for SLES4SAP installation flow
+# Maintainer: Alvaro Carvajal <acarvajal@suse.de>
 
 use strict;
 use base "y2logsstep";
 use testapi;
 
 sub run {
-    assert_screen "sles4sap-product-installation-mode";
-    send_key "alt-s";    # SUSE Linux Enterprise Server
-    save_screenshot;
-    assert_screen "sles4sap-standard-sles-selected";
-    if (get_var("SLES4SAP_MODE") =~ /sles4sap/) {
-        send_key "alt-u";    # SLES for SAP
-        assert_screen "sles4sap-product-selected";
-        if (check_var('SLES4SAP_MODE', 'sles4sap_wizard')) {
-            send_key "alt-a";    # lAunch SAP product installation wizard
-            assert_screen "sles4sap-wizard-selected";
+    if (sle_version_at_least('15')) {
+        my $expected_needle = check_var('SLES4SAP_MODE', 'sles4sap_wizard') ? "sles4sap-wizard-option-selected" : "sles4sap-wizard-option-not-selected";
+        assert_screen [qw(sles4sap-wizard-option-selected sles4sap-wizard-option-not-selected)];
+        send_key "alt-a" unless (match_has_tag($expected_needle));
+        assert_screen $expected_needle;
+    }
+    else {
+        assert_screen "sles4sap-product-installation-mode";
+        send_key "alt-s";    # SUSE Linux Enterprise Server
+        save_screenshot;
+        assert_screen "sles4sap-standard-sles-selected";
+        if (get_var("SLES4SAP_MODE") =~ /sles4sap/) {
+            send_key "alt-u";    # SLES for SAP
+            assert_screen "sles4sap-product-selected";
+            if (check_var('SLES4SAP_MODE', 'sles4sap_wizard')) {
+                send_key "alt-a";    # lAunch SAP product installation wizard
+                assert_screen "sles4sap-wizard-selected";
+            }
         }
     }
     save_screenshot;

--- a/tests/installation/sles4sap_product_installation_mode.pm
+++ b/tests/installation/sles4sap_product_installation_mode.pm
@@ -5,7 +5,7 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use utils qw(sle_version_at_least);
+use utils 'sle_version_at_least';
 
 sub run {
     if (sle_version_at_least('15')) {

--- a/tests/installation/sles4sap_product_installation_mode.pm
+++ b/tests/installation/sles4sap_product_installation_mode.pm
@@ -1,4 +1,13 @@
 #!/usr/bin/perl -w
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
 # Summary: Handle "Choose Operation System Edition" screen for SLES4SAP installation flow
 # Maintainer: Alvaro Carvajal <acarvajal@suse.de>
 

--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -29,5 +29,9 @@ sub run {
     }
 }
 
+sub test_flags {
+    return {milestone => 1};
+}
+
 1;
 # vim: set sw=4 et:

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -26,6 +26,10 @@ sub run {
 
     select_console 'root-console';
 
+    unless (tuned_is 'running') {
+        script_run "saptune daemon start";
+    }
+
     die "Command 'saptune daemon status' returned unexpected output. Expected tuned to be running"
       unless (tuned_is 'running');
 

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -27,18 +27,18 @@ sub run {
     select_console 'root-console';
 
     unless (tuned_is 'running') {
-        script_run "saptune daemon start";
+        assert_script_run "saptune daemon start";
     }
 
     die "Command 'saptune daemon status' returned unexpected output. Expected tuned to be running"
       unless (tuned_is 'running');
 
     assert_script_run "saptune daemon stop";
-    die "Command 'saptune daemon stop' couldn't stop tuned"
+    die "Command 'saptune daemon stop' didn't stop tuned"
       unless (tuned_is 'stopped');
 
     assert_script_run "saptune daemon start";
-    die "Command 'saptune daemon start' couldn't start tuned"
+    die "Command 'saptune daemon start' didn't start tuned"
       unless (tuned_is 'running');
 
     my $output = script_output "saptune solution list";


### PR DESCRIPTION
1) Added test installation/sles4sap_product_installation to handle SLES4SAP-15's installation tests.
2) Updated installation/sles4sap_product_installation so it works with SLES4SAP-15.
3) Changed sles4sap/patterns so it works as a milestone test.
4) Changed sles4sap/saptune so tuned is started if it's not started by default
5) Updated handle_method() in lib/utils.pm so it doesn't type 2 usernames in a row (root and $testapi::username) when both ROOTONLY and DM_NEEDS_USERNAME are set

Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/563