### PR TITLE
xfstests: continue process when softfail happened

### DIFF
--- a/tests/xfstests/enable_kdump.pm
+++ b/tests/xfstests/enable_kdump.pm
@@ -28,7 +28,7 @@ sub run {
     # Also panic when softlockup
     # workaround bsc#1104778, skip s390x in 12SP4
     assert_script_run('echo "kernel.softlockup_panic = 1" >> /etc/sysctl.conf');
-    my $output = script_output('sysctl -p');
+    my $output = script_output('sysctl -p', 10, proceed_on_failure => 1);
     unless ($output =~ /kernel.softlockup_panic = 1/) {
         record_soft_failure 'bsc#1104778';
     }


### PR DESCRIPTION
After https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5645, when script_output fail, test process will stop. See: https://openqa.suse.de/tests/2023999#step/enable_kdump/10
Simple modify to continue process for softfail.

- Verification run: http://10.67.133.102/tests/664#step/enable_kdump/12
