### PR TITLE
Check services sapconf, uuidd.socket, sysstat

### DIFF
--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -84,8 +84,7 @@ sub run_developers_tests {
 }
 
 sub verify_sapconf_service {
-    my $svc  = shift;
-    my $desc = shift;
+    my ($svc, $desc) = @_;
 
     my $output      = script_output "systemctl status $svc";
     my $statusregex = $svc . ' - ' . $desc . '.+' . 'Loaded: loaded \(/usr/lib/systemd/system/' . $svc . ';.+';


### PR DESCRIPTION
As requested in fate#325363, add additional checks for the services sapconf.service, uuidd.socket and sysstat.service in tests/sles4sap/sacponf.

- Related ticket: https://fate.suse.com/325363
- Needles: N/A
- Verification run: http://mango.suse.de/tests/296 (SLES4SAP 15RC2 gnome), http://mango.suse.de/tests/295 (SLES4SAP 15RC2 textmode), http://mango.suse.de/tests/297 (SLES4SAP 12SP3)
