### PR TITLE
Add service widget for samba in TW

### DIFF
--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -177,7 +177,7 @@ sub setup_samba {
 
     # service starts during boot, wait to load default data
     assert_screen 'yast2_samba-startup-configuration';
-    if (is_sle('<15') || is_leap('<15.1') || is_tumbleweed) {
+    if (is_sle('<15') || is_leap('<15.1')) {
         send_key 'alt-r';
         assert_screen 'yast2_samba-server_start-during-boot';
     }


### PR DESCRIPTION
TW just got service widget in [samba module](https://openqa.opensuse.org/tests/752405#step/yast2_samba/31)
- Related ticket: https://progress.opensuse.org/issues/40067

