### PR TITLE
Revert changes to systemctl (b35ec85)

### DIFF
--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2017 SUSE LLC
+# Copyright © 2016-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -11,7 +11,7 @@
 # Summary: Test if login manager is usable with many users
 #   This test checks if many users make the login manager hard to use
 #   i.e. if it takes more than one click to access the username text field
-# Maintainer: Dominik Heidler <dheidler@suse.de>
+# Maintainer: Dominik Heidler <dheidler@suse.de>, Rodion Iafarov <riafarov@suse.com>
 # Tags: poo#9694
 
 use base "x11test";
@@ -20,7 +20,7 @@ use testapi;
 use utils;
 
 sub ensure_multi_user_target {
-    systemctl 'isolate multi-user.target';
+    type_string "systemctl isolate multi-user.target\n";
     reset_consoles;
     wait_still_screen 10;
     # isolating multi-user.target logs us out
@@ -28,7 +28,7 @@ sub ensure_multi_user_target {
 }
 
 sub ensure_graphical_target {
-    systemctl 'isolate graphical.target';
+    type_string "systemctl isolate graphical.target\n";
     reset_consoles;
 }
 


### PR DESCRIPTION
As a part of refactoring, we have replaced systemctl calls with wrapper
function. Whereas for multi_users_dm test suite, we won't get return
code.

Doesn't fix the test though, as it break due to https://bugzilla.opensuse.org/show_bug.cgi?id=1063060 

Revert [PR#3263](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/3263).
