### PR TITLE
Fix shortkey for DASD formatting in SLE 12 SP4

### DIFF
--- a/tests/installation/disk_activation.pm
+++ b/tests/installation/disk_activation.pm
@@ -108,7 +108,7 @@ sub run {
             if (check_screen 'dasd-device-formatted', 30) {
                 assert_screen 'action-list';
                 # shortcut changed for sle 15
-                send_key is_sle('15+') ? 'o' : 'f';
+                send_key 'o';
                 assert_screen 'confirm-dasd-format';    # confirmation popup
                 send_key 'alt-y';
                 format_dasd;


### PR DESCRIPTION
Now we have same shortcut for DASD formatting in SLE15 and SLE12.

See [poo#30676](https://progress.opensuse.org/issues/30676).

- [Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/893)
- [Verification run](http://g226.suse.de/tests/2065#)
