### PR TITLE
Adjust splitusr test suite for storage-ng

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -123,6 +123,8 @@ sub addpart {
         send_key_until_needlematch "partition-selected-$args{fsid}-type", 'up';
     }
     if ($args{mount}) {
+        send_key 'alt-o' if is_storage_ng;
+        wait_still_screen 1;
         send_key 'alt-m';
         type_string "$args{mount}";
     }


### PR DESCRIPTION
storage-ng is now in factory, hence in TW. Test module  requires
adjustments to add partition mounted to /usr.
Test is also executed on leap with storage-ng, but was not adjusted.

See [poo#30520](https://progress.opensuse.org/issues/30520).
- [Needles](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/308)
- Verification runs: 
  * [TW - no storage-ng](http://g226.suse.de/tests/321)
  * [TW - storage-ng](http://g226.suse.de/tests/329)
  * [leap15](http://g226.suse.de/tests/330)
