### PR TITLE
Fix firewall-cmd command

### DIFF
--- a/tests/autoyast/verify_firewalld.pm
+++ b/tests/autoyast/verify_firewalld.pm
@@ -16,10 +16,10 @@ use testapi;
 use utils 'systemctl';
 
 sub run {
-    # Verify firewalld is running, returns 0 code only is running
-    assert_script_run('firewall-offline-cmd --state');
     # Verify that service is active
     systemctl 'is-active firewalld.service';
+    # Verify firewalld is running, returns 0 code only is running
+    assert_script_run('firewall-cmd --state');
     my $errors = '';
     # Verify services configured for external zone
     my $zone_config = script_output('firewall-offline-cmd --list-services --zone=public');


### PR DESCRIPTION
This change was not committed, but has to be a part of
[PR#4533](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4533).

Verification run has this change, but missed in the PR: http://g226.suse.de/tests/894/modules/verify_firewalld/steps/1/src