### PR TITLE
Add additional package update check

### DIFF
--- a/tests/update/updates_packagekit_kde.pm
+++ b/tests/update/updates_packagekit_kde.pm
@@ -29,7 +29,7 @@ sub run {
     ensure_unlocked_desktop;
     turn_off_kde_screensaver;
 
-    my @updates_installed_tags = qw(updates_none updates_available);
+    my @updates_installed_tags = qw(updates_none updates_available updates_available-tray);
     assert_screen [qw(updates_available-tray tray-without-updates-available)];
     if (match_has_tag 'updates_available-tray') {
         assert_and_click("updates_available-tray");
@@ -59,6 +59,19 @@ sub run {
             elsif (match_has_tag('updates_available')) {
                 # look again
                 if (check_screen 'updates_none', 0) {
+                    record_soft_failure 'boo#1041112';
+                    last;
+                }
+            }
+            # Check, if there are more updates available
+            elsif (match_has_tag('updates_available-tray')) {
+                # look again
+                if (check_screen 'updates_available-tray', 30) {
+                    assert_and_click("updates_available-tray");
+                }
+                else {
+                    # Make sure, that there are no updates, otherwise fail
+                    assert_screen 'updates_none';
                     record_soft_failure 'boo#1041112';
                     last;
                 }


### PR DESCRIPTION
Fix poo#41030: If there is zypper update in the queue, it is installed
first (before other packages). It is needed to do one more check for
available updates and repeat installation steps.

There was added check to stage when are updates installed. If there
is still need for package installation, it will repeat whole update procedure.
Workaround had to be implemented for delayed status of update widget.
If is such state detected, additional check for no updates is done. 

- Related ticket: https://progress.opensuse.org/issues/41030
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run:  http://10.100.12.105/tests/199#step/updates_packagekit_kde/1

1.Zypper update installation
http://10.100.12.105/tests/199#step/updates_packagekit_kde/12
2. Check for more updates
http://10.100.12.105/tests/199#step/updates_packagekit_kde/14
3. Installation of other updates
http://10.100.12.105/tests/199#step/updates_packagekit_kde/17
4. All updates installed/check for update 
http://10.100.12.105/tests/199#step/updates_packagekit_kde/19
5. Check for no updates
http://10.100.12.105/tests/199#step/updates_packagekit_kde/21
