### PR TITLE
 Add softfail bsc1017558:truncated timestamps

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -189,6 +189,7 @@ sub boot_local_disk {
 sub boot_into_snapshot {
     send_key_until_needlematch('boot-menu-snapshot', 'down', 10, 5);
     send_key 'ret';
+    record_soft_failure 'bsc#1017558:Cannot view timestamp of read-only snapshots in GRUB as names truncated' if is_leap;
     # assert needle to avoid send down key early in grub_test_snapshot.
     assert_screen 'snap-default' if get_var('OFW');
     # in upgrade/migration scenario, we want to boot from snapshot 1 before migration.


### PR DESCRIPTION
- Related ticket: [[functional][y] Reproduce bsc#1017558 "Cannot view timestamp of read-only snapshots in GRUB as names truncated"](https://progress.opensuse.org/issues/33274)
- Verification run: [opensuse-15.1-DVD-x86_64-Build272.2-boot_to_snapshot@64bit ](http://dhcp128.suse.cz/tests/4797#step/grub_test/6)
