### PR TITLE
Correct force_cron_run name / catch systemd timer system performance impact

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -966,7 +966,7 @@ sub load_consoletests {
     loadtest 'console/integration_services' if is_hyperv;
     loadtest "locale/keymap_or_locale";
     loadtest "console/repo_orphaned_packages_check" if is_jeos;
-    loadtest "console/force_cron_run" unless is_jeos;
+    loadtest "console/force_scheduled_tasks" unless is_jeos;
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/check_locked_package";
     }
@@ -1566,8 +1566,8 @@ sub load_x11_installation {
     loadtest "x11/x11_setup";
     # temporary adding test modules which applies hacks for missing parts in sle15
     loadtest "console/sle15_workarounds" if is_sle and sle_version_at_least('15');
-    loadtest "console/hostname"       unless is_bridged_networking;
-    loadtest "console/force_cron_run" unless is_jeos;
+    loadtest "console/hostname"              unless is_bridged_networking;
+    loadtest "console/force_scheduled_tasks" unless is_jeos;
     loadtest "shutdown/grub_set_bootargs";
     loadtest "shutdown/shutdown";
 }
@@ -1772,8 +1772,8 @@ sub load_create_hdd_tests {
     # temporary adding test modules which applies hacks for missing parts in sle15
     loadtest 'console/sle15_workarounds' if is_sle('15+');
     loadtest 'console/integration_services' if is_hyperv;
-    loadtest 'console/hostname'       unless is_bridged_networking;
-    loadtest 'console/force_cron_run' unless is_jeos;
+    loadtest 'console/hostname'              unless is_bridged_networking;
+    loadtest 'console/force_scheduled_tasks' unless is_jeos;
     # Remove repos pointing to download.opensuse.org and add snaphot repo from o3
     replace_opensuse_repos_tests if is_repo_replacement_required;
     loadtest 'console/scc_deregistration' if get_var('SCC_DEREGISTER');
@@ -1824,7 +1824,7 @@ sub load_syscontainer_tests() {
 }
 
 sub load_toolchain_tests {
-    loadtest "console/force_cron_run";
+    loadtest "console/force_scheduled_tasks";
     loadtest "toolchain/install";
     loadtest "toolchain/gcc_fortran_compilation";
     loadtest "toolchain/gcc_compilation";

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -468,7 +468,7 @@ else {
     elsif (is_jeos) {
         load_boot_tests();
         loadtest "jeos/firstrun";
-        loadtest "console/force_cron_run";
+        loadtest "console/force_scheduled_tasks";
         loadtest "jeos/diskusage";
         loadtest "jeos/root_fs_size";
         loadtest "jeos/mount_by_label";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -733,7 +733,7 @@ if (is_jeos) {
     load_boot_tests();
     loadtest "jeos/firstrun";
     loadtest "jeos/record_machine_id";
-    loadtest "console/force_cron_run";
+    loadtest "console/force_scheduled_tasks";
     loadtest "jeos/grub2_gfxmode";
     loadtest 'jeos/revive_xen_domain' if check_var('VIRSH_VMM_FAMILY', 'xen');
     loadtest "jeos/diskusage";

--- a/tests/console/force_scheduled_tasks.pm
+++ b/tests/console/force_scheduled_tasks.pm
@@ -7,7 +7,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Avoid suprises later and run the cron jobs explicitly
+# Summary: Avoid suprises later and run scheduled tasks explicitly, be it cron
+#   jobs or systemd timer
 # Maintainer: Stephan Kulow <coolo@suse.de>
 # Tags: bsc#1017461, bsc#1063638
 


### PR DESCRIPTION
* Keep systemd timer active on "system performance" scenarios
* Rename "force_cron_run" to more appropriate name also covering systemd timer

Verified locally with `isotovideo -d _exit_after_schedule=1` regarding the schedule change:

```
[2018-07-02T17:28:18.0002 CEST] [debug] scheduling bootloader tests/installation/bootloader.pm
[2018-07-02T17:28:18.0005 CEST] [debug] scheduling welcome tests/installation/welcome.pm
[2018-07-02T17:28:18.0005 CEST] [debug] scheduling keyboard_selection tests/installation/keyboard_selection.pm
[2018-07-02T17:28:18.0006 CEST] [debug] scheduling accept_license tests/installation/accept_license.pm
[2018-07-02T17:28:18.0007 CEST] [debug] scheduling skip_registration tests/installation/skip_registration.pm
[2018-07-02T17:28:18.0009 CEST] [debug] scheduling addon_products_sle tests/installation/addon_products_sle.pm
[2018-07-02T17:28:18.0010 CEST] [debug] scheduling system_role tests/installation/system_role.pm
Useless use of a constant ("timeout") in void context at /var/lib/openqa/share/tests/sle/lib/partition_setup.pm line 125.
Useless use of a constant (10) in void context at /var/lib/openqa/share/tests/sle/lib/partition_setup.pm line 125.
[2018-07-02T17:28:18.0013 CEST] [debug] scheduling partitioning tests/installation/partitioning.pm
[2018-07-02T17:28:18.0013 CEST] [debug] scheduling partitioning_finish tests/installation/partitioning_finish.pm
[2018-07-02T17:28:18.0014 CEST] [debug] scheduling releasenotes tests/installation/releasenotes.pm
[2018-07-02T17:28:18.0015 CEST] [debug] scheduling installer_timezone tests/installation/installer_timezone.pm
[2018-07-02T17:28:18.0015 CEST] [debug] scheduling logpackages tests/installation/logpackages.pm
[2018-07-02T17:28:18.0016 CEST] [debug] scheduling user_settings tests/installation/user_settings.pm
[2018-07-02T17:28:18.0017 CEST] [debug] scheduling user_settings_root tests/installation/user_settings_root.pm
[2018-07-02T17:28:18.0018 CEST] [debug] scheduling installation_overview tests/installation/installation_overview.pm
[2018-07-02T17:28:18.0018 CEST] [debug] scheduling disable_grub_timeout tests/installation/disable_grub_timeout.pm
[2018-07-02T17:28:18.0020 CEST] [debug] scheduling start_install tests/installation/start_install.pm
[2018-07-02T17:28:18.0021 CEST] [debug] scheduling await_install tests/installation/await_install.pm
[2018-07-02T17:28:18.0022 CEST] [debug] scheduling logs_from_installation_system tests/installation/logs_from_installation_system.pm
[2018-07-02T17:28:18.0023 CEST] [debug] scheduling reboot_after_installation tests/installation/reboot_after_installation.pm
[2018-07-02T17:28:18.0024 CEST] [debug] scheduling grub_test tests/installation/grub_test.pm
[2018-07-02T17:28:18.0025 CEST] [debug] scheduling first_boot tests/installation/first_boot.pm
[2018-07-02T17:28:18.0026 CEST] [debug] scheduling consoletest_setup tests/console/consoletest_setup.pm
[2018-07-02T17:28:18.0027 CEST] [debug] scheduling keymap_or_locale tests/locale/keymap_or_locale.pm
[2018-07-02T17:28:18.0028 CEST] [debug] scheduling force_scheduled_tasks tests/console/force_scheduled_tasks.pm
[2018-07-02T17:28:18.0028 CEST] [debug] scheduling textinfo tests/console/textinfo.pm
[2018-07-02T17:28:18.0029 CEST] [debug] scheduling hostname tests/console/hostname.pm
[2018-07-02T17:28:18.0030 CEST] [debug] scheduling installation_snapshots tests/console/installation_snapshots.pm
[2018-07-02T17:28:18.0030 CEST] [debug] scheduling xorg_vt tests/console/xorg_vt.pm
[2018-07-02T17:28:18.0031 CEST] [debug] scheduling zypper_lr tests/console/zypper_lr.pm
[2018-07-02T17:28:18.0031 CEST] [debug] scheduling zypper_ref tests/console/zypper_ref.pm
[2018-07-02T17:28:18.0032 CEST] [debug] scheduling ncurses tests/console/ncurses.pm
[2018-07-02T17:28:18.0033 CEST] [debug] scheduling yast2_lan tests/console/yast2_lan.pm
[2018-07-02T17:28:18.0034 CEST] [debug] scheduling curl_https tests/console/curl_https.pm
[2018-07-02T17:28:18.0034 CEST] [debug] scheduling glibc_sanity tests/console/glibc_sanity.pm
[2018-07-02T17:28:18.0035 CEST] [debug] scheduling zypper_in tests/console/zypper_in.pm
[2018-07-02T17:28:18.0036 CEST] [debug] scheduling yast2_i tests/console/yast2_i.pm
[2018-07-02T17:28:18.0037 CEST] [debug] scheduling yast2_bootloader tests/console/yast2_bootloader.pm
[2018-07-02T17:28:18.0038 CEST] [debug] scheduling vim tests/console/vim.pm
[2018-07-02T17:28:18.0039 CEST] [debug] scheduling sshd tests/console/sshd.pm
[2018-07-02T17:28:18.0040 CEST] [debug] scheduling ssh_cleanup tests/console/ssh_cleanup.pm
[2018-07-02T17:28:18.0041 CEST] [debug] scheduling mtab tests/console/mtab.pm
[2018-07-02T17:28:18.0042 CEST] [debug] scheduling consoletest_finish tests/console/consoletest_finish.pm
[2018-07-02T17:28:18.0047 CEST] [debug] scheduling desktop_runner tests/x11/desktop_runner.pm
[2018-07-02T17:28:18.0047 CEST] [debug] scheduling xterm tests/x11/xterm.pm
[2018-07-02T17:28:18.0048 CEST] [debug] scheduling sshxterm tests/x11/sshxterm.pm
[2018-07-02T17:28:18.0049 CEST] [debug] scheduling gnome_control_center tests/x11/gnome_control_center.pm
[2018-07-02T17:28:18.0050 CEST] [debug] scheduling gnome_terminal tests/x11/gnome_terminal.pm
[2018-07-02T17:28:18.0051 CEST] [debug] scheduling gedit tests/x11/gedit.pm
[2018-07-02T17:28:18.0052 CEST] [debug] scheduling firefox tests/x11/firefox.pm
[2018-07-02T17:28:18.0055 CEST] [debug] scheduling yast2_snapper tests/x11/yast2_snapper.pm
[2018-07-02T17:28:18.0056 CEST] [debug] scheduling glxgears tests/x11/glxgears.pm
[2018-07-02T17:28:18.0056 CEST] [debug] scheduling nautilus tests/x11/nautilus.pm
[2018-07-02T17:28:18.0058 CEST] [debug] scheduling desktop_mainmenu tests/x11/desktop_mainmenu.pm
[2018-07-02T17:28:18.0059 CEST] [debug] scheduling reboot_gnome tests/x11/reboot_gnome.pm
[2018-07-02T17:28:18.0060 CEST] [debug] scheduling shutdown tests/x11/shutdown.pm
```

Verification run in openQA: http://lord.arch/tests/1280