### PR TITLE
Revert "Add info about the current window system"

### DIFF
--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -14,7 +14,6 @@
 use base 'opensusebasetest';
 use strict;
 use testapi;
-use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
@@ -26,12 +25,6 @@ sub run {
     }
     else {
         $self->wait_boot(bootloader_time => $timeout);
-    }
-    if (is_sle && !check_var('DESKTOP', 'textmode')) {
-        x11_start_program('xterm');
-        my $window_system = script_output('echo $XDG_SESSION_TYPE');
-        script_run('exit', 0);
-        record_info("$window_system", "Current window system is $window_system");
     }
 }
 


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#5304

As discussed with @baierjan we should make sure that "boot_to_desktop" only fails when the boot fails. Better we look for an explicit test module to schedule the check in. This makes understanding of test failures simpler and we can check for prerequisites in the right order, e.g. first test "desktop_runner", then "xterm", then this module, etc.