### PR TITLE
Use registration for autoyast installations

### DIFF
--- a/data/autoyast_sle12/autoinst_h1_btrfs.xml
+++ b/data/autoyast_sle12/autoinst_h1_btrfs.xml
@@ -70,6 +70,28 @@
       <start_multipath config:type="boolean">false</start_multipath>
     </storage>
   </general>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
   <host>
     <hosts config:type="list">
       <hosts_entry>

--- a/data/autoyast_sle12/autoinst_h3_xfs.xml
+++ b/data/autoyast_sle12/autoinst_h3_xfs.xml
@@ -61,6 +61,28 @@
       <start_multipath config:type="boolean">false</start_multipath>
     </storage>
   </general>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
   <host>
     <hosts config:type="list">
       <hosts_entry>

--- a/data/autoyast_sle12/autoinst_h5_btrfs_uuid.xml
+++ b/data/autoyast_sle12/autoinst_h5_btrfs_uuid.xml
@@ -59,6 +59,28 @@
       <start_multipath config:type="boolean">false</start_multipath>
     </storage>
   </general>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
   <groups config:type="list">
 
   </groups>

--- a/data/autoyast_sle12/autoyast_ext4.xml
+++ b/data/autoyast_sle12/autoyast_ext4.xml
@@ -61,6 +61,28 @@
       <use>all</use>
     </drive>
   </partitioning>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
   <software>
     <packages config:type="list">
       <package>glibc</package>

--- a/data/autoyast_sle12/autoyast_gnome.xml
+++ b/data/autoyast_sle12/autoyast_gnome.xml
@@ -6,6 +6,28 @@
       <confirm config:type="boolean">false</confirm>
     </mode>
   </general>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
   <keyboard>
     <keyboard_values>
       <delay/>

--- a/data/autoyast_sle12/autoyast_multipath.xml
+++ b/data/autoyast_sle12/autoyast_multipath.xml
@@ -25,6 +25,29 @@ pre init scripts feature. See poo#20818.
     </signature-handling>
   </general>
 
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>
   </deploy_image>

--- a/data/autoyast_sle12/autoyast_sdk.xml
+++ b/data/autoyast_sle12/autoyast_sdk.xml
@@ -14,6 +14,28 @@
       <confirm config:type="boolean">false</confirm>
     </mode>
   </general>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
   <keyboard>
     <keyboard_values>
       <delay/>

--- a/data/autoyast_sle12/autoyast_sdk_ha.xml
+++ b/data/autoyast_sle12/autoyast_sdk_ha.xml
@@ -18,6 +18,28 @@
       <confirm config:type="boolean">false</confirm>
     </mode>
   </general>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
   <keyboard>
     <keyboard_values>
       <delay/>

--- a/data/autoyast_sle12/bug-887653_autoinst_jy-snapshot.xml
+++ b/data/autoyast_sle12/bug-887653_autoinst_jy-snapshot.xml
@@ -89,22 +89,22 @@
     <errors>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">120</timeout>
+      <timeout config:type="integer">0</timeout>
     </errors>
     <messages>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">30</timeout>
+      <timeout config:type="integer">0</timeout>
     </messages>
     <warnings>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">30</timeout>
+      <timeout config:type="integer">0</timeout>
     </warnings>
     <yesno_messages>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">120</timeout>
+      <timeout config:type="integer">0</timeout>
     </yesno_messages>
   </report>
   <runlevel>

--- a/data/autoyast_sle15/autoyast_btrfs.xml
+++ b/data/autoyast_sle15/autoyast_btrfs.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-basesystem</product>
-        <product_dir>/Module-Basesystem</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-desktop-applications</product>
-        <product_dir>/Module-Desktop-Applications</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-server-applications</product>
-        <product_dir>/Module-Server-Applications</product_dir>
-      </listentry>
-    </add_on_products>
-  </add-on>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-desktop-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
   <general>
     <mode>
       <confirm config:type="boolean">false</confirm>

--- a/data/autoyast_sle15/autoyast_btrfs.xml
+++ b/data/autoyast_sle15/autoyast_btrfs.xml
@@ -43,7 +43,6 @@
   </language>
   <ntp-client>
     <ntp_policy>auto</ntp_policy>
-    <peers config:type="list"/>
   </ntp-client>
   <partitioning config:type="list">
     <drive>

--- a/data/autoyast_sle15/autoyast_btrfs.xml
+++ b/data/autoyast_sle15/autoyast_btrfs.xml
@@ -28,6 +28,28 @@
       <btrfs_set_default_subvolume_name config:type="boolean">false</btrfs_set_default_subvolume_name>
     </storage>
   </general>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
   <keyboard>
     <keyboard_values>
       <delay/>

--- a/data/autoyast_sle15/autoyast_error.xml
+++ b/data/autoyast_sle15/autoyast_error.xml
@@ -2,26 +2,30 @@
 <!DOCTYPE profile>
 <!-- the purpose of this autoyast file is to test the error dialog in stage 1 and 2     the errors are not fatal so the installation can continue after confirmation-->
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-desktop-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
   <add-on>
     <add_on_products config:type="list">
       <listentry>
         <media_url><![CDATA[dvd:///?devices=/dev/sr0]]></media_url>
         <product_dir>/</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-basesystem</product>
-        <product_dir>/Module-Basesystem</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-desktop-applications</product>
-        <product_dir>/Module-Desktop-Applications</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-server-applications</product>
-        <product_dir>/Module-Server-Applications</product_dir>
       </listentry>
     </add_on_products>
   </add-on>

--- a/data/autoyast_sle15/autoyast_eula.xml
+++ b/data/autoyast_sle15/autoyast_eula.xml
@@ -30,12 +30,34 @@
             </listentry>
         </add_on_products>
     </add-on>
+    <report>
+      <errors>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </errors>
+      <messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </messages>
+      <warnings>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </warnings>
+      <yesno_messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </yesno_messages>
+    </report>
     <networking>
         <keep_install_network config:type="boolean">true</keep_install_network>
     </networking>
     <users config:type="list">
         <user>
-            <fullname>Bernhard M. Wiedemann</fullname>  
+            <fullname>Bernhard M. Wiedemann</fullname>
             <encrypted config:type="boolean">false</encrypted>
             <user_password>nots3cr3t</user_password>
             <username>bernhard</username>

--- a/data/autoyast_sle15/autoyast_ext4.xml
+++ b/data/autoyast_sle15/autoyast_ext4.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-basesystem</product>
-        <product_dir>/Module-Basesystem</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-desktop-applications</product>
-        <product_dir>/Module-Desktop-Applications</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-server-applications</product>
-        <product_dir>/Module-Server-Applications</product_dir>
-      </listentry>
-    </add_on_products>
-  </add-on>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-desktop-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
   <general>
     <mode>
       <confirm config:type="boolean">false</confirm>

--- a/data/autoyast_sle15/autoyast_ext4.xml
+++ b/data/autoyast_sle15/autoyast_ext4.xml
@@ -40,7 +40,6 @@
   </language>
   <ntp-client>
     <ntp_policy>auto</ntp_policy>
-    <peers config:type="list"/>
   </ntp-client>
   <partitioning config:type="list">
     <drive>

--- a/data/autoyast_sle15/autoyast_ext4.xml
+++ b/data/autoyast_sle15/autoyast_ext4.xml
@@ -105,6 +105,28 @@
       <product>SLES15</product>
     </products>
   </software>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
   <networking>
     <interfaces config:type="list">
       <interface>

--- a/data/autoyast_sle15/autoyast_gnome.xml
+++ b/data/autoyast_sle15/autoyast_gnome.xml
@@ -40,7 +40,6 @@
   </language>
   <ntp-client>
     <ntp_policy>auto</ntp_policy>
-    <peers config:type="list"/>
   </ntp-client>
   <software>
     <packages config:type="list">

--- a/data/autoyast_sle15/autoyast_gnome.xml
+++ b/data/autoyast_sle15/autoyast_gnome.xml
@@ -25,6 +25,28 @@
       <confirm config:type="boolean">false</confirm>
     </mode>
   </general>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
   <keyboard>
     <keyboard_values>
       <delay/>

--- a/data/autoyast_sle15/autoyast_gnome.xml
+++ b/data/autoyast_sle15/autoyast_gnome.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-basesystem</product>
-        <product_dir>/Module-Basesystem</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-desktop-applications</product>
-        <product_dir>/Module-Desktop-Applications</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-server-applications</product>
-        <product_dir>/Module-Server-Applications</product_dir>
-      </listentry>
-    </add_on_products>
-  </add-on>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-desktop-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
   <general>
     <mode>
       <confirm config:type="boolean">false</confirm>

--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -44,6 +44,29 @@ pre init scripts feature. See poo#20818.
       <import_gpg_key config:type="boolean">true</import_gpg_key>
     </signature-handling>
   </general>
+  
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
 
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>

--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -5,26 +5,27 @@ Test suite is based on profile received from our beta customers.
 It contains multipath and profile is edited during runtime using
 pre init scripts feature. See poo#20818.
 -->
+<?xml version="1.0" encoding="UTF-8"?>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-basesystem</product>
-        <product_dir>/Module-Basesystem</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-desktop-applications</product>
-        <product_dir>/Module-Desktop-Applications</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-server-applications</product>
-        <product_dir>/Module-Server-Applications</product_dir>
-      </listentry>
-    </add_on_products>
-  </add-on>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-desktop-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
   <general>
     <mode>
       <confirm config:type="boolean">false</confirm>
@@ -47,10 +48,6 @@ pre init scripts feature. See poo#20818.
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>
   </deploy_image>
-
-  <suse_register>
-    <do_registration config:type="boolean">false</do_registration>
-  </suse_register>
 
   <ssh_import>
     <copy_config config:type="boolean">false</copy_config>

--- a/data/autoyast_sle15/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle15/bug-872532_ix64ph1069.xml
@@ -735,7 +735,6 @@
       <package>dconf</package>
       <package>girepository-1_0</package>
       <package>grub2-snapper-plugin</package>
-      <package>gsettings-backend-dconf</package>
       <package>gxditview</package>
       <package>libXaw7</package>
       <package>libXmu6</package>
@@ -744,7 +743,6 @@
       <package>libgirepository-1_0-1</package>
       <package>plymouth-dracut</package>
       <package>python-gobject</package>
-      <package>python-gobject-cairo</package>
       <package>snapper</package>
       <package>snapper-zypp-plugin</package>
       <package>ucode-intel</package>

--- a/data/autoyast_sle15/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle15/bug-872532_ix64ph1069.xml
@@ -1,25 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-basesystem</product>
-        <product_dir>/Module-Basesystem</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-desktop-applications</product>
-        <product_dir>/Module-Desktop-Applications</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-server-applications</product>
-        <product_dir>/Module-Server-Applications</product_dir>
-      </listentry>
-    </add_on_products>
-  </add-on>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
   <bootloader>
     <global>
       <append> ${extra_cmdline} splash=silent quiet showopts crashkernel=164M-:82M</append>
@@ -806,9 +801,6 @@
       <package>python3-base</package>
     </remove-packages>
   </software>
-  <suse_register>
-    <do_registration config:type="boolean">false</do_registration>
-  </suse_register>
   <timezone>
     <hwclock>UTC</hwclock>
     <timezone>Europe/Berlin</timezone>

--- a/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
@@ -1,35 +1,35 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-    <add-on>
-      <add_on_products config:type="list">
-        <listentry>
-          <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-          <product>sle-module-basesystem</product>
-          <product_dir>/Module-Basesystem</product_dir>
-        </listentry>
-        <listentry>
-          <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-          <product>sle-module-desktop-applications</product>
-          <product_dir>/Module-Desktop-Applications</product_dir>
-        </listentry>
-        <listentry>
-          <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-          <product>sle-module-server-applications</product>
-          <product_dir>/Module-Server-Applications</product_dir>
-        </listentry>
-      </add_on_products>
-    </add-on>
+    <suse_register>
+      <do_registration config:type="boolean">true</do_registration>
+      <email/>
+      <reg_code>{{SCC_REGCODE}}</reg_code>
+      <install_updates config:type="boolean">true</install_updates>
+      <reg_server>{{SCC_URL}}</reg_server>
+      <addons config:type="list">
+        <addon>
+          <name>sle-module-server-applications</name>
+          <version>{{VERSION}}</version>
+          <arch>{{ARCH}}</arch>
+        </addon>
+        <addon>
+          <name>sle-module-desktop-applications</name>
+          <version>{{VERSION}}</version>
+          <arch>{{ARCH}}</arch>
+        </addon>
+      </addons>
+    </suse_register>
     <scripts>
+      <chroot-scripts config:type="list">
+        <script>
+          <filename>3_chroot.sh</filename>
+          <interpreter>shell</interpreter>
+          <location/>
+          <feedback config:type="boolean">false</feedback>
+          <feedback_type>message</feedback_type>
 
-    <chroot-scripts config:type="list">
-      <script>
-        <filename>3_chroot.sh</filename>
-        <interpreter>shell</interpreter>
-        <location/>
-        <feedback config:type="boolean">false</feedback>
-    <feedback_type>message</feedback_type>
-        <source><![CDATA[#!/bin/sh
+          <source><![CDATA[#!/bin/sh
 tee YaST2-Second-Stage.service <<EOT
 [Unit]
 Description=YaST2 Second Stage
@@ -880,9 +880,6 @@ find / -name YaST2-Second-Stage.service
       <package>python3-base</package>
     </remove-packages>
   </software>
-  <suse_register>
-    <do_registration config:type="boolean">false</do_registration>
-  </suse_register>
   <timezone>
     <hwclock>UTC</hwclock>
     <timezone>Europe/Prague</timezone>

--- a/data/autoyast_sle15/bug-877438_ix64ph1029.xml
+++ b/data/autoyast_sle15/bug-877438_ix64ph1029.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-basesystem</product>
-        <product_dir>/Module-Basesystem</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-desktop-applications</product>
-        <product_dir>/Module-Desktop-Applications</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-server-applications</product>
-        <product_dir>/Module-Server-Applications</product_dir>
-      </listentry>
-    </add_on_products>
-  </add-on>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-desktop-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
   <software>
     <products config:type="list">
       <product>SLES15</product>
@@ -120,9 +120,6 @@
     <default_target>multi-user</default_target>
     <services config:type="list"/>
   </services-manager>
-  <suse_register>
-    <do_registration config:type="boolean">false</do_registration>
-  </suse_register>
   <timezone>
     <hwclock>UTC</hwclock>
     <timezone>Europe/Berlin</timezone>

--- a/data/autoyast_sle15/bug-879147_autoinst.xml
+++ b/data/autoyast_sle15/bug-879147_autoinst.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-    <add-on>
-      <add_on_products config:type="list">
-        <listentry>
-          <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-          <product>sle-module-basesystem</product>
-          <product_dir>/Module-Basesystem</product_dir>
-        </listentry>
-        <listentry>
-          <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-          <product>sle-module-desktop-applications</product>
-          <product_dir>/Module-Desktop-Applications</product_dir>
-        </listentry>
-        <listentry>
-          <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-          <product>sle-module-server-applications</product>
-          <product_dir>/Module-Server-Applications</product_dir>
-        </listentry>
-      </add_on_products>
-    </add-on>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-desktop-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
   <bootloader>
     <device_map config:type="list">
       <device_map_entry>
@@ -277,9 +277,6 @@
       <product>SLES15</product>
     </products>
   </software>
-  <suse_register>
-    <do_registration config:type="boolean">false</do_registration>
-  </suse_register>
   <timezone>
     <hwclock>UTC</hwclock>
     <timezone>Europe/Berlin</timezone>

--- a/data/autoyast_sle15/bug-879147_autoinst.xml
+++ b/data/autoyast_sle15/bug-879147_autoinst.xml
@@ -271,10 +271,6 @@
       <pattern>minimal_base</pattern>
       <pattern>x11</pattern>
     </patterns>
-    <packages config:type="list">
-      <!-- ntp package must be explicitly listed, see bsc#984146#c7 -->
-      <package>ntp</package>
-    </packages>
     <image/>
     <instsource/>
     <products config:type="list">

--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -1,25 +1,25 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-  <add-on>
-     <add_on_products config:type="list">
-        <listentry>
-          <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-          <product>sle-module-basesystem</product>
-          <product_dir>/Module-Basesystem</product_dir>
-        </listentry>
-        <listentry>
-          <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-          <product>sle-module-desktop-applications</product>
-          <product_dir>/Module-Desktop-Applications</product_dir>
-        </listentry>
-        <listentry>
-          <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-          <product>sle-module-server-applications</product>
-          <product_dir>/Module-Server-Applications</product_dir>
-      </listentry>
-    </add_on_products>
-  </add-on>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-desktop-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
   <bootloader>
     <global>
       <append> resume=/dev/sda1 splash=silent quiet crashkernel=176M-:88M  showopts</append>
@@ -546,9 +546,6 @@
       <product>SLES15</product>
     </products>
   </software>
-  <suse_register>
-    <do_registration config:type="boolean">false</do_registration>
-  </suse_register>
   <timezone>
     <hwclock>UTC</hwclock>
     <timezone>Europe/Berlin</timezone>

--- a/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
+++ b/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
@@ -107,22 +107,22 @@
     <errors>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">120</timeout>
+      <timeout config:type="integer">0</timeout>
     </errors>
     <messages>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">30</timeout>
+      <timeout config:type="integer">0</timeout>
     </messages>
     <warnings>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">30</timeout>
+      <timeout config:type="integer">0</timeout>
     </warnings>
     <yesno_messages>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">120</timeout>
+      <timeout config:type="integer">0</timeout>
     </yesno_messages>
   </report>
   <runlevel>

--- a/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
+++ b/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-basesystem</product>
-        <product_dir>/Module-Basesystem</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-desktop-applications</product>
-        <product_dir>/Module-Desktop-Applications</product_dir>
-      </listentry>
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-        <product>sle-module-server-applications</product>
-        <product_dir>/Module-Server-Applications</product_dir>
-      </listentry>
-    </add_on_products>
-  </add-on>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+      <addon>
+        <name>sle-module-desktop-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
   <firewall>
     <enable_firewall config:type="boolean">false</enable_firewall>
     <start_firewall config:type="boolean">false</start_firewall>

--- a/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
+++ b/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
@@ -64,17 +64,15 @@
     </interfaces>
   </networking>
   <ntp-client>
-    <configure_dhcp config:type="boolean">false</configure_dhcp>
-    <peers config:type="list">
-      <peer>
-        <address>pool.ntp.org</address>
-        <initial_sync config:type="boolean">true</initial_sync>
-        <options/>
-        <type>server</type>
-      </peer>
-    </peers>
-    <start_at_boot config:type="boolean">true</start_at_boot>
-    <start_in_chroot config:type="boolean">true</start_in_chroot>
+    <ntp_policy>auto</ntp_policy>
+    <ntp_servers config:type="list">
+      <ntp_server>
+        <iburst config:type="boolean">false</iburst>
+        <address>cz.pool.ntp.org</address>
+        <offline config:type="boolean">true</offline>
+      </ntp_server>
+    </ntp_servers>
+    <ntp_sync>15</ntp_sync>
   </ntp-client>
   <partitioning config:type="list">
     <drive>

--- a/data/autoyast_sle15/mini.xml
+++ b/data/autoyast_sle15/mini.xml
@@ -2,15 +2,20 @@
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
     <!-- very minimal autoyast profile -->
-    <add-on>
-      <add_on_products config:type="list">
-        <listentry>
-          <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
-          <product>sle-module-basesystem</product>
-          <product_dir>/Module-Basesystem</product_dir>
-        </listentry>
-      </add_on_products>
-    </add-on>
+    <suse_register>
+      <do_registration config:type="boolean">true</do_registration>
+      <email/>
+      <reg_code>{{SCC_REGCODE}}</reg_code>
+      <install_updates config:type="boolean">true</install_updates>
+      <reg_server>{{SCC_URL}}</reg_server>
+      <addons config:type="list">
+        <addon>
+          <name>sle-module-basesystem</name>
+          <version>{{VERSION}}</version>
+          <arch>{{ARCH}}</arch>
+        </addon>
+      </addons>
+    </suse_register>
     <networking>
         <keep_install_network config:type="boolean">true</keep_install_network>
     </networking>

--- a/data/autoyast_sle15/mini.xml
+++ b/data/autoyast_sle15/mini.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-    <!-- very minimal autoyast profile -->
+    <!-- minimal autoyast profile -->
     <suse_register>
       <do_registration config:type="boolean">true</do_registration>
       <email/>
@@ -37,4 +37,26 @@
             <username>root</username>
         </user>
     </users>
+    <report>
+      <errors>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </errors>
+      <messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </messages>
+      <warnings>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </warnings>
+      <yesno_messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </yesno_messages>
+    </report>
 </profile>

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1500,6 +1500,7 @@ else {
             load_patching_tests();
         }
         else {
+            loadtest "autoyast/prepare_profile" if get_var "AUTOYAST_PREPARE_PROFILE";
             load_boot_tests();
         }
         load_autoyast_tests();

--- a/tests/autoyast/prepare_profile.pm
+++ b/tests/autoyast/prepare_profile.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Expand variables in the autoyast profiles and make it accessible for SUT
+#
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
+
+use strict;
+use base "opensusebasetest";
+use testapi;
+
+sub run {
+    my $path = get_required_var('AUTOYAST');
+    # Get file from data directory
+    my $profile = get_test_data($path);
+    # Return if profile is not available
+    return unless $profile;
+
+    # Expand variables
+    my @vars = qw(SCC_REGCODE SCC_URL VERSION ARCH);
+    foreach (@vars) {
+        my $value = get_var($_);
+        # Skip if value is not defined
+        next unless $value;
+        $profile =~ s/\{\{$_\}\}/$value/g;
+    }
+    # Upload modified profile
+    save_tmp_file($path, $profile);
+    # Set AUTOYAST variable with new url
+    my $url = autoinst_url . "/files/$path";
+    set_var('AUTOYAST', $url);
+}
+
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+
+# vim: set sw=4 et:


### PR DESCRIPTION
For SLE15 default scenario is to register system and activate
repositories provided by SCC. Hence, we should use this as default for
autoyast installations as well. For obvious reasons we cannot put reg
code in the public github repo, so we have introduced mechanism for
variable expansion, which doesn't require support server.

Workers require upgrade in order to use this feature. To be on safe side
and not to break other autoyast installations, profile modification is
performed when AUTOYAST_PREPARE_PROFILE variable is set. Consequently,
test suites will have to have this variable, and ISO_1 can be removed
for most of them.

See [poo#28349](https://progress.opensuse.org/issues/28349).

This PR additionally contains fixes for ntp and removes timeouts for errors and warning messages to process them properly. All verification runs are basically the same, and many fail due to existing bugs.
What is important - proof that this flow works and profiles are properly modified, as without expanded variables installation will fail.

NOTE: Please, do NOT merge before workers upgrade on osd.

Verification runs:
* http://g226.suse.de/tests/214
* http://g226.suse.de/tests/220
* http://g226.suse.de/tests/221
* http://g226.suse.de/tests/222
* http://g226.suse.de/tests/223
* http://g226.suse.de/tests/224
* http://g226.suse.de/tests/225
* http://g226.suse.de/tests/226
* http://g226.suse.de/tests/227
* http://g226.suse.de/tests/228
