### PR TITLE
Fix consoletest_setup on ipmi

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -266,7 +266,8 @@ sub assert_gui_app {
 # console font, we need to call systemd-vconsole-setup to workaround
 # that
 sub check_console_font {
-    return if check_var('BACKEND', 'spvm');
+    # Does not make sense on ssh-based consoles
+    return if (check_var('BACKEND', 'spvm')) || (check_var('BACKEND', 'ipmi'));
     # we do not await the console here, as we have to expect the font to be broken
     # for the needle to match
     select_console('root-console', await_console => 0);

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -16,14 +16,14 @@
 use base "consoletest";
 use testapi;
 use utils;
+use ipmi_backend_utils 'use_ssh_serial_console';
 use strict;
 
 sub run {
     my $self = shift;
     # let's see how it looks at the beginning
     save_screenshot;
-
-    select_console 'root-console';
+    check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
 
     # init
     check_console_font;


### PR DESCRIPTION
- see https://progress.opensuse.org/issues/3826 for details
- verification run:
  http://e13.suse.de/tests/7980#step/consoletest_setup
- needle PR:
  https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/928
