### PR TITLE
Fix conditions for snapshot screen check

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -82,7 +82,7 @@ sub boot_into_snapshot {
     send_key_until_needlematch('boot-menu-snapshot', 'down', 10, 5);
     send_key 'ret';
     # assert needle to avoid send down key early in grub_test_snapshot.
-    assert_screen 'snap-default' if get_var('OFW');
+    assert_screen 'snap-default' if (get_var('OFW') && get_var('ROLLBACK_AFTER_MIGRATION'));
     # in upgrade/migration scenario, we want to boot from snapshot 1 before migration.
     if ((get_var('UPGRADE') && !get_var('ONLINE_MIGRATION', 0)) || get_var('ZDUP')) {
         send_key_until_needlematch('snap-before-update', 'down', 40, 5);


### PR DESCRIPTION
Added ROLLBACK_AFTER_MIGRATION to the conditions to prevent this
breaking our tests, but also to keep the fix for our apac colleagues

- Related ticket: https://progress.opensuse.org/issues/36271

Original PR which broke our tests:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4988
