### PR TITLE
Install systemd-container rpm in networkd_init

### DIFF
--- a/tests/networkd/networkd_init.pm
+++ b/tests/networkd/networkd_init.pm
@@ -19,9 +19,11 @@ sub run {
     my ($self) = @_;
 
     select_console 'root-console';
+
+    zypper_call("in bridge-utils systemd-container");
+
     assert_script_run("ls -la --color /var/lib/machines");
 
-    zypper_call("in bridge-utils");
     assert_script_run("brctl addbr br0");
     assert_script_run("ip li set br0 up");
 


### PR DESCRIPTION
This is needed to use nspawn-containers which are
used in the networkd testsuite.

Fixes [poo#32596](https://progress.opensuse.org/issues/32596)