### PR TITLE
JeOS: Record machine-id

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -704,6 +704,7 @@ testapi::set_distribution(susedistribution->new());
 if (is_jeos) {
     load_boot_tests();
     loadtest "jeos/firstrun";
+    loadtest "jeos/record_machine_id";
     loadtest "console/force_cron_run";
     loadtest "jeos/grub2_gfxmode";
     loadtest 'jeos/revive_xen_domain' if check_var('VIRSH_VMM_FAMILY', 'xen');

--- a/tests/jeos/record_machine_id.pm
+++ b/tests/jeos/record_machine_id.pm
@@ -1,0 +1,24 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Record machine-id
+# Maintainer: Michal Nowak <mnowak@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use testapi;
+
+sub run {
+    select_console 'root-console';
+
+    my $machine_id = script_output('cat /etc/machine-id');
+    record_info('/etc/machine-id', $machine_id);
+}
+
+1;


### PR DESCRIPTION
https://progress.opensuse.org/issues/37832

This just records `/etc/machine-id` in openQA job. I don't see a
reliable (and easy) way in openQA to make sure `machine-id` differs for
every installation/deployment. One has to manually check that the
`machine-id` differs among instances of the same image, and among build
of the same machine. And that it's set at all.

Validation runs:
* `jeos-main@64bit-virtio-vga`: http://nilgiri.suse.cz/tests/261#step/record_machine_id/4
* `jeos-main@svirt-xen-hvm`: http://nilgiri.suse.cz/tests/262#step/record_machine_id/4
* `jeos-main@svirt-xen-pv`: http://nilgiri.suse.cz/tests/263#step/record_machine_id/4