### PR TITLE
Be more forgiving with aarch64 pkcon install

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -185,7 +185,9 @@ sub x11_start_program {
 sub ensure_installed {
     my ($self, $pkgs, %args) = @_;
     my $pkglist = ref $pkgs eq 'ARRAY' ? join ' ', @$pkgs : $pkgs;
-    $args{timeout} //= 90;
+    # aarch64 is known to be our slowest architecture in many regards,
+    # especially when it is about I/O so be a bit more forgiving here
+    $args{timeout} //= check_var('ARCH', 'aarch64') ? 300 : 90;
 
     testapi::x11_start_program('xterm');
     $self->become_root;


### PR DESCRIPTION
See https://openqa.suse.de/tests/1449400#step/glxgears/12 as an example of
`pkcon install` of Mesa-demo-x timing out sporadically.