### PR TITLE
Replace 'reboot' with power_action()

### DIFF
--- a/tests/boot/snapper_rollback.pm
+++ b/tests/boot/snapper_rollback.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,6 +15,7 @@ use testapi;
 use utils;
 use strict;
 use migration qw(check_rollback_system boot_into_ro_snapshot);
+use power_action_utils 'power_action';
 
 sub run {
     my ($self) = @_;
@@ -29,8 +30,7 @@ sub run {
     # rollback
     script_run("snapper rollback -d rollback-before-migration");
     assert_script_run("snapper list | tail -n 2 | grep rollback");
-    script_run("systemctl reboot", 0);
-    reset_consoles;
+    power_action('reboot', textmode => 1, keepconsole => 1);
     $self->wait_boot(ready_time => 300, bootloader_time => 300);
     select_console 'root-console';
     check_rollback_system;


### PR DESCRIPTION
The code is effectively the same as for `migration/sle12_online_migration/snapper_rollback`.

Fails here: https://openqa.suse.de/tests/2001748#step/snapper_rollback/14
Validation run: http://nilgiri.suse.cz/tests/961