### PR TITLE
Modify filesystem test for Kubic

### DIFF
--- a/tests/caasp/filesystem_ro.pm
+++ b/tests/caasp/filesystem_ro.pm
@@ -31,8 +31,13 @@ sub run {
         assert_script_run 'btrfs property get /var/log ro | grep "ro=false"';
     }
 
-    assert_script_run "grep '/ btrfs ro' /etc/fstab";
-    assert_script_run "mount | grep 'on / type btrfs (ro,'";
+    if (is_caasp 'caasp') {
+        assert_script_run "grep '/ btrfs ro' /etc/fstab";
+        assert_script_run "mount | grep 'on / type btrfs (ro,'";
+    }
+    else {
+        record_soft_failure 'bsc#1079000 - Missing readonly option in fstab';
+    }
 }
 
 1;

--- a/tests/caasp/filesystem_ro.pm
+++ b/tests/caasp/filesystem_ro.pm
@@ -14,6 +14,7 @@
 use base "opensusebasetest";
 use strict;
 use testapi;
+use version_utils 'is_caasp';
 
 sub run {
     assert_script_run "! touch /should_fail";
@@ -21,7 +22,14 @@ sub run {
     assert_script_run "touch /var/log/should_succeed";
 
     assert_script_run 'btrfs property get / ro | grep "ro=true"';
-    assert_script_run 'btrfs property get /var/log ro | grep "ro=false"';
+
+    if (is_caasp '4.0+') {
+        assert_script_run 'btrfs property get /var ro | grep "ro=false"';
+        assert_script_run 'lsattr -ld /var | grep No_COW';
+    }
+    else {
+        assert_script_run 'btrfs property get /var/log ro | grep "ro=false"';
+    }
 
     assert_script_run "grep '/ btrfs ro' /etc/fstab";
     assert_script_run "mount | grep 'on / type btrfs (ro,'";


### PR DESCRIPTION
Fix for: https://openqa.opensuse.org/tests/598031#step/filesystem_ro/12
Local run: http://dhcp91.suse.cz/tests/1179#step/overlayfs/4 (fails on product bug later)
