### PR TITLE
Check firewalld status properly

### DIFF
--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -33,7 +33,7 @@ sub initialize_y2lan {
     become_root;
     # make sure that firewalld is stopped, or we have later pops for firewall activation warning
     # or timeout for command 'ip a' later
-    if ((is_sle('15+') or is_leap('15.0+')) and assert_script_run("systemctl show -p ActiveState firewalld.service | grep ActiveState=active")) {
+    if ((is_sle('15+') or is_leap('15.0+')) and script_run("systemctl show -p ActiveState firewalld.service | grep ActiveState=inactive")) {
         systemctl 'stop firewalld';
         assert_script_run("systemctl show -p ActiveState firewalld.service | grep ActiveState=inactive");
     }


### PR DESCRIPTION
firewalld status check is not correct, and using assert_script_run would make die for the test that was not expected.
- Related ticket: https://progress.opensuse.org/issues/35965
- Needles: N/A
- Verification run: 
firewalld actived - http://openqa-apac1.suse.de/tests/886#step/yast2_lan_restart/14
firewalld inactived - http://openqa-apac1.suse.de/tests/882#step/yast2_lan_restart/12
