### PR TITLE
Fix kernel_kexec not waiting for the login-prompt ending up in wrong tty

### DIFF
--- a/tests/qa_automation/kernel_kexec.pm
+++ b/tests/qa_automation/kernel_kexec.pm
@@ -47,7 +47,8 @@ sub run {
     script_run("systemctl kexec", 0);
     # wait for reboot
     reset_consoles();
-    select_console("root-console");
+    assert_screen('linux-login', 300);
+    select_console('root-console');
     # Check kernel cmdline parameter
     my $result = script_output("cat /proc/cmdline", 120);
     print "Checking kernel boot parameter...\nCurrent:  $result\nExpected: $cmdline\n";


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/33307

Verification run: http://lord.arch/tests/659