### PR TITLE
Timeout command before it fails

### DIFF
--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -256,7 +256,7 @@ sub script_retry {
     for (1 .. $retry) {
         type_string "# Trying $_ of $retry:\n";
 
-        $ret = script_run($cmd);
+        $ret = script_run "timeout 25 $cmd";
         last if defined($ret) && $ret == $ecode;
 
         die("Waiting for Godot: $cmd") if $retry == $_;


### PR DESCRIPTION
Command should timeout before script_run fails to not make red squares when not needed.
Default script_run timeout is 30s, so timeout 25 should work fine.

Fix for: https://openqa.suse.de/tests/1651835#step/stack_reboot/19
Local run:
 - http://dhcp165.suse.cz/tests/3403#step/stack_initialize/23 - with timeout
 - http://dhcp165.suse.cz/tests/3409#step/stack_initialize/23 - without timeout