### PR TITLE
install_packages: handle conflict between python3-tdb and python-tdb

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -173,8 +173,10 @@ sub problem_can_be_skipped {
     return 1 if $pkg =~ /^skelcd-installer-net-openSUSE/;
     # conflicts with openafs-client, fuse client is experimental
     return 1 if $pkg =~ /^openafs-fuse_client/;
-    # conclifcts with namespace:otherproviders(mpich-hpc-macros-devel)
+    # conflicts with namespace:otherproviders(mpich-hpc-macros-devel)
     return 1 if $pkg =~ /^mpich-ofi.*gnu-hpc-macros-devel/;
+    # python-tdb is used by default currently
+    return 1 if $pkg =~ /^python3-tdb/;
 
     return;
 }


### PR DESCRIPTION
This change handles the conflict between `python3-tdb` and `python-tdb`

- See: https://build.opensuse.org/request/show/643257

Fixes: 

- https://openqa.opensuse.org/tests/778571#step/install_packages/9
- https://openqa.opensuse.org/tests/778572#step/install_packages/9
- https://openqa.opensuse.org/tests/778573#step/install_packages/9

```
+++ PROBLEMS: +++
package python3-tdb-1.3.15-lp150.1.8.x86_64 conflicts with python-tdb provided by python-tdb-1.3.15-lp150.1.8.x86_64
  + solution
    - do not ask to install python3-tdb-1.3.15-lp150.1.8.x86_64
PCBS 'python3-tdb-1.3.15-lp150.1.8.x86_64': 'package python3-tdb-1.3.15-lp150.1.8.x86_64 conflicts with python-tdb provided by python-tdb-1.3.15-lp150.1.8.x86_64'
  + solution
    - do not ask to install python-tdb-1.3.15-lp150.1.8.x86_64
PCBS 'python-tdb-1.3.15-lp150.1.8.x86_64': 'package python3-tdb-1.3.15-lp150.1.8.x86_64 conflicts with python-tdb provided by python-tdb-1.3.15-lp150.1.8.x86_64'

```

To test:

`data/lsmfip --verbose libtdb1 python-tdb-32bit python3-tdb-32bit tdb-tools python3-tdb-debuginfo tdb-tools-debuginfo python3-tdb libtdb1-debuginfo-32bit python-tdb libtdb-devel python3-tdb-debuginfo-32bit tdb-debugsource libtdb1-debuginfo python-tdb-debuginfo-32bit libtdb1-32bit python-tdb-debuginfo`
