### PR TITLE
Run systemd_testsuite in extratests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1506,6 +1506,9 @@ sub load_extra_tests_textmode {
     }
     # bind need source package and legacy and development module on SLE15+
     loadtest 'console/bind' if get_var('MAINT_TEST_REPO');
+    if (is_sle('>=15')) {
+        loadtest 'console/systemd_testsuite';
+    }
     loadtest 'console/mdadm' unless is_jeos;
     if (get_var("SYSAUTHTEST")) {
         # sysauth test scenarios run in the console

--- a/tests/console/systemd_testsuite.pm
+++ b/tests/console/systemd_testsuite.pm
@@ -22,6 +22,9 @@ sub run {
     if (is_leap('=15.0')) {
         $qa_head_repo = 'https://download.opensuse.org/repositories/devel:/openSUSE:/QA:/Leap:/15/openSUSE_Leap_15.0/';
     }
+    elsif (is_sle('=15')) {
+        $qa_head_repo = 'http://download.suse.de/ibs/QA:/SLE15/standard/';
+    }
 
     # install systemd testsuite
     select_console 'root-console';


### PR DESCRIPTION
Use systemd_testsuite in mau-extratests and make sure QA:/SLE15/standard repository, where package systemd-qa-testsuite resides, is used for SLE 15 instead of QA:Head.

- Related ticket: https://progress.opensuse.org/issues/40391
- Needles: 
- Verification run: http://hoorhay.suse.cz/tests/17
