### PR TITLE
other_DE: Reset lightdm settings after installing a new DE

### DIFF
--- a/tests/console/install_otherDE_pattern.pm
+++ b/tests/console/install_otherDE_pattern.pm
@@ -30,8 +30,8 @@ sub run {
     }
     assert_script_run("zypper -n in -t $zypp_type $pattern", 600);
 
-    # Toggle the default window manager
-    assert_script_run("sed -i 's/DEFAULT_WM=.*/DEFAULT_WM=\"${pattern}\"/' /etc/sysconfig/windowmanager");
+    # Reset the state of lightdm, to have the new default in use (lightdm saves what the user's last session was)
+    assert_script_run("rm ~lightdm/.cache/lightdm-gtk-greeter/state /var/lib/AccountsService/users/*");
 }
 
 sub test_flags {


### PR DESCRIPTION
lightdm stores the last session used for login by name, not by refering
to 'default', so once a new DE is installed which changes the
xsession-default.desktop (via update-alternatives), this is not direcly
used by lightdm.

Reset the lightdm cached information to get the next login done using
the configured system default.

Additionally, clean up setting the default_wm in
/etc/sysconfig/windowmanager: this file has been deprecated after Leap
42.x.

- Related ticket: https://progress.opensuse.org/issues/33334
- Needles: N/A
- Verification run: http://dimstar.internet-box.ch:81/tests/129

