### PR TITLE
Process existing partitions if page is shown

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -249,14 +249,16 @@ sub take_first_disk_storage_ng {
     # So making it flexible, still assert the screen if want to verify explicitly
     select_first_hard_disk;
 
+    assert_screen [qw(existing-partitions partition-scheme)];
     # If drive is not formatted, we have select hard disks page
     # On ipmi we always have unformatted drive
-    if (get_var('ISO_IN_EXTERNAL_DRIVE') || check_var('BACKEND', 'ipmi')) {
-        assert_screen 'existing-partitions';
+    # Sometimes can have existing installation on iscsi
+    if (match_has_tag 'existing-partitions') {
         send_key $cmd{next};
+        assert_screen 'partition-scheme';
     }
-    assert_screen 'partition-scheme';
     send_key $cmd{next};
+
     # select btrfs file system
     if (check_var('VIDEOMODE', 'text')) {
         assert_screen 'select-root-filesystem';


### PR DESCRIPTION
On iSCSI we may get disk with installation on disk, which is not always
the case. There can be other scenarios where we cannot predict our
expectation. Consequently, we should check if existing partitions were
detected and process screen instead of hard-coded flow.

See [poo#23554](https://progress.opensuse.org/issues/23554).
[Verification run](http://gershwin.arch.suse.de/tests/356).
