### PR TITLE
install_package: handle conflict of opencv packages with -qt5

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -165,6 +165,8 @@ sub problem_can_be_skipped {
     return 1 if $pkg =~ /^mvapich2-testsuite/;
     # conflict with python3-talloc-devel
     return 1 if $pkg =~ /^python-talloc-devel/;
+    # conflict with the non-qt5
+    return 1 if $pkg =~ /^(python(|3)-)?opencv-qt5/;
 
     return;
 }


### PR DESCRIPTION
install_package: handle conflict of opencv packages with -qt5 counterparts

Fixes:
https://openqa.opensuse.org/tests/671739#step/install_packages/9
https://openqa.opensuse.org/tests/671740#step/install_packages/9
https://openqa.opensuse.org/tests/671741#step/install_packages/9

Test maintainer is @coolo 