### PR TITLE
Close gnucash with mouse click

### DIFF
--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -32,16 +32,10 @@ sub run {
         send_key 'alt-c';
         assert_screen('test-gnucash-tips-closed');
     }
-    send_key 'ctrl-q';    # Exit
+    assert_and_click('gnucash-close-window');
+    assert_and_click('gnucash-close-without-saving-changes');
 
-    # arbitrary limit
-    for (1 .. 7) {
-        assert_screen [qw(test-gnucash-1 gnucash gnucash-save-changes generic-desktop)];
-        last              if match_has_tag 'generic-desktop';
-        send_key 'alt-c'  if match_has_tag 'test-gnucash-1';
-        send_key 'alt-w'  if match_has_tag 'gnucash-save-changes';
-        send_key 'ctrl-q' if match_has_tag 'gnucash';
-    }
+    assert_screen('generic-desktop');
 }
 
 1;


### PR DESCRIPTION
An sporadic race condition happened
when the loop iterates faster than the display updates.

**gnucash** is a GUI test, mouse clicks should be ok.

- Related ticket: https://progress.opensuse.org/issues/40319
- **Merge needles first**: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/436
- Verification run: http://10.160.66.74/tests/overview?build=github_5745 (10 of 10 passed. 10 are enough since I was always able to reproduce the race condition on at least 4 of 10 before these changes)
