### PR TITLE
Enable container module when ENABLE_ALL_SCC_MODULES

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -363,7 +363,7 @@ if (is_update_test_repo_test && !get_var('MAINT_TEST_REPO')) {
 if (get_var('ENABLE_ALL_SCC_MODULES') && !get_var('SCC_ADDONS')) {
     if (sle_version_at_least('15')) {
         # Add only modules which are not pre-selected
-        my $addons = 'legacy,sdk,pcm';
+        my $addons = 'legacy,sdk,pcm,contm';
         set_var('SCC_ADDONS', $addons);
         set_var('PATTERNS',   'default,asmm,pcm');
     }


### PR DESCRIPTION
Enable container module when ENABLE_ALL_SCC_MODULES

- Related ticket: https://progress.opensuse.org/issues/26744
- Verification run: [copland#828#step/scc_registration/25](http://copland.arch.suse.de/tests/828#step/scc_registration/25)
