### PR TITLE
Fix zypper call adding repos

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -266,8 +266,6 @@ sub is_repo_replacement_required {
     return is_opensuse()                  # Is valid scenario onlu for openSUSE
       && !is_staging()                    # Do not have mirrored repos on staging
       && !get_var('KEEP_ONLINE_REPOS')    # Set variable no to replace variables
-      && !is_updates_tests()              # Is not required for update and upgrade tests, repos are already injected
-      && !is_upgrade()
       && get_var('SUSEMIRROR')            # Skip if required variable is not set (leap live tests)
       && !get_var('OFFLINE_SUT');         # Do not run if SUT is offine
 }

--- a/tests/console/zypper_ar.pm
+++ b/tests/console/zypper_ar.pm
@@ -8,7 +8,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: harmorize zypper_ref between SLE and openSUSE
+# Summary: Add repos from corresponding mirror only if do not exist
 # Maintainer: Max Lin <mlin@suse.com>
 
 use base "consoletest";
@@ -25,7 +25,7 @@ sub run {
         foreach (@repos_to_add) {
             next unless get_var("REPO_$_");    # Skip repo if not defined
             $repourl = $urlprefix . "/" . get_var("REPO_$_");
-            zypper_call "ar -c $repourl $_";
+            assert_script_run "zypper lr | grep -w $_ || zypper ar -c $repourl $_";    # Skip add repo if already added
         }
     }
     else {


### PR DESCRIPTION
Correct #5166 as zypper_call does not make sense to pass it pipes by parameters because has internal handling of that ignoring all after the pipe, so grep was ignored in previous PR. In this way is more clear an maintainable.

- Related ticket: https://progress.opensuse.org/issues/36829
- Verification run: 
  - [opensuse-Tumbleweed-NET-x86_64-Build20180605-zdup_tw2twnext_gnome@64bit ](http://dhcp254.suse.cz/tests/1567#step/zypper_ar/8)
  - [opensuse-Tumbleweed-DVD-x86_64-Build20180605-cryptlvm@64bit ](http://dhcp254.suse.cz/tests/1566#step/zypper_ar/8)
