### PR TITLE
Retry query nodes unless it works

### DIFF
--- a/tests/caasp/stack_kubernetes.pm
+++ b/tests/caasp/stack_kubernetes.pm
@@ -24,7 +24,7 @@ sub run {
     assert_script_run "kubectl cluster-info";
     assert_script_run "kubectl cluster-info > cluster.before_update";
     assert_script_run "kubectl config view --flatten=true | tee /dev/$serialdev";
-    assert_script_run "kubectl get nodes";
+    script_retry "kubectl get nodes", delay => 10;
     assert_script_run "! kubectl get cs --no-headers | grep -v Healthy";
 
     # Check cluster size


### PR DESCRIPTION
The `kubectl get nodes` seems to behave inconsistently. The
intention of the PR is to retry the action in case of failure.

- Related ticket: https://progress.opensuse.org/issues/36258
- Needles: *not needed*
- Verification run: http://skyrim.qam.suse.de/tests/2977
