### PR TITLE
Fix workaround unselected desktop module

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -204,7 +204,7 @@ sub fill_in_registration_data {
             # Activate the last of the expected modules to select them manually, as not preselected but at least dependencies are handled
             my $addons = (split(/,/, $SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')}))[-1] . (get_var('SCC_ADDONS') ? ',' . get_var('SCC_ADDONS') : '');
             # Add desktop module if not preselected and not yet added
-            if (match_has_tag('desktop-not-selected') && $addons !~ /desktop/) {
+            if (match_has_tag('desktop-not-selected') && $addons !~ /(?:desktop|we|sdk)/) {
                 $addons .= ',desktop';
             }
             set_var('SCC_ADDONS', $addons);


### PR DESCRIPTION
Two failures found on 360.1:
- https://openqa.suse.de/tests/1283237#step/scc_registration/41
- https://openqa.suse.de/tests/1283270#step/scc_registration/39

---

- Related ticket: None
- Verification run: http://copland.arch.suse.de/tests/1671#step/scc_registration/23
