### PR TITLE
Workaround bsc#1084997: remove package libburnia-tools failed

### DIFF
--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -118,10 +118,11 @@ sub run {
         }
         # can happen multiple times
         if (match_has_tag('ERROR-removing-package')) {
-            record_soft_failure;
             send_key 'alt-d';    # details
             assert_screen 'ERROR-removing-package-details';
             send_key 'alt-i';    # ignore
+            assert_screen 'WARNING-ignoring-package-failure';
+            send_key 'alt-o';    # ok
             next;
         }
         if (get_var('LIVECD') and match_has_tag('screenlock')) {


### PR DESCRIPTION
Nearly all migration (SLE 12 -> 15) tests failed due to known issue bsc#1084997, we have to workaround the problem since it takes some time to fix the issue in maintenance circle.

Remove record_soft_failure without a reason, the needle for
ERROR-removing-package should be created package specific
and labeled as workaround.
Assert screen WARNING-ignoring-package-failure and send ok

- Related ticket: https://progress.opensuse.org/issues/33487
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/775
- Verification run:
   * media_upgrade_sles12sp3@64bit-smp: http://openqa-apac1.suse.de/tests/493#step/await_install/4
