### PR TITLE
Add warning handler for overwritting manually edited setup

### DIFF
--- a/tests/installation/partitioning_filesystem.pm
+++ b/tests/installation/partitioning_filesystem.pm
@@ -25,15 +25,8 @@ sub run {
     select_first_hard_disk if (check_screen('select-hard-disks', 0) && check_var('BACKEND', 'ipmi'));
 
     if (get_var('PARTITIONING_WARNINGS')) {
-        if (is_storage_ng) {
-            assert_screen 'partition-scheme';
-            # No warnings with storage ng stack
-            record_soft_failure 'bsc#1055756';
-        }
-        else {
-            assert_screen 'proposal-will-overwrite-manual-changes';
-            send_key 'alt-y';
-        }
+        assert_screen 'proposal-will-overwrite-manual-changes';
+        send_key 'alt-y';
     }
     if (is_storage_ng) {
         assert_screen [qw(partition-scheme existing-partitions)];


### PR DESCRIPTION
Storage-ng stack warns user that partition computing proposal will overwrite manual changes done so far. [bsc#1055756](https://bugzilla.suse.com/show_bug.cgi?id=1055756)
Changes could not be verified in o3 due to missing test case btrfs+warnings.

- Related ticket: [[sle][functional][y] test fails in partitioning_filesystem - new popup warning when accessing guided setup](https://progress.opensuse.org/issues/39569)
- Verification runs: 
[sle12sp4 Build0366-btrfs+warnings](http://dhcp128.suse.cz/tests/5794#step/partitioning_filesystem/3)
[sle15sp1 Build28.1-btrfs+warnings](http://dhcp128.suse.cz/tests/5793#step/partitioning_filesystem/3)
[sle12sp4 - btrfs](http://dhcp128.suse.cz/tests/5792#step/partitioning_filesystem/2)
[sle15sp1 - btrfs](http://dhcp128.suse.cz/tests/5795#step/partitioning_filesystem/3)

