### PR TITLE
Adopt version switch in snapper rollback tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -632,6 +632,7 @@ sub load_extra_tests {
 
 sub load_rollback_tests {
     loadtest "boot/grub_test_snapshot";
+    loadtest "migration/version_switch_origin_system";
     if (get_var('UPGRADE') || get_var('ZDUP')) {
         loadtest "boot/snapper_rollback";
     }


### PR DESCRIPTION
Before doing snapper rollback, we need switch back to the
original version which is before system being upgraded.
Otherwise it might be failed to select tty console, for
example, on SLE15 X is changed to tty2.
Refer to poo#30150 for details

- Related ticket: https://progress.opensuse.org/issues/30150
- Needles: N/A
- Verification run: http://10.67.18.143/tests/113