### PR TITLE
Update sapconf test for SLES for SAP 15

### DIFF
--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -36,9 +36,9 @@ sub run {
         # the use of the 'textmode' system role
         die "Pattern sap_server not installed by default"
           unless (check_var('SYSTEM_ROLE', 'textmode'));
-        record_info('install sap_server', 'Installing sap_server pattern and starting sapconf');
+        record_info('install sap_server', 'Installing sap_server pattern and starting tuned');
         assert_script_run("zypper in -y -t pattern sap_server");
-        assert_script_run("sapconf start");
+        assert_script_run("systemctl start tuned");
     }
 
     # Dry run of each pattern's installation before actual installation

--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -56,12 +56,14 @@ sub run {
     my $default_profile = $1;
     record_info("Current profile", "Current default profile: $default_profile");
 
-    $output = script_output "tuned-adm recommend";
-    record_info("Recommended profile", "Recommended profile: $output");
-
     $statusregex = join('.+', @tuned_profiles);
     $output = script_output "tuned-adm list";
     die "Command 'tuned-adm list' output is not recognized" unless ($output =~ m|$statusregex|s);
+
+    $output = script_output "tuned-adm recommend";
+    record_info("Recommended profile", "Recommended profile: $output");
+    die "Command 'tuned-adm recommended' recommended profile is not in 'tuned-adm list'"
+      unless (grep(/$output/, @tuned_profiles));
 
     foreach my $p (@tuned_profiles) {
         assert_script_run "tuned-adm profile_info $p" if sle_version_at_least('15');

--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -12,9 +12,14 @@
 
 use base "sles4sap";
 use testapi;
+use version_utils 'sle_version_at_least';
 use strict;
 
-my %profiles = (
+my @tuned_profiles = qw(balanced desktop latency-performance network-latency
+  network-throughput powersave sap-ase sap-bobj sap-hana sap-netweaver saptune
+  throughput-performance virtual-guest virtual-host);
+
+my %sapconf_profiles = (
     hana   => 'sap-hana',
     b1     => 'sap-hana',
     ase    => 'sap-ase',
@@ -25,8 +30,9 @@ my %profiles = (
 sub check_profile {
     my $current = shift;
     my $output  = script_output "tuned-adm active";
-    die "Tuned profile change failed. Expected 'Current active profile: $profiles{$current}', got: [$output]"
-      unless ($output =~ /Current active profile: $profiles{$current}/);
+    my $profile = sle_version_at_least('15') ? $current : $sapconf_profiles{$current};
+    die "Tuned profile change failed. Expected 'Current active profile: $profile', got: [$output]"
+      unless ($output =~ /Current active profile: $profile/);
 }
 
 sub run {
@@ -34,26 +40,48 @@ sub run {
 
     select_console 'root-console';
 
-    my $output = script_output "sapconf status";
+    my $output = script_output "systemctl status tuned";
     my $statusregex
       = 'tuned.service - Dynamic System Tuning Daemon.+'
       . 'Loaded: loaded \(/usr/lib/systemd/system/tuned.service;.+'
       . 'Active: active \(running\).+'
       . 'Starting Dynamic System Tuning Daemon.+'
       . 'Started Dynamic System Tuning Daemon.';
-    die "Command 'sapconf status' output is not recognized" unless ($output =~ m|$statusregex|s);
+    die "Command 'systemctl status tuned' output is not recognized" unless ($output =~ m|$statusregex|s);
+
+    assert_script_run("rpm -q sapconf");
 
     $output = script_output "tuned-adm active";
     $output =~ /Current active profile: ([a-z\-]+)/;
     my $default_profile = $1;
     record_info("Current profile", "Current default profile: $default_profile");
 
-    foreach my $cmd ('start', keys %profiles) {
-        $output = script_output "sapconf $cmd";
-        die "Command 'sapconf $cmd' output is not recognized" unless ($output =~ /Forwarding action to tuned\-adm\./);
-        next if ($cmd eq 'start');
-        check_profile($cmd);
+    $output = script_output "tuned-adm recommend";
+    record_info("Recommended profile", "Recommended profile: $output");
+
+    $statusregex = join('.+', @tuned_profiles);
+    $output = script_output "tuned-adm list";
+    die "Command 'tuned-adm list' output is not recognized" unless ($output =~ m|$statusregex|s);
+
+    foreach my $p (@tuned_profiles) {
+        assert_script_run "tuned-adm profile_info $p" if sle_version_at_least('15');
+        assert_script_run "tuned-adm profile $p";
+        check_profile($p);
     }
+
+    unless (sle_version_at_least('15')) {
+        foreach my $cmd ('start', keys %sapconf_profiles) {
+            $output = script_output "sapconf $cmd";
+            die "Command 'sapconf $cmd' output is not recognized"
+              unless ($output =~ /Forwarding action to tuned\-adm\./);
+            next if ($cmd eq 'start');
+            check_profile($cmd);
+        }
+    }
+
+    assert_script_run "tuned-adm off";
+    $output = script_output "tuned-adm active || true";
+    die "Command 'tuned-adm off' failed to disable profile" unless ($output =~ /No current active profile/);
 
     # Set default profile again
     assert_script_run "tuned-adm profile $default_profile";


### PR DESCRIPTION
`sapconf` cli will be dropped from SLES4SAP-15 per https://fate.suse.com/324490 and bsc#1070505. This PR updates `tests/sles4sap/patterns` and `tests/sles4sap/sapconf`, switching its calls to `sapconf` for the equivalent `systemctl status tuned` and `tuned-adm profile` commands. Also adds several checks to `tuned-adm` sub commands.

- Related ticket: https://fate.suse.com/324490 & https://bugzilla.suse.com/show_bug.cgi?id=1070505
- Needles: N/A
- Verification run: http://mango.suse.de/tests/255 (SLES4SAP-15 textmode), http://mango.suse.de/tests/256 (SLES4SAP-15 gnome), http://mango.suse.de/tests/257 (SLES4SAP 12SP3)