### PR TITLE
Use common method to get SCC version for registration in AY

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -34,6 +34,7 @@ our @EXPORT = qw(
   yast_scc_registration
   skip_registration
   scc_deregistration
+  scc_version
   get_addon_fullname
   rename_scc_addons
   is_module

--- a/tests/autoyast/prepare_profile.pm
+++ b/tests/autoyast/prepare_profile.pm
@@ -15,6 +15,7 @@ use strict;
 use base "opensusebasetest";
 use testapi;
 use version_utils 'is_sle';
+use registration 'scc_version';
 use File::Copy 'copy';
 use File::Path 'make_path';
 
@@ -26,10 +27,7 @@ sub run {
     return unless $profile;
 
     # Expand VERSION, as e.g. 15-SP1 has to be mapped to 15.1
-    if (my $version = get_var('VERSION')) {
-        if (is_sle('>15')) {
-            $version =~ s/-SP/./;
-        }
+    if (my $version = scc_version(get_var('VERSION', ''))) {
         $profile =~ s/\{\{VERSION\}\}/$version/g;
     }
     # For s390x and svirt backends need to adjust network configuration

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -24,6 +24,7 @@ use utils;
 use mm_network;
 use mm_tests;
 use opensusebasetest 'firewall';
+use registration 'scc_version';
 
 my $pxe_server_set   = 0;
 my $quemu_proxy_set  = 0;
@@ -419,7 +420,7 @@ sub setup_aytests {
     # Expand variables
     sed -i -e 's|{{SCC_REGCODE}}|" . get_var('SCC_REGCODE') . "|g' \\
            -e 's|{{SCC_URL}}|" . get_var('SCC_URL') . "|g' \\
-           -e 's|{{VERSION}}|" . get_var('VERSION') . "|g' \\
+           -e 's|{{VERSION}}|" . scc_version . "|g' \\
            -e 's|{{ARCH}}|" . get_var('ARCH') . "|g' \\
            -e 's|{{MSG_TIMEOUT}}|0|g' \\
            -e 's|{{REPO1_URL}}|http://10.0.2.1/aytests/files/repos/sles12|g' \\
@@ -571,4 +572,3 @@ sub test_flags {
 }
 
 1;
-


### PR DESCRIPTION
Follow up for #5583. I've missed that we need same thing for aytests
repo profiles, and hence can use common functionality.

See [poo#39656](https://progress.opensuse.org/issues/39656).

- [Standlalone ay test](http://g226.suse.de/tests/2224).
- [Multimachine ay test](http://gershwin.arch.suse.de/tests/599)
