### PR TITLE
Use correct naming syntax for iscsi iqn

### DIFF
--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -47,7 +47,7 @@ sub run {
     send_key 'ctrl-a';                                                                  # select all text inside target field
     wait_still_screen(2, 10);
     send_key 'delete';                                                                  # text it is automatically selected after tab, delete
-    type_string 'iqn.openqa.de';
+    type_string 'iqn.2016-02.de.openqa';
     wait_still_screen(2, 10);
     send_key 'tab';                                                                     # tab to identifier field
     wait_still_screen(2, 10);

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -348,7 +348,7 @@ sub setup_iscsi_server {
 
     # Change Target value
     for (1 .. 40) { send_key 'backspace'; }
-    type_string 'iqn.openqa.de';
+    type_string 'iqn.2016-02.de.openqa';
     wait_still_screen 3;
 
     # Select Identifier field


### PR DESCRIPTION
Requires: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/834
Verification run: http://artemis.suse.de/tests/259

The verification run will still fail at a later state due to [bsc#1091626](https://bugzilla.suse.com/show_bug.cgi?id=1091626).