### PR TITLE
Use zypper_call to avoid HTTP response: 502 error

### DIFF
--- a/tests/console/zypper_ref.pm
+++ b/tests/console/zypper_ref.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -14,17 +14,11 @@
 use base "consoletest";
 use strict;
 use testapi;
+use utils 'zypper_call';
 
 sub run {
     select_console 'root-console';
-
-    script_run("zypper ref; echo zypper-ref-\$? > /dev/$serialdev", 0);
-    # don't trust graphic driver repo
-    assert_screen([qw(new-repo-need-key zypper_ref)], timeout => 300);
-    if (match_has_tag('new-repo-need-key')) {
-        type_string "r\n";
-    }
-    wait_serial("zypper-ref-0") || die "zypper ref failed";
+    zypper_call '--gpg-auto-import-keys ref';
 }
 
 sub test_flags {


### PR DESCRIPTION
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/887
- Verification run: http://10.100.12.155/tests/5214
