### PR TITLE
Revert "Introduce workarounds to upgrade leap 15.0 to TW"

### DIFF
--- a/tests/installation/upgrade_select.pm
+++ b/tests/installation/upgrade_select.pm
@@ -30,17 +30,8 @@ sub run {
         send_key $cmd{ok};
     }
 
-    my $update_list_needles = ['select-for-update'];
-    # Detect if empty list is shown due to bsc#1105335
-    push @$update_list_needles, 'empty-update-list' if check_var('ORIGINAL_VERSION', '15.0');
     # hardware detection and waiting for updates from suse.com can take a while
-    assert_screen_with_soft_timeout($update_list_needles, timeout => 500, soft_timeout => 100, bugref => 'bsc#1028774');
-    if (match_has_tag 'empty-update-list') {
-        record_soft_failure('bsc#1105335');
-        # Check show all partitions checkbox
-        send_key('alt-s');
-        assert_screen 'select-for-update';
-    }
+    assert_screen_with_soft_timeout('select-for-update', timeout => 500, soft_timeout => 100, bugref => 'bsc#1028774');
     send_key $cmd{next};
     assert_screen [qw(remove-repository license-agreement license-agreement-accepted)], 240;
     if (match_has_tag("license-agreement") || match_has_tag("license-agreement-accepted")) {


### PR DESCRIPTION
This reverts commit c0dc88a52d950ba72199174109c0598d1b067231.

[bsc#1105335](https://bugzilla.suse.com/show_bug.cgi?id=1105335) is
fixed, so we can remove the workaround and soft failure.

- [Needles](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/450)
- [Verification run](http://g226.suse.de/tests/2755#)
