### PR TITLE
install_packages: handle conflicts between providers of mpich-hpc-macros-devel

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -173,6 +173,8 @@ sub problem_can_be_skipped {
     return 1 if $pkg =~ /^skelcd-installer-net-openSUSE/;
     # conflicts with openafs-client, fuse client is experimental
     return 1 if $pkg =~ /^openafs-fuse_client/;
+    # conclifcts with namespace:otherproviders(mpich-hpc-macros-devel)
+    return 1 if $pkg =~ /^mpich-ofi.*gnu-hpc-macros-devel/;
 
     return;
 }


### PR DESCRIPTION
handle conflicts between providers of `mpich-hpc-macros-devel`:

```
+++ PROBLEMS: +++
package mpich_3_2_1-gnu-hpc-macros-devel-3.2.1-lp150.4.1.x86_64 conflicts with namespace:otherproviders(mpich-hpc-macros-devel) provided by mpich-ofi_3_2_1-gnu-hpc-macros-devel-3.2.1-lp150.4.1.x86_64
  + solution
    - do not ask to install mpich_3_2_1-gnu-hpc-macros-devel-3.2.1-lp150.4.1.x86_64
PCBS 'mpich_3_2_1-gnu-hpc-macros-devel-3.2.1-lp150.4.1.x86_64': 'package mpich_3_2_1-gnu-hpc-macros-devel-3.2.1-lp150.4.1.x86_64 conflicts with namespace:otherproviders(mpich-hpc-macros-devel) provided by mpich-ofi_3_2_1-gnu-hpc-macros-devel-3.2.1-lp150.4.1.x86_64'
  + solution
    - do not ask to install mpich-ofi_3_2_1-gnu-hpc-macros-devel-3.2.1-lp150.4.1.x86_64
PCBS 'mpich-ofi_3_2_1-gnu-hpc-macros-devel-3.2.1-lp150.4.1.x86_64': 'package mpich_3_2_1-gnu-hpc-macros-devel-3.2.1-lp150.4.1.x86_64 conflicts with namespace:otherproviders(mpich-hpc-macros-devel) provided by mpich-ofi_3_2_1-gnu-hpc-macros-devel-3.2.1-lp150.4.1.x86_64'
package mpich-ofi-gnu-hpc-macros-devel-3.2.1-lp150.4.1.noarch requires mpich-ofi_3_2_1-gnu-hpc-macros-devel = 3.2.1, but none of the providers can be installed
  + solution
    - do not ask to install mpich-ofi-gnu-hpc-macros-devel-3.2.1-lp150.4.1.noarch
PCBS 'mpich-ofi-gnu-hpc-macros-devel-3.2.1-lp150.4.1.noarch': 'package mpich-ofi-gnu-hpc-macros-devel-3.2.1-lp150.4.1.noarch requires mpich-ofi_3_2_1-gnu-hpc-macros-devel = 3.2.1, but none of the providers can be installed'
  + solution
    - do not ask to install mpich-gnu-hpc-macros-devel-3.2.1-lp150.4.1.noarch
PCBS 'mpich-gnu-hpc-macros-devel-3.2.1-lp150.4.1.noarch': 'package mpich-ofi-gnu-hpc-macros-devel-3.2.1-lp150.4.1.noarch requires mpich-ofi_3_2_1-gnu-hpc-macros-devel = 3.2.1, but none of the providers can be installed'

```

Fixes:

- https://openqa.opensuse.org/tests/768410#step/install_packages/9
- https://openqa.opensuse.org/tests/768411#step/install_packages/9
- https://openqa.opensuse.org/tests/768412#step/install_packages/9

See:

- https://build.opensuse.org/request/show/640151
- https://build.opensuse.org/project/show/openSUSE:Maintenance:8873

To test:

`data/lsmfip --verbose mpich-ofi_3_2_1-gnu-hpc-macros-devel mpich-gnu-hpc-devel-static mpich-ofi-gnu-hpc-devel mpich-gnu-hpc-devel mpich_3_2_1-gnu-hpc-debugsource mpich-ofi-debuginfo mpich-gnu-hpc-macros-devel mpich-ofi-gnu-hpc mpich-debugsource mpich-ofi mpich-ofi_3_2_1-gnu-hpc-devel mpich mpich-ofi-debugsource mpich-gnu-hpc mpich-devel mpich-ofi-gnu-hpc-macros-devel mpich-ofi_3_2_1-gnu-hpc mpich-ofi_3_2_1-gnu-hpc-devel-static mpich_3_2_1-gnu-hpc-debuginfo mpich-ofi_3_2_1-gnu-hpc-debugsource mpich-debuginfo mpich-ofi-gnu-hpc-devel-static mpich_3_2_1-gnu-hpc-macros-devel mpich-ofi-devel mpich_3_2_1-gnu-hpc mpich-ofi_3_2_1-gnu-hpc-debuginfo mpich_3_2_1-gnu-hpc-devel mpich_3_2_1-gnu-hpc-devel-static`