### PR TITLE
Replace runc with docker-runc

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -295,7 +295,7 @@ sub load_slepos_tests {
 
 sub load_docker_tests {
     loadtest "console/docker";
-    loadtest "console/runc";
+    loadtest "console/docker_runc";
     # No package 'docker-compose' in SLE
     if (!is_sle) {
         loadtest "console/docker_compose";

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -124,7 +124,7 @@ sub load_feature_tests {
     # Container Tests
     if (!check_var('SYSTEM_ROLE', 'microos')) {
         loadtest 'console/docker';
-        loadtest 'console/runc';
+        loadtest 'console/docker_runc';
     }
 }
 


### PR DESCRIPTION
We maintaine two different versions of runc. Both packages
are pointing to a different binary location, thus we need
tests for both of them.

This PR disables 'runc' test temporarily, and replaces it
with 'docker-runc' which is the recommended (and in most
cases it's pre-installed) package.



- Related ticket: https://progress.opensuse.org/issues/31657
- Needles: not needed
- Verification run: 
SLES http://ultron.suse.de:82/tests/14#step/docker_runc/77
Kubic http://ultron.suse.de:82/tests/9#step/docker_runc/71