### PR TITLE
Implement image checksum verification for svirt

### DIFF
--- a/tests/installation/data_integrity.pm
+++ b/tests/installation/data_integrity.pm
@@ -16,7 +16,10 @@ use testapi;
 use data_integrity_utils 'verify_checksum';
 
 sub run {
-    verify_checksum;
+    my $dir_path;
+    $dir_path = '/var/lib/libvirt/images/' if check_var('BACKEND', 'svirt');
+    $dir_path = get_var('HYPERV_DISK', 'D:') . '\\cache\\' if check_var('VIRSH_VMM_FAMILY', 'hyperv');
+    verify_checksum($dir_path);
 }
 
 1;


### PR DESCRIPTION
https://trello.com/c/ATxUsjcv/252-p3-enhance-image-download-mechanism-on-hyper-v

Check image SHA-256 checksum on svirt.

Validation runs:
* jeos-extratest@svirt-hyperv: http://nilgiri.suse.cz/tests/1659#step/data_integrity/3
* jeos-main@svirt-xen-hvm: http://nilgiri.suse.cz/tests/1654#step/data_integrity/3
* allpatterns@svirt-xen-pv: http://nilgiri.suse.cz/tests/1656#step/data_integrity/3
* lvm+RAID1@svirt-hyperv: http://nilgiri.suse.cz/tests/1660#step/data_integrity/3
* default_install@svirt-hyperv2012r2: http://nilgiri.suse.cz/tests/1664#step/data_integrity/3
* default@64bit: http://nilgiri.suse.cz/tests/1657#step/data_integrity/1
* jeos-main-de_DE@64bit-virtio-vga: http://nilgiri.suse.cz/tests/1662#step/data_integrity/1