### PR TITLE
JeOS: Keep GRUB timeout on Xen PV

### DIFF
--- a/tests/jeos/grub2_gfxmode.pm
+++ b/tests/jeos/grub2_gfxmode.pm
@@ -22,7 +22,7 @@ use bootloader_setup qw(change_grub_config grep_grub_settings grub_mkconfig set_
 sub run {
     change_grub_config('=.*', '=1024x768', 'GRUB_GFXMODE=');
     change_grub_config('^#',  '',          'GRUB_GFXMODE');
-    change_grub_config('=.*', '=-1',       'GRUB_TIMEOUT');
+    change_grub_config('=.*', '=-1',       'GRUB_TIMEOUT') unless check_var('VIRSH_VMM_TYPE', 'linux');
     grep_grub_settings('^GRUB_GFXMODE=1024x768$');
     set_framebuffer_resolution;
     set_extrabootparams_grub_conf;


### PR DESCRIPTION
Fails here:
https://openqa.suse.de/tests/2119495#step/revive_xen_domain/12 (and many
other places of JeOS build 7.1).

Because we don't have GRUB on VNC console on Xen PV we need to keep the
timeout (as we keep it on SLES by not scheduling
`disable_grub_timeout.pm`.

Regression: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5867.