### PR TITLE
Enable linuxrc coredumps and increase debug level

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -67,8 +67,11 @@ sub run {
     my $type_speed = 20;
     # Execute installation command on pxe management cmd console
     type_string ${image_path} . " ", $type_speed;
-    type_string "vga=791 ",   $type_speed;
-    type_string "Y2DEBUG=1 ", $type_speed;
+    type_string "vga=791 ",                      $type_speed;
+    type_string "Y2DEBUG=1 ",                    $type_speed;
+    type_string "linuxrc.core=/dev/$serialdev ", $type_speed;
+    type_string "linuxrc.log=/dev/$serialdev ",  $type_speed;
+    type_string "linuxrc.debug=4,trace ",        $type_speed;
 
     if ((check_var('BACKEND', 'ipmi') && !check_var('AUTOYAST', '1')) || get_var('SES5_DEPLOY')) {
         my $cmdline = '';


### PR DESCRIPTION
Issue reported in #poo38411 was not reproduced on local openQA instance. However we were missing some linuxrc boot parameters which we are already using regularly in other tests.
On the top of that we should also increase debug level of linuxrc. 
* [redirect linuxrc.log to serial](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/c712b7edfe65eea0df9d6ad0fede7a915b4576c6/lib/bootloader_setup.pm#L366)
* [enable linuxrc coredumps](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/c712b7edfe65eea0df9d6ad0fede7a915b4576c6/lib/bootloader_setup.pm#L372)

- Related ticket: [[functional][y][sporadic][ipmi] test fails in boot_from_pxe - installer does not show up](https://progress.opensuse.org/issues/38411)