### PR TITLE
svirt: Image to upload is now openQA-SUT-1b.img

### DIFF
--- a/tests/shutdown/svirt_upload_assets.pm
+++ b/tests/shutdown/svirt_upload_assets.pm
@@ -54,7 +54,7 @@ sub run {
         if (($format ne 'raw') and ($format ne 'qcow2')) {
             next;
         }
-        push @toextract, {name => $name, format => $format, svirt_name => $svirt->name . chr(ord('a') + $i - 1)};
+        push @toextract, {name => $name, format => $format, svirt_name => $svirt->name . chr(ord('b') + $i - 1)};
     }
     for my $asset (@toextract) {
         extract_assets($asset);


### PR DESCRIPTION
It used to be openQA-SUT-1a but now is openQA-SUT-1b due to this change: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3906.

Fails here: https://openqa.suse.de/tests/1257128/#step/svirt_upload_assets/6.