### PR TITLE
Do not have system roles on SLE15-sp1 if single role is available

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -328,12 +328,16 @@ sub is_using_system_role {
     #system_role selection during installation was added as a new feature since sles12sp2
     #so system_role.pm should be loaded for all tests that actually install to versions over sles12sp2
     #no matter with or without INSTALL_TO_OTHERS tag
-    return is_sle('>=12-SP2')
+    # On SLE 15 SP0 we unconditionally have system roles screen
+    # SLE 15 SP1 has system roles only if more than one is available, meaning either registered or with all packages DVD
+    # On kubic, leap 15.1+, TW we have it instead of desktop selection screen
+    return is_sle('>=12-SP2') && is_sle('<15')
       && check_var('ARCH', 'x86_64')
       && is_server()
       && (!is_sles4sap() || is_sles4sap_standard())
       && (install_this_version() || install_to_other_at_least('12-SP2'))
-      || is_sle('15+')    # SLE 15 has system roles without extra conditions
+      || is_sle('=15')
+      || (is_sle('>15') && (check_var('SCC_REGISTER', 'installation') || get_var('ADDONS')))
       || (is_opensuse && !is_leap('<15.1'))    # Also on leap 15.1, TW
       || is_caasp('kubic');                    # And Kubic
 }


### PR DESCRIPTION
On SLE 15 SP1 we have no system roles screen if there is only one
available. It includes all unregistered scenarios, except when using
all-packages DVD.

See [poo#41858](https://progress.opensuse.org/issues/41858) and [fate#324713](https://fate.suse.com/324713).

### Verification run
 * [skip reg](http://g226.suse.de/tests/2729)
 * [offline+skip reg](http://g226.suse.de/tests/2727)
 * [skip reg + all packages DVD](http://g226.suse.de/tests/2728)

