### PR TITLE
Fix release notes test in textmode

### DIFF
--- a/tests/caasp/oci_overview.pm
+++ b/tests/caasp/oci_overview.pm
@@ -31,9 +31,16 @@ sub run {
     mouse_hide;
 
     # Check release notes
-    assert_and_click 'release-notes-open';
-    assert_screen 'release-notes-' . get_var('VERSION');
-    assert_and_click 'release-notes-close';
+    if (check_var('VIDEOMODE', 'text')) {
+        send_key 'alt-e';
+        assert_screen 'release-notes-' . get_var('VERSION');
+        send_key 'ret';
+    }
+    else {
+        assert_and_click 'release-notes-open';
+        assert_screen 'release-notes-' . get_var('VERSION');
+        assert_and_click 'release-notes-close';
+    }
 }
 
 1;


### PR DESCRIPTION
Failed jobs:
 - https://openqa.suse.de/tests/1510606#step/oci_overview/4

Needles:
 - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/333 - Kubic
 - https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/730 - CaaSP

Local runs:
 - http://dhcp91.suse.cz/tests/1527#step/oci_overview/2 - Kubic
 - http://dhcp91.suse.cz/tests/1528#step/oci_overview/3 - CaaSP