### PR TITLE
Assert selected keyboard layout in textmode before typing

### DIFF
--- a/tests/installation/keyboard_selection.pm
+++ b/tests/installation/keyboard_selection.pm
@@ -25,6 +25,7 @@ sub switch_keyboard_layout {
     send_key_until_needlematch("keyboard-layout-$keyboard_layout", 'down', 60);
     if (check_var('DESKTOP', 'textmode')) {
         send_key 'ret';
+        assert_screen "keyboard-layout-$keyboard_layout-selected";
         send_key 'alt-e';    # Keyboard Test in text mode
     }
     else {


### PR DESCRIPTION
On aarch64 we see issue that we do start typing in text field, and due
to missing sync, we pressed keys before language was actually selected.

See [poo#36091](https://progress.opensuse.org/issues/36091).

- [Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/848)
- [Verification run](http://g226.suse.de/tests/1817)
