### PR TITLE
Fix counter asserting license selected

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -231,7 +231,7 @@ sub verify_translation {
     for my $language (qw(korean english-us)) {
         wait_screen_change { send_key 'alt-l' };
         send_key 'home';
-        send_key_until_needlematch("license-language-selected-$language", 'down');
+        send_key_until_needlematch("license-language-selected-$language", 'down', 60, 1);
         assert_screen "license-content-$language";
     }
 }


### PR DESCRIPTION
To avoid  this timeout https://openqa.suse.de/tests/1735248#step/accept_license/26 when there are more languages available.

- Related ticket: https://progress.opensuse.org/issues/35452

