### PR TITLE
Do not press space to avoid first pattern selection

### DIFF
--- a/tests/installation/select_patterns_and_packages.pm
+++ b/tests/installation/select_patterns_and_packages.pm
@@ -75,13 +75,11 @@ sub gotopatterns {
         wait_screen_change { send_key 'alt-f' };
         for (1 .. 4) { send_key 'up'; }
         send_key 'ret';
-        assert_screen 'patterns-list-selected';
     }
     else {
         send_key 'tab';
-        send_key ' ';
-        assert_screen 'patterns-list-selected';
     }
+    assert_screen 'patterns-list-selected';
 }
 
 sub package_action {


### PR DESCRIPTION
Old code caused selection of the first pattern, which was fine for many
scenarios, but broke scenario where we select only Cloud Azure pattern.

See [poo#38870](https://progress.opensuse.org/issues/38870).
- [Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/917)
- Verification runs:
     - [selecting aws-all](http://g226.suse.de/tests/2482#step/select_patterns_and_packages/13) (aws-all selected as per PATTERNS setting)
     - [selecting azure-all](http://g226.suse.de/tests/2477#step/select_patterns_and_packages/28) (no aws -all selected in comparison to https://openqa.suse.de/tests/2002975#step/select_patterns_and_packages/28
