### PR TITLE
Uncheck scc beta filter and assert screen change

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -308,6 +308,7 @@ sub fill_in_registration_data {
                 else {
                     send_key 'alt-f';    # uncheck 'Filter Out Beta Version'
                 }
+                assert_screen('scc-beta-filter-unchecked');
             }
             my @scc_addons = split(/,/, get_var('SCC_ADDONS', ''));
             # remove emty elements


### PR DESCRIPTION
Make sure 'Hide Beta Versions' unchecked before going forward,
otherwise it will cause problem such as the cursor is back to
scc-beta-filter-checkbox area unexpectly

- Related ticket: https://progress.opensuse.org/issues/34465
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/823
- Verification run: http://openqa-apac1.suse.de/tests/822#step/patch_before_migration/30
