### PR TITLE
Fix zypper rr in docker_image_rpm

### DIFF
--- a/tests/console/docker_image_rpm.pm
+++ b/tests/console/docker_image_rpm.pm
@@ -39,9 +39,9 @@ sub run {
         $image_path = '/usr/share/suse-docker-images/native/*-image*.tar.xz';
 
         # For Tumbleweed, the image is wrapped inside an RPM
-        zypper_call "ar -fG $repo_url";
+        zypper_call "ar -fGn virtualization $repo_url";
         zypper_call "in opensuse-tumbleweed-image";
-        zypper_call "rr $repo_url";
+        zypper_call "rr virtualization";
     }
     else {
         die 'Only know about Tumbleweed and Leap 15.0+ docker images';


### PR DESCRIPTION
The zypper fails to remove the virtualization repository which contains the RPM we test in this test - there's no red square but it should be fixed anyways.

- Related ticket: [poo#40691](https://progress.opensuse.org/issues/40691)
- Needles: No need
- Verification run: [Tumbleweed](http://pdostal-server.suse.cz/tests/1168#step/docker_image_rpm/14)
