### PR TITLE
HPC: add web-scripting module to medium

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -382,7 +382,7 @@ if (get_var('SUPPORT_SERVER_ROLES', '') =~ /aytest/ && !get_var('AYTESTS_REPO'))
 
 # Workaround to be able to use create_hdd_hpc_textmode simultaneously  in SLE15 and SLE12 SP*
 if (check_var('SLE_PRODUCT', 'hpc') && check_var('INSTALLONLY', '1') && is_sle('<15')) {
-    set_var('SCC_ADDONS',   'hpcm');
+    set_var('SCC_ADDONS',   'hpcm,wsm');
     set_var('SCC_REGISTER', 'installation');
 }
 


### PR DESCRIPTION
Some HPC packages ( e.g. ganglia-web ) requires Web-Scripting module enabled