### PR TITLE
Hyper-V: Support RDP8 graphics pipeline (/gfx option)

### DIFF
--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -233,7 +233,7 @@ sub run {
       . get_var('HYPERV_USERNAME') . " /p:'"
       . get_var('HYPERV_PASSWORD') . "' /v:"
       . get_var('HYPERV_SERVER')
-      . " /cert-ignore /vmconnect:$vmguid /f /log-level:DEBUG 2>&1 > $xfreerdp_log; echo $vmguid > xfreerdp_${name}_stop; done; ";
+      . " /gfx /cert-ignore /vmconnect:$vmguid /f /log-level:DEBUG 2>&1 > $xfreerdp_log; echo $vmguid > xfreerdp_${name}_stop; done; ";
 
     hyperv_cmd_with_retry("$ps Start-VM $name", {msg => ($winserver eq '2016') ? 'used by another process' : undef});
 


### PR DESCRIPTION
According to
https://github.com/FreeRDP/FreeRDP/issues/4717#issuecomment-401063101
`/gfx` might help with sudden disconnects to Hyper-V host.

If the problem with disconnects (aka black screen with Xorg cross in the
middle) worsens, revert this.

Run couple of jobs with this option and it seems to work, needles match:
* `jeos-main@svirt-hyperv`: http://nilgiri.suse.cz/tests/292
* `minimal+base@svirt-hyperv`: http://nilgiri.suse.cz/tests/290
* `lvm+RAID1@svirt-hyperv-uefi`: http://nilgiri.suse.cz/tests/302
* `lvm+RAID1@svirt-hyperv`: http://nilgiri.suse.cz/tests/301