### PR TITLE
Remove soft-failure for Evolution skip look up button

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -352,12 +352,6 @@ sub start_evolution {
     wait_screen_change { type_string "$mail_box" };
     save_screenshot();
 
-    # skip server look up for localhost email address
-    if ($mail_box =~ /localhost/) {
-        record_soft_failure 'bsc#1049387 - Evolution Skip lookup button sometimes doesn\'t work';
-        assert_and_click "evolution-mail-skip-look-up-checkbox";
-        save_screenshot();
-    }
     send_key $self->{next};
 }
 


### PR DESCRIPTION
Fix poo#37093: Fix for bsc#1049387 was created and released, soft-failure
can be deleted.

- Related ticket: https://progress.opensuse.org/issues/37093
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/870
- Verification run: http://10.100.12.105/tests/2196
