### PR TITLE
Add workaround for missing phub option among modules

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -333,9 +333,14 @@ sub fill_in_registration_data {
                     # go to the top of the list before looking for the addon
                     send_key "home";
                     # move the list of addons down until the current addon is found
-                    send_key_until_needlematch "scc-module-$addon", "down";
-                    # checkmark the requested addon
-                    assert_and_click "scc-module-$addon";
+                    if (check_var('VERSION', '12-SP4') && $addon =~ 'phub') {
+                        record_soft_failure 'bsc#1092568';
+                    }
+                    else {
+                        send_key_until_needlematch "scc-module-$addon", "down";
+                        # checkmark the requested addon
+                        assert_and_click "scc-module-$addon";
+                    }
                 }
             }
             save_screenshot;


### PR DESCRIPTION
- Related ticket: [[sle][functional][y][easy] test fails in scc_registration - phub missing for SLE12SP4](https://progress.opensuse.org/issues/35871)
- Verification run: [sle-12-SP4-Server-DVD-x86_64-Build0239-gnome+proxy_SCC+allmodules@64bit](http://dhcp151.suse.cz/tests/2330#step/scc_registration/47)
- Not affected sle15
[sle-15-Installer-DVD-x86_64-Build609.1-gnome+proxy_SCC+allmodules@64bit](http://dhcp151.suse.cz/tests/2329#step/scc_registration/23)