### PR TITLE
Add openSCAP online&offline remediating test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1789,6 +1789,7 @@ sub load_security_tests_openscap {
     loadtest "security/openscap/oscap_xccdf_scanning";
     loadtest "security/openscap/oscap_source_datastream";
     loadtest "security/openscap/oscap_result_datastream";
+    loadtest "security/openscap/oscap_remediating_online";
 }
 
 sub load_systemd_patches_tests {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1790,6 +1790,7 @@ sub load_security_tests_openscap {
     loadtest "security/openscap/oscap_source_datastream";
     loadtest "security/openscap/oscap_result_datastream";
     loadtest "security/openscap/oscap_remediating_online";
+    loadtest "security/openscap/oscap_remediating_offline";
 }
 
 sub load_systemd_patches_tests {

--- a/tests/security/openscap/oscap_remediating_offline.pm
+++ b/tests/security/openscap/oscap_remediating_offline.pm
@@ -1,0 +1,63 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Post-scan remediation test - offline
+# Maintainer: Wes <whdu@suse.com>
+# Tags: poo#36919, tc#1621175
+
+use base "consoletest";
+use strict;
+use testapi;
+use utils;
+use openscaptest;
+
+sub run {
+    my $remediate_result = "scan-xccdf-remediate-results.xml";
+
+    my $remediate_match = 'm/
+              Rule.*no_direct_root_logins.*Result.*fixed.*
+              Rule.*rule_misc_sysrq.*Result.*fixed/sxx';
+
+    my $remediate_result_match = 'm/
+              <\?xml\s+version="[0-9]+\.[0-9]+"\s+encoding="UTF-8".*
+              <Benchmark.*<Profile\s+id="standard".*
+              select.*no_direct_root_logins.*selected="true".*
+              select.*rule_misc_sysrq.*selected="true".*
+              Rule.*no_direct_root_logins"\s+selected="false".*
+              Rule.*rule_misc_sysrq"\s+selected="false".*
+              TestResult.*
+              rule-result.*idref="no_direct_root_logins".*result.*fail.*
+              rule-result.*idref="rule_misc_sysrq".*result.*fail.*
+              TestResult.*
+              rule-result.*idref="no_direct_root_logins".*result.*fixed.*
+              rule-result.*idref="rule_misc_sysrq".*result.*fixed.*
+              score\s+system="urn:xccdf:scoring:default".*
+              maximum="[0-9]+/sxx';
+
+    ensure_generated_file($xccdf_result);
+    prepare_remediate_validation;
+
+    validate_script_output "oscap xccdf remediate --results $remediate_result $xccdf_result", sub { $remediate_match };
+    validate_result($remediate_result, $remediate_result_match);
+
+    # Verify the remediate action result
+    validate_script_output "cat /etc/securetty",         sub { m/^$/ };
+    validate_script_output "cat /proc/sys/kernel/sysrq", sub { m/^0$/ };
+
+    # Restore
+    finish_remediate_validation;
+}
+
+1;

--- a/tests/security/openscap/oscap_remediating_online.pm
+++ b/tests/security/openscap/oscap_remediating_online.pm
@@ -1,0 +1,63 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Post-scan remediation test - online
+# Maintainer: Wes <whdu@suse.com>
+# Tags: poo#36916, tc#1621174
+
+use base "consoletest";
+use strict;
+use testapi;
+use utils;
+use openscaptest;
+
+sub run {
+    my $remediate_result = "scan-xccdf-remediate-results.xml";
+
+    my $remediate_match = 'm/
+                      Rule.*no_direct_root_logins.*Result.*fail.*
+                      Rule.*rule_misc_sysrq.*Result.*fail.*
+                      Starting\s+Remediation.*
+                      Rule.*no_direct_root_logins.*Result.*fixed.*
+                      Rule.*rule_misc_sysrq.*Result.*fixed/sxx';
+
+    my $remediate_result_match = 'm/
+              version="[0-9]+\.[0-9]+"\s+encoding="UTF-8".*
+              <Benchmark.*<Profile\s+id="standard".*
+              select.*no_direct_root_logins.*selected="true".*
+              select.*rule_misc_sysrq.*selected="true".*
+              Rule.*no_direct_root_logins"\s+selected="false".*
+              Rule.*rule_misc_sysrq"\s+selected="false".*
+              TestResult.*platform.*cpe:\/o:suse.*
+              rule-result.*idref="no_direct_root_logins".*result.*fixed.*
+              rule-result.*idref="rule_misc_sysrq".*result.*fixed.*
+              score\s+system="urn:xccdf:scoring:default".*
+              maximum="[0-9]+/sxx ';
+
+    prepare_remediate_validation;
+
+    # Remediate
+    validate_script_output "oscap xccdf eval --remediate --profile standard --results $remediate_result xccdf.xml", sub { $remediate_match };
+    validate_result($remediate_result, $remediate_result_match);
+
+    # Verify the remediate action result
+    validate_script_output "cat /etc/securetty",         sub { m/^$/ };
+    validate_script_output "cat /proc/sys/kernel/sysrq", sub { m/^0$/ };
+
+    # Restore
+    finish_remediate_validation;
+}
+
+1;

--- a/tests/security/openscap/oscap_setup.pm
+++ b/tests/security/openscap/oscap_setup.pm
@@ -22,6 +22,7 @@ use strict;
 use testapi;
 use utils;
 use openscaptest;
+use version_utils 'is_opensuse';
 
 sub run {
 
@@ -29,6 +30,11 @@ sub run {
 
     oscap_get_test_file("oval.xml");
     oscap_get_test_file("xccdf.xml");
+
+    # xccdf.xml is for SLE, the CPE is different on openSUSE
+    if (is_opensuse) {
+        assert_script_run "sed -i 's#cpe:/o:suse#cpe:/o:opensuse#g' xccdf.xml";
+    }
 }
 
 sub test_flags {

--- a/tests/security/openscap/oscap_xccdf_scanning.pm
+++ b/tests/security/openscap/oscap_xccdf_scanning.pm
@@ -38,7 +38,7 @@ sub run {
         idref="rule_misc_sysrq"\s+selected="true".*
         <Rule\s+id="no_direct_root_logins"\s+selected="false".*
         <Rule\s+id="rule_misc_sysrq"\s+selected="false".*
-        <TestResult.*<platform.*cpe:\/o:suse.*
+        <TestResult.*<platform.*cpe:\/o:(open)?suse.*
         <rule-result.*idref="no_direct_root_logins".*<result.*fail.*
         <rule-result.*idref="rule_misc_sysrq".*<result.*fail.*
         <score\s+system="urn:xccdf:scoring:default".*
@@ -55,7 +55,7 @@ sub run {
         idref="rule_misc_sysrq"\s+selected="true".*
         <Rule\s+id="no_direct_root_logins"\s+selected="false".*
         <Rule\s+id="rule_misc_sysrq"\s+selected="false".*
-        <TestResult.*<platform.*cpe:\/o:suse.*
+        <TestResult.*<platform.*cpe:\/o:(open)?suse.*
         <rule-result.*idref="no_direct_root_logins".*<result.*fail.*
         <rule-result.*idref="rule_misc_sysrq".*<result.*notselected.*
         <score\s+system="urn:xccdf:scoring:default".*


### PR DESCRIPTION
Add openSCAP online remediating ([poo#36916](https://progress.opensuse.org/issues/36916)), offline remediating ([poo#36919](https://progress.opensuse.org/issues/36919))

Change oscap_setup.pm, to modify xccdf.pm, change cpe to o:opensuse when it is testing in Leap or Tumbleweed.

- Related ticket: https://progress.opensuse.org/issues/36916, https://progress.opensuse.org/issues/36919
- Verification run:
  - SLE: http://10.67.17.9/tests/1009
  - Tumbleweed: http://10.67.17.9/tests/1011