### PR TITLE
Wait more time for the yast2 to finish package installation

### DIFF
--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -83,7 +83,7 @@ sub run {
         }
     }
 
-    wait_serial("y2-i-status-0", 60) || die "'yast2 sw_single' didn't finish";
+    wait_serial("y2-i-status-0", 120) || die "'yast2 sw_single' didn't finish";
 
     $self->clear_and_verify_console;         # clear screen to see that second update does not do any more
     assert_script_run("rpm -e $pkgname");    # erase $pkgname


### PR DESCRIPTION
This issue failed for the yast2 not finished the installation of package, and from the reproduction log on o.s.d the timeout should be about 80s at this situation. So increase the timeout value to 120 as a workaround.

- Related ticket: https://progress.opensuse.org/issues/34480
- Verification run: http://10.161.32.24/tests/43
