### PR TITLE
Fix openSUSE QAM tests blocked by packagekit in zypper_add_repos

### DIFF
--- a/tests/console/zypper_add_repos.pm
+++ b/tests/console/zypper_add_repos.pm
@@ -14,19 +14,21 @@
 use base "consoletest";
 use strict;
 use testapi;
+use utils qw(pkcon_quit zypper_call);
 
 sub run {
     my $val = get_var("ZYPPER_ADD_REPOS");
     return unless $val;
 
     select_console 'root-console';
+    pkcon_quit;
     my $prefix = get_var("ZYPPER_ADD_REPO_PREFIX", 'openqa');
 
     my $i = 0;
     # do not check gpg if the repo is untrusted
     my $untrusted = $prefix eq 'untrusted' ? '-G' : '';
     for my $url (split(/,/, $val)) {
-        assert_script_run("zypper -n ar $untrusted -c -f $url $prefix$i");
+        zypper_call("ar $untrusted -c -f $url $prefix$i");
         ++$i;
     }
 }


### PR DESCRIPTION
As "zypper_add_repos" is scheduled before consoletest_setup which is the
"proper" setup step we have to ensure that packagekit is stopped before trying
to use low level zypper calls.

This fixes a problem when the many zypper calls we need to add maintenance
incident repos are blocked by packagekit running in the background.

Verification run: http://lord.arch/tests/1042

Related progress issue: https://progress.opensuse.org/issues/36390