### PR TITLE
Add & remove cluster nodes

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -535,7 +535,7 @@ sub specific_caasp_params {
         # Wait until admin node genarates autoyast profile
         pause_until 'VELUM_CONFIGURED' if get_var('AUTOYAST');
         # Wait until first round of nodes are processed
-        pause_until 'NODES_ACCEPTED' if get_var('DELAYED_WORKER');
+        pause_until 'NODES_ACCEPTED' if get_var('DELAYED');
     }
 }
 

--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -22,7 +22,7 @@ use utils qw(power_action assert_shutdown_and_restore_system);
 our @EXPORT = qw(
   trup_call trup_install rpmver process_reboot check_reboot_changes microos_login
   handle_simple_pw export_cluster_logs script_retry
-  get_delayed_worker update_scheduled
+  get_delayed update_scheduled
   pause_until unpause);
 
 # Return names and version of packages for transactional-update tests
@@ -53,14 +53,19 @@ sub rpmver {
 
 # Export logs from cluster admin/workers
 sub export_cluster_logs {
-    script_run "journalctl > journal.log", 60;
-    upload_logs "journal.log";
+    if (is_caasp 'local') {
+        record_info 'Logs skipped', 'Log export skipped because of LOCAL DEVENV';
+    }
+    else {
+        script_run "journalctl > journal.log", 60;
+        upload_logs "journal.log";
 
-    script_run 'supportconfig -b -B supportconfig', 500;
-    upload_logs '/var/log/nts_supportconfig.tbz';
+        script_run 'supportconfig -b -B supportconfig', 500;
+        upload_logs '/var/log/nts_supportconfig.tbz';
 
-    upload_logs('/var/log/transactional-update.log', failok => 1);
-    upload_logs('/var/log/YaST2/y2log-1.gz') if get_var 'AUTOYAST';
+        upload_logs('/var/log/transactional-update.log', failok => 1);
+        upload_logs('/var/log/YaST2/y2log-1.gz') if get_var 'AUTOYAST';
+    }
 }
 
 # Weak password warning should be displayed only once - bsc#1025835
@@ -192,12 +197,23 @@ sub get_admin_job {
     }
 }
 
-sub get_delayed_worker {
-    my @cluster_jobs = get_cluster_jobs;
-    for my $job_id (@cluster_jobs) {
-        return $job_id if get_job_info($job_id)->{settings}->{DELAYED_WORKER};
+# Return job id of delayed node when role filter is set
+# Return number of delayed jobs without filter
+# get_delayed [master|worker]
+sub get_delayed {
+    my $role = shift;
+
+    my ($drole, $count);
+    my @jobs = get_cluster_jobs;
+    for my $job_id (@jobs) {
+        if ($drole = get_job_info($job_id)->{settings}->{DELAYED}) {
+            if ($role) {
+                return $job_id if $role eq $drole;
+            }
+            $count++;
+        }
     }
-    return 0;
+    return $count;
 }
 
 sub update_scheduled {
@@ -238,14 +254,12 @@ sub script_retry {
 
 # All events ordered by execution
 my %events = (
-    support_server_ready     => 'Wait for dhcp, dns, ntp, ..',
-    VELUM_STARTED            => 'Wait until velum starts to login there from controller',
-    VELUM_CONFIGURED         => 'Velum has to be configured before autoyast installations start',
-    NODES_ACCEPTED           => 'Wait until salt-keys are accepted to set password on autoyast nodes',
-    REBOOT_FINISHED          => 'Re-login when system rebooted after update/reboot test',
-    DELAYED_WORKER_INSTALLED => 'Wait until we have new node that we can add to existing cluster',
-    DELAYED_NODES_ACCEPTED   => 'Wait until salt-keys are accepted to set password on autoyast nodes',
-    CNTRL_FINISHED           => 'Wait on CaaSP nodes until controller finishes testing',
+    support_server_ready => 'Wait for dhcp, dns, ntp, ..',
+    VELUM_STARTED        => 'Wait until velum starts to login there from controller',
+    VELUM_CONFIGURED     => 'Velum has to be configured before autoyast installations start',
+    NODES_ACCEPTED       => 'Wait until salt-keys are accepted to start booting delayed nodes',
+    AUTOYAST_PW_SET      => 'Wait on autoyast nodes until passord is set from admin with salt',
+    CNTRL_FINISHED       => 'Wait on CaaSP nodes until controller finishes testing',
 );
 
 # CaaSP specific unpausing
@@ -255,6 +269,8 @@ sub unpause {
     # Handle cluster failure on controller node
     if (uc($event) eq 'ALL') {
         foreach my $e (keys %events) {
+            # We need passwords mostly on failure
+            next if $e eq 'AUTOYAST_PW_SET';
             lockapi::mutex_create $e;
         }
     }
@@ -272,8 +288,8 @@ sub pause_until {
 
     # Mutexes created by child jobs (not controller)
     my $owner;
-    $owner = get_admin_job      if $event eq 'VELUM_STARTED';
-    $owner = get_delayed_worker if $event eq 'DELAYED_WORKER_INSTALLED';
+    $owner = get_admin_job if $event eq 'VELUM_STARTED';
+    $owner = get_admin_job if $event eq 'AUTOYAST_PW_SET';
 
     lockapi::mutex_wait($event, $owner, $events{$event});
 }

--- a/lib/caasp_controller.pm
+++ b/lib/caasp_controller.pm
@@ -8,22 +8,24 @@ use lockapi 'barrier_destroy';
 use mmapi 'wait_for_children';
 
 use Exporter 'import';
-our @EXPORT = qw($admin_fqdn
+our @EXPORT = qw($admin_fqdn $master_fqdn
   confirm_insecure_https velum_login switch_to download_kubeconfig click_click xy);
 
 our $admin_fqdn = 'admin.openqa.test';
+# Extra space to check for bsc#1087447
+our $master_fqdn = 'master-api.openqa.test ';
 
 # 10% of clicks are lost because ajax refreshes Velum during click
+# bsc#1048975 - User interaction is lost after page refresh
 sub click_click {
     my ($x, $y) = @_;
     mouse_set $x, $y;
-    for (1 .. 3) {
+    for (1 .. 2) {
         mouse_click;
         # Don't click-and-drag
         sleep 1;
     }
     mouse_hide;
-    record_info 'bsc#1048975', 'User interaction is lost after page refresh';
 }
 
 # Get xy coordinates for:
@@ -87,7 +89,8 @@ sub post_fail_hook {
     sleep if check_var('DEBUG_SLEEP', 'controller');
 
     # Destroy barriers and create mutexes to avoid deadlock
-    barrier_destroy 'WORKERS_INSTALLED';
+    barrier_destroy 'NODES_ONLINE';
+    barrier_destroy 'DELAYED_NODES_ONLINE';
     unpause 'ALL';
 
     # Wait for log export from all nodes

--- a/lib/caasp_controller.pm
+++ b/lib/caasp_controller.pm
@@ -6,6 +6,7 @@ use testapi;
 use caasp 'unpause';
 use lockapi 'barrier_destroy';
 use mmapi 'wait_for_children';
+use version_utils 'is_caasp';
 
 use Exporter 'import';
 our @EXPORT = qw($admin_fqdn $master_fqdn
@@ -14,6 +15,8 @@ our @EXPORT = qw($admin_fqdn $master_fqdn
 our $admin_fqdn = 'admin.openqa.test';
 # Extra space to check for bsc#1087447
 our $master_fqdn = 'master-api.openqa.test ';
+# CaaSP 2.0 will keep the bug
+chop $master_fqdn if is_caasp('=2.0');
 
 # 10% of clicks are lost because ajax refreshes Velum during click
 # bsc#1048975 - User interaction is lost after page refresh

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -128,7 +128,7 @@ sub is_caasp {
     elsif ($filter eq 'VMX') {
         return get_var('FLAVOR') !~ /DVD/;    # If not DVD it's VMX
     }
-    elsif ($filter =~ /^\d\.\d\+?$/) {
+    elsif ($filter =~ /\d\.\d\+?$/) {
         # If we use '+' it means "this or newer", which includes tumbleweed
         return ($filter =~ /\+$/) if check_var('VERSION', 'Tumbleweed');
         return check_version($filter, qr/\d\.\d/);

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -12,7 +12,7 @@ BEGIN {
 use utils;
 use version_utils 'is_caasp';
 use main_common;
-use caasp qw(update_scheduled get_delayed_worker);
+use caasp qw(update_scheduled get_delayed);
 
 init_main();
 
@@ -157,7 +157,7 @@ sub load_stack_tests {
         else {
             loadtest 'caasp/stack_reboot';
         }
-        loadtest 'caasp/stack_add_remove' if get_delayed_worker;
+        loadtest 'caasp/stack_add_remove' if get_delayed;
         unless (is_caasp('staging') || is_caasp('local')) {
             loadtest 'caasp/stack_conformance';
         }
@@ -171,12 +171,12 @@ sub load_stack_tests {
 
 # Init cluster variables
 sub stack_init {
-    my $children       = get_children;
-    my $delayed_worker = get_delayed_worker;
+    my $children      = get_children;
+    my $stack_delayed = get_delayed;
 
-    my $stack_size    = (keys %$children) - !!$delayed_worker;
-    my $stack_masters = $stack_size > 6 ? 3 : 1;                 # For 6+ node clusters select 3 masters
-    my $stack_workers = $stack_size - $stack_masters - 1;        # Do not count admin node into workers
+    my $stack_size    = (keys %$children) - $stack_delayed;
+    my $stack_masters = $stack_size > 5 ? 3 : 1;              # For 5+ node clusters select 3 masters
+    my $stack_workers = $stack_size - $stack_masters - 1;     # Do not count admin node into workers
 
     # Die more explicitly if you restart controller job (because stack_size = 0)
     die "Stack test can be re-run by restarting admin job" unless $stack_size;
@@ -186,8 +186,10 @@ sub stack_init {
     set_var 'STACK_NODES',   $stack_size - 1;
     set_var 'STACK_MASTERS', $stack_masters;
     set_var 'STACK_WORKERS', $stack_workers;
+    set_var 'STACK_DELAYED', $stack_delayed;
 
-    barrier_create("WORKERS_INSTALLED", $stack_size);
+    barrier_create("NODES_ONLINE",         $stack_size);
+    barrier_create("DELAYED_NODES_ONLINE", $stack_delayed + 1);
 }
 
 if (get_var('STACK_ROLE')) {

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -29,6 +29,8 @@ sub cleanup_needles {
     unregister_needle_tags('ENV-FLAVOR-JeOS-for-kvm');
     unregister_needle_tags('ENV-ARCH-s390x');
     unregister_needle_tags('ENV-OFW-1');
+
+    unregister_needle_tags('CAASP-VERSION-2.0') if is_caasp('3.0+');
 }
 $needle::cleanuphandler = \&cleanup_needles;
 

--- a/tests/caasp/stack_add_remove.pm
+++ b/tests/caasp/stack_add_remove.pm
@@ -101,7 +101,6 @@ sub run {
     if (check_var 'STACK_MASTERS', 3) {
         remove_node 'master-rm', unsupported => 1;
         check_kubernetes($n - 1);
-        # record_soft_failure 'bsc#1093123 - Master node removal fails';
 
         if (get_delayed 'master') {
             add_node 'master-add';

--- a/tests/caasp/stack_add_remove.pm
+++ b/tests/caasp/stack_add_remove.pm
@@ -11,59 +11,103 @@
 # Maintainer: Martin Kravec <mkravec@suse.com>
 use parent 'caasp_controller';
 use caasp_controller;
-use caasp qw(pause_until unpause);
+use caasp qw(pause_until get_delayed);
+use lockapi 'barrier_wait';
 
 use strict;
 use testapi;
 
-sub add_nodes {
+
+sub accept_delayed_nodes {
     # Accept pending nodes
-    send_key_until_needlematch 'velum-bootstrap-accept-nodes', 'pgdn', 2, 3;
+    send_key 'end';
     assert_and_click 'velum-bootstrap-accept-nodes';
-    save_screenshot;
-    send_key 'home';
+    wait_still_screen;
 
     # Nodes are moved from pending to new
-    assert_and_click "velum-1-nodes-accepted", 'left', 90;
-    unpause 'DELAYED_NODES_ACCEPTED';
+    send_key 'home';
+    my $n = get_var 'STACK_DELAYED';
+    assert_screen "velum-$n-nodes-accepted", 90;
+}
 
-    # Bootstrap new node
-    wait_still_screen 3;
-    assert_and_click 'unassigned-select-all';
+# Select node and role based on needle match
+sub add_node {
+    my $node = shift;
+    record_info 'Add node', $node;
+
+    click_click xy('velum-new-nodes');
+    click_click xy("$node-setrole-xy");
     assert_and_click 'unassigned-add-nodes';
     assert_screen 'velum-bootstrap-done';
     send_key 'end';
-    assert_screen 'velum-adding-nodes-done', 900;
+
+    # Wait until node is added or error
+    assert_screen ['velum-adding-nodes-done', 'velum-status-error'], 900;
+    die 'Adding node failed' if match_has_tag('velum-status-error');
 }
 
-sub remove_nodes {
-    mouse_set xy('delayed-remove-xy');
-    mouse_click;
+# Remove node based on needle match
+sub remove_node {
+    my $node = shift;
+    my %args = @_;
+
+    record_info 'Remove node', $node;
+    click_click xy("$node-remove-xy");
     assert_and_click 'confirm-removal';
-    sleep 7;
-    assert_screen 'velum-adding-nodes-done', 900;
+    if ($args{unsupported}) {
+        wait_still_screen 3;
+        assert_and_click 'confirm-unsupported';
+    }
+
+    # Wait until node is removed or error
+    my $timer = time + 900;
+    assert_screen "$node-pending";
+    while (check_screen "$node-pending", 5) {
+        sleep 25;
+        die 'Node removal timeout' if $timer - time < 0;
+        die 'Node removal failed' if check_screen('velum-status-error', 0);
+    }
     send_key 'home';
 }
 
+# Has also function of wait_still_screen
 sub check_kubernetes {
     my $nodes_count = shift;
+
     switch_to 'xterm';
-    assert_script_run "kubectl cluster-info";
-    assert_script_run "kubectl get nodes --no-headers | tee /dev/tty | wc -l | grep $nodes_count";
+    # Replace with assert_script_run when bug is fixed
+    my $count_failed = script_run "kubectl get nodes --no-headers | tee /dev/tty | wc -l | grep $nodes_count";
+    if ($count_failed) {
+        record_soft_failure 'bsc#1094078 - Node removal eats unassigned node';
+    }
     switch_to 'velum';
 }
 
 sub run {
-    pause_until 'DELAYED_WORKER_INSTALLED';
+    switch_to 'velum';
+    barrier_wait {name => 'DELAYED_NODES_ONLINE', check_dead_job => 1};
 
-    record_info 'Add node';
-    add_nodes;
-    check_kubernetes(get_required_var('STACK_NODES') + 1);
+    accept_delayed_nodes;
+    my $n = get_required_var('STACK_NODES');
 
-    record_info 'Remove node';
-    remove_nodes;
-    check_kubernetes(get_required_var('STACK_NODES'));
+    if (get_delayed 'worker') {
+        add_node 'worker-addrm';
+        check_kubernetes($n + 1);
+
+        remove_node 'worker-addrm';
+        check_kubernetes($n);
+    }
+
+    if (check_var 'STACK_MASTERS', 3) {
+        remove_node 'master-rm', unsupported => 1;
+        check_kubernetes($n - 1);
+        # record_soft_failure 'bsc#1093123 - Master node removal fails';
+
+        if (get_delayed 'master') {
+            add_node 'master-add';
+            check_kubernetes($n);
+        }
+    }
 }
 
 1;
-

--- a/tests/caasp/stack_admin.pm
+++ b/tests/caasp/stack_admin.pm
@@ -16,26 +16,15 @@ use testapi;
 use caasp;
 use version_utils 'is_caasp';
 
-# Set default password on worker nodes - bsc#1030876
+# Set password on autoyast nodes - bsc#1030876
 sub set_autoyast_password {
     script_run 'id=$(docker ps | grep salt-master | awk \'{print $1}\')';
     script_run 'pw=$(python -c "import crypt; print crypt.crypt(\'nots3cr3t\', \'\$6\$susetest\')")';
-    script_run 'docker exec $id salt -E ".{32}" shadow.set_password root "$pw"';
-}
+    script_run 'docker exec $id salt -E ".{32}" shadow.set_password root "$pw"', 60;
 
-# Handle update process
-sub handle_update_reboot {
-    # Download update script
-    assert_script_run 'curl -O ' . data_url("caasp/update.sh");
-    assert_script_run 'chmod +x update.sh';
-
-    pause_until 'REBOOT_FINISHED';
-
-    # Admin node was rebooted only if update passed
-    if (check_screen 'linux-login-casp', 0) {
-        reset_consoles;
-        select_console 'root-console';
-    }
+    # Unlock and wait for propagation
+    unpause 'AUTOYAST_PW_SET';
+    sleep 60;
 }
 
 sub run() {
@@ -43,21 +32,20 @@ sub run() {
     script_retry 'curl -kLI localhost | grep _velum_session', retry => 15, delay => 15;
     unpause 'VELUM_STARTED';
 
-    # Set password for autoyast cluster nodes
-    if (is_caasp 'DVD') {
-        pause_until 'NODES_ACCEPTED';
-        set_autoyast_password;
-    }
+    # Download update script
+    assert_script_run 'curl -O ' . data_url("caasp/update.sh");
+    assert_script_run 'chmod +x update.sh';
 
-    handle_update_reboot;
-
-    # Set password for autoyast cluster nodes
-    if (is_caasp('DVD') && get_delayed_worker) {
-        pause_until 'DELAYED_NODES_ACCEPTED';
-        set_autoyast_password;
-    }
-
+    # Wait during tests from controller
     pause_until 'CNTRL_FINISHED';
+
+    # Login if node was rebooted (update|reboot modules)
+    if (check_screen 'linux-login-casp', 0) {
+        reset_consoles;
+        select_console 'root-console';
+    }
+
+    set_autoyast_password if is_caasp 'DVD';
     export_cluster_logs;
 }
 

--- a/tests/caasp/stack_admin.pm
+++ b/tests/caasp/stack_admin.pm
@@ -24,7 +24,7 @@ sub set_autoyast_password {
 
     # Unlock and wait for propagation
     unpause 'AUTOYAST_PW_SET';
-    sleep 60;
+    sleep 30 if is_caasp('local');
 }
 
 sub run() {

--- a/tests/caasp/stack_bootstrap.pm
+++ b/tests/caasp/stack_bootstrap.pm
@@ -35,12 +35,19 @@ sub select_roles {
     # Wait until warning messages disappears
     wait_still_screen 2;
 
-    # Select master.openqa.test
-    send_key_until_needlematch "master-checkbox-xy", 'pgdn', 2, 5;
-    click_click xy('master-checkbox-xy');
-    # For 6+ node clusters select 2 more random masters
-    for (2 .. get_var('STACK_MASTERS')) {
-        click_click xy('master-role-button');
+    # Select Kubernetes API FQDN
+    send_key_until_needlematch "master-api-setrole-xy", 'pgdn', 2, 5;
+    click_click xy('master-api-setrole-xy');
+
+    # For bigger clusters select 2 more masters
+    if (check_var('STACK_MASTERS', 3)) {
+        send_key 'home';
+        send_key_until_needlematch "master-rm-setrole-xy", 'pgdn', 2, 5;
+        click_click xy('master-rm-setrole-xy');
+
+        send_key 'home';
+        send_key_until_needlematch "master-ay-setrole-xy", 'pgdn', 2, 5;
+        click_click xy('master-ay-setrole-xy');
     }
 }
 
@@ -58,7 +65,7 @@ sub bootstrap {
 
     # External Kubernetes API & Dashboard FQDN
     for (1 .. 3) { send_key 'tab'; }
-    type_string 'master.openqa.test';
+    type_string $master_fqdn;
     send_key 'tab';
     type_string $admin_fqdn;
     assert_and_click "velum-bootstrap";
@@ -80,7 +87,7 @@ sub run {
         record_soft_failure('bsc#1080969 - 504 Gateway timed out');
         send_key_until_needlematch 'velum-bootstrap-page', 'f5', 30, 60;
     }
-    barrier_wait {name => "WORKERS_INSTALLED", check_dead_job => 1};
+    barrier_wait {name => "NODES_ONLINE", check_dead_job => 1};
 
     accept_nodes;
     select_roles;

--- a/tests/caasp/stack_kubernetes.pm
+++ b/tests/caasp/stack_kubernetes.pm
@@ -48,7 +48,7 @@ sub run {
 
     # Check deployed application in firefox
     type_string "NODEPORT=`kubectl get svc | egrep -o '80:3[0-9]{4}' | cut -d: -f2`\n";
-    type_string "firefox node1.openqa.test:\$NODEPORT\n";
+    type_string "firefox mixed.openqa.test:\$NODEPORT\n";
     assert_screen 'nginx-alpine';
     send_key 'ctrl-w';
 }

--- a/tests/caasp/stack_reboot.pm
+++ b/tests/caasp/stack_reboot.pm
@@ -15,7 +15,7 @@ use caasp_controller;
 
 use strict;
 use testapi;
-use caasp qw(script_retry unpause);
+use caasp 'script_retry';
 
 sub run {
     switch_to 'xterm';
@@ -39,7 +39,6 @@ sub run {
     assert_script_run "kubectl get nodes --no-headers | wc -l | grep $nodes_count";
 
     switch_to 'velum';
-    unpause 'REBOOT_FINISHED';
 }
 
 1;

--- a/tests/caasp/stack_update.pm
+++ b/tests/caasp/stack_update.pm
@@ -18,7 +18,7 @@ use caasp_controller;
 
 use strict;
 use testapi;
-use caasp qw(update_scheduled unpause script_retry);
+use caasp qw(update_scheduled script_retry);
 use version_utils 'is_caasp';
 
 # Set up ssh to admin node and run update script on all nodes
@@ -123,7 +123,6 @@ sub run {
     record_info 'Reboot', 'Orchestrate the reboot via Velum';
     orchestrate_velum_reboot;
     check_update_changes;
-    unpause 'REBOOT_FINISHED';
 }
 
 1;


### PR DESCRIPTION
WIP: merge after GM release

To deploy this PR this needs to be changed
 - masters: add `master-RM` and `master-ay`, rename `master` to `master-API`
 - workers: rename `node1` to `miXed` and `delayed` to `worker-addrm`
 - hostnames based on http://dhcp165.suse.cz/tests/5302#step/stack_add_remove/16
 - set DELAYED=master|worker variables on `*add*` nodes, remove DELAYED_WORKER
 - upload new cloud-configs with VMX setup changes

Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/863

Local runs
 - http://dhcp165.suse.cz/tests/5760#step/stack_add_remove/80 - VMX 3 masters
 - http://dhcp165.suse.cz/tests/5778#step/stack_add_remove/78 - DVD 3 masters
 - http://dhcp165.suse.cz/tests/5492 - DVD 1 master
 - http://skyrim.qam.suse.de/tests/3314 - QAM

Add and remove cluster nodes
 - node identification with xy needles
 - worker node add & remove
 - master node replacement (remove & add)
 - explicitly select master nodes during bootstrap
 - change get_delayed_workers sub into get_delayed
 - improve log export logic on cluster workers

Mutex cleanup
 - replace DELAYED_NODES_ACCEPTED with AUTOYAST_PW_SET
 - replace WORKERS_INSTALLED with NODES_ONLINE
 - remove REBOOT_FINISHED
 - move DELAYED_WORKER_INSTALLED into barrier

General cleanup
 - rename nodes to match cluster roles (worker/master/node)
 - rename of xy needle tags to match hostname
 - don't export logs in local dev envs