### PR TITLE
Check license accepting in extended installation

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -209,13 +209,15 @@ sub deal_with_dependency_issues {
     }
 }
 
-sub verify_license_has_to_be_accepted {
-    # license+lang
+sub accept_license {
     if (get_var('HASLICENSE')) {
-        send_key $cmd{next};
-        assert_screen 'license-not-accepted';
-        send_key $cmd{ok};
-        wait_still_screen 1;
+        # explicitly check that the license has to be accepted
+        if (get_var('INSTALLER_EXTENDED_TEST')) {
+            send_key $cmd{next};
+            assert_screen 'license-not-accepted';
+            send_key $cmd{ok};
+            wait_still_screen 1;
+        }
         send_key $cmd{accept};    # accept license
         wait_still_screen 1;
         save_screenshot;

--- a/tests/installation/accept_license.pm
+++ b/tests/installation/accept_license.pm
@@ -39,14 +39,14 @@ sub run {
     if (match_has_tag('inst-welcome-no-product-list')) {
         return send_key $cmd{next} unless match_has_tag('license-agreement');
     }
-    $self->verify_license_has_to_be_accepted;
+    $self->accept_license;
     $self->verify_license_translations;
     send_key $cmd{next};
     # workaround for bsc#1059317, multiple times clicking accept license
     my $count = 5;
     while (check_screen('license-not-accepted', 3) && $count >= 1) {
         record_soft_failure 'bsc#1059317';
-        $self->verify_license_has_to_be_accepted;
+        $self->accept_license;
         send_key $cmd{next};
         $count--;
     }

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -112,7 +112,7 @@ sub run {
         }
     }
     else {
-        $self->verify_license_has_to_be_accepted;
+        $self->accept_license;
     }
 
     assert_screen 'languagepicked';


### PR DESCRIPTION
An additional check if the license is accepted or not was executed
in all the installation tests.

The commit moves the check to 'installer_extended' test suite.

- Related ticket: [poo#42608](https://progress.opensuse.org/issues/42608)
- Verification Runs:
   - No check, SLE12-SP4: [create_hdd_gnome@64bit](http://oorlov-vm.qa.suse.de/tests/420);
   - Check in installer_extended, SLE12-SP4: [installer_extended@64bit](http://oorlov-vm.qa.suse.de/tests/421);
   - No check, SLE15: [create_hdd_textmode@64bit](http://oorlov-vm.qa.suse.de/tests/422);
   - Check in installer_extended, SLE15: [installer_extended@64bit](http://oorlov-vm.qa.suse.de/tests/423).
