### PR TITLE
Fix clvmd installation in SLEHA15

### DIFF
--- a/tests/ha/clvmd_lvmlockd.pm
+++ b/tests/ha/clvmd_lvmlockd.pm
@@ -40,8 +40,14 @@ sub run {
             record_soft_failure 'bsc#1076045';
             zypper_call 'in lvm2-lockd';
         }
+
+        # Test if package is installed
+        assert_script_run 'rpm -q lvm2-lvmlockd';
     }
     else {
+        # In SLE15, lvmlockd is installed by default, not clvmd/cmirrord
+        zypper_call 'in lvm2-clvm lvm2-cmirrord' if (is_sle && sle_version_at_least('15'));
+
         # Test if packages are installed
         assert_script_run 'rpm -q lvm2-clvm lvm2-cmirrord';
     }


### PR DESCRIPTION
Failed run: https://openqa.suse.de/tests/1439607#step/clvmd_lvmlockd/7

Now in SLEHA15, lvmlockd is installed by default to replace clvmd/cmirrord.
clvmd/cmirrord are still provided for migration purposes, but need
to be installed manually.