### PR TITLE
Adjust AY btrfs test for storage-ng

### DIFF
--- a/data/autoyast_sle15/autoyast_btrfs.xml
+++ b/data/autoyast_sle15/autoyast_btrfs.xml
@@ -24,9 +24,6 @@
     <mode>
       <confirm config:type="boolean">false</confirm>
     </mode>
-    <storage>
-      <btrfs_set_default_subvolume_name config:type="boolean">false</btrfs_set_default_subvolume_name>
-    </storage>
   </general>
   <report>
     <errors>
@@ -98,18 +95,20 @@
           <partition_nr config:type="integer">2</partition_nr>
           <resize config:type="boolean">false</resize>
           <subvolumes config:type="list">
-            <listentry>
+            <subvolume>
               <copy_on_write config:type="boolean">true</copy_on_write>
               <path>opt</path>
-            </listentry>
-            <listentry>
+            </subvolume>
+            <subvolume>
               <copy_on_write config:type="boolean">false</copy_on_write>
               <path>tmp</path>
-            </listentry>
-            <listentry>
+            </subvolume>
+            <subvolume>
               <path>usr/local</path>
-            </listentry>
+            </subvolume>
           </subvolumes>
+          <!-- Create empty prefix, see bsc#1090095 -->
+          <subvolumes_prefix><![CDATA[]]></subvolumes_prefix>
         </partition>
         <partition>
           <create config:type="boolean">true</create>


### PR DESCRIPTION
As per [bsc#1090095](https://bugzilla.suse.com/show_bug.cgi?id=1090095),
we are now supposed to use subvolumes_prefix tag and
btrfs_set_default_subvolume_name is not supported for storage-ng.

This requires changes in the profile and expectations.

- Verification runs: 
  * [sle 12](http://gershwin.arch.suse.de/tests/351)
  * [sle 15](http://gershwin.arch.suse.de/tests/350)
