### PR TITLE
[CLOUD] Install azure-cli in install_ipa module

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2066,9 +2066,9 @@ sub load_toolchain_tests {
 }
 
 sub load_publiccloud_tests {
-    loadtest "publiccloud/install_ipa"  if get_var('INSTALL_IPA');
-    loadtest "publiccloud/upload_image" if get_var('PUBLIC_CLOUD_IMAGE_LOCATION');
-    loadtest "publiccloud/ipa"          if get_var('PUBLIC_CLOUD_IPA_TESTS');
+    loadtest "publiccloud/prepare_tools" if get_var('PUBLIC_CLOUD_PREPARE_TOOLS');
+    loadtest "publiccloud/upload_image"  if get_var('PUBLIC_CLOUD_IMAGE_LOCATION');
+    loadtest "publiccloud/ipa"           if get_var('PUBLIC_CLOUD_IPA_TESTS');
 }
 
 sub load_common_opensuse_sle_tests {

--- a/tests/publiccloud/install_ipa.pm
+++ b/tests/publiccloud/install_ipa.pm
@@ -65,6 +65,12 @@ sub run {
     assert_script_run("touch .config/ipa/config");
     assert_script_run("ipa list");
     assert_script_run("ipa --version");
+
+    # install azure cli
+    zypper_call('in curl');
+    assert_script_run('sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc');
+    zypper_call('addrepo --name "Azure CLI" --check https://packages.microsoft.com/yumrepos/azure-cli azure-cli');
+    zypper_call('install --from azure-cli -y azure-cli');
 }
 
 sub test_flags {

--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -81,12 +81,12 @@ sub test_flags {
 
 =head1 Discussion
 
-Install IPA tool in SLE image. This image gets published and can be used 
+Install public cloud tools in SLE image. This image gets published and can be used 
 for specific tests for azure, amazon and google CSPs.
 
 =head1 Configuration
 
-=head2 INSTALL_IPA
+=head2 PUBLIC_CLOUD_PREPARE_TOOLS
 
 Activate this test module by setting this variable.
 

--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -41,12 +41,6 @@ sub prepare_os {
         zypper_call('in python-ec2uploadimg');
         assert_script_run("curl " . data_url('publiccloud/ec2utils.conf') . " -o /root/.ec2utils.conf");
     }
-    elsif (check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {
-        zypper_call('in curl');
-        assert_script_run('sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc');
-        zypper_call('addrepo --name "Azure CLI" --check https://packages.microsoft.com/yumrepos/azure-cli azure-cli');
-        zypper_call('install --from azure-cli -y azure-cli');
-    }
 }
 
 sub provider_factory {


### PR DESCRIPTION
The install_ipa module is the central place to install all common
publiccloud tools.
This cleanup is needed for further changes.

- Related ticket: https://progress.opensuse.org/issues/38738
- Verification run: 
      http://cfconrad-vm.qa.suse.de/tests/1639 (upload_image)
      http://cfconrad-vm.qa.suse.de/tests/1635 (install_ipa)
