### PR TITLE
LTP/install: Fix installation of kernel-default-extra package

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -31,7 +31,8 @@ sub scc_we_enabled {
 
 sub add_desktop_productivity_module {
     if (get_required_var('ARCH') eq 'x86_64' and check_var('DISTRI', 'sle') and sle_version_at_least('15')) {
-        add_suseconnect_product("sle-module-desktop-productivity");
+        zypper_call('ar http://openqa.suse.de/assets/repo/' . get_required_var('REPO_SLE15_MODULE_DESKTOP_PRODUCTIVITY') . ' DPM', dumb_term => 1);
+        zypper_call('--gpg-auto-import-keys ref',                                                                                  dumb_term => 1);
     }
 }
 


### PR DESCRIPTION
Desktop Productivity should have never been available for SLES, but it
contains kernel-default-extra package needed for LTP network ipsec
tests. Thus adding it manually.

- Verification run: 
http://quasar.suse.cz/tests/51 (SLES)
http://quasar.suse.cz/tests/52 (openSUSE)
