### PR TITLE
No separated home partition on s390x for SLE version < 15

### DIFF
--- a/tests/installation/partitioning_togglehome.pm
+++ b/tests/installation/partitioning_togglehome.pm
@@ -26,15 +26,13 @@ sub run {
         send_key $cmd{next};
         installation_user_settings::await_password_check if get_var('ENCRYPT');
     }
-    if (!check_screen 'disabledhome', 0) {
-        # detect whether new (Radio Buttons) YaST behaviour
-        my $new_radio_buttons = check_screen('inst-partition-radio-buttons', 0);
-        send_key $new_radio_buttons ? 'alt-r' : 'alt-p';
-    }
-    if (check_var('ARCH', 's390x') and !check_screen('disabledhome', 0)) {
-        record_soft_failure('bsc#1072869');
-    }
-    else {
+    # For s390x there was no offering of separated home partition until SLE 15 See bsc#1072869
+    if (!check_var('ARCH', 's390x') or is_storage_ng()) {
+        if (!check_screen 'disabledhome', 0) {
+            # detect whether new (Radio Buttons) YaST behaviour
+            my $new_radio_buttons = check_screen('inst-partition-radio-buttons', 0);
+            send_key $new_radio_buttons ? 'alt-r' : 'alt-p';
+        }
         assert_screen 'disabledhome';
     }
     send_key(is_storage_ng() ? 'alt-n' : 'alt-o');    # finish editing settings


### PR DESCRIPTION
## Related ticket
- https://progress.opensuse.org/issues/29405

## Verification run

#### SLE 12-SP4
- s390x [coplant#10#step/partitioning_togglehome/1](http://copland.arch.suse.de/tests/10#step/partitioning_togglehome/1)
- x86_64 [copland#9#step/partitioning_togglehome/2](http://copland.arch.suse.de/tests/9#step/partitioning_togglehome/2)

#### SLE 15
- s390x [copland#12#step/partitioning_togglehome/4](http://copland.arch.suse.de/tests/12#step/partitioning_togglehome/4)
- x86_64 [copland#11#step/partitioning_togglehome/4](http://copland.arch.suse.de/tests/11#step/partitioning_togglehome/4)