### PR TITLE
CaaSP can't use zypper install

### DIFF
--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -122,8 +122,10 @@ sub load_feature_tests {
     loadtest 'caasp/journal_check';
 
     # Container Tests
-    loadtest 'console/docker';
-    loadtest 'console/runc';
+    if (!check_var('SYSTEM_ROLE', 'microos')) {
+        loadtest 'console/docker';
+        loadtest 'console/runc';
+    }
 }
 
 sub load_stack_tests {

--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -32,7 +32,7 @@ use version_utils 'is_caasp';
 sub run {
     select_console("root-console");
 
-    if (is_caasp && check_var('FLAVOR', 'DVD') && !check_var('SYSTEM_ROLE', 'plain')) {
+    if (is_caasp) {
         # Docker should be pre-installed in MicroOS
         die "Docker is not pre-installed." if script_run("zypper se -x --provides -i docker | grep docker");
     }


### PR DESCRIPTION
Fix for: https://openqa.opensuse.org/tests/604987#step/docker/6
Local runs:
 - http://dhcp91.suse.cz/tests/1356 - DVD
 - http://dhcp91.suse.cz/tests/1355 - Kubic - fails on valid bug