### PR TITLE
Increase timeout for java installation

### DIFF
--- a/tests/console/java.pm
+++ b/tests/console/java.pm
@@ -35,7 +35,7 @@ sub run {
     diag "checking variable: bootstrap_conflicts_rt = $bootstrap_conflicts_rt";
 
     if (check_var("DISTRI", "sle")) {
-        zypper_call "in java-*";
+        zypper_call("in java-*", timeout => 1400);
     }
 
     if (check_var("DISTRI", "opensuse")) {


### PR DESCRIPTION
Fix poo#30514: Default timeout 700 is sometimes not enough and test
fai:
https://openqa.suse.de/tests/1398998#step/java/10.
https://openqa.suse.de/tests/1441136#step/java/10

- Related ticket: https://progress.opensuse.org/issues/30514
- Needles: none
- Verification run: http://10.100.12.105/tests/831
