### PR TITLE
Fix fencing failing test in SLE-HA

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1062,11 +1062,11 @@ sub load_ha_cluster_tests {
     # Test fencing feature
     loadtest "ha/fencing";
 
-    # Show HA cluster status *after* fencing test
-    loadtest "ha/check_after_fencing";
-
     # Node1 will be fenced, so we have to wait for it to boot
     loadtest "boot/boot_to_desktop" if (!get_var("HA_CLUSTER_JOIN"));
+
+    # Show HA cluster status *after* fencing test
+    loadtest "ha/check_after_fencing";
 
     # Check logs to find error and upload all needed logs
     loadtest "ha/check_logs";


### PR DESCRIPTION
During the rebase of PR#4198 a loadtest has been inverted...
So the test is failing like this:
 - https://openqa.suse.de/tests/1386520#step/check_after_fencing/7

This commit fix this issue.