### PR TITLE
Add workaround for writable combobox noformat partition

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -133,6 +133,10 @@ sub addpart {
     if ($args{fsid}) {                            # $args{fsid} will describe needle tag below
         send_key 'alt-i';                         # select File system ID
         send_key 'home';                          # start from the top of the list
+        if ($args{role} eq 'raw' && !check_var('VIDEOMODE', 'text')) {
+            record_soft_failure('bsc#1079399 - Combobox is writable');
+            for (1 .. 10) { send_key 'up'; }
+        }
         send_key_until_needlematch "partition-selected-$args{fsid}-type", 'down';
     }
 
@@ -143,7 +147,7 @@ sub addpart {
         assert_screen 'partition-encrypt';
         send_key $cmd{next};
         assert_screen 'partition-password-prompt';
-        send_key 'alt-e';                         # select password field
+        send_key 'alt-e';    # select password field
         type_password;
         send_key 'tab';
         type_password;


### PR DESCRIPTION
Since the combobox is writable, the home key moves the type cursor to the beginning of the string instead of selecting first option.

- Related tickets:
  - [poo#30670](https://progress.opensuse.org/issues/30670)
  - [bsc#1079399](https://bugzilla.suse.com/show_bug.cgi?id=1079399)
- Verification run:
  - Note: _Since I don't have any ppc64le machine, I verified the workaround forcing aarch64 to install on uefi, so the extra noformat partition BOOT EFI is needed (same combobox)_
  - [copland#825#step/partitioning_warnings/19](http://copland.arch.suse.de/tests/825#step/partitioning_warnings/19)