### PR TITLE
Handle ssh login on s390 zkvm

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -656,6 +656,7 @@ sub activate_console {
     }
     elsif ($console eq 'svirt') {
         my $os_type = check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 'windows' : 'linux';
+        handle_password_prompt;
         $self->set_standard_prompt('root', os_type => $os_type, skip_set_standard_prompt => $args{skip_set_standard_prompt});
         save_svirt_pty;
     }


### PR DESCRIPTION
Moved the login handling from the backend to the distribution,
so assert_screen can be used for synchronization

- Related ticket: https://progress.opensuse.org/issues/41504
- Verification run: http://pinky.arch.suse.de/tests/1583
- Required adaptions in the backend: https://github.com/os-autoinst/os-autoinst/pull/1038
