### PR TITLE
Fix post_fail_hook to get logs

### DIFF
--- a/tests/x11/gnomecase/change_password.pm
+++ b/tests/x11/gnomecase/change_password.pm
@@ -152,10 +152,4 @@ sub run {
     send_key "ret";
 }
 
-sub post_fail_hook {
-    my ($self) = @_;
-    # get rid of plymouth splash during reboot
-    send_key 'esc' if $self->{await_reboot};
-}
-
 1;


### PR DESCRIPTION
- Fail without logs: https://openqa.suse.de/tests/2109076#step/change_password/42
- Verification run: http://10.100.12.155/tests/7140
