### PR TITLE
keymap reschedule after console_setup module

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -887,11 +887,11 @@ sub load_inst_tests {
 
 sub load_consoletests {
     return unless consolestep_is_applicable();
-    loadtest "locale/keymap_or_locale";
     if (get_var("ADDONS", "") =~ /rt/) {
         loadtest "rt/kmp_modules";
     }
     loadtest "console/consoletest_setup";
+    loadtest "locale/keymap_or_locale";
     loadtest "console/force_cron_run" unless is_jeos;
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/check_locked_package";


### PR DESCRIPTION
Reschedule keymap_or_locale test after console_setup module in lib/main_common.pm.

- Related ticket: 
[[sle 12 sp4][functional][y][yast][fast] test fails in keymap_or_locale - us_keymap_logged_x11 doesn't match or is missing](https://progress.opensuse.org/issues/33256)
[[sle][functional][easy] fix keyboard layout switching tests](https://progress.opensuse.org/issues/33151)

- Verification runs: 
[sle-15-Installer-DVD-x86_64-Build503.1-minimal_x@64bit](http://dhcp228.suse.cz/tests/911)
[sle-15-Installer-DVD-x86_64-Build503.1-gnome@64bit](http://dhcp228.suse.cz/tests/912)
[sle-15-Installer-DVD-x86_64-Build503.1-textmode@64bi](http://dhcp228.suse.cz/tests/913)
[sle-12-SP3-Server-DVD-Updates-x86_64-Build20180315-2-mau-webserver@64bit](http://dhcp228.suse.cz/tests/910)
[sle-12-SP3-Server-DVD-Updates-x86_64-Build20180315-2-qam-textmode@64bit](http://dhcp228.suse.cz/tests/915)
[sle-12-SP3-Server-DVD-Updates-x86_64-Build20180315-2-qam-minimal+base@64bit](http://dhcp228.suse.cz/tests/914)
[opensuse-42.2-Updates-x86_64-Build20180206-1-textmode@64bit](http://dhcp228.suse.cz/tests/916)
[opensuse-Tumbleweed-DVD-x86_64-Build20180313-textmode@64bit](http://dhcp228.suse.cz/tests/919)
[opensuse-15.0-DVD-x86_64-Build164.1-textmode@64bit](http://dhcp228.suse.cz/tests/922)
[opensuse-42.2-UpdateTest-x86_64-Build20180206-1-textmode@64bit-2G](http://dhcp228.suse.cz/tests/923)
