### PR TITLE
Fix product name in ay profiles

### DIFF
--- a/data/autoyast_sle15/autoyast_SuSEfirewall.xml
+++ b/data/autoyast_sle15/autoyast_SuSEfirewall.xml
@@ -21,7 +21,7 @@
   </networking>
   <software>
     <products config:type="list">
-      <product>SLES15</product>
+      <product>SLES</product>
     </products>
   </software>
   <users config:type="list">

--- a/data/autoyast_sle15/autoyast_btrfs.xml
+++ b/data/autoyast_sle15/autoyast_btrfs.xml
@@ -153,7 +153,7 @@
       <pattern>x11_enhanced</pattern>
     </patterns>
     <products config:type="list">
-      <product>SLES15</product>
+      <product>SLES</product>
     </products>
   </software>
   <networking>

--- a/data/autoyast_sle15/autoyast_error.xml
+++ b/data/autoyast_sle15/autoyast_error.xml
@@ -95,7 +95,7 @@
       <pattern>x11</pattern>
     </patterns>
     <products config:type="list">
-      <product>SLES15</product>
+      <product>SLES</product>
     </products>
   </software>
   <networking>

--- a/data/autoyast_sle15/autoyast_eula.xml
+++ b/data/autoyast_sle15/autoyast_eula.xml
@@ -70,7 +70,7 @@
     </users>
     <software>
         <products config:type="list">
-            <product>SLES15</product>
+            <product>SLES</product>
             <product>sle-ha</product>
             <product>sle-we</product>
         </products>

--- a/data/autoyast_sle15/autoyast_ext4.xml
+++ b/data/autoyast_sle15/autoyast_ext4.xml
@@ -102,7 +102,7 @@
       <pattern>x11_enhanced</pattern>
     </patterns>
     <products config:type="list">
-      <product>SLES15</product>
+      <product>SLES</product>
     </products>
   </software>
   <report>

--- a/data/autoyast_sle15/autoyast_gnome.xml
+++ b/data/autoyast_sle15/autoyast_gnome.xml
@@ -81,7 +81,7 @@
       <pattern>x11_enhanced</pattern>
     </patterns>
     <products config:type="list">
-      <product>SLES15</product>
+      <product>SLES</product>
     </products>
   </software>
   <networking>

--- a/data/autoyast_sle15/autoyast_media_up_gnome.xml
+++ b/data/autoyast_sle15/autoyast_media_up_gnome.xml
@@ -81,7 +81,7 @@
   </report>
   <software>
     <products config:type="list">
-        <product>SLES15</product>
+        <product>SLES</product>
     </products>
   </software>
   <upgrade>

--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -524,7 +524,7 @@ pre init scripts feature. See poo#20818.
       <package>zisofs-tools</package>
     </remove-packages>
     <products config:type="list">
-      <product>SLES15</product>
+      <product>SLES</product>
     </products>
   </software>
 

--- a/data/autoyast_sle15/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle15/bug-872532_ix64ph1069.xml
@@ -696,7 +696,7 @@
       <pattern>base</pattern>
     </patterns>
     <products config:type="list">
-      <product>SLES15</product>
+      <product>SLES</product>
     </products>
     <remove-packages config:type="list">
       <package>glibc-32bit</package>

--- a/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
@@ -787,7 +787,7 @@ find / -name YaST2-Second-Stage.service
       <pattern>minimal_base</pattern>
     </patterns>
     <products config:type="list">
-        <product>SLES15</product>
+        <product>SLES</product>
     </products>
     <remove-packages config:type="list">
       <package>glibc-32bit</package>

--- a/data/autoyast_sle15/bug-877438_ix64ph1029.xml
+++ b/data/autoyast_sle15/bug-877438_ix64ph1029.xml
@@ -22,7 +22,7 @@
   </suse_register>
   <software>
     <products config:type="list">
-      <product>SLES15</product>
+      <product>SLES</product>
     </products>
   </software>
   <bootloader>

--- a/data/autoyast_sle15/bug-879147_autoinst.xml
+++ b/data/autoyast_sle15/bug-879147_autoinst.xml
@@ -274,7 +274,7 @@
     <image/>
     <instsource/>
     <products config:type="list">
-      <product>SLES15</product>
+      <product>SLES</product>
     </products>
   </software>
   <timezone>

--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -483,7 +483,7 @@
       <package>yast2-control-center-qt</package>
     </remove-packages>
     <products config:type="list">
-      <product>SLES15</product>
+      <product>SLES</product>
     </products>
   </software>
   <timezone>

--- a/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
+++ b/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
@@ -192,7 +192,7 @@
       <pattern>base</pattern>
     </patterns>
     <products config:type="list">
-      <product>SLES15</product>
+      <product>SLES</product>
     </products>
   </software>
   <timezone>

--- a/data/autoyast_sle15/mini.xml
+++ b/data/autoyast_sle15/mini.xml
@@ -21,7 +21,7 @@
     </networking>
     <software>
         <products config:type="list">
-            <product>SLES15</product>
+            <product>SLES</product>
         </products>
     </software>
     <users config:type="list">


### PR DESCRIPTION
SLES15 became invalid product, should be SLES now.

See [poo#33133](https://progress.opensuse.org/issues/33133).

See also [doc](https://github.com/yast/yast-autoinstallation/blob/master/doc/profile_changes_SLE15.md)

[Verification run](http://g226.suse.de/tests/904#). Note, just a single verification run to prove that it fixes the issue.
