### PR TITLE
Enhance search of y2logs errors in installation

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -120,15 +120,22 @@ done", "binaries-with-missing-libraries.txt", {timeout => 60, noupload => 1});
 sub investigate_yast2_failure {
     my ($self) = shift;
 
+    my $error_detected;
     # first check if badlist exists which could be the most likely problem
     if (my $badlist = script_output 'test -f /var/log/YaST2/badlist && cat /var/log/YaST2/badlist | tail -n 20 || true') {
         record_info 'Likely error detected: badlist', "badlist content:\n\n$badlist", result => 'fail';
+        $error_detected = 1;
     }
-    if (my $y2log_internal_error = script_output 'grep -B 3 \'Internal error. Please report a bug report\' /var/log/YaST2/y2log | tail -n 20 || true') {
-        record_info 'Internal error in YaST2 detected', "Details:\n\n$y2log_internal_error", result => 'fail';
+    # Array with possible strings to search in YaST2 logs
+    my @y2log_errors = ('Internal error. Please report a bug report', '<3>', 'No textdomain configured');
+    for my $y2log_error (@y2log_errors) {
+        if (my $y2log_error_result = script_output 'grep -B 3 \'' . $y2log_error . '\' /var/log/YaST2/y2log | tail -n 20 || true') {
+            record_info 'YaST2 log error detected', "Details:\n\n$y2log_error_result", result => 'fail';
+            $error_detected = 1;
+        }
     }
-    elsif (my $y2log_other_error = script_output 'grep -B 3 \'<3>\' /var/log/YaST2/y2log | tail -n 20 || true') {
-        record_info 'Other error in YaST2 detected', "Details:\n\n$y2log_other_error", result => 'fail';
+    if (get_var('ASSERT_Y2LOGS') && $error_detected) {
+        die "YaST2 error(s) detected. Please, check details";
     }
 }
 

--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -236,7 +236,10 @@ sub save_upload_y2logs {
 sub post_fail_hook {
     my $self = shift;
     get_to_console;
-    $self->save_upload_y2logs;
+
+    # Avoid collectin logs twice when investigate_yast2_failure() is inteded to hard-fail
+    $self->save_upload_y2logs unless get_var('ASSERT_Y2LOGS');
+
     if (get_var('FILESYSTEM', 'btrfs') =~ /btrfs/) {
         assert_script_run 'btrfs filesystem df /mnt | tee /tmp/btrfs-filesystem-df-mnt.txt';
         assert_script_run 'btrfs filesystem usage /mnt | tee /tmp/btrfs-filesystem-usage-mnt.txt';

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -44,4 +44,8 @@ sub run {
     $self->save_upload_y2logs();
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;


### PR DESCRIPTION
Enhance (more scalable solution) search of y2logs errors/warning or any string to allow warnings to be detected by openQA and are not be hidden.

- Related ticket: https://progress.opensuse.org/issues/33931
- Verification run: 
  - http://dhcp254.suse.cz/tests/1162#step/logs_from_installation_system/41
