### PR TITLE
Move change_password to the end to fix poo#33442

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1506,13 +1506,13 @@ sub load_x11_gnome {
     loadtest "x11/gnomecase/nautilus_permission";
     loadtest "x11/gnomecase/nautilus_open_ftp";
     loadtest "x11/gnomecase/application_starts_on_login";
-    loadtest "x11/gnomecase/change_password";
     loadtest "x11/gnomecase/login_test";
     if (is_sle '12-SP1+') {
         loadtest "x11/gnomecase/gnome_classic_switch";
     }
     loadtest "x11/gnomecase/gnome_default_applications";
     loadtest "x11/gnomecase/gnome_window_switcher";
+    loadtest "x11/gnomecase/change_password";
 }
 
 sub load_x11_other {


### PR DESCRIPTION
The change_password case seems not stable to run (perhaps by worker performance), and it blocks the subsequent cases' finishing, so we need to move it to the end of the execution queue to allow the following cases to run before it

- Related ticket: https://progress.opensuse.org/issues/33442
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/769
- Verification run: http://10.67.18.138/tests/64#