### PR TITLE
Don't wait for velum on non-autoyast installations

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -528,7 +528,7 @@ sub specific_caasp_params {
         mutex_unlock 'dhcp';
     }
     # Wait until admin node genarates autoyast profile
-    if (check_var 'STACK_ROLE', 'worker') {
+    if (check_var('STACK_ROLE', 'worker') && get_var('AUTOYAST')) {
         mutex_lock "VELUM_CONFIGURED";
         mutex_unlock "VELUM_CONFIGURED";
     }


### PR DESCRIPTION
This willl speed up mostly VMX deployments
 - before: 27:34 minutes - http://dhcp91.suse.cz/tests/8482
 - after: 14:16 minutes - http://dhcp91.suse.cz/tests/8573