### PR TITLE
Fix accept_license to not force soft-failure

### DIFF
--- a/tests/installation/accept_license.pm
+++ b/tests/installation/accept_license.pm
@@ -39,10 +39,8 @@ sub run {
     if (match_has_tag('inst-welcome-no-product-list')) {
         return send_key $cmd{next} unless match_has_tag('license-agreement');
     }
-    if (check_var('INSTALLER_EXTENDED_TEST', '1')) {
-        $self->verify_license_has_to_be_accepted;
-        $self->verify_translation;
-    }
+    $self->verify_license_has_to_be_accepted;
+    $self->verify_translation if (check_var('INSTALLER_EXTENDED_TEST', '1'));
     send_key $cmd{next};
     # workaround for bsc#1059317, multiple times clicking accept license
     my $count = 5;


### PR DESCRIPTION
This will fix the problem with so many soft-failure as for the jobs without INSTALLER_EXTENDED_TEST subroutine verify_license_has_to_be_accepted shoud be triggered. We missed that in #5129 

- Related ticket: https://progress.opensuse.org/issues/35452
- Verification run: http://dhcp254.suse.cz/tests/1513
