### PR TITLE
Add toolchain_zypper test to openSUSE

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -965,5 +965,12 @@ if (get_var("CLONE_SYSTEM")) {
 
 load_create_hdd_tests if get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1");
 
+if (get_var("TCM") || check_var("ADDONS", "tcm")) {
+    loadtest "console/force_cron_run";
+    loadtest "toolchain/install";
+    loadtest "toolchain/gcc_fortran_compilation";
+    loadtest "toolchain/gcc_compilation";
+}
+
 1;
 # vim: set sw=4 et:

--- a/tests/toolchain/gcc_fortran_compilation.pm
+++ b/tests/toolchain/gcc_fortran_compilation.pm
@@ -15,7 +15,7 @@ use base "opensusebasetest";
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least);
 
 sub run {
     my $self = shift;
@@ -29,8 +29,10 @@ sub run {
     script_run 'tar jxf fcvs21_f95.tar.bz2';
     script_run 'cp FM923.DAT fcvs21_f95/';
     script_run 'pushd fcvs21_f95';
-    # gfortran (and gcc) fixed to version in SLE12 after the yearly gcc update with Toolchain module
-    my $fortran_version = is_sle && sle_version_at_least('15') ? "gfortran" : "gfortran-5";
+    my $fortran_version = "gfortran";
+    if ((is_sle && !sle_version_at_least('15')) or (is_leap and !leap_version_at_least('15.0'))) {
+        $fortran_version = "gfortran-5";    # gfortran (and gcc) fixed to version in SLE12 after the yearly gcc update with Toolchain module
+    }
     script_run "sed -i 's/g77/$fortran_version/g' driver_*";
     script_run 'echo "exit \${failed}" >> driver_parse';
 

--- a/tests/toolchain/install.pm
+++ b/tests/toolchain/install.pm
@@ -47,10 +47,10 @@ sub run {
         script_run 'export CC=/usr/bin/gcc-5';
         script_run 'export CXX=/usr/bin/g++-5';
     }
-    elsif (is_sle) {
+    else {
         # No need to be fixed to version (that is only for products receiving the yearly gcc update)
         # but it needs to activate development tool module
-        add_suseconnect_product("sle-module-development-tools");
+        add_suseconnect_product("sle-module-development-tools") if is_sle;
         zypper_call 'in -t pattern devel_basis';
         zypper_call 'in gcc-fortran';    # from Base System Module
         script_run 'export CC=/usr/bin/gcc';


### PR DESCRIPTION
Add toolchain_zypper test to test gcc, fortran, etc. also in openSUSE for TW and Leap 15.0.

- Related ticket: [poo#29366](https://progress.opensuse.org/issues/29366)
- Verification run:  [TW](http://dhcp227/tests/798) & [Leap 15.0](http://dhcp227/tests/800) (looks like an inconsistency in packages comparing with SLE15)
