### PR TITLE
Fix s390x-kvm tests failing on double definition of "destroy"

### DIFF
--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -68,6 +68,7 @@ sub set_svirt_domain_elements {
     # on zdup and online migration we need to redefine in between
     # If boot from existing hdd image, we expect shutdown on reboot
     unless (!get_var('ZDUP') and !get_var('ONLINE_MIGRATION') and !get_var('BOOT_HDD_IMAGE') and !get_var('AUTOYAST')) {
+        $svirt->change_domain_element(on_reboot => undef);
         $svirt->change_domain_element(on_reboot => 'destroy');
     }
 }


### PR DESCRIPTION
Verification runs: 100 jobs passed in the range
http://lord.arch/tests/898 to http://lord.arch/tests/999

Related progress issue: https://progress.opensuse.org/issues/36078