### PR TITLE
Add keyboard layout test to Installer

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -202,6 +202,7 @@ sub load_boot_tests {
 
 sub load_inst_tests {
     loadtest "installation/welcome";
+    loadtest "installation/keyboard_selection";
     if (check_var('ARCH', 's390x')) {
         loadtest "installation/disk_activation";
     }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -561,6 +561,7 @@ sub install_this_version {
 
 sub load_inst_tests {
     loadtest "installation/welcome";
+    loadtest "installation/keyboard_selection";
     if (get_var('DUD_ADDONS')) {
         loadtest "installation/dud_addon";
     }

--- a/tests/installation/keyboard_selection.pm
+++ b/tests/installation/keyboard_selection.pm
@@ -1,0 +1,64 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Switch keyboard layout to a different language and switch back to default
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.de>
+
+use strict;
+use warnings;
+use base "y2logsstep";
+use testapi;
+use version_utils qw(is_sle sle_version_at_least);
+
+sub switch_keyboard_layout {
+    return unless get_var('INSTALL_KEYBOARD_LAYOUT');
+    my $keyboard_layout = get_var('INSTALL_KEYBOARD_LAYOUT');
+    # for instance, select france and test "querty"
+    send_key 'alt-k';    # Keyboard Layout
+    send_key_until_needlematch("keyboard-layout-$keyboard_layout", 'down', 60);
+    if (check_var('DESKTOP', 'textmode')) {
+        send_key 'ret';
+        send_key 'alt-e';    # Keyboard Test in text mode
+    }
+    else {
+        send_key 'alt-y';    # Keyboard Test in graphic mode
+    }
+    type_string "azerty";
+    assert_screen "keyboard-test-$keyboard_layout";
+    # Select back default keyboard layout
+    send_key 'alt-k';
+    send_key_until_needlematch("keyboard-layout", 'up', 60);
+    send_key 'ret' if (check_var('DESKTOP', 'textmode'));
+}
+
+sub run {
+    switch_keyboard_layout;
+
+    send_key $cmd{next} unless (is_sle && sle_version_at_least('15') && get_var('UPGRADE'));
+    if (!check_var('INSTLANG', 'en_US') && check_screen 'langincomplete', 1) {
+        send_key 'alt-f';
+    }
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    # system might be stuck on bootup showing only splash screen so we press
+    # esc to show console logs
+    send_key 'esc';
+    select_console('install-shell');
+    # in case we could not even reach the installer welcome screen and logs
+    # could not be collected on the serial output:
+    $self->save_upload_y2logs;
+    $self->get_ip_address;
+    upload_logs '/var/log/linuxrc.log';
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -113,10 +113,6 @@ sub run {
     }
 
     assert_screen 'languagepicked';
-    send_key $cmd{next} unless (is_sle && sle_version_at_least('15') && get_var('UPGRADE'));
-    if (!check_var('INSTLANG', 'en_US') && check_screen 'langincomplete', 1) {
-        send_key 'alt-f';
-    }
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Add keyboard layout test to Installer. This functionality could be tested just by switching to only one language, but I wanted to create a function to iterate languages to have more test cover and reuse code. It was not strictly necessary but it helped me to found and issue in some languages, for example in Czech that is using a qwertz keyboard. qemu is mapping keys with  /usr/share/qemu/keymaps/cz and /usr/share/qemu/keymaps/en-us and I was able to reproduce why this code cannot achive alt-y once you switch to check in the Installer. Just need to use -k option in qemu to setup properly, meaning even if we test several switch to languages in future if we want to move forward with installer with a different keyboard we need to go in en-us or have available another parameter to use this -k option of qemu, which is not implemented atm in the backend.

- Related ticket: https://progress.opensuse.org/issues/30583
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/670
- Verification run: 
  * http://dhcp227/tests/355 (without parameter)
  * http://dhcp227tests/354 (1 language & default)
  * http://dhcp227tests/353 (2 languages & default)
  

