### PR TITLE
Change in expected reboot/shutdown for KVM VMs

### DIFF
--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -65,9 +65,9 @@ sub set_svirt_domain_elements {
         assert_screen "kernel-saved";
     }
     # after installation we need to redefine the domain, so just shutdown
-    # on zdup and online migration we don't need to redefine in between
-    # If boot from existing hdd image, we don't expect shutdown on reboot
-    if (!get_var('ZDUP') and !get_var('ONLINE_MIGRATION') and !get_var('BOOT_HDD_IMAGE') and !get_var('AUTOYAST')) {
+    # on zdup and online migration we need to redefine in between
+    # If boot from existing hdd image, we expect shutdown on reboot
+    unless (!get_var('ZDUP') and !get_var('ONLINE_MIGRATION') and !get_var('BOOT_HDD_IMAGE') and !get_var('AUTOYAST')) {
         $svirt->change_domain_element(on_reboot => 'destroy');
     }
 }


### PR DESCRIPTION
Related change in svirt backend.
https://github.com/os-autoinst/os-autoinst/pull/956/files

- Related ticket: [[sle][functional][u][fast] test fails in bootloader_zkvm - Failed to define domain from /var/lib/libvirt/images/openQA-SUT-3.xml](https://progress.opensuse.org/issues/36063)

