### PR TITLE
Fix SLE15 installation version when SLE12 previously present

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -350,6 +350,10 @@ sub is_sle12_hdd_in_upgrade {
     return get_var('UPGRADE') && !sle_version_at_least('15', version_variable => 'HDDVERSION');
 }
 
+sub is_sle12_layered_before_install {
+    return get_var('VERSION_LAYERED');
+}
+
 sub type_string_slow {
     my ($string) = @_;
 
@@ -1451,7 +1455,12 @@ sub get_root_console_tty {
     is running on tty2 by default. see also: bsc#1054782
 =cut
 sub get_x11_console_tty {
-    my $new_gdm = !(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15.0')) && !is_sle12_hdd_in_upgrade && !is_caasp;
+    my $new_gdm
+      = !(is_sle   && !sle_version_at_least('15'))
+      && !(is_leap && !leap_version_at_least('15.0'))
+      && !is_sle12_hdd_in_upgrade
+      && !is_caasp
+      && !is_sle12_layered_before_install;
     return (check_var('DESKTOP', 'gnome') && get_var('NOAUTOLOGIN') && $new_gdm) ? 2 : 7;
 }
 


### PR DESCRIPTION
Fix sle version on SLE15 Installation with previous SLE12 installed. We need to change sle version at the middle of the test, due to two products are being under test.
We also need the following parameters added to jobs gnome+do_not_import_ssh_keys & gnome+import_ssh_keys to make it work:

SCC_REGISTER=installation 
VERSION=12-SP1 
VERSION_ACTUAL=15

- Related ticket: https://progress.opensuse.org/issues/25854
- Needles:  https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/576
- Verification run: http://dhcp227/tests/398#
