### PR TITLE
Fix gnome-tweak-tool command name change on tumbleweed

### DIFF
--- a/tests/x11/gnomecase/application_starts_on_login.pm
+++ b/tests/x11/gnomecase/application_starts_on_login.pm
@@ -14,7 +14,7 @@ use base "x11test";
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_leap sle_version_at_least);
+use version_utils qw(is_leap is_tumbleweed sle_version_at_least);
 
 sub tweak_startupapp_menu {
     my ($self) = @_;
@@ -26,7 +26,10 @@ sub tweak_startupapp_menu {
     }
     else {
         # tweak-tool entry is not in gnome-control-center of SLE15;
-        x11_start_program 'gnome-tweak-tool';
+	if (is_tumbleweed) {
+	       	x11_start_program 'gnome-tweaks';
+	}
+	else x11_start_program 'gnome-tweak-tool';
     }
     assert_screen "tweak-tool";
     # increase the default timeout - the switching can be slow


### PR DESCRIPTION
Command name `gnome-tweak-tool` has been changed into `gnome-tweaks` on tumbleweed due to a newer gnome version. 
Add judgement so that the correct command name `gnome-tweaks` would be used on tumbleweed. 

- Related ticket: https://progress.opensuse.org/issues/38969
- Verification run: http://10.67.18.38/tests/88#step/application_starts_on_login/3
