### PR TITLE
Add back snapper_used_space test for openSUSE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1644,7 +1644,7 @@ sub load_filesystem_tests {
         # kernel module required by thin-LVM
         loadtest 'console/snapper_thin_lvm' unless is_jeos;
     }
-    loadtest 'console/snapper_used_space' if is_sle('15-SP1+');
+    loadtest 'console/snapper_used_space' if (is_sle('15-SP1+') || (is_opensuse && !is_leap('<15.1')));
 }
 
 sub load_wicked_tests {


### PR DESCRIPTION
Adding back this test as we should keep in mind to start testing features always with openSUSE TW. Besides it was already working for [TW](https://openqa.opensuse.org/tests/777954#step/snapper_used_space/36) and [Leap15.1](https://openqa.opensuse.org/tests/778247#step/snapper_used_space/36).
- Related ticket: Related tickets: https://progress.opensuse.org/issues/41309 and https://progress.opensuse.org/issues/42716
