### PR TITLE
Add workarounds for SLED dual boot

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -892,6 +892,7 @@ sub load_inst_tests {
         loadtest "installation/installation_overview";
         # On Xen PV we don't have GRUB on VNC
         loadtest "installation/disable_grub_timeout" unless check_var('VIRSH_VMM_TYPE', 'linux');
+        loadtest "installation/grub_probe_foreignos" if (get_var('DUALBOOT') && is_sle('15+'));
         if (check_var('VIDEOMODE', 'text') && check_var('BACKEND', 'ipmi')) {
             loadtest "installation/disable_grub_graphics";
         }

--- a/tests/installation/grub_probe_foreignos.pm
+++ b/tests/installation/grub_probe_foreignos.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Enable probe foreign os for SLE dual boot scenario
+# Maintainer: Grace Wang <gwang@suse.com>
+# Tags: bsc#1089516
+
+use strict;
+use warnings;
+use base "y2logsstep";
+use testapi;
+use utils;
+use version_utils qw(is_sle is_leap);
+
+sub run {
+    record_soft_failure('bsc#1089516');
+    # Verify Installation Settings overview is displayed as starting point
+    assert_screen "installation-settings-overview-loaded";
+
+    # Select section booting on Installation Settings overview (video mode)
+    send_key_until_needlematch 'booting-section-selected', 'tab';
+    assert_screen 'booting-section-selected';
+    send_key 'ret';
+
+    assert_screen([qw(inst-bootloader-settings inst-bootloader-settings-first_tab_highlighted)]);
+    # Depending on an optional button "release notes" we need to press "tab"
+    # to go to the first tab
+    send_key 'tab' unless match_has_tag 'inst-bootloader-settings-first_tab_highlighted';
+    send_key_until_needlematch 'inst-bootloader-options-highlighted', 'right';
+    assert_screen 'installation-bootloader-options';
+    # Enable Probe Forengn OS
+    send_key 'alt-b';
+    assert_screen 'enable_probe_foreignos';
+    wait_still_screen(3);
+
+    send_key 'alt-o';
+    assert_screen 'installation-settings-overview-loaded';
+}
+
+1;
+# vim: set sw=4 et:

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -15,10 +15,22 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
-use version_utils qw(is_leap is_storage_ng);
+use version_utils qw(is_leap is_storage_ng is_sle sle_version_at_least);
 
 sub run {
     assert_screen 'partitioning-edit-proposal-button', 40;
+
+    if (get_var("DUALBOOT")) {
+        if (is_sle && sle_version_at_least('15')) {
+            record_soft_failure('bsc#1089723 Make sure keep the existing windows partition');
+            assert_screen "delete-partition";
+            send_key "alt-g";
+            assert_and_click "resize-or-remove-ifneeded";
+            send_key "up";
+            assert_and_click "resize-ifneeded";
+            for (1 .. 3) { send_key "alt-n"; }
+        }
+    }
 
     # Storage NG introduces a new partitioning dialog. We detect this
     # by the existence of the "Guided Setup" button and set the


### PR DESCRIPTION
Add workarounds for SLED dual boot

Existing bugs that block SLED15 dual boot testing:
https://bugzilla.suse.com/show_bug.cgi?id=1089516
https://bugzilla.suse.com/show_bug.cgi?id=1089723

- Related ticket: https://progress.opensuse.org/issues/31741
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/812
- Verification run: http://10.160.65.144/tests/406