### PR TITLE
load_zdup_tests: Restrict version switch to sle

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -216,7 +216,8 @@ sub load_zdup_tests {
     }
     loadtest 'installation/zdup';
     loadtest 'installation/post_zdup';
-    loadtest "migration/version_switch_upgrade_target";
+    # Restrict version switch to sle until opensuse adopts it
+    loadtest "migration/version_switch_upgrade_target" if is_sle;
     loadtest 'boot/boot_to_desktop';
 }
 


### PR DESCRIPTION
opensuse tests do not use version switch in upgrade testing,
so version_switch_upgrade_target.pm in load_zdup_tests will
cause zdup test failed on Tumbleweed, restrict it to sle.

- Related ticket: https://progress.opensuse.org/issues/30379
- Needles: N/A
- Verification run: http://openqa-apac1.suse.de/tests/138
