### PR TITLE
Cleanup workaround from zypper_lifecycle.pm

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1176,8 +1176,7 @@ sub load_consoletests {
         loadtest "console/xfce_gnome_deps";
     }
     if (!is_staging() && is_sle && sle_version_at_least('12-SP2')) {
-        # This test uses serial console too much to be reliable on Hyper-V. See (poo#30613)
-        loadtest "console/zypper_lifecycle" unless is_hyperv;
+        loadtest "console/zypper_lifecycle";
         if (check_var_array('SCC_ADDONS', 'tcm') && !sle_version_at_least('15')) {
             loadtest "console/zypper_lifecycle_toolchain";
         }

--- a/tests/console/zypper_lifecycle.pm
+++ b/tests/console/zypper_lifecycle.pm
@@ -35,16 +35,10 @@ sub run {
     # 3. verify that "zypper lifecycle" shows correct package eol based on the
     # data from step 2
     my ($base_repos, $package, $prod);
-    # Workaround for poo#30613, surround product with >< and use these markers for parsing
-    my $output = script_output "echo '>>>'\$(basename `readlink /etc/products.d/baseproduct ` .prod)'<<<'";
-    if ($output =~ />>>(?<prod>.+)<<</) {
-        $prod = $+{prod};
-    }
-    die "Could not parse product (see poo#30613):\nOutput: '$output'" unless $prod;
-
+    my $prod = script_output 'basename `readlink /etc/products.d/baseproduct ` .prod';
     # select a package suitable for the following test
     # the package must be installed from base product repo
-    $output = script_output 'echo $(zypper -n -x se -i -t product -s ' . $prod . ')', 300;
+    my $output = script_output 'echo $(zypper -n -x se -i -t product -s ' . $prod . ')', 300;
     # Parse base repositories
     if (my @repos = $output =~ /repository="([^"]+)"/g) {
         $base_repos = join(" ", @repos);


### PR DESCRIPTION
- workaround for serial output which are not required anymore
- see https://progress.opensuse.org/issues/38417 and
  workaround for https://progress.opensuse.org/issues/30613
- verification run:
  http://e13.suse.de/tests/7992#step/zypper_lifecycle
