### PR TITLE
Add support for pre-SLE12 needles

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -220,7 +220,11 @@ sub sle_version_at_least {
     my $version_variable = $args{version_variable} // 'VERSION';
 
     if ($version eq '12') {
-        return !check_var($version_variable, '11-SP4');
+        return !(
+               check_var($version_variable, '11-SP1')
+            or check_var($version_variable, '11-SP2')
+            or check_var($version_variable, '11-SP3')
+            or check_var($version_variable, '11-SP4'));
     }
 
     if ($version eq '12-SP1') {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -57,7 +57,10 @@ sub cleanup_needles {
         unregister_needle_tags("ENV-VERSION-11-SP4");
     }
 
-    my $tounregister = sle_version_at_least('12-SP2') ? '0' : '1';
+    my $tounregister = sle_version_at_least('12') ? '0' : '1';
+    unregister_needle_tags("ENV-12ORLATER-$tounregister");
+
+    $tounregister = sle_version_at_least('12-SP2') ? '0' : '1';
     unregister_needle_tags("ENV-SP2ORLATER-$tounregister");
 
     $tounregister = sle_version_at_least('12-SP3') ? '0' : '1';


### PR DESCRIPTION
In order to support SLE11SPx, tag ENV-12ORLATER-x was added and function `sle_version_at_least` was updated to correctly recognize older versions.

- Related ticket: https://progress.opensuse.org/issues/36282
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/851
