### PR TITLE
Skip 2nd&3rd runs when all selecting patterns in sle15

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -84,6 +84,7 @@ sub workaround_dependency_issues {
             sleep 2;
         }
     }
+    return 1;
 }
 
 # to break dependency issues

--- a/tests/installation/select_patterns_and_packages.pm
+++ b/tests/installation/select_patterns_and_packages.pm
@@ -22,6 +22,7 @@
 use base "y2logsstep";
 use strict;
 use testapi;
+use version_utils 'is_sle';
 
 my $secondrun = 0;    # bsc#1029660
 
@@ -154,7 +155,7 @@ sub package_action {
 
 sub run {
     my ($self) = @_;
-
+    my $dep_issue;
     $self->gotopatterns;
     if (get_var('PATTERNS')) {
         my %wanted_patterns;
@@ -190,8 +191,9 @@ sub run {
                 };
                 assert_screen 'current-pattern-selected', 5;
             }
-            $self->workaround_dependency_issues;
-            # stick to the default patterns
+            # stick to the default patterns. Check if at least 1 dep. issue was displayed
+            $dep_issue = $self->workaround_dependency_issues || $dep_issue;
+
             if (get_var('PATTERNS', '') =~ /default/) {
                 $needs_to_be_selected = $selected;
             }
@@ -204,12 +206,17 @@ sub run {
         }
     }
     $self->package_action;
-    $secondrun++;
-    $self->gotopatterns;
-    $self->package_action;
-    $secondrun--;
-    $self->gotopatterns;
-    $self->package_action('unblock');
+    if (is_sle('15+') and check_var('PATTERNS', 'all') and $dep_issue) {
+        record_soft_failure "bsc#1084064 - Cloud patterns conflicts";    # skip second & third runs
+    }
+    else {
+        $secondrun++;
+        $self->gotopatterns;
+        $self->package_action;
+        $secondrun--;
+        $self->gotopatterns;
+        $self->package_action('unblock');
+    }
 }
 
 1;


### PR DESCRIPTION
While [this bug/future requested feature](https://bugzilla.suse.com/show_bug.cgi?id=1084064) related with conflicts among cloud patterns is fixed/implemented we can skip from the test 2nd and 3rd run (which I was not able to figure out what is its purpose for old products) but at least in this test we will select all patterns not conflicting atm. Added checking if there is some conflicting package, we flag it and then we skip next runs. 

- Related ticket: https://progress.opensuse.org/issues/27817
- Verification run: http://dhcp254.suse.cz/tests/770#step/select_patterns_and_packages/196