### PR TITLE
utils: handle_login: do not send spurious ret

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -766,9 +766,6 @@ sub handle_login {
             send_key 'ret';
         }
     }
-    else {
-        send_key 'ret';
-    }
     assert_screen 'displaymanager-password-prompt', no_wait => 1;
     type_password;
     send_key "ret";


### PR DESCRIPTION
Commit fa407950 reworked the code to make it more readable, but added
an additional else block sending return. RET needs only be sent on DMs
that have a user selection to be done, which is handled in the IF cases.

The additional RET causes issues in for example sddm, where RET triggers
a login without password, passing this on to the pam stack. During this
time, the password login field is insensitive to further input and
openQA does not wait for the field to turn active again before typing.

Smoketest: http://dimstar.internet-box.ch:81/tests/638 (clone of https://openqa.opensuse.org/tests/580407)