### PR TITLE
Fix reboot_gnome on s390

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -739,9 +739,10 @@ unless explicitly overridden by setting C<$textmode> to either 0 or 1.
 =cut
 sub power_action {
     my ($action, %args) = @_;
-    $args{observe}     //= 0;
-    $args{keepconsole} //= 0;
-    $args{textmode}    //= check_var('DESKTOP', 'textmode');
+    $args{observe}      //= 0;
+    $args{keepconsole}  //= 0;
+    $args{textmode}     //= check_var('DESKTOP', 'textmode');
+    $args{first_reboot} //= 0;
     die "'action' was not provided" unless $action;
     prepare_system_shutdown;
     unless ($args{keepconsole}) {
@@ -775,10 +776,10 @@ sub power_action {
         record_soft_failure("boo#1057637 shutdown_timeout increased to $shutdown_timeout (s) expecting to complete.");
     }
     # no need to redefine the system when we boot from an existing qcow image
-    # Do not redefine if autoyast, as did initial reboot already
+    # Do not redefine if autoyast or s390 zKVM reboot, as did initial reboot already
     if (check_var('VIRSH_VMM_FAMILY', 'kvm')
         || check_var('VIRSH_VMM_FAMILY', 'xen')
-        || (get_var('S390_ZKVM') && !get_var('BOOT_HDD_IMAGE') && !get_var('AUTOYAST')))
+        || (get_var('S390_ZKVM') && !get_var('BOOT_HDD_IMAGE') && !get_var('AUTOYAST') && $args{first_reboot}))
     {
         assert_shutdown_and_restore_system($action, $shutdown_timeout);
     }

--- a/tests/installation/reboot_after_installation.pm
+++ b/tests/installation/reboot_after_installation.pm
@@ -38,7 +38,7 @@ sub run {
         send_key 'alt-o';    # Reboot
     };
 
-    power_action('reboot', observe => 1, keepconsole => 1);
+    power_action('reboot', observe => 1, keepconsole => 1, first_reboot => 1);
 }
 
 1;


### PR DESCRIPTION
Previously test checked for 'shut off' in case of s390 reboot_gnome, but
in fact, the vm state was 'running', as vm parameters were redefined
during the initial reboot and reboot=>destroy was changed to
reboot=>undef.

The commit adds an additional verification if the reboot is performing
on s390 system and it is not an initial one.

1. Related ticket: [poo#36279](https://progress.opensuse.org/issues/36279)
2. Verification runs:
- reboot_gnome on s380: http://oorlov-vm.qa.suse.de/tests/55
- reboot_gnome on xen (to check, that my changes do not break tests on other environments): http://oorlov-vm.qa.suse.de/tests/53
- To check, that my changes don't break tests on s390, that use assert_shutdown in other modules (e.g. shutdown.pm): http://oorlov-vm.qa.suse.de/tests/55#step/shutdown/19