### PR TITLE
Remove mouse_hide in gdm

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -230,7 +230,8 @@ sub run {
         elsif (match_has_tag('autoyast-postpartscript')) {
             @needles = grep { $_ ne 'autoyast-postpartscript' } @needles;
             $postpartscript = 1;
-        } elsif (match_has_tag('autoyast-error')) {
+        }
+        elsif (match_has_tag('autoyast-error')) {
             die 'Error detected during first stage of the installation';
         }
     }
@@ -259,7 +260,6 @@ sub run {
     # CaaSP does not have second stage
     return if is_caasp;
     # Second stage starts here
-    mouse_hide(1);
     $maxtime = 1000;
     $timer   = 0;
     $stage   = 'stage2';
@@ -280,7 +280,8 @@ sub run {
         }
         elsif (match_has_tag('warning-pop-up')) {
             handle_warnings;    # Process warnings during stage 2
-        } elsif (match_has_tag('autoyast-error')) {
+        }
+        elsif (match_has_tag('autoyast-error')) {
             die 'Error detected during second stage of the installation';
         }
     }


### PR DESCRIPTION
[Mouse cursor was hidden](https://openqa.suse.de/tests/2140958#step/installation/64) when the SUT booted to gdm first time after installation so the user was not pre-selected as it is in [first_boot module](https://openqa.suse.de/tests/2167040#step/first_boot/1).

- Related ticket: [[functional][y][autoyast][sporadic] test fails in installation, user is not preselected if target system is gnome](https://progress.opensuse.org/issues/42281)
- Verification run: [sle-15-SP1-Installer-DVD-x86_64-Build75.6-autoyast_btrfs@64bit](http://dhcp128.suse.cz/tests/7374#step/installation/26)
