### PR TITLE
Replace xmllint by jing

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -21,7 +21,7 @@ use testapi;
 use utils;
 use version_utils qw(is_sle is_leap is_tumbleweed);
 
-our @EXPORT = qw (smt_wizard smt_mirror_repo rmt_wizard rmt_mirror_repo prepare_source_repo disable_source_repo get_repo_var);
+our @EXPORT = qw (smt_wizard smt_mirror_repo rmt_wizard rmt_mirror_repo prepare_source_repo disable_source_repo get_repo_var_name);
 
 =head2 get_repo_var_name
 This takes something like "MODULE_BASESYSTEM_SOURCE" as parameter

--- a/tests/console/yast2_clone_system.pm
+++ b/tests/console/yast2_clone_system.pm
@@ -14,8 +14,10 @@
 use base "console_yasttest";
 use strict;
 use testapi;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_opensuse);
 use utils 'zypper_call';
+use repo_tools 'get_repo_var_name';
+use serial_terminal 'select_virtio_console';
 
 sub run {
     select_console 'root-console';
@@ -33,12 +35,25 @@ sub run {
     }
     wait_serial('yast2-clone-system-status-0') || die "'yast2 clone_system' didn't finish";
 
+    select_virtio_console;
     # Replace unitialized email variable - bsc#1015158
     assert_script_run 'sed -i "/server_email/ s/postmaster@/\0suse.com/" /root/autoinst.xml';
 
     # Check and upload profile for chained tests
     upload_asset "/root/autoinst.xml";
-    if (script_run 'xmllint --noout --relaxng /usr/share/YaST2/schema/autoyast/rng/profile.rng /root/autoinst.xml') {
+
+    unless (is_opensuse) {
+        my $devel_repo = get_required_var(is_sle('>=15') ? get_repo_var_name("MODULE_DEVELOPMENT_TOOLS") : 'REPO_SLE_SDK');
+        zypper_call "ar -c $utils::OPENQA_FTP_URL/" . $devel_repo . " devel-repo";
+    }
+
+    zypper_call '--gpg-auto-import-keys ref';
+    zypper_call 'install jing';
+
+    my $rc_jing    = script_run 'jing /usr/share/YaST2/schema/autoyast/rng/profile.rng /root/autoinst.xml';
+    my $rc_xmllint = script_run 'xmllint --noout --relaxng /usr/share/YaST2/schema/autoyast/rng/profile.rng /root/autoinst.xml';
+
+    if (($rc_jing) || ($rc_xmllint)) {
         if (is_sle('<15')) {
             record_soft_failure 'bsc#1103712';
         }
@@ -49,6 +64,8 @@ sub run {
 
     # Remove for autoyast_removed test - poo#11442
     assert_script_run "rm /root/autoinst.xml";
+    # Return from VirtIO console
+    select_console 'root-console';
 }
 
 1;


### PR DESCRIPTION
- Related ticket: [[functional][y] use jing in addition to xmllint to validate autoyast profile](https://progress.opensuse.org/issues/39188)
- Verification runs:
[sle-15-SP1-Installer-DVD-x86_64-Build19.7-clone_system@64bit](http://dhcp128.suse.cz/tests/5696)
[sle-12-SP4-Server-DVD-x86_64-Build0330-clone_system@64bit](http://dhcp128.suse.cz/tests/5698)
[opensuse-Tumbleweed-DVD-x86_64-Build20180812-clone_system@64bit](http://dhcp128.suse.cz/tests/5697)
