### PR TITLE
Close gnucash with mouse click

### DIFF
--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -14,6 +14,7 @@
 use base "x11test";
 use strict;
 use testapi;
+use version_utils 'is_leap';
 
 sub run {
     ensure_installed('gnucash gnucash-docs yelp');
@@ -32,16 +33,8 @@ sub run {
         send_key 'alt-c';
         assert_screen('test-gnucash-tips-closed');
     }
-    send_key 'ctrl-q';    # Exit
-
-    # arbitrary limit
-    for (1 .. 7) {
-        assert_screen [qw(test-gnucash-1 gnucash gnucash-save-changes generic-desktop)];
-        last              if match_has_tag 'generic-desktop';
-        send_key 'alt-c'  if match_has_tag 'test-gnucash-1';
-        send_key 'alt-w'  if match_has_tag 'gnucash-save-changes';
-        send_key 'ctrl-q' if match_has_tag 'gnucash';
-    }
+    assert_and_click('gnucash-close-window');
+    assert_and_click('gnucash-close-without-saving-changes') if (is_leap('<=15.1'));
 }
 
 1;


### PR DESCRIPTION
An sporadic race condition happened when the loop iterated faster than the display updates.

**gnucash** is a GUI test, mouse clicks should be ok.

- Related ticket: https://progress.opensuse.org/issues/40319
- **Please merge needles first**: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/439

## Verification run:

|                      | gnome             | kde                  | xfce                 | lxde                  |
| ---------------- | ------------------ | ------------------- | ------------------ | ------------------ |
| Tumbleweed | [tw-gnome](http://slindomansilla-vm.qa.suse.de/tests/94) | [10x tw-kde](http://slindomansilla-vm.qa.suse.de/tests/overview?build=poo_40319-gnucash) (4 of 10 failing on **ensure_installed**. See [PR#5830](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5830)) | [tw-xfce](http://slindomansilla-vm.qa.suse.de/tests/108) (Fails on **ensure_installed**, see [PR#5830](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5830)) | [tw-lxde](http://slindomansilla-vm.qa.suse.de/tests/111) |
| Leap 15.1     | [leap15.1-gnome](http://slindomansilla-vm.qa.suse.de/tests/96) | [leap15.1-kde](http://slindomansilla-vm.qa.suse.de/tests/97) | [leap15.1-xfce](http://slindomansilla-vm.qa.suse.de/tests/115) | N/A |
| Leap 15        | [leap15.0-gnome](http://slindomansilla-vm.qa.suse.de/tests/117) | [leap15.0-kde](http://slindomansilla-vm.qa.suse.de/tests/122) | [leap15.0-xfce](http://slindomansilla-vm.qa.suse.de/tests/133) | N/A |
| Leap 42.3     | (coming soon) | (coming soon) | (coming soon) | N/A |
