### PR TITLE
Use light html5test page for first run

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -521,7 +521,7 @@ sub start_clean_firefox {
 
     x11_start_program('xterm');
     # Clean and Start Firefox
-    type_string "killall -9 firefox;rm -rf .moz* .config/iced* .cache/iced* .local/share/gnome-shell/extensions/*; firefox suse.com >firefox.log 2>&1 &\n";
+    type_string "killall -9 firefox;rm -rf .moz* .config/iced* .cache/iced* .local/share/gnome-shell/extensions/*; firefox html5test.opensuse.org >firefox.log 2>&1 &\n";
     assert_screen 'firefox-launch', 150;
     # maximize window
     send_key 'alt-f10' if is_sle('<=12-sp1');


### PR DESCRIPTION
any page is better and easier to load than suse.com

- Related ticket: https://progress.opensuse.org/issues/40637
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/946
- Verification run: http://10.100.12.155/tests/7129