### PR TITLE
Disable nssusrfiles test - poo#42020

### DIFF
--- a/tests/caasp/overlayfs.pm
+++ b/tests/caasp/overlayfs.pm
@@ -15,9 +15,12 @@ use base "opensusebasetest";
 use strict;
 use testapi;
 use caasp 'process_reboot';
+use version_utils 'is_caasp';
 
 sub run() {
-    assert_script_run "grep 'passwd:.*usrfiles' /etc/nsswitch.conf";
+    if (!is_caasp '4.0+') {
+        assert_script_run "grep 'passwd:.*usrfiles' /etc/nsswitch.conf";
+    }
 
     record_info 'Setup';
     script_run 'transactional-update shell', 0;


### PR DESCRIPTION
On Kubic/CaaSP 4+ nssusrfiles no longer exists, so only test it in other cases

- Related ticket: https://progress.opensuse.org/issues/42020
- Needles: None needed
