### PR TITLE
poo#32077: Uncheck Xen PV install medium

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -191,7 +191,13 @@ sub addlv {
 sub unselect_xen_pv_cdrom {
     if (check_var('VIRSH_VMM_TYPE', 'linux')) {
         assert_screen 'select-hard-disk';
-        send_key 'alt-d';
+        if (get_var('TEXTMODE')) {
+            send_key_until_needlematch 'uncheck-install-medium', 'tab';
+            send_key 'spc';
+        }
+        else {
+            assert_and_click 'uncheck-install-medium';
+        }
         send_key $cmd{next};
     }
 }


### PR DESCRIPTION
Validation runs:
* create_hdd_textmode: http://assam.suse.cz/tests/558
* create_hdd_gnome: http://assam.suse.cz/tests/557

- Related ticket: https://progress.opensuse.org/issues/32077
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/728