### PR TITLE
Increase timeout for assert_screen in chromium

### DIFF
--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -29,12 +29,12 @@ sub run {
     # Additional waiting to prevent unready address bar
     # https://progress.opensuse.org/issues/36304
     wait_still_screen(1);
-    type_string "about:\n";
+    type_string "chrome://version \n";
     assert_screen 'chromium-about';
 
     wait_screen_change { send_key 'ctrl-l' };
     type_string "https://html5test.opensuse.org\n";
-    assert_screen 'chromium-html-test';
+    assert_screen 'chromium-html-test', 90;
     send_key 'alt-f4';
 }
 


### PR DESCRIPTION
- prevent timeout issue for assert_screen html_test and make it stable
- see https://progress.opensuse.org/issues/36304
- verification run http://e13.suse.de/tests/8471#step/chromium/19
