### PR TITLE
Accept license automatically when install packages for java test

### DIFF
--- a/tests/console/java.pm
+++ b/tests/console/java.pm
@@ -27,15 +27,15 @@ sub run {
     pkcon_quit;
 
     # Capture the return code value of the following scenarios
-    my $bootstrap_pkg_rt       = zypper_call("se java-*bootstrap",  exitcode => [0, 104]);
-    my $bootstrap_conflicts_rt = zypper_call("in --dry-run java-*", exitcode => [0, 4]);
+    my $bootstrap_pkg_rt = zypper_call("se java-*bootstrap", exitcode => [0, 104]);
+    my $bootstrap_conflicts_rt = zypper_call("in --auto-agree-with-licenses --dry-run java-*", exitcode => [0, 4]);
 
     # logs / debugging purposes
     diag "checking variable: bootstrap_pkg_rt = $bootstrap_pkg_rt";
     diag "checking variable: bootstrap_conflicts_rt = $bootstrap_conflicts_rt";
 
     if (check_var("DISTRI", "sle")) {
-        zypper_call("in java-*", timeout => 1400);
+        zypper_call("in --auto-agree-with-licenses java-*", timeout => 1400);
     }
 
     if (check_var("DISTRI", "opensuse")) {


### PR DESCRIPTION
We should accept the license automatically with '--auto-agree-with-licenses' option and only install java-*openjdk* packages since there is no javac alternative support for java-1_8_0-ibm and test_java.sh need javac to compile a java class as a test item .  (java-1_8_0-openjdk and java-1_8_0-ibm come from the repo of legacy.) 

- Related ticket: https://progress.opensuse.org/issues/36339
- Verification run: http://openqa-apac1.suse.de/tests/1157
