### PR TITLE
Mask serial-getty service to reduce pollution on the serial

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -36,6 +36,14 @@ sub run {
     script_run "ip addr show";
     save_screenshot;
 
+    # Stop serial-getty on serial console to avoid serial output pollution with login prompt
+    # Mask and stop only if SERIALDEV is defined or is qemu backend
+    my $serial_console = get_var('SERIALDEV') || (check_var('BACKEND', 'qemu') ? 'ttyS0' : undef);
+    if ($serial_console) {
+        systemctl "mask serial-getty\@$serial_console";
+        systemctl "stop serial-getty\@$serial_console";
+    }
+
     # Stop packagekit
     systemctl 'mask packagekit.service';
     systemctl 'stop packagekit.service';


### PR DESCRIPTION
During research of the issue we have identified that one of the sources
which pollutes serial output and interferes script_output calls are
login prompt messages generated by serial-getty service.
So, along with packagekit, we mask it for console tests and unmask
afterwards.

See [poo#30613](https://progress.opensuse.org/issues/30613).

- Verification runs:
[x86-64](http://g226.suse.de/tests/2006) One "Welcome" instead of two
[ppc64](http://g226.suse.de/tests/2007)
[x-kvm](http://g226.suse.de/tests/2010)