### PR TITLE
Make Tumbleweed needles available to the TumbleweedTest flavor

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -145,7 +145,7 @@ sub is_caasp {
 sub is_tumbleweed {
     # Tumbleweed and its stagings
     return 0 unless check_var('DISTRI', 'opensuse');
-    return 1 if check_var('VERSION', 'Tumbleweed');
+    return 1 if get_var('VERSION') =~ /Tumbleweed/;
     return get_var('VERSION') =~ /^Staging:/;
 }
 


### PR DESCRIPTION
This can help with failures like
https://openqa.opensuse.org/tests/637683#step/bootloader/3 where
VERSION=TumbleweedTest and therefore the normal needles which we need here are
unregistered.