### PR TITLE
Ensure that send_key doesn't run on virtio console

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -9,10 +9,13 @@ use utils 'show_tasks_in_blocked_state';
 sub post_fail_hook {
     my $self = shift;
 
-    show_tasks_in_blocked_state;
+    my $defer_blocked_task_info = testapi::is_serial_terminal();
+    show_tasks_in_blocked_state unless ($defer_blocked_task_info);
 
     select_console 'log-console';
     save_screenshot;
+
+    show_tasks_in_blocked_state if ($defer_blocked_task_info);
 
     upload_logs('/var/log/zypper.log');
     $self->remount_tmp_if_ro;

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1014,9 +1014,12 @@ sub zypper_ar {
 }
 
 sub show_tasks_in_blocked_state {
-    # info will be sent to serial tty
-    send_key 'alt-sysrq-w';
-    wait_serial('SysRq : Show Blocked State', 1);
+    # sending sysrqs doesn't work for hyperv
+    if (!check_var('MACHINE', 'svirt-hyperv')) {
+        send_key 'alt-sysrq-w';
+        # info will be sent to serial tty
+        wait_serial('SysRq : Show Blocked State', 1);
+    }
 }
 
 1;


### PR DESCRIPTION
Call show_tasks_in_blocked_state after selecting
non-virtio console.

https://progress.opensuse.org/issues/39497