### PR TITLE
Increase size of bios boot partition as per new requirements

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -27,7 +27,7 @@ sub addpart {
     elsif ($part eq 'boot-efi')  { $size = 300; }
     elsif ($part eq 'root')      { $size = 8000; }
     elsif ($part eq 'swap')      { $size = 100; }
-    elsif ($part eq 'bios-boot') { $size = 1; }
+    elsif ($part eq 'bios-boot') { $size = 2; }
     else                         { die 'Unknown argument'; }
 
     assert_screen "expert-partitioner";


### PR DESCRIPTION
Proactive fix for (this test on staging)[https://openqa.opensuse.org/tests/611321#step/partitioning_raid/81].

No needle update required.

[Verification run](http://g226.suse.de/tests/799#step/partitioning_raid/149).
