### PR TITLE
main.pm: lightdm is now the default displaymanager for Tumbleweed

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -84,9 +84,8 @@ unless (get_var("DESKTOP")) {
 
 if (check_var('DESKTOP', 'minimalx')) {
     set_var("NOAUTOLOGIN", 1);
-    # lightdm is the default DM since Leap 15.0 per boo#1081760
-    # staging project keep to use xdm due to lightdm will not be in staging project
-    if (!is_leap('15.0+') || get_var('STAGING')) {
+    # lightdm is the default DM for Tumbleweed and Leap 15.0 per boo#1081760
+    if (is_leap('<15.0')) {
         set_var("XDMUSED",           1);
         set_var('DM_NEEDS_USERNAME', 1);
     }


### PR DESCRIPTION
lightdm is the default displaymanager for Tumbleweed, and since Ring1/Ring2 has been merged, this change should apply to staging project also.

miniamlX/lightdm already works on Leap 15.0 and Leap 15.1 a while now https://openqa.opensuse.org/tests/747695 , this PR just make the same thing apply to Tumbleweed.

- Related ticket: https://progress.opensuse.org/issues/40640
