### PR TITLE
Update evolution server preparation for SLE15

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -223,12 +223,14 @@ sub check_new_mail_evolution {
     my $config      = $self->getconfig_emailaccount;
     my $mail_passwd = $config->{$i}->{passwd};
     assert_screen "evolution_mail-online", 240;
+    assert_and_click "evolution-send-receive";
     if (check_screen "evolution_mail-auth", 30) {
         if (sle_version_at_least('12-SP2')) {
             send_key "alt-p";
         }
         type_password $mail_passwd;
         send_key "ret";
+        assert_screen "evolution_mail-max-window";
     }
     send_key "alt-w";
     send_key "ret";


### PR DESCRIPTION
Fix poo#37674: Adapt dovecot configuration to SLE15, add assert/click
to send/receive button to increase test stability.

Tests which were fixed are:
evolution_prepare_servers
evolution_mail_imap
evolution_mail_pop
evolution_timezone_setup
evolution_meeting_imap
evolution_meeting_pop

- Related ticket: https://progress.opensuse.org/issues/37674
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/890
- Verification run: 
SLE12 http://10.100.12.105/tests/2505
SLE15 http://10.100.12.105/tests/2491
