### PR TITLE
Add PReP partition when leaving partition_warnings module

### DIFF
--- a/tests/installation/partitioning_warnings.pm
+++ b/tests/installation/partitioning_warnings.pm
@@ -179,7 +179,7 @@ sub run {
     else {
         ## Clean up previous root
         remove_partition;
-        addboot if get_var('UEFI');
+        addboot if (get_var('UEFI') || get_var('OFW'));
         addpart(role => 'swap', size => 500);
     }
 


### PR DESCRIPTION
- Related ticket: [[openSUSE][functional][y][yast] Check warning for too small PReP (ppc), EFI (aarch64), Bios Boot (x86_64+GPT) or root partition / on openSUSE](https://progress.opensuse.org/issues/40940) & [[sle][functional][y] test fails in partitioning_filesystem - changes in partitoning_warning breaks partitioning_filesystem](https://progress.opensuse.org/issues/41618)
