### PR TITLE
Fix poo#31702 - fail in reboot-gnome

### DIFF
--- a/tests/migration/reboot_to_upgrade.pm
+++ b/tests/migration/reboot_to_upgrade.pm
@@ -27,7 +27,10 @@ sub run {
     set_var('PATCHED_SYSTEM', 1) if get_var('PATCH');
 
     # Reboot from Installer media for upgrade
-    set_var('BOOT_HDD_IMAGE', 0) if get_var('UPGRADE') || get_var('AUTOUPGRADE');
+    # Aarch64 need BOOT_HDD_IMAGE=1 to keep the correct flow to boot from disk for x11/reboot_gnome.
+    if (get_var('UPGRADE') || get_var('AUTOUPGRADE')) {
+        set_var('BOOT_HDD_IMAGE', 0) unless check_var('ARCH', 'aarch64');
+    }
     assert_script_run "sync", 300;
     type_string "reboot -f\n";
 }


### PR DESCRIPTION
This issue happened for aarch64 boot from disk flow depends on BOOT_HDD_IMAGE=1 and this variable changed to 0 on reboot_to_upgrade. We need to keep BOOT_HDD_IMAGE=1 for x11/reboot-gnome in aarch64.

- Related ticket: https://progress.opensuse.org/issues/31702
- Verification run: http://10.161.32.24/tests/31
