### PR TITLE
[NFV] Add silent mode to zypper and git

### DIFF
--- a/tests/nfv/moongen_installation.pm
+++ b/tests/nfv/moongen_installation.pm
@@ -28,10 +28,10 @@ sub run {
 
     select_virtio_console();
 
-    zypper_call('in git-core gcc gcc-c++ make cmake libnuma-devel kernel-source pciutils', timeout => 300);
+    zypper_call('--quiet in git-core gcc gcc-c++ make cmake libnuma-devel kernel-source pciutils', timeout => 300);
 
     # Clone repository
-    assert_script_run("git clone --depth 1 $moongen_repo", timeout => 300);
+    assert_script_run("git clone --quiet --depth 1 $moongen_repo", timeout => 300);
 
     # Install MoonGen and dependencies
     assert_script_run("cd MoonGen");

--- a/tests/nfv/prepare_env.pm
+++ b/tests/nfv/prepare_env.pm
@@ -31,11 +31,11 @@ sub run {
 
     select_virtio_console();
 
-    zypper_call('in git-core openvswitch-switch dpdk qemu tcpdump', timeout => 200);
+    zypper_call('--quiet in git-core openvswitch-switch dpdk qemu tcpdump', timeout => 200);
 
     # Clone repositories
-    assert_script_run("git clone --depth 1 $vsperf_repo");
-    assert_script_run("git clone --depth 1 $dpdk_repo");
+    assert_script_run("git clone --quiet --depth 1 $vsperf_repo");
+    assert_script_run("git clone --quiet --depth 1 $dpdk_repo");
 
     # Start the openvswitch daemon
     systemctl 'start openvswitch', timeout => 200;

--- a/tests/nfv/trex_installation.pm
+++ b/tests/nfv/trex_installation.pm
@@ -28,10 +28,10 @@ sub run {
 
     select_virtio_console();
 
-    zypper_call('in git-core gcc gcc-c++ make cmake libnuma-devel kernel-source pciutils', timeout => 300);
+    zypper_call('--quiet in git-core gcc gcc-c++ make cmake libnuma-devel kernel-source pciutils', timeout => 300);
 
     # Clone Trex repository
-    assert_script_run("git clone --depth 1 $trex_repo $trex_dest", timeout => 500);
+    assert_script_run("git clone --quiet --depth 1 $trex_repo $trex_dest", timeout => 600);
 
     # Copy sample config file to default localtion
     assert_script_run("cp $trex_dest/scripts/cfg/simple_cfg.yaml /etc/trex_cfg.yaml");


### PR DESCRIPTION
With --quiet mode in both git and zypper commands, we avoid extra lines (e.g. progress) in the serial output that fill out the output serial_terminal.txt with unnecessary information. 

- Verification runs
http://10.161.8.29/tests/270
http://10.161.8.29/tests/271