### PR TITLE
Add SLES12 SP3 autoyast profiles of s390x

### DIFF
--- a/data/autoyast_sle12/autoyast_sles12sp3+alladdons_allpatterns_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3+alladdons_allpatterns_reg_full_s390x.xml
@@ -1,0 +1,427 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Products/SLE-Module-Web-Scripting/12/s390x/product/]]></media_url>
+        <product>sle-module-web-scripting</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Products/SLE-Module-Toolchain/12/s390x/product/]]></media_url>
+        <product>sle-module-toolchain</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Products/SLE-Module-Public-Cloud/12/s390x/product/]]></media_url>
+        <product>sle-module-public-cloud</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Products/SLE-Module-Legacy/12/s390x/product/]]></media_url>
+        <product>sle-module-legacy</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Products/SLE-Module-Containers/12/s390x/product/]]></media_url>
+        <product>sle-module-containers</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Products/SLE-Module-Adv-Systems-Management/12/s390x/product/]]></media_url>
+        <product>sle-module-adv-systems-management</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/install/SLP/SLE-12-SP3-HA-GEO-GM/s390x/DVD1/]]></media_url>
+        <product>sle-ha-geo</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/install/SLP/SLE-12-SP3-HA-GM/s390x/DVD1/]]></media_url>
+        <product>sle-ha</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/install/SLP/SLE-12-SP3-SDK-GM/s390x/DVD1/]]></media_url>
+        <product>sle-sdk</product>
+        <product_dir>/</product_dir>
+      </listentry>
+    </add_on_products>
+  </add-on>
+
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <dasd>
+    <devices config:type="list">
+      <listentry>
+        <device>DASD</device>
+        <dev_name>/dev/dasda</dev_name>
+        <channel>0.0.0150</channel>
+        <diag config:type="boolean">false</diag>
+      </listentry>
+    </devices>
+  </dasd>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <services-manager>
+  <default_target>graphical</default_target>
+    <services>
+      <enable config:type="list">
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <keyboard>
+    <keyboard_values>
+      <delay/>
+      <discaps config:type="boolean">false</discaps>
+      <numlock>bios</numlock>
+      <rate/>
+    </keyboard_values>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel>112M</crash_kernel>
+    <crash_xen_kernel>112M\&lt;4G</crash_xen_kernel>
+    <general>
+      <KDUMPTOOL_FLAGS/>
+      <KDUMP_COMMANDLINE/>
+      <KDUMP_COMMANDLINE_APPEND/>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_CPUS/>
+      <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_HOST_KEY/>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>5</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_KERNELVER/>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NET_TIMEOUT>30</KDUMP_NET_TIMEOUT>
+      <KDUMP_NOTIFICATION_CC/>
+      <KDUMP_NOTIFICATION_TO/>
+      <KDUMP_POSTSCRIPT/>
+      <KDUMP_PRESCRIPT/>
+      <KDUMP_REQUIRED_PROGRAMS/>
+      <KDUMP_SAVEDIR>/var/crash</KDUMP_SAVEDIR>
+      <KDUMP_SMTP_PASSWORD/>
+      <KDUMP_SMTP_SERVER/>
+      <KDUMP_SMTP_USER/>
+      <KDUMP_TRANSFER/>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+      <KEXEC_OPTIONS/>
+    </general>
+  </kdump>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list"/>
+  </ntp-client>
+  <software>
+    <image/>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <instsource/>
+    <packages config:type="list">
+      <package>snapper</package>
+      <package>sles-release</package>
+      <package>sle-sdk-release</package>
+      <package>sle-ha-release</package>
+      <package>sle-ha-geo-release</package>
+      <package>sle-module-web-scripting-release</package>
+      <package>sle-module-toolchain-release</package>
+      <package>sle-module-public-cloud-release</package>
+      <package>sle-module-legacy-release</package>
+      <package>sle-module-containers-release</package>
+      <package>sle-module-adv-systems-management-release</package>
+      <package>openssh</package>
+      <package>kexec-tools</package>
+      <package>kdump</package>
+      <package>iproute2</package>
+      <package>grub2</package>
+      <package>glibc</package>
+      <package>e2fsprogs</package>
+      <package>btrfsprogs</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>32bit</pattern>
+      <pattern>Amazon-Web-Services</pattern>
+      <pattern>Basis-Devel</pattern>
+      <pattern>CFEngien</pattern>
+      <pattern>Machinery</pattern>
+      <pattern>Minimal</pattern>
+      <pattern>OpenStack</pattern>
+      <pattern>Puppet</pattern>
+      <pattern>SDK-C-C++</pattern>
+      <pattern>SDK-Certification</pattern>
+      <pattern>SDK-Doc</pattern>
+      <pattern>SDK-YaST</pattern>
+      <pattern>WBEM</pattern>
+      <pattern>apparmor</pattern>
+      <pattern>base</pattern>
+      <pattern>dhcp_dns_server</pattern>
+      <pattern>directory_server</pattern>
+      <pattern>documentation</pattern>
+      <pattern>file_server</pattern>
+      <pattern>fips</pattern>
+      <pattern>gateway_server</pattern>
+      <pattern>gcc5</pattern>
+      <pattern>gnome-basic</pattern>
+      <pattern>ha_geo</pattern>
+      <pattern>ha_sles</pattern>
+      <pattern>hwcrypto</pattern>
+      <pattern>kvm_server</pattern>
+      <pattern>kvm_tools</pattern>
+      <pattern>lamp_server</pattern>
+      <pattern>mail_server</pattern>
+      <pattern>ofed</pattern>
+      <pattern>oracle_server</pattern>
+      <pattern>printing</pattern>
+      <pattern>sap_server</pattern>
+      <pattern>sles-Basis-Devel-32bit</pattern>
+      <pattern>sles-Minimal-32bit</pattern>
+      <pattern>sles-WBEM-32bit</pattern>
+      <pattern>sles-apparmor-32bit</pattern>
+      <pattern>sles-base-32bit</pattern>
+      <pattern>sles-dhcp_dns_server-32bit</pattern>
+      <pattern>sles-directory_server-32bit</pattern>
+      <pattern>sles-documentation-32bit</pattern>
+      <pattern>sles-file_server-32bit</pattern>
+      <pattern>sles-fips-32bit</pattern>
+      <pattern>sles-gateway_server-32bit</pattern>
+      <pattern>sles-hwcrypto-32bit</pattern>
+      <pattern>sles-kvm_server-32bit</pattern>
+      <pattern>sles-kvm_tools-32bit</pattern>
+      <pattern>sles-lamp_server-32bit</pattern>
+      <pattern>sles-mail_server-32bit</pattern>
+      <pattern>sles-ofed-32bit</pattern>
+      <pattern>sles-oracle_server-32bit</pattern>
+      <pattern>sles-printing-32bit</pattern>
+      <pattern>sles-sap_server-32bit</pattern>
+      <pattern>sles-x11-32bit</pattern>
+      <pattern>smt</pattern>
+      <pattern>x11</pattern>
+      <pattern>yast2</pattern>
+    </patterns>
+  </software>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+
+    <addons config:type="list">
+
+      <addon>
+        <!-- SUSE Linux Enterprise High Availability Extension -->
+        <name>sle-ha</name>
+        <version>12.3</version>
+        <arch>s390x</arch>
+        <reg_code>{{SCC_REGCODE_HA}}</reg_code>
+      </addon>
+
+      <addon>
+        <!-- SUSE Linux Enterprise High Availability GEO Extension -->
+        <!-- Depends on: SUSE Linux Enterprise High Availability Extension -->
+        <name>sle-ha-geo</name>
+        <version>12.3</version>
+        <arch>s390x</arch>
+        <reg_code>{{SCC_REGCODE_GEO}}</reg_code>
+      </addon>
+
+      <addon>
+        <!-- SUSE Linux Enterprise Software Development Kit -->
+        <name>sle-sdk</name>
+        <version>12.3</version>
+        <arch>s390x</arch>
+      </addon>
+
+      <addon>
+        <!-- Advanced Systems Management Module -->
+        <name>sle-module-adv-systems-management</name>
+        <version>12</version>
+        <arch>s390x</arch>
+      </addon>
+
+      <addon>
+        <!-- Containers Module -->
+        <name>sle-module-containers</name>
+        <version>12</version>
+        <arch>s390x</arch>
+      </addon>
+
+      <addon>
+        <!-- Legacy Module -->
+        <name>sle-module-legacy</name>
+        <version>12</version>
+        <arch>s390x</arch>
+      </addon>
+
+      <addon>
+        <!-- Public Cloud Module -->
+        <name>sle-module-public-cloud</name>
+        <version>12</version>
+        <arch>s390x</arch>
+      </addon>
+
+      <addon>
+        <!-- Toolchain Module -->
+        <name>sle-module-toolchain</name>
+        <version>12</version>
+        <arch>s390x</arch>
+      </addon>
+
+      <addon>
+        <!-- Web and Scripting Module -->
+        <name>sle-module-web-scripting</name>
+        <version>12</version>
+        <arch>s390x</arch>
+      </addon>
+    </addons>
+
+  </suse_register>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id/>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>suse</domain>
+      <hostname>linux-gspv</hostname>
+      <nameservers config:type="list">
+        <nameserver>10.160.0.1</nameserver>
+      </nameservers>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>static</bootproto>
+        <device>eth0</device>
+        <ipaddr>{{HostIP}}</ipaddr>
+        <netmask>255.255.240.0</netmask>
+        <prefixlen>20</prefixlen>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>KERNELS</rule>
+        <value>0.0.0700</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+      <routes config:type="list">
+        <route>
+          <destination>default</destination>
+          <device>eth0</device>
+          <gateway>10.161.159.254</gateway>
+          <netmask>-</netmask>
+        </route>
+      </routes>
+    </routing>
+    <s390-devices config:type="list">
+      <listentry>
+        <chanids>0.0.0700 0.0.0701 0.0.0702</chanids>
+        <portname>no portname required</portname>
+        <type>qeth</type>
+      </listentry>
+      <listentry>
+        <chanids>   </chanids>
+        <type/>
+      </listentry>
+    </s390-devices>
+  </networking>
+  <firewall>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+  </firewall>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Berlin</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact>-1</inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/data/autoyast_sle12/autoyast_sles12sp3+alladdons_default_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3+alladdons_default_reg_full_s390x.xml
@@ -1,0 +1,384 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Products/SLE-Module-Web-Scripting/12/s390x/product/]]></media_url>
+        <product>sle-module-web-scripting</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Products/SLE-Module-Toolchain/12/s390x/product/]]></media_url>
+        <product>sle-module-toolchain</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Products/SLE-Module-Public-Cloud/12/s390x/product/]]></media_url>
+        <product>sle-module-public-cloud</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Products/SLE-Module-Legacy/12/s390x/product/]]></media_url>
+        <product>sle-module-legacy</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Products/SLE-Module-Containers/12/s390x/product/]]></media_url>
+        <product>sle-module-containers</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/ibs/SUSE/Products/SLE-Module-Adv-Systems-Management/12/s390x/product/]]></media_url>
+        <product>sle-module-adv-systems-management</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/install/SLP/SLE-12-SP3-HA-GEO-GM/s390x/DVD1/]]></media_url>
+        <product>sle-ha-geo</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/install/SLP/SLE-12-SP3-HA-GM/s390x/DVD1/]]></media_url>
+        <product>sle-ha</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/install/SLP/SLE-12-SP3-SDK-GM/s390x/DVD1/]]></media_url>
+        <product>sle-sdk</product>
+        <product_dir>/</product_dir>
+      </listentry>
+    </add_on_products>
+  </add-on>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <dasd>
+    <devices config:type="list">
+      <listentry>
+        <device>DASD</device>
+        <dev_name>/dev/dasda</dev_name>
+        <channel>0.0.0150</channel>
+        <diag config:type="boolean">false</diag>
+      </listentry>
+    </devices>
+  </dasd>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <services-manager>
+  <default_target>graphical</default_target>
+    <services>
+      <enable config:type="list">
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <keyboard>
+    <keyboard_values>
+      <delay/>
+      <discaps config:type="boolean">false</discaps>
+      <numlock>bios</numlock>
+      <rate/>
+    </keyboard_values>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel>112M</crash_kernel>
+    <crash_xen_kernel>112M\&lt;4G</crash_xen_kernel>
+    <general>
+      <KDUMPTOOL_FLAGS/>
+      <KDUMP_COMMANDLINE/>
+      <KDUMP_COMMANDLINE_APPEND/>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_CPUS/>
+      <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_HOST_KEY/>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>5</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_KERNELVER/>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NET_TIMEOUT>30</KDUMP_NET_TIMEOUT>
+      <KDUMP_NOTIFICATION_CC/>
+      <KDUMP_NOTIFICATION_TO/>
+      <KDUMP_POSTSCRIPT/>
+      <KDUMP_PRESCRIPT/>
+      <KDUMP_REQUIRED_PROGRAMS/>
+      <KDUMP_SAVEDIR>/var/crash</KDUMP_SAVEDIR>
+      <KDUMP_SMTP_PASSWORD/>
+      <KDUMP_SMTP_SERVER/>
+      <KDUMP_SMTP_USER/>
+      <KDUMP_TRANSFER/>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+      <KEXEC_OPTIONS/>
+    </general>
+  </kdump>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list"/>
+  </ntp-client>
+  <software>
+    <image/>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <instsource/>
+    <packages config:type="list">
+      <package>snapper</package>
+      <package>sles-release</package>
+      <package>sle-sdk-release</package>
+      <package>sle-ha-release</package>
+      <package>sle-ha-geo-release</package>
+      <package>sle-module-web-scripting-release</package>
+      <package>sle-module-toolchain-release</package>
+      <package>sle-module-public-cloud-release</package>
+      <package>sle-module-legacy-release</package>
+      <package>sle-module-containers-release</package>
+      <package>sle-module-adv-systems-management-release</package>
+      <package>openssh</package>
+      <package>kexec-tools</package>
+      <package>kdump</package>
+      <package>iproute2</package>
+      <package>grub2</package>
+      <package>glibc</package>
+      <package>e2fsprogs</package>
+      <package>btrfsprogs</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>32bit</pattern>
+      <pattern>Minimal</pattern>
+      <pattern>apparmor</pattern>
+      <pattern>base</pattern>
+      <pattern>documentation</pattern>
+      <pattern>gcc5</pattern>
+      <pattern>gnome-basic</pattern>
+      <pattern>ha_geo</pattern>
+      <pattern>ha_sles</pattern>
+      <pattern>sles-Minimal-32bit</pattern>
+      <pattern>sles-apparmor-32bit</pattern>
+      <pattern>sles-base-32bit</pattern>
+      <pattern>sles-documentation-32bit</pattern>
+      <pattern>sles-x11-32bit</pattern>
+      <pattern>x11</pattern>
+      <pattern>yast2</pattern>
+    </patterns>
+  </software>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+
+    <addons config:type="list">
+
+      <addon>
+        <!-- SUSE Linux Enterprise High Availability Extension -->
+        <name>sle-ha</name>
+        <version>12.3</version>
+        <arch>s390x</arch>
+        <reg_code>{{SCC_REGCODE_HA}}</reg_code>
+      </addon>
+
+      <addon>
+        <!-- SUSE Linux Enterprise High Availability GEO Extension -->
+        <!-- Depends on: SUSE Linux Enterprise High Availability Extension -->
+        <name>sle-ha-geo</name>
+        <version>12.3</version>
+        <arch>s390x</arch>
+        <reg_code>{{SCC_REGCODE_GEO}}</reg_code>
+      </addon>
+
+      <addon>
+        <!-- SUSE Linux Enterprise Software Development Kit -->
+        <name>sle-sdk</name>
+        <version>12.3</version>
+        <arch>s390x</arch>
+      </addon>
+
+      <addon>
+        <!-- Advanced Systems Management Module -->
+        <name>sle-module-adv-systems-management</name>
+        <version>12</version>
+        <arch>s390x</arch>
+      </addon>
+
+      <addon>
+        <!-- Containers Module -->
+        <name>sle-module-containers</name>
+        <version>12</version>
+        <arch>s390x</arch>
+      </addon>
+
+      <addon>
+        <!-- Legacy Module -->
+        <name>sle-module-legacy</name>
+        <version>12</version>
+        <arch>s390x</arch>
+      </addon>
+
+      <addon>
+        <!-- Public Cloud Module -->
+        <name>sle-module-public-cloud</name>
+        <version>12</version>
+        <arch>s390x</arch>
+      </addon>
+
+      <addon>
+        <!-- Toolchain Module -->
+        <name>sle-module-toolchain</name>
+        <version>12</version>
+        <arch>s390x</arch>
+      </addon>
+
+      <addon>
+        <!-- Web and Scripting Module -->
+        <name>sle-module-web-scripting</name>
+        <version>12</version>
+        <arch>s390x</arch>
+      </addon>
+    </addons>
+
+  </suse_register>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id/>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>suse</domain>
+      <hostname>linux-gspv</hostname>
+      <nameservers config:type="list">
+        <nameserver>10.160.0.1</nameserver>
+      </nameservers>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>static</bootproto>
+        <device>eth0</device>
+        <ipaddr>{{HostIP}}</ipaddr>
+        <netmask>255.255.240.0</netmask>
+        <prefixlen>20</prefixlen>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>KERNELS</rule>
+        <value>0.0.0700</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+      <routes config:type="list">
+        <route>
+          <destination>default</destination>
+          <device>eth0</device>
+          <gateway>10.161.159.254</gateway>
+          <netmask>-</netmask>
+        </route>
+      </routes>
+    </routing>
+    <s390-devices config:type="list">
+      <listentry>
+        <chanids>0.0.0700 0.0.0701 0.0.0702</chanids>
+        <portname>no portname required</portname>
+        <type>qeth</type>
+      </listentry>
+      <listentry>
+        <chanids>   </chanids>
+        <type/>
+      </listentry>
+    </s390-devices>
+  </networking>
+  <firewall>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+  </firewall>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Berlin</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact>-1</inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/data/autoyast_sle12/autoyast_sles12sp3+sdk+ha+geo_allpatterns_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3+sdk+ha+geo_allpatterns_reg_full_s390x.xml
@@ -1,0 +1,342 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/install/SLP/SLE-12-SP3-HA-GEO-GM/s390x/DVD1/]]></media_url>
+        <product>sle-ha-geo</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/install/SLP/SLE-12-SP3-HA-GM/s390x/DVD1/]]></media_url>
+        <product>sle-ha</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/install/SLP/SLE-12-SP3-SDK-GM/s390x/DVD1/]]></media_url>
+        <product>sle-sdk</product>
+        <product_dir>/</product_dir>
+      </listentry>
+    </add_on_products>
+  </add-on>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <dasd>
+    <devices config:type="list">
+      <listentry>
+        <device>DASD</device>
+        <dev_name>/dev/dasda</dev_name>
+        <channel>0.0.0150</channel>
+        <diag config:type="boolean">false</diag>
+      </listentry>
+    </devices>
+  </dasd>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <services-manager>
+  <default_target>graphical</default_target>
+    <services>
+      <enable config:type="list">
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <keyboard>
+    <keyboard_values>
+      <delay/>
+      <discaps config:type="boolean">false</discaps>
+      <numlock>bios</numlock>
+      <rate/>
+    </keyboard_values>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel>112M</crash_kernel>
+    <crash_xen_kernel>112M\&lt;4G</crash_xen_kernel>
+    <general>
+      <KDUMPTOOL_FLAGS/>
+      <KDUMP_COMMANDLINE/>
+      <KDUMP_COMMANDLINE_APPEND/>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_CPUS/>
+      <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_HOST_KEY/>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>5</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_KERNELVER/>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NET_TIMEOUT>30</KDUMP_NET_TIMEOUT>
+      <KDUMP_NOTIFICATION_CC/>
+      <KDUMP_NOTIFICATION_TO/>
+      <KDUMP_POSTSCRIPT/>
+      <KDUMP_PRESCRIPT/>
+      <KDUMP_REQUIRED_PROGRAMS/>
+      <KDUMP_SAVEDIR>/var/crash</KDUMP_SAVEDIR>
+      <KDUMP_SMTP_PASSWORD/>
+      <KDUMP_SMTP_SERVER/>
+      <KDUMP_SMTP_USER/>
+      <KDUMP_TRANSFER/>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+      <KEXEC_OPTIONS/>
+    </general>
+  </kdump>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list"/>
+  </ntp-client>
+  <software>
+    <image/>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <instsource/>
+    <packages config:type="list">
+      <package>snapper</package>
+      <package>sles-release</package>
+      <package>sle-sdk-release</package>
+      <package>sle-ha-release</package>
+      <package>sle-ha-geo-release</package>
+      <package>kexec-tools</package>
+      <package>kdump</package>
+      <package>iproute2</package>
+      <package>grub2</package>
+      <package>openssh</package>
+      <package>glibc</package>
+      <package>e2fsprogs</package>
+      <package>btrfsprogs</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>32bit</pattern>
+      <pattern>Basis-Devel</pattern>
+      <pattern>Minimal</pattern>
+      <pattern>SDK-C-C++</pattern>
+      <pattern>SDK-Doc</pattern>
+      <pattern>SDK-YaST</pattern>
+      <pattern>WBEM</pattern>
+      <pattern>apparmor</pattern>
+      <pattern>base</pattern>
+      <pattern>dhcp_dns_server</pattern>
+      <pattern>directory_server</pattern>
+      <pattern>documentation</pattern>
+      <pattern>file_server</pattern>
+      <pattern>fips</pattern>
+      <pattern>gateway_server</pattern>
+      <pattern>gnome-basic</pattern>
+      <pattern>ha_geo</pattern>
+      <pattern>ha_sles</pattern>
+      <pattern>hwcrypto</pattern>
+      <pattern>kvm_server</pattern>
+      <pattern>kvm_tools</pattern>
+      <pattern>lamp_server</pattern>
+      <pattern>mail_server</pattern>
+      <pattern>ofed</pattern>
+      <pattern>oracle_server</pattern>
+      <pattern>printing</pattern>
+      <pattern>sap_server</pattern>
+      <pattern>sles-Basis-Devel-32bit</pattern>
+      <pattern>sles-Minimal-32bit</pattern>
+      <pattern>sles-WBEM-32bit</pattern>
+      <pattern>sles-apparmor-32bit</pattern>
+      <pattern>sles-base-32bit</pattern>
+      <pattern>sles-dhcp_dns_server-32bit</pattern>
+      <pattern>sles-directory_server-32bit</pattern>
+      <pattern>sles-documentation-32bit</pattern>
+      <pattern>sles-file_server-32bit</pattern>
+      <pattern>sles-fips-32bit</pattern>
+      <pattern>sles-gateway_server-32bit</pattern>
+      <pattern>sles-hwcrypto-32bit</pattern>
+      <pattern>sles-kvm_server-32bit</pattern>
+      <pattern>sles-kvm_tools-32bit</pattern>
+      <pattern>sles-lamp_server-32bit</pattern>
+      <pattern>sles-mail_server-32bit</pattern>
+      <pattern>sles-ofed-32bit</pattern>
+      <pattern>sles-oracle_server-32bit</pattern>
+      <pattern>sles-printing-32bit</pattern>
+      <pattern>sles-sap_server-32bit</pattern>
+      <pattern>sles-x11-32bit</pattern>
+      <pattern>smt</pattern>
+      <pattern>x11</pattern>
+      <pattern>yast2</pattern>
+    </patterns>
+  </software>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+
+    <addons config:type="list">
+
+      <addon>
+        <!-- SUSE Linux Enterprise High Availability Extension -->
+        <name>sle-ha</name>
+        <version>12.3</version>
+        <arch>s390x</arch>
+        <reg_code>{{SCC_REGCODE_HA}}</reg_code>
+      </addon>
+
+      <addon>
+        <!-- SUSE Linux Enterprise High Availability GEO Extension -->
+        <!-- Depends on: SUSE Linux Enterprise High Availability Extension -->
+        <name>sle-ha-geo</name>
+        <version>12.3</version>
+        <arch>s390x</arch>
+        <reg_code>{{SCC_REGCODE_GEO}}</reg_code>
+      </addon>
+
+      <addon>
+        <!-- SUSE Linux Enterprise Software Development Kit -->
+        <name>sle-sdk</name>
+        <version>12.3</version>
+        <arch>s390x</arch>
+      </addon>
+
+    </addons>
+
+  </suse_register>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id/>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>suse</domain>
+      <hostname>linux-gspv</hostname>
+      <nameservers config:type="list">
+        <nameserver>10.160.0.1</nameserver>
+      </nameservers>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>static</bootproto>
+        <device>eth0</device>
+        <ipaddr>{{HostIP}}</ipaddr>
+        <netmask>255.255.240.0</netmask>
+        <prefixlen>20</prefixlen>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>KERNELS</rule>
+        <value>0.0.0700</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+      <routes config:type="list">
+        <route>
+          <destination>default</destination>
+          <device>eth0</device>
+          <gateway>10.161.159.254</gateway>
+          <netmask>-</netmask>
+        </route>
+      </routes>
+    </routing>
+    <s390-devices config:type="list">
+      <listentry>
+        <chanids>0.0.0700 0.0.0701 0.0.0702</chanids>
+        <portname>no portname required</portname>
+        <type>qeth</type>
+      </listentry>
+      <listentry>
+        <chanids>   </chanids>
+        <type/>
+      </listentry>
+    </s390-devices>
+  </networking>
+  <firewall>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+  </firewall>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Berlin</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact>-1</inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/data/autoyast_sle12/autoyast_sles12sp3+sdk+ha+geo_default_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3+sdk+ha+geo_default_reg_full_s390x.xml
@@ -1,0 +1,306 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/install/SLP/SLE-12-SP3-HA-GEO-GM/s390x/DVD1/]]></media_url>
+        <product>sle-ha-geo</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/install/SLP/SLE-12-SP3-HA-GM/s390x/DVD1/]]></media_url>
+        <product>sle-ha</product>
+        <product_dir>/</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.suse.de/install/SLP/SLE-12-SP3-SDK-GM/s390x/DVD1/]]></media_url>
+        <product>sle-sdk</product>
+        <product_dir>/</product_dir>
+      </listentry>
+    </add_on_products>
+  </add-on>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <dasd>
+    <devices config:type="list">
+      <listentry>
+        <device>DASD</device>
+        <dev_name>/dev/dasda</dev_name>
+        <channel>0.0.0150</channel>
+        <diag config:type="boolean">false</diag>
+      </listentry>
+    </devices>
+  </dasd>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <services-manager>
+  <default_target>graphical</default_target>
+    <services>
+      <enable config:type="list">
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <keyboard>
+    <keyboard_values>
+      <delay/>
+      <discaps config:type="boolean">false</discaps>
+      <numlock>bios</numlock>
+      <rate/>
+    </keyboard_values>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel>112M</crash_kernel>
+    <crash_xen_kernel>112M\&lt;4G</crash_xen_kernel>
+    <general>
+      <KDUMPTOOL_FLAGS/>
+      <KDUMP_COMMANDLINE/>
+      <KDUMP_COMMANDLINE_APPEND/>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_CPUS/>
+      <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_HOST_KEY/>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>5</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_KERNELVER/>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NET_TIMEOUT>30</KDUMP_NET_TIMEOUT>
+      <KDUMP_NOTIFICATION_CC/>
+      <KDUMP_NOTIFICATION_TO/>
+      <KDUMP_POSTSCRIPT/>
+      <KDUMP_PRESCRIPT/>
+      <KDUMP_REQUIRED_PROGRAMS/>
+      <KDUMP_SAVEDIR>/var/crash</KDUMP_SAVEDIR>
+      <KDUMP_SMTP_PASSWORD/>
+      <KDUMP_SMTP_SERVER/>
+      <KDUMP_SMTP_USER/>
+      <KDUMP_TRANSFER/>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+      <KEXEC_OPTIONS/>
+    </general>
+  </kdump>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list"/>
+  </ntp-client>
+  <software>
+    <image/>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <instsource/>
+    <packages config:type="list">
+      <package>snapper</package>
+      <package>sles-release</package>
+      <package>sle-sdk-release</package>
+      <package>sle-ha-release</package>
+      <package>sle-ha-geo-release</package>
+      <package>openssh</package>
+      <package>kexec-tools</package>
+      <package>kdump</package>
+      <package>iproute2</package>
+      <package>grub2</package>
+      <package>glibc</package>
+      <package>e2fsprogs</package>
+      <package>btrfsprogs</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>32bit</pattern>
+      <pattern>Minimal</pattern>
+      <pattern>apparmor</pattern>
+      <pattern>base</pattern>
+      <pattern>documentation</pattern>
+      <pattern>gnome-basic</pattern>
+      <pattern>ha_geo</pattern>
+      <pattern>ha_sles</pattern>
+      <pattern>sles-Minimal-32bit</pattern>
+      <pattern>sles-apparmor-32bit</pattern>
+      <pattern>sles-base-32bit</pattern>
+      <pattern>sles-documentation-32bit</pattern>
+      <pattern>sles-x11-32bit</pattern>
+      <pattern>x11</pattern>
+      <pattern>yast2</pattern>
+    </patterns>
+  </software>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+
+    <addons config:type="list">
+
+      <addon>
+        <!-- SUSE Linux Enterprise High Availability Extension -->
+        <name>sle-ha</name>
+        <version>12.3</version>
+        <arch>s390x</arch>
+        <reg_code>{{SCC_REGCODE_HA}}</reg_code>
+      </addon>
+
+      <addon>
+        <!-- SUSE Linux Enterprise High Availability GEO Extension -->
+        <!-- Depends on: SUSE Linux Enterprise High Availability Extension -->
+        <name>sle-ha-geo</name>
+        <version>12.3</version>
+        <arch>s390x</arch>
+        <reg_code>{{SCC_REGCODE_GEO}}</reg_code>
+      </addon>
+
+      <addon>
+        <!-- SUSE Linux Enterprise Software Development Kit -->
+        <name>sle-sdk</name>
+        <version>12.3</version>
+        <arch>s390x</arch>
+      </addon>
+
+    </addons>
+
+  </suse_register>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id/>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>suse</domain>
+      <hostname>linux-gspv</hostname>
+      <nameservers config:type="list">
+        <nameserver>10.160.0.1</nameserver>
+      </nameservers>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>static</bootproto>
+        <device>eth0</device>
+        <ipaddr>{{HostIP}}</ipaddr>
+        <netmask>255.255.240.0</netmask>
+        <prefixlen>20</prefixlen>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>KERNELS</rule>
+        <value>0.0.0700</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+      <routes config:type="list">
+        <route>
+          <destination>default</destination>
+          <device>eth0</device>
+          <gateway>10.161.159.254</gateway>
+          <netmask>-</netmask>
+        </route>
+      </routes>
+    </routing>
+    <s390-devices config:type="list">
+      <listentry>
+        <chanids>0.0.0700 0.0.0701 0.0.0702</chanids>
+        <portname>no portname required</portname>
+        <type>qeth</type>
+      </listentry>
+      <listentry>
+        <chanids>   </chanids>
+        <type/>
+      </listentry>
+    </s390-devices>
+  </networking>
+  <firewall>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+  </firewall>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Berlin</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact>-1</inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/data/autoyast_sle12/autoyast_sles12sp3_allpatterns_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3_allpatterns_reg_full_s390x.xml
@@ -1,0 +1,286 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <dasd>
+    <devices config:type="list">
+      <listentry>
+        <device>DASD</device>
+        <dev_name>/dev/dasda</dev_name>
+        <channel>0.0.0150</channel>
+        <diag config:type="boolean">false</diag>
+      </listentry>
+    </devices>
+  </dasd>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <services-manager>
+  <default_target>graphical</default_target>
+    <services>
+      <enable config:type="list">
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <keyboard>
+    <keyboard_values>
+      <delay/>
+      <discaps config:type="boolean">false</discaps>
+      <numlock>bios</numlock>
+      <rate/>
+    </keyboard_values>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel>112M</crash_kernel>
+    <crash_xen_kernel>112M\&lt;4G</crash_xen_kernel>
+    <general>
+      <KDUMPTOOL_FLAGS/>
+      <KDUMP_COMMANDLINE/>
+      <KDUMP_COMMANDLINE_APPEND/>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_CPUS/>
+      <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_HOST_KEY/>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>5</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_KERNELVER/>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NET_TIMEOUT>30</KDUMP_NET_TIMEOUT>
+      <KDUMP_NOTIFICATION_CC/>
+      <KDUMP_NOTIFICATION_TO/>
+      <KDUMP_POSTSCRIPT/>
+      <KDUMP_PRESCRIPT/>
+      <KDUMP_REQUIRED_PROGRAMS/>
+      <KDUMP_SAVEDIR>/var/crash</KDUMP_SAVEDIR>
+      <KDUMP_SMTP_PASSWORD/>
+      <KDUMP_SMTP_SERVER/>
+      <KDUMP_SMTP_USER/>
+      <KDUMP_TRANSFER/>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+      <KEXEC_OPTIONS/>
+    </general>
+  </kdump>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list"/>
+  </ntp-client>
+  <software>
+    <image/>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <instsource/>
+    <packages config:type="list">
+      <package>snapper</package>
+      <package>sles-release</package>
+      <package>openssh</package>
+      <package>kexec-tools</package>
+      <package>kdump</package>
+      <package>iproute2</package>
+      <package>grub2</package>
+      <package>glibc</package>
+      <package>e2fsprogs</package>
+      <package>btrfsprogs</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>32bit</pattern>
+      <pattern>Basis-Devel</pattern>
+      <pattern>Minimal</pattern>
+      <pattern>WBEM</pattern>
+      <pattern>apparmor</pattern>
+      <pattern>base</pattern>
+      <pattern>dhcp_dns_server</pattern>
+      <pattern>directory_server</pattern>
+      <pattern>documentation</pattern>
+      <pattern>file_server</pattern>
+      <pattern>fips</pattern>
+      <pattern>gateway_server</pattern>
+      <pattern>gnome-basic</pattern>
+      <pattern>hwcrypto</pattern>
+      <pattern>kvm_server</pattern>
+      <pattern>kvm_tools</pattern>
+      <pattern>lamp_server</pattern>
+      <pattern>mail_server</pattern>
+      <pattern>ofed</pattern>
+      <pattern>oracle_server</pattern>
+      <pattern>printing</pattern>
+      <pattern>sap_server</pattern>
+      <pattern>sles-Basis-Devel-32bit</pattern>
+      <pattern>sles-Minimal-32bit</pattern>
+      <pattern>sles-WBEM-32bit</pattern>
+      <pattern>sles-apparmor-32bit</pattern>
+      <pattern>sles-base-32bit</pattern>
+      <pattern>sles-dhcp_dns_server-32bit</pattern>
+      <pattern>sles-directory_server-32bit</pattern>
+      <pattern>sles-documentation-32bit</pattern>
+      <pattern>sles-file_server-32bit</pattern>
+      <pattern>sles-fips-32bit</pattern>
+      <pattern>sles-gateway_server-32bit</pattern>
+      <pattern>sles-hwcrypto-32bit</pattern>
+      <pattern>sles-kvm_server-32bit</pattern>
+      <pattern>sles-kvm_tools-32bit</pattern>
+      <pattern>sles-lamp_server-32bit</pattern>
+      <pattern>sles-mail_server-32bit</pattern>
+      <pattern>sles-ofed-32bit</pattern>
+      <pattern>sles-oracle_server-32bit</pattern>
+      <pattern>sles-printing-32bit</pattern>
+      <pattern>sles-sap_server-32bit</pattern>
+      <pattern>sles-x11-32bit</pattern>
+      <pattern>smt</pattern>
+      <pattern>x11</pattern>
+      <pattern>yast2</pattern>
+    </patterns>
+  </software>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+  </suse_register>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id/>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>suse</domain>
+      <hostname>linux-gspv</hostname>
+      <nameservers config:type="list">
+        <nameserver>10.160.0.1</nameserver>
+      </nameservers>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>static</bootproto>
+        <device>eth0</device>
+        <ipaddr>{{HostIP}}</ipaddr>
+        <netmask>255.255.240.0</netmask>
+        <prefixlen>20</prefixlen>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>KERNELS</rule>
+        <value>0.0.0700</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+      <routes config:type="list">
+        <route>
+          <destination>default</destination>
+          <device>eth0</device>
+          <gateway>10.161.159.254</gateway>
+          <netmask>-</netmask>
+        </route>
+      </routes>
+    </routing>
+    <s390-devices config:type="list">
+      <listentry>
+        <chanids>0.0.0700 0.0.0701 0.0.0702</chanids>
+        <portname>no portname required</portname>
+        <type>qeth</type>
+      </listentry>
+      <listentry>
+        <chanids>   </chanids>
+        <type/>
+      </listentry>
+    </s390-devices>
+  </networking>
+  <firewall>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+  </firewall>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Berlin</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact>-1</inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/data/autoyast_sle12/autoyast_sles12sp3_default_reg_full_s390x.xml
+++ b/data/autoyast_sle12/autoyast_sles12sp3_default_reg_full_s390x.xml
@@ -132,7 +132,7 @@
   </software>
   <suse_register>
     <do_registration config:type="boolean">true</do_registration>
-    <reg_code>25af9a31773574ab</reg_code>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
     <install_updates config:type="boolean">true</install_updates>
   </suse_register>
   <networking>

--- a/tests/autoyast/prepare_profile.pm
+++ b/tests/autoyast/prepare_profile.pm
@@ -24,7 +24,7 @@ sub run {
     # Return if profile is not available
     return unless $profile;
     # Expand variables
-    my @vars = qw(SCC_REGCODE SCC_URL VERSION ARCH HostIP);
+    my @vars = qw(SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_URL VERSION ARCH HostIP);
     for my $var (@vars) {
         my $value;
         if ($var eq 'HostIP') {


### PR DESCRIPTION
add those profiles for s390x zVM upgrade test cases
those files include default and all patterns,registered and fully update


- Related ticket: https://progress.opensuse.org/issues/33481
- Verification run: 
   SLES12 SP3, default install, proxy SCC -- http://bartok.arch.suse.de/tests/239
   SLES12 SP3, all patterns, Packages media  -- http://bartok.arch.suse.de/tests/237
   SLES12 SP3 + SDK + HA + Geo, all patterns, proxy SCC -- http://bartok.arch.suse.de/tests/233
   SLES12 SP3 + SDK + HA + Geo, default install, Packages media -- http://bartok.arch.suse.de/tests/236
   SLES12 SP3, all addons, default install, proxy SCC -- http://bartok.arch.suse.de/tests/232
   SLES12 SP3, all addons, all patterns, Packages media -- http://bartok.arch.suse.de/tests/238
