### PR TITLE
Add workaround for shutdown fail on kde

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -560,7 +560,7 @@ sub poweroff_x11 {
 
     if (check_var("DESKTOP", "kde")) {
         send_key "ctrl-alt-delete";    # shutdown
-        assert_screen 'logoutdialog', 15;
+        assert_screen_with_soft_timeout('logoutdialog', timeout => 90, soft_timeout => 15, 'bsc#1091933');
 
         if (get_var("PLASMA5")) {
             assert_and_click 'sddm_shutdown_option_btn';


### PR DESCRIPTION
The commit adds soft-fail in case if logout
popup takes longer then 15 sec to be appeared
on KDE.

Related tickets: [bsc#1091933](https://bugzilla.novell.com/show_bug.cgi?id=1091933)
[poo#35215](https://progress.opensuse.org/issues/35215)
