### PR TITLE
Fix yast2_control_center dialog transition

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -57,8 +57,10 @@ sub start_addon_products {
 sub start_media_check {
     search 'check';
     assert_and_click 'yast2_control-center_media-check';
-    assert_and_click 'yast2_control-center_media-check_close', timeout => 180;
-    assert_screen 'yast2-control-center-ui',                   timeout => 60;
+    wait_still_screen;
+    assert_screen 'yast2_control-center_media-check_close';
+    send_key 'alt-l';
+    assert_screen 'yast2-control-center-ui';
 }
 
 sub start_online_update {


### PR DESCRIPTION
This change revert to original behaviour for transition to mediacheck due to the dialog takes time to load and the needles matches too soon. I tried to create this needle with two areas https://openqa.suse.de/tests/2019657#step/yast2_control_center/39 but it didn't work so we need to put back wait_still_screen ant trust on the shortcut.

- Related ticket: https://progress.opensuse.org/issues/39626
- Needles: (already present in prod)
- Verification run: not needed (it only fails in prod not in local)
