### PR TITLE
Fix HA cluster check with 3+ nodes

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -210,24 +210,18 @@ sub ha_export_logs {
     my @y2logs;
 
     # Extract HA logs and upload them
-    select_console 'root-console';
     script_run "touch $corosync_conf";
     script_run "hb_report $report_opt -E $bootstrap_log $hb_log", 120;
     upload_logs "$bootstrap_log";
     upload_logs "$hb_log.tar.bz2";
 
     # Extract YaST logs and upload them
-    script_run "save_y2logs", 120;
+    script_run 'save_y2logs /tmp/y2logs.tar.bz2', 120;
+    upload_logs '/tmp/y2logs.tar.bz2';
 
     # Generate the packages list
     script_run "rpm -qa > $packages_list";
     upload_logs "$packages_list";
-
-    # We can find multiple y2log files
-    push @y2logs, script_output 'ls /tmp/y2log-*.tar.xz';
-    foreach my $y2log (@y2logs) {
-        upload_logs "$y2log";
-    }
 }
 
 sub check_cluster_state {
@@ -284,7 +278,7 @@ sub post_run_hook {
 }
 
 sub post_fail_hook {
-    my $self = shift;
+    my ($self) = @_;
 
     # Save a screenshot before trying further measures which might fail
     save_screenshot;

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -123,13 +123,13 @@ sub investigate_yast2_failure {
 
     # first check if badlist exists which could be the most likely problem
     if (my $badlist = script_output 'test -f /var/log/YaST2/badlist && cat /var/log/YaST2/badlist | tail -n 20 || true') {
-        record_info 'Likely error detected: badlist', "badlist content:\n\n$badlist", 'fail';
+        record_info 'Likely error detected: badlist', "badlist content:\n\n$badlist", result => 'fail';
     }
     if (my $y2log_internal_error = script_output 'grep -B 3 \'Internal error. Please report a bug report\' /var/log/YaST2/y2log | tail -n 20 || true') {
-        record_info 'Internal error in YaST2 detected', "Details:\n\n$y2log_internal_error", 'fail';
+        record_info 'Internal error in YaST2 detected', "Details:\n\n$y2log_internal_error", result => 'fail';
     }
     elsif (my $y2log_other_error = script_output 'grep -B 3 \'<3>\' /var/log/YaST2/y2log | tail -n 20 || true') {
-        record_info 'Other error in YaST2 detected', "Details:\n\n$y2log_other_error", 'fail';
+        record_info 'Other error in YaST2 detected', "Details:\n\n$y2log_other_error", result => 'fail';
     }
 }
 

--- a/tests/ha/check_after_fencing.pm
+++ b/tests/ha/check_after_fencing.pm
@@ -23,8 +23,7 @@ sub run {
     barrier_wait("CHECK_AFTER_FENCING_BEGIN_$cluster_name");
 
     # We need to be sure to be root and, after fencing, the default console on node01 is not root
-    # As we do a 'reset_consoles' on all other nodes, we can do 'select_console' on all to
-    select_console 'root-console';
+    select_console 'root-console' if is_node(1);
 
     # Wait for the cluster to be up on the fenced node
     # We can execute this test on all nodes, so do it as it's easier to code :-)

--- a/tests/ha/fencing.pm
+++ b/tests/ha/fencing.pm
@@ -24,21 +24,12 @@ sub run {
     check_cluster_state;
     barrier_wait("CHECK_BEFORE_FENCING_END_$cluster_name");
 
-    # 'barrier_wait' needs to be done separately to ensure that
-    # 'reset_consoles' as been done on all nodes before fencing
-    if (is_node(2)) {
-        barrier_wait("BEFORE_FENCING_$cluster_name");
+    # Reset consoles on all nodes and wait for nodes to be synchronised
+    reset_consoles;
+    barrier_wait("BEFORE_FENCING_$cluster_name");
 
-        # Fence the node
-        assert_script_run 'crm -F node fence ' . get_node_to_join;
-
-        # Wait a little to be sure that fence command is on his way
-        sleep 60;
-    }
-    else {
-        reset_consoles;
-        barrier_wait("BEFORE_FENCING_$cluster_name");
-    }
+    # Fence the master node
+    assert_script_run 'crm -F node fence ' . get_node_to_join if is_node(2);
 }
 
 1;


### PR DESCRIPTION
3+ nodes HA clusters need some modification to be able to work:
- fix a script_run call timeout that sometimes happen (see this [issue](http://1b147.qa.suse.de/tests/16#step/check_logs/4))
- choose the right console
- reset console on 2nd node after fencing

Verification runs: [node01](http://1b147.qa.suse.de/tests/87), [node02](http://1b147.qa.suse.de/tests/86), [node03](http://1b147.qa.suse.de/tests/81)

EDIT: new verification runs:
- 2-nodes cluster: [node01](http://1b147.qa.suse.de/tests/460) and [node02](http://1b147.qa.suse.de/tests/459)
- 3-nodes cluster: [node01](http://1b147.qa.suse.de/tests/468), [node02](http://1b147.qa.suse.de/tests/467) and [node03](http://1b147.qa.suse.de/tests/462)