### PR TITLE
Use y2logstep post_fail_hook in AY installation

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -1,7 +1,7 @@
 # Base for YaST tests.  Switches to text console 2 and uploady y2logs
 
 package console_yasttest;
-use base "opensusebasetest";
+use base 'y2logsstep';
 use strict;
 
 use testapi;
@@ -12,27 +12,11 @@ sub post_fail_hook {
     select_console 'log-console';
     save_screenshot;
 
-    script_run "dmesg > /dev/$serialdev";
     upload_logs('/var/log/zypper.log');
-    my $fn = '/tmp/y2logs.tar.bz2';
-    # only upload if save_y2log succeeded
-    if (!script_run "save_y2logs $fn") {
-        upload_logs $fn;
-    }
-    else {
-        # there is a severe problem, e.g. could be bsc#985850 or bsc#990384 so
-        # save more, let's hope there is enough memory for intermediate
-        # storage
-        record_soft_failure 'bsc#990384';
-        # CAUTION just assuming that '/dev/vda2' is the root device here, does
-        # not work for LVM setup and others but we want to debug non-LVM first
-        # /dev/root is not recognized as btrfs device
-        $fn = '/dev/shm/vda2_brfs_debug_tree';
-        assert_script_run "btrfs-debug-tree /dev/vda2 &> $fn";
-        upload_logs $fn;
-    }
-    save_screenshot;
-    $self->investigate_yast2_failure();
+    $self->remount_tmp_if_ro;
+    $self->save_upload_y2logs;
+    $self->save_system_logs;
+    $self->save_strace_gdb_output('yast');
 }
 
 sub post_run_hook {

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -17,7 +17,7 @@
 # Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
 
 use strict;
-use base "opensusebasetest";
+use base 'y2logsstep';
 use testapi;
 use utils;
 use version_utils 'is_caasp';
@@ -52,10 +52,8 @@ sub save_and_upload_yastlogs {
     my $name = $stage . ($suffix // '');
     # save logs and continue
     select_console 'install-shell';
-
     # the network may be down with keep_install_network=false
     # use static ip in that case if not on s390x
-    assert_script_run "save_y2logs /tmp/y2logs-$name.tar.bz2";
     if (!check_var("BACKEND", "s390x")) {
         type_string " if ! ping -c 1 10.0.2.2 ; then
             ip addr add 10.0.2.200/24 dev eth0
@@ -72,10 +70,6 @@ sub save_and_upload_yastlogs {
     if (script_run '! test -e /tmp/profile/modified.xml') {
         upload_logs '/tmp/profile/modified.xml';
     }
-
-    upload_logs "/tmp/y2logs-$name.tar.bz2";
-    $self->save_and_upload_log('btrfs filesystem usage /mnt', 'btrfs-filesystem-usage-mnt.txt');
-    $self->save_and_upload_log('df',                          'df.txt');
     save_screenshot;
     clear_console;
     select_console 'installation';
@@ -294,6 +288,7 @@ sub test_flags {
 sub post_fail_hook {
     my ($self) = shift;
     $self->save_and_upload_yastlogs;
+    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -47,10 +47,8 @@ sub save_and_upload_stage_logs {
     upload_logs "/tmp/logs-stage1-error$i.tar.bz2";
 }
 
-sub save_and_upload_yastlogs {
-    my ($self, $suffix) = @_;
-    my $name = $stage . ($suffix // '');
-    # save logs and continue
+sub upload_autoyast_profile {
+    my ($self) = @_;
     select_console 'install-shell';
     # the network may be down with keep_install_network=false
     # use static ip in that case if not on s390x
@@ -80,7 +78,7 @@ sub handle_expected_errors {
     my $i = $args{iteration};
     record_info('Expected error', 'Iteration = ' . $i);
     send_key "alt-s";    #stop
-    $self->save_and_upload_yastlogs("_expected_error$i");
+    $self->save_upload_y2logs("-$stage-expected_error$i");
     $i++;
     wait_screen_change { send_key 'tab' };    #continue
     wait_screen_change { send_key 'ret' };
@@ -287,7 +285,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    $self->save_and_upload_yastlogs;
+    $self->upload_autoyast_profile;
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
We have a lot of useful features implemented in y2logstep to gather
information in case of failed installation, which we also should use in
AY installation.

See [poo#28851](https://progress.opensuse.org/issues/28851).

#### Verification runs
[YaST log investigation for AY](http://g226.suse.de/tests/2039#downloads)
[extra logs for yast ncurses tests](http://g226.suse.de/tests/2044#downloads)
