### PR TITLE
Migration from Leap 42.3 to SLE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -467,6 +467,7 @@ sub load_zdup_tests {
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/lock_package";
     }
+    loadtest 'installation/zdup_prepare_repos';
     loadtest 'installation/zdup';
     loadtest 'installation/post_zdup';
     # Restrict version switch to sle until opensuse adopts it

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -467,7 +467,11 @@ sub load_zdup_tests {
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/lock_package";
     }
-    loadtest 'installation/zdup_prepare_repos';
+    if (get_var("USE_SUSECONNECT")) {
+        loadtest "console/zdup_prepare_leap_sle";
+    } else {
+        loadtest 'installation/zdup_prepare_repos';
+    }
     loadtest 'installation/zdup';
     loadtest 'installation/post_zdup';
     # Restrict version switch to sle until opensuse adopts it

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1046,9 +1046,11 @@ else {
         load_default_autoyast_tests;
     }
     elsif (installzdupstep_is_applicable()) {
-        # Staging cannot be registered, so Staging cannot be patched before testing upgrades in staging
-        if (!is_staging) {
-            load_patching_tests();
+        if (get_var('HDDVERSION', '') !~ /opensuse-/) {
+            # Staging cannot be registered, so Staging cannot be patched before testing upgrades in staging
+            if (!is_staging) {
+                load_patching_tests();
+            }
         }
         load_zdup_tests();
     }

--- a/tests/console/zdup_prepare_leap_sle.pm
+++ b/tests/console/zdup_prepare_leap_sle.pm
@@ -1,0 +1,84 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: prepare migration from Leap to SLE
+#   Documentation for 15:
+#   https://www.suse.com/de-de/documentation/sles-15/book_sle_upgrade/data/sec_upgrade-online_opensuse_to_sle.html
+#   12 is not supported and inoffical
+# Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+
+use base "console_yasttest";
+use strict;
+use testapi;
+use utils qw(zypper_call);
+
+sub run {
+    my $reg_code   = get_required_var('SCC_REGCODE');
+    my $scc_url    = get_required_var('SCC_URL');
+    my $scc_addons = get_var('SCC_ADDONS', '');
+
+    # so if we are migrating from Leap to SLE we just make SUSEConnect believe
+    # we are on SLE
+    my $hddversion = get_var('HDDVERSION', '');
+    my $version = get_var('VERSION');
+    $version =~ s/-SP/./;    # 12-SP3 -> 12.3
+    my $product .= "SLES/$version/" . get_var('ARCH');
+
+    select_console 'root-console';
+
+    # make sure we have SUSEConnect and the right build key
+    zypper_call "in SUSEConnect";
+    # suse build key conflicts with openSUSE-build-key. We can't uninstall
+    # openSUSE-build-key though as patterns need it :(
+    # should be only needed on 12
+    {
+        zypper_call "download suse-build-key";
+        assert_script_run "rpm -Uvh --force --nodeps /var/cache/zypp/packages/*/noarch/suse-build-key-*.rpm";
+        assert_script_run "rpm --import /usr/lib/rpm/gnupg/keys/*";
+
+        # just for openQA. it expects the firewall to be enabled in the
+        # application tests later.
+        zypper_call "in SuSEfirewall2";
+        assert_script_run "SuSEfirewall2 on";
+    }
+    # disable the openSUSE repos
+    zypper_call('mr -d -a');
+    # register!
+    script_run "SUSEConnect --url $scc_url -r $reg_code -p $product";
+    # forcibly install the product. SUSEConnect cannot do that for us due to conflicts
+    zypper_call('in --force-resolution -y -l -t product SLES -openSUSE');
+
+    # restore product, bug in 42
+    {
+        script_run("ln -s SLES.prod /etc/products.d/baseproduct");
+    }
+
+    # just for the fun of it here
+    script_run("SUSEConnect --list-extensions");
+
+    # remove some known file conflicts in 12 to avoid dup complaining later
+    {
+        script_run("rpm -e --nodeps libmtp-udev libmtp9 libtheoradec1 libtheoraenc1");
+        # in 42 gawk comes from Factory and uses update-alternatives.
+        # Downgrading to the one from SLE breaks the awk link which in turn
+        # breaks rpm %post scripts, like grub. So we have to forcibly fix
+        # gawk here.
+        zypper_call("in -y -f gawk");
+        zypper_call("in -y -f gawk");
+
+        # SLE12 failed to use a better console font
+        script_run("sed -i -e 's/eurlatgr/lat9w-16/' /etc/sysconfig/console");
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/installation/post_zdup.pm
+++ b/tests/installation/post_zdup.pm
@@ -26,6 +26,8 @@ sub run {
     # whatever the default in the image is.
     systemctl('set-default --force graphical.target');
 
+    script_run("rpm -qa --qf '%{vendor} %{name}\n' | tee /dev/$serialdev");
+
     # switch to root-console (in case we are in X)
     select_console 'root-console';
     power_action('reboot', keepconsole => 1, textmode => 1);

--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -15,7 +15,6 @@
 use base "installbasetest";
 use strict;
 use testapi;
-use utils 'OPENQA_FTP_URL';
 
 sub run {
     my $self = shift;
@@ -26,86 +25,15 @@ sub run {
     my $zypper_dup_notifications = qr/^View the notifications now\? \[y/m;
     my $zypper_dup_error         = qr/^Abort, retry, ignore\? \[a/m;
     my $zypper_dup_finish        = qr/^There are some running programs that might use files|ZYPPER-DONE/m;
-    my $zypper_packagekit        = qr/^Tell PackageKit to quit\?/m;
-    my $zypper_packagekit_again  = qr/^Try again\?/m;
-    my $zypper_repo_disabled     = qr/^Repository '[^']+' has been successfully disabled./m;
     my $zypper_dup_fileconflict  = qr/^File conflicts .*^Continue\? \[y/ms;
     my $zypper_retrieving        = qr/Retrieving: \S+/;
     my $zypper_check_conflicts   = qr/Checking for file conflicts: \S+/;
 
-    # This is just for reference to know how the network was configured prior to the update
-    script_run "ip addr show";
-    save_screenshot;
+    my $dup_args = get_var('ZDUP_FORCE_RESOLUTION') ? '--force-resolution' : '';
 
-    # before disable we need to have cdrkit installed to get proper iso appid
-    script_run "zypper -n in cdrkit-cdrtools-compat";
-    # Disable all repos, so we do not need to remove one by one
-    # beware PackageKit!
-    script_run("zypper modifyrepo --all --disable | tee /dev/$serialdev", 0);
-    my $out = wait_serial([$zypper_packagekit, $zypper_repo_disabled], 120);
-    while ($out) {
-        if ($out =~ $zypper_packagekit || $out =~ $zypper_packagekit_again) {
-            send_key 'y';
-            send_key 'ret';
-        }
-        elsif ($out =~ $zypper_repo_disabled) {
-            last;
-        }
-        $out = wait_serial([$zypper_repo_disabled, $zypper_packagekit_again, $zypper_packagekit], 120);
-    }
-    unless ($out) {
-        save_screenshot;
-        $self->result('fail');
-        return;
-    }
+    script_run("(zypper dup $dup_args -l;echo ZYPPER-DONE) | tee /dev/$serialdev", 0);
 
-    my $defaultrepo;
-    if (get_var('SUSEMIRROR')) {
-        $defaultrepo = "http://" . get_var("SUSEMIRROR");
-    }
-    else {
-        #SUSEMIRROR not set, zdup from ftp source for online migration
-        if (get_var('TEST') =~ /migration_zdup_online_sle12_ga/) {
-            my $flavor  = get_var("FLAVOR");
-            my $version = get_var("VERSION");
-            my $build   = get_var("BUILD");
-            my $arch    = get_var("ARCH");
-            $defaultrepo = "$utils::OPENQA_FTP_URL/SLE-$version-$flavor-$arch-Build$build-Media1";
-        }
-        else {
-            # SUSEMIRROR not set, zdup from attached ISO
-            my $build  = get_var("BUILD");
-            my $flavor = get_var("FLAVOR");
-            script_run "ls -al /dev/disk/by-label";
-            my $isoinfo = "isoinfo -d -i /dev/\$dev | grep \"Application id\" | awk -F \" \" '{print \$3}'";
-
-            script_run "dev=;
-                       for i in sr0 sr1 sr2 sr3 sr4 sr5; do
-                       label=`$isoinfo`
-                       case \$label in
-                           *$flavor-*$build*) echo \"\$i match\"; dev=\"/dev/\$i\"; break;;
-                           *) continue;;
-                       esac
-                       done
-                       [ -z \$dev ] || echo \"found dev \$dev with label \$label\"";
-            # get all attached ISOs including addons' as zdup dup repos
-            my $srx = script_output("ls -al /dev/disk/by-label | grep -E /sr[0-9]+ | wc -l");
-            for my $n (0 .. $srx - 1) {
-                $defaultrepo .= "dvd:/?devices=\${dev:-/dev/sr$n}+";
-            }
-        }
-    }
-
-    my $nr = 1;
-    foreach my $r (split(/\+/, get_var("ZDUPREPOS", $defaultrepo))) {
-        assert_script_run("zypper -n addrepo \"$r\" repo$nr");
-        $nr++;
-    }
-    assert_script_run("zypper -n refresh", 240);
-
-    script_run("(zypper dup -l;echo ZYPPER-DONE) | tee /dev/$serialdev", 0);
-
-    $out = wait_serial([$zypper_dup_continue, $zypper_dup_conflict, $zypper_dup_error], 240);
+    my $out = wait_serial([$zypper_dup_continue, $zypper_dup_conflict, $zypper_dup_error], 240);
     while ($out) {
         if ($out =~ $zypper_dup_conflict) {
             if (get_var("WORKAROUND_DEPS")) {

--- a/tests/installation/zdup_prepare_repos.pm
+++ b/tests/installation/zdup_prepare_repos.pm
@@ -1,0 +1,102 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: prepare repos for zdup.test
+# Maintainer: Oliver Kurz <okurz@suse.de>
+
+use base "installbasetest";
+use strict;
+use testapi;
+use utils 'OPENQA_FTP_URL';
+
+sub run {
+    my $self = shift;
+
+    # precompile regexes
+    my $zypper_packagekit       = qr/^Tell PackageKit to quit\?/m;
+    my $zypper_packagekit_again = qr/^Try again\?/m;
+    my $zypper_repo_disabled    = qr/^Repository '[^']+' has been successfully disabled./m;
+
+    # This is just for reference to know how the network was configured prior to the update
+    script_run "ip addr show";
+    save_screenshot;
+
+    # before disable we need to have cdrkit installed to get proper iso appid
+    script_run "zypper -n in cdrkit-cdrtools-compat";
+    # Disable all repos, so we do not need to remove one by one
+    # beware PackageKit!
+    script_run("zypper modifyrepo --all --disable | tee /dev/$serialdev", 0);
+    my $out = wait_serial([$zypper_packagekit, $zypper_repo_disabled], 120);
+    while ($out) {
+        if ($out =~ $zypper_packagekit || $out =~ $zypper_packagekit_again) {
+            send_key 'y';
+            send_key 'ret';
+        }
+        elsif ($out =~ $zypper_repo_disabled) {
+            last;
+        }
+        $out = wait_serial([$zypper_repo_disabled, $zypper_packagekit_again, $zypper_packagekit], 120);
+    }
+    unless ($out) {
+        save_screenshot;
+        $self->result('fail');
+        return;
+    }
+
+    my $defaultrepo;
+    if (get_var('SUSEMIRROR')) {
+        $defaultrepo = "http://" . get_var("SUSEMIRROR");
+    }
+    else {
+        #SUSEMIRROR not set, zdup from ftp source for online migration
+        if (get_var('TEST') =~ /migration_zdup_online_sle12_ga/) {
+            my $flavor  = get_var("FLAVOR");
+            my $version = get_var("VERSION");
+            my $build   = get_var("BUILD");
+            my $arch    = get_var("ARCH");
+            $defaultrepo = "$utils::OPENQA_FTP_URL/SLE-$version-$flavor-$arch-Build$build-Media1";
+        }
+        else {
+            # SUSEMIRROR not set, zdup from attached ISO
+            my $build  = get_var("BUILD");
+            my $flavor = get_var("FLAVOR");
+            script_run "ls -al /dev/disk/by-label";
+            my $isoinfo = "isoinfo -d -i /dev/\$dev | grep \"Application id\" | awk -F \" \" '{print \$3}'";
+
+            script_run "dev=;
+                       for i in sr0 sr1 sr2 sr3 sr4 sr5; do
+                       label=`$isoinfo`
+                       case \$label in
+                           *$flavor-*$build*) echo \"\$i match\"; dev=\"/dev/\$i\"; break;;
+                           *) continue;;
+                       esac
+                       done
+                       [ -z \$dev ] || echo \"found dev \$dev with label \$label\"";
+            # get all attached ISOs including addons' as zdup dup repos
+            my $srx = script_output("ls -al /dev/disk/by-label | grep -E /sr[0-9]+ | wc -l");
+            for my $n (0 .. $srx - 1) {
+                $defaultrepo .= "dvd:/?devices=\${dev:-/dev/sr$n}+";
+            }
+        }
+    }
+
+    my $nr = 1;
+    foreach my $r (split(/\+/, get_var("ZDUPREPOS", $defaultrepo))) {
+        assert_script_run("zypper -n addrepo \"$r\" repo$nr");
+        $nr++;
+    }
+    assert_script_run("zypper -n refresh", 240);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Automated migration test from Leap 42.3 to SLE

Needs a separate run to generate a text mode image including all updates for Leap. Sample job templates are in the commit.
Only two needles are needed AFAICT, one for the 42.3 bootloader and another one for zypper done due to the different font.

This can serve as template for the mandatory migration feature of 15. The 12 specific parts here can be guarded for that.

- Verification run: https://tortuga.suse.de/tests/311