### PR TITLE
Escape $ in zypper lifecycle command

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -36,7 +36,7 @@ sub run {
     # data from step 2
     my ($base_repos, $package, $prod);
     # Workaround for poo#30613, surround product with >< and use these markers for parsing
-    my $output = script_output "echo '>>>'$(basename `readlink /etc/products.d/baseproduct ` .prod)'<<<'";
+    my $output = script_output "echo '>>>'\$(basename `readlink /etc/products.d/baseproduct ` .prod)'<<<'";
     if ($output =~ />>>(?<prod>.+)<<</) {
         $prod = $+{prod};
     }


### PR DESCRIPTION
In [PR#4327](]https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4327) I've missed escaping $ sign, not sure how did it work in verification run locally, but fails on production.

See [poo#29646](https://progress.opensuse.org/issues/29646).

[Verification run](http://g226.suse.de/tests/647).
