### PR TITLE
Handle network manager default in openSUSE

### DIFF
--- a/lib/y2_common.pm
+++ b/lib/y2_common.pm
@@ -1,0 +1,57 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: This module provides common subroutines for YaST2 modules in graphical and text mode
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.com>
+
+package y2_common;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use testapi;
+use version_utils qw(is_opensuse is_leap);
+
+our @EXPORT = qw(is_network_manager_default
+  continue_info_network_manager_default
+  accept_warning_network_manager_default
+);
+
+=head2 is_network_manager_default
+openSUSE has network manager as default except for older leap versions
+=cut
+sub is_network_manager_default {
+    return is_opensuse unless is_leap('<=15.0');
+}
+
+=head2 continue_info_network_manager_default
+Click on Continue when appears info indicating that network interfaces are controlled by Network Manager
+=cut
+sub continue_info_network_manager_default {
+    if (is_network_manager_default) {
+        assert_screen 'yast2-lan-warning-network-manager';
+        send_key $cmd{continue};
+    }
+}
+
+=head2 accept_warning_network_manager_default
+Click on OK when appears a warning indicating that network interfaces are controlled by Network Manager
+=cut
+sub accept_warning_network_manager_default {
+    if (is_network_manager_default) {
+        $cmd{overview_tab} = 'alt-v';
+        assert_screen 'yast2-lan-warning-network-manager';
+        send_key $cmd{ok};
+        assert_screen 'yast2_lan-global-tab';
+        send_key $cmd{overview_tab};
+    }
+}
+
+1;

--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -18,6 +18,7 @@ use Exporter 'import';
 use testapi;
 use utils 'systemctl';
 use version_utils qw(is_sle is_leap);
+use y2_common 'accept_warning_network_manager_default';
 
 our @EXPORT_OK = qw(
   initialize_y2lan
@@ -45,6 +46,7 @@ sub initialize_y2lan {
 
 sub open_network_settings {
     type_string "yast2 lan\n";
+    accept_warning_network_manager_default;
     assert_screen 'yast2_lan', 100;       # yast2 lan overview tab
     wait_still_screen(2);
 }

--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -15,7 +15,8 @@ use base qw(console_yasttest y2logsstep);
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_leap is_sle sle_version_at_least);
+use version_utils qw(is_leap is_sle);
+use y2_common 'continue_info_network_manager_default';
 use constant RETRIES => 5;
 # Test "yast2 dhcp-server" functionality
 # Ensure that all combinations of running/stopped and active/inactive
@@ -78,7 +79,7 @@ sub run {
     # First execution (wizard-like interface)
     #
     script_run 'yast2 dns-server', 0;
-    # Just do next-next until the last step
+    continue_info_network_manager_default;
     assert_screen 'yast2-dns-server-step1';
     send_key 'alt-n';
     assert_screen 'yast2-dns-server-step2';
@@ -114,6 +115,7 @@ sub run {
     # Second execution (tree-based interface)
     #
     script_run 'yast2 dns-server', 0;
+    continue_info_network_manager_default;
     if (is_sle('<15') || is_leap('<15.1')) {
         assert_screen([qw(yast2-service-running-enabled yast2_still_susefirewall2)], 90);
         if (match_has_tag 'yast2_still_susefirewall2') {
@@ -140,6 +142,7 @@ sub run {
     # Third execution (tree-based interface)
     #
     script_run 'yast2 dns-server', 0;
+    continue_info_network_manager_default;
     if (is_sle('<15') || is_leap('<15.1')) {
         assert_screen 'yast2-service-stopped-enabled';
         # Start the service
@@ -160,6 +163,7 @@ sub run {
     # Fourth execution (tree-based interface)
     #
     script_run 'yast2 dns-server', 0;
+    continue_info_network_manager_default;
     if (is_sle('<15') || is_leap('<15.1')) {
         assert_screen 'yast2-service-running-disabled', 90;
         # Stop the service

--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -15,6 +15,7 @@ use base "console_yasttest";
 use testapi;
 use utils 'zypper_call';
 use version_utils qw(is_sle is_leap);
+use y2_common 'continue_info_network_manager_default';
 
 sub run {
     my $self = shift;
@@ -23,6 +24,7 @@ sub run {
     # install http server
     zypper_call("-q in yast2-http-server");
     script_run("yast2 http-server; echo yast2-http-server-status-\$? > /dev/$serialdev", 0);
+    continue_info_network_manager_default;
     assert_screen 'http-server', 180;    # check page "Initializing HTTP Server Configuration"
     wait_still_screen 1;
     send_key 'alt-i';                    # make sure that apache2, apache2-prefork packages needs to be installed

--- a/tests/console/yast2_lan_hostname.pm
+++ b/tests/console/yast2_lan_hostname.pm
@@ -15,28 +15,35 @@ use base "console_yasttest";
 use strict;
 use testapi;
 use utils;
+use y2_common 'accept_warning_network_manager_default';
 
 sub hostname_via_dhcp {
     my $dhcp = shift;
 
+    # keyboard shortcuts
+    $cmd{hostname_dns_tab} = 'alt-s';
+    $cmd{home}             = 'home';
+    $cmd{spc}              = 'spc';
+
     type_string "yast2 lan\n";
+    accept_warning_network_manager_default;
     assert_screen([qw(yast2_lan yast2_still_susefirewall2)], 90);
     if (match_has_tag 'yast2_still_susefirewall2') {
         record_soft_failure "bsc#1059569";
-        send_key 'alt-i';
+        send_key $cmd{install};
         assert_screen 'yast2_lan';
     }
-
-    send_key "alt-s";    # open hostname tab
+    # Hostname/DNS tab
+    send_key $cmd{hostname_dns_tab};
     assert_screen "yast2_lan-hostname-tab";
     for (1 .. 4) { send_key 'tab' }    # go to roll-down list
     wait_screen_change { send_key 'down'; };    # open roll-down list
-    send_key('home');                               # go to the top of list
+    send_key $cmd{home};
     assert_screen("yast2_lan-hostname-DHCP-no");    # check that topmost option is selected
     send_key_until_needlematch "yast2_lan-hostname-DHCP-$dhcp", 'down';
-    wait_screen_change { send_key 'spc'; };         # pick selected option
+    wait_screen_change { send_key $cmd{spc}; };
     assert_screen "yast2_lan-hostname-DHCP-$dhcp-selected";    # make sure that the option is actually selected
-    send_key 'alt-o';                                          # OK=>Save&Exit
+    send_key $cmd{ok};
     assert_screen 'console-visible';                           # yast module exited
     wait_still_screen;
     if ($dhcp eq 'no') {
@@ -67,4 +74,3 @@ sub post_fail_hook {
 }
 
 1;
-

--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -16,6 +16,7 @@ use base 'y2logsstep';
 use strict;
 use testapi;
 use y2lan_restart_common qw(initialize_y2lan verify_network_configuration);
+use y2_common 'is_network_manager_default';
 
 sub check_network_settings_tabs {
     send_key 'alt-g';    # Global options tab
@@ -75,9 +76,11 @@ sub run {
     initialize_y2lan;
     verify_network_configuration;    # check simple access to Overview tab
     verify_network_configuration(\&check_network_settings_tabs);
-    verify_network_configuration(\&check_network_card_setup_tabs);
-    verify_network_configuration(\&check_default_gateway);
-    verify_network_configuration(\&change_hw_device_name, 'dyn0', 'restart');
+    unless (is_network_manager_default) {
+        verify_network_configuration(\&check_network_card_setup_tabs);
+        verify_network_configuration(\&check_default_gateway);
+        verify_network_configuration(\&change_hw_device_name, 'dyn0', 'restart');
+    }
     type_string "killall xterm\n";
 }
 


### PR DESCRIPTION
Handle network manager default in openSUSE
- Related ticket: https://progress.opensuse.org/issues/40067
- Needles: [needles opensuse](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/437)
- Verification run: 
  - [Tumbleweed-yast2_ncurses](http://dhcp87.suse.cz/tests/2731)
  - [Tumbleweed-yast2_gui](http://dhcp87.suse.cz/tests/2730)
  - [Tumbleweed-extra_tests_on_gnome](http://dhcp87.suse.cz/tests/2729)