### PR TITLE
Add needle match for pidgin ready status for IRC

### DIFF
--- a/tests/x11/pidgin/pidgin_IRC.pm
+++ b/tests/x11/pidgin/pidgin_IRC.pm
@@ -40,7 +40,7 @@ sub run {
     assert_and_click 'pidgin-irc-account';
 
     # Warning of spoofing ip may appear
-    assert_screen([qw(pidgin-spoofing-ip pidgin-irc-sledtesting)]);
+    assert_screen([qw(pidgin-spoofing-ip pidgin-ready)]);
     if (match_has_tag('pidgin-spoofing-ip')) {
         wait_screen_change {
             send_key is_sle('<15') ? "alt-tab" : "alt-`";
@@ -51,9 +51,10 @@ sub run {
     }
 
     # CTCP Version and warning about scan may appear
-    assert_screen([qw(pidgin-ctcp-version pidgin-irc-sledtesting)]);
+    assert_screen([qw(pidgin-ctcp-version pidgin-ready)]);
     if (match_has_tag('pidgin-ctcp-version')) {
-        wait_screen_change { send_key "ctrl-w"; }    # close it
+        wait_screen_change { send_key "ctrl-w" };    # close it
+        assert_screen("pidgin-ready");               # Assure that pidgin is ready
     }
 
     # Join a chat


### PR DESCRIPTION
Fix poo#41201: Pidgin test randomly fails on spoofing and ctcp version
check. There is multi assert match with incorrect needle sledtesting.
Needle appears only after keyboard input, not at this stage. New needle
match for pidgin ready status was created to avoid situation.

- Related ticket: https://progress.opensuse.org/issues/41201
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/948
- Verification run: 
SLE15: http://10.100.12.105/tests/331#step/pidgin_IRC/15
SLE12SP3: http://10.100.12.105/tests/330#step/pidgin_IRC/14
