### PR TITLE
sles4sap: Add new needles to assert_screen in NetWeaver ASCS install

### DIFF
--- a/tests/sles4sap/netweaver_ascs_install.pm
+++ b/tests/sles4sap/netweaver_ascs_install.pm
@@ -60,7 +60,11 @@ sub run {
 
     # If running in DESKTOP=gnome, systemd-logind restart may cause the graphical console to
     # reset and appear in SUD, so need to select 'root-console' again
-    assert_screen([qw(root-console displaymanager displaymanager-password-prompt generic-desktop text-login)]);
+    assert_screen(
+        [
+            qw(root-console displaymanager displaymanager-password-prompt generic-desktop
+              text-login linux-login started-x-displaymanager-info)
+        ]);
     select_console 'root-console' unless (match_has_tag 'root-console');
 
     assert_script_run "saptune daemon start";


### PR DESCRIPTION
This is a fix for the race condition presented in https://openqa.suse.de/tests/1620737#step/netweaver_ascs_install/8, where after a `systemctl restart logind.service`, the screen remains for over 30 seconds in the boot screen without any login prompt, causing the call to `assert_screen` to fail and abort the test.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/blob/master/started-x-displaymanager-info-20180416.json & https://gitlab.suse.de/openqa/os-autoinst-needles-sles/blob/master/started-x-displaymanager-info-20180416.png
- Verification run: http://mango.suse.de/tests/329
