### PR TITLE
Make sure screen changed before calling handle_login function (for slow workers)

### DIFF
--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -74,6 +74,8 @@ sub run {
         send_key 'ctrl-a';
         type_string "$user\n";
     }
+    # Make sure screen changed before calling handle_login function (for slow workers)
+    wait_still_screen;
     handle_login($user, 1);
     assert_screen 'generic-desktop', 60;
     # verify correct user is logged in


### PR DESCRIPTION
This should fix https://openqa.opensuse.org/tests/761294#step/multi_users_dm/1 where *handle_login* is called before the screen changed to the right screen, which breaks the handle_login behavior.

The aarch64 openQA worker behavior (slowness) is not reproducible locally on my aarch64 system. So, I hope it will be enough.