### PR TITLE
Fix partitining_warnings for SLE12 SP4

### DIFF
--- a/tests/installation/partitioning_warnings.pm
+++ b/tests/installation/partitioning_warnings.pm
@@ -70,19 +70,24 @@ sub run {
     # Warning about small partition is shown later for non storage-ng
     # On power we get warning about missing prepboot before too small partition warning, which is different to arm
     # That is relevant for old storage stack, on s390x we don't get warning about missing boot/zipl
-    process_warning(warning => 'too-small-for-snapshots', key => 'alt-n') if !is_storage_ng() && !check_var('ARCH', 'ppc64le');
-    process_missing_special_partitions;
-    process_warning(warning => 'too-small-for-snapshots', key => 'alt-n') if !is_storage_ng() && check_var('ARCH', 'ppc64le');
     # Swap warning is not shown in storage-ng as controlled by the checkbox
     if (!is_storage_ng) {
         # No further warnings on x86_64 and s390x on non-storage-ng
         if (get_var('ARCH') =~ /x86_64|s390x/) {
+            process_warning(warning => 'too-small-for-snapshots');
             process_warning(warning => 'no-swap');
             return;
         }
         else {
+            process_warning(warning => 'too-small-for-snapshots', key => 'alt-n') if !check_var('ARCH', 'ppc64le');
+            process_missing_special_partitions;
+            process_warning(warning => 'too-small-for-snapshots', key => 'alt-n') if check_var('ARCH', 'ppc64le');
             process_warning(warning => 'no-swap', key => 'alt-n');
         }
+    }
+    else {
+        # in storage-ng need to process only special warnings
+        process_missing_special_partitions;
     }
 
     ## Add required partitions as per warnings


### PR DESCRIPTION
Fixing regression introduced in #4803, pressed No in one of the
warnings, so got back to the expert partitioner.

This only affected s390x and x86 as we don't have special warnings
there.

See [poo#34498](https://progress.opensuse.org/issues/34498).

#### Verification runs: 
 * [s390x](http://g226.suse.de/tests/1701)
 * [arm](http://g226.suse.de/tests/1702)
 * [ppc64le](http://g226.suse.de/tests/1703) (unstable worker, failed in the next test module)
 * [x86_64](http://gershwin.arch.suse.de/tests/302)
