### PR TITLE
Add verification for Network parameter DHCLIENT_SET_HOSTNAME

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -686,6 +686,7 @@ sub load_inst_tests {
         loadtest "installation/upgrade_select_opensuse" if is_opensuse;
     }
     if (is_sle) {
+        loadtest 'installation/network_configuration' if get_var('NETWORK_CONFIGURATION');
         # SCC registration is not required in media based upgrade since SLE15
         unless (sle_version_at_least('15') && get_var('MEDIA_UPGRADE')) {
             if (check_var('SCC_REGISTER', 'installation')) {
@@ -1685,9 +1686,10 @@ sub load_toolchain_tests {
 }
 
 sub load_common_opensuse_sle_tests {
-    load_autoyast_clone_tests if get_var("CLONE_SYSTEM");
-    load_create_hdd_tests     if get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1");
-    load_toolchain_tests      if get_var("TCM") || check_var("ADDONS", "tcm");
+    load_autoyast_clone_tests           if get_var("CLONE_SYSTEM");
+    load_create_hdd_tests               if get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1");
+    load_toolchain_tests                if get_var("TCM") || check_var("ADDONS", "tcm");
+    loadtest 'console/network_hostname' if get_var('NETWORK_CONFIGURATION');
 }
 
 sub load_ssh_key_import_tests {

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -27,6 +27,7 @@ use version_utils qw(is_sle sle_version_at_least is_sle12_hdd_in_upgrade);
 our @EXPORT = qw(
   add_suseconnect_product
   remove_suseconnect_product
+  assert_registration_screen_present
   fill_in_registration_data
   registration_bootloader_cmdline
   registration_bootloader_params
@@ -167,6 +168,17 @@ sub register_addons {
     }
 
     return $regcodes_entered;
+}
+
+sub assert_registration_screen_present {
+    if (!get_var("HDD_SCC_REGISTERED")) {
+        assert_screen_with_soft_timeout(
+            'scc-registration',
+            timeout      => 350,
+            soft_timeout => 300,
+            bugref       => 'bsc#1028774'
+        );
+    }
 }
 
 sub fill_in_registration_data {

--- a/tests/console/network_hostname.pm
+++ b/tests/console/network_hostname.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify hostname is setup according options selected in the installer.
+# - Verify variable DHCLIENT_SET_HOSTNAME is set to 'no'
+# - Verify hostname is of the form linux-xxxx https://github.com/openSUSE/linuxrc/blob/master/linuxrc_hostname.md,
+# which means that is not taken into account dhcp configuration provided for this test via NICTYPE_USER_OPTIONS=hostname=myguest
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.de>
+
+use base "consoletest";
+use strict;
+use testapi;
+
+sub run {
+    select_console 'root-console';
+    assert_script_run 'grep DHCLIENT_SET_HOSTNAME=\"no\" /etc/sysconfig/network/dhcp';
+    assert_script_run 'hostname | grep -E "linux-[[:alnum:]]{4}"';
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/installation/network_configuration.pm
+++ b/tests/installation/network_configuration.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify default options in Network Configuration during installation
+# and modify some of these options.
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.de>
+
+use base "y2logsstep";
+use strict;
+use warnings;
+use testapi;
+use registration 'assert_registration_screen_present';
+
+sub run {
+    assert_registration_screen_present;
+    send_key 'alt-w';    # Network Configuration
+    assert_screen 'inst-network';
+    send_key 'alt-s';    # Hostname/DNS
+    assert_screen 'inst-network-hostname-dns-tab';
+    assert_and_click 'inst-network-hostname-dhcp';
+    assert_and_click 'inst-network-hostname-dhcp-modified';
+    send_key $cmd{next};
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/installation/scc_registration.pm
+++ b/tests/installation/scc_registration.pm
@@ -24,14 +24,7 @@ use registration;
 use utils 'assert_screen_with_soft_timeout';
 
 sub run {
-    if (!get_var("HDD_SCC_REGISTERED")) {
-        assert_screen_with_soft_timeout(
-            'scc-registration',
-            timeout      => 350,
-            soft_timeout => 300,
-            bugref       => 'bsc#1028774'
-        );
-    }
+    assert_registration_screen_present;
     fill_in_registration_data;
 }
 


### PR DESCRIPTION
Verify that **DHCLIENT_SET_HOSTNAME** preloaded from control file does not overwrite the customer selection and check that hostname in the installed system is the right one according https://github.com/openSUSE/linuxrc/blob/master/linuxrc_hostname.md. Hostname in the form linux-xxxx is only reached if the installer really disables dhcp (not just the verification that the setting is properly set) given that the test include a fixed hostname **NICTYPE_USER_OPTIONS=hostname=myguest** which is taken into account only when is using dhcp.

- Related ticket: https://progress.opensuse.org/issues/25724
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/710
- Verification runs:
  - [sle-15-Installer-DVD-x86_64-Build459.1-network_configuration@64bit](http://dhcp227/tests/605)
  - [sle-12-SP4-Server-DVD-x86_64-Build0230-network_configuration@64bit](http://dhcp227/tests/609)