### PR TITLE
Fix alt-o sent unexpected in installation_overview

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -102,12 +102,14 @@ sub break_dependency {
     }
     else {
         while (check_screen('dependency-issue', 5)) {
-            send_key 'alt-2';                                 # 2 is the option to break dependency
-            sleep 1;
-            send_key 'spc';                                   # select it
-            sleep 1;
-            send_key 'alt-o';                                 # OK
-            sleep 2;
+            # 2 is the option to break dependency
+            send_key 'alt-2';
+            # higher similarity level as this should only select a single
+            # entry, not close the dialog or something
+            wait_screen_change(sub { send_key 'spc' }, undef, similarity_level => 55);
+            # lower similarity level to not confuse the button press for
+            # screen change
+            wait_screen_change(sub { send_key 'alt-o' }, undef, similarity_level => 48);
         }
     }
 }


### PR DESCRIPTION
Use wait_screen_change to escape that assert the last 'dependency-issue' twice and sent the alt-o unexpected which cause the 'option' be selected and dependency-issue-fixed can't be assert.

- Related ticket: https://progress.opensuse.org/issues/36031
- Verification run: http://openqa-apac1.suse.de/tests/1062#step/installation_overview/20
