### PR TITLE
Use correct variable for debug info repo

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -73,8 +73,7 @@ sub prepare_for_kdump {
         return;
     }
 
-    if (get_var('REPO_0_DEBUGINFO')) {
-        my $snapshot_debuginfo_repo = get_var('REPO_0_DEBUGINFO');
+    if (my $snapshot_debuginfo_repo = get_var('REPO_OSS_DEBUGINFO')) {
         zypper_call('ar -f ' . get_var('MIRROR_HTTP') . "-debuginfo $snapshot_debuginfo_repo");
         install_kernel_debuginfo;
         script_run "zypper -n rr $snapshot_debuginfo_repo";


### PR DESCRIPTION
After we have renamed REPO_O_DEBUG to be tracked properly by GRU, it
broke test which used that variable, so use correct one.

See [poo#40286](https://progress.opensuse.org/issues/40286).

[Verification run](http://g226.suse.de/tests/2557#step/kdump_and_crash/6).