### PR TITLE
Fix referenced bug bsc#1059569

### DIFF
--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -88,7 +88,6 @@ sub run {
     if (is_sle('<15') || is_leap('<15.1')) {
         assert_screen([qw(yast2-dns-server-step3 yast2_still_susefirewall2)], 90);
         if (match_has_tag 'yast2_still_susefirewall2') {
-            record_soft_failure "bsc#1059569";
             send_key 'alt-i';
             assert_screen 'yast2-dns-server-step3';
         }
@@ -119,7 +118,6 @@ sub run {
     if (is_sle('<15') || is_leap('<15.1')) {
         assert_screen([qw(yast2-service-running-enabled yast2_still_susefirewall2)], 90);
         if (match_has_tag 'yast2_still_susefirewall2') {
-            record_soft_failure "bsc#1059569";
             send_key 'alt-i';
             assert_screen 'yast2-service-running-enabled';
         }

--- a/tests/console/yast2_lan_hostname.pm
+++ b/tests/console/yast2_lan_hostname.pm
@@ -29,7 +29,6 @@ sub hostname_via_dhcp {
     accept_warning_network_manager_default;
     assert_screen([qw(yast2_lan yast2_still_susefirewall2)], 90);
     if (match_has_tag 'yast2_still_susefirewall2') {
-        record_soft_failure "bsc#1059569";
         send_key $cmd{install};
         assert_screen 'yast2_lan';
     }

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -270,17 +270,11 @@ sub start_ca_management {
 
 sub start_wake_on_lan {
     search('wake');
-    assert_screen [qw(yast2_control-center_wake-on-lan yast2_control_no_modules), timeout => 60];
-    if (match_has_tag('yast2_control_no_modules') && sle_version_at_least('15')) {
-        # No wol on SLE 15 atm
-        record_soft_failure 'bsc#1059569';
-        return;
-    }
     assert_and_click 'yast2_control-center_wake-on-lan';
-    assert_screen 'yast2_control-center_wake-on-lan_install_cancel', timeout => 180;
-    send_key 'alt-c';
-    assert_screen 'yast2_control-center_wake-on-lan_install_error';
-    send_key 'alt-o';
+    assert_screen 'yast2_control-center_wake-on-lan_install_wol';
+    send_key $cmd{install};    # wol needs to be installed
+    assert_screen 'yast2_control-center_wake-on-lan_overview', timeout => 60;
+    send_key 'alt-f';
     assert_screen 'yast2-control-center-ui', timeout => 60;
 }
 
@@ -320,10 +314,10 @@ sub run {
     if (is_sle '15+') {
         # kdump is disabled by default, so ensure that it's installed
         ensure_installed 'yast2-kdump';
-        record_soft_failure 'bsc#1059569';
+        record_soft_failure 'bsc#1108669';
         # see bsc#1062331, sound is not added to the yast2 pattern
         # also add missing yast2-ca-management and yast2-auth-server
-        ensure_installed 'yast2-sound yast2-ca-management yast2-auth-server';
+        ensure_installed 'yast2-boot-server yast2-sound yast2-ca-management yast2-auth-server';
     }
     $self->launch_yast2_module_x11('', target_match => 'yast2-control-center-ui', match_timeout => 180);
 

--- a/tests/yast2_gui/yast2_network_settings.pm
+++ b/tests/yast2_gui/yast2_network_settings.pm
@@ -33,7 +33,6 @@ sub run {
 
     $self->launch_yast2_module_x11('lan', target_match => [qw(yast2-lan-ui yast2_still_susefirewall2 yast2-lan-warning-network-manager)], match_timeout => 60);
     if (match_has_tag 'yast2_still_susefirewall2') {
-        record_soft_failure "bsc#1059569";
         send_key $cmd{install};
         wait_still_screen;
     }


### PR DESCRIPTION
Fix referenced bug bsc#1059569.
Once YaST module yast2-boot-server is included, search for WOL and then it requires installation of package wol (without soft-failure? as it will not be fixed)
- Related ticket: https://progress.opensuse.org/issues/40907
- Needles: [needles SLE](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/939)
- Verification run: [sle-15-SP1-yast2_gui](http://dhcp87.suse.cz/tests/latest?version=15-SP1&flavor=Installer-DVD&arch=x86_64&distri=sle&machine=64bit&test=yast2_gui#step/yast2_control_center/109)
