### PR TITLE
Remove call to select_console from node02

### DIFF
--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -23,8 +23,11 @@ sub run {
     barrier_wait("CHECK_AFTER_REBOOT_BEGIN_$cluster_name");
 
     # We need to be sure to be root and, after fencing, the default console on node01 is not root
-    reset_consoles if (is_node(1) && !get_var('HDDVERSION'));
-    select_console 'root-console';
+    # Only do this on node01, as node02 console is expected to be the root-console
+    if (is_node(1) && !get_var('HDDVERSION')) {
+        reset_consoles;
+        select_console 'root-console';
+    }
 
     # Wait for resources to be started
     wait_until_resources_started;


### PR DESCRIPTION
Remove call to `select_console 'root-console'` from node02, as the selected terminal is expected to be the correct one. Only call `select_console` on node01 where a call to `reset_consoles` has been made.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
- Failed tests: https://openqa.suse.de/tests/1915292#step/check_after_reboot/3
- Last successful: https://openqa.suse.de/tests/1896517#step/check_after_reboot/1
