### PR TITLE
Fix ay profiles according to bsc#1076406, bsc#1077984  and packages availability changes

### DIFF
--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -271,7 +271,7 @@ pre init scripts feature. See poo#20818.
           <crypt_fs config:type="boolean">false</crypt_fs>
           <filesystem config:type="symbol">xfs</filesystem>
           <format config:type="boolean">true</format>
-          <fstopt>noatime,barrier=0,inode64</fstopt>
+          <fstopt>noatime,nobarrier,inode64</fstopt>
           <loop_fs config:type="boolean">false</loop_fs>
           <lv_name>lvroot</lv_name>
           <mount>/</mount>
@@ -285,7 +285,7 @@ pre init scripts feature. See poo#20818.
           <crypt_fs config:type="boolean">false</crypt_fs>
           <filesystem config:type="symbol">xfs</filesystem>
           <format config:type="boolean">true</format>
-          <fstopt>noatime,barrier=0,inode64</fstopt>
+          <fstopt>noatime,nobarrier,inode64</fstopt>
           <loop_fs config:type="boolean">false</loop_fs>
           <lv_name>lvopt</lv_name>
           <mount>/opt</mount>
@@ -299,7 +299,7 @@ pre init scripts feature. See poo#20818.
           <crypt_fs config:type="boolean">false</crypt_fs>
           <filesystem config:type="symbol">xfs</filesystem>
           <format config:type="boolean">true</format>
-          <fstopt>noatime,barrier=0,inode64</fstopt>
+          <fstopt>noatime,nobarrier,inode64</fstopt>
           <loop_fs config:type="boolean">false</loop_fs>
           <lv_name>lvvar</lv_name>
           <mount>/var</mount>
@@ -313,7 +313,7 @@ pre init scripts feature. See poo#20818.
           <crypt_fs config:type="boolean">false</crypt_fs>
           <filesystem config:type="symbol">xfs</filesystem>
           <format config:type="boolean">true</format>
-          <fstopt>noatime,barrier=0,nodev,inode64</fstopt>
+          <fstopt>noatime,nobarrier,nodev,inode64</fstopt>
           <loop_fs config:type="boolean">false</loop_fs>
           <lv_name>lvhome</lv_name>
           <mount>/home</mount>
@@ -327,7 +327,7 @@ pre init scripts feature. See poo#20818.
           <crypt_fs config:type="boolean">false</crypt_fs>
           <filesystem config:type="symbol">xfs</filesystem>
           <format config:type="boolean">true</format>
-          <fstopt>noatime,barrier=0,nodev,nosuid,noexec,inode64</fstopt>
+          <fstopt>noatime,nobarrier,nodev,nosuid,noexec,inode64</fstopt>
           <loop_fs config:type="boolean">false</loop_fs>
           <lv_name>lvtmp</lv_name>
           <mount>/tmp</mount>

--- a/data/autoyast_sle15/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle15/bug-872532_ix64ph1069.xml
@@ -731,7 +731,6 @@
     <image/>
     <instsource/>
     <packages config:type="list">
-      <package>dbus-1-python</package>
       <package>dconf</package>
       <package>girepository-1_0</package>
       <package>grub2-snapper-plugin</package>
@@ -742,14 +741,12 @@
       <package>libdconf1</package>
       <package>libgirepository-1_0-1</package>
       <package>plymouth-dracut</package>
-      <package>python-gobject</package>
       <package>snapper</package>
       <package>snapper-zypp-plugin</package>
       <package>ucode-intel</package>
       <package>xbitmaps</package>
       <package>yast2-snapper</package>
       <package>yast2-trans-en_US</package>
-      <package>zypp-plugin-python</package>
     </packages>
     <patterns config:type="list">
       <pattern>minimal_base</pattern>

--- a/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
@@ -33,18 +33,29 @@
 tee YaST2-Second-Stage.service <<EOT
 [Unit]
 Description=YaST2 Second Stage
+# If xinetd is enabled, make sure it's already running so we can stop it during
+# initialization of the VNC server
 After=apparmor.service local-fs.target plymouth-start.service
-Before=systemd-user-sessions.service network.service NetworkManager.service firewalld.service
+Conflicts=plymouth-start.service
+Before=getty@tty1.service serial-getty@ttyS0.service serial-getty@ttyS1.service serial-getty@ttyS2.service
+Before=display-manager.service
 ConditionPathExists=/var/lib/YaST2/runme_at_boot
 
 [Service]
 Type=oneshot
-Environment=SYSTEMCTL_OPTIONS=--ignore-dependencies TERM=linux
-# Turn off plymouth completely before accessing tty
+# PX_MODULE_PATH=""  ==>
+# Do not load libproxy modules (config_kde4 module crashes because of Qt4/Qt5
+# clash), empty path causes that the installed modules are not found. Sysconfig
+# and envvar extensions are still loaded, /etc/sysconfig/proxy values are still
+# used correctly (see bnc#866692 and bnc#866692 for details).
+Environment=TERM=linux PX_MODULE_PATH=""
 ExecStartPre=-/usr/bin/plymouth quit
 ExecStart=/usr/lib/YaST2/startup/YaST2.Second-Stage
 RemainAfterExit=yes
 TimeoutSec=0
+# Initialize tty1 in order to remove old YaST output and to show the cursor
+# again (bnc#1018037)
+ExecStartPost=/bin/sh -c '/usr/bin/printf "\033c" > /dev/tty1'
 ExecStartPost=/usr/bin/rm -f /var/lib/YaST2/runme_at_boot
 ExecStartPost=/usr/bin/systemctl restart systemd-vconsole-setup.service
 StandardInput=tty

--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -481,7 +481,6 @@
     <packages config:type="list">
       <package>at-spi2-atk-common</package>
       <package>at-spi2-atk-gtk2</package>
-      <package>dbus-1-python</package>
       <package>dconf</package>
       <package>ft2demos</package>
       <package>grub2-snapper-plugin</package>
@@ -504,18 +503,14 @@
       <package>libtheora0</package>
       <package>libvisual</package>
       <package>plymouth-dracut</package>
-      <package>python-gobject</package>
-      <package>python-gobject-cairo</package>
       <package>snapper</package>
       <package>snapper-zypp-plugin</package>
       <package>ucode-intel</package>
       <package>xf86-input-evdev</package>
       <package>xf86-input-wacom</package>
-      <package>xf86-video-modesetting</package>
       <package>yast2-snapper</package>
       <package>yast2-trans-en_US</package>
       <package>yast2-x11</package>
-      <package>zypp-plugin-python</package>
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>


### PR DESCRIPTION
In the profile we modify ay second stage service settings which got
outdated and lead to system not starting properly.

Now it's inline with YaST2-Second-Stage.service

See bsc#1076406.

Verification runs:
[bsc#1076406](http://g226.suse.de/tests/580)
Fixes for missing software:
[bug-872532_ix64ph1069](http://g226.suse.de/tests/606)
[bug-887126_autoinst](http://g226.suse.de/tests/603)