### PR TITLE
Fixing test module partitioning_warnings

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -90,11 +90,6 @@ sub addpart {
     my (%args) = @_;
     assert_screen 'expert-partitioner';
     send_key $cmd{addpart};
-    # partitioning type does not appear when GPT disk used, GPT is default for UEFI
-    # also doesn't appear with storage-ng, as GPT is by default there
-    if (is_storage_ng && check_screen 'partition-size', 0) {
-        record_soft_failure 'bsc#1055743';
-    }
     unless (get_var('UEFI') || check_var('BACKEND', 's390x') || is_storage_ng) {
         assert_screen 'partitioning-type';
         send_key $cmd{next};

--- a/tests/installation/partitioning_warnings.pm
+++ b/tests/installation/partitioning_warnings.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -27,6 +27,11 @@ sub run {
     elsif (get_var('OFW')) {             # ppc64le need PReP /boot
         addpart(role => 'raw', size => 500, fsid => 'PReP');
     }
+    elsif (is_storage_ng && check_var('ARCH', 'x86_64')) {
+        # Storage-ng has GPT by defaut, so need bios-boot partition for legacy boot, which is only on x86_64
+        addpart(role => 'raw', fsid => 'bios-boot', size => 2);
+    }
+
     # create small enough partition (11GB) to get warning
     addpart(role => 'OS', size => 11000, format => 'btrfs');
 

--- a/tests/installation/partitioning_warnings.pm
+++ b/tests/installation/partitioning_warnings.pm
@@ -39,7 +39,7 @@ sub run {
     send_key $cmd{accept};
     if (is_storage_ng) {
         assert_screen 'partitioning-edit-proposal-button';
-        record_soft_failure 'bsc#1055744';
+        record_soft_failure('bsc#1085131 - no warning for too small btrfs / for snapshots');
     }
     else {
         # expect partition setup warning pop-ups

--- a/tests/installation/partitioning_warnings.pm
+++ b/tests/installation/partitioning_warnings.pm
@@ -50,10 +50,7 @@ sub run {
         assert_screen 'partition-warning-no-efi-boot';
         wait_screen_change { send_key 'alt-y' };    # yes
     }
-    if (is_storage_ng && !check_screen('partitioning-edit-proposal-button', 0)) {
-        record_soft_failure 'bsc#1055747';
-    }
-    else {
+    if (!is_storage_ng) {
         assert_screen 'partition-warning-no-swap';
         wait_screen_change { send_key 'alt-y' };    # yes
     }


### PR DESCRIPTION
## Motivation

- Related job: https://openqa.suse.de/tests/1509521
- Related ticket: https://progress.opensuse.org/issues/32527
- Verification run: http://copland.arch.suse.de/tests/939#step/partitioning_warnings/33

----

## Remove invalid soft-failure
Manually verified partition role with DOS partition table.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1055743
- superseeds: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4531

----

## Add BIOS boot partition

For this test suite it was not added. x86_64 on GTP table needs this partition.