### PR TITLE
[WICKED] Startandstop test 4

### DIFF
--- a/tests/wicked/startandstop_ref.pm
+++ b/tests/wicked/startandstop_ref.pm
@@ -33,8 +33,12 @@ sub run {
     record_info('Test 3', 'Bridge - ifup, remove all config, ifreload');
     mutex_wait('test_3_ready');
 
+    record_info('Test 4', 'Bridge - ifup, remove one config, ifreload');
+    mutex_wait('test_4_ready');
+
     record_info('Test 5', 'Standalone card - ifdown, ifreload');
     mutex_wait('test_5_ready');
+
 }
 
 1;

--- a/tests/wicked/startandstop_sut.pm
+++ b/tests/wicked/startandstop_sut.pm
@@ -82,6 +82,18 @@ sub run {
     $results{3} = $res ? "PASSED" : "FAILED";
     mutex_create("test_3_ready");
 
+    $self->before_scenario('Test 4', 'Bridge - ifup, remove all config, ifreload', $iface);
+    $self->get_from_data('wicked/ifcfg/br0',    $config);
+    $self->get_from_data('wicked/ifcfg/dummy0', $dummy);
+    $self->setup_bridge($config, $dummy, 'ifup');
+    assert_script_run("rm $config");
+    assert_script_run("wicked ifreload --timeout infinite all");
+    my $res1 = script_run("ip link|grep br0");
+    my $res2 = script_run("ip link|grep dummy0");
+    $results{4} = $res1 && !$res2 ? "PASSED" : "FAILED";
+    $self->cleanup($dummy, "dummy0");
+    mutex_create("test_4_ready");
+
     $self->before_scenario('Test 5', 'Standalone card - ifdown, ifreload', $iface);
     $config = '/etc/sysconfig/network/ifcfg-' . $iface;
     $self->get_from_data('wicked/dynamic_address/ifcfg-eth0', $config);


### PR DESCRIPTION
Bridge - ifup, remove one config, ifreload

    When I create a bridge on interface eth1 from legacy files
    Then I delete the config file for br1
    #  
    When I bring up all by ifreload
    Then there should not be the br1 card anymore
    But the dummy1 card should still be there
    And the eth1 card should still be there

- Related ticket: https://progress.opensuse.org/issues/41660
- Verification run: http://fromm.arch.suse.de/tests/2026
