### PR TITLE
Put encrypted password in the multipath profile

### DIFF
--- a/data/autoyast_sle12/autoyast_multipath.xml
+++ b/data/autoyast_sle12/autoyast_multipath.xml
@@ -526,7 +526,7 @@ pre init scripts feature. See poo#20818.
       <home>/root</home>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>$1$DQqmdVuc$eRGSnDOk7fs0aC2Vp2JzD1</user_password>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>

--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -542,7 +542,7 @@ pre init scripts feature. See poo#20818.
       <home>/root</home>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>nots3cr3t</user_password>
+      <user_password>$1$DQqmdVuc$eRGSnDOk7fs0aC2Vp2JzD1</user_password>
     </user>
     <user>
       <encrypted config:type="boolean">false</encrypted>


### PR DESCRIPTION
When added password, I've missed that we have encrypted option set to
true, so increasing coverage by testing this feature as well.

No verification run possible, tested manually.

