### PR TITLE
poo#27436: Various storage-ng partitioning fixes

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -41,6 +41,11 @@ sub wipe_existing_partitions_storage_ng {
 sub wipe_existing_partitions {
     assert_screen('release-notes-button');
     send_key match_has_tag('bsc#1054478') ? 'alt-x' : $cmd{expertpartitioner};
+    if (is_storage_ng) {
+        # start with existing configuration
+        send_key 'down';
+        send_key 'ret';
+    }
     assert_screen 'expert-partitioner';
     wait_still_screen;
     #Use storage ng

--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -116,6 +116,9 @@ sub set_lvm {
     send_key "shift-tab";
     # select LVM
     send_key "down";
+    if (is_storage_ng) {
+        send_key 'down' for (1 .. 3);
+    }
 
     # create volume group
     send_key "alt-d";
@@ -444,7 +447,6 @@ sub run {
         assert_screen 'acceptedpartitioning';
     }
 }
-
 
 1;
 # vim: set sw=4 et:

--- a/tests/installation/partitioning_resize_root.pm
+++ b/tests/installation/partitioning_resize_root.pm
@@ -16,10 +16,16 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
+use utils 'is_storage_ng';
 
 sub run {
     die "Test needs at least 40 GB HDD size" unless (get_required_var('HDDSIZEGB') > 40);
     send_key $cmd{expertpartitioner};
+    if (is_storage_ng) {
+        # start with preconfigured partitions
+        send_key 'down';
+        send_key 'ret';
+    }
     assert_screen 'expert-partitioner';
     send_key_until_needlematch 'volume-management', 'down';
     send_key 'tab';


### PR DESCRIPTION
Fixes following test suites:
* RAID0 & co.: http://assam.suse.cz/tests/1040
* lvm+RAID1: http://assam.suse.cz/tests/1178
* lvm+resize_root: http://assam.suse.cz/tests/998
* lvm-full-encrypt: http://assam.suse.cz/tests/1000

And probably other RAID-related test suites as well.

Requires: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/566.