### PR TITLE
Virtualization: collect failure logs when upgrade tests fail

### DIFF
--- a/lib/proxymode.pm
+++ b/lib/proxymode.pm
@@ -11,7 +11,7 @@ package proxymode;
 # Summary: proxymode: The basic lib for using proxy mode to connect or operation with physical machine
 # Maintainer: John <xgwang@suse.com>
 
-use base 'basetest';
+use base 'y2logsstep';
 use testapi;
 use strict;
 

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -7,14 +7,14 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-package login_console;
-# Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm support fully, xen support not done yet
+# Summary: virt_autotest: the initial version of virtualization automation test in openqa, with kvm and xen support fully
 # Maintainer: alice <xlai@suse.com>
 
+package login_console;
+use base "y2logsstep";
 use strict;
 use warnings;
 use File::Basename;
-use base "opensusebasetest";
 use testapi;
 use ipmi_backend_utils;
 

--- a/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
@@ -18,7 +18,7 @@ use base "reboot_and_wait_up";
 
 sub run {
     my $self    = shift;
-    my $timeout = 1200;
+    my $timeout = 600;
     set_var("reboot_for_upgrade_step", "yes");
     $self->reboot_and_wait_up($timeout);
 }


### PR DESCRIPTION
When host upgrade tests fail, currently it does not push logs for debugging. This PR inherites relative classes from y2logsstep to call its post_fail_hook for debugging logs.

- Verification run: http://10.67.18.220/tests/510#
Note, this job does not finish successfully because it has blocking bug, but it does verify the log collection when test fail.