### PR TITLE
Add URL error judgement for zypper migration

### DIFF
--- a/tests/migration/sle12_online_migration/zypper_migration.pm
+++ b/tests/migration/sle12_online_migration/zypper_migration.pm
@@ -31,6 +31,7 @@ sub run {
     my $zypper_migration_notification = qr/^View the notifications now\? \[y/m;
     my $zypper_migration_failed       = qr/^Migration failed/m;
     my $zypper_migration_license      = qr/Do you agree with the terms of the license\? \[y/m;
+    my $zypper_migration_urlerror     = qr/URI::InvalidURIError/m;
 
     # start migration
     script_run("(zypper migration;echo ZYPPER-DONE) | tee /dev/$serialdev", 0);
@@ -70,7 +71,8 @@ sub run {
         }
         elsif ($out =~ $zypper_migration_conflict
             || $out =~ $zypper_migration_fileconflict
-            || $out =~ $zypper_migration_failed)
+            || $out =~ $zypper_migration_failed
+            || $out =~ $zypper_migration_urlerror)
         {
             $self->result('fail');
             save_screenshot;


### PR DESCRIPTION
Add the URL error judgement for zypper migration to report an error, so won't show an unexpected pass here.

- Related ticket: https://progress.opensuse.org/issues/40700
- Verification run: http://openqa-apac1.suse.de/tests/1684#step/zypper_migration/4
