### PR TITLE
Remove nomodeset kernel parameter from multipath ay profile

### DIFF
--- a/data/autoyast_sle12/autoyast_multipath.xml
+++ b/data/autoyast_sle12/autoyast_multipath.xml
@@ -47,7 +47,7 @@ pre init scripts feature. See poo#20818.
       <timeout config:type="integer">0</timeout>
     </yesno_messages>
   </report>
-  
+
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>
   </deploy_image>
@@ -64,7 +64,7 @@ pre init scripts feature. See poo#20818.
   <bootloader>
     <global>
       <activate>true</activate>
-      <append>mce=dont_log_ce edd=off consoleblank=0 nomodeset rd.lvm.vg=system biosdevname=0 elevator=deadline</append>
+      <append>mce=dont_log_ce edd=off consoleblank=0 rd.lvm.vg=system biosdevname=0 elevator=deadline</append>
       <boot_mbr>true</boot_mbr>
       <timeout config:type="integer">8</timeout>
       <secure-boot>off</secure-boot>

--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -79,7 +79,7 @@ pre init scripts feature. See poo#20818.
   <bootloader>
     <global>
       <activate>true</activate>
-      <append>mce=dont_log_ce edd=off consoleblank=0 nomodeset rd.lvm.vg=system biosdevname=0 elevator=deadline</append>
+      <append>mce=dont_log_ce edd=off consoleblank=0 rd.lvm.vg=system biosdevname=0 elevator=deadline</append>
       <boot_mbr>true</boot_mbr>
       <timeout config:type="integer">8</timeout>
       <secure-boot>off</secure-boot>


### PR DESCRIPTION
This parameter makes system to boot using 25x80 layout for console.
This breaks openQA, as we expect 128x48 console.

Removing nomodeset kernel parameter resolves this issue.

No verification run, as special worker is required. Verified manually using following qemu options:
```
qemu-system-x86_64 -enable-kvm -cpu qemu64 -display gtk -vga std -m 1024 -boot d \
-device virtio-scsi-pci,id=scsi0 -device virtio-scsi-pci,id=scsi1 \
-device scsi-hd,drive=hd1a,bus=scsi0.0 \
-device scsi-hd,drive=hd1b,bus=scsi1.0 \
-drive file=VM/generic.qcow2,cache=none,if=none,id=hd1a,serial='mpath1',media=disk,format=raw,file.locking=off \
-drive file=VM/generic.qcow2,cache=none,if=none,id=hd1b,serial='mpath1',media=disk,format=raw,file.locking=off \
-drive file=VM/iso/SLE-15-Installer-DVD-x86_64-Build438.1-Media1.iso,media=cdrom,format=raw \
-S -monitor telnet:127.0.0.1:22222,server,nowait \
-netdev user,id=qanet0 -device virtio-net,netdev=qanet0,mac=52:54:00:12:34:56
```

