### PR TITLE
Add workaround for language selection on enlightenment

### DIFF
--- a/tests/x11/enlightenment_first_start.pm
+++ b/tests/x11/enlightenment_first_start.pm
@@ -17,6 +17,12 @@ use utils;
 
 sub run {
     mouse_hide();
+    assert_screen [qw(enlightenment_keyboard_english enlightenment_language_english)];
+    if (match_has_tag 'enlightenment_language_english') {
+        record_soft_failure('bsc#1076835 - Enlightenment: newly asks for language');
+        assert_and_click "enlightenment_language_english";
+        assert_and_click "enlightenment_assistant_next";
+    }
     assert_and_click "enlightenment_keyboard_english";
     assert_and_click "enlightenment_assistant_next";
     assert_and_click "enlightenment_profile_selection";


### PR DESCRIPTION
The commit adds soft failure for
enlightenment_first_start module,
by adding all the required steps
for selecting language on first
start of the system.

- Related tickets: [poo#35647](https://progress.opensuse.org/issues/35647), [bsc#1076835](https://bugzilla.opensuse.org/show_bug.cgi?id=1076835)
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/380
- Verification run: http://10.160.65.138/tests/92#step/enlightenment_first_start/1
