### PR TITLE
zypper_lifecycle: Ensure product name is only matched in its own line

### DIFF
--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -106,7 +106,7 @@ sub run {
 
     my $product_eol;
     for my $l (split /\n/, $overview) {
-        if ($l =~ /(?<!Codestream:)\s+$product_name\s*(\S*)/) {
+        if ($l =~ /^(?<!Codestream:)\s+$product_name\s*(\S*)/) {
             $product_eol = $1;
             last;
         }


### PR DESCRIPTION
Prevent matching in case on our serialdev we have a getty prompt interfering
with the message "Welcome to SUSE Linux Enterprise …".

see https://openqa.suse.de/tests/1642305#step/zypper_lifecycle/34

Related progress issue: https://progress.opensuse.org/issues/32761