### PR TITLE
Fix workaround of live-CD reboot failure handling

### DIFF
--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -20,24 +20,6 @@ use version_utils 'is_sle';
 use bootloader_setup qw(stop_grub_timeout boot_into_snapshot);
 
 
-=head2 handle_livecd_reboot_failure
-
-Handle a potential failure on a live CD related to boo#993885 that the reboot
-action from a desktop session does not work and we are stuck on the desktop.
-=cut
-sub handle_livecd_reboot_failure {
-    mouse_hide;
-    wait_still_screen;
-    assert_screen([qw(generic-desktop-after_installation grub2)]);
-    if (match_has_tag('generic-desktop-after_installation')) {
-        record_soft_failure 'boo#993885 Kde-Live net installer does not reboot after installation';
-        select_console 'install-shell';
-        type_string "reboot\n";
-        save_screenshot;
-        assert_screen 'grub2', 300;
-    }
-}
-
 =head2 set_vmware_videomode
 
 bsc#997263 - VMware screen resolution defaults to 800x600
@@ -108,7 +90,6 @@ sub bug_workaround_bsc1005313 {
 sub run {
     my ($self) = @_;
 
-    $self->handle_livecd_reboot_failure if get_var('LIVECD');
     $self->handle_installer_medium_bootup;
     workaround_type_encrypted_passphrase;
     # 60 due to rare slowness e.g. multipath poo#11908


### PR DESCRIPTION
Fixes a regression introduced by 18a65b9b in combination with a649d1e6.
Whenever we reset the consoles we have to ensure that the system was really
rebooted so that the next `select_console` call finds a not logged in session
as is expected for non-activated consoles. In the case of the KDE
Live-Installer however the reboot requested by the installer does not work
(boo#993885) but we already reset the consoles causing the test to look for
a 'text-login' needle when we would just encounter a still active
'install-shell'. This commit fixes this by moving the
`handle_livecd_reboot_failure` call within the `power_action` command where
the actual reboot is requested but failing to reboot the system so that after
exiting the `power_action` call we ensured that the system really rebooted as
well as that the consoles are reset.

Verification run: http://lord.arch/tests/505

Related progress issue: https://progress.opensuse.org/issues/31480