### PR TITLE
Change file path to snapfile

### DIFF
--- a/tests/console/snapper_undochange.pm
+++ b/tests/console/snapper_undochange.pm
@@ -18,7 +18,7 @@ sub run {
     my ($self) = @_;
     select_console 'root-console';
 
-    my $snapfile     = '/root/snapfile';
+    my $snapfile     = '/etc/snapfile';
     my @snapper_runs = 'snapper';
     push @snapper_runs, 'snapper --no-dbus' if get_var('SNAPPER_NODBUS');
 
@@ -26,7 +26,7 @@ sub run {
         $self->snapper_nodbus_setup if $snapper =~ /dbus/;
 
         assert_script_run "snapbf=`$snapper create -p -d 'before undochange test'`", 90;
-        script_run "date > $snapfile";
+        script_run "date > $snapfile";    # simulate system changing by adding new dummy file
         assert_script_run "snapaf=`$snapper create -p -d 'after undochange test'`", 90;
 
         # Delete snapfile


### PR DESCRIPTION
As /root is not a sub-volume by default on SUSE distributions, the /root
folder is excluded by snapper while doing snapshots of the system. This
commit changes the path to a dummy file, that is used to simulate system
changing.

- Related ticket: https://progress.opensuse.org/issues/33649
- Needles: do not require
- Verification run: http://149.44.172.105/tests/146