### PR TITLE
s390x: Adapt bootloader to work with z/VM 6.3

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -124,7 +124,10 @@ EO_frickin_boot_parms
             $s3270->sequence_3270("String(\"qaboot $repo_host $dir_with_suse_ins\")", "ENTER", "Wait(InputField)",);
             # wait for qaboot dumping us into xedit. If this fails, probably the
             # download of kernel or initrd timed out and we retry
-            $r = $s3270->expect_3270(buffer_ready => qr/X E D I T/, timeout => 60);
+
+            # temporary workaround - using needles instead of output_delim -> see poo#32008
+            # $r = $s3270->expect_3270(output_delim => qr/X E D I T/, timeout => 60);
+            assert_screen 'xedit';
         };
         last unless ($@);
         diag "s3270 sequence failed: $@";
@@ -134,12 +137,16 @@ EO_frickin_boot_parms
 
     $s3270->sequence_3270(qw( String(INPUT) ENTER ));
 
-    $r = $s3270->expect_3270(buffer_ready => qr/Input-mode/);
+    # temporary workaround - using needles instead of output_delim -> see poo#32008
+    # $r = $s3270->expect_3270(output_delim => qr/Input-mode/);
+    assert_screen 'xedit-input';
 
     # can't use qw() because of space in commands...
     $s3270->sequence_3270(split /\n/, $sequence);
 
-    $r = $s3270->expect_3270(buffer_ready => qr/X E D I T/);
+    # temporary workaround - using needles instead of output_delim -> see poo#32008
+    # $r = $s3270->expect_3270(output_delim => qr/X E D I T/);
+    assert_screen 'xedit';
 
     ## Remove the "manual=1" and the empty line at the end
     ## of the parmfile.
@@ -151,7 +158,9 @@ EO_frickin_boot_parms
     $s3270->sequence_3270(qw(String(BOTTOM) ENTER String(DELETE) ENTER));
     $s3270->sequence_3270(qw(String(BOTTOM) ENTER String(DELETE) ENTER));
 
-    $r = $s3270->expect_3270(buffer_ready => qr/X E D I T/);
+    # temporary workaround - using needles instead of output_delim -> see poo#  TODO
+    # $r = $s3270->expect_3270(output_delim => qr/X E D I T/);
+    assert_screen 'xedit';
 
     # save the parmfile.  ftpboot then starts the installation.
     $s3270->sequence_3270(qw( String(FILE) ENTER ));


### PR DESCRIPTION
due to the breakdown of the storage backend of the mainframe, we moved the s390 guests to a new LPAR, which is now running z/VM 6.3

to make bootloader_s390.pm workable with those, some changes were necessary
since z/VM 5.4 won't come back soonish (or ever), I didn't do some kind of if/else for the different versions and adapted everything to z/VM 6.3

For now, to speed up things, I've solved this with needles - this should be improved later on
see [poo#32008](https://progress.opensuse.org/issues/32008)  (link to follow)


see [poo#32011](https://progress.opensuse.org/issues/32011)

see [needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/714)
see [workerconf](https://gitlab.suse.de/openqa/salt-pillars-openqa/merge_requests/75)
see [verification run](http://opeth/tests/131)