### PR TITLE
Skip hpcm license check for SLE15 HPC product

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -67,7 +67,7 @@ our %SLE15_DEFAULT_MODULES = (
     sles4sap => 'base,desktop,serverapp,ha,sapapp',
 );
 
-our @SLE15_ADDONS_WITHOUT_LICENSE = qw(ha sdk wsm we);
+our @SLE15_ADDONS_WITHOUT_LICENSE = qw(ha sdk wsm we hpcm);
 
 # Method to determine if a short name references a module based on what's defined
 # on %SLE15_MODULES
@@ -84,7 +84,7 @@ sub accept_addons_license {
     #   isc co SUSE:SLE-15:GA 000product
     #   grep -l EULA SUSE:SLE-15:GA/000product/*.product | sed 's/.product//'
     # All shown products have a license that should be checked.
-    my @addons_with_license = qw(geo live rt idu ids lgm hpcm ses);
+    my @addons_with_license = qw(geo live rt idu ids lgm ses);
 
     # In SLE 15 some modules do not have license or have the same
     # license (see bsc#1089163) and so are not be shown twice


### PR DESCRIPTION
Enhancement poo#37925: Maintenance flow needs variables SCC_ADDONS
and SLE_PRODUCT defined at the same time. License check for hpc module
needs to be skipped for SLE15.

- Related ticket: https://progress.opensuse.org/issues/37925
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/878
- Verification run SLE15 without license check:
http://10.100.12.105/tests/2373#step/scc_registration/1
- Verification run SLE12-SP3 with license:
http://10.100.12.105/tests/2374#step/scc_registration/28
