### PR TITLE
install_otherDE: do not err in case files to be removed do not exist

### DIFF
--- a/tests/console/install_otherDE_pattern.pm
+++ b/tests/console/install_otherDE_pattern.pm
@@ -31,7 +31,7 @@ sub run {
     assert_script_run("zypper -n in -t $zypp_type $pattern", 600);
 
     # Reset the state of lightdm, to have the new default in use (lightdm saves what the user's last session was)
-    assert_script_run("rm ~lightdm/.cache/lightdm-gtk-greeter/state /var/lib/AccountsService/users/*");
+    assert_script_run("rm -f ~lightdm/.cache/lightdm-gtk-greeter/state /var/lib/AccountsService/users/*");
 }
 
 sub test_flags {


### PR DESCRIPTION
The last fix was a bit ambitious: only Leap so far brings lightdm with minimalX.
On Tumbleweed, the patterns are desynced and still bring xdm for this case, which in
turn means that after switching, there are no lightdm state/cache files yet to be removed.

Followup fix - addresses the new failure seen in
https://openqa.opensuse.org/tests/662515#step/install_otherDE_pattern/8