### PR TITLE
Add exception for kernel 4.4.144 - 94.11.3 in LP tests

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -77,10 +77,12 @@ sub install_lock_kernel {
     # version numbers can be 'out of sync'
     my $numbering_exception = {
         'kernel-source' => {
-            '4.4.59-92.17.3' => '4.4.59-92.17.2',
+            '4.4.59-92.17.3'  => '4.4.59-92.17.2',
+            '4.4.114-94.11.3' => '4.4.114-94.11.2',
         },
         'kernel-macros' => {
-            '4.4.59-92.17.3' => '4.4.59-92.17.2',
+            '4.4.59-92.17.3'  => '4.4.59-92.17.2',
+            '4.4.114-94.11.3' => '4.4.114-94.11.2',
         }};
 
     my @packages = qw(kernel-default kernel-default-devel kernel-macros kernel-source);


### PR DESCRIPTION
fixes https://openqa.suse.de/tests/overview?distri=sle&version=12-SP3&build=%3A7098%3Akgraft-patch-SLE12-SP3_Update_8.1523440274&groupid=107
