### PR TITLE
[CLOUD] Upload images to CSP

### DIFF
--- a/data/publiccloud/ec2utils.conf
+++ b/data/publiccloud/ec2utils.conf
@@ -1,0 +1,213 @@
+# One can configure as many accounts as one chooses. Configured accounts
+# start with the "account-" prefix. Account information is retrieved by any
+# of the ec2utils tools by combining the prefix "account-" with the name
+# specified with the --account command line option
+#
+# For example the information for the "account-servers" configuration is
+# used by specifying --account servers on the command line of any of the
+# tools
+[account-servers]
+access_key_id =
+secret_access_key =
+ssh_key_name =
+ssh_private_key =
+subnet_id_us-east-1 =
+security_group_ids_us-east-1 =
+
+[account-root]
+access_key_id =
+secret_access_key =
+ssh_key_name =
+ssh_private_key =
+security_group_ids_eu-central-1=
+
+# The aki IDs are published by Amazon on the following page:
+# http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/UserProvidedKernels.html#AmazonKernelImageIDs
+# The ami, instance_type, and user are needed for those utilities that require
+# a running instance in Amazon EC2 to perform their operations.
+[region-ap-northeast-1]
+ami = ami-383c1956
+instance_type = t2.micro
+aki_i386 = aki-136bf512
+aki_x86_64 = aki-176bf516
+g2_aki_x86_64 = aki-f1ad9bf0
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-ap-northeast-2]
+ami = ami-249b554a
+instance_type = t2.micro
+aki_i386 = aki-01a66b6f
+aki_x86_64 = aki-01a66b6f
+g2_aki_x86_64 = aki-0ea66b60
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-ap-southeast-1]
+ami = ami-c9b572aa
+instance_type = t2.micro
+aki_i386 = aki-ae3973fc
+aki_x86_64 = aki-503e7402
+g2_aki_x86_64 = aki-ca755498
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-ap-southeast-2]
+ami = ami-48d38c2b
+instance_type = t2.micro
+aki_i386 = aki-cd62fff7
+aki_x86_64 = aki-c362fff9
+g2_aki_x86_64 = aki-8faec3b5
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-cn-north-1]
+ami = ami-bcc45885
+instance_type = t2.micro
+aki_i386 = aki-908f1da9
+aki_x86_64 = aki-9e8f1da7
+g2_aki_x86_64 = aki-9c4ad8a5
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-eu-central-1]
+ami = ami-bc5b48d0
+instance_type = t2.micro
+aki_i386 = aki-3e4c7a23
+aki_x86_64 = aki-184c7a05
+g2_aki_x86_64 = aki-e23f09ff
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-eu-west-1]
+ami = ami-bff32ccc
+instance_type = t2.micro
+aki_i386 = aki-68a3451f
+aki_x86_64 = aki-52a34525
+g2_aki_x86_64 = aki-fce8478b
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-sa-east-1]
+ami = ami-6817af04
+instance_type = t2.micro
+aki_i386 = aki-5b53f446
+aki_x86_64 = aki-5553f448
+g2_aki_x86_64 = aki-b99024a4
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-us-east-1]
+#Amazon Linux
+#ami = ami-4b814f22
+# SLES 12
+ami = ami-60b6c60a
+instance_type = t2.micro
+aki_i386 = aki-8f9dcae6
+aki_x86_64 = aki-919dcaf8
+g2_aki_x86_64 = aki-f4bc469c
+user = ec2-user
+backing-store = mag,ssd
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-us-east-2]
+ami = ami-71ca9114
+instance_type = t2.micro
+aki_i386 = aki-da055ebf
+aki_x86_64 = aki-d83a61bd
+user = ec2-user
+backing-store = ssd
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-us-gov-west-1]
+ami = ami-c2b5d7e1
+instance_type = t2.micro
+aki_i386 = aki-1fe98d3c
+aki_x86_64 = aki-1de98d3e
+g2_aki_x86_64 = aki-07026424
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-us-west-1]
+ami = ami-d5ea86b5
+instance_type = t2.micro
+aki_i386 = aki-8e0531cb
+aki_x86_64 = aki-880531cd
+g2_aki_x86_64 = aki-f9786dbc
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-us-west-2]
+ami = ami-f0091d91
+instance_type = t2.micro
+aki_i386 = aki-f08f11c0
+aki_x86_64 = aki-fc8f11cc
+g2_aki_x86_64 = aki-5f125d6f
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-ca-central-1]
+ami = ami-a954d1cd
+instance_type = t2.micro
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-eu-west-2]
+ami = ami-403e2524
+instance_type = t2.micro
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-eu-west-3]
+ami = ami-8ee056f3
+instance_type = t2.micro
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-ap-south-1]
+ami = ami-531a4c3c
+instance_type = t2.micro
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =
+
+[region-cn-northwest-1]
+ami = ami-23978241
+instance_type = t2.micro
+user = ec2-user
+# Allow a region to overwrite the account key
+# ssk_key_name =
+# ssh_private_key =

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2036,8 +2036,9 @@ sub load_toolchain_tests {
 }
 
 sub load_publiccloud_tests {
-    loadtest "publiccloud/install_ipa" if get_var('INSTALL_IPA');
-    loadtest "publiccloud/ipa"         if get_var('PUBLIC_CLOUD_PROVIDER');
+    loadtest "publiccloud/install_ipa"  if get_var('INSTALL_IPA');
+    loadtest "publiccloud/upload_image" if get_var('PUBLIC_CLOUD_IMAGE_LOCATION');
+    loadtest "publiccloud/ipa"          if get_var('PUBLIC_CLOUD_IPA_TESTS');
 }
 
 sub load_common_opensuse_sle_tests {

--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -1,0 +1,91 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: helper class for azure
+#
+# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+
+package publiccloud::azure;
+use Mojo::Base 'publiccloud::provider';
+use Mojo::JSON qw(decode_json encode_json);
+use testapi;
+
+has tenantid => undef;
+
+sub init {
+    my ($self) = @_;
+
+    assert_script_run('az login --service-principal -u ' . $self->key_id . ' -p '
+          . $self->key_secret . ' -t ' . $self->tenantid);
+}
+
+sub find_img {
+    my ($self, $name) = @_;
+
+    my $jgroups = decode_json(script_output("az group list"));
+    for my $g (@{$jgroups}) {
+        if ($name eq $g->{name}) {
+            return $name;
+        }
+    }
+
+    return;
+}
+
+sub upload_img {
+    my ($self, $file) = @_;
+
+    if ($file =~ m/vhdfixed\.xz$/) {
+        assert_script_run("xz -d $file", timeout => 60 * 5);
+        $file =~ s/\.xz$//;
+    }
+
+    my $suffix = time();
+    my ($img_name) = $file =~ /([^\/]+)$/;
+    $img_name =~ s/\.vhdfixed/.vhd/;
+
+    my $group     = $self->prefix . "-" . $img_name;
+    my $acc       = $self->prefix . "-" . $suffix;
+    my $container = $self->prefix . "-" . $suffix;
+    my $disk_name = $self->prefix . "-" . $suffix;
+
+    $acc = uc($acc);
+    $acc =~ s/[^\da-z]//g;
+    $acc = substr($acc, 0, 24);
+
+    assert_script_run("az group create --name $group -l " . $self->region);
+
+    assert_script_run("az storage account create --resource-group $group "
+          . "-l " . $self->region . " --name $acc --kind Storage --sku Standard_LRS");
+
+    my $output = script_output("az storage account keys list "
+          . "--resource-group $group --account-name $acc");
+    my $json = decode_json($output);
+    my $key  = undef;
+    if (@{$json} > 0) {
+        $key = $json->[0]->{value};
+    }
+    die("Storage account key not found!") unless $key;
+
+    assert_script_run("az storage container create --account-name $acc "
+          . "--name $container");
+
+    assert_script_run("az storage blob upload --max-connections 4 "
+          . "--account-name $acc --account-key $key --container-name $container "
+          . "--type page --file '$file' --name $img_name", timeout => 60 * 90);
+    assert_script_run("az disk create --resource-group $group --name $disk_name "
+          . "--source https://$acc.blob.core.windows.net/$container/$img_name");
+
+    assert_script_run("az image create --resource-group $group --name $img_name "
+          . "--os-type Linux --source='$disk_name'");
+
+    return $img_name;
+}
+
+1;

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -1,0 +1,106 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Helper class for amazon ec2
+#
+# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+
+package publiccloud::ec2;
+use Mojo::Base 'publiccloud::provider';
+use testapi;
+
+has ssh_key      => undef;
+has ssh_key_file => undef;
+
+sub init {
+    my ($self, %params) = @_;
+
+    assert_script_run("export AWS_ACCESS_KEY_ID=" . $self->key_id);
+    assert_script_run("export AWS_SECRET_ACCESS_KEY=" . $self->key_secret);
+    assert_script_run('export AWS_DEFAULT_REGION="' . $self->region . '"');
+}
+
+sub find_img {
+    my ($self, $name) = @_;
+
+    $name = $self->prefix . '-' . $name;
+
+    my $out = script_output("aws ec2 describe-images  --filters 'Name=name,Values=$name'");
+    if ($out =~ /"ImageId":\s+"([^"]+)"/) {
+        return $1;
+    }
+    return;
+}
+
+sub create_ssh_key {
+    my ($self, $prefix, $out_file) = @_;
+
+    return $self->ssh_key if ($self->ssh_key);
+
+    for my $i (0 .. 9) {
+        my $key_name = $prefix . "_" . $i;
+        my $cmd      = "aws ec2 create-key-pair --key-name '" . $key_name
+          . "' --query 'KeyMaterial' --output text > " . $out_file;
+        my $ret = script_run($cmd);
+        if (defined($ret) && $ret == 0) {
+            $self->ssh_key($key_name);
+            $self->ssh_key_file($out_file);
+            return $key_name;
+        }
+    }
+    return;
+}
+
+sub delete_ssh_key {
+    my $self = shift;
+    my $name = shift || $self->ssh_key;
+
+    return unless $name;
+
+    assert_script_run("aws ec2 delete-key-pair --key-name " . $name);
+    $self->ssh_key(undef);
+}
+
+sub upload_img {
+    my ($self, $file) = @_;
+
+    die("Create key-pair failed") unless ($self->create_ssh_key($self->prefix . time, 'QA_SSH_KEY.pem'));
+
+    my ($img_name) = $file =~ /([^\/]+)$/;
+
+    assert_script_run("ec2uploadimg --access-id '"
+          . $self->key_id
+          . "' -s '"
+          . $self->key_secret . "' "
+          . "--backing-store ssd "
+          . "--grub2 "
+          . "--machine 'x86_64' "
+          . "-n '" . $self->prefix . '-' . $img_name . "' "
+          . (($img_name =~ /hvm/i) ? "--virt-type hvm --sriov-support " : "--virt-type para ")
+          . "--verbose "
+          . "--regions '" . $self->region . "' "
+          . "--ssh-key-pair '" . $self->ssh_key . "' "
+          . "--private-key-file " . $self->ssh_key_file . " "
+          . "-d 'OpenQA tests' "
+          . "'$file'",
+        timeout => 60 * 60
+    );
+
+    my $ami = $self->find_img($img_name);
+    die("Cannot find image after upload!") unless $ami;
+    return $ami;
+}
+
+sub cleanup {
+    my ($self) = @_;
+
+    $self->delete_ssh_key;
+}
+
+1;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -1,0 +1,64 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Base helper class for public cloud
+#
+# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+
+package publiccloud::provider;
+use Mojo::Base -base;
+
+has key_id     => undef;
+has key_secret => undef;
+has region     => undef;
+has prefix     => 'openqa';
+
+=head1 METHODS
+ 
+=head2 init
+ 
+Needs provider specific credentials, e.g. key_id, key_secret, region.
+
+=cut
+sub init {
+    die('init() isn\'t implemented');
+}
+
+
+=head2 find_img
+
+Retrieves the image-id by given image C<name>.
+
+=cut
+sub find_img {
+    die('find_image() isn\'t implemented');
+}
+
+=head2 upload_image
+
+Upload a image to the CSP. Required parameter is the
+location of the C<image> file.
+
+Retrieves the image-id after upload or die.
+
+=cut
+sub upload_image {
+    die('find_image() isn\'t implemented');
+}
+
+=head2 cleanup
+
+This method is called called after each test on failure or success.
+
+=cut
+sub cleanup {
+}
+
+1;
+

--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -1,0 +1,139 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Testmodule to upload images to CSP
+#
+# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+use utils;
+use serial_terminal 'select_virtio_console';
+use version_utils 'is_sle';
+use registration 'add_suseconnect_product';
+use publiccloud::ec2;
+use publiccloud::azure;
+
+sub prepare_os {
+
+    if (is_sle) {
+        my $modver = get_required_var('VERSION') =~ s/-SP\d+//r;
+        add_suseconnect_product('sle-module-public-cloud', $modver);
+    }
+
+    if (check_var('PUBLIC_CLOUD_PROVIDER', 'EC2')) {
+        zypper_call('in python-ec2uploadimg aws-cli');
+        assert_script_run("curl " . data_url('publiccloud/ec2utils.conf') . " -o /root/.ec2utils.conf");
+    }
+    elsif (check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {
+        zypper_call('in curl');
+        assert_script_run('sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc');
+        zypper_call('addrepo --name "Azure CLI" --check https://packages.microsoft.com/yumrepos/azure-cli azure-cli');
+        zypper_call('install --from azure-cli -y azure-cli');
+    }
+}
+
+sub provider_factory {
+    if (check_var('PUBLIC_CLOUD_PROVIDER', 'EC2')) {
+        return publiccloud::ec2->new(
+            key_id     => get_required_var('PUBLIC_CLOUD_KEY_ID'),
+            key_secret => get_required_var('PUBLIC_CLOUD_KEY_SECRET'),
+            region     => get_var('PUBLIC_CLOUD_REGION', 'eu-central-1')
+        );
+
+    }
+    elsif (check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {
+        return publiccloud::azure->new(
+            key_id     => get_required_var('PUBLIC_CLOUD_KEY_ID'),
+            key_secret => get_required_var('PUBLIC_CLOUD_KEY_SECRET'),
+            region     => get_var('PUBLIC_CLOUD_REGION', 'westeurope'),
+            tenantid   => get_required_var('PUBLIC_CLOUD_TENANT_ID')
+        );
+    }
+    else {
+        die('Unknown PUBLIC_CLOUD_PROVIDER given');
+    }
+}
+
+sub run {
+    my ($self) = @_;
+    select_virtio_console();
+
+    prepare_os;
+
+    my $provider = $self->{provider} = provider_factory;
+    $provider->init;
+
+    my $img_url = get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION');
+    my ($img_name) = $img_url =~ /([^\/]+)$/;
+
+    if (my $img = $provider->find_img($img_name)) {
+        record_info("Image $img_name already exists!");
+        set_var('PUBLIC_CLOUD_IMAGE_ID', $img_name);
+        return;
+    }
+
+    assert_script_run("wget $img_url -O $img_name", timeout => 60 * 10);
+
+    my $img_id = $provider->upload_img($img_name);
+
+    set_var('PUBLIC_CLOUD_IMAGE_ID', $img_id);
+
+    $provider->cleanup;
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+
+    if ($self->{provider}) {
+        $self->{provider}->cleanup;
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+
+1;
+
+=head1 Discussion
+
+OpenQA script to upload images into public cloud. This test module is only
+added if PUBLIC_CLOUD_IMAGE_LOCATION is set.
+
+=head1 Configuration
+
+=head2 PUBLIC_CLOUD_PROVIDER
+
+The type of the CSP (e.g. AZURE, EC2)
+
+=head2 PUBLIC_CLOUD_IMAGE_LOCATION
+
+The URL where the image gets downloaded from. The name of the image gets extracted
+from this URL.
+
+=head2 PUBLIC_CLOUD_KEY_ID
+
+The CSP credentials key-id to used to access API.
+
+=head2 PUBLIC_CLOUD_KEY_SECRET
+
+The CSP credentials secret used to access API.
+
+=head2 PUBLIC_CLOUD_REGION
+
+The region to use. (default-azure: westeurope, default-ec2: eu-central-1)
+
+=head2 PUBLIC_CLOUD_TENANT_ID
+
+This is B<only for azure> and used to create the service account file.
+
+=cut

--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -66,9 +66,9 @@ sub run {
     my ($self) = @_;
     select_virtio_console();
 
-    prepare_os;
+    prepare_os();
 
-    my $provider = $self->{provider} = provider_factory;
+    my $provider = $self->{provider} = provider_factory();
     $provider->init;
 
     my $img_url = get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION');
@@ -86,14 +86,14 @@ sub run {
 
     set_var('PUBLIC_CLOUD_IMAGE_ID', $img_id);
 
-    $provider->cleanup;
+    $provider->cleanup();
 }
 
 sub post_fail_hook {
     my ($self) = @_;
 
     if ($self->{provider}) {
-        $self->{provider}->cleanup;
+        $self->{provider}->cleanup();
     }
 }
 


### PR DESCRIPTION
Upload images to CSP either azure or amazon ec2.
The image, which is given by PUBLIC_CLOUD_IMAGE_LOCATION, gets
downloaded first and then uploaded to CSP.

Extract common functions in a helper classes. This
can be later extended, e.g. calling IPA tool.
Long time goal, is to replace the cli calls by native perl api
calls like paws and azure-sdk-perl.

The upload_image test module exit successful, if a image or
resource group (azure) with the same name already exists.
Once the image is uploaded or the image exists on CSP the
variable PUBLIC_CLOUD_IMAGE_ID is set with the proper value.

Add file ec2utils.conf, it is used by ec2uploadimg.

- Verification run:
   azure: http://cfconrad-vm.qa.suse.de/tests/697
   aws ec2: http://cfconrad-vm.qa.suse.de/tests/696 (image exists)
   aws ec2: http://cfconrad-vm.qa.suse.de/tests/699
