### PR TITLE
SLES4SAP 12SP4 initial test fixes

### DIFF
--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -38,9 +38,18 @@ sub check_profile {
       unless ($output =~ /Current active profile: $profile/);
 }
 
+sub save_tuned_conf {
+    my $tag = shift;
+    my $log = "/tmp/conf_and_logs_$tag.tar.gz";
+    script_run "tar -zcf $log /etc/tuned/* /var/log/tuned/*";
+    upload_logs $log;
+}
+
 sub run_developers_tests {
     my $devel_repo = 'https://gitlab.suse.de/AngelaBriel/sapconf-test/repository/master/archive.tar.gz';
     my $log        = '/tmp/sapconf_test.log';
+
+    save_tuned_conf 'before';
 
     # Download and unpack the test scripts supplied by the developers
     # Continue if it can not be downloaded
@@ -87,6 +96,8 @@ sub run_developers_tests {
 
     # Return to homedir just in case
     type_string "cd\n";
+
+    save_tuned_conf 'after';
 }
 
 sub verify_sapconf_service {

--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -19,7 +19,7 @@ my @tuned_profiles = is_sle('>=15') ?
   qw(balanced desktop latency-performance network-latency network-throughput
   powersave sapconf saptune throughput-performance virtual-guest virtual-host)
   : qw(balanced desktop latency-performance network-latency
-  network-throughput powersave sap-ase sap-bobj sap-hana sap-netweaver saptune
+  network-throughput powersave sap-ase sap-bobj sap-hana sap-netweaver
   throughput-performance virtual-guest virtual-host);
 
 my %sapconf_profiles = (
@@ -75,6 +75,8 @@ sub run_developers_tests {
         next unless ($summary =~ /^Test/);
         # Do nothing with passing tests. The summary will be shown on the script_output step
         next if ($summary =~ /PASSED$/);
+        # Skip results of fate#325548 on SLES4SAP versions before 15
+        next if ($summary =~ /fate325548/ and is_sle('<15'));
         if ($summary =~ /Test #(bsc|fate)([0-9]+)/) {
             record_soft_failure "$1#$2";
         }

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -12,6 +12,7 @@
 
 use base "sles4sap";
 use testapi;
+use version_utils 'is_sle';
 use strict;
 
 sub tuned_is {
@@ -23,12 +24,18 @@ sub tuned_is {
 sub run {
     my ($self) = @_;
 
+    # Test has to work differently on x86_64 and ppc64le. Will verify test
+    # is running on ppc64le via the OFW variable
+    my $is_ppc64le = get_var('OFW');
+
     # List of solutions is different between saptune in x86_64 and in ppc64le
-    # Will check whether test is running in ppc64le with the OFW variable
     my @solutions
-      = get_var('OFW') ?
+      = $is_ppc64le ?
       qw(HANA MAXDB NETWEAVER S4HANA-APPSERVER S4HANA-DBSERVER)
       : qw(BOBJ HANA MAXDB NETWEAVER S4HANA-APPSERVER S4HANA-DBSERVER SAP-ASE);
+
+    # Skip test if SLES4SAP version is before 15 and running on ppc64le
+    return if (is_sle('<15') and $is_ppc64le);
 
     select_console 'root-console';
 


### PR DESCRIPTION
This PR fixes some minor issues detected on the test cases for SLES4SAP on 12SP4:

- The list of tuned profiles listed with tuned-adm is different on 12-SP4 on ppc64le to the one on x86_64 and on SLES4SAP 15. This pull request updates the list so the test also works on 12-SP4 on ppc64le.
- Similarly, saptune is not available in SLES4SAP 12SP4 on ppc64le, so an extra check has been added to skip the text if called in such an scenario
- Finally, FATE#325548 is not implemented on 12SP4, so we check for that and avoid soft failing unless the test is running on SLES4SAP 15.

Additionally, this PR also includes a change to upload tuned configuration files and logs before and after the developer-supplied test in sapconf.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/377 (15) & http://mango.suse.de/tests/381 (12SP4)
