### PR TITLE
Add wait to ganglia cluster verifications

### DIFF
--- a/tests/hpc/ganglia_client.pm
+++ b/tests/hpc/ganglia_client.pm
@@ -44,6 +44,8 @@ sub run {
     my $max_retries = 7;
     for (1 .. $max_retries) {
         eval {
+            # Wait for ganglia cluster setup
+            sleep 5;
             # Check if gmond has connected to gmetad
             validate_script_output "gstat -a", sub { m/.*Hosts: ${nodes}.*/ };
         };
@@ -58,6 +60,8 @@ sub run {
     my $gmetric_max_retries = 3;
     for (1 .. $gmetric_max_retries) {
         eval {
+            # Wait for gmetric update
+            sleep 5;
             # Check if gmetric is available
             assert_script_run "echo \"\\n\" | nc ${server_hostname} 8649 | grep $testMetric";
         };


### PR DESCRIPTION
Fix poo#35269: Ganglia test was migrated to virtio console, but
verification by gstat/gmetric are done to fast over the loop.

- Related ticket: https://progress.opensuse.org/issues/35269
- Needles: none
- Verification run: http://10.100.12.105/tests/1518#
