### PR TITLE
Keep only one AppArmor variable and call function

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -101,9 +101,7 @@ our @EXPORT = qw(
   load_security_tests_web
   load_security_tests_misc
   load_security_tests_crypt
-  load_security_tests_apparmor_status
-  load_security_tests_apparmor_genprof
-  load_security_tests_apparmor_misc
+  load_security_tests_apparmor
   load_systemd_patches_tests
   load_create_hdd_tests
   load_virtualization_tests
@@ -1743,20 +1741,14 @@ sub load_security_tests_crypt {
 }
 
 # Other security tests other than FIPS
-sub load_security_tests_apparmor_status {
+sub load_security_tests_apparmor {
     loadtest "security/apparmor/aa_status";
     loadtest "security/apparmor/aa_enforce";
     loadtest "security/apparmor/aa_complain";
-}
-
-sub load_security_tests_apparmor_genprof {
     loadtest "security/apparmor/aa_genprof";
     loadtest "security/apparmor/aa_autodep";
     loadtest "security/apparmor/aa_logprof";
     loadtest "security/apparmor/aa_easyprof";
-}
-
-sub load_security_tests_apparmor_misc {
     loadtest "security/apparmor/aa_notify";
 }
 

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -407,14 +407,8 @@ elsif (get_var('SECURITYTEST')) {
     elsif (check_var('SECURITYTEST', 'crypt')) {
         load_security_tests_crypt;
     }
-    elsif (check_var("SECURITYTEST", "apparmor_status")) {
-        load_security_tests_apparmor_status;
-    }
-    elsif (check_var("SECURITYTEST", "apparmor_genprof")) {
-        load_security_tests_apparmor_genprof;
-    }
-    elsif (check_var("SECURITYTEST", "apparmor_misc")) {
-        load_security_tests_apparmor_misc;
+    elsif (check_var("SECURITYTEST", "apparmor")) {
+        load_security_tests_apparmor;
     }
 }
 elsif (get_var('SYSTEMD_TESTSUITE')) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -855,14 +855,8 @@ elsif (get_var("FIPS_TS") || get_var("SECURITY")) {
         # Load client tests by APPTESTS variable
         load_applicationstests;
     }
-    elsif (check_var("SECURITY", "apparmor_status")) {
-        load_security_tests_apparmor_status;
-    }
-    elsif (check_var("SECURITY", "apparmor_genprof")) {
-        load_security_tests_apparmor_genprof;
-    }
-    elsif (check_var("SECURITY", "apparmor_misc")) {
-        load_security_tests_apparmor_misc;
+    elsif (check_var("SECURITY", "apparmor")) {
+        load_security_tests_apparmor;
     }
 }
 elsif (get_var('SMT')) {


### PR DESCRIPTION
- Merge variable apparmor_status, apparmor_genprof and apparmor_msic
  to "apparmor" in main.pm (poo#37006)
- Merge all apparmor call functions to "load_security_tests_apparmor"
  in lib/main_common.pm (poo#37006)

As we discussed in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5330#pullrequestreview-133865720 I would like to merge all AppArmor variables and call functions to a single one for easily management.

- Related ticket: https://progress.opensuse.org/issues/37006
- Verification run:
  - SLE: http://10.67.17.9/tests/841
  - Tumbleweed: http://10.67.17.9/tests/842