### PR TITLE
LTP: Make all failures soft only

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -42,6 +42,7 @@ our @EXPORT = qw(
   installzdupstep_is_applicable
   is_desktop
   is_kernel_test
+  is_ltp_test
   is_livesystem
   is_mediacheck
   is_mediacheck
@@ -219,14 +220,19 @@ sub packagekit_available {
     return !check_var('FLAVOR', 'Rescue-CD');
 }
 
-sub is_kernel_test {
+sub is_ltp_test {
     return (get_var('INSTALL_LTP')
           || get_var('LTP_COMMAND_FILE')
-          || get_var('QA_TEST_KLP_REPO')
-          || get_var('INSTALL_KOTD')
-          || get_var('VIRTIO_CONSOLE_TEST')
-          || get_var('NVMFTESTS'))
-      || get_var('TRINITY');
+          || get_var('NVMFTESTS'));
+}
+
+sub is_kernel_test {
+    return is_ltp_test() ||
+      (get_var('QA_TEST_KLP_REPO')
+        || get_var('INSTALL_KOTD')
+        || get_var('VIRTIO_CONSOLE_TEST')
+        || get_var('NVMFTESTS')
+        || get_var('TRINITY'));
 }
 
 # Isolate the loading of LTP tests because they often rely on newer features

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -678,7 +678,7 @@ if (is_sle('=12-SP4') && check_var('ARCH', 'aarch64')) {
     push @$serial_failures, {type => 'hard', message => 'bsc#1093797', pattern => quotemeta 'Internal error: Oops: 96000006'};
 }
 if (is_kernel_test()) {
-    my $type = get_var('INSTALL_LTP') ? 'soft' : 'hard';
+    my $type = is_ltp_test() ? 'soft' : 'hard';
     push @$serial_failures, {type => $type, message => 'Kernel Ooops found',             pattern => quotemeta 'Oops:'};
     push @$serial_failures, {type => $type, message => 'Kernel BUG found',               pattern => qr/kernel BUG at/i};
     push @$serial_failures, {type => $type, message => 'WARNING CPU in kernel messages', pattern => quotemeta 'WARNING: CPU'};


### PR DESCRIPTION
LTP test consists from many tests, using serial failures as hard make
them fail in boot_ltp (except already handled install_ltp).