### PR TITLE
Added PostgreSQL 10 install for SLES15

### DIFF
--- a/tests/console/php7_postgresql96.pm
+++ b/tests/console/php7_postgresql96.pm
@@ -30,7 +30,7 @@ sub run {
     setup_apache2(mode => 'PHP7');
 
     # install requirements
-    zypper_call 'in php7-pgsql postgresql96-server sudo';
+    zypper_call 'in php7-pgsql postgresql*-server sudo';
 
     # start postgresql service
     systemctl 'start postgresql';


### PR DESCRIPTION
PostgreSQL 9.6 has been replaced by PostgreSQL 10 in SLES15
Replace PostgrSQL version with '*' in the zypper command

- Related ticket: https://progress.opensuse.org/issues/35883
- Verification run: https://openqa-apac1.suse.de/tests/931
