### PR TITLE
Improve pop-ups processing for the first and second stages of ay installation

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -185,7 +185,8 @@ sub run {
             accept_license;
         }
         elsif (match_has_tag('inst-betawarning')) {
-            send_key $cmd{ok};
+            wait_screen_change { send_key $cmd{ok} };
+            @needles = grep { $_ ne 'inst-betawarning' } @needles;
             push(@needles, 'autoyast-license') if (get_var('AUTOYAST_LICENSE'));
             next;
         }


### PR DESCRIPTION
The problem we see now is that same pop-up matches twice, so we press ok
twice, which results in unstable behavior as second press goes to the
next pop-up. Additionally we also need to process warnings during second stage.

Fixes https://openqa.suse.de/tests/1509496
[Verification run pop-up](http://gershwin.arch.suse.de/tests/117).
[Verification run pop-up during second stage](http://gershwin.arch.suse.de/tests/117).

Required for [poo#31957](https://progress.opensuse.org/issues/31957).
