### PR TITLE
Fix console selection for IPMI

### DIFF
--- a/tests/kernel/ib_tests.pm
+++ b/tests/kernel/ib_tests.pm
@@ -16,6 +16,7 @@ use strict;
 use testapi;
 use utils;
 use lockapi;
+use ipmi_backend_utils;
 
 sub check_dmesg {
     my $dmesg_cmd = 'dmesg';
@@ -113,7 +114,7 @@ sub ibtest_master {
 sub run {
     my $role = get_required_var('IBTEST_ROLE');
 
-    select_console 'root-ssh';
+    use_ssh_serial_console;
     zypper_call('ar -f -G ' . get_required_var('GA_REPO'));
 
     if ($role eq "IBTEST_MASTER") {
@@ -129,7 +130,7 @@ sub run {
         ibtest_slave;
     }
 
-    power_action('poweroff', observe => 0, keepconsole => 0);
+    power_action('poweroff');
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Investigation on failing calls to power_action showed that the console
selected in ib_tests.pm is wrom..
When using select_console 'root-ssh', the console is working fine - but
power_action cannot be executed successfully. This commit fixes the
behavior for shutdown in this test by using use_ssh_serial_console
instead, which disables the SOL-console first and configures the correct
serial device.

Signed-off-by: Michael Moese <mmoese@suse.de>