### PR TITLE
Update path of "orphaned_packages_check"

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -627,7 +627,7 @@ sub load_online_migration_tests {
     if (check_var("MIGRATION_METHOD", 'zypper')) {
         loadtest "migration/sle12_online_migration/zypper_migration";
     }
-    loadtest "migration/sle12_online_migration/orphaned_packages_check";
+    loadtest 'console/orphaned_packages_check';
     loadtest "migration/sle12_online_migration/post_migration";
 }
 


### PR DESCRIPTION
For online migrtion test cases, the path of "orphaned_packages_check" is obsolete.
Update its path in main.pm

- See Poo 38177
