### PR TITLE
Replace not working ntp server address

### DIFF
--- a/tests/ses/nodes_preparation.pm
+++ b/tests/ses/nodes_preparation.pm
@@ -79,7 +79,7 @@ EOF
     systemctl 'disable apparmor';
     systemctl 'stop apparmor';
     # configure and start chrony, time synchroniation server for nodes is master
-    my $ntp_server = check_var('HOSTNAME', 'master') ? 'ntp1.suse.de' : 'master.openqa.test';
+    my $ntp_server = check_var('HOSTNAME', 'master') ? 'ntp.suse.de' : 'master.openqa.test';
     assert_script_run "sed -i '/pool/d' /etc/chrony.conf";
     if (check_var('HOSTNAME', 'master')) {
         # set ntp server and add allow for nodes to sync with master


### PR DESCRIPTION
- Failure:
https://openqa.suse.de/tests/2009675#step/nodes_preparation/28
- Verification run: 
http://10.100.12.155/tests/6107#step/nodes_preparation/26