### PR TITLE
Add test module for ZNC and connect using weechat

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1508,6 +1508,7 @@ sub load_extra_tests_textmode {
         loadtest "console/openqa_review";
         loadtest "console/zbar";
         loadtest "console/a2ps";    # a2ps is not a ring package and thus not available in staging
+        loadtest "console/znc";
         loadtest "console/weechat";
         loadtest "console/nano";
         loadtest "console/steamcmd" if (check_var('ARCH', 'i586') || check_var('ARCH', 'x86_64'));

--- a/tests/console/weechat.pm
+++ b/tests/console/weechat.pm
@@ -27,6 +27,17 @@ sub run {
     select_console('user-console');
     script_run("weechat; echo weechat-status-\$? > /dev/$serialdev", 0);
     assert_screen('weechat');
+
+    type_string("/server add znc localhost/12345 -ssl -ssl_verify=0 -username=bernhard/freenode -password=$testapi::password\n");
+    assert_screen('weechat-server-added');
+
+    type_string("/connect znc\n");
+    assert_screen('weechat-no-longer-away');
+
+    type_string("/query *status\n");
+    type_string("Version\n");
+    assert_screen('weechat-znc-status-version');
+
     type_string("/quit\n");
     wait_serial("weechat-status-0") || die "'weechat' could not finish successfully";
 }

--- a/tests/console/znc.pm
+++ b/tests/console/znc.pm
@@ -1,0 +1,86 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Setup ZNC IRC bouncer as proxy to freenode
+# Maintainer: Dominik Heidler <dheidler@suse.de>
+
+use base 'consoletest';
+use strict;
+use testapi;
+use utils qw(zypper_call systemctl);
+
+sub run {
+    select_console('root-console');
+    zypper_call('in znc');
+
+    script_run("sudo -u znc znc --makeconf | tee /dev/$serialdev; echo zncconf-status-\$? > /dev/$serialdev", 0);
+
+    wait_serial('Listen on port');
+    type_string("12345\n");
+
+    wait_serial('Listen using SSL');
+    type_string("yes\n");
+
+    wait_serial('Listen using both IPv4 and IPv6');
+    type_string("yes\n");
+
+    wait_serial('Username');
+    type_string("bernhard\n");
+
+    wait_serial('Enter password');
+    type_string("$testapi::password\n");
+
+    wait_serial('Confirm password');
+    type_string("$testapi::password\n");
+
+    wait_serial('Nick');
+    type_string("\n");
+
+    wait_serial('Alternate nick');
+    type_string("\n");
+
+    wait_serial('Ident');
+    type_string("\n");
+
+    wait_serial('Real name');
+    type_string("Bernhard M. Wiedemann\n");
+
+    wait_serial('Bind host');
+    type_string("\n");
+
+    wait_serial('Set up a network');
+    type_string("yes\n");
+
+    wait_serial('Name');
+    type_string("\n");
+
+    wait_serial('Server host');
+    type_string("\n");
+
+    wait_serial('Server uses SSL');
+    type_string("\n");
+
+    wait_serial('Server port');
+    type_string("\n");
+
+    wait_serial('Server password');
+    type_string("\n");
+
+    wait_serial('Initial channels');
+    type_string("\n");
+
+    wait_serial('Launch ZNC now');
+    type_string("no\n");
+
+    wait_serial("zncconf-status-0") || die "'znc --makeconf' could not finish successfully";
+
+    systemctl 'start znc';
+    systemctl 'status znc';
+}
+
+1;
+


### PR DESCRIPTION
This will help us catching bugs like https://bugzilla.suse.com/show_bug.cgi?id=1108450 in the future.

Verification: http://artemis.suse.de/tests/536#step/weechat/8
Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/443