### PR TITLE
Revert "Align s390x special boot handling to other architectures"

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1263,9 +1263,13 @@ sub reconnect_s390 {
         select_console('iucvconn');
     }
     else {
-        wait_serial('GNU GRUB') || diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
-        select_console('svirt');
-        type_line_svirt '', expect => $login_ready, timeout => $args{timeout}, fail_message => 'Could not find login prompt';
+        my $r = wait_serial($login_ready, 300);
+        if ($r && $r =~ qr/Welcome to SUSE Linux Enterprise 15/) {
+            record_soft_failure('bsc#1040606');
+        }
+        elsif ($r && is_sle) {
+            $r =~ qr/Welcome to SUSE Linux Enterprise Server/ || die "Correct welcome string not found";
+        }
     }
 
     # SLE >= 15 does not offer auto-started VNC server in SUT, only login prompt as in textmode

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -21,6 +21,15 @@ use version_utils qw(is_sle is_leap);
 sub run {
     my ($self) = shift;
 
+    if (check_var('ARCH', 's390x')) {
+        # on s390x we do not wait for the grub menu or can not handle it like
+        # do we on other architectures or backends. Also, we do not have the
+        # same problem that we could miss the grub screen with timeout so we
+        # skip disabling the grub timeout
+        diag 'Skipping disabling grub timeout on s390x as we can not catch the grub screen there';
+        return;
+    }
+
     # Verify Installation Settings overview is displayed as starting point
     assert_screen "installation-settings-overview-loaded";
 


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#5116

Broke https://openqa.suse.de/tests/1805562
See https://openqa.suse.de/tests/overview?distri=sle&version=12-SP4&build=0274&groupid=139&arch=s390x&failed_modules=reconnect_s390,disable_grub_timeout