### PR TITLE
WIP: Add workaround for hostname dhcp/dns update

### DIFF
--- a/tests/console/hostname.pm
+++ b/tests/console/hostname.pm
@@ -40,6 +40,16 @@ sub run {
         assert_script_run "ip addr show br0 | grep UP";
         save_screenshot;
     }
+
+    my $network_restart_count = 0;
+    # Verify DNS is updated and restart network if verification fails
+    while ($network_restart_count < 2 && script_run("host ${hostname}")) {
+        record_soft_failure "bsc#981651";
+        systemctl('restart network');
+        systemctl('status network');
+        save_screenshot;
+        $network_restart_count++;
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
Fix poo#32158: Implement workaround for bsc#981651. If hostname check
fail, proceed with network restart.


- Related ticket: https://progress.opensuse.org/issues/32158
- Needles: none
- Verification run: http://10.100.12.105/tests/1524
http://10.100.12.105/tests/1523

