### PR TITLE
Workaround license shown twice during upgrade

### DIFF
--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -33,10 +33,11 @@ sub run {
     # hardware detection and waiting for updates from suse.com can take a while
     assert_screen_with_soft_timeout('select-for-update', timeout => 500, soft_timeout => 100, bugref => 'bsc#1028774');
     send_key $cmd{next};
-    assert_screen [qw(remove-repository license-agreement)], 240;
-    if (match_has_tag("license-agreement")) {
+    assert_screen [qw(remove-repository license-agreement license-agreement-accepted)], 240;
+    if (match_has_tag("license-agreement") || match_has_tag("license-agreement-accepted")) {
         record_soft_failure 'bsc#1077703: incorrect license agreement is shown during upgrade';
-        send_key 'alt-a';
+        send_key 'alt-a' unless match_has_tag("license-agreement-accepted");
+        record_soft_failure 'bsc#1080450: license agreement is shown twice' if match_has_tag("license-agreement-accepted");
         send_key $cmd{next};
         assert_screen "remove-repository";
     }


### PR DESCRIPTION
Workaround the issue that license agreement is shown twice when upgrade sles12sp3 to 15 on s390x.
Refer to : https://bugzilla.suse.com/show_bug.cgi?id=1077703#c7

- Related ticket: https://progress.opensuse.org/issues/31564
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/695
- Verification run:
   * Installation on x86_64: http://openqa-apac1.suse.de/tests/243
   * Upgrade on x86_64: http://openqa-apac1.suse.de/tests/239
   * Upgrade on aarch64: http://openqa-apac1.suse.de/tests/241
   * Upgrade on s390x: http://openqa-apac1.suse.de/tests/250
     (Test on zkvm failed due to network timeout, which can be ignored here.)
