### PR TITLE
Add verification to x11_start_program

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -191,14 +191,16 @@ sub x11_start_program {
     # after 'ret' press we should wait in this case nevertheless
     wait_still_screen(3) unless ($args{no_wait} || ($args{valid} && $args{target_match} && !check_var('DESKTOP', 'kde')));
     return unless $args{valid};
+    my @target = ref $args{target_match} eq 'ARRAY' ? @{$args{target_match}} : $args{target_match};
     for (1 .. 3) {
-        assert_screen([ref $args{target_match} eq 'ARRAY' ? @{$args{target_match}} : $args{target_match}, 'desktop-runner-border'],
-            $args{match_timeout}, no_wait => $args{match_no_wait});
+        assert_screen([@target, 'desktop-runner-border'], $args{match_timeout}, no_wait => $args{match_no_wait});
         last unless match_has_tag 'desktop-runner-border';
         wait_screen_change {
             send_key 'ret';
         };
     }
+    # asserting program came up properly
+    die "Did not find target needle for tag(s) '@target'" if match_has_tag 'desktop-runner-border';
 }
 
 sub ensure_installed {


### PR DESCRIPTION
Added a verification to x11_start_program that the program really
started

Fixes the wrong type casting from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4670
In the verification run are two modules that use single tags and tag arrays to check both cases

- Related ticket: https://progress.opensuse.org/issues/31687
- Verification run: http://pinky.arch.suse.de/tests/964 and following 4 "new_x11_verification" runs
