### PR TITLE
Add bios boot partition for storage-ng for RAID

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -74,6 +74,7 @@ sub init_cmd {
       entiredisk alt-e
       guidedsetup alt-g
       rescandevices alt-e
+      exp_part_finish alt-f
     );
 
     if (check_var('INSTLANG', "de_DE")) {

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -25,9 +25,10 @@ sub run {
     if (match_has_tag('storage-ng')) {
         set_var('STORAGE_NG', 1);
         # Define changed shortcuts
-        $cmd{donotformat} = 'alt-t';
-        $cmd{addraid}     = 'alt-i';
-        $cmd{filesystem}  = 'alt-a';
+        $cmd{donotformat}     = 'alt-t';
+        $cmd{addraid}         = 'alt-i';
+        $cmd{filesystem}      = 'alt-a';
+        $cmd{exp_part_finish} = 'alt-n';
         if (check_var('DISTRI', 'opensuse')) {
             $cmd{expertpartitioner} = 'alt-x';
             $cmd{rescandevices}     = 'alt-c';


### PR DESCRIPTION
As per bsc#1063957 there is a change in behavior and now bios boot
partition is required for storage-ng.

- Related ticket: [poo#28573](https://progress.opensuse.org/issues/28573).
- [Needles openSUSE](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/294)
- [Needles SLE](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/603)

- [Verification run openSUSE](http://gershwin.arch.suse.de/tests/89)
- [Verification run SLE](http://g226.suse.de/tests/3#)