### PR TITLE
docker_image_rpm: Fix repo path for AArch64

### DIFF
--- a/tests/console/docker_image_rpm.pm
+++ b/tests/console/docker_image_rpm.pm
@@ -29,7 +29,12 @@ sub run {
     install_docker_when_needed();
 
     if (is_tumbleweed) {
-        $repo_url = 'https://download.opensuse.org/repositories/Virtualization:containers:images:openSUSE-Tumbleweed/container/Virtualization:containers:images:openSUSE-Tumbleweed.repo';
+        if (check_var('ARCH', 'aarch64')) {
+            $repo_url = 'https://download.opensuse.org/repositories/Virtualization:containers:images:openSUSE-Tumbleweed/container_ARM/Virtualization:containers:images:openSUSE-Tumbleweed.repo';
+        }
+        else {
+            $repo_url = 'https://download.opensuse.org/repositories/Virtualization:containers:images:openSUSE-Tumbleweed/container/Virtualization:containers:images:openSUSE-Tumbleweed.repo';
+        }
         $image_name = 'opensuse/tumbleweed:current';
         $image_path = '/usr/share/suse-docker-images/native/*-image*.tar.xz';
 


### PR DESCRIPTION
Fixes https://openqa.opensuse.org/tests/745850#step/docker_image_rpm/16

Tested locally.