### PR TITLE
Add custom delays in salt master-minion communications

### DIFF
--- a/tests/console/salt.pm
+++ b/tests/console/salt.pm
@@ -27,10 +27,11 @@ systemctl status salt-master
 sed -i -e "s/#master: salt/master: localhost/" /etc/salt/minion
 systemctl start salt-minion
 systemctl status --no-pager salt-minion
-salt-key --accept-all -y
 EOF
     assert_script_run($_) foreach (split /\n/, $cmd);
-    validate_script_output "salt '*' test.ping | grep -woh True > /dev/$serialdev", sub { m/True/ };
+    sleep(5);    # left the minion some time to send its public key poo#28723
+    assert_script_run("salt-key --accept-all -y");
+    validate_script_output "salt '*' test.ping -t 10 | grep -woh True > /dev/$serialdev", sub { m/True/ };
     assert_script_run 'systemctl stop salt-master salt-minion';
 }
 


### PR DESCRIPTION
Add custom delays in salt master-minion communications, one for the master to get stored the minion's public key and another one for the pinging process.

- Related ticket: [poo#28723](https://progress.opensuse.org/issues/28723)
- Verification run: [sle-15-Installer-DVD-x86_64-Build393.1-cryptlvm_minimal_x@64bit](http://dhcp227/tests/780)
