### PR TITLE
Unified security test variable for both SLE and openSUSE

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -357,26 +357,26 @@ elsif (get_var("ISO_IN_EXTERNAL_DRIVE")) {
     load_inst_tests();
     load_reboot_tests();
 }
-elsif (get_var('SECURITYTEST')) {
+elsif (get_var('SECURITY_TEST')) {
     boot_hdd_image;
     loadtest "console/consoletest_setup";
     loadtest "console/hostname";
-    if (check_var('SECURITYTEST', 'core')) {
+    if (check_var('SECURITY_TEST', 'core')) {
         load_security_tests_core;
     }
-    elsif (check_var('SECURITYTEST', 'web')) {
+    elsif (check_var('SECURITY_TEST', 'web')) {
         load_security_tests_web;
     }
-    elsif (check_var('SECURITYTEST', 'misc')) {
+    elsif (check_var('SECURITY_TEST', 'misc')) {
         load_security_tests_misc;
     }
-    elsif (check_var('SECURITYTEST', 'crypt')) {
+    elsif (check_var('SECURITY_TEST', 'crypt')) {
         load_security_tests_crypt;
     }
-    elsif (check_var("SECURITYTEST", "apparmor")) {
+    elsif (check_var("SECURITY_TEST", "apparmor")) {
         load_security_tests_apparmor;
     }
-    elsif (check_var("SECURITYTEST", "openscap")) {
+    elsif (check_var("SECURITY_TEST", "openscap")) {
         load_security_tests_openscap;
     }
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -831,7 +831,7 @@ elsif (get_var("SUPPORT_SERVER")) {
 elsif (get_var("SLEPOS")) {
     load_slepos_tests();
 }
-elsif (get_var("FIPS_TS") || get_var("SECURITY")) {
+elsif (get_var("FIPS_TS") || get_var("SECURITY_TEST")) {
     prepare_target();
     if (get_var('BOOT_HDD_IMAGE')) {
         loadtest "console/consoletest_setup";
@@ -862,10 +862,10 @@ elsif (get_var("FIPS_TS") || get_var("SECURITY")) {
         # Load client tests by APPTESTS variable
         load_applicationstests;
     }
-    elsif (check_var("SECURITY", "apparmor")) {
+    elsif (check_var("SECURITY_TEST", "apparmor")) {
         load_security_tests_apparmor;
     }
-    elsif (check_var("SECURITY", "openscap")) {
+    elsif (check_var("SECURITY_TEST", "openscap")) {
         load_security_tests_openscap;
     }
 }


### PR DESCRIPTION
Change variable to 'SECURITY_TEST' ([poo#37805](https://progress.opensuse.org/issues/37805)) to make it unified for SLE and openSUSE, and less confusing.

- Related ticket: https://progress.opensuse.org/issues/37805
- Verification run:
  - SLE AppArmor: http://10.67.17.9/tests/1055
  - SLE openSCAP: http://10.67.17.9/tests/1056
  - Tumbleweed AppArmor: http://10.67.17.9/tests/1057
  - Tumbleweed openSCAP: http://10.67.17.9/tests/1058
