### PR TITLE
Extend EULA verification to openSUSE

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -221,13 +221,13 @@ sub verify_license_has_to_be_accepted {
     }
 }
 
-sub verify_translation {
-    return if check_var('VIDEOMODE', 'text');
-    for my $language (qw(korean english-us)) {
+sub verify_license_translations {
+    return if (!get_var('INSTALLER_EXTENDED_TEST') || (is_sle && get_var("BETA")) || check_var('VIDEOMODE', 'text'));
+    for my $language (split(/,/, get_var('EULA_LANGUAGES')), 'english-us') {
         wait_screen_change { send_key 'alt-l' };
         send_key 'home';
         send_key_until_needlematch("license-language-selected-$language", 'down', 60, 1);
-        assert_screen "license-content-$language";
+        assert_screen "license-content-$language";    # needs wait for loading content
     }
 }
 

--- a/tests/installation/accept_license.pm
+++ b/tests/installation/accept_license.pm
@@ -40,7 +40,7 @@ sub run {
         return send_key $cmd{next} unless match_has_tag('license-agreement');
     }
     $self->verify_license_has_to_be_accepted;
-    $self->verify_translation if get_var('INSTALLER_EXTENDED_TEST') && !get_var("BETA");
+    $self->verify_license_translations;
     send_key $cmd{next};
     # workaround for bsc#1059317, multiple times clicking accept license
     my $count = 5;

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -116,6 +116,7 @@ sub run {
     }
 
     assert_screen 'languagepicked';
+    $self->verify_license_translations unless is_sle('15+');
 }
 
 1;


### PR DESCRIPTION
Extend EULA verification to openSUSE. 
- Related ticket: https://progress.opensuse.org/issues/40040
- Needles: [needles openSUSE](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/432)
- Verification run: [Tumbleweed-installer_extended](http://dhcp87.suse.cz/tests/2605#step/welcome/62) | [Leap-15.1-installer_extended](http://dhcp87.suse.cz/tests/2604#step/welcome/59) | [15-SP1-installer_extended](http://dhcp87.suse.cz/tests/2606#step/accept_license/3) | [sle-12-SP4-installer_extended](http://dhcp87.suse.cz/tests/2603#step/welcome/6)

After merged, needs to set `EULA_LANGUAGES=korean` in OSD and `EULA_LANGUAGES=japanese` in O3.