### PR TITLE
Check orphan package after upgrade

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1056,6 +1056,7 @@ sub load_consoletests {
     if (check_var_array('SCC_ADDONS', 'tcm') && get_var('PATTERNS') && sle_version_at_least('12-SP3')) {
         loadtest "feature/feature_console/deregister";
     }
+    loadtest 'migration/sle12_online_migration/orphaned_packages_check' if get_var('UPGRADE');
 
     loadtest "console/consoletest_finish";
 }


### PR DESCRIPTION
Get orphan packages list by running orphaned_packages_check test module after upgrade.

It is not a bug that there are some orphan packages after upgrade, so just collect the orphan packages and save as a log which maybe required for further checking by anyone interested (maybe PM?).

- Related ticket: https://progress.opensuse.org/issues/34000
- Needles: N/A
- Verification run: http://openqa-apac1.suse.de/tests/614#step/orphaned_packages_check/7
