### PR TITLE
Patch SLE 11 with SMT

### DIFF
--- a/tests/update/patch_before_migration.pm
+++ b/tests/update/patch_before_migration.pm
@@ -146,10 +146,23 @@ sub sle_register {
             yast_scc_registration();
         }
         else {
-            my $reg_code = get_required_var("NCC_REGCODE");
-            my $reg_mail = get_required_var("NCC_MAIL");
-            assert_script_run('suse_register -e');
-            assert_script_run("suse_register -n -a email=$reg_mail -a regcode-sles=$reg_code", 300);
+            # Erase all local files created from a previous executed registration
+            assert_script_run('suse_register -E');
+            # Register SLE 11 to SMT server
+            my $smt_url = get_var('SMT_URL', '');
+            if ($smt_url) {
+                my $setup_script = 'clientSetup4SMT.sh';
+                assert_script_run("wget $smt_url/repo/tools/$setup_script" =~ s/https/http/r);
+                assert_script_run("chmod +x $setup_script");
+                assert_script_run("echo y | ./$setup_script $smt_url/center/regsvc");
+                assert_script_run("suse_register -n");
+            }
+            # Otherwise, register SLE 11 to NCC server
+            else {
+                my $reg_code = get_required_var("NCC_REGCODE");
+                my $reg_mail = get_required_var("NCC_MAIL");
+                assert_script_run("suse_register -n -a email=$reg_mail -a regcode-sles=$reg_code", 300);
+            }
         }
     }
     # Unregister sle after update


### PR DESCRIPTION
Register SLES 11 to SMT server and patch the system

This change is required to upgrade SLES 11-SP4 to 15 via SMT server.

- Related ticket: https://progress.opensuse.org/issues/33436
- Needles: None
- Verification run: http://openqa-apac1.suse.de/tests/570#step/patch_before_migration/34
