### PR TITLE
install_packages: Handle mutually exclusive ffmpeg devel packages

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -154,8 +154,8 @@ sub problem_can_be_skipped {
     return 1 if $pkg =~ /^julia-compat(-devel)?/;
     # conflicts with wxWidgets-3_0-devel/
     return 1 if $pkg =~ /^wxWidgets-3_0-nostl-devel/;
-    # conflicts with split devel packages from ffmpeg (3)
-    return 1 if $pkg =~ /^ffmpeg2-devel/;
+    # ffmpeg was split into -2,3,4, and the -devel packages are mutually exclusive
+    return 1 if $pkg =~ /^ffmpeg-[23]-.*-devel/;
     # conflicts with libjpeg62-devel
     return 1 if $pkg =~ /^libjpeg8-devel/;
     # conflicts with the plain variant


### PR DESCRIPTION
Following the ffmpeg split into -2,3,4, pick one -devel package set as they are mutually exclusive. On Leap 15.0 ffmpeg 3 remains the default, pick 4 nevertheless.

Fixes: 

- https://openqa.opensuse.org/tests/721762#step/install_packages/9
- https://openqa.opensuse.org/tests/721281#step/install_packages/9
- https://openqa.opensuse.org/tests/721282#step/install_packages/9
- https://openqa.opensuse.org/tests/721283#step/install_packages/9
- https://openqa.opensuse.org/tests/721284#step/install_packages/9
- https://openqa.opensuse.org/tests/721285#step/install_packages/9

Verification run: `data/lsmfip --verbose ffmpeg-3-libavresample-devel libswscale5-debuginfo libpostproc54-debuginfo libavfilter7-debuginfo libavutil56-debuginfo libswscale4-debuginfo libavcodec58 ffmpeg-4-private-devel ffmpeg-3-libavfilter-devel ffmpeg-4-libavfilter-devel libavformat58 libavutil55 ffmpeg-3-libpostproc-devel libavcodec58-debuginfo libavresample3 libswresample3-debuginfo libavresample4 ffmpeg-3-private-devel libswresample2-debuginfo ffmpeg-4-libavcodec-devel libavdevice57-debuginfo libpostproc55-debuginfo ffmpeg-3-libswscale-devel ffmpeg-3-libswresample-devel libswresample2 libswresample3 libavresample4-debuginfo libavdevice58-debuginfo ffmpeg-4-libavformat-devel libswscale4 ffmpeg-3-debuginfo libavdevice58 libavutil55-debuginfo ffmpeg-4-libavdevice-devel libpostproc55 libpostproc54 ffmpeg-4-libavutil-devel libavdevice57 libavformat57 ffmpeg-3-libavcodec-devel libavfilter6-debuginfo ffmpeg-4-debugsource ffmpeg-3-libavdevice-devel libavutil56 libavformat58-debuginfo libavfilter6 libavfilter7 libavresample3-debuginfo ffmpeg-4-libpostproc-devel libavcodec57 ffmpeg-4-libswresample-devel ffmpeg-3-libavformat-devel ffmpeg-4-libavresample-devel ffmpeg-3-debugsource libswscale5 ffmpeg-3-libavutil-devel ffmpeg-3 libavformat57-debuginfo libavcodec57-debuginfo ffmpeg-4-libswscale-devel`

- Incident: [openSUSE:Maintenance:8548](https://build.opensuse.org/project/show/openSUSE:Maintenance:8548)
- [RR#627968](https://build.opensuse.org/request/show/627968)