### PR TITLE
ipmi: Ensure correct serialdev for ipmi after reboot

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -34,7 +34,7 @@ sub use_ssh_serial_console {
     console('sol')->disable if check_var('BACKEND', 'ipmi');
     select_console('root-ssh');
     $serialdev = 'sshserial';
-    set_var('SERIALDEV', 'sshserial');
+    set_var('SERIALDEV', $serialdev);
     bmwqemu::save_vars();
 }
 

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -10,14 +10,15 @@
 # Summary: Execute SUT changes which should be permanent
 # Maintainer: Rodion Iafarov <riafarov@suse.com>
 
-use base "consoletest";
+use base 'consoletest';
 use testapi;
 use utils;
+use ipmi_backend_utils 'use_ssh_serial_console';
 use strict;
 
 sub run {
     my ($self) = @_;
-    select_console 'root-console';
+    check_var('BACKEND', 'ipmi') ? use_ssh_serial_console : select_console 'root-console';
 
     ensure_serialdev_permissions;
 


### PR DESCRIPTION
[progress ticket](https://progress.opensuse.org/issues/39665)
[Verification run 1](http://opeth.suse.de/tests/3096)
[Verification run 2](http://e13.suse.de/tests/7975)
