### PR TITLE
Update sub register_addons to fix poo#35197

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -158,7 +158,7 @@ sub register_addons {
                 send_key_until_needlematch "scc-code-field-$addon", 'tab';
             }
             else {
-                assert_and_click "scc-code-field-$addon", 60;
+                assert_and_click "scc-code-field-$addon", 'left', 60;
             }
             type_string $regcode;
             save_screenshot;


### PR DESCRIPTION
update `assert_and_click "scc-code-field-$addon", 60;` to 
`assert_and_click "scc-code-field-$addon", 'left', 60;`

- Related ticket: https://progress.opensuse.org/issues/35197

