### PR TITLE
[Urgent] Move PR#5735 into offline upgrade specific section

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -62,6 +62,21 @@ sub login_to_console {
             #grub may not showup after upgrade because default GRUB_TERMINAL setting
             #when fixed in separate PR, will uncomment following line
             #assert_screen([qw(grub2 grub1)], 120);
+
+            my $host_installed_version = get_var('VERSION_TO_INSTALL', get_var('VERSION', ''));
+            ($host_installed_version) = $host_installed_version =~ /^(\d+)/;
+            if ($host_installed_version eq '11') {
+                assert_screen('sshd-server-started-config', 180);
+                use_ssh_serial_console;
+                save_screenshot;
+                #start system first configuration after finishing upgrading from sles-11-sp4
+                type_string("yast.ssh\n");
+                assert_screen('will-linux-login', $timeout);
+                select_console('sol', await_console => 0);
+                save_screenshot;
+                send_key 'ret';
+                save_screenshot;
+            }
         }
         #setup vars
         set_var("reboot_for_upgrade_step", undef);
@@ -69,21 +84,6 @@ sub login_to_console {
     }
     save_screenshot;
     send_key 'ret';
-
-    my $host_installed_version = get_var('VERSION_TO_INSTALL', get_var('VERSION', ''));
-    ($host_installed_version) = $host_installed_version =~ /^(\d+)/;
-    if (check_var('offline_upgrade', 'yes') && ($host_installed_version eq '11')) {
-        assert_screen('sshd-server-started-config', 180);
-        use_ssh_serial_console;
-        save_screenshot;
-        #start system first configuration after finishing upgrading from sles-11-sp4
-        type_string("yast.ssh\n");
-        assert_screen('will-linux-login', $timeout);
-        select_console('sol', await_console => 0);
-        save_screenshot;
-        send_key 'ret';
-        save_screenshot;
-    }
 
     assert_screen(['linux-login', 'virttest-displaymanager'], $timeout);
     #use console based on ssh to avoid unstable ipmi


### PR DESCRIPTION
This change can prevent PR#5735 from being executed repeatedly when reboot after upgrade from sle11 already finishes

- Related ticket: https://openqa.suse.de/tests/2162714#step/reboot_and_wait_up_normal#2/16
- Needles: n/a
- Verification run: No need

This modification is just relocation of PR#5735, which had already been merged into master. So its execution will be confined into more strict scope. Please help merge this into master asap if no outstanding issue.
