### PR TITLE
Transit from overview to partitions tab

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
-use version_utils qw(is_leap is_storage_ng is_sle sle_version_at_least);
+use version_utils qw(is_leap is_storage_ng is_sle sle_version_at_least is_tumbleweed);
 use partition_setup '%partition_roles';
 
 sub run {
@@ -49,6 +49,7 @@ sub run {
         $cmd{resize}           = 'alt-r';
         $cmd{raw_volume}       = 'alt-r';
         $cmd{enable_snapshots} = 'alt-a';
+        $cmd{addpart}          = 'alt-r' unless is_tumbleweed;
         # Set shortcut for role selection when creating partition
         $partition_roles{raw} = $cmd{raw_volume};
 

--- a/tests/installation/partitioning_splitusr.pm
+++ b/tests/installation/partitioning_splitusr.pm
@@ -14,7 +14,7 @@
 use base "y2logsstep";
 use strict;
 use testapi;
-use version_utils 'is_storage_ng';
+use version_utils qw(is_storage_ng is_tumbleweed);
 use partition_setup 'addpart';
 
 sub run {
@@ -27,12 +27,21 @@ sub run {
 
     # select root partition
     send_key_until_needlematch 'vda-selected', 'right';
+    wait_screen_change { send_key 'alt-p' } if is_storage_ng;
     send_key "tab";
     wait_screen_change { send_key "tab" };
     send_key "home";
     wait_still_screen(2);
     send_key_until_needlematch 'root-partition-selected', 'down', 5, 2;    # Select root partition
-                                                                           # Different shortcut on storage-ng
+                                                                           # Resize has been moved under drop down button Modify in storage-ng
+    if (is_storage_ng and (!is_tumbleweed)) {
+        wait_screen_change { send_key 'alt-m' };
+        wait_still_screen(2);
+        send_key 'down' for (0 .. 1);
+        save_screenshot;
+        send_key 'ret';
+    }
+
     wait_screen_change { send_key $cmd{resize} };                          # Resize
     send_key 'alt-u';                                                      # Custom size
     send_key $cmd{size_hotkey} if is_storage_ng;


### PR DESCRIPTION
- Related ticket: [[functional][y] test fails in partitioning_splitusr - probably a change in behavior of yast/storage-ng](https://progress.opensuse.org/issues/41060)
- Verification runs:
  * [opensuse-15.1-DVD-x86_64-Build312.1-splitusr@64bit](http://dhcp128.suse.cz/tests/6789#step/partitioning_splitusr/1)
  * [opensuse-Tumbleweed-DVD-x86_64-Build20181001-splitusr@64bit](http://dhcp128.suse.cz/tests/6790#step/partitioning_splitusr/1)
