### PR TITLE
Disable sle2docker for SLE15 and higher

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -579,7 +579,7 @@ sub load_extra_tests {
             if (check_var('DISTRI', 'opensuse')) {
                 loadtest "console/docker_compose";
             }
-            if (check_var('DISTRI', 'sle')) {
+            if (check_var('DISTRI', 'sle') && !(sle_version_at_least('15'))) {
                 loadtest "console/sle2docker";
             }
         }


### PR DESCRIPTION
Fix bsc#1064684: sle2docker is not available in SLE15.
Sle2docker test is included only in SLE12 test runs.

- Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1064684
- Verification run SLE15: http://10.100.12.105/tests/712
- Verification run SLE12: http://10.100.12.105/tests/713

