### PR TITLE
Change pattern for finding root partition

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -194,11 +194,8 @@ sub get_installation_partition {
     # For details, please refer to bug 1101806.
     my $cmd        = '';
     my $y2log_file = '/var/log/YaST2/y2log';
-    if (is_sle('15+')) {
-        $cmd = qq{grep 'Commit Action "Adding mount point / of .* to /etc/fstab"' $y2log_file | grep -o "/dev/[^ ]*"};
-    }
-    elsif (is_sle('12+')) {
-        $cmd = qq{sed -n '/INSTALL INFO info:Adding entry for mount point \\\/ to \\\/etc\\\/fstab/{x;p};h' $y2log_file | grep -o "/dev/[^ ]*"};
+    if (is_sle('12+')) {
+        $cmd = qq{grep -o '/dev/[^ ]\\+ /mnt ' $y2log_file | head -n1 | cut -f1 -d' '};
     }
     else {
         die "Not support finding root partition for products lower than sle12.";


### PR DESCRIPTION
Installation log in SLE15 / SLE12-SP3 has no such lines. However, there should be a line from fstab which we can find with a simpler regex.

- Related ticket: https://progress.opensuse.org/issues/40634
- Verification runs: 
  - http://panigale.suse.cz/tests/84 (SLE12-SP3)
  - http://panigale.suse.cz/tests/123 (SLE12-SP4)
  - http://panigale.suse.cz/tests/85 (SLE15)
  - http://panigale.suse.cz/tests/151 (SLE12-SP3 textmode)
  - http://panigale.suse.cz/tests/154 (SLE12-SP4 textmode)
  - http://panigale.suse.cz/tests/165 (SLE15 textmode)
