### PR TITLE
Stop etcd and clean up before running kubeadm

### DIFF
--- a/tests/console/kubeadm.pm
+++ b/tests/console/kubeadm.pm
@@ -19,6 +19,10 @@ use utils "systemctl";
 sub run {
     select_console("root-console");
 
+    record_info 'etcd', 'Stop etcd and clean up';
+    systemctl 'disable --now etcd';
+    script_run 'rm -r /var/lib/etcd/*';
+
     record_info 'Setup', 'Test: Package Installation';
     my $packages = 'kubernetes-client kubernetes-kubelet kubernetes-kubeadm docker-kubic cri-tools';
     trup_install($packages);


### PR DESCRIPTION
In our scenario *etcd* is installed externally (outside of kubeadm).
As a result *kubeadm* cannot touch `/var/lib/etcd` or even the
daemon itself. This PR makes sure that the *external* etcd is
not running and any related files are cleaned up.

- Related ticket: *none*
- Needles: *not needed*
- Verification run: http://skyrim.qam.suse.de/tests/206#step/kubeadm/54
