### PR TITLE
Hyper-V: X11 to VT switch

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -371,6 +371,7 @@ sub load_svirt_boot_tests {
 
 sub load_svirt_vm_setup_tests {
     return unless check_var('BACKEND', 'svirt');
+    set_bridged_networking;
     if (check_var("VIRSH_VMM_FAMILY", "hyperv")) {
         # Loading bootloader_hyperv here when UPGRADE is on (i.e. offline migration is underway)
         # means loading it for the second time. Which might be apropriate if we want to reconfigure

--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -167,7 +167,7 @@ sub boot_into_ro_snapshot {
     if (!check_screen('linux-login', 200)) {
         record_soft_failure 'bsc#980337';
         for (1 .. 10) {
-            send_key "ctrl-alt-f1";
+            check_var('VIRSH_VMM_FAMILY', 'hyperv') ? send_key 'alt-f1' : send_key 'ctrl-alt-f1';
             if (check_screen('tty1-selected', 12)) {
                 return 1;
             }

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -42,6 +42,7 @@ our @EXPORT = qw(
   ensure_unlocked_desktop
   install_to_other_at_least
   is_bridged_networking
+  set_bridged_networking
   ensure_fullscreen
   assert_screen_with_soft_timeout
   pkcon_quit
@@ -480,6 +481,10 @@ sub install_to_other_at_least {
 }
 
 sub is_bridged_networking {
+    return get_var('BRIDGED_NETWORKING');
+}
+
+sub set_bridged_networking {
     my $ret = 0;
     if (check_var('BACKEND', 'svirt') and !check_var('ARCH', 's390x')) {
         my $vmm_family = get_required_var('VIRSH_VMM_FAMILY');
@@ -487,7 +492,6 @@ sub is_bridged_networking {
     }
     # Some needles match hostname which we can't set permanently with bridge.
     set_var('BRIDGED_NETWORKING', 1) if $ret;
-    return $ret;
 }
 
 =head2 set_hostname

--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -22,6 +22,9 @@ sub run {
     # We have tests that boot from HDD and wait for DVD boot menu's timeout, so
     # the timeout here must cover it. UEFI DVD adds some 60 seconds on top.
     my $timeout = get_var('UEFI') ? 140 : 80;
+    # Add additional 60 seconds if the test suite is migration as reboot from
+    # pre-migration system may take an additional time.
+    $timeout += 60 if get_var('PATCH') || get_var('ONLINE_MIGRATION');
     # Do not attempt to log into the desktop of a system installed with SLES4SAP
     # being prepared for upgrade, as it does not have an unprivileged user to test
     # with other than the SAP Administrator

--- a/tests/installation/post_zdup.pm
+++ b/tests/installation/post_zdup.pm
@@ -24,7 +24,7 @@ sub run {
     # Remove the --force when this is fixed: https://bugzilla.redhat.com/1075131
     # Because of poo#32458 Hyper-V can't switch from VT to X11 and has to use
     # whatever the default in the image is.
-    systemctl('set-default --force graphical.target') unless check_var('VIRSH_VMM_FAMILY', 'hyperv');
+    systemctl('set-default --force graphical.target');
 
     # switch to root-console (in case we are in X)
     select_console 'root-console';


### PR DESCRIPTION
Implement X11 to VT switch on Hyper-V and various others subtle enhancements and workaround-removals for Hyper-V.

Hyper-V validation runs:
* [7 online and offline migration](http://nilgiri.suse.cz/tests/overview?distri=sle&version=12-SP4&build=0366&groupid=1&machine=svirt-hyperv&machine=svirt-hyperv-uefi)
* JeOS: http://nilgiri.suse.cz/tests/1131
* textmode: http://nilgiri.suse.cz/tests/1150
* mediacheck: http://nilgiri.suse.cz/tests/1140
* memtest: http://nilgiri.suse.cz/tests/1141
* lvm+RAID1: http://nilgiri.suse.cz/tests/1139
* default_install: http://nilgiri.suse.cz/tests/1143
* minimal+base: http://nilgiri.suse.cz/tests/1142

Once merged, Hyper-V test suites needs to be set to `DESKTOP=gnome`, where appropriate.

Replaces https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/4613.