### PR TITLE
Adjust autoyast profile for SLE15

### DIFF
--- a/data/autoyast_sle15/autoyast_btrfs.xml
+++ b/data/autoyast_sle15/autoyast_btrfs.xml
@@ -124,9 +124,12 @@
       <pattern>base</pattern>
       <pattern>basesystem</pattern>
       <pattern>documentation</pattern>
+      <pattern>enhanced_base</pattern>
       <pattern>gnome_basic</pattern>
+      <pattern>gnome_basis</pattern>
       <pattern>minimal_base</pattern>
       <pattern>x11</pattern>
+      <pattern>x11_enhanced</pattern>
     </patterns>
     <products config:type="list">
       <product>SLES15</product>

--- a/data/autoyast_sle15/autoyast_ext4.xml
+++ b/data/autoyast_sle15/autoyast_ext4.xml
@@ -95,9 +95,12 @@
       <pattern>base</pattern>
       <pattern>basesystem</pattern>
       <pattern>documentation</pattern>
+      <pattern>enhanced_base</pattern>
       <pattern>gnome_basic</pattern>
+      <pattern>gnome_basis</pattern>
       <pattern>minimal_base</pattern>
       <pattern>x11</pattern>
+      <pattern>x11_enhanced</pattern>
     </patterns>
     <products config:type="list">
       <product>SLES15</product>

--- a/data/autoyast_sle15/autoyast_gnome.xml
+++ b/data/autoyast_sle15/autoyast_gnome.xml
@@ -52,9 +52,12 @@
       <pattern>base</pattern>
       <pattern>basesystem</pattern>
       <pattern>documentation</pattern>
+      <pattern>enhanced_base</pattern>
       <pattern>gnome_basic</pattern>
+      <pattern>gnome_basis</pattern>
       <pattern>minimal_base</pattern>
       <pattern>x11</pattern>
+      <pattern>x11_enhanced</pattern>
     </patterns>
     <products config:type="list">
       <product>SLES15</product>

--- a/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
+++ b/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
@@ -78,7 +78,8 @@
   </ntp-client>
   <partitioning config:type="list">
     <drive>
-      <device>/dev/vda</device>
+      <device>/dev/sda</device>
+      <disklabel>gpt</disklabel>
       <partitions config:type="list">
         <partition>
           <create config:type="boolean">true</create>
@@ -101,6 +102,7 @@
           <mount>/</mount>
         </partition>
       </partitions>
+      <use>all</use>
     </drive>
   </partitioning>
   <report>


### PR DESCRIPTION
This is result of next iteration of autoyast profiles adjustments.
Previously, profile was failing in early phase, so now we can proceed
further.

For other 3 profiles we include 3 patterns which were missing in before.

[Verification run](http://g226.suse.de/tests/526#).

[Verification run for btrfs](http://g226.suse.de/tests/555#) fails now with firewall bug
