### PR TITLE
Check release notes for SLE 15 addons

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -14,10 +14,10 @@
 use base "y2logsstep";
 use strict;
 use testapi;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
-    assert_screen('release-notes-button', 5);
+    assert_screen('release-notes-button', 60);
     return if match_has_tag('bsc#1054478');
 
     # workaround for bsc#1014178
@@ -28,11 +28,16 @@ sub run {
     }
     my $addons = get_var('ADDONS', get_var('ADDONURL', get_var('DUD_ADDONS', '')));
     my @addons = split(/,/, $addons);
-    if (check_var('SCC_REGISTER', 'installation')) {
+    if (check_var('SCC_REGISTER', 'installation') || (get_var("UPGRADE") && is_sle('15+'))) {
         my @scc_addons = grep { $_ ne "" } split(/,/, get_var('SCC_ADDONS', ''));
 
         push @addons, @scc_addons;
     }
+    # Unique addons
+    my %seen;
+    for (@addons) { $seen{$_}++; }
+    @addons = keys %seen;
+
     if (get_var("UPGRADE")) {
         send_key "alt-e";    # open release notes window
     }
@@ -54,9 +59,12 @@ sub run {
     my @no_relnotes = qw(we lgm asmm certm contm pcm tcm wsm hpcm ids idu phub all-packages sapapp);
 
     # No release-notes for basic modules on SLE 15
-    if (sle_version_at_least('15') && check_var('DISTRI', 'sle')) {
-        # Note: no Release Notes to for HA, should be modified for GA version
-        push @no_relnotes, qw(base script desktop productivity serverapp legacy sdk ha);
+    if (is_sle('15+')) {
+        push @no_relnotes, qw(base script desktop productivity serverapp legacy sdk);
+        # WE has release-notes on SLE 15
+        @no_relnotes = grep(!/^we$/, @no_relnotes);
+        # HA-GEO has been removed on SLE 15
+        @addons = grep(!/^geo$/, @addons);
     }
 
     # no relnotes for ltss in QAM_MINIMAL
@@ -66,6 +74,11 @@ sub run {
         push @no_relnotes, qw(geo);
     }
     if (@addons) {
+        if (!check_var('VIDEOMODE', 'text')) {
+            # Make sure release notes window is shown to avoid sending key too early
+            # It takes longer time to show multilple release notes for addons
+            assert_screen([qw(release-notes-sle-ok-button release-notes-sle-close-button)], 120);
+        }
         for my $a (@addons) {
             next if grep { $a eq $_ } @no_relnotes;
             send_key_until_needlematch("release-notes-$a", 'right', 4, 60);


### PR DESCRIPTION
releasenotes needs longer time to show in upgrade, with
some time is required to initialize installation (poo#32953)

releasenotes of the addon products should be also checked
during upgrade (poo#30067)

- Related tickets: 
   * https://progress.opensuse.org/issues/32953
   * https://progress.opensuse.org/issues/30067
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/756
- Verification runs: 
   * gnome@64bit-smp: http://openqa-apac1.suse.de/tests/430#step/releasenotes/6
   * gnome+skip_registration@64bit-smp: http://openqa-apac1.suse.de/tests/437#step/releasenotes/6
   * media_upgrade_sles12sp3@64bit-smp: http://openqa-apac1.suse.de/tests/433#step/releasenotes/5
   * media_upgrade_sles12sp3+ha+geo+sdk+we@64bit-smp: http://openqa-apac1.suse.de/tests/434#step/releasenotes/9
   * scc_upgrade_sles12sp3@64bit-smp: http://openqa-apac1.suse.de/tests/435#step/releasenotes/4
   * scc_upgrade_sles12sp3+ha+geo+sdk+we@64bit-smp: http://openqa-apac1.suse.de/tests/436#step/releasenotes/10