### PR TITLE
Revert "Close gnucash with mouse click"

### DIFF
--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -32,10 +32,16 @@ sub run {
         send_key 'alt-c';
         assert_screen('test-gnucash-tips-closed');
     }
-    assert_and_click('gnucash-close-window');
-    assert_and_click('gnucash-close-without-saving-changes');
+    send_key 'ctrl-q';    # Exit
 
-    assert_screen('generic-desktop');
+    # arbitrary limit
+    for (1 .. 7) {
+        assert_screen [qw(test-gnucash-1 gnucash gnucash-save-changes generic-desktop)];
+        last              if match_has_tag 'generic-desktop';
+        send_key 'alt-c'  if match_has_tag 'test-gnucash-1';
+        send_key 'alt-w'  if match_has_tag 'gnucash-save-changes';
+        send_key 'ctrl-q' if match_has_tag 'gnucash';
+    }
 }
 
 1;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#5745 to fix TW testing, see https://progress.opensuse.org/issues/40319#note-9