### PR TITLE
gnome_tweak_tool: fix more errors introduced with b303ffe0

### DIFF
--- a/tests/x11/gnome_tweak_tool.pm
+++ b/tests/x11/gnome_tweak_tool.pm
@@ -20,9 +20,10 @@ sub run {
     mouse_hide(1);
     x11_start_program('gnome-tweaks', target_match => \@gnome_tweak_matches);
     if (match_has_tag('command-not-found')) {
-        # GNOME Tweak tools was renamed to GNOME tweaks during 3.28 dev branch
-        # AS the new name yielded a 'command-not-found', starts as old command
-        x11_start_program('gnome-tweak-tools');
+        # GNOME Tweak tool was renamed to GNOME Tweaks during 3.28 dev branch
+        # As the new name yielded a 'command-not-found', start as old command
+        send_key 'esc';
+        x11_start_program('gnome-tweak-tool');
     }
     assert_and_click "gnome-tweak-tool-fonts";
     assert_screen "gnome-tweak-tool-fonts-dialog";


### PR DESCRIPTION
Fix gnome-tweak-tool to also work with old name

This time there is also a smoke test running of the code against GNOME Live image of current TW snapshot: http://dimstar.internet-box.ch:81/tests/30#step/gnome_tweak_tool/6

This shows 'gnome-tweaks' attempted to be started, failing, then falling back to gnome-tweak-tool, correctly started.

The added ```send_key 'esc';``` is to close the runner window; as otherwise gnome-tweak-tool is appended to the pre-typed text 'gnome-tweaks'