### PR TITLE
apachetest: Bump timeout for gensslcert (poo#30718)

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -74,7 +74,7 @@ sub setup_apache2 {
     # Create x509 certificate for this apache server
     if ($mode eq "SSL") {
         my $gensslcert_C_opt = '-C $(hostname)' unless is_sle && sle_version_at_least('15');
-        assert_script_run "gensslcert -n \$(hostname) $gensslcert_C_opt -e webmaster@\$(hostname)", 600;
+        assert_script_run "gensslcert -n \$(hostname) $gensslcert_C_opt -e webmaster@\$(hostname)", 900;
         assert_script_run 'ls /etc/apache2/ssl.crt/$(hostname)-server.crt /etc/apache2/ssl.key/$(hostname)-server.key';
     }
 


### PR DESCRIPTION
Last timeout bump was in Nov 2016 so it's not too often :)

Related progress issue: https://progress.opensuse.org/issues/30718