### PR TITLE
Make grub2 needle timeout configurable

### DIFF
--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -89,12 +89,13 @@ sub bug_workaround_bsc1005313 {
 
 sub run {
     my ($self) = @_;
+    my $timeout = get_var('GRUB_TIMEOUT', 90);
 
     $self->handle_installer_medium_bootup;
     workaround_type_encrypted_passphrase;
     # 60 due to rare slowness e.g. multipath poo#11908
     # 90 as a workaround due to the qemu backend fallout
-    assert_screen 'grub2', 90;
+    assert_screen 'grub2', $timeout;
     stop_grub_timeout;
     set_vmware_videomode if check_var('VIRSH_VMM_FAMILY', 'vmware');
     boot_into_snapshot if get_var("BOOT_TO_SNAPSHOT");


### PR DESCRIPTION
Boot process takes longer in bare metal machines. We have observed several times (not always) that grub2_test fails due to a timeout because the grub screen doesn't appear before 90 seconds. This way, we make the timeout configurable by the user (90 by default as before).