### PR TITLE
Update handle_login to workaround bsc#1086425

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -824,7 +824,6 @@ sub random_string {
 
 sub handle_login {
     assert_screen 'displaymanager';    # wait for DM, then try to login
-    mouse_hide();
     wait_still_screen;
     if (get_var('ROOTONLY')) {
         if (check_screen 'displaymanager-username-notlisted', 10) {
@@ -840,8 +839,14 @@ sub handle_login {
     elsif (check_var('DESKTOP', 'gnome')) {
         # DMs in condition above have to select user
         if (is_sle('15+') || is_leap('15.0+') || is_tumbleweed) {
-            assert_and_click "displaymanager-$username";
-            record_soft_failure 'bgo#657996 - user account not selected by default, have to use mouse to login';
+            assert_screen [qw(displaymanager-user-selected displaymanager-user-notselected)];
+            if (match_has_tag('displaymanager-user-notselected')) {
+                assert_and_click "displaymanager-$username";
+                record_soft_failure 'bsc#1086425- user account not selected by default, have to use mouse to login';
+            }
+            elsif (match_has_tag('displaymanager-user-selected')) {
+                send_key 'ret';
+            }
         }
         else {
             send_key 'ret';


### PR DESCRIPTION
The default user of gdm will be selected for the scenario of reboot or first boot, we can just press enter to login. But for the scenario of log out and re-login we have to use assert_and_click to work around
[bsc#1086425](https://bugzilla.suse.com/show_bug.cgi?id=1086425#add_comment).

- Use a SUSE bug id instead
- Use mouse to assert_and_click, record soft failure when the keyboard focus of gdm user is lost
- Drop mouse_hide since it will lost the keyboard focus even in the scenario of reboot

---

- Related ticket: https://progress.opensuse.org/issues/33484
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/783
- Verification run: http://10.67.17.30/tests/327

    + Soft failure was recorded in the scenario of log out and re-login:
       http://10.67.17.30/tests/327#step/test_handle_login/9
    
    + Just press enter to login in the scenario of reboot:
       http://10.67.17.30/tests/327#step/test_handle_login/19
