### PR TITLE
Fix virtualization role tests for firewall disabled

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -18,7 +18,7 @@ use testapi qw(check_var get_var get_required_var set_var check_var_array diag);
 use autotest;
 use utils;
 use version_utils qw(
-  is_hyperv_in_gui is_jeos is_gnome_next is_krypton_argon is_leap is_opensuse is_sle is_sles4sap is_sles4sap_standard sle_version_at_least is_desktop_installed is_installcheck is_rescuesystem is_staging is_tumbleweed
+  is_hyperv_in_gui is_jeos is_gnome_next is_krypton_argon is_leap is_opensuse is_sle is_sles4sap is_sles4sap_standard sle_version_at_least is_desktop_installed is_installcheck is_rescuesystem is_staging is_tumbleweed is_virtualization_server
 );
 use bmwqemu ();
 use strict;
@@ -962,8 +962,8 @@ sub load_consoletests {
         loadtest "console/yast2_bootloader";
     }
     loadtest "console/vim" if is_opensuse || !sle_version_at_least('15') || !get_var('PATTERNS') || check_var_array('PATTERNS', 'enhanced_base');
-    # textmode install comes without firewall by default atm on openSUSE
-    if ((is_sle || !check_var("DESKTOP", "textmode")) && !is_staging() && !is_krypton_argon) {
+# textmode install comes without firewall by default atm on openSUSE. For virtualizatoin server xen and kvm is disabled by default: https://fate.suse.com/324207
+    if ((is_sle || !check_var("DESKTOP", "textmode")) && !is_staging() && !is_krypton_argon && !is_virtualization_server) {
         loadtest "console/firewall_enabled";
     }
     if (is_jeos) {

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -43,6 +43,7 @@ our @EXPORT = qw (
   is_desktop_installed
   is_system_upgrading
   is_pre_15
+  is_virtualization_server
 );
 
 sub is_leap;
@@ -69,6 +70,10 @@ sub is_installcheck {
 
 sub is_rescuesystem {
     return get_var('RESCUESYSTEM');
+}
+
+sub is_virtualization_server {
+    return get_var('SYSTEM_ROLE', '') =~ /(kvm|xen)/;
 }
 
 # Works only for versions comparable by string (not leap 42.X)

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -16,6 +16,7 @@ use base "consoletest";
 use strict;
 use testapi;
 use utils;
+use version_utils 'is_virtualization_server';
 
 # check if sshd works
 sub run {
@@ -26,7 +27,7 @@ sub run {
 
     select_console 'root-console';
 
-    systemctl 'stop ' . $self->firewall;
+    systemctl 'stop ' . $self->firewall if !is_virtualization_server;
     script_run('chkconfig sshd on');
     assert_script_run("chkconfig sshd on", 60);
     assert_script_run("rcsshd restart",    60);    # will do nothing if it is already running


### PR DESCRIPTION
Unschedule test firewall_enabled and avoid to stop firewall in sshd test for virtualization server kvm or xen.

- Related ticket: https://progress.opensuse.org/issues/32812
- Fate ticket: https://fate.suse.com/324207
- Verification run: 
  - [sle-15-Installer-DVD-x86_64-Build501.2-textmode+xen_server_role@64bit](http://dhcp227.suse.cz/tests/742#step/sshd/17)  
  - [sle-15-Installer-DVD-x86_64-Build501.2-textmode+kvm_server_role@64bit](http://dhcp227.suse.cz/tests/743#step/sshd/17)