### PR TITLE
Do not run snapshot thingie on maintenance/updates/incidents

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -948,7 +948,7 @@ sub load_consoletests {
     if (get_var('SYSTEM_ROLE', '') =~ /kvm|xen/) {
         loadtest "console/patterns";
     }
-    if (snapper_is_applicable()) {
+    if (snapper_is_applicable() && !is_updates_tests()) {
         if (get_var("UPGRADE")) {
             loadtest "console/upgrade_snapshots";
         }
@@ -1167,7 +1167,7 @@ sub load_x11tests {
         loadtest "x11/dolphin";
     }
     # SLES4SAP default installation does not configure snapshots
-    if (snapper_is_applicable() and !is_sles4sap()) {
+    if (snapper_is_applicable() and !is_updates_tests() and !is_sles4sap()) {
         loadtest "x11/yast2_snapper";
     }
     if (xfcestep_is_applicable()) {


### PR DESCRIPTION
installation_snapshots/upgrade_snapshots/yast2_snapper does not make sense to be standard test for maintenance/updates/incidents jobs.