### PR TITLE
Make sure Application finder shows up before starting to use keyboard.

### DIFF
--- a/tests/x11/xfce4_appfinder.pm
+++ b/tests/x11/xfce4_appfinder.pm
@@ -17,7 +17,7 @@ use testapi;
 
 
 sub run {
-    send_key "alt-f2";
+    wait_screen_change { send_key "alt-f2"; };
     send_key "down";
     type_string "about\n";
     assert_screen 'test-xfce4_appfinder-1';


### PR DESCRIPTION
Fix https://openqa.opensuse.org/tests/738495#step/xfce4_appfinder/3
