### PR TITLE
Adapt partitioning_lvm for *activate_existing* tests to storage_ng

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -196,14 +196,17 @@ sub unselect_xen_pv_cdrom {
 sub enable_encryption_guided_setup {
     my $self = shift;
     send_key $cmd{encryptdisk};
-    if (!get_var('ENCRYPT_ACTIVATE_EXISTING')) {
-        assert_screen 'inst-encrypt-password-prompt';
-        type_password;
-        send_key 'tab';
-        type_password;
-        send_key $cmd{next};
-        installation_user_settings::await_password_check;
+    # Bug is only in old storage stack
+    if (get_var('ENCRYPT_ACTIVATE_EXISTING') && !is_storage_ng) {
+        record_info 'bsc#993247 https://fate.suse.com/321208', 'activated encrypted partition will not be recreated as encrypted';
+        return;
     }
+    assert_screen 'inst-encrypt-password-prompt';
+    type_password;
+    send_key 'tab';
+    type_password;
+    send_key $cmd{next};
+    installation_user_settings::await_password_check;
 }
 
 1;


### PR DESCRIPTION
- adapt workflow at guided setup for storage_ng
- verification run: http://e13.suse.de/tests/321#step/partitioning_lvm
- add inst-encrypt-password-prompt in enable_encryption_guided_setup
- see poo#30637 for more details
- needle PR:
 https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/687
