### PR TITLE
LTP: Upload kernel config

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -268,6 +268,8 @@ sub run {
         assert_script_run("uname -v | grep -E '(/kGraft-|/lp-)'");
     }
 
+    upload_logs('/boot/config-$(uname -r)', failok => 1);
+
     add_we_repo_if_available;
     if (is_sle('12+') || is_opensuse) {
         add_custom_grub_entries;


### PR DESCRIPTION
Useful for debugging

- Verification run: http://quasar.suse.cz/tests/609#downloads
contains install_ltp-config-4.12.14-94.28-default
http://quasar.suse.cz/tests/609/file/install_ltp-config-4.12.14-94.28-default