### PR TITLE
Always load zypper_lr test for migraion

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1032,6 +1032,11 @@ else {
         load_inst_tests();
         load_reboot_tests();
         loadtest "migration/post_upgrade";
+        # Always load zypper_lr test for migration case and get repo information for investigation
+        if (get_var("INSTALLONLY")) {
+            loadtest "console/consoletest_setup";
+            loadtest "console/zypper_lr";
+        }
     }
     elsif (get_var("BOOT_HDD_IMAGE") && !is_jeos) {
         if (get_var("RT_TESTS")) {


### PR DESCRIPTION
Load zypper_lr for migration test case and get the repo list after migrtion.

- Related ticket: https://progress.opensuse.org/issues/31267
- Verification run: http://10.67.17.147/tests/34#step/zypper_lr/2
