### PR TITLE
Fix kde mult_user_dm: \n already selects pw field

### DIFF
--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -73,7 +73,6 @@ sub run {
         wait_screen_change { send_key 'shift-tab' };
         send_key 'ctrl-a';
         type_string "$user\n";
-        send_key 'tab';
     }
     handle_login($user, 1);
     assert_screen 'generic-desktop', 60;


### PR DESCRIPTION
Verification run: http://artemis.suse.de/tests/291
Fixes https://progress.opensuse.org/issues/36088