### PR TITLE
Properly handle cluster failure on admin node

### DIFF
--- a/tests/caasp/stack_admin.pm
+++ b/tests/caasp/stack_admin.pm
@@ -37,9 +37,11 @@ sub handle_update_reboot {
     mutex_lock 'UPDATE_FINISHED';
     mutex_unlock 'UPDATE_FINISHED';
 
-    # Admin node was rebooted
-    reset_consoles;
-    select_console 'root-console';
+    # Admin node was rebooted only if update passed
+    if (check_screen 'linux-login-casp', 0) {
+        reset_consoles;
+        select_console 'root-console';
+    }
 }
 
 sub run() {


### PR DESCRIPTION
If test on controller node fails before updating/rebooting the cluster then select_console fails to match needle. Login again only if necessary on admin node.

Failed job: https://openqa.suse.de/tests/1621466#step/stack_admin/20
Local run: http://dhcp165.suse.cz/tests/3010