### PR TITLE
Move zypper calls back to consoletest_setup

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -41,6 +41,12 @@ sub run {
     # Stop packagekit
     systemctl 'mask packagekit.service';
     systemctl 'stop packagekit.service';
+
+    # Installing a minimal system gives a pattern conflicting with anything not minimal
+    # Let's uninstall 'the pattern' (no packages affected) in order to be able to install stuff
+    script_run 'rpm -qi patterns-openSUSE-minimal_base-conflicts && zypper -n rm patterns-openSUSE-minimal_base-conflicts';
+    # Install curl and tar in order to get the test data
+    zypper_call 'install curl tar';
     # upload_logs requires curl, but we wanted the initial state of the system
     upload_logs "/tmp/psaxf.log";
     upload_logs "/tmp/loadavg_consoletest_setup.txt";

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -21,14 +21,6 @@ sub run {
 
     ensure_serialdev_permissions;
 
-    # Stop packagekit as may lock zypper and fail zypper calls, if it's running
-    systemctl 'stop packagekit.service' unless script_run('systemctl is-active packagekit.service');
-    # Installing a minimal system gives a pattern conflicting with anything not minimal
-    # Let's uninstall 'the pattern' (no packages affected) in order to be able to install stuff
-    script_run 'rpm -qi patterns-openSUSE-minimal_base-conflicts && zypper -n rm patterns-openSUSE-minimal_base-conflicts';
-    # Install curl and tar in order to get the test data
-    zypper_call 'install curl tar';
-
     # BSC#997263 - VMware screen resolution defaults to 800x600
     if (check_var('VIRSH_VMM_FAMILY', 'vmware')) {
         assert_script_run("sed -ie '/GFXMODE=/s/=.*/=1024x768x32/' /etc/default/grub");


### PR DESCRIPTION
After #5642 broke QAM, decided to move zypper calls back, so we don't
have to stop/mask twice, once in system_prepare and second time in
consoletest_setup. We should find better solution, as some actions make
sense in create_hdd scenarios, so we don't need to repeat them every
single time we boot into the image. However, as not every image expects
packagekit to be stopped, we cannot put it in a single place. Therefore,
moving zypper calls back too.

- [Verification run](http://g226.suse.de/tests/2521)
