### PR TITLE
Correct api using

### DIFF
--- a/tests/qa_automation/execute_test_run.pm
+++ b/tests/qa_automation/execute_test_run.pm
@@ -39,7 +39,7 @@ sub run {
         upload_logs($tarball, timeout => 600);
 
         #convert to junit log
-        my $script_output = get_test_data($run_log);
+        my $script_output = script_output("cat $run_log");
         my $tc_result     = analyzeResult($script_output);
         my $xml_result    = generateXML($tc_result);
         script_output "echo \'$xml_result\' > /tmp/output.xml", 7200;


### PR DESCRIPTION
API get_test_data use wrongly in previous PR 
https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/3847e26ce6aa2a7c511d0b6140823d5c60393fe6

It return wrong value, cause all userspace tests fail. Revert this line back to script_output.

- Verification run: http://10.67.133.102/tests/463#
