### PR TITLE
Virtualization: add junit log for subcases in guest migration tests

### DIFF
--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -95,7 +95,8 @@ sub generateXML {
             status    => $case_status,
             time      => $my_hash{$item}->{time});
         $writer->startTag('system-err');
-        $writer->characters("None");
+        my $system_err = ($my_hash{$item}->{error} ? $my_hash{$item}->{error} : 'None');
+        $writer->characters("$system_err");
         $writer->endTag('system-err');
 
         $writer->startTag('system-out');


### PR DESCRIPTION
Add junit log to show the subtests as individual item in final result display.

- Verification run: http://10.67.18.220/tests/374
