### PR TITLE
Don't run NFS test on local runs

### DIFF
--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -121,7 +121,9 @@ sub load_feature_tests {
     loadtest 'caasp/overlayfs';
     loadtest 'caasp/services_enabled';
     loadtest 'caasp/one_line_checks';
-    loadtest 'caasp/nfs_client' if get_var('NFS_SHARE');
+    if (get_var('NFS_SHARE') && !is_caasp('local')) {
+        loadtest 'caasp/nfs_client';
+    }
 
     # Transactional updates
     loadtest 'caasp/transactional_update';


### PR DESCRIPTION
NFS_SHARE is not accessible on opensuse. Cloned jobs have this variable, and fail.

Fix for: http://dhcp165.suse.cz/tests/4126#step/nfs_client/5