### PR TITLE
Only run dstat in certain conditions

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1363,7 +1363,8 @@ sub load_extra_tests {
         loadtest "console/unzip";
         loadtest "console/gpg";
         loadtest "console/shells";
-        loadtest "console/dstat";
+        # dstat is not in sle12sp1
+        loadtest "console/dstat" if is_sle('12-SP2+') || is_opensuse;
         # MyODBC-unixODBC not available on < SP2 and sle 15 and only in SDK
         if (sle_version_at_least('12-SP2') && !(sle_version_at_least('15'))) {
             loadtest "console/mysql_odbc" if check_var_array('ADDONS', 'sdk') || check_var_array('SCC_ADDONS', 'sdk');


### PR DESCRIPTION
dstat is not in sle12sp1.
We need >= sle12sp2 or openSUSE.

See bsc#1085238.
