### PR TITLE
Unschedule data_integrity as it broke bootloader processing

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -426,7 +426,6 @@ sub is_remote_backend {
 sub load_boot_tests {
     if (get_var("ISO_MAXSIZE") && !is_remote_backend) {
         loadtest "installation/isosize";
-        loadtest "installation/data_integrity" if data_integrity_is_applicable;
     }
     if ((get_var("UEFI") || is_jeos()) && !check_var("BACKEND", "svirt")) {
         loadtest "installation/bootloader_uefi";


### PR DESCRIPTION
See [poo#42632](https://progress.opensuse.org/issues/42632).

Here is the run without module scheduled where it works: https://openqa.suse.de/tests/2183791