### PR TITLE
Update AutoYaST profile to add minimal registration section

### DIFF
--- a/data/autoyast_sle15/autoyast_scc_up.xml
+++ b/data/autoyast_sle15/autoyast_scc_up.xml
@@ -63,4 +63,8 @@
   <upgrade>
     <stop_on_solver_conflict config:type="boolean">true</stop_on_solver_conflict>
   </upgrade>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <reg_server>{{SCC_URL}}</reg_server>
+  </suse_register>
 </profile>


### PR DESCRIPTION
Add the registration section in the autoyast profile, it will be registered to Proxy SCC or SCC or SMT server depends on the setting of SCC_URL in test suite.

- Related ticket: https://progress.opensuse.org/issues/35887
- Verification run: http://openqa-apac1.suse.de/tests/896#step/installation/43  failed for bsc#1087241
                            http://openqa-apac1.suse.de/tests/894
