### PR TITLE
Fix update_packagekit_gpk when reboot is needed

### DIFF
--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -50,7 +50,7 @@ sub run {
     select_console 'x11', await_console => 0;
 
     my @updates_tags = qw(updates_none updates_available package-updater-privileged-user-warning updates_restart_application updates_installed-restart);
-    my @updates_installed_tags = qw(updates_none updates_installed-logout updates_installed-restart updates_restart_application );
+    my @updates_installed_tags = qw(updates_none updates_installed-logout updates_installed-restart updates_restart_application);
 
     setup_system;
 
@@ -70,17 +70,15 @@ sub run {
         elsif (match_has_tag("updates_available")) {
             send_key "alt-i";    # install
 
-            # Authenticate on SLES
-            # FIXME: actually only do that on SLE
-            push @updates_installed_tags, 'updates_authenticate';
-            check_screen \@updates_installed_tags;
-            if (match_has_tag("updates_authenticate")) {
-                type_string "$password\n";
-                pop @updates_installed_tags;
-            }
-
             # Wait until installation is done
-            assert_screen \@updates_installed_tags, 3600;
+            push @updates_installed_tags, 'updates_authenticate' if is_sle;
+            do {
+                assert_screen \@updates_installed_tags, 3600;
+                if (match_has_tag("updates_authenticate")) {
+                    type_string "$password\n";
+                    pop @updates_installed_tags;
+                }
+            } while (match_has_tag 'updates_authenticate');
             if (match_has_tag("updates_none")) {
                 send_key 'ret';
                 if (check_screen "updates_installed-restart", 0) {

--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -49,7 +49,7 @@ sub run {
     }
     select_console 'x11', await_console => 0;
 
-    my @updates_tags           = qw(updates_none updates_available package-updater-privileged-user-warning updates_restart_application);
+    my @updates_tags = qw(updates_none updates_available package-updater-privileged-user-warning updates_restart_application updates_installed-restart);
     my @updates_installed_tags = qw(updates_none updates_installed-logout updates_installed-restart updates_restart_application );
 
     setup_system;


### PR DESCRIPTION
Added the tag for a needed reboot to the target_match array when
starting the updater so we match and continue in the rare case the
updater is restarted when reboot is required

- Related ticket: https://progress.opensuse.org/issues/34210
- Needles: none
- Verification run: http://pinky.arch.suse.de/tests/976

The correct handling can be seen here:
http://pinky.arch.suse.de/tests/976#step/updates_packagekit_gpk/25
