### PR TITLE
Increase sleep from 5s to 10s to avoid desktop_mainmenu fails.

### DIFF
--- a/tests/x11/desktop_mainmenu.pm
+++ b/tests/x11/desktop_mainmenu.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,7 +18,8 @@ use testapi;
 
 
 sub run {
-    sleep 5;
+    # some desktops need some time to accept user input
+    sleep 10;
     if (check_var("DESKTOP", "lxde")) {
         # or Super_L or Windows key
         x11_start_program('lxpanelctl menu', target_match => 'test-desktop_mainmenu-1');


### PR DESCRIPTION
Increase sleep from 5s to 10s to avoid desktop_mainmenu fails.

Follow-up to 28ac756, 75992512c854ebaddf763e08a88057abec0f9702
Fixes: https://openqa.opensuse.org/tests/578763#step/desktop_mainmenu/2
Fixes: https://progress.opensuse.org/issues/30079