### PR TITLE
replace generic needle text-login in copy_iso_to_external_drive.pm

### DIFF
--- a/tests/console/copy_iso_to_external_drive.pm
+++ b/tests/console/copy_iso_to_external_drive.pm
@@ -43,7 +43,7 @@ sub run {
 sub post_run_hook {
     #prepare environment for next test
     type_string "logout\n";
-    assert_screen "text-login";
+    select_console 'root-console';
     select_console "x11";
 }
 


### PR DESCRIPTION
- tty$-selected should be matched now, see poo#34471 for details
- replace assert_screen 'text_login' sub post_run_hook by
  select_console 'root-console'
- verification:
  http://e13.suse.de/tests/2731#step/copy_iso_to_external_drive

