### PR TITLE
Load steamcmd only on x86* as it is only available for x86*

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1478,7 +1478,7 @@ sub load_extra_tests_textmode {
         loadtest "console/a2ps";    # a2ps is not a ring package and thus not available in staging
         loadtest "console/weechat";
         loadtest "console/nano";
-        loadtest "console/steamcmd";
+        loadtest "console/steamcmd" if (check_var('ARCH', 'i586') || check_var('ARCH', 'x86_64'));
     }
     if (get_var("IPSEC")) {
         loadtest "console/ipsec_tools_h2h";


### PR DESCRIPTION
It will fix test failure on aarch64: https://openqa.opensuse.org/tests/744693#step/steamcmd/6