### PR TITLE
New tests for apparmor aa_status, aa_enforce and SECURITY env

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -101,6 +101,7 @@ our @EXPORT = qw(
   load_security_tests_web
   load_security_tests_misc
   load_security_tests_crypt
+  load_security_tests_apparmor_status
   load_systemd_patches_tests
   load_create_hdd_tests
   load_virtualization_tests
@@ -1734,6 +1735,11 @@ sub load_security_tests_crypt {
     loadtest "console/yast2_dm_crypt";
     loadtest "console/cryptsetup";
     loadtest "console/consoletest_finish";
+}
+
+# Other security tests other than FIPS
+sub load_security_tests_apparmor_status {
+    loadtest "security/apparmor/aa_status";
 }
 
 sub load_systemd_patches_tests {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1740,6 +1740,7 @@ sub load_security_tests_crypt {
 # Other security tests other than FIPS
 sub load_security_tests_apparmor_status {
     loadtest "security/apparmor/aa_status";
+    loadtest "security/apparmor/aa_enforce";
 }
 
 sub load_systemd_patches_tests {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -407,6 +407,9 @@ elsif (get_var('SECURITYTEST')) {
     elsif (check_var('SECURITYTEST', 'crypt')) {
         load_security_tests_crypt;
     }
+    elsif (check_var("SECURITYTEST", "apparmor_status")) {
+        load_security_tests_apparmor_status;
+    }
 }
 elsif (get_var('SYSTEMD_TESTSUITE')) {
     load_systemd_patches_tests;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -796,6 +796,15 @@ elsif (get_var("FIPS_TS")) {
         load_applicationstests;
     }
 }
+elsif (get_var('SECURITY')) {
+    prepare_target();
+    if (get_var('BOOT_HDD_IMAGE')) {
+        loadtest "console/consoletest_setup";
+    }
+    if (check_var("SECURITY", "apparmor_status")) {
+        load_security_tests_apparmor_status;
+    }
+}
 elsif (get_var('SMT')) {
     prepare_target();
     loadtest "x11/smt_disconnect_prepare";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -764,7 +764,7 @@ elsif (get_var("SUPPORT_SERVER")) {
 elsif (get_var("SLEPOS")) {
     load_slepos_tests();
 }
-elsif (get_var("FIPS_TS")) {
+elsif (get_var("FIPS_TS") || get_var("SECURITY")) {
     prepare_target();
     if (get_var('BOOT_HDD_IMAGE')) {
         loadtest "console/consoletest_setup";
@@ -795,13 +795,7 @@ elsif (get_var("FIPS_TS")) {
         # Load client tests by APPTESTS variable
         load_applicationstests;
     }
-}
-elsif (get_var('SECURITY')) {
-    prepare_target();
-    if (get_var('BOOT_HDD_IMAGE')) {
-        loadtest "console/consoletest_setup";
-    }
-    if (check_var("SECURITY", "apparmor_status")) {
+    elsif (check_var("SECURITY", "apparmor_status")) {
         load_security_tests_apparmor_status;
     }
 }

--- a/tests/security/apparmor/aa_status.pm
+++ b/tests/security/apparmor/aa_status.pm
@@ -1,0 +1,46 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: apparmor tools testing - aa-status
+# Maintainer: Wes <whdu@suse.com>
+# Tags: poo#36874, tc#1621138
+
+use base "consoletest";
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    select_console 'root-console';
+
+    systemctl('restart apparmor');
+
+    validate_script_output "aa-status", sub {
+        m/
+        module\ is\ loaded.*
+        profiles\ are\ loaded.*
+        profiles\ are\ in\ enforce\ mode.*
+        profiles\ are\ in\ complain\ mode.*
+        processes\ are\ in\ enforce\ mode.*
+        processes\ are\ in\ complain\ mode.*
+        processes\ are\ unconfined/sxx
+    };
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Add case aa_status [poo#36874](https://progress.opensuse.org/issues/36874)
Add SECURITY env and call function
[poo#37006](https://progress.opensuse.org/issues/37006)

More cases will be submitted in future.

- Related ticket: https://progress.opensuse.org/issues/36874
- Related ticket: https://progress.opensuse.org/issues/37006
- Verification run:
  - SLES12SP4: http://10.67.17.9/tests/573
  - openSUSE Leap 15.0: http://10.67.17.9/tests/581
