### PR TITLE
Add php selector to ganglia-server

### DIFF
--- a/tests/hpc/ganglia_server.pm
+++ b/tests/hpc/ganglia_server.pm
@@ -20,6 +20,7 @@ use warnings;
 use testapi;
 use lockapi;
 use utils;
+use version_utils 'is_sle';
 
 sub run {
     my $self = shift;
@@ -40,7 +41,9 @@ sub run {
 
     #install web frontend and start apache
     zypper_call('in ganglia-web');
-    assert_script_run('a2enmod php7');
+    # SLE15 has installed by default php7, SLE12 has php5
+    my $php_mod = is_sle('15+') ? 'php7' : 'php5';
+    script_run('a2enmod ' . $php_mod);
     systemctl('start apache2');
     my $page_url = "http://ganglia-server/ganglia/?r=hour&cs=&ce=&c=unspecified&h=";
     $page_url .= "ganglia-server.openqa.test&tab=m&vn=&hide-hf=false";


### PR DESCRIPTION
Fix poo#35368: Ganglia server test failed on SLE12, because of
different php version installed by default. SLE12 has installed by
default php5 and SLE15 has php7.

assert_script_run was also changed to script_run, because a2enmod don't return
anything useful.

Reproduction of the issue: https://openqa.suse.de/tests/1638628#step/ganglia_server/18

- Related ticket: https://progress.opensuse.org/issues/35368
- Needles: none
- Verification run:
SLE15: http://10.100.12.105/tests/overview?build=581.4&distri=sle&version=15&groupid=127
SLE12: http://10.100.12.105/tests/overview?build=:ganglia&distri=sle&version=12-SP3&groupid=127
