### PR TITLE
Remove missing xf86-video-modesetting package from ay profile

### DIFF
--- a/data/autoyast_sle12/bug-887126_autoinst.xml
+++ b/data/autoyast_sle12/bug-887126_autoinst.xml
@@ -499,7 +499,6 @@
       <package>xf86-input-void</package>
       <package>xf86-input-wacom</package>
       <package>xf86-video-cirrus</package>
-      <package>xf86-video-modesetting</package>
       <package>yast2-snapper</package>
       <package>yast2-trans-en_US</package>
       <package>yast2-x11</package>


### PR DESCRIPTION
As confirmed in
[bsc1092308](https://bugzilla.suse.com/show_bug.cgi?id=1092308), it's
expected that package is not available anymore.

[Verification run](http://gershwin.arch.suse.de/tests/376).

