### PR TITLE
Add SLES4SAP migration tests based on SLES code

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -842,7 +842,7 @@ sub load_inst_tests {
                 loadtest "installation/skip_registration" unless check_var('SLE_PRODUCT', 'leanos');
             }
         }
-        if (is_sles4sap and !sle_version_at_least('15')) {
+        if (is_sles4sap and !sle_version_at_least('15') and !is_upgrade()) {
             loadtest "installation/sles4sap_product_installation_mode";
         }
         if (get_var('MAINT_TEST_REPO')) {
@@ -863,7 +863,7 @@ sub load_inst_tests {
         if (is_sle12sp2_using_system_role() || is_sle('15+')) {
             loadtest "installation/system_role";
         }
-        if (is_sles4sap() and sle_version_at_least('15') and check_var('SYSTEM_ROLE', 'default')) {
+        if (is_sles4sap() and sle_version_at_least('15') and check_var('SYSTEM_ROLE', 'default') and !is_upgrade()) {
             loadtest "installation/sles4sap_product_installation_mode";
         }
         # Kubic doesn't have a partitioning step

--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -24,7 +24,7 @@ use testapi;
 use utils;
 use registration;
 use qam qw/remove_test_repositories/;
-use version_utils qw(sle_version_at_least is_sle);
+use version_utils qw(sle_version_at_least is_sle is_sles4sap);
 
 our @EXPORT = qw(
   setup_sle
@@ -113,10 +113,10 @@ sub record_disk_info {
     if (get_var('FILESYSTEM', 'btrfs') =~ /btrfs/) {
         assert_script_run 'btrfs filesystem df / | tee /tmp/btrfs-filesystem-df.txt';
         assert_script_run 'btrfs filesystem usage / | tee /tmp/btrfs-filesystem-usage.txt';
-        assert_script_run 'snapper list | tee /tmp/snapper-list.txt';
+        assert_script_run 'snapper list | tee /tmp/snapper-list.txt' unless (is_sles4sap());
         upload_logs '/tmp/btrfs-filesystem-df.txt';
         upload_logs '/tmp/btrfs-filesystem-usage.txt';
-        upload_logs '/tmp/snapper-list.txt';
+        upload_logs '/tmp/snapper-list.txt' unless (is_sles4sap());
     }
     assert_script_run 'df -h > /tmp/df.txt';
     upload_logs '/tmp/df.txt';

--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -25,7 +25,7 @@ sub run {
     # Do not attempt to log into the desktop of a system installed with SLES4SAP
     # being prepared for upgrade, as it does not have an unprivileged user to test
     # with other than the SAP Administrator
-    my $nologin = (get_var('HDDVERSION') and is_upgrade() and is_sles4sap()) ? 1 : 0;
+    my $nologin = (get_var('HDDVERSION') and is_upgrade() and is_sles4sap());
     if (check_var('VIRSH_VMM_TYPE', 'linux')) {
         wait_serial('Welcome to SUSE Linux', $timeout) || die "System did not boot in $timeout seconds.";
     }

--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -14,6 +14,7 @@
 use base 'opensusebasetest';
 use strict;
 use testapi;
+use version_utils qw(is_upgrade is_sles4sap);
 
 sub run {
     my ($self) = @_;
@@ -21,11 +22,15 @@ sub run {
     # We have tests that boot from HDD and wait for DVD boot menu's timeout, so
     # the timeout here must cover it. UEFI DVD adds some 60 seconds on top.
     my $timeout = get_var('UEFI') ? 140 : 80;
+    # Do not attempt to log into the desktop of a system installed with SLES4SAP
+    # being prepared for upgrade, as it does not have an unprivileged user to test
+    # with other than the SAP Administrator
+    my $nologin = (get_var('HDDVERSION') and is_upgrade() and is_sles4sap()) ? 1 : 0;
     if (check_var('VIRSH_VMM_TYPE', 'linux')) {
         wait_serial('Welcome to SUSE Linux', $timeout) || die "System did not boot in $timeout seconds.";
     }
     else {
-        $self->wait_boot(bootloader_time => $timeout);
+        $self->wait_boot(bootloader_time => $timeout, nologin => $nologin);
     }
 }
 

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -40,9 +40,12 @@ sub run {
     # Config bootloader is not be supported during an upgrade
     # Add exception for SLES11SP4 base update, configure grub for this scenario
     if (get_var('UPGRADE') && (!is_sle('<15') || !is_leap('<15.0')) && (!check_var('HDDVERSION', '11-SP4'))) {
-        assert_screen "bootloader-config-unsupport";
-        send_key 'ret';
-        return;
+        assert_screen([qw(bootloader-config-unsupport inst-bootloader-settings inst-bootloader-settings-first_tab_highlighted)]);
+        if (match_has_tag 'bootloader-config-unsupport') {
+            send_key 'ret';
+            return;
+        }
+        record_info('Bootloader conf', 'Config bootloader should not be supported during upgrade', result => 'softfail');
     }
     assert_screen([qw(inst-bootloader-settings inst-bootloader-settings-first_tab_highlighted)]);
     # Depending on an optional button "release notes" we need to press "tab"

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -17,7 +17,7 @@ use strict;
 use base "y2logsstep";
 use testapi;
 use utils qw(handle_login handle_emergency);
-use version_utils qw(sle_version_at_least is_sle is_leap);
+use version_utils qw(sle_version_at_least is_sle is_leap is_desktop_installed is_upgrade is_sles4sap);
 use base 'opensusebasetest';
 
 sub run {
@@ -43,6 +43,12 @@ sub run {
     }
     elsif ((get_var('DESKTOP', '') =~ /textmode|serverro/) || get_var('BOOT_TO_SNAPSHOT')) {
         assert_screen('linux-login', $boot_timeout) unless check_var('ARCH', 's390x');
+        return;
+    }
+    # On SLES4SAP upgrade tests with desktop, only check for a DM screen with the SAP System
+    # Administrator user listed but do not attempt to login
+    if (get_var('HDDVERSION') and is_desktop_installed() and is_upgrade() and is_sles4sap()) {
+        assert_screen 'displaymanager-sapadm', $boot_timeout;
         return;
     }
     # On IPMI, when selecting x11 console, we are already logged in.

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -12,7 +12,7 @@ use base "consoletest";
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_sle is_desktop_installed);
+use version_utils qw(is_sle is_desktop_installed is_upgrade is_sles4sap);
 use migration;
 use registration;
 use qam;
@@ -24,6 +24,11 @@ sub patching_sle {
     # Save VIDEOMODE and SCC_REGISTER vars
     my $orig_videomode    = get_var('VIDEOMODE',    '');
     my $orig_scc_register = get_var('SCC_REGISTER', '');
+
+    # Do not attempt to log into the desktop of a system installed with SLES4SAP
+    # being prepared for upgrade, as it does not have an unprivileged user to test
+    # with other than the SAP Administrator
+    my $nologin = (get_var('HDDVERSION') and is_upgrade() and is_sles4sap()) ? 1 : 0;
 
     # Skip registration here since we use autoyast profile to register origin system on zVM
     if (!get_var('UPGRADE_ON_ZVM')) {
@@ -58,7 +63,7 @@ sub patching_sle {
             # Workaround for test failed of the reboot operation need to wait some jobs done
             # Add '-f' to force the reboot to avoid the test be blocked here
             type_string "reboot -f\n";
-            $self->wait_boot(textmode => !is_desktop_installed(), ready_time => 600, bootloader_time => 300);
+            $self->wait_boot(textmode => !is_desktop_installed(), ready_time => 600, bootloader_time => 300, nologin => $nologin);
             # Setup again after reboot
             $self->setup_sle();
         }

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -28,7 +28,7 @@ sub patching_sle {
     # Do not attempt to log into the desktop of a system installed with SLES4SAP
     # being prepared for upgrade, as it does not have an unprivileged user to test
     # with other than the SAP Administrator
-    my $nologin = (get_var('HDDVERSION') and is_upgrade() and is_sles4sap()) ? 1 : 0;
+    my $nologin = (get_var('HDDVERSION') and is_upgrade() and is_sles4sap());
 
     # Skip registration here since we use autoyast profile to register origin system on zVM
     if (!get_var('UPGRADE_ON_ZVM')) {


### PR DESCRIPTION
This PR includes changes to SLES test code to make it possible to reuse while testing offline and scc based upgrades with SLES for SAP Applications. Changes are basically:

- Skip SLES4SAP product installation test during install when testing upgrades.
- Skip btrfs snapshots tests from SLES on SLES4SAP.
- Do not attempt to log in as an unprivileged user in Gnome, as SLES4SAP installation only sets up the system administrator user, and the SAP software installers set up different unprivileged users as the ones defined elsewhere in the code base.
- Check for extra needles in `installation/disable_grub_timeout`, as even though bootloader configuration should not be available during upgrades, it is available when upgrading SLES4SAP.
- Change SLES4SAP specific tests to also work with upgraded systems; in particular patterns test does not require to fail if the `sap_server` pattern is not installed on an upgraded system and sapconf test needs to verify if the active profile is `saptune` in order to skip some parts of the test.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/931
- Verification runs:

1. 12p3 to 12sp4 offline: http://mango.suse.de/tests/466
2. 12sp2 to 12sp4 offline: http://mango.suse.de/tests/468
3. 12sp1 to 12sp4 offline: http://mango.suse.de/tests/469
4. 11sp4 to 12sp4 offline: http://mango.suse.de/tests/470
5. 12sp3 to 12sp4 registered to SCC: http://mango.suse.de/tests/474
6. 12sp2 to 12sp4 registered to SCC: http://mango.suse.de/tests/475
7. 12sp1 to 12sp4 registered to SCC: http://mango.suse.de/tests/476
8. 11sp4 (unregistered) to 12sp4 with SCC registration: http://mango.suse.de/tests/477
9. 12sp4 installation test (regression): http://mango.suse.de/tests/467
10. 12sp3 SLES+HA to 12sp4 (regression): http://mango.suse.de/tests/479