### PR TITLE
Get current console based on the testapi version

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -17,6 +17,7 @@ use version_utils 'is_sle';
 use utils;
 use testapi;
 use lockapi;
+use isotovideo;
 
 our @EXPORT = qw(
   $crm_mon_cmd
@@ -310,8 +311,11 @@ sub get_lun {
 
 sub pre_run_hook {
     my ($self) = @_;
-
-    $prev_console = $autotest::selected_console;
+    if (isotovideo::get_version() == 12) {
+        $prev_console = $autotest::selected_console;
+    } else {
+        $prev_console = $testapi::selected_console;
+    }
 }
 
 sub post_run_hook {

--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -314,6 +314,9 @@ sub pre_run_hook {
     if (isotovideo::get_version() == 12) {
         $prev_console = $autotest::selected_console;
     } else {
+        # perl -c will give a "only used once" message
+        # here and this makes the travis ci tests fail.
+        1 if defined $testapi::selected_console;
         $prev_console = $testapi::selected_console;
     }
 }

--- a/lib/isotovideo.pm
+++ b/lib/isotovideo.pm
@@ -1,4 +1,4 @@
-package isotovideo_interface;
+package isotovideo;
 use strict;
 use utf8;
 use warnings;
@@ -7,6 +7,12 @@ sub VERSION {
     my ($package, $version) = @_;
 
     die "isotovideo interface version $version required--this is version $main::INTERFACE" if $version != $main::INTERFACE;
+}
+
+sub get_version {
+    my $version = $main::INTERFACE;
+    ($version) =~ /\d+/;
+    return $version;
 }
 
 1;

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -5,13 +5,17 @@ use base "opensusebasetest";
 use strict;
 use testapi;
 use utils;
+use isotovideo;
 
 our $prev_console;
 
 sub pre_run_hook {
     my ($self) = @_;
-
-    $prev_console = $testapi::selected_console;
+    if (isotovideo::get_version() == 12) {
+        $prev_console = $autotest::selected_console;
+    } else {
+        $prev_console = $testapi::selected_console;
+    }
 }
 
 sub post_run_hook {


### PR DESCRIPTION
Use the isotovideo/testapi interface version, to pich which console to select.

This should go away as soon as we deploy on OSD :) and be replaced for a proper testapi call, as a rule of thumb: we should not rely on global variables between os-autoinst and test distributions, but on api calls instead. 