### PR TITLE
Adjust Registration Server shortcuts for SLE15

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -440,7 +440,12 @@ sub fill_in_reg_server {
     }
     else {
         send_key "alt-i";
-        send_key "alt-o";
+        if (sle_version_at_least('15')) {
+            send_key "alt-l";
+        }
+        else {
+            send_key "alt-o";
+        }
         type_string get_required_var("SMT_URL");
     }
     save_screenshot;


### PR DESCRIPTION
Add version check for SLES15
Update Registration Server shortcuts for SLES15

- Verification run: http://10.67.17.147/tests/1730#step/scc_registration/2