### PR TITLE
Fortran: remove Test 016 from FM509

### DIFF
--- a/data/toolchain/FM509-remove-TEST-016.patch
+++ b/data/toolchain/FM509-remove-TEST-016.patch
@@ -1,0 +1,25 @@
+--- FM509.f	2002-04-30 11:46:54.000000000 +0200
++++ FM509.f.new	2018-06-15 13:24:06.435447979 +0200
+@@ -369,22 +369,6 @@ C
+ 20150      IVFAIL = IVFAIL + 1                                          03680509
+            WRITE (I02,80018) IVTNUM, CVCOMP, CVCORR                     03690509
+  0151      CONTINUE                                                     03700509
+-C                                                                       03710509
+-CT016*  TEST 016   ****  FCVS PROGRAM 509  ****                         03720509
+-C                                                                       03730509
+-           IVTNUM = 16                                                  03740509
+-           CVCOMP = ' '                                                 03750509
+-           CVCORR = 'IFTHROUN                      '                    03760509
+-      CALL SN512(C1N001(5)(2:9),CVCOMP)                                 03770509
+-           IVCOMP = 0                                                   03780509
+-           IF (CVCOMP.EQ.'IFTHROUN                      ') IVCOMP = 1   03790509
+-40160      IF (IVCOMP - 1) 20160, 10160, 20160                          03800509
+-10160      IVPASS = IVPASS + 1                                          03810509
+-           WRITE (I02,80002) IVTNUM                                     03820509
+-           GO TO 0161                                                   03830509
+-20160      IVFAIL = IVFAIL + 1                                          03840509
+-           WRITE (I02,80018) IVTNUM, CVCOMP, CVCORR                     03850509
+- 0161      CONTINUE                                                     03860509
+ C                                                                       03870509
+ CBB** ********************** BBCSUM0  **********************************03880509
+ C**** WRITE OUT TEST SUMMARY                                            03890509

--- a/tests/toolchain/gcc_fortran_compilation.pm
+++ b/tests/toolchain/gcc_fortran_compilation.pm
@@ -1,17 +1,17 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Fortran test for SLE Toolchain Module's GCC
+# Summary: Fortran test
 # Maintainer: Michal Nowak <mnowak@suse.com>
 
-use base "opensusebasetest";
+use base 'opensusebasetest';
 use strict;
 use testapi;
 use utils;
@@ -20,24 +20,26 @@ use version_utils qw(is_sle is_leap);
 sub run {
     my $self = shift;
 
-    my $package_main  = data_url('toolchain/fcvs21_f95.tar.bz2');
-    my $package_fix   = data_url('toolchain/FM923.DAT');
-    my $package_patch = data_url('toolchain/adapt-FM406-to-fortran-95.patch');
-    assert_script_run "wget $package_main",  60;
-    assert_script_run "wget $package_fix",   60;
-    assert_script_run "wget $package_patch", 60;
-    script_run 'tar jxf fcvs21_f95.tar.bz2';
-    script_run 'cp FM923.DAT fcvs21_f95/';
-    script_run 'pushd fcvs21_f95';
-    my $fortran_version = "gfortran";
-    if (is_sle('<15') or is_leap('<15.0')) {
-        $fortran_version = "gfortran-5";    # gfortran (and gcc) fixed to version in SLE12 after the yearly gcc update with Toolchain module
-    }
-    script_run "sed -i 's/g77/$fortran_version/g' driver_*";
-    script_run 'echo "exit \${failed}" >> driver_parse';
+    my $package_main   = data_url('toolchain/fcvs21_f95.tar.bz2');
+    my $package_fix    = data_url('toolchain/FM923.DAT');
+    my $package_patch1 = data_url('toolchain/adapt-FM406-to-fortran-95.patch');
+    my $package_patch2 = data_url('toolchain/FM509-remove-TEST-016.patch');
 
-    script_run "patch -p0 < ../adapt-FM406-to-fortran-95.patch";
-    script_run "rm FM001.f FM005.f FM109.f FM257.f";
+    assert_script_run "wget $package_main $package_fix $package_patch1 $package_patch2";
+
+    assert_script_run 'tar jxf fcvs21_f95.tar.bz2';
+    assert_script_run 'cp FM923.DAT fcvs21_f95/';
+    assert_script_run 'pushd fcvs21_f95';
+
+    # gfortran (and gcc) fixed to version in SLE12 after the yearly gcc update with Toolchain module
+    my $fortran_version = (is_sle('<15') || is_leap('<15.0')) ? 'gfortran-5' : 'gfortran';
+
+    assert_script_run "sed -i 's/g77/$fortran_version/g' driver_*";
+    assert_script_run 'echo "exit \${failed}" >> driver_parse';
+
+    assert_script_run 'patch -p0 < ../adapt-FM406-to-fortran-95.patch';
+    assert_script_run 'patch -p0 < ../FM509-remove-TEST-016.patch';
+    assert_script_run 'rm FM001.f FM005.f FM109.f FM257.f';
 
     # Build
     assert_script_run './driver_parse 2>&1 | tee /tmp/build.log; if [ ${PIPESTATUS[0]} -ne 0 ]; then false; fi', 120;
@@ -46,12 +48,7 @@ sub run {
     # Verify
     assert_script_run('! grep -P -L "(0 TESTS FAILED|0 ERRORS ENCOUNTERED)" *.res | grep FM');
 
-    save_screenshot;
-    script_run 'popd';
-
-    # poo#33376: added to investigate OOM
-    assert_script_run 'free -m';
-    save_screenshot;
+    assert_script_run 'popd';
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Fixes: https://progress.opensuse.org/issues/37273

Validation runs:
* opensuse-Tumbleweed-DVD-x86_64-Build20180608-toolchain_zypper@64bit: http://nilgiri.suse.cz/tests/150
* sle-12-SP4-Server-DVD-x86_64-Build0254-toolchain_zypper@64bit-smp: http://nilgiri.suse.cz/tests/154