### PR TITLE
Update gnote_link_note and gnote_undo_redo to fix poo#36343

### DIFF
--- a/tests/x11/gnote/gnote_link_note.pm
+++ b/tests/x11/gnote/gnote_link_note.pm
@@ -28,12 +28,8 @@ sub run {
     send_key 'ctrl-ret';    #switch to link
     assert_screen 'gnote-note-start-here';
 
-    wait_screen_change { send_key 'ctrl-tab' };                     #jump to toolbar
-    wait_screen_change { send_key 'ctrl-tab' } if is_sle('15+');    #jump to toolbar
-    wait_screen_change {
-        for (1 .. 6) { send_key 'right' }
-    };
-    wait_screen_change { send_key 'ret' };
+    # click the menu button on the tool bar
+    assert_and_click 'gnote-new-note-menu';
     wait_screen_change { send_key 'down' };
     if (get_var('SP2ORLATER') || is_tumbleweed) {
         wait_screen_change { send_key 'ret' };

--- a/tests/x11/gnote/gnote_undo_redo.pm
+++ b/tests/x11/gnote/gnote_undo_redo.pm
@@ -19,7 +19,7 @@ use version_utils 'is_sle';
 
 
 sub undo_redo_once {
-    assert_screen 'gnote-new-note-1';
+    send_key_until_needlematch 'gnote-new-note-1', 'left';
     send_key "ctrl-z";    #undo
     assert_screen 'gnote-new-note';
     send_key "ctrl-shift-z";    #redo
@@ -37,8 +37,7 @@ sub run {
     $self->undo_redo_once;
 
     #assure undo and redo take effect after save note and re-enter note
-    send_key "ctrl-tab";    #jump to toolbar
-    send_key "ret";         #back to all notes interface
+    assert_and_click 'gnote-back2allnotes';
     send_key_until_needlematch 'gnote-new-note-matched', 'down', 6;
     wait_still_screen 3;
     send_key "ret";


### PR DESCRIPTION
Update gnote_link_note.pm and gnote_undo_redo.pm to fix poo#36343
The earlier implementation with 'send_key' may fail from time to time.
Use "assert_and_click" to make it more stable.

- Related ticket: https://progress.opensuse.org/issues/36343
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/849
- Verification run: 
SLED15 Wayland: http://10.67.19.170/tests/459#
SLED15 X11: http://10.67.19.170/tests/460#
SLED12SP3: http://10.67.19.170/tests/458#