### PR TITLE
Fix docker image path

### DIFF
--- a/tests/console/docker_image.pm
+++ b/tests/console/docker_image.pm
@@ -28,7 +28,7 @@ sub run {
         }
     }
     elsif (is_sle("=15")) {
-        push @image_names, "registry.suse.de/suse/sle-15/update/cr/images/suse/sle15:current";
+        push @image_names, "registry.suse.de/suse/sle-15/update/cr/images/suse/sle15:latest";
     }
     else {
         die("This test only works at SLE12SP3 and SLE15.");


### PR DESCRIPTION
tested manually, sle15:current does not exist, can be checked also here http://registry.suse.de/cgi-bin/cooverview
```
# docker pull registry.suse.de/suse/sle-15/update/cr/images/suse/sle15
Using default tag: latest
latest: Pulling from suse/sle-15/update/cr/images/suse/sle15
085ba4dc28a7: Pull complete 
Digest: sha256:4570ef14a2671dbeb793a3e9ab4d41dc735f52a3c8024a91ef468329692676dc
Status: Downloaded newer image for registry.suse.de/suse/sle-15/update/cr/images/suse/sle15:latest
#
# docker pull registry.suse.de/suse/sle-15/update/cr/images/suse/sle15:latest
latest: Pulling from suse/sle-15/update/cr/images/suse/sle15
Digest: sha256:4570ef14a2671dbeb793a3e9ab4d41dc735f52a3c8024a91ef468329692676dc
Status: Image is up to date for registry.suse.de/suse/sle-15/update/cr/images/suse/sle15:latest
#
```

- Verification run: http://10.100.12.155/tests/6231

