### PR TITLE
Remove waiting for welcome message in wait boot

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -457,8 +457,6 @@ sub wait_boot {
 
     # on s390x svirt encryption is unlocked with workaround_type_encrypted_passphrase before here
     unlock_if_encrypted if !get_var('S390_ZKVM');
-    # On remote backends we sync on Welcome message already where possible, mitigating bsc#1112109
-    wait_serial(get_login_message()) unless is_remote_backend;
 
     if ($textmode || check_var('DESKTOP', 'textmode')) {
         my $textmode_needles = [qw(linux-login emergency-shell emergency-mode)];

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -29,6 +29,8 @@ sub run {
     # Doing early due to bsc#1103199 and bsc#1112109
     systemctl "stop serial-getty\@$testapi::serialdev";
     systemctl "disable serial-getty\@$testapi::serialdev";
+    # Mask if is qemu backend as use serial in remote installations e.g. during reboot
+    systemctl "mask serial-getty\@$testapi::serialdev" if check_var('BACKEND', 'qemu');
     # init
     check_console_font;
 
@@ -60,9 +62,6 @@ sub run {
         # grep all also compressed files e.g. y2log-1.gz
         assert_script_run 'less /var/log/YaST2/y2log*|grep "Automatic DHCP configuration not started - an interface is already configured"';
     }
-
-    # Mask if is qemu backend as use serial in remote installations e.g. during reboot
-    systemctl "mask serial-getty\@$testapi::serialdev" if check_var('BACKEND', 'qemu');
 
     save_screenshot;
     $self->clear_and_verify_console;


### PR DESCRIPTION
Regression introduced in #6027, which doesn't work in many scenarios.

Also, addressing second comment from the initial PR.

See [poo#42359](https://progress.opensuse.org/issues/42359).

[Verification run](http://gershwin.arch.suse.de/tests/624)