### PR TITLE
Adapt and reuse extra test for migration cases

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1428,6 +1428,8 @@ sub load_extra_tests {
     loadtest "console/hostname";
     if (any_desktop_is_applicable()) {
         load_extra_tests_desktop;
+        # both load console test and x11 test in one job for migration test
+        load_extra_tests_textmode if (check_var('EXTRATEST', 'upgrade'));
     }
     else {
         load_extra_tests_textmode;


### PR DESCRIPTION
Reuse extra regression test for migration case
Both load extra console test and x11 test in one job with `extra=upgrade`

-See Poo#35194

- Related ticket: https://progress.opensuse.org/issues/35194
- Verification run: 
* Migration case run : http://10.67.17.147/tests/108
* Extra test run after migration: http://10.67.17.147/tests/127
