### PR TITLE
Fix snapper_undochange to boot into rescue mode

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -42,7 +42,7 @@ sub snapper_nodbus_setup {
     my ($self) = @_;
     if (script_run('! systemctl is-active dbus')) {
         script_run('systemctl rescue', 0);
-        assert_screen 'emergency-shell';
+        assert_screen('emergency-shell', 120);
         type_password;
         send_key 'ret';
         $self->set_standard_prompt('root');


### PR DESCRIPTION
The commit resolves an issue when 'snapper_undochange' and 'snapper_thin_lvm' randomly fail to get into emergency shell.
Waiting timeout for emergency shell to be boot was increased from 30 sec to 120 sec.

- Related ticket: https://progress.opensuse.org/issues/32371
- Verification runs: 13 last builds from http://149.44.172.105/tests/214 to http://149.44.172.105/tests/201
