### PR TITLE
Workaround release notes issues in sle15 upgrade

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -64,6 +64,13 @@ sub run {
         push @no_relnotes, qw(geo);
     }
     if (@addons) {
+        # Workaround release notes issues in upgrade sle12+addons to sle15
+        # The workaround must be removed after bugs fixed
+        if (get_var('UPGRADE') && sle_version_at_least('15')) {
+            assert_screen 'release-notes-sle-close-button', 60;
+            wait_screen_change { send_key 'alt-c'; };
+            return record_soft_failure 'bsc#1075149, bsc#1073488';
+        }
         for my $a (@addons) {
             next if grep { $a eq $_ } @no_relnotes;
             send_key_until_needlematch("release-notes-$a", 'right', 4, 60);


### PR DESCRIPTION
Workaround known issues bsc#1075149 and bsc#1073488:
skip checking release notes in upgrade from sle12+addons
to sle15, mark the test as soft failed and keep it going
forward to disclosure further potential issues during the
packages upgrading in next step.
The workaround must be removed after bugs fixed.
- poo#30168

- Related ticket: https://progress.opensuse.org/issues/30168
- Needles: N/A
- Verification run: 
   * upgrade from sles12-sp3: http://openqa-apac1.suse.de/tests/115
   * upgrade from sles12-sp3+ha+geo+sdk+we: http://openqa-apac1.suse.de/tests/117
     (Failure is expected, which is known issue bsc#1069705)