### PR TITLE
CaaSP: nfs_client: check directory with trailing / in autofs case

### DIFF
--- a/tests/caasp/nfs_client.pm
+++ b/tests/caasp/nfs_client.pm
@@ -60,7 +60,7 @@ sub run {
         }
         $script .= "echo -e \"/tmp/$a\\t/etc/auto.nfs\\t--timeout=10\" >> /etc/auto.master\n";
         $script .= "systemctl start autofs\n";
-        $script .= chkdir_strip("/tmp/$a/share");
+        $script .= chkdir_strip("/tmp/$a/share/");
 
         # autofs mount should be unmounted after 10 sec automatically
         $script .= "sleep 15\n";


### PR DESCRIPTION
As part of a kernel change, ls /tmp/nfs/share does not trigger the automount,
which is an intentional behavior change:

commit 42f46148217865a545e129612075f3d828a2c4e4
Author: Ian Kent <raven@themaw.net>
Date:   Fri Sep 8 16:16:24 2017 -0700

    autofs: fix AT_NO_AUTOMOUNT not being honored

Fixes https://bugzilla.opensuse.org/show_bug.cgi?id=1068916

[type description  here]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
