### PR TITLE
[NFV] Install git-core instead of the entire git package

### DIFF
--- a/tests/nfv/moongen_installation.pm
+++ b/tests/nfv/moongen_installation.pm
@@ -26,7 +26,7 @@ sub run {
 
     select_console 'root-console';
 
-    zypper_call('in git gcc gcc-c++ make cmake libnuma-devel kernel-source pciutils', timeout => 300);
+    zypper_call('in git-core gcc gcc-c++ make cmake libnuma-devel kernel-source pciutils', timeout => 300);
 
     # Clone repository
     assert_script_run("git clone $moongen_repo");

--- a/tests/nfv/vsperf_installation.pm
+++ b/tests/nfv/vsperf_installation.pm
@@ -27,7 +27,7 @@ sub run {
 
     select_console 'root-console';
 
-    zypper_call('in git', timeout => 200);
+    zypper_call('in git-core', timeout => 200);
 
     # Clone repository
     assert_script_run "git clone $vsperf_repo";


### PR DESCRIPTION
No need to install the entire git package since the scripts will only use basic git commands. git-core is enough and helps to save some time and disk space.

- Verification run: http://10.161.8.29/tests/148
