### PR TITLE
Put back missing releasenotes_origin removed with 79e7d4ca

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -709,6 +709,7 @@ sub load_inst_tests {
             loadtest 'installation/add_update_test_repo';
         }
         loadtest "installation/addon_products_sle";
+        loadtest 'installation/releasenotes_origin' if get_var('CHECK_RELEASENOTES_ORIGIN');
     }
     if (noupdatestep_is_applicable()) {
         # Krypton/Argon disable the network configuration stage


### PR DESCRIPTION
Seems like with 79e7d4ca I removed the schedule for releasenotes_origin and no
one realized.