### PR TITLE
Fix lvmlockd check for SLEHA15

### DIFF
--- a/tests/ha/clvmd_lvmlockd.pm
+++ b/tests/ha/clvmd_lvmlockd.pm
@@ -42,7 +42,7 @@ sub run {
         }
 
         # Test if package is installed
-        assert_script_run 'rpm -q lvm2-lvmlockd';
+        assert_script_run 'rpm -q lvm2-lockd';
     }
     else {
         # In SLE15, lvmlockd is installed by default, not clvmd/cmirrord


### PR DESCRIPTION
Fix for; http://moon.qa.suse.cz/tests/1452#step/clvmd_lvmlockd/9

Wrong package name used during rpm call...

- Verification run: http://moon.qa.suse.cz/tests/1499