### PR TITLE
Improve handling bsc#1008493 in yast2_tftp module

### DIFF
--- a/tests/console/yast2_tftp.pm
+++ b/tests/console/yast2_tftp.pm
@@ -55,20 +55,24 @@ sub run {
 
     # view log
     send_key 'alt-v';                                                                     # open log window
+
+    # bsc#1008493 is still open, but error pop-up doesn't always appear immediately
+    # so wait still screen before assertion
+    wait_still_screen 3;
     assert_screen([qw(yast2_tftp_view_log_error yast2_tftp_view_log_show)]);
     if (match_has_tag('yast2_tftp_view_log_error')) {
         # softfail for opensuse when error for view log throws out
         record_soft_failure "bsc#1008493";
-        send_key 'alt-o';                                                                 # confirm the error message
+        wait_screen_change { send_key 'alt-o' };    # confirm the error message
     }
-    send_key 'alt-c';                                                                     # close the window
+    send_key 'alt-c';                               # close the window
     assert_screen 'yast2_tftp_closed_port';
     # now finish tftp server configuration
-    send_key 'alt-o';                                                                     # confirm changes
+    send_key 'alt-o';                               # confirm changes
 
     # and confirm for creating new directory
     assert_screen 'yast2_tftp_create_new_directory';
-    send_key 'alt-y';                                                                     # approve creation of new directory
+    send_key 'alt-y';                               # approve creation of new directory
 
     # wait for yast2 tftp configuration completion
     wait_serial("yast2-tftp-server-status-0", 180) || die "'yast2 tftp-server' failed";
@@ -83,4 +87,3 @@ sub run {
 }
 
 1;
-


### PR DESCRIPTION
Once in a while we may match log needle, if error is not shown
immediately. So, move soft-failure further, so we actually try to close
dialog, and if it didn't work, we check if error is shown.

Be aware that this issue doesn't appear often, and wait_still_screen
would also do the trick, but we don't to wait for no reason.

See [poo#34072](https://progress.opensuse.org/issues/34072).

- Needles: [PR#351](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/351)
- Verification runs: 
  * [TW](http://gershwin.arch.suse.de/tests/303)
  * [Leap15](http://gershwin.arch.suse.de/tests/301)
