### PR TITLE
Enable CNCF K8s Conformance tests for QAM

### DIFF
--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -135,7 +135,7 @@ sub load_stack_tests {
         loadtest 'caasp/stack_kubernetes';
         loadtest 'caasp/stack_update'      if update_scheduled;
         loadtest 'caasp/stack_add_nodes'   if get_delayed_worker;
-        loadtest 'caasp/stack_conformance' if !is_caasp('staging') && !is_caasp('qam');
+        loadtest 'caasp/stack_conformance' if !is_caasp('staging');
         loadtest 'caasp/stack_finalize';
     }
     else {

--- a/tests/caasp/stack_conformance.pm
+++ b/tests/caasp/stack_conformance.pm
@@ -7,8 +7,10 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Run k8s conformance testsuite
-# Maintainer: Martin Kravec <mkravec@suse.com>
+# Summary: Run CNCF K8s Conformance tests
+#   Maintain certified status of CaaSP under k8s certification
+#   Project: https://github.com/cncf/k8s-conformance
+# Maintainer: Martin Kravec <mkravec@suse.com>, Panagiotis Georgiadis <pgeorgiadis@suse.com>
 
 use parent 'caasp_controller';
 use caasp_controller;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/32368
- Needles: *not needed*
- Verification run: http://skyrim.qam.suse.de/tests/2176
