### PR TITLE
Failing to upload default grub file can be accepted

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -158,7 +158,7 @@ sub setup_console_in_grub {
     }
     save_screenshot;
     upload_logs($grub_cfg_file);
-    upload_logs($grub_default_file);
+    upload_logs($grub_default_file, failok => 1);
 }
 
 sub mount_installation_disk {


### PR DESCRIPTION
This file does not exist on old SLESs. So test suites relating to these SLESs should not fail.

- Related ticket: https://openqa.suse.de/tests/1880375#
- Needles: n/a
- Verification run: n/a

Please help merge this asap. I do not want to block anyone's test run. 
@mitiao @alice-suse @XGWang0 @xguo @Julie-CAO