### PR TITLE
main_common: do not need to clear repos on dualboot

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -640,6 +640,7 @@ sub need_clear_repos {
       && (!get_var('INSTALLONLY') || get_var('PUBLISH_HDD_1'))
       && !get_var('BOOT_TO_SNAPSHOT')
       && !get_var('LIVETEST')
+      && !get_var('DUALBOOT')
       && (is_opensuse && !is_updates_tests)
       && !(is_jeos && !is_staging)
       || (is_sle && get_var("FLAVOR", '') =~ m/^Staging2?[\-]DVD$/ && get_var("SUSEMIRROR"));


### PR DESCRIPTION
DUALBOOT scenario should be stopped once boot to Windows, no needs to do clear up repos steps.

- Fixes https://progress.opensuse.org/issues/40313