### PR TITLE
Migrate regression-gnome cases to SLED15

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -22,7 +22,7 @@ use strict;
 
 use testapi qw(is_serial_terminal :DEFAULT);
 use mm_network;
-use version_utils qw(is_caasp is_leap is_sle is_sle12_hdd_in_upgrade leap_version_at_least sle_version_at_least);
+use version_utils qw(is_caasp is_leap is_tumbleweed is_sle is_sle12_hdd_in_upgrade leap_version_at_least sle_version_at_least);
 
 our @EXPORT = qw(
   check_console_font
@@ -1111,7 +1111,13 @@ sub handle_login {
     }
     if (check_var('DESKTOP', 'gnome') || (check_var('DESKTOP', 'lxde') && check_var('VERSION', '42.1'))) {
         # DMs in condition above have to select user
-        send_key 'ret';
+        if ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0')) || is_tumbleweed) {
+            assert_and_click "displaymanager-$username";
+            record_soft_failure 'bgo#657996 - user account not selected by default, have to use mouse to login';
+        }
+        else {
+            send_key 'ret';
+        }
     }
     assert_screen 'displaymanager-password-prompt', no_wait => 1;
     type_password;

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -5,6 +5,7 @@ use base "opensusebasetest";
 use strict;
 use testapi;
 use utils 'type_string_slow';
+use version_utils qw(leap_version_at_least sle_version_at_least);
 
 sub post_fail_hook {
     my ($self) = shift;
@@ -28,8 +29,11 @@ sub switch_wm {
     assert_and_click "user-logout-sector";
     assert_and_click "logout-system";
     assert_screen "logout-dialogue";
+    send_key 'tab' if sle_version_at_least('15');
     send_key "ret";
     assert_screen "displaymanager";
+    # The keyboard focus was losing in gdm of SLE15 bgo#657996
+    mouse_set(520, 350) if sle_version_at_least('15');
     send_key "ret";
     assert_screen "originUser-login-dm";
     type_password;
@@ -48,12 +52,19 @@ sub prepare_sle_classic {
     assert_screen "desktop-gnome-classic", 120;
     $self->application_test;
 
-    # Log out and switch to SLE Classic
+    # Log out and switch back to default session
     $self->switch_wm;
     assert_and_click "displaymanager-settings";
-    assert_and_click "dm-sle-classic";
-    send_key "ret";
-    assert_screen "desktop-sle-classic", 120;
+    if (sle_version_at_least('15')) {
+        assert_and_click 'dm-gnome-shell';
+        send_key 'ret';
+        assert_screen 'desktop-gnome-shell', 120;
+    }
+    else {
+        assert_and_click 'dm-sle-classic';
+        send_key 'ret';
+        assert_screen 'desktop-sle-classic', 120;
+    }
 }
 
 sub test_terminal {


### PR DESCRIPTION
This testsuite will be renamed as desktopapps-gnome and scheduled under Desktop Applications

- desktopapps-gnome: BOOTFROM=c, REGRESSION=gnome, SLE_PRODUCT=sled,
  HDD_1=SLE-%VERSION%-%ARCH%-Build%BUILD%-sled-gnome.qcow2,
  START_AFTER_TEST=create_hdd_sled_gnome
- auto-save-session test of application_starts_on_login.pm was removed
  from SLED15
- gnome_default_applications.pm is not updated in this commit, I will submit it next week

----

- Related ticket: https://progress.opensuse.org/issues/27166
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/626
- Verification run: 
  http://10.67.17.30/tests/55
  http://10.67.17.30/tests/53
