### PR TITLE
Add a workaround for firefox_emaillink bsc#1079512, poo#31159

### DIFF
--- a/tests/x11/firefox/firefox_emaillink.pm
+++ b/tests/x11/firefox/firefox_emaillink.pm
@@ -81,7 +81,12 @@ sub run {
         wait_still_screen 3;
         send_key "alt-a";
     }
-    assert_screen('firefox-email_link-send');
+    assert_screen [qw(firefox-email_link-send firefox-launch)];
+    if (match_has_tag('firefox-launch')) {
+        record_soft_failure 'bsc#1079512 - evolution dumped core';
+        $self->exit_firefox;
+        return;
+    }
     wait_screen_change {
         send_key "esc";
     };


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/31159
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/745
- Verification run: 
  http://10.67.17.30/tests/243
  http://10.67.17.30/tests/245