### PR TITLE
Fix remove_suseconnect_product method

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -127,7 +127,7 @@ sub remove_suseconnect_product {
     $version //= scc_version();
     $arch    //= get_required_var('ARCH');
     $params  //= '';
-    assert_script_run("SUSEConnect -p $name/$version/$arch $params");
+    assert_script_run("SUSEConnect -d $name/$version/$arch $params");
 }
 
 sub register_addons {


### PR DESCRIPTION
As @mitiao correctly noticed in PR#4290, it should be -d to disable
module and not -p.
