### PR TITLE
Remove two test cases in remote-desktop-client1 from SLED12SP4

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1754,8 +1754,8 @@ sub load_x11_remote {
     # load onetime vncsession testing
     if (check_var('REMOTE_DESKTOP_TYPE', 'one_time_vnc')) {
         loadtest 'x11/remote_desktop/onetime_vncsession_xvnc_tigervnc';
-        loadtest 'x11/remote_desktop/onetime_vncsession_xvnc_remmina';
-        loadtest 'x11/remote_desktop/onetime_vncsession_xvnc_java' if is_sle('<15');
+        loadtest 'x11/remote_desktop/onetime_vncsession_xvnc_remmina' if is_sle('>=15');
+        loadtest 'x11/remote_desktop/onetime_vncsession_xvnc_java'    if is_sle('<12-sp4');
         loadtest 'x11/remote_desktop/onetime_vncsession_multilogin_failed';
     }
     # load persistemt vncsession, x11 forwarding, xdmcp with gdm testing


### PR DESCRIPTION
Remove onetime_vncsession_xvnc_remmina from SLED12SP4, since there is no remmina available in SLED12SP4 or earlier.

Remove onetime_vncsession_xvnc_java from SLED12SP4 since Java plugin is no longer supported in firefox 52

- Related ticket: https://progress.opensuse.org/issues/36820
- Verification run: 
  http://10.67.19.139/tests/528#
  http://10.67.19.139/tests/527#