### PR TITLE
Drop the redundant send_key in sled15_workarounds to fix poo#28597

### DIFF
--- a/tests/x11regressions/sled15_workarounds.pm
+++ b/tests/x11regressions/sled15_workarounds.pm
@@ -21,14 +21,16 @@ sub run {
     assert_and_click 'displaymanager';
     mouse_hide();
     wait_still_screen;
-    send_key 'ret';
     # Move the keyboard focus to the gear icon in gdm greeter
     for (1 .. 2) { send_key 'tab'; }
     send_key 'ret';
     # Switch to GNOME Shell session
     send_key 'right';
     send_key 'down';
+    save_screenshot;
     send_key 'ret';
+    # Move the keyboard focus back to gdm password input box
+    for (1 .. 2) { send_key 'tab'; }
     assert_screen 'displaymanager-password-prompt';
     type_password;
     send_key "ret";


### PR DESCRIPTION
### Observation

I have tried the qcow2 image created by this case, the system will fallback to sle-classic when booting to desktop again.That is to say this case didn't switch the session to GNOME Shell permanently, it only took effect for one time.

### Reasons

gmd prompted that `"Sorry, that didn't work. Please try again."` since there is a redundant `send_key 'ret'`in line 24 of the case. And in line 33 the keyboard focus wasn't in the input box when typing the password. 

Every time we chose the session via the gdm greeter gear icon the result will be written in 
`/var/lib/AccountsService/users/$username`. But the `XSession` variable in the configure file will be overwritten to NULL when you try to login with a wrong password or no password inputted. When we boot to desktop after a reboot it will fallback to the default session(sle-classic) since the `XSession` variable is NULL.

### Solution

- Drop the redundant send_key
- Move the keyboard focus back to the input box before line 33

---

- Related ticket: https://progress.opensuse.org/issues/28597
- Verification run: http://10.67.17.30/tests/2055#step/sled15_workarounds/6
