### PR TITLE
wicked: Startandstop Test 10

### DIFF
--- a/data/wicked/ifcfg/eth0.42
+++ b/data/wicked/ifcfg/eth0.42
@@ -1,0 +1,8 @@
+STARTMODE='auto'
+BOOTPROTO='static'
+VLAN_PROTOCOL='ieee802-1q'
+ETHERDEVICE='interface'
+VLAN_ID='42'
+IPADDR='ip_address'
+IPADDR6='fd00:4242:4242::123/48'
+

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1679,6 +1679,7 @@ sub load_wicked_tests {
         loadtest 'wicked/startandstop/' . $f . '/t07_bridge_ifdown_remove_one_config_ifreload_ifdown_ifup';
         loadtest 'wicked/startandstop/' . $f . '/t08_sit_tunnel_ifdown';
         loadtest 'wicked/startandstop/' . $f . '/t09_openvpn_tunnel_ifdown';
+        loadtest 'wicked/startandstop/' . $f . '/t10_vlan_ifup_all_ifdown_one_card';
     }
     else {
         die 'Unhandled WICKED test selection: ' . get_var('WICKED');

--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -17,7 +17,7 @@ use Exporter;
 use strict;
 use testapi;
 
-our @EXPORT = qw(setup_static_network recover_network can_upload_logs iface);
+our @EXPORT = qw(setup_static_network recover_network can_upload_logs iface ifc_exists);
 
 =head2 setup_static_network
 Configure static IP on SUT with setting up default GW.
@@ -77,6 +77,11 @@ sub recover_network {
     script_run 'ip r s';
 
     return can_upload_logs();
+}
+
+sub ifc_exists {
+    my ($ifc) = @_;
+    return !script_run('ip link show dev ' . $ifc);
 }
 
 1;

--- a/tests/wicked/advanced/ref/t01_gre_tunnel_legacy.pm
+++ b/tests/wicked/advanced/ref/t01_gre_tunnel_legacy.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/ref/t02_gre_tunnel_xml.pm
+++ b/tests/wicked/advanced/ref/t02_gre_tunnel_xml.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/ref/t03_sit_tunnel_legacy.pm
+++ b/tests/wicked/advanced/ref/t03_sit_tunnel_legacy.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/ref/t04_sit_tunnel_xml.pm
+++ b/tests/wicked/advanced/ref/t04_sit_tunnel_xml.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/ref/t05_ipip_tunnel_legacy.pm
+++ b/tests/wicked/advanced/ref/t05_ipip_tunnel_legacy.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/ref/t06_ipip_tunnel_xml.pm
+++ b/tests/wicked/advanced/ref/t06_ipip_tunnel_xml.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/ref/t07_tun_interface_legacy.pm
+++ b/tests/wicked/advanced/ref/t07_tun_interface_legacy.pm
@@ -28,7 +28,7 @@ sub run {
     $self->get_from_data('wicked/ifcfg/tun1_ref',      $config);
     $self->get_from_data('wicked/openvpn/server.conf', $openvpn_server);
     assert_script_run("sed 's/device/tun1/' -i $openvpn_server");
-    $self->setup_tuntap($config, 'tun1', 1);
+    $self->setup_tuntap($config, 'tun1');
 }
 
 sub test_flags {

--- a/tests/wicked/advanced/ref/t07_tun_interface_legacy.pm
+++ b/tests/wicked/advanced/ref/t07_tun_interface_legacy.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self)         = @_;

--- a/tests/wicked/advanced/ref/t08_tun_interface_xml.pm
+++ b/tests/wicked/advanced/ref/t08_tun_interface_xml.pm
@@ -28,7 +28,7 @@ sub run {
     $self->get_from_data('wicked/ifcfg/tun1_ref',      $config);
     $self->get_from_data('wicked/openvpn/server.conf', $openvpn_server);
     assert_script_run("sed 's/device/tun1/' -i $openvpn_server");
-    $self->setup_tuntap($config, 'tun1', 1);
+    $self->setup_tuntap($config, 'tun1');
 }
 
 sub test_flags {

--- a/tests/wicked/advanced/ref/t08_tun_interface_xml.pm
+++ b/tests/wicked/advanced/ref/t08_tun_interface_xml.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self)         = @_;

--- a/tests/wicked/advanced/ref/t09_tap_interface_legacy.pm
+++ b/tests/wicked/advanced/ref/t09_tap_interface_legacy.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self)         = @_;

--- a/tests/wicked/advanced/ref/t09_tap_interface_legacy.pm
+++ b/tests/wicked/advanced/ref/t09_tap_interface_legacy.pm
@@ -28,7 +28,7 @@ sub run {
     $self->get_from_data('wicked/ifcfg/tap1_ref',      $config);
     $self->get_from_data('wicked/openvpn/server.conf', $openvpn_server);
     assert_script_run("sed 's/device/tap1/' -i $openvpn_server");
-    $self->setup_tuntap($config, 'tap1', 1);
+    $self->setup_tuntap($config, 'tap1');
 }
 
 sub test_flags {

--- a/tests/wicked/advanced/ref/t10_tap_interface_xml.pm
+++ b/tests/wicked/advanced/ref/t10_tap_interface_xml.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self)         = @_;

--- a/tests/wicked/advanced/ref/t10_tap_interface_xml.pm
+++ b/tests/wicked/advanced/ref/t10_tap_interface_xml.pm
@@ -28,7 +28,7 @@ sub run {
     $self->get_from_data('wicked/ifcfg/tap1_ref',      $config);
     $self->get_from_data('wicked/openvpn/server.conf', $openvpn_server);
     assert_script_run("sed 's/device/tap1/' -i $openvpn_server");
-    $self->setup_tuntap($config, 'tap1', 1);
+    $self->setup_tuntap($config, 'tap1');
 }
 
 sub test_flags {

--- a/tests/wicked/advanced/ref/t11_bridge_interface_legacy.pm
+++ b/tests/wicked/advanced/ref/t11_bridge_interface_legacy.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/ref/t12_bridge_interface_xml.pm
+++ b/tests/wicked/advanced/ref/t12_bridge_interface_xml.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/sut/t01_gre_tunnel_legacy.pm
+++ b/tests/wicked/advanced/sut/t01_gre_tunnel_legacy.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/sut/t02_gre_tunnel_xml.pm
+++ b/tests/wicked/advanced/sut/t02_gre_tunnel_xml.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/sut/t03_sit_tunnel_legacy.pm
+++ b/tests/wicked/advanced/sut/t03_sit_tunnel_legacy.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/sut/t04_sit_tunnel_xml.pm
+++ b/tests/wicked/advanced/sut/t04_sit_tunnel_xml.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/sut/t05_ipip_tunnel_legacy.pm
+++ b/tests/wicked/advanced/sut/t05_ipip_tunnel_legacy.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/sut/t06_ipip_tunnel_xml.pm
+++ b/tests/wicked/advanced/sut/t06_ipip_tunnel_xml.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/sut/t07_tun_interface_legacy.pm
+++ b/tests/wicked/advanced/sut/t07_tun_interface_legacy.pm
@@ -26,7 +26,7 @@ sub run {
     record_info('Info', 'Create a tun interface from legacy ifcfg files');
     $self->get_from_data('wicked/ifcfg/tun1_sut', $config);
     $self->setup_openvpn_client('tun1');
-    $self->setup_tuntap($config, 'tun1', 0);
+    $self->setup_tuntap($config, 'tun1');
     my $res = $self->get_test_result('tun1');
     die if ($res eq 'FAILED');
 }

--- a/tests/wicked/advanced/sut/t07_tun_interface_legacy.pm
+++ b/tests/wicked/advanced/sut/t07_tun_interface_legacy.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/sut/t08_tun_interface_xml.pm
+++ b/tests/wicked/advanced/sut/t08_tun_interface_xml.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/sut/t09_tap_interface_legacy.pm
+++ b/tests/wicked/advanced/sut/t09_tap_interface_legacy.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/sut/t09_tap_interface_legacy.pm
+++ b/tests/wicked/advanced/sut/t09_tap_interface_legacy.pm
@@ -26,7 +26,7 @@ sub run {
     record_info('Info', 'Create a tap interface from legacy ifcfg files');
     $self->get_from_data('wicked/ifcfg/tap1_sut', $config);
     $self->setup_openvpn_client('tap1');
-    $self->setup_tuntap($config, 'tap1', 0);
+    $self->setup_tuntap($config, 'tap1');
     my $res = $self->get_test_result('tap1');
     die if ($res eq 'FAILED');
 }

--- a/tests/wicked/advanced/sut/t10_tap_interface_xml.pm
+++ b/tests/wicked/advanced/sut/t10_tap_interface_xml.pm
@@ -26,7 +26,7 @@ sub run {
     record_info('Info', 'Create a tap interface from Wicked XML files');
     $self->get_from_data('wicked/xml/tap.xml', $config);
     $self->setup_openvpn_client('tap1');
-    $self->setup_tuntap($config, 'tap1', 0);
+    $self->setup_tuntap($config, 'tap1');
     my $res = $self->get_test_result('tap1');
     die if ($res eq 'FAILED');
 }

--- a/tests/wicked/advanced/sut/t10_tap_interface_xml.pm
+++ b/tests/wicked/advanced/sut/t10_tap_interface_xml.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/sut/t11_bridge_interface_legacy.pm
+++ b/tests/wicked/advanced/sut/t11_bridge_interface_legacy.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/advanced/sut/t12_bridge_interface_xml.pm
+++ b/tests/wicked/advanced/sut/t12_bridge_interface_xml.pm
@@ -16,9 +16,6 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use utils 'systemctl';
-use lockapi;
-use mmapi;
 
 sub run {
     my ($self) = @_;

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -36,7 +36,7 @@ sub run {
     #download script for check interface status
     $self->get_from_data('wicked/check_interfaces.sh', '/data/check_interfaces.sh', executable => 1) if check_var('WICKED', 'basic');
     if (check_var('WICKED', 'advanced') || check_var('WICKED', 'startandstop')) {
-        setup_static_network(ip => $self->get_ip(is_wicked_ref => check_var('IS_WICKED_REF', 1), type => 'host'));
+        setup_static_network(ip => $self->get_ip(type => 'host', netmask => 1));
     } else {
         systemctl('restart network');
     }

--- a/tests/wicked/startandstop/ref/t10_vlan_ifup_all_ifdown_one_card.pm
+++ b/tests/wicked/startandstop/ref/t10_vlan_ifup_all_ifdown_one_card.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: VLAN - ifup all, ifdown one card
+# Maintainer: Anton Smorodskyi <asmorodskyi@suse.com>
+#             Jose Lausuch <jalausuch@suse.com>
+#             Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+
+use base 'wickedbase';
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    record_info('Info', 'VLAN - ifup all, ifdown one card');
+}
+
+sub test_flags {
+    return {always_rollback => 1, wicked_need_sync => 1};
+}
+
+1;

--- a/tests/wicked/startandstop/sut/t01_standalone_card_ifdown_ifreload.pm
+++ b/tests/wicked/startandstop/sut/t01_standalone_card_ifdown_ifreload.pm
@@ -27,7 +27,7 @@ sub run {
     $self->get_from_data('wicked/dynamic_address/ifcfg-eth0', $config);
     assert_script_run('wicked ifdown --timeout infinite ' . $iface);
     assert_script_run('wicked ifreload ' . $iface);
-    my $static_ip = $self->get_ip(type => 'host', no_mask => 1);
+    my $static_ip = $self->get_ip(type => 'host');
     my $dhcp_ip = $self->get_current_ip($iface);
     if (defined($dhcp_ip) && $static_ip ne $dhcp_ip) {
         $res = $self->get_test_result('host');

--- a/tests/wicked/startandstop/sut/t04_bridge_ifup_remove_all_config_ifreload.pm
+++ b/tests/wicked/startandstop/sut/t04_bridge_ifup_remove_all_config_ifreload.pm
@@ -15,7 +15,7 @@
 use base 'wickedbase';
 use strict;
 use testapi;
-use network_utils 'iface';
+use network_utils qw(iface ifc_exists);
 
 sub run {
     my ($self) = @_;
@@ -27,7 +27,7 @@ sub run {
     $self->setup_bridge($config, $dummy, 'ifup');
     assert_script_run("rm /etc/sysconfig/network/ifcfg-$iface $config $dummy");
     assert_script_run("wicked ifreload --timeout infinite all");
-    die if (!script_run("ip link | grep 'dummy0\|br0'"));
+    die if (ifc_exists('dummy0') || ifc_exists('br0'));
 }
 
 sub test_flags {

--- a/tests/wicked/startandstop/sut/t05_bridge_ifup_remove_one_config_ifreload.pm
+++ b/tests/wicked/startandstop/sut/t05_bridge_ifup_remove_one_config_ifreload.pm
@@ -15,6 +15,7 @@
 use base 'wickedbase';
 use strict;
 use testapi;
+use network_utils qw(iface ifc_exists);
 
 sub run {
     my ($self) = @_;
@@ -25,8 +26,9 @@ sub run {
     $self->setup_bridge($config, $dummy, 'ifup');
     assert_script_run("rm $config");
     assert_script_run("wicked ifreload --timeout infinite all");
-    my $res = script_run("ip link | grep br0") && !script_run("ip link | grep dummy0") ? "PASSED" : "FAILED";
-    die if ($res eq 'FAILED');
+    die if (ifc_exists('br0'));
+    die unless (ifc_exists('dummy0'));
+    die unless (ifc_exists(iface()));
 }
 
 sub test_flags {

--- a/tests/wicked/startandstop/sut/t06_bridge_ifdown_create_new_config_ifreload_ifdown_ifup.pm
+++ b/tests/wicked/startandstop/sut/t06_bridge_ifdown_create_new_config_ifreload_ifdown_ifup.pm
@@ -15,6 +15,7 @@
 use base 'wickedbase';
 use strict;
 use testapi;
+use network_utils 'ifc_exists';
 
 sub run {
     my ($self) = @_;
@@ -25,18 +26,13 @@ sub run {
     $self->setup_bridge($config, $dummy, 'ifup');
     assert_script_run('wicked ifdown --timeout infinite br0');
     assert_script_run('wicked ifdown --timeout infinite dummy0');
-    die if (script_run(q(ip link | grep 'dummy0\|br0')) == 0);
+    die if (ifc_exists('dummy0') || ifc_exists('br0'));
     assert_script_run('wicked ifreload --timeout infinite all');
-    my $res1 = script_run('ip link | grep br0');
-    my $res2 = script_run('ip link | grep dummy0');
-    die if ($res1 || $res2);
+    die unless (ifc_exists('br0') && ifc_exists('dummy0'));
     my $current_ip = $self->get_current_ip('br0');
     my $expected_ip = $self->get_ip(type => 'br0');
-    if (!defined($current_ip) || $current_ip ne $expected_ip) {
-        record_info('IP missmatch', 'IP is ' . ($current_ip || 'none')
-              . ' but expected was ' . $expected_ip, result => 'fail');
-        die;
-    }
+    die('IP missmatch', 'IP is ' . ($current_ip || 'none') . ' but expected was ' . $expected_ip)
+      if (!defined($current_ip) || $current_ip ne $expected_ip);
     die if ($self->get_test_result('br0') eq 'FAILED');
     assert_script_run('wicked ifdown --timeout infinite all');
     assert_script_run('wicked ifup --timeout infinite all');

--- a/tests/wicked/startandstop/sut/t06_bridge_ifdown_create_new_config_ifreload_ifdown_ifup.pm
+++ b/tests/wicked/startandstop/sut/t06_bridge_ifdown_create_new_config_ifreload_ifdown_ifup.pm
@@ -31,7 +31,7 @@ sub run {
     my $res2 = script_run('ip link | grep dummy0');
     die if ($res1 || $res2);
     my $current_ip = $self->get_current_ip('br0');
-    my $expected_ip = $self->get_ip(type => 'br0', no_mask => 1);
+    my $expected_ip = $self->get_ip(type => 'br0');
     if (!defined($current_ip) || $current_ip ne $expected_ip) {
         record_info('IP missmatch', 'IP is ' . ($current_ip || 'none')
               . ' but expected was ' . $expected_ip, result => 'fail');

--- a/tests/wicked/startandstop/sut/t08_sit_tunnel_ifdown.pm
+++ b/tests/wicked/startandstop/sut/t08_sit_tunnel_ifdown.pm
@@ -15,6 +15,7 @@
 use base 'wickedbase';
 use strict;
 use testapi;
+use network_utils 'ifc_exists';
 
 sub run {
     my ($self) = @_;
@@ -23,7 +24,7 @@ sub run {
     $self->setup_tunnel($config, 'sit1');
     if ($self->get_test_result('sit1', 'v6') ne 'FAILED') {
         assert_script_run("wicked ifdown --timeout infinite sit1");
-        die if (!script_run('ip link | grep sit1'));
+        die if (ifc_exists('sit1'));
     }
 }
 

--- a/tests/wicked/startandstop/sut/t09_openvpn_tunnel_ifdown.pm
+++ b/tests/wicked/startandstop/sut/t09_openvpn_tunnel_ifdown.pm
@@ -15,23 +15,18 @@
 use base 'wickedbase';
 use strict;
 use testapi;
+use network_utils 'ifc_exists';
 
 sub run {
     my ($self) = @_;
     my $config = '/etc/sysconfig/network/ifcfg-tun1';
     $self->get_from_data('wicked/ifcfg/tun1_sut', $config);
     $self->setup_openvpn_client('tun1');
-    $self->setup_tuntap($config, 'tun1', 0);
-    my $res = $self->get_test_result('tun1');
-    if ($res ne 'FAILED') {
-        assert_script_run('wicked ifdown --timeout infinite tun1');
-        my $res1 = script_run('ip link | grep tun1');
-        my $res2 = script_run('systemctl -q is-active openvpn@client');
-        if (!$res1 || !$res2) {
-            $res = 'FAILED';
-        }
-    }
-    die if ($res eq 'FAILED');
+    $self->setup_tuntap($config, 'tun1');
+    die if ($self->get_test_result('tun1') eq 'FAILED');
+    assert_script_run('wicked ifdown --timeout infinite tun1');
+    die if (ifc_exists('tun1'));
+    die if (script_run('systemctl -q is-active openvpn@client') == 0);
 }
 
 sub test_flags {

--- a/tests/wicked/startandstop/sut/t10_vlan_ifup_all_ifdown_one_card.pm
+++ b/tests/wicked/startandstop/sut/t10_vlan_ifup_all_ifdown_one_card.pm
@@ -1,0 +1,42 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: VLAN - ifup all, ifdown one card
+# Maintainer: Anton Smorodskyi <asmorodskyi@suse.com>
+#             Jose Lausuch <jalausuch@suse.com>
+#             Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+
+use base 'wickedbase';
+use strict;
+use testapi;
+use network_utils qw(iface ifc_exists);
+
+sub run {
+    my ($self) = @_;
+    my $iface  = iface();
+    my $config = "/etc/sysconfig/network/ifcfg-$iface.42";
+    $self->get_from_data('wicked/ifcfg/eth0.42', $config);
+    my $local_ip = $self->get_ip(type => 'vlan', netmask => 1);
+    $local_ip =~ s'/'\\/';
+    assert_script_run("sed 's/ip_address/$local_ip/' -i $config");
+    assert_script_run("sed 's/interface/$iface/' -i $config");
+    script_run("cat $config");
+    assert_script_run('wicked ifup --timeout infinite all');
+    assert_script_run('ip a');
+    die if (!ifc_exists($iface . '.42'));
+    assert_script_run("wicked ifdown --timeout infinite $iface.42");
+    die if (ifc_exists($iface . '.42'));
+    die if (!ifc_exists($iface));
+}
+
+sub test_flags {
+    return {always_rollback => 1, wicked_need_sync => 1};
+}
+
+1;


### PR DESCRIPTION
VLAN - ifup all, ifdown one card

When I create a VLAN on interface eth0 from legacy files
And I bring up all from legacy files
Then I bring down eth0.42
And there should not be the eth0.42 card anymore
But the eth0 card should still be there

- Related ticket: https://progress.opensuse.org/issues/41699
- Verification run: http://cfconrad-vm.qa.suse.de/tests/2259
