### PR TITLE
Apply custom COM port settings

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -116,11 +116,12 @@ sub setup_console_in_grub {
     if ($grub_ver eq "grub2") {
         #grub2
         if (${virt_type} eq "xen") {
+            my $com_settings = get_var('IPMI_CONSOLE') ? "com2=" . get_var('IPMI_CONSOLE') : "";
             $cmd
               = "cp $grub_cfg_file ${grub_cfg_file}.org "
               . "\&\& sed -ri '/(multiboot|module\\s*.*vmlinuz)/ "
               . "{s/(console|loglevel|log_lvl|guest_loglvl)=[^ ]*//g; "
-              . "/multiboot/ s/\$/ console=com2,115200 log_lvl=all guest_loglvl=all sync_console/; "
+              . "/multiboot/ s/\$/ console=com2,115200 log_lvl=all guest_loglvl=all sync_console $com_settings/; "
               . "/module\\s*.*vmlinuz/ s/\$/ console=$ipmi_console,115200 console=tty loglevel=5/;}; "
               . "s/timeout=-{0,1}[0-9]{1,}/timeout=30/g;"
               . "' $grub_cfg_file";


### PR DESCRIPTION
Some HW machines can have different COM settings for SOL over IPMI. This commit introduces new variable to set the redirection settings (baud, irq, ...) for XEN.

- Related ticket: https://progress.opensuse.org/issues/40685
- Verification runs: 
  - http://panigale.suse.cz/tests/84
  - http://panigale.suse.cz/tests/85
