### PR TITLE
Stop serial grab where necessary

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -452,10 +452,7 @@ sub assert_shutdown_and_restore_system {
     $shutdown_timeout //= 60;
     my $vnc_console = get_required_var('SVIRT_VNC_CONSOLE');
     console($vnc_console)->disable_vnc_stalls;
-    # Ideally, `assert_shutdown` is here instead of `sleep`, but poo#16418
-    # prevent us to be it so. Rather wait couple of seconds more than risk
-    # an 2 hour hang.
-    sleep($shutdown_timeout);
+    assert_shutdown($shutdown_timeout);
     if ($action eq 'reboot') {
         reset_consoles;
         # Set disk as a primary boot device

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -169,6 +169,11 @@ sub prepare_system_shutdown {
         }
         console('installation')->disable_vnc_stalls;
     }
+    if (check_var('BACKEND', 'svirt')) {
+        my $vnc_console = get_required_var('SVIRT_VNC_CONSOLE');
+        console($vnc_console)->disable_vnc_stalls;
+        console('svirt')->stop_serial_grab;
+    }
 }
 
 # assert_gui_app (optionally installs and) starts an application, checks it started
@@ -640,10 +645,6 @@ sub power_action {
     $args{textmode}    //= check_var('DESKTOP', 'textmode');
     die "'action' was not provided" unless $action;
     prepare_system_shutdown;
-    if (check_var('BACKEND', 'svirt')) {
-        my $vnc_console = get_required_var('SVIRT_VNC_CONSOLE');
-        console($vnc_console)->disable_vnc_stalls;
-    }
     unless ($args{keepconsole}) {
         select_console $args{textmode} ? 'root-console' : 'x11';
     }


### PR DESCRIPTION
Fixes poo#16418: "svirt: openQA won't perform another query_isotovideo
check when VM is down -> incompletes" (second part in os-autoinst).

Validation run: http://assam.suse.cz/tests/95 (restarted 20 times in
revive_xen_domain test module).

```
[2017-12-20T14:34:04.0946 CET] [debug]
/var/lib/openqa/share/tests/sle/tests/jeos/revive_xen_domain.pm:24
called utils::power_action
[2017-12-20T14:34:04.0946 CET] [debug] <<<
backend::console_proxy::__ANON__(wrapped_call={
  'console' => 'svirt',
  'function' => 'stop_serial_grab',
  'args' => []
})

[2017-12-20T14:35:13.0170 CET] [debug] <<<
backend::console_proxy::__ANON__(wrapped_call={
  'args' => [],
  'function' => 'start_serial_grab',
  'console' => 'svirt'
})
[2017-12-20T14:35:13.0477 CET] [debug] Connection to
root@openqaw5-xen.qa.suse.de established
```

Requires this PR to be deployed to OSD: https://github.com/os-autoinst/os-autoinst/pull/899