### PR TITLE
Revert "Check license accepting in extended installation"

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -209,15 +209,13 @@ sub deal_with_dependency_issues {
     }
 }
 
-sub accept_license {
+sub verify_license_has_to_be_accepted {
+    # license+lang
     if (get_var('HASLICENSE')) {
-        # explicitly check that the license has to be accepted
-        if (get_var('INSTALLER_EXTENDED_TEST')) {
-            send_key $cmd{next};
-            assert_screen 'license-not-accepted';
-            send_key $cmd{ok};
-            wait_still_screen 1;
-        }
+        send_key $cmd{next};
+        assert_screen 'license-not-accepted';
+        send_key $cmd{ok};
+        wait_still_screen 1;
         send_key $cmd{accept};    # accept license
         wait_still_screen 1;
         save_screenshot;

--- a/tests/installation/accept_license.pm
+++ b/tests/installation/accept_license.pm
@@ -39,14 +39,14 @@ sub run {
     if (match_has_tag('inst-welcome-no-product-list')) {
         return send_key $cmd{next} unless match_has_tag('license-agreement');
     }
-    $self->accept_license;
+    $self->verify_license_has_to_be_accepted;
     $self->verify_license_translations;
     send_key $cmd{next};
     # workaround for bsc#1059317, multiple times clicking accept license
     my $count = 5;
     while (check_screen('license-not-accepted', 3) && $count >= 1) {
         record_soft_failure 'bsc#1059317';
-        $self->accept_license;
+        $self->verify_license_has_to_be_accepted;
         send_key $cmd{next};
         $count--;
     }

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -112,7 +112,7 @@ sub run {
         }
     }
     else {
-        $self->accept_license;
+        $self->verify_license_has_to_be_accepted;
     }
 
     assert_screen 'languagepicked';


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#6000
Broke test on zVM https://openqa.suse.de/tests/2192383#step/accept_license/3 as there is a bug.