### PR TITLE
Fix yast2_lan - yast2 not closed in 90s

### DIFF
--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -79,7 +79,7 @@ sub run {
     assert_screen 'test-yast2_lan-1';
 
     send_key "alt-o";    # OK=>Save&Exit
-    wait_serial("yast2-lan-status-0", 90) || die "'yast2 lan' didn't finish";
+    wait_serial("yast2-lan-status-0", 180) || die "'yast2 lan' didn't finish";
 
     wait_still_screen;
     $self->clear_and_verify_console;


### PR DESCRIPTION
Sometimes the aarch64 worker is somehow slow which cause the yast2 not closed in 90s. Change it to 180s to workaround this issue.

- Related ticket: https://progress.opensuse.org/issues/32806
- Verification run: http://10.161.32.24/tests/41#
