### PR TITLE
Adjust resize_root to the partitioner UI changes

### DIFF
--- a/tests/installation/partitioning_resize_root.pm
+++ b/tests/installation/partitioning_resize_root.pm
@@ -17,6 +17,7 @@ use warnings;
 use base "y2logsstep";
 use testapi;
 use version_utils 'is_storage_ng';
+use partition_setup 'resize_partition';
 
 sub run {
     die "Test needs at least 40 GB HDD size" unless (get_required_var('HDDSIZEGB') > 40);
@@ -30,9 +31,7 @@ sub run {
     send_key_until_needlematch 'volume-management', 'down';
     send_key 'tab';
     send_key_until_needlematch 'volume-management-root-selected', 'down';
-    send_key $cmd{resize};
-    assert_screen 'volume-management-resize-maximum-selected';
-    send_key((is_storage_ng) ? "$cmd{next}" : "$cmd{ok}");
+    resize_partition;
     send_key $cmd{accept};
     assert_screen 'partitioning-subvolumes-shown';
 }


### PR DESCRIPTION
See [poo#42368](https://progress.opensuse.org/issues/42368).

Code is not used in openSUSE.

[needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/961).

#### Verification runs:
[resize_root sle12](http://g226.suse.de/tests/2741)
[resize_root sle15 sp1](http://g226.suse.de/tests/2742)
[lvm-encrypt-separate-boot sp4](http://g226.suse.de/tests/2745)
