### PR TITLE
Do not reset NUMDISKS if RAIDLEVEL is not present

### DIFF
--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -31,8 +31,9 @@ sub run {
     my $hyperv_intermediary = select_console('hyperv-intermediary');
     my $name                = $svirt->name;
 
-    # Workaround before fix in svirt (https://github.com/os-autoinst/os-autoinst/pull/879) is deployed
-    set_var('NUMDISKS', defined get_var('RAIDLEVEL') ? 4 : 1);
+    # Workaround before fix in svirt (https://github.com/os-autoinst/os-autoinst/pull/901) is deployed
+    my $n = get_var('NUMDISKS', 1);
+    set_var('NUMDISKS', defined get_var('RAIDLEVEL') ? 4 : $n);
 
     # Mount openQA NFS share to drive N:
     hyperv_cmd("if not exist N: ( mount \\\\openqa.suse.de\\var\\lib\\openqa\\share\\factory N: )");

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -36,8 +36,9 @@ sub run {
     my $name  = $svirt->name;
     my $repo;
 
-    # Workaround before fix in svirt (https://github.com/os-autoinst/os-autoinst/pull/879) is deployed
-    set_var('NUMDISKS', defined get_var('RAIDLEVEL') ? 4 : 1);
+    # Workaround before fix in svirt (https://github.com/os-autoinst/os-autoinst/pull/901) is deployed
+    my $n = get_var('NUMDISKS', 1);
+    set_var('NUMDISKS', defined get_var('RAIDLEVEL') ? 4 : $n);
 
     my $xenconsole = "hvc0";
     if (!get_var('SP2ORLATER')) {


### PR DESCRIPTION
Currently if `RAIDLEVEL` is not set but `NUMDISKS` is , `NUMDISKS` is
reset to `1`. Thus preventing runs with e.g. `NUMDISKS=2`.

Should be removed when fix in os-autoinst is deployed to OSD.