### PR TITLE
Fix nvmftests

### DIFF
--- a/tests/kernel/nvmftests.pm
+++ b/tests/kernel/nvmftests.pm
@@ -28,7 +28,7 @@ sub run {
 
     assert_script_run('cd /var/lib/nvmftests');
     assert_script_run('ln -sf tests/config config');
-    assert_script_run('nose2 --verbose', 3600);
+    assert_script_run('nose2 --verbose', 1200);
 
     power_action('poweroff');
 }

--- a/tests/kernel/nvmftests.pm
+++ b/tests/kernel/nvmftests.pm
@@ -24,7 +24,7 @@ sub run {
     zypper_call('ar -f -G ' . get_required_var('BENCHMARK_REPO'));
     zypper_call('ar -f -G ' . get_required_var('DEVEL_LANG_PYTHON_REPO'));
     zypper_call('--gpg-auto-import-keys ref');
-    zypper_call('in nvmftests');
+    zypper_call('in --no-recommends nvmftests');
 
     assert_script_run('cd /var/lib/nvmftests');
     assert_script_run('ln -sf tests/config config');


### PR DESCRIPTION
Small changes to fix nvmftests
- reduce timeout. increasing it was not solving any issues.
- install packages without recommended packages.
