### PR TITLE
Verify VLC startup command

### DIFF
--- a/tests/x11/vlc.pm
+++ b/tests/x11/vlc.pm
@@ -22,7 +22,7 @@ use testapi;
 
 sub run {
     ensure_installed('vlc');
-    x11_start_program('vlc --no-autoscale', target_match => 'vlc-first-time-wizard');
+    x11_start_program('vlc --no-autoscale', target_match => 'vlc-first-time-wizard', match_typed => 'target_match_vlc');
     send_key "ret";
     assert_screen "vlc-main-window";
     send_key "ctrl-l";


### PR DESCRIPTION
Set the match target setting to ensure that vlc is not started too early

- Related ticket: https://progress.opensuse.org/issues/31687
- Verification run: http://pinky.arch.suse.de/tests/938
- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4670
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/341