### PR TITLE
Fix system roles expectations when using ADDONURL vars

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -343,7 +343,7 @@ sub is_using_system_role {
       && (!is_sles4sap() || is_sles4sap_standard())
       && (install_this_version() || install_to_other_at_least('12-SP2'))
       || is_sle('=15')
-      || (is_sle('>15') && (check_var('SCC_REGISTER', 'installation') || get_var('ADDONS')))
+      || (is_sle('>15') && (check_var('SCC_REGISTER', 'installation') || get_var('ADDONS') || get_var('ADDONURL')))
       || (is_opensuse && !is_leap('<15.1'))    # Also on leap 15.1, TW
       || is_caasp('kubic');                    # And Kubic
 }


### PR DESCRIPTION
Missed case from #5906, as ADDONURL can be used too to define addons.

See [poo#41858](https://progress.opensuse.org/issues/41858).

- [Verification run](http://g226.suse.de/tests/2747).
