### PR TITLE
Wait longer for pop-ups

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -540,7 +540,7 @@ sub firefox_check_popups {
     for (1 .. 2) {
         # wait for any popup to showup but not expect a too long still time
         # because of dynamic openSUSE start page background logo
-        wait_still_screen(1);
+        wait_still_screen(3);
         assert_screen [qw(firefox_trackinfo firefox_readerview_window firefox_clean)], 60;
         # handle the tracking protection pop up
         if (match_has_tag('firefox_trackinfo')) {


### PR DESCRIPTION
- Fail: [Missed pop-up was then covering match field of another needle](https://openqa.suse.de/tests/2070011#step/firefox/12)
- Verification run: http://10.100.12.155/tests/6460#step/firefox/13
