### PR TITLE
Fix grub_test on cryptlvm and aarch64

### DIFF
--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -49,12 +49,14 @@ sub handle_installer_medium_bootup {
             assert_screen 'grub2';
         }
         # use firmware boot manager of aarch64 to boot upgraded system
-        if (check_var('ARCH', 'aarch64') && get_var('UPGRADE')) {
+        if (check_var('ARCH', 'aarch64')) {
             send_key_until_needlematch 'inst-bootmenu-boot-harddisk', 'up';
             send_key 'ret';
             $self->handle_uefi_boot_disk_workaround;
         }
         else {
+            # we need to assure that we boot from the disk
+            send_key_until_needlematch 'inst-bootmenu-boot-harddisk', 'up';
             send_key 'ret';
         }
     }


### PR DESCRIPTION
Now checking whether booting from the correct device as intended

I wonder why we had that much luck for such a long time

- Related ticket: https://progress.opensuse.org/issues/40127
- Verification run: http://pinky.arch.suse.de/tests/1453#
