### PR TITLE
Check for pre GM phase

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -256,12 +256,8 @@ sub fill_in_registration_data {
     # Process modules on sle 15
     if (is_sle '15+') {
         my $modules_needle = "modules-preselected-" . get_required_var('SLE_PRODUCT');
-        if (check_var('BETA', '1')) {
-            assert_screen('scc-beta-filter-checkbox');
-            send_key('alt-i');
-        }
-        elsif (!check_screen($modules_needle, 0)) {
-            record_info('bsc#1094457 : SLE 15 modules are still in BETA while product enter GMC phase');
+        # During BETA and pre-GM phase, scc offer the modules as BETA.
+        if (check_var('BETA', '1') || check_var('GMC', '1')) {
             assert_screen('scc-beta-filter-checkbox');
             send_key('alt-i');
         }


### PR DESCRIPTION
- Between BETA and GM phase, the product behaves in a mixture of both and we have to handle this state.

Proposing GMC setting flag to handle this situation. See discussions here https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5124 and here https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5126.

- Related ticket: https://progress.opensuse.org/issues/36453
- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5141
- Verification run: http://10.160.66.74/tests/343#step/scc_registration/9