### PR TITLE
install_package: handle conflict between python{,3}-talloc-devel

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -163,6 +163,8 @@ sub problem_can_be_skipped {
     # conflict with mvapich2 packages
     return 1 if $pkg =~ /^mvapich2-psm(2)?/;
     return 1 if $pkg =~ /^mvapich2-testsuite/;
+    # conflict with python3-talloc-devel
+    return 1 if $pkg =~ /^python-talloc-devel/;
 
     return;
 }


### PR DESCRIPTION
`install_package`: handle conflict between `python{,3}-talloc-devel`

Fixes:
https://openqa.opensuse.org/tests/639470#step/install_packages/9
https://openqa.opensuse.org/tests/639468#step/install_packages/9
https://openqa.opensuse.org/tests/639469#step/install_packages/9

Test maintainer @coolo 

Verification: 

```
data/lsmfip python3-talloc-devel python-talloc-devel
INSTALL python-talloc-devel-2.1.10-2.3.1.x86_64
INSTALL python3-talloc-devel-2.1.10-2.3.1.x86_64
++ skipping python-talloc-devel-2.1.10-2.3.1.x86_64 and retry
INSTALL python3-talloc-devel-2.1.10-2.3.1.x86_64
python3-talloc-devel
not installing python-talloc-devel
```