### PR TITLE
Fix parsing of product EOL value (bsc#1057788)

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -106,7 +106,7 @@ sub run {
 
     my $product_eol;
     for my $l (split /\n/, $overview) {
-        if ($l =~ /$product_name\s*(\S*)/) {
+        if ($l =~ /(?<!Codestream:)\s+$product_name\s*(\S*)/) {
             $product_eol = $1;
             last;
         }
@@ -117,7 +117,6 @@ sub run {
     # verify that package eol defaults to product eol
     $output = script_output "zypper lifecycle $package", 300;
     unless ($output =~ /$package(-\S+)?\s+$product_eol/) {
-        return record_soft_failure 'bsc#1057788' if is_sle('15+');
         die "$package lifecycle entry incorrect:'$output', expected: '/$package-\\S+\\s+$product_eol'";
     }
 


### PR DESCRIPTION
For "SP0" of each product the output of `zypper lifecycle` is ambiguous. We
have to ensure that actually the second line of codestream+product output is
parsed which includes the EOL of the service pack.

Also removes soft-fail for fixed
https://bugzilla.suse.com/show_bug.cgi?id=1057788

Verification run: http://lord.arch/tests/657