### PR TITLE
Add disable_vnc_stalls for ipmi backend before reboot

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -211,8 +211,12 @@ sub clear_console {
 # in some backends we need to prepare the reboot/shutdown
 sub prepare_system_shutdown {
     # kill the ssh connection before triggering reboot
-    console('root-ssh')->kill_ssh if check_var('BACKEND', 'ipmi');
-
+    if (check_var('BACKEND', 'ipmi')) {
+        console('root-ssh')->kill_ssh;
+        console('installation')->disable_vnc_stalls;
+        console('sol')->disable_vnc_stalls;
+        console('root-ssh')->disable_vnc_stalls;
+    }
     if (check_var('ARCH', 's390x')) {
         if (check_var('BACKEND', 's390x')) {
             # kill serial ssh connection (if it exists)


### PR DESCRIPTION
This is to try the solution suggested for issue -- half open socket on ipmi, see https://progress.opensuse.org/issues/32746. Local verification passes which shows this PR will not block anything and it behaves normally in workflow. However whether it can improve stability and decrease incomplete job due to this issue.

- Related ticket: https://progress.opensuse.org/issues/32746
- Verification run: 
please note this verification cares mostly reboot related steps result
http://10.67.18.220/tests/90
http://10.67.18.220/tests/76
