### PR TITLE
s390x: Adapt FORMAT_DASD_YAST to check for multiple values

### DIFF
--- a/tests/installation/disk_activation.pm
+++ b/tests/installation/disk_activation.pm
@@ -100,8 +100,8 @@ sub run {
             format_dasd;
         }
 
-        # format DASD if the variable is that, because we format it usually pre-installation
-        elsif (get_var('FORMAT_DASD_YAST')) {
+        # Test DASD formatting within YaST during installation
+        elsif (check_var('FORMAT_DASD_YAST', 1)) {
             send_key 'alt-s';                           # select all
             assert_screen 'dasd-selected';
             send_key 'alt-a';                           # perform action button


### PR DESCRIPTION
Allows us to test formatting during installation with `FORMAT_DASD_YAST=1`
and also without any formatting by setting `FORMAT_DAST_YAST=0`
@okurz