### PR TITLE
[qa_automation] Decouple kexec test from qa_run.pm module

### DIFF
--- a/tests/qa_automation/kernel_kexec.pm
+++ b/tests/qa_automation/kernel_kexec.pm
@@ -16,7 +16,7 @@
 # Summary:  [qa_automation] kexec testsuite
 # Maintainer: Nathan Zhao <jtzhao@suse.com>
 
-use base "qa_run";
+use base "opensusebasetest";
 use strict;
 use testapi;
 


### PR DESCRIPTION
Since qa_run.pm will be removed soon, decouple kexec test from it.

- Verification run: http://10.67.131.155/tests/401