### PR TITLE
Generalize multi-machine test for HPC

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1036,6 +1036,28 @@ sub load_slenkins_tests {
     return 0;
 }
 
+sub load_cluster_boot {
+    if (check_var('ARCH', 'aarch64')) {
+        # We need to boot *before* waiting for support server
+        # Because of TianoCore UEFI boot method
+        loadtest "boot/boot_to_desktop";
+        # Wait for support server to complete its initialization
+        loadtest "support_server/wait_support_server";
+        # TODO: poo#32110 add reboot or ensure that network is up
+    }
+    else {
+        # Wait for support server to complete its initialization
+        loadtest "support_server/wait_support_server";
+        loadtest "boot/boot_to_desktop";
+    }
+    # Standard boot and configuration
+    loadtest "qa_automation/patch_and_reboot" if is_updates_tests;
+    loadtest "console/consoletest_setup"      if is_updates_tests;
+    loadtest "console/hostname";
+
+    return 1;
+}
+
 sub load_ha_cluster_tests {
     return unless (get_var("HA_CLUSTER"));
 
@@ -1540,8 +1562,13 @@ elsif (get_var('HPC')) {
         load_reboot_tests();
     }
     else {
-        loadtest 'boot/boot_to_desktop';
-        loadtest 'hpc/setup_network' if check_var('NICTYPE', 'tap');
+        if (get_var('CLUSTER_NODES')) {
+            load_cluster_boot();
+        }
+        else {
+            loadtest 'boot/boot_to_desktop';
+            loadtest 'hpc/setup_network' if check_var('NICTYPE', 'tap');
+        }
         loadtest 'hpc/enable_in_zypper' if (sle_version_at_least('15'));
         if (check_var('HPC', 'conman')) {
             loadtest 'hpc/conman';

--- a/tests/hpc/mrsh_master.pm
+++ b/tests/hpc/mrsh_master.pm
@@ -21,15 +21,15 @@ use lockapi;
 use utils;
 
 sub run {
-    my $self     = shift;
-    my $slave_ip = get_required_var('HPC_SLAVE_IP');
-    barrier_create("MRSH_INSTALLATION_FINISHED", 2);
-    barrier_create("MRSH_MUNGE_ENABLED",         2);
-    barrier_create("SLAVE_MRLOGIN_STARTED",      2);
-    barrier_create("MRSH_MASTER_DONE",           2);
-
-    # set proper hostname
-    assert_script_run "hostnamectl set-hostname mrsh-master";
+    my $self = shift;
+    # Get number of nodes
+    my $nodes = get_required_var("CLUSTER_NODES");
+    barrier_create("MRSH_INSTALLATION_FINISHED", $nodes);
+    barrier_create("MRSH_MUNGE_ENABLED",         $nodes);
+    barrier_create("SLAVE_MRLOGIN_STARTED",      $nodes);
+    barrier_create("MRSH_MASTER_DONE",           $nodes);
+    # Synchronize all slave nodes with master
+    mutex_create("MRSH_MASTER_BARRIERS_CONFIGURED");
 
     systemctl 'stop ' . $self->firewall;
 
@@ -37,8 +37,11 @@ sub run {
     zypper_call('in mrsh mrsh-server');
     barrier_wait("MRSH_INSTALLATION_FINISHED");
 
-    # copy key
-    $self->exec_and_insert_password("scp -o StrictHostKeyChecking=no /etc/munge/munge.key root\@$slave_ip:/etc/munge/munge.key");
+    # Copy munge key to all slave nodes
+    for (my $node = 1; $node < $nodes; $node++) {
+        my $node_name = sprintf("mrsh-slave%02d", $node);
+        $self->exec_and_insert_password("scp -o StrictHostKeyChecking=no /etc/munge/munge.key root\@${node_name}:/etc/munge/munge.key");
+    }
     mutex_create("MRSH_KEY_COPIED");
 
     # start munge
@@ -52,15 +55,17 @@ sub run {
     # run mrlogin, mrcp, and mrsh (as normal and local user, e.g. nobody)
     type_string("su - nobody\n");
     assert_screen("user-nobody");
-    type_string("mrlogin $slave_ip\n");
-    assert_screen("mrlogin");
-    send_key('ctrl-d');
-    assert_screen("mrlogout");
-    assert_script_run("mrsh $slave_ip rm -f /tmp/hello");
-    assert_script_run("echo \"Hello world!\" >/tmp/hello");
-    assert_script_run("mrcp /tmp/hello $slave_ip:/tmp/hello");
-    assert_script_run("mrsh $slave_ip cat /tmp/hello");
-
+    for (my $node = 1; $node < $nodes; $node++) {
+        my $node_name = sprintf("mrsh-slave%02d", $node);
+        type_string("mrlogin ${node_name} \n");
+        assert_screen("mrlogin");
+        send_key('ctrl-d');
+        assert_screen("mrlogout");
+        assert_script_run("mrsh ${node_name}  rm -f /tmp/hello");
+        assert_script_run("echo \"Hello world!\" >/tmp/hello");
+        assert_script_run("mrcp /tmp/hello ${node_name}:/tmp/hello");
+        assert_script_run("mrsh ${node_name}  cat /tmp/hello");
+    }
     barrier_wait("MRSH_MASTER_DONE");
 }
 

--- a/tests/hpc/mrsh_slave.pm
+++ b/tests/hpc/mrsh_slave.pm
@@ -22,13 +22,18 @@ use utils;
 sub run {
     my $self = shift;
 
-    # set proper hostname
-    assert_script_run "hostnamectl set-hostname mrsh-slave";
+    # Synchronize with master
+    mutex_lock("MRSH_MASTER_BARRIERS_CONFIGURED");
+    mutex_unlock("MRSH_MASTER_BARRIERS_CONFIGURED");
+
+    # Stop firewall
+    systemctl 'stop ' . $self->firewall;
 
     # install mrsh
     zypper_call('in mrsh mrsh-server');
     barrier_wait("MRSH_INSTALLATION_FINISHED");
     mutex_lock("MRSH_KEY_COPIED");
+    mutex_unlock("MRSH_KEY_COPIED");
 
     # start munge
     $self->enable_and_start('munge');

--- a/tests/hpc/munge_master.pm
+++ b/tests/hpc/munge_master.pm
@@ -19,30 +19,37 @@ use lockapi;
 use utils;
 
 sub run {
-    my $self     = shift;
-    my $slave_ip = get_required_var('HPC_SLAVE_IP');
-    barrier_create("MUNGE_INSTALLATION_FINISHED", 2);
-    barrier_create("MUNGE_SERVICE_ENABLED",       2);
+    my $self = shift;
 
-    # set proper hostname
-    assert_script_run('hostnamectl set-hostname munge-master');
+    # Get number of nodes
+    my $nodes = get_required_var("CLUSTER_NODES");
+    barrier_create("MUNGE_INSTALLATION_FINISHED", $nodes);
+    barrier_create("MUNGE_SERVICE_ENABLED",       $nodes);
+    # Synchronize all slave nodes with master
+    mutex_create("MUNGE_MASTER_BARRIERS_CONFIGURED");
 
-    # install munge and wait for slave
+    # Install munge and wait for slave
     zypper_call('in munge');
     barrier_wait('MUNGE_INSTALLATION_FINISHED');
 
-    # copy munge key
-    $self->exec_and_insert_password("scp -o StrictHostKeyChecking=no /etc/munge/munge.key root\@$slave_ip:/etc/munge/munge.key");
+    # Copy munge key to all slave nodes
+    for (my $node = 1; $node < $nodes; $node++) {
+        my $node_name = sprintf("munge-slave%02d", $node);
+        $self->exec_and_insert_password("scp -o StrictHostKeyChecking=no /etc/munge/munge.key root\@${node_name}:/etc/munge/munge.key");
+    }
     mutex_create('MUNGE_KEY_COPIED');
 
-    # enable and start service
+    # Enable and start service
     $self->enable_and_start('munge');
     barrier_wait("MUNGE_SERVICE_ENABLED");
 
-    # test if munch works fine
+    # Test if munge works fine
     assert_script_run('munge -n');
     assert_script_run('munge -n | unmunge');
-    $self->exec_and_insert_password("munge -n | ssh $slave_ip unmunge");
+    for (my $node = 1; $node < $nodes; $node++) {
+        my $node_name = sprintf("munge-slave%02d", $node);
+        $self->exec_and_insert_password("munge -n | ssh ${node_name} unmunge");
+    }
     assert_script_run('remunge');
     mutex_create('MUNGE_DONE');
 }


### PR DESCRIPTION
Enhancement poo#20308:  Rewrite current HPC multimachine setup to use
supportserver for providing dhcp and dns to 2+ nodes.

- Related ticket: https://progress.opensuse.org/issues/20308
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/715
- Verification run: http://10.100.12.105/tests/overview?groupid=97&distri=sle&version=12-SP2&build=%3A20182102-2

Tests  `qa_automation/patch_and_reboot` and `console/consoletest_setup` are only for QAM.
New function `load_cluster_boot` in main.pm was created, it can be use by other cluster non-HPC tests.

#### Supportserver  
http://10.100.12.105/tests/1303
Is in default configuration, there is no special configuration. It serves core services
dhcp and dns. It is not needed to hard-code static ip addresses anymore.

Each cluster should have own support server test suite. Supporserver could be shared between clusters,
but based on experience, it is not recommended.
qam-hpc-slurm-supportserver:
BOOTFROM=c
BOOT_HDD_IMAGE=1
DESKTOP=textmode
HDDMODEL=scsi-hd
HDD_1=sle-ha-supportserver-x86_64.qcow2
NICTYPE=tap
START_AFTER_TEST=qam-hpc-install
SUPPORT_SERVER=1
SUPPORT_SERVER_ROLES=dhcp,dns
VIDEOMODE=text
VIRTIO_CONSOLE=0
WORKER_CLASS=tap

Naming of test suite could be with qam for QAM for QA without, just hpc-slurm-supportserver.
This depends on particular needs. Should be better to keep test suites separate in openQA.

Support server image is taken from HA, we can create our own if needed.

#### Master node
http://10.100.12.105/tests/1316
Master node is the main one, which controls multi machine barriers.

There is only one new variable `CLUSTER_NODES`, which indicates usage
of cluster and number od nodes. Variable is mandatory for master and slave nodes.

Selection of the test to run is in already existing `HPC` variable.

qam-hpc-cluster-slurm-master:
BOOTFROM=c
BOOT_HDD_IMAGE=1
CLUSTER_NODES=3
DESKTOP=textmode
HDDMODEL=scsi-hd
HDD_1=SLES-%VERSION%-%ARCH%-qam-hpc-install-Build%BUILD%.qcow2
HOSTNAME=slurm-master
HPC=slurm_master
NICTYPE=tap
PARALLEL_WITH=qam-hpc-slurm-supportserver
WORKER_CLASS=tap

#### Slave node
http://10.100.12.105/tests/1317

qam-hpc-slurm-slave01:
BOOTFROM=c
BOOT_HDD_IMAGE=1
CLUSTER_NODES=3
DESKTOP=textmode
HDDMODEL=scsi-hd
HDD_1=SLES-%VERSION%-%ARCH%-qam-hpc-install-Build%BUILD%.qcow2
HOSTNAME=slurm-slave01
HPC=slurm_slave
NICTYPE=tap
PARALLEL_WITH=qam-hpc-slurm-supportserver,qam-hpc-slurm-master
WORKER_CLASS=tap

qam-hpc-slurm-slave02:
BOOTFROM=c
BOOT_HDD_IMAGE=1
CLUSTER_NODES=3
DESKTOP=textmode
HDDMODEL=scsi-hd
HDD_1=SLES-%VERSION%-%ARCH%-qam-hpc-install-Build%BUILD%.qcow2
HOSTNAME=slurm-slave02
HPC=slurm_slave
NICTYPE=tap
PARALLEL_WITH=qam-hpc-slurm-supportserver,qam-hpc-slurm-master
WORKER_CLASS=tap
