### PR TITLE
Remove SYSTEM_ROLE_STYLE and SYSTEM_ROLE_FIRST_FLOW variables

### DIFF
--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -40,10 +40,6 @@ testapi::set_distribution(susedistribution->new());
 
 set_var 'FAIL_EXPECTED', 'SMALL-DISK' if get_var('HDDSIZEGB') < 12;
 
-if (is_caasp('kubic')) {
-    set_var('SYSTEM_ROLE_FIRST_FLOW', 1);
-}
-
 # Set console for XEN-PV
 if (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')) {
     set_var('SERIALDEV', 'hvc0');

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -90,21 +90,17 @@ if (check_var('DESKTOP', 'minimalx')) {
         set_var('DM_NEEDS_USERNAME', 1);
     }
     # Set patterns for the new system role flow, as we need to select patterns, similarly to SLE12
-    if (get_var('SYSTEM_ROLE_STYLE') && !get_var('PATTERNS')) {
+    if (is_using_system_role && !get_var('PATTERNS')) {
         set_var('PATTERNS', 'default,minimalx');
     }
 }
 
-if (get_var('SYSTEM_ROLE_STYLE') && check_var('DESKTOP', 'lxde') && !get_var('PATTERNS')) {
+if (is_using_system_role && check_var('DESKTOP', 'lxde') && !get_var('PATTERNS')) {
     set_var('PATTERNS', 'default,lxde');
 }
 
-if (get_var('SYSTEM_ROLE_STYLE') && check_var('DESKTOP', 'xfce') && !get_var('PATTERNS')) {
+if (is_using_system_role && check_var('DESKTOP', 'xfce') && !get_var('PATTERNS')) {
     set_var('PATTERNS', 'default,xfce');
-}
-
-if (is_leap('15.0+') || is_tumbleweed()) {
-    set_var('SYSTEM_ROLE_FIRST_FLOW', 1);
 }
 
 # openSUSE specific variables

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -53,10 +53,9 @@ sub run {
         $partition_roles{raw} = $cmd{raw_volume};
 
         if (check_var('DISTRI', 'opensuse')) {
-            #TODO remove SYSTEM_ROLE_FIRST_FLOW usages with versions checks
-            $cmd{expertpartitioner} = get_var('SYSTEM_ROLE_FIRST_FLOW') ? 'alt-e' : 'alt-x';
-            $cmd{enablelvm}         = get_var('SYSTEM_ROLE_FIRST_FLOW') ? 'alt-e' : 'alt-a';
-            $cmd{encryptdisk}       = get_var('SYSTEM_ROLE_FIRST_FLOW') ? 'alt-a' : 'alt-l';
+            $cmd{expertpartitioner} = 'alt-e';
+            $cmd{enablelvm}         = 'alt-e';
+            $cmd{encryptdisk}       = 'alt-a';
         }
     }
 


### PR DESCRIPTION
We have introduced variables to enable desired behavior, as changes were
reaching products at different time. Now, we already have this settled,
so no need in that and we can simply rely on the versions of the
products.

See [poo#41516](https://progress.opensuse.org/issues/41516).

#### Verification runs:

 * [sle 12 sp1 qam gnome](http://g226.suse.de/tests/2692)
 * [sle 12 sp3 qam gnome](http://g226.suse.de/tests/2690)
 * [sle 12 sp4 cryptlvm](http://g226.suse.de/tests/2687)
 * [sle 15 btrfs](http://g226.suse.de/tests/2689)
 * [sle 15 staging](http://g226.suse.de/tests/2702)
 * [sle 15 qam gnome](http://g226.suse.de/tests/2691)

 * [leap 42.3 updates cryptlvm](http://g226.suse.de/tests/2698)
 * [leap 42.3 install with updates gnome](http://g226.suse.de/tests/2697)
 * [leap 15.0 kde](http://g226.suse.de/tests/2696)
 * [leap 15.1 ext4](http://g226.suse.de/tests/2695)
 * [leap 15.1 staging](http://g226.suse.de/tests/2700)

* [TW RAID0](http://g226.suse.de/tests/2707)
* [TW xfce](http://g226.suse.de/tests/2708)
* [TW kubic](http://g226.suse.de/tests/2711)

Some of jobs failed, but that's not related to the change.
