### PR TITLE
Improve yast2_dns: false positive and bsc#1102235

### DIFF
--- a/lib/yast2_widget_utils.pm
+++ b/lib/yast2_widget_utils.pm
@@ -18,7 +18,16 @@ use Exporter;
 use strict;
 use testapi;
 
-our @EXPORT = qw(change_service_configuration);
+our @EXPORT = qw(change_service_configuration verify_service_configuration);
+
+=head2 verify_service_configuration
+Verify service configuration: status
+=cut
+sub verify_service_configuration {
+    my (%args) = @_;
+    my $status = $args{status};
+    assert_screen "yast2_ncurses_service_$status";
+}
 
 =head2 change_service_configuration
 Modify service configuration: "after writing" and/or "after reboot" steps


### PR DESCRIPTION
Improve yast2_dns: false positive and bsc#1102235. In newer products it is used apply button to check first that the service state was modified in the new widget and then double-check it in the console. For older products we already were checking with needles the change of the service on the gui (as it is done on the fly). For the first run is different (there is no apply) and we need use some timeout strategy in the code. I checked a better way (changing configuration file for the service for systemctl to be able to wait longer but it is not possible in this case due to yast has not eve written the file yet in the first run. I also added some useful record_info for presenting better the phases of this test and I did some refactor.

- Related ticket: https://progress.opensuse.org/issues/41186
- Needles: [needles_opensuse](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/441) and [needles_sle](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/947)
- Verification run:
  - [Tumbleweed yast2_ncurses yast2_dns](http://dhcp42.suse.cz/tests/92#step/yast2_dns_server/96)
  - [sle-15-SP1-yast2_ncurses](http://dhcp42.suse.cz/tests/93#step/yast2_dns_server/91)
  - [sle-12-SP4 yast2_ncurses yast2_dns](http://dhcp42.suse.cz/tests/91#step/yast2_dns_server/45)
