### PR TITLE
LTP/install: Improve adding Workstation Extension addon/module

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -25,19 +25,13 @@ sub add_repos {
     zypper_call('--gpg-auto-import-keys ref', dumb_term => 1);
 }
 
-sub scc_we_enabled {
-    script_run("zypper -n products -i", 0);
-    return wait_serial(qr/Workstation Extension/);
-}
-
 sub add_we_repo_if_available {
-    # opensuse (doesn't have extensions) or SLE as registered product
-    if (check_var('DISTRI', 'opensuse') || scc_we_enabled) {
-        return;
-    }
+    # opensuse doesn't have extensions
+    return if check_var('DISTRI', 'opensuse');
+
     my $ar_url;
     my $we_repo = get_var('REPO_SLE_WE15_POOL');
-    if ($we_repo and check_var('DISTRI', 'sle') and sle_version_at_least('15')) {
+    if ($we_repo && check_var('DISTRI', 'sle') && sle_version_at_least('15')) {
         $ar_url = "http://openqa.suse.de/assets/repo/$we_repo";
     }
     # productQA test with enabled we as iso_2


### PR DESCRIPTION
Run scc_we_enabled() after trying to add modules via variables.
If we run it before, it reports an error (red box) which is currently
on SLE 15 false positive.

This is a regression from commit
03b6c228 ("LTP/install: Rewrite dependencies")
so put it back as it was when originally added in commit:
3bf6935c ("Install ntfsprogs if is WE available as registered product.")

- Verification run: http://quasar.suse.cz/tests/479, http://quasar.suse.cz/tests/480
- Fixes issue: https://openqa.suse.de/tests/1440238#step/install_ltp/16