### PR TITLE
Fix zdup when repos already present

### DIFF
--- a/tests/console/zypper_ar.pm
+++ b/tests/console/zypper_ar.pm
@@ -25,7 +25,7 @@ sub run {
         foreach (@repos_to_add) {
             next unless get_var("REPO_$_");    # Skip repo if not defined
             $repourl = $urlprefix . "/" . get_var("REPO_$_");
-            zypper_call "ar -c $repourl $_";
+            zypper_call "ar -c $repourl $_" if zypper_call("lr | grep $_", allow_exit_codes => [1]);
         }
     }
     else {


### PR DESCRIPTION
As a fallout of #5153 we can check if the repo is already there:

- Related ticket: https://progress.opensuse.org/issues/36333
- Verification run: http://dhcp254.suse.cz/tests/1551#step/zypper_ar/7
