### PR TITLE
Remove BETA in code for zvm migration

### DIFF
--- a/tests/migration/version_switch_origin_system.pm
+++ b/tests/migration/version_switch_origin_system.pm
@@ -32,7 +32,6 @@ sub run {
 
     # Reset vars for autoyast installation of origin system
     if (get_var('UPGRADE_ON_ZVM')) {
-        set_var('BETA',         0);
         set_var('UPGRADE',      0);
         set_var('SCC_REGISTER', 'none');
     }

--- a/tests/migration/version_switch_upgrade_target.pm
+++ b/tests/migration/version_switch_upgrade_target.pm
@@ -31,7 +31,6 @@ sub run {
 
     # Reset vars for upgrade on zVM
     if (get_var('UPGRADE_ON_ZVM')) {
-        set_var('BETA',                1);
         set_var('UPGRADE',             1);
         set_var('AUTOYAST',            0);
         set_var('DESKTOP',             'textmode');


### PR DESCRIPTION
We should remove the setting of 'BETA' in test code which is set in medium of openQA to describe the development stage. 

- Related ticket: https://progress.opensuse.org/issues/36478
- Verification run: http://haendel.arch.suse.de/tests/70#step/welcome/4
