### PR TITLE
Move testsuite for NVMe Over Fabrics to main_ltp.pm

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -53,7 +53,6 @@ our @EXPORT = qw(
   load_slepos_tests
   load_docker_tests
   load_sles4sap_tests
-  load_nvmftests
   installzdupstep_is_applicable
   snapper_is_applicable
   chromestep_is_applicable
@@ -210,7 +209,8 @@ sub is_kernel_test {
           || get_var('INSTALL_KOTD')
           || get_var('QA_TEST_KLP_REPO')
           || get_var('INSTALL_KOTD')
-          || get_var('VIRTIO_CONSOLE_TEST'));
+          || get_var('VIRTIO_CONSOLE_TEST')
+          || get_var('NVMFTESTS'));
 }
 
 # Isolate the loading of LTP tests because they often rely on newer features
@@ -1705,17 +1705,11 @@ sub load_toolchain_tests {
     loadtest "console/kdump_and_crash" if is_sle && kdump_is_applicable;
 }
 
-sub load_nvmftests {
-    return unless consolestep_is_applicable();
-    loadtest "kernel/nvmftests";
-}
-
 sub load_common_opensuse_sle_tests {
     load_autoyast_clone_tests           if get_var("CLONE_SYSTEM");
     load_create_hdd_tests               if get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1");
     load_toolchain_tests                if get_var("TCM") || check_var("ADDONS", "tcm");
     loadtest 'console/network_hostname' if get_var('NETWORK_CONFIGURATION');
-    load_nvmftests                      if get_var('NVMFTESTS');
 }
 
 sub load_ssh_key_import_tests {

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -22,7 +22,7 @@ use autotest;
 use utils;
 use LTP::TestInfo qw(testinfo);
 use File::Basename 'basename';
-use main_common 'load_bootloader_s390x';
+use main_common qw(load_bootloader_s390x boot_hdd_image);
 use 5.018;
 
 our @EXPORT = 'load_kernel_tests';
@@ -139,6 +139,10 @@ sub load_kernel_tests {
     }
     elsif (get_var('VIRTIO_CONSOLE_TEST')) {
         loadtest 'virtio_console';
+    }
+    elsif (get_var('NVMFTESTS')) {
+        boot_hdd_image;
+        loadtest 'nvmftests';
     }
 
     if (check_var('BACKEND', 'svirt') && get_var('PUBLISH_HDD_1')) {


### PR DESCRIPTION
The nvmftests are a kernel testsuite. And while they don't belong to
LTP, the name "LTP" is used as synonym for kernel tests here.

- Verification run: http://10.160.67.206/tests/319

Signed-off-by: Michael Moese <mmoese@suse.de>
