### PR TITLE
Don't allow grep as zypper_call parameter

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -618,7 +618,7 @@ sub rename_scc_addons {
 sub install_docker_when_needed {
     if (is_caasp) {
         # Docker should be pre-installed in MicroOS
-        die 'Docker is not pre-installed.' if zypper_call('se -x --provides -i docker | grep docker', allow_exit_codes => [0, 1]);
+        die 'Docker is not pre-installed.' unless zypper_call('se -x --provides -i docker');
     }
     else {
         if (is_sle('<15')) {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -345,6 +345,7 @@ sub zypper_call {
     my $dumb_term        = $args{dumb_term};
 
     my $printer = $log ? "| tee /tmp/$log" : $dumb_term ? '| cat' : '';
+    die 'Exit code is from PIPESTATUS[0], not grep' if $command =~ /^((?!`).)*\| ?grep/;
 
     # Retrying workarounds
     my $ret;

--- a/tests/console/repo_package_install.pm
+++ b/tests/console/repo_package_install.pm
@@ -29,7 +29,7 @@ sub run {
     return unless sle_version_at_least('15');
     for my $package (keys %packages) {
         my $args = $packages{$package}->{installed} ? '--installed-only' : '--not-installed-only';
-        zypper_call('se ' . $args . ' --match-exact --details ' . $package . ' | grep ' . $packages{$package}->{repo});
+        assert_script_run("zypper se -n $args --match-exact --details $package | grep " . $packages{$package}->{repo});
     }
 }
 


### PR DESCRIPTION
Prevent people from using grep as zypper_call parameter.
Construct won't work, grep exit status is not considered.
```
if (zypper_call "se -i $pkg | grep $text")..
```

Only zypper exit status is handled properly.

Local runs: http://dhcp165.suse.cz/tests/5689#step/first_boot/13