### PR TITLE
Add service widget to yast2_tftp in Leap

### DIFF
--- a/tests/console/yast2_tftp.pm
+++ b/tests/console/yast2_tftp.pm
@@ -27,7 +27,7 @@ sub run {
     wait_still_screen(3);
     my $boot_image_dir_shortcut  = 'alt-i';
     my $firewall_detail_shortcut = 'alt-d';
-    if (is_sle('<15') || is_leap || is_tumbleweed) {
+    if (is_sle('<15') || is_leap('<15.1') || is_tumbleweed) {
         assert_screen([qw(yast2_tftp-server_configuration yast2_still_susefirewall2)], 90);
         if (match_has_tag 'yast2_still_susefirewall2') {
             record_soft_failure "bsc#1059569";


### PR DESCRIPTION
Leap just got the service widget for tftp, see [here](https://openqa.opensuse.org/tests/746882#step/yast2_tftp/6).

- Related ticket: https://progress.opensuse.org/issues/40067
- Needles: not needed
- Verification run: not needed
