### PR TITLE
fix change_password under X11 in SLE15SP1

### DIFF
--- a/tests/x11/gnomecase/change_password.pm
+++ b/tests/x11/gnomecase/change_password.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2017 SUSE LLC
+# Copyright © 2016-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -144,7 +144,7 @@ sub run {
 
     #delete the added user: test
     # We should kill the active user test in SLE15
-    assert_script_run 'loginctl kill-user test' if (sle_version_at_least('15'));
+    assert_script_run 'loginctl terminate-user test' if (sle_version_at_least('15'));
     wait_still_screen;
     type_string "userdel -f test\n";
     assert_screen "user-test-deleted";


### PR DESCRIPTION
https://progress.opensuse.org/issues/34867

Under X11, `loginctl kill-user` causes the system to freeze, it should be `loginctl terminate-user`.

- Related ticket: https://progress.opensuse.org/issues/34867
- Needles: none 
- Verification run: http://10.67.17.212/tests/256
