### PR TITLE
Tumbleweed also switched to firewalld

### DIFF
--- a/tests/console/firewall_enabled.pm
+++ b/tests/console/firewall_enabled.pm
@@ -15,10 +15,10 @@
 use base 'opensusebasetest';
 use strict;
 use testapi;
-use version_utils qw(is_jeos is_leap is_sle leap_version_at_least sle_version_at_least);
+use version_utils qw(is_jeos is_leap is_sle is_tumbleweed leap_version_at_least sle_version_at_least);
 
 sub run {
-    if ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0'))) {
+    if ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0')) || is_tumbleweed) {
         if (is_jeos) {
             assert_script_run("grep '^FW_CONFIGURATIONS_EXT=\"sshd\"\\|^FW_SERVICES_EXT_TCP=\"ssh\"' /etc/sysconfig/SuSEfirewall2");
         }


### PR DESCRIPTION
With snapshot 0117, Tumbleweed switched to firewalld by default (as CODE15 already did too).

