### PR TITLE
Increase download timeout to 10 minutes

### DIFF
--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -61,9 +61,9 @@ sub run {
     assert_script_run("docker image pull hello-world", timeout => 300);
     #   - pull image of last released version of openSUSE Leap
     my $last_released_leap_version = '42.3';
-    assert_script_run("docker image pull opensuse:$last_released_leap_version", timeout => 300);
+    assert_script_run("docker image pull opensuse:$last_released_leap_version", timeout => 600);
     #   - pull image of openSUSE Tumbleweed
-    assert_script_run('docker image pull opensuse/tumbleweed', timeout => 300);
+    assert_script_run('docker image pull opensuse/tumbleweed', timeout => 600);
 
     # local images can be listed
     #   - BUG https://github.com/docker/for-linux/issues/220


### PR DESCRIPTION
- Related failing test: https://openqa.suse.de/tests/1562134#step/docker/20
- Verification run: http://copland.arch.suse.de/tests/1013