### PR TITLE
Disable auto ballooning when create vm guest

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -117,11 +117,14 @@ sub setup_console_in_grub {
         #grub2
         if (${virt_type} eq "xen") {
             my $com_settings = get_var('IPMI_CONSOLE') ? "com2=" . get_var('IPMI_CONSOLE') : "";
+            #bsc#1107572 workaround(Comment9 "This dom0 memory amount works well with hosts having 4 to 8 Gigs of RAM.
+            #With host containing larger amounts of memory, you may want to increase this to something larger.")
+            #dom0_mem=1024M,max:1024M
             $cmd
               = "cp $grub_cfg_file ${grub_cfg_file}.org "
               . "\&\& sed -ri '/(multiboot|module\\s*.*vmlinuz)/ "
               . "{s/(console|loglevel|log_lvl|guest_loglvl)=[^ ]*//g; "
-              . "/multiboot/ s/\$/ console=com2,115200 log_lvl=all guest_loglvl=all sync_console $com_settings/; "
+              . "/multiboot/ s/\$/ dom0_mem=1024M,max:1024M console=com2,115200 log_lvl=all guest_loglvl=all sync_console $com_settings/; "
               . "/module\\s*.*vmlinuz/ s/\$/ console=$ipmi_console,115200 console=tty loglevel=5/;}; "
               . "s/timeout=-{0,1}[0-9]{1,}/timeout=30/g;"
               . "' $grub_cfg_file";


### PR DESCRIPTION
This is workaround for bsc#1107572. The host has to have some memory available to switch a guest to shadow mode. There not being enough might be a sign of ballooning being enabled, which leads to vm guest crash or its boot process exit. So append "dom0_mem=1024M,max:1024M" to xen command line will disable auto ballooning.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1107572
- Needles: n/a
- Verification run: https://10.67.17.5/tests/97

@alice-suse @XGWang0 @xguo @Julie-CAO
