### PR TITLE
Fix typo in toolchain post_fail_hook

### DIFF
--- a/tests/console/kdump_and_crash.pm
+++ b/tests/console/kdump_and_crash.pm
@@ -56,7 +56,7 @@ sub post_fail_hook {
 
     script_run 'ls -lah /boot/';
     script_run 'tar -cvfJ /tmp/crash_saved.tar.xz /var/crash/*';
-    upload_logs '/tmp/crash_saved.xz';
+    upload_logs '/tmp/crash_saved.tar.xz';
 
     $self->SUPER::post_fail_hook;
 }


### PR DESCRIPTION
Fix typo from previous PR #4984 as I changed compression at the very last minute.
- Related ticket: https://progress.opensuse.org/issues/33376
