### PR TITLE
Add basic test for Hawk web interface

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1043,6 +1043,9 @@ sub load_ha_cluster_tests {
         loadtest "ha/filesystem";
     }
 
+    # Test Hawk Web interface
+    loadtest "ha/check_hawk";
+
     # Show HA cluster status before fencing test
     loadtest "ha/crm_mon";
 

--- a/tests/ha/TODO.md
+++ b/tests/ha/TODO.md
@@ -1,4 +1,3 @@
-- Add a 'systemctl status hawk' test as well as a curl connection to hawk port test
 - Add a 'remove node' test after fencing (for 2 nodes cluster or more, so the node02 will always be removed), need to be tested with both hostname and IP address
 - Add a 'remove all resources but stonith' test to be able to clear the cluster configuration at the end. This will let us the option to re-use the VMs for SAPA HANA tests for example
 - Add a DRBD active/active test + cLVM ontop of a DRBD device

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -72,6 +72,8 @@ sub run {
         barrier_create("CLUSTER_MD_STARTED_$cluster_name",          $num_nodes);
         barrier_create("CLUSTER_MD_RESOURCE_CREATED_$cluster_name", $num_nodes);
         barrier_create("CLUSTER_MD_CHECKED_$cluster_name",          $num_nodes);
+        barrier_create("HAWK_INIT_$cluster_name",                   $num_nodes);
+        barrier_create("HAWK_CHECKED_$cluster_name",                $num_nodes);
     }
 
     # Wait for all children to start

--- a/tests/ha/check_hawk.pm
+++ b/tests/ha/check_hawk.pm
@@ -1,0 +1,42 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Basic check of Hawk Web interface
+# Maintainer: Loic Devulder <ldevulder@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use testapi;
+use lockapi;
+use hacluster;
+
+sub run {
+    my $hawk_port = '7630';
+
+    barrier_wait("HAWK_INIT_$cluster_name");
+
+    # Test the Hawk service
+    assert_script_run 'systemctl show -p ActiveState hawk.service | grep ActiveState=active';
+
+    # Test the Hawk port
+    assert_script_run "ss -nap | grep -w ':$hawk_port'";
+
+    # Test Hawk connection
+    assert_script_run "nc -zv localhost $hawk_port";
+
+    barrier_wait("HAWK_CHECKED_$cluster_name");
+}
+
+# Specific test_flags for this test module
+sub test_flags {
+    return {milestone => 1};
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
For now, just a small test to check if Hawk service is up.

- See [poo#30270](https://progress.opensuse.org/issues/30270)
- Verification run: [sle15-node01](http://moon.qa.suse.cz/tests/700)