### PR TITLE
install_packages: handle conflict between openafs-client and openafs-fuse_client

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -171,6 +171,8 @@ sub problem_can_be_skipped {
     return 1 if $pkg =~ /^cloud-netconfig-azure/;
     # conflicts with otherproviders(skelcd-installer), skelcd-installer-openSUSE
     return 1 if $pkg =~ /^skelcd-installer-net-openSUSE/;
+    # conflicts with openafs-client, fuse client is experimental
+    return 1 if $pkg =~ /^openafs-fuse_client/;
 
     return;
 }


### PR DESCRIPTION
install_packages: handle conflict between openafs-client and openafs-fuse_client

```
package openafs-fuse_client-1.8.0-lp150.1.4.x86_64 conflicts with openafs-client provided by openafs-client-1.8.0-lp150.1.4.x86_64
```

Fixes:

- https://openqa.opensuse.org/tests/724328#step/install_packages/9
- https://openqa.opensuse.org/tests/724329#step/install_packages/9
- https://openqa.opensuse.org/tests/724330#step/install_packages/9
- https://build.opensuse.org/project/show/openSUSE:Maintenance:8582
- https://build.opensuse.org/request/show/628794

Verification: `data/lsmfip --verbose openafs-devel crash-kmp-default hdjmod-debugsource crash-eppic crash-debugsource openafs-fuse_client-debuginfo virtualbox-websrv pcfclock v4l2loopback-debugsource dpdk-kmp-default-debuginfo dpdk-debugsource dpdk-debuginfo crash crash-doc virtualbox-guest-x11 virtualbox-host-kmp-default lttng-modules sysdig openafs-server dpdk-devel-debuginfo v4l2loopback-kmp-default virtualbox-guest-tools xtables-addons-debuginfo bbswitch-debugsource drbd-kmp-default xtables-addons-kmp-default openafs-kmp-default virtualbox-guest-source drbd sysdig-debuginfo python3-virtualbox-debuginfo openafs v4l2loopback-utils openafs-debuginfo bbswitch-kmp-default openafs-client bbswitch-kmp-default-debuginfo lttng-modules-kmp-default-debuginfo lttng-modules-debugsource sysdig-debugsource xtables-addons openafs-debugsource openafs-fuse_client crash-devel openafs-kernel-source libdpdk-17_11-0-debuginfo openafs-authlibs virtualbox-host-kmp-default-debuginfo openafs-kmp-default-debuginfo virtualbox-qt pcfclock-kmp-default v4l2loopback-kmp-default-debuginfo dpdk-tools virtualbox-devel dpdk-tools-debuginfo bbswitch crash-gcore-debuginfo dpdk-doc virtualbox xtables-addons-kmp-default-debuginfo virtualbox-guest-x11-debuginfo vhba-kmp-default-debuginfo hdjmod-kmp-default-debuginfo dpdk crash-debuginfo openafs-client-debuginfo virtualbox-guest-kmp-default libdpdk-17_11-0 virtualbox-debuginfo drbd-debugsource openafs-server-debuginfo crash-eppic-debuginfo crash-gcore drbd-kmp-default-debuginfo dpdk-examples virtualbox-qt-debuginfo hdjmod-kmp-default openafs-authlibs-devel openafs-devel-debuginfo virtualbox-host-source virtualbox-guest-desktop-icons dpdk-kmp-default sysdig-kmp-default virtualbox-debugsource sysdig-kmp-default-debuginfo pcfclock-debuginfo virtualbox-websrv-debuginfo vhba-kmp-default virtualbox-guest-tools-debuginfo virtualbox-vnc pcfclock-kmp-default-debuginfo pcfclock-debugsource dpdk-examples-debuginfo openafs-authlibs-debuginfo crash-kmp-default-debuginfo dpdk-devel python3-virtualbox lttng-modules-kmp-default virtualbox-guest-kmp-default-debuginfo`