### PR TITLE
Use grub to detect reboot

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -162,7 +162,8 @@ sub run {
         #Verify timeout and continue if there was a match
         next unless verify_timeout_and_check_screen(($timer += $check_time), \@needles);
         if (match_has_tag('autoyast-boot')) {
-            send_key 'ret';    # grub timeout is disable, so press any key is needed to pass the grub
+            send_key 'ret';    # press enter if grub timeout is disabled, like we have in reinstall scenarios
+            last;              # if see grub, we get to the second stage, as it appears after bios-boot which we may miss
         }
         #repeat until timeout or login screen
         elsif (match_has_tag('nonexisting-package')) {
@@ -266,7 +267,9 @@ sub run {
             $num_errors++;
         }
         elsif (match_has_tag('autoyast-boot')) {
-            send_key 'ret';    # grub timeout is disable, so press any key is needed to pass the grub
+            # if we matched bios-boot tag during stage1 we may get grub menu, legacy behavior
+            # keep it as a fallback if grub timeout is disabled
+            send_key 'ret';
         }
         elsif (match_has_tag('warning-pop-up')) {
             handle_warnings;    # Process warnings during stage 2
@@ -287,4 +290,3 @@ sub post_fail_hook {
 }
 
 1;
-


### PR DESCRIPTION
Normally in the runs we are able to match bios-boot needle, but in some
scenarios we are to slow and already get grub menu which appears
afterwards. In case of the ay test for error detection during second
stage, we fail to do so as still are in the loop of the first stage
which is wrong. So exit the loop if detected grub.

We still have to leave second grub menu detection because we may match
bios-boot and stuck in grub if it has no timeout. This is done only
because we may break a lot of tests if remove bios-boot needles.

See [poo#34654](https://progress.opensuse.org/issues/34654).

- Verification runs:
  * [error dialog](http://g226.suse.de/tests/1747)
  * [reinstall scenario](http://g226.suse.de/tests/1757)
