### PR TITLE
Adjust PReP partition size as per recommendations

### DIFF
--- a/tests/installation/partitioning_full_lvm.pm
+++ b/tests/installation/partitioning_full_lvm.pm
@@ -23,7 +23,7 @@ use version_utils 'is_storage_ng';
 sub run {
     create_new_partition_table;
     if (get_var('OFW')) {    # ppc64le always needs PReP boot
-        addpart(role => 'raw', size => 500, fsid => 'PReP');
+        addpart(role => 'raw', size => 8, fsid => 'PReP');
     }
     elsif (get_var('UEFI')) {    # UEFI needs partition mounted to /boot/efi for
         addpart(role => 'efi', size => 256);


### PR DESCRIPTION
In sle 15 now there is a check for recommended size of PReP boot
partition, which should be between 2 and 8 MiB. Adjust test accordingly
and update ticket for partitioning_warnings to verify this case too.

See [poo#33475](https://progress.opensuse.org/issues/33475).

No verification run possible due to incompatible workers problem.
