### PR TITLE
Revert "Fix amqp test: install python dep for python-pika"

### DIFF
--- a/tests/console/rabbitmq.pm
+++ b/tests/console/rabbitmq.pm
@@ -23,8 +23,7 @@ sub run {
     assert_script_run('zypper -n in rabbitmq-server');
     systemctl 'start rabbitmq-server';
     systemctl 'status rabbitmq-server';
-    record_soft_failure 'obs sr#636625: manually install python as python-pika rpm is missing the requirement';
-    assert_script_run('zypper -n in python-pika python');
+    assert_script_run('zypper -n in python-pika');
     my $cmd = <<'EOF';
 mkdir rabbitmq
 cd rabbitmq


### PR DESCRIPTION
This reverts commit b8bee6cbcacf74f83a727459df726e64ccd70d96.

Current tumbleweed version now has the correct dependencies set.
Verification: http://artemis.suse.de/tests/522#step/rabbitmq/8