### PR TITLE
Fix regexp for linux command in some archs

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -106,7 +106,7 @@ sub add_custom_grub_entries {
     die("Unexpected number of grub entries: $cnt_new, expected: " . ($cnt_orig * 2)) if ($cnt_orig * 2 != $cnt_new);
     $cnt_new = script_output("grep -c 'menuentry .$distro.*($grub_param)' /boot/grub2/grub.cfg");
     die("Unexpected number of new grub entries: $cnt_new, expected: " . ($cnt_orig)) if ($cnt_orig != $cnt_new);
-    $cnt_new = script_output("grep -c 'linux.*/boot/vmlinu.* $grub_param ' /boot/grub2/grub.cfg");
+    $cnt_new = script_output("grep -c 'linux.*/boot/.* $grub_param ' /boot/grub2/grub.cfg");
     die("Unexpected number of new grub entries with '$grub_param': $cnt_new, expected: " . ($cnt_orig)) if ($cnt_orig != $cnt_new);
 }
 


### PR DESCRIPTION
add_custom_grub_entries() adds new boot options into /boot/grub2/grub.cfg
and check changes. Some archs has different name of kernel image:

* aarch64-virtio
linux	/boot/Image-4.12.14-23-default root=UUID=f2eab56d-b670-4dde-b7d4-eb766834a2ca  ${extra_cmdline} plymouth.ignore-serial-consoles console=ttyAMA0 console=tty splash=silent showopts
* s390x-kvm-sle12:
linux	${btrfs_subvol}/boot/image-4.12.14-94.27-default root=/dev/vda3 ima_policy=tcb  ${extra_cmdline} hvc_iucv=8 TERM=dumb resume=/dev/disk/by-path/ccw-0.0.0000-part2 crashkernel=112M

=> we need to grep just for linux.*/boot/.*

Verified on restarted jobs:
http://pinotage-4.arch.suse.de/tests/9 (aarch64)
http://quasar.suse.cz/tests/381 (64bit)