### PR TITLE
Add update test for CaaSP

### DIFF
--- a/data/caasp/update.sh
+++ b/data/caasp/update.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -exuo pipefail
+
+# Fake update repositories for QA tests
+# 2.0 -> 2.0 http://download.suse.de/ibs/Devel:/CASP:/2.0:/ControllerNode:/TestUpdate/standard/Devel:CASP:2.0:ControllerNode:TestUpdate.repo
+# 3.0 -> 3.0 TODO
+
+usage() {
+	echo "Usage: $0
+		[-s $REPO] Setup all nodes with update REPO
+		[-c] Check that update was applied" 1>&2
+	exit 1
+}
+
+while getopts "s:c" opt; do
+case $opt in
+	s)
+		SETUP=$OPTARG
+		;;
+	c)
+		CHECK=true
+		;;
+	\?)
+		usage
+		;;
+	:)
+		echo "Option -$opt requires an argument." >&2
+		usage
+		;;
+esac
+done
+
+# Set up some shortcuts
+saltid=$(docker ps | grep salt-master | awk '{print $1}')
+where="-P roles:(admin|kube-(master|minion))"
+srun="docker exec -i $saltid salt --batch 7"
+runner="$srun $where cmd.run"
+
+if [ ! -z "${SETUP:-}" ]; then
+	# Remove non-existent ISO repository
+	# Workaround because of higher package versions
+	$runner "zypper rr 1"
+
+	# Add repository as system venodors
+	$runner 'echo -e "[main]\nvendors = suse,opensuse,obs://build.suse.de,obs://build.opensuse.org" > /etc/zypp/vendors.d/vendors.conf'
+	$runner "zypper ar --refresh --no-gpgcheck $SETUP UPDATE"
+	$runner "zypper lr -U"
+
+	# Manually Trigger Transactional Update (or wait up to 24 hours for it run by itself)
+	$runner 'systemctl disable --now transactional-update.timer'
+	$runner '/usr/sbin/transactional-update cleanup dup salt'
+
+	# Manually Refresh the Grains (or wait up to 10 minutes)
+	$srun '*' saltutil.refresh_grains
+
+elif [ ! -z "${CHECK:-}" ]; then
+	# caasp-container-manifests
+	# check installed version
+	zypper if --provides caasp-container-manifests | grep 100.0.0
+	# check there is a "fo:bar" in the public manifests
+	grep "fo: bar" /usr/share/caasp-container-manifests/public.yaml
+	# check the change has been "activated"
+	grep "fo: bar" /etc/kubernetes/manifests/public.yaml
+	
+	# container-feeder
+	# check installed version
+	zypper if --provides container-feeder | grep 100.0.0
+	# check changes in README - zypper config changed to exclude doc
+	# grep "This image has been updated fine" /usr/share/doc/packages/container-feeder/README.md
+	
+	# kubernetes-salt
+	# check version
+	zypper if --provides kubernetes-salt | grep 100.0
+	# check etc/motd in a minion node
+	COMMAND="grep 'This has been updated fine' /etc/motd"
+	$srun -P "roles:kube-minion" cmd.run "$COMMAND" | grep 'This has been updated fine'
+	
+	# velum image
+	# check version
+	rpm -q sles12-velum-image | grep sles12-velum-image-100.0.0.*
+	# check image has been loaded
+	image_id=$(docker images | grep sles12/velum | grep 100.0 | head -1 | awk '{print $3}')
+	container_id=$(docker ps | grep $image_id | grep dashboard | awk '{print $1}')
+	# check change is in the image
+	docker exec -i $container_id ls /IMAGE_UPDATED
+fi
+
+# Workaround for assert_script_run "update.sh | tee $serialdev | grep EXIT_0", otherwise exit status is from tee
+echo 'EXIT_OK'

--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -18,7 +18,7 @@ use testapi;
 use mmapi;
 use utils qw(power_action assert_shutdown_and_restore_system);
 
-our @EXPORT = qw(handle_simple_pw process_reboot trup_call write_detail_output get_admin_job);
+our @EXPORT = qw(handle_simple_pw process_reboot trup_call write_detail_output get_admin_job update_scheduled);
 
 # Weak password warning should be displayed only once - bsc#1025835
 sub handle_simple_pw {
@@ -119,6 +119,22 @@ sub get_admin_job {
         if (get_job_info($job_id)->{settings}->{STACK_ROLE} eq 'admin') {
             return $job_id;
         }
+    }
+}
+
+sub update_scheduled {
+    # Don't update MicroOS tests
+    return 0 unless get_var('STACK_ROLE');
+
+    # Don't update staging
+    return 0 if get_var('FLAVOR') =~ /Staging-?-DVD/;
+
+    # Return update repository if it's set on controller node
+    if (check_var('STACK_ROLE', 'controller')) {
+        return get_var('INCIDENT_REPO');
+    }
+    else {
+        return get_job_info(get_controller_job)->{settings}->{INCIDENT_REPO};
     }
 }
 

--- a/lib/caasp_controller.pm
+++ b/lib/caasp_controller.pm
@@ -45,13 +45,14 @@ sub post_fail_hook {
     sleep if check_var('DEBUG_SLEEP', 'controller');
 
     # Destroy barriers and create mutexes to avoid deadlock
-    barrier_destroy "WORKERS_INSTALLED";
-    mutex_create "NODES_ACCEPTED";
+    barrier_destroy 'WORKERS_INSTALLED';
+    mutex_create 'NODES_ACCEPTED';
     mutex_create 'VELUM_CONFIGURED';
-    mutex_create "CNTRL_FINISHED";
+    mutex_create 'UPDATE_FINISHED';
+    mutex_create 'CNTRL_FINISHED';
 
     # Wait for log export from admin node
-    mutex_lock "ADMIN_LOGS_EXPORTED", get_admin_job;
+    mutex_lock 'ADMIN_LOGS_EXPORTED', get_admin_job;
 }
 
 1;

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -11,6 +11,7 @@ BEGIN {
 }
 use utils;
 use main_common;
+use caasp 'update_scheduled';
 
 init_main();
 
@@ -128,6 +129,8 @@ sub load_stack_tests {
         loadtest 'caasp/stack_configure';
         loadtest 'caasp/stack_bootstrap';
         loadtest 'caasp/stack_kubernetes';
+        loadtest 'caasp/stack_update' if update_scheduled;
+        loadtest 'caasp/stack_finalize';
     }
     else {
         loadtest "caasp/stack_" . get_var('STACK_ROLE');

--- a/tests/caasp/oci_keyboard.pm
+++ b/tests/caasp/oci_keyboard.pm
@@ -21,6 +21,9 @@ sub run {
     send_key 'up';
     send_key 'ret' if check_var('VIDEOMODE', 'text');
 
+    # Wait for keyboard switch before typing
+    sleep 1;
+
     # Check that UK layout is active
     send_key 'alt-g';
     type_string '~@#\"|';    # writes ¬"£#@~

--- a/tests/caasp/stack_bootstrap.pm
+++ b/tests/caasp/stack_bootstrap.pm
@@ -38,7 +38,7 @@ sub select_nodes {
     # Select all nodes as workers
     assert_and_click 'velum-bootstrap-select-nodes';
     # Wait until warning messages disappears
-    wait_still_screen 3;
+    wait_still_screen 2;
 }
 
 # Select master.openqa.test and additional master nodes
@@ -54,6 +54,8 @@ sub select_master {
     # Select master node
     mouse_set $x, $y;
     mouse_click;
+    # Don't click-and-drag
+    sleep 1;
     mouse_hide;
 
     # Give velum time to process
@@ -114,7 +116,7 @@ sub kubectl_config {
 
     # Download takes few seconds
     sleep 5;
-    save_screenshot;
+    assert_and_click 'velum-kubeconfig-back';
 }
 
 sub run {

--- a/tests/caasp/stack_finalize.pm
+++ b/tests/caasp/stack_finalize.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Last controller module test
+# Maintainer: Martin Kravec <mkravec@suse.com>
+
+use parent 'caasp_controller';
+
+use strict;
+use lockapi 'mutex_create';
+use mmapi 'wait_for_children';
+
+sub run {
+    # Allow cluster nodes to finish
+    mutex_create "CNTRL_FINISHED";
+    # Wait until they export logs
+    wait_for_children;
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/tests/caasp/stack_kubernetes.pm
+++ b/tests/caasp/stack_kubernetes.pm
@@ -14,8 +14,6 @@ use parent 'caasp_controller';
 use strict;
 use utils;
 use testapi;
-use lockapi 'mutex_create';
-use mmapi 'wait_for_children';
 
 sub run {
     # Use downloaded kubeconfig to display basic information
@@ -25,6 +23,7 @@ sub run {
 
     assert_script_run "kubectl cluster-info";
     assert_script_run "kubectl get nodes";
+    assert_script_run "! kubectl get cs --no-headers | grep -v Healthy";
 
     # Check cluster size
     # %number_of_jobs - minus admin job
@@ -49,9 +48,8 @@ sub run {
     type_string "firefox node1.openqa.test:\$NODEPORT\n";
     assert_screen 'nginx-alpine';
 
-    # Put this in last controller module test
-    mutex_create "CNTRL_FINISHED";
-    wait_for_children;
+    # Switch back to velum
+    send_key "ctrl-tab";
 }
 
 1;

--- a/tests/caasp/stack_update.pm
+++ b/tests/caasp/stack_update.pm
@@ -1,0 +1,83 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Update cluster from OBS repository
+#   SSH keys are already generated
+#   SSH config was modified to not check identity
+#   Script is not run on admin to avoid mutex hell
+# Maintainer: Martin Kravec <mkravec@suse.com>
+
+use parent 'caasp_controller';
+use caasp_controller;
+
+use strict;
+use testapi;
+use lockapi 'mutex_create';
+use caasp 'update_scheduled';
+
+# Set up ssh to admin node and run update script on all nodes
+sub setup_update_repository {
+    my $repo = update_scheduled;
+
+    # Switch to xterm
+    send_key 'alt-tab';    # select_console 'user-console'
+    script_run 'ssh-copy-id -f admin.openqa.test', 0;
+    assert_screen 'ssh-password-prompt';
+    type_password;
+    send_key 'ret';
+    assert_script_run "ssh admin.openqa.test './update.sh -s $repo' | tee /dev/$serialdev | grep EXIT_OK", 120;
+
+    # Switch to velum
+    send_key 'alt-tab';    # select_console 'x11';
+}
+
+# Check that update changed system as expected
+sub check_update_changes {
+    # Switch to xterm
+    send_key 'alt-tab';    # select_console 'user-console'
+
+    # Kubernetes checks
+    assert_script_run "kubectl cluster-info";
+    assert_script_run "! kubectl get cs --no-headers | grep -v Healthy";
+    my $nodes_count = get_required_var("STACK_NODES");
+    assert_script_run "kubectl get nodes --no-headers | wc -l | grep $nodes_count";
+
+    # Containers check
+    assert_script_run "ssh admin.openqa.test './update.sh -c' | tee /dev/$serialdev | grep EXIT_OK", 60;
+
+    # Switch to velum
+    send_key 'alt-tab';    # select_console 'x11';
+}
+
+sub run {
+    setup_update_repository;
+
+    my $nodes = get_required_var('STACK_NODES');
+    assert_screen "velum-$nodes-nodes-outdated";
+    die "Can't update nodes before admin" if check_screen "velum-update-all", 0;
+
+    # Update admin node (~160s for admin reboot)
+    assert_and_click 'velum-update-admin';
+    assert_and_click 'velum-update-reboot';
+
+    # Update all nodes - this part takes long time (~2 minutes per node)
+    assert_screen "velum-$nodes-nodes-outdated", 300;
+    die "Admin should be updated already" if check_screen 'velum-update-admin', 0;
+    assert_and_click "velum-update-all";
+
+    assert_screen 'velum-bootstrap-done', $nodes * 150;
+    die "Nodes should be updated already" if check_screen "velum-0-nodes-outdated", 0;
+
+    check_update_changes;
+    mutex_create 'UPDATE_FINISHED';
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/tests/caasp/stack_worker.pm
+++ b/tests/caasp/stack_worker.pm
@@ -14,6 +14,7 @@ use base "opensusebasetest";
 use strict;
 use testapi;
 use lockapi;
+use caasp 'update_scheduled';
 
 sub run {
     # Notify others that installation finished
@@ -26,7 +27,14 @@ sub run {
 
 sub post_run_hook {
     # Password is set later on autoyast nodes
-    select_console('root-console') if get_var('AUTOYAST');
+    if (get_var 'AUTOYAST') {
+        select_console('root-console');
+    }
+    # Cluster node was rebooted
+    elsif (update_scheduled) {
+        reset_consoles;
+        select_console 'root-console';
+    }
 
     script_run "journalctl > journal.log", 90;
     upload_logs "journal.log";


### PR DESCRIPTION
Local run: http://dhcp91.suse.cz/tests/8276
Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/581
 - contains needles for 5-node jobs, others will fail on velum-<3>-nodes-outdated needle

New SLES image (with ssh workarounds) uploaded

