### PR TITLE
Don't start  'addon_products_via_SCC_yast2' on slenkins tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1112,7 +1112,7 @@ else {
             if (get_var("ADDONS")) {
                 loadtest "installation/addon_products_yast2";
             }
-            if (get_var('SCC_ADDONS')) {
+            if (get_var('SCC_ADDONS') && !get_var('SLENKINS_NODE')) {
                 loadtest "installation/addon_products_via_SCC_yast2";
             }
             if (get_var("ISCSI_SERVER")) {


### PR DESCRIPTION
fixes : https://openqa.suse.de/tests/1784906
