### PR TITLE
Enable partition_filesystem for textmode

### DIFF
--- a/tests/installation/partitioning_filesystem.pm
+++ b/tests/installation/partitioning_filesystem.pm
@@ -21,8 +21,9 @@ sub run {
 
     my $fs = get_var('FILESYSTEM');
 
-    # click the button
-    assert_and_click 'edit-proposal-settings';
+    # open the partinioner
+    assert_screen 'edit-proposal-settings';
+    wait_screen_change { send_key $cmd{guidedsetup} };
 
     if (get_var('PARTITIONING_WARNINGS')) {
         if (is_storage_ng) {
@@ -41,17 +42,22 @@ sub run {
         send_key $cmd{next};
     }
     # select the combo box
-    assert_and_click 'default-root-filesystem';
+    assert_screen 'default-root-filesystem';
+    send_key 'alt-f';
+    assert_screen 'filesystem-root-menu-selected';
 
     # select filesystem
-    assert_and_click "filesystem-$fs";
+    send_key 'home';
+    send_key_until_needlematch("filesystem-$fs", 'down', 20, 3);
+    send_key 'ret' if check_var('DESKTOP', 'textmode');
+
     assert_screen "$fs-selected";
     send_key(is_storage_ng() ? $cmd{next} : 'alt-o');
 
     # make sure we're back from the popup
     assert_screen 'edit-proposal-settings';
 
-    mouse_hide;
+    mouse_hide unless check_var('DESKTOP', 'textmode');
 }
 
 1;


### PR DESCRIPTION
Adapted the partition_filesystem module for textmode
FILESYSTEM setting is required to trigger it.

- Related ticket: https://progress.opensuse.org/issues/27961
- Needles openSUSE: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/303
- Needles SLE: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/636
- Verification runs:
  - SLE
    -12/3
      - [Btrfs txt](http://pinky.arch.suse.de/tests/109)  [Btrfs gui](http://pinky.arch.suse.de/tests/139)
      - [Ext4 txt](http://pinky.arch.suse.de/tests/108) [Ext4 gui](http://pinky.arch.suse.de/tests/142)
      - [XFS txt](http://pinky.arch.suse.de/tests/107)  [XFS gui](http://pinky.arch.suse.de/tests/141)
   - 15
      - [Ext2 txt](http://pinky.arch.suse.de/tests/98#)  [Ext2 gui](http://pinky.arch.suse.de/tests/120#)
      - [Ext3](http://pinky.arch.suse.de/tests/102#)
      - [Ext4 txt](http://pinky.arch.suse.de/tests/103#)  [Ext4 gui](http://pinky.arch.suse.de/tests/130#)  
      - [XFS txt](http://pinky.arch.suse.de/tests/97) [XFS gui](http://pinky.arch.suse.de/tests/125)
      - [Btrfs txt](http://pinky.arch.suse.de/tests/96) [Btrfs gui](http://pinky.arch.suse.de/tests/117)
