### PR TITLE
Migrate ganglia to new multimachine setup

### DIFF
--- a/tests/hpc/ganglia_client.pm
+++ b/tests/hpc/ganglia_client.pm
@@ -21,9 +21,18 @@ use utils;
 
 sub run {
     my $self = shift;
-    my ($server_ip) = get_required_var('HPC_MASTER_IP') =~ /(.*)\/.*/;
 
-    assert_script_run('hostnamectl set-hostname ganglia-client');
+    # Get number of nodes
+    my $nodes = get_required_var("CLUSTER_NODES");
+    # Get ganglia-server hostname
+    my $server_hostname = get_required_var("GANGLIA_SERVER_HOSTNAME");
+    # Synchronize with server
+    mutex_lock("GANGLIA_SERVER_BARRIERS_CONFIGURED");
+    mutex_unlock("GANGLIA_SERVER_BARRIERS_CONFIGURED");
+
+    # Stop firewall
+    systemctl 'stop ' . $self->firewall;
+
     zypper_call 'in ganglia-gmond';
 
     # wait for gmetad to be started
@@ -39,18 +48,17 @@ sub run {
     for (1 .. $max_retries) {
         eval {
             # Check if gmond has connected to gmetad
-            validate_script_output "gstat -a", sub { m/.*Hosts: 2.*/ };
+            validate_script_output "gstat -a", sub { m/.*Hosts: ${nodes}.*/ };
         };
         last unless ($@);
         record_info 'waiting for nodes', 'Not all nodes connected yet. Retrying...';
     }
     die "Not all nodes were connected after $max_retries retries." if $@;
 
-
     # Check if an arbitrary value could be sent via gmetric command
     my $testMetric = "openQA";
     type_string "gmetric -n \"$testMetric\" -v \"openQA\" -t string | tee /dev/ttyS0";
-    assert_script_run "echo \"\\n\" | nc $server_ip 8649 | grep $testMetric";
+    assert_script_run "echo \"\\n\" | nc ${server_hostname} 8649 | grep $testMetric";
 
     barrier_wait('GANGLIA_CLIENT_DONE');
     barrier_wait('GANGLIA_SERVER_DONE');

--- a/tests/hpc/ganglia_server.pm
+++ b/tests/hpc/ganglia_server.pm
@@ -22,16 +22,23 @@ use lockapi;
 use utils;
 
 sub run {
-    my $self        = shift;
-    my $slave_ip    = get_required_var('HPC_SLAVE_IP');
-    my ($server_ip) = get_required_var('HPC_HOST_IP') =~ /(.*)\/.*/;
-    barrier_create("GANGLIA_INSTALLED",      2);
-    barrier_create("GANGLIA_SERVER_DONE",    2);
-    barrier_create("GANGLIA_CLIENT_DONE",    2);
-    barrier_create("GANGLIA_GMETAD_STARTED", 2);
-    barrier_create("GANGLIA_GMOND_STARTED",  2);
+    my $self = shift;
+    # Get number of nodes
+    my $nodes = get_required_var("CLUSTER_NODES");
+    # Get hostname
+    my $hostname = get_required_var("HOSTNAME");
+    # Create cluster barriers
+    barrier_create("GANGLIA_INSTALLED",      $nodes);
+    barrier_create("GANGLIA_SERVER_DONE",    $nodes);
+    barrier_create("GANGLIA_CLIENT_DONE",    $nodes);
+    barrier_create("GANGLIA_GMETAD_STARTED", $nodes);
+    barrier_create("GANGLIA_GMOND_STARTED",  $nodes);
+    # Synchronize all slave nodes with master
+    mutex_create("GANGLIA_SERVER_BARRIERS_CONFIGURED");
 
-    assert_script_run('hostnamectl set-hostname ganglia-server');
+    # Stop firewall
+    systemctl 'stop ' . $self->firewall;
+
     zypper_call('in ganglia-gmetad ganglia-gmond ganglia-gmetad-skip-bcheck');
     systemctl 'start gmetad';
     barrier_wait('GANGLIA_GMETAD_STARTED');
@@ -51,7 +58,7 @@ sub run {
     select_console('x11');
 
     # start browser and access ganglia web ui
-    x11_start_program("firefox http://$server_ip/ganglia", valid => 0);
+    x11_start_program("firefox http://${hostname}/ganglia", valid => 0);
     $self->firefox_check_default;
     assert_screen('ganglia-web');
     assert_and_click('ganglia-node-dropdown');


### PR DESCRIPTION
Enhancement poo#20308:  Update ganglia  multimachine setup to use
supportserver for providing dhcp and dns to 2+ nodes.

- Related ticket: https://progress.opensuse.org/issues/20308
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/727
- Verification run 2 node cluster:
supportserver http://10.100.12.105/tests/646
server http://10.100.12.105/tests/647
client http://10.100.12.105/tests/648
- Verification run 3 node cluster:
client02 http://10.100.12.105/tests/697
client01 http://10.100.12.105/tests/696
server http://10.100.12.105/tests/695
supportserver http://10.100.12.105/tests/694