### PR TITLE
Migrate 11 regression-firefox cases to SLED15

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -440,26 +440,26 @@ sub load_x11regression_firefox {
     loadtest "x11regressions/firefox/firefox_fullscreen";
     loadtest "x11regressions/firefox/firefox_health";
     loadtest "x11regressions/firefox/firefox_flashplayer";
+    loadtest "x11regressions/firefox/firefox_pagesaving";
+    loadtest "x11regressions/firefox/firefox_private";
+    loadtest "x11regressions/firefox/firefox_mhtml";
+    loadtest "x11regressions/firefox/firefox_extensions";
+    loadtest "x11regressions/firefox/firefox_appearance";
+    loadtest "x11regressions/firefox/firefox_passwd";
+    loadtest "x11regressions/firefox/firefox_html5";
+    loadtest "x11regressions/firefox/firefox_developertool";
+    loadtest "x11regressions/firefox/firefox_rss";
+    loadtest "x11regressions/firefox/firefox_ssl";
+    if (!get_var("OFW") && check_var('BACKEND', 'qemu')) {
+        loadtest "x11/firefox_audio";
+    }
     # The following cases are still not migrated to SLE15
     unless (is_sle && sle_version_at_least('15')) {
         loadtest "x11regressions/firefox/firefox_emaillink";
         loadtest "x11regressions/firefox/firefox_extcontent";
         loadtest "x11regressions/firefox/firefox_java";
-        loadtest "x11regressions/firefox/firefox_pagesaving";
-        loadtest "x11regressions/firefox/firefox_private";
-        loadtest "x11regressions/firefox/firefox_mhtml";
         loadtest "x11regressions/firefox/firefox_plugins";
-        loadtest "x11regressions/firefox/firefox_extensions";
-        loadtest "x11regressions/firefox/firefox_appearance";
         loadtest "x11regressions/firefox/firefox_gnomeshell";
-        loadtest "x11regressions/firefox/firefox_passwd";
-        loadtest "x11regressions/firefox/firefox_html5";
-        loadtest "x11regressions/firefox/firefox_developertool";
-        loadtest "x11regressions/firefox/firefox_rss";
-        loadtest "x11regressions/firefox/firefox_ssl";
-        if (!get_var("OFW") && check_var('BACKEND', 'qemu')) {
-            loadtest "x11/firefox_audio";
-        }
     }
 }
 

--- a/tests/x11regressions/firefox/firefox_mhtml.pm
+++ b/tests/x11regressions/firefox/firefox_mhtml.pm
@@ -14,6 +14,7 @@
 use strict;
 use base "x11regressiontest";
 use testapi;
+use version_utils 'sle_version_at_least';
 
 sub run {
     my ($self) = @_;
@@ -33,9 +34,13 @@ sub run {
     assert_and_click('firefox-mhtml-unmht');
     for my $i (1 .. 2) { send_key "tab"; }
     send_key "spc";
-    assert_and_click('unmht_restart_now');
-    $self->firefox_check_popups;
+    unless (sle_version_at_least('15')) {
+        assert_and_click('unmht_restart_now');
+        $self->firefox_check_popups;
+    }
+    wait_still_screen 3;
     assert_and_click('firefox-my-addons');
+    send_key 'f5' if (sle_version_at_least('15'));
     assert_screen('firefox-mhtml-unmht_installed', 90);
 
     wait_screen_change { send_key "ctrl-w" };


### PR DESCRIPTION
- These cases will be added to testsuite desktopapps-firefox
- Update firefox_mhtml
- This commit contains 11 cases of regression-firefox, the remain cases will be migrated later.

---

- Related ticket: https://progress.opensuse.org/issues/30661
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/666
- Verification run: http://10.67.17.30/tests/110
