### PR TITLE
Allow theme installation in Firefox test

### DIFF
--- a/tests/x11/firefox/firefox_appearance.pm
+++ b/tests/x11/firefox/firefox_appearance.pm
@@ -31,6 +31,9 @@ sub run {
     type_string "addons.mozilla.org/en-US/firefox/addon/opensuse\n";
     assert_screen('firefox-appearance-mozilla_addons', 90);
     assert_and_click "firefox-appearance-addto";
+    if (check_screen("firefox-appearance-addto-permissions_requested", 10)) {
+        assert_and_click "firefox-appearance-addto-permissions_requested";
+    }
     assert_screen('firefox-appearance-installed', 90);
     # Undo the theme installation
     send_key "alt-u";


### PR DESCRIPTION
New Firefox requires explicit allow before theme installation.

- Related ticket: https://progress.opensuse.org/issues/37725
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/876
- Verification run: http://panigale.suse.cz/tests/2366#step/firefox_appearance/13