### PR TITLE
Disable nssusrfiles (not really an overlayfs test) test - poo#42020

### DIFF
--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -120,7 +120,7 @@ sub load_feature_tests {
     loadtest 'caasp/create_autoyast' unless check_var('VIRSH_VMM_FAMILY', 'hyperv');
     loadtest 'caasp/libzypp_config';
     loadtest 'caasp/filesystem_ro';
-    loadtest 'caasp/overlayfs';
+    loadtest 'caasp/overlayfs' unless is_caasp('4.0+'); 
     loadtest 'caasp/services_enabled';
     loadtest 'caasp/one_line_checks';
     loadtest 'caasp/nfs_client' if get_var('NFS_SHARE');


### PR DESCRIPTION
Despite the name the test doesn't test overlayfs, but only nss files in /usr, which is a feature no longer relevant in Kubic

- Related ticket: https://progress.opensuse.org/issues/42020
