### PR TITLE
Fix brackets in ternary send_key calls

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -103,7 +103,7 @@ sub create_new_partition_table {
         assert_screen "create-new-partition-table";
         send_key $table_type_hotkey{$table_type};
         assert_screen "partition-table-$table_type-selected";
-        send_key((is_storage_ng) ? $cmd{next} : $cmd{ok});    # OK
+        send_key((is_storage_ng()) ? $cmd{next} : $cmd{ok});    # OK
         send_key 'alt-p' if (is_storage_ng and (!is_tumbleweed));    # return back to Partitions tab
     }
     unless (is_storage_ng and (!is_tumbleweed)) {
@@ -154,7 +154,7 @@ sub resize_partition {
     # Set maximum size for the partition
     set_partition_size;
     assert_screen 'partition-maximum-size-selected';
-    send_key((is_storage_ng) ? "$cmd{next}" : "$cmd{ok}");
+    send_key((is_storage_ng()) ? "$cmd{next}" : "$cmd{ok}");
 }
 
 sub addpart {
@@ -179,9 +179,9 @@ sub addpart {
         else {
             send_key 'alt-a' if is_storage_ng;    # Select to format partition, not selected by default
             wait_still_screen 1;
-            send_key((is_storage_ng) ? 'alt-f' : 'alt-s');
+            send_key((is_storage_ng()) ? 'alt-f' : 'alt-s');
             wait_screen_change { send_key 'home' };    # start from the top of the list
-            assert_screen(((is_storage_ng) ? 'partition-selected-ext2-type' : 'partition-selected-btrfs-type'), timeout => 10);
+            assert_screen(((is_storage_ng()) ? 'partition-selected-ext2-type' : 'partition-selected-btrfs-type'), timeout => 10);
             send_key_until_needlematch "partition-selected-$args{format}-type", 'down', 10, 5;
         }
     }
@@ -211,7 +211,7 @@ sub addpart {
         send_key 'tab';
         type_password;
     }
-    send_key((is_storage_ng) ? $cmd{next} : $cmd{finish});
+    send_key((is_storage_ng()) ? $cmd{next} : $cmd{finish});
 }
 
 sub addvg {
@@ -266,7 +266,7 @@ sub addlv {
     assert_screen 'partition-lv-size';
 
     if ($args{size}) {    # use default max size if not defined
-        send_key((is_storage_ng) ? 'alt-t' : $cmd{customsize});    # custom size
+        send_key((is_storage_ng()) ? 'alt-t' : $cmd{customsize});    # custom size
         assert_screen 'partition-custom-size-selected';
         send_key 'alt-s' if is_storage_ng;
         # Remove text

--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -166,7 +166,7 @@ sub set_lvm {
     type_string "root";
     assert_screen 'volumegroup-name-root';
 
-    send_key is_storage_ng() ? $cmd{next} : $cmd{finish};
+    send_key(is_storage_ng() ? $cmd{next} : $cmd{finish});
     wait_still_screen;
 
     # create logical volume
@@ -194,7 +194,7 @@ sub set_lvm {
     assert_screen('volume-pick-os-role');
     send_key $cmd{next};
     assert_screen 'volume-mount-as-root';
-    send_key is_storage_ng() ? $cmd{next} : $cmd{finish};
+    send_key(is_storage_ng() ? $cmd{next} : $cmd{finish});
 }
 
 sub modify_uefi_boot_partition {
@@ -215,7 +215,7 @@ sub modify_uefi_boot_partition {
     send_key $cmd{next};
     assert_screen 'partition-format';
     # We have different shortcut for Format option when editing partition
-    send_key is_storage_ng_newui ? 'alt-f' : 'alt-a';
+    send_key(is_storage_ng_newui() ? 'alt-f' : 'alt-a');
     send_key 'home';
     send_key_until_needlematch 'partitioning_raid-format_default_UEFI', 'down';
     # format as FAT (first choice)
@@ -228,7 +228,7 @@ sub modify_uefi_boot_partition {
     # enter mount point
     type_string '/boot/efi';
     assert_screen 'partitioning_raid-mount_point_boot_efi';
-    send_key is_storage_ng() ? $cmd{next} : $cmd{finish};
+    send_key(is_storage_ng() ? $cmd{next} : $cmd{finish});
     assert_screen 'expert-partitioner';
     send_key is_storage_ng() ? 'tab' : 'shift-tab';
     send_key 'shift-tab' unless is_storage_ng;

--- a/tests/installation/partitioning_warnings.pm
+++ b/tests/installation/partitioning_warnings.pm
@@ -35,7 +35,7 @@ sub process_warning {
 
 sub process_missing_special_partitions {
     # Have missing boot/zipl partition warning only in storage_ng
-    if (is_storage_ng && check_var('ARCH', 's390x')) {    # s390x needs /boot/zipl on ext partition
+    if (is_storage_ng() && check_var('ARCH', 's390x')) {    # s390x needs /boot/zipl on ext partition
         process_warning(warning => 'no-boot-zipl', key => 'alt-n');
     }
     elsif (get_var('OFW')) {                              # ppc64le needs PReP /boot
@@ -51,7 +51,7 @@ sub process_missing_special_partitions {
 }
 
 sub remove_partition {
-    my $remove_key = (is_storage_ng) ? 'alt-e' : 'alt-t';
+    my $remove_key = ((is_storage_ng()) ? 'alt-e' : 'alt-t');
     $remove_key = 'alt-t' if is_tumbleweed;
     wait_screen_change { send_key($remove_key) };
     assert_screen 'remove-partition';
@@ -93,7 +93,7 @@ sub run {
     send_key $cmd{accept};
     # Check no root partition warning (has different keys, with storage-ng it's an error)
     record_info('Test: No root', 'Test warning for missing root partition');
-    process_warning(warning => 'no-root-partition', key => (is_storage_ng) ? 'alt-o' : 'alt-n');
+    process_warning(warning => 'no-root-partition', key => ((is_storage_ng()) ? 'alt-o' : 'alt-n'));
     if (!is_storage_ng) {
         record_info('Test: No boot', "Missing boot partition for " . get_var('ARCH'));
         process_missing_special_partitions;


### PR DESCRIPTION
Fix for
one more Use of ?PATTERN? without explicit operator is deprecated at /var/lib/openqa/cache/tests/sle/tests/installation/partitioning_raid.pm line 218