### PR TITLE
wine test is only for x86* since it downloads an x86 exe for the test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1353,7 +1353,7 @@ sub load_extra_tests_desktop {
             loadtest "x11/multi_users_dm";
         }
         # wine is only in openSUSE for various reasons, including legal ones
-        loadtest 'x11/wine';
+        loadtest 'x11/wine' if (check_var('ARCH', 'i586') || check_var('ARCH', 'x86_64'));
 
     }
     # the following tests care about network and need some DE specific


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/35341
