### PR TITLE
Fixes to autoyast profiles

### DIFF
--- a/data/autoyast_sle15/autoyast_SuSEfirewall.xml
+++ b/data/autoyast_sle15/autoyast_SuSEfirewall.xml
@@ -10,7 +10,7 @@
     <reg_server>{{SCC_URL}}</reg_server>
     <addons config:type="list">
       <addon>
-        <name>sle-module-basesystem</name>
+        <name>sle-module-server-applications</name>
         <version>{{VERSION}}</version>
         <arch>{{ARCH}}</arch>
       </addon>
@@ -20,6 +20,9 @@
     <keep_install_network config:type="boolean">true</keep_install_network>
   </networking>
   <software>
+    <packages config:type="list">
+      <package>apache2</package>
+    </packages>
     <products config:type="list">
       <product>SLES</product>
     </products>

--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -429,7 +429,6 @@
       <package>at-spi2-atk-common</package>
       <package>at-spi2-atk-gtk2</package>
       <package>dconf</package>
-      <package>ft2demos</package>
       <package>grub2-snapper-plugin</package>
       <package>gsettings-backend-dconf</package>
       <package>gstreamer-plugins-base</package>


### PR DESCRIPTION
Some more changes to firewall and missing packages. Fixes installation, handled without ticket.

Verification runs:
 * [firewall ay](http://g226.suse.de/tests/927)
 * [missing package](http://g226.suse.de/tests/928)

Fixes https://openqa.suse.de/tests/1542451 and https://openqa.suse.de/tests/1542455