### PR TITLE
Update addon_products_sle: Select a sle15 product

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -58,7 +58,7 @@ our %SLE15_MODULES = (
 # manually
 our %SLE15_DEFAULT_MODULES = (
     sles     => 'base,serverapp',
-    sled     => 'base,desktop,productivity',
+    sled     => 'base,desktop',
     sles4sap => 'base,desktop,serverapp,ha,sapapp',
 );
 

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -25,8 +25,20 @@ sub handle_all_packages_medium {
 
     # For SLE installation / upgrade with the all-packages media, user has
     # to select the required extensions / modules manually
-    my @addons = split(/,/, $SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')});
+    my $sle_prod = get_required_var('SLE_PRODUCT');
+    my @addons = split(/,/, $SLE15_DEFAULT_MODULES{$sle_prod});
+
+    # According to installation guide, select a sle product is mandatory
+    # when install with the all-packages media, so add the base product
+    # (sles/sled/etc) as a fake addon
+    push @addons, $sle_prod if !grep(/^$sle_prod$/, @addons);
+
+    # Select Desktop-Applications module if gnome is wanted
     push @addons, 'desktop' if check_var('DESKTOP', 'gnome') && !grep(/^desktop$/, @addons);
+
+    # The SLEWE extension is required to install/upgrade SLED 15
+    # Refer to https://bugzilla.suse.com/show_bug.cgi?id=1078958#c4
+    push @addons, 'we' if check_var('SLE_PRODUCT', 'sled') && !grep(/^we$/, @addons);
 
     # The legacy module is required if upgrade from previous version (bsc#1066338)
     push @addons, 'legacy' if get_var('UPGRADE') && !grep(/^legacy$/, @addons);


### PR DESCRIPTION
According to the sle15 quick installation guide, selecting a
product (i.e. sles or sled) is mandatory during installation
with the all-packages media.
Starting with Beta 6, the Desktop Productivity module has been
dropped from the all-packages media, user has to select the
Workstation Extension during SLED 15 installation, refer to:
https://bugzilla.suse.com/show_bug.cgi?id=1078958#c4
- poo#31303, poo#31276

Refer to the page 23 (Section: 1.2.4 Selecting Extensions and Modules) of https://w3.suse.de/~fs/doku/SLE_15_beta4/sles_installquick.pdf

- Related ticket: https://progress.opensuse.org/issues/31276
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/696
- Verification run: 
   * installation of sles: http://openqa-apac1.suse.de/tests/274
   * installation of sled: http://openqa-apac1.suse.de/tests/278
