### PR TITLE
LTP: Fix get_ltp_tag() for non-master branches

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -238,8 +238,12 @@ sub is_kernel_test {
 
 sub get_ltp_tag {
     my $tag = get_var('LTP_RUNTEST_TAG');
-    if (!defined $tag) {
-        $tag = get_var('DISTRI') . '-' . get_var('VERSION') . '-' . get_var('ARCH') . '-' . get_var('BUILD') . '-' . get_var('FLAVOR') . '-' . get_var('LTP_RELEASE', 'master') . '@' . get_var('MACHINE');
+    if (!defined $tag && defined get_var('HDD_1')) {
+        $tag = get_var('PUBLISH_HDD_1');
+        $tag = get_var('HDD_1') if (!defined $tag);
+        $tag = basename($tag);
+    } else {
+        $tag = get_var('DISTRI') . '-' . get_var('VERSION') . '-' . get_var('ARCH') . '-' . get_var('BUILD') . '-' . get_var('FLAVOR') . '@' . get_var('MACHINE');
     }
     return $tag . '.txt';
 }


### PR DESCRIPTION
LTP_RELEASE is defined only for install_ltp.pm. Expecting it's defined
for the tests leads to using wrong tag (=> searching for wrong file)
for non-master branches.

That leads going back to previous version for QEMU based tests:
* PUBLISH_HDD_1 must be used for install_ltp.pm
* HDD_1 must be used for actual tests.

Bare metal tests (IPMI based), which don't use qcow images, need to use
complicated way of tag using DISTRI, VERSION, ... variables (for both
install_ltp.pm and actual tests). This version is not able to
distinguish between different git branches in the same architecture,
that's why it's not used for QEMU based tests (see poo#35041).

Fixes: bca493a1b ("LTP: Adjust tags for bare metal tests")

Verification run:
- http://quasar.suse.cz/tests/932
- http://quasar.suse.cz/tests/934