### PR TITLE
FIX update packagekit gpk on Leap

### DIFF
--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -77,7 +77,8 @@ sub run {
             if (match_has_tag("updates_none")) {
                 send_key 'ret';
                 if (check_screen "updates_installed-restart", 0) {
-                    power_action 'reboot';
+                    select_console 'root-console';
+                    type_string "reboot\n";
                     $self->wait_boot;
                     turn_off_screensaver;
                 }
@@ -87,7 +88,8 @@ sub run {
                 send_key "alt-c";    # close
             }
             elsif (match_has_tag("updates_installed-restart")) {
-                power_action 'reboot';
+                select_console 'root-console';
+                type_string "reboot\n";
                 $self->wait_boot;
                 turn_off_screensaver;
             }


### PR DESCRIPTION
Exchanged the power_action 'reboot' with a manual approach
since reboot_x11 did not work

- Related ticket: https://progress.opensuse.org/issues/27573
- Verification run: http://pinky.arch.suse.de/tests/244#
- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3941