### PR TITLE
Adjust profile according to bsc#1070788

### DIFF
--- a/data/autoyast_sle15/bug-879147_autoinst.xml
+++ b/data/autoyast_sle15/bug-879147_autoinst.xml
@@ -286,30 +286,24 @@
     <timezone>Europe/Berlin</timezone>
   </timezone>
   <user_defaults>
-    <expire/>
-    <group>500</group>
-    <groups/>
+    <group>100</group>
     <home>/home</home>
-    <inactive/>
     <no_groups config:type="boolean">true</no_groups>
-    <shell/>
-    <skel/>
     <umask>022</umask>
+    <shell>/bin/bash</shell>
   </user_defaults>
   <users config:type="list">
-    <user>
-      <fullname>Bernhard M. Wiedemann</fullname>
-      <encrypted config:type="boolean">false</encrypted>
-      <user_password>nots3cr3t</user_password>
-      <username>bernhard</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">false</encrypted>
-      <fullname>root</fullname>
-      <gid>0</gid>
-      <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
-      <username>root</username>
-    </user>
+      <user>
+        <encrypted config:type="boolean">false</encrypted>
+        <fullname>Bernhard M. Wiedemann</fullname>
+        <user_password>nots3cr3t</user_password>
+        <username>bernhard</username>
+      </user>
+      <user>
+        <encrypted config:type="boolean">false</encrypted>
+        <fullname>root</fullname>
+        <user_password>nots3cr3t</user_password>
+        <username>root</username>
+      </user>
   </users>
 </profile>


### PR DESCRIPTION
Without this change login shell is not defined for user bernhard, which
leads to situation when gnome doesn't list users in the system, but
shows prompt for username.
This behavior is there for 10 years, documentation will be updated
accordingly.
[Verification run](http://g226.suse.de/tests/552)
