### PR TITLE
Avoid serial output problems on ipmi backend

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -841,6 +841,7 @@ sub load_inst_tests {
             and !is_hyperv_in_gui
             and !is_bridged_networking
             and !check_var('BACKEND', 's390x')
+            and !check_var('BACKEND', 'ipmi')
             and is_sle('12-SP2+'))
         {
             loadtest "installation/hostname_inst";


### PR DESCRIPTION
Avoid serial output problems on _ipmi backend_ by not loading **hostname_inst** module like for s390x.
**hostname_inst** is loaded when _INSTALLONLY=1_

Failed: http://10.160.66.74/tests/146#step/hostname_inst/7

- Related ticket: https://progress.opensuse.org/issues/32089
- Verification run: http://10.160.66.74/tests/166
