### PR TITLE
More adjustments for default desktop on sle15

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -175,6 +175,10 @@ if (sle_version_at_least('15')) {
     set_var('SCC_REGISTER', get_var('SCC_REGISTER', 'installation'));
     # depending on registration only limited system roles are available
     set_var('SYSTEM_ROLE', get_var('SYSTEM_ROLE', is_desktop_module_available() ? 'default' : 'minimal'));
+    # set SYSTEM_ROLE to textmode for SLE4SAP on SLE15 instead of triggering change_desktop (see poo#29589)
+    if (is_sles4sap && check_var('SYSTEM_ROLE', 'default') && check_var('DESKTOP', 'textmode')) {
+        set_var('SYSTEM_ROLE', 'textmode');
+    }
     # in the 'minimal' system role we can not execute many test modules
     set_var('INSTALLONLY', get_var('INSTALLONLY', check_var('SYSTEM_ROLE', 'minimal')));
 }
@@ -617,7 +621,7 @@ sub load_inst_tests {
         {
             loadtest "installation/system_role";
         }
-        if (is_sles4sap() and sle_version_at_least('15')) {
+        if (is_sles4sap() and sle_version_at_least('15') and check_var('SYSTEM_ROLE', 'default')) {
             loadtest "installation/sles4sap_product_installation_mode";
         }
         loadtest "installation/partitioning";
@@ -686,7 +690,7 @@ sub load_inst_tests {
             loadtest "installation/logpackages";
         }
         if (is_sles4sap()) {
-            if (is_sles4sap_standard()) {
+            if (is_sles4sap_standard() or !check_var('SYSTEM_ROLE', 'default')) {
                 loadtest "installation/user_settings";
             }    # sles4sap wizard installation doesn't have user_settings step
         }


### PR DESCRIPTION
As expected, we have missed some scenarios:
  * SLES4SAP has gnome as default
  * gnome is default if add desktop as addon using all packages dvd, etc.
  * we cannot select minimalx using roles, need to schedule "change_desktop"

NOTE: for DESKTOP on osd we have only 4 possible values: none,textmode,minimalx,gnome.

Initial [PR#4249](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4249).

See [poo#29589](https://progress.opensuse.org/issues/29589).

[NEEDLES](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/658)
- Verification runs:
  * [workaround modules contains desktop](http://g226.suse.de/tests/476)
  * [DESKTOP=minimalx](http://g226.suse.de/tests/475)
  * [INSTALLONLY, DESKTOP not set](http://g226.suse.de/tests/477)
  * [DESKTOP=textmode](http://g226.suse.de/tests/478)
  * [DESKTOP=gnome](http://g226.suse.de/tests/479)
  * [sles4sap textmode](http://g226.suse.de/tests/484)
  * [sles4sap gnome](http://g226.suse.de/tests/483)