### PR TITLE
Improve logging in post_fail_hook for shutdown module

### DIFF
--- a/tests/x11/shutdown.pm
+++ b/tests/x11/shutdown.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/x11/shutdown.pm
+++ b/tests/x11/shutdown.pm
@@ -39,9 +39,9 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = @_;
-    # In case plymouth splash shows up and the shutdown is blocked, show
-    # console logs - save screen of console (plymouth splash screen in disabled at boottime)
-    send_key('esc') if $self->{await_shutdown};
+    # Reveal what is behind Plymouth splash screen
+    wait_screen_change { send_key('esc') } if $self->{await_shutdown};
+    # save a screenshot before trying further measures which might fail
     save_screenshot;
 }
 

--- a/tests/x11/shutdown.pm
+++ b/tests/x11/shutdown.pm
@@ -43,6 +43,8 @@ sub post_fail_hook {
     wait_screen_change { send_key('esc') } if $self->{await_shutdown};
     # save a screenshot before trying further measures which might fail
     save_screenshot;
+    # try to save logs as a last resort
+    $self->export_logs;
 }
 
 1;


### PR DESCRIPTION
The commit adds more logging to post_fail_hook to improve issues debugging for 'shutdown' module, that fails sporadically on different environments and architectures.
Also, it improves splash screen hiding, by adding 'wait-for-screen-to-be-changed' approach,
as useful information for debugging may also be presented under the splash screen.

- Related ticket: https://progress.opensuse.org/issues/35215
- Verification run: http://10.160.65.138/tests/398#step/shutdown/18
