### PR TITLE
Increase timeout for installation_overview_before due to hyperv machine speed

### DIFF
--- a/tests/installation/installation_overview_before.pm
+++ b/tests/installation/installation_overview_before.pm
@@ -25,7 +25,7 @@ sub run {
     # 'inst-overview' needle is used in many places and sometimes includes only
     # parts which are there while overview is still loading. This check has to be
     # performed only once, as state of buttons can be different
-    assert_screen "installation-settings-overview-loaded";
+    assert_screen('installation-settings-overview-loaded', 90);
 
     if (check_screen('manual-intervention', 0)) {
         $self->deal_with_dependency_issues;


### PR DESCRIPTION
Increase timeout for this test because hyperv tests sporadically stuck due "evaluating package selection" pop-up takes more than 30s to disappear in these machines.

- Related ticket: https://progress.opensuse.org/issues/32524
