### PR TITLE
desktop_menu: send key until the menu opens to avoid timing issues

### DIFF
--- a/tests/x11/desktop_mainmenu.pm
+++ b/tests/x11/desktop_mainmenu.pm
@@ -33,7 +33,7 @@ sub run {
         mouse_hide(1);
     }
     else {
-        send_key "alt-f1";      # open main menu
+        send_key_until_needlematch 'test-desktop_mainmenu-1', 'alt-f1', 20;
     }
     assert_screen 'test-desktop_mainmenu-1', 20;
 


### PR DESCRIPTION
desktop_menu: send key until the menu opens to avoid timing issues

Follow-up to 28ac756, 7599251, 782e229.
Fixes: https://openqa.opensuse.org/tests/578763#step/desktop_mainmenu/2
Fixes: https://progress.opensuse.org/issues/30079

- Related ticket: https://progress.opensuse.org/issues/30079
- Verification run: http://dexter.suse.de/tests/17#step/desktop_mainmenu/4

The verification passed, but I did not have a local fail (timing issue).
