### PR TITLE
Fix lvm on top of raid partitioning

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -172,11 +172,17 @@ sub set_lvm {
     wait_still_screen;
 
     # create logical volume
-    send_key "alt-d";
-    send_key "down";
-    send_key "down";
-    send_key "ret";
-
+    if ($older_product) {
+        send_key "alt-d";
+        send_key "down";
+        send_key "down";
+        send_key "ret";
+    }
+    else {
+        send_key 'alt-o';
+        assert_screen 'logical-volumes-dropdown-open';
+        assert_and_click 'add-logical-volume';
+    }
     # create normal volume with name root
     assert_screen 'add-lvm-on-root';
     type_string "root";


### PR DESCRIPTION
Adjustment in drop-down menu due to new Storage-ng UI when using lvm on top or raid partitioning.

- Related ticket: https://progress.opensuse.org/issues/41300
- Needles: [needles sle](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/964)
- Verification run: [sle-15-SP1-RAID0 with LVM added](http://dhcp42.suse.cz/tests/363#step/partitioning_raid/300)
