### PR TITLE
Use entire disk in case there are partitions

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -290,14 +290,11 @@ sub take_first_disk {
         };
         send_key $cmd{next};
 
-        if ($args{iscsi}) {
-            assert_screen 'preparing-disk-overview';
-        }
-        else {
-            assert_screen "use-entire-disk";
-            wait_screen_change { send_key "alt-e" };    # use entire disk
-        }
-
+        # with iscsi we may or may not have previous installation on the disk,
+        # depending on the scenario we get different screens
+        # same can happen with ipmi installations
+        assert_screen [qw(use-entire-disk preparing-disk-overview)];
+        wait_screen_change { send_key "alt-e" } if match_has_tag 'use-entire-disk';    # use entire disk
         send_key $cmd{next};
     }
 }


### PR DESCRIPTION
With iscsi we may or may not have installation on the disk,
depending on the scenario we may have different screen
same can happen with ipmi installations.

Note: affects only SLE12.
See [poo#36060](https://progress.opensuse.org/issues/36060).

[Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/842).

- Verification runs:
  * [iscsi empty disk](http://gershwin.arch.suse.de/tests/362#step/partitioning_iscsi/5)
  * [iscsi partitioned disk](http://gershwin.arch.suse.de/tests/361#step/partitioning_iscsi/3)
 
