### PR TITLE
Need more time to boot to desktop under s390_zkvm

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -16,7 +16,7 @@ use testapi qw(send_key %cmd assert_screen check_screen check_var get_var save_s
 
 sub handle_password_prompt {
     if (!get_var("LIVETEST") && !get_var('LIVECD')) {
-        assert_screen "password-prompt";
+        assert_screen "password-prompt", get_var("S390_ZKVM") ? 120 : undef;
         type_password;
         send_key('ret');
     }


### PR DESCRIPTION
This issue always appear in migration group on s390x, need extend timeout

- Related ticket: https://progress.opensuse.org/issues/32749
- Affect test cases: https://openqa.suse.de/tests/1546872,https://openqa.suse.de/tests/1546866
