### PR TITLE
Add a remmina xvnc remote desktop case

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -418,6 +418,7 @@ sub load_x11_remote {
     # load onetime vncsession testing
     if (check_var('REMOTE_DESKTOP_TYPE', 'one_time_vnc')) {
         loadtest 'x11/remote_desktop/onetime_vncsession_xvnc_tigervnc';
+        loadtest 'x11/remote_desktop/onetime_vncsession_xvnc_remmina';
         loadtest 'x11/remote_desktop/onetime_vncsession_xvnc_java' if is_sle('<15');
         loadtest 'x11/remote_desktop/onetime_vncsession_multilogin_failed';
     }

--- a/tests/x11/remote_desktop/onetime_vncsession_xvnc_remmina.pm
+++ b/tests/x11/remote_desktop/onetime_vncsession_xvnc_remmina.pm
@@ -1,0 +1,80 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Remote Login: One-time VNC Session with remmina and xvnc
+# Maintainer: Chingkai <qkzhu@suse.com>
+# Tags: tc#1610354
+
+use strict;
+use base 'basetest';
+use testapi;
+use lockapi;
+use utils;
+
+sub run {
+    #wait for supportserver if not yet ready
+    mutex_lock 'dhcp';
+    mutex_unlock 'dhcp';
+    mutex_lock 'xvnc';
+
+    # Make sure the client gets the IP address
+    x11_start_program('xterm');
+    become_root;
+    assert_script_run 'dhclient';
+    type_string "exit\n";
+    send_key 'alt-f4';
+
+    # Start Remmina and login the remote server
+    x11_start_program('remmina', target_match => 'remmina-launched');
+
+    # The default host key is right Ctrl which is not supported by openQA
+    # Change the host key to 'z'
+    send_key 'ctrl-p';
+    assert_screen 'remmina-preferences';
+    assert_and_click 'remmina-preferences-keyboard';
+    assert_and_click 'remmina-preferences-hostkey';
+    assert_screen 'remmina-hostkey-setting';
+    send_key 'z';
+    assert_screen 'remmina-hostkey-configured';
+    send_key 'esc';
+
+    # Add a new VNC connection
+    assert_and_click 'remmina-plus-button';
+    assert_and_click 'remmina-protocol';
+    assert_and_click 'remmina-protocol-vnc';
+    assert_and_click 'remmina-advanced-setting';
+    assert_and_click 'remmina-disable-encryption';
+    assert_and_click 'remmina-basic-setting';
+    assert_and_click 'remmina-server-url';
+    type_string '10.0.2.1:1';
+    assert_and_click 'remmina-color-depth';
+    assert_and_click 'remmina-color-16bpp';
+    assert_and_click 'remmina-quality';
+    assert_and_click 'remmina-quality-good';
+    assert_and_click 'remmina-connect';
+    assert_screen 'remmina-connected';
+
+    # Enter the full screen mode
+    send_key 'z-f';
+    handle_login;
+    assert_screen 'generic-desktop';
+
+    # Disconnect with the remote server
+    send_key 'z-f4';
+    assert_screen 'remmina-launched';
+
+    # Quit remmina and clean the preferences file
+    send_key 'ctrl-q';
+    x11_start_program('rm ~/.config/remmina/remmina.pref', valid => 0);
+
+    mutex_unlock 'xvnc';
+}
+
+1;
+# vim: set sw=4 et:


### PR DESCRIPTION
We replaced vinagre with remmina in SLE15, this case will use remmina as client to access onetime xvnc remote desktop server.

---

- Related ticket: https://progress.opensuse.org/issues/31489
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/790
- Verification run: http://10.67.17.30/tests/341
