### PR TITLE
Fix rc-local test in userspace_systemd

### DIFF
--- a/tests/qa_automation/execute_test_run.pm
+++ b/tests/qa_automation/execute_test_run.pm
@@ -21,11 +21,11 @@ use upload_system_log;
 use base "opensusebasetest";
 
 sub run {
-    my $timeout  = abs(get_var("MAX_JOB_TIME", 9600) - 1200);         #deduct 20 minutes for previous steps, due to poo#30183
-    my $test     = get_var("QA_TESTSUITE") . get_var("QA_VERSION");
-    my $runfile  = "/usr/share/qa/tools/test_$test-run";
-    my $runfile2 = "/usr/lib/ctcs2/tools/test_$test-run";
-    my $run_log  = "/tmp/$test-run.log";
+    my $timeout         = abs(get_var("MAX_JOB_TIME", 9600) - 1200);         #deduct 20 minutes for previous steps, due to poo#30183
+    my $test            = get_var("QA_TESTSUITE") . get_var("QA_VERSION");
+    my $runfile         = "/usr/share/qa/tools/test_$test-run";
+    my $runfile2        = "/usr/lib/ctcs2/tools/test_$test-run";
+    my $run_log         = "/tmp/$test-run.log";
     my $boot_local_file = "/etc/init.d/boot.local";
 
     # add a dummy boot.local file as it is not expected to be created by default anymore,

--- a/tests/qa_automation/execute_test_run.pm
+++ b/tests/qa_automation/execute_test_run.pm
@@ -26,6 +26,12 @@ sub run {
     my $runfile  = "/usr/share/qa/tools/test_$test-run";
     my $runfile2 = "/usr/lib/ctcs2/tools/test_$test-run";
     my $run_log  = "/tmp/$test-run.log";
+    my $boot_local_file = "/etc/init.d/boot.local";
+
+    # add a dummy boot.local file as it is not expected to be created by default anymore,
+    # but it is required for rc-local service to be run (see bsc#1075734)
+    assert_script_run "echo '#!/bin/sh' | tee $boot_local_file";
+    assert_script_run "chmod +x $boot_local_file";
 
     #execute test run
     script_run("if [ -e $runfile ]; then $runfile |tee $run_log; else $runfile2 |tee $run_log; fi", $timeout);


### PR DESCRIPTION
The commit fixes 'check-rc-local' test
by adding dummy '/etc/init.d/boot.local
file, as it is required for rc-local
service to be started. According to the
systemd maintainers, the file is not
expected to be added by default anymore.

Related tickets:
[poo#32548](https://progress.opensuse.org/issues/32548),
[bsc#1082976](https://bugzilla.suse.com/show_bug.cgi?id=1082976)
Verification run: http://10.160.65.138/tests/19#step/1_systemd/34