### PR TITLE
Fix partition raid - remaining adjustments

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -170,15 +170,15 @@ sub set_lvm {
 
     # create logical volume
     if (is_storage_ng_newui) {
+        send_key 'alt-o';
+        assert_screen 'logical-volumes-dropdown-open';
+        assert_and_click 'add-logical-volume';
+    }
+    else {
         send_key "alt-d";
         send_key "down";
         send_key "down";
         send_key "ret";
-    }
-    else {
-        send_key 'alt-o';
-        assert_screen 'logical-volumes-dropdown-open';
-        assert_and_click 'add-logical-volume';
     }
     # create normal volume with name root
     assert_screen 'add-lvm-on-root';
@@ -210,8 +210,10 @@ sub modify_uefi_boot_partition {
     assert_screen 'partitioning_raid-disk_vda_with_partitions-selected';
     # edit first partition
     send_key 'alt-e';
-    assert_screen 'partition-role';
-    send_key $cmd{next};
+    if (is_storage_ng_newui) {
+        assert_screen 'partition-role';
+        send_key $cmd{next};
+    }
     assert_screen 'partition-format';
     # We have different shortcut for Format option when editing partition
     send_key(is_storage_ng_newui() ? 'alt-f' : 'alt-a');
@@ -530,7 +532,6 @@ sub enter_partitioning {
 }
 
 sub run {
-
     enter_partitioning;
     add_partitions;
     add_raid;


### PR DESCRIPTION
For sle12 sp4  I forgot to branch this code for partitioning raid when modifying uefi boot partition.
For sle15 sp1 we didn't reverse the logic properly [here](https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/54b7384eca760b53ef794333e16bed43c1404680#diff-533959a61b1dcb52f611e4132ffad317L175) when incorporating the shared function.
- Related ticket: https://progress.opensuse.org/issues/41300
- Verification run: 
  - [sle-12-SP4-RAID0@aarch64](http://dhcp42.suse.cz/tests/420#step/partitioning_raid/273)
  - [sle-15-SP1-lvm+RAID1@64bit](http://dhcp42.suse.cz/tests/418#step/partitioning_raid/297)
