### PR TITLE
install_packages: handle mvapich2 conflicts

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -160,6 +160,9 @@ sub problem_can_be_skipped {
     return 1 if $pkg =~ /^libjpeg8-devel/;
     # conflicts with the plain variant
     return 1 if $pkg =~ /^openvswitch-dpdk/;
+    # conflict with mvapich2 packages
+    return 1 if $pkg =~ /^mvapich2-psm(2)?/;
+    return 1 if $pkg =~ /^mvapich2-testsuite/;
 
     return;
 }


### PR DESCRIPTION
This handles conflicts of `mvapich2` packages for `install_packages` tests.

- Related bug: [bsc#934090](https://bugzilla.suse.com/show_bug.cgi?id=934090)
- Related test failures:
https://openqa.opensuse.org/tests/623020#step/install_packages/13
https://openqa.opensuse.org/tests/623021#step/install_packages/13
https://openqa.opensuse.org/tests/623022#step/install_packages/13
These will NOT be fixed completely, as the problem of a file conflict with `mvapich2-testsuite` without package conflict remains.

- Verification:
`data/lsmfip mvapich2 mvapich2-devel mvapich2-devel-static mvapich2-psm mvapich2-psm-devel mvapich2-psm-devel-static mvapich2-psm2 mvapich2-psm2-devel mvapich2-psm2-devel-static mvapich2-testsuite`

````
[...]
mvapich2
mvapich2-devel
mvapich2-devel-static
mvapich2-testsuite
not installing mvapich2-psm
not installing mvapich2-psm-devel
not installing mvapich2-psm-devel-static
not installing mvapich2-psm2
not installing mvapich2-psm2-devel
not installing mvapich2-psm2-devel-static
````