### PR TITLE
Adapt accept_license when BETA product

### DIFF
--- a/tests/installation/accept_license.pm
+++ b/tests/installation/accept_license.pm
@@ -40,7 +40,7 @@ sub run {
         return send_key $cmd{next} unless match_has_tag('license-agreement');
     }
     $self->verify_license_has_to_be_accepted;
-    $self->verify_translation if get_var('INSTALLER_EXTENDED_TEST');
+    $self->verify_translation if get_var('INSTALLER_EXTENDED_TEST') && !get_var("BETA");
     send_key $cmd{next};
     # workaround for bsc#1059317, multiple times clicking accept license
     my $count = 5;


### PR DESCRIPTION
Adapt accept_license when BETA product. During BETA phase we don't have available all EULA translations.

- Related ticket: https://progress.opensuse.org/issues/39968
- Needles: not needed
- Verification run: [create_hdd_minimal_base+sdk](http://dhcp87.suse.cz/tests/2157) (running)
