### PR TITLE
Fix condition not to write autoupgrade if not PXE boot

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -518,7 +518,7 @@ sub specific_bootmenu_params {
             $args .= $netsetup;
         }
     }
-    if (get_var("AUTOUPGRADE") || get_var("UPGRADE_FROM_AUTOYAST") || get_var("UPGRADE")) {
+    if (get_var("AUTOUPGRADE") || get_var("AUTOYAST") && (("UPGRADE_FROM_AUTOYAST") || get_var("UPGRADE"))) {
         $args .= " autoupgrade=1";
     }
 


### PR DESCRIPTION
Regresion introduced in #5537, I've moved part of the code which was
triggered only for pxe boot scenarios, which broke all non-pxe boot
upgrade scenarios. Condition is now adjusted. See [original code](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5537/files#diff-49acdcad3f0cdbc11210a53dc7cd0ceaL45).

See [poo#18236](https://progress.opensuse.org/issues/18236).
#### Verification runs
   * [TW update leap](http://g226.suse.de/tests/2360)
   * [staging](http://g226.suse.de/tests/2359)
