### PR TITLE
Fix firefox pop-up and emaillink

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1805,8 +1805,7 @@ sub load_x11_webbrowser_extra {
     loadtest "x11/firefox/firefox_developertool";
     loadtest "x11/firefox/firefox_rss";
     loadtest "x11/firefox/firefox_ssl";
-    # evolution is not installed without WE addon
-    loadtest "x11/firefox/firefox_emaillink" if (get_var('MRU_ADDONS') || get_var('HDD_1')) =~ /we/;
+    loadtest "x11/firefox/firefox_emaillink";
     loadtest "x11/firefox/firefox_plugins";
     # IcedTea-Web plugin is part of NPAPI dropped in version 52 available only on DESKTOP with currently 45.2
     loadtest "x11/firefox/firefox_java" if get_var('FLAVOR') =~ /Desktop/;

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -616,10 +616,10 @@ sub firefox_check_default {
 sub firefox_check_popups {
     # Check whether there are any pop up windows and handle them one by one
     for (1 .. 2) {
-        # wait for any popup to showup but not expect a too long still time
-        # because of dynamic openSUSE start page background logo
-        wait_still_screen(3);
-        assert_screen [qw(firefox_trackinfo firefox_readerview_window firefox-url-loaded)], 60;
+        # assert loaded webpage
+        assert_screen 'firefox-url-loaded', 60;
+        # check pop-ups
+        assert_screen [qw(firefox_trackinfo firefox_readerview_window firefox-launch)];
         # handle the tracking protection pop up
         if (match_has_tag('firefox_trackinfo')) {
             wait_screen_change { assert_and_click 'firefox_trackinfo'; };

--- a/tests/x11/firefox/firefox_emaillink.pm
+++ b/tests/x11/firefox/firefox_emaillink.pm
@@ -32,7 +32,12 @@ sub run {
     wait_still_screen 3;
     send_key "e";
     unless (sle_version_at_least('15')) {
-        assert_screen('firefox-email_link-welcome', 90);
+        assert_screen(['firefox-email_link-welcome', 'firefox-email-mutt'], 90);
+        if (match_has_tag('firefox-email-mutt')) {
+            # if evolution is not installed, e.g. when WE is not pressent, mutt in terminal is used poo#42500
+            $self->exit_firefox;
+            return;
+        }
 
         send_key $next_key;
 


### PR DESCRIPTION
The pop-up issue is hard to reproduce because html5test.opensuse.org is garbage and the tracking feature is mostly not loaded. Tag firefox-url-loaded is too generic for it, rather use firefox-launch tag which will not match when pop-up is present.

- Related ticket: https://progress.opensuse.org/issues/38966 & https://progress.opensuse.org/issues/42476
- Verification run:
http://10.100.12.155/tests/8126#step/firefox_emaillink/5
http://10.100.12.155/tests/8123#step/firefox/5

