### PR TITLE
Do not use systemctl api

### DIFF
--- a/tests/qa_automation/kernel_kexec.pm
+++ b/tests/qa_automation/kernel_kexec.pm
@@ -43,7 +43,8 @@ sub run {
     # kexec -l
     assert_script_run("kexec -l $kernel_new --initrd=$initrd_new --command-line='$cmdline'");
     # kexec -e
-    systemctl 'kexec';
+    # don't use built-in systemctl api, see poo#31180
+    script_run("systemctl kexec", 0);
     # wait for reboot
     reset_consoles();
     select_console("root-console");


### PR DESCRIPTION
Fix poo#31180: kexec started to fail after migration to new systemctl
api. Test waited for systemctl response, but system was restarted
(as expected) and didn't receive response.
https://openqa.suse.de/tests/1411655#step/kernel_kexec/22

kexec part was reverted as it was before migration. Added comment to avoid it in the future.

- Related ticket: https://progress.opensuse.org/issues/31180
- Needles: none
- Verification run: http://10.100.12.105/tests/826
