### PR TITLE
remove 2. parameter from send_key

### DIFF
--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -18,8 +18,7 @@ use utils;
 sub verify_default_keymap_textmode {
     my ($test_string, $tag, %tty) = @_;
 
-    # test keymap in login prompt of generally unused tty3 and typing test string wait 3 seconds
-    defined($tty{console}) ? select_console($tty{console}) : send_key('alt-f3', 3);
+    defined($tty{console}) ? select_console($tty{console}) : send_key('alt-f3');
     type_string($test_string);
     assert_screen($tag);
     # clear line in order to add user bernhard to tty group


### PR DESCRIPTION
- Related ticket: [[functional][fast][easy][y]remove second parameter to send_key](https://progress.opensuse.org/issues/33457)

