### PR TITLE
LTP/shutdown: Run ver_linux only after running tests

### DIFF
--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -33,9 +33,11 @@ sub run {
         export_to_json($tinfo->test_result_export);
     }
 
-    my $ver_linux_log = '/tmp/ver_linux_before.txt';
-    script_run("\$LTPROOT/ver_linux > $ver_linux_log 2>&1");
-    upload_logs($ver_linux_log, failok => 1);
+    if (get_var('LTP_COMMAND_FILE')) {
+        my $ver_linux_log = '/tmp/ver_linux_after.txt';
+        script_run("\$LTPROOT/ver_linux > $ver_linux_log 2>&1");
+        upload_logs($ver_linux_log, failok => 1);
+    }
 
     script_run('[ "$ENABLE_WICKED" ] && systemctl enable wicked');
     script_run('journalctl --no-pager -p warning');


### PR DESCRIPTION
as running it after installing LTP ver_linux it's not installed yet
("-bash: /ver_linux: No such file or directory") and it's not needed
anyway.
Fixes: 5e7207d5 ("LTP: Put back ver_linux call after testing")

Also rename output file to "after" (which is clear that this is second
ver_linux run) as it was when originaly added in:
8f8932c0 ("LTP: Run ver_linux also at the end of testing")