### PR TITLE
LTP: Reintroduce using proc_sys_dump module

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -32,6 +32,11 @@ sub loadtest {
     autotest::loadtest("tests/kernel/$test.pm", %args);
 }
 
+sub shutdown_ltp {
+    loadtest('proc_sys_dump') if get_var('PROC_SYS_DUMP');
+    loadtest('shutdown_ltp', @_);
+}
+
 sub parse_openposix_runfile {
     my ($path, $cmd_pattern, $cmd_exclude, $test_result_export) = @_;
 
@@ -89,7 +94,7 @@ sub loadtest_from_runtest_file {
         parse_runtest_file($path . "/ltp-$name-" . $tag, $cmd_pattern, $cmd_exclude, $test_result_export);
     }
 
-    loadtest('shutdown_ltp', run_args => testinfo($test_result_export));
+    shutdown_ltp(run_args => testinfo($test_result_export));
 }
 
 # Replace loadtest_from_runtest_file with this to stress test reverting to
@@ -117,12 +122,12 @@ sub load_kernel_tests {
         }
         loadtest 'install_ltp';
         #loadtest 'boot_ltp';
-        loadtest 'shutdown_ltp';
+        shutdown_ltp();
     }
     elsif (get_var('LTP_SETUP_NETWORKING')) {
         loadtest 'boot_ltp';
         loadtest 'ltp_setup_networking';
-        loadtest 'shutdown_ltp';
+        shutdown_ltp();
     }
     elsif (get_var('LTP_COMMAND_FILE')) {
         if (get_var('INSTALL_KOTD')) {


### PR DESCRIPTION
This allows again using proc_sys_dump.pm.

Fixes: 9666e5fd ("LTP: Make test execution more robust and better results")
* `PROC_SYS_DUMP=1`
http://quasar.suse.cz/tests/1138#step/proc_sys_dump/8

* `PROC_SYS_DUMP=1, PROC_SYS_USE_WHITELIST=1`
http://quasar.suse.cz/tests/1139#step/proc_sys_dump/8

* Without `PROC_SYS_DUMP*`
http://quasar.suse.cz/tests/1137