### PR TITLE
Add comment for performing sync aheand of reboot

### DIFF
--- a/tests/update/patch_before_migration.pm
+++ b/tests/update/patch_before_migration.pm
@@ -58,6 +58,8 @@ sub patching_sle {
         # Update origin system on zVM that is controlled by autoyast profile and reboot is done by end of autoyast installation
         # So we skip reboot here after fully patched on zVM to reduce times of reconnection to s390x
         if (!get_var('UPGRADE_ON_ZVM')) {
+            # Perform sync ahead of reboot to flush filesystem buffers that probably reduce time of sync during rebooting
+            # In the case no need to always enlarge timeout of wait_boot
             assert_script_run 'sync', 600;
             type_string "reboot\n";
             $self->wait_boot(textmode => !is_desktop_installed(), ready_time => 600, bootloader_time => 250);


### PR DESCRIPTION
By comparing build [535.1](https://openqa.suse.de/tests/overview?distri=sle&version=15&build=535.1&groupid=111) and build [533.2](https://openqa.suse.de/tests/overview?distri=sle&version=15&build=533.2&groupid=111) this action looks work.
The failure of reboot after fully patch at step `patch_before_migration` was not shown in 535.1, especially on ppc64le.