### PR TITLE
Hyper-V: Mount NFS with retry

### DIFF
--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -65,7 +65,8 @@ sub run {
     set_var('NUMDISKS', defined get_var('RAIDLEVEL') ? 4 : $n);
 
     # Mount openQA NFS share to drive N:
-    hyperv_cmd("if not exist N: ( mount \\\\openqa.suse.de\\var\\lib\\openqa\\share\\factory N: )");
+    hyperv_cmd_with_retry("if not exist N: ( mount \\\\openqa.suse.de\\var\\lib\\openqa\\share\\factory N: )",
+        {msg => 'Another instance of this command is already running'});
 
     # Copy assets from NFS to Hyper-V cache
     for my $n ('', 1 .. 9) {


### PR DESCRIPTION
Mounting NFS on Hyper-V sometimes fails with: "Another instance of
this command is already running.  Please wait for the other instance to
complete.  If this condition persists, please try the 'net use'
command." (https://openqa.suse.de/tests/1502897/file/autoinst-log.txt)

`hyperv_cmd_with_retry` makes sure the command is re-triggered after
some time.

I was unable to simulate the problem, but this change should do.