### PR TITLE
Align s390x special boot handling to other architectures 

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1265,6 +1265,7 @@ sub reconnect_s390 {
     else {
         wait_serial('GNU GRUB') || diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
         select_console('svirt');
+        save_svirt_pty;
         type_line_svirt '', expect => $login_ready, timeout => $args{timeout}, fail_message => 'Could not find login prompt';
     }
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -121,7 +121,7 @@ sub type_line_svirt {
 
 sub unlock_zvm_disk {
     my ($console) = @_;
-    eval { console('x3270')->expect_3270(output_delim => 'Please enter passphrase') };
+    eval { console('x3270')->expect_3270(output_delim => 'Please enter passphrase', timeout => 30) };
     if ($@) {
         diag 'No passphrase asked, continuing';
     }
@@ -134,7 +134,7 @@ sub unlock_zvm_disk {
 
 sub handle_grub_zvm {
     my ($console) = @_;
-    eval { $console->expect_3270(output_delim => 'GNU GRUB'); };
+    eval { $console->expect_3270(output_delim => 'GNU GRUB', timeout => 30); };
     if ($@) {
         diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
     }
@@ -1250,8 +1250,8 @@ sub reconnect_s390 {
     # different behaviour for z/VM and z/KVM
     if (check_var('BACKEND', 's390x')) {
         my $console = console('x3270');
-        # grub is handled in unlock_if_encrypted
-        handle_grub_zvm($console) unless get_var('ENCRYPT');
+        # grub is handled in unlock_if_encrypted unless affected by bsc#993247 or https://fate.suse.com/321208
+        handle_grub_zvm($console) if (!get_var('ENCRYPT') || get_var('ENCRYPT_ACTIVATE_EXISTING') && !get_var('ENCRYPT_FORCE_RECOMPUTE'));
         my $r;
         eval { $r = console('x3270')->expect_3270(output_delim => $login_ready, timeout => $args{timeout}); };
         if ($@) {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1263,13 +1263,9 @@ sub reconnect_s390 {
         select_console('iucvconn');
     }
     else {
-        my $r = wait_serial($login_ready, 300);
-        if ($r && $r =~ qr/Welcome to SUSE Linux Enterprise 15/) {
-            record_soft_failure('bsc#1040606');
-        }
-        elsif ($r && is_sle) {
-            $r =~ qr/Welcome to SUSE Linux Enterprise Server/ || die "Correct welcome string not found";
-        }
+        wait_serial('GNU GRUB') || diag 'Could not find GRUB screen, continuing nevertheless, trying to boot';
+        select_console('svirt');
+        type_line_svirt '', expect => $login_ready, timeout => $args{timeout}, fail_message => 'Could not find login prompt';
     }
 
     # SLE >= 15 does not offer auto-started VNC server in SUT, only login prompt as in textmode

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -21,15 +21,6 @@ use version_utils qw(is_sle is_leap);
 sub run {
     my ($self) = shift;
 
-    if (check_var('ARCH', 's390x')) {
-        # on s390x we do not wait for the grub menu or can not handle it like
-        # do we on other architectures or backends. Also, we do not have the
-        # same problem that we could miss the grub screen with timeout so we
-        # skip disabling the grub timeout
-        diag 'Skipping disabling grub timeout on s390x as we can not catch the grub screen there';
-        return;
-    }
-
     # Verify Installation Settings overview is displayed as starting point
     assert_screen "installation-settings-overview-loaded";
 


### PR DESCRIPTION
The PR is made to align s390x kvm special boot handling to other architectures to have less specialization where not needed. It adjusts 'reconnect_s390' subroutine to always wait for grub menu and send 'ret'. 
Fixes additional issues we have identified after merging the original PR #5116.

- Related ticket: https://progress.opensuse.org/issues/26836
- Verification runs: 
  [zkvm non-encrypted](http://10.160.65.138/tests/169)
  [zkvm encrypted](http://10.160.65.138/tests/188#step/reconnect_s390/4) (fails, see https://progress.opensuse.org/issues/36268)
  [autoyast reinstall zkvm](http://g226.suse.de/tests/2023#)
  [zVM btrfs](http://opeth.suse.de/tests/2852)
  [zVM encrypted](http://opeth.suse.de/tests/2853)