### PR TITLE
Lowered similarity level in x11_start_program

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -203,7 +203,7 @@ sub x11_start_program {
     send_key 'ret';
     # As above especially krunner seems to take some time before disappearing
     # after 'ret' press we should wait in this case nevertheless
-    wait_still_screen(3) unless ($args{no_wait} || ($args{valid} && $args{target_match} && !check_var('DESKTOP', 'kde')));
+    wait_still_screen(3, similarity_level => 45) unless ($args{no_wait} || ($args{valid} && $args{target_match} && !check_var('DESKTOP', 'kde')));
     return unless $args{valid};
     my @target = ref $args{target_match} eq 'ARRAY' ? @{$args{target_match}} : $args{target_match};
     for (1 .. 3) {


### PR DESCRIPTION
Lowered the similarity level for wait_still_screen in
x11_start_program to avoid wasting time with timeouts caused
by a blinking cursor. The value 45 is based on recent timeouts
having a value of 47

- Related ticket: https://progress.opensuse.org/issues/15310
- Verification run: http://pinky.arch.suse.de/tests/1344
As seen in http://pinky.arch.suse.de/tests/1344/file/autoinst-log.txt there are no more timeouts of wait_still_screen unlike the job mentioned in the ticket
