### PR TITLE
Raid specific needles

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -496,16 +496,16 @@ sub run {
     }
     # check overview page for Suggested partitioning
     if (get_var("LVM") and !get_var("UEFI")) {
-        assert_screen 'acceptedpartitioningraidlvm';
+        assert_screen 'acceptedpartitioningraid' . get_var("RAIDLEVEL") . 'lvm';
     }
     elsif (get_var("LVM") and get_var("UEFI")) {
-        assert_screen 'acceptedpartitioningraidlvmefi';
+        assert_screen 'acceptedpartitioningraid' . get_var("RAIDLEVEL") . 'lvm-efi';
     }
     elsif (get_var("UEFI") and !get_var("LVM")) {
-        assert_screen 'acceptedpartitioningraidefi';
+        assert_screen 'acceptedpartitioningraid' . get_var("RAIDLEVEL") . 'efi';
     }
     else {
-        assert_screen 'acceptedpartitioning';
+        assert_screen('acceptedpartitioningraid' . get_var("RAIDLEVEL"));
     }
 }
 


### PR DESCRIPTION
Make specific needles for each raid type

- Related ticket: https://progress.opensuse.org/issues/28955
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/694

## Verification run:

| RAID TYPE  | SLE15 | SLE12-SP4 | SLE12-SP3 |
| --------------- | --------- | -------------- | --------------- |
| RAID0  | [copland#834](http://copland.arch.suse.de/tests/834) | [copland#844](http://copland.arch.suse.de/tests/844) | [copland#847](http://copland.arch.suse.de/tests/847) |
| RAID1  | [copland#836](http://copland.arch.suse.de/tests/836) | N/A | [copland#848](http://copland.arch.suse.de/tests/848) |
| RAID10  | [copland#837](http://copland.arch.suse.de/tests/837) | N/A | [copland#849](http://copland.arch.suse.de/tests/849) |
| RAID5  | [copland#839](http://copland.arch.suse.de/tests/839) | N/A | [copland#850](http://copland.arch.suse.de/tests/850) |
| RAID6  | [copland#840](http://copland.arch.suse.de/tests/840) | N/A | [copland#851](http://copland.arch.suse.de/tests/851) |
| LVM+RAID1  | [copland#843](http://copland.arch.suse.de/tests/843) | N/A | [copland#854](http://copland.arch.suse.de/tests/854) |