### PR TITLE
Assert screen after wireshark closure

### DIFF
--- a/tests/x11/wireshark.pm
+++ b/tests/x11/wireshark.pm
@@ -159,7 +159,7 @@ sub run {
     send_key "alt-f4";
     assert_screen "wireshark-fullscreen";
     send_key "alt-f4";
-
+    assert_screen "generic-desktop-with-terminal";
     # clean-up
     assert_script_run "rm /tmp/wireshark-openQA-test.pcapng";
     type_string "exit\n";


### PR DESCRIPTION
Fix poo#31315: It takes sometime to close Wireshark. Properly detect,
that Wireshark is closed.

- Related ticket: https://progress.opensuse.org/issues/31315
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/685
- Verification run SLE-SP3: http://10.100.12.105/tests/852#step/wireshark/79
- Verification run SLE-SP2: http://10.100.12.105/tests/853#step/wireshark/81