### PR TITLE
Display merged kubeconfig settings

### DIFF
--- a/tests/caasp/stack_kubernetes.pm
+++ b/tests/caasp/stack_kubernetes.pm
@@ -22,6 +22,7 @@ sub run {
     switch_to 'xterm';
     assert_script_run "kubectl cluster-info";
     assert_script_run "kubectl cluster-info > cluster.before_update";
+    assert_script_run "kubectl config view | tee /dev/$serialdev";
     assert_script_run "kubectl get nodes";
     assert_script_run "! kubectl get cs --no-headers | grep -v Healthy";
 


### PR DESCRIPTION
I discussed it with the *docker* team and we both concluded that it would be a good addition to have the output of this command. I don't consider it as *logfile* so I would prefer to collect it via the *devconsole*.

- Related ticket: *not needed -- too small of an enhancement*
- Needles: *not needed*
- Verification run: http://skyrim.qam.suse.de/tests/2581#step/stack_kubernetes/7