### PR TITLE
Fix CaaSP node removal again

### DIFF
--- a/tests/caasp/stack_add_remove.pm
+++ b/tests/caasp/stack_add_remove.pm
@@ -34,9 +34,11 @@ sub add_nodes {
     assert_screen 'velum-bootstrap-done';
     send_key 'end';
     assert_screen 'velum-adding-nodes-done', 900;
+    send_key 'home';
 }
 
 sub remove_nodes {
+    send_key 'end';
     mouse_set xy('delayed-remove-xy');
     mouse_click;
     assert_and_click 'confirm-removal';


### PR DESCRIPTION
Because switch_to function is not robust enough.

Fix for: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5004