### PR TITLE
Adapt welcome product selection for SLE 15 SP1

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -95,14 +95,19 @@ sub run {
         # In upgrade mode, there is no product list shown in welcome screen
         unless (check_var('ARCH', 's390x') || get_var('UPGRADE')) {
             assert_screen('select-product');
-            my %hotkey = (
-                sles     => 's',
-                sled     => 'u',
-                sles4sap => get_var('OFW') ? 'u' : 'i',
-                hpc      => check_var('ARCH', 'x86_64') ? 'x' : 'u'
-            );
             my $product = get_required_var('SLE_PRODUCT');
-            send_key 'alt-' . $hotkey{$product};
+            if (check_var('VIDEOMODE', 'text')) {
+                my %hotkey = (
+                    sles     => 's',
+                    sled     => 'u',
+                    sles4sap => get_var('OFW') ? 'u' : 'i',
+                    hpc      => check_var('ARCH', 'x86_64') ? 'x' : 'u'
+                );
+                send_key 'alt-' . $hotkey{$product};
+            }
+            else {
+                assert_and_click('before-select-product-' . $product);
+            }
             assert_screen('select-product-' . $product);
         }
     }


### PR DESCRIPTION
Adapt welcome product selection using better approach with needle and potentially unblocking other test modules to be executed for sle15sp1 recently setup.

- Related ticket: https://progress.opensuse.org/issues/38711
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/907
- Verification run: [create_hdd_sled_gnome](http://dhcp87.suse.cz/tests/2088#step/welcome/5) | [gnome](http://dhcp87.suse.cz/tests/2087#step/welcome/5)