### PR TITLE
Add space between number and text

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -176,7 +176,7 @@ sub run {
 
     if (get_var("AUTOYAST_LICENSE")) {
         if ($confirmed_licenses == 0 || $confirmed_licenses != get_var("AUTOYAST_LICENSE", 0)) {
-            die "Autoyast License shown: $confirmed_licenses, but expected: " . get_var('AUTOYAST_LICENSE') . "times";
+            die "Autoyast License shown: $confirmed_licenses, but expected: " . get_var('AUTOYAST_LICENSE') . " time(s)";
         }
     }
 


### PR DESCRIPTION
Added a space between the number of expected Warnings and the word
'times'
Also put the 's' of times in brackets

- Related ticket: https://progress.opensuse.org/issues/23668
