### PR TITLE
Move static aytests variables expansion from cgi to sed

### DIFF
--- a/data/supportserver/aytests/aytests.cgi
+++ b/data/supportserver/aytests/aytests.cgi
@@ -10,8 +10,4 @@ echo "replacing MAC '$MAC' in '$FILE'" > /dev/stderr
 
 echo "Content-type: text/xml"
 echo
-sed -e "s|{{MAC1}}|$MAC|g" \
-    -e "s|{{REPO1_URL}}|http://10.0.2.1/aytests/files/repos/sles12|g" \
-    -e "s|{{POST_SCRIPT_URL}}|http://10.0.2.1/aytests/files/scripts/post_script.sh|g" \
-    -e "s|{{INIT_SCRIPT_URL}}|http://10.0.2.1/aytests/files/scripts/init_script.sh|g" \
-     "/srv/www/htdocs/aytests/$FILE"
+sed -e "s|{{MAC1}}|$MAC|g" "/srv/www/htdocs/aytests/$FILE"

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -410,6 +410,9 @@ sub setup_aytests {
            -e 's|{{VERSION}}|" . get_var('VERSION') . "|g' \\
            -e 's|{{ARCH}}|" . get_var('ARCH') . "|g' \\
            -e 's|{{MSG_TIMEOUT}}|0|g' \\
+           -e 's|{{REPO1_URL}}|http://10.0.2.1/aytests/files/repos/sles12|g' \\
+           -e 's|{{POST_SCRIPT_URL}}|http://10.0.2.1/aytests/files/scripts/post_script.sh|g' \\
+           -e 's|{{INIT_SCRIPT_URL}}|http://10.0.2.1/aytests/files/scripts/init_script.sh|g' \\
            /srv/www/htdocs/aytests/*.xml;
 
     systemctl restart apache2;


### PR DESCRIPTION
So having a single place where we do variable expansion didn't work well. Idea was to get file content from support_server before starting child VM and then reupload it using workers mojolicious server. However, for multimachine setup we don't have routes configured to access support server http from outside, so it's not guaranteed to be there on the workers. Hence we have to keep this expansion in 2 places, and expanding MAC address is not possible other way as it not available before support server is contacted. So with this PR moving everything that can be done statically to one place and will have to continue using cgi for some cases like MAC.

See [poo#30246](https://progress.opensuse.org/issues/30246).

- Verification run:
 * [tftp](http://gershwin.arch.suse.de/tests/94)
 * [support server](http://gershwin.arch.suse.de/tests/93)
