### PR TITLE
Replacing module URLs with local addresses for SLES 15 or above is already done

### DIFF
--- a/tests/virt_autotest/host_upgrade_step2_run.pm
+++ b/tests/virt_autotest/host_upgrade_step2_run.pm
@@ -34,7 +34,6 @@ sub run {
     my $upgrade_product = get_required_var('UPGRADE_PRODUCT');
     my ($upgrade_release) = lc($upgrade_product) =~ /sles-([0-9]+)-sp/;
     if ($upgrade_release >= 15) {
-        repl_addon_with_daily_build_module_in_files('/root/autoupg.xml');
         upload_logs('/root/autoupg.xml');
     }
 }


### PR DESCRIPTION
Replacing module URLs with local addresses for SLES 15 or above is already done in vh test script

1.`repl_addon_with_daily_build_module_in_files` is not suitable for vh host upgrade scenario
2.Replacing module URLs with local addresses for SLES 15 or above is done in `vh-update-lib.sh`
3.Remove `repl_addon_with_daily_build_module_in_files` in `host_upgrade_step2_run`

- Related ticket: https://openqa.suse.de/tests/1890144#
- Needles: n/a
- Verification run: https://10.67.17.5/tests/479/file/host_upgrade_step2_run-autoupg.xml

@alice-suse @XGWang0 @xguo @Julie-CAO