### PR TITLE
Use netdevice parameter from linuxrc on ipmi

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -50,6 +50,10 @@ sub run {
         $openqa_url = 'http://' . $openqa_url unless $openqa_url =~ /http:\/\//;
         my $repo = $openqa_url . "/assets/repo/${image_name}";
         $image_path = "$path/linux initrd=$path/initrd install=$repo";
+        if (check_var('BACKEND', 'ipmi')) {
+            my $netdevice = get_var('SUT_NETDEVICE', 'eth0');
+            $image_path .= "?device=$netdevice";
+        }
     }
     elsif (match_has_tag('prague-pxe-menu')) {
         send_key_until_needlematch 'pxe-stable-iso-entry', 'down';


### PR DESCRIPTION
Workaround to avoid the installation process to get stuck during booting on IPMI when multiple network interfaces are connected

- Related ticket: https://progress.opensuse.org/issues/26948
- Verification run: http://copland.arch.suse.de/tests/922
