### PR TITLE
Do not enable source repo before the workaround

### DIFF
--- a/tests/console/zypper_info.pm
+++ b/tests/console/zypper_info.pm
@@ -46,8 +46,6 @@ sub test_package_output {
 sub run {
     select_console 'root-console';
 
-    prepare_source_repo;
-
     if (is_leap('15.0+') and get_var('ARCH') =~ /aarch64|ppc64le/) {
         record_soft_failure(
             'for Leap:15.0:Ports aarch64 and ppc64le, do not enable source repo, waiting for solved issue https://progress.opensuse.org/issues/36256');
@@ -55,6 +53,8 @@ sub run {
         test_package_output;
         return;
     }
+
+    prepare_source_repo;
 
     # check for zypper info
     test_package_output;


### PR DESCRIPTION
Do not enable source repo before aarch64 and ppc64le workaround.

- Related ticket:  https://progress.opensuse.org/issues/36256
