### PR TITLE
Really disable xcreensaver autostart on LXDE, not only in system config file but also in user config file

### DIFF
--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -29,8 +29,9 @@ sub setup_system {
     else {
         script_run("xscreensaver-command -exit");
         if (check_var("DESKTOP", "lxde")) {
-            # Disable xscreensaver autostart on LXDE
+            # Disable xscreensaver autostart on LXDE (from system wide config and user config)
             script_sudo('sed -i "s/\@xscreensaver -no-splash//" /etc/xdg/lxsession/LXDE/autostart');
+            script_run('sed -i "s/\@xscreensaver -no-splash//" ~/.config/lxsession/LXDE/autostart');
         }
     }
     send_key("ctrl-d");


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/40094
