### PR TITLE
Check for no textmode instead of gnome

### DIFF
--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -22,7 +22,7 @@ use version_utils 'sle_version_at_least';
 sub run {
     # On IPMI, when selecting x11 console, we are connecting to the VNC server on the SUT.
     # select_console('x11'); also performs a login, so we should be at generic-desktop.
-    my $gnome_ipmi = (check_var('BACKEND', 'ipmi') && check_var('DESKTOP', 'gnome'));
+    my $gnome_ipmi = (check_var('BACKEND', 'ipmi') && !check_var('DESKTOP', 'textmode'));
     select_console('x11') if ($gnome_ipmi);
     my $boot_timeout = (get_var('SES5_DEPLOY') || check_var('VIRSH_VMM_FAMILY', 'hyperv')) ? 450 : 200;
     # SLE >= 15 s390x does not offer auto-started VNC server in SUT, only login prompt as in textmode


### PR DESCRIPTION
Because this should also work for test suite default, without settings.

---

- Related ticket: https://progress.opensuse.org/issues/32089
- Verification run:
  - SLE12-SP4 gnome (coming soon)
  - SLE12-SP4 gnome@ipmi (coming soon)
  - SLE12-SP4 textmode (coming soon)
  - SLE15 gnome (coming soon)
  - SLE15 default@ipmi (coming soon)
  - SLE15 textmode@ipmi (coming soon)
