### PR TITLE
RMT installation and mirror repos from SCC

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -570,6 +570,10 @@ sub is_smt {
     return ((get_var("PATTERNS", '') || get_var('HDD_1', '')) =~ /smt/) && !sle_version_at_least('15');
 }
 
+sub is_rmt {
+    return ((get_var("PATTERNS", '') || get_var('HDD_1', '')) =~ /rmt/) && is_sle('>=15');
+}
+
 sub remove_common_needles {
     my $no_skipto = get_var('SKIPTO') ? 0 : 1;
     unregister_needle_tags("ENV-SKIPTO-$no_skipto");
@@ -909,6 +913,7 @@ sub load_consoletests {
         loadtest "console/check_locked_package";
     }
     loadtest "console/textinfo";
+    loadtest "console/rmt" if is_rmt;
     loadtest "console/hostname" unless is_bridged_networking;
     replace_opensuse_repos_tests if get_var('DISABLE_ONLINE_REPOS');
     if (get_var('SYSTEM_ROLE', '') =~ /kvm|xen/) {

--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: common parts on SMT and RMT
-# Maintainer: Dehai Kong <dhkong@suse.com>
+# Maintainer: Dehai Kong <dhkong@suse.com> Jaiwei Sun <jwsun@suse.com>
 
 package repo_tools;
 
@@ -18,8 +18,9 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
+use utils;
 
-our @EXPORT = qw (smt_wizard smt_mirror_repo);
+our @EXPORT = qw (smt_wizard smt_mirror_repo rmt_wizard rmt_mirror_repo);
 
 sub smt_wizard {
     type_string "yast2 smt-wizard;echo yast2-smt-wizard-\$? > /dev/$serialdev\n";
@@ -68,6 +69,48 @@ sub smt_mirror_repo {
     assert_script_run 'smt-mirror', 600;
     save_screenshot;
 }
+
+sub rmt_wizard {
+    my $SCC_Password = get_var('SCC_PWD');
+    my $SCC_User     = get_var('SCC_USER');
+
+    # install RMT and mariadb
+    zypper_call 'in rmt-server';
+    zypper_call 'in mariadb';
+
+    # check mysql status and config mysql for RMT
+    systemctl 'start mysql.service';
+    systemctl 'status mysql.service';
+    my $cmd = 'mysql -u root -p <<EOFF 
+GRANT ALL PRIVILEGES ON \`rmt\`.* TO rmt@localhost IDENTIFIED BY \'rmt\'; 
+FLUSH PRIVILEGES; 
+EOFF';
+    type_string "$cmd\n";
+    assert_screen('rmt-sqladmin-password', 40);
+    send_key 'ret';
+
+    # Modify rmt config file
+    assert_script_run "sed -i '/^[][ ]*username:[][ ]*\$/d' /etc/rmt.conf";
+    assert_script_run "sed -i '/^[][ ]*password/d' /etc/rmt.conf";
+    assert_script_run "sed -i '/adapter/i\ \\ \\ password: rmt' /etc/rmt.conf";
+    assert_script_run "sed -i '/scc/a\ \\ \\ password: $SCC_Password' /etc/rmt.conf";
+    assert_script_run "sed -i '/scc/a\ \\ \\ username: $SCC_User' /etc/rmt.conf";
+
+    # Start rmt server
+    systemctl 'start rmt';
+    systemctl 'status rmt';
+}
+
+sub rmt_mirror_repo {
+    my $repo_list = get_var('RMT_REPO') || 'sle-module-legacy/15/x86_64';
+    assert_script_run 'rmt-cli sync', 1800;
+    for my $repo (split(/,/, $repo_list)) {
+        assert_script_run "rmt-cli products enable $repo", 600;
+    }
+    assert_script_run 'rmt-cli mirror', 1800;
+    assert_script_run 'rmt-cli repo list';
+}
+
 
 sub test_flags {
     return {fatal => 1};

--- a/tests/console/rmt.pm
+++ b/tests/console/rmt.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Add rmt configuration test
+#    test installation and upgrade with rmt pattern, basic configuration via
+#    rmt-wizard and validation with rmt-cli repos rmt-cli scc sync return value
+# Maintainer: Jiawei Sun <jwsun@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use repo_tools;
+use version_utils;
+
+sub run {
+    select_console('root-console');
+
+    # No need to config rmt if the system upgraded from SLE12SPx with SMT
+    rmt_wizard unless (is_upgrade && (get_var('HDD_1', '') =~ /smt/));
+    # mirror and sync a base repo from SCC
+    rmt_mirror_repo();
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
Install RMT pattern for SLES15
Config RMT server with SCC account
Mirror repos from SCC (default is sle-module-legacy/15/x86_64)
Support Define mirrors by use parameter RMT_REPO
Supprt SMT to RMT migration

-See Poo#28552 & Poo#28693

- Related ticket: https://progress.opensuse.org/issues/28693
                           https://progress.opensuse.org/issues/28552
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/771
- Verification run: http://10.67.17.147/tests/2243#step/rmt/2
