### PR TITLE
Increase ssh_vnc_wait_time for impi

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -109,7 +109,7 @@ sub run {
     save_screenshot;
 
     if ((check_var('BACKEND', 'ipmi') && !get_var('AUTOYAST')) || get_var('SES5_DEPLOY')) {
-        my $ssh_vnc_wait_time = get_var('SES5_DEPLOY') ? 300 : 210;
+        my $ssh_vnc_wait_time = 300;
         assert_screen((check_var('VIDEOMODE', 'text') ? 'sshd' : 'vnc') . '-server-started', $ssh_vnc_wait_time);
         select_console 'installation';
 


### PR DESCRIPTION
- see https://progress.opensuse.org/issues/41693
- verification run
  http://e13.suse.de/tests/8638#step/boot_from_pxe/8
