### PR TITLE
Add SLE15 style system roles for openSUSE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -302,6 +302,17 @@ sub is_leanos {
     return 0;
 }
 
+sub is_sle12sp2_using_system_role {
+    #system_role selection during installation was added as a new feature since sles12sp2
+    #so system_role.pm should be loaded for all tests that actually install to versions over sles12sp2
+    #no matter with or without INSTALL_TO_OTHERS tag
+    return is_sle('>=12-SP2')
+      && check_var('ARCH', 'x86_64')
+      && is_server()
+      && (!is_sles4sap() || is_sles4sap_standard())
+      && (install_this_version() || install_to_other_at_least('12-SP2'));
+}
+
 sub is_desktop_module_selected {
     # desktop applications module is selected if following variables have following values:
     # productivity and ha require desktop applications, so it's preselected
@@ -534,10 +545,15 @@ sub load_system_role_tests {
         loadtest "installation/logpackages";
     }
     loadtest "installation/disable_online_repos" if get_var('DISABLE_ONLINE_REPOS') && !get_var('OFFLINE_SUT');
-    loadtest "installation/installer_desktopselection" if is_opensuse;
-    loadtest "installation/system_role" if is_caasp('kubic');
+    # SYSTEM_ROLE_STYLE will be included in Mediums for openSUSE products progressively offering this new dialog
+    # i.e.: not all staging will receive it at the same time
+    if (get_var('SYSTEM_ROLE_STYLE') || is_caasp('kubic')) {
+        loadtest "installation/system_role";
+    }
+    elsif (is_opensuse) {
+        loadtest "installation/installer_desktopselection";
+    }
 }
-
 sub load_jeos_tests {
     load_boot_tests();
     loadtest "jeos/firstrun";
@@ -829,18 +845,7 @@ sub load_inst_tests {
         if (get_var("SYSTEM_ROLE_FIRST_FLOW")) {
             load_system_role_tests;
         }
-        #system_role selection during installation was added as a new feature since sles12sp2
-        #so system_role.pm should be loaded for all tests that actually install to versions over sles12sp2
-        #no matter with or without INSTALL_TO_OTHERS tag
-        if (
-            is_sle
-            && (check_var('ARCH', 'x86_64')
-                && sle_version_at_least('12-SP2')
-                && is_server()
-                && (!is_sles4sap() || is_sles4sap_standard())
-                && (install_this_version() || install_to_other_at_least('12-SP2'))
-                || is_sle('15+')))
-        {
+        if (is_sle12sp2_using_system_role() || is_sle('15+')) {
             loadtest "installation/system_role";
         }
         if (is_sles4sap() and sle_version_at_least('15') and check_var('SYSTEM_ROLE', 'default')) {

--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -7,15 +7,14 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Check system role selection screen or select system role. Added in SLE 12 SP2
-# Maintainer: Jozef Pupava <jpupava@suse.com>
+# Summary: Check default system role selection screen (only for SLE) and select system role. Added in SLE 12 SP2
+# Maintainer: Jozef Pupava <jpupava@suse.com>, Joaquín Rivera <jeriveramoya@suse.com>
 # Tags: poo#16650, poo#25850
 
 use strict;
 use base "y2logsstep";
 use testapi;
-use version_utils qw(is_sle is_caasp);
-
+use version_utils qw(is_sle is_caasp is_opensuse);
 
 my %role_hotkey = (
     gnome    => 's',
@@ -28,7 +27,7 @@ my %role_hotkey = (
 sub change_system_role {
     my ($system_role) = @_;
     # Since SLE 15 we do not have shortcuts for system roles anymore
-    if ((is_sle '15+') || (is_caasp 'kubic')) {
+    if (is_sle('15+') || is_caasp('kubic') || is_opensuse) {
         if (check_var('VIDEOMODE', 'text')) {
             # Expect that no actions are done before and default system role is preselected
             send_key_until_needlematch "system-role-$system_role-focused",  'down';    # select role
@@ -51,16 +50,20 @@ sub assert_system_role {
     # Still initializing the system at this point, can take some time
     # Asserting screen with preselected role
     # Proper default role assertion will be addressed in poo#37504
-    assert_screen 'system-role-default-system', 180;
-    my $system_role = get_var('SYSTEM_ROLE', 'default');
-    if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default')) {
-        change_system_role($system_role);
+    # Product might or might not have default selected
+    if (is_opensuse) {
+        assert_screen('before-role-selection', 180);
+        change_system_role(get_var('SYSTEM_ROLE', get_var('DESKTOP')));
+    }
+    else {
+        assert_screen('system-role-default-system', 180);
+        my $system_role = get_var('SYSTEM_ROLE', 'default');
+        change_system_role($system_role) if ($system_role && !check_var('SYSTEM_ROLE', 'default'));
     }
     send_key $cmd{next};
 }
 
 sub run {
-    # Define default role
     assert_system_role;
 }
 


### PR DESCRIPTION
Add SLE15 style system roles for openSUSE after revert in #5552.
- Related ticket: https://progress.opensuse.org/issues/39014
- Needles: not needed (already merged in https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/407)
- Verification run: according to review I can provide additional jobs due to verification in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5529#issuecomment-411026907 still applies.
