### PR TITLE
Revert 'get_var MACHINE' for broken aarch64 firmware

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -204,7 +204,7 @@ sub select_bootmenu_more {
         # newer versions of qemu on arch automatically add 'console=ttyS0' so
         # we would end up nowhere. Setting console parameter explicitly
         # See https://bugzilla.suse.com/show_bug.cgi?id=1032335 for details
-        type_string_slow ' console=tty1' if get_var('MACHINE', '') =~ /aarch64/;
+        type_string_slow ' console=tty1' if get_var('MACHINE') =~ /aarch64/;
         # Hyper-V defaults to 1280x1024, we need to fix it here
         type_hyperv_fb_video_resolution if check_var('VIRSH_VMM_FAMILY', 'hyperv');
         send_key 'f10';
@@ -367,7 +367,7 @@ sub wait_boot {
         # booted so we have to handle that
         # because of broken firmware, bootindex doesn't work on aarch64 bsc#1022064
         push @tags, 'inst-bootmenu' if ((get_var('USBBOOT') and get_var('UEFI')) || (check_var('ARCH', 'aarch64') and get_var('UEFI')) || get_var('OFW'));
-        $self->handle_uefi_boot_disk_workaround if (check_var('ARCH', 'aarch64') && get_var('UEFI') && get_var('BOOT_HDD_IMAGE') && !$in_grub);
+        $self->handle_uefi_boot_disk_workaround if (get_var('MACHINE') =~ /aarch64/ && get_var('UEFI') && get_var('BOOT_HDD_IMAGE') && !$in_grub);
         check_screen(\@tags, $bootloader_time);
         if (match_has_tag("bootloader-shim-import-prompt")) {
             send_key "down";

--- a/tests/boot/uefi_bootmenu.pm
+++ b/tests/boot/uefi_bootmenu.pm
@@ -21,7 +21,7 @@ sub run {
     my ($self) = @_;
     # because of broken firmware, bootindex doesn't work on aarch64 bsc#1022064
     # selecting a workaround is handled in boot/boot_to_desktop
-    return if (check_var('ARCH', 'aarch64') && get_var('BOOT_HDD_IMAGE'));
+    return if (get_var('MACHINE') =~ /aarch64/ && get_var('BOOT_HDD_IMAGE'));
     tianocore_select_bootloader;
     if (check_var('BOOTFROM', 'd')) {
         send_key_until_needlematch('tianocore-bootmanager-dvd', 'down', 5, 1);


### PR DESCRIPTION
Re-use 'get_var MACHINE' instead of 'check_var ARCH' for broken UEFI aarch64 firmware.