### PR TITLE
Adjust RAID test for storage ng

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -75,7 +75,7 @@ sub init_cmd {
       guidedsetup alt-g
       rescandevices alt-e
       exp_part_finish alt-f
-      size_hotkey ctrl-a
+      size_hotkey alt-s
     );
 
     if (check_var('INSTLANG', "de_DE")) {

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -29,7 +29,6 @@ sub run {
         $cmd{addraid}         = 'alt-i';
         $cmd{filesystem}      = 'alt-a';
         $cmd{exp_part_finish} = 'alt-n';
-        $cmd{size_hotkey}     = 'alt-s';
         if (check_var('DISTRI', 'opensuse')) {
             $cmd{expertpartitioner} = 'alt-x';
             $cmd{rescandevices}     = 'alt-c';


### PR DESCRIPTION
For storage-ng for legacy boot we now need bios boot partition on every
device. boot raid partition is not required anymore in this scenario.

NOTE: Needles are created only for RAID0 atm.

- Related ticket: [poo#28573](https://progress.opensuse.org/issues/28573)
- Needles: 
  * [SLE](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/615)
  * [openSUSE](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/298)
- Verification runs: 
  * [SLE12SP4](http://g226.suse.de/tests/60)
  * [SLE15](http://g226.suse.de/tests/61)
  * [TW](http://g226.suse.de/tests/64)
  * [Leap15](http://g226.suse.de/tests/67)