### PR TITLE
Only enable wifi tests where available on openSUSE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -546,7 +546,9 @@ sub load_extra_tests {
         # well
         if (check_var('DESKTOP', 'gnome')) {
             loadtest 'x11/yast2_lan_restart';
-            if (!is_sle || sle_version_at_least('12-SP4')) {
+            # we only have the test dependencies, e.g. hostapd available in
+            # openSUSE
+            if (check_var('DISTRI', 'opensuse')) {
                 loadtest 'x11/network/hwsim_wpa2_enterprise_setup';
                 loadtest 'x11/network/yast2_network_setup';
                 loadtest 'x11/network/NM_wpa2_enterprise';


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/29369