### PR TITLE
Add workaround for shutdown timeout fail on sle12

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -223,8 +223,8 @@ sub power_action {
     }
     my $soft_fail_data;
     my $shutdown_timeout = 60;
-    # Shutdown takes longer than 60 seconds on SLE 15
-    if (is_sle('15+') && check_var('DESKTOP', 'gnome') && ($action eq 'poweroff')) {
+    # Shutdown takes longer than 60 seconds on SLE12 SP4 and SLE 15
+    if (is_sle('12+') && check_var('DESKTOP', 'gnome') && ($action eq 'poweroff')) {
         $soft_fail_data = {bugref => 'bsc#1055462', soft_timeout => 60, timeout => $shutdown_timeout *= 3};
     }
     # The timeout is increased as shutdown takes longer on Live CD


### PR DESCRIPTION
Shutdown test fails because SLE is not able to shutdown in 60 seconds
when using gnome.

It started failing on SLE12 with the same symptoms as on SLE15 previously (e.g. https://openqa.suse.de/tests/2109795). The commit adds SLE12 to the list of systems 
with that issue, and allows to call soft fail in case if shutdown takes longer than default timeout.

Please, see [poo#23402](https://progress.opensuse.org/issues/23402) and [bsc#1055462](https://bugzilla.suse.com/show_bug.cgi?id=1055462) for the details of the issue.

Verification runs:

- Passed shutdown on SLE12 SP4: http://oorlov-vm.qa.suse.de/tests/209
- Soft-failed shutdown on SLE12 SP4 (with 1 sec timeout to cause the soft-fail): http://oorlov-vm.qa.suse.de/tests/210
