### PR TITLE
Split testsuite desktopapps-firefox into two testsuites

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -361,17 +361,20 @@ logcurrentenv(
       SLE_PRODUCT SPLITUSR VIDEOMODE)
 );
 
-sub load_x11_firefox {
+sub load_x11_webbrowser_core {
     loadtest "x11/firefox/firefox_smoke";
-    loadtest "x11/firefox/firefox_localfiles";
     loadtest "x11/firefox/firefox_urlsprotocols";
     loadtest "x11/firefox/firefox_downloading";
-    loadtest "x11/firefox/firefox_headers";
-    loadtest "x11/firefox/firefox_pdf";
     loadtest "x11/firefox/firefox_changesaving";
     loadtest "x11/firefox/firefox_fullscreen";
-    loadtest "x11/firefox/firefox_health";
     loadtest "x11/firefox/firefox_flashplayer";
+}
+
+sub load_x11_webbrowser_extra {
+    loadtest "x11/firefox/firefox_localfiles";
+    loadtest "x11/firefox/firefox_headers";
+    loadtest "x11/firefox/firefox_pdf";
+    loadtest "x11/firefox/firefox_health";
     loadtest "x11/firefox/firefox_pagesaving";
     loadtest "x11/firefox/firefox_private";
     loadtest "x11/firefox/firefox_mhtml";
@@ -667,9 +670,21 @@ elsif (get_var('NFV')) {
 }
 elsif (get_var("REGRESSION")) {
     load_common_x11;
+    # Used by QAM testing
     if (check_var("REGRESSION", "firefox")) {
         loadtest "boot/boot_to_desktop";
-        load_x11_firefox();
+        load_x11_webbrowser_core();
+        load_x11_webbrowser_extra();
+    }
+    # Used by Desktop Applications Group
+    elsif (check_var("REGRESSION", "webbrowser_core")) {
+        loadtest "boot/boot_to_desktop";
+        load_x11_webbrowser_core();
+    }
+    # Used by Desktop Applications Group
+    elsif (check_var("REGRESSION", "webbrowser_extra")) {
+        loadtest "boot/boot_to_desktop";
+        load_x11_webbrowser_extra();
     }
     elsif (check_var("REGRESSION", "message")) {
         loadtest "boot/boot_to_desktop";


### PR DESCRIPTION
All the firefox cases are scheduled under one suite desktopapps-firefox
- which will take about 1.5 hours to run.
- all the remaining cases will be skipped if the first case failed due
  to the backend issue poo#29634

This commit will split the testsuite into two:
- desktopapps-webbrowser-core which contains the cases with high priority
- desktopapps-webbrowser-extra which contains the remaining cases
- sub firefox_check_default was also updated to fix poo#31048

---

- Related ticket: 
  https://progress.opensuse.org/issues/33349
  https://progress.opensuse.org/issues/31048
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/773
- Verification runs:

  + SLE15:
     http://10.67.17.30/tests/280
     http://10.67.17.30/tests/279

  + SLED12SP3:
     http://10.67.17.30/tests/283
     the passing of firefox_smoke could verify the affect on SLE12
