### PR TITLE
Remove apache2-example-pages to avoid warning message shown

### DIFF
--- a/tests/x11/smt.pm
+++ b/tests/x11/smt.pm
@@ -24,6 +24,8 @@ sub run {
     # Avoid blank screen since smt sync needs time
     turn_off_gnome_screensaver;
     become_root;
+    # remove apache2-example-pages to avoid warning message shown during smt test
+    assert_script_run 'rpm -qa apache2-example-pages && rpm -e apache2-example-pages';
     smt_wizard();
     assert_script_run 'smt-sync', 800;
     assert_script_run 'smt-repos';


### PR DESCRIPTION
The unexpected warning message will be shown if we do smt regression test with all patterns selected on base system. We need remove the apache2-example-pages before smt regression test, then no warning message shown any more and this fix won't affect any other test.

- Related ticket: https://progress.opensuse.org/issues/41591
- Verification run: http://openqa-apac1.suse.de/tests/1729
