### PR TITLE
Fix condition for repo replacement in openSUSE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -267,8 +267,6 @@ sub is_repo_replacement_required {
     return is_opensuse()                  # Is valid scenario onlu for openSUSE
       && !is_staging()                    # Do not have mirrored repos on staging
       && !get_var('KEEP_ONLINE_REPOS')    # Set variable no to replace variables
-      && !is_updates_tests()              # Is not required for update and upgrade tests, repos are already injected
-      && !is_upgrade()
       && get_var('SUSEMIRROR')            # Skip if required variable is not set (leap live tests)
       && !get_var('OFFLINE_SUT');         # Do not run if SUT is offine
 }


### PR DESCRIPTION
Remove conditions that avoid to have correct repos related with current snapshot in openSUSE products.

- Related ticket: https://progress.opensuse.org/issues/36333
- Verification run: http://dhcp254.suse.cz/tests/overview?distri=opensuse&version=Tumbleweed&build=20180529%40update_tests&groupid=2
For instance, it fixes the broken kate scenario: http://dhcp254.suse.cz/tests/1495