### PR TITLE
Fix regex to detect broken man page

### DIFF
--- a/tests/console/journalctl.pm
+++ b/tests/console/journalctl.pm
@@ -19,7 +19,7 @@ use testapi;
 sub run {
     if (script_run('command -v man') == 0) {
         my $output = script_output('man -P cat journalctl');
-        record_soft_failure('bsc#1063066 - broken manpage') if ($output =~ m/\.SH "NAME"/);
+        record_soft_failure('bsc#1063066 - broken manpage') if ($output =~ m/\s+\.SH /);
     }
 }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/27050
- Verification run:
  - Bug is not present: http://slindomansilla-vm.qa.suse.de/tests/473
  - Bug is present: http://slindomansilla-vm.qa.suse.de/tests/472#step/journalctl/7
