### PR TITLE
Replace rhythmbox by gnome-music in SLE15 to fix tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1105,7 +1105,7 @@ sub load_x11tests {
         # TODO test on openSUSE https://progress.opensuse.org/issues/31972
         if (is_sle && (!is_server || we_is_applicable)) {
             loadtest "x11/eog";
-            loadtest "x11/rhythmbox";
+            loadtest(is_sle('<15') ? "x11/rhythmbox" : "x11/gnome_music");
             loadtest "x11/wireshark";
             loadtest "x11/ImageMagick";
             loadtest "x11/ghostscript";

--- a/tests/x11/gnome_music.pm
+++ b/tests/x11/gnome_music.pm
@@ -17,7 +17,8 @@ use testapi;
 use utils;
 
 sub run {
-    assert_gui_app('gnome-music');
+    assert_gui_app('gnome-music', install => 1);
+    send_key('alt-f4');
 }
 
 1;


### PR DESCRIPTION
Rhythmbox has been replaced in WE module for sle15 by gnome-music. Gnome-music is not installed by default, therefore we have to ensure proper deployment of this package.

- Related ticket: [[sles][functional][medium] test fails in rhythmbox: according to bsc#1078704, rhythmbox was dropped and replaced by gnome-music - test adaptation?](https://progress.opensuse.org/issues/31540)
- Needles: [Gnome-music screen for sles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/778)
- Verification run: [sle-15-Installer-DVD-x86_64-Build514.1-we-module@64bit-virtio-vga](http://dhcp228.suse.cz/tests/1139#step/gnome_music/18)
