### PR TITLE
Fix shutdown timeout issue on LIVECD

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -721,6 +721,10 @@ sub power_action {
         record_soft_failure('bsc#1055462');
         $shutdown_timeout *= 3;
     }
+    # The timeout is increased as shutdown takes longer on Live CD
+    if (get_var('LIVECD')) {
+        $shutdown_timeout *= 4;
+    }
     if (get_var("OFW") && check_var('DISTRI', 'opensuse') && check_var('DESKTOP', 'gnome') && get_var('PUBLISH_HDD_1')) {
         $shutdown_timeout *= 3;
         record_soft_failure("boo#1057637 shutdown_timeout increased to $shutdown_timeout (s) expecting to complete.");


### PR DESCRIPTION
The commit resolves the issue when test
fails on shutdown module, as on Live CD
it takes longer time.

- Related ticket: [poo#35215](https://progress.opensuse.org/issues/35215)
- Verification runs: All the runs (18) from http://10.160.65.138/tests/446 to http://10.160.65.138/tests/464
