### PR TITLE
Skip version switching for zdup without patching

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -223,7 +223,7 @@ sub load_zdup_tests {
     loadtest 'installation/zdup';
     loadtest 'installation/post_zdup';
     # Restrict version switch to sle until opensuse adopts it
-    loadtest "migration/version_switch_upgrade_target" if is_sle;
+    loadtest "migration/version_switch_upgrade_target" if is_sle and get_var("UPGRADE_TARGET_VERSION");
     loadtest 'boot/boot_to_desktop';
 }
 


### PR DESCRIPTION
Version switch to upgrade target is not required during zdup
without patching test.


- Related ticket: https://progress.opensuse.org/issues/31387
- Needles: None
- Verification run: http://openqa-apac1.suse.de/tests/224
