### PR TITLE
Use explicit timeout on every check_screen call to make time investment obvious

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -193,7 +193,7 @@ sub x11_start_program {
     init_desktop_runner($program, $timeout);
     # With match_typed we check typed text and if doesn't match - retrying
     # Is required by firefox test on kde, as typing fails on KDE desktop runnner sometimes
-    if ($args{match_typed} && !check_screen($args{match_typed})) {
+    if ($args{match_typed} && !check_screen($args{match_typed}, 30)) {
         send_key 'esc';
         init_desktop_runner($program, $timeout);
     }

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -446,7 +446,7 @@ sub ensure_unlocked_desktop {
                 # open run command prompt (if screen isn't locked)
                 mouse_hide(1);
                 send_key 'alt-f2';
-                if (check_screen 'desktop-runner') {
+                if (check_screen 'desktop-runner', 30) {
                     send_key 'esc';
                     assert_screen 'generic-desktop';
                 }

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -107,7 +107,7 @@ sub import_pictures {
     send_key "ret";
 
     # Choose 'Import in Place'
-    if (check_screen 'shotwell-import-prompt') {
+    if (check_screen 'shotwell-import-prompt', 30) {
         send_key "alt-i";
     }
     assert_screen 'shotwell-imported-tip';
@@ -223,7 +223,7 @@ sub check_new_mail_evolution {
     my $config      = $self->getconfig_emailaccount;
     my $mail_passwd = $config->{$i}->{passwd};
     assert_screen "evolution_mail-online", 240;
-    if (check_screen "evolution_mail-auth") {
+    if (check_screen "evolution_mail-auth", 30) {
         if (sle_version_at_least('12-SP2')) {
             send_key "alt-p";
         }
@@ -251,7 +251,7 @@ sub check_new_mail_evolution {
     # Delete the message and expunge the deleted item if not used POP3
     if ($protocol != "POP") {
         send_key "ctrl-e";
-        if (check_screen "evolution_mail-expunge") {
+        if (check_screen "evolution_mail-expunge", 30) {
             send_key "alt-e";
         }
         assert_screen "evolution_mail-ready";
@@ -290,7 +290,7 @@ sub send_meeting_request {
     send_key "ctrl-s";
     assert_screen "evolution_mail-sendinvite_meeting", 60;
     send_key "ret";
-    if (check_screen "evolution_mail-auth") {
+    if (check_screen "evolution_mail-auth", 30) {
         if (sle_version_at_least('12-SP2')) {
             send_key "alt-a";    #disable keyring option, only need in SP2 or later
             send_key "alt-p";
@@ -389,7 +389,7 @@ sub setup_mail_account {
     my $mail_recvport   = $config->{$account}->{$port_key};
 
     $self->start_evolution($mail_box);
-    if (check_screen "evolution_wizard-skip-lookup") {
+    if (check_screen "evolution_wizard-skip-lookup", 30) {
         send_key "alt-s";
     }
 
@@ -490,7 +490,7 @@ sub setup_mail_account {
     }
     assert_screen "evolution_wizard-done";
     send_key "alt-a";
-    if (check_screen "evolution_mail-auth") {
+    if (check_screen "evolution_mail-auth", 30) {
         if (sle_version_at_least('12-SP2')) {
             send_key "alt-a";    #disable keyring option, only in SP2
             send_key "alt-p";
@@ -498,10 +498,10 @@ sub setup_mail_account {
         type_password $mail_passwd;
         send_key "ret";
     }
-    if (check_screen "evolution_mail-init-window") {
+    if (check_screen "evolution_mail-init-window", 30) {
         send_key "super-up";
     }
-    if (check_screen "evolution_mail-auth") {
+    if (check_screen "evolution_mail-auth", 30) {
         if (sle_version_at_least('12-SP2')) {
             send_key "alt-p";
         }
@@ -741,11 +741,11 @@ sub evolution_send_message {
     type_string "Test email send and receive.";
     send_key "ctrl-ret";
     if (sle_version_at_least('12-SP2')) {
-        if (check_screen "evolution_mail_send_mail_dialog") {
+        if (check_screen "evolution_mail_send_mail_dialog", 30) {
             send_key "ret";
         }
     }
-    if (check_screen "evolution_mail-auth") {
+    if (check_screen "evolution_mail-auth", 30) {
         if (sle_version_at_least('12-SP2')) {
             send_key "alt-a";    #disable keyring option, only in SP2
             send_key "alt-p";

--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -192,7 +192,7 @@ sub deal_with_dependency_issues {
         my $interval = 10;
         my $timetick = 0;
 
-        while (check_screen('adapting_proposal', no_wait => 1)) {
+        while (check_screen('adapting_proposal', timeout => 30, no_wait => 1)) {
             sleep 10;
             $timetick += $interval;
             last if $timetick >= $timeout;
@@ -201,7 +201,7 @@ sub deal_with_dependency_issues {
     }
 
     # In text mode dependency issues may occur again after resolving them
-    if (check_screen 'manual-intervention') {
+    if (check_screen 'manual-intervention', 30) {
         $self->deal_with_dependency_issues;
     }
 }

--- a/tests/console/yast2_ftp.pm
+++ b/tests/console/yast2_ftp.pm
@@ -147,7 +147,7 @@ sub run {
     wait_screen_change { send_key 'down' };
     send_key 'ret';
     # Soft-fail bsc#1041829 on TW
-    if (check_var('VERSION', 'Tumbleweed') && check_screen('yast2_ftp_syntax_error_bsc#1041829')) {
+    if (check_var('VERSION', 'Tumbleweed') && check_screen('yast2_ftp_syntax_error_bsc#1041829', 30)) {
         record_soft_failure('bsc#1041829');
         wait_screen_change { send_key 'alt-c'; };
         wait_screen_change { send_key 'alt-f'; };

--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -105,7 +105,7 @@ sub run {
     send_key 'alt-t';
     assert_screen 'http_start_apache2';             # make sure that apache2 server got started when booting
     send_key 'alt-f';                               # now finish the tests :)
-    check_screen 'http_install_apache2_mods';
+    check_screen 'http_install_apache2_mods', 30;
     send_key 'alt-i';                               # confirm to install apache2_mod_perl, apache2_mod_php, apache2_mod_python
 
     # if popup, confirm to enable apache2 configuratuion

--- a/tests/console/yast2_vnc.pm
+++ b/tests/console/yast2_vnc.pm
@@ -40,7 +40,7 @@ sub run {
     send_key 'alt-a';
     if (is_sle('<15') || is_leap('<15.0')) {
         # open port in firewall if it is eanbaled and check network interfaces, check long text by send key right.
-        if (check_screen 'yast2_vnc_open_port_firewall') {
+        if (check_screen 'yast2_vnc_open_port_firewall', 30) {
             send_key 'alt-p';
             send_key 'alt-d';
             assert_screen 'yast2_vnc_firewall_port_details';

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -86,7 +86,7 @@ sub handle_all_packages_medium {
         assert_screen([qw(addon-products-nonempty sle-product-license-agreement)], 60);
         last if (match_has_tag 'addon-products-nonempty');
         if (match_has_tag 'sle-product-license-agreement') {
-            if (@addons_license_tags && check_screen(\@addons_license_tags)) {
+            if (@addons_license_tags && check_screen(\@addons_license_tags, 30)) {
                 $addon_license_num++;
             }
             wait_screen_change { send_key 'alt-a' };

--- a/tests/installation/addon_products_yast2.pm
+++ b/tests/installation/addon_products_yast2.pm
@@ -108,7 +108,7 @@ sub run {
             }
             else {
                 skip_registration;
-                if (check_screen("scc-skip-base-system-reg-warning")) {
+                if (check_screen("scc-skip-base-system-reg-warning", 30)) {
                     wait_screen_change { send_key "alt-y" };    # confirmed skip SCC registration
                 }
             }

--- a/tests/installation/disk_activation.pm
+++ b/tests/installation/disk_activation.pm
@@ -17,7 +17,7 @@ use testapi;
 use version_utils 'is_sle';
 
 sub format_dasd {
-    while (check_screen 'process-dasd-format') {
+    while (check_screen 'process-dasd-format', 30) {
         diag("formatting DASD ...");
         sleep 20;
     }
@@ -105,7 +105,7 @@ sub run {
             send_key 'alt-s';                           # select all
             assert_screen 'dasd-selected';
             send_key 'alt-a';                           # perform action button
-            if (check_screen 'dasd-device-formatted') {
+            if (check_screen 'dasd-device-formatted', 30) {
                 assert_screen 'action-list';
                 # shortcut changed for sle 15
                 send_key is_sle('15+') ? 'o' : 'f';

--- a/tests/installation/setup_online_repos.pm
+++ b/tests/installation/setup_online_repos.pm
@@ -96,7 +96,7 @@ sub run {
         while (1) {
             send_key 'alt-t';       # Trust
                                     # for some reason the key is prompted twice, bug?
-            last unless check_screen 'import-untrusted-gpg-key-598D0E63B3FD7E48';
+            last unless check_screen 'import-untrusted-gpg-key-598D0E63B3FD7E48', 30;
         }
     }
 }

--- a/tests/installation/sles4sap_wizard.pm
+++ b/tests/installation/sles4sap_wizard.pm
@@ -24,7 +24,7 @@ sub run {
     send_key $cmd{next};
     assert_screen "sles4sap-wizard-installation-mode";
     send_key $cmd{next};
-    if (check_screen('sles4sap-wizard-installation-servers-detected')) {
+    if (check_screen('sles4sap-wizard-installation-servers-detected', 30)) {
         #sap-installation-wizard found sapinst shared over NFS, don't use it
         send_key 'alt-o';    #Okay
     }

--- a/tests/installation/sles4sap_wizard_swpm.pm
+++ b/tests/installation/sles4sap_wizard_swpm.pm
@@ -19,13 +19,13 @@ sub run {
         assert_screen "sles4sap-wizard-tuned-profile-throughput";
     }
     send_key $cmd{next};
-    if (check_screen 'sles4sap-wizard-tuned-profile-confirmation') {
+    if (check_screen 'sles4sap-wizard-tuned-profile-confirmation', 30) {
         send_key 'alt-y';    # Yes
     }
     assert_screen "sles4sap-wizard-tuned-profile-applied";
     send_key 'alt-o';        # Ok
     send_key $cmd{next};
-    if (check_screen('sles4sap-wizard-no-space-left')) {
+    if (check_screen('sles4sap-wizard-no-space-left', 30)) {
         send_key 'alt-o';    #Okay
         die 'this is a bug, there is plenty of space';
     }

--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -63,7 +63,7 @@ sub run {
             # Assume no more than 6 possible migration targets
             for (1 .. 5) {
                 send_key 'down';
-                unless (check_screen $migration_target_base) {
+                unless (check_screen $migration_target_base, 30) {
                     record_info 'Likely error detected', 'Incorrect migration target? See https://fate.suse.com/323165', result => 'fail';
                     last;
                 }

--- a/tests/installation/upgrade_select_opensuse.pm
+++ b/tests/installation/upgrade_select_opensuse.pm
@@ -33,7 +33,7 @@ sub handle_beta_warning {
 
 sub run {
     # offline DVD upgrade may not have network (boo#995771)
-    if (!check_var("FLAVOR", "NET") && check_screen('network-not-configured')) {
+    if (!check_var("FLAVOR", "NET") && check_screen('network-not-configured', 30)) {
         send_key $cmd{next};
         assert_screen('ERROR-cannot-download-repositories');
         send_key 'alt-o';
@@ -42,7 +42,7 @@ sub run {
         assert_screen('list-of-online-repositories', 10);
         send_key $cmd{next};
 
-        if (check_screen('inst-betawarning')) {
+        if (check_screen('inst-betawarning', 30)) {
             handle_beta_warning;
         }
         elsif (get_var("BETA")) {
@@ -50,7 +50,7 @@ sub run {
         }
         # Bug 881107 - there is 2nd license agreement screen in openSUSE upgrade
         # http://bugzilla.opensuse.org/show_bug.cgi?id=881107
-        if (check_screen('upgrade-license-agreement')) {
+        if (check_screen('upgrade-license-agreement', 30)) {
             check_bsc997635;
         }
     }

--- a/tests/sles4sap/desktop_icons.pm
+++ b/tests/sles4sap/desktop_icons.pm
@@ -20,7 +20,7 @@ sub run {
 
     select_console 'x11';
     # Check for SLES4SAP Desktop icons
-    if (check_screen 'sles4sap-desktop') {
+    if (check_screen 'sles4sap-desktop', 30) {
         assert_and_dclick 'sles4sap-desktop-cheatsheet';
         assert_screen 'sles4sap-cheatsheet', 90;
         send_key 'alt-f4';

--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -48,7 +48,7 @@ sub run {
             # the assert_screen, record a soft failure
             wait_still_screen;
             if (match_has_tag('updates_none')) {
-                if (check_screen 'updates_none') {
+                if (check_screen 'updates_none', 30) {
                     last;
                 }
                 else {

--- a/tests/x11/empathy/empathy_irc.pm
+++ b/tests/x11/empathy/empathy_irc.pm
@@ -60,7 +60,7 @@ sub run {
 
     # cleaning
     send_key "f4";
-    if (!check_screen 'empathy-disable-account') {
+    if (!check_screen 'empathy-disable-account', 30) {
         assert_and_click 'empathy-menu';
         assert_and_click 'empathy-menu-accounts';
     }

--- a/tests/x11/evolution/evolution_smoke.pm
+++ b/tests/x11/evolution/evolution_smoke.pm
@@ -62,7 +62,7 @@ sub run {
 
     type_string "$mail_passwd";
     send_key "ret";
-    if (check_screen "evolution_mail-init-window") {
+    if (check_screen "evolution_mail-init-window", 30) {
         send_key "super-up";
     }
     assert_screen "evolution_mail-max-window";

--- a/tests/x11/evolution/evolution_timezone_setup.pm
+++ b/tests/x11/evolution/evolution_timezone_setup.pm
@@ -38,7 +38,7 @@ sub run {
     send_key "alt-s";
     wait_still_screen 3;
     send_key "ret";
-    if (check_screen "timezone-asia") {
+    if (check_screen "timezone-asia", 30) {
         send_key "right";
         send_key_until_needlematch("timezone-shanghai", "up");
     }

--- a/tests/x11/firefox/firefox_headers.pm
+++ b/tests/x11/firefox/firefox_headers.pm
@@ -43,7 +43,7 @@ sub run {
     # Exit
     send_key "alt-f4";
 
-    if (check_screen('firefox-save-and-quit')) {
+    if (check_screen('firefox-save-and-quit', 30)) {
         # confirm "save&quit"
         send_key "ret";
     }

--- a/tests/x11/gnome_terminal.pm
+++ b/tests/x11/gnome_terminal.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,7 +20,7 @@ sub run {
     mouse_hide(1);
     x11_start_program('gnome-terminal');
     send_key "ctrl-shift-t";
-    if (!check_screen "gnome-terminal-second-tab") {
+    if (!check_screen "gnome-terminal-second-tab", 30) {
         record_info('workaround', 'gnome_terminal does not open second terminal when shortcut is pressed (see bsc#999243)');
     }
     $self->enter_test_text('gnome-terminal', cmd => 1);

--- a/tests/x11/gnomecase/application_starts_on_login.pm
+++ b/tests/x11/gnomecase/application_starts_on_login.pm
@@ -45,9 +45,7 @@ sub start_dconf {
         # dconf-editor entry is not in gnome-control-center of SLE15;
         x11_start_program 'dconf-editor';
     }
-    if (check_screen("dconf-caution")) {
-        assert_and_click "will-be-careful";
-    }
+    assert_and_click 'will-be-careful' if check_screen 'dconf-caution', 0;
 }
 
 sub alter_status_auto_save_session {
@@ -70,7 +68,7 @@ sub alter_status_auto_save_session {
         type_string "auto-save-session\n";
     }
     assert_and_click "auto-save-session";
-    if (check_screen("changing-scheme-popup")) {
+    if (check_screen("changing-scheme-popup", 30)) {
         assert_and_click "auto-save-session-alter-use-default";
         assert_and_click "auto-save-session-true";
         assert_and_click "auto-save-session-apply";

--- a/tests/x11/libreoffice/libreoffice_double_click_file.pm
+++ b/tests/x11/libreoffice/libreoffice_double_click_file.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2017 SUSE LLC
+# Copyright © 2016-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -42,9 +42,7 @@ sub run {
             send_key 'ctrl-q';
         }
     }
-    if (!check_screen("generic-desktop")) {
-        send_key "ctrl-q";
-    }
+    send_key 'ctrl-q' unless check_screen 'generic-desktop', 0;
 
     #clean up
     $self->cleanup_libreoffice_recent_file();

--- a/tests/x11/libreoffice/libreoffice_open_specified_file.pm
+++ b/tests/x11/libreoffice/libreoffice_open_specified_file.pm
@@ -39,9 +39,7 @@ sub run {
         if ($i % 3 == 0) { send_key_until_needlematch('libreoffice-test-doc', 'alt-f4', 5, 10); }
         $i++;
     }
-    if (!check_screen("generic-desktop")) {
-        send_key "ctrl-q";
-    }
+    send_key 'ctrl-q' unless check_screen 'generic-desktop', 0;
 
     #clean up
     $self->cleanup_libreoffice_recent_file();

--- a/tests/x11/pidgin/pidgin_IRC.pm
+++ b/tests/x11/pidgin/pidgin_IRC.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -41,7 +41,7 @@ sub run {
     wait_screen_change { send_key "alt-c" };
 
     # Warning of spoofing ip may appear
-    if (check_screen("pidgin-spoofing-ip")) {
+    if (check_screen("pidgin-spoofing-ip", 0)) {
         wait_screen_change {
             send_key "alt-tab";
         };

--- a/tests/x11/tracker/tracker_by_command.pm
+++ b/tests/x11/tracker/tracker_by_command.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -23,7 +23,7 @@ sub run {
     x11_start_program('xterm');
     if (sle_version_at_least('12-SP2')) {
         script_run 'tracker search emtpyfile';
-        record_soft_failure 'bsc#1074582 tracker can not index empty file automatically' if check_screen 'tracker-cmdsearch-noemptyfile';
+        record_soft_failure 'bsc#1074582 tracker can not index empty file automatically' if check_screen 'tracker-cmdsearch-noemptyfile', 30;
         # Wait 20s for tracker to index the test file
         wait_still_screen 20;
         script_run "tracker search newfile";

--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -42,9 +42,9 @@ sub run {
     type_string "yast2 snapper\n";
     assert_screen 'yast2_snapper-snapshots', 100;
     # ensure the last screenshots are visible
-    send_key 'end';
+    wait_screen_change { send_key 'end' };
     # Make sure the test snapshot is not there
-    die("Unexpected snapshot found") if (check_screen([qw(grub_comment)], 1));
+    die("Unexpected snapshot found") if (check_screen([qw(grub_comment)], 0));
 
     # Create a new snapshot
     $self->y2snapper_create_snapshot();

--- a/tests/x11/yast2_lan_restart_devices.pm
+++ b/tests/x11/yast2_lan_restart_devices.pm
@@ -44,7 +44,7 @@ sub add_device {
         send_key 'alt-g';             # General
         send_key 'alt-i';             # Bridged devices
         assert_screen 'yast2_lan_bridged_devices';
-        if (check_screen('yast2_lan_default_NIC_bridge')) {
+        if (check_screen('yast2_lan_default_NIC_bridge', 0)) {
             send_key 'alt-d';         # select Bridged Devices region
             send_key 'spc';
             wait_still_screen;

--- a/tests/yast2_gui/yast2_lang.pm
+++ b/tests/yast2_gui/yast2_lang.pm
@@ -37,7 +37,7 @@ sub run {
     # Problem here is that sometimes installation takes longer than 10 minutes
     # And then screen saver is activated, so add this step to wake
     my $timeout = 0;
-    until (check_screen 'generic-desktop' || ++$timeout > 10) {
+    until (check_screen('generic-desktop', 30) || ++$timeout > 10) {
         # Now it will install required language packages and exit
         # Put in the loop, because sometimes button is not pressed
         wait_screen_change { send_key 'alt-o'; };


### PR DESCRIPTION
This also serves as preparation for
https://github.com/os-autoinst/os-autoinst/pull/965 which changes the default
timeout of check_screen from 30 seconds to 0.