### PR TITLE
poo#30616: Log xfreerdp's debug output

### DIFF
--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -198,12 +198,13 @@ sub run {
 
     # xfreerdp should be run with fullscreen option (/f) so the needle match.
     # Typing this string takes so long that we would miss grub menu, so...
+    my ($jobid) = get_required_var('NAME') =~ /(\d+)/;
+    my $xfreerdp_log = "/tmp/${jobid}-xfreerdp-${name}-\$(date +%s).log";
     type_string "rm -fv xfreerdp_${name}_stop* xfreerdp_${name}.log; while true; do inotifywait xfreerdp_${name}_stop; DISPLAY=:$xvncport xfreerdp /u:"
       . get_var('HYPERV_USERNAME') . " /p:'"
       . get_var('HYPERV_PASSWORD') . "' /v:"
       . get_var('HYPERV_SERVER')
-      . " /cert-ignore /vmconnect:$vmguid /f 2>&1 >> xfreerdp_${name}.log; echo $vmguid > xfreerdp_${name}_stop; done";
-    #      . " /cert-ignore /jpeg /jpeg-quality:100 /fast-path:1 /bpp:32 /vmconnect:$vmguid /f";
+      . " /cert-ignore /vmconnect:$vmguid /f /log-level:DEBUG 2>&1 > $xfreerdp_log; echo $vmguid > xfreerdp_${name}_stop; done; ";
 
     hyperv_cmd_with_retry("$ps Start-VM $name");
 


### PR DESCRIPTION
This adds debug logging to `xfreerdp`. We need it to debug cases where
`xfreerdp` from no aparent reason disconnects (or is disconnected) from
Hyper-V host (see poo#30616). Creates one log per `xfreerdp` connection.

The resulting log is about 25 MB per 80 minute job. Cleaning cron job is
set on the storage.

If the logging is not useful to gather more information for poo#30616,
or when we have the information, we might remove this.

Validation run:
* http://assam.suse.cz/tests/600#step/bootloader_hyperv/37