### PR TITLE
Clean up patch_before_migration

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -566,12 +566,14 @@ sub load_patching_tests {
     }
     set_var('BOOT_HDD_IMAGE', 1);
     boot_hdd_image;
-    loadtest 'update/patch_before_migration';
+    loadtest 'update/patch_sle';
     if (is_upgrade) {
         # Lock package for offline migration by Yast installer
         if (get_var('LOCK_PACKAGE') && !installzdupstep_is_applicable) {
             loadtest 'console/lock_package';
         }
+        loadtest 'migration/remove_ltss';
+        loadtest 'migration/record_disk_info';
         # Reboot from DVD and perform upgrade
         loadtest "migration/reboot_to_upgrade";
         # After original system patched, switch to UPGRADE_TARGET_VERSION
@@ -968,7 +970,9 @@ else {
         # Use autoyast to perform origin system installation
         load_default_autoyast_tests;
         # Load this to perform some other actions before upgrade even though registration and patching is controlled by autoyast
-        loadtest 'update/patch_before_migration';
+        loadtest 'update/patch_sle';
+        loadtest 'migration/remove_ltss';
+        loadtest 'migration/record_disk_info';
         loadtest "migration/version_switch_upgrade_target";
         load_default_tests;
         loadtest "migration/post_upgrade";

--- a/tests/migration/record_disk_info.pm
+++ b/tests/migration/record_disk_info.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Record the disk usage before migration
+# Maintainer: Qingming Su <qmsu@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use migration 'record_disk_info';
+
+sub run {
+    select_console 'root-console';
+
+    # The disk space usage info would be helpful to debug upgrade failure
+    # with disk exhausted error
+    record_disk_info;
+}
+
+1;

--- a/tests/migration/remove_ltss.pm
+++ b/tests/migration/remove_ltss.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Remove LTSS product before migration
+# Maintainer: Qingming Su <qmsu@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use migration 'remove_ltss';
+
+sub run {
+    select_console 'root-console';
+
+    # Migration with LTSS is not possible, remove it before upgrade
+    remove_ltss;
+}
+
+1;


### PR DESCRIPTION
1, version_variable => 'HDDVERSION' is not required with
adoption of version switch during migration
2, replace obsolete sle_version_at_least with is_sle
3, drop use of lib/migration.pm, split remove_ltss
and record_disk_info as separate test modules
4, rename to patch_sle to be a generic module for sle
patching, not only useful during migration
5, remove is_smt_or_module_tests, instead control the
test process with var SCC_REGISTER in test settings
6, move install_patterns and install_packages down to
after system being patched
7, other small cleanups

- Related ticket: https://progress.opensuse.org/issues/30061
- Needles: None
- Verification run: http://openqa-apac1.suse.de/tests/839
