### PR TITLE
y2logsstep: Use proper wait_screen_change with similarity levels to increase robustness

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -942,7 +942,6 @@ sub load_inst_tests {
             loadtest "installation/sles4sap_wizard_swpm";
         }
     }
-
 }
 
 sub load_consoletests {

--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -76,11 +76,13 @@ sub workaround_dependency_issues {
     }
     else {
         while (check_screen('dependency-issue', 5)) {
-            send_key 'alt-1';
-            sleep 1;
-            send_key 'spc';
-            sleep 1;
-            wait_screen_change { send_key 'alt-o' };
+            wait_screen_change { send_key 'alt-1' };
+            # higher similarity level as this should only select a single
+            # entry, not close the dialog or something
+            wait_screen_change(sub { send_key 'spc' }, undef, similarity_level => 55);
+            # lower similarity level to not confuse the button press for
+            # screen change
+            wait_screen_change(sub { send_key 'alt-o' }, undef, similarity_level => 48);
         }
     }
     return 1;
@@ -154,8 +156,6 @@ sub deal_with_dependency_issues {
         die 'Dependency problems';
     }
 
-    # Press "Esc" in case "Options" menu is open by accident
-    send_key 'esc';
     assert_screen 'dependency-issue-fixed';    # make sure the dependancy issue is fixed now
     send_key 'alt-a';                          # Accept
     sleep 2;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -995,6 +995,7 @@ else {
         load_patching_tests() if get_var('PATCH');
         load_boot_tests();
         load_inst_tests();
+        return 1 if get_var('EXIT_AFTER_START_INSTALL');
         load_reboot_tests();
         loadtest "migration/post_upgrade";
         # Always load zypper_lr test for migration case and get repo information for investigation


### PR DESCRIPTION
This way we should also be able to remove the workaround recently introduced
with aacdfd84 to close the accidentally opened options menu after we confirmed
the last dependency issues with 'alt-o' already but the dependency issue
dialog was in at least one case confirmed twice because the
`wait_screen_change` already triggered on just a button pressed down even
though the dialog never disappeared itself.

By checking the actual similarity levels from the autoinst-log.txt we can set
proper levels for the individual calls.

Verification runs:
 * http://lord.arch/tests/874 and 10 previous ones