### PR TITLE
Split consoletest_setup and stop serial-getty service

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -426,6 +426,7 @@ sub load_rescuecd_tests {
 }
 
 sub load_autoyast_clone_tests {
+    loadtest "console/system_prepare";
     loadtest "console/consoletest_setup";
     loadtest "console/yast2_clone_system";
     loadtest "console/consoletest_finish";
@@ -1039,6 +1040,7 @@ sub load_consoletests {
     if (get_var("ADDONS", "") =~ /rt/) {
         loadtest "rt/kmp_modules";
     }
+    loadtest "console/system_prepare";
     loadtest "console/consoletest_setup";
     loadtest "console/lvm_thin_check" if get_var('LVM_THIN_LV');
     loadtest 'console/integration_services' if is_hyperv;
@@ -1536,6 +1538,7 @@ sub load_filesystem_tests {
     return if get_var("INSTALLONLY") || get_var("DUALBOOT") || get_var("RESCUECD");
 
     # setup $serialdev permission and so on
+    loadtest "console/system_prepare";
     loadtest "console/consoletest_setup";
     loadtest 'console/integration_services' if is_hyperv;
     loadtest "console/hostname";
@@ -1944,7 +1947,8 @@ sub load_create_hdd_tests {
     # temporary adding test modules which applies hacks for missing parts in sle15
     loadtest 'console/sle15_workarounds' if is_sle('15+');
     loadtest 'console/integration_services' if is_hyperv;
-    loadtest 'console/hostname'              unless is_bridged_networking;
+    loadtest 'console/hostname' unless is_bridged_networking;
+    loadtest 'console/system_prepare';
     loadtest 'console/force_scheduled_tasks' unless is_jeos;
     # Remove repos pointing to download.opensuse.org and add snaphot repo from o3
     replace_opensuse_repos_tests if is_repo_replacement_required;
@@ -1981,6 +1985,7 @@ sub load_syscontainer_tests() {
     return if get_var("INSTALLONLY") || get_var("DUALBOOT") || get_var("RESCUECD");
 
     # setup $serialdev permission and so on
+    loadtest "console/system_prepare";
     loadtest "console/consoletest_setup";
 
     # Install needed pieces

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -171,6 +171,7 @@ sub load_fixup_firewall {
 sub load_consoletests_minimal {
     return unless (is_staging() && get_var('UEFI') || is_gnome_next || is_krypton_argon);
     # Stagings should test yast2-bootloader in miniuefi at least but not all
+    loadtest "console/system_prepare";
     loadtest "console/consoletest_setup";
     loadtest "console/textinfo";
     loadtest "console/hostname";
@@ -183,6 +184,7 @@ sub load_consoletests_minimal {
 sub load_otherDE_tests {
     if (get_var("DE_PATTERN")) {
         my $de = get_var("DE_PATTERN");
+        loadtest "console/system_prepare";
         loadtest "console/consoletest_setup";
         loadtest "console/hostname";
         loadtest "update/zypper_clear_repos";
@@ -238,7 +240,7 @@ sub install_online_updates {
 
 sub load_qam_install_tests {
     return 0 unless get_var('INSTALL_PACKAGES');
-
+    loadtest "console/system_prepare";
     loadtest 'console/consoletest_setup';
     loadtest 'console/import_gpg_keys';
     loadtest 'update/zypper_up';
@@ -359,6 +361,7 @@ elsif (get_var("ISO_IN_EXTERNAL_DRIVE")) {
 }
 elsif (get_var('SECURITY_TEST')) {
     boot_hdd_image;
+    loadtest "console/system_prepare";
     loadtest "console/consoletest_setup";
     loadtest "console/hostname";
     if (check_var('SECURITY_TEST', 'core')) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -460,6 +460,7 @@ sub load_ha_cluster_tests {
 
     # Patch (if needed) and basic configuration
     loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
+    loadtest "console/system_prepare";
     loadtest 'console/consoletest_setup';
     loadtest 'console/hostname';
 
@@ -529,6 +530,7 @@ sub load_ha_cluster_tests {
 }
 
 sub load_feature_tests {
+    loadtest "console/system_prepare";
     loadtest "console/consoletest_setup";
     loadtest "feature/feature_console/zypper_releasever";
     loadtest "feature/feature_console/suseconnect";
@@ -735,6 +737,7 @@ elsif (get_var("SLEPOS")) {
 elsif (get_var("SECURITY_TEST")) {
     prepare_target();
     if (get_var('BOOT_HDD_IMAGE')) {
+        loadtest "console/system_prepare";
         loadtest "console/consoletest_setup";
     }
     if (check_var("SECURITY_TEST", "fips_setup")) {
@@ -1046,6 +1049,7 @@ else {
         loadtest "migration/post_upgrade";
         # Always load zypper_lr test for migration case and get repo information for investigation
         if (get_var("INSTALLONLY")) {
+            loadtest "console/system_prepare";
             loadtest "console/consoletest_setup";
             loadtest 'console/integration_services' if is_hyperv;
             loadtest "console/zypper_lr";

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -49,6 +49,11 @@ sub run {
         assert_script_run 'less /var/log/YaST2/y2log*|grep "Automatic DHCP configuration not started - an interface is already configured"';
     }
 
+    # Stop serial-getty on serial console to avoid serial output pollution with login prompt
+    systemctl "stop serial-getty\@$testapi::serialdev";
+    # Mask if is qemu backend as use serial in remote installations e.g. during reboot
+    systemctl "mask serial-getty\@$testapi::serialdev" if check_var('BACKEND', 'qemu');
+
     save_screenshot;
     $self->clear_and_verify_console;
 

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Execute SUT changes which should be permanent
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
+
+use base "consoletest";
+use testapi;
+use utils;
+use strict;
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+
+    ensure_serialdev_permissions;
+
+    # Installing a minimal system gives a pattern conflicting with anything not minimal
+    # Let's uninstall 'the pattern' (no packages affected) in order to be able to install stuff
+    script_run 'rpm -qi patterns-openSUSE-minimal_base-conflicts && zypper -n rm patterns-openSUSE-minimal_base-conflicts';
+    # Install curl and tar in order to get the test data
+    zypper_call 'install curl tar';
+
+    # BSC#997263 - VMware screen resolution defaults to 800x600
+    if (check_var('VIRSH_VMM_FAMILY', 'vmware')) {
+        assert_script_run("sed -ie '/GFXMODE=/s/=.*/=1024x768x32/' /etc/default/grub");
+        assert_script_run("sed -ie '/GFXPAYLOAD_LINUX=/s/=.*/=1024x768x32/' /etc/default/grub");
+        assert_script_run("grub2-mkconfig -o /boot/grub2/grub.cfg");
+    }
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -38,3 +38,5 @@ sub run {
 sub test_flags {
     return {milestone => 1, fatal => 1};
 }
+
+1;


### PR DESCRIPTION
Resurrection of #5315.
consoletest_setup serves multiple purposes, introducing permanent
changes as well as temporary changes which should be triggered before
each test execution. Secondly, we run actions which are required in each
execution, e.g. stopping packagekit service and enable it when tests are
executed.


During research of the issue we have identified that one of the sources
which pollutes serial output and interferes script_output calls are
login prompt messages generated by serial-getty service.
So, along with packagekit, we mask it for console tests and unmask
afterwards.

See [poo#30613](https://progress.opensuse.org/issues/30613).

- Verification runs: (coming)
