### PR TITLE
Adjust docker_image test to work for Leap as well

### DIFF
--- a/tests/console/docker_image.pm
+++ b/tests/console/docker_image.pm
@@ -14,30 +14,50 @@ use base 'consoletest';
 use testapi;
 use utils;
 use strict;
+use version_utils qw(is_leap is_tumbleweed);
 
 sub run {
     select_console 'root-console';
 
-    check_var('VERSION', 'Tumbleweed') || die 'Only have docker images for Tumbleweed';
+    my $version = get_required_var('VERSION');
 
-    my $rpm_name   = 'opensuse-tumbleweed-image';
-    my $image_name = 'opensuse/tumbleweed:current';
+    my $image_name;
+    my $image_path;
 
-    # Install the image
-    zypper_call "in docker $rpm_name";
+    if (is_tumbleweed) {
+        $image_name = 'opensuse/tumbleweed:current';
+        $image_path = '/usr/share/suse-docker-images/native/*-image*.tar.xz';
+
+        # For Tumbleweed, the image is wrapped inside an RPM
+        zypper_call "in docker opensuse-tumbleweed-image";
+    }
+    elsif (is_leap('15.0+')) {
+        $image_name = "opensuse-leap-$version:current";
+        $image_path = "/usr/share/suse-docker-images/native/opensuse-leap${version}-image.tar.xz";
+
+        # For Leap, the docker image is the ISO asset
+        my $image_filename = get_required_var('ISO');
+        $image_filename =~ s/^.*\///;
+        my $image_url = autoinst_url("/assets/other/$image_filename");
+        assert_script_run "curl $image_url --create-dirs -o $image_path";
+    }
+    else {
+        die 'Only know about Tumbleweed and Leap 15.0+ docker images';
+    }
+
     # Start the docker daemon, normally done by previous test modules already
     systemctl 'start docker';
     systemctl 'status docker';
     assert_script_run 'docker info';
 
     # Load the image
-    assert_script_run 'docker load -i /usr/share/suse-docker-images/native/*-image*.tar.xz';
+    assert_script_run "docker load -i $image_path";
     # Show that the image got registered
     assert_script_run "docker images $image_name";
     # Running executables works
     assert_script_run qq{docker container run --rm $image_name echo "I work" | grep "I work"};
-    # It is openSUSE Tumbleweed
-    assert_script_run qq{docker container run --rm $image_name cat /etc/os-release | grep 'PRETTY_NAME="openSUSE Tumbleweed"'};
+    # It is the correct openSUSE version
+    validate_script_output qq{docker container run --rm $image_name cat /etc/os-release}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}( .*)?"/ };
     # Zypper and network are working
     assert_script_run qq{docker container run --rm $image_name zypper -v ref | grep "All repositories have been refreshed"};
 
@@ -50,7 +70,6 @@ EOF
 
     # Remove the image again to save space
     assert_script_run "docker image rm --force $image_name";
-    zypper_call "rm $rpm_name";
 }
 
 1;


### PR DESCRIPTION
For Leap, the docker image is tested differently. The docker image is
tested by using the image itself as the media to be tested.
A preexisting HDD is booted and used to run the docker image, which is
downloaded from the worker manually.

Verification runs: http://10.160.67.86/tests/45 (Leap 15.0)
http://10.160.67.86/tests/46 (TW)