### PR TITLE
Rename gnome-basic to gnome_basic pattern for sle 15 autoyast profiles

### DIFF
--- a/data/autoyast_sle15/autoyast_btrfs.xml
+++ b/data/autoyast_sle15/autoyast_btrfs.xml
@@ -124,7 +124,7 @@
       <pattern>base</pattern>
       <pattern>basesystem</pattern>
       <pattern>documentation</pattern>
-      <pattern>gnome-basic</pattern>
+      <pattern>gnome_basic</pattern>
       <pattern>minimal_base</pattern>
       <pattern>x11</pattern>
     </patterns>

--- a/data/autoyast_sle15/autoyast_error.xml
+++ b/data/autoyast_sle15/autoyast_error.xml
@@ -86,7 +86,7 @@
       <pattern>apparmor</pattern>
       <pattern>base</pattern>
       <pattern>documentation</pattern>
-      <pattern>gnome-basic</pattern>
+      <pattern>gnome_basic</pattern>
       <pattern>minimal_base</pattern>
       <pattern>x11</pattern>
     </patterns>

--- a/data/autoyast_sle15/autoyast_ext4.xml
+++ b/data/autoyast_sle15/autoyast_ext4.xml
@@ -95,7 +95,7 @@
       <pattern>base</pattern>
       <pattern>basesystem</pattern>
       <pattern>documentation</pattern>
-      <pattern>gnome-basic</pattern>
+      <pattern>gnome_basic</pattern>
       <pattern>minimal_base</pattern>
       <pattern>x11</pattern>
     </patterns>

--- a/data/autoyast_sle15/autoyast_gnome.xml
+++ b/data/autoyast_sle15/autoyast_gnome.xml
@@ -52,7 +52,7 @@
       <pattern>base</pattern>
       <pattern>basesystem</pattern>
       <pattern>documentation</pattern>
-      <pattern>gnome-basic</pattern>
+      <pattern>gnome_basic</pattern>
       <pattern>minimal_base</pattern>
       <pattern>x11</pattern>
     </patterns>

--- a/data/autoyast_sle15/bug-879147_autoinst.xml
+++ b/data/autoyast_sle15/bug-879147_autoinst.xml
@@ -264,7 +264,7 @@
     <patterns config:type="list">
       <pattern>base</pattern>
       <pattern>basesystem</pattern>
-      <pattern>gnome-basic</pattern>
+      <pattern>gnome_basic</pattern>
       <pattern>minimal_base</pattern>
       <pattern>x11</pattern>
     </patterns>

--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -525,7 +525,7 @@
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>
-      <pattern>gnome-basic</pattern>
+      <pattern>gnome_basic</pattern>
       <pattern>minimal_base</pattern>
       <pattern>x11</pattern>
     </patterns>


### PR DESCRIPTION
gnome-basic pattern was renamed to gnome_basic. Installation verified
manually.
