### PR TITLE
Add INCIDENT_ID support to qam-minimal tests

### DIFF
--- a/tests/qam-minimal/install_patterns.pm
+++ b/tests/qam-minimal/install_patterns.pm
@@ -40,10 +40,15 @@ sub install_packages {
 }
 
 sub run {
-    my ($self) = @_;
-    my $patch = get_required_var('INCIDENT_PATCH');
+    my ($self)      = @_;
+    my $incident_id = get_var('INCIDENT_ID');
+    my $patch       = get_var('INCIDENT_PATCH');
+    my $repo        = get_var('INCIDENT_REPO');
+    check_patch_variables($patch, $incident_id);
 
     select_console 'root-console';
+    my $patches = '';
+    $patches = get_patches($incident_id, $repo) if $incident_id;
 
     pkcon_quit;
     zypper_call("ref");
@@ -59,6 +64,7 @@ sub run {
     # now we have gnome installed - restore DESKTOP variable
     set_var('DESKTOP', get_var('FULL_DESKTOP'));
 
+    $patch = $patch ? $patch : $patches;
     my $patch_status = is_patch_needed($patch, 1);
     install_packages($patch_status) if $patch_status;
 


### PR DESCRIPTION
Feature poo#37036: Maintenance bot for SLE15 will use new INCIDENT_ID
variable for jobs. Tests should support new INCIDENT_ID and old
INCIDENT_PATCH variables.

- Related ticket: https://progress.opensuse.org/issues/37036
- Needles: none
- Verification runs with INCIDENT_ID
http://10.100.12.105/tests/2312
http://10.100.12.105/tests/2313
- Verification runs with INCIDENT_PATCH
http://10.100.12.105/tests/2314
http://10.100.12.105/tests/2311