### PR TITLE
Fix regexp to match repo and package names

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -41,7 +41,7 @@ sub run {
     my ($base_repos, $package);
     my $output = script_output 'echo $(zypper -n -x se -i -t product -s ' . $prod . ')', 300;
     # Parse base repositories
-    if (my @repos = $output =~ /repository="([\w-]+)"/g) {
+    if (my @repos = $output =~ /repository="(.+)"/g) {
         $base_repos = join(" ", @repos);
     }
 
@@ -49,7 +49,7 @@ sub run {
 
     $output = script_output 'echo $(for repo in ' . $base_repos . ' ; do zypper -n -x se -t package -i -s -r $repo ; done )', 300;
     # Parse package name
-    if ($output =~ /name="(?<package>[\w-]+)"/) {
+    if ($output =~ /name="(?<package>.+)"/) {
         $package = $+{package};
     }
 


### PR DESCRIPTION
Trying to make picky regexp, I've tried to hard and missed the point
that dot can be there. To play it safe, we switch to same regexp we had
in command line, as it was good enough.

- Related ticket: [poo#25716](https://progress.opensuse.org/issues/25716).
- [Verification run](http://g226.suse.de/tests/401)
