### PR TITLE
Remove zypper_info test on SLED

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -976,7 +976,8 @@ sub load_consoletests {
     # We also don't have any repos on staging and update/upgrade tests.
     # This test uses serial console too much to be reliable on Hyper-V (poo#30613)
     # Test doesn't make sense on live images too, don't have source repo there.
-    if (!is_staging() && !is_updates_tests() && !is_upgrade() && !is_jeos() && !is_hyperv() && !is_livesystem()) {
+    # Skip this test for SLED (poo#36397)
+    if (!is_staging() && !is_updates_tests() && !is_upgrade() && !is_jeos() && !is_hyperv() && !is_livesystem() && !is_desktop()) {
         loadtest "console/zypper_info";
     }
     # Add non-oss and debug repos for o3 and remove other by default


### PR DESCRIPTION
As discussed in poo#36397, `zypper_info` test is not needed on SLED, so removing it.

- Related ticket: https://progress.opensuse.org/issues/36397
- Needles: no changes
- Verification run: http://10.67.19.79/tests/31  There is no `zypper_info` compared with https://openqa.suse.de/tests/1748676#step/zypper_info/9
