### PR TITLE
Improve regexp and get less output on serial device in zypper_lifecycle

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -41,15 +41,15 @@ sub run {
     my ($base_repos, $package);
     my $output = script_output 'echo $(zypper -n -x se -i -t product -s ' . $prod . ')', 300;
     # Parse base repositories
-    if (my @repos = $output =~ /repository="(.+)"/g) {
+    if (my @repos = $output =~ /repository="([^"]+)"/g) {
         $base_repos = join(" ", @repos);
     }
 
     die "Got malformed repo list:\n $output" unless $base_repos;
 
-    $output = script_output 'echo $(for repo in ' . $base_repos . ' ; do zypper -n -x se -t package -i -s -r $repo ; done )', 300;
+    $output = script_output 'echo $(for repo in ' . $base_repos . ' ; do zypper -n -x se -t package -i -s -r $repo ; done | grep name= | head -n 1 )', 300;
     # Parse package name
-    if ($output =~ /name="(?<package>.+)"/) {
+    if ($output =~ /name="(?<package>[^"]+)"/) {
         $package = $+{package};
     }
 


### PR DESCRIPTION
In some runs with SP3 zypper command we execute throws too much data and
it's not possible to parse script-finished part with exit code, which
fails test.

Fixes issues introduced by [PR#3909](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3909)

- Related ticket: [poo#25716](https://progress.opensuse.org/issues/25716)
- Verification run: g226.suse.de/tests/438#
