### PR TITLE
Exclude mdadm test on jeos

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1506,7 +1506,7 @@ sub load_extra_tests_textmode {
     }
     # bind need source package and legacy and development module on SLE15+
     loadtest 'console/bind' if get_var('MAINT_TEST_REPO');
-    loadtest 'console/mdadm';
+    loadtest 'console/mdadm' unless is_jeos;
     if (get_var("SYSAUTHTEST")) {
         # sysauth test scenarios run in the console
         loadtest "sysauth/sssd";


### PR DESCRIPTION
jeos kernel is missing md_mod module

- Related ticket: https://progress.opensuse.org/issues/40277
- Verification run: http://10.100.12.155/tests/5894
