### PR TITLE
Updated nis client/server test

### DIFF
--- a/data/x11/workaround_nfs-kernel-server.xml
+++ b/data/x11/workaround_nfs-kernel-server.xml
@@ -1,0 +1,13 @@
+<?xml version=\"1.0\" encoding=\"utf-8\"?>
+<service>
+  <short>NFS kernel-server test</short>
+  <description>The nfs-kernel-server workaround</description>
+  <port protocol=\"tcp\" port=\"2049\"/>
+  <port protocol=\"udp\" port=\"2049\"/>
+  <port protocol=\"tcp\" port=\"20048\"/>
+  <port protocol=\"udp\" port=\"20048\"/>
+  <port protocol=\"udp\" port=\"51068\"/>
+  <port protocol=\"tcp\" port=\"52385\"/>
+  <port protocol=\"tcp\" port=\"46095\"/>
+  <port protocol=\"udp\" port=\"35672\"/>
+</service>

--- a/data/x11/workaround_ypbind.xml
+++ b/data/x11/workaround_ypbind.xml
@@ -1,0 +1,9 @@
+<?xml version=\"1.0\" encoding=\"utf-8\"?>
+<service>
+  <short>NIS</short>
+  <description>NIS workaround</description>
+  <port protocol=\"tcp\" port=\"111\"/>
+  <port protocol=\"tcp\" port=\"639\"/>
+  <port protocol=\"udp\" port=\"111\"/>
+  <port protocol=\"udp\" port=\"637\"/>
+</service>

--- a/data/x11/workaround_ypserv.xml
+++ b/data/x11/workaround_ypserv.xml
@@ -1,0 +1,9 @@
+<?xml version=\"1.0\" encoding=\"utf-8\"?>
+<service>
+  <short>NIS</short>
+  <description>NIS workaround</description>
+  <port protocol=\"tcp\" port=\"111\"/>
+  <port protocol=\"udp\" port=\"111\"/>
+  <port protocol=\"tcp\" port=\"913\"/>
+  <port protocol=\"udp\" port=\"913\"/>
+</service>

--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -22,12 +22,23 @@ use utils qw(systemctl turn_off_gnome_screensaver);
 sub run {
     my ($self) = @_;
     x11_start_program('xterm -geometry 155x45+5+5', target_match => 'xterm');
-    turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
     become_root;
+    turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
     configure_default_gateway;
     configure_static_ip('10.0.2.1/24');
     configure_static_dns(get_host_resolv_conf());
-    assert_script_run 'zypper -n in yast2-nis-server';
+    # added nfs for sle15
+    assert_script_run 'zypper -n in yast2-nis-server yast2-nfs-server';
+    if ($self->firewall eq 'firewalld') {
+        my $firewalld_ypserv_service = get_test_data('x11/workaround_ypserv.xml');
+        my $firewalld_nfs_service    = get_test_data('x11/workaround_nfs-kernel-server.xml');
+
+        record_soft_failure('bsc#1083486');
+        assert_script_run("echo \"$firewalld_ypserv_service\" > /usr/lib/firewalld/services/ypserv.xml");
+        assert_script_run("echo \"$firewalld_nfs_service\" > /usr/lib/firewalld/services/nfs-kernel-server.xml");
+        assert_script_run('firewall-cmd --reload');
+    }
+
     type_string "yast2 nis_server\n";
     assert_screen 'nis-server-setup-status';
     send_key 'alt-m';    # NIS master server
@@ -36,17 +47,17 @@ sub run {
     assert_screen 'nis-server-master-server-setup', 90;
     send_key 'tab';      # jump to NIS domain name
     type_string 'nis.openqa.suse.de';
-    send_key 'alt-a';    # unselect active slave NIS server exists checkbox
-    send_key 'alt-f';    # open firewall port
+    wait_screen_change { send_key 'alt-a' };    # unselect active slave NIS server exists checkbox
+    send_key 'alt-f';                           # open firewall port
     wait_still_screen 4;
     save_screenshot;
-    send_key 'alt-o';    # other global setting button
+    send_key 'alt-o';                           # other global setting button
     assert_screen 'nis-server-master-server-detail-setup';
-    send_key 'alt-o';    # OK
+    send_key 'alt-o';                           # OK
     send_key $cmd{next};
     assert_screen 'nis-server-server-maps-setup';
-    send_key 'tab';      # jump to map list
-    my $c = 1;           # select all maps
+    send_key 'tab';                             # jump to map list
+    my $c = 1;                                  # select all maps
     while ($c <= 11) {
         send_key 'spc';
         send_key 'down';
@@ -55,46 +66,46 @@ sub run {
     wait_still_screen 4;
     save_screenshot;
     send_key $cmd{next};
-    send_key 'alt-a';    # add
-    wait_still_screen 4, 4;    # blinking cursor
+    send_key 'alt-a';                           # add
+    wait_still_screen 4, 4;                     # blinking cursor
     type_string '255.255.255.0';
     send_key 'tab';
     type_string '10.0.2.0';
-    send_key 'alt-o';          # OK
+    send_key 'alt-o';                           # OK
     save_screenshot;
-    send_key 'alt-f';          # finish
+    send_key 'alt-f';                           # finish
     assert_screen 'yast2_closed_xterm_visible';
-    mutex_create('nis_ready');    # setup is done client can connect
+    mutex_create('nis_ready');                  # setup is done client can connect
     type_string "yast2 nfs_server\n";
     assert_screen 'nfs-server-configuration';
-    send_key 'alt-f';             # open port in firewall
-    send_key 'alt-m';             # NFSv4 domain name field
+    send_key 'alt-f';                           # open port in firewall
+    send_key 'alt-m';                           # NFSv4 domain name field
     type_string 'nfs.openqa.suse.de';
-    wait_still_screen 4, 4;       # blinking cursor
-    send_key 'alt-s';             # start nfs server
-    wait_still_screen 4, 4;       # blinking cursor
-    send_key 'alt-n';             # next / OK
+    wait_still_screen 4, 4;                     # blinking cursor
+    send_key 'alt-s';                           # start nfs server
+    wait_still_screen 4, 4;                     # blinking cursor
+    send_key 'alt-n';                           # next / OK
     assert_screen 'nfs-server-export';
     send_key 'alt-d';
-    wait_still_screen 4, 4;       # blinking cursor
+    wait_still_screen 4, 4;                     # blinking cursor
     type_string '/home/nis_user';
-    send_key 'alt-o';             # OK
+    send_key 'alt-o';                           # OK
     assert_screen 'nfs-server-directory-does-not-exist';
-    send_key 'alt-y';             # yes, create it
-    wait_still_screen 4, 4;       # blinking cursor
-    send_key 'alt-p';             # go to options field
-    wait_still_screen 4, 4;       # blinking cursor
-    send_key 'left';              # unselect options and leave cursor at beginning
-    wait_still_screen 4, 4;       # blinking cursor
+    send_key 'alt-y';                           # yes, create it
+    wait_still_screen 4, 4;                     # blinking cursor
+    send_key 'alt-p';                           # go to options field
+    wait_still_screen 4, 4;                     # blinking cursor
+    send_key 'left';                            # unselect options and leave cursor at beginning
+    wait_still_screen 4, 4;                     # blinking cursor
     send_key 'delete';
     send_key 'delete';
     send_key 'delete';
-    type_string 'rw,no_';         # rw,no_root_squash
-    wait_still_screen 4, 4;       # blinking cursor
+    type_string 'rw,no_';                       # rw,no_root_squash
+    wait_still_screen 4, 4;                     # blinking cursor
     save_screenshot;
-    send_key 'alt-o';             # OK
+    send_key 'alt-o';                           # OK
     assert_screen 'nfs-server-export';
-    send_key 'alt-f';             # finish
+    send_key 'alt-f';                           # finish
     assert_screen 'yast2_closed_xterm_visible';
     systemctl 'stop ' . $self->firewall;                              # bsc#999873
     script_run 'rpcinfo -u localhost ypserv';                         # ypserv is running


### PR DESCRIPTION
bsc#1089851 -> reporting missing firewalld service files
bsc#1090886 -> yast2 nis client does not mount configured nfs share by itself ( on sle12sp4 works without any issues )

- Related ticket: [[sle][functional][fast][y][easy] test fails in nis_client - needs to install ypbind first](https://progress.opensuse.org/issues/35074)
- Needles: [Updated needles for nis client/server test (font update)](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/828)
- Verification runs: 
[sle-15-Installer-DVD-x86_64-Build581.4-nis_server@64bit](http://dhcp151.suse.cz/tests/2156)
[sle-15-Installer-DVD-x86_64-Build581.4-nis_client@64bit](http://dhcp151.suse.cz/tests/2157)

[sle-12-SP4-Server-DVD-x86_64-Build0236-nis_server@64bit](http://dhcp151.suse.cz/tests/2122)
[sle-12-SP4-Server-DVD-x86_64-Build0236-nis_client@64bit](http://dhcp151.suse.cz/tests/2123)
