### PR TITLE
Collect logs if clone, wicked or repo test module fail

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -40,29 +40,5 @@ sub post_run_hook {
     $self->clear_and_verify_console;
 }
 
-# Executes the command line tests from a yast repository (in master or in the
-# given optional branch) using prove
-sub run_yast_cli_test {
-    my ($self, $packname) = @_;
-    my $PACKDIR = '/usr/src/packages';
-
-    assert_script_run "zypper -n in $packname";
-    assert_script_run "zypper -n si $packname";
-    assert_script_run "rpmbuild -bp $PACKDIR/SPECS/$packname.spec";
-    script_run "pushd $PACKDIR/BUILD/$packname-*";
-
-    # Run 'prove' only if there is a directory called t
-    script_run("if [ -d t ]; then echo -n 'run'; else echo -n 'skip'; fi > /dev/$serialdev", 0);
-    my $action = wait_serial(['run', 'skip'], 10);
-    if ($action eq 'run') {
-        assert_script_run('prove -v', timeout => 90, fail_message => 'yast cli tests failed');
-    }
-
-    script_run 'popd';
-
-    # Should we cleanup after?
-    #script_run "rm -rf $packname-*";
-}
-
 1;
 # vim: set sw=4 et:

--- a/tests/autoyast/clone.pm
+++ b/tests/autoyast/clone.pm
@@ -17,7 +17,7 @@
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
 use strict;
-use base 'basetest';
+use base 'console_yasttest';
 use testapi;
 
 sub run {

--- a/tests/autoyast/repos.pm
+++ b/tests/autoyast/repos.pm
@@ -17,7 +17,7 @@
 # Maintainer: Pavel Sladek <psladek@suse.cz>
 
 use strict;
-use base 'basetest';
+use base 'console_yasttest';
 use testapi;
 use utils;
 

--- a/tests/autoyast/wicked.pm
+++ b/tests/autoyast/wicked.pm
@@ -17,7 +17,7 @@
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
 use strict;
-use base 'basetest';
+use base 'consoletest';
 use testapi;
 
 sub run {

--- a/tests/console/yast2_cmdline.pm
+++ b/tests/console/yast2_cmdline.pm
@@ -1,22 +1,45 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Support for the new tests for yast command line
-# G-Maintainer: Ancor Gonzalez Sosa <ancor@suse.de>
+# Summary: Support for the new tests for yast command line
+# Maintainer: Ancor Gonzalez Sosa <ancor@suse.de>
 
 use base "console_yasttest";
 use strict;
 use testapi;
 
+# Executes the command line tests from a yast repository (in master or in the
+# given optional branch) using prove
+sub run_yast_cli_test {
+    my ($packname) = @_;
+    my $PACKDIR = '/usr/src/packages';
+
+    assert_script_run "zypper -n in $packname";
+    assert_script_run "zypper -n si $packname";
+    assert_script_run "rpmbuild -bp $PACKDIR/SPECS/$packname.spec";
+    script_run "pushd $PACKDIR/BUILD/$packname-*";
+
+    # Run 'prove' only if there is a directory called t
+    script_run("if [ -d t ]; then echo -n 'run'; else echo -n 'skip'; fi > /dev/$serialdev", 0);
+    my $action = wait_serial(['run', 'skip'], 10);
+    if ($action eq 'run') {
+        assert_script_run('prove -v', timeout => 90, fail_message => 'yast cli tests failed');
+    }
+
+    script_run 'popd';
+
+    # Should we cleanup after?
+    #script_run "rm -rf $packname-*";
+}
+
 sub run {
-    my $self = shift;
     select_console 'root-console';
 
     # Install test requirement
@@ -26,8 +49,8 @@ sub run {
     assert_script_run 'zypper mr -e repo-source';
 
     # Run YaST CLI tests
-    $self->run_yast_cli_test('yast2-network');
-    $self->run_yast_cli_test('yast2-dns-server');
+    run_yast_cli_test('yast2-network');
+    run_yast_cli_test('yast2-dns-server');
 }
 
 1;


### PR DESCRIPTION
During autoyast installation we do not collect logs in case of failures
for some modules. In order to simplify review process we should do so.

- [poo#28717](https://progress.opensuse.org/issues/28717)
- [Verification run](http://gershwin.arch.suse.de/tests/79)