### PR TITLE
[WIP] Unlock encrypted drives on zVM

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -378,7 +378,7 @@ sub load_boot_tests {
 
 sub load_reboot_tests {
     # there is encryption passphrase prompt which is handled in installation/boot_encrypt
-    if (check_var("ARCH", "s390x") && !(get_var('ENCRYPT') && check_var('BACKEND', 'svirt'))) {
+    if (check_var("ARCH", "s390x") && !get_var('ENCRYPT')) {
         loadtest "installation/reconnect_s390";
     }
     if (uses_qa_net_hardware()) {
@@ -395,7 +395,7 @@ sub load_reboot_tests {
         if (get_var('ENCRYPT')) {
             loadtest "installation/boot_encrypt";
             # reconnect after installation/boot_encrypt
-            if (check_var('BACKEND', 'svirt') && check_var('ARCH', 's390x')) {
+            if (check_var('ARCH', 's390x')) {
                 loadtest "installation/reconnect_s390";
             }
         }

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -117,6 +117,30 @@ sub type_line_svirt {
     }
 }
 
+sub unlock_zvm_disk {
+    my ($console) = @_;
+    eval { console('x3270')->expect_3270(output_delim => 'Please enter passphrase') };
+    if ($@) {
+        diag 'No passphrase asked, continuing';
+    }
+    else {
+        $console->sequence_3270("String(\"$testapi::password\")", "ENTER");
+        diag 'Passphrase entered';
+    }
+
+}
+
+sub handle_grub_zvm {
+    my ($console) = @_;
+    eval { $console->expect_3270(output_delim => 'GNU GRUB'); };
+    if ($@) {
+        diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
+    }
+    else {
+        $console->sequence_3270("ENTER", "ENTER", "ENTER", "ENTER");
+    }
+}
+
 sub unlock_if_encrypted {
     my (%args) = @_;
     $args{check_typed_password} //= 0;
@@ -134,6 +158,13 @@ sub unlock_if_encrypted {
         }
         wait_serial("Please enter passphrase for disk.*", 100);
         type_line_svirt "$password";
+    }    # Handle zVM scenario
+    elsif (get_var('BACKEND', 's390x')) {
+        my $console = console('x3270');
+        # Enter password before GRUB if boot is encrypted
+        unlock_zvm_disk($console) if (get_var('FULL_LVM_ENCRYPT'));
+        handle_grub_zvm($console);
+        unlock_zvm_disk($console);
     }
     else {
         assert_screen("encrypted-disk-password-prompt", 200);
@@ -1177,13 +1208,8 @@ sub reconnect_s390 {
     # different behaviour for z/VM and z/KVM
     if (check_var('BACKEND', 's390x')) {
         my $console = console('x3270');
-        eval { $console->expect_3270(output_delim => 'GNU GRUB'); };
-        if ($@) {
-            diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
-        }
-        else {
-            $console->sequence_3270("ENTER", "ENTER", "ENTER", "ENTER");
-        }
+        # grub is handled in unlock_if_encrypted
+        handle_grub_zvm($console) unless get_var('ENCRYPT');
         my $r;
         eval { $r = console('x3270')->expect_3270(output_delim => $login_ready, timeout => $args{timeout}); };
         if ($@) {


### PR DESCRIPTION
As a part of [poo#35959](https://progress.opensuse.org/issues/35959) we
would like to introduce test suite where we activate existing partitions
and scenarios based on cryptlvm are perfect candidates for it.
This PR add possibility to boot with encrypted partitions on zVM.

After it's merged, scenario can be enabled on zVM, however we need to
introduce special WORKER_CLASS to chain job in the way that they are
executed on the same worker, and hence reuse same DASD devices.