### PR TITLE
hpc: Unify setup of static network

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1469,6 +1469,7 @@ elsif (get_var('HPC')) {
     }
     else {
         loadtest 'boot/boot_to_desktop';
+        loadtest 'hpc/setup_network' if check_var('NICTYPE', 'tap');
         loadtest 'hpc/enable_in_zypper' if (sle_version_at_least('15'));
         if (check_var('HPC', 'conman')) {
             loadtest 'hpc/conman';

--- a/tests/hpc/mrsh_master.pm
+++ b/tests/hpc/mrsh_master.pm
@@ -28,14 +28,8 @@ sub run {
     barrier_create("SLAVE_MRLOGIN_STARTED",      2);
     barrier_create("MRSH_MASTER_DONE",           2);
 
-    select_console 'root-console';
-    $self->setup_static_network(get_required_var('HPC_HOST_IP'));
-
     # set proper hostname
     assert_script_run "hostnamectl set-hostname mrsh-master";
-
-    # stop firewall
-    $self->stop_firewall();
 
     # install mrsh
     zypper_call('in mrsh mrsh-server');

--- a/tests/hpc/mrsh_slave.pm
+++ b/tests/hpc/mrsh_slave.pm
@@ -21,11 +21,6 @@ use utils;
 
 sub run {
     my $self = shift;
-    select_console 'root-console';
-    $self->setup_static_network(get_required_var('HPC_HOST_IP'));
-
-    # stop firewall, so key can be copied
-    $self->stop_firewall();
 
     # set proper hostname
     assert_script_run "hostnamectl set-hostname mrsh-slave";

--- a/tests/hpc/munge_master.pm
+++ b/tests/hpc/munge_master.pm
@@ -24,10 +24,6 @@ sub run {
     barrier_create("MUNGE_INSTALLATION_FINISHED", 2);
     barrier_create("MUNGE_SERVICE_ENABLED",       2);
 
-    select_console 'root-console';
-
-    $self->setup_static_network(get_required_var('HPC_HOST_IP'));
-
     # set proper hostname
     assert_script_run('hostnamectl set-hostname munge-master');
 

--- a/tests/hpc/munge_slave.pm
+++ b/tests/hpc/munge_slave.pm
@@ -20,12 +20,6 @@ use utils;
 
 sub run {
     my $self = shift;
-    select_console 'root-console';
-
-    $self->setup_static_network(get_required_var('HPC_HOST_IP'));
-
-    # stop firewall, so key can be copied
-    $self->stop_firewall();
 
     # set proper hostname
     assert_script_run('hostnamectl set-hostname munge-slave');

--- a/tests/hpc/pdsh_master.pm
+++ b/tests/hpc/pdsh_master.pm
@@ -27,14 +27,8 @@ sub run {
     barrier_create("PDSH_MUNGE_ENABLED",         2);
     barrier_create("PDSH_SLAVE_DONE",            2);
 
-    select_console 'root-console';
-    $self->setup_static_network(get_required_var('HPC_HOST_IP'));
-
     # set proper hostname
     assert_script_run "hostnamectl set-hostname pdsh-master";
-
-    # stop firewall
-    $self->stop_firewall();
 
     # install mrsh
     zypper_call('in mrsh-server munge');

--- a/tests/hpc/pdsh_slave.pm
+++ b/tests/hpc/pdsh_slave.pm
@@ -23,12 +23,6 @@ sub run {
     my $self      = shift;
     my $master_ip = get_required_var('HPC_MASTER_IP');
 
-    select_console 'root-console';
-    $self->setup_static_network(get_required_var('HPC_HOST_IP'));
-
-    # stop firewall, so key can be copied
-    $self->stop_firewall();
-
     # set proper hostname
     assert_script_run "hostnamectl set-hostname pdsh-slave";
 

--- a/tests/hpc/setup_network.pm
+++ b/tests/hpc/setup_network.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: HPC helper module which sets up static network needed by HPC multimachine tests
+# Maintainer: soulofdestiny <mgriessmeier@suse.com>
+
+use base "hpcbase";
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+
+    select_console 'root-console';
+    $self->setup_static_network(get_required_var('HPC_HOST_IP'));
+
+    # stop firewall, so key can be copied
+    $self->stop_firewall();
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -25,12 +25,6 @@ sub run {
     barrier_create("SLURM_MASTER_SERVICE_ENABLED", 2);
     barrier_create("SLURM_SLAVE_SERVICE_ENABLED",  2);
 
-    select_console 'root-console';
-    $self->setup_static_network(get_required_var('HPC_HOST_IP'));
-
-    # stop firewall
-    $self->stop_firewall();
-
     # set proper hostname
     assert_script_run "hostnamectl set-hostname slurm-master";
 

--- a/tests/hpc/slurm_slave.pm
+++ b/tests/hpc/slurm_slave.pm
@@ -23,12 +23,6 @@ sub run {
     my ($host_ip_without_netmask) = get_required_var('HPC_HOST_IP') =~ /(.*)\/.*/;
     my $master_ip                 = get_required_var('HPC_MASTER_IP');
 
-    select_console 'root-console';
-    $self->setup_static_network(get_required_var('HPC_HOST_IP'));
-
-    # stop firewall, so key can be copied
-    $self->stop_firewall();
-
     # set proper hostname
     assert_script_run "hostnamectl set-hostname slurm-slave";
 


### PR DESCRIPTION
for sle15 we add the HPC repo through zypper for now
This is why we need to have a test module which is setting up the static network and static dns before

validation runs done:

(sle15) mrsh: http://kimball.arch.suse.de/tests/232 and 233 (failing for another reason)
(sle15) pdsh: http://kimball.arch.suse.de/tests/230 and 231
(sle15) munge: http://kimball.arch.suse.de/tests/234 and 235
(sle15) slurm: http://kimball.arch.suse.de/tests/236 and 237 (failing for another reason)

TODO: crosscheck if this also works for sle12 scenarios