### PR TITLE
s390: Fix decrypt after reboot for encrypted installations

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -117,8 +117,9 @@ sub unlock_if_encrypted {
 
     return unless get_var("ENCRYPT");
 
-    if (check_var('ARCH', 's390x') && check_var('BACKEND', 'svirt')) {
+    if (get_var('S390_ZKVM')) {
         my $password = $testapi::password;
+        select_console('svirt');
 
         # enter passphrase twice (before grub and after grub) if full disk is encrypted
         if (get_var('FULL_LVM_ENCRYPT')) {


### PR DESCRIPTION
[Verification run](http://opeth/tests/220)
[related progress ticket](https://progress.opensuse.org/issues/30694)