### PR TITLE
Add synchronization points after loading new screen

### DIFF
--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -79,8 +79,10 @@ sub run {
         assert_screen 'yast2-dns-server-step3';
     }
 
-    # Enable dns server and finish
-    wait_screen_change { send_key 'alt-s' };
+    # Enable dns server and finish after yast2 loads default settings
+    assert_screen 'yast2-dns-server-fw-port-is-closed';
+    send_key 'alt-s';
+    assert_screen 'yast2-dns-server-start-named-now';
     send_key 'alt-f';
     assert_screen 'root-console';
     # The wizard-like interface still uses the old approach of always starting the service


### PR DESCRIPTION
We need to wait while yast2 loads default data before starting with the configuration of DNS.

- Related ticket: [[functional][y] test fails in yast2_dns_server - improve post_fail_hook or investigation process](https://progress.opensuse.org/issues/36109)
- Needles - o3: [Ensure start now checkbox is used]()
- Needles - osd: [Ensure start now checkbox is used](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/861)
- Verification oS run: [opensuse-Tumbleweed-DVD-x86_64-Build20180528-yast2_ncurses@64b](http://dhcp151.suse.cz/tests/3313)
- Verification sle run: [sle-15-Installer-DVD-x86_64-Build653.1-yast2_ncurses@64bit](http://dhcp151.suse.cz/tests/3314)
