### PR TITLE
Libstorage-NG: update 'filesystem' shortcut

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -27,13 +27,10 @@ sub run {
         # Define changed shortcuts
         $cmd{donotformat} = 'alt-t';
         $cmd{addraid}     = 'alt-i';
+        $cmd{filesystem}  = 'alt-a';
         if (check_var('DISTRI', 'opensuse')) {
             $cmd{expertpartitioner} = 'alt-x';
             $cmd{rescandevices}     = 'alt-c';
-
-        }
-        else {
-            $cmd{filesystem} = 'alt-a';
         }
     }
 


### PR DESCRIPTION
Commit eb83956fce1 changed the shortcut for openSUSE to be different
than SLE. Changes introduced since then show this no longer to be valid,
and all three tested products (TW, Leap, SLE) use alt-a to select
"Format device".

Reference screenshots:
SLE15: https://openqa.suse.de/tests/1258060#step/partitioning_raid/201
Leap15: https://openqa.opensuse.org/tests/537687#step/partitioning_raid/201
Tumbleweed: https://openqa.opensuse.org/tests/537668#step/partitioning_raid/44

