### PR TITLE
Move puppet to Package hub module test for sle15

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -820,7 +820,10 @@ sub load_consoletests {
     loadtest "console/ncurses";
     loadtest "console/yast2_lan" unless is_bridged_networking;
     loadtest "console/curl_https";
-    if (check_var_array('SCC_ADDONS', 'asmm')) {
+    if (check_var_array('SCC_ADDONS', 'asmm') && !sle_version_at_least('15')) {
+        loadtest "console/puppet";
+    }
+    if (check_var_array('SCC_ADDONS', 'phub') && sle_version_at_least('15')) {
         loadtest "console/puppet";
     }
     if (check_var_array('SCC_ADDONS', 'asmm') || sle_version_at_least('15') && !is_staging()) {


### PR DESCRIPTION
Remove puppet case with Advanced systems management module for sles15
Add puppet case with package hub module for sles15

- See POO#30334

- Related ticket: https://progress.opensuse.org/issues/30334
- Verification run: 
* Load puppet test with phm http://10.67.17.147/tests/2018
* Disable puppet test with assm http://10.67.17.147/tests/2019