### PR TITLE
Record free disk space before upgrade

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -31,6 +31,7 @@ our @EXPORT = qw(
   register_system_in_textmode
   remove_ltss
   disable_installation_repos
+  record_disk_info
 );
 
 sub setup_migration {
@@ -88,5 +89,19 @@ sub disable_installation_repos {
     }
 }
 
+# Record disk info to help debug diskspace exhausted
+# issue during upgrade
+sub record_disk_info {
+    if (get_var('FILESYSTEM', 'btrfs') =~ /btrfs/) {
+        assert_script_run 'btrfs filesystem df / | tee /tmp/btrfs-filesystem-df.txt';
+        assert_script_run 'btrfs filesystem usage / | tee /tmp/btrfs-filesystem-usage.txt';
+        assert_script_run 'snapper list | tee /tmp/snapper-list.txt';
+        upload_logs '/tmp/btrfs-filesystem-df.txt';
+        upload_logs '/tmp/btrfs-filesystem-usage.txt';
+        upload_logs '/tmp/snapper-list.txt';
+    }
+    assert_script_run 'df -h > /tmp/df.txt';
+    upload_logs '/tmp/df.txt';
+}
 1;
 # vim: sw=4 et

--- a/tests/update/patch_before_migration.pm
+++ b/tests/update/patch_before_migration.pm
@@ -76,6 +76,10 @@ sub patching_sle {
     # Both of them need registration during offline migration
     if (!(is_smt_or_module_tests || get_var('KEEP_REGISTERED'))) { set_var("SCC_REGISTER", ''); }
 
+    # Record the installed rpm list
+    assert_script_run 'rpm -qa > /tmp/rpm-qa.txt';
+    upload_logs '/tmp/rpm-qa.txt';
+
     # mark system patched
     set_var("SYSTEM_PATCHED", 1);
 }
@@ -132,6 +136,7 @@ sub run {
 
     $self->setup_migration();
     $self->patching_sle();
+    $self->record_disk_info;
 }
 
 sub test_flags {


### PR DESCRIPTION
Record the hdd disk info to help debug diskspace exhausted
issue during upgrade.
- see poo#30249

- Related ticket: https://progress.opensuse.org/issues/30249
- Needles: None
- Verification run: http://10.67.18.143/tests/171#step/patch_before_migration/76
