### PR TITLE
[NFV] Move NFV baremetal logic to main.pm

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1540,21 +1540,11 @@ sub load_networkd_tests {
 }
 
 sub load_nfv_master_tests {
-    load_boot_tests();
-    load_inst_tests();
-    load_reboot_tests();
-    loadtest "kernel/mellanox_config";
-    load_reboot_tests();
     loadtest "nfv/prepare_env";
     loadtest "nfv/run_integration_tests";
 }
 
 sub load_nfv_trafficgen_tests {
-    load_boot_tests();
-    load_inst_tests();
-    load_reboot_tests();
-    loadtest "kernel/mellanox_config";
-    load_reboot_tests();
     loadtest "nfv/trex_installation";
 }
 

--- a/tests/kernel/ib_tests.pm
+++ b/tests/kernel/ib_tests.pm
@@ -115,7 +115,6 @@ sub run {
     my $role = get_required_var('IBTEST_ROLE');
 
     use_ssh_serial_console;
-    zypper_call('ar -f -G ' . get_required_var('GA_REPO'));
 
     if ($role eq "IBTEST_MASTER") {
         zypper_call('ar -f -G ' . get_required_var('DEVEL_TOOLS_REPO'));


### PR DESCRIPTION
Move the installation and reboot functions to a common place together with other baremetal tests.
Also, group the mellanox configuration logic together. 

- Verification run: http://loewe.arch.suse.de/tests/840#
