### PR TITLE
zypper_clear_repos: only run sed with at least one matched file

### DIFF
--- a/tests/update/zypper_clear_repos.pm
+++ b/tests/update/zypper_clear_repos.pm
@@ -34,7 +34,7 @@ sub run {
         # With FATE#320494 the local repository would be disabled after installation
         # in Staging, enable it here.
         clear_console;
-        assert_script_run("grep -rl 'baseurl=cd:///?devices' $repos_folder | xargs sed -i 's/^enabled=0/enabled=1/g'");
+        assert_script_run("grep -rl 'baseurl=cd:///?devices' $repos_folder | xargs --no-run-if-empty sed -i 's/^enabled=0/enabled=1/g'");
         script_run("zypper lr -d");
         save_screenshot;    # take a screenshot after repo enabled
     }


### PR DESCRIPTION
Fixes issues newly seen in Staging:

https://openqa.opensuse.org/tests/688549#step/zypper_clear_repos/14

(so far this did not happen in staging, as we did not have any USBBoot enabled tests; test was added to better get a feel for product-builder changes