### PR TITLE
Schedule salt test on JeOS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1526,6 +1526,7 @@ sub load_extra_tests_textmode {
     loadtest "console/curl_ipv6";
     loadtest "console/wget_ipv6";
     loadtest "console/unzip";
+    loadtest "console/salt" if is_jeos;
     loadtest "console/gpg";
     loadtest "console/rsync";
     loadtest "console/shells";

--- a/tests/console/salt.pm
+++ b/tests/console/salt.pm
@@ -16,8 +16,14 @@ use base "consoletest";
 use strict;
 use testapi;
 use utils qw(zypper_call pkcon_quit systemctl);
+use version_utils 'is_jeos';
+use registration 'add_suseconnect_product';
 
 sub run {
+    if (is_jeos) {
+        my $version = get_required_var('VERSION') =~ s/([0-9]+).*/$1/r;
+        add_suseconnect_product('sle-module-adv-systems-management', $version);
+    }
     select_console 'root-console';
     pkcon_quit;
     zypper_call('in salt-master salt-minion');


### PR DESCRIPTION
Schedule salt test on JeOS

Progress ticket: https://progress.opensuse.org/issues/40265
Validation runs: http://ccret.suse.cz/tests/1234, http://ccret.suse.cz/tests/1235#
