### PR TITLE
[WICKED] Add Template for Startandstop Feature

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1650,6 +1650,10 @@ sub load_wicked_tests {
         loadtest 'wicked/advanced_ref' if check_var('IS_WICKED_REF', '1');
         loadtest 'wicked/advanced_sut' if check_var('IS_WICKED_REF', '0');
     }
+    elsif (check_var('WICKED', 'startandstop')) {
+        loadtest 'wicked/startandstop_ref' if check_var('IS_WICKED_REF', '1');
+        loadtest 'wicked/startandstop_sut' if check_var('IS_WICKED_REF', '0');
+    }
     else {
         die 'Unhandled WICKED test selection: ' . get_var('WICKED');
     }

--- a/tests/wicked/advanced_ref.pm
+++ b/tests/wicked/advanced_ref.pm
@@ -18,18 +18,6 @@ use utils 'systemctl';
 use lockapi;
 use mmapi;
 
-sub create_tunnel_with_commands {
-
-    my ($self, $type, $mode, $sub_mask) = @_;
-    my $local_ip  = $self->get_ip(no_mask => 1, is_wicked_ref => 1, type => 'host');
-    my $remote_ip = $self->get_ip(no_mask => 1, is_wicked_ref => 0, type => 'host');
-    my $tunnel_ip = $self->get_ip(is_wicked_ref => 1, type => $type);
-    assert_script_run("ip tunnel add $type mode $mode remote $remote_ip local $local_ip");
-    assert_script_run("ip link set $type up");
-    assert_script_run("ip addr add $tunnel_ip/$sub_mask dev $type");
-    assert_script_run("ip addr");
-}
-
 sub run {
     my ($self) = @_;
     my $openvpn_server = '/etc/openvpn/server.conf';

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -34,7 +34,7 @@ sub run {
     assert_script_run('mkdir -p /data/{static_address,dynamic_address}');
     #download script for check interface status
     $self->get_from_data('wicked/check_interfaces.sh', '/data/check_interfaces.sh', executable => 1) if check_var('WICKED', 'basic');
-    if (check_var('WICKED', 'advanced')) {
+    if (check_var('WICKED', 'advanced') || check_var('WICKED', 'startandstop')) {
         setup_static_network(ip => $self->get_ip(is_wicked_ref => check_var('IS_WICKED_REF', 1), type => 'host'));
     } else {
         systemctl('restart network');

--- a/tests/wicked/startandstop_ref.pm
+++ b/tests/wicked/startandstop_ref.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Startandstop test cases for wicked. Reference machine which used to
+#          support tests running on SUT
+# Maintainer: Anton Smorodskyi <asmorodskyi@suse.com>
+#             Jose Lausuch <jalausuch@suse.com>
+#             Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+
+use base 'wickedbase';
+use strict;
+use testapi;
+use utils 'systemctl';
+use lockapi;
+use mmapi;
+
+sub run {
+    my ($self) = @_;
+    my $openvpn_server = '/etc/openvpn/server.conf';
+
+    record_info('Test 1', 'Bridge - ifreload');
+    # Do actions here
+    mutex_wait('test_1_ready');
+    # Clean up test
+
+}
+
+1;

--- a/tests/wicked/startandstop_sut.pm
+++ b/tests/wicked/startandstop_sut.pm
@@ -1,0 +1,72 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Startandstop test cases for wicked. SUT machine.
+# Test scenarios:
+# Test 1  : Bridge - ifreload
+# Test 2  : Bridge - ifup, ifreload
+# Test 3  : Bridge - ifup, remove all config, ifreload
+# Test 4  : Bridge - ifup, remove one config, ifreload
+# Test 5  : Standalone card - ifdown, ifreload
+# Test 6  : VLAN - ifdown, modify config, ifreload
+# Test 7  : Bridge - ifdown, create new config, ifreload, ifdown, ifup
+# Test 8  : Bridge - ifdown, remove one config, ifreload, ifdown, ifup
+# Test 9  : VLAN - ifdown, modify one config, ifreload, ifdown, ifup
+# Test 10 : VLAN - ifup all, ifdown one card
+# Test 11 : Complex layout - ifup twice
+# Test 12 : Complex layout - ifup 3 times
+# Test 13 : Complex layout - ifdown
+# Test 14 : Complex layout - ifdown twice
+# Test 15 : Complex layout - ifdown 3 times
+# Test 16 : Complex layout - ifreload
+# Test 17 : Complex layout - ifreload twice
+# Test 18 : Complex layout - ifreload, config change, ifreload
+# Test 19 : Complex layout - ifup, ifstatus
+# Test 20 : Complex layout - ifup, ifstatus, ifdown, ifstatus
+# Test 21 : SIT tunnel - ifdown
+# Test 22 : OpenVPN tunnel - ifdown
+#
+# Maintainer: Anton Smorodskyi <asmorodskyi@suse.com>
+#             Jose Lausuch <jalausuch@suse.com>
+#             Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+
+use base 'wickedbase';
+use strict;
+use testapi;
+use utils 'systemctl';
+use network_utils 'iface';
+use lockapi;
+use mmapi;
+
+sub run {
+    my ($self) = @_;
+    my %results;
+    my $iface = iface();
+
+    $self->before_scenario('Test 1', 'Bridge - ifreload');
+    my $config = '/etc/sysconfig/network/ifcfg-br0';
+    # Do actions here
+    # $results{1} = $self->get_test_result("ifcfg-br0", "");
+    $results{1} = 'PASSED';
+    mutex_create("test_1_ready");
+    #$self->cleanup($config, "ifcfg-br0");
+
+
+    ## processing overall results
+    wait_for_children;
+    my $failures = grep { $_ eq "FAILED" } values %results;
+    if ($failures > 0) {
+        foreach my $key (sort keys %results) {
+            diag "\n Test$key --- " . $results{$key};
+        }
+        die "Some tests failed";
+    }
+}
+
+1;


### PR DESCRIPTION
Add template modules for Wicked Startandstop Feature:
https://github.com/openSUSE/wicked-testsuite/blob/master/features/wicked_5_startandstop.feature

Proof run of advanced suite: http://fromm.arch.suse.de/tests/1871 
Proof run of startandstop suite: http://fromm.arch.suse.de/tests/1887#

- This relates to a set of tickets:
https://progress.opensuse.org/projects/suseqa/issues?utf8=%E2%9C%93&set_filter=1&f%5B%5D=status_id&op%5Bstatus_id%5D=o&f%5B%5D=subject&op%5Bsubject%5D=~&v%5Bsubject%5D%5B%5D=%5Bkernel%5D%5Bwicked%5D&f%5B%5D=&c%5B%5D=subject&c%5B%5D=project&c%5B%5D=status&c%5B%5D=assigned_to&c%5B%5D=fixed_version&c%5B%5D=is_private&c%5B%5D=due_date&c%5B%5D=relations&group_by=
