### PR TITLE
scc_registration: Check for correct needle-tag

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -310,7 +310,7 @@ sub fill_in_registration_data {
             # remove emty elements
             @scc_addons = grep { $_ ne '' } @scc_addons;
 
-            if (!(check_screen 'scc_module-phub', 0)) {
+            if (!(check_screen 'scc-module-phub', 0)) {
                 record_soft_failure 'boo#1056047';
                 #find and remove phub
                 @scc_addons = grep { !/phub/ } @scc_addons;


### PR DESCRIPTION
```
[2018-04-05T02:25:01.0238 CEST] [debug] <<< testapi::check_screen(mustmatch='scc_module-phub', timeout=0)
[2018-04-05T02:25:01.0242 CEST] [debug] NO matching needles for scc_module-phub
```

the needle with the tag `scc-module-phub` exists, but was never found due to this typo