### PR TITLE
Fix running cron jobs without timeout (regression from #5097)

### DIFF
--- a/tests/console/force_scheduled_tasks.pm
+++ b/tests/console/force_scheduled_tasks.pm
@@ -39,7 +39,7 @@ sub run {
     settle_load;
     my $before = time;
     # run cron jobs or systemd timers which can affect system performance and mask systemd timers later
-    assert_script_run('find /etc/cron.{hourly,daily,weekly,monthly} -type f -executable -exec echo cron job: {} \; -exec {} \;');
+    assert_script_run('find /etc/cron.{hourly,daily,weekly,monthly} -type f -executable -exec echo cron job: {} \; -exec {} \;', 1000);
     my $systemd_tasks_cmd = 'echo "Triggering systemd timed service $i" && systemctl start $i';
     $systemd_tasks_cmd .= ' && systemctl mask $i' unless get_var('SOFTFAIL_BSC1063638');
     assert_script_run(


### PR DESCRIPTION
As in before, when executing cron jobs we should apply a bigger timeout
especially because we measure the actual time anywany.

Related progress issue: https://progress.opensuse.org/issues/38228