### PR TITLE
Do not expand /var subvolume in yast2_snapper tests

### DIFF
--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -61,12 +61,9 @@ sub y2snapper_show_changes_and_delete {
     if ($ncurses) {
         wait_screen_change { send_key "ret" };
         wait_screen_change { send_key "end" };
-        wait_screen_change { send_key "ret" };
     }
     else {
         wait_screen_change { send_key "tab" };
-        wait_screen_change { send_key "spc" };
-        send_key "down";
         wait_screen_change { send_key "spc" };
     }
     # Make sure it shows the new files from the unpacked tarball


### PR DESCRIPTION
modern skelcd-control-* definitions now include a /var subvolume, meaning /var is not present in snapper snapshots

The yast2_snapper test needlessly expands the menu to show the /var contents for the benefit of the screenshot only. They are not needled (as they are variable)

Without /var in the rootfilesystem, this test is now broken in SLE stagings (and would be in openSUSE if it was tested there) because the test instead de-selects the last file in the root filesystem tree.

This patch retains the actual test code but removes the needless expansion of the now absent /var filetree