### PR TITLE
Migration: Prolong bootloader timeout

### DIFF
--- a/tests/migration/sle12_online_migration/zypper_patch.pm
+++ b/tests/migration/sle12_online_migration/zypper_patch.pm
@@ -27,7 +27,7 @@ sub run {
     fully_patch_system;
     remove_ltss;
     power_action('reboot', keepconsole => 1, textmode => 1);
-    $self->wait_boot(textmode => !is_desktop_installed, ready_time => 600);
+    $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 300, ready_time => 600);
     $self->setup_migration;
 }
 


### PR DESCRIPTION
Fail: https://openqa.suse.de/tests/2114498#step/zypper_patch/17

Sometimes 100 seconds is not enough to reboot to the upgraded system.
300 seconds will hopefuly make it more stable.