### PR TITLE
serial_terminal: Prevent using virtio console also on IPMI

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -101,12 +101,17 @@ sub select_virtio_console {
     my %args = shift;
     my $is_virtio = $args{force} || get_var('VIRTIO_CONSOLE');
 
-    if ($is_virtio && !get_var('S390_ZKVM')) {
-        select_console('root-virtio-terminal');
-        return 1;
+    if ($is_virtio) {
+        if (get_var('S390_ZKVM')) {
+            bmwqemu::fctwarn("Cannot use virtio console on s390 on ZKVM");
+        } elsif (check_var('BACKEND', 'ipmi')) {
+            bmwqemu::fctwarn("Cannot use virtio console on IPMI");
+        } else {
+            select_console('root-virtio-terminal');
+            return 1;
+        }
     }
 
-    bmwqemu::fctwarn("Cannot use virtio console on s390 on ZKVM") if $is_virtio;
     select_console('root-console');
     return 0;
 }


### PR DESCRIPTION
virtio console is not implemented only on svirt backend, but also on
IPMI backend.

This fixes error on test install_ltp_baremetal@64bit-ipmi
https://openqa.suse.de/tests/2194485/file/autoinst-log.txt

Odd number of elements in hash assignment at /var/lib/openqa/cache/tests/sle/products/sle/../../lib/serial_terminal.pm line 101.
Use of uninitialized value in list assignment at /var/lib/openqa/cache/tests/sle/products/sle/../../lib/serial_terminal.pm line 101.
[2018-10-20T10:15:53.0156 CEST] [debug] /var/lib/openqa/cache/tests/sle/tests/kernel/install_ltp.pm:272 called serial_terminal::select_virtio_console
[2018-10-20T10:15:53.0156 CEST] [debug] <<< testapi::select_console(testapi_console='root-virtio-terminal')
console root-virtio-terminal does not exist at /usr/lib/os-autoinst/backend/driver.pm line 92.
DIE Can't call method "select" on an undefined value at /usr/lib/os-autoinst/backend/baseclass.pm line 529.

 at /usr/lib/os-autoinst/backend/baseclass.pm line 80.
	backend::baseclass::die_handler('Can\'t call method "select" on an undefined value at /usr/lib...') called at /usr/lib/os-autoinst/backend/baseclass.pm line 529
	backend::baseclass::select_console('backend::ipmi=HASH(0x76ceaf8)', 'HASH(0x7f5d858)') called at /usr/lib/os-autoinst/backend/baseclass.pm line 75
	backend::baseclass::handle_command('backend::ipmi=HASH(0x76ceaf8)', 'HASH(0x6e70458)') called at /usr/lib/os-autoinst/backend/baseclass.pm line 487
	backend::baseclass::check_socket('backend::ipmi=HASH(0x76ceaf8)', 'IO::Handle=GLOB(0x2fd0978)', 0) called at /usr/lib/os-autoinst/backend/ipmi.pm line 131
	backend::ipmi::check_socket('backend::ipmi=HASH(0x76ceaf8)', 'IO::Handle=GLOB(0x2fd0978)', 0) called at /usr/lib/os-autoinst/backend/baseclass.pm line 246
	eval {...} called at /usr/lib/os-autoinst/backend/baseclass.pm line 156
	backend::baseclass::run_capture_loop('backend::ipmi=HASH(0x76ceaf8)') called at /usr/lib/os-autoinst/backend/baseclass.pm line 129
	backend::baseclass::run('backend::ipmi=HASH(0x76ceaf8)', 13, 16) called at /usr/lib/os-autoinst/backend/driver.pm line 92
	backend::driver::__ANON__('Mojo::IOLoop::ReadWriteProcess=HASH(0x6d6c380)') called at /usr/lib/perl5/vendor_perl/5.18.2/Mojo/IOLoop/ReadWriteProcess.pm line 325
	eval {...} called at /usr/lib/perl5/vendor_perl/5.18.2/Mojo/IOLoop/ReadWriteProcess.pm line 325
	Mojo::IOLoop::ReadWriteProcess::_fork('Mojo::IOLoop::ReadWriteProcess=HASH(0x6d6c380)', 'CODE(0x29a2848)') called at /usr/lib/perl5/vendor_perl/5.18.2/Mojo/IOLoop/ReadWriteProcess.pm line 476
	Mojo::IOLoop::ReadWriteProcess::start('Mojo::IOLoop::ReadWriteProcess=HASH(0x6d6c380)') called at /usr/lib/os-autoinst/backend/driver.pm line 94
	backend::driver::start('backend::driver=HASH(0x6bebe20)') called at /usr/lib/os-autoinst/backend/driver.pm line 50
	backend::driver::new('backend::driver', 'ipmi') called at /usr/bin/isotovideo line 184
	main::init_backend() called at /usr/bin/isotovideo line 249