### PR TITLE
Rely on bootindex for USBBoot

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -220,7 +220,10 @@ sub pre_bootmenu_setup {
         sleep 60;
         return 3;
     }
-    if (get_var("USBBOOT")) {
+
+    # After version 12 the USB storage is set as the default boot device using
+    # bootindex. Before 12 it needs to be selected in the BIOS.
+    if (isotovideo::get_version() < 12 && get_var("USBBOOT")) {
         assert_screen "boot-menu", 5;
         # support multiple versions of seabios, does not harm to press
         # multiple keys here: seabios<1.9: f12, seabios=>1.9: esc


### PR DESCRIPTION
The bootindex of the USB storage device is now set to zero under all
circumstances so it is not necessary to go into the bios and select it.