### PR TITLE
Add autoyast eula profile for sle15

### DIFF
--- a/data/autoyast_sle15/autoyast_eula.xml
+++ b/data/autoyast_sle15/autoyast_eula.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <general>
+        <mode>
+            <confirm config:type="boolean">false</confirm>
+            <confirm_base_product_license config:type="boolean">true</confirm_base_product_license>
+        </mode>
+    </general>
+    <add-on>
+        <add_on_products config:type="list">
+             <listentry>
+                <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+                <product>sle-module-basesystem</product>
+                <product_dir>/Module-Basesystem</product_dir>
+             </listentry>
+             <listentry>
+                <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+                <product_dir>/Product-HA</product_dir>
+                <product>sle-ha</product>
+                <alias>High availability module</alias>
+                <confirm_license config:type="boolean">true</confirm_license>
+            </listentry>
+            <listentry>
+                <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+                <product_dir>/Product-WE</product_dir>
+                <product>sle-we</product>
+                <alias>Workstation Extension</alias>
+                <confirm_license config:type="boolean">true</confirm_license>
+            </listentry>
+        </add_on_products>
+    </add-on>
+    <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <users config:type="list">
+        <user>
+            <fullname>Bernhard M. Wiedemann</fullname>  
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <software>
+        <products config:type="list">
+            <product>SLES15</product>
+            <product>sle-ha</product>
+            <product>sle-we</product>
+        </products>
+    </software>
+</profile>

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -176,7 +176,7 @@ sub run {
 
     if (get_var("AUTOYAST_LICENSE")) {
         if ($confirmed_licenses == 0 || $confirmed_licenses != get_var("AUTOYAST_LICENSE", 0)) {
-            die "autoyast_license";
+            die "Autoyast License shown: $confirmed_licenses, but expected: " . get_var('AUTOYAST_LICENSE') . "times";
         }
     }
 


### PR DESCRIPTION
Also improved the error message if the license is not shown

- Related ticket: https://progress.opensuse.org/issues/23668
- Verification run: http://pinky.arch.suse.de/tests/508
