### PR TITLE
system_workarounds: disable watchdog permanently

### DIFF
--- a/tests/installation/system_workarounds.pm
+++ b/tests/installation/system_workarounds.pm
@@ -17,10 +17,11 @@ use base 'opensusebasetest';
 sub run {
     select_console('root-console');
 
-    # boo#1105302 - Disable kernel watchdog on aarch64
+    # boo#1105302 - Disable kernel watchdog on aarch64 (for running system and for next boot)
     if (check_var('ARCH', 'aarch64')) {
         record_info('boo#1105302', "Disable kernel watchdog to avoid test failures due to 'watchdog: BUG: soft lockup - CPU#0 stuck for XXs!'");
         assert_script_run('echo 0 > /proc/sys/kernel/watchdog_thresh');
+        assert_script_run('echo "kernel.watchdog_thresh = 0" > /etc/sysctl.d/watchdog.conf');
     }
 }
 


### PR DESCRIPTION
not only for the current live system.

It will fix https://openqa.opensuse.org/tests/783004#step/consoletest_finish/3
