### PR TITLE
Adjust upgrade_snapshots to new snapper ls output

### DIFF
--- a/tests/console/upgrade_snapshots.pm
+++ b/tests/console/upgrade_snapshots.pm
@@ -23,12 +23,12 @@ sub run {
 
     script_run("snapper list | tee /dev/$serialdev", 0);
     # Check if the snapshot called 'before update' is there
-    wait_serial('pre\s*(\|[^|]*){4}\s*\|\s*number\s*\|\s*before (update|online migration)\s*\|\s*important=yes', 20)
+    wait_serial('pre\s*(\|[^|]*){4,}\s*\|\s*number\s*\|\s*before (update|online migration)\s*\|\s*important=yes', 20)
       || die 'upgrade snapshots test failed';
 
     script_run("snapper list | tee /dev/$serialdev", 0);
     # Check if the snapshot called 'after update' is there
-    wait_serial('post\s*(\|[^|]*){4}\s*\|\s*number\s*\|\s*after (update|online migration)\s*\|\s*important=yes', 20)
+    wait_serial('post\s*(\|[^|]*){4,}\s*\|\s*number\s*\|\s*after (update|online migration)\s*\|\s*important=yes', 20)
       || die 'upgrade snapshots test failed';
 }
 


### PR DESCRIPTION
Adjust test to new snapper ls output. Regex updated to be able to move 4 or 5 columns to the right.

- Related ticket: https://progress.opensuse.org/issues/42635
- Verification run (still running):
  - [Tumbleweed-kde+system_performance-upgrade_snapshots](http://dhcp42.suse.cz/tests/448#step/upgrade_snapshots/4)
  - [Leap15.1-kde+system_performance-upgrade_snapshots](http://dhcp42.suse.cz/tests/447#step/upgrade_snapshots/4)

