### PR TITLE
Work bsc#1103199 and bsc#1112109 around

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -18,7 +18,27 @@ use testapi qw(check_var get_var get_required_var set_var check_var_array diag);
 use autotest;
 use utils;
 use version_utils qw(
-  is_hyperv is_hyperv_in_gui is_jeos is_gnome_next is_krypton_argon is_leap is_opensuse is_sle is_sles4sap is_sles4sap_standard sle_version_at_least is_desktop_installed is_installcheck is_rescuesystem is_staging is_tumbleweed is_virtualization_server is_caasp is_upgrade
+  is_caasp
+  is_desktop_installed
+  is_gnome_next
+  is_hyperv
+  is_hyperv_in_gui
+  is_installcheck
+  is_jeos
+  is_krypton_argon
+  is_leap
+  is_opensuse
+  is_remote_backend
+  is_rescuesystem
+  is_sle
+  is_sles4sap
+  is_sles4sap_standard
+  is_staging
+  is_svirt_except_s390x
+  is_tumbleweed
+  is_upgrade
+  is_virtualization_server
+  sle_version_at_least
 );
 use bmwqemu ();
 use strict;
@@ -418,19 +438,14 @@ sub load_svirt_vm_setup_tests {
     }
 }
 
-sub is_remote_backend {
-    # s390x uses only remote repos
-    return check_var('ARCH', 's390x') || check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm');
-}
-
 sub load_boot_tests {
-    if (get_var("ISO_MAXSIZE") && !is_remote_backend) {
+    if (get_var("ISO_MAXSIZE") && (!is_remote_backend() || is_svirt_except_s390x())) {
         loadtest "installation/isosize";
     }
     if ((get_var("UEFI") || is_jeos()) && !check_var("BACKEND", "svirt")) {
         loadtest "installation/bootloader_uefi";
     }
-    elsif (check_var("BACKEND", "svirt") && !check_var("ARCH", "s390x")) {
+    elsif (is_svirt_except_s390x()) {
         load_svirt_vm_setup_tests;
     }
     elsif (uses_qa_net_hardware() || get_var("PXEBOOT")) {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -17,29 +17,7 @@ use Exporter;
 use testapi qw(check_var get_var get_required_var set_var check_var_array diag);
 use autotest;
 use utils;
-use version_utils qw(
-  is_caasp
-  is_desktop_installed
-  is_gnome_next
-  is_hyperv
-  is_hyperv_in_gui
-  is_installcheck
-  is_jeos
-  is_krypton_argon
-  is_leap
-  is_opensuse
-  is_remote_backend
-  is_rescuesystem
-  is_sle
-  is_sles4sap
-  is_sles4sap_standard
-  is_staging
-  is_svirt_except_s390x
-  is_tumbleweed
-  is_upgrade
-  is_virtualization_server
-  sle_version_at_least
-);
+use version_utils qw(:VERSION :BACKEND :SCENARIO);
 use bmwqemu ();
 use strict;
 use warnings;

--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -15,6 +15,7 @@ use autotest;
 use base 'Exporter';
 use Exporter;
 use bmwqemu ();
+use version_utils qw(is_sle is_leap);
 
 BEGIN {
     our @EXPORT = qw(
@@ -53,7 +54,9 @@ wait_serial(get_login_message(), 300);
 =cut
 sub get_login_message {
     my $arch = get_required_var("ARCH");
-    return check_var('VERSION', 'Tumbleweed') ? qr/Welcome to openSUSE Tumbleweed 20.*/ : qr/Welcome to SUSE Linux Enterprise .*\($arch\)/;
+    return is_sle() ? qr/Welcome to SUSE Linux Enterprise .*\($arch\)/
+      : is_leap()   ? qr/Welcome to openSUSE Leap.*/
+      :               qr/Welcome to openSUSE Tumbleweed 20.*/;
 }
 
 =head2 login

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -4,7 +4,7 @@ use serial_terminal ();
 use strict;
 use utils
   qw(type_string_slow ensure_unlocked_desktop save_svirt_pty get_root_console_tty get_x11_console_tty ensure_serialdev_permissions pkcon_quit zypper_call);
-use version_utils qw(is_hyperv_in_gui is_sle is_leap);
+use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x);
 use ipmi_backend_utils 'use_ssh_serial_console';
 
 # Base class implementation of distribution class necessary for testapi
@@ -355,7 +355,7 @@ sub init_consoles {
     }
 
     # svirt backend, except s390x ARCH
-    if (!get_var('S390_ZKVM') and check_var('BACKEND', 'svirt')) {
+    if (is_svirt_except_s390x) {
         my $hostname = get_var('VIRSH_GUEST');
         my $port = get_var('VIRSH_INSTANCE', 1) + 5900;
 
@@ -371,7 +371,7 @@ sub init_consoles {
     }
 
     if (get_var('BACKEND', '') =~ /qemu|ikvm|generalhw/
-        || (check_var('BACKEND', 'svirt') && !get_var('S390_ZKVM')))
+        || is_svirt_except_s390x)
     {
         $self->add_console('install-shell',  'tty-console', {tty => 2});
         $self->add_console('installation',   'tty-console', {tty => check_var('VIDEOMODE', 'text') ? 1 : 7});

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -21,33 +21,55 @@ use strict;
 use testapi qw(check_var get_var set_var);
 use version 'is_lax';
 
-our @EXPORT = qw (
-  is_caasp
-  is_hyperv
-  is_hyperv_in_gui
-  is_gnome_next
-  is_jeos
-  is_krypton_argon
-  is_leap
-  is_opensuse
-  is_sle
-  is_staging
-  is_sles4sap
-  is_sles4sap_standard
-  is_tumbleweed
-  is_storage_ng
-  is_upgrade
-  is_sle12_hdd_in_upgrade
-  is_installcheck
-  is_rescuesystem
-  sle_version_at_least
-  is_desktop_installed
-  is_system_upgrading
-  is_pre_15
-  is_virtualization_server
-  is_aarch64_uefi_boot_hdd
-  is_remote_backend
-  is_svirt_except_s390x
+use constant {
+    VERSION => [
+        qw(
+          is_sle
+          is_pre_15
+          is_caasp
+          is_gnome_next
+          is_jeos
+          is_krypton_argon
+          is_leap
+          is_opensuse
+          is_tumbleweed
+          is_rescuesystem
+          is_sles4sap
+          is_sles4sap_standard
+          is_staging
+          is_storage_ng
+          sle_version_at_least
+          )
+    ],
+    BACKEND => [
+        qw(
+          is_hyperv
+          is_hyperv_in_gui
+          is_aarch64_uefi_boot_hdd
+          is_remote_backend
+          is_svirt_except_s390x
+          is_remote_backend
+          is_svirt_except_s390x
+          )
+    ],
+    SCENARIO => [
+        qw(
+          is_upgrade
+          is_sle12_hdd_in_upgrade
+          is_installcheck
+          is_desktop_installed
+          is_system_upgrading
+          is_virtualization_server
+          )
+      ]
+};
+
+our @EXPORT = (@{(+VERSION)}, @{(+SCENARIO)}, @{+BACKEND});
+
+our %EXPORT_TAGS = (
+    VERSION  => (VERSION),
+    BACKEND  => (BACKEND),
+    SCENARIO => (SCENARIO)
 );
 
 sub is_leap;

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -46,6 +46,8 @@ our @EXPORT = qw (
   is_pre_15
   is_virtualization_server
   is_aarch64_uefi_boot_hdd
+  is_remote_backend
+  is_svirt_except_s390x
 );
 
 sub is_leap;
@@ -273,4 +275,13 @@ sub is_pre_15 {
 
 sub is_aarch64_uefi_boot_hdd {
     return get_var('MACHINE') =~ /aarch64/ && get_var('UEFI') && get_var('BOOT_HDD_IMAGE');
+}
+
+sub is_svirt_except_s390x {
+    return !get_var('S390_ZKVM') && check_var('BACKEND', 'svirt');
+}
+
+sub is_remote_backend {
+    # s390x uses only remote repos
+    return check_var('ARCH', 's390x') || check_var('BACKEND', 'svirt') || check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm');
 }

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -73,6 +73,12 @@ my $distri = testapi::get_required_var('CASEDIR') . '/lib/susedistribution.pm';
 require $distri;
 testapi::set_distribution(susedistribution->new());
 
+# Set serial failures
+my $serial_failures = [];
+push @$serial_failures, {type => 'soft', message => 'bsc#1112109', pattern => qr/serial-getty.*service: Service RestartSec=.*ms expired, scheduling restart/};
+
+$testapi::distri->set_expected_serial_failures($serial_failures);
+
 unless (get_var("DESKTOP")) {
     if (check_var("VIDEOMODE", "text")) {
         set_var("DESKTOP", "textmode");

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -671,6 +671,7 @@ my $serial_failures = [];
 if (is_sle('=12-SP4') && check_var('ARCH', 'aarch64')) {
     push @$serial_failures, {type => 'hard', message => 'bsc#1093797', pattern => quotemeta 'Internal error: Oops: 96000006'};
 }
+push @$serial_failures, {type => 'soft', message => 'bsc#1112109', pattern => qr/serial-getty.*service: Service hold-off time over, scheduling restart/};
 if (is_kernel_test()) {
     my $type = is_ltp_test() ? 'soft' : 'hard';
     push @$serial_failures, {type => $type, message => 'Kernel Ooops found',             pattern => quotemeta 'Oops:'};

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -25,6 +25,10 @@ sub run {
     save_screenshot;
     check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
 
+    # Stop serial-getty on serial console to avoid serial output pollution with login prompt
+    # Doing early due to bsc#1103199 and bsc#1112109
+    systemctl "stop serial-getty\@$testapi::serialdev";
+    systemctl "disable serial-getty\@$testapi::serialdev";
     # init
     check_console_font;
 
@@ -57,8 +61,6 @@ sub run {
         assert_script_run 'less /var/log/YaST2/y2log*|grep "Automatic DHCP configuration not started - an interface is already configured"';
     }
 
-    # Stop serial-getty on serial console to avoid serial output pollution with login prompt
-    systemctl "stop serial-getty\@$testapi::serialdev";
     # Mask if is qemu backend as use serial in remote installations e.g. during reboot
     systemctl "mask serial-getty\@$testapi::serialdev" if check_var('BACKEND', 'qemu');
 


### PR DESCRIPTION
We have a bug, which interferes with usage of serial console. On qemu
backend it's enough to wait for welcome message on tty, which means that
service is running. On Xen HVM service gets restarted constantly, so the
only possible workaround is to stop it ASAP.

See [poo#42359](https://progress.opensuse.org/issues/42359).

#### Verification runs
[default ppc64le](http://g226.suse.de/tests/2825)
[default 64bit](http://g226.suse.de/tests/2846)
[opensuse gnome](http://g226.suse.de/tests/2849)