### PR TITLE
Increase timeout for gpg --list-keys

### DIFF
--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -70,7 +70,7 @@ sub gpg_generate_key {
     }
     else {
         # list gpg keys
-        validate_script_output("gpg --list-keys", sub { m/\[ultimate\] $user_name \<$email\>/ });
+        validate_script_output("gpg --list-keys", sub { m/\[ultimate\] $user_name \<$email\>/ }, 90);
     }
 }
 


### PR DESCRIPTION
Fix poo#33100: gpg --list-keys can timeout on slower openQA workers.
Timeout was changed from default value 30 to 90.

- Related ticket: https://progress.opensuse.org/issues/33100
- Needles: None
- Verification run: http://10.100.12.105/tests/1073#step/gpg/28
