### PR TITLE
Clean up redundant physical disks before offline host upgrade

### DIFF
--- a/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
@@ -14,7 +14,8 @@ use strict;
 use warnings;
 use File::Basename;
 use testapi;
-use base "reboot_and_wait_up";
+use virt_utils 'clean_up_red_disks';
+use base 'reboot_and_wait_up';
 
 sub run {
     my $self = shift;
@@ -30,17 +31,18 @@ sub run {
     #get the version that the host should upgrade to
     my $host_upgrade_version = get_required_var('UPGRADE_PRODUCT');                        #format sles-15-sp0
     ($host_upgrade_version) = $host_upgrade_version =~ /sles-(\d+)-sp/i;
-    print("Debug info for reboot_and_wait_up_upgrade: host_installed_version is $host_installed_version, host_upgrade_version is $host_upgrade_version.\n");
+    diag("Debug info for reboot_and_wait_up_upgrade: host_installed_version is $host_installed_version, host_upgrade_version is $host_upgrade_version");
     #online upgrade actually
     if ("$host_installed_version" eq "$host_upgrade_version") {
         set_var("offline_upgrade", "no");
         $timeout = 120;
-        print("Debug info for reboot_and_wait_up_upgrade: this is online upgrade.\n");
+        diag("Debug info for reboot_and_wait_up_upgrade: this is online upgrade");
     }
     else {
         #OpenQA needs ssh way to trigger offline upgrade
         script_run("sed -i s/sshd=1/ssh=1/g /boot/grub2/grub.cfg /boot/grub/menu.lst");
-        print("Debug info for reboot_and_wait_up_upgrade: this is offline upgrade.\n");
+        diag("Debug info for reboot_and_wait_up_upgrade: this is offline upgrade. Need to clean up redundant disks using clean_up_red_disks.");
+        clean_up_red_disks;
     }
 
     $self->reboot_and_wait_up($timeout);


### PR DESCRIPTION
This modification is to solve the issue that offline product upgrade does not automatically mount highlighted product os to be upgraded if more that one physical disks exist, especially when these redundant disks also have os installed on themselves. So openQA test run will wait till time out at "Select upgrade product" step, which may fail many test cases using similar environment.

- Related ticket: https://openqa.suse.de/tests/1865229#step/reboot_and_wait_up_upgrade/29
- Needles: N/A
- Verification run: https://10.67.17.5/tests/419#step/reboot_and_wait_up_upgrade/7

@alice-suse @XGWang0 @xguo @Julie-CAO