### PR TITLE
Fix setup_static_network() in utils

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1113,7 +1113,7 @@ sub setup_static_network {
     my ($self, $ip) = @_;
     assert_script_run("echo 'default 10.0.2.2 - -' > /etc/sysconfig/network/routes");
     my $iface = script_output('ls /sys/class/net/ | grep -v lo | head -1');
-    assert_script_run "echo \"STARTMODE='auto'\nBOOTPROTO='static'\nIPADDR='$ip'\" > /etc/sysconfig/network/ifcfg-$iface";
+    assert_script_run qq(echo -e "\\nSTARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$ip'">/etc/sysconfig/network/ifcfg-$iface);
     assert_script_run "rcnetwork restart";
     assert_script_run "ip addr";
     assert_script_run "ping -c 1 10.0.2.2 || journalctl -b --no-pager > /dev/$serialdev";


### PR DESCRIPTION
With the previous command, OpenQA hangs a for some time and shows an error. 
Example of error: https://openqa.suse.de/tests/1816918#step/before_test/56

Verification run: http://fromm.arch.suse.de/tests/691#step/before_test/56
