### PR TITLE
Handle local dev environments in CaaSP

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -139,6 +139,9 @@ sub is_caasp {
     elsif ($filter eq 'qam') {
         return check_var('FLAVOR', 'CaaSP-DVD-Incidents') || get_var('LOCAL_QAM_DEVENV');
     }
+    elsif ($filter eq 'local') {
+        return get_var('LOCAL_DEVENV') || get_var('LOCAL_QAM_DEVENV');
+    }
     elsif ($filter =~ /staging/) {
         return get_var('FLAVOR') =~ /Staging-.-DVD/;
     }

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -156,8 +156,11 @@ sub load_stack_tests {
         else {
             loadtest 'caasp/stack_reboot';
         }
-        loadtest 'caasp/stack_add_nodes'   if get_delayed_worker;
-        loadtest 'caasp/stack_conformance' if !is_caasp('staging');
+        loadtest 'caasp/stack_add_nodes' if get_delayed_worker;
+        unless (is_caasp('staging') || is_caasp('local')) {
+            loadtest 'caasp/stack_conformance';
+        }
+
         loadtest 'caasp/stack_finalize';
     }
     else {


### PR DESCRIPTION
Follow-up on idea of local devenv from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4830, this should allow to reuse it for non-qam tests.

Local run: http://dhcp165.suse.cz/tests/2926