### PR TITLE
Increase timeouts for the snapper cleanup

### DIFF
--- a/tests/console/snapper_cleanup.pm
+++ b/tests/console/snapper_cleanup.pm
@@ -44,8 +44,8 @@ sub snapper_cleanup {
 
     for (1 .. $scratch_size_gb) { assert_script_run("$snap_create", 500); }
     script_run "echo There are `$snaps_numb` snapshots BEFORE cleanup";
-    assert_script_run("snapper cleanup number",  180);    # cleanup created snapshots
-    assert_script_run("btrfs quota rescan -w /", 15);
+    assert_script_run("snapper cleanup number",  300);    # cleanup created snapshots
+    assert_script_run("btrfs quota rescan -w /", 90);
     script_run "echo There are `$snaps_numb` snapshots AFTER cleanup";
     assert_script_run("btrfs qgroup show -pcre /", 3);
     assert_script_run("snapper list");


### PR DESCRIPTION
On TW test module fails due to timeouts when cleaning snapshots.
Increase them to have more stable automated tests.

Recent example:
https://openqa.opensuse.org/tests/527476#step/snapper_cleanup/122
