### PR TITLE
Wait to avoid send down key early in grub_test_snapshot

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -81,7 +81,8 @@ sub boot_local_disk {
 sub boot_into_snapshot {
     send_key_until_needlematch('boot-menu-snapshot', 'down', 10, 5);
     send_key 'ret';
-    wait_still_screen 10;
+    # wait to avoid send down key early in grub_test_snapshot.
+    wait_still_screen 1;
     # in upgrade/migration scenario, we want to boot from snapshot 1 before migration.
     if ((get_var('UPGRADE') && !get_var('ONLINE_MIGRATION', 0)) || get_var('ZDUP')) {
         send_key_until_needlematch('snap-before-update', 'down', 40, 5);


### PR DESCRIPTION
We need to wait a while after select the 'Start bootloader from a read-only snapshot' and enter 'ret' to avoid send 'down' key too early in grub_test_snapshot.

- Related ticket: https://progress.opensuse.org/issues/35332
- Verification run: http://10.161.32.24/tests/66
