### PR TITLE
Virtualization: add result parser for TIMEOUT testcase

### DIFF
--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -38,7 +38,7 @@ sub analyzeResult {
     $text =~ /Test in progress(.*)Test run complete/s;
     my $rough_result = $1;
     foreach (split("\n", $rough_result)) {
-        if ($_ =~ /(\S+)\s+\.{3}\s+\.{3}\s+(PASSED|FAILED|SKIPPED)\s+\((\S+)\)/g) {
+        if ($_ =~ /(\S+)\s+\.{3}\s+\.{3}\s+(PASSED|FAILED|SKIPPED|TIMEOUT)\s+\((\S+)\)/g) {
             $result->{$1}{status} = $2;
             $result->{$1}{time}   = $3;
         }


### PR DESCRIPTION
Current guest installation can not parse TIMEOUT guests correctly, which results in failure https://openqa.suse.de/tests/1405553#step/guest_installation_run/8. So this commit is to fix it.

No verification job, since code change is so small and I am confident with the 
change to work.