### PR TITLE
[WICKED] Escape single quote before using in echo

### DIFF
--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -21,7 +21,8 @@ sub run {
     my ($self) = @_;
     select_virtio_console();
     my $enable_command_logging = 'export PROMPT_COMMAND=\'logger -t openQA_CMD "$(history 1 | sed "s/^[ ]*[0-9]\+[ ]*//")"\'';
-    assert_script_run("echo \"$enable_command_logging\" >> /root/.bashrc");
+    my $escaped                = $enable_command_logging =~ s/'/'"'"'/gr;
+    assert_script_run("echo '$escaped' >> /root/.bashrc");
     assert_script_run($enable_command_logging);
     systemctl("stop " . opensusebasetest::firewall);
     systemctl("disable " . opensusebasetest::firewall);


### PR DESCRIPTION
Escape each single quote with `'"'"'` before using it in `echo '$var'`.

This fix the setting of PROMPT_COMMAND in .bashrc.

- Verification run: http://cfconrad-vm.qa.suse.de/tests/1852/file/serial_terminal.txt
