### PR TITLE
Remove ftp test repo

### DIFF
--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -91,7 +91,7 @@ sub add_test_repositories {
 # Function that will remove all test repos
 sub remove_test_repositories {
 
-    type_string 'repos=($(zypper lr -e - | grep name=TEST | cut -d= -f2)); if [ ${#repos[@]} -ne 0 ]; then zypper rr ${repos[@]}; fi';
+    type_string 'repos=($(zypper lr -e - | grep "name=TEST|baseurl=ftp" | cut -d= -f2)); if [ ${#repos[@]} -ne 0 ]; then zypper rr ${repos[@]}; fi';
     type_string "\n";
 }
 


### PR DESCRIPTION
Remove ftp test repos
For some test case, ftp repos will be added in install steps, need remove them in case cause any error.

- See Poo#38645

- Related ticket: https://progress.opensuse.org/issues/38645
- Verification run: http://openqa-apac1.suse.de/tests/1277#step/online_migration_setup/18