### PR TITLE
Fix toolchain test failing in gcc version

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1600,7 +1600,7 @@ load_create_hdd_tests if get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1");
 if (get_var("TCM") || check_var("ADDONS", "tcm")) {
     loadtest "console/force_cron_run";
     loadtest "toolchain/install";
-    loadtest "toolchain/gcc5_fortran_compilation";
+    loadtest "toolchain/gcc_fortran_compilation";
     loadtest "toolchain/gcc_compilation";
     loadtest "console/kdump_and_crash" if kdump_is_applicable;
 }

--- a/tests/toolchain/gcc_fortran_compilation.pm
+++ b/tests/toolchain/gcc_fortran_compilation.pm
@@ -1,19 +1,21 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Fortran test for SLE Toolchain Module's GCC5
+# Summary: Fortran test for SLE Toolchain Module's GCC
 # Maintainer: Michal Nowak <mnowak@suse.com>
 
 use base "opensusebasetest";
 use strict;
 use testapi;
+use utils;
+use version_utils qw(is_sle sle_version_at_least);
 
 sub run {
     my $self = shift;
@@ -27,7 +29,9 @@ sub run {
     script_run 'tar jxf fcvs21_f95.tar.bz2';
     script_run 'cp FM923.DAT fcvs21_f95/';
     script_run 'pushd fcvs21_f95';
-    script_run "sed -i 's/g77/gfortran-5/g' driver_*";
+    # gfortran (and gcc) fixed to version in SLE12 after the yearly gcc update with Toolchain module
+    my $fortran_version = is_sle && sle_version_at_least('15') ? "gfortran" : "gfortran-5";
+    script_run "sed -i 's/g77/$fortran_version/g' driver_*";
     script_run 'echo "exit \${failed}" >> driver_parse';
 
     script_run "patch -p0 < ../adapt-FM406-to-fortran-95.patch";


### PR DESCRIPTION
Fix toolchain test failing in gcc version using image to boot (instead of doing all the steps to install) for SLE15. The pattern used for SLE-12 is not found and the suggestion in this bug https://bugzilla.suse.com/show_bug.cgi?id=1070151 does not have fortran, so this PR includes packages needed for test modules in toolchain. When installing through pattern the version of dependencies (i.e fortran) is fixed to 5 in sle12 but when installing via packages symlinks for fortran are created without including the version number.

New settings needed when cloning+retriggering job in openQA:

BOOT_HDD_IMAGE=1 
DESKTOP=textmode
FLAVOR=Installer-DVD 
TEST=toolchain_zypper (in order to use another existing chained children job)
QA_TESTSET=
TCM=1 
INSTALLONLY=1

- Related ticket: https://progress.opensuse.org/issues/25380
- Verification run: [SLE15](http://dhcp227/tests/557) & [SLE12](http://dhcp227/tests/554)

Note: added QEMU_DISABLE_SNAPSHOTS=1 for verification in SLE12 to avoid saving snapshots due to https://bugzilla.suse.com/show_bug.cgi?id=1035453 but verification should be still valid.
