### PR TITLE
Check if AUTOYAST variable for ipmi

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -83,7 +83,7 @@ sub run {
     type_string ${image_path} . " ", $type_speed;
     bootmenu_default_params(pxe => 1, baud_rate => '115200');
 
-    if ((check_var('BACKEND', 'ipmi') && !check_var('AUTOYAST', '1')) || get_var('SES5_DEPLOY')) {
+    if ((check_var('BACKEND', 'ipmi') && !get_var('AUTOYAST')) || get_var('SES5_DEPLOY')) {
         my $cmdline = '';
         if (check_var('VIDEOMODE', 'text')) {
             $cmdline .= 'ssh=1 ';    # trigger ssh-text installation


### PR DESCRIPTION
We've compared AUTOYAST to '1', whereas variable is supposed to contain
profile name and is not used as a flag normally, which was not the case
for some test suites, which are now adjusted.

See [poo#40364](https://progress.opensuse.org/issues/40364).

- [Verification run](http://gershwin.arch.suse.de/tests/605#)
