### PR TITLE
Increase testsuite run timeout and add policy.cfg

### DIFF
--- a/data/ses/policy_4nodes.cfg
+++ b/data/ses/policy_4nodes.cfg
@@ -1,0 +1,36 @@
+## Cluster Assignment
+cluster-ceph/cluster/*.sls
+
+## Roles
+# ADMIN
+role-master/cluster/master*.sls
+role-admin/cluster/*.sls
+
+# MON
+role-mon/cluster/node[234]*.sls
+
+# MGR (mgrs are usually colocated with mons)
+role-mgr/cluster/node[234]*.sls
+
+# MDS
+role-mds/cluster/node1*.sls
+
+# IGW
+role-igw/cluster/node1*.sls
+
+# RGW
+role-rgw/cluster/node1*.sls
+
+# NFS
+role-ganesha/cluster/node1*.sls
+
+# openATTIC
+role-openattic/cluster/master*.sls
+
+# COMMON
+config/stack/default/global.yml
+config/stack/default/ceph/cluster.yml
+
+## Profiles
+profile-default/cluster/*.sls
+profile-default/stack/default/ceph/minions/*.yml

--- a/tests/ses/deepsea_testsuite.pm
+++ b/tests/ses/deepsea_testsuite.pm
@@ -54,7 +54,7 @@ sub run {
  then cat ping.log && false; else salt \'*\' test.ping && break; fi; done';
         assert_script_run 'salt \'*\' cmd.run \'lsblk\'';
         # rgw is testing ceph health status with additional 900 timeout
-        my $testsuite_timout = check_var('DEEPSEA_TESTSUITE', 'health-rgw') ? 2200 : 1500;
+        my $testsuite_timout = check_var('DEEPSEA_TESTSUITE', 'health-rgw') ? 2900 : 2000;
         assert_script_run "suites/basic/$deepsea_testsuite.sh --cli | tee /dev/tty /dev/$serialdev | grep ^OK\$", $testsuite_timout;
     }
     else {


### PR DESCRIPTION
Deepsea testsuites started to fail due to timeout

Failure: https://openqa.suse.de/tests/overview?distri=sle&version=12-SP3&build=%3A6942%3Adeepsea.1522051732&groupid=144

testrun: http://10.100.12.155/tests/639#settings