### PR TITLE
Enter password for grub in case of encrypted LVM on zVM

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -186,7 +186,9 @@ sub unlock_if_encrypted {
     elsif (check_var('BACKEND', 's390x')) {
         my $console = console('x3270');
         # Enter password before GRUB if boot is encrypted
-        unlock_zvm_disk($console) if (get_var('FULL_LVM_ENCRYPT'));
+        # Boot partition is always encrypted, if not using expert partitioner with
+        # separate unencrypted boot
+        unlock_zvm_disk($console) unless get_var('UNENCRYPTED_BOOT');
         handle_grub_zvm($console);
         unlock_zvm_disk($console);
     }


### PR DESCRIPTION
On s390x boot partition gets encrypted in case of guided partitioning
both with storage-ng and without, hence requires entering passphrase
twice. With this change, we can reuse cryptlvm test-suite completely on
zVM.

See [poo#35959](https://progress.opensuse.org/issues/35959).

- Verification runs: 
  * [sle 15](http://g226.suse.de/tests/1842) 
  * [sle 12 SP4](http://g226.suse.de/tests/1843) 

NOTE: both test suites fail on zypper_info as I have not provided all repos when triggering test on OSD.
