### PR TITLE
Fix problem with closing vlc by assert_and_click

### DIFF
--- a/tests/x11/vlc.pm
+++ b/tests/x11/vlc.pm
@@ -31,13 +31,12 @@ sub run {
     assert_screen "vlc-network-window";
     send_key "backspace";
     type_string autoinst_url . "/data/Big_Buck_Bunny_8_seconds_bird_clip.ogv";
-    assert_screen "url_check";
+    assert_screen "url_check", 90;
     assert_and_click "vlc-play_button";
     # The video is actually 23 seconds long so give a bit of headroom for
     # startup
     assert_screen "vlc-done-playing", 90;
-    # sometimes send_key for closing windows not working
-    send_key_until_needlematch 'generic-desktop', "ctrl-q", 5, 5;
+    assert_and_click "close_vlc";
 }
 
 1;


### PR DESCRIPTION
even send_key_until_needlematch 'generic-desktop', "ctrl-q", 10, 10;
won't work realiable, we try now with assert_and_click 'close_app'.

see ticket https://progress.opensuse.org/issues/37713 for details
verification run: http://e13.suse.de/tests/9354#next_previous

needle PR:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/444
