### PR TITLE
Xen PV: Try harder to match welcome banner

### DIFF
--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -21,7 +21,7 @@ sub run {
     # the timeout here must cover it. UEFI DVD adds some 60 seconds on top.
     my $timeout = get_var('UEFI') ? 140 : 80;
     if (check_var('VIRSH_VMM_TYPE', 'linux')) {
-        wait_serial("Welcome to SUSE Linux", $timeout) || die "System did not boot in $timeout seconds.";
+        wait_serial("Welcome to .*SUSE Linux", $timeout) || die "System did not boot in $timeout seconds.";
     }
     else {
         $self->wait_boot(bootloader_time => $timeout);


### PR DESCRIPTION
https://openqa.suse.de/tests/1838957#step/boot_to_desktop/2

`boot_to_desktop` on Xen PV is unable to match welcome to SUSE banner
because of something which looks like a terminal candy:

```
Welcome to [0;32mSUSE Linux Enterprise Server 12 SP4[0m!
```

Validation run: http://nilgiri.suse.cz/tests/339#step/boot_to_desktop/2