### PR TITLE
Add workaround for dolphin's create new submenu not opening on 42.3

### DIFF
--- a/tests/x11/dolphin.pm
+++ b/tests/x11/dolphin.pm
@@ -37,8 +37,11 @@ sub run {
     my $lastarea = $create_new->{area}->[-1];
     my $x        = int($lastarea->{x} + $lastarea->{w} / 2);
     my $y        = int($lastarea->{y} + $lastarea->{h} / 2);
-    mouse_set($x, $y);
+
+    # Workaround: In 42.3 clicking without moving doesn't open the submenu
+    mouse_set($x - 5, $y);
     mouse_click();
+    mouse_set($x, $y);
 
     assert_and_click 'dolphin_create_new_text_file';
     mouse_hide();


### PR DESCRIPTION
Although the mouse clicks and the cursor is visibly on top of the menu entry, the menu doesn't open. With moving around a bit, it does.

- Verification run: http://10.160.67.86/tests/121
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/398