### PR TITLE
[xfstests] Add XFSTESTS_RANGES to allow specifying a range of tests to run

### DIFF
--- a/tests/xfstests/enable_kdump.pm
+++ b/tests/xfstests/enable_kdump.pm
@@ -14,8 +14,9 @@ package enable_kdump;
 use strict;
 use 5.018;
 use warnings;
-use base "opensusebasetest";
+use base 'opensusebasetest';
 use utils qw(power_action zypper_call);
+use serial_terminal 'select_virtio_console';
 use kdump_utils;
 use testapi;
 
@@ -24,8 +25,8 @@ sub run {
     select_console('root-console');
 
     # Also panic when softlockup
-    assert_script_run("echo 'kernel.softlockup_panic = 1' >> /etc/sysctl.conf");
-    assert_script_run("sysctl -p");
+    assert_script_run('echo "kernel.softlockup_panic = 1" >> /etc/sysctl.conf');
+    assert_script_run('sysctl -p');
 
     # Activate kdump
     prepare_for_kdump;
@@ -34,7 +35,7 @@ sub run {
     # Reboot
     power_action('reboot');
     $self->wait_boot;
-    select_console('root-console');
+    select_virtio_console();
     return 1 unless kdump_is_active;
 }
 

--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -14,35 +14,35 @@ package install;
 use 5.018;
 use strict;
 use warnings;
-use base "opensusebasetest";
+use base 'opensusebasetest';
+use serial_terminal 'select_virtio_console';
 use utils;
 use testapi;
 
-my $LOG_FILE = "/tmp/xfstests.log";
+my $STATUS_LOG = '/tmp/status.log';
 
 # Create log file used to generate junit xml report
 sub log_create {
     my $file = shift;
-    my $cmd  = "[[ -f $file ]] || ";
-    $cmd .= "echo 'Test in progress' > $file";
+    my $cmd  = "[[ -f $file ]] || echo 'Test in progress' > $file";
     assert_script_run($cmd);
 }
 
 sub run {
     my $self = shift;
-    select_console('root-console');
+    select_virtio_console();
 
     # Add QA repo
     my $qa_head_repo = get_var('QA_HEAD_REPO', '');
     zypper_call("--no-gpg-check ar -f '$qa_head_repo' qa-ibs", timeout => 600);
 
     # Install qa_test_xfstests
-    zypper_call("--gpg-auto-import-keys ref", timeout => 600);
-    zypper_call("in qa_test_xfstests",        timeout => 1200);
-    assert_script_run("/usr/share/qa/qa_test_xfstests/install.sh", 600);
+    zypper_call('--gpg-auto-import-keys ref', timeout => 600);
+    zypper_call('in qa_test_xfstests',        timeout => 1200);
+    assert_script_run('/usr/share/qa/qa_test_xfstests/install.sh', 600);
 
     # Create log file
-    log_create($LOG_FILE);
+    log_create($STATUS_LOG);
 }
 
 1;

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -14,19 +14,17 @@ package partition;
 use 5.018;
 use strict;
 use warnings;
-use base "opensusebasetest";
+use base 'opensusebasetest';
+use serial_terminal 'select_virtio_console';
 use utils;
 use testapi;
 
 sub run {
     my $self = shift;
-    select_console('root-console');
-
-    # Install parted
-    zypper_call("in parted", timeout => 600);
+    select_virtio_console();
 
     # Create partitions
-    my ($filesystem, $category) = split(/-/, get_var("XFSTESTS"));
+    my $filesystem = get_required_var('XFSTESTS');
     assert_script_run("/usr/share/qa/qa_test_xfstests/partition.py --delhome $filesystem && sync", 600);
 }
 

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -14,37 +14,47 @@ package run;
 use 5.018;
 use strict;
 use warnings;
-use base "opensusebasetest";
+use base 'opensusebasetest';
 use File::Basename;
 use testapi;
 use utils;
-use kdump_utils;
 
 # Heartbeat variables
-my $HB_INTVL   = get_var("XFSTESTS_HEARTBEAT_INTERVAL") || 5;
-my $HB_TIMEOUT = get_var("XFSTESTS_HEARTBEAT_TIMEOUT")  || 200;
-my $HB_PATN    = "<heartbeat>";
-my $HB_DONE    = "<done>";
-my $HB_DONE_FILE = "/tmp/test.done";
-my $HB_EXIT_FILE = "/tmp/test.exit";
+my $HB_INTVL   = get_var('XFSTESTS_HEARTBEAT_INTERVAL') || 5;
+my $HB_TIMEOUT = get_var('XFSTESTS_HEARTBEAT_TIMEOUT')  || 200;
+my $HB_PATN    = '<heartbeat>';
+my $HB_DONE    = '<done>';
+my $HB_DONE_FILE = '/tmp/test.done';
+my $HB_EXIT_FILE = '/tmp/test.exit';
+my $HB_SCRIPT    = '/tmp/heartbeat.sh';
 
 # xfstests variables
-my $WRAPPER  = "/usr/share/qa/qa_test_xfstests/wrapper.sh";
-my $LOG_FILE = "/tmp/xfstests.log";
+my $TEST_RANGES  = get_required_var('XFSTESTS_RANGES');
+my $TEST_WRAPPER = '/usr/share/qa/qa_test_xfstests/wrapper.sh';
+my %BLACKLIST    = map { $_ => 1 } split(/,/, get_var('XFSTESTS_BLACKLIST'));
+my $STATUS_LOG   = '/tmp/status.log';
+my $INST_DIR     = '/opt/xfstests';
+my $LOG_DIR      = '/tmp/log';
+my $KDUMP_DIR    = '/tmp/kdump';
 
-# blacklist
-my %BLACKLIST = map { $_ => 1 } split(/,/, get_var("XFSTESTS_BLACKLIST"));
+# Create heartbeat script, directories(Call it only once)
+sub test_prepare {
+    my $redir  = " >> /dev/$serialdev";
+    my $script = <<END_CMD;
+#!/bin/sh
+rm -f $HB_DONE_FILE $HB_EXIT_FILE
+while [[ ! -f $HB_EXIT_FILE ]]; do
+    sleep $HB_INTVL
+    [[ -f $HB_DONE_FILE ]] && echo '$HB_DONE' $redir || echo '$HB_PATN' $redir
+done
+END_CMD
+    assert_script_run("cat > $HB_SCRIPT <<'END'\n$script\nEND\n( exit \$?)");
+    assert_script_run("mkdir -p $KDUMP_DIR $LOG_DIR");
+}
 
-
+# Start heartbeat, setup environment variables(Call it everytime SUT reboots)
 sub heartbeat_start {
-    my $redir = " >> /dev/$serialdev";
-    my $cmd   = "while [[ ! -f $HB_EXIT_FILE ]]; do ";
-    $cmd .= "sleep $HB_INTVL; ";
-    $cmd .= "[[ -f $HB_DONE_FILE ]] && ";
-    $cmd .= "echo \"$HB_DONE\" $redir || echo \"$HB_PATN\" $redir";
-    $cmd .= "; done";
-    script_run("rm -f $HB_DONE_FILE $HB_EXIT_FILE");
-    type_string("nohup bash -c '$cmd' &\n");
+    type_string(". ~/.xfstests; nohup sh $HB_SCRIPT &\n");
 }
 
 # Stop heartbeat
@@ -57,11 +67,11 @@ sub heartbeat_stop {
 sub heartbeat_wait {
     # When under heavy load, the SUT might be unable to send
     # heartbeat messages to serial console. That's why HB_TIMEOUT
-    # is set to 300 by default: waiting for such tests to finish.
+    # is set to 200 by default: waiting for such tests to finish.
     my $ret = wait_serial([$HB_PATN, $HB_DONE], $HB_TIMEOUT);
     if ($ret) {
         if ($ret =~ /$HB_PATN/) {
-            return ($HB_PATN, "");
+            return ($HB_PATN, '');
         }
         else {
             my $status;
@@ -69,18 +79,18 @@ sub heartbeat_wait {
             my $ret = script_output("cat $HB_DONE_FILE; rm -f $HB_DONE_FILE");
             $ret =~ s/^\s+|\s+$//g;
             if ($ret == 0) {
-                $status = "PASSED";
+                $status = 'PASSED';
             }
             elsif ($ret == 22) {
-                $status = "SKIPPED";
+                $status = 'SKIPPED';
             }
             else {
-                $status = "FAILED";
+                $status = 'FAILED';
             }
             return ($HB_DONE, $status);
         }
     }
-    return ("", "FAILED");
+    return ('', 'FAILED');
 }
 
 # Wait for test to finish
@@ -94,24 +104,33 @@ sub test_wait {
     return ($type, $status, $time);
 }
 
+# Return the name of a test(e.g. xfs-005)
+# test - specific test(e.g. xfs/005)
+sub test_name {
+    my $test = shift;
+    return $test =~ s/\//-/gr;
+}
+
 # Add one test result to log file
+# file   - log file
+# test   - specific test(e.g. xfs/008)
+# status - test status
+# time   - time consumed
 sub log_add {
-    my ($file, $name, $status, $time) = @_;
-    my $cmd = "echo '$name ... ... $status (${time}s)' >> $file && sync";
+    my ($file, $test, $status, $time) = @_;
+    my $name = test_name($test);
+    my $cmd  = "echo '$name ... ... $status (${time}s)' >> $file && sync";
     type_string("\n");
     assert_script_run($cmd);
 }
 
-# Create log dir and set environment variables
-sub test_prepare {
-    my $category = shift;
-    type_string("mkdir -p /tmp/$category; . ~/.xfstests\n");
-}
-
-# List all the tests of a specific category
-sub test_list {
-    my $dir    = shift;
-    my $output = script_output("find $dir -regex '.*/[0-9]+'", 200);
+# Return all the tests of a specific xfstests category
+# category - xfstests category(e.g. generic)
+# dir      - xfstests installation dir(e.g. /opt/xfstests)
+sub tests_from_category {
+    my ($category, $dir) = @_;
+    my $cmd    = "find '$dir/tests/$category' -regex '.*/[0-9]+'";
+    my $output = script_output($cmd, 60);
     my @tests  = split(/\n/, $output);
     foreach my $test (@tests) {
         $test = basename($test);
@@ -119,69 +138,100 @@ sub test_list {
     return @tests;
 }
 
+# Return a list of tests to run from given test ranges
+# ranges - test ranges(e.g. xfs/001-100,btrfs/100-159)
+# dir    - xfstests installation dir(e.g. /opt/xfstests)
+sub tests_from_ranges {
+    my ($ranges, $dir) = @_;
+    if ($ranges !~ /\w+(\/\d+-\d+)?(,\w+(\/\d+-\d+)?)*/) {
+        die "Invalid test ranges: $ranges";
+    }
+
+    my %cache;
+    my @tests;
+    foreach my $range (split(/,/, $ranges)) {
+        my ($min, $max) = (0, 99999);
+        my ($category, $min_max) = split(/\//, $range);
+        if (defined($min_max)) {
+            ($min, $max) = split(/-/, $min_max);
+        }
+        unless (exists($cache{$category})) {
+            $cache{$category} = [tests_from_category($category, $dir)];
+            assert_script_run("mkdir -p $LOG_DIR/$category");
+        }
+        foreach my $num (@{$cache{$category}}) {
+            if ($num >= $min and $num <= $max) {
+                push(@tests, "$category/$num");
+            }
+        }
+    }
+    return @tests;
+}
+
 # Run a single test and write log to file
-# category - category of tests(e.g. xfs, btrfs, generic)
-# test  - specific test(e.g. 001, 002)
+# test - test to run(e.g. xfs/001)
 sub test_run {
-    my $category = shift;
-    my $test     = shift;
-    my $cmd      = "\n$WRAPPER '$category/$test' | ";
-    $cmd .= "tee /tmp/$category/$test.log; ";
+    my $test = shift;
+    my ($category, $num) = split(/\//, $test);
+    my $cmd = "\n$TEST_WRAPPER '$test' | ";
+    $cmd .= "tee $LOG_DIR/$category/$num; ";
     $cmd .= "echo \${PIPESTATUS[0]} > $HB_DONE_FILE\n";
     type_string($cmd);
 }
-
 
 sub run {
     my $self = shift;
     select_console('root-console');
 
     # Get test list
-    my ($filesystem, $category) = split(/-/, get_var("XFSTESTS"));
-    my @tests = test_list("/opt/xfstests/tests/$category");
+    my @tests = tests_from_ranges($TEST_RANGES, $INST_DIR);
 
+    test_prepare;
     heartbeat_start;
-    test_prepare($category);
-    my @crashed;
     foreach my $test (@tests) {
         # Skip tests inside blacklist
-        if (exists($BLACKLIST{"$category/$test"})) {
+        if (exists($BLACKLIST{$test})) {
             next;
         }
 
-        my $name = "$category-$test";
-        script_run("echo '$category/$test:' | tee /dev/$serialdev");
-        test_run($category, $test);
+        # Run test and wait for it to finish
+        my ($category, $num) = split(/\//, $test);
+
+        # TODO: Remove this after kdump data uploading is implemented
+        assert_script_run("echo '$test:' | tee /dev/$serialdev");
+
+        test_run($test);
         my ($type, $status, $time) = test_wait;
         if ($type eq $HB_DONE) {
-            # Test finished
-            log_add($LOG_FILE, $name, $status, $time);
+            # Test finished without crashing SUT
+            log_add($STATUS_LOG, $test, $status, $time);
             next;
         }
 
-        # Wait for kdump to finish.
+        # SUT crashed. Wait for kdump to finish.
         # After that, SUT will reboot automatically
         eval {
             power_action('reboot', observe => 1, keepconsole => 1);
             $self->wait_boot(in_grub => 1, bootloader_time => 60);
         };
-        # If SUT didn't reboot, force reset
+        # If SUT didn't reboot for some reason, force reset
         if ($@) {
-            power("reset");
+            power('reset');
             $self->wait_boot(in_grub => 1);
         }
 
         sleep(1);
         select_console('root-console');
-        log_add($LOG_FILE, $name, $status, $time);
-        heartbeat_start;
-        test_prepare($category);
 
-        # TODO: upload kdump dmesg
-        push(@crashed, "$category/$test");
+        # TODO: upload kdump data
+
+        log_add($STATUS_LOG, $test, $status, $time);
+
+        # Prepare for the next test
+        heartbeat_start;
+
     }
     heartbeat_stop;
-    script_run("echo '@crashed'");
 }
 
 1;


### PR DESCRIPTION
xfstests has lots of tests which may not be able to finish within 9 hours. Thus, I've added a XFSTESTS_RANGES variable to allow specifying a range of tests to run. So that we can create several openQA testsuites, each with a different range, to make them run in parallel.
Besides, I've enabled virtio console where it doesn't affect the test.

- Related ticket: https://progress.opensuse.org/issues/35625
- Verification run: http://10.67.133.102/tests/374
