### PR TITLE
Harmonize openSUSE/SLE schedule for image creation

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -953,12 +953,7 @@ if (get_var("CLONE_SYSTEM")) {
     load_autoyast_clone_tests;
 }
 
-if (get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1")) {
-    if (get_var("INSTALLONLY")) {
-        loadtest "shutdown/grub_set_bootargs";
-        loadtest "shutdown/shutdown";
-    }
-}
+load_create_hdd_tests if get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1");
 
 1;
 # vim: set sw=4 et:

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -70,17 +70,6 @@ sub is_update_test_repo_test {
     return get_var('TEST') !~ /^mru-/ && is_updates_tests;
 }
 
-sub is_bridged_networking {
-    my $ret = 0;
-    if (check_var('BACKEND', 'svirt') and !check_var('ARCH', 's390x')) {
-        my $vmm_family = get_required_var('VIRSH_VMM_FAMILY');
-        $ret = ($vmm_family =~ /xen|vmware|hyperv/);
-    }
-    # Some needles match hostname which we can't set permanently with bridge.
-    set_var('BRIDGED_NETWORKING', 1) if $ret;
-    return $ret;
-}
-
 sub default_desktop {
     return undef   if get_var('VERSION', '') lt '12';
     return 'gnome' if get_var('VERSION', '') lt '15';
@@ -1167,7 +1156,7 @@ elsif (get_var("REGRESSION")) {
         loadtest "x11regressions/x11regressions_setup";
         # temporary adding test modules which applies hacks for missing parts in sle15
         loadtest "console/sle15_workarounds" if sle_version_at_least('15');
-        loadtest "console/hostname" unless is_bridged_networking;
+        loadtest "console/hostname"       unless is_bridged_networking;
         loadtest "console/force_cron_run" unless is_jeos;
         loadtest "shutdown/grub_set_bootargs";
         loadtest "shutdown/shutdown";
@@ -1589,19 +1578,7 @@ if (get_var("CLONE_SYSTEM")) {
     load_autoyast_clone_tests;
 }
 
-if (get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1")) {
-    if (get_var("INSTALLONLY")) {
-        # temporary adding test modules which applies hacks for missing parts in sle15
-        loadtest "console/sle15_workarounds" if sle_version_at_least('15');
-        loadtest "console/hostname" unless is_bridged_networking;
-        loadtest "console/force_cron_run" unless is_jeos;
-        loadtest "shutdown/grub_set_bootargs";
-        loadtest "shutdown/shutdown";
-        if (check_var("BACKEND", "svirt")) {
-            loadtest "shutdown/svirt_upload_assets";
-        }
-    }
-}
+load_create_hdd_tests if get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1");
 
 if (get_var("TCM") || check_var("ADDONS", "tcm")) {
     loadtest "console/force_cron_run";


### PR DESCRIPTION
The images generated when the according test variables are set including
"INSTALLONLY" should use the same schedule for both openSUSE in SLE in
general. This commit extracts the wrongly duplicated code into
lib/main_common.pm . This should have no effect on SLE because the schedule is
unchanged. The main effect for openSUSE is that now 'console/force_cron_run'
is called which can make quite some difference for downstream jobs where the
sporadic "btrfs rebalancing" could slow down the SUT.

The only downside is that the image creation job takes longer to execute
force_cron_run, e.g. 40 minutes in the verification run instead of just 24
minutes. But to me that drawback does not outweigh the benefit.

Verification run: http://lord.arch/tests/8060

Related progress issue: https://progress.opensuse.org/issues/27004