### PR TITLE
Avoid x11 reboot between patching and upgrade test

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1118,23 +1118,18 @@ sub load_online_migration_tests {
 }
 
 sub load_patching_tests {
-    if (check_var("ARCH", "s390x")) {
-        if (check_var('BACKEND', 's390x')) {
-            loadtest "installation/bootloader_s390";
-        }
-        else {
-            loadtest "installation/bootloader_zkvm";
-        }
-    }
     # Switch to orginal system version for upgrade tests
     if (is_upgrade) {
         # Save HDDVERSION to ORIGIN_SYSTEM_VERSION
         set_var('ORIGIN_SYSTEM_VERSION', get_var('HDDVERSION'));
         # Save VERSION to UPGRADE_TARGET_VERSION
         set_var('UPGRADE_TARGET_VERSION', get_var('VERSION'));
+        # Always boot from installer DVD in upgrade test
+        set_var('BOOTFROM', 'd');
         loadtest "migration/version_switch_origin_system";
     }
-    loadtest 'boot/boot_to_desktop';
+    set_var('BOOT_HDD_IMAGE', 1);
+    boot_hdd_image;
     loadtest 'update/patch_before_migration';
     if (is_upgrade) {
         # Lock package for offline migration by Yast installer
@@ -1142,14 +1137,12 @@ sub load_patching_tests {
             loadtest 'console/lock_package';
         }
         # Reboot from DVD and perform upgrade
-        loadtest 'console/consoletest_finish';
-        loadtest 'x11/reboot_and_install';
+        loadtest "migration/reboot_to_upgrade";
         # After original system patched, switch to UPGRADE_TARGET_VERSION
         # For ZDUP upgrade, version switch back later
         if (get_var('UPGRADE') || get_var('AUTOUPGRADE')) {
             loadtest "migration/version_switch_upgrade_target";
         }
-        loadtest 'installation/bootloader_zkvm' if get_var('S390_ZKVM');
     }
 }
 
@@ -1545,13 +1538,9 @@ else {
         loadtest "installation/first_boot";
     }
     elsif (get_var("AUTOYAST") || get_var("AUTOUPGRADE")) {
-        if (get_var('PATCH')) {
-            load_patching_tests();
-        }
-        else {
-            loadtest "autoyast/prepare_profile" if get_var "AUTOYAST_PREPARE_PROFILE";
-            load_boot_tests();
-        }
+        loadtest "autoyast/prepare_profile" if get_var "AUTOYAST_PREPARE_PROFILE";
+        load_patching_tests() if get_var('PATCH');
+        load_boot_tests();
         load_autoyast_tests();
         load_reboot_tests();
     }
@@ -1567,14 +1556,11 @@ else {
         load_online_migration_tests();
     }
     elsif (get_var("UPGRADE")) {
-        if (get_var('PATCH')) {
-            load_patching_tests();
-        }
-        else {
-            load_boot_tests();
-        }
+        load_patching_tests() if get_var('PATCH');
+        load_boot_tests();
         load_inst_tests();
         load_reboot_tests();
+        loadtest "migration/post_upgrade";
     }
     elsif (get_var("BOOT_HDD_IMAGE") && !is_jeos) {
         if (get_var("RT_TESTS")) {

--- a/tests/migration/post_upgrade.pm
+++ b/tests/migration/post_upgrade.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Actions required after upgrade
+#       Such as:
+#       1) Change the HDDVERSION to UPGRADE_TARGET_VERSION
+#       2) Reset the x11 console to correct tty
+# Maintainer: Qingming Su <qmsu@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use utils 'get_x11_console_tty';
+
+sub run {
+    # Reset HDDVERSION after upgrade
+    set_var('HDDVERSION', get_var('UPGRADE_TARGET_VERSION', get_var('VERSION')));
+
+    # On SLE15, tty7 is reserved for gdm, tty2 is the first user x11 console
+    console('x11')->{args}->{tty} = get_x11_console_tty;
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/migration/reboot_to_upgrade.pm
+++ b/tests/migration/reboot_to_upgrade.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Reboot machine to perform upgrade
+#       Just trigger reboot action, afterwards tests will be
+#       incepted by later test modules, such as tests in
+#       load_boot_tests or wait_boot in setup_zdup.pm
+# Maintainer: Qingming Su <qmsu@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+
+    select_console 'root-console';
+
+    # Mark the hdd has been patched
+    set_var('PATCHED_SYSTEM', 1) if get_var('PATCH');
+
+    # Reboot from Installer media for upgrade
+    set_var('BOOT_HDD_IMAGE', 0) if get_var('UPGRADE') || get_var('AUTOUPGRADE');
+    power_action('reboot', textmode => 1);
+}
+
+1;
+
+# vim: set sw=4 et:


### PR DESCRIPTION
Reboot is required between patching and upgrade test, but it is
not necessary to reboot from x11 gnome, which is more likely to
fail than text mode.
Just trigger reboot action, afterwards tests will be incepted by
later test modules, i.e. tests in load_boot_tests or wait_boot
in setup_zdup.pm, which will help reduce duplicated codes for
booting test during upgrade.
- poo#30340, poo#30177

Also use boot_hdd_image to strip existing codes in patching tests.

- Related ticket: 
   * https://progress.opensuse.org/issues/30177
   * https://progress.opensuse.org/issues/30340
- Needles: None
- Verification run:
   * autoupgrade on x86_64: http://openqa-apac1.suse.de/tests/182 (Test failed with bsc#1075744)
   * zdup on x86_64: http://openqa-apac1.suse.de/tests/198
   * zdup on s390x/zkvm: http://openqa-apac1.suse.de/tests/201 (Failure after upgrade can be ignored)
   * media upgrade on x86_64: http://openqa-apac1.suse.de/tests/196
   * media upgrade on s390x/zkvm: http://openqa-apac1.suse.de/tests/189 (Test failed with bsc#1072113)
   * media upgrade on aarch64: http://openqa-apac1.suse.de/tests/178 (Test failed with bsc#1072113)