### PR TITLE
Revert "Revert "Don't do workaround if UEFI_PFLASH_VARS is present""

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -369,7 +369,8 @@ sub wait_boot {
         # booted so we have to handle that
         # because of broken firmware, bootindex doesn't work on aarch64 bsc#1022064
         push @tags, 'inst-bootmenu' if ((get_var('USBBOOT') and get_var('UEFI')) || (check_var('ARCH', 'aarch64') and get_var('UEFI')) || get_var('OFW'));
-        $self->handle_uefi_boot_disk_workaround if (get_var('MACHINE') =~ /aarch64/ && get_var('UEFI') && get_var('BOOT_HDD_IMAGE') && !$in_grub);
+        $self->handle_uefi_boot_disk_workaround
+          if (get_var('MACHINE') =~ /aarch64/ && get_var('UEFI') && get_var('BOOT_HDD_IMAGE') && !$in_grub && !get_var('UEFI_PFLASH_VARS'));
         check_screen(\@tags, $bootloader_time);
         if (match_has_tag("bootloader-shim-import-prompt")) {
             send_key "down";

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -370,7 +370,11 @@ sub wait_boot {
         # because of broken firmware, bootindex doesn't work on aarch64 bsc#1022064
         push @tags, 'inst-bootmenu' if ((get_var('USBBOOT') and get_var('UEFI')) || (check_var('ARCH', 'aarch64') and get_var('UEFI')) || get_var('OFW'));
         $self->handle_uefi_boot_disk_workaround
-          if (get_var('MACHINE') =~ /aarch64/ && get_var('UEFI') && get_var('BOOT_HDD_IMAGE') && !$in_grub && !get_var('UEFI_PFLASH_VARS'));
+          if (get_var('MACHINE') =~ /aarch64/
+            && get_var('UEFI')
+            && get_var('BOOT_HDD_IMAGE')
+            && !$in_grub
+            && !(isotovideo::get_version() >= 12 && get_var('UEFI_PFLASH_VARS')));
         check_screen(\@tags, $bootloader_time);
         if (match_has_tag("bootloader-shim-import-prompt")) {
             send_key "down";


### PR DESCRIPTION
Don't try to use the UEFI console to select the correct boot device if the
UEFI_PFLASH_VARS var is present.

This requires https://github.com/os-autoinst/os-autoinst/pull/985

