### PR TITLE
sle: Fail hard if a necessary addon repo can not be reached (e.g. staging)

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -292,11 +292,11 @@ if (sle_version_at_least('15') && !check_var('SCC_REGISTER', 'installation')) {
             my $module_repo_name = get_var($repo_variable_name, $default_repo_name);
             my $url = "$utils::OPENQA_FTP_URL/$module_repo_name";
             # Verify if url exists before adding
-            if (head($url)) {
-                set_var('ADDONURL_' . uc $short_name, "$utils::OPENQA_FTP_URL/$module_repo_name");
-                $addonurl .= "$short_name,";
-            }
+            die "URL $url could not be accessed, missing repo?" unless head($url);
+            set_var('ADDONURL_' . uc $short_name, "$utils::OPENQA_FTP_URL/$module_repo_name");
+            $addonurl .= "$short_name,";
         }
+        die '$addonurl (test variable \'ADDONURL\') could not be set' unless $addonurl;
         #remove last comma from ADDONURL setting value
         $addonurl =~ s/,$//;
         set_var("ADDONURL", $addonurl);


### PR DESCRIPTION
During "evaluation" of the main.pm we do a very dirty thing: We probe
repositories over network and try to handle errors gracefully and
therefore hiding errors such has happened for SLE15-SP1 staging tests
which fail to boot into a gnome session because we end up in a text
login because gnome was never installed as it was never selected during
installation as the repo variable was never set as the URL could not be
verified.

Related progress issue: https://progress.opensuse.org/issues/38453