### PR TITLE
POO#29637 Replace script_output(foo) with other code

### DIFF
--- a/tests/qa_automation/execute_test_run.pm
+++ b/tests/qa_automation/execute_test_run.pm
@@ -34,13 +34,12 @@ sub run {
 
     #output result to serial0 and upload test log
     if (get_var("QA_TESTSUITE")) {
-        my $test_log = script_output("ls /var/log/qa/ctcs2/");
-        my $tarball  = "/tmp/$test_log.tar.bz2";
-        assert_script_run("tar cjf $tarball -C /var/log/qa/ctcs2 $test_log");
+        my $tarball = "/tmp/testlog.tar.bz2";
+        assert_script_run("tar cjf $tarball -C /var/log/qa/ctcs2 `ls /var/log/qa/ctcs2/`");
         upload_logs($tarball, timeout => 600);
 
         #convert to junit log
-        my $script_output = script_output("cat $run_log");
+        my $script_output = get_test_data($run_log);
         my $tc_result     = analyzeResult($script_output);
         my $xml_result    = generateXML($tc_result);
         script_output "echo \'$xml_result\' > /tmp/output.xml", 7200;


### PR DESCRIPTION
This is one of fix for poo#29637, it will influence userspace/kernel tests in QA:Head(start with qa_test_), and reduce test fail by unexpected words catching.

- Related ticket: https://progress.opensuse.org/issues/29637
- Verification run: http://10.67.133.102/tests/460
(Test failed, but test script runs OK, especially the code change part. Log upload successful)
