### PR TITLE
[WIP] Fix selected_console call

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -311,7 +311,7 @@ sub get_lun {
 sub pre_run_hook {
     my ($self) = @_;
 
-    $prev_console = $testapi::selected_console;
+    $prev_console = $autotest::selected_console;
 }
 
 sub post_run_hook {

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -11,7 +11,7 @@ our $prev_console;
 sub pre_run_hook {
     my ($self) = @_;
 
-    $prev_console = $testapi::selected_console;
+    $prev_console = $autotest::selected_console;
 }
 
 sub post_run_hook {


### PR DESCRIPTION
Due to last Qemu changes, `selected_console` has been moved from `testapi.pm` to `autotest.pm`, so call procedure needs to be changed.

- Verification run: XXXX
