### PR TITLE
Adapt yast2 http to new widget

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -281,6 +281,7 @@ sub save_strace_gdb_output {
     # Collect yast2 installer or yast2 module trace if is still running
     if (!script_run(qq{ps -eo pid,comm | grep -i [y]2start | cut -f 2 -d " " > /dev/$serialdev}, 0)) {
         chomp(my $yast_pid = wait_serial(qr/^[\d{4}]/, 10));
+        return unless defined($yast_pid);
         my $trace_timeout = 120;
         my $strace_log    = '/tmp/yast_trace.log';
         my $strace_ret    = script_run("timeout $trace_timeout strace -f -o $strace_log -tt -p $yast_pid", ($trace_timeout + 5));
@@ -298,8 +299,10 @@ sub save_strace_gdb_output {
           cmdline
           environ
           smaps);
+
+        my $opt = defined($is_yast_module) ? 'module' : 'installer';
         foreach (@procfs_files) {
-            $self->save_and_upload_log("cat /proc/$yast_pid/$_", "/tmp/yast2-installer.$_");
+            $self->save_and_upload_log("cat /proc/$yast_pid/$_", "/tmp/yast2-$opt.$_");
         }
         # We enable gdb differently in the installer and in the installed SUT
         if ($is_yast_module) {

--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -13,18 +13,18 @@
 use strict;
 use base "console_yasttest";
 use testapi;
-
-
+use utils 'zypper_call';
+use version_utils qw(is_sle is_leap);
 
 sub run {
 
     select_console 'root-console';
     # install http server
-    assert_script_run("/usr/bin/zypper -n -q in yast2-http-server");
+    zypper_call("-q in yast2-http-server");
     script_run("yast2 http-server; echo yast2-http-server-status-\$? > /dev/$serialdev", 0);
-    assert_screen 'http-server', 60;    # check page "Initializing HTTP Server Configuration"
+    assert_screen 'http-server', 180;    # check page "Initializing HTTP Server Configuration"
     wait_still_screen 1;
-    send_key 'alt-i';                   # make sure that apache2, apache2-prefork packages needs to be installed
+    send_key 'alt-i';                    # make sure that apache2, apache2-prefork packages needs to be installed
 
     # check http server wizard (1/5) -- Network Device Selection
     # wait for potential popup
@@ -101,18 +101,32 @@ sub run {
     send_key 'alt-n';                               # go to page http server wizard (4/5) and confirm with next
     assert_screen 'http_vitual_host_page';          # check wizard page (4/5)
     send_key 'alt-n';                               # go to http server wizard (5/5) --summary
-    assert_screen 'http_summary';                   # check the summary page and go to select start apache2 sever when booting
-    send_key 'alt-t';
-    assert_screen 'http_start_apache2';             # make sure that apache2 server got started when booting
-    send_key 'alt-f';                               # now finish the tests :)
-    check_screen 'http_install_apache2_mods', 30;
-    send_key 'alt-i';                               # confirm to install apache2_mod_perl, apache2_mod_php, apache2_mod_python
+                                                    # make sure that apache2 server got started when booting
+    if ((is_sle '<15') || (is_leap)) {
+        assert_screen 'http_summary';
+        send_key 'alt-t';
+        assert_screen 'http_start_apache2';
+    }
+    else {
+        assert_screen 'yast2_ncurses_service_start_widget';
+        send_key 'alt-t';
+        send_key_until_needlematch 'yast2_ncurses_service_start_widget_start_after_conf', 'up';
+        send_key 'ret';
+        assert_screen 'yast2_ncurses_service_start_widget_check_start_after_conf';
+        send_key 'alt-a';
+        send_key_until_needlematch 'yast2_ncurses_service_start_widget_start_on_boot', 'up';
+        send_key 'ret';
+        assert_screen 'yast2_ncurses_service_start_widget_check_start_on_boot';
+    }
+    send_key 'alt-f';    # now finish the tests :)
+    check_screen 'http_install_apache2_mods', 60;
+    send_key 'alt-i';    # confirm to install apache2_mod_perl, apache2_mod_php, apache2_mod_python
 
     # if popup, confirm to enable apache2 configuratuion
     if (check_screen('http_enable_apache2', 10)) {
         wait_screen_change { send_key 'alt-o'; };
     }
-    wait_serial("yast2-http-server-status-0", 180) || die "'yast2 http-server' didn't finish";
+    wait_serial("yast2-http-server-status-0", 240) || die "'yast2 http-server' didn't finish";
 }
 1;
 


### PR DESCRIPTION
While I was testing stability issues of yast2_http.pm, new widget just hit the recent builds of TW and SLE15SP1 which was prevent me to run the test properly. Eventually I have noticed that ``post_fail_hook`` executes part of code related to installation only.

- Related ticket: [[functional][y][sporadic] test fails in yast2_http (openqa.opensuse.org not reachable / timeout on package installation / unstable?)](https://progress.opensuse.org/issues/38810)
- Needles: 
o3 [New widget needles for yast2 http #413](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/413)
[ osd ](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/909)
- Verification runs:
[opensuse-15.1-DVD-x86_64-Build282.3-yast2_ncurses@64bit](http://dhcp128.suse.cz/tests/5710)
[opensuse-Tumbleweed-DVD-x86_64-Build20180812-yast2_ncurses@64bit](http://dhcp128.suse.cz/tests/5712)
[sle-12-SP4-Server-DVD-x86_64-Build0339-yast2_ncurses@64bit](http://dhcp128.suse.cz/tests/5711)
[sle-15-SP1-Installer-DVD-x86_64-Build20.3-yast2_ncurses@64bit](http://dhcp128.suse.cz/tests/5713)
