### PR TITLE
Improve gdb in postfail hook for installer

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -302,7 +302,7 @@ sub post_fail_hook {
         }
 
         assert_script_run 'extend gdb';
-        my $gdb_ret = script_run("timeout $trace_timeout gdb attach $installer_pid > /tmp/installer_gdb.log", ($trace_timeout + 5));
+        my $gdb_ret = script_run("gdb attach $installer_pid --batch -q -ex 'thread apply all bt' -ex q > /tmp/installer_gdb.log", ($trace_timeout + 5));
         if (!script_run '[[ -e /tmp/installer_gdb.log ]]') {
             upload_logs '/tmp/installer_gdb.log';
         }


### PR DESCRIPTION
- Related ticket: [[functional][y][hard] Improve auto-investigation in case the yast installer gets stuck](https://progress.opensuse.org/issues/35709)
- Verification run: [gdb example from failed Build665.2-allpatterns@64bit](http://dhcp151.suse.cz/tests/3595/file/accept_license-installer_gdb.log)
