### PR TITLE
Create soft-failure in yast_virtualization

### DIFF
--- a/tests/virtualization/virt_install.pm
+++ b/tests/virtualization/virt_install.pm
@@ -19,10 +19,9 @@ sub run {
     x11_start_program('xterm');
     become_root;
     script_run('virt-install --name TESTING --memory 512 --disk none --boot cdrom --graphics vnc &', 0);
-    x11_start_program('vncviewer :0', target_match => 'virtman-gnome_virt-install', match_timeout => 100);
+    x11_start_program('vncviewer :0', target_match => 'virtman-gnome_virt-install', match_timeout => 200);
     # closing all windows
     send_key 'alt-f4' for (0 .. 2);
 }
 
 1;
-

--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -20,6 +20,10 @@ sub run {
     x11_start_program('xterm');
     send_key 'alt-f10';
     become_root;
+    if (script_run('zypper se -i yast2-vm') == 104) {
+        record_soft_failure 'bsc#1083398 - YaST2-virtualization provides wrong components for SLED';
+        assert_script_run 'zypper in -y yast2-vm';
+    }
     $self->launch_yast2_module_x11('virtualization');
     # select everything
     send_key 'alt-x';    # XEN Server
@@ -57,4 +61,3 @@ sub test_flags {
 }
 
 1;
-


### PR DESCRIPTION
- Summary:
  - Create soft-failure installing yast2-vm as it is no longer part of the patterns
  - Increase time-out in virt_install

- Related ticket: https://progress.opensuse.org/issues/34405
- Bug related: https://bugzilla.suse.com/show_bug.cgi?id=1083398
- Verification run: 
  - [Soft-failure](http://dhcp254.suse.cz/tests/1293#step/yast_virtualization/10)
  - [Statitstics for virt_install](http://dhcp254.suse.cz/tests/overview?distri=opensuse&version=Tumbleweed&build=20180527%40virtualization_jeriveramoya&groupid=1)
