### PR TITLE
Move libnuma-devel to maybedeps for s390x

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -92,7 +92,6 @@ sub install_build_dependencies {
       libacl-devel
       libaio-devel
       libcap-devel
-      libnuma-devel
       libopenssl-devel
       libselinux-devel
       libtirpc-devel
@@ -107,6 +106,7 @@ sub install_build_dependencies {
       libacl-devel-32bit
       libaio-devel-32bit
       libcap-devel-32bit
+      libnuma-devel
       libnuma-devel-32bit
       libopenssl-devel-32bit
       libselinux-devel-32bit


### PR DESCRIPTION
[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
