### PR TITLE
JeOS: Do not lose screen resolution on Hyper-V & Xen PV

### DIFF
--- a/tests/console/snapper_jeos_cli.pm
+++ b/tests/console/snapper_jeos_cli.pm
@@ -19,14 +19,17 @@ sub run {
     my ($self) = @_;
 
     select_console('root-console');
-    my $file = '/etc/openQA_snapper_test';
+    my $file       = '/etc/openQA_snapper_test';
+    my $openqainit = 'openqainit';
+    assert_script_run("snapper create -d $openqainit");
     assert_script_run("touch $file");
     my $openqalatest = 'openqalatest';
     assert_script_run("snapper create -d $openqalatest");
     assert_script_run("snapper list");
-    my $latest_snapshot = script_output("snapper list | grep -w $openqalatest | awk '{ print \$3 }' | tr -d '\\n'");
-    my $init_snapshot   = script_output("snapper list | grep 'single.*Initial Status' | awk '{ print \$3 }' | tr -d '\\n'");
-    my $openqarollback  = 'openqarollback';
+    my $openqainit_snapshot = script_output("snapper list | grep -w $openqainit | awk '{ print \$3 }' | tr -d '\\n'");
+    my $latest_snapshot     = script_output("snapper list | grep -w $openqalatest | awk '{ print \$3 }' | tr -d '\\n'");
+    my $init_snapshot       = script_output("snapper list | grep 'single.*$openqainit' | awk '{ print \$3 }' | tr -d '\\n'");
+    my $openqarollback      = 'openqarollback';
     assert_script_run("snapper rollback -d $openqarollback $init_snapshot");
     assert_script_run("snapper list");
     power_action('reboot');
@@ -44,6 +47,14 @@ sub run {
     assert_script_run("snapper list");
     assert_script_run("ls -l $file");
     assert_script_run("rm -v $file");
+    assert_script_run("snapper rollback $openqainit_snapshot");
+    assert_script_run("snapper list");
+    power_action('reboot');
+    $self->wait_boot;
+
+    select_console('root-console');
+    assert_script_run("snapper list");
+    assert_script_run("! ls -l $file");
 }
 
 1;


### PR DESCRIPTION
On Hyper-V the default screen resolution is higher than the openQA
standard one, on Xen PV it's lower, so we have to make it permanent in
grub configuration. Formerly we were loosing the configuration because
we were rolling back to Initial snapshot which does not have it. Now we
rollback to a custom snapshot.

Fails here: https://openqa.suse.de/tests/1640722#step/snapper_jeos_cli/39
Validation runs:
* jeos-filesystem@svirt-hyperv: http://nilgiri.suse.cz/tests/499
* jeos-filesystem@svirt-xen-pv: http://nilgiri.suse.cz/tests/505