### PR TITLE
Replace check_var ARCH ppc64le by get_var OFW

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -57,7 +57,7 @@ sub stop_grub_timeout {
 }
 
 sub boot_local_disk {
-    if (check_var('ARCH', 'ppc64le')) {
+    if (get_var('OFW')) {
         # TODO use bootindex to properly boot from disk when first in boot order is cd-rom
         wait_screen_change { send_key 'ret' };
         assert_screen [qw(inst-slof bootloader grub2 inst-bootmenu)];
@@ -132,13 +132,13 @@ sub select_bootmenu_option {
 
     if (get_var('UPGRADE')) {
         # OFW has contralily oriented menu behavior
-        send_key_until_needlematch 'inst-onupgrade', check_var('ARCH', 'ppc64le') ? 'up' : 'down', 10, 5;
+        send_key_until_needlematch 'inst-onupgrade', get_var('OFW') ? 'up' : 'down', 10, 5;
     }
     else {
         if (get_var('PROMO') || get_var('LIVETEST') || get_var('LIVE_INSTALLATION')) {
             send_key_until_needlematch 'boot-live-' . get_var('DESKTOP'), 'down', 10, 5;
         }
-        elsif (check_var('ARCH', 'ppc64le')) {
+        elsif (get_var('OFW')) {
             send_key_until_needlematch 'inst-oninstallation', 'up', 10, 5;
         }
         elsif (!get_var('JEOS')) {
@@ -210,7 +210,7 @@ sub type_hyperv_fb_video_resolution {
 }
 
 sub bootmenu_default_params {
-    if (check_var('ARCH', 'ppc64le')) {
+    if (get_var('OFW')) {
         # edit menu, wait until we get to grub edit
         wait_screen_change { send_key "e" };
         # go down to kernel entry
@@ -265,7 +265,7 @@ sub bootmenu_default_params {
 sub bootmenu_network_source {
     # set HTTP-source to not use factory-snapshot
     if (get_var("NETBOOT")) {
-        if (check_var('ARCH', 'ppc64le')) {
+        if (get_var('OFW')) {
             if (get_var("SUSEMIRROR")) {
                 type_string_very_slow ' install=http://' . get_var("SUSEMIRROR");
             }

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -333,7 +333,7 @@ sub workaround_type_encrypted_passphrase {
     return if get_var('UNENCRYPTED_BOOT');
     return if !get_var('ENCRYPT') && !get_var('FULL_LVM_ENCRYPT');
     # ppc64le on pre-storage-ng boot was part of encrypted LVM
-    return if !get_var('FULL_LVM_ENCRYPT') && !is_storage_ng && !check_var('ARCH', 'ppc64le');
+    return if !get_var('FULL_LVM_ENCRYPT') && !is_storage_ng && !get_var('OFW');
     # If the encrypted disk is "just activated" it does not mean that the
     # installer would propose an encrypted installation again
     return if get_var('ENCRYPT_ACTIVATE_EXISTING') && !get_var('ENCRYPT_FORCE_RECOMPUTE');

--- a/tests/console/kdump_and_crash.pm
+++ b/tests/console/kdump_and_crash.pm
@@ -44,7 +44,7 @@ sub run {
     select_console 'root-console';
 
     # all but PPC64LE arch's vmlinux images are gzipped
-    my $suffix = check_var('ARCH', 'ppc64le') ? '' : '.gz';
+    my $suffix = get_var('OFW') ? '' : '.gz';
     assert_script_run 'find /var/crash/';
     my $crash_cmd = "echo exit | crash `ls -1t /var/crash/*/vmcore | head -n1` /boot/vmlinux-`uname -r`$suffix";
     assert_script_run "$crash_cmd", 600;

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -39,7 +39,7 @@ sub run {
     }
     # on ppc64le boot have to be confirmed with ctrl-x or F10
     # and it doesn't have nice graphical menu with video and language options
-    if (!check_var('ARCH', 'ppc64le')) {
+    if (!get_var('OFW')) {
         select_bootmenu_language;
         select_bootmenu_video_mode;
         # boot

--- a/tests/installation/partitioning_full_lvm.pm
+++ b/tests/installation/partitioning_full_lvm.pm
@@ -22,10 +22,10 @@ use version_utils 'is_storage_ng';
 
 sub run {
     create_new_partition_table;
-    if (check_var('ARCH', 'ppc64le')) {    # ppc64le always needs PReP boot
+    if (get_var('OFW')) {    # ppc64le always needs PReP boot
         addpart(role => 'raw', size => 500, fsid => 'PReP');
     }
-    elsif (get_var('UEFI')) {              # UEFI needs partition mounted to /boot/efi for
+    elsif (get_var('UEFI')) {    # UEFI needs partition mounted to /boot/efi for
         addpart(role => 'efi', size => 100);
     }
     elsif (is_storage_ng && check_var('ARCH', 'x86_64')) {

--- a/tests/installation/partitioning_warnings.pm
+++ b/tests/installation/partitioning_warnings.pm
@@ -24,7 +24,7 @@ sub run {
     if (check_var('ARCH', 's390x')) {    # s390x need /boot/zipl on ext partition
         addpart(role => 'OS', size => 500, format => 'ext2', mount => '/boot');
     }
-    elsif (check_var('ARCH', 'ppc64le')) {    # ppc64le need PReP /boot
+    elsif (get_var('OFW')) {             # ppc64le need PReP /boot
         addpart(role => 'raw', size => 500, fsid => 'PReP');
     }
     # create small enough partition (11GB) to get warning

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -101,7 +101,7 @@ sub run {
                 sles4sap => 'i',
                 hpc      => 'x'
             );
-            $hotkey{sles4sap} = 'u' if check_var('ARCH', 'ppc64le');
+            $hotkey{sles4sap} = 'u' if get_var('OFW');
             my $product = get_required_var('SLE_PRODUCT');
             send_key 'alt-' . $hotkey{$product};
             assert_screen('select-product-' . $product);

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -172,7 +172,7 @@ sub run {
     $self->wait_boot;
 
     # poo#18980
-    if (check_var('ARCH', 'ppc64le') && check_var('VIRTIO_CONSOLE', 1)) {
+    if (get_var('OFW') && check_var('VIRTIO_CONSOLE', 1)) {
         select_console('root-console');
         add_serial_console('hvc1');
     }

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -24,7 +24,7 @@ sub run {
     my ($self) = @_;
 
     my @solutions
-      = check_var('ARCH', 'ppc64le') ?
+      = get_var('OFW') ?
       qw(HANA MAXDB NETWEAVER S4HANA-APPSERVER S4HANA-DBSERVER)
       : qw(BOBJ HANA MAXDB NETWEAVER S4HANA-APPSERVER S4HANA-DBSERVER SAP-ASE);
 

--- a/tests/x11/reboot_and_install.pm
+++ b/tests/x11/reboot_and_install.pm
@@ -49,7 +49,7 @@ sub run {
     }
     else {
         # boot
-        my $key = check_var('ARCH', 'ppc64le') || check_var('ARCH', 'aarch64') ? 'ctrl-x' : 'ret';
+        my $key = get_var('OFW') || check_var('ARCH', 'aarch64') ? 'ctrl-x' : 'ret';
         send_key $key;
     }
 


### PR DESCRIPTION
problem initially detected on ppc64 (BE) tests failures
with openSUSE snapshot 2018021 as reported by
https://progress.opensuse.org/issues/32155

* Assumption: OFW key defined in used templates for PowerPC arches
(ppc64, ppc64le) which is the case for default opensuse templates
(bot not for sle one <= potential TODO)
```
$find . -name templates -exec grep -Hn backend -A8 {}
\; |grep -E 'backend|ppc64|OFW' |grep ppc64 -A100
products/opensuse/templates-2691- name => "ppc64le",
products/opensuse/templates-2694- { key => "OFW", value => 1 },
products/opensuse/templates-2695- { key => "QEMU", value => "ppc64" },
products/opensuse/templates:2704: backend => "qemu",
products/opensuse/templates-2705- name => "ppc64",
products/opensuse/templates-2708- { key => "OFW", value => 1 },
products/opensuse/templates-2709- { key => "QEMU", value => "ppc64" },
products/opensuse/templates:2718: backend => "qemu",
products/opensuse/templates-2719- name => "ppc64le-multipath",
products/opensuse/templates-2723- { key => "OFW", value => 1 },
products/opensuse/templates-2724- { key => "QEMU", value => "ppc64" },
products/opensuse/templates:2733: backend => "qemu",
products/opensuse/templates-2734- name => "ppc64-multipath",
products/opensuse/templates-2738- { key => "OFW", value => 1 },
products/opensuse/templates-2739- { key => "QEMU", value => "ppc64" },
products/opensuse/templates:2748: backend => "qemu",
```

- Related ticket: https://progress.opensuse.org/issues/32155
- Verification run: not yet
