### PR TITLE
Mount shared memory to tmp if fs becomes read-only

### DIFF
--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -20,7 +20,7 @@ sub post_fail_hook {
     my ($self) = shift;
     select_console('log-console');
     $self->SUPER::post_fail_hook;
-
+    $self->remount_tmp_if_ro;
     # Export logs after failure
     assert_script_run("journalctl --no-pager -b 0 > /tmp/full_journal.log");
     upload_logs "/tmp/full_journal.log";

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -144,7 +144,7 @@ sub export_logs {
     my ($self) = shift;
     select_console 'log-console';
     save_screenshot;
-
+    $self->remount_tmp_if_ro;
     $self->problem_detection;
 
     $self->save_and_upload_log('cat /proc/loadavg', '/tmp/loadavg.txt', {screenshot => 1});
@@ -493,6 +493,18 @@ sub firewall {
     return ($old_product_versions || $upgrade_from_susefirewall) ? 'SuSEfirewall2' : 'firewalld';
 }
 
+=head2 remount_tmp_if_ro
+
+    remount_tmp_if_ro()
+
+Mounts /tmp to shared memory if not possible to write to tmp.
+For example, save_y2logs creates temporary files there.
+
+=cut
+sub remount_tmp_if_ro {
+    script_run 'touch /tmp/test_ro || mount -t tmpfs /dev/shm /tmp';
+}
+
 # useful post_fail_hook for any module that calls wait_boot
 #
 # we could use the same approach in all cases of boot/reboot/shutdown in case
@@ -504,6 +516,7 @@ sub post_fail_hook {
     # 'esc' just in case the plymouth splash screen is shown and we can not
     # see any interesting console logs.
     send_key 'esc';
+    save_screenshot;
 }
 
 1;

--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -258,7 +258,9 @@ sub post_fail_hook {
       environ
       smaps);
 
+    $self->SUPER::post_fail_hook;
     get_to_console;
+    $self->get_ip_address;
     $self->remount_tmp_if_ro;
     # Avoid collectin logs twice when investigate_yast2_failure() is inteded to hard-fail
     $self->save_upload_y2logs unless get_var('ASSERT_Y2LOGS');

--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -259,7 +259,7 @@ sub post_fail_hook {
       smaps);
 
     get_to_console;
-
+    $self->remount_tmp_if_ro;
     # Avoid collectin logs twice when investigate_yast2_failure() is inteded to hard-fail
     $self->save_upload_y2logs unless get_var('ASSERT_Y2LOGS');
 

--- a/tests/installation/keyboard_selection.pm
+++ b/tests/installation/keyboard_selection.pm
@@ -48,17 +48,4 @@ sub run {
     }
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
-    # system might be stuck on bootup showing only splash screen so we press
-    # esc to show console logs
-    send_key 'esc';
-    select_console('install-shell');
-    # in case we could not even reach the installer welcome screen and logs
-    # could not be collected on the serial output:
-    $self->save_upload_y2logs;
-    $self->get_ip_address;
-    upload_logs '/var/log/linuxrc.log';
-}
-
 1;

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -113,17 +113,4 @@ sub run {
     assert_screen 'languagepicked';
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
-    # system might be stuck on bootup showing only splash screen so we press
-    # esc to show console logs
-    send_key 'esc';
-    select_console('install-shell');
-    # in case we could not even reach the installer welcome screen and logs
-    # could not be collected on the serial output:
-    $self->save_upload_y2logs;
-    $self->get_ip_address;
-    upload_logs '/var/log/linuxrc.log';
-}
-
 1;


### PR DESCRIPTION
In one of the runs btrfs became read only and we were not able to
collect logs, so we could investigate issue further.
Now we try to create file under /tmp and mount /dev/shm in case command
fails. This will help in case non-btrfs gets read only as a fallback.

See [poo#35167](https://progress.opensuse.org/issues/35167).

- [Verification run](http://g226.suse.de/tests/1949#step/yast2_control_center/52) ro property is set to root and tmp, then test is failed with die call.
