### PR TITLE
xfstests: Add info into log and add a NO_KDUMP to disable kdump

### DIFF
--- a/lib/ctcs2_to_junit.pm
+++ b/lib/ctcs2_to_junit.pm
@@ -99,12 +99,20 @@ sub generateXML {
             name      => $test,
             status    => $case_status,
             time      => $test_results{$test}->{time});
-        $writer->startTag('system-err');
-        $writer->characters("");
-        $writer->endTag('system-err');
-        $writer->startTag('system-out');
-        $writer->characters("");
-        $writer->endTag('system-out');
+        if ($case_status eq 'failure' || $case_status eq 'skipped') {
+            (my $test_path = $test) =~ s/-/\//;
+            $test_path = '/opt/log/' . $test_path;
+            my $test_out_content = script_output("cat $test_path\n", 600);
+            $writer->startTag('system-out');
+            $writer->characters($test_out_content);
+            $writer->endTag('system-out');
+            if ($case_status eq 'failure') {
+                my $test_err_content = script_output("echo '====out.bad log====\n';\ncat $test_path" . ".out.bad;\necho '\n====full log====\n';\ncat  $test_path" . ".full", 600);
+                $writer->startTag('system-err');
+                $writer->characters($test_err_content);
+                $writer->endTag('system-err');
+            }
+        }
         $writer->endTag('testcase');
     }
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -897,8 +897,14 @@ elsif (get_var("QA_TESTSUITE")) {
     loadtest "qa_automation/execute_test_run";
 }
 elsif (get_var("XFSTESTS")) {
+    #Workaround bsc#1101787
+    if (check_var('ARCH', 'aarch64') && check_var('VERSION', '12-SP4')) {
+        set_var('NO_KDUMP', 1);
+    }
     loadtest "boot/boot_to_desktop";
-    loadtest "xfstests/enable_kdump";
+    unless (get_var('NO_KDUMP')) {
+        loadtest "xfstests/enable_kdump";
+    }
     loadtest "xfstests/install";
     loadtest "xfstests/partition";
     loadtest "xfstests/run";

--- a/tests/xfstests/enable_kdump.pm
+++ b/tests/xfstests/enable_kdump.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 #
 # Summary: Enable kdump and verify it's enabled
-# Maintainer: Nathan Zhao <jtzhao@suse.com>
+# Maintainer: Yong Sun <yosun@suse.com>
 package enable_kdump;
 
 use strict;

--- a/tests/xfstests/generate_report.pm
+++ b/tests/xfstests/generate_report.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 #
 # Summary: Upload logs and generate junit report
-# Maintainer: Nathan Zhao <jtzhao@suse.com>
+# Maintainer: Yong Sun <yosun@suse.com>
 package generate_report;
 
 use strict;
@@ -54,8 +54,10 @@ sub run {
     # Upload test logs
     upload_subdirs($LOG_DIR, 1200);
 
-    # Upload kdump logs
-    upload_subdirs($KDUMP_DIR, 1200);
+    # Upload kdump logs if not set "NO_KDUMP"
+    unless (get_var('NO_KDUMP')) {
+        upload_subdirs($KDUMP_DIR, 1200);
+    }
 
     # Junit xml report
     my $script_output = script_output("cat $STATUS_LOG", 600);

--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 #
 # Summary: Install xfstests
-# Maintainer: Nathan Zhao <jtzhao@suse.com>
+# Maintainer: Yong Sun <yosun@suse.com>
 package install;
 
 use 5.018;

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 #
 # Summary: Create partitions for xfstests
-# Maintainer: Nathan Zhao <jtzhao@suse.com>
+# Maintainer: Yong Sun <yosun@suse.com>
 package partition;
 
 use 5.018;

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 #
 # Summary: Run tests
-# Maintainer: Nathan Zhao <jtzhao@suse.com>
+# Maintainer: Yong Sun <yosun@suse.com>
 package run;
 
 use 5.018;
@@ -277,11 +277,13 @@ sub run {
 
         sleep(1);
         select_console('root-console');
-        # Save kdump data to KDUMP_DIR
-        unless (save_kdump($test, $KDUMP_DIR)) {
-            # If no kdump data found, write warning to log
-            my $msg = "Warning: $test crashed SUT but has no kdump data";
-            script_run("echo '$msg' >> $LOG_DIR/$category/$num");
+        # Save kdump data to KDUMP_DIR if not set "NO_KDUMP"
+        unless (get_var('NO_KDUMP')) {
+            unless (save_kdump($test, $KDUMP_DIR)) {
+                # If no kdump data found, write warning to log
+                my $msg = "Warning: $test crashed SUT but has no kdump data";
+                script_run("echo '$msg' >> $LOG_DIR/$category/$num");
+            }
         }
 
         # Add test status to STATUS_LOG file


### PR DESCRIPTION
This PR including two modification:
1. Add "test output", ".out.bad", ".full" log shows in webUI result. Since ctcs2_to_junit.pm used in different code base of tests, so create xfstests_to_junit.pm follow tests/xfstests related log.
2. Use VAR "NO_KDUMP" to disable kdump related process to workaround aarch64 kdump bug block all xfstests.

- Related ticket: https://progress.opensuse.org/issues/36439
- Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1101787
- Verification run: 
http://10.67.133.102/tests/561#step/1_/3
All logs shows in "failed" and "skipped" tests.
http://10.67.133.102/tests/562
After set "NO_KDUMP=1" in openQA, the enable_dump part skipped. And kdump related code also skipped in run.pm and generic_report.pm