### PR TITLE
Add load_bootloader_s390x() to reduce duplicity

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -47,6 +47,7 @@ our @EXPORT = qw(
   console_is_applicable
   boot_hdd_image
   maybe_load_kernel_tests
+  load_bootloader_s390x
   load_yast2_ncurses_tests
   load_yast2_gui_tests
   load_extra_tests
@@ -413,15 +414,22 @@ sub unregister_needle_tags {
     for my $n (@a) { $n->unregister($tag); }
 }
 
+sub load_bootloader_s390x {
+    return 0 unless check_var("ARCH", "s390x");
+
+    if (check_var("BACKEND", "s390x")) {
+        loadtest "installation/bootloader_s390";
+    }
+    else {
+        loadtest "installation/bootloader_zkvm";
+    }
+    return 1;
+}
+
 sub boot_hdd_image {
     get_required_var('BOOT_HDD_IMAGE');
     if (check_var("BACKEND", "svirt")) {
-        if (check_var("ARCH", "s390x")) {
-            loadtest "installation/bootloader_zkvm";
-        }
-        else {
-            loadtest "installation/bootloader_svirt";
-        }
+        loadtest "installation/bootloader_svirt" unless load_bootloader_s390x();
     }
     if (get_var('UEFI') && (get_var('BOOTFROM') || get_var('BOOT_HDD_IMAGE'))) {
         loadtest "boot/uefi_bootmenu";

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -195,11 +195,8 @@ sub load_boot_tests {
         set_var("DELAYED_START", "1");
         loadtest "autoyast/pxe_boot";
     }
-    elsif (check_var('ARCH', 's390x')) {
-        loadtest "installation/bootloader_s390";
-    }
     else {
-        loadtest "installation/bootloader";
+        loadtest "installation/bootloader" unless load_bootloader_s390x();
     }
 }
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -530,20 +530,12 @@ sub load_boot_tests {
     elsif (uses_qa_net_hardware()) {
         loadtest "boot/boot_from_pxe";
     }
-    elsif (check_var("ARCH", "s390x")) {
-        if (check_var('BACKEND', 's390x')) {
-            loadtest "installation/bootloader_s390";
-        }
-        else {
-            loadtest "installation/bootloader_zkvm";
-        }
-    }
     elsif (get_var("PXEBOOT")) {
         set_var("DELAYED_START", "1");
         loadtest "autoyast/pxe_boot";
     }
     else {
-        loadtest "installation/bootloader";
+        loadtest "installation/bootloader" unless load_bootloader_s390x();
     }
 }
 
@@ -1569,9 +1561,7 @@ else {
             loadtest "rt/boot_rt_kernel";
         }
         else {
-            if (get_var('S390_ZKVM')) {
-                loadtest 'installation/bootloader_zkvm';
-            }
+            load_bootloader_s390x();
             loadtest "boot/boot_to_desktop";
             if (get_var("ADDONS")) {
                 loadtest "installation/addon_products_yast2";


### PR DESCRIPTION
This is humble attempt to remove duplicity. I tested it only on create_hdd_gnome@zkvm (http://quasar.suse.cz/tests/192), which fails later on in change desktop not due this change.

@Soulofdestiny change in load_boot_tests() for openSUSE
@asmorodskyi change in boot_hdd_image()
@okurz change in load_boot_tests() for SLE