### PR TITLE
Migrate regression-documentation to SLED15

### DIFF
--- a/lib/x11regressiontest.pm
+++ b/lib/x11regressiontest.pm
@@ -68,7 +68,8 @@ sub clean_shotwell {
 sub upload_libreoffice_specified_file {
 
     x11_start_program('xterm');
-    assert_script_run("wget " . autoinst_url . "/data/x11regressions/ooo-test-doc-types.tar.bz2 -O /home/$username/Documents/ooo-test-doc-types.tar.bz2");
+    type_string_slow("wget " . autoinst_url . "/data/x11regressions/ooo-test-doc-types.tar.bz2 -O /home/$username/Documents/ooo-test-doc-types.tar.bz2");
+    send_key "ret";
     wait_still_screen;
     type_string("cd /home/$username/Documents && ls -l");
     send_key "ret";
@@ -111,7 +112,7 @@ sub cleanup_libreoffice_recent_file {
 }
 
 sub open_libreoffice_options {
-    if (is_tumbleweed) {
+    if (is_tumbleweed or (is_sle && sle_version_at_least('15'))) {
         send_key 'alt-f12';
     }
     else {

--- a/tests/x11regressions/gnote/gnote_link_note.pm
+++ b/tests/x11regressions/gnote/gnote_link_note.pm
@@ -16,7 +16,7 @@ use base 'x11regressiontest';
 use strict;
 use testapi;
 use utils;
-use version_utils "is_tumbleweed";
+use version_utils qw(is_sle is_tumbleweed sle_version_at_least);
 
 
 sub run {
@@ -28,7 +28,8 @@ sub run {
     send_key 'ctrl-ret';    #switch to link
     assert_screen 'gnote-note-start-here';
 
-    wait_screen_change { send_key 'ctrl-tab' };    #jump to toolbar
+    wait_screen_change { send_key 'ctrl-tab' };                                              #jump to toolbar
+    wait_screen_change { send_key 'ctrl-tab' } if (is_sle && sle_version_at_least('15'));    #jump to toolbar
     wait_screen_change {
         for (1 .. 6) { send_key 'right' }
     };
@@ -40,7 +41,7 @@ sub run {
     assert_screen 'gnote-what-link-here';
     wait_screen_change { send_key 'esc' };
     #close the note "Start Here"
-    wait_screen_change { send_key 'ctrl-w' } if (!is_tumbleweed);
+    wait_screen_change { send_key 'ctrl-w' } if (!is_tumbleweed && (is_sle && !sle_version_at_least('15')));
     $self->cleanup_gnote;
 }
 

--- a/tests/x11regressions/gnote/gnote_rename_title.pm
+++ b/tests/x11regressions/gnote/gnote_rename_title.pm
@@ -15,6 +15,7 @@
 use base "x11regressiontest";
 use strict;
 use testapi;
+use version_utils qw(is_sle sle_version_at_least);
 
 
 sub run {
@@ -25,7 +26,8 @@ sub run {
     send_key "up";
     type_string "new title-opensuse\n";
     send_key "ctrl-tab";    #jump to toolbar
-    send_key "ret";         #back to all notes interface
+    send_key "ctrl-tab" if (is_sle && sle_version_at_least('15'));    #jump to toolbar for SLED15
+    send_key "ret";                                                   #back to all notes interface
     send_key_until_needlematch 'gnote-new-note-title-matched', 'down', 6;
     send_key "delete";
     send_key "tab";

--- a/tests/x11regressions/gnote/gnote_undo_redo.pm
+++ b/tests/x11regressions/gnote/gnote_undo_redo.pm
@@ -15,6 +15,7 @@
 use base "x11regressiontest";
 use strict;
 use testapi;
+use version_utils qw(is_sle sle_version_at_least);
 
 
 sub undo_redo_once {
@@ -37,15 +38,17 @@ sub run {
 
     #assure undo and redo take effect after save note and re-enter note
     send_key "ctrl-tab";    #jump to toolbar
-    send_key "ret";         #back to all notes interface
+    send_key "ctrl-tab" if (is_sle && sle_version_at_least('15'));    #jump to toolbar for SLED15
+    send_key "ret";                                                   #back to all notes interface
     send_key_until_needlematch 'gnote-new-note-matched', 'down', 6;
     wait_still_screen 3;
     send_key "ret";
     $self->undo_redo_once;
 
     #clean: remove the created new note
-    send_key "ctrl-tab";    #jump to toolbar
-    send_key "ret";         #back to all notes interface
+    send_key "ctrl-tab";                                              #jump to toolbar
+    send_key "ctrl-tab" if (is_sle && sle_version_at_least('15'));    #jump to toolbar for SLED15
+    send_key "ret";                                                   #back to all notes interface
     send_key_until_needlematch 'gnote-new-note-matched', 'down', 6;
     send_key "delete";
     send_key "tab";

--- a/tests/x11regressions/libreoffice/libreoffice_default_theme.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_default_theme.pm
@@ -14,12 +14,12 @@
 use base "x11regressiontest";
 use testapi;
 use utils;
-use version_utils 'is_tumbleweed';
+use version_utils qw(is_sle is_tumbleweed sle_version_at_least);
 use strict;
 
 sub check_lo_theme {
     x11_start_program('ooffice');
-    if (is_tumbleweed) {
+    if (is_tumbleweed || (is_sle && sle_version_at_least('15'))) {
         send_key 'alt-f12';
     }
     else {

--- a/tests/x11regressions/libreoffice/libreoffice_double_click_file.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_double_click_file.pm
@@ -13,6 +13,7 @@
 use base "x11regressiontest";
 use strict;
 use testapi;
+use version_utils qw(is_sle sle_version_at_least);
 
 sub run {
     my $self = shift;
@@ -34,7 +35,12 @@ sub run {
         send_key_until_needlematch("libreoffice-specified-list-$tag", "right", 50, 1);
         assert_and_dclick("libreoffice-specified-list-$tag");
         assert_screen("libreoffice-test-$tag", 90);
-        send_key 'ctrl-q';
+        if (is_sle && sle_version_at_least('15')) {
+            send_key 'alt-f4';
+        }
+        else {
+            send_key 'ctrl-q';
+        }
     }
     if (!check_screen("generic-desktop")) {
         send_key "ctrl-q";

--- a/tests/x11regressions/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_mainmenu_components.pm
@@ -14,7 +14,7 @@ use base "x11regressiontest";
 use strict;
 use testapi;
 use utils;
-use version_utils "is_tumbleweed";
+use version_utils qw(is_sle is_tumbleweed sle_version_at_least);
 
 # open desktop mainmenu and click office
 sub open_mainmenu {
@@ -54,7 +54,7 @@ sub select_base_and_cleanup {
 sub run {
     my $self = shift;
 
-    if (!is_tumbleweed) {
+    if (!is_tumbleweed && (is_sle && !sle_version_at_least('15'))) {
         # launch components from mainmenu
         $self->open_mainmenu();
         assert_and_click 'mainmenu-office-lo';    #open lo

--- a/tests/x11regressions/libreoffice/libreoffice_mainmenu_favorites.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_mainmenu_favorites.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -14,6 +14,7 @@
 use base "x11regressiontest";
 use strict;
 use testapi;
+use version_utils qw(is_sle sle_version_at_least);
 
 sub run {
     # start destop application memu
@@ -22,8 +23,10 @@ sub run {
     assert_screen('test-desktop_mainmenu-1');
 
     # find the favorites button
-    assert_and_click('application-menu-favorites');
-    assert_screen('menu-favorites-libreoffice');
+    if (is_sle && !sle_version_at_least('15')) {
+        assert_and_click('application-menu-favorites');
+        assert_screen('menu-favorites-libreoffice');
+    }
 
     # find the LibreOffice
     assert_and_click('favorites-list-libreoffice');

--- a/tests/x11regressions/libreoffice/libreoffice_recent_documents.pm
+++ b/tests/x11regressions/libreoffice/libreoffice_recent_documents.pm
@@ -15,7 +15,7 @@ use base "x11regressiontest";
 use strict;
 use testapi;
 use utils;
-use version_utils 'is_tumbleweed';
+use version_utils qw(is_sle is_tumbleweed sle_version_at_least);
 
 sub run {
     # Edit file hello.odt using oowriter
@@ -36,8 +36,13 @@ sub run {
     wait_still_screen;
     x11_start_program('oowriter');
     send_key "alt-f";
+    # Because of bsc#1074057 alt-f is not working in libreoffice under wayland
+    # use another way to replace alt-f in SLED15
+    if (is_sle && sle_version_at_least('15')) {
+        assert_and_click 'ooffice-writing-file', 'left', 10;
+    }
     assert_screen 'oowriter-menus-file';
-    if (is_tumbleweed) {
+    if (is_tumbleweed || (is_sle && sle_version_at_least('15'))) {
         send_key 'down';
         wait_still_screen 3;
         send_key 'u';


### PR DESCRIPTION
- This testsuite will be renamed as desktopapps-documentation and scheduled under Desktop Applications
- desktopapps-documentation:
      BOOTFROM=c, REGRESSION=documentation, SLE_PRODUCT=sled,
      HDD_1=SLE-%VERSION%-%ARCH%-Build%BUILD%-sled-gnome.qcow2,
      START_AFTER_TEST=create_hdd_sled_gnome
- Update x11regressiontest.pm to resolve the input string issue
- Update 3 test cases for gnote
- Update 5 test cases for libreoffice

see also poo#27169

-----

- Related ticket: https://progress.opensuse.org/issues/27169
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/630
- Verification run: http://10.67.17.21/tests/207
