### PR TITLE
Add INCIDENT_ID support to qam kernel tests

### DIFF
--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -110,7 +110,7 @@ sub get_patches {
     $repo =~ tr/,/ /;
 
     # Search for patches by incident, exclude not needed
-    my $patches = script_output("zypper patches -r $repo | awk -F '|' '/needed/ && !/not needed/ && /$incident_id/ { printf \$2 }'");
+    my $patches = script_output("zypper patches -r $repo | awk -F '|' '/[Nn]eeded/ && !/[Nn]ot [Nn]eeded/ && /$incident_id/ { printf \$2 }'");
     # Remove carriage returns and make patch list on one line
     $patches =~ s/\r//g;
     return $patches;

--- a/tests/kernel/qa_test_klp.pm
+++ b/tests/kernel/qa_test_klp.pm
@@ -16,16 +16,22 @@ use base 'opensusebasetest';
 use testapi;
 use utils;
 use registration;
+use qam;
 
 sub run {
     my $git_repo = get_required_var('QA_TEST_KLP_REPO');
     my ($test_type) = $git_repo =~ /qa_test_(\w+).git/;
 
+    # Set and check patch variables
+    my $incident_id = get_var('INCIDENT_ID');
+    my $patch       = get_var('INCIDENT_PATCH');
+    check_patch_variables($patch, $incident_id);
+
     select_console('root-console');
     zypper_call('ar -f -G ' . get_required_var('QA_HEAD_REPO') . ' qa_head');
     zypper_call('in -l bats hiworkload');
 
-    if (check_var('DISTRI', 'sle') and get_var('INCIDENT_PATCH', '')) {
+    if (check_var('DISTRI', 'sle') and ($patch or $incident_id)) {
         add_suseconnect_product("sle-sdk");
     }
 


### PR DESCRIPTION
Feature poo#37036: Maintenance bot for SLE15 will use new INCIDENT_ID
variable for jobs. Tests should support new INCIDENT_ID and old
INCIDENT_PATCH variables.

- Related ticket: https://progress.opensuse.org/issues/37036
- Needles: none
- Verification run:
Kernel update with INCIDENT_ID http://10.100.12.105/tests/2344
Kernel update with INCIDENT_PATCH http://10.100.12.105/tests/2345
Kgraft update with INCIDENT_ID http://10.100.12.105/tests/2342
Kgraft update with INCIDENT_PATCH http://10.100.12.105/tests/2343