### PR TITLE
Add unicast test for HA

### DIFF
--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -22,13 +22,14 @@ sub run {
     my $bootstrap_log = '/var/log/ha-cluster-bootstrap.log';
     my $corosync_conf = '/etc/corosync/corosync.conf';
     my $sbd_device    = get_lun;
+    my $unicast_opt   = get_var("HA_UNICAST") ? '-u' : '';
     my $quorum_policy = 'stop';
     my $join_timeout  = 60;
 
     # If we failed to initialize the cluster, trying again but in debug mode
     # Note: the default timeout need to be increase because it can takes time to join the cluster
-    if (script_run "ha-cluster-init -y -s $sbd_device", $join_timeout) {
-        assert_script_run "crm -dR cluster init -y -s $sbd_device", $join_timeout;
+    if (script_run "ha-cluster-init -y -s $sbd_device $unicast_opt", $join_timeout) {
+        assert_script_run "crm -dR cluster init -y -s $sbd_device $unicast_opt", $join_timeout;
     }
 
     # Signal that the cluster stack is initialized


### PR DESCRIPTION
By default HA stack is configured for multicast. Some company
still use unicast and so this should be tested.

- Verification run: http://1b147.qa.suse.de/tests/2857#step/ha_cluster_join/8

Note: the test is failing because of a bug, that's why this test should added :)
