### PR TITLE
install_packages: handle conflict between cloud-netconfig-ec2, cloud-…

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -167,6 +167,8 @@ sub problem_can_be_skipped {
     return 1 if $pkg =~ /^python-talloc-devel/;
     # conflict with the non-qt5
     return 1 if $pkg =~ /^(python(|3)-)?opencv-qt5/;
+    # conflict with cloud-netconfig-ec2
+    return 1 if $pkg =~ /^cloud-netconfig-azure/;
 
     return;
 }


### PR DESCRIPTION
install_packages: handle conflict between cloud-netconfig-ec2, cloud-netconfig-azure

To test:
`data/lsmfip --verbose cloud-netconfig-ec2 cloud-netconfig-azure`

Fixes:
https://openqa.opensuse.org/tests/689626#step/install_packages/9
https://openqa.opensuse.org/tests/689627#step/install_packages/9
https://openqa.opensuse.org/tests/689628#step/install_packages/9