### PR TITLE
Test that we can't stop docker using ^C because that must be supported by the application running insude the container

### DIFF
--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -116,6 +116,18 @@ sub run {
         assert_script_run('man -P cat docker config | grep "docker-config - Manage Docker configs"');
     }
 
+    # Try to stop container using ctrl+c
+    type_string("docker run --rm opensuse/tumbleweed sleep 30\n");
+    type_string("# Let's press ctrl+c right now ... ");
+    send_key 'ctrl-c';
+    type_string("# ... and we seem to be still in container\n");
+    # If echo works then ctrl-c stopped sleep
+    type_string "echo 'ctrlc_timeout' > /dev/$serialdev\n";
+    if (wait_serial 'ctrlc_timeout', 10, 1) {
+        die 'ctrl-c stopped container';
+    }
+    die "Something went wrong" unless wait_serial('ctrlc_timeout', 30);
+
     # containers can be stopped
     assert_script_run("docker container stop $container_name");
     assert_script_run("docker container inspect --format='{{.State.Running}}' $container_name | grep false");


### PR DESCRIPTION
Hello,

this test was requested after bsc#1073877 and bsc#1089732

Some programs (f.e. bash) can handle signals and so we can close them by pressing ^C
Another programs (f.e. sleep) cannot do that and so this test checks exactly this.

- Related ticket: https://progress.opensuse.org/issues/36784
- Needles: Not needed
- Verification run: [SLE12](http://pdostal-server.suse.cz/tests/786), [SLE15](http://pdostal-server.suse.cz/tests/788), [Tumbleweed](http://pdostal-server.suse.cz/tests/812), [Leap15](http://pdostal-server.suse.cz/tests/811)