### PR TITLE
New perltidy is broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
 before_install:
   - eval $(curl https://travis-perl.github.io/init) --perl
   - echo "requires 'Code::DRY';" >> cpanfile
+  - echo "requires 'Perl::Tidy', '>= 20180101, != 20180219';" >> cpanfile
 install:
   - make prepare
 script:


### PR DESCRIPTION
New perltidy it spurts an empty file, thus all builds are failing.

Just to see if downgrading fix the issue - cherry picked a failing PR
