### PR TITLE
Add KEEP_GRUB_TIMEOUT variable

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -992,7 +992,8 @@ sub load_inst_tests {
     if (installyaststep_is_applicable()) {
         loadtest "installation/installation_overview";
         # On Xen PV we don't have GRUB on VNC
-        loadtest "installation/disable_grub_timeout" unless check_var('VIRSH_VMM_TYPE', 'linux');
+        set_var('KEEP_GRUB_TIMEOUT', 1) if check_var('VIRSH_VMM_TYPE', 'linux');
+        loadtest "installation/disable_grub_timeout" unless get_var('KEEP_GRUB_TIMEOUT');
         if (check_var('VIDEOMODE', 'text') && check_var('BACKEND', 'ipmi')) {
             loadtest "installation/disable_grub_graphics";
         }


### PR DESCRIPTION
There are some machine configurations and/or specific hardware where disabling the grub timeout can lead to the system not booting once installation is completed (more info on the linked ticket).

As there is no way to properly know all scenarios where such a problem might occur, this pull request introduces the `KEEP_GRUB_TIMEOUT` variable to control when the `installation/disable_grub_timeout` is loaded during installations. Currently it is always loaded whenever `VIRSH_VMM_TYPE` is not `linux`.

- Related ticket: https://progress.opensuse.org/issues/42026#note-5
- Needles: N/A
- Verification runs:

1. Without `KEEP_GRUB_TIMEOUT` set: http://mango.suse.de/tests/537
2. With `KEEP_GRUB_TIMEOUT=0` set: http://mango.suse.de/tests/538
3. With `KEEP_GRUB_TIMEOUT=1` set: http://mango.suse.de/tests/539
