### PR TITLE
Don't schedule isosize module for remote backends

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -412,9 +412,13 @@ sub load_svirt_vm_setup_tests {
     }
 }
 
-sub load_boot_tests {
+sub is_remote_backend {
     # s390x uses only remote repos
-    if (get_var("ISO_MAXSIZE") && !check_var('ARCH', 's390x')) {
+    return check_var('ARCH', 's390x') || check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm');
+}
+
+sub load_boot_tests {
+    if (get_var("ISO_MAXSIZE") && !is_remote_backend) {
         loadtest "installation/isosize";
     }
     if ((get_var("UEFI") || is_jeos()) && !check_var("BACKEND", "svirt")) {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/41480
- Verification run: http://slindomansilla-vm.qa.suse.de/tests/overview?build=fozzie_poo41480
