### PR TITLE
memtest needs to be shutdown with care on svirt

### DIFF
--- a/tests/installation/memtest.pm
+++ b/tests/installation/memtest.pm
@@ -11,18 +11,20 @@
 # Summary: Simple memtest
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
-use base "opensusebasetest";
+use base 'opensusebasetest';
 use strict;
 use testapi;
 use bootloader_setup 'ensure_shim_import';
+use utils 'power_action';
 
 sub run {
     my $self = shift;
 
     ensure_shim_import;
     $self->select_bootmenu_more('inst-onmemtest', 1);
-    assert_screen "pass-complete", check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 1100 : 700;
-    send_key "esc";
+    assert_screen 'pass-complete', check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 1100 : 700;
+    send_key 'esc';
+    power_action('poweroff', keepconsole => 1, observe => 1);
 }
 
 sub test_flags {


### PR DESCRIPTION
On svirt every restart/shutdown has to be either triggered or at least
observed by `power_action()` otherwise it may stuck in various ways
(https://progress.opensuse.org/issues/37510), or pass in sheer luck.

In memtest the shutdown happens by `Esc` key on memtest pass.

Validation run:
* Xen HVM: http://nilgiri.suse.cz/tests/235