### PR TITLE
Ltp/fix net.sh

### DIFF
--- a/data/ltp/net.sh
+++ b/data/ltp/net.sh
@@ -1,26 +1,30 @@
 #!/bin/sh
 # emulate $LTPROOT/testscripts/network.sh
 
-export TCID="network_settings"
-export TST_ID="$TCID"
+load_tst_net()
+{
+	export TCID="network_settings"
+	export TST_ID="$TCID"
 
-if [ -f "$LTPROOT/testcases/bin/tst_net.sh" ]; then
-	export TST_NO_DEFAULT_RUN=1
-	file="tst_net.sh"
-	echo "Using new API ($file)"
-else
-	export TST_TOTAL=1
-	file="test_net.sh"
-	echo "Using legacy API ($file)"
-fi
+	if [ -f "$LTPROOT/testcases/bin/tst_net.sh" ]; then
+		export TST_NO_DEFAULT_RUN=1
+		file="tst_net.sh"
+		echo "Using new API ($file)"
+	else
+		export TST_TOTAL=1
+		file="test_net.sh"
+		echo "Using legacy API ($file)"
+	fi
 
-. $file
-ret=$?
-echo $ret
+	. $file
+	ret=$?
 
-# new API
-unset TST_ID TST_NO_DEFAULT_RUN
-# legacy API
-unset TCID TST_TOTAL TST_LIB_LOADED
+	# new API
+	unset TST_ID TST_NO_DEFAULT_RUN
+	# legacy API
+	unset TCID TST_TOTAL TST_LIB_LOADED
 
-exit $ret
+	return $ret
+}
+
+load_tst_net

--- a/data/ltp/net.sh
+++ b/data/ltp/net.sh
@@ -2,6 +2,7 @@
 # emulate $LTPROOT/testscripts/network.sh
 
 export TCID="network_settings"
+export TST_ID="$TCID"
 
 if [ -f "$LTPROOT/testcases/bin/tst_net.sh" ]; then
 	export TST_NO_DEFAULT_RUN=1
@@ -18,8 +19,8 @@ ret=$?
 echo $ret
 
 # new API
-unset TCID TST_NO_DEFAULT_RUN
+unset TST_ID TST_NO_DEFAULT_RUN
 # legacy API
-unset TST_TOTAL TST_LIB_LOADED
+unset TCID TST_TOTAL TST_LIB_LOADED
 
 exit $ret

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -109,7 +109,8 @@ EOF
 
         # emulate $LTPROOT/testscripts/network.sh
         assert_script_run('curl ' . data_url("ltp/net.sh") . ' -o net.sh', 60);
-        assert_script_run('sh ./net.sh');
+        assert_script_run('chmod 755 net.sh');
+        assert_script_run('. ./net.sh');
 
         script_run('env');
 


### PR DESCRIPTION
Fixes: poo#35095

Broken:
https://openqa.opensuse.org/tests/667771#step/in6_02/6
in6_02.c:64: CONF: LHOST_IFACES not defined or invalid

Fixed:
http://quasar.suse.cz/tests/16#step/in6_02/5
 in6_02.c:258: INFO: get interface name from LHOST_IFACES: 'ltp_ns_veth2'
