### PR TITLE
Fix SLE-HA aarch64 not booting anymore

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1005,11 +1005,14 @@ sub load_slenkins_tests {
 sub load_ha_cluster_tests {
     return unless (get_var("HA_CLUSTER"));
 
+    # We need to boot *before* waiting for support server
+    # Because of TianoCore UEFI boot method
+    loadtest "boot/boot_to_desktop";
+
     # Wait for support server to complete its initialization
     loadtest "ha/wait_support_server";
 
     # Standard boot and configuration
-    loadtest "boot/boot_to_desktop";
     loadtest "qa_automation/patch_and_reboot" if is_updates_tests;
     loadtest "console/consoletest_setup";
     loadtest "console/hostname" unless is_bridged_networking;


### PR DESCRIPTION
Due to a change in [PR#4020](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4020), aarch64 is not booting
anymore for SLE-HA tests. This PR fix this.

Fix failing test:
- http://moon.qa.suse.cz/tests/1072

Verification run:
- http://moon.qa.suse.cz/tests/1082