### PR TITLE
Display login prompt properly

### DIFF
--- a/tests/caasp/stack_worker.pm
+++ b/tests/caasp/stack_worker.pm
@@ -31,8 +31,9 @@ sub run {
 }
 
 sub post_run_hook {
+    send_key 'ret';
     # Cluster was rebooted during stack tests
-    if (check_screen 'linux-login-casp', 0) {
+    if (check_screen 'linux-login-casp', 7) {
         reset_consoles;
         select_console 'root-console';
     }


### PR DESCRIPTION
Fix for: https://openqa.suse.de/tests/1643876#step/stack_worker/1

Problem was introduced with PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4925. I was not able to reproduce it, so without local run.