### PR TITLE
Add one more needle check to firefox_headers

### DIFF
--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -545,6 +545,22 @@ sub firefox_check_popups {
     }
 }
 
+sub firefox_open_url {
+    my ($self, $url) = @_;
+    my $counter = 1;
+    while (1) {
+        send_key 'alt-d';
+        send_key 'delete';
+        last if check_screen('firefox-empty-bar', 3);
+        if ($counter++ > 5) {
+            assert_screen('firefox-empty-bar', 0);
+            last;    # in case it worked
+        }
+    }
+    type_string "$url\n";
+    $self->firefox_check_popups;
+}
+
 sub exit_firefox {
     # Exit
     send_key_until_needlematch([qw(firefox-save-and-quit xterm-left-open xterm-without-focus)], "alt-f4", 3, 30);

--- a/tests/x11regressions/firefox/firefox_headers.pm
+++ b/tests/x11regressions/firefox/firefox_headers.pm
@@ -28,10 +28,7 @@ sub run {
     send_key "esc";
     send_key "ctrl-shift-q";
     assert_screen 'firefox-headers-inspector';
-    send_key "ctrl-l";
-    wait_still_screen 3;
-    type_string "www.gnu.org\n";
-    $self->firefox_check_popups;
+    $self->firefox_open_url('www.gnu.org');
     assert_screen('firefox-headers-website', 90);
 
     send_key "down";


### PR DESCRIPTION
The inspector seems to eat keys, so try in a loop to empty the firefox search bar.

- Related ticket: https://progress.opensuse.org/issues/28288
- Verification runs: 10/10: http://tortuga.suse.de/tests
