### PR TITLE
Remove toolchain life cycle test from SLE15

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -897,7 +897,7 @@ sub load_consoletests {
     }
     if (!is_staging() && sle_version_at_least('12-SP2')) {
         loadtest "console/zypper_lifecycle";
-        if (check_var_array('SCC_ADDONS', 'tcm')) {
+        if (check_var_array('SCC_ADDONS', 'tcm') && !sle_version_at_least('15')) {
             loadtest "console/zypper_lifecycle_toolchain";
         }
     }


### PR DESCRIPTION
Packages in Toolchain module are moved to Development module in SLE15
and some old packages are moved out, like gcc5,gcc6.


- Related ticket: https://progress.opensuse.org/issues/30201
- Verification run: http://10.67.18.165/tests/21#
