### PR TITLE
Use power_action() in user_defined_snapshot

### DIFF
--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2017 SUSE LLC
+# Copyright © 2016-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -52,7 +52,7 @@ sub run {
     send_key_until_needlematch([qw(grub_comment)], 'pgdn');
     # C'l'ose  the snapper module
     send_key "alt-l";
-    type_string "reboot\n";
+    power_action('reboot', keepconsole => 1, textmode => 1);
 
     $self->handle_uefi_boot_disk_workaround() if get_var('MACHINE') =~ qr'aarch64';
     assert_screen "grub2";
@@ -72,6 +72,7 @@ sub run {
     $self->wait_boot(textmode => 1, in_grub => 1);
     # request reboot again to ensure we will end up in the original system
     send_key 'ctrl-alt-delete';
+    power_action('reboot', keepconsole => 1, textmode => 1, observe => 1);
     $self->wait_boot;
 }
 


### PR DESCRIPTION
Xen has to use `power_action()` when the operating system is restarted
for the restart to work reliably.

Fails here: https://openqa.suse.de/tests/1589864
Validation run: http://nilgiri.suse.cz/tests/277

Needle associated with a test further down the road in the test suite: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/796

https://progress.opensuse.org/issues/34348