### PR TITLE
Handle errors during autoyast installation with explicit tag

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -230,6 +230,8 @@ sub run {
         elsif (match_has_tag('autoyast-postpartscript')) {
             @needles = grep { $_ ne 'autoyast-postpartscript' } @needles;
             $postpartscript = 1;
+        } elsif (match_has_tag('autoyast-error')) {
+            die 'Error detected during first stage of the installation';
         }
     }
 
@@ -278,6 +280,8 @@ sub run {
         }
         elsif (match_has_tag('warning-pop-up')) {
             handle_warnings;    # Process warnings during stage 2
+        } elsif (match_has_tag('autoyast-error')) {
+            die 'Error detected during second stage of the installation';
         }
     }
 


### PR DESCRIPTION
We already handle some standard dialogs which throw errors, but used
warning-popup tag. Having explicit tag will remove possible confusion.

See [poo#17906](https://progress.opensuse.org/issues/17906).

- [Verification run](http://g226.suse.de/tests/2580).
