### PR TITLE
Disable toolchain module for QAM

### DIFF
--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -222,7 +222,7 @@ else {
 # REGISTER = 'installation' -> Registers with SCC during the installation
 if (get_var('REGISTER') && !check_var('STACK_ROLE', 'controller')) {
     loadtest 'caasp/register_and_check';
-    loadtest 'caasp/register_toolchain';
+    loadtest 'caasp/register_toolchain' if is_caasp('3.0+');
 }
 
 if (get_var('EXTRA', '') =~ /FEATURES/) {


### PR DESCRIPTION
Fix for: https://openqa.suse.de/tests/1683580#step/register_toolchain/4