### PR TITLE
Add openSCAP info, oval and xccdf scanning cases, with call function

### DIFF
--- a/data/openscap/oval.xml
+++ b/data/openscap/oval.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ns0:oval_definitions xmlns:ns0="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:ns1="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:ns2="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://oval.mitre.org/XMLSchema/oval-definitions-5 oval-definitions-schema.xsd                       http://oval.mitre.org/XMLSchema/oval-common-5 oval-common-schema.xsd                       http://oval.mitre.org/XMLSchema/oval-definitions-5#independent independent-definitions-schema.xsdi">
+
+  <ns0:generator>
+    <ns1:schema_version>5.11</ns1:schema_version>
+    <ns1:timestamp>2017-10-09T12:00:00</ns1:timestamp>
+  </ns0:generator>
+
+  <ns0:definitions>
+    <ns0:definition id="oval:no_direct_root_logins:def:1" class="compliance" version="1">
+      <ns0:metadata>
+        <ns0:title>Direct root Logins Not Allowed</ns0:title>
+        <ns0:description>Detailed description...</ns0:description>
+        <ns0:reference ref_id="no_direct_root_logins"/>
+      </ns0:metadata>
+      <ns0:criteria operator="AND">
+        <ns0:criterion comment="serial ports /etc/securetty" test_ref="oval:no_direct_root_logins:tst:1"/>
+        <ns0:criterion comment="serial ports /etc/securetty" test_ref="oval:etc_securetty_exists:tst:2"/>
+      </ns0:criteria>
+    </ns0:definition>
+    <ns0:definition class="compliance" id="oval:rule_misc_sysrq:def:1" version="1">
+      <ns0:metadata>
+        <ns0:title>sysctl kernel.sysrq must be 0</ns0:title>
+        <ns0:description>sysctl kernel.sysrq must be 0</ns0:description>
+      </ns0:metadata>
+      <ns0:criteria>
+        <ns0:criterion test_ref="oval:rule_misc_sysrq:tst:1" comment="sysctl kernel.sysrq must be 0"/>
+      </ns0:criteria>
+    </ns0:definition>
+  </ns0:definitions>
+
+  <ns0:tests>
+    <ns2:textfilecontent54_test id="oval:no_direct_root_logins:tst:1" check="all" check_existence="all_exist" comment="no entries in /etc/securetty" version="1">
+      <ns2:object object_ref="oval:no_direct_root_logins:obj:1"/>
+    </ns2:textfilecontent54_test>
+    <ns2:textfilecontent54_test id="oval:etc_securetty_exists:tst:2" check="all" check_existence="all_exist" comment="/etc/securetty file exists" version="1">
+      <ns2:object object_ref="oval:etc_securetty_exists:obj:2"/>
+    </ns2:textfilecontent54_test>
+
+    <ns2:textfilecontent54_test id="oval:rule_misc_sysrq:tst:1" version="1" check="at least one" comment="sysctl kernel.sysrq must be 0" check_existence="at_least_one_exists">
+      <ns2:object object_ref="oval:rule_misc_sysrq:obj:1"/>
+      <ns2:state state_ref="oval:rule_misc_sysrq:ste:1"/>
+    </ns2:textfilecontent54_test>
+  </ns0:tests>
+
+  <ns0:objects>
+    <ns2:textfilecontent54_object id="oval:no_direct_root_logins:obj:1" comment="no entries /etc/securetty" version="1">
+      <ns2:filepath>/etc/securetty</ns2:filepath>
+      <ns2:pattern operation="pattern match">^$</ns2:pattern>
+      <ns2:instance datatype="int" operation="greater than or equal">1</ns2:instance>
+    </ns2:textfilecontent54_object>
+    <ns2:textfilecontent54_object id="oval:etc_securetty_exists:obj:2" comment="/etc/securetty file exists" version="1">
+      <ns2:filepath>/etc/securetty</ns2:filepath>
+      <ns2:pattern operation="pattern match">^.*$</ns2:pattern>
+      <ns2:instance datatype="int">1</ns2:instance>
+    </ns2:textfilecontent54_object>
+    <ns2:textfilecontent54_object id="oval:rule_misc_sysrq:obj:1" version="1" comment="Non-comment lines in /proc/sys/kernel/sysrq">
+      <ns2:filepath>/proc/sys/kernel/sysrq</ns2:filepath>
+      <ns2:pattern operation="pattern match">^[[:space:]]*([^#[:space:]].*[^[:space:]]?)[[:space:]]*$</ns2:pattern>
+      <ns2:instance datatype="int" operation="greater than or equal">1</ns2:instance>
+    </ns2:textfilecontent54_object>
+  </ns0:objects>
+
+  <ns0:states>
+    <ns2:textfilecontent54_state id="oval:rule_misc_sysrq:ste:1" version="1" comment="The match of 0">
+      <ns2:subexpression operation="pattern match">0</ns2:subexpression>
+    </ns2:textfilecontent54_state>
+  </ns0:states>
+
+</ns0:oval_definitions>

--- a/data/openscap/xccdf.xml
+++ b/data/openscap/xccdf.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="test">
+  <status date="2017-10-09">draft</status>
+  <title>Hardening SUSE Linux Enterprise</title>
+  <platform idref="cpe:/o:suse"/>
+  <version>1</version>
+
+  <Profile id="standard">
+    <title>Standard System Security Profile</title>
+    <select idref="no_direct_root_logins" selected="true"/>
+    <select idref="rule_misc_sysrq" selected="true"/>
+  </Profile>
+
+  <Group id="root_logins">
+    <title>Restrict Root Logins</title>
+
+    <Rule id="no_direct_root_logins" selected="false" severity="medium">
+      <title>Direct root Logins Not Allowed</title>
+      <fix system="urn:xccdf:fix:script:sh">echo &gt; /etc/securetty</fix>
+      <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+        <check-content-ref name="oval:no_direct_root_logins:def:1" href="oval.xml"/>
+      </check>
+    </Rule>
+
+  </Group>
+
+  <Rule id="rule_misc_sysrq" selected="false">
+    <title>sysctl kernel.sysrq must be 0</title>
+    <fix system="urn:xccdf:fix:script:sh">echo 0 &gt; /proc/sys/kernel/sysrq</fix>
+    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+      <check-content-ref name="oval:rule_misc_sysrq:def:1" href="oval.xml"/>
+    </check>
+  </Rule>
+
+</Benchmark>

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1760,6 +1760,7 @@ sub load_security_tests_apparmor {
 sub load_security_tests_openscap {
     loadtest "security/openscap/oscap_info";
     loadtest "security/openscap/oscap_oval_scanning";
+    loadtest "security/openscap/oscap_xccdf_scanning";
 }
 
 sub load_systemd_patches_tests {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -102,6 +102,7 @@ our @EXPORT = qw(
   load_security_tests_misc
   load_security_tests_crypt
   load_security_tests_apparmor
+  load_security_tests_openscap
   load_systemd_patches_tests
   load_create_hdd_tests
   load_virtualization_tests
@@ -1754,6 +1755,10 @@ sub load_security_tests_apparmor {
     loadtest "security/apparmor/aa_logprof";
     loadtest "security/apparmor/aa_easyprof";
     loadtest "security/apparmor/aa_notify";
+}
+
+sub load_security_tests_openscap {
+    loadtest "security/openscap/oscap_info";
 }
 
 sub load_systemd_patches_tests {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1759,6 +1759,7 @@ sub load_security_tests_apparmor {
 
 sub load_security_tests_openscap {
     loadtest "security/openscap/oscap_info";
+    loadtest "security/openscap/oscap_oval_scanning";
 }
 
 sub load_systemd_patches_tests {

--- a/lib/openscaptest.pm
+++ b/lib/openscaptest.pm
@@ -1,0 +1,52 @@
+# Copyright (C) 2017-2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Base module for openSCAP test cases
+# Maintainer: Wes <whdu@suse.com>
+
+package openscaptest;
+
+use strict;
+use testapi;
+use utils;
+use version_utils qw(is_sle is_leap);
+use base 'consoletest';
+
+sub oscap_get_test_file {
+    my ($self, $source) = @_;
+
+    assert_script_run "test -f $source || wget " . data_url("openscap/$source");
+}
+
+sub validate_result {
+    my ($self, $result_file, $match) = @_;
+
+    assert_script_run "xmllint $result_file";
+    validate_script_output "cat $result_file", sub { $match };
+    upload_logs($result_file);
+}
+
+sub pre_run_hook {
+    my ($self) = @_;
+
+    select_console 'root-console';
+
+    zypper_call('in openscap-utils');
+
+    $self->oscap_get_test_file("oval.xml");
+    $self->oscap_get_test_file("xccdf.xml");
+}
+
+1;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -410,6 +410,9 @@ elsif (get_var('SECURITYTEST')) {
     elsif (check_var("SECURITYTEST", "apparmor")) {
         load_security_tests_apparmor;
     }
+    elsif (check_var("SECURITYTEST", "openscap")) {
+        load_security_tests_openscap;
+    }
 }
 elsif (get_var('SYSTEMD_TESTSUITE')) {
     load_systemd_patches_tests;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -863,6 +863,9 @@ elsif (get_var("FIPS_TS") || get_var("SECURITY")) {
     elsif (check_var("SECURITY", "apparmor")) {
         load_security_tests_apparmor;
     }
+    elsif (check_var("SECURITY", "openscap")) {
+        load_security_tests_openscap;
+    }
 }
 elsif (get_var('SMT')) {
     prepare_target();

--- a/tests/security/openscap/oscap_info.pm
+++ b/tests/security/openscap/oscap_info.pm
@@ -1,0 +1,52 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Determine type and print information about a openscap source file
+# Maintainer: Wes <whdu@suse.com>
+# Tags: poo#36901, tc#1621169
+
+use base "openscaptest";
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+
+    validate_script_output "oscap info oval.xml", sub {
+        m/
+            Document\ type:\ OVAL\ Definitions.*
+            OVAL\ version:\ [0-9]+.*
+            Generated:\ [0-9]+.*
+            Imported:\ [0-9]+/sxx
+    };
+
+    validate_script_output "oscap info xccdf.xml", sub {
+        m/
+            Document\ type:\ XCCDF\ Checklist.*
+            Checklist\ version:\ [0-9]+.*
+            Imported:\ [0-9]+.*
+            Status:\ draft.*
+            Generated:\ [0-9]+.*
+            Resolved:\ false.*
+            Profiles:.*
+            standard.*
+            Referenced\ check\ files:.*
+            oval\.xml.*
+            system:/sxx
+    };
+}
+
+1;

--- a/tests/security/openscap/oscap_oval_scanning.pm
+++ b/tests/security/openscap/oscap_oval_scanning.pm
@@ -1,0 +1,76 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Perform evaluation of oval (Open Vulnerability and Assessment
+#          Language) file
+# Maintainer: Wes <whdu@suse.com>
+# Tags: poo#36904, tc#1621170
+
+use base "openscaptest";
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+
+    my $oval_result        = "scan-oval-results.xml";
+    my $oval_result_single = "scan-oval-results-single.xml";
+
+    my $scanning_match = 'm/
+        Definition\ oval:rule_misc_sysrq:def:[0-9]:\ false.*
+        Definition\ oval:no_direct_root_logins:def:[0-9]:\ false.*
+        Evaluation\ done/sxx';
+
+    my $result_match = 'm/
+        encoding="UTF-8".*
+        <oval_results\ xmlns:xsi.*XMLSchema-instance.*
+        xmlns:oval=.*oval-common-5.*xmlns=.*oval-results-5.*
+        xsi:schemaLocation=.*oval-results-5.*
+        oval-results-schema.xsd.*oval-common-schema.xsd">.*
+        <generator>.*product_name>cpe:\/a:open-scap:oscap.*
+        product_version>.*
+        <oval_definitions.*
+        <definition.*id="oval:rule_misc_sysrq:def:1".*compliance.*
+        <criterion.*test_ref="oval:rule_misc_sysrq:tst:1".*
+        <definition.*id="oval:no_direct_root_logins:def:1".*compliance.*
+        <criterion.*test_ref="oval:no_direct_root_logins:tst:1".*
+                    test_ref="oval:etc_securetty_exists:tst:2".*
+        <results.*<system.*<definitions.*
+        definition_id="oval:rule_misc_sysrq:def:1".*
+        result="false".*
+        definition_id="oval:no_direct_root_logins:def:1".*
+        result="false"/sxx';
+
+    my $scanning_match_single = 'm/
+        Definition\ oval:rule_misc_sysrq:def:[0-9]:\ false.*
+        Evaluation\ done/sxx';
+
+    my $result_match_single = 'm/
+        encoding="UTF-8".*
+        <results.*<system.*<definitions.*
+        definition_id="oval:rule_misc_sysrq:def:1".*
+        result="false".*
+        definition_id="oval:no_direct_root_logins:def:1".*
+        result="not\ evaluated"/sxx';
+
+    validate_script_output "oscap oval eval --results $oval_result oval.xml", sub { $scanning_match };
+    $self->validate_result($oval_result, $result_match);
+
+    validate_script_output "oscap oval eval --id oval:rule_misc_sysrq:def:1 --results $oval_result_single oval.xml", sub { $scanning_match_single };
+    $self->validate_result($oval_result_single, $result_match_single);
+}
+
+1;

--- a/tests/security/openscap/oscap_xccdf_scanning.pm
+++ b/tests/security/openscap/oscap_xccdf_scanning.pm
@@ -1,0 +1,82 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Perform evaluation of XCCDF (The eXtensible Configuration
+#          Checklist Description Format) file
+# Maintainer: Wes <whdu@suse.com>
+# Tags: poo#36907, tc#1621171
+
+use base "openscaptest";
+use strict;
+use testapi;
+use utils;
+use version_utils qw(is_sle is_leap);
+
+sub run {
+    my ($self) = @_;
+
+    my $xccdf_result        = "scan-xccdf-results.xml";
+    my $xccdf_result_single = "scan-xccdf-results-single.xml";
+
+    my $scanning_match = 'm/
+        Rule.*no_direct_root_logins.*fail.*
+        Rule.*rule_misc_sysrq.*fail/sxx';
+
+    my $result_match = 'm/
+        encoding="UTF-8".*
+        <Benchmark.*<Profile\s+id="standard".*<select.*
+        idref="no_direct_root_logins"\ selected="true".*
+        idref="rule_misc_sysrq"\s+selected="true".*
+        <Rule\s+id="no_direct_root_logins"\s+selected="false".*
+        <Rule\s+id="rule_misc_sysrq"\s+selected="false".*
+        <TestResult.*<platform.*cpe:\/o:suse.*
+        <rule-result.*idref="no_direct_root_logins".*<result.*fail.*
+        <rule-result.*idref="rule_misc_sysrq".*<result.*fail.*
+        <score\s+system="urn:xccdf:scoring:default".*
+        maximum="[0-9]+/sxx';
+
+    my $scanning_match_single = 'm/
+        Title.*Direct\ root\ Logins\ Not\ Allowed.*
+        Rule.*no_direct_root_logins.*fail/sxx';
+
+    my $result_match_single = 'm/
+        encoding="UTF-8".*
+        <Benchmark.*<Profile\s+id="standard".*<select.*
+        idref="no_direct_root_logins"\ selected="true".*
+        idref="rule_misc_sysrq"\s+selected="true".*
+        <Rule\s+id="no_direct_root_logins"\s+selected="false".*
+        <Rule\s+id="rule_misc_sysrq"\s+selected="false".*
+        <TestResult.*<platform.*cpe:\/o:suse.*
+        <rule-result.*idref="no_direct_root_logins".*<result.*fail.*
+        <rule-result.*idref="rule_misc_sysrq".*<result.*notselected.*
+        <score\s+system="urn:xccdf:scoring:default".*
+        maximum="[0-9]+/sxx';
+
+    # Always return failed here, so we use "||true" as workaround
+    validate_script_output "oscap xccdf eval --profile standard --results $xccdf_result xccdf.xml || true", sub { $scanning_match };
+
+    $self->validate_result($xccdf_result, $result_match);
+
+    # Single rule testing only available on the higher version for
+    # openscap-utils
+    if (!(is_sle('<15') or is_leap('<15.0'))) {    # openscap >= 1.2.16
+        validate_script_output "oscap xccdf eval --profile standard --rule no_direct_root_logins --results $xccdf_result_single xccdf.xml || true",
+          sub { $scanning_match_single };
+
+        $self->validate_result($xccdf_result_single, $result_match_single);
+    }
+}
+
+1;


### PR DESCRIPTION
Add "load_security_tests_openscap" call function ([poo#37006](https://progress.opensuse.org/issues/37006)). Add base module lib/openscaptest.pm
Add tests/security/openscap/oscap_info.pm ([poo#36901](https://progress.opensuse.org/issues/36901)), tests/security/openscap/oscap_oval_scanning.pm ([poo#36904](https://progress.opensuse.org/issues/36904)), tests/security/openscap/oscap_xccdf_scanning.pm ([poo#36907](https://progress.opensuse.org/issues/36907))

- Related ticket:
  - https://progress.opensuse.org/issues/36901
  - https://progress.opensuse.org/issues/36904
  - https://progress.opensuse.org/issues/36907
  - https://progress.opensuse.org/issues/37006
- Verification run:
  - SLE: http://10.67.17.9/tests/917
  - Tumbleweed: http://10.67.17.9/tests/918
