### PR TITLE
Fix scrolling in yast2 scc - 2nd try

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -23,6 +23,7 @@ use strict;
 use testapi;
 use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl);
 use version_utils qw(is_sle is_caasp sle_version_at_least is_sle12_hdd_in_upgrade);
+use constant ADDONS_COUNT => 50;
 
 our @EXPORT = qw(
   add_suseconnect_product
@@ -182,6 +183,23 @@ sub assert_registration_screen_present {
     }
 }
 
+sub verify_preselected_modules {
+    my $modules_needle = shift;
+
+    return if check_screen($modules_needle, 30);    # pre-selected modules visible without scrolling
+    my @modules = ('basesystem', 'server', split(/,/, get_var('ADDONS', '')));
+    my @needles = map { 'addon-' . $_ } @modules;
+    for (1 .. ADDONS_COUNT) {
+        check_screen \@needles, 0;
+        for my $needle (@needles) {
+            @needles = grep { $_ ne $needle } @needles if match_has_tag($needle);
+        }
+        last if (!@needles || check_screen('scrolled-to-bottom', 0));
+        send_key('down');
+    }
+    die 'Scroll reached to bottom not finding individual needles for each module.' if @needles;
+}
+
 sub fill_in_registration_data {
     my ($addon, $uc_addon);
     fill_in_reg_server() if (!get_var("HDD_SCC_REGISTERED"));
@@ -193,7 +211,7 @@ sub fill_in_registration_data {
       import-untrusted-gpg-key-idv-key-A5665AC46976A827
     );
     unless (get_var('SCC_REGISTER', '') =~ /addon|network/) {
-        my $counter = 50;
+        my $counter = ADDONS_COUNT;
         my @tags
           = qw(local-registration-servers registration-online-repos import-untrusted-gpg-key module-selection contacting-registration-server refreshing-repository);
         if (get_var('SCC_URL') || get_var('SMT_URL')) {
@@ -265,7 +283,7 @@ sub fill_in_registration_data {
             assert_screen('scc-beta-filter-checkbox');
             send_key('alt-i');
         }
-        assert_screen($modules_needle);
+        verify_preselected_modules($modules_needle);
         # Add desktop module for SLES if desktop is gnome
         # Need desktop application for minimalx to make change_desktop work
         if (check_var('SLE_PRODUCT', 'sles')
@@ -310,7 +328,7 @@ sub fill_in_registration_data {
                 assert_screen('scc-beta-filter-unchecked');
             }
             my @scc_addons = split(/,/, get_var('SCC_ADDONS', ''));
-            # remove emty elements
+            # remove empty elements
             @scc_addons = grep { $_ ne '' } @scc_addons;
 
             for my $addon (@scc_addons) {
@@ -339,7 +357,7 @@ sub fill_in_registration_data {
                             next;
                         }
                     }
-                    send_key_until_needlematch ["scc-module-$addon", "scc-module-$addon-selected"], "down", 40;
+                    send_key_until_needlematch ["scc-module-$addon", "scc-module-$addon-selected"], "down", ADDONS_COUNT;
                     if (match_has_tag("scc-module-$addon")) {
                         # checkmark the requested addon
                         assert_and_click "scc-module-$addon";
@@ -356,7 +374,7 @@ sub fill_in_registration_data {
                 assert_screen 'scc-registration-already-registered';
                 wait_screen_change { send_key $cmd{next} };
                 for my $addon (@scc_addons) {
-                    assert_screen "scc-module-$addon-selected";
+                    send_key_until_needlematch "scc-module-$addon-selected", "down", ADDONS_COUNT;
                 }
             }
             wait_screen_change { send_key $cmd{next} };    # all addons selected
@@ -370,7 +388,7 @@ sub fill_in_registration_data {
                 wait_still_screen 2;
             }
             # start addons/modules registration, it needs longer time if select multiple or all addons/modules
-            my $counter = 50;
+            my $counter = ADDONS_COUNT;
             while ($counter--) {
                 die 'Addon registration repeated too much. Check if SCC is down.' if ($counter eq 1);
                 assert_screen [

--- a/tests/installation/addon_products_via_SCC_yast2.pm
+++ b/tests/installation/addon_products_via_SCC_yast2.pm
@@ -15,26 +15,26 @@ use base qw(y2logsstep y2x11test);
 use strict;
 use testapi;
 use registration 'fill_in_registration_data';
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 use utils 'turn_off_gnome_screensaver';
 
+=head2 test_setup
+Define proxy SCC. For SLE 15 we need to clean existing registration
+=cut
 sub test_setup {
     select_console 'root-console';
-    my $proxy_scc;
-    if (sle_version_at_least '15') {
-        # Remove registration from the system
-        assert_script_run 'SUSEConnect --clean';
-        # Define proxy SCC
-        assert_script_run 'echo "url: ' . get_var('SCC_URL') . '" > /etc/SUSEConnect';
-    }    # add every used addon to regurl for proxy SCC
+    if (is_sle('>=15')) {
+        assert_script_run 'SUSEConnect --clean';                                          # Remove registration from the system
+        assert_script_run 'echo "url: ' . get_var('SCC_URL') . '" > /etc/SUSEConnect';    # Define proxy SCC
+    }
     elsif (get_var('SCC_ADDONS')) {
+        # Add every used addon to regurl for proxy SCC
         my @addon_proxy = ("url: http://server-" . get_var('BUILD_SLE'));
         for my $addon (split(/,/, get_var('SCC_ADDONS', ''))) {
-            my $uc_addon = uc $addon;    # change to uppercase to match variable
+            my $uc_addon = uc $addon;                                                     # change to uppercase to match variable
             push(@addon_proxy, "\b.$addon-" . get_var("BUILD_$uc_addon"));
         }
-        # Define proxy SCC
-        assert_script_run "echo \"@addon_proxy.proxy.scc.suse.de\" > /etc/SUSEConnect";
+        assert_script_run "echo \"@addon_proxy.proxy.scc.suse.de\" > /etc/SUSEConnect";    # Define proxy SCC
     }
     turn_off_gnome_screensaver;
     select_console 'x11';
@@ -42,7 +42,8 @@ sub test_setup {
 
 sub run {
     my ($self) = @_;
-    test_setup;                          # Define proxy SCC. For SLE 15 we need to clean existing registration.
+
+    test_setup;
     $self->launch_yast2_module_x11('scc', target_match => [qw(scc-registration packagekit-warning)], maximize_window => 1);
     if (match_has_tag 'packagekit-warning') {
         send_key 'alt-y';


### PR DESCRIPTION
It re-adds the logic reverted in #6076 for scrolling ~and fix a wrong refactored logic to determine properly if it is beta or not. Now it would soft-fails if finds the checkbox, which makes more sense, so when `modules-preselected-<sle_product>` will not be able to match in one shot in future~, function  `verify_preselected` can be used (or adapted) to check one by one.

- Related ticket: https://progress.opensuse.org/issues/42014
- Verification run:
  - [sle-15-Desktop-openssh-qam-allpatterns](http://dhcp42.suse.cz/tests/546#step/scc_registration/14)
  - [sle-15-SP1-sles+sdk+proxy_SCC_via_YaST](http://dhcp42.suse.cz/tests/548#step/addon_products_via_SCC_yast2/34) 
  - [sle-12-SP4-sles+sdk+proxy_SCC_via_YaST](http://dhcp42.suse.cz/tests/549#step/addon_products_via_SCC_yast2/29)