### PR TITLE
Remove missing packages from multipath ay profile

### DIFF
--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -377,7 +377,6 @@ pre init scripts feature. See poo#20818.
     <install_recommended config:type="boolean">true</install_recommended>
     <packages config:type="list">
       <package>bash-doc</package>
-      <package>samba</package>
       <package>cups</package>
       <package>dmidecode</package>
       <package>libgmodule-2_0-0</package>
@@ -386,16 +385,13 @@ pre init scripts feature. See poo#20818.
       <package>libXi6</package>
       <package>libXtst6</package>
       <package>lsscsi</package>
-      <package>python-gobject2</package>
       <package>sg3_utils</package>
       <package>sssd</package>
-      <package>sssd-ad</package>
       <package>sssd-krb5</package>
       <package>sssd-krb5-common</package>
       <package>sssd-ldap</package>
       <package>sudo</package>
       <package>sysstat</package>
-      <package>tuned</package>
       <package>ucode-intel</package>
       <package>vsftpd</package>
       <package>xauth</package>


### PR DESCRIPTION
More packages are not available in given modules. Simply removing as
test is not relying on those.
Verification run is not possible, verified manually.

Fixes: https://openqa.suse.de/tests/1499175#