### PR TITLE
Split install_and_reboot for easier problem analysis

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -88,6 +88,7 @@ our @EXPORT = qw(
   load_networkd_tests
   load_nfv_master_tests
   load_nfv_trafficgen_tests
+  load_common_installation_steps_tests
   load_iso_in_external_tests
   load_x11_documentation
   load_x11_gnome
@@ -648,6 +649,12 @@ sub boot_hdd_image {
     loadtest "boot/boot_to_desktop";
 }
 
+sub load_common_installation_steps_tests {
+    loadtest 'installation/await_install';
+    loadtest 'installation/logs_from_installation_system';
+    loadtest 'installation/reboot_after_installation';
+}
+
 sub load_inst_tests {
     loadtest "installation/welcome";
     loadtest "installation/keyboard_selection";
@@ -860,7 +867,7 @@ sub load_inst_tests {
         loadtest "installation/start_install";
     }
     return 1 if get_var('EXIT_AFTER_START_INSTALL');
-    loadtest "installation/install_and_reboot";
+    load_common_installation_steps_tests;
     if (check_var('BACKEND', 'svirt') and check_var('ARCH', 's390x')) {
         # on svirt we need to redefine the xml-file to boot the installed kernel
         loadtest "installation/redefine_svirt_domain";

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -89,8 +89,7 @@ sub load_caasp_inst_tests {
         return if check_var('FAIL_EXPECTED', 'SMALL-DISK');
         return if check_var('FAIL_EXPECTED', 'BSC_1043619');
 
-        # Actual installation
-        loadtest 'installation/install_and_reboot';
+        load_common_installation_steps_tests;
     }
 }
 

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -1,0 +1,48 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Collect logs from the installation system just before we try to
+#   reboot into the installed system
+# Maintainer: Oliver Kurz <okurz@suse.de>
+
+use strict;
+use base 'y2logsstep';
+use testapi;
+use lockapi;
+use utils;
+use version_utils qw(is_caasp is_hyperv_in_gui);
+use ipmi_backend_utils;
+
+sub run {
+    my ($self) = @_;
+    return if get_var('REMOTE_CONTROLLER') || is_caasp || is_hyperv_in_gui;
+    select_console 'install-shell';
+
+    # check for right boot-device on s390x (zVM, DASD ONLY)
+    if (check_var('BACKEND', 's390x') && !check_var('S390_DISK', 'ZFCP')) {
+        if (script_run('lsreipl | grep 0.0.0150')) {
+            die "IPL device was not set correctly";
+        }
+    }
+    # while technically SUT has a different network than the BMC
+    # we require ssh installation anyway
+    if (check_var('BACKEND', 'ipmi')) {
+        use_ssh_serial_console;
+        # set serial console for xen
+        set_serial_console_on_xen('/mnt') if (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen'));
+    }
+    else {
+        # avoid known issue in FIPS mode: bsc#985969
+        $self->get_ip_address();
+    }
+    $self->save_upload_y2logs();
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/installation/reboot_after_installation.pm
+++ b/tests/installation/reboot_after_installation.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Prepare and trigger the reboot into the installed system
+# Maintainer: Oliver Kurz <okurz@suse.de>
+
+use strict;
+use base 'y2logsstep';
+use testapi;
+use utils;
+
+sub run {
+    select_console 'installation';
+    wait_screen_change {
+        send_key 'alt-o';    # Reboot
+    };
+
+    power_action('reboot', observe => 1, keepconsole => 1);
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Test modules with "and" in the name are already candidates for splitting :)
Previously "install_and_reboot" was mainly doing three things while taking
some time for installation as well as conducting a lot of steps to collect
logs before rebooting. This commit splits the test module into the more
product relevant part "await_install" which by itself most likely takes the
longest time and the other two modules "logs_from_installation_system" -
mainly test relevant - and "reboot_after_installation" - last checkpoint
before the actual rebooting of the machine. This simplifies error
identification just by the potential failing test module as well as easier
investigation and test development using qemu snapshots. On top it serves as a
good extension point whenever we want to conduct another step just before
requesting the reboot after installation.

Verification runs:
* SLE: http://lord.arch/tests/520
* Kubic: http://lord.arch/tests/526