### PR TITLE
Revert "Don't do workaround if UEFI_PFLASH_VARS is present"

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -362,8 +362,7 @@ sub wait_boot {
         # booted so we have to handle that
         # because of broken firmware, bootindex doesn't work on aarch64 bsc#1022064
         push @tags, 'inst-bootmenu' if ((get_var('USBBOOT') and get_var('UEFI')) || (check_var('ARCH', 'aarch64') and get_var('UEFI')) || get_var('OFW'));
-        $self->handle_uefi_boot_disk_workaround
-          if (get_var('MACHINE') =~ /aarch64/ && get_var('UEFI') && get_var('BOOT_HDD_IMAGE') && !$in_grub && !get_var('UEFI_PFLASH_VARS'));
+        $self->handle_uefi_boot_disk_workaround if (get_var('MACHINE') =~ /aarch64/ && get_var('UEFI') && get_var('BOOT_HDD_IMAGE') && !$in_grub);
         check_screen(\@tags, $bootloader_time);
         if (match_has_tag("bootloader-shim-import-prompt")) {
             send_key "down";


### PR DESCRIPTION
This reverts commit 46cdd8af53fa9d91859459f4d51f3524ca03c08d because
UEFI_PFLASH_VARS needs to be added to a large number of tests cases which is
more difficult than changing one line of code. So I would like to add the
variables before the QEMU rewrite is deployed.