### PR TITLE
Test file operations in dolphin

### DIFF
--- a/tests/x11/dolphin.pm
+++ b/tests/x11/dolphin.pm
@@ -1,23 +1,74 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Startup of dolphin
-# Maintainer: Oliver Kurz <okurz@suse.de>
+# Summary: Start dolphin and do some file operations
+# Maintainer: Fabian Vogt <fvogt@suse.de>
 
 use base "x11test";
 use strict;
 use testapi;
 
 sub run {
-    x11_start_program('dolphin');
-    send_key "alt-f4";
+    x11_start_program 'dolphin';
+
+    # Go to ~/Documents
+    assert_and_click 'dolphin_icon_documents';
+    assert_screen 'dolphin_documents_empty';
+
+    # Create a new folder
+    send_key 'f10';
+    type_string 'stuff';
+    assert_screen 'dolphin_new_folder';
+    send_key 'ret';
+    # Enter the new folder
+    send_key 'ret';
+
+    # Context menu: "Create new" -> "Text file"
+    assert_and_click 'dolphin_stuff_empty', 'right';
+    my $create_new = assert_screen 'dolphin_create_new';
+
+    my $lastarea = $create_new->{area}->[-1];
+    my $x        = int($lastarea->{x} + $lastarea->{w} / 2);
+    my $y        = int($lastarea->{y} + $lastarea->{h} / 2);
+    mouse_set($x, $y);
+    mouse_click();
+
+    assert_and_click 'dolphin_create_new_text_file';
+    mouse_hide();
+    type_string 'empty';
+    assert_screen 'dolphin_new_text_file';
+    send_key 'ret';
+    assert_screen 'dolphin_stuff_full';
+
+    # Go back up to ~/Documents
+    assert_and_click 'dolphin_navbar_documents';
+    # Add "stuff" to Places
+    assert_and_click 'dolphin_icon_stuff', 'right';
+    assert_and_click 'dolphin_add_places';
+
+    # Verify that it's visible in the file picker
+    x11_start_program('kdialog --getopenfilename', valid => 0);
+    assert_screen 'kdialog_places_stuff';
+    send_key 'alt-f4';
+
+    # Remove the directory forcibly
+    assert_screen 'dolphin_icon_stuff';
+    send_key 'shift-delete';
+    assert_screen 'dolphin_force_remove';
+    send_key 'ret';
+
+    # Remove the places entry again
+    assert_and_click 'dolphin_places_stuff', 'right';
+    assert_and_click 'dolphin_places_remove';
+
+    send_key 'alt-f4';
 }
 
 1;


### PR DESCRIPTION
This adds file operations to the dolphin test.

- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/396
- Verification run: http://10.160.67.86/tests/111
