### PR TITLE
Revert "Ensure disabling home directory"

### DIFF
--- a/tests/installation/partitioning_togglehome.pm
+++ b/tests/installation/partitioning_togglehome.pm
@@ -35,7 +35,7 @@ sub run {
         elsif (is_storage_ng && !get_var('LVM')) {
             $cmd{toggle_home} = 'alt-o';
         }
-        wait_screen_change { send_key $cmd{toggle_home} };
+        send_key $cmd{toggle_home};
         assert_screen 'disabledhome';
     }
     send_key(is_storage_ng() ? 'alt-n' : 'alt-o');    # finish editing settings


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#5250

As discussed in the QSF review we might have misunderstood the problem here. Since the ticket https://progress.opensuse.org/issues/29462 was reported originally we have reworked the test module anyway so most likely the original issue can not appear anymore in the same way anyway. Also, `wait_screen_change` ensures the screen is changed *after* the action within the parentheses is executed, not before.