### PR TITLE
[WIP] Add startup verification to inkscape test

### DIFF
--- a/tests/x11/inkscape.pm
+++ b/tests/x11/inkscape.pm
@@ -17,7 +17,7 @@ use testapi;
 
 sub run {
     ensure_installed('inkscape', timeout => 300);
-    x11_start_program('inkscape');
+    x11_start_program('inkscape', target_match => 'inkscape', match_typed => 'inkscape_typed');
     send_key "alt-f4";    # Exit
 }
 


### PR DESCRIPTION
Now verifies the typed command and whether inkscape started correctly


- Related ticket: https://progress.opensuse.org/issues/30805
- Needles: TBD
- Verification run: TBD
