### PR TITLE
Kill PackageKit if it blocks YaST (poo#33517)

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -43,7 +43,14 @@ sub search {
 
 sub start_addon_products {
     assert_and_click 'yast2_control-center_add-on';
-    assert_screen 'yast2_control-center_add-on_installed', timeout => 180;
+
+    my @tags = qw(yast2_control-center_add-on_installed yast2_control-center-ask_packagekit_to_quit);
+    do {
+        assert_screen \@tags;
+        # Let it kill PackageKit, in case it is running.
+        wait_screen_change { send_key 'alt-y' } if match_has_tag('yast2_control-center-ask_packagekit_to_quit');
+    } until (match_has_tag('yast2_control-center_add-on_installed'));
+
     send_key 'alt-o';
     assert_screen 'yast2-control-center-ui', timeout => 60;
 }


### PR DESCRIPTION
The clicking approach works – using a wisely selected needle even with all the repeated dialogs that ask to try to quit again.

- Related ticket: https://progress.opensuse.org/issues/33517
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/349
- Verification run: http://boltzmann.suse.de/tests/55
It maybe fails due to missing needles for another issue.


