### PR TITLE
Skip version_switch for online upgrade

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -649,7 +649,7 @@ sub load_patching_tests {
         set_var('UPGRADE_TARGET_VERSION', get_var('VERSION'));
         # Always boot from installer DVD in upgrade test
         set_var('BOOTFROM', 'd');
-        loadtest "migration/version_switch_origin_system";
+        loadtest "migration/version_switch_origin_system" if (!get_var('ONLINE_MIGRATION'));
     }
     set_var('BOOT_HDD_IMAGE', 1);
     boot_hdd_image;


### PR DESCRIPTION
version_switch is used for sles15 offline migration
No need load this test for SLES12SPx online migration
Skip it for online migration test


- Related ticket: https://progress.opensuse.org/issues/38360
