### PR TITLE
Fix welcome module for upgrade to sle15 scenarios

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -403,5 +403,5 @@ configuration, otherwise returns false (0).
 =cut
 
 sub has_license_on_welcome_screen {
-    return get_var('HASLICENSE') && (!has_product_selection || is_sle('<15'));
+    return get_var('HASLICENSE') && ((is_sle('15+') && check_var('ARCH', 's390x')) || is_sle('<15'));
 }


### PR DESCRIPTION
The module failed due to invalid condition while checking if License
Agreement should be shown on Welcome screen. The condition did not
consider upgrade to sle15 scenarios, where neither Product Selection,
nor License Agreement are shown on Welcome screen.

The commit adds an appropriate fix for that case.

[poo#42608](https://progress.opensuse.org/issues/42608)
