### PR TITLE
Fix typo for tar in kdump_and_crash

### DIFF
--- a/tests/console/kdump_and_crash.pm
+++ b/tests/console/kdump_and_crash.pm
@@ -55,7 +55,7 @@ sub post_fail_hook {
     my ($self) = @_;
 
     script_run 'ls -lah /boot/';
-    script_run 'tar -cvfJ /tmp/crash_saved.tar.xz /var/crash/*';
+    script_run 'tar -cvJf /tmp/crash_saved.tar.xz -C /var/crash .';
     upload_logs '/tmp/crash_saved.tar.xz';
 
     $self->SUPER::post_fail_hook;


### PR DESCRIPTION
f parameter  should be followed by file name.
- Related ticket: https://progress.opensuse.org/issues/33376
