### PR TITLE
Wait until the update applet is busy before checking results

### DIFF
--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -37,10 +37,15 @@ sub run {
         while (1) {
             assert_and_click_until_screen_change('updates_click-install');
 
+            # Wait until installation starts, intended to time out
+            wait_still_screen(stilltime => 4, timeout => 5);
+
             # Wait until installation is done
             assert_screen \@updates_installed_tags, 3600;
-            # Make sure we saw the right string and the same screen or a
-            # different one
+
+            # Make sure the applet has fetched the current status from the backend
+            # and has finished redrawing. In case the update status changed after
+            # the assert_screen, record a soft failure
             wait_still_screen;
             if (match_has_tag('updates_none')) {
                 if (check_screen 'updates_none') {


### PR DESCRIPTION
After the last change, there is still a small chance the update applet
still shows the state prior to the click, i.e. assert_screen matches
immediately.

Delay the assert_screen until we have seen some activity. The
wait_still_screen will typically time out 10 seconds after the update has
started. The correct next step is to wait for the update to finish using
assert_screen_change.

wait_still_screen is used as a lightweight check for screen activity
instead of a wait_screen_change loop with timeout. A simple delay would
not record screen activity in the log.

Signed-off-by: Stefan Brüns <stefan.bruens@rwth-aachen.de>

- Related ticket: https://progress.opensuse.org/issues/31327
- Verification run: none