### PR TITLE
Add autoyast profiles to test multipath

### DIFF
--- a/data/autoyast_sle12/autoyast_multipath.xml
+++ b/data/autoyast_sle12/autoyast_multipath.xml
@@ -1,0 +1,580 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <final_reboot config:type="boolean">true</final_reboot>
+    </mode>
+    <storage>
+      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
+      <start_multipath config:type="boolean">false</start_multipath>
+    </storage>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">false</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">false</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+  </general>
+
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+
+  <suse_register>
+    <do_registration config:type="boolean">false</do_registration>
+  </suse_register>
+
+  <ssh_import>
+    <copy_config config:type="boolean">false</copy_config>
+    <import config:type="boolean">false</import>
+  </ssh_import>
+
+  <bootloader>
+    <global>
+      <activate>true</activate>
+      <append>mce=dont_log_ce edd=off consoleblank=0 nomodeset rd.lvm.vg=system biosdevname=0 elevator=deadline</append>
+      <boot_mbr>true</boot_mbr>
+      <timeout config:type="integer">8</timeout>
+      <secure-boot>off</secure-boot>
+      <suse_btrfs config:type="boolean">false</suse_btrfs>
+      <os_prober>false</os_prober>
+      <terminal>console</terminal>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+
+  <firewall>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+  </firewall>
+
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel>384M</crash_kernel>
+    <general>
+      <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>5</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_NETCONFIG/>
+      <KDUMP_SAVEDIR>file:///var/crash</KDUMP_SAVEDIR>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+    </general>
+  </kdump>
+
+  <keyboard>
+    <keyboard_values>
+      <delay>250</delay>
+      <rate>30.0</rate>
+      <numlock>yes</numlock>
+      <discaps config:type="boolean">true</discaps>
+    </keyboard_values>
+    <keymap>english-us</keymap>
+  </keyboard>
+
+  <language>
+    <language>en_US</language>
+    <languages>en_US,de_DE</languages>
+  </language>
+
+  <mail>
+    <listen_remote config:type="boolean">false</listen_remote>
+    <postfix_mda config:type="symbol">local</postfix_mda>
+  </mail>
+
+  <networking>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+
+    <dhcp_options>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+
+    <dns>
+      <dhcp_hostname config:type="boolean">false</dhcp_hostname>
+      <hostname>vtest3</hostname>
+      <domain>suse.de</domain>
+      <nameservers config:type="list">
+        <nameserver>8.8.8.8</nameserver>
+        <nameserver></nameserver>
+      </nameservers>
+      <searchlist config:type="list">
+      </searchlist>
+    </dns>
+
+    <interfaces config:type="list">
+      <interface>
+        <device>eth1</device>
+        <usercontrol>no</usercontrol>
+        <startmode>auto</startmode>
+        <bootproto>dhcp</bootproto>
+      </interface>
+      <interface>
+        <device>lan0</device>
+        <usercontrol>no</usercontrol>
+        <startmode>auto</startmode>
+        <bootproto>static</bootproto>
+        <ipaddr>192.168.139.48</ipaddr>
+        <netmask>255.255.255.0</netmask>
+      </interface>
+    </interfaces>
+
+    <net-udev config:type="list">
+      <rule>
+        <name>eth1</name>
+        <rule>ATTR{address}</rule>
+        <value>52:54:00:6a:38:e8</value>
+      </rule>
+      <rule>
+        <name>lan0</name>
+        <rule>ATTR{address}</rule>
+        <value>52:54:00:ac:f5:33</value>
+      </rule>
+    </net-udev>
+
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+      <routes config:type="list">
+        <route>
+          <destination>default</destination>
+          <device>-</device>
+          <gateway>10.0.2.2</gateway>
+          <netmask>-</netmask>
+        </route>
+      </routes>
+    </routing>
+
+  </networking>
+
+
+  <host>
+    <hosts config:type="list">
+      <hosts_entry>
+        <host_address>127.0.0.1</host_address>
+        <names config:type="list">
+          <name>localhost localhost.localdomain localhost4 localhost4.localdomain4</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>::1</host_address>
+        <names config:type="list">
+          <name>localhost localhost.localdomain localhost6 localhost6.localdomain6</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>192.168.139.45</host_address>
+        <names config:type="list">
+          <name>katello.wojo.home</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>192.168.139.48</host_address>
+        <names config:type="list">
+          <name>vtest3.wojo.home vtest3</name>
+        </names>
+      </hosts_entry>
+    </hosts>
+  </host>
+
+  <partitioning config:type="list">
+    <drive>
+      <initialize config:type="boolean">true</initialize>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <device>/dev/placeholder</device>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">BOOTFSTYPE</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>BOOTMOUNTO</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>BOOTMOUNTP</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">6878</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>256M</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <format config:type="boolean">false</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <lvm_group>system</lvm_group>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">142</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>max</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+  </drive>
+    <drive>
+      <device>/dev/system</device>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>noatime,barrier=0,inode64</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <lv_name>lvroot</lv_name>
+          <mount>/</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <resize config:type="boolean">false</resize>
+          <size>6144M</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>noatime,barrier=0,inode64</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <lv_name>lvopt</lv_name>
+          <mount>/opt</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <resize config:type="boolean">false</resize>
+          <size>1536M</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>noatime,barrier=0,inode64</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <lv_name>lvvar</lv_name>
+          <mount>/var</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <resize config:type="boolean">false</resize>
+          <size>5120M</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>noatime,barrier=0,nodev,inode64</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <lv_name>lvhome</lv_name>
+          <mount>/home</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <resize config:type="boolean">false</resize>
+          <size>1024M</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>noatime,barrier=0,nodev,nosuid,noexec,inode64</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <lv_name>lvtmp</lv_name>
+          <mount>/tmp</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <resize config:type="boolean">false</resize>
+          <size>2048M</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <lv_name>lvswap</lv_name>
+          <mount>swap</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <resize config:type="boolean">false</resize>
+          <size>4096M</size>
+          <stripes config:type="integer">1</stripes>
+          <stripesize config:type="integer">4</stripesize>
+        </partition>
+      </partitions>
+      <pesize>64M</pesize>
+      <type config:type="symbol">CT_LVM</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <disable config:type="list">
+      </disable>
+      <enable config:type="list">
+        <service>atd</service>
+        <service>kexec-load</service>
+        <service>sshd</service>
+        <service>sysstat</service>
+        <service>tuned</service>
+      </enable>
+    </services>
+  </services-manager>
+
+  <software>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <packages config:type="list">
+      <package>bash-doc</package>
+      <package>samba</package>
+      <package>cups</package>
+      <package>dmidecode</package>
+      <package>libgmodule-2_0-0</package>
+      <package>libgobject-2_0-0</package>
+      <package>libgthread-2_0-0</package>
+      <package>libXi6</package>
+      <package>libXtst6</package>
+      <package>lsscsi</package>
+      <package>perl-Net-SNMP</package>
+      <package>python-gobject2</package>
+      <package>python-jabberpy</package>
+      <package>sg3_utils</package>
+      <package>sssd</package>
+      <package>sssd-ad</package>
+      <package>sssd-krb5</package>
+      <package>sssd-krb5-common</package>
+      <package>sssd-ldap</package>
+      <package>sssd-tools</package>
+      <package>sudo</package>
+      <package>sysstat</package>
+      <package>tuned</package>
+      <package>ucode-intel</package>
+      <package>vsftpd</package>
+      <package>xauth</package>
+      <package>xterm</package>
+      <package>xinetd</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>base</pattern>
+      <pattern>Minimal</pattern>
+    </patterns>
+    <post-packages config:type="list">
+      <package>vim</package>
+    </post-packages>
+    <remove-packages config:type="list">
+      <package>atmel-firmware</package>
+      <package>autoconf</package>
+      <package>automake</package>
+      <package>adjtimex</package>
+      <package>btrfsmaintenance</package>
+      <package>cdrkit-cdrtools-compat</package>
+      <package>command-not-found</package>
+      <package>crash-kmp-default</package>
+      <package>cryptconfig</package>
+      <package>cups-filters-ghostscript</package>
+      <package>FirmwareUpdateKit</package>
+      <package>finger</package>
+      <package>fping</package>
+      <package>genisoimage</package>
+      <package>ghostscript</package>
+      <package>ghostscript-fonts-other</package>
+      <package>ghostscript-fonts-std</package>
+      <package>ghostscript-x11</package>
+      <package>gpm</package>
+      <package>groff-full</package>
+      <package>grub2-systemd-sleep-plugin</package>
+      <package>gxditview</package>
+      <package>icedax</package>
+      <package>inst-source-utils</package>
+      <package>ipw-firmware</package>
+      <package>iscsiuio</package>
+      <package>joe</package>
+      <package>libao4</package>
+      <package>libao-plugins4</package>
+      <package>libasound2</package>
+      <package>libauparse0</package>
+      <package>libburn4</package>
+      <package>libburnia-tools</package>
+      <package>libcryptmount0</package>
+      <package>libtool</package>
+      <package>libdm0</package>
+      <package>libFLAC8</package>
+      <package>libiniparser0</package>
+      <package>libisoburn1</package>
+      <package>libisofs6</package>
+      <package>libiw30</package>
+      <package>libjasper1</package>
+      <package>libjbig2</package>
+      <package>libjpeg8</package>
+      <package>libmng1</package>
+      <package>libmozjs-17_0</package>
+      <package>libkate1</package>
+      <package>liboggkate1</package>
+      <package>liblcms1</package>
+      <package>libnetpbm11</package>
+      <package>libogg0</package>
+      <package>libopenct1</package>
+      <package>libsndfile1</package>
+      <package>libply2</package>
+      <package>libply-boot-client2</package>
+      <package>libply-splash-core2</package>
+      <package>libply-splash-graphics2</package>
+      <package>libpulse0</package>
+      <package>libtidyp-1_04-0</package>
+      <package>libtiff5</package>
+      <package>libsnapper2</package>
+      <package>libspeex1</package>
+      <package>libvorbis0</package>
+      <package>libvorbisenc2</package>
+      <package>libvorbisfile3</package>
+      <package>netpbm</package>
+      <package>open-iscsi</package>
+      <package>openct</package>
+      <package>openldap2-client</package>
+      <package>opensc</package>
+      <package>openslp-server</package>
+      <package>opie</package>
+      <package>pam_mount</package>
+      <package>pango-modules</package>
+      <package>pcsc-lite</package>
+      <package>perl-HTML-Tidy</package>
+      <package>plymouth</package>
+      <package>plymouth-branding-SLE</package>
+      <package>plymouth-dracut</package>
+      <package>plymouth-plugin-label</package>
+      <package>plymouth-plugin-script</package>
+      <package>plymouth-scripts</package>
+      <package>ppp</package>
+      <package>pptp</package>
+      <package>psutils</package>
+      <package>python-gobject-cairo</package>
+      <package>quota</package>
+      <package>rollback-helper</package>
+      <package>rsh</package>
+      <package>scout</package>
+      <package>samba-winbind</package>
+      <package>smartmontools</package>
+      <package>snapper</package>
+      <package>snapper-zypp-plugin</package>
+      <package>SuSEfirewall2</package>
+      <package>telnet</package>
+      <package>vlock</package>
+      <package>vorbis-tools</package>
+      <package>wireless-tools</package>
+      <package>wodim</package>
+      <package>x86info</package>
+      <package>yast2-audit-laf</package>
+      <package>yast2-boot-server</package>
+      <package>yast2-dhcp-server</package>
+      <package>yast2-ftp-server</package>
+      <package>yast2-http-server</package>
+      <package>yast2-nis-client</package>
+      <package>yast2-nis-server</package>
+      <package>yast2-snapper</package>
+      <package>yast2-squid</package>
+      <package>yast2-sudo</package>
+      <package>yast2-vm</package>
+      <package>yast2-vpn</package>
+      <package>ypbind</package>
+      <package>yp-tools</package>
+      <package>zisofs-tools</package>
+    </remove-packages>
+  </software>
+
+  <users config:type="list">
+    <user>
+      <username>root</username>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password></user_password>
+    </user>
+  </users>
+  <scripts>
+    <pre-scripts config:type="list">
+      <script>
+        <debug config:type="boolean">true</debug>
+        <filename>pre_disklayout</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+if [ ! -e /tmp/profile/modified.xml ]; then
+        cp /tmp/profile/autoinst.xml /tmp/profile/modified.xml
+fi
+# Enable mutlipath
+sed -i -e '/^      <start_multipath/ c\
+      <start_multipath config:type="boolean">true</start_multipath>
+' /tmp/profile/modified.xml
+# Set device
+sed -i -e "/^      <device>\/dev\/placeholder/ c\
+      <device>/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1</device>" /tmp/profile/modified.xml
+# Set fs type, mount point and mount options
+# EFI
+if [ -e /sys/firmware/efi ]; then
+      sed -i -e 's/<loader_type>grub2/<loader_type>grub2-efi/g' \
+             -e 's/>(hd0,0)/>\/boot/g' \
+             -e 's/BOOTFSTYPE/vfat/g' \
+             -e 's/BOOTMOUNTP/\/boot\/efi/g' \
+             -e 's/BOOTMOUNTO/umask=00002,utf8=true/g' \
+             -e 's/6878/259/g' /tmp/profile/modified.xml
+      sed -i -e '/\<post-packages\>/ a\
+    <package>efishell</package>
+' /tmp/profile/modified.xml
+else
+      sed -i -e 's/BOOTFSTYPE/xfs/g' \
+             -e 's/BOOTMOUNTP/\/boot/g' \
+             -e 's/BOOTMOUNTO/nobarrier,nodev,nosuid/g' \
+             -e 's/6878/131/g' /tmp/profile/modified.xml
+fi
+]]>
+        </source>
+      </script>
+      <script>
+        <debug config:type="boolean">true</debug>
+        <filename>pre_config</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+touch /etc/udev/rules.d/70-persistent-net.rules
+sed -i -e '/52:54:00:6a:38:e8/ Id' /etc/udev/rules.d/70-persistent-net.rules
+iface=`ip -o link | grep -i '52:54:00:6a:38:e8' | awk '{print $2}' | sed -e 's/://'`
+if [ -n "${iface}" ]; then
+    echo "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", ATTR{address}==\"52:54:00:6a:38:e8\", NAME=\"${iface}\"" >> /etc/udev/rules.d/70-persistent-net.rules
+fi
+sed -i -e '/52:54:00:ac:f5:33/ Id' /etc/udev/rules.d/70-persistent-net.rules
+iface=`ip -o link | grep -i '52:54:00:ac:f5:33' | awk '{print $2}' | sed -e 's/://'`
+if [ -n "${iface}" ]; then
+    echo "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", ATTR{address}==\"52:54:00:ac:f5:33\", NAME=\"${iface}\"" >> /etc/udev/rules.d/70-persistent-net.rules
+fi
+]]>
+        </source>
+      </script>
+    </pre-scripts>
+    <chroot-scripts config:type="list">
+      <script>
+        <filename>cp-resolv.sh</filename>
+        <chrooted config:type="boolean">false</chrooted>
+        <interpreter>shell</interpreter>
+        <notification>Copying resolv.conf into chroot</notification>
+        <source><![CDATA[
+cp /etc/resolv.conf /mnt/etc
+]]>
+        </source>
+      </script>
+    </chroot-scripts>
+  </scripts>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Berlin</timezone>
+  </timezone>
+</profile>

--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -1,0 +1,604 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+        <product>sle-module-basesystem</product>
+        <product_dir>/Basesystem</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+        <product>sle-module-desktop-applications</product>
+        <product_dir>/Desktop-Applications</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+        <product>sle-module-server-applications</product>
+        <product_dir>/Server-Applications</product_dir>
+      </listentry>
+    </add_on_products>
+  </add-on>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <final_reboot config:type="boolean">true</final_reboot>
+    </mode>
+    <storage>
+      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
+      <start_multipath config:type="boolean">false</start_multipath>
+    </storage>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">false</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">false</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+  </general>
+
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+
+  <suse_register>
+    <do_registration config:type="boolean">false</do_registration>
+  </suse_register>
+
+  <ssh_import>
+    <copy_config config:type="boolean">false</copy_config>
+    <import config:type="boolean">false</import>
+  </ssh_import>
+
+  <bootloader>
+    <global>
+      <activate>true</activate>
+      <append>mce=dont_log_ce edd=off consoleblank=0 nomodeset rd.lvm.vg=system biosdevname=0 elevator=deadline</append>
+      <boot_mbr>true</boot_mbr>
+      <timeout config:type="integer">8</timeout>
+      <secure-boot>off</secure-boot>
+      <suse_btrfs config:type="boolean">false</suse_btrfs>
+      <os_prober>false</os_prober>
+      <terminal>console</terminal>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+
+  <firewall>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+  </firewall>
+
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel>384M</crash_kernel>
+    <general>
+      <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>5</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_NETCONFIG/>
+      <KDUMP_SAVEDIR>file:///var/crash</KDUMP_SAVEDIR>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+    </general>
+  </kdump>
+
+  <keyboard>
+    <keyboard_values>
+      <delay>250</delay>
+      <rate>30.0</rate>
+      <numlock>yes</numlock>
+      <discaps config:type="boolean">true</discaps>
+    </keyboard_values>
+    <keymap>english-us</keymap>
+  </keyboard>
+
+  <language>
+    <language>en_US</language>
+    <languages>en_US,de_DE</languages>
+  </language>
+
+  <mail>
+    <listen_remote config:type="boolean">false</listen_remote>
+    <postfix_mda config:type="symbol">local</postfix_mda>
+  </mail>
+
+  <networking>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+
+    <dhcp_options>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+
+    <dns>
+      <dhcp_hostname config:type="boolean">false</dhcp_hostname>
+      <hostname>vtest3</hostname>
+      <domain>suse.de</domain>
+      <nameservers config:type="list">
+        <nameserver>8.8.8.8</nameserver>
+        <nameserver></nameserver>
+      </nameservers>
+      <searchlist config:type="list">
+      </searchlist>
+    </dns>
+
+    <interfaces config:type="list">
+      <interface>
+        <device>eth1</device>
+        <usercontrol>no</usercontrol>
+        <startmode>auto</startmode>
+        <bootproto>dhcp</bootproto>
+      </interface>
+      <interface>
+        <device>lan0</device>
+        <usercontrol>no</usercontrol>
+        <startmode>auto</startmode>
+        <bootproto>static</bootproto>
+        <ipaddr>192.168.139.48</ipaddr>
+        <netmask>255.255.255.0</netmask>
+      </interface>
+    </interfaces>
+
+    <net-udev config:type="list">
+      <rule>
+        <name>eth1</name>
+        <rule>ATTR{address}</rule>
+        <value>52:54:00:6a:38:e8</value>
+      </rule>
+      <rule>
+        <name>lan0</name>
+        <rule>ATTR{address}</rule>
+        <value>52:54:00:ac:f5:33</value>
+      </rule>
+    </net-udev>
+
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+      <routes config:type="list">
+        <route>
+          <destination>default</destination>
+          <device>-</device>
+          <gateway>10.0.2.2</gateway>
+          <netmask>-</netmask>
+        </route>
+      </routes>
+    </routing>
+
+  </networking>
+
+
+  <host>
+    <hosts config:type="list">
+      <hosts_entry>
+        <host_address>127.0.0.1</host_address>
+        <names config:type="list">
+          <name>localhost localhost.localdomain localhost4 localhost4.localdomain4</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>::1</host_address>
+        <names config:type="list">
+          <name>localhost localhost.localdomain localhost6 localhost6.localdomain6</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>192.168.139.45</host_address>
+        <names config:type="list">
+          <name>katello.wojo.home</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>192.168.139.48</host_address>
+        <names config:type="list">
+          <name>vtest3.wojo.home vtest3</name>
+        </names>
+      </hosts_entry>
+    </hosts>
+  </host>
+
+  <partitioning config:type="list">
+    <drive>
+      <initialize config:type="boolean">true</initialize>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <device>/dev/placeholder</device>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">BOOTFSTYPE</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>BOOTMOUNTO</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>BOOTMOUNTP</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">6878</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>256M</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <format config:type="boolean">false</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <lvm_group>system</lvm_group>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">142</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>max</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+  </drive>
+    <drive>
+      <device>/dev/system</device>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>noatime,barrier=0,inode64</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <lv_name>lvroot</lv_name>
+          <mount>/</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <resize config:type="boolean">false</resize>
+          <size>6144M</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>noatime,barrier=0,inode64</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <lv_name>lvopt</lv_name>
+          <mount>/opt</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <resize config:type="boolean">false</resize>
+          <size>1536M</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>noatime,barrier=0,inode64</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <lv_name>lvvar</lv_name>
+          <mount>/var</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <resize config:type="boolean">false</resize>
+          <size>5120M</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>noatime,barrier=0,nodev,inode64</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <lv_name>lvhome</lv_name>
+          <mount>/home</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <resize config:type="boolean">false</resize>
+          <size>1024M</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>noatime,barrier=0,nodev,nosuid,noexec,inode64</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <lv_name>lvtmp</lv_name>
+          <mount>/tmp</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <resize config:type="boolean">false</resize>
+          <size>2048M</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <lv_name>lvswap</lv_name>
+          <mount>swap</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <resize config:type="boolean">false</resize>
+          <size>4096M</size>
+          <stripes config:type="integer">1</stripes>
+          <stripesize config:type="integer">4</stripesize>
+        </partition>
+      </partitions>
+      <pesize>64M</pesize>
+      <type config:type="symbol">CT_LVM</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <disable config:type="list">
+      </disable>
+      <enable config:type="list">
+        <service>atd</service>
+        <service>kexec-load</service>
+        <service>sshd</service>
+        <service>sysstat</service>
+        <service>tuned</service>
+      </enable>
+    </services>
+  </services-manager>
+
+  <software>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <packages config:type="list">
+      <package>bash-doc</package>
+      <package>samba</package>
+      <package>cups</package>
+      <package>dmidecode</package>
+      <package>libgmodule-2_0-0</package>
+      <package>libgobject-2_0-0</package>
+      <package>libgthread-2_0-0</package>
+      <package>libXi6</package>
+      <package>libXtst6</package>
+      <package>lsscsi</package>
+      <package>perl-Net-SNMP</package>
+      <package>python-gobject2</package>
+      <package>python-jabberpy</package>
+      <package>sg3_utils</package>
+      <package>sssd</package>
+      <package>sssd-ad</package>
+      <package>sssd-krb5</package>
+      <package>sssd-krb5-common</package>
+      <package>sssd-ldap</package>
+      <package>sssd-tools</package>
+      <package>sudo</package>
+      <package>sysstat</package>
+      <package>tuned</package>
+      <package>ucode-intel</package>
+      <package>vsftpd</package>
+      <package>xauth</package>
+      <package>xterm</package>
+      <package>xinetd</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>base</pattern>
+      <pattern>basesystem</pattern>
+      <pattern>basesystem_enchanced</pattern>
+      <pattern>minimal_base</pattern>
+    </patterns>
+    <post-packages config:type="list">
+      <package>vim</package>
+    </post-packages>
+    <remove-packages config:type="list">
+      <package>atmel-firmware</package>
+      <package>autoconf</package>
+      <package>automake</package>
+      <package>adjtimex</package>
+      <package>btrfsmaintenance</package>
+      <package>cdrkit-cdrtools-compat</package>
+      <package>command-not-found</package>
+      <package>crash-kmp-default</package>
+      <package>cryptconfig</package>
+      <package>cups-filters-ghostscript</package>
+      <package>FirmwareUpdateKit</package>
+      <package>finger</package>
+      <package>fping</package>
+      <package>genisoimage</package>
+      <package>ghostscript</package>
+      <package>ghostscript-fonts-other</package>
+      <package>ghostscript-fonts-std</package>
+      <package>ghostscript-x11</package>
+      <package>gpm</package>
+      <package>groff-full</package>
+      <package>grub2-systemd-sleep-plugin</package>
+      <package>gxditview</package>
+      <package>icedax</package>
+      <package>inst-source-utils</package>
+      <package>ipw-firmware</package>
+      <package>iscsiuio</package>
+      <package>joe</package>
+      <package>libao4</package>
+      <package>libao-plugins4</package>
+      <package>libasound2</package>
+      <package>libauparse0</package>
+      <package>libburn4</package>
+      <package>libburnia-tools</package>
+      <package>libcryptmount0</package>
+      <package>libtool</package>
+      <package>libdm0</package>
+      <package>libFLAC8</package>
+      <package>libiniparser0</package>
+      <package>libisoburn1</package>
+      <package>libisofs6</package>
+      <package>libiw30</package>
+      <package>libjasper1</package>
+      <package>libjbig2</package>
+      <package>libjpeg8</package>
+      <package>libmng1</package>
+      <package>libmozjs-17_0</package>
+      <package>libkate1</package>
+      <package>liboggkate1</package>
+      <package>liblcms1</package>
+      <package>libnetpbm11</package>
+      <package>libogg0</package>
+      <package>libopenct1</package>
+      <package>libsndfile1</package>
+      <package>libply2</package>
+      <package>libply-boot-client2</package>
+      <package>libply-splash-core2</package>
+      <package>libply-splash-graphics2</package>
+      <package>libpulse0</package>
+      <package>libtidyp-1_04-0</package>
+      <package>libtiff5</package>
+      <package>libsnapper2</package>
+      <package>libspeex1</package>
+      <package>libvorbis0</package>
+      <package>libvorbisenc2</package>
+      <package>libvorbisfile3</package>
+      <package>netpbm</package>
+      <package>open-iscsi</package>
+      <package>openct</package>
+      <package>openldap2-client</package>
+      <package>opensc</package>
+      <package>openslp-server</package>
+      <package>opie</package>
+      <package>pam_mount</package>
+      <package>pango-modules</package>
+      <package>pcsc-lite</package>
+      <package>perl-HTML-Tidy</package>
+      <package>plymouth</package>
+      <package>plymouth-branding-SLE</package>
+      <package>plymouth-dracut</package>
+      <package>plymouth-plugin-label</package>
+      <package>plymouth-plugin-script</package>
+      <package>plymouth-scripts</package>
+      <package>ppp</package>
+      <package>pptp</package>
+      <package>psutils</package>
+      <package>python-gobject-cairo</package>
+      <package>quota</package>
+      <package>rollback-helper</package>
+      <package>rsh</package>
+      <package>scout</package>
+      <package>samba-winbind</package>
+      <package>smartmontools</package>
+      <package>snapper</package>
+      <package>snapper-zypp-plugin</package>
+      <package>SuSEfirewall2</package>
+      <package>telnet</package>
+      <package>vlock</package>
+      <package>vorbis-tools</package>
+      <package>wireless-tools</package>
+      <package>wodim</package>
+      <package>x86info</package>
+      <package>yast2-audit-laf</package>
+      <package>yast2-boot-server</package>
+      <package>yast2-dhcp-server</package>
+      <package>yast2-ftp-server</package>
+      <package>yast2-http-server</package>
+      <package>yast2-nis-client</package>
+      <package>yast2-nis-server</package>
+      <package>yast2-snapper</package>
+      <package>yast2-squid</package>
+      <package>yast2-sudo</package>
+      <package>yast2-vm</package>
+      <package>yast2-vpn</package>
+      <package>ypbind</package>
+      <package>yp-tools</package>
+      <package>zisofs-tools</package>
+    </remove-packages>
+    <products config:type="list">
+      <product>SLES15</product>
+    </products>
+  </software>
+
+  <users config:type="list">
+    <user>
+      <username>root</username>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password></user_password>
+    </user>
+  </users>
+  <scripts>
+    <pre-scripts config:type="list">
+      <script>
+        <debug config:type="boolean">true</debug>
+        <filename>pre_disklayout</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+if [ ! -e /tmp/profile/modified.xml ]; then
+        cp /tmp/profile/autoinst.xml /tmp/profile/modified.xml
+fi
+# Enable mutlipath
+sed -i -e '/^      <start_multipath/ c\
+      <start_multipath config:type="boolean">true</start_multipath>
+' /tmp/profile/modified.xml
+# Set device
+sed -i -e "/^      <device>\/dev\/placeholder/ c\
+      <device>/dev/mapper/0QEMU_QEMU_HARDDISK_mpath1</device>" /tmp/profile/modified.xml
+# Set fs type, mount point and mount options
+# EFI
+if [ -e /sys/firmware/efi ]; then
+      sed -i -e 's/<loader_type>grub2/<loader_type>grub2-efi/g' \
+             -e 's/>(hd0,0)/>\/boot/g' \
+             -e 's/BOOTFSTYPE/vfat/g' \
+             -e 's/BOOTMOUNTP/\/boot\/efi/g' \
+             -e 's/BOOTMOUNTO/umask=00002,utf8=true/g' \
+             -e 's/6878/259/g' /tmp/profile/modified.xml
+      sed -i -e '/\<post-packages\>/ a\
+    <package>efishell</package>
+' /tmp/profile/modified.xml
+else
+      sed -i -e 's/BOOTFSTYPE/xfs/g' \
+             -e 's/BOOTMOUNTP/\/boot/g' \
+             -e 's/BOOTMOUNTO/nobarrier,nodev,nosuid/g' \
+             -e 's/6878/131/g' /tmp/profile/modified.xml
+fi
+]]>
+        </source>
+      </script>
+      <script>
+        <debug config:type="boolean">true</debug>
+        <filename>pre_config</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+touch /etc/udev/rules.d/70-persistent-net.rules
+sed -i -e '/52:54:00:6a:38:e8/ Id' /etc/udev/rules.d/70-persistent-net.rules
+iface=`ip -o link | grep -i '52:54:00:6a:38:e8' | awk '{print $2}' | sed -e 's/://'`
+if [ -n "${iface}" ]; then
+    echo "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", ATTR{address}==\"52:54:00:6a:38:e8\", NAME=\"${iface}\"" >> /etc/udev/rules.d/70-persistent-net.rules
+fi
+sed -i -e '/52:54:00:ac:f5:33/ Id' /etc/udev/rules.d/70-persistent-net.rules
+iface=`ip -o link | grep -i '52:54:00:ac:f5:33' | awk '{print $2}' | sed -e 's/://'`
+if [ -n "${iface}" ]; then
+    echo "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", ATTR{address}==\"52:54:00:ac:f5:33\", NAME=\"${iface}\"" >> /etc/udev/rules.d/70-persistent-net.rules
+fi
+]]>
+        </source>
+      </script>
+    </pre-scripts>
+    <chroot-scripts config:type="list">
+      <script>
+        <filename>cp-resolv.sh</filename>
+        <chrooted config:type="boolean">false</chrooted>
+        <interpreter>shell</interpreter>
+        <notification>Copying resolv.conf into chroot</notification>
+        <source><![CDATA[
+cp /etc/resolv.conf /mnt/etc
+]]>
+        </source>
+      </script>
+    </chroot-scripts>
+  </scripts>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Berlin</timezone>
+  </timezone>
+</profile>


### PR DESCRIPTION
We got profile from one of our beta customers which we have adjusted for
sle 12 sp3 and sle 15. Profile testing profile requires multipath to be
configured. In openQA we have special worker class for this. Hence, no
local verification run. Tested manually. On SLE15 installation fails due to reported bug, minor adjustments to the software section may be required.

Profile tests multipath and dynamic changes to the profile using pre-scripts feature.

Test suite requires MULTIPATH setting set to true, and AUTOYAST setting pointing to the profile.

- Related ticket: [poo#20818](https://progress.opensuse.org/issues/20818).
