### PR TITLE
Browser tests: temporarily switch to a private instance of html5test

### DIFF
--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -33,7 +33,7 @@ sub run {
 
     send_key "ctrl-l";
     sleep 1;
-    type_string "https://html5test.com/index.html\n";
+    type_string "http://html5test.leuenberger.net/index.html\n";
     assert_screen 'chromium-html5test', 30;
 
     send_key "alt-f4";

--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -19,7 +19,7 @@ use testapi;
 
 sub start_firefox {
     my ($self) = @_;
-    x11_start_program('firefox https://html5test.com/index.html', valid => 0);
+    x11_start_program('firefox http://html5test.leuenberger.net/index.html', valid => 0);
     $self->firefox_check_default;
     $self->firefox_check_popups;
     assert_screen 'firefox-html5test';


### PR DESCRIPTION
[type description  here]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
