### PR TITLE
Wait screen change when verify missing autoyast on overview page

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -50,8 +50,8 @@ sub run {
     # Check autoyast has been removed in SP2 (fate#317970)
     if (get_var("SP2ORLATER") && !check_var("INSTALL_TO_OTHERS", 1)) {
         if (check_var('VIDEOMODE', 'text')) {
-            send_key 'alt-l';
-            send_key 'ret';
+            wait_screen_change { send_key 'alt-l' };
+            wait_screen_change { send_key 'ret' };
             send_key 'tab';
         }
         else {


### PR DESCRIPTION
In text mode we use release notes button to navigate to the overview
area and then scroll. However, on hyperv as we have problems with
performance, we still had focus on release notes button.
Failure happened only ones, but can potentially break.

See [poo#33979](https://progress.opensuse.org/issues/33979).