### PR TITLE
Use correct name to disable src repo for sle maint update tests

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -148,7 +148,12 @@ sub prepare_source_repo {
 }
 
 sub disable_source_repo {
-    zypper_call("mr -d repo-source");
+    if (is_sle && get_var('FLAVOR') =~ /-Updates$|-Incidents$/) {
+        zypper_call(q{mr -d $(zypper -n lr | awk '/-Source/ {print $1}')});
+    }
+    elsif (script_run('zypper lr repo-source') == 0) {
+        zypper_call("mr -d repo-source");
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
See https://progress.opensuse.org/issues/38393 and https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5498#issuecomment-410784513