### PR TITLE
Fix serialdev permissions for older distribution versions using group "tty"

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -956,7 +956,7 @@ sub ensure_serialdev_permissions {
     # ownership has effect immediately, group change is for effect after
     # reboot an alternative https://superuser.com/a/609141/327890 would need
     # handling of optional sudo password prompt within the exec
-    assert_script_run "chown $testapi::username /dev/$testapi::serialdev && gpasswd -a $testapi::username dialout";
+    assert_script_run "chown $testapi::username /dev/$testapi::serialdev && gpasswd -a $testapi::username \$(stat -c %G /dev/$testapi::serialdev)";
 }
 
 1;


### PR DESCRIPTION
See https://openqa.suse.de/tests/1369983#step/piglit/22 for the problem.
Followup to
https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/e652aefe66c3a650398bd89ff7c80cbc9853329e