### PR TITLE
Fix toggle home shortcut on TW

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -78,6 +78,7 @@ sub init_cmd {
       size_hotkey alt-s
       sync_interval alt-n
       sync_without_daemon alt-y
+      guidedsetup_home_part alt-p
     );
 
     if (check_var('INSTLANG', "de_DE")) {

--- a/tests/installation/disable_online_repos.pm
+++ b/tests/installation/disable_online_repos.pm
@@ -27,7 +27,7 @@ sub run {
     assert_screen 'desktop-selection';
     send_key 'alt-o';    # press configure online repos button
     assert_screen 'online-repos-configuration';
-    send_key is_leap() ? 'alt-l' : 'alt-i';    # navigate to the List
+    send_key 'alt-l';    # navigate to the List
 
     # Disable repos
     if (is_leap) {

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -15,6 +15,7 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
+use version_utils 'is_leap';
 
 sub run {
     assert_screen 'partitioning-edit-proposal-button', 40;
@@ -35,6 +36,8 @@ sub run {
             $cmd{rescandevices}     = 'alt-c';
             $cmd{enablelvm}         = 'alt-a';
             $cmd{encryptdisk}       = 'alt-l';
+            # On TW have different shortcut for toggling separate home partition
+            $cmd{toggle_home} = 'alt-o' unless is_leap;
         }
     }
 

--- a/tests/installation/partitioning_togglehome.pm
+++ b/tests/installation/partitioning_togglehome.pm
@@ -19,7 +19,7 @@ use version_utils 'is_storage_ng';
 use partition_setup 'unselect_xen_pv_cdrom';
 
 sub run {
-    wait_screen_change { send_key(is_storage_ng() ? 'alt-g' : 'alt-d') };    # open proposal settings
+    wait_screen_change { send_key($cmd{guidedsetup}) };    # open proposal settings
     if (is_storage_ng) {
         unselect_xen_pv_cdrom;
         assert_screen 'partition-scheme';
@@ -30,8 +30,8 @@ sub run {
     if (!check_var('ARCH', 's390x') or is_storage_ng()) {
         if (!check_screen 'disabledhome', 0) {
             # detect whether new (Radio Buttons) YaST behaviour
-            my $new_radio_buttons = check_screen('inst-partition-radio-buttons', 0);
-            send_key $new_radio_buttons ? 'alt-r' : 'alt-p';
+            $cmd{toggle_home} = 'alt-r' if check_screen('inst-partition-radio-buttons', 0);
+            send_key $cmd{toggle_home};
         }
         assert_screen 'disabledhome';
     }


### PR DESCRIPTION
Updated control file cause changes in gui for storage-ng, these changes
will also reach other distris, TW was hit first.

See [poo#30499](https://progress.opensuse.org/issues/30499).

[Needles](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/307)
- Verification runs: 
  * [gnome](http://g226.suse.de/tests/291)
  * [textmode](http://g226.suse.de/tests/292)
