### PR TITLE
Fix more regressions caused by repo replacement for openSUSE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -236,7 +236,6 @@ sub is_kernel_test {
 }
 
 sub replace_opensuse_repos_tests {
-    return if get_var('OFFLINE_SUT');
     loadtest "update/zypper_clear_repos";
     loadtest "console/zypper_ar";
     loadtest "console/zypper_ref";
@@ -250,8 +249,13 @@ sub is_updates_tests {
 }
 
 sub is_repo_replacement_required {
-    # Do no schedule for listed scenarios and if mirror variable is not set (e.g. leap live tests)
-    return is_opensuse() && !is_staging() && !get_var('KEEP_ONLINE_REPOS') && !is_updates_tests() && !is_upgrade() && get_var('SUSEMIRROR');
+    return is_opensuse()                  # Is valid scenario onlu for openSUSE
+      && !is_staging()                    # Do not have mirrored repos on staging
+      && !get_var('KEEP_ONLINE_REPOS')    # Set variable no to replace variables
+      && !is_updates_tests()              # Is not required for update and upgrade tests, repos are already injected
+      && !is_upgrade()
+      && get_var('SUSEMIRROR')            # Skip if required variable is not set (leap live tests)
+      && !get_var('OFFLINE_SUT');         # Do not run if SUT is offine
 }
 
 sub is_memtest {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -250,7 +250,8 @@ sub is_updates_tests {
 }
 
 sub is_repo_replacement_required {
-    return is_opensuse() && !is_staging() && !get_var('KEEP_ONLINE_REPOS') && !is_updates_tests() && !is_upgrade();
+    # Do no schedule for listed scenarios and if mirror variable is not set (e.g. leap live tests)
+    return is_opensuse() && !is_staging() && !get_var('KEEP_ONLINE_REPOS') && !is_updates_tests() && !is_upgrade() && get_var('SUSEMIRROR');
 }
 
 sub is_memtest {

--- a/tests/update/zypper_clear_repos.pm
+++ b/tests/update/zypper_clear_repos.pm
@@ -18,6 +18,8 @@ use utils;
 
 sub run {
     select_console 'root-console';
+    # packagekit service may block zypper when operate on repos
+    pkcon_quit;
 
     # remove Factory repos
     my $repos_folder = '/etc/zypp/repos.d';


### PR DESCRIPTION
## Description
Run pkcon_quit before adding repos and do not schedule repo replacement if SUSE_MIRROR is not defined

In some scenarios we can have packagekit running which will make adding
repos impossible. So proactively disable it using consoletest_setup.
  
For Leap live images we don't have mirrors available, so should not try
to replace repos. But still need to do that for TW live images.

See [poo#32038](https://progress.opensuse.org/issues/32038).

After this is merged, we can remove KEEP_ONLINE_REPOS variable from all live leap installations and create_hdd_gnome.

### Verification runs:
 * [create_hdd_gnome](http://gershwin.arch.suse.de/tests/248#)
 * [leap live image](http://gershwin.arch.suse.de/tests/240)
