### PR TITLE
Add support for offline installation

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -236,6 +236,7 @@ sub is_kernel_test {
 }
 
 sub replace_opensuse_repos_tests {
+    return if get_var('OFFLINE_SUT');
     loadtest "update/zypper_clear_repos";
     loadtest "console/zypper_ar";
     loadtest "console/zypper_ref";
@@ -493,9 +494,9 @@ sub load_system_role_tests {
     if (!get_var("REMOTE_CONTROLLER") && !check_var('BACKEND', 'ipmi') && !is_hyperv_in_gui && !get_var("LIVECD")) {
         loadtest "installation/logpackages";
     }
-    loadtest "installation/disable_online_repos"       if get_var('DISABLE_ONLINE_REPOS');
+    loadtest "installation/disable_online_repos" if get_var('DISABLE_ONLINE_REPOS') && !get_var('OFFLINE_SUT');
     loadtest "installation/installer_desktopselection" if is_opensuse;
-    loadtest "installation/system_role"                if is_caasp('kubic');
+    loadtest "installation/system_role" if is_caasp('kubic');
 }
 
 sub installzdupstep_is_applicable {
@@ -689,6 +690,7 @@ sub load_inst_tests {
     if (is_sle '15+') {
         loadtest "installation/accept_license" if get_var('HASLICENSE');
     }
+    loadtest 'installation/network_configuration' if get_var('OFFLINE_SUT');
     if (get_var('IBFT')) {
         loadtest "installation/iscsi_configuration";
     }

--- a/tests/installation/installer_desktopselection.pm
+++ b/tests/installation/installer_desktopselection.pm
@@ -44,7 +44,7 @@ sub run {
     send_key 'spc';                                                            # Select the desktop
 
     assert_screen "$d-selected";
-    if (check_var('VERSION', 'Tumbleweed')) {
+    if (check_var('VERSION', 'Tumbleweed') && !get_var('OFFLINE_SUT')) {
         send_key 'alt-o';                                                      # configure online repos
         wait_still_screen 3;                                                   # wait for the potential 'low memory warning' to show up
         assert_screen 'repo-list';

--- a/tests/installation/network_configuration.pm
+++ b/tests/installation/network_configuration.pm
@@ -18,13 +18,18 @@ use testapi;
 use registration 'assert_registration_screen_present';
 
 sub run {
-    assert_registration_screen_present;
-    send_key 'alt-w';    # Network Configuration
-    assert_screen 'inst-network';
-    send_key 'alt-s';    # Hostname/DNS
-    assert_screen 'inst-network-hostname-dns-tab';
-    assert_and_click 'inst-network-hostname-dhcp';
-    assert_and_click 'inst-network-hostname-dhcp-modified';
+    if (get_var 'OFFLINE_SUT') {
+        assert_screen 'inst-networksettings';
+    }
+    else {
+        assert_registration_screen_present;
+        send_key 'alt-w';    # Network Configuration
+        assert_screen 'inst-network';
+        send_key 'alt-s';    # Hostname/DNS
+        assert_screen 'inst-network-hostname-dns-tab';
+        assert_and_click 'inst-network-hostname-dhcp';
+        assert_and_click 'inst-network-hostname-dhcp-modified';
+    }
     send_key $cmd{next};
 }
 


### PR DESCRIPTION
https://progress.opensuse.org/issues/33262

Successfull local run: http://artemis.suse.de/tests/143

Settings to be used for new Testsuite:
```cfg
DESKTOP=textmode
INSTALLONLY=1
OFFLINE_SUT=1
VIDEOMODE=text
```