### PR TITLE
Do not replace online repos for maintenance and update tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -39,6 +39,7 @@ our @EXPORT = qw(
   is_server
   is_sles4sap
   is_sles4sap_standard
+  is_updates_tests
   need_clear_repos
   have_scc_repos
   load_svirt_vm_setup_tests
@@ -239,8 +240,15 @@ sub replace_opensuse_repos_tests {
     loadtest "console/zypper_ar";
 }
 
+sub is_updates_tests {
+    my $flavor = get_required_var('FLAVOR');
+    # Incidents might be also Incidents-Gnome or Incidents-Kernel
+    # -Updates changed to just Updates, and added Maintenance$ to match flavor for openSUSE
+    return $flavor =~ /Updates$/ || $flavor =~ /-Incidents/ || $flavor =~ /Maintenance$/;
+}
+
 sub is_repo_replacement_required {
-    return is_opensuse && !is_staging && !get_var('KEEP_ONLINE_REPOS');
+    return is_opensuse() && !is_staging() && !get_var('KEEP_ONLINE_REPOS') && !is_updates_tests();
 }
 
 sub is_memtest {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -28,12 +28,6 @@ use main_common;
 
 init_main();
 
-sub is_updates_tests {
-    my $flavor = get_required_var('FLAVOR');
-    # Incidents might be also Incidents-Gnome or Incidents-Kernel
-    return $flavor =~ /-Updates$/ || $flavor =~ /-Incidents/;
-}
-
 sub is_new_installation {
     return !get_var('UPGRADE') && !get_var('ONLINE_MIGRATION') && !get_var('ZDUP') && !get_var('AUTOUPGRADE');
 }

--- a/tests/console/zypper_ar.pm
+++ b/tests/console/zypper_ar.pm
@@ -30,7 +30,7 @@ sub run {
     }
     else {
         # non-NET installs have only milestone repo, which might be incompatible.
-        my $repourl = 'http://' . get_var("SUSEMIRROR");
+        my $repourl = 'http://' . get_required_var("SUSEMIRROR");
         unless (get_var("FULLURL")) {
             $repourl = $repourl . "/repo/oss";
         }


### PR DESCRIPTION
Another regression introduced by
[PR#4679](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4679).
We should not schedule these module for maintenance and update tests.

See [poo#32038](https://progress.opensuse.org/issues/32038) and parent
[poo#17436](https://progress.opensuse.org/issues/17436).

- Verification runs: 
  * [update test](http://gershwin.arch.suse.de/tests/219)
  * [maintenance test](http://gershwin.arch.suse.de/tests/218)
