### PR TITLE
Fix shortcut for online repos list for TW on aarch64

### DIFF
--- a/tests/installation/disable_online_repos.pm
+++ b/tests/installation/disable_online_repos.pm
@@ -27,7 +27,7 @@ sub run {
     assert_screen 'desktop-selection';
     send_key 'alt-o';    # press configure online repos button
     assert_screen 'online-repos-configuration';
-    send_key 'alt-l';    # navigate to the List
+    send_key((!is_leap() && check_var('ARCH', 'aarch64')) ? 'alt-i' : 'alt-l');    # navigate to the List
 
     # Disable repos
     if (is_leap) {


### PR DESCRIPTION
Fixes: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4234
NOTE: last build was 8 days ago, shortcut got changed in the build this week, so I strongly recommend to wait for a new build before merging. It's unlikely to have different behavior on different architectures. 