### PR TITLE
Several SLES4SAP-15 Tests Improvements

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1171,7 +1171,7 @@ sub load_sles4sap_tests {
     loadtest "sles4sap/sapconf";
     loadtest "sles4sap/saptune";
     if (get_var('NW')) {
-        loadtest "sles4sap/nw_ascs_install" if (get_var('SLES4SAP_MODE') !~ /wizard/);
+        loadtest "sles4sap/netweaver_ascs_install" if (get_var('SLES4SAP_MODE') !~ /wizard/);
         loadtest "sles4sap/netweaver_ascs";
     }
 }

--- a/tests/sles4sap/desktop_icons.pm
+++ b/tests/sles4sap/desktop_icons.pm
@@ -12,6 +12,7 @@
 
 use base "sles4sap";
 use testapi;
+use version_utils 'sle_version_at_least';
 use strict;
 
 sub run {
@@ -26,9 +27,10 @@ sub run {
     }
     else {
         # There was no match for the desktop icons needle
-        # Verify that there's at least a generic desktop and soft fail
+        # Verify that there is at least a generic desktop and
+        # fail unless we're in SLE-15 where there are no icons
         assert_screen 'generic-desktop';
-        record_soft_failure 'bsc#1072646';
+        record_soft_failure 'bsc#1072646' unless sle_version_at_least('15');
     }
 }
 

--- a/tests/sles4sap/netweaver_ascs.pm
+++ b/tests/sles4sap/netweaver_ascs.pm
@@ -7,8 +7,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Checks NetWeaver's ASCS installation as performed by sles4sap/nw_ascs_install
-# Requires: sles4sap/nw_ascs_install, ENV variable SAPADM
+# Summary: Checks NetWeaver's ASCS installation as performed by sles4sap/netweaver_ascs_install
+# Requires: sles4sap/netweaver_ascs_install, ENV variable SAPADM
 # Maintainer: Alvaro Carvajal <acarvajal@suse.de>
 
 use base "sles4sap";
@@ -22,7 +22,7 @@ sub run {
 
     select_console 'root-console';
 
-    # The SAP Admin was set in sles4sap/nw_ascs_install
+    # The SAP Admin was set in sles4sap/netweaver_ascs_install
     my $sapadmin = get_required_var('SAPADM');
     my $sid = uc(substr($sapadmin, 0, 3));
 

--- a/tests/sles4sap/netweaver_ascs_install.pm
+++ b/tests/sles4sap/netweaver_ascs_install.pm
@@ -33,6 +33,7 @@ sub run {
       SAPINST_INPUT_PARAMETERS_URL=/sapinst/inifile.params
       SAPINST_EXECUTE_PRODUCT_ID=NW_ABAP_ASCS:NW750.HDB.ABAPHA
       SAPINST_SKIP_DIALOGS=true SAPINST_SLP_MODE=false);
+    my $nettout = 600;    # Time out for NetWeaver's sources related commands
 
     $proto = 'cifs' if ($proto eq 'smb' or $proto eq 'smbfs');
     die "netweaver_ascs_install: currently only supported protocols are nfs and smb/smbfs/cifs"
@@ -60,14 +61,14 @@ sub run {
     assert_script_run "mount -t $proto $path /mnt";
     type_string "cd /mnt\n";
     type_string "cd " . get_var('ARCH') . "\n";    # Change to ARCH specific subdir if exists
-    assert_script_run "tar -cf - . | (cd /sapinst/; tar -pxf - )", 600;
+    assert_script_run "tar -cf - . | (cd /sapinst/; tar -pxf - )", $nettout;
 
     # Check everything was copied correctly
     my $cmd = q|find . -type f -exec md5sum {} \; > /tmp/check-nw-media|;
-    assert_script_run $cmd, 600;
+    assert_script_run $cmd, $nettout;
     type_string "cd /sapinst\n";
     assert_script_run "umount /mnt";
-    assert_script_run "md5sum -c /tmp/check-nw-media", 600;
+    assert_script_run "md5sum -c /tmp/check-nw-media", $nettout;
 
     # Define a valid hostname/IP address in /etc/hosts
     assert_script_run "curl -f -v " . autoinst_url . "/data/sles4sap/add_ip_hostname2hosts.sh > /tmp/add_ip_hostname2hosts.sh";
@@ -97,7 +98,7 @@ sub run {
     $cmd = "../SWPM/sapinst";
     $cmd = $cmd . ' ' . join(' ', @sapoptions);
 
-    assert_script_run $cmd, 600;
+    assert_script_run $cmd, $nettout;
 }
 
 sub post_fail_hook {

--- a/tests/sles4sap/netweaver_ascs_install.pm
+++ b/tests/sles4sap/netweaver_ascs_install.pm
@@ -31,7 +31,7 @@ sub run {
     my @sapoptions = qw(
       SAPINST_USE_HOSTNAME=$(hostname)
       SAPINST_INPUT_PARAMETERS_URL=/sapinst/inifile.params
-      SAPINST_EXECUTE_PRODUCT_ID=NW_ABAP_ASCS:NW740SR2.ADA.PIHA
+      SAPINST_EXECUTE_PRODUCT_ID=NW_ABAP_ASCS:NW750.HDB.ABAPHA
       SAPINST_SKIP_DIALOGS=true SAPINST_SLP_MODE=false);
 
     $proto = 'cifs' if ($proto eq 'smb' or $proto eq 'smbfs');

--- a/tests/sles4sap/netweaver_ascs_install.pm
+++ b/tests/sles4sap/netweaver_ascs_install.pm
@@ -35,7 +35,7 @@ sub run {
       SAPINST_SKIP_DIALOGS=true SAPINST_SLP_MODE=false);
 
     $proto = 'cifs' if ($proto eq 'smb' or $proto eq 'smbfs');
-    die "nw_ascs_install: currently only supported protocols are nfs and smb/smbfs/cifs"
+    die "netweaver_ascs_install: currently only supported protocols are nfs and smb/smbfs/cifs"
       unless ($proto eq 'nfs' or $proto eq 'cifs');
 
     # Normalize path depending on the protocol

--- a/tests/sles4sap/nw_ascs_install.pm
+++ b/tests/sles4sap/nw_ascs_install.pm
@@ -64,10 +64,10 @@ sub run {
 
     # Check everything was copied correctly
     my $cmd = q|find . -type f -exec md5sum {} \; > /tmp/check-nw-media|;
-    assert_script_run $cmd, 300;
+    assert_script_run $cmd, 600;
     type_string "cd /sapinst\n";
     assert_script_run "umount /mnt";
-    assert_script_run "md5sum -c /tmp/check-nw-media", 300;
+    assert_script_run "md5sum -c /tmp/check-nw-media", 600;
 
     # Define a valid hostname/IP address in /etc/hosts
     assert_script_run "curl -f -v " . autoinst_url . "/data/sles4sap/add_ip_hostname2hosts.sh > /tmp/add_ip_hostname2hosts.sh";


### PR DESCRIPTION
This PR contains the following:

- Increase timeout in NetWeaver's source files verification commands from 5 minutes to 10. The copy command remains with a timeout of 10 minutes. This change is submitted with the purpose of avoiding false positives due to timeouts as in: https://openqa.suse.de/tests/1450788#step/nw_ascs_install/24
- Updated product id of NetWeaver in tests/sles4sap/netweaver_ascs_install.
- Rename tests/sles4sap/nw_ascs_install to tests/sles4sap/netweaver_ascs_install for consistency with  tests/sles4sap/netweaver_ascs
- Fix tests/sles4sap/desktop_icons with information regarding FATE#324384 and bsc#1072646 indicating the removal of SLES4SAP icons from the desktop.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/220 & http://mango.suse.de/tests/221
