### PR TITLE
Check that zypper does not return 0 if update was aborted

### DIFF
--- a/tests/caasp/rebootmgr.pm
+++ b/tests/caasp/rebootmgr.pm
@@ -112,13 +112,13 @@ sub check_strategy_etcd_lock {
 sub run {
     type_string "tput civis\n";
 
-    record_info 'Test #1', 'Test instant reboot';
+    record_info 'Instantly', 'Test instant reboot';
     check_strategy_instantly;
 
-    record_info 'Test #2', 'Test maint-window strategy';
+    record_info 'Maint-window', 'Test maint-window strategy';
     check_strategy_maint_window;
 
-    record_info 'Test #3', 'Test etcd locking strategy';
+    record_info 'Etcd', 'Test etcd locking strategy';
     check_strategy_etcd_lock;
 }
 

--- a/tests/caasp/transactional_update.pm
+++ b/tests/caasp/transactional_update.pm
@@ -78,19 +78,19 @@ sub run {
     if (check_var('DISTRI', 'caasp')) {
         $ptfutsver     = '5.3.61';
         $ptfutsverlong = '5-5.3.61';
-        $oriutsver     = '5.29.2';
+        $oriutsver     = '5.30.1';
     }
 
     script_run "rebootmgrctl set-strategy off";
 
     get_utt_packages;
 
-    record_info 'Test #1', 'Install package - snapshot #1';
+    record_info 'Install ptf', 'Install package - snapshot #1';
     trup_call "ptf install update-test-trival/update-test-security-$ptfutsverlong.x86_64.rpm";
     check_reboot_changes;
     check_package "$ptfutsver";
 
-    record_info 'Test #2', 'Add repository and update - snapshot #2';
+    record_info 'Update #1', 'Add repository and update - snapshot #2';
     # FIXME: Disable test for now on Kubic, as impossible to change package versions ATM
     if (check_var('DISTRI', 'kubic')) {
         record_soft_failure('Test #2 Skipped on openSUSE Kubic');
@@ -105,19 +105,29 @@ sub run {
         check_package "$oriutsver";
     }
 
-    record_info 'Test #3', 'System should be up to date - no changes expected';
+    record_info 'Update #2', 'System should be up to date - no changes expected';
     trup_call 'cleanup up';
     check_reboot_changes 0;
 
-    record_info 'Test #4', 'Remove package - snapshot #3';
+    # Check that zypper does not return 0 if update was aborted
+    # Package name is trivial (not trival) and it's not broken on kubic
+    if (check_var('DISTRI', 'caasp')) {
+        record_info 'Broken pkg', 'Install broken package - snapshot #3';
+        trup_call "pkg install update-test-trival/update-test-trival-$ptfutsverlong.x86_64.rpm";
+        check_reboot_changes;
+        trup_call 'cleanup dup';
+        check_reboot_changes, 0;
+    }
+
+    record_info 'Remove pkg', 'Remove package - snapshot #4';
     trup_call 'pkg remove update-test-security';
     check_reboot_changes;
     check_package;
 
-    record_info 'Test #5', 'Revert to first snapshot we created - snapshot #4';
     # On Hyper-V and Xen PV we modified GRUB to add special framebuffer provisions to scale down,
     # and scale up, respectively, the hypervizor's native screen resolution. As it involved
     # an additional snapshot, magic snapshot numbers below have to be altered properly.
+    record_info 'Rollback', 'Revert to first snapshot we created - snapshot #5';
     my $snap = is_caasp('VMX') ? 2 : 3;
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('VIRSH_VMM_TYPE', 'linux')) {
         $snap++;


### PR DESCRIPTION
https://progress.opensuse.org/issues/18644

Local run:
 - http://dhcp91.suse.cz/tests/8302 - caasp
 - http://dhcp91.suse.cz/tests/8303 - kubic