### PR TITLE
Add test suite to test encrypted partitions without lvm

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -15,8 +15,9 @@ use Exporter;
 use strict;
 use testapi;
 use version_utils 'is_storage_ng';
+use installation_user_settings 'await_password_check';
 
-our @EXPORT = qw(wipe_existing_partitions addpart addlv unselect_xen_pv_cdrom);
+our @EXPORT = qw(wipe_existing_partitions addpart addlv unselect_xen_pv_cdrom enable_encryption_guided_setup);
 
 my %role = qw(
   OS alt-o
@@ -169,6 +170,20 @@ sub unselect_xen_pv_cdrom {
         assert_screen 'select-hard-disk';
         send_key 'alt-e';
         send_key $cmd{next};
+    }
+}
+
+# Enables encryption in guided setup during installation
+sub enable_encryption_guided_setup {
+    my $self = shift;
+    send_key $cmd{encryptdisk};
+    if (!get_var('ENCRYPT_ACTIVATE_EXISTING')) {
+        assert_screen 'inst-encrypt-password-prompt';
+        type_password;
+        send_key 'tab';
+        type_password;
+        send_key $cmd{next};
+        installation_user_settings::await_password_check;
     }
 }
 

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -72,7 +72,7 @@ sub init_cmd {
       package p
       bootloader b
       entiredisk alt-e
-      guidedsetup alt-g
+      guidedsetup alt-d
       rescandevices alt-e
       exp_part_finish alt-f
       size_hotkey alt-s

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -236,6 +236,9 @@ sub load_inst_tests {
         if (defined(get_var("RAIDLEVEL"))) {
             loadtest "installation/partitioning_raid";
         }
+        elsif (check_var('LVM', 0) && get_var('ENCRYPT')) {
+            loadtest 'installation/partitioning_crypt_no_lvm';
+        }
         elsif (get_var("LVM")) {
             loadtest "installation/partitioning_lvm";
         }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -610,6 +610,9 @@ sub load_inst_tests {
         if (defined(get_var("RAIDLEVEL"))) {
             loadtest "installation/partitioning_raid";
         }
+        elsif (check_var('LVM', 0) && get_var('ENCRYPT')) {
+            loadtest 'installation/partitioning_crypt_no_lvm';
+        }
         elsif (get_var("LVM")) {
             loadtest "installation/partitioning_lvm";
         }

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -29,6 +29,7 @@ sub run {
         $cmd{addraid}         = 'alt-i';
         $cmd{filesystem}      = 'alt-a';
         $cmd{exp_part_finish} = 'alt-n';
+        $cmd{guidedsetup}     = 'alt-g';
         if (check_var('DISTRI', 'opensuse')) {
             $cmd{expertpartitioner} = 'alt-x';
             $cmd{rescandevices}     = 'alt-c';

--- a/tests/installation/partitioning_crypt_no_lvm.pm
+++ b/tests/installation/partitioning_crypt_no_lvm.pm
@@ -1,0 +1,42 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test installation with encrypted drive, but without lvm
+# This is possible only with storage-ng.
+#
+# Tags: poo#26810, fate#320182
+#
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
+
+use strict;
+use base "opensusebasetest";
+use testapi;
+use version_utils 'is_storage_ng';
+use partition_setup 'enable_encryption_guided_setup';
+
+sub run {
+    die "Encrypting without lvm is only possible with storage_ng" unless is_storage_ng;
+
+    send_key $cmd{guidedsetup};    # select guided setup
+    assert_screen 'inst-partitioning-scheme';
+
+    # Enable encryption
+    enable_encryption_guided_setup;
+    # Verify filesystem
+    assert_screen 'inst-filesystem-options';
+    # btrfs should be selected by default
+    assert_screen 'btrfs-selected';
+    send_key $cmd{next};
+
+    assert_screen 'inst-encrypt-no-lvm';
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/tests/installation/partitioning_lvm.pm
+++ b/tests/installation/partitioning_lvm.pm
@@ -17,6 +17,7 @@ use warnings;
 use parent qw(installation_user_settings y2logsstep);
 use testapi;
 use version_utils qw(sle_version_at_least is_storage_ng leap_version_at_least);
+use partition_setup 'enable_encryption_guided_setup';
 
 sub save_logs_and_resume {
     my $self = shift;
@@ -57,12 +58,7 @@ sub run {
 
     # Storage NG introduces a new partitioning dialog. partitioning.pm detects this by the existence of the "Guided Setup" button
     # and sets the STORAGE_NG variable. This button uses a new hotkey.
-    if (is_storage_ng) {
-        send_key "alt-g";
-    }
-    else {
-        send_key "alt-d";
-    }
+    send_key $cmd{guidedsetup};
 
     my $numdisks = get_var("NUMDISKS");
     print "NUMDISKS = $numdisks\n";
@@ -107,18 +103,10 @@ sub run {
         send_key $cmd{enablelvm};
         assert_screen "inst-partitioning-lvm-enabled";
         if (get_var("ENCRYPT")) {
-            send_key $cmd{encryptdisk};
-            if (!get_var('ENCRYPT_ACTIVATE_EXISTING')) {
-                assert_screen 'inst-encrypt-password-prompt';
-                type_password;
-                send_key 'tab';
-                type_password;
-                send_key 'alt-n';
-                $self->await_password_check;
-            }
+            enable_encryption_guided_setup;
         }
         else {
-            send_key 'alt-n';
+            send_key $cmd{next};
         }
         assert_screen "inst-filesystem-options";
         send_key 'alt-n';


### PR DESCRIPTION
New test suite for storage ng to encrypt partitions without lvm.
Can be enabled by setting LVM=0 and ENCRYPT=1.

See [poo#26810](https://progress.opensuse.org/issues/26810).

- Needles: 
  * [SLE15](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/638)
  * [Leap15](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/304)
- Verification run: 
  * [SLE15](http://g226.suse.de/tests/240#)
  * [Leap15](http://g226.suse.de/tests/255#)

