### PR TITLE
Fix is_pre_15 helper function

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -251,5 +251,5 @@ sub is_system_upgrading {
 }
 
 sub is_pre_15 {
-    return (is_sle('<15')) || is_leap('<15.0') || !is_tumbleweed;
+    return (is_sle('<15') || is_leap('<15.0')) && !is_tumbleweed;
 }


### PR DESCRIPTION
Function returns true for all distris except TW, so fixing condition
there. Fixes apparmor test.

- Related ticket: [poo#30027](https://progress.opensuse.org/issues/30027)
- [Verification run](http://g226.suse.de/tests/956)
