### PR TITLE
More time for Kdump on Hyper-V

### DIFF
--- a/tests/console/kdump_and_crash.pm
+++ b/tests/console/kdump_and_crash.pm
@@ -39,8 +39,8 @@ sub run {
     return 1 unless kdump_is_active;
     do_kdump;
     power_action('reboot', observe => 1, keepconsole => 1);
-    # wait for system's reboot
-    $self->wait_boot;
+    # Wait for system's reboot; more time for Hyper-V as it's slow.
+    $self->wait_boot(bootloader_time => check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 200 : undef);
     select_console 'root-console';
 
     # all but PPC64LE arch's vmlinux images are gzipped


### PR DESCRIPTION
Fails here: https://openqa.suse.de/tests/1616988#step/kdump_and_crash/61
In the video one can see that the kernel memory dump actually succeeded
but needed more time to catch grub during restart.