### PR TITLE
Fix s390x-kvm instances relying on ping without needing Net::Telnet for now

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,3 @@
-requires 'Net::Telnet';
 requires 'File::Basename';
 requires 'Data::Dumper';
 requires 'XML::LibXML';


### PR DESCRIPTION
Probe the ssh port from the worker side, not ping from SUT, in case ping is
not installed in the SUT.

Executed a local test run of a standard scenario with 0/800 fails but also I
could not reproduce initial connection problems in 800 runs, maybe because
there were no concurrent runs.

The perl package "Net::Telnet" is not provided on our workers by default even
though the dependency was mentioned in cpanfile. However, Net::Telnet was not
used anymore in our tests since 866b07ae9 where in before it was only used to
a very limited extent in a hyperv specific module.