### PR TITLE
Remove soft-fail to fix poo#39248

### DIFF
--- a/tests/installation/isosize.pm
+++ b/tests/installation/isosize.pm
@@ -22,12 +22,7 @@ sub run {
     my $result = 'ok';
     my $max    = get_var("ISO_MAXSIZE", 0);
     if (!$size || !$max || $size > $max) {
-        if (check_var('VERSION', '12-SP4') && check_var('FLAVOR', 'Desktop-DVD')) {
-            record_soft_failure("bsc#1101761 - SLED ISO size is over limit");
-        }
-        else {
-            $result = 'fail';
-        }
+        $result = 'fail';
     }
     if (!defined $size) {
         diag("iso path invalid: $iso");


### PR DESCRIPTION
The ISO size bug bsc#1101761 has been fix, so remove soft-fail for it.

- Related ticket: 
  https://progress.opensuse.org/issues/39248
