### PR TITLE
Fix missing braces in is_storage_ng_newui call

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -252,18 +252,16 @@ sub addlv {
     send_key 'right' if is_sle('<15');
     send_key 'alt-i' if (is_storage_ng_newui);
     wait_still_screen 2;
-    send_key(
-        is_storage_ng_newui ? $cmd{addlv} : $cmd{addpart});
+    send_key(is_storage_ng_newui() ? $cmd{addlv} : $cmd{addpart});
     if (!is_storage_ng) {
-        send_key 'down' for (0..1);
+        send_key 'down' for (0 .. 1);
         save_screenshot;
     }
     assert_screen 'partition-lv-type';
     send_key 'alt-g';
     wait_still_screen 2;
     type_string $args{name};
-    send_key($args{thinpool} ? 'alt-t' : $args{thinvolume} ? 'alt-i' : 'alt-o'
-    );
+    send_key($args{thinpool} ? 'alt-t' : $args{thinvolume} ? 'alt-i' : 'alt-o');
     send_key $cmd{next};
     assert_screen 'partition-lv-size';
 


### PR DESCRIPTION
Regression: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5958

Fails: https://openqa.suse.de/tests/2182879/file/autoinst-log.txt

Validation: http://nilgiri.suse.cz/tests/1251

The other change is required by our tidy.