### PR TITLE
Make the timeout for contacting scc server longer

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -160,7 +160,7 @@ sub register_addons {
                 send_key_until_needlematch "scc-code-field-$addon", 'tab';
             }
             else {
-                assert_and_click "scc-code-field-$addon", 'left', 60;
+                assert_and_click "scc-code-field-$addon", 'left', 120;
             }
             type_string $regcode;
             save_screenshot;


### PR DESCRIPTION
The timeout needs to be longer to allow wait for all modules to register succesfuly.

- Related ticket: https://progress.opensuse.org/issues/37632
- Verification run: http://panigale.suse.cz/tests/2336#step/scc_registration/32
