### PR TITLE
Fix "mysql_srv" test failure by reordering it

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1130,9 +1130,9 @@ sub load_consoletests {
     }
     loadtest "console/mtab";
     if (!get_var("NOINSTALL") && !get_var("LIVETEST") && (check_var("DESKTOP", "textmode"))) {
+        loadtest "console/mysql_srv";
         # disable these tests of server packages for SLED (poo#36436)
         load_console_server_tests() unless is_desktop;
-        loadtest "console/mysql_srv";
     }
     if (check_var("DESKTOP", "xfce")) {
         loadtest "console/xfce_gnome_deps";


### PR DESCRIPTION
mysql_srv should run before mysql_odbc (which is in `load_console_server_tests`)

Fix regression (https://openqa.opensuse.org/tests/707426) caused by my recent PR (https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5318).

- Related ticket: https://progress.opensuse.org/issues/38468
- Needles: no changes

@DimStar77  I'll post my verification run when it is done.
