### PR TITLE
Don't do Aarch64 workaround if UEFI_PFLASH_VARS is present

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -383,7 +383,8 @@ sub wait_boot {
         # booted so we have to handle that
         # because of broken firmware, bootindex doesn't work on aarch64 bsc#1022064
         push @tags, 'inst-bootmenu' if ((get_var('USBBOOT') and get_var('UEFI')) || (check_var('ARCH', 'aarch64') and get_var('UEFI')) || get_var('OFW'));
-        $self->handle_uefi_boot_disk_workaround if (get_var('MACHINE') =~ /aarch64/ && get_var('UEFI') && get_var('BOOT_HDD_IMAGE') && !$in_grub);
+        $self->handle_uefi_boot_disk_workaround
+          if (get_var('MACHINE') =~ /aarch64/ && get_var('UEFI') && get_var('BOOT_HDD_IMAGE') && !$in_grub && !get_var('UEFI_PFLASH_VARS'));
         check_screen(\@tags, $bootloader_time);
         if (match_has_tag("bootloader-shim-import-prompt")) {
             send_key "down";


### PR DESCRIPTION
With the QEMU backend refactor, three new variables have been introduced for
configuring UEFI firmware on pflash drives:

UEFI_PFLASH_CODE - Specifies the file containing the read-only UEFI firmware
code.
UEFI_PFLASH_VARS - Specifies the file which contains the UEFI firmware
variables.
PUBLISH_PFLASH_VARS - Specifies the name of the file to publish the pflash
variables to which can be used in a chained test.

If the VARS file is present then there is no need to perform the aarch64
workaround because the VARS file should contain the correct device to boot
from.

https://github.com/os-autoinst/os-autoinst/pull/942
https://progress.opensuse.org/issues/35431
