### PR TITLE
Disable online repos and add o3 mirror for openSUSE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -68,6 +68,7 @@ our @EXPORT = qw(
   load_syscontainer_tests
   load_toolchain_tests
   load_common_opensuse_sle_tests
+  replace_opensuse_repos_tests
 );
 
 sub init_main {
@@ -157,6 +158,11 @@ sub is_bridged_networking {
     return $ret;
 }
 
+sub replace_opensuse_repos_tests {
+    loadtest "update/zypper_clear_repos";
+    loadtest "console/zypper_ar";
+}
+
 sub load_rescuecd_tests {
     if (rescuecdstep_is_applicable()) {
         loadtest "rescuecd/rescuecd";
@@ -165,6 +171,10 @@ sub load_rescuecd_tests {
 
 sub load_autoyast_clone_tests {
     loadtest "console/consoletest_setup";
+    # Remove repos pointing to download.opensuse.org and add snaphot repo from o3
+    if (check_var('DISTRI', 'opensuse')) {
+        replace_opensuse_repos_tests;
+    }
     loadtest "console/yast2_clone_system";
     loadtest "console/consoletest_finish";
 }
@@ -543,12 +553,17 @@ sub load_extra_tests {
         }
     }
     else {
+        # Run zypper info before as tests source repo
+        loadtest "console/zypper_info";
+        # Remove repos pointing to download.opensuse.org and add snaphot repo from o3
+        if (check_var('DISTRI', 'opensuse')) {
+            replace_opensuse_repos_tests;
+        }
         loadtest "console/zypper_lr_validate";
         loadtest "console/openvswitch";
         # dependency of git test
         loadtest "console/sshd";
         loadtest "console/zypper_ref";
-        loadtest "console/zypper_info";
         loadtest "console/update_alternatives";
         # start extra console tests from here
         # Audio device is not supported on ppc64le, s390x, JeOS, and Xen PV
@@ -570,7 +585,6 @@ sub load_extra_tests {
             loadtest "console/pcre";
             loadtest "console/openqa_review";
             loadtest "console/zbar";
-            loadtest "console/zypper_ar";
             loadtest "console/a2ps";    # a2ps is not a ring package and thus not available in staging
             loadtest "console/weechat";
             loadtest "console/nano";

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -273,6 +273,7 @@ sub load_inst_tests {
         loadtest "installation/logpackages";
     }
     if (noupdatestep_is_applicable()) {
+        loadtest "installation/disable_online_repos" if get_var('DISABLE_ONLINE_REPOS');
         loadtest "installation/installer_desktopselection";
         if (get_var('IMPORT_USER_DATA')) {
             loadtest 'installation/user_import';
@@ -379,6 +380,7 @@ sub load_consoletests {
     }
     loadtest "console/textinfo";
     loadtest "console/hostname";
+    replace_opensuse_repos_tests if get_var('DISABLE_ONLINE_REPOS');
     if (snapper_is_applicable()) {
         if (get_var("UPGRADE")) {
             loadtest "console/upgrade_snapshots";
@@ -392,7 +394,8 @@ sub load_consoletests {
     }
     loadtest "console/zypper_lr";
     loadtest 'console/enable_usb_repo' if check_var('USBBOOT', 1);
-    if (have_addn_repos) {
+    # If DISABLE_ONLINE_REPOS, mirror repo is already added
+    if (have_addn_repos && !get_var('DISABLE_ONLINE_REPOS')) {
         loadtest "console/zypper_ar";
     }
     loadtest "console/zypper_ref";

--- a/tests/installation/disable_online_repos.pm
+++ b/tests/installation/disable_online_repos.pm
@@ -1,0 +1,48 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Disable online repos during installation
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
+
+use strict;
+use base "y2logsstep";
+use testapi;
+use version_utils 'is_leap';
+
+sub run {
+    assert_screen 'desktop-selection';
+    send_key 'alt-o';    # press configure online repos button
+    assert_screen 'online-repos-configuration';
+    send_key is_leap() ? 'alt-l' : 'alt-i';    # navigate to the List
+
+    # Disable repos
+    if (is_leap) {
+        # We have update non-oss repo on leap
+        send_key_until_needlematch 'main-update-nos-oss-repo-disabled', 'spc', 3, 1;
+        send_key 'down';
+    }
+    send_key_until_needlematch 'main-update-repo-disabled', 'spc', 3, 1;
+    send_key 'down';
+    send_key_until_needlematch 'main-repo-oss-disabled', 'spc', 3, 1;
+    send_key 'down';
+    send_key_until_needlematch 'main-repo-non-oss-disabled', 'spc', 3, 1;
+    assert_screen 'online-repos-disabled';
+    send_key $cmd{next};
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
For openSUSE it's hard to replace repos which we use. In most of the
scenarios it works fine as we don't install packages which are not
available on DVD or mirror in case of net install. Whereas it causes
issues in some scenarios when we install additional software in the
tests.
There are 2 parts for the solution, one is to modify repositories in the
installer, which is possible only by tweaking control.xml before we
trigger installation, or by at least disabling online repos which point
to download.opensuse.org. It's easier to handle scenario with installed
system and we already have test modules which do this task. As of now we
enable this behavior with feature variable and for test suites which
fail due to this particular issue. After we see that it works fine, we
can apply it as default behavior and exclude some scenarios if needed.
Behavior can be enabled with DISABLE_ONLINE_REPOS variable.

- Related ticket: [poo#17436](https://progress.opensuse.org/issues/17436).
- Needles: [PR#300](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/300).
- Verification runs:
   * [TW textmode](http://g226.suse.de/tests/166)
   * [TW btrfs x11](http://g226.suse.de/tests/118)
   * [TW extra tests on gnome](http://g226.suse.de/tests/115)
   * [leap 15 create hdd gnome x11](http://g226.suse.de/tests/124)
   * [leap 15 text mode x11](http://g226.suse.de/tests/125) missing MyODBC-unixODBC package (should get resolved for leap 15)
