### PR TITLE
salt-master is not available for SLE15 staging

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -812,7 +812,7 @@ sub load_consoletests {
     if (check_var_array('SCC_ADDONS', 'asmm')) {
         loadtest "console/puppet";
     }
-    if (check_var_array('SCC_ADDONS', 'asmm') || sle_version_at_least('15')) {
+    if (check_var_array('SCC_ADDONS', 'asmm') || sle_version_at_least('15') && !is_staging()) {
         loadtest "console/salt";
     }
     if (check_var("ARCH", "x86_64")) {


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/28964