### PR TITLE
Reset mouse pointer on non-QEMU backends

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -377,6 +377,9 @@ sub ensure_unlocked_desktop {
                 # responsiveness.
                 # open run command prompt (if screen isn't locked)
                 mouse_hide(1);
+                # implementation in backend/driver.pm is QEMU-specific,
+                # so we have to reset pointer on non-QEMU backends.
+                mouse_hide unless check_var('BACKEND', 'qemu');
                 send_key 'alt-f2';
                 if (check_screen 'desktop-runner') {
                     send_key 'esc';


### PR DESCRIPTION
`mouse_hide` is implemented in a QEMU-specific way, so after
`mouse_hide(1)` we have to set the pointed to hidden place.

Fails here: https://openqa.suse.de/tests/1317182#step/consoletest_finish/18
Validation run: http://assam.suse.cz/tests/28