### PR TITLE
Add autoyast profile to test for firewalld

### DIFF
--- a/data/autoyast_sle15/autoyast_firewalld.xml
+++ b/data/autoyast_sle15/autoyast_firewalld.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email/>
+    <reg_code>{{SCC_REGCODE}}</reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server>{{SCC_URL}}</reg_server>
+    <addons config:type="list">
+      <addon>
+        <name>sle-module-server-applications</name>
+        <version>{{VERSION}}</version>
+        <arch>{{ARCH}}</arch>
+      </addon>
+    </addons>
+  </suse_register>
+  <networking>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+  </networking>
+  <software>
+    <packages config:type="list">
+      <package>apache2</package>
+    </packages>
+    <products config:type="list">
+      <product>SLES</product>
+    </products>
+  </software>
+  <users config:type="list">
+    <user>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <firewall>
+    <zones config:type="list">
+      <zone>
+        <name>public</name>
+        <interfaces config:type="list">
+          <interface>eth0</interface>
+        </interfaces>
+        <services config:type="list">
+          <service>apache2</service>
+          <service>apache2-ssl</service>
+        </services>
+        <ports config:type="list">
+          <port>8080/tcp</port>
+          <port>9090/udp</port>
+        </ports>
+      </zone>
+      <zone>
+        <name>trusted</name>
+        <services config:type="list">
+          <service>ssh</service>
+        </services>
+        <ports config:type="list">
+          <port>22/tcp</port>
+          <port>5353/udp</port>
+        </ports>
+      </zone>
+    </zones>
+    <enable_firewall config:type="boolean">true</enable_firewall>
+    <start_firewall config:type="boolean">true</start_firewall>
+    <log_denied_packets>unicast</log_denied_packets>
+    <default_zone>public</default_zone>
+  </firewall>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id/>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>suse.local</domain>
+      <hostname>linux-nwlk</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+    </routing>
+  </networking>
+</profile>


### PR DESCRIPTION
We already have test for firewalld which uses SuSEfirewall style
configuration. This profile contains exactly same config, so it can be
verified using same test module (as it was initial idea).

See [poo#26728](https://progress.opensuse.org/issues/26728).

Test suite will require following settings:

AUTOYAST=autoyast_sle15/autoyast_firewalld.xml
AUTOYAST_CONFIRM=1
AUTOYAST_PREPARE_PROFILE=1
INSTALLONLY=1

[Verification run](http://gershwin.arch.suse.de/tests/342#).
