### PR TITLE
Enable single-master testing scenario for QAM

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -137,7 +137,7 @@ sub is_caasp {
         return check_var('DISTRI', $filter);
     }
     elsif ($filter eq 'qam') {
-        return check_var('FLAVOR', 'CaaSP-DVD-Incidents');
+        return check_var('FLAVOR', 'CaaSP-DVD-Incidents') || get_var('LOCAL_QAM_DEVENV');
     }
     elsif ($filter =~ /staging/) {
         return get_var('FLAVOR') =~ /Staging-.-DVD/;

--- a/tests/caasp/stack_update.pm
+++ b/tests/caasp/stack_update.pm
@@ -20,6 +20,7 @@ use strict;
 use testapi;
 use lockapi 'mutex_create';
 use caasp 'update_scheduled';
+use version_utils 'is_caasp';
 
 # Set up ssh to admin node and run update script on all nodes
 sub setup_update_repository {
@@ -46,7 +47,7 @@ sub check_update_changes {
     assert_script_run "kubectl get nodes --no-headers | wc -l | grep $nodes_count";
 
     # QAM: incidents repo with real maintenance updates
-    if (check_var('FLAVOR', 'CaaSP-DVD-Incidents')) {
+    if (is_caasp('qam')) {
         # TODO
     }
     else {


### PR DESCRIPTION
In order to be able to locally develop CaaSP tests, we need quite a powerful workstation. This change, allows us to develop our tests using less resources (smaller cluster).

- Related ticket: https://progress.opensuse.org/issues/34834
- Needles: Not needed
- Verification run: http://skyrim.qam.suse.de/tests/2659#
