### PR TITLE
Create qcow2 image suitable for RPi/JeOS on aarch64

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -608,6 +608,12 @@ sub load_system_role_tests {
     }
 }
 sub load_jeos_tests {
+    if (get_var('PREPARE_RPI')) {
+        loadtest "boot/boot_to_desktop";
+        loadtest "jeos/prepare_rpi_image";
+        loadtest "shutdown/shutdown";
+        return;
+    }
     unless (get_var('LTP_COMMAND_FILE')) {
         load_boot_tests();
         loadtest "jeos/firstrun";

--- a/tests/jeos/prepare_rpi_image.pm
+++ b/tests/jeos/prepare_rpi_image.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Decompress RPi raw.xz image, resize to 16GB, convert to qcow2 and upload as asset
+# Maintainer: Tomas Hehejik <thehejik@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+use utils 'zypper_call';
+
+sub run {
+    my $version       = get_var('VERSION');
+    my $build         = get_var('BUILD');
+    my $rpi_image_url = "http://openqa.suse.de/assets/hdd/SLES$version-JeOS.aarch64-15.1-RaspberryPi-Build$build.raw.xz";
+
+    (my $rpi_image_rawxz = $rpi_image_url) =~ s/.*\///;
+    (my $rpi_image_raw   = $rpi_image_rawxz) =~ s/\.[^.]+$//;
+    (my $rpi_image_qcow2 = $rpi_image_raw) =~ s/\.raw/\.qcow2/;
+
+    select_console('root-console');
+
+    # System should be registered already - we need qemu-img binary
+    zypper_call('in --no-recommends qemu-tools');
+
+    # Download, prepare and upload the image
+    assert_script_run("time curl --fail -s -O -L $rpi_image_url");
+    assert_script_run("time unxz $rpi_image_rawxz",                                            600);
+    assert_script_run("time qemu-img resize -f raw $rpi_image_raw 16G",                        600);
+    assert_script_run("time qemu-img convert -f raw -O qcow2 $rpi_image_raw $rpi_image_qcow2", 600);
+    upload_asset("$rpi_image_qcow2", 1);
+}
+
+1;


### PR DESCRIPTION
This commit is needed for preparation of openqa qcow2 compatible image from original aarch64-raw.xz image for Rpi3. I wanted to avoid changing of rsync.pl regarding to extraction of raw.xz archive and 'qemu-image convert' action because it would be a time/CPU expensive operation so I moved this task (unxz, qemu-img convert) to aarch64 worker side where it doesn't hurt so much.

Basically it does following:
* start any registered generic UEFI aarch64 VM with curl and xzcat binaries (JeOS contains both)
* download rsynced raw.xz image from osd
* decompress and convert image by qemu-img in root's home dir
* upload the qcow2 image via upload_asset() to osd

Needed rsync.pl change for syncing raw.xz image on osd is already merged https://gitlab.suse.de/openqa/scripts/merge_requests/261

Media definition: JeOS-for-RaspberryPi
```
+HDD_1=SLES%VERSION%-JeOS.%ARCH%-15.1-RaspberryPi-Build%BUILD%.qcow2
JEOS=1
SCC_REGCODE=regcode
SCC_URL=http://all-0000.proxy.scc.suse.de
```

Test definition: prepare_RPi_image
```
+HDD_1=sle-15-sp1-jeos_raspberry-aarch64.qcow2
DESKTOP=textmode
INSTALLONLY=1
PREPARE_RPI=1
UEFI_PFLASH_VARS=sle-15-sp1-jeos_raspberry-aarch64-uefi-vars.qcow2
```

- Related ticket: https://progress.opensuse.org/issues/40658
- Needles: none
- Verification runs:
  - prepare job http://dhcp105.suse.cz/tests/1094
  - one slightly modified jeos job http://dhcp105.suse.cz/tests/1095
