### PR TITLE
Exclude never worked user_defined_snapshots on xen

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1370,7 +1370,8 @@ sub load_extra_tests_desktop {
         # start extra x11 tests from here
         loadtest 'x11/vnc_two_passwords';
         # TODO: check why this is not called on opensuse
-        loadtest 'x11/user_defined_snapshot';
+        # poo#35574 - Excluded for Xen PV as it was never passed due to the fail while interacting with grub.
+        loadtest 'x11/user_defined_snapshot' unless (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux'));
     }
     elsif (check_var('DISTRI', 'opensuse')) {
         if (gnomestep_is_applicable()) {


### PR DESCRIPTION
The commit excludes the module from extra_tests_on_gnome job for xen pv, as it was never passed due to the fail of interacting with grub.

**For reviewers:** After discussion during planning game, it was decided to exclude the module and postpone the further investigations related to the issue (Please see 'Suggestions' section of the [related ticket](https://progress.opensuse.org/issues/35574#Suggestions)).

Related ticket: [poo#35574](https://progress.opensuse.org/issues/35574)