### PR TITLE
Save session log from ~/.local/share/sddm/*session.log

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -155,11 +155,11 @@ sub export_logs {
     }
 
     # do not upload empty .xsession-errors
-    script_run
-      "xsefiles=(/home/*/.xsession-errors*); for file in \${xsefiles[@]}; do if [ -s \$file ]; then echo xsefile-valid > /dev/$serialdev; fi; done",
+    script_run "xsefiles=(/home/*/{.xsession-errors*,.local/share/sddm/*session.log}); "
+      . "for file in \${xsefiles[@]}; do if [ -s \$file ]; then echo xsefile-valid > /dev/$serialdev; fi; done",
       0;
     if (wait_serial("xsefile-valid", 10)) {
-        $self->save_and_upload_log('cat /home/*/.xsession-errors*', '/tmp/XSE.log', {screenshot => 1});
+        $self->save_and_upload_log('cat /home/*/{.xsession-errors*,.local/share/sddm/*session.log}', '/tmp/XSE.log', {screenshot => 1});
     }
 
     $self->save_and_upload_log('systemctl list-unit-files', '/tmp/systemctl_unit-files.log');


### PR DESCRIPTION
SDDM redirects the STDOUT/STDERR to {xorg,wayland}-session.log in its
own directory.
GDM uses the user journal, which is already included in the output
from journalctl, other DMs are TBD.

Signed-off-by: Stefan Brüns <stefan.bruens@rwth-aachen.de>

- Verification run: none
- Expression was tested locally to return the log file created by SDDM
