### PR TITLE
poo#28627: Fix regressed gensslcert

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -72,7 +72,8 @@ sub setup_apache2 {
     }
     # Create x509 certificate for this apache server
     if ($mode eq "SSL") {
-        assert_script_run 'gensslcert -n $(hostname) -e webmaster@$(hostname)', 600;
+        my $gensslcert_C_opt = '-C $(hostname)' unless is_sle && sle_version_at_least('15');
+        assert_script_run "gensslcert -n \$(hostname) $gensslcert_C_opt -e webmaster@\$(hostname)", 600;
         assert_script_run 'ls /etc/apache2/ssl.crt/$(hostname)-server.crt /etc/apache2/ssl.key/$(hostname)-server.key';
     }
 


### PR DESCRIPTION
SLES12SP1 QAM test regressed from PR#3957. This ought fix it.

Validation runs:
* SLES15: http://assam.suse.cz/tests/1286
* SLES12SP1: http://assam.suse.cz/tests/1284

Sorry for the regression.
@dasantiago @mimi1vx 