### PR TITLE
Optimize trup_install

### DIFF
--- a/tests/console/runc.pm
+++ b/tests/console/runc.pm
@@ -24,7 +24,7 @@ sub run {
     my $runc = '/usr/sbin/runc';
 
     record_info 'Test #1', 'Test: Installation';
-    trup_install('runc');
+    trup_install('runc skopeo umoci');
 
     record_info 'Setup', 'Requirements';
     assert_script_run('mkdir test_runc && cd test_runc');
@@ -66,6 +66,7 @@ sub run {
 
     record_info 'Clean', 'Leave it clean for other tests';
     script_run('cd');
+    script_run('rm -r test_runc');
 }
 
 1;


### PR DESCRIPTION
So far, `trup_install` fails in case you are trying to install
a package which has been already available on the system.

As a result this PR makes sure that it will install only
the packages that are not present on the current status of the
system and it will also skip the others (pre-installed). In
case all the packages are pre-installed, no action will be
taken; function will happily return.

Furthermore, it will also print a friendly notification
about it.

- Related ticket: https://progress.opensuse.org/issues/37552
- Needles: *not needed*
- Verification run: http://skyrim.qam.suse.de/tests/3386#
