### PR TITLE
Add basic error output validation to postgresql test

### DIFF
--- a/tests/console/postgresql_server.pm
+++ b/tests/console/postgresql_server.pm
@@ -27,13 +27,18 @@ sub run {
     # start the postgresql service
     systemctl 'start postgresql.service', timeout => 200;
 
-    # check the status
-    systemctl 'show -p ActiveState postgresql.service | grep ActiveState=active';
-    systemctl 'show -p SubState postgresql.service | grep SubState=running';
+    # check the status, if failed, get possible cause
+    assert_script_run 'systemctl show -p ActiveState postgresql.service | grep ActiveState=active';
+    assert_script_run 'systemctl show -p SubState postgresql.service | grep SubState=running';
 
     # test basic functionality of postgresql
     setup_pgsqldb;
     destroy_pgsqldb;
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    $self->export_logs;
 }
 
 1;


### PR DESCRIPTION
If for some reason postgresql fails to start, test script checks for daemon
status and if it is not active, print output of "systemct status" instead of just failed message.

Fixes poo#25610 - postgresql96server is hard to investigate on errors / should
be enabled on openSUSE

Test results can be seen at:
http://miurasan.ddns.net/tests/668#step/postgresql_server

Enable postgresql test on opensuse.
