### PR TITLE
[NFV] Increase timeout of MoonGen installation

### DIFF
--- a/tests/nfv/moongen_installation.pm
+++ b/tests/nfv/moongen_installation.pm
@@ -33,7 +33,7 @@ sub run {
 
     # Install MoonGen and dependencies
     assert_script_run("cd MoonGen");
-    assert_script_run("bash -x build.sh",           300);
+    assert_script_run("bash -x build.sh",           500);
     assert_script_run("bash -x setup-hugetlbfs.sh", 300);
     assert_script_run("bash -x bind-interfaces.sh", 300);
 }


### PR DESCRIPTION
With the new SLE15 builds, 300 seconds is not enough to build MoonGen packages. This increases it to 500.
- Verification run: http://10.161.8.29/tests/145
