### PR TITLE
Adjust yast2_vnc for s390x

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -124,11 +124,11 @@ sub scc_version {
 Wrapper for SUSEConnect -p $name.
 =cut
 sub add_suseconnect_product {
-    my ($name, $version, $arch, $params) = @_;
+    my ($name, $version, $arch, $params, $timeout) = @_;
     $version //= scc_version();
     $arch    //= get_required_var('ARCH');
     $params  //= '';
-    assert_script_run("SUSEConnect -p $name/$version/$arch $params");
+    assert_script_run("SUSEConnect -p $name/$version/$arch $params", $timeout);
 }
 
 =head2 remove_suseconnect_product


### PR DESCRIPTION
Adjust yast2_vnc for s390x.

- Related ticket: https://progress.opensuse.org/issues/39332
- Verification run: 
  - [sle-12-SP4-yast2_ncurses_yast2_vnc@s390x](http://dhcp87.suse.cz/tests/2794#step/yast2_vnc/10)
  - [Tumbleweed-yast2_ncurses_yast2_vnc@64bit](http://dhcp87.suse.cz/tests/2792#step/yast2_vnc/12)
