### PR TITLE
Revert "Mask serial-getty service to reduce pollution on the serial"

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -36,14 +36,6 @@ sub run {
     script_run "ip addr show";
     save_screenshot;
 
-    # Stop serial-getty on serial console to avoid serial output pollution with login prompt
-    # Mask and stop only if SERIALDEV is defined or is qemu backend
-    my $serial_console = get_var('SERIALDEV') || (check_var('BACKEND', 'qemu') ? 'ttyS0' : undef);
-    if ($serial_console) {
-        systemctl "mask serial-getty\@$serial_console";
-        systemctl "stop serial-getty\@$serial_console";
-    }
-
     # Stop packagekit
     systemctl 'mask packagekit.service';
     systemctl 'stop packagekit.service';


### PR DESCRIPTION
See https://progress.opensuse.org/issues/38525
Reverts os-autoinst/os-autoinst-distri-opensuse#5315