### PR TITLE
JeOS needs wget installed, add module for kdump

### DIFF
--- a/tests/console/java.pm
+++ b/tests/console/java.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -13,11 +13,13 @@
 #          the Hello World program
 # Maintainer: Panos Georgiadis <pgeorgiadis@suse.com>
 # Maintainer: Andrej Semen <asemen@suse.com>
+
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;
 use utils;
-use base "consoletest";
+
 sub run {
     select_console 'root-console';
 
@@ -60,7 +62,8 @@ sub run {
         }
     }
 
-    assert_script_run "wget --quiet " . data_url('console/test_java.sh');
+    zypper_call 'in wget';
+    assert_script_run 'wget --quiet ' . data_url('console/test_java.sh');
     assert_script_run 'chmod +x test_java.sh';
     assert_script_run './test_java.sh';
 }

--- a/tests/console/kdump_and_crash.pm
+++ b/tests/console/kdump_and_crash.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2017 SUSE LLC
+# Copyright © 2016-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Run 'crash' utility on a kernel memory dump
-# Maintainer: Michal Nowak <mnowak@suse.com>, Yi Xu <yxu@suse.com>
+# Maintainer: Michal Nowak <mnowak@suse.com>
 
 use base "console_yasttest";
 use strict;
@@ -23,7 +23,10 @@ sub run {
     select_console('root-console');
 
     # preparation for crash test
-    add_suseconnect_product("sle-module-development-tools") if is_sle and sle_version_at_least('15');
+    if (is_sle && sle_version_at_least('15')) {
+        add_suseconnect_product('sle-module-desktop-applications');
+        add_suseconnect_product('sle-module-development-tools');
+    }
     prepare_for_kdump;
     activate_kdump;
 

--- a/tests/console/unzip.pm
+++ b/tests/console/unzip.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,10 +20,12 @@
 use base "consoletest";
 use strict;
 use testapi;
+use utils 'zypper_call';
 
 sub run {
     # Preparation
     select_console 'root-console';
+    zypper_call 'in wget unzip';
     assert_script_run 'mkdir -p /tmp/unzip-test/ && pushd /tmp/unzip-test';
 
     # 1. Unzip (basic usage)

--- a/tests/console/wget_ipv6.pm
+++ b/tests/console/wget_ipv6.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,8 +15,11 @@
 use base "consoletest";
 use strict;
 use testapi;
+use utils 'zypper_call';
 
 sub run {
+    select_console 'root-console';
+    zypper_call 'in wget';
     select_console 'user-console';
     assert_script_run('rpm -q wget');
     assert_script_run('wget -O- -q www3.zq1.de/test.txt');


### PR DESCRIPTION
JeOS does not have `wget` by default, we have to install it when
required for the test (same with `unzip`).

development-tools module requires desktop-applications module to be
installed first.

Fails here: http://assam.suse.cz/tests/270
Validation run: http://assam.suse.cz/tests/276