### PR TITLE
Test salt connection and add proper mtu to static configuration

### DIFF
--- a/lib/mm_network.pm
+++ b/lib/mm_network.pm
@@ -40,15 +40,16 @@ sub get_host_resolv_conf {
 }
 
 sub configure_static_ip {
-    my ($ip)     = @_;
+    my ($ip, $mtu) = @_;
     my $net_conf = parse_network_configuration();
     my $mac      = $net_conf->{fixed}->{mac};
+    $mtu //= 1458;
     script_run "NIC=`grep $mac /sys/class/net/*/address |cut -d / -f 5`";
     assert_script_run "echo \$NIC";
     my ($ip_no_mask, $mask) = split('/', $ip);
     script_run "arping -w 1 -I \$NIC $ip_no_mask";    # check for duplicate IP
 
-    assert_script_run "echo \"STARTMODE='auto'\nBOOTPROTO='static'\nIPADDR='$ip'\" > /etc/sysconfig/network/ifcfg-\$NIC";
+    assert_script_run "echo \"STARTMODE='auto'\nBOOTPROTO='static'\nIPADDR='$ip'\nMTU='$mtu'\" > /etc/sysconfig/network/ifcfg-\$NIC";
     save_screenshot;
     assert_script_run "rcnetwork restart";
     assert_script_run "ip addr";

--- a/tests/ses/deepsea_testsuite.pm
+++ b/tests/ses/deepsea_testsuite.pm
@@ -47,6 +47,10 @@ sub run {
         assert_script_run 'uname -a';
         assert_script_run 'cat /etc/os-release';
         assert_script_run 'rpm -q deepsea-qa';
+        # test salt connection with ping poo#33016
+        assert_script_run 'for i in {1..7}; do echo "try $i" && if [[ $(salt \'*\' test.ping |& tee ping.log) = *"Not connected"* ]];
+ then cat ping.log && false; else salt \'*\' test.ping && break; fi; done';
+        assert_script_run 'salt \'*\' cmd.run \'lsblk\'';
         # rgw is testing ceph health status with additional 900 timeout
         my $testsuite_timout = check_var('DEEPSEA_TESTSUITE', 'health-rgw') ? 2200 : 1500;
         assert_script_run "suites/basic/$deepsea_testsuite.sh --cli | tee /dev/tty /dev/$serialdev | grep ^OK\$", $testsuite_timout;


### PR DESCRIPTION
Deepsea tests were not failing like this before also they don't fail on my local openqa, so I don't know what exactly is worog, but this should make it better.

- Related ticket: https://progress.opensuse.org/issues/33016
- Verification run: http://10.100.12.155/tests/6596