### PR TITLE
LTP: Install nfs-kernel-server package

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -63,6 +63,7 @@ sub install_runtime_dependencies {
       kernel-default-extra
       net-tools
       net-tools-deprecated
+      nfs-kernel-server
       ntfsprogs
       numactl
       psmisc


### PR DESCRIPTION
This package contain exportfs, which is needed for NFS tests
(runtest/net.nf and exportfs.sh, which is not in runtest file yet).

This package isn't required (build not fail, when it's not available).