### PR TITLE
Switch to tty1 multi-times in ro snapshot

### DIFF
--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -14,19 +14,12 @@ use base "consoletest";
 use testapi;
 use utils;
 use strict;
-use migration 'check_rollback_system';
+use migration qw(check_rollback_system boot_into_ro_snapshot);
 
 sub run {
     my ($self) = @_;
 
-    # assert the we are on a ro snapshot.
-    # assert_screen 'linux-login', 200;
-    # workaround known issue: bsc#980337
-    if (!check_screen('linux-login', 200)) {
-        record_soft_failure 'bsc#980337';
-        send_key "ctrl-alt-f1";
-        assert_screen 'tty1-selected';
-    }
+    boot_into_ro_snapshot;
     select_console 'root-console';
     # 1)
     script_run('touch NOWRITE;test ! -f NOWRITE', 0);

--- a/tests/migration/sle12_online_migration/snapper_rollback.pm
+++ b/tests/migration/sle12_online_migration/snapper_rollback.pm
@@ -15,21 +15,12 @@ use strict;
 use testapi;
 use power_action_utils 'power_action';
 use version_utils 'is_desktop_installed';
-use migration 'check_rollback_system';
+use migration qw(check_rollback_system boot_into_ro_snapshot);
 
 sub run {
     my ($self) = @_;
 
-    # login to before online migration snapshot
-    # tty would not appear quite often after booting snapshot
-    # it is a known bug bsc#980337
-    # in this case select tty1 first then select root console
-    if (!check_screen('linux-login', 200)) {
-        record_soft_failure 'bsc#980337';
-        send_key "ctrl-alt-f1";
-        assert_screen 'tty1-selected';
-    }
-
+    boot_into_ro_snapshot;
     select_console 'root-console';
     script_run "snapper rollback";
 


### PR DESCRIPTION
- To fix: https://openqa.suse.de/tests/1969085#step/snapper_rollback/1
- Related ticket: https://progress.opensuse.org/issues/40154
- Verification run: http://openqa-apac1.suse.de/tests/1587#step/snapper_rollback/3

This MAY fix some sporadic failures during booting read-only snapshot at snapper rollback stage.
The failure is hard to reproduce, sometimes it would not appear if we give another run.
