### PR TITLE
Enable Public Cloud Module for allmodules test

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -353,7 +353,7 @@ if (is_update_test_repo_test && !get_var('MAINT_TEST_REPO')) {
 if (get_var('ENABLE_ALL_SCC_MODULES') && !get_var('SCC_MODULES')) {
     if (sle_version_at_least('15')) {
         # Add only modules which are not pre-selected
-        my $addons = (get_var('SCC_ADDONS') ? get_var('SCC_ADDONS') . ',' : '') . 'legacy,sdk';
+        my $addons = (get_var('SCC_ADDONS') ? get_var('SCC_ADDONS') . ',' : '') . 'legacy,sdk,pcm';
         set_var('SCC_ADDONS', $addons);
         set_var('PATTERNS',   'default,asmm,pcm');
     }


### PR DESCRIPTION
Enable Public Cloud Module for test scenario gnome+proxy_SCC+allmodules
- Related ticket: https://progress.opensuse.org/issues/26740 https://progress.opensuse.org/issues/26770
- Verification run: http://f146.suse.de/tests/1760