### PR TITLE
Fix s390x-kvm instances relying on ping for connection check

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -347,18 +347,13 @@ sub wait_boot {
             select_console('iucvconn');
         }
         else {
-            my $worker_hostname = get_required_var('WORKER_HOSTNAME');
             workaround_type_encrypted_passphrase if get_var('S390_ZKVM');
             wait_serial('GNU GRUB') || diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
             select_console('svirt');
             save_svirt_pty;
             type_line_svirt '', expect => $login_ready, timeout => $ready_time + 100, fail_message => 'Could not find login prompt';
             $self->rewrite_static_svirt_network_configuration();
-            # check up to five times if the SUT it able to ping the worker before trying to connect a console
-            type_line_svirt "'for i in {1..5}; do ping -W 1 -c 1 $worker_hostname && break; sleep 5; done'",
-              expect       => '0% packet loss',
-              timeout      => 60,
-              fail_message => 'SUT was not able to ping hypervisor, network down?';
+            type_line_svirt "systemctl is-active sshd", expect => 'active';
         }
 
         # on z/(K)VM we need to re-select a console

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -295,6 +295,9 @@ sub rewrite_static_svirt_network_configuration {
     type_line_svirt "\"cat /etc/sysconfig/network/ifcfg-\*\"", expect => '#';
     type_line_svirt "systemctl restart network",               expect => '#';
     type_line_svirt "systemctl is-active network",             expect => 'active';
+    type_line_svirt 'systemctl is-active sshd',                expect => 'active';
+    # make sure we can reach the SSH server in the SUT
+    type_string "for i in {1..7}; do (nc -z $virsh_guest 22 && break) || (echo \"retry: \$i\" ; sleep 5; false); done\n";
 }
 
 =head2 wait_boot
@@ -353,7 +356,7 @@ sub wait_boot {
             save_svirt_pty;
             type_line_svirt '', expect => $login_ready, timeout => $ready_time + 100, fail_message => 'Could not find login prompt';
             $self->rewrite_static_svirt_network_configuration();
-            type_line_svirt "systemctl is-active sshd", expect => 'active';
+
         }
 
         # on z/(K)VM we need to re-select a console


### PR DESCRIPTION
Probe the ssh port from the worker side, not ping from SUT, in case ping is
not installed in the SUT.

Executed a local test run of a standard scenario with 0/800 fails but also I
could not reproduce initial connection problems in 800 runs, maybe because
there were no concurrent runs.