### PR TITLE
 Synchronization update of yast2 lan gui wizard

### DIFF
--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -46,6 +46,7 @@ sub initialize_y2lan {
 sub open_network_settings {
     type_string "yast2 lan\n";
     assert_screen 'yast2_lan', 100;       # yast2 lan overview tab
+    wait_still_screen(2);
 }
 
 sub close_network_settings {

--- a/tests/x11/yast2_lan_restart_devices.pm
+++ b/tests/x11/yast2_lan_restart_devices.pm
@@ -67,7 +67,7 @@ sub add_device {
     elsif ($device eq 'VLAN') {
         send_key 'alt-v';
         send_key 'tab';
-        type_string '12';
+        wait_screen_change { type_string '12' };
         send_key 'alt-n';
     }
     else {
@@ -115,10 +115,10 @@ sub delete_device {
     save_screenshot;
     send_key 'alt-i';    # Edit NIC
     assert_screen 'yast2_lan_network_card_setup';
-    send_key 'alt-y';    # Dynamic address
-    send_key 'alt-n';    # Next
+    wait_screen_change { send_key 'alt-y' };    # Dynamic address
+    send_key 'alt-n';                           # Next
     close_network_settings;
-    assert_script_run '> journal.log';    # clear journal.log
+    assert_script_run '> journal.log';          # clear journal.log
 }
 
 sub check_device {


### PR DESCRIPTION
- Related ticket: [[opensuse][functional][y][sporadic] yast2_lan_restart_devices module is not closed when expected](https://progress.opensuse.org/issues/36748)
- Verification run: [sle12sp4](http://dhcp128.suse.cz/tests)
