### PR TITLE
Disable xcreensaver autostart on LXDE

### DIFF
--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -28,6 +28,10 @@ sub setup_system {
     }
     else {
         script_run("xscreensaver-command -exit");
+        if (check_var("DESKTOP", "lxde")) {
+            # Disable xscreensaver autostart on LXDE
+            script_sudo("sed -i 's/\@xscreensaver -no-splash//' /etc/xdg/lxsession/LXDE/autostart");
+        }
     }
     send_key("ctrl-d");
 }


### PR DESCRIPTION
Disable xscreensaver on LXDE for good.
It will fix such a failure: https://openqa.opensuse.org/tests/758433#step/glxgears/19

- Related ticket: https://progress.opensuse.org/issues/40094
