### PR TITLE
Don't execute yast2_ntpclient with system role 'HA (GEO) node'

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -500,7 +500,10 @@ sub load_ha_cluster_tests {
     loadtest "qa_automation/patch_and_reboot" if is_updates_tests;
     loadtest "console/consoletest_setup";
     loadtest "console/hostname" unless is_bridged_networking;
-    loadtest "console/yast2_ntpclient";
+
+    # NTP is already configured with 'HA node' and 'HA GEO node' System Roles
+    # 'default' System Role is 'HA node' if HA Product i selected
+    loadtest "console/yast2_ntpclient" unless (get_var('SYSTEM_ROLE', '') =~ /default|ha/);
 
     # Update the image if needed
     if (get_var("FULL_UPDATE")) {


### PR DESCRIPTION
`yast2_ntpclient` test is failing because of new HA System Roles.
NTP is already configured by the system role, so configuration is
not needed anymore in this case.

- Related ticket: https://progress.opensuse.org/issues/33148
- Verification run: [node01](http://moon.qa.suse.cz/tests/2552) and [node02](http://moon.qa.suse.cz/tests/2553)