### PR TITLE
Fix power_action() in snapper_rollback

### DIFF
--- a/tests/migration/sle12_online_migration/snapper_rollback.pm
+++ b/tests/migration/sle12_online_migration/snapper_rollback.pm
@@ -33,10 +33,8 @@ sub run {
     select_console 'root-console';
     script_run "snapper rollback";
 
-    # reboot into the origin system before online migration
-    # execute reboot command directly since it is in a read-only snapshot
-    script_run("systemctl reboot", 0);
-    reset_consoles;
+    # reboot into the system before online migration
+    power_action('reboot', textmode => 1, keepconsole => 1);
     $self->wait_boot(textmode => !is_desktop_installed);
     select_console 'root-console';
 


### PR DESCRIPTION
The problem with PR 5582 was that `power_action()` was changing console
to `x11` when `DESKTOP` was set to `gnome`. Now, for non-Xen platforms,
it will essentially just execute "reboot" from command line. For Xen
platforms it will do the same but suggar-coat it with Xen-specific
stuff.

Fails here: https://openqa.suse.de/tests/1954241#step/snapper_rollback/16
Validation run: http://nilgiri.suse.cz/tests/952#step/snapper_rollback/14