### PR TITLE
Fix sporadic boot issue on aarch64 with TianoCore

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -545,10 +545,12 @@ sub specific_caasp_params {
 }
 
 sub tianocore_enter_menu {
-    # press F2 and be quick about it
-    send_key_until_needlematch('tianocore-mainmenu', 'f2', 15, 1);
+    # we need to reduce this waiting time as much as possible
+    while (!check_screen('tianocore-mainmenu', 0, no_wait => 1)) {
+        send_key 'f2';
+        sleep 0.1;
+    }
 }
-
 
 sub tianocore_select_bootloader {
     tianocore_enter_menu;


### PR DESCRIPTION
`boot_to_desktop` sometimes fails in HA tests: https://openqa.suse.de/tests/1582829#step/boot_to_desktop%231/19

This happens mainly on aarch64, sometimes on x86_64. After investigation, this is because node01 fencing can takes time, and `boot_to_desktop` test is started too soon.

So, adding an `assert_screen` before entering UEFI menu in `handle_uefi_boot_disk_workaround` do the job and work for all existing tests that use `boot_to_desktop`.

- Related ticket: https://progress.opensuse.org/issues/34183
- Needles: Not needed
- Verification run: http://1b147.qa.suse.de/tests/768, http://1b147.qa.suse.de/tests/770 and http://1b147.qa.suse.de/tests/773 on aarch64, and http://1b147.qa.suse.de/tests/766 on x86_64 (not impacted but to be sure)