### PR TITLE
Add zypper patch support for sles11 before migration

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -440,7 +440,7 @@ sub wait_boot {
         handle_emergency if (match_has_tag('emergency-shell') or match_has_tag('emergency-mode'));
 
         if (!$nologin) {
-            if (get_var('DM_NEEDS_USERNAME')) {
+            if (get_var('DM_NEEDS_USERNAME') || check_var('VERSION', '11-SP4')) {
                 type_string "$username\n";
             }
             # log in

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -957,7 +957,13 @@ sub ensure_serialdev_permissions {
     # ownership has effect immediately, group change is for effect after
     # reboot an alternative https://superuser.com/a/609141/327890 would need
     # handling of optional sudo password prompt within the exec
-    assert_script_run "chown $testapi::username /dev/$testapi::serialdev && gpasswd -a $testapi::username \$(stat -c %G /dev/$testapi::serialdev)";
+    # Need backwards support for SLES11-SP4 here, the command "gpasswd" and "stat" are only available with SLES-12 at least.
+    if (is_sle && check_var('VERSION', '11-SP4')) {
+        assert_script_run "chown $username /dev/$serialdev";
+    }
+    else {
+        assert_script_run "chown $testapi::username /dev/$testapi::serialdev && gpasswd -a $testapi::username \$(stat -c %G /dev/$testapi::serialdev)";
+    }
 }
 
 1;

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -137,8 +137,12 @@ sub sle_version_at_least {
     my ($version, %args) = @_;
     my $version_variable = $args{version_variable} // 'VERSION';
 
+    if ($version eq '12') {
+        return !check_var($version_variable, '11-SP4');
+    }
+
     if ($version eq '12-SP1') {
-        return !check_var($version_variable, '12');
+        return sle_version_at_least('12', version_variable => $version_variable) && !check_var($version_variable, '12');
     }
 
     if ($version eq '12-SP2') {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -104,6 +104,9 @@ sub cleanup_needles {
     if ((get_var('VERSION', '') ne '12-SP3') && (get_var('BASE_VERSION', '') ne '12-SP3')) {
         unregister_needle_tags("ENV-VERSION-12-SP3");
     }
+    if ((get_var('VERSION', '') ne '11-SP4') && (get_var('BASE_VERSION', '') ne '11-SP4')) {
+        unregister_needle_tags("ENV-VERSION-11-SP4");
+    }
 
     my $tounregister = sle_version_at_least('12-SP2') ? '0' : '1';
     unregister_needle_tags("ENV-SP2ORLATER-$tounregister");

--- a/tests/update/patch_before_migration.pm
+++ b/tests/update/patch_before_migration.pm
@@ -33,7 +33,7 @@ sub patching_sle {
 
     assert_script_run("zypper lr && zypper mr --disable --all");
     save_screenshot;
-    yast_scc_registration();
+    sle_register("register");
     assert_script_run('zypper lr -d');
 
     # install all patterns
@@ -66,7 +66,7 @@ sub patching_sle {
 
     }
     else {
-        scc_deregistration(version_variable => 'HDDVERSION');
+        sle_register("unregister");
     }
     remove_ltss;
     assert_script_run("zypper mr --enable --all");
@@ -125,6 +125,32 @@ sub install_patterns {
         zypper_call "in -t pattern $pt";
     }
 }
+
+sub sle_register {
+    my ($action) = @_;
+    # Register sle before update
+    if ($action eq 'register') {
+        if (sle_version_at_least('12')) {
+            yast_scc_registration();
+        }
+        else {
+            my $reg_code = get_required_var("NCC_REGCODE");
+            my $reg_mail = get_required_var("NCC_MAIL");
+            assert_script_run('suse_register -e');
+            assert_script_run("suse_register -n -a email=$reg_mail -a regcode-sles=$reg_code", 300);
+        }
+    }
+    # Unregister sle after update
+    if ($action eq 'unregister') {
+        if (sle_version_at_least('12')) {
+            scc_deregistration(version_variable => 'HDDVERSION');
+        }
+        else {
+            assert_script_run('suse_register -E');
+        }
+    }
+}
+
 
 sub run {
     my ($self) = @_;


### PR DESCRIPTION
Add zypper update support for sles11 before migration
Update reboot steps for sles11 in reboot_and_install.pm
Add tty switch support for sles11 after zypper patch

- See Poo#29095 [sle][migration][sle15] Migrate from 11 -> 15


- Related ticket: https://progress.opensuse.org/issues/29095
- Verification run: http://10.67.17.147/tests/2065
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/637