### PR TITLE
Add snapper ncurse into yast2_ncurses test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1224,6 +1224,7 @@ sub load_yast2_ncurses_tests {
     }
     loadtest "console/yast2_http";
     loadtest "console/yast2_ftp";
+    loadtest "console/yast2_snapper_ncurses";
     # back to desktop
     loadtest "console/consoletest_finish";
 }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/31753
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/741
- Verification run: http://10.67.17.71/tests/288#step/yast2_snapper_ncurses/37
