### PR TITLE
[Urgent] Add first system configuration step after offline upgrade from SLES-11-SP4

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -70,8 +70,22 @@ sub login_to_console {
     save_screenshot;
     send_key 'ret';
 
-    assert_screen(['linux-login', 'virttest-displaymanager'], $timeout);
+    my $host_installed_version = get_var('VERSION_TO_INSTALL', get_var('VERSION', ''));
+    ($host_installed_version) = $host_installed_version =~ /^(\d+)/;
+    if (check_var('offline_upgrade', 'yes') && ($host_installed_version eq '11')) {
+        assert_screen('sshd-server-started-config', 180);
+        use_ssh_serial_console;
+        save_screenshot;
+        #start system first configuration after finishing upgrading from sles-11-sp4
+        type_string("yast.ssh\n");
+        assert_screen('will-linux-login', $timeout);
+        select_console('sol', await_console => 0);
+        save_screenshot;
+        send_key 'ret';
+        save_screenshot;
+    }
 
+    assert_screen(['linux-login', 'virttest-displaymanager'], $timeout);
     #use console based on ssh to avoid unstable ipmi
     use_ssh_serial_console;
 }


### PR DESCRIPTION
Add first system configuration step after offline upgrade from SLES-11-SP4

'linux-login' needle can not be matched up when it comes to offline upgrade
from SLES-11-SP4, because there is one more extra step, first system
configuration, needs to be performed after finishing upgrade process.
Otherwise, the upgraded system will not boot into 'linux login' anyway.

- Related ticket: https://openqa.suse.de/tests/2030117#step/reboot_and_wait_up_upgrade/46
- Needles: n/a
- Verification run: https://10.67.17.5/tests/89

@alice-suse @XGWang0 @xguo @Julie-CAO