### PR TITLE
Fix new role style for sle

### DIFF
--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -58,7 +58,7 @@ sub assert_system_role {
     else {
         assert_screen('system-role-default-system', 180);
         my $system_role = get_var('SYSTEM_ROLE', 'default');
-        change_system_role($system_role) if ($system_role && !check_var('SYSTEM_ROLE', 'default'));
+        change_system_role($system_role) if (get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'));
     }
     send_key $cmd{next};
 }


### PR DESCRIPTION
Fix new role style for sle. That change reverts to the original functionality. I tried to reuse the variable with good intention to clean code but it didn't work. This code revert to the original logic for sle so, for example, this job will not fail: https://openqa.suse.de/tests/latest?machine=64bit&test=gpt&flavor=Server-DVD&arch=x86_64&distri=sle&version=12-SP4#step/system_role/4 it will not enter in the subroutine that changes the default.

- Related ticket: https://progress.opensuse.org/issues/39014
- Needles: not needed
- Verification run: not needed
