### PR TITLE
Remove version from repo variable names

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -29,8 +29,8 @@ sub install_kernel_debuginfo {
 }
 
 sub get_repo_url_for_kdump_sle {
-    return join('/', $utils::OPENQA_FTP_URL, get_var('REPO_SLE15_MODULE_BASESYSTEM_DEBUG'))
-      if get_var('REPO_SLE15_MODULE_BASESYSTEM_DEBUG')
+    return join('/', $utils::OPENQA_FTP_URL, get_var('REPO_SLE_MODULE_BASESYSTEM_DEBUG'))
+      if get_var('REPO_SLE_MODULE_BASESYSTEM_DEBUG')
       and is_sle('15+');
     return join('/', $utils::OPENQA_FTP_URL, get_var('REPO_SLES_DEBUG')) if get_var('REPO_SLES_DEBUG');
 }

--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -30,10 +30,8 @@ called on SLE15-SP1.
 =cut
 sub get_repo_var_name {
     my ($repo_name) = @_;
-    my $distri      = uc get_required_var("DISTRI");
-    my $version     = get_required_var("VERSION");
-    $version =~ s/-/_/;
-    return "REPO_${distri}${version}_${repo_name}";
+    my $distri = uc get_required_var("DISTRI");
+    return "REPO_${distri}_${repo_name}";
 }
 
 sub smt_wizard {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -281,8 +281,8 @@ if (sle_version_at_least('15') && !check_var('SCC_REGISTER', 'installation')) {
             # Assign the proper repo name if current $short_name references a module or a product/extension.
             my $repo_variable_name
               = is_module($short_name) ?
-              "REPO_SLE${version}_MODULE_${repo_name}"
-              : "REPO_SLE${version}_PRODUCT_${repo_name}";
+              "REPO_SLE_MODULE_${repo_name}"
+              : "REPO_SLE_PRODUCT_${repo_name}";
             # Replace dashes with underscore symbols, as not used in the variable name
             $repo_variable_name =~ s/-/_/;
             my $default_repo_name

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -32,7 +32,7 @@ sub add_we_repo_if_available {
     return if check_var('DISTRI', 'opensuse');
 
     my $ar_url;
-    my $we_repo = get_var('REPO_SLE_WE15_POOL');
+    my $we_repo = get_var('REPO_SLE_WE_POOL');
     if ($we_repo && check_var('DISTRI', 'sle') && sle_version_at_least('15')) {
         $ar_url = "http://openqa.suse.de/assets/repo/$we_repo";
     }


### PR DESCRIPTION
The commit removes version from repo variable names in order to
simplify test code and avoid adding fixes to variable names for each
version.

Related ticket: [poo#39869](https://progress.opensuse.org/issues/39869)

**For reviewers:** This PR should be merged alongside with https://gitlab.suse.de/openqa/scripts/merge_requests/247. So please consider the merge request in 'scripts' before merging this one.
