### PR TITLE
Update rsync test

### DIFF
--- a/tests/console/rsync.pm
+++ b/tests/console/rsync.pm
@@ -18,6 +18,12 @@ use utils;
 use version_utils qw(is_opensuse is_sle is_jeos);
 
 sub run {
+    # try to install rsync if the test does not run on JeOS
+    if (!is_jeos) {
+        select_console 'root-console';
+        zypper_call('-t in rsync', dumb_term => 1);
+    }
+
     # create the folders and files that will be synced
     select_console('root-console');
     assert_script_run('mkdir /tmp/rsync_test_folder_a');


### PR DESCRIPTION
Add zypper in step for the cases where rsync is not installed by default

Related ticket: https://progress.opensuse.org/issues/40667

Validation runs: 
jeos: http://ccret.suse.cz/tests/1043
opensuse: http://ccret.suse.cz/tests/1047
opensuse_jeos: http://ccret.suse.cz/tests/1046#
sle: http://ccret.suse.cz/tests/1049
