### PR TITLE
Workaroud for gnome-basic missing with migration from SLES11 to SLES15

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -24,6 +24,10 @@ sub run {
     record_soft_failure('bsc#1054974') if get_var('ALL_MODULES');
     # overview-generation
     # this is almost impossible to check for real
+    if (check_screen('missing_gnome_basic', 0)) {
+        record_soft_failure('bsc#1069728: Offline migration from SLES 11SP4 to SLES15 failed: gnome-basic pattern not found');
+        send_key 'alt-o';
+    }
     assert_screen "installation-settings-overview-loaded";
 
     $self->deal_with_dependency_issues;


### PR DESCRIPTION
Workaround for missing gnome-basic with media migration from SLES11 to SLES15
Add record_soft_failure if meet bsc#1069728
Send key alt-o to close error message

- Related ticket: https://progress.opensuse.org/issues/29095
- Verification run: http://10.67.17.147/tests/1894#step/installation_overview/2

  