### PR TITLE
Add soft-failures where lower console messages level

### DIFF
--- a/tests/console/yast2_ntpclient.pm
+++ b/tests/console/yast2_ntpclient.pm
@@ -34,6 +34,7 @@ sub run {
     # test often fails due to info kernel messages disrupting screen
     # decrease logging level to warning to avoid this
     assert_script_run 'dmesg -n 4';
+    record_soft_failure 'bsc#1011815';
 
     # check network at first
     assert_script_run('if ! systemctl -q is-active network; then systemctl -q start network; fi');
@@ -184,4 +185,3 @@ sub run {
     systemctl "show -p ActiveState $ntp_service.service | grep ActiveState=active";
 }
 1;
-

--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -266,6 +266,7 @@ sub setup_samba {
 sub setup_yast2_auth_server {
     # workaround kernel message floating over console
     assert_script_run "dmesg -n 4";
+    record_soft_failure 'bsc#1011815';
 
     # check network at first
     assert_script_run("if ! systemctl -q is-active network; then systemctl -q start network; fi");
@@ -346,4 +347,3 @@ sub post_fail_hook {
 }
 
 1;
-


### PR DESCRIPTION
See [poo#19398](https://progress.opensuse.org/issues/19398).

Removing needle which causes false positives.
- [Needles](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/386).

