### PR TITLE
Adjustments for firewalld

### DIFF
--- a/tests/yast2_gui/yast2_firewall.pm
+++ b/tests/yast2_gui/yast2_firewall.pm
@@ -16,16 +16,9 @@ use base "y2x11test";
 use strict;
 use testapi;
 use utils;
+use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least);
 
-sub run {
-    my $self = shift;
-
-    select_console 'root-console';
-    zypper_call('in yast2-http-server apache2 apache2-prefork', timeout => 1200);
-    select_console 'x11', await_console => 0;
-
-    $self->launch_yast2_module_x11('firewall', match_timeout => 60);
-
+sub susefirewall2 {
     # 	enter page interfaces and change zone for network interface
     assert_and_click("yast2_firewall_config_list");
     assert_screen "yast2_firewall_interfaces";
@@ -73,6 +66,50 @@ sub run {
     send_key "alt-n";
     assert_screen "yast2_firewall_summary", 30;
     send_key "alt-f";
+}
+
+sub firewalld {
+    # the inplementation of new firewall module is not completed yet.
+    # see bsc#1072659 for more details.
+    # So check layout and some basic stuffs only.
+
+    # check menu entries
+    assert_and_click 'firewall-options-menu';
+    assert_and_click 'firewall-view-menu';
+    assert_and_click 'firewall-help-menu';
+
+    # check zones public and some details
+    # Todo: check services, Ports, Protocols, Source Ports, Masquerading, Port Forwarding etc.
+    # check configuration details for zones, services, ipsets, icmp types, helpers, direct configuration
+    assert_screen 'firewall-zones-public';
+    assert_and_click 'firewall-config-services';
+    assert_screen 'firewall-config-services-list';
+    assert_and_click 'firewall-ipsets';
+    assert_screen 'firewall-ipsets-entry';
+
+    # now close and exit
+    assert_and_click 'firewall-file-menu';
+    assert_and_click 'firewall-file-quit';
+
+    # incomplete implementation
+    record_soft_failure 'bsc#1072659';
+}
+
+sub run {
+    my $self = shift;
+    select_console 'root-console';
+    zypper_call('in yast2-http-server apache2 apache2-prefork', timeout => 1200);
+    if ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0'))) {
+        zypper_call('in firewall-config', timeout => 60);
+        select_console 'x11', await_console => 0;
+        $self->launch_yast2_module_x11('firewall', target_match => 'firewall-start-page', match_timeout => 60);
+        firewalld;
+    }
+    else {
+        select_console 'x11', await_console => 0;
+        $self->launch_yast2_module_x11('firewall', match_timeout => 60);
+        susefirewall2;
+    }
 }
 
 1;


### PR DESCRIPTION
- workaround issue with missing new package firewall-config
- create new workflow for firewalld implementation
- add softfail for bsc#1072659
- verification runs:
  SLES 15: http://e13.suse.de/tests/214#step/yast2_firewall
  Leap 15.0: http://e13.suse.de/tests/223#step/yast2_firewall
  TW: http://e13.suse.de/tests/221#step/yast2_firewall
  SLES 12 SP3: http://e13.suse.de/tests/218#step/yast2_firewall
Needles PR:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/627
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/301
