### PR TITLE
Fix for poo#33658 - add more wait time for "snapper list"

### DIFF
--- a/tests/console/upgrade_snapshots.pm
+++ b/tests/console/upgrade_snapshots.pm
@@ -23,12 +23,12 @@ sub run {
 
     script_run("snapper list | tee /dev/$serialdev", 0);
     # Check if the snapshot called 'before update' is there
-    wait_serial('pre\s*(\|[^|]*){4}\s*\|\s*number\s*\|\s*before (update|online migration)\s*\|\s*important=yes', 5)
+    wait_serial('pre\s*(\|[^|]*){4}\s*\|\s*number\s*\|\s*before (update|online migration)\s*\|\s*important=yes', 20)
       || die 'upgrade snapshots test failed';
 
     script_run("snapper list | tee /dev/$serialdev", 0);
     # Check if the snapshot called 'after update' is there
-    wait_serial('post\s*(\|[^|]*){4}\s*\|\s*number\s*\|\s*after (update|online migration)\s*\|\s*important=yes', 5)
+    wait_serial('post\s*(\|[^|]*){4}\s*\|\s*number\s*\|\s*after (update|online migration)\s*\|\s*important=yes', 20)
       || die 'upgrade snapshots test failed';
 }
 


### PR DESCRIPTION
This issue happened for the "snapper list" not finished in 5s, sometimes the 'snapper list' may need more time to run and clean itself especially when the system is slow. It should be fixed by add more wait time for the 'snapper list'. 
For example, I have tried to verify it by cloning o.s.d job with TIMEOUT_SCALE=2 and TIMEOUT_SCALE=6. The test with TIMEOUT_SCALE=2 still failed while the test with TIMEOUT_SCALE=6 passed.

- Related ticket: https://progress.opensuse.org/issues/33658
- Verification run:https://openqa.suse.de/tests/1577721
