### PR TITLE
Check for (non-)presence of vim-data & JeOS needle

### DIFF
--- a/tests/console/vim.pm
+++ b/tests/console/vim.pm
@@ -14,11 +14,15 @@
 use base "consoletest";
 use strict;
 use testapi;
+use version_utils 'is_jeos';
 
 sub run {
     assert_script_run 'rpm -qi vim';
+    # vim-data package must not be present on JeOS
+    assert_script_run((is_jeos() ? '! ' : '') . 'rpm -qi vim-data');
     type_string "vim /etc/passwd\n";
-    assert_screen 'vim-showing-passwd';
+    my $jeos = is_jeos() ? '-jeos' : '';
+    assert_screen "vim-showing-passwd$jeos";
     wait_screen_change { type_string ":q!\n" };
 }
 


### PR DESCRIPTION
Per PRD on JeOS we must not have vim-data present (quote: Standard Linux/Unix
editor "vim", but without additional scripts → no "vim-data").

Also using different needle match for JeOS. On SLES we expect vim-data
and soft-fail otherwise, on JeOS we must not have vim-data.

Soft-fails here: https://openqa.suse.de/tests/1313341#step/vim/3
Validation run: http://assam.suse.cz/tests/18
Needle: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/609
