### PR TITLE
Disable invalid cd and dvd repos after rollback

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -129,6 +129,8 @@ sub check_rollback_system {
     # check rollback-helper service is enabled and worked properly
     systemctl('is-active rollback');
 
+    # Disable the obsolete cd and dvd repos to avoid zypper error
+    assert_script_run("zypper mr -d -m cd -m dvd");
     # Verify registration status matches current system version
     # system is un-registered during media based upgrade
     assert_script_run('curl -s ' . data_url('console/check_registration_status.py') . ' | python') unless get_var('MEDIA_UPGRADE');


### PR DESCRIPTION
The cd and dvd used to install origin system, e.g. SLE 12-SP3,
don't exist during upgrade to SLE 15, because SLE 15 installer
is loaded from same cd or dvd device. Then related SLE 12-SP3
repos become invalid after snapper rollback.

- Related ticket: https://progress.opensuse.org/issues/34753
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: http://openqa-apac1.suse.de/tests/737#step/snapper_rollback/40
