### PR TITLE
Adjust shortcut for RAID10 on storage-ng

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -109,7 +109,8 @@ sub setraidlevel {
         1  => 1,
         5  => 5,
         6  => 6,
-        10 => ((is_sle && sle_version_at_least('15')) ? 'o' : 'g'));
+        10 => 'g'
+    );
     wait_screen_change { send_key "alt-$entry{$level}"; };
 
     wait_screen_change { send_key "alt-i"; };    # move to RAID name input field


### PR DESCRIPTION
Now we have same hotkey for RAID10.

- Related ticket: https://progress.opensuse.org/issues/28899
- Needles: 
  * [SLE](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/616)
  * [openSUSE](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/299)
- Verification run: 
  * [SLE](http://g226.suse.de/tests/76)
  * [openSUSE](http://g226.suse.de/tests/87)
