### PR TITLE
Reset consoles tty after version switching

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -33,6 +33,7 @@ our @EXPORT = qw(
   disable_installation_repos
   record_disk_info
   check_rollback_system
+  reset_consoles_tty
 );
 
 sub setup_migration {
@@ -131,6 +132,13 @@ sub check_rollback_system {
     # Verify registration status matches current system version
     # system is un-registered during media based upgrade
     assert_script_run('curl -s ' . data_url('console/check_registration_status.py') . ' | python') unless get_var('MEDIA_UPGRADE');
+}
+
+# Reset tty for x11 and root consoles
+sub reset_consoles_tty {
+    console('x11')->set_tty(get_x11_console_tty);
+    console('root-console')->set_tty(get_root_console_tty);
+    reset_consoles;
 }
 
 1;

--- a/tests/migration/post_upgrade.pm
+++ b/tests/migration/post_upgrade.pm
@@ -10,7 +10,6 @@
 # Summary: Actions required after upgrade
 #       Such as:
 #       1) Change the HDDVERSION to UPGRADE_TARGET_VERSION
-#       2) Reset the x11 console to correct tty
 # Maintainer: Qingming Su <qmsu@suse.com>
 
 use base "opensusebasetest";
@@ -22,9 +21,6 @@ use utils 'get_x11_console_tty';
 sub run {
     # Reset HDDVERSION after upgrade
     set_var('HDDVERSION', get_var('UPGRADE_TARGET_VERSION', get_var('VERSION')));
-
-    # On SLE15, tty7 is reserved for gdm, tty2 is the first user x11 console
-    console('x11')->{args}->{tty} = get_x11_console_tty;
 }
 
 1;

--- a/tests/migration/version_switch_origin_system.pm
+++ b/tests/migration/version_switch_origin_system.pm
@@ -17,6 +17,7 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
+use migration;
 
 sub run {
     # Before upgrade or after rollback, switch to original system version
@@ -35,6 +36,9 @@ sub run {
         set_var('UPGRADE',      0);
         set_var('SCC_REGISTER', 'none');
     }
+
+    record_info('Version', 'VERSION=' . get_var('VERSION'));
+    reset_consoles_tty;
 }
 
 1;

--- a/tests/migration/version_switch_upgrade_target.pm
+++ b/tests/migration/version_switch_upgrade_target.pm
@@ -17,6 +17,7 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
+use migration;
 
 sub run {
     # After being patched, original system is ready for upgrade
@@ -38,6 +39,9 @@ sub run {
         # Set this to load extra needle during scc registration in sle15
         set_var('HDDVERSION', get_var('BASE_VERSION'));
     }
+
+    record_info('Version', 'VERSION=' . get_var('VERSION'));
+    reset_consoles_tty;
 }
 
 1;


### PR DESCRIPTION
Change the x11 and root console tty as required during upgrade:
 * root console to tty2 and x11 to tty7 for patching SLE 12
 * root console to tty6 and x11 to tty2 after upgrading to 15
 * root console to tty2 and x11 to tty7 when rollback to 12

- Related ticket: https://progress.opensuse.org/issues/33898
- Needles: None
- Verification run: 
   * media_upgrade_sles12sp3@64bit-smp: http://openqa-apac1.suse.de/tests/707
   * autoupgrade_sles12sp3_media@64bit-smp: http://openqa-apac1.suse.de/tests/709