### PR TITLE
Fix issue about no /etc/default/grub file is isued to upload on sles-…

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -144,6 +144,7 @@ sub setup_console_in_grub {
         $cmd = "cat $grub_default_file $grub_cfg_file";
         assert_script_run($cmd);
         save_screenshot;
+        upload_logs($grub_default_file);
     }
     elsif ($grub_ver eq "grub1") {
         $cmd
@@ -158,7 +159,6 @@ sub setup_console_in_grub {
     }
     save_screenshot;
     upload_logs($grub_cfg_file);
-    upload_logs($grub_default_file);
 }
 
 sub mount_installation_disk {


### PR DESCRIPTION
Fix virtualization internal issue about un-upload /etc/default/grub file to master due to sles-11-sp4 lacks of this file

- Related ticket: https://trello.com/c/alFAmT5D/233-p1openqa-updatepkg-failure-on-sle11sp4-host
- Verification run: http://10.67.19.191/tests/51
