### PR TITLE
Export logs to debug velum startup failure

### DIFF
--- a/tests/caasp/stack_admin.pm
+++ b/tests/caasp/stack_admin.pm
@@ -66,5 +66,16 @@ sub run() {
     export_cluster_logs;
 }
 
+sub post_fail_hook {
+    # Variable to enable failed cluster debug
+    sleep if check_var('DEBUG_SLEEP', 'admin');
+
+    script_run "journalctl > journal.log";
+    upload_logs "journal.log";
+
+    script_run 'supportconfig -i psuse_caasp -B supportconfig', 120;
+    upload_logs '/var/log/nts_supportconfig.tbz';
+}
+
 1;
 # vim: set sw=4 et:


### PR DESCRIPTION
To get logs for: https://openqa.suse.de/tests/1415939#step/stack_admin/29