### PR TITLE
Accept license during upgrade on s390x/aarch64

### DIFF
--- a/tests/installation/accept_license.pm
+++ b/tests/installation/accept_license.pm
@@ -26,7 +26,12 @@ sub run {
     my ($self) = @_;
 
     # workaround for bsc#1069124: Skip the license check in upgrade mode
-    return record_soft_failure('bsc#1069124: License is not shown in upgrade') if is_sle && sle_version_at_least('15') && get_var('UPGRADE');
+    # During upgrade to sle 15, license agreement is shown on aarch64 and s390x
+    # but not shown on ppc64le and x86_64 at the moment
+    if (is_sle && sle_version_at_least(15) && get_var('UPGRADE') && !check_var('ARCH', 'aarch64') && !check_var('ARCH', 's390x')) {
+        send_key $cmd{next};
+        return record_soft_failure('bsc#1069124: License is not shown in upgrade');
+    }
 
     assert_screen([qw(network-settings-button license-agreement)]);
     if (match_has_tag('network-settings-button')) {

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -108,7 +108,7 @@ sub run {
     }
 
     assert_screen 'languagepicked';
-    send_key $cmd{next};
+    send_key $cmd{next} unless (is_sle && sle_version_at_least('15') && get_var('UPGRADE'));
     if (!check_var('INSTLANG', 'en_US') && check_screen 'langincomplete', 1) {
         send_key 'alt-f';
     }


### PR DESCRIPTION
The license agreement shown at welcome screen (during upgrade) is
only observed on aarch64 and s390x, but not on ppc64le or x86_64
It is expected behavior on s390x and aarch64, according to:
https://bugzilla.suse.com/show_bug.cgi?id=1069124#c8
- see poo#29104 for details

- Related ticket: https://progress.opensuse.org/issues/29104
- Needles: N/A
- Verification run: http://openqa-apac1.suse.de/tests/293
    Note: The test failure at grub_test is an known product issue: bsc#1072113 