### PR TITLE
Improve close log window in ntpclient

### DIFF
--- a/tests/console/yast2_ntpclient.pm
+++ b/tests/console/yast2_ntpclient.pm
@@ -152,11 +152,9 @@ sub run {
         assert_screen 'yast2_ntp-client_new_file_name';
         send_key 'alt-o';
         assert_screen 'yast2_ntp-client_display_log';
-        wait_still_screen 1;
-        send_key 'alt-c';
 
         # assert that we are back to configuration page
-        assert_screen 'yast2_ntp-client_configuration';
+        send_key_until_needlematch('yast2_ntp-client_configuration', 'alt-c');
         wait_still_screen 1;
     }
 


### PR DESCRIPTION
Fix poo#30814: Log window is not sometimes closed, improve alt-c
key press.

Log window during ntpclient configuration is not sometimes closed:
https://openqa.suse.de/tests/1416449#step/yast2_ntpclient/33

Although is alt-c pressed, it is not sometimes registered. The goal is to improve behavior and 
close window properly. wait_still_screen was replaced by send_key_until_needlematch.

There was also issue with needle ntp-client-configuration, it was matched even with log window
opened. Old needle was deleted and was replaced by new with one more matching area.

- Related ticket: https://progress.opensuse.org/issues/30814
- Needles SLES: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/660
- Needle openSUSE: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/312

- Verification run SLE15: http://10.100.12.105/tests/820#step/yast2_ntpclient/15
- Verification run SLE12: http://10.100.12.105/tests/806#step/yast2_ntpclient/38
- Verification run Leap: http://10.100.12.105/tests/821#step/yast2_ntpclient/38
- Verification run Tumbleweed: http://10.100.12.105/tests/819#step/yast2_ntpclient/14

Although this change looks trivial, there is higher degree of complexity in needles.
ntp-client-configuration needle tag is shared between all distributions. There are in fact 4 different needles. SLE12 and Leap have same logic in needles, but on different places. Tumbleweed and SLE15 have needles with different logic, but thanks to same needle name, there could be potential conflict.

- SLE15: yast2_ntpclient-yast2_ntp-client_configuration-20171226 (no change)
- SLE12: yast2_ntpclient-yast2_ntp-client_configuration-20180125 (new one)
- Leap: yast2_ntpclient-yast2_ntp-client_configuration-20180125 (new one)
- TW: yast2_ntpclient-yast2_ntp-client_configuration-20180119(added one more area in json)