### PR TITLE
Migrate the console_setup and hostname from load_extra_test to the load_create_hdd

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1349,8 +1349,6 @@ sub load_extra_tests_desktop {
     }
     elsif (check_var('DISTRI', 'opensuse')) {
         if (gnomestep_is_applicable()) {
-            # Setup env for x11 regression tests
-            loadtest "x11/x11_setup";
             # poo#18850 java test support for firefox, run firefox before chrome
             # as otherwise have wizard on first run to import settings from it
             loadtest "x11/firefox/firefox_java";
@@ -1465,10 +1463,7 @@ sub load_extra_tests {
     # pre-conditions for extra tests ie. the tests are running based on preinstalled image
     return if get_var("INSTALLONLY") || get_var("DUALBOOT") || get_var("RESCUECD");
 
-    # setup $serialdev permission and so on
-    loadtest "console/consoletest_setup";
     loadtest 'console/integration_services' if is_hyperv;
-    loadtest "console/hostname";
     if (any_desktop_is_applicable()) {
         load_extra_tests_desktop;
     }
@@ -1778,6 +1773,8 @@ sub load_create_hdd_tests {
     loadtest 'console/integration_services' if is_hyperv;
     loadtest 'console/hostname'              unless is_bridged_networking;
     loadtest 'console/force_scheduled_tasks' unless is_jeos;
+    # setup $serialdev permission and so on
+    loadtest "console/consoletest_setup";
     # Remove repos pointing to download.opensuse.org and add snaphot repo from o3
     replace_opensuse_repos_tests if is_repo_replacement_required;
     loadtest 'console/scc_deregistration' if get_var('SCC_DEREGISTER');


### PR DESCRIPTION
In order to test more using the created hdd.


Test run:
   Gnome: http://10.67.19.67/tests/overview?distri=opensuse&version=Tumbleweed&build=00020&groupid=1
   KDE: http://10.67.19.67/tests/overview?distri=opensuse&version=Tumbleweed&build=00021&groupid=1