### PR TITLE
Move mouse cursor on backround field

### DIFF
--- a/tests/ses/openattic.pm
+++ b/tests/ses/openattic.pm
@@ -25,6 +25,7 @@ sub run {
         zypper_call 'in firefox icewm xinit xorg-x11-server';
         type_string "startx\n";    # start icewm
         assert_screen 'generic-desktop';
+        mouse_set 100, 100;
         mouse_click 'right';
         send_key_until_needlematch 'xterm', 'ret';
         type_string "firefox http://master\n";    # open openattic web running on master node


### PR DESCRIPTION
Mouse cursor is on the panel and right click then does not do what is expected, so move it on the background.

- Related ticket: https://progress.opensuse.org/issues/35785
- Verification run: http://10.100.12.155/tests/3321#step/openattic/4
