### PR TITLE
Remove wait_still_screen from search subroutine

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -39,7 +39,6 @@ sub search {
         send_key 'backspace';
     }
     wait_screen_change { type_string $name; } if $name;
-    wait_still_screen 1;
 }
 
 sub start_addon_products {


### PR DESCRIPTION
As pointed out by @okurz, due to blinking cursor we waste quite some
time waiting for the still screen. It can be safely removed, as we
always do assert screen afterwards.
  