### PR TITLE
Inform contributors that the links may be changed or removed

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 [type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]
 
-- Related ticket: https://progress.opensuse.org/issues/xyz
-- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
-- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
+- Related ticket: [url here or REMOVE line] (eg. https://progress.opensuse.org/issues/xyz)
+- Needles: [url here or REMOVE line] (eg. https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz)
+- Verification run: [url here or REMOVE line] (eg. openqa.mypersonalinstance.de/tests/xyz#step/module/x)


### PR DESCRIPTION
Because people still forget to update or removed placeholder of the PR template.

Motivation here: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4847#issuecomment-381887038