### PR TITLE
[Wicked] Fix typo in ifcfg_tap file

### DIFF
--- a/data/wicked/ifcfg-tap1_sut
+++ b/data/wicked/ifcfg-tap1_sut
@@ -1,6 +1,6 @@
 STARTMODE='manual'
 BOOTPROTO='static'
-TUNNEL='tun'
+TUNNEL='tap'
 TUNNEL_SET_OWNER='root'
 TUNNEL_SET_GROUP='root'
 LINK_REQUIRED=no


### PR DESCRIPTION
Because of this, Wicked suite fails in OSD when setting up the TAP device from ifcfg files. https://openqa.suse.de/tests/1853615

The bug was introduced in this commit
https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/8e0d2f50d66faefbc040ed206c9fcbc2fbfe5a9a