### PR TITLE
Ensure we are logged in before leaving, when in boo#1102563 case

### DIFF
--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -76,6 +76,7 @@ sub run {
     if (match_has_tag('displaymanager')) {
         record_soft_failure 'boo#1102563';
         handle_login;
+        assert_screen 'generic-desktop';
     }
     if (match_has_tag('kde-greeter')) {
         send_key "esc";


### PR DESCRIPTION
This fixes https://openqa.opensuse.org/tests/713800 