### PR TITLE
Fix steam on non-x86_64 and unsynchronized typing

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1285,8 +1285,8 @@ sub load_extra_tests_desktop {
             }
             loadtest "x11/seahorse";
             # only scheduled on gnome and was developed only for gnome but no
-            # special reason should prevent it to be scheduled in another DE
-            loadtest 'x11/steam';
+            # special reason should prevent it to be scheduled in another DE.
+            loadtest 'x11/steam' if check_var('ARCH', 'x86_64');
         }
 
         if (chromestep_is_applicable()) {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -167,7 +167,7 @@ Disable screensaver in gnome. To be called from a command prompt, for example an
 
 =cut
 sub turn_off_gnome_screensaver {
-    type_string "gsettings set org.gnome.desktop.session idle-delay 0\n";
+    script_run 'gsettings set org.gnome.desktop.session idle-delay 0';
 }
 
 


### PR DESCRIPTION
* Fix unsynchronized typing in turn_off_gnome_screensaver
* Correct 'steam' test schedule to x86_64 only