### PR TITLE
Workaround for wrong screen switch from bootloader to inst-slof

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -178,6 +178,9 @@ sub boot_local_disk {
         # TODO use bootindex to properly boot from disk when first in boot order is cd-rom
         wait_screen_change { send_key 'ret' };
         assert_screen [qw(inst-slof bootloader grub2 inst-bootmenu)];
+        if (match_has_tag 'bootloader') {
+            assert_screen 'inst-slof';
+        }
         if (match_has_tag 'grub2') {
             diag 'already in grub2, returning from boot_local_disk';
             stop_grub_timeout;


### PR DESCRIPTION
This issue failed for the screen switched unexpected to bootloader then to inst-slof, while we need assert the inst-slof after needle  inst-bootmenu-boot-harddisk matched. Workaround this by if assert the bootloader, continue to assert the inst-slof.

- Related ticket: https://progress.opensuse.org/issues/38996
- Verification run: no PPC worker resource, so I can't verify it locally
