### PR TITLE
Select last node in snaphots tree to verify difference screen

### DIFF
--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -63,6 +63,8 @@ sub y2snapper_show_changes_and_delete {
     send_key "alt-s";
     assert_screen 'yast2_snapper-collapsed_testdata', 200;
     if ($ncurses) {
+        # Select last directory in the tree and expand it
+        wait_screen_change { send_key "end" };
         wait_screen_change { send_key "ret" };
         wait_screen_change { send_key "end" };
     }


### PR DESCRIPTION
In yast2_snapper_ncurses test depending on the run we may have multiple
directories in the snapshot. In ncurses we use end key to navigate to
last file in the tree, but if there are multiple roots, we navigate to
the directory node where expected menu is not shown. When selecting last
directory and expand it, test will work in both setups.

See [poo#36069](https://progress.opensuse.org/issues/36069).

- [Verification run](http://g226.suse.de/tests/1849#).
