### PR TITLE
snapper_cleanup: avoid to uselessly run into ENOSPC, poo#36838

### DIFF
--- a/tests/console/snapper_cleanup.pm
+++ b/tests/console/snapper_cleanup.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -14,7 +14,7 @@ use base 'btrfs_test';
 use strict;
 use testapi;
 use utils 'clear_console';
-use List::Util 'max';
+use List::Util qw(max min);
 
 my $exp_excl_space;
 my $btrfs_fs_usage = 'btrfs filesystem usage / --raw';
@@ -33,13 +33,13 @@ sub get_space {
     return max(@numbers);
 }
 sub snapper_cleanup {
+    my ($scratch_size_gb, $scratchfile_mb) = @_;
     my $snaps_numb = "snapper list | grep number | wc -l";
 
     script_run($btrfs_fs_usage);
     # we want to fill up disk enough so that snapper cleanup triggers
-    my $scratch_size_gb = 3;
-    my $fill_space      = 'dd if=/dev/urandom of=data bs=1M count=1024';
-    my $snap_create     = "snapper create --cleanup number --command '$fill_space'";
+    my $fill_space  = "dd if=/dev/urandom of=data bs=1M count=$scratchfile_mb";
+    my $snap_create = "snapper create --cleanup number --command '$fill_space'";
     assert_script_run "btrfs filesystem show --mbytes /";
 
     for (1 .. $scratch_size_gb) { assert_script_run("$snap_create", 500); }
@@ -51,11 +51,11 @@ sub snapper_cleanup {
     assert_script_run("snapper list");
     clear_console;
     script_run($btrfs_fs_usage);
-    # Get actual exckusive disk space to verify exclusive disk space is taken into account
+    # Get actual exclusive disk space to verify exclusive disk space is taken into account
     my $qgroup_excl_space = get_space("btrfs qgroup show  / --raw | grep 1/0 | awk -F ' ' '{print\$3}'");
     if ($qgroup_excl_space > $exp_excl_space) {
-        my $msg = "bsc#998360: Exclusive space is above user-defined limit: "
-          . "$exp_excl_space (expected exclusive disk space) < $qgroup_excl_space (expected exclusive disk space)";
+        my $msg = "bsc#998360: qgroup 1/0: Exclusive space is above user-defined limit:\n"
+          . "$exp_excl_space (expected exclusive disk space) < $qgroup_excl_space (consumed exclusive disk space)";
         if (check_var('VERSION', '12-SP2')) {
             record_soft_failure $msg;
         }
@@ -70,20 +70,68 @@ sub run {
 
     if (get_var("UPGRADE") || get_var("AUTOUPGRADE") && !get_var("BOOT_TO_SNAPSHOT")) {
         assert_script_run "snapper setup-quota";
-        assert_script_run "snapper set-config NUMBER_LIMIT=2-10 NUMBER_LIMIT_IMPORTANT=4-10 SPACE_LIMIT=0.5";
+        # Note: Later, NUMBER_LIMIT will be customized (unconditionally), too
+        assert_script_run "snapper set-config NUMBER_LIMIT_IMPORTANT=4-10 SPACE_LIMIT=0.5";
     }
 
-    assert_script_run("snapper get-config");    # get initial cfg
-    assert_script_run("snapper list");          # get initial list of snap's
-    assert_script_run("snapper set-config NUMBER_MIN_AGE=0");
+    my ($n_scratch_prepost, $scratchfile_mb,     $safety_margin_mb,       $initially_free);
+    my ($nmax_snapshots,    $number_limit_upper, $number_limit_upper_max, $n);
+    my ($number_limit_pre,  $number_min_age_pre);
+
+    # test parameters; hardcoded values found appropriate in past tests
+    $n_scratch_prepost = 3;
+    $scratchfile_mb    = 1024;
+    # Keep the test from filling the last 300 MB of the filesystem, poo#36838
+    # Takes into account that scratch file "data" is not yet present at the beginning
+    $safety_margin_mb = 300 + $scratchfile_mb;
+    # Never keep more snapshots than this after cleanup: it would only consume
+    # runtime without adding substance. 18 seems a reasonable empirical limit.
+    $number_limit_upper_max = 18;
+
+    # get initial cfg and save initial NUMBER_LIMIT and NUMBER_MIN_AGE settings for later restore
+    assert_script_run("snapper get-config");
+    foreach (split /\n/, script_output("snapper get-config")) {
+        $number_limit_pre   = $1 if (m/^NUMBER_LIMIT\s+\|\s+([-\d]+)\s*$/);
+        $number_min_age_pre = $1 if (m/^NUMBER_MIN_AGE\s+\|\s+(\d+)\s*$/);
+    }
+    assert_script_run("snapper list");    # get initial list of snap's
+
+    # check amount of free fs disk space and adapt to it
+    # This test creates pre/post snapshot pairs each of which costs about $scratchfile_mb MiB
+    # Disk space thus dictates: number of present test snapshots must never exceed $nmax_snapshots
+    $initially_free = get_space("$btrfs_fs_usage | awk -F ' ' '/Free .estimated.:.*min:/{print\$3}'");    # bytes
+    $nmax_snapshots = int(($initially_free / (1024 * 1024) - $safety_margin_mb) / $scratchfile_mb) * 2;
+
+    # NUMBER_LIMIT setting such that disk space after cleanup
+    # allows another $n_scratch_prepost pre/post snapshot pairs
+    $number_limit_upper = $nmax_snapshots - $n_scratch_prepost * 2;
+    if ($number_limit_upper > 0) {
+        # plenty of free space? No ambition to fill it all, then.
+        $number_limit_upper = min($number_limit_upper, $number_limit_upper_max);
+        assert_script_run "snapper set-config NUMBER_LIMIT=2-$number_limit_upper NUMBER_MIN_AGE=0";
+    }
+    elsif ($number_limit_upper == 0) {
+        assert_script_run "snapper set-config NUMBER_LIMIT=0 NUMBER_MIN_AGE=0";
+    }
+    else {
+        die("Insufficient initial disk space left on / to run this test: $initially_free bytes");
+    }
+    assert_script_run("snapper get-config");    # report customized cfg
     assert_script_run("btrfs qgroup show -pc /", 3);
     # Exclusive disk space of qgroup should be ~50% of the fs space as set with SPACE_LIMIT
     $exp_excl_space = get_space("$btrfs_fs_usage | sed -n '2p' | awk -F ' ' '{print\$3}'") / 2;
     # We need to run snapper at least couple of times to ensure it cleans up properly
-    # '4' is an arbitrary value proven by test
-    for (1 .. 4) { snapper_cleanup; }
+    # Specifically: let Iteration $n - 3 be the last to not yet be forced by the
+    # NUMBER_LIMIT setting alone to actually carry out clean-ups
+    $n = $number_limit_upper / ($n_scratch_prepost * 2) + 3;
 
-    assert_script_run("snapper set-config NUMBER_MIN_AGE=1800");
+    for (1 .. $n) { snapper_cleanup($n_scratch_prepost, $scratchfile_mb); }
+
+    # tidy up and restore default settings
+    assert_script_run("snapper set-config NUMBER_LIMIT=0; snapper cleanup number; rm -fv data", 300);
+    assert_script_run("snapper set-config NUMBER_LIMIT=$number_limit_pre NUMBER_MIN_AGE=$number_min_age_pre");
+    assert_script_run("snapper get-config; snapper ls");    # final report
+    assert_script_run("$btrfs_fs_usage");                   # final report
 }
 
 1;


### PR DESCRIPTION
The current hardcoded test parameters combined with the default setting of `NUMBER_LIMIT=2-10` are prone to making the test run out of disk space during snapshot creation if less than about 9 GB
free filesystem space is left at the beginning. The resulting fails are useless.

This patch adds initial free disk space detection. It then adjusts snapper setting `NUMBER_LIMIT` such that the cleanups (if working properly) free sufficiently much so as to prevent filesystem
overfill even before the "snapper cleanup" invocations. It also adapts the number of invocations of snapper_cleanup() such that some actual cleanup action is to be expected in any case.

Independently of the above, the test will now remove its leftovers after a successful run (tidy-up).

# Description

## References

### Related ticket: https://progress.opensuse.org/issues/36838
### Verification runs:
- (SLE12SP3): http://mime.qam.suse.de/tests/24#step/snapper_cleanup/153
- (SLE15): https://openqa.suse.de/tests/1749976#step/snapper_cleanup/106 (riafarov requested to check this one out), versus clone (run with the patched test): http://mime.qam.suse.de/tests/25#step/snapper_cleanup/218

## Objectives

1. Enable the test to adapt to initial disk space conditions.
2. Adapt the number of invocations of snapper_cleanup() in run()  such that at least in the last three invocations actual cleanup will be carried out.
3. Adjust NUMBER_LIMIT as large as possible subject to the condition that at least about 300 MB of the filesystem are left free at any time. On the other hand, limit the upper bound so as to forestall excessive test runtime in case there is plenty of free space (selected limit: 18).
4. Put the hardcoded test parameters into suitable variables for more convenient handling.
5. Add proper tidy-up code at the end.

## Expected behavior

The initial amount of free filesystem diskspace (in GB) sets NUMBER_LIMIT and the number of invocations of `snapper_cleanup()` as in the following list. The last entry in each line describes when cleanup will start. _Example:_ for about 8.3 - 9.3 GB initially free the test would set `NUMBER_LIMIT=2-8`and run four `snapper_cleanup()` iterations. Cleanup would occur first in iteration 2 and delete 4 snapshots.

`  < 4.3        |     N/A                N/A                          N/A`
` 4.3-5.3      |       0                    3                            1/6`
` 5.3-7.3      |      2-2                  3                            1/4`
` 6.3-7.3      |      2-4                  3                            1/2`
` 7.3-8.3      |      2-6                  4                            2/6`
 `8.3-9.3      |      2-8                  4                            2/4`
` 9.3-10.3    |      2-10                4                            2/2`
`10.3-11.3   |      2-12                5                            3/6`
`11.3-12.3   |      2-14                5                            3/4`
`12.3-13.3   |      2-16                5                            3/2`
`> 13.3        |      2-18                6                            4/6`


The failed testruns mentioned in poo#36838 started with about 9.0 GB free and ran with `NUMBER_LIMIT=2-10`: too much. Iteration 2 would clean just one pre/post snapshot pair, and iteration 3 would regularly cause ENOSPC.

## Notes

Many recent runs of this test (within job mau-filesystem (SLE12), resp., job extra_tests_filesystem (SLE15)) started with a small number of "cleanup per number/important=yes" snapshots present. This test leaves them untouched since the initial setting of NUMBER_LIMIT_IMPORTANT=4-10 does not trigger any cleanup for them. This patch leaves it that way. Is it desirable to change this?

Cleaning up the very first pre/post snapshot pair will, by itself, recover just about nothing. Reason: the big scratch file `data` is not present yet in the pre snapshot, and the copy in the post snapshot is also present in the pre snapshot of the second pre/post pair. By contrast, each subsequent pre/post cleanup is expected to free space about the size of file `data` (1 GB, as of now).

The qgroup 1/0 check for bsc#998360 is still effective. In fact, a version of the patched test modified for standalone run triggered several fails on a SLES-12 SP3 system whose btrfs root filesystem
featured an overall size of 19.3 GB, free space about 14.5 GB. Running with NUMBER_LIMIT=2-18 the qgroup 1/0 grew to over 10 GB even after cleanup, in violation to the SPACE_LIMIT=0.5 setting.