### PR TITLE
[WIP] Fix snapper related tests by moving snapshot test data from /root to /etc

### DIFF
--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -3,6 +3,7 @@ package y2snapper_common;
 use strict;
 use testapi;
 use utils;
+use version_utils;
 
 # Helper for letting y2-snapper to create a snapper snapshot
 sub y2snapper_create_snapshot {
@@ -43,7 +44,10 @@ sub y2snapper_new_snapshot {
 }
 
 sub y2snapper_untar_testfile {
-    assert_script_run "tar -xzf /home/$username/data/yast2_snapper.tgz";
+    # Due to the product change for bsc#1085266 /root is not included in
+    # snapshots anymore
+    my $args = is_sle('<15') || is_leap('<15.0') ? '' : '-C /etc';
+    assert_script_run "tar $args -xzf /home/$username/data/yast2_snapper.tgz";
 }
 
 sub y2snapper_show_changes_and_delete {


### PR DESCRIPTION
The products changed and /root is now a subvolume as well so a snapshot will
not include changes in there. Moving to /etc should prevent this problem as we
can expect / always be snapshotted. This would require needle updates
to all products where we run yast2_snapper as well as yast2_snapper_ncurses
so I opted for a backward compatible approach first and only doing the change
for the products which are affected by the change of the /root subvol.

Related needle PRs:
* SLE15: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/789

Verification runs:
* SLE15: http://lord.arch/tests/665

Related progress issue: https://progress.opensuse.org/issues/34018