### PR TITLE
Add missing version_utils

### DIFF
--- a/tests/console/zypper_lr_validate.pm
+++ b/tests/console/zypper_lr_validate.pm
@@ -14,6 +14,7 @@ use base "consoletest";
 use strict;
 use testapi;
 use utils;
+use version_utils 'sle_version_at_least';
 
 sub validatelr {
     my ($args) = @_;


### PR DESCRIPTION
zypper_lr_validated started to fail  with error:
```
# Test died: Undefined subroutine &zypper_lr_validate::sle_version_at_least called at /var/lib/openqa/cache/tests/sle/tests/console/zypper_lr_validate.pm line 333.
```
https://openqa.suse.de/tests/1368561#step/zypper_lr_validate/9
Function `sle_version_at_least` was recently moved to version_utils, so test was updated to use version_utils.

- Related ticket: https://progress.opensuse.org/issues/30039
- Needles: none
- Verification run: http://10.100.12.105/tests/754
