### PR TITLE
Detect stuck on analyzing system during upgrade

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -20,6 +20,8 @@ use version_utils 'sle_version_at_least';
 
 sub run {
     my ($self) = shift;
+    # Wait finish of "Analyzing your system" during upgrade
+    $self->detect_stuck_at_system_analyzing if get_var("UPGRADE");
     # Softfail not to forget remove workaround
     record_soft_failure('bsc#1054974') if get_var('ALL_MODULES');
     # overview-generation

--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -17,6 +17,11 @@ use testapi;
 use version_utils 'is_sle';
 
 sub run {
+    my $self = shift;
+
+    # Wait finish of "Analyzing your system" during upgrade
+    $self->detect_stuck_at_system_analyzing if get_var("UPGRADE");
+
     assert_screen('release-notes-button', 60);
     return if match_has_tag('bsc#1054478');
 


### PR DESCRIPTION
Long time is observed on "Analyzing your system" at
releasenotes / installation_overview or "Adapting
the proposal to the current settings" after fixing
conflicts. Die test if system stuck is detected.

The "Analyzing your system" screen is not observed during new installation, so restrict to upgrade tests only.

- Related ticket: https://progress.opensuse.org/issues/34474
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/810
- Verification run: 
   * [x86_64] proxyscc_upgrade_sles12sp3+PackageHub@64bit-smp: http://openqa-apac1.suse.de/tests/740
   * [aarch64] proxyscc_upgrade_sles12sp3@aarch64: http://openqa-apac1.suse.de/tests/742
