### PR TITLE
Fix version for sle15 GA in partition raid

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -18,7 +18,7 @@ use testapi;
 use version_utils qw(is_storage_ng is_sle is_leap is_tumbleweed);
 
 # tumbleweed is not older product, but it didn't roll out yet
-my $older_product = is_sle('<15') || is_leap('<15.1') || is_tumbleweed;
+my $older_product = is_sle('<=15') || is_leap('<15.1') || is_tumbleweed;
 
 sub switch_partitions_tab {
     $cmd{addpart} = 'alt-r';
@@ -154,8 +154,10 @@ sub set_lvm {
 
     # create volume group
     send_key "alt-d";
-    send_key "down";
-    send_key "ret";
+    if ($older_product) {
+        send_key "down";
+        send_key "ret";
+    }
 
     assert_screen 'lvmsetupraid';
     # add all unformated lvm devices


### PR DESCRIPTION
 - Fix version for sle15 GA in partition_raid due it does have the new UI for storage-ng
 - Add Volume Group also changed (see attachment as it is only visible doing some frame-wise checking 
![screenshot from 2018-10-16 11-30-33](https://user-images.githubusercontent.com/31735282/47007172-e75f7780-d137-11e8-9c7d-baca9c5f1da7.png)
of the downloaded video) and checking in https://openqa.suse.de/tests/2175049#downloads) which is the reason than previous job fails
- Related ticket: https://progress.opensuse.org/issues/42488
