### PR TITLE
Add more steps to select all modules in text mode

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -415,7 +415,7 @@ sub select_addons_in_textmode {
     my ($addon, $flag) = @_;
     if ($flag) {
         send_key_until_needlematch 'scc-module-area-selected', 'tab';
-        send_key_until_needlematch "scc-module-$addon",        'down';
+        send_key_until_needlematch "scc-module-$addon", 'down', 30;
         if (check_var('ARCH', 'aarch64') && check_var('HDDVERSION', '12-SP2') && check_screen('scc-module-tcm-selected', 5)) {
             record_info('Workaround',
                 "Toolchain module is selected and installed by default on sles12sp2 aarch64\nSee: https://progress.opensuse.org/issues/19852");


### PR DESCRIPTION
Increased module selection re-try times to 30 in text mode
With more and more addons (some beta ones) are available in scc for sle 12-sp3, 20 steps in send_key_until_needlematch is not enough to select some sle 12-sp3 modules, i.e. tcm, wsm
- See Poo#31168

- Related ticket: https://progress.opensuse.org/issues/31168
- Verification run:  
   * tool chain moduel http://10.67.17.147/tests/2094#step/patch_before_migration/56 (failed by bad network connection)
   * all module case  http://10.67.17.147/tests/2095
