### PR TITLE
snapper_rollback: show status of rollback.service

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -127,6 +127,7 @@ sub check_rollback_system {
     return unless is_sle;
     # Check SUSEConnect status for SLE
     # check rollback-helper service is enabled and worked properly
+    systemctl('status rollback');
     systemctl('is-active rollback');
 
     # Disable the obsolete cd and dvd repos to avoid zypper error


### PR DESCRIPTION
Show the status of rollback.service for bsc#1089478 debugging

- Related ticket: https://progress.opensuse.org/issues/35212
- Needles: None
- Verification run: http://openqa-apac1.suse.de/tests/785#step/snapper_rollback/37