### PR TITLE
Add extension license handling before regcode

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -87,15 +87,10 @@ sub accept_addons_license {
             sleep 5;
         }
         # No license agreements are shown in SLE 15 at the moment
-        if (sle_version_at_least('15')) {
-            record_soft_failure 'bsc#1057223';
-        }
-        else {
-            assert_screen "scc-addon-license-$addon", 60;
-            addon_decline_license;
-            wait_still_screen 2;
-            send_key $cmd{next};
-        }
+        assert_screen "scc-addon-license-$addon", 60;
+        addon_decline_license;
+        wait_still_screen 2;
+        send_key $cmd{next};
     }
 }
 
@@ -428,6 +423,7 @@ sub fill_in_registration_data {
                 assert_screen 'yast-scc-emptypkg';
                 send_key 'alt-a';
             }
+            accept_addons_license('ha') if (check_var('SLE_PRODUCT', 'sles4sap'));
         }
     }
     else {


### PR DESCRIPTION
Starting with build 533.2 of SLES-15, the license agreement for extensions is being shown before the screen requesting the registration code during installation. This commits removes the code that was adding a soft-failure with bsc#1057223 when handling addons in SLES-15 installation, and adds a special case for accepting the HA extension license when installing SLES4SAP.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/786
- Verification run: http://mango.suse.de/tests/298 (SLES+HA), http://mango.suse.de/tests/299 (SLES4SAP), http://mango.suse.de/tests/300 (SLES+HA, VIDEOMODE=text), http://mango.suse.de/tests/301 (SLES4SAP, VIDEOMODE=text)
