### PR TITLE
Select SMT_URL with 'atl-l' since SLE 12-SP3

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -553,12 +553,14 @@ sub fill_in_reg_server {
     }
     else {
         send_key "alt-i";
-        if (sle_version_at_least('15')) {
+        if (is_sle('12-sp3+')) {
             send_key "alt-l";
         }
         else {
             send_key "alt-o";
         }
+        # Remove https://smt.example.com
+        for (1 .. 30) { send_key 'backspace'; }
         type_string get_required_var("SMT_URL");
     }
     save_screenshot;


### PR DESCRIPTION
The shortcut of selecting SMT_URL has been changed to
'atl-l' on since SLE 12-SP3.

- Related ticket: https://progress.opensuse.org/issues/31165
- Needles: None
- Verification run: http://openqa-apac1.suse.de/tests/458#step/patch_before_migration/21
   (Note: Test failed with known issue bsc#1080518)
