### PR TITLE
Reorder System Role evaluation in default_desktop

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -302,11 +302,11 @@ sub is_desktop_module_selected {
 }
 
 sub default_desktop {
+    return 'textmode' if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'));
     return undef   if get_var('VERSION', '') lt '12';
     return 'gnome' if get_var('VERSION', '') lt '15';
     # with SLE 15 LeanOS only the default is textmode
     return 'gnome' if get_var('BASE_VERSION', '') =~ /^12/;
-    return 'textmode' if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'));
     return 'gnome' if is_desktop_module_selected;
     # default system role for sles and sled
     return 'textmode' if is_server || !get_var('SCC_REGISTER') || !check_var('SCC_REGISTER', 'installation');


### PR DESCRIPTION
Update default_desktop subroutine in order to avoid schedule of change_desktop.pm & installation_overview_before.pm modules for SYSTEM_ROLE={kvm,xen} for sle12-sp4 tests

- Related ticket: [[sle][functional][y][yast][medium] New test scenarios: videomode_text+textmode+role_kvm (… and xen)](https://progress.opensuse.org/issues/34219)
