### PR TITLE
Increase iterations count for patterns selection in SLE15

### DIFF
--- a/tests/installation/select_patterns_and_packages.pm
+++ b/tests/installation/select_patterns_and_packages.pm
@@ -163,7 +163,7 @@ sub run {
             $wanted_patterns{$p} = 1;
         }
 
-        my $counter = 70;
+        my $counter = 80;
         while (1) {
             die "looping for too long" unless ($counter--);
             my $needs_to_be_selected;


### PR DESCRIPTION
For SLE15 we now have more patterns, so we fail to iterate over all of
them.

See [poo#37598](https://progress.opensuse.org/issues/37598).

- [Verification run](http://g226.suse.de/tests/2020#)
