### PR TITLE
Fix size hot key for RAID tests

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -75,6 +75,7 @@ sub init_cmd {
       guidedsetup alt-g
       rescandevices alt-e
       exp_part_finish alt-f
+      size_hotkey ctrl-a
     );
 
     if (check_var('INSTLANG', "de_DE")) {

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -29,6 +29,7 @@ sub run {
         $cmd{addraid}         = 'alt-i';
         $cmd{filesystem}      = 'alt-a';
         $cmd{exp_part_finish} = 'alt-n';
+        $cmd{size_hotkey}     = 'alt-s';
         if (check_var('DISTRI', 'opensuse')) {
             $cmd{expertpartitioner} = 'alt-x';
             $cmd{rescandevices}     = 'alt-c';


### PR DESCRIPTION
After code refactoring I've missed adding $cmd{size_hotkey} so test
started to fail as we do not press anything.