### PR TITLE
Fix x11-desktopapps-documentation failed test cases

### DIFF
--- a/tests/x11/gnote/gnote_rename_title.pm
+++ b/tests/x11/gnote/gnote_rename_title.pm
@@ -25,9 +25,7 @@ sub run {
     send_key "up";
     send_key "up";
     type_string "new title-opensuse\n";
-    send_key "ctrl-tab";    #jump to toolbar
-    send_key "ctrl-tab" if is_sle('15+');    #jump to toolbar for SLED15
-    send_key "ret";                          #back to all notes interface
+    send_key 'esc';    #back to all notes interface
     send_key_until_needlematch 'gnote-new-note-title-matched', 'down', 6;
     send_key "delete";
     send_key "tab";

--- a/tests/x11/gnote/gnote_undo_redo.pm
+++ b/tests/x11/gnote/gnote_undo_redo.pm
@@ -38,17 +38,14 @@ sub run {
 
     #assure undo and redo take effect after save note and re-enter note
     send_key "ctrl-tab";    #jump to toolbar
-    send_key "ctrl-tab" if is_sle('15+');    #jump to toolbar for SLED15
-    send_key "ret";                          #back to all notes interface
+    send_key "ret";         #back to all notes interface
     send_key_until_needlematch 'gnote-new-note-matched', 'down', 6;
     wait_still_screen 3;
     send_key "ret";
     $self->undo_redo_once;
 
     #clean: remove the created new note
-    send_key "ctrl-tab";                     #jump to toolbar
-    send_key "ctrl-tab" if is_sle('15+');    #jump to toolbar for SLED15
-    send_key "ret";                          #back to all notes interface
+    send_key "esc";
     send_key_until_needlematch 'gnote-new-note-matched', 'down', 6;
     send_key "delete";
     send_key "tab";

--- a/tests/x11/libreoffice/libreoffice_recent_documents.pm
+++ b/tests/x11/libreoffice/libreoffice_recent_documents.pm
@@ -35,7 +35,9 @@ sub run {
     # Check Recent Documents
     wait_still_screen;
     x11_start_program('oowriter');
-    send_key "alt-f";
+    if (is_sle('<15')) {
+        send_key "alt-f";
+    }
     # Because of bsc#1074057 alt-f is not working in libreoffice under wayland
     # use another way to replace alt-f in SLED15
     if (is_sle '15+') {


### PR DESCRIPTION
Updated gnote_rename_title.pm
Updated gnote_undo_redo.pm
Updated libreoffice_recent_documents.pm
To make the above 3 test cases able to run successfully on x11.

- Related ticket: https://progress.opensuse.org/issues/35272
- Verification run: 
SLED15
wayland: http://10.67.18.138/tests/124
x11:        http://10.67.18.138/tests/123
12SP3:   http://10.67.18.138/tests/125
