### PR TITLE
Add soft failure for missing samba directives

### DIFF
--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -56,6 +56,7 @@ sub smb_conf_checker {
 
     if ($error ne "") {
         assert_script_run("echo \"$error\" > /tmp/failed_smb_directives.log");
+        return record_soft_failure "bsc#1106876 - Missing smb.conf directives" if (is_sle('>=15') || is_leap('>=15.0'));
         die 'Missing smb.conf directives';
     }
 }


### PR DESCRIPTION
Add soft failure for missing samba directives while the [bug](https://bugzilla.suse.com/show_bug.cgi?id=1106876) is fixed, so automation can continue testing other YaST modules.

- Related ticket: https://progress.opensuse.org/issues/40067
- Needles: not needed
- Verification run: [sle-15-SP1-yast2_ncurses](http://dhcp87.suse.cz/tests/2610#step/yast2_samba/98)
