### PR TITLE
Allow to set shutdown timeout with DEBUG_SHUTDOWN

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -789,8 +789,8 @@ sub power_action {
             }
         }
     }
-    # Shutdown takes longer than 60 seconds on SLE 15
     my $shutdown_timeout = 60;
+    # Shutdown takes longer than 60 seconds on SLE 15
     if (is_sle('15+') && check_var('DESKTOP', 'gnome') && ($action eq 'poweroff')) {
         record_soft_failure('bsc#1055462');
         $shutdown_timeout *= 3;
@@ -803,6 +803,7 @@ sub power_action {
         $shutdown_timeout *= 3;
         record_soft_failure("boo#1057637 shutdown_timeout increased to $shutdown_timeout (s) expecting to complete.");
     }
+    $shutdown_timeout = get_var("DEBUG_SHUTDOWN") if (get_var('DEBUG_SHUTDOWN'));
     # no need to redefine the system when we boot from an existing qcow image
     # Do not redefine if autoyast, as did initial reboot already
     if (check_var('VIRSH_VMM_FAMILY', 'kvm')


### PR DESCRIPTION
The commit adds ability to specify shutdown timeout by assigning the
value to DEBUG_SHUTDOWN parameter.

This allows to manipulate with the shutdown timeout without adding
changes to the code, e.g. to gather more logs or check if the issue with
shutdown related to the low timeout.

- Related ticket: [poo#35215](https://progress.opensuse.org/issues/35215)
- Verification runs: 
Timeout is set to 1 with 'DEBUG_SHUTDOWN=1': http://oorlov-vm.qa.suse.de/tests/28
Timeout is set to 300 with 'DEBUG_SHUTDOWN=300': http://oorlov-vm.qa.suse.de/tests/30

**Please note: After merging the commit, please do not forget to change the DEBUG_SHUTDOWN value for 'kde' test suite on o3 to something like 300**: https://openqa.opensuse.org/admin/test_suites