### PR TITLE
Do not let the module fail on known dns_srv + s390x bug

### DIFF
--- a/tests/console/dns_srv.pm
+++ b/tests/console/dns_srv.pm
@@ -16,11 +16,6 @@ use testapi;
 use utils qw(is_bridged_networking systemctl);
 
 sub run {
-    # Skip the entire test on bridget networks (e.g. Xen, Hyper-V)
-    if (is_bridged_networking) {
-        record_soft_failure 'Bug 1064438: "bind" cannot resolve localhost';
-        return;
-    }
     select_console 'root-console';
 
     # Install bind
@@ -36,7 +31,13 @@ sub run {
     systemctl 'show -p SubState named.service|grep SubState=running';
 
     # verify dns server responds to anything
-    assert_script_run "host localhost localhost";
+    my $e = script_run "host localhost localhost";
+    if ($e) {
+        record_soft_failure 'Bug 1064438: "bind" cannot resolve localhost' if get_var('S390_ZKVM');
+        record_info 'Skip the entire test on bridged networks (e.g. Xen, Hyper-V)' if (is_bridged_networking);
+        return if (is_bridged_networking || get_var('S390_ZKVM'));
+        die "Command 'host localhost localhost' failed, cannot resolv localhost";
+    }
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/34990
- Verification run:
  - x86_64: http://10.160.66.74/tests/186#step/dns_srv/16
  - (not able to find a working shared worker)
