### PR TITLE
Download the new kubeconfig in case of failure

### DIFF
--- a/tests/caasp/stack_kubernetes.pm
+++ b/tests/caasp/stack_kubernetes.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Test kubernetes by deploying nginx
-# Maintainer: Martin Kravec <mkravec@suse.com>
+# Maintainer: Martin Kravec <mkravec@suse.com>, Panagiotis Georgiadis <pgeorgiadis@suse.com>
 
 use parent 'caasp_controller';
 use caasp_controller;
@@ -21,6 +21,7 @@ sub run {
     # Use downloaded kubeconfig to display basic information
     switch_to 'xterm';
     assert_script_run "kubectl cluster-info";
+    assert_script_run "kubectl cluster-info > cluster.before_update";
     assert_script_run "kubectl get nodes";
     assert_script_run "! kubectl get cs --no-headers | grep -v Healthy";
 


### PR DESCRIPTION
If DEX gets updated, it might be that the old kubeconfig will no
longer be working. In this scenario, it is advised to download
and use the new one.

- Related ticket: https://progress.opensuse.org/issues/32023
- Needles: *not needed*
- Verification run: http://skyrim.qam.suse.de/tests/1856#step/stack_update/31
