### PR TITLE
Increase salt-ping command timeout

### DIFF
--- a/tests/console/salt.pm
+++ b/tests/console/salt.pm
@@ -33,7 +33,7 @@ EOF
     sleep(30);
     assert_script_run("salt-key --accept-all -y");
     record_soft_failure 'bsc#1069711';    # Added 180s to ping minion
-    validate_script_output "salt '*' test.ping -t 180 | grep -woh True > /dev/$serialdev", sub { m/True/ }, 180;
+    validate_script_output "salt '*' test.ping -t 180 | grep -woh True > /dev/$serialdev", sub { m/True/ }, 190;
     assert_script_run 'systemctl stop salt-master salt-minion';
 }
 


### PR DESCRIPTION
180 seconds ping timeout vs. 180 seconds command timeout can be a close race and can result in fails from openQA before the command fails and therefore no useful message is shown -> quiet cumbersome to review.

- Related ticket: [none] - discovered while reviewing
- Needles: Already exist
- Verification run: https://openqa.suse.de/tests/1381089#previous (see soft-fails)
