### PR TITLE
Move gnucash to extra-tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1284,7 +1284,6 @@ sub load_x11tests {
     }
     if (is_opensuse && !is_livesystem) {
         if (!is_staging) {
-            loadtest "x11/gnucash";
             loadtest "x11/hexchat";
         }
         loadtest "x11/vlc";
@@ -1425,6 +1424,7 @@ sub load_extra_tests_desktop {
         }
         # wine is only in openSUSE for various reasons, including legal ones
         loadtest 'x11/wine' if get_var('ARCH', '') =~ /x86_64|i586/;
+        loadtest "x11/gnucash";
 
     }
     # the following tests care about network and need some DE specific


### PR DESCRIPTION
GnuCash is annoying enough to 'fail often' (for valid reasons) - but there
is no need to test it in every possible desktop scenario. Having it as part
of the extra_tests_on_* is perfectly sufficient and representative enough.

