### PR TITLE
New tests for gnuhealth-client (poo#30044)

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -351,9 +351,16 @@ elsif (get_var('GNUHEALTH')) {
     boot_hdd_image;
     loadtest 'gnuhealth/gnuhealth_install';
     loadtest 'gnuhealth/gnuhealth_setup';
-    loadtest 'gnuhealth/tryton_install';
-    loadtest 'gnuhealth/tryton_preconfigure';
-    loadtest 'gnuhealth/tryton_first_time';
+    if (is_leap('<15.0')) {
+        loadtest 'gnuhealth/tryton_install';
+        loadtest 'gnuhealth/tryton_preconfigure';
+        loadtest 'gnuhealth/tryton_first_time';
+    }
+    else {
+        loadtest 'gnuhealth/gnuhealth_client_install';
+        loadtest 'gnuhealth/gnuhealth_client_preconfigure';
+        loadtest 'gnuhealth/gnuhealth_client_first_time';
+    }
 }
 elsif (is_rescuesystem) {
     loadtest "installation/rescuesystem";

--- a/tests/gnuhealth/gnuhealth_client_first_time.pm
+++ b/tests/gnuhealth/gnuhealth_client_first_time.pm
@@ -1,0 +1,50 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: first time startup for admin user for gnuhealth-client
+# Maintainer: Christopher Hofmann <cwh@suse.de>
+
+use base 'x11test';
+use strict;
+use testapi;
+use version_utils qw(is_leap is_tumbleweed);
+
+sub run {
+    if (is_tumbleweed || is_leap('42.3+')) {
+        wait_screen_change { send_key 'tab' };
+        send_key 'ret';
+        assert_screen 'gnuhealth-login_password';
+    }
+    else {
+        send_key_until_needlematch 'gnuhealth-login_password', 'tab';
+    }
+    type_string "susetesting\n";
+    assert_screen 'gnuhealth-module_configuration_wizard_start';
+    send_key 'ret';
+    assert_screen 'gnuhealth-module_configuration_wizard-add_users-welcome';
+    send_key 'ret';
+    assert_screen 'gnuhealth-module_configuration_wizard-add_users_dialog';
+    # let's not add a user for now
+    send_key 'alt-e';
+    assert_screen 'gnuhealth-module_configuration_wizard-next_step';
+    send_key 'alt-n';
+    assert_screen 'gnuhealth-module_configuration_wizard-configuration_done';
+    send_key 'alt-o';
+    assert_screen 'gnuhealth-admin_view', 300;
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+# overwrite the base class check for a clean desktop
+sub post_run_hook {
+}
+
+1;

--- a/tests/gnuhealth/gnuhealth_client_install.pm
+++ b/tests/gnuhealth/gnuhealth_client_install.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: gnuhealth tryton client installation and startup
+# Maintainer: Christopher Hofmann <cwh@suse.de>
+
+use base 'x11test';
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    ensure_installed 'gnuhealth-client';
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/gnuhealth/gnuhealth_client_preconfigure.pm
+++ b/tests/gnuhealth/gnuhealth_client_preconfigure.pm
@@ -1,0 +1,65 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: first time administration and setup work for gnuhealth-client
+# Maintainer: Christopher Hofmann <cwh@suse.de>
+
+use base 'x11test';
+use strict;
+use testapi;
+use version_utils qw(is_leap is_tumbleweed);
+
+sub run {
+    x11_start_program('gnuhealth-client');
+    assert_and_click 'gnuhealth-client-manage_profiles';
+    # wait for indexing to be done
+    wait_still_screen(3);
+    assert_and_click 'gnuhealth-client-manage_profiles-add';
+    type_string 'localhost';
+    send_key_until_needlematch 'gnuhealth-client-manage_profiles-host_textfield_selected', 'tab';
+    type_string 'localhost';
+    send_key 'tab';
+    if (is_tumbleweed || is_leap('42.3+')) {
+        assert_screen 'gnuhealth-client-manage_profiles-database_selected';
+        type_string 'admin';
+    }
+    else {
+        # button 'create' should appear, weird GUI behaviour
+        assert_and_click 'gnuhealth-client-manage_profiles-create_database';
+        # gnuhealth server password
+        type_string 'susetesting';
+        send_key 'tab';
+        # database name
+        type_string 'gnuhealth_demo';
+        send_key 'tab';
+        send_key 'tab';
+        # admin password
+        type_string 'susetesting';
+        send_key 'tab';
+        type_string 'susetesting';
+        # wait for create button to be active
+        assert_and_click 'gnuhealth-client-manage_profiles-create_database-create';
+
+    }
+    # back to profiles menue
+    assert_screen 'gnuhealth-client-manage_profiles-add', 300;
+    send_key 'ret';
+    # back to login dialog
+    assert_screen 'gnuhealth-client';
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+# overwrite the base class check for a clean desktop
+sub post_run_hook {
+}
+
+1;


### PR DESCRIPTION
In TW and Leap 15, the tryton frontend (package tryton) will be replaced with the gnuhealth-client (package gnuhealth-client). These changes replace all the tryton tests by gnuhealth-client for oS Leap 15.0 and newer.

- Related ticket: https://progress.opensuse.org/issues/30044
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/372
- Verification run: http://boltzmann.suse.de/tests/90
