### PR TITLE
[NFV] Add test for Vsperf installation

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -649,6 +649,7 @@ sub load_wicked_tests {
 sub load_nfv_tests {
     boot_hdd_image();
     loadtest "nfv/openvswitch_dpdk";
+    loadtest "nfv/vsperf_installation";
 }
 
 sub load_iso_in_external_tests {

--- a/tests/nfv/openvswitch_dpdk.pm
+++ b/tests/nfv/openvswitch_dpdk.pm
@@ -21,6 +21,7 @@ use testapi;
 use strict;
 use utils;
 
+
 sub run {
     select_console 'root-console';
 
@@ -40,5 +41,10 @@ sub run {
     assert_script_run "ovs-vsctl del-br ovs-openqa-br0";
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
+
 1;
+
 # vim: set sw=4 et:

--- a/tests/nfv/vsperf_installation.pm
+++ b/tests/nfv/vsperf_installation.pm
@@ -1,0 +1,48 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: VSPerf tool installation
+#
+#   This test does the following
+#    - Installs git to clone vswitchperf repo
+#    - Fetches the non-merged patch to support SLES15
+#    - Removes the lines to skip OVS, DPDK and QEMU compilation
+#    - Executes the script to install all the needed packages for VSPerf
+#
+# Maintainer: Jose Lausuch <jalausuch@suse.com>
+
+use base "consoletest";
+use testapi;
+use strict;
+use utils;
+
+sub run {
+    my $vsperf_repo = "https://gerrit.opnfv.org/gerrit/vswitchperf";
+
+    select_console 'root-console';
+
+    zypper_call('in git', timeout => 200);
+
+    # Clone repository
+    assert_script_run "git clone $vsperf_repo";
+    assert_script_run "cd vswitchperf/systems";
+
+    # Checkout the patch supporting SLE15 (to be removed once the patch is merged upstream)
+    assert_script_run "git fetch $vsperf_repo refs/changes/17/48017/3 && git checkout FETCH_HEAD";
+
+    # Hack to skip the OVS, DPDK and QEMU compilation as SLE15 will use the vanilla packages
+    assert_script_run "sed -n -e :a -e '1,8!{P;N;D;};N;ba' -i build_base_machine.sh";
+
+    # Vsperf packages installation
+    assert_script_run("bash -x build_base_machine.sh", 300);
+}
+
+1;
+
+# vim: set sw=4 et:


### PR DESCRIPTION
Add a new file to manage the OPNFV VSPerf installation containing all the needed
packages and dependencies to run the tool 

- Related ticket: https://progress.opensuse.org/issues/25764
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: http://10.161.8.29/tests/112
