### PR TITLE
Workaround sporadic issue with steam.pm

### DIFF
--- a/tests/x11/steam.pm
+++ b/tests/x11/steam.pm
@@ -38,8 +38,14 @@ sub run {
 'find $HOME/.steam/root/ubuntu12_32/steam-runtime/*/usr/lib/ \( -name "libstdc++.so.6" -o -name "libgpg-error.so.0" -o -name "libxcb.so.1" -o -name "libgcc_s.so.1" \) -exec mv "{}" "{}.bak" \; -print';
         script_run 'steam', 0;
     }
-    assert_screen 'steam-login', 600;
-    send_key 'alt-f4';
+    # record_soft_failure for issue with steamAPI_Init
+    assert_screen [qw(steam-login steamapi-init-failed)], 600;
+    if (match_has_tag 'steamapi-init-failed') {
+        send_key 'alt-f4';
+        record_soft_failure 'bsc#1102525, steamAPI_Init failed';
+    }
+    wait_screen_change { send_key 'alt-f4' };
+    wait_still_screen(3);
     script_run 'exit', 0;
 }
 


### PR DESCRIPTION
- add softfail for https://bugzilla.opensuse.org/show_bug.cgi?id=1102525
- add wait_screen_change and wait_still_screen to fix issue with send_key
- see https://progress.opensuse.org/issues/36337 for more details
- verification runs:
  http://e13.suse.de/tests/7080#step/steam
  http://e13.suse.de/tests/7073#step/steam
- needle PR: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/400
