### PR TITLE
Modify consoletest_setup for poo#38531

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1375,8 +1375,6 @@ sub load_extra_tests_desktop {
     }
     elsif (check_var('DISTRI', 'opensuse')) {
         if (gnomestep_is_applicable()) {
-            # Setup env for x11 regression tests
-            loadtest "x11/x11_setup";
             # poo#18850 java test support for firefox, run firefox before chrome
             # as otherwise have wizard on first run to import settings from it
             loadtest "x11/firefox/firefox_java";
@@ -1491,10 +1489,7 @@ sub load_extra_tests {
     # pre-conditions for extra tests ie. the tests are running based on preinstalled image
     return if get_var("INSTALLONLY") || get_var("DUALBOOT") || get_var("RESCUECD");
 
-    # setup $serialdev permission and so on
-    loadtest "console/consoletest_setup";
     loadtest 'console/integration_services' if is_hyperv;
-    loadtest "console/hostname";
     if (any_desktop_is_applicable()) {
         load_extra_tests_desktop;
     }
@@ -1811,6 +1806,8 @@ sub load_create_hdd_tests {
     loadtest 'console/integration_services' if is_hyperv;
     loadtest 'console/hostname'              unless is_bridged_networking;
     loadtest 'console/force_scheduled_tasks' unless is_jeos;
+    # setup $serialdev permission and so on
+    loadtest "console/consoletest_setup";
     # Remove repos pointing to download.opensuse.org and add snaphot repo from o3
     replace_opensuse_repos_tests if is_repo_replacement_required;
     loadtest 'console/scc_deregistration' if get_var('SCC_DEREGISTER');

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1164,6 +1164,7 @@ sub ensure_serialdev_permissions {
     }
     else {
         assert_script_run "chown $testapi::username /dev/$testapi::serialdev && gpasswd -a $testapi::username \$(stat -c %G /dev/$testapi::serialdev)";
+        assert_script_run "gpasswd -a $testapi::username dialout";
     }
 }
 


### PR DESCRIPTION
Add the bernhard to dialout group and tty group in consoletest_setup.
In this way, bernhard and /dev/ttyS0 belongs to the same group after
reboot. So, bernhard would have permission write to /dev/ttyS0.

- Related ticket: 
          [poo#38531](https://progress.opensuse.org/issues/38531)
          [poo#38480](https://progress.opensuse.org/issues/38480)
          [poo#37027](https://progress.opensuse.org/issues/37027)
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/399
- Verification run(include sle-sp2 mentioned in poo#38480): 
          [create_hdd_gnome](http://10.67.19.67/tests/348)
          [extra_tests_on_gnome](http://10.67.19.67/tests/372)
          [create_hdd_kde](http://10.67.19.67/tests/351)
          [extra_tests_on_kde](http://10.67.19.67/tests/373)
          [create_hdd_textmode](http://10.67.19.67/tests/352)
          [extra_tests_in_textmode](http://10.67.19.67/tests/371)
          [mru-install-minimal-with-addons](http://10.67.19.67/tests/381)
          [mau-extratests](http://10.67.19.67/tests/384)