### PR TITLE
Split extra tests to independent suites

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -404,7 +404,7 @@ elsif (get_var('SYSTEMD_TESTSUITE')) {
 }
 elsif (get_var('DOCKER_IMAGE_TEST')) {
     boot_hdd_image;
-    load_docker_tests;
+    load_extra_tests_docker;
 }
 else {
     if (get_var("LIVETEST") || get_var('LIVE_INSTALLATION') || get_var('LIVE_UPGRADE')) {


### PR DESCRIPTION
This scenario takes to much time. This commit adds possibility to split the test suite into multiple ones (just by changing variable and adding a loader function accordingly). Old tests should still use the old mau-extratest suite, changes are limited to the test scheduling.

- Related ticket: https://progress.opensuse.org/issues/41900
- Verification runs: 
  - http://panigale.suse.cz/tests/814 (old settings with EXTRATEST=1)
  - http://panigale.suse.cz/tests/809 (zypper only test with EXTRATEST=zypper)
  - http://panigale.suse.cz/tests/810 (kdump_and_crash with EXTRATEST=kdump)
  - http://panigale.suse.cz/tests/813 (explicit components with EXTRATEST=console,docker)
