### PR TITLE
Install missing lvm2 to fix snapper_thin_lvm

### DIFF
--- a/tests/console/snapper_thin_lvm.pm
+++ b/tests/console/snapper_thin_lvm.pm
@@ -14,6 +14,7 @@
 use base 'btrfs_test';
 use testapi;
 use strict;
+use utils 'zypper_call';
 
 sub run {
     my ($self) = @_;
@@ -24,6 +25,7 @@ sub run {
     my $mnt_thin          = '/mnt/thin';
     my $mnt_thin_snapshot = $mnt_thin . '-snapshot';
 
+    zypper_call 'in lvm2';
     foreach my $snapper (@snapper_runs) {
         $self->snapper_nodbus_setup if $snapper =~ /dbus/;
 


### PR DESCRIPTION
The snapper_thin_lvm module used commands of lvm2 package, but the package itself was missed, because lvm2 no longer pulled by os-prober.

The commit adds steps for installing the lvm2 package.

Related ticket: [poo#37659](https://progress.opensuse.org/issues/37659)
Verification run: http://10.160.65.138/tests/237

**For reviewers:** Just in case, I'm attaching a screenshot of a reference run, as my local machine might be off at review time.
![fd3strb](https://user-images.githubusercontent.com/37581072/42888020-92577228-8aa7-11e8-9a90-a4c0765897b9.png)

