### PR TITLE
Fix race condition in assert_and_click_until_screen_change

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -447,8 +447,8 @@ sub assert_and_click_until_screen_change {
     my $i = 0;
 
     for (; $i < $repeat; $i++) {
-        wait_screen_change(sub { assert_and_click $mustmatch }, $wait_change);
-        last unless check_screen($mustmatch, 0);
+        my $changed = wait_screen_change(sub { assert_and_click $mustmatch }, $wait_change);
+        last if $changed;
     }
 
     return $i;


### PR DESCRIPTION
Whenever the release causes multiple screen changes (e.g. "change in
button appearance" and "new screen after event", the check_screen may
misdetect a successful click.

A screen change is signaled by the wait_screen_change return code, which
can be used to detect events caused by the click.

See poo#31327

Signed-off-by: Stefan Brüns <stefan.bruens@rwth-aachen.de>

- Related ticket: https://progress.opensuse.org/issues/31327
- Verification run: none
- only checked for syntax with make tidy