### PR TITLE
xfstests: make XFSTESTS_RANGES support separate single tests

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -168,8 +168,14 @@ sub tests_from_ranges {
     foreach my $range (split(/,/, $ranges)) {
         my ($min, $max) = (0, 99999);
         my ($category, $min_max) = split(/\//, $range);
-        if (defined($min_max)) {
+        unless (defined($min_max)) {
+            next;
+        }
+        if ($min_max =~ /\d+-\d+/) {
             ($min, $max) = split(/-/, $min_max);
+        }
+        else {
+            $min = $max = $min_max;
         }
         unless (exists($cache{$category})) {
             $cache{$category} = [tests_from_category($category, $dir)];


### PR DESCRIPTION
`XFSTESTS_RANGES` (one parameter in osd for xfstests) could only be a range (e.g. generic/140-145) if configure tests separate it will not run at all(e.g. `generic/140,generic/143,generic/144`).

It will fails shows in "generate_report", but the problem is in "run" step.
http://10.67.133.102/tests/576

In fixed code, `$min_max` could be a test number or a test range, e.g. 140 or 140-143

- Related ticket: https://progress.opensuse.org/issues/38927
- Verification run: http://10.67.133.102/tests/577
