### PR TITLE
Fix unlocking of encrypted boot partition in storage-ng setups

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -374,15 +374,11 @@ sub wait_boot {
             send_key "ret";
             assert_screen "grub2", 15;
         }
-        elsif (match_has_tag("migration-source-system-grub2") or match_has_tag('grub2')) {
-            send_key "ret";    # boot to source system
-        }
         elsif (get_var("LIVETEST")) {
             # prevent if one day booting livesystem is not the first entry of the boot list
             if (!match_has_tag("boot-live-" . get_var("DESKTOP"))) {
                 send_key_until_needlematch("boot-live-" . get_var("DESKTOP"), 'down', 10, 5);
             }
-            send_key "ret";
         }
         elsif (match_has_tag('inst-bootmenu')) {
             # assuming the cursor is on 'installation' by default and 'boot from
@@ -390,8 +386,6 @@ sub wait_boot {
             send_key_until_needlematch 'inst-bootmenu-boot-harddisk', 'up';
             boot_local_disk;
             assert_screen 'grub2', 15;
-            # confirm default choice
-            send_key 'ret';
         }
         elsif (match_has_tag('encrypted-disk-password-prompt')) {
             # unlock encrypted disk before grub
@@ -402,6 +396,8 @@ sub wait_boot {
             # check_screen timeout
             die "needle 'grub2' not found";
         }
+        # confirm default choice
+        send_key 'ret';
     }
 
     # On Xen we have to re-connect to serial line as Xen closed it after restart

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -336,6 +336,7 @@ sub wait_boot {
             select_console('iucvconn');
         }
         else {
+            workaround_type_encrypted_passphrase if get_var('S390_ZKVM');
             wait_serial('GNU GRUB') || diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
             select_console('svirt');
             save_svirt_pty;
@@ -410,7 +411,7 @@ sub wait_boot {
         select_console('sut');
     }
 
-    # on s390x svirt is encryption unlocked with workaround_type_encrypted_passphrase before this wait_boot
+    # on s390x svirt encryption is unlocked with workaround_type_encrypted_passphrase before here
     unlock_if_encrypted if !get_var('S390_ZKVM');
 
     if ($textmode || check_var('DESKTOP', 'textmode')) {

--- a/tests/installation/boot_encrypt.pm
+++ b/tests/installation/boot_encrypt.pm
@@ -8,7 +8,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Unlock encrypted partitions during bootup
+# Summary: Unlock encrypted partitions during bootup after the bootloader
+#   passed, e.g. from plymouth
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
 use strict;

--- a/tests/installation/partitioning_full_lvm.pm
+++ b/tests/installation/partitioning_full_lvm.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -38,8 +38,11 @@ sub run {
     }
 
     # ppc with lvm requires separate boot on storage-ng or if want to test with UNENCRYPTED_BOOT set to true
-    if (get_var('UNENCRYPTED_BOOT') || check_var('ARCH', 'ppc64le') && is_storage_ng) {
+    if (get_var('UNENCRYPTED_BOOT')) {
         addpart(role => 'OS', size => 500, format => 'ext2', mount => '/boot');
+    }
+    elsif (check_var('ARCH', 'ppc64le') && is_storage_ng) {
+        addpart(role => 'OS', size => 500, format => 'ext2', mount => '/boot', encrypt => 1);
     }
 
     addpart(role => 'raw', encrypt => 1);

--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -21,8 +21,6 @@ sub run {
     # 'keepconsole => 1' is workaround for bsc#1044072
     power_action('reboot', keepconsole => 1);
 
-    # on s390x svirt encryption unlock has to be done before this wait_boot
-    workaround_type_encrypted_passphrase if get_var('S390_ZKVM');
     $self->wait_boot(bootloader_time => 300);
 }
 


### PR DESCRIPTION
I encountered multiple conflicting locations where the password prompt for
encrypted disks is handled depending on architecture, storage-ng or not, etc.
This commit makes sure that the unlocking only hapens in one location in a
utils function `workaround_type_encrypted_passphrase` which is used in the
calling locations.

Also adding documentation to functions, extracting smaller methods within the
complex grub_test module,

Verification runs:
* SLE15 x86_64 cryptlvm: http://lord.arch/tests/480
* SLE12SP4 x86_64 cryptlvm: http://lord.arch/tests/468
* SLE12SP4 x86_64 lvm-full-encrypt: http://lord.arch/tests/476
* SLE15 x86_64 staging: http://lord.arch/tests/475

Related progress issue: https://progress.opensuse.org/issues/27829