### PR TITLE
LTP/network: Remove $LTPROOT/testscripts/network.sh emulation

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -107,8 +107,6 @@ EOF
 { export ENABLE_WICKED=1; systemctl disable wicked; }'
         );
 
-        # emulate $LTPROOT/testscripts/network.sh
-        assert_script_run('TST_TOTAL=1 TCID="network_settings"; . test_net.sh; export TCID= TST_LIB_LOADED=');
         script_run('env');
 
         # Disable IPv4 and IPv6 iptables.
@@ -149,14 +147,8 @@ EOF
         script_run('cat /etc/hosts');
 
         script_run('ip addr');
-        script_run('ip netns exec ltp_ns ip addr');
         script_run('ip route');
         script_run('ip -6 route');
-
-        script_run('ping -c 2 $IPV4_NETWORK.$LHOST_IPV4_HOST');
-        script_run('ping -c 2 $IPV4_NETWORK.$RHOST_IPV4_HOST');
-        script_run('ping6 -c 2 $IPV6_NETWORK:$LHOST_IPV6_HOST');
-        script_run('ping6 -c 2 $IPV6_NETWORK:$RHOST_IPV6_HOST');
     }
 
     assert_script_run('cd $LTPROOT/testcases/bin');


### PR DESCRIPTION
Tested on 3 SLE/openSUSE versions, LTP 3 releases.

* SLE12-SP1_Update_26 (x86_64, QAM), latest release 20180118
http://quasar.suse.cz/tests/1106
http://quasar.suse.cz/tests/1099 (error here is not caused by changes)

* SLE15 Build543.1 (x86_64), master
http://quasar.suse.cz/tests/1104
* SLE15 Build543.1 (x86_64), network-next:
http://quasar.suse.cz/tests/1101
http://quasar.suse.cz/tests/1117

* Tumbleweed Build20180403 (x86_64)
http://quasar.suse.cz/tests/1100

There are more tests in http://quasar.suse.cz/tests, the failing ones should not be caused by this change.