### PR TITLE
Revert "Use type speed 2 for bootloader"

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -89,11 +89,6 @@ use constant SLOW_TYPING_SPEED => 13;
 # mangling
 use constant VERY_SLOW_TYPING_SPEED => 4;
 
-# Due to missed keys on boot parameters on Leap 42.3 workers, try with even
-# slower typing speed until they are upgraded to Leap 15.0
-# https://progress.opensuse.org/issues/40670
-use constant EXTREME_SLOW_TYPING_SPEED => 2;
-
 # openQA internal ftp server url
 our $OPENQA_FTP_URL = "ftp://openqa.suse.de";
 

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -28,7 +28,7 @@ sub run {
     bootmenu_network_source;
     specific_bootmenu_params;
     specific_caasp_params;
-    registration_bootloader_params(utils::EXTREME_SLOW_TYPING_SPEED);
+    registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
     mutex_wait 'support_server_ready' if get_var('USE_SUPPORT_SERVER');
     # on ppc64le boot have to be confirmed with ctrl-x or F10
     # and it doesn't have nice graphical menu with video and language options


### PR DESCRIPTION
It doesn't help with the issue.

This reverts commit d2657e1a5479216d3f347f45b27512dd7e9f8378.

- Related ticket: https://progress.opensuse.org/issues/40670
