### PR TITLE
SLE11 SP4 kde desktop do not need type username

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -441,7 +441,8 @@ sub wait_boot {
         handle_emergency if (match_has_tag('emergency-shell') or match_has_tag('emergency-mode'));
 
         if (!$nologin) {
-            if (get_var('DM_NEEDS_USERNAME') || check_var('VERSION', '11-SP4')) {
+            # SLE11 SP4 kde desktop do not need type username
+            if (get_var('DM_NEEDS_USERNAME')) {
                 type_string "$username\n";
             }
             # log in


### PR DESCRIPTION
Fix poo#34993, avoid to type username into password field

- Related ticket: https://progress.opensuse.org/issues/34993
- Verification run: http://10.67.18.165/tests/overview?build=574.1&distri=sle&version=15
