### PR TITLE
Make Apache tests more stable on Hyper-V

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -126,12 +126,8 @@ sub setup_apache2 {
     assert_script_run qq{echo -e "<?php\nphpinfo()\n?>" > /srv/www/htdocs/index.php};
 
     # Verify apache+ssl works
-    if ($mode =~ m/SSL|NSS/) {
-        validate_script_output 'curl -k https://localhost/hello.html', sub { m/Hello Linux/ };
-    }
-    else {
-        validate_script_output 'curl http://localhost/hello.html', sub { m/Hello Linux/ };
-    }
+    my $curl_option = ($mode =~ m/SSL|NSS/) ? '-k https' : 'http';
+    assert_script_run "curl $curl_option://localhost/hello.html | grep 'Hello Linux'";
 
     if ($mode =~ /PHP5|PHP7/) {
         assert_script_run "curl --no-buffer http://localhost/index.php | grep \"\$(uname -s -n -r -v -m)\"";


### PR DESCRIPTION
At times Hyper-V's serial console is unstable and not very reliable for
longer strings: https://openqa.suse.de/tests/1607375#step/apache_ssl/37.

Validation run: http://nilgiri.suse.cz/tests/318