### PR TITLE
 Sync update in drive selection

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -67,7 +67,9 @@ sub addpart {
         send_key_until_needlematch 'partition-selected-bios-boot-type', 'down';
     }
     else {
-        send_key_until_needlematch 'partition-selected-raid-type', 'down';
+        # poo#35134 Sporadic synchronization failure resulted in incorrect choice of partition type
+        # add partition screen was not refreshing fast enough
+        send_key_until_needlematch 'partition-selected-raid-type', 'down', 20, 3;
     }
     send_key(is_storage_ng() ? $cmd{next} : $cmd{finish});
 }


### PR DESCRIPTION
- Related ticket: [[functional][opensuse][y][easy] test fails in partitioning_raid - The screen is not refreshed fast enough after sending hotkey, which makes needles to match too late](https://progress.opensuse.org/issues/35134)
- Verification run: [opensuse-15.0-DVD-x86_64-Build267.2-RAID1@64bit](http://dhcp151.suse.cz/tests/3054)

11 runs are scheduled from 3044-3054.