### PR TITLE
Set correct base class for installation test

### DIFF
--- a/tests/installation/partitioning_crypt_no_lvm.pm
+++ b/tests/installation/partitioning_crypt_no_lvm.pm
@@ -15,7 +15,7 @@
 # Maintainer: Rodion Iafarov <riafarov@suse.com>
 
 use strict;
-use base "opensusebasetest";
+use base 'y2logsstep';
 use testapi;
 use version_utils 'is_storage_ng';
 use partition_setup 'enable_encryption_guided_setup';


### PR DESCRIPTION
As correctly noticed by Ludwig in [poo#33067](https://progress.opensuse.org/issues/33067), wrong base class was used.