### PR TITLE
Expect vim only when not messing with patterns where it is not included

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -821,7 +821,7 @@ sub load_consoletests {
     loadtest "console/zypper_in";
     loadtest "console/yast2_i";
     loadtest "console/yast2_bootloader";
-    loadtest "console/vim";
+    loadtest "console/vim" if !sle_version_at_least('15') || !get_var('PATTERNS') || check_var_array('PATTERNS', 'enhanced_base');
     if (!is_staging()) {
         loadtest "console/firewall_enabled";
     }


### PR DESCRIPTION
Tested the schedule evaluation locally:
* SLE12 (no pattern changes): executed
* SLE12 minimal,base: executed
* SLE15 (no pattern changes): executed
* SLE15 minimal,base: *not* executed
* SLE15 with enhanced_base: executed

Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1065049