### PR TITLE
Do not schedule zypper_clear_repos twice

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1006,8 +1006,10 @@ sub load_consoletests {
     loadtest 'console/enable_usb_repo' if check_var('USBBOOT', 1);
 
     # Do not clear repos twice if replace repos for openSUSE
-    if (need_clear_repos() && !is_repo_replacement_required()) {
+    # On staging repos are already removed, using CLEAR_REPOS flag variable
+    if (need_clear_repos() && !is_repo_replacement_required() && !get_var('CLEAR_REPOS')) {
         loadtest "update/zypper_clear_repos";
+        set_var('CLEAR_REPOS', 1);
     }
     #have SCC repo for SLE product
     if (have_scc_repos()) {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -252,6 +252,7 @@ sub load_system_update_tests {
     return unless updates_is_applicable;
     if (need_clear_repos) {
         loadtest "update/zypper_clear_repos";
+        set_var('CLEAR_REPOS', 1);
     }
 
     if (get_var('ZYPPER_ADD_REPOS')) {


### PR DESCRIPTION
On staging we call load_system_update_tests which already schedules
repos removal. So we should not call is second time.

Fixes schedule for openSUSE staging.

- [Verification run](http://g226.suse.de/tests/1884).
