### PR TITLE
Remove timeout from salt installation

### DIFF
--- a/tests/console/salt.pm
+++ b/tests/console/salt.pm
@@ -20,7 +20,7 @@ use utils qw(zypper_call pkcon_quit systemctl);
 sub run {
     select_console 'root-console';
     pkcon_quit;
-    zypper_call("in salt-master salt-minion", timeout => 180);
+    zypper_call('in salt-master salt-minion');
     my $cmd = <<'EOF';
 systemctl start salt-master
 systemctl status salt-master


### PR DESCRIPTION
I've seen at least once that salt installation failed on Hyper-V because
of the timeout. I'd rather use the default `zypper_call` timeout to
eliminate disk & network performance interference.