### PR TITLE
Set patterns for lxde,xfce,minimalx if system roles are used

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -90,6 +90,18 @@ if (check_var('DESKTOP', 'minimalx')) {
         set_var("XDMUSED",           1);
         set_var('DM_NEEDS_USERNAME', 1);
     }
+    # Set patterns for the new system role flow, as we need to select patterns, similarly to SLE12
+    if (get_var('SYSTEM_ROLE_STYLE') && !get_var('PATTERNS')) {
+        set_var('PATTERNS', 'default,minimalx');
+    }
+}
+
+if (get_var('SYSTEM_ROLE_STYLE') && check_var('DESKTOP', 'lxde') && !get_var('PATTERNS')) {
+    set_var('PATTERNS', 'default,lxde');
+}
+
+if (get_var('SYSTEM_ROLE_STYLE') && check_var('DESKTOP', 'xfce') && !get_var('PATTERNS')) {
+    set_var('PATTERNS', 'default,xfce');
 }
 
 if (is_leap('15.0+') || is_tumbleweed()) {

--- a/tests/installation/system_role.pm
+++ b/tests/installation/system_role.pm
@@ -42,8 +42,9 @@ sub change_system_role {
         send_key 'alt-' . $role_hotkey{$system_role};
         assert_screen "system-role-$system_role-selected";
     }
-    # every system role other than default will end up in textmode
-    set_var('DESKTOP', 'textmode');
+    # every system role other than default will end up in textmode for SLE
+    # But can be minimalx/lxde/xfce
+    set_var('DESKTOP', 'textmode') unless is_opensuse;
 }
 
 sub assert_system_role {


### PR DESCRIPTION
See [poo#39017](https://progress.opensuse.org/issues/39017).

- [Needles](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/426)
- [Verification run](http://g226.suse.de/tests/2461)
