### PR TITLE
Add default modules for SLES15 media migration

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -15,7 +15,7 @@ use strict;
 use base "y2logsstep";
 use testapi;
 use utils 'addon_license';
-use version_utils 'is_sle';
+use version_utils qw(is_sle sle_version_at_least);
 use qam 'advance_installer_window';
 use registration qw(%SLE15_DEFAULT_MODULES rename_scc_addons);
 
@@ -43,6 +43,13 @@ sub handle_all_packages_medium {
     # The legacy module is required if upgrade from previous version (bsc#1066338)
     push @addons, 'legacy' if get_var('UPGRADE') && !grep(/^legacy$/, @addons);
 
+    # For SLES12SPx and SLES11SPx to SLES15 migration, need add the demand module at least for media migration manually
+    if (get_var('MEDIA_UPGRADE') && !sle_version_at_least('15', version_variable => 'HDDVERSION') && !check_var('SLE_PRODUCT', 'sled')) {
+        my @demand_addon = qw(contm desktop legacy serverapp script);
+        for my $a (@demand_addon) {
+            push @addons, $a if !grep(/^$a$/, @addons);
+        }
+    }
     # In upgrade testing, the sle addons, including extensions and modules,
     # are defined with SCC_ADDONS, thus the addons could be patched on
     # the original system (the system-to-be-upgraded).


### PR DESCRIPTION
Add follow modules for SLES12SPx&SLSE11 to SLES15 migration
SLE-Product-SLES15
SLE-Module-Basesystem15
SLE-Module-Containers15
SLE-Module-Desktop-Applications15
SLE-Module-Legacy15
SLE-Module-Server-Applications15
SLE-Module-Web-Scripting15
- See poo#34021

- Related ticket: https://progress.opensuse.org/issues/34021
- Verification run: http://10.67.17.147/tests/2256
