### PR TITLE
Allow to set OPENQA_BASEDIR for svirt host

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -747,7 +747,8 @@ sub zkvm_add_disk {
     my ($svirt) = @_;
     if (my $hdd = get_var('HDD_1')) {
         my $basename = basename($hdd);
-        my $hdd_dir  = "/var/lib/openqa/share/factory/hdd";
+        my $basedir  = svirt_host_basedir();
+        my $hdd_dir  = "$basedir/openqa/share/factory/hdd";
         chomp(my $hdd_path = `find $hdd_dir -name $basename | head -n1`);
         diag("HDD path found: $hdd_path");
         if (get_var('PATCHED_SYSTEM')) {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -75,6 +75,7 @@ our @EXPORT = qw(
   set_hostname
   zypper_ar
   show_tasks_in_blocked_state
+  svirt_host_basedir
 );
 
 
@@ -1035,6 +1036,10 @@ sub show_tasks_in_blocked_state {
         # info will be sent to serial tty
         wait_serial('SysRq : Show Blocked State', 1);
     }
+}
+
+sub svirt_host_basedir {
+    return get_var('VIRSH_OPENQA_BASEDIR', '/var/lib');
 }
 
 1;

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -62,8 +62,9 @@ sub run {
     $svirt->change_domain_element(on_reboot => undef);
     $svirt->change_domain_element(on_reboot => 'destroy');
 
-    my $dev_id = 'a';
-    my $isodir = '/var/lib/openqa/share/factory/iso /var/lib/openqa/share/factory/iso/fixed';
+    my $dev_id  = 'a';
+    my $basedir = svirt_host_basedir();
+    my $isodir  = "$basedir/openqa/share/factory/iso $basedir/openqa/share/factory/iso/fixed";
     # In netinstall we don't have ISO media, for the rest we attach it, if it's defined
     if (my $isofile = get_var('ISO')) {
         my $isopath = copy_image($isofile, $isodir);
@@ -89,7 +90,7 @@ sub run {
         }
     }
 
-    my $hdddir = '/var/lib/openqa/share/factory/hdd /var/lib/openqa/share/factory/hdd/fixed';
+    my $hdddir = "$basedir/openqa/share/factory/hdd $basedir/openqa/share/factory/hdd/fixed";
     my $size_i = get_var('HDDSIZEGB', '10');
     foreach my $n (1 .. get_var('NUMDISKS')) {
         if (my $hdd = get_var('HDD_' . $n)) {

--- a/variables.md
+++ b/variables.md
@@ -87,6 +87,7 @@ USBBOOT | boolean | false | Indicates booting to the usb device.
 USEIMAGES |||
 VERSION | string | | Contains major version of the product. E.g. 15-SP1 or 15.1
 VIDEOMODE | string | | Indicates/defines video mode used for the installation. Empty value uses default, other possible values `text`, `ssh-x` for installation ncurses and x11 over ssh respectivelyю
+VIRSH_OPENQA_BASEDIR | string | /var/lib | The OPENQA_BASEDIR configured on the svirt host (only relevant for the svirt backend).
 UNENCRYPTED_BOOT | boolean | false | Indicates/defines existence of unencrypted boot partition in the SUT.
 WAYLAND | boolean | false | Enables wayland tests in the system.
 XDMUSED | boolean | false | Indicates availability of xdm.


### PR DESCRIPTION
The location of the openqa directory can be adjusted using OPENQA_BASEDIR (so it isn't always under /var/lib).

This change allows to use the svirt backend with a host using that variable by adding VIRSH_OPENQA_BASEDIR in accordance to the worker config.

Verification run: ![screenshot_20181024_153037](https://user-images.githubusercontent.com/10248953/47433946-c20ae300-d7a1-11e8-9687-659461e944e1.png)  
(It is at least passed the point where the changes of this PR matter.)