### PR TITLE
disable_online_repos: Adjust keyboard shortcuts for Tumbleweed

### DIFF
--- a/tests/installation/disable_online_repos.pm
+++ b/tests/installation/disable_online_repos.pm
@@ -21,13 +21,13 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use version_utils 'is_leap';
+use version_utils qw(is_leap is_tumbleweed);
 
 sub run {
     assert_screen 'desktop-selection';
     send_key 'alt-o';    # press configure online repos button
     assert_screen 'online-repos-configuration';
-    send_key 'alt-l';    # navigate to the List
+    send_key(is_tumbleweed() ? 'alt-u' : 'alt-l');    # navigate to the List
 
     # Disable repos
     if (is_leap) {


### PR DESCRIPTION
With latest yast, the 'Use online repos' label was replaced, which causes yast to assign a new keyboard shortcut.

Smoke test runs of this change against TW and Leap, both passing:

* Tumbleweed: http://dimstar.internet-box.ch:81/tests/49
* Leap 15.0: http://dimstar.internet-box.ch:81/tests/51