### PR TITLE
Tidy code to fix testsuite

### DIFF
--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -30,10 +30,10 @@ sub run {
     if (check_var('ARCH', 'x86_64')) {
         send_key 'alt-x';    # XEN Server, only available on x86_64: bsc#1088175
     }
-    send_key 'alt-e';    # Xen tools
-    send_key 'alt-k';    # KVM Server
-    send_key 'alt-v';    # KVM tools
-    send_key 'alt-l';    # libvirt-lxc
+    send_key 'alt-e';        # Xen tools
+    send_key 'alt-k';        # KVM Server
+    send_key 'alt-v';        # KVM tools
+    send_key 'alt-l';        # libvirt-lxc
 
     # launch the installation
     send_key 'alt-a';


### PR DESCRIPTION
Seems to have been introduced by https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/0af23ca4af7f53a03fdfd655d6ba3dff442afe39

@ggardet please make sure to run `./tools/tidy` before committing and avoid pushing directly to master without a PR if it is not urgent.