### PR TITLE
Improve yast2 vnc sync key presses

### DIFF
--- a/lib/yast2_shortcuts.pm
+++ b/lib/yast2_shortcuts.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Shortcuts for yast modules
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.com>
+
+package yast2_shortcuts;
+
+use strict;
+use warnings;
+use testapi;
+use version_utils qw(is_leap is_sle is_opensuse);
+
+use Exporter 'import';
+our @EXPORT_OK = qw($is_older_product %remote_admin %firewall_settings %firewall_details $confirm);
+
+our $is_older_product = is_sle('<15') || is_leap('<15.0');
+our %remote_admin = (
+    allow_remote_admin_with_session    => 'alt-a',
+    allow_remote_admin_without_session => 'alt-l',
+    do_not_allow_remote_admin          => 'alt-n'
+);
+our %firewall_settings = (
+    open_port => $is_older_product ? 'alt-p' : 'alt-f',
+    details => 'alt-d'
+);
+our %firewall_details = (
+    network_interfaces => 'alt-e',
+    select_all         => 'alt-a'
+);
+our $confirm = $is_older_product ? $cmd{ok} : $cmd{next};
+
+1;

--- a/tests/console/yast2_vnc.pm
+++ b/tests/console/yast2_vnc.pm
@@ -52,17 +52,6 @@ sub check_service_listening {
     }
 }
 
-sub check_firewall_open_vnc {
-    my $cmd_check_firewall = 'firewall-cmd --list-services | grep \'tigervnc tigervnc-https\'';
-    if (script_run($cmd_check_firewall)) {
-        record_soft_failure 'boo#1088647 - firewalld does not create rule for vnc';
-        assert_script_run('firewall-cmd --zone=public --add-service=tigervnc --permanent');
-        assert_script_run('firewall-cmd --zone=public --add-service=tigervnc-https --permanent');
-        assert_script_run('firewall-cmd --reload');
-        assert_script_run($cmd_check_firewall);
-    }
-}
-
 sub test_setup {
     select_console 'root-console';
     assert_script_run("if ! systemctl -q is-active network; then systemctl -q start network; fi");
@@ -74,13 +63,10 @@ sub test_setup {
 }
 
 sub run {
-    my $self = shift;
-
     test_setup;
     configure_remote_admin;
     return if check_var('ARCH', 's390x');    # exit here as port is already open for s390x
     check_service_listening;
-    check_firewall_open_vnc if ($self->firewall eq 'firewalld');
 }
 
 1;

--- a/tests/console/yast2_vnc.pm
+++ b/tests/console/yast2_vnc.pm
@@ -7,70 +7,42 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Add test for yast2 vnc
-# Maintainer: Zaoliang Luo <zluo@suse.de>
+# Summary: Configure remote administration with yast2 vnc
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.com>
 
 use strict;
 use base "console_yasttest";
 use testapi;
 use utils;
-use version_utils qw(is_leap is_sle);
 use registration 'add_suseconnect_product';
+use yast2_shortcuts qw($is_older_product %remote_admin %firewall_settings %firewall_details $confirm);
 
-sub open_firewall_port {
-    # open port in firewall if it is enabled and check network interfaces, check long text by send key right.
-    assert_screen [qw(yast2_vnc_open_port_firewall yast2_vnc_firewall_port_closed)];
-    if (match_has_tag 'yast2_vnc_open_port_firewall' && (is_sle('<15') || is_leap('<15.0'))) {
-        send_key 'alt-p';
-        send_key 'alt-d';
-        assert_screen 'yast2_vnc_firewall_port_details';
-        send_key 'alt-e';
-        for (1 .. 5) { send_key 'right'; }
-        send_key 'alt-a';
-        send_key 'alt-o';
-    }
-    elsif (match_has_tag 'yast2_vnc_firewall_port_closed') {
-        send_key 'alt-f';    # Open port
-        assert_screen 'yast2_vnc_firewall_port_open';
-    }
+sub configure_remote_admin {
+    # Remote Administration Settings
+    assert_screen 'yast2_vnc_remote_administration';
+    return if check_var('ARCH', 's390x');
+    send_key $remote_admin{allow_remote_admin_with_session};
+    assert_screen 'yast2_vnc_allow_remote_admin_with_session';
+    # Firewall Settings
+    assert_screen 'yast2_vnc_firewall_port_closed';
+    send_key $firewall_settings{open_port};
+    # Firewall Details
+    assert_screen 'yast2_vnc_firewall_port_open';
+    send_key $firewall_settings{details};
+    assert_screen 'yast2_vnc_firewall_port_details';
+    send_key $firewall_details{network_interfaces};
+    assert_screen 'yast2_vnc_firewall_details_interface_selected';
+    send_key $cmd{ok};
+    assert_screen 'yast2_vnc_firewall_details_selected';
+    # Confirm configuration
+    send_key $confirm;
+    assert_screen 'yast2_vnc_warning_text';
+    send_key $cmd{ok};
+    wait_serial('yast2-remote-status-0', 60) || die "'yast2 remote' didn't finish";
 }
 
-sub run {
-    my $self = shift;
-    select_console 'root-console';
-
-    # check network at first
-    assert_script_run("if ! systemctl -q is-active network; then systemctl -q start network; fi");
-
-    # install components to test plus dependencies for checking
-    my $packages = 'vncmanager xorg-x11';
-    # netstat is deprecated in newer versions, use 'ss' instead
-    my $older_products = is_sle('<15') || is_leap('<15.0');
-    $packages .= ' net-tools' if $older_products;
-    if (check_var('ARCH', 's390x') && !$older_products) {
-        add_suseconnect_product('sle-module-desktop-applications', undef, undef, undef, 180);
-    }
-    zypper_call("in $packages");
-
-    # start Remote Administration configuration
-    script_run("yast2 remote; echo yast2-remote-status-\$? > /dev/$serialdev", 0);
-
-    # check Remote Administration VNC got started
-    assert_screen 'yast2_vnc_remote_administration';
-
-    unless (check_var('ARCH', 's390x')) {
-        send_key 'alt-a';    # enable remote administration
-        open_firewall_port;
-    }
-    send_key($older_products ? $cmd{ok} : $cmd{next});
-    # confirm with OK for Warning dialogue
-    assert_screen 'yast2_vnc_warning_text';
-    send_key 'alt-o';
-    wait_serial('yast2-remote-status-0', 60) || die "'yast2 remote' didn't finish";
-    return if check_var('ARCH', 's390x');    # exit here as port is already open for s390x
-
-    # Check service listening
-    my $cmd_check_port = $older_products ? 'netstat' : 'ss' . ' -tln | grep -E LISTEN.*:5901';
+sub check_service_listening {
+    my $cmd_check_port = $is_older_product ? 'netstat' : 'ss -tln | grep -E LISTEN.*:5901';
     if (script_run($cmd_check_port)) {
         record_soft_failure 'boo#1088646 - service vncmanager is not started automatically';
         systemctl('status vncmanager', expect_false => 1);
@@ -78,17 +50,37 @@ sub run {
         systemctl('status vncmanager');
         assert_script_run $cmd_check_port;
     }
-    # Check firewall open for vnc
-    if ($self->firewall eq 'firewalld') {
-        my $cmd_check_firewall = 'firewall-cmd --list-services | grep \'tigervnc tigervnc-https\'';
-        if (script_run($cmd_check_firewall)) {
-            record_soft_failure 'boo#1088647 - firewalld does not create rule for vnc';
-            assert_script_run('firewall-cmd --zone=public --add-service=tigervnc --permanent');
-            assert_script_run('firewall-cmd --zone=public --add-service=tigervnc-https --permanent');
-            assert_script_run('firewall-cmd --reload');
-            assert_script_run($cmd_check_firewall);
-        }
+}
+
+sub check_firewall_open_vnc {
+    my $cmd_check_firewall = 'firewall-cmd --list-services | grep \'tigervnc tigervnc-https\'';
+    if (script_run($cmd_check_firewall)) {
+        record_soft_failure 'boo#1088647 - firewalld does not create rule for vnc';
+        assert_script_run('firewall-cmd --zone=public --add-service=tigervnc --permanent');
+        assert_script_run('firewall-cmd --zone=public --add-service=tigervnc-https --permanent');
+        assert_script_run('firewall-cmd --reload');
+        assert_script_run($cmd_check_firewall);
     }
+}
+
+sub test_setup {
+    select_console 'root-console';
+    assert_script_run("if ! systemctl -q is-active network; then systemctl -q start network; fi");
+    if (check_var('ARCH', 's390x') && !$is_older_product) {
+        add_suseconnect_product('sle-module-desktop-applications', undef, undef, undef, 180);
+    }
+    zypper_call('in vncmanager xorg-x11' . ($is_older_product ? ' net-tools' : ''));
+    script_run("yast2 remote; echo yast2-remote-status-\$? > /dev/$serialdev", 0);
+}
+
+sub run {
+    my $self = shift;
+
+    test_setup;
+    configure_remote_admin;
+    return if check_var('ARCH', 's390x');    # exit here as port is already open for s390x
+    check_service_listening;
+    check_firewall_open_vnc if ($self->firewall eq 'firewalld');
 }
 
 1;

--- a/tools/detect_code_dups
+++ b/tools/detect_code_dups
@@ -102,11 +102,13 @@ sub __get_text {
         $statement->delete;
     }
     }
-    # test_flags are duplicates
-    for my $sub (@{$Document->find('PPI::Statement::Sub')}) {
-    if ($sub->name eq 'test_flags') {
-        $sub->delete;
-    }
+
+    # check if file contains any sub-routine declaration
+    for my $sub (@{$Document->find('PPI::Statement::Sub') || []}) {
+        # test_flags can be duplicates, ignore them
+        if ($sub->name eq 'test_flags') {
+            $sub->delete;
+        }
     }
 
     #my $lines = _dump($Document, []);
@@ -156,7 +158,7 @@ my $last_lcp = 0;
 
     # filter out when the lcp for this index is smaller than our requested minimal length
     my $lcp;    # length of match
-    my $res = ($lcp = Code::DRY::get_len_at($_)) >= $minlength; 
+    my $res = ($lcp = Code::DRY::get_len_at($_)) >= $minlength;
 
     $res = $res && $lcp != $last_lcp;
 


### PR DESCRIPTION
Improve yast2 vnc sync key presses.

- Related ticket: https://progress.opensuse.org/issues/41192
- Needles: 
  - [~needles SLE~](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/974)
  - [~needles openSUSE~](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/461)
- Verification run:
  - [sle-15-SP1-yast2_ncurses yast2_vnc](http://dhcp42.suse.cz/tests/538#step/yast2_vnc/18)
  - [sle-12-SP4-yast2_ncurses yast2_vnc](http://dhcp42.suse.cz/tests/543#step/yast2_vnc/18)
  - [Tumbleweed-yast2_ncurses yast2_vnc](http://dhcp42.suse.cz/tests/557#step/yast2_vnc/24)
  - [Leap-15.1-yast2_ncurses yast2_vnc](http://dhcp42.suse.cz/tests/558#step/yast2_vnc/24)