### PR TITLE
Introduce lvm thin for sle

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -84,6 +84,7 @@ sub init_cmd {
       toggle_home alt-p
       raw_volume alt-a
       enable_snapshots alt-n
+      system_view alt-s
     );
 
     if (check_var('INSTLANG', "de_DE")) {

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -49,7 +49,6 @@ sub run {
         $cmd{resize}           = 'alt-r';
         $cmd{raw_volume}       = 'alt-r';
         $cmd{enable_snapshots} = 'alt-a';
-        $cmd{system_view}      = 'alt-s';
         # Set shortcut for role selection when creating partition
         $partition_roles{raw} = $cmd{raw_volume};
 

--- a/tests/installation/partitioning_full_lvm.pm
+++ b/tests/installation/partitioning_full_lvm.pm
@@ -22,24 +22,7 @@ use version_utils 'is_storage_ng';
 
 sub run {
     create_new_partition_table;
-    if (get_var('OFW')) {    # ppc64le always needs PReP boot
-        addpart(role => 'raw', size => 8, fsid => 'PReP');
-    }
-    elsif (get_var('UEFI')) {    # UEFI needs partition mounted to /boot/efi for
-        addpart(role => 'efi', size => 256);
-    }
-    elsif (is_storage_ng && check_var('ARCH', 'x86_64')) {
-        # Storage-ng has GPT by defaut, so need bios-boot partition for legacy boot, which is only on x86_64
-        addpart(role => 'raw', fsid => 'bios-boot', size => 2);
-    }
-    elsif (check_var('ARCH', 's390x')) {
-        # s390x need /boot/zipl on ext partition
-        addpart(role => 'OS', size => 500, format => 'ext2', mount => '/boot/zipl');
-    }
-
-    if (get_var('UNENCRYPTED_BOOT')) {
-        addpart(role => 'OS', size => 500, format => 'ext2', mount => '/boot');
-    }
+    addboot;
 
     addpart(role => 'raw', encrypt => 1);
     assert_screen 'expert-partitioner';

--- a/tests/installation/partitioning_lvm_thin_provisioning.pm
+++ b/tests/installation/partitioning_lvm_thin_provisioning.pm
@@ -15,16 +15,16 @@ use strict;
 use warnings;
 use base 'y2logsstep';
 use testapi;
-use partition_setup qw(create_new_partition_table addpart addlv addvg);
+use partition_setup qw(create_new_partition_table addpart addlv addvg addboot);
 use version_utils 'is_storage_ng';
 
 sub run {
     create_new_partition_table;
+    addboot if is_storage_ng;
     # create boot and 2 lvm partitions
-    addpart(role => 'raw', fsid => 'bios-boot', size => 2);
-    addpart(role => 'raw', size => 10000);
-    addpart(role => 'raw');
-    # create volume group for root and swap non thin lvs
+    addpart(role => 'raw', size => 15000);    #rootfs + swap
+    addpart(role => 'raw');                   # home on thin lv
+                                              # create volume group for root and swap non thin lvs
     addvg(name => 'vg-no-thin');
     addlv(name => 'lv-swap', role => 'swap', size => 2000);
     addlv(name => 'lv-root', role => 'OS');
@@ -32,6 +32,7 @@ sub run {
     addvg(name => 'vg-thin');
     addlv(name => 'thin_pool', thinpool => 1);
     addlv(name => 'thin_lv_home', role => 'data', thinvolume => 1);
+    save_screenshot;
     send_key $cmd{accept};
 
 }


### PR DESCRIPTION
As the initial part we need to introduce a common function for adding boot partition, which won't break existing tests (e.g. lvm-full-encrypt)

- Related ticket: [[sle][functional][yast][y][mandatory][medium] LVM Thin Provisioning on SLE](https://progress.opensuse.org/issues/39026)
- Verification runs: [sle-15-SP1-Installer-DVD-x86_64-Build35.18-lvm-full-encrypt@64bit](http://dhcp128.suse.cz/tests/6089#step/partitioning_full_lvm/1)
[sle-12-SP4-Server-DVD-x86_64-Build0378-lvm-full-encrypt@64bit](http://dhcp128.suse.cz/tests/6094#step/partitioning_full_lvm/1)\

LVM thin test suite:
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/937
- Verification runs: [sle-15-SP1-Installer-DVD-x86_64-Build35.18-lvm_thin_volumes@64bit](http://dhcp128.suse.cz/tests/6129)

Sle12SP4 fails on bsc#1027586
