### PR TITLE
Don't expect license on already registered addon and viewed license

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -882,6 +882,11 @@ sub addon_license {
     push @tags, (get_var("BETA_$uc_addon") ? "addon-betawarning-$addon" : "addon-license-$addon");
   license: {
         do {
+            # license on SLE15+ is shown only once during registration bsc#1057223
+            # don't expect license if addon was already registered via SCC and license already viewed
+            if (sle_version_at_least('15') && check_var('SCC_REGISTER', 'installation') && get_var('SCC_ADDONS') =~ /$addon/ && !check_screen \@tags) {
+                return 1;
+            }
             assert_screen \@tags;
             if (match_has_tag('import-untrusted-gpg-key')) {
                 record_info 'untrusted gpg key', "Trusting untrusted GPG key", result => 'softfail';


### PR DESCRIPTION
License is not shown twice, only once e.g. first at SCC registration

[This](https://openqa.suse.de/tests/1773785) test passed because addon is sdk without license, test with addon with license e.g. SES will [fail](https://openqa.suse.de/tests/1850185#step/addon_products_sle/15)

- Verification run:
http://10.100.12.155/tests/5529
http://10.100.12.155/tests/5535
