### PR TITLE
Bootloader: Speed up media check selection

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -195,7 +195,7 @@ sub select_bootmenu_more {
         send_key_until_needlematch $tag, 'up';
     }
     else {
-        send_key_until_needlematch($tag, 'down', 10, 5);
+        send_key_until_needlematch($tag, 'down', 10, 3);
     }
     if (get_var('UEFI')) {
         send_key 'e';


### PR DESCRIPTION
The default grub menu is shown for 8 seconds. The first second is
'wasted' waiting for the detection of the bootloader (check if shim
import would be needed or the bootloader), second is in checking the
bootloader being present and if it has the more menu

from here, a 5 s timeout to detect that we are 'not yet on the
mediacheck' is a lot of time - and gets us very close to the limit of
grub waiting for us (often beyond the limit)

Speed up to waiting only 3 seconds, which moves us away from the limit
and gives a much better chance to hit 'down' in time. Moving the
selection line down in 3s is still very realistic.

Fixes https://progress.opensuse.org/issues/28757