### PR TITLE
[NFV] Fix dpdk_devbind tool path

### DIFF
--- a/data/nfv/conf/02_vswitch.conf
+++ b/data/nfv/conf/02_vswitch.conf
@@ -57,8 +57,7 @@ PATHS['dpdk'] = {
             'testpmd': os.path.join(RTE_TARGET, 'app', 'testpmd'),
         },
         'bin': {
-            'bind-tool': '/usr/share/dpdk/tools/dpdk*bind.py',
-            'bind-tool': '/root/dpdk/usertools/dpdk-devbind.py',
+            'bind-tool': '/usr/share/dpdk/usertools/dpdk-devbind.py',
             'modules' : ['uio', 'igb_uio'],
             'testpmd' : 'testpmd'
         }

--- a/tests/nfv/prepare_env.pm
+++ b/tests/nfv/prepare_env.pm
@@ -49,7 +49,7 @@ sub run {
     my $child_id       = (keys %$children)[0];
 
     record_info("INFO", "Install needed packages for NFV tests: OVS, DPKD, QEMU");
-    zypper_call('--quiet in git-core openvswitch-switch dpdk qemu tcpdump', timeout => 60 * 4);
+    zypper_call('--quiet in git-core openvswitch-switch dpdk dpdk-tools qemu tcpdump', timeout => 60 * 4);
 
     assert_script_run("cd /root/");
     record_info("INFO", "Clone VSPerf repository");


### PR DESCRIPTION
dpdk repository is not cloned any longer and the dpdk_devbind tool was not updated properly. By installing the package dpdk-tools, we make sure  dpdk-devbind.py is there and no need to clone dpdk repo.
