### PR TITLE
Execute glxgears for openSUSE staging tests to be in line with SLE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -195,9 +195,8 @@ sub is_kde_live {
     return get_var('FLAVOR', '') =~ /KDE-Live/;
 }
 
-# TODO check why we want this enabled on SLE staging but not openSUSE staging
 sub packagekit_available {
-    return !check_var('FLAVOR', 'Rescue-CD') && (!is_staging || is_sle);
+    return !check_var('FLAVOR', 'Rescue-CD');
 }
 
 sub is_kernel_test {


### PR DESCRIPTION
glxgears requires Mesa-demo-x to be added to the staging project to be able to
execute glxgears which might serve as a good openGL test as well as a test
exercising packagekit operations.