### PR TITLE
Enable salt test on openSUSE staging project

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1086,7 +1086,7 @@ sub load_consoletests {
     }
     # salt in SLE is only available for SLE12 ASMM or SLES15 and variants of
     # SLES but not SLED
-    if (!is_staging && (is_opensuse || (check_var_array('SCC_ADDONS', 'asmm') || (sle_version_at_least('15') && !is_desktop)))) {
+    if (is_opensuse || !is_staging && (check_var_array('SCC_ADDONS', 'asmm') || sle_version_at_least('15') && !is_desktop)) {
         loadtest "console/salt";
     }
     if (check_var('ARCH', 'x86_64')


### PR DESCRIPTION
Enable salt test on openSUSE TW and Leap staging project.
