### PR TITLE
Wait more time for SCC deregister

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -581,7 +581,7 @@ sub scc_deregistration {
     my (%args) = @_;
     $args{version_variable} //= 'VERSION';
     if (sle_version_at_least('12-SP1', version_variable => $args{version_variable})) {
-        assert_script_run('SUSEConnect -d --cleanup');
+        assert_script_run('SUSEConnect -d --cleanup', 200);
         my $output = script_output 'SUSEConnect -s';
         die "System is still registered" unless $output =~ /Not Registered/;
         save_screenshot;


### PR DESCRIPTION
The SCC deregister operation need more time than 90s, we should increase the waiting time for SCC deregister.

- Related ticket: https://progress.opensuse.org/issues/39245
- Verification run: https://openqa.suse.de/tests/1962156#
I clone the job and set TIMEOUT_SCALE=4, the time for SUSEConnect -d --cleanup finished is about 95s, anyway I think we can set the timeout as 200s.
