### PR TITLE
Add ability to debug shutdown issues

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -486,6 +486,13 @@ sub specific_bootmenu_params {
         $args .= " autoupgrade=1";
     }
 
+    # Boot the system with the debug options if shutdown takes suspiciously long time.
+    # Please, see https://freedesktop.org/wiki/Software/systemd/Debugging/#index2h1 for the details.
+    # Further actions for saving debug logs are done in 'shutdown/cleanup_before_shutdown' module.
+    if (get_var('DEBUG_SHUTDOWN')) {
+        $args .= " systemd.log_level=debug systemd.log_target=kmsg log_buf_len=1M printk.devkmsg=on enforcing=0 plymouth.enable=0";
+    }
+
     if (get_var("IBFT")) {
         $args .= " withiscsi=1";
     }

--- a/tests/shutdown/cleanup_before_shutdown.pm
+++ b/tests/shutdown/cleanup_before_shutdown.pm
@@ -21,6 +21,13 @@ use version_utils;
 
 sub run {
     select_console('root-console');
+    # Collect detailed logs to investigate shutdown issues and redirect them to serial console.
+    # Please see https://freedesktop.org/wiki/Software/systemd/Debugging/#index2h1 for the details.
+    # Boot options that are required to make logs more detalized are located in 'bootloader_setup.pm'
+    if (get_var('DEBUG_SHUTDOWN')) {
+        assert_script_run "echo -e '#!/bin/sh\\ndmesg > /dev/$serialdev' > /usr/lib/systemd/system-shutdown/debug.sh";
+        assert_script_run "chmod +x /usr/lib/systemd/system-shutdown/debug.sh";
+    }
     if (get_var('DROP_PERSISTENT_NET_RULES')) {
         type_string "rm -f /etc/udev/rules.d/70-persistent-net.rules\n";
     }


### PR DESCRIPTION
The commit adds functionality that allows to save detailed logs for investigating issues with shutdown.

The job should be run with DEBUG_SHUTDOWN parameter, so that shutdown debug script will write all the detailed logs to the serial console.

It covers two cases: when using normal installation of the OS and Live CD.

- Related ticket: https://progress.opensuse.org/issues/35215
- Verification run: http://oorlov-vm.qa.suse.de/tests/21