### PR TITLE
[IMPORTANT]  [sle12sp4] Make 12 sp4 guest install works

### DIFF
--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -14,6 +14,7 @@ use base "virt_autotest_base";
 use strict;
 use warnings;
 use testapi;
+use virt_utils;
 
 sub get_script_run {
     my $prd_version = script_output("cat /etc/issue");
@@ -24,7 +25,8 @@ sub get_script_run {
     else {
         $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-virt_install_withopt-run";
     }
-
+    # testsuite setting pre-handling for no service pack products
+    handle_sp_in_settings_with_fcs("GUEST_PATTERN");
     my $guest_pattern = get_var('GUEST_PATTERN', 'sles-12-sp2-64-[p|f]v-def-net');
     my $parallel_num  = get_var("PARALLEL_NUM",  "2");
     $pre_test_cmd = $pre_test_cmd . " -f " . $guest_pattern . " -n " . $parallel_num . " -r ";

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -23,8 +23,10 @@ use XML::Writer;
 use IO::File;
 use proxymode;
 use virt_autotest_base;
+use version_utils 'is_sle';
 
-our @EXPORT = qw(update_guest_configurations_with_daily_build repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile);
+our @EXPORT
+  = qw(update_guest_configurations_with_daily_build repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0);
 
 sub get_version_for_daily_build_guest {
     my $version = '';
@@ -107,11 +109,38 @@ sub repl_guest_autoyast_addon_with_daily_build_module {
     repl_addon_with_daily_build_module_in_files("$file_list");
 }
 
+# Many virtualization testsuites contain settings composed by %DISTRI%s-%VERSION%
+# that need special handling for sp0/fcs, when integer products are being tested, eg sle15
+sub handle_sp_in_settings {
+    my ($var_name, $value_for_sp) = @_;
+
+    die "We only support sles product currently!" unless is_sle;
+
+    # We need small case variable value
+    my $var_value = lc(get_required_var("$var_name"));
+    # Add $value_for_sp after release for products like sle15, sle16
+    if ($var_value !~ /sp/ && "$value_for_sp") {
+        $var_value =~ s/(sles-\d+)/$1-$value_for_sp/;
+    }
+    set_var("$var_name", "$var_value");
+    bmwqemu::save_vars();
+}
+
+sub handle_sp_in_settings_with_fcs {
+    my $var_name = shift;
+    handle_sp_in_settings($var_name, "fcs");
+}
+
+sub handle_sp_in_settings_with_sp0 {
+    my $var_name = shift;
+    handle_sp_in_settings($var_name, "sp0");
+}
+
 sub update_guest_configurations_with_daily_build {
     repl_repo_in_sourcefile;
     repl_module_in_sourcefile;
-    #qa_lib_virtauto pkg will handle replacing module url with module link in source.xx for sle15 and 15+
-    #repl_guest_autoyast_addon_with_daily_build_module;
+    # qa_lib_virtauto pkg will handle replacing module url with module link in source.xx for sle15 and 15+
+    # repl_guest_autoyast_addon_with_daily_build_module;
 }
 
 1;

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -64,8 +64,8 @@ sub repl_repo_in_sourcefile {
 sub repl_module_in_sourcefile {
     my $version = get_version_for_daily_build_guest;
     $version =~ s/fcs/sp0/;
-    my $release = ($version =~ /(\d+)-/m);
-    #We only support sle product, and only products >= sle15 has module link
+    my ($release) = ($version =~ /(\d+)-/m);
+    # We only support sle product, and only products >= sle15 has module link
     return unless (is_sle && $release >= 15);
 
     my $replaced_item = "(source.(Basesystem|Desktop-Applications|Legacy|Server-Applications|Development-Tools|Web-Scripting).sles-" . $version . "-64=)";

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -58,10 +58,14 @@ sub repl_repo_in_sourcefile {
         print "Do not need to change resource for $veritem item\n";
     }
 }
-#Replace module repos configured in sources.* with openqa daily build repos
+# Replace module repos configured in sources.* with openqa daily build repos
 sub repl_module_in_sourcefile {
     my $version = get_version_for_daily_build_guest;
     $version =~ s/fcs/sp0/;
+    my $release = ($version =~ /(\d+)-/m);
+    #We only support sle product, and only products >= sle15 has module link
+    return unless (is_sle && $release >= 15);
+
     my $replaced_item = "(source.(Basesystem|Desktop-Applications|Legacy|Server-Applications|Development-Tools|Web-Scripting).sles-" . $version . "-64=)";
     $version =~ s/-sp0//;
     my $daily_build_module = "http://openqa.suse.de/assets/repo/SLE-${version}-Module-\\2-POOL-x86_64-Build" . get_required_var('BUILD') . "-Media1/";
@@ -106,7 +110,8 @@ sub repl_guest_autoyast_addon_with_daily_build_module {
 sub update_guest_configurations_with_daily_build {
     repl_repo_in_sourcefile;
     repl_module_in_sourcefile;
-    repl_guest_autoyast_addon_with_daily_build_module;
+    #qa_lib_virtauto pkg will handle replacing module url with module link in source.xx for sle15 and 15+
+    #repl_guest_autoyast_addon_with_daily_build_module;
 }
 
 1;


### PR DESCRIPTION
Background:
Virtualization testsuites contains quite some settings which are used as parameters when calling underlying test scripts. They are generated via DISTRI/VERSION variables. However these parameters are required to handle fcs/sp0 correctly for products without service-pack, for example, sle15/sle16, and they need different handling comparing with products with service pack, eg sles12sp4. 

Solution:
So to reuse testsuites and share same setting for different but parallel testing targets,  we need to handle these settings inside test code according to test target.
Here the common library functions and changes for guest installation project are done. Meanwhile it fixes update_pkg failure in 12sp4 openqa test.
Changes for other projects will be in separate PR.


- Verification run: 
Please ignore the overall test status, just verify real code change part since it takes too long to finish.
http://10.67.18.220/tests/117
http://10.67.18.220/tests/109
http://10.67.18.220/tests/104
