### PR TITLE
Record info because there is no detection mechanism for bug

### DIFF
--- a/tests/caasp/stack_bootstrap.pm
+++ b/tests/caasp/stack_bootstrap.pm
@@ -45,7 +45,7 @@ sub click_click {
         sleep 1;
     }
     mouse_hide;
-    record_soft_failure 'bsc#1048975 - User interaction is lost after page refresh';
+    record_info 'bsc#1048975', 'User interaction is lost after page refresh';
 }
 
 # Select master.openqa.test and additional master nodes


### PR DESCRIPTION
Bug is present for long time and I don't think it's critical enough for soft_fail. There is also no detection mechanism. I prefer record_info here and keep soft_failures for bugs that are being worked on.

Local run: http://dhcp91.suse.cz/tests/1004