### PR TITLE
Move from brctl to bridge tool

### DIFF
--- a/tests/networkd/networkd_bridge.pm
+++ b/tests/networkd/networkd_bridge.pm
@@ -66,7 +66,7 @@ Address=44.0.0.2/24
     $self->assert_script_run_container("node2", "systemctl restart systemd-networkd");
     # Workaround for gh#systemd/systemd#5043
     $self->wait_for_networkd("node2", "br0");
-    $self->assert_script_run_container("node2", "brctl show");
+    $self->assert_script_run_container("node2", "bridge link");
     $self->assert_script_run_container("node2", "ping -c1 44.0.0.1");
 
 

--- a/tests/networkd/networkd_init.pm
+++ b/tests/networkd/networkd_init.pm
@@ -20,17 +20,17 @@ sub run {
 
     select_console 'root-console';
 
-    zypper_call("in bridge-utils systemd-container");
+    zypper_call("in systemd-container");
 
     assert_script_run("mkdir -p /var/lib/machines/");
 
-    assert_script_run("brctl addbr br0");
+    assert_script_run("ip li add name br0 type bridge");
     assert_script_run("ip li set br0 up");
 
     $self->setup_nspawn_unit();
 
     my $pkg_repo        = "dvd:/?devices=/dev/sr0";
-    my $pkgs_to_install = "systemd shadow zypper openSUSE-release vim iproute2 iputils bridge-utils";
+    my $pkgs_to_install = "systemd shadow zypper openSUSE-release vim iproute2 iputils";
 
     $self->setup_nspawn_container("node1", $pkg_repo, $pkgs_to_install);
     $self->setup_nspawn_container("node2", $pkg_repo, $pkgs_to_install);
@@ -38,7 +38,7 @@ sub run {
     $self->start_nspawn_container("node1");
     $self->start_nspawn_container("node2");
 
-    assert_script_run("brctl show br0");
+    assert_script_run("bridge link");
 
     $self->assert_script_run_container("node1", "zypper lr -u");
     $self->assert_script_run_container("node1", "ip a");


### PR DESCRIPTION
`brctl` from `bridge-utils` RPM is deprecated, so better use `ip` and `bridge`.