### PR TITLE
Also ensure bzip2 being installed

### DIFF
--- a/tests/autoyast/repos.pm
+++ b/tests/autoyast/repos.pm
@@ -26,9 +26,9 @@ sub run {
     assert_script_run 'ip a || ifstatus all';
     pkcon_quit;
     zypper_call 'ref';
-    # make sure that save_y2logs from yast2 package and tar is installed
+    # make sure that save_y2logs from yast2 package, tar and bzip2 are installed
     # even on minimal system
-    zypper_call 'in yast2 tar';
+    zypper_call 'in yast2 tar bzip2';
     assert_script_run 'save_y2logs /tmp/y2logs.tar.bz2';
     upload_logs '/tmp/y2logs.tar.bz2';
 }


### PR DESCRIPTION
bzip2 happened to be pulled in by libsolv-tools until recently, but
relying on such a co-incidence is not helpful for testing

On regular openSUSE installations, bzip2 is recommended by
patterns-base-enhanced_base, but not by the minimal patterns.

