### PR TITLE
Improve iscsi MM test synchronization

### DIFF
--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -35,9 +35,9 @@ sub run {
     wait_still_screen(2, 10);
     assert_screen 'iscsi-initiator-service';
     send_key "alt-v";             # go to discovered targets tab
-    wait_still_screen(2, 10);
+    assert_screen 'iscsi-discovered-targets';
     send_key "alt-d";             # press discovery button
-    wait_still_screen(2, 10);
+    assert_screen 'iscsi-discovery';
     send_key "alt-i";             # go to IP address field
     wait_still_screen(2, 10);
     type_string "10.0.2.1";

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -31,7 +31,7 @@ sub run {
     configure_static_dns(get_host_resolv_conf());
     zypper_call 'in yast2-iscsi-lio-server';
     assert_script_run 'dd if=/dev/zero of=/root/iscsi-disk seek=1M bs=8192 count=1';    # create iscsi LUN
-    type_string "yast2 iscsi-lio-server\n";
+    type_string "yast2 iscsi-lio-server; echo yast2-iscsi-server-\$? > /dev/$serialdev\n";
     assert_screen 'iscsi-lio-server';
     send_key 'alt-o';                                                                   # open port in firewall
     wait_still_screen(2, 10);
@@ -82,7 +82,7 @@ sub run {
     }
     assert_screen 'iscsi-target-overview-target-tab';
     send_key 'alt-f';                                                                   # finish
-    wait_still_screen(2, 10);
+    wait_serial("yast2-iscsi-server-0", 180) || die "'yast2 iscsi-lio ' didn't finish or exited with non-zero code";
     mutex_create('iscsi_ready');                                                        # setup is done client can connect
     type_string "killall xterm\n";
     wait_for_children;                                                                  # run till client is done


### PR DESCRIPTION
There are multiple issues with test suite. First one which is most
likely causing random false positives is that we don't wait till iscsi
server wizard returns, hence in case of low performance (e.g. btrfs
balance), we may not wait till server is configured before trying to
connect to the client.

On the client side we didn't assert that actions happened, confusing
reviewer by expected screen which is 2 dialogs away from the failed
screen.

See [poo#36730](https://progress.opensuse.org/issues/36730).

- [Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/869).
- Verification runs:
  * [iscsi_server](http://gershwin.arch.suse.de/tests/523#) 
  * [iscsi_client](http://gershwin.arch.suse.de/tests/524#) 
