### PR TITLE
Enable soft-failure for zVM in dns_srv

### DIFF
--- a/tests/console/dns_srv.pm
+++ b/tests/console/dns_srv.pm
@@ -33,9 +33,9 @@ sub run {
     # verify dns server responds to anything
     my $e = script_run "host localhost localhost";
     if ($e) {
-        record_soft_failure 'Bug 1064438: "bind" cannot resolve localhost' if get_var('S390_ZKVM');
+        record_soft_failure 'Bug 1064438: "bind" cannot resolve localhost' if check_var('ARCH', 's390x');
         record_info 'Skip the entire test on bridged networks (e.g. Xen, Hyper-V)' if (is_bridged_networking);
-        return if (is_bridged_networking || get_var('S390_ZKVM'));
+        return if (is_bridged_networking || check_var('ARCH', 's390x'));
         die "Command 'host localhost localhost' failed, cannot resolv localhost";
     }
 }


### PR DESCRIPTION
We have same issue on zVM as on ZKVM. Hence, enabling behavior for s390x
architecture and not only zKVM.

- [Verification run](http://g226.suse.de/tests/1864#).
