### PR TITLE
Adapt keyboard shortcuts to new firefox version

### DIFF
--- a/tests/x11/firefox/firefox_downloading.pm
+++ b/tests/x11/firefox/firefox_downloading.pm
@@ -57,16 +57,16 @@ sub dl_pause {
     send_key "p";
 }
 
-# firefox 62 in sle15 does not have option or shortcut to cancel only button
+# firefox 60.2 does not have option or shortcut to cancel only button
 sub dl_cancel {
-    if (is_sle('15+')) {
-        assert_and_click('firefox-downloading-cancel-button');
-    }
-    else {
+    if (is_sle('=12sp4')) {
         dl_pause();
         dl_menu();
         send_key "c";
         wait_still_screen 3, 6;
+    }
+    else {
+        assert_and_click('firefox-downloading-cancel-button');
     }
 }
 

--- a/tests/x11/firefox/firefox_passwd.pm
+++ b/tests/x11/firefox/firefox_passwd.pm
@@ -32,7 +32,7 @@ sub run {
 
     send_key "alt-shift-u";
     wait_still_screen 3;
-    send_key 'spc' if is_sle('15+');
+    send_key 'spc' unless is_sle('=12-sp4');
 
     assert_screen('firefox-passwd-master_setting');
 

--- a/tests/x11/firefox/firefox_ssl.pm
+++ b/tests/x11/firefox/firefox_ssl.pm
@@ -27,8 +27,8 @@ sub run {
     # go to advanced button and press it
     send_key "tab";
     send_key "ret";
-    # sle15+ has checkbox above buttons (2 tabs) and rest has checkbox under buttons (3 tabs)
-    my $count = is_sle('15+') ? 2 : 3;
+    # firefox 60.2+ has checkbox above buttons (2 tabs) and rest has checkbox under buttons (3 tabs)
+    my $count = is_sle('=12sp4') ? 3 : 2;
     for (1 .. $count) { send_key "tab"; }
     send_key "ret";
 


### PR DESCRIPTION
I assume 12SP4 has still older firefox version

- Related ticket: https://progress.opensuse.org/issues/42611