### PR TITLE
Hyper-V: Simplify console check

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -530,8 +530,7 @@ sub hyperv_console_switch {
     die 'hyperv_console_switch: Console was not provided' unless $console;
     diag 'hyperv_console_switch: Console number was not provided' unless $nr;
     # If we are in VT, 'Alt-Fx' switch already worked
-    return if check_screen(["tty$nr-selected", 'text-logged-in-root', 'linux-login',
-            'installation', 'install-shell', 'install-shell2', 'inst-console', "$console"], 10);
+    return if check_screen('any-console', 10);
     # We are in X11 and wan't to switch to VT
     testapi::x11_start_program('xterm');
     self->distribution::script_sudo("exec chvt $nr; exit", 0);


### PR DESCRIPTION
It seems that too many needles were checked and it makes needle matching
too slow: https://openqa.suse.de/tests/2049289. Simpler needle is fine
though.

Validation runs:
* JeOS: http://nilgiri.suse.cz/tests/1190
* JeOS: http://nilgiri.suse.cz/tests/1195
* migration_offline_sle12sp3_minimalupdate_hyperv: http://nilgiri.suse.cz/tests/1197
* migration_zdup_offline_sle12sp3_allpatterns_fullupdate_hyperv: http://nilgiri.suse.cz/tests/1198