### PR TITLE
Introduce flow for validation of the installation

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1057,7 +1057,6 @@ sub load_consoletests {
     loadtest 'qa_automation/patch_and_reboot' if is_updates_tests && !get_var('QAM_MINIMAL');
     loadtest "console/system_prepare";
     loadtest "console/consoletest_setup";
-    loadtest "console/lvm_thin_check" if get_var('LVM_THIN_LV');
     loadtest 'console/integration_services' if is_hyperv;
     loadtest "locale/keymap_or_locale";
     loadtest "console/repo_orphaned_packages_check" if is_jeos;
@@ -1999,9 +1998,7 @@ sub load_systemd_patches_tests {
     loadtest 'console/systemd_testsuite';
 }
 
-sub load_create_hdd_tests {
-    return unless get_var('INSTALLONLY');
-    # install SES packages and deepsea testsuites
+sub load_system_prepare_tests {
     loadtest 'ses/install_ses' if check_var_array('ADDONS', 'ses') || check_var_array('SCC_ADDONS', 'ses');
     # temporary adding test modules which applies hacks for missing parts in sle15
     loadtest 'console/sle15_workarounds' if is_sle('15+');
@@ -2013,6 +2010,12 @@ sub load_create_hdd_tests {
     replace_opensuse_repos_tests if is_repo_replacement_required;
     loadtest 'console/scc_deregistration' if get_var('SCC_DEREGISTER');
     loadtest 'shutdown/grub_set_bootargs';
+}
+
+sub load_create_hdd_tests {
+    return unless get_var('INSTALLONLY');
+    # install SES packages and deepsea testsuites
+    load_system_prepare_tests;
     load_shutdown_tests;
     if (check_var('BACKEND', 'svirt')) {
         if (is_hyperv) {
@@ -2074,12 +2077,24 @@ sub load_publiccloud_tests {
     loadtest 'publiccloud/run_ltp'       if get_var('PUBLIC_CLOUD_LTP');
 }
 
+# Scheduling set for validation of specific installation
+sub load_installation_validation_tests {
+    load_system_prepare_tests;
+    # See description of INSTALLATION_VALIDATION in variables.md
+    # Possible values:
+    # - console/lvm_thin_check for thin LVM
+    for my $module (split(',', get_var('INSTALLATION_VALIDATION'))) {
+        loadtest $module;
+    }
+}
+
 sub load_common_opensuse_sle_tests {
     load_autoyast_clone_tests           if get_var("CLONE_SYSTEM");
     load_publiccloud_tests              if get_var('PUBLIC_CLOUD');
     load_create_hdd_tests               if get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1");
     load_toolchain_tests                if get_var("TCM") || check_var("ADDONS", "tcm");
     loadtest 'console/network_hostname' if get_var('NETWORK_CONFIGURATION');
+    load_installation_validation_tests  if get_var('INSTALLATION_VALIDATION');
 }
 
 sub load_ssh_key_import_tests {

--- a/variables.md
+++ b/variables.md
@@ -43,6 +43,7 @@ HASLICENSE | boolean | true if SLE, false otherwise | Enables processing and val
 HDDVERSION | string | | Indicates version of the system installed on the HDD.
 HTTPPROXY  |||
 EXPECTED_INSTALL_HOSTNAME | string | | Contains expected hostname YaST installer got from the environment (DHCP, 'hostname=' as a kernel cmd line argument)
+INSTALLATION_VALIDATION | string | | Comma separated list of modules to be used for installed system validation, should be used in combination with INSTALLONLY, to schedule only relevant test modules.
 INSTALLONLY | boolean | false | Indicates that test suite conducts only installation. Is recommended to be used for all jobs which create and publish images
 INSTLANG | string | en_US | Installation locale settings.
 IPXE | boolean | false | Indicates ipxe boot.
@@ -52,6 +53,7 @@ LAPTOP |||
 LIVECD | boolean | false | Indicates live image being used.
 LIVETEST | boolean | false | Indicates test of live system.
 LVM | boolean | false | Use lvm for partitioning.
+LVM_THIN_LV | boolean | false | Use thin provisioning logical volumes for partitioning,
 MACHINE | string | | Define machine name which defines worker specific configuration, including WORKER_CLASS.
 MEDIACHECK | boolean | false | Enables `installation/mediacheck` test module.
 MEMTEST | boolean | false | Enables `installation/memtest` test module.


### PR DESCRIPTION
In many test suites we use standard set of test modules to validate that
SUT is functional. However, it's not efficient to run the very same set
of test modules for each installation. For example, if the only
difference of the setup is ext4 instead of btrfs, we need to validate
that FS works fine and risks that firefox won't start are quite low.

See [poo#42854](https://progress.opensuse.org/issues/42848).

This requires following settings of the test suite:
```
INSTALLONLY=1
INSTALLATION_VALIDATION=console/lvm_thin_check
```

- [Verification run](http://g226.suse.de/tests/2998).
