### PR TITLE
partitioning_resize_root update for SLE15

### DIFF
--- a/tests/installation/partitioning_resize_root.pm
+++ b/tests/installation/partitioning_resize_root.pm
@@ -32,7 +32,7 @@ sub run {
     send_key_until_needlematch 'volume-management-root-selected', 'down';
     send_key $cmd{resize};
     assert_screen 'volume-management-resize-maximum-selected';
-    send_key $cmd{ok};
+    send_key((is_storage_ng) ? "$cmd{next}" : "$cmd{ok}");
     send_key $cmd{accept};
     assert_screen 'partitioning-subvolumes-shown';
 }


### PR DESCRIPTION
There some changes within the partitioning workflow in SLE15 installation process, which are causing  failures in lvm resize.

Resize manager screen changed it's properties:
* fullscreen instead of popup
* "next" instead of "ok" button

Suggested Partitioning screen:
* change in subvolume actions, which are grouped and hidden under (see details) section

- Related ticket: [[sle][functional][easy][yast] test fails in partitioning_resize_root - needs adaptions for sle15](https://progress.opensuse.org/issues/31420)
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/726
- Verification runs:
[sle-15-Installer-DVD-x86_64-Build482.3-lvm+resize_root@64bit](http://dhcp228.suse.cz/tests/750)
[sle-12-SP4-Server-DVD-x86_64-Build0230-lvm+resize_root@64bit](http://dhcp228.suse.cz/tests/751) 
