### PR TITLE
Check migration target is correct

### DIFF
--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -42,7 +42,25 @@ sub run {
             send_key $cmd{ok};
         }
         else {
-            assert_screen 'migration_target_' . lc(get_var('SLE_PRODUCT', 'sles')), 120;
+            send_key 'alt-p';
+            # Confirm default migration target matches correct base product
+            my $migration_target_base = 'migration_target_' . lc(get_var('SLE_PRODUCT', 'sles')) . lc(get_var('VERSION'));
+            assert_screen $migration_target_base, 120;
+            # Confirm other migration targets match the same base product
+            # Assume no more than 6 possible migration targets
+            for (1 .. 5) {
+                send_key 'down';
+                unless (check_screen $migration_target_base) {
+                    record_info 'Likely error detected', 'Incorrect migration target? See https://fate.suse.com/323165', result => 'fail';
+                    last;
+                }
+            }
+            # Back to default migration target
+            wait_screen_change {
+                send_key 'home';
+            };
+            save_screenshot;
+
             send_key $cmd{next};
         }
     }


### PR DESCRIPTION
- add version tag in migration target needle
- check all migration targets use the same base product
- see poo#29232 for details

- Related ticket: https://progress.opensuse.org/issues/29232
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/606
- Verification run: http://10.67.18.143/tests/13#step/upgrade_select/5 (The failure is expected, see bsc#1071185)