### PR TITLE
Wait longer for reg code window

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -158,7 +158,7 @@ sub register_addons {
                 send_key_until_needlematch "scc-code-field-$addon", 'tab';
             }
             else {
-                assert_and_click "scc-code-field-$addon";
+                assert_and_click "scc-code-field-$addon", 60;
             }
             type_string $regcode;
             save_screenshot;


### PR DESCRIPTION
In test below the window did appear 3 seconds before timeout, another tests failed.
It is aarch64 issue, but I think additional wait time should be not a problem.
https://openqa.suse.de/tests/1627984/file/autoinst-log.txt