### PR TITLE
HA: fix upgrade tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -458,7 +458,7 @@ sub load_ha_cluster_tests {
 
     # Test HA after an upgrade, so no need to configure the HA stack
     if (get_var('HDDVERSION')) {
-        loadtest 'ha/upgrade_from_sle11sp4_workarounds' if get_var('HDDVERSION', '11-SP4');
+        loadtest 'ha/upgrade_from_sle11sp4_workarounds' if check_var('HDDVERSION', '11-SP4');
         loadtest 'ha/check_after_reboot';
         return 1;
     }

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -63,7 +63,7 @@ sub run {
         barrier_create("HAWK_CHECKED_$cluster_name",                $num_nodes);
 
         # Create barrier for some upgrade tests
-        if (get_var('HDDVERSION', '11-SP4')) {
+        if (check_var('HDDVERSION', '11-SP4')) {
             barrier_create("SLE11_UPGRADE_INIT_$cluster_name",  $num_nodes);
             barrier_create("SLE11_UPGRADE_START_$cluster_name", $num_nodes);
             barrier_create("SLE11_UPGRADE_DONE_$cluster_name",  $num_nodes);

--- a/tests/ha/upgrade_from_sle11sp4_workarounds.pm
+++ b/tests/ha/upgrade_from_sle11sp4_workarounds.pm
@@ -19,7 +19,7 @@ use hacluster;
 
 # Do some stuff that need to be workaround in SLE15
 sub run {
-    return unless get_var('HDDVERSION', '11-SP4');
+    return unless check_var('HDDVERSION', '11-SP4');
 
     my ($self)        = @_;
     my $cluster_name  = get_cluster_name;


### PR DESCRIPTION
'get_var' was used instead of 'check_var', so upgrade tests are
not correctly executed on SLE-12-SP*.