### PR TITLE
yast2-virtualization: Select xen server only where xen_server pattern is supported: x86_64

### DIFF
--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -27,7 +27,9 @@ sub run {
     }
     $self->launch_yast2_module_x11('virtualization');
     # select everything
-    send_key 'alt-x';    # XEN Server
+    if (check_var('ARCH', 'x86_64')) {
+        send_key 'alt-x';    # XEN Server, only available on x86_64: bsc#1088175
+    }
     send_key 'alt-e';    # Xen tools
     send_key 'alt-k';    # KVM Server
     send_key 'alt-v';    # KVM tools


### PR DESCRIPTION
It will fix aarch64 test: https://openqa.opensuse.org/tests/778362#step/yast_virtualization/21
