### PR TITLE
Add new test for data integrity

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -13,6 +13,7 @@ requires 'Selenium::Remote::Driver';
 requires 'Selenium::Chrome';
 requires 'Selenium::Waiter';
 requires 'Selenium::Remote::WDKeys';
+requires 'Digest::file';
 
 on 'test' => sub {
   requires 'Code::DRY';

--- a/lib/data_integrity_utils.pm
+++ b/lib/data_integrity_utils.pm
@@ -1,0 +1,43 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Library to verify image data integrity by comparing SHA256 checksums.
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.com>
+
+package data_integrity_utils;
+
+use base Exporter;
+use Exporter;
+use strict;
+use testapi;
+use File::Basename;
+use Digest::file 'digest_file_hex';
+
+our @EXPORT = 'verify_checksum';
+
+=head2 verify_checksum
+Verify image data integrity by comparing SHA256 checksums
+=cut
+sub verify_checksum {
+    my ($dir_path) = shift;    # for backends other than qemu, image directory path needs to be set
+
+    diag "Comparing data integrity calculated with SHA256 digest against checksum from IBS/OBS via rsync.pl";
+    foreach my $image (grep { /^CHECKSUM_/ } keys %bmwqemu::vars) {
+        my $checksum = get_required_var $image;
+        $image =~ s/CHECKSUM_//;
+        my $image_path = get_required_var $image;
+        $image_path = $dir_path . basename($image_path) if $dir_path;
+        my $digest = digest_file_hex($image_path, "SHA-256");
+        record_info("$image Ok", "$image_path: Ok") && next if $checksum eq $digest;
+        my $msg_fail = "SHA256 checksum does not match for $image:\n\tCalculated: $digest\n\tExpected:   $checksum";
+        record_info("$image Fail", $msg_fail, result => 'fail');
+    }
+}
+
+1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -186,6 +186,12 @@ sub setup_env {
     }
 }
 
+sub data_integrity_is_applicable {
+    # Other backends than qemu, i.e.Xen, zKVM or Hyper-V will check it later after the image is downloaded
+    return check_var('BACKEND', 'qemu') &&
+      grep { /^CHECKSUM_/ } keys %bmwqemu::vars;
+}
+
 sub any_desktop_is_applicable {
     return get_var("DESKTOP") !~ /textmode/;
 }
@@ -403,6 +409,7 @@ sub load_boot_tests {
     # s390x uses only remote repos
     if (get_var("ISO_MAXSIZE") && !check_var('ARCH', 's390x')) {
         loadtest "installation/isosize";
+        loadtest "installation/data_integrity" if data_integrity_is_applicable;
     }
     if ((get_var("UEFI") || is_jeos()) && !check_var("BACKEND", "svirt")) {
         loadtest "installation/bootloader_uefi";

--- a/tests/installation/data_integrity.pm
+++ b/tests/installation/data_integrity.pm
@@ -1,0 +1,22 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify data integrity of the images provided by comparing checksums.
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+use data_integrity_utils 'verify_checksum';
+
+sub run {
+    verify_checksum;
+}
+
+1;


### PR DESCRIPTION
Add new test for data integrity: verify data integrity of the iso image by comparing checksum from IBS/OBS with checksum on the worker.
Variable `ISO_CHECKSUM` is not yet available, it depends on this other progress ticket [Need to crosscheck ISOs against checksum in rsync.pl and/or before starting test](https://progress.opensuse.org/issues/13302)
I kept the same behavior than in isosize.pm test for the test to not die, but not sure if still want to do it like that for checksum.
- Related ticket: https://progress.opensuse.org/issues/41414
- Verification run: 
  - [sle-15-SP1-create_hdd_gnome iso_checksum ok](http://dhcp42.suse.cz/tests/215/file/autoinst-log.txt)
  - [sle-15-SP1-create_hdd_gnome iso_checksum fail](http://dhcp42.suse.cz/tests/216/file/autoinst-log.txt)