### PR TITLE
Fix erroneous console switch in remote-SSH installation

### DIFF
--- a/tests/installation/reboot_after_installation.pm
+++ b/tests/installation/reboot_after_installation.pm
@@ -16,7 +16,11 @@ use testapi;
 use utils;
 
 sub run {
-    select_console 'installation';
+    # on remote installations we can not try to switch to the installation
+    # console but we never switched away, see
+    # logs_from_installation_system.pm, so we should be safe to ignore this
+    # call
+    select_console 'installation' unless get_var('REMOTE_CONTROLLER');
     wait_screen_change {
         send_key 'alt-o';    # Reboot
     };


### PR DESCRIPTION
Regression was introduced with 9ce66aba.

See https://openqa.suse.de/tests/1502530#step/reboot_after_installation/1