### PR TITLE
Replace which by type when retrieving logs

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -248,7 +248,7 @@ sub save_upload_y2logs {
 sub get_available_compression {
     my %extensions = ('bzip2' => '.bz2', 'gzip' => '.gz', 'xz' => '.xz');
     foreach my $binary (sort keys %extensions) {
-        return $extensions{$binary} unless script_run("which $binary");
+        return $extensions{$binary} unless script_run("type $binary");
     }
     return "";
 }


### PR DESCRIPTION
Replace which command by type when retrieving logs due to in #5591 was reported that there was some QAM tests broken.

- Related ticket: https://progress.opensuse.org/issues/39683
- Needles: not needed
- Verification run:
  - [qam-allpatterns](http://dhcp87.suse.cz/tests/2143#step/logs_from_installation_system/17)
  - [krypton-live-installation](http://dhcp87.suse.cz/tests/2141#step/logs_from_installation_system/22)
