### PR TITLE
Replace change to console withselect_console

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -21,43 +21,7 @@ sub run {
     # let's see how it looks at the beginning
     save_screenshot;
 
-    # Special keys like Ctrl-Alt-Fx does not work on Hyper-V atm. Alt-Fx however do.
-    my $tty1_key = 'ctrl-alt-f1';
-    if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
-        $tty1_key = 'alt-f1';
-    }
-
-    if (!check_var('ARCH', 's390x')) {
-        # verify there is a text console on tty1
-        for (1 .. 6) {
-            send_key $tty1_key;
-            if (check_screen("tty1-selected", 5)) {
-                last;
-            }
-        }
-        if (!check_screen "tty1-selected", 5) {    #workaround for bsc#977007
-            record_soft_failure "unable to switch to the text mode";
-            send_key 'ctrl-alt-backspace';         #kill X and log in again
-            send_key 'ctrl-alt-backspace';
-            assert_screen 'displaymanager', 200;    #copy from installation/first_boot.pm
-            mouse_hide();
-            if (get_var('DM_NEEDS_USERNAME')) {
-                type_string $username;
-            }
-            if (match_has_tag("sddm")) {
-                # make sure choose plasma5 session
-                assert_and_click "sddm-sessions-list";
-                assert_and_click "sddm-sessions-plasma5";
-                assert_and_click "sddm-password-input";
-            }
-            else {
-                wait_screen_change { send_key 'ret' };
-            }
-            type_string "$password";
-            send_key "ret";
-            send_key_until_needlematch "tty1-selected", $tty1_key, 6, 5;
-        }
-    }
+    select_console 'root-console';
 
     # init
     check_console_font;


### PR DESCRIPTION
Replacing the hardcoded switch to tty1 with select_console
function to avoid unexpected behaviour and duplicate code

- no directly related ticket, found in progress of [this](https://progress.opensuse.org/issues/27961)
- no needles
- Verification run x86: http://pinky.arch.suse.de/tests/167#
- Verificationrun for HyperV needed
