### PR TITLE
Process multiple beta warnings in AY installation and fix regressions for expected errors upload

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -235,8 +235,9 @@ sub save_upload_y2logs {
     $suffix //= '';
 
     assert_script_run 'sed -i \'s/^tar \(.*$\)/tar --warning=no-file-changed -\1 || true/\' /usr/sbin/save_y2logs';
-    assert_script_run "save_y2logs /tmp/y2logs$suffix.tar.bz2", 180;
-    upload_logs "/tmp/y2logs.tar.bz2";
+    my $filename = "/tmp/y2logs$suffix.tar.bz2";
+    assert_script_run "save_y2logs $filename", 180;
+    upload_logs $filename;
     save_screenshot();
     $self->investigate_yast2_failure();
 }

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -78,7 +78,9 @@ sub handle_expected_errors {
     my $i = $args{iteration};
     record_info('Expected error', 'Iteration = ' . $i);
     send_key "alt-s";    #stop
+    select_console 'install-shell';
     $self->save_upload_y2logs("-$stage-expected_error$i");
+    select_console 'installation';
     $i++;
     wait_screen_change { send_key 'tab' };    #continue
     wait_screen_change { send_key 'ret' };

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -122,7 +122,8 @@ sub run {
         send_key 'ret';    # boot from hard disk
         return;
     }
-    my @needles = qw(bios-boot nonexisting-package reboot-after-installation linuxrc-install-fail scc-invalid-url warning-pop-up autoyast-boot);
+    my @needles           = qw(bios-boot nonexisting-package reboot-after-installation linuxrc-install-fail scc-invalid-url warning-pop-up autoyast-boot);
+    my $expected_licenses = get_var('AUTOYAST_LICENSE');
     push @needles, 'autoyast-confirm'        if get_var('AUTOYAST_CONFIRM');
     push @needles, 'autoyast-postpartscript' if get_var('USRSCR_DIALOG');
     # bios-boot needle does not match if worker stalls during boot - poo#28648
@@ -138,7 +139,7 @@ sub run {
     if (get_var('BETA')) {
         push(@needles, 'inst-betawarning');
     }
-    elsif (get_var('AUTOYAST_LICENSE')) {
+    elsif ($expected_licenses) {
         push(@needles, 'autoyast-license');
     }
 
@@ -203,11 +204,13 @@ sub run {
         }
         elsif (match_has_tag('autoyast-license')) {
             accept_license;
+            # In SLE 12 we have BETA warning shown for each addon
+            push(@needles, 'inst-betawarning') if --$expected_licenses;
         }
         elsif (match_has_tag('inst-betawarning')) {
             wait_screen_change { send_key $cmd{ok} };
             @needles = grep { $_ ne 'inst-betawarning' } @needles;
-            push(@needles, 'autoyast-license') if (get_var('AUTOYAST_LICENSE'));
+            push(@needles, 'autoyast-license') if $expected_licenses;
             next;
         }
         elsif (match_has_tag('untrusted-ca-cert')) {


### PR DESCRIPTION
We have disabled timeout on all messages in AY profiles, then it got
clear that BETA warning is shown every time license for
product/extension added.

See [poo#38444](https://progress.opensuse.org/issues/38444).

#### Verification runs
[EULA (muliple Beta warnings)](http://g226.suse.de/tests/2060#).
[expected errors](http://g226.suse.de/tests/2062#)

