### PR TITLE
Drop xinetd for SLE 15, leap 15 and TW

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1205,7 +1205,7 @@ sub load_yast2_ncurses_tests {
     # TODO https://progress.opensuse.org/issues/20200
     # softfail record #bsc1049433 for samba and xinetd
     loadtest "console/yast2_samba";
-    loadtest "console/yast2_xinetd";
+    loadtest "console/yast2_xinetd" if is_sle('<15') || is_leap('<15.0');
     loadtest "console/yast2_apparmor";
     loadtest "console/yast2_lan_hostname";
     # internal nis server in suse network is used, but this is not possible for


### PR DESCRIPTION
xinetd was dropped and should not be scheduled for leap 15, sle 15 and
TW. See [poo#32674](https://progress.opensuse.org/issues/32674).

```
[2018-03-13T10:04:54.0268 CET] [debug] scheduling boot_to_desktop tests/boot/boot_to_desktop.pm
[2018-03-13T10:04:54.0272 CET] [debug] scheduling consoletest_setup tests/console/consoletest_setup.pm
[2018-03-13T10:04:54.0272 CET] [debug] scheduling hostname tests/console/hostname.pm
[2018-03-13T10:04:54.0273 CET] [debug] scheduling zypper_lr tests/console/zypper_lr.pm
[2018-03-13T10:04:54.0274 CET] [debug] scheduling zypper_ref tests/console/zypper_ref.pm
[2018-03-13T10:04:54.0276 CET] [debug] scheduling yast2_proxy tests/console/yast2_proxy.pm
[2018-03-13T10:04:54.0277 CET] [debug] scheduling yast2_ntpclient tests/console/yast2_ntpclient.pm
[2018-03-13T10:04:54.0280 CET] [debug] scheduling yast2_tftp tests/console/yast2_tftp.pm
[2018-03-13T10:04:54.0285 CET] [debug] scheduling yast2_vnc tests/console/yast2_vnc.pm
[2018-03-13T10:04:54.0290 CET] [debug] scheduling yast2_samba tests/console/yast2_samba.pm
[2018-03-13T10:04:54.0298 CET] [debug] scheduling yast2_apparmor tests/console/yast2_apparmor.pm
[2018-03-13T10:04:54.0303 CET] [debug] scheduling yast2_lan_hostname tests/console/yast2_lan_hostname.pm
[2018-03-13T10:04:54.0308 CET] [debug] scheduling yast2_nis tests/console/yast2_nis.pm
[2018-03-13T10:04:54.0312 CET] [debug] scheduling yast2_dns_server tests/console/yast2_dns_server.pm
[2018-03-13T10:04:54.0354 CET] [debug] scheduling yast2_nfs_client tests/console/yast2_nfs_client.pm
[2018-03-13T10:04:54.0368 CET] [debug] scheduling yast2_http tests/console/yast2_http.pm
[2018-03-13T10:04:54.0372 CET] [debug] scheduling yast2_ftp tests/console/yast2_ftp.pm
[2018-03-13T10:04:54.0373 CET] [debug] scheduling consoletest_finish tests/console/consoletest_finish.pm
[2018-03-13T10:04:54.0373 CET] [debug] Early exit has been requested with _EXIT_AFTER_SCHEDULE. Only evaluating test schedule.
```
