### PR TITLE
Update maintainer information for ImageMagick test

### DIFF
--- a/tests/x11/ImageMagick.pm
+++ b/tests/x11/ImageMagick.pm
@@ -20,7 +20,7 @@
 #    others are drawn from scratch. The preloaded script contains all
 #    the executed commands because typing them appeared to be extremely
 #    time-consuming.
-# Maintainer: Romanos Dodopoulos <romanos.dodopoulos@suse.cz>
+# Maintainer: Veronika Svecova <vsvecova@suse.cz>
 
 use base "opensusebasetest";
 use strict;


### PR DESCRIPTION
This is to remove Romanos Dodopoulos as mainainer of ImageMagick.pm and substitute for Veronika Svecova, due to the fact that @rwmanos no longer works at SUSE.

I skipped the verification run as the code itself has not been touched; only the comment line with maintainer information has been edited.