### PR TITLE
Migrate 10 regression-firefox cases to SLED15

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -417,31 +417,34 @@ sub uses_qa_net_hardware {
 sub load_x11regression_firefox {
     loadtest "x11regressions/firefox/firefox_smoke";
     loadtest "x11regressions/firefox/firefox_localfiles";
-    loadtest "x11regressions/firefox/firefox_emaillink";
     loadtest "x11regressions/firefox/firefox_urlsprotocols";
     loadtest "x11regressions/firefox/firefox_downloading";
-    loadtest "x11regressions/firefox/firefox_extcontent";
     loadtest "x11regressions/firefox/firefox_headers";
     loadtest "x11regressions/firefox/firefox_pdf";
     loadtest "x11regressions/firefox/firefox_changesaving";
     loadtest "x11regressions/firefox/firefox_fullscreen";
     loadtest "x11regressions/firefox/firefox_health";
     loadtest "x11regressions/firefox/firefox_flashplayer";
-    loadtest "x11regressions/firefox/firefox_java";
-    loadtest "x11regressions/firefox/firefox_pagesaving";
-    loadtest "x11regressions/firefox/firefox_private";
-    loadtest "x11regressions/firefox/firefox_mhtml";
-    loadtest "x11regressions/firefox/firefox_plugins";
-    loadtest "x11regressions/firefox/firefox_extensions";
-    loadtest "x11regressions/firefox/firefox_appearance";
-    loadtest "x11regressions/firefox/firefox_gnomeshell";
-    loadtest "x11regressions/firefox/firefox_passwd";
-    loadtest "x11regressions/firefox/firefox_html5";
-    loadtest "x11regressions/firefox/firefox_developertool";
-    loadtest "x11regressions/firefox/firefox_rss";
-    loadtest "x11regressions/firefox/firefox_ssl";
-    if (!get_var("OFW") && check_var('BACKEND', 'qemu')) {
-        loadtest "x11/firefox_audio";
+    # The following cases are still not migrated to SLE15
+    unless (is_sle && sle_version_at_least('15')) {
+        loadtest "x11regressions/firefox/firefox_emaillink";
+        loadtest "x11regressions/firefox/firefox_extcontent";
+        loadtest "x11regressions/firefox/firefox_java";
+        loadtest "x11regressions/firefox/firefox_pagesaving";
+        loadtest "x11regressions/firefox/firefox_private";
+        loadtest "x11regressions/firefox/firefox_mhtml";
+        loadtest "x11regressions/firefox/firefox_plugins";
+        loadtest "x11regressions/firefox/firefox_extensions";
+        loadtest "x11regressions/firefox/firefox_appearance";
+        loadtest "x11regressions/firefox/firefox_gnomeshell";
+        loadtest "x11regressions/firefox/firefox_passwd";
+        loadtest "x11regressions/firefox/firefox_html5";
+        loadtest "x11regressions/firefox/firefox_developertool";
+        loadtest "x11regressions/firefox/firefox_rss";
+        loadtest "x11regressions/firefox/firefox_ssl";
+        if (!get_var("OFW") && check_var('BACKEND', 'qemu')) {
+            loadtest "x11/firefox_audio";
+        }
     }
 }
 

--- a/tests/x11regressions/firefox/firefox_changesaving.pm
+++ b/tests/x11regressions/firefox/firefox_changesaving.pm
@@ -31,6 +31,9 @@ sub run {
         send_key "alt-tab";    #Switch to firefox
     };
 
+    # Open a new tab to avoid the keyboard focus is misled by the homepage
+    send_key 'ctrl-t';
+    wait_still_screen 3;
     wait_screen_change {
         send_key "alt-e";
     };
@@ -38,7 +41,7 @@ sub run {
     assert_screen('firefox-changesaving-preferences', 30);
 
     send_key "alt-shift-s";
-    send_key "down";           #Show a blank page
+    send_key "down";    #Show a blank page
     assert_screen('firefox-changesaving-showblankpage', 30);
 
     wait_screen_change {

--- a/tests/x11regressions/firefox/firefox_localfiles.pm
+++ b/tests/x11regressions/firefox/firefox_localfiles.pm
@@ -34,7 +34,7 @@ sub run {
 
     # so
     send_key "alt-d";
-    type_string "/usr/lib/libnss3.so\n";
+    type_string "/usr/lib64/libnss3.so\n";
     $self->firefox_check_popups;
     assert_screen('firefox-local_files-so', 60);
     send_key "esc";


### PR DESCRIPTION
This testsuite will be renamed as desktopapps-firefox and scheduled under Desktop Applications

- desktopapps-firefox:BOOTFROM=c,REGRESSION=firefox,SLE_PRODUCT=sled,
  HDD_1=SLE-%VERSION%-%ARCH%-Build%BUILD%-sled-gnome.qcow2,
  START_AFTER_TEST=create_hdd_sled_gnome
- This commit contains 10 cases of regression-firefox, the remain cases will be migrated later.

  see also: poo#30661

---

- Related ticket: https://progress.opensuse.org/issues/30661
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/659
- Verification run: http://10.67.17.30/tests/102
