### PR TITLE
Use key shortcuts to enter user info

### DIFF
--- a/tests/installation/user_settings.pm
+++ b/tests/installation/user_settings.pm
@@ -18,33 +18,33 @@ use testapi;
 
 sub run {
     my ($self) = @_;
-    assert_screen "inst-usersetup";
+    assert_screen 'inst-usersetup';
     if (get_var 'ROOTONLY') {
         send_key 'alt-s';
         assert_screen 'inst-rootonly-selected';
         # done user setup
         send_key $cmd{next};
+        return;
     }
-    else {
-        type_string $realname;
-        send_key "tab";
-
-        send_key "tab";
-        $self->type_password_and_verification;
-        assert_screen "inst-userinfostyped";
-        if (get_var("NOAUTOLOGIN") && !check_screen('autologindisabled', timeout => 0)) {
-            send_key $cmd{noautologin};
-            assert_screen "autologindisabled";
-        }
-        if (get_var("DOCRUN")) {
-            send_key $cmd{otherrootpw};
-            assert_screen "rootpwdisabled";
-        }
-
-        # done user setup
-        send_key $cmd{next};
-        $self->await_password_check;
+    
+    send_key 'alt-f';    # Select full name text field
+    type_string $realname;
+    send_key 'alt-p';    # Select password field
+    $self->type_password_and_verification;
+    assert_screen 'inst-userinfostyped';
+    if (get_var('NOAUTOLOGIN') && !check_screen('autologindisabled', timeout => 0)) {
+        send_key $cmd{noautologin};
+        assert_screen 'autologindisabled';
     }
+    if (get_var('DOCRUN')) {
+        send_key $cmd{otherrootpw};
+        assert_screen 'rootpwdisabled';
+    }
+
+    # done user setup
+    send_key $cmd{next};
+    $self->await_password_check;
+
 }
 1;
 # vim: set sw=4 et:


### PR DESCRIPTION
3 months ago we had an issue on zkvm when username wasn't typed in user
name field and then password was typed there. The only way I was able to
reproduce this issue was but unfocusing text field. Using shortcut keys
is more reliable than expecting that you can type in the field. Needle
already asserts if we have all controls in place, as well if everything
was typed properly.

See [poo#27600](https://progress.opensuse.org/issues/27600).
[Verification run](http://g226.suse.de/tests/811).
