### PR TITLE
Multiple improvements to SLES4SAP tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1149,7 +1149,7 @@ sub load_sles4sap_tests {
     return if get_var('INSTALLONLY');
     loadtest "sles4sap/patterns";
     loadtest "sles4sap/sapconf";
-    loadtest "sles4sap/saptune";
+    loadtest "sles4sap/saptune" if (check_var('ARCH', 'x86_64'));
     if (get_var('NW')) {
         loadtest "sles4sap/nw_ascs_install" if (get_var('SLES4SAP_MODE') !~ /wizard/);
         loadtest "sles4sap/netweaver_ascs";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1149,7 +1149,7 @@ sub load_sles4sap_tests {
     return if get_var('INSTALLONLY');
     loadtest "sles4sap/patterns";
     loadtest "sles4sap/sapconf";
-    loadtest "sles4sap/saptune" if (check_var('ARCH', 'x86_64'));
+    loadtest "sles4sap/saptune";
     if (get_var('NW')) {
         loadtest "sles4sap/nw_ascs_install" if (get_var('SLES4SAP_MODE') !~ /wizard/);
         loadtest "sles4sap/netweaver_ascs";

--- a/tests/sles4sap/nw_ascs_install.pm
+++ b/tests/sles4sap/nw_ascs_install.pm
@@ -32,7 +32,7 @@ sub run {
       SAPINST_USE_HOSTNAME=$(hostname)
       SAPINST_INPUT_PARAMETERS_URL=/sapinst/inifile.params
       SAPINST_EXECUTE_PRODUCT_ID=NW_ABAP_ASCS:NW740SR2.ADA.PIHA
-      SAPINST_SKIP_DIALOGS=true SAPINST_SLP_MODE=true);
+      SAPINST_SKIP_DIALOGS=true SAPINST_SLP_MODE=false);
 
     $proto = 'cifs' if ($proto eq 'smb' or $proto eq 'smbfs');
     die "nw_ascs_install: currently only supported protocols are nfs and smb/smbfs/cifs"
@@ -44,20 +44,22 @@ sub run {
     select_console 'root-console';
 
     # This installs Netweaver's ASCS. Start by making sure the correct
-    # SAP profile is set in the system
+    # SAP profile and solution are configured in the system
     assert_script_run "tuned-adm profile sap-netweaver";
     assert_script_run "saptune solution apply NETWEAVER";
-    assert_script_run "kill -1 \$(ps aux|grep systemd-logind|awk '{print \$2}'|head -1)";
+    assert_script_run q/kill -1 $(ps aux|grep systemd-logind|awk '{print $2}'|head -1)/;
     assert_script_run "saptune daemon start";
+    assert_script_run "saptune solution verify NETWEAVER";
     my $output = script_output "tuned-adm active";
     record_info("tuned profile", $output);
-    my $output = script_output "saptune daemon status";
+    $output = script_output "saptune daemon status";
     record_info("tuned status", $output);
 
     # Copy media
     assert_script_run "mkdir /sapinst";
     assert_script_run "mount -t $proto $path /mnt";
     type_string "cd /mnt\n";
+    type_string "cd " . get_var('ARCH') . "\n"; # Change to ARCH specific subdir if exists
     assert_script_run "tar -cf - . | (cd /sapinst/; tar -pxf - )", 600;
 
     # Check everything was copied correctly
@@ -87,7 +89,7 @@ sub run {
     assert_script_run "chmod -R 0775 /sapinst/unattended";
 
     # Set SAPADM to the SAP Admin user for future use
-    my $sid = script_output "awk '/NW_GetSidNoProfiles.sid/ {print \$NF}' inifile.params", 10;
+    my $sid = script_output q|awk '/NW_GetSidNoProfiles.sid/ {print $NF}' inifile.params|, 10;
     set_var('SAPADM', lc($sid) . 'adm');
 
     # Start the installation
@@ -102,10 +104,10 @@ sub post_fail_hook {
     my $self = shift;
 
     $self->export_logs();
-    upload_logs "/sapinst/unattended/sapinst.log";
     upload_logs "/tmp/check-nw-media";
     $self->save_and_upload_log('ls -alF /sapinst/unattended', '/tmp/nw_unattended_ls.log');
     $self->save_and_upload_log('ls -alF /sbin/mount*',        '/tmp/sbin_mount_ls.log');
+    upload_logs "/sapinst/unattended/sapinst.log";
 }
 
 1;

--- a/tests/sles4sap/nw_ascs_install.pm
+++ b/tests/sles4sap/nw_ascs_install.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2017-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/sles4sap/nw_ascs_install.pm
+++ b/tests/sles4sap/nw_ascs_install.pm
@@ -59,7 +59,7 @@ sub run {
     assert_script_run "mkdir /sapinst";
     assert_script_run "mount -t $proto $path /mnt";
     type_string "cd /mnt\n";
-    type_string "cd " . get_var('ARCH') . "\n"; # Change to ARCH specific subdir if exists
+    type_string "cd " . get_var('ARCH') . "\n";    # Change to ARCH specific subdir if exists
     assert_script_run "tar -cf - . | (cd /sapinst/; tar -pxf - )", 600;
 
     # Check everything was copied correctly

--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2017-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -50,7 +50,7 @@ sub run {
 
     foreach my $cmd ('start', keys %profiles) {
         $output = script_output "sapconf $cmd";
-        die "Command 'sapconf $cmd' output is not recognized" unless ($output =~ /Forwarding action to tuned\-adm.$/);
+        die "Command 'sapconf $cmd' output is not recognized" unless ($output =~ /Forwarding action to tuned\-adm\./);
         next if ($cmd eq 'start');
         check_profile($cmd);
     }

--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -26,7 +26,7 @@ sub check_profile {
     my $current = shift;
     my $output  = script_output "tuned-adm active";
     die "Tuned profile change failed. Expected 'Current active profile: $profiles{$current}', got: [$output]"
-        unless ($output =~ /Current active profile: $profiles{$current}/);
+      unless ($output =~ /Current active profile: $profiles{$current}/);
 }
 
 sub run {

--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -13,6 +13,21 @@
 use base "sles4sap";
 use testapi;
 use strict;
+
+my %profiles = (
+    hana   => 'sap-hana',
+    b1     => 'sap-hana',
+    ase    => 'sap-ase',
+    sybase => 'sap-ase',
+    bobj   => 'sap-bobj'
+);
+
+sub check_profile {
+    my $current = shift;
+    my $output  = script_output "tuned-adm active";
+    die "Tuned profile change failed. Expected 'Current active profile: $profiles{$current}', got: [$output]"
+        unless ($output =~ /Current active profile: $profiles{$current}/);
+}
 
 sub run {
     my ($self) = @_;
@@ -28,10 +43,20 @@ sub run {
       . 'Started Dynamic System Tuning Daemon.$';
     die "Command 'sapconf status' output is not recognized" unless ($output =~ m|$statusregex|s);
 
-    foreach my $cmd (qw(start hana b1 ase sybase bobj)) {
+    $output = script_output "tuned-adm active";
+    $output =~ /Current active profile: ([a-z\-]+)/;
+    my $default_profile = $1;
+    record_info("Current profile", "Current default profile: $default_profile");
+
+    foreach my $cmd ('start', keys %profiles) {
         $output = script_output "sapconf $cmd";
         die "Command 'sapconf $cmd' output is not recognized" unless ($output =~ /Forwarding action to tuned\-adm.$/);
+        next if ($cmd eq 'start');
+        check_profile($cmd);
     }
+
+    # Set default profile again
+    assert_script_run "tuned-adm profile $default_profile";
 }
 
 1;

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -24,6 +24,11 @@ sub run {
     my ($self) = @_;
     my @solutions = qw(BOBJ HANA MAXDB NETWEAVER S4HANA-APPSERVER S4HANA-DBSERVER SAP-ASE);
 
+    if (check_var('ARCH', 'x86_64')) {
+        record_info('saptune', 'saptune is not available in this architecture: ' . get_var('ARCH'));
+        return;
+    }
+
     select_console 'root-console';
 
     unless (tuned_is 'running') {

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -46,7 +46,7 @@ sub run {
     die "Command 'saptune solution list' output is not recognized" unless ($output =~ m|$regexp|s);
 
     $output = script_output "saptune note list";
-    $regexp = '^All notes \(\+ denotes manually enabled notes, \* denotes notes enabled by solutions\):';
+    $regexp = 'All notes \(\+ denotes manually enabled notes, \* denotes notes enabled by solutions\):';
     die "Command 'saptune note list' output is not recognized" unless ($output =~ m|$regexp|);
 }
 

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -24,11 +24,6 @@ sub run {
     my ($self) = @_;
     my @solutions = qw(BOBJ HANA MAXDB NETWEAVER S4HANA-APPSERVER S4HANA-DBSERVER SAP-ASE);
 
-    if (check_var('ARCH', 'x86_64')) {
-        record_info('saptune', 'saptune is not available in this architecture: ' . get_var('ARCH'));
-        return;
-    }
-
     select_console 'root-console';
 
     unless (tuned_is 'running') {

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -17,7 +17,7 @@ use strict;
 sub tuned_is {
     my $pattern = shift;
     my $output  = script_output "saptune daemon status 2>&1 || true";
-    $output =~ /^Daemon \(tuned\.service\) is $pattern./;
+    $output =~ /Daemon \(tuned\.service\) is $pattern./;
 }
 
 sub run {

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright


### PR DESCRIPTION
This PR features the following improvements to the sles4sap tests:

- Removal of ^ and $ in saptune/sapconf regular expressions so that it doesn't produce false positives on tests runs when the serial console gets contaminated with extra characters as in https://openqa.suse.de/tests/1405642#step/saptune/17 or 
https://openqa.suse.de/tests/1404143#step/sapconf/13
- Adds SAP Profile name verification after profile changes in sapconf test.
- Sets NetWeaver profile and solution before NetWeaver's ASCS installation.
- Adds support for multiple ARCHs in NetWeaver's ASCS installation with a single shared volume passed on the NW variable so there's no need for architecture specific test suites.
- Changes value of SAPINST_SLP_MODE to false (required by NetWeaver's 7.42 unattended installation as documented in https://launchpad.support.sap.com/#/notes/0002575377).

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/195
