### PR TITLE
Remove unneeded server tests on SLED

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -955,6 +955,38 @@ sub load_inst_tests {
     }
 }
 
+sub load_console_server_tests {
+    if (check_var('BACKEND', 'qemu') && !is_jeos) {
+        # The NFS test expects the IP to be 10.0.2.15
+        loadtest "console/yast2_nfs_server";
+    }
+    loadtest "console/http_srv";
+    loadtest "console/dns_srv";
+    loadtest "console/postgresql_server" unless (is_leap('<15.0'));
+    # TODO test on openSUSE https://progress.opensuse.org/issues/31972
+    if (is_sle && sle_version_at_least('12-SP1')) {    # shibboleth-sp not available on SLES 12 GA
+        loadtest "console/shibboleth";
+    }
+    if (!is_staging && (is_opensuse || get_var('ADDONS', '') =~ /wsm/ || get_var('SCC_ADDONS', '') =~ /wsm/)) {
+        # TODO test on openSUSE https://progress.opensuse.org/issues/31972
+        loadtest "console/pcre" if is_sle;
+        # TODO test on SLE https://progress.opensuse.org/issues/31972
+        loadtest "console/mysql_odbc" if is_opensuse;
+        if (is_leap('<15.0') || is_sle('<15')) {
+            loadtest "console/php5";
+            loadtest "console/php5_mysql";
+            loadtest "console/php5_postgresql96";
+        }
+        loadtest "console/php7";
+        loadtest "console/php7_mysql";
+        loadtest "console/php7_postgresql96";
+    }
+    # TODO test on openSUSE https://progress.opensuse.org/issues/31972
+    loadtest "console/apache_ssl" if is_sle;
+    # TODO test on openSUSE https://progress.opensuse.org/issues/31972
+    loadtest "console/apache_nss" if is_sle;
+}
+
 sub load_consoletests {
     return unless consolestep_is_applicable();
     if (get_var("ADDONS", "") =~ /rt/) {
@@ -1081,36 +1113,9 @@ sub load_consoletests {
     }
     loadtest "console/mtab";
     if (!get_var("NOINSTALL") && !get_var("LIVETEST") && (check_var("DESKTOP", "textmode"))) {
-        if (check_var('BACKEND', 'qemu') && !is_jeos) {
-            # The NFS test expects the IP to be 10.0.2.15
-            loadtest "console/yast2_nfs_server";
-        }
-        loadtest "console/http_srv";
+        # disable these tests of server packages for SLED (poo#36436)
+        load_console_server_tests() unless is_desktop;
         loadtest "console/mysql_srv";
-        loadtest "console/dns_srv";
-        loadtest "console/postgresql_server" unless (is_leap('<15.0'));
-        # TODO test on openSUSE https://progress.opensuse.org/issues/31972
-        if (is_sle && sle_version_at_least('12-SP1')) {    # shibboleth-sp not available on SLES 12 GA
-            loadtest "console/shibboleth";
-        }
-        if (!is_staging && (is_opensuse || get_var('ADDONS', '') =~ /wsm/ || get_var('SCC_ADDONS', '') =~ /wsm/)) {
-            # TODO test on openSUSE https://progress.opensuse.org/issues/31972
-            loadtest "console/pcre" if is_sle;
-            # TODO test on SLE https://progress.opensuse.org/issues/31972
-            loadtest "console/mysql_odbc" if is_opensuse;
-            if (is_leap('<15.0') || is_sle('<15')) {
-                loadtest "console/php5";
-                loadtest "console/php5_mysql";
-                loadtest "console/php5_postgresql96";
-            }
-            loadtest "console/php7";
-            loadtest "console/php7_mysql";
-            loadtest "console/php7_postgresql96";
-        }
-        # TODO test on openSUSE https://progress.opensuse.org/issues/31972
-        loadtest "console/apache_ssl" if is_sle;
-        # TODO test on openSUSE https://progress.opensuse.org/issues/31972
-        loadtest "console/apache_nss" if is_sle;
     }
     if (check_var("DESKTOP", "xfce")) {
         loadtest "console/xfce_gnome_deps";


### PR DESCRIPTION
As discussed in [poo#36436](https://progress.opensuse.org/issues/36436), these server tests should not be run on SLED because they are not installed.

- Related ticket: https://progress.opensuse.org/issues/36436
- Needles: no changes
- Verification run: http://10.67.19.79/tests/44  Those failed server tests disappeared compared with https://openqa.suse.de/tests/1794244
