### PR TITLE
Fix scheduling regression for EXIT_AFTER_START_INSTALL

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -513,7 +513,7 @@ else {
         }
     }
     else {
-        load_default_tests;
+        return 1 if load_default_tests;
     }
 
     unless (install_online_updates()

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1082,7 +1082,7 @@ else {
             loadtest 'installation/first_boot';
         }
         else {
-            load_default_tests;
+            return 1 if load_default_tests;
         }
     }
     unless (load_applicationstests() || load_slenkins_tests()) {


### PR DESCRIPTION
Before 5d83981898c92dc3665919b67b29f19a41fab8ac we returned from the main.pm to end the scheduling. With that commit the `if` for EXIT_AFTER_START_INSTALL happened inside a function and therefore we just returned from that function but not out of the main.pm. This fixes a regression introduced by #4432

- Related ticket: https://progress.opensuse.org/issues/32395
- Needles: [not required]
- Verification run:
  - EXIT_AFTER_START_INSTALL=1: http://openqa.glados.qa.suse.de/tests/74/file/autoinst-log.txt
  - EXIT_AFTER_START_INSTALL=0: http://openqa.glados.qa.suse.de/tests/75/file/autoinst-log.txt
