### PR TITLE
Exclude update tests from hardcoded HPC workaround

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -382,8 +382,9 @@ if (get_var('SUPPORT_SERVER_ROLES', '') =~ /aytest/ && !get_var('AYTESTS_REPO'))
     }
 }
 
-# Workaround to be able to use create_hdd_hpc_textmode simultaneously  in SLE15 and SLE12 SP*
-if (check_var('SLE_PRODUCT', 'hpc') && check_var('INSTALLONLY', '1') && is_sle('<15')) {
+# Workaround to be able to use create_hdd_hpc_textmode simultaneously in SLE15 and SLE12 SP*
+# and exlude maintenance tests
+if (check_var('SLE_PRODUCT', 'hpc') && check_var('INSTALLONLY', '1') && is_sle('<15') && !is_updates_tests) {
     set_var('SCC_ADDONS',   'hpcm,wsm');
     set_var('SCC_REGISTER', 'installation');
 }


### PR DESCRIPTION
 Fix poo#38498: Hardcoded variable settings for HPC doesn't support LTSS.
Maintenance tests have to be excluded from the workaround.

- Related ticket: https://progress.opensuse.org/issues/38498
- Needles: none
- Verification run: 
12-SP2 http://10.100.12.105/tests/3070
12-SP3 http://10.100.12.105/tests/3047
12-SP4 http://10.100.12.105/tests/3046