### PR TITLE
partitioning_raid: Adjust prep partitioning size to recent YaST requirements

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -277,8 +277,8 @@ sub add_prep_boot_partition {
         wait_screen_change { send_key $cmd{size_hotkey} };
     }
     wait_screen_change { send_key 'ctrl-a' };    # Select text field content
-    type_string "200 MB";
-    assert_screen 'partitioning_raid-custom-size-200MB';
+    type_string "8 MB";
+    assert_screen 'partitioning_raid-custom-size-8MB';
     send_key 'alt-n';
     assert_screen 'partition-role';
     send_key "alt-a";


### PR DESCRIPTION
Will change the prep partition size as shown in
https://openqa.suse.de/tests/1555276#step/partitioning_raid/11 , should
prevent the warning as shown in
https://openqa.suse.de/tests/1555276#step/partitioning_raid/225
apparently introduced in recent SLE15 builds.

I did not test this on ppc64le. The prep partition size was never adapted
since ppc64le tests were introduced with 7d412a36 in 2015 so I assume we
should also be fine for other products.