### PR TITLE
Split yast2_lan_restart test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -539,6 +539,7 @@ sub load_extra_tests {
         # well
         if (check_var('DESKTOP', 'gnome')) {
             loadtest 'x11/yast2_lan_restart';
+            loadtest 'x11/yast2_lan_restart_devices';
             # we only have the test dependencies, e.g. hostapd available in
             # openSUSE
             if (check_var('DISTRI', 'opensuse')) {

--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -1,0 +1,104 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: YaST logic on Network Restart while no config changes were made
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.com>
+# Tags: fate#318787 poo#11450
+
+package y2lan_restart_common;
+
+use strict;
+use Exporter 'import';
+use testapi;
+use utils 'systemctl';
+use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least);
+
+our @EXPORT_OK = qw(
+  initialize_y2lan
+  open_network_settings
+  close_network_settings
+  check_network_status
+  verify_network_configuration
+);
+
+sub initialize_y2lan {
+    select_console 'x11';
+    x11_start_program("xterm -geometry 155x50+5+5", target_match => 'xterm');
+    become_root;
+    # make sure that firewalld is stopped, or we have later pops for firewall activation warning
+    # or timeout for command 'ip a' later
+    if (((is_sle && sle_version_at_least('15')) or (is_leap && leap_version_at_least('15.0')))
+        and assert_script_run("systemctl show -p ActiveState firewalld.service | grep ActiveState=active"))
+    {
+        systemctl 'stop firewalld';
+        assert_script_run("systemctl show -p ActiveState firewalld.service | grep ActiveState=inactive");
+    }
+    # enable debug for detailed messages and easier detection of restart
+    assert_script_run 'sed -i \'s/DEBUG="no"/DEBUG="yes"/\' /etc/sysconfig/network/config';
+    type_string "journalctl -f|egrep -i --line-buffered 'shutting down|ifdown all' > journal.log &\n";
+    assert_script_run '> journal.log';    # clear journal.log
+}
+
+sub open_network_settings {
+    type_string "yast2 lan\n";
+    assert_screen 'yast2_lan', 100;       # yast2 lan overview tab
+}
+
+sub close_network_settings {
+    wait_still_screen;
+    send_key 'alt-o';
+    # new: warning pops up for firewall, alt-y for assign it to zone
+    assert_screen([qw(yast2-lan-restart_firewall_active_warning yast2_closed_xterm_visible yast2_lan_packages_need_to_be_installed)], 120);
+    if (match_has_tag 'yast2-lan-restart_firewall_active_warning') {
+        send_key 'alt-y';
+        wait_still_screen 1;
+        send_key 'alt-n';
+        wait_still_screen 1;
+        send_key 'alt-o';
+    }
+    elsif (match_has_tag 'yast2_lan_packages_need_to_be_installed') {
+        send_key 'alt-i';
+    }
+    assert_screen 'yast2_closed_xterm_visible', 120;    # ensure coming back to root console
+    type_string "\n\n";                                 # make space for better readability of the console
+}
+
+sub check_network_status {
+    my ($expected_status, $device) = @_;
+    $expected_status //= 'no_restart';
+    assert_script_run 'ip a';
+    if ($device eq 'bond') {
+        record_soft_failure 'bsc#992113';
+    }
+    else {
+        assert_script_run 'dig suse.com|grep \'status: NOERROR\'';    # test if conection and DNS is working
+    }
+    assert_script_run 'cat journal.log';                              # print journal.log
+    if ($expected_status eq 'restart') {
+        assert_script_run '[ -s journal.log ]';                       # journal.log size is greater than zero (network restarted)
+    }
+    elsif ((is_sle && !sle_version_at_least('15')) || (is_leap && !leap_version_at_least('15.0'))) {
+        assert_script_run '[ ! -s journal.log ]';
+    }
+    assert_script_run '> journal.log';                                # clear journal.log
+    type_string "\n\n";                                               # make space for better readability of the console
+}
+
+sub verify_network_configuration {
+    my ($fn, $dev_name, $expected_status, $workaround) = @_;
+    open_network_settings;
+
+    $fn->($dev_name) if $fn;                                          # verify specific action
+
+    close_network_settings;
+    check_network_status($expected_status, $workaround);
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/x11/yast2_lan_restart_devices.pm
+++ b/tests/x11/yast2_lan_restart_devices.pm
@@ -1,0 +1,142 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: YaST logic on Network Restart while no config changes were made
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.com>
+# Tags: fate#318787 poo#11450
+
+use base 'y2logsstep';
+
+use strict;
+use testapi;
+use y2lan_restart_common qw(initialize_y2lan open_network_settings close_network_settings check_network_status);
+
+sub add_device {
+    my $device = shift;
+    assert_screen 'yast2_closed_xterm_visible', 120;
+    open_network_settings;
+
+    if ($device eq 'bond') {
+        send_key 'alt-i';    # Edit NIC
+        assert_screen 'yast2_lan_network_card_setup';
+        send_key 'alt-k';             # No link (Bonding Slavees)
+        send_key 'alt-n';
+        assert_screen 'yast2_lan';    # yast2 lan overview tab
+    }
+    send_key 'alt-a';                 # Add NIC
+    assert_screen 'yast2_lan_hardware_dialog';
+    send_key 'alt-d';                 # Device type
+    send_key 'home';                  # Jump to beginning of list
+    send_key_until_needlematch "yast2_lan_device_type_$device", 'down';
+    send_key 'alt-n';                 # Next
+    assert_screen 'yast2_lan_network_card_setup';
+    send_key 'alt-y';                 # Dynamic address
+    wait_still_screen;
+    if ($device eq 'bridge') {
+        send_key 'alt-g';             # General
+        send_key 'alt-i';             # Bridged devices
+        assert_screen 'yast2_lan_bridged_devices';
+        if (check_screen('yast2_lan_default_NIC_bridge')) {
+            send_key 'alt-d';         # select Bridged Devices region
+            send_key 'spc';
+            wait_still_screen;
+            save_screenshot;
+        }
+        send_key 'alt-n';
+        assert_screen 'yast2_lan_select_already_configured_device';
+        send_key 'alt-o';
+    }
+    elsif ($device eq 'bond') {
+        send_key 'alt-o';             # Bond slaves
+        assert_screen 'yast2_lan_bond_slaves';
+        send_key_until_needlematch 'yast2_lan_bond_slave_tab_selected', 'tab';
+        send_key 'tab';               # select Bond Slaves and Order field
+        send_key 'spc';               # check network interface
+        wait_still_screen;
+        save_screenshot;
+        send_key 'alt-n';
+    }
+    elsif ($device eq 'VLAN') {
+        send_key 'alt-v';
+        send_key 'tab';
+        type_string '12';
+        send_key 'alt-n';
+    }
+    else {
+        send_key 'alt-n';
+    }
+    close_network_settings;
+    assert_script_run '> journal.log';    # clear journal.log
+}
+
+sub select_special_device_tab {
+    my $device = shift;
+    open_network_settings;
+    send_key 'tab';
+    send_key 'tab';
+    send_key 'home';
+    send_key_until_needlematch "yast2_lan_device_${device}_selected", 'down';
+    send_key 'alt-i';                     # Edit NIC
+    assert_screen 'yast2_lan_network_card_setup';
+    if ($device eq 'bridge') {
+        send_key 'alt-g';                 # General
+        send_key 'alt-i';                 # Bridged devices
+        assert_screen 'yast2_lan_bridged_devices';
+    }
+    elsif ($device eq 'bond') {
+        send_key 'alt-o';                 # Bond slaves
+        assert_screen 'yast2_lan_bond_slaves';
+    }
+    elsif ($device eq 'VLAN') {
+        assert_screen 'yast2_lan_VLAN';
+    }
+    wait_still_screen;
+    send_key 'alt-n';
+    close_network_settings;
+}
+
+sub delete_device {
+    my $device = shift;
+    open_network_settings;
+    send_key 'tab';
+    send_key 'tab';
+    send_key 'home';
+    send_key_until_needlematch "yast2_lan_device_${device}_selected", 'down';
+    send_key 'alt-t';    # Delete NIC
+    wait_still_screen;
+    save_screenshot;
+    send_key 'alt-i';    # Edit NIC
+    assert_screen 'yast2_lan_network_card_setup';
+    send_key 'alt-y';    # Dynamic address
+    send_key 'alt-n';    # Next
+    close_network_settings;
+    assert_script_run '> journal.log';    # clear journal.log
+}
+
+sub check_device {
+    my $device = shift;
+    add_device($device);
+    select_special_device_tab($device);
+    check_network_status('', $device);
+    delete_device($device);
+}
+
+sub run {
+    initialize_y2lan;
+    check_device($_) foreach qw(bridge bond VLAN);
+    type_string "killall xterm\n";
+}
+
+sub post_fail_hook {
+    assert_script_run 'journalctl -b > /tmp/journal', 90;
+    upload_logs '/tmp/journal';
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Split yast2_lan_restart test: yast2_lan_restart test now is divided into two tests, one linked to the general actions in the different tabs with its corresponding potential restarts and the other linked to addition/deletion of devices. For this code has been created a utility/common code package in order to reuse code. This library include a subroutine to load different action aka _plugin pattern_ in some programming languages, so we don't repeat actions/code at the beginning and at the end of any test that try to modify the network in a particular way. Perl import of this library is implemented to allow proper subroutine calls from caller namespace (from the test).

- Related ticket: https://progress.opensuse.org/issues/28666
- Verification runs: 
  - [sle-15-Installer-DVD-x86_64-Build422.1-extra_tests_on_gnome@64bit](http://dhcp227/tests/277)
  - [sle-12-SP4-Server-DVD-x86_64-Build0164-extra_tests_on_gnome@64bit](http://dhcp227/tests/286)
  - [opensuse-Tumbleweed-DVD-x86_64-Build20180122-extra_tests_on_gnome@64bit](http://dhcp227/tests/280)