### PR TITLE
Set default username for SLE_PRODUCT=sles4sap

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -95,7 +95,7 @@ sub set_defaults_for_username_and_password {
         $testapi::password = '';
     }
     else {
-        if (get_var('FLAVOR', '') =~ /SAP/) {
+        if (get_var('FLAVOR', '') =~ /SAP/ or get_var('SLE_PRODUCT', '') =~ /sles4sap/) {
             $testapi::username = "root";    #in sles4sap only root user created
         }
         else {


### PR DESCRIPTION
Set 'root' as default username when SLE_PRODUCT is sles4sap.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/166 & http://mango.suse.de/tests/165
