### PR TITLE
sles4sap/sapconf: Ignore timeout on developer's test run

### DIFF
--- a/tests/sles4sap/netweaver_ascs_install.pm
+++ b/tests/sles4sap/netweaver_ascs_install.pm
@@ -46,7 +46,7 @@ sub run {
 
     # This installs Netweaver's ASCS. Start by making sure the correct
     # SAP profile and solution are configured in the system
-    assert_script_run "tuned-adm profile sap-netweaver";
+    assert_script_run "tuned-adm profile saptune";
     assert_script_run "saptune solution apply NETWEAVER";
     assert_script_run "systemctl restart systemd-logind.service";
 

--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -15,9 +15,12 @@ use testapi;
 use version_utils qw(is_staging is_sle);
 use strict;
 
-my @tuned_profiles = qw(balanced desktop latency-performance network-latency
-  network-throughput powersave sapconf saptune throughput-performance virtual-guest
-  virtual-host);
+my @tuned_profiles = is_sle('>=15') ?
+  qw(balanced desktop latency-performance network-latency network-throughput
+  powersave sapconf saptune throughput-performance virtual-guest virtual-host)
+  : qw(balanced desktop latency-performance network-latency
+  network-throughput powersave sap-ase sap-bobj sap-hana sap-netweaver saptune
+  throughput-performance virtual-guest virtual-host);
 
 my %sapconf_profiles = (
     hana   => 'sap-hana',

--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -61,7 +61,8 @@ sub run_developers_tests {
     }
     assert_script_run "chmod +x sapconf_test.sh";
     $ret = script_run "./sapconf_test.sh -c local -p no | tee $log", 600;
-    record_soft_failure "sapconf_test.sh returned error code: [$ret]" unless (defined $ret and $ret == 0);
+    # Record soft fail only if script returns an error. Ignore timeout as test completion is checked below
+    record_soft_failure "sapconf_test.sh returned error code: [$ret]" if (defined $ret and $ret != 0);
     upload_logs $log;
 
     # Check summary of tests on log for bug report
@@ -117,7 +118,7 @@ sub run {
 
     $output = script_output "tuned-adm recommend";
     record_info("Recommended profile", "Recommended profile: $output");
-    die "Command 'tuned-adm recommended' recommended profile is not in 'tuned-adm list'"
+    die "Command 'tuned-adm recommend' recommended profile is not in 'tuned-adm list'"
       unless (grep(/$output/, @tuned_profiles));
 
     foreach my $p (@tuned_profiles) {

--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -16,8 +16,8 @@ use version_utils qw(is_staging is_sle);
 use strict;
 
 my @tuned_profiles = qw(balanced desktop latency-performance network-latency
-  network-throughput powersave sap-ase sap-bobj sap-hana sap-netweaver saptune
-  throughput-performance virtual-guest virtual-host);
+  network-throughput powersave sapconf saptune throughput-performance virtual-guest
+  virtual-host);
 
 my %sapconf_profiles = (
     hana   => 'sap-hana',


### PR DESCRIPTION
This PR removes the soft fail if `script_run` timeouts while running the developers' supplied test script, as its status and output is checked in steps after that. No need to soft fail with error code `undef` on timeouts when further information is gathered and reported while checking the generated log.

Also including adjustments for sapconf profiles as the newer version drops the sap-ase, sap-hana, sap-bobj and sap-netweaver profiles in favor of the sapconf profile.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/306
