### PR TITLE
Use new name of package and increase timeout

### DIFF
--- a/tests/console/systemd_testsuite.pm
+++ b/tests/console/systemd_testsuite.pm
@@ -24,21 +24,11 @@ sub run {
     select_console 'root-console';
     zypper_call "ar $qa_head_repo systemd-testrepo";
     zypper_call '--gpg-auto-import-keys ref';
-    assert_script_run 'systemd --version';                                               # show version
-    assert_script_run 'systemd_version=`systemd --version | head -1 | cut -d\  -f2`';    # save version to var
-    my $package_name = 'systemd-v$systemd_version-testsuite';
-    assert_script_run 'zypper -n se -sx ' . $package_name;
-    zypper_call 'in ' . $package_name;
-    if (is_leap('16.0+') || is_tumbleweed || is_sle('16+')) {
-        # Systemd has split its nspawn feature to a systemd-container package.
-        #   - This change is not included in SLE15 nor Leap15.
-        record_soft_failure('poo#32614 - Missing systemd-container');
-        zypper_call('in systemd-container');
-    }
+    zypper_call 'in systemd-qa-testsuite';
 
     # run the testsuite test scripts
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh --all 2>&1 | tee /tmp/testsuite.log', 1200;
+    assert_script_run './run-tests.sh --all 2>&1 | tee /tmp/testsuite.log', 2100;
     assert_script_run 'grep "# FAIL:  0" /tmp/testsuite.log';
     assert_script_run 'grep "# ERROR: 0" /tmp/testsuite.log';
 }


### PR DESCRIPTION
manual test took 30 mintues 15 seconds to complete.

- Related ticket: https://progress.opensuse.org/issues/32614
- Verification run: http://10.160.66.74/tests/109#step/systemd_testsuite/20 (the failure is known and tblume is working on it. I will create a proper ticket when it gets to TW, so it can have proper links to a 24/7 available resource)