### PR TITLE
Increase timeout for updating CaaSP during installation

### DIFF
--- a/tests/installation/install_and_reboot.pm
+++ b/tests/installation/install_and_reboot.pm
@@ -68,6 +68,9 @@ sub run {
     if (check_var('SCC_REGISTER', 'installation') && !get_var('SCC_URL')) {
         $timeout = 5500;
     }
+    if (check_var('REGISTER', 'installation') && is_caasp) {
+        $timeout = 5500;
+    }
     # aarch64 can be particularily slow depending on the hardware
     $timeout *= 2 if check_var('ARCH', 'aarch64') && get_var('MAX_JOB_TIME');
     # encryption, LVM and RAID makes it even slower


### PR DESCRIPTION
During the installation with enabled updates, CaaSP takes more
than the default timeout (current: 2000s). This happens because
of two main reasons:

[1] The number of released maintenance updates have been increased;
    especially the Velum update is ~1GB

[2] The network connection speed is not stable.

- Related ticket: https://progress.opensuse.org/issues/30364
- Needles: No Need
- Verification run: http://skyrim.qam.suse.de/tests/1416 (it took ~2800 sec)
