### PR TITLE
Fix gnucash on LXDE

### DIFF
--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -27,7 +27,8 @@ sub run {
     # Leave tutorial window
     wait_screen_change { send_key 'alt-f4' };
     # Leave tips windows for GNOME case
-    if (check_var('DESKTOP', 'gnome') || check_var('DESKTOP', 'xfce')) {
+    if (check_var('DESKTOP', 'gnome') || check_var('DESKTOP', 'xfce') || check_var('DESKTOP', 'lxde')) {
+        send_key 'alt-tab' if (check_var('DESKTOP', 'lxde'));
         wait_screen_change { send_key 'alt-c' };
     }
     send_key 'ctrl-q';    # Exit


### PR DESCRIPTION
Fixed the gnucash test for lxde by switching the focus on the tip
window and adding a needle for the 'save changes' window

- Related ticket: https://progress.opensuse.org/issues/34717
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/368
- Verification run: http://pinky.arch.suse.de/tests/1017 and following
