### PR TITLE
Remove old comment "Accept 'text-login' by default

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -552,7 +552,6 @@ sub activate_console {
             # or when using remote consoles which can take some seconds, e.g.
             # just after ssh login
             assert_screen \@tags, 60;
-            # Accept 'text-login' by default
             if (match_has_tag("tty$nr-selected")) {
                 type_string "$user\n";
                 handle_password_prompt;


### PR DESCRIPTION
- see https://progress.opensuse.org/issues/34471, comment #29
- now we use needle tty$number-selected

