### PR TITLE
Fix pattern name for Azure on SLE15

### DIFF
--- a/tests/console/validate_packages_and_patterns.pm
+++ b/tests/console/validate_packages_and_patterns.pm
@@ -20,7 +20,9 @@ my %software = ();
 
 # Define test data
 if (check_var('VALIDATE_PCM_PATTERN', 'azure')) {
-    $software{'Microsoft-Azure'} = {
+    # We have different pattern names on SLE 15 and SLE 12
+    my $azure_pattern = is_sle('15+') ? 'Microsoft_Azure' : 'Microsoft-Azure';
+    $software{$azure_pattern} = {
         repo      => 'Module-Public-Cloud',
         installed => 1,
         condition => sub { check_var_array('PATTERNS', 'azure') },


### PR DESCRIPTION
See [poo#38870](https://progress.opensuse.org/issues/38870).

- [Verification run](http://g226.suse.de/tests/2484#step/validate_packages_and_patterns/7).

Fails due to [bsc#1106444](https://bugzilla.suse.com/show_bug.cgi?id=1106444).
