### PR TITLE
Fix firefox_headers test by waiting for the right thing

### DIFF
--- a/tests/x11regressions/firefox/firefox_headers.pm
+++ b/tests/x11regressions/firefox/firefox_headers.pm
@@ -26,8 +26,10 @@ sub run {
     assert_screen('firefox-launch', 90);
 
     send_key "esc";
-    wait_screen_change { send_key "ctrl-shift-q" };
-    wait_screen_change { send_key "alt-d" };
+    send_key "ctrl-shift-q";
+    assert_screen 'firefox-headers-inspector';
+    send_key "ctrl-l";
+    wait_still_screen 3;
     type_string "www.gnu.org\n";
     $self->firefox_check_popups;
     assert_screen('firefox-headers-website', 90);


### PR DESCRIPTION
The test was a bit too eager, one more assert_screen and we're good

- Related ticket: https://progress.opensuse.org/issues/28288
- Needles already pushed
- Verification run: https://tortuga.suse.de/tests/52#step/firefox_headers/15
