### PR TITLE
Fix setup_online_repos test flow for openSUSE Leap 15.0 incident tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -501,6 +501,9 @@ sub load_docker_tests {
 }
 
 sub load_system_role_tests {
+    if (installwithaddonrepos_is_applicable() && !get_var("LIVECD")) {
+        loadtest "installation/setup_online_repos";
+    }
     # Do not run on REMOTE_CONTROLLER, IPMI and on Hyper-V in GUI mode
     if (!get_var("REMOTE_CONTROLLER") && !check_var('BACKEND', 'ipmi') && !is_hyperv_in_gui && !get_var("LIVECD")) {
         loadtest "installation/logpackages";
@@ -853,9 +856,6 @@ sub load_inst_tests {
 
     if (noupdatestep_is_applicable()) {
         loadtest "installation/installer_timezone" if !is_caasp('kubic');
-        if (installwithaddonrepos_is_applicable() && !get_var("LIVECD")) {
-            loadtest "installation/setup_online_repos";
-        }
         # the test should run only in scenarios, where installed
         # system is not being tested (e.g. INSTALLONLY etc.)
         # The test also won't work reliably when network is bridged (non-s390x svirt).

--- a/tests/installation/setup_online_repos.pm
+++ b/tests/installation/setup_online_repos.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,6 +15,7 @@
 use base "y2logsstep";
 use strict;
 use testapi;
+use version_utils;
 
 sub run {
     # ordered according to real repos lists
@@ -39,7 +40,7 @@ sub run {
         send_key_until_needlematch 'setup_online_repos-repos-list', 'tab';
     }
     else {
-        send_key 'alt-i';
+        send_key is_sle('<15') || is_leap('<15.0') ? 'alt-i' : 'alt-u';
     }
 
     foreach my $repotag (@default_repos) {
@@ -82,15 +83,19 @@ sub run {
             assert_screen "inst-betawarning", 500;
             send_key 'alt-o';
         }
-        assert_screen 'license-dialog-oss-repo';
-        send_key $cmd{next};    # Next
+        # older product versions check for same license multiple times so we
+        # need to check that
+        if (is_sle('<15') || is_leap('<15.0')) {
+            assert_screen 'license-dialog-oss-repo';
+            send_key $cmd{next};    # Next
+        }
     }
 
     if (get_var("WITH_UNTESTED_REPO")) {
         assert_screen 'import-untrusted-gpg-key-598D0E63B3FD7E48';
         while (1) {
-            send_key 'alt-t';    # Trust
-                                 # for some reason the key is prompted twice, bug?
+            send_key 'alt-t';       # Trust
+                                    # for some reason the key is prompted twice, bug?
             last unless check_screen 'import-untrusted-gpg-key-598D0E63B3FD7E48';
         }
     }


### PR DESCRIPTION
Verification run: http://lord.arch/tests/882

Related needle PR:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/365

Related progress issue: https://progress.opensuse.org/issues/35994