### PR TITLE
Fix missing packages for InfiniBand testsuite

### DIFF
--- a/tests/kernel/ib_tests.pm
+++ b/tests/kernel/ib_tests.pm
@@ -102,6 +102,9 @@ sub run {
 
     use_ssh_serial_console;
 
+    # Add the GA repository
+    zypper_call("ar -f -G " . get_required_var('GA_REPO'));
+
     # unload firewall. MPI- and libfabric-tests require too many open ports
     script_run("systemctl stop firewalld");
 


### PR DESCRIPTION
In order to correctly run the InfiniBand testsuite, it is neccesary to
install some packages from the GA repo. Adding the repository makes the
package installation succeed again.

Signed-off-by: Michael Moese <mmoese@suse.de>