### PR TITLE
Autoupgrade to SLE15 from SCC and SMT

### DIFF
--- a/data/autoyast_sle15/autoyast_scc_up.xml
+++ b/data/autoyast_sle15/autoyast_scc_up.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <bootloader>
+    <global>
+      <activate>false</activate>
+      <boot_extended>false</boot_extended>
+      <boot_mbr>true</boot_mbr>
+      <boot_root>true</boot_root>
+      <generic_mbr>false</generic_mbr>
+      <timeout config:type="integer">5</timeout>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <second_stage config:type="boolean">false</second_stage>
+    </mode>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">false</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+  </general>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages>en_US</languages>
+  </language>
+  <report>
+    <errors>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <warnings>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <messages>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <yesno_messages>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <software>
+    <products config:type="list">
+        <product>SLES</product>
+    </products>
+  </software>
+  <upgrade>
+    <stop_on_solver_conflict config:type="boolean">true</stop_on_solver_conflict>
+  </upgrade>
+</profile>

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -139,6 +139,8 @@ sub run {
     # Autoyast reboot automatically without confirmation, usually assert 'bios-boot' that is not existing on zVM
     # So push a needle to check upcoming reboot on zVM that is a way to indicate the stage done
     push @needles, 'autoyast-stage1-reboot-upcoming' if check_var('BACKEND', 's390x');
+    # Import untrusted certification for SMT
+    push @needles, 'untrusted-ca-cert' if get_var('SMT_URL');
     # Workaround for removing package error during upgrade
     push(@needles, 'ERROR-removing-package') if get_var("AUTOUPGRADE");
     # Kill ssh proactively before reboot to avoid half-open issue on zVM
@@ -207,6 +209,11 @@ sub run {
             wait_screen_change { send_key $cmd{ok} };
             @needles = grep { $_ ne 'inst-betawarning' } @needles;
             push(@needles, 'autoyast-license') if (get_var('AUTOYAST_LICENSE'));
+            next;
+        }
+        elsif (match_has_tag('untrusted-ca-cert')) {
+            send_key 'alt-t';
+            wait_still_screen 5;
             next;
         }
         elsif (match_has_tag('ERROR-removing-package')) {


### PR DESCRIPTION
It is required to test autoupgrade (upgrade with autoyast) from SLE 12 to 15 via SCC or SMT.

- Related ticket: https://progress.opensuse.org/issues/33778
- Needles: None
- Verification run: 
   * autoupgrade_sles12sp3_scc@64bit-smp: http://openqa-apac1.suse.de/tests/555
   * autoupgrade_sles12sp3_smt@64bit-smp: http://openqa-apac1.suse.de/tests/556
