### PR TITLE
Fix postreg test for s390x

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -940,6 +940,7 @@ elsif (get_var('ISO_IN_EXTERNAL_DRIVE')) {
 }
 # post registration testsuites using suseconnect or yast
 elsif (have_scc_repos()) {
+    load_bootloader_s390x();    # schedule svirt/s390x bootloader if required
     loadtest "boot/boot_to_desktop";
     if (get_var('USE_SUSECONNECT')) {
         loadtest "console/suseconnect_scc";


### PR DESCRIPTION
For post-registration we have changed test suite for sle 15 to boot into the
image, however sle12 test suite did full installation. This problem is
general and we fixed that in test suite settings.
For s390x we also haven't scheduled bootloader test module, this is fixed
here.

See [poo#30703](https://progress.opensuse.org/issues/30703).
[Verification run](http://g226.suse.de/tests/951#)
