### PR TITLE
Avoid double start of updater

### DIFF
--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -89,7 +89,7 @@ sub run {
                 next;
             }
             elsif (match_has_tag("updates_installed-logout") || match_has_tag("updates_restart_application")) {
-                send_key "alt-c";    # close
+                wait_screen_change { send_key "alt-c"; };    # close
 
                 # The logout is not acted upon, which may miss a libzypp update
                 # Force reloading of packagekitd (bsc#1075260, poo#30085)


### PR DESCRIPTION
Now waits for updater to close after sending alt-c
This should prevent the application from being started twice

- Related ticket: https://progress.opensuse.org/issues/28875
- Needles: NONE
- Verification run: http://pinky.arch.suse.de/tests/1068 and following 20