### PR TITLE
Move ipmi specific logic to activate_console

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -208,4 +208,3 @@ sub set_serial_console_on_xen {
 
 
 1;
-

--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -34,13 +34,6 @@ sub get_ip_address {
 }
 
 sub get_to_console {
-    if (check_var('BACKEND', 'ipmi')) {
-        use_ssh_serial_console;
-        get_ip_address;
-        save_screenshot();
-        return;
-    }
-
     my @tags = qw(yast-still-running linuxrc-install-fail linuxrc-repo-not-found);
     my $ret = check_screen(\@tags, 5);
     if ($ret && match_has_tag("linuxrc-repo-not-found")) {    # KVM only


### PR DESCRIPTION
We have different hacks here and there for different backends. In case
of remote installations, including ipmi, we don't have different
consoles, but just ssh. So to make other code work on ipmi. This PR
makes one step in this direction.

- Verification runs:
  [post_fail_hook](http://g226.suse.de/tests/1966#)

Triggering installation with console tests, to check if can be enabled on ipmi.
