### PR TITLE
Force creating correct needles to assert selected tty

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -518,9 +518,9 @@ sub activate_console {
                 handle_password_prompt;
             }
             elsif (match_has_tag("text-login") && !$args{ensure_tty_selected}) {
-                record_soft_failure("poo#32926, couldn't assert tty was switched");
-                # Introduce artificial delay to get better chances to get right tty
-                wait_still_screen 3;
+                # Try to match tty$nr-selected explicitly so we have all correct needles before
+                # making ensure_tty_selected default behavior
+                record_soft_failure("poo#32926, couldn't assert tty was switched") unless check_screen("tty$nr-selected");
                 type_string "$user\n";
                 handle_password_prompt;
             }


### PR DESCRIPTION
As found by @coolo, 3 seconds of wait_still_screen do not resolve the
problem (see
https://openqa.opensuse.org/tests/659550#step/zypper_add_repos/1). So, two solve two issues in one, we will wait 30 seconds before
typing if we don't have correct needle, so we will get all required
needles before we make this assertion by default.

See [poo#32926](https://progress.opensuse.org/issues/32926).
