### PR TITLE
Fix yast2_nis module when NIS Domain is prefilled

### DIFF
--- a/tests/console/yast2_nis.pm
+++ b/tests/console/yast2_nis.pm
@@ -44,21 +44,22 @@ sub run() {
     send_key 'alt-m';
     assert_screen 'nis-client-automounter-enabled';    # this checks if nis and automounter got really enabled
     send_key 'alt-i';                                  # enter Nis domain for enter string suse.de
+    send_key_until_needlematch 'nis-domain-empty-field', 'backspace';    # clear NIS Domain field if it is prefilled
     type_string "suse.de";
     send_key 'alt-a';
     type_string "10.162.0.1";
-    wait_screen_change { send_key 'alt-p' };           # check Netconfif NIS Policy
+    wait_screen_change { send_key 'alt-p' };                             # check Netconfif NIS Policy
     send_key 'up';
     wait_screen_change { send_key 'ret' };
-    assert_screen 'only-manual-changes';               # check the needle
-    send_key 'alt-p';                                  # enter Netconfif NIS Policy again for custom policy
+    assert_screen 'only-manual-changes';                                 # check the needle
+    send_key 'alt-p';                                                    # enter Netconfif NIS Policy again for custom policy
     wait_screen_change { send_key 'down' };
     send_key 'ret';
-    wait_screen_change { send_key 'alt-x' };           # check Expert...
+    wait_screen_change { send_key 'alt-x' };                             # check Expert...
     wait_screen_change { send_key 'alt-b' };
-    assert_screen 'expert_settings';                   # check the needle enable Broken server
+    assert_screen 'expert_settings';                                     # check the needle enable Broken server
     send_key 'alt-y';
-    wait_screen_change { type_string "-c" };           # only checks if the config file has syntax errors and exits
+    wait_screen_change { type_string "-c" };                             # only checks if the config file has syntax errors and exits
     wait_screen_change { send_key 'alt-o' };
     send_key_until_needlematch('nfs-client-configuration', 'alt-s', 2, 5);    # enter NFS configuration, sometimes fails, retry
     send_key 'alt-a';                                                         # add nfs settings


### PR DESCRIPTION
The commit fixes the issue, when NIS Domain field is prefilled and testing framework does not expect that.

The issue happened, because NIS Domain field is prefilled with 'suse.de' on s380x installation, and the test just adds 'suse.de' again to the same string. Please see the [screenshot](https://openqa.suse.de/tests/2177977#step/yast2_nis/7) from the step as an example ("suse.desuse.de" is typed in NIS Domain field).

- Related issue: [poo42122](https://progress.opensuse.org/issues/42122);
- **Needles:** https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/965;
- Verification Runs: 
    - [yast2_ncurses@s390x-kvm-sle12](http://oorlov-vm.qa.suse.de/tests/380), where the NIS Domain field is prefilled;
    - [yast2_ncurses@64bit](http://oorlov-vm.qa.suse.de/tests/415), where it is not prefilled. To show that there is no regression on the tests that passed before.
