### PR TITLE
Fix the time out for install fully patch update

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -357,7 +357,7 @@ sub fill_in_registration_data {
                 wait_still_screen 2;
             }
             # start addons/modules registration, it needs longer time if select multiple or all addons/modules
-            my $counter = 30;
+            my $counter = 50;
             while ($counter--) {
                 assert_screen [
                     qw(import-untrusted-gpg-key yast_scc-pkgtoinstall yast-scc-emptypkg inst-addon contacting-registration-server refreshing-repository)];

--- a/tests/update/patch_before_migration.pm
+++ b/tests/update/patch_before_migration.pm
@@ -53,7 +53,7 @@ sub patching_sle {
     if (get_var('FULL_UPDATE')) {
         fully_patch_system();
         type_string "reboot\n";
-        $self->wait_boot(textmode => !is_desktop_installed(), ready_time => 600, bootloader_time => 200);
+        $self->wait_boot(textmode => !is_desktop_installed(), ready_time => 600, bootloader_time => 250);
 
         # Go back to the initial state, before the patching
         $self->setup_migration();


### PR DESCRIPTION
- Related ticket:  https://progress.opensuse.org/issues/31291
- Needles: None
- Verification run: Verify the fix on my own xp machine: log: http://10.67.19.184/tests/104#. 

It needs more time for the addons/modules registration, so I change the $counter from 30 to 50 to extend the time.
For the PPC resource limit, I can't verify it on PPC64, while from log we think the bootloader_time need to be more to wait the reboot done. So I change the bootloader_time to 250. 
