### PR TITLE
xfstests: Change all /tmp folder to /opt

### DIFF
--- a/tests/xfstests/generate_report.pm
+++ b/tests/xfstests/generate_report.pm
@@ -20,10 +20,10 @@ use File::Basename;
 use testapi;
 use ctcs2_to_junit;
 
-my $STATUS_LOG = '/tmp/status.log';
-my $LOG_DIR    = '/tmp/log';
-my $KDUMP_DIR  = '/tmp/kdump';
-my $JUNIT_FILE = '/tmp/output.xml';
+my $STATUS_LOG = '/opt/status.log';
+my $LOG_DIR    = '/opt/log';
+my $KDUMP_DIR  = '/opt/kdump';
+my $JUNIT_FILE = '/opt/output.xml';
 
 sub log_end {
     my $file = shift;

--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -19,7 +19,7 @@ use serial_terminal 'select_virtio_console';
 use utils;
 use testapi;
 
-my $STATUS_LOG = '/tmp/status.log';
+my $STATUS_LOG = '/opt/status.log';
 
 # Create log file used to generate junit xml report
 sub log_create {

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -24,18 +24,18 @@ my $HB_INTVL   = get_var('XFSTESTS_HEARTBEAT_INTERVAL') || 30;
 my $HB_TIMEOUT = get_var('XFSTESTS_HEARTBEAT_TIMEOUT')  || 40;
 my $HB_PATN    = '<heartbeat>';
 my $HB_DONE    = '<done>';
-my $HB_DONE_FILE = '/tmp/test.done';
-my $HB_EXIT_FILE = '/tmp/test.exit';
-my $HB_SCRIPT    = '/tmp/heartbeat.sh';
+my $HB_DONE_FILE = '/opt/test.done';
+my $HB_EXIT_FILE = '/opt/test.exit';
+my $HB_SCRIPT    = '/opt/heartbeat.sh';
 
 # xfstests variables
 my $TEST_RANGES  = get_required_var('XFSTESTS_RANGES');
 my $TEST_WRAPPER = '/usr/share/qa/qa_test_xfstests/wrapper.sh';
 my %BLACKLIST    = map { $_ => 1 } split(/,/, get_var('XFSTESTS_BLACKLIST'));
-my $STATUS_LOG   = '/tmp/status.log';
+my $STATUS_LOG   = '/opt/status.log';
 my $INST_DIR     = '/opt/xfstests';
-my $LOG_DIR      = '/tmp/log';
-my $KDUMP_DIR    = '/tmp/kdump';
+my $LOG_DIR      = '/opt/log';
+my $KDUMP_DIR    = '/opt/kdump';
 my $MAX_TIME     = 2400;
 
 # Create heartbeat script, directories(Call it only once)


### PR DESCRIPTION
Log files temporary storage in /tmp, when some tests make system kdump and reboot, previous test log will lost. So all test log should store in somewhere stable, in case we already use /opt in this testsuite, then we pick /opt also use to store logs. After change to this folder even kdump happened and reboot, all test log still exist.

- Verification run: http://10.67.133.102/tests/550
  Inside log tarball it contain all logs run before kdump happened. http://10.67.133.102/tests/550/file/log-generic.tar.xz 
