### PR TITLE
LTP: Print AppArmor status

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -90,6 +90,8 @@ sub run {
 
     script_run('ps axf') if ($is_network || $is_ima);
 
+    script_run('aa-enabled; aa-status');
+
     if ($is_network) {
         # poo#18762: Sometimes there is physical NIC which is not configured.
         # One of the reasons can be renaming by udev rule in


### PR DESCRIPTION
Some networking tests are influenced by AppArmor, so it's good to print
at least actual config.