### PR TITLE
Add soft failure to restart network after set hostname

### DIFF
--- a/tests/console/hostname.pm
+++ b/tests/console/hostname.pm
@@ -14,6 +14,7 @@
 use base "consoletest";
 use strict;
 use testapi;
+use utils;
 
 sub run {
     select_console 'root-console';
@@ -28,6 +29,17 @@ sub run {
     script_run "systemctl --no-pager status network.service";
     save_screenshot;
     assert_script_run "if systemctl -q is-active network.service; then systemctl reload-or-restart network.service; fi";
+    if (script_run("ip addr show br0 | grep DOWN") == 0) {
+        record_soft_failure('bsc#1061051');
+        systemctl('reload network');
+        systemctl('status network');
+        save_screenshot;
+        systemctl('restart network');
+        systemctl('status network');
+        save_screenshot;
+        assert_script_run "ip addr show br0 | grep UP";
+        save_screenshot;
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
br0 is stuck in setup-in-progress. Reload and Restart fixes the issue. Screenshots included to see that finishes in "up" status.

- Related ticket: https://progress.opensuse.org/issues/28603
- Verification run: http://dhc227/tests/585#
