### PR TITLE
.travis.yml: Test both stable Leap 42.3 perl version as well as more recent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: perl
 perl:
+  - "5.18"
   - "5.26"
 addons:
   apt:


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5368 not
too long ago updated the perl version to use for tests to the current
perl version of openSUSE Tumbleweed at the time. However, recently we
introduced a problem which was not detected by the tests but only on the
production infrastructure which runs on SLE 12 SP3 / openSUSE Leap 42.3
so probably we should test both perl versions in a matrix.