### PR TITLE
Remove unavailable packages from bug-876411_btrfs_h5_autoinst profile

### DIFF
--- a/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
@@ -818,7 +818,6 @@ find / -name YaST2-Second-Stage.service
     <image/>
     <instsource/>
     <packages config:type="list">
-      <package>dbus-1-python</package>
       <package>dconf</package>
       <package>girepository-1_0</package>
       <package>grub2-snapper-plugin</package>
@@ -833,15 +832,12 @@ find / -name YaST2-Second-Stage.service
       <package>libvmtools0</package>
       <package>open-vm-tools</package>
       <package>plymouth-dracut</package>
-      <package>python-gobject</package>
-      <package>python-gobject-cairo</package>
       <package>snapper</package>
       <package>snapper-zypp-plugin</package>
       <package>ucode-amd</package>
       <package>xbitmaps</package>
       <package>yast2-snapper</package>
       <package>yast2-trans-en_US</package>
-      <package>zypp-plugin-python</package>
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>


### PR DESCRIPTION
Same as in PR#4297, was hidden as failed on another issue before.

[Verification run](http://g226.suse.de/tests/617)
