### PR TITLE
Verify disable firewall in virt roles & enable it

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -87,7 +87,11 @@ sub run {
             }
         }
     }
-
+    if (check_var('SYSTEM_ROLE', 'kvm') or check_var('SYSTEM_ROLE', 'xen')) {
+        send_key_until_needlematch 'firewall-disabled', 'tab';
+        send_key 'ret';
+        assert_screen 'firewall-enabled';
+    }
     if (check_screen('inst-overview-bootloader-warning', 0)) {
         record_soft_failure 'bsc#1024409';
         send_key 'alt-i';    #install


### PR DESCRIPTION
Verify disabled firewall in virtualization roles according https://fate.suse.com/324207 and enable it.

- Related ticket: https://progress.opensuse.org/issues/32812
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/748
- Verification run: 
  - [sle-15-Installer-DVD-x86_64-Build489.2-textmode+kvm_server_role@64bit](http://dhcp227.suse.cz/tests/723#step/installation_overview/15)
  - [sle-15-Installer-DVD-x86_64-Build489.2-textmode+xen_server_role@64bit ](http://dhcp227.suse.cz/tests/722#step/installation_overview/15)