### PR TITLE
[WIP] Assert screen before typing on partition format

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -121,6 +121,7 @@ sub addpart {
         if ($args{format} eq 'donotformat') {
             send_key $cmd{donotformat};
             send_key 'alt-u';
+            assert_screen 'partition-no-format-no-mount';
         }
         else {
             send_key 'alt-a' if is_storage_ng;    # Select to format partition, not selected by default
@@ -132,7 +133,9 @@ sub addpart {
     }
     if ($args{fsid}) {                            # $args{fsid} will describe needle tag below
         send_key 'alt-i';                         # select File system ID
+        assert_screen 'partition-no-format-highlighted';
         send_key 'home';                          # start from the top of the list
+        assert_screen 'partition-no-format-first-option';
         send_key_until_needlematch "partition-selected-$args{fsid}-type", 'down';
     }
 

--- a/tests/installation/partitioning_warnings.pm
+++ b/tests/installation/partitioning_warnings.pm
@@ -27,6 +27,10 @@ sub run {
     elsif (check_var('ARCH', 'ppc64le')) {    # ppc64le need PReP /boot
         addpart(role => 'raw', size => 500, fsid => 'PReP');
     }
+    elsif (get_var('UEFI')) {
+        addpart(role => 'raw', size => 500, fsid => 'efi');
+    }
+
     # create small enough partition (11GB) to get warning
     addpart(role => 'OS', size => 11000, format => 'btrfs');
 


### PR DESCRIPTION
'home'/'end' key not sent. Trying asserting screen before typing.

- Related ticket: https://progress.opensuse.org/issues/30670
- Needles: (pending)
- Verification run:
  -  aarch64 (pending)
  - s390x (pending)
  - [x86_64](http://copland.arch.suse.de/tests/806#step/partitioning_warnings/24)
