### PR TITLE
Improve grub terminal settings and upload grub config files for both xen and kvm test

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -943,8 +943,11 @@ elsif (get_var("VIRT_AUTOTEST")) {
         loadtest "virt_autotest/reboot_and_wait_up_upgrade";
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
             loadtest "virt_autotest/setup_xen_serial_console";
-            loadtest "virt_autotest/reboot_and_wait_up_normal";
         }
+        else {
+            loadtest "virt_autotest/setup_kvm_serial_console";
+        }
+        loadtest "virt_autotest/reboot_and_wait_up_normal";
         loadtest "virt_autotest/host_upgrade_step3_run";
     }
     elsif (get_var("VIRT_PRJ3_GUEST_MIGRATION_SOURCE")) {

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -35,7 +35,8 @@ sub run {
     if (check_var('BACKEND', 'ipmi')) {
         use_ssh_serial_console;
         # set serial console for xen
-        set_serial_console_on_xen('/mnt') if (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen'));
+        set_serial_console_on_vh('/mnt', '', 'xen') if (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen'));
+        set_serial_console_on_vh('/mnt', '', 'kvm') if (check_var('HOST_HYPERVISOR', 'kvm') || check_var('SYSTEM_ROLE', 'kvm'));
     }
     else {
         # avoid known issue in FIPS mode: bsc#985969

--- a/tests/virt_autotest/host_upgrade_generate_run_file.pm
+++ b/tests/virt_autotest/host_upgrade_generate_run_file.pm
@@ -19,6 +19,10 @@ use testapi;
 sub get_script_run {
     my $pre_test_cmd;
 
+    handle_sp_in_settings_with_sp0("UPGRADE_PRODUCT");
+    handle_sp_in_settings_with_sp0("GUEST_LIST");
+    handle_sp_in_settings_with_sp0("BASE_PRODUCT");
+
     my $mode         = get_var("TEST_MODE",       "");
     my $hypervisor   = get_var("HOST_HYPERVISOR", "");
     my $base         = get_var("BASE_PRODUCT",    "");    #EXAMPLE, sles-11-sp3

--- a/tests/virt_autotest/setup_kvm_serial_console.pm
+++ b/tests/virt_autotest/setup_kvm_serial_console.pm
@@ -1,14 +1,14 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 #
-# Summary: Setup xen serial console so that ipmitool can work normally from 3rd generation openqa ipmi backend.
-# Maintainer: Alice <xlai@suse.com>
+# Summary: Setup kvm serial console so that ipmitool can work normally from 3rd generation openqa ipmi backend.
+# Maintainer: Wayne <wchen@suse.com>
 
 use strict;
 use warnings;
@@ -17,7 +17,7 @@ use base "virt_autotest_base";
 use ipmi_backend_utils;
 
 sub run {
-    set_serial_console_on_vh('', '', 'xen') if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen"));
+    set_serial_console_on_vh('', '', 'kvm') if (check_var("HOST_HYPERVISOR", "kvm") || check_var("SYSTEM_ROLE", "kvm"));
 }
 
 sub test_flags {

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -43,7 +43,8 @@ sub update_package {
 sub run {
     my $self = shift;
     $self->update_package();
-    set_serial_console_on_xen if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen"));
+    set_serial_console_on_vh('', '', 'xen') if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen"));
+    set_serial_console_on_vh('', '', 'kvm') if (check_var("HOST_HYPERVISOR", "kvm") || check_var("SYSTEM_ROLE", "kvm"));
     update_guest_configurations_with_daily_build();
 }
 


### PR DESCRIPTION
This PR solves problems such as missing grub2 menu at boot time, infinite time out value of boot menu and wrong serial console being used in xen host by default. Additionally, kvm host test also reset grub terminal to "console serial" instead of "serial". So under any circumstances, grub2 menu will show up on boot. And, at the same time, grub2 configuration file of kvm host will also be uploaded to openQA server during run time, which saves potential debug effort when unexpected things happen to grub2 and makes test cases look more uniform between xen and kvm scenarios.
Please refer to the following link for successful run with this change: https://10.67.17.5/tests/285 and https://10.67.17.5/tests/318

- Related ticket: QA-APACII PRJ2 Virtualization Host Upgrade
  https://bugzilla.suse.com/tr_show_case.cgi?case_id=1679254
  https://bugzilla.suse.com/tr_show_case.cgi?case_id=1679256
  https://bugzilla.suse.com/tr_show_case.cgi?case_id=1679155
- Needles: Using https://gitlab.suse.de/openqa/os-autoinst-needles-sles
- Verification run: https://10.67.17.5/tests/285 and https://10.67.17.5/tests/318

@alice-suse @XGWang0 @Julie-CAO @xguo