### PR TITLE
Fix power_action_utils import in post_zdup module

### DIFF
--- a/tests/installation/post_zdup.pm
+++ b/tests/installation/post_zdup.pm
@@ -15,6 +15,7 @@ use base "installbasetest";
 use strict;
 use testapi;
 use utils;
+use power_action_utils 'power_action';
 
 sub run {
     clear_console;


### PR DESCRIPTION
The PR fixes missed power_action_utils import in post_zdup module. 

It was happened due to recent https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5613 that extracted power_action_utils from utils.