### PR TITLE
Enable updates during default SLE15 installation again

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -132,10 +132,8 @@ if (sle_version_at_least('15')) {
 }
 
 # don't want updates, as we don't test it or rely on it in any tests, if is executed during installation
-# Proxy SCC replaces all update repo urls and we end up having invalid update repos, and we
-# also do not want to have official update repos, which will lead to inconsistent SUT.
 # For released products we want install updates during installation, only in minimal workflow disable
-set_var('DISABLE_SLE_UPDATES', get_var('DISABLE_SLE_UPDATES', get_var('QAM_MINIMAL') || (is_sle('15+') && !is_updates_tests)));
+set_var('DISABLE_SLE_UPDATES', get_var('DISABLE_SLE_UPDATES', get_var('QAM_MINIMAL')));
 
 # Set serial console for Xen PV
 if (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')) {


### PR DESCRIPTION
Whatever the reason was that proxy-SCC update repo rewriting did not work for
us we do not know anymore and want to use the same approach for all SLE
versions.

Related progress issue: https://progress.opensuse.org/issues/34099