### PR TITLE
Improve search in YaST Control Center

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -42,36 +42,27 @@ sub search {
 }
 
 sub start_addon_products {
+    search('add-on');
     assert_and_click 'yast2_control-center_add-on';
-
     my @tags = qw(yast2_control-center_add-on_installed yast2_control-center-ask_packagekit_to_quit);
     do {
         assert_screen \@tags;
         # Let it kill PackageKit, in case it is running.
         wait_screen_change { send_key 'alt-y' } if match_has_tag('yast2_control-center-ask_packagekit_to_quit');
     } until (match_has_tag('yast2_control-center_add-on_installed'));
-
     send_key 'alt-o';
     assert_screen 'yast2-control-center-ui', timeout => 60;
 }
 
-sub start_add_system_extensions_or_modules {
-    search 'system ext';
-    assert_and_click 'yast2_control-center_add-system-extensions-or-modules';
-    assert_screen 'yast2_control-center_registration', timeout => 180;
-    send_key 'alt-r';
-    assert_screen 'yast2-control-center-ui', timeout => 60;
-}
-
 sub start_media_check {
+    search 'check';
     assert_and_click 'yast2_control-center_media-check';
-    assert_screen 'yast2_control-center_media-check_close', timeout => 180;
-    wait_still_screen;
-    send_key 'alt-l';
-    assert_screen 'yast2-control-center-ui', timeout => 60;
+    assert_and_click 'yast2_control-center_media-check_close', timeout => 180;
+    assert_screen 'yast2-control-center-ui',                   timeout => 60;
 }
 
 sub start_online_update {
+    search 'online update';
     # to test the online update configuration dialog we need update repos
     # which are removed unless explicitly selected to be kept
     if (is_opensuse && !get_var('KEEP_ONLINE_REPOS')) {
@@ -95,7 +86,7 @@ sub start_online_update {
 }
 
 sub start_software_repositories {
-    search('software');
+    search('software repo');
     assert_and_click 'yast2_control-center_software-repositories';
     my @tags = qw(yast2_control-center_configured-software-repositories yast2_control-center-ask_packagekit_to_quit);
     do {
@@ -108,171 +99,8 @@ sub start_software_repositories {
     assert_screen 'yast2-control-center-ui', timeout => 60;
 }
 
-sub start_sound {
-    search('sound');
-    assert_and_click 'yast2_control-center_sound';
-    assert_screen 'yast2_control-center_sound_configuration', timeout => 180;
-    send_key 'alt-o';
-    assert_screen 'yast2-control-center-ui', timeout => 60;
-}
-
-sub start_fonts {
-    search('fonts');
-    assert_and_click 'yast2_control-center_fonts';
-    assert_screen 'yast2_control-center_fonts-configuration', timeout => 180;
-    send_key 'alt-o';
-    assert_screen 'yast2-control-center-ui', timeout => 60;
-}
-
-sub start_sysconfig_editor {
-    search('sysconfig');
-    assert_and_click 'yast2_control-sysconfig-editor';
-    assert_screen 'yast2_control-center_etc-sysconfig-editor', timeout => 180;
-    send_key 'alt-o';
-    assert_screen 'yast2-control-center-ui', timeout => 60;
-}
-
-sub start_kernel_dump {
-    search('dump');
-    assert_and_click 'yast2_control-kernel-kdump';
-    assert_screen 'yast2_control-center_kernel-kdump-configuration', timeout => 180;
-    send_key 'alt-o';    # Press ok
-    assert_screen 'yast2-control-center-ui', timeout => 60;
-}
-
-sub start_kernel_settings {
-    search('kernel');
-    assert_and_click 'yast2_control-center-kernel-settings';
-    assert_screen 'yast2_control-center_kernel-settings_pci-id-setup', timeout => 180;
-    send_key 'alt-o';
-    assert_screen 'yast2-control-center-ui', timeout => 60;
-}
-
-sub start_partitioner {
-    search('partitioner');
-    assert_and_click 'yast2_control-center-partitioner';
-    assert_screen [qw(yast2_control-center-partitioner_warning yast2_control-center-partitioner_expert)], timeout => 180;
-    # Define if storage-ng
-    set_var('STORAGE_NG', 1) if match_has_tag 'storage-ng';
-
-    if (match_has_tag 'yast2_control-center-partitioner_warning') {
-        send_key 'alt-y';
-    }
-    elsif (is_storage_ng && match_has_tag 'yast2_control-center-partitioner_expert') {
-        # Soft-fail if storage ng and no warning is shown
-        record_soft_failure 'bsc#1068905';
-    }
-    else {
-        # Fail with expected assertion in case no match
-        assert_screen 'yast2_control-center-partitioner_warning', 0;
-    }
-    assert_screen 'yast2_control-center-partitioner_expert', timeout => 60;
-    send_key 'alt-f';
-    if (is_storage_ng) {
-        assert_screen 'expert-partitioner-modify-confirmation';
-        wait_screen_change { send_key 'alt-o' };    #Continue
-    }
-    assert_screen 'yast2-control-center-ui', timeout => 60;
-}
-
-sub start_authentication_server {
-    search 'authentication';
-    assert_and_click 'yast2_control-center_authentication-server';
-    do {
-        assert_screen [
-            qw(yast2_control-center-authentication-server_install yast2_control-center-authentication-server_configuration yast2_control-center-authentication-server_empty_first_page)
-        ], timeout => 180;
-        send_key 'alt-i' if match_has_tag 'yast2_control-center-authentication-server_install';
-        send_key 'alt-n' if match_has_tag 'yast2_control-center-authentication-server_empty_first_page';
-    } until (match_has_tag 'yast2_control-center-authentication-server_configuration');
-    # cancel, just check the first page
-    send_key 'alt-c';
-    assert_screen 'yast2-control-center-ui', timeout => 60;
-}
-
-sub start_user_logon_management {
-    search('user');
-    assert_and_click 'yast2_control-center_user-logon-management';
-    assert_screen 'yast2_control-center_user-logon-management_finish', timeout => 180;
-    send_key 'alt-f';
-    assert_screen 'yast2_control-center_user-logon-management_new-users';
-    send_key 'alt-o';
-    assert_screen 'yast2-control-center-ui', timeout => 180;
-}
-
-sub start_vpn_gateway {
-    search('vpn');
-    assert_and_click 'yast2_control-center_vpn-gateway-client';
-    assert_screen 'yast2-vpn-gateway-client', timeout => 180;
-    send_key 'alt-c';
-    assert_screen 'yast2-control-center-ui', timeout => 60;
-}
-
-sub start_wake_on_lan {
-    search('wake');
-    assert_screen [qw(yast2_control-center_wake-on-lan yast2_control_no_modules), timeout => 60];
-    if (match_has_tag('yast2_control_no_modules') && sle_version_at_least('15')) {
-        # No wol on SLE 15 atm
-        record_soft_failure 'bsc#1059569';
-        return;
-    }
-    assert_and_click 'yast2_control-center_wake-on-lan';
-    assert_screen 'yast2_control-center_wake-on-lan_install_cancel', timeout => 180;
-    send_key 'alt-c';
-    assert_screen 'yast2_control-center_wake-on-lan_install_error';
-    send_key 'alt-o';
-    assert_screen 'yast2-control-center-ui', timeout => 60;
-}
-
-sub start_ca_management {
-    search('ca ');
-    assert_and_click 'yast2_control-center_ca-management';
-    assert_screen 'yast2-ca-management', timeout => 180;
-    send_key 'alt-f';
-    assert_screen 'yast2-control-center-ui', timeout => 60;
-}
-
-sub start_common_server_certificate {
-    search('cert');
-    assert_and_click 'yast2_control-center_common-server-certificate';
-    assert_screen 'yast2-common-server-certificate', timeout => 180;
-    send_key 'alt-r';
-    assert_screen 'yast2-control-center-ui', timeout => 60;
-}
-
-sub start_security_center {
-    search('security');
-    assert_and_click 'yast2_control-center_security-center-and-hardening';
-    assert_screen 'yast2_control-center_security-center-and-hardening_overview', timeout => 180;
-    send_key 'alt-o';
-    assert_screen 'yast2-control-center-ui', timeout => 60;
-}
-
-sub start_sudo {
-    search('sudo');
-    assert_and_click 'yast2_control-center_sudo';
-    assert_screen 'yast2_control-center_sudo_rules', timeout => 180;
-    send_key 'alt-o';
-    assert_screen 'yast2-control-center-ui', timeout => 60;
-}
-
-sub start_user_and_group_management {
-    search('user and');
-    assert_and_click 'yast2_control-center_user-and-group-management';
-    assert_screen 'yast2_control-center_user-and-group-management_users', timeout => 180;
-    send_key 'alt-o';
-    assert_screen 'yast2-control-center-ui', timeout => 60;
-}
-
-sub start_hypervisor {
-    search('hypervisor');
-    assert_and_click 'yast2_control-center_install-hypervisor-and-tools';
-    assert_screen 'yast2-install-hypervisor-and-tools', timeout => 180;
-    send_key 'alt-c';
-    assert_screen 'yast2-control-center-ui', timeout => 60;
-}
-
 sub start_printer {
+    search('printer');
     # for now only test on SLE as openSUSE looks different. Can be extended
     # later
     if (check_var('DISTRI', 'sle')) {
@@ -323,6 +151,168 @@ sub start_printer {
     }
 }
 
+sub start_sound {
+    search('sound');
+    assert_and_click 'yast2_control-center_sound';
+    assert_screen 'yast2_control-center_sound_configuration', timeout => 180;
+    send_key 'alt-o';
+    assert_screen 'yast2-control-center-ui', timeout => 60;
+}
+
+sub start_sysconfig_editor {
+    search('sysconfig');
+    assert_and_click 'yast2_control-sysconfig-editor';
+    assert_screen 'yast2_control-center_etc-sysconfig-editor', timeout => 180;
+    send_key 'alt-o';
+    assert_screen 'yast2-control-center-ui', timeout => 60;
+}
+
+sub start_partitioner {
+    search('partitioner');
+    assert_and_click 'yast2_control-center-partitioner';
+    assert_screen [qw(yast2_control-center-partitioner_warning yast2_control-center-partitioner_expert)], timeout => 180;
+    # Define if storage-ng
+    set_var('STORAGE_NG', 1) if match_has_tag 'storage-ng';
+
+    if (match_has_tag 'yast2_control-center-partitioner_warning') {
+        send_key 'alt-y';
+    }
+    elsif (is_storage_ng && match_has_tag 'yast2_control-center-partitioner_expert') {
+        # Soft-fail if storage ng and no warning is shown
+        record_soft_failure 'bsc#1068905';
+    }
+    else {
+        # Fail with expected assertion in case no match
+        assert_screen 'yast2_control-center-partitioner_warning', 0;
+    }
+    assert_screen 'yast2_control-center-partitioner_expert', timeout => 60;
+    send_key 'alt-f';
+    if (is_storage_ng) {
+        assert_screen 'expert-partitioner-modify-confirmation';
+        wait_screen_change { send_key 'alt-o' };    #Continue
+    }
+    assert_screen 'yast2-control-center-ui', timeout => 60;
+}
+
+sub start_vpn_gateway {
+    search('vpn');
+    assert_and_click 'yast2_control-center_vpn-gateway-client';
+    assert_screen 'yast2-vpn-gateway-client', timeout => 180;
+    send_key 'alt-c';
+    assert_screen 'yast2-control-center-ui', timeout => 60;
+}
+
+sub start_security_center {
+    search('security center');
+    assert_and_click 'yast2_control-center_security-center-and-hardening';
+    assert_screen 'yast2_control-center_security-center-and-hardening_overview', timeout => 180;
+    send_key 'alt-o';
+    assert_screen 'yast2-control-center-ui', timeout => 60;
+}
+
+sub start_sudo {
+    search('sudo');
+    assert_and_click 'yast2_control-center_sudo';
+    assert_screen 'yast2_control-center_sudo_rules', timeout => 180;
+    send_key 'alt-o';
+    assert_screen 'yast2-control-center-ui', timeout => 60;
+}
+
+sub start_user_and_group_management {
+    search('login');
+    assert_and_click 'yast2_control-center_user-and-group-management';
+    assert_screen 'yast2_control-center_user-and-group-management_users', timeout => 180;
+    send_key 'alt-o';
+    assert_screen 'yast2-control-center-ui', timeout => 60;
+}
+
+sub start_hypervisor {
+    search('hypervisor');
+    assert_and_click 'yast2_control-center_install-hypervisor-and-tools';
+    assert_screen 'yast2-install-hypervisor-and-tools', timeout => 180;
+    send_key 'alt-c';
+    assert_screen 'yast2-control-center-ui', timeout => 60;
+}
+
+sub start_add_system_extensions_or_modules {
+    search 'system ext';
+    assert_and_click 'yast2_control-center_add-system-extensions-or-modules';
+    assert_screen 'yast2_control-center_registration', timeout => 180;
+    send_key 'alt-r';
+    assert_screen 'yast2-control-center-ui', timeout => 60;
+}
+
+sub start_kernel_dump {
+    search('dump');
+    assert_and_click 'yast2_control-kernel-kdump';
+    assert_screen 'yast2_control-center_kernel-kdump-configuration', timeout => 180;
+    send_key 'alt-o';    # Press ok
+    assert_screen 'yast2-control-center-ui', timeout => 60;
+}
+
+sub start_common_server_certificate {
+    search('cert');
+    assert_and_click 'yast2_control-center_common-server-certificate';
+    assert_screen 'yast2-common-server-certificate', timeout => 180;
+    send_key 'alt-r';
+    assert_screen 'yast2-control-center-ui', timeout => 60;
+}
+
+sub start_ca_management {
+    search('ca ');
+    assert_and_click 'yast2_control-center_ca-management';
+    assert_screen 'yast2-ca-management', timeout => 180;
+    send_key 'alt-f';
+    assert_screen 'yast2-control-center-ui', timeout => 60;
+}
+
+sub start_wake_on_lan {
+    search('wake');
+    assert_screen [qw(yast2_control-center_wake-on-lan yast2_control_no_modules), timeout => 60];
+    if (match_has_tag('yast2_control_no_modules') && sle_version_at_least('15')) {
+        # No wol on SLE 15 atm
+        record_soft_failure 'bsc#1059569';
+        return;
+    }
+    assert_and_click 'yast2_control-center_wake-on-lan';
+    assert_screen 'yast2_control-center_wake-on-lan_install_cancel', timeout => 180;
+    send_key 'alt-c';
+    assert_screen 'yast2_control-center_wake-on-lan_install_error';
+    send_key 'alt-o';
+    assert_screen 'yast2-control-center-ui', timeout => 60;
+}
+
+sub start_authentication_server {
+    search 'directory server';
+    assert_and_click 'yast2_control-center_authentication-server';
+    do {
+        assert_screen [
+            qw(yast2_control-center-authentication-server_install yast2_control-center-authentication-server_configuration yast2_control-center-authentication-server_empty_first_page)
+        ], timeout => 180;
+        send_key 'alt-i' if match_has_tag 'yast2_control-center-authentication-server_install';
+        send_key 'alt-n' if match_has_tag 'yast2_control-center-authentication-server_empty_first_page';
+    } until (match_has_tag 'yast2_control-center-authentication-server_configuration');
+    # cancel, just check the first page
+    send_key 'alt-c';
+    assert_screen 'yast2-control-center-ui', timeout => 60;
+}
+
+sub start_kernel_settings {
+    search('kernel settings');
+    assert_and_click 'yast2_control-center-kernel-settings';
+    assert_screen 'yast2_control-center_kernel-settings_pci-id-setup', timeout => 180;
+    send_key 'alt-o';
+    assert_screen 'yast2-control-center-ui', timeout => 60;
+}
+
+sub start_fonts {
+    search('fonts');
+    assert_and_click 'yast2_control-center_fonts';
+    assert_screen 'yast2_control-center_fonts-configuration', timeout => 180;
+    send_key 'alt-o';
+    assert_screen 'yast2-control-center-ui', timeout => 60;
+}
+
 sub run {
     my $self = shift;
     if (is_sle '15+') {
@@ -334,15 +324,6 @@ sub run {
         ensure_installed 'yast2-sound yast2-ca-management yast2-auth-server';
     }
     $self->launch_yast2_module_x11('', target_match => 'yast2-control-center-ui', match_timeout => 180);
-
-    # search module by typing string
-    search('add');
-    assert_screen 'yast2_control-center_search_add', 60;
-
-    # start yast2 modules
-    for (1 .. 6) {
-        send_key 'backspace';
-    }
 
     start_addon_products;
     start_media_check;


### PR DESCRIPTION
This improve a little the searching producing only one match for every search and creating a needle accordingly,  but I didn't find really useful the keywords as we need to type all the string with comas exactly like it is in the .desktop file in /usr/share/applications/YaST2/.
I also was checking it with some VMs the modules that are not in my system, that by the way do not support the keywords because some of them were dropped a time ago. The name value in .desktop file, that is the same that is displayed in the icon is the most reliable. Normally we don't need the full name, so we avoid to type too much, but for the specific case that does not work, "Software Repo" is the shorter combinations that I could find.

I also did some re-ordering of the code, at least to have the subroutines in the same order than are called in the code, at least the next one to touch this code will get less dizzy than me. I found start_user_logon_management that was not used, so I excluded (there is a table and the OK button does not work, so it needs extra work that I am not sure if for an old module is needed) and I added some search() to ensure we always search, so we can improve stability and not trust in what is in the screen from previous actions.

- Related ticket: https://progress.opensuse.org/issues/39626
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/920
- Verification run: [sle-15-SP1-yast2_gui](http://dhcp87.suse.cz/tests/2401)
