### PR TITLE
Fix wrong logic evaluation in disable_grub_timeout

### DIFF
--- a/tests/console/openvswitch.pm
+++ b/tests/console/openvswitch.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2017 SUSE LLC
+# Copyright © 2016-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -23,10 +23,14 @@ use base "consoletest";
 use testapi;
 use strict;
 use utils;
+use version_utils qw(is_sle sle_version_at_least);
 
 sub run {
     select_console 'root-console';
-
+    if (is_sle && sle_version_at_least('15')) {
+        my $ret = zypper_call('in openvswitch-switch', exitcode => [0, 104], timeout => 300);
+        return record_soft_failure 'bsc#1082757' if $ret == 104;
+    }
     zypper_call('in openvswitch-switch iputils', timeout => 300);
 
     # Start the openvswitch daemon

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -32,7 +32,7 @@ sub run {
 
     # Workaround for bsc#1070233: not update "Booting" option in upgrade mode
     return record_soft_failure('bsc#1070233: Error if click on Booting option')
-      if (get_var('UPGRADE') && !(is_sle && !sle_version_at_least('15')) || !(is_leap && !leap_version_at_least('15.0')));
+      if (get_var('UPGRADE') && (!(is_sle && !sle_version_at_least('15')) || !(is_leap && !leap_version_at_least('15.0'))));
 
     # Verify Installation Settings overview is displayed as starting point
     assert_screen "installation-settings-overview-loaded";


### PR DESCRIPTION
Regression introduced with 28af263e. The record_soft_failure should only ever
be called on upgrade.