### PR TITLE
[WIP] LTP: Remove piped tee from zypper_call()

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -20,8 +20,8 @@ use registration;
 
 sub add_repos {
     my $qa_head_repo = get_required_var('QA_HEAD_REPO');
-    zypper_call("ar $qa_head_repo qa_repo");
-    zypper_call('--gpg-auto-import-keys ref');
+    zypper_call("ar $qa_head_repo qa_repo",   dumb_term => 1);
+    zypper_call('--gpg-auto-import-keys ref', dumb_term => 1);
 }
 
 sub scc_we_enabled {
@@ -42,8 +42,8 @@ sub add_we_repo_if_available {
     }
     # productQA test with enabled we as iso_2
     if (get_var('BUILD_WE') && get_var('ISO_2')) {
-        zypper_call 'ar dvd:///?devices=/dev/sr2 WSE', log => 'add-WSE.txt';
-        zypper_call '--gpg-auto-import-keys ref',      log => 'ref-WSE.txt';
+        zypper_call('ar dvd:///?devices=/dev/sr2 WSE', log => 'add-WSE.txt', dumb_term => 1);
+        zypper_call('--gpg-auto-import-keys ref',      log => 'ref-WSE.txt', dumb_term => 1);
     }
 }
 
@@ -62,7 +62,7 @@ sub install_runtime_dependencies {
       tpm-tools
       wget
     );
-    zypper_call('-t in ' . join(' ', @deps) . ' | tee');
+    zypper_call('-t in ' . join(' ', @deps), dumb_term => 1);
 
     # kernel-default-extra are only for SLE (in WE)
     # net-tools-deprecated are not available for SLE15
@@ -97,7 +97,7 @@ sub install_build_dependencies {
       libtirpc-devel
       make
     );
-    zypper_call('-t in ' . join(' ', @deps) . ' | tee');
+    zypper_call('-t in ' . join(' ', @deps), dumb_term => 1);
 
     my @maybe_deps = qw(
       gcc-32bit
@@ -137,7 +137,7 @@ sub install_from_git {
 }
 
 sub install_from_repo {
-    zypper_call 'in qa_test_ltp';
+    zypper_call('in qa_test_ltp', dumb_term => 1);
     assert_script_run q(find ${LTPROOT:-/opt/ltp}/testcases/bin/openposix/conformance/interfaces/ -name '*.run-test' > ~/openposix_test_list.txt);
     script_run 'rpm -q qa_test_ltp > /opt/ltp_version';
 }

--- a/tests/kernel/ltp_setup_networking.pm
+++ b/tests/kernel/ltp_setup_networking.pm
@@ -26,14 +26,14 @@ sub install {
       psmisc
       tcpdump
     );
-    zypper_call('-t in ' . join(' ', @deps) . ' | tee');
+    zypper_call('-t in ' . join(' ', @deps), dumb_term => 1);
 
     # clients
     @deps = qw(
       dhcp-client
       telnet
     );
-    zypper_call('-t in ' . join(' ', @deps) . ' | tee');
+    zypper_call('-t in ' . join(' ', @deps), dumb_term => 1);
 
     # services
     @deps = qw(
@@ -44,7 +44,7 @@ sub install {
       rsync
       vsftpd
     );
-    zypper_call('-t in ' . join(' ', @deps) . ' | tee');
+    zypper_call('-t in ' . join(' ', @deps), dumb_term => 1);
 }
 
 sub setup {


### PR DESCRIPTION
Adding '| tee' to zypper_call() was inspired by commit
2e114fed ("Move iputils package from setup network to install LTP")
which added pipe to script_run().

But adding it to zypper_call() is wrong because it does not fail on
error due pipe. This is problematic as we use zypper_call() to install
packages without the testing does not make sense (e.g. git for cloning LTP).
Tests without these packages usually fail anyway, but later which is
misleading.

NOTE about boo#1055315 ("Zypper outputs ANSI characters regardless of
termcap") mentioned in 2e114fed: keep the workaround as the fix is
available only for Tumbleweed.
