### PR TITLE
xfstests: Add *.out.bad and *.full log into tarbal

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -254,6 +254,12 @@ sub run {
         if ($type eq $HB_DONE) {
             # Test finished without crashing SUT
             log_add($STATUS_LOG, $test, $status, $time);
+            if ($status =~ /FAILED/) {
+                my $cmd = "cat /opt/xfstests/results/$category/$num.out.bad | tee $LOG_DIR/$category/$num.out.bad";
+                script_run($cmd);
+                $cmd = "cat /opt/xfstests/results/$category/$num.full | tee $LOG_DIR/$category/$num.full";
+                script_run($cmd);
+            }
             next;
         }
 


### PR DESCRIPTION
Now we don't have enough log output in xfstests to debug some minor fail. This PR to add *.out.bad and *.full log into log tarbal when test failed.

- Verification run: http://10.67.133.102/tests/544#
  After this change inside http://10.67.133.102/tests/544/file/log-btrfs.tar.xz you can see the full log.