### PR TITLE
Multiple fixes for  partitioning_warnings

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -121,18 +121,22 @@ sub addpart {
             send_key 'alt-a' if is_storage_ng;    # Select to format partition, not selected by default
             wait_still_screen 1;
             send_key((is_storage_ng) ? 'alt-f' : 'alt-s');
-            send_key 'home';                      # start from the top of the list
-            send_key_until_needlematch "partition-selected-$args{format}-type", 'down';
+            wait_screen_change { send_key 'home' };    # start from the top of the list
+            send_key_until_needlematch "partition-selected-$args{format}-type", 'down', 10, 2;
         }
     }
-    if ($args{fsid}) {                            # $args{fsid} will describe needle tag below
-        send_key 'alt-i';                         # select File system ID
-        send_key 'home';                          # start from the top of the list
+    # Enable snapshots option works only with btrfs
+    if ($args{enable_snapshots} && $args{format} eq 'btrfs') {
+        send_key_until_needlematch('partition-btrfs-snapshots-enabled', (is_storage_ng) ? 'alt-p' : 'alt-n');
+    }
+    if ($args{fsid}) {                                 # $args{fsid} will describe needle tag below
+        send_key 'alt-i';                              # select File system ID
+        send_key 'home';                               # start from the top of the list
         if ($args{role} eq 'raw' && !check_var('VIDEOMODE', 'text')) {
             record_soft_failure('bsc#1079399 - Combobox is writable');
             for (1 .. 10) { send_key 'up'; }
         }
-        send_key_until_needlematch "partition-selected-$args{fsid}-type", 'down';
+        send_key_until_needlematch "partition-selected-$args{fsid}-type", 'down', 10, 2;
     }
 
     mount_device $args{mount} if $args{mount};

--- a/tests/installation/partitioning_warnings.pm
+++ b/tests/installation/partitioning_warnings.pm
@@ -19,40 +19,92 @@ use testapi;
 use partition_setup;
 use version_utils 'is_storage_ng';
 
+sub process_warning {
+    my (%args) = @_;
+    assert_screen 'partition-warning-' . $args{warning};
+    $args{key} //= 'alt-y';    # By default press yes, to accept the settings
+    wait_screen_change { send_key $args{key} };
+}
+
+sub process_missing_special_partitions {
+    # Have missing boot/zipl partition warning only in storage_ng
+    if (is_storage_ng && check_var('ARCH', 's390x')) {    # s390x needs /boot/zipl on ext partition
+        process_warning(warning => 'no-boot-zipl', key => 'alt-n');
+    }
+    elsif (get_var('OFW')) {                              # ppc64le needs PReP /boot
+        process_warning(warning => 'no-prep-boot', key => 'alt-n');
+    }
+    elsif (get_var('UEFI')) {
+        process_warning(warning => 'no-efi-boot', key => 'alt-n');
+    }
+    elsif (is_storage_ng() && check_var('ARCH', 'x86_64')) {
+        # Storage-ng has GPT by defaut, so warn about missing bios-boot partition for legacy boot, which is only on x86_64
+        process_warning(warning => 'no-bios-boot', key => 'alt-n');
+    }
+}
+
 sub run {
     create_new_partition_table;
+    # Verify missing root partition error is shown
+    assert_screen 'expert-partitioner';
+    send_key $cmd{accept};
+    # Check no root partition warning (has different keys, with storage-ng it's an error)
+    process_warning(warning => 'no-root-partition', key => (is_storage_ng) ? 'alt-o' : 'alt-n');
+    if (!is_storage_ng) {
+        process_missing_special_partitions;
+        process_warning(warning => 'no-swap', key => 'alt-n');
+    }
+    # create small enough partition (11GB) to get warning for enabled snapshots
+    # on storage-ng snaphots are disabled as per proposal when partition is to small, so enable to check the warning
+    addpart(role => 'OS', size => 11000, format => 'btrfs', enable_snapshots => is_storage_ng);
+
+    # In storage-ng we get this warning when adding/editing partition
+    if (is_storage_ng) {
+        process_warning(warning => 'too-small-for-snapshots');
+        send_key $cmd{next};
+    }
+
+    assert_screen 'expert-partitioner';
+    send_key $cmd{accept};
+    # Verify warning about missing swap and too small partition size on non storage-ng
+    # Warning about small partition is shown later for non storage-ng
+    # On power we get warning about missing prepboot before too small partition warning, which is different to arm
+    # That is relevant for old storage stack, on s390x we don't get warning about missing boot/zipl
+    process_warning(warning => 'too-small-for-snapshots', key => 'alt-n') if !is_storage_ng() && !check_var('ARCH', 'ppc64le');
+    process_missing_special_partitions;
+    process_warning(warning => 'too-small-for-snapshots', key => 'alt-n') if !is_storage_ng() && check_var('ARCH', 'ppc64le');
+    # Swap warning is not shown in storage-ng as controlled by the checkbox
+    if (!is_storage_ng) {
+        # No further warnings on x86_64 and s390x on non-storage-ng
+        if (get_var('ARCH') =~ /x86_64|s390x/) {
+            process_warning(warning => 'no-swap');
+            return;
+        }
+        else {
+            process_warning(warning => 'no-swap', key => 'alt-n');
+        }
+    }
+
+    ## Add required partitions as per warnings
     if (check_var('ARCH', 's390x')) {    # s390x need /boot/zipl on ext partition
         addpart(role => 'OS', size => 500, format => 'ext2', mount => '/boot');
     }
     elsif (get_var('OFW')) {             # ppc64le need PReP /boot
-        addpart(role => 'raw', size => 500, fsid => 'PReP');
+        addpart(role => 'raw', size => 8, fsid => 'PReP');
     }
-    elsif (is_storage_ng && check_var('ARCH', 'x86_64')) {
+    elsif (get_var('UEFI')) {
+        addpart(role => 'efi', size => 256);
+    }
+    elsif (check_var('ARCH', 'x86_64')) {
         # Storage-ng has GPT by defaut, so need bios-boot partition for legacy boot, which is only on x86_64
         addpart(role => 'raw', fsid => 'bios-boot', size => 2);
     }
 
-    # create small enough partition (11GB) to get warning
-    addpart(role => 'OS', size => 11000, format => 'btrfs');
-
     assert_screen 'expert-partitioner';
     send_key $cmd{accept};
-    if (is_storage_ng) {
-        assert_screen 'partitioning-edit-proposal-button';
-        record_soft_failure('bsc#1085131 - no warning for too small btrfs / for snapshots');
-    }
-    else {
-        # expect partition setup warning pop-ups
-        assert_screen 'partition-warning-too-small-for-snapshots';
-        wait_screen_change { send_key 'alt-y' };    # yes
-    }
-    if (get_var('UEFI')) {
-        assert_screen 'partition-warning-no-efi-boot';
-        wait_screen_change { send_key 'alt-y' };    # yes
-    }
-    if (!is_storage_ng) {
-        assert_screen 'partition-warning-no-swap';
-        wait_screen_change { send_key 'alt-y' };    # yes
+    if (!is_storage_ng()) {
+        process_warning(warning => 'too-small-for-snapshots');
+        process_warning(warning => 'no-swap');
     }
 }
 


### PR DESCRIPTION
So, we now can check warning if partition is too small to handle
snapshots.
On power test is currently failing due to too big prep boot partition.

See [poo#34498](https://progress.opensuse.org/issues/34498).

[Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/802).

#### Verification runs:
* [sle 15 x86_64](http://gershwin.arch.suse.de/tests/280)
* [sle 12 sp4 x86_64](http://gershwin.arch.suse.de/tests/281)
* [sle 12 sp4 zkvm](http://g226.suse.de/tests/1393)
* [sle 15 zkvm](http://g226.suse.de/tests/1420)
* [sle 12 sp4 ppc64le](http://g226.suse.de/tests/1655)
* [sle 15 ppc64le](http://g226.suse.de/tests/1404#)
* [sle 12 sp4 aarch64](http://g226.suse.de/tests/1657#)
* [sle 15 aarch64](http://g226.suse.de/tests/1665#)