### PR TITLE
Fix repo variable name in main for products/extensions

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -234,7 +234,7 @@ if (sle_version_at_least('15') && !check_var('SCC_REGISTER', 'installation')) {
             my $repo_variable_name
               = is_module($short_name) ?
               "REPO_SLE${version}_MODULE_${repo_name}"
-              : "REPO_SLE_${repo_name}${version}_POOL";
+              : "REPO_SLE${version}_PRODUCT_${repo_name}";
             my $default_repo_name
               = is_module($short_name) ?
               "$prefix-Module-$full_name-POOL-$arch-Build$build-Media1"


### PR DESCRIPTION
Default repo variable name for extensions changed in osd from `REPO_SLE_<extension><version>_POOL` to `REPO_SLE<version>_PRODUCT_<extension>` on 20180329. This has impacted the Staging tests that include extensions such as HA in the `WORKAROUND_MODULES` variable, as now they cannot find the extension's repo in Staging.

Failing test: https://openqa.suse.de/tests/1582611
Last working one: https://openqa.suse.de/tests/1576671

(Check vars.json for more details on the changes to the variable names)

This pull request updates `sle/main.pm` to use the new name.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/316
