### PR TITLE
Add integration to new service configuration widget

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -5,20 +5,28 @@ use base 'y2logsstep';
 use strict;
 use testapi;
 
-sub assert_service_widget {
+sub change_service_configuration {
     my ($self, %args) = @_;
-    my $after_writing_conf = $args{after_writing_conf} || 'alt-f';
-    my $after_reboot       = $args{after_reboot}       || 'alt-a';
+    my $after_writing_ref = $args{after_writing};
+    my $after_reboot_ref  = $args{after_reboot};
 
     assert_screen 'yast2_ncurses_service_start_widget';
-    send_key $after_writing_conf;
-    send_key_until_needlematch 'yast2_ncurses_service_start_widget_start_after_conf', 'up';
+    change_service_configuration_step('after_writing_conf', $after_writing_ref) if $after_writing_ref;
+    change_service_configuration_step('after_reboot',       $after_reboot_ref)  if $after_reboot_ref;
+}
+
+sub change_service_configuration_step {
+    my ($step_name, $step_conf_ref) = @_;
+    my ($action)         = keys %$step_conf_ref;
+    my ($shortcut)       = values %$step_conf_ref;
+    my $needle_selection = 'yast2_ncurses_service_' . $action . '_' . $step_name;
+    my $needle_check     = 'yast2_ncurses_service_check_' . $action . '_' . $step_name;
+
+    send_key $shortcut;
+    send_key 'end';
+    send_key_until_needlematch $needle_selection, 'up', 5, 1;
     send_key 'ret';
-    assert_screen 'yast2_ncurses_service_start_widget_check_start_after_conf';
-    send_key $after_reboot;
-    send_key_until_needlematch 'yast2_ncurses_service_start_widget_start_on_boot', 'up';
-    send_key 'ret';
-    assert_screen 'yast2_ncurses_service_start_widget_check_start_on_boot';
+    assert_screen $needle_check;
 }
 
 sub post_fail_hook {

--- a/tests/console/yast2_ftp.pm
+++ b/tests/console/yast2_ftp.pm
@@ -85,18 +85,25 @@ sub run {
 
     # start yast2 ftp configuration
     type_string "yast2 ftp-server; echo yast2-ftp-server-status-\$? > /dev/$serialdev\n";
-    assert_screen 'ftp-server';                 # check ftp server configuration page
-    send_key 'alt-w';                           # make sure ftp start-up when booting
-    assert_screen 'ftp_server_when_booting';    # check service start when booting
+    assert_screen 'ftp-server';    # check ftp server configuration page
+    if (is_sle('<15') || is_leap('<15.1')) {
+        send_key 'alt-w';                           # make sure ftp start-up when booting
+        assert_screen 'ftp_server_when_booting';    # check service start when booting
+    }
+    else {
+        $self->change_service_configuration(
+            after_writing => {start         => 'alt-t'},
+            after_reboot  => {start_on_boot => 'alt-a'}
+        );
+    }
 
     # General
     send_key_until_needlematch 'yast2_ftp_start-up_selected', 'tab';
     wait_screen_change { send_key 'down' };
-    wait_screen_change { send_key 'ret' };      # enter page General
-
+    wait_screen_change { send_key 'ret' };          # enter page General
     assert_screen 'yast2_tftp_general_selected';
-    assert_screen 'ftp_welcome_mesage';         # check welcome message for add strings
-    send_key 'alt-w';                           # select welcome message to edit
+    assert_screen 'ftp_welcome_mesage';             # check welcome message for add strings
+    send_key 'alt-w';                               # select welcome message to edit
     send_key_until_needlematch 'yast2_tftp_empty_welcome_message', 'backspace';    # delete existing welcome strings
     type_string($vsftpd_directives->{ftpd_banner});                                # type new welcome text
     assert_screen 'ftp_welcome_message_added';                                     # check new welcome text
@@ -199,5 +206,5 @@ sub post_fail_hook {
 sub test_flags {
     return {milestone => 1};
 }
-1;
 
+1;

--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -109,7 +109,10 @@ sub run {
         assert_screen 'http_start_apache2';
     }
     else {
-        $self->assert_service_widget(after_writing_conf => 'alt-w', after_reboot => 'alt-e');
+        $self->change_service_configuration(
+            after_writing => {start         => 'alt-t'},
+            after_reboot  => {start_on_boot => 'alt-a'}
+        );
     }
     send_key 'alt-f';                               # now finish the tests :)
     check_screen 'http_install_apache2_mods', 60;
@@ -121,4 +124,5 @@ sub run {
     }
     wait_serial("yast2-http-server-status-0", 240) || die "'yast2 http-server' didn't finish";
 }
+
 1;

--- a/tests/console/yast2_proxy.pm
+++ b/tests/console/yast2_proxy.pm
@@ -89,7 +89,10 @@ sub run {
         send_key_until_needlematch 'yast2_proxy_service_start', 'alt-b';    #Start service when booting
     }
     else {
-        $self->assert_service_widget;
+        $self->change_service_configuration(
+            after_writing => {start         => 'alt-f'},
+            after_reboot  => {start_on_boot => 'alt-a'}
+        );
     }
 
     # if firewall is enabled, then send_key alt-p, else move to page http ports


### PR DESCRIPTION
Add integration to new service configuration widget. It includes: yast2_proxy, yast2_samba, yast2_dns_server, yast2_http and yast2_ftp using a mapped version of the user control due to it was necessary to control different behaviors (start, stop, disabled, ...) besides reusing code.

- Related ticket: https://progress.opensuse.org/issues/39725
- Needles: 
  - [openSUSE](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/427)
  - [SLE](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/916)
- Verification run: 
  - [Tumbleweed-yast2_ncurses](http://dhcp87.suse.cz/tests/2327#step/yast2_ftp/125)
  - [sle-15-SP1-yast2_ncurses](http://dhcp87.suse.cz/tests/2337)
