### PR TITLE
Change patterns for SLE15

### DIFF
--- a/tests/qam-minimal/install_patterns.pm
+++ b/tests/qam-minimal/install_patterns.pm
@@ -23,6 +23,7 @@ use strict;
 
 use utils;
 use qam;
+use version_utils 'is_sle';
 use testapi;
 
 sub install_packages {
@@ -49,7 +50,7 @@ sub run {
     zypper_call("pt");
     save_screenshot;
 
-    zypper_call("in -t pattern base x11 gnome-basic apparmor", exitcode => [0, 102], timeout => 2000);
+    zypper_call("in -t pattern base x11 " . (is_sle('>=15') ? 'gnome_basic' : 'gnome-basic') . " apparmor", exitcode => [0, 102], timeout => 2000);
 
     systemctl 'set-default graphical.target';
     script_run('sed -i -r "s/^DISPLAYMANAGER=\"\"/DISPLAYMANAGER=\"gdm\"/" /etc/sysconfig/displaymanager');


### PR DESCRIPTION
Pattern gnome-basic has different name in SLE15.

- Related ticket: https://progress.opensuse.org/issues/36583
- Verification run: http://panigale.suse.cz/tests/1675#step/install_patterns/8