### PR TITLE
Disable docker tests for SLE lower than 12-SP2

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -603,7 +603,7 @@ sub load_extra_tests {
         if (get_var("IPSEC")) {
             loadtest "console/ipsec_tools_h2h";
         }
-        load_docker_tests if check_var('ARCH', 'x86_64');
+        load_docker_tests if (check_var('ARCH', 'x86_64') && (sle_version_at_least('12-SP2') || !is_sle));
         loadtest "console/git";
         loadtest "console/java";
         loadtest "console/sysctl";


### PR DESCRIPTION
Fix poo#31810: SLE 12-SP1 should have ltss coverage only without
container module in openQA. Docker test have to be available for
openSUSE and SLE at least version 12-SP2.

- Related ticket: https://progress.opensuse.org/issues/31810
- Needles: none
- Verification runs:
SLE 12-SP1: http://10.100.12.105/tests/1070 without docker tests
SLE 12-SP2: http://10.100.12.105/tests/1071 with docker
openSUSE: http://10.100.12.105/tests/1072 with docker
