### PR TITLE
poo#30222: Re-connect serial line on JeOS and in install_and_reboot

### DIFF
--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -173,13 +173,11 @@ sub run {
         select_console 'installation';
     }
 
-    prepare_system_shutdown;
-
     wait_screen_change {
         send_key 'alt-o';    # Reboot
     };
 
-    assert_shutdown_and_restore_system if check_var('VIRSH_VMM_FAMILY', 'xen');
+    power_action('reboot', observe => 1, keepconsole => 1);
 }
 
 1;


### PR DESCRIPTION
Wherever we restart the OS (or let it restart) without using `power_action` sub, it won't work on svirt.

`prepare_system_shutdown` is part of `power_action`.

Fails here: https://openqa.suse.de/tests/1374849#step/consoletest_setup/9
Validation run: http://assam.suse.cz/tests/262