### PR TITLE
Media upgrade does not need test deregister

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1110,7 +1110,7 @@ sub load_consoletests {
         }
     }
     loadtest 'console/install_all_from_repository' if get_var('INSTALL_ALL_REPO');
-    if (check_var_array('SCC_ADDONS', 'tcm') && get_var('PATTERNS') && sle_version_at_least('12-SP3')) {
+    if (check_var_array('SCC_ADDONS', 'tcm') && get_var('PATTERNS') && is_sle('<15') && !get_var("MEDIA_UPGRADE")) {
         loadtest "feature/feature_console/deregister";
     }
     loadtest 'migration/sle12_online_migration/orphaned_packages_check' if get_var('UPGRADE');


### PR DESCRIPTION
SLE15 does not have tcm anymore,it has integrated into development tools module.But, in this test module, it uses tcm as certain module to test this feature. It has not suitable for SLE15 testing and we do not need to test this module in migration job group.

- Related ticket: https://progress.opensuse.org/issues/32842
- Verification run: http://10.67.18.165/tests/145
