### PR TITLE
[systemd-testsuite] Show logs of failed tests

### DIFF
--- a/tests/console/systemd_testsuite.pm
+++ b/tests/console/systemd_testsuite.pm
@@ -51,6 +51,12 @@ sub post_fail_hook {
     assert_script_run('cp /tmp/testsuite.log logs/');
     assert_script_run('tar -cjf systemd-testsuite-logs.tar.bz2 logs/');
     upload_logs('systemd-testsuite-logs.tar.bz2');
+    # Remove ANSI colors and filter failed tests
+    my $failed_tests = script_output("sed --quiet 's/\x1b\[[0-9;]*m//g; /^FAIL:/p' /tmp/testsuite.log");
+    for my $test_name ($failed_tests =~ /^FAIL: ([\w-]*)$/mg) {
+        my $log_content = script_output("cat logs/$test_name-run.log");
+        record_info("Failed test '$test_name'", "Failed test '$test_name' \n$log_content", result => 'fail');
+    }
 }
 
 


### PR DESCRIPTION
Improve test results with logs of failed tests.

- Related ticket: https://progress.opensuse.org/issues/32614
- Verification run: http://10.160.66.74/tests/69#step/systemd_testsuite/55 (laptop, only available when powered on)
