### PR TITLE
wicked: collect logs before and after each module

### DIFF
--- a/tests/wicked/basic.pm
+++ b/tests/wicked/basic.pm
@@ -61,7 +61,6 @@ sub run {
     assert_script_run("ping -q -c1 -W1 -I $iface 10.0.2.2");
     validate_script_output("ip address show dev $iface", sub { m/inet/g; });
     validate_script_output("wicked show dev $iface",     sub { m/\[dhcp\]/g; });
-    $self->save_and_upload_wicked_log();
 }
 
 1;

--- a/tests/wicked/config_files.pm
+++ b/tests/wicked/config_files.pm
@@ -60,7 +60,6 @@ sub run {
     $self->before_scenario('Test 6', 'Set up static routes from wicked XML files', $iface);
     assert_script_run("wicked ifup --ifconfig /data/static_address/static-addresses-and-routes.xml $iface");
     $self->assert_wicked_state(ping_ip => '10.0.2.2', iface => $iface);
-    $self->save_and_upload_wicked_log();
 }
 
 1;

--- a/tests/wicked/startandstop/sut/t10_vlan_ifup_all_ifdown_one_card.pm
+++ b/tests/wicked/startandstop/sut/t10_vlan_ifup_all_ifdown_one_card.pm
@@ -27,10 +27,10 @@ sub run {
     assert_script_run("sed 's/ip_address/$local_ip/' -i $config");
     assert_script_run("sed 's/interface/$iface/' -i $config");
     script_run("cat $config");
-    assert_script_run('wicked ifup --timeout infinite all');
+    $self->wicked_command('ifup', 'all');
     assert_script_run('ip a');
     die if (!ifc_exists($iface . '.42'));
-    assert_script_run("wicked ifdown --timeout infinite $iface.42");
+    $self->wicked_command('ifdown', "$iface.42");
     die if (ifc_exists($iface . '.42'));
     die if (!ifc_exists($iface));
 }


### PR DESCRIPTION
Collect logs before and after each module is executed.
Thanks to "revert to snapshot feature", we will not drag logs from test X in test X+1 
 
- Related ticket: https://progress.opensuse.org/issues/42641
- Verification runs: 
  basic: http://fromm.arch.suse.de/tests/2489#downloads
  advanced: http://fromm.arch.suse.de/tests/2486#downloads
  startstop: http://fromm.arch.suse.de/tests/2483#downloads

