### PR TITLE
Test postgresql on Leap only from >=15

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1076,7 +1076,7 @@ sub load_consoletests {
         loadtest "console/http_srv";
         loadtest "console/mysql_srv";
         loadtest "console/dns_srv";
-        loadtest "console/postgresql_server";
+        loadtest "console/postgresql_server" unless (is_leap('<15.0'));
         # TODO test on openSUSE https://progress.opensuse.org/issues/31972
         if (is_sle && sle_version_at_least('12-SP1')) {    # shibboleth-sp not available on SLES 12 GA
             loadtest "console/shibboleth";


### PR DESCRIPTION
Fixing https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5068

- Related ticket: https://progress.opensuse.org/issues/27014
- Verification run:
  - TW: http://10.160.66.74/tests/317 (module is scheduled -> ok)
  - Leap 15: http://10.160.66.74/tests/318 (module is scheduled -> ok)
  - Leap 42.3: http://10.160.66.74/tests/316 (module is not scheduled -> ok)
