### PR TITLE
Fix SLES version to check when calling hb_report

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -214,7 +214,7 @@ sub ha_export_logs {
     my $corosync_conf = '/etc/corosync/corosync.conf';
     my $hb_log        = '/var/log/hb_report';
     my $packages_list = '/tmp/packages.list';
-    my $report_opt    = '-f0' unless is_sle('15+');
+    my $report_opt    = '-f0' unless is_sle('12-sp4+');
     my @y2logs;
 
     # Extract HA logs and upload them


### PR DESCRIPTION
`hb_report` does not recognize the time format `-f0` with the crmsh version present in SLES HAE 15, and also with the version present in 12-SP4 beginning with build 0315 of SLES-12SP4 and build 0138 of HAE 12SP4. This pull request checks for `12-SP4+` instead of `15+` before deciding whether to call hb_report with or without option `-f0`

- Related ticket: N/A.
- Failing tests: https://openqa.suse.de/tests/1882258#step/check_logs/5 & https://openqa.suse.de/tests/1882259#step/check_logs/5
- Last good: https://openqa.suse.de/tests/1853795 & https://openqa.suse.de/tests/1853796
- Needles: N/A
- Verification run: N/A
