### PR TITLE
[WIP] Hyper-V: Change console from X11 to TTY

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -307,6 +307,7 @@ sub load_svirt_boot_tests {
 
 sub load_svirt_vm_setup_tests {
     return unless check_var('BACKEND', 'svirt');
+    set_bridged_networking;
     if (check_var("VIRSH_VMM_FAMILY", "hyperv")) {
         loadtest "installation/bootloader_hyperv";
     }
@@ -639,9 +640,7 @@ sub load_bootloader_s390x {
 
 sub boot_hdd_image {
     get_required_var('BOOT_HDD_IMAGE');
-    if (check_var("BACKEND", "svirt")) {
-        loadtest "installation/bootloader_svirt" unless load_bootloader_s390x();
-    }
+    load_svirt_vm_setup_tests if check_var("BACKEND", "svirt") && !load_bootloader_s390x;
     if (get_var('UEFI') && (get_var('BOOTFROM') || get_var('BOOT_HDD_IMAGE'))) {
         loadtest "boot/uefi_bootmenu";
     }

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -318,6 +318,9 @@ sub wait_boot {
     my $in_grub         = $args{in_grub} // 0;
     my $nologin         = $args{nologin};
 
+    # Our Hyper-V host is slow
+    $ready_time *= 2 if check_var('VIRSH_VMM_FAMILY', 'hyperv');
+
     # used to register a post fail hook being active while we are waiting for
     # boot to be finished to help investigate in case the system is stuck in
     # shutting down or booting up

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -15,7 +15,7 @@ use lockapi;
 use needle;
 use registration;
 use utils;
-use version_utils qw(is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem sle_version_at_least is_desktop_installed is_jeos is_sle is_staging is_upgrade);
+use version_utils qw(is_caasp is_installcheck is_rescuesystem sle_version_at_least is_desktop_installed is_jeos is_sle is_staging is_upgrade);
 use File::Find;
 use File::Basename;
 use LWP::Simple 'head';

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -25,6 +25,10 @@ sub run {
 
     # init
     check_console_font;
+    select_console 'x11';
+    select_console 'root-console';
+    select_console 'x11';
+    select_console 'root-console';
     ensure_serialdev_permissions;
     script_run 'echo "set -o pipefail" >> /etc/bash.bashrc.local';
     script_run '. /etc/bash.bashrc.local';
@@ -77,8 +81,10 @@ sub run {
 
 sub post_fail_hook {
     my $self = shift;
+    #diag 'sleep';
+    #sleep;
 
-    $self->export_logs();
+    #$self->export_logs();
 }
 
 sub test_flags {


### PR DESCRIPTION
poo#32458

On Hyper-V `Ctrl` from `Ctrl-Alt-Fx` is lost in VNC-to-RDP translation,
but we may change console via `chvt` command from userspace.

It's hard to find the right place in openQA tests code where to do the switch.

(Contains other crap as well, mostly see `lib/susedistribution.pm`.)