### PR TITLE
Installer environment is determined by VIDEOMODE

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -190,7 +190,7 @@ sub addlv {
 sub unselect_xen_pv_cdrom {
     if (check_var('VIRSH_VMM_TYPE', 'linux')) {
         assert_screen 'select-hard-disk';
-        if (get_var('TEXTMODE')) {
+        if (check_var('VIDEOMODE', 'text')) {
             send_key_until_needlematch 'uncheck-install-medium', 'tab';
             send_key 'spc';
         }


### PR DESCRIPTION
It is `VIDEOMODE` not `TEXTMODE` variable which determines environment
of the installer. Changing it accordingly for `unselect_xen_pv_cdrom()`.

Fails here:
* ext4@svirt-xen-pv: https://openqa.suse.de/tests/1642236#step/partitioning_filesystem/25
* create_hdd_textmode@svirt-xen-pv: https://openqa.suse.de/tests/1642240#step/partitioning_togglehome/24

Validation runs:
* ext4@svirt-xen-pv: http://nilgiri.suse.cz/tests/512
* create_hdd_textmode@svirt-xen-pv: http://nilgiri.suse.cz/tests/511

Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/827