### PR TITLE
Always check readerview pop-up and continue if not present

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -544,8 +544,8 @@ sub start_clean_firefox {
 
     # get rid of the reader & tracking pop-up once, first test should have milestone flag
     $self->firefox_open_url('eu.httpbin.org/html');
-    # no reader view pop-up on sle15+
-    if (is_sle('<15')) {
+    wait_still_screen(3);
+    if (check_screen 'firefox_readerview_window') {
         wait_still_screen(3);
         assert_and_click 'firefox_readerview_window';
     }

--- a/tests/x11/firefox/firefox_headers.pm
+++ b/tests/x11/firefox/firefox_headers.pm
@@ -32,6 +32,7 @@ sub run {
     assert_and_click('firefox-headers-select-other');
     # refresh page
     send_key 'f5';
+    wait_still_screen 3;
     assert_screen 'firefox-url-loaded';
     assert_and_click('firefox-headers-select-gnu.org');
     assert_screen('firefox-headers-first_item');


### PR DESCRIPTION
Looks like readerview pop-up is not showing up in never firefox versions

https://openqa.suse.de/tests/2180343#step/firefox_smoke/17
