### PR TITLE
Increase rescue timeout from 100s to 120s

### DIFF
--- a/tests/installation/rescuesystem.pm
+++ b/tests/installation/rescuesystem.pm
@@ -26,7 +26,7 @@ sub run {
         $self->select_bootmenu_more('inst-rescuesystem', 1);
     }
 
-    assert_screen 'keyboardmap-list', 100;
+    assert_screen 'keyboardmap-list', 120;
     send_key "ret";
 
     # Login as root (no password)


### PR DESCRIPTION
required at least for ppc64le tw since snapshot 20180407
https://openqa.opensuse.org/tests/652499#
