### PR TITLE
 Add needles for switched tabs in yast2 bootloader

### DIFF
--- a/tests/yast2_gui/yast2_bootloader.pm
+++ b/tests/yast2_gui/yast2_bootloader.pm
@@ -18,8 +18,6 @@
 use base "y2x11test";
 use strict;
 use testapi;
-# TO be removed!!!
-use utils 'ensure_unlocked_desktop';
 
 sub run {
     my $self = shift;
@@ -34,12 +32,14 @@ sub run {
     #	kernel parameters and use graphical console
     wait_still_screen 3;
     assert_and_click 'yast2-bootloader_kernel-parameters';
+    assert_screen 'yast2-bootloader_kernel-parameters-switched';
     send_key 'alt-p';
     send_key 'end';
     assert_screen 'yast2-bootloader_use-graphical-console';
 
     #	bootloader options and set probe foreign OS, timeout
     assert_and_click 'yast2-bootloader_bootloader-options';
+    assert_screen 'yast2-bootloader_bootloader-options-switched';
     send_key 'alt-b';
     wait_still_screen 3;
     send_key 'alt-t';


### PR DESCRIPTION
- Related ticket: [[functional][y][sporadic] test fails in yast2_bootloader, tab is not opened but tests continues to press keys on leap 15](https://progress.opensuse.org/issues/39215)
- Needles: [sle](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/932)
[opensuse](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/433)
- Verification runs: 
[opensuse-Tumbleweed-DVD-x86_64-Build20180904-yast2_gui@64bit](http://dhcp128.suse.cz/tests/5985#step/yast2_bootloader/18)
[opensuse-15.1-DVD-x86_64-Build297.5-yast2_gui@64bit](http://dhcp128.suse.cz/tests/5988#step/yast2_bootloader/18)
[sle-12-SP4-Server-DVD-x86_64-Build0374-yast2_gui@64bit](http://dhcp128.suse.cz/tests/5989#step/yast2_bootloader/18)
[sle-15-SP1-Installer-DVD-x86_64-Build28.1-yast2_gui@64b](http://dhcp128.suse.cz/tests/5990#step/yast2_bootloader/18)
