### PR TITLE
Add a workaround case for SLED to fix poo#28240

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1155,6 +1155,8 @@ elsif (get_var("REGRESSION")) {
         load_inst_tests();
         load_reboot_tests();
         loadtest "x11regressions/x11regressions_setup";
+        # temporary adding test modules which switchs the default desktop session to GNOME Shell for sled15
+        loadtest 'x11regressions/sled15_workarounds' if sle_version_at_least('15');
         # temporary adding test modules which applies hacks for missing parts in sle15
         loadtest "console/sle15_workarounds" if sle_version_at_least('15');
         loadtest "console/hostname"       unless is_bridged_networking;

--- a/tests/x11regressions/sled15_workarounds.pm
+++ b/tests/x11regressions/sled15_workarounds.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: SLED15 workaround fate#324384 Use GNOME Shell session as default
+# Maintainer: Chingkai <qkzhu@suse.com>
+
+use base "x11regressiontest";
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    # Switch to GNOME Shell so that all desktop cases can be prepared before fate#324384 is done.
+    handle_logout;
+    assert_and_click 'displaymanager';
+    mouse_hide();
+    wait_still_screen;
+    send_key 'ret';
+    # Move the keyboard focus to the gear icon in gdm greeter
+    for (1 .. 2) { send_key 'tab'; }
+    send_key 'ret';
+    # Switch to GNOME Shell session
+    send_key 'right';
+    send_key 'down';
+    send_key 'ret';
+    assert_screen 'displaymanager-password-prompt';
+    type_password;
+    send_key "ret";
+    assert_screen 'desktop-gnome-shell';
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
We are going to switch the default GNOME session to GNOME Shell after
Beta3 is released. But at the same time we are also migrating test
cases under x11regression to SLED15， however these cases & needles
could be affected by the unimplemented feature.

It's better to add a workaround now which will switch the default
desktop session to GNOME Shell after the installation of SLED.
This will help us migrate the x11regression cases for just one time.

  see also: poo#28240, fate#324384

- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/586
- Related ticket: https://progress.opensuse.org/issues/28240
- Verification run: http://10.67.17.30/tests/2033#step/sled15_workarounds/8
