### PR TITLE
Disable docker tests on SLE12-SP2

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1406,7 +1406,7 @@ sub load_extra_tests_textmode {
     # Currently for our SLE12 validation tests we are not using a
     # registered SLE installation so we should not schedule the test
     # modules.
-    load_docker_tests if (check_var('ARCH', 'x86_64') && ((is_sle('12-SP2+') && (is_sle('<12-SP4') || is_sle('15+')) || !is_sle)));
+    load_docker_tests if (check_var('ARCH', 'x86_64') && (is_sle('12-SP3+') || !is_sle));
     loadtest "console/kdump_and_crash" if kdump_is_applicable;
     loadtest "console/consoletest_finish";
 }


### PR DESCRIPTION
Fix poo#34636: SLE12-SP2 was moved to LTSS and docker is not available.
Failure: https://openqa.suse.de/tests/1604628#step/docker/6

- Related ticket: https://progress.opensuse.org/issues/34636
- Needles: none
- Verification runs:
SLE12-SP2 http://10.100.12.105/tests/1194 docker not present
SLE12-SP3: http://10.100.12.105/tests/1195  docker is included
SLE15: http://10.100.12.105/tests/1196 docker is included