### PR TITLE
Fix keyboard timing

### DIFF
--- a/tests/x11regressions/firefox/firefox_java.pm
+++ b/tests/x11regressions/firefox/firefox_java.pm
@@ -20,6 +20,7 @@ sub java_testing {
     my ($self) = @_;
 
     send_key "ctrl-t";
+    assert_screen 'firefox-new-tab';
     send_key "alt-d";
     type_string "http://www.java.com/en/download/installed.jsp?detect=jre\n";
 

--- a/tests/x11regressions/firefox/firefox_private.pm
+++ b/tests/x11regressions/firefox/firefox_private.pm
@@ -19,8 +19,9 @@ sub run {
     my ($self) = @_;
     $self->start_firefox;
 
+    wait_still_screen 1;
     send_key "ctrl-shift-p";
-    send_key "alt-d";
+    assert_screen 'firefox-private-browsing';
     type_string "gnu.org\n";
     $self->firefox_check_popups;
     assert_screen('firefox-private-gnu', 90);


### PR DESCRIPTION
Fix poo#27618: Keyboard shortcut is typed fast, Firefox is not able to
switch to private mode. Also fix potential timing issue in firefox_java.

- Related ticket: https://progress.opensuse.org/issues/27618
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/572
- Verification run: 
SLE12-SP2: http://10.100.12.105/tests/589#step/firefox_private/9
SLE12-SP3: http://10.100.12.105/tests/583#step/firefox_private/9

Wait was replaced with new needle match for Firefox java new tab and Firefox private browsing.
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/577

Private browsing: http://10.100.12.105/tests/591#step/firefox_private/9
New tab: http://10.100.12.105/tests/591#step/firefox_java/14

