### PR TITLE
Check system status after snapper rollback

### DIFF
--- a/data/console/check_registration_status.py
+++ b/data/console/check_registration_status.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+import sys
+import json
+import subprocess
+
+# Read the distribution info
+with open('/etc/os-release') as f:
+    dist = {}
+    for line in f:
+        k,v = line.rstrip().split('=')
+        v = v.strip('"')
+        dist[k] = v
+
+dist['BASE_VERSION'] = dist['VERSION_ID'].split('.')[0]
+print("Current system: %(NAME)s %(VERSION_ID)s [base version: %(BASE_VERSION)s]" % dist)
+
+cmd = ['SUSEConnect', '-s']
+proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+stdout, stderr = proc.communicate()
+
+if proc.returncode != 0:
+    print("Error executing command: %s" % ' '.join(cmd))
+    print("stderr: %s" % stderr)
+    print("stdout: %s" % stdout)
+
+# SUSEConnect status of every product (base product, extension or module),
+# should has the same version with current system, either "Not Registered"
+# or "Registered" products.
+# Return the account of missing matched product
+ret = 0
+for prod in json.loads(stdout, encoding="utf-8"):
+    prod['base_version'] = prod['version'].split('.')[0]
+    prod['result'] = 'match'
+
+    # Module version is not service pack specific
+    if prod['identifier'].find('module') != -1:
+        if dist['BASE_VERSION'] != prod['base_version']:
+            prod['result'] = 'mismatch'
+    else:
+        if dist['VERSION_ID'] != prod['version']:
+            prod['result'] = 'mismatch'
+
+    if prod['result'] == 'mismatch':
+        ret += 1
+    print("Product %(identifier)s with version %(version)s is %(status)s [%(result)s]" % prod)
+
+sys.exit(ret)

--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -14,6 +14,7 @@ use base "consoletest";
 use testapi;
 use utils;
 use strict;
+use migration 'check_rollback_system';
 
 sub run {
     my ($self) = @_;
@@ -39,6 +40,7 @@ sub run {
     reset_consoles;
     $self->wait_boot;
     select_console 'root-console';
+    check_rollback_system;
 }
 
 sub test_flags {

--- a/tests/migration/sle12_online_migration/snapper_rollback.pm
+++ b/tests/migration/sle12_online_migration/snapper_rollback.pm
@@ -15,17 +15,7 @@ use strict;
 use testapi;
 use utils;
 use version_utils 'is_desktop_installed';
-
-sub check_rollback_system {
-    # first to check rollback-helper service is enabled and worked properly
-    my $output = script_output "systemctl status rollback.service";
-    if ($output !~ /enabled.*?code=exited,\sstatus=0\/SUCCESS/s) {
-        die "rollback service was failed";
-    }
-
-    # second to check if repos were rolled back to original
-    script_run("zypper lr -u | tee /dev/$serialdev");
-}
+use migration 'check_rollback_system';
 
 sub run {
     my ($self) = @_;


### PR DESCRIPTION
Verify the system is properly rolled back, including:
 1) rollback.service is running
 2) repository version is correct
 3) registration status is synced up

- Related ticket: https://progress.opensuse.org/issues/34069
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/798
- Verification run: http://openqa-apac1.suse.de/tests/681#step/snapper_rollback/43