### PR TITLE
Add (again) workaround for too small / partition on Leap 15.0 (boo#1093372)

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -816,7 +816,10 @@ sub load_inst_tests {
             }
             loadtest "installation/partitioning_filesystem";
         }
-        if (get_var("TOGGLEHOME")) {
+        # boo#1093372 Leap 15.0 proposes a separate home even on small disks
+        # making the root partition likely to small so we should switch the
+        # defaults here
+        if (get_var("TOGGLEHOME") || (is_leap('15.0+') && get_var('HDDSIZEGB', 0) < 12)) {
             loadtest "installation/partitioning_togglehome";
             if (get_var('LVM') && get_var('RESIZE_ROOT_VOLUME')) {
                 loadtest "installation/partitioning_resize_root";

--- a/tests/installation/partitioning_togglehome.pm
+++ b/tests/installation/partitioning_togglehome.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,10 +15,11 @@ use strict;
 use base "y2logsstep";
 use testapi;
 use installation_user_settings;
-use version_utils 'is_storage_ng';
+use version_utils qw(is_storage_ng is_leap);
 use partition_setup 'unselect_xen_pv_cdrom';
 
 sub run {
+    record_soft_failure 'boo#1093372' if (!get_var('TOGGLEHOME') && is_leap('15.1+'));
     wait_screen_change { send_key($cmd{guidedsetup}) };    # open proposal settings
     if (is_storage_ng) {
         unselect_xen_pv_cdrom;
@@ -41,6 +42,7 @@ sub run {
         assert_screen 'disabledhome';
     }
     send_key(is_storage_ng() ? 'alt-n' : 'alt-o');    # finish editing settings
+    save_screenshot;
 }
 
 1;


### PR DESCRIPTION
262dfeca2 has been reverted in 9fb6d9530 as tests broke that already have a
big enough hard disk. Now checking for HDDSIZEGB before.