### PR TITLE
partitioning_lvm: send the proper shortcut key on TW if storage-NG

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -58,6 +58,8 @@ sub init_cmd {
       filesystem alt-s
       expertpartitioner alt-e
       encrypt alt-e
+      encryptdisk alt-a
+      enablelvm alt-e
       resize alt-i
       acceptlicense alt-a
       instdetails alt-d

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -31,6 +31,8 @@ sub run {
         if (check_var('DISTRI', 'opensuse')) {
             $cmd{expertpartitioner} = 'alt-x';
             $cmd{rescandevices}     = 'alt-c';
+            $cmd{enablelvm}         = 'alt-a';
+            $cmd{encryptdisk}       = 'alt-l';
         }
     }
 

--- a/tests/installation/partitioning_lvm.pm
+++ b/tests/installation/partitioning_lvm.pm
@@ -100,20 +100,10 @@ sub run {
             assert_screen "inst-select-root-disk";
             send_key 'alt-n';
         }
-        if (leap_version_at_least('15.0')) {
-            send_key 'alt-a';
-        }
-        else {
-            send_key 'alt-e';
-        }
+        send_key $cmd{enablelvm};
         assert_screen "inst-partitioning-lvm-enabled";
         if (get_var("ENCRYPT")) {
-            if (leap_version_at_least('15.0')) {
-                send_key 'alt-l';
-            }
-            else {
-                send_key 'alt-a';
-            }
+            send_key $cmd{encryptdisk};
             if (!get_var('ENCRYPT_ACTIVATE_EXISTING')) {
                 assert_screen 'inst-encrypt-password-prompt';
                 type_password;


### PR DESCRIPTION
storage-NG is testing on TW staging now and openqa has to send the proper shortcut key on TW as well.

- Related failure: https://openqa.opensuse.org/tests/528199
- Verification run: http://147.2.211.11/tests/532
