### PR TITLE
Add workarounds for SLE15 migration test

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -22,7 +22,7 @@ use strict;
 
 use testapi;
 use utils qw(addon_decline_license assert_screen_with_soft_timeout);
-use version_utils 'sle_version_at_least';
+use version_utils qw(is_sle sle_version_at_least is_system_upgrading);
 
 our @EXPORT = qw(
   add_suseconnect_product
@@ -201,10 +201,10 @@ sub fill_in_registration_data {
     }
 
     # Soft-failure for module preselection
-    if (sle_version_at_least('15') && check_var('DISTRI', 'sle')) {
+    if (is_sle && sle_version_at_least('15')) {
         my $modules_needle = "modules-preselected-" . get_required_var('SLE_PRODUCT');
         if (get_var('UPGRADE') || get_var('PATCH')) {
-            check_screen($modules_needle, 5);
+            return record_soft_failure('bsc#1070031: Module Selection is missing in upgrade') if is_system_upgrading && !check_screen($modules_needle, 5);
         }
         else {
             if (check_var('BETA', '1')) {

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -36,6 +36,7 @@ our @EXPORT = qw (
   leap_version_at_least
   sle_version_at_least
   is_desktop_installed
+  is_system_upgrading
 );
 
 sub is_jeos {
@@ -190,4 +191,9 @@ sub leap_version_at_least {
 
 sub is_desktop_installed {
     return get_var("DESKTOP") !~ /textmode|minimalx/;
+}
+
+sub is_system_upgrading {
+    # If PATCH=1, make sure patch action is finished
+    return get_var('UPGRADE') && (!get_var('PATCH') || (get_var('PATCH') && get_var('SYSTEM_PATCHED')));
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -14,7 +14,7 @@ use lockapi;
 use needle;
 use registration;
 use utils;
-use version_utils qw(is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem sle_version_at_least is_desktop_installed is_jeos);
+use version_utils qw(is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem sle_version_at_least is_desktop_installed is_jeos is_sle);
 use File::Find;
 use File::Basename;
 use LWP::Simple 'head';
@@ -573,11 +573,14 @@ sub load_inst_tests {
             loadtest "installation/disk_space_fill";
         }
     }
-    if (check_var('SCC_REGISTER', 'installation')) {
-        loadtest "installation/scc_registration";
-    }
-    else {
-        loadtest "installation/skip_registration" unless check_var('SLE_PRODUCT', 'leanos');
+    # SCC registration is not required in media based upgrade since SLE15
+    unless (is_sle && sle_version_at_least('15') && get_var('MEDIA_UPGRADE')) {
+        if (check_var('SCC_REGISTER', 'installation')) {
+            loadtest "installation/scc_registration";
+        }
+        else {
+            loadtest "installation/skip_registration" unless check_var('SLE_PRODUCT', 'leanos');
+        }
     }
     if (is_sles4sap and !sle_version_at_least('15')) {
         loadtest "installation/sles4sap_product_installation_mode";

--- a/tests/installation/accept_license.pm
+++ b/tests/installation/accept_license.pm
@@ -20,9 +20,14 @@
 use strict;
 use base "y2logsstep";
 use testapi;
+use version_utils qw(is_sle sle_version_at_least);
 
 sub run {
     my ($self) = @_;
+
+    # workaround for bsc#1069124: Skip the license check in upgrade mode
+    return record_soft_failure('bsc#1069124: License is not shown in upgrade') if is_sle && sle_version_at_least('15') && get_var('UPGRADE');
+
     assert_screen([qw(network-settings-button license-agreement)]);
     if (match_has_tag('network-settings-button')) {
         # workaround for hpc missing license: https://bugzilla.suse.com/show_bug.cgi?id=1060174

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -30,6 +30,9 @@ sub run {
         return;
     }
 
+    # Workaround for bsc#1070233: not update "Booting" option in upgrade mode
+    return record_soft_failure('bsc#1070233: Error if click on Booting option') if is_sle && sle_version_at_least('15') && get_var('UPGRADE');
+
     # Verify Installation Settings overview is displayed as starting point
     assert_screen "installation-settings-overview-loaded";
 

--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -15,6 +15,7 @@ use strict;
 use base "y2logsstep";
 use testapi;
 use utils 'assert_screen_with_soft_timeout';
+use version_utils qw(is_sle sle_version_at_least);
 
 sub run {
     if (get_var('ENCRYPT')) {
@@ -34,6 +35,17 @@ sub run {
     send_key $cmd{next};
     assert_screen "remove-repository", 240;
     send_key $cmd{next};
+    # Select migration target in sle15 upgrade
+    if (is_sle && sle_version_at_least('15')) {
+        if (get_var('MEDIA_UPGRADE')) {
+            assert_screen 'upgrade-unregistered-system';
+            send_key $cmd{ok};
+        }
+        else {
+            assert_screen 'migration_target_' . lc(get_var('SLE_PRODUCT', 'sles')), 120;
+            send_key $cmd{next};
+        }
+    }
 }
 
 1;

--- a/tests/update/patch_before_migration.pm
+++ b/tests/update/patch_before_migration.pm
@@ -52,11 +52,11 @@ sub patching_sle {
         $self->setup_migration();
     }
 
-    if (get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/) {
+    if (get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/ || get_var('KEEP_REGISTERED')) {
         # The system is registered.
         set_var('HDD_SCC_REGISTERED', 1);
         # SKIP the module installation window, from the add_update_test_repo test
-        set_var('SKIP_INSTALLER_SCREEN', 1);
+        set_var('SKIP_INSTALLER_SCREEN', 1) if get_var('MAINT_TEST_REPO');
 
     }
     else {
@@ -68,6 +68,9 @@ sub patching_sle {
     # keep the value of SCC_REGISTER for offline migration tests with smt pattern or modules
     # Both of them need registration during offline migration
     if (!is_smt_or_module_tests) { set_var("SCC_REGISTER", ''); }
+
+    # mark system patched
+    set_var("SYSTEM_PATCHED", 1);
 }
 
 sub run {


### PR DESCRIPTION
  - workaround for bsc#1069124: skip the license check
  - workaround for bsc#1070031: skip the module selection
  - workaround for bsc#1070233: not update booting option
  - keep hdd registered if set var KEEP_REGISTERED=1
  - make sure no product list shown in welcome screen
  - skip SCC registration in media based upgrade
  - select migration target

poo#27376, poo#27504

[type description  here]

- Related ticket: https://progress.opensuse.org/issues/27376
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/590
- Verification run: http://openqa-apac1.suse.de/tests/202