### PR TITLE
Revert "Workaround for issue of closing windows in gnuscash.pm"

### DIFF
--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -34,9 +34,9 @@ sub run {
         send_key 'alt-tab' if check_var('DESKTOP', 'lxde');
         wait_screen_change { send_key 'alt-c' };
     }
-    # sometimes send_key for closing windows not working
-    send_key_until_needlematch 'gnucash-save-changes', "ctrl-q", 5, 5;
-    wait_screen_change { send_key 'alt-w' };
+    send_key 'ctrl-q';    # Exit
+    assert_screen [qw(gnucash-save-changes generic-desktop)];
+    wait_screen_change { send_key 'alt-w' } if match_has_tag 'gnucash-save-changes';
 }
 
 1;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#5188

The old multi-tag assert_screen is certainly still the way to go.

Fixes https://progress.opensuse.org/issues/38057