### PR TITLE
Change root password and add bernhard to multipath profile

### DIFF
--- a/data/autoyast_sle12/autoyast_multipath.xml
+++ b/data/autoyast_sle12/autoyast_multipath.xml
@@ -47,7 +47,7 @@ pre init scripts feature. See poo#20818.
       <timeout config:type="integer">0</timeout>
     </yesno_messages>
   </report>
-  
+
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>
   </deploy_image>
@@ -526,7 +526,16 @@ pre init scripts feature. See poo#20818.
       <home>/root</home>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password></user_password>
+      <user_password>nots3cr3t</user_password>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
     </user>
   </users>
   <scripts>

--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -542,7 +542,16 @@ pre init scripts feature. See poo#20818.
       <home>/root</home>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password></user_password>
+      <user_password>nots3cr3t</user_password>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
     </user>
   </users>
   <scripts>


### PR DESCRIPTION
We require default password for root and bernhard as a user in the
profile.

Verification is not possible, as requires special type of worker.
Fixes: https://openqa.suse.de/tests/1446242#step/console/5
