### PR TITLE
List NICs from the top in network settings

### DIFF
--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -27,6 +27,8 @@ sub check_network_settings_tabs {
 }
 
 sub check_network_card_setup_tabs {
+    wait_screen_change { send_key 'home' };
+    send_key_until_needlematch 'yast2_lan_select_eth_card', 'down';
     send_key 'alt-i';
     assert_screen 'yast2_lan_network_card_setup';
     send_key 'alt-w';


### PR DESCRIPTION
- Related ticket: [[sle][functional][y][fast] test fails in yast2_lan_restart - OSA NIC card selected](https://progress.opensuse.org/issues/37589)
- Needles: 
   - [OSD](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/875)
   - [o3](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/387)
- Verification runs:
   - OSD [sle-15-Installer-DVD-ppc64le-Build668.1-extra_tests_on_gnome@ppc64le](http://dhcp151.suse.cz/tests/3615#step/yast2_lan_restart/49)
   - o3 [opensuse-Tumbleweed-DVD-x86_64-Build20180619-extra_tests_on_gnome@64bit](http://dhcp151.suse.cz/tests/3613#step/yast2_lan_restart/42)





  
