### PR TITLE
Remove empty elements from SCC_ADDONS

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -285,6 +285,9 @@ sub fill_in_registration_data {
                 }
             }
             my @scc_addons = split(/,/, get_var('SCC_ADDONS', ''));
+            # remove emty elements
+            @scc_addons = grep { $_ ne '' } @scc_addons;
+
             if (!(check_screen 'scc_module-phub', 0)) {
                 record_soft_failure 'boo#1056047';
                 #find and remove phub


### PR DESCRIPTION
unfortuanetly QAM handles addons in `mru-install-minimal-with-addon` test with this construction
`SCC_ADDONS=%MRU_ADDONS%,%REQUIRED_ADDONS%`, on LTSS systems is MRU_ADDONS empty which leads to `SCC_ADDONS=,ltss` 

- Related ticket: https://progress.opensuse.org/issues/31699
- Verification run: http://quasar.suse.cz/tests/646
