### PR TITLE
Use partition_setup functions to setup full lvm

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -231,8 +231,13 @@ sub addvg {
     assert_screen 'partition-add-volume-group';
     send_key 'alt-v';
     type_string $args{name};
-    assert_and_click 'partition-select-first-from-top';
-    send_key 'alt-a';
+    if ($args{add_all_pvs}) {
+        send_key 'alt-d';
+    }
+    else {
+        assert_and_click 'partition-select-first-from-top';
+        send_key 'alt-a';
+    }
     wait_still_screen 2;
     save_screenshot;
     send_key(is_storage_ng() ? $cmd{next} : $cmd{finish});


### PR DESCRIPTION
- Related ticket: [[sle][functional][y][fast] Expert Partitioner UI upgrade - create partition table](https://progress.opensuse.org/issues/41903)
- Needles: 
  * [OSD](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/967)
  * [o3](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/454)
- Verification runs:
   * [sle-15-SP1-Installer-DVD-x86_64-Build75.1-lvm-full-encrypt@64bit](http://dhcp128.suse.cz/tests/7145#step/partitioning_full_lvm/1) 
   * [sle-15-SP1-Installer-DVD-x86_64-Build75.1-lvm-encrypt-separate-boot@64bit](http://dhcp128.suse.cz/tests/7146#step/partitioning_full_lvm/1)
   * [opensuse-Tumbleweed-DVD-x86_64-Build20181017-lvm-full-encrypt@64bit](http://dhcp128.suse.cz/tests/7154#step/partitioning_full_lvm/75)
   * [opensuse-Tumbleweed-DVD-x86_64-Build20181017-lvm-encrypt-separate-boot@64bit](http://dhcp128.suse.cz/tests/7152#step/partitioning_full_lvm/1)
  * [sle-12-SP4-Server-DVD-x86_64-Build0429-lvm-encrypt-separate-boot@64bit](http://dhcp128.suse.cz/tests/7156#step/partitioning_full_lvm/1)
  * [sle-12-SP4-Server-DVD-x86_64-Build0429-lvm-full-encrypt@64bi](http://dhcp128.suse.cz/tests/7155#step/partitioning_full_lvm/1)
