### PR TITLE
Test that we can't stop docker using ^C

### DIFF
--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -123,7 +123,7 @@ sub run {
     type_string("# ... and we seem to be still in container\n");
     # If echo works then ctrl-c stopped sleep
     type_string "echo 'ctrlc_timeout' > /dev/$serialdev\n";
-    if (wait_serial 'ctrlc_timeout', 10, 1) {
+    if (wait_serial('ctrlc_timeout', 10, 1) =~ 'ctrlc_timeout') {
         die 'ctrl-c stopped container';
     }
     die "Something went wrong" unless wait_serial('ctrlc_timeout', 30);


### PR DESCRIPTION
Fix of #5301

this test was requested after bsc#1073877 and bsc#1089732

Some programs (f.e. bash) can handle signals and so we can close them by pressing ^C
Another programs (f.e. sleep) cannot do that and so this test checks exactly this.

- Related ticket: https://progress.opensuse.org/issues/36784
- Needles: Not needed
- Verification run: Not yet
