### PR TITLE
Increase salt timeout in the soft failure

### DIFF
--- a/tests/console/salt.pm
+++ b/tests/console/salt.pm
@@ -32,8 +32,8 @@ EOF
     record_soft_failure 'bsc#1069711';    # Added 30s wait for public key from minion present in master
     sleep(30);
     assert_script_run("salt-key --accept-all -y");
-    record_soft_failure 'bsc#1069711';    # Added 120s to ping minion
-    validate_script_output "salt '*' test.ping -t 120 | grep -woh True > /dev/$serialdev", sub { m/True/ }, 120;
+    record_soft_failure 'bsc#1069711';    # Added 180s to ping minion
+    validate_script_output "salt '*' test.ping -t 180 | grep -woh True > /dev/$serialdev", sub { m/True/ }, 180;
     assert_script_run 'systemctl stop salt-master salt-minion';
 }
 


### PR DESCRIPTION
Increase salt timeout in the soft failure.  salt workaround didn't work for https://openqa.suse.de/tests/1370487#step/salt/22. While the bug if fixed, we can improve the workaround increasing the timeout.

- Related ticket: https://progress.opensuse.org/issues/29583#change-82212
- Verification run: after it will be merged, only reproducible in prod.
