### PR TITLE
Skip load version switch for online migration

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1481,7 +1481,8 @@ sub load_extra_tests {
 sub load_rollback_tests {
     return if check_var('ARCH', 's390x');
     loadtest "boot/grub_test_snapshot";
-    loadtest "migration/version_switch_origin_system";
+    # Skip load version switch for online migration
+    loadtest "migration/version_switch_origin_system" if (!get_var("ONLINE_MIGRATION"));
     if (get_var('UPGRADE') || get_var('ZDUP')) {
         loadtest "boot/snapper_rollback";
     }


### PR DESCRIPTION
For online migration, it is only support service pack upgrade.
It is not need to load version switch function.

- See Poo#38360