### PR TITLE
Fix AY EULA test suite for GMC

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -130,8 +130,7 @@ sub run {
         send_key 'ret';    # boot from hard disk
         return;
     }
-    my @needles
-      = qw(bios-boot nonexisting-package reboot-after-installation linuxrc-install-fail scc-invalid-url warning-pop-up inst-betawarning autoyast-boot);
+    my @needles = qw(bios-boot nonexisting-package reboot-after-installation linuxrc-install-fail scc-invalid-url warning-pop-up autoyast-boot);
     push @needles, 'autoyast-confirm'        if get_var('AUTOYAST_CONFIRM');
     push @needles, 'autoyast-postpartscript' if get_var('USRSCR_DIALOG');
     # bios-boot needle does not match if worker stalls during boot - poo#28648
@@ -143,6 +142,14 @@ sub run {
     push @needles, 'untrusted-ca-cert' if get_var('SMT_URL');
     # Workaround for removing package error during upgrade
     push(@needles, 'ERROR-removing-package') if get_var("AUTOUPGRADE");
+    # If it's beta, we may match license screen before pop-up shows, so check for pop-up first
+    if (get_var('BETA')) {
+        push(@needles, 'inst-betawarning');
+    }
+    elsif (get_var('AUTOYAST_LICENSE')) {
+        push(@needles, 'autoyast-license');
+    }
+
     # Kill ssh proactively before reboot to avoid half-open issue on zVM, do not need this on zKVM
     prepare_system_shutdown if check_var('BACKEND', 's390x');
     my $postpartscript = 0;


### PR DESCRIPTION
AY test fails without BETA=1 setting as we process license only if beta
warning was expected.

See [poo#36493](https://progress.opensuse.org/issues/36493).

- [Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/854)
- Verification run (not available 24/7):
 * [sle15](http://g226.suse.de/tests/1834#)
 * [sle12](http://g226.suse.de/tests/1835#)