### PR TITLE
Add test for rsync

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1006,6 +1006,7 @@ sub load_console_server_tests {
         # The NFS test expects the IP to be 10.0.2.15
         loadtest "console/yast2_nfs_server";
     }
+    loadtest "console/rsync";
     loadtest "console/http_srv";
     loadtest "console/dns_srv";
     loadtest "console/postgresql_server" unless (is_leap('<15.0'));
@@ -1474,6 +1475,7 @@ sub load_extra_tests_textmode {
     loadtest "console/wget_ipv6";
     loadtest "console/unzip";
     loadtest "console/gpg";
+    loadtest "console/rsync";
     loadtest "console/shells";
     # dstat is not in sle12sp1
     loadtest "console/dstat" if is_sle('12-SP2+') || is_opensuse;

--- a/tests/console/rsync.pm
+++ b/tests/console/rsync.pm
@@ -1,0 +1,69 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: This module creates files that are synced afterwards using rsync.
+# Maintainer: Ciprian Cret <ccret@suse.com>
+
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+use utils;
+use version_utils qw(is_opensuse is_sle is_jeos);
+
+sub run {
+    # create the folders and files that will be synced
+    select_console('root-console');
+    assert_script_run('mkdir /tmp/rsync_test_folder_a');
+    assert_script_run('mkdir /tmp/rsync_test_folder_b');
+    assert_script_run('echo rsync_test > /tmp/rsync_test_folder_a/rsync_test_file');
+    assert_script_run("echo '#!/bin/sh\\necho Hello World' > /tmp/rsync_test_folder_a/rsync_test_sh.sh");
+    assert_script_run('tar -cvf /tmp/rsync_test_folder_a/rsync_test_tar.tar /tmp/rsync_test_folder_a/rsync_test_file');
+
+    my $md5_initial_file = script_output('md5sum /tmp/rsync_test_folder_a/rsync_test_file');
+    my $md5_initial_sh   = script_output('md5sum /tmp/rsync_test_folder_a/rsync_test_sh.sh');
+    my $md5_initial_tar  = script_output('md5sum /tmp/rsync_test_folder_a/rsync_test_tar.tar');
+
+    # in case localhost is already inside known_hosts
+    if (script_run('! test -e ~/.ssh')) {
+        assert_script_run('ssh-keygen -R localhost');
+    }
+    type_string("rsync -avzr /tmp/rsync_test_folder_a/ root\@localhost:/tmp/rsync_test_folder_b; echo \$\? > /tmp/rsync_return_code.txt\n");
+    if (is_jeos || is_sle) {
+        assert_screen('remote-ssh-login');
+    }
+    elsif (is_opensuse) {
+        assert_screen('accept-ssh-host-key');
+    }
+    type_string('yes');
+    send_key('ret');
+    assert_screen('password-prompt');
+    type_password;
+    send_key('ret');
+    assert_screen('rsync');
+    assert_script_run('$(exit $(cat /tmp/rsync_return_code.txt))');
+
+    # keep the md5 hash value of the synced file and folder
+    my $md5_synced_file = script_output('md5sum /tmp/rsync_test_folder_b/rsync_test_file');
+    my $md5_synced_sh   = script_output('md5sum /tmp/rsync_test_folder_b/rsync_test_sh.sh');
+    my $md5_synced_tar  = script_output('md5sum /tmp/rsync_test_folder_b/rsync_test_tar.tar');
+
+    # compare the hash values
+    die("MD5 hash value of the synced text file is different from the initial one") unless ($md5_initial_file == $md5_synced_file);
+    die("MD5 hash value of the synced sh file is different from the initial one")   unless ($md5_initial_sh == $md5_synced_sh);
+    die("MD5 hash value of the synced tar file is different from the initial one")  unless ($md5_initial_tar == $md5_synced_tar);
+}
+
+sub post_run_hook {
+    assert_script_run('rm -rf /tmp/rsync_test_folder_a');
+    assert_script_run('rm -rf /tmp/rsync_test_folder_b');
+    assert_script_run('rm /tmp/rsync_return_code.txt');
+}
+
+1;


### PR DESCRIPTION
This test is added because JeOS comes with rsync by default for syncing
with other systems.

Progress ticket: https://progress.opensuse.org/issues/39782

Validation runs:
JeOS: http://10.100.51.171/tests/192
OpenSUSE: http://10.100.51.171/tests/193
SLE12-SP4: http://10.100.51.171/tests/194

SLE Needles PR: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/915
OpenSUSE Needls PR: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/421