### PR TITLE
Enable generic yast log collection

### DIFF
--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -85,8 +85,10 @@ sub run {
 }
 
 sub post_fail_hook {
+    my ($self) = @_;
     assert_script_run 'journalctl -b > /tmp/journal', 90;
     upload_logs '/tmp/journal';
+    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
https://openqa.suse.de/tests/2083021#step/yast2_lan_restart/53 now faces issues where we could use logs from `save_y2logs` but we don't collect them. This just enables the generic collection from the super-"class".

- Related ticket: none
- Needles: none
- Verification run: just did it like @rwx788 told me :)