### PR TITLE
Send ctrl+c during post_fail_hook

### DIFF
--- a/tests/x11/vnc_two_passwords.pm
+++ b/tests/x11/vnc_two_passwords.pm
@@ -112,6 +112,8 @@ sub run {
 }
 
 sub post_fail_hook {
+    # xev seems to hang, send control-c to ensure that we can actually type
+    send_key "ctrl-c";
     upload_logs('/tmp/xev_log', failok => 1);
 }
 


### PR DESCRIPTION
To help a bit with the investigation, try to send the ctrl+c to at least get the xev.log in case of failure.

Related progress ticket: https://progress.opensuse.org/issues/35869