### PR TITLE
Product classification for testing docker seccomp

### DIFF
--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -28,14 +28,29 @@ use testapi;
 use utils;
 use strict;
 use registration;
+use version_utils qw(is_sle is_leap);
+
+sub test_seccomp {
+    my $no_seccomp = script_run('docker info | tee /dev/tty | grep seccomp');
+    if ($no_seccomp) {
+        my $err_seccomp_support = 'boo#1072367 - Docker Engine does NOT have seccomp support';
+        if (is_sle('<15') || is_leap('<15.0')) {
+            record_info('WONTFIX', $err_seccomp_support);
+        }
+        else {
+            die($err_seccomp_support);
+        }
+    }
+    else {
+        record_info('seccomp', 'Docker Engine supports seccomp');
+    }
+}
 
 sub run {
     select_console("root-console");
 
     install_docker_when_needed;
-
-    # boo#1072367 - docker engine doesn't have seccomp support
-    assert_script_run('docker info | tee /dev/tty | grep seccomp');
+    test_seccomp;
 
     # images can be searched on the Docker Hub
     validate_script_output("docker search --no-trunc opensuse", sub { m/This project contains the stable releases of the openSUSE distribution/ });


### PR DESCRIPTION
This bug is not going to be fixed for any SLE12 system. Thus
we will capture this using `soft_fail` instead of `die`.

- Related ticket: https://progress.opensuse.org/issues/36964
- Needles: *not needed*
- Verification run:

* SLE12-SP3: http://skyrim.qam.suse.de/tests/3350#step/docker/14
* MicroOS: http://skyrim.qam.suse.de/tests/3349#step/docker/12
