### PR TITLE
hpc: increase timeout of switch_to_sle-hpc

### DIFF
--- a/tests/hpc/migration.pm
+++ b/tests/hpc/migration.pm
@@ -29,7 +29,7 @@ sub run {
     script_run('SUSEConnect -s');
     add_suseconnect_product('sle-module-hpc',           '12');
     add_suseconnect_product('sle-module-web-scripting', '12');
-    assert_script_run("switch_to_sle-hpc -e testing\@suse.com -r $scc_code");
+    assert_script_run("switch_to_sle-hpc -e testing\@suse.com -r $scc_code", 600);
     assert_script_run('ls -la /etc/products.d/');
 }
 


### PR DESCRIPTION
Due to SCC slowiness script run took ages and test start constantly  failing with timeout. After discussion with Egbert who stated that it is normal for this script to run for 4-5 minutes I decided to put 10 minutes timeout. 