### PR TITLE
Fix docker_image* scheduling for Tumbleweed and SLE12.4

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -502,7 +502,7 @@ sub load_slepos_tests {
 sub load_docker_tests {
     loadtest "console/docker";
     loadtest "console/docker_runc";
-    if (is_sle('12-SP3+')) {
+    if (is_sle('=12-SP3') || is_sle('=15')) {
         loadtest "console/docker_image";
         loadtest "console/sle2docker";
     }

--- a/tests/console/docker_image.pm
+++ b/tests/console/docker_image.pm
@@ -20,15 +20,6 @@ use version_utils "is_sle";
 sub run {
     select_console "root-console";
 
-    my $version     = get_required_var("VERSION");
-    my $SCC_REGCODE = get_required_var("SCC_REGCODE");
-
-    if (script_run("SUSEConnect --status-text") != 0) {
-        assert_script_run("SUSEConnect --cleanup");
-        assert_script_run("SUSEConnect -r $SCC_REGCODE");
-        add_suseconnect_product("sle-module-containers", substr($version, 0, 2));
-    }
-
     my $image_name;
     if (is_sle("=12-SP3")) {
         $image_name = "registry.suse.de/suse/sle-12-sp3/update/products/casp30/container/sles12:sp3";
@@ -38,6 +29,15 @@ sub run {
     }
     else {
         die("This test only works at SLE12SP3 and SLE15.");
+    }
+
+    my $version     = get_required_var("VERSION");
+    my $SCC_REGCODE = get_required_var("SCC_REGCODE");
+
+    if (script_run("SUSEConnect --status-text") != 0) {
+        assert_script_run("SUSEConnect --cleanup");
+        assert_script_run("SUSEConnect -r $SCC_REGCODE");
+        add_suseconnect_product("sle-module-containers", substr($version, 0, 2));
     }
 
     # Allow our internal 'insecure' registry


### PR DESCRIPTION
Hello, 

this is the fix of #5350:
 * Disabling `docker_image` for `SLE12.4` - we don't have an image for this version at `registry.suse.de`
 * Scheduling `docker_image_rpm` for Tumbleweed as it was before
 * Fixing `docker_image` so it will fail with an error if running on unsupported versions

- Related ticket: https://progress.opensuse.org/issues/36775#change-137096
- Needles: No need
- Verification run: [12.3](http://pdostal-server.suse.cz/tests/968), [12.4](http://pdostal-server.suse.cz/tests/966), [15](http://pdostal-server.suse.cz/tests/967), [Tumbleweed](http://pdostal-server.suse.cz/tests/965)
