### PR TITLE
Fix error introduced into wireshark test in previous PR#5376

### DIFF
--- a/tests/x11/wireshark.pm
+++ b/tests/x11/wireshark.pm
@@ -56,7 +56,7 @@ sub run {
     assert_and_click "wireshark-help";
     assert_and_click "about-wireshark";
     assert_screen [qw(wireshark-gui-qt wireshark-gui-gtk)];
-    my $wireshark_gui_version = match_has_tag "wireshark-gui-qt" ? "qt" : "gtk";
+    my $wireshark_gui_version = match_has_tag("wireshark-gui-qt") ? "qt" : "gtk";
     assert_and_click "wireshark-about-ok";
 
     # check GUI/file set
@@ -111,7 +111,10 @@ sub run {
     assert_screen "wireshark-capturing";
 
     # set filter
-    send_key "ctrl-/" if $wireshark_gui_version eq "qt";
+    if ($wireshark_gui_version eq "qt") {
+        wait_still_screen 1;
+        send_key "ctrl-/";
+    }
     assert_screen "wireshark-filter-selected";
     type_string "dns.a and dns.qry.name == \"www.suse.com\"\n";
     assert_screen "wireshark-filter-applied";


### PR DESCRIPTION
The previous PR for wireshark #5376 introduced an error by using wrong syntax for match_has_tag, so the condition where it was used did not get evaluated properly. This PR is fixing it, plus also adding a little sleep time further down in the test.

- Related ticket: https://progress.opensuse.org/issues/34351
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/886 (already merged)
- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5376 (already merged)
- Verification run:
SLE12-SP3: http://dreamyhamster.suse.cz/tests/169#step/wireshark/26
SLE12=SP4: http://dreamyhamster.suse.cz/tests/170#step/wireshark/26
SLE15-GA: http://dreamyhamster.suse.cz/tests/156#step/wireshark/26
