### PR TITLE
Add 5s delay before next key bypass bsc#1041747

### DIFF
--- a/tests/installation/installer_desktopselection.pm
+++ b/tests/installation/installer_desktopselection.pm
@@ -23,6 +23,10 @@ sub run {
 
     # this error pop-up is present only on TW now
     if (check_var('VERSION', 'Tumbleweed')) {
+        if (get_var('OFW')) {
+            record_soft_failure('bsc#1041747 - as bypass, wait 5s before to issue next key');
+            sleep 5;
+        }
         send_key $cmd{next};
         assert_screen 'desktop-not-selected';
         send_key $cmd{ok};


### PR DESCRIPTION
specific to PowerPC bug
https://bugzilla.suse.com/show_bug.cgi?id=1041747
still present on o3 snapshot 20180504
https://openqa.opensuse.org/tests/670535#step/installer_desktopselection/3