### PR TITLE
Update yast_scc_registration to wait longer for registration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -182,7 +182,7 @@ sub fill_in_registration_data {
 
     my @known_untrusted_keys = qw(import-trusted-gpg-key-nvidia-F5113243C66B6EAE import-trusted-gpg-key-phub-9C214D4065176565);
     unless (get_var('SCC_REGISTER', '') =~ /addon|network/) {
-        my $counter = 30;
+        my $counter = 50;
         my @tags
           = qw(local-registration-servers registration-online-repos import-untrusted-gpg-key module-selection contacting-registration-server refreshing-repository);
         if (get_var('SCC_URL') || get_var('SMT_URL')) {
@@ -192,6 +192,7 @@ sub fill_in_registration_data {
         # https://bugzilla.suse.com/show_bug.cgi?id=1070031#c11
         push @tags, 'inst-addon' if is_sle('15+') && is_sle12_hdd_in_upgrade;
         while ($counter--) {
+            die 'Registration repeated too much. Check if SCC is down.' if ($counter eq 1);
             assert_screen(\@tags);
             if (match_has_tag("import-untrusted-gpg-key")) {
                 if (check_var("IMPORT_UNTRUSTED_KEY", 1) || check_screen(\@known_untrusted_keys, 0)) {
@@ -247,7 +248,6 @@ sub fill_in_registration_data {
             elsif (match_has_tag('inst-addon')) {
                 return;
             }
-            die 'Registration repeated too much. Check if SCC is down.' if ($counter eq 1);
         }
     }
 
@@ -354,6 +354,7 @@ sub fill_in_registration_data {
             # start addons/modules registration, it needs longer time if select multiple or all addons/modules
             my $counter = 50;
             while ($counter--) {
+                die 'Addon registration repeated too much. Check if SCC is down.' if ($counter eq 1);
                 assert_screen [
                     qw(import-untrusted-gpg-key yast_scc-pkgtoinstall yast-scc-emptypkg inst-addon contacting-registration-server refreshing-repository)];
                 if (match_has_tag('import-untrusted-gpg-key')) {
@@ -414,7 +415,6 @@ sub fill_in_registration_data {
                     # it would show software install dialog if scc registration correctly by yast2 scc
                     last;
                 }
-                die 'Addon registration repeated too much. Check if SCC is down.' if ($counter eq 1);
             }
         }
         else {


### PR DESCRIPTION
Longer time is required to contact the registration server during
upgrade to SLE 15 via SCC, especially in case with multiple addons
installed on the original system
Also fix the issue that test never shows an explicit reason when
fails at contacting registration server

- Related ticket: https://progress.opensuse.org/issues/33922
- Needles: None
- Verification run: 
   * proxyscc_upgrade_sles12sp3+ha+geo+sdk+we@64bit-smp: http://openqa-apac1.suse.de/tests/620
