### PR TITLE
Extend timeout to load installation settings overview

### DIFF
--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -73,7 +73,8 @@ sub run {
     wait_still_screen(1);
     save_screenshot;
     send_key $cmd{ok};
-    assert_screen 'installation-settings-overview-loaded';
+    # Adapting system setting needs longer time in case of installing/upgrading with multi-addons
+    assert_screen 'installation-settings-overview-loaded', 120;
 }
 
 1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/36373
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/1710000#step/disable_grub_timeout/14
