### PR TITLE
[Wicked] Fix ifcfg files for GRE tunnel

### DIFF
--- a/data/wicked/ifcfg-gre1_ref
+++ b/data/wicked/ifcfg-gre1_ref
@@ -1,6 +1,0 @@
-STARTMODE='auto'
-BOOTPROTO='static'
-NAME='GRE tunnel interface'
-
-TUNNEL='gre'
-TUNNEL_TTL='64'

--- a/data/wicked/ifcfg-gre1_sut
+++ b/data/wicked/ifcfg-gre1_sut
@@ -1,6 +1,8 @@
 STARTMODE='auto'
 BOOTPROTO='static'
 NAME='GRE tunnel interface'
-
 TUNNEL='gre'
 TUNNEL_TTL='64'
+TUNNEL_LOCAL_IPADDR='local_ip'
+TUNNEL_REMOTE_IPADDR='remote_ip'
+IPADDR='tunnel_ip'


### PR DESCRIPTION
The advanced_sut test fails in OSD because of this bug:
https://openqa.suse.de/tests/1816918#

This completes https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5361  which introduced this bug.

