### PR TITLE
Fix timeout in check_logs on 3-nodes clusters

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -213,7 +213,7 @@ sub ha_export_logs {
 
     # Extract HA logs and upload them
     script_run "touch $corosync_conf";
-    script_run "hb_report $report_opt -E $bootstrap_log $hb_log", 120;
+    script_run "hb_report $report_opt -E $bootstrap_log $hb_log", 300;
     upload_logs "$bootstrap_log";
     upload_logs "$hb_log.tar.bz2";
 


### PR DESCRIPTION
A sporadic timeout can occurs sometimes on 3-nodes clusters during execution of `check_logs` test.
This PR fix it by increasing the timeout when `hb_report` command is executed.