### PR TITLE
Detect bsc#1063638 on btrfs

### DIFF
--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -32,6 +32,9 @@ sub run {
     else {
         $self->wait_boot(bootloader_time => $timeout, nologin => $nologin);
     }
+
+    # Detect btrfs balancing if filesystem is set to btrfs, or undef, as btrfs is default
+    push @{$self->{serial_failures}}, {type => 'soft', message => 'bsc#1063638', pattern => qr/BTRFS info.*relocating/} if get_var('SOFTFAIL_BSC1063638');
 }
 
 sub test_flags {

--- a/tests/console/force_scheduled_tasks.pm
+++ b/tests/console/force_scheduled_tasks.pm
@@ -30,6 +30,7 @@ sub settle_load {
 }
 
 sub run {
+    my ($self) = @_;
     select_console 'root-console';
 
     # show dmesg output in console during cron run
@@ -50,6 +51,11 @@ sub run {
 
     # return dmesg output to normal
     assert_script_run "dmesg -n 1";
+
+    # Detect btrfs balancing if filesystem is set to btrfs, or undef, as btrfs is default
+    if (get_var('FILESYSTEM', 'btrfs') eq 'btrfs' || get_var('SOFTFAIL_BSC1063638')) {
+        push @{$self->{serial_failures}}, {type => 'soft', message => 'bsc#1063638', pattern => qr/BTRFS info.*relocating/};
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
It's a bit tricky as we run btrfs maintenance tasks in the tests, so not
to have false positives we can put it after btrfs balancing is done, and
for other scenarios boot_to_desktop is the most common place, as for x11
tests we won't run consoletest_setup, and consoletest_setup has
force_scheduled_tasks after it, leading to the false positives.
Therefore, I would keep it that conservative and address scenarios which
are affected individually (e.g. yast_gui tests).

See [poo#39059](https://progress.opensuse.org/issues/39059).

#### Verification runs:
* [default](http://g226.suse.de/tests/2567#)
* [yast gui](http://g226.suse.de/tests/2568#)