### PR TITLE
SLES4SAP Tests Improvements

### DIFF
--- a/tests/sles4sap/netweaver_ascs_install.pm
+++ b/tests/sles4sap/netweaver_ascs_install.pm
@@ -52,8 +52,7 @@ sub run {
 
     # If running in DESKTOP=gnome, systemd-logind restart may cause the graphical console to
     # reset and appear in SUD, so need to select 'root-console' again
-    wait_still_screen;
-    select_console 'root-console';
+    select_console 'root-console' unless (check_screen 'root-console');
 
     assert_script_run "saptune daemon start";
     assert_script_run "saptune solution verify NETWEAVER";

--- a/tests/sles4sap/netweaver_ascs_install.pm
+++ b/tests/sles4sap/netweaver_ascs_install.pm
@@ -52,7 +52,8 @@ sub run {
 
     # If running in DESKTOP=gnome, systemd-logind restart may cause the graphical console to
     # reset and appear in SUD, so need to select 'root-console' again
-    select_console 'root-console' unless (check_screen 'root-console');
+    assert_screen([qw(root-console displaymanager displaymanager-password-prompt generic-desktop)]);
+    select_console 'root-console' unless (match_has_tag 'root-console');
 
     assert_script_run "saptune daemon start";
     assert_script_run "saptune solution verify NETWEAVER";

--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -24,7 +24,7 @@ sub run {
     select_console 'root-console';
 
     # Disable packagekit
-    systemctl '--now mask packagekit.service';
+    pkcon_quit;
 
     my $base_pattern = sle_version_at_least('15') ? 'patterns-server-enterprise-sap_server' : 'patterns-sles-sap_server';
 
@@ -55,9 +55,6 @@ sub run {
         die "SAP zypper pattern [$pattern] info check failed"
           unless ($output =~ /i\+\s\|\spatterns-$pattern\s+\|\spackage\s\|\sRequired/);
     }
-
-    # Enable packagekit
-    systemctl '--now unmask packagekit.service';
 }
 
 sub test_flags {

--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -12,6 +12,7 @@
 
 use base "sles4sap";
 use testapi;
+use utils;
 use version_utils 'sle_version_at_least';
 use strict;
 
@@ -21,6 +22,9 @@ sub run {
     my $output      = '';
 
     select_console 'root-console';
+
+    # Disable packagekit
+    systemctl '--now mask packagekit.service';
 
     my $base_pattern = sle_version_at_least('15') ? 'patterns-server-enterprise-sap_server' : 'patterns-sles-sap_server';
 
@@ -51,6 +55,9 @@ sub run {
         die "SAP zypper pattern [$pattern] info check failed"
           unless ($output =~ /i\+\s\|\spatterns-$pattern\s+\|\spackage\s\|\sRequired/);
     }
+
+    # Enable packagekit
+    systemctl '--now unmask packagekit.service';
 }
 
 sub test_flags {

--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -40,7 +40,7 @@ sub run {
       . 'Loaded: loaded \(/usr/lib/systemd/system/tuned.service;.+'
       . 'Active: active \(running\).+'
       . 'Starting Dynamic System Tuning Daemon.+'
-      . 'Started Dynamic System Tuning Daemon.$';
+      . 'Started Dynamic System Tuning Daemon.';
     die "Command 'sapconf status' output is not recognized" unless ($output =~ m|$statusregex|s);
 
     $output = script_output "tuned-adm active";


### PR DESCRIPTION
This PR includes the following:

1. Replaces the call to `wait_still_screen` in `tests/sles4sap/netweaver_ascs_install` with a call to ~check_screen 'root-console'~ `assert_screen` with multiple tags. The call to `systemctl restart systemd-logind` does reset the screen away from `root-console` when `DESKTOP=gnome`, but instead of waiting for the screen to stop from changing, a call to verify if the `root-console` is correctly selected followed by a `select_console 'root-console'` also fixes the test, while improving readibility. Also, when the test is run in a system with `DESKTOP=textmode`, ~check_screen~ `assert_screen` should return faster as the `root-console` is not changed instead of the 7 seconds of still screen in `wait_still_screen`, while when `DESKTOP=gnome` the default timeout of ~check_screen~ `assert_screen` is the same as the timeout of `wait_still_screen`.
2. Improve regexp in `tests/sles4sap/sapconf` to avoid false positives when the serial console is contaminated with extra characters.
3. Disable `packagekit` before `zypper` calls in `tests/sles4sap/patterns`. ~Re-enable after test is done~. This in order to fix these false positives: https://openqa.suse.de/tests/1485695#step/patterns/27

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/245 & http://mango.suse.de/tests/246