### PR TITLE
Add ghostscript soft-failure for transparency example

### DIFF
--- a/tests/x11/ghostscript.pm
+++ b/tests/x11/ghostscript.pm
@@ -32,6 +32,14 @@ sub run {
     # special case for gv which is not installed on all flavors
     my $gv_missing = zypper_call("in gv", exitcode => [0, 104]);
 
+    # Remove known failing test file poo#41393/bsc#1109788
+    my $excluded_file = "/usr/share/ghostscript/9.25/examples/transparency_example.ps";
+    my $file_status   = script_run("ls $excluded_file");
+    unless ($file_status) {
+        record_soft_failure("bsc#1109788");
+        assert_script_run("rm $excluded_file");
+    }
+
     # exit root shell
     type_string "exit\n";
 


### PR DESCRIPTION
Fix poo#41393: ghostscript test permanently fails on file
transparency_example.ps. File will be deleted for successful test
and soft-failure for bsc#1109788 will be generated.

- Related ticket: https://progress.opensuse.org/issues/41393
- Needles: none
- Verification run: http://10.100.12.105/tests/302#step/ghostscript/25
