### PR TITLE
 Detect YaST errors during installation and  Use new shortcuts also for tumbleweed 

### DIFF
--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -52,7 +52,7 @@ sub run {
 
     # workaround for yast popups and
     # detect "Wrong Digest" error to end test earlier
-    my @tags = qw(rebootnow yast2_wrong_digest yast2_package_retry);
+    my @tags = qw(rebootnow yast2_wrong_digest yast2_package_retry yast2_error);
     if (get_var("UPGRADE")) {
         push(@tags, "ERROR-removing-package");
         push(@tags, "DIALOG-packages-notifications");
@@ -101,6 +101,10 @@ sub run {
         }
         else {
             assert_screen \@tags, $timeout;
+        }
+
+        if (match_has_tag("yast2_error")) {
+            die "A YaST error occurred. Check the logs.";
         }
 
         if (match_has_tag("yast2_wrong_digest")) {

--- a/tests/installation/partitioning_expert.pm
+++ b/tests/installation/partitioning_expert.pm
@@ -17,29 +17,30 @@ use base "y2logsstep";
 use testapi;
 
 sub run() {
-    send_key $cmd{expertpartitioner};
+    wait_screen_change { send_key 'alt-x-c' };    # Expert partitioner, using current proposal
     assert_screen 'expert-partitioner';
 
     # Delete home partition
     assert_and_click 'hard-disks';
     assert_and_click 'home';
 
-    wait_screen_change { send_key 'alt-d' };    # Delete
-    wait_screen_change { send_key 'alt-y' };    # Confirm with 'yes'
-    assert_and_click 'hard-disks';
-    save_screenshot;
+    wait_screen_change { send_key 'alt-d' };      # Delete
+    assert_screen 'really-delete';
+    wait_screen_change { send_key 'alt-y' };      # Confirm with 'yes'
 
     # Add a btrfs subvolume
     assert_and_click 'btrfs';
-    wait_screen_change { send_key 'alt-e' };    # Edit
-    wait_screen_change { send_key 'alt-a' };    # Add
+    wait_screen_change { send_key 'alt-d' };      # Edit
+    wait_screen_change { send_key 'alt-a' };      # Add
     type_string '@/usr/lib';
-    wait_screen_change { send_key 'alt-n' };    # noCoW
-    wait_screen_change { send_key 'alt-o' };    # Ok
-    wait_screen_change { send_key 'alt-o' };    # Ok
+    wait_screen_change { send_key 'alt-n' };      # noCoW
+    save_screenshot;
+    wait_screen_change { send_key 'alt-o' };      # Ok
+    wait_screen_change { send_key 'alt-o' };      # Ok
 
     wait_screen_change { send_key $cmd{accept} };
     assert_and_click 'see-details';
+    assert_screen 'usr-lib';
     die "/home still there" if check_screen('home', 0);
 }
 


### PR DESCRIPTION
During YaST development it happens from time to time that we get errors during installation that can only be detected after the really long installation timeout has ended. This change shortens the failures significantly.

Also the way how to get into the expert partitioner has changed. Here the test has been changed accordingly and also got a few more checks and screen shots to make it more reliable.

- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/286
- Verification run: 
  YaST Error detection: https://yast-openqa.suse.cz/tests/7468#step/install_and_reboot/3
  Expert partitioner: https://yast-openqa.suse.cz/tests/7461#step/partitioning_expert/1
