### PR TITLE
Migrate two xdmcp cases to SLED15

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -874,6 +874,18 @@ sub configure_static_ip_nm {
     wait_screen_change { send_key 'alt-f4' };
 }
 
+# Open the firewall port of xdmcp service
+sub configure_xdmcp_firewall {
+    # Open the firewall port of xdmcp service
+    if (is_sle '15+') {
+        assert_script_run 'firewall-cmd --permanent --zone=public --add-port=6000-6010/tcp';
+        assert_script_run 'firewall-cmd --permanent --zone=public --add-port=177/udp';
+        assert_script_run 'firewall-cmd --reload';
+    }
+    else {
+        assert_script_run 'yast2 firewall services add zone=EXT service=service:xdmcp';
+    }
+}
 
 1;
 # vim: set sw=4 et:

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -426,7 +426,7 @@ sub load_x11_remote {
     elsif (check_var('REMOTE_DESKTOP_TYPE', 'persistent_vnc')) {
         loadtest 'x11/remote_desktop/persistent_vncsession_xvnc';
         loadtest 'x11/remote_desktop/x11_forwarding_openssh';
-        loadtest 'x11/remote_desktop/xdmcp_gdm' if is_sle('<15');
+        loadtest 'x11/remote_desktop/xdmcp_gdm';
     }
     # load xdmcp with xdm testing
     elsif (check_var('REMOTE_DESKTOP_TYPE', 'xdmcp_xdm')) {

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -286,12 +286,12 @@ sub setup_xdmcp_server {
     return if $xdmcp_server_set;
 
     if (check_var('REMOTE_DESKTOP_TYPE', 'xdmcp_xdm')) {
-        script_run "sed -i -e 's|^DISPLAYMANAGER=.*|DISPLAYMANAGER=\"xdm\"|' /etc/sysconfig/displaymanager";
-        script_run "sed -i -e 's|^DEFAULT_WM=.*|DEFAULT_WM=\"icewm\"|' /etc/sysconfig/windowmanager";
+        assert_script_run "sed -i -e 's|^DISPLAYMANAGER=.*|DISPLAYMANAGER=\"xdm\"|' /etc/sysconfig/displaymanager";
+        assert_script_run "sed -i -e 's|^DEFAULT_WM=.*|DEFAULT_WM=\"icewm\"|' /etc/sysconfig/windowmanager";
     }
-    script_run 'yast2 firewall services add zone=EXT service=service:xdmcp';
-    script_run "sed -i -e 's|^DISPLAYMANAGER_REMOTE_ACCESS=.*|DISPLAYMANAGER_REMOTE_ACCESS=\"yes\"|' /etc/sysconfig/displaymanager";
-    script_run "sed -i -e 's|^\\[xdmcp\\]|\\[xdmcp\\]\\nMaxSessions=2|' /etc/gdm/custom.conf";
+    assert_script_run 'yast2 firewall services add zone=EXT service=service:xdmcp';
+    assert_script_run "sed -i -e 's|^DISPLAYMANAGER_REMOTE_ACCESS=.*|DISPLAYMANAGER_REMOTE_ACCESS=\"yes\"|' /etc/sysconfig/displaymanager";
+    assert_script_run "sed -i -e 's|^\\[xdmcp\\]|\\[xdmcp\\]\\nMaxSessions=2|' /etc/gdm/custom.conf";
     systemctl('restart display-manager');
     assert_screen 'displaymanager';
     select_console 'root-console';

--- a/tests/x11/remote_desktop/xdmcp_gdm.pm
+++ b/tests/x11/remote_desktop/xdmcp_gdm.pm
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
-# Summary: Remote Login: XDMCP with gdm and SLE-Classic configured
+# Summary: Remote Login: XDMCP with gdm and GNOME session configured
 # Maintainer: Chingkai <qkzhu@suse.com>
 # Tags: tc#1586203
 
@@ -23,8 +23,11 @@ use base 'x11test';
 use testapi;
 use lockapi;
 use utils;
+use version_utils 'is_sle';
 
 sub run {
+    my ($self) = @_;
+
     # Wait for supportserver if not yet ready
     mutex_lock 'dhcp';
     mutex_unlock 'dhcp';
@@ -34,7 +37,7 @@ sub run {
     x11_start_program('xterm');
     become_root;
     assert_script_run 'dhclient';
-    assert_script_run 'yast2 firewall services add zone=EXT service=service:xdmcp';
+    $self->configure_xdmcp_firewall;
     type_string "exit\n";
 
     # Remote access SLES via Xephyr

--- a/tests/x11/remote_desktop/xdmcp_xdm.pm
+++ b/tests/x11/remote_desktop/xdmcp_xdm.pm
@@ -21,8 +21,11 @@ use strict;
 use base 'x11test';
 use testapi;
 use lockapi;
+use version_utils 'is_sle';
 
 sub run {
+    my ($self) = @_;
+
     # Wait for supportserver if not yet ready
     mutex_lock 'dhcp';
     mutex_unlock 'dhcp';
@@ -32,7 +35,7 @@ sub run {
     x11_start_program('xterm');
     become_root;
     assert_script_run 'dhclient';
-    assert_script_run 'yast2 firewall services add zone=EXT service=service:xdmcp';
+    $self->configure_xdmcp_firewall;
     type_string "exit\n";
 
     # Remote access SLES via Xephyr


### PR DESCRIPTION
- Migrate xdmcp_gdm, xdmcp_xdm to SLED15, the steps of setting firewall were updated since we are using firewalld in SLE15
- Replace script_run with assert_script_run for xdmcp supportserver setup in setup.pm

---

- Related ticket: https://progress.opensuse.org/issues/31489
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/791
- Verification runs:

  xdmcp_xdm: http://10.67.17.30/tests/356
  xdmcp_gdm: http://10.67.17.30/tests/357
