### PR TITLE
Mask unit type 'timer' with unit type 'service'

### DIFF
--- a/tests/console/force_scheduled_tasks.pm
+++ b/tests/console/force_scheduled_tasks.pm
@@ -41,7 +41,7 @@ sub run {
     # run cron jobs or systemd timers which can affect system performance and mask systemd timers later
     assert_script_run('find /etc/cron.{hourly,daily,weekly,monthly} -type f -executable -exec echo cron job: {} \; -exec {} \;', 1000);
     my $systemd_tasks_cmd = 'echo "Triggering systemd timed service $i" && systemctl start $i';
-    $systemd_tasks_cmd .= ' && systemctl mask $i' unless get_var('SOFTFAIL_BSC1063638');
+    $systemd_tasks_cmd .= ' && systemctl mask $i.{service,timer}' unless get_var('SOFTFAIL_BSC1063638');
     assert_script_run(
         'for i in $(systemctl list-units --type=timer --state=active --no-legend | sed -e \'s/\(\S\+\)\.timer\s.*/\1/\'); do ' . $systemd_tasks_cmd . '; done');
     record_soft_failure 'bsc#1063638 - review I/O scheduling parameters of btrfsmaintenance' if (time - $before) > 60 && get_var('SOFTFAIL_BSC1063638');


### PR DESCRIPTION
When unit logrotate.service is masked, logrotate.timer should be masked
as well, otherwise logrotate.timer fails on boot. Same with other masked
services.

Fails here: https://openqa.suse.de/tests/1949035#step/console_reboot/3

Validation run: http://nilgiri.suse.cz/tests/950#step/force_scheduled_tasks/8