### PR TITLE
[WIP] Assert desktop-runner is ready before sending 'ret'

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -140,6 +140,7 @@ sub init_desktop_runner {
     else {
         type_string $program;
     }
+    assert_screen 'desktop-runner-program-found';
 }
 
 =head2 x11_start_program


### PR DESCRIPTION
Avoid race condition by asserting that desktop-runner is ready before sending 'ret'.

- Related ticket: https://progress.opensuse.org/issues/37354
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/389
- Verification run: http://10.160.66.74/tests/388#step/desktop_runner/2
