### PR TITLE
Handle fixed pkg name typo for update-test-trivial (was: update-test-trival)

### DIFF
--- a/tests/console/validate_packages_and_patterns.pm
+++ b/tests/console/validate_packages_and_patterns.pm
@@ -64,7 +64,11 @@ elsif (check_var('VALIDATE_PCM_PATTERN', 'aws')) {
     # Define more packages with the same set of expectations
     $software{'update-test-interactive'} = $software{'update-test-feature'};
     $software{'update-test-security'}    = $software{'update-test-feature'};
-    $software{'update-test-trival'}      = $software{'update-test-feature'};
+    if (is_sle('15+')) {
+        $software{'update-test-trivial'} = $software{'update-test-feature'};
+    } else {
+        $software{'update-test-trival'} = $software{'update-test-feature'};
+    }
 }
 
 sub verify_installation_and_repo {


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/40868
Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1113704

SLE12SP4: http://artemis.suse.de/tests/780
SLE15SP1: http://artemis.suse.de/tests/779