### PR TITLE
Add EULA verification in Accept license

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -223,6 +223,16 @@ sub verify_license_has_to_be_accepted {
     }
 }
 
+sub verify_translation {
+    return if check_var('VIDEOMODE', 'text');
+    for my $language (qw(korean english-us)) {
+        wait_screen_change { send_key 'alt-l' };
+        send_key 'home';
+        send_key_until_needlematch("license-language-selected-$language", 'down');
+        assert_screen "license-content-$language";
+    }
+}
+
 sub save_upload_y2logs {
     my ($self) = shift;
     assert_script_run 'sed -i \'s/^tar \(.*$\)/tar --warning=no-file-changed -\1 || true/\' /usr/sbin/save_y2logs';

--- a/tests/installation/accept_license.pm
+++ b/tests/installation/accept_license.pm
@@ -39,7 +39,10 @@ sub run {
     if (match_has_tag('inst-welcome-no-product-list')) {
         return send_key $cmd{next} unless match_has_tag('license-agreement');
     }
-    $self->verify_license_has_to_be_accepted;
+    if (check_var('INSTALLER_EXTENDED_TEST', '1')) {
+        $self->verify_license_has_to_be_accepted;
+        $self->verify_translation;
+    }
     send_key $cmd{next};
     # workaround for bsc#1059317, multiple times clicking accept license
     my $count = 5;


### PR DESCRIPTION
Add EULA verification when accepting license (for instance, korean and check back English US).
For text mode we would need to change the language in the boot loader and we cannot automate with openQA afterward, so this covers only the graphic mode. For the text mode I can take a look manually. If the language is not changed in text mode in the boot loader, situation looks like this: http://dhcp254.suse.cz/tests/1283#step/accept_license/10

- Related ticket: https://progress.opensuse.org/issues/35452
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/856
- Verification run: http://dhcp254.suse.cz/tests/1277#step/accept_license/1
