### PR TITLE
Select search text field content before pressing backspace

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -35,6 +35,7 @@ sub search {
     }
     else {
         send_key 'alt-s';
+        send_key 'ctrl-a';
         send_key 'backspace';
     }
     wait_screen_change { type_string $name; } if $name;


### PR DESCRIPTION
In some cases if yast module is not opened and we got to the search
field, content is not removed. With ctrl-a this won't happen as we
select text before hitting backspace.

[Verification run](http://g226.suse.de/tests/96#)
Fixes: https://openqa.suse.de/tests/1320196#step/yast2_control_center/155