### PR TITLE
install_package: handle conflict between python-ldb-devel, python3-ldb-devel

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -177,6 +177,8 @@ sub problem_can_be_skipped {
     return 1 if $pkg =~ /^mpich-ofi.*gnu-hpc-macros-devel/;
     # python-tdb is used by default currently
     return 1 if $pkg =~ /^python3-tdb/;
+    # conflicts python-ldb-devel
+    return 1 if $pkg =~ /^python3-ldb-devel/;
 
     return;
 }


### PR DESCRIPTION
Handles conflict between `python-ldb-devel` and `python3-ldb-devel` updated in the same incidents:

```
+++ PROBLEMS: +++
package python3-ldb-devel-1.1.29-1.3.x86_64 conflicts with python-ldb-devel provided by python-ldb-devel-1.1.29-1.3.x86_64
  + solution
    - do not ask to install python3-ldb-devel-1.1.29-1.3.x86_64
PCBS 'python3-ldb-devel-1.1.29-1.3.x86_64': 'package python3-ldb-devel-1.1.29-1.3.x86_64 conflicts with python-ldb-devel provided by python-ldb-devel-1.1.29-1.3.x86_64'
  + solution
    - do not ask to install python-ldb-devel-1.1.29-1.3.x86_64
PCBS 'python-ldb-devel-1.1.29-1.3.x86_64': 'package python3-ldb-devel-1.1.29-1.3.x86_64 conflicts with python-ldb-devel provided by python-ldb-devel-1.1.29-1.3.x86_64'
```

Fixes:

- https://openqa.opensuse.org/tests/779038#step/install_packages/9
- https://openqa.opensuse.org/tests/779039#step/install_packages/9
- https://openqa.opensuse.org/tests/779040#step/install_packages/9

See: https://build.opensuse.org/request/show/643550

To verify: `data/lsmfip --verbose ldb-tools-debuginfo libldb1-32bit python-ldb libldb-devel ldb-tools python-ldb-32bit libldb1-debuginfo python3-ldb-32bit libldb1-debuginfo-32bit python3-ldb python-ldb-debuginfo python3-ldb-devel python-ldb-debuginfo-32bit libldb1 python-ldb-devel ldb-debugsource python3-ldb-debuginfo-32bit python3-ldb-debuginfo`
