### PR TITLE
Improve regexp to extract directory

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -280,8 +280,8 @@ sub bootmenu_network_source {
             my ($m_server, $m_share, $m_directory);
 
             # Parse SUSEMIRROR into variables
-            if ($m_mirror =~ m{^[a-z]+://([a-zA-Z0-9.-]*)(/.*)$}) {
-                ($m_server, $m_directory) = ($1, $2);
+            if ($m_mirror =~ m{^[a-z]+://(?<server>[a-zA-Z0-9.-]*)/(?<dir>.*)$}) {
+                ($m_server, $m_directory) = ($+{server}, $+{dir});
                 if ($m_protocol eq "smb") {
                     ($m_share, $m_directory) = $m_directory =~ /\/(.+?)(\/.*)/;
                 }


### PR DESCRIPTION
As of now we get leading '/' in front of the ftp directory which is
wrong.

[Verification run](http://gershwin.arch.suse.de/tests/61#step/bootloader/11)