### PR TITLE
Fix problem with closing kontact by assert_and_click

### DIFF
--- a/tests/x11/kontact.pm
+++ b/tests/x11/kontact.pm
@@ -35,7 +35,7 @@ sub run {
         # KF5-based account assistant ignores alt-f4
         wait_screen_change { send_key 'alt-c' } if match_has_tag('test-kontact-1');
     } until (match_has_tag('kontact-window'));
-    send_key 'ctrl-q';
+    assert_and_click 'close_kontact';
     # Since gcc7 used for packages within openSUSE Factory kontact seems to
     # persist consistently as a process in the background causing kontact to
     # be "restored" after a re-login/reboot causing later tests to fail. To


### PR DESCRIPTION
send_key doesn't work realiable and it failed sporadic for closing
kontact. Use assert_and_click to fix this issue
verification run: http://e13.suse.de/tests/9420#step/kontact/15
see https://progress.opensuse.org/issues/35589
needle PR:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/447

