### PR TITLE
Fix update tests by not relying on download.o.o

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -252,7 +252,9 @@ sub is_kernel_test {
 }
 
 sub replace_opensuse_repos_tests {
+    return if get_var('CLEAR_REPOS');
     loadtest "update/zypper_clear_repos";
+    set_var('CLEAR_REPOS', 1);
     loadtest "console/zypper_ar";
     loadtest "console/zypper_ref";
 }
@@ -273,6 +275,7 @@ sub is_repo_replacement_required {
       && !is_staging()                    # Do not have mirrored repos on staging
       && !get_var('KEEP_ONLINE_REPOS')    # Set variable no to replace variables
       && get_var('SUSEMIRROR')            # Skip if required variable is not set (leap live tests)
+      && !get_var('ZYPPER_ADD_REPOS')     # Skip if manual repos are specified
       && !get_var('OFFLINE_SUT');         # Do not run if SUT is offine
 }
 
@@ -610,7 +613,7 @@ sub installwithaddonrepos_is_applicable {
 }
 
 sub need_clear_repos {
-    return (is_opensuse && is_staging()) || (is_sle && get_var("FLAVOR", '') =~ m/^Staging2?[\-]DVD$/ && get_var("SUSEMIRROR"));
+    return (is_opensuse && !is_updates_tests) || (is_sle && get_var("FLAVOR", '') =~ m/^Staging2?[\-]DVD$/ && get_var("SUSEMIRROR"));
 }
 
 sub have_scc_repos {
@@ -1935,8 +1938,13 @@ sub load_system_update_tests {
 
     return if get_var('SYSTEM_UPDATED');
     if (need_clear_repos() && !get_var('CLEAR_REPOS')) {
-        loadtest "update/zypper_clear_repos";
-        set_var('CLEAR_REPOS', 1);
+        if (is_repo_replacement_required()) {
+            replace_opensuse_repos_tests;
+        }
+        else {
+            loadtest "update/zypper_clear_repos";
+            set_var('CLEAR_REPOS', 1);
+        }
     }
     loadtest "console/zypper_add_repos" if get_var('ZYPPER_ADD_REPOS');
     return unless updates_is_applicable();


### PR DESCRIPTION
Schedule zypper_clear_repos before installing updates

https://progress.opensuse.org/issues/38393

When we do an openSUSE installation in openQA it will get the download.opensuse.org repos added by the installer.
This can lead to problems as the updates will get installed from the doo repos (from the old snapshot).