### PR TITLE
Workaround issue with video playing of vlc

### DIFF
--- a/tests/x11/vlc.pm
+++ b/tests/x11/vlc.pm
@@ -35,8 +35,15 @@ sub run {
     assert_and_click "vlc-play_button";
     # The video is actually 23 seconds long so give a bit of headroom for
     # startup
-    assert_screen "vlc-done-playing", 90;
-    assert_and_click "close_vlc";
+    assert_screen [qw(vlc-video-info-only vlc-done-playing), 90];
+    if (match_has_tag 'vlc-done-playing') {
+        wait_still_screen;
+        assert_and_click "close_vlc";
+    }
+    elsif (match_has_tag 'vlc-video-info-only') {
+        wait_screen_change(sub { send_key 'alt-f4'; }, 90);
+        record_soft_failure('boo#1102838 - VLC fails to play video');
+    }
 }
 
 1;


### PR DESCRIPTION
we have problem with video playing, but existing needle could not detect
and check this issue. So create a new one at place where video is playing
for the case that video cannot be played and vlc shows video information
only. Add record_soft_failure for this case and it's required new needle
vlc-video-info-only

see ticket https://progress.opensuse.org/issues/37713 for more details

verificatiion run:
http://e13.suse.de/tests/9652#step/vlc/25
http://e13.suse.de/tests/9640#step/vlc/25

needle PR:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/453
