### PR TITLE
Update desktopapps-gnome testsuite on Tumbleweed

### DIFF
--- a/tests/x11/gnomecase/application_starts_on_login.pm
+++ b/tests/x11/gnomecase/application_starts_on_login.pm
@@ -26,7 +26,7 @@ sub tweak_startupapp_menu {
     }
     else {
         # tweak-tool entry is not in gnome-control-center of SLE15;
-        x11_start_program 'gnome-tweak-tool';
+        x11_start_program 'gnome-tweaks';
     }
     assert_screen "tweak-tool";
     # increase the default timeout - the switching can be slow

--- a/tests/x11/gnomecase/login_test.pm
+++ b/tests/x11/gnomecase/login_test.pm
@@ -16,11 +16,12 @@ use base "x11test";
 use strict;
 use testapi;
 use utils;
+use version_utils qw(is_opensuse is_sle);
 
 sub auto_login_alter {
     my ($self) = @_;
     $self->unlock_user_settings;
-    send_key "alt-u";
+    send_key "alt-u" if is_sle;
     send_key "alt-f4";
 }
 
@@ -31,7 +32,7 @@ sub run {
     $self->auto_login_alter;
     my $ov = get_var('NOAUTOLOGIN');
     set_var('NOAUTOLOGIN', '');
-    power_action('reboot');
+    power_action('reboot', keepconsole => 1) if is_opensuse;
     $self->wait_boot(bootloader_time => 300);
     set_var('NOAUTOLOGIN', $ov);
     $self->auto_login_alter;

--- a/tests/x11/gnomecase/login_test.pm
+++ b/tests/x11/gnomecase/login_test.pm
@@ -32,7 +32,12 @@ sub run {
     $self->auto_login_alter;
     my $ov = get_var('NOAUTOLOGIN');
     set_var('NOAUTOLOGIN', '');
-    power_action('reboot', keepconsole => 1) if is_opensuse;
+    if (is_sle) {
+        power_action('reboot');
+    }
+    else {
+        power_action('reboot', keepconsole => 1);
+    }
     $self->wait_boot(bootloader_time => 300);
     set_var('NOAUTOLOGIN', $ov);
     $self->auto_login_alter;


### PR DESCRIPTION
Migrate regression-gnome cases of SLE to Tumbleweed and then named desktopapps-gnome
In order to test desktop application operation on Tumbleweed, like [osd#1879230](https://openqa.suse.de/tests/1879230)
- Related ticket:
[poo#38969](https://progress.opensuse.org/issues/38969)
- Needles: 
[needles](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/404)
- Verification run: 
[create_hdd_gnome](http://10.67.19.67/tests/464)
[desktopapps-gnome](http://10.67.19.67/tests/481)