### PR TITLE
[WIP] Add non interactive to zypper se in virtualization test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -267,8 +267,6 @@ sub is_repo_replacement_required {
     return is_opensuse()                  # Is valid scenario onlu for openSUSE
       && !is_staging()                    # Do not have mirrored repos on staging
       && !get_var('KEEP_ONLINE_REPOS')    # Set variable no to replace variables
-      && !is_updates_tests()              # Is not required for update and upgrade tests, repos are already injected
-      && !is_upgrade()
       && get_var('SUSEMIRROR')            # Skip if required variable is not set (leap live tests)
       && !get_var('OFFLINE_SUT');         # Do not run if SUT is offine
 }

--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -20,7 +20,8 @@ sub run {
     x11_start_program('xterm');
     send_key 'alt-f10';
     become_root;
-    if (script_run('zypper se -i yast2-vm') == 104) {
+    pkcon_quit;
+    if (script_run('zypper se -n -i yast2-vm') == 104) {
         record_soft_failure 'bsc#1083398 - YaST2-virtualization provides wrong components for SLED';
         assert_script_run 'zypper in -y yast2-vm';
     }


### PR DESCRIPTION
I forgot to add non-interactive mode for zypper se in virtualization tests so I found failing some of my verification in O3, for instance, https://openqa.opensuse.org/tests/685137#step/yast_virtualization/7

- Related ticket: https://progress.opensuse.org/issues/34405
- Verification run: 
