### PR TITLE
Do not schedule zypper_info on hyperv and refresh replaced repos for openSUSE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -238,6 +238,7 @@ sub is_kernel_test {
 sub replace_opensuse_repos_tests {
     loadtest "update/zypper_clear_repos";
     loadtest "console/zypper_ar";
+    loadtest "console/zypper_ref";
 }
 
 sub is_updates_tests {
@@ -964,11 +965,13 @@ sub load_consoletests {
     if (have_scc_repos()) {
         loadtest "console/yast_scc";
     }
-    # If is_repo_replacement_required returns true, we already have added mirror repo
-    if (have_addn_repos() && !is_repo_replacement_required()) {
-        loadtest "console/zypper_ar";
+    # If is_repo_replacement_required returns true, we already have added mirror repo and refreshed repos
+    if (!is_repo_replacement_required()) {
+        if (have_addn_repos()) {
+            loadtest "console/zypper_ar";
+        }
+        loadtest "console/zypper_ref";
     }
-    loadtest "console/zypper_ref";
     loadtest "console/ncurses";
     loadtest "console/yast2_lan" unless is_bridged_networking;
     # no local certificate store

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -18,7 +18,7 @@ use testapi qw(check_var get_var get_required_var set_var check_var_array diag);
 use autotest;
 use utils;
 use version_utils qw(
-  is_hyperv is_hyperv_in_gui is_jeos is_gnome_next is_krypton_argon is_leap is_opensuse is_sle is_sles4sap is_sles4sap_standard sle_version_at_least is_desktop_installed is_installcheck is_rescuesystem is_staging is_tumbleweed is_virtualization_server is_caasp
+  is_hyperv is_hyperv_in_gui is_jeos is_gnome_next is_krypton_argon is_leap is_opensuse is_sle is_sles4sap is_sles4sap_standard sle_version_at_least is_desktop_installed is_installcheck is_rescuesystem is_staging is_tumbleweed is_virtualization_server is_caasp is_upgrade
 );
 use bmwqemu ();
 use strict;
@@ -249,7 +249,7 @@ sub is_updates_tests {
 }
 
 sub is_repo_replacement_required {
-    return is_opensuse() && !is_staging() && !get_var('KEEP_ONLINE_REPOS') && !is_updates_tests();
+    return is_opensuse() && !is_staging() && !get_var('KEEP_ONLINE_REPOS') && !is_updates_tests() && !is_upgrade();
 }
 
 sub is_memtest {
@@ -931,9 +931,10 @@ sub load_consoletests {
     # rely on default repos we get after installation.
     # The test can't be run on JeOS as it's heavily dependant
     # on repos from installation medium.
-    # We also don't have any repos on staging and update tests.
+    # We also don't have any repos on staging and update/upgrade tests.
     # This test uses serial console too much to be reliable on Hyper-V (poo#30613)
-    if (!is_staging() && !is_updates_tests() && !is_jeos() && !is_hyperv()) {
+    # Test doesn't make sense on live images too, don't have source repo there.
+    if (!is_staging() && !is_updates_tests() && !is_upgrade() && !is_jeos() && !is_hyperv() && !is_livesystem()) {
         loadtest "console/zypper_info";
     }
     # Add non-oss and debug repos for o3 and remove other by default

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -22,8 +22,9 @@ use testapi qw(check_var get_var set_var);
 use version 'is_lax';
 
 our @EXPORT = qw (
-  is_hyperv_in_gui
   is_caasp
+  is_hyperv
+  is_hyperv_in_gui
   is_gnome_next
   is_jeos
   is_krypton_argon
@@ -52,8 +53,12 @@ sub is_jeos {
     return get_var('FLAVOR', '') =~ /^JeOS/;
 }
 
+sub is_hyperv {
+    return check_var('VIRSH_VMM_FAMILY', 'hyperv');
+}
+
 sub is_hyperv_in_gui {
-    return check_var('VIRSH_VMM_FAMILY', 'hyperv') && !check_var('VIDEOMODE', 'text');
+    return is_hyperv && !check_var('VIDEOMODE', 'text');
 }
 
 sub is_krypton_argon {


### PR DESCRIPTION
After moving repo replacement to create hdd scenarios, I haven't
included refresh step, which is not executed before installing packages
in x11 tests (e.g. gnuhealth).
So schedule this now and don't in case it was already scheduled.

As a result of [poo#32038](https://progress.opensuse.org/issues/32038),
we moved zypper_info test module from extra tests to console tests.

This test module was never executed on hyperv and fails due to
[poo#30613](https://progress.opensuse.org/issues/30613). So, exclude it for hyperv.

For ZDUP scenarios we already use only OSS repos, so don't schedule repos replacement there.

##Verification runs
NOTE: No verification run for hyperv possible.
* [gnu health](http://gershwin.arch.suse.de/tests/225#)
* [create hdd](http://gershwin.arch.suse.de/tests/224#)
* [zdup](http://gershwin.arch.suse.de/tests/230#)
* [kde-live](http://gershwin.arch.suse.de/tests/231#)
