### PR TITLE
[WICKED] Startandstop Test 7

### DIFF
--- a/tests/wicked/startandstop_ref.pm
+++ b/tests/wicked/startandstop_ref.pm
@@ -39,6 +39,9 @@ sub run {
     record_info('Test 5', 'Standalone card - ifdown, ifreload');
     mutex_wait('test_5_ready');
 
+    record_info('Test 7', 'Bridge - ifdown, create new config, ifreload, ifdown, ifup');
+    mutex_wait('test_7_ready');
+
     record_info('Test 8', 'Bridge - ifdown, remove one config, ifreload, ifdown, ifup');
     mutex_wait('test_8_ready');
 


### PR DESCRIPTION
When I create a bridge on interface eth1 from legacy files
And I bring down br1
And I bring down dummy1
Then there should not be the br1 card anymore
And there should not be the dummy1 card anymore

When I create a bridge on interface eth1 from legacy files by ifreload
Then there should be a new br1 card
And there should be a new dummy1 card
And the bridge should have the correct address
And I should be able to ping through the bridge

When I bring down all
And I bring up all from legacy files
Then I should be able to ping a reference machine from my dynamic
address

- Related ticket: https://progress.opensuse.org/issues/41672
- Verification run: http://cfconrad-vm.qa.suse.de/tests/1978#step/startandstop_sut/425
