### PR TITLE
Update win10 test cases to adapt win10 april update

### DIFF
--- a/tests/installation/win10_firstboot.pm
+++ b/tests/installation/win10_firstboot.pm
@@ -16,24 +16,48 @@ use strict;
 use testapi;
 
 sub run {
-    assert_screen 'windows-first-boot', 1000;
-    send_key 'alt-e';    # use express settings button
-    assert_screen 'windows-owner', 200;
-    assert_and_click 'windows-next';    # no alt-n shortcut
-    assert_and_click 'windows-local-active-directory';
-    assert_and_click 'windows-next';    # no alt-n shortcut
-    assert_screen 'windows-user', 60;
-    send_key 'tab';                     # select user name
-    type_string $realname;
-    send_key 'tab';                     # go to password
-    type_password;
-    send_key 'tab';                     # go to password
-    type_password;
-    send_key 'tab';                     # go to hint (hint is important for windows)
-    type_string 'security';
-    wait_still_screen;
-    send_key 'alt-n';                   # next
-    assert_screen 'desktop-at-first-boot', 600;
+    assert_screen 'windows-start-with-region', 1000;
+    assert_and_click 'windows-yes';
+    assert_screen 'windows-keyboard-layout';
+    assert_and_click 'windows-yes';
+    assert_and_click 'windows-skip-second-keyboard';
+    assert_screen 'windows-signin-with-ms', 1000;
+    assert_and_click 'windows-offline';
+    assert_and_click 'windows-no-signin-ms-instead';
+    sleep 3;
+    type_string $realname;    # input account name
+    assert_and_click 'windows-next';
+    type_password;            # input password
+    assert_and_click 'windows-next';
+    type_password;            # confirm password
+    assert_and_click 'windows-next';
+    for (1 .. 3) {
+        sleep 3;
+        assert_and_click 'windows-security-question';
+        send_key 'down';
+        send_key 'ret';
+        send_key 'tab';
+        type_string 'security';
+        sleep 3;
+        assert_and_click 'windows-next';
+    }
+    assert_screen 'windows-make-cortana-personal-assistant';
+    assert_and_click 'windows-no';
+    assert_and_click 'windows-dont-use-speech-recognition';
+    assert_and_click 'windows-accept';
+    assert_and_click 'windows-dont-user-my-location';
+    assert_and_click 'windows-accept';
+    assert_and_click 'windows-turn-off-find-device';
+    assert_and_click 'windows-accept';
+    assert_and_click 'windows-send-full-diagnostic-data';
+    assert_and_click 'windows-accept';
+    assert_and_click 'windows-dont-improve-inking&typing';
+    assert_and_click 'windows-accept';
+    assert_and_click 'windows-dont-get-tailored-experiences';
+    assert_and_click 'windows-accept';
+    assert_and_click 'windows-dont-use-adID';
+    assert_and_click 'windows-accept';
+    assert_screen 'windows-first-boot', 600;
 }
 
 1;

--- a/tests/installation/win10_reboot.pm
+++ b/tests/installation/win10_reboot.pm
@@ -17,16 +17,11 @@ use testapi;
 use windows_utils;
 
 sub run {
-    send_key 'super';    # windows menu
-
-    assert_screen 'windows-menu';
-
-    send_key 'up';
-    send_key 'up';
-    send_key 'spc';      # press power button
-    send_key 'up';
-    send_key 'spc';      # press shutdown button
-
+    assert_and_click 'windows-close-edge';
+    send_key 'alt-f4';
+    assert_screen 'windows-shutdown';
+    send_key 'down';    # switch from 'Shut down' to 'Restart'
+    send_key 'ret';     # press ok to restart
     wait_boot_windows;
 }
 

--- a/tests/installation/win10_shutdown.pm
+++ b/tests/installation/win10_shutdown.pm
@@ -16,14 +16,9 @@ use strict;
 use testapi;
 
 sub run {
-    send_key 'super';    # windows menu
-    assert_screen 'windows-menu';
-    send_key 'up';
-    send_key 'up';
-    send_key 'spc';          # press power button
-    send_key 'up';
-    send_key 'up';
-    send_key 'shift-ret';    # press shutdown button, use shift to avoid hybrid-shutdown
+    send_key 'alt-f4';
+    assert_screen 'windows-shutdown';
+    send_key 'ret';    # press ok to shutdown the os
     assert_shutdown;
 }
 


### PR DESCRIPTION
- Since first boot configuration changed, so update win10_firstboot
- Simplify the reboot and shutdown steps for win10_reboot and
win10_shutdown

- Related ticket: https://progress.opensuse.org/issues/37243
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/388
- Verification run: http://147.2.212.151/tests/42#
