### PR TITLE
Fix multi-user.target isolation in multi_user_dm

### DIFF
--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -21,6 +21,11 @@ use utils;
 
 sub ensure_multi_user_target {
     type_string "systemctl isolate multi-user.target\n";
+    wait_still_screen 5;
+    send_key "ctrl-alt-f" . get_root_console_tty;
+    wait_screen_change {
+        send_key "ctrl-c";
+    }
     reset_consoles;
     wait_still_screen 10;
     # isolating multi-user.target logs us out


### PR DESCRIPTION
This doesn't fix the whole multi_user_dm test.
In a previous run with this patch it looked like as if just
some needles were missing but currently there seems to be
some issue with the graphics driver: http://artemis.suse.de/tests/165#step/multi_users_dm/15

I still would like to have this already merged as it will help to track that issue.