### PR TITLE
LTP: Upload missing dmesg output

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -299,6 +299,9 @@ sub run {
 sub post_fail_hook {
     my $self = shift;
 
+    script_run("dmesg > /tmp/dmesg.txt");
+    upload_logs("/tmp/dmesg.txt", failok => 1);
+
     # bsc#1024050
     script_run('pkill pidstat');
     upload_logs('/tmp/pidstat.txt', failok => 1);

--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -39,6 +39,9 @@ sub run {
         upload_logs($ver_linux_log, failok => 1);
     }
 
+    script_run("dmesg > /tmp/dmesg.txt");
+    upload_logs("/tmp/dmesg.txt", failok => 1);
+
     script_run('[ "$ENABLE_WICKED" ] && systemctl enable wicked');
     script_run('journalctl --no-pager -p warning');
     power_action('poweroff');


### PR DESCRIPTION
This output is not needed for intel archs, but let's upload it
for it as well.

Fixes: poo#38915

- Verified run
http://quasar.suse.cz/tests/614#downloads
http://quasar.suse.cz/tests/614/file/shutdown_ltp-dmesg.txt
http://quasar.suse.cz/tests/615#downloads
http://quasar.suse.cz/tests/615/file/shutdown_ltp-dmesg.txt