### PR TITLE
Recover network if cannot reach worker

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -80,7 +80,7 @@ sub handle_expected_errors {
     record_info('Expected error', 'Iteration = ' . $i);
     send_key "alt-s";    #stop
     select_console 'install-shell';
-    $self->save_upload_y2logs("-$stage-expected_error$i");
+    $self->save_upload_y2logs(suffix => "-$stage-expected_error$i");
     select_console 'installation';
     $i++;
     wait_screen_change { send_key 'tab' };    #continue

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -42,7 +42,8 @@ sub run {
         # avoid known issue in FIPS mode: bsc#985969
         $self->get_ip_address();
     }
-    $self->save_upload_y2logs();
+    # We don't change network setup here, so should work
+    $self->save_upload_y2logs(no_ntwrk_recovery => 1);
 }
 
 sub test_flags {

--- a/tests/x11/network/yast2_network_setup.pm
+++ b/tests/x11/network/yast2_network_setup.pm
@@ -51,7 +51,7 @@ sub configure_system {
 sub post_fail_hook {
     my ($self) = @_;
     select_console 'log-console';
-    y2logsstep::save_upload_y2logs;
+    y2logsstep::save_upload_y2logs($self);
     $self->SUPER::post_fail_hook;
 }
 


### PR DESCRIPTION
 In some tests we may break network, so log upload will fail. For qemu
 backend, it's fairly easy to recover to at least get logs.

See [poo#40049](https://progress.opensuse.org/issues/40049).
#5678 broke staging, as we cannot recover network in the same way during installation, so exclude it for now, as well as non-qemu backends, as not trivial to recover network there.

#### Verification runs
 * [yast2_network](http://g226.suse.de/tests/2610#step/yast2_network_setup/18) Logs were uploaded, even though network was down.
 * [installation](http://g226.suse.de/tests/2589) (no network recovery)
 * [test run where recovery failed](http://g226.suse.de/tests/2591#step/yast2_network_setup/37) 