### PR TITLE
docker: Register containers module as needed on SLE>=15

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1336,7 +1336,6 @@ sub load_extra_tests {
         if (get_var("IPSEC")) {
             loadtest "console/ipsec_tools_h2h";
         }
-        load_docker_tests if (check_var('ARCH', 'x86_64') && (sle_version_at_least('12-SP2') || !is_sle));
         loadtest "console/git";
         loadtest "console/java";
         loadtest "console/sysctl";
@@ -1354,6 +1353,9 @@ sub load_extra_tests {
             # sysauth test scenarios run in the console
             loadtest "sysauth/sssd";
         }
+        # schedule the docker tests later as it needs the containers module on
+        # SLE>=15 and therefore would potentially pollute other test modules
+        load_docker_tests if (check_var('ARCH', 'x86_64') && (sle_version_at_least('12-SP2') || !is_sle));
         loadtest "console/kdump_and_crash" if kdump_is_applicable;
         loadtest "console/consoletest_finish";
     }

--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -27,7 +27,8 @@ use base "consoletest";
 use testapi;
 use utils;
 use strict;
-use version_utils 'is_caasp';
+use version_utils qw(is_caasp is_sle sle_version_at_least);
+use registration;
 
 sub run {
     select_console("root-console");
@@ -37,6 +38,7 @@ sub run {
         die "Docker is not pre-installed." if script_run("zypper se -x --provides -i docker | grep docker");
     }
     else {
+        add_suseconnect_product('sle-module-containers') if is_sle && sle_version_at_least('15');
         # docker package can be installed
         zypper_call("in docker");
     }


### PR DESCRIPTION
Also moving the docker test modules further back in the test schedule as an
additional module can have a potential impact on later test modules.

Verification run: http://lord.arch/tests/613#step/docker/2

Related progress issue: https://progress.opensuse.org/issues/31453