### PR TITLE
Remove invalid soft-failure

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -90,11 +90,6 @@ sub addpart {
     my (%args) = @_;
     assert_screen 'expert-partitioner';
     send_key $cmd{addpart};
-    # partitioning type does not appear when GPT disk used, GPT is default for UEFI
-    # also doesn't appear with storage-ng, as GPT is by default there
-    if (is_storage_ng && check_screen 'partition-size', 0) {
-        record_soft_failure 'bsc#1055743';
-    }
     unless (get_var('UEFI') || check_var('BACKEND', 's390x') || is_storage_ng) {
         assert_screen 'partitioning-type';
         send_key $cmd{next};


### PR DESCRIPTION
Manually verified partition role with DOS partition table.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1055743
- Verification run: http://copland.arch.suse.de/tests/938
