### PR TITLE
Make root_fs_size test more robust

### DIFF
--- a/tests/jeos/root_fs_size.pm
+++ b/tests/jeos/root_fs_size.pm
@@ -1,7 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -9,18 +8,15 @@
 # without any warranty.
 
 # Summary: Check root filesystem size
-# Maintainer: mkravec <mkravec@suse.com>
+# Maintainer: Michal Nowak <mnowak@suse.com>
 
-use base "opensusebasetest";
+use base 'opensusebasetest';
 use strict;
 use testapi;
 
 sub run {
-    my $expected_size = "24G";
-    if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
-        $expected_size = "30G";
-    }
-    validate_script_output "df --output=size -BG / | sed 1d | tr -d ' '", sub { /^$expected_size$/ }
+    my $expected_size = check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 30 : 24;
+    assert_script_run "df --output=size --block-size=G / | sed 1d | tr -d ' ' | grep ^${expected_size}G\$";
 }
 
 1;


### PR DESCRIPTION
The match for root FS size is not robust enough and sometimes other
output gets in it's way:
https://openqa.suse.de/tests/1334014#step/root_fs_size/4.

Validation run: http://assam.suse.cz/tests/78#step/root_fs_size/1