### PR TITLE
No firefox for ppc64le

### DIFF
--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -27,6 +27,10 @@ sub start_firefox {
 
 sub run() {
     my ($self) = shift;
+    if (get_var('OFW')) {
+        record_soft_failure('boo#1094668 - do not start firefox as failure for ppc64le');
+        return;
+    }
     mouse_hide(1);
     $self->start_firefox();
     send_key "alt-h";


### PR DESCRIPTION
bypass failure reported in openQA test
https://openqa.opensuse.org/tests/682425#step/firefox/4

tracked by bug
https://bugzilla.opensuse.org/show_bug.cgi?id=1094668