### PR TITLE
Validate ADDONURL test variable

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -292,11 +292,12 @@ if (sle_version_at_least('15') && !check_var('SCC_REGISTER', 'installation')) {
             my $module_repo_name = get_var($repo_variable_name, $default_repo_name);
             my $url = "$utils::OPENQA_FTP_URL/$module_repo_name";
             # Verify if url exists before adding
-            die "URL $url could not be accessed, missing repo?" unless head($url);
-            set_var('ADDONURL_' . uc $short_name, "$utils::OPENQA_FTP_URL/$module_repo_name");
-            $addonurl .= "$short_name,";
+            if (head($url)) {
+                set_var('ADDONURL_' . uc $short_name, "$utils::OPENQA_FTP_URL/$module_repo_name");
+                $addonurl .= "$short_name,";
+            }
         }
-        die '$addonurl (test variable \'ADDONURL\') could not be set' unless $addonurl;
+
         #remove last comma from ADDONURL setting value
         $addonurl =~ s/,$//;
         set_var("ADDONURL", $addonurl);


### PR DESCRIPTION
Validate value of ``ADDONURL`` agains ``WORKAROUND_MODULES`` test variable to prevent skipping modules which are intended to be installed as addon over FTP in ``addon_product_sle``.

- Related ticket: [[sle][functional][y] test fails in addon_products_sle - Add hint to test if ADDONURL isn't](https://progress.opensuse.org/issues/38732)
- Verification runs: 
[sle-15-SP1-Installer-DVD-x86_64-Build28.1-skip_registration+workaround_modules@uefi - empty ADDONURL](http://dhcp128.suse.cz/tests/5861#step/addon_products_sle/7)
[sle-15-SP1-Installer-DVD-x86_64-Build28.1-skip_registration+workaround_modules@uefi - missed modules](http://dhcp128.suse.cz/tests/5844#step/addon_products_sle/7)
Test suites executing ``addon_products_sle`` without ``ADDONURL``  and ``WORKAROUND_MODULES`` should not be affected.
[sle-15-SP1-Installer-DVD-x86_64-Build28.1-RAID0@64bit](http://dhcp128.suse.cz/tests/5847)
