### PR TITLE
hpc: Increase robustness of ganglia testcase

### DIFF
--- a/tests/hpc/ganglia_server.pm
+++ b/tests/hpc/ganglia_server.pm
@@ -25,14 +25,18 @@ sub run {
     my $self        = shift;
     my $slave_ip    = get_required_var('HPC_SLAVE_IP');
     my ($server_ip) = get_required_var('HPC_HOST_IP') =~ /(.*)\/.*/;
-    barrier_create("GANGLIA_INSTALLED",   2);
-    barrier_create("GANGLIA_SERVER_DONE", 2);
-    barrier_create("GANGLIA_CLIENT_DONE", 2);
+    barrier_create("GANGLIA_INSTALLED",      2);
+    barrier_create("GANGLIA_SERVER_DONE",    2);
+    barrier_create("GANGLIA_CLIENT_DONE",    2);
+    barrier_create("GANGLIA_GMETAD_STARTED", 2);
+    barrier_create("GANGLIA_GMOND_STARTED",  2);
 
     assert_script_run('hostnamectl set-hostname ganglia-server');
     zypper_call('in ganglia-gmetad ganglia-gmond ganglia-gmetad-skip-bcheck');
     systemctl 'start gmetad';
+    barrier_wait('GANGLIA_GMETAD_STARTED');
     systemctl 'start gmond';
+    barrier_wait('GANGLIA_GMOND_STARTED');
 
     # wait for client
     barrier_wait('GANGLIA_INSTALLED');


### PR DESCRIPTION
basically adding a retry if not all nodes are connected at the first call of ´gstat -a´
according to the developer, this can take some time

Verification run: 
http://drnek.arch.suse.de/tests/188#step/setup_network/1