### PR TITLE
[xfstests] Upload kdump data; Run tests in random order; Limit execut…

### DIFF
--- a/tests/xfstests/enable_kdump.pm
+++ b/tests/xfstests/enable_kdump.pm
@@ -35,8 +35,12 @@ sub run {
     # Reboot
     power_action('reboot');
     $self->wait_boot;
-    select_virtio_console();
-    return 1 unless kdump_is_active;
+    select_console('root-console');
+    die "Failed to enable kdump" unless kdump_is_active;
+}
+
+sub test_flags {
+    return {fatal => 1};
 }
 
 1;

--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -45,4 +45,8 @@ sub run {
     log_create($STATUS_LOG);
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
+
 1;

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -28,4 +28,8 @@ sub run {
     assert_script_run("/usr/share/qa/qa_test_xfstests/partition.py --delhome $filesystem && sync", 600);
 }
 
+sub test_flags {
+    return {fatal => 1};
+}
+
 1;


### PR DESCRIPTION
The pull request contains 3 features:
- Upload kdump data
- Run tests in random order
- Limit execution time of a single test

- Related ticket: https://progress.opensuse.org/issues/36145
https://progress.opensuse.org/issues/21000
https://progress.opensuse.org/issues/35754
- Verification run: http://10.67.133.102/tests/432
