### PR TITLE
Redirect gsettings error messages to /dev/null

### DIFF
--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -53,7 +53,7 @@ sub notification_handler {
     my ($feature, $state) = @_;
 
     select_console('user-console');
-    assert_script_run("gsettings get $feature && gsettings set $feature $state || true");
+    assert_script_run("(gsettings get $feature && gsettings set $feature $state) 2>/dev/null || true");
 }
 
 sub verify_default_keymap_x11 {


### PR DESCRIPTION
- Related ticket: [[functional][y][fast] No such schema "DejaDup" - error message about gsettings in seemingly unrelated test](https://progress.opensuse.org/issues/36057)
- Verification runs:
* [sle-15-Installer-DVD-x86_64-Build611.1-gnome@64bit](http://dhcp151.suse.cz/tests/2353#step/keymap_or_locale/2)
* [opensuse-15.0-NET-x86_64-Build245.2-update_Leap_42.2_cryptlvm@uefi](http://dhcp151.suse.cz/tests/2351#step/keymap_or_locale/2)
* [opensuse-15.0-NET-x86_64-Build245.2-update_Leap_42.2_gnome@64bit-2G](http://dhcp151.suse.cz/tests/2348) 
