### PR TITLE
Minor fixes for InfiniBand tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -630,9 +630,7 @@ sub load_baremetal_tests {
             barrier_create('IBTEST_BEGIN', 2);
             barrier_create('IBTEST_DONE',  2);
         }
-        else {
-            mellanox_config();
-        }
+        mellanox_config();
         loadtest "kernel/ib_tests";
     }
     elsif (get_var('NFV')) {

--- a/tests/kernel/ib_tests.pm
+++ b/tests/kernel/ib_tests.pm
@@ -66,7 +66,7 @@ sub ibtest_master {
     # do all test preparations and setup
     zypper_call('ar -f -G ' . get_required_var('DEVEL_TOOLS_REPO'));
     zypper_call('--gpg-auto-import-keys ref');
-    zypper_call('in git twopence bc');
+    zypper_call('in git-core twopence bc');
 
     # create symlinks, the package is (for now) broken
     assert_script_run('ln -sf /usr/lib64/libtwopence.so.0.3.8 /usr/lib64/libtwopence.so.0');


### PR DESCRIPTION
- mellanox_config() must be called in any case now
- install package "git-core" instead of "git", as the latter is not part
  of the default distribution

Signed-off-by: Michael Moese <mmoese@suse.de>

