### PR TITLE
Blacklist productivity addon instead of SDK

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -218,7 +218,7 @@ sub fill_in_registration_data {
             # Activate the last of the expected modules to select them manually, as not preselected but at least dependencies are handled
             my $addons = (split(/,/, $SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')}))[-1] . (get_var('SCC_ADDONS') ? ',' . get_var('SCC_ADDONS') : '');
             # Add desktop module if not preselected and not yet added
-            if (match_has_tag('desktop-not-selected') && $addons !~ /(?:desktop|we|sdk)/) {
+            if (match_has_tag('desktop-not-selected') && $addons !~ /(?:desktop|we|productivity)/) {
                 $addons .= ',desktop';
             }
             set_var('SCC_ADDONS', $addons);


### PR DESCRIPTION
- Blacklist for workaround to select desktop apps module.
- Productivity is the real responsible for autoselected desktop apps module.

---

- Verification run: [copland#1683#step/scc_registration/41](http://copland.arch.suse.de/tests/1683#step/scc_registration/41) (please, be aware that the failure is because of the missing SDK module, so my fix works.
