### PR TITLE
Fix desktop_runner unresponsiveness due to forced gdm login

### DIFF
--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -16,7 +16,6 @@ use strict;
 use testapi;
 
 sub run {
-    select_console('x11');
     ensure_installed('gnucash gnucash-docs yelp');
     x11_start_program('gnucash');
     send_key "ctrl-h";    # open user tutorial


### PR DESCRIPTION
Selecting the console 'x11' might not sound harmful but in case of gdm
it actually is because 'x11' is the tty which runs only the login
manager and never the actual logged in session (tty2 vs. tty7).
01de66341 introduced the explicit `select_console('x11')` which sounds
harmless at first but is not.

See https://openqa.opensuse.org/tests/740670 for a failure that is
expected to be fixed by this.