### PR TITLE
Pattern fix for SLES4SAP-12 and saptune solutions fix for SLES4SAP-15 on ppc64le

### DIFF
--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -12,6 +12,7 @@
 
 use base "sles4sap";
 use testapi;
+use version_utils 'sle_version_at_least';
 use strict;
 
 sub run {
@@ -21,10 +22,12 @@ sub run {
 
     select_console 'root-console';
 
+    my $base_pattern = sle_version_at_least('15') ? 'patterns-server-enterprise-sap_server' : 'patterns-sles-sap_server';
+
     # First check pattern sap_server which is installed by default in SLES4SAP
     # when 'SLES for SAP Applications' system role is selected
     $output = script_output("zypper info -t pattern sap_server");
-    if ($output !~ /i\+\s\|\spatterns-server-enterprise-sap_server\s+\|\spackage\s\|\sRequired/) {
+    if ($output !~ /i\+\s\|\s$base_pattern\s+\|\spackage\s\|\sRequired/) {
         # Pattern sap_server is not installed. Could either be a bug or caused by
         # the use of the 'textmode' system role
         die "Pattern sap_server not installed by default"

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -26,8 +26,8 @@ sub run {
 
     # In ppc64le not all solutions are available
     if (check_var('ARCH', 'ppc64le')) {
-        shift @solutions; # Remove BOBJ
-        pop @solutions;   # Remove SAP-ASE
+        shift @solutions;    # Remove BOBJ
+        pop @solutions;      # Remove SAP-ASE
     }
 
     select_console 'root-console';

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -22,13 +22,11 @@ sub tuned_is {
 
 sub run {
     my ($self) = @_;
-    my @solutions = qw(BOBJ HANA MAXDB NETWEAVER S4HANA-APPSERVER S4HANA-DBSERVER SAP-ASE);
 
-    # In ppc64le not all solutions are available
-    if (check_var('ARCH', 'ppc64le')) {
-        shift @solutions;    # Remove BOBJ
-        pop @solutions;      # Remove SAP-ASE
-    }
+    my @solutions
+      = check_var('ARCH', 'ppc64le') ?
+      qw(HANA MAXDB NETWEAVER S4HANA-APPSERVER S4HANA-DBSERVER)
+      : qw(BOBJ HANA MAXDB NETWEAVER S4HANA-APPSERVER S4HANA-DBSERVER SAP-ASE);
 
     select_console 'root-console';
 

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -24,6 +24,12 @@ sub run {
     my ($self) = @_;
     my @solutions = qw(BOBJ HANA MAXDB NETWEAVER S4HANA-APPSERVER S4HANA-DBSERVER SAP-ASE);
 
+    # In ppc64le not all solutions are available
+    if (check_var('ARCH', 'ppc64le')) {
+        shift @solutions; # Remove BOBJ
+        pop @solutions;   # Remove SAP-ASE
+    }
+
     select_console 'root-console';
 
     unless (tuned_is 'running') {


### PR DESCRIPTION
1. Fixes sap_server pattern check in SLES4SAP 12.
2. Remove BOBJ and SAP-ASE from saptune solutions array when ARCH=ppc64le, as those solutions are not implemented in that architecture.

- Related ticket: N/A
- Needles: N/A
- Verification runs: http://mango.suse.de/tests/205 (15, textmode), http://mango.suse.de/tests/206 (15, gnome), http://mango.suse.de/tests/207 (12sp3). Verification run on ppc64le will be performed in o.s.d.