### PR TITLE
Fix check_hawk test issue

### DIFF
--- a/tests/ha/check_hawk.pm
+++ b/tests/ha/check_hawk.pm
@@ -27,7 +27,7 @@ sub run {
     systemctl 'show -p ActiveState hawk.service | grep ActiveState=active';
 
     # Test the Hawk port
-    assert_script_run "ss -nap | grep -w ':$hawk_port'";
+    assert_script_run "ss -nap | grep '.*LISTEN.*:$hawk_port\[[:blank:]]*'";
 
     # Test Hawk connection
     assert_script_run "nc -zv localhost $hawk_port";


### PR DESCRIPTION
On SLE-12-SP4, `check_hawk` [fails](https://openqa.suse.de/tests/1767107#step/check_hawk/5) while trying to check for network's port openess.
Fix this by changing the 'grep' expression.

- Verification run: http://1b147.qa.suse.de/tests/2191#step/check_hawk/3