### PR TITLE
Add explicit "desktop_runner" test to cool down system load after login

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1133,6 +1133,8 @@ sub load_x11tests {
     if (kdestep_is_applicable() && get_var("WAYLAND")) {
         loadtest "x11/start_wayland_plasma5";
     }
+    # first module after login or startup to check prerequisites
+    loadtest "x11/desktop_runner";
     if (xfcestep_is_applicable()) {
         loadtest "x11/xfce4_terminal";
     }

--- a/tests/x11/desktop_runner.pm
+++ b/tests/x11/desktop_runner.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test the desktop runner which is a prerequisite for many other
+#   modules
+# Maintainer: Oliver Kurz <okurz@suse.de>
+
+use base 'x11test';
+use strict;
+use testapi;
+
+sub run {
+    # we do not want to validate the result but leave this for other modules
+    x11_start_program('true', valid => 0, no_wait => 1);
+}
+
+1;


### PR DESCRIPTION
Verification run: http://lord.arch/tests/1039#step/desktop_runner/3

Related progress issue: https://progress.opensuse.org/issues/36117