### PR TITLE
[WIP] Add workaround btrfs balance

### DIFF
--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -20,6 +20,10 @@ sub run {
     x11_start_program('xterm');
     send_key 'alt-f10';
     become_root;
+    while (1) {
+        last unless (script_run("btrfs balance status -v / | grep 'No balance found on'"));
+        save_screenshot;
+    }
     if (script_run('zypper se -i yast2-vm') == 104) {
         record_soft_failure 'bsc#1083398 - YaST2-virtualization provides wrong components for SLED';
         assert_script_run 'zypper in -y yast2-vm';


### PR DESCRIPTION
I found necessary to add stability to this tests checking for the status of the btrfs balance. When running  script  btrfs-balance.sh it detects that is running in that moment (if it is the case) so I found this way to check for the status. Basically the test is very affected by this, failing randomly, not able to run x11 application or installing application. This is related with discussion in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5097 so this could be and idea of workaround perhaps. I will let in WIP for discussion too as there is no bug I could point it yet and perhaps the proper solution will arrive soon?

- Related ticket: https://progress.opensuse.org/issues/34405
- Verification run: http://dhcp254.suse.cz/tests/1431
