### PR TITLE
Add 'nologin' parameter for wait_boot

### DIFF
--- a/tests/x11regressions/gnomecase/change_password.pm
+++ b/tests/x11regressions/gnomecase/change_password.pm
@@ -46,6 +46,7 @@ sub reboot_system {
     my ($self) = @_;
     reboot_x11;
     $self->{await_reboot} = 1;
+    $self->wait_boot(nologin => 1);
     assert_screen "displaymanager", 200;
     $self->{await_reboot} = 0;
     send_key "ret";


### PR DESCRIPTION
This allows boot to graphical DM without login to it.
Usable for tests like gnomecase/change_password

Fixes poo#29066

- Related ticket: https://progress.opensuse.org/issues/29066
- Verification run: http://quasar.suse.cz/tests/30#step/change_password/32
