### PR TITLE
[SLE15 GMC][URGENT] Installation: make select_first_hard_disk work correctly on SUT with more than 2 disks

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -187,21 +187,20 @@ sub addlv {
 }
 
 sub select_first_hard_disk {
-    assert_screen [qw(existing-partitions hard-disk-dev-sdb-selected)];
-    if (match_has_tag 'hard-disk-dev-sdb-selected' || get_var('SELECT_FIRST_DISK')) {
-        if (check_var('VIDEOMODE', 'text')) {
-            if (match_has_tag 'hotkey_d') {
-                send_key 'alt-d';
-            }
-            elsif (match_has_tag 'hotkey_e') {
-                send_key 'alt-e';
+    my $matched_needle = assert_screen [qw(existing-partitions hard-disk-dev-sdb-selected  hard-disk-dev-non-sda-selected)];
+    if (match_has_tag 'hard-disk-dev-non-sda-selected' || match_has_tag 'hard-disk-dev-sdb-selected' || get_var('SELECT_FIRST_DISK')) {
+        # SUT may have any number disks, only keep the first, unselect all other disks
+        foreach my $tag (@{$matched_needle->{needle}->{tags}}) {
+            if (check_var('VIDEOMODE', 'text')) {
+                if ($tag =~ /hotkey_([a-z])/) {
+                    send_key 'alt-' . $1;    # Unselect non-first drive
+                }
             }
             else {
-                die 'Needle needs tag \'hotkey_d\' or \'hotkey_e\'';
+                if ($tag =~ /hard-disk-dev-sd[a-z]-selected/) {
+                    assert_and_click $tag;    # Unselect non-first drive
+                }
             }
-        }
-        else {
-            assert_and_click 'hard-disk-dev-sdb-selected';    # Unselect second drive
         }
         assert_screen 'select-hard-disks-one-selected';
         send_key $cmd{next};


### PR DESCRIPTION
Virtualization job group purchased two new ipmi machines which have over 2 physical disks each. However host installation failed at partition_firstdisk because current code only handles 2 disks properly, see https://openqa.suse.de/tests/1710004#step/partitioning_firstdisk/4. So code is changed to support SUT with more than 1 disks, no matter it is 2 or more. 

- Needles: 
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/850

- Verification run: 
Note: the verification job is not waited until final success, only verifies that partition_firstdisk passed.
partitioning_firstdisk pass on SUT with 4 disks
http://10.67.18.220/tests/9#step/partitioning_firstdisk/3
partitioning_firstdisk pass on SUT with 2 disks
http://10.67.18.220/tests/14#step/partitioning_firstdisk/5
