### PR TITLE
Improve stability to select root partition instead of boot

### DIFF
--- a/tests/installation/partitioning_splitusr.pm
+++ b/tests/installation/partitioning_splitusr.pm
@@ -26,23 +26,24 @@ sub run {
     }
 
     # select root partition
-    send_key_until_needlematch 'vda-selected', 'down';
+    send_key_until_needlematch 'vda-selected', 'right';
     send_key "tab";
-    send_key "tab";
+    wait_screen_change { send_key "tab" };
     send_key "home";
-    send_key_until_needlematch 'root-partition-selected', 'down';    # Select root partition
-                                                                     # Different shortcut on storage-ng
-    wait_screen_change { send_key $cmd{resize} };                    # Resize
-    send_key 'alt-u';                                                # Custom size
+    wait_still_screen(2);
+    send_key_until_needlematch 'root-partition-selected', 'down', 5, 2;    # Select root partition
+                                                                           # Different shortcut on storage-ng
+    wait_screen_change { send_key $cmd{resize} };                          # Resize
+    send_key 'alt-u';                                                      # Custom size
     send_key $cmd{size_hotkey} if is_storage_ng;
     type_string '1.5G';
     send_key(is_storage_ng() ? $cmd{next} : 'ret');
     if (is_storage_ng) {
         # warning: / should be >= 10 GiB or disable snapshots
         assert_screen 'partition-splitusr-root-warning';
-        wait_screen_change { send_key 'alt-y' };                     # accept warning for small /
+        wait_screen_change { send_key 'alt-y' };                           # accept warning for small /
         wait_screen_change { send_key 'alt-s' };
-        send_key_until_needlematch 'vda-selected', 'left';           # Select vda again
+        send_key_until_needlematch 'vda-selected', 'left';                 # Select vda again
     }
 
     # add /usr


### PR DESCRIPTION
- Related ticket: [[functional][y] test fails in partitioning_splitusr - probably a change in behavior of yast/storage-ng](https://progress.opensuse.org/issues/41060)
- Verification run: [opensuse-Tumbleweed-DVD-x86_64-Build20181001-splitusr@64bit](http://dhcp128.suse.cz/tests/6746#step/partitioning_splitusr/1)
