### PR TITLE
Fix race condition on update installation

### DIFF
--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -35,7 +35,7 @@ sub run {
 
         # First update package manager, then packages, then bsc#992773 (2x)
         while (1) {
-            assert_and_click('updates_click-install');
+            assert_and_click_until_screen_change('updates_click-install');
 
             # Wait until installation is done
             assert_screen \@updates_installed_tags, 3600;


### PR DESCRIPTION
The intended behaviour is to:
1. Click on the "Install updates" button
   -> updates starts
2. Wait until a screen appears with either "No updates available" or
   "n updates available" (multiple update steps).

As the screen matching "updates_click-install" also matches the
"n updates available" match, the second match may happen before the
update has actually started.
The check will then hang in the second round, waiting for the
assert_and_click('updates_click-install');

Using a assert_and_click_until_screen_change waits until the click has
been acted upon and the assert_screen waits until the update round has
finished.

https://progress.opensuse.org/issues/31327
