### PR TITLE
Add DRBD status check

### DIFF
--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -38,6 +38,8 @@ sub run {
         barrier_create("DRBD_CREATE_CONF_$cluster_name",            $num_nodes);
         barrier_create("DRBD_ACTIVATE_DEVICE_$cluster_name",        $num_nodes);
         barrier_create("DRBD_CREATE_DEVICE_$cluster_name",          $num_nodes);
+        barrier_create("DRBD_CHECK_ONE_DONE_$cluster_name",         $num_nodes);
+        barrier_create("DRBD_CHECK_TWO_DONE_$cluster_name",         $num_nodes);
         barrier_create("DRBD_DOWN_DONE_$cluster_name",              $num_nodes);
         barrier_create("DRBD_MIGRATION_DONE_$cluster_name",         $num_nodes);
         barrier_create("DRBD_REVERT_DONE_$cluster_name",            $num_nodes);


### PR DESCRIPTION
Check for DRBD connection status before and after resource migration.

- Related ticket: https://progress.opensuse.org/issues/31522
- Verification run: http://moon.qa.suse.cz/tests/1602#step/drbd_passive/66 and http://moon.qa.suse.cz/tests/1602#step/drbd_passive/79
