### PR TITLE
Ensure disabling home directory

### DIFF
--- a/tests/installation/partitioning_togglehome.pm
+++ b/tests/installation/partitioning_togglehome.pm
@@ -35,7 +35,7 @@ sub run {
         elsif (is_storage_ng && !get_var('LVM')) {
             $cmd{toggle_home} = 'alt-o';
         }
-        send_key $cmd{toggle_home};
+        wait_screen_change { send_key $cmd{toggle_home} };
         assert_screen 'disabledhome';
     }
     send_key(is_storage_ng() ? 'alt-n' : 'alt-o');    # finish editing settings


### PR DESCRIPTION
- Related ticket: [[sle][functional][yast][easy][y] test fails in partitioning_togglehome SLE 12-SP4 - On aarch64 a synchronization fails, activating the separated home partition](https://progress.opensuse.org/issues/29462)
- Verification run: [sle-12-SP4-Server-DVD-aarch64-Build0256-create_hdd_textmode@aarch64](http://dhcp151.suse.cz/tests/3587#step/partitioning_togglehome/1)
