### PR TITLE
Fix docker test on SLE12 validation tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -489,7 +489,7 @@ sub load_docker_tests {
     if (!is_sle) {
         loadtest "console/docker_compose";
     }
-    if (is_sle('<15')) {
+    if (is_sle('<12-SP4')) {
         loadtest "console/sle2docker";
     }
 }

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -636,7 +636,12 @@ sub install_docker_when_needed {
         die 'Docker is not pre-installed.' if zypper_call('se -x --provides -i docker | grep docker', allow_exit_codes => [0, 1]);
     }
     else {
-        add_suseconnect_product('sle-module-containers') if is_sle('15+');
+        if (is_sle('<15')) {
+            assert_script_run('zypper se docker || zypper -n ar -f http://download.suse.de/ibs/SUSE:/SLE-12:/Update/standard/SUSE:SLE-12:Update.repo');
+        }
+        else {
+            add_suseconnect_product('sle-module-containers');
+        }
         # docker package can be installed
         zypper_call('in docker');
     }

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -55,7 +55,6 @@ our @EXPORT = qw(
   addon_license
   addon_products_is_applicable
   noupdatestep_is_applicable
-  validate_repos
   turn_off_kde_screensaver
   turn_off_gnome_screensaver
   random_string


### PR DESCRIPTION
docker is part of the containers-module. Our SLE12 test scenario
extra_tests_in_textmode runs based on an unregistered SLES installation so the
module is not immediately available. Adding the update repo which includes the
module solves the problem same as is already done in other places. As the
validation tests focus on the base system and not the modules I guess we can
go with this approach.

Alternatives would have been:
* O1: Just register the whole system and add the module for just one test
  module -> deregister again after the test module
* O2: Publish the hdd image from a test suite that registers the system and
  add a new test scenario like "extra_tests_registered" where we would
  schedule the docker module -> Con: Quite different test flow for SLE12 vs.
  SLE15 as well as openSUSE

Verification run: http://lord.arch/tests/755

Related progress issue: https://progress.opensuse.org/issues/33184