### PR TITLE
Test SLE base images from registry.suse.de

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -502,12 +502,13 @@ sub load_slepos_tests {
 sub load_docker_tests {
     loadtest "console/docker";
     loadtest "console/docker_runc";
-    # No package 'docker-compose' in SLE
-    if (!is_sle) {
-        loadtest "console/docker_compose";
-    }
-    if (is_sle('<12-SP4')) {
+    if (is_sle('12-SP3+')) {
+        loadtest "console/docker_image";
         loadtest "console/sle2docker";
+    }
+    elsif (is_opensuse) {
+        loadtest "console/docker_image_rpm";
+        loadtest "console/docker_compose";
     }
 }
 

--- a/tests/console/docker_image.pm
+++ b/tests/console/docker_image.pm
@@ -7,69 +7,74 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Test installation and running of the docker image for this snapshot
-# Maintainer: Fabian Vogt <fvogt@suse.com>
+# Summary: Test installation and running of the docker image from the registry for this snapshot
+# Maintainer: Pavel Dostál <pdostal@suse.cz>
 
 use base 'consoletest';
 use testapi;
 use utils;
 use strict;
-use version_utils qw(is_leap is_tumbleweed);
+use registration "add_suseconnect_product";
+use version_utils "is_sle";
 
 sub run {
-    select_console 'root-console';
+    select_console "root-console";
 
-    my $version = get_required_var('VERSION');
+    my $version     = get_required_var("VERSION");
+    my $SCC_REGCODE = get_required_var("SCC_REGCODE");
+
+    if (script_run("SUSEConnect --status-text") != 0) {
+        assert_script_run("SUSEConnect --cleanup");
+        assert_script_run("SUSEConnect -r $SCC_REGCODE");
+        add_suseconnect_product("sle-module-containers", substr($version, 0, 2));
+    }
 
     my $image_name;
-    my $image_path;
-
-    if (is_tumbleweed) {
-        $image_name = 'opensuse/tumbleweed:current';
-        $image_path = '/usr/share/suse-docker-images/native/*-image*.tar.xz';
-
-        # For Tumbleweed, the image is wrapped inside an RPM
-        zypper_call "in docker opensuse-tumbleweed-image";
+    if (is_sle("=12-SP3")) {
+        $image_name = "registry.suse.de/suse/sle-12-sp3/update/products/casp30/container/sles12:sp3";
     }
-    elsif (is_leap('15.0+')) {
-        $image_name = "opensuse-leap-$version:current";
-        $image_path = "/usr/share/suse-docker-images/native/opensuse-leap${version}-image.tar.xz";
-
-        # For Leap, the docker image is the ISO asset
-        my $image_filename = get_required_var('ISO');
-        $image_filename =~ s/^.*\///;
-        my $image_url = autoinst_url("/assets/other/$image_filename");
-        assert_script_run "curl $image_url --create-dirs -o $image_path";
+    elsif (is_sle("=15")) {
+        $image_name = "registry.suse.de/suse/sle-15/update/cr/images/suse/sle15:current";
     }
     else {
-        die 'Only know about Tumbleweed and Leap 15.0+ docker images';
+        die("This test only works at SLE12SP3 and SLE15.");
     }
 
-    # Start the docker daemon, normally done by previous test modules already
-    systemctl 'start docker';
-    systemctl 'status docker';
-    assert_script_run 'docker info';
+    # Allow our internal 'insecure' registry
+    zypper_call("in docker");
+    assert_script_run("mkdir -p /etc/docker");
+    assert_script_run('cat /etc/docker/daemon.json; true');
+    assert_script_run(
+        'echo "{ \"insecure-registries\" : [\"registry.suse.de\", \"registry.suse.de:443\", \"registry.suse.de:5000\"] }" > /etc/docker/daemon.json');
+    assert_script_run('cat /etc/docker/daemon.json');
+    systemctl('restart docker');
 
     # Load the image
-    assert_script_run "docker load -i $image_path";
-    # Show that the image got registered
-    assert_script_run "docker images $image_name";
+    assert_script_run("docker pull $image_name", 120);
     # Running executables works
-    assert_script_run qq{docker container run --rm $image_name echo "I work" | grep "I work"};
-    # It is the correct openSUSE version
-    validate_script_output qq{docker container run --rm $image_name cat /etc/os-release}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}( .*)?"/ };
-    # Zypper and network are working
-    assert_script_run qq{docker container run --rm $image_name zypper -v ref | grep "All repositories have been refreshed"};
+    assert_script_run("docker container run --rm $image_name echo 'I work' | grep 'I work'");
+    # It is the right SLE version
+    if (is_sle("=12-SP3")) {
+        validate_script_output("docker container run --rm $image_name cat /etc/os-release", sub { /PRETTY_NAME="SUSE Linux Enterprise Server 12 SP3"/ });
+    }
+    elsif (is_sle("=15")) {
+        validate_script_output qq{docker container run --rm $image_name cat /etc/os-release}, sub { /PRETTY_NAME="SUSE Linux Enterprise Server 15"/ };
+    }
+    # zypper lr
+    assert_script_run("docker container run --rm $image_name zypper lr -s");
+    # zypper ref
+    assert_script_run("docker container run --rm $image_name zypper -v ref | grep 'All repositories have been refreshed'");
 
-    # Interactive session works
-    type_string <<"EOF";
-docker container run --rm -it $image_name /bin/bash; echo DOCKER-\$?- > /dev/$serialdev
-exit 42
-EOF
-    wait_serial 'DOCKER-42-' || die 'Interactive test failed';
+    # container-diff
+    assert_script_run(
+        "curl -LO https://storage.googleapis.com/container-diff/latest/container-diff-linux-amd64 &&
+        chmod +x container-diff-linux-amd64 && sudo mv container-diff-linux-amd64 /usr/local/bin/container-diff"
+    );
+    assert_script_run("container-diff analyze daemon://$image_name --type=rpm > /tmp/container-diff.txt");
+    upload_asset("/tmp/container-diff.txt");
 
     # Remove the image again to save space
-    assert_script_run "docker image rm --force $image_name";
+    assert_script_run("docker image rm --force $image_name");
 }
 
 1;

--- a/tests/console/docker_image_rpm.pm
+++ b/tests/console/docker_image_rpm.pm
@@ -1,0 +1,75 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test installation and running of the docker image from RPM repository for this snapshot
+# Maintainer: Fabian Vogt <fvogt@suse.com>
+
+use base 'consoletest';
+use testapi;
+use utils;
+use strict;
+use version_utils qw(is_leap is_tumbleweed);
+
+sub run {
+    select_console 'root-console';
+
+    my $version = get_required_var('VERSION');
+
+    my $image_name;
+    my $image_path;
+
+    if (is_tumbleweed) {
+        $image_name = 'opensuse/tumbleweed:current';
+        $image_path = '/usr/share/suse-docker-images/native/*-image*.tar.xz';
+
+        # For Tumbleweed, the image is wrapped inside an RPM
+        zypper_call "in docker opensuse-tumbleweed-image";
+    }
+    elsif (is_leap('15.0+')) {
+        $image_name = "opensuse-leap-$version:current";
+        $image_path = "/usr/share/suse-docker-images/native/opensuse-leap${version}-image.tar.xz";
+
+        # For Leap, the docker image is the ISO asset
+        my $image_filename = get_required_var('ISO');
+        $image_filename =~ s/^.*\///;
+        my $image_url = autoinst_url("/assets/other/$image_filename");
+        assert_script_run "curl $image_url --create-dirs -o $image_path";
+    }
+    else {
+        die 'Only know about Tumbleweed and Leap 15.0+ docker images';
+    }
+
+    # Start the docker daemon, normally done by previous test modules already
+    systemctl 'start docker';
+    systemctl 'status docker';
+    assert_script_run 'docker info';
+
+    # Load the image
+    assert_script_run "docker load -i $image_path";
+    # Show that the image got registered
+    assert_script_run "docker images $image_name";
+    # Running executables works
+    assert_script_run qq{docker container run --rm $image_name echo "I work" | grep "I work"};
+    # It is the correct openSUSE version
+    validate_script_output qq{docker container run --rm $image_name cat /etc/os-release}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}( .*)?"/ };
+    # Zypper and network are working
+    assert_script_run qq{docker container run --rm $image_name zypper -v ref | grep "All repositories have been refreshed"};
+
+    # Interactive session works
+    type_string <<"EOF";
+docker container run --rm -it $image_name /bin/bash; echo DOCKER-\$?- > /dev/$serialdev
+exit 42
+EOF
+    wait_serial 'DOCKER-42-' || die 'Interactive test failed';
+
+    # Remove the image again to save space
+    assert_script_run "docker image rm --force $image_name";
+}
+
+1;


### PR DESCRIPTION
This is test for QAM ensuring that the SLE baseimage from `registry.suse.de` isn't broken.

- Related ticket: https://progress.opensuse.org/issues/36775
- Needles: No need - console test
- Verification run: [15](http://pdostal-server.suse.cz/tests/954), [12.3](http://pdostal-server.suse.cz/tests/956)
