### PR TITLE
[WIP] Fix type speed when x11 starts a program

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -160,7 +160,7 @@ sub x11_start_program {
     # too fast typing or looses characters because of the load caused (also
     # see below). See https://progress.opensuse.org/issues/18200
     if (check_var('DESKTOP', 'kde')) {
-        type_string_slow $program;
+        type_string_very_slow $program;
     }
     else {
         type_string $program;


### PR DESCRIPTION
Adjust type speed when x11 starts a program to avoid sporadic issues.

- Related ticket: https://progress.opensuse.org/issues/25972
- Verification run: (not yet)
