### PR TITLE
Correct the firewall selection on upgrade

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -484,7 +484,9 @@ sub enter_test_text {
 }
 
 sub firewall {
-    return ((is_sle && !sle_version_at_least('15')) || (is_leap && !leap_version_at_least('15.0'))) ? 'SuSEfirewall2' : 'firewalld';
+    my $old_product_versions = (is_sle && !sle_version_at_least('15')) || (is_leap && !leap_version_at_least('15.0'));
+    my $upgrade_from_susefirewall = get_var('UPGRADE') && get_var('HDD_1') =~ /\b(1[123]|42)[\.-]/;
+    return ($old_product_versions || $upgrade_from_susefirewall) ? 'SuSEfirewall2' : 'firewalld';
 }
 
 # useful post_fail_hook for any module that calls wait_boot

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -340,7 +340,7 @@ sub load_fixup_network {
     # openSUSE 13.2's (and earlier) systemd has broken rules for virtio-net, not applying predictable names (despite being configured)
     # A maintenance update breaking networking names sounds worse than just accepting that 13.2 -> TW breaks with virtio-net
     # At this point, the system has been updated, but our network interface changed name (thus we lost network connection)
-    my @old_hdds = qw(openSUSE-12.1 openSUSE-12.2 openSUSE-12.3 openSUSE-13.1-gnome openSUSE-13.2);
+    my @old_hdds = qw(openSUSE-13.1-gnome openSUSE-13.2);
     return unless grep { check_var('HDDVERSION', $_) } @old_hdds;
 
     loadtest "fixup/network_configuration";
@@ -355,7 +355,7 @@ sub load_fixup_firewall {
     # firewall being disabled since
     # https://build.opensuse.org/request/show/483163
     # which seems to be in openSUSE Tumbleweed since 20170413
-    return unless get_var('HDDVERSION', '') =~ /openSUSE-(12.1|12.2|13.1-gnome)/;
+    return unless get_var('HDDVERSION', '') =~ /openSUSE-(13.1-gnome)/;
     loadtest 'fixup/enable_firewall';
 }
 

--- a/tests/console/firewall_enabled.pm
+++ b/tests/console/firewall_enabled.pm
@@ -23,9 +23,7 @@ sub run {
         if (is_jeos) {
             assert_script_run("grep '^FW_CONFIGURATIONS_EXT=\"sshd\"\\|^FW_SERVICES_EXT_TCP=\"ssh\"' /etc/sysconfig/SuSEfirewall2");
         }
-        elsif (script_run('firewallctl state')) {
-            record_soft_failure('bsc#1054977');
-        }
+        assert_script_run('firewallctl state');
     }
     else {
         assert_script_run('SuSEfirewall2 status');

--- a/tests/fixup/enable_firewall.pm
+++ b/tests/fixup/enable_firewall.pm
@@ -18,7 +18,6 @@ use utils 'systemctl';
 
 sub run {
     my ($self) = @_;
-    record_soft_failure('boo#1036590') if get_var('HDDVERSION', '') =~ /openSUSE-(12.1|12.2)/;
     x11_start_program('xterm');
     systemctl 'start ' . $self->firewall;
     send_key "alt-f4";


### PR DESCRIPTION
It seems that firewalld is only the default on new installations while
upgrades preserve SuSEfirewall2 (for now).

See failure occurences like
* SLE upgrade test https://openqa.suse.de/tests/1404147#step/firewall_enabled/3
* openSUSE 13.1->TW https://openqa.opensuse.org/tests/590508#step/enable_firewall/4
* openSUSE 42.2->TW https://openqa.opensuse.org/tests/590533#step/firewall_enabled/3
* openSUSE 13.2->15.0 https://openqa.opensuse.org/tests/590684#step/firewall_enabled/3

Verification run: http://lord.arch/tests/391#step/firewall_enabled/1

Related progress issue: https://progress.opensuse.org/issues/28726