### PR TITLE
Workaround boot timeout issue for user_defined_snapshot.pm

### DIFF
--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -58,7 +58,7 @@ sub run {
     assert_screen "grub2";
     send_key 'up';
 
-    send_key_until_needlematch("boot-menu-snapshot", 'down', 10, 5);
+    send_key_until_needlematch("boot-menu-snapshot", 'down', 10, 60);
     send_key 'ret';
 
     # On slow VMs we press down key before snapshots list is on screen


### PR DESCRIPTION
- increase timeout for boot
- see https://progress.opensuse.org/issues/35011 for details
- verification run:
  http://e13.suse.de/tests/6015#step/user_defined_snapshot
