### PR TITLE
Add Scripting module to all modules

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -321,7 +321,7 @@ if (is_update_test_repo_test && !get_var('MAINT_TEST_REPO')) {
 if (get_var('ENABLE_ALL_SCC_MODULES') && !get_var('SCC_ADDONS')) {
     if (sle_version_at_least('15')) {
         # Add only modules which are not pre-selected
-        my $addons = 'legacy,sdk,pcm';
+        my $addons = 'legacy,sdk,pcm,wsm';
         # Container module is missing for aarch64. Not a bug. fate#323788
         $addons .= ',contm' unless (check_var('ARCH', 'aarch64'));
         set_var('SCC_ADDONS', $addons);


### PR DESCRIPTION
Added the wsm to the ENABLE_ALL_SCC_MODULES setting

- Related ticket: https://progress.opensuse.org/issues/27817
- Verification run: http://pinky.arch.suse.de/tests/306

@okurz 
