### PR TITLE
Enable update repos on SLE 15 by default

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -131,11 +131,9 @@ if (sle_version_at_least('15')) {
     }
 }
 
-# don't want updates, as we don't test it or rely on it in any tests, if is executed during installation
-# Proxy SCC replaces all update repo urls and we end up having invalid update repos, and we
-# also do not want to have official update repos, which will lead to inconsistent SUT.
+# DISABLE_SLE_UPDATES can be used to disable online update repos
 # For released products we want install updates during installation, only in minimal workflow disable
-set_var('DISABLE_SLE_UPDATES', get_var('DISABLE_SLE_UPDATES', get_var('QAM_MINIMAL') || (is_sle('15+') && !is_updates_tests)));
+set_var('DISABLE_SLE_UPDATES', get_var('DISABLE_SLE_UPDATES', get_var('QAM_MINIMAL')));
 
 # Set serial console for Xen PV
 if (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')) {


### PR DESCRIPTION
For SLE 15 previously we had an issue that update repos were replaced by
proxy SCC to non-existing ones, as we don't sync them. Now all update
repos per module are mapped to the same mirror on OSD. So it's safe to
enable this behavior for SLE 15.

See [poo#34099](https://progress.opensuse.org/issues/34099).

- Verification runs: 
  * [enable_updates](http://g226.suse.de/tests/1764#)
  * [disable_updates](http://g226.suse.de/tests/1765#)
