### PR TITLE
[WIP] Split out the setup of the serial device to reduce the need to schedule consoletest_setup

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -436,6 +436,7 @@ sub load_rescuecd_tests {
 }
 
 sub load_autoyast_clone_tests {
+    loadtest "console/setup_serialdev";
     loadtest "console/system_prepare";
     loadtest "console/consoletest_setup";
     loadtest "console/yast2_clone_system";
@@ -1057,6 +1058,7 @@ sub load_consoletests {
         loadtest "rt/kmp_modules";
     }
     loadtest 'qa_automation/patch_and_reboot' if is_updates_tests && !get_var('QAM_MINIMAL');
+    loadtest "console/setup_serialdev";
     loadtest "console/system_prepare";
     loadtest "console/check_network";
     loadtest "console/system_state";
@@ -1644,6 +1646,7 @@ sub load_rollback_tests {
 }
 
 sub load_extra_tests_filesystem {
+    loadtest "console/setup_serialdev";
     loadtest "console/system_prepare";
     if (get_var("FILESYSTEM", "btrfs") eq "btrfs") {
         loadtest "console/snapper_jeos_cli" if is_jeos;
@@ -2295,7 +2298,7 @@ sub load_extra_tests_syscontainer {
     # pre-conditions for system container tests ie. the tests are running based on preinstalled image
     return if get_var("INSTALLONLY") || get_var("DUALBOOT") || get_var("RESCUECD");
 
-    # setup $serialdev permission and so on
+    loadtest "console/setup_serialdev";
     loadtest "console/system_prepare";
     loadtest "console/check_network";
     loadtest "console/system_state";

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2209,6 +2209,7 @@ sub load_system_prepare_tests {
     loadtest 'console/sle15_workarounds' if is_sle('15+');
     loadtest 'console/integration_services' if is_hyperv || is_vmware;
     loadtest 'console/hostname' unless is_bridged_networking;
+    loadtest 'console/setup_serialdev';
     loadtest 'console/system_prepare';
     loadtest 'console/force_scheduled_tasks' unless is_jeos;
     # Remove repos pointing to download.opensuse.org and add snaphot repo from o3

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -180,6 +180,7 @@ sub load_fixup_firewall {
 sub load_consoletests_minimal {
     return unless (is_staging() && get_var('UEFI') || is_gnome_next || is_krypton_argon);
     # Stagings should test yast2-bootloader in miniuefi at least but not all
+    loadtest "console/setup_serialdev";
     loadtest "console/system_prepare";
     loadtest "console/prepare_test_data";
     loadtest "console/consoletest_setup";
@@ -194,6 +195,7 @@ sub load_consoletests_minimal {
 sub load_otherDE_tests {
     if (get_var("DE_PATTERN")) {
         my $de = get_var("DE_PATTERN");
+        loadtest "console/setup_serialdev";
         loadtest "console/system_prepare";
         loadtest "console/consoletest_setup";
         loadtest "console/hostname";
@@ -250,6 +252,7 @@ sub install_online_updates {
 
 sub load_qam_install_tests {
     return 0 unless get_var('INSTALL_PACKAGES');
+    loadtest "console/setup_serialdev";
     loadtest "console/system_prepare";
     loadtest "console/prepare_test_data";
     loadtest 'console/consoletest_setup';

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -441,6 +441,7 @@ sub load_slenkins_tests {
 }
 
 sub load_feature_tests {
+    loadtest "console/setup_serialdev";
     loadtest "console/system_prepare";
     loadtest "console/consoletest_setup";
     loadtest "feature/feature_console/zypper_releasever";

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -35,7 +35,6 @@ sub run {
     disable_serial_getty;
     # init
     check_console_font;
-
     script_run 'echo "set -o pipefail" >> /etc/bash.bashrc.local';
     script_run '. /etc/bash.bashrc.local';
 

--- a/tests/console/setup_serialdev.pm
+++ b/tests/console/setup_serialdev.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Ensure the serial device can be used for os-autoinst testapi calls
+#   as non-privileged user. This is a prerequisite for every test calling
+#   commands from the testapi, for example "script_run".
+# Maintainer: Oliver Kurz <okurz@suse.de>
+
+use base 'consoletest';
+use testapi;
+use utils 'ensure_serialdev_permissions';
+use strict;
+
+sub run {
+    ensure_serialdev_permissions;
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -23,8 +23,6 @@ sub run {
     my ($self) = @_;
     check_var('BACKEND', 'ipmi') ? use_ssh_serial_console : select_console 'root-console';
 
-    ensure_serialdev_permissions;
-
     # Configure serial consoles for virtio support
     # poo#18860 Enable console on hvc0 on SLES < 12-SP2
     # poo#44699 Enable console on hvc1 to fix login issues on ppc64le

--- a/tests/sysauth/sssd.pm
+++ b/tests/sysauth/sssd.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,7 +19,6 @@ use version;
 
 
 sub run {
-    # Assume consoletest_setup is completed
     select_console 'root-console';
 
     # Install test subjects and test scripts


### PR DESCRIPTION
"consoletest_setup" is a bit of a mixed case: It conducts some steps necessary
for "console" tests but also some of the other test modules that just use the
console or even just an xterm window. This commit splits out the setup of the
serial device which is most likely the most important step so that this step
can be scheduled in more test suite flows where it is needed but
consoletest_setup would be too big.

See https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4900
as a motivation to do this.