### PR TITLE
Implement password prompt handle for svirt consoles

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -319,6 +319,7 @@ sub set_standard_prompt {
     if ($os_type eq 'windows') {
         $prompt_sign = $user eq 'root' ? '# ' : '$$ ';
         type_string "prompt $prompt_sign\n";
+        type_string "cls\n";    # clear the screen
     }
     elsif ($os_type eq 'linux') {
         type_string "which tput 2>&1 && PS1=\"\\\[\$(tput bold 2; tput setaf 1)\\\]$prompt_sign\\\[\$(tput sgr0)\\\] \"\n";


### PR DESCRIPTION
https://progress.opensuse.org/issues/42668

os-autoinst/os-autoinst#1038 removed
backend-side password handle, requiring test-code to do the work
instead. This implements password prompt handle for `svirt` and
`hyperv-intermediary` consoles.

I tested only Xen & Hyper-V:
* jeos-main-de_DE@svirt-hyperv: http://nilgiri.suse.cz/tests/1277
* default_install@svirt-hyperv: http://nilgiri.suse.cz/tests/1285
* textmode@svirt-hyperv: http://nilgiri.suse.cz/tests/1286
* migration_offline_sle12sp3_allpatterns_fullupdate_hyperv@svirt-hyperv: http://nilgiri.suse.cz/tests/1283
* om_proxyscc_sles12sp3_allpatterns_full_update_by_yast_hyperv@svirt-hyperv: http://nilgiri.suse.cz/tests/1284
* jeos-extratest@svirt-xen-pv: http://nilgiri.suse.cz/tests/1288
* default@svirt-xen-hvm: http://nilgiri.suse.cz/tests/1289

The other commit clears Windows console on `set_standard_prompt`.