### PR TITLE
Wait longer for the correct number of nodes

### DIFF
--- a/tests/caasp/stack_update.pm
+++ b/tests/caasp/stack_update.pm
@@ -62,7 +62,7 @@ sub run {
     setup_update_repository;
 
     my $nodes = get_required_var('STACK_NODES');
-    assert_screen "velum-$nodes-nodes-outdated";
+    send_key_until_needlematch "velum-$nodes-nodes-outdated", 'f5', 5, 60;
     if (check_screen "velum-update-all", 0) {
         record_soft_failure 'bnc#1085677 - Should not update nodes before admin';
     }


### PR DESCRIPTION
Sometimes, when the cluster is quite big, then Velum is quite slow
on changes. As a result it takes *some time* to calculate the
correct number of nodes.

- Related ticket: **none**
- Needles: **not needed**
- Verification run: http://skyrim.qam.suse.de/tests/2806