### PR TITLE
update firefox_java to match website changes

### DIFF
--- a/tests/x11/firefox/firefox_java.pm
+++ b/tests/x11/firefox/firefox_java.pm
@@ -25,7 +25,10 @@ sub java_testing {
     type_string "http://www.java.com/en/download/installed.jsp?detect=jre\n";
 
     wait_still_screen 3;
-    assert_and_click('firefox-java-agree-and-proceed') if check_screen('oracle-cookies-handling', 0);
+    if (check_screen('oracle-cookies-handling')) {
+        assert_and_click('firefox-java-agree-and-proceed');
+        assert_and_click('oracle-cookies-close');
+    }
 
     wait_still_screen 3;
     if (check_screen('firefox-java-security', 0)) {


### PR DESCRIPTION
The upstream java.com has updated its cookie handling (because of GDPR).  So we need to tweak our test a little to reflect that change -- we need to close an extra popup window.

- Related ticket: https://progress.opensuse.org/issues/38951
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/910
- Verification run: http://10.67.17.181/tests/109#step/firefox_java/20
