### PR TITLE
Improve sync of registration and addons

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -423,18 +423,17 @@ sub fill_in_registration_data {
             }
         }
         else {
-            send_key $cmd{next};
+            wait_screen_change { send_key $cmd{next} };
             if (check_var('HDDVERSION', '12')) {
                 assert_screen 'yast-scc-emptypkg';
                 send_key 'alt-a';
             }
         }
     }
-    else {
-        if (!get_var('SCC_REGISTER', '') =~ /addon|network/) {
-            send_key $cmd{next};
-        }
+    elsif (!get_var('SCC_REGISTER', '') =~ /addon|network/) {
+        wait_screen_change { send_key $cmd{next} };
     }
+
 }
 
 sub select_addons_in_textmode {

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -128,6 +128,7 @@ sub run {
         set_var('SKIP_INSTALLER_SCREEN', 0);
     }
     $self->process_unsigned_files([qw(inst-addon addon-products)]);
+    wait_still_screen;
     assert_screen [qw(inst-addon addon-products)];
     if (get_var("ADDONS")) {
         send_key match_has_tag('inst-addon') ? 'alt-k' : 'alt-a';


### PR DESCRIPTION
Problem we see in
[poo#33193](https://progress.opensuse.org/issues/33193) is actually not
only about needle, we press next there and match screen which is shown
for a fraction of second. So as a part of the ticket we improve handling
of the pages. [Here](http://g226.suse.de/tests/931#step/addon_products_sle/1) you can see screen which is there, but not for long.

- [Verification run](http://g226.suse.de/tests/932)
- [Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/765)

