### PR TITLE
Fix unlocking of encrypted boot partition in storage-ng setups

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -336,6 +336,7 @@ sub wait_boot {
             select_console('iucvconn');
         }
         else {
+            workaround_type_encrypted_passphrase if get_var('S390_ZKVM');
             wait_serial('GNU GRUB') || diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
             select_console('svirt');
             save_svirt_pty;
@@ -373,15 +374,11 @@ sub wait_boot {
             send_key "ret";
             assert_screen "grub2", 15;
         }
-        elsif (match_has_tag("migration-source-system-grub2") or match_has_tag('grub2')) {
-            send_key "ret";    # boot to source system
-        }
         elsif (get_var("LIVETEST")) {
             # prevent if one day booting livesystem is not the first entry of the boot list
             if (!match_has_tag("boot-live-" . get_var("DESKTOP"))) {
                 send_key_until_needlematch("boot-live-" . get_var("DESKTOP"), 'down', 10, 5);
             }
-            send_key "ret";
         }
         elsif (match_has_tag('inst-bootmenu')) {
             # assuming the cursor is on 'installation' by default and 'boot from
@@ -389,8 +386,6 @@ sub wait_boot {
             send_key_until_needlematch 'inst-bootmenu-boot-harddisk', 'up';
             boot_local_disk;
             assert_screen 'grub2', 15;
-            # confirm default choice
-            send_key 'ret';
         }
         elsif (match_has_tag('encrypted-disk-password-prompt')) {
             # unlock encrypted disk before grub
@@ -401,6 +396,8 @@ sub wait_boot {
             # check_screen timeout
             die "needle 'grub2' not found";
         }
+        # confirm default choice
+        send_key 'ret';
     }
 
     # On Xen we have to re-connect to serial line as Xen closed it after restart
@@ -410,7 +407,7 @@ sub wait_boot {
         select_console('sut');
     }
 
-    # on s390x svirt is encryption unlocked with workaround_type_encrypted_passphrase before this wait_boot
+    # on s390x svirt encryption is unlocked with workaround_type_encrypted_passphrase before here
     unlock_if_encrypted if !get_var('S390_ZKVM');
 
     if ($textmode || check_var('DESKTOP', 'textmode')) {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -311,10 +311,17 @@ sub minimal_patch_system {
     }
 }
 
+=head2 workaround_type_encrypted_passphrase
+
+    workaround_type_encrypted_passphrase()
+
+Record soft-failure for unresolved feature which we think is important and then unlock encrypted boot partitions if we expect it to be encrypted. This condition is met on 'storage-ng' which by default puts the boot partition within the encrypted LVM same as in test scenarios where we explicitly create an LVM including boot (C<FULL_LVM_ENCRYPT>). C<ppc64le> was already doing the same by default also in the case of pre-storage-ng but not anymore for storage-ng.
+
+=cut
 sub workaround_type_encrypted_passphrase {
     if (
         get_var('FULL_LVM_ENCRYPT')
-        || (check_var('ARCH', 'ppc64le')
+        || (   (check_var('ARCH', 'ppc64le') || (get_var('STORAGE_NG') && !check_var('ARCH', 'ppc64le')))
             && (get_var('ENCRYPT') && !get_var('ENCRYPT_ACTIVATE_EXISTING') || get_var('ENCRYPT_FORCE_RECOMPUTE'))))
     {
         record_soft_failure 'workaround https://fate.suse.com/320901' if sle_version_at_least('12-SP4');

--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -21,8 +21,6 @@ sub run {
     # 'keepconsole => 1' is workaround for bsc#1044072
     power_action('reboot', keepconsole => 1);
 
-    # on s390x svirt encryption unlock has to be done before this wait_boot
-    workaround_type_encrypted_passphrase if get_var('S390_ZKVM');
     $self->wait_boot(bootloader_time => 300);
 }
 


### PR DESCRIPTION
Verification runs:
* SLE15 x86_64 cryptlvm: http://lord.arch/tests/425
* SLE12SP4 x86_64 cryptlvm: http://lord.arch/tests/426
* SLE12SP4 x86_64 lvm-full-encrypt: http://lord.arch/tests/430

Related progress issue: https://progress.opensuse.org/issues/27829