### PR TITLE
Enable chrony shortcut for ntp-client on TW

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -105,7 +105,8 @@ sub init_cmd {
     if (check_var('INSTLANG', "fr_FR")) {
         $testapi::cmd{next} = "alt-s";
     }
-    if ((is_sle && sle_version_at_least '15') || (is_leap && leap_version_at_least '15.0')) {
+
+    if (!(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15.0'))) {
         # SLE15/Leap15 use Chrony instead of ntp
         $testapi::cmd{sync_interval}       = "alt-i";
         $testapi::cmd{sync_without_daemon} = "alt-s";


### PR DESCRIPTION
New ntp-client is now on TW. Hence, required some adjustments, as
currently test module expects old ntp-client.

See [poo#26776](https://progress.opensuse.org/issues/26776).

- Needles: [openSUSE](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/318)
Needles for SLE were created using webUI.
- Verification runs: 
  * [SLE15](http://g226.suse.de/tests/661)
  * [TW](http://g226.suse.de/tests/663)
  * [leap15](http://g226.suse.de/tests/662)
