### PR TITLE
Add import of record_soft_failure to lib/susedistribution

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -10,7 +10,7 @@ use version_utils qw(is_hyperv_in_gui is_sle is_leap);
 # don't import script_run - it will overwrite script_run from distribution and create a recursion
 use testapi qw(send_key %cmd assert_screen check_screen check_var get_var save_screenshot
   match_has_tag set_var type_password type_string wait_serial
-  mouse_hide send_key_until_needlematch record_info
+  mouse_hide send_key_until_needlematch record_info record_soft_failure
   wait_still_screen wait_screen_change get_required_var diag);
 
 


### PR DESCRIPTION
Commit https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/7cec2973a0f4f8ab32a10da9428a0f3159c08efc added a call to `record_soft_failure()` in `lib/susedistribution` without also adding it into the imported methods from testapi.

- Related ticket: poo#32926
- Needles: N/A
- Verification run: N/A
