### PR TITLE
Adjust timeout when switching language in TW

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -226,7 +226,7 @@ sub verify_license_translations {
     for my $language (split(/,/, get_var('EULA_LANGUAGES')), 'english-us') {
         wait_screen_change { send_key 'alt-l' };
         send_key 'home';
-        send_key_until_needlematch("license-language-selected-$language", 'down', 60, 1);
+        send_key_until_needlematch("license-language-selected-$language", 'down', 60, 3);
         assert_screen "license-content-$language";    # needs wait for loading content
     }
 }


### PR DESCRIPTION
 We need to adjust timeout to avoid in prod [Tumbleweed-installer_extended_welcome](https://openqa.opensuse.org/tests/752172) (in local VR works)

- Related ticket: https://progress.opensuse.org/issues/40040