### PR TITLE
Fix 'tooglehome' scheduled by mistake on Leap 15.0 on RAID0

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -829,7 +829,8 @@ sub load_inst_tests {
         # making the root partition likely to small so we should switch the
         # defaults here unless we reconfigure using the guided proposal or
         # expert partitioner anyway
-        if (get_var("TOGGLEHOME") || (is_leap('15.0+') && get_var('HDDSIZEGB', 0) <= 20 && !get_var('RAIDLEVEL') && !get_var('LVM') && !get_var('FILESYSTEM')))
+        if (get_var("TOGGLEHOME")
+            || (is_leap('15.0+') && get_var('HDDSIZEGB', 0) <= 20 && !defined get_var('RAIDLEVEL') && !get_var('LVM') && !get_var('FILESYSTEM')))
         {
             loadtest "installation/partitioning_togglehome";
             if (get_var('LVM') && get_var('RESIZE_ROOT_VOLUME')) {


### PR DESCRIPTION
Trying to just evaluate the variable "RAIDLEVEL" in boolean context is wrong
as "RAIDLEVEL=0" evaluates to false but we want to just check if it is *any*
RAID test so using "defined" works here.

Schedule locally verified based on the following scenarios:

* Leap 15.0 Updates, standard: togglehome scheduled
* Leap 15.0 RAID0: togglehome *not* scheduled
* Leap 15.0 RAID1: togglehome *not* scheduled