### PR TITLE
New test cases for apparmor aa-autodep and aa-logprof

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -1,0 +1,128 @@
+# Copyright (C) 2017-2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Base module for AppArmor test cases
+# Maintainer: Wes <whdu@suse.com>
+
+package apparmortest;
+
+use strict;
+use testapi;
+use utils;
+use version_utils qw(is_sle is_leap);
+
+use base 'consoletest';
+
+# Disable stdout buffering to make pipe works
+sub aa_disable_stdout_buf {
+    my ($self, $app) = @_;
+    if (is_sle('<15') or is_leap('<15.0')) {    # apparmor < 2.8.95
+        assert_script_run "sed -i '/use strict;/a \$|=1;' $app";
+    }
+    else {                                      # apparmor >= 2.8.95
+        assert_script_run "export PYTHONUNBUFFERED=1";
+    }
+}
+
+
+# $prof_dir_tmp: The target temporary directory
+# $type:
+# 0  - Copy only the basic structure of profile directory
+# != 0 (default) - Copy full contents under the profile directory
+sub aa_tmp_prof_prepare {
+    my ($self, $prof_dir_tmp, $type) = @_;
+    my $prof_dir = "/etc/apparmor.d";
+    $type //= 1;
+
+    if ($type == 0) {
+        assert_script_run "mkdir $prof_dir_tmp";
+        assert_script_run "cp -r $prof_dir/{tunables,abstractions} $prof_dir_tmp/";
+        if (is_sle('<15') or is_leap('<15.0')) {    # apparmor < 2.8.95
+            assert_script_run "cp -r $prof_dir/program-chunks $prof_dir_tmp/";
+        }
+    }
+    else {
+        assert_script_run "cp -r $prof_dir $prof_dir_tmp";
+    }
+}
+
+# Verify the program could start with the temporary profiles
+# Then restore it to the enforce status with normal profiles
+sub aa_tmp_prof_verify {
+    my ($self, $prof_dir_tmp, $prog) = @_;
+
+    assert_script_run("aa-disable $prog");
+
+    assert_script_run("aa-enforce -d $prof_dir_tmp $prog");
+    systemctl("restart $prog");
+    assert_script_run("aa-disable -d $prof_dir_tmp $prog");
+
+    assert_script_run("aa-enforce $prog");
+    systemctl("restart $prog");
+}
+
+sub aa_tmp_prof_clean {
+    my ($self, $prof_dir_tmp) = @_;
+
+    assert_script_run "rm -rf $prof_dir_tmp";
+}
+
+# For interactive command, answer the question according to the contents
+# matched. Need an arrayref to pass the contents to be filtered and the
+# Answer send_key
+sub aa_interactive_run {
+    my ($self, $cmd, $scan, $timeout) = @_;
+    my $output;
+    my @words;
+    $timeout //= 180;
+
+    for my $k (@$scan) {
+        push(@words, $k->{word});
+    }
+
+    if ($cmd) {
+        script_run("(" . $cmd . ")| tee /dev/$serialdev", 0);
+    }
+
+  LOOP: {
+        do {
+            $output = wait_serial(\@words, $timeout) || die "Uknown Options!";
+            for my $i (@$scan) {
+                if ($output =~ $i->{word}) {
+                    if ($i->{key}) {
+                        send_key $i->{key};
+                        last LOOP if ($i->{end});
+                        last;
+                    }
+                    elsif ($i->{end}) {
+                        last LOOP;
+                    }
+                    else {
+                        die "$i->{word} - 'key' or 'end' should be specified";
+                    }
+                }
+            }
+        } while ($output);
+    }
+}
+
+sub pre_run_hook {
+    my ($self) = @_;
+
+    select_console 'root-console';
+    systemctl('restart apparmor');
+}
+
+1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1753,6 +1753,7 @@ sub load_security_tests_apparmor_status {
 sub load_security_tests_apparmor_genprof {
     loadtest "security/apparmor/aa_genprof";
     loadtest "security/apparmor/aa_autodep";
+    loadtest "security/apparmor/aa_logprof";
 }
 
 sub load_systemd_patches_tests {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1752,6 +1752,7 @@ sub load_security_tests_apparmor_status {
 
 sub load_security_tests_apparmor_genprof {
     loadtest "security/apparmor/aa_genprof";
+    loadtest "security/apparmor/aa_autodep";
 }
 
 sub load_systemd_patches_tests {

--- a/tests/security/apparmor/aa_autodep.pm
+++ b/tests/security/apparmor/aa_autodep.pm
@@ -1,0 +1,97 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Guess basic AppArmor profile requirements with aa_autodep
+# Maintainer: Wes <whdu@suse.com>
+# Tags: poo#36889, tc#1621141
+
+use strict;
+use base "consoletest";
+use testapi;
+use utils;
+use version_utils qw(is_sle is_leap);
+
+sub run {
+
+    my $aa_prof     = "/etc/apparmor.d";
+    my $aa_tmp_prof = "/tmp/apparmor.d";
+
+    my $aa_autodep_inactive = qr/Inactive local profile/m;
+    my $aa_autodep_done     = qr/AUTODEP-DONE/m;
+    my $aa_autodep_check    = [$aa_autodep_inactive, $aa_autodep_done];
+
+    my $output;
+
+    select_console 'root-console';
+
+    # Must disable stdout buffering to make pipe works
+    if (is_sle('<15') or is_leap('<15.0')) {    # apparmor < 2.8.95
+        assert_script_run "sed -i '/use strict;/a \$|=1;' /usr/sbin/aa-autodep";
+    }
+    else {                                      # apparmor >= 2.8.95
+        assert_script_run "export PYTHONUNBUFFERED=1";
+    }
+
+    assert_script_run "mkdir $aa_tmp_prof";
+    assert_script_run "cp -r $aa_prof/{tunables,abstractions} $aa_tmp_prof/";
+
+    if (is_sle('<15') or is_leap('<15.0')) {    # apparmor < 2.8.95
+        assert_script_run "cp -r $aa_prof/program-chunks $aa_tmp_prof/";
+    }
+
+    assert_script_run "aa-autodep -d $aa_tmp_prof/ nscd";
+    save_screenshot;
+
+    validate_script_output "cat $aa_tmp_prof/usr.sbin.nscd", sub {
+        m/
+            include\s+<tunables\/global>.*
+            \/usr\/sbin\/nscd\s+flags=\(complain\)\s*\{.*
+            include\s+<abstractions\/base>.*
+            \/usr\/sbin\/nscd\s+mr.*
+            \}/sxx
+    };
+
+    save_screenshot;
+
+    assert_script_run "rm -f $aa_tmp_prof/usr.sbin.nscd";
+
+    # Test batch profiles generation function
+    script_run("(aa-autodep --d $aa_tmp_prof /usr/bin/pam*;echo 'AUTODEP-DONE')|tee /dev/$serialdev", 0);
+
+    {
+        do {
+            $output = wait_serial($aa_autodep_check, 300);
+            if ($output =~ $aa_autodep_inactive) {
+                send_key "c";
+                send_key "ret";
+            }
+            elsif ($output =~ $aa_autodep_done) {
+                save_screenshot;
+                last;
+            }
+            else {
+                die "Unknown options!";
+            }
+        } while ($output);
+    }
+
+    # Output generated profiles list to serial console
+    assert_script_run "ls -1 $aa_tmp_prof/*pam* |tee /dev/$serialdev";
+
+    # Clean up
+    assert_script_run("rm -rf $aa_tmp_prof");
+}
+
+1;

--- a/tests/security/apparmor/aa_genprof.pm
+++ b/tests/security/apparmor/aa_genprof.pm
@@ -18,77 +18,57 @@
 # Tags: poo#36886, tc#1621140
 
 use strict;
-use base "consoletest";
+use base "apparmortest";
 use testapi;
 use utils;
-use version_utils qw(is_sle is_leap);
 
 sub run {
+    my ($self) = @_;
 
-    my $aa_tmp_prof       = "/tmp/apparmor.d";
-    my $aa_genprof_allow  = qr/\(A\)llow.*\(D\)eny/m;
-    my $aa_genprof_scan   = qr/\(S\)can system/m;
-    my $aa_genprof_finish = $aa_genprof_scan;
-    my $aa_genprof_save   = qr/\(S\)ave Changes/m;
-    my $aa_genprof_filter = [$aa_genprof_allow, $aa_genprof_finish, $aa_genprof_save];
+    my $aa_tmp_prof           = "/tmp/apparmor.d";
+    my $aa_genprof_filter_pre = [
+        {
+            word => qr/\(S\)can system.*\(F\)inish/m,
+            key  => 's',
+            end  => 1,
+        },
+    ];
+    my $aa_genprof_filter = [
+        {
+            word => qr/\(A\)llow.*\(D\)eny/m,
+            key  => 'a',
+        },
+        {
+            word => qr/\(S\)ave Changes/m,
+            key  => 's',
+        },
+        {
+            word => qr/\(S\)can system.*\(F\)inish/m,
+            key  => 'f',
+            end  => 1,
+        },
+    ];
 
-    select_console 'root-console';
-
-    systemctl('restart apparmor');
     systemctl('start auditd');
 
-    save_screenshot;
+    $self->aa_disable_stdout_buf("/usr/sbin/aa-genprof");
+    $self->aa_tmp_prof_prepare("$aa_tmp_prof");
 
-    # Must disable stdout buffering to make pipe works
-    if (is_sle('<15') or is_leap('<15.0')) {    # apparmor < 2.8.95
-        assert_script_run "sed -i '/use strict;/a \$|=1;' /usr/sbin/aa-genprof";
-    }
-    else {                                      # apparmor >= 2.8.95
-        assert_script_run "export PYTHONUNBUFFERED=1";
-    }
-
-    # Test in a separate profile directory to avoid messing up
-    assert_script_run("cp -r /etc/apparmor.d $aa_tmp_prof");
     assert_script_run("rm -f  $aa_tmp_prof/usr.sbin.nscd");
 
     # Run the command in background so that we could run other commands
     script_run("(aa-genprof -d $aa_tmp_prof nscd|tee /dev/$serialdev) &", 0);
-    sleep 3;
-    send_key 'ret';                             # Back to the shell prompt
+    sleep 2;
+    send_key 'ret';    # Back to the shell prompt
 
     systemctl('restart nscd');
 
     # Call the job to the front ground
     script_run("fg", 0);
-    send_key 'ret';                             # Work around for Tumblweed
+    send_key 'ret';    # Work around for Tumblweed
 
-    my $output = wait_serial($aa_genprof_scan);
-
-    # Interactive prompt capture
-    die "UI - Scan failed!" unless $output =~ $aa_genprof_scan;
-    send_key 's';                               #(S)can
-
-    {
-        do {
-            $output = wait_serial($aa_genprof_filter);
-            if ($output =~ $aa_genprof_allow) {
-                send_key 'a';                   #(A)llow
-            }
-            elsif ($output =~ $aa_genprof_finish) {
-                send_key 'f';                   #(F)inish
-                wait_serial('Finished generating profile for')
-                  || die "Not finish in time";
-                save_screenshot;
-                last;
-            }
-            elsif ($output =~ $aa_genprof_save) {
-                send_key 's';                   #(S)ave
-            }
-            else {
-                die "Unknown options!";
-            }
-        } while ($output);
-    }
+    $self->aa_interactive_run(undef, $aa_genprof_filter_pre);
+    $self->aa_interactive_run(undef, $aa_genprof_filter);
 
     # Not all rules will be checked here, only the critical ones.
     validate_script_output "cat $aa_tmp_prof/usr.sbin.nscd", sub {
@@ -100,14 +80,8 @@ sub run {
             }/sxx
     };
 
-    # Verify nscd could start with new generated profile
-    assert_script_run("aa-enforce -d $aa_tmp_prof /usr/sbin/nscd");
-    systemctl('restart nscd');
-
-    # Clean up and restore
-    assert_script_run("aa-disable -d $aa_tmp_prof /usr/sbin/nscd");
-    assert_script_run("rm -rf $aa_tmp_prof");
-    systemctl('restart nscd');
+    $self->aa_tmp_prof_verify("$aa_tmp_prof", 'nscd');
+    $self->aa_tmp_prof_clean("$aa_tmp_prof");
 }
 
 1;

--- a/tests/security/apparmor/aa_logprof.pm
+++ b/tests/security/apparmor/aa_logprof.pm
@@ -1,0 +1,103 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test the utility for updating AppArmor security profiles
+# Maintainer: Wes <whdu@suse.com>
+# Tags: poo#36892, tc#1621143
+
+use strict;
+use base "consoletest";
+use testapi;
+use utils;
+use version_utils qw(is_sle is_leap);
+
+sub run {
+
+    my $output;
+    my $aa_prof     = "/etc/apparmor.d";
+    my $aa_tmp_prof = "/tmp/apparmor.d";
+
+    my $aa_logprof_allow = qr/\(A\)llow/m;
+    my $aa_logprof_save  = qr/\(S\)ave Changes/m;
+
+    select_console 'root-console';
+
+    systemctl('restart apparmor');
+    systemctl('stop nscd');
+    systemctl('restart auditd');
+
+    # Must disable stdout buffering to make pipe works
+    if (is_sle('<15') or is_leap('<15.0')) {    # apparmor < 2.8.95
+        assert_script_run "sed -i '/use strict;/a \$|=1;' /usr/sbin/aa-logprof";
+    }
+    else {                                      # apparmor >= 2.8.95
+        assert_script_run "export PYTHONUNBUFFERED=1";
+    }
+
+    assert_script_run "cp -r $aa_prof $aa_tmp_prof";
+
+    my @aa_logprof_items = ('capability setuid', '\/var\/log\/nscd.log');
+
+    # Remove some rules from profile
+    foreach my $item (@aa_logprof_items) {
+        assert_script_run "sed -i '/$item/d' $aa_tmp_prof/usr.sbin.nscd";
+    }
+
+    validate_script_output "aa-complain -d $aa_tmp_prof usr.sbin.nscd", sub { m/Setting.*complain/ };
+
+    systemctl('start nscd');
+
+    script_run("aa-logprof -d $aa_tmp_prof|tee /dev/$serialdev", 0);
+
+    # Interactive prompt capture
+    {
+        do {
+            $output = wait_serial([$aa_logprof_allow, $aa_logprof_save]);
+            if ($output =~ $aa_logprof_allow) {
+                send_key 'a';
+            }
+            elsif ($output =~ $aa_logprof_save) {
+                send_key 's';
+                last;
+            }
+            else {
+                die "Unknown options!";
+            }
+        } while ($output);
+    }
+
+    validate_script_output "cat $aa_tmp_prof/usr.sbin.nscd", sub {
+        m/
+            include\s+<tunables\/global>.*
+            \/usr\/sbin\/nscd\s+flags=\(complain\)\s*\{.*
+            \/etc\/nscd\.conf\s+r.*
+            \/usr\/sbin\/nscd\s+mrix.*
+            \}/sxx
+    };
+
+    # Verify nscd could start with new generated profile
+    assert_script_run("aa-enforce -d $aa_tmp_prof /usr/sbin/nscd");
+    systemctl('restart nscd');
+
+    # Restore
+    assert_script_run("aa-disable -d $aa_tmp_prof /usr/sbin/nscd");
+    assert_script_run("aa-enforce /usr/sbin/nscd");
+    systemctl('restart nscd');
+
+    # Clean up
+    assert_script_run("rm -rf $aa_tmp_prof");
+}
+
+1;


### PR DESCRIPTION
New test cases for apparmor aa-autodep([poo#36889](https://progress.opensuse.org/issues/36889)) and aa-logprof([poo#36892](https://progress.opensuse.org/issues/36892))

- Related ticket:
  - aa-autodep: https://progress.opensuse.org/issues/36889
  - aa-logprof: https://progress.opensuse.org/issues/36892
- Verification run:
  - SLE: http://10.67.17.9/tests/777
  - Tumbleweed: http://10.67.17.9/tests/776
