### PR TITLE
Workaround auto-login failure on GNOME on AArch64

### DIFF
--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -56,6 +56,10 @@ sub run {
     if (check_var('DESKTOP', 'kde') && get_var('VERSION', '') =~ /^1[23]/) {
         push(@tags, 'kde-greeter');
     }
+    # boo#1102563 - autologin fails on aarch64 with GNOME on current Tumbleweed
+    if (!is_sle('<=15') && !is_leap('<=15.0') && check_var('ARCH', 'aarch64') && check_var('DESKTOP', 'gnome')) {
+        push(@tags, 'displaymanager');
+    }
     # GNOME and KDE get into screenlock after 5 minutes without activities.
     # using multiple check intervals here then we can get the wrong desktop
     # screenshot at least in case desktop screenshot changed, otherwise we get
@@ -69,6 +73,10 @@ sub run {
     }
     # the last check after previous intervals must be fatal
     assert_screen \@tags, $check_interval;
+    if (match_has_tag('displaymanager')) {
+        record_soft_failure 'boo#1102563';
+        handle_login;
+    }
     if (match_has_tag('kde-greeter')) {
         send_key "esc";
         assert_screen 'generic-desktop';


### PR DESCRIPTION
- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=1102563
- Needles: no update needed
- Verification run: tested on a personal instance of os-autoinst with TW snapshot 20180722 with GNOME test
