### PR TITLE
More robust check for open ssh port in SUT

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,6 +4,7 @@ requires 'XML::LibXML';
 requires 'XML::Writer';
 requires 'XML::Simple';
 requires 'IO::File';
+requires 'IO::Socket::INET';
 requires 'List::Util';
 requires 'LWP::Simple';
 requires 'File::Copy';


### PR DESCRIPTION
[related poo](https://progress.opensuse.org/issues/33202)
[MR for adding package to the worker](https://gitlab.suse.de/openqa/salt-states-openqa/merge_requests/49)

verification in working case after 4 retries:
![verification in working case after 4 retries](https://user-images.githubusercontent.com/3983634/42078316-494ee6cc-7b7c-11e8-8bcb-51d2e7b4ed59.png)

failing case with proper die message:
![failing case with proper die message](https://user-images.githubusercontent.com/3983634/42078318-4b7d622a-7b7c-11e8-9795-b8f4aa4e2953.png)

@coolo @okurz 
