### PR TITLE
[WICKED] Startandstop Test 22

### DIFF
--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -44,7 +44,7 @@ sub run {
     record_info('INFO', 'Checking that network service is up');
     systemctl('is-active network');
     systemctl('is-active wicked');
-    zypper_call('--quiet in openvpn', timeout => 200) if (check_var('WICKED', 'advanced'));
+    zypper_call('--quiet in openvpn', timeout => 200) if (check_var('WICKED', 'advanced') || check_var('WICKED', 'startandstop'));
 }
 
 sub test_flags {

--- a/tests/wicked/startandstop_ref.pm
+++ b/tests/wicked/startandstop_ref.pm
@@ -39,6 +39,14 @@ sub run {
     record_info('Test 5', 'Standalone card - ifdown, ifreload');
     mutex_wait('test_5_ready');
 
+    record_info('Test 22', 'OpenVPN tunnel - ifdown');
+    my $config = '/etc/sysconfig/network/ifcfg-tun1';
+    $self->get_from_data('wicked/ifcfg/tun1_ref',      $config);
+    $self->get_from_data('wicked/openvpn/server.conf', $openvpn_server);
+    assert_script_run("sed \'s/device/tun1/\' -i $openvpn_server");
+    $self->setup_tuntap($config, "tun1", 1);
+    mutex_wait('test_22_ready');
+    $self->cleanup($config, "tun1");
 }
 
 1;


### PR DESCRIPTION
OpenVPN tunnel - ifdown

When I create a tun interface from legacy files
Then both machines should have a new tun1 card
When I bring down tun1
Then there should not be the tun1 card anymore
And the openvpn daemon should not be running anymore

- Related ticket: https://progress.opensuse.org/issues/41735
- Verification run: http://cfconrad-vm.qa.suse.de/tests/1912

@jlausuch @asmorodskyi plz have a look