### PR TITLE
Fix wrong scheduling of hostname_inst on openSUSE (regression in #4432)

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -795,7 +795,7 @@ sub load_inst_tests {
             and !is_hyperv_in_gui
             and !is_bridged_networking
             and !check_var('BACKEND', 's390x')
-            and sle_version_at_least('12-SP2'))
+            and is_sle && sle_version_at_least('12-SP2'))
         {
             loadtest "installation/hostname_inst";
         }


### PR DESCRIPTION
See https://openqa.opensuse.org/tests/615862#step/hostname_inst/2

Seems like hostname_inst was never tried on openSUSE.