### PR TITLE
Use yast2 migration ncurses for s390x

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -140,6 +140,9 @@ if (sle_version_at_least('15')) {
 # For released products we want install updates during installation, only in minimal workflow disable
 set_var('DISABLE_SLE_UPDATES', get_var('DISABLE_SLE_UPDATES', get_var('QAM_MINIMAL')));
 
+# set remote connection variable for s390x, svirt and ipmi
+set_var('REMOTE_CONNECTION', 'vnc') if get_var('BACKEND', '') =~ /s390x|svirt|ipmi/;
+
 # Set serial console for Xen PV
 if (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')) {
     if (sle_version_at_least('12-SP2')) {

--- a/tests/migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/migration/sle12_online_migration/yast2_migration.pm
@@ -17,10 +17,17 @@ use utils;
 use power_action_utils 'power_action';
 use version_utils 'is_desktop_installed';
 
+sub yast2_migration_gnome_remote {
+    return check_var('MIGRATION_METHOD', 'yast') && check_var('DESKTOP', 'gnome') && get_var('REMOTE_CONNECTION');
+}
+
 sub run {
     my $self = shift;
 
-    if (!is_desktop_installed()) {
+    # According to bsc#1106017, use yast2 migration in gnome environment is not possible on s390x
+    # due to vnc session over xinetd service could be stopped during migration that cause gnome exit
+    # so use yast2 migration under root console
+    if (!is_desktop_installed() || yast2_migration_gnome_remote) {
         select_console 'root-console';
     }
     else {


### PR DESCRIPTION
According to bsc#1106017, use yast2 migration in gnome environment is not possible on s390x due to vnc session over xinetd service could be stopped during migration that cause current gnome session exit.
See: https://bugzilla.suse.com/show_bug.cgi?id=1106017

- Related ticket: https://progress.opensuse.org/issues/40763
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/933
- Verification run: http://openqa-apac1.suse.de/tests/1674#step/yast2_migration/15