### PR TITLE
Select cri-o container runtime

### DIFF
--- a/tests/caasp/stack_configure.pm
+++ b/tests/caasp/stack_configure.pm
@@ -28,6 +28,13 @@ sub velum_config {
     # Install Tiller
     send_key 'spc';
 
+    # Select container runtime
+    if (check_var('CONTAINER_RUNTIME', 'cri-o')) {
+        send_key 'pgdn';
+        assert_and_click 'container-runtime-cri-o';
+        wait_still_screen 3;
+    }
+
     # Make sure next button is visible
     send_key 'pgdn';
     assert_and_click "velum-next";

--- a/tests/caasp/stack_kubernetes.pm
+++ b/tests/caasp/stack_kubernetes.pm
@@ -31,6 +31,10 @@ sub run {
     my $nodes_count = get_required_var("STACK_NODES");
     assert_script_run "kubectl get nodes --no-headers | wc -l | grep $nodes_count";
 
+    # Check container runtime [docker|cri-o]
+    my $runtime = get_var('CONTAINER_RUNTIME', 'docker');
+    assert_script_run "kubectl describe nodes | grep -c Runtime.*$runtime | grep $nodes_count";
+
     # Deploy nginx minimal application and check pods started succesfully
     my $pods_count = get_required_var("STACK_WORKERS") * 15;
     assert_script_run "kubectl run nginx --image=nginx:stable-alpine --replicas=$pods_count --port=80";


### PR DESCRIPTION
Deploy cluster with cri-o container runtime and check afterwards. OpenQA tests are already set up.

Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/824
Local run: http://dhcp165.suse.cz/tests/3153