### PR TITLE
Update bootloader cmdline for SMT installation

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -378,7 +378,7 @@ sub select_addons_in_textmode {
 sub registration_bootloader_cmdline {
     # https://www.suse.com/documentation/smt11/book_yep/data/smt_client_parameters.html
     # SCC_URL=https://smt.example.com
-    if (my $url = get_var('SCC_URL') || get_var('SMT_URL')) {
+    if (my $url = get_var('SMT_URL') || get_var('SCC_URL')) {
         my $cmdline = " regurl=$url";
         $cmdline .= " regcert=$url" if get_var('SCC_CERT');
         return $cmdline;


### PR DESCRIPTION
Set regurl as smt server address if exist.

- Verification run: http://10.67.17.147/tests/1766#step/bootloader/7
