### PR TITLE
Fix sporadic match timeout issue for firefox_audio.pm

### DIFF
--- a/tests/x11/firefox_audio.pm
+++ b/tests/x11/firefox_audio.pm
@@ -21,7 +21,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     start_audiocapture;
-    x11_start_program('firefox ' . data_url('1d5d9dD.oga'), target_match => 'test-firefox_audio-1', match_timeout => 35);
+    x11_start_program('firefox ' . data_url('1d5d9dD.oga'), target_match => 'test-firefox_audio-1', match_timeout => 90);
     sleep 1;    # at least a second of silence
 
     # firefox_audio is unstable due to bsc#1048271, we don't want to invest


### PR DESCRIPTION
- increase timeout to 90 seconds for match_timeout
- see poo#33019 for more details
- verification runs over 40 times and got mostly successful results
  http://e13.suse.de/tests/913#step/firefox_audio
