### PR TITLE
yast2_dns_server: fixup usage of systemctl

### DIFF
--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -27,10 +27,10 @@ sub assert_running {
     my $running = shift;
 
     if ($running) {
-        systemctl 'is-active named || true | grep -E "^active"', timeout => 300;
+        assert_script_run '(systemctl is-active named || true) | grep -E "^active"', timeout => 300;
     }
     else {
-        systemctl 'is-active named || true | grep -E "^(inactive|unknown)"';
+        assert_script_run '(systemctl is-active named || true) | grep -E "^(inactive|unknown)"';
     }
 }
 


### PR DESCRIPTION
The systsmctl helper function is not applicable here, as we make use of
a bash construct piped to grep. Without the proper placements of brackets,
the return value is 0, even though grep did find what we expected, which in
turn means we should see retval 0.

In this occurrence, skip using the systemctl helper function and revert back
to using assert_script_run.

This reverts the commit dc07df5 and parts of 21fff909