### PR TITLE
Remove space characters around wait_serial output.

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -153,6 +153,7 @@ sub get_installation_partition {
     #Do not use script_output because when the command fail, script_output dies
     type_string(qq{fdisk -l | grep "^/dev/sda.*\\*" | cut -d ' ' -f 1 | tee /dev/$serialdev\n});
     $partition = wait_serial;
+    $partition =~ s/^\s+|\s+$//g;
     save_screenshot;
     if (is_storage_ng && ($partition eq '')) {
         record_soft_failure "bsc#1080729 - Partitioner does not mark boot flag";


### PR DESCRIPTION
This is to fix failure in https://openqa.suse.de/tests/1471528#step/install_and_reboot/21, which didn't remove the unnecessary new line/blank characters from wait_serial output.

- Verification run: http://10.67.18.220/tests/547#step/logs_from_installation_system/16