### PR TITLE
Fix pidgin test for SLE15

### DIFF
--- a/tests/x11/pidgin/pidgin_IRC.pm
+++ b/tests/x11/pidgin/pidgin_IRC.pm
@@ -15,12 +15,15 @@
 use base "x11test";
 use strict;
 use testapi;
-
+use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
     my $CHANNELNAME = "susetesting";
     x11_start_program('pidgin');
+
+    # Focus the welcome window in SLE15
+    assert_and_click("pidgin-welcome-not-focused") if is_sle('>=15');
 
     # Create account
     wait_screen_change { send_key "alt-a" };
@@ -57,13 +60,22 @@ sub run {
     send_key "alt-j";
 
     # Should open sledtesting channel
-    assert_screen 'pidgin-irc-sledtesting';
+    # we need to switch tabs on SLE15
+    if (is_sle('>=15')) {
+        assert_and_click 'pidgin-irc-sledtesting';
+    }
+    else {
+        assert_screen 'pidgin-irc-sledtesting';
+    }
 
     # Send a message
     send_key "alt-tab";
     type_string "Hello from openQA\n";
     assert_screen 'pidgin-irc-msgsent';
     wait_screen_change { send_key "ctrl-w" };
+
+    # There is another tab to close on SLE15
+    wait_screen_change { send_key "ctrl-w" } if is_sle('>=15');
 
     # Cleaning
     $self->pidgin_remove_account;

--- a/tests/x11/pidgin/prep_pidgin.pm
+++ b/tests/x11/pidgin/prep_pidgin.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,7 @@ use base "x11test";
 use strict;
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
     mouse_hide(1);
@@ -26,9 +26,13 @@ sub run {
     x11_start_program('pidgin');
     send_key "alt-c";
 
-    # pidgin main winodow is hidden in tray at first run
-    # need to show up the main window
-    if (sle_version_at_least('12-SP2')) {
+    # pidgin main window is hidden in tray at first run
+    # need to show up the main window (12-SP2 and SP3)
+    # the main window is shown correctly in SLE15
+    if (is_sle('>=15')) {
+        wait_still_screen;
+    }
+    elsif (is_sle('>=12-sp2')) {
         hold_key "ctrl-alt";
         send_key "tab";
         wait_still_screen;


### PR DESCRIPTION
Pidgin has slightly different behavior on SLE15

- Related ticket: https://progress.opensuse.org/issues/37680
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/896
- Verification runs:
    - http://panigale.suse.cz/tests/2494
    - http://panigale.suse.cz/tests/2495
    - http://panigale.suse.cz/tests/2497
