### PR TITLE
kdump: Give zypper in way more time

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -18,7 +18,7 @@ our @EXPORT = qw(install_kernel_debuginfo prepare_for_kdump activate_kdump kdump
 
 sub install_kernel_debuginfo {
     assert_script_run 'zypper ref', 300;
-    zypper_call('-v in $(rpmquery kernel-default | sed "s/kernel-default/kernel-default-debuginfo/")', timeout => 1400);
+    zypper_call('-v in $(rpmquery kernel-default | sed "s/kernel-default/kernel-default-debuginfo/")', timeout => 4000);
 }
 
 sub prepare_for_kdump_sle {


### PR DESCRIPTION
For maintenance we install the >500MB from scc - and right after updates
the infrastructure is about 200KB/s, so 20 minutes is not enough time.

Related issue: https://progress.opensuse.org/issues/28720

