### PR TITLE
Fix lvm and RAID tests shortcuts for new installation flow on leap

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -32,11 +32,11 @@ sub run {
         $cmd{exp_part_finish} = 'alt-n';
         $cmd{guidedsetup}     = 'alt-g';
         if (check_var('DISTRI', 'opensuse')) {
-            $cmd{expertpartitioner} = 'alt-x';
-            $cmd{rescandevices}     = 'alt-c';
             #TODO remove SYSTEM_ROLE_FIRST_FLOW usages with versions checks
-            $cmd{enablelvm}   = get_var('SYSTEM_ROLE_FIRST_FLOW') ? 'alt-e' : 'alt-a';
-            $cmd{encryptdisk} = get_var('SYSTEM_ROLE_FIRST_FLOW') ? 'alt-a' : 'alt-l';
+            $cmd{expertpartitioner} = get_var('SYSTEM_ROLE_FIRST_FLOW') ? 'alt-e' : 'alt-x';
+            $cmd{rescandevices}     = get_var('SYSTEM_ROLE_FIRST_FLOW') ? 'alt-e' : 'alt-c';
+            $cmd{enablelvm}         = get_var('SYSTEM_ROLE_FIRST_FLOW') ? 'alt-e' : 'alt-a';
+            $cmd{encryptdisk}       = get_var('SYSTEM_ROLE_FIRST_FLOW') ? 'alt-a' : 'alt-l';
         }
     }
 

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -34,8 +34,9 @@ sub run {
         if (check_var('DISTRI', 'opensuse')) {
             $cmd{expertpartitioner} = 'alt-x';
             $cmd{rescandevices}     = 'alt-c';
-            $cmd{enablelvm}         = 'alt-a';
-            $cmd{encryptdisk}       = 'alt-l';
+            #TODO remove SYSTEM_ROLE_FIRST_FLOW usages with versions checks
+            $cmd{enablelvm}   = get_var('SYSTEM_ROLE_FIRST_FLOW') ? 'alt-e' : 'alt-a';
+            $cmd{encryptdisk} = get_var('SYSTEM_ROLE_FIRST_FLOW') ? 'alt-a' : 'alt-l';
         }
     }
 


### PR DESCRIPTION
We will have slightly different flow in installer for openSUSE soon, and
some shortcuts are different ATM, so fix it to pass the staging and not
to break existing tests.

- Needles: [PR#338](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/338)
- Verification runs:
   * [crypt_lvm](http://g226.suse.de/tests/963#)
   * [RAID1](http://g226.suse.de/tests/978#)
