### PR TITLE
Process WE license when install SLED

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -62,7 +62,7 @@ our %SLE15_MODULES = (
 # manually
 our %SLE15_DEFAULT_MODULES = (
     sles     => 'base,serverapp',
-    sled     => 'base,desktop',
+    sled     => 'base,desktop,we',
     sles4sap => 'base,desktop,serverapp,ha,sapapp',
 );
 
@@ -143,11 +143,14 @@ sub remove_suseconnect_product {
 
 sub register_addons {
     my (@scc_addons) = @_;
-
+    my $sle_prod = get_required_var('SLE_PRODUCT');
     my ($regcodes_entered, $uc_addon);
     for my $addon (@scc_addons) {
         # no need to input registration code if register via SMT
         last if (get_var('SMT_URL'));
+        # Do not need to write registration code if product includes it
+        next if $SLE15_DEFAULT_MODULES{$sle_prod} =~ /$addon/;
+
         $uc_addon = uc $addon;    # change to uppercase to match variable
         if ($addon eq 'phub') {
             record_soft_failure 'bsc#1046172';
@@ -274,6 +277,12 @@ sub fill_in_registration_data {
             $addons = $addons ? $addons . ',desktop' : 'desktop';
             set_var('SCC_ADDONS', $addons);
         }
+        # Add WE for SLED to process license, if not added explicitly (which should never be the case)
+        # TODO: remove/adjust when get unified licenses, so same license is not shown twice.
+        if (check_var('SLE_PRODUCT', 'sled') && (my $addons = get_var('SCC_ADDONS')) !~ /we/) {
+            $addons = $addons ? $addons . ',we' : 'we';
+            set_var('SCC_ADDONS', $addons);
+        }
     }
 
     if (check_var('SCC_REGISTER', 'installation') || check_var('SCC_REGISTER', 'yast') || check_var('SCC_REGISTER', 'console')) {
@@ -308,6 +317,7 @@ sub fill_in_registration_data {
                 }
             }
             my @scc_addons = split(/,/, get_var('SCC_ADDONS', ''));
+            my $sle_prod = get_required_var('SLE_PRODUCT');
             # remove emty elements
             @scc_addons = grep { $_ ne '' } @scc_addons;
 
@@ -317,6 +327,8 @@ sub fill_in_registration_data {
                 @scc_addons = grep { !/phub/ } @scc_addons;
             }
             for my $addon (@scc_addons) {
+                # Do not select modules which are preselected on SLE15 already
+                next if $SLE15_DEFAULT_MODULES{$sle_prod} =~ /$addon/;
                 if (check_var('VIDEOMODE', 'text') || check_var('SCC_REGISTER', 'console')) {
                     # The actions of selecting scc addons have been changed on SP2 or later in textmode
                     # For online migration, we have to do registration on pre-created HDD, set a flag


### PR DESCRIPTION
For SLED, we have WE module pre-selected which has additional license.
Previously, we didn't see any products with additional licenses and it
also can get fixed after we have unified license mechanism and same
content is not shown multiple times.
This can be extended further to process all required modules as we do
with SCC_ADDONS variable, but skipping module selection.

- Related ticket: [poo#34060](https://progress.opensuse.org/issues/34060)
- [Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/803)
- [Verification run](http://gershwin.arch.suse.de/tests/292#)
