### PR TITLE
Revert "Fix race condition on update installation"

### DIFF
--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -35,7 +35,7 @@ sub run {
 
         # First update package manager, then packages, then bsc#992773 (2x)
         while (1) {
-            assert_and_click_until_screen_change('updates_click-install');
+            assert_and_click('updates_click-install');
 
             # Wait until installation is done
             assert_screen \@updates_installed_tags, 3600;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#4340

@StefanBruens is that something we can revert until it does not crash? 

Fixes https://openqa.opensuse.org/tests/603989#step/updates_packagekit_kde/9
Fixes https://openqa.opensuse.org/tests/604179#step/updates_packagekit_kde/9