### PR TITLE
Fix half-open issue  socket (poo#32746)

### DIFF
--- a/tests/installation/reboot_after_installation.pm
+++ b/tests/installation/reboot_after_installation.pm
@@ -35,8 +35,10 @@ sub run {
         my $svirt = console('svirt');
         $svirt->change_domain_element(os => boot => {dev => 'hd'});
     }
+    testapi::query_isotovideo('backend_set_ssh_half_open_expected');
     send_key 'alt-o';    # Reboot
     power_action('reboot', observe => 1, keepconsole => 1, first_reboot => 1);
+    testapi::query_isotovideo('backend_clean_ssh_half_open_expected');
 }
 
 1;


### PR DESCRIPTION
Switch off the monitor during reboot , means half-open is expected.

- Related ticket: https://progress.opensuse.org/issues/32746
- Needles: None
- Verification run: http://10.67.132.86/tests/352
