### PR TITLE
Stop relying on isotovideo binary for the interface version

### DIFF
--- a/lib/isotovideo_interface.pm
+++ b/lib/isotovideo_interface.pm
@@ -6,10 +6,7 @@ use warnings;
 sub VERSION {
     my ($package, $version) = @_;
 
-    qx/isotovideo --version/ =~ /interface v(\d+)/;
-    my $last_version = $1 // 0;
-
-    die "isotovideo interface version $version required--this is version $last_version" if $version != $last_version;
+    die "isotovideo interface version $version required--this is version $main::INTERFACE" if $version != $main::INTERFACE;
 }
 
 1;


### PR DESCRIPTION

[Coolo had a good point!](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4216#issuecomment-358221559)

Binary call replacement with symbol table lookup for the interface version.


- Related ticket: https://progress.opensuse.org/issues/10474

**Verification run**
- http://tragicbox.suse.cz/tests/348/file/autoinst-log.txt
- http://tragicbox.suse.cz/tests/347/file/autoinst-log.txt

