### PR TITLE
Fix libreoffice base installing on tumbleweed in regression-documentation

### DIFF
--- a/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
@@ -93,6 +93,7 @@ sub run {
     # launch components from Activities overview
     $self->open_overview();
     type_string "base";
+    wait_still_screen 10;
     # tag is base-install means libreoffice-base not installed
     if (check_screen 'base-install') {
         send_key 'esc';


### PR DESCRIPTION
Libreoffice base installation check fails as we did not wait untill typing finishesl. Add `wait_still_screen 10` in order that typing is finished. 

- Related ticket: https://progress.opensuse.org/issues/23780
- Verification run: http://10.67.18.38/tests/83#step/libreoffice_mainmenu_components/2
