### PR TITLE
sles4sap/netweaver: Add sapinst_dev.log on failure

### DIFF
--- a/tests/sles4sap/netweaver_ascs_install.pm
+++ b/tests/sles4sap/netweaver_ascs_install.pm
@@ -126,6 +126,7 @@ sub post_fail_hook {
     $self->save_and_upload_log('ls -alF /sapinst/unattended', '/tmp/nw_unattended_ls.log');
     $self->save_and_upload_log('ls -alF /sbin/mount*',        '/tmp/sbin_mount_ls.log');
     upload_logs "/sapinst/unattended/sapinst.log";
+    upload_logs "/sapinst/unattended/sapinst_dev.log";
 }
 
 1;


### PR DESCRIPTION
Upload `sapinst_dev.log` file when `tests/sles4sap/netweaver_ascs_install` fails.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/348
