### PR TITLE
Increase size for /boot/efi partition in lvm tests

### DIFF
--- a/tests/installation/partitioning_full_lvm.pm
+++ b/tests/installation/partitioning_full_lvm.pm
@@ -26,7 +26,7 @@ sub run {
         addpart(role => 'raw', size => 500, fsid => 'PReP');
     }
     elsif (get_var('UEFI')) {    # UEFI needs partition mounted to /boot/efi for
-        addpart(role => 'efi', size => 100);
+        addpart(role => 'efi', size => 256);
     }
     elsif (is_storage_ng && check_var('ARCH', 'x86_64')) {
         # Storage-ng has GPT by defaut, so need bios-boot partition for legacy boot, which is only on x86_64


### PR DESCRIPTION
As a requirement, we now expect that /boot/efi partition is at least 256 MiB.

Fixes https://openqa.suse.de/tests/1508891#step/partitioning_full_lvm/49

[Verification run](http://g226.suse.de/tests/880#).