### PR TITLE
Hyper-V 2016 actually uses 'the object is in use'

### DIFF
--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -235,7 +235,7 @@ sub run {
       . get_var('HYPERV_SERVER') . ' +auto-reconnect /auto-reconnect-max-retries:10'
       . " /cert-ignore /vmconnect:$vmguid /f /log-level:DEBUG 2>&1 > $xfreerdp_log; echo $vmguid > xfreerdp_${name}_stop; done; ";
 
-    hyperv_cmd_with_retry("$ps Start-VM $name", {msg => ($winserver eq '2016') ? 'used by another process' : undef});
+    hyperv_cmd_with_retry("$ps Start-VM $name");
 
     # ...we execute the command right after VMs starts.
     send_key 'ret';


### PR DESCRIPTION
https://progress.opensuse.org/issues/41144

`hyperv_cmd_with_retry` is used in situations where the Hyper-V command
fails because the image is still downloaded by another job but we
attempted to use it.

It was a mistake to expect 'used by another process' in such cases 'The
operation cannot be performed while the object is in use.' (the actual
default here) should be used instead. Now, `Start-VM` command will be
re-triggered after some time.