### PR TITLE
[NFV] Increase timeout for performance tests

### DIFF
--- a/tests/nfv/run_performance_tests.pm
+++ b/tests/nfv/run_performance_tests.pm
@@ -27,7 +27,7 @@ sub run_test {
     record_info("INFO", "Running test case $testname");
     record_info("INFO", "Command to run: $cmd");
     if (check_var('BACKEND', 'ipmi')) {
-        assert_script_run($cmd, timeout => 4000);
+        assert_script_run($cmd, timeout => 60 * 60 * 1.5);
     } elsif (check_var('BACKEND', 'qemu')) {
         record_info("INFO", "Skip test as this is a virtual environment. Generate dummy results instead.");
         assert_script_run("mkdir -p $results_dir/results_dummy");

--- a/tests/nfv/trex_installation.pm
+++ b/tests/nfv/trex_installation.pm
@@ -34,7 +34,7 @@ sub run {
 
     # Download and extract T-Rex package
     record_info("INFO", "Download TREX package");
-    assert_script_run("wget $url", 1800);
+    assert_script_run("wget $url", timeout => 60 * 30);
     assert_script_run("tar -xzf $tarball");
     assert_script_run("mv $trex_version $trex_dest");
 


### PR DESCRIPTION
After some manual tests, the first NFV test takes something around 70-80 minutes to finish, so, to be in the safe place, time out is set to 90 min. 

No proof runs as this can be run only on bare metal, but it's a trivial change.