### PR TITLE
Disable test for switching into LibreOffice dialog

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -183,44 +183,6 @@ sub open_libreoffice_options {
     }
 }
 
-# check libreoffice dialog windows setting- "gnome dialog" or "libreoffice dialog"
-sub check_libreoffice_dialogs {
-    my ($self) = shift;
-
-    # make sure libreoffice dialog option is disabled status
-    $self->open_libreoffice_options;
-
-    assert_screen("ooffice-tools-options");
-    send_key_until_needlematch('libreoffice-options-general', 'down');
-    assert_screen("libreoffice-general-dialogs-disabled");
-    send_key "alt-o";
-    wait_still_screen 3;
-    send_key "alt-o";
-    assert_screen("libreoffice-gnome-dialogs");
-    send_key "alt-c";
-    wait_still_screen 3;
-
-    # enable libreoffice dialog
-    $self->open_libreoffice_options;
-    assert_screen("libreoffice-options-general");
-    send_key "alt-u";
-    assert_screen("libreoffice-general-dialogs-enabled");
-    send_key "alt-o";
-    wait_still_screen 3;
-    send_key "alt-o";
-    assert_screen("libreoffice-specific-dialogs");
-    send_key "alt-c";
-    wait_still_screen 3;
-
-    # restore the default setting
-    $self->open_libreoffice_options;
-    assert_screen("libreoffice-options-general");
-    send_key "alt-u";
-    wait_still_screen 3;
-    send_key "alt-o";
-
-}
-
 # get email account information for Evolution test cases
 sub getconfig_emailaccount {
     my ($self) = @_;

--- a/tests/x11/libreoffice/libreoffice_open_specified_file.pm
+++ b/tests/x11/libreoffice/libreoffice_open_specified_file.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2017 SUSE LLC
+# Copyright © 2016-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,9 +22,8 @@ sub run {
     wait_still_screen;
     $self->upload_libreoffice_specified_file();
 
-    # check libreoffice dialogs setting
+    # start libreoffice
     x11_start_program('libreoffice');
-    $self->check_libreoffice_dialogs();
 
     # open test files of different formats
     my $i = 0;


### PR DESCRIPTION
New version of Libreoffice misses some options. As the system dialogs are the desired ones (bsc#1084826), this should disable the testcase for switching into LibreOffice-style dialog and back to the system ones.

Related tickets:
- https://progress.opensuse.org/issues/35098
- https://progress.opensuse.org/issues/34144

Verification run: http://panigale.suse.cz/tests/115