### PR TITLE
Remove addons license checking for SLE15+

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -121,11 +121,6 @@ sub handle_addon {
     if (is_sle('15+') && $addon !~ /^ses$|^rt$/) {
         send_key 'spc';
         send_key $cmd{next};
-        wait_still_screen 2;
-
-        # In SLE 15 some modules do not have license or have the same
-        # license (see bsc#1089163) and so are not be shown twice
-        addon_license($addon) unless (grep { $addon eq $_ } @SLE15_ADDONS_WITHOUT_LICENSE);
         wait_still_screen 2;
     }
 }


### PR DESCRIPTION
License is never shown when adding addons with Packages DVD.
So we can remove call to `addon_license` function for SLE15+.

I manually tried to add **ALL** Modules/Products with Packages DVD and I never had any license shown. So I think this code could simply be removed.

This PR fix this failing test: https://openqa.suse.de/tests/1684333#step/addon_products_sle/16
Verification run: http://1b147.qa.suse.de/tests/1695
