### PR TITLE
[NFV] Add module to process results

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1583,7 +1583,10 @@ sub load_networkd_tests {
 sub load_nfv_master_tests {
     loadtest "nfv/prepare_env";
     loadtest "nfv/run_integration_tests" if (check_var('BACKEND', 'qemu'));
-    loadtest "nfv/run_performance_tests" if (check_var('BACKEND', 'ipmi'));
+    if (check_var('BACKEND', 'ipmi')) {
+        loadtest "nfv/run_performance_tests";
+        loadtest "nfv/process_perf_results";
+    }
 }
 
 sub load_nfv_trafficgen_tests {

--- a/tests/kernel/mellanox_config.pm
+++ b/tests/kernel/mellanox_config.pm
@@ -33,7 +33,8 @@ sub run {
     my $protocol = get_var('MLX_PROTOCOL') || 2;
 
     if (check_var('VERSION', '15')) {
-        zypper_call('ar -f -G ' . get_required_var('GA_REPO'));
+        my $GA_REPO = 'http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/SUSE:SLE-15:GA.repo';
+        zypper_call("ar -f -G $GA_REPO");
     }
     zypper_call('--quiet in kernel-source rpm-build', timeout => 200);
 

--- a/tests/nfv/prepare_env.pm
+++ b/tests/nfv/prepare_env.pm
@@ -78,7 +78,7 @@ sub run {
 
     # Clone Trex repo inside VSPerf directories
     record_info("Clone TREX");
-    assert_script_run("cd /root/vswitchperf/src/trex; make", timeout => 200);
+    assert_script_run("cd /root/vswitchperf/src/trex; make", timeout => 500);
 
     # Copy VSPERF custom configuration files
     record_info("Copy config");

--- a/tests/nfv/process_perf_results.pm
+++ b/tests/nfv/process_perf_results.pm
@@ -1,0 +1,57 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Process results of  NFV Performance tests :
+#       - package and upload  perf logs to openQA job
+#       - fill up results DB with data
+# Maintainer: Anton Smorodskyi <asmorodskyi@suse.com>, Jose Lausuch <jalausuch@suse.com>
+
+use base "opensusebasetest";
+use testapi;
+use strict;
+use serial_terminal 'select_virtio_console';
+
+sub run {
+    select_console 'root-ssh' if (check_var('BACKEND', 'ipmi'));
+    select_virtio_console()   if (check_var('BACKEND', 'qemu'));
+
+    my $logs_path      = '/tmp/vsperf_logs.tar.gz';
+    my $results_folder = '/tmp';
+    my $export_script  = 'https://raw.githubusercontent.com/asmorodskyi/vsperf_influxdb_connector/master/export.py';
+
+    record_info("Install requests");
+    assert_script_run("pip2 install -q requests");
+
+    record_info("Upload logs");
+    assert_script_run("cd $results_folder");
+    assert_script_run("tar -czvf $logs_path $results_folder/results_*");
+    upload_logs($logs_path, failok => 1);
+
+    # Get OVS version
+    my $ovs_version = script_output(q(ovs-vswitchd --version|head -1|awk '{print $NF}'));
+
+    # Generate JOB URL (OSD)
+    my ($test_id) = get_required_var("NAME") =~ m{^([^-]*)};
+    $test_id =~ s/^0+//;
+    my $test_url = "http://openqa.suse.de/tests/$test_id";
+
+    record_info("Parse results");
+    assert_script_run("wget $export_script");
+    assert_script_run('chmod +x export.py');
+    assert_script_run(sprintf('./export.py --parsefolder "%s" --targeturl http://10.86.0.128:8086 --os_version %s --os_build %s --vswitch_version %s --openqa_url %s',
+            $results_folder, get_var('VERSION'), get_var('BUILD'), $ovs_version, $test_url));
+
+    upload_logs('/tmp/export.log', failok => 1);
+}
+
+sub test_flags {
+    return {fatal => 0};
+}
+
+1;

--- a/tests/nfv/run_performance_tests.pm
+++ b/tests/nfv/run_performance_tests.pm
@@ -20,16 +20,12 @@ sub run {
 
     record_info("Check Hugepages");
     assert_script_run('cat /proc/meminfo |grep -i huge');
+
     record_info("Start test");
     assert_script_run('source /root/vsperfenv/bin/activate && cd /root/vswitchperf/');
     assert_script_run('./vsperf --conf-file=/root/vswitchperf/conf/10_custom.conf --vswitch OvsVanilla phy2phy_tput',
         timeout => 3600);
     mutex_create("NFV_TESTING_DONE");
-
-    record_info("Upload logs");
-    script_run("cd /tmp");
-    script_run(q(find . -type d -name "results*"|xargs -d "\n" tar -czvf vsperf_logs.tar.gz));
-    upload_logs('vsperf_logs.tar.gz', failok => 1);
 }
 
 sub test_flags {


### PR DESCRIPTION
This module will upload the results to openqa and will call an external script to parse and push the data to the NFV dashboard.

- Related ticket: https://progress.opensuse.org/issues/38999
- Verification runs:
    (baremetal): http://loewe.arch.suse.de/tests/1138#
    (virtual): http://fromm.arch.suse.de/tests/1297
    the export.log is uploaded as attachment http://fromm.arch.suse.de/tests/1297/file/process_perf_results-export.log 
Response from DB: <empty> means that it is ok, otherwise, there will be an error message from InfluxDB.
 