### PR TITLE
Recover network if cannot reach worker

### DIFF
--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Functional methods to operate on network
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
+package network_utils;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+
+our @EXPORT = qw(setup_static_network check_and_recover_network);
+
+use testapi;
+
+=head2 setup_static_network
+Configure static IP on SUT with setting up default GW.
+Also doing test ping to 10.0.2.2 to check that network is alive
+=cut
+sub setup_static_network {
+    my ($ip) = @_;
+    assert_script_run("echo 'default 10.0.2.2 - -' > /etc/sysconfig/network/routes");
+    assert_script_run("echo 'nameserver 10.160.0.1' >> /etc/resolv.conf");
+    my $iface = script_output('ls /sys/class/net/ | grep -v lo | head -1');
+    assert_script_run qq(echo -e "\\nSTARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$ip'">/etc/sysconfig/network/ifcfg-$iface);
+    assert_script_run "rcnetwork restart";
+    assert_script_run "ip addr";
+    assert_script_run "ping -c 1 10.0.2.2 || journalctl -b --no-pager > /dev/$serialdev";
+}
+
+1;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -64,7 +64,6 @@ our @EXPORT = qw(
   get_root_console_tty
   get_x11_console_tty
   OPENQA_FTP_URL
-  setup_static_network
   arrays_differ
   ensure_serialdev_permissions
   assert_and_click_until_screen_change
@@ -831,21 +830,6 @@ sub get_x11_console_tty {
       && !check_var('VIRSH_VMM_TYPE', 'linux')
       && !get_var('VERSION_LAYERED');
     return (check_var('DESKTOP', 'gnome') && get_var('NOAUTOLOGIN') && $new_gdm) ? 2 : 7;
-}
-
-=head2 setup_static_network
-Configure static IP on SUT with setting up default GW.
-Also doing test ping to 10.0.2.2 to check that network is alive
-=cut
-sub setup_static_network {
-    my ($self, $ip) = @_;
-    assert_script_run("echo 'default 10.0.2.2 - -' > /etc/sysconfig/network/routes");
-    assert_script_run("echo 'nameserver 10.160.0.1' >> /etc/resolv.conf");
-    my $iface = script_output('ls /sys/class/net/ | grep -v lo | head -1');
-    assert_script_run qq(echo -e "\\nSTARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$ip'">/etc/sysconfig/network/ifcfg-$iface);
-    assert_script_run "rcnetwork restart";
-    assert_script_run "ip addr";
-    assert_script_run "ping -c 1 10.0.2.2 || journalctl -b --no-pager > /dev/$serialdev";
 }
 
 =head2  arrays_differ

--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -118,7 +118,7 @@ sub before_scenario {
         assert_script_run("ifbind.sh unbind $iface");
         script_run("rm /etc/sysconfig/network/ifcfg-$iface");
         assert_script_run("ifbind.sh bind $iface");
-        $self->setup_static_network($self->get_ip(is_wicked_ref => check_var('IS_WICKED_REF', 1), type => 'host'));
+        $self->setup_static_network(ip => $self->get_ip(is_wicked_ref => check_var('IS_WICKED_REF', 1), type => 'host'));
     }
     record_info($title, $text);
 }

--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -14,6 +14,7 @@ package wickedbase;
 
 use base 'opensusebasetest';
 use utils 'systemctl';
+use network_utils 'setup_static_network';
 use testapi;
 
 sub assert_wicked_state {

--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -4,7 +4,9 @@ use testapi;
 use strict;
 use version_utils qw(is_sle is_caasp);
 use ipmi_backend_utils;
+use network_utils;
 use utils 'zypper_call';
+
 
 sub use_wicked {
     script_run "cd /proc/sys/net/ipv4/conf";
@@ -236,13 +238,20 @@ sub save_upload_y2logs {
     $suffix //= '';
 
     return if (get_var('NOLOGS'));
-
-    assert_script_run 'sed -i \'s/^tar \(.*$\)/tar --warning=no-file-changed -\1 || true/\' /usr/sbin/save_y2logs';
-    my $filename = "/tmp/y2logs$suffix.tar" . get_available_compression();
-    assert_script_run "save_y2logs $filename", 180;
-    upload_logs $filename;
-    save_screenshot();
-    $self->investigate_yast2_failure();
+    # Try to recover network if cannot reach gw
+    # Upload logs if everything works
+    if (can_upload_logs() || recover_network()) {
+        assert_script_run 'sed -i \'s/^tar \(.*$\)/tar --warning=no-file-changed -\1 || true/\' /usr/sbin/save_y2logs';
+        my $filename = "/tmp/y2logs$suffix.tar" . get_available_compression();
+        assert_script_run "save_y2logs $filename", 180;
+        upload_logs $filename;
+        save_screenshot();
+        $self->investigate_yast2_failure();
+    } else {    # Redirect logs content to serial
+        script_run("journalctl -b --no-pager > /dev/$serialdev");
+        script_run("dmesg > /dev/$serialdev");
+        script_run("cat /var/log/YaST/y2log > /dev/$serialdev");
+    }
 }
 
 sub get_available_compression {

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -13,6 +13,7 @@
 use base 'wickedbase';
 use strict;
 use testapi;
+use network_utils 'setup_static_network';
 use utils qw(zypper_call systemctl);
 use serial_terminal 'select_virtio_console';
 
@@ -34,7 +35,7 @@ sub run {
     #download script for check interface status
     $self->get_from_data('wicked/check_interfaces.sh', '/data/check_interfaces.sh', executable => 1) if check_var('WICKED', 'basic');
     if (check_var('WICKED', 'advanced')) {
-        $self->setup_static_network($self->get_ip(is_wicked_ref => check_var('IS_WICKED_REF', 1), type => 'host'));
+        setup_static_network($self->get_ip(is_wicked_ref => check_var('IS_WICKED_REF', 1), type => 'host'));
     } else {
         systemctl('restart network');
     }

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -35,7 +35,7 @@ sub run {
     #download script for check interface status
     $self->get_from_data('wicked/check_interfaces.sh', '/data/check_interfaces.sh', executable => 1) if check_var('WICKED', 'basic');
     if (check_var('WICKED', 'advanced')) {
-        setup_static_network($self->get_ip(is_wicked_ref => check_var('IS_WICKED_REF', 1), type => 'host'));
+        setup_static_network(ip => $self->get_ip(is_wicked_ref => check_var('IS_WICKED_REF', 1), type => 'host'));
     } else {
         systemctl('restart network');
     }


### PR DESCRIPTION
 In some tests we may break network, so log upload will fail. For qemu
 backend, it's fairly easy to recover to at least get logs.

See [poo#40049](https://progress.opensuse.org/issues/40049).

#### Verification runs
 * [yast2_network](http://g226.suse.de/tests/2504#downloads) Logs were uploaded, even though network was down.
 * [wicked test](http://g226.suse.de/tests/2517#) Fails in the same place as without changes, but affected module passes.

