### PR TITLE
zypper lifecycle: Hard-code package on JeOS

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -16,7 +16,6 @@ use strict;
 use testapi;
 use utils;
 
-
 our $date_re = qr/[0-9]{4}-[0-9]{2}-[0-9]{2}/;
 
 sub run {
@@ -52,7 +51,16 @@ sub run {
     if ($output =~ /name="(?<package>[^"]+)"/) {
         $package = $+{package};
     }
-
+    # For JeOS build testing we are always using the latest repositories, because
+    # JeOS images are build with a *different* build number to SLES/Leap. It seems
+    # that SLES repositories are not populated with packages for several hours
+    # (I have seen the test pass after 14 hours from the image creation), and actually
+    # no package in the image comes from any repository - it's from the image. So we
+    # hard-code 'sles-release' package, and it... works. Somehow.
+    if (!$package && is_jeos) {
+        record_soft_failure "Hardcoding 'sles-release' package for lifecycle check";
+        $package = 'sles-release';
+    }
     die "No suitable package found. Script output:\n$output" unless $package;
 
     my $testdate        = '2020-02-03';


### PR DESCRIPTION
For JeOS build testing we are always using the latest repositories,
because JeOS images are build with a *different* build number to
SLES/Leap. It seems that SLES repositories are not populated with
packages for several hours (I have seen the test pass after 14 hours
from the image creation), and actually no package in the image comes
from any repository - it's from the image. So we hard-code
'sles-release' package, and it... works. Somehow.

Fails w/o the workaround http://assam.suse.cz/tests/1289, passes with
the workaround http://assam.suse.cz/tests/1291 *at the same time*.

@thehejik 