### PR TITLE
Increase limit to scroll through all modules

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -340,7 +340,7 @@ sub fill_in_registration_data {
                             next;
                         }
                     }
-                    send_key_until_needlematch ["scc-module-$addon", "scc-module-$addon-selected"], "down";
+                    send_key_until_needlematch ["scc-module-$addon", "scc-module-$addon-selected"], "down", 40;
                     if (match_has_tag("scc-module-$addon")) {
                         # checkmark the requested addon
                         assert_and_click "scc-module-$addon";


### PR DESCRIPTION
After adding more modules to SLE12, the default limit of 20 presses is not enough.

- Related ticket: 
  - https://progress.opensuse.org/issues/40916
  - https://progress.opensuse.org/issues/40961
- Verification run: http://panigale.suse.cz/tests/153#step/scc_registration/85
