### PR TITLE
Create encrypted partition to verify disk activation on zVM

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -211,6 +211,26 @@ sub show_debug {
     type_string "reset\n";
 }
 
+sub create_encrypted_part {
+    my $self = shift;
+    # activate install-shell to do pre-install dasd-format
+    select_console('install-shell');
+
+    # bring dasd online
+    # exit status 0 -> everything ok
+    # exit status 8 -> unformatted but still usable (e.g. from previous testrun)
+    my $r = script_run("dasd_configure 0.0.0150 1");
+    die "DASD in undefined state" unless (defined($r) && ($r == 0 || $r == 8));
+    # create partition table
+    assert_script_run 'parted -s /dev/dasda mklabel gpt';
+    # create single partition
+    assert_script_run 'parted -s /dev/dasda mkpart 512 100%';
+    # encrypt created partition
+    assert_script_run 'echo nots3cr3t | cryptsetup luksFormat -q --type luks2 --force-password /dev/dasda1';
+    # bring DASD down again to test the activation during the installation
+    assert_script_run("dasd_configure 0.0.0150 0");
+}
+
 sub format_dasd {
     my $self = shift;
     my $r;
@@ -285,6 +305,7 @@ sub run {
 
     # format DAST before installation by default
     format_dasd if (check_var('FORMAT_DASD', 'pre_install'));
+    create_encrypted_part if get_var('ENCRYPT_ACTIVATE_EXISTING');
 
     select_console("installation");
 


### PR DESCRIPTION
We have technical limitation with zVM, as those are bare metal machines.
To test encrypted partitions we need to run 2 jobs sequentially which
cannot be guaranteed if machine is used for other jobs.
To still cover this scenario on zVM, we create empty encrypted partition
which then we activate.

See [poo#35959](https://progress.opensuse.org/issues/35959).

- [Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/867)
- [Verification run](http://g226.suse.de/tests/1883#)
