### PR TITLE
Fix poo #28648

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -105,6 +105,13 @@ sub run {
     my $timer      = 0;    # Prevent endless loop
 
     mouse_hide(1);
+
+    # QAM CaaSP specific
+    if (is_caasp && check_var('FLAVOR', 'CaaSP-DVD-Incidents')) {
+        assert_screen('bios-boot', 1200);
+        return;
+    }
+
     check_screen \@needles, $check_time;
     until (match_has_tag('reboot-after-installation') || match_has_tag('bios-boot')) {
         #Verify timeout and continue if there was a match


### PR DESCRIPTION
Add an exception for QAM CaaSP workflow in respect to autoyast.
This is required for the stability of our scenarios. The `generic`
autoyast test is using _too many_ needle tags, thus our systems
are prone to miss the `bios-boot` tag/needle when we deploy a
*10-node* CaaSP cluster.

The reason behind this is that we are using autoyast just to bring
the workers up to the defined state. Any error that happens in
between, is not really important to capture it _on time_. In any
case, if something breaks during the autoyast installation, we will
encounter it anyway in the end of the installation.

Simply put, risking the stability of our tests in order to save
a couple of minutes it's something we would like to avoid.

As a result, this PR removes the ability of consistantly scanning
for errors during the autoyast installation, but it keeps looking
for the only needle we care specifically.

- Related ticket: https://progress.opensuse.org/issues/28648
- Needles: not needed
- Verification run: http://skyrim.qam.suse.de/tests/overview?distri=caasp&version=2.0&build=4&groupid=98
