### PR TITLE
Add workaround for puppet

### DIFF
--- a/tests/console/puppet.pm
+++ b/tests/console/puppet.pm
@@ -14,10 +14,14 @@ use base "consoletest";
 use strict;
 use testapi;
 use utils;
+use version_utils 'is_sle';
 
 sub run {
     select_console 'root-console';
     pkcon_quit;
+    if (script_run('zypper se puppet') == 104 && is_sle('15+')) {
+        return record_soft_failure 'bsc#1092498 - puppet disappeared from packagehub or was never added';
+    }
     my $output      = "puppet cert list --all | grep -woh puppetslave.local > /dev/$serialdev";
     my $puppet_conf = <<"EOF";
 zypper -n in puppet-server puppet


### PR DESCRIPTION
Add workaround for puppet

- Related ticket: https://progress.opensuse.org/issues/36024
- Verification run: http://dhcp254.suse.cz/tests/1267#step/puppet/7
