### PR TITLE
Run kubeadm init twice

### DIFF
--- a/tests/console/kubeadm.pm
+++ b/tests/console/kubeadm.pm
@@ -29,8 +29,9 @@ sub run {
     systemctl('is-active kubelet');
 
     record_info 'Test #1', 'Test: Initialize kubeadm';
-    assert_script_run('kubeadm reset');
-    assert_script_run('kubeadm init');
+    record_soft_failure "bsc#1093132" if script_run('kubeadm init');
+    script_run('kubeadm reset');
+    assert_script_run('kubeadm init', 180);
 
 }
 


### PR DESCRIPTION
kubic fails at first because of this stupid bug about port. Although this is a bug, it's not *that* the core of the problem. After *resetting* it, the port bug goes away and we find the **real problem** which is timeout while marking the master label.

- Related ticket: *none*
- Needles: *not needed*
- Verification run: http://skyrim.qam.suse.de/tests/3426#step/kubeadm/48
