### PR TITLE
Remove unsupported '-C' option of 'gensslcert`

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -72,7 +72,7 @@ sub setup_apache2 {
     }
     # Create x509 certificate for this apache server
     if ($mode eq "SSL") {
-        assert_script_run 'gensslcert -n $(hostname) -C $(hostname) -e webmaster@$(hostname)', 600;
+        assert_script_run 'gensslcert -n $(hostname) -e webmaster@$(hostname)', 600;
         assert_script_run 'ls /etc/apache2/ssl.crt/$(hostname)-server.crt /etc/apache2/ssl.key/$(hostname)-server.key';
     }
 


### PR DESCRIPTION
On SLE15 we don't have the `-C` option of `gensslcert` no more, just
removing it seems to be sufficient for the test to pass.

Fails on:
* JeOS: https://openqa.suse.de/tests/1276338
* SLES: https://openqa.suse.de/tests/1269012

Validation run on JeOS: http://assam.suse.cz/tests/1279

The `apache_ssl` might run in other job groups than SLE:Functional but I
was unable to find test case with `SECURITYTEST=web` on OOO, nor that
`fips_tests_web` (which has `FIPS_TS=web`) runs in any job group.