### PR TITLE
Parse script output as may get polluted with system output

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -21,8 +21,10 @@ sub set_playground_disk {
             $vd = 'sd';
         }
         assert_script_run 'parted --script --machine -l';
-        my $disk = script_output 'parted --script --machine -l |& sed -n \'s@^\(/dev/' . $vd . '[ab]\):.*unknown.*$@\1@p\'';
-        set_var('PLAYGROUNDDISK', $disk);
+        my $output = script_output 'parted --script --machine -l';
+        # Parse playground disk
+        $output =~ m|(?<disk>/dev/$vd[ab]):.*unknown.*| || die "Failed to parse playground disk, got following output:\n$output";
+        set_var('PLAYGROUNDDISK', $+{disk});
     }
 }
 


### PR DESCRIPTION
Script output uses serial device to get execution result, however it's
used for other output as well and sometimes script output is polluted
with system output. We have same issue with kernel messages, which end
up on serial device. It doesn't look like output is in the middle of
other output, which should increase chances of getting expected values.

See [poo#25716](https://progress.opensuse.org/issues/25716).
[Verification run](http://g226.suse.de/tests/339)
