### PR TITLE
Assert tty selected by default and softfail with text-login

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -513,7 +513,14 @@ sub activate_console {
             # just after ssh login
             assert_screen \@tags, 60;
             # Accept 'text-login' by default
-            if (match_has_tag("tty$nr-selected") || match_has_tag("text-login") && !$args{ensure_tty_selected}) {
+            if (match_has_tag("tty$nr-selected")) {
+                type_string "$user\n";
+                handle_password_prompt;
+            }
+            elsif (match_has_tag("text-login") && !$args{ensure_tty_selected}) {
+                record_soft_failure("poo#32926, couldn't assert tty was switched");
+                # Introduce artificial delay to get better chances to get right tty
+                wait_still_screen 3;
                 type_string "$user\n";
                 handle_password_prompt;
             }


### PR DESCRIPTION
On hyperv we see issued with our flow, as we may start entering login
name before we switched to the selected tty. Hence, default behavior,
should be to assert that we have switched to required tty first. To be
on safe side, we fallback to old behavior to identify cases where it
didn't work and analyze those.

[Verification run](http://g226.suse.de/tests/1711#).

See [poo#32926](https://progress.opensuse.org/issues/32926).

