### PR TITLE
New tests for gnuhealth-client (poo#30044)

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -351,9 +351,9 @@ elsif (get_var('GNUHEALTH')) {
     boot_hdd_image;
     loadtest 'gnuhealth/gnuhealth_install';
     loadtest 'gnuhealth/gnuhealth_setup';
-    loadtest 'gnuhealth/tryton_install';
-    loadtest 'gnuhealth/tryton_preconfigure';
-    loadtest 'gnuhealth/tryton_first_time';
+    loadtest 'gnuhealth/gnuhealth_client_install';
+    loadtest 'gnuhealth/gnuhealth_client_preconfigure';
+    loadtest 'gnuhealth/gnuhealth_client_first_time';
 }
 elsif (is_rescuesystem) {
     loadtest "installation/rescuesystem";

--- a/tests/gnuhealth/gnuhealth_client_first_time.pm
+++ b/tests/gnuhealth/gnuhealth_client_first_time.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,27 +16,28 @@ use testapi;
 use version_utils qw(is_leap is_tumbleweed);
 
 sub run {
+    my $gnuhealth = get_var('GNUHEALTH_CLIENT', 'gnuhealth-client');
     if (is_tumbleweed || is_leap('42.3+')) {
         wait_screen_change { send_key 'tab' };
         send_key 'ret';
-        assert_screen 'tryton-login_password';
+        assert_screen "$gnuhealth-login_password";
     }
     else {
-        send_key_until_needlematch 'tryton-login_password', 'tab';
+        send_key_until_needlematch "gnuhealth-login_password", 'tab';
     }
     type_string "susetesting\n";
-    assert_screen 'tryton-module_configuration_wizard_start';
+    assert_screen "$gnuhealth-module_configuration_wizard_start";
     send_key 'ret';
-    assert_screen 'tryton-module_configuration_wizard-add_users-welcome';
+    assert_screen "$gnuhealth-module_configuration_wizard-add_users-welcome";
     send_key 'ret';
-    assert_screen 'tryton-module_configuration_wizard-add_users_dialog';
+    assert_screen "$gnuhealth-module_configuration_wizard-add_users_dialog";
     # let's not add a user for now
     send_key 'alt-e';
-    assert_screen 'tryton-module_configuration_wizard-next_step';
+    assert_screen "$gnuhealth-module_configuration_wizard-next_step";
     send_key 'alt-n';
-    assert_screen 'tryton-module_configuration_wizard-configuration_done';
+    assert_screen "$gnuhealth-module_configuration_wizard-configuration_done";
     send_key 'alt-o';
-    assert_screen 'tryton-admin_view', 300;
+    assert_screen "$gnuhealth-admin_view", 300;
 }
 
 sub test_flags {

--- a/tests/gnuhealth/gnuhealth_client_install.pm
+++ b/tests/gnuhealth/gnuhealth_client_install.pm
@@ -1,22 +1,25 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: gnuhealth tryton client installation and startup
+# Summary: gnuhealth client installation and startup
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base 'x11test';
 use strict;
 use testapi;
+use version_utils 'is_leap';
 
 sub run {
     my ($self) = @_;
-    ensure_installed 'tryton';
+    my $gnuhealth = get_var('GNUHEALTH_CLIENT', is_leap('<15.0') ? 'tryton' : 'gnuhealth-client');
+    set_var('GNUHEALTH_CLIENT', $gnuhealth);
+    ensure_installed $gnuhealth;
 }
 
 sub test_flags {

--- a/tests/gnuhealth/gnuhealth_client_preconfigure.pm
+++ b/tests/gnuhealth/gnuhealth_client_preconfigure.pm
@@ -1,13 +1,13 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: first time administration and setup work for gnuhealth tryton
+# Summary: first time administration and setup work for gnuhealth client
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base 'x11test';
@@ -16,22 +16,23 @@ use testapi;
 use version_utils qw(is_leap is_tumbleweed);
 
 sub run {
-    x11_start_program('tryton');
-    assert_and_click 'tryton-manage_profiles';
+    my $gnuhealth = get_var('GNUHEALTH_CLIENT', 'gnuhealth-client');
+    x11_start_program($gnuhealth);
+    assert_and_click "$gnuhealth-manage_profiles";
     # wait for indexing to be done
     wait_still_screen(3);
-    assert_and_click 'tryton-manage_profiles-add';
+    assert_and_click "$gnuhealth-manage_profiles-add";
     type_string 'localhost';
-    send_key_until_needlematch 'tryton-manage_profiles-host_textfield_selected', 'tab';
+    send_key_until_needlematch "$gnuhealth-manage_profiles-host_textfield_selected", 'tab';
     type_string 'localhost';
     send_key 'tab';
     if (is_tumbleweed || is_leap('42.3+')) {
-        assert_screen 'tryton-manage_profiles-database_selected';
+        assert_screen "$gnuhealth-manage_profiles-database_selected";
         type_string 'admin';
     }
     else {
         # button 'create' should appear, weird GUI behaviour
-        assert_and_click 'tryton-manage_profiles-create_database';
+        assert_and_click "$gnuhealth-manage_profiles-create_database";
         # tryton server password
         type_string 'susetesting';
         send_key 'tab';
@@ -44,14 +45,14 @@ sub run {
         send_key 'tab';
         type_string 'susetesting';
         # wait for create button to be active
-        assert_and_click 'tryton-manage_profiles-create_database-create';
+        assert_and_click "$gnuhealth-manage_profiles-create_database-create";
 
     }
     # back to profiles menue
-    assert_screen 'tryton-manage_profiles-add', 300;
+    assert_screen "$gnuhealth-manage_profiles-add", 300;
     send_key 'ret';
     # back to login dialog
-    assert_screen 'tryton-startup';
+    assert_screen "$gnuhealth-startup";
 }
 
 sub test_flags {


### PR DESCRIPTION
In TW and Leap 15, the tryton frontend (package tryton) is replaced with
the gnuhealth-client (package gnuhealth-client). These changes replace all the
tryton tests by gnuhealth-client for oS Leap 15.0 and newer.

Verification run: http://lord.arch/tests/1142

Related progress ticket: https://progress.opensuse.org/issues/30044