### PR TITLE
Adjust autoyast profiles for missing software

### DIFF
--- a/data/autoyast_sle15/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle15/bug-872532_ix64ph1069.xml
@@ -779,28 +779,20 @@
     <image/>
     <instsource/>
     <packages config:type="list">
-      <package>crash-kmp-default</package>
       <package>dbus-1-python</package>
       <package>dconf</package>
-      <package>desktop-translations</package>
       <package>girepository-1_0</package>
-      <package>gnome-icon-theme-symbolic</package>
       <package>grub2-snapper-plugin</package>
       <package>gsettings-backend-dconf</package>
       <package>gxditview</package>
       <package>libXaw7</package>
       <package>libXmu6</package>
-      <package>libboost_system1_54_0</package>
-      <package>libboost_thread1_54_0</package>
       <package>libbtrfs0</package>
       <package>libdconf1</package>
       <package>libgirepository-1_0-1</package>
-      <package>libproxy1-config-gnome3</package>
-      <package>openssh-askpass</package>
       <package>plymouth-dracut</package>
       <package>python-gobject</package>
       <package>python-gobject-cairo</package>
-      <package>rng-tools</package>
       <package>snapper</package>
       <package>snapper-zypp-plugin</package>
       <package>ucode-intel</package>

--- a/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
@@ -860,27 +860,20 @@ find / -name YaST2-Second-Stage.service
     <image/>
     <instsource/>
     <packages config:type="list">
-      <package>crash-kmp-default</package>
       <package>dbus-1-python</package>
       <package>dconf</package>
-      <package>desktop-translations</package>
       <package>girepository-1_0</package>
-      <package>gnome-icon-theme-symbolic</package>
       <package>grub2-snapper-plugin</package>
       <package>gsettings-backend-dconf</package>
       <package>gxditview</package>
       <package>libXaw7</package>
       <package>libXmu6</package>
-      <package>libboost_system1_54_0</package>
-      <package>libboost_thread1_54_0</package>
       <package>libbtrfs0</package>
       <package>libdconf1</package>
       <package>libdnet1</package>
       <package>libgirepository-1_0-1</package>
-      <package>libproxy1-config-gnome3</package>
       <package>libvmtools0</package>
       <package>open-vm-tools</package>
-      <package>openssh-askpass</package>
       <package>plymouth-dracut</package>
       <package>python-gobject</package>
       <package>python-gobject-cairo</package>

--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -478,22 +478,16 @@
     <packages config:type="list">
       <package>at-spi2-atk-common</package>
       <package>at-spi2-atk-gtk2</package>
-      <package>crash-kmp-default</package>
       <package>dbus-1-python</package>
       <package>dconf</package>
-      <package>desktop-translations</package>
       <package>ft2demos</package>
-      <package>gnome-icon-theme-symbolic</package>
       <package>grub2-snapper-plugin</package>
       <package>gsettings-backend-dconf</package>
       <package>gstreamer-plugins-base</package>
       <package>gstreamer-plugins-base-lang</package>
       <package>gtk3-metatheme-adwaita</package>
       <package>gxditview</package>
-      <package>input-utils</package>
       <package>libSDL-1_2-0</package>
-      <package>libboost_system1_54_0</package>
-      <package>libboost_thread1_54_0</package>
       <package>libbtrfs0</package>
       <package>libcdda_interface0</package>
       <package>libcdda_paranoia0</package>
@@ -504,7 +498,6 @@
       <package>libgstriff-1_0-0</package>
       <package>libgsttag-1_0-0</package>
       <package>libgstvideo-1_0-0</package>
-      <package>libproxy1-config-gnome3</package>
       <package>libtheora0</package>
       <package>libvisual</package>
       <package>plymouth-dracut</package>
@@ -514,9 +507,7 @@
       <package>snapper-zypp-plugin</package>
       <package>ucode-intel</package>
       <package>xf86-input-evdev</package>
-      <package>xf86-input-void</package>
       <package>xf86-input-wacom</package>
-      <package>xf86-video-cirrus</package>
       <package>xf86-video-modesetting</package>
       <package>yast2-snapper</package>
       <package>yast2-trans-en_US</package>

--- a/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
+++ b/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
@@ -174,7 +174,6 @@
     <packages config:type="list">
       <package>autoyast2</package>
       <package>vim</package>
-      <package>mc</package>
       <package>iputils</package>
       <package>less</package>
       <package>screen</package>

--- a/data/autoyast_sle15/mini.xml
+++ b/data/autoyast_sle15/mini.xml
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-    <!--  very minimal autoyast profile-->
+    <!-- very minimal autoyast profile -->
+    <add-on>
+      <add_on_products config:type="list">
+        <listentry>
+          <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+          <product>sle-module-basesystem</product>
+          <product_dir>/Module-Basesystem</product_dir>
+        </listentry>
+      </add_on_products>
+    </add-on>
     <networking>
         <keep_install_network config:type="boolean">true</keep_install_network>
     </networking>

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -128,29 +128,6 @@ sub run {
                 send_key_until_needlematch 'create-partition-plans-finished', $cmd{ok};
                 next;
             }
-            if (match_has_tag('bsc#1055034') || match_has_tag('bsc#1054895')) {
-                record_soft_failure('bsc#1055034');
-                if (check_screen 'bsc#1054895', 0) {
-                    record_soft_failure('bsc#1054895');
-                }
-                send_key $cmd{ok};
-                next;
-            }
-            if (match_has_tag('bsc#1056356')) {
-                record_soft_failure('bsc#1056356');
-                send_key $cmd{ok};
-                next;
-            }
-            if (match_has_tag('bsc#1058099')) {
-                record_soft_failure('bsc#1058099');
-                send_key $cmd{ok};
-                next;
-            }
-            if (match_has_tag('bsc#1058999')) {
-                record_soft_failure('bsc#1058999');
-                send_key $cmd{ok};
-                next;
-            }
 
             die "Unknown popup message" unless check_screen('autoyast-known-warning', 0);
 


### PR DESCRIPTION
We have sorted out part with software and for some packages repo has
been changed. Now we remove softfailure and fixate this behavior as
expected. All workaround needles will be removed as well.

yast2, autoyast2 and autoyast2-installation packages are not available
on the medium, so minimal installation actually requires base system
module which contains these.
See [bsc#1069756](https://bugzilla.suse.com/show_bug.cgi?id=1054895)
and [bsc#1054895](https://bugzilla.suse.com/show_bug.cgi?id=1054895).

Please, merge [Needles MR#605](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/605).
[verification run](http://g226.suse.de/tests/18#)