### PR TITLE
Wait until node list is displayed

### DIFF
--- a/tests/caasp/stack_add_nodes.pm
+++ b/tests/caasp/stack_add_nodes.pm
@@ -29,6 +29,7 @@ sub accept_nodes {
 }
 
 sub bootstrap {
+    wait_still_screen 3;
     assert_and_click 'unassigned-select-all';
     assert_and_click 'unassigned-add-nodes';
     assert_screen 'velum-bootstrap-done';


### PR DESCRIPTION
Select remaining nodes button is clicked before node list displays - so nothing gets selected.

Fix for: https://openqa.suse.de/tests/1626141#