### PR TITLE
kdump_and_crash: Take newest kernel instead of first

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -13,7 +13,7 @@ use Exporter;
 use strict;
 use testapi;
 use utils;
-use List::Util qw(first);
+use List::Util qw(maxstr);
 use version_utils qw(is_sle is_jeos);
 
 our @EXPORT = qw(install_kernel_debuginfo prepare_for_kdump activate_kdump kdump_is_active do_kdump);
@@ -23,7 +23,7 @@ sub install_kernel_debuginfo {
     my $kernel = is_jeos() ? 'kernel-default-base' : 'kernel-default';
     my @kernels = split(/\n/, script_output('rpmquery --queryformat="%{NAME}-%{VERSION}-%{RELEASE}\n" ' . $kernel));
     my ($uname) = script_output('uname -r') =~ /(\d+\.\d+\.\d+)-*/;
-    my $debuginfo = first { $_ =~ /\Q$uname\E/ } @kernels;
+    my $debuginfo = maxstr grep { $_ =~ /\Q$uname\E/ } @kernels;
     $debuginfo =~ s/$kernel/kernel-default-debuginfo/g;
     zypper_call("-v in $debuginfo", timeout => 4000);
 }


### PR DESCRIPTION
https://progress.opensuse.org/issues/36328

Validation run: http://tortuga.suse.de/tests/210#step/kdump_and_crash/32