### PR TITLE
Allow formatting DASD before installation, during or not at all

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -167,6 +167,15 @@ sub setup_env {
         # Does _not_ work on aarch64
         set_var('UEFI_PFLASH', 1);
     }
+    # By default format DASD devices before installation
+    if (check_var('BACKEND', 's390x')) {
+        # Format DASD before the installation by default
+        # Skip format dasd before origin system installation by autoyast in 'Upgrade on zVM'
+        # due to channel not activation issue. Need further investigation on it.
+        # Also do not format if activate existing partitions
+        my $format_dasd = get_var('S390_DISK') || get_var('UPGRADE') || get_var('ENCRYPT_ACTIVATE_EXISTING') ? 'never' : 'pre_install';
+        set_var('FORMAT_DASD', get_var('FORMAT_DASD', $format_dasd));
+    }
 }
 
 sub any_desktop_is_applicable {

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -283,12 +283,8 @@ sub run {
     # activate console so we can call wait_serial later
     my $c = select_console('iucvconn', await_console => 0);
 
-    # we also want to test the formatting during the installation if the variable is set
-    # Skip format dasd before origin system installation by autoyast in 'Upgrade on zVM'
-    # due to channal not activation issue. Need further investigation on it.
-    if (!get_var("FORMAT_DASD_YAST") && !get_var('S390_DISK') && !get_var('UPGRADE') && !get_var('UPGRADE_ON_ZVM')) {
-        format_dasd;
-    }
+    # format DAST before installation by default
+    format_dasd if (check_var('FORMAT_DASD', 'pre_install'));
 
     select_console("installation");
 

--- a/tests/installation/disk_activation.pm
+++ b/tests/installation/disk_activation.pm
@@ -100,8 +100,8 @@ sub run {
             format_dasd;
         }
 
-        # format DASD if the variable is that, because we format it usually pre-installation
-        elsif (get_var('FORMAT_DASD_YAST')) {
+        # format DASD if the variable is that, because we format it as pre-installation step by default
+        elsif (check_var('FORMAT_DASD', 'install')) {
             send_key 'alt-s';                           # select all
             assert_screen 'dasd-selected';
             send_key 'alt-a';                           # perform action button


### PR DESCRIPTION
To increase coverage and flexibility, we want to control formatting of
DASD by setting one of 3 possible values.
Now one can set FORMAT_DASD='pre_install' to perfrom formatting before
installation, 'install' to use YaST installer features during
installation or 'never' to reuse existing partitions on the disk.

By default pre-installation formatting will be conducted, except for
some special scenarios.

See [poo#35959](https://progress.opensuse.org/issues/35959).