### PR TITLE
Change outdated URL to a working one in firefox_extcontent

### DIFF
--- a/tests/x11regressions/firefox/firefox_extcontent.pm
+++ b/tests/x11regressions/firefox/firefox_extcontent.pm
@@ -19,7 +19,7 @@ sub run {
     my ($self) = @_;
     $self->start_firefox;
 
-    my $ext_link = "http://mirror.bej.suse.com/dist/install/SLP/SLE-12-Server-GM/x86_64/dvd1/";
+    my $ext_link = "http://mirror.bej.suse.com/dist/install/SLP/SLE-12-SP3-Server-GM/x86_64/dvd1/";
 
     send_key "esc";
     sleep 1;


### PR DESCRIPTION
The test module was using a testing URL linking to SLE12 GA on BEJ mirrror (http://mirror.bej.suse.com/dist/install/SLP/SLE-12-Server-GM/x86_64/dvd1/), which was recently removed from this mirror.

I swapped the outdated link for a working one (http://mirror.bej.suse.com/dist/install/SLP/SLE-12-SP3-Server-GM/x86_64/dvd1/). SP3 should stick for a while, I guess.

- Related ticket: https://progress.opensuse.org/issues/29915
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/635
- Verification run: http://dreamyhamster.suse.cz/tests/6#step/firefox_extcontent/12

  
  