### PR TITLE
Fix function call that was interpreted as bareword

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -58,7 +58,7 @@ sub run {
     # (I have seen the test pass after 14 hours from the image creation), and actually
     # no package in the image comes from any repository - it's from the image. So we
     # hard-code 'sles-release' package, and it... works. Somehow.
-    if (!$package && is_jeos) {
+    if (!$package && is_jeos()) {
         record_soft_failure "Hardcoding 'sles-release' package for lifecycle check";
         $package = 'sles-release';
     }


### PR DESCRIPTION
error on tests/console/zypper_lifecycle.pm: Bareword "is_jeos" not allowed while "strict subs" in use at /var/lib/openqa/cache/tests/sle/tests/console/zypper_lifecycle.pm line 61.

- Related ticket: https://progress.opensuse.org/issues/29691
- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4111
- Verification run (not incomplete is enough):
  - http://copland.arch.suse.de/tests/19
  - http://copland.arch.suse.de/tests/20
