### PR TITLE
Enable disable_grub_timeout for SLE11 base ugrade

### DIFF
--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -16,7 +16,7 @@ use warnings;
 use base "y2logsstep";
 use testapi;
 use utils;
-use version_utils qw(is_sle is_leap is_tumbleweed);
+use version_utils qw(is_sle is_leap);
 
 sub run {
     my ($self) = shift;
@@ -47,7 +47,8 @@ sub run {
     }
 
     # Config bootloader is not be supported during an upgrade
-    if (get_var('UPGRADE') && (!is_sle('<15') || !is_leap('<15.0'))) {
+    # Add exception for SLES11SP4 base update, configure grub for this scenario
+    if (get_var('UPGRADE') && (!is_sle('<15') || !is_leap('<15.0')) && (!check_var('HDDVERSION', '11-SP4'))) {
         assert_screen "bootloader-config-unsupport";
         send_key 'ret';
         return;


### PR DESCRIPTION
Add disable_grub_time for SLES11SP4 base migration.
Configure grub if original system version is SLES11SP4

-See Poo#36018

- Related ticket: https://progress.opensuse.org/issues/36018
- Verification run: http://openqa-apac1.suse.de/tests/916#step/disable_grub_timeout/11
