### PR TITLE
dolphin: check folder is created before trying to open it

### DIFF
--- a/tests/x11/dolphin.pm
+++ b/tests/x11/dolphin.pm
@@ -28,6 +28,8 @@ sub run {
     type_string 'stuff';
     assert_screen 'dolphin_new_folder';
     send_key 'ret';
+    # Check new folder is created
+    assert_screen 'dolphin_stuff_folder';
     # Enter the new folder
     send_key 'ret';
 


### PR DESCRIPTION
Fix test on aarch64, where 2nd 'ret' key is typed too early: https://openqa.opensuse.org/tests/778932#step/dolphin/9
Related needle: https://github.com/os-autoinst/os-autoinst-needles-opensuse/commit/62510297047ef98626dede804cdb4caf37a760c5