### PR TITLE
xfstests: load boot_hdd_image before test

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -804,7 +804,7 @@ elsif (get_var("XFSTESTS")) {
     if (check_var('ARCH', 'aarch64') && check_var('VERSION', '12-SP4')) {
         set_var('NO_KDUMP', 1);
     }
-    loadtest "boot/boot_to_desktop";
+    boot_hdd_image;
     unless (get_var('NO_KDUMP')) {
         loadtest "xfstests/enable_kdump";
     }


### PR DESCRIPTION
xfstests load "boot/boot_to_desktop" directly, it didn't use boot_hdd_image. So if using a zkvm machine it will not load installation/bootloader_zkvm.pm before booting. This makes all xfstests fail in s390x booting part.

- Related ticket: https://progress.opensuse.org/issues/38591
- VR: No verify run in s390x, only a VR in x86_64: http://10.67.133.102/tests/621