### PR TITLE
Adapt toggle_home hotkey on TW with storage-ng

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
-use version_utils 'is_leap';
+use version_utils qw(is_leap is_storage_ng);
 
 sub run {
     assert_screen 'partitioning-edit-proposal-button', 40;
@@ -36,8 +36,6 @@ sub run {
             $cmd{rescandevices}     = 'alt-c';
             $cmd{enablelvm}         = 'alt-a';
             $cmd{encryptdisk}       = 'alt-l';
-            # On TW have different shortcut for toggling separate home partition
-            $cmd{toggle_home} = 'alt-o' unless is_leap;
         }
     }
 

--- a/tests/installation/partitioning_togglehome.pm
+++ b/tests/installation/partitioning_togglehome.pm
@@ -29,8 +29,13 @@ sub run {
     # For s390x there was no offering of separated home partition until SLE 15 See bsc#1072869
     if (!check_var('ARCH', 's390x') or is_storage_ng()) {
         if (!check_screen 'disabledhome', 0) {
-            # detect whether new (Radio Buttons) YaST behaviour
-            $cmd{toggle_home} = 'alt-r' if check_screen('inst-partition-radio-buttons', 0);
+            # toggle_home hotkey can change
+            if (check_screen('inst-partition-radio-buttons', 0)) {
+                $cmd{toggle_home} = 'alt-r';
+            }
+            elsif (check_screen('proposed-separated-swap', 0)) {
+                $cmd{toggle_home} = 'alt-o';
+            }
             send_key $cmd{toggle_home};
         }
         assert_screen 'disabledhome';


### PR DESCRIPTION
toggle_home hotkey not adapted on TW with storage-ng

- Related ticket: https://progress.opensuse.org/issues/30871
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/313
- Verification run: 
  - [TW](http://copland.arch.suse.de/tests/796#step/partitioning_togglehome/7)
  - [SLE 15](http://copland.arch.suse.de/tests/797#step/partitioning_togglehome/5)
  - [SLE 12-SP4](http://copland.arch.suse.de/tests/801#step/partitioning_togglehome/3)
  - [Leap 15](http://copland.arch.suse.de/tests/798#step/partitioning_togglehome/5)
  - [Leap 42.3](http://copland.arch.suse.de/tests/802#step/partitioning_togglehome/3)
