### PR TITLE
Unschedule yast2_lan_restart_devices when Network Manager

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1438,7 +1438,7 @@ sub load_extra_tests_desktop {
     # well
     if (check_var('DESKTOP', 'gnome')) {
         loadtest 'x11/yast2_lan_restart';
-        loadtest 'x11/yast2_lan_restart_devices';
+        loadtest 'x11/yast2_lan_restart_devices' unless is_leap('<=15.0');
         # we only have the test dependencies, e.g. hostapd available in
         # openSUSE
         if (check_var('DISTRI', 'opensuse')) {


### PR DESCRIPTION
Missed my last commit in #5752 (probably I had some issues with rebase). This should unschedule the second part of the test as it doesn't make sense when Network Manager is default.

- Related ticket: https://progress.opensuse.org/issues/40067