### PR TITLE
Replace wait_still_screen by linux-login needle

### DIFF
--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -23,7 +23,7 @@ sub verify_default_keymap_textmode {
     }
     else {
         send_key('alt-f3');
-        wait_still_screen;
+        assert_screen("linux-login");
     }
 
     type_string($test_string);


### PR DESCRIPTION
Test string has been typed before tty3 was fully activated. This led to mistyping of test string in login prompt test case. Issue has not been reproduced in local runs anymore. OpenQA console functions has not been modified due to high risk of affecting other unrelated test suites.


- Related ticket: [[sle][functional][easy] fix keyboard layout switching tests](https://progress.opensuse.org/issues/33151)
- Verification run: [sle-15-Installer-DVD-aarch64-Build530.1-default@aarch64](http://dhcp228.suse.cz/tests/1194#step/keymap_or_locale/3)
