### PR TITLE
Remove uneeded 'record_soft_failure' in HA tests

### DIFF
--- a/tests/ha/check_logs.pm
+++ b/tests/ha/check_logs.pm
@@ -20,9 +20,7 @@ sub run {
     my $cluster_name = get_cluster_name;
 
     # Checking cluster state can take time, so default timeout is not enough
-    # script_run return undef in case of timeout
-    my $ret = script_run 'crm script run health', 240;
-    record_soft_failure 'bsc#1071519' unless (defined $ret and $ret == 0);
+    assert_script_run 'crm script run health', 240;
 
     barrier_wait("LOGS_CHECKED_$cluster_name");
 

--- a/tests/ha/clvmd_lvmlockd.pm
+++ b/tests/ha/clvmd_lvmlockd.pm
@@ -35,12 +35,9 @@ sub run {
     # DLM process/resource needs to be started
     ensure_dlm_running;
 
+    # lvm2-lockd package should be installed by default
     if ($lock_mgr eq 'lvmlockd') {
-        # Test if package is installed, if not install it and record a softfailure
-        if (!is_package_installed 'lvm2-lockd') {
-            record_soft_failure 'bsc#1076045';
-            zypper_call 'in lvm2-lockd';
-        }
+        die 'lvm2-lockd package is not installed' unless is_package_installed 'lvm2-lockd';
     }
     else {
         # In SLE15, lvmlockd is installed by default, not clvmd/cmirrord

--- a/tests/ha/filesystem.pm
+++ b/tests/ha/filesystem.pm
@@ -65,11 +65,7 @@ sub run {
 
     # ocfs2 package should be installed by default
     if ($fs_type eq 'ocfs2') {
-        # Test if OCFS2 kernel module package is installed
-        if (!is_package_installed 'ocfs2-kmp-default') {
-            record_soft_failure 'bsc#1060601';
-            zypper_call 'in ocfs2-kmp-default';
-        }
+        die 'ocfs2-kmp-default kernel package is not installed' unless is_package_installed 'ocfs2-kmp-default';
     }
 
     # xfsprogs is not installed by default, so we need to install it if needed

--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -49,9 +49,7 @@ sub run {
     assert_script_run "sbd -d $sbd_device list";
 
     # Check if the multicast port is correct (should be 5405 or 5407 by default)
-    if (script_run "grep -Eq '^[[:blank:]]*mcastport:[[:blank:]]*(5405|5407)[[:blank:]]*' $corosync_conf") {
-        record_soft_failure 'bsc#1066196';
-    }
+    assert_script_run "grep -Eq '^[[:blank:]]*mcastport:[[:blank:]]*(5405|5407)[[:blank:]]*' $corosync_conf";
 
     # Do a check of the cluster with a screenshot
     save_state;

--- a/tests/ha/vg.pm
+++ b/tests/ha/vg.pm
@@ -70,19 +70,7 @@ sub run {
         assert_script_run "pvcreate -y $vg_luns";
         $vg_type = '--shared' if (get_var("USE_LVMLOCKD"));
         assert_script_run "vgcreate $vg_type $vg_name $vg_luns";
-
-        if (script_run "lvcreate -n $lv_name -l100%FREE $vg_name") {
-            if (!get_var("USE_LVMLOCKD")) {
-                # Sometimes an 'Error locking on node' error could appear
-                # A refresh of clvmd is needed in this case, it's a old bug!
-                record_soft_failure 'bsc#1076042';
-                script_run 'clvmd -R ; sleep 5 ; clvmd -R';    # Multiple refresh could be necessary
-                assert_script_run "lvcreate -n $lv_name -l100%FREE $vg_name";
-            }
-            else {
-                die 'error while executing lvcreate command';
-            }
-        }
+        assert_script_run "lvcreate -n $lv_name -l100%FREE $vg_name";
 
         # With lvmlockd, VG lock should be stopped before starting HA resource
         if (get_var("USE_LVMLOCKD")) {


### PR DESCRIPTION
Remove these solved bugs:
 - bsc#1060601
 - bsc#1066196
 - bsc#1071519
 - bsc#1076042
 - bsc#1076045

- Verification run: http://1b147.qa.suse.de/tests/2436
