### PR TITLE
Modify main.pm & installation_mode to handle new Leap/TW inst flow

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -479,6 +479,15 @@ sub load_docker_tests {
     }
 }
 
+sub load_system_role_tests {
+    # Do not run on REMOTE_CONTROLLER, IPMI and on Hyper-V in GUI mode
+    if (!get_var("REMOTE_CONTROLLER") && !check_var('BACKEND', 'ipmi') && !is_hyperv_in_gui && !get_var("LIVECD")) {
+        loadtest "installation/logpackages";
+    }
+    loadtest "installation/disable_online_repos" if get_var('DISABLE_ONLINE_REPOS');
+    loadtest "installation/installer_desktopselection" if is_opensuse;
+}
+
 sub installzdupstep_is_applicable {
     return !get_var("NOINSTALL") && !get_var("RESCUECD") && get_var("ZDUP");
 }
@@ -685,6 +694,10 @@ sub load_inst_tests {
     if (is_opensuse && noupdatestep_is_applicable() && !get_var("LIVECD")) {
         loadtest "installation/installation_mode";
     }
+    # Run system_role/desktop selection tests if using the new openSUSE installation flow
+    if (is_opensuse && noupdatestep_is_applicable() && get_var("SYSTEM_ROLE_FIRST_FLOW")) {
+        load_system_role_tests;
+    }
     if (!get_var("LIVECD") && get_var("UPGRADE")) {
         loadtest "installation/upgrade_select";
         if (check_var("UPGRADE", "LOW_SPACE")) {
@@ -808,12 +821,10 @@ sub load_inst_tests {
         {
             loadtest "installation/hostname_inst";
         }
-        # Do not run on REMOTE_CONTROLLER, IPMI and on Hyper-V in GUI mode
-        if (!get_var("REMOTE_CONTROLLER") && !check_var('BACKEND', 'ipmi') && !is_hyperv_in_gui && !get_var("LIVECD")) {
-            loadtest "installation/logpackages";
+        # Do not run system_role/desktop selection if using the new openSUSE installation flow
+        if (!get_var("SYSTEM_ROLE_FIRST_FLOW")) {
+            load_system_role_tests;
         }
-        loadtest "installation/disable_online_repos" if get_var('DISABLE_ONLINE_REPOS');
-        loadtest "installation/installer_desktopselection" if is_opensuse;
         if (is_sles4sap()) {
             if (
                 is_sles4sap_standard()    # Schedule module only for SLE15 with non-default role

--- a/tests/installation/installation_mode.pm
+++ b/tests/installation/installation_mode.pm
@@ -19,8 +19,8 @@ use testapi;
 sub run {
     # autoconf phase
     # includes downloads
-    assert_screen [qw(partitioning-edit-proposal-button inst-instmode)], 120;
-    if (match_has_tag("partitioning-edit-proposal-button")) {
+    assert_screen [qw(partitioning-edit-proposal-button before-role-selection inst-instmode)], 120;
+    if (match_has_tag("partitioning-edit-proposal-button") || match_has_tag("before-role-selection")) {
         # new desktop selection workflow
         set_var('NEW_DESKTOP_SELECTION', 1);
         return;


### PR DESCRIPTION
https://github.com/yast/skelcd-control-openSUSE/pull/121 and https://github.com/yast/skelcd-control-openSUSE/pull/122 will introduce a new installation workflow for Leap 15 and Tumbleweed

This PR is needed to ensure that new flow can be tested, by using the newly introduced "SYSTEM_ROLE_FIRST_FLOW" variable (this will likely be replaced by a VERSION check in the future, but we need the variable first so we can stage the changes)

This test also changes one of the needle tags looked for in installation_mode because it's function for checking for the new desktop selection is made easier by the fact it will now be looking AT the new desktop selection screen at that time.

This PR should not impact any current product testing or maintenance runs

- Related ticket: none
- Needles: none needed
- Verification run: none possible