### PR TITLE
Add skopeo test

### DIFF
--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -124,6 +124,7 @@ sub load_feature_tests {
     if (!check_var('SYSTEM_ROLE', 'microos')) {
         loadtest 'console/docker';
         loadtest 'console/docker_runc';
+        loadtest 'console/skopeo' if is_caasp('kubic') && check_var('SYSTEM_ROLE', 'plain');
     }
 }
 

--- a/tests/caasp/transactional_update.pm
+++ b/tests/caasp/transactional_update.pm
@@ -51,25 +51,6 @@ sub check_package {
     }
 }
 
-sub check_reboot_changes {
-    my $change_expected = shift // 1;
-
-    # Compare currently mounted and default subvolume
-    my $time    = time;
-    my $mounted = "mnt-$time";
-    my $default = "def-$time";
-    assert_script_run "mount | grep 'on / ' | egrep -o 'subvolid=[0-9]*' | cut -d'=' -f2 > $mounted";
-    assert_script_run "btrfs su get-default / | cut -d' ' -f2 > $default";
-    my $change_happened = script_run "diff $mounted $default";
-
-    # If changes are expected check that default subvolume changed
-    die "Error during diff" if $change_happened > 1;
-    die "Change expected: $change_expected, happeed: $change_happened" if $change_expected != $change_happened;
-
-    # Reboot into new snapshot
-    process_reboot 1 if $change_happened;
-}
-
 sub run {
     script_run "rebootmgrctl set-strategy off";
 

--- a/tests/console/skopeo.pm
+++ b/tests/console/skopeo.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test skopeo installation and basic usage
+#    Cover the following aspects of skopeo:
+#      * Inspecting a repository before pulling it
+#      * Copy an image from Docker registry into an OCI image-spec
+# Maintainer: Panagiotis Georgiadis <pgeorgiadis@suse.com>
+
+use strict;
+use base "consoletest";
+use testapi;
+use caasp;
+
+sub run {
+    select_console("root-console");
+
+    record_info 'Test #1', 'Test: Installation';
+    my $package = 'skopeo';
+    trup_install($package);
+
+    record_info 'Test #2', 'Test: inspecting a repository';
+    assert_script_run('skopeo inspect docker://docker.io/opensuse');               # without tag
+    assert_script_run('skopeo inspect docker://docker.io/opensuse:tumbleweed');    # with tag
+
+    record_info 'Test #3', 'Test: Copying images';
+    assert_script_run('mkdir folder');
+    assert_script_run('skopeo copy docker://docker.io/opensuse:tumbleweed dir:folder',                        120);
+    assert_script_run('skopeo copy docker://docker.io/opensuse:tumbleweed oci:opensuse_ocilayout:tumbleweed', 120);
+
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
skopeo is a command line utility that performs various operations
on container images and image repositories.

- Related ticket: https://progress.opensuse.org/issues/31516
- Needles: none
- Verification run:
 * SLE 15: http://ultron.suse.de:81/tests/3#step/skopeo/6
 * TW: http://ultron.suse.de:81/tests/4#step/skopeo/6
