### PR TITLE
Fix harmonization update

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -141,18 +141,6 @@ logcurrentenv(
       LIVECD NETBOOT NOIMAGES QEMUVGA SPLITUSR VIDEOMODE)
 );
 
-sub updates_is_applicable {
-    # we don't want live systems to run out of memory or virtual disk space.
-    # Applying updates on a live system would not be persistent anyway.
-    # Also, applying updates on BOOT_TO_SNAPSHOT is useless.
-    # Also, updates on INSTALLONLY do not match the meaning
-    return !get_var('INSTALLONLY') && !get_var('BOOT_TO_SNAPSHOT') && !get_var('DUALBOOT') && !get_var('UPGRADE') && !is_livesystem;
-}
-
-sub guiupdates_is_applicable {
-    return get_var("DESKTOP") =~ /gnome|kde|xfce|lxde/ && !check_var("FLAVOR", "Rescue-CD");
-}
-
 sub have_addn_repos {
     return !get_var("NET") && !get_var("EVERGREEN") && get_var("SUSEMIRROR") && !is_staging();
 }
@@ -248,31 +236,6 @@ sub install_online_updates {
     return 1;
 }
 
-sub load_system_update_tests {
-    return unless updates_is_applicable;
-    if (need_clear_repos) {
-        loadtest "update/zypper_clear_repos";
-        set_var('CLEAR_REPOS', 1);
-    }
-
-    if (get_var('ZYPPER_ADD_REPOS')) {
-        loadtest "console/zypper_add_repos";
-    }
-    if (guiupdates_is_applicable()) {
-        loadtest "update/prepare_system_for_update_tests";
-        if (check_var("DESKTOP", "kde")) {
-            loadtest "update/updates_packagekit_kde";
-        }
-        else {
-            loadtest "update/updates_packagekit_gpk";
-        }
-        loadtest "update/check_system_is_updated";
-    }
-    else {
-        loadtest "update/zypper_up";
-    }
-}
-
 sub load_qam_install_tests {
     return 0 unless get_var('INSTALL_PACKAGES');
 
@@ -283,7 +246,6 @@ sub load_qam_install_tests {
     loadtest 'console/zypper_add_repos';
     loadtest 'console/qam_zypper_patch';
     loadtest 'console/qam_verify_package_install';
-
 
     return 1;
 }


### PR DESCRIPTION
Harmonize updating handling SUSE/openSUSE:

- Related ticket: https://progress.opensuse.org/issues/31954
- Previous PR #5175 and its revert #5308
- Verification run:
 - opensuse-Staging:J-Staging2-DVD-x86_64-Build1945.2-gnome@64bit: [O3](https://openqa.opensuse.org/tests/696687) vs [local](http://dhcp254.suse.cz/tests/1981/file/autoinst-log.txt)
 -  opensuse-Staging:J-Staging2-DVD-x86_64-Build1945.2-textmode@64bit: [O3](https://openqa.opensuse.org/tests/696690) vs [local](http://dhcp254.suse.cz/tests/1980/file/autoinst-log.txt)
-  sle-15-Installer-DVD-x86_64-Build668.1-textmode@64bit: [OSD](https://openqa.suse.de/tests/1772437) vs [local](http://dhcp254.suse.cz/tests/1977/file/autoinst-log.txt)
-  sle-15-Installer-DVD-x86_64-Build668.1-gnome@64bit: [OSD](https://openqa.suse.de/tests/1773793) vs [local](http://dhcp254.suse.cz/tests/1978/file/autoinst-log.txt)
-  sle-12-SP3-Desktop-DVD-Incidents-x86_64-Build:6592:libqt5-qtbase.1530147934-qam-allpatterns@64bit: [OSD](https://openqa.suse.de/tests/1790992) vs [local](http://dhcp254.suse.cz/tests/1979/file/autoinst-log.txt)



