### PR TITLE
Extend module selection workaround

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -203,6 +203,10 @@ sub fill_in_registration_data {
             record_soft_failure('bsc#1056413');
             # Activate the last of the expected modules to select them manually, as not preselected but at least dependencies are handled
             my $addons = (split(/,/, $SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')}))[-1] . (get_var('SCC_ADDONS') ? ',' . get_var('SCC_ADDONS') : '');
+            # Add desktop module if not preselected and not yet added
+            if (match_has_tag('desktop-not-selected') && $addons !~ /desktop/) {
+                $addons .= ',desktop';
+            }
             set_var('SCC_ADDONS', $addons);
         }
     }


### PR DESCRIPTION
The current logic only selects the last module in the list and blindly expects a system-role which is not available just by selecting the last module.

- Needles: already available on OSD
- Verification run: http://openqa.glados.qa.suse.de/tests/588
