### PR TITLE
Select ipmi sol console after installation

### DIFF
--- a/tests/boot/qa_net_boot_from_hdd.pm
+++ b/tests/boot/qa_net_boot_from_hdd.pm
@@ -1,20 +1,23 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# G-Summary: Let real hardware boot to BIOS and PXE menu before grub_test
-# G-Maintainer: Stephan Kulow <coolo@suse.de>
+# Summary: Let real hardware boot to BIOS and PXE menu before grub_test
+# Maintainer: Stephan Kulow <coolo@suse.de>
 
 use base "basetest";
 use strict;
 use testapi;
 
 sub run {
+    if (check_var('BACKEND', 'ipmi')) {
+        select_console 'sol', await_console => 0;
+    }
     assert_screen "qa-net-selection", 300;
     # boot to hard disk is default
     send_key 'ret';


### PR DESCRIPTION
A black screen appears after installation on ipmi machines. The sol console has to be selected after installation to continue.

- Related ticket: https://progress.opensuse.org/issues/27108
- Verification run: http://copland.arch.suse.de/tests/786#step/qa_net_boot_from_hdd/1
