### PR TITLE
Add test for SuSEfirewall style ay profile for firewalld

### DIFF
--- a/data/autoyast_sle15/autoyast_SuSEfirewall.xml
+++ b/data/autoyast_sle15/autoyast_SuSEfirewall.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <!-- minimal autoyast profile -->
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-basesystem</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
+  <networking>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+  </networking>
+  <software>
+    <products config:type="list">
+      <product>SLES15</product>
+    </products>
+  </software>
+  <users config:type="list">
+    <user>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <firewall>
+    <FW_DEV_EXT>eth0</FW_DEV_EXT>
+    <FW_DEV_DMZ>any</FW_DEV_DMZ>
+    <FW_CONFIGURATIONS_EXT>apache2 apache2-ssl</FW_CONFIGURATIONS_EXT>
+    <FW_CONFIGURATIONS_INT>sshd</FW_CONFIGURATIONS_INT>
+    <FW_SERVICES_EXT_TCP>8080</FW_SERVICES_EXT_TCP>
+    <FW_SERVICES_EXT_UDP>9090</FW_SERVICES_EXT_UDP>
+    <FW_SERVICES_INT_TCP>22</FW_SERVICES_INT_TCP>
+    <FW_SERVICES_INT_UDP>5353</FW_SERVICES_INT_UDP>
+    <enable_firewall config:type="boolean">true</enable_firewall>
+    <start_firewall config:type="boolean">true</start_firewall>
+  </firewall>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id/>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>suse.local</domain>
+      <hostname>linux-nwlk</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+    </routing>
+  </networking>
+</profile>

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -407,6 +407,7 @@ sub load_autoyast_tests {
     loadtest("autoyast/login");
     loadtest("autoyast/wicked");
     loadtest("autoyast/autoyast_verify") if get_var("AUTOYAST_VERIFY");
+    loadtest('autoyast/' . get_var("AUTOYAST_VERIFY_MODULE")) if get_var("AUTOYAST_VERIFY_MODULE");
     if (get_var("SUPPORT_SERVER_GENERATOR")) {
         loadtest("support_server/configure");
     }

--- a/tests/autoyast/verify_firewalld.pm
+++ b/tests/autoyast/verify_firewalld.pm
@@ -1,0 +1,43 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify firewall configuration after installation using ay profile
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
+
+use base 'basetest';
+use strict;
+use testapi;
+use utils 'systemctl';
+
+sub run {
+    # Verify firewalld is running, returns 0 code only is running
+    assert_script_run('firewall-offline-cmd --state');
+    # Verify that service is active
+    systemctl 'is-active firewalld.service';
+    my $errors = '';
+    # Verify services configured for external zone
+    my $zone_config = script_output('firewall-offline-cmd --list-services --zone=public');
+    $errors .= "services are not configured for public zone, expected http and https, got: $zone_config\n" unless $zone_config =~ /http https/;
+    # Verify ports configured for external zone
+    $zone_config = script_output('firewall-offline-cmd --list-ports --zone=public');
+    $errors .= "ports are not configured for public zone, expected 8080/tcp 9090/udp, got: $zone_config\n" unless $zone_config =~ m|8080/tcp 9090/udp|;
+    # Verify services configured for internal zone
+    $zone_config = script_output('firewall-offline-cmd --list-services --zone=trusted');
+    $errors .= "services are not configured for trusted zone, expected ssh, got: $zone_config\n" unless $zone_config =~ /ssh/;
+    # Verify ports configured for internal zone
+    $zone_config = script_output('firewall-offline-cmd --list-ports --zone=trusted');
+    $errors .= "ports are not configured for trusted zone, expected 22/tcp 5353/udp, got: $zone_config\n" unless $zone_config =~ m|22/tcp 5353/udp|;
+
+    # Fail the test if any error
+    die "Test failed:\n$errors" if $errors;
+}
+
+1;
+
+# vim: sw=4 et


### PR DESCRIPTION
Test suite requires following settings: 
AUTOYAST=autoyast_sle15/autoyast_SuSEfirewall.xml 
AUTOYAST_VERIFY_MODULE=verify_firewalld

See [poo#31957](https://progress.opensuse.org/issues/31957).

[Verification run](http://g226.suse.de/tests/894).
