### PR TITLE
Adapt yast2_datetime.pm

### DIFF
--- a/tests/yast2_gui/yast2_datetime.pm
+++ b/tests/yast2_gui/yast2_datetime.pm
@@ -20,10 +20,13 @@ use testapi;
 
 sub run {
     my $self = shift;
-    $self->launch_yast2_module_x11('timezone', target_match => [qw(yast2-datetime-ui yast2-datetime_ntp-conf)], match_timeout => 90);
+    $self->launch_yast2_module_x11('timezone', target_match => [qw(yast2-datetime-ui yast2-datetime_ntp-conf require_install_chrony)], match_timeout => 90);
     if (match_has_tag 'yast2-datetime_ntp-conf') {
         send_key 'alt-d';
         send_key 'alt-o';
+    }
+    elsif (match_has_tag 'require_install_chrony') {
+        send_key 'alt-i';
     }
     assert_screen 'yast2-timezone-ui', 60;
 


### PR DESCRIPTION
- chrony is the replacement for ntp, so need to adapt test.
- see poo#31450 for more details
- verification run: http://e13.suse.de/tests/362#step/yast2_datetime
- needle PR:
  https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/704
