### PR TITLE
Include virt_utils to use specific subroutines

### DIFF
--- a/tests/virt_autotest/host_upgrade_generate_run_file.pm
+++ b/tests/virt_autotest/host_upgrade_generate_run_file.pm
@@ -15,6 +15,7 @@ use base "host_upgrade_base";
 use strict;
 use warnings;
 use testapi;
+use virt_utils;
 
 sub get_script_run {
     my $pre_test_cmd;


### PR DESCRIPTION
Include virt_utils to use specific subroutines. "use virt_utils" is missing from lib/host_upgrade_generate_run_file.pm. 

- Related ticket: http://openqa.suse.de/tests/1874312/modules/host_upgrade_generate_run_file/steps/1/src
- Needles: Using https://gitlab.suse.de/openqa/os-autoinst-needles-sles
- Verification run: http://localhost/tests/376/modules/host_upgrade_generate_run_file/steps/1/src

@alice-suse @XGWang0 @xguo @Julie-CAO
