### PR TITLE
Process online repos screen only once

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -177,6 +177,8 @@ sub fill_in_registration_data {
                 else {
                     wait_screen_change { send_key $cmd{next} };
                 }
+                # Remove tag from array not to match twice
+                @tags = grep { $_ ne 'registration-online-repos' } @tags;
                 next;
             }
             elsif (match_has_tag('module-selection')) {


### PR DESCRIPTION
On slow SUTs when we process online repos pop-up, dialog can still be
there in the next loop iteration, so will match again. In case of
pressing 'No' it leads to pressing 'Next' button and reaching addons
page. So, here simply remove tag from expected tags array.

See [poo#27448](https://progress.opensuse.org/issues/27448).
[Verification run](http://g226.suse.de/tests/247#step/scc_registration/5)
