### PR TITLE
hpc: need separate variable for second reg code

### DIFF
--- a/tests/hpc/migration.pm
+++ b/tests/hpc/migration.pm
@@ -20,7 +20,7 @@ use serial_terminal 'select_virtio_console';
 
 sub run {
     my $self     = shift;
-    my $scc_code = get_required_var('SCC_REGCODE_HPC');
+    my $scc_code = get_required_var('SCC_REGCODE_HPC_PRODUCT');
     select_virtio_console();
 
     assert_script_run('ls -la /etc/products.d/');


### PR DESCRIPTION
SCC_REGCODE_HPC variable used during image creation. All tests currently expect image to be SLES 12 + HPC module . hpc_migration scenario requires SLE 12 HPC Product reg key so we need separate variables to store it