### PR TITLE
Pick eth card 0 before editing

### DIFF
--- a/tests/x11/yast2_lan_restart_devices.pm
+++ b/tests/x11/yast2_lan_restart_devices.pm
@@ -23,6 +23,8 @@ sub add_device {
     open_network_settings;
 
     if ($device eq 'bond') {
+        wait_screen_change { send_key 'home' };
+        send_key_until_needlematch 'yast2_lan_select_eth_card', 'down';
         send_key 'alt-i';    # Edit NIC
         assert_screen 'yast2_lan_network_card_setup';
         send_key 'alt-k';             # No link (Bonding Slavees)


### PR DESCRIPTION
- Related ticket: [[sle][functional][y][fast] test fails in yast2_lan_restart_devices - needle yast2_lan_network_card_setup doesn't match](https://progress.opensuse.org/issues/36850)
- Needles: [Add detected eth card 0 needle](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/872)
- Verification run: [sle-15-Installer-DVD-ppc64le-Build665.2-extra_tests_on_gnome@ppc64le](http://dhcp151.suse.cz/tests/3574)
