### PR TITLE
s390x: Get correct output of ifcfg-*

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -282,9 +282,9 @@ sub rewrite_static_svirt_network_configuration {
     my $virsh_guest = get_required_var('VIRSH_GUEST');
     type_line_svirt "sed -i \"\\\"s:IPADDR='[0-9.]*/\\([0-9]*\\)':IPADDR='$virsh_guest/\\1':\\\" /etc/sysconfig/network/ifcfg-\*\"", expect => '#';
     type_string "# output of current network configuration for debugging\n";
-    type_line_svirt "cat /etc/sysconfig/network/ifcfg-\*", expect => '#';
-    type_line_svirt "systemctl restart network",           expect => '#';
-    type_line_svirt "systemctl is-active network",         expect => 'active';
+    type_line_svirt "\"cat /etc/sysconfig/network/ifcfg-\*\"", expect => '#';
+    type_line_svirt "systemctl restart network",               expect => '#';
+    type_line_svirt "systemctl is-active network",             expect => 'active';
 }
 
 =head2 wait_boot


### PR DESCRIPTION
fixes errors like

```
cat /etc/sysconfig/network/ifcfg-eth2 /etc/sysconfig/network/ifcfg-e
eth2.old /etc/sysconfig/network/ifcfg-lo
cat: /etc/sysconfig/network/ifcfg-eth2: No such file or directory
cat: /etc/sysconfig/network/ifcfg-eth2.old: No such file or directory
```


see verification:
http://opeth/tests/13/file/autoinst-log.txt

@okurz 