### PR TITLE
Update regression-documentation case on Tumbleweed

### DIFF
--- a/tests/x11/gnote/gnote_rename_title.pm
+++ b/tests/x11/gnote/gnote_rename_title.pm
@@ -19,18 +19,14 @@ use version_utils 'is_sle';
 
 
 sub run {
+    my ($self) = @_;
     x11_start_program('gnote');
     send_key "ctrl-n";
     assert_screen 'gnote-new-note', 5;
     send_key "up";
     send_key "up";
     type_string "new title-opensuse\n";
-    send_key 'esc';    #back to all notes interface
-    send_key_until_needlematch 'gnote-new-note-title-matched', 'down', 6;
-    send_key "delete";
-    send_key "tab";
-    send_key "ret";
-    send_key "ctrl-w";
+    $self->cleanup_gnote;
 }
 
 1;

--- a/tests/x11/gnote/gnote_search_body.pm
+++ b/tests/x11/gnote/gnote_search_body.pm
@@ -20,6 +20,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     $self->gnote_launch();
+    send_key "down" if check_screen 'gnote-start-here-matched_TW';
     send_key "ret";
     $self->gnote_search_and_close('and', 'gnote-search-body-and');
 }

--- a/tests/x11/gnote/gnote_search_title.pm
+++ b/tests/x11/gnote/gnote_search_title.pm
@@ -20,6 +20,7 @@ use testapi;
 sub run {
     my ($self) = @_;
     $self->gnote_launch();
+    send_key "down" if check_screen 'gnote-start-here-matched_TW';
     send_key "ret";
     $self->gnote_search_and_close('here', 'gnote-search-title-here');
 }

--- a/tests/x11/gnote/gnote_undo_redo.pm
+++ b/tests/x11/gnote/gnote_undo_redo.pm
@@ -44,13 +44,7 @@ sub run {
     $self->undo_redo_once;
 
     #clean: remove the created new note
-    send_key "esc";
-    send_key_until_needlematch 'gnote-new-note-matched', 'down', 6;
-    send_key "delete";
-    send_key "tab";
-    send_key "ret";
-    assert_screen "gnote-first-launched";
-    send_key "ctrl-w";
+    $self->cleanup_gnote;
 }
 
 1;

--- a/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
@@ -15,6 +15,7 @@ use strict;
 use testapi;
 use utils;
 use version_utils qw(is_sle is_tumbleweed);
+use repo_tools qw(prepare_oss_repo disable_oss_repo);
 
 # open desktop mainmenu and click office
 sub open_mainmenu {
@@ -92,42 +93,57 @@ sub run {
 
     # launch components from Activities overview
     $self->open_overview();
-    type_string "base";                                #open base
+    type_string "base";
+    # tag is base-install means libreoffice-base not installed
+    if (assert_screen 'base-install') {
+        send_key 'esc';
+        send_key 'esc';
+        x11_start_program('xterm');
+        script_run("gsettings set org.gnome.desktop.session idle-delay 0", 0);    #value=0 means never blank screen
+        become_root;
+        prepare_oss_repo;
+        script_run("zypper in -y libreoffice-base",                          900);
+        script_run("gsettings set org.gnome.desktop.session idle-delay 900", 0);     #default value=900
+        disable_oss_repo;
+        send_key 'alt-f4';
+        $self->open_overview();
+        type_string "base";
+    }
     assert_screen 'overview-office-base';
     send_key "ret";
     select_base_and_cleanup;
 
     $self->open_overview();
-    type_string "calc";                                #open calc
+    type_string "calc";                                                              #open calc
     assert_and_click 'overview-office-calc';
     assert_screen 'test-oocalc-1';
-    send_key "ctrl-q";                                 #close calc
+    send_key "ctrl-q";                                                               #close calc
 
     $self->open_overview();
-    type_string "draw";                                #open draw
+    type_string "draw";                                                              #open draw
     assert_screen 'overview-office-draw';
     send_key "ret";
     assert_screen 'oodraw-launched';
-    send_key "ctrl-q";                                 #close draw
+    send_key "ctrl-q";                                                               #close draw
 
     $self->open_overview();
-    type_string "impress";                             #open impress
+    type_string "impress";                                                           #open impress
     assert_screen 'overview-office-impress';
     send_key "ret";
     assert_screen [qw(ooimpress-select-a-template ooimpress-launched)];
     if (match_has_tag 'ooimpress-select-a-template') {
-        send_key 'alt-f4';                             # close impress template window
+        send_key 'alt-f4';                                                           # close impress template window
         assert_screen 'ooimpress-launched';
     }
-    send_key "ctrl-q";                                 #close impress
+    send_key "ctrl-q";                                                               #close impress
 
     $self->open_overview();
-    type_string "writer";                              #open writer
+    type_string "writer";                                                            #open writer
     assert_screen 'overview-office-writer';
     send_key "ret";
     assert_screen 'test-ooffice-1';
     assert_and_click 'ooffice-writing-area', 'left', 10;
-    send_key "ctrl-q";                                 #close writer
+    send_key "ctrl-q";                                                               #close writer
 }
 
 1;

--- a/tests/x11/libreoffice/libreoffice_recent_documents.pm
+++ b/tests/x11/libreoffice/libreoffice_recent_documents.pm
@@ -35,13 +35,13 @@ sub run {
     # Check Recent Documents
     wait_still_screen;
     x11_start_program('oowriter');
-    if (is_sle('<15')) {
-        send_key "alt-f";
-    }
     # Because of bsc#1074057 alt-f is not working in libreoffice under wayland
     # use another way to replace alt-f in SLED15
     if (is_sle '15+') {
         assert_and_click 'ooffice-writing-file', 'left', 10;
+    }
+    else {
+        send_key "alt-f";    # is_sle('<15') and openSUSE all need to send key
     }
     assert_screen 'oowriter-menus-file';
     if (is_tumbleweed || is_sle('15+')) {


### PR DESCRIPTION
Migrate regression-documentation cases of SLE to Tumbleweed

1. Update the cases
2. Create testsuite in o.o.o

**testsuite of regression-installation:**
DESKTOP=gnome
HDD_1=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2
REGRESSION=documentation
START_AFTER_TEST=create_hdd_gnome

Needle:
        [PR#409](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/409)

Reference:
        [poo#23780](https://progress.opensuse.org/issues/23780)
Verfication run:
        [create_hdd_gnome](http://10.67.19.67/tests/614)
        [qam-regression-documentation](http://10.67.19.67/tests/666)

