### PR TITLE
Update reboot_to_upgrade to reboot instantly

### DIFF
--- a/tests/migration/reboot_to_upgrade.pm
+++ b/tests/migration/reboot_to_upgrade.pm
@@ -28,7 +28,8 @@ sub run {
 
     # Reboot from Installer media for upgrade
     set_var('BOOT_HDD_IMAGE', 0) if get_var('UPGRADE') || get_var('AUTOUPGRADE');
-    power_action('reboot', textmode => 1);
+    assert_script_run "sync", 300;
+    type_string "reboot --force\n";
 }
 
 1;


### PR DESCRIPTION
Subsequent test fails in bootloader if it takes too long
to shutdown the machine before reboot, so just sync the
filesystem and force reboot without wait.

- Related ticket: https://progress.opensuse.org/issues/32893
Also a workaround to https://progress.opensuse.org/issues/33118
- Needles: None
- Verification run: (await_install failed with bsc#1084997)
   * media_upgrade_sles12sp3_workaround_modules@zkvm: http://openqa-apac1.suse.de/tests/440#step/welcome/1
   * media_upgrade_sles12sp3_allpatterns@aarch64: http://openqa-apac1.suse.de/tests/441#step/welcome/1
   * media_upgrade_sles12sp3@64bit-smp: http://openqa-apac1.suse.de/tests/442#step/welcome/1
   * media_upgrade_sles12sp3+ha+geo+sdk+we@64bit-smp: http://openqa-apac1.suse.de/tests/443#step/welcome/1
