### PR TITLE
Wrap keyboard selection to avoid early next keypress

### DIFF
--- a/tests/installation/keyboard_selection.pm
+++ b/tests/installation/keyboard_selection.pm
@@ -36,7 +36,7 @@ sub switch_keyboard_layout {
     # Select back default keyboard layout
     send_key 'alt-k';
     send_key_until_needlematch("keyboard-layout", 'up', 60);
-    send_key 'ret' if (check_var('DESKTOP', 'textmode'));
+    wait_screen_change { send_key 'ret' } if (check_var('DESKTOP', 'textmode'));
 }
 
 sub run {


### PR DESCRIPTION
We have some stability issues of switch_keyboard_textmode test suite on arm.
[PR#5098](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5098) fixed initial issue, but now we have failures when switch to the next screen with license.

See [poo#36091](https://progress.opensuse.org/issues/36091).
[Verification run](http://g226.suse.de/tests/1820).
