### PR TITLE
Press Enter on CaaSP/Kubic Grub screen like openSUSE grub_test

### DIFF
--- a/tests/caasp/first_boot.pm
+++ b/tests/caasp/first_boot.pm
@@ -23,6 +23,7 @@ sub run {
     # On DVD images stall prevents reliable matching of BIOS needle - poo#28648
     if (is_caasp('DVD') && !get_var('AUTOYAST')) {
         assert_screen 'grub2';
+        send_key 'ret';
     }
 
     # Check ssh keys & ip information are displayed


### PR DESCRIPTION
Now we're using openSUSE's installation tests, we need Kubic's grub_test to be more like openSUSE's

https://openqa.opensuse.org/tests/646356#step/first_boot/3

