### PR TITLE
Clean up qa_net test module usages

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -324,9 +324,6 @@ sub load_boot_tests {
     if ((get_var("UEFI") || is_jeos()) && !check_var("BACKEND", "svirt")) {
         loadtest "installation/bootloader_uefi";
     }
-    elsif (get_var("IPMI_HOSTNAME")) {    # abuse of variable for now
-        loadtest "installation/qa_net";
-    }
     elsif (check_var("BACKEND", "svirt") && !check_var("ARCH", "s390x")) {
         load_svirt_vm_setup_tests;
     }


### PR DESCRIPTION
[PR#4432](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4432/files) has revealed code path which is outdated. Test module was removed in this [commit](https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/6c24784f609b5b20b314e5fbe0f6acc3479bd54a) for sle, but not for opensuse. As we don't trigger this path on o3, we haven't seen this issue. So removing from main_common.

See [poo#32146](https://progress.opensuse.org/issues/32146).

