### PR TITLE
Add break after 20 tries in updates_gpk_packagekit

### DIFF
--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -61,9 +61,10 @@ sub run {
 
     setup_system;
 
+    my $counter = 0;
     while (1) {
         x11_start_program('gpk-update-viewer', target_match => \@updates_tags, match_timeout => 100);
-
+        $counter += 1;
         if ($testapi::username eq 'root' and match_has_tag("package-updater-privileged-user-warning")) {
             # Special case if gpk-update-viewer is running as root. Click on Continue Anyway and reassert
             send_key "alt-a";    # Continue Anyway
@@ -113,6 +114,7 @@ sub run {
                 setup_system;
             }
         }
+        die "Took too many tries" if $counter >= 20;
     }
 }
 


### PR DESCRIPTION
If updates_packagekit_gpk fails to install all updates in twenty
iterations we now break to avoid endless loops

- Related ticket: https://progress.opensuse.org/issues/41105
