### PR TITLE
Fix ternary operator for perl 5.18 in releasenotes_origin

### DIFF
--- a/tests/installation/releasenotes_origin.pm
+++ b/tests/installation/releasenotes_origin.pm
@@ -32,7 +32,7 @@ sub run {
     }
     type_string "exit\n";
     # If we don't have system role screen, release notes origin is verified on partitioning screen
-    my $current_screen = is_using_system_role ? 'system-role-default-system' : 'partitioning-edit-proposal-button';
+    my $current_screen = is_using_system_role() ? 'system-role-default-system' : 'partitioning-edit-proposal-button';
     assert_screen $current_screen, 180;
 }
 


### PR DESCRIPTION
Travis checks to catch such issues will be handled in
[poo#42953](https://progress.opensuse.org/issues/42953).

Fixes: 
```
[2018-10-26T09:19:32.0091 CEST] [debug] error on tests/installation/releasenotes_origin.pm: Search pattern not terminated or ternary operator parsed as search pattern at /var/lib/openqa/cache/tests/sle/tests/installation/releasenotes_origin.pm line 35.
```

See [poo#41858](https://progress.opensuse.org/issues/41858.
