### PR TITLE
Support Kubic's new installation workflow

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -18,7 +18,7 @@ use testapi qw(check_var get_var get_required_var set_var check_var_array diag);
 use autotest;
 use utils;
 use version_utils qw(
-  is_hyperv_in_gui is_jeos is_gnome_next is_krypton_argon is_leap is_opensuse is_sle is_sles4sap is_sles4sap_standard sle_version_at_least is_desktop_installed is_installcheck is_rescuesystem is_staging is_tumbleweed is_virtualization_server
+  is_hyperv_in_gui is_jeos is_gnome_next is_krypton_argon is_leap is_opensuse is_sle is_sles4sap is_sles4sap_standard sle_version_at_least is_desktop_installed is_installcheck is_rescuesystem is_staging is_tumbleweed is_virtualization_server is_caasp
 );
 use bmwqemu ();
 use strict;
@@ -484,8 +484,9 @@ sub load_system_role_tests {
     if (!get_var("REMOTE_CONTROLLER") && !check_var('BACKEND', 'ipmi') && !is_hyperv_in_gui && !get_var("LIVECD")) {
         loadtest "installation/logpackages";
     }
-    loadtest "installation/disable_online_repos" if get_var('DISABLE_ONLINE_REPOS');
+    loadtest "installation/disable_online_repos"       if get_var('DISABLE_ONLINE_REPOS');
     loadtest "installation/installer_desktopselection" if is_opensuse;
+    loadtest "installation/system_role"                if is_caasp('kubic');
 }
 
 sub installzdupstep_is_applicable {
@@ -809,7 +810,7 @@ sub load_inst_tests {
     }
 
     if (noupdatestep_is_applicable()) {
-        loadtest "installation/installer_timezone";
+        loadtest "installation/installer_timezone" if !is_caasp('kubic');
         if (installwithaddonrepos_is_applicable() && !get_var("LIVECD")) {
             loadtest "installation/setup_online_repos";
         }
@@ -841,7 +842,7 @@ sub load_inst_tests {
             loadtest 'installation/user_import';
         }
         else {
-            loadtest "installation/user_settings";
+            loadtest "installation/user_settings" if !is_caasp('kubic');
         }
         if (is_sle || get_var("DOCRUN") || get_var("IMPORT_USER_DATA") || get_var("ROOTONLY")) {    # root user
             loadtest "installation/user_settings_root";

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -72,24 +72,29 @@ sub load_caasp_inst_tests {
         loadtest 'autoyast/installation';
     }
     else {
-        loadtest 'caasp/oci_overview';
+        if (get_var 'MULTI_STEP_KUBIC_FLOW') {
+            load_inst_tests;
+        }
+        else {
+            loadtest 'caasp/oci_overview';
 
-        # Check keyboard layout
-        loadtest 'caasp/oci_keyboard';
-        # Register system
-        loadtest 'caasp/oci_register' if check_var('REGISTER', 'installation');
-        # Set root password
-        loadtest 'caasp/oci_password';
-        # Set system Role
-        loadtest 'caasp/oci_role';
-        # Start installation
-        loadtest 'caasp/oci_install';
+            # Check keyboard layout
+            loadtest 'caasp/oci_keyboard';
+            # Register system
+            loadtest 'caasp/oci_register' if check_var('REGISTER', 'installation');
+            # Set root password
+            loadtest 'caasp/oci_password';
+            # Set system Role
+            loadtest 'caasp/oci_role';
+            # Start installation
+            loadtest 'caasp/oci_install';
 
-        # Can not start installation with partitioning error
-        return if check_var('FAIL_EXPECTED', 'SMALL-DISK');
-        return if check_var('FAIL_EXPECTED', 'BSC_1043619');
+            # Can not start installation with partitioning error
+            return if check_var('FAIL_EXPECTED', 'SMALL-DISK');
+            return if check_var('FAIL_EXPECTED', 'BSC_1043619');
 
-        load_common_installation_steps_tests;
+            load_common_installation_steps_tests;
+        }
     }
 }
 

--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -14,7 +14,7 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_caasp);
 
 
 my %role_hotkey = (
@@ -28,7 +28,7 @@ my %role_hotkey = (
 sub change_system_role {
     my ($system_role) = @_;
     # Since SLE 15 we do not have shortcuts for system roles anymore
-    if (is_sle '15+') {
+    if ((is_sle '15+') || (is_caasp 'kubic')) {
         if (check_var('VIDEOMODE', 'text')) {
             # Expect that no actions are done before and default system role is preselected
             send_key_until_needlematch "system-role-$system_role-focused",  'down';    # select role


### PR DESCRIPTION
Kubic's installation workflow is changing - https://github.com/yast/skelcd-control-Kubic/pull/3

This PR prepares openQA so we can test it.

I intend to merge both the skelcd and this at the same time, but if someone merges this earlier it should be harmless due to the use of the temporary MULTI_STEP_KUBIC_FLOW variable.

**Instructions for DimStar/Future Richard:**

The Kubic product will need the following variables:

 - `MULTI_STEP_KUBIC_FLOW` - temporary. We can drop this variable and replace it with an `if is_caasp 'kubic'` once it's checked in. We don't have to care about maintenance, but we will need to preserve the old workflow for CaaSP.
 - `ROOTONLY=1` - needed because kubic will only have a root account. Now we're reusing more standard tests we need to make use of this logic
- `SYSTEM_ROLE` will need to be set and needled in appropriate scenarios

Verification run is not possible - code not merged yet ;)

notes:

the plan in the future will be for Tumbleweed / Leap 15.1 to use the system_role test the same way Kubic is here, hence my attempt to reuse that module now even though the `if is_caasp('kubic')` is a little ugly