### PR TITLE
Add modules to supportserver

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -737,6 +737,12 @@ elsif (is_installcheck) {
 elsif (get_var("SUPPORT_SERVER")) {
     loadtest "support_server/login";
     loadtest "support_server/setup";
+    if (get_var("SUPPORT_SERVER_MODULES")) {
+        my @modules = split(/,/, get_var('SUPPORT_SERVER_MODULES', ''));
+        foreach my $module (@modules) {
+            loadtest "$module";
+        }
+    }
     if (get_var("REMOTE_CONTROLLER")) {
         loadtest "remote/remote_controller";
         load_inst_tests();


### PR DESCRIPTION
Enhancement poo#42950: Current implementation of supportserver setup
is done in one `setup.pm` file. If there is a need for new function,
file is updated and it grows. Supportserver modules were implemented
to avoid overuse of setup file. Behavior is controlled by variable
`SUPPORT_SERVER_MODULES` which contains list of modules to load.
Load order is same like order in variable.

- Related ticket: https://progress.opensuse.org/issues/42950
- Needles: none
- Verification run: http://10.100.12.105/tests/1131
Run was done with following configuration:
SUPPORT_SERVER_MODULES=console/consoletest_setup,console/hostname

PRO:
* current supportserver behavior is not impacted
* any existing module can be loaded, it means that code can be shared between normal tests and supportserver

CONS: 
* probably security issue, when test is loaded based on the variable content, can be mitigated by allowed modules definition in main.pm
* variable can be longer, if there are several modules defined




