### PR TITLE
Run PostgreSQL10 on SLES 15

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -861,7 +861,7 @@ sub load_consoletests {
         loadtest "console/http_srv";
         loadtest "console/mysql_srv";
         loadtest "console/dns_srv";
-        loadtest "console/postgresql96server";
+        loadtest "console/postgresql_server";
         if (sle_version_at_least('12-SP1')) {    # shibboleth-sp not available on SLES 12 GA
             loadtest "console/shibboleth";
         }

--- a/tests/console/postgresql_server.pm
+++ b/tests/console/postgresql_server.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Postgres tests for SLE12
+# Summary: Postgres tests
 # Maintainer: Ondřej Súkup <osukup@suse.cz>
 
 use base "consoletest";
@@ -19,20 +19,16 @@ use apachetest;
 sub run {
     select_console 'root-console';
 
+    my $pgsql_server = sle_version_at_least('15') ? 'postgresql10-server' : 'postgresql96-server';
     # install the postgresql server package
-    zypper_call 'in postgresql96-server sudo';
+    zypper_call "in $pgsql_server sudo";
 
     # start the postgresql service
     assert_script_run 'systemctl start postgresql.service', 200;
 
     # check the status
     assert_script_run 'systemctl show -p ActiveState postgresql.service | grep ActiveState=active';
-    if (is_sle && sle_version_at_least('15')) {
-        record_soft_failure 'Workaround for bsc#1060639: postgresql96 server service exits with "active (exited)"';
-    }
-    else {
-        assert_script_run 'systemctl show -p SubState postgresql.service | grep SubState=running';
-    }
+    assert_script_run 'systemctl show -p SubState postgresql.service | grep SubState=running';
 
     # test basic functionality of postgresql
     setup_pgsqldb;


### PR DESCRIPTION
Make PostgreSQL server test's name more generic. Run it with v10 on
SLE-15, with 9.6 elsewhere as it used to be.

Validation run: http://assam.suse.cz/tests/1227
Addresses: https://progress.opensuse.org/issues/27512