### PR TITLE
Check free memory in the system during Toolchain tests

### DIFF
--- a/tests/toolchain/gcc_compilation.pm
+++ b/tests/toolchain/gcc_compilation.pm
@@ -22,6 +22,10 @@ sub run {
     assert_script_run('make -j$(getconf _NPROCESSORS_ONLN) 2>&1 | tee /tmp/make.log; if [ ${PIPESTATUS[0]} -ne 0 ]; then false; fi', 3600);
     assert_script_run('./gawk \'{ print }\' /etc/hostname');
     save_screenshot;
+
+    # poo#33376: added to investigate OOM
+    assert_script_run 'free -m';
+    save_screenshot;
 }
 
 sub post_fail_hook {

--- a/tests/toolchain/gcc_fortran_compilation.pm
+++ b/tests/toolchain/gcc_fortran_compilation.pm
@@ -48,6 +48,10 @@ sub run {
 
     save_screenshot;
     script_run 'popd';
+
+    # poo#33376: added to investigate OOM
+    assert_script_run 'free -m';
+    save_screenshot;
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
During Toolchain tests we are already checking memory after installation of the tools but not after c and c++ compiliation neither fortran. In order to catch what could be the memory issue for ppc (which have already 4G of available RAM) we can add these couple of verifications and see if it decreased substantially in some point.

- Related ticket: https://progress.opensuse.org/issues/33376#change-105310
- Verification run: (I don't have a ppc remote worker, but it should be fine as it is a small change for debug, not even a soft-failure as probably is fine that will stay there in the test due to all the issue seen with the memory on this set of tests in different architectures)
