### PR TITLE
Fix all SES licenses and addon behavior for non-Packages ISO module

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -81,14 +81,18 @@ sub accept_addons_license {
     #   isc co SUSE:SLE-15:GA 000product
     #   grep -l EULA SUSE:SLE-15:GA/000product/*.product | sed 's/.product//'
     # All shown products have a license that should be checked.
-    my @addons_with_license = qw(geo live rt idu ids lgm hpcm);
+    my @addons_with_license = qw(geo live rt idu ids lgm hpcm ses);
 
     # In SLE 15 some modules do not have license or have the same
     # license (see bsc#1089163) and so are not be shown twice
     push @addons_with_license, qw(ha sdk wsm we) unless is_sle('15+');
+    # SES6 license is not shown now in SLE15
+    if (is_sle('15+') && get_var('SCC_ADDONS') =~ /ses/) {
+        record_soft_failure 'bsc#1090012 - missing SES6 license';
+        @addons_with_license = grep(!/^ses$/, @addons_with_license);
+    }
 
     for my $addon (@scc_addons) {
-        record_soft_failure 'bsc#1090012 - missing SES6 license' if $addon eq 'ses';
         # most modules don't have license, skip them
         next unless grep { $addon eq $_ } @addons_with_license;
         while (check_screen('scc-downloading-license', 5)) {

--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -55,8 +55,8 @@ sub run {
         send_key 'tab';          # select tab area
     }
 
-    # no release-notes for WE and all modules, SES - bsc#1090005
-    my @no_relnotes = qw(we lgm asmm certm contm pcm tcm wsm hpcm ids idu phub all-packages sapapp ses);
+    # no release-notes for WE and all modules
+    my @no_relnotes = qw(we lgm asmm certm contm pcm tcm wsm hpcm ids idu phub all-packages sapapp);
 
     # No release-notes for basic modules and Live-Patching on SLE 15
     if (is_sle('15+')) {
@@ -65,6 +65,11 @@ sub run {
         @no_relnotes = grep(!/^we$/, @no_relnotes);
         # HA-GEO has been removed on SLE 15
         @addons = grep(!/^geo$/, @addons);
+        # SES6 does not have RN now bsc#1090005
+        if (get_var('SCC_ADDONS') =~ /ses/) {
+            push @no_relnotes, 'ses';
+            record_soft_failure 'bsc#1090005 - missing SES6 release notes';
+        }
     }
 
     # no relnotes for ltss in QAM_MINIMAL
@@ -85,7 +90,6 @@ sub run {
             assert_screen([qw(release-notes-sle-ok-button release-notes-sle-close-button)], 300);
         }
         for my $a (@addons) {
-            record_soft_failure 'bsc#1090005 - missing SES6 release notes' if $a eq 'ses';
             next if grep { $a eq $_ } @no_relnotes;
             send_key_until_needlematch("release-notes-$a", 'right', 4, 60);
             send_key 'left';    # move back to first tab


### PR DESCRIPTION
Fix SES6 and SES5 and fix addon behavior when added module is not from the Packages ISO

Verification run:
SES6 http://10.100.12.155/tests/1540
SES5 http://10.100.12.155/tests/1543

edit: removed the ISO part, not needed any more