### PR TITLE
zypper_lifecycle: import is_jeos()

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -15,7 +15,7 @@ use base "consoletest";
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils qw(is_sle is_jeos sle_version_at_least);
 
 our $date_re = qr/[0-9]{4}-[0-9]{2}-[0-9]{2}/;
 


### PR DESCRIPTION
Fixes regression from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3979 at https://openqa.suse.de/tests/1340517/.