### PR TITLE
Adapt partitioning_filesystem for ipmi

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -835,7 +835,7 @@ sub load_inst_tests {
         if (get_var("IBFT")) {
             loadtest "installation/partitioning_iscsi";
         }
-        if (uses_qa_net_hardware() || get_var('SELECT_FIRST_DISK') || get_var("ISO_IN_EXTERNAL_DRIVE")) {
+        if ((uses_qa_net_hardware() && !get_var('FILESYSTEM')) || get_var('SELECT_FIRST_DISK') || get_var("ISO_IN_EXTERNAL_DRIVE")) {
             loadtest "installation/partitioning_firstdisk";
         }
         loadtest "installation/partitioning_finish";

--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -17,7 +17,7 @@ use testapi;
 use version_utils 'is_storage_ng';
 use installation_user_settings 'await_password_check';
 
-our @EXPORT = qw(addpart addlv create_new_partition_table enable_encryption_guided_setup take_first_disk unselect_xen_pv_cdrom);
+our @EXPORT = qw(addpart addlv create_new_partition_table enable_encryption_guided_setup select_first_hard_disk take_first_disk unselect_xen_pv_cdrom);
 
 my %role = qw(
   OS alt-o
@@ -185,6 +185,28 @@ sub addlv {
     send_key(is_storage_ng() ? $cmd{next} : $cmd{finish});
 }
 
+sub select_first_hard_disk {
+    assert_screen [qw(existing-partitions hard-disk-dev-sdb-selected)];
+    if (match_has_tag 'hard-disk-dev-sdb-selected' || get_var('SELECT_FIRST_DISK')) {
+        if (check_var('VIDEOMODE', 'text')) {
+            if (match_has_tag 'hotkey_d') {
+                send_key 'alt-d';
+            }
+            elsif (match_has_tag 'hotkey_e') {
+                send_key 'alt-e';
+            }
+            else {
+                die 'Needle needs tag \'hotkey_d\' or \'hotkey_e\'';
+            }
+        }
+        else {
+            assert_and_click 'hard-disk-dev-sdb-selected';    # Unselect second drive
+        }
+        assert_screen 'select-hard-disks-one-selected';
+        send_key $cmd{next};
+    }
+}
+
 # On Xen PV "CDROM" is of the same type as a disk block device so YaST
 # naturally sees it as a "disk". We have to uncheck the "CDROM".
 sub unselect_xen_pv_cdrom {
@@ -225,25 +247,7 @@ sub take_first_disk_storage_ng {
     assert_screen 'select-hard-disks';
     # It's not always the case that SUT has 2 drives, for ipmi it's changing
     # So making it flexible, still assert the screen if want to verify explicitly
-    assert_screen [qw(existing-partitions hard-disk-dev-sdb-selected)];
-    if (match_has_tag 'hard-disk-dev-sdb-selected' || get_var('SELECT_FIRST_DISK')) {
-        if (check_var('VIDEOMODE', 'text')) {
-            if (match_has_tag 'hotkey_d') {
-                send_key 'alt-d';
-            }
-            elsif (match_has_tag 'hotkey_e') {
-                send_key 'alt-e';
-            }
-            else {
-                die 'Needle needs tag \'hotkey_d\' or \'hotkey_e\'';
-            }
-        }
-        else {
-            assert_and_click 'hard-disk-dev-sdb-selected';    # Unselect second drive
-        }
-        assert_screen 'select-hard-disks-one-selected';
-        send_key $cmd{next};
-    }
+    select_first_hard_disk;
 
     # If drive is not formatted, we have select hard disks page
     # On ipmi we always have unformatted drive

--- a/tests/installation/partitioning_filesystem.pm
+++ b/tests/installation/partitioning_filesystem.pm
@@ -15,7 +15,7 @@ use strict;
 use base "y2logsstep";
 use testapi;
 use version_utils 'is_storage_ng';
-use partition_setup 'unselect_xen_pv_cdrom';
+use partition_setup qw(select_first_hard_disk unselect_xen_pv_cdrom);
 
 sub run {
 
@@ -24,6 +24,8 @@ sub run {
     # open the partinioner
     assert_screen 'edit-proposal-settings';
     wait_screen_change { send_key $cmd{guidedsetup} };
+
+    select_first_hard_disk if (check_screen 'select-hard-disks', 0);
 
     if (get_var('PARTITIONING_WARNINGS')) {
         if (is_storage_ng) {


### PR DESCRIPTION
Adapt partitioning_filesystem for ipmi, being able to select first disk.

- Related ticket: https://progress.opensuse.org/issues/32089
- Verification run:
  - ipmi for partitioning_filesystem with 1 disk: http://10.160.66.74/tests/214#step/partitioning_filesystem/12
  - ipmi for partitioning_filesystem with 2 disks: _We only have IPMI machines with 2 disks on OSD. It can only be verified there._
  - x86_64: http://10.160.66.74/tests/212#step/partitioning_filesystem/11
  - ipmi for partitioning_firstdisk: http://10.160.66.74/tests/213#step/partitioning_firstdisk/7