### PR TITLE
HA: fix sle11sp4 upgrade tests

### DIFF
--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -61,13 +61,9 @@ sub run {
         barrier_create("CLUSTER_MD_CHECKED_$cluster_name",          $num_nodes);
         barrier_create("HAWK_INIT_$cluster_name",                   $num_nodes);
         barrier_create("HAWK_CHECKED_$cluster_name",                $num_nodes);
-
-        # Create barrier for some upgrade tests
-        if (check_var('HDDVERSION', '11-SP4')) {
-            barrier_create("SLE11_UPGRADE_INIT_$cluster_name",  $num_nodes);
-            barrier_create("SLE11_UPGRADE_START_$cluster_name", $num_nodes);
-            barrier_create("SLE11_UPGRADE_DONE_$cluster_name",  $num_nodes);
-        }
+        barrier_create("SLE11_UPGRADE_INIT_$cluster_name",          $num_nodes);
+        barrier_create("SLE11_UPGRADE_START_$cluster_name",         $num_nodes);
+        barrier_create("SLE11_UPGRADE_DONE_$cluster_name",          $num_nodes);
 
         # Create barriers for multiple tests
         foreach my $fs_tag ('LUN', 'CLUSTER_MD', 'DRBD_PASSIVE', 'DRBD_ACTIVE') {


### PR DESCRIPTION
HDDVERSION variable doesn't exist in the support-server test.
So remove the 'check_var' and always create the lock, even if it is not used.

Failing test: https://openqa.suse.de/tests/2165614#step/upgrade_from_sle11sp4_workarounds/21