### PR TITLE
Re-connect to serial line after restart

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -636,6 +636,9 @@ sub power_action {
     else {
         assert_shutdown($shutdown_timeout) if $action eq 'poweroff';
         reset_consoles;
+        if (check_var('BACKEND', 'svirt') && $action ne 'poweroff') {
+            console('svirt')->start_serial_grab;
+        }
     }
 }
 


### PR DESCRIPTION
In PR #4107 we stop serial line grab to get rid of stalls on Xen, however
I forgot to start serial line grab afterwards for non-Xen svirt runs.

Fails here: https://openqa.suse.de/tests/1381066#step/console_reboot/13
Validation run: http://assam.suse.cz/tests/255