### PR TITLE
Do not apply workaround for reboot when shut down

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -671,7 +671,7 @@ sub power_action {
         # We should only reset consoles if the system really rebooted.
         # Otherwise the next select_console will check for a login prompt
         # instead of handling the still logged in system.
-        handle_livecd_reboot_failure if get_var('LIVECD');
+        handle_livecd_reboot_failure if get_var('LIVECD') && $action eq 'reboot';
         reset_consoles;
         if (check_var('BACKEND', 'svirt') && $action ne 'poweroff') {
             console('svirt')->start_serial_grab;


### PR DESCRIPTION
Fixes regression introduced by
[PR#4400](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4400)
as we are applying workaround for reboot when performing shutdown.

See [poo#31720](https://progress.opensuse.org/issues/31720).
- Verification runs:
  * [tw gnome live](http://g226.suse.de/tests/814).
  * [tw kde-live](http://g226.suse.de/tests/815)
  * [leap 15 gnome live](http://g226.suse.de/tests/816)
