### PR TITLE
updates_packagekit_gpk: Restart packagekitd to pick up libzypp changes

### DIFF
--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -86,6 +86,10 @@ sub run {
             }
             elsif (match_has_tag("updates_installed-logout")) {
                 send_key "alt-c";    # close
+
+                # The logout is not acted upon, which may miss a libzypp update
+                # Force reloading of packagekitd (bsc#1075260, poo#30085)
+                x11_start_program('pkcon quit');
             }
             elsif (match_has_tag("updates_installed-restart")) {
                 power_action 'reboot', textmode => 1;


### PR DESCRIPTION
The logout is not acted upon, which may miss a libzypp update.
Stop the daemon via pkcon quit to have it restarted for the next loop.

Should fix https://progress.opensuse.org/issues/30085
Fixes https://openqa.opensuse.org/tests/578640#step/updates_packagekit_gpk/24
Fixes https://openqa.opensuse.org/tests/578636#step/updates_packagekit_gpk/21
Related to https://bugzilla.opensuse.org/show_bug.cgi?id=1075260

- Related ticket: https://progress.opensuse.org/issues/30085
- Verification run: not done
