### PR TITLE
Disable docker_image test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -526,11 +526,7 @@ sub load_slepos_tests {
 sub load_docker_tests {
     loadtest "console/docker";
     loadtest "console/docker_runc";
-    if (is_sle('=15')) {
-        loadtest "console/docker_image";
-    }
-    elsif (is_sle('=12-SP3')) {
-        loadtest "console/docker_image";
+    if (is_sle('=12-SP3')) {
         loadtest "console/sle2docker";
     }
     if (is_tumbleweed) {


### PR DESCRIPTION
Hello,

since this test has some unstable and some pending dependencies I feel that the safest option is to temporarily disable it.
This test is meant to be used by QAM but we do not test docker images yet. That's also why I keep the test in the repository.

- Related ticket: [poo#36775](https://progress.opensuse.org/issues/36775)
- Needles: No need
- Verification run: No need
