### PR TITLE
Upgrade SLE12SP3 to SLE15 with zVM

### DIFF
--- a/data/autoyast_sle12/autoyast_sles12sp3_default_reg_full.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3_default_reg_full.xml
@@ -1,0 +1,254 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <dasd>
+    <devices config:type="list">
+      <listentry>
+        <device>DASD</device>
+        <dev_name>/dev/dasda</dev_name>
+        <channel>0.0.0150</channel>
+        <diag config:type="boolean">false</diag>
+      </listentry>
+    </devices>
+  </dasd>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <services-manager>
+  <default_target>graphical</default_target>
+    <services>
+      <enable config:type="list">
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <keyboard>
+    <keyboard_values>
+      <delay/>
+      <discaps config:type="boolean">false</discaps>
+      <numlock>bios</numlock>
+      <rate/>
+    </keyboard_values>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel>112M</crash_kernel>
+    <crash_xen_kernel>112M\&lt;4G</crash_xen_kernel>
+    <general>
+      <KDUMPTOOL_FLAGS/>
+      <KDUMP_COMMANDLINE/>
+      <KDUMP_COMMANDLINE_APPEND/>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_CPUS/>
+      <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_HOST_KEY/>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>5</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_KERNELVER/>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NET_TIMEOUT>30</KDUMP_NET_TIMEOUT>
+      <KDUMP_NOTIFICATION_CC/>
+      <KDUMP_NOTIFICATION_TO/>
+      <KDUMP_POSTSCRIPT/>
+      <KDUMP_PRESCRIPT/>
+      <KDUMP_REQUIRED_PROGRAMS/>
+      <KDUMP_SAVEDIR>/var/crash</KDUMP_SAVEDIR>
+      <KDUMP_SMTP_PASSWORD/>
+      <KDUMP_SMTP_SERVER/>
+      <KDUMP_SMTP_USER/>
+      <KDUMP_TRANSFER/>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+      <KEXEC_OPTIONS/>
+    </general>
+  </kdump>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list"/>
+  </ntp-client>
+  <software>
+    <image/>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <instsource/>
+    <packages config:type="list">
+      <package>snapper</package>
+      <package>sles-release</package>
+      <package>openssh</package>
+      <package>kexec-tools</package>
+      <package>kdump</package>
+      <package>iproute2</package>
+      <package>grub2</package>
+      <package>glibc</package>
+      <package>e2fsprogs</package>
+      <package>btrfsprogs</package>
+      <package>SuSEfirewall2</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>32bit</pattern>
+      <pattern>Minimal</pattern>
+      <pattern>apparmor</pattern>
+      <pattern>base</pattern>
+      <pattern>documentation</pattern>
+      <pattern>gnome-basic</pattern>
+      <pattern>sles-Minimal-32bit</pattern>
+      <pattern>sles-apparmor-32bit</pattern>
+      <pattern>sles-base-32bit</pattern>
+      <pattern>sles-documentation-32bit</pattern>
+      <pattern>sles-x11-32bit</pattern>
+      <pattern>x11</pattern>
+      <pattern>yast2</pattern>
+    </patterns>
+  </software>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <reg_code>25af9a31773574ab</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+  </suse_register>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id/>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>suse</domain>
+      <hostname>linux-gspv</hostname>
+      <nameservers config:type="list">
+        <nameserver>10.160.0.1</nameserver>
+      </nameservers>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>static</bootproto>
+        <device>eth0</device>
+        <ipaddr>{{HostIP}}</ipaddr>
+        <netmask>255.255.240.0</netmask>
+        <prefixlen>20</prefixlen>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>KERNELS</rule>
+        <value>0.0.0700</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+      <routes config:type="list">
+        <route>
+          <destination>default</destination>
+          <device>eth0</device>
+          <gateway>10.161.159.254</gateway>
+          <netmask>-</netmask>
+        </route>
+      </routes>
+    </routing>
+    <s390-devices config:type="list">
+      <listentry>
+        <chanids>0.0.0700 0.0.0701 0.0.0702</chanids>
+        <portname>no portname required</portname>
+        <type>qeth</type>
+      </listentry>
+      <listentry>
+        <chanids>   </chanids>
+        <type/>
+      </listentry>
+    </s390-devices>
+  </networking>
+  <firewall>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+  </firewall>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Berlin</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact>-1</inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/tests/autoyast/autoyast_reboot.pm
+++ b/tests/autoyast/autoyast_reboot.pm
@@ -19,10 +19,19 @@
 use strict;
 use base 'basetest';
 use testapi;
+use utils;
 
 sub run {
+    # Kill ssh proactively before reboot to avoid half-open issue on zVM
+    prepare_system_shutdown;
+
     type_string("shutdown -r now\n");
     reset_consoles;
+
+    # We have to reconnect in next on zVM
+    if (check_var("BACKEND", "s390x")) {
+        return;
+    }
 
     assert_screen("bios-boot",  900);
     assert_screen("bootloader", 30);

--- a/tests/autoyast/console.pm
+++ b/tests/autoyast/console.pm
@@ -23,14 +23,17 @@ use utils 'power_action';
 
 sub run {
     my ($self) = @_;
-    # trying to change consoles manually because of bsc#1042554
-    send_key 'ctrl-alt-f2';
-    send_key 'alt-f2';
-    if (!check_screen 'text-login') {
-        record_soft_failure 'bsc#1042554';
-        send_key 'ctrl-alt-delete';
-        power_action('reboot', keepconsole => 0, observe => 0);
-        $self->wait_boot();
+    # Trying to change consoles manually because of bsc#1042554
+    # And no need on zVM
+    if (!check_var('BACKEND', 's390x')) {
+        send_key 'ctrl-alt-f2';
+        send_key 'alt-f2';
+        if (!check_screen 'text-login') {
+            record_soft_failure 'bsc#1042554';
+            send_key 'ctrl-alt-delete';
+            power_action('reboot', keepconsole => 0, observe => 0);
+            $self->wait_boot();
+        }
     }
     select_console 'root-console';
 }

--- a/tests/autoyast/prepare_profile.pm
+++ b/tests/autoyast/prepare_profile.pm
@@ -24,12 +24,18 @@ sub run {
     # Return if profile is not available
     return unless $profile;
     # Expand variables
-    my @vars = qw(SCC_REGCODE SCC_URL VERSION ARCH);
-    foreach (@vars) {
-        my $value = get_var($_);
+    my @vars = qw(SCC_REGCODE SCC_URL VERSION ARCH HostIP);
+    for my $var (@vars) {
+        my $value;
+        if ($var eq 'HostIP') {
+            ($value) = get_var('S390_NETWORK_PARAMS') =~ /HostIP=(.*?)\//;
+        }
+        else {
+            $value = get_var($var);
+        }
         # Skip if value is not defined
         next unless $value;
-        $profile =~ s/\{\{$_\}\}/$value/g;
+        $profile =~ s/\{\{$var\}\}/$value/g;
     }
     # Upload modified profile
     save_tmp_file($path, $profile);

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -22,6 +22,7 @@ use English;
 
 use bootloader_setup;
 use registration;
+use utils 'shorten_url';
 
 # try to find the 2 longest lines that are below beyond the limit
 # collapsing the lines - we have a limit of 10 lines
@@ -94,6 +95,17 @@ sub prepare_parmfile {
 
     $params .= specific_bootmenu_params;
     $params .= registration_bootloader_cmdline if check_var('SCC_REGISTER', 'installation');
+
+    # Pass autoyast parameter for s390x, shorten the url because of 72 columns limit in x3270 xedit
+    # If 'AUTOYAST_PREPARE_PROFILE' is true, shorten url directly, otherwise shorten url with data_url method
+    if (get_var('AUTOYAST')) {
+        if (get_var('AUTOYAST_PREPARE_PROFILE')) {
+            $params .= " autoyast=" . shorten_url(get_var('AUTOYAST'));
+        }
+        else {
+            $params .= " autoyast=" . shorten_url(data_url(get_var('AUTOYAST')));
+        }
+    }
     return split_lines($params);
 }
 
@@ -272,7 +284,9 @@ sub run {
     my $c = select_console('iucvconn', await_console => 0);
 
     # we also want to test the formatting during the installation if the variable is set
-    if (!get_var("FORMAT_DASD_YAST") && !get_var('S390_DISK') && !get_var('UPGRADE')) {
+    # Skip format dasd before origin system installation by autoyast in 'Upgrade on zVM'
+    # due to channal not activation issue. Need further investigation on it.
+    if (!get_var("FORMAT_DASD_YAST") && !get_var('S390_DISK') && !get_var('UPGRADE') && !get_var('UPGRADE_ON_ZVM')) {
         format_dasd;
     }
 

--- a/tests/migration/version_switch_origin_system.pm
+++ b/tests/migration/version_switch_origin_system.pm
@@ -28,6 +28,13 @@ sub run {
         # Switch to original system version and reload needles
         set_var('VERSION', $original_version, reload_needles => 1);
     }
+
+    # Reset vars for autoyast installation of origin system
+    if (get_var('UPGRADE_ON_ZVM')) {
+        set_var('BETA',         0);
+        set_var('UPGRADE',      0);
+        set_var('SCC_REGISTER', 'none');
+    }
 }
 
 1;

--- a/tests/migration/version_switch_upgrade_target.pm
+++ b/tests/migration/version_switch_upgrade_target.pm
@@ -26,6 +26,16 @@ sub run {
         # Switch to upgrade target version and reload needles
         set_var('VERSION', $upgrade_target_version, reload_needles => 1);
     }
+
+    # Reset vars for upgrade on zVM
+    if (get_var('UPGRADE_ON_ZVM')) {
+        set_var('BETA',                1);
+        set_var('UPGRADE',             1);
+        set_var('AUTOYAST',            0);
+        set_var('DESKTOP',             'textmode');
+        set_var('SCC_REGISTER',        'installation');
+        set_var('REPO_UPGRADE_BASE_0', 0);
+    }
 }
 
 1;

--- a/tests/update/patch_before_migration.pm
+++ b/tests/update/patch_before_migration.pm
@@ -24,17 +24,20 @@ sub is_smt_or_module_tests {
 sub patching_sle {
     my ($self) = @_;
 
-    set_var("VIDEOMODE",    'text');
-    set_var("SCC_REGISTER", 'installation');
-    # remember we perform registration on pre-created HDD images
-    if (sle_version_at_least('12-SP2', version_variable => 'HDDVERSION')) {
-        set_var('HDD_SP2ORLATER', 1);
-    }
+    # Skip registration here since we use autoyast profile to register origin system on zVM
+    if (!get_var('UPGRADE_ON_ZVM')) {
+        set_var("VIDEOMODE",    'text');
+        set_var("SCC_REGISTER", 'installation');
+        # remember we perform registration on pre-created HDD images
+        if (sle_version_at_least('12-SP2', version_variable => 'HDDVERSION')) {
+            set_var('HDD_SP2ORLATER', 1);
+        }
 
-    assert_script_run("zypper lr && zypper mr --disable --all");
-    save_screenshot;
-    sle_register("register");
-    assert_script_run('zypper lr -d');
+        assert_script_run("zypper lr && zypper mr --disable --all");
+        save_screenshot;
+        sle_register("register");
+        assert_script_run('zypper lr -d');
+    }
 
     # install all patterns
     install_patterns() if (get_var('PATTERNS'));
@@ -52,11 +55,15 @@ sub patching_sle {
 
     if (get_var('FULL_UPDATE')) {
         fully_patch_system();
-        type_string "reboot\n";
-        $self->wait_boot(textmode => !is_desktop_installed(), ready_time => 600, bootloader_time => 250);
+        # Update origin system on zVM that is controlled by autoyast profile and reboot is done by end of autoyast installation
+        # So we skip reboot here after fully patched on zVM to reduce times of reconnection to s390x
+        if (!get_var('UPGRADE_ON_ZVM')) {
+            type_string "reboot\n";
+            $self->wait_boot(textmode => !is_desktop_installed(), ready_time => 600, bootloader_time => 250);
 
-        # Go back to the initial state, before the patching
-        $self->setup_migration();
+            # Go back to the initial state, before the patching
+            $self->setup_migration();
+        }
     }
 
     if (get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/ || get_var('KEEP_REGISTERED')) {


### PR DESCRIPTION
Not use 2 chained jobs anymore to perform upgrade on zVM. Using autoyast to install origin system and then perform media upgrade or proxyscc upgrade on it. Upgrade scenarios could be controlled by different autoyast profile of origin system.
- Related ticket: https://progress.opensuse.org/issues/29101
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/768
- Verification run:
upgrade by media: http://bartok.arch.suse.de/tests/166 cancelled due to bsc#1084997
upgrade by proxy:  http://bartok.arch.suse.de/tests/168 failed in scc_registration should be other potential issue