### PR TITLE
zypper migration retry on HTTP error 502

### DIFF
--- a/tests/migration/sle12_online_migration/zypper_migration.pm
+++ b/tests/migration/sle12_online_migration/zypper_migration.pm
@@ -41,6 +41,7 @@ sub run {
         $zypper_migration_error,  $zypper_migration_conflict, $zypper_migration_fileconflict, $zypper_migration_notification,
         $zypper_migration_failed, $zypper_migration_license
     ];
+    my $zypper_migration_error_cnt = 0;
     my $out = wait_serial($migration_checks, $timeout);
     while ($out) {
         if ($out =~ $zypper_migration_target) {
@@ -56,8 +57,18 @@ sub run {
             send_key "y";
             send_key "ret";
         }
-        elsif ($out =~ $zypper_migration_error
-            || $out =~ $zypper_migration_conflict
+        elsif ($out =~ $zypper_migration_error) {
+            $zypper_migration_error_cnt += 1;
+            die 'Migration failed with zypper error' if $zypper_migration_error_cnt > 3;
+            record_info("Migration error [$zypper_migration_error_cnt/3]",
+                'zypper migration error, will sleep for a while and retry',
+                result => 'softfail');
+            sleep 60;
+            # Retry zypper action
+            send_key 'r';
+            send_key 'ret';
+        }
+        elsif ($out =~ $zypper_migration_conflict
             || $out =~ $zypper_migration_fileconflict
             || $out =~ $zypper_migration_failed)
         {


### PR DESCRIPTION
Sometimes zypper migration fails on Hyper-V with a following error:
https://openqa.suse.de/tests/2001946#step/zypper_migration/4. I was
wondering if we could retry couple of times to see if we eventually go
thru.

Currently the HTTP 502 error is not happening, so I can't test if it's
effective, but on the other hand it should not break anything and we
could find out on OSD if it works.