### PR TITLE
Handle select hard disk screen in leap

### DIFF
--- a/tests/installation/partitioning_togglehome.pm
+++ b/tests/installation/partitioning_togglehome.pm
@@ -21,7 +21,11 @@ sub run {
     record_soft_failure 'boo#1093372' if (!get_var('TOGGLEHOME') && is_leap('15.1+'));
     send_key $cmd{guidedsetup};
     if (is_storage_ng) {
-        assert_screen 'partition-scheme';
+        assert_screen [qw(existing-partitions partition-scheme)];
+        if (match_has_tag 'existing-partitions') {
+            send_key $cmd{next};
+            assert_screen 'partition-scheme';
+        }
         send_key $cmd{next};
         installation_user_settings::await_password_check if get_var('ENCRYPT');
     }


### PR DESCRIPTION
- Related ticket: [[functional][y] test fails in partitioning_togglehome - "select hard disk" shown](https://progress.opensuse.org/issues/40292)
- Verification runs: [opensuse-15.1-DVD-x86_64-Build307.2-gnome+import_ssh_keys@64bit-2G](http://dhcp128.suse.cz/tests/6509#step/partitioning_togglehome/1)
[opensuse-15.1-DVD-x86_64-Build307.2-gnome+do_not_import_ssh_keys@64bit-2G](http://dhcp128.suse.cz/tests/6510#step/partitioning_togglehome/1)
[sle-15-SP1-Installer-DVD-x86_64-Build50.1-lvm+resize_root@64bit](http://dhcp128.suse.cz/tests/6508#step/partitioning_togglehome/1)
