### PR TITLE
Switch to correct console in post_fail_hook for ipmi test failures

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -3,6 +3,7 @@ use base "installbasetest";
 use testapi;
 use strict;
 use version_utils 'sle_version_at_least';
+use ipmi_backend_utils;
 
 sub use_wicked {
     script_run "cd /proc/sys/net/ipv4/conf";
@@ -33,6 +34,13 @@ sub get_ip_address {
 }
 
 sub get_to_console {
+    if (check_var('BACKEND', 'ipmi')) {
+        use_ssh_serial_console;
+        get_ip_address;
+        save_screenshot();
+        return;
+    }
+
     my @tags = qw(yast-still-running linuxrc-install-fail linuxrc-repo-not-found);
     my $ret = check_screen(\@tags, 5);
     if ($ret && match_has_tag("linuxrc-repo-not-found")) {    # KVM only


### PR DESCRIPTION
For any tests which based on ipmi backend( virtualization does),  when host installation fails at earlier steps, logs need to be collected in post_fail_hook in y2logstep.pm.  On the current ipmi backend , to collect logs, it needs to switch to ssh based console. However current code does not switch to such console and fail to collect necessary logs when installation fails. This PR is to fix this.

- job with described issue: https://openqa.suse.de/tests/1302680 , no yast logs uploaded
- Verification run: http://10.67.18.220/tests/492, logs are uploaded