### PR TITLE
SLE-HA multi-cluster enhancement

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -4,15 +4,6 @@ use strict;
 use testapi;
 use utils 'systemctl';
 
-sub exec_and_insert_password {
-    my ($self, $cmd) = @_;
-    type_string $cmd;
-    send_key "ret";
-    assert_screen('password-prompt', 60);
-    type_password;
-    send_key "ret";
-}
-
 sub enable_and_start {
     my ($self, $arg) = @_;
     systemctl "enable $arg";

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -70,6 +70,7 @@ our @EXPORT = qw(
   arrays_differ
   ensure_serialdev_permissions
   assert_and_click_until_screen_change
+  exec_and_insert_password
 );
 
 
@@ -1000,6 +1001,18 @@ sub ensure_serialdev_permissions {
     else {
         assert_script_run "chown $testapi::username /dev/$testapi::serialdev && gpasswd -a $testapi::username \$(stat -c %G /dev/$testapi::serialdev)";
     }
+}
+
+=head2 exec_and_insert_password
+Execute a command that ask for a password and insert it.
+=cut
+sub exec_and_insert_password {
+    my $cmd = shift;
+    type_string "$cmd";
+    send_key "ret";
+    assert_screen('password-prompt', 60);
+    type_password;
+    send_key "ret";
 }
 
 1;

--- a/tests/ha/check_after_fencing.pm
+++ b/tests/ha/check_after_fencing.pm
@@ -17,6 +17,8 @@ use lockapi;
 use hacluster;
 
 sub run {
+    my $cluster_name = get_cluster_name;
+
     barrier_wait("CHECK_BEFORE_FENCING_BEGIN_$cluster_name");
 
     # We need to be sure to be root and, after fencing, the default console on node01 is not root

--- a/tests/ha/check_before_fencing.pm
+++ b/tests/ha/check_before_fencing.pm
@@ -17,6 +17,8 @@ use lockapi;
 use hacluster;
 
 sub run {
+    my $cluster_name = get_cluster_name;
+
     # Check cluster state
     barrier_wait("CHECK_BEFORE_FENCING_BEGIN_$cluster_name");
 

--- a/tests/ha/check_hawk.pm
+++ b/tests/ha/check_hawk.pm
@@ -18,7 +18,8 @@ use hacluster;
 use utils 'systemctl';
 
 sub run {
-    my $hawk_port = '7630';
+    my $cluster_name = get_cluster_name;
+    my $hawk_port    = '7630';
 
     barrier_wait("HAWK_INIT_$cluster_name");
 

--- a/tests/ha/check_logs.pm
+++ b/tests/ha/check_logs.pm
@@ -17,6 +17,8 @@ use lockapi;
 use hacluster;
 
 sub run {
+    my $cluster_name = get_cluster_name;
+
     barrier_wait("FENCING_DONE_$cluster_name");
 
     # Do some extra verification and export logs

--- a/tests/ha/cluster_md.pm
+++ b/tests/ha/cluster_md.pm
@@ -20,11 +20,12 @@ use hacluster;
 sub run {
     my $mdadm_conf         = '/etc/mdadm.conf';
     my $csync_conf         = '/etc/csync2/csync2.cfg';
-    my $clustermd_lun_01   = block_device_real_path '/dev/disk/by-path/ip-*-lun-1';
-    my $clustermd_lun_02   = block_device_real_path '/dev/disk/by-path/ip-*-lun-2';
+    my $clustermd_lun_01   = get_lun(use_once => 0);
+    my $clustermd_lun_02   = get_lun(use_once => 0);
     my $clustermd_rsc      = 'cluster_md';
     my $clustermd_device   = '/dev/md0';
     my $clustermd_name_opt = undef;
+    my $cluster_name       = get_cluster_name;
 
     if (is_sle '15+') {
         $clustermd_device   = "/dev/md/$clustermd_rsc";

--- a/tests/ha/clvmd_lvmlockd.pm
+++ b/tests/ha/clvmd_lvmlockd.pm
@@ -19,8 +19,9 @@ use lockapi;
 use hacluster;
 
 sub run {
-    my $lvm_conf = '/etc/lvm/lvm.conf';
-    my $lock_mgr = 'clvm';
+    my $cluster_name = get_cluster_name;
+    my $lvm_conf     = '/etc/lvm/lvm.conf';
+    my $lock_mgr     = 'clvm';
 
     # lvmlockd is only available in SLE15+
     if (get_var("USE_LVMLOCKD")) {

--- a/tests/ha/dlm.pm
+++ b/tests/ha/dlm.pm
@@ -17,6 +17,8 @@ use lockapi;
 use hacluster;
 
 sub run {
+    my $cluster_name = get_cluster_name;
+
     # Wait until DLM test is initialized
     barrier_wait("DLM_INIT_$cluster_name");
 

--- a/tests/ha/fencing.pm
+++ b/tests/ha/fencing.pm
@@ -17,13 +17,15 @@ use lockapi;
 use hacluster;
 
 sub run {
+    my $cluster_name = get_cluster_name;
+
     # 'barrier_wait' needs to be done separately to ensure that
     # 'reset_consoles' as been done on all nodes before fencing
     if (is_node(2)) {
         barrier_wait("BEFORE_FENCING_$cluster_name");
 
         # Fence the node
-        assert_script_run 'crm -F node fence ' . get_var('HA_CLUSTER_JOIN');
+        assert_script_run 'crm -F node fence ' . get_node_to_join;
 
         # Wait a little to be sure that fence command is on his way
         sleep 60;

--- a/tests/ha/filesystem.pm
+++ b/tests/ha/filesystem.pm
@@ -18,12 +18,13 @@ use lockapi;
 use hacluster;
 
 sub run {
-    my $node     = script_output 'hostname';
-    my $fs_lun   = undef;
-    my $fs_rsc   = undef;
-    my $resource = 'lun';
-    my $fs_type  = 'ocfs2';
-    my $fs_opts  = '-F -N 16';                 # Force the filesystem creation and allows 16 nodes
+    my $cluster_name = get_cluster_name;
+    my $node         = get_hostname;
+    my $fs_lun       = undef;
+    my $fs_rsc       = undef;
+    my $resource     = 'lun';
+    my $fs_type      = 'ocfs2';
+    my $fs_opts      = '-F -N 16';         # Force the filesystem creation and allows 16 nodes
 
     # This Filesystem test can be called multiple time
     if (read_tag eq 'cluster_md') {
@@ -31,7 +32,7 @@ sub run {
     }
     elsif (read_tag eq 'drbd_passive') {
         $resource = 'drbd_passive';
-        $fs_lun   = '/dev/drbd_passive';
+        $fs_lun   = '/dev/drbd_passive' if is_node(1);
         $fs_type  = 'xfs';
         $fs_opts  = '-f';
     }
@@ -39,9 +40,9 @@ sub run {
         $resource = 'drbd_active';
     }
     else {
-        $fs_lun = block_device_real_path '/dev/disk/by-path/ip-*-lun-3';
+        $fs_lun = get_lun if is_node(1);
     }
-    $fs_lun = "/dev/vg_$resource/lv_openqa" if not defined $fs_lun;
+    $fs_lun = "/dev/vg_$resource/lv_openqa" if (not defined $fs_lun && is_node(1));
     $fs_rsc = "fs_$resource";
 
     # Create tag for barrier_wait

--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -18,10 +18,10 @@ use hacluster;
 
 sub run {
     # Validate cluster creation with ha-cluster-init tool
-    my $self          = shift;
+    my $cluster_name  = get_cluster_name;
     my $bootstrap_log = '/var/log/ha-cluster-bootstrap.log';
     my $corosync_conf = '/etc/corosync/corosync.conf';
-    my $sbd_device    = block_device_real_path '/dev/disk/by-path/ip-*-lun-0';
+    my $sbd_device    = get_lun;
     my $quorum_policy = 'stop';
     my $join_timeout  = 60;
 

--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Join cluster node to existing cluster
+# Summary: Add node to existing cluster
 # Maintainer: Loic Devulder <ldevulder@suse.com>
 
 use base 'opensusebasetest';
@@ -17,13 +17,16 @@ use lockapi;
 use hacluster;
 
 sub run {
+    my $cluster_name = get_cluster_name;
+    my $node_to_join = get_node_to_join;
+
     # Wait until cluster is initialized
     diag 'Wait until cluster is initialized...';
     barrier_wait("CLUSTER_INITIALIZED_$cluster_name");
 
-    # Try to join the HA cluster through node HA_CLUSTER_JOIN
-    assert_script_run 'ping -c1 ' . get_var('HA_CLUSTER_JOIN');
-    type_string "ha-cluster-join -yc " . get_var('HA_CLUSTER_JOIN') . "\n";
+    # Try to join the HA cluster through first node
+    assert_script_run "ping -c1 $node_to_join";
+    type_string "ha-cluster-join -yc $node_to_join\n";
     assert_screen 'ha-cluster-join-password';
     type_password;
     send_key 'ret';

--- a/tests/ha/iscsi_client.pm
+++ b/tests/ha/iscsi_client.pm
@@ -28,7 +28,7 @@ sub run {
     send_key 'alt-i';    # Initiator name
     wait_still_screen 3;
     for (1 .. 40) { send_key 'backspace'; }
-    type_string 'iqn.1996-04.de.suse:01:' . get_var('HOSTNAME') . '.' . get_var('CLUSTER_NAME');
+    type_string 'iqn.1996-04.de.suse:01:' . get_hostname . '.' . get_cluster_name;
     wait_still_screen 3;
     send_key 'alt-v';    # discoVered targets
     wait_still_screen 3;

--- a/tests/ha/vg.pm
+++ b/tests/ha/vg.pm
@@ -18,6 +18,7 @@ use lockapi;
 use hacluster;
 
 sub run {
+    my $cluster_name    = get_cluster_name;
     my $lvm_conf        = '/etc/lvm/lvm.conf';
     my $lv_name         = 'lv_openqa';
     my $vg_exclusive    = 'false';
@@ -29,23 +30,23 @@ sub run {
     # This test can be called multiple time
     if (read_tag eq 'cluster_md') {
         $resource = 'cluster_md';
-        $vg_luns  = '/dev/md*';
+        $vg_luns = '/dev/md*' if is_node(1);
 
         # Use a named RAID in SLE15
-        $vg_luns = "/dev/md/$resource" if is_sle('15+');
+        $vg_luns = "/dev/md/$resource" if (is_sle('15+') && is_node(1));
     }
     elsif (read_tag eq 'drbd_passive') {
         $resource     = 'drbd_passive';
-        $vg_luns      = "/dev/$resource";
+        $vg_luns      = "/dev/$resource" if is_node(1);
         $vg_exclusive = 'true';
         $vg_type      = '--clustered n';
     }
     elsif (read_tag eq 'drbd_active') {
         $resource = 'drbd_active';
-        $vg_luns  = "/dev/$resource";
+        $vg_luns = "/dev/$resource" if is_node(1);
     }
     else {
-        $vg_luns = block_device_real_path '/dev/disk/by-path/ip-*-lun-1' . ' ' . block_device_real_path '/dev/disk/by-path/ip-*-lun-2';
+        $vg_luns = get_lun . ' ' . get_lun if is_node(1);
     }
     my $vg_name = "vg_$resource";
 

--- a/tests/hpc/mrsh_master.pm
+++ b/tests/hpc/mrsh_master.pm
@@ -40,7 +40,7 @@ sub run {
     # Copy munge key to all slave nodes
     for (my $node = 1; $node < $nodes; $node++) {
         my $node_name = sprintf("mrsh-slave%02d", $node);
-        $self->exec_and_insert_password("scp -o StrictHostKeyChecking=no /etc/munge/munge.key root\@${node_name}:/etc/munge/munge.key");
+        exec_and_insert_password("scp -o StrictHostKeyChecking=no /etc/munge/munge.key root\@${node_name}:/etc/munge/munge.key");
     }
     mutex_create("MRSH_KEY_COPIED");
 

--- a/tests/hpc/munge_master.pm
+++ b/tests/hpc/munge_master.pm
@@ -35,7 +35,7 @@ sub run {
     # Copy munge key to all slave nodes
     for (my $node = 1; $node < $nodes; $node++) {
         my $node_name = sprintf("munge-slave%02d", $node);
-        $self->exec_and_insert_password("scp -o StrictHostKeyChecking=no /etc/munge/munge.key root\@${node_name}:/etc/munge/munge.key");
+        exec_and_insert_password("scp -o StrictHostKeyChecking=no /etc/munge/munge.key root\@${node_name}:/etc/munge/munge.key");
     }
     mutex_create('MUNGE_KEY_COPIED');
 
@@ -48,7 +48,7 @@ sub run {
     assert_script_run('munge -n | unmunge');
     for (my $node = 1; $node < $nodes; $node++) {
         my $node_name = sprintf("munge-slave%02d", $node);
-        $self->exec_and_insert_password("munge -n | ssh ${node_name} unmunge");
+        exec_and_insert_password("munge -n | ssh ${node_name} unmunge");
     }
     assert_script_run('remunge');
     mutex_create('MUNGE_DONE');

--- a/tests/hpc/pdsh_master.pm
+++ b/tests/hpc/pdsh_master.pm
@@ -41,7 +41,7 @@ sub run {
     # Copy munge key to all slave nodes
     for (my $node = 1; $node < $nodes; $node++) {
         my $node_name = sprintf("pdsh-slave%02d", $node);
-        $self->exec_and_insert_password("scp -o StrictHostKeyChecking=no /etc/munge/munge.key root\@${node_name}:/etc/munge/munge.key");
+        exec_and_insert_password("scp -o StrictHostKeyChecking=no /etc/munge/munge.key root\@${node_name}:/etc/munge/munge.key");
     }
     mutex_create("PDSH_KEY_COPIED");
 

--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -53,8 +53,8 @@ EOF
     # Copy munge key and slurm conf to all slave nodes
     for (my $node = 1; $node < $nodes; $node++) {
         my $node_name = sprintf("slurm-slave%02d", $node);
-        $self->exec_and_insert_password("scp -o StrictHostKeyChecking=no /etc/munge/munge.key root\@${node_name}:/etc/munge/munge.key");
-        $self->exec_and_insert_password("scp -o StrictHostKeyChecking=no /etc/slurm/slurm.conf root\@${node_name}:/etc/slurm/slurm.conf");
+        exec_and_insert_password("scp -o StrictHostKeyChecking=no /etc/munge/munge.key root\@${node_name}:/etc/munge/munge.key");
+        exec_and_insert_password("scp -o StrictHostKeyChecking=no /etc/slurm/slurm.conf root\@${node_name}:/etc/slurm/slurm.conf");
     }
     # enable and start munge
     $self->enable_and_start('munge');


### PR DESCRIPTION
Currently, if we want to run multiple HA cluster we have to create a support-server for each (see https://openqa.suse.de/tests/overview?distri=sle&version=15&build=456.1&groupid=143).
This is not very efficient...

So, we need to improve support of multi-clusters in support-server by generating a list a LUN for each wanted cluster and we can store it in a file that can be copied on the node.
Each nodes can after get this list.

This is also useful if we want to have a more flexible support-server configuration for iSCSI LUN, by having a dynamic function that can return us the next available LUN.
And we also need this to be able to run multiple cluster in the same network for testing geo-clustering (with booth).

At this time, this PR is HA specific, but if this can be useful for others, I can create a new poo# to adapt this change. But I think after a validation time in HA :)

- Related ticket: https://progress.opensuse.org/issues/32551

Verification runs:
- http://moon.qa.suse.cz/tests/2005
- http://moon.qa.suse.cz/tests/2007
- http://moon.qa.suse.cz/tests/2008
- http://moon.qa.suse.cz/tests/2009
- http://moon.qa.suse.cz/tests/2010
- http://moon.qa.suse.cz/tests/2011
- http://moon.qa.suse.cz/tests/2012