### PR TITLE
xfstests: Make long log short

### DIFF
--- a/lib/ctcs2_to_junit.pm
+++ b/lib/ctcs2_to_junit.pm
@@ -102,7 +102,7 @@ sub generateXML {
         if (!get_var('QA_TESTSUITE') && ($case_status eq 'failure' || $case_status eq 'skipped')) {
             (my $test_path = $test) =~ s/-/\//;
             $test_path = '/opt/log/' . $test_path;
-            my $test_out_content = script_output("cat $test_path| sed \"s/'//g\" | sed \"s/[\\x00-\\x08\\x0B-\\x0C\\x0E-\\x1F]//g\"", 600);
+            my $test_out_content = script_output("cat $test_path| sed \"s/'//g\" | sed \"s/[\\x00-\\x08\\x0B-\\x0C\\x0E-\\x1F]//g\"|tail -n 200", 600);
             $writer->startTag('system-out');
             $writer->characters($test_out_content);
             $writer->endTag('system-out');
@@ -110,12 +110,12 @@ sub generateXML {
                 my $test_err_content = script_output("
                     echo '====out.bad log====';
                     if [ -f $test_path.out.bad ];
-                        then cat $test_path.out.bad|sed \"s/'//g\"|sed \"s/[\\x00-\\x08\\x0B-\\x0C\\x0E-\\x1F]//g\";
+                        then cat $test_path.out.bad|sed \"s/'//g\"|sed \"s/[\\x00-\\x08\\x0B-\\x0C\\x0E-\\x1F]//g\"|tail -n 200;
                     else echo '$test_path.out.bad not exist';
                     fi;
                     echo '====full log====';
                     if [ -f $test_path.full ];
-                        then cat $test_path.full|sed \"s/'//g\"|sed \"s/[\\x00-\\x08\\x0B-\\x0C\\x0E-\\x1F]//g\";
+                        then cat $test_path.full|sed \"s/'//g\"|sed \"s/[\\x00-\\x08\\x0B-\\x0C\\x0E-\\x1F]//g\"|tail -n 200;
                     else echo '$test_path.full not exist';
                     fi;
                 ", 600);


### PR DESCRIPTION
Since some test log too long to output in website, this PR to cut long log short to 200 lines. Most of log is around 10s of lines, only 1~2 tests has a 1800+ long log, so cut log output to 200 make sence. It will reduce test time to a reasonable time. to solve following test can't finish problem:
https://openqa.suse.de/tests/2177782 

- Related ticket: https://progress.opensuse.org/issues/39239
- Verification run: http://10.67.133.102/tests/687#
(tested with longest log testcase, with this change test can finish in 10 minutes, without this PR, test will last for 2 hours)
