### PR TITLE
Revert password field selection using shortcut

### DIFF
--- a/tests/installation/user_settings.pm
+++ b/tests/installation/user_settings.pm
@@ -28,8 +28,9 @@ sub run {
     }
 
     send_key 'alt-f';    # Select full name text field
-    type_string $realname;
-    send_key 'alt-p';    # Select password field
+    wait_screen_change { type_string $realname };
+    send_key 'tab';      # Select password field
+    send_key 'tab';
     $self->type_password_and_verification;
     assert_screen 'inst-userinfostyped';
     if (get_var('NOAUTOLOGIN') && !check_screen('autologindisabled', timeout => 0)) {


### PR DESCRIPTION
Rebase of original #4448 (with passing ci)

Change introduced in
[PR#4437](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4437)
caused more new problems, and was trying to fix problem that happened
just once. Somehow, even keypresses are correct, we do not type password
correctly. So I remove change to select password field and use tab key
instead. I was not able to reproduce exactly same issue, when password
is typed only once.

Verification runs (from #4448)
http://g226.suse.de/tests/829
http://g226.suse.de/tests/828

- Related ticket: https://progress.opensuse.org/issues/27600
- Fixes https://openqa.opensuse.org/tests/614188#step/user_settings/3
- Fixes https://openqa.opensuse.org/tests/614196#step/user_settings/1