### PR TITLE
Upload ay profile when modified and if installation fails

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -7,6 +7,8 @@ requires 'XML::Simple';
 requires 'IO::File';
 requires 'List::Util';
 requires 'LWP::Simple';
+requires 'File::Copy';
+requires 'File::Path';
 
 on 'test' => sub {
   requires 'Code::DRY';

--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -5,7 +5,6 @@ Test suite is based on profile received from our beta customers.
 It contains multipath and profile is edited during runtime using
 pre init scripts feature. See poo#20818.
 -->
-<?xml version="1.0" encoding="UTF-8"?>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <suse_register>
     <do_registration config:type="boolean">true</do_registration>
@@ -44,7 +43,7 @@ pre init scripts feature. See poo#20818.
       <import_gpg_key config:type="boolean">true</import_gpg_key>
     </signature-handling>
   </general>
-  
+
   <report>
     <errors>
       <log config:type="boolean">true</log>

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -60,6 +60,15 @@ sub save_and_upload_yastlogs {
         route add default gw 10.0.2.2
       fi
     ";
+    # Upload autoyast profile if file exists
+    if (script_run '! test -e /tmp/profile/autoinst.xml') {
+        upload_logs '/tmp/profile/autoinst.xml';
+    }
+    # Upload modified profile if pre-install script uses this feature
+    if (script_run '! test -e /tmp/profile/modified.xml') {
+        upload_logs '/tmp/profile/modified.xml';
+    }
+
     upload_logs "/tmp/y2logs-$name.tar.bz2";
     $self->save_and_upload_log('btrfs filesystem usage /mnt', 'btrfs-filesystem-usage-mnt.txt');
     $self->save_and_upload_log('df',                          'df.txt');

--- a/tests/autoyast/prepare_profile.pm
+++ b/tests/autoyast/prepare_profile.pm
@@ -14,6 +14,8 @@
 use strict;
 use base "opensusebasetest";
 use testapi;
+use File::Copy 'copy';
+use File::Path 'make_path';
 
 sub run {
     my $path = get_required_var('AUTOYAST');
@@ -21,7 +23,6 @@ sub run {
     my $profile = get_test_data($path);
     # Return if profile is not available
     return unless $profile;
-
     # Expand variables
     my @vars = qw(SCC_REGCODE SCC_URL VERSION ARCH);
     foreach (@vars) {
@@ -32,6 +33,9 @@ sub run {
     }
     # Upload modified profile
     save_tmp_file($path, $profile);
+    # Copy profile to ulogs directory, so profile is available in job logs
+    make_path('ulogs');
+    copy(hashed_string($path), 'ulogs/autoyast_profile.xml');
     # Set AUTOYAST variable with new url
     my $url = autoinst_url . "/files/$path";
     set_var('AUTOYAST', $url);


### PR DESCRIPTION
At the moment it's very confusing which profile has been used for the
installation. What makes it worse is that we normally collect profile in
clone test module, which doesn't help when installation fails.
With this commit we save ay tests profile using hack and ulogs directory
and if installation fails using post_fail_hook. It covers most of the
scenarios. If installer will crash and end up in linux rc, we won't be
able to get profile from SUT, but may consider downloading it and then
uploading as a log file.

Done as a part of [poo#28349](https://progress.opensuse.org/issues/28349).
[Verification run](http://g226.suse.de/tests/277#downloads)

Added a fix for multipath profile as xml section was accidentally added twice
