### PR TITLE
JeOS: Workaround bsc#1073877

### DIFF
--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -27,7 +27,7 @@ use base "consoletest";
 use testapi;
 use utils;
 use strict;
-use version_utils qw(is_caasp is_sle sle_version_at_least);
+use version_utils qw(is_jeos is_sle);
 use registration;
 
 sub run {
@@ -91,6 +91,10 @@ sub run {
     $output = script_output('docker container run tw:saved curl -I google.de');
     die("network is not working inside of the container tw:saved") unless ($output =~ m{Location: http://www\.google\.de/});
 
+    if (is_jeos && is_sle('15+')) {
+        record_soft_failure('bsc#1073877 - Docker fails to stop container on JeOS');
+        return;
+    }
     # containers can be stopped
     assert_script_run("docker container stop $container_name");
     assert_script_run("docker container inspect --format='{{.State.Running}}' $container_name | grep false");


### PR DESCRIPTION
`docker stop` fails only on SLES15 JeOS.

Also removed sub uses from version_utils which I forgot to remove last
time touching this file.

Fails here: https://openqa.suse.de/tests/1610703#step/docker/57
Validation run: http://nilgiri.suse.cz/tests/348