### PR TITLE
memtest: End the test after mem check passed

### DIFF
--- a/tests/installation/memtest.pm
+++ b/tests/installation/memtest.pm
@@ -15,16 +15,12 @@ use base 'opensusebasetest';
 use strict;
 use testapi;
 use bootloader_setup 'ensure_shim_import';
-use utils 'power_action';
 
 sub run {
     my $self = shift;
-
     ensure_shim_import;
     $self->select_bootmenu_more('inst-onmemtest', 1);
-    assert_screen 'pass-complete', check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 1100 : 700;
-    send_key 'esc';
-    power_action('poweroff', keepconsole => 1, observe => 1);
+    assert_screen('pass-complete', 700);
 }
 
 sub test_flags {


### PR DESCRIPTION
To fix a regression from https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5269. (Sorry.)

Well, it turn's out that `Esc` restarts not shutdowns the system. And I
really don't see any reason to restart the system after the check
passed, so just ending the test, when we are done. (Btw, we never
restarted the system before, we just send `Esc` to restart it, but
turned the system off immediately.)

Also removed the Hyper-V specifix check as `TIMEOUT_SCALE` does that for
us.

Fails here:
* memtest@64bit: https://openqa.suse.de/tests/1784183
* memtest@svirt-hyperv: https://openqa.suse.de/tests/1784204

Validation:
* memtest@svirt-hyperv: http://nilgiri.suse.cz/tests/244