### PR TITLE
LTP: Change failures to soft for install_ltp

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -678,12 +678,13 @@ if (is_sle('=12-SP4') && check_var('ARCH', 'aarch64')) {
     push @$serial_failures, {type => 'hard', message => 'bsc#1093797', pattern => quotemeta 'Internal error: Oops: 96000006'};
 }
 if (is_kernel_test()) {
-    push @$serial_failures, {type => 'hard', message => 'Kernel Ooops found',             pattern => quotemeta 'Oops:'};
-    push @$serial_failures, {type => 'hard', message => 'Kernel BUG found',               pattern => qr/kernel BUG at/i};
-    push @$serial_failures, {type => 'hard', message => 'WARNING CPU in kernel messages', pattern => quotemeta 'WARNING: CPU'};
-    push @$serial_failures, {type => 'hard', message => 'Kernel stack is corrupted',      pattern => quotemeta 'stack-protector: Kernel stack is corrupted'};
-    push @$serial_failures, {type => 'hard', message => 'Kernel BUG found',               pattern => quotemeta 'BUG: failure at'};
-    push @$serial_failures, {type => 'hard', message => 'Kernel Ooops found',             pattern => quotemeta '-[ cut here ]-'};
+    my $type = get_var('INSTALL_LTP') ? 'soft' : 'hard';
+    push @$serial_failures, {type => $type, message => 'Kernel Ooops found',             pattern => quotemeta 'Oops:'};
+    push @$serial_failures, {type => $type, message => 'Kernel BUG found',               pattern => qr/kernel BUG at/i};
+    push @$serial_failures, {type => $type, message => 'WARNING CPU in kernel messages', pattern => quotemeta 'WARNING: CPU'};
+    push @$serial_failures, {type => $type, message => 'Kernel stack is corrupted',      pattern => quotemeta 'stack-protector: Kernel stack is corrupted'};
+    push @$serial_failures, {type => $type, message => 'Kernel BUG found',               pattern => quotemeta 'BUG: failure at'};
+    push @$serial_failures, {type => $type, message => 'Kernel Ooops found',             pattern => quotemeta '-[ cut here ]-'};
 }
 $testapi::distri->set_expected_serial_failures($serial_failures);
 


### PR DESCRIPTION
While we want to trigger LTP failures as hard, it's not desired to
do it for install_ltp.pm as many tests depends on it.

Verification run:
* sle-12-SP4-Server-DVD-x86_64-Build0366-install_ltp+sle+Server-DVD@64bit
http://quasar.suse.cz/tests/650
* sle-12-SP4-Server-DVD-x86_64-Build0366-ltp_ima@64bit
http://quasar.suse.cz/tests/657