### PR TITLE
Migrate 2 xvnc cases to SLE15

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -415,7 +415,7 @@ sub load_x11_remote {
     # load onetime vncsession testing
     if (check_var('REMOTE_DESKTOP_TYPE', 'one_time_vnc')) {
         loadtest 'x11/remote_desktop/onetime_vncsession_xvnc_tigervnc';
-        loadtest 'x11/remote_desktop/onetime_vncsession_xvnc_java';
+        loadtest 'x11/remote_desktop/onetime_vncsession_xvnc_java' if is_sle('<15');
         loadtest 'x11/remote_desktop/onetime_vncsession_multilogin_failed';
     }
     # load persistemt vncsession, x11 forwarding, xdmcp with gdm testing

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -252,8 +252,6 @@ sub setup_xvnc_server {
         send_key 'alt-a';
     }
     wait_still_screen 3;
-    send_key 'alt-p';
-    wait_still_screen 3;
     send_key 'alt-o';
     if (check_var('REMOTE_DESKTOP_TYPE', 'persistent_vnc')) {
         assert_screen 'xvnc-vncmanager-required';
@@ -263,6 +261,7 @@ sub setup_xvnc_server {
     send_key 'ret';
     wait_serial('yast-remote-status-0', 90) || die "'yast remote' didn't finish";
     wait_still_screen 3;
+    assert_script_run 'yast2 firewall services add zone=EXT service=service:vnc-server';
     systemctl('restart display-manager');
     assert_screen 'displaymanager';
     select_console 'root-console';

--- a/tests/x11/remote_desktop/onetime_vncsession_multilogin_failed.pm
+++ b/tests/x11/remote_desktop/onetime_vncsession_multilogin_failed.pm
@@ -24,7 +24,7 @@ use lockapi;
 use utils;
 
 sub start_vncviewer {
-    x11_start_program('vncviewer 10.0.2.1:1 -Fullscreen', target_match => [qw(displaymanager vnc_certificate_warning)]);
+    x11_start_program('vncviewer 10.0.2.1:1 -Fullscreen -SecurityTypes None', target_match => [qw(displaymanager vnc_certificate_warning)]);
     if (match_has_tag 'vnc_certificate_warning') {
         send_key 'ret';
         assert_screen [qw(displaymanager vnc_certificate_warning-2)];

--- a/tests/x11/remote_desktop/onetime_vncsession_xvnc_tigervnc.pm
+++ b/tests/x11/remote_desktop/onetime_vncsession_xvnc_tigervnc.pm
@@ -39,15 +39,14 @@ sub run {
     # Start vncviewer and login with fullscreen
     x11_start_program('vncviewer', target_match => 'vnc_password_dialog');
     type_string '10.0.2.1:1';
+    wait_still_screen 3;
     assert_and_click 'vncviewer-options';
     assert_and_click 'vncviewer-options-screen';
     assert_and_click 'vncviewer-options-fullscreen';
+    assert_and_click 'vncviewer-options-security';
+    assert_and_click 'vncviewer-options-tlsx509';
     assert_and_click 'vncviewer-options-ok';
     wait_still_screen 3;
-    send_key 'ret';
-    assert_screen 'vnc_certificate_warning';
-    send_key 'ret';
-    assert_screen 'vnc_certificate_warning-2';
     send_key 'ret';
     handle_login;
     assert_screen 'generic-desktop';


### PR DESCRIPTION
- These cases will be added to testsuite desktopapps-remote
- Update the setup steps of supportserver role xvnc_server since we are using SLES12SP3 as the remote desktop supportserver
- Drop onetime_vncsession_xvnc_java.pm for SLE15, the NPAPI needed for the Java plugin is deprecated in Esr#52
- Update 2 xvnc cases

---

- Related ticket: https://progress.opensuse.org/issues/31489
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/740
- Verification run: 
  desktopapps-remote-client1: http://10.67.17.30/tests/235
  desktopapps-remote-supportserver1: http://10.67.17.30/tests/234
