### PR TITLE
Add SCC proxy regurl to spvm boot cmdline

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -36,6 +36,7 @@ our @EXPORT = qw(
   type_hyperv_fb_video_resolution
   bootmenu_network_source
   specific_bootmenu_params
+  remote_install_bootmenu_params
   specific_caasp_params
   select_bootmenu_video_mode
   select_bootmenu_language
@@ -609,6 +610,23 @@ sub specific_bootmenu_params {
 
     type_string_very_slow $args;
     save_screenshot;
+}
+
+sub remote_install_bootmenu_params {
+    my $params = "";
+    if (check_var("BACKEND", "spvm")) {
+        $params .= " sshd=1 ";    # only start ssh daemon
+    }
+    elsif (check_var("VIDEOMODE", "text") || check_var("VIDEOMODE", "ssh-x")) {
+        $params .= " ssh=1 ";     # trigger ssh-text installation
+    }
+    else {
+        $params .= " sshd=1 VNC=1 VNCSize=1024x768 VNCPassword=$testapi::password ";
+    }
+
+    $params .= "sshpassword=$testapi::password ";
+
+    return $params;
 }
 
 sub select_bootmenu_video_mode {

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -19,7 +19,7 @@ use Time::HiRes 'sleep';
 
 use testapi;
 use utils;
-use version_utils qw(is_caasp is_jeos is_leap is_sle);
+use version_utils qw(is_caasp is_jeos is_leap is_sle is_remote_backend);
 use caasp 'pause_until';
 use mm_network;
 
@@ -307,8 +307,8 @@ sub bootmenu_type_console_params {
     type_string_very_slow "console=${serialdev}${baud_rate} ";
 
     # See bsc#1011815, last console set as boot parameter is linked to /dev/console
-    # and doesn't work if set to serial device. Don't want this on ipmi backend.
-    type_string_very_slow "console=tty " unless check_var('BACKEND', 'ipmi');
+    # and doesn't work if set to serial device. Don't want this on remote backends.
+    type_string_very_slow "console=tty " unless (is_remote_backend);
 }
 
 sub uefi_bootmenu_params {

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -72,14 +72,7 @@ sub prepare_parmfile {
     $params .= " " . get_var('S390_NETWORK_PARAMS');
     $params .= " " . get_var('EXTRABOOTPARAMS');
 
-    if (check_var("VIDEOMODE", "text") || check_var("VIDEOMODE", "ssh-x")) {
-        $params .= " ssh=1 ";    # trigger ssh-text installation
-    }
-    else {
-        $params .= " sshd=1 VNC=1 VNCSize=1024x768 VNCPassword=$testapi::password ";
-    }
-
-    $params .= "sshpassword=$testapi::password ";
+    $params .= remote_install_bootmenu_params;
 
     # we have to hardcode the hostname here - the true hostname would
     # create a too long parameter ;(

--- a/tests/installation/bootloader_spvm.pm
+++ b/tests/installation/bootloader_spvm.pm
@@ -88,15 +88,25 @@ sub run {
 
     # clear the prompt (and create an error) in case the above went wrong
     type_string "\n";
+    wait_still_screen;
 
     my $repo     = get_required_var('REPO_0');
     my $mirror   = get_netboot_mirror;
     my $mntpoint = "mnt/openqa/repo/$repo/boot/ppc64le";
-    type_string "linux $mntpoint/linux vga=normal console=hvc0 install=$mirror ";
-    type_string "sshd=1 sshpassword=$testapi::password\n";
+    assert_screen "pvm-grub-command-line-fresh-prompt";
+    type_string_slow "linux $mntpoint/linux vga=normal install=$mirror ";
+    bootmenu_default_params;
+    bootmenu_network_source;
+    specific_bootmenu_params;
+    registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
+    type_string_slow " sshd=1 sshpassword=$testapi::password\n";
 
-    type_string "initrd $mntpoint/initrd\n";
+    assert_screen "pvm-grub-command-line-fresh-prompt", 180;    # kernel is downloaded while waiting
+    type_string_slow "initrd $mntpoint/initrd\n";
+    wait_still_screen;
     save_screenshot;
+
+    assert_screen "pvm-grub-command-line-fresh-prompt", 180;    # initrd is downloaded while waiting
     type_string "boot\n";
     save_screenshot;
 

--- a/tests/installation/bootloader_spvm.pm
+++ b/tests/installation/bootloader_spvm.pm
@@ -99,7 +99,8 @@ sub run {
     bootmenu_network_source;
     specific_bootmenu_params;
     registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
-    type_string_slow " sshd=1 sshpassword=$testapi::password\n";
+    type_string_slow remote_install_bootmenu_params;
+    type_string_slow "\n";
 
     assert_screen "pvm-grub-command-line-fresh-prompt", 180;    # kernel is downloaded while waiting
     type_string_slow "initrd $mntpoint/initrd\n";

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -29,17 +29,7 @@ sub set_svirt_domain_elements {
         my $cmdline = get_var('VIRSH_CMDLINE') . " install=$repo ";
         my $name    = $svirt->name;
 
-        if (check_var("VIDEOMODE", "text")) {
-            $cmdline .= "ssh=1 ";    # trigger ssh-text installation
-        }
-        else {
-            $cmdline .= "sshd=1 vnc=1 VNCPassword=$testapi::password ";    # trigger default VNC installation
-        }
-
-        # we need ssh access to gather logs
-        # 'ssh=1' and 'sshd=1' are equal, both together don't work
-        # so let's just set the password here
-        $cmdline .= "sshpassword=$testapi::password ";
+        $cmdline .= remote_install_bootmenu_params;
 
         if (get_var('UPGRADE')) {
             $cmdline .= "upgrade=1 ";


### PR DESCRIPTION
Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/969/diffs
Verification: http://artemis.suse.de/tests/729#step/bootloader_spvm/22 http://artemis.suse.de/tests/729#step/system_role/1
Ticket: https://progress.opensuse.org/issues/42728

<s>When this is merged, the SLE12SP4 ppc64le mediums on OSD must be configured to not add the `OFW=1` variable. The actual OFW-tests should still get that var via their machine entries.</s> (done)