### PR TITLE
Add info about the current window system

### DIFF
--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -14,6 +14,7 @@
 use base 'opensusebasetest';
 use strict;
 use testapi;
+use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
@@ -25,6 +26,12 @@ sub run {
     }
     else {
         $self->wait_boot(bootloader_time => $timeout);
+    }
+    if (is_sle && !check_var('DESKTOP', 'textmode')) {
+        x11_start_program('xterm');
+        my $window_system = script_output('echo $XDG_SESSION_TYPE');
+        script_run('exit', 0);
+        record_info("$window_system", "Current window system is $window_system");
     }
 }
 


### PR DESCRIPTION
We want to know if we are using x11 or wayland inside desktop tests.

- Related ticket: https://progress.opensuse.org/issues/37931
- Verification runs: 
    - http://panigale.suse.cz/tests/2412#step/boot_to_desktop/10
    - http://panigale.suse.cz/tests/2414#step/boot_to_desktop/10