### PR TITLE
Add dev tools module to kdump_and_crash for sle15

### DIFF
--- a/tests/console/kdump_and_crash.pm
+++ b/tests/console/kdump_and_crash.pm
@@ -15,12 +15,15 @@ use strict;
 use testapi;
 use utils;
 use kdump_utils;
+use version_utils qw(is_sle sle_version_at_least);
+use registration;
 
 sub run {
     my ($self) = @_;
     select_console('root-console');
 
     # preparation for crash test
+    add_suseconnect_product("sle-module-development-tools") if is_sle and sle_version_at_least('15');
     prepare_for_kdump;
     activate_kdump;
 


### PR DESCRIPTION
Add dev tools module to kdump_and_crash for sle15

- Related ticket: https://progress.opensuse.org/issues/28854
- Verification run: I will need help for ppc verifications, at least someone remembered if verifications in this [PR](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4024) (to be closed after this one is merged) are still valid.
