### PR TITLE
Fix two cases of 'Use of uninitialized value ...'

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -852,6 +852,7 @@ C<$modifiers> for sed replacement, e.g. "g".
 sub change_grub_config {
     die((caller(0))[3] . ' expects from 2 to 4 arguments') unless (@_ >= 2 && @_ <= 4);
     my ($old, $new, $search, $modifiers) = @_;
+    $modifiers //= '';
     $search = "/$search/" if defined $search;
 
     assert_script_run("sed -ie '${search}s/${old}/${new}/${modifiers}' " . GRUB_DEFAULT_FILE);

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -18,6 +18,7 @@ use testapi qw(send_key %cmd assert_screen check_screen check_var get_var save_s
 
 sub handle_password_prompt {
     my ($console) = @_;
+    $console //= '';
 
     return if get_var("LIVETEST") || get_var('LIVECD');
     assert_screen "password-prompt";


### PR DESCRIPTION
Two fixes for "Use of uninitialized value ..."

Validation runs:
* Hyper-V: http://nilgiri.suse.cz/tests/1294
* QEMU: http://nilgiri.suse.cz/tests/1295