### PR TITLE
Fix yast2_nfs_server failing on aarch64

### DIFF
--- a/tests/console/yast2_nfs_server.pm
+++ b/tests/console/yast2_nfs_server.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2015 SUSE LLC
+# Copyright © 2015-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -76,7 +76,7 @@ sub run {
     # Done
     assert_screen 'nfs-share-saved';
     send_key 'alt-f';
-    wait_serial("YAST-DONE-0-", 5);
+    wait_serial('YAST-DONE-0-') or die "'yast2 nfs-server' didn't finish";
 
     # Back on the console, test mount locally
     clear_console;


### PR DESCRIPTION
The timeout selection should be a bit more resiliant. Also, "wait_serial" does
not fail the test on failure so there should be a handling with "die".

See https://openqa.suse.de/tests/1618346#step/yast2_nfs_server/12

Verification run: http://lord.arch/tests/772#step/yast2_nfs_server/12