### PR TITLE
Fix ipmi text mode test suite

### DIFF
--- a/tests/installation/scc_registration.pm
+++ b/tests/installation/scc_registration.pm
@@ -27,8 +27,8 @@ sub run {
     if (!get_var("HDD_SCC_REGISTERED")) {
         assert_screen_with_soft_timeout(
             'scc-registration',
-            timeout      => 300,
-            soft_timeout => 100,
+            timeout      => 350,
+            soft_timeout => 300,
             bugref       => 'bsc#1028774'
         );
     }


### PR DESCRIPTION
Previously ipmi installations had 2 disks and we were unselecting one of
them. This is not always the case. As expectations are changing, do it
flexible now considering which screen is shown.

Verification runs provided for the failing test suite and other which use same test module.

Also, bumped timeout as fails on production with current one.

See [poo#25510](https://progress.opensuse.org/issues/25510).

- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/705
- Verification runs:
  * [ipmi](http://g226.suse.de/tests/771)
  * [extrenal_iso_sle15](http://g226.suse.de/tests/775)
  * [tw](http://g226.suse.de/tests/774)
  * [select_disk](http://g226.suse.de/tests/776)
