### PR TITLE
Fix shortcut variable name

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -78,7 +78,7 @@ sub init_cmd {
       size_hotkey alt-s
       sync_interval alt-n
       sync_without_daemon alt-y
-      guidedsetup_home_part alt-p
+      toggle_home alt-p
     );
 
     if (check_var('INSTLANG', "de_DE")) {


### PR DESCRIPTION
I've forgotten to rename variable in susedistribution in
[PR#4234](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4234)

This breaks tests on SLE.

See [poo#30499](https://progress.opensuse.org/issues/30499).
