### PR TITLE
Add support for products/extensions in WORKAROUND_MODULES

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -35,6 +35,7 @@ our @EXPORT = qw(
   scc_deregistration
   get_addon_fullname
   rename_scc_addons
+  is_module
   %SLE15_MODULES
   %SLE15_DEFAULT_MODULES
 );
@@ -62,6 +63,13 @@ our %SLE15_DEFAULT_MODULES = (
     sled     => 'base,desktop',
     sles4sap => 'base,desktop,serverapp,ha,sapapp',
 );
+
+# Method to determine if a short name references a module based on what's defined
+# on %SLE15_MODULES
+sub is_module {
+    my $name = shift;
+    return defined $SLE15_MODULES{$name};
+}
 
 sub accept_addons_license {
     my (@scc_addons) = @_;

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -51,6 +51,7 @@ our %SLE15_MODULES = (
     serverapp    => 'Server-Applications',
     contm        => 'Containers',
     pcm          => 'Public-Cloud',
+    sapapp       => 'SAP-Applications',
 );
 
 # The expected modules of a default installation per product. Use them if they

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -289,11 +289,17 @@ if (sle_version_at_least('15') && !check_var('SCC_REGISTER', 'installation')) {
             if (is_staging()) {
                 $prefix .= "-Staging:" . get_var("STAGING");
             }
-            my $module_repo_name = get_var("REPO_SLE${version}_MODULE_${repo_name}", "$prefix-Module-$full_name-POOL-$arch-Build$build-Media1");
             # REPO_SLE* settings and repo names are different for products and modules
-            # Assign the proper repo name if current $short_name is not a module.
-            $module_repo_name = get_var("REPO_SLE_${repo_name}${version}_POOL", "$prefix-Product-$full_name-POOL-$arch-Build$build-Media1")
-              unless (is_module($short_name));
+            # Assign the proper repo name if current $short_name references a module or a product/extension.
+            my $repo_variable_name
+              = is_module($short_name) ?
+              "REPO_SLE${version}_MODULE_${repo_name}"
+              : "REPO_SLE_${repo_name}${version}_POOL";
+            my $default_repo_name
+              = is_module($short_name) ?
+              "$prefix-Module-$full_name-POOL-$arch-Build$build-Media1"
+              : "$prefix-Product-$full_name-POOL-$arch-Build$build-Media1";
+            my $module_repo_name = get_var($repo_variable_name, $default_repo_name);
             my $url = "$utils::OPENQA_FTP_URL/$module_repo_name";
             # Verify if url exists before adding
             if (head($url)) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -290,8 +290,10 @@ if (sle_version_at_least('15') && !check_var('SCC_REGISTER', 'installation')) {
                 $prefix .= "-Staging:" . get_var("STAGING");
             }
             my $module_repo_name = get_var("REPO_SLE${version}_MODULE_${repo_name}", "$prefix-Module-$full_name-POOL-$arch-Build$build-Media1");
+            # REPO_SLE* settings and repo names are different for products than for modules
+            # Assign the proper repo name if current $short_name is not a module.
             $module_repo_name = get_var("REPO_SLE_${full_name}${version}_POOL", "$prefix-Product-$full_name-POOL-$arch-Build$build-Media1")
-              if ($short_name eq lc($full_name));    # REPO_SLE* settings and repo names are different for products than for modules
+              if ($full_name eq uc($short_name));
             my $url = "$utils::OPENQA_FTP_URL/$module_repo_name";
             # Verify if url exists before adding
             if (head($url)) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -280,7 +280,7 @@ if (sle_version_at_least('15') && !check_var('SCC_REGISTER', 'installation')) {
         for my $short_name (@modules) {
             # Map the module's full name from its short name.
             # If it's not defined in $registration::SLE15_MODULES, then assume it's a Product/Extension and treat accordingly
-            my $full_name = $registration::SLE15_MODULES{$short_name} ? $registration::SLE15_MODULES{$short_name} : uc $short_name;
+            my $full_name = is_module($short_name) ? $registration::SLE15_MODULES{$short_name} : uc $short_name;
             my $repo_name = uc $full_name;
             # Replace dashes with underscore symbols
             $repo_name =~ s/-/_/;
@@ -290,10 +290,10 @@ if (sle_version_at_least('15') && !check_var('SCC_REGISTER', 'installation')) {
                 $prefix .= "-Staging:" . get_var("STAGING");
             }
             my $module_repo_name = get_var("REPO_SLE${version}_MODULE_${repo_name}", "$prefix-Module-$full_name-POOL-$arch-Build$build-Media1");
-            # REPO_SLE* settings and repo names are different for products than for modules
+            # REPO_SLE* settings and repo names are different for products and modules
             # Assign the proper repo name if current $short_name is not a module.
-            $module_repo_name = get_var("REPO_SLE_${full_name}${version}_POOL", "$prefix-Product-$full_name-POOL-$arch-Build$build-Media1")
-              if ($full_name eq uc($short_name));
+            $module_repo_name = get_var("REPO_SLE_${repo_name}${version}_POOL", "$prefix-Product-$full_name-POOL-$arch-Build$build-Media1")
+              unless (is_module($short_name));
             my $url = "$utils::OPENQA_FTP_URL/$module_repo_name";
             # Verify if url exists before adding
             if (head($url)) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -278,7 +278,9 @@ if (sle_version_at_least('15') && !check_var('SCC_REGISTER', 'installation')) {
         my $addonurl;
 
         for my $short_name (@modules) {
-            my $full_name = $registration::SLE15_MODULES{$short_name};
+            # Map the module's full name from its short name.
+            # If it's not defined in $registration::SLE15_MODULES, then assume it's a Product/Extension and treat accordingly
+            my $full_name = $registration::SLE15_MODULES{$short_name} ? $registration::SLE15_MODULES{$short_name} : uc $short_name;
             my $repo_name = uc $full_name;
             # Replace dashes with underscore symbols
             $repo_name =~ s/-/_/;
@@ -288,6 +290,8 @@ if (sle_version_at_least('15') && !check_var('SCC_REGISTER', 'installation')) {
                 $prefix .= "-Staging:" . get_var("STAGING");
             }
             my $module_repo_name = get_var("REPO_SLE${version}_MODULE_${repo_name}", "$prefix-Module-$full_name-POOL-$arch-Build$build-Media1");
+            $module_repo_name = get_var("REPO_SLE_${full_name}${version}_POOL", "$prefix-Product-$full_name-POOL-$arch-Build$build-Media1")
+              if ($short_name eq lc($full_name));    # REPO_SLE* settings and repo names are different for products than for modules
             my $url = "$utils::OPENQA_FTP_URL/$module_repo_name";
             # Verify if url exists before adding
             if (head($url)) {


### PR DESCRIPTION
This adds support to `WORKAROUND_MODULES` so it can include products (such as sles, sled, sles_sap) or extensions (such as ha) in the variable with the purpose of using it when skipping SCC
registration or testing in staging areas.

Also included in the PR is the inclusion of `sapapp` in the map of modules' short names to full names defined in lib/registration.pm.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/231 & http://mango.suse.de/tests/232
