### PR TITLE
Sles4sap desktop check

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1154,6 +1154,7 @@ sub load_patching_tests {
 
 sub load_sles4sap_tests {
     return if get_var('INSTALLONLY');
+    loadtest "sles4sap/desktop_icons" if (is_desktop_installed());
     loadtest "sles4sap/patterns";
     loadtest "sles4sap/sapconf";
     loadtest "sles4sap/saptune";

--- a/tests/sles4sap/desktop_icons.pm
+++ b/tests/sles4sap/desktop_icons.pm
@@ -21,7 +21,7 @@ sub run {
     # Check for SLES4SAP Desktop icons
     if (check_screen 'sles4sap-desktop') {
         assert_and_dclick 'sles4sap-desktop-cheatsheet';
-        assert_screen 'sles4sap-cheatsheet';
+        assert_screen 'sles4sap-cheatsheet', 90;
         send_key 'alt-f4';
     }
     else {

--- a/tests/sles4sap/desktop_icons.pm
+++ b/tests/sles4sap/desktop_icons.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: SLES for SAP Applications default desktop icons check
+# Maintainer: Alvaro Carvajal <acarvajal@suse.de>
+
+use base "sles4sap";
+use testapi;
+use strict;
+
+sub run {
+    my ($self) = @_;
+
+    select_console 'x11';
+    # Check for SLES4SAP Desktop icons
+    if (check_screen 'sles4sap-desktop') {
+        assert_and_dclick 'sles4sap-desktop-cheatsheet';
+        assert_screen 'sles4sap-cheatsheet';
+        send_key 'alt-f4';
+    }
+    else {
+        # There was no match for the desktop icons needle
+        # Verify that there's at least a generic desktop and soft fail
+        assert_screen 'generic-desktop';
+        record_soft_failure 'bsc#1072646';
+    }
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
This adds a test to verify the existence of icons for the SAP Installation Wizard and the Cheat Sheet for Windows Users on SLES4SAP's root desktop, and to check the content of the Cheat Sheet.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/655
- Verification run: http://mango.suse.de/tests/200 (12sp3), http://mango.suse.de/tests/197 (15)