### PR TITLE
Fix shortcut changing in the partitioner for partitioning_raid

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -62,6 +62,7 @@ sub init_cmd {
       encryptdisk alt-a
       enablelvm alt-e
       resize alt-i
+      customsize alt-c
       acceptlicense alt-a
       instdetails alt-d
       rebootnow alt-n

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -39,14 +39,15 @@ sub run {
         set_var('STORAGE_NG', 1);
         # Define changed shortcuts
         $cmd{donotformat}     = 'alt-t';
-        $cmd{addraid}         = 'alt-i';
-        $cmd{filesystem}      = 'alt-a';
+        $cmd{addraid}         = 'alt-r';
+        $cmd{filesystem}      = 'alt-r';
+        $cmd{rescandevices}   = 'alt-r';
+        $cmd{customsize}      = 'alt-o';
         $cmd{exp_part_finish} = 'alt-n';
         $cmd{guidedsetup}     = 'alt-g';
         if (check_var('DISTRI', 'opensuse')) {
             #TODO remove SYSTEM_ROLE_FIRST_FLOW usages with versions checks
             $cmd{expertpartitioner} = get_var('SYSTEM_ROLE_FIRST_FLOW') ? 'alt-e' : 'alt-x';
-            $cmd{rescandevices}     = get_var('SYSTEM_ROLE_FIRST_FLOW') ? 'alt-e' : 'alt-c';
             $cmd{enablelvm}         = get_var('SYSTEM_ROLE_FIRST_FLOW') ? 'alt-e' : 'alt-a';
             $cmd{encryptdisk}       = get_var('SYSTEM_ROLE_FIRST_FLOW') ? 'alt-a' : 'alt-l';
         }

--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -42,7 +42,7 @@ sub addpart {
     assert_screen "partition-size";
     if (is_storage_ng) {
         # maximum size is selected by default
-        send_key 'alt-c';
+        send_key $cmd{customsize};
         assert_screen 'partition-custom-size-selected';
         send_key 'alt-s';
     }
@@ -268,7 +268,7 @@ sub add_prep_boot_partition {
     assert_screen 'partitioning-size';
     # Storage-ng has maximum size selected by default
     if (is_storage_ng) {
-        send_key 'alt-c';
+        send_key $cmd{customsize};
         wait_screen_change { send_key $cmd{size_hotkey} };
     }
     wait_screen_change { send_key 'ctrl-a' };    # Select text field content


### PR DESCRIPTION
Start from storage NG 4.0.179, the shortcuts has been changed in the several places, update shortcut configs to fix partitioning_raid fail.

- Fail run: https://openqa.opensuse.org/tests/675479
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/370
- Verification run:
* RAID0: http://147.2.211.128/tests/65
* RAID1: http://147.2.211.128/tests/69
