### PR TITLE
Adjust YaST2 Samba after logon drive

### DIFF
--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -73,26 +73,24 @@ sub setup_yast2_ldap_server {
         s => 'ca_cert_pem',
         v => 'srv_cert_key_pkcs12'
     );
-
     assert_script_run 'wget ' . data_url('console/samba_ca_cert.pem');
     assert_script_run 'wget ' . data_url('console/samba_server_cert.p12');
-
     # setup FQDN hostname
     assert_script_run("hostname $ldap_directives{fqdn}");
     assert_script_run("echo \"127.0.0.1 $ldap_directives{fqdn} openqa\" > /etc/hosts");
     assert_script_run("echo \"$ldap_directives{fqdn}\" > /etc/hostname");
 
+    record_info 'Setup LDAP', 'Create New Directory Instance';
     script_run("yast2 ldap-server; echo yast2-ldap-server-status-\$? > /dev/$serialdev ", 0);
-
-    # setup LDAP
     wait_still_screen(2);
     foreach (sort keys %ldap_options_to_dirs) {
         wait_screen_change { send_key "alt-$_" };
         type_string($ldap_directives{$ldap_options_to_dirs{$_}} . "\n");
     }
     assert_screen 'yast2_samba-389ds-setup';
-    send_key "alt-o";
-    # workaround for cert name issue
+    send_key $cmd{ok};
+
+    record_info 'Setup LDAP',                                 'Workaround for cert name issue';
     assert_screen 'yast2_samba-389ds-setup-error-workaround', 90;
     send_key 'ret';
     wait_screen_change { send_key "alt-c" };
@@ -100,177 +98,6 @@ sub setup_yast2_ldap_server {
     assert_script_run('certutil -d /etc/dirsrv/slapd-openqatest --rename -n "openqa.ldaptest.org - Suse" --new-n Server-Cert');
     systemctl 'start dirsrv@' . $ldap_directives{dir_instance};
     systemctl 'status dirsrv@' . $ldap_directives{dir_instance};
-}
-
-sub setup_ldap_in_samba {
-    ## swith to LDAP Settings
-    send_key 'alt-l';
-    assert_screen 'yast2_samba-server_ldap-settings';
-    send_key 'alt-b';
-    assert_screen 'yast2_samba-server_ldap_value_rewritten';
-    send_key 'alt-y';
-    assert_screen 'yast2_samba-server_ldap_passwd_checked';
-    send_key 'alt-e';
-    type_string 'ldap://localhost:389';
-    # set admin password and search base dn
-    wait_screen_change { send_key 'alt-a' };
-    type_string(is_sle('<15') ? $ldap_directives{dir_manager_dn} . ",$ldap_directives{dir_suffix}" : $ldap_directives{dir_manager_dn});
-    wait_screen_change { send_key 'alt-p' };
-    type_string($ldap_directives{dir_manager_passwd});
-    wait_screen_change { send_key 'alt-g' };
-    type_string($ldap_directives{dir_manager_passwd});
-    wait_screen_change { send_key 'alt-n' };
-    type_string($ldap_directives{dn_container});
-    # check advanced settings befor run test connection to ldap server
-    wait_screen_change { send_key 'alt-v' };
-    send_key 'ret';
-    # enter expert ldap settings
-    assert_screen 'yast2_samba-server_ldap_advanced_expert_settings';
-
-    ## expert ldap settings
-    # change replication sleep and time-out
-    wait_screen_change { send_key 'alt-p' };
-    type_string "990\n";
-    wait_screen_change { send_key 'alt-t' };
-    type_string "7\n";
-
-    # change to not use SSL or TLS
-    wait_screen_change { send_key 'alt-u' };
-    send_key 'up';
-    assert_screen 'yast2_samba-server_ldap_advanced_expert_settings_not-use-ssl';
-    send_key 'ret';
-    wait_screen_change { send_key 'alt-o' };
-
-    # now run test connection
-    send_key 'alt-t';
-    assert_screen 'yast2_samba-server_ldap_test-connection';
-    wait_screen_change { send_key 'alt-o' };
-}
-
-sub setup_samba {
-    script_run("yast2 samba-server; echo yast2-samba-server-status-\$? > /dev/$serialdev", 0);
-
-    # samba-server configuration for SLE older than 15 or opensuse TW
-    assert_screen([qw(yast2_samba_installation yast2_still_susefirewall2)], 60);
-    if (match_has_tag 'yast2_still_susefirewall2') {
-        send_key 'alt-c';
-    }
-
-    wait_screen_change { send_key 'alt-w' };
-    for (1 .. 12) { send_key 'backspace'; }
-    # give a new name for Workgroup
-    type_string($samba_directives{workgroup});
-    assert_screen 'yast2_samba-server_workgroup_new';
-    send_key 'alt-n';
-
-    ## Handle Domain Controller in sle12
-    if (is_sle('<15') || is_leap('<15.0')) {
-        # select "Not a Domain Controller"
-        assert_screen 'yast2_samba_server_selection';
-        send_key 'alt-c';
-
-        # check "Not a DC" is select
-        assert_screen 'yast2_samba-server_not-a-dc_selected';
-        send_key 'alt-n';
-    }
-
-    # service starts during boot, wait to load default data
-    assert_screen 'yast2_samba-startup-configuration';
-    if (is_sle('<15') || is_leap('<15.1')) {
-        send_key 'alt-r';
-        assert_screen 'yast2_samba-server_start-during-boot';
-    }
-    else {
-        change_service_configuration(
-            after_writing => {start         => 'alt-e'},
-            after_reboot  => {start_on_boot => 'alt-a'}
-        );
-    }
-    # open firewalld port
-    send_key 'alt-f';
-    assert_screen 'yast2_samba_open_port_firewall';
-
-    ## switch to Samba Configuration - Shares
-    send_key 'alt-s';
-    wait_still_screen(2);
-    assert_screen 'yast2_samba-server_shares';
-    # add a shares config html_public
-    send_key 'alt-a';
-    assert_screen 'yast2_samba-server_new-share';
-    # enter share details
-    send_key 'alt-n';
-    type_string('html_public');
-    wait_screen_change { send_key 'alt-a' };    # set share description
-    type_string($samba_directives{comment});
-    wait_screen_change { send_key 'alt-s' };
-    for (1 .. 5) { send_key 'backspace'; }
-    type_string($samba_directives{path});       # set share path to /home/html_public
-    send_key 'alt-r';                           # set read-only
-
-    # check config before confirm new share with ok, confirm to create new share path
-    assert_screen 'yast2_samba-server_new-share_create';
-    send_key 'alt-o';
-    assert_screen 'yast2_samba-server_new-share-path';
-    send_key 'alt-y';                           # confirm new path
-
-    # back to samba configuration and make some changes to share directories
-    assert_screen 'yast2_samba-added_html_share';
-    send_key 'alt-w';                           # allow users to share directories
-    wait_screen_change { send_key 'alt-g' };    # allow guest access
-    send_key 'alt-m';
-    type_string($samba_directives{usershare_max_shares} . "\n");    # Maximum number of shares
-
-    ## switch to identity configuration
-    send_key 'alt-d';
-    assert_screen 'yast2_samba-server_identity';
-
-    ## domain controller in sle15
-    # select "Not a Domain Controller"
-    if (is_sle('>=15') || is_leap('>=15.0') || is_tumbleweed) {
-        wait_screen_change { send_key 'alt-a' };
-        send_key 'ret';
-        # check "Not a DC" is select
-        assert_screen 'yast2_samba-server_not-a-dc_selected';
-    }
-
-    # use wins server support and check NetBIOS hostname Advanced settings
-    wait_screen_change { send_key 'alt-i' };
-    wait_screen_change { send_key 'alt-e' };
-    type_string($samba_directives{netbios_name});
-    send_key 'alt-v';
-    assert_screen 'yast2_samba-server_identity_netbios_advanced_expert';
-    send_key 'ret';
-    assert_screen 'yast2_samba-server_netbios_name_change_warning';
-    wait_screen_change { send_key 'alt-o' };
-    # change logon drive to C:
-    send_key_until_needlematch 'yast2_samba-server_netbios_logon-drive', 'down';
-    wait_screen_change { send_key 'ret' };
-    for (1 .. 2) { send_key 'backspace'; }
-    type_string($samba_directives{logon_drive});
-    wait_screen_change { send_key 'alt-o' };
-    send_key 'alt-o';
-
-    ## swith to Trusted Domains
-    # add a trusted domain, wait while all data is properly loaded
-    wait_still_screen(2);
-    send_key 'alt-t';
-    assert_screen 'yast2_samba-server_trusted-domains';
-    wait_screen_change { send_key 'alt-a' };
-    type_string('suse.de');
-    wait_screen_change { send_key 'alt-p' };
-    type_string('testing');
-    send_key 'alt-o';
-    assert_screen 'yast2_samba-server_trusted-domains_error';
-    wait_screen_change { send_key 'alt-o' };
-    assert_screen 'yast2_samba-server_trusted-domains_cancel_configuration';
-    wait_screen_change { send_key 'alt-c' };
-
-    #setup samba
-    setup_ldap_in_samba;
-
-    # finally, close with OK
-    send_key 'alt-o';
-    wait_serial('yast2-samba-server-status-0', 60) || die "'yast2 samba-server' didn't finish";
 }
 
 sub setup_yast2_auth_server {
@@ -326,11 +153,237 @@ sub setup_yast2_auth_server {
     systemctl "show -p ActiveState slapd.service | grep ActiveState=active";
 }
 
-sub run {
-    my $self = shift;
+sub set_workgroup {
+    record_info 'Samba Installation', 'Step 1 of 1';
+    my %actions = (name => {shortcut => 'alt-w', value => $samba_directives{workgroup}});
+    assert_screen 'yast2_samba_installation';
+    wait_screen_change { send_key $actions{name}->{shortcut} };
+    for (1 .. 12) { send_key 'backspace'; }
+    type_string $actions{name}->{value};
+    assert_screen 'yast2_samba-server_workgroup_new';
+    send_key $cmd{next};
+}
 
+sub handle_domain_controller {
+    record_info 'Samba Installation', 'Handle domain controller';
+    # select "Not a Domain Controller"
+    assert_screen 'yast2_samba_server_selection';
+    send_key 'alt-c';
+    # check "Not a DC" is select
+    assert_screen 'yast2_samba-server_not-a-dc_selected';
+    send_key 'alt-n';
+}
+
+sub setup_samba_startup {
+    record_info 'Samba Configuration', 'Start-Up';
+    my %actions = (firewall => {shortcut => 'alt-f'});
+
+    assert_screen 'yast2_samba-startup-configuration';
+    if (is_sle('<15') || is_leap('<15.1')) {
+        send_key 'alt-r';
+        assert_screen 'yast2_samba-server_start-during-boot';
+    }
+    else {
+        change_service_configuration(
+            after_writing => {start         => 'alt-e'},
+            after_reboot  => {start_on_boot => 'alt-a'}
+        );
+    }
+    send_key $actions{firewall}->{shortcut};
+    assert_screen 'yast2_samba_open_port_firewall';
+}
+
+sub setup_samba_share {
+    record_info 'Samba Configuration', 'Shares';
+    my %actions = (
+        shares             => {shortcut => 'alt-s'},
+        name               => {shortcut => 'alt-n', value => 'html_public'},
+        description        => {shortcut => 'alt-a', value => $samba_directives{comment}},
+        path               => {shortcut => 'alt-s', value => $samba_directives{path}},
+        readonly           => {shortcut => 'alt-r'},
+        yes                => {shortcut => 'alt-y'},
+        allow_users        => {shortcut => 'alt-w'},
+        allow_guest_access => {shortcut => 'alt-g'},
+        maximum            => {shortcut => 'alt-m', value => $samba_directives{usershare_max_shares} . "\n"},
+    );
+
+    send_key $actions{shares}->{shortcut};
+    assert_screen 'yast2_samba-server_shares';
+    send_key $cmd{add};
+
+    # Identification
+    assert_screen 'yast2_samba-server_new-share';
+    send_key $actions{name}->{shortcut};
+    type_string $actions{name}->{value};
+    wait_screen_change { send_key $actions{description}->{shortcut} };
+    type_string $actions{description}->{value};
+
+    # Share Type
+    wait_screen_change { send_key $actions{path}->{shortcut}; };
+    for (1 .. 5) { send_key 'backspace'; }
+    type_string $actions{path}->{value};
+    send_key $actions{readonly}->{shortcut};
+    assert_screen 'yast2_samba-server_new-share_create';
+    send_key $cmd{ok};
+    assert_screen 'yast2_samba-server_new-share-path';
+    send_key $actions{yes}->{shortcut};
+
+    # back to samba configuration and make some changes to share directories
+    assert_screen 'yast2_samba-added_html_share';
+    send_key $actions{allow_users}->{shortcut};
+    wait_screen_change { send_key $actions{allow_guest_access}->{shortcut} };
+    send_key $actions{maximum}->{shortcut};
+    type_string $actions{maximum}->{value};
+}
+
+sub setup_samba_identity {
+    record_info 'Samba Configuration', 'Identity';
+    my %actions = (
+        identity          => {shortcut => 'alt-d'},
+        domain_controller => {shortcut => 'alt-a'},
+        win_server        => {shortcut => 'alt-i'},
+        netbios           => {shortcut => 'alt-e', value => $samba_directives{netbios_name}},
+        advanced          => {shortcut => 'alt-v'},
+        logon_drive       => {value    => $samba_directives{logon_drive}}
+    );
+
+    send_key $actions{identity}->{shortcut};
+    assert_screen 'yast2_samba-server_identity';
+    # select "Not a Domain Controller" in new products
+    if (is_sle('>=15') || is_leap('>=15.0') || is_tumbleweed) {
+        wait_screen_change { send_key $actions{domain_controller}->{shortcut} };
+        send_key 'ret';
+        # check "Not a DC" is select
+        assert_screen 'yast2_samba-server_not-a-dc_selected';
+    }
+    wait_screen_change { send_key $actions{win_server}->{shortcut} };
+    wait_screen_change { send_key $actions{netbios}->{shortcut} };
+    type_string $actions{netbios}->{value};
+    send_key $actions{advanced}->{shortcut};
+    assert_screen 'yast2_samba-server_identity_netbios_advanced_expert';
+    send_key 'ret';
+    assert_screen 'yast2_samba-server_netbios_name_change_warning';
+    wait_screen_change { send_key $cmd{ok} };
+    # change logon drive to C:
+    send_key_until_needlematch 'yast2_samba-server_netbios_logon-drive', 'down';
+    wait_screen_change { send_key 'ret' };
+    for (1 .. 2) { send_key 'backspace'; }
+    type_string $actions{logon_drive}->{value};
+    wait_screen_change { send_key $cmd{ok} };
+    send_key $cmd{ok};
+    # return back to last tab (when some tab is navigated ncurses highlights all letters)
+    assert_screen 'yast2_samba-server_identity_navigated';
+}
+
+sub setup_samba_trusted_domains {
+    record_info 'Samba Configuration', 'Trusted domains';
+    my %actions = (
+        trusted_domains => {shortcut => 'alt-t', value => "990\n"},
+        name            => {value    => 'suse.de'},
+        password        => {shortcut => 'alt-p', value => 'testing'}
+    );
+    send_key $actions{trusted_domains}->{shortcut};
+    assert_screen 'yast2_samba-server_trusted-domains';
+    wait_screen_change { send_key $cmd{add} };
+    type_string $actions{name}->{value};
+    wait_screen_change { send_key $actions{password}->{shortcut} };
+    type_string $actions{password}->{value};
+    send_key $cmd{ok};
+
+    assert_screen 'yast2_samba-server_trusted-domains_error';
+    wait_screen_change { send_key $cmd{ok} };
+    assert_screen 'yast2_samba-server_trusted-domains_cancel_configuration';
+    wait_screen_change { send_key $cmd{cancel} };
+}
+
+sub setup_samba_ldap {
+    record_info 'Samba Configuration', 'LDAP Settings';
+    my $administratio_dn = is_sle('<15') ? $ldap_directives{dir_manager_dn} . ",$ldap_directives{dir_suffix}" : $ldap_directives{dir_manager_dn};
+    my %actions = (
+        ldap                 => {shortcut => 'alt-l'},
+        use_password_backend => {shortcut => 'alt-b'},
+        yes                  => {shortcut => 'alt-y'},
+        server_url           => {shortcut => 'alt-e', value => 'ldap://localhost:389'},
+        administration_dn    => {shortcut => 'alt-a', value => $administratio_dn},
+        password             => {shortcut => 'alt-p', value => $ldap_directives{dir_manager_passwd}},
+        password_retry       => {shortcut => 'alt-g', value => $ldap_directives{dir_manager_passwd}},
+        search_base_dn       => {shortcut => 'alt-n', value => $ldap_directives{dn_container}}
+    );
+
+    send_key $actions{ldap}->{shortcut};
+    assert_screen 'yast2_samba-server_ldap-settings';
+
+    send_key $actions{use_password_backend}->{shortcut};
+    assert_screen 'yast2_samba-server_ldap_value_rewritten';
+    send_key $actions{yes}->{shortcut};
+
+    assert_screen 'yast2_samba-server_ldap_passwd_checked';
+    send_key $actions{server_url}->{shortcut};
+    type_string $actions{server_url}->{value};
+    # set admin password and search base dn
+    wait_screen_change { send_key $actions{administration_dn}->{shortcut} };
+    type_string $actions{administration_dn}->{value};
+    wait_screen_change { send_key $actions{password}->{shortcut} };
+    type_string $actions{password}->{value};
+    wait_screen_change { send_key $actions{password_retry}->{shortcut} };
+    type_string $actions{password_retry}->{value};
+    wait_screen_change { send_key $actions{search_base_dn}->{shortcut} };
+    type_string $actions{search_base_dn}->{value};
+    save_screenshot;
+}
+
+sub setup_samba_ldap_expert {
+    record_info 'Samba Configuration', 'Expert LDAP Settings';
+    my %actions = (
+        advanced       => {shortcut => 'alt-v'},
+        replication    => {shortcut => 'alt-p', value => "990\n"},
+        timeout        => {shortcut => 'alt-t', value => "7\n"},
+        use_ssl_or_tls => {shortcut => 'alt-u'},
+        test           => {shortcut => 'alt-t'}
+    );
+
+    # check advanced settings before run test connection to ldap server
+    wait_screen_change { send_key $actions{advanced}->{shortcut} };
+    send_key 'ret';
+
+    assert_screen 'yast2_samba-server_ldap_advanced_expert_settings';
+    wait_screen_change { send_key $actions{replication}->{shortcut} };
+    type_string $actions{replication}->{value};
+    wait_screen_change { send_key $actions{timeout}->{shortcut} };
+    type_string $actions{timeout}->{value};
+
+    # change to not use SSL or TLS
+    wait_screen_change { send_key $actions{use_ssl_or_tls}{shortcut} };
+    send_key 'up';
+    assert_screen 'yast2_samba-server_ldap_advanced_expert_settings_not-use-ssl';
+    send_key 'ret';
+    wait_screen_change { send_key $cmd{ok} };
+
+    # now run test connection
+    send_key $actions{test}{shortcut};
+    assert_screen 'yast2_samba-server_ldap_test-connection';
+    wait_screen_change { send_key $cmd{ok} };
+}
+
+sub setup_samba {
+    script_run("yast2 samba-server; echo yast2-samba-server-status-\$? > /dev/$serialdev", 0);
+
+    set_workgroup;
+    handle_domain_controller if (is_sle('<15') || is_leap('<15.0'));
+    setup_samba_startup;
+    setup_samba_share;
+    setup_samba_identity;
+    setup_samba_trusted_domains;
+    setup_samba_ldap;
+    setup_samba_ldap_expert;
+
+    send_key $cmd{ok};
+    wait_serial('yast2-samba-server-status-0', 60) || die "'yast2 samba-server' didn't finish";
+}
+
+sub run {
     select_console 'root-console';
-    zypper_call('in samba yast2-samba-server yast2-auth-server');
+    zypper_call 'in samba yast2-samba-server yast2-auth-server';
 
     # setup ldap instance (openldap or 389-ds) for samba
     if (is_sle('<15') || is_leap('<15.0')) {
@@ -341,7 +394,7 @@ sub run {
         record_soft_failure "bsc#1088152";
         setup_yast2_ldap_server;
     }
-    $self->setup_samba;
+    setup_samba;
     # check samba server status
     # samba doesn't start up correctly on TW, so add record soft failure here
     if (script_run('systemctl show -p ActiveState smb.service | grep ActiveState=active')) {


### PR DESCRIPTION
Adjust YaST2 Samba after logon drive. This problem is solved with this particular [line](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5874/files#diff-aa915e11c5c494b22e6f52cf54d0b504R275) and the needles provided. 
Besides I provided a refactor as is clear that for developing better transitions among screen first step is to organize the code so is easier to see what is missing at the beginning or end of particular actions performed in different dialogs.

- Related ticket: https://progress.opensuse.org/issues/41477
- Needles: [needles sle](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/953) and [needles openSUSE](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/442)
- Verification run: 
  - [Tumbleweed yast2_ncurses yast2_samba](http://dhcp42.suse.cz/tests/146#step/yast2_samba/132)
  - [sle-15-SP1-yast2_ncurses yast2_samba](http://dhcp42.suse.cz/tests/145#step/yast2_samba/120)
  - [sle-12-SP4 yast2_ncurses yast2_samba](http://dhcp42.suse.cz/tests/144#step/yast2_samba/120)
