### PR TITLE
[NFV] Increase T-Rex package download timeout

### DIFF
--- a/tests/nfv/trex_installation.pm
+++ b/tests/nfv/trex_installation.pm
@@ -34,7 +34,7 @@ sub run {
 
     # Download and extract T-Rex package
     record_info("INFO", "Download TREX package");
-    assert_script_run("wget $url", 900);
+    assert_script_run("wget $url", 1800);
     assert_script_run("tar -xzf $tarball");
     assert_script_run("mv $trex_version $trex_dest");
 


### PR DESCRIPTION
Lately, the Cisco server where the T-Rex package is downloaded from takes more time than usual. After some local tests downloading the package manually, ~25 minutes is needed. 