### PR TITLE
Add SLE15 style system roles for openSUSE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -302,6 +302,17 @@ sub is_leanos {
     return 0;
 }
 
+sub is_sle12sp2_using_system_role {
+    #system_role selection during installation was added as a new feature since sles12sp2
+    #so system_role.pm should be loaded for all tests that actually install to versions over sles12sp2
+    #no matter with or without INSTALL_TO_OTHERS tag
+    return is_sle('>=12-SP2')
+      && check_var('ARCH', 'x86_64')
+      && is_server()
+      && (!is_sles4sap() || is_sles4sap_standard())
+      && (install_this_version() || install_to_other_at_least('12-SP2'));
+}
+
 sub is_desktop_module_selected {
     # desktop applications module is selected if following variables have following values:
     # productivity and ha require desktop applications, so it's preselected
@@ -534,8 +545,13 @@ sub load_system_role_tests {
         loadtest "installation/logpackages";
     }
     loadtest "installation/disable_online_repos" if get_var('DISABLE_ONLINE_REPOS') && !get_var('OFFLINE_SUT');
-    loadtest "installation/installer_desktopselection" if is_opensuse;
-    loadtest "installation/system_role" if is_caasp('kubic');
+    if (is_leap('<=15.0')) {
+        loadtest "installation/installer_desktopselection";
+    }
+    elsif (is_tumbleweed || is_caasp('kubic') || is_sle12sp2_using_system_role() || is_sle('15+'))
+    {
+        loadtest "installation/system_role";
+    }
 }
 
 sub load_jeos_tests {
@@ -828,20 +844,6 @@ sub load_inst_tests {
         # Run system_role/desktop selection tests if using the new openSUSE installation flow
         if (get_var("SYSTEM_ROLE_FIRST_FLOW")) {
             load_system_role_tests;
-        }
-        #system_role selection during installation was added as a new feature since sles12sp2
-        #so system_role.pm should be loaded for all tests that actually install to versions over sles12sp2
-        #no matter with or without INSTALL_TO_OTHERS tag
-        if (
-            is_sle
-            && (check_var('ARCH', 'x86_64')
-                && sle_version_at_least('12-SP2')
-                && is_server()
-                && (!is_sles4sap() || is_sles4sap_standard())
-                && (install_this_version() || install_to_other_at_least('12-SP2'))
-                || is_sle('15+')))
-        {
-            loadtest "installation/system_role";
         }
         if (is_sles4sap() and sle_version_at_least('15') and check_var('SYSTEM_ROLE', 'default')) {
             loadtest "installation/sles4sap_product_installation_mode";

--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -7,14 +7,14 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Check system role selection screen or select system role. Added in SLE 12 SP2
-# Maintainer: Jozef Pupava <jpupava@suse.com>
+# Summary: Check default system role selection screen (only for SLE) and select system role. Added in SLE 12 SP2
+# Maintainer: Jozef Pupava <jpupava@suse.com>, Joaquín Rivera <jeriveramoya@suse.com>
 # Tags: poo#16650, poo#25850
 
 use strict;
 use base "y2logsstep";
 use testapi;
-use version_utils qw(is_sle is_caasp);
+use version_utils qw(is_sle is_caasp is_opensuse);
 
 
 my %role_hotkey = (
@@ -28,7 +28,7 @@ my %role_hotkey = (
 sub change_system_role {
     my ($system_role) = @_;
     # Since SLE 15 we do not have shortcuts for system roles anymore
-    if ((is_sle '15+') || (is_caasp 'kubic')) {
+    if (is_sle('15+') || is_caasp('kubic') || is_opensuse) {
         if (check_var('VIDEOMODE', 'text')) {
             # Expect that no actions are done before and default system role is preselected
             send_key_until_needlematch "system-role-$system_role-focused",  'down';    # select role
@@ -51,16 +51,14 @@ sub assert_system_role {
     # Still initializing the system at this point, can take some time
     # Asserting screen with preselected role
     # Proper default role assertion will be addressed in poo#37504
-    assert_screen 'system-role-default-system', 180;
-    my $system_role = get_var('SYSTEM_ROLE', 'default');
-    if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default')) {
-        change_system_role($system_role);
-    }
+    assert_screen [qw(before-role-selection system-role-default-system)], 180;
+    die "SYSTEM_ROLE is not defined" if (match_has_tag 'before-role-selection') && !get_var('SYSTEM_ROLE');
+    my $system_role = is_opensuse ? get_var('SYSTEM_ROLE') : get_var('SYSTEM_ROLE', 'default');
+    change_system_role($system_role) if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'));
     send_key $cmd{next};
 }
 
 sub run {
-    # Define default role
     assert_system_role;
 }
 


### PR DESCRIPTION
Add SLE15 style system roles for openSUSE

- Related ticket: https://progress.opensuse.org/issues/39014
- Needles: I am not sure how to create the needles, should I expect that openSUSE products will have a default value as in SLE, because atm there is not.
- Verification run (not yet): 