### PR TITLE
Make sure addons list is shown before checking

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -76,8 +76,8 @@ sub handle_all_packages_medium {
     my $counter = 2 + (scalar @addons_license_tags);
     my $addon_license_num = 0;
     while ($counter--) {
-        assert_screen([qw(addon-products sle-product-license-agreement)], 60);
-        last if (match_has_tag 'addon-products');
+        assert_screen([qw(addon-products-nonempty sle-product-license-agreement)], 60);
+        last if (match_has_tag 'addon-products-nonempty');
         if (match_has_tag 'sle-product-license-agreement') {
             if (@addons_license_tags && check_screen(\@addons_license_tags)) {
                 $addon_license_num++;
@@ -86,12 +86,12 @@ sub handle_all_packages_medium {
                 record_soft_failure 'bsc#1081647';
             }
             wait_screen_change { send_key 'alt-a' };
-            send_key 'alt-n';
+            wait_screen_change { send_key 'alt-n' };
         }
     }
     record_info "Error", "License agreement not shown for some addons", result => 'fail'
       if @addons_license_tags && ($addon_license_num != scalar @addons_license_tags);
-    assert_screen "addon-products";
+    assert_screen "addon-products-nonempty";
     # Confirm all required addons are properly added
     foreach (@addons) {
         send_key 'home';


### PR DESCRIPTION
Assert screen addon-products-nonempty to make sure
addons are shown before checking the addons.
Add wait_screen_change together with send_key 'alt-n'
to avoid asserting the same screenshot in next loop

Currently in addon_products_sle module (line 79), we assert_screen "addon-products" before checking the selected addons, but it actually matched an unexpected screen, for example: https://openqa.suse.de/tests/1541780#step/addon_products_sle/59

Seems it takes some time to show the addons list, we have to wait for a while before checking the addons with send_key_until_needlematch. Otherwise it will send key "down" too early if not match first addon within default timeout, and it leads to test failure in some cases.

- Related ticket: https://progress.opensuse.org/issues/32962
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/770
- Verification run: 
   * gnome+skip_registration@64bit-smp: http://openqa-apac1.suse.de/tests/487#step/addon_products_sle/54
   * media_upgrade_sles12sp3@64bit-smp: http://openqa-apac1.suse.de/tests/486#step/addon_products_sle/59
   * media_upgrade_sles12sp3+ha+geo+sdk+we@64bit-smp: http://openqa-apac1.suse.de/tests/485#step/addon_products_sle/96
