### PR TITLE
Fix "root prompt not ready" problems

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -317,7 +317,7 @@ sub become_root {
 
     $self->script_sudo('bash', 0);
     type_string "whoami > /dev/$testapi::serialdev\n";
-    wait_serial("root", 10) || die "Root prompt not there";
+    wait_serial('root') || die "Root prompt not there";
     type_string "cd /tmp\n";
     $self->set_standard_prompt('root');
     type_string "clear\n";


### PR DESCRIPTION
A timeout of just 10 seconds can be too short and should not be a hard
requirement we want to rely on, especially because we already type the
"whoami" command immediately after we ask to evaluate the login password
which can increase the necessary evaluation time even more.

Related progress issue: https://progress.opensuse.org/issues/38198