### PR TITLE
Set tty correctly

### DIFF
--- a/tests/migration/post_upgrade.pm
+++ b/tests/migration/post_upgrade.pm
@@ -24,7 +24,7 @@ sub run {
     set_var('HDDVERSION', get_var('UPGRADE_TARGET_VERSION', get_var('VERSION')));
 
     # On SLE15, tty7 is reserved for gdm, tty2 is the first user x11 console
-    console('x11')->{args}->{tty} = get_x11_console_tty;
+    console('x11')->set_tty(get_x11_console_tty);
 }
 
 1;

--- a/tests/x11/start_wayland_plasma5.pm
+++ b/tests/x11/start_wayland_plasma5.pm
@@ -42,7 +42,7 @@ sub run {
     assert_screen 'generic-desktop', 60;
 
     # We're now in a wayland session, which is in a different VT
-    console('x11')->{args}->{tty} = 3;
+    console('x11')->set_tty(3);
 
     # Workaround (part 2): KWin does not work with the workaround so we need to undo it
     # to allow relogins to succeed


### PR DESCRIPTION
* The previous attempts should not have been working because only the proxy object was modified. Apparently the setting wasn't actually used.
* Related ticket: https://progress.opensuse.org/issues/25702
* Requires test API introduced with https://github.com/os-autoinst/os-autoinst/pull/933