### PR TITLE
Use higher timeout for check_screen in desktop_mainmenu

### DIFF
--- a/tests/x11/desktop_mainmenu.pm
+++ b/tests/x11/desktop_mainmenu.pm
@@ -33,7 +33,7 @@ sub run {
         mouse_hide(1);
     }
     else {
-        send_key_until_needlematch 'test-desktop_mainmenu-1', 'alt-f1', 20;
+        send_key_until_needlematch 'test-desktop_mainmenu-1', 'alt-f1', 5, 10;
     }
     assert_screen 'test-desktop_mainmenu-1', 20;
 


### PR DESCRIPTION
Should fix https://progress.opensuse.org/issues/30079

- Verification run: http://10.160.67.86/tests/23 and http://10.160.67.86/tests/24 passed on the first try now.
