### PR TITLE
Do not run consoletest_setup for networkd tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1420,7 +1420,6 @@ sub load_wicked_tests {
 }
 
 sub load_networkd_tests {
-    loadtest "console/consoletest_setup";
     loadtest 'networkd/networkd_init';
     loadtest 'networkd/networkd_dhcp';
     loadtest 'networkd/networkd_vlan';


### PR DESCRIPTION
`consoletest_setup` takes very long and is
not needed for running the testsuite.