### PR TITLE
Add dry-run check on SLES4SAP pattern testing

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -12,15 +12,12 @@ sub pre_run_hook {
     my ($self) = @_;
 
     $prev_console = $testapi::selected_console;
-
-    unless (defined $prev_console) {
-        $prev_console = check_var('DESKTOP', 'gnome') ? 'x11' : 'root-console';
-    }
 }
 
 sub post_run_hook {
     my ($self) = @_;
 
+    return unless ($prev_console);
     select_console($prev_console, await_console => 0);
     ensure_unlocked_desktop if ($prev_console eq 'x11');
 }

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -12,6 +12,10 @@ sub pre_run_hook {
     my ($self) = @_;
 
     $prev_console = $testapi::selected_console;
+
+    unless (defined $prev_console) {
+        $prev_console = check_var('DESKTOP', 'gnome') ? 'x11' : 'root-console';
+    }
 }
 
 sub post_run_hook {

--- a/tests/sles4sap/netweaver_ascs_install.pm
+++ b/tests/sles4sap/netweaver_ascs_install.pm
@@ -49,7 +49,12 @@ sub run {
     assert_script_run "tuned-adm profile sap-netweaver";
     assert_script_run "saptune solution apply NETWEAVER";
     assert_script_run "systemctl restart systemd-logind.service";
+
+    # If running in DESKTOP=gnome, systemd-logind restart may cause the graphical console to
+    # reset and appear in SUD, so need to select 'root-console' again
+    wait_still_screen;
     select_console 'root-console';
+
     assert_script_run "saptune daemon start";
     assert_script_run "saptune solution verify NETWEAVER";
     my $output = script_output "tuned-adm active";

--- a/tests/sles4sap/netweaver_ascs_install.pm
+++ b/tests/sles4sap/netweaver_ascs_install.pm
@@ -49,6 +49,7 @@ sub run {
     assert_script_run "tuned-adm profile sap-netweaver";
     assert_script_run "saptune solution apply NETWEAVER";
     assert_script_run "systemctl restart systemd-logind.service";
+    select_console 'root-console';
     assert_script_run "saptune daemon start";
     assert_script_run "saptune solution verify NETWEAVER";
     my $output = script_output "tuned-adm active";

--- a/tests/sles4sap/netweaver_ascs_install.pm
+++ b/tests/sles4sap/netweaver_ascs_install.pm
@@ -48,7 +48,7 @@ sub run {
     # SAP profile and solution are configured in the system
     assert_script_run "tuned-adm profile sap-netweaver";
     assert_script_run "saptune solution apply NETWEAVER";
-    assert_script_run q/kill -1 $(ps aux|grep systemd-logind|awk '{print $2}'|head -1)/;
+    assert_script_run "systemctl restart systemd-logind.service";
     assert_script_run "saptune daemon start";
     assert_script_run "saptune solution verify NETWEAVER";
     my $output = script_output "tuned-adm active";

--- a/tests/sles4sap/netweaver_ascs_install.pm
+++ b/tests/sles4sap/netweaver_ascs_install.pm
@@ -33,7 +33,7 @@ sub run {
       SAPINST_INPUT_PARAMETERS_URL=/sapinst/inifile.params
       SAPINST_EXECUTE_PRODUCT_ID=NW_ABAP_ASCS:NW750.HDB.ABAPHA
       SAPINST_SKIP_DIALOGS=true SAPINST_SLP_MODE=false);
-    my $nettout = 600;    # Time out for NetWeaver's sources related commands
+    my $nettout = 900;    # Time out for NetWeaver's sources related commands
 
     $proto = 'cifs' if ($proto eq 'smb' or $proto eq 'smbfs');
     die "netweaver_ascs_install: currently only supported protocols are nfs and smb/smbfs/cifs"

--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -37,6 +37,14 @@ sub run {
         assert_script_run("sapconf start");
     }
 
+    # Dry run of each pattern's installation before actual installation
+    foreach my $pattern (@sappatterns) {
+        assert_script_run("zypper in -D -y -t pattern $pattern");
+        $output = script_output("zypper info --requires $pattern");
+        record_info("requirements pattern: $pattern", $output);
+    }
+
+    # Actual installation and verification
     foreach my $pattern (@sappatterns) {
         assert_script_run("zypper in -y -t pattern $pattern", 100);
         $output = script_output "zypper info -t pattern $pattern";


### PR DESCRIPTION
- Add dry-run check on SLES4SAP pattern testing.
- Increase timeout for network operation on NetWeaver's ASCS install.
- Assign default $prev_console in lib/sles4sap.pm when there's no selected console.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/241
