### PR TITLE
NM_wpa2_enterprise: Add workaround for wrong wifi card selected (boo#1079320)

### DIFF
--- a/tests/x11/network/NM_wpa2_enterprise.pm
+++ b/tests/x11/network/NM_wpa2_enterprise.pm
@@ -38,7 +38,12 @@ sub run {
 
     # connect again to see if NM has a "connection" after we disabled v4 and v6
     $self->connect_to_network;
-    assert_screen 'network_manager-network_connected';
+    assert_screen [qw(network_manager-network_connected network_manager-wrong_card_selected)];
+    if (match_has_tag 'network_manager-wrong_card_selected') {
+        record_soft_failure 'boo#1079320';
+        assert_and_click 'network_manager-wrong_card_selected';
+        assert_screen 'network_manager-network_connected';
+    }
     assert_and_click 'network_manager-close-click';
 }
 


### PR DESCRIPTION
Verification run: http://lord.arch/tests/1036
