### PR TITLE
Migrate regression-other cases to SLED15

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -708,7 +708,8 @@ sub load_x11regression_other {
         loadtest "x11/gnomeapps/gnome_documents";
         loadtest "x11regressions/totem/totem_launch";
     }
-    if (check_var('DISTRI', 'sle') && sle_version_at_least('12-SP2')) {
+    # shotwell was replaced by gnome-photos in SLE15 & yast_virtualization isn't in SLE15
+    if (is_sle && sle_version_at_least('12-SP2') && !sle_version_at_least('15')) {
         loadtest "x11regressions/shotwell/shotwell_import";
         loadtest "x11regressions/shotwell/shotwell_edit";
         loadtest "x11regressions/shotwell/shotwell_export";
@@ -717,14 +718,17 @@ sub load_x11regression_other {
     }
     if (get_var("DESKTOP") =~ /kde|gnome/) {
         loadtest "x11regressions/tracker/prep_tracker";
-        loadtest "x11regressions/tracker/tracker_starts";
-        loadtest "x11regressions/tracker/tracker_searchall";
-        loadtest "x11regressions/tracker/tracker_pref_starts";
-        loadtest "x11regressions/tracker/tracker_open_apps";
+        # tracker-gui/tracker-needle was dropped since version 1.99.0
+        if (!sle_version_at_least('15')) {
+            loadtest "x11regressions/tracker/tracker_starts";
+            loadtest "x11regressions/tracker/tracker_searchall";
+            loadtest "x11regressions/tracker/tracker_pref_starts";
+            loadtest "x11regressions/tracker/tracker_open_apps";
+            loadtest "x11regressions/tracker/tracker_mainmenu";
+        }
         loadtest "x11regressions/tracker/tracker_by_command";
         loadtest "x11regressions/tracker/tracker_info";
         loadtest "x11regressions/tracker/tracker_search_in_nautilus";
-        loadtest "x11regressions/tracker/tracker_mainmenu";
         loadtest "x11regressions/tracker/clean_tracker";
     }
 }

--- a/tests/x11regressions/brasero/brasero_launch.pm
+++ b/tests/x11regressions/brasero/brasero_launch.pm
@@ -16,7 +16,7 @@ use testapi;
 use utils;
 
 sub run {
-    assert_gui_app('brasero', install => 1, remain => 1);
+    assert_gui_app('brasero', install => !is_sle, remain => 1);
 
     # check about window
     send_key 'alt-h';

--- a/tests/x11regressions/tracker/tracker_by_command.pm
+++ b/tests/x11regressions/tracker/tracker_by_command.pm
@@ -21,6 +21,8 @@ use utils;
 sub run {
     x11_start_program('xterm');
     if (sle_version_at_least('12-SP2')) {
+        script_run "tracker daemon -s";
+        script_run "tracker status";
         script_run "tracker search newfile";
     }
     else {


### PR DESCRIPTION
This testsuite will be renamed as desktopapps-other and scheduled under Desktop Applications

- testsuite **desktopapps-other:** 
```
  BOOTFROM=c
  SLE_PRODUCT=sled
  REGRESSION=other
  HDD_1=SLE-%VERSION%-%ARCH%-Build%BUILD%-sled-gnome.qcow2
  START_AFTER_TEST=create_hdd_sled_gnome
```
- shotwell cases were dropped in SLED15
- tracker GUI cases were dropped in SLED15

---

- Related ticket: https://progress.opensuse.org/issues/27229
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/595
- Verification run: http://10.67.17.30/tests/2059
`  The failure of brasero was caused by a known bug.`
