### PR TITLE
Fix poo#29562

### DIFF
--- a/tests/console/runc.pm
+++ b/tests/console/runc.pm
@@ -100,7 +100,7 @@ sub run {
     assert_script_run("! runc state test2");
 
     # Cleanup, remove all images
-    assert_script_run("docker rmi --force \$(docker images -q)");
+    assert_script_run("docker rmi --force busybox");
 }
 
 1;


### PR DESCRIPTION
Do not remove all docker images, but only the one that
gets introduced by the 'setup' phase of the test itself.

- Related ticket: https://progress.opensuse.org/issues/29562
