### PR TITLE
Remove obsolete /var nocow check (now a partition)

### DIFF
--- a/tests/caasp/filesystem_ro.pm
+++ b/tests/caasp/filesystem_ro.pm
@@ -25,7 +25,6 @@ sub run {
 
     if (is_caasp '4.0+') {
         assert_script_run 'btrfs property get /var ro | grep "ro=false"';
-        assert_script_run 'lsattr -ld /var | grep No_COW';
     }
     else {
         assert_script_run 'btrfs property get /var/log ro | grep "ro=false"';


### PR DESCRIPTION
https://openqa.opensuse.org/tests/721788#step/filesystem_ro/14

CaaSP 4/Kubic now has a /var partition, so there is no point checking for nocow any more