### PR TITLE
Add Mellanox configuration for Baremetal testing

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1543,6 +1543,8 @@ sub load_nfv_master_tests {
     load_boot_tests();
     load_inst_tests();
     load_reboot_tests();
+    loadtest "kernel/mellanox_config";
+    load_reboot_tests();
     loadtest "nfv/prepare_env";
     loadtest "nfv/run_integration_tests";
 }
@@ -1550,6 +1552,8 @@ sub load_nfv_master_tests {
 sub load_nfv_trafficgen_tests {
     load_boot_tests();
     load_inst_tests();
+    load_reboot_tests();
+    loadtest "kernel/mellanox_config";
     load_reboot_tests();
     loadtest "nfv/trex_installation";
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -681,6 +681,8 @@ sub load_baremetal_tests {
             barrier_create('IBTEST_BEGIN', 3);
             barrier_create('IBTEST_DONE',  3);
         }
+        loadtest "kernel/mellanox_config";
+        load_reboot_tests();
         loadtest "kernel/ib_tests";
     }
 }

--- a/tests/kernel/ib_tests.pm
+++ b/tests/kernel/ib_tests.pm
@@ -114,7 +114,6 @@ sub run {
     my $role = get_required_var('IBTEST_ROLE');
 
     select_console 'root-ssh';
-    zypper_call('ar -f -G ' . get_required_var('GA_REPO'));
 
     if ($role eq "IBTEST_MASTER") {
         zypper_call('ar -f -G ' . get_required_var('DEVEL_TOOLS_REPO'));

--- a/tests/kernel/mellanox_config.pm
+++ b/tests/kernel/mellanox_config.pm
@@ -1,0 +1,72 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Mellanox Link protocol config
+# This configures the interfaces according to the
+# variable MLX_PROTOCOL. By default ETH if not set.
+# Maintainer: Jose Lausuch <jalausuch@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+use utils;
+use ipmi_backend_utils;
+
+our $device1 = '/dev/mst/mt4119_pciconf0';
+our $device2 = '/dev/mst/mt4119_pciconf0.1';
+
+sub show_links {
+    assert_script_run("mlxconfig -d $device1 q|grep LINK_TYPE");
+    assert_script_run("mlxconfig -d $device2 q|grep LINK_TYPE");
+}
+
+sub run {
+    use_ssh_serial_console;
+    my $mft_version = get_required_var('MFT_VERSION');
+    my $protocol = get_var('MLX_PROTOCOL') || 2;
+
+    zypper_call('ar -f -G ' . get_required_var('GA_REPO'));
+    zypper_call('--quiet in kernel-source rpm-build', timeout => 200);
+
+    # Install Mellanox Firmware Tool (MFT)
+    assert_script_run("wget http://www.mellanox.com/downloads/MFT/" . $mft_version . ".tgz");
+    assert_script_run("tar -xzvf " . $mft_version . ".tgz");
+    assert_script_run("rm " . $mft_version . ".tgz");
+    assert_script_run("./" . $mft_version . "/install.sh");
+    assert_script_run("mst start");
+
+    # List network devices
+    assert_script_run("lspci|egrep -i 'network|ethernet'");
+    if (script_run("lspci|grep -i mellanox") != 0) {
+        die "echo There is no Mellanox card here";
+    }
+    if (script_run("ls " . $device1) != 0) {
+        die "echo The directory $device1 doesn't exist";
+    }
+    if (script_run("ls " . $device2) != 0) {
+        die "echo The directory $device2 doesn't exist";
+    }
+
+    # Change Link protocol
+    script_run("echo Wanted Link protocol is $protocol");
+    show_links();
+    assert_script_run("mlxconfig -y -d $device1 set LINK_TYPE_P1=$protocol LINK_TYPE_P2=$protocol");
+    assert_script_run("mlxconfig -y -d $device2 set LINK_TYPE_P1=$protocol LINK_TYPE_P2=$protocol");
+    show_links();
+
+    # Reboot system
+    power_action('reboot', keepconsole => 1);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+

--- a/tests/nfv/prepare_env.pm
+++ b/tests/nfv/prepare_env.pm
@@ -31,7 +31,6 @@ sub run {
 
     select_virtio_console();
 
-    zypper_call('ar -f -G ' . get_required_var('GA_REPO'));
     zypper_call('--quiet in git-core openvswitch-switch dpdk qemu tcpdump', timeout => 200);
 
     # Clone repositories


### PR DESCRIPTION
This script is to be used by Infiniband and NFV to set up the LINK protocol of the Mellanox interfaces before running the tests.

- Verification run: http://loewe.arch.suse.de/tests/828
