### PR TITLE
Avoid multiple start of updater and looping

### DIFF
--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -80,7 +80,7 @@ sub run {
                 }
             } while (match_has_tag 'updates_authenticate');
             if (match_has_tag("updates_none")) {
-                send_key 'ret';
+                wait_screen_change { send_key 'ret'; };
                 if (check_screen "updates_installed-restart", 0) {
                     power_action 'reboot', textmode => 1;
                     $self->wait_boot;


### PR DESCRIPTION
Now waits for pop-up to close after sending ret to get a chance to check
screen properly
It will fix the looping encountered in Leap 15.0 aarch64 test:
https://openqa.opensuse.org/tests/691642#step/updates_packagekit_gpk/19