### PR TITLE
install_packages: handle conflict between providers of skelcd-installer

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -169,6 +169,8 @@ sub problem_can_be_skipped {
     return 1 if $pkg =~ /^(python(|3)-)?opencv-qt5/;
     # conflict with cloud-netconfig-ec2
     return 1 if $pkg =~ /^cloud-netconfig-azure/;
+    # conflicts with otherproviders(skelcd-installer), skelcd-installer-openSUSE
+    return 1 if $pkg =~ /^skelcd-installer-net-openSUSE/;
 
     return;
 }


### PR DESCRIPTION
install_packages: handle conflict between providers of skelcd-installer

`skelcd-installer-openSUSE` conflicts with `skelcd-installer-net-openSUSE`

to test:
`data/lsmfip --verbose tftpboot-installation-openSUSE-Leap-15.0-x86_64 install-initrd-openSUSE skelcd-installer-openSUSE installation-images-debuginfodeps-openSUSE skelcd-installer-net-openSUSE`

Fixes:
https://openqa.opensuse.org/tests/690116#step/install_packages/9
https://openqa.opensuse.org/tests/690117#step/install_packages/9
https://openqa.opensuse.org/tests/690118#step/install_packages/9

Test maintainer: @coolo 
