### PR TITLE
yast2_firewall: Tumbleweed has switched to firewalld

### DIFF
--- a/tests/yast2_gui/yast2_firewall.pm
+++ b/tests/yast2_gui/yast2_firewall.pm
@@ -16,7 +16,7 @@ use base "y2x11test";
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least);
+use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least is_tumbleweed);
 
 sub susefirewall2 {
     # 	enter page interfaces and change zone for network interface
@@ -99,7 +99,7 @@ sub run {
     my $self = shift;
     select_console 'root-console';
     zypper_call('in yast2-http-server apache2 apache2-prefork', timeout => 1200);
-    if ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0'))) {
+    if ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0')) || is_tumbleweed) {
         zypper_call('in firewall-config', timeout => 60);
         select_console 'x11', await_console => 0;
         $self->launch_yast2_module_x11('firewall', target_match => 'firewall-start-page', match_timeout => 60);


### PR DESCRIPTION
I haven't seen (yet) an easy way to turn around the diff in a way that would take TW plus leap/sle15, without potentially breaking maintenance (if the module is not in maintenance tests, then of course we can just drop the if/else and assume firewalld from now on)