### PR TITLE
xfstests: replace script_output to script_run

### DIFF
--- a/tests/xfstests/enable_kdump.pm
+++ b/tests/xfstests/enable_kdump.pm
@@ -28,7 +28,7 @@ sub run {
     # Also panic when softlockup
     # workaround bsc#1104778, skip s390x in 12SP4
     assert_script_run('echo "kernel.softlockup_panic = 1" >> /etc/sysctl.conf');
-    my $output = script_output('sysctl -p');
+    my $output = script_run('sysctl -p');
     unless ($output =~ /kernel.softlockup_panic = 1/) {
         record_soft_failure 'bsc#1104778';
     }


### PR DESCRIPTION
The previous modify not help to continue test, and still fail in the bug issue. 
https://openqa.suse.de/tests/2006628#step/enable_kdump/18
Actually softfail shouldn't use with script_output, it should be changed to script_run.

- Related PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5645
- Verification run: http://10.67.133.102/tests/655
