### PR TITLE
Fix sporadic error on vnc connection to vm

### DIFF
--- a/tests/virtualization/virt_install.pm
+++ b/tests/virtualization/virt_install.pm
@@ -19,7 +19,8 @@ sub run {
     x11_start_program('xterm');
     become_root;
     script_run('virt-install --name TESTING --memory 512 --disk none --boot cdrom --graphics vnc &', 0);
-    x11_start_program('vncviewer :0', target_match => 'virtman-gnome_virt-install', match_timeout => 200);
+    wait_still_screen;
+    x11_start_program('vncviewer :0', target_match => 'virtman-gnome_virt-install', match_timeout => 100);
     # closing all windows
     send_key 'alt-f4' for (0 .. 2);
 }


### PR DESCRIPTION
I discovered that there is not issue with the timeout so I reverted the increment to 200 to its original value and what we need is to wait for the VM to finish its process of creation. Sporadically when we tried to open a session the process was in the middle and failed. If we wait for screen to be still we can solve that situation.

- Related ticket: https://progress.opensuse.org/issues/34405
- Verification run: http://dhcp254.suse.cz/tests/1398
