### PR TITLE
Enter Partitioner correctly, fix RAID shortcut

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -19,13 +19,14 @@ use testapi;
 sub run {
     assert_screen 'partitioning-edit-proposal-button', 40;
 
-    # Storage NG introduces a new partitioning dialog. We detect this by the existence of the "Guided Setup" button
-    # and set the STORAGE_NG variable so later tests know about this.
+    # Storage NG introduces a new partitioning dialog. We detect this
+    # by the existence of the "Guided Setup" button and set the
+    # STORAGE_NG variable so later tests know about this.
     if (match_has_tag('storage-ng')) {
         set_var('STORAGE_NG', 1);
         # Define changed shortcuts
         $cmd{donotformat} = 'alt-t';
-        $cmd{addraid}     = 'alt-d';
+        $cmd{addraid}     = 'alt-i';
         if (check_var('DISTRI', 'opensuse')) {
             $cmd{expertpartitioner} = 'alt-x';
             $cmd{rescandevices}     = 'alt-c';

--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -161,6 +161,10 @@ sub run {
 
     # With storage ng, we go directly to expert partitioner and invalidate configuration by rescan
     if (is_storage_ng) {
+        # start with existing partitions
+        send_key 'down' for (1 .. 2);
+        send_key 'ret';
+        assert_screen 'expert-partitioner';
         send_key $cmd{rescandevices};              # Rescan devices
         assert_screen 'rescan-devices-warning';    # Confirm rescan
         send_key 'alt-y';


### PR DESCRIPTION
* They way to get into Expert Partitioner has changed.
* Changed storage-ng's `addraid` shotrcut.

Validation run: http://assam.suse.cz/tests/886