### PR TITLE
gnome_tweaks_tools: binary is being renamed in GNOME 3.28

### DIFF
--- a/tests/x11/gnome_tweak_tool.pm
+++ b/tests/x11/gnome_tweak_tool.pm
@@ -15,8 +15,15 @@ use strict;
 use testapi;
 
 sub run {
+    my @gnome_tweak_matches = qw(gnome-tweaks gnome-tweak-tool command-not-found);
+
     mouse_hide(1);
-    x11_start_program('gnome-tweak-tool');
+    x11_start_program('gnome-tweaks', target_match => \@gnome_tweak_matches);
+    if (match_has_tag('command-not-cound')) {
+        # GNOME Tweak tools was renamed to GNOME tweaks during 3.28 dev branch
+        # AS the new name yielded a 'command-not-found', starts as old command
+        x11_start_program('gnome-tweak-tools');
+    }
     assert_and_click "gnome-tweak-tool-fonts";
     assert_screen "gnome-tweak-tool-fonts-dialog";
     send_key "alt-f4";


### PR DESCRIPTION
GNOME 3.28 renames the binary of gnome-tweak-tools to gnome-tweaks (the UI parts were changed during GNOME 3.26 already, so it is just completing the work)

As SLEAP15 will be shipping GNOME 3.26, we need to cope with both names (also for maintenance releases). We thus attempt to start 'gnome-tweaks' (new name), in case this is not found (indicated by GNOME's desktop-runner showing 'command not found', matched with a needle) we fall back to attempting to start the old name.

