### PR TITLE
toolchain: Don't fail the test if package does not exist

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -92,7 +92,7 @@ sub prepare_for_kdump {
 sub activate_kdump {
     # activate kdump
     type_string "echo \"remove potential harmful nokogiri package boo#1047449\"\n";
-    zypper_call('rm -y ruby2.1-rubygem-nokogiri');
+    zypper_call('rm -y ruby2.1-rubygem-nokogiri', exitcode => [0, 104]);
     script_run 'yast2 kdump', 0;
     my @tags = qw(yast2-kdump-disabled yast2-kdump-enabled yast2-kdump-restart-info yast2-missing_package yast2_console-finished);
     do {


### PR DESCRIPTION
also accepts zyppers' exit code 104 if package does not exist
[related poo](https://progress.opensuse.org/issues/34255)