### PR TITLE
Update configure_xdmcp_firewall to fix poo#31489#note-11

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -876,8 +876,9 @@ sub configure_static_ip_nm {
 
 # Open the firewall port of xdmcp service
 sub configure_xdmcp_firewall {
-    # Open the firewall port of xdmcp service
-    if (is_sle '15+') {
+    my ($self) = @_;
+
+    if ($self->firewall eq 'firewalld') {
         assert_script_run 'firewall-cmd --permanent --zone=public --add-port=6000-6010/tcp';
         assert_script_run 'firewall-cmd --permanent --zone=public --add-port=177/udp';
         assert_script_run 'firewall-cmd --reload';


### PR DESCRIPTION
Use `$self->firewall eq 'firewalld'` to check if the SUT is using firewalld

---

- Related ticket: https://progress.opensuse.org/issues/31489#note-11
- Verification run: http://10.67.17.30/tests/372
