### PR TITLE
WIP: Fix poo #28648

### DIFF
--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -30,6 +30,9 @@ sub export_cluster_logs {
 
     upload_logs('/var/log/transactional-update.log', failok => 1);
     upload_logs('/var/log/YaST2/y2log-1.gz') if get_var 'AUTOYAST';
+    # bug: supportconfig is not collecing all the required logs
+    script_run 'docker logs $(docker ps -a | grep "velum-dashboard" | awk \'{print $1}\') > velum-dashboard.log', 60;
+    upload_logs('velum-dashboard.log', failok => 1);
 }
 
 # Weak password warning should be displayed only once - bsc#1025835

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -68,7 +68,7 @@ sub load_boot_tests {
 # One-click installer - fate#322328
 sub load_inst_tests {
     if (get_var 'AUTOYAST') {
-        loadtest 'autoyast/installation';
+        loadtest 'autoyast/installation' unless check_var('FLAVOR', 'CaaSP-DVD-Incidents');
     }
     else {
         loadtest 'caasp/oci_overview';
@@ -166,7 +166,7 @@ if (get_var('STACK_ROLE')) {
     else {
         load_boot_tests;
         load_inst_tests if is_caasp('DVD');
-        loadtest 'caasp/first_boot';
+        loadtest 'caasp/first_boot' unless check_var('FLAVOR', 'CaaSP-DVD-Incidents');
     }
     load_stack_tests;
 }

--- a/tests/caasp/stack_admin.pm
+++ b/tests/caasp/stack_admin.pm
@@ -40,6 +40,11 @@ sub handle_update {
 }
 
 sub run() {
+    if (check_var('FLAVOR', 'CaaSP-DVD-Incidents')) {
+        assert_screen('linux-login-casp', 300);
+        reset_consoles;
+        select_console 'root-console';
+    }
     # Admin node needs long time to start web interface - bsc#1031682
     # Wait in loop until velum is available until controller node can connect
     my $timeout   = 240;

--- a/tests/caasp/stack_update.pm
+++ b/tests/caasp/stack_update.pm
@@ -64,7 +64,7 @@ sub run {
     assert_and_click 'velum-update-reboot';
 
     # Update all nodes - this part takes long time (~2 minutes per node)
-    assert_screen "velum-$nodes-nodes-outdated", 300;
+    assert_screen "velum-$nodes-nodes-outdated", 1200;
     die "Admin should be updated already" if check_screen 'velum-update-admin', 0;
     assert_and_click "velum-update-all";
 

--- a/tests/caasp/stack_worker.pm
+++ b/tests/caasp/stack_worker.pm
@@ -17,6 +17,11 @@ use lockapi;
 use caasp;
 
 sub run {
+    # Make sure the installation has finished
+    if (check_var('FLAVOR', 'CaaSP-DVD-Incidents')) {
+        assert_screen('linux-login-casp', 1200);
+    }
+
     # Notify others that installation finished
     barrier_wait "WORKERS_INSTALLED";
 


### PR DESCRIPTION
Removes the ability of consistantly scanning for errors during the
autoyast installation. In case of failure, the test timeout in
worst case in 20 minutes.

- Related ticket: https://progress.opensuse.org/issues/28648
- Needles: Not needed
- Verification run: http://skyrim.qam.suse.de/tests/overview?distri=caasp&version=2.0&build=%3A6053%3Avelum.2&groupid=98
