### PR TITLE
svirt: Support BOOT_HDD_IMAGE

### DIFF
--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -46,6 +46,7 @@ sub run {
         $xenconsole = "xvc0";
     }
 
+    set_var('BOOTFROM', 'c') if get_var('BOOT_HDD_IMAGE');
     if (check_var('BOOTFROM', 'c')) {
         $svirt->change_domain_element(os => boot => {dev => 'hd'});
     }


### PR DESCRIPTION
Reading qemu backend sources `BOOT_HDD_IMAGE` is what users should use,
`BOOTFROM` variable is somewhat secondary in this regard.

Fails here: https://openqa.suse.de/tests/1642243#step/user_defined_snapshot/27
Validation run: http://nilgiri.suse.cz/tests/516