### PR TITLE
New test case: Disconnected SMT

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -1,0 +1,77 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: common parts on SMT and RMT
+# Maintainer: Dehai Kong <dhkong@suse.com>
+
+package repo_tools;
+
+use base Exporter;
+use Exporter;
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+
+our @EXPORT = qw (smt_wizard smt_mirror_repo);
+
+sub smt_wizard {
+    type_string "yast2 smt-wizard;echo yast2-smt-wizard-\$? > /dev/$serialdev\n";
+    assert_screen 'smt-wizard-1';
+    send_key 'alt-u';
+    wait_still_screen;
+    type_string 'SCC_ORG_DAJJBA';
+    send_key 'alt-p';
+    wait_still_screen;
+    type_string '043107d3db';
+    send_key 'alt-n';
+    assert_screen 'smt-wizard-2';
+    send_key 'alt-d';
+    wait_still_screen;
+    type_password;
+    send_key 'tab';
+    type_password;
+    send_key 'alt-n';
+    assert_screen 'smt-mariadb-password', 60;
+    type_password;
+    send_key 'tab';
+    type_password;
+    send_key 'alt-o';
+    assert_screen 'smt-server-cert';
+    send_key 'alt-r';
+    assert_screen 'smt-CA-password';
+    send_key 'alt-p';
+    wait_still_screen;
+    type_password;
+    send_key 'tab';
+    type_password;
+    send_key 'alt-o';
+    assert_screen 'smt-installation-overview';
+    send_key 'alt-n';
+    if (check_var("SMT", "internal")) {
+        assert_screen 'smt-sync-failed', 100;    # expect fail because there is no network
+        send_key 'alt-o';
+    }
+    wait_serial("yast2-smt-wizard-0", 400) || die 'smt wizard failed';
+}
+
+sub smt_mirror_repo {
+    # Verify smt mirror function and mirror a tiny released repo from SCC. Hardcode it as SLES12-SP3-Installer-Updates
+    assert_script_run 'smt-repos --enable-mirror SLES12-SP3-Installer-Updates sle-12-x86_64';
+    save_screenshot;
+    assert_script_run 'smt-mirror', 600;
+    save_screenshot;
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/lib/suseconnect_register.pm
+++ b/lib/suseconnect_register.pm
@@ -46,12 +46,14 @@ sub command_register {
     my $zypper_conflict = qr/^Choose from above solutions by number[\s\S,]* \[1/m;
     my $zypper_continue = qr/^Continue\? \[y/m;
     my $zypper_done     = qr/Run.*to list these programs|^ZYPPER-DONE/m;
+    my $registered      = qr/Registered*/m;
 
     if (!$addon) {
         my $reg_code = get_required_var("SCC_REGCODE");
         $version =~ s/\-SP/./;
         script_run("(SUSEConnect -p SLES/$version/$arch --regcode $reg_code) | tee /dev/$serialdev", 0);
-        my $out = wait_serial($zypper_conflict, 240);
+        my $out = wait_serial($zypper_conflict, 240) if (get_var("ZDUP"));    # zdup migration will have confilct
+        my $out = wait_serial($registered) if (!get_var("ZDUP"));             # just register a bare system
 
         #resolve potential conflict by zypper
         if ($out =~ $zypper_conflict) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1270,6 +1270,16 @@ elsif (get_var("FIPS_TS")) {
         load_applicationstests;
     }
 }
+elsif (get_var('SMT')) {
+    prepare_target();
+    loadtest "x11/smt_disconnect_prepare";
+    if (check_var('SMT', 'external')) {
+        loadtest "x11/smt_disconnect_external";
+    }
+    elsif (check_var('SMT', 'internal')) {
+        loadtest "x11/smt_disconnect_internal";
+    }
+}
 elsif (get_var("HA_CLUSTER")) {
     load_ha_cluster_tests();
 }

--- a/tests/x11/smt.pm
+++ b/tests/x11/smt.pm
@@ -10,12 +10,13 @@
 # Summary: Add smt configuration test
 #    test installation and upgrade with smt pattern, basic configuration via
 #    smt-wizard and validation with smt-repos smt-sync return value
-# Maintainer: Jozef Pupava <jpupava@suse.com>
+# Maintainer: Jozef Pupava <jpupava@suse.com>, Jiawei Sun <jwsun@suse.com>, Dehai Kong <dhkong@suse.com>
 
 use base "x11test";
 use strict;
 use warnings;
 use testapi;
+use repo_tools;
 
 sub run {
     x11_start_program('xterm -geometry 150x35+5+5', target_match => 'xterm');
@@ -27,50 +28,6 @@ sub run {
     # mirror and sync a base repo from SCC
     smt_mirror_repo();
     type_string "killall xterm\n";
-}
-
-sub smt_wizard {
-
-    type_string "yast2 smt-wizard;echo yast2-smt-wizard-\$? > /dev/$serialdev\n";
-    assert_screen 'smt-wizard-1';
-    send_key 'alt-u';
-    wait_still_screen;
-    type_string 'SCC_ORG_DAJJBA';
-    send_key 'alt-p';
-    wait_still_screen;
-    type_string '043107d3db';
-    send_key 'alt-n';
-    assert_screen 'smt-wizard-2';
-    send_key 'alt-d';
-    wait_still_screen;
-    type_password;
-    send_key 'tab';
-    type_password;
-    send_key 'alt-n';
-    assert_screen 'smt-mariadb-password', 60;
-    type_password;
-    send_key 'tab';
-    type_password;
-    send_key 'alt-o';
-    assert_screen 'smt-server-cert';
-    send_key 'alt-r';
-    assert_screen 'smt-CA-password';
-    send_key 'alt-p';
-    wait_still_screen;
-    type_password;
-    send_key 'tab';
-    type_password;
-    send_key 'alt-o';
-    assert_screen 'smt-installation-overview';
-    send_key 'alt-n';
-    wait_serial("yast2-smt-wizard-0", 400) || die 'smt wizard failed';
-}
-
-sub smt_mirror_repo {
-
-    # Verify smt mirror function and mirror a tiny released repo from SCC. Hardcode it as SLES12-SP3-Installer-Updates
-    assert_script_run 'smt-repos --enable-mirror SLES12-SP3-Installer-Updates sle-12-x86_64';
-    assert_script_run 'smt-mirror', 600;
 }
 
 sub test_flags {

--- a/tests/x11/smt_disconnect_external.pm
+++ b/tests/x11/smt_disconnect_external.pm
@@ -1,0 +1,63 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Disconnect SMT external
+# Maintainer: Dehai Kong <dhkong@suse.com>
+
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use mmapi;
+use mm_network;
+use repo_tools;
+
+sub run {
+    x11_start_program('xterm -geometry 150x35+5+5', target_match => 'xterm');
+
+    # avoid black screen because it will be cost too much time
+    type_string("gsettings set org.gnome.desktop.session idle-delay 0\n");
+    save_screenshot;
+    become_root;
+
+    # setting external SMT configure
+    smt_wizard();
+
+    assert_script_run 'smt-sync', 600;
+    assert_script_run 'smt-repos';
+
+    # enable,mirror and sync one repo for internal using
+    smt_mirror_repo();
+    assert_script_run 'smt-sync --todir /mnt/Mobile-disk', 600;
+    save_screenshot;
+
+    mutex_create("disconnect_smt_1");
+
+    # lock and unlock internal smt mutex to get update DB and sync to mobile disk
+    my $children = get_children();
+    my $child_id = (keys %$children)[0];
+    mutex_lock('disconnect_smt_2', $child_id);
+    mutex_unlock('disconnect_smt_2', $child_id);
+    assert_script_run 'smt-mirror --dbreplfile /mnt/Mobile-disk/updateDB --fromlocalsmt --directory /mnt/Mobile-disk -L /var/log/smt/smt-mirror-example.log',
+      600;
+    assert_script_run 'smt-sync --todir /mnt/Mobile-disk', 600;
+
+    # create mutex to let internal smt do daily operation
+    mutex_create("disconnect_smt_3");
+    type_string "killall xterm\n";
+    wait_for_children;
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/smt_disconnect_internal.pm
+++ b/tests/x11/smt_disconnect_internal.pm
@@ -1,0 +1,90 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Disconnected SMT internal
+# Maintainer: Dehai Kong <dhkong@suse.com>
+
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use mmapi;
+use mm_network;
+use repo_tools;
+
+sub run {
+    my $external_IP = '10.0.2.111';
+    x11_start_program('xterm -geometry 150x35+5+5', target_match => 'xterm');
+
+    # avoid black screen because it will be cost too much time
+    type_string("gsettings set org.gnome.desktop.session idle-delay 0\n");
+    save_screenshot;
+    become_root;
+
+    # setting internal SMT configure
+    smt_wizard();
+
+    # setting internal SMT server
+    type_string("yast2 smt-server;echo yast2-smt-server-\$? > /dev/$serialdev\n");
+    assert_screen("smt-server-1");
+    send_key("alt-s");
+    assert_screen("smt-server-jobs");
+    send_key("alt-t");    # delete SCC Registration job
+    assert_screen("smt-delete-entry");
+    send_key("alt-y");
+    send_key("alt-t");    # delete Synchronization of Updates job
+    assert_screen("smt-delete-entry");
+    send_key("alt-y");
+    send_key("alt-o");
+    assert_screen("smt-mariadb-password-required");
+    type_password;
+    send_key("alt-o");
+    assert_screen 'smt-sync-failed', 100;
+    send_key 'alt-o';
+    wait_serial("yast2-smt-server-0", 400) || die 'smt server failed';
+
+    # network up and mount mobile disk
+    my $net_conf = parse_network_configuration();
+    my $mac      = $net_conf->{fixed}->{mac};
+    script_run "NIC=`grep $mac /sys/class/net/*/address |cut -d / -f 5`";
+    assert_script_run("ip link set \$NIC up");
+    assert_script_run("mount -t nfs $external_IP\:\/mnt\/Mobile-disk \/mnt\/Mobile-disk");
+
+    mutex_lock('disconnect_smt_1');
+    mutex_unlock('disconnect_smt_1');
+
+    # smt sync from mobile disk and create update DB
+    assert_script_run("smt-sync --fromdir \/mnt\/Mobile-disk", 600);
+    assert_script_run("smt-repos --enable-mirror SLES12-SP3-Installer-Updates sle-12-x86_64");
+    assert_script_run("smt-sync --createdbreplacementfile \/mnt\/Mobile-disk\/updateDB", 600);
+
+    # internal smt create a mutex to let external sync repos
+    mutex_create("disconnect_smt_2");
+
+    mutex_lock('disconnect_smt_3');
+    mutex_unlock('disconnect_smt_3');
+
+    # daily Internal SMT Server Operation
+    assert_script_run("smt-sync --fromdir \/mnt\/Mobile-disk",                           600);
+    assert_script_run("smt-mirror --fromdir \/mnt\/Mobile-disk",                         600);
+    assert_script_run("smt-sync --createdbreplacementfile \/mnt\/Mobile-disk\/updateDB", 600);
+    # check enabled repos
+    assert_script_run("smt-repos  --only-enabled | grep SLES12-SP3-Installer-Updates");
+    assert_script_run("umount \/mnt\/Mobile-disk");
+
+    type_string "killall xterm\n";
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/smt_disconnect_prepare.pm
+++ b/tests/x11/smt_disconnect_prepare.pm
@@ -1,0 +1,69 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Do some prepare for internal and external SMT on disconnect SMT case
+# Maintainer: Dehai Kong <dhkong@suse.com>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+use migration;
+use mm_network;
+use mm_tests;
+use suseconnect_register;
+
+sub run {
+    select_console("root-console");
+    if (check_var("SMT", "internal")) {
+        configure_static_network('10.0.2.100/24');
+    }
+    else {
+        configure_static_network('10.0.2.111/24');
+    }
+
+    # server running smt must be registered
+    command_register(get_required_var('VERSION'));
+
+    systemctl("disable SuSEfirewall2");
+    systemctl("stop SuSEfirewall2");
+
+    # external smt should enalbe nfs and share a file to simulate a mobile disk
+    if (check_var("SMT", "external")) {
+        systemctl("enable nfs-server.service");
+        systemctl("start nfs-server.service");
+        systemctl("enable nfs.service");
+        systemctl("start nfs.service");
+        assert_script_run("mkdir -p \/mnt\/Mobile-disk");
+        assert_script_run("chmod 777 \/mnt\/Mobile-disk");
+        assert_script_run("echo \"\/mnt\/Mobile-disk *(rw,no_root_squash,sync,no_subtree_check,crossmnt,nohide)\" >> \/etc\/exports");
+        assert_script_run("exportfs -ar");
+    }
+    else {
+        systemctl("enable nfs.service");
+        systemctl("start nfs.service");
+        assert_script_run("mkdir -p \/mnt\/Mobile-disk");
+    }
+
+    # internal smt should close network to simulate a restricted network
+    if (check_var("SMT", "internal")) {
+        my $net_conf = parse_network_configuration();
+        my $mac      = $net_conf->{fixed}->{mac};
+        script_run "NIC=`grep $mac /sys/class/net/*/address |cut -d / -f 5`";
+        assert_script_run("ip link set \$NIC down");
+    }
+
+    select_console("x11");
+}
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Based on below Doc reference:
https://www.suse.com/documentation/sles-12/book_smt/data/smt_disconnected.html
Related POO#:https://progress.opensuse.org/issues/28459
it must be worked after install smt pattern to save a HDD image
Local verify:
http://10.67.18.165/tests/259
http://10.67.18.165/tests/264
http://10.67.18.165/tests/265
Related MR#:https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/592

Change the exist smt test case, verify on local:
http://10.67.18.165/tests/266