### PR TITLE
Fix assertion of the screen in releasenotes_origin

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -52,7 +52,6 @@ our @EXPORT = qw(
   is_sles4sap_standard
   is_updates_test_repo
   is_updates_tests
-  is_using_system_role
   kdestep_is_applicable
   kdump_is_applicable
   load_autoyast_clone_tests
@@ -311,13 +310,6 @@ sub is_mediacheck {
     return get_var('MEDIACHECK');
 }
 
-sub is_server {
-    return 1 if is_sles4sap();
-    return 1 if get_var('FLAVOR', '') =~ /^Server/;
-    return 0 unless is_leanos();
-    return check_var('SLE_PRODUCT', 'sles');
-}
-
 sub is_desktop {
     return get_var('FLAVOR', '') =~ /^Desktop/ || check_var('SLE_PRODUCT', 'sled');
 }
@@ -326,29 +318,6 @@ sub is_leanos {
     return 1 if get_var('FLAVOR', '') =~ /^Leanos/;
     return 1 if get_var('FLAVOR', '') =~ /^Installer-/;
     return 0;
-}
-
-sub is_using_system_role {
-    #system_role selection during installation was added as a new feature since sles12sp2
-    #so system_role.pm should be loaded for all tests that actually install to versions over sles12sp2
-    #no matter with or without INSTALL_TO_OTHERS tag
-    # On SLE 15 SP0 we unconditionally have system roles screen
-    # SLE 15 SP1 has system roles only if more than one is available, meaning either registered or with all packages DVD
-    # On kubic, leap 15.1+, TW we have it instead of desktop selection screen
-    return is_sle('>=12-SP2') && is_sle('<15')
-      && check_var('ARCH', 'x86_64')
-      && is_server()
-      && (!is_sles4sap() || is_sles4sap_standard())
-      && (install_this_version() || install_to_other_at_least('12-SP2'))
-      || is_sle('=15')
-      || (is_sle('>15') && (check_var('SCC_REGISTER', 'installation') || get_var('ADDONS') || get_var('ADDONURL')))
-      || (is_opensuse && !is_leap('<15.1'))    # Also on leap 15.1, TW
-      || is_caasp('kubic');                    # And Kubic
-}
-
-# On leap 15.0 we have desktop selection first, and everywhere, where we have system roles
-sub is_using_system_role_first_flow {
-    return is_leap('=15.0') || is_using_system_role;
 }
 
 sub is_desktop_module_selected {
@@ -792,10 +761,6 @@ sub unregister_needle_tags {
     my ($tag) = @_;
     my @a = @{needle::tags($tag)};
     for my $n (@a) { $n->unregister($tag); }
-}
-
-sub install_this_version {
-    return !check_var('INSTALL_TO_OTHERS', 1);
 }
 
 sub load_bootloader_s390x {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -314,12 +314,6 @@ sub is_desktop {
     return get_var('FLAVOR', '') =~ /^Desktop/ || check_var('SLE_PRODUCT', 'sled');
 }
 
-sub is_leanos {
-    return 1 if get_var('FLAVOR', '') =~ /^Leanos/;
-    return 1 if get_var('FLAVOR', '') =~ /^Installer-/;
-    return 0;
-}
-
 sub is_desktop_module_selected {
     # desktop applications module is selected if following variables have following values:
     # ha require desktop applications on sle <15, so it's preselected

--- a/lib/mm_tests.pm
+++ b/lib/mm_tests.pm
@@ -20,6 +20,7 @@ use strict;
 use testapi;
 use utils;
 use mm_network;
+use version_utils ':SCENARIO';
 
 our @EXPORT = qw(
   configure_static_network

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -41,7 +41,6 @@ our @EXPORT = qw(
   workaround_type_encrypted_passphrase
   select_user_gnome
   ensure_unlocked_desktop
-  install_to_other_at_least
   is_bridged_networking
   set_bridged_networking
   ensure_fullscreen
@@ -482,25 +481,6 @@ sub ensure_unlocked_desktop {
         wait_still_screen 2;           # slow down loop
         die 'ensure_unlocked_desktop repeated too much. Check for X-server crash.' if ($counter eq 1);    # die loop when generic-desktop not matched
     }
-}
-
-#Check the real version of the test machine is at least some value, rather than the VERSION variable
-#It is for version checking for tests with variable "INSTALL_TO_OTHERS".
-sub install_to_other_at_least {
-    my $version = shift;
-
-    if (!check_var("INSTALL_TO_OTHERS", "1")) {
-        return 0;
-    }
-
-    #setup the var for real VERSION
-    my $real_installed_version = get_var("REPO_0_TO_INSTALL");
-    $real_installed_version =~ /.*SLES?-(\d+-SP\d+)-.*/m;
-    $real_installed_version = $1;
-    set_var("REAL_INSTALLED_VERSION", $real_installed_version);
-    bmwqemu::save_vars();
-
-    return sle_version_at_least($version, version_variable => "REAL_INSTALLED_VERSION");
 }
 
 sub is_bridged_networking {

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -39,6 +39,8 @@ use constant {
           is_staging
           is_storage_ng
           sle_version_at_least
+          is_using_system_role
+          is_using_system_role_first_flow
           )
     ],
     BACKEND => [
@@ -54,12 +56,15 @@ use constant {
     ],
     SCENARIO => [
         qw(
+          install_this_version
+          install_to_other_at_least
           is_upgrade
           is_sle12_hdd_in_upgrade
           is_installcheck
           is_desktop_installed
           is_system_upgrading
           is_virtualization_server
+          is_server
           )
       ]
 };
@@ -306,4 +311,57 @@ sub is_svirt_except_s390x {
 sub is_remote_backend {
     # s390x uses only remote repos
     return check_var('ARCH', 's390x') || check_var('BACKEND', 'svirt') || check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm');
+}
+
+sub is_server {
+    return 1 if is_sles4sap();
+    return 1 if get_var('FLAVOR', '') =~ /^Server/;
+    return 0 unless is_leanos();
+    return check_var('SLE_PRODUCT', 'sles');
+}
+
+sub install_this_version {
+    return !check_var('INSTALL_TO_OTHERS', 1);
+}
+
+#Check the real version of the test machine is at least some value, rather than the VERSION variable
+#It is for version checking for tests with variable "INSTALL_TO_OTHERS".
+sub install_to_other_at_least {
+    my $version = shift;
+
+    if (!check_var("INSTALL_TO_OTHERS", "1")) {
+        return 0;
+    }
+
+    #setup the var for real VERSION
+    my $real_installed_version = get_var("REPO_0_TO_INSTALL");
+    $real_installed_version =~ /.*SLES?-(\d+-SP\d+)-.*/m;
+    $real_installed_version = $1;
+    set_var("REAL_INSTALLED_VERSION", $real_installed_version);
+    bmwqemu::save_vars();
+
+    return sle_version_at_least($version, version_variable => "REAL_INSTALLED_VERSION");
+}
+
+sub is_using_system_role {
+    #system_role selection during installation was added as a new feature since sles12sp2
+    #so system_role.pm should be loaded for all tests that actually install to versions over sles12sp2
+    #no matter with or without INSTALL_TO_OTHERS tag
+    # On SLE 15 SP0 we unconditionally have system roles screen
+    # SLE 15 SP1 has system roles only if more than one is available, meaning either registered or with all packages DVD
+    # On kubic, leap 15.1+, TW we have it instead of desktop selection screen
+    return is_sle('>=12-SP2') && is_sle('<15')
+      && check_var('ARCH', 'x86_64')
+      && is_server()
+      && (!is_sles4sap() || is_sles4sap_standard())
+      && (install_this_version() || install_to_other_at_least('12-SP2'))
+      || is_sle('=15')
+      || (is_sle('>15') && (check_var('SCC_REGISTER', 'installation') || get_var('ADDONS') || get_var('ADDONURL')))
+      || (is_opensuse && !is_leap('<15.1'))    # Also on leap 15.1, TW
+      || is_caasp('kubic');                    # And Kubic
+}
+
+# On leap 15.0 we have desktop selection first, and everywhere, where we have system roles
+sub is_using_system_role_first_flow {
+    return is_leap('=15.0') || is_using_system_role;
 }

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -316,7 +316,8 @@ sub is_remote_backend {
 sub is_server {
     return 1 if is_sles4sap();
     return 1 if get_var('FLAVOR', '') =~ /^Server/;
-    return 0 unless is_leanos();
+    # If unified installer, we need to check SLE_PRODUCT
+    return 0 if get_var('FLAVOR', '') !~ /^Installer-/;
     return check_var('SLE_PRODUCT', 'sles');
 }
 

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -13,7 +13,7 @@ use warnings;
 use testapi qw(check_var get_var get_required_var set_var);
 use lockapi;
 use needle;
-use version_utils qw(is_opensuse is_sle);
+use version_utils ':VERSION';
 use File::Find;
 use File::Basename;
 

--- a/tests/installation/releasenotes_origin.pm
+++ b/tests/installation/releasenotes_origin.pm
@@ -14,7 +14,7 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use version_utils 'is_sle';
+use version_utils ':VERSION';
 
 sub run {
     assert_screen('release-notes-button');
@@ -31,7 +31,9 @@ sub run {
         }
     }
     type_string "exit\n";
-    assert_screen 'system-role-default-system', 180;
+    # If we don't have system role screen, release notes origin is verified on partitioning screen
+    my $current_screen = is_using_system_role ? 'system-role-default-system' : 'partitioning-edit-proposal-button';
+    assert_screen $current_screen, 180;
 }
 
 1;


### PR DESCRIPTION
When having single system role, release notes are verified on
partitioning screen, hence need to adjust expectations.

Includes patch for the issue introduced in #6039.

See [poo#41858](https://progress.opensuse.org/issues/41858).

#### Verification runs
[release notes](http://g226.suse.de/tests/2873)
[affected qam test](http://g226.suse.de/tests/2875)
