### PR TITLE
sysauth: Port from legacy python-PAM to maintained python3-pam

### DIFF
--- a/data/sssd-tests/pamtest.py
+++ b/data/sssd-tests/pamtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 Call PAM service to test user credentials.
@@ -6,34 +6,19 @@ Return status 0 on success, 1 on error.
 Invocation: <service_name> <user_name> <plain_password>
 '''
 
-import sys, PAM
+import sys, pam
 
 if len(sys.argv) != 1 + 3:
 	sys.exit(1)
 
 (_, service, user, password) = sys.argv
 
-def pamconv(auth, qlist):
-	resp = []
-	for (query,hint) in qlist:
-		if hint == PAM.PAM_PROMPT_ECHO_ON or hint == PAM.PAM_PROMPT_ECHO_OFF:
-			resp.append((password, 0))
-		elif hint == PAM.PAM_PROMPT_ERROR_MSG or hint == PAM.PAM_PROMPT_TEXT_INFO:
-			print query
-			resp.append(('', 0));
-		else:
-			return None
-	return resp
-
-pam = PAM.pam()
-pam.start(service)
-pam.set_item(PAM.PAM_USER, user)
-pam.set_item(PAM.PAM_CONV, pamconv)
-
+p = pam.pam()
 try:
-	pam.authenticate()
-	pam.acct_mgmt()
+	ret=p.authenticate(user, password, service)
 except Exception as e:
 	print(e)
 	sys.exit(1)
+if ret: sys.exit(0)
+else: sys.exit(1)
 

--- a/tests/sysauth/sssd.pm
+++ b/tests/sysauth/sssd.pm
@@ -23,7 +23,7 @@ sub run {
 
     # Install test subjects and test scripts
     my @test_subjects = qw(
-      python-pam
+      python3-python-pam
       sssd sssd-krb5 sssd-krb5-common sssd-ldap sssd-tools
       openldap2 openldap2-client
       krb5 krb5-client krb5-server krb5-plugin-kdb-ldap


### PR DESCRIPTION
Port to the newer ctype python pam module and python3

- Related ticket: https://progress.opensuse.org/issues/31246
- Needles: N/A
- Verification run: http://dimstar.internet-box.ch:81/tests/87
