### PR TITLE
[WIP]assert_screen in partitioning_finish.pm should be performed before pressing next

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -335,7 +335,7 @@ sub take_first_disk {
         # same can happen with ipmi installations
         assert_screen [qw(use-entire-disk preparing-disk-overview)];
         wait_screen_change { send_key "alt-e" } if match_has_tag 'use-entire-disk';    # use entire disk
-        send_key $cmd{next};
+        save_screenshot;
     }
 }
 

--- a/tests/installation/partitioning_finish.pm
+++ b/tests/installation/partitioning_finish.pm
@@ -19,6 +19,7 @@ sub run {
     wait_still_screen();
     send_key $cmd{next};
     assert_screen "after-partitioning";
+    send_key $cmd{next};
 }
 
 1;


### PR DESCRIPTION
Although sequence of operations of selecting first entire disk is correct, assert_screen in partitioning_finish will not capture suggested partition screen after finishing edit proposal. Because pressing next twice will advance to the next configuration item in installation. 

- Related ticket: 
  Many test suites run have the same problem as this one
  https://openqa.suse.de/tests/2130666#step/partitioning_finish/1
- Needles: after-partitioning
- Verification run: http://10.162.187.154/tests/73