### PR TITLE
Add functionality to publish HA images

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -567,8 +567,12 @@ sub load_ha_cluster_tests {
     # Show HA cluster status *after* fencing test
     loadtest 'ha/check_after_fencing';
 
-    # Check logs to find error and upload all needed logs
-    loadtest 'ha/check_logs';
+    # Check logs to find error and upload all needed logs if we are not
+    # in installation/publishing mode
+    loadtest 'ha/check_logs' if !get_var('INSTALLONLY');
+
+    # If needed, do some actions prior to the shutdown
+    loadtest 'ha/prepare_shutdown' if get_var('INSTALLONLY');
 
     return 1;
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -514,7 +514,7 @@ sub load_ha_cluster_tests {
 
     # NTP is already configured with 'HA node' and 'HA GEO node' System Roles
     # 'default' System Role is 'HA node' if HA Product i selected
-    loadtest "console/yast2_ntpclient" unless (get_var('SYSTEM_ROLE', '') =~ /default|ha/);
+    loadtest 'console/yast2_ntpclient' unless (get_var('SYSTEM_ROLE', '') =~ /default|ha/);
 
     # Update the image if needed
     if (get_var('FULL_UPDATE')) {
@@ -562,7 +562,7 @@ sub load_ha_cluster_tests {
     loadtest 'ha/fencing';
 
     # Node1 will be fenced, so we have to wait for it to boot
-    boot_hdd_image if (!get_var('HA_CLUSTER_JOIN'));
+    boot_hdd_image if !get_var('HA_CLUSTER_JOIN');
 
     # Show HA cluster status *after* fencing test
     loadtest 'ha/check_after_fencing';

--- a/tests/ha/firewall_disable.pm
+++ b/tests/ha/firewall_disable.pm
@@ -7,21 +7,24 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Disable firewall in HA tests
+# Summary: Disable firewall in HA tests if needed
 # Maintainer: Loic Devulder <ldevulder@suse.com>
 
 use base 'opensusebasetest';
 use strict;
 use testapi;
 use hacluster;
+use utils 'systemctl';
 
 sub run {
     my ($self) = @_;
     my $firewall = $self->firewall;
 
-    # Deactivate firewall if needed
-    if (is_package_installed "$firewall") {
-        assert_script_run "systemctl -q is-active $firewall && systemctl disable $firewall; systemctl stop $firewall";
+    if (is_package_installed $firewall) {
+        # SuSEfirewall2 can't be disabled and stopped at
+        # the same time using 'disable --now'...
+        systemctl "disable $firewall";
+        systemctl "stop $firewall";
     }
 }
 

--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -30,7 +30,7 @@ sub run {
     assert_screen 'ha-cluster-join-password';
     type_password;
     send_key 'ret';
-    wait_still_screen;
+    wait_still_screen(stilltime => 10);
 
     # Indicate that the other nodes have joined the cluster
     barrier_wait("NODE_JOINED_$cluster_name");

--- a/tests/ha/prepare_shutdown.pm
+++ b/tests/ha/prepare_shutdown.pm
@@ -1,0 +1,22 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Do some actions prior to the shutdown
+# Maintainer: Loic Devulder <ldevulder@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use utils 'systemctl';
+
+sub run {
+    # We need to stop pacemaker to avoid fencing during shutdown
+    systemctl 'stop pacemaker.service';
+}
+
+1;

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -398,7 +398,7 @@ sub setup_iscsi_server {
                        -e '/\\/cache_dynamic_acls\$/s/^echo 0/echo 1/'      \\
                        -e '/\\/generate_node_acls\$/s/^echo 0/echo 1/'      \\
                        -e '/\\/authentication\$/s/^echo 1/echo 0/' /etc/target/lio_setup.sh";
-    systemctl('start target');
+    systemctl('enable --now target');
     select_console 'root-console';
 
     $iscsi_server_set = 1;


### PR DESCRIPTION
For migration purposes (SLE-n -> SLE-n+1) we need to publish the HA nodes images as well as the support-server, because iSCSI LUNs need to be kept.

- Related ticket: https://progress.opensuse.org/issues/37474
- Verification runs: [ha-node01](http://1b147.qa.suse.de/tests/2191), [ha-node02](http://1b147.qa.suse.de/tests/2192) and [ha-supportserver](http://1b147.qa.suse.de/tests/2190)
