### PR TITLE
 Wait longer before running 'vncviewer'

### DIFF
--- a/tests/virtualization/virt_install.pm
+++ b/tests/virtualization/virt_install.pm
@@ -19,7 +19,7 @@ sub run {
     x11_start_program('xterm');
     become_root;
     script_run('virt-install --name TESTING --memory 512 --disk none --boot cdrom --graphics vnc &', 0);
-    wait_still_screen(3);
+    wait_still_screen(15);
     x11_start_program('vncviewer :0', target_match => 'virtman-gnome_virt-install', match_timeout => 100);
     # closing all windows
     send_key 'alt-f4' for (0 .. 2);


### PR DESCRIPTION
3s is a bit short, especially for our aarch64 worker. 
According to local tests on aarch64, 15s is a good value.

Fix https://openqa.opensuse.org/tests/746942#step/virt_install/31
