### PR TITLE
Add record info for postfailhooks and check proper variable

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -564,6 +564,7 @@ sub remount_tmp_if_ro {
 ## of wait_boot, e.g. see `git grep -l reboot | xargs grep -L wait_boot`
 sub post_fail_hook {
     my ($self) = @_;
+    record_info('post fail hook', 'Post fail hook started for test distribution.');
     return if testapi::is_serial_terminal();    # in case it is VIRTIO_CONSOLE=1 nothing below make sense
 
     show_tasks_in_blocked_state;

--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -55,7 +55,7 @@ sub run {
     send_key "alt-l";
     $self->{in_wait_boot} = 1;
     power_action('reboot', keepconsole => 1, textmode => 1);
-    $self->handle_uefi_boot_disk_workaround() if get_var('MACHINE') =~ qr'aarch64';
+    $self->handle_uefi_boot_disk_workaround() if check_var('ARCH', 'aarch64');
     assert_screen "grub2";
     send_key 'up';
 


### PR DESCRIPTION
While having the post fail hooks is very useful, specially when they are called in chain, it' s no fun to try to figure out what happened or when the actual post fail hook started, let' s use a record info for that? :)

On the other hand, sneak in a proper check for ARCH instead of MACHINE in the user_defined_snapshot test