### PR TITLE
Add upgrade tests for HA

### DIFF
--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -27,7 +27,9 @@ sub run {
         die 'A valid number of nodes is mandatory' if ($num_nodes lt '2');
 
         # BARRIER_HA_ needs to also wait the support-server
-        barrier_create("BARRIER_HA_$cluster_name",                  $num_nodes + 1);
+        barrier_create("BARRIER_HA_$cluster_name", $num_nodes + 1);
+
+        # Create barriers for HA clusters
         barrier_create("CLUSTER_INITIALIZED_$cluster_name",         $num_nodes);
         barrier_create("NODE_JOINED_$cluster_name",                 $num_nodes);
         barrier_create("DLM_INIT_$cluster_name",                    $num_nodes);
@@ -48,8 +50,8 @@ sub run {
         barrier_create("LOCK_INIT_$cluster_name",                   $num_nodes);
         barrier_create("LOCK_RESOURCE_CREATED_$cluster_name",       $num_nodes);
         barrier_create("LOGS_CHECKED_$cluster_name",                $num_nodes);
-        barrier_create("CHECK_AFTER_FENCING_BEGIN_$cluster_name",   $num_nodes);
-        barrier_create("CHECK_AFTER_FENCING_END_$cluster_name",     $num_nodes);
+        barrier_create("CHECK_AFTER_REBOOT_BEGIN_$cluster_name",    $num_nodes);
+        barrier_create("CHECK_AFTER_REBOOT_END_$cluster_name",      $num_nodes);
         barrier_create("CHECK_BEFORE_FENCING_BEGIN_$cluster_name",  $num_nodes);
         barrier_create("CHECK_BEFORE_FENCING_END_$cluster_name",    $num_nodes);
         barrier_create("CLUSTER_MD_INIT_$cluster_name",             $num_nodes);

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Check cluster status *after* fencing
+# Summary: Check cluster status *after* reboot
 # Maintainer: Loic Devulder <ldevulder@suse.com>
 
 use base 'opensusebasetest';
@@ -19,23 +19,21 @@ use hacluster;
 sub run {
     my $cluster_name = get_cluster_name;
 
-    # Check cluster state *after* fencing
-    barrier_wait("CHECK_AFTER_FENCING_BEGIN_$cluster_name");
+    # Check cluster state *after* reboot
+    barrier_wait("CHECK_AFTER_REBOOT_BEGIN_$cluster_name");
 
     # We need to be sure to be root and, after fencing, the default console on node01 is not root
-    if (is_node(1)) {
-        reset_consoles;
-        select_console 'root-console';
-    }
+    reset_consoles if (is_node(1) && !get_var('HDDVERSION'));
+    select_console 'root-console';
 
-    # Wait for the cluster to be up on the fenced node
-    # We can execute this test on all nodes, so do it as it's easier to code :-)
-    assert_script_run 'crm cluster wait_for_startup';
+    # Wait for resources to be started
+    wait_until_resources_started;
 
     # And check for the state of the whole cluster
     check_cluster_state;
 
-    barrier_wait("CHECK_AFTER_FENCING_END_$cluster_name");
+    # Synchronize all nodes
+    barrier_wait("CHECK_AFTER_REBOOT_END_$cluster_name");
 }
 
 1;


### PR DESCRIPTION
This commit adds code to be able to upgrade a HA cluster with all HA stack/resources configured, and test that all is still running well after the upgrade.

Verification run:
* http://1b147.qa.suse.de/tests/2508
* http://1b147.qa.suse.de/tests/2511
* http://1b147.qa.suse.de/tests/2537
* http://1b147.qa.suse.de/tests/2539