### PR TITLE
Add soft failure to boot image when kernel arg noresume ignored

### DIFF
--- a/tests/shutdown/grub_set_bootargs.pm
+++ b/tests/shutdown/grub_set_bootargs.pm
@@ -26,6 +26,10 @@ sub run {
         }
     }
     push @cmds, 'sed -i "s#GRUB_CMDLINE_LINUX_DEFAULT=\"[^\"]*\"#GRUB_CMDLINE_LINUX_DEFAULT=\"$new_cmdline\"#" /etc/default/grub';
+    if (script_run('! grep -q resume=.*by-path /proc/cmdline')) {
+        record_soft_failure "boo#1079537 - kernel argument noresume ignored - resume from suspend failing when the image started on different VM";
+        push @cmds, 'sed -i "s/# GRUB_DISABLE_LINUX_UUID=true/GRUB_DISABLE_LINUX_UUID=true/" /etc/default/grub';
+    }
     push @cmds, 'grub2-mkconfig -o /boot/grub2/grub.cfg';
 
     # Slow type for 12-SP2 aarch64 image creation test to try to avoid filling up the key event queue


### PR DESCRIPTION
boot_to_desktop test module is failing due to timeout of one of its device, in particular, swap device. We need a workaround while this bug is solved: https://bugzilla.suse.com/show_bug.cgi?id=1079537
Best place that I found to add it is in module grub_set_bootargs due to the problem is in the published image. We can achieve that disabling GRUB_DISABLE_LINUX_UUID only when (recording soft failure) 'by-path' is present in /proc/cmdline.
- Related ticket: https://progress.opensuse.org/issues/32533
- Verification run: 
  -  [sle-15-Installer-DVD-x86_64-Build489.1-skip_registration@64bit](http://dhcp227.suse.cz/tests/682#step/grub_set_bootargs/12)
  - [ sle-15-Installer-DVD-x86_64-Build489.1-minimal+proxy_SCC-postreg_SUSEconnect@64bit](http://dhcp227.suse.cz/tests/683) 