### PR TITLE
Add cleared-console tag for verify keymap textmode subroutine s390x-specific

### DIFF
--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -23,7 +23,7 @@ sub verify_default_keymap_textmode {
     }
     else {
         send_key('alt-f3');
-        assert_screen("linux-login");
+        assert_screen([qw(linux-login cleared-console)]);
     }
 
     type_string($test_string);


### PR DESCRIPTION
Login consoles are cleared in s390x environment, thus linux-login needles do not match.

- Related ticket: [[sle][functional][u][s390x][medium] test fails in keymap_or_locale - missing select root console](https://progress.opensuse.org/issues/33247)
- Verification run: [sle-15-Installer-DVD-s390x-Build533.2-gnome@s390x-kvm-sle12](http://dhcp228.suse.cz/tests/1228#step/keymap_or_locale/9)
