### PR TITLE
Add service widget for iscsi

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -5,30 +5,6 @@ use base 'y2logsstep';
 use strict;
 use testapi;
 
-sub change_service_configuration {
-    my ($self, %args) = @_;
-    my $after_writing_ref = $args{after_writing};
-    my $after_reboot_ref  = $args{after_reboot};
-
-    assert_screen 'yast2_ncurses_service_start_widget';
-    change_service_configuration_step('after_writing_conf', $after_writing_ref) if $after_writing_ref;
-    change_service_configuration_step('after_reboot',       $after_reboot_ref)  if $after_reboot_ref;
-}
-
-sub change_service_configuration_step {
-    my ($step_name, $step_conf_ref) = @_;
-    my ($action)         = keys %$step_conf_ref;
-    my ($shortcut)       = values %$step_conf_ref;
-    my $needle_selection = 'yast2_ncurses_service_' . $action . '_' . $step_name;
-    my $needle_check     = 'yast2_ncurses_service_check_' . $action . '_' . $step_name;
-
-    send_key $shortcut;
-    send_key 'end';
-    send_key_until_needlematch $needle_selection, 'up', 5, 1;
-    send_key 'ret';
-    assert_screen $needle_check;
-}
-
 sub post_fail_hook {
     my $self = shift;
 

--- a/lib/yast2_widget_utils.pm
+++ b/lib/yast2_widget_utils.pm
@@ -1,0 +1,55 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: This module provides helper functions for handling YaST widgets in text and graphical mode
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.de>
+
+package yast2_widget_utils;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use testapi;
+
+our @EXPORT = qw(change_service_configuration);
+
+=head2 change_service_configuration
+Modify service configuration: "after writing" and/or "after reboot" steps
+=cut
+sub change_service_configuration {
+    my (%args)            = @_;
+    my $after_writing_ref = $args{after_writing};
+    my $after_reboot_ref  = $args{after_reboot};
+
+    assert_screen 'yast2_ncurses_service_start_widget';
+    change_service_configuration_step('after_writing_conf', $after_writing_ref) if $after_writing_ref;
+    change_service_configuration_step('after_reboot',       $after_reboot_ref)  if $after_reboot_ref;
+}
+
+=head2 change_service_configuration_step
+Modify one service configuration step
+=cut
+sub change_service_configuration_step {
+    my ($step_name, $step_conf_ref) = @_;
+    my ($action)         = keys %$step_conf_ref;
+    my ($shortcut)       = values %$step_conf_ref;
+    my $needle_selection = 'yast2_ncurses_service_' . $action . '_' . $step_name;
+    my $needle_check     = 'yast2_ncurses_service_check_' . $action . '_' . $step_name;
+
+    send_key $shortcut;
+    send_key 'end';
+    send_key_until_needlematch $needle_selection, 'up', 5, 1;
+    if (get_var('Y2UITEST_NCURSES')) {
+        send_key 'ret';
+        assert_screen $needle_check;
+    }
+}
+
+1;

--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -18,6 +18,8 @@ use utils;
 use version_utils qw(is_leap is_sle);
 use y2_common 'continue_info_network_manager_default';
 use constant RETRIES => 5;
+use yast2_widget_utils 'change_service_configuration';
+
 # Test "yast2 dhcp-server" functionality
 # Ensure that all combinations of running/stopped and active/inactive
 # can be set
@@ -99,7 +101,7 @@ sub run {
         assert_screen 'yast2-dns-server-start-named-now';
     }
     else {
-        $self->change_service_configuration(
+        change_service_configuration(
             after_writing => {start         => 'alt-t'},
             after_reboot  => {start_on_boot => 'alt-a'}
         );
@@ -128,7 +130,7 @@ sub run {
         assert_screen 'yast2-service-stopped-enabled';
     }
     else {
-        $self->change_service_configuration(after_writing => {stop => 'alt-t'});
+        change_service_configuration(after_writing => {stop => 'alt-t'});
     }
     # Cancel yast2 to check the effect
     # workaround for single send_key 'alt-c' because it doesn't work.
@@ -152,7 +154,7 @@ sub run {
         wait_screen_change { send_key 'alt-t' };
     }
     else {
-        $self->change_service_configuration(after_reboot => {do_not_start => 'alt-a'});
+        change_service_configuration(after_reboot => {do_not_start => 'alt-a'});
     }
     send_key 'alt-o';
     assert_screen 'root-console', 180;
@@ -171,7 +173,7 @@ sub run {
         assert_screen 'yast2-service-stopped-disabled';
     }
     else {
-        $self->change_service_configuration(after_writing => {stop => 'alt-t'});
+        change_service_configuration(after_writing => {stop => 'alt-t'});
     }
     # Finish
     send_key 'alt-o';

--- a/tests/console/yast2_ftp.pm
+++ b/tests/console/yast2_ftp.pm
@@ -16,6 +16,7 @@ use testapi;
 use utils;
 use version_utils;
 use y2logsstep;
+use yast2_widget_utils 'change_service_configuration';
 
 sub vsftd_setup_checker {
     my $config_ref              = pop();
@@ -91,7 +92,7 @@ sub run {
         assert_screen 'ftp_server_when_booting';    # check service start when booting
     }
     else {
-        $self->change_service_configuration(
+        change_service_configuration(
             after_writing => {start         => 'alt-t'},
             after_reboot  => {start_on_boot => 'alt-a'}
         );

--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -16,10 +16,9 @@ use testapi;
 use utils 'zypper_call';
 use version_utils qw(is_sle is_leap);
 use y2_common 'continue_info_network_manager_default';
+use yast2_widget_utils 'change_service_configuration';
 
 sub run {
-    my $self = shift;
-
     select_console 'root-console';
     # install http server
     zypper_call("-q in yast2-http-server");
@@ -111,7 +110,7 @@ sub run {
         assert_screen 'http_start_apache2';
     }
     else {
-        $self->change_service_configuration(
+        change_service_configuration(
             after_writing => {start         => 'alt-t'},
             after_reboot  => {start_on_boot => 'alt-a'}
         );

--- a/tests/console/yast2_proxy.pm
+++ b/tests/console/yast2_proxy.pm
@@ -15,6 +15,7 @@ use base "console_yasttest";
 use testapi;
 use utils;
 use version_utils qw(is_sle is_leap);
+use yast2_widget_utils 'change_service_configuration';
 
 my %sub_menu_needles = (
     start_up      => 'yast2_proxy_start-up',
@@ -59,8 +60,6 @@ sub post_fail_hook {
 }
 
 sub run {
-    my $self = shift;
-
     select_console 'root-console';
     if (is_sle '15+') {
         zypper_call('in squid');
@@ -89,7 +88,7 @@ sub run {
         send_key_until_needlematch 'yast2_proxy_service_start', 'alt-b';    #Start service when booting
     }
     else {
-        $self->change_service_configuration(
+        change_service_configuration(
             after_writing => {start         => 'alt-f'},
             after_reboot  => {start_on_boot => 'alt-a'}
         );

--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -16,6 +16,7 @@ use testapi;
 use utils;
 use version_utils qw(is_sle is_leap is_tumbleweed);
 use y2logsstep;
+use yast2_widget_utils 'change_service_configuration';
 
 my %ldap_directives = (
     fqdn                => 'openqa.ldaptest.org',
@@ -147,8 +148,6 @@ sub setup_ldap_in_samba {
 }
 
 sub setup_samba {
-    my $self = shift;
-
     script_run("yast2 samba-server; echo yast2-samba-server-status-\$? > /dev/$serialdev", 0);
 
     # samba-server configuration for SLE older than 15 or opensuse TW
@@ -182,7 +181,7 @@ sub setup_samba {
         assert_screen 'yast2_samba-server_start-during-boot';
     }
     else {
-        $self->change_service_configuration(
+        change_service_configuration(
             after_writing => {start         => 'alt-e'},
             after_reboot  => {start_on_boot => 'alt-a'}
         );

--- a/tests/console/yast2_tftp.pm
+++ b/tests/console/yast2_tftp.pm
@@ -15,10 +15,9 @@ use base "console_yasttest";
 use testapi;
 use utils;
 use version_utils qw(is_sle is_leap is_tumbleweed);
+use yast2_widget_utils 'change_service_configuration';
 
 sub run {
-    my $self = shift;
-
     select_console 'root-console';
     zypper_call("in tftp yast2-tftp-server", timeout => 240);
     script_run("yast2 tftp-server; echo yast2-tftp-server-status-\$? > /dev/$serialdev", 0);
@@ -40,7 +39,7 @@ sub run {
         $firewall_detail_shortcut = 'alt-i';
     }
     else {
-        $self->change_service_configuration(
+        change_service_configuration(
             after_writing => {start           => 'alt-t'},
             after_reboot  => {start_on_demand => 'alt-a'}
         );

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -19,7 +19,6 @@ use lockapi;
 use utils 'turn_off_gnome_screensaver';
 
 sub run {
-    my ($self) = @_;
     x11_start_program('xterm -geometry 160x45+5+5', target_match => 'xterm');
     turn_off_gnome_screensaver;
     become_root;
@@ -35,7 +34,7 @@ sub run {
     wait_still_screen(2, 10);
     assert_screen 'iscsi-initiator-service';
     send_key "alt-v";             # go to discovered targets tab
-    assert_screen 'iscsi-discovered-targets';
+    assert_screen 'iscsi-discovered-targets', 120;
     send_key "alt-d";             # press discovery button
     assert_screen 'iscsi-discovery';
     send_key "alt-i";             # go to IP address field


### PR DESCRIPTION
Add service widget for iscsi. Widget was successfully integrated in a base file for text mode. Logic has been moved to a util file so it can be used from graphical and text mode. Timeout increased for detecting targets in iscsi_client.

- Related ticket: https://progress.opensuse.org/issues/40067
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/927
- Verification run: 
  - [sle-15-SP1-iscsi_client](http://dhcp87.suse.cz/tests/2508) (with expected issue detecting targets)
  - [sle-15-SP1-iscsi_server](http://dhcp87.suse.cz/tests/2507)
  - [sle-15-SP1-yast2_ncurses](http://dhcp87.suse.cz/tests/2514) (for retro-compatibility in text mode, with expected [samba bug](https://bugzilla.suse.com/show_bug.cgi?id=1106876))
