### PR TITLE
Fix scrolling in yast2 scc

### DIFF
--- a/tests/installation/addon_products_via_SCC_yast2.pm
+++ b/tests/installation/addon_products_via_SCC_yast2.pm
@@ -15,26 +15,26 @@ use base qw(y2logsstep y2x11test);
 use strict;
 use testapi;
 use registration 'fill_in_registration_data';
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 use utils 'turn_off_gnome_screensaver';
 
+=head2 test_setup
+Define proxy SCC. For SLE 15 we need to clean existing registration
+=cut
 sub test_setup {
     select_console 'root-console';
-    my $proxy_scc;
-    if (sle_version_at_least '15') {
-        # Remove registration from the system
-        assert_script_run 'SUSEConnect --clean';
-        # Define proxy SCC
-        assert_script_run 'echo "url: ' . get_var('SCC_URL') . '" > /etc/SUSEConnect';
-    }    # add every used addon to regurl for proxy SCC
+    if (is_sle('>=15')) {
+        assert_script_run 'SUSEConnect --clean';                                          # Remove registration from the system
+        assert_script_run 'echo "url: ' . get_var('SCC_URL') . '" > /etc/SUSEConnect';    # Define proxy SCC
+    }
     elsif (get_var('SCC_ADDONS')) {
+        # Add every used addon to regurl for proxy SCC
         my @addon_proxy = ("url: http://server-" . get_var('BUILD_SLE'));
         for my $addon (split(/,/, get_var('SCC_ADDONS', ''))) {
-            my $uc_addon = uc $addon;    # change to uppercase to match variable
+            my $uc_addon = uc $addon;                                                     # change to uppercase to match variable
             push(@addon_proxy, "\b.$addon-" . get_var("BUILD_$uc_addon"));
         }
-        # Define proxy SCC
-        assert_script_run "echo \"@addon_proxy.proxy.scc.suse.de\" > /etc/SUSEConnect";
+        assert_script_run "echo \"@addon_proxy.proxy.scc.suse.de\" > /etc/SUSEConnect";    # Define proxy SCC
     }
     turn_off_gnome_screensaver;
     select_console 'x11';
@@ -42,7 +42,8 @@ sub test_setup {
 
 sub run {
     my ($self) = @_;
-    test_setup;                          # Define proxy SCC. For SLE 15 we need to clean existing registration.
+
+    test_setup;
     $self->launch_yast2_module_x11('scc', target_match => [qw(scc-registration packagekit-warning)], maximize_window => 1);
     if (match_has_tag 'packagekit-warning') {
         send_key 'alt-y';


### PR DESCRIPTION
SLE12SP4: When going back in registration to verify if the dialog remembers addon selection is needed to scroll too in the same way than when we are selecting it previously.
~SLE15SP1: Assert the needles before, so it only will take care of the pre-selected modules and leave the handling of the modules to the code below that iterates addon by addon.~

- Related ticket: https://progress.opensuse.org/issues/42014
- Needles:
  -  [~needles SLE~](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/971)
  - [~more needles SLE~](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/973)
- Verification run: 
  - [sle-12-SP4-sles+sdk+proxy_SCC_via_YaST](http://dhcp42.suse.cz/tests/467#step/addon_products_via_SCC_yast2/34)
  - [sle-15-SP1-sles+sdk+proxy_SCC_via_YaST](http://dhcp42.suse.cz/tests/508#step/addon_products_via_SCC_yast2/34) 
