### PR TITLE
Add version restriction to fix poo#31381

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -743,11 +743,13 @@ sub load_x11regression_other {
         loadtest "x11regressions/brasero/brasero_launch";
         loadtest "x11/gnomeapps/gnome_documents";
         loadtest "x11regressions/totem/totem_launch";
-        loadtest "x11/xterm";
-        loadtest "x11/sshxterm";
-        loadtest "x11/gnome_control_center";
-        loadtest "x11/gnome_tweak_tool";
-        loadtest "x11/seahorse";
+        if (is_sle && sle_version_at_least('15')) {
+            loadtest "x11/xterm";
+            loadtest "x11/sshxterm";
+            loadtest "x11/gnome_control_center";
+            loadtest "x11/gnome_tweak_tool";
+            loadtest "x11/seahorse";
+        }
     }
     # shotwell was replaced by gnome-photos in SLE15 & yast_virtualization isn't in SLE15
     if (is_sle && sle_version_at_least('12-SP2') && !sle_version_at_least('15')) {


### PR DESCRIPTION
Add version restriction so that the below cases won't affect maintenance. 
The below cases were originally added for SLED15 only.

loadtest "x11/xterm";
loadtest "x11/sshxterm";
loadtest "x11/gnome_control_center";
loadtest "x11/gnome_tweak_tool";
loadtest "x11/seahorse";

- Related ticket: https://progress.opensuse.org/issues/31381
- Verification run: 
   SLED12-SP3: http://10.67.17.21/tests/315
   SLED15: http://10.67.17.21/tests/316