### PR TITLE
Harmonize the main.pm files further to DRY

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -22,7 +22,6 @@ use utils;
 use version_utils qw(is_jeos is_caasp leap_version_at_least);
 use lockapi;
 use mm_network;
-use main_common 'addon_products_is_applicable';
 
 our @EXPORT = qw(
   stop_grub_timeout

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -18,7 +18,7 @@ use testapi qw(check_var get_var get_required_var set_var check_var_array diag);
 use autotest;
 use utils;
 use version_utils qw(
-  is_jeos is_gnome_next is_krypton_argon is_sle leap_version_at_least sle_version_at_least is_desktop_installed is_installcheck is_rescuesystem
+  is_hyperv_in_gui is_jeos is_gnome_next is_krypton_argon is_leap is_opensuse is_sle is_sles4sap is_sles4sap_standard leap_version_at_least sle_version_at_least is_desktop_installed is_installcheck is_rescuesystem
 );
 use bmwqemu ();
 use strict;
@@ -31,9 +31,20 @@ our @EXPORT = qw(
   set_defaults_for_username_and_password
   setup_env
   logcurrentenv
+  default_desktop
+  is_desktop
+  is_livesystem
+  is_memtest
+  is_mediacheck
+  is_server
+  is_sles4sap
   is_staging
   is_bridged_networking
+  need_clear_repos
+  have_scc_repos
   load_svirt_vm_setup_tests
+  load_inst_tests
+  load_svirt_boot_tests
   load_boot_tests
   load_reboot_tests
   load_rescuecd_tests
@@ -55,6 +66,7 @@ our @EXPORT = qw(
   rescuecdstep_is_applicable
   bootencryptstep_is_applicable
   addon_products_is_applicable
+  we_is_applicable
   remove_common_needles
   remove_desktop_needles
   check_env
@@ -66,6 +78,8 @@ our @EXPORT = qw(
   is_kernel_test
   load_kernel_tests
   load_bootloader_s390x
+  load_consoletests
+  load_x11tests
   load_yast2_ncurses_tests
   load_yast2_gui_tests
   load_extra_tests
@@ -79,6 +93,7 @@ our @EXPORT = qw(
   load_x11regression_documentation
   load_x11regression_gnome
   load_x11regression_other
+  load_common_x11regression
   load_security_tests_core
   load_security_tests_web
   load_security_tests_misc
@@ -92,6 +107,7 @@ our @EXPORT = qw(
   load_toolchain_tests
   load_common_opensuse_sle_tests
   replace_opensuse_repos_tests
+  load_ssh_key_import_tests
 );
 
 sub init_main {
@@ -166,6 +182,14 @@ sub logcurrentenv {
     }
 }
 
+sub have_addn_repos {
+    return
+         !get_var("NET")
+      && !get_var("EVERGREEN")
+      && get_var("SUSEMIRROR")
+      && !get_var("FLAVOR", '') =~ m/^Staging2?[\-]DVD$/;
+}
+
 sub is_staging {
     return get_var('STAGING');
 }
@@ -179,6 +203,19 @@ sub is_bridged_networking {
     # Some needles match hostname which we can't set permanently with bridge.
     set_var('BRIDGED_NETWORKING', 1) if $ret;
     return $ret;
+}
+
+sub is_livesystem {
+    return (check_var("FLAVOR", 'Rescue-CD') || get_var("LIVETEST"));
+}
+
+sub is_kde_live {
+    return get_var('FLAVOR', '') =~ /KDE-Live/;
+}
+
+# TODO check why we want this enabled on SLE staging but not openSUSE staging
+sub packagekit_available {
+    return !check_var('FLAVOR', 'Rescue-CD') && (!is_staging || is_sle);
 }
 
 sub is_kernel_test {
@@ -223,6 +260,52 @@ sub is_memtest {
 
 sub is_mediacheck {
     return get_var('MEDIACHECK');
+}
+
+sub is_server {
+    return 1 if is_sles4sap();
+    return 1 if get_var('FLAVOR', '') =~ /^Server/;
+    return 0 unless is_leanos();
+    return check_var('SLE_PRODUCT', 'sles');
+}
+
+sub is_desktop {
+    return get_var('FLAVOR', '') =~ /^Desktop/ || check_var('SLE_PRODUCT', 'sled');
+}
+
+sub is_leanos {
+    return 1 if get_var('FLAVOR', '') =~ /^Leanos/;
+    return 1 if get_var('FLAVOR', '') =~ /^Installer-/;
+    return 0;
+}
+
+sub is_desktop_module_selected {
+    # desktop applications module is selected if following variables have following values:
+    # productivity and ha require desktop applications, so it's preselected
+    # same is true for sles4sap
+    return
+         get_var('ADDONS', '') =~ /all-packages|desktop|we/
+      || get_var('WORKAROUND_MODULES', '') =~ /desktop|we/
+      || get_var('ADDONURL',           '') =~ /desktop|we/
+      || get_var('SCC_ADDONS',         '') =~ /desktop|we|productivity|ha/
+      || is_sles4sap;
+}
+
+sub default_desktop {
+    return undef   if get_var('VERSION', '') lt '12';
+    return 'gnome' if get_var('VERSION', '') lt '15';
+    # with SLE 15 LeanOS only the default is textmode
+    return 'gnome' if get_var('BASE_VERSION', '') =~ /^12/;
+    return 'textmode' if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'));
+    return 'gnome' if is_desktop_module_selected;
+    # default system role for sles and sled
+    return 'textmode' if is_server || !get_var('SCC_REGISTER') || !check_var('SCC_REGISTER', 'installation');
+    # remaining cases are is_desktop and check_var('SCC_REGISTER', 'installation'), hence gnome
+    return 'gnome';
+}
+
+sub uses_qa_net_hardware {
+    return check_var("BACKEND", "ipmi") || check_var("BACKEND", "generalhw");
 }
 
 sub load_svirt_boot_tests {
@@ -467,6 +550,42 @@ sub addon_products_is_applicable {
     return !get_var("LIVECD") && get_var("ADDONURL");
 }
 
+sub we_is_applicable {
+    return
+         is_server()
+      && (get_var("ADDONS", "") =~ /we/ or get_var("SCC_ADDONS", "") =~ /we/ or get_var("ADDONURL", "") =~ /we/)
+      && get_var('MIGRATION_REMOVE_ADDONS', '') !~ /we/;
+}
+
+sub installwithaddonrepos_is_applicable {
+    return get_var("HAVE_ADDON_REPOS") && !get_var("UPGRADE") && !get_var("NET");
+}
+
+sub need_clear_repos {
+    return (is_opensuse && is_staging()) || (is_sle && get_var("FLAVOR", '') =~ m/^Staging2?[\-]DVD$/ && get_var("SUSEMIRROR"));
+}
+
+sub have_scc_repos {
+    return check_var('SCC_REGISTER', 'console');
+}
+
+sub rt_is_applicable {
+    return is_server() && get_var("ADDONS", "") =~ /rt/;
+}
+
+sub xfcestep_is_applicable {
+    return check_var("DESKTOP", "xfce");
+}
+
+sub lxdestep_is_applicable {
+    return check_var("DESKTOP", "lxde");
+}
+
+sub is_smt {
+    # Smt is replaced with rmt in SLE 15, see bsc#1061291
+    return ((get_var("PATTERNS", '') || get_var('HDD_1', '')) =~ /smt/) && !sle_version_at_least('15');
+}
+
 sub remove_common_needles {
     my $no_skipto = get_var('SKIPTO') ? 0 : 1;
     unregister_needle_tags("ENV-SKIPTO-$no_skipto");
@@ -528,6 +647,10 @@ sub unregister_needle_tags {
     for my $n (@a) { $n->unregister($tag); }
 }
 
+sub install_this_version {
+    return !check_var('INSTALL_TO_OTHERS', 1);
+}
+
 sub load_bootloader_s390x {
     return 0 unless check_var("ARCH", "s390x");
 
@@ -550,6 +673,533 @@ sub boot_hdd_image {
     }
     loadtest "support_server/wait_support_server" if get_var('USE_SUPPORT_SERVER');
     loadtest "boot/boot_to_desktop";
+}
+
+sub load_inst_tests {
+    loadtest "installation/welcome";
+    loadtest "installation/keyboard_selection";
+    if (get_var('DUD_ADDONS')) {
+        loadtest "installation/dud_addon";
+    }
+    if (is_sle && sle_version_at_least('15')) {
+        loadtest "installation/accept_license" if get_var('HASLICENSE');
+    }
+    if (get_var('IBFT')) {
+        loadtest "installation/iscsi_configuration";
+    }
+    if (check_var('ARCH', 's390x')) {
+        if (check_var('BACKEND', 's390x')) {
+            loadtest "installation/disk_activation";
+        }
+        elsif (!sle_version_at_least('12-SP2')) {
+            loadtest "installation/skip_disk_activation";
+        }
+    }
+    if (get_var('ENCRYPT_CANCEL_EXISTING') || get_var('ENCRYPT_ACTIVATE_EXISTING')) {
+        loadtest "installation/encrypted_volume_activation";
+    }
+    if (get_var('MULTIPATH')) {
+        loadtest "installation/multipath";
+    }
+    if (is_opensuse && noupdatestep_is_applicable() && !get_var("LIVECD")) {
+        loadtest "installation/installation_mode";
+    }
+    if (!get_var("LIVECD") && get_var("UPGRADE")) {
+        loadtest "installation/upgrade_select";
+        if (check_var("UPGRADE", "LOW_SPACE")) {
+            loadtest "installation/disk_space_fill";
+        }
+        loadtest "installation/upgrade_select_opensuse" if is_opensuse;
+    }
+    if (is_sle) {
+        # SCC registration is not required in media based upgrade since SLE15
+        unless (sle_version_at_least('15') && get_var('MEDIA_UPGRADE')) {
+            if (check_var('SCC_REGISTER', 'installation')) {
+                loadtest "installation/scc_registration";
+            }
+            else {
+                loadtest "installation/skip_registration" unless check_var('SLE_PRODUCT', 'leanos');
+            }
+        }
+        if (is_sles4sap and !sle_version_at_least('15')) {
+            loadtest "installation/sles4sap_product_installation_mode";
+        }
+        if (get_var('MAINT_TEST_REPO')) {
+            loadtest 'installation/add_update_test_repo';
+        }
+        loadtest "installation/addon_products_sle";
+    }
+    if (noupdatestep_is_applicable()) {
+        # Krypton/Argon disable the network configuration stage
+        if (get_var("LIVECD") && !is_krypton_argon) {
+            loadtest "installation/livecd_network_settings";
+        }
+        #system_role selection during installation was added as a new feature since sles12sp2
+        #so system_role.pm should be loaded for all tests that actually install to versions over sles12sp2
+        #no matter with or without INSTALL_TO_OTHERS tag
+        if (
+            is_sle
+            && (   check_var('ARCH', 'x86_64')
+                && sle_version_at_least('12-SP2')
+                && is_server()
+                && (!is_sles4sap() || is_sles4sap_standard())
+                && (install_this_version() || install_to_other_at_least('12-SP2'))
+                || sle_version_at_least('15')))
+        {
+            loadtest "installation/system_role";
+        }
+        if (is_sles4sap() and sle_version_at_least('15')) {
+            loadtest "installation/sles4sap_product_installation_mode";
+        }
+        loadtest "installation/partitioning";
+        if (defined(get_var("RAIDLEVEL"))) {
+            loadtest "installation/partitioning_raid";
+        }
+        elsif (check_var('LVM', 0) && get_var('ENCRYPT')) {
+            loadtest 'installation/partitioning_crypt_no_lvm';
+        }
+        elsif (get_var("LVM")) {
+            loadtest "installation/partitioning_lvm";
+        }
+        elsif (get_var('FULL_LVM_ENCRYPT')) {
+            loadtest 'installation/partitioning_full_lvm';
+        }
+        if (get_var("FILESYSTEM")) {
+            if (get_var('PARTITIONING_WARNINGS')) {
+                loadtest 'installation/partitioning_warnings';
+            }
+            loadtest "installation/partitioning_filesystem";
+        }
+        if (get_var("TOGGLEHOME")) {
+            loadtest "installation/partitioning_togglehome";
+            if (get_var('LVM') && get_var('RESIZE_ROOT_VOLUME')) {
+                loadtest "installation/partitioning_resize_root";
+            }
+        }
+        if (get_var("EXPERTPARTITIONER")) {
+            loadtest "installation/partitioning_expert";
+        }
+        if (get_var("ENLARGESWAP") && get_var("QEMURAM", 1024) > 4098) {
+            loadtest "installation/installation_enlargeswap";
+        }
+
+        if (get_var("SPLITUSR")) {
+            loadtest "installation/partitioning_splitusr";
+        }
+        if (get_var("DELETEWINDOWS")) {
+            loadtest "installation/partitioning_guided";
+        }
+        if (get_var("IBFT")) {
+            loadtest "installation/partitioning_iscsi";
+        }
+        if (uses_qa_net_hardware() || get_var('SELECT_FIRST_DISK') || get_var("ISO_IN_EXTERNAL_DRIVE")) {
+            loadtest "installation/partitioning_firstdisk";
+        }
+        loadtest "installation/partitioning_finish";
+    }
+    if (installwithaddonrepos_is_applicable() && !get_var("LIVECD")) {
+        loadtest "installation/setup_online_repos";
+    }
+    if (is_opensuse && addon_products_is_applicable() && !leap_version_at_least('42.3')) {
+        loadtest "installation/addon_products";
+    }
+    # the VNC gadget is too unreliable to click, but we
+    # need to be able to do installations on it. The release notes
+    # functionality needs to be covered by other backends
+    # Skip release notes test on sle 15 if have addons
+    if (is_sle && !check_var('BACKEND', 'generalhw') && !check_var('BACKEND', 'ipmi') && !(sle_version_at_least('15') && get_var('ADDONURL'))) {
+        loadtest "installation/releasenotes";
+    }
+
+    if (noupdatestep_is_applicable()) {
+        loadtest "installation/installer_timezone";
+        # the test should run only in scenarios, where installed
+        # system is not being tested (e.g. INSTALLONLY etc.)
+        # The test also won't work reliably when network is bridged (non-s390x svirt).
+        if (    !consolestep_is_applicable()
+            and !get_var("REMOTE_CONTROLLER")
+            and !is_hyperv_in_gui
+            and !is_bridged_networking
+            and !check_var('BACKEND', 's390x')
+            and sle_version_at_least('12-SP2'))
+        {
+            loadtest "installation/hostname_inst";
+        }
+        # Do not run on REMOTE_CONTROLLER, IPMI and on Hyper-V in GUI mode
+        if (!get_var("REMOTE_CONTROLLER") && !check_var('BACKEND', 'ipmi') && !is_hyperv_in_gui && !get_var("LIVECD")) {
+            loadtest "installation/logpackages";
+        }
+        loadtest "installation/disable_online_repos" if get_var('DISABLE_ONLINE_REPOS');
+        loadtest "installation/installer_desktopselection" if is_opensuse;
+        if (is_sles4sap()) {
+            if (
+                is_sles4sap_standard()    # Schedule module only for SLE15 with non-default role
+                || sle_version_at_least('15') && get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'))
+            {
+                loadtest "installation/user_settings";
+            }    # sles4sap wizard installation doesn't have user_settings step
+        }
+        elsif (get_var('IMPORT_USER_DATA')) {
+            loadtest 'installation/user_import';
+        }
+        else {
+            loadtest "installation/user_settings";
+        }
+        if (is_sle || get_var("DOCRUN") || get_var("IMPORT_USER_DATA") || get_var("ROOTONLY")) {    # root user
+            loadtest "installation/user_settings_root";
+        }
+        if (get_var('PATTERNS') || get_var('PACKAGES')) {
+            loadtest "installation/installation_overview_before";
+            loadtest "installation/select_patterns_and_packages";
+        }
+        elsif (
+            is_sle
+            && (!check_var('DESKTOP', default_desktop)
+                && (!sle_version_at_least('15') || check_var('DESKTOP', 'minimalx'))))
+        {
+            # With SLE15 we change desktop using role and not by unselecting packages (Use SYSTEM_ROLE variable),
+            # If we have minimalx, as there is no such a role, there we use old approach
+            loadtest "installation/installation_overview_before";
+            loadtest "installation/change_desktop";
+        }
+    }
+    if (get_var("UEFI") && get_var("SECUREBOOT")) {
+        loadtest "installation/secure_boot";
+    }
+    # for upgrades on s390 zKVM we need to change the static ip adress of the image to reboot properly
+    if (check_var('BACKEND', 'svirt') && check_var('ARCH', 's390x') && get_var('UPGRADE')) {
+        loadtest "installation/set_static_ip";
+    }
+    if (installyaststep_is_applicable()) {
+        loadtest "installation/installation_overview";
+        # On Xen PV we don't have GRUB on VNC
+        loadtest "installation/disable_grub_timeout" unless check_var('VIRSH_VMM_TYPE', 'linux');
+        if (check_var('VIDEOMODE', 'text') && check_var('BACKEND', 'ipmi')) {
+            loadtest "installation/disable_grub_graphics";
+        }
+
+        if (check_var("UPGRADE", "LOW_SPACE")) {
+            loadtest "installation/disk_space_release";
+        }
+        if (ssh_key_import) {
+            loadtest "installation/ssh_key_setup";
+        }
+        loadtest "installation/start_install";
+    }
+    return 1 if get_var('EXIT_AFTER_START_INSTALL');
+    loadtest "installation/install_and_reboot";
+    if (check_var('BACKEND', 'svirt') and check_var('ARCH', 's390x')) {
+        # on svirt we need to redefine the xml-file to boot the installed kernel
+        loadtest "installation/redefine_svirt_domain";
+    }
+    if (is_sles4sap()) {
+        if (check_var('SLES4SAP_MODE', 'sles4sap_wizard')) {
+            loadtest "installation/sles4sap_wizard";
+            if (get_var("TREX")) {
+                loadtest "installation/sles4sap_wizard_trex";
+            }
+            if (get_var("NW")) {
+                loadtest "installation/sles4sap_wizard_nw";
+            }
+            loadtest "installation/sles4sap_wizard_swpm";
+        }
+    }
+
+}
+
+sub load_consoletests {
+    return unless consolestep_is_applicable();
+    if (get_var("ADDONS", "") =~ /rt/) {
+        loadtest "rt/kmp_modules";
+    }
+    loadtest "console/consoletest_setup";
+    loadtest "console/force_cron_run" unless is_jeos;
+    if (get_var("LOCK_PACKAGE")) {
+        loadtest "console/check_locked_package";
+    }
+    loadtest "console/textinfo";
+    loadtest "console/hostname" unless is_bridged_networking;
+    replace_opensuse_repos_tests if get_var('DISABLE_ONLINE_REPOS');
+    if (get_var('SYSTEM_ROLE', '') =~ /kvm|xen/) {
+        loadtest "console/patterns";
+    }
+    if (snapper_is_applicable()) {
+        if (get_var("UPGRADE")) {
+            loadtest "console/upgrade_snapshots";
+        }
+        # zypper and sle12 doesn't do upgrade or installation snapshots
+        # SLES4SAP default installation flow does not configure snapshots
+        elsif (!get_var("ZDUP") and !check_var('VERSION', '12') and !is_sles4sap()) {
+            loadtest "console/installation_snapshots";
+        }
+    }
+    if (get_var("DESKTOP") !~ /textmode/ && !check_var("ARCH", "s390x")) {
+        loadtest "console/xorg_vt";
+    }
+    loadtest "console/zypper_lr";
+    loadtest 'console/enable_usb_repo' if check_var('USBBOOT', 1);
+    if (need_clear_repos()) {
+        loadtest "update/zypper_clear_repos";
+    }
+    #have SCC repo for SLE product
+    if (have_scc_repos()) {
+        loadtest "console/yast_scc";
+    }
+    # If DISABLE_ONLINE_REPOS, mirror repo is already added
+    if (have_addn_repos && !get_var('DISABLE_ONLINE_REPOS')) {
+        loadtest "console/zypper_ar";
+    }
+    loadtest "console/zypper_ref";
+    loadtest "console/ncurses";
+    loadtest "console/yast2_lan" unless is_bridged_networking;
+    # no local certificate store
+    if (!is_krypton_argon) {
+        loadtest "console/curl_https";
+    }
+    if (is_sle && (check_var_array('SCC_ADDONS', 'asmm') && !sle_version_at_least('15'))
+        || (check_var_array('SCC_ADDONS', 'phub') && sle_version_at_least('15')))
+    {
+        loadtest "console/puppet";
+    }
+    if (!is_staging && (is_opensuse || (check_var_array('SCC_ADDONS', 'asmm') || sle_version_at_least('15')))) {
+        loadtest "console/salt";
+    }
+    if (   check_var('ARCH', 'x86_64')
+        || check_var('ARCH', 'i686')
+        || check_var('ARCH', 'i586'))
+    {
+        loadtest "console/glibc_sanity";
+    }
+    # openSUSE has "load_system_update_tests" for that,
+    # https://progress.opensuse.org/issues/31954 to improve
+    if (is_sle && !gnomestep_is_applicable()) {
+        loadtest "update/zypper_up";
+    }
+    loadtest "console/console_reboot" if is_jeos;
+    loadtest "console/zypper_in";
+    loadtest "console/yast2_i";
+    if (!get_var("LIVETEST")) {
+        loadtest "console/yast2_bootloader";
+    }
+    loadtest "console/vim" if is_opensuse || !sle_version_at_least('15') || !get_var('PATTERNS') || check_var_array('PATTERNS', 'enhanced_base');
+    # textmode install comes without firewall by default atm on openSUSE
+    if ((is_sle || !check_var("DESKTOP", "textmode")) && !is_staging() && !is_krypton_argon) {
+        loadtest "console/firewall_enabled";
+    }
+    if (is_jeos) {
+        loadtest "console/gpt_ptable";
+        loadtest "console/kdump_disabled";
+        loadtest "console/sshd_running";
+    }
+    if (rt_is_applicable()) {
+        loadtest "console/rt_is_realtime";
+        loadtest "console/rt_devel_packages";
+        loadtest "console/rt_peak_pci";
+        loadtest "console/rt_preempt_test";
+    }
+    loadtest "console/sshd";
+    loadtest "console/ssh_cleanup";
+    if (is_opensuse && !get_var("LIVETEST") && !is_staging() && !is_jeos) {
+        # in live we don't have a password for root so ssh doesn't
+        # work anyways, and except staging_core image, the rest of
+        # staging_* images don't need run this test case
+        #
+        # On JeOS we don't have fuse.ko in kernel-default-base package.
+        loadtest "console/sshfs";
+    }
+    loadtest "console/mtab";
+    if (!get_var("NOINSTALL") && !get_var("LIVETEST") && (check_var("DESKTOP", "textmode"))) {
+        if (check_var('BACKEND', 'qemu') && !is_jeos) {
+            # The NFS test expects the IP to be 10.0.2.15
+            loadtest "console/yast2_nfs_server";
+        }
+        loadtest "console/http_srv";
+        loadtest "console/mysql_srv";
+        loadtest "console/dns_srv";
+        # TODO test on openSUSE -> https://progress.opensuse.org/issues/27014
+        loadtest "console/postgresql_server" if is_sle;
+        # TODO test on openSUSE https://progress.opensuse.org/issues/31972
+        if (is_sle && sle_version_at_least('12-SP1')) {    # shibboleth-sp not available on SLES 12 GA
+            loadtest "console/shibboleth";
+        }
+        if (!is_staging && (is_opensuse || get_var('ADDONS', '') =~ /wsm/ || get_var('SCC_ADDONS', '') =~ /wsm/)) {
+            # TODO test on openSUSE https://progress.opensuse.org/issues/31972
+            loadtest "console/pcre" if is_sle;
+            # TODO test on SLE https://progress.opensuse.org/issues/31972
+            loadtest "console/mysql_odbc" if is_opensuse;
+            if ((is_leap && !leap_version_at_least('15.0')) || (is_sle && !sle_version_at_least('15'))) {
+                loadtest "console/php5";
+                loadtest "console/php5_mysql";
+                loadtest "console/php5_postgresql96";
+            }
+            loadtest "console/php7";
+            loadtest "console/php7_mysql";
+            loadtest "console/php7_postgresql96";
+        }
+        # TODO test on openSUSE https://progress.opensuse.org/issues/31972
+        loadtest "console/apache_ssl" if is_sle;
+        # TODO test on openSUSE https://progress.opensuse.org/issues/31972
+        loadtest "console/apache_nss" if is_sle;
+    }
+    if (check_var("DESKTOP", "xfce")) {
+        loadtest "console/xfce_gnome_deps";
+    }
+    if (!is_staging() && is_sle && sle_version_at_least('12-SP2')) {
+        # This test uses serial console too much to be reliable on Hyper-V
+        # (poo#30613)
+        loadtest "console/zypper_lifecycle" unless check_var('VIRSH_VMM_FAMILY', 'hyperv');
+        if (check_var_array('SCC_ADDONS', 'tcm') && !sle_version_at_least('15')) {
+            loadtest "console/zypper_lifecycle_toolchain";
+        }
+    }
+    loadtest 'console/install_all_from_repository' if get_var('INSTALL_ALL_REPO');
+    if (check_var_array('SCC_ADDONS', 'tcm') && get_var('PATTERNS') && sle_version_at_least('12-SP3')) {
+        loadtest "feature/feature_console/deregister";
+    }
+
+    loadtest "console/consoletest_finish";
+}
+
+sub load_x11tests {
+    return
+      unless (!get_var("INSTALLONLY")
+        && is_desktop_installed()
+        && !get_var("DUALBOOT")
+        && !get_var("RESCUECD")
+        && !get_var("HA_CLUSTER"));
+    if (is_smt()) {
+        loadtest "x11/smt";
+    }
+    loadtest "x11/user_gui_login" if is_opensuse && !get_var("LIVETEST") && !get_var("NOAUTOLOGIN");
+    if (get_var("XDMUSED")) {
+        loadtest "x11/x11_login";
+    }
+    if (kdestep_is_applicable() && get_var("WAYLAND")) {
+        loadtest "x11/start_wayland_plasma5";
+    }
+    if (xfcestep_is_applicable()) {
+        loadtest "x11/xfce4_terminal";
+    }
+    loadtest "x11/xterm";
+    loadtest "x11/sshxterm" unless get_var("LIVETEST");
+    if (gnomestep_is_applicable()) {
+        # openSUSE has an explicit update check elsewhere
+        loadtest "update/updates_packagekit_gpk" if is_sle && !is_staging;
+        loadtest "x11/gnome_control_center";
+        # TODO test on SLE https://progress.opensuse.org/issues/31972
+        loadtest "x11/gnome_tweak_tool" if is_opensuse;
+        loadtest "x11/gnome_terminal";
+        loadtest "x11/gedit";
+    }
+    if (kdestep_is_applicable() && !is_kde_live) {
+        loadtest "x11/kate";
+    }
+    # no firefox on KDE-Live # boo#1022499
+    loadtest "x11/firefox" unless is_kde_live;
+    if (is_opensuse && !get_var("OFW") && check_var('BACKEND', 'qemu') && !check_var('FLAVOR', 'Rescue-CD') && !is_kde_live) {
+        loadtest "x11/firefox_audio";
+    }
+    if (gnomestep_is_applicable() && !(get_var("LIVECD") || is_server)) {
+        loadtest "x11/thunderbird";
+    }
+    if (chromiumstep_is_applicable() && !(is_staging() || is_livesystem)) {
+        loadtest "x11/chromium";
+    }
+    if (xfcestep_is_applicable()) {
+        loadtest "x11/midori" unless (is_staging || is_livesystem);
+        loadtest "x11/ristretto";
+    }
+    if (gnomestep_is_applicable()) {
+        # TODO test on openSUSE https://progress.opensuse.org/issues/31972
+        if (is_sle && (!is_server || we_is_applicable)) {
+            loadtest "x11/eog";
+            loadtest "x11/rhythmbox";
+            loadtest "x11/wireshark";
+            loadtest "x11/ImageMagick";
+            loadtest "x11/ghostscript";
+        }
+    }
+    if (get_var("DESKTOP") =~ /kde|gnome/ && (!is_server || we_is_applicable) && !is_kde_live && !is_krypton_argon && !is_gnome_next) {
+        loadtest "x11/ooffice";
+    }
+    if (get_var("DESKTOP") =~ /kde|gnome/ && !get_var("LIVECD") && (!is_server || we_is_applicable)) {
+        loadtest "x11/oomath";
+        loadtest "x11/oocalc";
+    }
+    if (kdestep_is_applicable()) {
+        loadtest "x11/khelpcenter";
+        if (get_var("PLASMA5")) {
+            loadtest "x11/systemsettings5";
+        }
+        else {
+            loadtest "x11/systemsettings";
+        }
+        loadtest "x11/dolphin";
+    }
+    # SLES4SAP default installation does not configure snapshots
+    if (snapper_is_applicable() and !is_sles4sap()) {
+        loadtest "x11/yast2_snapper";
+    }
+    if (xfcestep_is_applicable()) {
+        loadtest "x11/thunar";
+        if (!get_var("USBBOOT") && !is_livesystem) {
+            loadtest "x11/reboot_xfce";
+        }
+    }
+    if (lxdestep_is_applicable()) {
+        if (!get_var("USBBOOT") && !is_livesystem) {
+            loadtest "x11/reboot_lxde";
+        }
+    }
+    loadtest "x11/glxgears" if packagekit_available && !get_var('LIVECD');
+    if (kdestep_is_applicable()) {
+        if (!is_krypton_argon && !is_kde_live) {
+            loadtest "x11/amarok";
+        }
+        loadtest "x11/kontact" unless is_kde_live;
+        if (!get_var("USBBOOT") && !is_livesystem) {
+            if (get_var("PLASMA5")) {
+                loadtest "x11/reboot_plasma5";
+            }
+            else {
+                loadtest "x11/reboot_kde";
+            }
+        }
+    }
+    if (gnomestep_is_applicable()) {
+        loadtest "x11/nautilus" unless get_var("LIVECD");
+        loadtest "x11/gnome_music" if is_opensuse;
+        loadtest "x11/evolution" if (!is_server() || we_is_applicable());
+        if (!get_var("USBBOOT") && !is_livesystem) {
+            loadtest "x11/reboot_gnome";
+        }
+        load_testdir('x11/gnomeapps') if is_gnome_next;
+    }
+    loadtest "x11/desktop_mainmenu";
+    if (is_sles4sap() and !is_sles4sap_standard()) {
+        load_sles4sap_tests();
+    }
+
+    if (xfcestep_is_applicable()) {
+        loadtest "x11/xfce4_appfinder";
+        if (!(get_var("FLAVOR") eq 'Rescue-CD')) {
+            loadtest "x11/xfce_lightdm_logout_login";
+        }
+    }
+
+    if (is_opensuse && !get_var("LIVECD")) {
+        loadtest "x11/inkscape";
+        loadtest "x11/gimp";
+    }
+    if (is_opensuse && !is_staging && !is_livesystem) {
+        loadtest "x11/gnucash";
+        loadtest "x11/hexchat";
+        loadtest "x11/vlc";
+    }
+    # Need to skip shutdown to keep backend alive if running rollback tests after migration
+    unless (get_var('ROLLBACK_AFTER_MIGRATION')) {
+        loadtest "x11/shutdown";
+    }
 }
 
 sub load_yast2_ncurses_tests {
@@ -812,6 +1462,20 @@ sub load_iso_in_external_tests {
     loadtest "x11/reboot_and_install";
 }
 
+sub load_x11regression_installation {
+    set_var('NOAUTOLOGIN', 1) if is_opensuse;
+    load_boot_tests();
+    load_inst_tests();
+    load_reboot_tests();
+    loadtest "x11regressions/x11regressions_setup";
+    # temporary adding test modules which applies hacks for missing parts in sle15
+    loadtest "console/sle15_workarounds" if is_sle and sle_version_at_least('15');
+    loadtest "console/hostname" unless is_bridged_networking;
+    loadtest "console/force_cron_run" unless is_jeos;
+    loadtest "shutdown/grub_set_bootargs";
+    loadtest "shutdown/shutdown";
+}
+
 sub load_x11regression_documentation {
     return unless check_var('DESKTOP', 'gnome');
     loadtest "x11regressions/gnote/gnote_first_run";
@@ -891,6 +1555,24 @@ sub load_x11regression_other {
         loadtest "x11regressions/tracker/tracker_info";
         loadtest "x11regressions/tracker/tracker_search_in_nautilus";
         loadtest "x11regressions/tracker/clean_tracker";
+    }
+}
+
+sub load_common_x11regression {
+    if (check_var("REGRESSION", "installation")) {
+        load_x11regression_installation;
+    }
+    elsif (check_var("REGRESSION", "gnome")) {
+        loadtest "boot/boot_to_desktop";
+        load_x11regression_gnome();
+    }
+    elsif (check_var("REGRESSION", "documentation")) {
+        loadtest "boot/boot_to_desktop";
+        load_x11regression_documentation();
+    }
+    elsif (check_var("REGRESSION", "other")) {
+        loadtest "boot/boot_to_desktop";
+        load_x11regression_other();
     }
 }
 
@@ -1030,6 +1712,18 @@ sub load_common_opensuse_sle_tests {
     load_autoyast_clone_tests if get_var("CLONE_SYSTEM");
     load_create_hdd_tests     if get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1");
     load_toolchain_tests      if get_var("TCM") || check_var("ADDONS", "tcm");
+}
+
+sub load_ssh_key_import_tests {
+    loadtest "boot/boot_to_desktop";
+    # setup ssh key, we know what ssh keys we have and can verify if they are imported or not
+    loadtest "x11/ssh_key_check";
+    # reboot after test specific setup and start installation/update
+    loadtest "x11/reboot_and_install";
+    load_inst_tests();
+    load_reboot_tests();
+    # verify previous defined ssh keys
+    loadtest "x11/ssh_key_verify";
 }
 
 1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -35,6 +35,7 @@ our @EXPORT = qw(
   is_bridged_networking
   load_svirt_vm_setup_tests
   load_boot_tests
+  load_reboot_tests
   load_rescuecd_tests
   load_zdup_tests
   load_autoyast_tests
@@ -276,6 +277,36 @@ sub load_boot_tests {
     }
 }
 
+sub load_reboot_tests {
+    # there is encryption passphrase prompt which is handled in installation/boot_encrypt
+    if (check_var("ARCH", "s390x") && !(get_var('ENCRYPT') && check_var('BACKEND', 'svirt'))) {
+        loadtest "installation/reconnect_s390";
+    }
+    if (uses_qa_net_hardware()) {
+        loadtest "boot/qa_net_boot_from_hdd";
+    }
+    if (installyaststep_is_applicable()) {
+        # test makes no sense on s390 because grub2 can't be captured
+        if (!(check_var("ARCH", "s390x") or (check_var('VIRSH_VMM_FAMILY', 'xen') and check_var('VIRSH_VMM_TYPE', 'linux')))) {
+            loadtest "installation/grub_test";
+            if ((snapper_is_applicable()) && get_var("BOOT_TO_SNAPSHOT")) {
+                loadtest "installation/boot_into_snapshot";
+            }
+        }
+        if (get_var('ENCRYPT')) {
+            loadtest "installation/boot_encrypt";
+            # reconnect after installation/boot_encrypt
+            if (check_var('BACKEND', 'svirt') && check_var('ARCH', 's390x')) {
+                loadtest "installation/reconnect_s390";
+            }
+        }
+        loadtest "installation/first_boot";
+    }
+    if (get_var("DUALBOOT")) {
+        loadtest "installation/reboot_eject_cd";
+        loadtest "installation/boot_windows";
+    }
+}
 
 sub load_rescuecd_tests {
     if (rescuecdstep_is_applicable()) {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -18,7 +18,7 @@ use testapi qw(check_var get_var get_required_var set_var check_var_array diag);
 use autotest;
 use utils;
 use version_utils qw(
-  is_hyperv_in_gui is_jeos is_gnome_next is_krypton_argon is_leap is_opensuse is_sle is_sles4sap is_sles4sap_standard leap_version_at_least sle_version_at_least is_desktop_installed is_installcheck is_rescuesystem
+  is_hyperv_in_gui is_jeos is_gnome_next is_krypton_argon is_leap is_opensuse is_sle is_sles4sap is_sles4sap_standard leap_version_at_least sle_version_at_least is_desktop_installed is_installcheck is_rescuesystem is_staging
 );
 use bmwqemu ();
 use strict;
@@ -38,8 +38,6 @@ our @EXPORT = qw(
   is_mediacheck
   is_server
   is_sles4sap
-  is_staging
-  is_bridged_networking
   need_clear_repos
   have_scc_repos
   load_svirt_vm_setup_tests
@@ -65,7 +63,6 @@ our @EXPORT = qw(
   consolestep_is_applicable
   rescuecdstep_is_applicable
   bootencryptstep_is_applicable
-  addon_products_is_applicable
   we_is_applicable
   remove_common_needles
   remove_desktop_needles
@@ -188,21 +185,6 @@ sub have_addn_repos {
       && !get_var("EVERGREEN")
       && get_var("SUSEMIRROR")
       && !get_var("FLAVOR", '') =~ m/^Staging2?[\-]DVD$/;
-}
-
-sub is_staging {
-    return get_var('STAGING');
-}
-
-sub is_bridged_networking {
-    my $ret = 0;
-    if (check_var('BACKEND', 'svirt') and !check_var('ARCH', 's390x')) {
-        my $vmm_family = get_required_var('VIRSH_VMM_FAMILY');
-        $ret = ($vmm_family =~ /xen|vmware|hyperv/);
-    }
-    # Some needles match hostname which we can't set permanently with bridge.
-    set_var('BRIDGED_NETWORKING', 1) if $ret;
-    return $ret;
 }
 
 sub is_livesystem {
@@ -521,10 +503,6 @@ sub installyaststep_is_applicable {
     return !get_var("NOINSTALL") && !get_var("RESCUECD") && !get_var("ZDUP");
 }
 
-sub noupdatestep_is_applicable {
-    return !get_var("UPGRADE");
-}
-
 sub kdestep_is_applicable {
     return check_var("DESKTOP", "kde");
 }
@@ -544,10 +522,6 @@ sub rescuecdstep_is_applicable {
 
 sub ssh_key_import {
     return get_var("SSH_KEY_IMPORT") || get_var("SSH_KEY_DO_NOT_IMPORT");
-}
-
-sub addon_products_is_applicable {
-    return !get_var("LIVECD") && get_var("ADDONURL");
 }
 
 sub we_is_applicable {
@@ -1470,7 +1444,7 @@ sub load_x11regression_installation {
     loadtest "x11regressions/x11regressions_setup";
     # temporary adding test modules which applies hacks for missing parts in sle15
     loadtest "console/sle15_workarounds" if is_sle and sle_version_at_least('15');
-    loadtest "console/hostname" unless is_bridged_networking;
+    loadtest "console/hostname"       unless is_bridged_networking;
     loadtest "console/force_cron_run" unless is_jeos;
     loadtest "shutdown/grub_set_bootargs";
     loadtest "shutdown/shutdown";
@@ -1651,7 +1625,7 @@ sub load_create_hdd_tests {
     return unless get_var('INSTALLONLY');
     # temporary adding test modules which applies hacks for missing parts in sle15
     loadtest 'console/sle15_workarounds' if is_sle && sle_version_at_least('15');
-    loadtest 'console/hostname' unless is_bridged_networking;
+    loadtest 'console/hostname'       unless is_bridged_networking;
     loadtest 'console/force_cron_run' unless is_jeos;
     loadtest 'console/scc_deregistration' if get_var('SCC_DEREGISTER');
     loadtest 'shutdown/grub_set_bootargs';

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -27,7 +27,10 @@ our @EXPORT = qw (
   is_jeos
   is_krypton_argon
   is_leap
+  is_opensuse
   is_sle
+  is_sles4sap
+  is_sles4sap_standard
   is_tumbleweed
   is_storage_ng
   is_upgrade
@@ -119,9 +122,22 @@ sub is_leap {
     return 1 if get_var('VERSION', '') =~ /[0-9]{2,}\.[0-9]/;
 }
 
+sub is_opensuse {
+    return 0 unless check_var('DISTRI', 'opensuse');
+    return 1;
+}
+
 sub is_sle {
     return 0 unless check_var('DISTRI', 'sle');
     return 1;
+}
+
+sub is_sles4sap {
+    return get_var('FLAVOR', '') =~ /SAP/ || check_var('SLE_PRODUCT', 'sles4sap');
+}
+
+sub is_sles4sap_standard {
+    return is_sles4sap && check_var('SLES4SAP_MODE', 'sles');
 }
 
 sub is_storage_ng {

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -29,6 +29,7 @@ our @EXPORT = qw (
   is_leap
   is_opensuse
   is_sle
+  is_staging
   is_sles4sap
   is_sles4sap_standard
   is_tumbleweed
@@ -138,6 +139,10 @@ sub is_sles4sap {
 
 sub is_sles4sap_standard {
     return is_sles4sap && check_var('SLES4SAP_MODE', 'sles');
+}
+
+sub is_staging {
+    return get_var('STAGING');
 }
 
 sub is_storage_ng {

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -43,7 +43,7 @@ if (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')
     set_var('SERIALDEV', 'hvc0');
 }
 
-sub load_boot_tests {
+sub load_kubic_boot_tests {
     if (is_caasp 'DVD') {
         if (get_var("UEFI")) {
             loadtest 'installation/bootloader_uefi';
@@ -174,7 +174,7 @@ if (get_var('STACK_ROLE')) {
         loadtest "support_server/setup";
     }
     else {
-        load_boot_tests;
+        load_kubic_boot_tests;
         load_inst_tests if is_caasp('DVD');
         loadtest 'caasp/first_boot';
     }
@@ -182,7 +182,7 @@ if (get_var('STACK_ROLE')) {
 }
 else {
     # ==== MicroOS tests ====
-    load_boot_tests;
+    load_kubic_boot_tests;
     if (is_caasp 'DVD') {
         if (get_var('EXTRA', '') =~ /RCSHELL/) {
             load_rcshell_tests;

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -43,7 +43,7 @@ if (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')
     set_var('SERIALDEV', 'hvc0');
 }
 
-sub load_kubic_boot_tests {
+sub load_caasp_boot_tests {
     if (is_caasp 'DVD') {
         if (get_var("UEFI")) {
             loadtest 'installation/bootloader_uefi';
@@ -67,7 +67,7 @@ sub load_kubic_boot_tests {
 }
 
 # One-click installer - fate#322328
-sub load_inst_tests {
+sub load_caasp_inst_tests {
     if (get_var 'AUTOYAST') {
         loadtest 'autoyast/installation';
     }
@@ -174,21 +174,21 @@ if (get_var('STACK_ROLE')) {
         loadtest "support_server/setup";
     }
     else {
-        load_kubic_boot_tests;
-        load_inst_tests if is_caasp('DVD');
+        load_caasp_boot_tests;
+        load_caasp_inst_tests if is_caasp('DVD');
         loadtest 'caasp/first_boot';
     }
     load_stack_tests;
 }
 else {
     # ==== MicroOS tests ====
-    load_kubic_boot_tests;
+    load_caasp_boot_tests;
     if (is_caasp 'DVD') {
         if (get_var('EXTRA', '') =~ /RCSHELL/) {
             load_rcshell_tests;
             return 1;
         }
-        load_inst_tests;
+        load_caasp_inst_tests;
         return 1 if get_var 'FAIL_EXPECTED';
     }
     loadtest 'caasp/first_boot';

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -705,6 +705,13 @@ sub load_slenkins_tests {
     return 0;
 }
 
+sub load_default_tests {
+    load_boot_tests();
+    load_inst_tests();
+    return 1 if get_var('EXIT_AFTER_START_INSTALL');
+    load_reboot_tests();
+}
+
 # load the tests in the right order
 if (is_kernel_test()) {
     load_kernel_tests();
@@ -887,10 +894,7 @@ else {
         }
     }
     else {
-        load_boot_tests();
-        load_inst_tests();
-        return 1 if get_var('EXIT_AFTER_START_INSTALL');
-        load_reboot_tests();
+        load_default_tests;
     }
 
     unless (install_online_updates()

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -287,33 +287,6 @@ sub load_inst_tests {
     loadtest "installation/install_and_reboot";
 }
 
-sub load_reboot_tests {
-    if (check_var('ARCH', 's390x')) {
-        loadtest "installation/reconnect_s390";
-    }
-    if (installyaststep_is_applicable()) {
-        # s390 has no 'grub' that can be easily checked
-        if (!check_var('ARCH', 's390x')) {
-            loadtest "installation/grub_test";
-        }
-        if (get_var('ENCRYPT')) {
-            loadtest "installation/boot_encrypt";
-        }
-        if ((snapper_is_applicable()) && get_var("BOOT_TO_SNAPSHOT")) {
-            loadtest "installation/boot_into_snapshot";
-            if (get_var("UPGRADE")) {
-                loadtest "installation/snapper_rollback";
-            }
-        }
-        loadtest "installation/first_boot";
-    }
-
-    if (get_var("DUALBOOT")) {
-        loadtest "installation/reboot_eject_cd";
-        loadtest "installation/boot_windows";
-    }
-}
-
 sub load_fixup_network {
     # openSUSE 13.2's (and earlier) systemd has broken rules for virtio-net, not applying predictable names (despite being configured)
     # A maintenance update breaking networking names sounds worse than just accepting that 13.2 -> TW breaks with virtio-net

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -13,6 +13,7 @@ use warnings;
 use testapi qw(check_var get_var get_required_var set_var);
 use lockapi;
 use needle;
+use version_utils qw(is_opensuse is_sle);
 use File::Find;
 use File::Basename;
 
@@ -20,7 +21,8 @@ BEGIN {
     unshift @INC, dirname(__FILE__) . '/../../lib';
 }
 use utils;
-use version_utils qw(is_jeos is_gnome_next is_krypton_argon is_leap is_tumbleweed is_rescuesystem leap_version_at_least is_desktop_installed);
+use version_utils
+  qw(is_jeos is_gnome_next is_krypton_argon is_leap is_tumbleweed is_rescuesystem leap_version_at_least is_desktop_installed is_opensuse is_sle);
 use main_common;
 
 init_main();
@@ -129,26 +131,6 @@ logcurrentenv(
       LIVECD NETBOOT NOIMAGES QEMUVGA SPLITUSR VIDEOMODE)
 );
 
-sub is_server {
-    return (check_var('ARCH', 'aarch64') || get_var("OFW") || check_var("FLAVOR", "Server-DVD"));
-}
-
-sub is_livesystem {
-    return (check_var("FLAVOR", 'Rescue-CD') || get_var("LIVETEST"));
-}
-
-sub is_kde_live {
-    return get_var('FLAVOR', '') =~ /KDE-Live/;
-}
-
-sub xfcestep_is_applicable {
-    return check_var("DESKTOP", "xfce");
-}
-
-sub installwithaddonrepos_is_applicable {
-    return get_var("HAVE_ADDON_REPOS") && !get_var("UPGRADE") && !get_var("NET");
-}
-
 sub updates_is_applicable {
     # we don't want live systems to run out of memory or virtual disk space.
     # Applying updates on a live system would not be persistent anyway.
@@ -161,130 +143,8 @@ sub guiupdates_is_applicable {
     return get_var("DESKTOP") =~ /gnome|kde|xfce|lxde/ && !check_var("FLAVOR", "Rescue-CD");
 }
 
-sub packagekit_available {
-    return !check_var('FLAVOR', 'Rescue-CD') && !is_staging;
-}
-
-sub lxdestep_is_applicable {
-    return check_var("DESKTOP", "lxde");
-}
-
-sub need_clear_repos {
-    return is_staging();
-}
-
 sub have_addn_repos {
     return !get_var("NET") && !get_var("EVERGREEN") && get_var("SUSEMIRROR") && !is_staging();
-}
-
-sub load_inst_tests {
-    loadtest "installation/welcome";
-    loadtest "installation/keyboard_selection";
-    if (check_var('ARCH', 's390x')) {
-        loadtest "installation/disk_activation";
-    }
-    if (get_var("MULTIPATH")) {
-        loadtest "installation/multipath";
-    }
-    if (get_var('ENCRYPT_CANCEL_EXISTING') || get_var('ENCRYPT_ACTIVATE_EXISTING')) {
-        loadtest "installation/encrypted_volume_activation";
-    }
-    if (noupdatestep_is_applicable() && !get_var("LIVECD")) {
-        loadtest "installation/installation_mode";
-    }
-    if (!get_var("LIVECD") && get_var("UPGRADE")) {
-        loadtest "installation/upgrade_select";
-        if (check_var("UPGRADE", "LOW_SPACE")) {
-            loadtest "installation/disk_space_fill";
-        }
-        loadtest "installation/upgrade_select_opensuse";
-    }
-    if (noupdatestep_is_applicable()) {
-        # Krypton/Argon disable the network configuration stage
-        if (get_var("LIVECD") && !is_krypton_argon) {
-            loadtest "installation/livecd_network_settings";
-        }
-        loadtest "installation/partitioning";
-        if (get_var("ISO_IN_EXTERNAL_DRIVE")) {
-            loadtest "installation/partitioning_firstdisk";
-        }
-        if (defined(get_var("RAIDLEVEL"))) {
-            loadtest "installation/partitioning_raid";
-        }
-        elsif (check_var('LVM', 0) && get_var('ENCRYPT')) {
-            loadtest 'installation/partitioning_crypt_no_lvm';
-        }
-        elsif (get_var("LVM")) {
-            loadtest "installation/partitioning_lvm";
-        }
-        if (get_var("FILESYSTEM")) {
-            if (get_var('PARTITIONING_WARNINGS')) {
-                loadtest 'installation/partitioning_warnings';
-            }
-            loadtest "installation/partitioning_filesystem";
-        }
-        if (get_var("TOGGLEHOME")) {
-            loadtest "installation/partitioning_togglehome";
-            if (get_var('LVM') && get_var('RESIZE_ROOT_VOLUME')) {
-                loadtest "installation/partitioning_resize_root";
-            }
-        }
-        if (get_var("EXPERTPARTITIONER")) {
-            loadtest "installation/partitioning_expert";
-        }
-        if (get_var("SPLITUSR")) {
-            loadtest "installation/partitioning_splitusr";
-        }
-        if (get_var("DELETEWINDOWS")) {
-            loadtest "installation/partitioning_guided";
-        }
-        loadtest "installation/partitioning_finish";
-        loadtest "installation/installer_timezone";
-    }
-    if (installwithaddonrepos_is_applicable() && !get_var("LIVECD")) {
-        loadtest "installation/setup_online_repos";
-    }
-    if (addon_products_is_applicable() && !leap_version_at_least('42.3')) {
-        loadtest "installation/addon_products";
-    }
-    if (noupdatestep_is_applicable() && !get_var("LIVECD") && !get_var("REMOTE_CONTROLLER")) {
-        loadtest "installation/logpackages";
-    }
-    if (noupdatestep_is_applicable()) {
-        loadtest "installation/disable_online_repos" if get_var('DISABLE_ONLINE_REPOS');
-        loadtest "installation/installer_desktopselection";
-        if (get_var('IMPORT_USER_DATA')) {
-            loadtest 'installation/user_import';
-        }
-        else {
-            loadtest "installation/user_settings";
-        }
-        if (get_var("DOCRUN") || get_var("IMPORT_USER_DATA") || get_var("ROOTONLY")) {    # root user
-            loadtest "installation/user_settings_root";
-        }
-    }
-    if (noupdatestep_is_applicable()) {
-        if (get_var('PATTERNS') || get_var('PACKAGES')) {
-            loadtest "installation/installation_overview_before";
-            loadtest "installation/select_patterns_and_packages";
-        }
-        loadtest "installation/disable_grub_timeout";
-    }
-    if (get_var("UEFI") && get_var("SECUREBOOT")) {
-        loadtest "installation/secure_boot";
-    }
-    if (installyaststep_is_applicable()) {
-        loadtest "installation/installation_overview";
-        if (check_var("UPGRADE", "LOW_SPACE")) {
-            loadtest "installation/disk_space_release";
-        }
-        if (ssh_key_import) {
-            loadtest "installation/ssh_key_setup";
-        }
-        loadtest "installation/start_install";
-    }
-    return 1 if get_var('EXIT_AFTER_START_INSTALL');
-    loadtest "installation/install_and_reboot";
 }
 
 sub load_fixup_network {
@@ -318,98 +178,6 @@ sub load_consoletests_minimal {
     loadtest "console/hostname";
     if (!get_var("LIVETEST")) {
         loadtest "console/yast2_bootloader";
-    }
-    loadtest "console/consoletest_finish";
-}
-
-sub load_consoletests {
-    return unless consolestep_is_applicable();
-    loadtest "console/consoletest_setup";
-    loadtest "console/force_cron_run" if !is_jeos;
-    if (get_var("LOCK_PACKAGE")) {
-        loadtest "console/check_locked_package";
-    }
-    loadtest "console/textinfo";
-    loadtest "console/hostname";
-    replace_opensuse_repos_tests if get_var('DISABLE_ONLINE_REPOS');
-    if (snapper_is_applicable()) {
-        if (get_var("UPGRADE")) {
-            loadtest "console/upgrade_snapshots";
-        }
-        else {
-            loadtest "console/installation_snapshots";
-        }
-    }
-    if (get_var("DESKTOP") !~ /textmode/) {
-        loadtest "console/xorg_vt";
-    }
-    loadtest "console/zypper_lr";
-    loadtest 'console/enable_usb_repo' if check_var('USBBOOT', 1);
-    # If DISABLE_ONLINE_REPOS, mirror repo is already added
-    if (have_addn_repos && !get_var('DISABLE_ONLINE_REPOS')) {
-        loadtest "console/zypper_ar";
-    }
-    loadtest "console/zypper_ref";
-    loadtest "console/ncurses";
-    loadtest "console/yast2_lan";
-    # no local certificate store
-    if (!is_krypton_argon) {
-        loadtest "console/curl_https";
-    }
-    if (   check_var('ARCH', 'x86_64')
-        || check_var('ARCH', 'i686')
-        || check_var('ARCH', 'i586'))
-    {
-        loadtest "console/glibc_sanity";
-    }
-    loadtest "console/zypper_in";
-    loadtest "console/yast2_i";
-    if (!get_var("LIVETEST")) {
-        loadtest "console/yast2_bootloader";
-    }
-    loadtest "console/vim";
-    # textmode install comes without firewall by default atm
-    if (!check_var("DESKTOP", "textmode") && !is_staging() && !is_krypton_argon) {
-        loadtest "console/firewall_enabled";
-    }
-    if (is_jeos) {
-        loadtest "console/gpt_ptable";
-        loadtest "console/kdump_disabled";
-        loadtest "console/sshd_running";
-    }
-    loadtest "console/sshd";
-    loadtest "console/ssh_cleanup";
-    if (!get_var("LIVETEST") && !is_staging() && !is_jeos) {
-        # in live we don't have a password for root so ssh doesn't
-        # work anyways, and except staging_core image, the rest of
-        # staging_* images don't need run this test case
-        #
-        # On JeOS we don't have fuse.ko in kernel-default-base package.
-        loadtest "console/sshfs";
-    }
-    loadtest "console/mtab";
-    if (!get_var("NOINSTALL") && !get_var("LIVETEST") && (check_var("DESKTOP", "textmode"))) {
-        if (check_var('BACKEND', 'qemu') && !is_jeos) {
-            # The NFS test expects the IP to be 10.0.2.15
-            loadtest "console/yast2_nfs_server";
-        }
-        loadtest "console/http_srv";
-        loadtest "console/mysql_srv";
-        loadtest "console/dns_srv";
-        if (!is_staging) {
-            loadtest "console/mysql_odbc";
-            if (is_leap && !leap_version_at_least('15.0')) {
-                loadtest "console/php5";
-                loadtest "console/php5_mysql";
-                loadtest "console/php5_postgresql96";
-            }
-        }
-        loadtest "console/php7";
-        loadtest "console/php7_mysql";
-        loadtest "console/php7_postgresql96";
-    }
-    if (check_var("DESKTOP", "xfce")) {
-        loadtest "console/xfce_gnome_deps";
     }
     loadtest "console/consoletest_finish";
 }
@@ -450,129 +218,6 @@ sub load_lxqt_tests {
 
 sub load_mate_tests {
     loadtest "x11/mate_terminal";
-}
-
-sub load_x11tests {
-    return unless (!get_var("INSTALLONLY") && is_desktop_installed() && !get_var("DUALBOOT") && !get_var("RESCUECD"));
-
-    loadtest "x11/user_gui_login" unless get_var("LIVETEST") || get_var("NOAUTOLOGIN");
-    if (get_var("XDMUSED")) {
-        loadtest "x11/x11_login";
-    }
-    if (kdestep_is_applicable() && get_var("WAYLAND")) {
-        loadtest "x11/start_wayland_plasma5";
-    }
-    if (xfcestep_is_applicable()) {
-        loadtest "x11/xfce4_terminal";
-    }
-    loadtest "x11/xterm";
-    loadtest "x11/sshxterm" unless get_var("LIVETEST");
-    if (gnomestep_is_applicable()) {
-        loadtest "x11/gnome_control_center";
-        loadtest "x11/gnome_tweak_tool";
-        loadtest "x11/gnome_terminal";
-        loadtest "x11/gedit";
-    }
-    if (kdestep_is_applicable() && !is_kde_live) {
-        loadtest "x11/kate";
-    }
-    # no firefox on KDE-Live # boo#1022499
-    loadtest "x11/firefox" unless is_kde_live;
-    if (!get_var("OFW") && check_var('BACKEND', 'qemu') && !check_var('FLAVOR', 'Rescue-CD') && !is_kde_live) {
-        loadtest "x11/firefox_audio";
-    }
-    if (gnomestep_is_applicable() && !(get_var("LIVECD") || is_server)) {
-        loadtest "x11/thunderbird";
-    }
-    if (chromiumstep_is_applicable() && !(is_staging() || is_livesystem)) {
-        loadtest "x11/chromium";
-    }
-    if (xfcestep_is_applicable()) {
-        loadtest "x11/midori" unless (is_staging || is_livesystem);
-        loadtest "x11/ristretto";
-    }
-    if (gnomestep_is_applicable()) {
-        loadtest "x11/eog";
-    }
-    if (get_var("DESKTOP") =~ /kde|gnome/ && !get_var("LIVECD") && !is_server) {
-        loadtest "x11/oomath";
-        loadtest "x11/oocalc";
-    }
-    if (get_var("DESKTOP") =~ /kde|gnome/ && !is_server && !is_kde_live && !is_krypton_argon && !is_gnome_next) {
-        loadtest "x11/ooffice";
-    }
-    if (kdestep_is_applicable()) {
-        loadtest "x11/khelpcenter";
-        if (get_var("PLASMA5")) {
-            loadtest "x11/systemsettings5";
-        }
-        else {
-            loadtest "x11/systemsettings";
-        }
-        loadtest "x11/dolphin";
-    }
-    if (snapper_is_applicable()) {
-        loadtest "x11/yast2_snapper";
-    }
-    if (xfcestep_is_applicable()) {
-        loadtest "x11/thunar";
-        if (!get_var("USBBOOT") && !is_livesystem) {
-            loadtest "x11/reboot_xfce";
-        }
-    }
-    if (lxdestep_is_applicable()) {
-        if (!get_var("USBBOOT") && !is_livesystem) {
-            loadtest "x11/reboot_lxde";
-        }
-    }
-    loadtest "x11/glxgears" if (packagekit_available && !get_var('LIVECD'));
-    if (kdestep_is_applicable()) {
-        if (!is_krypton_argon && !is_kde_live) {
-            loadtest "x11/amarok";
-        }
-        loadtest "x11/kontact" unless is_kde_live;
-        if (!get_var("USBBOOT") && !is_livesystem) {
-            if (get_var("PLASMA5")) {
-                loadtest "x11/reboot_plasma5";
-            }
-            else {
-                loadtest "x11/reboot_kde";
-            }
-        }
-    }
-    if (gnomestep_is_applicable()) {
-        loadtest "x11/nautilus" unless get_var("LIVECD");
-        loadtest "x11/gnome_music";
-        loadtest "x11/evolution" unless is_server;
-        if (!get_var("USBBOOT") && !is_livesystem) {
-            loadtest "x11/reboot_gnome";
-        }
-        load_testdir('x11/gnomeapps') if is_gnome_next;
-    }
-    loadtest "x11/desktop_mainmenu";
-
-    if (xfcestep_is_applicable()) {
-        loadtest "x11/xfce4_appfinder";
-        if (!(get_var("FLAVOR") eq 'Rescue-CD')) {
-            loadtest "x11/xfce_lightdm_logout_login";
-        }
-    }
-
-    unless (get_var("LIVECD")) {
-        loadtest "x11/inkscape";
-        loadtest "x11/gimp";
-    }
-    if (   !is_staging()
-        && !is_livesystem)
-    {
-        loadtest "x11/gnucash";
-        loadtest "x11/hexchat";
-        loadtest "x11/vlc";
-    }
-    # Need to skip shutdown to keep backend alive if running rollback tests after migration
-    unless (get_var('ROLLBACK_AFTER_MIGRATION')) {
-        loadtest "x11/shutdown";
-    }
 }
 
 sub install_online_updates {
@@ -728,35 +373,17 @@ elsif (get_var('NFV')) {
     load_nfv_tests();
 }
 elsif (get_var("REGRESSION")) {
-    if (check_var("REGRESSION", "installation")) {
-        set_var('NOAUTOLOGIN', 1);
-        load_boot_tests();
-        load_inst_tests();
-        load_reboot_tests();
-        loadtest "x11regressions/x11regressions_setup";
-        loadtest "console/hostname";
-        loadtest "console/force_cron_run";
-        loadtest "shutdown/grub_set_bootargs";
-        loadtest "shutdown/shutdown";
-    }
-    elsif (check_var("REGRESSION", "documentation")) {
-        loadtest "boot/boot_to_desktop";
-        load_x11regression_documentation();
-    }
-    elsif (check_var("REGRESSION", "gnome")) {
-        loadtest "boot/boot_to_desktop";
-        load_x11regression_gnome();
-    }
-    elsif (check_var("REGRESSION", "other")) {
-        loadtest "boot/boot_to_desktop";
-        load_x11regression_other();
-    }
+    load_common_x11regression;
 }
 elsif (is_mediacheck) {
+    load_svirt_vm_setup_tests;
     loadtest "installation/mediacheck";
 }
 elsif (is_memtest) {
-    loadtest "installation/memtest";
+    if (!get_var("OFW")) {    #no memtest on PPC
+        load_svirt_vm_setup_tests;
+        loadtest "installation/memtest";
+    }
 }
 elsif (get_var("FILESYSTEM_TEST")) {
     boot_hdd_image;
@@ -803,15 +430,7 @@ elsif (get_var("WINDOWS")) {
     loadtest "installation/win10_shutdown";
 }
 elsif (ssh_key_import) {
-    loadtest "boot/boot_to_desktop";
-    # setup ssh key, we know what ssh keys we have and can verify if they are imported or not
-    loadtest "x11/ssh_key_check";
-    # reboot after test specific setup and start installation/update
-    loadtest "x11/reboot_and_install";
-    load_inst_tests();
-    load_reboot_tests();
-    # verify previous defined ssh keys
-    loadtest "x11/ssh_key_verify";
+    load_ssh_key_import_tests;
 }
 elsif (get_var("ISO_IN_EXTERNAL_DRIVE")) {
     load_iso_in_external_tests();

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -22,7 +22,7 @@ BEGIN {
 }
 use utils;
 use version_utils
-  qw(is_jeos is_gnome_next is_krypton_argon is_leap is_tumbleweed is_rescuesystem leap_version_at_least is_desktop_installed is_opensuse is_sle);
+  qw(is_jeos is_gnome_next is_krypton_argon is_leap is_tumbleweed is_rescuesystem leap_version_at_least is_desktop_installed is_opensuse is_sle is_staging);
 use main_common;
 
 init_main();

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -177,29 +177,6 @@ sub have_addn_repos {
     return !get_var("NET") && !get_var("EVERGREEN") && get_var("SUSEMIRROR") && !is_staging();
 }
 
-sub load_boot_tests {
-    if (get_var("ISO_MAXSIZE")) {
-        loadtest "installation/isosize";
-    }
-    if (get_var("OFW")) {
-        loadtest "installation/bootloader_ofw";
-    }
-    elsif (get_var("UEFI") || is_jeos) {
-        # TODO: rename to bootloader_grub2
-        loadtest "installation/bootloader_uefi";
-    }
-    elsif (get_var("IPMI_HOSTNAME")) {    # abuse of variable for now
-        loadtest "installation/qa_net";
-    }
-    elsif (get_var("PXEBOOT")) {
-        set_var("DELAYED_START", "1");
-        loadtest "autoyast/pxe_boot";
-    }
-    else {
-        loadtest "installation/bootloader" unless load_bootloader_s390x();
-    }
-}
-
 sub load_inst_tests {
     loadtest "installation/welcome";
     loadtest "installation/keyboard_selection";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -730,37 +730,6 @@ sub load_inst_tests {
 
 }
 
-sub load_reboot_tests {
-    # there is encryption passphrase prompt which is handled in installation/boot_encrypt
-    if (check_var("ARCH", "s390x") && !(get_var('ENCRYPT') && check_var('BACKEND', 'svirt'))) {
-        loadtest "installation/reconnect_s390";
-    }
-    if (uses_qa_net_hardware()) {
-        loadtest "boot/qa_net_boot_from_hdd";
-    }
-    if (installyaststep_is_applicable()) {
-        # test makes no sense on s390 because grub2 can't be captured
-        if (!(check_var("ARCH", "s390x") or (check_var('VIRSH_VMM_FAMILY', 'xen') and check_var('VIRSH_VMM_TYPE', 'linux')))) {
-            loadtest "installation/grub_test";
-            if ((snapper_is_applicable()) && get_var("BOOT_TO_SNAPSHOT")) {
-                loadtest "installation/boot_into_snapshot";
-            }
-        }
-        if (get_var('ENCRYPT')) {
-            loadtest "installation/boot_encrypt";
-            # reconnect after installation/boot_encrypt
-            if (check_var('BACKEND', 'svirt') && check_var('ARCH', 's390x')) {
-                loadtest "installation/reconnect_s390";
-            }
-        }
-        loadtest "installation/first_boot";
-    }
-    if (get_var("DUALBOOT")) {
-        loadtest "installation/reboot_eject_cd";
-        loadtest "installation/boot_windows";
-    }
-}
-
 sub load_consoletests {
     return unless consolestep_is_applicable();
     if (get_var("ADDONS", "") =~ /rt/) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -7,6 +7,7 @@
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
+
 use strict;
 use warnings;
 use testapi qw(check_var get_var get_required_var set_var check_var_array diag);
@@ -27,36 +28,6 @@ use main_common;
 
 init_main();
 
-sub is_server {
-    return 1 if is_sles4sap();
-    return 1 if get_var('FLAVOR', '') =~ /^Server/;
-    return 0 unless is_leanos();
-    return check_var('SLE_PRODUCT', 'sles');
-}
-
-sub is_desktop {
-    return get_var('FLAVOR', '') =~ /^Desktop/ || check_var('SLE_PRODUCT', 'sled');
-}
-
-sub is_leanos {
-    return 1 if get_var('FLAVOR', '') =~ /^Leanos/;
-    return 1 if get_var('FLAVOR', '') =~ /^Installer-/;
-    return 0;
-}
-
-sub is_sles4sap {
-    return get_var('FLAVOR', '') =~ /SAP/ || check_var('SLE_PRODUCT', 'sles4sap');
-}
-
-sub is_sles4sap_standard {
-    return is_sles4sap && check_var('SLES4SAP_MODE', 'sles');
-}
-
-sub is_smt {
-    # Smt is replaced with rmt in SLE 15, see bsc#1061291
-    return ((get_var("PATTERNS", '') || get_var('HDD_1', '')) =~ /smt/) && !sle_version_at_least('15');
-}
-
 sub is_updates_tests {
     my $flavor = get_required_var('FLAVOR');
     # Incidents might be also Incidents-Gnome or Incidents-Kernel
@@ -69,31 +40,6 @@ sub is_new_installation {
 
 sub is_update_test_repo_test {
     return get_var('TEST') !~ /^mru-/ && is_updates_tests && get_required_var('FLAVOR') !~ /-Minimal$/;
-}
-
-sub is_desktop_module_selected {
-    # desktop applications module is selected if following variables have following values:
-    # productivity and ha require desktop applications, so it's preselected
-    # same is true for sles4sap
-    return
-         get_var('ADDONS', '') =~ /all-packages|desktop|we/
-      || get_var('WORKAROUND_MODULES', '') =~ /desktop|we/
-      || get_var('ADDONURL',           '') =~ /desktop|we/
-      || get_var('SCC_ADDONS',         '') =~ /desktop|we|productivity|ha/
-      || is_sles4sap;
-}
-
-sub default_desktop {
-    return undef   if get_var('VERSION', '') lt '12';
-    return 'gnome' if get_var('VERSION', '') lt '15';
-    # with SLE 15 LeanOS only the default is textmode
-    return 'gnome' if get_var('BASE_VERSION', '') =~ /^12/;
-    return 'textmode' if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'));
-    return 'gnome' if is_desktop_module_selected;
-    # default system role for sles and sled
-    return 'textmode' if is_server || !get_var('SCC_REGISTER') || !check_var('SCC_REGISTER', 'installation');
-    # remaining cases are is_desktop and check_var('SCC_REGISTER', 'installation'), hence gnome
-    return 'gnome';
 }
 
 sub cleanup_needles {
@@ -415,38 +361,6 @@ logcurrentenv(
       SLE_PRODUCT SPLITUSR VIDEOMODE)
 );
 
-
-sub need_clear_repos {
-    return get_var("FLAVOR", '') =~ m/^Staging2?[\-]DVD$/ && get_var("SUSEMIRROR");
-}
-
-sub have_scc_repos {
-    return check_var('SCC_REGISTER', 'console');
-}
-
-sub have_addn_repos {
-    return
-         !get_var("NET")
-      && !get_var("EVERGREEN")
-      && get_var("SUSEMIRROR")
-      && !get_var("FLAVOR", '') =~ m/^Staging2?[\-]DVD$/;
-}
-
-sub rt_is_applicable {
-    return is_server() && get_var("ADDONS", "") =~ /rt/;
-}
-
-sub we_is_applicable {
-    return
-         is_server()
-      && (get_var("ADDONS", "") =~ /we/ or get_var("SCC_ADDONS", "") =~ /we/ or get_var("ADDONURL", "") =~ /we/)
-      && get_var('MIGRATION_REMOVE_ADDONS', '') !~ /we/;
-}
-
-sub uses_qa_net_hardware {
-    return check_var("BACKEND", "ipmi") || check_var("BACKEND", "generalhw");
-}
-
 sub load_x11regression_firefox {
     loadtest "x11regressions/firefox/firefox_smoke";
     loadtest "x11regressions/firefox/firefox_localfiles";
@@ -520,413 +434,6 @@ sub load_x11regression_remote {
     }
     elsif (check_var('REMOTE_DESKTOP_TYPE', 'vino_client')) {
         loadtest 'x11regressions/remote_desktop/vino_client';
-    }
-}
-
-sub install_this_version {
-    return !check_var('INSTALL_TO_OTHERS', 1);
-}
-
-sub load_inst_tests {
-    loadtest "installation/welcome";
-    loadtest "installation/keyboard_selection";
-    if (get_var('DUD_ADDONS')) {
-        loadtest "installation/dud_addon";
-    }
-    if (sle_version_at_least('15')) {
-        loadtest "installation/accept_license" if get_var('HASLICENSE');
-    }
-    if (get_var('IBFT')) {
-        loadtest "installation/iscsi_configuration";
-    }
-    if (check_var('ARCH', 's390x')) {
-        if (check_var('BACKEND', 's390x')) {
-            loadtest "installation/disk_activation";
-        }
-        elsif (!sle_version_at_least('12-SP2')) {
-            loadtest "installation/skip_disk_activation";
-        }
-    }
-    if (get_var('ENCRYPT_CANCEL_EXISTING') || get_var('ENCRYPT_ACTIVATE_EXISTING')) {
-        loadtest "installation/encrypted_volume_activation";
-    }
-    if (get_var('MULTIPATH')) {
-        loadtest "installation/multipath";
-    }
-    if (get_var('UPGRADE')) {
-        loadtest "installation/upgrade_select";
-        if (check_var("UPGRADE", "LOW_SPACE")) {
-            loadtest "installation/disk_space_fill";
-        }
-    }
-    # SCC registration is not required in media based upgrade since SLE15
-    unless (is_sle && sle_version_at_least('15') && get_var('MEDIA_UPGRADE')) {
-        if (check_var('SCC_REGISTER', 'installation')) {
-            loadtest "installation/scc_registration";
-        }
-        else {
-            loadtest "installation/skip_registration" unless check_var('SLE_PRODUCT', 'leanos');
-        }
-    }
-    if (is_sles4sap and !sle_version_at_least('15')) {
-        loadtest "installation/sles4sap_product_installation_mode";
-    }
-    if (get_var('MAINT_TEST_REPO')) {
-        loadtest 'installation/add_update_test_repo';
-    }
-    loadtest "installation/addon_products_sle";
-    if (get_var('CHECK_RELEASENOTES_ORIGIN')) {
-        loadtest 'installation/releasenotes_origin';
-    }
-    if (noupdatestep_is_applicable()) {
-        #system_role selection during installation was added as a new feature since sles12sp2
-        #so system_role.pm should be loaded for all tests that actually install to versions over sles12sp2
-        #no matter with or without INSTALL_TO_OTHERS tag
-        if (   check_var('ARCH', 'x86_64')
-            && sle_version_at_least('12-SP2')
-            && is_server()
-            && (!is_sles4sap() || is_sles4sap_standard())
-            && (install_this_version() || install_to_other_at_least('12-SP2'))
-            || sle_version_at_least('15'))
-        {
-            loadtest "installation/system_role";
-        }
-        if (is_sles4sap() and sle_version_at_least('15') and check_var('SYSTEM_ROLE', 'default')) {
-            loadtest "installation/sles4sap_product_installation_mode";
-        }
-        loadtest "installation/partitioning";
-        if (defined(get_var("RAIDLEVEL"))) {
-            loadtest "installation/partitioning_raid";
-        }
-        elsif (check_var('LVM', 0) && get_var('ENCRYPT')) {
-            loadtest 'installation/partitioning_crypt_no_lvm';
-        }
-        elsif (get_var("LVM")) {
-            loadtest "installation/partitioning_lvm";
-        }
-        elsif (get_var('FULL_LVM_ENCRYPT')) {
-            loadtest 'installation/partitioning_full_lvm';
-        }
-        if (get_var("FILESYSTEM")) {
-            if (get_var('PARTITIONING_WARNINGS')) {
-                loadtest 'installation/partitioning_warnings';
-            }
-            loadtest "installation/partitioning_filesystem";
-        }
-        if (get_var("TOGGLEHOME")) {
-            loadtest "installation/partitioning_togglehome";
-            if (get_var('LVM') && get_var('RESIZE_ROOT_VOLUME')) {
-                loadtest "installation/partitioning_resize_root";
-            }
-        }
-        if (get_var("ENLARGESWAP") && get_var("QEMURAM", 1024) > 4098) {
-            loadtest "installation/installation_enlargeswap";
-        }
-
-        if (get_var("SPLITUSR")) {
-            loadtest "installation/partitioning_splitusr";
-        }
-        if (get_var("IBFT")) {
-            loadtest "installation/partitioning_iscsi";
-        }
-        if (uses_qa_net_hardware() || get_var('SELECT_FIRST_DISK') || get_var("ISO_IN_EXTERNAL_DRIVE")) {
-            loadtest "installation/partitioning_firstdisk";
-        }
-        loadtest "installation/partitioning_finish";
-    }
-    # the VNC gadget is too unreliable to click, but we
-    # need to be able to do installations on it. The release notes
-    # functionality needs to be covered by other backends
-    # Skip release notes test on sle 15 if have addons
-    if (!check_var('BACKEND', 'generalhw') && !check_var('BACKEND', 'ipmi') && !(sle_version_at_least('15') && get_var('ADDONURL'))) {
-        loadtest "installation/releasenotes";
-    }
-    if (noupdatestep_is_applicable()) {
-        loadtest "installation/installer_timezone";
-        # the test should run only in scenarios, where installed
-        # system is not being tested (e.g. INSTALLONLY etc.)
-        # The test also won't work reliably when network is bridged (non-s390x svirt).
-        if (    !consolestep_is_applicable()
-            and !get_var("REMOTE_CONTROLLER")
-            and !is_hyperv_in_gui
-            and !is_bridged_networking
-            and !check_var('BACKEND', 's390x')
-            and sle_version_at_least('12-SP2'))
-        {
-            loadtest "installation/hostname_inst";
-        }
-        # Do not run on REMOTE_CONTROLLER, IPMI and on Hyper-V in GUI mode
-        if (!get_var("REMOTE_CONTROLLER") && !check_var('BACKEND', 'ipmi') && !is_hyperv_in_gui) {
-            loadtest "installation/logpackages";
-        }
-        if (is_sles4sap()) {
-            if (
-                is_sles4sap_standard()    # Schedule module only for SLE15 with non-default role
-                || sle_version_at_least('15') && get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'))
-            {
-                loadtest "installation/user_settings";
-            }    # sles4sap wizard installation doesn't have user_settings step
-        }
-        elsif (get_var('IMPORT_USER_DATA')) {
-            loadtest 'installation/user_import';
-        }
-        else {
-            loadtest "installation/user_settings";
-        }
-        loadtest "installation/user_settings_root";
-        if (get_var('PATTERNS') || get_var('PACKAGES')) {
-            loadtest "installation/installation_overview_before";
-            loadtest "installation/select_patterns_and_packages";
-        }
-        elsif (!check_var('DESKTOP', default_desktop)
-            && (!sle_version_at_least('15') || check_var('DESKTOP', 'minimalx')))
-        {
-            # With SLE15 we change desktop using role and not by unselecting packages (Use SYSTEM_ROLE variable),
-            # If we have minimalx, as there is no such a role, there we use old approach
-            loadtest "installation/installation_overview_before";
-            loadtest "installation/change_desktop";
-        }
-    }
-    if (get_var("UEFI") && get_var("SECUREBOOT")) {
-        loadtest "installation/secure_boot";
-    }
-    # for upgrades on s390 zKVM we need to change the static ip adress of the image to reboot properly
-    if (check_var('BACKEND', 'svirt') && check_var('ARCH', 's390x') && get_var('UPGRADE')) {
-        loadtest "installation/set_static_ip";
-    }
-    if (installyaststep_is_applicable()) {
-        loadtest "installation/installation_overview";
-        # On Xen PV we don't have GRUB on VNC
-        loadtest "installation/disable_grub_timeout" unless check_var('VIRSH_VMM_TYPE', 'linux');
-        if (check_var('VIDEOMODE', 'text') && check_var('BACKEND', 'ipmi')) {
-            loadtest "installation/disable_grub_graphics";
-        }
-        if (check_var("UPGRADE", "LOW_SPACE")) {
-            loadtest "installation/disk_space_release";
-        }
-        if (ssh_key_import) {
-            loadtest "installation/ssh_key_setup";
-        }
-        loadtest "installation/start_install";
-    }
-    return 1 if get_var('EXIT_AFTER_START_INSTALL');
-    loadtest "installation/install_and_reboot";
-    if (check_var('BACKEND', 'svirt') and check_var('ARCH', 's390x')) {
-        # on svirt we need to redefine the xml-file to boot the installed kernel
-        loadtest "installation/redefine_svirt_domain";
-    }
-    if (is_sles4sap()) {
-        if (check_var('SLES4SAP_MODE', 'sles4sap_wizard')) {
-            loadtest "installation/sles4sap_wizard";
-            if (get_var("TREX")) {
-                loadtest "installation/sles4sap_wizard_trex";
-            }
-            if (get_var("NW")) {
-                loadtest "installation/sles4sap_wizard_nw";
-            }
-            loadtest "installation/sles4sap_wizard_swpm";
-        }
-    }
-
-}
-
-sub load_consoletests {
-    return unless consolestep_is_applicable();
-    if (get_var("ADDONS", "") =~ /rt/) {
-        loadtest "rt/kmp_modules";
-    }
-    loadtest "console/consoletest_setup";
-    loadtest "console/force_cron_run" unless is_jeos;
-    if (get_var("LOCK_PACKAGE")) {
-        loadtest "console/check_locked_package";
-    }
-    loadtest "console/textinfo";
-    loadtest "console/hostname" unless is_bridged_networking;
-    if (get_var('SYSTEM_ROLE', '') =~ /kvm|xen/) {
-        loadtest "console/patterns";
-    }
-    if (snapper_is_applicable()) {
-        if (get_var("UPGRADE")) {
-            loadtest "console/upgrade_snapshots";
-        }
-        # zypper and sle12 doesn't do upgrade or installation snapshots
-        # SLES4SAP default installation flow does not configure snapshots
-        elsif (!get_var("ZDUP") and !check_var('VERSION', '12') and !is_sles4sap()) {
-            loadtest "console/installation_snapshots";
-        }
-    }
-    if (get_var("DESKTOP") !~ /textmode/ && !check_var("ARCH", "s390x")) {
-        loadtest "console/xorg_vt";
-    }
-    loadtest "console/zypper_lr";
-    loadtest 'console/enable_usb_repo' if check_var('USBBOOT', 1);
-    if (need_clear_repos()) {
-        loadtest "update/zypper_clear_repos";
-    }
-    #have SCC repo for SLE product
-    if (have_scc_repos()) {
-        loadtest "console/yast_scc";
-    }
-    elsif (have_addn_repos()) {
-        loadtest "console/zypper_ar";
-    }
-    loadtest "console/zypper_ref";
-    loadtest "console/ncurses";
-    loadtest "console/yast2_lan" unless is_bridged_networking;
-    loadtest "console/curl_https";
-    if (check_var_array('SCC_ADDONS', 'asmm') && !sle_version_at_least('15')) {
-        loadtest "console/puppet";
-    }
-    if (check_var_array('SCC_ADDONS', 'phub') && sle_version_at_least('15')) {
-        loadtest "console/puppet";
-    }
-    if (check_var_array('SCC_ADDONS', 'asmm') || sle_version_at_least('15') && !is_staging()) {
-        loadtest "console/salt";
-    }
-    if (check_var("ARCH", "x86_64")) {
-        loadtest "console/glibc_sanity";
-    }
-    if (check_var('ARCH', 'aarch64')) {
-        loadtest "console/acpi";
-    }
-    if (!gnomestep_is_applicable()) {
-        loadtest "update/zypper_up";
-    }
-    if (is_jeos()) {
-        loadtest "console/console_reboot";
-    }
-    loadtest "console/zypper_in";
-    loadtest "console/yast2_i";
-    loadtest "console/yast2_bootloader";
-    loadtest "console/vim" if !sle_version_at_least('15') || !get_var('PATTERNS') || check_var_array('PATTERNS', 'enhanced_base');
-    if (!is_staging()) {
-        loadtest "console/firewall_enabled";
-    }
-    if (is_jeos()) {
-        loadtest "console/gpt_ptable";
-        loadtest "console/kdump_disabled";
-        loadtest "console/sshd_running";
-    }
-    if (rt_is_applicable()) {
-        loadtest "console/rt_is_realtime";
-        loadtest "console/rt_devel_packages";
-        loadtest "console/rt_peak_pci";
-        loadtest "console/rt_preempt_test";
-    }
-    loadtest "console/sshd";
-    loadtest "console/ssh_cleanup";
-    loadtest "console/mtab";
-    if (!get_var("NOINSTALL") && !is_desktop && (check_var("DESKTOP", "textmode"))) {
-        if (!is_staging() && check_var('BACKEND', 'qemu') && !is_jeos) {
-            # The NFS test expects the IP to be 10.0.2.15
-            loadtest "console/yast2_nfs_server";
-        }
-        loadtest "console/http_srv";
-        loadtest "console/mysql_srv";
-        # Hyper-V host is in .suse.cz domain and the test is unstable
-        loadtest "console/dns_srv";
-        loadtest "console/postgresql_server";
-        if (sle_version_at_least('12-SP1')) {    # shibboleth-sp not available on SLES 12 GA
-            loadtest "console/shibboleth";
-        }
-        if (get_var('ADDONS', '') =~ /wsm/ || get_var('SCC_ADDONS', '') =~ /wsm/) {
-            loadtest "console/pcre";
-            if (!sle_version_at_least('15')) {
-                loadtest "console/php5";
-                loadtest "console/php5_mysql";
-                loadtest "console/php5_postgresql96";
-            }
-            loadtest "console/php7";
-            loadtest "console/php7_mysql";
-            loadtest "console/php7_postgresql96";
-        }
-        loadtest "console/apache_ssl";
-        loadtest "console/apache_nss";
-    }
-    if (check_var("DESKTOP", "xfce")) {
-        loadtest "console/xfce_gnome_deps";
-    }
-    if (!is_staging() && sle_version_at_least('12-SP2')) {
-        # This test uses serial console too much to be reliable on Hyper-V (poo#30613)
-        loadtest "console/zypper_lifecycle" unless check_var('VIRSH_VMM_FAMILY', 'hyperv');
-        if (check_var_array('SCC_ADDONS', 'tcm') && !sle_version_at_least('15')) {
-            loadtest "console/zypper_lifecycle_toolchain";
-        }
-    }
-    loadtest 'console/install_all_from_repository' if get_var('INSTALL_ALL_REPO');
-    if (check_var_array('SCC_ADDONS', 'tcm') && get_var('PATTERNS') && sle_version_at_least('12-SP3')) {
-        loadtest "feature/feature_console/deregister";
-    }
-    loadtest "console/consoletest_finish";
-}
-
-sub load_x11tests {
-    return
-      unless (!get_var("INSTALLONLY")
-        && is_desktop_installed()
-        && !get_var("DUALBOOT")
-        && !get_var("RESCUECD")
-        && !get_var("HA_CLUSTER"));
-
-    if (is_smt()) {
-        loadtest "x11/smt";
-    }
-    if (get_var("XDMUSED")) {
-        loadtest "x11/x11_login";
-    }
-    loadtest "x11/xterm";
-    loadtest "x11/sshxterm";
-    if (gnomestep_is_applicable()) {
-        loadtest "update/updates_packagekit_gpk" unless is_staging;
-        loadtest "x11/gnome_control_center";
-        loadtest "x11/gnome_terminal";
-        loadtest "x11/gedit";
-    }
-    if (kdestep_is_applicable()) {
-        loadtest "x11/kate";
-    }
-    loadtest "x11/firefox";
-    if (!is_server() || we_is_applicable()) {
-        if (gnomestep_is_applicable()) {
-            loadtest "x11/eog";
-            loadtest "x11/rhythmbox";
-            loadtest "x11/wireshark";
-            loadtest "x11/ImageMagick";
-            loadtest "x11/ghostscript";
-        }
-        if (get_var('DESKTOP') =~ /kde|gnome/) {
-            loadtest "x11/ooffice";
-            loadtest "x11/oomath";
-            loadtest "x11/oocalc";
-        }
-    }
-    if (kdestep_is_applicable()) {
-        loadtest "x11/khelpcenter";
-        loadtest "x11/systemsettings";
-        loadtest "x11/dolphin";
-    }
-    # SLES4SAP default installation does not configure snapshots
-    if (snapper_is_applicable() and !is_sles4sap()) {
-        loadtest "x11/yast2_snapper";
-    }
-    loadtest "x11/glxgears";
-    if (kdestep_is_applicable()) {
-        loadtest "x11/amarok";
-        loadtest "x11/kontact";
-        loadtest "x11/reboot_kde";
-    }
-    if (gnomestep_is_applicable()) {
-        loadtest "x11/nautilus";
-        loadtest "x11/evolution" if (!is_server() || we_is_applicable());
-        loadtest "x11/reboot_gnome";
-    }
-    loadtest "x11/desktop_mainmenu";
-    if (is_sles4sap() and !is_sles4sap_standard()) {
-        load_sles4sap_tests();
-    }
-    # Need to skip shutdown to keep backend alive if running rollback tests after migration
-    unless (get_var('ROLLBACK_AFTER_MIGRATION')) {
-        loadtest "x11/shutdown";
     }
 }
 
@@ -1171,37 +678,14 @@ elsif (get_var('NFV')) {
     }
 }
 elsif (get_var("REGRESSION")) {
-    if (check_var("REGRESSION", "installation")) {
-        load_boot_tests();
-        load_inst_tests();
-        load_reboot_tests();
-        loadtest "x11regressions/x11regressions_setup";
-        # temporary adding test modules which applies hacks for missing parts in sle15
-        loadtest "console/sle15_workarounds" if sle_version_at_least('15');
-        loadtest "console/hostname"       unless is_bridged_networking;
-        loadtest "console/force_cron_run" unless is_jeos;
-        loadtest "shutdown/grub_set_bootargs";
-        loadtest "shutdown/shutdown";
-    }
-    elsif (check_var("REGRESSION", "firefox")) {
+    load_common_x11regression;
+    if (check_var("REGRESSION", "firefox")) {
         loadtest "boot/boot_to_desktop";
         load_x11regression_firefox();
-    }
-    elsif (check_var("REGRESSION", "gnome")) {
-        loadtest "boot/boot_to_desktop";
-        load_x11regression_gnome();
-    }
-    elsif (check_var("REGRESSION", "documentation")) {
-        loadtest "boot/boot_to_desktop";
-        load_x11regression_documentation();
     }
     elsif (check_var("REGRESSION", "message")) {
         loadtest "boot/boot_to_desktop";
         load_x11regression_message();
-    }
-    elsif (check_var("REGRESSION", "other")) {
-        loadtest "boot/boot_to_desktop";
-        load_x11regression_other();
     }
     elsif (check_var('REGRESSION', 'remote')) {
         loadtest 'boot/boot_to_desktop';
@@ -1459,15 +943,7 @@ elsif (get_var("WINDOWS")) {
     loadtest "installation/win10_installation";
 }
 elsif (ssh_key_import) {
-    loadtest "boot/boot_to_desktop";
-    # setup ssh key, we know what ssh keys we have and can verify if they are imported or not
-    loadtest "x11/ssh_key_check";
-    # reboot after test specific setup and start installation/update
-    loadtest "x11/reboot_and_install";
-    load_inst_tests();
-    load_reboot_tests();
-    # verify previous defined ssh keys
-    loadtest "x11/ssh_key_verify";
+    load_ssh_key_import_tests;
 }
 elsif (get_var('ISO_IN_EXTERNAL_DRIVE')) {
     load_iso_in_external_tests();

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -15,7 +15,7 @@ use lockapi;
 use needle;
 use registration;
 use utils;
-use version_utils qw(is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem sle_version_at_least is_desktop_installed is_jeos is_sle is_upgrade);
+use version_utils qw(is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem sle_version_at_least is_desktop_installed is_jeos is_sle is_staging is_upgrade);
 use File::Find;
 use File::Basename;
 use LWP::Simple 'head';

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -523,55 +523,6 @@ sub load_x11regression_remote {
     }
 }
 
-sub load_svirt_boot_tests {
-    # Unless GRUB2 supports framebuffer on Xen PV (bsc#961638), grub2 tests
-    # has to be skipped there.
-    if (!(check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux'))) {
-        if (get_var("UEFI") || is_jeos) {
-            loadtest "installation/bootloader_uefi";
-        }
-        elsif (!get_var('NETBOOT')) {
-            loadtest "installation/bootloader";
-        }
-    }
-}
-
-sub load_svirt_vm_setup_tests {
-    return unless check_var('BACKEND', 'svirt');
-    if (check_var("VIRSH_VMM_FAMILY", "hyperv")) {
-        loadtest "installation/bootloader_hyperv";
-    }
-    else {
-        loadtest "installation/bootloader_svirt";
-    }
-    unless (is_installcheck || is_memtest || is_rescuesystem || is_mediacheck) {
-        load_svirt_boot_tests;
-    }
-}
-
-sub load_boot_tests {
-    # s390x uses only remote repos
-    if (get_var("ISO_MAXSIZE") && !check_var('ARCH', 's390x')) {
-        loadtest "installation/isosize";
-    }
-    if ((get_var("UEFI") || is_jeos()) && !check_var("BACKEND", "svirt")) {
-        loadtest "installation/bootloader_uefi";
-    }
-    elsif (check_var("BACKEND", "svirt") && !check_var("ARCH", "s390x")) {
-        load_svirt_vm_setup_tests;
-    }
-    elsif (uses_qa_net_hardware()) {
-        loadtest "boot/boot_from_pxe";
-    }
-    elsif (get_var("PXEBOOT")) {
-        set_var("DELAYED_START", "1");
-        loadtest "autoyast/pxe_boot";
-    }
-    else {
-        loadtest "installation/bootloader" unless load_bootloader_s390x();
-    }
-}
-
 sub install_this_version {
     return !check_var('INSTALL_TO_OTHERS', 1);
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1142,6 +1142,14 @@ sub prepare_target {
     }
 }
 
+sub load_default_tests {
+    load_boot_tests();
+    load_inst_tests();
+    return 1 if get_var('EXIT_AFTER_START_INSTALL');
+    load_reboot_tests();
+}
+
+
 my $distri = testapi::get_required_var('CASEDIR') . '/lib/susedistribution.pm';
 require $distri;
 testapi::set_distribution(susedistribution->new());
@@ -1610,10 +1618,7 @@ else {
             loadtest 'installation/first_boot';
         }
         else {
-            load_boot_tests();
-            load_inst_tests();
-            return 1 if get_var('EXIT_AFTER_START_INSTALL');
-            load_reboot_tests();
+            load_default_tests;
         }
     }
     unless (load_applicationstests() || load_slenkins_tests()) {

--- a/tests/console/dns_srv.pm
+++ b/tests/console/dns_srv.pm
@@ -13,8 +13,7 @@
 use strict;
 use base "consoletest";
 use testapi;
-use main_common 'is_bridged_networking';
-use utils 'systemctl';
+use utils qw(is_bridged_networking systemctl);
 
 sub run {
     # Skip the entire test on bridget networks (e.g. Xen, Hyper-V)

--- a/tests/installation/installer_desktopselection.pm
+++ b/tests/installation/installer_desktopselection.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -13,7 +13,7 @@
 
 use strict;
 use base "y2logsstep";
-use main_common 'addon_products_is_applicable';
+use utils 'addon_products_is_applicable';
 use testapi;
 use version_utils 'leap_version_at_least';
 

--- a/tests/installation/installer_timezone.pm
+++ b/tests/installation/installer_timezone.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -14,7 +14,7 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use main_common "noupdatestep_is_applicable";
+use utils 'noupdatestep_is_applicable';
 
 sub run {
     assert_screen "inst-timezone", 125 || die 'no timezone';

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -16,8 +16,7 @@ use warnings;
 use base "y2logsstep";
 use testapi;
 use utils 'ensure_fullscreen';
-use version_utils qw(is_sle sle_version_at_least);
-use main_common 'is_staging';
+use version_utils qw(is_sle sle_version_at_least is_staging);
 
 sub run {
     my ($self) = @_;


### PR DESCRIPTION
* DRY on openSUSE/SLE load_ssh_key_import_tests
* DRY on openSUSE/SLE load_inst_tests
* DRY on openSUSE/SLE load_console_tests
* DRY on openSUSE/SLE load_x11_tests
* DRY on openSUSE/SLE x11regression tests

The impact of the change should be only on the schedule so I mainly compared
the evaluated schedule rather than look into the results from the test
modules. Mainly the change is a refactoring with no visible impact on actual
test execution. However, in some cases the order of modules execution was
changed for either SLE or openSUSE to harmonize both.

Verification runs:
* openSUSE staging cryptlvm: http://lord.arch/tests/596
* openSUSE TW textmode: http://lord.arch/tests/601
* openSUSE TW textmode: http://lord.arch/tests/591
* openSUSE TW gnome: http://lord.arch/tests/595
* openSUSE TW kde: http://lord.arch/tests/603
* openSUSE TW lxde: http://lord.arch/tests/593
* openSUSE TW lxde: http://lord.arch/tests/598
* openSUSE Leap 42.3 maintenance gnome: http://lord.arch/tests/589
* SLE staging gnome: http://lord.arch/tests/597

Related progress issue: https://progress.opensuse.org/issues/15132