### PR TITLE
Adjust vnc-start-server needle timeout

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -109,7 +109,7 @@ sub run {
     save_screenshot;
 
     if ((check_var('BACKEND', 'ipmi') && !get_var('AUTOYAST')) || get_var('SES5_DEPLOY')) {
-        my $ssh_vnc_wait_time = get_var('SES5_DEPLOY') ? 300 : 180;
+        my $ssh_vnc_wait_time = get_var('SES5_DEPLOY') ? 300 : 210;
         assert_screen((check_var('VIDEOMODE', 'text') ? 'sshd' : 'vnc') . '-server-started', $ssh_vnc_wait_time);
         select_console 'installation';
 


### PR DESCRIPTION
- Related ticket: [[functional][y][sporadic][ipmi] test fails in boot_from_pxe - installer does not show up](https://progress.opensuse.org/issues/38411)
- Verification run: [sle-12-SP4-Server-DVD-x86_64-Build0290-default@64bit-ipmi ](http://dhcp128.suse.cz/tests/4808#step/boot_from_pxe/6)
