### PR TITLE
[NFV] Add Performance tests

### DIFF
--- a/data/nfv/conf/00_common.conf
+++ b/data/nfv/conf/00_common.conf
@@ -1,0 +1,154 @@
+# Copyright 2015-2017 Intel Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ###########################
+# Common setting potentially accessed by all components.
+# ###########################
+
+import os
+import copy
+
+# default language and encoding, which will be set in case
+# that locale is not set properly
+DEFAULT_LOCALE = 'en_US.UTF-8'
+
+# default language and encoding, which will be used by external
+# commands; This values will be set in case, that VSPERF parses
+# command output.
+DEFAULT_CMD_LOCALE = 'en_US.UTF-8'
+
+# ############################
+# Directories
+# ############################
+
+ROOT_DIR = os.path.normpath(os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), '../'))
+TRAFFICGEN_DIR = os.path.join(ROOT_DIR, 'tools/pkt_gen')
+SYSMETRICS_DIR = os.path.join(ROOT_DIR, 'tools/collectors')
+
+# Dictionary PATHS is used for configuration of vswitches, dpdk and qemu.
+# It contains paths to various utilities, temporary directories and kernel
+# modules used by VSPERF. Particular sections of PATHS dictionary are spread
+# among several configuration files, i.e.:
+# conf/02_vswtich.conf - configuration of vswitches (i.e. PATHS['vswitch'])
+#                        and dpdk (i.e. PATHS['dpdk']) can be found there
+# conf/04_vnf.conf     - configuration of qemu (i.e. PATHS['qemu']) can
+#                        be found there
+#
+# VSPERF will process PATHS dictionary before execution of every testcase
+# and it will create a testcase specific dictionary TOOLS with paths to the
+# utilities used by the test. During PATHS processing, following rules
+# will apply for every item of PATHS dictionary:
+#     item 'type' - string, which defines the type of paths ('src' or 'bin') to be selected
+#           for a given section:
+#               'src' means, that VSPERF will use OVS, DPDK or QEMU built from sources
+#                   e.g. by execution of systems/build_base_machine.sh script during VSPERF
+#                   installation
+#               'bin' means, that VSPERF will use OVS, DPDK or QEMU binaries installed
+#                   in the OS, e.g. via OS specific packaging system
+#     item 'path' - string with valid path; Its content is checked for existence, prefixed
+#           with section name and stored into TOOLS for later use
+#           e.g. TOOLS['dpdk_src'] or TOOLS['vswitch_src']
+#     item 'modules' - list of strings; Every value from given list is checked for '.ko'
+#           suffix. In case it matches and it is not an absolute path to the module, then
+#           module name is prefixed with 'path' defined for the same section
+#           e.g. TOOLS['vswitch_modules'] = [
+#               '/tmp/vsperf/src_vanilla/ovs/ovs/datapath/linux/openvswitch.ko']
+#     all other items - string - if given string is a relative path and item 'path'
+#           is defined for a given section, then item content will be prefixed with
+#           content of the 'path'. Otherwise tool name will be searched within
+#           standard system directories. Also any OS filename wildcards will be
+#           expanded to the real path. At the end of processing, every absolute
+#           path is checked for its existence. In case that temporary path (i.e. path
+#           with '_tmp' suffix) doesn't exist, then log will be written and vsperf will
+#           continue. If any other path will not exist, then vsperf execution will
+#           be terminated with runtime error.
+#
+# Note: In case that 'bin' type is set for DPDK, then TOOLS['dpdk_src'] will be set to
+# the value of PATHS['dpdk']['src']['path']. The reason is, that VSPERF uses downloaded
+# DPDK sources to copy DPDK and testpmd into the GUEST, where testpmd is built. In case,
+# that DPDK sources are not available, then vsperf will continue with test execution,
+# but testpmd can't be used as a guest loopback. This is useful in case, that other guest
+# loopback applications (e.g. buildin) are used by CI jobs, etc.
+PATHS = {}
+
+# ############################
+# Process configuration
+# ############################
+
+# shell command to use when running commands through Pexpect
+SHELL_CMD = ['/bin/bash', '-c']
+
+# ############################
+# Logging configuration
+# ############################
+
+# default log output directory for all logs
+LOG_DIR = '/tmp'
+
+# default log for all "small" executables
+LOG_FILE_DEFAULT = 'overall.log'
+
+# log file for all commands executed on host
+LOG_FILE_HOST_CMDS = 'host-cmds.log'
+
+# ############################
+# Test configuration
+# ############################
+
+# verbosity of output to 'stdout'
+# NOTE: output to log files is always 'debug' level
+VERBOSITY = 'debug'
+
+# dictionary of test-specific parameters. These values are accessible
+# from anywhere in the test framework so be careful with naming
+# conventions
+TEST_PARAMS = {}
+
+# delay enforced after every step to allow system to process changes
+TEST_STEP_DELAY = 5
+
+# parameter used, when running mupltiple tests, to accumulate _PARAMS_LIST
+# parameters for multiple tests running in a series
+CUMULATIVE_PARAMS = False
+
+# metric used by the performance matrix for comparision and analysis
+# of tests run in a series. Must always refer to a numeric value.
+# For example: 'throughput_rx_mbps', 'throughput_rx_fps', 'avg_latency_ns'
+MATRIX_METRIC = 'throughput_rx_fps'
+
+# ############################
+# Modules
+# ############################
+
+# following modules will be excluded from automatic load by LoaderServant
+# it can be used to suppress automatic load of obsoleted or abstract modules
+# Example:
+#   EXCLUDE_MODULES = ['ovs_vanilla', 'qemu_virtio_net', 'pidstat']
+EXCLUDE_MODULES = ["testcenter-rfc2544-throughput"]
+
+# ############################
+# Vsperf Internal Options
+# ############################
+# following options should not be changed by the user
+
+# internal list to keep track of PIDs of jobs executed by vsperf
+_EXECUTED_PIDS = []
+
+# dictionary containing the test-specific parameters of all tests being run
+# for the purposes of cummulative parameter assignment using performance matrix
+_PARAMS_LIST = {}
+
+# index number of the current test, used for naming of result files
+_TEST_INDEX = 0

--- a/data/nfv/conf/01_testcases.conf
+++ b/data/nfv/conf/01_testcases.conf
@@ -1,0 +1,429 @@
+# Copyright 2015-2018 Intel Corporation., Tieto
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file describes a list of testcases.  Each testcase is described as a
+# dictionary in a list of dictionaries.
+#
+# The dictionary keys, their meanings and available values are:
+#
+# "Name": "phy2phy_burst",         # A human-readable string identifying the
+#                                  # test.
+# "Deployment": "p2p",             # One of the supported deployment scenarios.
+# "Description": "Lorem ipsum..."  # Optional. A human-readable string
+#                                  # describing the test.
+# "Frame Modification": "vlan"     # One of the supported frame modifications:
+#                                  # vlan, mpls, mac, dscp, ttl, ip_addr,
+#                                  # ip_port.
+# "Load": dictionary               # Optional. Configures background load
+#                                  # during testcase execution.
+#                                  # The tool used to generate load is
+#                                  # defined  by LOADGEN configuration.
+#                                  # Default setting of Dummy can be found in
+#                                  # 07_loadgen.conf.
+#   Description of "Load" dictionary keys, their meanings and available values:
+#
+#   "load": 0-100                  # percentage of cores which should be
+#                                  # utilized by load generator
+#                                  # e.g. load = 70%, detected cpu cores = 14 =>
+#                                  # round(14*0.7)=10, i.e. 10 instances of load
+#                                  # generator will be executed
+#   "reserved": 0- (Default 0)     # Optional. Defines number of cores reserved
+#                                  # for vsperf
+#                                  # e.g. load = 80%, detected cpu cores = 14,
+#                                  # reserved = 4 => round((14-4)*0.8)=8,
+#                                  # i.e. 8 load gen. instances will be executed
+#   "pattern" : "c"                # stress/stress-ng specific; Number of 'c',
+#                                  # 'm' and 'i' defines ratio between cpu, mem
+#                                  # and io workers respectively
+#                                  # e.g. "ccccmmi" => ratio among workers types
+#                                  # will be 3:2:1, so in case that 12 stress
+#                                  # instances should be executed, then 6 cpu,
+#                                  # 4 memory and 2 io workers will be executed
+#   "load_memory": 0-100           # Optional. Defines percentage of the system
+#                                  # memory, which should be utilized by memory
+#                                  # workers (if they are part of "pattern").
+#                                  # if not specified then default stress(-ng)
+#                                  # value will be used
+#   "options": ""                  # Optional. Additional command line options
+#                                  # to be passed to the load generator.
+# "vSwitch" : "OvsVanilla"         # Defines vSwitch to be used for test execution.
+#                                  # It will override any VSWITCH option stated
+#                                  # in configuration files or value specified
+#                                  # on command line through --vswitch parameter.
+# "VNF" : "QemuVirtioNet"          # Defines VNF to be used for test execution.
+#                                  # It will override any VNF option stated
+#                                  # in configuration files or value specified
+#                                  # on command line through --vnf parameter.
+# "Trafficgen" : "Dummy"           # Defines traffic generator to be used for test
+#                                  # execution. It will override any VNF option
+#                                  # stated in configuration files or value
+#                                  # specified on command line through --trafficgen
+#                                  # parameter.
+# "Parameters" : {'TRAFFICGEN_PKT_SIZES' : (512,)},
+#                                  # Dictionary with testcase specific configuration
+#                                  # environment. Specified parameters will be modified
+#                                  # before the test execution and their original values will
+#                                  # be restored after TC finishes. This dictionary will
+#                                  # override any values defined by TEST_PARAMS option
+#                                  # stated in configuration files or values specified
+#                                  # on command line through --test-params parameter.
+#
+# "TestSteps": []                  # Definition of detailed test steps.
+#                                  # In case that this list is defined, then
+#                                  # vsperf will execute defined test steps
+#                                  # one by one. It can be used to configure
+#                                  # vswitch, insert flows and transmit traffic.
+#                                  # It is possible to refer to result of any
+#                                  # previous step through #STEP[i][j] macro.
+#                                  # Where i is a number of step (starts from 0)
+#                                  # and j is index of result returned by step i.
+# "Test Modifier": [FrameMod|Other],
+# "Dependency": [Test_Case_Name |None],
+
+#
+# Generic performance TC definitions
+#
+PERFORMANCE_TESTS = [
+    {
+        "Name": "phy2phy_tput",
+        "Deployment": "p2p",
+        "Description": "LTD.Throughput.RFC2544.PacketLossRatio",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_throughput",
+            },
+        },
+    },
+    {
+        "Name": "phy2phy_forwarding",
+        "Deployment": "p2p",
+        "Description": "LTD.Forwarding.RFC2889.MaxForwardingRate",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2889_forwarding",
+            },
+        },
+    },
+    {
+        "Name": "phy2phy_learning",
+        "Deployment": "p2p",
+        "Description": "LTD.AddrLearning.RFC2889.AddrLearningRate",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2889_learning",
+            },
+        },
+    },
+    {
+        "Name": "phy2phy_caching",
+        "Deployment": "p2p",
+        "Description": "LTD.AddrCaching.RFC2889.AddrCachingCapacity",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2889_caching",
+            },
+        },
+    },
+    {
+        "Name": "back2back",
+        "Deployment": "p2p",
+        "Description": "LTD.Throughput.RFC2544.BackToBackFrames",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_back2back",
+            },
+        },
+    },
+    {
+        "Name": "phy2phy_tput_mod_vlan",
+        "Deployment": "p2p",
+        "Frame Modification": "vlan",
+        "Description": "LTD.Throughput.RFC2544.PacketLossRatioFrameModification",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_throughput",
+            },
+        },
+    },
+        {
+        "Name": "phy2phy_tput_mod_vlan_cont",
+        "Deployment": "p2p",
+        "Frame Modification": "vlan",
+        "Description": "Phy2Phy VLAN Continuous Stream",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_continuous",
+                "frame_rate" : 100,
+            },
+        },
+    },
+    {
+        "Name": "phy2phy_cont",
+        "Deployment": "p2p",
+        "Description": "Phy2Phy Continuous Stream",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_continuous",
+                "frame_rate" : 100,
+            },
+        },
+    },
+    {
+        "Name": "phy2phy_burst",
+        "Deployment": "p2p",
+        "Description": "Phy2Phy single burst of 1000 frames at 100% frame rate",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "burst",
+                "frame_rate" : 100,
+                "burst_size" : 1000,
+            },
+        },
+    },
+    {
+        "Name": "pvp_cont",
+        "Deployment": "pvp",
+        "Description": "PVP Continuous Stream",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_continuous",
+                "frame_rate" : 100,
+            },
+        },
+    },
+    {
+        "Name": "pvvp_cont",
+        "Deployment": "pvvp",
+        "Description": "PVVP Continuous Stream",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_continuous",
+                "frame_rate" : 100,
+            },
+        },
+    },
+    {
+        "Name": "pvpv_cont",
+        "Deployment": "pvpv",
+        "Description": "Two VMs in parallel with Continuous Stream",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_continuous",
+                "frame_rate" : 100,
+            },
+        },
+    },
+    {
+        "Name": "phy2phy_scalability",
+        "Deployment": "p2p",
+        "Description": "LTD.Scalability.Flows.RFC2544.0PacketLoss",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_throughput",
+                "multistream" : 8000,
+            },
+        },
+    },
+    {
+        "Name": "phy2phy_scalability_cont",
+        "Deployment": "p2p",
+        "Description": "Phy2Phy Scalability Continuous Stream",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_continuous",
+                "frame_rate" : 100,
+                "multistream" : 8000,
+            },
+        },
+    },
+    {
+        "Name": "pvp_tput",
+        "Deployment": "pvp",
+        "Description": "LTD.Throughput.RFC2544.PacketLossRatio",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_throughput",
+            },
+        },
+    },
+    {
+        "Name": "pvp_back2back",
+        "Deployment": "pvp",
+        "Description": "LTD.Throughput.RFC2544.BackToBackFrames",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_back2back",
+            },
+        },
+    },
+    {
+        "Name": "pvvp_tput",
+        "Collector": "cpu",
+        "Deployment": "pvvp",
+        "Description": "LTD.Throughput.RFC2544.PacketLossRatio",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_throughput",
+            },
+        },
+    },
+    {
+        "Name": "pvvp_back2back",
+        "Collector": "cpu",
+        "Deployment": "pvvp",
+        "Description": "LTD.Throughput.RFC2544.BackToBackFrames",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_back2back",
+            },
+        },
+    },
+    {
+        "Name": "phy2phy_cpu_load",
+        "Deployment": "p2p",
+        "Description": "LTD.CPU.RFC2544.0PacketLoss",
+        "Load" : {
+            "load" : 100,
+            "reserved" : 4,
+            "pattern" : "c",
+        },
+        "Parameters" : {
+            "LOADGEN" : "StressNg",
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_throughput",
+            },
+        },
+    },
+    {
+        "Name": "phy2phy_mem_load",
+        "Deployment": "p2p",
+        "Description": "LTD.Memory.RFC2544.0PacketLoss",
+        "Load" : {
+            "load" : 50,
+            "pattern" : "m",
+            "load_memory" : 80,
+        },
+        "Parameters" : {
+            "LOADGEN" : "StressNg",
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_throughput",
+            },
+        },
+    },
+    #
+    # Backward compatible definition of VPP TCs.
+    # It will be removed after CI reporting will be fixed to use
+    # default TCs for VPP reporting.
+    #
+    {
+        "Name": "phy2phy_tput_vpp",
+        "Deployment": "p2p",
+        "Description": "VPP: LTD.Throughput.RFC2544.PacketLossRatio",
+        "vSwitch" : "VppDpdkVhost",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_throughput",
+            },
+        },
+    },
+    {
+        "Name": "phy2phy_cont_vpp",
+        "Deployment": "p2p",
+        "Description": "VPP: Phy2Phy Continuous Stream",
+        "vSwitch" : "VppDpdkVhost",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_continuous",
+                "frame_rate" : 100,
+            },
+        },
+    },
+    {
+        "Name": "phy2phy_back2back_vpp",
+        "Deployment": "p2p",
+        "Description": "VPP: LTD.Throughput.RFC2544.BackToBackFrames",
+        "vSwitch" : "VppDpdkVhost",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_back2back",
+            },
+        },
+    },
+    {
+        "Name": "pvp_tput_vpp",
+        "Deployment": "pvp",
+        "Description": "VPP: LTD.Throughput.RFC2544.PacketLossRatio",
+        "vSwitch" : "VppDpdkVhost",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_throughput",
+            },
+        },
+    },
+    {
+        "Name": "pvp_cont_vpp",
+        "Deployment": "pvp",
+        "Description": "VPP: PVP Continuous Stream",
+        "vSwitch" : "VppDpdkVhost",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_continuous",
+            },
+        },
+    },
+    {
+        "Name": "pvp_back2back_vpp",
+        "Deployment": "pvp",
+        "Description": "VPP: LTD.Throughput.RFC2544.BackToBackFrames",
+        "vSwitch" : "VppDpdkVhost",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_back2back",
+            },
+        },
+    },
+    {
+        "Name": "pvvp_tput_vpp",
+        "Deployment": "pvvp",
+        "Description": "VPP: LTD.Throughput.RFC2544.PacketLossRatio",
+        "vSwitch" : "VppDpdkVhost",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_throughput",
+            },
+        },
+    },
+    {
+        "Name": "pvvp_cont_vpp",
+        "Deployment": "pvvp",
+        "Description": "VPP: PVP Continuous Stream",
+        "vSwitch" : "VppDpdkVhost",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_continuous",
+            },
+        },
+    },
+    {
+        "Name": "pvvp_back2back_vpp",
+        "Deployment": "pvvp",
+        "Description": "VPP: LTD.Throughput.RFC2544.BackToBackFrames",
+        "vSwitch" : "VppDpdkVhost",
+        "Parameters" : {
+            "TRAFFIC" : {
+                "traffic_type" : "rfc2544_back2back",
+            },
+        },
+    },
+]

--- a/data/nfv/conf/02_vswitch.conf
+++ b/data/nfv/conf/02_vswitch.conf
@@ -1,0 +1,250 @@
+# Copyright 2015-2018 Intel Corporation, Tieto and others.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# OVS Command timeout for execution of commands.
+OVS_CMD_TIMEOUT = 10
+
+# ############################
+# DPDK configuration
+# ############################
+
+# DPDK target used when builing DPDK
+RTE_TARGET = 'x86_64-native-linuxapp-gcc'
+
+# list of NIC HWIDs to which traffic generator is connected
+# e.g. WHITELIST_NICS = ['05:00.0', '05:00.1']
+# NIC HWIDs for given network device name can be retrieved
+# by call of ehtool:
+# e.g. ethtool -i eth0
+# In case of NIC with SRIOV support, it is possible to define,
+# which virtual function should be used
+# e.g. value '0000:05:00.0|vf1' will configure two VFs and second VF
+# will be used for testing
+WHITELIST_NICS = ['03:00.0', '03:00.1']
+
+# List defines an amount of memory to be allocated by DPDK at NUMA nodes. This
+# option is shared by all vSwitches with DPDK support. In case, that there is
+# a socket-mem configuration specified in vSwitch specific configuration option,
+# then it will be overridden by DPDK_SOCKET_MEM value.
+DPDK_SOCKET_MEM = ['1024', '0']
+
+# vhost character device file used by dpdkvhostport QemuWrap cases
+VHOST_DEV_FILE = 'ovs-vhost-net'
+
+# location of vhost-user sockets relative to 'ovs_var_tmp'
+VHOST_USER_SOCKS = 'dpdkvhostuser*'
+
+# please see conf/00_common.conf for description of PATHS dictionary
+PATHS['dpdk'] = {
+        'type' : 'bin',
+        'src': {
+            'path': os.path.join(ROOT_DIR, 'src/dpdk/dpdk/'),
+            # To use vfio set:
+            # 'modules' : ['uio', 'vfio-pci'],
+            'modules' : ['uio', os.path.join(RTE_TARGET, 'kmod/igb_uio.ko')],
+            'bind-tool': '*tools/dpdk*bind.py',
+            'testpmd': os.path.join(RTE_TARGET, 'app', 'testpmd'),
+        },
+        'bin': {
+            'bind-tool': '/usr/share/dpdk/tools/dpdk*bind.py',
+            'bind-tool': '/root/dpdk/usertools/dpdk-devbind.py',
+            'modules' : ['uio', 'igb_uio'],
+            'testpmd' : 'testpmd'
+        }
+    }
+
+# ############################
+# Directories
+# ############################
+VSWITCH_DIR = os.path.join(ROOT_DIR, 'vswitches')
+
+# please see conf/00_common.conf for description of PATHS dictionary
+# Every vswitch type supported by VSPERF must have its configuration
+# stored inside PATHS['vswitch']. List of all supported vswitches
+# can be obtained by call of ./vsperf --list-vswitches
+#
+# Directories defined by "ovs_var_tmp" and "ovs_etc_tmp" will be used
+# by OVS to temporarily store its configuration, pid and socket files.
+# In case, that these directories exist already, then their original
+# content will be restored after the testcase execution.
+
+PATHS['vswitch'] = {
+    'none' : {      # used by SRIOV tests
+        'type' : 'src',
+        'src' : {},
+    },
+    'OvsDpdkVhost': {
+        'type' : 'bin',
+        'src': {
+            'path': os.path.join(ROOT_DIR, 'src/ovs/ovs/'),
+            'ovs-vswitchd': 'vswitchd/ovs-vswitchd',
+            'ovsdb-server': 'ovsdb/ovsdb-server',
+            'ovsdb-tool': 'ovsdb/ovsdb-tool',
+            'ovsschema': 'vswitchd/vswitch.ovsschema',
+            'ovs-vsctl': 'utilities/ovs-vsctl',
+            'ovs-ofctl': 'utilities/ovs-ofctl',
+            'ovs-dpctl': 'utilities/ovs-dpctl',
+            'ovs-appctl': 'utilities/ovs-appctl',
+        },
+        'bin': {
+            'ovs-vswitchd': 'ovs-vswitchd',
+            'ovsdb-server': 'ovsdb-server',
+            'ovsdb-tool': 'ovsdb-tool',
+            'ovsschema': '/usr/share/openvswitch/vswitch.ovsschema',
+            'ovs-vsctl': 'ovs-vsctl',
+            'ovs-ofctl': 'ovs-ofctl',
+            'ovs-dpctl': 'ovs-dpctl',
+            'ovs-appctl': 'ovs-appctl',
+        }
+    },
+    'ovs_var_tmp': '/usr/local/var/run/openvswitch/',
+    'ovs_etc_tmp': '/usr/local/etc/openvswitch/',
+    'VppDpdkVhost': {
+        'type' : 'bin',
+        'src': {
+            'path': os.path.join(ROOT_DIR, 'src/vpp/vpp/build-root/install-vpp-native/vpp'),
+            'vpp': 'bin/vpp',
+            'vppctl': 'bin/vppctl',
+            'vpp_plugin_path' : 'lib64/vpp_plugins',
+        },
+        'bin': {
+            'vpp': 'vpp',
+            'vppctl': 'vppctl',
+            'vpp_plugin_path' : '/usr/lib/vpp_plugins',
+        }
+    },
+}
+
+# default OvsVanilla configuration is similar to OvsDpdkVhost except 'path' and 'modules'
+PATHS['vswitch'].update({'OvsVanilla' : copy.deepcopy(PATHS['vswitch']['OvsDpdkVhost'])})
+PATHS['vswitch']['OvsVanilla']['src']['path'] = os.path.join(ROOT_DIR, 'src_vanilla/ovs/ovs/')
+PATHS['vswitch']['OvsVanilla']['src']['modules'] = ['datapath/linux/openvswitch.ko']
+PATHS['vswitch']['OvsVanilla']['bin']['modules'] = ['openvswitch']
+
+# ############################
+# vswitch configuration
+# ############################
+# These are DPDK EAL parameters and they may need to be changed depending on
+# hardware configuration, like cpu numbering and NUMA.
+
+# parameters used for legacy DPDK configuration through '--dpdk' option of ovs-vswitchd
+# e.g. ovs-vswitchd --dpdk --socket-mem 1024,0
+# This config line is also used for pkt_fwd option (TestPMD phy2phy and pvp tests)
+# NOTE: DPDK socket mem allocation is driven by parameter DPDK_SOCKET_MEM
+VSWITCHD_DPDK_ARGS = ['-c', '0x4', '-n', '4']
+
+# options used for new type of OVS configuration via calls to ovs-vsctl
+# e.g. ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-socket-mem="1024,0"
+# NOTE: DPDK socket mem allocation is driven by parameter DPDK_SOCKET_MEM
+VSWITCHD_DPDK_CONFIG = {
+    'dpdk-init' : 'true',
+    'dpdk-lcore-mask' : '0x4',
+}
+# Note: VSPERF will automatically detect, which type of DPDK configuration should
+# be used.
+
+# Defines if VSWITCH should be a server for sockets of DPDK vhost-user
+# interfaces (True) or not (False). Support of vhost user server mode
+# in Open vSwitch is deprecated and will be removed in future releases.
+# Note: Qemu 2.7 and newer is required to support settings
+# VSWITCH_VHOSTUSER_SERVER_MODE = False
+VSWITCH_VHOSTUSER_SERVER_MODE = True
+
+# To enable multi queue with dpdk modify the below param to the number of
+# queues for dpdk. 0 = disabled
+VSWITCH_DPDK_MULTI_QUEUES = 0
+
+# Use old style OVS DPDK Multi-queue startup. If testing versions of OVS 2.5.0
+# or before, enable this setting to allow DPDK Multi-queue to enable correctly.
+OVS_OLD_STYLE_MQ = False
+
+# parameters passed to ovs-vswitchd in case that OvsVanilla is selected
+VSWITCHD_VANILLA_ARGS = []
+
+# Bridge name to be used by VSWTICH
+VSWITCH_BRIDGE_NAME = 'vsperf-br0'
+
+# A tunnel type used by OP2P and PTUNP deployments
+# Supported values: 'vxlan', 'gre' or 'geneve'
+TUNNEL_TYPE = 'vxlan'
+
+# directory where hugepages will be mounted on system init
+HUGEPAGE_DIR = '/dev/hugepages'
+
+# If no hugepages are available, try to allocate HUGEPAGE_RAM_ALLOCATION.
+# Default is 10 GB.
+# 10 GB (10485760 kB) or more is recommended for PVP & PVVP testing scenarios.
+HUGEPAGE_RAM_ALLOCATION = 10485760
+
+# Sets OVS PMDs core mask to 30 for affinitization to 5th and 6th CPU core.
+# Note that the '0x' notation should not be used.
+VSWITCH_PMD_CPU_MASK = '30'
+VSWITCH_AFFINITIZATION_ON = 1
+
+VSWITCH_FLOW_TIMEOUT = '30000'
+
+# log file for ovs-vswitchd
+LOG_FILE_VSWITCHD = 'vswitchd.log'
+
+# log file for ovs-dpdk
+LOG_FILE_OVS = 'ovs.log'
+
+# default vswitch implementation
+VSWITCH = "OvsDpdkVhost"
+
+VSWITCH_JUMBO_FRAMES_ENABLED = False
+VSWITCH_JUMBO_FRAMES_SIZE = 9000
+
+# default arguments of OVS ctl tools
+OVS_VSCTL_ARGS = []
+OVS_OFCTL_ARGS = ['-O', 'OpenFlow13']   # backward compatible default value
+OVS_APPCTL_ARGS = []
+
+# default flow template to be used by OVS classes
+OVS_FLOW_TEMPLATE = {
+    'idle_timeout': '0'
+}
+
+# enable or disable configuration of routing tables; See vswitchperf_design.rst
+# for details.
+OVS_ROUTING_TABLES = False
+
+#########################
+## VPP
+#########################
+# Set of arguments used for startup of VPP
+# NOTE: DPDK socket mem allocation is driven by parameter DPDK_SOCKET_MEM
+VSWITCH_VPP_CLI_SOCK = ''
+VSWITCH_VPP_ARGS = {
+    'unix' : [
+        'interactive',      # required by VSPERF to detect successful VPP startup
+        'log /tmp/vpp.log',
+        'full-coredump',
+    ],
+    'cpu' : [
+        'main-core 2',
+        'workers 2',
+        'corelist-workers 4,5',
+    ],
+}
+
+# log file for VPP
+LOG_FILE_VPP = 'vsperf-vpp.log'
+
+# Select l2 connection method used by VPP.
+# Supported values are: 'xconnect', 'l2patch' and 'bridge'
+VSWITCH_VPP_L2_CONNECT_MODE = 'xconnect'
+
+# Options used during creation of dpdkvhostuser interface
+VSWITCH_VPP_VHOSTUSER_ARGS = ['feature-mask',  '0xFF']

--- a/data/nfv/conf/03_traffic.conf
+++ b/data/nfv/conf/03_traffic.conf
@@ -1,0 +1,553 @@
+# Copyright 2015-2018 Intel Corporation., Tieto
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ############################
+# Traffic gen configuration
+# ############################
+
+# log file for all traffic generator related commands
+LOG_FILE_TRAFFIC_GEN = 'traffic-gen.log'
+
+# TRAFFIC dictionary defines traffic parameters used by all traffic generators.
+# Detailed description of TRAFFIC dictionary items follows:
+#
+#    'traffic_type'  - One of the supported traffic types.
+#                      E.g. rfc2544_throughput, rfc2544_back2back,
+#                      rfc2544_continuous or burst
+#                      Data type: str
+#                      Default value: "rfc2544_throughput".
+#    'bidir'         - Specifies if generated traffic will be full-duplex (True)
+#                      or half-duplex (False)
+#                      Data type: str
+#                      Supported values: "True", "False"
+#                      Default value: "False".
+#    'frame_rate'    - Defines desired percentage of frame rate used during
+#                      continuous stream tests.
+#                      Data type: int
+#                      Default value: 100.
+#    'burst_size'    - Defines a number of frames in the single burst, which is sent
+#                      by burst traffic type. Burst size is applied for each direction,
+#                      i.e. the total number of tx frames will be 2*burst_size in case of
+#                      bidirectional traffic.
+#                      Data type: int
+#                      Default value: 100.
+#    'multistream'   - Defines number of flows simulated by traffic generator.
+#                      Value 0 disables multistream feature
+#                      Data type: int
+#                      Supported values: 0-65536 for 'L4' stream type
+#                                        unlimited for 'L2' and 'L3' stream types
+#                      Default value: 0.
+#    'stream_type'   - Stream type is an extension of the "multistream" feature.
+#                      If multistream is disabled, then stream type will be
+#                      ignored. Stream type defines ISO OSI network layer used
+#                      for simulation of multiple streams.
+#                      Data type: str
+#                      Supported values:
+#                         "L2" - iteration of destination MAC address
+#                         "L3" - iteration of destination IP address
+#                         "L4" - iteration of destination port
+#                                of selected transport protocol
+#                      Default value: "L4".
+#    'pre_installed_flows'
+#                   -  Pre-installed flows is an extension of the "multistream"
+#                      feature. If enabled, it will implicitly insert a flow
+#                      for each stream. If multistream is disabled, then
+#                      pre-installed flows will be ignored.
+#                      Data type: str
+#                      Supported values:
+#                         "Yes" - flows will be inserted into OVS
+#                         "No"  - flows won't be inserted into OVS
+#                      Default value: "No".
+#    'flow_type'     - Defines flows complexity.
+#                      Data type: str
+#                      Supported values:
+#                         "port" - flow is defined by ingress ports
+#                         "IP"   - flow is defined by ingress ports
+#                                  and src and dst IP addresses
+#                      Default value: "port"
+#    'flow_control'  - Controls flow control support by traffic generator.
+#                      Supported values:
+#                         False  - flow control is disabled
+#                         True   - flow control is enabled
+#                      Default value: False
+#                      Note: Currently it is supported by IxNet only
+#    'learning_frames' - Controls learning frames support by traffic generator.
+#                      Supported values:
+#                         False  - learning freames are disabled
+#                         True   - learning freames are enabled
+#                      Default value: True
+#                      Note: Currently it is supported by IxNet only
+#    'l2'            - A dictionary with l2 network layer details. Supported
+#                      values are:
+#        'srcmac'    - Specifies source MAC address filled by traffic generator.
+#                      NOTE: It can be modified by vsperf in some scenarios.
+#                      Data type: str
+#                      Default value: "00:00:00:00:00:00".
+#        'dstmac'    - Specifies destination MAC address filled by traffic generator.
+#                      NOTE: It can be modified by vsperf in some scenarios.
+#                      Data type: str
+#                      Default value: "00:00:00:00:00:00".
+#        'framesize' - Specifies default frame size. This value should not be
+#                      changed directly. It will be overridden during testcase
+#                      execution by values specified by list TRAFFICGEN_PKT_SIZES.
+#                      Data type: int
+#                      Default value: 64
+#    'l3'            - A dictionary with l3 network layer details. Supported
+#                      values are:
+#        'enabled'   - Specifies if l3 layer should be enabled or disabled.
+#                      Data type: bool
+#                      Default value: True
+#                      NOTE: Supported only by IxNet trafficgen class
+#        'srcip'     - Specifies source MAC address filled by traffic generator.
+#                      NOTE: It can be modified by vsperf in some scenarios.
+#                      Data type: str
+#                      Default value: "1.1.1.1".
+#        'dstip'     - Specifies destination MAC address filled by traffic generator.
+#                      NOTE: It can be modified by vsperf in some scenarios.
+#                      Data type: str
+#                      Default value: "90.90.90.90".
+#        'proto'     - Specifies protocol type.
+#                      Please check particular traffic generator implementation
+#                      for supported protocol types.
+#                      Data type: str
+#                      Default value: "udp".
+#    'l4'            - A dictionary with l4 network layer details. Supported
+#                      values are:
+#        'enabled'   - Specifies if l4 layer should be enabled or disabled.
+#                      Data type: bool
+#                      Default value: True
+#                      NOTE: Supported only by IxNet trafficgen class
+#        'srcport'   - Specifies source port of selected transport protocol.
+#                      NOTE: It can be modified by vsperf in some scenarios.
+#                      Data type: int
+#                      Default value: 3000
+#        'dstport'   - Specifies destination port of selected transport protocol.
+#                      NOTE: It can be modified by vsperf in some scenarios.
+#                      Data type: int
+#                      Default value: 3001
+#    'vlan'          - A dictionary with vlan encapsulation details. Supported
+#                      values are:
+#        'enabled'   - Specifies if vlan encapsulation should be enabled or
+#                      disabled.
+#                      Data type: bool
+#                      Default value: False
+#        'id'        - Specifies vlan id.
+#                      Data type: int (NOTE: must fit to 12 bits)
+#                      Default value: 0
+#        'priority'  - Specifies a vlan priority (PCP header field).
+#                      Data type: int (NOTE: must fit to 3 bits)
+#                      Default value: 0
+#        'cfi'       - Specifies if frames can or cannot be dropped during
+#                      congestion (DEI header field).
+#                      Data type: int (NOTE: must fit to 1 bit)
+#                      Default value: 0
+#    'capture'       - A dictionary with traffic capture configuration.
+#                      NOTE: It is supported only by T-Rex traffic generator.
+#        'enabled'   - Specifies if traffic should be captured
+#                      Data type: bool
+#                      Default value: False
+#        'tx_ports'  - A list of ports, where frames transmitted towards DUT will
+#                      be captured. Ports have numbers 0 and 1. TX packet capture
+#                      is disabled if list of ports is empty.
+#                      Data type: list
+#                      Default value: [0]
+#        'rx_ports'  - A list of ports, where frames received from DUT will
+#                      be captured. Ports have numbers 0 and 1. RX packet capture
+#                      is disabled if list of ports is empty.
+#                      Data type: list
+#                      Default value: [1]
+#        'count'     - A number of frames to be captured. The same count value
+#                      is applied to both TX and RX captures.
+#                      Data type: int
+#                      Default value: 1
+#        'filter'    - An expression used to filter TX and RX packets. It uses the same
+#                      syntax as pcap library. See pcap-filter man page for additional
+#                      details.
+#                      Data type: str
+#                      Default value: ''
+#    'scapy'         - A dictionary with definition of a frame content for both traffic
+#                      directions. The frame content is defined by a SCAPY notation.
+#                      NOTE: It is supported only by the T-Rex traffic generator.
+#                      Following keywords can be used to refer to the related parts of
+#                      the TRAFFIC dictionary:
+#                           Ether_src   - refers to TRAFFIC['l2']['srcmac']
+#                           Ether_dst   - refers to TRAFFIC['l2']['dstmac']
+#                           IP_proto    - refers to TRAFFIC['l3']['proto']
+#                           IP_PROTO    - refers to upper case version of TRAFFIC['l3']['proto']
+#                           IP_src      - refers to TRAFFIC['l3']['srcip']
+#                           IP_dst      - refers to TRAFFIC['l3']['dstip']
+#                           IP_PROTO_sport - refers to TRAFFIC['l4']['srcport']
+#                           IP_PROTO_dport - refers to TRAFFIC['l4']['dstport']
+#                           Dot1Q_prio  - refers to TRAFFIC['vlan']['priority']
+#                           Dot1Q_id    - refers to TRAFFIC['vlan']['cfi']
+#                           Dot1Q_vlan  - refers to TRAFFIC['vlan']['id']
+#        '0'         - A string with the frame definition for the 1st direction.
+#                      Data type: str
+#                      Default value: 'Ether(src={Ether_src}, dst={Ether_dst})/'
+#                                     'Dot1Q(prio={Dot1Q_prio}, id={Dot1Q_id}, vlan={Dot1Q_vlan})/'
+#                                     'IP(proto={IP_proto}, src={IP_src}, dst={IP_dst})/'
+#                                     '{IP_PROTO}(sport={IP_PROTO_sport}, dport={IP_PROTO_dport})'
+#        '1'         - A string with the frame definition for the 2nd direction.
+#                      Data type: str
+#                      Default value: 'Ether(src={Ether_dst}, dst={Ether_src})/'
+#                                     'Dot1Q(prio={Dot1Q_prio}, id={Dot1Q_id}, vlan={Dot1Q_vlan})/'
+#                                     'IP(proto={IP_proto}, src={IP_dst}, dst={IP_src})/'
+#                                     '{IP_PROTO}(sport={IP_PROTO_dport}, dport={IP_PROTO_sport})',
+TRAFFIC = {
+    'traffic_type' : 'rfc2544_throughput',
+    'frame_rate' : 100,
+    'burst_size' : 100,
+    'bidir' : 'True',  # will be passed as string in title format to tgen
+    'multistream' : 0,
+    'stream_type' : 'L4',
+    'pre_installed_flows' : 'No',           # used by vswitch implementation
+    'flow_type' : 'port',                   # used by vswitch implementation
+    'flow_control' : False,                 # supported only by IxNet
+    'learning_frames' : True,               # supported only by IxNet
+    'l2': {
+        'framesize': 64,
+        'srcmac': '00:00:00:00:00:00',
+        'dstmac': '00:00:00:00:00:00',
+    },
+    'l3': {
+        'enabled': True,
+        'proto': 'udp',
+        'srcip': '1.1.1.1',
+        'dstip': '90.90.90.90',
+    },
+    'l4': {
+        'enabled': True,
+        'srcport': 3000,
+        'dstport': 3001,
+    },
+    'vlan': {
+        'enabled': False,
+        'id': 0,
+        'priority': 0,
+        'cfi': 0,
+    },
+    'capture': {
+        'enabled': False,
+        'tx_ports' : [0],
+        'rx_ports' : [1],
+        'count': 1,
+        'filter': '',
+    },
+    'scapy': {
+        'enabled': False,
+        '0' : 'Ether(src={Ether_src}, dst={Ether_dst})/'
+              'Dot1Q(prio={Dot1Q_prio}, id={Dot1Q_id}, vlan={Dot1Q_vlan})/'
+              'IP(proto={IP_proto}, src={IP_src}, dst={IP_dst})/'
+              '{IP_PROTO}(sport={IP_PROTO_sport}, dport={IP_PROTO_dport})',
+        '1' : 'Ether(src={Ether_dst}, dst={Ether_src})/'
+              'Dot1Q(prio={Dot1Q_prio}, id={Dot1Q_id}, vlan={Dot1Q_vlan})/'
+              'IP(proto={IP_proto}, src={IP_dst}, dst={IP_src})/'
+              '{IP_PROTO}(sport={IP_PROTO_dport}, dport={IP_PROTO_sport})',
+    }
+}
+
+#path to traffic generators directory.
+TRAFFICGEN_DIR = os.path.join(ROOT_DIR, 'tools/pkt_gen')
+
+# traffic generator to use in tests
+#TRAFFICGEN = 'TestCenter'
+TRAFFICGEN = 'Dummy'
+#TRAFFICGEN = 'IxNet'
+#TRAFFICGEN = 'Ixia'
+#TRAFFICGEN = 'Xena'
+#TRAFFICGEN = 'Moongen'
+#TRAFFICGEN = 'Trex'
+
+# List of packet sizes to send.
+# Expand like this: (64, 128, 256, 512, 1024)
+TRAFFICGEN_PKT_SIZES = (64,)
+
+TRAFFICGEN_DURATION = 30
+
+TRAFFICGEN_RFC2544_TESTS = 1
+TRAFFICGEN_RFC2889_TRIALS = 1
+TRAFFICGEN_LOSSRATE = 0.0
+
+##############################
+# DUMMY Configuration -- BEGIN
+
+# By default, dummy traffic generator asks for "measured" values.
+# Following dictionary allows to preconfigure these values and
+# to avoid user interaction. It can be useful for automated
+# integration tests.
+# Example of values for continuous traffic type:
+#   TRAFFICGEN_DUMMY_RESULTS{'frames rx': 500000,
+#                            'frames tx': 500000,
+#                            'rx rate %': 100,
+#                            'tx rate %': 100,
+#                            'frameloss %': 0,
+#                            'min latency': 1,
+#                            'max latency': 15,
+#                            'avg latency': 2.5,
+#                           }
+#
+TRAFFICGEN_DUMMY_RESULTS = {}
+
+# DUMMY Configuration -- END
+############################
+
+#############################
+# IXIA Configuration -- BEGIN
+
+# path to 'ixos' install path
+TRAFFICGEN_IXIA_ROOT_DIR = '/opt/ixos'
+
+# network address of IXIA chassis
+TRAFFICGEN_IXIA_HOST = ''
+
+TRAFFICGEN_IXIA_CARD = ''
+
+TRAFFICGEN_IXIA_PORT1 = ''
+
+TRAFFICGEN_IXIA_PORT2 = ''
+
+TRAFFICGEN_IXNET_LIB_PATH = '/opt/ixnetwork/lib/IxTclNetwork'
+
+# IxNetwork host IP address
+TRAFFICGEN_IXNET_MACHINE = ''
+TRAFFICGEN_IXNET_PORT = ''
+TRAFFICGEN_IXNET_USER = ''
+TRAFFICGEN_IXNET_CHASSIS = ''
+
+# The result directory on $TRAFFICGEN_IXNET_MACHINE
+TRAFFICGEN_IXNET_TESTER_RESULT_DIR = ''
+
+# The result directory on DUT. This needs to map to the same directory
+# as the previous one
+TRAFFICGEN_IXNET_DUT_RESULT_DIR = ''
+
+# directory with 3rd party scripts generated by IXIA tools
+TRAFFICGEN_IXIA_3RD_PARTY = os.path.join(ROOT_DIR, '3rd_party/ixia')
+
+# default TCL script, which will be used for IXNETWORK configuration
+TRAFFICGEN_IXNET_TCL_SCRIPT = 'ixnetrfc2544.tcl'
+
+# IXIA Configuration -- END
+###########################
+
+
+###########################################
+# Spirent TestCenter Configuration -- BEGIN
+
+# Path to Python 2 executable
+TRAFFICGEN_STC_PYTHON2_PATH = "/bin/python2.7"
+
+# Path to the location of the TestCenter files
+TRAFFICGEN_STC_TESTCENTER_PATH = os.path.join(ROOT_DIR, 'tools/pkt_gen/testcenter')
+
+# Name of the TestCenter RFC2544 Tput helper python script
+TRAFFICGEN_STC_RFC2544_TPUT_TEST_FILE_NAME = "testcenter-rfc2544-throughput.py"
+
+# Name of the Testcenter RFC2899 Tput Helper Python Scripts
+TRAFFICGEN_STC_RFC2889_TEST_FILE_NAME = "testcenter-rfc2889-rest.py"
+
+# 2889 Port Locations
+TRAFFICGEN_STC_RFC2889_LOCATION = ""
+
+# The address of the Spirent Lab Server to use
+TRAFFICGEN_STC_LAB_SERVER_ADDR = ""
+
+# The address of the Spirent License Server in your environment
+TRAFFICGEN_STC_LICENSE_SERVER_ADDR = ""
+
+# The address of the TestCenter chassis that holds the east port
+TRAFFICGEN_STC_EAST_CHASSIS_ADDR = ""
+
+# The slot number of the card that holds the east port
+TRAFFICGEN_STC_EAST_SLOT_NUM = ""
+
+# The port number on the card that holds the east port
+TRAFFICGEN_STC_EAST_PORT_NUM = ""
+
+# The address of the TestCenter chassis that holds the west port
+TRAFFICGEN_STC_WEST_CHASSIS_ADDR = ""
+
+# The slot number of the card that holds the west port
+TRAFFICGEN_STC_WEST_SLOT_NUM = ""
+
+# The port number on the card that holds the west port
+TRAFFICGEN_STC_WEST_PORT_NUM = ""
+
+# The friendly name to identify the Spirent Lab Server test session
+TRAFFICGEN_STC_TEST_SESSION_NAME = "RFC2544 Tput"
+# The directory to copy results to
+
+TRAFFICGEN_STC_RESULTS_DIR = os.path.join(ROOT_DIR, "Results")
+#  The prefix for the CSV results file
+
+TRAFFICGEN_STC_CSV_RESULTS_FILE_PREFIX = "RFC2544_tput"
+# The number of trials to execute during the test
+
+TRAFFICGEN_STC_NUMBER_OF_TRIALS = "1"
+
+# The duration of each trial executed during the test, in seconds
+TRAFFICGEN_STC_TRIAL_DURATION_SEC = "60"
+
+# The traffic pattern between endpoints, BACKBONE, MESH or PAIR
+TRAFFICGEN_STC_TRAFFIC_PATTERN = "PAIR"
+
+# The search mode used to find the throughput rate, COMBO, STEP or BINARY
+TRAFFICGEN_STC_SEARCH_MODE = "BINARY"
+
+# The learning mode used during the test, AUTO, L2_LEARNING, L3_LERNING, or NONE
+TRAFFICGEN_STC_LEARNING_MODE = "AUTO"
+
+# The minimum percent line rate that will be used during the test
+TRAFFICGEN_STC_RATE_LOWER_LIMIT_PCT = "1.0"
+
+# The maximum percent line rate that will be used during the test
+TRAFFICGEN_STC_RATE_UPPER_LIMIT_PCT = "99.0"
+
+# If SearchMode is BINARY, the percent line rate that will be used at the start of the test
+TRAFFICGEN_STC_RATE_INITIAL_PCT = "99.0"
+
+# When SearchMode is STEP, the percent increase in load per step
+TRAFFICGEN_STC_RATE_STEP_PCT = "10.0"
+
+# The minimum percentage of load adjustment between iterations
+TRAFFICGEN_STC_RESOLUTION_PCT = "1.0"
+
+# The frame size, in bytes
+TRAFFICGEN_STC_FRAME_SIZE = "256"
+
+# The maximum acceptable frame loss percent in any iteration
+TRAFFICGEN_STC_ACCEPTABLE_FRAME_LOSS_PCT = "0.0"
+
+# The address to assign to the first emulated device interface on the first east port
+TRAFFICGEN_STC_EAST_INTF_ADDR = ""
+
+# The gateway address to assign to the first emulated device interface on the first east port
+TRAFFICGEN_STC_EAST_INTF_GATEWAY_ADDR = ""
+
+# The address to assign to the first emulated device interface on the first west port
+TRAFFICGEN_STC_WEST_INTF_ADDR = ""
+
+# The gateway address to assign to the first emulated device interface on the first west port
+TRAFFICGEN_STC_WEST_INTF_GATEWAY_ADDR = ""
+
+# Print additional information to the terminal during the test
+TRAFFICGEN_STC_VERBOSE = "True"
+
+# Spirent TestCenter Configuration -- END
+#########################################
+
+#############################
+# Xena Configuration -- BEGIN
+
+# Xena traffic generator connection info
+TRAFFICGEN_XENA_IP = ''
+TRAFFICGEN_XENA_PORT1 = ''
+TRAFFICGEN_XENA_PORT2 = ''
+TRAFFICGEN_XENA_USER = ''
+TRAFFICGEN_XENA_PASSWORD = ''
+TRAFFICGEN_XENA_MODULE1 = ''
+TRAFFICGEN_XENA_MODULE2 = ''
+
+# Xena Port IP info
+TRAFFICGEN_XENA_PORT0_IP = '192.168.199.10'
+TRAFFICGEN_XENA_PORT0_CIDR = 24
+TRAFFICGEN_XENA_PORT0_GATEWAY = '192.168.199.1'
+TRAFFICGEN_XENA_PORT1_IP = '192.168.199.11'
+TRAFFICGEN_XENA_PORT1_CIDR = 24
+TRAFFICGEN_XENA_PORT1_GATEWAY = '192.168.199.1'
+
+# Xena RFC 2544 options
+# Please reference xena documentation before making changes to these settings
+TRAFFICGEN_XENA_2544_TPUT_INIT_VALUE = '10.0'
+TRAFFICGEN_XENA_2544_TPUT_MIN_VALUE = '0.1'
+TRAFFICGEN_XENA_2544_TPUT_MAX_VALUE = '100.0'
+TRAFFICGEN_XENA_2544_TPUT_VALUE_RESOLUTION = '0.5'
+TRAFFICGEN_XENA_2544_TPUT_USEPASS_THRESHHOLD = 'false'
+TRAFFICGEN_XENA_2544_TPUT_PASS_THRESHHOLD = '0.0'
+
+# Xena RFC 2544 final verification options
+TRAFFICGEN_XENA_RFC2544_VERIFY = False
+TRAFFICGEN_XENA_RFC2544_VERIFY_DURATION = 120 # in seconds
+# Number of verify attempts before giving up...
+TRAFFICGEN_XENA_RFC2544_MAXIMUM_VERIFY_ATTEMPTS = 10
+# Logic for restarting binary search, see documentation for details
+TRAFFICGEN_XENA_RFC2544_BINARY_RESTART_SMART_SEARCH = True
+
+# Xena Continuous traffic options
+# Please reference xena documentation before making changes to these settings
+TRAFFICGEN_XENA_CONT_PORT_LEARNING_ENABLED = True
+TRAFFICGEN_XENA_CONT_PORT_LEARNING_DURATION = 3
+
+# Xena Configuration -- END
+###########################
+
+###################################################
+# MoonGen Configuration and Connection Info-- BEGIN
+
+# Ex: TRAFFICGEN_MOONGEN_HOST_IP_ADDR = "192.10.1.1"
+TRAFFICGEN_MOONGEN_HOST_IP_ADDR = ''
+TRAFFICGEN_MOONGEN_USER = ''
+TRAFFICGEN_MOONGEN_BASE_DIR = ''
+TRAFFICGEN_MOONGEN_PORTS = ''
+# Ex. 10 Gbps: TRAFFICGEN_MOONGEN_LINE_SPEED_GBPS = '10'
+# Today only 10 Gbps is supported
+TRAFFICGEN_MOONGEN_LINE_SPEED_GBPS = ''
+
+# MoonGen Configuration and Connection Info-- END
+#################################################
+
+################################################
+# Trex Configuration and Connection Info-- BEGIN
+
+# Example: TRAFFICGEN_TREX_HOST_IP_ADDR = "192.10.1.1"
+# Example: TRAFFICGEN_TREX_USER = 'root'
+# Example: TRAFFICGEN_TREX_BASE_DIR = '/traffic_gen/trex/'
+# Example: TRAFFICGEN_TREX_PORT1 = '00:00:00:00:00:00'
+TRAFFICGEN_TREX_HOST_IP_ADDR = ''
+TRAFFICGEN_TREX_USER = ''
+TRAFFICGEN_TREX_BASE_DIR = ''
+TRAFFICGEN_TREX_PORT1 = ''
+TRAFFICGEN_TREX_PORT2 = ''
+# RFC2544 Throughput execution will end after threshold below is reached.
+# It defines maximal difference between frame rate of successful (i.e. defined
+# frameloss reached) and unsuccessful (i.e. frameloss exceeded) iterations.
+TRAFFICGEN_TREX_RFC2544_TPUT_THRESHOLD = 0.05
+# Latency statistics are collected by separate stream created for each interface.
+# Parameter below defines frequency of packets used for latency measurement in PPS.
+# Value 0 will disable latency specific streams.
+TRAFFICGEN_TREX_LATENCY_PPS = 1000
+# Enablement of learning packets before sending test traffic
+TRAFFICGEN_TREX_LEARNING_MODE = True
+TRAFFICGEN_TREX_LEARNING_DURATION = 5
+# FOR SR-IOV or multistream layer 2 tests to work with T-Rex enable Promiscuous mode
+TRAFFICGEN_TREX_PROMISCUOUS = False
+# Enable below options to force T-rex api to attempt to use speed specified on server
+# side when pushing traffic. For 40G use 40000. For 25G use 25000.
+TRAFFICGEN_TREX_FORCE_PORT_SPEED = False
+TRAFFICGEN_TREX_PORT_SPEED = 10000 # 10G
+
+PATHS['trafficgen'] = {
+    'Trex': {
+        'type' : 'src',
+        'src': {
+            'path': os.path.join(ROOT_DIR, 'src/trex/trex/scripts/automation/trex_control_plane/stl')
+    }
+  }
+}
+# TRex validation option for RFC2544
+TRAFFICGEN_TREX_VERIFICATION_MODE = False
+TRAFFICGEN_TREX_VERIFICATION_DURATION = 60
+TRAFFICGEN_TREX_MAXIMUM_VERIFICATION_TRIALS = 10
+# TREX Configuration and Connection Info-- END
+##############################################

--- a/data/nfv/conf/04_vnf.conf
+++ b/data/nfv/conf/04_vnf.conf
@@ -1,0 +1,218 @@
+# Copyright 2015-2016 Intel Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ############################
+# VNF configuration
+# ############################
+VNF_DIR = os.path.join(ROOT_DIR, 'vnfs/')
+VNF = 'QemuDpdkVhostUser'
+VNF_AFFINITIZATION_ON = True
+
+# ############################
+# Directories, executables and log files
+# ############################
+
+# please see conf/00_common.conf for description of PATHS dictionary
+PATHS['qemu'] = {
+    'type' : 'bin',
+    'src': {
+        'path': os.path.join(ROOT_DIR, 'src/qemu/qemu/'),
+        'qemu-system': 'x86_64-softmmu/qemu-system-x86_64'
+    },
+    'bin': {
+        'qemu-system': 'qemu-system-x86_64'
+    }
+}
+
+# log file for qemu
+LOG_FILE_QEMU = 'qemu.log'
+
+# log file for all commands executed on guest(s)
+# multiple guests will result in log files with the guest number appended
+LOG_FILE_GUEST_CMDS = 'guest-cmds.log'
+
+# ############################
+# Guest configuration
+# ############################
+# All configuration options related to a particular VM instance are defined as
+# lists and prefixed with `GUEST_` label. It is essential, that there is enough
+# items in all `GUEST_` options to cover all VM instances involved in the test.
+# In case there is not enough items, then VSPERF will use the first item of
+# particular `GUEST_` option to expand the list to required length. First option
+# can contain macros starting with `#` to generate VM specific values. These
+# macros can be used only for options of `list` or `str` types with `GUEST_`
+# prefix.
+# Following macros are supported:
+#
+# * #VMINDEX - it is replaced by index of VM being executed; This macro is
+#   expanded first, so it can be used inside other macros.
+#
+# * #MAC(mac_address[, step]) - it will iterate given `mac_address` with
+#   optional `step`. In case that step is not defined, then it is set to 1.
+#   It means, that first VM will use the value of `mac_address`, second VM
+#   value of `mac_address` increased by `step`, etc.
+#
+# * #IP(ip_address[, step]) - it will iterate given `ip_address` with optional
+#   step. In case that step is not defined, then it is set to 1.
+#   It means, that first VM will use the value of `ip_address`, second VM
+#   value of `ip_address` increased by `step`, etc.
+#
+# * #EVAL(expression) - it will evaluate given `expression` as python code;
+#   Only simple expressions should be used. Call of the functions is not
+#   supported.
+
+# directory which is shared to QEMU guests. Useful for exchanging files
+# between host and guest, VNF specific share will be created
+# For 2 VNFs you may use ['/tmp/qemu0_share', '/tmp/qemu1_share']
+GUEST_SHARE_DIR = ['/tmp/qemu0_share']
+
+# location of guest disk image
+# For 2 VNFs you may use ['guest1.img', 'guest2.img']
+GUEST_IMAGE = ['']
+
+# guarding timer for VM start up
+# For 2 VNFs you may use [180, 180]
+GUEST_TIMEOUT = [180]
+
+# Guest images may require different drive types such as ide to mount shared
+# locations and/or boot correctly. You can modify the types here.
+GUEST_BOOT_DRIVE_TYPE = ['scsi']
+GUEST_SHARED_DRIVE_TYPE = ['scsi']
+
+# guest loopback application method; supported options are:
+#       'testpmd'       - testpmd from dpdk will be built and used
+#       'l2fwd'         - l2fwd module provided by Huawei will be built and used
+#       'linux_bridge'  - linux bridge will be configured
+#       'buildin'       - nothing will be configured by vsperf; VM image must
+#                         ensure traffic forwarding between its interfaces
+#       'clean'         - nothing will be configured, but automatic login will
+#                         be performed; Useful for stepdriven testcases.
+# For 2 VNFs you may use ['testpmd', 'l2fwd']
+GUEST_LOOPBACK = ['testpmd']
+
+# guest driver binding option; support options are:
+#	'igb_uio_from_src'  - build igb_uio driver from downloaded source files
+#	'uio_pci_generic'   - use uio_pci_generic driver
+#	'vfio_no_iommu'     - use unsafe vfio driver without iommu (requires
+#                             image with supported kernel 4.5 or greater and
+#                             dpdk 16.04 or greater. VSPerf vloop image does not
+#                             support this mode.
+GUEST_DPDK_BIND_DRIVER = ['igb_uio_from_src']
+
+# username for guest image
+GUEST_USERNAME = ['root']
+
+# password for guest image
+GUEST_PASSWORD = ['root']
+
+# login username prompt for guest image
+GUEST_PROMPT_LOGIN = ['.* login:']
+
+# login password prompt for guest image
+GUEST_PROMPT_PASSWORD = ['Password: ']
+
+# standard prompt for guest image
+GUEST_PROMPT = ['root.*#']
+
+# defines the number of NICs configured for each guest, it must be less or equal to
+# the number of NICs configured in GUEST_NICS
+GUEST_NICS_NR = [2]
+
+# template for guests with 4 NICS, but only GUEST_NICS_NR NICS will be configured at runtime
+GUEST_NICS = [[{'device' : 'eth0', 'mac' : '#MAC(00:00:00:00:00:01,2)', 'pci' : '00:04.0', 'ip' : '#IP(192.168.1.2,4)/24'},
+               {'device' : 'eth1', 'mac' : '#MAC(00:00:00:00:00:02,2)', 'pci' : '00:05.0', 'ip' : '#IP(192.168.1.3,4)/24'},
+               {'device' : 'eth2', 'mac' : '#MAC(cc:00:00:00:00:01,2)', 'pci' : '00:06.0', 'ip' : '#IP(192.168.1.4,4)/24'},
+               {'device' : 'eth3', 'mac' : '#MAC(cc:00:00:00:00:02,2)', 'pci' : '00:07.0', 'ip' : '#IP(192.168.1.5,4)/24'},
+             ]]
+
+# amount of host memory allocated for each guest
+GUEST_MEMORY = ['2048']
+# number of hugepages configured inside each guest
+GUEST_HUGEPAGES_NR = ['1024']
+
+# test-pmd requires 2 VM cores
+# It is also possible to configure GUEST's CPU topology,
+# e.g. GUEST_SMP = ["sockets=1,cores=2"]
+GUEST_SMP = ['2']
+
+# cpu features to the guest, default options provided to pass all available
+# host processor features to the guest. Also tsc deadline timer for guest,
+# the guest PMU, the invariant TSC options can be provided as well.
+GUEST_CPU_OPTIONS = ['host,migratable=off']
+
+# Host cores to use to affinitize the SMP cores of a QEMU instance
+# For 2 VNFs you may use [(4,5), (6, 7)]
+GUEST_CORE_BINDING = [('#EVAL(6+2*#VMINDEX)', '#EVAL(7+2*#VMINDEX)')]
+
+# pin guest vCPU threads to another pCPU core. This reduces the noise from qemu
+# housekeeping threads. By default the GUEST_THREAD_BINDING will be none.
+GUEST_THREAD_BINDING = [ None ]
+
+# Queues per NIC inside guest for multi-queue configuration, requires switch
+# multi-queue to be enabled for dpdk. Set to 0 for disabled. Can be enabled if
+# using Vanilla OVS without enabling switch multi-queue.
+GUEST_NIC_QUEUES = [0]
+
+# Disable VHost user guest NIC merge buffers by enabling the below setting. This
+# can improve performance when not using Jumbo Frames.
+GUEST_NIC_MERGE_BUFFERS_DISABLE = [True]
+
+# Virtio-Net vhost thread CPU mapping. If using  vanilla OVS with virtio-net,
+# you can affinitize the vhost-net threads by enabling the below setting. There
+# is one vhost-net thread per port per queue so one guest with 2 queues will
+# have 4 vhost-net threads. If more threads are present than CPUs given, the
+# affinitize will overlap CPUs in a round robin fashion.
+VSWITCH_VHOST_NET_AFFINITIZATION = False
+VSWITCH_VHOST_CPU_MAP = [4,5,8,11]
+
+GUEST_START_TIMEOUT = [120]
+GUEST_OVS_DPDK_DIR = ['/root/ovs_dpdk']
+GUEST_OVS_DPDK_SHARE = ['/mnt/ovs_dpdk_share']
+
+# IP addresses to use for Vanilla OVS PXP testing
+# Consider using RFC 2544/3330 recommended IP addresses for benchmark testing.
+# Network: 198.18.0.0/15
+# Netmask: 255.254.0.0
+# Broadcast: 198.19.255.255
+# First IP: 198.18.0.1
+# Last IP: 198.19.255.254
+# Hosts: 131070
+#
+
+# ARP entries for the IXIA ports and the bridge you are using:
+VANILLA_TGEN_PORT1_IP = '1.1.1.10'
+VANILLA_TGEN_PORT1_MAC = 'AA:BB:CC:DD:EE:FF'
+
+VANILLA_TGEN_PORT2_IP = '1.1.2.10'
+VANILLA_TGEN_PORT2_MAC = 'AA:BB:CC:DD:EE:F0'
+
+GUEST_BRIDGE_IP = ['#IP(1.1.1.5)/16']
+
+# ############################
+# Guest TESTPMD configuration
+# ############################
+
+# set of configuration parameters, which will be passed to the testpmd
+# executed inside the guest
+# Note: Testpmd must be executed in interactive mode. It means, that
+# VSPERF won't work correctly if '-i' will be removed.
+GUEST_TESTPMD_PARAMS = ['-c 0x3 -n 4 --socket-mem 512 -- '
+                        '--burst=64 -i --txqflags=0xf00 '
+                        '--disable-hw-vlan']
+
+# packet forwarding mode supported by testpmd; Please see DPDK documentation
+# for comprehensive list of modes supported by your version.
+# e.g. io|mac|mac_retry|macswap|flowgen|rxonly|txonly|csum|icmpecho|...
+# Note: Option "mac_retry" has been changed to "mac retry" since DPDK v16.07
+GUEST_TESTPMD_FWD_MODE = ['csum']

--- a/data/nfv/conf/05_collector.conf
+++ b/data/nfv/conf/05_collector.conf
@@ -1,0 +1,57 @@
+# Copyright 2015-2018 Intel Corporation, Spirent Communications
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ############################
+# Collector configuration
+# ############################
+
+COLLECTOR = 'Pidstat'
+COLLECTOR_DIR = os.path.join(ROOT_DIR, 'tools/collectors')
+
+# processes to be monitored by pidstat
+PIDSTAT_MONITOR = ['ovs-vswitchd', 'ovsdb-server', 'qemu-system-x86_64', 'vpp']
+
+# options which will be passed to pidstat
+PIDSTAT_OPTIONS = '-dur'
+
+# sampling interval used by pidstat to collect statistics
+PIDSTAT_SAMPLE_INTERVAL = 1
+
+# prefix of pidstat's log file; separate log file is created
+# for each testcase in the directory with results
+LOG_FILE_PIDSTAT = 'pidstat'
+
+##########################################
+# Collectd Specific configuration
+##########################################
+COLLECTD_IP = "127.0.0.1"
+COLLECTD_PORT = 25826
+COLLECTD_SECURITY_LEVEL = 0
+COLLECTD_AUTH_FILE = ''
+LOG_FILE_COLLECTD = 'collectd'
+
+# Configure filters - Interested (KEYS), Not-Interested (XKEYS)
+COLLECTD_CPU_KEYS = ['system', 'idle']
+COLLECTD_PROCESSES_KEYS = ['user', 'system']
+COLLECTD_INTERFACE_KEYS = ['dropped']
+COLLECTD_OVSSTAT_KEYS = ['dropped', 'broadcast']
+COLLECTD_DPDKSTAT_KEYS = ['dropped']
+COLLECTD_INTELRDT_KEYS = ['llc']
+
+# Interface types to exclude
+COLLECTD_INTERFACE_XKEYS = ['docker', 'lo']
+# Core-Ids to Exclude from
+# Provide individual core-ids or range of core-ids.
+# The range is specified using '-'
+COLLECTD_INTELRDT_XKEYS = [ ]

--- a/data/nfv/conf/06_pktfwd.conf
+++ b/data/nfv/conf/06_pktfwd.conf
@@ -1,0 +1,39 @@
+# Copyright 2016 Intel Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ####################################################
+# General packet forwarding configuration
+# ####################################################
+
+PKTFWD_DIR = os.path.join(ROOT_DIR, 'tools/pkt_fwd')
+PKTFWD = 'TestPMD'
+
+# ############################
+# TestPMD configuration: http://dpdk.org/doc/guides/testpmd_app_ug/index.html
+# ############################
+
+TESTPMD_ARGS = []
+# packet forwarding mode supported by testpmd; Please see DPDK documentation
+# for comprehensive list of modes supported by your version.
+# e.g. io|mac|mac_retry|macswap|flowgen|rxonly|txonly|csum|icmpecho|...
+# Note: Option "mac_retry" has been changed to "mac retry" since DPDK v16.07
+TESTPMD_FWD_MODE = 'csum'
+# checksum calculation layer: ip|udp|tcp|sctp|outer-ip
+TESTPMD_CSUM_LAYER = 'ip'
+# checksum calculation place: hw (hardware) | sw (software)
+TESTPMD_CSUM_CALC = 'sw'
+# recognize tunnel headers: on|off
+TESTPMD_CSUM_PARSE_TUNNEL = 'off'
+
+PIDSTAT_MONITOR = ['ovs-vswitchd', 'ovsdb-server', 'qemu-system-x86_64', 'vpp', 'testpmd']

--- a/data/nfv/conf/07_loadgen.conf
+++ b/data/nfv/conf/07_loadgen.conf
@@ -1,0 +1,37 @@
+# Copyright 2015 Intel Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+LOADGEN_DIR = os.path.join(ROOT_DIR, 'tools/load_gen')
+
+######################################################
+# LOADGEN tool: one of DummyLoadGen, Stress, StressNg,
+# and StressorVM
+######################################################
+LOADGEN = "DummyLoadGen"
+######################################################
+
+
+######################################################
+# StressorVm specific COnfiguration
+######################################################
+NN_COUNT = 1
+NN_MEMORY = ['4096']
+NN_SMP = ['2']
+NN_IMAGE = ['/home/opnfv/stressng-images/stressng-high-TypeE.qemu']
+NN_SHARED_DRIVE_TYPE = ['scsi']
+NN_BOOT_DRIVE_TYPE = ['scsi']
+NN_CORE_BINDING = [('9','10')]
+NN_NICS_NR = ['2']
+NN_BASE_VNC_PORT = 4
+NN_LOG_FILE = 'nnqemu.log'

--- a/data/nfv/conf/08_llcmanagement.conf
+++ b/data/nfv/conf/08_llcmanagement.conf
@@ -1,0 +1,62 @@
+# Copyright 2017-2018 Spirent Communications.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##################################
+# LLC Management Configuration   #
+##################################
+
+####################################################################
+# Specify how the policy is defined.
+# Select any one of the following: COS, CUSTOM.
+####################################################################
+POLICY_TYPE = 'COS'
+
+####################################################################
+# Policy Definition by COS
+# Choose any one class of service among Gold, Silver and Bronze.
+# The min-cache and max-cache for these 3 services vary.
+# gold - has the maximum with 'guaranteed' allocation.
+# sliver-bf- lower than gold, and best effort.
+# bronze-shared - least and shared.
+# This value will be used for "policy" variable in the REST call.
+####################################################################
+VSWITCH_COS = "silver-bf"
+VNF_COS     = "silver-bf"
+PMD_COS = "gold"
+NOISEVM_COS = "bronze-shared"
+
+####################################################################
+# CUSTOM Policy Definition
+# Specify Minimum and Maximum Cache Values each workload
+# [mincache, maxcache]
+####################################################################
+VSWITCH_CA = [10, 18]
+VNF_CA = [8, 10]
+PMD_CA = [10, 16]
+NOISEVM_CA = [1, 1]
+
+####################################################################
+# Intel RMD Server Specific Configuration
+# Port: 8081 (Debug) 8888 (normal)
+# Version: v1
+# IP: only localhost.
+####################################################################
+RMD_PORT = 8081
+RMD_SERVER_IP = '127.0.0.1'
+RMD_API_VERSION = 'v1'
+
+####################################################################
+# LLC Allocation Control.
+####################################################################
+LLC_ALLOCATION = False

--- a/data/nfv/conf/10_custom.conf
+++ b/data/nfv/conf/10_custom.conf
@@ -1,0 +1,76 @@
+# Copyright 2015 Intel Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#RTE_TARGET = '' # the relevant DPDK build target
+
+# traffic generator to use in tests
+#TRAFFICGEN = 'TestCenter'
+#TRAFFICGEN = 'Dummy'
+#TRAFFICGEN = 'IxNet'
+#TRAFFICGEN = 'Ixia'
+#TRAFFICGEN = 'Xena'
+#TRAFFICGEN = 'Moongen'
+TRAFFICGEN = 'Trex'
+
+###################################################
+# TREX Configuration and Connection Info-- BEGIN
+
+# Example: TRAFFICGEN_TREX_HOST_IP_ADDR = "192.10.1.1"
+# Example: TRAFFICGEN_TREX_USER = 'root'
+# Example: TRAFFICGEN_TREX_BASE_DIR = '/traffic_gen/trex/'
+# Example: TRAFFICGEN_TREX_PORT1 = '00:00:00:00:00:00'
+TRAFFICGEN_TREX_HOST_IP_ADDR = 'trafficgen_ip'
+TRAFFICGEN_TREX_USER = 'root'
+TRAFFICGEN_TREX_BASE_DIR = '/tmp/trex-core/'
+TRAFFICGEN_TREX_PORT1 = '03:00.0'
+TRAFFICGEN_TREX_PORT2 = '03:00.1'
+# Latency statistics are collected by separate stream created for each interface.
+# Parameter below defines frequency of packets used for latency measurement in PPS.
+# Value 0 will disable latency specific streams.
+TRAFFICGEN_TREX_LATENCY_PPS = 1000
+# Enablement of learning packets before sending test traffic
+TRAFFICGEN_TREX_LEARNING_MODE = True
+TRAFFICGEN_TREX_LEARNING_DURATION = 5
+# FOR SR-IOV or multistream layer 2 tests to work with T-Rex enable Promiscuous mode
+TRAFFICGEN_TREX_PROMISCUOUS = False
+# Enable below options to force T-rex api to attempt to use speed specified on server
+# side when pushing traffic. For 40G use 40000. For 25G use 25000.
+TRAFFICGEN_TREX_FORCE_PORT_SPEED = False
+TRAFFICGEN_TREX_PORT_SPEED = 10000 # 10G
+# TRex validation option for RFC2544
+TRAFFICGEN_TREX_VERIFICATION_MODE = False
+TRAFFICGEN_TREX_VERIFICATION_DURATION = 60
+TRAFFICGEN_TREX_MAXIMUM_VERIFICATION_TRIALS = 10
+
+# TREX Configuration and Connection Info-- END
+####################################################
+
+####################################################
+#TEST_PARAMS = {'TRAFFICGEN_PKT_SIZES':(64,)}
+#OPNFV_INSTALLER = "Fuel"
+#OPNFV_URL = "http://testresults.opnfv.org/test/api/v1"
+#PACKAGE_LIST = "src/package-list.mk"
+
+
+# Binary package configuration for RHEL 7.3 systems with Vanilla OVS
+####################################################################
+# Uncomment these lines for binary usage of Vanilla OVS.
+
+PATHS['vswitch']['ovs_var_tmp'] = '/var/run/openvswitch/'
+PATHS['vswitch']['ovs_etc_tmp'] = '/etc/openvswitch/'
+PATHS['vswitch']['OvsVanilla']['bin']['modules'] = [
+        'libcrc32c', 'ip_tunnel', 'vxlan', 'gre', 'nf_nat', 'nf_nat_ipv6',
+        'nf_nat_ipv4', 'nf_conntrack', 'nf_defrag_ipv4', 'nf_defrag_ipv6',
+        'openvswitch']
+PATHS['vswitch']['OvsVanilla']['type'] = 'bin'

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1583,11 +1583,13 @@ sub load_networkd_tests {
 
 sub load_nfv_master_tests {
     loadtest "nfv/prepare_env";
-    loadtest "nfv/run_integration_tests";
+    loadtest "nfv/run_integration_tests" if (check_var('BACKEND', 'qemu'));
+    loadtest "nfv/run_performance_tests" if (check_var('BACKEND', 'ipmi'));
 }
 
 sub load_nfv_trafficgen_tests {
     loadtest "nfv/trex_installation";
+    loadtest "nfv/trex_runner" if (check_var('BACKEND', 'ipmi'));
 }
 
 sub load_iso_in_external_tests {

--- a/tests/kernel/mellanox_ofed.pm
+++ b/tests/kernel/mellanox_ofed.pm
@@ -17,9 +17,12 @@ use base "opensusebasetest";
 use strict;
 use testapi;
 use utils;
+use serial_terminal 'select_virtio_console';
 
 sub run {
-    select_console 'root-ssh';
+    select_console 'root-ssh' if (check_var('BACKEND', 'ipmi'));
+    select_virtio_console()   if (check_var('BACKEND', 'qemu'));
+
     my $ofed_url      = get_required_var('OFED_URL');
     my $ofed_file_tgz = (split(/\//, $ofed_url))[-1];
     my $ofed_dir      = ((split(/\.tgz/, $ofed_file_tgz))[0]);
@@ -30,7 +33,7 @@ sub run {
     elsif (check_var('VERSION', '12-SP4')) {
         my $SDK_REPO = 'http://download.suse.de/ibs/SUSE:/SLE-12-SP4:/GA:/TEST/images/repo/SLE-12-SP4-SDK-POOL-x86_64-Media1/';
         zypper_call("--quiet ar -f $SDK_REPO SLE-12-SP4-SDK-POOL");
-        zypper_call('--quiet in openvswitch python-devel python-libxml2 libopenssl1_0_0 insserv-compat libstdc++-devel createrepo rpm-build kernel-syms', timeout => 500);
+        zypper_call('--quiet in openvswitch python-devel python-libxml2 libopenssl1_0_0 insserv-compat libstdc++-devel createrepo rpm-build kernel-syms tk', timeout => 500);
     }
     else {
         die "OS VERSION not supported. Available only on 15 and 12-SP4";
@@ -40,12 +43,15 @@ sub run {
     assert_script_run("wget $ofed_url");
     assert_script_run("tar -xvf $ofed_file_tgz");
     assert_script_run("cd $ofed_dir");
-    assert_script_run("./mlnxofedinstall --skip-distro-check --add-kernel-support --with-mft --with-mstflint --dpdk --upstream-libs", timeout => 1000);
-    assert_script_run("modprobe -rv rpcrdma");
-    assert_script_run("/etc/init.d/openibd restart");
-    script_run("ibv_devinfo");
-    script_run("ibdev2netdev");
-    script_run("ofed_info -s");
+    if (check_var('BACKEND', 'ipmi')) {
+        record_info("OFED install");
+        assert_script_run("./mlnxofedinstall --skip-distro-check --add-kernel-support --with-mft --with-mstflint --dpdk --upstream-libs", timeout => 2000);
+        assert_script_run("modprobe -rv rpcrdma");
+        assert_script_run("/etc/init.d/openibd restart");
+        script_run("ibv_devinfo");
+        script_run("ibdev2netdev");
+        script_run("ofed_info -s");
+    }
 }
 
 sub test_flags {

--- a/tests/nfv/run_integration_tests.pm
+++ b/tests/nfv/run_integration_tests.pm
@@ -16,14 +16,13 @@ use base "opensusebasetest";
 use testapi;
 use strict;
 use utils;
-use mmapi;
 use serial_terminal 'select_virtio_console';
 
 sub run {
+    select_virtio_console();
+
     my $self        = shift;
     my $vsperf_conf = "/etc/vsperf_ovs.conf";
-
-    select_virtio_console();
 
     # use conf file from data dir
     assert_script_run("curl " . data_url('nfv/vsperf_ovs_dummy.conf') . " -o $vsperf_conf");
@@ -41,4 +40,3 @@ sub run {
 }
 
 1;
-

--- a/tests/nfv/run_performance_tests.pm
+++ b/tests/nfv/run_performance_tests.pm
@@ -1,0 +1,37 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Run NFV Performance tests
+# Maintainer: Jose Lausuch <jalausuch@suse.com>
+
+use base "opensusebasetest";
+use testapi;
+use strict;
+use lockapi;
+
+sub run {
+    select_console 'root-ssh';
+
+    record_info("Start test");
+    assert_script_run('source /root/vsperfenv/bin/activate && cd /root/vswitchperf/');
+    assert_script_run('./vsperf --conf-file=/root/vswitchperf/conf/10_custom.conf --vswitch OvsVanilla phy2phy_tput',
+        timeout => 3600);
+    mutex_create("NFV_TESTING_DONE");
+
+    record_info("Upload logs");
+    script_run("cd /tmp");
+    script_run(q(find . -type d -name "results*"|xargs -d "\n" tar -czvf vsperf_logs.tar.gz));
+    upload_logs('vsperf_logs.tar.gz', failok => 1);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/nfv/trex_installation.pm
+++ b/tests/nfv/trex_installation.pm
@@ -17,10 +17,13 @@ use strict;
 use utils;
 use lockapi;
 use mmapi;
+use serial_terminal 'select_virtio_console';
 
 sub run {
-    select_console 'root-ssh';
+    select_console 'root-ssh' if (check_var('BACKEND', 'ipmi'));
+    select_virtio_console()   if (check_var('BACKEND', 'qemu'));
 
+    my ($self)       = @_;
     my $trex_version = get_required_var('TG_VERSION');
     my $tarball      = "$trex_version.tar.gz";
     my $url          = "http://trex-tgn.cisco.com/trex/release/$tarball";
@@ -30,26 +33,32 @@ sub run {
     my $PORT_2       = get_required_var('PORT_2');
 
     # Download and extract T-Rex package
+    record_info("Download TREX");
     assert_script_run("wget $url", 900);
     assert_script_run("tar -xzf $tarball");
     assert_script_run("mv $trex_version $trex_dest");
 
     # Copy config file and replace port values
+    record_info("TREX Config");
     assert_script_run("curl " . data_url('nfv/trex_cfg.yaml') . " -o $trex_conf");
     assert_script_run("sed -i 's/PORT_0/$PORT_1/' -i $trex_conf");
     assert_script_run("sed -i 's/PORT_1/$PORT_2/' -i $trex_conf");
     assert_script_run("cat $trex_conf");
 
-    assert_script_run("ip link set dev eth2 up");
-    assert_script_run("ip link set dev eth3 up");
+    if (check_var('BACKEND', 'ipmi')) {
+        record_info("Bring mellanox interfaces up");
+        assert_script_run("ip link set dev eth2 up");
+        assert_script_run("ip link set dev eth3 up");
+    }
 
-    mutex_create("NFV_trafficgen_ready");
+    record_info("Stop Firewall");
+    systemctl 'stop ' . $self->firewall;
 
-    # Start daemon
-    assert_script_run("cd $trex_dest");
-    assert_script_run("./trex_daemon_server start");
+    record_info("TREX ready");
+    mutex_create("NFV_TRAFFICGEN_READY");
 
-    mutex_wait('NFV_testing_ready');
+    record_info("Wait for VSPerf");
+    mutex_wait('NFV_VSPERF_READY');
 }
 
 1;

--- a/tests/nfv/trex_runner.pm
+++ b/tests/nfv/trex_runner.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Trex traffic generator runner
+#
+# Maintainer: Jose Lausuch <jalausuch@suse.com>
+
+use base "opensusebasetest";
+use testapi;
+use strict;
+use utils;
+use lockapi;
+
+sub run {
+    select_console 'root-ssh';
+
+    my $trex_dir = "/tmp/trex-core";
+
+    record_info("Start TREX");
+    script_run("cd /tmp/trex-core");
+    type_string("nohup bash /tmp/trex-core/t-rex-64 -i &\n");
+
+    mutex_wait('NFV_TESTING_DONE');
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/14996

This also splits virtual from baremetal runs. On virtual environments, it will only install the needed packages and run some integration tests. For Baremetal environments, it will actually run the performance tests that are the target of this activity.

- Verification runs: 
BAREMETAL: 
http://loewe.arch.suse.de/tests/1050
http://loewe.arch.suse.de/tests/1051
VIRTUAL:
http://fromm.arch.suse.de/tests/1259
http://fromm.arch.suse.de/tests/1260
