### PR TITLE
Use specific repo for Leap15

### DIFF
--- a/tests/console/systemd_testsuite.pm
+++ b/tests/console/systemd_testsuite.pm
@@ -19,6 +19,9 @@ use version_utils qw(is_leap is_tumbleweed is_sle);
 
 sub run {
     my $qa_head_repo = get_required_var('QA_HEAD_REPO');
+    if (is_leap('=15.0')) {
+        $qa_head_repo = 'https://download.opensuse.org/repositories/devel:/openSUSE:/QA:/Leap:/15/openSUSE_Leap_15.0/';
+    }
 
     # install systemd testsuite
     select_console 'root-console';


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/32614
- Verification run: http://localhost/tests/134 (the failure is a different issue, see https://progress.opensuse.org/issues/35035)
