### PR TITLE
xvda disk now has 'e' accelerator instead of 'd'

### DIFF
--- a/tests/installation/partitioning_togglehome.pm
+++ b/tests/installation/partitioning_togglehome.pm
@@ -24,7 +24,7 @@ sub run {
         # naturally sees it as a "disk". We have to uncheck the "CDROM".
         if (check_var('VIRSH_VMM_TYPE', 'linux')) {
             assert_screen 'select-hard-disk';
-            send_key 'alt-d';
+            send_key 'alt-e';
             send_key $cmd{next};
         }
         assert_screen 'partition-scheme';


### PR DESCRIPTION
Fails here
* https://openqa.suse.de/tests/1308446#step/partitioning_togglehome/1
* https://openqa.suse.de/tests/1311035#step/partitioning_togglehome/1