### PR TITLE
[WICKED] Standalone card - ifdown, ifreload

### DIFF
--- a/tests/wicked/startandstop_ref.pm
+++ b/tests/wicked/startandstop_ref.pm
@@ -33,6 +33,8 @@ sub run {
     record_info('Test 3', 'Bridge - ifup, remove all config, ifreload');
     mutex_wait('test_3_ready');
 
+    record_info('Test 5', 'Standalone card - ifdown, ifreload');
+    mutex_wait('test_5_ready');
 }
 
 1;


### PR DESCRIPTION
When I set up dynamic IP addresses for eth0 from legacy files
And I bring down eth0
And I bring up eth0 by ifreload
Then eth0 should use the dynamic addresses
But eth0 should not use the static addresses
And I should be able to ping a reference machine from my dynamic address

This test requires the support_server with DHCP.

- Related ticket: https://progress.opensuse.org/issues/41663
- Verification run: http://fromm.arch.suse.de/tests/1960
