### PR TITLE
Remove workaround of package hub registration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -152,13 +152,9 @@ sub register_addons {
         next if $SLE15_DEFAULT_MODULES{$sle_prod} =~ /$addon/;
 
         $uc_addon = uc $addon;    # change to uppercase to match variable
-        if ($addon eq 'phub') {
-            record_soft_failure 'bsc#1046172';
-            set_var('SCC_REGCODE_PHUB', get_required_var('SCC_REGCODE'));
-        }
         if (my $regcode = get_var("SCC_REGCODE_$uc_addon")) {
             # skip addons which doesn't need to input scc code
-            next unless grep { $addon eq $_ } qw(ha geo we live rt ltss phub ses);
+            next unless grep { $addon eq $_ } qw(ha geo we live rt ltss ses);
             if (check_var('VIDEOMODE', 'text')) {
                 send_key_until_needlematch "scc-code-field-$addon", 'tab';
             }
@@ -321,11 +317,6 @@ sub fill_in_registration_data {
             # remove emty elements
             @scc_addons = grep { $_ ne '' } @scc_addons;
 
-            if (!(check_screen 'scc-module-phub', 0)) {
-                record_soft_failure 'boo#1056047';
-                #find and remove phub
-                @scc_addons = grep { !/phub/ } @scc_addons;
-            }
             for my $addon (@scc_addons) {
                 # Do not select modules which are preselected on SLE15 already
                 next if $SLE15_DEFAULT_MODULES{$sle_prod} =~ /$addon/;
@@ -455,7 +446,7 @@ sub select_addons_in_textmode {
     my ($addon, $flag) = @_;
     if ($flag) {
         send_key_until_needlematch 'scc-module-area-selected', 'tab';
-        send_key_until_needlematch "scc-module-$addon", 'down', 30;
+        send_key_until_needlematch "scc-module-$addon", 'down', 30, 5;
         if (check_var('ARCH', 'aarch64') && check_var('HDDVERSION', '12-SP2') && check_screen('scc-module-tcm-selected', 5)) {
             record_info('Workaround',
                 "Toolchain module is selected and installed by default on sles12sp2 aarch64\nSee: https://progress.opensuse.org/issues/19852");


### PR DESCRIPTION
Remove workaround for boo#1056047, bug has been fixed and
the workaround itself leads to problem now
Remove workaround for bsc#1046172, the issue has been gone
no registration code is asked for package hub neither for
SLE 12-SP3 nor 15.
Increase timeout to 5s for SUT responsing to key 'down'

- Related ticket: https://progress.opensuse.org/issues/34459
- Needles: None
- Verification run: http://openqa-apac1.suse.de/tests/718
