### PR TITLE
Update window_system to make ensure permission

### DIFF
--- a/tests/x11/window_system.pm
+++ b/tests/x11/window_system.pm
@@ -13,8 +13,12 @@
 use base "x11test";
 use strict;
 use testapi;
+use utils 'ensure_serialdev_permissions';
 
 sub run {
+    select_console 'root-console';
+    ensure_serialdev_permissions;
+    select_console('x11');
     x11_start_program('xterm');
     my $window_system = script_output('echo $XDG_SESSION_TYPE');
     script_run('exit', 0);


### PR DESCRIPTION
Add ensure_serialdev_permissions into window_system to
make user Berhard and /dev/ttyS0 belongs to the same
group.

Reference:
[Before update test run](http://10.67.19.67/tests/684#step/window_system/4)
[After update test run](http://10.67.19.67/tests/683#step/window_system/16)