### PR TITLE
Add optional filter for version to is_sle

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -16,7 +16,7 @@ use strict;
 
 use testapi;
 use utils;
-use version_utils qw(is_sle leap_version_at_least sle_version_at_least);
+use version_utils qw(is_sle leap_version_at_least);
 
 our @EXPORT = qw(setup_apache2 setup_pgsqldb destroy_pgsqldb test_pgsql test_mysql);
 
@@ -73,7 +73,7 @@ sub setup_apache2 {
     }
     # Create x509 certificate for this apache server
     if ($mode eq "SSL") {
-        my $gensslcert_C_opt = '-C $(hostname)' unless is_sle && sle_version_at_least('15');
+        my $gensslcert_C_opt = '-C $(hostname)' unless is_sle('15+');
         assert_script_run "gensslcert -n \$(hostname) $gensslcert_C_opt -e webmaster@\$(hostname)", 900;
         assert_script_run 'ls /etc/apache2/ssl.crt/$(hostname)-server.crt /etc/apache2/ssl.key/$(hostname)-server.key';
     }

--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -12,7 +12,7 @@ package hacluster;
 use base Exporter;
 use Exporter;
 use strict;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 use warnings;
 use testapi;
 
@@ -186,7 +186,7 @@ sub ha_export_logs {
     my $corosync_conf = '/etc/corosync/corosync.conf';
     my $hb_log        = '/var/log/hb_report';
     my $packages_list = '/tmp/packages.list';
-    my $report_opt    = '-f0' unless (is_sle && sle_version_at_least('15'));
+    my $report_opt    = '-f0' unless is_sle('15+');
     my @y2logs;
 
     # Extract HA logs and upload them

--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -2,7 +2,6 @@ package hpcbase;
 use base "opensusebasetest";
 use strict;
 use testapi;
-use version_utils qw(is_sle sle_version_at_least);
 use utils 'systemctl';
 
 sub exec_and_insert_password {

--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -14,7 +14,7 @@ use strict;
 use testapi;
 use utils;
 use List::Util qw(first);
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 
 our @EXPORT = qw(install_kernel_debuginfo prepare_for_kdump activate_kdump kdump_is_active do_kdump);
 
@@ -30,8 +30,7 @@ sub install_kernel_debuginfo {
 sub get_repo_url_for_kdump_sle {
     return join('/', $utils::OPENQA_FTP_URL, get_var('REPO_SLE15_MODULE_BASESYSTEM_DEBUG'))
       if get_var('REPO_SLE15_MODULE_BASESYSTEM_DEBUG')
-      and is_sle
-      and sle_version_at_least('15');
+      and is_sle('15+');
     return join('/', $utils::OPENQA_FTP_URL, get_var('REPO_SLES_DEBUG')) if get_var('REPO_SLES_DEBUG');
 }
 

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -18,7 +18,7 @@ use testapi qw(check_var get_var get_required_var set_var check_var_array diag);
 use autotest;
 use utils;
 use version_utils qw(
-  is_hyperv_in_gui is_jeos is_gnome_next is_krypton_argon is_leap is_opensuse is_sle is_sles4sap is_sles4sap_standard leap_version_at_least sle_version_at_least is_desktop_installed is_installcheck is_rescuesystem is_staging
+  is_hyperv_in_gui is_jeos is_gnome_next is_krypton_argon is_leap is_opensuse is_sle is_sles4sap is_sles4sap_standard leap_version_at_least sle_version_at_least is_desktop_installed is_installcheck is_rescuesystem is_staging is_tumbleweed
 );
 use bmwqemu ();
 use strict;
@@ -472,7 +472,7 @@ sub load_docker_tests {
     if (!is_sle) {
         loadtest "console/docker_compose";
     }
-    if (is_sle && !sle_version_at_least('15')) {
+    if (is_sle('<15')) {
         loadtest "console/sle2docker";
     }
 }
@@ -660,7 +660,7 @@ sub load_inst_tests {
     if (get_var('DUD_ADDONS')) {
         loadtest "installation/dud_addon";
     }
-    if (is_sle && sle_version_at_least('15')) {
+    if (is_sle '15+') {
         loadtest "installation/accept_license" if get_var('HASLICENSE');
     }
     if (get_var('IBFT')) {
@@ -801,7 +801,7 @@ sub load_inst_tests {
             and !is_hyperv_in_gui
             and !is_bridged_networking
             and !check_var('BACKEND', 's390x')
-            and is_sle && sle_version_at_least('12-SP2'))
+            and is_sle('12-SP2+'))
         {
             loadtest "installation/hostname_inst";
         }
@@ -1323,7 +1323,7 @@ sub load_extra_tests {
             loadtest "console/aplay";
         }
         loadtest "console/command_not_found";
-        if (check_var('DISTRI', 'sle') && sle_version_at_least('12-SP2')) {
+        if (is_sle '12-sp2+') {
             # Check for availability of packages and the corresponding repository, only makes sense for SLE
             loadtest 'console/repo_package_install';
             loadtest 'console/openssl_alpn';
@@ -1393,19 +1393,17 @@ sub load_filesystem_tests {
         loadtest "console/btrfs_autocompletion";
         if (get_var("NUMDISKS", 0) > 1) {
             loadtest "console/btrfs_qgroups";
-            if (check_var('DISTRI', 'opensuse') || (check_var('DISTRI', 'sle') && sle_version_at_least('12-SP2'))) {
+            if (check_var('DISTRI', 'opensuse') || is_sle('12-sp2+')) {
                 loadtest 'console/snapper_cleanup';
             }
-            if (check_var('DISTRI', 'sle') && sle_version_at_least('12-SP2')) {
+            if (is_sle '12-sp2+') {
                 loadtest "console/btrfs_send_receive";
             }
         }
     }
     loadtest 'console/snapper_undochange';
     loadtest 'console/snapper_create';
-    if (   (check_var('DISTRI', 'sle') && sle_version_at_least('12-SP3'))
-        || (check_var('DISTRI', 'opensuse') && (leap_version_at_least('42.3') || check_var('VERSION', 'Tumbleweed'))))
-    {
+    if (is_sle('12-sp3+') || leap_version_at_least('42.3') || is_tumbleweed) {
         loadtest 'console/snapper_thin_lvm';
     }
 }
@@ -1497,7 +1495,7 @@ sub load_x11_gnome {
     loadtest "x11/gnomecase/application_starts_on_login";
     loadtest "x11/gnomecase/change_password";
     loadtest "x11/gnomecase/login_test";
-    if (check_var('DISTRI', 'sle') && sle_version_at_least('12-SP1')) {
+    if (is_sle '12-SP1+') {
         loadtest "x11/gnomecase/gnome_classic_switch";
     }
     loadtest "x11/gnomecase/gnome_default_applications";
@@ -1509,7 +1507,7 @@ sub load_x11_other {
         loadtest "x11/brasero/brasero_launch";
         loadtest "x11/gnomeapps/gnome_documents";
         loadtest "x11/totem/totem_launch";
-        if (is_sle && sle_version_at_least('15')) {
+        if (is_sle '15+') {
             loadtest "x11/xterm";
             loadtest "x11/sshxterm";
             loadtest "x11/gnome_control_center";
@@ -1518,7 +1516,7 @@ sub load_x11_other {
         }
     }
     # shotwell was replaced by gnome-photos in SLE15 & yast_virtualization isn't in SLE15
-    if (is_sle && sle_version_at_least('12-SP2') && !sle_version_at_least('15')) {
+    if (is_sle('>=12-sp2') && is_sle('<15')) {
         loadtest "x11/shotwell/shotwell_import";
         loadtest "x11/shotwell/shotwell_edit";
         loadtest "x11/shotwell/shotwell_export";
@@ -1573,7 +1571,7 @@ sub load_security_tests_core {
     }
     loadtest "fips/openssl/openssl_pubkey_rsa";
     loadtest "fips/openssl/openssl_pubkey_dsa";
-    if (sle_version_at_least('12-SP2') || check_var('VERSION', 'Tumbleweed')) {
+    if (is_sle('12-SP2+') || is_tumbleweed) {
         loadtest "console/openssl_alpn";
     }
     loadtest "console/sshd";
@@ -1634,7 +1632,7 @@ sub load_systemd_patches_tests {
 sub load_create_hdd_tests {
     return unless get_var('INSTALLONLY');
     # temporary adding test modules which applies hacks for missing parts in sle15
-    loadtest 'console/sle15_workarounds' if is_sle && sle_version_at_least('15');
+    loadtest 'console/sle15_workarounds' if is_sle('15+');
     loadtest 'console/hostname'       unless is_bridged_networking;
     loadtest 'console/force_cron_run' unless is_jeos;
     loadtest 'console/scc_deregistration' if get_var('SCC_DEREGISTER');

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -5,7 +5,7 @@ use bootloader_setup qw(boot_local_disk tianocore_enter_menu zkvm_add_disk zkvm_
 use testapi;
 use strict;
 use utils;
-use version_utils qw(is_sle is_leap sle_version_at_least leap_version_at_least is_upgrade);
+use version_utils qw(is_sle is_leap leap_version_at_least is_upgrade);
 
 
 # Base class for all openSUSE tests
@@ -495,7 +495,7 @@ under test, the version and if the SUT is an upgrade.
 
 =cut
 sub firewall {
-    my $old_product_versions = (is_sle && !sle_version_at_least('15')) || (is_leap && !leap_version_at_least('15.0'));
+    my $old_product_versions = is_sle('<15') || (is_leap && !leap_version_at_least('15.0'));
     my $upgrade_from_susefirewall = is_upgrade && get_var('HDD_1') =~ /\b(1[123]|42)[\.-]/;
     return ($old_product_versions || $upgrade_from_susefirewall) ? 'SuSEfirewall2' : 'firewalld';
 }

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -195,7 +195,7 @@ sub fill_in_registration_data {
         }
         # The "Extension and Module Selection" won't be shown during upgrade to sle15, refer to:
         # https://bugzilla.suse.com/show_bug.cgi?id=1070031#c11
-        push @tags, 'inst-addon' if is_sle && sle_version_at_least('15') && is_sle12_hdd_in_upgrade;
+        push @tags, 'inst-addon' if is_sle('15+') && is_sle12_hdd_in_upgrade;
         while ($counter--) {
             assert_screen(\@tags);
             if (match_has_tag("import-untrusted-gpg-key")) {
@@ -257,7 +257,7 @@ sub fill_in_registration_data {
     }
 
     # Process modules on sle 15
-    if (is_sle && sle_version_at_least('15')) {
+    if (is_sle '15+') {
         my $modules_needle = "modules-preselected-" . get_required_var('SLE_PRODUCT');
         if (check_var('BETA', '1')) {
             assert_screen('scc-beta-filter-checkbox');

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -3,7 +3,7 @@ use base 'distribution';
 use serial_terminal ();
 use strict;
 use utils qw(type_string_slow ensure_unlocked_desktop save_svirt_pty get_root_console_tty get_x11_console_tty ensure_serialdev_permissions);
-use version_utils qw(is_hyperv_in_gui is_sle sle_version_at_least is_leap leap_version_at_least);
+use version_utils qw(is_hyperv_in_gui is_sle is_leap leap_version_at_least);
 
 # Base class implementation of distribution class necessary for testapi
 
@@ -106,7 +106,7 @@ sub init_cmd {
         $testapi::cmd{next} = "alt-s";
     }
 
-    if (!(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15.0'))) {
+    if (!is_sle('<15') && !(is_leap && !leap_version_at_least('15.0'))) {
         # SLE15/Leap15 use Chrony instead of ntp
         $testapi::cmd{sync_interval}       = "alt-i";
         $testapi::cmd{sync_without_daemon} = "alt-s";

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -668,7 +668,7 @@ sub power_action {
     }
     # Shutdown takes longer than 60 seconds on SLE 15
     my $shutdown_timeout = 60;
-    if (sle_version_at_least('15') && check_var('DISTRI', 'sle') && check_var('DESKTOP', 'gnome')) {
+    if (is_sle('15+') && check_var('DESKTOP', 'gnome')) {
         record_soft_failure('bsc#1055462');
         $shutdown_timeout *= 3;
     }
@@ -804,7 +804,7 @@ sub handle_login {
     }
     elsif (check_var('DESKTOP', 'gnome')) {
         # DMs in condition above have to select user
-        if ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0')) || is_tumbleweed) {
+        if (is_sle('15+') || (is_leap && leap_version_at_least('15.0')) || is_tumbleweed) {
             assert_and_click "displaymanager-$username";
             record_soft_failure 'bgo#657996 - user account not selected by default, have to use mouse to login';
         }
@@ -953,7 +953,7 @@ is running on tty2 by default. see also: bsc#1054782
 =cut
 sub get_x11_console_tty {
     my $new_gdm
-      = !(is_sle   && !sle_version_at_least('15'))
+      = !is_sle('<15')
       && !(is_leap && !leap_version_at_least('15.0'))
       && !is_sle12_hdd_in_upgrade
       && !is_caasp

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -173,7 +173,7 @@ sub cleanup_libreoffice_recent_file {
 }
 
 sub open_libreoffice_options {
-    if (is_tumbleweed or (is_sle && sle_version_at_least('15'))) {
+    if (is_tumbleweed or is_sle('15+')) {
         send_key 'alt-f12';
     }
     else {

--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -17,7 +17,7 @@ use strict;
 use Exporter 'import';
 use testapi;
 use utils 'systemctl';
-use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least);
+use version_utils qw(is_sle is_leap leap_version_at_least);
 
 our @EXPORT_OK = qw(
   initialize_y2lan
@@ -33,9 +33,7 @@ sub initialize_y2lan {
     become_root;
     # make sure that firewalld is stopped, or we have later pops for firewall activation warning
     # or timeout for command 'ip a' later
-    if (((is_sle && sle_version_at_least('15')) or (is_leap && leap_version_at_least('15.0')))
-        and assert_script_run("systemctl show -p ActiveState firewalld.service | grep ActiveState=active"))
-    {
+    if ((is_sle('15+') or leap_version_at_least('15.0')) and assert_script_run("systemctl show -p ActiveState firewalld.service | grep ActiveState=active")) {
         systemctl 'stop firewalld';
         assert_script_run("systemctl show -p ActiveState firewalld.service | grep ActiveState=inactive");
     }
@@ -83,7 +81,7 @@ sub check_network_status {
     if ($expected_status eq 'restart') {
         assert_script_run '[ -s journal.log ]';                       # journal.log size is greater than zero (network restarted)
     }
-    elsif ((is_sle && !sle_version_at_least('15')) || (is_leap && !leap_version_at_least('15.0'))) {
+    elsif (is_sle('<15') || (is_leap && !leap_version_at_least('15.0'))) {
         assert_script_run '[ ! -s journal.log ]';
     }
     assert_script_run '> journal.log';                                # clear journal.log

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -509,7 +509,7 @@ sub load_ha_cluster_tests {
     }
 
     # SLE15 workarounds
-    loadtest "ha/sle15_workarounds" if (is_sle && sle_version_at_least('15'));
+    loadtest "ha/sle15_workarounds" if is_sle('15+');
 
     # Basic configuration
     loadtest "ha/firewall_disable";

--- a/tests/autoyast/verify_autoinst_btrfs.pm
+++ b/tests/autoyast/verify_autoinst_btrfs.pm
@@ -20,7 +20,7 @@
 use strict;
 use base 'basetest';
 use testapi;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 use XML::LibXML;
 
 #Xpath parser
@@ -44,7 +44,7 @@ sub run {
     $errors .= "enable_snapshots option check failed: $result_str\n" if ($result_str);
 
     ### Verify mount options btrfs_set_default_subvolume_name, this is valid only for SLE12, with storage-ng subvolumes_prefix is used
-    if (is_sle && sle_version_at_least '15') {
+    if (is_sle '15+') {
         $result_str = verify_option('//ns:subvolumes_prefix', '');
         record_soft_failure "bsc#1076337: subvolumes_prefix option check failed: $result_str" if ($result_str);
     }

--- a/tests/console/command_not_found.pm
+++ b/tests/console/command_not_found.pm
@@ -15,7 +15,7 @@ use base "consoletest";
 use testapi;
 use strict;
 use utils;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 use registration qw(add_suseconnect_product remove_suseconnect_product);
 
 # test for regression of bug http://bugzilla.suse.com/show_bug.cgi?id=952496
@@ -30,7 +30,7 @@ sub run {
         select_console 'user-console';
     }
 
-    my $not_installed_pkg = (is_sle && sle_version_at_least '15') ? 'wireshark' : 'xosview';
+    my $not_installed_pkg = is_sle('15+') ? 'wireshark' : 'xosview';
     my $cnf_cmd = qq{echo "\$(cnf $not_installed_pkg 2>&1 | tee /dev/stderr)" | grep -q "zypper install $not_installed_pkg"};
 
     save_screenshot;
@@ -38,7 +38,7 @@ sub run {
     return unless script_run($cnf_cmd);
 
     # Soft-fail if command execution fails on sle 15
-    if (is_sle && sle_version_at_least '15') {
+    if (is_sle '15+') {
         record_soft_failure 'https://fate.suse.com/323424';
         select_console 'root-console';
         add_suseconnect_product('sle-module-desktop-applications');

--- a/tests/console/kdump_and_crash.pm
+++ b/tests/console/kdump_and_crash.pm
@@ -15,7 +15,7 @@ use strict;
 use testapi;
 use utils;
 use kdump_utils;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 use registration;
 
 sub run {
@@ -23,7 +23,7 @@ sub run {
     select_console('root-console');
 
     # preparation for crash test
-    if (is_sle && sle_version_at_least('15')) {
+    if (is_sle '15+') {
         add_suseconnect_product('sle-module-desktop-applications');
         add_suseconnect_product('sle-module-development-tools');
     }

--- a/tests/console/mysql_odbc.pm
+++ b/tests/console/mysql_odbc.pm
@@ -20,7 +20,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least);
+use version_utils qw(is_sle is_leap leap_version_at_least);
 
 sub setup {
     # write odbc.ini
@@ -40,7 +40,7 @@ sub setup {
     assert_script_run "echo [mariadbodbc_mysql] > /etc/unixODBC/odbcinst.ini";
     assert_script_run "echo Description=ODBC for MySQL >> /etc/unixODBC/odbcinst.ini";
 
-    my $lib = (!(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15.0'))) ? 'libmaodbc' : 'libmyodbc5';
+    my $lib = (!is_sle('<15') && !(is_leap && !leap_version_at_least('15.0'))) ? 'libmaodbc' : 'libmyodbc5';
     assert_script_run 'echo Driver=$(rpm --eval "%_libdir")/' . $lib . '.so >> /etc/unixODBC/odbcinst.ini';
 
     assert_script_run 'echo Setup=$(rpm --eval "%_libdir")/libodbcmyS.so >> /etc/unixODBC/odbcinst.ini';
@@ -62,7 +62,7 @@ sub run {
     select_console 'root-console';
 
     # install requirements
-    my $odbc = (!(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15.0'))) ? 'mariadb-connector-odbc' : 'MyODBC-unixODBC';
+    my $odbc = (!is_sle('<15') && !(is_leap && !leap_version_at_least('15.0'))) ? 'mariadb-connector-odbc' : 'MyODBC-unixODBC';
     zypper_call 'in mysql mariadb-client sudo ' . $odbc;
 
     # restart mysql server

--- a/tests/console/pcre.pm
+++ b/tests/console/pcre.pm
@@ -14,7 +14,7 @@ use strict;
 use base "consoletest";
 use testapi;
 use utils;
-use version_utils qw(is_leap is_sle sle_version_at_least leap_version_at_least);
+use version_utils qw(is_leap is_sle leap_version_at_least);
 
 sub run {
     select_console 'root-console';
@@ -25,7 +25,7 @@ sub run {
     assert_script_run "./test_pcrecpp";
     save_screenshot;
 
-    my $php = ((is_leap && !leap_version_at_least('15.0')) || (is_sle && !sle_version_at_least('15'))) ? 'php5' : 'php7';
+    my $php = ((is_leap && !leap_version_at_least('15.0')) || is_sle('<15')) ? 'php5' : 'php7';
     zypper_call("in $php");
     assert_script_run "php simple.php | grep 'matches'";
     save_screenshot;

--- a/tests/console/sle15_workarounds.pm
+++ b/tests/console/sle15_workarounds.pm
@@ -19,12 +19,12 @@ use base qw(consoletest distribution);
 use strict;
 use testapi;
 use utils qw(zypper_call pkcon_quit);
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 
 sub run {
     my $self = shift;
-    return unless sle_version_at_least('15');
+    return unless is_sle('15+');
     # try to detect bsc#1054782 only on the backend which can handle
     # 'ctrl-alt-f2' directly
     if (check_var('BACKEND', 'qemu')) {

--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -23,7 +23,7 @@ use base 'y2logsstep';
 
 use testapi;
 use utils 'zypper_call';
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 use registration;
 
 sub run {
@@ -40,7 +40,7 @@ sub run {
     assert_script_run 'SUSEConnect --list-extensions';
 
     # add modules
-    if (is_sle && sle_version_at_least('15')) {
+    if (is_sle '15+') {
         foreach (split(',', $registration::SLE15_DEFAULT_MODULES{get_required_var('SLE_PRODUCT')} . $scc_addons)) {
             add_suseconnect_product("sle-module-" . lc($registration::SLE15_MODULES{$_}));
         }

--- a/tests/console/yast2_ntpclient.pm
+++ b/tests/console/yast2_ntpclient.pm
@@ -14,7 +14,7 @@ use strict;
 use base "console_yasttest";
 use testapi;
 use utils qw(type_string_slow zypper_call systemctl);
-use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least);
+use version_utils qw(is_sle is_leap leap_version_at_least);
 
 sub run {
     select_console 'root-console';
@@ -25,7 +25,7 @@ sub run {
     # ntp configuration is different in SLE15/Leap15
     # for now, Tumbleweed doesn't use Chrony
     # use sle_or_leap_15 variable to avoid executing is_* and *_version_at_least multiple time
-    my $is_chronyd = (!(is_sle && !sle_version_at_least('15')) && !(is_leap && !leap_version_at_least('15.0'))) ? 1 : 0;
+    my $is_chronyd = (!is_sle('<15') && !(is_leap && !leap_version_at_least('15.0'))) ? 1 : 0;
     $ntp_service = 'chronyd' if ($is_chronyd);
 
     # if support-server is used

--- a/tests/console/yast2_proxy.pm
+++ b/tests/console/yast2_proxy.pm
@@ -14,7 +14,7 @@ use strict;
 use base "console_yasttest";
 use testapi;
 use utils;
-use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least);
+use version_utils qw(is_sle is_leap leap_version_at_least);
 
 
 my %sub_menu_needles = (
@@ -61,7 +61,7 @@ sub post_fail_hook {
 
 sub run {
     select_console 'root-console';
-    if (is_sle && sle_version_at_least('15')) {
+    if (is_sle '15+') {
         zypper_call('in squid');
     }
 
@@ -101,7 +101,7 @@ sub run {
 
     # check network interfaces with open port in firewall
     # repeat action as sometimes keys are not triggering action on leap if workers are slow
-    if ((is_sle && !sle_version_at_least('15')) || (is_leap && !leap_version_at_least('15.0'))) {
+    if (is_sle('<15') || (is_leap && !leap_version_at_least('15.0'))) {
         send_key_until_needlematch 'yast2_proxy_network_interfaces', 'alt-d', 2, 5;
         wait_still_screen 1;
         send_key 'alt-n';

--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -14,7 +14,7 @@ use strict;
 use base "console_yasttest";
 use testapi;
 use utils;
-use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least);
+use version_utils qw(is_sle is_leap leap_version_at_least);
 
 sub setup_ldap {
     select_console 'root-console';
@@ -25,7 +25,7 @@ sub setup_ldap {
     assert_script_run("if ! systemctl -q is-active network; then systemctl -q start network; fi");
     # install local ldap server
 
-    if (is_sle && sle_version_at_least('15')) {
+    if (is_sle '15+') {
         my $ret = zypper_call('in yast2-auth-server openldap2-client tdb-tools', exitcode => [0, 104], timeout => 240);
         return record_soft_failure 'bsc#1060870' if $ret == 104;
     }
@@ -40,7 +40,7 @@ sub setup_ldap {
         send_key 'alt-c';
     }
     # only older version like SLES 12, Leap 42.3 as well as TW should still check the needle
-    if ((is_sle && !sle_version_at_least('15')) || (is_leap && !leap_version_at_least('15.0'))) {
+    if (is_sle('<15') || (is_leap && !leap_version_at_least('15.0'))) {
         assert_screen 'yast2_ldap_configuration_general-setting_firewall', 60;
     }
     send_key 'alt-e';
@@ -247,7 +247,7 @@ sub run {
     zypper_call("in samba yast2-samba-server");
     script_run("yast2 samba-server; echo yast2-samba-server-status-\$? > /dev/$serialdev", 0);
     # check Samba-Server Configuration got started
-    if ((is_sle && !sle_version_at_least('15')) || (is_leap && !leap_version_at_least('15.0'))) {
+    if (is_sle('<15') || (is_leap && !leap_version_at_least('15.0'))) {
         gui_current;
     }
     else {

--- a/tests/console/yast2_vnc.pm
+++ b/tests/console/yast2_vnc.pm
@@ -14,7 +14,7 @@ use strict;
 use base "console_yasttest";
 use testapi;
 use utils;
-use version_utils qw(is_leap is_sle sle_version_at_least leap_version_at_least);
+use version_utils qw(is_leap is_sle leap_version_at_least);
 
 
 sub run {
@@ -26,7 +26,7 @@ sub run {
     # install components to test plus dependencies for checking
     my $packages = 'vncmanager xorg-x11';
     # netstat is deprecated in newer versions, use 'ss' instead
-    my $use_nettools = (is_sle && !sle_version_at_least('15')) || (is_leap && !leap_version_at_least('15.0'));
+    my $use_nettools = is_sle('<15') || (is_leap && !leap_version_at_least('15.0'));
     $packages .= ' net-tools' if $use_nettools;
     zypper_call("in $packages");
 

--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -15,7 +15,7 @@ use base "consoletest";
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_sle is_jeos sle_version_at_least);
+use version_utils qw(is_sle is_jeos);
 
 our $date_re = qr/[0-9]{4}-[0-9]{2}-[0-9]{2}/;
 
@@ -117,7 +117,7 @@ sub run {
     # verify that package eol defaults to product eol
     $output = script_output "zypper lifecycle $package", 300;
     unless ($output =~ /$package(-\S+)?\s+$product_eol/) {
-        return record_soft_failure 'bsc#1057788' if (is_sle && sle_version_at_least('15'));
+        return record_soft_failure 'bsc#1057788' if is_sle('15+');
         die "$package lifecycle entry incorrect:'$output', expected: '/$package-\\S+\\s+$product_eol'";
     }
 

--- a/tests/ha/cluster_md.pm
+++ b/tests/ha/cluster_md.pm
@@ -12,7 +12,7 @@
 
 use base 'opensusebasetest';
 use strict;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 use testapi;
 use lockapi;
 use hacluster;
@@ -26,7 +26,7 @@ sub run {
     my $clustermd_device   = '/dev/md0';
     my $clustermd_name_opt = undef;
 
-    if (is_sle && sle_version_at_least('15')) {
+    if (is_sle '15+') {
         $clustermd_device   = "/dev/md/$clustermd_rsc";
         $clustermd_name_opt = "--name=$clustermd_rsc";
     }

--- a/tests/ha/clvmd_lvmlockd.pm
+++ b/tests/ha/clvmd_lvmlockd.pm
@@ -12,7 +12,7 @@
 
 use base 'opensusebasetest';
 use strict;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 use utils qw(zypper_call systemctl);
 use testapi;
 use lockapi;
@@ -24,7 +24,7 @@ sub run {
 
     # lvmlockd is only available in SLE15+
     if (get_var("USE_LVMLOCKD")) {
-        die 'lvmlockd can be only used on SLE15+' unless (is_sle && sle_version_at_least('15'));
+        die 'lvmlockd can be only used on SLE15+' unless is_sle('15+');
         $lock_mgr = 'lvmlockd';
     }
 
@@ -43,7 +43,7 @@ sub run {
     }
     else {
         # In SLE15, lvmlockd is installed by default, not clvmd/cmirrord
-        zypper_call 'in lvm2-clvm lvm2-cmirrord' if (is_sle && sle_version_at_least('15'));
+        zypper_call 'in lvm2-clvm lvm2-cmirrord' if is_sle('15+');
     }
 
     # Configure LVM for HA cluster

--- a/tests/ha/drbd_passive.pm
+++ b/tests/ha/drbd_passive.pm
@@ -16,7 +16,7 @@
 
 use base 'opensusebasetest';
 use strict;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 use testapi;
 use lockapi;
 use hacluster;
@@ -162,7 +162,7 @@ sub run {
     # Wait for DRBD to be checked
     barrier_wait("DRBD_RESOURCE_CREATED_$cluster_name");
 
-    if (is_sle && sle_version_at_least('12-SP3')) {
+    if (is_sle '12-SP3+') {
         # Need to stop/start the DRBD resource to be able to migrate it after
         # Is it the wanted behavior? Was not in SLE12-SP2, need to check with
         # developers for the new versions

--- a/tests/ha/sle15_workarounds.pm
+++ b/tests/ha/sle15_workarounds.pm
@@ -13,13 +13,13 @@
 
 use base 'opensusebasetest';
 use strict;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 use testapi;
 use hacluster;
 
 # Do some stuff that need to be workaround in SLE15
 sub run {
-    return unless (is_sle && sle_version_at_least('15'));
+    return unless is_sle('15+');
 
     # Modify the device number if needed
     if ((get_var('ISO', '') eq '') && (get_var('ISO_1', '') ne '')) {

--- a/tests/ha/vg.pm
+++ b/tests/ha/vg.pm
@@ -12,7 +12,7 @@
 
 use base 'opensusebasetest';
 use strict;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 use testapi;
 use lockapi;
 use hacluster;
@@ -32,7 +32,7 @@ sub run {
         $vg_luns  = '/dev/md*';
 
         # Use a named RAID in SLE15
-        $vg_luns = "/dev/md/$resource" if (is_sle && sle_version_at_least('15'));
+        $vg_luns = "/dev/md/$resource" if is_sle('15+');
     }
     elsif (read_tag eq 'drbd_passive') {
         $resource     = 'drbd_passive';

--- a/tests/installation/accept_license.pm
+++ b/tests/installation/accept_license.pm
@@ -20,7 +20,7 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
@@ -32,7 +32,7 @@ sub run {
     #   so the license agreement is shown at welcome screen
     # - other architectures contain more products, the license agreement won't
     #   be shown until user chooses which product to upgrade
-    push @tags, 'inst-welcome-no-product-list' if is_sle && sle_version_at_least(15) && get_var('UPGRADE');
+    push @tags, 'inst-welcome-no-product-list' if is_sle('15+') && get_var('UPGRADE');
 
     assert_screen \@tags;
     if (match_has_tag('network-settings-button')) {

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -16,7 +16,7 @@ use warnings;
 use base "y2logsstep";
 use testapi;
 use utils;
-use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least);
+use version_utils qw(is_sle is_leap leap_version_at_least);
 
 sub run {
     my ($self) = shift;
@@ -31,8 +31,9 @@ sub run {
     }
 
     # Workaround for bsc#1070233: not update "Booting" option in upgrade mode
-    return record_soft_failure('bsc#1070233: Error if click on Booting option')
-      if (get_var('UPGRADE') && (!(is_sle && !sle_version_at_least('15')) || !(is_leap && !leap_version_at_least('15.0'))));
+    if (get_var('UPGRADE') && (!is_sle('<15') || !(is_leap && !leap_version_at_least('15.0')))) {
+        return record_soft_failure('bsc#1070233: Error if click on Booting option');
+    }
 
     # Verify Installation Settings overview is displayed as starting point
     assert_screen "installation-settings-overview-loaded";
@@ -60,7 +61,7 @@ sub run {
     wait_still_screen(1);
     my $timeout = "-1";
     # SLE-12 GA only accepts positive integers in range [0,300]
-    $timeout = "60" if is_sle && !sle_version_at_least('12-SP1');
+    $timeout = "60" if is_sle('<12-SP1');
     type_string $timeout;
 
     # ncurses uses blocking modal dialog, so press return is needed

--- a/tests/installation/keyboard_selection.pm
+++ b/tests/installation/keyboard_selection.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 
 sub switch_keyboard_layout {
     return unless get_var('INSTALL_KEYBOARD_LAYOUT');
@@ -41,7 +41,7 @@ sub switch_keyboard_layout {
 sub run {
     switch_keyboard_layout;
 
-    send_key $cmd{next} unless (is_sle && sle_version_at_least('15') && get_var('UPGRADE'));
+    send_key $cmd{next} unless (is_sle('15+') && get_var('UPGRADE'));
     if (!check_var('INSTLANG', 'en_US') && check_screen 'langincomplete', 1) {
         send_key 'alt-f';
     }

--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use base 'y2logsstep';
 use testapi;
-use version_utils qw(is_storage_ng sle_version_at_least is_sle);
+use version_utils qw(is_storage_ng is_sle);
 
 # add a new primary partition
 #   $type == 3 => 0xFD Linux RAID

--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -14,7 +14,6 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use version_utils qw(sle_version_at_least is_sle);
 
 
 my %role_hotkey = (

--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -15,7 +15,7 @@ use strict;
 use base "y2logsstep";
 use testapi;
 use utils 'assert_screen_with_soft_timeout';
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 
 sub run {
     if (get_var('ENCRYPT')) {
@@ -42,7 +42,7 @@ sub run {
     }
     send_key $cmd{next};
     # Select migration target in sle15 upgrade
-    if (is_sle && sle_version_at_least('15')) {
+    if (is_sle '15+') {
         if (get_var('MEDIA_UPGRADE')) {
             assert_screen 'upgrade-unregistered-system';
             send_key $cmd{ok};

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -84,7 +84,7 @@ sub run {
         assert_screen 'inst-betawarning';
         wait_screen_change { send_key 'ret' };
     }
-    assert_screen((is_sle && sle_version_at_least('15') && get_var('UPGRADE')) ? 'inst-welcome-no-product-list' : 'inst-welcome');
+    assert_screen((is_sle('15+') && get_var('UPGRADE')) ? 'inst-welcome-no-product-list' : 'inst-welcome');
     mouse_hide;
     wait_still_screen(3);
 

--- a/tests/toolchain/gcc_fortran_compilation.pm
+++ b/tests/toolchain/gcc_fortran_compilation.pm
@@ -15,7 +15,7 @@ use base "opensusebasetest";
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least);
+use version_utils qw(is_sle is_leap leap_version_at_least);
 
 sub run {
     my $self = shift;
@@ -30,7 +30,7 @@ sub run {
     script_run 'cp FM923.DAT fcvs21_f95/';
     script_run 'pushd fcvs21_f95';
     my $fortran_version = "gfortran";
-    if ((is_sle && !sle_version_at_least('15')) or (is_leap and !leap_version_at_least('15.0'))) {
+    if (is_sle('<15') or (is_leap and !leap_version_at_least('15.0'))) {
         $fortran_version = "gfortran-5";    # gfortran (and gcc) fixed to version in SLE12 after the yearly gcc update with Toolchain module
     }
     script_run "sed -i 's/g77/$fortran_version/g' driver_*";

--- a/tests/toolchain/install.pm
+++ b/tests/toolchain/install.pm
@@ -15,7 +15,7 @@ use base "opensusebasetest";
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 use registration;
 
 sub run {
@@ -27,7 +27,7 @@ sub run {
     systemctl 'mask packagekit';
     systemctl 'stop packagekit';
 
-    if (is_sle && !sle_version_at_least('15')) {
+    if (is_sle '<15') {
         # toolchain channels
         if (!check_var('ADDONS', 'tcm')) {
             my $arch = get_var('ARCH');

--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -14,7 +14,7 @@ use base "x11test";
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 
 sub turn_off_screensaver {
     # Turn off screensaver
@@ -43,7 +43,7 @@ sub tell_packagekit_to_quit {
 # Update with GNOME PackageKit Update Viewer
 sub run {
     my ($self) = @_;
-    if (is_sle && sle_version_at_least('15')) {
+    if (is_sle '15+') {
         select_console 'root-console';
         zypper_call("in gnome-packagekit", timeout => 90);
         record_soft_failure 'bsc#1081584';

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -14,7 +14,6 @@ use base 'wickedbase';
 use strict;
 use testapi;
 use utils 'systemctl';
-use version_utils qw(is_sle sle_version_at_least);
 
 sub run {
     my ($self) = @_;

--- a/tests/x11/gnomecase/nautilus_permission.pm
+++ b/tests/x11/gnomecase/nautilus_permission.pm
@@ -14,14 +14,14 @@
 use base "x11test";
 use strict;
 use testapi;
-use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least is_tumbleweed);
+use version_utils qw(is_sle is_leap leap_version_at_least is_tumbleweed);
 
 
 sub run {
     x11_start_program('touch newfile', valid => 0);
     x11_start_program('nautilus');
     send_key_until_needlematch 'nautilus-newfile-matched', 'right', 15;
-    if ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0')) || is_tumbleweed) {
+    if (is_sle('15+') || leap_version_at_least('15.0') || is_tumbleweed) {
         assert_and_click 'nautilus-newfile-matched', 'right';
         record_soft_failure 'boo#1074057 qemu can not properly capture some keys in nautilus under GNOME wayland';
     }
@@ -45,7 +45,7 @@ sub run {
     send_key "ret";
     send_key "esc";      #close the dialog
                          #reopen the properties menu to check if the changes kept
-    if ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0')) || is_tumbleweed) {
+    if (is_sle('15+') || leap_version_at_least('15.0') || is_tumbleweed) {
         assert_and_click 'nautilus-newfile-matched', 'right';
     }
     else {

--- a/tests/x11/gnote/gnote_link_note.pm
+++ b/tests/x11/gnote/gnote_link_note.pm
@@ -16,7 +16,7 @@ use base 'x11test';
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_sle is_tumbleweed sle_version_at_least);
+use version_utils qw(is_sle is_tumbleweed);
 
 
 sub run {
@@ -28,8 +28,8 @@ sub run {
     send_key 'ctrl-ret';    #switch to link
     assert_screen 'gnote-note-start-here';
 
-    wait_screen_change { send_key 'ctrl-tab' };                                              #jump to toolbar
-    wait_screen_change { send_key 'ctrl-tab' } if (is_sle && sle_version_at_least('15'));    #jump to toolbar
+    wait_screen_change { send_key 'ctrl-tab' };                     #jump to toolbar
+    wait_screen_change { send_key 'ctrl-tab' } if is_sle('15+');    #jump to toolbar
     wait_screen_change {
         for (1 .. 6) { send_key 'right' }
     };
@@ -41,7 +41,7 @@ sub run {
     assert_screen 'gnote-what-link-here';
     wait_screen_change { send_key 'esc' };
     #close the note "Start Here"
-    wait_screen_change { send_key 'ctrl-w' } if (!is_tumbleweed && (is_sle && !sle_version_at_least('15')));
+    wait_screen_change { send_key 'ctrl-w' } if is_sle('<15');
     $self->cleanup_gnote;
 }
 

--- a/tests/x11/gnote/gnote_rename_title.pm
+++ b/tests/x11/gnote/gnote_rename_title.pm
@@ -15,7 +15,7 @@
 use base "x11test";
 use strict;
 use testapi;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 
 
 sub run {
@@ -26,8 +26,8 @@ sub run {
     send_key "up";
     type_string "new title-opensuse\n";
     send_key "ctrl-tab";    #jump to toolbar
-    send_key "ctrl-tab" if (is_sle && sle_version_at_least('15'));    #jump to toolbar for SLED15
-    send_key "ret";                                                   #back to all notes interface
+    send_key "ctrl-tab" if is_sle('15+');    #jump to toolbar for SLED15
+    send_key "ret";                          #back to all notes interface
     send_key_until_needlematch 'gnote-new-note-title-matched', 'down', 6;
     send_key "delete";
     send_key "tab";

--- a/tests/x11/gnote/gnote_undo_redo.pm
+++ b/tests/x11/gnote/gnote_undo_redo.pm
@@ -15,7 +15,7 @@
 use base "x11test";
 use strict;
 use testapi;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 
 
 sub undo_redo_once {
@@ -38,17 +38,17 @@ sub run {
 
     #assure undo and redo take effect after save note and re-enter note
     send_key "ctrl-tab";    #jump to toolbar
-    send_key "ctrl-tab" if (is_sle && sle_version_at_least('15'));    #jump to toolbar for SLED15
-    send_key "ret";                                                   #back to all notes interface
+    send_key "ctrl-tab" if is_sle('15+');    #jump to toolbar for SLED15
+    send_key "ret";                          #back to all notes interface
     send_key_until_needlematch 'gnote-new-note-matched', 'down', 6;
     wait_still_screen 3;
     send_key "ret";
     $self->undo_redo_once;
 
     #clean: remove the created new note
-    send_key "ctrl-tab";                                              #jump to toolbar
-    send_key "ctrl-tab" if (is_sle && sle_version_at_least('15'));    #jump to toolbar for SLED15
-    send_key "ret";                                                   #back to all notes interface
+    send_key "ctrl-tab";                     #jump to toolbar
+    send_key "ctrl-tab" if is_sle('15+');    #jump to toolbar for SLED15
+    send_key "ret";                          #back to all notes interface
     send_key_until_needlematch 'gnote-new-note-matched', 'down', 6;
     send_key "delete";
     send_key "tab";

--- a/tests/x11/libreoffice/libreoffice_default_theme.pm
+++ b/tests/x11/libreoffice/libreoffice_default_theme.pm
@@ -14,12 +14,12 @@
 use base "x11test";
 use testapi;
 use utils;
-use version_utils qw(is_sle is_tumbleweed sle_version_at_least);
+use version_utils qw(is_sle is_tumbleweed);
 use strict;
 
 sub check_lo_theme {
     x11_start_program('ooffice');
-    if (is_tumbleweed || (is_sle && sle_version_at_least('15'))) {
+    if (is_tumbleweed || is_sle('15+')) {
         send_key 'alt-f12';
     }
     else {

--- a/tests/x11/libreoffice/libreoffice_double_click_file.pm
+++ b/tests/x11/libreoffice/libreoffice_double_click_file.pm
@@ -13,7 +13,7 @@
 use base "x11test";
 use strict;
 use testapi;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 
 sub run {
     my $self = shift;
@@ -35,7 +35,7 @@ sub run {
         send_key_until_needlematch("libreoffice-specified-list-$tag", "right", 50, 1);
         assert_and_dclick("libreoffice-specified-list-$tag");
         assert_screen("libreoffice-test-$tag", 90);
-        if (is_sle && sle_version_at_least('15')) {
+        if (is_sle '15+') {
             send_key 'alt-f4';
         }
         else {

--- a/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
@@ -14,7 +14,7 @@ use base "x11test";
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_sle is_tumbleweed sle_version_at_least);
+use version_utils qw(is_sle is_tumbleweed);
 
 # open desktop mainmenu and click office
 sub open_mainmenu {
@@ -54,7 +54,7 @@ sub select_base_and_cleanup {
 sub run {
     my $self = shift;
 
-    if (!is_tumbleweed && (is_sle && !sle_version_at_least('15'))) {
+    if (!is_tumbleweed && is_sle('<15')) {
         # launch components from mainmenu
         $self->open_mainmenu();
         assert_and_click 'mainmenu-office-lo';    #open lo

--- a/tests/x11/libreoffice/libreoffice_mainmenu_favorites.pm
+++ b/tests/x11/libreoffice/libreoffice_mainmenu_favorites.pm
@@ -14,7 +14,7 @@
 use base "x11test";
 use strict;
 use testapi;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 
 sub run {
     # start destop application memu
@@ -23,7 +23,7 @@ sub run {
     assert_screen('test-desktop_mainmenu-1');
 
     # find the favorites button
-    if (is_sle && !sle_version_at_least('15')) {
+    if (is_sle '<15') {
         assert_and_click('application-menu-favorites');
         assert_screen('menu-favorites-libreoffice');
     }

--- a/tests/x11/libreoffice/libreoffice_recent_documents.pm
+++ b/tests/x11/libreoffice/libreoffice_recent_documents.pm
@@ -15,7 +15,7 @@ use base "x11test";
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_sle is_tumbleweed sle_version_at_least);
+use version_utils qw(is_sle is_tumbleweed);
 
 sub run {
     # Edit file hello.odt using oowriter
@@ -38,11 +38,11 @@ sub run {
     send_key "alt-f";
     # Because of bsc#1074057 alt-f is not working in libreoffice under wayland
     # use another way to replace alt-f in SLED15
-    if (is_sle && sle_version_at_least('15')) {
+    if (is_sle '15+') {
         assert_and_click 'ooffice-writing-file', 'left', 10;
     }
     assert_screen 'oowriter-menus-file';
-    if (is_tumbleweed || (is_sle && sle_version_at_least('15'))) {
+    if (is_tumbleweed || is_sle('15+')) {
         send_key 'down';
         wait_still_screen 3;
         send_key 'u';

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -23,7 +23,7 @@ use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least i
 sub search {
     my ($name) = @_;
     # with the gtk interface we have to click as there is no shortcut
-    if ((is_sle && !sle_version_at_least('15')) || (is_leap && !leap_version_at_least('15.0'))) {
+    if (is_sle('<15') || (is_leap && !leap_version_at_least('15.0'))) {
         assert_screen([qw(yast2_control-center_search_clear yast2_control-center_search)], no_wait => 1);
         if (match_has_tag 'yast2_control-center_search') {
             assert_and_click 'yast2_control-center_search';
@@ -294,7 +294,7 @@ sub start_printer {
 
 sub run {
     my $self = shift;
-    if (is_sle && sle_version_at_least '15') {
+    if (is_sle '15+') {
         # kdump is disabled by default, so ensure that it's installed
         ensure_installed 'yast2-kdump';
         record_soft_failure 'bsc#1059569';

--- a/tests/yast2_gui/yast2_firewall.pm
+++ b/tests/yast2_gui/yast2_firewall.pm
@@ -16,7 +16,7 @@ use base "y2x11test";
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_sle sle_version_at_least is_leap leap_version_at_least is_tumbleweed);
+use version_utils qw(is_sle is_leap leap_version_at_least is_tumbleweed);
 
 sub susefirewall2 {
     # 	enter page interfaces and change zone for network interface
@@ -99,7 +99,7 @@ sub run {
     my $self = shift;
     select_console 'root-console';
     zypper_call('in yast2-http-server apache2 apache2-prefork', timeout => 1200);
-    if ((is_sle && sle_version_at_least('15')) || (is_leap && leap_version_at_least('15.0')) || is_tumbleweed) {
+    if (is_sle('15+') || (is_leap && leap_version_at_least('15.0')) || is_tumbleweed) {
         zypper_call('in firewall-config', timeout => 60);
         select_console 'x11', await_console => 0;
         $self->launch_yast2_module_x11('firewall', target_match => 'firewall-start-page', match_timeout => 60);


### PR DESCRIPTION
Version checking mechanism for SLE requires the use of <b>is_sle</b> with <b>sle_version_at_least</b> because sle_version_at_least returns true for all non-sle products. I think it's confusing default leading to unreadable code.

I don't want to modify / fix sle_version_at_least at once, because it's returning true by default and it might break many tests. Instead I added optional version parameter to is_sle, allowing filtering this way:
```perl
Format: [= > < >= <=] version [+]
Example:
 is_sle '=12';
 is_sle '=12-sp3';
 is_sle '>=15';
 is_sle '15+';
 is_sle '<15'
```

Our code could be then rewritten into more readable way:
```perl
Now:
if (is_sle && sle_version_at_least '15')
if (is_sle && sle_version_at_least('12-SP2') && !sle_version_at_least('15'))

After:
if (is_sle '15+')
if (is_sle('>=12-sp2') && is_sle('<15'))
```

Local runs:
 - http://dhcp91.suse.cz/tests/1443 - SLE
 - http://dhcp91.suse.cz/tests/1440 - Kubic