### PR TITLE
Kubic - check for grub when rebooting

### DIFF
--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -74,7 +74,10 @@ sub process_reboot {
     power_action('reboot', observe => !$trigger, keepconsole => 1);
 
     # No grub bootloader on xen-pv
-    # grub2 needle is unreliable (stalls during timeout) - poo#28648
+    if (is_caasp('DVD') && !get_var('AUTOYAST')) {
+        assert_screen 'grub2';
+        send_key 'ret';
+    }
 
     assert_screen 'linux-login-casp', 180;
     select_console 'root-console';


### PR DESCRIPTION
poo28648 has been worked around, so we need to assert grub again

https://openqa.opensuse.org/tests/646658#step/overlayfs/10