### PR TITLE
Move CaaSP mutex handling to common place

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -20,7 +20,7 @@ use Time::HiRes 'sleep';
 use testapi;
 use utils;
 use version_utils qw(is_jeos is_caasp is_leap);
-use lockapi;
+use caasp 'pause_until';
 use mm_network;
 
 our @EXPORT = qw(
@@ -528,21 +528,14 @@ sub specific_caasp_params {
 
     # Wait for supportserver (controller node)
     if (!check_var 'STACK_ROLE', 'controller') {
-        mutex_lock 'dhcp';
-        mutex_unlock 'dhcp';
+        pause_until 'support_server_ready';
     }
 
     if (check_var('STACK_ROLE', 'worker')) {
         # Wait until admin node genarates autoyast profile
-        if (get_var 'AUTOYAST') {
-            mutex_lock 'VELUM_CONFIGURED';
-            mutex_unlock 'VELUM_CONFIGURED';
-        }
+        pause_until 'VELUM_CONFIGURED' if get_var('AUTOYAST');
         # Wait until first round of nodes are processed
-        if (get_var 'DELAYED_WORKER') {
-            mutex_lock 'NODES_ACCEPTED';
-            mutex_unlock 'NODES_ACCEPTED';
-        }
+        pause_until 'NODES_ACCEPTED' if get_var('DELAYED_WORKER');
     }
 }
 

--- a/lib/caasp_controller.pm
+++ b/lib/caasp_controller.pm
@@ -3,7 +3,8 @@ use base "opensusebasetest";
 
 use strict;
 use testapi;
-use lockapi;
+use caasp 'unpause';
+use lockapi 'barrier_destroy';
 use mmapi 'wait_for_children';
 
 use Exporter 'import';
@@ -84,11 +85,7 @@ sub post_fail_hook {
 
     # Destroy barriers and create mutexes to avoid deadlock
     barrier_destroy 'WORKERS_INSTALLED';
-    mutex_create 'NODES_ACCEPTED';
-    mutex_create 'DELAYED_NODES_ACCEPTED';
-    mutex_create 'VELUM_CONFIGURED';
-    mutex_create 'UPDATE_FINISHED';
-    mutex_create 'CNTRL_FINISHED';
+    unpause 'ALL';
 
     # Wait for log export from all nodes
     wait_for_children;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -21,7 +21,7 @@ use Exporter;
 use strict;
 
 use testapi qw(is_serial_terminal :DEFAULT);
-use lockapi;
+use lockapi 'mutex_wait';
 use mm_network;
 use version_utils qw(is_caasp is_leap is_tumbleweed is_sle is_sle12_hdd_in_upgrade sle_version_at_least is_storage_ng);
 use Mojo::UserAgent;
@@ -1218,13 +1218,7 @@ server is needed.
 
 =cut
 sub wait_supportserver {
-    return unless get_var('USE_SUPPORT_SERVER');
-
-    # We use mutex to do this
-    my $mutex = 'support_server_ready';
-    diag "Waiting for support server to complete setup (with mutex '$mutex')...";
-    mutex_lock($mutex);
-    mutex_unlock($mutex);
+    mutex_wait 'support_server_ready' if get_var('USE_SUPPORT_SERVER');
 }
 
 1;

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -185,7 +185,6 @@ sub stack_init {
     set_var 'STACK_NODES',   $stack_size - 1;
     set_var 'STACK_MASTERS', $stack_masters;
     set_var 'STACK_WORKERS', $stack_workers;
-    set_var 'STACK_DELAYED', $delayed_worker;
 
     barrier_create("WORKERS_INSTALLED", $stack_size);
 }

--- a/tests/caasp/stack_add_remove.pm
+++ b/tests/caasp/stack_add_remove.pm
@@ -11,10 +11,10 @@
 # Maintainer: Martin Kravec <mkravec@suse.com>
 use parent 'caasp_controller';
 use caasp_controller;
+use caasp qw(pause_until unpause);
 
 use strict;
 use testapi;
-use lockapi;
 
 sub add_nodes {
     # Accept pending nodes
@@ -25,7 +25,7 @@ sub add_nodes {
 
     # Nodes are moved from pending to new
     assert_and_click "velum-1-nodes-accepted", 'left', 90;
-    mutex_create "DELAYED_NODES_ACCEPTED";
+    unpause 'DELAYED_NODES_ACCEPTED';
 
     # Bootstrap new node
     wait_still_screen 3;
@@ -54,7 +54,7 @@ sub check_kubernetes {
 }
 
 sub run {
-    mutex_lock 'DELAYED_WORKER_INSTALLED', get_required_var('STACK_DELAYED');
+    pause_until 'DELAYED_WORKER_INSTALLED';
 
     record_info 'Add node';
     add_nodes;

--- a/tests/caasp/stack_admin.pm
+++ b/tests/caasp/stack_admin.pm
@@ -13,15 +13,11 @@
 use base "opensusebasetest";
 use strict;
 use testapi;
-use lockapi;
 use caasp;
 use version_utils 'is_caasp';
 
 # Set default password on worker nodes - bsc#1030876
 sub set_autoyast_password {
-    my $name = shift;
-    mutex_lock $name;
-    mutex_unlock $name;
     script_run 'id=$(docker ps | grep salt-master | awk \'{print $1}\')';
     script_run 'pw=$(python -c "import crypt; print crypt.crypt(\'nots3cr3t\', \'\$6\$susetest\')")';
     script_run 'docker exec $id salt -E ".{32}" shadow.set_password root "$pw"';
@@ -33,9 +29,7 @@ sub handle_update_reboot {
     assert_script_run 'curl -O ' . data_url("caasp/update.sh");
     assert_script_run 'chmod +x update.sh';
 
-    # Wait until update is finished
-    mutex_lock 'UPDATE_FINISHED';
-    mutex_unlock 'UPDATE_FINISHED';
+    pause_until 'REBOOT_FINISHED';
 
     # Admin node was rebooted only if update passed
     if (check_screen 'linux-login-casp', 0) {
@@ -47,17 +41,23 @@ sub handle_update_reboot {
 sub run() {
     # Admin node needs long time to start web interface - bsc#1031682
     script_retry 'curl -kLI localhost | grep _velum_session', retry => 15, delay => 15;
-    # Controller node can connect to velum now
-    mutex_create "VELUM_STARTED";
+    unpause 'VELUM_STARTED';
 
-    set_autoyast_password 'NODES_ACCEPTED' if is_caasp 'DVD';
+    # Set password for autoyast cluster nodes
+    if (is_caasp 'DVD') {
+        pause_until 'NODES_ACCEPTED';
+        set_autoyast_password;
+    }
+
     handle_update_reboot;
-    set_autoyast_password 'DELAYED_NODES_ACCEPTED' if is_caasp('DVD') && get_delayed_worker;
 
-    # Wait until controller node finishes
-    mutex_lock "CNTRL_FINISHED";
-    mutex_unlock "CNTRL_FINISHED";
+    # Set password for autoyast cluster nodes
+    if (is_caasp('DVD') && get_delayed_worker) {
+        pause_until 'DELAYED_NODES_ACCEPTED';
+        set_autoyast_password;
+    }
 
+    pause_until 'CNTRL_FINISHED';
     export_cluster_logs;
 }
 

--- a/tests/caasp/stack_bootstrap.pm
+++ b/tests/caasp/stack_bootstrap.pm
@@ -14,7 +14,8 @@ use caasp_controller;
 
 use strict;
 use testapi;
-use lockapi;
+use lockapi 'barrier_wait';
+use caasp 'unpause';
 use utils;
 use version_utils 'is_caasp';
 
@@ -25,7 +26,7 @@ sub accept_nodes {
     # Nodes are moved from pending
     my $nodes = get_required_var('STACK_NODES');
     assert_screen_with_soft_timeout("velum-$nodes-nodes-accepted", timeout => 150, soft_timeout => 45, bugref => 'bsc#1046663');
-    mutex_create "NODES_ACCEPTED";
+    unpause 'NODES_ACCEPTED';
 }
 
 sub select_roles {

--- a/tests/caasp/stack_configure.pm
+++ b/tests/caasp/stack_configure.pm
@@ -16,7 +16,7 @@ use version_utils 'is_caasp';
 
 use strict;
 use testapi;
-use lockapi;
+use caasp 'unpause';
 
 # Fill certificate information
 sub velum_config {
@@ -42,7 +42,7 @@ sub velum_config {
     assert_screen 'velum-tips-page';
     assert_and_click "velum-next";
 
-    mutex_create 'VELUM_CONFIGURED';
+    unpause 'VELUM_CONFIGURED';
 }
 
 # Upload autoyast profile

--- a/tests/caasp/stack_finalize.pm
+++ b/tests/caasp/stack_finalize.pm
@@ -13,12 +13,12 @@
 use parent 'caasp_controller';
 
 use strict;
-use lockapi 'mutex_create';
+use caasp 'unpause';
 use mmapi 'wait_for_children';
 
 sub run {
     # Allow cluster nodes to finish
-    mutex_create "CNTRL_FINISHED";
+    unpause 'CNTRL_FINISHED';
     # Wait until they export logs
     wait_for_children;
 }

--- a/tests/caasp/stack_initialize.pm
+++ b/tests/caasp/stack_initialize.pm
@@ -22,8 +22,7 @@ use caasp_controller;
 
 use strict;
 use testapi;
-use caasp 'get_admin_job';
-use lockapi qw(mutex_lock mutex_unlock);
+use caasp 'pause_until';
 use utils qw(ensure_serialdev_permissions turn_off_gnome_screensaver);
 
 sub firefox_import_ca {
@@ -53,9 +52,7 @@ sub run {
     send_key "ctrl-l";
     send_key 'super-up';
 
-    # Wait until dashboard becomes ready
-    mutex_lock "VELUM_STARTED", get_admin_job;
-    mutex_unlock "VELUM_STARTED";
+    pause_until 'VELUM_STARTED';
     firefox_import_ca;
 }
 

--- a/tests/caasp/stack_reboot.pm
+++ b/tests/caasp/stack_reboot.pm
@@ -22,22 +22,18 @@ sub run {
     switch_to 'xterm';
     my $admin = 'admin.openqa.test';
 
-    # Test admin reboot
+    record_info 'Admin reboot',       'Test admin node reboot';
     script_run "ssh $admin 'reboot'", 0;
-
-    record_info 'Admin off', 'Wait until admin node powers off';
+    # Wait until admin node powers off
     script_retry "ping -c1 -W1 $admin", expect => 1, retry => 3, delay => 10;
-
-    record_info 'Admin on', 'Wait until velum is reachable again';
+    # Wait until velum is reachable again
     script_retry "curl -kLI -m5 $admin | grep _velum_session";
 
-    # Test cluster reboot
+    record_info 'Cluster reboot', 'Test cluster reboot';
     assert_script_run "ssh $admin './update.sh -r' | tee /dev/$serialdev | grep EXIT_OK";
-
-    record_info 'Cluster off', 'Waiting until cluster powers off';
+    # Wait until cluster powers off
     script_retry 'kubectl get nodes', expect => 1, retry => 3, delay => 10;
-
-    record_info 'Cluster on', 'Waiting until kubernetes is reachable again';
+    # Wait until kubernetes is reachable again
     script_retry 'kubectl get nodes';
 
     # Run basic kubernetes tests

--- a/tests/caasp/stack_reboot.pm
+++ b/tests/caasp/stack_reboot.pm
@@ -15,8 +15,7 @@ use caasp_controller;
 
 use strict;
 use testapi;
-use caasp 'script_retry';
-use lockapi 'mutex_create';
+use caasp qw(script_retry unpause);
 
 sub run {
     switch_to 'xterm';
@@ -41,7 +40,7 @@ sub run {
     assert_script_run "kubectl get nodes --no-headers | wc -l | grep $nodes_count";
 
     switch_to 'velum';
-    mutex_create 'UPDATE_FINISHED';
+    unpause 'REBOOT_FINISHED';
 }
 
 1;

--- a/tests/caasp/stack_update.pm
+++ b/tests/caasp/stack_update.pm
@@ -18,8 +18,7 @@ use caasp_controller;
 
 use strict;
 use testapi;
-use lockapi 'mutex_create';
-use caasp 'update_scheduled';
+use caasp qw(update_scheduled unpause);
 use version_utils 'is_caasp';
 
 # Set up ssh to admin node and run update script on all nodes
@@ -88,7 +87,7 @@ sub run {
     die "Nodes should be updated already" if check_screen "velum-0-nodes-outdated", 0;
 
     check_update_changes;
-    mutex_create 'UPDATE_FINISHED';
+    unpause 'REBOOT_FINISHED';
 }
 
 1;

--- a/tests/caasp/stack_worker.pm
+++ b/tests/caasp/stack_worker.pm
@@ -13,21 +13,20 @@
 use base "opensusebasetest";
 use strict;
 use testapi;
-use lockapi;
+use lockapi 'barrier_wait';
 use caasp;
 
 sub run {
     # Notify others that installation finished
     if (get_var 'DELAYED_WORKER') {
-        mutex_create "DELAYED_WORKER_INSTALLED";
+        unpause 'DELAYED_WORKER_INSTALLED';
     }
     else {
         barrier_wait "WORKERS_INSTALLED";
     }
 
     # Wait until controller node finishes
-    mutex_lock "CNTRL_FINISHED";
-    mutex_unlock "CNTRL_FINISHED";
+    pause_until 'CNTRL_FINISHED';
 }
 
 sub post_run_hook {

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -17,7 +17,6 @@ use strict;
 use Time::HiRes 'sleep';
 
 use testapi;
-use lockapi;
 use bootloader_setup;
 use registration;
 use utils;


### PR DESCRIPTION
PR brings following improvements:
 - abstraction from mutexes:
    - rename `mutex_lock & mutex_unlock` -> `pause_until`
    - rename `mutex_create` -> `unpause`
    - child job location search is moved  to lib (get_admin_job, get_delayed_worker)
 - all mutexes are documented in single place
 - pausing / unpausing is visible in tests with record_info

Local runs:
 - http://dhcp165.suse.cz/tests/4069#step/stack_initialize/18 - VMX
 - http://dhcp165.suse.cz/tests/3663#step/stack_initialize/18 - DVD
 - http://dhcp165.suse.cz/tests/3669#step/stack_bootstrap/15 - when bootstrap fails