### PR TITLE
installation_user_settings: Remove old workarounds for fixed bugs

### DIFF
--- a/lib/installation_user_settings.pm
+++ b/lib/installation_user_settings.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -23,14 +23,8 @@ sub type_password_and_verification {
 
 sub await_password_check {
     # PW too easy (cracklib)
-    if (check_var('LIVECD', 1)) {
-        record_soft_failure 'boo#1013206' unless check_screen 'inst-userpasswdtoosimple';
-    }
-    else {
-        # bsc#937012 is resolved in > SLE 12
-        assert_screen 'inst-userpasswdtoosimple' unless (check_var('VERSION', '12') && check_var('ARCH', 's390x'));
-    }
-    send_key 'ret' if match_has_tag 'inst-userpasswdtoosimple';
+    assert_screen 'inst-userpasswdtoosimple';
+    send_key 'ret';
 }
 
 1;


### PR DESCRIPTION
We do not run SLE 12 GA s390x tests anymore so we do not need to handle the
old specific workaround anymore as well.