### PR TITLE
Migrate persistent vnc and x11 forwarding cases to SLED15

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -425,7 +425,7 @@ sub load_x11_remote {
     elsif (check_var('REMOTE_DESKTOP_TYPE', 'persistent_vnc')) {
         loadtest 'x11/remote_desktop/persistent_vncsession_xvnc';
         loadtest 'x11/remote_desktop/x11_forwarding_openssh';
-        loadtest 'x11/remote_desktop/xdmcp_gdm';
+        loadtest 'x11/remote_desktop/xdmcp_gdm' if is_sle('<15');
     }
     # load xdmcp with xdm testing
     elsif (check_var('REMOTE_DESKTOP_TYPE', 'xdmcp_xdm')) {

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -253,7 +253,7 @@ sub setup_xvnc_server {
     return if $xvnc_server_set;
 
     if (check_var('REMOTE_DESKTOP_TYPE', 'persistent_vnc')) {
-        zypper_call('ar dvd:///?devices=/dev/sr0 dvd1repo');
+        zypper_call('ar http://openqa.suse.de/assets/repo/SLE-12-SP3-SERVER-POOL-x86_64-Media1-CURRENT/ sles12sp3dvd1_repo');
         zypper_call('ref');
     }
     script_run("yast remote; echo yast-remote-status-\$? > /dev/$serialdev", 0);

--- a/tests/x11/remote_desktop/persistent_vncsession_xvnc.pm
+++ b/tests/x11/remote_desktop/persistent_vncsession_xvnc.pm
@@ -67,7 +67,20 @@ sub run {
     $self->start_vncviewer;
     handle_login;
     assert_screen 'generic-desktop';
-    x11_start_program('gnome-terminal');
+    # Hold Alt key inside the vncviewer
+    send_key 'f8';
+    assert_screen 'vncviewer-menu';
+    send_key 'a';
+    wait_still_screen 3;
+    send_key 'f2';
+    assert_screen 'desktop-runner';
+    # Release key inside the vncviewer
+    send_key 'f8';
+    assert_screen 'vncviewer-menu';
+    send_key 'a';
+    wait_still_screen 3;
+    type_string "gnome-terminal\n";
+    assert_screen 'gnome-terminal-launched';
     type_string "vncmanager-controller\n";
     assert_screen 'vncmanager-controller';
     assert_and_click 'vncmanager-controller-visibility';
@@ -102,13 +115,13 @@ sub run {
     hold_key 'alt';
     send_key_until_needlematch('vncviewer-minimize', 'tab');
     release_key 'alt';
-    send_key 'alt-f4';
-    mouse_set(1000, 30);
+    assert_screen 'gnome-terminal-launched';
     assert_and_click 'system-indicator';
     assert_and_click 'user-logout-sector';
     assert_and_click 'logout-system';
     assert_screen 'logout-dialogue';
     send_key 'ret';
+    assert_screen 'generic-desktop';
 
     mutex_unlock 'xvnc';
 }


### PR DESCRIPTION
- Update the supportserver repo since we are using SLES12SP3 now
- Update persistent_vncsession_xvnc since the behavior of vncviewer has changed

---

- Related ticket: https://progress.opensuse.org/issues/31489
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/787
- Verification run: http://10.67.17.30/tests/335
