### PR TITLE
Fix mysql_odbc scheduled where package is not available

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2,7 +2,7 @@ package main_common;
 use base Exporter;
 use File::Basename;
 use Exporter;
-use testapi qw(check_var get_var get_required_var set_var diag);
+use testapi qw(check_var get_var get_required_var set_var check_var_array diag);
 use autotest;
 use utils;
 use version_utils qw(is_jeos is_gnome_next is_krypton_argon is_sle leap_version_at_least sle_version_at_least is_desktop_installed);
@@ -597,9 +597,9 @@ sub load_extra_tests {
         loadtest "console/zypper_moo";
         loadtest "console/gpg";
         loadtest "console/shells";
-        # MyODBC-unixODBC not available on < SP2 and sle 15
+        # MyODBC-unixODBC not available on < SP2 and sle 15 and only in SDK
         if (sle_version_at_least('12-SP2') && !(sle_version_at_least('15'))) {
-            loadtest "console/mysql_odbc";
+            loadtest "console/mysql_odbc" if check_var_array('ADDONS', 'sdk') || check_var_array('SCC_ADDONS', 'sdk');
         }
         if (get_var("SYSAUTHTEST")) {
             # sysauth test scenarios run in the console


### PR DESCRIPTION
The package MyODBC-unixODBC is only available in SDK.

Local schedule verification:

```
scheduling boot_to_desktop tests/boot/boot_to_desktop.pm
scheduling consoletest_setup tests/console/consoletest_setup.pm
scheduling hostname tests/console/hostname.pm
scheduling zypper_info tests/console/zypper_info.pm
scheduling zypper_lr_validate tests/console/zypper_lr_validate.pm
scheduling openvswitch tests/console/openvswitch.pm
scheduling sshd tests/console/sshd.pm
scheduling zypper_ref tests/console/zypper_ref.pm
scheduling update_alternatives tests/console/update_alternatives.pm
scheduling aplay tests/console/aplay.pm
scheduling command_not_found tests/console/command_not_found.pm
scheduling repo_package_install tests/console/repo_package_install.pm
scheduling openssl_alpn tests/console/openssl_alpn.pm
scheduling autoyast_removed tests/console/autoyast_removed.pm
scheduling docker tests/console/docker.pm
scheduling runc tests/console/runc.pm
scheduling sle2docker tests/console/sle2docker.pm
scheduling git tests/console/git.pm
scheduling java tests/console/java.pm
scheduling curl_ipv6 tests/console/curl_ipv6.pm
scheduling wget_ipv6 tests/console/wget_ipv6.pm
scheduling unzip tests/console/unzip.pm
scheduling zypper_moo tests/console/zypper_moo.pm
scheduling gpg tests/console/gpg.pm
scheduling shells tests/console/shells.pm
scheduling kdump_and_crash tests/console/kdump_and_crash.pm
scheduling consoletest_finish tests/console/consoletest_finish.pm
```

Related progress issue: https://progress.opensuse.org/issues/30679