### PR TITLE
Adapt to new changes in storage-ng

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -282,7 +282,7 @@ sub run {
             send_key 'right';
             send_key_until_needlematch "partitioning_raid-disk_vda-selected", "down";
             # edit first partition
-            send_key 'alt-e';
+            send_key(is_storage_ng() ? 'alt-i' : 'alt-e');
             assert_screen 'partition-format';
             # format as FAT (first choice) unless storage-ng
             send_key 'alt-a';
@@ -295,6 +295,10 @@ sub run {
             }
             # mount point selection
             send_key 'alt-o';
+            if (is_storage_ng) {
+                assert_screen('partitioning_raid-mount_point-selected');
+                send_key 'alt-m';
+            }
             assert_screen 'partitioning_raid-mount_point-focused';
             # enter mount point
             type_string '/boot/efi';


### PR DESCRIPTION
- new hotkey for edit button
- Mount mount textbox is not automatically selected
----
- Related ticket: [poo#28576](https://progress.opensuse.org/issues/28576)
- Needles:
  - [gl#os-autoinst-needles-sles/mr/591](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/591) (**merged**)
  - [gl#os-autoinst-needles-sles/mr/593](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/593)
- Verification run:
  - SLE 12-SP3 aarch64: [copland#1665#step/partitioning_raid/188](http://copland.arch.suse.de/tests/1665#step/partitioning_raid/188)
  - SLE 12-SP3 x86_64: [copland#1667#step/partitioning_raid/180](http://copland.arch.suse.de/tests/1667#step/partitioning_raid/180)
  - SLE 15 aarch64: [copland#1666#step/partitioning_raid/233](http://copland.arch.suse.de/tests/1666#step/partitioning_raid/233)
  - SLE 15 x86_64: (not yet)
