### PR TITLE
Implement system role selection without shortcut usage

### DIFF
--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -14,6 +14,7 @@
 use strict;
 use base "y2logsstep";
 use testapi;
+use version_utils 'is_sle';
 
 
 my %role_hotkey = (
@@ -26,8 +27,22 @@ my %role_hotkey = (
 
 sub change_system_role {
     my ($system_role) = @_;
-    send_key 'alt-' . $role_hotkey{$system_role};
-    assert_screen "system-role-$system_role-selected";
+    # Since SLE 15 we do not have shortcuts for system roles anymore
+    if (is_sle '15+') {
+        if (check_var('VIDEOMODE', 'text')) {
+            # Expect that no actions are done before and default system role is preselected
+            send_key_until_needlematch "system-role-$system_role-focused",  'down';    # select role
+            send_key_until_needlematch "system-role-$system_role-selected", 'spc';     # enable role
+        }
+        else {
+            assert_and_click "system-role-$system_role";
+            assert_screen "system-role-$system_role-selected";
+        }
+    }
+    else {
+        send_key 'alt-' . $role_hotkey{$system_role};
+        assert_screen "system-role-$system_role-selected";
+    }
     # every system role other than default will end up in textmode
     set_var('DESKTOP', 'textmode');
 }


### PR DESCRIPTION
As a result of [bsc#1084674](https://bugzilla.suse.com/show_bug.cgi?id=1084674),
now we cannot use shortkeys to select system role.
Hence, click in case of x11 installation and using navigation keys for ncurses.

See [poo#33562](https://progress.opensuse.org/issues/33562).

- [Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/779)
- Verification runs:
  * [ncurses non default role](http://g226.suse.de/tests/1000) Note: this is just to prove code works, I was not able to find any scenario where it's required on production, so some needles may be missing
  * [textmode+role_textmode](http://g226.suse.de/tests/995)
  * [textmode+xen_server_role](http://g226.suse.de/tests/996)
  * [textmode+kvm_server_role](http://g226.suse.de/tests/993)
  * [minimal+role_minimal](http://g226.suse.de/tests/992)
