### PR TITLE
Fix updates_packagekit_gpk for sles 15

### DIFF
--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -43,8 +43,11 @@ sub tell_packagekit_to_quit {
 # Update with GNOME PackageKit Update Viewer
 sub run {
     my ($self) = @_;
-    # updates_packagekit_gpk is disabled for SLE15 because of bsc#1060844
-    return record_soft_failure 'bsc#1060844' if sle_version_at_least('15') && is_sle();
+    if (is_sle && sle_version_at_least('15')) {
+        select_console 'root-console';
+        zypper_call("in gnome-packagekit", timeout => 90);
+        record_soft_failure 'bsc#1081584';
+    }
     select_console 'x11', await_console => 0;
 
     my @updates_tags           = qw(updates_none updates_available package-updater-privileged-user-warning updates_restart_application);


### PR DESCRIPTION
- remove softfailure for bsc#1060844
- provide a workaround for bsc#1081584
- see poo#17712 for more details
- verification run:
  http://e13.suse.de/tests/373#step/updates_packagekit_gpk
- needle PR:
  https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/712