### PR TITLE
Simplify common autoyast/create_hdd/toolchain tests for openSUSE/SLE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -66,6 +66,8 @@ our @EXPORT = qw(
   is_memtest
   is_mediacheck
   load_syscontainer_tests
+  load_toolchain_tests
+  load_common_opensuse_sle_tests
 );
 
 sub init_main {
@@ -863,6 +865,20 @@ sub load_syscontainer_tests() {
 
     # Run the actual test
     loadtest 'virtualization/syscontainer_image_test';
+}
+
+sub load_toolchain_tests {
+    loadtest "console/force_cron_run";
+    loadtest "toolchain/install";
+    loadtest "toolchain/gcc_fortran_compilation";
+    loadtest "toolchain/gcc_compilation";
+    loadtest "console/kdump_and_crash" if is_sle && kdump_is_applicable;
+}
+
+sub load_common_opensuse_sle_tests {
+    load_autoyast_clone_tests if get_var("CLONE_SYSTEM");
+    load_create_hdd_tests     if get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1");
+    load_toolchain_tests      if get_var("TCM") || check_var("ADDONS", "tcm");
 }
 
 1;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -959,18 +959,7 @@ else {
     }
 }
 
-if (get_var("CLONE_SYSTEM")) {
-    load_autoyast_clone_tests;
-}
-
-load_create_hdd_tests if get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1");
-
-if (get_var("TCM") || check_var("ADDONS", "tcm")) {
-    loadtest "console/force_cron_run";
-    loadtest "toolchain/install";
-    loadtest "toolchain/gcc_fortran_compilation";
-    loadtest "toolchain/gcc_compilation";
-}
+load_common_opensuse_sle_tests;
 
 1;
 # vim: set sw=4 et:

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1589,19 +1589,7 @@ else {
     }
 }
 
-if (get_var("CLONE_SYSTEM")) {
-    load_autoyast_clone_tests;
-}
-
-load_create_hdd_tests if get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1");
-
-if (get_var("TCM") || check_var("ADDONS", "tcm")) {
-    loadtest "console/force_cron_run";
-    loadtest "toolchain/install";
-    loadtest "toolchain/gcc_fortran_compilation";
-    loadtest "toolchain/gcc_compilation";
-    loadtest "console/kdump_and_crash" if kdump_is_applicable;
-}
+load_common_opensuse_sle_tests;
 
 1;
 # vim: set sw=4 et:


### PR DESCRIPTION
Verification log output from local run of openSUSE toolchain tests:

```
scheduling boot_to_desktop tests/boot/boot_to_desktop.pm
scheduling force_cron_run tests/console/force_cron_run.pm
scheduling install tests/toolchain/install.pm
scheduling gcc_fortran_compilation tests/toolchain/gcc_fortran_compilation.pm
scheduling gcc_compilation tests/toolchain/gcc_compilation.pm
```