### PR TITLE
SLE11 SP4 does not support "--force" with reboot

### DIFF
--- a/tests/migration/reboot_to_upgrade.pm
+++ b/tests/migration/reboot_to_upgrade.pm
@@ -29,7 +29,7 @@ sub run {
     # Reboot from Installer media for upgrade
     set_var('BOOT_HDD_IMAGE', 0) if get_var('UPGRADE') || get_var('AUTOUPGRADE');
     assert_script_run "sync", 300;
-    type_string "reboot --force\n";
+    type_string "reboot -f\n";
 }
 
 1;


### PR DESCRIPTION
Change "--force" to "-f",it will work on both SLE11 and SLE12

- Failed run: http://10.67.18.165/tests/60#step/version_switch_upgrade_target/1
- Verification run: http://10.67.18.165/tests/62#step/version_switch_upgrade_target/1
