### PR TITLE
yast2_lan_restart: Prevent trying to stop non-existing firewalld

### DIFF
--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -228,7 +228,9 @@ sub run {
     become_root;
     # make sure that firewalld is stopped, or we have later pops for firewall activation warning
     # or timeout for command 'ip a' later
-    if (script_run "systemctl show -p ActiveState firewalld.service | grep ActiveState=active") {
+    if (((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0')))
+        && script_run "systemctl show -p ActiveState firewalld.service | grep ActiveState=active")
+    {
         assert_script_run "systemctl stop firewalld";
     }
     # enable debug for detailed messages and easier detection of restart


### PR DESCRIPTION
See
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3956#issuecomment-349888347

Verification run: http://lord.arch/tests/2