### PR TITLE
Virtualization: use daily build module repos in guest upgrade test

### DIFF
--- a/tests/virt_autotest/guest_upgrade_run.pm
+++ b/tests/virt_autotest/guest_upgrade_run.pm
@@ -16,6 +16,7 @@
 use strict;
 use warnings;
 use base "virt_autotest_base";
+use virt_utils;
 use testapi;
 
 sub get_script_run {
@@ -34,6 +35,10 @@ sub run {
     my $self = shift;
     my $timeout = get_var("MAX_TEST_TIME", "36000") + 10;
     script_run("echo \"Debug info: max_test_time is $timeout\"");
+    #Modify source configuration file sources.* of virtauto-data pkg on host
+    #to use openqa daily build installer repo and module repo for guests,
+    #and it will be copied into guests to be used during guest upgrade test
+    repl_module_in_sourcefile();
     $self->run_test($timeout, "guest_upgrade_test ... ... PASSED", "no", "yes", "/var/log/qa/", "guest-upgrade-logs");
 }
 


### PR DESCRIPTION
Current guest upgrade can work for milestones in openqa, but for candidates validation before milestones, the repo does not use daily build and makes mismatch for installation repo and module url during guest upgrade.
This PR is to fix this, by using daily build openqa repos completely in underlying test configuration file.

- Verification run: http://10.67.18.220/tests/563#step/guest_upgrade_run/6
   Please ignore the overall status - fail, it is expected because using all openqa repo make test slow down significantly during installation and upgrade. So the test fail with timeout issue.
   The core test verification is done just in the screenshot in the job link given.
