### PR TITLE
Add new timezone selection to Evolution

### DIFF
--- a/tests/x11regressions/evolution/evolution_timezone_setup.pm
+++ b/tests/x11regressions/evolution/evolution_timezone_setup.pm
@@ -38,8 +38,14 @@ sub run {
     send_key "alt-s";
     wait_still_screen 3;
     send_key "ret";
-    send_key_until_needlematch("timezone-asia-shanghai", "up")
-      || send_key_until_needlematch("timezone-asia-shanghai", "down");
+    if (check_screen "timezone-asia") {
+        send_key "right";
+        send_key_until_needlematch("timezone-shanghai", "up");
+    }
+    else {
+        send_key_until_needlematch("timezone-asia-shanghai", "up")
+          || send_key_until_needlematch("timezone-asia-shanghai", "down");
+    }
     send_key "ret";
     assert_screen "asia-shanghai-timezone-setup";
     send_key "alt-o";


### PR DESCRIPTION
Fix poo#29363: Evolution changed timezone selection dialog in SLE12-SP3.

- Related ticket: https://progress.opensuse.org/issues/29363
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/613
- Verification run: 
SP3 new behavior: http://10.100.12.105/tests/737#step/evolution_timezone_setup/61
SP2 old behavior: http://10.100.12.105/tests/738#step/evolution_timezone_setup/79