### PR TITLE
Add new test for ca-certificates-mozilla

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1511,6 +1511,7 @@ sub load_extra_tests_console {
     loadtest "console/sysstat";
     loadtest "console/curl_ipv6";
     loadtest "console/wget_ipv6";
+    loadtest "console/ca_certificates_mozilla";
     loadtest "console/unzip";
     loadtest "console/salt" if is_jeos;
     loadtest "console/gpg";

--- a/tests/console/ca_certificates_mozilla.pm
+++ b/tests/console/ca_certificates_mozilla.pm
@@ -1,0 +1,24 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: QAM regression testing
+# Maintainer: Orestis Nalmpantis <onalmpantis@suse.de>
+
+use base "consoletest";
+use strict;
+use testapi;
+use utils 'zypper_call';
+
+sub run {
+    select_console 'root-console';
+    zypper_call 'in ca-certificates-mozilla openssl';
+    assert_script_run('echo "x" | openssl s_client -connect static.opensuse.org:443 | grep "Verify return code: 0"');
+}
+
+1;


### PR DESCRIPTION
Include QA Maintenance regression tests in openQA.

- Related ticket: https://progress.opensuse.org/issues/40721
- Needles: *not needed*
- Verification run: http://onalmpantis.suse.de/tests/33#step/ca_certificates_mozilla/1