### PR TITLE
Updated extra_tests_on_gnome and create_hdd_gnome test suites

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1350,8 +1350,6 @@ sub load_extra_tests_desktop {
     }
     elsif (check_var('DISTRI', 'opensuse')) {
         if (gnomestep_is_applicable()) {
-            # Setup env for x11 regression tests
-            loadtest "x11/x11_setup";
             # poo#18850 java test support for firefox, run firefox before chrome
             # as otherwise have wizard on first run to import settings from it
             loadtest "x11/firefox/firefox_java";
@@ -1467,9 +1465,7 @@ sub load_extra_tests {
     return if get_var("INSTALLONLY") || get_var("DUALBOOT") || get_var("RESCUECD");
 
     # setup $serialdev permission and so on
-    loadtest "console/consoletest_setup";
     loadtest 'console/integration_services' if is_hyperv;
-    loadtest "console/hostname";
     if (any_desktop_is_applicable()) {
         load_extra_tests_desktop;
     }
@@ -1774,6 +1770,7 @@ sub load_create_hdd_tests {
     loadtest 'console/integration_services' if is_hyperv;
     loadtest 'console/hostname'              unless is_bridged_networking;
     loadtest 'console/force_scheduled_tasks' unless is_jeos;
+    loadtest 'x11/x11_setup' if any_desktop_is_applicable;
     # Remove repos pointing to download.opensuse.org and add snaphot repo from o3
     replace_opensuse_repos_tests if is_repo_replacement_required;
     loadtest 'console/scc_deregistration' if get_var('SCC_DEREGISTER');


### PR DESCRIPTION
1. Moved the console/hostname from load_extra_tests to load_create_hdd_tests
2. Moved the x11/x11_setup from load_extra_tests to
   load_create_hdd_tests raplace the consoletest_setup.
3. Deleted the consoletest_setup from load_extra_tests.

In order to let hostname, x11_setup test in advance while create_hdd.

- Related ticket: https://progress.opensuse.org/issues/37027
- Verification run: http://10.67.19.67/tests/overview?build=00015&distri=opensuse&version=Tumbleweed&groupid=1
