### PR TITLE
Increase wait timeout for rescue mode to boot

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -42,7 +42,7 @@ sub snapper_nodbus_setup {
     my ($self) = @_;
     if (script_run('! systemctl is-active dbus')) {
         script_run('systemctl rescue', 0);
-        assert_screen('emergency-shell', 10);
+        assert_screen 'emergency-shell';
         type_password;
         send_key 'ret';
         $self->set_standard_prompt('root');


### PR DESCRIPTION
The commit resolves an issue when 'snapper_nodbus_setup' and 'snapper_thin_lvm' randomly fail to get into emergency shell.

Waiting timeout was increased from 10 sec to the default for 'assert_screen' 30 sec.

- Related ticket: https://progress.opensuse.org/issues/32371
- Verification runs: All the runs from http://10.160.64.32/tests/32 to http://10.160.64.32/tests/69

