### PR TITLE
Replace all deprecated occurences of "sle_version_at_least"

### DIFF
--- a/lib/installsummarystep.pm
+++ b/lib/installsummarystep.pm
@@ -2,7 +2,6 @@ package installsummarystep;
 use base "y2logsstep";
 use testapi;
 use strict;
-use version_utils 'sle_version_at_least';
 
 
 sub accept3rdparty {

--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -24,7 +24,7 @@ use testapi;
 use utils;
 use registration;
 use qam qw/remove_test_repositories/;
-use version_utils qw(sle_version_at_least is_sle);
+use version_utils 'is_sle';
 
 our @EXPORT = qw(
   setup_sle
@@ -76,7 +76,7 @@ sub register_system_in_textmode {
 
     # register system and addons in textmode for all archs
     set_var("VIDEOMODE", 'text');
-    if (sle_version_at_least('12-SP2', version_variable => 'HDDVERSION')) {
+    if (is_sle('12-SP2+', version_variable => 'HDDVERSION')) {
         set_var('HDD_SP2ORLATER', 1);
     }
     yast_scc_registration;

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2016 SUSE LLC
+# Copyright (C) 2015-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,7 +22,7 @@ use strict;
 
 use testapi;
 use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl);
-use version_utils qw(is_sle is_caasp sle_version_at_least is_sle12_hdd_in_upgrade);
+use version_utils qw(is_sle is_caasp is_sle12_hdd_in_upgrade);
 
 our @EXPORT = qw(
   add_suseconnect_product
@@ -579,7 +579,7 @@ sub fill_in_reg_server {
 sub scc_deregistration {
     my (%args) = @_;
     $args{version_variable} //= 'VERSION';
-    if (sle_version_at_least('12-SP1', version_variable => $args{version_variable})) {
+    if (is_sle('12-SP1+', version_variable => $args{version_variable})) {
         assert_script_run('SUSEConnect -d --cleanup');
         my $output = script_output 'SUSEConnect -s';
         die "System is still registered" unless $output =~ /Not Registered/;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -23,7 +23,7 @@ use strict;
 use testapi qw(is_serial_terminal :DEFAULT);
 use lockapi 'mutex_wait';
 use mm_network;
-use version_utils qw(is_caasp is_leap is_tumbleweed is_sle is_sle12_hdd_in_upgrade sle_version_at_least is_storage_ng is_jeos);
+use version_utils qw(is_caasp is_leap is_tumbleweed is_sle is_sle12_hdd_in_upgrade is_storage_ng is_jeos);
 use Mojo::UserAgent;
 
 our @EXPORT = qw(
@@ -396,7 +396,7 @@ sub fully_patch_system {
 sub minimal_patch_system {
     my (%args) = @_;
     $args{version_variable} //= 'VERSION';
-    if (sle_version_at_least('12-SP1', version_variable => $args{version_variable})) {
+    if (is_sle('12-SP1+', version_variable => $args{version_variable})) {
         zypper_call('patch --with-interactive -l --updatestack-only', exitcode => [0, 102, 103], timeout => 1500, log => 'minimal_patch.log');
     }
     else {
@@ -426,7 +426,7 @@ sub workaround_type_encrypted_passphrase {
     # If the encrypted disk is "just activated" it does not mean that the
     # installer would propose an encrypted installation again
     return if get_var('ENCRYPT_ACTIVATE_EXISTING') && !get_var('ENCRYPT_FORCE_RECOMPUTE');
-    record_soft_failure 'workaround https://fate.suse.com/320901' if sle_version_at_least('12-SP4');
+    record_soft_failure 'workaround https://fate.suse.com/320901' unless is_sle('<12-SP4');
     unlock_if_encrypted;
 }
 
@@ -497,7 +497,7 @@ sub install_to_other_at_least {
     set_var("REAL_INSTALLED_VERSION", $real_installed_version);
     bmwqemu::save_vars();
 
-    return sle_version_at_least($version, version_variable => "REAL_INSTALLED_VERSION");
+    return is_sle($version + '+', version_variable => "REAL_INSTALLED_VERSION");
 }
 
 sub is_bridged_networking {
@@ -874,7 +874,7 @@ sub addon_license {
         do {
             # license on SLE15+ is shown only once during registration bsc#1057223
             # don't expect license if addon was already registered via SCC and license already viewed
-            if (sle_version_at_least('15') && check_var('SCC_REGISTER', 'installation') && get_var('SCC_ADDONS') =~ /$addon/ && !check_screen \@tags) {
+            if (is_sle('15+') && check_var(' SCC_REGISTER ', ' installation ') && get_var(' SCC_ADDONS ') =~ /$addon/ && !check_screen \@tags) {
                 return 1;
             }
             assert_screen \@tags;
@@ -1095,7 +1095,7 @@ Since SLE 15 gdm is running on tty2, so we change behaviour for it and
 openSUSE distris, except for Xen PV (bsc#1086243).
 =cut
 sub get_root_console_tty {
-    return (sle_version_at_least('15') && !is_caasp && !check_var('VIRSH_VMM_TYPE', 'linux')) ? 6 : 2;
+    return (is_sle('15+') && !is_caasp && !check_var('VIRSH_VMM_TYPE', 'linux')) ? 6 : 2;
 }
 
 =head2 get_x11_console_tty
@@ -1154,7 +1154,7 @@ sub ensure_serialdev_permissions {
     # reboot an alternative https://superuser.com/a/609141/327890 would need
     # handling of optional sudo password prompt within the exec
     # Need backwards support for SLES11-SP4 here, the command "gpasswd" and "stat" are only available with SLES-12 at least.
-    if (is_sle && check_var('VERSION', '11-SP4')) {
+    if (is_sle('11-SP4')) {
         assert_script_run "chown $username /dev/$serialdev";
     }
     else {
@@ -1286,7 +1286,7 @@ sub reconnect_s390 {
     }
 
     # SLE >= 15 does not offer auto-started VNC server in SUT, only login prompt as in textmode
-    if (!check_var('DESKTOP', 'textmode') && !sle_version_at_least('15')) {
+    if (!check_var('DESKTOP', 'textmode') && !is_sle('15+')) {
         select_console('x11', await_console => 0);
     }
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -17,7 +17,7 @@ use registration;
 use utils;
 use mmapi 'get_parents';
 use version_utils
-  qw(is_hyperv is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem sle_version_at_least is_desktop_installed is_jeos is_sle is_staging is_upgrade);
+  qw(is_hyperv is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem is_desktop_installed is_jeos is_sle is_staging is_upgrade);
 use File::Find;
 use File::Basename;
 use LWP::Simple 'head';
@@ -59,16 +59,16 @@ sub cleanup_needles {
         unregister_needle_tags("ENV-VERSION-11-SP4");
     }
 
-    my $tounregister = sle_version_at_least('12') ? '0' : '1';
+    my $tounregister = is_sle('12+') ? '0' : '1';
     unregister_needle_tags("ENV-12ORLATER-$tounregister");
 
-    $tounregister = sle_version_at_least('12-SP2') ? '0' : '1';
+    $tounregister = is_sle('12-SP2+') ? '0' : '1';
     unregister_needle_tags("ENV-SP2ORLATER-$tounregister");
 
-    $tounregister = sle_version_at_least('12-SP3') ? '0' : '1';
+    $tounregister = is_sle('12-SP3+') ? '0' : '1';
     unregister_needle_tags("ENV-SP3ORLATER-$tounregister");
 
-    $tounregister = sle_version_at_least('15') ? '0' : '1';
+    $tounregister = is_sle('15+') ? '0' : '1';
     unregister_needle_tags("ENV-15ORLATER-$tounregister");
 
     if (!is_server) {
@@ -116,7 +116,7 @@ set_var('NOAUTOLOGIN', 1);
 set_var('HASLICENSE',  1);
 set_var('SLE_PRODUCT', get_var('SLE_PRODUCT', 'sles'));
 # Always register against SCC if SLE 15
-if (sle_version_at_least('15')) {
+if (is_sle('15+')) {
     set_var('SCC_REGISTER', get_var('SCC_REGISTER', 'installation'));
     # depending on registration only limited system roles are available
     set_var('SYSTEM_ROLE', get_var('SYSTEM_ROLE', is_desktop_module_available() ? 'default' : 'minimal'));
@@ -129,7 +129,7 @@ if (sle_version_at_least('15')) {
 }
 diag('default desktop: ' . default_desktop);
 set_var('DESKTOP', get_var('DESKTOP', default_desktop));
-if (sle_version_at_least('15')) {
+if (is_sle('15+')) {
     if (check_var('ARCH', 's390x') and get_var('DESKTOP', '') =~ /gnome|minimalx/) {
         diag 'BUG: bsc#1058071 - No VNC server available in SUT, disabling X11 tests. Re-enable after bug is fixed';
         set_var('DESKTOP', 'textmode');
@@ -142,7 +142,7 @@ set_var('DISABLE_SLE_UPDATES', get_var('DISABLE_SLE_UPDATES', get_var('QAM_MINIM
 
 # Set serial console for Xen PV
 if (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')) {
-    if (sle_version_at_least('12-SP2')) {
+    if (is_sle('12-SP2+')) {
         set_var('SERIALDEV', 'hvc0');
     }
     else {
@@ -150,11 +150,11 @@ if (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')
     }
 }
 
-if (sle_version_at_least('12-SP2')) {
+if (is_sle('12-SP2+')) {
     set_var('SP2ORLATER', 1);
 }
 
-if (sle_version_at_least('12-SP3')) {
+if (is_sle('12-SP3+')) {
     set_var('SP3ORLATER', 1);
 }
 
@@ -187,7 +187,7 @@ if (check_var('DESKTOP', 'minimalx')) {
 # This setting is used to set veriables properly when SDK or Development-Tools are required.
 # For SLE 15 we add Development-Tools during using SCC, and using ftp url in case of other versions.
 if (get_var('DEV_IMAGE')) {
-    if (sle_version_at_least('15')) {
+    if (is_sle('15+')) {
         # On SLE 15 activate Development-Tools module with SCC
         my $addons = (get_var('SCC_ADDONS') ? get_var('SCC_ADDONS') . ',' : '') . 'sdk';
         set_var('SCC_ADDONS', $addons);
@@ -249,7 +249,7 @@ if (check_var('SCC_REGISTER', 'installation') && get_var('ALL_ADDONS') && !get_v
 
 # This is workaround setting which will be removed once SCC add repos and allows adding modules
 # TODO: place it somewhere else since test module suseconnect_scc will use it
-if (sle_version_at_least('15') && !check_var('SCC_REGISTER', 'installation')) {
+if (is_sle('15+') && !check_var('SCC_REGISTER', 'installation')) {
     my @modules;
     if (get_var('ALL_MODULES')) {
         # By default add all modules
@@ -355,7 +355,7 @@ if (is_updates_test_repo && !get_var('MAINT_TEST_REPO')) {
 }
 
 if (get_var('ENABLE_ALL_SCC_MODULES') && !get_var('SCC_ADDONS')) {
-    if (sle_version_at_least('15')) {
+    if (is_sle('15+')) {
         # Add only modules which are not pre-selected
         # 'pcm' should be treated special as it is only applicable to cloud
         # installations
@@ -379,7 +379,7 @@ if (get_var('ENABLE_ALL_SCC_MODULES') && !get_var('SCC_ADDONS')) {
 
 # define aytests repo for support server (do not override defined value)
 if (get_var('SUPPORT_SERVER_ROLES', '') =~ /aytest/ && !get_var('AYTESTS_REPO')) {
-    if (sle_version_at_least('15')) {
+    if (is_sle('15+')) {
         set_var('AYTESTS_REPO', 'http://download.suse.de/ibs/Devel:/YaST:/Head/SUSE_SLE-15_GA/');
     }
     else {

--- a/tests/console/docker_runc.pm
+++ b/tests/console/docker_runc.pm
@@ -18,7 +18,7 @@
 use base "consoletest";
 use testapi;
 use utils;
-use version_utils qw(is_caasp is_sle sle_version_at_least);
+use version_utils 'is_caasp';
 use registration;
 use strict;
 

--- a/tests/console/postgresql_server.pm
+++ b/tests/console/postgresql_server.pm
@@ -14,13 +14,13 @@ use base "consoletest";
 use strict;
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 use apachetest;
 
 sub run {
     select_console 'root-console';
 
-    my $pgsql_server = sle_version_at_least('15') ? 'postgresql10-server' : 'postgresql96-server';
+    my $pgsql_server = (is_sle('<15') || is_leap('<15.0')) ? 'postgresql96-server' : 'postgresql10-server';
     # install the postgresql server package
     zypper_call "in $pgsql_server sudo";
 

--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,8 +15,8 @@ use base qw(console_yasttest y2logsstep);
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_leap is_sle sle_version_at_least);
 use constant RETRIES => 5;
+
 # Test "yast2 dhcp-server" functionality
 # Ensure that all combinations of running/stopped and active/inactive
 # can be set

--- a/tests/console/yast2_ntpclient.pm
+++ b/tests/console/yast2_ntpclient.pm
@@ -24,7 +24,7 @@ sub run {
 
     # ntp configuration is different in SLE15/Leap15
     # for now, Tumbleweed doesn't use Chrony
-    # use sle_or_leap_15 variable to avoid executing is_* and *_version_at_least multiple time
+    # use variable to avoid executing is_* multiple time
     my $is_chronyd = (!is_sle('<15') && !is_leap('<15.0')) ? 1 : 0;
     $ntp_service = 'chronyd' if ($is_chronyd);
 

--- a/tests/console/zypper_lr_validate.pm
+++ b/tests/console/zypper_lr_validate.pm
@@ -14,7 +14,7 @@ use base "consoletest";
 use strict;
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils qw(is_staging is_sle);
 
 sub validatelr {
     my ($args) = @_;
@@ -79,7 +79,7 @@ sub validatelr {
     # medium and the system is registered to SCC the repo should be disabled
     # if the system is SLE 12 SP2 and later; enabled otherwise, see PR#11460 and
     # FATE#320494.
-    my $scc_install_sle12sp2 = check_var('SCC_REGISTER', 'installation') and sle_version_at_least('12-SP2');
+    my $scc_install_sle12sp2 = check_var('SCC_REGISTER', 'installation') and is_sle('12-SP2+');
     my $enabled_repo;
     if ($args->{enabled_repo}) {
         $enabled_repo = $args->{enabled_repo};
@@ -106,8 +106,8 @@ sub validatelr {
         $cmd
           = "zypper lr --uri | awk -F \'|\' -v OFS=\' \' \'{ print \$3,\$4,\$NF }\' | tr -s \' \' | grep --color \"$product\[\[:space:\]\[:punct:\]\[:space:\]\]*$enabled_repo $uri\"";
     }
-    elsif (check_var('DISTRI', 'sle')) {
-        if (sle_version_at_least('15')) {
+    elsif (is_sle) {
+        if (is_sle('15+')) {
             my $distri = uc(get_var('DISTRI'));
             $cmd
               = "zypper lr --uri | awk -F \'|\' -v OFS=\' \' \'{ print \$2,\$3,\$4,\$NF }\' | tr -s \' \' | grep --color \"$distri\[\[:alnum:\]\[:punct:\]\]*-*$version-$product_channel $distri\[\[:alnum:\]\[:punct:\]\[:space:\]\]*-*$version-$product_channel $enabled_repo $uri\"";
@@ -168,10 +168,10 @@ sub validate_repos_sle {
             if (check_var("BACKEND", "ipmi") || check_var("BACKEND", "generalhw")) {
                 $uri = "http[s]*://.*suse";
             }
-            elsif (get_var('USBBOOT') && sle_version_at_least('12-SP3')) {
+            elsif (get_var('USBBOOT') && is_sle('12-SP3+')) {
                 $uri = "hd:///.*usb-";
             }
-            elsif (get_var('USBBOOT') && sle_version_at_least('12-SP2')) {
+            elsif (get_var('USBBOOT') && is_sle('12-SP2+')) {
                 $uri = "hd:///.*usbstick";
             }
             validatelr({product => "SLES", uri => $uri, version => $version});
@@ -331,7 +331,7 @@ sub validate_repos {
     script_run "clear";
     assert_script_run "zypper lr -d | tee /dev/$serialdev", 180;
 
-    if (check_var('DISTRI', 'sle') and !get_var('STAGING') and sle_version_at_least('12-SP1')) {
+    if (!is_staging and is_sle('12-SP1+')) {
         validate_repos_sle($version);
     }
 }

--- a/tests/fips/openssl/openssl_fips_cipher.pm
+++ b/tests/fips/openssl/openssl_fips_cipher.pm
@@ -1,6 +1,6 @@
 # openssl fips test
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,7 +15,7 @@ use base "consoletest";
 use testapi;
 use strict;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
     select_console 'root-console';
@@ -40,9 +40,7 @@ sub run {
 
     # With FIPS non-approved Cipher algorithms, openssl shall report failure
     my @invalid_cipher = ("bf", "cast5", "rc4", "seed", "des", "desx");
-    if (sle_version_at_least('12-SP2')) {
-        push @invalid_cipher, "des-ede";
-    }
+    push @invalid_cipher, "des-ede" unless is_sle('<12-SP2');
     for my $cipher (@invalid_cipher) {
         validate_script_output
           "openssl enc -$cipher -e -in $file_raw -out $file_enc -k $enc_passwd -md $hash_alg 2>&1 || true",

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -15,7 +15,7 @@ use strict;
 use base "y2logsstep";
 use testapi;
 use utils 'addon_license';
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 use qam 'advance_installer_window';
 use registration qw(%SLE15_DEFAULT_MODULES rename_scc_addons @SLE15_ADDONS_WITHOUT_LICENSE);
 
@@ -44,7 +44,7 @@ sub handle_all_packages_medium {
     push @addons, 'legacy' if get_var('UPGRADE') && !grep(/^legacy$/, @addons);
 
     # For SLES12SPx and SLES11SPx to SLES15 migration, need add the demand module at least for media migration manually
-    if (get_var('MEDIA_UPGRADE') && !sle_version_at_least('15', version_variable => 'HDDVERSION') && !check_var('SLE_PRODUCT', 'sled')) {
+    if (get_var('MEDIA_UPGRADE') && !is_sle('15+', version_variable => 'HDDVERSION') && !check_var('SLE_PRODUCT', 'sled')) {
         my @demand_addon = qw(desktop legacy serverapp script);
         for my $a (@demand_addon) {
             push @addons, $a if !grep(/^$a$/, @addons);

--- a/tests/installation/addon_products_via_SCC_yast2.pm
+++ b/tests/installation/addon_products_via_SCC_yast2.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,13 +15,13 @@ use base qw(y2logsstep y2x11test);
 use strict;
 use testapi;
 use registration 'fill_in_registration_data';
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 use utils 'turn_off_gnome_screensaver';
 
 sub test_setup {
     select_console 'root-console';
     my $proxy_scc;
-    if (sle_version_at_least '15') {
+    if (is_sle('15+')) {
         # Remove registration from the system
         assert_script_run 'SUSEConnect --clean';
         # Define proxy SCC

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2017 SUSE LLC
+# Copyright © 2016-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils qw(is_jeos is_caasp is_installcheck is_rescuesystem sle_version_at_least);
+use version_utils qw(is_jeos is_caasp is_installcheck is_rescuesystem is_sle);
 use registration 'registration_bootloader_cmdline';
 use File::Basename;
 
@@ -243,7 +243,7 @@ sub run {
         }
         type_string "echo -en '\\033[K' > \$pty\n";                         # end of line
         type_string "echo -en ' $cmdline' > \$pty\n";
-        if (sle_version_at_least('12-SP2') or is_caasp) {
+        if (is_sle('12-SP2+') or is_caasp) {
             type_string "echo -en ' xen-fbfront.video=32,1024,768 xen-kbdfront.ptr_size=1024,768 ' > \$pty\n";    # set kernel framebuffer
             type_string "echo -en ' console=hvc console=tty ' > \$pty\n";                                         # set consoles
         }

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -17,7 +17,7 @@ use strict;
 use base "y2logsstep";
 use testapi;
 use utils qw(handle_login handle_emergency);
-use version_utils qw(sle_version_at_least is_sle is_leap);
+use version_utils qw(is_sle is_leap);
 use base 'opensusebasetest';
 
 sub run {
@@ -32,7 +32,7 @@ sub run {
     }
     my $boot_timeout = (get_var('SES5_DEPLOY') || check_var('VIRSH_VMM_FAMILY', 'hyperv')) ? 450 : 200;
     # SLE >= 15 s390x does not offer auto-started VNC server in SUT, only login prompt as in textmode
-    return if check_var('ARCH', 's390x') && sle_version_at_least('15');
+    return if check_var('ARCH', 's390x') && is_sle('15+');
     if (check_var('WORKER_CLASS', 'hornet')) {
         # hornet does not show the console output
         diag "waiting $boot_timeout seconds to let hornet boot and finish initial script";

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,7 +15,6 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
-use version_utils 'sle_version_at_least';
 
 
 sub run {

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,14 +15,14 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
-use version_utils qw(is_leap is_storage_ng is_sle sle_version_at_least);
+use version_utils qw(is_leap is_storage_ng is_sle);
 use partition_setup '%partition_roles';
 
 sub run {
     assert_screen 'partitioning-edit-proposal-button', 40;
 
     if (get_var("DUALBOOT")) {
-        if (is_sle && sle_version_at_least('15')) {
+        if (is_sle('15+')) {
             record_soft_failure('bsc#1089723 Make sure keep the existing windows partition');
             assert_screen "delete-partition";
             send_key "alt-g";

--- a/tests/installation/partitioning_lvm.pm
+++ b/tests/installation/partitioning_lvm.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 use parent qw(installation_user_settings y2logsstep);
 use testapi;
-use version_utils qw(sle_version_at_least is_storage_ng);
+use version_utils 'is_storage_ng';
 use partition_setup 'enable_encryption_guided_setup';
 
 sub save_logs_and_resume {

--- a/tests/installation/sles4sap_product_installation_mode.pm
+++ b/tests/installation/sles4sap_product_installation_mode.pm
@@ -13,10 +13,10 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
-    if (sle_version_at_least('15')) {
+    if (is_sle('15+')) {
         my $expected_needle = check_var('SLES4SAP_MODE', 'sles4sap_wizard') ? "sles4sap-wizard-option-selected" : "sles4sap-wizard-option-not-selected";
         assert_screen [qw(sles4sap-wizard-option-selected sles4sap-wizard-option-not-selected)];
         send_key "alt-a" unless (match_has_tag($expected_needle));

--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,7 +15,6 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
-use version_utils 'sle_version_at_least';
 
 sub check_bsc982138 {
     if (check_screen('installation-details-view-remaining-time-gt2h', 5)) {

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -16,7 +16,7 @@ use warnings;
 use base "y2logsstep";
 use testapi;
 use utils 'ensure_fullscreen';
-use version_utils qw(is_sle sle_version_at_least is_staging);
+use version_utils qw(is_sle is_staging);
 
 sub run {
     my ($self) = @_;
@@ -31,11 +31,11 @@ sub run {
         push @welcome_tags, 'inst-welcome';
     }
     # Add tag for soft-failure on SLE 15
-    push @welcome_tags, 'no-product-found-on-scc' if sle_version_at_least('15');
+    push @welcome_tags, 'no-product-found-on-scc' if is_sle('15+');
     # Add tag for untrusted-ca-cert with SMT
     push @welcome_tags, 'untrusted-ca-cert' if get_var('SMT_URL');
     # Add tag for sle15 upgrade mode, where product list should NOT be shown
-    push @welcome_tags, 'inst-welcome-no-product-list' if sle_version_at_least('15') and get_var('UPGRADE');
+    push @welcome_tags, 'inst-welcome-no-product-list' if is_sle('15+') and get_var('UPGRADE');
     # Add tag to check for https://progress.opensuse.org/issues/30823 "test is
     # stuck in linuxrc asking if dhcp should be used"
     push @welcome_tags, 'linuxrc-dhcp-question';
@@ -90,7 +90,7 @@ sub run {
 
     # license+lang +product (on sle15)
     # On sle 15 license is on different screen, here select the product
-    if (sle_version_at_least('15') && check_var('DISTRI', 'sle')) {
+    if (is_sle('15+')) {
         # On s390x there will be only one product which means there is no product selection
         # In upgrade mode, there is no product list shown in welcome screen
         unless (check_var('ARCH', 's390x') || get_var('UPGRADE')) {

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -19,7 +19,7 @@ use registration;
 use utils;
 use bootloader_setup 'add_custom_grub_entries';
 use serial_terminal qw(add_serial_console select_virtio_console);
-use version_utils qw(is_sle sle_version_at_least is_opensuse);
+use version_utils qw(is_sle is_opensuse);
 
 sub add_repos {
     my $qa_head_repo = get_required_var('QA_HEAD_REPO');
@@ -29,11 +29,11 @@ sub add_repos {
 
 sub add_we_repo_if_available {
     # opensuse doesn't have extensions
-    return if check_var('DISTRI', 'opensuse');
+    return if is_opensuse;
 
     my $ar_url;
     my $we_repo = get_var('REPO_SLE_WE15_POOL');
-    if ($we_repo && check_var('DISTRI', 'sle') && sle_version_at_least('15')) {
+    if ($we_repo && is_sle('15+')) {
         $ar_url = "http://openqa.suse.de/assets/repo/$we_repo";
     }
     # productQA test with enabled we as iso_2

--- a/tests/shutdown/cleanup_before_shutdown.pm
+++ b/tests/shutdown/cleanup_before_shutdown.pm
@@ -17,14 +17,14 @@ use base 'opensusebasetest';
 use testapi;
 use serial_terminal 'add_serial_console';
 use utils;
-use version_utils;
+use version_utils 'is_sle';
 
 sub run {
     select_console('root-console');
     if (get_var('DROP_PERSISTENT_NET_RULES')) {
         type_string "rm -f /etc/udev/rules.d/70-persistent-net.rules\n";
     }
-    if (!sle_version_at_least('12-SP2') && check_var('VIRTIO_CONSOLE', 1)) {
+    if (is_sle('<12-SP2') && check_var('VIRTIO_CONSOLE', 1)) {
         add_serial_console('hvc0');
     }
     # Proceed with dhcp cleanup on qemu backend only.

--- a/tests/slenkins/slenkins_node.pm
+++ b/tests/slenkins/slenkins_node.pm
@@ -22,7 +22,6 @@ use testapi;
 use lockapi;
 use mmapi;
 use mm_network;
-use version_utils 'sle_version_at_least';
 use opensusebasetest 'firewall';
 
 sub run {

--- a/tests/sles4sap/desktop_icons.pm
+++ b/tests/sles4sap/desktop_icons.pm
@@ -12,7 +12,7 @@
 
 use base "sles4sap";
 use testapi;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 use strict;
 
 sub run {
@@ -30,7 +30,7 @@ sub run {
         # Verify that there is at least a generic desktop and
         # fail unless we're in SLE-15 where there are no icons
         assert_screen 'generic-desktop';
-        record_soft_failure 'bsc#1072646' unless sle_version_at_least('15');
+        record_soft_failure 'bsc#1072646' unless is_sle('15+');
     }
 }
 

--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -13,7 +13,7 @@
 use base "sles4sap";
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 use strict;
 
 sub run {
@@ -26,7 +26,7 @@ sub run {
     # Disable packagekit
     pkcon_quit;
 
-    my $base_pattern = sle_version_at_least('15') ? 'patterns-server-enterprise-sap_server' : 'patterns-sles-sap_server';
+    my $base_pattern = is_sle('15+') ? 'patterns-server-enterprise-sap_server' : 'patterns-sles-sap_server';
 
     # First check pattern sap_server which is installed by default in SLES4SAP
     # when 'SLES for SAP Applications' system role is selected

--- a/tests/x11/evolution/evolution_smoke.pm
+++ b/tests/x11/evolution/evolution_smoke.pm
@@ -14,7 +14,7 @@ use strict;
 use base "x11test";
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub evolution_wizard {
     my ($self, $mail_box) = @_;
@@ -22,11 +22,11 @@ sub evolution_wizard {
     # Follow the wizard to setup mail account
     $self->start_evolution($mail_box);
     assert_screen "evolution_wizard-account-summary", 60;
-    if (sle_version_at_least('12-SP2')) {
-        assert_and_click "evolution-option-next";
+    if (is_sle('<12-SP2')) {
+        send_key $self->{next};
     }
     else {
-        send_key $self->{next};
+        assert_and_click "evolution-option-next";
     }
 
     assert_screen "evolution_wizard-done";

--- a/tests/x11/firefox/firefox_emaillink.pm
+++ b/tests/x11/firefox/firefox_emaillink.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,15 +15,11 @@ use strict;
 use base "x11test";
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
-    my $next_key = "alt-o";
-
-    if (sle_version_at_least('12-SP2')) {
-        $next_key = "alt-n";
-    }
+    my $next_key = is_sle('<12-SP2') ? 'alt-o' : 'alt-n';
 
     $self->start_firefox;
 
@@ -31,7 +27,7 @@ sub run {
     send_key "alt-f";
     wait_still_screen 3;
     send_key "e";
-    unless (sle_version_at_least('15')) {
+    if (is_sle('<15')) {
         assert_screen('firefox-email_link-welcome', 90);
 
         send_key $next_key;
@@ -52,15 +48,15 @@ sub run {
         type_string "imap.suse.com";
         send_key "alt-n";    #Username
         type_string "test";
-        if (sle_version_at_least('12-SP2')) {
-            assert_and_click "evolution-option-next";
+        if (is_sle('<12-SP2')) {
+            send_key $next_key;
             wait_still_screen 3;
-            assert_and_click "evolution-option-next";
+            send_key $next_key;
         }
         else {
-            send_key $next_key;
+            assert_and_click "evolution-option-next";
             wait_still_screen 3;
-            send_key $next_key;
+            assert_and_click "evolution-option-next";
         }
 
         assert_screen('firefox-email_link-settings_sending');
@@ -71,11 +67,11 @@ sub run {
         };
 
         wait_still_screen 3;
-        if (sle_version_at_least('12-SP2')) {
-            assert_and_click "evolution-option-next";
+        if (is_sle('<12-SP2')) {
+            send_key $next_key;
         }
         else {
-            send_key $next_key;
+            assert_and_click "evolution-option-next";
         }
 
         wait_still_screen 3;

--- a/tests/x11/firefox/firefox_extcontent.pm
+++ b/tests/x11/firefox/firefox_extcontent.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -14,7 +14,7 @@
 use strict;
 use base "x11test";
 use testapi;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
@@ -41,7 +41,7 @@ sub run {
     sleep 1;
     send_key "ret";
 
-    assert_screen((sle_version_at_least('15')) ? 'firefox-extcontent-nautils' : 'firefox-extcontent-archive_manager');
+    assert_screen((is_sle('<15')) ? 'firefox-extcontent-archive_manager' : 'firefox-extcontent-nautils');
 
     send_key "ctrl-q";
 

--- a/tests/x11/firefox/firefox_mhtml.pm
+++ b/tests/x11/firefox/firefox_mhtml.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -14,7 +14,7 @@
 use strict;
 use base "x11test";
 use testapi;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
@@ -34,13 +34,13 @@ sub run {
     assert_and_click('firefox-mhtml-unmht');
     for my $i (1 .. 2) { send_key "tab"; }
     send_key "spc";
-    unless (sle_version_at_least('15')) {
+    if (is_sle('<15')) {
         assert_and_click('unmht_restart_now');
         $self->firefox_check_popups;
     }
     wait_still_screen 3;
     assert_and_click('firefox-my-addons');
-    send_key 'f5' if (sle_version_at_least('15'));
+    send_key 'f5' unless is_sle('<15');
     assert_screen('firefox-mhtml-unmht_installed', 90);
 
     wait_screen_change { send_key "ctrl-w" };

--- a/tests/x11/firefox/firefox_plugins.pm
+++ b/tests/x11/firefox/firefox_plugins.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,6 @@
 use strict;
 use base "x11test";
 use testapi;
-use version_utils 'sle_version_at_least';
 
 sub run {
     my ($self) = @_;

--- a/tests/x11/firefox/firefox_urlsprotocols.pm
+++ b/tests/x11/firefox/firefox_urlsprotocols.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,7 +15,7 @@ use strict;
 use base "x11test";
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
@@ -29,11 +29,11 @@ sub run {
         local => "file:///usr/share/w3m/w3mhelp.html"
     );
 
-    if (sle_version_at_least('12-SP2')) {
-        record_soft_failure 'bsc#1004573';
+    if (is_sle('<12-SP2')) {
+        $sites_url{smb} = "smb://mirror.bej.suse.com/dist/";
     }
     else {
-        $sites_url{smb} = "smb://mirror.bej.suse.com/dist/";
+        record_soft_failure 'bsc#1004573';
     }
     for my $proto (sort keys %sites_url) {
         send_key "esc";

--- a/tests/x11/gnomecase/change_password.pm
+++ b/tests/x11/gnomecase/change_password.pm
@@ -51,7 +51,7 @@ sub reboot_system {
     assert_screen "displaymanager", 200;
     $self->{await_reboot} = 0;
     # The keyboard focus is different between SLE15 and SLE12
-    send_key 'up' if sle_version_at_least('15');
+    send_key 'up' unless is_sle('<15');
     send_key "ret";
     wait_still_screen;
     type_string "$newpwd\n";
@@ -143,7 +143,7 @@ sub run {
 
     #delete the added user: test
     # We should kill the active user test in SLE15
-    assert_script_run 'loginctl kill-user test' if (sle_version_at_least('15'));
+    assert_script_run 'loginctl kill-user test' unless is_sle('<15');
     wait_still_screen;
     type_string "userdel -f test\n";
     assert_screen "user-test-deleted";

--- a/tests/x11/gnomecase/gnome_default_applications.pm
+++ b/tests/x11/gnomecase/gnome_default_applications.pm
@@ -1,6 +1,6 @@
 # Gnome tests
 #
-# Copyright © 2016-2017 SUSE LLC
+# Copyright © 2016-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,7 +15,7 @@ use base "x11test";
 use strict;
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
     # Prepare test files
@@ -78,17 +78,17 @@ sub open_default_apps {
     wait_still_screen;
     assert_and_dclick "gnomecase-defaultapps-bz2file";    #open bzip
     assert_screen 'gnomecase-defaultapps-bz2open';
-    send_key "ctrl-w" unless sle_version_at_least('15');    #close fileroller
+    send_key "ctrl-w" if is_sle('<15');                   #close fileroller
     wait_still_screen;
-    assert_and_dclick "gnomecase-defaultapps-gzfile";       #open gzip
+    assert_and_dclick "gnomecase-defaultapps-gzfile";     #open gzip
     assert_screen 'gnomecase-defaultapps-gzopen';
-    send_key "ctrl-w" unless sle_version_at_least('15');    #close fileroller
+    send_key "ctrl-w" if is_sle('<15');                   #close fileroller
     wait_still_screen;
-    assert_and_dclick "gnomecase-defaultapps-htmlfile";     #open html
+    assert_and_dclick "gnomecase-defaultapps-htmlfile";    #open html
     assert_screen 'gnomecase-defaultapps-firefoxopen';
-    send_key "alt-f4";                                      #close firefox
+    send_key "alt-f4";                                     #close firefox
     wait_still_screen;
-    send_key "ctrl-w";                                      #close nautilus
+    send_key "ctrl-w";                                     #close nautilus
 }
 
 # For each element, will check if the mimetype will open with the correct application
@@ -99,11 +99,11 @@ sub check_default_apps {
     my $returnCode = 1;
     my @message    = ();
     for my $app (@apps) {
-        if (sle_version_at_least('15')) {
-            $returnCode = script_run("[ '$app->[1]' == \$(gio mime '$app->[0]' |  awk 'NR==1{print \$NF}' | sed 's/[[:space:]]//' ) ]");
+        if (is_sle('<15')) {
+            $returnCode = script_run("[ '$app->[1]' == \$(gvfs-mime --query '$app->[0]' |  awk 'NR==1{print \$NF}' | sed 's/[[:space:]]//' ) ]");
         }
         else {
-            $returnCode = script_run("[ '$app->[1]' == \$(gvfs-mime --query '$app->[0]' |  awk 'NR==1{print \$NF}' | sed 's/[[:space:]]//' ) ]");
+            $returnCode = script_run("[ '$app->[1]' == \$(gio mime '$app->[0]' |  awk 'NR==1{print \$NF}' | sed 's/[[:space:]]//' ) ]");
         }
         if ($returnCode) {
             push @message, "The mimetype $app->[0] should open with $app->[1]";

--- a/tests/x11/gnomecase/nautilus_open_ftp.pm
+++ b/tests/x11/gnomecase/nautilus_open_ftp.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,7 @@
 use base 'x11test';
 use strict;
 use testapi;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
     x11_start_program('nautilus');
@@ -25,7 +25,7 @@ sub run {
     assert_screen 'nautilus-ftp-login';
     send_key 'ret';
     assert_screen 'nautilus-ftp-suse-com';
-    if (sle_version_at_least('12-SP2')) {
+    unless (is_sle('<12-SP2')) {
         assert_and_click 'unselected-pub';
         assert_and_click 'ftp-path-selected';
         wait_still_screen(2);

--- a/tests/x11/tracker/tracker_by_command.pm
+++ b/tests/x11/tracker/tracker_by_command.pm
@@ -16,20 +16,20 @@ use base "x11test";
 use strict;
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 
 sub run {
     x11_start_program('xterm');
-    if (sle_version_at_least('12-SP2')) {
+    if (is_sle('<12-SP2')) {
+        script_run "tracker-search newfile";
+    }
+    else {
         script_run 'tracker search emtpyfile';
         record_soft_failure 'bsc#1074582 tracker can not index empty file automatically' if check_screen 'tracker-cmdsearch-noemptyfile', 30;
         # Wait 20s for tracker to index the test file
         wait_still_screen 20;
         script_run "tracker search newfile";
-    }
-    else {
-        script_run "tracker-search newfile";
     }
     assert_screen 'tracker-cmdsearch-newfile';
     send_key 'alt-f4';

--- a/tests/x11/tracker/tracker_info.pm
+++ b/tests/x11/tracker/tracker_info.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,17 +16,12 @@ use base "x11test";
 use strict;
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 
 sub run {
     x11_start_program('xterm');
-    if (sle_version_at_least('12-SP2')) {
-        script_run "tracker info newpl.pl";
-    }
-    else {
-        script_run "tracker-info newpl.pl";
-    }
+    script_run is_sle('<12-SP2') ? 'tracker-info newpl.pl' : 'tracker info newpl.pl';
     assert_screen 'tracker-info-newpl';
     send_key "alt-f4";
 }

--- a/tests/x11/tracker/tracker_searchall.pm
+++ b/tests/x11/tracker/tracker_searchall.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,11 +15,11 @@ use base "x11test";
 use strict;
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
     x11_start_program("tracker-needle", target_match => 'tracker-needle-launched');
-    if (!sle_version_at_least('12-SP2')) {
+    if (is_sle('<12-SP2')) {
         wait_screen_change { send_key 'tab' };
         wait_screen_change { send_key 'tab' };
         wait_screen_change { send_key 'right' };

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -18,7 +18,7 @@ use base 'y2x11test';
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_opensuse is_sle sle_version_at_least is_leap is_tumbleweed is_storage_ng);
+use version_utils qw(is_opensuse is_sle is_leap is_tumbleweed is_storage_ng);
 
 sub search {
     my ($name) = @_;
@@ -211,7 +211,7 @@ sub start_vpn_gateway {
 sub start_wake_on_lan {
     search('wake');
     assert_screen [qw(yast2_control-center_wake-on-lan yast2_control_no_modules), timeout => 60];
-    if (match_has_tag('yast2_control_no_modules') && sle_version_at_least('15')) {
+    if (match_has_tag('yast2_control_no_modules') && is_sle('15+')) {
         # No wol on SLE 15 atm
         record_soft_failure 'bsc#1059569';
         return;
@@ -363,7 +363,7 @@ sub run {
         start_kernel_dump;
         # YaST2 CA management has been dropped from SLE15, see
         # https://bugzilla.suse.com/show_bug.cgi?id=1059569#c14
-        if (!sle_version_at_least('15')) {
+        if (!is_sle('15+')) {
             start_common_server_certificate;
             start_ca_management;
         }


### PR DESCRIPTION
Used the command

```
git grep -l 'version_at_least' | xargs sed -i -e "s/\(\w\+\)_version_at_least(.\(.[^'\"]\+\)/is_\1('\2+/g"
```

for the initial conversion and manual tweaking afterwards.

The main goal of this change is to get rid of `sle_version_at_least`. It
can not help much with the challenge to handle all the different
versions and distributions that we want to support.

Related progress issue: https://progress.opensuse.org/issues/38453