### PR TITLE
Wait for remote children in remote installation tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1293,7 +1293,7 @@ elsif (get_var("SUPPORT_SERVER")) {
         load_inst_tests();
     }
     loadtest "ha/barrier_init" if get_var("HA_CLUSTER_SUPPORT_SERVER");
-    unless (load_slenkins_tests() || get_var("REMOTE_CONTROLLER")) {
+    unless (load_slenkins_tests()) {
         loadtest "support_server/wait_children";
     }
 }

--- a/tests/support_server/wait_children.pm
+++ b/tests/support_server/wait_children.pm
@@ -25,27 +25,29 @@ use mmapi;
 sub run {
     my $self = shift;
 
-    type_string("journalctl -f |tee /dev/$serialdev\n");
+    # We don't need any logs from support server when running on REMOTE_CONTROLLER for remote SLE installation tests
+    type_string("journalctl -f |tee /dev/$serialdev\n") unless (get_var('REMOTE_CONTROLLER'));
 
     wait_for_children;
 
-    send_key("ctrl-c");
+    unless (get_var('REMOTE_CONTROLLER')) {
+        send_key("ctrl-c");
 
-    my @server_roles = split(',|;', lc(get_var("SUPPORT_SERVER_ROLES")));
-    my %server_roles = map { $_ => 1 } @server_roles;
+        my @server_roles = split(',|;', lc(get_var("SUPPORT_SERVER_ROLES")));
+        my %server_roles = map { $_ => 1 } @server_roles;
 
-    # No messages file in openSUSE which use journal by default
-    # Write journal log to /var/log/messages for openSUSE
-    if (check_var('DISTRI', 'opensuse')) {
-        script_run 'journalctl -b -x > /var/log/messages', 90;
+        # No messages file in openSUSE which use journal by default
+        # Write journal log to /var/log/messages for openSUSE
+        if (check_var('DISTRI', 'opensuse')) {
+            script_run 'journalctl -b -x > /var/log/messages', 90;
+        }
+        my $log_cmd = "tar cjf /tmp/logs.tar.bz2 /var/log/messages ";
+        if (exists $server_roles{qemuproxy} || exists $server_roles{aytest}) {
+            $log_cmd .= "/var/log/apache2 ";
+        }
+        assert_script_run $log_cmd;
+        upload_logs "/tmp/logs.tar.bz2";
     }
-    my $log_cmd = "tar cjf /tmp/logs.tar.bz2 /var/log/messages ";
-    if (exists $server_roles{qemuproxy} || exists $server_roles{aytest}) {
-        $log_cmd .= "/var/log/apache2 ";
-    }
-    assert_script_run $log_cmd;
-    upload_logs "/tmp/logs.tar.bz2";
-
     $self->result('ok');
 }
 


### PR DESCRIPTION
Currently the support_server VM and its DHCP service doesn't wait for initial bootup of remote VM when the installation is done and then the remote VM doesn't have any IPv4 address.

- Related ticket: https://progress.opensuse.org/issues/32107
- Needles: -
- Verification run: 
  * Before: https://openqa.suse.de/tests/1487230#step/remote_target/3 - note there is no ipv4 address for eth0 adaptor.
  * After: http://dhcp195.suse.cz/tests/594#step/remote_target/3
