### PR TITLE
Download kubeconfig more reliably

### DIFF
--- a/tests/caasp/stack_bootstrap.pm
+++ b/tests/caasp/stack_bootstrap.pm
@@ -127,11 +127,8 @@ sub kubectl_config {
     assert_screen 'dex-login-page';
     velum_login;
 
-    # Check that kubeconfig downloaded
     assert_screen 'velum-kubeconfig-page';
-
-    # Download takes few seconds
-    sleep 5;
+    assert_and_click 'firefox-downloading-save_enabled';
     assert_and_click 'velum-kubeconfig-back';
 }
 

--- a/tests/caasp/stack_kubernetes.pm
+++ b/tests/caasp/stack_kubernetes.pm
@@ -20,8 +20,7 @@ use testapi;
 sub run {
     # Use downloaded kubeconfig to display basic information
     switch_to 'xterm';
-    type_string "export KUBECONFIG=~/Downloads/kubeconfig\n";
-
+    assert_script_run 'mv ~/Downloads/kubeconfig ~/.kube/config';
     assert_script_run "kubectl cluster-info";
     assert_script_run "kubectl get nodes";
     assert_script_run "! kubectl get cs --no-headers | grep -v Healthy";


### PR DESCRIPTION
Fix for: https://openqa.suse.de/tests/1434578#step/stack_kubernetes/7
Local run: http://dhcp91.suse.cz/tests/1332#step/stack_kubernetes/3

Requires: Updated controller node image (enabled download dialog in firefox)