### PR TITLE
rails: Generate new app with --skip-bundle and --skip-test

### DIFF
--- a/tests/console/rails.pm
+++ b/tests/console/rails.pm
@@ -21,9 +21,9 @@ sub run {
     # need to handle this on our own
     my $cmd = <<'EOF';
 zypper -n in -C "rubygem(rails)"
-rails new -B mycoolapp
+rails new mycoolapp --skip-bundle --skip-test
 cd mycoolapp
-(rails server &)
+(rails server -b 0.0.0.0 &)
 for i in {1..100} ; do sleep 0.1; curl -s http://localhost:3000 | grep "<title>Ruby on Rails" && break ; done
 pkill -f "rails server" || pumactl -P tmp/pids/server.pid stop
 EOF


### PR DESCRIPTION
Reorder the command line, as parameters must appear AFTER the
application name, or they are being swallowed.

Regarding the parameters:
--skip-bundle was already in the test before (as -B), but writing things
out makes it more obvious.
--skip-test is needed as not all test modules are being packaged for
openSUSE. For regular development work this is fine, as those modules
are automatically installed using bundle install for the users.

Add -b 0.0.0.0 (bind all interfaces) to the rails server call as the
openQA setup fails to identify it automatically (reverse hostname
lookup)

https://bugzilla.opensuse.org/show_bug.cgi?id=1069441

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1069441
- Needles: N/A
- Verification run: http://dimstar.internet-box.ch:81/tests/92
