### PR TITLE
Remove empty elements from SCC_ADDONS in releasenotes

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -29,7 +29,9 @@ sub run {
     my $addons = get_var('ADDONS', get_var('ADDONURL', get_var('DUD_ADDONS', '')));
     my @addons = split(/,/, $addons);
     if (check_var('SCC_REGISTER', 'installation')) {
-        push @addons, split(/,/, get_var('SCC_ADDONS', ''));
+        my @scc_addons = grep { $_ ne "" } split(/,/, get_var('SCC_ADDONS', ''));
+
+        push @addons, @scc_addons;
     }
     if (get_var("UPGRADE")) {
         send_key "alt-e";    # open release notes window


### PR DESCRIPTION
same problem as https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4406

- Related ticket: https://progress.opensuse.org/issues/31699
- Verification run: http://quasar.suse.cz/tests/648#step/releasenotes/7
