### PR TITLE
Make wicked advanced tests more reliable

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1084,6 +1084,7 @@ Also doing test ping to 10.0.2.2 to check that network is alive
 sub setup_static_network {
     my ($self, $ip) = @_;
     assert_script_run("echo 'default 10.0.2.2 - -' > /etc/sysconfig/network/routes");
+    assert_script_run("echo 'nameserver 10.160.0.1' >> /etc/resolv.conf");
     my $iface = script_output('ls /sys/class/net/ | grep -v lo | head -1');
     assert_script_run qq(echo -e "\\nSTARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$ip'">/etc/sysconfig/network/ifcfg-$iface);
     assert_script_run "rcnetwork restart";

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -24,10 +24,6 @@ sub run {
     assert_script_run($enable_command_logging);
     systemctl("stop " . opensusebasetest::firewall);
     systemctl("disable " . opensusebasetest::firewall);
-    record_info('INFO', 'Checking that network is up');
-    zypper_call('--quiet in openvpn', timeout => 200);
-    systemctl('is-active network');
-    systemctl('is-active wicked');
     assert_script_run('[ -z "$(coredumpctl -1 --no-pager --no-legend)" ]');
     record_info('INFO', 'Setting debug level for wicked logs');
     assert_script_run('sed -e "s/^WICKED_DEBUG=.*/WICKED_DEBUG=\"all\"/g" -i /etc/sysconfig/network/config');
@@ -41,6 +37,10 @@ sub run {
         $self->setup_static_network($self->get_ip(is_wicked_ref => check_var('IS_WICKED_REF', 1), type => 'host'));
     }
     $self->get_from_data('wicked/ifbind.sh', '/bin/ifbind.sh', executable => 1);
+    record_info('INFO', 'Checking that network service is up');
+    systemctl('is-active network');
+    systemctl('is-active wicked');
+    zypper_call('--quiet in openvpn', timeout => 200) if (check_var('WICKED', 'advanced'));
 }
 
 sub test_flags {


### PR DESCRIPTION
Fix poo#39887: Current wicked test call zypper before network is fully
configured, static configuration is missing nameserver definition.

DNS configuration was added to static setup. Network service check is
done after network configuration. OpenVPN is moved to the end of the
test and installed only for advanced test.

- Related ticket: https://progress.opensuse.org/issues/39887
- Needles: none
- Verification run: 
http://10.100.12.105/tests/overview?build=21.2&distri=sle&version=15-SP1&groupid=43
