### PR TITLE
Add support for SLES4SAP Product Selection on ppc64le

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -97,6 +97,7 @@ sub run {
                 sles4sap => 'i',
                 hpc      => 'x'
             );
+            $hotkey{sles4sap} = 'u' if check_var('ARCH', 'ppc64le');
             my $product = get_required_var('SLE_PRODUCT');
             send_key 'alt-' . $hotkey{$product};
             assert_screen('select-product-' . $product);


### PR DESCRIPTION
Product selection of SLES4SAP on x86_64 is accomplished with the hotkey alt-i, but on ppc64le that key combination is invalid and instead alt-u is required.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/145 (on x86_64)
