### PR TITLE
Add autoupgrade test for sle15

### DIFF
--- a/data/autoyast_sle15/autoyast_media_up_gnome.xml
+++ b/data/autoyast_sle15/autoyast_media_up_gnome.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+        <product>sle-module-basesystem</product>
+        <product_dir>/Module-Basesystem</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+        <product>sle-module-desktop-applications</product>
+        <product_dir>/Module-Desktop-Applications</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+        <product>sle-module-server-applications</product>
+        <product_dir>/Module-Server-Applications</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+        <product>sle-module-legacy</product>
+        <product_dir>/Module-Legacy</product_dir>
+      </listentry>
+    </add_on_products>
+  </add-on>
+  <bootloader>
+    <global>
+      <activate>false</activate>
+      <boot_extended>false</boot_extended>
+      <boot_mbr>true</boot_mbr>
+      <boot_root>true</boot_root>
+      <generic_mbr>false</generic_mbr>
+      <timeout config:type="integer">5</timeout>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <second_stage config:type="boolean">false</second_stage>
+    </mode>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">false</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+  </general>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages>en_US</languages>
+  </language>
+  <report>
+    <errors>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <warnings>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <messages>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <yesno_messages>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <software>
+    <products config:type="list">
+        <product>SLES15</product>
+    </products>
+  </software>
+  <upgrade>
+    <only_installed_packages config:type="boolean">false</only_installed_packages>
+    <stop_on_solver_conflict config:type="boolean">true</stop_on_solver_conflict>
+  </upgrade>
+</profile>

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -188,6 +188,7 @@ sub load_zdup_tests {
     }
     loadtest 'installation/zdup';
     loadtest 'installation/post_zdup';
+    loadtest "migration/version_switch_upgrade_target";
     loadtest 'boot/boot_to_desktop';
 }
 

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -30,6 +30,7 @@ our @EXPORT = qw (
   is_sle
   is_tumbleweed
   is_storage_ng
+  is_upgrade
   is_sle12_hdd_in_upgrade
   is_installcheck
   is_rescuesystem
@@ -118,8 +119,12 @@ sub is_storage_ng {
     return get_var('STORAGE_NG');
 }
 
+sub is_upgrade {
+    return get_var('UPGRADE') || get_var('ONLINE_MIGRATION') || get_var('ZDUP') || get_var('AUTOUPGRADE');
+}
+
 sub is_sle12_hdd_in_upgrade {
-    return get_var('UPGRADE') && !sle_version_at_least('15', version_variable => 'HDDVERSION');
+    return is_upgrade && !sle_version_at_least('15', version_variable => 'HDDVERSION');
 }
 
 sub sle_version_at_least {
@@ -195,5 +200,5 @@ sub is_desktop_installed {
 
 sub is_system_upgrading {
     # If PATCH=1, make sure patch action is finished
-    return get_var('UPGRADE') && (!get_var('PATCH') || (get_var('PATCH') && get_var('SYSTEM_PATCHED')));
+    return is_upgrade && (!get_var('PATCH') || (get_var('PATCH') && get_var('SYSTEM_PATCHED')));
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -14,7 +14,7 @@ use lockapi;
 use needle;
 use registration;
 use utils;
-use version_utils qw(is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem sle_version_at_least is_desktop_installed is_jeos is_sle);
+use version_utils qw(is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem sle_version_at_least is_desktop_installed is_jeos is_sle is_upgrade);
 use File::Find;
 use File::Basename;
 use LWP::Simple 'head';
@@ -1099,15 +1099,31 @@ sub load_patching_tests {
             loadtest "installation/bootloader_zkvm";
         }
     }
+    # Switch to orginal system version for upgrade tests
+    if (is_upgrade) {
+        # Save HDDVERSION to ORIGIN_SYSTEM_VERSION
+        set_var('ORIGIN_SYSTEM_VERSION', get_var('HDDVERSION'));
+        # Save VERSION to UPGRADE_TARGET_VERSION
+        set_var('UPGRADE_TARGET_VERSION', get_var('VERSION'));
+        loadtest "migration/version_switch_origin_system";
+    }
     loadtest 'boot/boot_to_desktop';
     loadtest 'update/patch_before_migration';
-    # Lock package for offline migration by Yast installer
-    if (get_var('LOCK_PACKAGE') && !installzdupstep_is_applicable) {
-        loadtest 'console/lock_package';
+    if (is_upgrade) {
+        # Lock package for offline migration by Yast installer
+        if (get_var('LOCK_PACKAGE') && !installzdupstep_is_applicable) {
+            loadtest 'console/lock_package';
+        }
+        # Reboot from DVD and perform upgrade
+        loadtest 'console/consoletest_finish';
+        loadtest 'x11/reboot_and_install';
+        # After original system patched, switch to UPGRADE_TARGET_VERSION
+        # For ZDUP upgrade, version switch back later
+        if (get_var('UPGRADE') || get_var('AUTOUPGRADE')) {
+            loadtest "migration/version_switch_upgrade_target";
+        }
+        loadtest 'installation/bootloader_zkvm' if get_var('S390_ZKVM');
     }
-    loadtest 'console/consoletest_finish';
-    loadtest 'x11/reboot_and_install';
-    loadtest 'installation/bootloader_zkvm' if get_var('S390_ZKVM');
 }
 
 sub load_sles4sap_tests {
@@ -1517,12 +1533,13 @@ else {
         load_boot_tests();
         load_online_migration_tests();
     }
-    elsif (get_var("PATCH")) {
-        #Before upgrading, orginal system version is actually HDDVERSION
-        loadtest "migration/version_switch_origin_system";
-        load_patching_tests();
-        #After original system patched, switch to UPGRADE_TARGET_VERSION
-        loadtest "migration/version_switch_upgrade_target";
+    elsif (get_var("UPGRADE")) {
+        if (get_var('PATCH')) {
+            load_patching_tests();
+        }
+        else {
+            load_boot_tests();
+        }
         load_inst_tests();
         load_reboot_tests();
     }

--- a/tests/migration/version_switch_origin_system.pm
+++ b/tests/migration/version_switch_origin_system.pm
@@ -7,9 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-# Summary: Changes the VERSION to HDDVERSION and reload needles.
-#       At the beginning of upgrading, we need patch the original
-#       system, which is still old version at the moment.
+# Summary: Change the VERSION to ORIGIN_SYSTEM_VERSION and also
+#       reload needles.
+#       At the beginning of upgrade, we need patch the original
+#       system on hdd, which is still old version at the moment.
 # Maintainer: Qingming Su <qmsu@suse.com>
 
 use base "opensusebasetest";
@@ -18,13 +19,15 @@ use warnings;
 use testapi;
 
 sub run {
-    return unless get_var('UPGRADE');
+    # Before upgrade or after rollback, switch to original system version
+    # Do NOT use HDDVERSION because it might be changed in another test
+    # module, such as: reboot_and_install.pm
+    my $original_version = get_required_var('ORIGIN_SYSTEM_VERSION');
 
-    #Before upgrading, orginal system version is actually HDDVERSION
-    #Save VERSION TO UPGRADE_TARGET_VERSION
-    set_var('UPGRADE_TARGET_VERSION', get_var('VERSION'));
-    #Switch to orginal system version, which is HDDVERSION
-    set_var('VERSION', get_required_var('HDDVERSION'), reload_needles => 1);
+    if (get_var('VERSION') ne $original_version) {
+        # Switch to original system version and reload needles
+        set_var('VERSION', $original_version, reload_needles => 1);
+    }
 }
 
 1;

--- a/tests/migration/version_switch_upgrade_target.pm
+++ b/tests/migration/version_switch_upgrade_target.pm
@@ -19,11 +19,13 @@ use warnings;
 use testapi;
 
 sub run {
-    return unless get_var('UPGRADE');
+    # After being patched, original system is ready for upgrade
+    my $upgrade_target_version = get_required_var('UPGRADE_TARGET_VERSION');
 
-    #After being patched, orginal system is ready for upgrade
-    #Switch VERSION to UPGRADE_TARGET_VERSION
-    set_var('VERSION', get_required_var('UPGRADE_TARGET_VERSION'), reload_needles => 1);
+    if (get_var('VERSION') ne $upgrade_target_version) {
+        # Switch to upgrade target version and reload needles
+        set_var('VERSION', $upgrade_target_version, reload_needles => 1);
+    }
 }
 
 1;


### PR DESCRIPTION
Adopt version switch in autoupgrade and zdup tests by 
moving version switch modules into load_patching_tests and
load_zdup_tests functions to make the version switching
applicable for all kinds of upgrading tests, not only offline
upgrade, but also autoupgrade and zdup.

- Related ticket: https://progress.opensuse.org/issues/30056
- Needles: N/A
- Verification run: 
   * [upgrade] http://openqa-apac1.suse.de/tests/98
   * [autoupgrade] http://openqa-apac1.suse.de/tests/97
   * [zdup] http://openqa-apac1.suse.de/tests/99