### PR TITLE
Do not assert default role is the selected one

### DIFF
--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -49,11 +49,13 @@ sub change_system_role {
 
 sub assert_system_role {
     # Still initializing the system at this point, can take some time
-    # Verify default role for SLE15, it's text for sles and gnome for sled
-    assert_screen 'system-role-default-system', 180;
     my $system_role = get_var('SYSTEM_ROLE', 'default');
     if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default')) {
         change_system_role($system_role);
+    }
+    else {
+        # Verify default role for SLE15, it's text for sles and gnome for sled
+        assert_screen 'system-role-default-system', 180;
     }
     send_key $cmd{next};
 }


### PR DESCRIPTION
The former code assumed that the default role is always the selected one, this is not true as it depends on the selected modules.

- Related ticket: https://progress.opensuse.org/issues/37468
- Verification run:
  - http://panigale.suse.cz/tests/2315#step/system_role/1
  - http://panigale.suse.cz/tests/2314#step/system_role/1