### PR TITLE
Prevent skipping of /dev/xvd{b,c} drives

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -343,10 +343,6 @@ sub run {
         send_key "right" unless is_storage_ng;
         assert_screen 'partitioning_raid-hard_disks-unfolded';
         send_key "down";
-        # CDROM is xvda and is seen as a disk block devide, we have to skip it
-        if (check_var('VIRSH_VMM_TYPE', 'linux')) {
-            send_key 'down' for (1 .. 3);
-        }
     }
 
     my @devices = qw(vda vdb vdc vdd);


### PR DESCRIPTION
- Related ticket: [[sle][functional][y][fast] test fails in partitioning_raid - /dev/xvdb was not matched](https://progress.opensuse.org/issues/37477)
- Verification run: [sle-12-SP4-Server-DVD-x86_64-Build0256-lvm+RAID1@svirt-xen-pv](http://dhcp151.suse.cz/tests/3592#step/partitioning_raid/193)
