### PR TITLE
xfstests: skip s390x set softlockup in kdump bsc#1104778

### DIFF
--- a/tests/xfstests/enable_kdump.pm
+++ b/tests/xfstests/enable_kdump.pm
@@ -26,8 +26,12 @@ sub run {
     select_console('root-console');
 
     # Also panic when softlockup
+    # workaround bsc#1104778, skip s390x in 12SP4
     assert_script_run('echo "kernel.softlockup_panic = 1" >> /etc/sysctl.conf');
-    assert_script_run('sysctl -p');
+    my $output = script_output('sysctl -p');
+    unless ($output =~ /kernel.softlockup_panic = 1/) {
+        record_soft_failure 'bsc#1104778';
+    }
 
     # Activate kdump
     prepare_for_kdump;


### PR DESCRIPTION
xfstests fails all in s390x by bsc#1104778, this bug is a P3 bug, assume need long time to fix. Workaround it by this PR.

- Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1104778
- Verification run: http://10.67.133.102/tests/630
