### PR TITLE
Retry starting firefox if typed wrongly on KDE

### DIFF
--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -19,7 +19,8 @@ use testapi;
 
 sub start_firefox {
     my ($self) = @_;
-    x11_start_program('firefox https://html5test.opensuse.org', valid => 0);
+    # Using match_typed parameter on KDE as typing in desktop runner may fail
+    x11_start_program('firefox https://html5test.opensuse.org', valid => 0, match_typed => ((check_var('DESKTOP', 'kde')) ? "firefox_url_typed" : ''));
     $self->firefox_check_default;
     $self->firefox_check_popups;
     assert_screen 'firefox-html-test';


### PR DESCRIPTION
On KDE we have instability with desktop runner and for some reason
beginning of the line sometimes is not there.
To work this around, we will retry starting application if needle
doesn't match.

- [poo#25972](https://progress.opensuse.org/issues/25972)
- [Needles](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/319)
- [Verification run](http://g226.suse.de/tests/725#)

NOTE: In this [run](http://g226.suse.de/tests/712) I have inverted logic, on the video one can see that we close desktop runner and type starting string again.
