### PR TITLE
JeOS: Disable zypper_info again

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1431,7 +1431,10 @@ sub load_extra_tests_textmode {
     # dependency of git test
     loadtest "console/sshd";
     loadtest "console/zypper_ref";
-    loadtest "console/zypper_info";
+    # The test can't be run on JeOS as it's heavily dependant on SLES build number we don't have in JeOS
+    unless (is_jeos) {
+        loadtest "console/zypper_info";
+    }
     loadtest "console/update_alternatives";
     # start extra console tests from here
     # Audio device is not supported on ppc64le, s390x, JeOS, and Xen PV


### PR DESCRIPTION
Fails here: https://openqa.suse.de/tests/1899996#step/zypper_info/6

`zypper_info` was enabled in de4b83de087e680ad8712845edae39df16df0f11
commit but it shouldn't. JeOS jobs don't have variables like
`REPO_SLES_SOURCE` or `REPO_SLE15_MODULE_BASESYSTEM_SOURCE` because of
the way how the images are being built.