### PR TITLE
Adjust modules names according to the medium

### DIFF
--- a/data/autoyast_sle15/autoyast_btrfs.xml
+++ b/data/autoyast_sle15/autoyast_btrfs.xml
@@ -6,17 +6,17 @@
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-basesystem</product>
-        <product_dir>/Basesystem</product_dir>
+        <product_dir>/Module-Basesystem</product_dir>
       </listentry>
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-desktop-applications</product>
-        <product_dir>/Desktop-Applications</product_dir>
+        <product_dir>/Module-Desktop-Applications</product_dir>
       </listentry>
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-server-applications</product>
-        <product_dir>/Server-Applications</product_dir>
+        <product_dir>/Module-Server-Applications</product_dir>
       </listentry>
     </add_on_products>
   </add-on>

--- a/data/autoyast_sle15/autoyast_error.xml
+++ b/data/autoyast_sle15/autoyast_error.xml
@@ -11,17 +11,17 @@
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-basesystem</product>
-        <product_dir>/Basesystem</product_dir>
+        <product_dir>/Module-Basesystem</product_dir>
       </listentry>
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-desktop-applications</product>
-        <product_dir>/Desktop-Applications</product_dir>
+        <product_dir>/Module-Desktop-Applications</product_dir>
       </listentry>
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-server-applications</product>
-        <product_dir>/Server-Applications</product_dir>
+        <product_dir>/Module-Server-Applications</product_dir>
       </listentry>
     </add_on_products>
   </add-on>

--- a/data/autoyast_sle15/autoyast_ext4.xml
+++ b/data/autoyast_sle15/autoyast_ext4.xml
@@ -6,17 +6,17 @@
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-basesystem</product>
-        <product_dir>/Basesystem</product_dir>
+        <product_dir>/Module-Basesystem</product_dir>
       </listentry>
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-desktop-applications</product>
-        <product_dir>/Desktop-Applications</product_dir>
+        <product_dir>/Module-Desktop-Applications</product_dir>
       </listentry>
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-server-applications</product>
-        <product_dir>/Server-Applications</product_dir>
+        <product_dir>/Module-Server-Applications</product_dir>
       </listentry>
     </add_on_products>
   </add-on>

--- a/data/autoyast_sle15/autoyast_gnome.xml
+++ b/data/autoyast_sle15/autoyast_gnome.xml
@@ -6,17 +6,17 @@
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-basesystem</product>
-        <product_dir>/Basesystem</product_dir>
+        <product_dir>/Module-Basesystem</product_dir>
       </listentry>
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-desktop-applications</product>
-        <product_dir>/Desktop-Applications</product_dir>
+        <product_dir>/Module-Desktop-Applications</product_dir>
       </listentry>
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-server-applications</product>
-        <product_dir>/Server-Applications</product_dir>
+        <product_dir>/Module-Server-Applications</product_dir>
       </listentry>
     </add_on_products>
   </add-on>

--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -7,17 +7,17 @@
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-basesystem</product>
-        <product_dir>/Basesystem</product_dir>
+        <product_dir>/Module-Basesystem</product_dir>
       </listentry>
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-desktop-applications</product>
-        <product_dir>/Desktop-Applications</product_dir>
+        <product_dir>/Module-Desktop-Applications</product_dir>
       </listentry>
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-server-applications</product>
-        <product_dir>/Server-Applications</product_dir>
+        <product_dir>/Module-Server-Applications</product_dir>
       </listentry>
     </add_on_products>
   </add-on>

--- a/data/autoyast_sle15/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle15/bug-872532_ix64ph1069.xml
@@ -6,17 +6,17 @@
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-basesystem</product>
-        <product_dir>/Basesystem</product_dir>
+        <product_dir>/Module-Basesystem</product_dir>
       </listentry>
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-desktop-applications</product>
-        <product_dir>/Desktop-Applications</product_dir>
+        <product_dir>/Module-Desktop-Applications</product_dir>
       </listentry>
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-server-applications</product>
-        <product_dir>/Server-Applications</product_dir>
+        <product_dir>/Module-Server-Applications</product_dir>
       </listentry>
     </add_on_products>
   </add-on>

--- a/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
@@ -6,17 +6,17 @@
         <listentry>
           <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
           <product>sle-module-basesystem</product>
-          <product_dir>/Basesystem</product_dir>
+          <product_dir>/Module-Basesystem</product_dir>
         </listentry>
         <listentry>
           <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
           <product>sle-module-desktop-applications</product>
-          <product_dir>/Desktop-Applications</product_dir>
+          <product_dir>/Module-Desktop-Applications</product_dir>
         </listentry>
         <listentry>
           <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
           <product>sle-module-server-applications</product>
-          <product_dir>/Server-Applications</product_dir>
+          <product_dir>/Module-Server-Applications</product_dir>
         </listentry>
       </add_on_products>
     </add-on>

--- a/data/autoyast_sle15/bug-877438_ix64ph1029.xml
+++ b/data/autoyast_sle15/bug-877438_ix64ph1029.xml
@@ -6,17 +6,17 @@
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-basesystem</product>
-        <product_dir>/Basesystem</product_dir>
+        <product_dir>/Module-Basesystem</product_dir>
       </listentry>
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-desktop-applications</product>
-        <product_dir>/Desktop-Applications</product_dir>
+        <product_dir>/Module-Desktop-Applications</product_dir>
       </listentry>
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-server-applications</product>
-        <product_dir>/Server-Applications</product_dir>
+        <product_dir>/Module-Server-Applications</product_dir>
       </listentry>
     </add_on_products>
   </add-on>

--- a/data/autoyast_sle15/bug-879147_autoinst.xml
+++ b/data/autoyast_sle15/bug-879147_autoinst.xml
@@ -6,17 +6,17 @@
         <listentry>
           <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
           <product>sle-module-basesystem</product>
-          <product_dir>/Basesystem</product_dir>
+          <product_dir>/Module-Basesystem</product_dir>
         </listentry>
         <listentry>
           <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
           <product>sle-module-desktop-applications</product>
-          <product_dir>/Desktop-Applications</product_dir>
+          <product_dir>/Module-Desktop-Applications</product_dir>
         </listentry>
         <listentry>
           <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
           <product>sle-module-server-applications</product>
-          <product_dir>/Server-Applications</product_dir>
+          <product_dir>/Module-Server-Applications</product_dir>
         </listentry>
       </add_on_products>
     </add-on>

--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -6,17 +6,17 @@
         <listentry>
           <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
           <product>sle-module-basesystem</product>
-          <product_dir>/Basesystem</product_dir>
+          <product_dir>/Module-Basesystem</product_dir>
         </listentry>
         <listentry>
           <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
           <product>sle-module-desktop-applications</product>
-          <product_dir>/Desktop-Applications</product_dir>
+          <product_dir>/Module-Desktop-Applications</product_dir>
         </listentry>
         <listentry>
           <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
           <product>sle-module-server-applications</product>
-          <product_dir>/Server-Applications</product_dir>
+          <product_dir>/Module-Server-Applications</product_dir>
       </listentry>
     </add_on_products>
   </add-on>

--- a/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
+++ b/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
@@ -6,17 +6,17 @@
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-basesystem</product>
-        <product_dir>/Basesystem</product_dir>
+        <product_dir>/Module-Basesystem</product_dir>
       </listentry>
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-desktop-applications</product>
-        <product_dir>/Desktop-Applications</product_dir>
+        <product_dir>/Module-Desktop-Applications</product_dir>
       </listentry>
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
         <product>sle-module-server-applications</product>
-        <product_dir>/Server-Applications</product_dir>
+        <product_dir>/Module-Server-Applications</product_dir>
       </listentry>
     </add_on_products>
   </add-on>


### PR DESCRIPTION
In build 368.3 all packages medium got new names for the modules. All
profiles for SLE15 require adjustment.

[Verification run](http://gershwin.arch.suse.de/tests/86#).