### PR TITLE
Fix CaaSP conformance test

### DIFF
--- a/tests/caasp/stack_conformance.pm
+++ b/tests/caasp/stack_conformance.pm
@@ -41,7 +41,7 @@ sub run {
     # Expect: SUCCESS! -- 123 Passed | 0 Failed | 0 Pending | 586 Skipped PASS
     script_run 'tar -xzf sonobuoy.tgz';
     upload_logs 'plugins/e2e/results/e2e.log';
-    assert_script_run "tail -2 plugins/e2e/results/e2e.log | tee /dev/tty | grep $sb_pass";
+    assert_script_run "tail -5 plugins/e2e/results/e2e.log | tee /dev/tty | grep $sb_pass";
 
     switch_to 'velum';
 }


### PR DESCRIPTION
Failed test: https://openqa.suse.de/tests/1549996#step/stack_conformance/106

New format:
```
...
...
Ran 125 of 782 Specs in 2750.896 seconds
SUCCESS! -- 125 Passed | 0 Failed | 0 Pending | 657 Skipped PASS

Ginkgo ran 1 suite in 45m51.50323749s
Test Suite Passed
```