### PR TITLE
JeOS: Deploy with German keyboard, locale, & lang

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -272,11 +272,18 @@ sub script_sudo($$) {
     return;
 }
 
-# Simplified but still colored prompt for better readability.
+=head2 set_standard_prompt
+
+  set_standard_prompt([$user] [[, os_type] [, skip_set_standard_prompt]])
+
+C<$user> and C<os_type> affect prompt sign. C<skip_set_standard_prompt> options
+skip the entire routine.
+=cut
 sub set_standard_prompt {
-    my ($self, $user, $os_type) = @_;
+    my ($self, $user, %args) = @_;
+    return if $args{skip_set_standard_prompt};
     $user ||= $testapi::username;
-    $os_type ||= 'linux';
+    my $os_type = $args{os_type} // 'linux';
     my $prompt_sign = $user eq 'root' ? '#' : '$';
     if ($os_type eq 'windows') {
         $prompt_sign = $user eq 'root' ? '# ' : '$$ ';
@@ -472,8 +479,19 @@ sub ensure_user {
     type_string("su - $user\n") if $user ne 'root';
 }
 
-# callback whenever a console is selected for the first time
-# accepts agruments provided to select_console
+=head2 activate_console
+
+  activate_console($console [, [ensure_tty_selected => 0|1, ] [skip_set_standard_prompt => 0|1, ] [skip_setterm => 0|1, ]])
+
+Callback whenever a console is selected for the first time. Accepts arguments
+provided to select_console().
+
+C<skip_set_standard_prompt> and C<skip_setterm> arguments skip respective routines,
+e.g. if you want select_console() without addition console setup. Then, at some
+point, you should set it on your own.
+
+Option C<ensure_tty_selected> ensures TTY is selected.
+=cut
 sub activate_console {
     my ($self, $console, %args) = @_;
 
@@ -541,7 +559,7 @@ sub activate_console {
             }
         }
         assert_screen "text-logged-in-$user";
-        $self->set_standard_prompt($user);
+        $self->set_standard_prompt($user, skip_set_standard_prompt => $args{skip_set_standard_prompt});
         assert_screen $console;
     }
     elsif ($type eq 'virtio-terminal') {
@@ -552,11 +570,11 @@ sub activate_console {
         handle_password_prompt;
         ensure_user($user);
         assert_screen(["text-logged-in-$user", "text-login"], 60);
-        $self->set_standard_prompt($user);
+        $self->set_standard_prompt($user, skip_set_standard_prompt => $args{skip_set_standard_prompt});
     }
     elsif ($console eq 'svirt') {
         my $os_type = check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 'windows' : 'linux';
-        $self->set_standard_prompt('root', $os_type);
+        $self->set_standard_prompt('root', os_type => $os_type, skip_set_standard_prompt => $args{skip_set_standard_prompt});
         save_svirt_pty;
     }
     elsif (
@@ -578,7 +596,7 @@ sub activate_console {
         # On s390x 'setterm' binary is not present as there's no linux console
         if (!check_var('ARCH', 's390x')) {
             # Disable console screensaver
-            $self->script_run('setterm -blank 0');
+            $self->script_run('setterm -blank 0') unless $args{skip_setterm};
         }
     }
 }

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -1,7 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2015-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,38 +14,71 @@ use base "opensusebasetest";
 use strict;
 use testapi;
 use version_utils 'is_sle';
-use utils 'assert_screen_with_soft_timeout';
+use utils qw(assert_screen_with_soft_timeout ensure_serialdev_permissions);
 
-sub select_locale {
-    assert_screen 'jeos-locale', 300;
-    my $lang = get_var('INSTLANG', 'us');
-    send_key_until_needlematch "jeos-system-locale-$lang", 'e', 50;
-    send_key 'ret';
+sub post_fail_hook {
+    assert_script_run('timedatectl');
+    assert_script_run('locale');
+    assert_script_run('cat /etc/vconsole.conf');
+    assert_script_run('ldd --help');
 }
-sub accept_license {
-    assert_screen 'jeos-license', 60;
-    send_key 'ret';
-    assert_screen 'jeos-doyouaccept';
-    send_key 'ret';
-}
-sub select_keyboard {
-    assert_screen 'jeos-keylayout', 200;
-    send_key 'ret';
+
+sub verify_user_info {
+    my (%args) = @_;
+    my $user = $args{user_is_root};
+    my $lang = get_var('JEOSINSTLANG', 'en_US');
+
+    my %tz_data = ('en_US' => 'UTC', 'de_DE' => 'Europe/Berlin');
+    assert_script_run("timedatectl | awk '\$1 ~ /Time/ { print \$3 }' | grep ^" . $tz_data{$lang} . "\$");
+
+    my %locale_data = ('en_US' => 'en_US.UTF-8', 'de_DE' => 'de_DE.UTF-8');
+    assert_script_run("locale | tr -d \\'\\\" | awk -F= '\$1 ~ /LC_CTYPE/ { print \$2 }' | grep ^" . $locale_data{$lang} . "\$");
+
+    my %keymap_data = ('en_US' => 'us', 'de_DE' => 'de');
+    assert_script_run("awk -F= '\$1 ~ /KEYMAP/ { print \$2 }' /etc/vconsole.conf | grep ^" . $keymap_data{$lang} . "\$");
+
+    my %lang_data = ('en_US' => 'For bug reporting', 'de_DE' => 'Eine Anleitung zum Melden');
+    # User has locale defined in firstboot, root always defaults to POSIX (i.e. English)
+    my $proglang = $args{user_is_root} ? 'en_US' : $lang;
+    assert_script_run("ldd --help | grep '^" . $lang_data{$proglang} . "'");
 }
 
 sub run {
-    select_locale;
-    accept_license if is_sle;
-    select_keyboard;
+    my $lang = get_var('JEOSINSTLANG', 'en_US');
+    my %keylayout_key = ('en_US' => 'e', 'de_DE' => 'd');
+    # For 'en_US' pick 'en_US', for 'de_DE' select 'de_DE'
+    my %locale_key = ('en_US' => 'e', 'de_DE' => 'd');
+    # For 'en_US' pick 'UTC', for 'de_DE' select 'Europe/Berlin'
+    my %tz_key = ('en_US' => 'u', 'de_DE' => 'e');
 
-    assert_screen 'jeos-timezone';    # timzezone window, continue with selected timezone
+    # Select locale
+    assert_screen 'jeos-locale', 300;
+    send_key_until_needlematch "jeos-system-locale-$lang", $locale_key{$lang}, 50;
     send_key 'ret';
 
-    assert_screen 'jeos-root-password';    # set root password
+    # Accept license
+    if (is_sle) {
+        assert_screen 'jeos-license', 60;
+        send_key 'ret';
+        assert_screen 'jeos-doyouaccept';
+        send_key 'ret';
+    }
+
+    # Select language
+    send_key_until_needlematch "jeos-keylayout-$lang", $keylayout_key{$lang}, 30;
+    send_key 'ret';
+
+    # Select timezone
+    send_key_until_needlematch "jeos-timezone-$lang", $tz_key{$lang}, 10;
+    send_key 'ret';
+
+    # Enter password
+    assert_screen 'jeos-root-password';
     type_password;
     send_key 'ret';
 
-    assert_screen 'jeos-confirm-root-password';    # confirm root password
+    # Confirm password
+    assert_screen 'jeos-confirm-root-password';
     type_password;
     send_key 'ret';
 
@@ -61,19 +93,37 @@ sub run {
     # Meltdown/Spectre mitigations makes this even worse.
     assert_screen_with_soft_timeout('linux-login', timeout => 1000, soft_timeout => 300, bugref => 'bsc#1077007');
 
-    select_console 'root-console';
+    select_console('root-console', skip_set_standard_prompt => 1, skip_setterm => 1);
 
-    assert_script_run "useradd -m $username -c '$realname'";    # create user account
-    my $str = time;
-    script_run "passwd $username; echo $str-\$?- > /dev/$serialdev", 0;    # set user's password
-    assert_screen 'passwd-prompt';
-    type_password;
-    send_key 'ret';
-    assert_screen 'passwd-retype-prompt';
-    type_password;
-    send_key 'ret';
-    my $ret = wait_serial "$str-\\d+-", 10;
-    die "passwd failed" unless (defined $ret && $ret =~ /$str-0-/);
+    type_string('1234%^&*()qwerty');
+    assert_screen("keymap-letter-data-$lang");
+    send_key('ctrl-u');
+    # Set 'us' keyboard as openQA can't operate with non-us keyboard layouts
+    if ($lang ne 'en_US') {
+        # With the foreign keyboard, type 'loadkeys us'
+        my %loadkeys_reset = ('de_DE' => 'loadkezs us');
+        type_string("$loadkeys_reset{$lang}\n");
+        wait_still_screen;
+    }
+    # Manually configure root-console as we skipped some parts in root-console's activation
+    $testapi::distri->set_standard_prompt('root');
+    assert_script_run('setterm -blank 0');
+
+    verify_user_info(user_is_root => 1);
+
+    # Create user account
+    assert_script_run "useradd -m $username -c '$realname'";
+    assert_script_run "echo $username:$password | chpasswd";
+
+    ensure_serialdev_permissions;
+
+    select_console 'user-console';
+    verify_user_info;
+
+    select_console 'root-console';
+    if ($lang ne 'en_US') {
+        assert_script_run("sed -ie '/KEYMAP=/s/=.*/=us/' /etc/vconsole.conf");
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
https://progress.opensuse.org/issues/36067

This implements JeOS deployment with non-default keyboard, language,
locales; German ones initially.

openQA supports only a limited set of characters we are able to type
(i.e. ASCII), which makes testing with non-us keyboards cumbersome.
So I get rid of it ASAP and set us keyboard soon, but some options
has to be added to susedistribution.pm to test at least basics.

Validation run:
* `de_DE`: http://nilgiri.suse.cz/tests/661
* `en_US`: http://nilgiri.suse.cz/tests/662

Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/845