### PR TITLE
Extend timeout for module registration

### DIFF
--- a/tests/caasp/register_toolchain.pm
+++ b/tests/caasp/register_toolchain.pm
@@ -19,7 +19,7 @@ sub run {
     my $list_addons = script_output('LANG=C SUSEConnect --list');
     record_soft_failure('bsc#1090729') if $list_addons =~ /SUSE CaaS Plattform/;
     my $install_command = ($list_addons =~ /Install with:\s+(.*)/) ? $1 : die "Command for installing not available";
-    if (script_run($install_command)) {
+    if (script_run($install_command, 60)) {
         record_soft_failure('bsc#1090200');
         # Workarond for registering by transactional-update instead of SUSEConnect
         assert_script_run 'transactional-update register -p caasp-toolchain/' . get_var('VERSION') . '/x86_64';


### PR DESCRIPTION
Fix for: https://openqa.suse.de/tests/1686842#step/register_toolchain/5