### PR TITLE
Support Transactional host system role

### DIFF
--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -31,7 +31,7 @@ sub run {
         select_console 'root-ssh';
         return;
     }
-    elsif (check_var('DESKTOP', 'textmode') || get_var('BOOT_TO_SNAPSHOT')) {
+    elsif ((get_var('DESKTOP', '') =~ /textmode|serverro/) || get_var('BOOT_TO_SNAPSHOT')) {
         assert_screen('linux-login', $boot_timeout) unless check_var('ARCH', 's390x');
         return;
     }

--- a/tests/installation/installer_desktopselection.pm
+++ b/tests/installation/installer_desktopselection.pm
@@ -29,11 +29,11 @@ sub run {
     }
     if (get_var('NEW_DESKTOP_SELECTION')) {
         # select computer role
-        if ($d ne 'kde' && $d ne 'gnome' && $d ne 'textmode') {
+        if ($d !~ /kde|gnome|textmode|serverro/) {
             $d = 'custom';
         }
     }
-    if ($d ne 'kde' && $d ne 'gnome') {
+    if ($d !~ /kde|gnome|serverro/) {
         # up to 42.1 textmode was below 'other'
         if (!($d eq 'textmode' && check_screen 'has-server-selection', 2)) {
             send_key_until_needlematch 'selection_on_desktop_other', 'tab';    # Move the selection to 'Other'


### PR DESCRIPTION
Needed for the new transactional_host_install_only test, which tests that the role works as described here:

https://kubic.opensuse.org/blog/2018-04-04-transactionalupdates/