### PR TITLE
Show more details on package updater failure

### DIFF
--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -50,7 +50,7 @@ sub run {
     select_console 'x11', await_console => 0;
 
     my @updates_tags = qw(updates_none updates_available package-updater-privileged-user-warning updates_restart_application updates_installed-restart);
-    my @updates_installed_tags = qw(updates_none updates_installed-logout updates_installed-restart updates_restart_application);
+    my @updates_installed_tags = qw(updates_none updates_installed-logout updates_installed-restart updates_restart_application updates_failed);
 
     setup_system;
 
@@ -77,6 +77,11 @@ sub run {
                 if (match_has_tag("updates_authenticate")) {
                     type_string "$password\n";
                     pop @updates_installed_tags;
+                }
+                if (match_has_tag("updates_failed")) {
+                    assert_and_click("updates_failed");
+                    save_screenshot;
+                    die "Failed to process request";
                 }
             } while (match_has_tag 'updates_authenticate');
             if (match_has_tag("updates_none")) {


### PR DESCRIPTION
If the updater fails, make it possible to show more details.

- Related ticket: https://progress.opensuse.org/issues/37970
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/879
- Verification runs: 
    - http://panigale.suse.cz/tests/2402#step/updates_packagekit_gpk/27
    - http://panigale.suse.cz/tests/2404#step/updates_packagekit_gpk/13