### PR TITLE
Add post_fail_hook record_info for boot_to_desktop

### DIFF
--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -17,6 +17,7 @@ use testapi;
 
 sub run {
     my ($self) = @_;
+    $self->{in_boot_desktop} = 1;
     # We have tests that boot from HDD and wait for DVD boot menu's timeout, so
     # the timeout here must cover it. UEFI DVD adds some 60 seconds on top.
     my $timeout = get_var('UEFI') ? 140 : 80;


### PR DESCRIPTION
- see https://progress.opensuse.org/issues/38537
- verification runs:
  http://e13.suse.de/tests/7652#step/boot_to_desktop/6
  http://e13.suse.de/tests/7708#step/user_defined_snapshot/21