### PR TITLE
Add workaround to inform btrfs to commit transaction

### DIFF
--- a/tests/console/btrfs_qgroups.pm
+++ b/tests/console/btrfs_qgroups.pm
@@ -77,14 +77,20 @@ sub run {
     my $write_chunk = 'dd if=/dev/zero bs=1M count=40 of=e/file';
     assert_script_run "for c in {1..2}; do $write_chunk; done", fail_message => 'bsc#1019614 overwriting same file should not exceed quota';
     # write some more times to the same file to be sure
-    if (script_run "for c in {1..38}; do $write_chunk; done") {
+    if (script_run("for c in {1..38}; do $write_chunk; done")) {
         record_soft_failure 'bsc#1019614';
     }
     assert_script_run 'sync';
     assert_script_run 'rm e/file', fail_message => 'bsc#993841';
     # test exceeding real quota
-    assert_script_run '! for c in {1..2}; do dd if=/dev/zero bs=1M count=40 of=e/file_$c; done';
-    assert_script_run 'rm e/file_*';
+    my $files_creation = '! for c in {1..2}; do dd if=/dev/zero bs=1M count=40 of=e/file_$c; done';
+    assert_script_run $files_creation;
+    if (script_run('rm e/file_*')) {
+        record_soft_failure 'bsc#1113042  -- btrfs is not informed to commit transaction';
+        assert_script_run 'sync';
+        assert_script_run $files_creation;
+        assert_script_run 'rm e/file_*';
+    }
 
     assert_script_run "cd; umount $dest";
     assert_script_run "btrfsck $disk";


### PR DESCRIPTION
Add workaround for https://bugzilla.suse.com/show_bug.cgi?id=1113042
- Related ticket: https://progress.opensuse.org/issues/42842
- Verification run: [sle-12-SP4-extra_tests_filesystem_btrfs_qgroups](http://dhcp42.suse.cz/tests/458#step/btrfs_qgroups/75)
