### PR TITLE
Add test module for deregistration from SCC

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -820,6 +820,7 @@ sub load_create_hdd_tests {
     loadtest 'console/sle15_workarounds' if is_sle && sle_version_at_least('15');
     loadtest 'console/hostname' unless is_bridged_networking;
     loadtest 'console/force_cron_run' unless is_jeos;
+    loadtest 'console/scc_deregistration' if get_var('SCC_DEREGISTER');
     loadtest 'shutdown/grub_set_bootargs';
     loadtest 'shutdown/shutdown';
     loadtest 'shutdown/svirt_upload_assets' if check_var('BACKEND', 'svirt');

--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -29,7 +29,6 @@ use version_utils 'sle_version_at_least';
 our @EXPORT = qw(
   setup_migration
   register_system_in_textmode
-  de_register
   remove_ltss
   disable_installation_repos
 );
@@ -67,24 +66,6 @@ sub register_system_in_textmode {
         set_var('HDD_SP2ORLATER', 1);
     }
     yast_scc_registration;
-}
-
-sub de_register {
-    my (%args) = @_;
-    $args{version_variable} //= 'VERSION';
-    if (sle_version_at_least('12-SP1', version_variable => $args{version_variable})) {
-        assert_script_run('SUSEConnect -d --cleanup');
-        my $output = script_output 'SUSEConnect -s';
-        die "System is still registered" unless $output =~ /Not Registered/;
-        save_screenshot;
-    }
-    else {
-        assert_script_run("zypper removeservice `zypper services --show-enabled-only --sort-by-name | awk {'print\$5'} | sed -n '1,2!p'`");
-        assert_script_run('rm /etc/zypp/credentials.d/* /etc/SUSEConnect');
-        my $output = script_output 'SUSEConnect -s';
-        die "System is still registered" unless $output =~ /Not Registered/;
-        save_screenshot;
-    }
 }
 
 # Remove LTSS product and manually remove its relevant package before migration

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -31,6 +31,7 @@ our @EXPORT = qw(
   registration_bootloader_params
   yast_scc_registration
   skip_registration
+  scc_deregistration
   get_addon_fullname
   %SLE15_MODULES
   %SLE15_DEFAULT_MODULES
@@ -484,6 +485,25 @@ sub fill_in_reg_server {
     }
     save_screenshot;
     wait_screen_change { send_key $cmd{next} };
+}
+
+# De-register the system from the SUSE Customer Center
+sub scc_deregistration {
+    my (%args) = @_;
+    $args{version_variable} //= 'VERSION';
+    if (sle_version_at_least('12-SP1', version_variable => $args{version_variable})) {
+        assert_script_run('SUSEConnect -d --cleanup');
+        my $output = script_output 'SUSEConnect -s';
+        die "System is still registered" unless $output =~ /Not Registered/;
+        save_screenshot;
+    }
+    else {
+        assert_script_run("zypper removeservice `zypper services --show-enabled-only --sort-by-name | awk {'print\$5'} | sed -n '1,2!p'`");
+        assert_script_run('rm /etc/zypp/credentials.d/* /etc/SUSEConnect');
+        my $output = script_output 'SUSEConnect -s';
+        die "System is still registered" unless $output =~ /Not Registered/;
+        save_screenshot;
+    }
 }
 
 1;

--- a/tests/console/scc_deregistration.pm
+++ b/tests/console/scc_deregistration.pm
@@ -1,0 +1,32 @@
+# Copyright (C) 2017 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Deregister from the SUSE Customer Center
+# Maintainer: Qingming Su <qmsu@suse.com>
+
+use strict;
+use base "consoletest";
+use testapi;
+use registration "scc_deregistration";
+
+sub run {
+    return unless (get_var('SCC_REGISTER') || get_var('HDD_SCC_REGISTERED'));
+
+    select_console 'root-console';
+    scc_deregistration;
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/online_migration/sle12_online_migration/register_without_ltss.pm
+++ b/tests/online_migration/sle12_online_migration/register_without_ltss.pm
@@ -13,12 +13,13 @@
 use base "console_yasttest";
 use strict;
 use testapi;
+use registration;
 use migration;
 
 sub run {
     select_console 'root-console';
 
-    de_register(version_variable => 'HDDVERSION');
+    scc_deregistration(version_variable => 'HDDVERSION');
     remove_ltss;
 
     # Re-register system without LTSS with resetting SCC_ADDONS variable without ltss

--- a/tests/update/patch_before_migration.pm
+++ b/tests/update/patch_before_migration.pm
@@ -60,7 +60,7 @@ sub patching_sle {
 
     }
     else {
-        de_register(version_variable => 'HDDVERSION');
+        scc_deregistration(version_variable => 'HDDVERSION');
     }
     remove_ltss;
     assert_script_run("zypper mr --enable --all");


### PR DESCRIPTION
- see poo#29526 for details

De-register system from the SUSE Customer Center:
  The "updated" hdd image could save much time at "patch_before_migration" step during migration tests, but the existing scc credentials may cause issue, so we need de-register from scc after installation, and do registration again during migration.

- Related ticket: https://progress.opensuse.org/issues/29526
- Needles: None
- Verification run: http://10.67.18.143/tests/31
