### PR TITLE
deal_with_dependency_issues: Close unexpected Options menu

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -154,6 +154,8 @@ sub deal_with_dependency_issues {
         die 'Dependency problems';
     }
 
+    # Press "Esc" in case "Options" menu is open by accident
+    send_key 'esc';
     assert_screen 'dependency-issue-fixed';    # make sure the dependancy issue is fixed now
     send_key 'alt-a';                          # Accept
     sleep 2;


### PR DESCRIPTION
The Options menu could be open by accident, for example by
extra send_key 'alt-o', which is unexpected and fails test

Such as:
https://openqa.suse.de/tests/1630746#step/installation_overview/27

wait_screen_change added to workaround_dependency_issues did help improve the test stability, 
```
wait_screen_change { send_key 'alt-o' };
```
but I could still reproduce the issue in 20% of my tests. So I would like to press 'Esc' explicitly in test to avoid such issue.

- Related ticket: https://progress.opensuse.org/issues/35209
- Needles: N/A
- Verification run: 
   * (No Options menu shown) http://openqa-apac1.suse.de/tests/813#step/installation_overview/25
   * (With Options menu shown) http://openqa-apac1.suse.de/tests/818#step/installation_overview/25
