### PR TITLE
publiccloud: Use provider class to trigger ipa

### DIFF
--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -51,4 +51,13 @@ sub provider_factory {
     }
 }
 
+sub get_image_id {
+    my ($provider) = @_;
+
+    my $image_id = get_var('PUBLIC_CLOUD_IMAGE_ID');
+    $image_id //= $provider->find_img(get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION'));
+    die('Missing valid image_id') unless ($image_id);
+    return $image_id;
+}
+
 1;

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -108,9 +108,8 @@ sub ipa {
     $args{results_dir}   //= 'ipa_results';
     $args{distro}        //= 'sles';
     my $user = 'ec2-user';
-    my $ssh_key_file =
 
-      $args{tests} =~ s/,/ /g;
+    $args{tests} =~ s/,/ /g;
 
     die("Create key-pair failed") unless ($self->create_ssh_key($self->prefix . time, 'QA_SSH_KEY.pem'));
 

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -20,9 +20,9 @@ has region     => undef;
 has prefix     => 'openqa';
 
 =head1 METHODS
- 
+
 =head2 init
- 
+
 Needs provider specific credentials, e.g. key_id, key_secret, region.
 
 =cut
@@ -58,6 +58,30 @@ This method is called called after each test on failure or success.
 
 =cut
 sub cleanup {
+}
+
+=head2 ipa
+
+  ipa(instance_type => <string>, cleanup => <bool>, tests => <string>, timeout => <seconds>, results_dir => <string>, distro => <string>);
+
+Call ipa tool and retrieves a hashref as result. Do not die if ipa call exit with error.
+  $result_hash = {
+        instance_id => <string>,    # unique CSP instance id
+        ip          => <ipaddress>, # public IP of instance
+        username    => <string>,    # username for ssh connection
+        ssh_key     => <string>,    # path to ssh-key for connection
+        logfile     => <string>,    # the pytest logfile
+        results     => <string>,    # json results file
+        tests       => <int>,       # total number of tests
+        pass        => <int>,       # successful tests
+        skip        => <int>,       # skipped tests
+        fail        => <int>,       # number of failed tests
+        error       => <int>,       # number of errors
+  };
+
+=cut
+sub ipa {
+    die('ipa() isn\'t implemented');
 }
 
 =head2 parse_ipa_output

--- a/tests/publiccloud/ipa.pm
+++ b/tests/publiccloud/ipa.pm
@@ -11,209 +11,49 @@
 #
 # Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>
 
-use base "opensusebasetest";
+use base "publiccloud::basetest";
 use strict;
 use testapi;
-use utils;
 use serial_terminal 'select_virtio_console';
-
-sub get_ipa_tests {
-    my $ipa_tests = get_required_var('PUBLIC_CLOUD_IPA_TESTS');
-    $ipa_tests =~ s/,/ /g;
-    return $ipa_tests;
-}
-
-sub save_logs {
-    my $ret = script_run("test -d ipa_results");
-    return if (!defined($ret) || $ret != 0);
-
-    my $image = get_required_var('PUBLIC_CLOUD_IMAGE_ID');
-
-    my $output = script_output("find ipa_results -type f");
-    for my $file (split(/\n/, $output)) {
-        if ($file =~ m"ipa_results/ec2/ami-[0-9a-z]+/i-[0-9a-z]+/[0-9]{14}\.(log|results)" or
-            $file =~ m"ipa_results/azure/$image/azure-ipa-test-\w+/[0-9]{14}\.(log|results)") {
-            upload_logs($file, failok => 1);
-            if ($file =~ /results$/) {
-                parse_extra_log(IPA => $file);
-            }
-        }
-    }
-}
-
-sub ec2_find_secgroup {
-    my ($name) = @_;
-
-    my $out = script_output("aws ec2 describe-security-groups --group-names '$name'", 30, proceed_on_failure => 1);
-    if ($out =~ /"GroupId":\s+"([^"]+)"/) {
-        return $1;
-    }
-    return;
-}
-
-sub ec2_create_secgroup {
-    my ($name) = @_;
-
-    my $secgroup_id = ec2_find_secgroup($name);
-    return $secgroup_id if (defined($secgroup_id));
-
-    assert_script_run("aws ec2 create-security-group --group-name '$name' --description 'SSH_OPEN'");
-    assert_script_run("aws ec2 authorize-security-group-ingress --group-name '$name' --protocol tcp --port 22 --cidr 0.0.0.0/0");
-    assert_script_run("aws ec2 authorize-security-group-ingress --group-name '$name' --protocol icmp --cidr 0.0.0.0/0 --port 0 ");
-    return ec2_find_secgroup($name);
-}
-
-sub ec2_create_ssh_key {
-    my ($prefix, $out_file) = @_;
-
-    for my $i (0 .. 9) {
-        my $key_name = $prefix . "_" . $i;
-        my $cmd      = "aws ec2 create-key-pair --key-name '" . $key_name . "' --query 'KeyMaterial' --output text > " . $out_file;
-        my $ret      = script_run($cmd);
-        if (defined($ret) && $ret == 0) {
-            return $key_name;
-        }
-    }
-    die("Unable to create SSH key on aws with prefix '$prefix'");
-}
-
-sub ec2_cleanup {
-    my ($self) = @_;
-
-    # Terminate instance
-    if (defined($self->{'ipa_instance_id'})) {
-        assert_script_run("aws ec2 terminate-instances --instance-ids " . $self->{'ipa_instance_id'});
-    }
-
-    if (defined($self->{'ipa_ssh_key_name'})) {
-        assert_script_run("aws ec2 delete-key-pair --key-name " . $self->{'ipa_ssh_key_name'});
-    }
-}
-
-sub ec2_run_ipa {
-    my ($self) = @_;
-
-    my $region = get_var('PUBLIC_CLOUD_REGION', 'eu-central-1');
-
-    assert_script_run("export AWS_ACCESS_KEY_ID=" . get_required_var('PUBLIC_CLOUD_KEY_ID'));
-    assert_script_run("export AWS_SECRET_ACCESS_KEY=" . get_required_var('PUBLIC_CLOUD_KEY_SECRET'));
-    assert_script_run('export AWS_DEFAULT_REGION="' . $region . '"');
-
-    # Create SSH key.
-    my $ssh_key_name = ec2_create_ssh_key("openqa_" . time, 'QA_SSH_KEY.pem');
-    $self->{'ipa_ssh_key_name'} = $ssh_key_name;
-
-    # Create security group
-    my $secgroup_id = ec2_create_secgroup("qa_secgroup");
-    die "Failed on creating security group" unless $secgroup_id;
-
-    #Prestart instance, cause IPA might use the wrong security group
-    my $ami_id = get_required_var("PUBLIC_CLOUD_IMAGE_ID");
-    my ($instance_id)
-      = script_output("aws ec2 run-instances --image-id $ami_id --instance-type '"
-          . get_var('PUBLIC_CLOUD_INSTANCE_TYPE', 't2.large')
-          . "' --key-name " . $ssh_key_name . " --security-group-ids '$secgroup_id'")
-      =~ /"InstanceId":\s*"([^"]+)"/;
-    $self->{'ipa_instance_id'} = $instance_id;
-
-
-    assert_script_run(
-        "ipa test ec2 "
-          . "--access-key-id '"
-          . get_required_var('PUBLIC_CLOUD_KEY_ID') . "' "
-          . "--secret-access-key '"
-          . get_required_var('PUBLIC_CLOUD_KEY_SECRET') . "' "
-          . "-D 'IPA test $ami_id' "
-          . "--distro sles "
-          . "-R '$instance_id' "
-          . "--region '$region' "
-          . "-u ec2-user "
-          . "--ssh-private-key-file QA_SSH_KEY.pem "
-          . "--ssh-key-name '" . $ssh_key_name . "' "
-          . "--results-dir ipa_results "
-          . get_ipa_tests(),
-        timeout => 600
-    );
-    delete $self->{'ipa_instance_id'};
-
-    ec2_cleanup;
-}
-
-sub az_run_ipa {
-    my ($self) = @_;
-
-    my $clientid      = get_required_var('PUBLIC_CLOUD_KEY_ID');
-    my $clientsecret  = get_required_var('PUBLIC_CLOUD_KEY_SECRET');
-    my $subscription  = get_required_var('PUBLIC_CLOUD_SUBSCRIPTION_ID');
-    my $tenantid      = get_required_var('PUBLIC_CLOUD_TENANT_ID');
-    my $image         = get_required_var('PUBLIC_CLOUD_IMAGE_ID');
-    my $instance_type = get_var('PUBLIC_CLOUD_INSTANCE_TYPE', 'Standard_A2');
-    my $region        = get_var('PUBLIC_CLOUD_REGION', 'westeurope');
-
-    my $credentials = <<EOT;
-{
-  "clientId": "$clientid", 
-  "clientSecret": "$clientsecret", 
-  "subscriptionId": "$subscription", 
-  "tenantId": "$tenantid", 
-  "activeDirectoryEndpointUrl": "https://login.microsoftonline.com", 
-  "resourceManagerEndpointUrl": "https://management.azure.com/", 
-  "activeDirectoryGraphResourceId": "https://graph.windows.net/", 
-  "sqlManagementEndpointUrl": "https://management.core.windows.net:8443/", 
-  "galleryEndpointUrl": "https://gallery.azure.com/", 
-  "managementEndpointUrl": "https://management.core.windows.net/"
-}
-EOT
-
-    save_tmp_file("azure_credentials.txt", $credentials);
-    assert_script_run('curl -O ' . autoinst_url . "/files/azure_credentials.txt");
-
-    assert_script_run('ssh-keygen -b 2048 -t rsa -q -N "" -f ~/.ssh/id_rsa');
-
-    assert_script_run(
-        "ipa test azure "
-          . "--service-account-file azure_credentials.txt "
-          . "-D 'IPA test $image' "
-          . "--distro sles "
-          . "--ssh-private-key-file ~/.ssh/id_rsa "
-          . "--region '$region' "
-          . "--results-dir ipa_results "
-          . "--cleanup "
-          . "--instance-type '$instance_type' "
-          . "-i '$image' "
-          . get_ipa_tests(),
-        timeout => 1200
-    );
-}
 
 sub run {
     my ($self) = @_;
 
     select_virtio_console();
 
-    if (check_var('PUBLIC_CLOUD_PROVIDER', 'EC2')) {
-        ec2_run_ipa($self);
-    }
-    elsif (check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {
-        az_run_ipa($self);
-    }
-    elsif (check_var('PUBLIC_CLOUD_PROVIDER', 'GOOGLE')) {
-        record_info('info', 'to be implemented');
-    }
-    else {
-        die('Unknown PUBLIC_CLOUD_PROVIDER given');
-    }
-    save_logs;
+    my $provider = $self->{provider} = $self->provider_factory();
+
+    my $ipa = $provider->ipa(
+        instance_type => get_var('PUBLIC_CLOUD_INSTANCE_TYPE'),
+        cleanup       => 1,
+        image_id      => $self->get_image_id($provider),
+        tests         => get_required_var('PUBLIC_CLOUD_IPA_TESTS'),
+        results_dir   => 'ipa_results'
+    );
+
+    upload_logs($ipa->{logfile});
+    parse_extra_log(IPA => $ipa->{results});
+
+    $provider->cleanup();
+    delete $self->{provider};
+    assert_script_run('rm -rf ipa_results');
+
+    # fail, if at least one test failed
+    die if ($ipa->{fail} > 0);
 }
 
 sub post_fail_hook {
     my ($self) = @_;
 
-    save_logs;
-
-    if (check_var('PUBLIC_CLOUD_PROVIDER', 'EC2')) {
-        ec2_cleanup($self);
+    if ($self->{provider}) {
+        $self->{provider}->cleanup();
     }
+
+    # upload logs on unexpected failure
+    my $ret = script_run('test -d ipa_results');
+    return if (!defined($ret) || $ret != 0);
+    assert_script_run('tar -zcvf ipa_results.tar.gz ipa_results');
+    upload_logs('ipa_results.tar.gz', failok => 1);
 }
 
 1;
@@ -223,7 +63,7 @@ sub post_fail_hook {
 This module use IPA tool to test public cloud SLE images.
 Logs are uploaded at the end.
 
-When running IPA from SLES, it must have a valid SCC registration to enable 
+When running IPA from SLES, it must have a valid SCC registration to enable
 public cloud module.
 
 The variables DISTRI, VERSION and ARCH must correspond to the system where
@@ -231,15 +71,18 @@ IPA get installed in and not to the public cloud image.
 
 =head1 Configuration
 
-=head2 PUBLIC_CLOUD_IMAGE_ID
+=head2 PUBLIC_CLOUD_IMAGE_ID or PUBLIC_CLOUD_IMAGE_LOCATION
 
 The image ID which is used to instantiate a VM and run tests on it.
-For azure, the name of the image, e.g. B<SUSE:SUSE-Manager-Server-BYOS:3.1:2018.08.27>.
+It is taken from C<PUBLIC_CLOUD_IMAGE_ID> or if not exists it will be retrived from CSP
+by searching for the file given with C<PUBLIC_CLOUD_IMAGE_LOCATION>.
+
+For azure, the name of the image, e.g. B<SLES12-SP4-Azure-BYOS.x86_64-0.9.0-Build3.23.vhd>.
 For ec2 the AMI, e.g. B<ami-067a77ef88a35c1a5>.
 
 =head2 PUBLIC_CLOUD_PROVIDER
 
-The type of the CSP (Cloud service provider). 
+The type of the CSP (Cloud service provider).
 
 =head2 PUBLIC_CLOUD_KEY_ID
 

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -38,13 +38,10 @@ sub run {
     my $provider = $self->{provider} = $self->provider_factory();
     $provider->init();
 
-    my $image_id = get_var('PUBLIC_CLOUD_IMAGE_ID');
-    $image_id //= $provider->find_img(get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION'));
-
     my $instance = $provider->ipa(
         instance_type => get_var('PUBLIC_CLOUD_INSTANCE_TYPE'),
         cleanup       => 0,
-        image_id      => $image_id
+        image_id      => $self->get_image_id($provider)
     );
 
     assert_script_run('curl ' . data_url('publiccloud/restart_instance.sh') . ' -o ~/restart_instance.sh');


### PR DESCRIPTION
We use the provider class and it's children to abstract the
differences of each CSP.
This change cleanup the ipa.pm testmodule to go the same approach.

- Related ticket: https://progress.opensuse.org/issues/30454
- Verification run: 
  - http://cfconrad-vm.qa.suse.de/tests/2354 (azure)
  - http://cfconrad-vm.qa.suse.de/tests/2356 (ec2)
