### PR TITLE
Restrain soft failure of bsc#1055462 to poweroff

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -719,7 +719,7 @@ sub power_action {
     }
     # Shutdown takes longer than 60 seconds on SLE 15
     my $shutdown_timeout = 60;
-    if (is_sle('15+') && check_var('DESKTOP', 'gnome')) {
+    if (is_sle('15+') && check_var('DESKTOP', 'gnome') && ($action eq 'poweroff')) {
         record_soft_failure('bsc#1055462');
         $shutdown_timeout *= 3;
     }


### PR DESCRIPTION
The soft failure of bsc#1055462 appeared during installation
or upgrade at reboot_after_installation step is unexpected, so
restrict the soft failure only to power_action('poweroff')

- Related ticket: None
- Needles: None
- Verification run: http://openqa-apac1.suse.de/tests/813#step/reboot_after_installation/1
