### PR TITLE
Add support for running NVMe Over Fabrics Testsuite

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -53,6 +53,7 @@ our @EXPORT = qw(
   load_slepos_tests
   load_docker_tests
   load_sles4sap_tests
+  load_nvmftests
   installzdupstep_is_applicable
   snapper_is_applicable
   chromestep_is_applicable
@@ -1685,11 +1686,17 @@ sub load_toolchain_tests {
     loadtest "console/kdump_and_crash" if is_sle && kdump_is_applicable;
 }
 
+sub load_nvmftests {
+    return unless consolestep_is_applicable();
+    loadtest "kernel/nvmftests";
+}
+
 sub load_common_opensuse_sle_tests {
     load_autoyast_clone_tests           if get_var("CLONE_SYSTEM");
     load_create_hdd_tests               if get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1");
     load_toolchain_tests                if get_var("TCM") || check_var("ADDONS", "tcm");
     loadtest 'console/network_hostname' if get_var('NETWORK_CONFIGURATION');
+    load_nvmftests                      if get_var('NVMFTESTS');
 }
 
 sub load_ssh_key_import_tests {

--- a/tests/kernel/nvmftests.pm
+++ b/tests/kernel/nvmftests.pm
@@ -1,0 +1,85 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: new test that runs NVMe over Fabrics testsuite
+# Maintainer: Michael Moese <mmoese@suse.de>
+
+use base 'opensusebasetest';
+use strict;
+use testapi;
+use utils 'zypper_call';
+use serial_terminal 'select_virtio_console';
+
+sub run {
+    select_virtio_console();
+
+    zypper_call('ar -f -G ' . get_required_var('BENCHMARK_REPO'));
+    zypper_call('ar -f -G ' . get_required_var('DEVEL_LANG_PYTHON_REPO'));
+    zypper_call('--gpg-auto-import-keys ref');
+    zypper_call('in nvmftests');
+
+    assert_script_run('cd /var/lib/nvmftests');
+    assert_script_run('ln -sf tests/config config');
+    assert_script_run('nose2 --verbose', 1200);
+
+    power_action('poweroff');
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+sub post_fail_hook { }
+
+1;
+
+
+=head1 Configuration
+
+=head2 Required Repositories
+
+The NVMe over Fabrics Unit Test Framework requires repositories from OBS to run:
+- devel:languages:python
+- benchmark
+
+Apart from that, no further repositories are required for SLE and openSUSE.
+
+=head2 Example
+Example Leap 15 test suite configuration
+
+BENCHMARK_REPO="https://download.opensuse.org/repositories/benchmark/openSUSE_Leap_15.0/benchmark.repo"
+BOOT_HDD_IMAGE=1
+DESKTOP=textmode
+DEVEL_LANG_PYTHON_REPO="https://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_15.0/devel:languages:python.repo"
+HDD_1=SLES-%VERSION%-%ARCH%-minimal_with_sdk_installed.qcow2
+HDDMODEL_2='nvme'
+NUMDISKS=2
+ISO=SLE-%VERSION%-Server-DVD-%ARCH%-Build%BUILD%-Media1.iso
+ISO_1=SLE-%VERSION%-SDK-DVD-%ARCH%-Build%BUILD_SDK%-Media1.iso
+ISO_2=SLE-%VERSION%-WE-DVD-%ARCH%-Build%BUILD_WE%-Media1.iso
+NVMFTESTS=1
+PUBLISH_HDD_1=SLES-%VERSION%-%ARCH%-minimal_with_ltp_installed.qcow2
+QEMUCPUS=4
+QEMURAM=4096
+START_AFTER_TEST=create_hdd_textmode
+TEST='nvmftests'
+VIRTIO_CONSOLE=1
+
+For SLE the configuration is similar, but the two repositories need to be adjusted with the correct builds.
+
+=head2 NVMFTESTS
+Set this to "1" to enable the execution of nvmftests
+
+=head2 DEVEL_LANG_PYTHON_REPO
+This variable points to the devel_languages:python project's repo in OBS. 
+
+=head2 BENCHMARK_REPO
+This variable points to the benchmark project's repo in OBS.
+
+# vim: set sw=4 et:


### PR DESCRIPTION
Add support to run the NVMe over Fabrics Testsuite [1],now available in OBS in [2].

The testsuite runs inside a virtual machine, does not depend on any physical hardware, but requires one NVMe disk configured for QEMU. The testsuite is potentially destructive on the first available NVMe.

- Related ticket: https://progress.opensuse.org/issues/27726
- Verification run: http://10.160.67.206/tests/296

[1] https://github.com/ChaitanayaKulkarni/nvmftests
[2] https://build.opensuse.org/project/show/benchmark

Signed-off-by: Michael Moese <mmoese@suse.de>