### PR TITLE
the secondary needles would currently not appear as we are not in the…

### DIFF
--- a/tests/x11/pidgin/pidgin_IRC.pm
+++ b/tests/x11/pidgin/pidgin_IRC.pm
@@ -40,7 +40,7 @@ sub run {
     assert_and_click 'pidgin-irc-account';
 
     # Warning of spoofing ip may appear
-    assert_screen([qw(pidgin-spoofing-ip pidgin-irc-sledtesting)]);
+    assert_screen("pidgin-spoofing-ip", 3);
     if (match_has_tag('pidgin-spoofing-ip')) {
         wait_screen_change {
             send_key is_sle('<15') ? "alt-tab" : "alt-`";
@@ -51,7 +51,7 @@ sub run {
     }
 
     # CTCP Version and warning about scan may appear
-    assert_screen([qw(pidgin-ctcp-version pidgin-irc-sledtesting)]);
+    assert_screen("pidgin-ctcp-version", 3);
     if (match_has_tag('pidgin-ctcp-version')) {
         wait_screen_change { send_key "ctrl-w"; }    # close it
     }


### PR DESCRIPTION
… channel.

just use a timeout waiting for screens that might appear

- Related ticket: https://progress.opensuse.org/issues/41201
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz

I have NOT done a verification run (not yet set up my own openqa cluster)