### PR TITLE
Replace deprecated firewallctl command

### DIFF
--- a/tests/console/firewall_enabled.pm
+++ b/tests/console/firewall_enabled.pm
@@ -19,7 +19,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     if ($self->firewall eq 'firewalld') {
-        assert_script_run('firewallctl state');
+        assert_script_run('firewall-cmd --state');
     }
     else {
         assert_script_run('SuSEfirewall2 status');


### PR DESCRIPTION
Replace deprecated firewallctl command with firewall-cmd.

- Related ticket: https://progress.opensuse.org/issues/33076
- Verification run: http://dhcp227.suse.cz/tests/734#step/firewall_enabled/1
