### PR TITLE
Only run hwsim-wifi tests where supported

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -533,9 +533,11 @@ sub load_extra_tests {
         # well
         if (check_var('DESKTOP', 'gnome')) {
             loadtest 'x11/yast2_lan_restart';
-            loadtest 'x11/network/hwsim_wpa2_enterprise_setup';
-            loadtest 'x11/network/yast2_network_setup';
-            loadtest 'x11/network/NM_wpa2_enterprise';
+            if (!is_sle || sle_version_at_least('12-SP3')) {
+                loadtest 'x11/network/hwsim_wpa2_enterprise_setup';
+                loadtest 'x11/network/yast2_network_setup';
+                loadtest 'x11/network/NM_wpa2_enterprise';
+            }
         }
     }
     else {


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/29369