### PR TITLE
Add repo source to yast2_cmdline module to test network & http rpms

### DIFF
--- a/tests/console/yast2_cmdline.pm
+++ b/tests/console/yast2_cmdline.pm
@@ -14,6 +14,8 @@
 use base "console_yasttest";
 use strict;
 use testapi;
+use utils 'zypper_call';
+use repo_tools 'prepare_source_repo';
 
 # Executes the command line tests from a yast repository (in master or in the
 # given optional branch) using prove
@@ -42,6 +44,8 @@ sub run_yast_cli_test {
 sub run {
     select_console 'root-console';
 
+    prepare_source_repo;
+
     # Install test requirement
     assert_script_run 'zypper -n in rpm-build';
 
@@ -50,7 +54,7 @@ sub run {
 
     # Run YaST CLI tests
     run_yast_cli_test('yast2-network');
-    run_yast_cli_test('yast2-dns-server');
+    run_yast_cli_test('yast2-http-server');
 }
 
 1;


### PR DESCRIPTION
- Related ticket: [[functional][y][yast] Add yast2_ui_devel scenario (was: please remove yast2_cmdline from 42.3 test plan)](https://progress.opensuse.org/issues/20206)
- Verification runs: 
[sle-15-Installer-DVD-x86_64-Build661.1-yast2_ui_devel@64bit-minimal_with_sdk661.1_installed](http://dhcp151.suse.cz/tests/3508)
[sle-15-Installer-DVD-x86_64-Build665.2-allpatterns@64bit](http://dhcp151.suse.cz/tests/3512#step/zypper_info/10)
[sle-12-SP4-Server-DVD-x86_64-Build0254-allpatterns@64bit](http://dhcp151.suse.cz/tests/3513#step/zypper_info/10)

I have not found any test for openSuSE