### PR TITLE
Make snapper tests outside of /root

### DIFF
--- a/tests/console/snapper_undochange.pm
+++ b/tests/console/snapper_undochange.pm
@@ -18,7 +18,7 @@ sub run {
     my ($self) = @_;
     select_console 'root-console';
 
-    my $snapfile     = '/root/snapfile';
+    my $snapfile     = '/snapfile';
     my @snapper_runs = 'snapper';
     push @snapper_runs, 'snapper --no-dbus' if get_var('SNAPPER_NODBUS');
 

--- a/tests/installation/boot_into_snapshot.pm
+++ b/tests/installation/boot_into_snapshot.pm
@@ -25,7 +25,7 @@ sub run {
     assert_screen 'linux-login', 200;
     select_console 'root-console';
     # 1)
-    assert_script_run('touch NOWRITE;test ! -f NOWRITE');
+    assert_script_run('touch /NOWRITE;test ! -f /NOWRITE');
     # 1b) just debugging infos
     assert_script_run("snapper --iso list");
     assert_script_run("cat /etc/os-release");


### PR DESCRIPTION
/root is no longer part of the / volume in order to not rollback
root-owned files, which could lead to data loss. This in turn means
our test can't rely on /root rolling back or being non-writable.

- Related ticket: https://progress.opensuse.org/issues/33649
