### PR TITLE
SES workarounds for missing license and release notes

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -81,13 +81,14 @@ sub accept_addons_license {
     #   isc co SUSE:SLE-15:GA 000product
     #   grep -l EULA SUSE:SLE-15:GA/000product/*.product | sed 's/.product//'
     # All shown products have a license that should be checked.
-    my @addons_with_license = qw(geo live rt idu ids lgm hpcm ses);
+    my @addons_with_license = qw(geo live rt idu ids lgm hpcm);
 
     # In SLE 15 some modules do not have license or have the same
     # license (see bsc#1089163) and so are not be shown twice
     push @addons_with_license, qw(ha sdk wsm we) unless is_sle('15+');
 
     for my $addon (@scc_addons) {
+        record_soft_failure 'bsc#1090012 - missing SES6 license' if $addon eq 'ses';
         # most modules don't have license, skip them
         next unless grep { $addon eq $_ } @addons_with_license;
         while (check_screen('scc-downloading-license', 5)) {

--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -55,8 +55,8 @@ sub run {
         send_key 'tab';          # select tab area
     }
 
-    # no release-notes for WE and all modules
-    my @no_relnotes = qw(we lgm asmm certm contm pcm tcm wsm hpcm ids idu phub all-packages sapapp);
+    # no release-notes for WE and all modules, SES - bsc#1090005
+    my @no_relnotes = qw(we lgm asmm certm contm pcm tcm wsm hpcm ids idu phub all-packages sapapp ses);
 
     # No release-notes for basic modules and Live-Patching on SLE 15
     if (is_sle('15+')) {
@@ -85,6 +85,7 @@ sub run {
             assert_screen([qw(release-notes-sle-ok-button release-notes-sle-close-button)], 300);
         }
         for my $a (@addons) {
+            record_soft_failure 'bsc#1090005 - missing SES6 release notes' if $a eq 'ses';
             next if grep { $a eq $_ } @no_relnotes;
             send_key_until_needlematch("release-notes-$a", 'right', 4, 60);
             send_key 'left';    # move back to first tab


### PR DESCRIPTION
- Verification run: http://10.100.12.155/tests/1489