### PR TITLE
Remove soft-fail (empty list) for Docker

### DIFF
--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -66,9 +66,7 @@ sub run {
     assert_script_run('docker image pull opensuse/tumbleweed', timeout => 300);
 
     # local images can be listed
-    #   - BUG https://github.com/docker/for-linux/issues/220
     assert_script_run('docker image ls none');
-    record_soft_failure('https://github.com/docker/for-linux/issues/220');
     #   - filter with tag
     assert_script_run(qq{docker image ls alpine:$alpine_image_version | grep "alpine\\s*$alpine_image_version"});
     #   - filter without tag


### PR DESCRIPTION
After discussion with upstream [1] this is not considered to be
a bug for Docker.

[1] https://github.com/docker/for-linux/issues/220

- Related ticket: -
- Needles: -
- Verification run: -
