### PR TITLE
Disable vino_screensharing_available for openSUSE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1231,7 +1231,8 @@ sub load_x11tests {
         loadtest "x11/hexchat";
         loadtest "x11/vlc";
     }
-    if (gnomestep_is_applicable() && !is_staging()) {
+    # https://progress.opensuse.org/issues/37342
+    if (is_sle() && gnomestep_is_applicable() && !is_staging()) {
         loadtest "x11/remote_desktop/vino_screensharing_available";
     }
     if (kdestep_is_applicable()) {


### PR DESCRIPTION
Hello,

according various configurations of openSUSE i"d like to disable my test `vino_screensharing_available` for everything except `SLE`.
As I'm not mistaken my test works just fine in SLE distributions and therefore there's no need to disable it for SLE as well.

- Related ticket: https://progress.opensuse.org/issues/37342
- Needles: No need
- Verification run: [Tumblewee](http://pdostal-server.suse.cz/tests/691) & [SLE](http://pdostal-server.suse.cz/tests/692).

Thank you