### PR TITLE
Only press Alt-Tab if the screenlock is a black screen in await_install

### DIFF
--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -27,8 +27,10 @@ sub handle_livecd_screenlock {
         # the only 'window' shown, tab over the empty password field and
         # confirm unlocking
         send_key 'alt-tab';
-        send_key 'tab';
-        send_key 'ret';
+        if (!match_has_tag('blackscreen')) {
+            send_key 'tab';
+            send_key 'ret';
+        }
     } while (check_screen('screenlock', 20));
     save_screenshot;
     # can take a long time until the screen unlock happens as the


### PR DESCRIPTION
A black screen might just be power saving and not the lockscreen, in
which case no "destructive" keyboard input must be done. In case the
lockscreen shows after waking the display up, it is handled like it was before.

Fixes https://progress.opensuse.org/issues/40799
Verification run: http://10.160.67.86/tests/157