### PR TITLE
Add DEV option in BETA variable for velum footer

### DIFF
--- a/tests/caasp/stack_configure.pm
+++ b/tests/caasp/stack_configure.pm
@@ -63,7 +63,7 @@ sub run {
 
     # Check that footer has proper tag
     my $v = get_var('VERSION');
-    $v .= '-dev' if get_var 'BETA';
+    $v .= '-dev' if check_var('BETA', 'DEV');
     assert_screen "velum-footer-version-$v";
 
     # Register to velum


### PR DESCRIPTION
BETA (installation beta warning) and DEV (velum footer) are not always the same

Failed job: https://openqa.suse.de/tests/1678963#step/stack_configure/5
Caused by: https://github.com/kubic-project/velum/commit/4a274dea8df6012c241e06bcc2ffac34fe44454d