### PR TITLE
Revert "Migrate the console_setup and hostname from load_extra_test to the load_create_hdd"

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1375,6 +1375,8 @@ sub load_extra_tests_desktop {
     }
     elsif (check_var('DISTRI', 'opensuse')) {
         if (gnomestep_is_applicable()) {
+            # Setup env for x11 regression tests
+            loadtest "x11/x11_setup";
             # poo#18850 java test support for firefox, run firefox before chrome
             # as otherwise have wizard on first run to import settings from it
             loadtest "x11/firefox/firefox_java";
@@ -1489,7 +1491,10 @@ sub load_extra_tests {
     # pre-conditions for extra tests ie. the tests are running based on preinstalled image
     return if get_var("INSTALLONLY") || get_var("DUALBOOT") || get_var("RESCUECD");
 
+    # setup $serialdev permission and so on
+    loadtest "console/consoletest_setup";
     loadtest 'console/integration_services' if is_hyperv;
+    loadtest "console/hostname";
     if (any_desktop_is_applicable()) {
         load_extra_tests_desktop;
     }
@@ -1806,8 +1811,6 @@ sub load_create_hdd_tests {
     loadtest 'console/integration_services' if is_hyperv;
     loadtest 'console/hostname'              unless is_bridged_networking;
     loadtest 'console/force_scheduled_tasks' unless is_jeos;
-    # setup $serialdev permission and so on
-    loadtest "console/consoletest_setup";
     # Remove repos pointing to download.opensuse.org and add snaphot repo from o3
     replace_opensuse_repos_tests if is_repo_replacement_required;
     loadtest 'console/scc_deregistration' if get_var('SCC_DEREGISTER');


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#5387

We have too many current failures, e.g. https://progress.opensuse.org/issues/38480 as well as more, e.g. https://progress.opensuse.org/issues/38525 and https://progress.opensuse.org/issues/30613#note-60