### PR TITLE
Add autoyast ipmi SES5 test

### DIFF
--- a/data/ses/bee.xml
+++ b/data/ses/bee.xml
@@ -1,0 +1,536 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <bootloader>
+    <global>
+      <activate>true</activate>
+      <append>splash=silent quiet showopts crashkernel=123M,high crashkernel=72M,low</append>
+      <boot_boot>true</boot_boot>
+      <boot_extended>false</boot_extended>
+      <boot_mbr>false</boot_mbr>
+      <boot_root>false</boot_root>
+      <generic_mbr>true</generic_mbr>
+      <gfxmode>auto</gfxmode>
+      <hiddenmenu>false</hiddenmenu>
+      <os_prober>false</os_prober>
+      <terminal>gfxterm</terminal>
+      <timeout config:type="integer">3</timeout>
+      <trusted_grub>false</trusted_grub>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <storage>
+      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
+      <start_multipath config:type="boolean">false</start_multipath>
+    </storage>
+  </general>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel config:type="list">
+      <listentry>123M,high</listentry>
+      <listentry>72M,low</listentry>
+    </crash_kernel>
+    <general>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>10</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NET_TIMEOUT>30</KDUMP_NET_TIMEOUT>
+      <KDUMP_SAVEDIR>file:///var/crash</KDUMP_SAVEDIR>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+    </general>
+  </kdump>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+  </language>
+  <networking>
+    <dhcp_options>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">false</dhcp_hostname>
+      <domain>qam.suse.cz</domain>
+      <hostname>bee</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <searchlist config:type="list">
+        <search>qam.suse.cz</search>
+      </searchlist>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth0</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>I350 Gigabit Network Connection</name>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth1</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>I350 Gigabit Network Connection</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth2</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>Ethernet Controller X710 for 10GbE SFP+</name>
+        <startmode>hotplug</startmode>
+      </interface>
+<!-- only eth4 is acive network interface, but sometimes during the installationboot is eth3 active, to avoid unnecessary complications eth3 is configured via dhcp too -->
+      <interface>
+        <bootproto>dhcp4</bootproto>
+        <device>eth3</device>
+        <dhclient_set_hostname>yes</dhclient_set_hostname>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <name>Ethernet Controller X710 for 10GbE SFP+</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>dhcp4</bootproto>
+        <device>eth4</device>
+        <dhclient_set_hostname>yes</dhclient_set_hostname>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <name>Ethernet Controller 10-Gigabit X540-AT2</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth5</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>Ethernet Controller 10-Gigabit X540-AT2</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>eth6</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <ipaddr>192.168.0.86</ipaddr>
+        <mtu>9000</mtu>
+        <name>Ethernet Controller 10-Gigabit X540-AT2</name>
+        <netmask>255.255.255.0</netmask>
+        <prefixlen>24</prefixlen>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth7</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>Ethernet Controller 10-Gigabit X540-AT2</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">false</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>ATTR{address}</rule>
+        <value>0c:c4:7a:6c:2e:36</value>
+      </rule>
+      <rule>
+        <name>eth1</name>
+        <rule>ATTR{address}</rule>
+        <value>0c:c4:7a:6c:2e:37</value>
+      </rule>
+      <rule>
+        <name>eth2</name>
+        <rule>ATTR{address}</rule>
+        <value>3c:fd:fe:9c:cd:48</value>
+      </rule>
+      <rule>
+        <name>eth3</name>
+        <rule>ATTR{address}</rule>
+        <value>3c:fd:fe:9c:cd:49</value>
+      </rule>
+      <rule>
+        <name>eth4</name>
+        <rule>ATTR{address}</rule>
+        <value>a0:36:9f:6e:32:4c</value>
+      </rule>
+      <rule>
+        <name>eth5</name>
+        <rule>ATTR{address}</rule>
+        <value>a0:36:9f:6e:32:4e</value>
+      </rule>
+      <rule>
+        <name>eth6</name>
+        <rule>ATTR{address}</rule>
+        <value>a0:36:9f:70:72:18</value>
+      </rule>
+      <rule>
+        <name>eth7</name>
+        <rule>ATTR{address}</rule>
+        <value>a0:36:9f:70:72:1a</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+    </routing>
+    <setup_before_proposal config:type="boolean">true</setup_before_proposal>
+  </networking>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list">
+      <peer>
+        <address>hornet.qam.suse.cz</address>
+        <options>burst iburst</options>
+        <type>server</type>
+      </peer>
+      <peer>
+        <address>/var/lib/ntp/drift/ntp.drift</address>
+        <comment># path for drift file</comment>
+        <type>driftfile</type>
+      </peer>
+      <peer>
+        <address>/var/log/ntp</address>
+        <comment># alternate log file</comment>
+        <type>logfile</type>
+      </peer>
+      <peer>
+        <address>/etc/ntp.keys</address>
+        <comment># path for keys file</comment>
+        <type>keys</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># define trusted keys</comment>
+        <type>trustedkey</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># key (7) for accessing server variables</comment>
+        <type>requestkey</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># key (6) for accessing server variables</comment>
+        <type>controlkey</type>
+      </peer>
+    </peers>
+    <restricts config:type="list">
+      <restrict>
+        <options>ipv6 notrap nomodify nopeer noquery</options>
+        <target>default</target>
+      </restrict>
+      <restrict>
+        <target>127.0.0.1</target>
+      </restrict>
+      <restrict>
+        <target>::1</target>
+      </restrict>
+    </restricts>
+    <start_at_boot config:type="boolean">true</start_at_boot>
+    <start_in_chroot config:type="boolean">false</start_in_chroot>
+    <sync_interval config:type="integer">5</sync_interval>
+    <synchronize_time config:type="boolean">false</synchronize_time>
+  </ntp-client>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/md</device>
+      <disklabel>msdos</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>noatime</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_nr config:type="integer">0</partition_nr>
+          <raid_options>
+            <device_order config:type="list">
+              <device>/dev/disk/by-id/scsi-0ATA_SATA_SSD_B4500757042400103664-part1</device>
+              <device>/dev/disk/by-id/scsi-0ATA_SATA_SSD_96D707560C2400162440-part1</device>
+            </device_order>
+            <persistent_superblock config:type="boolean">false</persistent_superblock>
+            <raid_name>/dev/md/root</raid_name>
+            <raid_type>raid0</raid_type>
+          </raid_options>
+          <resize config:type="boolean">false</resize>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_MD</type>
+      <use>all</use>
+    </drive>
+    <drive>
+      <device>/dev/disk/by-id/scsi-0ATA_SATA_SSD_B4500757042400103664</device>
+      <disklabel>gpt</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <format config:type="boolean">false</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">253</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <raid_name>/dev/md/root</raid_name>
+          <resize config:type="boolean">false</resize>
+          <size>29.7G</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">ext4</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/boot</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>max</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+    <drive>
+      <device>/dev/disk/by-id/scsi-0ATA_SATA_SSD_96D707560C2400162440</device>
+      <disklabel>gpt</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <format config:type="boolean">false</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">253</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <raid_name>/dev/md/root</raid_name>
+          <resize config:type="boolean">false</resize>
+          <size>29.7G</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <scripts>
+    <init-scripts config:type="list">
+      <script>
+        <filename>post.sh</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+#!/bin/sh
+### stop ssh while script is running
+systemctl stop sshd.service
+###
+### add ssh keys, created bug bsc#1066342 as the keys are not added via <authorized_keys> in <user>
+mkdir -m 700 /root/.ssh
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDWWOicPToKZ+Pqx+rA9Ny6tBXaG9x4xUjEw2KA4Ww3s8+D8xt4HynEGaOvXd4qfAlfbs0BnGC+QMo4u2T4+MLf34pgudv1bnXSWVj7M3/OeQv7WDU8fI4W8NEmoSGZaeXAzvNTSok/6kmGEOeU4Qwxu9pcCowaeLv0f0HNH1HTK7piGq2TzAZeLdIQeXb5Fa3HKCvoKCrlt3yTzX3shIKbeBg5KvwcQ/zn1ftvLMDhBEfBO1b1eWprie6otPBbLYBawzTbQ6GMUH3GjWD2+G04xPuEVtuBEGLtZ+s6rlxMEkm3uqrKOCZW++hcqRTYttvooW5GSRGDVrppaIpzxCHH root@hornet' >> /root/.ssh/authorized_keys
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCm/z0MRb/MVoFeC0lCA45XIbUxyaZ+DTpMEEjQ30/PH2DFSdu4izguNyog+qMHmKAgBQWZWHr1DwXYTjZ4ZiQR6YShxb269S6QO0uqQ6U6SFBHwEyoaY1ooZgcPdCyjXKRSPieTHI1VojxiReDVNnDgrCObac4RWi5EU0JDSgKJI5HT+LjW9NLJGu+ikPuXbr479F6DFET5uV1ht09g5ppvkF2fDLojobaWf1og2JD7EPOg1E4MKX2juxrxSyhLFNaD1esBchKIryymQqIwAMqJsFeiU9YuAQ/N3xkvVUq3DSjeRU2okcpuo/FPP5ulHOTrRoyLQMkKl+BntCh5Sxj jpupava@suse.com' >> /root/.ssh/authorized_keys
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCqhWVTosH12864VGY5S3/k0yKc59GbV0m2WxD28gAf+uvJ1/y8gekD2wDzBv0DWqEekYLV7L68gpapDXyGosQeZ6n5OO/NZFZmW+Xq1P7P1QHJil6kVpwk927lzX440pwNf3+PRvTbLzlbuVFWJRpiykv+juJyIFjzXLJRF67wB2qgZVm5cRs/GOi4fnvTaou/Ae51mvsO8M3JL5cphApFKD/AO/X+3pHBhLjvaW33cYsp0Z4Rce1nm8wxSmvuJRF+HAfjBlknhDl5ZaJGA96RYA+g9WbAXimFprg4xeiRp7liPExQwtVgackJweoC4MahC1glmjC3eOh9dvrrxLnALOLMOkyCSK/tOF/iq2PJaLViObanPI8mnNkMLbdJyzUBf8hRGdSLcw98qxaf0sSZ+vz4VQS6e9CwX7ikkNNsTeYXjnJ+1yU3mfCW1CXJDr7kBDVG2OTLefCpMY8WBAYDiEaK0RW83cBcFIKfecKYd0qStHRaOsvmyWdFYgBh2vM1UWjro5WXlb+7aJPrUp8ZruapkUXUwhjHA7FwGA4ysE0tsOVVFm0Dw8tvyVVkVNm/9EObG28dWctioZ2+ZEzTWgMJU26Q+wOJ/U4qZyIvpMRUgPZc5nM9J8kcmvNWtb6DV9k/6p8h28kiOxPkxLtPP+3TlBCHjq//mhEnJZ/d8w== shshyukriev@suse.com' >> /root/.ssh/authorized_keys
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDEfz0lP5oO03Rw8vSyzqwt06VIEFA4x478DERaSWHPTD5ULqqdZQS1vsFpTtAm1eT4Ix4njXvSh4T2d2aXYyCgB+ElJI1h0tpbtX7OtenJ7c3rUows61jqmXLFrnIfWbZL2uhomTsOziQwxKoXS3PRxFgoRaZGzHGD4J4HOEfiP8YHQ53igUKbmmDY8yVZya/dyEtKe8bukcbZbGIosKgMoaLsdpbNkln7bU1oLqMuogHGtqRdZ9gQLz2mz5I7Ml/lSeCEdbkqVbOjydVhF2Qm4bvbVjyER+n0VqhXOmeKcauEOQbEafYrJjWvDetMY4j8NwWCeJq0QA7gYRd7967 bhavel@blackbird.suse.cz' >> /root/.ssh/authorized_keys
+###
+### register SLES and SES
+SUSEConnect -p ses/5/x86_64 -r 35eb00e8035bf5b0
+###
+### remove first repo
+zypper rr 1
+###
+### install salt-minion ceph
+zypper -n in salt-minion ceph
+###
+### set hornet as master and turn off ipv6
+sed -i 's/#master: salt/master: hornet/' /etc/salt/minion
+sed -i 's/#ipv6: False/ipv6: False/' /etc/salt/minion
+###
+### add hornet master salt pki
+echo '-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo/Ex4NV6sFAL0tUMJcC5
+5dPMbBjVKjCJ7aqm95vv2XeU0JofXywWLT8U4toKVgtM8UZfsEoJ9R6HE52lYQAJ
+48mbijjGjgcQqVGXHSksD/mrAaLioAuzESR/LM66+BFqV2rcJGoCx/aSlm8D7EeC
+3AQpKs0xHfLIq+pjR9X76idagg7Xd7pEqcz92Ggpg5fzBdw4OgSvBytElMTuxUU6
+Eno5TGlyW8K86RAQXT0nGlHUQ6GkEkXe/DPaUTNmM1hGKwxuEfJH37mh57hsu95a
+/xDJ01SkqAVPc7s5fMxWTTjpZNt5hKi0tJnC8vtn6k0NDU1FyolTxn/URRzLFPv+
+dwIDAQAB
+-----END PUBLIC KEY-----' > /etc/salt/pki/minion/minion_master.pub
+###
+### hornet knows bee under this keys, no need to accept new keys on hornet with salt-key -A -y
+echo '-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAwqRLz+6xom/vR+u0DUJeTL2bQN+4e83eCKVG8Hk+RB+FqIew
+W4viMaWBymWXa7Au9O84ArgAQkEX7Wxu+k7iP9cLfU5RCVgQ67a+rRSl8K5nBLV8
+tVl1Qd6pClLTREDHya6UuexoG3Qr4nsGJKbmaS/PncKYrfdbyV5qGx79m0B7VqKb
+HkrYdknw9dDUfPW4ndchEWE4jE2Cf+2aX05tN0jGohLZ/x6pN2hc8vgA1SCORbxE
+jWp/BJERGBY2NHyZp3dGwWq9A4zHkOkQ4/OSXKqeH6qjjpLqoVG2PE9czfuU8ymt
+ta2V/NjKbFUfKgB/PQwo1FusC40yxYLyrupsbwIDAQABAoIBAGkLVCLm1hUtRbzR
+1v0k6VGPLn+nfZ/LLd4KnKthM5p+TJr0h9gQOUXD5bT+eObUUbM8e0T0WqdnC+vF
+jmsmMXJ0sy2wG4noblFX8bXlI90tsklXTPNuURr4eNAqfPwj3e7ZekiQ7mqKmriC
+3oDfVhBEjk6827tfeLjHbIowgnvLMNcE1ppBs49iDUtU1Fl0OGdjvxM01T6hSAwd
+UxDJLHZIhFOMOWXB800sNZHF1SM1D7BWDRJgS2PbMbtc7LqIeUDJQwzHwmlZVoEv
+hFJMIXk524dfH1O2RtysnEh4C+3tUKfBCkvrHlgMfQZt2J7BcJsTrEaqp6LBkEJC
+39724JECgYEAwsqWLiKD5Nf/c2/5JoimMcY9Its2YcHjRKb6IY17QAfFL9LIglx+
+61b+eRhn9ToGmqxVCw04FDBrw/PZqnjx/MURn8ViDXls+yHJDk+VSLMQwR8VEIQL
+zZ+UFIB84A/D2AGRusNmYdB81wu6ljmsaMQIIL6K+C584XFo0FxujAcCgYEA/82t
+d1j8UY1bXyKQxXft28aC9zSgVkqhx+qO8UBj+G6SSPb+c9lZCmywbQ6WGqr1Vdvv
+xB6RhqhaCkt4BQX1+4a5cLa/BCS6rYgH3/9zbnjmyk/qPxTwWW4GUrV43R/G0kfh
+Mmx7K6rdogt4tEo3amD70F1kYHjJkPzgUsny0lkCgYEAuI7VyBRvvw1gPXGkMPxb
+6uEW38WvOuRHfq5uZAf29O3nyK3/yHP21Ofx565WISS/SSFq2jPGJGrUUC7k1v4M
+2R+m2ShdBMM9nJugMWz51o3CnBflD2bs///of5xVtL17I1gpSTkF8jtlbSLxwJAY
+aJMD2HJwnUD+lWOsmW5aV1UCgYBFzf60Ptg7+PMiNvCCsoN6IeXDR90pLxyOzXdM
+ZmHhfWr19lDhlEI0Egzi9cQIavagA3CeeCkGMhLAFHAgDsxdYxpfo77khpFaoXBk
+s/TwBJYWR1CI/lHIVbnsABGHZhB/eZX+iJPkCrCIc9DwggA1S1nsNlAZ81wt8JPW
+g717oQKBgCAA3rooj1ojHt3ToWo/vJ2YhwArZSS2KWJSW7FCHnttAK2t5IaWCZvu
+GCgD0egbjET1szFZfGWv/U0mQIZzNoEqpGhFClzZQTw763KYK/YOW66WnttRLt/X
+C1bLXjm9sppo46wR65fktV79n/96WRb1FSB3MAeYRtpGTmCvxmqm
+-----END RSA PRIVATE KEY-----' > /etc/salt/pki/minion/minion.pem
+echo '-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwqRLz+6xom/vR+u0DUJe
+TL2bQN+4e83eCKVG8Hk+RB+FqIewW4viMaWBymWXa7Au9O84ArgAQkEX7Wxu+k7i
+P9cLfU5RCVgQ67a+rRSl8K5nBLV8tVl1Qd6pClLTREDHya6UuexoG3Qr4nsGJKbm
+aS/PncKYrfdbyV5qGx79m0B7VqKbHkrYdknw9dDUfPW4ndchEWE4jE2Cf+2aX05t
+N0jGohLZ/x6pN2hc8vgA1SCORbxEjWp/BJERGBY2NHyZp3dGwWq9A4zHkOkQ4/OS
+XKqeH6qjjpLqoVG2PE9czfuU8ymtta2V/NjKbFUfKgB/PQwo1FusC40yxYLyrups
+bwIDAQAB
+-----END PUBLIC KEY-----' > /etc/salt/pki/minion/minion.pub
+###
+### wipe disks
+for d in a b c d g h i j; do sgdisk -z /dev/sd${d};done
+###
+### enable and start salt-minion
+systemctl enable salt-minion.service
+systemctl start salt-minion.service
+###
+### add text about minion deployment via autoyast into motd
+echo '
+---------------------------------------------------------------------
+
+SAS5 node bee.qam.suse.cz was deployed with autoyast profile
+https://pes.suse.de/QA_Maintenance/Users/SES_Hardware
+salt-minion is configured and known to salt-master hornet.qam.suse.cz
+
+---------------------------------------------------------------------
+' > /etc/motd
+###
+### make sure host ssh key will be the same even when previous installation failed and the known key got lost
+grep 'HqKVS+l+ehb8ur7yi' /etc/ssh/ssh_host_ecdsa_key > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+echo '-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIOQe4oYCFu+TbpOOdb2JuA89acXApHz26hZ09tN573qGoAoGCCqGSM49
+AwEHoUQDQgAE2DhI0rYgWqjeHqKVS+l+ehb8ur7yikQsIvfUzPDwIz67UsgByfhO
+44bTOpPsYJ7Eq9AmJczbUZRE6QZB3kG3zw==
+-----END EC PRIVATE KEY-----' > /etc/ssh/ssh_host_ecdsa_key
+fi
+grep 'M21GUROkGQd5Bt88=' /etc/ssh/ssh_host_ecdsa_key.pub > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+echo 'ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNg4SNK2IFqo3h6ilUvpfnoW/Lq+8opELCL31Mzw8CM+u1LIAcn4TuOG0zqT7GCexKvQJiXM21GUROkGQd5Bt88= root@bee' > /etc/ssh/ssh_host_ecdsa_key.pub
+fi
+###
+### make eth3 inactive, was active only for installation as it was sometimes the active interface instead of eth4
+echo "BOOTPROTO='none'
+DHCLIENT_SET_DEFAULT_ROUTE='no'
+NAME='Ethernet Controller X710 for 10GbE SFP+'
+STARTMODE='hotplug'" > /etc/sysconfig/network/ifcfg-eth3
+###
+### start ssh when init-script is done
+systemctl start sshd.service
+exit 0
+
+]]></source>
+      </script>
+    </init-scripts>
+  </scripts>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <enable config:type="list">
+        <service>kdump-early</service>
+        <service>kdump</service>
+        <service>ntpd</service>
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <software>
+    <install_recommended config:type="boolean">true</install_recommended>
+<!-- can't be done because SES addon not registered above
+    <packages config:type="list">
+      <package>salt-minion</package>
+      <package>ceph</package>
+    </packages>
+-->
+    <patterns config:type="list">
+      <pattern>Minimal</pattern>
+      <pattern>base</pattern>
+      <pattern>yast2</pattern>
+    </patterns>
+  </software>
+  <ssh_import>
+    <copy_config config:type="boolean">true</copy_config>
+    <import config:type="boolean">true</import>
+    <device>/dev/md/root</device>
+  </ssh_import>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_code>30452ce234918d23</reg_code>
+    <slp_discovery config:type="boolean">false</slp_discovery>
+  </suse_register>
+<!-- adddon does not work on SP3 now, have re register manually
+  https://github.com/yast/yast-registration/wiki/Available-SCC-Extensions-for-Use-in-Autoyast
+  <addons config:type="list">
+    <addon>
+      <name>ses</name>
+      <version>5</version>
+      <arch>x86_64</arch>
+      <reg_code>35eb00e8035bf5b0</reg_code>
+    </addon>
+  </addons>
+-->
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Prague</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$6$cm4eO/pG$oQz0QbRmYF9ErQcKnD8b0q5rT/.TH9dzK6dpdADmqx3t5t673g8rbAoMMKHmAdhHAa9NjEc0M2HNerdC3c.K/0</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/data/ses/butterfly.xml
+++ b/data/ses/butterfly.xml
@@ -1,0 +1,535 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <bootloader>
+    <global>
+      <activate>true</activate>
+      <append>splash=silent quiet showopts crashkernel=123M,high crashkernel=72M,low</append>
+      <boot_boot>true</boot_boot>
+      <boot_extended>false</boot_extended>
+      <boot_mbr>false</boot_mbr>
+      <boot_root>false</boot_root>
+      <generic_mbr>true</generic_mbr>
+      <gfxmode>auto</gfxmode>
+      <hiddenmenu>false</hiddenmenu>
+      <os_prober>false</os_prober>
+      <terminal>gfxterm</terminal>
+      <timeout config:type="integer">3</timeout>
+      <trusted_grub>false</trusted_grub>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <storage>
+      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
+      <start_multipath config:type="boolean">false</start_multipath>
+    </storage>
+  </general>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel config:type="list">
+      <listentry>123M,high</listentry>
+      <listentry>72M,low</listentry>
+    </crash_kernel>
+    <general>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>10</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NET_TIMEOUT>30</KDUMP_NET_TIMEOUT>
+      <KDUMP_SAVEDIR>file:///var/crash</KDUMP_SAVEDIR>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+    </general>
+  </kdump>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+  </language>
+  <networking>
+    <dhcp_options>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">false</dhcp_hostname>
+      <domain>qam.suse.cz</domain>
+      <hostname>butterfly</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <searchlist config:type="list">
+        <search>qam.suse.cz</search>
+      </searchlist>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth0</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>I350 Gigabit Network Connection</name>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth1</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>I350 Gigabit Network Connection</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth2</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>Ethernet Controller X710 for 10GbE SFP+</name>
+        <startmode>hotplug</startmode>
+      </interface>
+<!-- only eth4 is acive network interface, but sometimes during the installationboot is eth3 active, to avoid unnecessary complications eth3 is configured via dhcp too -->
+      <interface>
+        <bootproto>dhcp4</bootproto>
+        <device>eth3</device>
+        <dhclient_set_hostname>yes</dhclient_set_hostname>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <name>Ethernet Controller X710 for 10GbE SFP+</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>dhcp4</bootproto>
+        <device>eth4</device>
+        <dhclient_set_hostname>yes</dhclient_set_hostname>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <name>Ethernet Controller 10-Gigabit X540-AT2</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth5</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>Ethernet Controller 10-Gigabit X540-AT2</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>eth6</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <ipaddr>192.168.0.92</ipaddr>
+        <mtu>9000</mtu>
+        <name>Ethernet Controller 10-Gigabit X540-AT2</name>
+        <netmask>255.255.255.0</netmask>
+        <prefixlen>24</prefixlen>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth7</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>Ethernet Controller 10-Gigabit X540-AT2</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">false</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>ATTR{address}</rule>
+        <value>0c:c4:7a:6c:2e:38</value>
+      </rule>
+      <rule>
+        <name>eth1</name>
+        <rule>ATTR{address}</rule>
+        <value>0c:c4:7a:6c:2e:39</value>
+      </rule>
+      <rule>
+        <name>eth2</name>
+        <rule>ATTR{address}</rule>
+        <value>3c:fd:fe:9c:cc:80</value>
+      </rule>
+      <rule>
+        <name>eth3</name>
+        <rule>ATTR{address}</rule>
+        <value>3c:fd:fe:9c:cc:81</value>
+      </rule>
+      <rule>
+        <name>eth4</name>
+        <rule>ATTR{address}</rule>
+        <value>a0:36:9f:6d:12:b0</value>
+      </rule>
+      <rule>
+        <name>eth5</name>
+        <rule>ATTR{address}</rule>
+        <value>a0:36:9f:6d:12:b2</value>
+      </rule>
+      <rule>
+        <name>eth6</name>
+        <rule>ATTR{address}</rule>
+        <value>a0:36:9f:6d:17:74</value>
+      </rule>
+      <rule>
+        <name>eth7</name>
+        <rule>ATTR{address}</rule>
+        <value>a0:36:9f:6d:17:76</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+    </routing>
+    <setup_before_proposal config:type="boolean">true</setup_before_proposal>
+  </networking>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list">
+      <peer>
+        <address>hornet.qam.suse.cz</address>
+        <options>burst iburst</options>
+        <type>server</type>
+      </peer>
+      <peer>
+        <address>/var/lib/ntp/drift/ntp.drift</address>
+        <comment># path for drift file</comment>
+        <type>driftfile</type>
+      </peer>
+      <peer>
+        <address>/var/log/ntp</address>
+        <comment># alternate log file</comment>
+        <type>logfile</type>
+      </peer>
+      <peer>
+        <address>/etc/ntp.keys</address>
+        <comment># path for keys file</comment>
+        <type>keys</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># define trusted keys</comment>
+        <type>trustedkey</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># key (7) for accessing server variables</comment>
+        <type>requestkey</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># key (6) for accessing server variables</comment>
+        <type>controlkey</type>
+      </peer>
+    </peers>
+    <restricts config:type="list">
+      <restrict>
+        <options>ipv6 notrap nomodify nopeer noquery</options>
+        <target>default</target>
+      </restrict>
+      <restrict>
+        <target>127.0.0.1</target>
+      </restrict>
+      <restrict>
+        <target>::1</target>
+      </restrict>
+    </restricts>
+    <start_at_boot config:type="boolean">true</start_at_boot>
+    <start_in_chroot config:type="boolean">false</start_in_chroot>
+    <sync_interval config:type="integer">5</sync_interval>
+    <synchronize_time config:type="boolean">false</synchronize_time>
+  </ntp-client>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/md</device>
+      <disklabel>msdos</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>noatime</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_nr config:type="integer">0</partition_nr>
+          <raid_options>
+            <device_order config:type="list">
+              <device>/dev/disk/by-id/scsi-0ATA_SATA_SSD_B4500757032400103087-part1</device>
+              <device>/dev/disk/by-id/scsi-0ATA_SATA_SSD_AF340757032400152410-part1</device>
+            </device_order>
+            <persistent_superblock config:type="boolean">false</persistent_superblock>
+            <raid_name>/dev/md/root</raid_name>
+            <raid_type>raid0</raid_type>
+          </raid_options>
+          <resize config:type="boolean">false</resize>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_MD</type>
+      <use>all</use>
+    </drive>
+    <drive>
+      <device>/dev/disk/by-id/scsi-0ATA_SATA_SSD_B4500757032400103087</device>
+      <disklabel>gpt</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <format config:type="boolean">false</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">253</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <raid_name>/dev/md/root</raid_name>
+          <resize config:type="boolean">false</resize>
+          <size>29.7G</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">ext4</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/boot</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>max</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+    <drive>
+      <device>/dev/disk/by-id/scsi-0ATA_SATA_SSD_AF340757032400152410</device>
+      <disklabel>gpt</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <format config:type="boolean">false</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">253</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <raid_name>/dev/md/root</raid_name>
+          <resize config:type="boolean">false</resize>
+          <size>29.7G</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <scripts>
+    <init-scripts config:type="list">
+      <script>
+        <filename>post.sh</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+#!/bin/sh
+### stop ssh while script is running
+systemctl stop sshd.service
+###
+### add ssh keys, created bug bsc#1066342 as the keys are not added via <authorized_keys> in <user>
+mkdir -m 700 /root/.ssh
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDWWOicPToKZ+Pqx+rA9Ny6tBXaG9x4xUjEw2KA4Ww3s8+D8xt4HynEGaOvXd4qfAlfbs0BnGC+QMo4u2T4+MLf34pgudv1bnXSWVj7M3/OeQv7WDU8fI4W8NEmoSGZaeXAzvNTSok/6kmGEOeU4Qwxu9pcCowaeLv0f0HNH1HTK7piGq2TzAZeLdIQeXb5Fa3HKCvoKCrlt3yTzX3shIKbeBg5KvwcQ/zn1ftvLMDhBEfBO1b1eWprie6otPBbLYBawzTbQ6GMUH3GjWD2+G04xPuEVtuBEGLtZ+s6rlxMEkm3uqrKOCZW++hcqRTYttvooW5GSRGDVrppaIpzxCHH root@hornet' >> /root/.ssh/authorized_keys
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCm/z0MRb/MVoFeC0lCA45XIbUxyaZ+DTpMEEjQ30/PH2DFSdu4izguNyog+qMHmKAgBQWZWHr1DwXYTjZ4ZiQR6YShxb269S6QO0uqQ6U6SFBHwEyoaY1ooZgcPdCyjXKRSPieTHI1VojxiReDVNnDgrCObac4RWi5EU0JDSgKJI5HT+LjW9NLJGu+ikPuXbr479F6DFET5uV1ht09g5ppvkF2fDLojobaWf1og2JD7EPOg1E4MKX2juxrxSyhLFNaD1esBchKIryymQqIwAMqJsFeiU9YuAQ/N3xkvVUq3DSjeRU2okcpuo/FPP5ulHOTrRoyLQMkKl+BntCh5Sxj jpupava@suse.com' >> /root/.ssh/authorized_keys
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCqhWVTosH12864VGY5S3/k0yKc59GbV0m2WxD28gAf+uvJ1/y8gekD2wDzBv0DWqEekYLV7L68gpapDXyGosQeZ6n5OO/NZFZmW+Xq1P7P1QHJil6kVpwk927lzX440pwNf3+PRvTbLzlbuVFWJRpiykv+juJyIFjzXLJRF67wB2qgZVm5cRs/GOi4fnvTaou/Ae51mvsO8M3JL5cphApFKD/AO/X+3pHBhLjvaW33cYsp0Z4Rce1nm8wxSmvuJRF+HAfjBlknhDl5ZaJGA96RYA+g9WbAXimFprg4xeiRp7liPExQwtVgackJweoC4MahC1glmjC3eOh9dvrrxLnALOLMOkyCSK/tOF/iq2PJaLViObanPI8mnNkMLbdJyzUBf8hRGdSLcw98qxaf0sSZ+vz4VQS6e9CwX7ikkNNsTeYXjnJ+1yU3mfCW1CXJDr7kBDVG2OTLefCpMY8WBAYDiEaK0RW83cBcFIKfecKYd0qStHRaOsvmyWdFYgBh2vM1UWjro5WXlb+7aJPrUp8ZruapkUXUwhjHA7FwGA4ysE0tsOVVFm0Dw8tvyVVkVNm/9EObG28dWctioZ2+ZEzTWgMJU26Q+wOJ/U4qZyIvpMRUgPZc5nM9J8kcmvNWtb6DV9k/6p8h28kiOxPkxLtPP+3TlBCHjq//mhEnJZ/d8w== shshyukriev@suse.com' >> /root/.ssh/authorized_keys
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDEfz0lP5oO03Rw8vSyzqwt06VIEFA4x478DERaSWHPTD5ULqqdZQS1vsFpTtAm1eT4Ix4njXvSh4T2d2aXYyCgB+ElJI1h0tpbtX7OtenJ7c3rUows61jqmXLFrnIfWbZL2uhomTsOziQwxKoXS3PRxFgoRaZGzHGD4J4HOEfiP8YHQ53igUKbmmDY8yVZya/dyEtKe8bukcbZbGIosKgMoaLsdpbNkln7bU1oLqMuogHGtqRdZ9gQLz2mz5I7Ml/lSeCEdbkqVbOjydVhF2Qm4bvbVjyER+n0VqhXOmeKcauEOQbEafYrJjWvDetMY4j8NwWCeJq0QA7gYRd7967 bhavel@blackbird.suse.cz' >> /root/.ssh/authorized_keys
+###
+### register SLES and SES
+SUSEConnect -p ses/5/x86_64 -r 35eb00e8035bf5b0
+###
+### remove first repo
+zypper rr 1
+###
+### install salt-minion ceph
+zypper -n in salt-minion ceph
+###
+### set hornet as master and turn off ipv6
+sed -i 's/#master: salt/master: hornet/' /etc/salt/minion
+sed -i 's/#ipv6: False/ipv6: False/' /etc/salt/minion
+###
+### add hornet master salt pki
+echo '-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo/Ex4NV6sFAL0tUMJcC5
+5dPMbBjVKjCJ7aqm95vv2XeU0JofXywWLT8U4toKVgtM8UZfsEoJ9R6HE52lYQAJ
+48mbijjGjgcQqVGXHSksD/mrAaLioAuzESR/LM66+BFqV2rcJGoCx/aSlm8D7EeC
+3AQpKs0xHfLIq+pjR9X76idagg7Xd7pEqcz92Ggpg5fzBdw4OgSvBytElMTuxUU6
+Eno5TGlyW8K86RAQXT0nGlHUQ6GkEkXe/DPaUTNmM1hGKwxuEfJH37mh57hsu95a
+/xDJ01SkqAVPc7s5fMxWTTjpZNt5hKi0tJnC8vtn6k0NDU1FyolTxn/URRzLFPv+
+dwIDAQAB
+-----END PUBLIC KEY-----' > /etc/salt/pki/minion/minion_master.pub
+###
+### hornet knows butterfly under this keys, no need to accept new keys on hornet with salt-key -A -y
+echo '-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAnCUD8q7iLArX3PYrQ3/+3y6u6k15gGkshsKg0bhJazNyZPek
+PoGsejMX1xt7ZysW1C7HVBwXs0GwwszTrhw1wnWr5C7gugkdW56vLSgOxZC6t0K2
+sIlzjyrwZTnG+M81jODaOHMtRT6jKnHDO5MNtSYYsYB2ACXls6MJ2kVyZu9xVeM1
+D8d7HQe+LOziyKoQ7gwCtIJ/yw4J2bPIWWIIFyKbvfW5LErOETfw4d9t3T97niTs
+YtxpCt6q8zh76Mg3zFKa2cmo5Epm6TXovxE5IkRbm8WiCx76sBmOa8/5gF5+/rsS
+AOjhuY4B5XOYqCDZ9ylaj/o5OzcxGIz+oheJ6wIDAQABAoIBAFZQj/IjgpteEx3u
+ZtQVeUref4q98SBvA1IrXMMR4GQGOIJf8scq37FddRxP8NODGkeI5F82eFN7SL8m
+gw2IQp+QdMjasRel2ji/a47GygOkkdKkamEEWoEV93W9jqQTx0JtObRi1u+kRIY+
+BPJ1w+oTeSsGHDTQvj2jLtsd8LO9ZAmi+c+h+8wnnvkwx+p9argKSGY/5VREbFzJ
+eZSbwQZsLzvIRPgQaZYV9Yt62gOWPsidnVhqYxWPitT2aDWRPYfr2dB6ot85GUSq
+EjS7CB9HnmtmgrLiBG8QIbGOPxLej6Z/yCiVb9Ut6fiwcBY1km3vBHuLELJdVspy
+708ERmECgYEAwyc82zTxoxxpNKF05lvo/+NRmIFhNv3AYh32ghMznC9MbUEAfNVz
+si5lYMiGMec6jsGCqqs4J9LuaR4SY+LBrjGO8ZciFDsmt1irrph57jFiEXZXn+fQ
+2uerCJWGOLEDgqD/7LXB+gOIasHKaYuHJtBZeqzxaKBSAcJKbC4XSt8CgYEAzNQt
+2/+qqIBa2QV+BuqcV1si4XngVVnFKDDxb44ivIDUMPnIFyr2alVM+6rFevKKbzOp
+Bsw/vxW4AZTrxiOGP0IdONivME4nNytwbcWagkvtwN4xu0t+WYzCaMSt3WgeVrHo
+1QRkb575IZ8bdKd8KG2pyLDsSxjqmoyaLrgJ7nUCgYABLFk3UCgrvN39DQNw5xiN
+gUZaTlzRQdFIRbnXqlnjFH23Im7oUTgy2AiP/mSgJC278fnhIMpjoucABshBhXl4
+nJ+pYCk6Sei/rW7Ky+vfvLhENpvsQC6HQmFK2etGp/nHbURcnfMel6rYSXX4EHit
+iQ8gp62D3YLgs9RStiw5rQKBgQDGTZHMkVzO392UiK230oHkTRabBxy6ZTvsql3E
+6+4TZAKLG/is/WouDkGG0ZF5c8G04WX+b9YzkLphxaTyYkhBjCewdpA9ixyKXCLw
+E8R/6zTWagfp1bAQ0KcTOX8+gOQGeR36xdLbAiUeeOTi7pfUqD8dTrSmDAxt7jwD
+iSgMVQKBgQCOL5U6r43VFgEO4mp3QP8VBKJr+3U2OagNMnI7rDooLDKHAdGcLi4J
+SFNESrNp2W74J4cTd1t6lkiPQqFXxIhQ29FtOhLqnlnydvhvdMeNFiczr6vvqdjM
+SzvdcV5/veV3hD5kMLtTdyiCKa5UavzM5EmR9fTFlM2HOXf9ZoF2RQ==
+-----END RSA PRIVATE KEY-----' > /etc/salt/pki/minion/minion.pem
+echo '-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnCUD8q7iLArX3PYrQ3/+
+3y6u6k15gGkshsKg0bhJazNyZPekPoGsejMX1xt7ZysW1C7HVBwXs0GwwszTrhw1
+wnWr5C7gugkdW56vLSgOxZC6t0K2sIlzjyrwZTnG+M81jODaOHMtRT6jKnHDO5MN
+tSYYsYB2ACXls6MJ2kVyZu9xVeM1D8d7HQe+LOziyKoQ7gwCtIJ/yw4J2bPIWWII
+FyKbvfW5LErOETfw4d9t3T97niTsYtxpCt6q8zh76Mg3zFKa2cmo5Epm6TXovxE5
+IkRbm8WiCx76sBmOa8/5gF5+/rsSAOjhuY4B5XOYqCDZ9ylaj/o5OzcxGIz+oheJ
+6wIDAQAB
+-----END PUBLIC KEY-----' > /etc/salt/pki/minion/minion.pub
+###
+### wipe disks
+for d in a b c d g h i j; do sgdisk -z /dev/sd${d};done
+###
+### enable and start salt-minion
+systemctl enable salt-minion.service
+systemctl start salt-minion.service
+###
+### add text about minion deployment via autoyast into motd
+echo '
+---------------------------------------------------------------------
+
+SAS5 node butterfly.qam.suse.cz was deployed with autoyast profile
+https://pes.suse.de/QA_Maintenance/Users/SES_Hardware
+salt-minion is configured and known to salt-master hornet.qam.suse.cz
+
+---------------------------------------------------------------------
+' > /etc/motd
+###
+### make sure host ssh key will be the same even when previous installation failed and the known key got lost
+grep 'U9MjvPWj7KDa5ETRi' /etc/ssh/ssh_host_ecdsa_key > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+echo '-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEICWwynyCGftRi2Wn7AoT0KkuACh/vAFEGUpbiD3UBg9BoAoGCCqGSM49
+AwEHoUQDQgAED/jcLr/7y6kNCCAU9MjvPWj7KDa5ETRiPyMW98/uZ+P6OLswAlBj
+MHA1PRvQmBnKskKQh1NJXCx120tUSWk4Ag==
+-----END EC PRIVATE KEY-----' > /etc/ssh/ssh_host_ecdsa_key
+fi
+grep 'TSVwsddtLVElpOAI=' /etc/ssh/ssh_host_ecdsa_key.pub > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+echo 'ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBA/43C6/+8upDQggFPTI7z1o+yg2uRE0Yj8jFvfP7mfj+ji7MAJQYzBwNT0b0JgZyrJCkIdTSVwsddtLVElpOAI= root@butterfly' > /etc/ssh/ssh_host_ecdsa_key.pub
+fi
+###
+### make eth3 inactive, was active only for installation as it was sometimes the active interface instead of eth4
+echo "BOOTPROTO='none'
+DHCLIENT_SET_DEFAULT_ROUTE='no'
+NAME='Ethernet Controller X710 for 10GbE SFP+'
+STARTMODE='hotplug'" > /etc/sysconfig/network/ifcfg-eth3
+###
+### start ssh when init-script is done
+systemctl start sshd.service
+exit 0
+]]></source>
+      </script>
+    </init-scripts>
+  </scripts>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <enable config:type="list">
+        <service>kdump-early</service>
+        <service>kdump</service>
+        <service>ntpd</service>
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <software>
+    <install_recommended config:type="boolean">true</install_recommended>
+<!-- can't be done because SES addon not registered above
+    <packages config:type="list">
+      <package>salt-minion</package>
+      <package>ceph</package>
+    </packages>
+-->
+    <patterns config:type="list">
+      <pattern>Minimal</pattern>
+      <pattern>base</pattern>
+      <pattern>yast2</pattern>
+    </patterns>
+  </software>
+  <ssh_import>
+    <copy_config config:type="boolean">true</copy_config>
+    <import config:type="boolean">true</import>
+    <device>/dev/md/root</device>
+  </ssh_import>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_code>30452ce234918d23</reg_code>
+    <slp_discovery config:type="boolean">false</slp_discovery>
+  </suse_register>
+<!-- adddon does not work on SP3 now, have re register manually
+  https://github.com/yast/yast-registration/wiki/Available-SCC-Extensions-for-Use-in-Autoyast
+  <addons config:type="list">
+    <addon>
+      <name>ses</name>
+      <version>5</version>
+      <arch>x86_64</arch>
+      <reg_code>35eb00e8035bf5b0</reg_code>
+    </addon>
+  </addons>
+-->
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Prague</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$6$lNAqqPR3$yB01ZCFVFYmSc2C9tHMk.MMwnmMGTmN5A5tVamu/Crd7VBNJ972J4oVqS7EHFxDXcqAGOl1uxePr/FrWlBQYM0</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/data/ses/fly.xml
+++ b/data/ses/fly.xml
@@ -1,0 +1,536 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <bootloader>
+    <global>
+      <activate>true</activate>
+      <append>splash=silent quiet showopts crashkernel=123M,high crashkernel=72M,low</append>
+      <boot_boot>true</boot_boot>
+      <boot_extended>false</boot_extended>
+      <boot_mbr>false</boot_mbr>
+      <boot_root>false</boot_root>
+      <generic_mbr>true</generic_mbr>
+      <gfxmode>auto</gfxmode>
+      <hiddenmenu>false</hiddenmenu>
+      <os_prober>false</os_prober>
+      <terminal>gfxterm</terminal>
+      <timeout config:type="integer">3</timeout>
+      <trusted_grub>false</trusted_grub>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <storage>
+      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
+      <start_multipath config:type="boolean">false</start_multipath>
+    </storage>
+  </general>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel config:type="list">
+      <listentry>123M,high</listentry>
+      <listentry>72M,low</listentry>
+    </crash_kernel>
+    <general>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>10</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NET_TIMEOUT>30</KDUMP_NET_TIMEOUT>
+      <KDUMP_SAVEDIR>file:///var/crash</KDUMP_SAVEDIR>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+    </general>
+  </kdump>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+  </language>
+  <networking>
+    <dhcp_options>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">false</dhcp_hostname>
+      <domain>qam.suse.cz</domain>
+      <hostname>fly</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <searchlist config:type="list">
+        <search>qam.suse.cz</search>
+      </searchlist>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth0</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>I350 Gigabit Network Connection</name>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth1</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>I350 Gigabit Network Connection</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth2</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>Ethernet Controller X710 for 10GbE SFP+</name>
+        <startmode>hotplug</startmode>
+      </interface>
+<!-- only eth4 is acive network interface, but sometimes during the installationboot is eth3 active, to avoid unnecessary complications eth3 is configured via dhcp too -->
+      <interface>
+        <bootproto>dhcp4</bootproto>
+        <device>eth3</device>
+        <dhclient_set_hostname>yes</dhclient_set_hostname>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <name>Ethernet Controller X710 for 10GbE SFP+</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>dhcp4</bootproto>
+        <device>eth4</device>
+        <dhclient_set_hostname>yes</dhclient_set_hostname>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <name>Ethernet Controller 10-Gigabit X540-AT2</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth5</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>Ethernet Controller 10-Gigabit X540-AT2</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>eth6</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <ipaddr>192.168.0.88</ipaddr>
+        <mtu>9000</mtu>
+        <name>Ethernet Controller 10-Gigabit X540-AT2</name>
+        <netmask>255.255.255.0</netmask>
+        <prefixlen>24</prefixlen>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth7</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>Ethernet Controller 10-Gigabit X540-AT2</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">false</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>ATTR{address}</rule>
+        <value>0c:c4:7a:6c:3e:ee</value>
+      </rule>
+      <rule>
+        <name>eth1</name>
+        <rule>ATTR{address}</rule>
+        <value>0c:c4:7a:6c:3e:ef</value>
+      </rule>
+      <rule>
+        <name>eth2</name>
+        <rule>ATTR{address}</rule>
+        <value>3c:fd:fe:9c:cd:9c</value>
+      </rule>
+      <rule>
+        <name>eth3</name>
+        <rule>ATTR{address}</rule>
+        <value>3c:fd:fe:9c:cd:9d</value>
+      </rule>
+      <rule>
+        <name>eth4</name>
+        <rule>ATTR{address}</rule>
+        <value>a0:36:9f:6e:32:00</value>
+      </rule>
+      <rule>
+        <name>eth5</name>
+        <rule>ATTR{address}</rule>
+        <value>a0:36:9f:6e:32:02</value>
+      </rule>
+      <rule>
+        <name>eth6</name>
+        <rule>ATTR{address}</rule>
+        <value>a0:36:9f:6d:1b:44</value>
+      </rule>
+      <rule>
+        <name>eth7</name>
+        <rule>ATTR{address}</rule>
+        <value>a0:36:9f:6d:1b:46</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+    </routing>
+    <setup_before_proposal config:type="boolean">true</setup_before_proposal>
+  </networking>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list">
+      <peer>
+        <address>hornet.qam.suse.cz</address>
+        <options>burst iburst</options>
+        <type>server</type>
+      </peer>
+      <peer>
+        <address>/var/lib/ntp/drift/ntp.drift</address>
+        <comment># path for drift file</comment>
+        <type>driftfile</type>
+      </peer>
+      <peer>
+        <address>/var/log/ntp</address>
+        <comment># alternate log file</comment>
+        <type>logfile</type>
+      </peer>
+      <peer>
+        <address>/etc/ntp.keys</address>
+        <comment># path for keys file</comment>
+        <type>keys</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># define trusted keys</comment>
+        <type>trustedkey</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># key (7) for accessing server variables</comment>
+        <type>requestkey</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># key (6) for accessing server variables</comment>
+        <type>controlkey</type>
+      </peer>
+    </peers>
+    <restricts config:type="list">
+      <restrict>
+        <options>ipv6 notrap nomodify nopeer noquery</options>
+        <target>default</target>
+      </restrict>
+      <restrict>
+        <target>127.0.0.1</target>
+      </restrict>
+      <restrict>
+        <target>::1</target>
+      </restrict>
+    </restricts>
+    <start_at_boot config:type="boolean">true</start_at_boot>
+    <start_in_chroot config:type="boolean">false</start_in_chroot>
+    <sync_interval config:type="integer">5</sync_interval>
+    <synchronize_time config:type="boolean">false</synchronize_time>
+  </ntp-client>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/md</device>
+      <disklabel>msdos</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>noatime</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_nr config:type="integer">0</partition_nr>
+          <raid_options>
+            <device_order config:type="list">
+              <device>/dev/disk/by-id/scsi-0ATA_SATA_SSD_96D707560C2400162379-part1</device>
+              <device>/dev/disk/by-id/scsi-0ATA_SATA_SSD_B4500757052400104722-part1</device>
+            </device_order>
+            <persistent_superblock config:type="boolean">false</persistent_superblock>
+            <raid_name>/dev/md/root</raid_name>
+            <raid_type>raid0</raid_type>
+          </raid_options>
+          <resize config:type="boolean">false</resize>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_MD</type>
+      <use>all</use>
+    </drive>
+    <drive>
+      <device>/dev/disk/by-id/scsi-0ATA_SATA_SSD_96D707560C2400162379</device>
+      <disklabel>gpt</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <format config:type="boolean">false</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">253</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <raid_name>/dev/md/root</raid_name>
+          <resize config:type="boolean">false</resize>
+          <size>29.7G</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">ext4</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/boot</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>max</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+    <drive>
+      <device>/dev/disk/by-id/scsi-0ATA_SATA_SSD_B4500757052400104722</device>
+      <disklabel>gpt</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <format config:type="boolean">false</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">253</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <raid_name>/dev/md/root</raid_name>
+          <resize config:type="boolean">false</resize>
+          <size>29.7G</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <scripts>
+    <init-scripts config:type="list">
+      <script>
+        <filename>post.sh</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+#!/bin/sh
+### stop ssh while script is running
+systemctl stop sshd.service
+###
+### add ssh keys, created bug bsc#1066342 as the keys are not added via <authorized_keys> in <user>
+mkdir -m 700 /root/.ssh
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDWWOicPToKZ+Pqx+rA9Ny6tBXaG9x4xUjEw2KA4Ww3s8+D8xt4HynEGaOvXd4qfAlfbs0BnGC+QMo4u2T4+MLf34pgudv1bnXSWVj7M3/OeQv7WDU8fI4W8NEmoSGZaeXAzvNTSok/6kmGEOeU4Qwxu9pcCowaeLv0f0HNH1HTK7piGq2TzAZeLdIQeXb5Fa3HKCvoKCrlt3yTzX3shIKbeBg5KvwcQ/zn1ftvLMDhBEfBO1b1eWprie6otPBbLYBawzTbQ6GMUH3GjWD2+G04xPuEVtuBEGLtZ+s6rlxMEkm3uqrKOCZW++hcqRTYttvooW5GSRGDVrppaIpzxCHH root@hornet' >> /root/.ssh/authorized_keys
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCm/z0MRb/MVoFeC0lCA45XIbUxyaZ+DTpMEEjQ30/PH2DFSdu4izguNyog+qMHmKAgBQWZWHr1DwXYTjZ4ZiQR6YShxb269S6QO0uqQ6U6SFBHwEyoaY1ooZgcPdCyjXKRSPieTHI1VojxiReDVNnDgrCObac4RWi5EU0JDSgKJI5HT+LjW9NLJGu+ikPuXbr479F6DFET5uV1ht09g5ppvkF2fDLojobaWf1og2JD7EPOg1E4MKX2juxrxSyhLFNaD1esBchKIryymQqIwAMqJsFeiU9YuAQ/N3xkvVUq3DSjeRU2okcpuo/FPP5ulHOTrRoyLQMkKl+BntCh5Sxj jpupava@suse.com' >> /root/.ssh/authorized_keys
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCqhWVTosH12864VGY5S3/k0yKc59GbV0m2WxD28gAf+uvJ1/y8gekD2wDzBv0DWqEekYLV7L68gpapDXyGosQeZ6n5OO/NZFZmW+Xq1P7P1QHJil6kVpwk927lzX440pwNf3+PRvTbLzlbuVFWJRpiykv+juJyIFjzXLJRF67wB2qgZVm5cRs/GOi4fnvTaou/Ae51mvsO8M3JL5cphApFKD/AO/X+3pHBhLjvaW33cYsp0Z4Rce1nm8wxSmvuJRF+HAfjBlknhDl5ZaJGA96RYA+g9WbAXimFprg4xeiRp7liPExQwtVgackJweoC4MahC1glmjC3eOh9dvrrxLnALOLMOkyCSK/tOF/iq2PJaLViObanPI8mnNkMLbdJyzUBf8hRGdSLcw98qxaf0sSZ+vz4VQS6e9CwX7ikkNNsTeYXjnJ+1yU3mfCW1CXJDr7kBDVG2OTLefCpMY8WBAYDiEaK0RW83cBcFIKfecKYd0qStHRaOsvmyWdFYgBh2vM1UWjro5WXlb+7aJPrUp8ZruapkUXUwhjHA7FwGA4ysE0tsOVVFm0Dw8tvyVVkVNm/9EObG28dWctioZ2+ZEzTWgMJU26Q+wOJ/U4qZyIvpMRUgPZc5nM9J8kcmvNWtb6DV9k/6p8h28kiOxPkxLtPP+3TlBCHjq//mhEnJZ/d8w== shshyukriev@suse.com' >> /root/.ssh/authorized_keys
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDEfz0lP5oO03Rw8vSyzqwt06VIEFA4x478DERaSWHPTD5ULqqdZQS1vsFpTtAm1eT4Ix4njXvSh4T2d2aXYyCgB+ElJI1h0tpbtX7OtenJ7c3rUows61jqmXLFrnIfWbZL2uhomTsOziQwxKoXS3PRxFgoRaZGzHGD4J4HOEfiP8YHQ53igUKbmmDY8yVZya/dyEtKe8bukcbZbGIosKgMoaLsdpbNkln7bU1oLqMuogHGtqRdZ9gQLz2mz5I7Ml/lSeCEdbkqVbOjydVhF2Qm4bvbVjyER+n0VqhXOmeKcauEOQbEafYrJjWvDetMY4j8NwWCeJq0QA7gYRd7967 bhavel@blackbird.suse.cz' >> /root/.ssh/authorized_keys
+###
+### register SLES and SES
+SUSEConnect -p ses/5/x86_64 -r 35eb00e8035bf5b0
+###
+### remove first repo
+zypper rr 1
+###
+### install salt-minion ceph
+zypper -n in salt-minion ceph
+###
+### set hornet as master and turn off ipv6
+sed -i 's/#master: salt/master: hornet/' /etc/salt/minion
+sed -i 's/#ipv6: False/ipv6: False/' /etc/salt/minion
+###
+### add hornet master salt pki
+echo '-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo/Ex4NV6sFAL0tUMJcC5
+5dPMbBjVKjCJ7aqm95vv2XeU0JofXywWLT8U4toKVgtM8UZfsEoJ9R6HE52lYQAJ
+48mbijjGjgcQqVGXHSksD/mrAaLioAuzESR/LM66+BFqV2rcJGoCx/aSlm8D7EeC
+3AQpKs0xHfLIq+pjR9X76idagg7Xd7pEqcz92Ggpg5fzBdw4OgSvBytElMTuxUU6
+Eno5TGlyW8K86RAQXT0nGlHUQ6GkEkXe/DPaUTNmM1hGKwxuEfJH37mh57hsu95a
+/xDJ01SkqAVPc7s5fMxWTTjpZNt5hKi0tJnC8vtn6k0NDU1FyolTxn/URRzLFPv+
+dwIDAQAB
+-----END PUBLIC KEY-----' > /etc/salt/pki/minion/minion_master.pub
+###
+### hornet knows fly under this keys, no need to accept new keys on hornet with salt-key -A -y
+echo '-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEAz8eyyThOIK2hmI+f9rA2kFuAMl1fBdoYgjB9XH9Oc8HyUZFJ
+8TL8muEE3Vx40uQVccy8tNzJJAL7RO8Rs9PXPRqrJyf9+kBjvZGxGhchaImZxl46
+suh0OtYGOxbBUp8bRVNESGLDzAtBHQQBj5jMYjJgmboBVUCI9IrwnBse/9Psk6m6
+HbuPy1LgvOeEFk1FX5QxM+NYsqAUNt7sz0guUQS+S/TrG6ZAMxEpAssHbJGnUax7
+4yD4wnWy5qhSf7/6IJyMwm+3Sc2HZXhDwuVOUw+a8aG8QP73PQ4aBKjG7KUOD/vj
+4Lkrd5nNY20h6zowxaKHTk+5u94s5NAjBXkK+QIDAQABAoIBAQC3wf00SD+QVv7b
+Veo62YzoDoRKBpnLKx8RxKCZ9V0EszoDOWMTlewhbXBH9UhF+sGca11Y9wpMdvaR
++HzHdUqeF7/WWWAcumV7eiYO1PYO5eLBtQRkxYBFqJLKH03KLDyKCyIQgoh3JFzp
+tGlM/e2Dytn0GrSjGPgGjfpNlQ7NYJ+L9U84bCsXf9O9GLQw76yTP/zy1RlhT61o
+pk/8ajy6Z6jQD9/te1pj57OCyyVBOIG12Rph3dwQX95kyHlt3phA4kCkqaSHgyYT
+N4EBucVUlfGLndV2/8wfDmwGAf+Q+ddlvWeUac1D/PtgiIZUyalVdWE9P+FzRhf/
++tM0rk8hAoGBAOIiW6c0Iq4a3XscY/XXfdNrzTrn8f3/PWk5qY9qb5AxIgNlwEl/
+I70MLNlFyTzVW1OumNJOscu25wxoH+uUfd+nDjtSn1N2zo7i4vahfGkpxsHLEeHY
+kQbbf5tOYIH1rcYZ9Kr5uLjgYnksPdvPJBKoaUea3RsFhKjyBgEg/ZoXAoGBAOs4
+yIerHEaf1p+yDj0cDyojorUymUgWGx7rvJaEozjMpy1HaIm8nVT5BKUzs8Wo7L80
+AeNWxi3dms+ac8ZCZL1ewtqlcShZzKEicrmsXnC0jz5FjZ9Ok5eN/xfVR5LLQCzK
+Xl6YsaTPor/SHDK5CxDwLXPp/+TWeI9nxTTwqn1vAoGBAL0m5ilnR7cAi9Clv8ts
+9Df7zVB/oYDHlnPFItruueEP6BaVbxFLQvaoD3+yixDSmrDVs8j+wGPZW0yacFDb
+Basljpb6loD3OPJ2QEjybSF+K14A4bVbNHxa8FNVbQ5oFXJGVc0KU4R5VIVtB1Us
+4EynCGE33cjzhbLXt0QMd3UDAoGAGD+OTI4TKCSqF2Rfm2UdGxb5WvyQWKIOwa1D
+j7C0stJGGaDW4fwTrALPu8gMrD+xyDQwTaNQYsIJh4VAkhueDveJ1shfVe2L7sCC
+Wymtwqiaa6z34IhVJrZ4qZhO/I7/Wp6yA8Zx6a+N84BRb9krjt9zkBN7UbfaTc5A
+wihdKvkCgYEAxWIjHsiono/qI/vs0NYCbKC9wGOYVSvE4AT64V0pndWawoRg+leg
+x0cH17OogpULOaVmK7ChgxhwtyPpnLbYfztNw8ox/O5n70sQ0SudR0zHLEdcqZsA
+IN+e1ERd9khTLkexB3EDLom2p+L3PgCpXunhvnp2C3DLPnGPcVrg7dE=
+-----END RSA PRIVATE KEY-----' > /etc/salt/pki/minion/minion.pem
+echo '-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAz8eyyThOIK2hmI+f9rA2
+kFuAMl1fBdoYgjB9XH9Oc8HyUZFJ8TL8muEE3Vx40uQVccy8tNzJJAL7RO8Rs9PX
+PRqrJyf9+kBjvZGxGhchaImZxl46suh0OtYGOxbBUp8bRVNESGLDzAtBHQQBj5jM
+YjJgmboBVUCI9IrwnBse/9Psk6m6HbuPy1LgvOeEFk1FX5QxM+NYsqAUNt7sz0gu
+UQS+S/TrG6ZAMxEpAssHbJGnUax74yD4wnWy5qhSf7/6IJyMwm+3Sc2HZXhDwuVO
+Uw+a8aG8QP73PQ4aBKjG7KUOD/vj4Lkrd5nNY20h6zowxaKHTk+5u94s5NAjBXkK
++QIDAQAB
+-----END PUBLIC KEY-----' > /etc/salt/pki/minion/minion.pub
+###
+### wipe disks
+for d in a b c d g h i j; do sgdisk -z /dev/sd${d};done
+###
+### enable and start salt-minion
+systemctl enable salt-minion.service
+systemctl start salt-minion.service
+###
+### add text about minion deployment via autoyast into motd
+echo '
+---------------------------------------------------------------------
+
+SAS5 node fly.qam.suse.cz was deployed with autoyast profile
+https://pes.suse.de/QA_Maintenance/Users/SES_Hardware
+salt-minion is configured and known to salt-master hornet.qam.suse.cz
+
+---------------------------------------------------------------------
+' > /etc/motd
+###
+### make sure host ssh key will be the same even when previous installation failed and the known key got lost
+grep '7CiwKmyjh77mSlXCH' /etc/ssh/ssh_host_ecdsa_key > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+echo '-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIMG6efSu4a1zfXmZ65YZ80CifprVK2BjbwCZS4rGJeHJoAoGCCqGSM49
+AwEHoUQDQgAE7M7lLwxv1HphfphFRvcpz/7CiwKmyjh77mSlXCHzAOnh0AFlUu9O
+5wQwQgyN0FDFiOn0u8bC7kUze9YzjSYJsQ==
+-----END EC PRIVATE KEY-----' > /etc/ssh/ssh_host_ecdsa_key
+fi
+grep 'Gwu5FM3vWM40mCbE=' /etc/ssh/ssh_host_ecdsa_key.pub > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+echo 'ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBOzO5S8Mb9R6YX6YRUb3Kc/+wosCpso4e+5kpVwh8wDp4dABZVLvTucEMEIMjdBQxYjp9LvGwu5FM3vWM40mCbE= root@fly' > /etc/ssh/ssh_host_ecdsa_key.pub
+fi
+###
+### make eth3 inactive, was active only for installation as it was sometimes the active interface instead of eth4
+echo "BOOTPROTO='none'
+DHCLIENT_SET_DEFAULT_ROUTE='no'
+NAME='Ethernet Controller X710 for 10GbE SFP+'
+STARTMODE='hotplug'" > /etc/sysconfig/network/ifcfg-eth3
+###
+### start ssh when init-script is done
+systemctl start sshd.service
+exit 0
+
+]]></source>
+      </script>
+    </init-scripts>
+  </scripts>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <enable config:type="list">
+        <service>kdump-early</service>
+        <service>kdump</service>
+        <service>ntpd</service>
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <software>
+    <install_recommended config:type="boolean">true</install_recommended>
+<!-- can't be done because SES addon not registered above
+    <packages config:type="list">
+      <package>salt-minion</package>
+      <package>ceph</package>
+    </packages>
+-->
+    <patterns config:type="list">
+      <pattern>Minimal</pattern>
+      <pattern>base</pattern>
+      <pattern>yast2</pattern>
+    </patterns>
+  </software>
+  <ssh_import>
+    <copy_config config:type="boolean">true</copy_config>
+    <import config:type="boolean">true</import>
+    <device>/dev/md/root</device>
+  </ssh_import>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_code>30452ce234918d23</reg_code>
+    <slp_discovery config:type="boolean">false</slp_discovery>
+  </suse_register>
+<!-- adddon does not work on SP3 now, have re register manually
+  https://github.com/yast/yast-registration/wiki/Available-SCC-Extensions-for-Use-in-Autoyast
+  <addons config:type="list">
+    <addon>
+      <name>ses</name>
+      <version>5</version>
+      <arch>x86_64</arch>
+      <reg_code>35eb00e8035bf5b0</reg_code>
+    </addon>
+  </addons>
+-->
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Prague</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$6$gRzdeqRI$WO0G5r8b5kqLH2.nJ1jIcwgQxe4C1u/OzesQ8duEUITFT3JN3aLxPsbi9GxJ3c2DvaM/IBudvpNkc27XeFPaY1</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/data/ses/hornet.xml
+++ b/data/ses/hornet.xml
@@ -1,0 +1,644 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <bootloader>
+    <global>
+      <activate>true</activate>
+      <append>resume=/dev/sda3 splash=silent quiet showopts crashkernel=112M,high crashkernel=72M,low</append>
+      <boot_boot>true</boot_boot>
+      <boot_extended>false</boot_extended>
+      <boot_mbr>false</boot_mbr>
+      <boot_root>false</boot_root>
+      <generic_mbr>true</generic_mbr>
+      <gfxmode>auto</gfxmode>
+      <hiddenmenu>false</hiddenmenu>
+      <os_prober>false</os_prober>
+      <terminal>gfxterm</terminal>
+      <timeout config:type="integer">3</timeout>
+      <trusted_grub>false</trusted_grub>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <storage>
+      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
+      <start_multipath config:type="boolean">false</start_multipath>
+    </storage>
+  </general>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel config:type="list">
+      <listentry>102M,high</listentry>
+      <listentry>72M,low</listentry>
+    </crash_kernel>
+    <general>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>10</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NET_TIMEOUT>30</KDUMP_NET_TIMEOUT>
+      <KDUMP_SAVEDIR>file:///var/crash</KDUMP_SAVEDIR>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+    </general>
+  </kdump>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+  </language>
+  <networking>
+    <dhcp_options>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">false</dhcp_hostname>
+      <domain>qam.suse.cz</domain>
+      <hostname>hornet</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <searchlist config:type="list">
+        <search>qam.suse.cz</search>
+      </searchlist>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>static</bootproto>
+        <device>eth0</device>
+        <ipaddr>192.168.0.84</ipaddr>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>I210 Gigabit Network Connection</name>
+        <netmask>255.255.255.0</netmask>
+        <prefixlen>24</prefixlen>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>dhcp4</bootproto>
+        <device>eth1</device>
+        <dhclient_set_hostname>yes</dhclient_set_hostname>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <name>I210 Gigabit Network Connection</name>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">false</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>ATTR{address}</rule>
+        <value>0c:c4:7a:77:90:c8</value>
+      </rule>
+      <rule>
+        <name>eth1</name>
+        <rule>ATTR{address}</rule>
+        <value>0c:c4:7a:77:90:c9</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+    </routing>
+    <setup_before_proposal config:type="boolean">true</setup_before_proposal>
+  </networking>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list">
+      <peer>
+        <address>ntp1.suse.cz</address>
+        <options>burst iburst</options>
+        <type>server</type>
+      </peer>
+      <peer>
+        <address>/var/lib/ntp/drift/ntp.drift</address>
+        <comment># path for drift file</comment>
+        <type>driftfile</type>
+      </peer>
+      <peer>
+        <address>/var/log/ntp</address>
+        <comment># alternate log file</comment>
+        <type>logfile</type>
+      </peer>
+      <peer>
+        <address>/etc/ntp.keys</address>
+        <comment># path for keys file</comment>
+        <type>keys</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># define trusted keys</comment>
+        <type>trustedkey</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># key (7) for accessing server variables</comment>
+        <type>requestkey</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># key (6) for accessing server variables</comment>
+        <type>controlkey</type>
+      </peer>
+    </peers>
+    <restricts config:type="list">
+      <restrict>
+        <options>ipv6 notrap nomodify nopeer noquery</options>
+        <target>default</target>
+      </restrict>
+      <restrict>
+        <target>127.0.0.1</target>
+      </restrict>
+      <restrict>
+        <target>::1</target>
+      </restrict>
+    </restricts>
+    <start_at_boot config:type="boolean">true</start_at_boot>
+    <start_in_chroot config:type="boolean">false</start_in_chroot>
+    <sync_interval config:type="integer">5</sync_interval>
+    <synchronize_time config:type="boolean">false</synchronize_time>
+  </ntp-client>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/md</device>
+      <disklabel>msdos</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">false</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>noatime</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_nr config:type="integer">0</partition_nr>
+          <raid_options>
+            <device_order config:type="list">
+              <device>/dev/sdb2</device>
+              <device>/dev/sda2</device>
+            </device_order>
+            <persistent_superblock config:type="boolean">false</persistent_superblock>
+            <raid_name>/dev/md/root</raid_name>
+            <raid_type>raid0</raid_type>
+          </raid_options>
+          <resize config:type="boolean">false</resize>
+        </partition>
+        <partition>
+          <create config:type="boolean">false</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">false</format>
+          <fstopt>noatime</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/var/nfsshare</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_nr config:type="integer">1</partition_nr>
+          <raid_options>
+            <device_order config:type="list">
+              <device>/dev/sdb1</device>
+              <device>/dev/sda1</device>
+            </device_order>
+            <persistent_superblock config:type="boolean">false</persistent_superblock>
+            <raid_name>/dev/md/nfsshare</raid_name>
+            <raid_type>raid1</raid_type>
+          </raid_options>
+          <resize config:type="boolean">false</resize>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_MD</type>
+      <use>0</use>
+    </drive>
+    <drive>
+      <device>/dev/sda</device>
+      <disklabel>gpt</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">false</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">false</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <format config:type="boolean">false</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">253</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <resize config:type="boolean">false</resize>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <format config:type="boolean">false</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">253</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>200G</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <label>swapa</label>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>swap</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">3</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>8G</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">ext4</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/boot</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">4</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>500M</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>2,3,4</use>
+    </drive>
+    <drive>
+      <device>/dev/sdb</device>
+      <disklabel>gpt</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">false</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">false</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <format config:type="boolean">false</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">253</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <resize config:type="boolean">false</resize>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <format config:type="boolean">false</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">253</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>200G</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <label>swapb</label>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>swap</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">3</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>8G</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>2,3</use>
+    </drive>
+  </partitioning>
+  <scripts>
+    <init-scripts config:type="list">
+      <script>
+        <filename>post.sh</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+#!/bin/sh
+###
+### stop ssh while script is running
+systemctl stop sshd.service
+###
+### create .ssh directory
+mkdir -m 700 /root/.ssh
+###
+### create ssh rsa key
+echo '-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA1ljonD06Cmfj6sfqwPTcurQV2hvceMVIxMNigOFsN7PPg/Mb
+eB8pxBmjr13eKnwJX27NAZxgvkDKOLtk+PjC39+KYLnb9W510llY+zN/znkL+1g1
+PHyOFvDRJqEhmWnlwM7zU0qJP+pJhhDnlOEMMbvaXAqMGni79H9BzR9R0yu6Yhqt
+k8wGXi3SEHl2+RWtxygr6Cgq5bd8k8197ISCm3gYOSr8HEP859X7byzA4QRHwTtW
+9Xlqa4nuqLTwWy2AWsM020OhjFB9xo1g9vhtOMT7hFbbgRBi7WfrOq5cTBJJt7qq
+yjgmVvvoXKkU2Lbb6KFuRkkRg1a6aWiKc8QhxwIDAQABAoIBABdl6S50+Ir+QED2
+xcd+c0HmOqRueiis0H66HVyYPunttO9gcFUygaqoadfQ1Vmp5JQIUlSkr2LVS73Z
+pvIOpacujbp1T2+BOVdW7YGuY3s0d3xeaqFJr3ENpKck27gVeUEM1j73WfgiKRh7
+a+wyjNQ4/2Mgu56AI3RTF+m+S35Tin57CZk70rk9a/cSbVsMOZrg+RqKyAGCLpDM
+SFrnbm9MZfj1Rj2Ccucgo9T+mXBGxpLb5rg+f5jXmYtecJI0hcNvNA71XANLU5J3
+pCMP63GaTbP40oLlMjG16KATHmdc28pPy6+SGIeKiyqW9FsWzb0W3BMFhB4LcdER
+seeZycECgYEA8qo18GBPsqMWy3H8TRUDZex3jIf8x0nLhhfXF9YB/e6TNWz/VsxT
+Su0/8Fx6joOKsO21ERZURzejk6ZuwJjqogZq9nsbEAXLVkOhhCeBAOi/7JwTQOZP
+6ZueD0ddfl4BxjgbtCeNo9xJOo69EuFOONfkjrZVMPJiHaevuc/t+9ECgYEA4iBU
+GLoyr0zelj02p0wllK3eEbALPDxxXRQDz/d08aXZv1KaUbE/ntBOOdH7nEFE9Lyt
+XUTxeIkqni1JjWsx6GwSH/QKHf2iLhpjXC1KY3SHVmTq14TvGPS++AF+3kVC20Vh
+Do/Z9Lcig9MkXqVZk/fh1R4aICJ4O0MijuTU4hcCgYAurxAxblXmx/laqlMfgStm
+MFfPcVnv/QJqiauXqlQ3xe4MGSwGRsi/YWUrmJ77S9Mitphe8SzFhq6xeRNVehWp
+lhJ92LEcJAE6V0h7ZB4tTpmdq2kI00YMayO9TL1v0iYFPEYYIoPdQkPUQCGfwDiM
+NvyBeBJrmDXH/rqPxLDEAQKBgQCIV0u9eQ80aVnQJmp8psoGAmtiKM4tbJhBsd62
+lxK43PIUjJ6lYQTmIdz4ueZGiYglNFonYXli3vmGU/IERbza0cZ/46nx+Uq/F4QP
+QPOYUduEOObsOafcWT2H1YcER6iPAx8JI60cAwvZhgZo1rPTJuPQlwzTkVUDDnCY
+zdqZ0wKBgQDnCFpK4n5OYnPGXCKhGi9f5N4yirb36Ouj11SC9QwtF41VHcd6KQmW
+8Evtf8ac/ea2hkHTwYiOVGvTe+J6eg+LxtJA3dtmzdQub1zRbz9GoeVV9wsDmagG
+vAHniM+EWXpoQ1jPOwrNyCdhBMOpBhQCTLxetrPQWH9yLJTX4cS9Cw==
+-----END RSA PRIVATE KEY-----' > /root/.ssh/id_rsa
+chmod 600 /root/.ssh/id_rsa
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDWWOicPToKZ+Pqx+rA9Ny6tBXaG9x4xUjEw2KA4Ww3s8+D8xt4HynEGaOvXd4qfAlfbs0BnGC+QMo4u2T4+MLf34pgudv1bnXSWVj7M3/OeQv7WDU8fI4W8NEmoSGZaeXAzvNTSok/6kmGEOeU4Qwxu9pcCowaeLv0f0HNH1HTK7piGq2TzAZeLdIQeXb5Fa3HKCvoKCrlt3yTzX3shIKbeBg5KvwcQ/zn1ftvLMDhBEfBO1b1eWprie6otPBbLYBawzTbQ6GMUH3GjWD2+G04xPuEVtuBEGLtZ+s6rlxMEkm3uqrKOCZW++hcqRTYttvooW5GSRGDVrppaIpzxCHH root@hornet' > /root/.ssh/id_rsa.pub
+###
+### add nodes to known hosts
+echo 'bee,10.100.12.186 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNg4SNK2IFqo3h6ilUvpfnoW/Lq+8opELCL31Mzw8CM+u1LIAcn4TuOG0zqT7GCexKvQJiXM21GUROkGQd5Bt88=
+fly,10.100.12.188 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBOzO5S8Mb9R6YX6YRUb3Kc/+wosCpso4e+5kpVwh8wDp4dABZVLvTucEMEIMjdBQxYjp9LvGwu5FM3vWM40mCbE=
+mosquito,10.100.12.190 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPWrP/kyRVDtndzYBu6ut2y9hV2YfPMu/IS1O3T2YhtKChXmZD9gaC8owXAC4MxXBxv2UDUnN/vaePlcKgHJ7TE=
+butterfly,10.100.12.192 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBA/43C6/+8upDQggFPTI7z1o+yg2uRE0Yj8jFvfP7mfj+ji7MAJQYzBwNT0b0JgZyrJCkIdTSVwsddtLVElpOAI=' > /root/.ssh/known_hosts
+###
+### add ssh keys, created bug bsc#1066342 as the keys are not added via <authorized_keys> in <user>
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCm/z0MRb/MVoFeC0lCA45XIbUxyaZ+DTpMEEjQ30/PH2DFSdu4izguNyog+qMHmKAgBQWZWHr1DwXYTjZ4ZiQR6YShxb269S6QO0uqQ6U6SFBHwEyoaY1ooZgcPdCyjXKRSPieTHI1VojxiReDVNnDgrCObac4RWi5EU0JDSgKJI5HT+LjW9NLJGu+ikPuXbr479F6DFET5uV1ht09g5ppvkF2fDLojobaWf1og2JD7EPOg1E4MKX2juxrxSyhLFNaD1esBchKIryymQqIwAMqJsFeiU9YuAQ/N3xkvVUq3DSjeRU2okcpuo/FPP5ulHOTrRoyLQMkKl+BntCh5Sxj jpupava@suse.com' >> /root/.ssh/authorized_keys
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCqhWVTosH12864VGY5S3/k0yKc59GbV0m2WxD28gAf+uvJ1/y8gekD2wDzBv0DWqEekYLV7L68gpapDXyGosQeZ6n5OO/NZFZmW+Xq1P7P1QHJil6kVpwk927lzX440pwNf3+PRvTbLzlbuVFWJRpiykv+juJyIFjzXLJRF67wB2qgZVm5cRs/GOi4fnvTaou/Ae51mvsO8M3JL5cphApFKD/AO/X+3pHBhLjvaW33cYsp0Z4Rce1nm8wxSmvuJRF+HAfjBlknhDl5ZaJGA96RYA+g9WbAXimFprg4xeiRp7liPExQwtVgackJweoC4MahC1glmjC3eOh9dvrrxLnALOLMOkyCSK/tOF/iq2PJaLViObanPI8mnNkMLbdJyzUBf8hRGdSLcw98qxaf0sSZ+vz4VQS6e9CwX7ikkNNsTeYXjnJ+1yU3mfCW1CXJDr7kBDVG2OTLefCpMY8WBAYDiEaK0RW83cBcFIKfecKYd0qStHRaOsvmyWdFYgBh2vM1UWjro5WXlb+7aJPrUp8ZruapkUXUwhjHA7FwGA4ysE0tsOVVFm0Dw8tvyVVkVNm/9EObG28dWctioZ2+ZEzTWgMJU26Q+wOJ/U4qZyIvpMRUgPZc5nM9J8kcmvNWtb6DV9k/6p8h28kiOxPkxLtPP+3TlBCHjq//mhEnJZ/d8w== shshyukriev@suse.com' >> /root/.ssh/authorized_keys
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDEfz0lP5oO03Rw8vSyzqwt06VIEFA4x478DERaSWHPTD5ULqqdZQS1vsFpTtAm1eT4Ix4njXvSh4T2d2aXYyCgB+ElJI1h0tpbtX7OtenJ7c3rUows61jqmXLFrnIfWbZL2uhomTsOziQwxKoXS3PRxFgoRaZGzHGD4J4HOEfiP8YHQ53igUKbmmDY8yVZya/dyEtKe8bukcbZbGIosKgMoaLsdpbNkln7bU1oLqMuogHGtqRdZ9gQLz2mz5I7Ml/lSeCEdbkqVbOjydVhF2Qm4bvbVjyER+n0VqhXOmeKcauEOQbEafYrJjWvDetMY4j8NwWCeJq0QA7gYRd7967 bhavel@blackbird.suse.cz' >> /root/.ssh/authorized_keys
+###
+### register SLES and SES
+SUSEConnect -p ses/5/x86_64 -r 35eb00e8035bf5b0
+###
+### remove first repo
+zypper rr 1
+###
+### install salt-master salt-minion deepsea ceph openattic
+zypper -n in salt-master salt-minion deepsea ceph openattic
+###
+### setup hornet master
+sed -i 's/#ipv6: False/ipv6: False/' /etc/salt/master
+###
+### set hornet as master and turn off ipv6
+sed -i 's/#master: salt/master: hornet/' /etc/salt/minion
+sed -i 's/#ipv6: False/ipv6: False/' /etc/salt/minion
+###
+### add hornet master salt pki and accept all minions
+echo '-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo/Ex4NV6sFAL0tUMJcC5
+5dPMbBjVKjCJ7aqm95vv2XeU0JofXywWLT8U4toKVgtM8UZfsEoJ9R6HE52lYQAJ
+48mbijjGjgcQqVGXHSksD/mrAaLioAuzESR/LM66+BFqV2rcJGoCx/aSlm8D7EeC
+3AQpKs0xHfLIq+pjR9X76idagg7Xd7pEqcz92Ggpg5fzBdw4OgSvBytElMTuxUU6
+Eno5TGlyW8K86RAQXT0nGlHUQ6GkEkXe/DPaUTNmM1hGKwxuEfJH37mh57hsu95a
+/xDJ01SkqAVPc7s5fMxWTTjpZNt5hKi0tJnC8vtn6k0NDU1FyolTxn/URRzLFPv+
+dwIDAQAB
+-----END PUBLIC KEY-----'|tee /etc/salt/pki/master/master.pub /etc/salt/pki/minion/minion_master.pub
+###
+### add minion pki keys
+echo '-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5jTWMFEjQ1wSa96xndk2
+QYjf+XmGGQW5dSTrHLq9Lj2VrkcavKpWS1Dp+rtyRFdJ1ESF6lp8ok1kmIpCTARe
+5JW97SqsbzllswZPNrINwV/QTx9prDFIjQkFH2C/P1f12qWaWJrFhL7symMx1d6D
+b+Pk2XQARYyblFtstztUZIh8+WhNJlLKOjqoOtQ1Cu8y2ss+atQYKKhf5R/k9j4K
+1CDOH9plGicsGl3hj1P3Oz7/JTSfACaPyf15WT7ppZ7cX8C/mgBBxDzKCSzq34nD
+wJgtl39MldTyAKBXrEQhUVkGWMkByypL41fhgkBOrtXFiShYJq97HLzpUSGaKUbP
+LQIDAQAB
+-----END PUBLIC KEY-----' > /etc/salt/pki/master/minions/hornet.qam.suse.cz
+echo '-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwqRLz+6xom/vR+u0DUJe
+TL2bQN+4e83eCKVG8Hk+RB+FqIewW4viMaWBymWXa7Au9O84ArgAQkEX7Wxu+k7i
+P9cLfU5RCVgQ67a+rRSl8K5nBLV8tVl1Qd6pClLTREDHya6UuexoG3Qr4nsGJKbm
+aS/PncKYrfdbyV5qGx79m0B7VqKbHkrYdknw9dDUfPW4ndchEWE4jE2Cf+2aX05t
+N0jGohLZ/x6pN2hc8vgA1SCORbxEjWp/BJERGBY2NHyZp3dGwWq9A4zHkOkQ4/OS
+XKqeH6qjjpLqoVG2PE9czfuU8ymtta2V/NjKbFUfKgB/PQwo1FusC40yxYLyrups
+bwIDAQAB
+-----END PUBLIC KEY-----' > /etc/salt/pki/master/minions/bee.qam.suse.cz
+echo '-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAz8eyyThOIK2hmI+f9rA2
+kFuAMl1fBdoYgjB9XH9Oc8HyUZFJ8TL8muEE3Vx40uQVccy8tNzJJAL7RO8Rs9PX
+PRqrJyf9+kBjvZGxGhchaImZxl46suh0OtYGOxbBUp8bRVNESGLDzAtBHQQBj5jM
+YjJgmboBVUCI9IrwnBse/9Psk6m6HbuPy1LgvOeEFk1FX5QxM+NYsqAUNt7sz0gu
+UQS+S/TrG6ZAMxEpAssHbJGnUax74yD4wnWy5qhSf7/6IJyMwm+3Sc2HZXhDwuVO
+Uw+a8aG8QP73PQ4aBKjG7KUOD/vj4Lkrd5nNY20h6zowxaKHTk+5u94s5NAjBXkK
++QIDAQAB
+-----END PUBLIC KEY-----' > /etc/salt/pki/master/minions/fly.qam.suse.cz
+echo '-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwO80xTKKXFpcbSAtI2Xm
+jdSnRJkgNekWLchrQWoIvoHrQ+D49BVnSAIyO3ZfsXY7rW3xblxgIMnVhVCI/b1Z
+wmu9ZjUHJF80/jGc/tmpzG7FxF09newowweyU2zebO8KLTe6YV6wx5uAlrmL9pfv
+YFTBXrRMUfw1J2NfI2FGxTrp1ruMqyttJK6afCYEoPQB46wySI+c1s8li6peM3mW
+y6kP6e/WBO/UrSOMG8t7r77nEOEbemXUtk/3Yj4POWudBSSEJBmfdhZB5PDKd4ft
+j1vqHUDZU3/ygS3buGgEDZbahv22V45f/st85wy9PEoAdVHSrZdJPV+ZI1DBmZwz
+KwIDAQAB
+-----END PUBLIC KEY-----' > /etc/salt/pki/master/minions/mosquito.qam.suse.cz
+echo '-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAnCUD8q7iLArX3PYrQ3/+
+3y6u6k15gGkshsKg0bhJazNyZPekPoGsejMX1xt7ZysW1C7HVBwXs0GwwszTrhw1
+wnWr5C7gugkdW56vLSgOxZC6t0K2sIlzjyrwZTnG+M81jODaOHMtRT6jKnHDO5MN
+tSYYsYB2ACXls6MJ2kVyZu9xVeM1D8d7HQe+LOziyKoQ7gwCtIJ/yw4J2bPIWWII
+FyKbvfW5LErOETfw4d9t3T97niTsYtxpCt6q8zh76Mg3zFKa2cmo5Epm6TXovxE5
+IkRbm8WiCx76sBmOa8/5gF5+/rsSAOjhuY4B5XOYqCDZ9ylaj/o5OzcxGIz+oheJ
+6wIDAQAB
+-----END PUBLIC KEY-----' > /etc/salt/pki/master/minions/butterfly.qam.suse.cz
+###
+### hornet master pki keys
+echo '-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAo/Ex4NV6sFAL0tUMJcC55dPMbBjVKjCJ7aqm95vv2XeU0Jof
+XywWLT8U4toKVgtM8UZfsEoJ9R6HE52lYQAJ48mbijjGjgcQqVGXHSksD/mrAaLi
+oAuzESR/LM66+BFqV2rcJGoCx/aSlm8D7EeC3AQpKs0xHfLIq+pjR9X76idagg7X
+d7pEqcz92Ggpg5fzBdw4OgSvBytElMTuxUU6Eno5TGlyW8K86RAQXT0nGlHUQ6Gk
+EkXe/DPaUTNmM1hGKwxuEfJH37mh57hsu95a/xDJ01SkqAVPc7s5fMxWTTjpZNt5
+hKi0tJnC8vtn6k0NDU1FyolTxn/URRzLFPv+dwIDAQABAoIBAHciipWRbRP9R2pR
+yf8RW8YpMM+JCDcdiM3+ilE7r4PAA5PHvG6D8iW1Rq9HteUrVyGqe1T3qN7I7W4S
+zKB9z7IJyw8aDSge+DujAAZ/6fY9/8gzny6g8eLOO+DK5lHpDfcyv4FyzEyV4ZaS
+XC5zFSRfna7t5/iUesF7leQZG3TfM0u67XwYlh/dKzFFoQMlcR7f9zJsOiirhzjt
+viAmbvRZ5RHNchA4DyYTdvjfqMBlMbInoWLh8jBACmGR5M9vXb4X0PitI6yVxNwq
+jMuWhHE/e1xh+rufSim3FPHqgNgm6zZ81uEo4f/SF2P+bwAg7Ms3SKlMhQXHcJ5E
+DhQ8ZfECgYEAuxf72GX6pl/1At1pd5D/2InvDc32J+mM+aYFwCEPMaeg9SmbrXjD
+P8FxW6ryJLuGsG8OvNJgDYFG9/0ByR5UPufAVRXCuhyj7LReillQHqXyDBOragrs
+7/SmxR0XLkfJ0UYrPzo5Z9AmaHC2fZFB8Nrpl/GmX/K7p3/V6OGv3D8CgYEA4FJi
+SWNz/zxGV0iAsiXRjxQg3X/CqwSf7slJTQt9V2dSwy73I2nlhinAKsDCjv5zqVBj
+LEFbp+VFA7u3PKF8/QlahO4Gy8+Z/2QmyWIy++eScn6r576OdvsvJRk5U4ENOUGv
+1rUao1nLJGv+qlBbdgHOhnADTgjL+6yH17Nnr8kCgYAvj4VCGYqCSNpsBAUPlBi1
+3zqZ88Wjl8dynzXPBZhrMwXDzPP6QTzBNFewyeAMXm964oCIl6I7TKXR3MtbaQ5Z
+f2hxOLrrvOQfBCsUWGf5oo3JbCajKmvZBARxD1gZN76iKIhN5ms5bLyWyDBb81Uj
++UJwkcmNkpMJnYGvVc/y2QKBgHDkRR6V9Iyg8u1+SXZeXgZZpOiUIY4bt7leh4tE
+mwHft+EOw8WIx8ArRtC9TazVFbRCBocBJXVrhr4IPIFA7DwT9wArIjRz+BZ1eqei
+yfHIawVABpeMaPosE1/iP91sdxE3o5y0bAGFcRyVVQa1hjHvWtaBjMg62R2BiKPf
+X/ExAoGAIkB2y3jbWIVRINWBnU0xsFBK4lgg86avZ58p8BCglsMmQi9J579Mu1kQ
+XAYkZUi3UGTRZbn7tgT8Dt6AAkblxQ5ZnzSp64iNptwQqK/QYHOAJ/3+yoYb0OIg
+zuU32KVHZrh3xZn+BjmzHdYqPMisc8lHDMed8Dm6g5EG0Eh9FdI=
+-----END RSA PRIVATE KEY-----' > /etc/salt/pki/master/master.pem
+###
+### hornet knows hornet minion under this keys, no need to accept new keys on hornet with salt-key -A -y
+echo '-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA5jTWMFEjQ1wSa96xndk2QYjf+XmGGQW5dSTrHLq9Lj2Vrkca
+vKpWS1Dp+rtyRFdJ1ESF6lp8ok1kmIpCTARe5JW97SqsbzllswZPNrINwV/QTx9p
+rDFIjQkFH2C/P1f12qWaWJrFhL7symMx1d6Db+Pk2XQARYyblFtstztUZIh8+WhN
+JlLKOjqoOtQ1Cu8y2ss+atQYKKhf5R/k9j4K1CDOH9plGicsGl3hj1P3Oz7/JTSf
+ACaPyf15WT7ppZ7cX8C/mgBBxDzKCSzq34nDwJgtl39MldTyAKBXrEQhUVkGWMkB
+yypL41fhgkBOrtXFiShYJq97HLzpUSGaKUbPLQIDAQABAoIBAGfP1+8+B7ruoFgI
+uuxF8dOn1+j2xmQuUq3jEiuIgpuBpihLZGFEJ1obiQhK04LCIkcZB5Lhb2b5o62u
+W6tQJULLzDRRlCUsKxKKe9pcfRuBC71CmzLNnrwLH0ZBKL11+ya4m1vtn7j3KG00
+QlsB1x/0E1WEnELA38ANYn9Wv/39O/jfWsDPxFqbNLgna30JafI2GKVNTpBXY+4M
+dJuluN5/tMagfs12wDFrVPK5OoWExgAscH7YRQFPaiKgO5zDnWH6CHCw/R9ZF7tV
+ahv8uj5q5O9+baY+EjQBudwQc+XDfZE371U36OONvwj1Lc1tPg4Hc5nTx18DiyaM
+31UsRcECgYEA8IkTvUowNq+tjssM0wEdFdoHSjgOAeGLK08vNXVAyhBuVK1+W8L9
+t2p/AIkbLiQflYwQV5FllQoFa4Yf9raPXPGMMxvexflcwGFvxm+VkvlVgeywat2U
+DkTxz6Rx2T3E+nmWP4HpTTc5rYpgDQSWzL/hxti3nEnmmN6zTLvr7nUCgYEA9QHB
+cqrKirhO6UfltBT4QLGyhLACz0BkhuFvj/1+3kqqSUzBRE/+Wyq89HqaudI6+r/o
+1XZ5Sw0gnWPg/tghRWpLiNBN9NnpJBIrPhmEHj+0tEYkgWQqBItmV64zVQh6kXhZ
+RBG4EDEX23Pl8xgtKsFum2ksMk1Ym7hMm5xpNtkCgYBoRlSbW90Y6AHqhFYT50iv
+n2xHnZNc92T4qoRBvYoPzx21cdz0dMy+xdk25zk0QI68qxKuk6ag/M4qteOHdc8i
+sMhho7RoyNiPwe3N7bO/Gn4aK/yy50n3AaZ+qMB+OAv7tdgPwgbc5ZMIi5NmMVYa
+fximtm6qv1LLdMfv/QujvQKBgHes390u57hSxtjUMbOA+rI/GkAN6ZFqlq/7tg7T
+eAEE36DmSREhMdE+UwXoTWOu+Pg6fXSnZh/uzZuTifdxgu7xOOwfM7UCLAtehJjU
+xeAwpgfYq0Q4tP17SgZSJOjIN3aPHqtNLGdcU5byScQwbv+PdIOdH+WCOmH16BWq
+lQohAoGBALrwKFy5hHwN2XKJPEMXTuDqQvr30vqkqBObknWsFNnAWlVJdu83wl+c
+osag0RXSh3KOx9ppeKiYYrvHxNiNWlc0Hl6NnA+qI7utrXNssA3pm9ZW6buLA+JI
+IPsNLq5kY9Q4SIOnmsaFX/s9u0ndf3BY+aTV6RoO5RnmcVMnlRb/
+-----END RSA PRIVATE KEY-----' > /etc/salt/pki/minion/minion.pem
+echo '-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5jTWMFEjQ1wSa96xndk2
+QYjf+XmGGQW5dSTrHLq9Lj2VrkcavKpWS1Dp+rtyRFdJ1ESF6lp8ok1kmIpCTARe
+5JW97SqsbzllswZPNrINwV/QTx9prDFIjQkFH2C/P1f12qWaWJrFhL7symMx1d6D
+b+Pk2XQARYyblFtstztUZIh8+WhNJlLKOjqoOtQ1Cu8y2ss+atQYKKhf5R/k9j4K
+1CDOH9plGicsGl3hj1P3Oz7/JTSfACaPyf15WT7ppZ7cX8C/mgBBxDzKCSzq34nD
+wJgtl39MldTyAKBXrEQhUVkGWMkByypL41fhgkBOrtXFiShYJq97HLzpUSGaKUbP
+LQIDAQAB
+-----END PUBLIC KEY-----' > /etc/salt/pki/minion/minion.pub
+###
+### set some default configuration
+#sed -i 's/^deepsea_minions:/# deepsea_minions:/' /srv/pillar/ceph/deepsea_minions.sls
+#sed -i 's/^# deepsea_minions: '\''\*'\''/deepsea_minions: '\''*\'\''/' /srv/pillar/ceph/deepsea_minions.sls
+#salt '*' grains.append deepsea default
+###
+### enable and start salt-minion
+systemctl enable salt-master.service
+systemctl start salt-master.service
+systemctl enable salt-minion.service
+systemctl start salt-minion.service
+### add text about minion deployment via autoyast into motd
+echo '
+---------------------------------------------------------------------
+
+SAS5 master node hornet.qam.suse.cz was deployed with autoyast profile
+https://pes.suse.de/QA_Maintenance/Users/SES_Hardware
+hornet.qam.suse.cz is configured as salt-msater
+salt-minion is configured and known to salt-master hornet.qam.suse.cz
+
+---------------------------------------------------------------------
+' > /etc/motd
+###
+### start ssh when init-script is done
+systemctl start sshd.service
+exit 0
+
+]]></source>
+      </script>
+    </init-scripts>
+  </scripts>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <enable config:type="list">
+        <service>kdump-early</service>
+        <service>kdump</service>
+        <service>ntpd</service>
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <nfs_server>
+    <nfs_exports config:type="list">
+      <nfs_export>
+        <allowed config:type="list">
+          <allowed_clients>*(rw,no_root_squash,sync,no_subtree_check)</allowed_clients>
+        </allowed>
+        <mountpoint>/var/nfsshare</mountpoint>
+      </nfs_export>
+    </nfs_exports>
+    <start_nfsserver config:type="boolean">true</start_nfsserver>
+  </nfs_server>
+  <software>
+    <install_recommended config:type="boolean">true</install_recommended>
+<!-- can't be done because SES addon not registered above
+    <packages config:type="list">
+      <package>salt-minion</package>
+      <package>ceph</package>
+    </packages>
+-->
+    <patterns config:type="list">
+      <pattern>Minimal</pattern>
+      <pattern>base</pattern>
+      <pattern>yast2</pattern>
+    </patterns>
+  </software>
+  <ssh_import>
+    <copy_config config:type="boolean">true</copy_config>
+    <import config:type="boolean">true</import>
+    <device>/dev/md/root</device>
+  </ssh_import>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_code>30452ce234918d23</reg_code>
+    <slp_discovery config:type="boolean">false</slp_discovery>
+  </suse_register>
+<!-- adddon does not work on SP3 now, have re register manually
+  https://github.com/yast/yast-registration/wiki/Available-SCC-Extensions-for-Use-in-Autoyast
+  <addons config:type="list">
+    <addon>
+      <name>ses</name>
+      <version>5</version>
+      <arch>x86_64</arch>
+      <reg_code>35eb00e8035bf5b0</reg_code>
+    </addon>
+  </addons>
+-->
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Prague</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+<!--      <user_password>$6$DAX16XYw$G/GPBVT/CN7G027Qy24XtQIUbB07yhsS7JSOQcaPOEYbFRKqelD7Kvw29OWewFLkMsxyphE7Dyn5PnCnRaWKQ/</user_password> -->
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/data/ses/mosquito.xml
+++ b/data/ses/mosquito.xml
@@ -1,0 +1,536 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <bootloader>
+    <global>
+      <activate>true</activate>
+      <append>splash=silent quiet showopts crashkernel=123M,high crashkernel=72M,low</append>
+      <boot_boot>true</boot_boot>
+      <boot_extended>false</boot_extended>
+      <boot_mbr>false</boot_mbr>
+      <boot_root>false</boot_root>
+      <generic_mbr>true</generic_mbr>
+      <gfxmode>auto</gfxmode>
+      <hiddenmenu>false</hiddenmenu>
+      <os_prober>false</os_prober>
+      <terminal>gfxterm</terminal>
+      <timeout config:type="integer">3</timeout>
+      <trusted_grub>false</trusted_grub>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <storage>
+      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
+      <start_multipath config:type="boolean">false</start_multipath>
+    </storage>
+  </general>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel config:type="list">
+      <listentry>123M,high</listentry>
+      <listentry>72M,low</listentry>
+    </crash_kernel>
+    <general>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>10</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NET_TIMEOUT>30</KDUMP_NET_TIMEOUT>
+      <KDUMP_SAVEDIR>file:///var/crash</KDUMP_SAVEDIR>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+    </general>
+  </kdump>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+  </language>
+  <networking>
+    <dhcp_options>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">false</dhcp_hostname>
+      <domain>qam.suse.cz</domain>
+      <hostname>mosquito</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <searchlist config:type="list">
+        <search>qam.suse.cz</search>
+      </searchlist>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth0</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>I350 Gigabit Network Connection</name>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth1</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>I350 Gigabit Network Connection</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth2</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>Ethernet Controller X710 for 10GbE SFP+</name>
+        <startmode>hotplug</startmode>
+      </interface>
+<!-- only eth4 is acive network interface, but sometimes during the installationboot is eth3 active, to avoid unnecessary complications eth3 is configured via dhcp too -->
+      <interface>
+        <bootproto>dhcp4</bootproto>
+        <device>eth3</device>
+        <dhclient_set_hostname>yes</dhclient_set_hostname>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <name>Ethernet Controller X710 for 10GbE SFP+</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>dhcp4</bootproto>
+        <device>eth4</device>
+        <dhclient_set_hostname>yes</dhclient_set_hostname>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <name>Ethernet Controller 10-Gigabit X540-AT2</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth5</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>Ethernet Controller 10-Gigabit X540-AT2</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>eth6</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <ipaddr>192.168.0.90</ipaddr>
+        <mtu>9000</mtu>
+        <name>Ethernet Controller 10-Gigabit X540-AT2</name>
+        <netmask>255.255.255.0</netmask>
+        <prefixlen>24</prefixlen>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>none</bootproto>
+        <device>eth7</device>
+        <dhclient_set_default_route>no</dhclient_set_default_route>
+        <name>Ethernet Controller 10-Gigabit X540-AT2</name>
+        <startmode>hotplug</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">false</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>ATTR{address}</rule>
+        <value>0c:c4:7a:6c:40:16</value>
+      </rule>
+      <rule>
+        <name>eth1</name>
+        <rule>ATTR{address}</rule>
+        <value>0c:c4:7a:6c:40:17</value>
+      </rule>
+      <rule>
+        <name>eth2</name>
+        <rule>ATTR{address}</rule>
+        <value>3c:fd:fe:9c:df:50</value>
+      </rule>
+      <rule>
+        <name>eth3</name>
+        <rule>ATTR{address}</rule>
+        <value>3c:fd:fe:9c:df:51</value>
+      </rule>
+      <rule>
+        <name>eth4</name>
+        <rule>ATTR{address}</rule>
+        <value>a0:36:9f:6d:13:78</value>
+      </rule>
+      <rule>
+        <name>eth5</name>
+        <rule>ATTR{address}</rule>
+        <value>a0:36:9f:6d:13:7a</value>
+      </rule>
+      <rule>
+        <name>eth6</name>
+        <rule>ATTR{address}</rule>
+        <value>a0:36:9f:6e:1c:74</value>
+      </rule>
+      <rule>
+        <name>eth7</name>
+        <rule>ATTR{address}</rule>
+        <value>a0:36:9f:6e:1c:76</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+    </routing>
+    <setup_before_proposal config:type="boolean">true</setup_before_proposal>
+  </networking>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list">
+      <peer>
+        <address>hornet.qam.suse.cz</address>
+        <options>burst iburst</options>
+        <type>server</type>
+      </peer>
+      <peer>
+        <address>/var/lib/ntp/drift/ntp.drift</address>
+        <comment># path for drift file</comment>
+        <type>driftfile</type>
+      </peer>
+      <peer>
+        <address>/var/log/ntp</address>
+        <comment># alternate log file</comment>
+        <type>logfile</type>
+      </peer>
+      <peer>
+        <address>/etc/ntp.keys</address>
+        <comment># path for keys file</comment>
+        <type>keys</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># define trusted keys</comment>
+        <type>trustedkey</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># key (7) for accessing server variables</comment>
+        <type>requestkey</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># key (6) for accessing server variables</comment>
+        <type>controlkey</type>
+      </peer>
+    </peers>
+    <restricts config:type="list">
+      <restrict>
+        <options>ipv6 notrap nomodify nopeer noquery</options>
+        <target>default</target>
+      </restrict>
+      <restrict>
+        <target>127.0.0.1</target>
+      </restrict>
+      <restrict>
+        <target>::1</target>
+      </restrict>
+    </restricts>
+    <start_at_boot config:type="boolean">true</start_at_boot>
+    <start_in_chroot config:type="boolean">false</start_in_chroot>
+    <sync_interval config:type="integer">5</sync_interval>
+    <synchronize_time config:type="boolean">false</synchronize_time>
+  </ntp-client>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/md</device>
+      <disklabel>msdos</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>noatime</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_nr config:type="integer">0</partition_nr>
+          <raid_options>
+            <device_order config:type="list">
+              <device>/dev/disk/by-id/scsi-0ATA_SATA_SSD_B4500757052400104468-part1</device>
+              <device>/dev/disk/by-id/scsi-0ATA_SATA_SSD_B4500757032400103089-part1</device>
+            </device_order>
+            <persistent_superblock config:type="boolean">false</persistent_superblock>
+            <raid_name>/dev/md/root</raid_name>
+            <raid_type>raid0</raid_type>
+          </raid_options>
+          <resize config:type="boolean">false</resize>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_MD</type>
+      <use>all</use>
+    </drive>
+    <drive>
+      <device>/dev/disk/by-id/scsi-0ATA_SATA_SSD_B4500757052400104468</device>
+      <disklabel>gpt</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <format config:type="boolean">false</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">253</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <raid_name>/dev/md/root</raid_name>
+          <resize config:type="boolean">false</resize>
+          <size>29.7G</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">ext4</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/boot</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>max</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+    <drive>
+      <device>/dev/disk/by-id/scsi-0ATA_SATA_SSD_B4500757032400103089</device>
+      <disklabel>gpt</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <format config:type="boolean">false</format>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">253</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <raid_name>/dev/md/root</raid_name>
+          <resize config:type="boolean">false</resize>
+          <size>29.7G</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <scripts>
+    <init-scripts config:type="list">
+      <script>
+        <filename>post.sh</filename>
+        <interpreter>shell</interpreter>
+        <source><![CDATA[
+#!/bin/sh
+### stop ssh while script is running
+systemctl stop sshd.service
+###
+### add ssh keys, created bug bsc#1066342 as the keys are not added via <authorized_keys> in <user>
+mkdir -m 700 /root/.ssh
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDWWOicPToKZ+Pqx+rA9Ny6tBXaG9x4xUjEw2KA4Ww3s8+D8xt4HynEGaOvXd4qfAlfbs0BnGC+QMo4u2T4+MLf34pgudv1bnXSWVj7M3/OeQv7WDU8fI4W8NEmoSGZaeXAzvNTSok/6kmGEOeU4Qwxu9pcCowaeLv0f0HNH1HTK7piGq2TzAZeLdIQeXb5Fa3HKCvoKCrlt3yTzX3shIKbeBg5KvwcQ/zn1ftvLMDhBEfBO1b1eWprie6otPBbLYBawzTbQ6GMUH3GjWD2+G04xPuEVtuBEGLtZ+s6rlxMEkm3uqrKOCZW++hcqRTYttvooW5GSRGDVrppaIpzxCHH root@hornet' >> /root/.ssh/authorized_keys
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCm/z0MRb/MVoFeC0lCA45XIbUxyaZ+DTpMEEjQ30/PH2DFSdu4izguNyog+qMHmKAgBQWZWHr1DwXYTjZ4ZiQR6YShxb269S6QO0uqQ6U6SFBHwEyoaY1ooZgcPdCyjXKRSPieTHI1VojxiReDVNnDgrCObac4RWi5EU0JDSgKJI5HT+LjW9NLJGu+ikPuXbr479F6DFET5uV1ht09g5ppvkF2fDLojobaWf1og2JD7EPOg1E4MKX2juxrxSyhLFNaD1esBchKIryymQqIwAMqJsFeiU9YuAQ/N3xkvVUq3DSjeRU2okcpuo/FPP5ulHOTrRoyLQMkKl+BntCh5Sxj jpupava@suse.com' >> /root/.ssh/authorized_keys
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCqhWVTosH12864VGY5S3/k0yKc59GbV0m2WxD28gAf+uvJ1/y8gekD2wDzBv0DWqEekYLV7L68gpapDXyGosQeZ6n5OO/NZFZmW+Xq1P7P1QHJil6kVpwk927lzX440pwNf3+PRvTbLzlbuVFWJRpiykv+juJyIFjzXLJRF67wB2qgZVm5cRs/GOi4fnvTaou/Ae51mvsO8M3JL5cphApFKD/AO/X+3pHBhLjvaW33cYsp0Z4Rce1nm8wxSmvuJRF+HAfjBlknhDl5ZaJGA96RYA+g9WbAXimFprg4xeiRp7liPExQwtVgackJweoC4MahC1glmjC3eOh9dvrrxLnALOLMOkyCSK/tOF/iq2PJaLViObanPI8mnNkMLbdJyzUBf8hRGdSLcw98qxaf0sSZ+vz4VQS6e9CwX7ikkNNsTeYXjnJ+1yU3mfCW1CXJDr7kBDVG2OTLefCpMY8WBAYDiEaK0RW83cBcFIKfecKYd0qStHRaOsvmyWdFYgBh2vM1UWjro5WXlb+7aJPrUp8ZruapkUXUwhjHA7FwGA4ysE0tsOVVFm0Dw8tvyVVkVNm/9EObG28dWctioZ2+ZEzTWgMJU26Q+wOJ/U4qZyIvpMRUgPZc5nM9J8kcmvNWtb6DV9k/6p8h28kiOxPkxLtPP+3TlBCHjq//mhEnJZ/d8w== shshyukriev@suse.com' >> /root/.ssh/authorized_keys
+echo 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDEfz0lP5oO03Rw8vSyzqwt06VIEFA4x478DERaSWHPTD5ULqqdZQS1vsFpTtAm1eT4Ix4njXvSh4T2d2aXYyCgB+ElJI1h0tpbtX7OtenJ7c3rUows61jqmXLFrnIfWbZL2uhomTsOziQwxKoXS3PRxFgoRaZGzHGD4J4HOEfiP8YHQ53igUKbmmDY8yVZya/dyEtKe8bukcbZbGIosKgMoaLsdpbNkln7bU1oLqMuogHGtqRdZ9gQLz2mz5I7Ml/lSeCEdbkqVbOjydVhF2Qm4bvbVjyER+n0VqhXOmeKcauEOQbEafYrJjWvDetMY4j8NwWCeJq0QA7gYRd7967 bhavel@blackbird.suse.cz' >> /root/.ssh/authorized_keys
+###
+### register SLES and SES
+SUSEConnect -p ses/5/x86_64 -r 35eb00e8035bf5b0
+###
+### remove first repo
+zypper rr 1
+###
+### install salt-minion ceph
+zypper -n in salt-minion ceph
+###
+### set hornet as master and turn off ipv6
+sed -i 's/#master: salt/master: hornet/' /etc/salt/minion
+sed -i 's/#ipv6: False/ipv6: False/' /etc/salt/minion
+###
+### add hornet master salt pki
+echo '-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo/Ex4NV6sFAL0tUMJcC5
+5dPMbBjVKjCJ7aqm95vv2XeU0JofXywWLT8U4toKVgtM8UZfsEoJ9R6HE52lYQAJ
+48mbijjGjgcQqVGXHSksD/mrAaLioAuzESR/LM66+BFqV2rcJGoCx/aSlm8D7EeC
+3AQpKs0xHfLIq+pjR9X76idagg7Xd7pEqcz92Ggpg5fzBdw4OgSvBytElMTuxUU6
+Eno5TGlyW8K86RAQXT0nGlHUQ6GkEkXe/DPaUTNmM1hGKwxuEfJH37mh57hsu95a
+/xDJ01SkqAVPc7s5fMxWTTjpZNt5hKi0tJnC8vtn6k0NDU1FyolTxn/URRzLFPv+
+dwIDAQAB
+-----END PUBLIC KEY-----' > /etc/salt/pki/minion/minion_master.pub
+###
+### hornet knows mosquito under this keys, no need to accept new keys on hornet with salt-key -A -y
+echo '-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAwO80xTKKXFpcbSAtI2XmjdSnRJkgNekWLchrQWoIvoHrQ+D4
+9BVnSAIyO3ZfsXY7rW3xblxgIMnVhVCI/b1Zwmu9ZjUHJF80/jGc/tmpzG7FxF09
+newowweyU2zebO8KLTe6YV6wx5uAlrmL9pfvYFTBXrRMUfw1J2NfI2FGxTrp1ruM
+qyttJK6afCYEoPQB46wySI+c1s8li6peM3mWy6kP6e/WBO/UrSOMG8t7r77nEOEb
+emXUtk/3Yj4POWudBSSEJBmfdhZB5PDKd4ftj1vqHUDZU3/ygS3buGgEDZbahv22
+V45f/st85wy9PEoAdVHSrZdJPV+ZI1DBmZwzKwIDAQABAoIBAQCFDXIK/IvGnNpY
+t3PpkYCqFxkziZZZF2GgOTMebY2SM+6XZTLKwWf0lO8nar8blzoYpFV3kmUIt6h0
+w9F1i3u3RK3dKny+bJoTIwvuBRXAUjQ480RnAFIsDcbBGbda0I7oGCKEu9SWE3te
+dp87dBQ1Dr48HYL0l0Xg3/rgX1l68a3bSwqEUJl/GJaKzrz8yOH9Qce0qS/8gbvD
+Cxy1umnTs6hVS6gXkHtShMJh0ThKWwug2dNfXuNzS8YyjS+YsV46O5lr3uhHYOnM
+4dnLPQSm68BEjN62Xuis8VY6UnhLySvQDXzojTNG+rdGp7SECuujz3iHv3FVKk2T
+3PgGrkfBAoGBAMhYNkaWMc41pLM4QpqvRyhmDtdOx5JXHZinZM6uw2Fgr/MQNZ1h
+ivkBT1ISvyWuY36iACLqPrsnpc1d4tbdp5zqysenQhhAuGqMPshGCw2JduaIpcej
+GlzulaFNjtvaubEHI1Jrv3dGEB6PvAMqGXveLM3VG/PVYmfxCmNSGo/zAoGBAPaI
+Aj0i2Jl5pEFf/44KBU8XI5G5OheP7cVTV5MAt8B5SKkou2Q8B7MHyvR20q9YAC4d
+a0o2MTBWdRfg20O+hX8Ha/RRM/HXZtoZthJXbBB2uTkMi3ZyzmZ+FCp91K3FVRCG
+TYy8vOuksSMy6VkleUVcvX9segNuIZBGZwR4LtXpAoGAZHrBdfN8NUT4Pp6X4QbJ
+tHxDMz8insWsZVSHHZXPDfa1KD3X9f/m+G3sv2gBkD9/TRKo6Nn87la7NF3DGCqB
+FxU28J11a76B/4YpMr7WakqoZITiSFcIMNXEG+tPG/r+KMhAseSyWXq9OOaz0A58
+S4Cpje41H7zEpwbgQ+H4ynsCgYAOQMzIVhRpwyOg9/jhcGjgKrlOuoPGSvb3OptM
+j3UQNrLhvM4gvGvBiQjN23TQ2GiiQecrEjkDz2vTppdmskQrlPVD2dIEAG0c3PGu
+28kOpp6M0tHZVkfimxV1Y3MBXPBPFUS0h1Dw2sO3AkGFeuoo/XSjQlVHj313Ruq7
+0mr6yQKBgAWqCPdrN9hoshRs4OIT3RwRpPuWqJbUroNmvoyhsatwEhQPr0TJh5u0
+JKcBUj0yuRkZtlizf5ViOhq/AHxm5QUK74IsIvnscDJ5tCDN7jJHv6Vje4hV57Yf
+qOmLwZDpcI6+znnO1ZJoRdF4pIv1AXXhh0VAk5TIWY5JqJ4EEp+T
+-----END RSA PRIVATE KEY-----' > /etc/salt/pki/minion/minion.pem
+echo '-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwO80xTKKXFpcbSAtI2Xm
+jdSnRJkgNekWLchrQWoIvoHrQ+D49BVnSAIyO3ZfsXY7rW3xblxgIMnVhVCI/b1Z
+wmu9ZjUHJF80/jGc/tmpzG7FxF09newowweyU2zebO8KLTe6YV6wx5uAlrmL9pfv
+YFTBXrRMUfw1J2NfI2FGxTrp1ruMqyttJK6afCYEoPQB46wySI+c1s8li6peM3mW
+y6kP6e/WBO/UrSOMG8t7r77nEOEbemXUtk/3Yj4POWudBSSEJBmfdhZB5PDKd4ft
+j1vqHUDZU3/ygS3buGgEDZbahv22V45f/st85wy9PEoAdVHSrZdJPV+ZI1DBmZwz
+KwIDAQAB
+-----END PUBLIC KEY-----' > /etc/salt/pki/minion/minion.pub
+###
+### wipe disks
+for d in a b c d g h i j; do sgdisk -z /dev/sd${d};done
+###
+### enable and start salt-minion
+systemctl enable salt-minion.service
+systemctl start salt-minion.service
+###
+### add text about minion deployment via autoyast into motd
+echo '
+---------------------------------------------------------------------
+
+SAS5 node mosquito.qam.suse.cz was deployed with autoyast profile
+https://pes.suse.de/QA_Maintenance/Users/SES_Hardware
+salt-minion is configured and known to salt-master hornet.qam.suse.cz
+
+---------------------------------------------------------------------
+' > /etc/motd
+###
+### make sure host ssh key will be the same even when previous installation failed and the known key got lost
+grep 'd3NgG7q63bL2FXZh8' /etc/ssh/ssh_host_ecdsa_key > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+echo '-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIMcpezq5wiGgv9IAD9UzMSaeQ6/Ii7VzxHoERdI+JpQPoAoGCCqGSM49
+AwEHoUQDQgAE9as/+TJFUO2d3NgG7q63bL2FXZh88y78hLU7dPZiG0oKFeZkP2Bo
+LyjBcALgzFcHG/ZQNSc3+9p4+VwqAcntMQ==
+-----END EC PRIVATE KEY-----' > /etc/ssh/ssh_host_ecdsa_key
+fi
+grep 'nN/vaePlcKgHJ7TE=' /etc/ssh/ssh_host_ecdsa_key.pub > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+echo 'ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBPWrP/kyRVDtndzYBu6ut2y9hV2YfPMu/IS1O3T2YhtKChXmZD9gaC8owXAC4MxXBxv2UDUnN/vaePlcKgHJ7TE= root@mosquito' > /etc/ssh/ssh_host_ecdsa_key.pub
+fi
+###
+### make eth3 inactive, was active only for installation as it was sometimes the active interface instead of eth4
+echo "BOOTPROTO='none'
+DHCLIENT_SET_DEFAULT_ROUTE='no'
+NAME='Ethernet Controller X710 for 10GbE SFP+'
+STARTMODE='hotplug'" > /etc/sysconfig/network/ifcfg-eth3
+###
+### start ssh when init-script is done
+systemctl start sshd.service
+exit 0
+
+]]></source>
+      </script>
+    </init-scripts>
+  </scripts>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <enable config:type="list">
+        <service>kdump-early</service>
+        <service>kdump</service>
+        <service>ntpd</service>
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <software>
+    <install_recommended config:type="boolean">true</install_recommended>
+<!-- can't be done because SES addon not registered above
+    <packages config:type="list">
+      <package>salt-minion</package>
+      <package>ceph</package>
+    </packages>
+-->
+    <patterns config:type="list">
+      <pattern>Minimal</pattern>
+      <pattern>base</pattern>
+      <pattern>yast2</pattern>
+    </patterns>
+  </software>
+  <ssh_import>
+    <copy_config config:type="boolean">true</copy_config>
+    <import config:type="boolean">true</import>
+    <device>/dev/md/root</device>
+  </ssh_import>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_code>30452ce234918d23</reg_code>
+    <slp_discovery config:type="boolean">false</slp_discovery>
+  </suse_register>
+<!-- adddon does not work on SP3 now, have re register manually
+  https://github.com/yast/yast-registration/wiki/Available-SCC-Extensions-for-Use-in-Autoyast
+  <addons config:type="list">
+    <addon>
+      <name>ses</name>
+      <version>5</version>
+      <arch>x86_64</arch>
+      <reg_code>35eb00e8035bf5b0</reg_code>
+    </addon>
+  </addons>
+-->
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Prague</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$6$l2H2TEZ5$xkUFPPbyjC6Z7GhAMYR0WT43S4qXinIs0k3GSUnGQlWmWGenk5.a.WOlpwTN20CVyyaGHV1orlw14tKhVeHWG1</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1532,7 +1532,12 @@ elsif (get_var('SYSTEMD_TESTSUITE')) {
     load_systemd_patches_tests;
 }
 else {
-    if (get_var("AUTOYAST") || get_var("AUTOUPGRADE")) {
+    if (get_var("SES5_DEPLOY")) {
+        loadtest "boot/boot_from_pxe";
+        loadtest "autoyast/installation";
+        loadtest "installation/first_boot";
+    }
+    elsif (get_var("AUTOYAST") || get_var("AUTOUPGRADE")) {
         if (get_var('PATCH')) {
             load_patching_tests();
         }

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -101,6 +101,15 @@ sub verify_timeout_and_check_screen {
 
 sub run {
     my ($self) = @_;
+
+    if (check_var('BACKEND', 'ipmi')) {
+        assert_screen 'installation-done', 750;
+        reset_consoles;
+        select_console 'sol', await_console => 0;
+        assert_screen 'prague-pxe-menu', 400;
+        send_key 'ret';    # boot from hard disk
+        return;
+    }
     my @needles
       = qw(bios-boot nonexisting-package reboot-after-installation linuxrc-install-fail scc-invalid-url warning-pop-up inst-betawarning autoyast-boot);
     push @needles, 'autoyast-confirm'        if get_var('AUTOYAST_CONFIRM');


### PR DESCRIPTION
Supermicro servers in Prague assigned for SES testing can be reinstalled with
this test, servers are deployed with installed salt, deepsea, ceph, openattic
configured is only salt, ssh keys of testers.
https://pes.suse.de/QA_Maintenance/Users/SES_Hardware/

- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/651
- Verification run: http://10.100.12.155/tests
