### PR TITLE
Assert screen before missing keys on lvm+raid1

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -148,18 +148,15 @@ sub set_lvm {
     type_string "root";
     assert_screen 'volume-name-root';
     send_key $cmd{next};
+    assert_screen('volume-name-root-max-size');
     send_key $cmd{next};
 
     assert_screen 'volume-pick-fs-role';
-    send_key "alt-o";    # Operating System
+    send_key "alt-o";
+    assert_screen('volume-pick-os-role');
     send_key $cmd{next};
-    if (is_storage_ng) {
-        assert_screen 'volume-mount-as-root';
-        send_key $cmd{next};
-    }
-
-    # keep default to mount as root and btrfs
-    wait_screen_change { send_key is_storage_ng() ? $cmd{next} : $cmd{finish}; };
+    assert_screen 'volume-mount-as-root';
+    send_key is_storage_ng() ? $cmd{next} : $cmd{finish};
 }
 
 sub modify_uefi_boot_partition {
@@ -472,7 +469,7 @@ sub run {
     # LVM on top of raid if needed
     if (get_var("LVM")) {
         set_lvm();
-        save_screenshot;
+        assert_screen('partitioning_raid-root_volume_created');
     }
 
     # done


### PR DESCRIPTION
- https://progress.opensuse.org/issues/33325
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/772
- Verification run:
  - aarch64 SLE12-SP3: [copland#990](http://copland.arch.suse.de/tests/990#step/partitioning_raid/198)
  - x86_64 SLE12-SP3: [copland#987](http://copland.arch.suse.de/tests/987#step/partitioning_raid/191)
  - aarch64 SLE12-SP4: [copland#986](http://copland.arch.suse.de/tests/986#step/partitioning_raid/198)
  - x86_64 SLE12-SP4: [copland#988](http://copland.arch.suse.de/tests/988#step/partitioning_raid/191)
  - aarch64 SLE15: [copland#993](http://copland.arch.suse.de/tests/993#step/partitioning_raid/202)
  - x86_64 SLE15: [copland#992](http://copland.arch.suse.de/tests/992#step/partitioning_raid/205)