### PR TITLE
Stop the CPU before and after data integrity check

### DIFF
--- a/lib/data_integrity_utils.pm
+++ b/lib/data_integrity_utils.pm
@@ -27,6 +27,9 @@ Verify image data integrity by comparing SHA256 checksums
 sub verify_checksum {
     my ($dir_path) = shift;    # for backends other than qemu, image directory path needs to be set
 
+    # Since this operation can take up some time, pause the CPU on QEMU backends
+    freeze_vm() if (check_var('BACKEND', 'qemu'));
+
     diag "Comparing data integrity calculated with SHA256 digest against checksum from IBS/OBS via rsync.pl";
     foreach my $image (grep { /^CHECKSUM_/ } keys %bmwqemu::vars) {
         my $checksum = get_required_var $image;
@@ -38,6 +41,9 @@ sub verify_checksum {
         my $msg_fail = "SHA256 checksum does not match for $image:\n\tCalculated: $digest\n\tExpected:   $checksum";
         record_info("$image Fail", $msg_fail, result => 'fail');
     }
+
+    resume_vm() if (check_var('BACKEND', 'qemu'));
+
 }
 
 1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -426,6 +426,7 @@ sub is_remote_backend {
 sub load_boot_tests {
     if (get_var("ISO_MAXSIZE") && !is_remote_backend) {
         loadtest "installation/isosize";
+        loadtest "installation/data_integrity" if data_integrity_is_applicable;
     }
     if ((get_var("UEFI") || is_jeos()) && !check_var("BACKEND", "svirt")) {
         loadtest "installation/bootloader_uefi";


### PR DESCRIPTION
To avoid the bootloader advancing too much, ensure that the CPU is
paused when the operation is executed, as it might take too long causing
the backend to miss the screens.

Verification run: http://phobos.suse.de/tests/1746409
Progress Ticket: https://progress.opensuse.org/issues/42632

Depends on os-autoinst/os-autoinst#1043 being deployed

This reverts commit d821ca93fbf75da64e962238d6923a0ef314d0b1.