### PR TITLE
Delete unselect_xen_pv_cdrom()

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,8 +17,7 @@ use testapi;
 use version_utils 'is_storage_ng';
 use installation_user_settings 'await_password_check';
 
-our @EXPORT
-  = qw(addpart addlv create_new_partition_table enable_encryption_guided_setup select_first_hard_disk take_first_disk unselect_xen_pv_cdrom %partition_roles);
+our @EXPORT = qw(addpart addlv create_new_partition_table enable_encryption_guided_setup select_first_hard_disk take_first_disk %partition_roles);
 
 our %partition_roles = qw(
   OS alt-o
@@ -204,22 +203,6 @@ sub select_first_hard_disk {
             assert_and_click 'hard-disk-dev-sdb-selected';    # Unselect second drive
         }
         assert_screen 'select-hard-disks-one-selected';
-        send_key $cmd{next};
-    }
-}
-
-# On Xen PV "CDROM" is of the same type as a disk block device so YaST
-# naturally sees it as a "disk". We have to uncheck the "CDROM".
-sub unselect_xen_pv_cdrom {
-    if (check_var('VIRSH_VMM_TYPE', 'linux')) {
-        assert_screen 'select-hard-disk';
-        if (check_var('VIDEOMODE', 'text')) {
-            send_key_until_needlematch 'uncheck-install-medium', 'tab';
-            send_key 'spc';
-        }
-        else {
-            assert_and_click 'uncheck-install-medium';
-        }
         send_key $cmd{next};
     }
 }

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017 SUSE LLC
+# Copyright © 2017-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tests/installation/partitioning_filesystem.pm
+++ b/tests/installation/partitioning_filesystem.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -14,13 +14,10 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use version_utils 'is_storage_ng';
-use partition_setup qw(select_first_hard_disk unselect_xen_pv_cdrom);
+use version_utils qw(is_storage_ng is_sle);
+use partition_setup 'select_first_hard_disk';
 
 sub run {
-
-    my $fs = get_var('FILESYSTEM');
-
     # open the partinioner
     assert_screen 'edit-proposal-settings';
     wait_screen_change { send_key $cmd{guidedsetup} };
@@ -39,7 +36,6 @@ sub run {
         }
     }
     if (is_storage_ng) {
-        unselect_xen_pv_cdrom;
         assert_screen [qw(partition-scheme existing-partitions)];
         if (match_has_tag 'existing-partitions') {
             send_key $cmd{next};
@@ -52,6 +48,7 @@ sub run {
     send_key 'alt-f';
     assert_screen 'filesystem-root-menu-selected';
 
+    my $fs = get_var('FILESYSTEM');
     # select filesystem
     send_key 'home';
     send_key_until_needlematch("filesystem-$fs", 'down', 20, 3);

--- a/tests/installation/partitioning_togglehome.pm
+++ b/tests/installation/partitioning_togglehome.pm
@@ -15,14 +15,12 @@ use strict;
 use base "y2logsstep";
 use testapi;
 use installation_user_settings;
-use version_utils qw(is_storage_ng is_leap);
-use partition_setup 'unselect_xen_pv_cdrom';
+use version_utils qw(is_storage_ng is_leap is_sle);
 
 sub run {
     record_soft_failure 'boo#1093372' if (!get_var('TOGGLEHOME') && is_leap('15.1+'));
     wait_screen_change { send_key($cmd{guidedsetup}) };    # open proposal settings
     if (is_storage_ng) {
-        unselect_xen_pv_cdrom;
         assert_screen 'partition-scheme';
         send_key $cmd{next};
         installation_user_settings::await_password_check if get_var('ENCRYPT');


### PR DESCRIPTION
Fix for bsc#1089274 has a side-effect of removing the weird YaST screen
on Xen PV where we had to unselect `/dev/xvda` CDROM device first to
proceed to the actuall Guided Setup.

Removing the whole `xen_pv_fix_disk_selection_screen()` is it was used
on SLES15.

Fails here (build 634.2):
* create_hdd_textmode: https://openqa.suse.de/tests/1706295
* ext4: https://openqa.suse.de/tests/1706099
* xfs: https://openqa.suse.de/tests/1706066

Validation runs:
* ext4: http://nilgiri.suse.cz/tests/729
* xfs: http://nilgiri.suse.cz/tests/730
* create_hdd_textmode: http://nilgiri.suse.cz/tests/731
* SLES12 ext4: http://nilgiri.suse.cz/tests/732