### PR TITLE
Fix smt-sync timeout issue

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -27,10 +27,10 @@ sub smt_wizard {
     assert_screen 'smt-wizard-1';
     send_key 'alt-u';
     wait_still_screen;
-    type_string 'SCC_ORG_DAJJBA';
+    type_string(get_required_var('SMT_ORG_NAME'));
     send_key 'alt-p';
     wait_still_screen;
-    type_string '043107d3db';
+    type_string(get_required_var('SMT_ORG_PASSWORD'));
     send_key 'alt-n';
     assert_screen 'smt-wizard-2';
     send_key 'alt-d';
@@ -59,7 +59,7 @@ sub smt_wizard {
         assert_screen 'smt-sync-failed', 100;    # expect fail because there is no network
         send_key 'alt-o';
     }
-    wait_serial("yast2-smt-wizard-0", 400) || die 'smt wizard failed';
+    wait_serial("yast2-smt-wizard-0", 800) || die 'smt wizard failed, it can be connection issue or credential issue';
 }
 
 sub smt_mirror_repo {
@@ -81,9 +81,9 @@ sub rmt_wizard {
     # check mysql status and config mysql for RMT
     systemctl 'start mysql.service';
     systemctl 'status mysql.service';
-    my $cmd = 'mysql -u root -p <<EOFF 
-GRANT ALL PRIVILEGES ON \`rmt\`.* TO rmt@localhost IDENTIFIED BY \'rmt\'; 
-FLUSH PRIVILEGES; 
+    my $cmd = 'mysql -u root -p <<EOFF
+GRANT ALL PRIVILEGES ON \`rmt\`.* TO rmt@localhost IDENTIFIED BY \'rmt\';
+FLUSH PRIVILEGES;
 EOFF';
     type_string "$cmd\n";
     assert_screen('rmt-sqladmin-password', 40);

--- a/tests/x11/smt.pm
+++ b/tests/x11/smt.pm
@@ -22,7 +22,7 @@ sub run {
     x11_start_program('xterm -geometry 150x35+5+5', target_match => 'xterm');
     become_root;
     smt_wizard();
-    assert_script_run 'smt-sync', 600;
+    assert_script_run 'smt-sync', 800;
     assert_script_run 'smt-repos';
 
     # mirror and sync a base repo from SCC


### PR DESCRIPTION
- run btrfs-balance.sh to prevent high load in background
- disable screensaver
- use credential for openQA which works better for smt
- more details:
  https://progress.opensuse.org/issues/34897
- verification run:
  http://e13.suse.de/tests/2690