### PR TITLE
Skip snapper rollback test on s390x

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1436,6 +1436,7 @@ sub load_extra_tests {
 }
 
 sub load_rollback_tests {
+    return if check_var('ARCH', 's390x');
     loadtest "boot/grub_test_snapshot";
     loadtest "migration/version_switch_origin_system";
     if (get_var('UPGRADE') || get_var('ZDUP')) {


### PR DESCRIPTION
Snapper rollback couldn't be tested on any openQA
s390x backend so far

- Related ticket: https://progress.opensuse.org/issues/35125
- Needles: None
- Verification run: http://openqa-apac1.suse.de/tests/760
