### PR TITLE
wicked: generic mutex approach

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -16,6 +16,7 @@ use base 'opensusebasetest';
 use utils 'systemctl';
 use network_utils;
 use testapi;
+use lockapi;
 
 sub assert_wicked_state {
     my ($self, %args) = @_;
@@ -190,4 +191,22 @@ sub get_test_result {
     }
 }
 
+sub do_mutex {
+    my ($self) = @_;
+    my $mutex_name = 'test_' . $self->{name} . '_ready';
+    if (check_var('IS_WICKED_REF', '1')) {
+        mutex_wait($mutex_name);
+    } else {
+        mutex_create($mutex_name);
+    }
+}
+
+sub done {
+    my ($self) = @_;
+    my $flags = $self->test_flags();
+    if ($flags->{wicked_need_sync}) {
+        $self->do_mutex();
+    }
+    $self->SUPER::done();
+}
 1;

--- a/tests/wicked/advanced/ref/t01_gre_tunnel_legacy.pm
+++ b/tests/wicked/advanced/ref/t01_gre_tunnel_legacy.pm
@@ -24,11 +24,10 @@ sub run {
     my ($self) = @_;
     record_info('Info', 'Create a GRE interface from legacy ifcfg files');
     $self->create_tunnel_with_commands('gre1', 'gre', '24');
-    mutex_wait('test_gre_tunnel_legacy_ready');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/ref/t02_gre_tunnel_xml.pm
+++ b/tests/wicked/advanced/ref/t02_gre_tunnel_xml.pm
@@ -24,11 +24,10 @@ sub run {
     my ($self) = @_;
     record_info('Info', 'Create a GRE interface from wicked XML files');
     $self->create_tunnel_with_commands('gre1', 'gre', '24');
-    mutex_wait('test_gre_tunnel_xml_ready');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/ref/t03_sit_tunnel_legacy.pm
+++ b/tests/wicked/advanced/ref/t03_sit_tunnel_legacy.pm
@@ -24,11 +24,10 @@ sub run {
     my ($self) = @_;
     record_info('Info', 'Create a SIT interface from legacy ifcfg files');
     $self->create_tunnel_with_commands('sit1', 'sit', '127');
-    mutex_wait('test_sit_tunnel_legacy_ready');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/ref/t04_sit_tunnel_xml.pm
+++ b/tests/wicked/advanced/ref/t04_sit_tunnel_xml.pm
@@ -24,11 +24,10 @@ sub run {
     my ($self) = @_;
     record_info('Info', 'Create a SIT interface from from Wicked XML files');
     $self->create_tunnel_with_commands('sit1', 'sit', '127');
-    mutex_wait('test_sit_tunnel_xml_ready');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/ref/t05_ipip_tunnel_legacy.pm
+++ b/tests/wicked/advanced/ref/t05_ipip_tunnel_legacy.pm
@@ -24,11 +24,10 @@ sub run {
     my ($self) = @_;
     record_info('Info', 'Create a IPIP interface from legacy ifcfg files');
     $self->create_tunnel_with_commands('tunl1', 'ipip', '24');
-    mutex_wait('test_ipip_tunnel_legacy_ready');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/ref/t06_ipip_tunnel_xml.pm
+++ b/tests/wicked/advanced/ref/t06_ipip_tunnel_xml.pm
@@ -24,11 +24,10 @@ sub run {
     my ($self) = @_;
     record_info('Info', 'Create a IPIP interface from Wicked XML files');
     $self->create_tunnel_with_commands('tunl1', 'ipip', '24');
-    mutex_wait('test_ipip_tunnel_xml_ready');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/ref/t07_tun_interface_legacy.pm
+++ b/tests/wicked/advanced/ref/t07_tun_interface_legacy.pm
@@ -29,11 +29,10 @@ sub run {
     $self->get_from_data('wicked/openvpn/server.conf', $openvpn_server);
     assert_script_run("sed 's/device/tun1/' -i $openvpn_server");
     $self->setup_tuntap($config, 'tun1', 1);
-    mutex_wait('test_tun_interface_legacy_ready');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/ref/t08_tun_interface_xml.pm
+++ b/tests/wicked/advanced/ref/t08_tun_interface_xml.pm
@@ -29,11 +29,10 @@ sub run {
     $self->get_from_data('wicked/openvpn/server.conf', $openvpn_server);
     assert_script_run("sed 's/device/tun1/' -i $openvpn_server");
     $self->setup_tuntap($config, 'tun1', 1);
-    mutex_wait('test_tun_interface_xml_ready');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/ref/t09_tap_interface_legacy.pm
+++ b/tests/wicked/advanced/ref/t09_tap_interface_legacy.pm
@@ -29,11 +29,10 @@ sub run {
     $self->get_from_data('wicked/openvpn/server.conf', $openvpn_server);
     assert_script_run("sed 's/device/tap1/' -i $openvpn_server");
     $self->setup_tuntap($config, 'tap1', 1);
-    mutex_wait('test_tap_interface_legacy_ready');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/ref/t10_tap_interface_xml.pm
+++ b/tests/wicked/advanced/ref/t10_tap_interface_xml.pm
@@ -29,11 +29,10 @@ sub run {
     $self->get_from_data('wicked/openvpn/server.conf', $openvpn_server);
     assert_script_run("sed 's/device/tap1/' -i $openvpn_server");
     $self->setup_tuntap($config, 'tap1', 1);
-    mutex_wait('test_tap_interface_xml_ready');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/ref/t11_bridge_interface_legacy.pm
+++ b/tests/wicked/advanced/ref/t11_bridge_interface_legacy.pm
@@ -25,11 +25,10 @@ sub run {
     record_info('Info', 'Create Bridge interface from legacy ifcfg files');
     # Note: No need to create a bridge interface, as the SUT will ping
     #       the IP of eth0 already configured.
-    mutex_wait('test_bridge_interface_legacy_ready');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/ref/t12_bridge_interface_xml.pm
+++ b/tests/wicked/advanced/ref/t12_bridge_interface_xml.pm
@@ -25,11 +25,10 @@ sub run {
     record_info('Info', 'Create Bridge interface from Wicked XML files');
     # Note: No need to create a bridge interface, as the SUT will ping
     #       the IP of eth0 already configured.
-    mutex_wait('test_bridge_interface_xml_ready');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/sut/t01_gre_tunnel_legacy.pm
+++ b/tests/wicked/advanced/sut/t01_gre_tunnel_legacy.pm
@@ -27,12 +27,11 @@ sub run {
     $self->get_from_data('wicked/ifcfg/gre1', $config);
     $self->setup_tunnel($config, 'gre1');
     my $res = $self->get_test_result('gre1');
-    mutex_create('test_gre_tunnel_legacy_ready');
     die if ($res eq 'FAILED');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/sut/t02_gre_tunnel_xml.pm
+++ b/tests/wicked/advanced/sut/t02_gre_tunnel_xml.pm
@@ -27,12 +27,11 @@ sub run {
     $self->get_from_data('wicked/xml/gre.xml', $config);
     $self->setup_tunnel($config, 'gre1');
     my $res = $self->get_test_result('gre1');
-    mutex_create('test_gre_tunnel_xml_ready');
     die if ($res eq 'FAILED');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/sut/t03_sit_tunnel_legacy.pm
+++ b/tests/wicked/advanced/sut/t03_sit_tunnel_legacy.pm
@@ -27,12 +27,11 @@ sub run {
     $self->get_from_data('wicked/ifcfg/sit1', $config);
     $self->setup_tunnel($config, 'sit1');
     my $res = $self->get_test_result('sit1', 'v6');
-    mutex_create('test_sit_tunnel_legacy_ready');
     die if ($res eq 'FAILED');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/sut/t04_sit_tunnel_xml.pm
+++ b/tests/wicked/advanced/sut/t04_sit_tunnel_xml.pm
@@ -27,12 +27,11 @@ sub run {
     $self->get_from_data('wicked/xml/sit.xml', $config);
     $self->setup_tunnel($config, 'sit1');
     my $res = $self->get_test_result('sit1', 'v6');
-    mutex_create('test_sit_tunnel_xml_ready');
     die if ($res eq 'FAILED');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/sut/t05_ipip_tunnel_legacy.pm
+++ b/tests/wicked/advanced/sut/t05_ipip_tunnel_legacy.pm
@@ -27,12 +27,11 @@ sub run {
     $self->get_from_data('wicked/ifcfg/tunl1', $config);
     $self->setup_tunnel($config, 'tunl1');
     my $res = $self->get_test_result('tunl1');
-    mutex_create('test_ipip_tunnel_legacy_ready');
     die if ($res eq 'FAILED');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/sut/t06_ipip_tunnel_xml.pm
+++ b/tests/wicked/advanced/sut/t06_ipip_tunnel_xml.pm
@@ -27,12 +27,11 @@ sub run {
     $self->get_from_data('wicked/xml/ipip.xml', $config);
     $self->setup_tunnel($config, 'tunl1');
     my $res = $self->get_test_result('tunl1');
-    mutex_create('test_ipip_tunnel_xml_ready');
     die if ($res eq 'FAILED');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/sut/t07_tun_interface_legacy.pm
+++ b/tests/wicked/advanced/sut/t07_tun_interface_legacy.pm
@@ -28,12 +28,11 @@ sub run {
     $self->setup_openvpn_client('tun1');
     $self->setup_tuntap($config, 'tun1', 0);
     my $res = $self->get_test_result('tun1');
-    mutex_create('test_tun_interface_legacy_ready');
     die if ($res eq 'FAILED');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/sut/t08_tun_interface_xml.pm
+++ b/tests/wicked/advanced/sut/t08_tun_interface_xml.pm
@@ -28,12 +28,11 @@ sub run {
     $self->setup_openvpn_client('tun1');
     $self->setup_tuntap($config, 'tun1');
     my $res = $self->get_test_result('tun1');
-    mutex_create('test_tun_interface_xml_ready');
     die if ($res eq 'FAILED');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/sut/t09_tap_interface_legacy.pm
+++ b/tests/wicked/advanced/sut/t09_tap_interface_legacy.pm
@@ -28,12 +28,11 @@ sub run {
     $self->setup_openvpn_client('tap1');
     $self->setup_tuntap($config, 'tap1', 0);
     my $res = $self->get_test_result('tap1');
-    mutex_create('test_tap_interface_legacy_ready');
     die if ($res eq 'FAILED');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/sut/t10_tap_interface_xml.pm
+++ b/tests/wicked/advanced/sut/t10_tap_interface_xml.pm
@@ -28,12 +28,11 @@ sub run {
     $self->setup_openvpn_client('tap1');
     $self->setup_tuntap($config, 'tap1', 0);
     my $res = $self->get_test_result('tap1');
-    mutex_create('test_tap_interface_xml_ready');
     die if ($res eq 'FAILED');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/sut/t11_bridge_interface_legacy.pm
+++ b/tests/wicked/advanced/sut/t11_bridge_interface_legacy.pm
@@ -29,12 +29,11 @@ sub run {
     $self->get_from_data('wicked/ifcfg/dummy0', $dummy);
     $self->setup_bridge($config, $dummy, 'ifup');
     my $res = $self->get_test_result('br0');
-    mutex_create('test_bridge_interface_legacy_ready');
     die if ($res eq 'FAILED');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;

--- a/tests/wicked/advanced/sut/t12_bridge_interface_xml.pm
+++ b/tests/wicked/advanced/sut/t12_bridge_interface_xml.pm
@@ -29,12 +29,11 @@ sub run {
     assert_script_run('rm /etc/sysconfig/network/ifcfg-eth0');
     $self->setup_bridge($config, '', 'ifup');
     my $res = $self->get_test_result('br0');
-    mutex_create('test_bridge_interface_xml_ready');
     die if ($res eq 'FAILED');
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {always_rollback => 1, wicked_need_sync => 1};
 }
 
 1;


### PR DESCRIPTION
Need:
In advanced wicked test-suite, each SUT testmodule has a corresponding
REF testmodule. These testmodules must be aligned at runtime.
We use mutex_xxx() to do so.

Problem:
When we just place the mutex_create() at the end of the run() method.
If a exception happen, the SUT and REF are running
out of sync, cause REF still waits for the corresponding mutex.

We could place the mutex in post_fail_hook() and post_run_hook(). But
we need to make sure that the mutex is only called once.

Implementation approach:
Override basetest::done() to have a single execution point
at the end of a test_module and do the mutex stuff.
Use wicked_need_sync flag in tests_flags() to control, if a
testmodule, which derive from wickedbase::, needs the mutex.

- Related ticket: https://progress.opensuse.org/issues/42641
- Verification run: 
  - http://cfconrad-vm.qa.suse.de/tests/2271 (SUT)
  - http://cfconrad-vm.qa.suse.de/tests/2272 (REF)
 
@foursixnine @asmorodskyi @jlausuch plz have a look