### PR TITLE
Add root-console selection after upgrade

### DIFF
--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -28,6 +28,9 @@ sub run {
         reset_consoles;
         select_console 'root-console';
     }
+    # This code is also called after boot on update tests. We must ensure to be on the root console
+    # in that case
+    select_console 'root-console' if (get_var('HDDVERSION'));
 
     # Wait for resources to be started
     wait_until_resources_started;


### PR DESCRIPTION
The HA test `check_after_reboot` is called on at least 4 scenarios:

1. On node 1, after it is fenced by node 2 on a cluster setup
2. On node 2, after fencing node 1.
3. On node 1, after upgrade.
4. On node 2, after upgrade.

It is required to issue a call to `reset_consoles` and to `select_console 'root-console'` on the first scenario, while no calls to `reset_consoles` and to `select_console` are required on the second scenario. On scenarios 3 and 4, only a call to `select_console 'root-console'` is required.

PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5574 wrongly removed the calls for scenarios 3 & 4, while fixing the calls for scenarios 1 & 2. This PR corrects this.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
- Failing Test: https://openqa.suse.de/tests/1963216