### PR TITLE
Add record_soft_failure for bsc#1101761 to fix poo#38630

### DIFF
--- a/tests/installation/isosize.pm
+++ b/tests/installation/isosize.pm
@@ -22,7 +22,12 @@ sub run {
     my $result = 'ok';
     my $max    = get_var("ISO_MAXSIZE", 0);
     if (!$size || !$max || $size > $max) {
-        $result = 'fail';
+        if (check_var('VERSION', '12-SP4') && check_var('FLAVOR', 'Desktop-DVD')) {
+            record_soft_failure("bsc#1101761 - SLED ISO size is over limit");
+        }
+        else {
+            $result = 'fail';
+        }
     }
     if (!defined $size) {
         diag("iso path invalid: $iso");


### PR DESCRIPTION
A lot of SLED test suites failed due to ISO size is over limit. (https://bugzilla.suse.com/show_bug.cgi?id=1101761 was filed to track this)
Add record_soft_failure so that it won't block further desktop testing in openQA. 

- Related ticket: https://progress.opensuse.org/issues/38630
- Verification run: 
SLED12SP4: http://10.67.19.170/tests/508
SLES12SP4: http://10.67.19.170/tests/509
