### PR TITLE
 Remove record_soft_failure 'bsc#1081584' from updates_packagekit_gpk

### DIFF
--- a/data/autoyast_sle15/autoyast_btrfs.xml
+++ b/data/autoyast_sle15/autoyast_btrfs.xml
@@ -138,6 +138,7 @@
       <package>kdump</package>
       <package>sles-release</package>
       <package>kexec-tools</package>
+      <package>gnome-packagekit</package>
     </packages>
     <patterns config:type="list">
       <pattern>apparmor</pattern>

--- a/data/autoyast_sle15/autoyast_ext4.xml
+++ b/data/autoyast_sle15/autoyast_ext4.xml
@@ -88,6 +88,7 @@
       <package>kdump</package>
       <package>sles-release</package>
       <package>kexec-tools</package>
+      <package>gnome-packagekit</package>
     </packages>
     <patterns config:type="list">
       <pattern>apparmor</pattern>

--- a/data/autoyast_sle15/autoyast_gnome.xml
+++ b/data/autoyast_sle15/autoyast_gnome.xml
@@ -67,6 +67,7 @@
     <packages config:type="list">
       <package>grub2</package>
       <package>sles-release</package>
+      <package>gnome-packagekit</package>
     </packages>
     <patterns config:type="list">
       <pattern>apparmor</pattern>

--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -42,13 +42,7 @@ sub tell_packagekit_to_quit {
 # Update with GNOME PackageKit Update Viewer
 sub run {
     my ($self) = @_;
-    if (is_sle '15+') {
-        select_console 'root-console';
-        zypper_call("in gnome-packagekit", timeout => 90);
-        record_soft_failure 'bsc#1081584';
-    }
     select_console 'x11', await_console => 0;
-
     my @updates_tags = qw(updates_none updates_available package-updater-privileged-user-warning updates_restart_application updates_installed-restart);
     my @updates_installed_tags = qw(updates_none updates_installed-logout updates_installed-restart updates_restart_application);
 


### PR DESCRIPTION
[bsc#1081584](https://bugzilla.suse.com/show_bug.cgi?id=1081584)
got resolved, so we can remove soft-failure. 
But we run updates_packagekit_gpk for some AY tests and
hence need to add package, so we can safely remove workaround.

See [poo#36991](https://progress.opensuse.org/issues/36991).
[Verification run](http://g226.suse.de/tests/1885#step/updates_packagekit_gpk/1).

