### PR TITLE
Don't check for missing needle while booting ARM

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -192,9 +192,6 @@ sub boot_local_disk {
             save_screenshot;
         }
     }
-    if (check_var('ARCH', 'aarch64') and get_var('UEFI')) {
-        assert_screen 'boot-firmware';
-    }
     send_key 'ret';
 }
 


### PR DESCRIPTION
For some reason we assert that `boot-firmware` is seen, but there appears to be
no such needle. Also this code used to report a soft failure, however the
soft failure was removed, but not the assert screen.

In any case we should not assert anything here, we should just press
enter. Booting on ARM works the same as X86 since the QEMU rewrite and if
someone is not using the rewrite, then they will go down a different code path
anyway. It seems like we are trying to assert that ARM does the wrong thing, which is really weird.

@mitiao this should fix https://openqa.suse.de/tests/1897300