### PR TITLE
Fix sporadic failure of seahorse.pm

### DIFF
--- a/tests/x11/seahorse.pm
+++ b/tests/x11/seahorse.pm
@@ -33,7 +33,7 @@ sub run {
     type_password;                                    # Re-type user password
     send_key "ret";                                   # Confirm password
     assert_and_click "seahorse-default_keyring", 'right';    # right click the new keyring
-    assert_and_click "seahorse-set_as_default";              # Set the new keyring as default
+    assert_and_click "seahorse-set_as_default",  60;         # Set the new keyring as default
     send_key "alt-f4";                                       # Close seahorse
 }
 


### PR DESCRIPTION
- increase timeout for assert_click to 60 sec
- see poo#33625 for more details
- verification run:
  http://e13.suse.de/tests/710#step/seahorse/9
