### PR TITLE
Disable dns_srv test on all bridged networks

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -850,7 +850,7 @@ sub load_consoletests {
         loadtest "console/http_srv";
         loadtest "console/mysql_srv";
         # Hyper-V host is in .suse.cz domain and the test is unstable
-        loadtest "console/dns_srv" unless check_var('VIRSH_VMM_FAMILY', 'hyperv');
+        loadtest "console/dns_srv";
         loadtest "console/postgresql_server";
         if (sle_version_at_least('12-SP1')) {    # shibboleth-sp not available on SLES 12 GA
             loadtest "console/shibboleth";

--- a/tests/console/dns_srv.pm
+++ b/tests/console/dns_srv.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -13,8 +13,14 @@
 use strict;
 use base "consoletest";
 use testapi;
+use main_common 'is_bridged_networking';
 
 sub run {
+    # Skip the entire test on bridget networks (e.g. Xen, Hyper-V)
+    if (is_bridged_networking) {
+        record_soft_failure 'Bug 1064438: "bind" cannot resolve localhost';
+        return;
+    }
     select_console 'root-console';
 
     # Install bind


### PR DESCRIPTION
Now fails on Xen PV as well: https://openqa.suse.de/tests/1274083#step/dns_srv/17
Validation run: http://assam.suse.cz/tests/1267 (`dns_srv` is not
scheduled)