### PR TITLE
Add judgement for live patching registration status on rollback test

### DIFF
--- a/data/console/check_registration_status.py
+++ b/data/console/check_registration_status.py
@@ -38,7 +38,14 @@ for prod in json.loads(stdout, encoding="utf-8"):
             prod['result'] = 'mismatch'
     else:
         if dist['VERSION_ID'] != prod['version']:
-            prod['result'] = 'mismatch'
+            # Live Patching is seen as Module before SLE12SP3, then seen as extension since SLE12SP3
+            # So its version should equal the base product's base version before SLE12SP3, while equal 
+            # the base product's version since SLE12SP3. 
+            if dist['VERSION_ID'] >= '12.3':
+                prod['result'] = 'mismatch'
+            else:
+                if dist['BASE_VERSION'] != prod['version']:
+                   prod['result'] = 'mismatch'
 
     if prod['result'] == 'mismatch':
         ret += 1


### PR DESCRIPTION
Live Patching is seen as Module before SLE12SP3, then seen as extension since SLE12SP3, so its version should equal the base product's base version before SLE12SP3, while equal the base product's version since SLE12SP3.

- Related ticket: https://progress.opensuse.org/issues/42158
- Verification run: http://openqa-apac1.suse.de/tests/1765#step/snapper_rollback/40
                            http://openqa-apac1.suse.de/tests/1766#step/snapper_rollback/40
