### PR TITLE
Reenable docker_image again with stable images

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -574,6 +574,10 @@ sub load_docker_tests {
     loadtest "console/docker_runc";
     if (is_sle('=12-SP3')) {
         loadtest "console/sle2docker";
+        loadtest "console/docker_image";
+    }
+    elsif (is_sle('=15')) {
+        loadtest "console/docker_image";
     }
     if (is_tumbleweed) {
         loadtest "console/docker_image_rpm";


### PR DESCRIPTION
Hello,

I'd like to enable the **docker_image** test again, now with final images for 12.3 as well as for 15.
I also do `container-diff diff` instead of `analyse` because the `registry.suse.com` works now.

- Related ticket: https://progress.opensuse.org/issues/36775
- Needles: No need
- Verification run: [SLES12sp3](http://skyrim.qam.suse.de/tests/3873) and [SLE15](http://skyrim.qam.suse.de/tests/3874).
