### PR TITLE
Increase boot timeout for grub test

### DIFF
--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -93,7 +93,8 @@ sub run {
     $self->handle_installer_medium_bootup;
     workaround_type_encrypted_passphrase;
     # 60 due to rare slowness e.g. multipath poo#11908
-    assert_screen 'grub2', 60;
+    # 90 as a workaround due to the qemu backend fallout
+    assert_screen 'grub2', 90;
     stop_grub_timeout;
     set_vmware_videomode if check_var('VIRSH_VMM_FAMILY', 'vmware');
     boot_into_snapshot if get_var("BOOT_TO_SNAPSHOT");


### PR DESCRIPTION
Since recent changes in the backend, bootorder is not the same anymore,
therefore that part of the code needs to be handled somewhere, for the
time being, wait a just wait bit more so the timeout boots from the hard
disk.