### PR TITLE
LTP: Fix regression in is_ltp_test()

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -222,8 +222,7 @@ sub packagekit_available {
 
 sub is_ltp_test {
     return (get_var('INSTALL_LTP')
-          || get_var('LTP_COMMAND_FILE')
-          || get_var('NVMFTESTS'));
+          || get_var('LTP_COMMAND_FILE'));
 }
 
 sub is_kernel_test {


### PR DESCRIPTION
NVMFTESTS are kernel tests, but obviously not LTP tests.
NVMFTESTS now treat serial failures as hard failures.

Fixes: c98fa9e9 LTP: Make all serial failures soft only