### PR TITLE
Perform disks clean-up for all host upgrade test suites

### DIFF
--- a/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_upgrade.pm
@@ -42,7 +42,7 @@ sub run {
         #OpenQA needs ssh way to trigger offline upgrade
         script_run("sed -i s/sshd=1/ssh=1/g /boot/grub2/grub.cfg /boot/grub/menu.lst");
         diag("Debug info for reboot_and_wait_up_upgrade: this is offline upgrade. Need to clean up redundant disks using clean_up_red_disks.");
-        clean_up_red_disks unless (($host_installed_version eq '11') || get_var('AUTOYAST', ''));
+        clean_up_red_disks unless check_var('VIRT_PRJ2_HOST_UPGRADE', '');
     }
 
     $self->reboot_and_wait_up($timeout);


### PR DESCRIPTION
1.The incident that PR#5483 tried to resolve now occurs to host
upgrade from sles11sp4 as well and quite frequently sometimes.
That is what this PR tries to fix.
2.And at the same time, replace existing autoyast file for
prj2_host_upgrade_sles11sp4_to_developing_kvm
prj2_host_upgrade_sles11sp4_to_developing_xen
with
http://10.67.134.67/install/autoinst/sle11_autoinst_all_take_1stdisk.xml,
which takes only the entire first disk instead of both first and second.
So we can perfrom disk clean-up as designed previously in PR#5483.

- Related ticket: 
   https://openqa.suse.de/tests/2190094
   https://openqa.suse.de/tests/2191007
- Needles: n/a
- Verification run: No need

@alice-suse @XGWang0 @guoxuguang @Julie-CAO