### PR TITLE
Avoid disk cleanup on SLES-11-SP4 and systems installed by Autoyast

### DIFF
--- a/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
@@ -42,11 +42,10 @@ sub run {
         #OpenQA needs ssh way to trigger offline upgrade
         script_run("sed -i s/sshd=1/ssh=1/g /boot/grub2/grub.cfg /boot/grub/menu.lst");
         diag("Debug info for reboot_and_wait_up_upgrade: this is offline upgrade. Need to clean up redundant disks using clean_up_red_disks.");
-        clean_up_red_disks;
+        clean_up_red_disks unless (($host_installed_version eq 11) || get_var('AUTOYAST', ''));
     }
 
     $self->reboot_and_wait_up($timeout);
 }
 
 1;
-

--- a/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
@@ -42,7 +42,7 @@ sub run {
         #OpenQA needs ssh way to trigger offline upgrade
         script_run("sed -i s/sshd=1/ssh=1/g /boot/grub2/grub.cfg /boot/grub/menu.lst");
         diag("Debug info for reboot_and_wait_up_upgrade: this is offline upgrade. Need to clean up redundant disks using clean_up_red_disks.");
-        clean_up_red_disks unless (($host_installed_version eq 11) || get_var('AUTOYAST', ''));
+        clean_up_red_disks unless (($host_installed_version eq '11') || get_var('AUTOYAST', ''));
     }
 
     $self->reboot_and_wait_up($timeout);

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -145,7 +145,7 @@ sub update_guest_configurations_with_daily_build {
 
 sub clean_up_red_disks {
     my $wait_script           = "120";
-    my $get_disks_not_used    = "ls /dev/sd* | grep -v -e \"/dev/sd[a].*\" -e \"/dev/sd[b-z].*[[:digit:]].*\"";
+    my $get_disks_not_used    = "ls /dev/sd* | grep -v -e \"/dev/sd[a].*\" | grep -o -e \"/dev/sd[b-z]\\\{1,\\\}[[:digit:]]\\\{0,\\\}\"";
     my $disks_not_used        = script_output($get_disks_not_used, $wait_script, type_command => 1, proceed_on_failure => 1);
     my $get_disks_nu_num      = "$get_disks_not_used | wc -l";
     my $disks_nu_num          = script_output($get_disks_nu_num, $wait_script, type_command => 1, proceed_on_failure => 1);
@@ -155,21 +155,31 @@ sub clean_up_red_disks {
     my $make_fs_cmd           = "mkfs.$fs_type_supported";
     my @disks_nu_array        = split(/\n+/, $disks_not_used);
     my $disks_nu_length       = scalar @disks_nu_array;
+    my $get_swaps_not_need    = "$get_disks_fs_overview | grep -v -e \"sd[a].*\" | grep -i swap | grep -o -e \"sd[b-z]\\\{1,\\\}[[:digit:]]\\\{0,\\\}\"";
+    my $swaps_not_used        = script_output($get_swaps_not_need, $wait_script, type_command => 1, proceed_on_failure => 1);
 
-    if (($disks_nu_length eq $disks_nu_num) && $disks_nu_num && $fs_type_supported) {
-        foreach my $item (@disks_nu_array) {
-            if ($item =~ /\/dev\/sd[b-z].*/) {
-                assert_script_run("wipefs -a $item && $make_fs_cmd $item");
+    if ($swaps_not_used) {
+        my @swaps_nu_array = split(/\n+/, $swaps_not_used);
+        foreach my $swapitem (@swaps_nu_array) {
+            if ($swapitem =~ /sd[b-z].*/) {
+                assert_script_run("swapoff /dev/$swapitem");
             }
         }
-        diag("Debug info: Redundant disks have already been formatted using mkfs.");
+
+        if (($disks_nu_length eq $disks_nu_num) && $disks_nu_num && $fs_type_supported) {
+            foreach my $item (@disks_nu_array) {
+                if ($item =~ /\/dev\/sd[b-z].*/) {
+                    assert_script_run("wipefs -a -f $item && $make_fs_cmd -f $item");
+                }
+            }
+            diag("Debug info: Redundant disks have already been formatted using mkfs.");
+        }
+        else {
+            diag("Debug info: Maybe there are no other disks functioning other than /dev/sda. Or something unexpected happened during obtaining available file system type.");
+        }
+        my $disks_fs_overview = script_output($get_disks_fs_overview, $wait_script, type_command => 1, proceed_on_failure => 1);
+        diag("Debug info: Disks and File Systems Overview:\n $disks_fs_overview");
     }
-    else {
-        diag("Debug info: Maybe there are no other disks functioning other than /dev/sda. Or something unexpected happened during obtaining available file system type.");
-    }
-    my $disks_fs_overview = script_output($get_disks_fs_overview, $wait_script, type_command => 1, proceed_on_failure => 1);
-    diag("Debug info: Disks and File Systems Overview:\n $disks_fs_overview");
 }
 
 1;
-

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -144,7 +144,7 @@ sub update_guest_configurations_with_daily_build {
 }
 
 sub clean_up_red_disks {
-    my $wait_script           = "120";
+    my $wait_script           = "600";
     my $get_disks_not_used    = "ls /dev/sd* | grep -v -e \"/dev/sd[a].*\" | grep -o -e \"/dev/sd[b-z]\\\{1,\\\}[[:digit:]]\\\{0,\\\}\"";
     my $disks_not_used        = script_output($get_disks_not_used, $wait_script, type_command => 1, proceed_on_failure => 1);
     my $get_disks_nu_num      = "$get_disks_not_used | wc -l";
@@ -155,31 +155,31 @@ sub clean_up_red_disks {
     my $make_fs_cmd           = "mkfs.$fs_type_supported";
     my @disks_nu_array        = split(/\n+/, $disks_not_used);
     my $disks_nu_length       = scalar @disks_nu_array;
-    my $get_swaps_not_need    = "$get_disks_fs_overview | grep -v -e \"sd[a].*\" | grep -i swap | grep -o -e \"sd[b-z]\\\{1,\\\}[[:digit:]]\\\{0,\\\}\"";
-    my $swaps_not_used        = script_output($get_swaps_not_need, $wait_script, type_command => 1, proceed_on_failure => 1);
+    my $get_swaps_not_need = "$get_disks_fs_overview | grep -v -e \"sd[a].*\" | grep -i \"\\\[SWAP\\\]\" | grep -o -e \"sd[b-z]\\\{1,\\\}[[:digit:]]\\\{0,\\\}\"";
+    my $swaps_not_used = script_output($get_swaps_not_need, $wait_script, type_command => 1, proceed_on_failure => 1);
 
     if ($swaps_not_used) {
         my @swaps_nu_array = split(/\n+/, $swaps_not_used);
         foreach my $swapitem (@swaps_nu_array) {
             if ($swapitem =~ /sd[b-z].*/) {
-                assert_script_run("swapoff /dev/$swapitem");
+                assert_script_run("swapoff /dev/$swapitem", $wait_script);
             }
         }
-
-        if (($disks_nu_length eq $disks_nu_num) && $disks_nu_num && $fs_type_supported) {
-            foreach my $item (@disks_nu_array) {
-                if ($item =~ /\/dev\/sd[b-z].*/) {
-                    assert_script_run("wipefs -a -f $item && $make_fs_cmd -f $item");
-                }
-            }
-            diag("Debug info: Redundant disks have already been formatted using mkfs.");
-        }
-        else {
-            diag("Debug info: Maybe there are no other disks functioning other than /dev/sda. Or something unexpected happened during obtaining available file system type.");
-        }
-        my $disks_fs_overview = script_output($get_disks_fs_overview, $wait_script, type_command => 1, proceed_on_failure => 1);
-        diag("Debug info: Disks and File Systems Overview:\n $disks_fs_overview");
     }
+
+    if (($disks_nu_length eq $disks_nu_num) && $disks_nu_num && $fs_type_supported) {
+        foreach my $item (@disks_nu_array) {
+            if ($item =~ /\/dev\/sd[b-z].*/) {
+                assert_script_run("wipefs -a -f $item && $make_fs_cmd $item", $wait_script);
+            }
+        }
+        diag("Debug info: Redundant disks have already been formatted using mkfs.");
+    }
+    else {
+        diag("Debug info: Maybe there are no other disks functioning other than /dev/sda. Or something unexpected happened during obtaining available file system type.");
+    }
+    my $disks_fs_overview = script_output($get_disks_fs_overview, $wait_script, type_command => 1, proceed_on_failure => 1);
+    diag("Debug info: Disks and File Systems Overview:\n $disks_fs_overview");
 }
 
 1;


### PR DESCRIPTION
1.Do not call clean_up_red_disks on SLES-11-SP4, which always get installed by Auotyast with formatting disks
2.Do not call clean_up_red_disks on systems installed by Autoyast because of the same reason as above
3.Swapoff the specific partition before wipefs on it if it is being used as swap
4.Add -f option to avoid manual intervention if encountered

@alice-suse @XGWang0 @xguo @Julie-CAO

- Related ticket: https://openqa.suse.de/tests/1937897#step/reboot_and_wait_up_upgrade/11
- Needles: n/a
- Verification run: https://10.67.17.5/tests/735
                            https://10.67.17.5/tests/737
                            https://10.67.17.5/tests/738
