### PR TITLE
Use proxy SCC on Xen PV

### DIFF
--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -16,6 +16,7 @@ use warnings;
 use testapi;
 use utils;
 use version_utils qw(is_jeos is_caasp is_installcheck is_rescuesystem sle_version_at_least);
+use registration 'registration_bootloader_cmdline';
 use File::Basename;
 
 sub copy_image {
@@ -212,7 +213,8 @@ sub run {
         my $cmdline = '';
         $cmdline .= 'textmode=1 ' if check_var('VIDEOMODE', 'text');
         $cmdline .= 'rescue=1 ' if is_installcheck || is_rescuesystem;    # rescue mode
-        $cmdline .= get_var('EXTRABOOTPARAMS') . ' ';
+        $cmdline .= get_var('EXTRABOOTPARAMS') . ' ' if get_var('EXTRABOOTPARAMS');
+        $cmdline .= registration_bootloader_cmdline if check_var('SCC_REGISTER', 'installation');
         type_string "export pty=`virsh dumpxml $name | grep \"console type=\" | sed \"s/'/ /g\" | awk '{ print \$5 }'`\n";
         type_string "echo \$pty\n";
         $svirt->resume;


### PR DESCRIPTION
We are not adding regurl boot parameter when system is expected to be
registered for Xen PV installations. So we end up with wrong repos, which do not
correspond to the SUT build.

See [poo#31735](https://progress.opensuse.org/issues/31735).

As I don't have svirt worker, I've just cloned job with EXTRABOOTPARAMS having exactly what registration_bootloader_cmdline returns: see url [here](https://openqa.suse.de/tests/1484025#step/scc_registration/1)