### PR TITLE
Resolve packages conflict in ay profiles

### DIFF
--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -457,7 +457,6 @@ pre init scripts feature. See poo#20818.
       <package>libjbig2</package>
       <package>libjpeg8</package>
       <package>libmng1</package>
-      <package>libmozjs-17_0</package>
       <package>libkate1</package>
       <package>liboggkate1</package>
       <package>liblcms1</package>

--- a/data/autoyast_sle15/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle15/bug-872532_ix64ph1069.xml
@@ -795,8 +795,6 @@
       <package>metatheme-adwaita-common</package>
       <package>perl-32bit</package>
       <package>perl-Test-Simple</package>
-      <package>python3</package>
-      <package>python3-base</package>
     </remove-packages>
   </software>
   <timezone>

--- a/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
@@ -876,8 +876,6 @@ find / -name YaST2-Second-Stage.service
       <package>metatheme-adwaita-common</package>
       <package>perl-32bit</package>
       <package>perl-Test-Simple</package>
-      <package>python3</package>
-      <package>python3-base</package>
     </remove-packages>
   </software>
   <timezone>

--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -537,8 +537,6 @@
       <package>libz1-32bit</package>
       <package>perl-32bit</package>
       <package>perl-Test-Simple</package>
-      <package>python3</package>
-      <package>python3-base</package>
       <package>xaw3dd</package>
       <package>yast2-control-center-qt</package>
     </remove-packages>


### PR DESCRIPTION
remove-packages section works in following way, that locks are enabled
for them and they do not get installed, however this breaks installation
as base system module requires some of them.
So, omitting python3, python3-base and libmozjs-17_0 packages in
remove-packages section.

See [bsc#1073649](https://bugzilla.suse.com/show_bug.cgi?id=1073649).

- Verification runs:
  * [autoyast_bug-872532_ix64ph1069](http://g226.suse.de/tests/490)
  * [bug-876411_btrfs_h5_autoinst](http://g226.suse.de/tests/489)
  * [autoyast_bug-887126_autoinst](http://g226.suse.de/tests/488)
