### PR TITLE
Keyboard layout post boot test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -889,6 +889,7 @@ sub load_inst_tests {
 
 sub load_consoletests {
     return unless consolestep_is_applicable();
+    loadtest "locale/keymap_or_locale";
     if (get_var("ADDONS", "") =~ /rt/) {
         loadtest "rt/kmp_modules";
     }

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -118,7 +118,8 @@ sub init_cmd {
 sub init_desktop_runner {
     my ($program, $timeout) = @_;
 
-    send_key 'alt-f2';
+    send_key(check_var('DESKTOP', 'minimalx') ? 'super-spc' : 'alt-f2');
+
     mouse_hide(1);
     if (!check_screen('desktop-runner', $timeout)) {
         record_info('workaround', 'desktop-runner does not show up on alt-f2, retrying up to three times (see bsc#978027)');
@@ -174,7 +175,7 @@ sub x11_start_program {
     $args{valid}         //= 1;
     $args{target_match}  //= $program;
     $args{match_no_wait} //= 0;
-    die "no desktop-runner available on minimalx" if check_var('DESKTOP', 'minimalx');
+
     # Start desktop runner and type command there
     init_desktop_runner($program, $timeout);
     # With match_typed we check typed text and if doesn't match - retrying

--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -1,0 +1,88 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Keyboard layout test in console and display manager after boot
+# Maintainer: Martin Loviska <mloviska@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+use utils;
+
+sub verify_default_keymap_textmode {
+    my ($test_string, $tag, %tty) = @_;
+
+    # test keymap in login prompt of generally unused tty3 and typing test string wait 3 seconds
+    defined($tty{console}) ? select_console($tty{console}) : send_key('alt-f3', 3);
+    type_string($test_string);
+    assert_screen($tag);
+    # clear line in order to add user bernhard to tty group
+    # clear line to avoid possible failures in following console tests if scheduled
+    send_key("ctrl-w");
+}
+
+sub list_locale_settings {
+    my ($self, $console) = @_;
+    # locale variables might differ from user to user
+    select_console($console);
+    $self->save_and_upload_log('localectl status', '/tmp/localectl.status.out');
+    $self->save_and_upload_log('locale',           '/tmp/locale.out');
+}
+
+sub list_locale_etc_settings {
+    my $self = shift;
+
+    select_console('user-console');
+    $self->save_and_upload_log('cat /etc/X11/xorg.conf.d/00-keyboard.conf', '/tmp/xorg.00-keyboard.conf.out');
+    $self->save_and_upload_log('cat /etc/vconsole.conf',                    '/tmp/vconsole.conf.out');
+}
+
+sub verify_default_keymap_x11 {
+    my ($test_string, $tag, $program) = @_;
+
+    select_console('x11');
+    x11_start_program($program);
+    type_string($test_string);
+    assert_screen($tag);
+    # clear line to avoid possible failures in following tests (eg. updates_packagekit_gpk)
+    send_key("ctrl-w");
+    # close xterm
+    send_key("ctrl-d");
+}
+
+sub run {
+    # uncomment in case of different keyboard than us is used during installation ( feature not ready yet )
+    # my $expected   = get_var('INSTALL_KEYBOARD_LAYOUT','us');
+    my $expected       = 'us';
+    my %keystroke_list = (
+        us => '`1234567890-=~!@#$%^&*()_+',
+        fr => '²&é"(-è_çà)=~1234567890°+',
+        de => '1234567890ß°!"§$%&/()=?',
+        cz => ';+ěščřžýáíé=1234567890%'
+    );
+    my $keystrokes = $keystroke_list{$expected};
+
+    if (check_var('DESKTOP', 'textmode')) {
+        assert_screen([qw(linux-login cleared-console)]);
+        verify_default_keymap_textmode($keystrokes, "${expected}_keymap");
+        verify_default_keymap_textmode($keystrokes, "${expected}_keymap", console => 'root-console');
+        ensure_serialdev_permissions;
+        verify_default_keymap_textmode($keystrokes, "${expected}_keymap", console => 'user-console');
+    }
+    elsif (get_var('DESKTOP') && (!check_var('DESKTOP', 'textmode'))) {
+        verify_default_keymap_x11($keystrokes, "${expected}_keymap_logged_x11", 'xterm');
+    }
+}
+
+sub test_flags {
+    return {milestone => 1};
+}
+1;
+
+# vim: set sw=4 et:


### PR DESCRIPTION
Keyboard layout test verifies installed keyboard mapping. This is meant to run after first_boot module. According to value of INSTALL_KEYBOARD_LAYOUT openQA variable, test selects corresponding predefined test string. 
This string simulates keystrokes of top keyboard row (first row below function keys up to backspace key) in different keymaps (currently defined keymaps - us, fr, de, cz).
Value of test string is then typed to xterm console in gdm or ttys for each logged user (bernhard & root) and in login prompt in textmode. Each string is verified by a needle.

As long as this test module is dealing with particular locale setting, it is prepared to be used for system locale verification by printing values of LC* variables, checking output of "localectl status" and printing content of /etc/vconsole.conf and /etc/X11/xorg.conf.d/00-keyboard.conf configuration files.
Further usage of extended locale test will be discussed.
[Motivation for locale extention](https://bugzilla.suse.com/show_bug.cgi?id=1074988)



## Verification:

SLE:
[sle-15-Installer-DVD-x86_64-Build457.1-locale_gnome@64bit](http://dhcp228.suse.cz/tests/628)
[sle-15-Installer-DVD-x86_64-Build457.1-locale_minimalx@64bit](http://dhcp228.suse.cz/tests/629)
[sle-15-Installer-DVD-x86_64-Build457.1-locale_textmode@64bit](http://dhcp228.suse.cz/tests/627)

Tumbleweed:
[opensuse-Tumbleweed-DVD-x86_64-Build20180214-locale_kde_tw@64bit](http://dhcp228.suse.cz/tests/611)
[opensuse-Tumbleweed-DVD-x86_64-Build20180214-locale_xfce_tw@64bit](http://dhcp228.suse.cz/tests/612)
[opensuse-Tumbleweed-DVD-x86_64-Build20180214-locale_textmode_tw@64bit](http://dhcp228.suse.cz/tests/630)

## New Verification:
SLE
[sle-15-Installer-DVD-x86_64-Build465.2-locale_gnome@64bit](http://dhcp228.suse.cz/tests/736)
[sle-15-Installer-DVD-x86_64-Build465.2-locale_minimalx@64b](http://dhcp228.suse.cz/tests/725)
[sle-15-Installer-DVD-x86_64-Build465.2-locale_textmode@64bit](http://dhcp228.suse.cz/tests/737)

Tumbleweed:
[opensuse-Tumbleweed-DVD-x86_64-Build20180224-locale_kde_tw@64bit](http://dhcp228.suse.cz/tests/721)
[opensuse-Tumbleweed-DVD-x86_64-Build20180224-locale_xfce_tw@64bit](http://dhcp228.suse.cz/tests/729)
[opensuse-Tumbleweed-DVD-x86_64-Build20180224-locale_textmode_tw@64bit](http://dhcp228.suse.cz/tests/738)