### PR TITLE
Revert "Fix shortcut for online repos list for TW on aarch64"

### DIFF
--- a/tests/installation/disable_online_repos.pm
+++ b/tests/installation/disable_online_repos.pm
@@ -27,7 +27,7 @@ sub run {
     assert_screen 'desktop-selection';
     send_key 'alt-o';    # press configure online repos button
     assert_screen 'online-repos-configuration';
-    send_key((!is_leap() && check_var('ARCH', 'aarch64')) ? 'alt-i' : 'alt-l');    # navigate to the List
+    send_key 'alt-l';    # navigate to the List
 
     # Disable repos
     if (is_leap) {


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#4248

Aarch64 was only slow on picking up the changes, but has now:
https://openqa.opensuse.org/tests/599509#step/disable_online_repos/4