### PR TITLE
SLE HA fixes

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -198,10 +198,16 @@ sub ha_export_logs {
 
     # Extract HA logs and upload them
     select_console 'root-console';
-    upload_logs "$bootstrap_log";
     script_run "touch $corosync_conf";
     script_run "hb_report -E $bootstrap_log $hb_log", 120;
+    upload_logs "$bootstrap_log"  if !script_run "test -e $bootstrap_log";
     upload_logs "$hb_log.tar.bz2" if !script_run "test -e $hb_log";
+
+    # Extract YaST logs and upload them
+    script_run "save_y2logs", 120;
+    if (my $y2logs = script_output 'ls -t /tmp/y2log-*.tar.xz | head -n 1') {
+        upload_logs "$y2logs";
+    }
 }
 
 sub post_run_hook {

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -215,8 +215,11 @@ sub fill_in_registration_data {
             assert_screen($modules_needle);
             # Add desktop module for SLES if desktop doesn't match default
             if (check_var('SLE_PRODUCT', 'sles') && (my $addons = get_var('SCC_ADDONS')) !~ /(?:desktop|we|productivity)/) {
-                $addons = $addons ? $addons . ',desktop' : 'desktop';
-                set_var('SCC_ADDONS', $addons);
+                # HA doesn't need to have desktop module selected
+                if ($addons !~ /(?:ha)/) {
+                    $addons = $addons ? $addons . ',desktop' : 'desktop';
+                    set_var('SCC_ADDONS', $addons);
+                }
             }
         }
     }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -991,7 +991,11 @@ sub load_slenkins_tests {
 
 sub load_ha_cluster_tests {
     return unless (get_var("HA_CLUSTER"));
+
+    # Wait for support server to complete its initialization
     loadtest "ha/wait_support_server";
+
+    # Standard boot and configuration
     loadtest "boot/boot_to_desktop";
     loadtest "qa_automation/patch_and_reboot" if is_updates_tests;
     loadtest "console/consoletest_setup";
@@ -1004,7 +1008,7 @@ sub load_ha_cluster_tests {
     }
 
     # SLE15 workarounds
-    loadtest "ha/sle15_workarounds" if sle_version_at_least('15');
+    loadtest "ha/sle15_workarounds" if (is_sle && sle_version_at_least('15'));
 
     # Basic configuration
     loadtest "ha/firewall_disable";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1041,11 +1041,9 @@ sub load_ha_cluster_tests {
 
     # Test fencing feature
     loadtest "ha/fencing";
-    if (!get_var("HA_CLUSTER_JOIN")) {
-        # Node1 will be fenced
-        loadtest "boot/boot_to_desktop";
-        loadtest "console/consoletest_setup";
-    }
+
+    # Node1 will be fenced, so we have to wait for it to boot
+    loadtest "boot/boot_to_desktop" if (!get_var("HA_CLUSTER_JOIN"));
 
     # Cluster status and check logs to find error
     loadtest "ha/check_cluster";

--- a/tests/ha/clvm.pm
+++ b/tests/ha/clvm.pm
@@ -112,7 +112,6 @@ sub run {
         assert_script_run "sed -ie '/\\<volume_list\\>[[:blank:]][[:blank:]]*=/ a volume_list = [ $vol_list ]' $lvm_conf";
     }
 
-
     # Wait until PV-VG-LV is created
     barrier_wait("CLVM_PV_VG_LV_CREATED_${barrier_tag}_$cluster_name");
 

--- a/tests/ha/drbd_passive.pm
+++ b/tests/ha/drbd_passive.pm
@@ -16,7 +16,7 @@
 
 use base 'opensusebasetest';
 use strict;
-use version_utils 'sle_version_at_least';
+use version_utils qw(is_sle sle_version_at_least);
 use testapi;
 use lockapi;
 use hacluster;
@@ -157,7 +157,7 @@ sub run {
     # Wait for DRBD to be checked
     barrier_wait("DRBD_RESOURCE_CREATED_$cluster_name");
 
-    if (sle_version_at_least('12-SP3')) {
+    if (is_sle && sle_version_at_least('12-SP3')) {
         # Need to stop/start the DRBD resource to be able to migrate it after
         # Is it the wanted behavior? Was not in SLE12-SP2, need to check with
         # developers for the new versions

--- a/tests/ha/firewall_disable.pm
+++ b/tests/ha/firewall_disable.pm
@@ -12,7 +12,7 @@
 
 use base 'opensusebasetest';
 use strict;
-use version_utils 'sle_version_at_least';
+use version_utils qw(is_sle sle_version_at_least);
 use testapi;
 use hacluster;
 
@@ -20,7 +20,7 @@ sub run {
     my $firewall = 'SuSEfirewall2';
 
     # SLE/openSUSE-15 use firewalld instead of the old SuSEfirewall2
-    if (sle_version_at_least('15')) {
+    if (is_sle && sle_version_at_least('15')) {
         $firewall = 'firewalld';
     }
 

--- a/tests/ha/sle15_workarounds.pm
+++ b/tests/ha/sle15_workarounds.pm
@@ -13,13 +13,13 @@
 
 use base 'opensusebasetest';
 use strict;
-use version_utils 'sle_version_at_least';
+use version_utils qw(is_sle sle_version_at_least);
 use testapi;
 use hacluster;
 
 # Do some stuff that need to be workaround in SLE15
 sub run {
-    return unless sle_version_at_least('15');
+    return unless (is_sle && sle_version_at_least('15'));
 
     # Modify the device number if needed
     if ((get_var('ISO', '') eq '') && (get_var('ISO_1', '') ne '')) {


### PR DESCRIPTION
Some changes/improvements in HA tests:
- Use `is_sle` when needed in HA tests
- Don't select Desktop Module for HA
- No need to execute `consoletest_setup` after fencing a node
- Add upload of YaST2 logs for HA tests
- Verification run: [sle15](http://moon.qa.suse.cz/tests/527) and [sle12sp3](http://moon.qa.suse.cz/tests/530)
  