### PR TITLE
Adjust partitioning_raid for new shortcuts

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -159,6 +159,11 @@ sub run {
     # create partitioning
     send_key(is_storage_ng() ? $cmd{expertpartitioner} : $cmd{createpartsetup});
 
+    if (sle_version_at_least '15') {
+        assert_screen 'expertpartitioner_list';
+        send_key 'tab';
+        send_key 'ret';
+    }
     # With storage ng, we go directly to expert partitioner and invalidate configuration by rescan
     if (is_storage_ng) {
         send_key $cmd{rescandevices};              # Rescan devices


### PR DESCRIPTION
Add version check for SLES15
Add needle check for expert partitioner drop down menu
Select expert partitioner option for version latest then 15

- see POO#27436


- Related ticket: https://progress.opensuse.org/issues/27436
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/565
- Verification run: http://10.67.17.147/tests/1709#step/partitioning_raid/1
