### PR TITLE
Increase delay in salt tests

### DIFF
--- a/tests/console/salt.pm
+++ b/tests/console/salt.pm
@@ -29,9 +29,9 @@ systemctl start salt-minion
 systemctl status --no-pager salt-minion
 EOF
     assert_script_run($_) foreach (split /\n/, $cmd);
-    sleep(5);    # left the minion some time to send its public key poo#28723
+    sleep(30);    # left the minion some time to send its public key poo#28723
     assert_script_run("salt-key --accept-all -y");
-    validate_script_output "salt '*' test.ping -t 10 | grep -woh True > /dev/$serialdev", sub { m/True/ };
+    validate_script_output "salt '*' test.ping -t 30 | grep -woh True > /dev/$serialdev", sub { m/True/ };
     assert_script_run 'systemctl stop salt-master salt-minion';
 }
 


### PR DESCRIPTION
Increase the delay. Delay included in [previous PR](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4079) was not sufficient.
- Related ticket: https://progress.opensuse.org/issues/29583
- Verification run: not reproducible in local, only in OSD.

This solution helped in some scenarios, for example: https://openqa.suse.de/tests/1333661#
so we are in the good path, just need to increase the time because the client have several timeout parameters.