### PR TITLE
Increase timeout value for yast snapper

### DIFF
--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -109,7 +109,7 @@ sub y2snapper_clean_and_quit {
     wait_screen_change { send_key "alt-l"; };
 
     if ($ncurses) {
-        wait_serial("yast2-snapper-status-0", 180) || die "yast2 snapper failed";
+        wait_serial("yast2-snapper-status-0", 240) || die "yast2 snapper failed";
     }
     else {
         # Wait until root gnome terminal is focussed, delete the directory and close window


### PR DESCRIPTION
I cloned the failed job and set TIMEOUT_SCALE=3 found the timeout is 184s, the origin timeout value is 180s. So we just increase the timeout value to 240s.

- Related ticket: https://progress.opensuse.org/issues/42590
- Verification run: https://openqa.suse.de/tests/2184894
