### PR TITLE
live_installation: Wait for the welcome screen before enabling fullscreen

### DIFF
--- a/tests/installation/live_installation.pm
+++ b/tests/installation/live_installation.pm
@@ -36,7 +36,8 @@ sub run {
     assert_and_click 'live-installation';
     assert_and_click 'maximize';
     mouse_hide;
-    wait_still_screen;
+    # Wait until the first screen is shown, only way to make sure it's idle
+    assert_screen 'inst-welcome', 180;
     # To fully reuse installer screenshots we set to fullscreen. Unfortunately
     # it seems no default shortcut is configured in plasma but we can use the
     # window context menu.


### PR DESCRIPTION
When loading the installation, there are some phases with no activity on
screen, which is enough for wait_still_screen. YaST isn't idle though,
which results in dialogs interrupting the context menu for fullscreen.

- Related ticket: https://progress.opensuse.org/issues/34381
- Verification run: http://10.160.67.86/tests/60#live
