### PR TITLE
Not init x11 as tty7 during upgrade SLE 12 to 15

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -948,7 +948,6 @@ sub get_x11_console_tty {
     my $new_gdm
       = !is_sle('<15')
       && !is_leap('<15.0')
-      && !is_sle12_hdd_in_upgrade
       && !is_caasp
       && !get_var('VERSION_LAYERED');
     return (check_var('DESKTOP', 'gnome') && get_var('NOAUTOLOGIN') && $new_gdm) ? 2 : 7;


### PR DESCRIPTION
Currently not possible to switch console tty during test, so if
x11 console is initialized as tty7, it can't be switched to tty2
after upgrade, which will lead to failures in later gui tests.
- poo#32668, poo#31039

For example, many migration tests failed at updates_packagekit_gpk which was gui regression test after upgrade:
https://openqa.suse.de/tests/1520798
https://openqa.suse.de/tests/1521850
https://openqa.suse.de/tests/1522203
https://openqa.suse.de/tests/1521860

- Related ticket: https://progress.opensuse.org/issues/32668
- Needles: None
- Verification run: 
   * upgrade sles 12-sp3 -> 15: http://openqa-apac1.suse.de/tests/365#step/updates_packagekit_gpk/25
   * upgrade sled 12-sp3 -> 15: http://openqa-apac1.suse.de/tests/364#step/updates_packagekit_gpk/25
