### PR TITLE
Isolate QAM incidents from fake updates in CaaSP

### DIFF
--- a/tests/caasp/stack_update.pm
+++ b/tests/caasp/stack_update.pm
@@ -49,7 +49,14 @@ sub check_update_changes {
     assert_script_run "kubectl get nodes --no-headers | wc -l | grep $nodes_count";
 
     # Containers check
-    assert_script_run "ssh admin.openqa.test './update.sh -c' | tee /dev/$serialdev | grep EXIT_OK", 60;
+    # QAM: incidents repo with real maintenance updates
+    if (check_var('FLAVOR', 'CaaSP-DVD-Incidents')) {
+        # TODO
+    }
+    else {
+        # QA: fake repo with pre-defined values (hardcoded)
+        assert_script_run "ssh admin.openqa.test './update.sh -c' | tee /dev/$serialdev | grep EXIT_OK", 60;
+    }
 
     # Switch to velum
     send_key 'alt-tab';    # select_console 'x11';


### PR DESCRIPTION
QA is using a special repository that tests a fake update, using hardcoded values as expected results. This however breaks QAM approach, where these values are reflecting the real world.

- Related ticket: https://openqa.suse.de/tests/1278553#step/stack_update/22
- Verification run: http://skyrim.qam.suse.de/tests/68#step/stack_update/12
