### PR TITLE
Remove workaround that's not valid anymore

### DIFF
--- a/tests/caasp/first_boot.pm
+++ b/tests/caasp/first_boot.pm
@@ -46,18 +46,6 @@ sub run {
     # Restart network to push hostname to dns
     if (is_caasp('VMX') && get_var('STACK_ROLE')) {
         systemctl 'restart network', timeout => 60;
-        # Workaround for bsc#1062717 when admin node has no fqdn hostname
-        record_soft_failure 'bsc#1062717';
-        get_var('TEST') =~ /.*-(\w+)$/;
-        my $fake_hostname = $1;
-        script_run "hostnamectl set-hostname $fake_hostname.openqa.test";
-        if (check_var('STACK_ROLE', 'admin')) {
-            script_run "rm /etc/pki/ldap.crt /etc/pki/velum.crt";
-            systemctl 'restart admin-node-setup.service';
-            script_run "docker rm -f \$(docker ps -f \"name=k8s_velum-dashboard\" -q)";
-            script_run "docker rm -f \$(docker ps -f \"name=k8s_openldap_velum\" -q)";
-        }
-        # End of workaround
     }
 }
 


### PR DESCRIPTION
Fixing: https://openqa.suse.de/tests/1548215#step/stack_bootstrap/29
Local run: http://dhcp165.suse.cz/tests/2086