### PR TITLE
QAM fixes for CaaSP3

### DIFF
--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -227,7 +227,7 @@ else {
 # REGISTER = 'installation' -> Registers with SCC during the installation
 if (get_var('REGISTER') && !check_var('STACK_ROLE', 'controller')) {
     loadtest 'caasp/register_and_check';
-    loadtest 'caasp/register_toolchain' if is_caasp('3.0+');
+    loadtest 'caasp/register_toolchain' unless is_caasp('qam');
 }
 
 if (get_var('EXTRA', '') =~ /FEATURES/) {

--- a/tests/caasp/stack_update.pm
+++ b/tests/caasp/stack_update.pm
@@ -45,11 +45,15 @@ sub orchestrate_velum_reboot {
         send_key_until_needlematch "velum-$n-nodes-outdated", 'f5', 10, 120;
     }
 
+    # Workaround for bsc#1099015
     if (check_screen 'velum-update-admin', 0) {
         record_soft_failure 'bsc#1099015 - Update admin node still visible after reboot';
-        sleep 60;
+        for (1 .. 10) {
+            sleep 60;
+            last unless (check_screen 'velum-update-admin', 0);
+        }
+        die "Admin should be updated already" if check_screen('velum-update-admin', 0);
     }
-    die "Admin should be updated already" if check_screen('velum-update-admin', 0);
     assert_and_click "velum-update-all";
 
     # 5 minutes per node


### PR DESCRIPTION
Fix some glitches for QAM to run CaaSP3.0 tests. The toolchain test is
written for MicroOS, so it needs adjustment to run into the cluster. Apart
from that, there's a bug triggering during the update which we had
to workaround that by adding some delay.

- Related ticket: *none*
- Needles: *not needed*
- Verification run: http://skyrim.qam.suse.de/tests/3534
