### PR TITLE
New test for apparmor aa-notify

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -103,6 +103,7 @@ our @EXPORT = qw(
   load_security_tests_crypt
   load_security_tests_apparmor_status
   load_security_tests_apparmor_genprof
+  load_security_tests_apparmor_misc
   load_systemd_patches_tests
   load_create_hdd_tests
   load_virtualization_tests
@@ -1753,6 +1754,10 @@ sub load_security_tests_apparmor_genprof {
     loadtest "security/apparmor/aa_autodep";
     loadtest "security/apparmor/aa_logprof";
     loadtest "security/apparmor/aa_easyprof";
+}
+
+sub load_security_tests_apparmor_misc {
+    loadtest "security/apparmor/aa_notify";
 }
 
 sub load_systemd_patches_tests {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -413,6 +413,9 @@ elsif (get_var('SECURITYTEST')) {
     elsif (check_var("SECURITYTEST", "apparmor_genprof")) {
         load_security_tests_apparmor_genprof;
     }
+    elsif (check_var("SECURITYTEST", "apparmor_misc")) {
+        load_security_tests_apparmor_misc;
+    }
 }
 elsif (get_var('SYSTEMD_TESTSUITE')) {
     load_systemd_patches_tests;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -861,6 +861,9 @@ elsif (get_var("FIPS_TS") || get_var("SECURITY")) {
     elsif (check_var("SECURITY", "apparmor_genprof")) {
         load_security_tests_apparmor_genprof;
     }
+    elsif (check_var("SECURITY", "apparmor_misc")) {
+        load_security_tests_apparmor_misc;
+    }
 }
 elsif (get_var('SMT')) {
     prepare_target();

--- a/tests/security/apparmor/aa_notify.pm
+++ b/tests/security/apparmor/aa_notify.pm
@@ -1,0 +1,66 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Display information about logged AppArmor messages
+# Maintainer: Wes <whdu@suse.com>
+# Tags: poo#36883, tc#1621139
+
+use strict;
+use base "apparmortest";
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+
+    my $tmp_prof  = "/tmp/apparmor.d";
+    my $audit_log = "/var/log/audit/audit.log";
+
+    systemctl('restart auditd');
+
+    $self->aa_tmp_prof_prepare("$tmp_prof");
+
+    #Add root user to the use_group
+    assert_script_run "sed -i s/admin/root/ /etc/apparmor/notify.conf";
+
+    assert_script_run "echo > $audit_log";
+
+    validate_script_output "aa-notify -l", sub { m/^$/ };
+
+    # Make it failed intentionally to get some audit messages
+    assert_script_run "sed -i '/\\/etc\\/nscd.conf/d' $tmp_prof/usr.sbin.nscd";
+
+    assert_script_run "aa-disable nscd";
+    assert_script_run "aa-enforce -d $tmp_prof nscd";
+
+    systemctl('restart nscd', expect_false => 1);
+    upload_logs($audit_log);
+
+    validate_script_output "aa-notify -l -v", sub {
+        m/
+            Name:\s+\/etc\/nscd\.conf.*
+            Denied:\s+r.*
+            AppArmor\sdenials:\s+[0-9]+\s+\(since/sxx
+    };
+
+    # Make sure it could restore to the default profile
+    assert_script_run "aa-disable -d $tmp_prof nscd";
+    assert_script_run "aa-enforce nscd";
+    systemctl("restart nscd");
+
+    $self->aa_tmp_prof_clean("$tmp_prof");
+}
+
+1;


### PR DESCRIPTION
* Add tests/security/apparmor/aa_notify.pm [poo#36883](https://progress.opensuse.org/issues/36883)
* Add "load_security_tests_apparmor_misc" call function [poo#37006](https://progress.opensuse.org/issues/37006)

- Verification run:
  - SLE: http://10.67.17.9/tests/837
  - Tumbleweed: http://10.67.17.9/tests/840