### PR TITLE
Die properly if cannot parse logs from test wrapper executor

### DIFF
--- a/lib/ctcs2_to_junit.pm
+++ b/lib/ctcs2_to_junit.pm
@@ -24,7 +24,7 @@ our @EXPORT = qw(analyzeResult generateXML);
 
 sub analyzeResult {
     my ($text) = @_;
-    my $result;
+    my $result = ();
     $text =~ /Test in progress(.*)Test run complete/s;
     my $rough_result = $1;
     foreach (split("\n", $rough_result)) {


### PR DESCRIPTION
In one of the runs script_output hasn't returned anything we could
parse, which is known issue of this api function.
This PR improves handling of such cases.

See [poo#36580](https://progress.opensuse.org/issues/36580).
