### PR TITLE
Upload crash dump when crash utility fails

### DIFF
--- a/tests/console/kdump_and_crash.pm
+++ b/tests/console/kdump_and_crash.pm
@@ -46,10 +46,19 @@ sub run {
     # all but PPC64LE arch's vmlinux images are gzipped
     my $suffix = get_var('OFW') ? '' : '.gz';
     assert_script_run 'find /var/crash/';
+
     my $crash_cmd = "echo exit | crash `ls -1t /var/crash/*/vmcore | head -n1` /boot/vmlinux-`uname -r`$suffix";
-    assert_script_run "$crash_cmd", 600;
-    validate_script_output "$crash_cmd", sub { m/PANIC/ }, 600;
+    validate_script_output "$crash_cmd", sub { m/PANIC:\s([^\s]+)/ }, 600;
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+
+    script_run 'ls -lah /boot/';
+    script_run 'tar -cvfJ /tmp/crash_saved.tar.xz /var/crash/*';
+    upload_logs '/tmp/crash_saved.xz';
+
+    $self->SUPER::post_fail_hook;
 }
 
 1;
-


### PR DESCRIPTION
Upload crash dump when crash utility fails. As requested in https://bugzilla.suse.com/show_bug.cgi?id=1090659 we need some way  to provide the dump to be analyzed. 

- Related ticket: https://progress.opensuse.org/issues/33376
- Verification run: for ppc we cannot reach that point, our shared worker does not run properly kdump, but similar code (excuding the if/else condition) that I did for 64bit looks good: http://dhcp254.suse.cz/tests/1184#downloads. The content of those files could reveal why is failing performing virtual-to-physical translation.
