### PR TITLE
Rewrote MySQL ODBC test to use mariadb

### DIFF
--- a/tests/console/mysql_odbc.pm
+++ b/tests/console/mysql_odbc.pm
@@ -40,12 +40,8 @@ sub setup {
     assert_script_run "echo [mariadbodbc_mysql] > /etc/unixODBC/odbcinst.ini";
     assert_script_run "echo Description=ODBC for MySQL >> /etc/unixODBC/odbcinst.ini";
 
-    if (!(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15.0'))) {
-        assert_script_run 'echo Driver=$(rpm --eval "%_libdir")/libmaodbc.so >> /etc/unixODBC/odbcinst.ini';
-    }
-    else {
-        assert_script_run 'echo Driver=$(rpm --eval "%_libdir")/libmyodbc5.so >> /etc/unixODBC/odbcinst.ini';
-    }
+    my $lib = (!(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15.0'))) ? 'libmaodbc' : 'libmyodbc5';
+    assert_script_run 'echo Driver=$(rpm --eval "%_libdir")/' . $lib . '.so >> /etc/unixODBC/odbcinst.ini';
 
     assert_script_run 'echo Setup=$(rpm --eval "%_libdir")/libodbcmyS.so >> /etc/unixODBC/odbcinst.ini';
     assert_script_run "echo UsageCount=2 >> /etc/unixODBC/odbcinst.ini";
@@ -66,12 +62,8 @@ sub run {
     select_console 'root-console';
 
     # install requirements
-    if (!(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15.0'))) {
-        zypper_call 'in mysql mariadb-client sudo mariadb-connector-odbc';
-    }
-    else {
-        zypper_call 'in mysql mariadb-client sudo MyODBC-unixODBC';
-    }
+    my $odbc = (!(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15.0'))) ? 'mariadb-connector-odbc' : 'MyODBC-unixODBC';
+    zypper_call 'in mysql mariadb-client sudo ' . $odbc;
 
     # restart mysql server
     systemctl "restart mysql";


### PR DESCRIPTION
MyODBC-unixODBC got replaced by mariadb-connector-odbc (see bsc#1067878)

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1070902
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/297
