### PR TITLE
disable_online_repos: Adjust keyboard shortcuts for all product

### DIFF
--- a/tests/installation/disable_online_repos.pm
+++ b/tests/installation/disable_online_repos.pm
@@ -21,13 +21,13 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use version_utils qw(is_leap is_tumbleweed);
+use version_utils 'is_leap';
 
 sub run {
     assert_screen 'desktop-selection';
     send_key 'alt-o';    # press configure online repos button
     assert_screen 'online-repos-configuration';
-    send_key(is_tumbleweed() ? 'alt-u' : 'alt-l');    # navigate to the List
+    send_key 'alt-u';    # navigate to the List
 
     # Disable repos
     if (is_leap) {


### PR DESCRIPTION
The shortcut changes alt-u also appears in Leap after had yast2-packager update, this change should be the default shortcut from now.

Smoke test run of Leap:

http://147.2.211.128/tests/3