### PR TITLE
s390x: Handle grub in wait_boot on zVM

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -317,8 +317,9 @@ sub wait_boot {
     if (check_var('ARCH', 's390x')) {
         my $login_ready = qr/Welcome to SUSE Linux Enterprise Server.*\(s390x\)/;
         if (check_var('BACKEND', 's390x')) {
-
-            console('x3270')->expect_3270(
+            my $console = console('x3270');
+            handle_grub_zvm($console);
+            $console->expect_3270(
                 output_delim => $login_ready,
                 timeout      => $ready_time + 100
             );

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -63,6 +63,7 @@ our @EXPORT = qw(
   handle_logout
   handle_relogin
   handle_emergency
+  handle_grub_zvm
   service_action
   assert_gui_app
   install_all_from_repo


### PR DESCRIPTION
qam fixed: http://opeth.suse.de/tests/2896