### PR TITLE
Add detection for boo#1097610

### DIFF
--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -53,7 +53,13 @@ sub gpg_generate_key {
     wait_still_screen 1;
     save_screenshot;
     type_string "O\n";
-    assert_screen("gpg-enter-passphrase");
+    assert_screen(["gpg-enter-passphrase", "gpg-generate-key-boo1097610"]);
+    if (match_has_tag('gpg-generate-key-boo1097610') && check_var('ARCH', 's390x')) {
+        record_soft_failure 'boo#1097610';
+        select_console 'root-console';
+        gpg_generate_key($key_size);
+        return;
+    }
 
     # enter wrong passphrase
     type_string "REALSECRETPHRASE\n";
@@ -109,15 +115,7 @@ sub gpg_encrypt_file {
 }
 
 sub run {
-
-    if (check_var('ARCH', 's390x')) {
-        record_soft_failure 'Using root console on s390x: boo#1097610';
-        select_console 'root-console';
-    }
-    else {
-        select_console 'user-console';
-    }
-
+    select_console 'user-console';
 
     # gpg key generated and file encrypted with two size of key
     for my $key_size (2048, 3072) {


### PR DESCRIPTION
Now only recording a softfail if it appears

Followup to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5223

- Related ticket: https://progress.opensuse.org/issues/37057
- Needles: created on OSD
- Verification run: http://pinky.arch.suse.de/tests/1267