### PR TITLE
LTP/fix missing dmesg output on ppc64le and s390x (poo#38915)

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -116,7 +116,7 @@ sub add_custom_grub_entries {
     $cmd .= " -e 's/\\(menuentry .\\\$(echo .\\\$os\\)/\\1 ($grub_param)/' $script_new";
     assert_script_run($cmd);
     upload_logs($script_new, failok => 1);
-    grub_mkconfig;
+    grub_mkconfig();
     upload_logs(GRUB_CFG_FILE, failok => 1);
 
     my $distro      = (is_sle() ? "SLES" : "openSUSE") . ' \\?' . get_required_var('VERSION');

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -14,6 +14,7 @@ use base 'consoletest';
 use testapi;
 use utils;
 use ipmi_backend_utils 'use_ssh_serial_console';
+use bootloader_setup qw(change_grub_config grub_mkconfig);
 use strict;
 
 sub run {
@@ -22,11 +23,11 @@ sub run {
 
     ensure_serialdev_permissions;
 
-    # BSC#997263 - VMware screen resolution defaults to 800x600
+    # bsc#997263 - VMware screen resolution defaults to 800x600
     if (check_var('VIRSH_VMM_FAMILY', 'vmware')) {
-        assert_script_run("sed -ie '/GFXMODE=/s/=.*/=1024x768x32/' /etc/default/grub");
-        assert_script_run("sed -ie '/GFXPAYLOAD_LINUX=/s/=.*/=1024x768x32/' /etc/default/grub");
-        assert_script_run("grub2-mkconfig -o /boot/grub2/grub.cfg");
+        change_grub_config('=.*', '=1024x768x32', 'GFXMODE=');
+        change_grub_config('=.*', '=1024x768x32', 'GFXPAYLOAD_LINUX=');
+        grub_mkconfig;
     }
 }
 

--- a/tests/jeos/grub2_gfxmode.pm
+++ b/tests/jeos/grub2_gfxmode.pm
@@ -17,15 +17,15 @@
 use base "opensusebasetest";
 use strict;
 use testapi;
-use bootloader_setup qw(set_framebuffer_resolution set_extrabootparams_grub_conf);
+use bootloader_setup qw(change_grub_config grep_grub_settings grub_mkconfig set_framebuffer_resolution set_extrabootparams_grub_conf);
 
 sub run {
-    assert_script_run("sed -ie '/GRUB_GFXMODE=/s/=.*/=1024x768/' /etc/default/grub");
-    assert_script_run("sed -ie '/GRUB_GFXMODE/s/^#//' /etc/default/grub");
-    assert_script_run('grep ^GRUB_GFXMODE=1024x768$ /etc/default/grub');
+    change_grub_config('=.*', '=1024x768', 'GRUB_GFXMODE=');
+    change_grub_config('^#',  '',          'GRUB_GFXMODE');
+    grep_grub_settings('^GRUB_GFXMODE=1024x768$');
     set_framebuffer_resolution;
     set_extrabootparams_grub_conf;
-    assert_script_run('grub2-mkconfig -o /boot/grub2/grub.cfg');
+    grub_mkconfig;
 }
 
 sub test_flags {

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -17,7 +17,7 @@ use File::Basename 'basename';
 use testapi;
 use registration;
 use utils;
-use bootloader_setup 'add_custom_grub_entries';
+use bootloader_setup qw(add_custom_grub_entries add_grub_cmdline_settings);
 use main_common 'get_ltp_tag';
 use power_action_utils 'power_action';
 use serial_terminal qw(add_serial_console select_virtio_console);
@@ -250,6 +250,7 @@ sub run {
     my $self     = shift;
     my $inst_ltp = get_var 'INSTALL_LTP';
     my $tag      = get_ltp_tag();
+    my $grub_param;
 
     if ($inst_ltp !~ /(repo|git)/i) {
         die 'INSTALL_LTP must contain "git" or "repo"';
@@ -274,6 +275,12 @@ sub run {
     upload_logs('/boot/config-$(uname -r)', failok => 1);
 
     add_we_repo_if_available;
+
+    $grub_param = 'console=hvc0'     if (get_var('ARCH') eq 'ppc64le');
+    $grub_param = 'console=ttysclp0' if (get_var('ARCH') eq 's390x');
+    if (defined $grub_param) {
+        add_grub_cmdline_settings($grub_param);
+    }
 
     if (is_sle('12+') || is_opensuse) {
         add_custom_grub_entries;

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -267,6 +267,11 @@ sub run {
     }
     select_virtio_console();
 
+    if (script_output('cat /sys/module/printk/parameters/time') eq 'N') {
+        script_run('echo 1 > /sys/module/printk/parameters/time');
+        $grub_param = 'printk.time=1';
+    }
+
     # check kGraft if KGRAFT=1
     if (check_var("KGRAFT", '1')) {
         assert_script_run("uname -v | grep -E '(/kGraft-|/lp-)'");
@@ -276,8 +281,8 @@ sub run {
 
     add_we_repo_if_available;
 
-    $grub_param = 'console=hvc0'     if (get_var('ARCH') eq 'ppc64le');
-    $grub_param = 'console=ttysclp0' if (get_var('ARCH') eq 's390x');
+    $grub_param .= ' console=hvc0'     if (get_var('ARCH') eq 'ppc64le');
+    $grub_param .= ' console=ttysclp0' if (get_var('ARCH') eq 's390x');
     if (defined $grub_param) {
         add_grub_cmdline_settings($grub_param);
     }


### PR DESCRIPTION
Verification run
on affected ppc64le
- previous: https://openqa.suse.de/tests/2068247/file/serial0.txt (no dmesg at all, only bootloader).
- new: http://quasar.suse.cz/tests/985/file/serial0.txt (whole dmesg, with timestamps :))
- http://quasar.suse.cz/tests/984

x68_64 (just for check new one):
- http://quasar.suse.cz/tests/980
- http://quasar.suse.cz/tests/981

Not tested on s390x.