### PR TITLE
svirt: Remove <on_reboot> before setting it

### DIFF
--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -57,6 +57,8 @@ sub run {
         $svirt->change_domain_element(os => boot => {dev => 'cdrom'}) if get_var('ISO');
     }
 
+    # Unless os-autoinst PR#956 is deployed we have to remove 'on_reboot' first
+    $svirt->change_domain_element(on_reboot => undef);
     $svirt->change_domain_element(on_reboot => 'destroy');
 
     my $dev_id = 'a';


### PR DESCRIPTION
Commit f5418ea3149a89a0075deac5c0001bbcfc7512c3 caused a regression on
Xen:

```
error: Failed to define domain from /var/lib/libvirt/images/openQA-SUT-1.xml
error: unsupported configuration: unknown on_reboot action: destroydestroy
```

Proper fix in os-autoinst PR#956.

Fails here: https://openqa.suse.de/tests/1639441
Validation run: http://nilgiri.suse.cz/tests/488