### PR TITLE
Export complete supportconfig on CaaSP

### DIFF
--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -52,7 +52,7 @@ sub export_cluster_logs {
     script_run "journalctl > journal.log", 60;
     upload_logs "journal.log";
 
-    script_run 'supportconfig -i psuse_caasp -B supportconfig', 120;
+    script_run 'supportconfig -b -B supportconfig', 500;
     upload_logs '/var/log/nts_supportconfig.tbz';
 
     upload_logs('/var/log/transactional-update.log', failok => 1);

--- a/tests/caasp/stack_admin.pm
+++ b/tests/caasp/stack_admin.pm
@@ -73,12 +73,7 @@ sub run() {
 sub post_fail_hook {
     # Variable to enable failed cluster debug
     sleep if check_var('DEBUG_SLEEP', 'admin');
-
-    script_run "journalctl > journal.log";
-    upload_logs "journal.log";
-
-    script_run 'supportconfig -i psuse_caasp -B supportconfig', 120;
-    upload_logs '/var/log/nts_supportconfig.tbz';
+    export_cluster_logs;
 }
 
 1;


### PR DESCRIPTION
We are exporting only suse_caasp module now.
Export of complete supportconfig was requested by developers.