### PR TITLE
yast2_control_center: Skip dropped CA management modules on SLE15

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -330,8 +330,12 @@ sub run {
     if (is_sle) {
         start_add_system_extensions_or_modules;
         start_kernel_dump;
-        start_common_server_certificate;
-        start_ca_management;
+        # YaST2 CA management has been dropped from SLE15, see
+        # https://bugzilla.suse.com/show_bug.cgi?id=1059569#c14
+        if (!sle_version_at_least('15')) {
+            start_common_server_certificate;
+            start_ca_management;
+        }
         start_wake_on_lan;
         # available by default only on SLES
         start_authentication_server;


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/31648