### PR TITLE
Unschedule snapper_used_space where fate not implemented

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1644,7 +1644,7 @@ sub load_filesystem_tests {
         # kernel module required by thin-LVM
         loadtest 'console/snapper_thin_lvm' unless is_jeos;
     }
-    loadtest 'console/snapper_used_space';
+    loadtest 'console/snapper_used_space' if is_sle('15-SP1+');
 }
 
 sub load_wicked_tests {


### PR DESCRIPTION
Unschedule snapper_used_space where [fate](https://fate.suse.com/323843) not implemented.

- Related tickets: https://progress.opensuse.org/issues/41309 and https://progress.opensuse.org/issues/42716
