### PR TITLE
LTP: Set ADDONURL=sdk for SLE12 SP4

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -689,6 +689,7 @@ if (is_jeos) {
 # load the tests in the right order
 if (is_kernel_test()) {
     if (get_var('LTP_BAREMETAL')) {
+        set_var('ADDONURL', 'sdk') if is_sle('=12-SP4');
         load_baremetal_tests();
     }
     load_kernel_tests();


### PR DESCRIPTION
This variable is conflicting for SLE12 SP4 (which requires it) and
SLE15 SP1 (cannot have it), that's why it's set in the code.

Verification run:
* sle-15-SP1-Installer-DVD-x86_64-Build59.1-install_ltp_baremetal_test@64bit
http://quasar.suse.cz/tests/1038

* sle-12-SP4-Server-DVD-x86_64-Build0406-install_ltp_baremetal_test@64bit
http://quasar.suse.cz/tests/1039

NOTE: it looks like ADDONURL_SDK is needed for sle-12-SP4.