### PR TITLE
Add leap_version_at_least in version_utils

### DIFF
--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -14,7 +14,7 @@ use strict;
 use base "console_yasttest";
 use testapi;
 use utils;
-use version_utils qw(is_sle sle_version_at_least is_leap);
+use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least);
 
 sub setup_ldap {
     select_console 'root-console';


### PR DESCRIPTION
- leap_version is missing, so add it
- verification run:
	http://e13.suse.de/tests/72#step/yast2_samba/32
