### PR TITLE
LTP: Test on more file systems

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -68,6 +68,9 @@ sub install_runtime_dependencies {
       quota
       sudo
       ntfsprogs
+      xfsprogs
+      dosfstools
+      fuse-exfat
     );
     for my $dep (@maybe_deps) {
         script_run('zypper -n -t in ' . $dep . ' | tee');


### PR DESCRIPTION
The LTP test runner can automatically detect 'mkfs.xfs', 'mkfs.fat', etc. and
use them to create a file system to run a test on. SLE15 does not have some of these tools
installed by default.

FYI @mimi1vx 