### PR TITLE
Add network restart to wicked basic test

### DIFF
--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -35,6 +35,8 @@ sub run {
     $self->get_from_data('wicked/check_interfaces.sh', '/data/check_interfaces.sh', executable => 1) if check_var('WICKED', 'basic');
     if (check_var('WICKED', 'advanced')) {
         $self->setup_static_network($self->get_ip(is_wicked_ref => check_var('IS_WICKED_REF', 1), type => 'host'));
+    } else {
+        systemctl('restart network');
     }
     $self->get_from_data('wicked/ifbind.sh', '/bin/ifbind.sh', executable => 1);
     record_info('INFO', 'Checking that network service is up');


### PR DESCRIPTION
Fix poo#40181: There is configured debug for the wicked in the test,
but service is not restarted for basic variant. Now it will be restarted
even for wicked basic test.

This should improve log details in case of failure and provide us more information
for troubleshooting. 

- Related ticket: https://progress.opensuse.org/issues/40181
- Needles: none
- Verification run: 
15-SP1: http://10.100.12.105/tests/overview?build=24.5&distri=sle&version=15-SP1&groupid=43
12-SP4: http://10.100.12.105/tests/overview?build=0341&distri=sle&version=12-SP4&groupid=43
