### PR TITLE
registration and LTP fixes

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -21,7 +21,7 @@ use Exporter;
 use strict;
 
 use testapi;
-use utils qw(addon_decline_license assert_screen_with_soft_timeout sle_version_at_least);
+use utils qw(addon_decline_license assert_screen_with_soft_timeout scc_version sle_version_at_least);
 
 our @EXPORT = qw(
   add_suseconnect_product

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -15,6 +15,7 @@ use warnings;
 use base 'opensusebasetest';
 use testapi;
 use utils;
+use registration;
 
 sub add_repos {
     my $qa_head_repo = get_required_var('QA_HEAD_REPO');

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -29,7 +29,7 @@ sub scc_we_enabled {
 }
 
 sub add_desktop_productivity_module {
-    if (check_var('DISTRI', 'sle') and sle_version_at_least('15')) {
+    if (get_required_var('ARCH') eq 'x86_64' and check_var('DISTRI', 'sle') and sle_version_at_least('15')) {
         add_suseconnect_product("sle-module-desktop-productivity");
     }
 }


### PR DESCRIPTION
Add missing module in registration.
Add missing module in LTP. @mimi1vx: This is for you, sorry to break it
Register Desktop productivity module only for x86_64 as this module isn't available for other architectures.