### PR TITLE
Increase timeout for trex download

### DIFF
--- a/tests/nfv/trex_installation.pm
+++ b/tests/nfv/trex_installation.pm
@@ -26,11 +26,11 @@ sub run {
 
     select_virtio_console();
 
-    assert_script_run("wget $url");
+    assert_script_run("wget $url", 900);
     assert_script_run("tar -xzf $tarball");
     assert_script_run("mv $trex_version $trex_dest");
 
-    # Copy sample config file to default localtion
+    # Copy sample config file to default location
     assert_script_run("cp $trex_dest/cfg/simple_cfg.yaml /etc/trex_cfg.yaml");
 }
 


### PR DESCRIPTION
Fix poo#36571: Download from external resource needs more time.
Timeout increased to 900 seconds. One typo in comment was fixed.

- Related ticket: https://progress.opensuse.org/issues/36571
- Needles: none
- Verification run: http://10.100.12.105/tests/2040
