### PR TITLE
[xfstests] Add testcase name into console output

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -150,6 +150,7 @@ sub run {
         }
 
         my $name = "$category-$test";
+        script_run("echo '$category/$test:' | tee /dev/$serialdev");
         test_run($category, $test);
         my ($type, $status, $time) = test_wait;
         if ($type eq $HB_DONE) {


### PR DESCRIPTION
After last update for xfstests in openQA, we can't analysis "call trace" print in console caused by which testcase, this PR simply add a testcase output before each test run. To add a flag for easy analysis.

- Verification run: http://10.67.133.102/tests/341
    And output can be seen in http://10.67.133.102/tests/341/file/serial0.txt
