### PR TITLE
poo#42686 replace alt-o by ret in seahorse.pm

### DIFF
--- a/tests/x11/seahorse.pm
+++ b/tests/x11/seahorse.pm
@@ -26,7 +26,7 @@ sub run {
     assert_and_dclick "seahorse-password-keyring";    # Selection: Password keyring
     assert_screen "seahorse-name-new-keyring";        # Dialog  "Add a password keyring; name it"
     type_string "Default Keyring";                    # Name of the keyring
-    send_key "alt-o";                                 # &Ok
+    send_key "ret";                                   # &Ok
     assert_screen "seahorse-password-dialog";         # Dialog "Passphrase for the new keyring"
     type_password;                                    # Users password (for auto unlock, it has to be the same)
     send_key "ret";                                   # Next field (confirm PW)


### PR DESCRIPTION

- Related ticket: https://progress.opensuse.org/issues/42686
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/457
- Verification run: locally on my ppc64le openQA instance

The referenced needle is not functionally required for this PR, but allow to have seahorse subtest to complete after correction of this PR.
