### PR TITLE
Handle warning pop up for small root fs

### DIFF
--- a/tests/installation/partitioning_splitusr.pm
+++ b/tests/installation/partitioning_splitusr.pm
@@ -32,14 +32,17 @@ sub run {
     send_key "home";
     send_key_until_needlematch 'root-partition-selected', 'down';    # Select root partition
                                                                      # Different shortcut on storage-ng
-    wait_screen_change { send_key((is_storage_ng) ? 'alt-z' : $cmd{resize}) };    # Resize
-    send_key(is_storage_ng() ? 'alt-c' : 'alt-u');                                # Custom size
+    wait_screen_change { send_key $cmd{resize} };                    # Resize
+    send_key 'alt-u';                                                # Custom size
     send_key $cmd{size_hotkey} if is_storage_ng;
     type_string '1.5G';
     send_key(is_storage_ng() ? $cmd{next} : 'ret');
     if (is_storage_ng) {
+        # warning: / should be >= 10 GiB or disable snapshots
+        assert_screen 'partition-splitusr-root-warning';
+        wait_screen_change { send_key 'alt-y' };                     # accept warning for small /
         wait_screen_change { send_key 'alt-s' };
-        send_key_until_needlematch 'vda-selected', 'left';                        # Select vda again
+        send_key_until_needlematch 'vda-selected', 'left';           # Select vda again
     }
 
     # add /usr


### PR DESCRIPTION
Adding handle for storage-ng partitioning warning when root fs is below the limit.
 
- Related ticket: [[functional][y] partitioning_splitusr need to process warning message](https://progress.opensuse.org/issues/35706)
- Needles: [Add small root fs warning needles #375](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/375)
- Verification run: [opensuse-15.0-DVD-x86_64-Build267.2-splitusr@64bit](http://dhcp151.suse.cz/tests/3217#step/partitioning_splitusr/14)
[opensuse-Tumbleweed-DVD-x86_64-BuildSnapshot20180527-splitusr@64bi](http://dhcp151.suse.cz/tests/3216#step/partitioning_splitusr/14)
