### PR TITLE
Use version_utils instead of utils

### DIFF
--- a/tests/shutdown/hyperv_upload_assets.pm
+++ b/tests/shutdown/hyperv_upload_assets.pm
@@ -14,7 +14,7 @@ use base 'installbasetest';
 use strict;
 use warnings;
 use testapi;
-use utils;
+use version_utils;
 
 use File::Basename 'fileparse_set_fstype';
 


### PR DESCRIPTION
Merge of old PR (https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/2948/)
makes `make test` fail:
https://travis-ci.org/os-autoinst/os-autoinst-distri-opensuse/builds/324481909?utm_source=github_status&utm_medium=notification