### PR TITLE
Ltp/audit

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -88,6 +88,8 @@ sub run {
         $tinfo->test_result_export->{environment} = $environment;
     }
 
+    script_run('ps axf') if ($is_network || $is_ima);
+
     if ($is_network) {
         # poo#18762: Sometimes there is physical NIC which is not configured.
         # One of the reasons can be renaming by udev rule in
@@ -152,7 +154,6 @@ EOF
         script_run('ip6tables -S');
 
         # display various network configuration
-        script_run('ps axf');
         script_run('netstat -nap');
 
         script_run('cat /etc/resolv.conf');

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -57,6 +57,7 @@ sub install_runtime_dependencies {
     # ntfsprogs are for SLE in WE, openSUSE has it in default repository
     my @maybe_deps = qw(
       acl
+      audit
       binutils
       dosfstools
       evmctl
@@ -231,7 +232,7 @@ EOF
     # SLE12GA uses too many old style services
     my $action = check_var('VERSION', '12') ? "enable" : "reenable";
 
-    foreach my $service (qw(dnsmasq nfsserver rpcbind vsftpd)) {
+    foreach my $service (qw(auditd dnsmasq nfsserver rpcbind vsftpd)) {
         if (is_sle('12+') || is_opensuse) {
             systemctl($action . " " . $service);
             assert_script_run("systemctl start $service || { systemctl status --no-pager $service; journalctl -xe --no-pager; false; }");


### PR DESCRIPTION
Enable auditd daemon (required by IMA)

- Related ticket: https://progress.opensuse.org/issues/37480
- Verification run:
* sle-12-SP4-Server-DVD-x86_64-Build0273-ltp_ima_next@64bit
http://quasar.suse.cz/tests/565
* sle-15-Installer-DVD-x86_64-Build668.1-ltp_ima_next@64bit
http://quasar.suse.cz/tests/564