### PR TITLE
Override fatal flag for yast2 modules tests

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -30,4 +30,8 @@ sub post_run_hook {
     $self->clear_and_verify_console;
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;


### PR DESCRIPTION
Fatal flag was inherited from lib/installbasetest.pm but there is no reason to not test next yast2 modules if one fails.

Mitigation for [poo#42413](https://progress.opensuse.org/issues/42413)