### PR TITLE
Fix desktop_runner / user_gui_login / gnucash

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -922,7 +922,7 @@ sub handle_login {
     $myuser //= $username;
     $user_selected //= 0;
 
-    assert_screen 'displaymanager';    # wait for DM, then try to login
+    assert_screen 'displaymanager', 90;    # wait for DM, then try to login
     wait_still_screen;
     if (get_var('ROOTONLY')) {
         if (check_screen 'displaymanager-username-notlisted', 10) {

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -844,4 +844,9 @@ sub configure_xdmcp_firewall {
     }
 }
 
+sub check_desktop_runner {
+    # we do not want to validate the result but leave this for other modules
+    x11_start_program('true', valid => 0, no_wait => 1);
+}
+
 1;

--- a/tests/x11/desktop_runner.pm
+++ b/tests/x11/desktop_runner.pm
@@ -16,8 +16,8 @@ use strict;
 use testapi;
 
 sub run {
-    # we do not want to validate the result but leave this for other modules
-    x11_start_program('true', valid => 0, no_wait => 1);
+    my ($self) = @_;
+    $self->check_desktop_runner;
 }
 
 1;

--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -31,8 +31,15 @@ sub run {
         wait_screen_change { send_key 'alt-c' };
     }
     send_key 'ctrl-q';    # Exit
-    assert_screen [qw(gnucash-save-changes generic-desktop)];
-    wait_screen_change { send_key 'alt-w' } if match_has_tag 'gnucash-save-changes';
+
+    # arbitrary limit
+    for (1 .. 7) {
+        assert_screen [qw(test-gnucash-1 gnucash gnucash-save-changes generic-desktop)];
+        last              if match_has_tag 'generic-desktop';
+        send_key 'alt-c'  if match_has_tag 'test-gnucash-1';
+        send_key 'alt-w'  if match_has_tag 'gnucash-save-changes';
+        send_key 'ctrl-q' if match_has_tag 'gnucash';
+    }
 }
 
 1;

--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -16,11 +16,7 @@ use strict;
 use testapi;
 
 sub run {
-    ensure_installed("gnucash");
-    ensure_installed("gnucash-docs");
-
-    # needed for viewing
-    ensure_installed("yelp");
+    ensure_installed('gnucash gnucash-docs yelp');
     x11_start_program('gnucash');
     send_key "ctrl-h";    # open user tutorial
     assert_screen 'test-gnucash-2';

--- a/tests/x11/reboot_plasma5.pm
+++ b/tests/x11/reboot_plasma5.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -11,7 +11,7 @@
 # Summary: Ensure system can reboot from plasma5 session
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
-use base "opensusebasetest";
+use base 'x11test';
 use strict;
 use testapi;
 use utils;
@@ -40,6 +40,10 @@ sub run {
         send_key "ret";
     }
     $self->wait_boot;
+    # Ensure the desktop runner is reactive again before going into other test
+    # modules
+    # https://progress.opensuse.org/issues/30805
+    $self->check_desktop_runner;
 }
 
 sub test_flags {


### PR DESCRIPTION
After reboot and immediately after login the system might be under bigger load
so that the desktop runner is not as responsive yet. By using the same
approach as in the desktop_runner test module in the reboot module after login
we ensure that any next module can rely on the desktop runner to be
responsive.

Also fix gnucash not closing main-window in the background.

Verification runs: http://lord.arch/tests/overview?version=Tumbleweed&build=20180703&distri=opensuse (No failures in desktop_runner, user_gui_login, gnucash)

Related progress issues: https://progress.opensuse.org/issues/30805, https://progress.opensuse.org/issues/38114