### PR TITLE
Deactivate USE_LVMLOCKD in SLE <15

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -511,6 +511,9 @@ sub load_slenkins_tests {
 sub load_ha_cluster_tests {
     return unless (get_var('HA_CLUSTER'));
 
+    # Only SLE-15+ has support for lvmlockd
+    set_var('USE_LVMLOCKD', 0) if (get_var('USE_LVMLOCKD') and is_sle('<15'));
+
     # Standard boot and configuration
     boot_hdd_image;
     loadtest 'ha/wait_barriers';


### PR DESCRIPTION
Only SLE-15+ has support for lvmlockd, so we need to force USE_LVMLOCKD to 0 if needed.

- Verification run: http://1b147.qa.suse.de/tests/2479
