### PR TITLE
Assert needle to avoid send down key early in grub_test_snapshot

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -81,8 +81,8 @@ sub boot_local_disk {
 sub boot_into_snapshot {
     send_key_until_needlematch('boot-menu-snapshot', 'down', 10, 5);
     send_key 'ret';
-    # wait to avoid send down key early in grub_test_snapshot.
-    wait_still_screen 1;
+    # assert needle to avoid send down key early in grub_test_snapshot.
+    assert_screen 'snap-default' if get_var('OFW');
     # in upgrade/migration scenario, we want to boot from snapshot 1 before migration.
     if ((get_var('UPGRADE') && !get_var('ONLINE_MIGRATION', 0)) || get_var('ZDUP')) {
         send_key_until_needlematch('snap-before-update', 'down', 40, 5);


### PR DESCRIPTION
There is a non-stable stuck before the snapshot list screen shown, so we need to assert needle to make the process more stable. Since this issue only happened on PPC64 and never found on other platform, so the assert_screen only works on PPC64. Needle with tag 'snap-default' already created.

- Related ticket: https://progress.opensuse.org/issues/35332
- Verification run: run on x86 machine since no PPC64 resource: http://openqa-apac1.suse.de/tests/900 
