### PR TITLE
Stop package-kit before zypper calls

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -8,7 +8,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: console test pre setup, stoping and disabling packagekit, install curl and tar to get logs and so on
+# Summary: console test pre setup, performing actions required to run tests
+# which are supposed to be reverted e.g. stoping and disabling packagekit and so on
+# Permanent changes are now executed in system_prepare module
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "consoletest";

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -21,6 +21,8 @@ sub run {
 
     ensure_serialdev_permissions;
 
+    # Stop packagekit as may lock zypper and fail zypper calls, if it's running
+    systemctl 'stop packagekit.service' if script_run('systemctl is-active packagekit.service');
     # Installing a minimal system gives a pattern conflicting with anything not minimal
     # Let's uninstall 'the pattern' (no packages affected) in order to be able to install stuff
     script_run 'rpm -qi patterns-openSUSE-minimal_base-conflicts && zypper -n rm patterns-openSUSE-minimal_base-conflicts';


### PR DESCRIPTION
See [poo#39539](https://progress.opensuse.org/issues/39539).

- [Verification run](http://g226.suse.de/tests/2210)
