### PR TITLE
Fix addon_products_sle sporadic failure

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -120,8 +120,8 @@ sub handle_addon {
     # modules like SES or RT that are not part of Packages ISO don't have this step, when bsc#1090012 will be fixed I will add else for license
     if (is_sle('15+') && $addon !~ /^ses$|^rt$/) {
         send_key 'spc';
-        send_key $cmd{next};
-        wait_still_screen 2;
+        wait_screen_change { send_key $cmd{next} };
+        assert_screen 'addon-product-installation';
     }
 }
 


### PR DESCRIPTION
A failure sometimes happens in 'addon_products_sle' since the last [change](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5047) on release notes, because wait time is lesser than before.

- Failing run: https://openqa.suse.de/tests/1693706#step/addon_products_sle/16
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/857
- Verification run: http://1b147.qa.suse.de/tests/1732