### PR TITLE
[sle][ha] Fix dual restart of DRBD resource

### DIFF
--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -44,8 +44,7 @@ sub run {
         barrier_create("DRBD_MIGRATION_DONE_$cluster_name",         $num_nodes);
         barrier_create("DRBD_REVERT_DONE_$cluster_name",            $num_nodes);
         barrier_create("DRBD_RESOURCE_CREATED_$cluster_name",       $num_nodes);
-        barrier_create("DRBD_RESOURCE_STOPPED_$cluster_name",       $num_nodes);
-        barrier_create("DRBD_RESOURCE_STARTED_$cluster_name",       $num_nodes);
+        barrier_create("DRBD_RESOURCE_RESTARTED_$cluster_name",     $num_nodes);
         barrier_create("DRBD_SETUP_DONE_$cluster_name",             $num_nodes);
         barrier_create("LOCK_INIT_$cluster_name",                   $num_nodes);
         barrier_create("LOCK_RESOURCE_CREATED_$cluster_name",       $num_nodes);


### PR DESCRIPTION
DRBD need to be stopped only on *one* node, not all.

- Related ticket: https://progress.opensuse.org/issues/32971, and also a missing part of https://progress.opensuse.org/issues/31522
- Needles: no new needle
- Verification run: [node01](http://moon.qa.suse.cz/tests/2294) and [node02](http://moon.qa.suse.cz/tests/2295)
