### PR TITLE
Increase timeout to fix poo#36841

### DIFF
--- a/tests/x11/remote_desktop/vino_client.pm
+++ b/tests/x11/remote_desktop/vino_client.pm
@@ -50,7 +50,7 @@ sub run {
     type_password;
     wait_still_screen 3;
     send_key 'ret';
-    assert_screen 'vinagre-gcc-sharing-activate';
+    assert_screen 'vinagre-gcc-sharing-activate', 120;
     wait_screen_change { send_key 'ctrl-w'; };    # Disconnect vinagre
     wait_screen_change { send_key 'ctrl-q'; };    # Exit vinagre
     save_screenshot;


### PR DESCRIPTION
Test suite "remote-desktop-vino-client" failed from time to time when doing assert_screen 'vinagre-gcc-sharing-activate' because of timeout error, so increase the maximum waiting time to fix this.

- Related ticket:  https://progress.opensuse.org/issues/36841
- Verification run: 
   http://10.67.18.150/tests/138
   http://10.67.18.150/tests/137
