### PR TITLE
Adapt to new Yast2 samba workflow - revert hostname change

### DIFF
--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -335,6 +335,7 @@ sub run {
         record_soft_failure "bsc#1068900";
     }
     smb_conf_checker;
+    set_hostname(get_var('HOSTNAME', 'susetest'));
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Revert hostname change at the end of this module to prevent test failures in subsequent test modules.