### PR TITLE
Velum does not disconnect during bootstrap in CaaSP 3

### DIFF
--- a/tests/caasp/stack_bootstrap.pm
+++ b/tests/caasp/stack_bootstrap.pm
@@ -16,6 +16,7 @@ use strict;
 use testapi;
 use lockapi;
 use utils;
+use version_utils 'is_caasp';
 
 
 sub accept_nodes {
@@ -105,10 +106,14 @@ sub bootstrap {
     assert_and_click "velum-bootstrap";
 
     # Wait until bootstrap finishes
-    assert_screen [qw(velum-bootstrap-done velum-api-disconnected)], 900;
-    if (match_has_tag('velum-api-disconnected')) {
-        setup_root_ca;
+    if (is_caasp '3.0+') {
         assert_screen 'velum-bootstrap-done', 900;
+        setup_root_ca;
+    }
+    else {
+        assert_screen 'velum-api-disconnected', 300;
+        setup_root_ca;
+        assert_screen 'velum-bootstrap-done', 600;
     }
 }
 


### PR DESCRIPTION
Local run:
 - CaaSP2 - http://dhcp91.suse.cz/tests/161
 - CaaSP3 - http://dhcp91.suse.cz/tests/156

Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/604