### PR TITLE
boot_from_pxe: Be even more forgiving with slow installation startup

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -109,7 +109,7 @@ sub run {
     save_screenshot;
 
     if ((check_var('BACKEND', 'ipmi') && !get_var('AUTOYAST')) || get_var('SES5_DEPLOY')) {
-        my $ssh_vnc_wait_time = 300;
+        my $ssh_vnc_wait_time = 600;
         assert_screen((check_var('VIDEOMODE', 'text') ? 'sshd' : 'vnc') . '-server-started', $ssh_vnc_wait_time);
         select_console 'installation';
 


### PR DESCRIPTION
As we have seen in https://progress.opensuse.org/issues/41693 as well as
https://progress.opensuse.org/issues/31375
we do have some machines which would boot up after long time but do not
manage to complete within 300s which is already pretty long but given
that the initial bootup of the installation system also includes some
potential hardware discovery it might take longer depending on specific
hardware setups. We can be more forgiving here as installation is
assumed to be conducted not that often as boots/reboots of the installed
system.

Related progress issue: https://progress.opensuse.org/issues/41693