### PR TITLE
Verify update-test* packages available for SLE12SP4

### DIFF
--- a/tests/console/repo_package_install.pm
+++ b/tests/console/repo_package_install.pm
@@ -14,23 +14,52 @@ use base "consoletest";
 use strict;
 use testapi;
 use utils;
-use version_utils qw(sle_version_at_least is_jeos);
+use version_utils qw(is_sle is_jeos);
 
 my %packages = (
-    # On JeOS Salt is present in the default image
     salt => {
         repo      => 'Basesystem',
-        installed => is_jeos() ? 1 : 0
-    });
+        installed => is_jeos() ? 1 : 0,       # On JeOS Salt is present in the default image
+        condition => sub { is_sle('15+') },
+    },
+    'update-test-feature' => {                # See poo#36451
+        repo      => is_sle('15+') ? 'Basesystem' : 'SLES',
+        installed => 0,
+        available => sub { get_var('BETA') },
+    },
+);
+# Define more packages with the same set of expectations
+$packages{'update-test-interactive'} = $packages{'update-test-feature'};
+$packages{'update-test-security'}    = $packages{'update-test-feature'};
+$packages{'update-test-trival'}      = $packages{'update-test-feature'};
 
 sub run {
     select_console 'root-console';
-    # for now only test for SLE>=15
-    return unless sle_version_at_least('15');
+    my $errors = '';    # Variable to accumulate errors
     for my $package (keys %packages) {
+        # Skip package if condition is defined and is false
+        next if defined($packages{$package}->{condition}) && !$packages{$package}->{condition}->();
         my $args = $packages{$package}->{installed} ? '--installed-only' : '--not-installed-only';
-        assert_script_run("zypper se -n $args --match-exact --details $package | grep " . $packages{$package}->{repo});
+        # Set flag if availability condition is defined and is true or not defined
+        my $available = !!(!defined($packages{$package}->{available}) || $packages{$package}->{available}->());
+        # Negate condition if package should not be available
+        my $cmd = $available ? '' : '! ';
+        $cmd .= "zypper se -n $args --match-exact --details $package";
+        # Verify repo only if package expected to be available
+        $cmd .= ' | grep ' . $packages{$package}->{repo} if $available;
+        # Record error in case non-zero return code
+        if (script_run($cmd)) {
+            if ($available) {
+                $errors .= "Package '$package' not found in @{ [ $packages{$package}->{repo} ] } or not preinstalled."
+                  . " Expected to be installed: @{ [ $packages{$package}->{installed} ? 'true' : 'false' ] }\n";
+            }
+            else {
+                $errors .= "Package '$package' found in @{ [ $packages{$package}->{repo} ] } repo, expected to be not available\n";
+            }
+        }
     }
+    # Fail in case of any unexpected results
+    die "$errors" if $errors;
 }
 
 1;


### PR DESCRIPTION
As planned, we extend test module to test packages availability and
location. Note, this is not applied for SLE15 as we don't have non BETA
repos available at the moment, so it's hard to check where to expect
them.
Also, not all of the listed packages are available on iso, so do not
test all of them.

See [poo#36451](https://progress.opensuse.org/issues/36451).

- Verification runs:
  * [SLE12](http://g226.suse.de/tests/1982)
  * [SLE15](http://g226.suse.de/tests/1979)
  * [Simulated failure](http://g226.suse.de/tests/1978#step/repo_package_install/7)
