### PR TITLE
Fix multiuser_dm test: use tab to select user

### DIFF
--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -64,10 +64,10 @@ sub run {
     assert_screen 'multi_users_dm', 180;    # gnome loading takes long sometimes
     wait_still_screen;
     if (check_var('DESKTOP', 'gnome')) {
-        send_key_until_needlematch('user#01_selected', 'up', 5, 3);    # select created user #01
+        send_key_until_needlematch('user#01_selected', 'tab', 5, 3);    # select created user #01
     }
     elsif (check_var('DESKTOP', 'xfce')) {
-        send_key 'down';                                               # select created user #01
+        send_key 'down';                                                # select created user #01
     }
     elsif (check_var('DESKTOP', 'kde')) {
         wait_screen_change { send_key 'shift-tab' };


### PR DESCRIPTION
Verification run: http://artemis.suse.de/tests/295

As of https://openqa.opensuse.org/tests/681835 grub doesn't have a random user preselected
so we need to go down, not up, until user1 is selected.