### PR TITLE
Fix aarch64 occasional failures in updates_packagekit_* due to screenlock

### DIFF
--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -48,6 +48,7 @@ sub run {
         record_soft_failure 'bsc#1081584';
     }
     select_console 'x11', await_console => 0;
+    ensure_unlocked_desktop;
 
     my @updates_tags = qw(updates_none updates_available package-updater-privileged-user-warning updates_restart_application updates_installed-restart);
     my @updates_installed_tags = qw(updates_none updates_installed-logout updates_installed-restart updates_restart_application updates_failed);

--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -26,6 +26,7 @@ sub kernel_updated {
 sub run {
     my ($self) = @_;
     select_console 'x11', await_console => 0;
+    ensure_unlocked_desktop;
     turn_off_kde_screensaver;
 
     my @updates_installed_tags = qw(updates_none updates_available);


### PR DESCRIPTION
screenlock: https://progress.opensuse.org/issues/39734

I tested it locally for KDE and GNOME on aarch64 with os-autoinst.