### PR TITLE
Align s390x special boot handling to other architectures

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1196,13 +1196,9 @@ sub reconnect_s390 {
         select_console('iucvconn');
     }
     else {
-        my $r = wait_serial($login_ready, 300);
-        if ($r && $r =~ qr/Welcome to SUSE Linux Enterprise 15/) {
-            record_soft_failure('bsc#1040606');
-        }
-        elsif ($r && is_sle) {
-            $r =~ qr/Welcome to SUSE Linux Enterprise Server/ || die "Correct welcome string not found";
-        }
+        wait_serial('GNU GRUB') || diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
+        select_console('svirt');
+        type_line_svirt '', expect => $login_ready, timeout => $args{timeout}, fail_message => 'Could not find login prompt';
     }
 
     # SLE >= 15 does not offer auto-started VNC server in SUT, only login prompt as in textmode

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -21,15 +21,6 @@ use version_utils qw(is_sle is_leap);
 sub run {
     my ($self) = shift;
 
-    if (check_var('ARCH', 's390x')) {
-        # on s390x we do not wait for the grub menu or can not handle it like
-        # do we on other architectures or backends. Also, we do not have the
-        # same problem that we could miss the grub screen with timeout so we
-        # skip disabling the grub timeout
-        diag 'Skipping disabling grub timeout on s390x as we can not catch the grub screen there';
-        return;
-    }
-
     # Verify Installation Settings overview is displayed as starting point
     assert_screen "installation-settings-overview-loaded";
 


### PR DESCRIPTION
The PR is made to align s390x kvm special boot handling to other architectures to have less specialization where not needed. It adjusts 'reconnect_s390' subroutine to always wait for grub menu and send 'ret'.

- Related ticket: https://progress.opensuse.org/issues/26836
- Verification run: http://10.160.65.138/tests/169
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/882