### PR TITLE
Adjust autoyast tests flow for s390x

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -450,7 +450,7 @@ hostname into DHCP/DNS
 if you change hostname using C<hostnamectl set-hostname>, then C<hostname -f>
 will fail with I<hostname: Name or service not known> also DHCP/DNS don't know
 about the changed hostname, you need to send a new DHCP request to update
-dynamic DNS yast2-network module does 
+dynamic DNS yast2-network module does
 C<NetworkService.ReloadOrRestart if Stage.normal || !Linuxrc.usessh>
 if hostname is changed via C<yast2 lan>
 =cut
@@ -729,7 +729,8 @@ sub power_action {
         record_soft_failure("boo#1057637 shutdown_timeout increased to $shutdown_timeout (s) expecting to complete.");
     }
     # no need to redefine the system when we boot from an existing qcow image
-    if (check_var('VIRSH_VMM_FAMILY', 'xen') || (get_var('S390_ZKVM') && !get_var('BOOT_HDD_IMAGE'))) {
+    # Do not redefine if autoyast, as did initial reboot already
+    if (check_var('VIRSH_VMM_FAMILY', 'xen') || (get_var('S390_ZKVM') && !get_var('BOOT_HDD_IMAGE') && !get_var('AUTOYAST'))) {
         assert_shutdown_and_restore_system($action, $shutdown_timeout);
     }
     else {

--- a/tests/autoyast/autoyast_reboot.pm
+++ b/tests/autoyast/autoyast_reboot.pm
@@ -20,25 +20,12 @@ use strict;
 use base 'basetest';
 use testapi;
 use utils;
+use version_utils 'is_sle';
 
 sub run {
-    # Kill ssh proactively before reboot to avoid half-open issue on zVM
-    prepare_system_shutdown;
-
-    type_string("shutdown -r now\n");
-    reset_consoles;
-
-    # We have to reconnect in next on zVM
-    if (check_var("BACKEND", "s390x")) {
-        return;
-    }
-
-    assert_screen("bios-boot",  900);
-    assert_screen("bootloader", 30);
-
-    if (check_var("BOOTFROM", "d")) {
-        assert_screen("inst-bootmenu", 60);
-    }
+    # We are already in console, so reboot from it and do not switch to x11 or root console
+    # Note, on s390x with SLE15 VNC is not running even if enabled in the profile
+    power_action('reboot', textmode => 1, keepconsole => 1);
 }
 
 1;

--- a/tests/autoyast/console.pm
+++ b/tests/autoyast/console.pm
@@ -20,12 +20,13 @@ use strict;
 use base 'y2logsstep';
 use testapi;
 use utils 'power_action';
+use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
-    # Trying to change consoles manually because of bsc#1042554
-    # And no need on zVM
-    if (!check_var('BACKEND', 's390x')) {
+    # Trying to change consoles manually because of bsc#1042554, not on s390x
+    # Bug is still there on SLE 12 SP4
+    if (is_sle('<15') && !check_var('ARCH', 's390x')) {
         send_key 'ctrl-alt-f2';
         send_key 'alt-f2';
         if (!check_screen 'text-login') {

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -45,10 +45,12 @@ sub set_svirt_domain_elements {
             $cmdline .= "upgrade=1 ";
         }
 
-        if (get_var('AUTOYAST')) {
-            $cmdline .= " autoyast=" . data_url(get_var('AUTOYAST')) . " ";
+        if (my $autoyast = get_var('AUTOYAST')) {
+            $autoyast = data_url($autoyast) if $autoyast !~ /^slp$|:\/\//;
+            $cmdline .= " autoyast=" . $autoyast;
         }
 
+        $cmdline .= ' ' . get_var("EXTRABOOTPARAMS") if get_var("EXTRABOOTPARAMS");
         $cmdline .= specific_bootmenu_params;
         $cmdline .= registration_bootloader_cmdline if check_var('SCC_REGISTER', 'installation');
 
@@ -65,7 +67,7 @@ sub set_svirt_domain_elements {
     # after installation we need to redefine the domain, so just shutdown
     # on zdup and online migration we don't need to redefine in between
     # If boot from existing hdd image, we don't expect shutdown on reboot
-    if (!get_var('ZDUP') and !get_var('ONLINE_MIGRATION') and !get_var('BOOT_HDD_IMAGE')) {
+    if (!get_var('ZDUP') and !get_var('ONLINE_MIGRATION') and !get_var('BOOT_HDD_IMAGE') and !get_var('AUTOYAST')) {
         $svirt->change_domain_element(on_reboot => 'destroy');
     }
 }


### PR DESCRIPTION
We got ay upgrade tests running on zVM, but didn't work for zKVM yet.
We tried to connect in smart way to check errors during the second
stage, but even with sync using startshell boot option it didn't work
and we decided to keep it as it is for now.

We have checked that these changes do not break existing tests,
including zVM, and tried to use common code we use to handle reboot not
to fix same issues in multiple places.

See [poo#11922](https://progress.opensuse.org/issues/11922).

- Verification runs:
  * [sle 15 reinstall zkvm](http://g226.suse.de/tests/1372)
  * [sle 15 migration zVM](http://g226.suse.de/tests/1374)
  * [sle 12 sp4 btrfs 64bit](http://gershwin.arch.suse.de/tests/235)
  * [sle 15 btrfs 64bit](http://gershwin.arch.suse.de/tests/234)

NOTE: migration zVM fails due to mismatching needles for x3270, but this part has not been touched by this PR