### PR TITLE
installation_overview: Simplify and cleanup

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -131,7 +131,7 @@ sub process_unsigned_files {
 sub deal_with_dependency_issues {
     my ($self) = @_;
 
-    return unless check_screen 'manual-intervention', 10;
+    return unless check_screen 'manual-intervention', 0;
 
     record_info 'dependency warning', "Dependency warning, working around dependency issues", result => 'fail';
 

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,53 +18,7 @@ use testapi;
 use version_utils 'sle_version_at_least';
 
 
-sub run {
-    my ($self) = shift;
-    # Softfail not to forget remove workaround
-    record_soft_failure('bsc#1054974') if get_var('ALL_MODULES');
-    # overview-generation
-    # this is almost impossible to check for real
-    assert_screen "installation-settings-overview-loaded", 150;
-
-    $self->deal_with_dependency_issues;
-
-    if (get_var("XEN")) {
-        assert_screen "inst-xen-pattern";
-    }
-
-    # preserve it for the video
-    wait_still_screen;
-
-    # In case the proposal does not fit on the screen, there is a scrollbar shown.
-    # Scroll down to see any errors.
-    if (check_screen('inst-scrollbar', 0)) {
-        send_key 'tab';
-        send_key 'end';
-
-        assert_screen "inst-overview-booting";
-
-        # preserve it for the video
-        wait_still_screen;
-    }
-
-    # Check autoyast has been removed in SP2 (fate#317970)
-    if (get_var("SP2ORLATER") && !check_var("INSTALL_TO_OTHERS", 1)) {
-        if (check_var('VIDEOMODE', 'text')) {
-            wait_screen_change { send_key 'alt-l' };
-            wait_screen_change { send_key 'ret' };
-            send_key 'tab';
-        }
-        else {
-            send_key_until_needlematch 'packages-section-selected', 'tab';
-        }
-        send_key 'end';
-        assert_screen 'autoyast_removed';
-    }
-
-    if (check_screen('manual-intervention', 0)) {
-        $self->deal_with_dependency_issues;
-    }
-
+sub ensure_ssh_unblocked {
     my $need_ssh = check_var('ARCH', 's390x');    # s390x always needs SSH
     $need_ssh = 1 if check_var('BACKEND', 'ipmi');    # we better be able to login
     $need_ssh = 1 if check_var('BACKEND', 'spvm');    # we better be able to login
@@ -88,12 +42,16 @@ sub run {
             }
         }
     }
+}
 
-    if (check_screen('inst-overview-bootloader-warning', 0)) {
-        record_soft_failure 'bsc#1024409';
-        send_key 'alt-i';    #install
-        assert_screen 'inst-overview-error-found';
-    }
+sub run {
+    my ($self) = shift;
+    # overview-generation
+    # this is almost impossible to check for real
+    assert_screen "installation-settings-overview-loaded", 150;
+    $self->deal_with_dependency_issues;
+    assert_screen "inst-xen-pattern" if get_var('XEN');
+    ensure_ssh_unblocked;
 }
 
 1;


### PR DESCRIPTION
Previously installation_overview was unnecessarily wasting time with
`wait_still_screen` calls which are not needed anymore after we introduced the
initial assert_screen which checks for a completely loaded screen. Also,
obsolete checks for old bugs were included in the code but not even executed
since we do not have the according needles anymore since a very long time. The
same is true for 'inst-scrollbar' and 'manual-intervention'. However, I
consider it possible that a need for 'manual-intervention' comes back which we
then can simply make use of by creating the according needle. In this case I
assume the time behaviour would be different anyway so we can reduce the
timeout to save another 10s.

Verification run: http://lord.arch/tests/1901

Related progress issue: https://progress.opensuse.org/issues/42875