### PR TITLE
Adjust order of tests to temparay fix poo#30159

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -714,16 +714,16 @@ sub load_x11regression_documentation {
     loadtest "x11regressions/gedit/gedit_launch";
     loadtest "x11regressions/gedit/gedit_save";
     loadtest "x11regressions/gedit/gedit_about";
+    loadtest "x11regressions/libreoffice/libreoffice_mainmenu_components";
+    loadtest "x11regressions/libreoffice/libreoffice_recent_documents";
+    loadtest "x11regressions/libreoffice/libreoffice_default_theme";
+    loadtest "x11regressions/libreoffice/libreoffice_double_click_file";
     if (sle_version_at_least('12-SP1')) {
         loadtest "x11regressions/libreoffice/libreoffice_mainmenu_favorites";
         loadtest "x11regressions/evolution/evolution_prepare_servers";
         loadtest "x11regressions/libreoffice/libreoffice_pyuno_bridge";
     }
-    loadtest "x11regressions/libreoffice/libreoffice_mainmenu_components";
-    loadtest "x11regressions/libreoffice/libreoffice_recent_documents";
-    loadtest "x11regressions/libreoffice/libreoffice_default_theme";
     loadtest "x11regressions/libreoffice/libreoffice_open_specified_file";
-    loadtest "x11regressions/libreoffice/libreoffice_double_click_file";
 }
 
 sub load_x11regression_gnome {


### PR DESCRIPTION
Since the evolution_prepare_servers, libreoffice_pyuno_bridge
and libreoffice_open_specified_file are not ready for SLED15.

Adjust the test case run order so that the failure of
evolution_prepare_servers won't block the following.

- Related ticket: https://progress.opensuse.org/issues/30159
