### PR TITLE
[NFV] Add full installation for Virtual mode

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1607,15 +1607,13 @@ sub load_networkd_tests {
 
 sub load_nfv_master_tests {
     loadtest "nfv/prepare_env";
+    loadtest "nfv/run_performance_tests";
     loadtest "nfv/run_integration_tests" if (check_var('BACKEND', 'qemu'));
-    if (check_var('BACKEND', 'ipmi')) {
-        loadtest "nfv/run_performance_tests";
-    }
 }
 
 sub load_nfv_trafficgen_tests {
     loadtest "nfv/trex_installation";
-    loadtest "nfv/trex_runner" if (check_var('BACKEND', 'ipmi'));
+    loadtest "nfv/trex_runner";
 }
 
 sub load_iso_in_external_tests {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -608,13 +608,12 @@ sub prepare_target {
 
 sub is_baremetal_test {
     return 1 if (get_var('IBTESTS'));
-    return 1 if (get_var('NFV') && check_var('BACKEND', 'ipmi'));
     return 0;
 }
 
 sub mellanox_config {
     loadtest "kernel/mellanox_config";
-    load_reboot_tests();
+    load_reboot_tests() if (check_var('BACKEND', 'ipmi'));
 }
 
 sub load_baremetal_tests {
@@ -633,16 +632,11 @@ sub load_baremetal_tests {
         mellanox_config();
         loadtest "kernel/ib_tests";
     }
-    elsif (get_var('NFV')) {
-        load_nfv_tests();
-    }
 }
 
 sub load_nfv_tests {
-    if (check_var('BACKEND', 'ipmi')) {
-        loadtest "nfv/hugepages_config" if get_var('HUGEPAGES');
-        mellanox_config();
-    }
+    loadtest "nfv/hugepages_config" if get_var('HUGEPAGES');
+    mellanox_config();
     loadtest "kernel/mellanox_ofed" if get_var('OFED_URL');
     if (check_var("NFV", "master")) {
         load_nfv_master_tests();
@@ -696,14 +690,14 @@ if (is_kernel_test()) {
     load_kernel_tests();
 }
 elsif (is_baremetal_test()) {
-    load_baremetal_tests;
+    load_baremetal_tests();
 }
 elsif (get_var("WICKED")) {
     boot_hdd_image();
     load_wicked_tests();
 }
 elsif (get_var("NFV")) {
-    boot_hdd_image();
+    load_baremetal_tests();
     load_nfv_tests();
 }
 elsif (get_var("REGRESSION")) {

--- a/tests/kernel/mellanox_ofed.pm
+++ b/tests/kernel/mellanox_ofed.pm
@@ -32,8 +32,7 @@ sub run {
         zypper_call('--quiet in openvswitch python-devel python2-libxml2-python libopenssl1_1 insserv-compat libstdc++6-devel-gcc7 createrepo_c rpm', timeout => 500);
     }
     elsif (check_var('VERSION', '12-SP4')) {
-        my $SDK_REPO = 'http://download.suse.de/ibs/SUSE:/SLE-12-SP4:/GA:/TEST/images/repo/SLE-12-SP4-SDK-POOL-x86_64-Media1/';
-        zypper_call("--quiet ar -f $SDK_REPO SLE-12-SP4-SDK-POOL");
+        zypper_call("--quiet ar -f http://download.suse.de/ibs/SUSE:/SLE-12-SP4:/GA:/TEST/images/repo/SLE-12-SP4-SDK-POOL-x86_64-Media1/ SLE-12-SP4-SDK-POOL1");
         zypper_call('--quiet in openvswitch python-devel python-libxml2 libopenssl1_0_0 insserv-compat libstdc++-devel createrepo rpm-build kernel-syms tk', timeout => 500);
     }
     else {
@@ -45,7 +44,7 @@ sub run {
     assert_script_run("tar -xvf $ofed_file_tgz");
     assert_script_run("cd $ofed_dir");
     if (check_var('BACKEND', 'ipmi')) {
-        record_info("OFED install");
+        record_info('INFO', 'OFED install');
         assert_script_run("./mlnxofedinstall --skip-distro-check --add-kernel-support --with-mft --with-mstflint --dpdk --upstream-libs", timeout => 2000);
         assert_script_run("modprobe -rv rpcrdma");
         assert_script_run("/etc/init.d/openibd restart");

--- a/tests/nfv/hugepages_config.pm
+++ b/tests/nfv/hugepages_config.pm
@@ -13,16 +13,18 @@ use base "opensusebasetest";
 use strict;
 use testapi;
 use utils;
+use serial_terminal 'select_virtio_console';
 
 sub run {
-    select_console 'root-ssh';
+    select_console 'root-ssh' if (check_var('BACKEND', 'ipmi'));
+    select_virtio_console()   if (check_var('BACKEND', 'qemu'));
 
     my $hugepages  = get_required_var('HUGEPAGES');
     my $hugepagesz = get_required_var('HUGEPAGESZ');
     my $grub_file  = '/boot/grub2/grub.cfg';
     my $boot_line  = "default_hugepagesz=$hugepagesz hugepagesz=$hugepagesz hugepages=$hugepages";
 
-    record_info("Kernel boot command");
+    record_info("INFO", "Add $boot_line to the Kernel boot command");
     assert_script_run("sed -i 's/showopts/showopts " . $boot_line . "/' " . $grub_file);
     assert_script_run("sed -i 's/showopts/showopts " . $boot_line . "/' " . $grub_file);
     assert_script_run("grub2-mkconfig");

--- a/tests/nfv/prepare_env.pm
+++ b/tests/nfv/prepare_env.pm
@@ -48,20 +48,20 @@ sub run {
     my $children       = get_children();
     my $child_id       = (keys %$children)[0];
 
-    record_info("Install OVS, DPKD");
+    record_info("INFO", "Install needed packages for NFV tests: OVS, DPKD, QEMU");
     zypper_call('--quiet in git-core openvswitch-switch dpdk qemu tcpdump', timeout => 200);
 
     assert_script_run("cd /root/");
-    record_info("Clone VSPerf");
+    record_info("INFO", "Clone VSPerf repository");
     assert_script_run("git clone --quiet --depth 1 --branch $vsperf_version $vsperf_repo", timeout => 200);
-    record_info("Clone DPKD");
-    assert_script_run("git clone --quiet --depth 1 $dpdk_repo", timeout => 500);
+    record_info("INFO", "Clone DPKD repository");
+    assert_script_run("git clone --quiet --depth 1 $dpdk_repo", timeout => 600);
 
-    record_info("Start openvswitch");
+    record_info("INFO", "Start openvswitch service");
     systemctl 'enable openvswitch', timeout => 200;
     systemctl 'start openvswitch',  timeout => 200;
 
-    record_info("VSPerf Installation");
+    record_info("INFO", "VSPerf Installation");
     assert_script_run("cd vswitchperf/systems");
     if (is_sle('>=15')) {
         # Hack to skip the OVS, DPDK and QEMU compilation as we will use the vanilla packages
@@ -72,18 +72,18 @@ sub run {
     elsif (check_var('VERSION', '12-SP4')) {
         assert_script_run("curl " . data_url('nfv/sles/12.4/build_base_machine.sh') . " -o /root/build_base_machine.sh");
         assert_script_run("chmod 755 /root/build_base_machine.sh");
-        assert_script_run("bash -x /root/build_base_machine.sh", timeout => 500);
+        assert_script_run("bash -x /root/build_base_machine.sh", timeout => 600);
     }
     else {
         die "OS VERSION not supported. Available only on >=15 and 12-SP4";
     }
 
     # Clone Trex repo inside VSPerf directories
-    record_info("Clone TREX");
-    assert_script_run("cd /root/vswitchperf/src/trex; make", timeout => 500);
+    record_info("INFO", "Clone TREX repository");
+    assert_script_run("cd /root/vswitchperf/src/trex; make", timeout => 600);
 
     # Copy VSPERF custom configuration files
-    record_info("Copy config");
+    record_info("INFO", "Copy VSPERF config files to target directory");
     assert_script_run("curl " . data_url('nfv/conf/00_common.conf') . " -o /root/vswitchperf/conf/00_common.conf");
     assert_script_run("curl " . data_url('nfv/conf/01_testcases.conf') . " -o /root/vswitchperf/conf/01_testcases.conf");
     assert_script_run("curl " . data_url('nfv/conf/02_vswitch.conf') . " -o /root/vswitchperf/conf/02_vswitch.conf");
@@ -96,25 +96,25 @@ sub run {
     assert_script_run("curl " . data_url('nfv/conf/10_custom.conf') . " -o /root/vswitchperf/conf/10_custom.conf");
     assert_script_run("sed -i 's/trafficgen_ip/$trafficgen_ip/' -i /root/vswitchperf/conf/10_custom.conf");
 
-    record_info("Wait NFV_TRAFFICGEN_READY");
+    record_info("INFO", "Wait for mutex NFV_TRAFFICGEN_READY");
     mutex_wait('NFV_TRAFFICGEN_READY', $child_id);
 
     if (check_var('BACKEND', 'ipmi')) {
         # Generate ssh keypair and ssh-copy-id to the Traffic generator machine
-        record_info("SSH KEY");
+        record_info("INFO", "Grant SSH access to trafficgen machine $trafficgen_ip");
         assert_script_run('ssh-keygen -b 2048 -t rsa -q -N "" -f ~/.ssh/id_rsa');
         exec_and_insert_password("ssh-copy-id -o StrictHostKeyChecking=no root\@$trafficgen_ip");
 
         # Bring mellanox interfaces up
-        record_info("Interfaces up");
+        record_info("INFO", "Bring Mellanox interfaces up");
         assert_script_run("ip link set dev eth2 up");
         assert_script_run("ip link set dev eth3 up");
     }
 
-    record_info("Stop Firewall");
+    record_info("INFO", "Stop Firewall");
     systemctl 'stop ' . $self->firewall;
 
-    record_info("Installation ready");
+    record_info("INFO", "Installation ready. Mutex NFV_VSPERF_READY created");
     mutex_create("NFV_VSPERF_READY");
 }
 

--- a/tests/nfv/run_integration_tests.pm
+++ b/tests/nfv/run_integration_tests.pm
@@ -17,6 +17,7 @@ use testapi;
 use strict;
 use utils;
 use serial_terminal 'select_virtio_console';
+use mmapi;
 
 sub run {
     select_virtio_console();
@@ -37,6 +38,8 @@ sub run {
     assert_script_run('./vsperf --conf-file=' . $vsperf_conf . ' --integration vswitch_add_del_vport');
     assert_script_run('./vsperf --conf-file=' . $vsperf_conf . ' --integration vswitch_add_del_vports');
     assert_script_run('./vsperf --conf-file=' . $vsperf_conf . ' --integration vswitch_vports_add_del_flow');
+
+    wait_for_children;
 }
 
 1;

--- a/tests/nfv/run_performance_tests.pm
+++ b/tests/nfv/run_performance_tests.pm
@@ -14,6 +14,7 @@ use base "opensusebasetest";
 use testapi;
 use strict;
 use lockapi;
+use serial_terminal 'select_virtio_console';
 
 our $results_dir = '/tmp';
 our $ovs_version;
@@ -22,20 +23,24 @@ our $test_url;
 sub run_test {
     my ($test, $vswitch) = @_;
     my $testname = "$test\_$vswitch";
-    record_info($testname);
-    assert_script_run("./vsperf --conf-file=/root/vswitchperf/conf/10_custom.conf --vswitch $vswitch $test", timeout => 4000);
-    record_info("Push Results");
-    assert_script_run(sprintf('./push2db.py --parsefolder "%s" --targeturl http://10.86.0.128:8086 --os_version %s --os_build %s --vswitch_version %s --openqa_url %s',
-            $results_dir, get_var('VERSION'), get_var('BUILD'), $ovs_version, $test_url));
-    assert_script_run("mv /tmp/push2db.log /tmp/push2db_$testname.log");
-    upload_logs("/tmp/push2db_$testname.log", failok => 1);
-    assert_script_run("tar -czvf /tmp/vsperf_logs_$testname.tar.gz $results_dir/results_*");
-    upload_logs("/tmp/vsperf_logs_$test.tar.gz", failok => 1);
-    assert_script_run("rm -r $results_dir/results_*");
+    my $cmd      = "./vsperf --conf-file=/root/vswitchperf/conf/10_custom.conf --vswitch $vswitch $test";
+    record_info("INFO", "Running test case $testname");
+    if (check_var('BACKEND', 'ipmi')) {
+        assert_script_run($cmd, timeout => 4000);
+        record_info("INFO", "Push VSPerf Results to InfluxDB");
+        assert_script_run(sprintf('./push2db.py --parsefolder "%s" --targeturl http://10.86.0.128:8086 --os_version %s --os_build %s --vswitch_version %s --openqa_url %s',
+                $results_dir, get_var('VERSION'), get_var('BUILD'), $ovs_version, $test_url));
+        assert_script_run("mv /tmp/push2db.log /tmp/push2db_$testname.log");
+        upload_logs("/tmp/push2db_$testname.log", failok => 1);
+        assert_script_run("tar -czvf /tmp/vsperf_logs_$testname.tar.gz $results_dir/results_*");
+        upload_logs("/tmp/vsperf_logs_$test.tar.gz", failok => 1);
+        assert_script_run("rm -r $results_dir/results_*");
+    }
 }
 
 sub run {
-    select_console 'root-ssh';
+    select_console 'root-ssh' if (check_var('BACKEND', 'ipmi'));
+    select_virtio_console()   if (check_var('BACKEND', 'qemu'));
 
     # Arrayss for test specs
     my @tests   = ('phy2phy_tput', 'phy2phy_cont');
@@ -51,21 +56,23 @@ sub run {
 
     assert_script_run("pip2 install -q requests");
 
-    record_info("Check Hugepages");
+    record_info("INFO", "Check Hugepages information");
     assert_script_run('cat /proc/meminfo |grep -i huge');
 
     # Get push to DB script
-    record_info("Get push2db.py");
+    record_info("INFO", "Download push2db.py script");
     assert_script_run("curl " . data_url('nfv/push2db.py') . " -o /root/vswitchperf/push2db.py");
     assert_script_run('chmod +x /root/vswitchperf/push2db.py');
 
-    record_info("Start tests");
+    record_info("INFO", "Start VSPERF environment");
     assert_script_run('source /root/vsperfenv/bin/activate && cd /root/vswitchperf/');
 
     for my $i (0 .. $#tests) {
         record_info("Test $i");
         run_test($tests[$i], $vswitch[$i]);
     }
+
+    record_info("INFO", "Mutex NFV_TESTING_DONE created");
     mutex_create("NFV_TESTING_DONE");
 }
 

--- a/tests/nfv/trex_installation.pm
+++ b/tests/nfv/trex_installation.pm
@@ -33,31 +33,31 @@ sub run {
     my $PORT_2       = get_required_var('PORT_2');
 
     # Download and extract T-Rex package
-    record_info("Download TREX");
+    record_info("INFO", "Download TREX package");
     assert_script_run("wget $url", 900);
     assert_script_run("tar -xzf $tarball");
     assert_script_run("mv $trex_version $trex_dest");
 
     # Copy config file and replace port values
-    record_info("TREX Config");
+    record_info("INFO", "Modify TREX config file.");
     assert_script_run("curl " . data_url('nfv/trex_cfg.yaml') . " -o $trex_conf");
     assert_script_run("sed -i 's/PORT_0/$PORT_1/' -i $trex_conf");
     assert_script_run("sed -i 's/PORT_1/$PORT_2/' -i $trex_conf");
     assert_script_run("cat $trex_conf");
 
     if (check_var('BACKEND', 'ipmi')) {
-        record_info("Bring mellanox interfaces up");
+        record_info("INFO", "Bring Mellanox interfaces up");
         assert_script_run("ip link set dev eth2 up");
         assert_script_run("ip link set dev eth3 up");
     }
 
-    record_info("Stop Firewall");
+    record_info("INFO", "Stop Firewall");
     systemctl 'stop ' . $self->firewall;
 
-    record_info("TREX ready");
+    record_info("INFO", "TREX installation & configuration ready. Mutex NFV_TRAFFICGEN_READY created.");
     mutex_create("NFV_TRAFFICGEN_READY");
 
-    record_info("Wait for VSPerf");
+    record_info("INFO", "Wait for VSPerf installation, wait for Mutex NFV_VSPERF_READY");
     mutex_wait('NFV_VSPERF_READY');
 }
 

--- a/tests/nfv/trex_runner.pm
+++ b/tests/nfv/trex_runner.pm
@@ -16,16 +16,19 @@ use testapi;
 use strict;
 use utils;
 use lockapi;
+use serial_terminal 'select_virtio_console';
 
 sub run {
-    select_console 'root-ssh';
+    select_console 'root-ssh' if (check_var('BACKEND', 'ipmi'));
+    select_virtio_console()   if (check_var('BACKEND', 'qemu'));
 
     my $trex_dir = "/tmp/trex-core";
 
-    record_info("Start TREX");
+    record_info("INFO", "Start TREX in background");
     script_run("cd /tmp/trex-core");
-    type_string("nohup bash /tmp/trex-core/t-rex-64 -i &\n");
+    type_string("nohup bash /tmp/trex-core/t-rex-64 -i &\n") if (check_var('BACKEND', 'ipmi'));
 
+    record_info("INFO", "Wait for NFV tests to be completed. Waiting for Mutex NFV_TESTING_DONE");
     mutex_wait('NFV_TESTING_DONE');
 }
 


### PR DESCRIPTION
For virtual jobs, we were using boot_from_hdd using the corresponding qcow sdk image. This makes things very different than baremetal version where the system is installed from scratch. 

With this new approach, we make virtual jobs be as similar as possible to the BM mode to detect potential errors in package installation, etc.  

Verification runs: http://fromm.arch.suse.de/tests/1514 http://fromm.arch.suse.de/tests/1515