### PR TITLE
keymap_or_local: Handle popups more resilient

### DIFF
--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -49,9 +49,17 @@ sub list_locale_etc_settings {
     $self->save_and_upload_log('cat /etc/vconsole.conf',                    '/tmp/vconsole.conf.out');
 }
 
+sub notification_handler {
+    my ($feature, $state) = @_;
+
+    select_console('user-console');
+    assert_script_run("gsettings get $feature && gsettings set $feature $state || true");
+}
+
 sub verify_default_keymap_x11 {
     my ($test_string, $tag, $program) = @_;
 
+    notification_handler('org.gnome.DejaDup periodic', 'false') if (check_var('DESKTOP', 'gnome'));
     select_console('x11');
     x11_start_program($program);
     type_string($test_string);


### PR DESCRIPTION
Add back gnome desktop popup handler but do not fail if DejaDup is not there
in the first place.