### PR TITLE
Assert screen before sending ctrl+q to gnucash

### DIFF
--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -28,7 +28,8 @@ sub run {
         # opened gets focussed but the last. Bring the tip window back to
         # focus if it is not
         send_key 'alt-tab' if check_var('DESKTOP', 'lxde');
-        wait_screen_change { send_key 'alt-c' };
+        send_key 'alt-c';
+        assert_screen('test-gnucash-tips-closed');
     }
     send_key 'ctrl-q';    # Exit
 


### PR DESCRIPTION
Sometimes the window was not closed (race condition between alt-c and ctrl-q)

- Related ticket: https://progress.opensuse.org/issues/38387
- Verification run: http://10.160.66.74/tests/796#step/gnucash/23
