### PR TITLE
Fix yast2_nis.pm

### DIFF
--- a/tests/console/yast2_nis.pm
+++ b/tests/console/yast2_nis.pm
@@ -14,28 +14,29 @@ use strict;
 use base "console_yasttest";
 use testapi;
 
-sub run {
+sub run() {
 
     select_console 'root-console';
     script_run "zypper -n in yast2-nis-client";    # make sure yast client module installed
     type_string "yast2 nis\n";
-    wait_still_screen(3);
-    assert_screen([qw(nis-client yast2_still_susefirewall2)], 90);
-    if (match_has_tag 'yast2_still_susefirewall2') {
-        record_soft_failure "bsc#1059569";
+    assert_screen([qw(nis-client yast2_package_install)], 60);
+    if (match_has_tag 'yast2_package_install') {
         send_key 'alt-i';
-        assert_screen 'nis-client';
     }
-
-    wait_screen_change { send_key 'alt-u' };
+    wait_still_screen;                             # install package takes a long time
+    send_key 'alt-u';
+    wait_screen_change { send_key 'alt-t' };
+    assert_screen([qw(open_port_in_firewall yast2_cannot-open-interface)]);
+    if (match_has_tag 'yast2_cannot-open-interface') {
+        record_soft_failure 'bsc#1069458';
+        send_key 'alt-y';
+    }
     send_key 'alt-m';
     assert_screen 'nis-client-automounter-enabled';    # this checks if nis and automounter got really enabled
     send_key 'alt-i';                                  # enter Nis domain for enter string suse.de
     type_string "suse.de";
     send_key 'alt-a';
     type_string "10.162.0.1";
-    send_key 'alt-t';                                  # open port in firewall
-    assert_screen 'open_port_in_firewall';             # check the port is open
     wait_screen_change { send_key 'alt-p' };           # check Netconfif NIS Policy
     send_key 'up';
     wait_screen_change { send_key 'ret' };
@@ -49,15 +50,8 @@ sub run {
     send_key 'alt-y';
     wait_screen_change { type_string "-c" };           # only checks if the config file has syntax errors and exits
     send_key 'alt-o';
-    assert_screen 'nis-client-configuration';
-    send_key 'alt-s';                                  # enter NFS configuration...
-
-    # add nfs settings
-    assert_screen([qw(nfs-client-configuration yast2_nfs_client_needs_install)], 90);
-    if (match_has_tag 'yast2_nfs_client_needs_install') {
-        send_key 'alt-i';
-        assert_screen 'nfs-client-configuration';
-    }
+    wait_screen_change { send_key 'alt-s' };           # enter NFS configuration...
+    assert_screen 'nfs-client-configuration';          # add nfs settings
     send_key 'alt-a';
     assert_screen 'nfs-server-hostname';               # check that type string is sucessful
     send_key 'alt-n';                                  # from here enter some configurations...
@@ -71,12 +65,19 @@ sub run {
     wait_screen_change { send_key 'alt-t' };           # go back to nfs configuration and delete configuration created before
     assert_screen 'nis_server_delete';                 # confirm to delete configuration
     send_key 'alt-y';
-    wait_screen_change { send_key 'alt-o' };
+    wait_still_screen 2;
+    send_key 'alt-o';
+    wait_still_screen 2;
     send_key 'alt-f';                                  # close the dialog...
-    assert_screen 'nis_server_not_found';              # check error message for 'nis server not found'
-    send_key 'alt-o';                                  # close it now even when config is not valid
+    assert_screen([qw(nis_server_not_found ypbind_error)]);
+    if (match_has_tag 'ypbind_error') {
+        record_soft_failure 'bsc#1073281';
+        send_key 'alt-o';
+    }
+    else {
+        send_key 'alt-o';                              # close it now even when config is not valid
+    }    # check error message for 'nis server not found'
 }
 1;
 
 # vim: set sw=4 et:
-


### PR DESCRIPTION
- add workaround for cannot_open_interface for firewall port
- add workaround for ypbind issue bsc#1073281
- see poo#29000 for more details
- verification run: http://e13.suse.de/tests/120#step/yast2_nis
- needles PR:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/621

