### PR TITLE
Wait longer to show install overview in upgrade

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -24,7 +24,7 @@ sub run {
     record_soft_failure('bsc#1054974') if get_var('ALL_MODULES');
     # overview-generation
     # this is almost impossible to check for real
-    assert_screen "installation-settings-overview-loaded";
+    assert_screen "installation-settings-overview-loaded", 150;
 
     $self->deal_with_dependency_issues;
 


### PR DESCRIPTION
In upgrade, it takes longer time to check package
dependencies before system is ready to upgrade. And
even longer time is required if multiple addons are
selected during upgrade.
- poo#31552

Many tests failed with this issue on o.s.d, such as:
https://openqa.suse.de/tests/1526008
https://openqa.suse.de/tests/1526165
https://openqa.suse.de/tests/1526200

It took ~130s at worst case.

- Related ticket: https://progress.opensuse.org/issues/31552
- Needles: None
- Verification run: 
   * installation with addons (SCC_ADDONS=ha,sdk,we): default timeout 30s -- http://10.67.18.143/tests/229
   * upgrade from packages media (ADDONS=all-packages): timeout 60 + 30 -- http://10.67.18.143/tests/227
   * upgrade from packages media (SCC_ADDONS=ha,geo,sdk,we): timout 60 + 30 * 4 -- http://10.67.18.143/tests/228