### PR TITLE
Use "x11test" as base for start_wayland_plasma5 to gather logs

### DIFF
--- a/tests/x11/start_wayland_plasma5.pm
+++ b/tests/x11/start_wayland_plasma5.pm
@@ -10,7 +10,7 @@
 # Summary: Prepare for wayland and log out of X11 and into wayland
 # Maintainer: Fabian Vogt <fvogt@suse.com>
 
-use base "opensusebasetest";
+use base "x11test";
 use strict;
 use testapi;
 use utils;


### PR DESCRIPTION
- Verification run: http://10.160.67.86/tests/126
