### PR TITLE
[Beta2 needed] xfstests: solve generate_report two bugs

### DIFF
--- a/lib/ctcs2_to_junit.pm
+++ b/lib/ctcs2_to_junit.pm
@@ -99,15 +99,15 @@ sub generateXML {
             name      => $test,
             status    => $case_status,
             time      => $test_results{$test}->{time});
-        if ($case_status eq 'failure' || $case_status eq 'skipped') {
+        if (!get_var('QA_TESTSUITE') && ($case_status eq 'failure' || $case_status eq 'skipped')) {
             (my $test_path = $test) =~ s/-/\//;
             $test_path = '/opt/log/' . $test_path;
-            my $test_out_content = script_output("cat $test_path\n", 600);
+            my $test_out_content = script_output("cat $test_path| sed \"s/'//g\"", 600);
             $writer->startTag('system-out');
             $writer->characters($test_out_content);
             $writer->endTag('system-out');
             if ($case_status eq 'failure') {
-                my $test_err_content = script_output("echo '====out.bad log====\n';\ncat $test_path" . ".out.bad;\necho '\n====full log====\n';\ncat  $test_path" . ".full", 600);
+                my $test_err_content = script_output("echo '====out.bad log====';if [ -f $test_path.out.bad ];then cat $test_path.out.bad|sed \"s/'//g\";else echo '$test_path.out.bad not exist';fi;echo '====full log====';if [ -f $test_path.full ]; then cat $test_path.full| sed \"s/'//g\"; else echo '$test_path.full not exist';fi;", 600);
                 $writer->startTag('system-err');
                 $writer->characters($test_err_content);
                 $writer->endTag('system-err');


### PR DESCRIPTION
This PR solve two bugs in generate_report.pm , involved by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5455
1. Fail by can't find log file , e.g.http://10.67.133.102/tests/596#step/generate_report/22
2. Fail by echo '$something', $something contain ', e.g. https://openqa.suse.de/tests/1877180#step/generate_report/30
Both internal bug makes fail case couldn't be debuged in xfstests.

- Related ticket: https://progress.opensuse.org/issues/38954
- Verification run: 
http://10.67.133.102/tests/603
http://10.67.133.102/tests/605
http://10.67.133.102/tests/606