### PR TITLE
Login only if system was rebooted

### DIFF
--- a/tests/caasp/stack_worker.pm
+++ b/tests/caasp/stack_worker.pm
@@ -32,9 +32,10 @@ sub run {
 
 sub post_run_hook {
     # Cluster was rebooted during stack tests
-    reset_consoles;
-    select_console 'root-console';
-
+    if (check_screen 'linux-login-casp', 0) {
+        reset_consoles;
+        select_console 'root-console';
+    }
     export_cluster_logs;
 }
 


### PR DESCRIPTION
If controller job does not reach reboot tests then we don't need to login again on worker nodes

Fix for: https://openqa.suse.de/tests/1640372#step/stack_worker/2