### PR TITLE
lib/utils: Fix handle_login() for ROOTONLY=1 cases

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -753,20 +753,21 @@ sub handle_login {
         }
         type_string "root\n";
     }
+    elsif (get_var('DM_NEEDS_USERNAME')) {
+        type_string "$username\n";
+    }
+    elsif (check_var('DESKTOP', 'gnome') || (check_var('DESKTOP', 'lxde') && check_var('VERSION', '42.1'))) {
+        # DMs in condition above have to select user
+        if ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0')) || is_tumbleweed) {
+            assert_and_click "displaymanager-$username";
+            record_soft_failure 'bgo#657996 - user account not selected by default, have to use mouse to login';
+        }
+        else {
+            send_key 'ret';
+        }
+    }
     else {
-        if (get_var('DM_NEEDS_USERNAME')) {
-            type_string "$username\n";
-        }
-        if (check_var('DESKTOP', 'gnome') || (check_var('DESKTOP', 'lxde') && check_var('VERSION', '42.1'))) {
-            # DMs in condition above have to select user
-            if ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0')) || is_tumbleweed) {
-                assert_and_click "displaymanager-$username";
-                record_soft_failure 'bgo#657996 - user account not selected by default, have to use mouse to login';
-            }
-            else {
-                send_key 'ret';
-            }
-        }
+        send_key 'ret';
     }
     assert_screen 'displaymanager-password-prompt', no_wait => 1;
     type_password;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -753,17 +753,19 @@ sub handle_login {
         }
         type_string "root\n";
     }
-    if (get_var('DM_NEEDS_USERNAME') and !get_var('ROOTONLY')) {
-        type_string "$username\n";
-    }
-    if (check_var('DESKTOP', 'gnome') || (check_var('DESKTOP', 'lxde') && check_var('VERSION', '42.1'))) {
-        # DMs in condition above have to select user
-        if ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0')) || is_tumbleweed) {
-            assert_and_click "displaymanager-$username";
-            record_soft_failure 'bgo#657996 - user account not selected by default, have to use mouse to login';
+    else {
+        if (get_var('DM_NEEDS_USERNAME')) {
+            type_string "$username\n";
         }
-        else {
-            send_key 'ret';
+        if (check_var('DESKTOP', 'gnome') || (check_var('DESKTOP', 'lxde') && check_var('VERSION', '42.1'))) {
+            # DMs in condition above have to select user
+            if ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0')) || is_tumbleweed) {
+                assert_and_click "displaymanager-$username";
+                record_soft_failure 'bgo#657996 - user account not selected by default, have to use mouse to login';
+            }
+            else {
+                send_key 'ret';
+            }
         }
     }
     assert_screen 'displaymanager-password-prompt', no_wait => 1;


### PR DESCRIPTION
This PR fixes the handle_login() method so it can be used on tests with ROOTONLY=1, DM_NEEDS_USERNAME=1 and DESKTOP=textmode on SLES/SLES4SAP.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/180
