### PR TITLE
Revert "Harmonize updating handling SUSE/openSUSE"

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -113,9 +113,6 @@ our @EXPORT = qw(
   load_common_opensuse_sle_tests
   replace_opensuse_repos_tests
   load_ssh_key_import_tests
-  updates_is_applicable
-  guiupdates_is_applicable
-  load_system_update_tests
 );
 
 sub init_main {
@@ -1043,7 +1040,11 @@ sub load_consoletests {
     {
         loadtest "console/glibc_sanity";
     }
-    load_system_update_tests();
+    # openSUSE has "load_system_update_tests" for that,
+    # https://progress.opensuse.org/issues/31954 to improve
+    if (is_sle && !gnomestep_is_applicable()) {
+        loadtest "update/zypper_up";
+    }
     loadtest "console/console_reboot" if is_jeos;
     loadtest "console/zypper_in";
     loadtest "console/yast2_i";
@@ -1127,17 +1128,13 @@ sub load_consoletests {
     loadtest "console/consoletest_finish";
 }
 
-sub x11tests_is_applicable {
-    return
-        !get_var("INSTALLONLY")
-      && is_desktop_installed()
-      && !get_var("DUALBOOT")
-      && !get_var("RESCUECD")
-      && !get_var("HA_CLUSTER");
-}
-
 sub load_x11tests {
-    return unless x11tests_is_applicable();
+    return
+      unless (!get_var("INSTALLONLY")
+        && is_desktop_installed()
+        && !get_var("DUALBOOT")
+        && !get_var("RESCUECD")
+        && !get_var("HA_CLUSTER"));
     if (is_smt()) {
         loadtest "x11/smt";
     }
@@ -1156,7 +1153,8 @@ sub load_x11tests {
     loadtest "x11/xterm";
     loadtest "x11/sshxterm" unless get_var("LIVETEST");
     if (gnomestep_is_applicable()) {
-        load_system_update_tests();
+        # openSUSE has an explicit update check elsewhere
+        loadtest "update/updates_packagekit_gpk" if is_sle && !is_staging;
         loadtest "x11/gnome_control_center";
         # TODO test on SLE https://progress.opensuse.org/issues/31972
         loadtest "x11/gnome_tweak_tool" if is_opensuse;
@@ -1859,42 +1857,6 @@ sub load_sles4sap_tests {
         loadtest "sles4sap/netweaver_ascs_install" if (get_var('SLES4SAP_MODE') !~ /wizard/);
         loadtest "sles4sap/netweaver_ascs";
     }
-}
-
-sub updates_is_applicable {
-    # we don't want live systems to run out of memory or virtual disk space.
-    # Applying updates on a live system would not be persistent anyway.
-    # Also, applying updates on BOOT_TO_SNAPSHOT is useless.
-    # Also, updates on INSTALLONLY do not match the meaning
-    return !get_var('INSTALLONLY') && !get_var('BOOT_TO_SNAPSHOT') && !get_var('DUALBOOT') && !get_var('UPGRADE') && !is_livesystem;
-}
-
-sub guiupdates_is_applicable {
-    return get_var("DESKTOP") =~ /gnome|kde|xfce|lxde/ && !check_var("FLAVOR", "Rescue-CD");
-}
-
-sub load_system_update_tests {
-    return if get_var('SYSTEM_UPDATED');
-    if (need_clear_repos()) {
-        loadtest "update/zypper_clear_repos";
-        set_var('CLEAR_REPOS', 1);
-    }
-    loadtest "console/zypper_add_repos" if get_var('ZYPPER_ADD_REPOS');
-    return unless updates_is_applicable();
-    if (guiupdates_is_applicable()) {
-        loadtest "update/prepare_system_for_update_tests" if !is_sle;
-        if (check_var("DESKTOP", "kde")) {
-            loadtest "update/updates_packagekit_kde";
-        }
-        elsif (x11tests_is_applicable()) {
-            loadtest "update/updates_packagekit_gpk" unless (is_sle && is_staging);
-        }
-        loadtest "update/check_system_is_updated" if !is_sle;
-    }
-    else {
-        loadtest "update/zypper_up";
-    }
-    set_var('SYSTEM_UPDATED', 1);
 }
 
 1;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -141,6 +141,18 @@ logcurrentenv(
       LIVECD NETBOOT NOIMAGES QEMUVGA SPLITUSR VIDEOMODE)
 );
 
+sub updates_is_applicable {
+    # we don't want live systems to run out of memory or virtual disk space.
+    # Applying updates on a live system would not be persistent anyway.
+    # Also, applying updates on BOOT_TO_SNAPSHOT is useless.
+    # Also, updates on INSTALLONLY do not match the meaning
+    return !get_var('INSTALLONLY') && !get_var('BOOT_TO_SNAPSHOT') && !get_var('DUALBOOT') && !get_var('UPGRADE') && !is_livesystem;
+}
+
+sub guiupdates_is_applicable {
+    return get_var("DESKTOP") =~ /gnome|kde|xfce|lxde/ && !check_var("FLAVOR", "Rescue-CD");
+}
+
 sub have_addn_repos {
     return !get_var("NET") && !get_var("EVERGREEN") && get_var("SUSEMIRROR") && !is_staging();
 }
@@ -236,6 +248,31 @@ sub install_online_updates {
     return 1;
 }
 
+sub load_system_update_tests {
+    return unless updates_is_applicable;
+    if (need_clear_repos) {
+        loadtest "update/zypper_clear_repos";
+        set_var('CLEAR_REPOS', 1);
+    }
+
+    if (get_var('ZYPPER_ADD_REPOS')) {
+        loadtest "console/zypper_add_repos";
+    }
+    if (guiupdates_is_applicable()) {
+        loadtest "update/prepare_system_for_update_tests";
+        if (check_var("DESKTOP", "kde")) {
+            loadtest "update/updates_packagekit_kde";
+        }
+        else {
+            loadtest "update/updates_packagekit_gpk";
+        }
+        loadtest "update/check_system_is_updated";
+    }
+    else {
+        loadtest "update/zypper_up";
+    }
+}
+
 sub load_qam_install_tests {
     return 0 unless get_var('INSTALL_PACKAGES');
 
@@ -246,6 +283,7 @@ sub load_qam_install_tests {
     loadtest 'console/zypper_add_repos';
     loadtest 'console/qam_zypper_patch';
     loadtest 'console/qam_verify_package_install';
+
 
     return 1;
 }


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#5175

As we figured out (thanks to @czerw), it broke https://openqa.suse.de/tests/1790992#step/updates_packagekit_gpk/18 tes suite as test module is scheduled differently.

@jknphy, please, adjust original PR for this scenario.
