### PR TITLE
Unselect cdrom on Xen in partitioning_filesystem

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -16,7 +16,7 @@ use strict;
 use testapi;
 use version_utils 'is_storage_ng';
 
-our @EXPORT = qw(wipe_existing_partitions addpart addlv);
+our @EXPORT = qw(wipe_existing_partitions addpart addlv unselect_xen_pv_cdrom);
 
 my %role = qw(
   OS alt-o
@@ -160,6 +160,16 @@ sub addlv {
     send_key $cmd{next};
     assert_screen 'partition-format';
     send_key $cmd{finish};
+}
+
+# On Xen PV "CDROM" is of the same type as a disk block device so YaST
+# naturally sees it as a "disk". We have to uncheck the "CDROM".
+sub unselect_xen_pv_cdrom {
+    if (check_var('VIRSH_VMM_TYPE', 'linux')) {
+        assert_screen 'select-hard-disk';
+        send_key 'alt-e';
+        send_key $cmd{next};
+    }
 }
 
 1;

--- a/tests/installation/partitioning_filesystem.pm
+++ b/tests/installation/partitioning_filesystem.pm
@@ -15,6 +15,7 @@ use strict;
 use base "y2logsstep";
 use testapi;
 use version_utils 'is_storage_ng';
+use partition_setup 'unselect_xen_pv_cdrom';
 
 sub run {
 
@@ -35,13 +36,7 @@ sub run {
         }
     }
     if (is_storage_ng) {
-        # On Xen PV "CDROM" is of the same type as a disk block device so YaST
-        # naturally sees it as a "disk". We have to uncheck the "CDROM".
-        if (check_var('VIRSH_VMM_TYPE', 'linux')) {
-            assert_screen 'select-hard-disk';
-            send_key 'alt-d';
-            send_key $cmd{next};
-        }
+        unselect_xen_pv_cdrom;
         assert_screen 'partition-scheme';
         send_key $cmd{next};
     }

--- a/tests/installation/partitioning_togglehome.pm
+++ b/tests/installation/partitioning_togglehome.pm
@@ -16,17 +16,12 @@ use base "y2logsstep";
 use testapi;
 use installation_user_settings;
 use version_utils 'is_storage_ng';
+use partition_setup 'unselect_xen_pv_cdrom';
 
 sub run {
     wait_screen_change { send_key(is_storage_ng() ? 'alt-g' : 'alt-d') };    # open proposal settings
     if (is_storage_ng) {
-        # On Xen PV "CDROM" is of the same type as a disk block device so YaST
-        # naturally sees it as a "disk". We have to uncheck the "CDROM".
-        if (check_var('VIRSH_VMM_TYPE', 'linux')) {
-            assert_screen 'select-hard-disk';
-            send_key 'alt-e';
-            send_key $cmd{next};
-        }
+        unselect_xen_pv_cdrom;
         assert_screen 'partition-scheme';
         send_key $cmd{next};
         installation_user_settings::await_password_check if get_var('ENCRYPT');


### PR DESCRIPTION
Follow-up to 70c742a1b6df625d1a1f89ee994377eba9c1296d but a more generic
one.

Fails here: https://openqa.suse.de/tests/1314774
Validation runs:
* `partitioning_filesystem`: http://assam.suse.cz/tests/21
* `partitioning_togglehome`: http://assam.suse.cz/tests/22