### PR TITLE
LTP: Introduce var to enable reboot after installation

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -121,7 +121,9 @@ sub load_kernel_tests {
             loadtest 'update_kernel';
         }
         loadtest 'install_ltp';
-        #loadtest 'boot_ltp';
+        if (get_var('LTP_INSTALL_REBOOT')) {
+            loadtest 'boot_ltp';
+        }
         shutdown_ltp();
     }
     elsif (get_var('LTP_COMMAND_FILE')) {

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -281,7 +281,7 @@ sub run {
     upload_runtest_files('${LTPROOT:-/opt/ltp}/runtest', $tag);
 
     select_console('root-console');
-    type_string "reboot\n" if get_var('LTP_INSTALL_REBOOT');
+    power_action('reboot', textmode => 1) if get_var('LTP_INSTALL_REBOOT');
 }
 
 sub post_fail_hook {

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -281,7 +281,7 @@ sub run {
     upload_runtest_files('${LTPROOT:-/opt/ltp}/runtest', $tag);
 
     select_console('root-console');
-    #type_string "reboot\n";
+    type_string "reboot\n" if get_var('LTP_INSTALL_REBOOT');
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
It appears the LTP installation module on SLE12-SP4 x86_64 publishes a
corrupted disk image which can not be booted (or even mounted). This
reintroduces a reboot to the LTP installation, but only if LTP_INSTALL_REBOOT
is set to one. So we can see if it is really the LTP installation corrupting
the disk image or the publishing process.

@pevik 