### PR TITLE
More adjustments for default role changes for SLE15 (third coming)

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -218,8 +218,9 @@ sub fill_in_registration_data {
             }
             assert_screen($modules_needle);
             # Add desktop module for SLES if desktop is gnome
+            # Need desktop application for minimalx to make change_desktop work
             if (   check_var('SLE_PRODUCT', 'sles')
-                && check_var('DESKTOP', 'gnome')
+                && (check_var('DESKTOP', 'gnome') || check_var('DESKTOP', 'minimalx'))
                 && (my $addons = get_var('SCC_ADDONS')) !~ /(?:desktop|we|productivity|ha)/)
             {
                 $addons = $addons ? $addons . ',desktop' : 'desktop';

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -690,7 +690,10 @@ sub load_inst_tests {
             loadtest "installation/logpackages";
         }
         if (is_sles4sap()) {
-            if (is_sles4sap_standard() or !check_var('SYSTEM_ROLE', 'default')) {
+            if (
+                is_sles4sap_standard()    # Schedule module only for SLE15 with non-default role
+                || sle_version_at_least('15') && get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'))
+            {
                 loadtest "installation/user_settings";
             }    # sles4sap wizard installation doesn't have user_settings step
         }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -72,12 +72,15 @@ sub is_update_test_repo_test {
 }
 
 sub is_desktop_module_selected {
+    # desktop applications module is selected if following variables have following values:
+    # productivity and ha require desktop applications, so it's preselected
+    # same is true for sles4sap
     return
-         check_var_array('ADDONS', 'all-packages')
-      || check_var_array('ADDONS',             'desktop')
-      || check_var_array('WORKAROUND_MODULES', 'desktop')
-      || check_var_array('ADDONURL',           'desktop')
-      || check_var_array('SCC_ADDONS',         'desktop');
+         get_var('ADDONS') =~ /all-packages|desktop|we/
+      || get_var('WORKAROUND_MODULES') =~ /desktop|we/
+      || get_var('ADDONURL') =~ /desktop|we/
+      || get_var('SCC_ADDONS') =~ /desktop|we|productivity|ha/
+      || is_sles4sap;
 }
 
 sub default_desktop {
@@ -87,8 +90,6 @@ sub default_desktop {
     return 'gnome' if get_var('BASE_VERSION', '') =~ /^12/;
     return 'textmode' if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'));
     return 'gnome' if is_desktop_module_selected;
-    # for sles4sap default is gnome, is server returns true for sles4sap
-    return 'gnome' if is_sles4sap;
     # default system role for sles and sled
     return 'textmode' if is_server || !get_var('SCC_REGISTER') || !check_var('SCC_REGISTER', 'installation');
     # remaining cases are is_desktop and check_var('SCC_REGISTER', 'installation'), hence gnome

--- a/tests/toolchain/install.pm
+++ b/tests/toolchain/install.pm
@@ -50,7 +50,10 @@ sub run {
     else {
         # No need to be fixed to version (that is only for products receiving the yearly gcc update)
         # but it needs to activate development tool module
-        add_suseconnect_product("sle-module-development-tools") if is_sle;
+        if (is_sle) {
+            add_suseconnect_product("sle-module-desktop-applications");
+            add_suseconnect_product("sle-module-development-tools");
+        }
         zypper_call 'in -t pattern devel_basis';
         zypper_call 'in gcc-fortran';    # from Base System Module
         script_run 'export CC=/usr/bin/gcc';


### PR DESCRIPTION
Changes introduced in [PR#4262](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4262)
were not good enough and affected SLE 12 scenarios where SYSTEM_ROLE is
not set, which also means default role. To play it safe, after
discussion with @alvarocarvajald, we decided to check version to change
behavior only for SLE15.

Fix issues with WE module and minimalx cuased by new desktop defaults

Continue fixing issues caused by new defaults for desktop in SLE15.
Additionally we fix following:
* toolchain test activates dev tools module, but desktop apps is not
    activated
* minimalx change desktop cannot unselect gnome, as module was not
    enabled, so we enable it for minimalx desktops as well
* return gnome as default if WE is activated, or registered with HA or
    productivity modules selected


See [poo#29274](https://progress.opensuse.org/issues/29274).

- Verification runs:
  * [sles4sap+gnome](http://g226.suse.de/tests/521)
  * [sles4sap+textmode](http://g226.suse.de/tests/520)
  * [sles4sap-12-sp3install-skip-registration](http://g226.suse.de/tests/519)
  * [toolchain](http://g226.suse.de/tests/568)
  * [minimalx](http://g226.suse.de/tests/570)
  * [we module](http://g226.suse.de/tests/569)
