### PR TITLE
Fix TOGGLEHOME for Leap 15.0 Updates

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -818,8 +818,10 @@ sub load_inst_tests {
         }
         # boo#1093372 Leap 15.0 proposes a separate home even on small disks
         # making the root partition likely to small so we should switch the
-        # defaults here
-        if (get_var("TOGGLEHOME") || (is_leap('15.0+') && get_var('HDDSIZEGB', 0) < 12)) {
+        # defaults here unless we reconfigure using the guided proposal or
+        # expert partitioner anyway
+        if (get_var("TOGGLEHOME") || (is_leap('15.0+') && get_var('HDDSIZEGB', 0) <= 20 && !get_var('RAIDLEVEL') && !get_var('LVM') && !get_var('FILESYSTEM')))
+        {
             loadtest "installation/partitioning_togglehome";
             if (get_var('LVM') && get_var('RESIZE_ROOT_VOLUME')) {
                 loadtest "installation/partitioning_resize_root";


### PR DESCRIPTION
The previous approach was plain wrong because the HDDSIZEGB was never smaller
than 12 GB but at least 20 GB. Tested local schedule evaluation for Leap 15.0
Update tests as well as Leap 15.0 validation tests.