### PR TITLE
Prevent any record_soft_failure which does not link to any ticket reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ test-no-wait_idle:
 	@! git grep wait_idle lib/ tests/
 
 .PHONY: test
-test: tidy test-compile test-merge test-dry test-no-wait_idle test-unused-modules
+test: tidy test-compile test-merge test-dry test-no-wait_idle test-unused-modules test-record_soft_failure-no-reference
 
 PERLCRITIC=PERL5LIB=tools/lib/perlcritic:$$PERL5LIB perlcritic --quiet --gentle --include Perl::Critic::Policy::HashKeyQuote --include Perl::Critic::Policy::ConsistentQuoteLikeWords
 
@@ -84,3 +84,7 @@ perlcritic: tools/lib/
 .PHONY: test-unused-modules
 test-unused-modules:
 	tools/detect_unused_modules
+
+.PHONY: test-record_soft_failure-no-reference
+test-record_soft_failure-no-reference:
+	@! git grep -E -e 'record_soft_failure.*\;' --and --not -e '([$$0-9a-z]+#[$$0-9]+|fate.suse.com/[0-9]|\$$[a-z]+)' lib/ tests/

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -362,7 +362,7 @@ sub fill_in_registration_data {
                     qw(import-untrusted-gpg-key yast_scc-pkgtoinstall yast-scc-emptypkg inst-addon contacting-registration-server refreshing-repository)];
                 if (match_has_tag('import-untrusted-gpg-key')) {
                     if (!check_screen(\@known_untrusted_keys, 0)) {
-                        record_soft_failure 'untrusted gpg key';
+                        die 'untrusted gpg key';
                     }
                     wait_screen_change {
                         send_key 'alt-t';

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -869,7 +869,7 @@ sub addon_license {
         do {
             assert_screen \@tags;
             if (match_has_tag('import-untrusted-gpg-key')) {
-                record_soft_failure 'untrusted gpg key';
+                record_info 'untrusted gpg key', "Trusting untrusted GPG key", result => 'softfail';
                 wait_screen_change { send_key 'alt-t' };
             }
             elsif (match_has_tag("addon-betawarning-$addon")) {

--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -137,7 +137,7 @@ sub deal_with_dependency_issues {
 
     return unless check_screen 'manual-intervention', 10;
 
-    record_soft_failure 'dependency warning';
+    record_info 'dependency warning', "Dependency warning, working around dependency issues", result => 'fail';
 
     if (check_var('VIDEOMODE', 'text')) {
         send_key 'alt-c';    # Change

--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -64,7 +64,7 @@ sub run {
     # no package in the image comes from any repository - it's from the image. So we
     # hard-code 'sles-release' package, and it... works. Somehow.
     if (!$package && is_jeos) {
-        record_soft_failure "Hardcoding 'sles-release' package for lifecycle check";
+        record_info 'Workaround', "Hardcoding 'sles-release' package for lifecycle check", result => 'softfail';
         $package = 'sles-release';
     }
     die "No suitable package found. Script output:\nOutput: '$output'" unless $package;

--- a/tests/installation/addon_products_yast2.pm
+++ b/tests/installation/addon_products_yast2.pm
@@ -52,7 +52,7 @@ sub run {
                 send_key 'alt-o';                                                   # continue
             }
             if (check_screen('import-untrusted-gpg-key', 10)) {                     # workaround untrusted key pop-up, record soft fail and trust it
-                record_soft_failure;
+                record_info 'untrusted key', 'Workaround untrusted key by accepting it', result => 'softfail';
                 send_key 'alt-t';
             }
             if (get_var("BETA_$uc_addon")) {
@@ -79,7 +79,7 @@ sub run {
             do {
                 assert_screen \@needles, 300;
                 if (match_has_tag('unsupported-packages')) {
-                    record_soft_failure 'unsuppoorted packages';
+                    die 'unsupported packages';
                     send_key 'alt-o';
                 }
                 if (match_has_tag('addon-installation-pop-up')) {

--- a/tests/installation/skip_registration.pm
+++ b/tests/installation/skip_registration.pm
@@ -32,7 +32,7 @@ sub run {
     );
     if (match_has_tag('yast2-windowborder-corner')) {
         if (check_var("INSTALLER_NO_SELF_UPDATE", 1)) {
-            die "installer should not self-update, therefore window should not have respawned, file bug and replace this line by record_soft_failure";
+            die "installer should not self-update, therefore window should not have respawned, file bug and replace this line with a soft-fail";
         }
         elsif (check_var('INSTALLER_SELF_UPDATE', 1)) {
             ensure_fullscreen(tag => 'yast2-windowborder-corner');

--- a/tests/installation/sles4sap_wizard_swpm.pm
+++ b/tests/installation/sles4sap_wizard_swpm.pm
@@ -26,8 +26,8 @@ sub run {
     send_key 'alt-o';        # Ok
     send_key $cmd{next};
     if (check_screen('sles4sap-wizard-no-space-left')) {
-        send_key 'alt-o';       #Okay
-        record_soft_failure;    #this is a bug, there is plenty of space
+        send_key 'alt-o';    #Okay
+        die 'this is a bug, there is plenty of space';
     }
     assert_screen "sles4sap-wizard-swpm-overview";    #the same screen as at the beginning of sles4sap_wizard_swpm
     send_key $cmd{next};

--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -70,11 +70,6 @@ sub run {
         # confirm
         assert_screen 'startupdate';
         send_key $cmd{update};
-
-        if (check_screen('ERROR-bootloader_preupdate', 3)) {
-            send_key 'alt-n';
-            record_soft_failure 'error bootloader preupdate';
-        }
         assert_screen "inst-packageinstallationstarted", $started_timeout;
 
         # view installation details

--- a/tests/installation/upgrade_select_opensuse.pm
+++ b/tests/installation/upgrade_select_opensuse.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -26,7 +26,7 @@ sub check_bsc997635 {
 
 sub handle_beta_warning {
     if (!get_var("BETA")) {
-        record_soft_failure "Beta warning in non beta product";
+        die "Beta warning in non beta product";
     }
     send_key 'alt-o';
 }
@@ -46,7 +46,7 @@ sub run {
             handle_beta_warning;
         }
         elsif (get_var("BETA")) {
-            record_soft_failure('missing beta warning even though BETA is set');
+            die 'missing beta warning even though BETA is set';
         }
         # Bug 881107 - there is 2nd license agreement screen in openSUSE upgrade
         # http://bugzilla.opensuse.org/show_bug.cgi?id=881107
@@ -57,7 +57,7 @@ sub run {
 
     if (check_screen(["installed-product-incompatible", "inst-betawarning"], 10)) {
         if (match_has_tag 'installed-product-incompatible') {
-            record_soft_failure 'installed product incompatible';
+            record_info 'installed product incompatible', result => 'fail';
             send_key 'alt-o';
         }
         else {

--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -109,7 +109,7 @@ sub run {
     while ($out) {
         if ($out =~ $zypper_dup_conflict) {
             if (get_var("WORKAROUND_DEPS")) {
-                record_soft_failure 'workaround dependencies';
+                record_info 'workaround dependencies';
                 send_key '1';
                 send_key 'ret';
             }
@@ -163,9 +163,6 @@ sub run {
             next;
         }
         elsif ($out =~ $zypper_dup_fileconflict) {
-            #             record_soft_failure;
-            #             send_key 'y';
-            #             send_key 'ret';
             $self->result('fail');
             save_screenshot;
             return;

--- a/tests/x11/evolution/evolution_smoke.pm
+++ b/tests/x11/evolution/evolution_smoke.pm
@@ -1,6 +1,6 @@
 # Evolution tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -50,7 +50,7 @@ sub run {
         last if (match_has_tag('evolution_mail-auth'));
         # if evolution still hangs on folders scanning after 10 tries, try another mail provider
         if ($time_counter == 10) {
-            record_soft_failure("Server is not responding, trying backup email provider.");
+            record_info('Connection problem', "Server is not responding, trying backup email provider.");
             my $mail_box = 'nooops_test3@gmx.com';
             evolution_wizard($self, $mail_box);
             assert_screen "evolution_mail-auth";


### PR DESCRIPTION
Our convention is to only use record_soft_failure in combination with a valid
bug reference, a ticket reference or also a fate link to prevent soft-failing
test cases which no one cares to make passed because there is simply no ticket
in any other issue management tool. This commit introduces a new check to
prevent inclusion of any new record_soft_failure without these valid
references.