### PR TITLE
wicked: use common wicked command

### DIFF
--- a/tests/wicked/startandstop/sut/t01_standalone_card_ifdown_ifreload.pm
+++ b/tests/wicked/startandstop/sut/t01_standalone_card_ifdown_ifreload.pm
@@ -25,8 +25,8 @@ sub run {
     $self->before_scenario('Test 01', 'Standalone card - ifdown, ifreload', $iface);
     record_info('Info', 'Standalone card - ifdown, ifreload');
     $self->get_from_data('wicked/dynamic_address/ifcfg-eth0', $config);
-    assert_script_run('wicked ifdown --timeout infinite ' . $iface);
-    assert_script_run('wicked ifreload ' . $iface);
+    $self->wicked_command('ifdown',   $iface);
+    $self->wicked_command('ifreload', $iface);
     my $static_ip = $self->get_ip(type => 'host');
     my $dhcp_ip = $self->get_current_ip($iface);
     if (defined($dhcp_ip) && $static_ip ne $dhcp_ip) {

--- a/tests/wicked/startandstop/sut/t04_bridge_ifup_remove_all_config_ifreload.pm
+++ b/tests/wicked/startandstop/sut/t04_bridge_ifup_remove_all_config_ifreload.pm
@@ -26,7 +26,7 @@ sub run {
     $self->get_from_data('wicked/ifcfg/dummy0', $dummy);
     $self->setup_bridge($config, $dummy, 'ifup');
     assert_script_run("rm /etc/sysconfig/network/ifcfg-$iface $config $dummy");
-    assert_script_run("wicked ifreload --timeout infinite all");
+    $self->wicked_command('ifreload', 'all');
     die if (ifc_exists('dummy0') || ifc_exists('br0'));
 }
 

--- a/tests/wicked/startandstop/sut/t05_bridge_ifup_remove_one_config_ifreload.pm
+++ b/tests/wicked/startandstop/sut/t05_bridge_ifup_remove_one_config_ifreload.pm
@@ -25,7 +25,7 @@ sub run {
     $self->get_from_data('wicked/ifcfg/dummy0', $dummy);
     $self->setup_bridge($config, $dummy, 'ifup');
     assert_script_run("rm $config");
-    assert_script_run("wicked ifreload --timeout infinite all");
+    $self->wicked_command('ifreload', 'all');
     die if (ifc_exists('br0'));
     die unless (ifc_exists('dummy0'));
     die unless (ifc_exists(iface()));

--- a/tests/wicked/startandstop/sut/t06_bridge_ifdown_create_new_config_ifreload_ifdown_ifup.pm
+++ b/tests/wicked/startandstop/sut/t06_bridge_ifdown_create_new_config_ifreload_ifdown_ifup.pm
@@ -24,18 +24,18 @@ sub run {
     $self->get_from_data('wicked/ifcfg/br0',    $config);
     $self->get_from_data('wicked/ifcfg/dummy0', $dummy);
     $self->setup_bridge($config, $dummy, 'ifup');
-    assert_script_run('wicked ifdown --timeout infinite br0');
-    assert_script_run('wicked ifdown --timeout infinite dummy0');
+    $self->wicked_command('ifdown', 'br0');
+    $self->wicked_command('ifdown', 'dummy0');
     die if (ifc_exists('dummy0') || ifc_exists('br0'));
-    assert_script_run('wicked ifreload --timeout infinite all');
+    $self->wicked_command('ifreload', 'all');
     die unless (ifc_exists('br0') && ifc_exists('dummy0'));
     my $current_ip = $self->get_current_ip('br0');
     my $expected_ip = $self->get_ip(type => 'br0');
     die('IP missmatch', 'IP is ' . ($current_ip || 'none') . ' but expected was ' . $expected_ip)
       if (!defined($current_ip) || $current_ip ne $expected_ip);
     die if ($self->get_test_result('br0') eq 'FAILED');
-    assert_script_run('wicked ifdown --timeout infinite all');
-    assert_script_run('wicked ifup --timeout infinite all');
+    $self->wicked_command('ifdown', 'all');
+    $self->wicked_command('ifup',   'all');
     die if ($self->get_test_result('br0') eq 'FAILED');
 }
 

--- a/tests/wicked/startandstop/sut/t07_bridge_ifdown_remove_one_config_ifreload_ifdown_ifup.pm
+++ b/tests/wicked/startandstop/sut/t07_bridge_ifdown_remove_one_config_ifreload_ifdown_ifup.pm
@@ -26,16 +26,16 @@ sub run {
     $self->get_from_data('wicked/ifcfg/br0',    $config);
     $self->get_from_data('wicked/ifcfg/dummy0', $dummy);
     $self->setup_bridge($config, $dummy, 'ifup');
-    assert_script_run("wicked ifdown --timeout infinite br0");
-    assert_script_run("wicked ifdown --timeout infinite dummy0");
+    $self->wicked_command('ifdown', 'br0');
+    $self->wicked_command('ifdown', 'dummy0');
     die if (ifc_exists('dummy0'));
     die if (ifc_exists('br0'));
     assert_script_run("rm $config");
-    assert_script_run("wicked ifreload --timeout infinite all");
+    $self->wicked_command('ifreload', 'all');
     die if (ifc_exists('br0'));
     die unless (ifc_exists('dummy0') && ifc_exists('eth0'));
-    assert_script_run("wicked ifdown --timeout infinite all");
-    assert_script_run("wicked ifup --timeout infinite all");
+    $self->wicked_command('ifdown', 'all');
+    $self->wicked_command('ifup',   'all');
     die if ($self->get_test_result('host') eq 'FAILED');
 }
 

--- a/tests/wicked/startandstop/sut/t08_sit_tunnel_ifdown.pm
+++ b/tests/wicked/startandstop/sut/t08_sit_tunnel_ifdown.pm
@@ -23,7 +23,7 @@ sub run {
     $self->get_from_data('wicked/ifcfg/sit1', $config);
     $self->setup_tunnel($config, 'sit1');
     if ($self->get_test_result('sit1', 'v6') ne 'FAILED') {
-        assert_script_run("wicked ifdown --timeout infinite sit1");
+        $self->wicked_command('ifdown', 'sit1');
         die if (ifc_exists('sit1'));
     }
 }

--- a/tests/wicked/startandstop/sut/t09_openvpn_tunnel_ifdown.pm
+++ b/tests/wicked/startandstop/sut/t09_openvpn_tunnel_ifdown.pm
@@ -24,7 +24,7 @@ sub run {
     $self->setup_openvpn_client('tun1');
     $self->setup_tuntap($config, 'tun1');
     die if ($self->get_test_result('tun1') eq 'FAILED');
-    assert_script_run('wicked ifdown --timeout infinite tun1');
+    $self->wicked_command('ifdown', 'tun1');
     die if (ifc_exists('tun1'));
     die if (script_run('systemctl -q is-active openvpn@client') == 0);
 }


### PR DESCRIPTION
The idea is to be compliant with the legacy suite by wicked using a common script to call wicked:
https://github.com/openSUSE/wicked-testsuite/blob/master/images-config/files-sut/wic.sh

- Related ticket: https://progress.opensuse.org/issues/42641
- Verification run: http://fromm.arch.suse.de/tests/2340
