### PR TITLE
Change url for testing http protocol in firefox

### DIFF
--- a/tests/x11regressions/firefox/firefox_urlsprotocols.pm
+++ b/tests/x11regressions/firefox/firefox_urlsprotocols.pm
@@ -22,7 +22,7 @@ sub run {
 
     # sites_url
     my %sites_url = (
-        http  => "http://jekyllrb.com/",
+        http  => "http://eu.httpbin.org/html",
         https => "https://www.google.com/",
         ftp   => "ftp://mirror.bej.suse.com/",
         local => "file:///usr/share/w3m/w3mhelp.html"


### PR DESCRIPTION
jekyllrb.com started redirecting to https protocol, so it was no longer useful for testing http.

I considered the BBC news website as a replacement, since they are planning to keep their news archive on http for accessibility reasons. However, in the end I opted for coolo's suggestion http://eu.httpbin.org/html - a site with a specific purpose of testing http.

- Related ticket: https://progress.opensuse.org/issues/26908
- Needles MR: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/599
- Verification run:
    SP2: http://dreamyhamster.suse.cz/tests/812#step/firefox_urlsprotocols/17
    SP3: http://dreamyhamster.suse.cz/tests/810#step/firefox_urlsprotocols/19