### PR TITLE
Enable login workarounds also after reboots

### DIFF
--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -84,6 +84,9 @@ sub microos_login {
     }
 
     select_console 'root-console';
+
+    # Don't match linux-login-casp twice
+    assert_script_run 'clear';
 }
 
 # Process reboot with an option to trigger it

--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -20,7 +20,7 @@ use version_utils 'is_caasp';
 use utils qw(power_action assert_shutdown_and_restore_system);
 
 our @EXPORT
-  = qw(handle_simple_pw process_reboot trup_call write_detail_output get_admin_job update_scheduled export_cluster_logs get_delayed_worker rpmver check_reboot_changes trup_install script_retry);
+  = qw(handle_simple_pw process_reboot trup_call write_detail_output get_admin_job update_scheduled export_cluster_logs get_delayed_worker rpmver check_reboot_changes trup_install script_retry microos_login);
 
 # Return names and version of packages for transactional-update tests
 sub rpmver {
@@ -69,6 +69,23 @@ sub handle_simple_pw {
     set_var 'SIMPLE_PW_CONFIRMED', 1;
 }
 
+# Assert login prompt and login as root
+sub microos_login {
+    assert_screen 'linux-login-casp', 150;
+
+    # Workers installed using autoyast have no password - bsc#1030876
+    return if get_var('AUTOYAST');
+
+    if (is_caasp 'VMX') {
+        # FreeRDP is not sending 'Ctrl' as part of 'Ctrl-Alt-Fx', 'Alt-Fx' is fine though.
+        my $key = check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 'alt-f2' : 'ctrl-alt-f2';
+        # First attempts to select tty2 are ignored - bsc#1035968
+        send_key_until_needlematch 'tty2-selected', $key, 10, 30;
+    }
+
+    select_console 'root-console';
+}
+
 # Process reboot with an option to trigger it
 sub process_reboot {
     my $trigger = shift // 0;
@@ -81,9 +98,7 @@ sub process_reboot {
         assert_screen 'grub2';
         send_key 'ret';
     }
-
-    assert_screen 'linux-login-casp', 180;
-    select_console 'root-console';
+    microos_login;
 }
 
 # Optionally skip exit status check in case immediate reboot is expected

--- a/tests/caasp/first_boot.pm
+++ b/tests/caasp/first_boot.pm
@@ -17,34 +17,18 @@ use testapi;
 use utils 'systemctl';
 use version_utils 'is_caasp';
 use bootloader_setup 'set_framebuffer_resolution';
-use caasp qw(process_reboot script_retry);
+use caasp qw(process_reboot script_retry microos_login);
 
 sub run {
-    if (is_caasp 'DVD') {
-        # On DVD images stall prevents reliable matching of BIOS needle - poo#28648
-        unless (get_var 'AUTOYAST') {
-            assert_screen 'grub2';
-            send_key 'ret';
-        }
-
-        assert_screen 'linux-login-casp', 100;
-
-        # Workers installed using autoyast have no password - bsc#1030876
-        unless (get_var 'AUTOYAST') {
-            select_console 'root-console';
-        }
+    # On DVD images stall prevents reliable matching of BIOS needle - poo#28648
+    if (is_caasp('DVD') && !get_var('AUTOYAST')) {
+        assert_screen 'grub2';
+        send_key 'ret';
     }
 
+    microos_login;
+
     if (is_caasp 'VMX') {
-        assert_screen 'linux-login-casp', 100;
-
-        # FreeRDP is not sending 'Ctrl' as part of 'Ctrl-Alt-Fx', 'Alt-Fx' is fine though.
-        my $key = check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 'alt-f2' : 'ctrl-alt-f2';
-        # First attempts to select tty2 are ignored - bsc#1035968
-        send_key_until_needlematch 'tty2-selected', $key, 10, 30;
-
-        select_console 'root-console';
-
         # Help cloud-init on cluster tests
         if (get_var 'STACK_ROLE') {
             # Wait for cloud-init initialization - bsc#1088654


### PR DESCRIPTION
Fix for: https://openqa.suse.de/tests/1621476#step/rebootmgr/52
Fix for: https://openqa.suse.de/tests/1626113#step/rebootmgr/23

Local runs:
 - http://dhcp165.suse.cz/tests/3072 - VMX
 - http://dhcp165.suse.cz/tests/3071 - DVD