### PR TITLE
Hardcode edgecast IP instead of relying on DNS

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -105,6 +105,17 @@ sub verify_timeout_and_check_screen {
 sub run {
     my ($self) = @_;
 
+    # Verify that workaround for Microfocus infobloxx GEO-IP DNS Cluster works
+    if (get_var('EDGECAST') && is_caasp('qam')) {
+        record_info 'Netfix', 'Go through Europe Microfocus info-bloxx';
+        my $edgecast_europe = get_var('EDGECAST');
+        assert_screen 'autoyaststart', 90;
+        select_console 'install-shell';
+        assert_script_run("echo $edgecast_europe updates.suse.com >> /etc/hosts");
+        script_run("ping -c 1 updates.suse.com | grep $edgecast_europe");
+        select_console 'installation';
+    }
+
     if (check_var('BACKEND', 'ipmi') && get_var("SES5_DEPLOY")) {
         assert_screen 'installation-done', 750;
         reset_consoles;

--- a/tests/caasp/oci_install.pm
+++ b/tests/caasp/oci_install.pm
@@ -22,8 +22,8 @@ sub run {
         record_info 'Netfix', 'Go through Europe Microfocus info-bloxx';
         my $edgecast_europe = get_var('EDGECAST');
         select_console 'install-shell';
-        assert_script_run("ping -c 3 updates.suse.com");
-        assert_script_run("ping -c 1 updates.suse.com | grep $edgecast_europe");
+        assert_script_run("echo $edgecast_europe updates.suse.com >> /etc/hosts");
+        script_run("ping -c 1 updates.suse.com | grep $edgecast_europe");
         select_console 'installation';
     }
 

--- a/tests/caasp/stack_initialize.pm
+++ b/tests/caasp/stack_initialize.pm
@@ -41,8 +41,7 @@ sub run {
         my $edgecast_europe = get_var('EDGECAST');
         assert_script_sudo("echo $edgecast_europe updates.suse.com >> /etc/hosts");
         assert_script_run("grep 'updates.suse.com' /etc/hosts");
-        assert_script_run("ping -c 3 updates.suse.com");
-        assert_script_run("ping -c 1 updates.suse.com | grep $edgecast_europe");
+        script_run("ping -c 1 updates.suse.com | grep $edgecast_europe");
     }
 
     # Leave xterm open for kubernetes tests


### PR DESCRIPTION
DNS configuration doesn't seem to always work as expected.
Since using Edgecast variable is a temporary workaround
this PR makes sure that **all** the nodes in QAM CaaSP
are going to use the same IP address to avoid timeouts.

- Related ticket: https://progress.opensuse.org/issues/32290#change-94690
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/731
- Verification run: *on the way*
