### PR TITLE
Add and change variables to run fips-only cases in security testing

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1717,12 +1717,12 @@ sub load_common_x11 {
     }
 }
 
-# Move fips testsuites to main_common to apply to SLE_FIPS + openSUSE
-# Rename load_fips_tests_* to load_security_tests_* to avoid confusedness since
+# The function name load_security_tests_* is to avoid confusing since
 # openSUSE does NOT have FIPS mode
-# Some tests are only valid for SLE FIPS and loaded if defined variables set
+# Some tests are valid only for FIPS Regression testing. Use
+# "FIPS_ENABLED" to control whether to run these "FIPS only" cases
 sub load_security_tests_core {
-    if (check_var('DISTRI', 'sle') && get_var('FIPS_TS')) {
+    if (check_var('DISTRI', 'sle') && get_var('FIPS_ENABLED')) {
         loadtest "fips/openssl/openssl_fips_alglist";
         loadtest "fips/openssl/openssl_fips_hash";
         loadtest "fips/openssl/openssl_fips_cipher";
@@ -1745,18 +1745,18 @@ sub load_security_tests_web {
     loadtest "console/wget_https";
     loadtest "console/w3m_https";
     loadtest "console/apache_ssl";
-    if (check_var('DISTRI', 'sle') && get_var('FIPS_TS')) {
+    if (check_var('DISTRI', 'sle') && get_var('FIPS_ENABLED')) {
         loadtest "fips/mozilla_nss/apache_nssfips";
         loadtest "console/libmicrohttpd";
     }
     loadtest "console/consoletest_finish";
-    if (check_var('DISTRI', 'sle') && get_var('FIPS_TS')) {
+    if (check_var('DISTRI', 'sle') && get_var('FIPS_ENABLED')) {
         loadtest "fips/mozilla_nss/firefox_nss";
     }
 }
 
 sub load_security_tests_misc {
-    if (check_var('DISTRI', 'sle') && get_var('FIPS_TS')) {
+    if (check_var('DISTRI', 'sle') && get_var('FIPS_ENABLED')) {
         loadtest "fips/curl_fips_rc4_seed";
         loadtest "console/aide_check";
     }
@@ -1774,7 +1774,7 @@ sub load_security_tests_misc {
 }
 
 sub load_security_tests_crypt {
-    if (check_var('DISTRI', 'sle') && get_var('FIPS_TS')) {
+    if (check_var('DISTRI', 'sle') && get_var('FIPS_ENABLED')) {
         loadtest "fips/ecryptfs_fips";
     }
     loadtest "console/gpg";

--- a/lib/mm_tests.pm
+++ b/lib/mm_tests.pm
@@ -46,7 +46,7 @@ sub configure_stunnel {
     if (!$is_server) {
         assert_script_run "sed -i 's/^client = no/client = yes/' /etc/stunnel/stunnel.conf";
     }
-    my $conf = get_var('FIPS_TS') || get_var('FIPS') ? "fips = yes\n" : '';
+    my $conf = get_var('FIPS_ENABLED') || get_var('FIPS') ? "fips = yes\n" : '';
     $conf .= "[VNC]\naccept = 15905\nconnect = ";
     $conf .= $is_server ? "5905\n" : "10.0.2.1:15905\n";
     assert_script_run "echo \"$conf\" >> /etc/stunnel/stunnel.conf";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -831,34 +831,34 @@ elsif (get_var("SUPPORT_SERVER")) {
 elsif (get_var("SLEPOS")) {
     load_slepos_tests();
 }
-elsif (get_var("FIPS_TS") || get_var("SECURITY_TEST")) {
+elsif (get_var("SECURITY_TEST")) {
     prepare_target();
     if (get_var('BOOT_HDD_IMAGE')) {
         loadtest "console/consoletest_setup";
     }
-    if (check_var("FIPS_TS", "setup")) {
+    if (check_var("SECURITY_TEST", "fips_setup")) {
         # Setup system into fips mode
         loadtest "fips/fips_setup";
     }
-    elsif (check_var("FIPS_TS", "fipsenv")) {
+    elsif (check_var("SECURITY_TEST", "fips_env")) {
         loadtest "fips/openssl/openssl_fips_env";
     }
-    elsif (check_var("FIPS_TS", "core")) {
+    elsif (check_var("SECURITY_TEST", "core")) {
         load_security_tests_core;
     }
-    elsif (check_var("FIPS_TS", "web")) {
+    elsif (check_var("SECURITY_TEST", "web")) {
         load_security_tests_web;
     }
-    elsif (check_var("FIPS_TS", "misc")) {
+    elsif (check_var("SECURITY_TEST", "misc")) {
         load_security_tests_misc;
     }
-    elsif (check_var("FIPS_TS", "crypt")) {
+    elsif (check_var("SECURITY_TEST", "crypt")) {
         load_security_tests_crypt;
     }
-    elsif (check_var("FIPS_TS", "ipsec")) {
+    elsif (check_var("SECURITY_TEST", "ipsec")) {
         loadtest "console/ipsec_tools_h2h";
     }
-    elsif (check_var("FIPS_TS", "mmtest")) {
+    elsif (check_var("SECURITY_TEST", "mmtest")) {
         # Load client tests by APPTESTS variable
         load_applicationstests;
     }

--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -71,7 +71,7 @@ sub gpg_generate_key {
     wait_still_screen 1;
     type_string "$passwd\n";
     wait_still_screen 1;
-    if (get_var("FIPS") || get_var("FIPS_TS") && $key_size == 1024) {
+    if (get_var("FIPS") || get_var("FIPS_ENABLED") && $key_size == 1024) {
         assert_screen("key-generation-failed");
     }
     else {
@@ -124,7 +124,7 @@ sub run {
     }
 
     # fips environment, 1024 bit RSA size key should NOT work
-    if (get_var("FIPS") || get_var("FIPS_TS")) {
+    if (get_var("FIPS") || get_var("FIPS_ENABLED")) {
         gpg_generate_key(1024);
     }
 }

--- a/tests/fips/openssl/openssl_fips_hash.pm
+++ b/tests/fips/openssl/openssl_fips_hash.pm
@@ -11,8 +11,8 @@
 # approved HASH algorithms: SHA1 and SHA2 (224, 256, 384, 512)
 
 # Summary: Add Hash and Cipher test cases for openssl-fips
-#    A new test suite is created for FIPS_TS, named "core", which will
-#    contain all the basic test cases for fips verificaton. Just like
+#    A new test suite "core" is created, which contains all the basic
+#    test cases for fips verificaton when FIPS_ENABLED is set, like
 #    the cases to verify opessl hash, cipher, or public key algorithms
 # Maintainer: Qingming Su <qingming.su@suse.com>
 

--- a/tests/shutdown/grub_set_bootargs.pm
+++ b/tests/shutdown/grub_set_bootargs.pm
@@ -19,7 +19,7 @@ sub run {
     my @cmds;
     push @cmds, "source /etc/default/grub";
     push @cmds, 'new_cmdline=`echo $GRUB_CMDLINE_LINUX_DEFAULT | sed \'s/\(^\| \)quiet\($\| \)/ /\'`';
-    if (get_var("ENABLE_FIPS")) {
+    if (get_var("FIPS_ENABLED")) {
         push @cmds, 'new_cmdline="$new_cmdline fips=1"';
         if (get_var("ENCRYPT") && !get_var("FULL_LVM_ENCRYPT")) {
             push @cmds, 'new_cmdline="$new_cmdline boot=$(df /boot | tail -1 | cut -d" " -f1)"';

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -439,7 +439,7 @@ sub setup_stunnel_server {
     assert_script_run 'chmod 0600 ~/.vnc/passwd';
     assert_script_run 'vncserver :5';
     assert_script_run 'netstat -nal | grep 5905';
-    if (get_var('FIPS_TS') || get_var('FIPS')) {
+    if (get_var('FIPS_ENABLED') || get_var('FIPS')) {
         assert_script_run "grep 'stunnel:.*FIPS mode enabled' /var/log/messages";
     }
     $disable_firewall = 1;


### PR DESCRIPTION
1. Introduce **FIPS_ENABLED** to control whether to run fips-only cases in lib/main_common.pm
2. Change **FIPS_TS** to **SECURITY_TEST** in main.pm to make them unified.

The benefit is that we can easily control whether to run these testsuites from FIPS environment or non-fips environment. So it can make these testsuite adoptable for more scenarios. And reduce coupling between two modules.

- Related ticket: https://progress.opensuse.org/issues/37805
- Verification run: 
  'web' testsuite as example here:
  - Run without FIPS_ENABLED: http://10.67.17.9/tests/1067
  - Run with FIPS_ENABLED: http://10.67.17.9/tests/1068
