### PR TITLE
Blackscreen is not a screenlock on liveCD, only for XFCE/LXDE

### DIFF
--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -125,7 +125,7 @@ sub run {
             send_key 'alt-o';    # ok
             next;
         }
-        if (get_var('LIVECD') and match_has_tag('screenlock')) {
+        if (get_var('LIVECD') and match_has_tag('screenlock') and !match_has_tag('blackscreen')) {
             handle_livecd_screenlock;
             $screenlock_previously_detected = 1;
             next;


### PR DESCRIPTION
so make sure we do not handle the blackscreen as a screenlock

- Related ticket: https://progress.opensuse.org/issues/40799
