### PR TITLE
Fix partitioning_togglehome for older product versions

### DIFF
--- a/tests/installation/partitioning_togglehome.pm
+++ b/tests/installation/partitioning_togglehome.pm
@@ -21,7 +21,7 @@ use partition_setup 'unselect_xen_pv_cdrom';
 sub run {
     record_soft_failure 'boo#1093372' if (!get_var('TOGGLEHOME') && is_leap('15.1+'));
     send_key $cmd{guidedsetup};
-    assert_screen 'partition-scheme';
+    assert_screen [qw(partition-scheme  inst-partition-radio-buttons)];
     if (is_storage_ng) {
         unselect_xen_pv_cdrom;
         assert_screen 'partition-scheme';


### PR DESCRIPTION
Verification run: http://lord.arch/tests/1052#step/partitioning_togglehome/1

Related progress issue: https://progress.opensuse.org/issues/36496