### PR TITLE
Revert "Do not assert default role is the selected one"

### DIFF
--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -49,13 +49,11 @@ sub change_system_role {
 
 sub assert_system_role {
     # Still initializing the system at this point, can take some time
+    # Verify default role for SLE15, it's text for sles and gnome for sled
+    assert_screen 'system-role-default-system', 180;
     my $system_role = get_var('SYSTEM_ROLE', 'default');
     if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default')) {
         change_system_role($system_role);
-    }
-    else {
-        # Verify default role for SLE15, it's text for sles and gnome for sled
-        assert_screen 'system-role-default-system', 180;
     }
     send_key $cmd{next};
 }

--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -49,7 +49,8 @@ sub change_system_role {
 
 sub assert_system_role {
     # Still initializing the system at this point, can take some time
-    # Verify default role for SLE15, it's text for sles and gnome for sled
+    # Asserting screen with preselected role
+    # Proper default role assertion will be addressed in poo#37504
     assert_screen 'system-role-default-system', 180;
     my $system_role = get_var('SYSTEM_ROLE', 'default');
     if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default')) {


### PR DESCRIPTION
This reverts commit f2102f0caa9457d9bd8cce2e10472c7c36bd263c.

As per discussion in #5249, we consider reverting change and fixing initial issue with the needle, and aim proper default role selection in [poo#37504](https://progress.opensuse.org/issues/37504).
