### PR TITLE
Don't call mellanox_config() when hardware not available

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -631,7 +631,9 @@ sub load_baremetal_tests {
             barrier_create('IBTEST_BEGIN', 3);
             barrier_create('IBTEST_DONE',  3);
         }
-        mellanox_config();
+        else {
+            mellanox_config();
+        }
         loadtest "kernel/ib_tests";
     }
     elsif (get_var('NFV')) {


### PR DESCRIPTION
When loading the InfiniBand tests, the master controlling the execution
does not have the Mellanox hardware available. Thus the script
configuring the boards must not be executed for the master.

Signed-off-by: Michael Moese <mmoese@suse.de>

