### PR TITLE
Add soft-failure samba conf for TW

### DIFF
--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -14,7 +14,7 @@ use strict;
 use base "console_yasttest";
 use testapi;
 use utils;
-use version_utils qw(is_sle is_leap is_tumbleweed);
+use version_utils qw(is_sle is_leap is_tumbleweed is_opensuse);
 use y2logsstep;
 
 my %ldap_directives = (
@@ -56,7 +56,7 @@ sub smb_conf_checker {
 
     if ($error ne "") {
         assert_script_run("echo \"$error\" > /tmp/failed_smb_directives.log");
-        return record_soft_failure "bsc#1106876 - Missing smb.conf directives" if (is_sle('>=15') || is_leap('>=15.0'));
+        return record_soft_failure "bsc#1106876 - Missing smb.conf directives" if (is_sle('>=15') || is_opensuse);
         die 'Missing smb.conf directives';
     }
 }


### PR DESCRIPTION
Add soft-failure also for TW as seen [here](https://openqa.opensuse.org/tests/756861#step/yast2_samba/97)

- Related ticket: https://progress.opensuse.org/issues/40067
