### PR TITLE
[xfstests] Support aarch64 and make test more reliable

### DIFF
--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -38,7 +38,7 @@ sub run {
 
     # Install qa_test_xfstests
     zypper_call("--gpg-auto-import-keys ref", timeout => 600);
-    zypper_call("-n in qa_test_xfstests",     timeout => 1200);
+    zypper_call("in qa_test_xfstests",        timeout => 1200);
     assert_script_run("/usr/share/qa/qa_test_xfstests/install.sh", 600);
 
     # Create log file

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -23,7 +23,7 @@ sub run {
     select_console('root-console');
 
     # Install parted
-    zypper_call("-n in parted", timeout => 600);
+    zypper_call("in parted", timeout => 600);
 
     # Create partitions
     my ($filesystem, $category) = split(/-/, get_var("XFSTESTS"));


### PR DESCRIPTION
1. Add in_grub option to wait_boot to support aarch64 kdump.
2. When heartbeat stops, first wait 60s for SUT to do kdump and reboot. If that fails, force reset the machine and wait_boot again.

- Related ticket: https://progress.opensuse.org/issues/20510
- Verification run: http://10.67.133.102/tests/338