### PR TITLE
Use case-insensitive match to avoid wrong judgement

### DIFF
--- a/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
@@ -29,7 +29,7 @@ sub run {
     ($host_installed_version) = $host_installed_version =~ /^(\d+)/;
     #get the version that the host should upgrade to
     my $host_upgrade_version = get_required_var('UPGRADE_PRODUCT');                        #format sles-15-sp0
-    ($host_upgrade_version) = $host_upgrade_version =~ /sles-(\d+)-sp/;
+    ($host_upgrade_version) = $host_upgrade_version =~ /sles-(\d+)-sp/i;
     print("Debug info for reboot_and_wait_up_upgrade: host_installed_version is $host_installed_version, host_upgrade_version is $host_upgrade_version.\n");
     #online upgrade actually
     if ("$host_installed_version" eq "$host_upgrade_version") {


### PR DESCRIPTION
Sometimes settings of openQA testsuites use either lower- or upper-case characters. This may cause test flow failure because certain test module fails to make right decision with case-sensitive match, for example, ($host_upgrade_version) = $host_upgrade_version =~ /sles-(\d+)-sp/ in reboot_and_wait_up_upgrade.

- Related ticket: https://openqa.suse.de/tests/1853612#comments
- Needles: Using https://gitlab.suse.de/openqa/os-autoinst-needles-sles
- Verification run: https://10.67.17.5/tests/376

@alice-suse @XGWang0 @guoxuguang @Julie-CAO
