### PR TITLE
Deregistering module and not whole system

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -127,7 +127,7 @@ sub remove_suseconnect_product {
     $version //= scc_version();
     $arch    //= get_required_var('ARCH');
     $params  //= '';
-    assert_script_run("SUSEConnect -d $name/$version/$arch $params");
+    assert_script_run("SUSEConnect -d -p $name/$version/$arch $params");
 }
 
 sub register_addons {


### PR DESCRIPTION
SUSEConnect deregisters whole system and not just single extension.

[Verification run](http://g226.suse.de/tests/676)

Fixes https://openqa.suse.de/tests/1450974#step/repo_package_install/6 as de-register whole system in previous test module.
