### PR TITLE
Add leap_version_at_least missing in version_utils

### DIFF
--- a/tests/console/yast2_proxy.pm
+++ b/tests/console/yast2_proxy.pm
@@ -14,7 +14,7 @@ use strict;
 use base "console_yasttest";
 use testapi;
 use utils;
-use version_utils qw(is_sle sle_version_at_least is_leap);
+use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least);
 
 
 my %sub_menu_needles = (


### PR DESCRIPTION
- see poo#28958 for details
- verification run:
 http://e13.suse.de/tests/79#step/yast2_proxy

