### PR TITLE
Add kubeadm test for Kubic

### DIFF
--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -136,6 +136,7 @@ sub load_feature_tests {
         loadtest 'console/docker_runc';
         # OCI Containers
         if (is_caasp('kubic') && check_var('SYSTEM_ROLE', 'plain')) {
+            loadtest 'console/kubeadm';
             loadtest 'console/skopeo';
             loadtest 'console/umoci';
             loadtest 'console/runc';

--- a/tests/console/kubeadm.pm
+++ b/tests/console/kubeadm.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test kubeadm installation and bootstrap single k8s cluster
+# Maintainer: Panagiotis Georgiadis <pgeorgiadis@suse.com>
+
+use strict;
+use base "consoletest";
+use testapi;
+use caasp;
+use utils "systemctl";
+
+sub run {
+    select_console("root-console");
+
+    record_info 'Setup', 'Test: Package Installation';
+    my $packages = 'kubernetes-client kubernetes-kubelet kubernetes-kubeadm docker-kubic cri-tools';
+    trup_install($packages);
+
+    record_info 'Prepare', 'Test: Enable and start required services';
+    systemctl('enable --now kubelet docker');
+    systemctl('is-active docker');
+    systemctl('is-active kubelet');
+
+    record_info 'Test #1', 'Test: Initialize kubeadm';
+    assert_script_run('kubeadm reset');
+    assert_script_run('kubeadm init');
+
+}
+
+1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/36154
- Needles: *not needed*
- Verification run: http://skyrim.qam.suse.de/tests/2948#step/kubeadm/33

As for now, kubeadm is broken and it hits https://bugzilla.opensuse.org/show_bug.cgi?id=1093132
there's no workaround atm.

