### PR TITLE
Handle encrypt booting in case of inst-bootmenu matched

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -410,10 +410,18 @@ sub wait_boot {
             # harddisk' is above
             send_key_until_needlematch 'inst-bootmenu-boot-harddisk', 'up';
             boot_local_disk;
-            check_screen(['grub2', 'tianocore-mainmenu'], 15)
+
+            my @tags = qw(grub2 tianocore-mainmenu);
+            push @tags, 'encrypted-disk-password-prompt' if (get_var('ENCRYPT'));
+
+            check_screen(\@tags, 15)
               || die 'niether grub2 or tianocore-mainmenu needles found';
             if (match_has_tag('tianocore-mainmenu')) {
                 $self->handle_uefi_boot_disk_workaround();
+                check_screen('encrypted-disk-password-prompt', 10);
+            }
+            if (match_has_tag('encrypted-disk-password-prompt')) {
+                workaround_type_encrypted_passphrase;
                 assert_screen('grub2');
             }
         }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/40601
https://progress.opensuse.org/issues/40604
- Needles: N/A
- Verification run: 
aarch64 - http://openqa-apac1.suse.de/tests/1680#step/boot_to_desktop/19
ppc64le - no worker to prove
