### PR TITLE
snapper_rollback: increase timeout of wait_boot

### DIFF
--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -38,7 +38,7 @@ sub run {
     assert_script_run("snapper list | tail -n 2 | grep rollback");
     script_run("systemctl reboot", 0);
     reset_consoles;
-    $self->wait_boot;
+    $self->wait_boot(ready_time => 300, bootloader_time => 300);
     select_console 'root-console';
     check_rollback_system;
 }


### PR DESCRIPTION
Longer time is required to reboot from a running system
for disk syncing, service stopping, etc

- Related ticket: https://progress.opensuse.org/issues/35131
- Needles: None
- Verification runs:
   * media_upgrade_sles12sp3@64bit-smp: http://openqa-apac1.suse.de/tests/761#step/snapper_rollback/19
   * proxyscc_upgrade_sles12sp3@64bit-smp: http://openqa-apac1.suse.de/tests/764#step/snapper_rollback/19
