### PR TITLE
[NFV] Add support for SLE12 SP4

### DIFF
--- a/data/nfv/sles/12.4/build_base_machine.sh
+++ b/data/nfv/sles/12.4/build_base_machine.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+zypper -q -n in -y $(echo "
+# compiler, tools and dependencies
+make
+automake
+gcc
+gcc-c++
+glibc
+glibc-devel
+fuse
+fuse-devel
+glib2-devel
+zlib-devel
+kernel-default
+kernel-default-devel
+pkg-config
+findutils-locate
+curl
+automake
+autoconf
+vim
+wget
+git-core
+pciutils
+cifs-utils
+socat
+sysstat
+java-1_8_0-openjdk
+mlocate
+
+python-setuptools
+python3-setuptools
+python3-devel
+
+# libraries
+libnuma1
+libnuma-devel
+libpixman-1-0
+libpixman-1-0-devel
+libtool
+libpcap-devel
+libnet9
+libncurses6
+libcurl4
+libcurl-devel
+libxml2
+libfuse2
+libopenssl1_0_0
+libopenssl-devel
+libpython3_4m1_0
+libzmq3
+
+" | grep -v ^#)
+
+wget -q http://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-12/standard/x86_64/sshpass-1.06-2.1.x86_64.rpm
+rpm -i sshpass-1.06-2.1.x86_64.rpm
+zypper ar -f -G https://download.opensuse.org/repositories/devel:/languages:/python:/backports/SLE_12_SP3/devel:languages:python:backports.repo
+zypper -q in -y -r devel_languages_python_backports python-pip python3-pip python3-tk
+pip install -q --upgrade pip
+pip3 install -q --upgrade pip
+zypper rr devel_languages_python_backports
+
+updatedb
+ln -sf $(locate libc.so.6) /lib/libc.so.6
+pip3 install -q virtualenv
+mkdir -p /dev/hugepages
+
+VSPERFENV_DIR="/root/vsperfenv"
+if [ -d "$VSPERFENV_DIR" ] ; then
+    echo "Directory $VSPERFENV_DIR already exists. Skipping python virtualenv creation."
+    exit
+fi
+
+cd /root/vswitchperf/systems/
+virtualenv "$VSPERFENV_DIR" --python /usr/bin/python
+source "$VSPERFENV_DIR"/bin/activate
+pip3 install -q -r ../requirements.txt

--- a/tests/kernel/mellanox_config.pm
+++ b/tests/kernel/mellanox_config.pm
@@ -31,7 +31,9 @@ sub run {
     my $mft_version = get_required_var('MFT_VERSION');
     my $protocol = get_var('MLX_PROTOCOL') || 2;
 
-    zypper_call('ar -f -G ' . get_required_var('GA_REPO'));
+    if (check_var('VERSION', '15')) {
+        zypper_call('ar -f -G ' . get_required_var('GA_REPO'));
+    }
     zypper_call('--quiet in kernel-source rpm-build', timeout => 200);
 
     # Install Mellanox Firmware Tool (MFT)
@@ -61,7 +63,7 @@ sub run {
     show_links();
 
     # Reboot system
-    power_action('reboot', keepconsole => 1);
+    power_action('reboot', textmode => 1, keepconsole => 1);
 }
 
 sub test_flags {
@@ -69,4 +71,3 @@ sub test_flags {
 }
 
 1;
-

--- a/tests/nfv/prepare_env.pm
+++ b/tests/nfv/prepare_env.pm
@@ -23,35 +23,61 @@ use base "opensusebasetest";
 use testapi;
 use strict;
 use utils;
+use lockapi;
+use mmapi;
 use serial_terminal 'select_virtio_console';
 
 sub run {
     my $vsperf_repo = "https://gerrit.opnfv.org/gerrit/vswitchperf";
     my $dpdk_repo   = "http://dpdk.org/git/dpdk";
+    my $host1       = get_required_var('NFVTEST_IP1');
+    my $host2       = get_required_var('NFVTEST_IP2');
+    my $children    = get_children();
+    my $child_id    = (keys %$children)[0];
 
     select_virtio_console();
 
     zypper_call('--quiet in git-core openvswitch-switch dpdk qemu tcpdump', timeout => 200);
 
     # Clone repositories
+    assert_script_run("cd /root/");
     assert_script_run("git clone --quiet --depth 1 $vsperf_repo");
     assert_script_run("git clone --quiet --depth 1 $dpdk_repo");
 
     # Start the openvswitch daemon
-    systemctl 'start openvswitch', timeout => 200;
-
-    # Make sure that basic OVS commands work
-    assert_script_run("ovs-vsctl add-br ovs-openqa-br0");
-    assert_script_run("ovs-vsctl set-fail-mode ovs-openqa-br0 standalone");
-    assert_script_run("ovs-vsctl get-fail-mode ovs-openqa-br0 | grep standalone");
-    assert_script_run("ovs-vsctl show");
-    assert_script_run("ovs-vsctl del-br ovs-openqa-br0");
+    systemctl 'enable openvswitch', timeout => 200;
+    systemctl 'start openvswitch',  timeout => 200;
 
     # VSPerf Installation
     assert_script_run("cd vswitchperf/systems");
-    # Hack to skip the OVS, DPDK and QEMU compilation as SLE15 will use the vanilla packages
-    assert_script_run("sed -n -e :a -e '1,8!{P;N;D;};N;ba' -i build_base_machine.sh");
-    assert_script_run("bash -x build_base_machine.sh", 300);
+    if (check_var('VERSION', '15')) {
+        # Hack to skip the OVS, DPDK and QEMU compilation as we will use the vanilla packages
+        assert_script_run("sed -n -e :a -e '1,8!{P;N;D;};N;ba' -i build_base_machine.sh");
+        zypper_call('ar -f http://download.suse.de/ibs/SUSE:/SLE-12:/GA/standard/SUSE:SLE-12:GA.repo SLE-12-GA-REPO');
+        assert_script_run("bash -x build_base_machine.sh", 300);
+    }
+    elsif (check_var('VERSION', '12-SP4')) {
+        assert_script_run("curl " . data_url('nfv/sles/12.4/build_base_machine.sh') . " -o /root/build_base_machine.sh");
+        assert_script_run("chmod 755 /root/build_base_machine.sh");
+        assert_script_run("bash -x /root/build_base_machine.sh", timeout => 500);
+    }
+    else {
+        die "OS VERSION not supported. Available only on 15 and 12-SP4";
+    }
+    assert_script_run("cd /root/vswitchperf/src/trex; make");
+
+    # Setup ssh keys, wait until trafficgen machine is up and ready
+    mutex_wait('NFV_trafficgen_ready', $child_id);
+    assert_script_run('ssh-keygen -b 2048 -t rsa -q -N "" -f ~/.ssh/id_rsa');
+    exec_and_insert_password("ssh-copy-id -o StrictHostKeyChecking=no root\@$host1");
+    exec_and_insert_password("ssh-copy-id -o StrictHostKeyChecking=no root\@$host2");
+
+    # Bring mellanox interfaces up
+    assert_script_run("ip link set dev eth2 up");
+    assert_script_run("ip link set dev eth2 up");
+
+    mutex_create("NFV_testing_ready");
+    wait_for_children;
 }
 
 sub test_flags {
@@ -59,4 +85,3 @@ sub test_flags {
 }
 
 1;
-

--- a/tests/nfv/trex_installation.pm
+++ b/tests/nfv/trex_installation.pm
@@ -15,6 +15,7 @@ use base "opensusebasetest";
 use testapi;
 use strict;
 use utils;
+use lockapi;
 use mmapi;
 
 sub run {
@@ -39,10 +40,16 @@ sub run {
     assert_script_run("sed -i 's/PORT_1/$PORT_2/' -i $trex_conf");
     assert_script_run("cat $trex_conf");
 
+    assert_script_run("ip link set dev eth2 up");
+    assert_script_run("ip link set dev eth3 up");
+
+    mutex_create("NFV_trafficgen_ready");
+
     # Start daemon
     assert_script_run("cd $trex_dest");
     assert_script_run("./trex_daemon_server start");
+
+    mutex_wait('NFV_testing_ready');
 }
 
 1;
-


### PR DESCRIPTION
This modifies the current scripts to support all the packaging needed for SLE12 SP4. So far, only SLE15 was supported. Besides that, there are some minor additions (i.e. ssh keys) to be able to execute the tests on bare metal.

- Related ticket: https://progress.opensuse.org/issues/37075

- Verification runs:
  http://loewe.arch.suse.de/tests/969
  http://loewe.arch.suse.de/tests/970

