### PR TITLE
JeOS: Disable GRUB timeout

### DIFF
--- a/tests/jeos/grub2_gfxmode.pm
+++ b/tests/jeos/grub2_gfxmode.pm
@@ -22,6 +22,7 @@ use bootloader_setup qw(change_grub_config grep_grub_settings grub_mkconfig set_
 sub run {
     change_grub_config('=.*', '=1024x768', 'GRUB_GFXMODE=');
     change_grub_config('^#',  '',          'GRUB_GFXMODE');
+    change_grub_config('=.*', '=-1',       'GRUB_TIMEOUT');
     grep_grub_settings('^GRUB_GFXMODE=1024x768$');
     set_framebuffer_resolution;
     set_extrabootparams_grub_conf;


### PR DESCRIPTION
https://progress.opensuse.org/issues/41888

Sometimes screen is stuck and GRUB is missed:
https://openqa.suse.de/tests/2110503#step/snapper_jeos_cli/86

We should do the same SLE did, to disable the timeout.

Validation runs:
* QEMU: http://nilgiri.suse.cz/tests/overview?distri=sle&version=12-SP4&build=6.61&groupid=2
* Hyper-V: http://nilgiri.suse.cz/tests/1206