### PR TITLE
Make znc/weechat test more reliable

### DIFF
--- a/tests/console/weechat.pm
+++ b/tests/console/weechat.pm
@@ -32,7 +32,7 @@ sub run {
     assert_screen('weechat-server-added');
 
     type_string("/connect znc\n");
-    assert_screen('weechat-no-longer-away');
+    assert_screen('weechat-welcome_to_znc');
 
     type_string("/query *status\n");
     type_string("Version\n");

--- a/tests/console/znc.pm
+++ b/tests/console/znc.pm
@@ -59,7 +59,7 @@ sub run {
     type_string("\n");
 
     wait_serial('Server host');
-    type_string("\n");
+    type_string("this.remote.irc.server.does.not.exist\n");
 
     wait_serial('Server uses SSL');
     type_string("\n");


### PR DESCRIPTION
Do not actually connect to freenode


Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/452
Verification: http://artemis.suse.de/tests/695