### PR TITLE
Correct autoyast installation code added for ipmi SES test

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -105,7 +105,7 @@ sub verify_timeout_and_check_screen {
 sub run {
     my ($self) = @_;
 
-    if (check_var('BACKEND', 'ipmi')) {
+    if (check_var('BACKEND', 'ipmi') && get_var("SES5_DEPLOY")) {
         assert_screen 'installation-done', 750;
         reset_consoles;
         select_console 'sol', await_console => 0;


### PR DESCRIPTION
Commit b6b6c355fcbf14e01c520b2ef4d45d2a3cc76b86 changes autoyast/installation.pm for special ipmi SES test behavior. However for other tests on ipmi, which needs the autoyast way to install hosts, like virtualization, needs original code path. This commit fails job https://openqa.suse.de/tests/1405554 which is successful before this commit. So add more condition check for running the special code.

- Verification run: http://10.67.18.220/tests/514 
  Host preparation is successful which uses autoyast way to install sle11sp4 host. Ignore the guest installation failure because wrong build is given.
