### PR TITLE
Fix addon_products_sle to not select module twice

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -27,7 +27,7 @@ sub handle_all_packages_medium {
     # addon medium and feature of installer is only available for SLE >= 15
     # anyway
     my @addons = split(/,/, $SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')});
-    push @addons, 'desktop' if check_var('DESKTOP', 'gnome') && ('desktop' !~ @addons);
+    push @addons, 'desktop' if check_var('DESKTOP', 'gnome') && !grep(/^desktop$/, @addons);
     foreach (@addons) {
         send_key 'home';
         send_key_until_needlematch "addon-products-all_packages-$_-highlighted", 'down';


### PR DESCRIPTION
- see poo#29772 for details

Previous code ('desktop' !~ @addons) didn't work, replace it with: !grep(/^desktop$/, @addons)

- Related ticket: https://progress.opensuse.org/issues/29772
- Needles: N/A
- Verification run: http://openqa-apac1.suse.de/tests/10
