### PR TITLE
Virtualization: replace host upgrade autoyast module urls with openqa daily build links

### DIFF
--- a/tests/virt_autotest/host_upgrade_step2_run.pm
+++ b/tests/virt_autotest/host_upgrade_step2_run.pm
@@ -14,6 +14,7 @@ use base "host_upgrade_base";
 #use virt_utils qw(set_serialdev);
 use testapi;
 use strict;
+use virt_utils;
 
 sub get_script_run {
     my $self = shift;
@@ -21,13 +22,21 @@ sub get_script_run {
     my $pre_test_cmd = $self->get_test_name_prefix;
     $pre_test_cmd .= "-run 02";
 
-    return "$pre_test_cmd";
+    return "rm /var/log/qa/old* /var/log/qa/ctcs2/* -r;" . "$pre_test_cmd";
 }
 
 sub run {
     my $self = shift;
     $self->run_test(12600, "Host upgrade to .* is done. Need to reboot system|Executing host upgrade to .* offline",
         "no", "yes", "/var/log/qa/", "host-upgrade-prepAndUpgrade");
+
+    #replace module url with openqa daily build modules link
+    my $upgrade_product = get_required_var('UPGRADE_PRODUCT');
+    my ($upgrade_release) = lc($upgrade_product) =~ /sles-([0-9]+)-sp/;
+    if ($upgrade_release >= 15) {
+        repl_addon_with_daily_build_module_in_files('/root/autoupg.xml');
+        upload_logs('/root/autoupg.xml');
+    }
 }
 
 1;

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -24,7 +24,7 @@ use IO::File;
 use proxymode;
 use virt_autotest_base;
 
-our @EXPORT = qw(update_guest_configurations_with_daily_build);
+our @EXPORT = qw(update_guest_configurations_with_daily_build repl_addon_with_daily_build_module_in_files);
 
 sub get_version_for_daily_build_guest {
     my $version = '';
@@ -59,21 +59,32 @@ sub repl_repo_in_sourcefile {
     }
 }
 
+sub repl_addon_with_daily_build_module_in_files {
+    my $file_list = shift;
+
+    $file_list =~ s/\n/ /g;
+    my $version = get_version_for_daily_build_guest;
+    $version =~ s/-fcs//;
+    $version = uc($version);
+    my $command
+      = "for file in $file_list;do "
+      . "sed -ri 's#^.*(Basesystem|Desktop-Applications|Legacy|Server-Applications|Development-Tools|Web-Scripting).*\$#"
+      . "<media_url>http://openqa.suse.de/assets/repo/SLE-${version}-Module-\\1-POOL-x86_64-Build"
+      . get_required_var('BUILD')
+      . "-Media1/</media_url>#' \$file;done";
+    assert_script_run($command);
+    save_screenshot;
+    assert_script_run("grep media_url $file_list -r");
+    save_screenshot;
+}
+
 sub repl_guest_autoyast_addon_with_daily_build_module {
     #replace the addons url in guest autoyast file in qa_lib_virtauto-data with the daily build module repos
     my $version = get_version_for_daily_build_guest;
     $version =~ s/-/\//;
     my $autoyast_root_dir = "/usr/share/qa/virtautolib/data/autoinstallation/sles/" . $version . "/";
-    my $command
-      = "for file in \`find $autoyast_root_dir -type f\`;do "
-      . "sed -ri 's#^.*(Basesystem|Desktop-Applications|Legacy|Server-Applications|Development-Tools).*\$#"
-      . "<media_url>http://openqa.suse.de/assets/repo/SLE-15-Module-\\1-POOL-x86_64-Build"
-      . get_required_var('BUILD')
-      . "-Media1/</media_url>#' \$file;done";
-    assert_script_run($command);
-    save_screenshot;
-    assert_script_run("grep media_url $autoyast_root_dir/* -r");
-    save_screenshot;
+    my $file_list         = &script_output("find $autoyast_root_dir -type f");
+    repl_addon_with_daily_build_module_in_files("$file_list");
 }
 
 sub update_guest_configurations_with_daily_build {


### PR DESCRIPTION
Virtualization tests host upgrade from virtualization's view. For upgrade from sle11/12 to sle15, the upgrade autoyast file needs to add modules as addons, which is different from upgrading to sle12. This PR is to accomplish it. 

- Verification run: http://10.67.18.220/tests/501
  Note, this job verifies the code changes which affect steps before switch_version_and_reload_needle. It proves new code working. However we can not finish it because it stops at real upgrading phase by a bug https://bugzilla.suse.com/show_bug.cgi?id=1071454.
 