### PR TITLE
ensure_installed: Make pkcon related failures more obvious / fallback to zypper

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -232,10 +232,7 @@ sub ensure_installed {
     testapi::assert_script_run('systemctl is-active -q packagekit || (systemctl unmask -q packagekit ; systemctl start -q packagekit)');
     type_string "exit\n";
     my $retries = 5;    # arbitrary
-    $self->script_run(
-"for i in {1..$retries} ; do pkcon install -yp $pkglist && break ; done ; RET=\$?; echo \"\n  pkcon finished\n\"; echo \"pkcon-\${RET}-\" > /dev/$testapi::serialdev",
-        0
-    );
+    $self->script_run("pkcon install -yp $pkglist; echo \"pkcon-\$?-\" > /dev/$testapi::serialdev", 0);
     my @tags = qw(Policykit Policykit-behind-window pkcon-finished);
     while (1) {
         last unless @tags;


### PR DESCRIPTION
Show errors more explicitly, e.g. in case of timeout connecting to the remote
repo see the obvious error message in
http://lord.arch/tests/1261#step/gnucash/15 instead of
http://lord.arch/tests/1260#step/gnucash/13 which is hiding the error message
behind a dimmed down authentication window which is not expected by the test
and never properly handled.

Verification run: http://lord.arch/tests/1262#step/gnucash/40