### PR TITLE
Exclude aarch64 from enabling container module

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -363,7 +363,9 @@ if (is_update_test_repo_test && !get_var('MAINT_TEST_REPO')) {
 if (get_var('ENABLE_ALL_SCC_MODULES') && !get_var('SCC_ADDONS')) {
     if (sle_version_at_least('15')) {
         # Add only modules which are not pre-selected
-        my $addons = 'legacy,sdk,pcm,contm';
+        my $addons = 'legacy,sdk,pcm';
+        # Container module is missing for aarch64. Not a bug. fate#323788
+        $addons .= ',contm' unless (check_var('ARCH', 'aarch64'));
         set_var('SCC_ADDONS', $addons);
         set_var('PATTERNS',   'default,asmm,pcm');
     }


### PR DESCRIPTION
- Expected to not have it for aarch64

- Related ticket: [bsc#1079995](https://bugzilla.suse.com/show_bug.cgi?id=1079995)
- Verification run:
  - [x86_64](http://copland.arch.suse.de/tests/829#step/scc_registration/24)
  - [aarch64](http://copland.arch.suse.de/tests/831#step/scc_registration/21)
