### PR TITLE
Add more warnings checks for storage-ng

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -66,6 +66,10 @@ sub create_new_partition_table {
     wait_still_screen 2;
     save_screenshot;
     send_key 'ret';
+    if (is_storage_ng) {
+        assert_screen 'expert-partitioner-confirm-dev-removal';
+        send_key 'alt-y';
+    }
     # create new partition table, change gpt table if it's available
     # storage-ng always allows partition table selection
     if (!get_var('UEFI') && !check_var('BACKEND', 's390x') || is_storage_ng) {
@@ -74,8 +78,10 @@ sub create_new_partition_table {
         assert_screen "partition-table-$table_type-selected";
         send_key((is_storage_ng) ? $cmd{next} : $cmd{ok});    # OK
     }
-    assert_screen 'partition-create-new-table';
-    send_key 'alt-y';
+    unless (is_storage_ng) {
+        assert_screen 'partition-create-new-table';
+        send_key 'alt-y';
+    }
 }
 
 sub mount_device {


### PR DESCRIPTION
- Related tickets:

* [[sle][functional][y][yast] Check warning for too small PReP (ppc), EFI (aarch64), Bios Boot (x86_64+GPT) or root partition /](https://progress.opensuse.org/issues/33160)
* [[functional][y][easy][fast] adapt test "partitioning_full_lvm" to handle new warning](https://progress.opensuse.org/issues/41153)

- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/940
- Verification runs: [sle-12-SP4-Server-DVD-x86_64-Build0393-btrfs+warnings@64bit](http://dhcp128.suse.cz/tests/6196)
[sle-15-SP1-Installer-DVD-x86_64-Build41.4-btrfs+warnings@64bit](http://dhcp128.suse.cz/tests/6195)
