### PR TITLE
Workaround for sle2docker

### DIFF
--- a/tests/console/runc.pm
+++ b/tests/console/runc.pm
@@ -97,6 +97,9 @@ sub run {
     record_info 'Test #10', 'Test: Delete a container';
     assert_script_run('runc delete test2');
     assert_script_run("! runc state test2");
+
+    # Cleanup, remove all images
+    assert_script_run("docker rmi --force \$(docker images -q)");
 }
 
 1;


### PR DESCRIPTION
There are two commit in this pull request:
- proper cleanup of docker images in runc test, otherwise sle2docker fails 
- workaround for bug,  sle2docker provides docker with incorrect image name  "suse/sles12sp2-docker", it should be only "suse/sles12sp2".

- Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1064010
- Verification run "runc": http://10.100.12.105//tests/643#step/runc/69
- Verification run "sle2docker":http://10.100.12.105//tests/643#step/sle2docker/29
