### PR TITLE
Remove soft-failure for 12-SP2 LTSS release note

### DIFF
--- a/tests/installation/releasenotes.pm
+++ b/tests/installation/releasenotes.pm
@@ -69,11 +69,6 @@ sub run {
 
     # no relnotes for ltss in QAM_MINIMAL
     push @no_relnotes, qw(ltss) if get_var('QAM_MINIMAL');
-    # no relnotes for ltss for SLE12-SP2 ltss
-    if (is_sle('=12-sp2')) {
-        push @no_relnotes, qw(ltss);
-        record_soft_failure 'bsc#1088636 - not updated release note for 12-SP2 LTSS';
-    }
     # no HA-GEO release-notes for s390x on SLE12-SP1 GM media, see bsc#1033504
     if (check_var('ARCH', 's390x') and check_var('BASE_VERSION', '12-SP1')) {
         push @no_relnotes, qw(geo);


### PR DESCRIPTION
Workaround bsc#1088636: Release note for 12-SP2 LTSS was created,
workaround is not needed anymore.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1088636
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/821
- Verification run: http://10.100.12.105/tests/1716#step/releasenotes/5
