### PR TITLE
Assert screen before sending alt-f4 to gnucash

### DIFF
--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -16,12 +16,14 @@ use strict;
 use testapi;
 
 sub run {
+    select_console('x11');
     ensure_installed('gnucash gnucash-docs yelp');
     x11_start_program('gnucash');
     send_key "ctrl-h";    # open user tutorial
     assert_screen 'test-gnucash-2';
     # Leave tutorial window
-    wait_screen_change { send_key 'alt-f4' };
+    send_key 'alt-f4';
+    assert_screen('gnucash');
     # Leave tips windows for GNOME/gtk case
     if (get_var('DESKTOP', '') =~ /gnome|xfce|lxde/) {
         # LXDE specifc behaviour: After closing one window not the first


### PR DESCRIPTION
On KDE, the problem is different, just after closing the help window, the main gnucash windows is some seconds unfocused, causing the keys alt-f4 to get lost.

- Related ticket: https://progress.opensuse.org/issues/38387
- Verification run: http://10.160.66.74/tests/820
