### PR TITLE
Introduce LVM thin volume test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -819,6 +819,9 @@ sub load_inst_tests {
             elsif (get_var('FULL_LVM_ENCRYPT')) {
                 loadtest 'installation/partitioning_full_lvm';
             }
+            elsif (get_var('LVM_THIN_LV')) {
+                loadtest "installation/partitioning_lvm_thin_provisioning";
+            }
             if (get_var("FILESYSTEM")) {
                 if (get_var('PARTITIONING_WARNINGS')) {
                     loadtest 'installation/partitioning_warnings';
@@ -994,6 +997,7 @@ sub load_consoletests {
         loadtest "rt/kmp_modules";
     }
     loadtest "console/consoletest_setup";
+    loadtest "console/lvm_thin_check" if get_var('LVM_THIN_LV');
     loadtest 'console/integration_services' if is_hyperv;
     loadtest "locale/keymap_or_locale";
     loadtest "console/repo_orphaned_packages_check" if is_jeos;

--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -17,7 +17,7 @@ use testapi;
 use version_utils 'is_storage_ng';
 use installation_user_settings 'await_password_check';
 
-our @EXPORT = qw(addpart addlv create_new_partition_table enable_encryption_guided_setup select_first_hard_disk take_first_disk %partition_roles);
+our @EXPORT = qw(addpart addlv addvg create_new_partition_table enable_encryption_guided_setup select_first_hard_disk take_first_disk %partition_roles);
 
 our %partition_roles = qw(
   OS alt-o
@@ -155,6 +155,27 @@ sub addpart {
     send_key((is_storage_ng) ? $cmd{next} : $cmd{finish});
 }
 
+sub addvg {
+    my (%args) = @_;
+
+    assert_screen 'expert-partitioner';
+    send_key $cmd{system_view};
+    send_key_until_needlematch('volume_management_feature', 'down');
+    send_key $cmd{addpart};
+    wait_still_screen 2;
+    save_screenshot;
+    send_key 'down';
+    send_key 'ret';
+    assert_screen 'partition-add-volume-group';
+    send_key 'alt-v';
+    type_string $args{name};
+    assert_and_click 'partition-select-first-from-top';
+    send_key 'alt-a';
+    wait_still_screen 2;
+    save_screenshot;
+    send_key(is_storage_ng() ? $cmd{next} : $cmd{finish});
+}
+
 sub addlv {
     my (%args) = @_;
     send_key $cmd{addpart};
@@ -165,6 +186,9 @@ sub addlv {
     send_key 'ret';    # create logical volume
     assert_screen 'partition-lv-type';
     type_string $args{name};
+
+    send_key($args{thinpool} ? 'alt-t' : $args{thinvolume} ? 'alt-i' : 'alt-o');
+
     send_key $cmd{next};
     assert_screen 'partition-lv-size';
     if ($args{size}) {    # use default max size if not defined
@@ -177,6 +201,7 @@ sub addlv {
         type_string $args{size} . 'mb';
     }
     send_key $cmd{next};
+    return if $args{thinpool};
     assert_screen 'partition-role';
     send_key $partition_roles{$args{role}};                        # swap role
     send_key $cmd{next};
@@ -184,6 +209,7 @@ sub addlv {
     # Add mount
     mount_device $args{mount} if $args{mount};
     send_key(is_storage_ng() ? $cmd{next} : $cmd{finish});
+    assert_screen 'expert-partitioner';
 }
 
 sub select_first_hard_disk {

--- a/tests/console/lvm_thin_check.pm
+++ b/tests/console/lvm_thin_check.pm
@@ -1,0 +1,73 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Simple LVM thin provisioning check
+# Maintainer: Martin Loviska <mloviska@suse.com>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use utils;
+use y2logsstep;
+use serial_terminal 'select_virtio_console';
+
+sub run {
+    my $lv_stats = {
+        write_access => qr/\s{2}LV Write Access \s+ read\/write/,
+        status       => qr/\s{2}LV Status \s+ available/,
+        readahead    => qr/\s{2}Read ahead sectors \s+ auto/,
+        # 254 as major no. points to dev-mapper, see /proc/devices
+        block_device => qr/\s{2}Block device \s+ 254:\d/
+    };
+
+    select_virtio_console();
+    record_info('INFO', 'Print lvm setup');
+    assert_script_run 'lsblk';
+    assert_script_run 'lvmdiskscan';
+    assert_script_run 'lvscan';
+    assert_script_run 'lvs -a  | tee original_usage';
+    assert_script_run 'pvs -a';
+    # thin volume does not exceed thin pool size in our tests
+    my @volumes = split(/\n/, script_output q[lvscan | awk '{print $2}'| sed s/\'//g]);
+    # check for read only volumes and
+    foreach my $volume (@volumes) {
+        chomp;
+        my $lvdisp_out = script_output "lvdisplay $volume";
+        foreach (keys %{$lv_stats}) {
+            die "Value of $lv_stats->{$_} was not found in $volume configuration" unless ($lvdisp_out =~ /(?<tested_string>$lv_stats->{$_})/);
+            record_info('TEST', "Found $+{tested_string} in $volume");
+        }
+    }
+
+    record_info('INFO', 'Create a file on thin volume');
+    my $test_file = '/home/bernhard/test_file.txt';
+    assert_script_run "dd if=/dev/zero of=$test_file count=1024 bs=1M";
+    assert_script_run "ls -lah $test_file";
+    assert_script_run 'lvs -a | tee instant_usage';
+    if ((script_run 'diff original_usage instant_usage') != 1) {
+        die "LVM usage stats do not differ!";
+    }
+}
+
+sub post_fail_hook {
+    my $self = shift;
+    select_console 'root-console';
+    my $lvmdump_regex = qr{/root/lvmdump-.*?-\d+\.tgz};
+    my $out           = script_output 'lvmdump';
+    if ($out =~ /(?<lvmdump_gzip>$lvmdump_regex)/) {
+        upload_logs "$+{lvmdump_gzip}";
+    }
+    $self->save_and_upload_log('lvm dumpconfig', '/tmp/lvm_dumpconf.out');
+    $self->SUPER::post_fail_hook;
+}
+
+1;
+

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -49,6 +49,7 @@ sub run {
         $cmd{resize}           = 'alt-r';
         $cmd{raw_volume}       = 'alt-r';
         $cmd{enable_snapshots} = 'alt-a';
+        $cmd{system_view}      = 'alt-s';
         # Set shortcut for role selection when creating partition
         $partition_roles{raw} = $cmd{raw_volume};
 

--- a/tests/installation/partitioning_lvm_thin_provisioning.pm
+++ b/tests/installation/partitioning_lvm_thin_provisioning.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: LVM thin provisioning setup
+# Maintainer: Martin Loviska <mloviska@suse.com>
+
+use strict;
+use warnings;
+use base 'y2logsstep';
+use testapi;
+use partition_setup qw(create_new_partition_table addpart addlv addvg);
+use version_utils 'is_storage_ng';
+
+sub run {
+    create_new_partition_table;
+    # create boot and 2 lvm partitions
+    addpart(role => 'raw', fsid => 'bios-boot', size => 2);
+    addpart(role => 'raw', size => 10000);
+    addpart(role => 'raw');
+    # create volume group for root and swap non thin lvs
+    addvg(name => 'vg-no-thin');
+    addlv(name => 'lv-swap', role => 'swap', size => 2000);
+    addlv(name => 'lv-root', role => 'OS');
+    # create volume group for thin lv
+    addvg(name => 'vg-thin');
+    addlv(name => 'thin_pool', thinpool => 1);
+    addlv(name => 'thin_lv_home', role => 'data', thinvolume => 1);
+    send_key $cmd{accept};
+
+}
+
+1;


### PR DESCRIPTION
- Related ticket: [[sle][functional][yast][y][mandatory][medium] LVM Thin Provisioning on openSUSE](https://progress.opensuse.org/issues/39023)
- Needles: [NEW:Select first drive in add VG menu #408](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/408)
- Verification runs:
*[opensuse-Tumbleweed-DVD-x86_64-BuildBuild20180731-lvm_thin_volumes@64bit](http://dhcp128.suse.cz/tests/5161#)
*[opensuse-Tumbleweed-DVD-x86_64-BuildBuild20180731-lvm_thin_volumes@64bit - post fail hook](http://dhcp128.suse.cz/tests/5170#downloads)
