### PR TITLE
LTP: Robust execution of tests

### DIFF
--- a/lib/LTP/TestInfo.pm
+++ b/lib/LTP/TestInfo.pm
@@ -1,0 +1,28 @@
+# Copyright © 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+package LTP::TestInfo;
+use Mojo::Base 'OpenQA::Test::RunArgs';
+
+our @EXPORT_OK = qw(testinfo);
+use Exporter 'import';
+
+has 'test';
+has test_result_export => sub { die 'Require test_result_export hashref'; };
+
+sub testinfo {
+    __PACKAGE__->new(test_result_export => shift @_, @_);
+}
+
+1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -8,6 +8,7 @@ use utils;
 use version_utils qw(is_jeos is_gnome_next is_krypton_argon is_sle leap_version_at_least sle_version_at_least is_desktop_installed);
 use strict;
 use warnings;
+use main_ltp;
 
 our @EXPORT = qw(
   init_main
@@ -44,9 +45,9 @@ our @EXPORT = qw(
   any_desktop_is_applicable
   console_is_applicable
   boot_hdd_image
+  maybe_load_kernel_tests
   load_yast2_ncurses_tests
   load_yast2_gui_tests
-  maybe_load_kernel_tests
   load_extra_tests
   load_rollback_tests
   load_filesystem_tests
@@ -433,55 +434,6 @@ sub load_yast2_gui_tests {
     loadtest "yast2_gui/yast2_network_settings";
     loadtest "yast2_gui/yast2_software_management";
     loadtest "yast2_gui/yast2_users";
-}
-
-sub maybe_load_kernel_tests {
-    if (get_var('INSTALL_LTP')) {
-        if (get_var('INSTALL_KOTD')) {
-            loadtest 'kernel/install_kotd';
-        }
-        if (get_var('FLAVOR', '') =~ /Incidents-Kernel$/) {
-            loadtest 'kernel/update_kernel';
-        }
-        loadtest 'kernel/install_ltp';
-        loadtest 'kernel/boot_ltp';
-        if (get_var('PROC_SYS_DUMP')) {
-            loadtest 'kernel/proc_sys_dump';
-        }
-        loadtest 'kernel/shutdown_ltp';
-    }
-    elsif (get_var('LTP_SETUP_NETWORKING')) {
-        loadtest 'kernel/boot_ltp';
-        loadtest 'kernel/ltp_setup_networking';
-        loadtest 'kernel/shutdown_ltp';
-    }
-    elsif (get_var('LTP_COMMAND_FILE')) {
-        if (get_var('INSTALL_KOTD')) {
-            loadtest 'kernel/install_kotd';
-        }
-        loadtest 'kernel/boot_ltp';
-        if (get_var('LTP_COMMAND_FILE') =~ m/ltp-aiodio.part[134]/) {
-            loadtest 'kernel/create_junkfile_ltp';
-        }
-        loadtest 'kernel/run_ltp';
-        if (get_var('PROC_SYS_DUMP')) {
-            loadtest 'kernel/proc_sys_dump';
-        }
-    }
-    elsif (get_var('QA_TEST_KLP_REPO')) {
-        if (get_var('INSTALL_KOTD')) {
-            loadtest 'kernel/install_kotd';
-        }
-        loadtest 'kernel/boot_ltp';
-        loadtest 'kernel/qa_test_klp';
-    }
-    elsif (get_var('VIRTIO_CONSOLE_TEST')) {
-        loadtest 'kernel/virtio_console';
-    }
-    else {
-        return 0;
-    }
-    return 1;
 }
 
 sub load_extra_tests {

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -1,0 +1,144 @@
+# Copyright © 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# See kernel/install_ltp.pm and kernel/run_ltp.pm for documentation.
+package main_ltp;
+use base 'Exporter';
+use Exporter;
+use testapi qw(get_var);
+use autotest;
+use utils;
+use LTP::TestInfo qw(testinfo);
+use File::Basename 'basename';
+use 5.018;
+
+our @EXPORT = qw(maybe_load_kernel_tests);
+
+sub loadtest {
+    my ($test, %args) = @_;
+    autotest::loadtest("tests/kernel/$test.pm", %args);
+}
+
+sub parse_openposix_runfile {
+    my ($path, $cmd_pattern, $cmd_exclude, $test_result_export) = @_;
+
+    open(my $rfile, $path) or die "Can not open runfile asset $path: $!";
+    while (my $line = <$rfile>) {
+        chomp($line);
+        if ($line =~ m/$cmd_pattern/ && !($line =~ m/$cmd_exclude/)) {
+            my $test = {name => basename($line, '.run-test'), command => $line};
+            my $tinfo = testinfo($test_result_export, test => $test);
+            loadtest('run_ltp', name => $test->{name}, run_args => $tinfo);
+        }
+    }
+}
+
+sub parse_runtest_file {
+    my ($path, $cmd_pattern, $cmd_exclude, $test_result_export) = @_;
+
+    open(my $rfile, $path) or die "Can not open runtest asset $path: $!";
+    while (my $line = <$rfile>) {
+        if ($line =~ /(^#)|(^$)/) {
+            next;
+        }
+
+        #Command format is "<name> <command> [<args>...] [#<comment>]"
+        if ($line =~ /^\s* ([\w-]+) \s+ (\S.+) #?/gx) {
+            my $test = {name => $1, command => $2};
+            my $tinfo = testinfo($test_result_export, test => $test);
+            if ($test->{name} =~ m/$cmd_pattern/ && !($test->{name} =~ m/$cmd_exclude/)) {
+                loadtest('run_ltp', name => $test->{name}, run_args => $tinfo);
+            }
+        }
+    }
+}
+
+sub loadtest_from_runtest_file {
+    my $name               = get_var('LTP_COMMAND_FILE');
+    my $path               = get_var('ASSETDIR') . '/other';
+    my $tag                = get_var('LTP_RUNTEST_TAG') || get_var('VERSION') . '-' . get_var('BUILD');
+    my $cmd_pattern        = get_var('LTP_COMMAND_PATTERN') || '.*';
+    my $cmd_exclude        = get_var('LTP_COMMAND_EXCLUDE') || '$^';
+    my $test_result_export = {
+        format      => 'result_array:v2',
+        environment => {},
+        results     => []};
+
+    loadtest('boot_ltp', run_args => testinfo($test_result_export));
+    if (get_var('LTP_COMMAND_FILE') =~ m/ltp-aiodio.part[134]/) {
+        loadtest 'create_junkfile_ltp';
+    }
+
+    if ($name eq 'openposix') {
+        parse_openposix_runfile($path . '/openposix-test-list-' . $tag, $cmd_pattern, $cmd_exclude, $test_result_export);
+    }
+    else {
+        parse_runtest_file($path . "/ltp-$name-" . $tag, $cmd_pattern, $cmd_exclude, $test_result_export);
+    }
+
+    loadtest('shutdown_ltp', run_args => testinfo($test_result_export));
+}
+
+# Replace loadtest_from_runtest_file with this to stress test reverting to
+# snapshots
+sub stress_snapshots {
+    my $count = 100;
+
+    for (my $i = 0; $i < $count / 2; $i++) {
+        # This will always fail and revert to the previous milestone, which
+        # will either be boot_ltp or write_random#$i
+        loadtest('run_ltp');
+        loadtest('write_random');
+    }
+}
+
+sub maybe_load_kernel_tests {
+    if (get_var('INSTALL_LTP')) {
+        if (get_var('INSTALL_KOTD')) {
+            loadtest 'install_kotd';
+        }
+        if (get_var('FLAVOR', '') =~ /Incidents-Kernel$/) {
+            loadtest 'update_kernel';
+        }
+        loadtest 'install_ltp';
+        loadtest 'boot_ltp';
+        loadtest 'shutdown_ltp';
+    }
+    elsif (get_var('LTP_SETUP_NETWORKING')) {
+        loadtest 'boot_ltp';
+        loadtest 'ltp_setup_networking';
+        loadtest 'shutdown_ltp';
+    }
+    elsif (get_var('LTP_COMMAND_FILE')) {
+        if (get_var('INSTALL_KOTD')) {
+            loadtest 'install_kotd';
+        }
+        loadtest_from_runtest_file();
+    }
+    elsif (get_var('QA_TEST_KLP_REPO')) {
+        if (get_var('INSTALL_KOTD')) {
+            loadtest 'install_kotd';
+        }
+        loadtest 'boot_ltp';
+        loadtest 'qa_test_klp';
+    }
+    elsif (get_var('VIRTIO_CONSOLE_TEST')) {
+        loadtest 'virtio_console';
+    }
+    else {
+        return 0;
+    }
+    return 1;
+}

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -16,8 +16,13 @@ use base 'opensusebasetest';
 use testapi;
 
 sub run {
-    my $self = shift;
-    $self->wait_boot;
+    my ($self, $tinfo) = shift;
+    my $ltp_env    = get_var('LTP_ENV');
+    my $cmd_file   = get_var('LTP_COMMAND_FILE') || '';
+    my $is_network = $cmd_file =~ m/^\s*(net|net_stress)\./;
+
+    # During install_ltp, the second boot may take longer than usual.
+    $self->wait_boot(ready_time => 500);
 
     if (get_var('VIRTIO_CONSOLE')) {
         select_console('root-virtio-terminal');
@@ -42,11 +47,129 @@ sub run {
         assert_script_run("uname -v| grep '/kGraft-'");
     }
 
+    if ($ltp_env) {
+        $ltp_env =~ s/,/ /g;
+        script_run("export $ltp_env");
+    }
     script_run('env');
+
+    my $ver_linux_path = '$LTPROOT/ver_linux';
+    my $ver_linux_log  = '/tmp/ver_linux_before.txt';
+    script_run("$ver_linux_path > $ver_linux_log 2>&1");
+    upload_logs($ver_linux_log);
+    my $ver_linux_out = script_output("cat $ver_linux_log");
+
+    if (defined $tinfo) {
+        my $environment = {
+            product     => get_var('DISTRI') . ':' . get_var('VERSION'),
+            revision    => get_var('BUILD'),
+            arch        => get_var('ARCH'),
+            kernel      => '',
+            libc        => '',
+            gcc         => '',
+            harness     => 'SUSE OpenQA',
+            ltp_version => ''
+        };
+        if ($ver_linux_out =~ qr'^Linux\s+(.*?)\s*$'m) {
+            $environment->{kernel} = $1;
+        }
+        if ($ver_linux_out =~ qr'^Linux C Library\s*>?\s*(.*?)\s*$'m) {
+            $environment->{libc} = $1;
+        }
+        if ($ver_linux_out =~ qr'^Gnu C\s*(.*?)\s*$'m) {
+            $environment->{gcc} = $1;
+        }
+        $environment->{ltp_version} = script_output('touch /opt/ltp_version; cat /opt/ltp_version');
+        $tinfo->test_result_export->{environment} = $environment;
+    }
+
+    if ($is_network) {
+        # poo#18762: Sometimes there is physical NIC which is not configured.
+        # One of the reasons can be renaming by udev rule in
+        # /etc/udev/rules.d/70-persistent-net.rules. This breaks some tests
+        # (even net namespace based ones).
+        # Workaround: configure physical NIS (if needed).
+        my $conf_nic_script = << 'EOF';
+dir=/sys/class/net
+ifaces="`basename -a $dir/* | grep -v -e ^lo -e ^tun -e ^virbr -e ^vnet`"
+for iface in $ifaces; do
+    config=/etc/sysconfig/network/ifcfg-$iface
+    if [ "`cat $dir/$iface/operstate`" = "down" ] && [ ! -e $config ]; then
+        echo "WARNING: create config '$config'"
+        printf "BOOTPROTO='dhcp'\nSTARTMODE='auto'\nDHCLIENT_SET_DEFAULT_ROUTE='yes'\n" > $config
+        systemctl restart network
+        sleep 1
+    fi
+done
+EOF
+        script_output($conf_nic_script);
+
+        # dhclient requires no wicked service not only running but also disabled
+        script_run(
+            'systemctl --no-pager -p Id show network.service | grep -q Id=wicked.service &&
+{ export ENABLE_WICKED=1; systemctl disable wicked; }'
+        );
+
+        # emulate $LTPROOT/testscripts/network.sh
+        assert_script_run('TST_TOTAL=1 TCID="network_settings"; . test_net.sh; export TCID= TST_LIB_LOADED=');
+        script_run('env');
+
+        # Disable IPv4 and IPv6 iptables.
+        # Disabling IPv4 is needed for iptables tests (net.tcp_cmds).
+        # Disabling IPv6 is needed for ICMPv6 tests (net.ipv6).
+        # This must be done after stopping network service and loading
+        # test_net.sh script.
+        my $disable_iptables_script = << 'EOF';
+iptables -P INPUT ACCEPT;
+iptables -P OUTPUT ACCEPT;
+iptables -P FORWARD ACCEPT;
+iptables -t nat -F;
+iptables -t mangle -F;
+iptables -F;
+iptables -X;
+
+ip6tables -P INPUT ACCEPT;
+ip6tables -P OUTPUT ACCEPT;
+ip6tables -P FORWARD ACCEPT;
+ip6tables -t nat -F;
+ip6tables -t mangle -F;
+ip6tables -F;
+ip6tables -X;
+EOF
+        script_output($disable_iptables_script);
+        # display resulting iptables
+        script_run('iptables -L');
+        script_run('iptables -S');
+        script_run('ip6tables -L');
+        script_run('ip6tables -S');
+
+        # display various network configuration
+        script_run('ps axf');
+        script_run('netstat -nap');
+
+        script_run('cat /etc/resolv.conf');
+        script_run('cat /etc/nsswitch.conf');
+        script_run('cat /etc/hosts');
+
+        script_run('ip addr');
+        script_run('ip netns exec ltp_ns ip addr');
+        script_run('ip route');
+        script_run('ip -6 route');
+
+        script_run('ping -c 2 $IPV4_NETWORK.$LHOST_IPV4_HOST');
+        script_run('ping -c 2 $IPV4_NETWORK.$RHOST_IPV4_HOST');
+        script_run('ping6 -c 2 $IPV6_NETWORK:$LHOST_IPV6_HOST');
+        script_run('ping6 -c 2 $IPV6_NETWORK:$RHOST_IPV6_HOST');
+    }
+
+    assert_script_run('cd $LTPROOT/testcases/bin');
 }
 
 sub test_flags {
-    return {fatal => 1};
+    return {
+        fatal     => 1,
+        milestone => 1,
+    };
 }
 
 1;

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -17,7 +17,6 @@ use base 'opensusebasetest';
 use testapi qw(is_serial_terminal :DEFAULT);
 use utils;
 use Time::HiRes qw(clock_gettime CLOCK_MONOTONIC);
-use File::Basename 'basename';
 use JSON;
 use serial_terminal;
 require bmwqemu;
@@ -38,83 +37,6 @@ sub commit_result {
 
     push @{$self->{details}}, $result;
     close $rfh;
-}
-
-sub parse_runfile {
-    my ($self, $cmd_file, $cmd_pattern, $cmd_exclude) = @_;
-    my @tests         = ();
-    my $tests_ignored = 0;
-    my $cmd_file_text = script_output('cat $LTPROOT/runtest/' . $cmd_file);
-
-    my ($result, $rfh) = $self->start_result('runfile', 'parse runfile');
-    say $rfh "## Parsing `$cmd_file` for tests which match `$cmd_pattern`";
-
-    for my $line (split(qr/[\n\r\f]+/, $cmd_file_text)) {
-        if ($line =~ /(^#)|(^$)/) {
-            next;
-        }
-
-        #Command format is "<name> <command> [<args>...] [#<comment>]"
-        if ($line =~ /^\s* ([\w-]+) \s+ (\S.+) #?/gx) {
-            my $test = {name => $1, command => $2};
-            if ($test->{name} =~ m/$cmd_pattern/ && !($test->{name} =~ m/$cmd_exclude/)) {
-                push @tests, $test;
-            }
-            else {
-                $tests_ignored++;
-            }
-            next;
-        }
-
-        if ($result->{result} ne 'fail') {
-            say $rfh "## Some lines could not be parsed: ";
-            $result->{result} = 'fail';
-            $self->{result}   = 'fail';
-        }
-        print $rfh $line;
-
-    }
-
-    say $rfh "\nUsing " . @tests . " test commands.";
-    print $rfh "Ignoring $tests_ignored test commands." if $tests_ignored > 0;
-    if (@tests < 1) {
-        $result->{result} = 'fail';
-        $self->{result}   = 'fail';
-    }
-
-    $self->commit_result($result, $rfh);
-
-    return @tests;
-}
-
-sub parse_openposix_runfile {
-    my ($self, $cmd_pattern, $cmd_exclude) = @_;
-    my $cmd_file_text = script_output('cat ~/openposix_test_list.txt');
-
-    my ($result, $rfh) = $self->start_result('runfile', 'parse openposix runfile');
-    say $rfh 'Parsing Openposix runfile for tests which match ' . $cmd_pattern;
-
-    my @tests = ();
-    my @lines = split qr/[\n\r\f]+/, $cmd_file_text;
-    for my $line (@lines) {
-        if ($line =~ m/$cmd_pattern/ && !($line =~ m/$cmd_exclude/)) {
-            push @tests,
-              {
-                name    => basename($line, '.run-test'),
-                command => $line
-              };
-        }
-    }
-
-    print $rfh 'Using ' . @tests . ' of ' . @lines . ' Openposix test cases';
-    if (@tests < 1) {
-        $result->{result} = 'fail';
-        $self->{result}   = 'fail';
-    }
-
-    $self->commit_result($result, $rfh);
-
-    return @tests;
 }
 
 sub parse_result_line {
@@ -323,208 +245,63 @@ sub thetime {
     return clock_gettime(CLOCK_MONOTONIC);
 }
 
-sub export_to_json {
-    my ($test_result_export) = @_;
-    my $export_file = 'ulogs/result_array.json';
-
-    if (!-d 'ulogs') {
-        mkdir('ulogs');
-    }
-    bmwqemu::save_json_file($test_result_export, $export_file);
-}
-
 sub run {
-    my ($self) = @_;
+    my ($self, $tinfo) = @_;
     my $cmd_file = get_var 'LTP_COMMAND_FILE';
     die 'Need LTP_COMMAND_FILE to know which tests to run' unless $cmd_file;
-    my $cmd_pattern = get_var('LTP_COMMAND_PATTERN') || '.*';
-    my $cmd_exclude = get_var('LTP_COMMAND_EXCLUDE') || '$^';
-    my $timeout     = get_var('LTP_TIMEOUT')         || 900;
-    my $ltp_env     = get_var('LTP_ENV');
-    my $is_posix    = $cmd_file =~ m/^\s*openposix\s*$/i;
-    my $is_network  = $cmd_file =~ m/^\s*(net|net_stress)\./;
-    my $tmp;
+    my $timeout = get_var('LTP_TIMEOUT') || 900;
+    my $is_posix = $cmd_file =~ m/^\s*openposix\s*$/i;
 
-    if ($ltp_env) {
-        $ltp_env =~ s/,/ /g;
-        script_run("export $ltp_env");
-        script_run('env');
+    unless (defined $tinfo) {
+        die 'Require LTP::TestInfo object from loadtest with LTP test case name and command line';
+    }
+    my $test_result_export = $tinfo->test_result_export;
+    my $test               = $tinfo->test;
+
+    my $fin_msg    = "### TEST $test->{name} COMPLETE >>> ";
+    my $cmd_text   = qq($test->{command}; echo "$fin_msg\$?");
+    my $klog_stamp = "echo 'OpenQA::run_ltp.pm: Starting $test->{name}' > /dev/$serialdev";
+    my $start_time = thetime();
+    my $set_rhost  = $test->{command} =~ m/^finger01|ftp01|rcp01|rdist01|rlogin01|rpc01|rpcinfo01|rsh01|telnet01/;
+
+    if ($set_rhost) {
+        assert_script_run(q(export RHOST='127.0.0.1'));
     }
 
-    my $test_result_export = {
-        format  => 'result_array:v1',
-        results => []};
-
-    my @tests;
-
-    if ($is_posix) {
-        @tests = $self->parse_openposix_runfile($cmd_pattern, $cmd_exclude);
+    if (is_serial_terminal) {
+        script_run($klog_stamp);
+        wait_serial(serial_term_prompt(), undef, 0, no_regex => 1);
+        type_string($cmd_text);
+        wait_serial($cmd_text, undef, 0, no_regex => 1);
+        type_string("\n");
     }
     else {
-        @tests = $self->parse_runfile($cmd_file, $cmd_pattern, $cmd_exclude);
+        type_string("($cmd_text) | tee /dev/$serialdev\n");
     }
+    my $test_log = wait_serial(qr/$fin_msg\d+/, $timeout, 0, record_output => 1);
+    my ($timed_out, $result_export) = $self->record_ltp_result($cmd_file, $test, $test_log, $fin_msg, thetime() - $start_time, $is_posix);
 
-    assert_script_run('cd $LTPROOT/testcases/bin');
-
-    my $ver_linux_path = '$LTPROOT/ver_linux';
-    my $ver_linux_log  = '/tmp/ver_linux_before.txt';
-    script_run("$ver_linux_path > $ver_linux_log 2>&1");
-    upload_logs($ver_linux_log);
-    my $ver_linux_out = script_output("cat $ver_linux_log");
-    my $environment   = {
-        product     => get_var('DISTRI') . ':' . get_var('VERSION'),
-        revision    => get_var('BUILD'),
-        arch        => get_var('ARCH'),
-        kernel      => '',
-        libc        => '',
-        gcc         => '',
-        harness     => 'SUSE OpenQA',
-        ltp_version => ''
-    };
-    if ($ver_linux_out =~ qr'^Linux\s+(.*?)\s*$'m) {
-        $environment->{kernel} = $1;
-    }
-    if ($ver_linux_out =~ qr'^Linux C Library\s*>?\s*(.*?)\s*$'m) {
-        $environment->{libc} = $1;
-    }
-    if ($ver_linux_out =~ qr'^Gnu C\s*(.*?)\s*$'m) {
-        $environment->{gcc} = $1;
-    }
-    $environment->{ltp_version} = script_output('touch /opt/ltp_version; cat /opt/ltp_version');
-
-    if ($is_network) {
-        # poo#18762: Sometimes there is physical NIC which is not configured.
-        # One of the reasons can be renaming by udev rule in
-        # /etc/udev/rules.d/70-persistent-net.rules. This breaks some tests
-        # (even net namespace based ones).
-        # Workaround: configure physical NIS (if needed).
-        $tmp = << 'EOF';
-dir=/sys/class/net
-ifaces="`basename -a $dir/* | grep -v -e ^lo -e ^tun -e ^virbr -e ^vnet`"
-for iface in $ifaces; do
-    config=/etc/sysconfig/network/ifcfg-$iface
-    if [ "`cat $dir/$iface/operstate`" = "down" ] && [ ! -e $config ]; then
-        echo "WARNING: create config '$config'"
-        printf "BOOTPROTO='dhcp'\nSTARTMODE='auto'\nDHCLIENT_SET_DEFAULT_ROUTE='yes'\n" > $config
-        systemctl restart network
-        sleep 1
-    fi
-done
-EOF
-        script_output($tmp);
-
-        # dhclient requires no wicked service not only running but also disabled
-        script_run(
-            'systemctl --no-pager -p Id show network.service | grep -q Id=wicked.service &&
-{ export ENABLE_WICKED=1; systemctl disable wicked; }'
-        );
-
-        # emulate $LTPROOT/testscripts/network.sh
-        assert_script_run('TST_TOTAL=1 TCID="network_settings"; . test_net.sh; export TCID= TST_LIB_LOADED=');
-        script_run('env');
-
-        # Disable IPv4 and IPv6 iptables.
-        # Disabling IPv4 is needed for iptables tests (net.tcp_cmds).
-        # Disabling IPv6 is needed for ICMPv6 tests (net.ipv6).
-        # This must be done after stopping network service and loading
-        # test_net.sh script.
-        $tmp = << 'EOF';
-iptables -P INPUT ACCEPT;
-iptables -P OUTPUT ACCEPT;
-iptables -P FORWARD ACCEPT;
-iptables -t nat -F;
-iptables -t mangle -F;
-iptables -F;
-iptables -X;
-
-ip6tables -P INPUT ACCEPT;
-ip6tables -P OUTPUT ACCEPT;
-ip6tables -P FORWARD ACCEPT;
-ip6tables -t nat -F;
-ip6tables -t mangle -F;
-ip6tables -F;
-ip6tables -X;
-EOF
-        script_output($tmp);
-        # display resulting iptables
-        script_run('iptables -L');
-        script_run('iptables -S');
-        script_run('ip6tables -L');
-        script_run('ip6tables -S');
-
-        # display various network configuration
-        script_run('ps axf');
-        script_run('netstat -nap');
-
-        script_run('cat /etc/resolv.conf');
-        script_run('cat /etc/nsswitch.conf');
-        script_run('cat /etc/hosts');
-
-        script_run('ip addr');
-        script_run('ip netns exec ltp_ns ip addr');
-        script_run('ip route');
-        script_run('ip -6 route');
-
-        script_run('ping -c 2 $IPV4_NETWORK.$LHOST_IPV4_HOST');
-        script_run('ping -c 2 $IPV4_NETWORK.$RHOST_IPV4_HOST');
-        script_run('ping6 -c 2 $IPV6_NETWORK:$LHOST_IPV6_HOST');
-        script_run('ping6 -c 2 $IPV6_NETWORK:$RHOST_IPV6_HOST');
-    }
-
-    for my $test (@tests) {
-        my $fin_msg    = "### TEST $test->{name} COMPLETE >>> ";
-        my $cmd_text   = qq($test->{command}; echo "$fin_msg\$?");
-        my $klog_stamp = "echo 'OpenQA::run_ltp.pm: Starting $test->{command}' > /dev/$serialdev";
-        my $start_time = thetime();
-        my $set_rhost  = $is_network && $test->{command} =~ m/^finger01|ftp01|rcp01|rdist01|rlogin01|rpc01|rpcinfo01|rsh01|telnet01/;
-
-        if ($set_rhost) {
-            assert_script_run(q(export RHOST='127.0.0.1'));
+    #$result_export->{environment} = $environment;
+    push(@{$test_result_export->{results}}, $result_export);
+    if ($timed_out) {
+        if (get_var('LTP_DUMP_MEMORY_ON_TIMEOUT')) {
+            save_memory_dump(filename => $test->{name});
         }
-
-        if (is_serial_terminal) {
-            script_run($klog_stamp);
-            wait_serial(serial_term_prompt(), undef, 0, no_regex => 1);
-            type_string($cmd_text);
-            wait_serial($cmd_text, undef, 0, no_regex => 1);
-            type_string("\n");
-        }
-        else {
-            type_string("($cmd_text) | tee /dev/$serialdev\n");
-        }
-        my $test_log = wait_serial(qr/$fin_msg\d+/, $timeout, 0, record_output => 1);
-        my ($timed_out, $result_export) = $self->record_ltp_result($cmd_file, $test, $test_log, $fin_msg, thetime() - $start_time, $is_posix);
-
-        $result_export->{environment} = $environment;
-        push(@{$test_result_export->{results}}, $result_export);
-        if ($timed_out) {
-            export_to_json($test_result_export);
-            if (get_var('LTP_DUMP_MEMORY_ON_TIMEOUT')) {
-                save_memory_dump(filename => $test->{name});
-            }
-            die "Can't continue; timed out waiting for LTP test case which may still be running or the OS may have crashed!";
-        }
-
-        if ($set_rhost) {
-            assert_script_run('unset RHOST');
-        }
+        die "Can't continue; timed out waiting for LTP test case which may still be running or the OS may have crashed!";
     }
 
-    export_to_json($test_result_export);
+    if ($set_rhost) {
+        assert_script_run('unset RHOST');
+    }
 
-    script_run('[ "$ENABLE_WICKED" ] && systemctl enable wicked');
-    script_run('journalctl --no-pager -p warning');
-
-    $ver_linux_log = '/tmp/ver_linux_after.txt';
-    script_run("$ver_linux_path > $ver_linux_log 2>&1");
-    upload_logs($ver_linux_log);
+    script_run('vmstat -w');
 }
 
 1;
 
 =head1 Discussion
 
-This module extracts an LTP runtest file from the VM, parses it and then
+This module extracts an LTP runtest file from the VM[1], parses it and then
 executes the LTP test cases defined on each line of the runtest file. Logs are
 uploaded and interpreted after each LTP test case completes.
 
@@ -535,6 +312,10 @@ executed by the shell.
 The output of each test case is parsed for lines containing CONF and FAIL.
 If these terms are found in the output then a neutral or fail result will be
 reported, otherwise a pass.
+
+[1] Actually the parsing is now done by lib/main_ltp.pm which is called from
+    main.pm after install_ltp has uploaded the runtest files as
+    assets. run_ltp is scheduled once for each LTP test case/executable.
 
 =head1 Configuration
 
@@ -580,6 +361,12 @@ LTP test itself.
 
 Comma separated list of environment variables to be set for tests.
 E.g.: key=value,key2="value with spaces",key3='another value with spaces'
+
+=head2 LTP_RUNTEST_TAG
+
+The runtest asset files are appended with git or pkg depending on how LTP was
+installed. By default the runtest files from the git installation will be
+uesd, but setting this variable to pkg allows that behavior to be overridden.
 
 =cut
 

--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-# Summary: This module simply shuts down the system allowing the storage volume (HDD_1) to be published.
+# Summary: Cleanup and shutdown after installing or running the LTP
 # Maintainer: Richard Palethorpe <rpalethorpe@suse.com>
 
 use 5.018;
@@ -16,7 +16,25 @@ use base 'opensusebasetest';
 use testapi;
 use utils;
 
+sub export_to_json {
+    my ($test_result_export) = @_;
+    my $export_file = 'ulogs/result_array.json';
+
+    if (!-d 'ulogs') {
+        mkdir('ulogs');
+    }
+    bmwqemu::save_json_file($test_result_export, $export_file);
+}
+
 sub run {
+    my ($self, $tinfo) = @_;
+
+    if (defined $tinfo) {
+        export_to_json($tinfo->test_result_export);
+    }
+
+    script_run('[ "$ENABLE_WICKED" ] && systemctl enable wicked');
+    script_run('journalctl --no-pager -p warning');
     type_string "poweroff\n";
     assert_shutdown 1800;
 }

--- a/tests/kernel/write_random.pm
+++ b/tests/kernel/write_random.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Write 100M of random data
+# Maintainer: Richard Palethorpe <rpalethorpe@suse.com>
+#
+# Used for stressing OpenQA milestones, see lib/main_ltp.pm.
+
+use 5.018;
+use warnings;
+use base 'opensusebasetest';
+use testapi qw(is_serial_terminal :DEFAULT);
+use utils;
+use Time::HiRes qw(clock_gettime CLOCK_MONOTONIC);
+use File::Basename 'basename';
+use serial_terminal;
+require bmwqemu;
+
+sub run {
+    my ($self) = @_;
+
+    assert_script_run('touch /tmp/random');
+    assert_script_run('dd if=/dev/urandom of=/tmp/random bs=4096 count=25600');
+}
+
+sub test_flags {
+    return {
+        fatal     => 1,
+        milestone => 1,
+    };
+}
+
+
+1;


### PR DESCRIPTION
Complete refactoring of run_ltp to allow rolling the test execution back when the VM crashes. As a side effect it gives each LTP test case a separate instance of run_ltp.pm in the UI.

https://progress.opensuse.org/issues/27124

Requires:
https://github.com/os-autoinst/os-autoinst/pull/887