### PR TITLE
Update gnote_cleanup can handle different needles

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -805,8 +805,9 @@ sub gnote_search_and_close {
 
 # remove the created new note
 sub cleanup_gnote {
+    my ($self, $needle) = @_;
     send_key 'esc';    #back to all notes interface
-    send_key_until_needlematch 'gnote-new-note-matched', 'down', 6;
+    send_key_until_needlematch $needle, 'down', 6;
     wait_screen_change { send_key 'delete' };
     wait_screen_change { send_key 'tab' };
     wait_screen_change { send_key 'ret' };

--- a/tests/x11/gnote/gnote_edit_format.pm
+++ b/tests/x11/gnote/gnote_edit_format.pm
@@ -35,7 +35,7 @@ sub run {
     send_key "ctrl-i";    #italic off
     assert_screen 'gnote-edit-format', 5;
 
-    $self->cleanup_gnote;
+    $self->cleanup_gnote('gnote-new-note-matched');
 }
 
 1;

--- a/tests/x11/gnote/gnote_link_note.pm
+++ b/tests/x11/gnote/gnote_link_note.pm
@@ -38,7 +38,7 @@ sub run {
     wait_screen_change { send_key 'esc' };
     #close the note "Start Here"
     wait_screen_change { send_key 'ctrl-w' } if is_sle('<15');
-    $self->cleanup_gnote;
+    $self->cleanup_gnote('gnote-new-note-matched');
 }
 
 1;

--- a/tests/x11/gnote/gnote_rename_title.pm
+++ b/tests/x11/gnote/gnote_rename_title.pm
@@ -26,7 +26,7 @@ sub run {
     send_key "up";
     send_key "up";
     type_string "new title-opensuse\n";
-    $self->cleanup_gnote;
+    $self->cleanup_gnote('gnote-new-note-title-matched');
 }
 
 1;

--- a/tests/x11/gnote/gnote_undo_redo.pm
+++ b/tests/x11/gnote/gnote_undo_redo.pm
@@ -44,7 +44,7 @@ sub run {
     $self->undo_redo_once;
 
     #clean: remove the created new note
-    $self->cleanup_gnote;
+    $self->cleanup_gnote('gnote-new-note-matched');
 }
 
 1;


### PR DESCRIPTION
Update "gnote_cleanup" function in order to handle
different input needles.

- Verification run: 
[qam-regression-documentation](http://10.67.19.181/tests/817)
TW is downloading the snapshot, please wait for a short time.
