### PR TITLE
Prevent unknown WICKED test variables

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1482,6 +1482,9 @@ sub load_wicked_tests {
     elsif (check_var('WICKED', 'advanced')) {
         loadtest 'wicked/advanced';
     }
+    else {
+        die 'Unhandled WICKED test selection: ' . get_var('WICKED');
+    }
 }
 
 sub load_networkd_tests {


### PR DESCRIPTION
It is always a good idea to have an else-branch on if/elsif

Verification run conducted locally with isotovideo.

Schedule in case of WICKED=basic (happy path):

```
scheduling boot_to_desktop tests/boot/boot_to_desktop.pm
scheduling before_test tests/wicked/before_test.pm
scheduling basic tests/wicked/basic.pm
scheduling config_files tests/wicked/config_files.pm
```

Schedule in case of WICKED=risky showing the error handling:

```
scheduling boot_to_desktop tests/boot/boot_to_desktop.pm
scheduling before_test tests/wicked/before_test.pm
Unhandled WICKED test selection: risky at /home/sebchlad/repos/os-autoinst-distri-opensuse/products/sle/../../lib/main_common.pm line 1486.
```

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
