### PR TITLE
Add a backup run file folder

### DIFF
--- a/tests/qa_automation/execute_test_run.pm
+++ b/tests/qa_automation/execute_test_run.pm
@@ -21,8 +21,13 @@ use upload_system_log;
 use base "opensusebasetest";
 
 sub run {
-    my $timeout = get_var("MAX_JOB_TIME") || 7200;
-    my $test    = get_var("QA_TESTSUITE") . get_var("QA_VERSION");
+    my $timeout   = get_var("MAX_JOB_TIME", 7200);
+    my $test      = get_var("QA_TESTSUITE") . get_var("QA_VERSION");
+    my $runfile   = "/usr/share/qa/tools/test_$test-run";
+    my $run_exist = script_run("ls $runfile | wc -l");
+    unless ($run_exist eq "1") {
+        $runfile = "/usr/lib/ctcs2/tools/test_$test-run";
+    }
     my $run_log = "/tmp/$test-run.log";
 
     #execute test run


### PR DESCRIPTION
Test file of some testsuite are not in /usr/share/qa/tools/, but in /usr/lib/ctcs2/tools/. Add a step to avoid fails like this "No such file or directory"
https://openqa.suse.de/tests/1385642#step/execute_test_run/8

- Verification run: http://10.67.133.102/tests/34