### PR TITLE
Unschedule yast2_lan_restart_devices when Network Manager-2nd try

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1443,7 +1443,7 @@ sub load_extra_tests_desktop {
     # well
     if (check_var('DESKTOP', 'gnome')) {
         loadtest 'x11/yast2_lan_restart';
-        loadtest 'x11/yast2_lan_restart_devices' unless is_leap('<=15.0');
+        loadtest 'x11/yast2_lan_restart_devices' if (!is_opensuse || is_leap('<=15.0'));
         # we only have the test dependencies, e.g. hostapd available in
         # openSUSE
         if (check_var('DISTRI', 'opensuse')) {


### PR DESCRIPTION
Unschedule yast2_lan_restart_devices when Network Manager-2nd try. It is a correction for #5780

Similar logic could be: `unless (is_opensuse && !is_leap('>15.0'))`
Neither of them is very readable, but unless with negate conditon inside I guess is worst.
I think both cover all products, if it SLE is scheduled, if is opensuse only if  is leap <=15.0 so TW (or any opensusue) is excluded which is ok.

- Related ticket: https://progress.opensuse.org/issues/40766
