### PR TITLE
Increase timeout to show release-notes-sle

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -95,7 +95,7 @@ sub run {
         send_key_until_needlematch("release-notes-sle", 'right');
     }
     else {
-        assert_screen 'release-notes-sle';    # SLE release notes
+        assert_screen 'release-notes-sle', 150;    # SLE release notes
     }
 
     # exit release notes window


### PR DESCRIPTION
Longer time is required to show release notes in case
installer is analyzing your system at background

- Related ticket: https://progress.opensuse.org/issues/34474
- Needles: None
- Verification run:
  * http://openqa-apac1.suse.de/tests/758#step/releasenotes/3