### PR TITLE
Run workaround for cnf only on SLE15

### DIFF
--- a/tests/console/command_not_found.pm
+++ b/tests/console/command_not_found.pm
@@ -20,6 +20,7 @@ use registration qw(add_suseconnect_product remove_suseconnect_product);
 
 # test for regression of bug http://bugzilla.suse.com/show_bug.cgi?id=952496
 sub run {
+    my ($self) = @_;
     # select user-console; for one we want to be sure cnf works for a user, 2nd assert_script_run does not work in root-console
     select_console 'user-console';
 
@@ -28,21 +29,23 @@ sub run {
     }
 
     my $not_installed_pkg = (is_sle && sle_version_at_least '15') ? 'wireshark' : 'xosview';
-    my $cnf_cmd           = "echo \"\$(cnf $not_installed_pkg 2>&1 | tee /dev/stderr)\" | grep -q \"zypper install $not_installed_pkg\"";
-    my $assert            = 1;
-    if (sle_version_at_least '15') {
-        my $assert = script_run($cnf_cmd);
+    my $cnf_cmd = "echo \"\$(cnf $not_installed_pkg 2>&1 | tee /dev/stderr)\" | grep -q \"zypper install $not_installed_pkg\"";
+
+    if (is_sle && sle_version_at_least '15') {
+        $self->{run_post_hook} = script_run($cnf_cmd);
         select_console 'root-console';
         record_soft_failure 'https://fate.suse.com/323424';
         add_suseconnect_product("sle-module-desktop-applications");
         select_console 'user-console';
     }
-    assert_script_run $cnf_cmd if $assert;    # Run command if not yet executed (workaround for SLE 15)
+    assert_script_run $cnf_cmd if $self->{run_post_hook};    # Run command if not yet executed (workaround for SLE 15)
     save_screenshot;
 }
 
-# deativate desktop applications module on sle 15
 sub post_run_hook {
+    # deativate desktop applications module on sle 15 if was activated
+    return unless shift->{run_post_hook};
+
     select_console 'root-console';
     remove_suseconnect_product("sle-module-desktop-applications");
     select_console 'user-console';


### PR DESCRIPTION
In [PR#4290](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4290) I've introduced changes so cnf post run hook is always executed, but we
need it only for SLE15 and only if command fails and we apply
workaround.

See fate#323424.

Verification runs: 
  * [SLE15](http://g226.suse.de/tests/578)
  * [openSUSE](http://g226.suse.de/tests/579)
