### PR TITLE
Use script_run instead restrictive systemctl wrapper i vnc_two_passwords

### DIFF
--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -14,7 +14,7 @@
 use base "x11test";
 use strict;
 use testapi;
-use utils qw(ensure_unlocked_desktop systemctl);
+use utils 'ensure_unlocked_desktop';
 
 my @options = ({pw => "full_access_pw", change => 1}, {pw => "view_only_pw", change => 0});
 my $theme = "/usr/share/gnome-shell/theme/gnome-classic.css";
@@ -30,7 +30,7 @@ sub type_and_wait {
 
 sub start_vnc_server {
     # Disable remote administration from previous tests
-    systemctl 'stop vncmanager';
+    script_run 'systemctl stop vncmanager';
 
     # Create password file
     type_string "tput civis\n";


### PR DESCRIPTION
Fixes poo#30781

- Related ticket: https://progress.opensuse.org/issues/30781
- Verification run: http://quasar.suse.cz/tests/440#step/vnc_two_passwords/4
