### PR TITLE
Fix update tests by not relying on download.o.o v2

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -616,7 +616,7 @@ sub installwithaddonrepos_is_applicable {
 }
 
 sub need_clear_repos {
-    return (is_opensuse && !is_updates_tests) || (is_sle && get_var("FLAVOR", '') =~ m/^Staging2?[\-]DVD$/ && get_var("SUSEMIRROR"));
+    return !get_var('BOOT_TO_SNAPSHOT') && (is_opensuse && !is_updates_tests) || (is_sle && get_var("FLAVOR", '') =~ m/^Staging2?[\-]DVD$/ && get_var("SUSEMIRROR"));
 }
 
 sub have_scc_repos {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -616,7 +616,7 @@ sub installwithaddonrepos_is_applicable {
 }
 
 sub need_clear_repos {
-    return !get_var('BOOT_TO_SNAPSHOT') && (is_opensuse && !is_updates_tests) || (is_sle && get_var("FLAVOR", '') =~ m/^Staging2?[\-]DVD$/ && get_var("SUSEMIRROR"));
+    return !get_var('BOOT_TO_SNAPSHOT') && !get_var('LIVETEST') && (is_opensuse && !is_updates_tests) || (is_sle && get_var("FLAVOR", '') =~ m/^Staging2?[\-]DVD$/ && get_var("SUSEMIRROR"));
 }
 
 sub have_scc_repos {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -616,7 +616,7 @@ sub installwithaddonrepos_is_applicable {
 }
 
 sub need_clear_repos {
-    return !get_var('BOOT_TO_SNAPSHOT') && !get_var('LIVETEST') && (is_opensuse && !is_updates_tests) || (is_sle && get_var("FLAVOR", '') =~ m/^Staging2?[\-]DVD$/ && get_var("SUSEMIRROR"));
+    return (!get_var('INSTALLONLY') || get_var('PUBLISH_HDD_1')) && !get_var('BOOT_TO_SNAPSHOT') && !get_var('LIVETEST') && (is_opensuse && !is_updates_tests) || (is_sle && get_var("FLAVOR", '') =~ m/^Staging2?[\-]DVD$/ && get_var("SUSEMIRROR"));
 }
 
 sub have_scc_repos {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1044,17 +1044,6 @@ sub load_consoletests {
     loadtest "console/textinfo";
     loadtest "console/rmt" if is_rmt;
     loadtest "console/hostname" unless is_bridged_networking;
-    # Run zypper info before as tests source repo are not yet synced to o3 and we
-    # rely on default repos we get after installation.
-    # The test can't be run on JeOS as it's heavily dependant
-    # on repos from installation medium.
-    # We also don't have any repos on staging and update/upgrade tests.
-    # This test uses serial console too much to be reliable on Hyper-V (poo#30613)
-    # Test doesn't make sense on live images too, don't have source repo there.
-    # Skip this test for SLED (poo#36397)
-    if (!is_staging() && !is_updates_tests() && !is_upgrade() && !is_jeos() && !is_hyperv() && !is_livesystem() && !is_desktop()) {
-        loadtest "console/zypper_info";
-    }
     # Add non-oss and debug repos for o3 and remove other by default
     replace_opensuse_repos_tests if is_repo_replacement_required;
     if (get_var('SYSTEM_ROLE', '') =~ /kvm|xen/) {
@@ -1439,6 +1428,7 @@ sub load_extra_tests_textmode {
     # dependency of git test
     loadtest "console/sshd";
     loadtest "console/zypper_ref";
+    loadtest "console/zypper_info";
     loadtest "console/update_alternatives";
     # start extra console tests from here
     # Audio device is not supported on ppc64le, s390x, JeOS, and Xen PV

--- a/tests/console/zypper_info.pm
+++ b/tests/console/zypper_info.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use repo_tools 'prepare_source_repo';
+use repo_tools qw(prepare_source_repo disable_source_repo);
 use version_utils qw(is_sle is_leap is_opensuse);
 
 sub test_srcpackage_output {
@@ -54,13 +54,13 @@ sub run {
         return;
     }
 
-    prepare_source_repo;
-
     # check for zypper info
     test_package_output;
 
     if (is_sle('>=12-SP2') || is_opensuse) {
+        prepare_source_repo;
         test_srcpackage_output;
+        disable_source_repo;
     }
 }
 


### PR DESCRIPTION
https://progress.opensuse.org/issues/38393

Todo:

- [x] Live: https://openqa.opensuse.org/tests/717627#step/consoletest_setup/29 ([verification](http://artemis.suse.de/tests/349))
- [x] Boot to snapshot: https://openqa.opensuse.org/tests/717439 ([verification](http://artemis.suse.de/tests/350))
- [x] `INSTALLONLY`: https://openqa.opensuse.org/tests/717442 ([verification](http://artemis.suse.de/tests/354))
- [x] `zypper_info`: https://openqa.opensuse.org/tests/717677#step/zypper_info/7 ([verification](http://artemis.suse.de/tests/359))
- [x] Do the replacement on image creation: https://openqa.opensuse.org/tests/717472 ([verification](http://artemis.suse.de/tests/355))