### PR TITLE
Do not select desktop applications module where not required

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -217,13 +217,13 @@ sub fill_in_registration_data {
                 send_key('alt-i');
             }
             assert_screen($modules_needle);
-            # Add desktop module for SLES if desktop doesn't match default
-            if (check_var('SLE_PRODUCT', 'sles') && (my $addons = get_var('SCC_ADDONS')) !~ /(?:desktop|we|productivity)/) {
-                # HA doesn't need to have desktop module selected
-                if ($addons !~ /(?:ha)/) {
-                    $addons = $addons ? $addons . ',desktop' : 'desktop';
-                    set_var('SCC_ADDONS', $addons);
-                }
+            # Add desktop module for SLES if desktop is gnome
+            if (   check_var('SLE_PRODUCT', 'sles')
+                && check_var('DESKTOP', 'gnome')
+                && (my $addons = get_var('SCC_ADDONS')) !~ /(?:desktop|we|productivity|ha)/)
+            {
+                $addons = $addons ? $addons . ',desktop' : 'desktop';
+                set_var('SCC_ADDONS', $addons);
             }
         }
     }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -76,10 +76,11 @@ sub default_desktop {
     return 'gnome' if get_var('VERSION', '') lt '15';
     # with SLE 15 LeanOS only the default is textmode
     return 'gnome' if get_var('BASE_VERSION', '') =~ /^12/;
-    # In sle15 we add repos manually to make a workaround of missing SCC, gnome will be installed as default system.
-    return 'gnome' if get_var('ADDONURL', '') =~ /(desktop|server)/;
     return 'textmode' if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'));
-    return 'gnome' if check_var_array('ADDONS', 'all-packages');
+    # default system role for sles and sled
+    return 'textmode' if is_server;
+    return 'gnome'    if is_desktop;
+    return 'gnome'    if check_var_array('ADDONS', 'all-packages');
     return (!get_var('SCC_REGISTER') || !check_var('SCC_REGISTER', 'installation')) ? 'textmode' : 'gnome';
 }
 
@@ -696,8 +697,8 @@ sub load_inst_tests {
         if (get_var('PATTERNS') || get_var('PACKAGES')) {
             loadtest "installation/installation_overview_before";
             loadtest "installation/select_patterns_and_packages";
-        }
-        elsif (!check_var('DESKTOP', default_desktop)) {
+        }    # With SLE15 we change desktop using role and not by inselecting packages (Use SYSTEM_ROLE variable)
+        elsif (!check_var('DESKTOP', default_desktop) && !sle_version_at_least('15')) {
             loadtest "installation/installation_overview_before";
             loadtest "installation/change_desktop";
         }

--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -14,11 +14,11 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use version_utils 'sle_version_at_least';
+use version_utils qw(sle_version_at_least is_sle);
 
 
 my %role_hotkey = (
-    default  => 's',    # sles with gnome
+    gnome    => 's',
     textmode => 't',
     minimal  => 'm',
     kvm      => 'k',
@@ -35,6 +35,7 @@ sub change_system_role {
 
 sub assert_system_role {
     # Still initializing the system at this point, can take some time
+    # Verify default role for SLE15, it's text for sles and gnome for sled
     assert_screen 'system-role-default-system', 180;
     my $system_role = get_var('SYSTEM_ROLE', 'default');
     if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default')) {
@@ -44,6 +45,7 @@ sub assert_system_role {
 }
 
 sub run {
+    # Define default role
     assert_system_role;
 }
 


### PR DESCRIPTION
For sles we should have only base system and system applications
enabled. If we DESKTOP set to gnome explicitly, then we enable it, or in
case of sled. After check of test suites we have, there is no a single
test suite which doesn't have DESKTOP variable explicitly defined and
doesn't have INSTALLONLY or EXIT_AFTER_START_INSTALL set to 1 in
functional job group.
So since now on we will have textmode installation by default for sles
and if this behavior doesn't fit, DESKTOP variable can be explicitly set
in the test suite.

See [poo#29589](https://progress.opensuse.org/issues/29589).

NOTE: these changes may break some test suites. Old behavior can be achieved by defining SYSTEM_ROLE and DESKTOP variables in test suite explicitly.

[Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/654)
- Verification runs: 
  * [DESKTOP=gnome](http://g226.suse.de/tests/335)
  * [DESKTOP=textmode](http://g226.suse.de/tests/336)
  * [DESKTOP not defined, INSTALLONLY](http://g226.suse.de/tests/345)
  * [DESKTOP not defined, EXIT_AFTER_START_INSTALL](http://g226.suse.de/tests/341)
