### PR TITLE
Add Firefox back to the KDE live tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1076,8 +1076,7 @@ sub load_x11tests {
     if (kdestep_is_applicable() && !is_kde_live) {
         loadtest "x11/kate";
     }
-    # no firefox on KDE-Live # boo#1022499
-    loadtest "x11/firefox" unless is_kde_live;
+    loadtest "x11/firefox";
     if (is_opensuse && !get_var("OFW") && check_var('BACKEND', 'qemu') && !check_var('FLAVOR', 'Rescue-CD') && !is_kde_live) {
         loadtest "x11/firefox_audio";
     }


### PR DESCRIPTION
The new livecd images had enough space for firefox again.
It does need 2 GiB RAM to work correctly.

Verification runs: http://10.160.67.86/tests/19 (wayland) and http://10.160.67.86/tests/22 (X)