### PR TITLE
Select bond slave with click instead of tab

### DIFF
--- a/tests/x11/yast2_lan_restart_devices.pm
+++ b/tests/x11/yast2_lan_restart_devices.pm
@@ -56,8 +56,8 @@ sub add_device {
         send_key 'alt-o';             # Bond slaves
         assert_screen 'yast2_lan_bond_slaves';
         send_key_until_needlematch 'yast2_lan_bond_slave_tab_selected', 'tab';
-        send_key 'tab';               # select Bond Slaves and Order field
-        send_key 'spc';               # check network interface
+        assert_and_click 'yast2_lan_bond_slave_network_interface';    # select network interface
+        send_key 'spc';                                               # check network interface
         wait_still_screen;
         save_screenshot;
         send_key 'alt-n';


### PR DESCRIPTION
Test fails because we don't always switch to the devices list using tab.
That is the case on Leap15.

See [poo#34312](https://progress.opensuse.org/issues/34312).

- Needles: 
  * [sle](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/814)
  * [openSUSE](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/355)
- Verification runs:
  * [sle 12](http://gershwin.arch.suse.de/tests/336)
  * [sle 15](http://gershwin.arch.suse.de/tests/339)
  * [leap 15](http://gershwin.arch.suse.de/tests/328)
  * [TW](http://gershwin.arch.suse.de/tests/331)
