### PR TITLE
Harden firefox pop-up check

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -613,11 +613,13 @@ sub firefox_check_default {
     }
 }
 
+# Check whether there are any pop up windows and handle them one by one
 sub firefox_check_popups {
-    # Check whether there are any pop up windows and handle them one by one
-    for (1 .. 2) {
-        # assert loaded webpage
-        assert_screen 'firefox-url-loaded', 60;
+    # assert loaded webpage
+    assert_screen 'firefox-url-loaded', 90;
+    for (1 .. 3) {
+        # slow down loop and give firefox time to show pop-up
+        sleep 5;
         # check pop-ups
         assert_screen [qw(firefox_trackinfo firefox_readerview_window firefox-launch)];
         # handle the tracking protection pop up


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/2197378#step/firefox/13
- Related ticket: https://progress.opensuse.org/issues/42776
- Verification run: http://10.100.12.155/tests/8486#step/firefox/10
