### PR TITLE
Adapt journal_check for new Spectre warning variation

### DIFF
--- a/tests/caasp/journal_check.pm
+++ b/tests/caasp/journal_check.pm
@@ -31,7 +31,7 @@ sub run {
         bsc_1025218_FEATURE => '.*dmi.*Firmware registration failed.*',
         bsc_1028060_FEATURE => '.*getting etcd lock took too long, reboot canceld.*',
         bsc_1071224         => '.*Failed to start Mask tmp.mount by default on SUSE systems.*',
-        poo_31951_FEATURE   => '.*Spectre V2 \: LFENCE not serializing.*',
+        poo_31951_FEATURE   => '.*Spectre V2 \:.*LFENCE not serializing.*',
     };
     my $master_pattern = "(" . join('|', map { "$_" } values %$bug_pattern) . ")";
 


### PR DESCRIPTION
New kernel has more verbose version of the previous warning

This should catch both variations

Will fix https://openqa.opensuse.org/tests/629072#step/journal_check/5