### PR TITLE
Split consoletest_setup to smaller parts

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1048,6 +1048,9 @@ sub load_consoletests {
     }
     loadtest 'qa_automation/patch_and_reboot' if is_updates_tests && !get_var('QAM_MINIMAL');
     loadtest "console/system_prepare";
+    loadtest "console/check_network";
+    loadtest "console/system_state";
+    loadtest "console/prepare_test_data";
     loadtest "console/consoletest_setup";
     loadtest 'console/integration_services' if is_hyperv;
     loadtest "locale/keymap_or_locale";
@@ -1321,6 +1324,9 @@ sub load_x11tests {
 sub load_yast2_ncurses_tests {
     boot_hdd_image;
     # setup $serialdev permission and so on
+    loadtest "console/check_network";
+    loadtest "console/system_state";
+    loadtest "console/prepare_test_data";
     loadtest "console/consoletest_setup";
     loadtest 'console/integration_services' if is_hyperv;
     loadtest "console/hostname";
@@ -1550,6 +1556,7 @@ sub load_extra_tests {
     return if get_var("INSTALLONLY") || get_var("DUALBOOT") || get_var("RESCUECD");
 
     # setup $serialdev permission and so on
+    loadtest "console/prepare_test_data";
     loadtest "console/consoletest_setup";
     loadtest 'console/integration_services' if is_hyperv;
     loadtest "console/hostname";
@@ -2131,6 +2138,9 @@ sub load_syscontainer_tests() {
 
     # setup $serialdev permission and so on
     loadtest "console/system_prepare";
+    loadtest "console/check_network";
+    loadtest "console/system_state";
+    loadtest "console/prepare_test_data";
     loadtest "console/consoletest_setup";
 
     # Install needed pieces

--- a/tests/console/check_network.pm
+++ b/tests/console/check_network.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Check network and ip address
+# Maintainer: Zaoliang Luo <zluo@suse.de>
+
+use base "consoletest";
+use testapi;
+use ipmi_backend_utils 'use_ssh_serial_console';
+use strict;
+
+sub run {
+    # let's see how it looks at the beginning
+    save_screenshot;
+    check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
+
+    # https://fate.suse.com/320347 https://bugzilla.suse.com/show_bug.cgi?id=988157
+    if (check_var('NETWORK_INIT_PARAM', 'ifcfg=eth0=dhcp')) {
+        # grep all also compressed files e.g. y2log-1.gz
+        assert_script_run 'less /var/log/YaST2/y2log*|grep "Automatic DHCP configuration not started - an interface is already configured"';
+    }
+    # check the network configuration
+    script_run "ip addr show";
+}
+
+1;

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -42,44 +42,15 @@ sub run {
 
     script_run 'echo "set -o pipefail" >> /etc/bash.bashrc.local';
     script_run '. /etc/bash.bashrc.local';
-    # Export the existing status of running tasks and system load for future reference (fail would export it again)
-    script_run "ps axf > /tmp/psaxf.log";
-    script_run "cat /proc/loadavg > /tmp/loadavg_consoletest_setup.txt";
-
-    # Just after the setup: let's see the network configuration
-    script_run "ip addr show";
-    save_screenshot;
 
     # Stop packagekit
     systemctl 'mask packagekit.service';
     systemctl 'stop packagekit.service';
 
-    # Installing a minimal system gives a pattern conflicting with anything not minimal
-    # Let's uninstall 'the pattern' (no packages affected) in order to be able to install stuff
-    script_run 'rpm -qi patterns-openSUSE-minimal_base-conflicts && zypper -n rm patterns-openSUSE-minimal_base-conflicts';
-    # Install curl and tar in order to get the test data
-    zypper_call 'install curl tar';
-    # upload_logs requires curl, but we wanted the initial state of the system
-    upload_logs "/tmp/psaxf.log";
-    upload_logs "/tmp/loadavg_consoletest_setup.txt";
-
-    # https://fate.suse.com/320347 https://bugzilla.suse.com/show_bug.cgi?id=988157
-    if (check_var('NETWORK_INIT_PARAM', 'ifcfg=eth0=dhcp')) {
-        # grep all also compressed files e.g. y2log-1.gz
-        assert_script_run 'less /var/log/YaST2/y2log*|grep "Automatic DHCP configuration not started - an interface is already configured"';
-    }
-
-    save_screenshot;
     $self->clear_and_verify_console;
-
     select_console 'user-console';
     # Shell enviromental variable MAILCHECK has to be updated for both users
     disable_bash_mail_notification;
-    assert_script_run "curl -L -v -f " . autoinst_url('/data') . " > test.data";
-    assert_script_run " cpio -id < test.data";
-    script_run "ls -al data";
-
-    save_screenshot;
 }
 
 sub post_fail_hook {

--- a/tests/console/prepare_test_data.pm
+++ b/tests/console/prepare_test_data.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: prepare test data
+# Maintainer: Zaoliang Luo <zluo@suse.de>
+
+use base "consoletest";
+use testapi;
+use utils;
+use ipmi_backend_utils 'use_ssh_serial_console';
+use strict;
+
+sub run {
+    check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
+
+    select_console 'user-console';
+    assert_script_run "curl -L -v -f " . autoinst_url('/data') . " > test.data";
+    assert_script_run " cpio -id < test.data";
+    script_run "ls -al data";
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;

--- a/tests/console/system_state.pm
+++ b/tests/console/system_state.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary:  Export the existing status of running tasks and system load
+# for future reference
+# Maintainer: Zaoliang Luo <zluo@suse.de>
+
+use base "consoletest";
+use testapi;
+use utils;
+use ipmi_backend_utils 'use_ssh_serial_console';
+use strict;
+
+sub run {
+    check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
+    script_run "ps axf > /tmp/psaxf.log";
+    script_run "cat /proc/loadavg > /tmp/loadavg_consoletest_setup.txt";
+}
+
+1;


### PR DESCRIPTION
split some parts from consoletest_setup to server single purpose per module save time
in job execution not needing to execute unnecessary test module
create "network", "test_data", "curl_upload_logs" and "uninstall_pattern"

verification runs:
autoyast_clone_tests
http://e13.suse.de/tests/9747 shows successful test run without new test modules:
check_network, uninstall_pattern, curl_upload_logs and check_test_data

more verification runs and changes will be added later!
