### PR TITLE
Record soft-failure for missing deps in pattern selection

### DIFF
--- a/tests/installation/select_patterns_and_packages.pm
+++ b/tests/installation/select_patterns_and_packages.pm
@@ -206,10 +206,7 @@ sub run {
         }
     }
     $self->package_action;
-    if (is_sle('15+') and check_var('PATTERNS', 'all') and $dep_issue) {
-        record_soft_failure "bsc#1084064 - Cloud patterns conflicts";    # skip second & third runs
-    }
-    else {
+    unless (is_sle('15+') && check_var('PATTERNS', 'all') && $dep_issue) {
         $secondrun++;
         $self->gotopatterns;
         $self->package_action;


### PR DESCRIPTION
Record individual soft-failure for missing dependencies in pattern selection.

- Related ticket: https://progress.opensuse.org/issues/34273
- Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1093073
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/843
- Verification run: http://dhcp254.suse.cz/tests/1246#step/select_patterns_and_packages/209
