### PR TITLE
Remove unnecessary match_has_tag condition

### DIFF
--- a/lib/installation_user_settings.pm
+++ b/lib/installation_user_settings.pm
@@ -27,7 +27,7 @@ sub await_password_check {
     # bsc#937012 is resolved in > SLE 12, skip if VERSION=12
     return if (is_sle('=12') && check_var('ARCH', 's390x'));
     assert_screen 'inst-userpasswdtoosimple';
-    send_key 'ret' if match_has_tag 'inst-userpasswdtoosimple';
+    send_key 'ret';
 
 }
 


### PR DESCRIPTION
match_has_tag doesn't make sense after assert_screen for single needle.
An improvement for
[PR#5082](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5082).

