### PR TITLE
Adapt new ServiceWidget - y2proxy & y2http

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -3,8 +3,23 @@
 package console_yasttest;
 use base 'y2logsstep';
 use strict;
-
 use testapi;
+
+sub assert_service_widget {
+    my ($self, %args) = @_;
+    my $after_writing_conf = $args{after_writing_conf} || 'alt-f';
+    my $after_reboot       = $args{after_reboot}       || 'alt-a';
+
+    assert_screen 'yast2_ncurses_service_start_widget';
+    send_key $after_writing_conf;
+    send_key_until_needlematch 'yast2_ncurses_service_start_widget_start_after_conf', 'up';
+    send_key 'ret';
+    assert_screen 'yast2_ncurses_service_start_widget_check_start_after_conf';
+    send_key $after_reboot;
+    send_key_until_needlematch 'yast2_ncurses_service_start_widget_start_on_boot', 'up';
+    send_key 'ret';
+    assert_screen 'yast2_ncurses_service_start_widget_check_start_on_boot';
+}
 
 sub post_fail_hook {
     my $self = shift;

--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -17,6 +17,7 @@ use utils 'zypper_call';
 use version_utils qw(is_sle is_leap);
 
 sub run {
+    my $self = shift;
 
     select_console 'root-console';
     # install http server
@@ -102,25 +103,17 @@ sub run {
     assert_screen 'http_vitual_host_page';          # check wizard page (4/5)
     send_key 'alt-n';                               # go to http server wizard (5/5) --summary
                                                     # make sure that apache2 server got started when booting
-    if ((is_sle '<15') || (is_leap)) {
+    if (is_sle('<15') || is_leap('<15.1')) {
         assert_screen 'http_summary';
         send_key 'alt-t';
         assert_screen 'http_start_apache2';
     }
     else {
-        assert_screen 'yast2_ncurses_service_start_widget';
-        send_key 'alt-t';
-        send_key_until_needlematch 'yast2_ncurses_service_start_widget_start_after_conf', 'up';
-        send_key 'ret';
-        assert_screen 'yast2_ncurses_service_start_widget_check_start_after_conf';
-        send_key 'alt-a';
-        send_key_until_needlematch 'yast2_ncurses_service_start_widget_start_on_boot', 'up';
-        send_key 'ret';
-        assert_screen 'yast2_ncurses_service_start_widget_check_start_on_boot';
+        $self->assert_service_widget(after_writing_conf => 'alt-w', after_reboot => 'alt-e');
     }
-    send_key 'alt-f';    # now finish the tests :)
+    send_key 'alt-f';                               # now finish the tests :)
     check_screen 'http_install_apache2_mods', 60;
-    send_key 'alt-i';    # confirm to install apache2_mod_perl, apache2_mod_php, apache2_mod_python
+    send_key 'alt-i';                               # confirm to install apache2_mod_perl, apache2_mod_php, apache2_mod_python
 
     # if popup, confirm to enable apache2 configuratuion
     if (check_screen('http_enable_apache2', 10)) {
@@ -129,4 +122,3 @@ sub run {
     wait_serial("yast2-http-server-status-0", 240) || die "'yast2 http-server' didn't finish";
 }
 1;
-


### PR DESCRIPTION
PR - Adapt new ServiceWidget - yast2_proxy and yast2_http taking into account that Leap 15.1 recently received it as we can see [here](https://openqa.opensuse.org/tests/739591#step/yast2_proxy/51). I also would like to provide some refactor.

- Related ticket: https://progress.opensuse.org/issues/39725
- Needles: not needed
- Verification run: [opensuse-15.1-yast2_ncurses](http://dhcp87.suse.cz/tests/2238#step/yast2_proxy/16)
