### PR TITLE
Mitigate instability when dealing with mount point in partitioner

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -118,6 +118,7 @@ sub mount_device {
     wait_still_screen 1;
     send_key 'alt-m';
     type_string "$mount";
+    wait_still_screen 1;
 }
 
 # Set size when adding or resizing partition
@@ -177,10 +178,10 @@ sub addpart {
             send_key 'alt-u';
         }
         else {
-            send_key 'alt-a' if is_storage_ng;    # Select to format partition, not selected by default
+            send_key(is_storage_ng() ? 'alt-r' : 'alt-a');    # Select to format partition
             wait_still_screen 1;
             send_key((is_storage_ng) ? 'alt-f' : 'alt-s');
-            wait_screen_change { send_key 'home' };    # start from the top of the list
+            wait_screen_change { send_key 'home' };           # start from the top of the list
             assert_screen(((is_storage_ng) ? 'partition-selected-ext2-type' : 'partition-selected-btrfs-type'), timeout => 10);
             send_key_until_needlematch "partition-selected-$args{format}-type", 'down', 10, 5;
         }
@@ -189,9 +190,9 @@ sub addpart {
     if ($args{enable_snapshots} && $args{format} eq 'btrfs') {
         send_key_until_needlematch('partition-btrfs-snapshots-enabled', $cmd{enable_snapshots});
     }
-    if ($args{fsid}) {                                 # $args{fsid} will describe needle tag below
-        send_key 'alt-i';                              # select File system ID
-        send_key 'home';                               # start from the top of the list
+    if ($args{fsid}) {                                        # $args{fsid} will describe needle tag below
+        send_key 'alt-i';                                     # select File system ID
+        send_key 'home';                                      # start from the top of the list
         if ($args{role} eq 'raw' && !check_var('VIDEOMODE', 'text')) {
             record_soft_failure('bsc#1079399 - Combobox is writable');
             for (1 .. 10) { send_key 'up'; }
@@ -211,7 +212,7 @@ sub addpart {
         send_key 'tab';
         type_password;
     }
-    send_key((is_storage_ng) ? $cmd{next} : $cmd{finish});
+    send_key(is_storage_ng() ? $cmd{next} : $cmd{finish});
 }
 
 sub addvg {

--- a/tests/installation/partitioning_warnings.pm
+++ b/tests/installation/partitioning_warnings.pm
@@ -158,6 +158,7 @@ sub run {
         ## Add boot partition ID with under limit boot partition size
         foreach (keys %roles) {
             addpart(role => $roles{$_}{role}, size => $roles{$_}{size}, format => $roles{$_}{format}, mount => $roles{$_}{mount}, fsid => $roles{$_}{fsid});
+            assert_screen 'expert-partitioner';
             send_key $cmd{accept};
             record_info("Test: $_", "Wrong partition ID or boot partition is too small");
             process_missing_special_partitions;


### PR DESCRIPTION
- Related ticket: [[sle][functional][y][sporadic] test fails in partitioning_warnings - instability when dealing with mount points](https://progress.opensuse.org/issues/42404)
- Verification run: [sle-15-SP1-Installer-DVD-aarch64-Build75.1-btrfs+warnings@aarch64](http://dhcp128.suse.cz/tests/7132#step/partitioning_warnings/71)