### PR TITLE
Adjustments ay profiles and yast control center due to dropped ca-mgmt

### DIFF
--- a/data/autoyast_sle15/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle15/bug-872532_ix64ph1069.xml
@@ -33,18 +33,6 @@
     <sections config:type="list">
     </sections>
   </bootloader>
-  <ca_mgm>
-    <CAName>YaST_Default_CA</CAName>
-    <ca_commonName>YaST Default CA (qa.suse.de)</ca_commonName>
-    <country>US</country>
-    <locality/>
-    <organisation/>
-    <organisationUnit/>
-    <password>ENTER PASSWORD HERE</password>
-    <server_email>postmaster@qa.suse.de</server_email>
-    <state/>
-    <takeLocalServerName config:type="boolean">true</takeLocalServerName>
-  </ca_mgm>
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>
   </deploy_image>

--- a/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
@@ -98,18 +98,6 @@ find / -name YaST2-Second-Stage.service
     <sections config:type="list">
     </sections>
   </bootloader>
-  <ca_mgm>
-    <CAName>YaST_Default_CA</CAName>
-    <ca_commonName>YaST Default CA (pnt.de)</ca_commonName>
-    <country>US</country>
-    <locality/>
-    <organisation/>
-    <organisationUnit/>
-    <password>ENTER PASSWORD HERE</password>
-    <server_email>postmaster@pnt.de</server_email>
-    <state/>
-    <takeLocalServerName config:type="boolean">true</takeLocalServerName>
-  </ca_mgm>
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>
   </deploy_image>

--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -66,18 +66,6 @@
       </section>
     </sections>
   </bootloader>
-  <ca_mgm>
-    <CAName>YaST_Default_CA</CAName>
-    <ca_commonName>YaST Default CA (suse.de)</ca_commonName>
-    <country>US</country>
-    <locality/>
-    <organisation/>
-    <organisationUnit/>
-    <password>ENTER PASSWORD HERE</password>
-    <server_email>postmaster@suse.de</server_email>
-    <state/>
-    <takeLocalServerName config:type="boolean">true</takeLocalServerName>
-  </ca_mgm>
   <deploy_image>
     <image_installation config:type="boolean">false</image_installation>
   </deploy_image>


### PR DESCRIPTION
yast2-ca-mgmt was dropped, see
[fate#319119](https://fate.suse.com/319119).
See [poo#31648](https://progress.opensuse.org/issues/31648).

[NEEDLES for yast2 control center](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/700)

NOTE: needles are fixing test suite, but not related to this change, it happened before.

Verification runs:
  * [autoyast_bug-887126_autoinst](http://g226.suse.de/tests/746)
  * [autoyast_bug-876411_btrfs_h5_autoinst](http://g226.suse.de/tests/745)
  * [autoyast_bug-872532_ix64ph1069](http://g226.suse.de/tests/744)
  * [yast2_control_center sle15](http://g226.suse.de/tests/749)
  * [yast2_control_center sle12sp4](http://g226.suse.de/tests/757)

Note, verification runs are now failing on firewalld bugs. This will be handled separately.