### PR TITLE
Add patch_and_reboot to HA tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -999,8 +999,9 @@ sub load_slenkins_tests {
 
 sub load_ha_cluster_tests {
     return unless (get_var("HA_CLUSTER"));
-    loadtest "boot/boot_to_desktop";
     loadtest "ha/wait_support_server";
+    loadtest "boot/boot_to_desktop";
+    loadtest "qa_automation/patch_and_reboot" if is_updates_tests;
     loadtest "console/consoletest_setup";
     loadtest "console/hostname" unless is_bridged_networking;
 


### PR DESCRIPTION
QAM needs patch_and_reboot for maintenance workflow. Waiting for
supportserver was moved to first position to provide configured network
to system during the boot already.

Related ticket: none
Needles: none
Verification run: http://10.100.12.105/tests/724 http://10.100.12.105/tests/725

If there will be conflict with other HA related changes, I can rebase it later.