### PR TITLE
Full lvm test adjustments for ppc and aarch

### DIFF
--- a/tests/installation/partitioning_full_lvm.pm
+++ b/tests/installation/partitioning_full_lvm.pm
@@ -9,7 +9,9 @@
 
 # Summary: Expert partitioner, full LVM encryption with MSDOS-MBR, without extra /boot on x86_64 arch https://fate.suse.com/320215
 #          on s390x and ppc64le with extra /boot, not on aarch64 because of UEFI
-# Maintainer: Jozef Pupava <jpupava@suse.com>
+#          Requirements are different for storage-ng https://github.com/yast/yast-storage-ng/blob/master/doc/boot-requirements.md
+#          With UNENCRYPTED_BOOT set to true, test will have separate /boot partition for all architectures
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
 
 use strict;
 use warnings;
@@ -20,19 +22,28 @@ use version_utils 'is_storage_ng';
 
 sub run {
     create_new_partition_table;
-    if (check_var('ARCH', 's390x') || get_var('UNENCRYPTED_BOOT')) {    # s390x need /boot/zipl on ext partition
-        addpart(role => 'OS', size => 500, format => 'ext2', mount => '/boot');
-    }
-    elsif (check_var('ARCH', 'ppc64le')) {                              # ppc64le need PReP /boot
+    if (check_var('ARCH', 'ppc64le')) {    # ppc64le always needs PReP boot
         addpart(role => 'raw', size => 500, fsid => 'PReP');
     }
-    elsif (is_storage_ng) {
-        # Storage-ng has GPT by defaut, so need bios-boot partition
+    elsif (get_var('UEFI')) {              # UEFI needs partition mounted to /boot/efi for
+        addpart(role => 'efi', size => 100);
+    }
+    elsif (is_storage_ng && check_var('ARCH', 'x86_64')) {
+        # Storage-ng has GPT by defaut, so need bios-boot partition for legacy boot, which is only on x86_64
         addpart(role => 'raw', fsid => 'bios-boot', size => 1);
     }
+    if (
+        check_var('ARCH', 's390x')         # s390x need /boot/zipl on ext partition
+        || get_var('UNENCRYPTED_BOOT')     # add explicitly if parameter is set
+        || check_var('ARCH', 'ppc64le') && is_storage_ng    # ppc with lvm requires separate boot on storage-ng
+      )
+    {
+        addpart(role => 'OS', size => 500, format => 'ext2', mount => '/boot');
+    }
+
     addpart(role => 'raw', encrypt => 1);
     assert_screen 'expert-partitioner';
-    send_key 'alt-s';                                                   # select System view
+    send_key 'alt-s';                                       # select System view
     send_key_until_needlematch('volume_management_feature', 'down');    # select Volume Management
     send_key $cmd{addpart};                                             # add
     wait_still_screen 2;


### PR DESCRIPTION
As per [boot requirements](https://github.com/yast/yast-storage-ng/blob/master/doc/boot-requirements.md#) ppc64 requires both /boot and prep boot partitions in case of lvm.

Test suite was never executed with UEFI, there we need efi boot partition.

See [poo#28507](https://progress.opensuse.org/issues/28507).

[Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/671#)
- Verification runs: 
   [arm full lvm SLE15](http://g226.suse.de/tests/591)
   [arm full lvm, separate boot SLE15](http://g226.suse.de/tests/602)
   [x86 full lvm SLE15](http://g226.suse.de/tests/597)
   [x86 full lvm, separate boot SLE15](http://g226.suse.de/tests/601)
   [x86 full lvm SLE12](http://g226.suse.de/tests/599)
   [x86 full lvm, separate boot SLE12](http://g226.suse.de/tests/595)
