### PR TITLE
Fix calls to sles4sap methods in main and main_common

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -38,6 +38,7 @@ our @EXPORT = qw(
   is_mediacheck
   is_server
   is_sles4sap
+  is_sles4sap_standard
   need_clear_repos
   have_scc_repos
   load_svirt_vm_setup_tests
@@ -51,6 +52,7 @@ our @EXPORT = qw(
   load_autoyast_clone_tests
   load_slepos_tests
   load_docker_tests
+  load_sles4sap_tests
   installzdupstep_is_applicable
   snapper_is_applicable
   chromestep_is_applicable
@@ -722,7 +724,7 @@ sub load_inst_tests {
         {
             loadtest "installation/system_role";
         }
-        if (is_sles4sap() and sle_version_at_least('15')) {
+        if (is_sles4sap() and sle_version_at_least('15') and check_var('SYSTEM_ROLE', 'default')) {
             loadtest "installation/sles4sap_product_installation_mode";
         }
         loadtest "installation/partitioning";
@@ -1700,6 +1702,18 @@ sub load_ssh_key_import_tests {
     load_reboot_tests();
     # verify previous defined ssh keys
     loadtest "x11/ssh_key_verify";
+}
+
+sub load_sles4sap_tests {
+    return if get_var('INSTALLONLY');
+    loadtest "sles4sap/desktop_icons" if (is_desktop_installed());
+    loadtest "sles4sap/patterns";
+    loadtest "sles4sap/sapconf";
+    loadtest "sles4sap/saptune";
+    if (get_var('NW')) {
+        loadtest "sles4sap/netweaver_ascs_install" if (get_var('SLES4SAP_MODE') !~ /wizard/);
+        loadtest "sles4sap/netweaver_ascs";
+    }
 }
 
 1;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -626,18 +626,6 @@ sub load_patching_tests {
     }
 }
 
-sub load_sles4sap_tests {
-    return if get_var('INSTALLONLY');
-    loadtest "sles4sap/desktop_icons" if (is_desktop_installed());
-    loadtest "sles4sap/patterns";
-    loadtest "sles4sap/sapconf";
-    loadtest "sles4sap/saptune";
-    if (get_var('NW')) {
-        loadtest "sles4sap/netweaver_ascs_install" if (get_var('SLES4SAP_MODE') !~ /wizard/);
-        loadtest "sles4sap/netweaver_ascs";
-    }
-}
-
 sub prepare_target {
     if (get_var("BOOT_HDD_IMAGE")) {
         boot_hdd_image;


### PR DESCRIPTION
Pull request https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4432 introduced some changes which moved methods out of main.pm into different libraries (version_utils, main_common, etc.). As a result, the schedule of SLES4SAP-related tasks is failing mainly due to 3 problems:

1. `is_sles4sap_standard` method is called in `products/sle/main.pm` but it's not being exported by `lib/main_common.pm` nor being specifically included in `products/sle/main.pm` in the line `use version_utils`; this causes failures like this: https://openqa.suse.de/tests/1493885/file/autoinst-log.txt

2. `load_sles4sap_tests` in being called in `lib/main_common.pm`, but it was defined in `products/sle/main.pm`.

3. Test `installation/sles4sap_product_installation_mode` is being scheduled when installing SLES4SAP with `SYSTEM_ROLE=textmode`, but the step is skipped in the installer for all system roles save SLES for SAP Applications. Failing test: https://openqa.suse.de/tests/1492176#step/sles4sap_product_installation_mode/2

This commit moves the `load_sles4sap_tests` method from `products/sle/main` to `lib/main_common` and exports it so it can also be used in main, exports `is_sles4sap_standard` in `lib/main_common` so it can be used in main, and adds the `SYSTEM_ROLE=default` check in `lib/main_common` (in the method `load_inst_tests`) when installing SLES4SAP-15 so the test `installation/sles4sap_product_installation_mode` is only loaded when the correct system role has been selected.

- Related ticket: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4432
- Needles: N/A
- Verification run: http://mango.suse.de/tests/252 & http://mango.suse.de/tests/253
