### PR TITLE
reboot_after_installation: Prevent invalid access of VNC during reboot

### DIFF
--- a/tests/installation/reboot_after_installation.pm
+++ b/tests/installation/reboot_after_installation.pm
@@ -35,10 +35,7 @@ sub run {
         my $svirt = console('svirt');
         $svirt->change_domain_element(os => boot => {dev => 'hd'});
     }
-    wait_screen_change {
-        send_key 'alt-o';    # Reboot
-    };
-
+    send_key 'alt-o';    # Reboot
     power_action('reboot', observe => 1, keepconsole => 1, first_reboot => 1);
 }
 


### PR DESCRIPTION
`wait_screen_change` relies on the VNC connection to the SUT which can
be harmful in case that connection is not available anymore and could
cause an observation of the "half-open socket"-error. Since the
`wait_screen_change` call was introduced we introduced support for IPMI
as well as the `power_action` method which should ensure a better check
if the reboot action has actually been triggered so I have a good
feeling that we do not need the `wait_screen_change`. The next calls
within `power_action` are all not relying on the VNC connection until it
is re-established so we are safe on this side.

Related progress issue: https://progress.opensuse.org/issues/32746