### PR TITLE
Revert "Detect bsc#1063638 on btrfs"

### DIFF
--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -35,9 +35,6 @@ sub run {
     else {
         $self->wait_boot(bootloader_time => $timeout, nologin => $nologin);
     }
-
-    # Detect btrfs balancing if filesystem is set to btrfs, or undef, as btrfs is default
-    push @{$self->{serial_failures}}, {type => 'soft', message => 'bsc#1063638', pattern => qr/BTRFS info.*relocating/} if get_var('SOFTFAIL_BSC1063638');
 }
 
 sub test_flags {

--- a/tests/console/force_scheduled_tasks.pm
+++ b/tests/console/force_scheduled_tasks.pm
@@ -30,7 +30,6 @@ sub settle_load {
 }
 
 sub run {
-    my ($self) = @_;
     select_console 'root-console';
 
     # show dmesg output in console during cron run
@@ -51,11 +50,6 @@ sub run {
 
     # return dmesg output to normal
     assert_script_run "dmesg -n 1";
-
-    # Detect btrfs balancing if filesystem is set to btrfs, or undef, as btrfs is default
-    if (get_var('FILESYSTEM', 'btrfs') eq 'btrfs' || get_var('SOFTFAIL_BSC1063638')) {
-        push @{$self->{serial_failures}}, {type => 'soft', message => 'bsc#1063638', pattern => qr/BTRFS info.*relocating/};
-    }
 }
 
 sub test_flags {


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#5770

This approach is too generic, provides false positives like one here https://openqa.opensuse.org/tests/760254#step/force_scheduled_tasks/15 which we don't want.