### PR TITLE
[NFV] Wait for MoonGen installation before running tests

### DIFF
--- a/tests/nfv/moongen_installation.pm
+++ b/tests/nfv/moongen_installation.pm
@@ -20,11 +20,15 @@ use base "consoletest";
 use testapi;
 use strict;
 use utils;
+use lockapi;
+use mmapi;
 
 sub run {
     my $moongen_repo = "https://github.com/emmericp/MoonGen.git";
 
     select_console 'root-console';
+
+    mutex_lock('nfv_trafficgen_ready');
 
     zypper_call('in git-core gcc gcc-c++ make cmake libnuma-devel kernel-source pciutils', timeout => 300);
 
@@ -36,6 +40,8 @@ sub run {
     assert_script_run("bash -x build.sh",           500);
     assert_script_run("bash -x setup-hugetlbfs.sh", 300);
     assert_script_run("bash -x bind-interfaces.sh", 300);
+
+    mutex_unlock('nfv_trafficgen_ready');
 }
 
 1;

--- a/tests/nfv/run_tests.pm
+++ b/tests/nfv/run_tests.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Placeholder for steps to run the tests
+#
+# Maintainer: Jose Lausuch <jalausuch@suse.com>
+
+use base "consoletest";
+use testapi;
+use strict;
+use utils;
+use lockapi;
+use mmapi;
+
+sub run {
+    select_console 'root-console';
+    mutex_create('nfv_trafficgen_ready');
+
+    # wait until traffic generator installation finishes
+    wait_for_children;
+
+    # placeholder for running tests
+    assert_script_run("ip a");
+
+}
+
+1;
+
+# vim: set sw=4 et:


### PR DESCRIPTION
Since NFV test uses 2 machines,  we need to make sure that the installation of the traffic generator is done on the second machine before triggering the tests on the first one.
Also there is a placeholder script for running the tests. This will be completed when multinet is ready.

- Verification run: 
    http://10.161.8.29/tests/29
    http://10.161.8.29/tests/30
