### PR TITLE
Wait while tty is ready to accept test string

### DIFF
--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -18,7 +18,14 @@ use utils;
 sub verify_default_keymap_textmode {
     my ($test_string, $tag, %tty) = @_;
 
-    defined($tty{console}) ? select_console($tty{console}) : send_key('alt-f3');
+    if (defined($tty{console})) {
+        select_console($tty{console});
+    }
+    else {
+        send_key('alt-f3');
+        wait_still_screen;
+    }
+
     type_string($test_string);
     assert_screen($tag);
     # clear line in order to add user bernhard to tty group


### PR DESCRIPTION
Test string has been typed before tty3 was fully activated. This led to mistyping of test string in login prompt test case. Issue has not been reproduced in local runs anymore. OpenQA console functions has not been modified due to high risk of affecting other unrelated test suites.

- Related ticket: [[sle][functional][easy] fix keyboard layout switching tests](https://progress.opensuse.org/issues/33151)
- Verification run: [for sle-15-Installer-DVD-aarch64-Build530.1-default@aarch64](http://dhcp228.suse.cz/tests/1173)
