### PR TITLE
Revert "Fix assertion of the screen in releasenotes_origin"

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -52,6 +52,7 @@ our @EXPORT = qw(
   is_sles4sap_standard
   is_updates_test_repo
   is_updates_tests
+  is_using_system_role
   kdestep_is_applicable
   kdump_is_applicable
   load_autoyast_clone_tests
@@ -325,6 +326,29 @@ sub is_leanos {
     return 1 if get_var('FLAVOR', '') =~ /^Leanos/;
     return 1 if get_var('FLAVOR', '') =~ /^Installer-/;
     return 0;
+}
+
+sub is_using_system_role {
+    #system_role selection during installation was added as a new feature since sles12sp2
+    #so system_role.pm should be loaded for all tests that actually install to versions over sles12sp2
+    #no matter with or without INSTALL_TO_OTHERS tag
+    # On SLE 15 SP0 we unconditionally have system roles screen
+    # SLE 15 SP1 has system roles only if more than one is available, meaning either registered or with all packages DVD
+    # On kubic, leap 15.1+, TW we have it instead of desktop selection screen
+    return is_sle('>=12-SP2') && is_sle('<15')
+      && check_var('ARCH', 'x86_64')
+      && is_server()
+      && (!is_sles4sap() || is_sles4sap_standard())
+      && (install_this_version() || install_to_other_at_least('12-SP2'))
+      || is_sle('=15')
+      || (is_sle('>15') && (check_var('SCC_REGISTER', 'installation') || get_var('ADDONS') || get_var('ADDONURL')))
+      || (is_opensuse && !is_leap('<15.1'))    # Also on leap 15.1, TW
+      || is_caasp('kubic');                    # And Kubic
+}
+
+# On leap 15.0 we have desktop selection first, and everywhere, where we have system roles
+sub is_using_system_role_first_flow {
+    return is_leap('=15.0') || is_using_system_role;
 }
 
 sub is_desktop_module_selected {

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -39,8 +39,6 @@ use constant {
           is_staging
           is_storage_ng
           sle_version_at_least
-          is_using_system_role
-          is_using_system_role_first_flow
           )
     ],
     BACKEND => [
@@ -308,27 +306,4 @@ sub is_svirt_except_s390x {
 sub is_remote_backend {
     # s390x uses only remote repos
     return check_var('ARCH', 's390x') || check_var('BACKEND', 'svirt') || check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm');
-}
-
-sub is_using_system_role {
-    #system_role selection during installation was added as a new feature since sles12sp2
-    #so system_role.pm should be loaded for all tests that actually install to versions over sles12sp2
-    #no matter with or without INSTALL_TO_OTHERS tag
-    # On SLE 15 SP0 we unconditionally have system roles screen
-    # SLE 15 SP1 has system roles only if more than one is available, meaning either registered or with all packages DVD
-    # On kubic, leap 15.1+, TW we have it instead of desktop selection screen
-    return is_sle('>=12-SP2') && is_sle('<15')
-      && check_var('ARCH', 'x86_64')
-      && is_server()
-      && (!is_sles4sap() || is_sles4sap_standard())
-      && (install_this_version() || install_to_other_at_least('12-SP2'))
-      || is_sle('=15')
-      || (is_sle('>15') && (check_var('SCC_REGISTER', 'installation') || get_var('ADDONS') || get_var('ADDONURL')))
-      || (is_opensuse && !is_leap('<15.1'))    # Also on leap 15.1, TW
-      || is_caasp('kubic');                    # And Kubic
-}
-
-# On leap 15.0 we have desktop selection first, and everywhere, where we have system roles
-sub is_using_system_role_first_flow {
-    return is_leap('=15.0') || is_using_system_role;
 }

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -13,7 +13,7 @@ use warnings;
 use testapi qw(check_var get_var get_required_var set_var);
 use lockapi;
 use needle;
-use version_utils ':VERSION';
+use version_utils qw(is_opensuse is_sle);
 use File::Find;
 use File::Basename;
 

--- a/tests/installation/releasenotes_origin.pm
+++ b/tests/installation/releasenotes_origin.pm
@@ -14,7 +14,7 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use version_utils ':VERSION';
+use version_utils 'is_sle';
 
 sub run {
     assert_screen('release-notes-button');
@@ -31,9 +31,7 @@ sub run {
         }
     }
     type_string "exit\n";
-    # If we don't have system role screen, release notes origin is verified on partitioning screen
-    my $current_screen = is_using_system_role ? 'system-role-default-system' : 'partitioning-edit-proposal-button';
-    assert_screen $current_screen, 180;
+    assert_screen 'system-role-default-system', 180;
 }
 
 1;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#6039

See https://progress.opensuse.org/issues/42899