### PR TITLE
Fix docker_image.pm, use install_docker_when_needed(), fix docker_image_rpm.pm

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -533,8 +533,11 @@ sub load_docker_tests {
         loadtest "console/docker_image";
         loadtest "console/sle2docker";
     }
-    elsif (is_opensuse) {
+    if (is_tumbleweed) {
         loadtest "console/docker_image_rpm";
+        loadtest "console/docker_compose";
+    }
+    elsif (is_opensuse && !is_tumbleweed) {
         loadtest "console/docker_compose";
     }
 }

--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -49,8 +49,8 @@ sub test_seccomp {
 sub run {
     select_console("root-console");
 
-    install_docker_when_needed;
-    test_seccomp;
+    install_docker_when_needed();
+    test_seccomp();
 
     # images can be searched on the Docker Hub
     validate_script_output("docker search --no-trunc opensuse", sub { m/This project contains the stable releases of the openSUSE distribution/ });
@@ -126,7 +126,7 @@ sub run {
     if (wait_serial('ctrlc_timeout', 10, 1) =~ 'ctrlc_timeout') {
         die 'ctrl-c stopped container';
     }
-    die "Something went wrong" unless wait_serial('ctrlc_timeout', 30);
+    die "Something went wrong" unless wait_serial('ctrlc_timeout', 40);
 
     # containers can be stopped
     assert_script_run("docker container stop $container_name");

--- a/tests/console/sle2docker.pm
+++ b/tests/console/sle2docker.pm
@@ -18,10 +18,13 @@
 use base "consoletest";
 use testapi;
 use utils;
+use registration "install_docker_when_needed";
 use strict;
 
 sub run {
     select_console('root-console');
+
+    install_docker_when_needed();
 
     # install sle2docker and sle docker image
     zypper_call("in sle2docker sles12sp2-docker-image");


### PR DESCRIPTION
Happy Monday, everyone,

I'm fixing some issues:
 * `docker_image.pm` has load-related timeout issue, see [poo#39557](https://progress.opensuse.org/issues/39557)
 * `docker.pm` has also timeout issue when running the `docker run sleep` command
 * `docker_image_rpm.pm` should run only on Tumbleweed, see [poo#39314](https://progress.opensuse.org/issues/39314)
 * I discovered `install_docker_when_needed()` function so I use it where it's possible.

- Related tickets: [poo#39557](https://progress.opensuse.org/issues/39557), [poo#39314](https://progress.opensuse.org/issues/39314)
- Needles: Not needed
- Verification run: [Tumbleweed](http://pdostal-server.suse.cz/tests/1045) [Leap 15.1](http://pdostal-server.suse.cz/tests/1036) [SLE 12sp3](http://pdostal-server.suse.cz/tests/1029) [SLE 15](http://pdostal-server.suse.cz/tests/1047#)
