### PR TITLE
Increase timeout for firefox default checks

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -527,7 +527,7 @@ sub start_firefox {
 
 sub firefox_check_default {
     # Set firefox as default browser if asked
-    assert_screen [qw(firefox_default_browser firefox_trackinfo firefox_readerview_window firefox_clean)], 120;
+    assert_screen [qw(firefox_default_browser firefox_trackinfo firefox_readerview_window firefox_clean)], 150;
     if (match_has_tag('firefox_default_browser')) {
         wait_screen_change {
             assert_and_click 'firefox_default_browser_yes';


### PR DESCRIPTION
Now very often basic firefox tests fail in x11/firefox because of new html5 tests are expanded and get longer execution time