### PR TITLE
Synchronization needle to avoid mistyping volume-name-root

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -147,6 +147,7 @@ sub set_lvm {
     send_key "ret";
 
     # create normal volume with name root
+    assert_screen 'add-lvm-on-root';
     type_string "root";
     assert_screen 'volume-name-root';
     send_key $cmd{next};


### PR DESCRIPTION
- Related ticket:[[sle][functional][hyperv][sporadic][y][yast][medium]test fails in partitioning_raid - too early typing of volume-name-root](https://progress.opensuse.org/issues/33472)
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/862
- o3 needle: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/379
- Verification run:  [sle-15-Installer-DVD-x86_64-Build653.1-lvm+RAID1@svirt-hyperv](http://dhcp151.suse.cz/tests/3326)
