### PR TITLE
Rename norollback to no_rollback

### DIFF
--- a/tests/caasp/transactional_update.pm
+++ b/tests/caasp/transactional_update.pm
@@ -100,7 +100,7 @@ sub run {
 }
 
 sub test_flags {
-    return {norollback => 1};
+    return {no_rollback => 1};
 }
 
 1;


### PR DESCRIPTION
Related to [change in os-autoinst](https://github.com/os-autoinst/os-autoinst/pull/1034).

As per feedback in the PR.

Please, only merge after https://github.com/os-autoinst/os-autoinst/pull/1034 is merged and deployed.

See [poo#30775](https://progress.opensuse.org/issues/30775).

