### PR TITLE
Run check_system_is_updated on sle

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2160,8 +2160,7 @@ sub load_system_update_tests {
                 loadtest "update/updates_packagekit_gpk";
                 set_var('SYSTEM_UPDATED', 1);
             }
-            # Test was never executed on SLE and fails currently
-            loadtest "update/check_system_is_updated" if !is_sle;
+            loadtest "update/check_system_is_updated";
         }
     }
     else {

--- a/tests/update/check_system_is_updated.pm
+++ b/tests/update/check_system_is_updated.pm
@@ -19,7 +19,10 @@ use utils 'ensure_serialdev_permissions';
 sub run {
     select_console 'root-console';
     ensure_serialdev_permissions;
-    assert_script_run "pkcon get-updates | tee /dev/$serialdev | grep 'There are no updates'";
+    # pkcon returns non-zero code (5 'Nothing useful was done.')
+    # so don't validate exit code and just match
+    script_run "pkcon get-updates | tee /dev/$serialdev", 0;
+    die "pkcon get-updates seems to contain updates, whereas was just updated" unless wait_serial('There are no updates');
 }
 
 sub test_flags {

--- a/tests/x11/gnome_control_center.pm
+++ b/tests/x11/gnome_control_center.pm
@@ -15,9 +15,12 @@
 use base "x11test";
 use strict;
 use testapi;
-
+use utils 'ensure_unlocked_desktop';
 
 sub run {
+    # If system update tests were executed, need to switch back to x11
+    select_console('x11', await_console => 0);
+    ensure_unlocked_desktop;
     mouse_hide(1);
     # for timeout selection see bsc#965857
     x11_start_program('gnome-control-center', match_timeout => 120);


### PR DESCRIPTION
There were multiple issues with this module. First of all, we switch to
root-console, which is not expected in case of SLE as next test expects
tty with X11. Secondly, we run test after consoletest_setup, so command
fails as pkcon returns non-zero code, which is expected.
I tried to use script_output, but even if we use `proceed_on_failure` it
doesn't return any output, as command failed.

See [poo#31954](https://progress.opensuse.org/issues/31954).

- [Verification run](http://g226.suse.de/tests/2681).
