### PR TITLE
Fix multi_user_dm test

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -941,7 +941,7 @@ sub handle_login {
         }
         type_string "root\n";
     }
-    elsif (get_var('DM_NEEDS_USERNAME')) {
+    elsif (match_has_tag('displaymanager-user-prompt') || get_var('DM_NEEDS_USERNAME')) {
         type_string "$myuser\n";
     }
     elsif (check_var('DESKTOP', 'gnome')) {

--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -64,10 +64,10 @@ sub run {
     assert_screen 'multi_users_dm', 180;    # gnome loading takes long sometimes
     wait_still_screen;
     if (check_var('DESKTOP', 'gnome')) {
-        send_key_until_needlematch('user#01_selected', 'tab', 5, 3);    # select created user #01
+        assert_and_click('user_not_listed');
     }
     elsif (check_var('DESKTOP', 'xfce')) {
-        send_key 'down';                                                # select created user #01
+        send_key 'down';                    # select created user #01
     }
     elsif (check_var('DESKTOP', 'kde')) {
         wait_screen_change { send_key 'shift-tab' };


### PR DESCRIPTION
I had to revert the multi_users_dm-user01_selected-20180803 needle as it broke the test:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/c7f0ecd53761649eae643ed9dcf0d51495983c3d
The needle is there to check if user01 is selected and must not match if user01 is NOT selected.

The test broke because the initial mouse cursor position was changed, again (from one of the corners to the middle of the screen), so it automatically selects user03 again.
So the send_key_until_needle_match needs to do again shift-tab insted of tab.