### PR TITLE
Fix missing space for stack_controller

### DIFF
--- a/tests/caasp/stack_configure.pm
+++ b/tests/caasp/stack_configure.pm
@@ -42,7 +42,7 @@ sub velum_config {
 sub upload_autoyast {
     send_key 'alt-tab';    # switch to xterm
     assert_screen 'xterm';
-    assert_script_run 'curl --location ' . get_var('DASHBOARD_URL') . '/autoyast' . '--output autoyast.xml';
+    assert_script_run 'curl --location ' . get_var('DASHBOARD_URL') . '/autoyast' . ' --output autoyast.xml';
     upload_logs('autoyast.xml');
     send_key 'alt-tab';    # switch to xterm
 }


### PR DESCRIPTION
There's no space between `--output` and `/autoyast`
thus the test fails to execute.
