### PR TITLE
Fix recovery of kdump_and_crash test after soft-fail

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -109,8 +109,7 @@ sub kdump_is_active {
         if ($status =~ /No kdump initial ramdisk found/) {
             record_soft_failure 'bsc#1021484 -- fail to create kdump initrd';
             assert_script_run 'systemctl restart kdump';
-            $status = script_output('systemctl status kdump ||:');
-            last;
+            next;
         }
         elsif ($status =~ /Active: active/) {
             return 1;


### PR DESCRIPTION
Original after successful application of workaround caused early end of test.
Now test continue with crash and its analyze

http://quasar.suse.cz/tests/102#
