### PR TITLE
Increase timeout to collect logs when snapper doesn't return

### DIFF
--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -124,7 +124,7 @@ sub y2snapper_failure_analysis {
     my ($self) = @_;
     # snapper actions can put the system under quite some load so we want to
     # give some more time, e.g. for login in the consoles
-    my $factor = 10;
+    my $factor = 30;
     my $previous_timeout_scale = get_var('TIMEOUT_SCALE', 1);
     set_var('TIMEOUT_SCALE', $previous_timeout_scale * $factor);
     select_console('log-console', await_console => 0);


### PR DESCRIPTION
See [poo#30619](https://progress.opensuse.org/issues/30619). To start
investigation we need logs, but in failed runs we are not able to log in
in 5 minutes frame. Increasing timeout scale there to 15 minutes in
order to get logs.