### PR TITLE
Stop pkon before virtualization tests

### DIFF
--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -20,6 +20,7 @@ sub run {
     x11_start_program('xterm');
     send_key 'alt-f10';
     become_root;
+    pkcon_quit;
     if (script_run('zypper se -i yast2-vm') == 104) {
         record_soft_failure 'bsc#1083398 - YaST2-virtualization provides wrong components for SLED';
         assert_script_run 'zypper in -y yast2-vm';


### PR DESCRIPTION
Stop pkon before virtualization tests to avoid: https://openqa.opensuse.org/tests/685137#step/yast_virtualization/7

- Related ticket: https://progress.opensuse.org/issues/34405
- Verification run: http://dhcp254.suse.cz/tests/1498
