### PR TITLE
Added gnome desktop popup handler - Deja Dup

### DIFF
--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -49,9 +49,17 @@ sub list_locale_etc_settings {
     $self->save_and_upload_log('cat /etc/vconsole.conf',                    '/tmp/vconsole.conf.out');
 }
 
+sub notification_handler {
+    my ($feature, $state) = @_;
+
+    select_console('user-console');
+    assert_script_run("gsettings set " . "$feature " . "$state");
+}
+
 sub verify_default_keymap_x11 {
     my ($test_string, $tag, $program) = @_;
 
+    notification_handler('org.gnome.DejaDup periodic', 'false') if (check_var('DESKTOP', 'gnome'));
     select_console('x11');
     x11_start_program($program);
     type_string($test_string);


### PR DESCRIPTION
Disable Deja Dup monitor in order to prevent desktop notification.

- Related ticket: [[functional][u][fast][medium] test fails in keymap_or_locale - potentially lost focus due to popup?](https://progress.opensuse.org/issues/34321)
- Needles: [Excluded notification area for leap pop-up #354](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/354)
- Verification run: [opensuse-15.0-NET-x86_64-Build219.1-update_Leap_42.2_cryptlvm@uefi](http://dhcp151.suse.cz/tests/2188#step/keymap_or_locale/10)