### PR TITLE
Add support for SLE_PRODUCT specific regcodes

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -460,6 +460,11 @@ sub get_addon_fullname {
 
 
 sub fill_in_reg_server {
+    # Set product specific SCC_REGCODE if it was provided. Defaults to SCC_REGCODE if set
+    my $scc_code = get_required_var('SCC_REGCODE') if get_var('SCC_REGCODE');
+    $scc_code = get_required_var('SCC_REGCODE_' . uc(get_var('SLE_PRODUCT')))
+      if (get_var('SLE_PRODUCT') and get_var('SCC_REGCODE_' . uc(get_var('SLE_PRODUCT'))));
+
     if (!get_var("SMT_URL")) {
         if (sle_version_at_least('15') && check_var('DESKTOP', 'textmode')) {
             send_key "alt-m";    # select email field if yast2 add-on
@@ -471,7 +476,7 @@ sub fill_in_reg_server {
         type_string get_required_var('SCC_EMAIL') if get_var('SCC_EMAIL');
         save_screenshot;
         send_key "alt-c";
-        type_string get_required_var('SCC_REGCODE') if get_var('SCC_REGCODE');
+        type_string $scc_code if ($scc_code);
     }
     else {
         send_key "alt-i";

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -461,8 +461,8 @@ sub get_addon_fullname {
 
 sub fill_in_reg_server {
     # Set product specific SCC_REGCODE if it was provided. Defaults to SCC_REGCODE if set
-    my $scc_code = get_required_var('SCC_REGCODE') if get_var('SCC_REGCODE');
-    $scc_code = get_required_var('SCC_REGCODE_' . uc(get_var('SLE_PRODUCT')))
+    my $scc_code = get_var('SCC_REGCODE', '') if get_var('SCC_REGCODE');
+    $scc_code = get_var('SCC_REGCODE_' . uc(get_var('SLE_PRODUCT')), '')
       if (get_var('SLE_PRODUCT') and get_var('SCC_REGCODE_' . uc(get_var('SLE_PRODUCT'))));
 
     if (!get_var("SMT_URL")) {
@@ -473,7 +473,7 @@ sub fill_in_reg_server {
             send_key "alt-e";    # select email field if installation
         }
         send_key "backspace";    # delete m or e
-        type_string get_required_var('SCC_EMAIL') if get_var('SCC_EMAIL');
+        type_string get_var('SCC_EMAIL') if get_var('SCC_EMAIL');
         save_screenshot;
         send_key "alt-c";
         type_string $scc_code if ($scc_code);

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -461,9 +461,11 @@ sub get_addon_fullname {
 
 sub fill_in_reg_server {
     # Set product specific SCC_REGCODE if it was provided. Defaults to SCC_REGCODE if set
-    my $scc_code = get_var('SCC_REGCODE', '') if get_var('SCC_REGCODE');
-    $scc_code = get_var('SCC_REGCODE_' . uc(get_var('SLE_PRODUCT')), '')
-      if (get_var('SLE_PRODUCT') and get_var('SCC_REGCODE_' . uc(get_var('SLE_PRODUCT'))));
+    my $regcode = get_var('SCC_REGCODE', '');
+    if (get_var('SLE_PRODUCT')) {
+        my $prdcode = get_var('SCC_REGCODE_' . uc(get_var('SLE_PRODUCT')), '');
+        $regcode = $prdcode if ($prdcode);
+    }
 
     if (!get_var("SMT_URL")) {
         if (sle_version_at_least('15') && check_var('DESKTOP', 'textmode')) {
@@ -476,7 +478,7 @@ sub fill_in_reg_server {
         type_string get_var('SCC_EMAIL') if get_var('SCC_EMAIL');
         save_screenshot;
         send_key "alt-c";
-        type_string $scc_code if ($scc_code);
+        type_string $regcode if ($regcode);
     }
     else {
         send_key "alt-i";


### PR DESCRIPTION
Adds support for product specific registration codes using the SLE_PRODUCT variable.

The content of SCC_REGCODE will be treated as the default registration code, which in turn can be overwritten by the variable SCC_REGCODE_ . getvar('SLE_PRODUCT').

This helps to streamline test suites, helping to avoid the need to create product/architecture specific tests.

- Related ticket: https://progress.opensuse.org/issues/25542
- Needles: N/A
- Verification run: http://mango.suse.de/tests/147 & http://mango.suse.de/tests/148