### PR TITLE
[NFV] Add Trex traffic generator installation

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -694,7 +694,7 @@ sub load_nfv_master_tests {
 
 sub load_nfv_trafficgen_tests {
     boot_hdd_image();
-    loadtest "nfv/moongen_installation";
+    loadtest "nfv/trex_installation";
 }
 
 sub load_iso_in_external_tests {

--- a/tests/nfv/moongen_installation.pm
+++ b/tests/nfv/moongen_installation.pm
@@ -20,7 +20,6 @@ use base "consoletest";
 use testapi;
 use strict;
 use utils;
-use lockapi;
 use mmapi;
 
 sub run {
@@ -28,20 +27,16 @@ sub run {
 
     select_console 'root-console';
 
-    mutex_lock('nfv_trafficgen_ready');
-
     zypper_call('in git-core gcc gcc-c++ make cmake libnuma-devel kernel-source pciutils', timeout => 300);
 
     # Clone repository
-    assert_script_run("git clone $moongen_repo", timeout => 300);
+    assert_script_run("git clone --depth 1 $moongen_repo", timeout => 300);
 
     # Install MoonGen and dependencies
     assert_script_run("cd MoonGen");
     assert_script_run("bash -x build.sh",           500);
     assert_script_run("bash -x setup-hugetlbfs.sh", 300);
     assert_script_run("bash -x bind-interfaces.sh", 300);
-
-    mutex_unlock('nfv_trafficgen_ready');
 }
 
 1;

--- a/tests/nfv/prepare_env.pm
+++ b/tests/nfv/prepare_env.pm
@@ -33,8 +33,8 @@ sub run {
     zypper_call('in git-core openvswitch-switch dpdk qemu tcpdump', timeout => 200);
 
     # Clone repositories
-    assert_script_run("git clone $vsperf_repo");
-    assert_script_run("git clone $dpdk_repo");
+    assert_script_run("git clone --depth 1 $vsperf_repo");
+    assert_script_run("git clone --depth 1 $dpdk_repo");
 
     # Start the openvswitch daemon
     systemctl 'start openvswitch', timeout => 200;

--- a/tests/nfv/run_integration_tests.pm
+++ b/tests/nfv/run_integration_tests.pm
@@ -16,7 +16,6 @@ use base "consoletest";
 use testapi;
 use strict;
 use utils;
-use lockapi;
 use mmapi;
 
 sub run {
@@ -24,10 +23,6 @@ sub run {
     my $vsperf_conf = "/etc/vsperf_ovs.conf";
 
     select_console 'root-console';
-    mutex_create('nfv_trafficgen_ready');
-
-    # wait until traffic generator installation finishes
-    wait_for_children;
 
     # use conf file from data dir
     assert_script_run("curl " . data_url('nfv/vsperf_ovs_dummy.conf') . " -o $vsperf_conf");

--- a/tests/nfv/trex_installation.pm
+++ b/tests/nfv/trex_installation.pm
@@ -1,0 +1,46 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Trex traffic generator installation
+#
+#   This test does the following
+#    - Clones Trex from official repo
+#    - Follow installation steps described in https://github.com/cisco-system-traffic-generator/trex-core/wiki
+#
+# Maintainer: Jose Lausuch <jalausuch@suse.com>
+
+use base "consoletest";
+use testapi;
+use strict;
+use utils;
+use mmapi;
+
+sub run {
+    my $trex_repo = "https://github.com/cisco-system-traffic-generator/trex-core.git";
+    my $trex_dest = "/tmp/trex-core";
+
+    select_console 'root-console';
+
+    zypper_call('in git-core gcc gcc-c++ make cmake libnuma-devel kernel-source pciutils', timeout => 300);
+
+    # Clone Trex repository
+    assert_script_run("git clone --depth 1 $trex_repo $trex_dest", timeout => 500);
+
+    # Copy sample config file to default localtion
+    assert_script_run("cp $trex_dest/scripts/cfg/simple_cfg.yaml /etc/trex_cfg.yaml");
+
+    # Compile Trex libraries
+    assert_script_run("cd $trex_dest/linux_dpdk");
+    assert_script_run("./b configure", 300);
+    assert_script_run("./b build",     1200);
+}
+
+1;
+
+# vim: set sw=4 et:


### PR DESCRIPTION
Substitute MoonGen trafficgen by Trex. 

This patch also uses depth -1 in all the commands that clone repositories to save some time.

- Verification run: http://10.161.8.29/tests/220#live
