### PR TITLE
LTP: Disable reboot after install to avoid snapshot

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -113,7 +113,7 @@ sub maybe_load_kernel_tests {
             loadtest 'update_kernel';
         }
         loadtest 'install_ltp';
-        loadtest 'boot_ltp';
+        #loadtest 'boot_ltp';
         loadtest 'shutdown_ltp';
     }
     elsif (get_var('LTP_SETUP_NETWORKING')) {

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -209,7 +209,7 @@ sub run {
     upload_runtest_files('${LTPROOT:-/opt/ltp}/runtest', $tag);
 
     select_console('root-console');
-    type_string "reboot\n";
+    #type_string "reboot\n";
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
boot_ltp is marked as a milestone so that we can revert to it during normal
testing. It is also ran after install_ltp as a sanity check to make sure the
system boots into a clean state after installing the LTP (because a lot of
tests depend on it, so we don't want every test to fail in boot_ltp). However
the qcow2 image published by install_ltp has become very large since boot_ltp
was marked as a milestone.

We don't want to remove boot_ltp's milstone, so instead we can remove boot_ltp
from the install_module. At least temporarily.

Also snapshots currently fail a lot, especially for VMs with larger amounts of
RAM in use.
