### PR TITLE
Delete obsolete workarounds for unexpected serial output

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -976,10 +976,9 @@ sub load_consoletests {
     # The test can't be run on JeOS as it's heavily dependant
     # on repos from installation medium.
     # We also don't have any repos on staging and update/upgrade tests.
-    # This test uses serial console too much to be reliable on Hyper-V (poo#30613)
     # Test doesn't make sense on live images too, don't have source repo there.
     # Skip this test for SLED (poo#36397)
-    if (!is_staging() && !is_updates_tests() && !is_upgrade() && !is_jeos() && !is_hyperv() && !is_livesystem() && !is_desktop()) {
+    if (!is_staging() && !is_updates_tests() && !is_upgrade() && !is_jeos() && !is_livesystem() && !is_desktop()) {
         loadtest "console/zypper_info";
     }
     # Add non-oss and debug repos for o3 and remove other by default
@@ -1116,8 +1115,7 @@ sub load_consoletests {
         loadtest "console/xfce_gnome_deps";
     }
     if (!is_staging() && is_sle && sle_version_at_least('12-SP2')) {
-        # This test uses serial console too much to be reliable on Hyper-V. See (poo#30613)
-        loadtest "console/zypper_lifecycle" unless is_hyperv;
+        loadtest "console/zypper_lifecycle";
         if (check_var_array('SCC_ADDONS', 'tcm') && !sle_version_at_least('15')) {
             loadtest "console/zypper_lifecycle_toolchain";
         }

--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -35,16 +35,11 @@ sub run {
     # 3. verify that "zypper lifecycle" shows correct package eol based on the
     # data from step 2
     my ($base_repos, $package, $prod);
-    # Workaround for poo#30613, surround product with >< and use these markers for parsing
-    my $output = script_output "echo '>>>'\$(basename `readlink /etc/products.d/baseproduct ` .prod)'<<<'";
-    if ($output =~ />>>(?<prod>.+)<<</) {
-        $prod = $+{prod};
-    }
-    die "Could not parse product (see poo#30613):\nOutput: '$output'" unless $prod;
+    my $prod = script_output 'basename `readlink /etc/products.d/baseproduct ` .prod';
 
     # select a package suitable for the following test
     # the package must be installed from base product repo
-    $output = script_output 'echo $(zypper -n -x se -i -t product -s ' . $prod . ')', 300;
+    my $output = script_output 'echo $(zypper -n -x se -i -t product -s ' . $prod . ')', 300;
     # Parse base repositories
     if (my @repos = $output =~ /repository="([^"]+)"/g) {
         $base_repos = join(" ", @repos);


### PR DESCRIPTION
After the getty processes on the serial device are disabled after
28070ebde we should not need workarounds anymore.

Related progress issue: https://progress.opensuse.org/issues/30613