### PR TITLE
New tests for openSCAP report generating and validating

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1803,6 +1803,7 @@ sub load_security_tests_openscap {
     loadtest "security/openscap/oscap_remediating_online";
     loadtest "security/openscap/oscap_remediating_offline";
     loadtest "security/openscap/oscap_generating_report";
+    loadtest "security/openscap/oscap_validating";
 }
 
 sub load_systemd_patches_tests {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1802,6 +1802,7 @@ sub load_security_tests_openscap {
     loadtest "security/openscap/oscap_result_datastream";
     loadtest "security/openscap/oscap_remediating_online";
     loadtest "security/openscap/oscap_remediating_offline";
+    loadtest "security/openscap/oscap_generating_report";
 }
 
 sub load_systemd_patches_tests {

--- a/tests/security/openscap/oscap_generating_report.pm
+++ b/tests/security/openscap/oscap_generating_report.pm
@@ -1,0 +1,89 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Generate document - security guide or report - form XCCDF file
+# Maintainer: Wes <whdu@suse.com>
+# Tags: poo#36925, tc#1621177
+
+use base 'consoletest';
+use strict;
+use testapi;
+use utils;
+use openscaptest;
+
+sub run {
+    my $xccdf_guide       = "xccdf_guide.html";
+    my $xccdf_report      = "xccdf_report.html";
+    my $xccdf_fix         = "xccdf_fix.sh";
+    my $oval_report       = "oval_report.html";
+    my $xccdf_oval_report = "xccdf_oval_report.html";
+
+    my $xccdf_guide_match = 'm/
+            Checklist.*
+            contains 2 rules.*
+            Restrict Root Logins.*
+            Direct root Logins Not Allowed.*
+            sysctl kernel.sysrq must be 0.*/sxx';
+
+    my $xccdf_report_match = 'm/
+            with profile.*Standard System Security Profile.*
+            The target system did not satisfy the conditions of 2 rules.*
+            Hardening SUSE Linux Enterprise.*2x fail.*
+            Restrict Root Logins.*1x fail.*
+            Direct root Logins Not Allowed.*
+            sysctl kernel.sysrq must be 0/sxx';
+
+    my $oval_report_match = 'm/
+            OVAL Results Generator Information.*
+            OVAL Definition Generator Information.*
+            System Information.*
+            cpe:\/a:open-scap:oscap.*
+            OVAL Definition Results.*
+            oval:rule_misc_sysrq:def:1.*false.*
+            oval:no_direct_root_logins:def:1.*false/sxx';
+
+    my $xccdf_oval_report_match = 'm/
+            with profile.*Standard System Security Profile.*
+            Evaluation Characteristics.*
+            CPE Platforms.*cpe:\/o:suse.*
+            Compliance and Scoring.*
+            The target system did not satisfy the conditions of 2 rules.*
+            Rule results.*2 failed.*
+            Severity of failed rules.*1 other.*
+            Score.*
+            Rule Overview.*
+    ';
+
+    ensure_generated_file($oval_result);
+    ensure_generated_file($xccdf_result);
+
+    # Generate XCCDF guide
+    assert_script_run "oscap xccdf generate guide --profile standard --output $xccdf_guide $xccdf_result";
+    validate_result($xccdf_guide, $xccdf_guide_match, 'html');
+
+    # Generate XCCDF report
+    assert_script_run "oscap xccdf generate report --profile standard --output $xccdf_report $xccdf_result";
+    validate_result($xccdf_report, $xccdf_report_match, 'html');
+
+    # Generate OVAL report
+    assert_script_run "oscap oval generate report --output $oval_report $oval_result";
+    validate_result($oval_report, $oval_report_match, 'html');
+
+    # Generate XCCDF report with additional information from failed OVAL tests
+    assert_script_run "oscap xccdf generate report --oval-template $oval_result --output $xccdf_oval_report $xccdf_result";
+    validate_result($xccdf_oval_report, $xccdf_oval_report_match, 'html');
+}
+
+1;

--- a/tests/security/openscap/oscap_validating.pm
+++ b/tests/security/openscap/oscap_validating.pm
@@ -1,0 +1,34 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Validate given OVAL and XCCDF file against a XML schema
+# Maintainer: Wes <whdu@suse.com>
+# Tags: poo#36928, tc#1626472
+
+use base 'consoletest';
+use strict;
+use testapi;
+use utils;
+use openscaptest;
+
+sub run {
+    assert_script_run "oscap oval validate oval.xml";
+    assert_script_run "oscap oval validate $oval_result";
+
+    assert_script_run "oscap xccdf validate xccdf.xml";
+    assert_script_run "oscap xccdf validate $xccdf_result";
+}
+
+1;


### PR DESCRIPTION
New tests for openSCAP report generating and validating:
"tests/security/openscap/oscap_generating_report.pm" ([poo#36925](https://progress.opensuse.org/issues/36925))
"tests/security/openscap/oscap_validating.pm" ([poo#36928](https://progress.opensuse.org/issues/36928))

- Related ticket:
  - https://progress.opensuse.org/issues/36925
  - https://progress.opensuse.org/issues/36928
- Verification run:
  - SLE: http://10.67.17.9/tests/1027
  - Tumbleweed: http://10.67.17.9/tests/1028
