### PR TITLE
Refactor barriers for HPC tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -702,7 +702,8 @@ elsif (get_var("SUPPORT_SERVER")) {
         loadtest "remote/remote_controller";
         load_inst_tests();
     }
-    loadtest "ha/barrier_init" if get_var("HA_CLUSTER");
+    loadtest "ha/barrier_init"  if get_var("HA_CLUSTER");
+    loadtest "hpc/barrier_init" if get_var("HPC");
     unless (load_slenkins_tests()) {
         loadtest "support_server/wait_children";
     }

--- a/tests/hpc/barrier_init.pm
+++ b/tests/hpc/barrier_init.pm
@@ -1,0 +1,67 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Initialization of barriers for HPC multimachine tests
+# Maintainer: Petr Cervinka <pcervinka@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use testapi;
+use lockapi;
+use utils;
+
+sub run {
+    # Get number of nodes
+    my $nodes = get_required_var("CLUSTER_NODES");
+
+    # Initialize barriers
+    if (check_var("HPC", "slurm")) {
+        barrier_create("SLURM_MASTER_SERVICE_ENABLED", $nodes);
+        barrier_create("SLURM_SLAVE_SERVICE_ENABLED",  $nodes);
+        barrier_create("SLURM_SETUP_DONE",             $nodes);
+        barrier_create('SLURM_MASTER_RUN_TESTS',       $nodes);
+    }
+    elsif (check_var("HPC", "mrsh")) {
+        barrier_create("MRSH_INSTALLATION_FINISHED", $nodes);
+        barrier_create("MRSH_KEY_COPIED",            $nodes);
+        barrier_create("MRSH_MUNGE_ENABLED",         $nodes);
+        barrier_create("SLAVE_MRLOGIN_STARTED",      $nodes);
+        barrier_create("MRSH_MASTER_DONE",           $nodes);
+    }
+    elsif (check_var("HPC", "munge")) {
+        barrier_create("MUNGE_INSTALLATION_FINISHED", $nodes);
+        barrier_create('MUNGE_KEY_COPIED',            $nodes);
+        barrier_create("MUNGE_SERVICE_ENABLED",       $nodes);
+        barrier_create('MUNGE_DONE',                  $nodes);
+    }
+    elsif (check_var("HPC", "pdsh")) {
+        barrier_create("PDSH_INSTALLATION_FINISHED", $nodes);
+        barrier_create("PDSH_KEY_COPIED",            $nodes);
+        barrier_create("PDSH_MUNGE_ENABLED",         $nodes);
+        barrier_create("MRSH_SOCKET_STARTED",        $nodes);
+        barrier_create("PDSH_SLAVE_DONE",            $nodes);
+    }
+    elsif (check_var("HPC", "ganglia")) {
+        barrier_create("GANGLIA_INSTALLED",      $nodes);
+        barrier_create("GANGLIA_SERVER_DONE",    $nodes);
+        barrier_create("GANGLIA_CLIENT_DONE",    $nodes);
+        barrier_create("GANGLIA_GMETAD_STARTED", $nodes);
+        barrier_create("GANGLIA_GMOND_STARTED",  $nodes);
+    }
+    else {
+        die("Unsupported test, check content of HPC variable");
+    }
+    record_info("barriers initialized");
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/hpc/ganglia_client.pm
+++ b/tests/hpc/ganglia_client.pm
@@ -26,9 +26,6 @@ sub run {
     my $nodes = get_required_var("CLUSTER_NODES");
     # Get ganglia-server hostname
     my $server_hostname = get_required_var("GANGLIA_SERVER_HOSTNAME");
-    # Synchronize with server
-    mutex_lock("GANGLIA_SERVER_BARRIERS_CONFIGURED");
-    mutex_unlock("GANGLIA_SERVER_BARRIERS_CONFIGURED");
 
     zypper_call 'in ganglia-gmond';
 

--- a/tests/hpc/ganglia_server.pm
+++ b/tests/hpc/ganglia_server.pm
@@ -27,14 +27,6 @@ sub run {
     my $nodes = get_required_var("CLUSTER_NODES");
     # Get hostname
     my $hostname = get_required_var("HOSTNAME");
-    # Create cluster barriers
-    barrier_create("GANGLIA_INSTALLED",      $nodes);
-    barrier_create("GANGLIA_SERVER_DONE",    $nodes);
-    barrier_create("GANGLIA_CLIENT_DONE",    $nodes);
-    barrier_create("GANGLIA_GMETAD_STARTED", $nodes);
-    barrier_create("GANGLIA_GMOND_STARTED",  $nodes);
-    # Synchronize all slave nodes with master
-    mutex_create("GANGLIA_SERVER_BARRIERS_CONFIGURED");
 
     zypper_call('in ganglia-gmetad ganglia-gmond ganglia-gmetad-skip-bcheck');
     systemctl 'start gmetad';
@@ -65,10 +57,6 @@ sub run {
 
     # tell client that server is done
     barrier_wait('GANGLIA_SERVER_DONE');
-    # barrier check period is 5 seconds , we sleeping for 6 to cover
-    # case when ganglia-client already reach this barrier but currently
-    # in sleep so it will die with owner already leave error on next check
-    sleep 6;
 }
 
 sub post_fail_hook {

--- a/tests/hpc/mrsh_slave.pm
+++ b/tests/hpc/mrsh_slave.pm
@@ -22,15 +22,10 @@ use utils;
 sub run {
     my $self = shift;
 
-    # Synchronize with master
-    mutex_lock("MRSH_MASTER_BARRIERS_CONFIGURED");
-    mutex_unlock("MRSH_MASTER_BARRIERS_CONFIGURED");
-
     # install mrsh
     zypper_call('in mrsh mrsh-server');
     barrier_wait("MRSH_INSTALLATION_FINISHED");
-    mutex_lock("MRSH_KEY_COPIED");
-    mutex_unlock("MRSH_KEY_COPIED");
+    barrier_wait("MRSH_KEY_COPIED");
 
     # start munge
     $self->enable_and_start('munge');

--- a/tests/hpc/munge_slave.pm
+++ b/tests/hpc/munge_slave.pm
@@ -21,23 +21,17 @@ use utils;
 sub run {
     my $self = shift;
 
-    # Synchronize with master
-    mutex_lock("MUNGE_MASTER_BARRIERS_CONFIGURED");
-    mutex_unlock("MUNGE_MASTER_BARRIERS_CONFIGURED");
-
     # install munge, wait for master and munge key
     zypper_call('in munge');
     barrier_wait('MUNGE_INSTALLATION_FINISHED');
-    mutex_lock('MUNGE_KEY_COPIED');
-    mutex_unlock('MUNGE_KEY_COPIED');
+    barrier_wait('MUNGE_KEY_COPIED');
 
     # start and enable munge
     $self->enable_and_start('munge');
     barrier_wait("MUNGE_SERVICE_ENABLED");
 
     # wait for master to finish
-    mutex_lock('MUNGE_DONE');
-    mutex_unlock('MUNGE_DONE');
+    barrier_wait('MUNGE_DONE');
 }
 
 sub post_fail_hook {

--- a/tests/hpc/pdsh_slave.pm
+++ b/tests/hpc/pdsh_slave.pm
@@ -23,22 +23,16 @@ sub run {
     my $self            = shift;
     my $server_hostname = get_required_var("PDSH_MASTER_HOSTNAME");
 
-    # Synchronize with master
-    mutex_lock("PDSH_MASTER_BARRIERS_CONFIGURED");
-    mutex_unlock("PDSH_MASTER_BARRIERS_CONFIGURED");
-
     my $packages_to_install = 'munge pdsh';
     $packages_to_install .= ' pdsh-genders' if get_var('PDSH_GENDER_TEST');
     zypper_call("in $packages_to_install");
     barrier_wait("PDSH_INSTALLATION_FINISHED");
-    mutex_lock("PDSH_KEY_COPIED");
-    mutex_unlock("PDSH_KEY_COPIED");
+    barrier_wait("PDSH_KEY_COPIED");
 
     # start munge
     $self->enable_and_start('munge');
     barrier_wait("PDSH_MUNGE_ENABLED");
-    mutex_lock("MRSH_SOCKET_STARTED");
-    mutex_unlock("MRSH_SOCKET_STARTED");
+    barrier_wait("MRSH_SOCKET_STARTED");
 
     assert_script_run('echo  "' . $server_hostname . ' type=genders-test" >> /etc/genders') if get_var('PDSH_GENDER_TEST');
 

--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -22,12 +22,6 @@ sub run {
     my $self = shift;
     # Get number of nodes
     my $nodes = get_required_var("CLUSTER_NODES");
-    # Initialize slurm barriers
-    barrier_create("SLURM_MASTER_SERVICE_ENABLED", $nodes);
-    barrier_create("SLURM_SLAVE_SERVICE_ENABLED",  $nodes);
-    barrier_create("SLURM_SETUP_DONE",             $nodes);
-    # Synchronize all slave nodes with master
-    mutex_create("SLURM_MASTER_BARRIERS_CONFIGURED");
 
     # install slurm
     zypper_call('in slurm slurm-munge');
@@ -71,7 +65,7 @@ EOF
     # run the actual test against both nodes
     assert_script_run("srun -N ${nodes} /bin/ls");
 
-    mutex_create('SLURM_MASTER_RUN_TESTS');
+    barrier_wait('SLURM_MASTER_RUN_TESTS');
 }
 
 sub test_flags {

--- a/tests/hpc/slurm_slave.pm
+++ b/tests/hpc/slurm_slave.pm
@@ -22,10 +22,6 @@ use version_utils 'is_sle';
 sub run {
     my $self = shift;
 
-    # Synchronize with master
-    mutex_lock("SLURM_MASTER_BARRIERS_CONFIGURED");
-    mutex_unlock("SLURM_MASTER_BARRIERS_CONFIGURED");
-
     # Install slurm
     zypper_call('in slurm-munge');
     # install slurm-node if sle15, not available yet for sle12
@@ -42,8 +38,7 @@ sub run {
     systemctl 'status slurmd';
     barrier_wait("SLURM_SLAVE_SERVICE_ENABLED");
 
-    mutex_lock("SLURM_MASTER_RUN_TESTS");
-    mutex_unlock("SLURM_MASTER_RUN_TESTS");
+    barrier_wait("SLURM_MASTER_RUN_TESTS");
 }
 
 sub test_flags {


### PR DESCRIPTION
Enhancement poo#35218: Supportserver was renamed to control node.
Barriers initialization was moved from master/server nodes to control
node. Not needed mutex locks were removed from tests.

Relations for master/slave were updated to contain `PARALLEL_WITH=hpc_{TEST}_control`.

- Related ticket: https://progress.opensuse.org/issues/35218
- Needles: none
- Verification run:
control: http://10.100.12.105/tests/1581
master:  http://10.100.12.105/tests/1594
slave:  http://10.100.12.105/tests/1583
