### PR TITLE
Adjust SCC registration yast test for SLE15

### DIFF
--- a/lib/y2x11test.pm
+++ b/lib/y2x11test.pm
@@ -11,7 +11,8 @@ use testapi;
 Launch a yast configuration module C<$module> or the yast control center if
 C<$module> is empty. Calls C<assert_screen> on C<$target_match>, defaults to
 C<yast2-$module-ui>. Optional C<$match_timeout> can be specified as a timeout
-on the C<assert_screen> call on C<$target_match>.
+on the C<assert_screen> call on C<$target_match>. C<$maximize_window> option
+allows to maximize application window using shortcut.
 =cut
 sub launch_yast2_module_x11 {
     my ($self, $module, %args) = @_;
@@ -34,6 +35,8 @@ sub launch_yast2_module_x11 {
     type_password;
     send_key 'ret';
     assert_screen $args{target_match}, $args{match_timeout};
+    # Uses hotkey for gnome, adjust if need for other desktop
+    send_key 'alt-f10' if $args{maximize_window};
 }
 
 sub post_fail_hook {

--- a/tests/installation/addon_products_via_SCC_yast2.pm
+++ b/tests/installation/addon_products_via_SCC_yast2.pm
@@ -15,29 +15,40 @@ use base qw(y2logsstep y2x11test);
 use strict;
 use testapi;
 use registration 'fill_in_registration_data';
+use version_utils 'sle_version_at_least';
 
-sub run {
-    my ($self) = @_;
-    x11_start_program('xterm');
-    # add every used addon to regurl for proxy SCC
-    if (get_var('SCC_ADDONS')) {
+sub test_setup {
+    select_console 'root-console';
+    my $proxy_scc;
+    if (sle_version_at_least '15') {
+        # Remove registration from the system
+        assert_script_run 'SUSEConnect --clean';
+        # Define proxy SCC
+        assert_script_run 'echo "url: ' . get_var('SCC_URL') . '" > /etc/SUSEConnect';
+    }    # add every used addon to regurl for proxy SCC
+    elsif (get_var('SCC_ADDONS')) {
         my @addon_proxy = ("url: http://server-" . get_var('BUILD_SLE'));
         for my $addon (split(/,/, get_var('SCC_ADDONS', ''))) {
             my $uc_addon = uc $addon;    # change to uppercase to match variable
             push(@addon_proxy, "\b.$addon-" . get_var("BUILD_$uc_addon"));
         }
-        script_sudo "echo \"@addon_proxy.proxy.scc.suse.de\" > /etc/SUSEConnect", 0;
+        # Define proxy SCC
+        assert_script_run "echo \"@addon_proxy.proxy.scc.suse.de\" > /etc/SUSEConnect";
     }
-    # Disable screensaver
-    type_string "gsettings set org.gnome.desktop.session idle-delay 0\n";
-    send_key "ctrl-d";
-    $self->launch_yast2_module_x11('scc', target_match => [qw(scc-registration packagekit-warning)]);
+    # Disable screensaver, fails sometimes on SLE12, so keep it as before without assertion
+    script_run "gsettings set org.gnome.desktop.session idle-delay 0";
+    select_console 'x11';
+}
+
+sub run {
+    my ($self) = @_;
+    test_setup;    # Define proxy SCC. For SLE 15 we need to clean existing registration.
+    $self->launch_yast2_module_x11('scc', target_match => [qw(scc-registration packagekit-warning)], maximize_window => 1);
     if (match_has_tag 'packagekit-warning') {
         send_key 'alt-y';
         assert_screen 'scc-registration';
     }
     fill_in_registration_data;
-    send_key 'alt-f4';    # close yast2 control center
     assert_screen 'generic-desktop';
 }
 


### PR DESCRIPTION
The main issue here was that we use already registered image.
Nevertheless, we can simply clean registration data and perform clean
registration again.

See [poo#29423](https://progress.opensuse.org/issues/29423).

[Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/707).
- Verification runs: 
  * [sle15](http://g226.suse.de/tests/807#)
  * [sle12](http://g226.suse.de/tests/805) NOTE, fails on the bug at the moment
