### PR TITLE
Schedule wine only on supported archs i586+x86_64

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1354,7 +1354,7 @@ sub load_extra_tests_desktop {
             loadtest "x11/multi_users_dm";
         }
         # wine is only in openSUSE for various reasons, including legal ones
-        loadtest 'x11/wine';
+        loadtest 'x11/wine' if get_var('ARCH', '') =~ /x86_64|i586/;
 
     }
     # the following tests care about network and need some DE specific


### PR DESCRIPTION
See https://openqa.opensuse.org/tests/660185#step/wine/26

Local schedule verification:

x86_64:

```
scheduling boot_to_desktop tests/boot/boot_to_desktop.pm
scheduling consoletest_setup tests/console/consoletest_setup.pm
scheduling hostname tests/console/hostname.pm
scheduling x11_setup tests/x11/x11_setup.pm
scheduling firefox_java tests/x11/firefox/firefox_java.pm
scheduling seahorse tests/x11/seahorse.pm
scheduling steam tests/x11/steam.pm
scheduling chrome tests/x11/chrome.pm
scheduling multi_users_dm tests/x11/multi_users_dm.pm
scheduling wine tests/x11/wine.pm
scheduling yast2_lan_restart tests/x11/yast2_lan_restart.pm
scheduling yast2_lan_restart_devices tests/x11/yast2_lan_restart_devices.pm
scheduling hwsim_wpa2_enterprise_setup tests/x11/network/hwsim_wpa2_enterprise_setup.pm
scheduling yast2_network_setup tests/x11/network/yast2_network_setup.pm
scheduling NM_wpa2_enterprise tests/x11/network/NM_wpa2_enterprise.pm
```

aarch64:

```
scheduling boot_to_desktop tests/boot/boot_to_desktop.pm
scheduling consoletest_setup tests/console/consoletest_setup.pm
scheduling hostname tests/console/hostname.pm
scheduling x11_setup tests/x11/x11_setup.pm
scheduling firefox_java tests/x11/firefox/firefox_java.pm
scheduling seahorse tests/x11/seahorse.pm
scheduling multi_users_dm tests/x11/multi_users_dm.pm
scheduling yast2_lan_restart tests/x11/yast2_lan_restart.pm
scheduling yast2_lan_restart_devices tests/x11/yast2_lan_restart_devices.pm
scheduling hwsim_wpa2_enterprise_setup tests/x11/network/hwsim_wpa2_enterprise_setup.pm
scheduling yast2_network_setup tests/x11/network/yast2_network_setup.pm
scheduling NM_wpa2_enterprise tests/x11/network/NM_wpa2_enterprise.pm
```