### PR TITLE
Remove missing services from SLE 15 profiles

### DIFF
--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -369,11 +369,9 @@ pre init scripts feature. See poo#20818.
       <disable config:type="list">
       </disable>
       <enable config:type="list">
-        <service>atd</service>
         <service>kexec-load</service>
         <service>sshd</service>
         <service>sysstat</service>
-        <service>tuned</service>
       </enable>
     </services>
   </services-manager>

--- a/data/autoyast_sle15/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle15/bug-872532_ix64ph1069.xml
@@ -651,15 +651,9 @@
     <services config:type="list">
       <service>cron</service>
       <service>getty@tty1</service>
-      <service>haveged</service>
       <service>kdump</service>
-      <service>nscd</service>
       <service>postfix</service>
-      <service>rsyslog</service>
       <service>sshd</service>
-      <service>firewalld</service>
-      <service>systemd-readahead-collect</service>
-      <service>systemd-readahead-replay</service>
       <service>wicked</service>
       <service>wickedd-auto4</service>
       <service>wickedd-dhcp4</service>

--- a/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
@@ -739,14 +739,9 @@ find / -name YaST2-Second-Stage.service
     <services config:type="list">
       <service>cron</service>
       <service>getty@tty1</service>
-      <service>haveged</service>
       <service>kdump</service>
-      <service>nscd</service>
       <service>postfix</service>
-      <service>rsyslog</service>
       <service>sshd</service>
-      <service>systemd-readahead-collect</service>
-      <service>systemd-readahead-replay</service>
       <service>wicked</service>
       <service>wickedd-auto4</service>
       <service>wickedd-dhcp4</service>

--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -372,15 +372,11 @@
       <service>getty@tty6</service>
       <service>haveged</service>
       <service>irqbalance</service>
-      <service>iscsi</service>
       <service>kdump</service>
       <service>nscd</service>
-      <service>ntpd</service>
       <service>postfix</service>
       <service>purge-kernels</service>
       <service>rsyslog</service>
-      <service>systemd-readahead-collect</service>
-      <service>systemd-readahead-replay</service>
       <service>wicked</service>
       <service>wickedd-auto4</service>
       <service>wickedd-dhcp4</service>
@@ -403,15 +399,11 @@
       <service>getty@tty6</service>
       <service>haveged</service>
       <service>irqbalance</service>
-      <service>iscsi</service>
       <service>kdump</service>
       <service>nscd</service>
-      <service>ntpd</service>
       <service>postfix</service>
       <service>purge-kernels</service>
       <service>rsyslog</service>
-      <service>systemd-readahead-collect</service>
-      <service>systemd-readahead-replay</service>
       <service>wicked</service>
       <service>wickedd-auto4</service>
       <service>wickedd-dhcp4</service>

--- a/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
+++ b/data/autoyast_sle15/bug-887653_autoinst_jy-snapshot.xml
@@ -138,10 +138,6 @@
         <service_status>enable</service_status>
       </service>
       <service>
-        <service_name>hamsta</service_name>
-        <service_status>enable</service_status>
-      </service>
-      <service>
         <service_name>sshd</service_name>
         <service_status>enable</service_status>
       </service>


### PR DESCRIPTION
We got changes, so we validate services now and show warning in case
they are missing. Hence, removing them not to trigger the warning.

See [poo#40130](https://progress.opensuse.org/issues/40130).

#### Verification runs
- [autoyast_bug-872532_ix64ph1069](http://g226.suse.de/tests/2404)
- [autoyast_bug-876411_btrfs_h5_autoinst](http://g226.suse.de/tests/2405)
- [autoyast_bug-887653_autoinst_jy-snapshot](http://g226.suse.de/tests/2407)
- [autoyast_multipath](http://g226.suse.de/tests/2408)
- [autoyast_bug-887126_autoinst](http://g226.suse.de/tests/2409).