### PR TITLE
Handle output redirection in cloud-config files

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -164,7 +164,7 @@ sub bootmenu_type_console_params {
 
     # See bsc#1011815, last console set as boot parameter is linked to /dev/console
     # and doesn't work if set to serial device.
-    type_string_very_slow "console=tty " unless is_caasp('VMX');
+    type_string_very_slow "console=tty ";
 }
 
 sub uefi_bootmenu_params {


### PR DESCRIPTION
Final stage of cloud-init was writing over login prompt. Updated cloud-config files were already uploaded - poo#34528

Local runs:
 - http://dhcp165.suse.cz//tests/3126#step/first_boot/2 - CaaSP
 - http://dhcp165.suse.cz/tests/3127#step/first_boot/2 - MicroOS

Described at http://cloudinit.readthedocs.io/en/latest/topics/logging.html
```yaml
# default firective
output: { all: "| tee -a /var/log/cloud-init-output.log" }

# new directive
output: {final: '/var/log/cloud-final.log'}
```