### PR TITLE
CaaSP cluster migration from GM to current build

### DIFF
--- a/data/caasp/update.sh
+++ b/data/caasp/update.sh
@@ -66,12 +66,15 @@ runner="$srun $where cmd.run"
 
 if [ ! -z "${SETUP:-}" ]; then
     # Remove non-existent ISO repository
-    # Workaround because of higher package versions
     $runner "zypper rr 1"
-
-    # Add repository as system venodors
-    $runner 'echo -e "[main]\nvendors = suse,opensuse,obs://build.suse.de,obs://build.opensuse.org" > /etc/zypp/vendors.d/vendors.conf'
-    $runner "zypper ar --refresh --no-gpgcheck $SETUP UPDATE"
+    if [ "$SETUP" == "dup" ]; then
+        # Deregister system before update
+        $runner "SUSEConnect -d"
+    else
+        # Add repository to system vendors
+        $runner 'echo -e "[main]\nvendors = suse,opensuse,obs://build.suse.de,obs://build.opensuse.org" > /etc/zypp/vendors.d/vendors.conf'
+        $runner "zypper ar --refresh --no-gpgcheck $SETUP UPDATE"
+    fi
     $runner "zypper lr -U"
 
 elif [ ! -z "${TEST:-}" ]; then

--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -215,8 +215,14 @@ sub trup_install {
     assert_script_run("rpm -q $input");
 }
 
+# Get current job id
+sub get_current_job {
+    my $name = get_required_var('NAME');
+    return int(substr($name, 0, 8));
+}
+
 sub get_controller_job {
-    die "Don't know how to find current job id" if check_var 'STACK_ROLE', 'controller';
+    return get_current_job if check_var('STACK_ROLE', 'controller');
 
     my $parents = get_parents();
     for my $job_id (@$parents) {
@@ -228,19 +234,11 @@ sub get_controller_job {
 
 # Get list of jobs in cluster
 sub get_cluster_jobs {
-    my @cluster_jobs;
-    if (check_var 'STACK_ROLE', 'controller') {
-        my $children = get_children();
-        @cluster_jobs = keys %$children;
-    }
-    else {
-        @cluster_jobs = @{get_job_info(get_controller_job)->{children}->{Parallel}};
-    }
-    return @cluster_jobs;
+    return @{get_job_info(get_controller_job)->{children}->{Parallel}};
 }
 
 sub get_admin_job {
-    die "Don't know how to find current job id" if check_var 'STACK_ROLE', 'admin';
+    return get_current_job if check_var('STACK_ROLE', 'admin');
 
     my @cluster_jobs = get_cluster_jobs;
     for my $job_id (@cluster_jobs) {

--- a/lib/caasp_controller.pm
+++ b/lib/caasp_controller.pm
@@ -15,8 +15,6 @@ our @EXPORT = qw($admin_fqdn $master_fqdn
 our $admin_fqdn = 'admin.openqa.test';
 # Extra space to check for bsc#1087447
 our $master_fqdn = ' master-api.openqa.test ';
-# CaaSP 2.0 will keep the bug
-$master_fqdn =~ s/^ | $//g if is_caasp('=2.0');
 
 # 10% of clicks are lost because ajax refreshes Velum during click
 # bsc#1048975 - User interaction is lost after page refresh

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -128,8 +128,8 @@ sub init_main {
 }
 
 sub loadtest {
-    my ($test) = @_;
-    autotest::loadtest("tests/$test.pm");
+    my ($test, %args) = @_;
+    autotest::loadtest("tests/$test.pm", %args);
 }
 
 sub load_testdir {

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -129,6 +129,12 @@ sub load_feature_tests {
     loadtest 'caasp/transactional_update';
     loadtest 'caasp/rebootmgr';
 
+    # Tests that require registered system
+    if (get_var 'REGISTER') {
+        loadtest 'caasp/register_and_check';
+        loadtest 'caasp/register_toolchain' if is_caasp('3.0+');
+    }
+
     # Journal errors
     loadtest 'caasp/journal_check';
 
@@ -173,7 +179,8 @@ sub load_stack_tests {
         loadtest 'caasp/stack_finalize';
     }
     else {
-        loadtest "caasp/stack_" . get_var('STACK_ROLE');
+        loadtest 'caasp/stack_' . get_var('STACK_ROLE');
+        loadtest 'caasp/register_and_check' if is_caasp('qam');
     }
 }
 
@@ -231,14 +238,7 @@ else {
     loadtest 'caasp/first_boot';
 }
 
-# ==== Extra tests run after installation  ====
-# REGISTER = 'suseconnect' -> Registers with SCC after the installation
-# REGISTER = 'installation' -> Registers with SCC during the installation
-if (get_var('REGISTER') && !check_var('STACK_ROLE', 'controller')) {
-    loadtest 'caasp/register_and_check';
-    loadtest 'caasp/register_toolchain' unless is_caasp('qam');
-}
-
+# MicroOS feature tests
 if (get_var('EXTRA', '') =~ /FEATURES/) {
     load_feature_tests;
 }

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -149,6 +149,9 @@ sub load_feature_tests {
 
 sub load_stack_tests {
     if (check_var 'STACK_ROLE', 'controller') {
+        if (update_scheduled 'dup') {
+            loadtest 'caasp/shift_version', name => 'ver=dec';
+        }
         loadtest 'caasp/stack_initialize';
         loadtest 'caasp/stack_configure';
         loadtest 'caasp/stack_bootstrap';
@@ -158,6 +161,9 @@ sub load_stack_tests {
         }
         else {
             loadtest 'caasp/stack_reboot';
+        }
+        if (update_scheduled 'dup') {
+            loadtest 'caasp/shift_version', name => 'ver=inc';
         }
         loadtest 'caasp/stack_add_remove' if get_delayed;
         unless (is_caasp('staging') || is_caasp('local')) {
@@ -202,6 +208,9 @@ if (get_var('STACK_ROLE')) {
         loadtest "support_server/setup";
     }
     else {
+        if (update_scheduled 'dup') {
+            loadtest 'caasp/shift_version', name => 'ver=dec';
+        }
         load_caasp_boot_tests;
         load_caasp_inst_tests if is_caasp('DVD');
         loadtest 'caasp/first_boot';

--- a/tests/caasp/shift_version.pm
+++ b/tests/caasp/shift_version.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Shift product version for upgrade test
+# Maintainer: Martin Kravec <mkravec@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+
+sub run {
+    my $self = shift;
+
+    my $nver;
+    my $cver = get_var('VERSION');
+
+    # Parse new version from module name
+    if ($self->{name} =~ 'inc|dec') {
+        $nver = $cver + 1 if $self->{name} =~ 'inc';
+        $nver = $cver - 1 if $self->{name} =~ 'dec';
+        $nver = sprintf("%.1f", $nver);
+    }
+    elsif ($self->{name} =~ '=') {
+        $nver = (split /=/, $self->{name})[1];
+    }
+    else {
+        die "Can't parse version from $self->{name}";
+    }
+
+    set_var('VERSION', $nver, reload_needles => 1);
+    record_info "version $cver>$nver", "Version shifted from $cver to $nver";
+}
+
+1;

--- a/tests/caasp/stack_admin.pm
+++ b/tests/caasp/stack_admin.pm
@@ -30,6 +30,12 @@ sub set_autoyast_password {
 sub run() {
     # Admin node needs long time to start web interface - bsc#1031682
     script_retry 'curl -kLI localhost | grep _velum_session', retry => 15, delay => 15;
+    # Enable salt debug
+    if (get_var 'DEBUG_SLEEP') {
+        script_run 'id=$(docker ps | grep salt-master | awk \'{print $1}\')';
+        script_run 'echo "log_level: trace" > /etc/caasp/salt-master-custom.conf';
+        script_run 'docker restart $id';
+    }
     unpause 'VELUM_STARTED';
 
     # Download update script

--- a/tests/caasp/stack_bootstrap.pm
+++ b/tests/caasp/stack_bootstrap.pm
@@ -53,6 +53,9 @@ sub select_roles {
 
 # Run bootstrap and download kubeconfig
 sub bootstrap {
+    # CaaSP 2.0 will keep bsc#1087447
+    $master_fqdn =~ s/^ | $//g if is_caasp('=2.0');
+
     # Click next button to 'Confirm bootstrap' page
     send_key_until_needlematch 'velum-next', 'pgdn', 2, 5;
     assert_and_click 'velum-next';

--- a/tests/caasp/stack_update.pm
+++ b/tests/caasp/stack_update.pm
@@ -90,9 +90,14 @@ sub update_check_changes {
 }
 
 # ./update.sh -s will set up repositories
-sub update_setup_repo {
+sub update_setup_repos {
     record_info 'Repo', 'Add the testing repository into each node of the cluster';
     switch_to 'xterm';
+
+    # Deregister before distribution update
+    if (update_scheduled 'dup') {
+        script_assert0 "ssh $admin_fqdn './update.sh -s dup' | tee /dev/$serialdev", 120;
+    }
 
     # Add UPDATE repository
     my $repo = update_scheduled;
@@ -156,7 +161,7 @@ sub update_perform_update {
 
 sub run {
     # update.sh -s $repo
-    update_setup_repo;
+    update_setup_repos;
 
     if (is_caasp 'qam') {
         install_new_packages;        # update.sh -n

--- a/tests/caasp/stack_update.pm
+++ b/tests/caasp/stack_update.pm
@@ -34,6 +34,7 @@ sub orchestrate_velum_reboot {
 
     # Update admin node (~160s for admin reboot)
     assert_and_click 'velum-update-admin';
+    wait_still_screen 3;
     assert_and_click 'velum-update-reboot';
 
     # Update all nodes - this part takes long time (~2 minutes per node)

--- a/tests/caasp/stack_update.pm
+++ b/tests/caasp/stack_update.pm
@@ -58,7 +58,13 @@ sub orchestrate_velum_reboot {
     assert_and_click "velum-update-all";
 
     # 5 minutes per node
-    assert_screen 'velum-bootstrap-done', $n * 300;
+    my @tags = qw(velum-retry velum-bootstrap-done);
+    assert_screen \@tags, $n * 300;
+    if (match_has_tag 'velum-retry') {
+        record_soft_failure 'bsc#000000 - Should have passed first time';
+        assert_and_click 'velum-retry';
+        assert_screen 'velum-bootstrap-done', $n * 300;
+    }
     die "Nodes should be updated already" if check_screen "velum-0-nodes-outdated", 0;
 }
 

--- a/tests/caasp/stack_update.pm
+++ b/tests/caasp/stack_update.pm
@@ -165,7 +165,7 @@ sub run {
     update_perform_update if is_needed();
 
     # update.sh -c
-    update_check_changes;
+    update_check_changes if update_scheduled('fake');
 }
 
 1;

--- a/tests/caasp/stack_worker.pm
+++ b/tests/caasp/stack_worker.pm
@@ -18,6 +18,11 @@ use autotest 'query_isotovideo';
 use caasp;
 
 sub run {
+    # Enable salt debug
+    if (get_var('DEBUG_SLEEP') && !get_var('AUTOYAST')) {
+        script_run 'echo "log_level: trace" >> /etc/salt/minion';
+        script_run 'systemctl restart salt-minion';
+    }
     # Notify others that installation finished
     if (get_var 'DELAYED') {
         barrier_wait 'DELAYED_NODES_ONLINE';


### PR DESCRIPTION
Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/935

Local runs:
 - http://dhcp126.suse.cz/tests/8493 - 3.0 -> 4.0

Update process:
 - set up cluster from CaaSP-GM
 - register during installation to get updates
 - deregister after installation, add extracted ISO as repository
 - run transactional-update dup and reboot from velum

Sample repo variables:
```
REPO_0=SUSE-CaaS-Platform-3.0-DVD-x86_64-Build0101-Media1
INCIDENT_REPO=http://openqa.suse.de/assets/repo/%REPO_0%
```