### PR TITLE
Resolve conflict between openvswitch-dpdk and the plain variants

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -158,6 +158,8 @@ sub problem_can_be_skipped {
     return 1 if $pkg =~ /^ffmpeg2-devel/;
     # conflicts with libjpeg62-devel
     return 1 if $pkg =~ /^libjpeg8-devel/;
+    # conflicts with the plain variant
+    return 1 if $pkg =~ /^openvswitch-dpdk/;
 
     return;
 }


### PR DESCRIPTION
Resolve conflict between openvswitch-dpdk and the plain variants.

Fixes:
https://openqa.opensuse.org/tests/546843#step/install_packages/9
https://openqa.opensuse.org/tests/546841#step/install_packages/9
https://openqa.opensuse.org/tests/546842#step/install_packages/9

- Incident: https://build.opensuse.org/project/show/openSUSE:Maintenance:7544
