### PR TITLE
Adjust iSCSI installation for SLE15

### DIFF
--- a/tests/installation/partitioning_firstdisk.pm
+++ b/tests/installation/partitioning_firstdisk.pm
@@ -17,78 +17,9 @@ use warnings;
 use base "y2logsstep";
 use testapi;
 use version_utils 'is_storage_ng';
-
-sub take_first_disk_storage_ng {
-    return unless is_storage_ng;
-    send_key $cmd{guidedsetup};    # select guided setup
-    assert_screen 'select-hard-disks';
-    # It's not always the case that SUT has 2 drives, for ipmi it's changing
-    # So making it flexible, still assert the screen if want to verify explicitly
-    assert_screen [qw(existing-partitions hard-disk-dev-sdb-selected)];
-    if (match_has_tag 'hard-disk-dev-sdb-selected' || get_var('SELECT_FIRST_DISK')) {
-        if (check_var('VIDEOMODE', 'text')) {
-            if (match_has_tag 'hotkey_d') {
-                send_key 'alt-d';
-            }
-            elsif (match_has_tag 'hotkey_e') {
-                send_key 'alt-e';
-            }
-            else {
-                die 'Needle needs tag \'hotkey_d\' or \'hotkey_e\'';
-            }
-        }
-        else {
-            assert_and_click 'hard-disk-dev-sdb-selected';    # Unselect second drive
-        }
-        assert_screen 'select-hard-disks-one-selected';
-        send_key $cmd{next};
-    }
-
-    # If drive is not formatted, we have select hard disks page
-    # On ipmi we always have unformatted drive
-    if (get_var('ISO_IN_EXTERNAL_DRIVE') || check_var('BACKEND', 'ipmi')) {
-        assert_screen 'existing-partitions';
-        send_key $cmd{next};
-    }
-    assert_screen 'partition-scheme';
-    send_key $cmd{next};
-    # select btrfs file system
-    if (check_var('VIDEOMODE', 'text')) {
-        assert_screen 'select-root-filesystem';
-        send_key 'alt-f';
-        send_key_until_needlematch 'filesystem-btrfs', 'down', 10, 3;
-        send_key 'ret';
-    }
-    else {
-        assert_and_click 'default-root-filesystem';
-        assert_and_click "filesystem-btrfs";
-    }
-    assert_screen "btrfs-selected";
-    send_key $cmd{next};
-}
-
-sub take_first_disk {
-    # create partitioning
-    send_key $cmd{createpartsetup};
-    assert_screen 'prepare-hard-disk';
-
-    wait_screen_change {
-        send_key 'alt-1';
-    };
-    send_key $cmd{next};
-
-    assert_screen 'use-entire-disk';
-    wait_screen_change {
-        send_key 'alt-e';
-    };
-    send_key $cmd{next};
-}
+use partition_setup 'take_first_disk';
 
 sub run {
-    if (is_storage_ng) {
-        take_first_disk_storage_ng;
-        return 1;
-    }
     take_first_disk;
 }
 

--- a/tests/installation/partitioning_iscsi.pm
+++ b/tests/installation/partitioning_iscsi.pm
@@ -15,18 +15,11 @@
 use strict;
 use base "y2logsstep";
 use testapi;
+use partition_setup 'take_first_disk';
 
 sub run {
-    send_key "alt-c";    # create partition setup
-    wait_still_screen(2);
-    assert_screen "preparing-disk-select-iscsi-disk";
-    send_key "alt-1";    # select ISCSI disk
-    send_key $cmd{next};
-    if (check_screen "preparing-disk-use-entire-disk-button", 10) {
-        send_key "alt-e";    # use entire iscsi disk
-    }
-    assert_screen "preparing-disk-overview";
-    send_key $cmd{next};
+    # Select iSCSI disk for installation
+    take_first_disk iscsi => 1;
 }
 
 1;


### PR DESCRIPTION
Test never worked for SLE15 and is still currently broken for all
distributions as requires changes in the backend
[PR#949](https://github.com/os-autoinst/os-autoinst/pull/949).

NOTE: see [PR#949](https://github.com/os-autoinst/os-autoinst/pull/949).

- [poo#23554](https://progress.opensuse.org/issues/23554)
- [Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/818)
- Verification runs:
  * [first_disk](http://g226.suse.de/tests/1732) refactoring didn't break it =D
  * [ibft SLE15](http://g226.suse.de/tests/1735)
  * [ibft SLE12](http://g226.suse.de/tests/1738)
