### PR TITLE
[NFV] Add Mellanox OFED package installation

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -701,6 +701,7 @@ sub load_baremetal_tests {
     }
     elsif (get_var('NFV')) {
         mellanox_config();
+        loadtest "kernel/mellanox_ofed" if get_var('OFED_URL');
         if (check_var("NFV", "master")) {
             load_nfv_master_tests();
         }

--- a/tests/kernel/mellanox_ofed.pm
+++ b/tests/kernel/mellanox_ofed.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Mellanox OFED package installation
+# This package is not ready for SLE15 yet, there is an available
+# package for SLE12-SP3 which is able to build the needed RPMs
+# on SLE15.
+# Maintainer: Jose Lausuch <jalausuch@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    select_console 'root-ssh';
+    my $ofed_url      = get_required_var('OFED_URL');
+    my $ofed_file_tgz = (split(/\//, $ofed_url))[-1];
+    my $ofed_dir      = ((split(/\.tgz/, $ofed_file_tgz))[0]);
+
+    zypper_call('--quiet in openvswitch python-devel python2-libxml2-python libopenssl1_0_0 insserv-compat libstdc++6-devel-gcc7 createrepo_c', timeout => 500);
+
+    # Install Mellanox OFED
+    assert_script_run("wget $ofed_url");
+    assert_script_run("tar -xvf $ofed_file_tgz");
+    assert_script_run("cd $ofed_dir");
+    assert_script_run("./mlnxofedinstall --skip-distro-check --add-kernel-support", timeout => 500);
+    assert_script_run("modprobe -rv rpcrdma");
+    assert_script_run("/etc/init.d/openibd restart");
+
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+


### PR DESCRIPTION
Installs OFED package if variable OFED_URL is set.

- Related ticket: https://progress.opensuse.org/issues/32869
- Verification run: http://loewe.arch.suse.de/tests/874#step/mellanox_ofed/15
- Information: http://www.mellanox.com/page/products_dyn?product_family=26
