### PR TITLE
Disable btrfs maintenance cron jobs on SLE12

### DIFF
--- a/tests/console/force_scheduled_tasks.pm
+++ b/tests/console/force_scheduled_tasks.pm
@@ -45,6 +45,8 @@ sub run {
     assert_script_run(
         'for i in $(systemctl list-units --type=timer --state=active --no-legend | sed -e \'s/\(\S\+\)\.timer\s.*/\1/\'); do ' . $systemd_tasks_cmd . '; done');
     record_soft_failure 'bsc#1063638 - review I/O scheduling parameters of btrfsmaintenance' if (time - $before) > 60 && get_var('SOFTFAIL_BSC1063638');
+    # Disable cron jobs on older SLE12 by symlinking them to /bin/true
+    assert_script_run('find /usr/share/btrfsmaintenance/ -type f -exec ln -fs /bin/true {} \;') unless get_var('SOFTFAIL_BSC1063638');
     sleep 3;    # some head room for the load average to rise
     settle_load;
 


### PR DESCRIPTION
The cron jobs are disabled on SLE12 due to boo#1063638 bug, which kills
system performance and fails many openQA tests after feature was
introduced in https://fate.suse.com/312751.

Nevertheless, the jobs are not disabled for 'system_performance' module
in order to have the issue reproducible there.

- Related ticket: [poo#41462](https://progress.opensuse.org/issues/41462)
- Verification runs:

    -  Regular scenario on SLE12 SP4 (cron jobs are disabled): http://oorlov-vm.qa.suse.de/tests/185#step/force_scheduled_tasks/1
    - 'system_performance' on SLE12 SP4 (cron jobs are not disabled): http://oorlov-vm.qa.suse.de/tests/190#step/force_scheduled_tasks/1
