### PR TITLE
Update "hostname" overload and "consoletest_setup" in create_hdd_* to make sure right permissions

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1504,7 +1504,6 @@ sub load_extra_tests {
     # setup $serialdev permission and so on
     loadtest "console/consoletest_setup";
     loadtest 'console/integration_services' if is_hyperv;
-    loadtest "console/hostname";
     if (any_desktop_is_applicable()) {
         load_extra_tests_desktop;
     }


### PR DESCRIPTION
`hostname` appeared in "create_hdd_*", so there is no need to
test again in "load_extra_tests_*"
`consoletest_setup` test in "create_hdd_*" is to make the user
and "/dev/tty" belongs to the same group, because some test suits
doesn't include "x11/x11_setup" or "consoletest_setup" after reboot

- Related ticket: 
[poo#38531](https://progress.opensuse.org/issues/38531)
[poo#38480](https://progress.opensuse.org/issues/38480)
[poo#37027](https://progress.opensuse.org/issues/37027)
- Verification run: 
[create_hdd_gnome](http://10.67.19.67/tests/348)
[extra_tests_on_gnome](http://10.67.19.67/tests/372)
[create_hdd_kde](http://10.67.19.67/tests/351)
[extra_tests_on_kde](http://10.67.19.67/tests/373)
[create_hdd_textmode](http://10.67.19.67/tests/352)
[extra_tests_in_textmode](http://10.67.19.67/tests/371)
