### PR TITLE
Check first fs in list when adding partition

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -122,6 +122,7 @@ sub addpart {
             wait_still_screen 1;
             send_key((is_storage_ng) ? 'alt-f' : 'alt-s');
             wait_screen_change { send_key 'home' };    # start from the top of the list
+            assert_screen 'partition-selected-ext2-type', timeout => 10;    # 1. fs in the list
             send_key_until_needlematch "partition-selected-$args{format}-type", 'down', 10, 5;
         }
     }
@@ -129,9 +130,9 @@ sub addpart {
     if ($args{enable_snapshots} && $args{format} eq 'btrfs') {
         send_key_until_needlematch('partition-btrfs-snapshots-enabled', $cmd{enable_snapshots});
     }
-    if ($args{fsid}) {                                 # $args{fsid} will describe needle tag below
-        send_key 'alt-i';                              # select File system ID
-        send_key 'home';                               # start from the top of the list
+    if ($args{fsid}) {                                                      # $args{fsid} will describe needle tag below
+        send_key 'alt-i';                                                   # select File system ID
+        send_key 'home';                                                    # start from the top of the list
         if ($args{role} eq 'raw' && !check_var('VIDEOMODE', 'text')) {
             record_soft_failure('bsc#1079399 - Combobox is writable');
             for (1 .. 10) { send_key 'up'; }


### PR DESCRIPTION
- Related ticket: [[sle][functional][y][fast] test fails in partitioning_warnings - file system selection got changed to ext2 after btrfs got checked before](https://progress.opensuse.org/issues/36637)
- Verification run: [sle-15-Installer-DVD-aarch64-Build665.1-btrfs+warnings@aarch64](http://dhcp151.suse.cz/tests/3400)
