### PR TITLE
Override fatal flag with always_rollback for yast2 modules tests

### DIFF
--- a/tests/console/yast2_apparmor.pm
+++ b/tests/console/yast2_apparmor.pm
@@ -160,5 +160,8 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
 }
 
-1;
+sub test_flags {
+    return {always_rollback => 1};
+}
 
+1;

--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -162,4 +162,8 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook();
 }
 
+sub test_flags {
+    return {always_rollback => 1};
+}
+
 1;

--- a/tests/console/yast2_ftp.pm
+++ b/tests/console/yast2_ftp.pm
@@ -205,7 +205,7 @@ sub post_fail_hook {
 }
 
 sub test_flags {
-    return {milestone => 1};
+    return {always_rollback => 1};
 }
 
 1;

--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -118,4 +118,8 @@ sub run {
     wait_serial("yast2-http-server-status-0", 240) || die "'yast2 http-server' didn't finish";
 }
 
+sub test_flags {
+    return {always_rollback => 1};
+}
+
 1;

--- a/tests/console/yast2_lan_hostname.pm
+++ b/tests/console/yast2_lan_hostname.pm
@@ -68,4 +68,8 @@ sub post_fail_hook {
     upload_logs '/etc/sysconfig/network/dhcp';
 }
 
+sub test_flags {
+    return {always_rollback => 1};
+}
+
 1;

--- a/tests/console/yast2_nfs_client.pm
+++ b/tests/console/yast2_nfs_client.pm
@@ -77,5 +77,8 @@ sub run {
     assert_script_run 'diff -b <(tail -n1 /etc/fstab) <(tail -n1 fstab_before)';
 }
 
-1;
+sub test_flags {
+    return {always_rollback => 1};
+}
 
+1;

--- a/tests/console/yast2_ntpclient.pm
+++ b/tests/console/yast2_ntpclient.pm
@@ -184,4 +184,9 @@ sub run {
     # check ntp synchronization service state
     systemctl "show -p ActiveState $ntp_service.service | grep ActiveState=active";
 }
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
 1;

--- a/tests/console/yast2_proxy.pm
+++ b/tests/console/yast2_proxy.pm
@@ -294,4 +294,8 @@ sub run {
     systemctl 'show -p SubState squid.service|grep SubState=running';
 }
 
+sub test_flags {
+    return {always_rollback => 1};
+}
+
 1;

--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -411,4 +411,8 @@ sub post_fail_hook {
     upload_logs('/tmp/failed_smb_directives.log');
 }
 
+sub test_flags {
+    return {always_rollback => 1};
+}
+
 1;

--- a/tests/console/yast2_snapper_ncurses.pm
+++ b/tests/console/yast2_snapper_ncurses.pm
@@ -36,4 +36,8 @@ sub post_fail_hook {
     $self->y2snapper_failure_analysis;
 }
 
+sub test_flags {
+    return {always_rollback => 1};
+}
+
 1;

--- a/tests/console/yast2_tftp.pm
+++ b/tests/console/yast2_tftp.pm
@@ -102,4 +102,8 @@ sub run {
     assert_script_run "echo $server_string | cmp - test";
 }
 
+sub test_flags {
+    return {always_rollback => 1};
+}
+
 1;

--- a/tests/console/yast2_vnc.pm
+++ b/tests/console/yast2_vnc.pm
@@ -91,4 +91,8 @@ sub run {
     }
 }
 
+sub test_flags {
+    return {always_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
Fatal flag was inherited by the test modules as they have same parent as
installation tests, where each step is fatal. Also, to improve test
bisection, we can start using always_rollback flag here.

Mitigation for [poo#42413](https://progress.opensuse.org/issues/42413).

#### Verification runs
[arm, old os-autoinst](http://g226.suse.de/tests/2860)
[64bit, updates os-autoinst](http://g226.suse.de/tests/2858)
