### PR TITLE
Check license accepting in extended installation

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -209,13 +209,16 @@ sub deal_with_dependency_issues {
     }
 }
 
-sub verify_license_has_to_be_accepted {
-    # license+lang
+sub accept_license {
+    my ($self, $verify_license_has_to_be_accepted) = @_;
     if (get_var('HASLICENSE')) {
-        send_key $cmd{next};
-        assert_screen 'license-not-accepted';
-        send_key $cmd{ok};
-        wait_still_screen 1;
+        # explicitly check that the license has to be accepted
+        if ($verify_license_has_to_be_accepted) {
+            send_key $cmd{next};
+            assert_screen 'license-not-accepted';
+            send_key $cmd{ok};
+            wait_still_screen 1;
+        }
         send_key $cmd{accept};    # accept license
         wait_still_screen 1;
         save_screenshot;

--- a/tests/installation/accept_license.pm
+++ b/tests/installation/accept_license.pm
@@ -39,14 +39,14 @@ sub run {
     if (match_has_tag('inst-welcome-no-product-list')) {
         return send_key $cmd{next} unless match_has_tag('license-agreement');
     }
-    $self->verify_license_has_to_be_accepted;
+    $self->accept_license(get_var('INSTALLER_EXTENDED_TEST'));
     $self->verify_license_translations;
     send_key $cmd{next};
     # workaround for bsc#1059317, multiple times clicking accept license
     my $count = 5;
     while (check_screen('license-not-accepted', 3) && $count >= 1) {
         record_soft_failure 'bsc#1059317';
-        $self->verify_license_has_to_be_accepted;
+        $self->accept_license(verify_license_has_to_be_accepted => 1);
         send_key $cmd{next};
         $count--;
     }

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -112,7 +112,7 @@ sub run {
         }
     }
     else {
-        $self->verify_license_has_to_be_accepted;
+        $self->accept_license(get_var('INSTALLER_EXTENDED_TEST'));
     }
 
     assert_screen 'languagepicked';


### PR DESCRIPTION
An additional check if the license is accepted or not was executed in all the installation tests.

The commit moves the check to 'installer_extended' test suite.

Note: My previous PR #6000 did not contain a solution for [bsc#1059317](https://bugzilla.suse.com/show_bug.cgi?id=1059317) workaround. So that the PR was reverted and this one is added. 

- Related ticket: [poo#42608](https://progress.opensuse.org/issues/42608)
- Verification runs:
   - Case, when workaround for bsc#1059317 called: [s390x-zVM-ctc](http://oorlov-vm.qa.suse.de/tests/440);
   - ncurses, default installation without explicit check: [create_hdd_textmode@64bit](http://oorlov-vm.qa.suse.de/tests/437);
   - default installation without explicit check: [create_hdd_gnome@64bit](http://oorlov-vm.qa.suse.de/tests/438);
   - Explicit check: [installer_extended@s390x-kvm-sle12](http://oorlov-vm.qa.suse.de/tests/439).