### PR TITLE
Migrate 5 regression-firefox cases to SLED15

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -451,16 +451,13 @@ sub load_x11regression_firefox {
     loadtest "x11regressions/firefox/firefox_developertool";
     loadtest "x11regressions/firefox/firefox_rss";
     loadtest "x11regressions/firefox/firefox_ssl";
+    loadtest "x11regressions/firefox/firefox_emaillink";
+    loadtest "x11regressions/firefox/firefox_plugins";
+    loadtest "x11regressions/firefox/firefox_java";
+    loadtest "x11regressions/firefox/firefox_extcontent";
+    loadtest "x11regressions/firefox/firefox_gnomeshell";
     if (!get_var("OFW") && check_var('BACKEND', 'qemu')) {
         loadtest "x11/firefox_audio";
-    }
-    # The following cases are still not migrated to SLE15
-    unless (is_sle && sle_version_at_least('15')) {
-        loadtest "x11regressions/firefox/firefox_emaillink";
-        loadtest "x11regressions/firefox/firefox_extcontent";
-        loadtest "x11regressions/firefox/firefox_java";
-        loadtest "x11regressions/firefox/firefox_plugins";
-        loadtest "x11regressions/firefox/firefox_gnomeshell";
     }
 }
 

--- a/tests/x11regressions/firefox/firefox_emaillink.pm
+++ b/tests/x11regressions/firefox/firefox_emaillink.pm
@@ -31,55 +31,56 @@ sub run {
     send_key "alt-f";
     wait_still_screen 3;
     send_key "e";
-    assert_screen('firefox-email_link-welcome', 90);
+    unless (sle_version_at_least('15')) {
+        assert_screen('firefox-email_link-welcome', 90);
 
-    send_key $next_key;
-
-    wait_still_screen 3;
-    send_key $next_key;
-
-    wait_still_screen 3;
-    send_key "alt-a";
-    type_string 'test@suse.com';
-    send_key $next_key;
-
-    sleep 1;
-    send_key "alt-s";    #Skip
-
-    assert_screen('firefox-email_link-settings_receiving', 90);
-    send_key "alt-s";    #Server
-    type_string "imap.suse.com";
-    send_key "alt-n";    #Username
-    type_string "test";
-    if (sle_version_at_least('12-SP2')) {
-        assert_and_click "evolution-option-next";
-        wait_still_screen 3;
-        assert_and_click "evolution-option-next";
-    }
-    else {
         send_key $next_key;
+
         wait_still_screen 3;
         send_key $next_key;
-    }
 
-    assert_screen('firefox-email_link-settings_sending');
-    send_key "alt-s";    #Server
-    type_string "smtp.suse.com";
-    wait_screen_change {
+        wait_still_screen 3;
+        send_key "alt-a";
+        type_string 'test@suse.com';
         send_key $next_key;
-    };
 
-    wait_still_screen 3;
-    if (sle_version_at_least('12-SP2')) {
-        assert_and_click "evolution-option-next";
+        sleep 1;
+        send_key "alt-s";    #Skip
+
+        assert_screen('firefox-email_link-settings_receiving', 90);
+        send_key "alt-s";    #Server
+        type_string "imap.suse.com";
+        send_key "alt-n";    #Username
+        type_string "test";
+        if (sle_version_at_least('12-SP2')) {
+            assert_and_click "evolution-option-next";
+            wait_still_screen 3;
+            assert_and_click "evolution-option-next";
+        }
+        else {
+            send_key $next_key;
+            wait_still_screen 3;
+            send_key $next_key;
+        }
+
+        assert_screen('firefox-email_link-settings_sending');
+        send_key "alt-s";    #Server
+        type_string "smtp.suse.com";
+        wait_screen_change {
+            send_key $next_key;
+        };
+
+        wait_still_screen 3;
+        if (sle_version_at_least('12-SP2')) {
+            assert_and_click "evolution-option-next";
+        }
+        else {
+            send_key $next_key;
+        }
+
+        wait_still_screen 3;
+        send_key "alt-a";
     }
-    else {
-        send_key $next_key;
-    }
-
-    wait_still_screen 3;
-    send_key "alt-a";
-
     assert_screen('firefox-email_link-send');
     wait_screen_change {
         send_key "esc";

--- a/tests/x11regressions/firefox/firefox_extcontent.pm
+++ b/tests/x11regressions/firefox/firefox_extcontent.pm
@@ -14,6 +14,7 @@
 use strict;
 use base "x11regressiontest";
 use testapi;
+use version_utils 'sle_version_at_least';
 
 sub run {
     my ($self) = @_;
@@ -40,7 +41,7 @@ sub run {
     sleep 1;
     send_key "ret";
 
-    assert_screen 'firefox-extcontent-archive_manager';
+    assert_screen((sle_version_at_least('15')) ? 'firefox-extcontent-nautils' : 'firefox-extcontent-archive_manager');
 
     send_key "ctrl-q";
 

--- a/tests/x11regressions/firefox/firefox_gnomeshell.pm
+++ b/tests/x11regressions/firefox/firefox_gnomeshell.pm
@@ -25,7 +25,12 @@ sub run {
     wait_still_screen 3;
     send_key "ctrl-shift-a";
     assert_and_click('firefox-plugins-tabicon');
-    assert_screen('firefox-gnomeshell-default', 30);
+    assert_screen [qw(firefox-gnomeshell-default firefox-plugins-missing)], 60;
+    if (match_has_tag('firefox-plugins-missing')) {
+        record_soft_failure 'bsc#1077707 - GNOME Shell Integration and other two plugins are not installed by default';
+        $self->exit_firefox;
+        return;
+    }
 
     send_key "alt-d";
     type_string "extensions.gnome.org\n";

--- a/tests/x11regressions/firefox/firefox_plugins.pm
+++ b/tests/x11regressions/firefox/firefox_plugins.pm
@@ -16,6 +16,7 @@
 use strict;
 use base "x11regressiontest";
 use testapi;
+use version_utils 'sle_version_at_least';
 
 sub run {
     my ($self) = @_;
@@ -25,7 +26,12 @@ sub run {
     wait_still_screen 3;
     send_key "ctrl-shift-a";
     assert_and_click('firefox-addons-plugins');
-    assert_screen('firefox-plugins-overview_01', 60);
+    assert_screen [qw(firefox-plugins-overview_01 firefox-plugins-missing)], 60;
+    if (match_has_tag('firefox-plugins-missing')) {
+        record_soft_failure 'bsc#1077707 - GNOME Shell Integration and other two plugins are not installed by default';
+        $self->exit_firefox;
+        return;
+    }
 
     for my $i (1 .. 2) { send_key "tab"; }
     send_key "pgdn";

--- a/tests/x11regressions/firefox/firefox_smoke.pm
+++ b/tests/x11regressions/firefox/firefox_smoke.pm
@@ -14,6 +14,7 @@
 use strict;
 use base "x11regressiontest";
 use testapi;
+use utils 'type_string_slow';
 
 sub run {
     my ($self) = @_;
@@ -27,7 +28,7 @@ sub run {
         send_key "esc";
         send_key "alt-d";
         sleep 1;
-        type_string $site. "\n";
+        type_string_slow $site. "\n";
         $self->firefox_check_popups;
         assert_screen('firefox-topsite_' . $site, 120);
     }


### PR DESCRIPTION
- These cases will be added to testsuite desktopapps-firefox
- Update firefox_smoke to fix poo#31048

---

- Related ticket: https://progress.opensuse.org/issues/30661
- Related ticket: https://progress.opensuse.org/issues/31048
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/677
- Verification run of SLE15: http://10.67.17.30/tests/144
- Verification run of SLE12-SP3: http://10.67.17.30/tests/145
