### PR TITLE
Upload zypper log when a zypper_call fails

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -307,7 +307,11 @@ sub zypper_call {
 
     if ($ret) {
         my ($ret_code) = $ret =~ /$str-(\d+)/;
-        die "'zypper -n $command' failed with code $ret_code" unless grep { $_ == $ret_code } @$allow_exit_codes;
+        unless (grep { $_ == $ret_code } @$allow_exit_codes) {
+            upload_logs('/var/log/zypper.log');
+            die "'zypper -n $command' failed with code $ret_code";
+        }
+
         return $ret_code;
     }
     die "zypper did not return an exitcode";


### PR DESCRIPTION
This is usefull for debugging zypper failures

A openqa  test is failing and i wanted the zypper logs for debug, as the repo works when i add it on my laptop.

The test: https://openqa.suse.de/tests/1305879#step/piglit/19

Verification run: http://tragicbox.suse.cz/tests/333#downloads
