### PR TITLE
Force specific isotovideo version

### DIFF
--- a/lib/isotovideo_interface.pm
+++ b/lib/isotovideo_interface.pm
@@ -1,0 +1,17 @@
+package isotovideo_interface;
+use strict;
+use utf8;
+use warnings;
+
+sub VERSION {
+    my ($package, $version) = @_;
+
+    qx/isotovideo --version/ =~ /interface v(\d+)/;
+    my $last_version = $1 // 0;
+
+    die "isotovideo interface version $version required--this is version $last_version" if $version != $last_version;
+}
+
+1;
+
+__END__


### PR DESCRIPTION
Mechanism to force a specific version of a isotovideo interface.

This will compare the version of the isotovideo by executing `isotovideo --version` and if the version doesn't match it will throw an exception

- Related ticket: https://progress.opensuse.org/issues/10474

**Verification run:** 

- Correct version specified:
http://tragicbox.suse.cz/tests/335/file/autoinst-log.txt

- Wrong version specified:
http://tragicbox.suse.cz/tests/336/file/autoinst-log.txt

