### PR TITLE
Fix encrypted kernel

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -329,9 +329,8 @@ sub workaround_type_encrypted_passphrase {
     # nothing to do if the boot partition is not encrypted in FULL_LVM_ENCRYPT
     return if get_var('UNENCRYPTED_BOOT');
     return if !get_var('ENCRYPT') && !get_var('FULL_LVM_ENCRYPT');
-    # ppc64le is always doing the opposite by default :)
-    # ppc storage-ng encrypt
-    return if (is_storage_ng && check_var('ARCH', 'ppc64le')) || (!is_storage_ng && !check_var('ARCH', 'ppc64le'));
+    # ppc64le on pre-storage-ng boot was part of encrypted LVM
+    return if !get_var('FULL_LVM_ENCRYPT') && !is_storage_ng && !check_var('ARCH', 'ppc64le');
     # If the encrypted disk is "just activated" it does not mean that the
     # installer would propose an encrypted installation again
     return if get_var('ENCRYPT_ACTIVATE_EXISTING') && !get_var('ENCRYPT_FORCE_RECOMPUTE');

--- a/tests/installation/partitioning_full_lvm.pm
+++ b/tests/installation/partitioning_full_lvm.pm
@@ -37,12 +37,8 @@ sub run {
         addpart(role => 'OS', size => 500, format => 'ext2', mount => '/boot/zipl');
     }
 
-    # ppc with lvm requires separate boot on storage-ng or if want to test with UNENCRYPTED_BOOT set to true
     if (get_var('UNENCRYPTED_BOOT')) {
         addpart(role => 'OS', size => 500, format => 'ext2', mount => '/boot');
-    }
-    elsif (check_var('ARCH', 'ppc64le') && is_storage_ng) {
-        addpart(role => 'OS', size => 500, format => 'ext2', mount => '/boot', encrypt => 1);
     }
 
     addpart(role => 'raw', encrypt => 1);


### PR DESCRIPTION
When the path /boot is encryped, grub needs password to access the kernel.

- Fixing:
  - https://openqa.suse.de/tests/1486799#step/grub_test/3
  - https://openqa.suse.de/tests/1486786#step/grub_test/3
  - https://openqa.suse.de/tests/1486752#step/grub_test/4
