### PR TITLE
Increase $timeout if offline upgrade

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -40,6 +40,7 @@ sub login_to_console {
         save_screenshot;
         #offline upgrade requires upgrading offline during reboot while online doesn't
         if (check_var('offline_upgrade', 'yes')) {
+            $timeout = 600;
             #boot to upgrade menuentry
             send_key 'down';
             send_key 'ret';


### PR DESCRIPTION
Upgrade from SLES-11-SP4 costs extra time to install packages.
Increase $timeout to avoid needel match time out.

- Related ticket: https://openqa.suse.de/tests/1969043#step/reboot_and_wait_up_upgrade/33
- Needles: n/a
- Verification run: n/a

@alice-suse @XGWang0 @xguo @Julie-CAO