### PR TITLE
Update expected expiration date for gcc packages

### DIFF
--- a/tests/console/zypper_lifecycle_toolchain.pm
+++ b/tests/console/zypper_lifecycle_toolchain.pm
@@ -26,9 +26,10 @@ sub run {
     my %expiration = (
         gcc5      => 'Now',
         libada5   => 'Now',
-        gcc6      => '2024-10-30',
-        libada6   => '2024-10-30',
-        toolchain => '2024-10-30'
+        gcc6      => 'Now',
+        gcc7      => '2024-10-30',
+        libada7   => '2024-10-30',
+        toolchain => '2024-10-30',
     );
 
     select_console 'root-console';


### PR DESCRIPTION
gcc6 reached it's expiration and is replaced by gcc7.

See [poo#37695](https://progress.opensuse.org/issues/37695).

- [Verification run](http://g226.suse.de/tests/2018#step/zypper_lifecycle_toolchain/17) (fails due to [bsc#1099853](https://bugzilla.suse.com/show_bug.cgi?id=1099853).
