### PR TITLE
Support SLES4SAP-15 textmode installation

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -65,6 +65,7 @@ our @EXPORT = qw(
   is_memtest
   is_mediacheck
   load_syscontainer_tests
+  load_sles4sap_tests
 );
 
 sub init_main {
@@ -846,6 +847,17 @@ sub load_syscontainer_tests() {
 
     # Run the actual test
     loadtest 'virtualization/syscontainer_image_test';
+}
+
+sub load_sles4sap_tests {
+    return if get_var('INSTALLONLY');
+    loadtest "sles4sap/patterns";
+    loadtest "sles4sap/sapconf";
+    loadtest "sles4sap/saptune";
+    if (get_var('NW')) {
+        loadtest "sles4sap/nw_ascs_install" if (get_var('SLES4SAP_MODE') !~ /wizard/);
+        loadtest "sles4sap/netweaver_ascs";
+    }
 }
 
 1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -65,7 +65,6 @@ our @EXPORT = qw(
   is_memtest
   is_mediacheck
   load_syscontainer_tests
-  load_sles4sap_tests
 );
 
 sub init_main {
@@ -847,17 +846,6 @@ sub load_syscontainer_tests() {
 
     # Run the actual test
     loadtest 'virtualization/syscontainer_image_test';
-}
-
-sub load_sles4sap_tests {
-    return if get_var('INSTALLONLY');
-    loadtest "sles4sap/patterns";
-    loadtest "sles4sap/sapconf";
-    loadtest "sles4sap/saptune";
-    if (get_var('NW')) {
-        loadtest "sles4sap/nw_ascs_install" if (get_var('SLES4SAP_MODE') !~ /wizard/);
-        loadtest "sles4sap/netweaver_ascs";
-    }
 }
 
 1;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1128,6 +1128,17 @@ sub load_patching_tests {
     loadtest 'installation/bootloader_zkvm_sym' if get_var('S390_ZKVM');
 }
 
+sub load_sles4sap_tests {
+    return if get_var('INSTALLONLY');
+    loadtest "sles4sap/patterns";
+    loadtest "sles4sap/sapconf";
+    loadtest "sles4sap/saptune";
+    if (get_var('NW')) {
+        loadtest "sles4sap/nw_ascs_install" if (get_var('SLES4SAP_MODE') !~ /wizard/);
+        loadtest "sles4sap/netweaver_ascs";
+    }
+}
+
 sub prepare_target {
     if (get_var("BOOT_HDD_IMAGE")) {
         boot_hdd_image;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -956,13 +956,7 @@ sub load_x11tests {
     }
     loadtest "x11/desktop_mainmenu";
     if (is_sles4sap() and !is_sles4sap_standard()) {
-        loadtest "sles4sap/patterns";
-        loadtest "sles4sap/sapconf";
-        loadtest "sles4sap/saptune";
-        if (get_var('NW')) {
-            loadtest "sles4sap/nw_ascs_install" if (get_var('SLES4SAP_MODE') !~ /wizard/);
-            loadtest "sles4sap/netweaver_ascs";
-        }
+        load_sles4sap_tests();
     }
     # Need to skip shutdown to keep backend alive if running rollback tests after migration
     unless (get_var('ROLLBACK_AFTER_MIGRATION')) {
@@ -1585,6 +1579,9 @@ else {
         load_rescuecd_tests();
         load_consoletests();
         load_x11tests();
+        if (is_sles4sap() and !is_sles4sap_standard() and !is_desktop_installed()) {
+            load_sles4sap_tests();
+        }
         if (get_var('ROLLBACK_AFTER_MIGRATION') && (snapper_is_applicable())) {
             load_rollback_tests();
         }

--- a/tests/installation/change_desktop.pm
+++ b/tests/installation/change_desktop.pm
@@ -60,8 +60,8 @@ sub change_desktop {
             send_key ' ';
         }
         if (check_var('DESKTOP', 'textmode')) {
-            send_key_until_needlematch 'x11-selected', 'down';
-            send_key ' ';
+            send_key_until_needlematch [qw(x11-selected x11-unselected)], 'down';
+            send_key ' ' if match_has_tag('x11-selected');
         }
         assert_screen "desktop-selected";
     }

--- a/tests/sles4sap/nw_ascs_install.pm
+++ b/tests/sles4sap/nw_ascs_install.pm
@@ -57,7 +57,7 @@ sub run {
     assert_script_run "md5sum -c /tmp/check-nw-media", 300;
 
     # Define a valid hostname/IP address in /etc/hosts
-    assert_script_run "wget -P /tmp " . autoinst_url . "/data/sles4sap/add_ip_hostname2hosts.sh";
+    assert_script_run "curl -f -v " . autoinst_url . "/data/sles4sap/add_ip_hostname2hosts.sh > /tmp/add_ip_hostname2hosts.sh";
     assert_script_run "/bin/bash -ex /tmp/add_ip_hostname2hosts.sh";
 
     # Use the correct hostname in SAP's inifile.params
@@ -65,7 +65,7 @@ sub run {
     assert_script_run $cmd;
 
     # Create an appropiate start_dir.cd file and an unattended installation directory
-    $cmd = 'ls | while read d; do test -d "$d" -a ! -h "$d" && echo $d; done | sed -e "s@^@/sapinst/@"';
+    $cmd = 'ls | while read d; do if [ -d "$d" -a ! -h "$d" ]; then echo $d; fi ; done | sed -e "s@^@/sapinst/@"';
     assert_script_run "$cmd > /tmp/start_dir.cd";
     type_string "mkdir -p /sapinst/unattended\n";
     assert_script_run "mv /tmp/start_dir.cd /sapinst/unattended/";


### PR DESCRIPTION
- Adds SLES4SAP tests for textmode installation.
- Creates load_sles4sap_tests() method.
- Adds support for SLES4SAP VIDEOMODE=text installation in tests/installation/change_desktop.pm
- Change wget to curl in tests/sles4sap/nw_ascs_install.pm

Sample runs:
http://mango.suse.de/tests/123
http://mango.suse.de/tests/122