### PR TITLE
Fix addon_products_sle to enable DesktopApp module

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -26,7 +26,9 @@ sub handle_all_packages_medium {
     # corresponds to the selected SLE15 product because the "all packages"
     # addon medium and feature of installer is only available for SLE >= 15
     # anyway
-    foreach (split(/,/, $SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')})) {
+    my @addons = split(/,/, $SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')});
+    push @addons, 'desktop' if check_var('DESKTOP', 'gnome') && ('desktop' !~ @addons);
+    foreach (@addons) {
         send_key 'home';
         send_key_until_needlematch "addon-products-all_packages-$_-highlighted", 'down';
         send_key 'spc';


### PR DESCRIPTION
For sle 15 installation / migration with all-packages media,
only default modules, i.e. Basesystem and ServerApp for sles
will be enabled. But DesktopApp module is also required if
gnome desktop is expected on sles.
- See poo#29640 for details

- Related ticket: https://progress.opensuse.org/issues/29640
- Needles: N/A
- Verification run: http://10.67.18.143/tests/86