### PR TITLE
Allow nvmftests to run when DEVEL_LANG_PYTHON_REPO is not set

### DIFF
--- a/tests/kernel/nvmftests.pm
+++ b/tests/kernel/nvmftests.pm
@@ -22,7 +22,13 @@ sub run {
     select_virtio_console();
 
     zypper_call('ar -f -G ' . get_required_var('BENCHMARK_REPO'));
-    zypper_call('ar -f -G ' . get_required_var('DEVEL_LANG_PYTHON_REPO'));
+    if (get_var('DEVEL_LANG_PYTHON_REPO')) {
+        zypper_call('ar -f -G ' . get_var('DEVEL_LANG_PYTHON_REPO'));
+    }
+    else {
+        assert_script_run('python -m ensurepip --default-pip');
+        assert_script_run('pip install nose nose2 natsort pep8 flake8 pylint epydoc');
+    }
     zypper_call('--gpg-auto-import-keys ref');
     zypper_call('in --no-recommends nvmftests');
 


### PR DESCRIPTION
When running the nvmftests, some python-packages are installed.
However, these fail to build, for example for SLE12-SP4. In order
to allow the testsuite to be executed, if packages are not available,
when unsetting DEVEL_LANG_TOOLS_REPO, the dependencies can be installed
using pip.

This workaround should help us running NVMe Over Fabrics tests until we have integrated blktests for openQA, which should replace this testsuite.

Signed-off-by: Michael Moese <mmoese@suse.de>