### PR TITLE
Role filter is not applied in CaaSP

### DIFF
--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -260,8 +260,9 @@ sub get_delayed {
         if ($drole = get_job_info($job_id)->{settings}->{DELAYED}) {
             if ($role) {
                 return $job_id if $role eq $drole;
+            } else {
+                $count++;
             }
-            $count++;
         }
     }
     return $count;


### PR DESCRIPTION
Fix for: http://uv300x.arch.suse.de:81/tests/325#step/stack_add_remove/9

Calling `get_delayed 'worker'` returns `$count` instead of false for jobs that have `DELAYED=master` set