### PR TITLE
Add --flatten=true parameter to the stack_kubernetes.pm CaaSP test

### DIFF
--- a/tests/caasp/stack_kubernetes.pm
+++ b/tests/caasp/stack_kubernetes.pm
@@ -23,7 +23,7 @@ sub run {
     switch_to 'xterm';
     assert_script_run "kubectl cluster-info";
     assert_script_run "kubectl cluster-info > cluster.before_update";
-    assert_script_run "kubectl config view | tee /dev/$serialdev";
+    assert_script_run "kubectl config view --flatten=true | tee /dev/$serialdev";
     assert_script_run "kubectl get nodes";
     assert_script_run "! kubectl get cs --no-headers | grep -v Healthy";
 


### PR DESCRIPTION
The CA Certificate was 'REDACTED' so now there's actual value.

- Related ticket: https://progress.opensuse.org/issues/34540
- Needles: Not needed
- Verification run: https://pdostal-server.suse.cz/tests/262#step/stack_kubernetes/6
