### PR TITLE
Fix uninitialized value error

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -49,7 +49,7 @@ sub save_and_upload_stage_logs {
 
 sub save_and_upload_yastlogs {
     my ($self, $suffix) = @_;
-    my $name = $stage . $suffix;
+    my $name = $stage . ($suffix // '');
     # save logs and continue
     select_console 'install-shell';
 


### PR DESCRIPTION
Fix for: https://openqa.suse.de/tests/1566993/file/autoinst-log.txt

Function is called from post_fail_hook by `$self->save_and_upload_yastlogs;` which produces
```
Use of uninitialized value $suffix in concatenation (.) or string at
/var/lib/openqa/cache/tests/caasp/tests/autoyast/installation.pm line 52.
```