### PR TITLE
[WIP] Increase kdump memory in ppc64le

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -99,7 +99,17 @@ sub activate_kdump {
         assert_screen \@tags, 300;
         # enable kdump if it is not already
         wait_screen_change { send_key 'alt-u' } if match_has_tag('yast2-kdump-disabled');
-        wait_screen_change { send_key 'alt-o' } if match_has_tag('yast2-kdump-enabled');
+        if (match_has_tag('yast2-kdump-enabled')) {
+            if (check_var('ARCH', 'ppc64le')) {
+                record_soft_failure 'bsc#XXXXXX -- fail to create kdump in ppc with Kdump Memory suggested in YaST2';
+                wait_screen_change { send_key 'alt-y' };
+                type_string '512';
+                send_key 'ret';
+                wait_still_screen;
+                save_screenshot;
+            }
+            wait_screen_change { send_key 'alt-o' }
+        }
         wait_screen_change { send_key 'alt-o' } if match_has_tag('yast2-kdump-restart-info');
         wait_screen_change { send_key 'alt-i' } if match_has_tag('yast2-missing_package');
     } until (match_has_tag('yast2_console-finished'));

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -123,7 +123,7 @@ sub add_suseconnect_product {
     $version //= scc_version();
     $arch    //= get_required_var('ARCH');
     $params  //= '';
-    assert_script_run("SUSEConnect -p $name/$version/$arch $params");
+    assert_script_run("SUSEConnect -p $name/$version/$arch $params", 120);
 }
 
 =head2 remove_suseconnect_product


### PR DESCRIPTION
Add a soft-failure to avoid kdumptool gets killed by OOM in ppc64le. Besides that, I needed to increase the timeout for SUSEConnect in my remote worker.
- Related ticket: https://progress.opensuse.org/issues/33376