### PR TITLE
Add widget service conf to yast2_tftp

### DIFF
--- a/tests/console/yast2_tftp.pm
+++ b/tests/console/yast2_tftp.pm
@@ -14,29 +14,40 @@ use strict;
 use base "console_yasttest";
 use testapi;
 use utils;
+use version_utils qw(is_sle is_leap is_tumbleweed);
 
 sub run {
+    my $self = shift;
+
     select_console 'root-console';
-
     zypper_call("in tftp yast2-tftp-server", timeout => 240);
-
     script_run("yast2 tftp-server; echo yast2-tftp-server-status-\$? > /dev/$serialdev", 0);
     # make sure the module is loaded and any potential popups are there to be
     # asserted later
     wait_still_screen(3);
-    assert_screen([qw(yast2_tftp-server_configuration yast2_still_susefirewall2)], 90);
-    if (match_has_tag 'yast2_still_susefirewall2') {
-        record_soft_failure "bsc#1059569";
-        send_key 'alt-i';
-        assert_screen 'yast2_tftp-server_configuration';
+    my $boot_image_dir_shortcut  = 'alt-i';
+    my $firewall_detail_shortcut = 'alt-d';
+    if (is_sle('<15') || is_leap('<15.1') || is_tumbleweed) {
+        assert_screen([qw(yast2_tftp-server_configuration yast2_still_susefirewall2)], 90);
+        if (match_has_tag 'yast2_still_susefirewall2') {
+            record_soft_failure "bsc#1059569";
+            send_key 'alt-i';
+            assert_screen 'yast2_tftp-server_configuration';
+        }
+        send_key 'alt-e';    # enable tftp
+        assert_screen 'yast2_tftp-server_configuration_enabled';
+        $boot_image_dir_shortcut  = 'alt-t';
+        $firewall_detail_shortcut = 'alt-i';
     }
-
-    send_key 'alt-e';    # enable tftp
-    assert_screen 'yast2_tftp-server_configuration_enabled';
-
+    else {
+        $self->change_service_configuration(
+            after_writing => {start           => 'alt-t'},
+            after_reboot  => {start_on_demand => 'alt-a'}
+        );
+    }
     # provide a new TFTP root directory path
     # workaround to resolve problem with first key press is lost, improve stability here by retrying
-    send_key_until_needlematch 'yast2_tftp-server_configuration_chdir', 'alt-t', 2, 3;    # select input field
+    send_key_until_needlematch 'yast2_tftp-server_configuration_chdir', $boot_image_dir_shortcut, 2, 3;
     for (1 .. 20) { send_key 'backspace'; }
     my $tftpboot_newdir = '/srv/tftpboot/new_dir';
     type_string $tftpboot_newdir;
@@ -45,16 +56,16 @@ sub run {
     # open port in firewall, if needed
     assert_screen([qw(yast2_tftp_open_port yast2_tftp_closed_port)]);
     if (match_has_tag('yast2_tftp_open_port')) {
-        send_key 'alt-f';                                                                 # open tftp port in firewall
+        send_key 'alt-f';    # open tftp port in firewall
         assert_screen 'yast2_tftp_port_opened';
-        send_key 'alt-i';                                                                 # open firewall details window
+        send_key $firewall_detail_shortcut;    # open firewall details window
         assert_screen 'yast2_tftp_firewall_details';
-        send_key 'alt-o';                                                                 # close the window
+        send_key 'alt-o';                      # close the window
         assert_screen 'yast2_tftp_closed_port';
     }
 
     # view log
-    send_key 'alt-v';                                                                     # open log window
+    send_key 'alt-v';                          # open log window
 
     # bsc#1008493 is still open, but error pop-up doesn't always appear immediately
     # so wait still screen before assertion


### PR DESCRIPTION
Integration of the service configuration widget is available in SLE 15 SP1 but not in TW yet.

- Related ticket: https://progress.opensuse.org/issues/39725
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/919
- Verification run: http://dhcp87.suse.cz/tests/2379
