### PR TITLE
Remove workaround for shutdown on KDE plasma5

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -629,26 +629,7 @@ sub poweroff_x11 {
     if (check_var("DESKTOP", "kde")) {
         send_key "ctrl-alt-delete";    # shutdown
         assert_screen_with_soft_timeout('logoutdialog', timeout => 90, soft_timeout => 15, 'bsc#1091933');
-
-        if (get_var("PLASMA5")) {
-            assert_and_click 'sddm_shutdown_option_btn';
-            if (check_screen([qw(sddm_shutdown_option_btn sddm_shutdown_btn)], 3)) {
-                # sometimes not reliable, since if clicked the background
-                # color of button should changed, thus check and click again
-                if (match_has_tag('sddm_shutdown_option_btn')) {
-                    assert_and_click 'sddm_shutdown_option_btn';
-                }
-                # plasma < 5.8
-                elsif (match_has_tag('sddm_shutdown_btn')) {
-                    assert_and_click 'sddm_shutdown_btn';
-                }
-            }
-        }
-        else {
-            type_string "\t";
-            assert_screen "kde-turn-off-selected", 2;
-            type_string "\n";
-        }
+        assert_and_click 'sddm_shutdown_option_btn';
     }
 
     if (check_var("DESKTOP", "gnome")) {


### PR DESCRIPTION
The commit removes workaround for the sutdown flow that breaks the test
as it checks twice for the same needle sddm_shutdown_option_btn.

The problem was that after first match the test immediately checks for
the same needle and founds it as system a little bit slow, then it tries
to press the shutdown button again, but the appropriate popup has
already gone.

**For reviewers:** The workaround was added in two places. The one for reboot was removed by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5409. This one removes the workaround for shutdown case.

- Related ticket: [poo#36040](https://progress.opensuse.org/issues/36040)
- Verification run: http://oorlov-vm.qa.suse.de/tests/14
