### PR TITLE
publiccloud: avoid running upload_img in ipa and ltp tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2068,10 +2068,18 @@ sub load_toolchain_tests {
 }
 
 sub load_publiccloud_tests {
-    loadtest "publiccloud/prepare_tools" if get_var('PUBLIC_CLOUD_PREPARE_TOOLS');
-    loadtest "publiccloud/upload_image"  if get_var('PUBLIC_CLOUD_IMAGE_LOCATION');
-    loadtest "publiccloud/ipa"           if get_var('PUBLIC_CLOUD_IPA_TESTS');
-    loadtest 'publiccloud/run_ltp'       if get_var('PUBLIC_CLOUD_LTP');
+    if (get_var('PUBLIC_CLOUD_PREPARE_TOOLS')) {
+        loadtest "publiccloud/prepare_tools";
+    }
+    elsif (get_var('PUBLIC_CLOUD_IPA_TESTS')) {
+        loadtest "publiccloud/ipa";
+    }
+    elsif (get_var('PUBLIC_CLOUD_LTP')) {
+        loadtest 'publiccloud/run_ltp';
+    }
+    elsif (get_var('PUBLIC_CLOUD_IMAGE_LOCATION')) {
+        loadtest "publiccloud/upload_image";
+    }
 }
 
 sub load_common_opensuse_sle_tests {

--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -53,11 +53,12 @@ sub provider_factory {
 }
 
 sub get_image_id {
-    my ($provider) = @_;
-
-    my $image_id = get_var('PUBLIC_CLOUD_IMAGE_ID');
-    $image_id //= $provider->find_img(get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION'));
-    die('Missing valid image_id') unless ($image_id);
+    my ($self, $provider) = @_;
+    my $img_url    = get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION');
+    my ($img_name) = $img_url =~ /([^\/]+)$/;
+    my $image_id   = $provider->find_img($img_name);
+    die("Image $img_name is not available in the cloud provider") unless ($image_id);
+    set_var('PUBLIC_CLOUD_IMAGE_ID', $image_id);
     return $image_id;
 }
 

--- a/tests/publiccloud/ipa.pm
+++ b/tests/publiccloud/ipa.pm
@@ -22,6 +22,7 @@ sub run {
     select_virtio_console();
 
     my $provider = $self->{provider} = $self->provider_factory();
+    $provider->init;
 
     my $ipa = $provider->ipa(
         instance_type => get_var('PUBLIC_CLOUD_INSTANCE_TYPE'),
@@ -114,4 +115,3 @@ This is B<only for azure> and used to create the service account file.
 This is B<only for azure> and used to create the service account file.
 
 =cut
-

--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -22,33 +22,9 @@ use publiccloud::ec2;
 use publiccloud::azure;
 use publiccloud::gce;
 
-sub prepare_os {
-
-    if (is_sle) {
-        my $modver = get_required_var('VERSION') =~ s/-SP\d+//r;
-        add_suseconnect_product('sle-module-public-cloud', $modver);
-    }
-
-    if (check_var('PUBLIC_CLOUD_PROVIDER', 'EC2')) {
-        if (is_sle) {
-            # disable Cloud_tools for this test
-            zypper_call('rr Cloud_Tools');
-            if (script_run('pip list | grep awscli') == 0) {
-                assert_script_run('pip uninstall -y awscli');
-            }
-            zypper_call('ref');
-            zypper_call('in aws-cli');
-        }
-        zypper_call('in python-ec2uploadimg');
-        assert_script_run("curl " . data_url('publiccloud/ec2utils.conf') . " -o /root/.ec2utils.conf");
-    }
-}
-
 sub run {
     my ($self) = @_;
     select_virtio_console();
-
-    prepare_os();
 
     my $provider = $self->{provider} = $self->provider_factory();
     $provider->init;


### PR DESCRIPTION
upload_img is executed always as a single module before running ipa and ltp tests. This avoids running upload_img again in those tests to get the image. 

- prepare_tools: http://fromm.arch.suse.de/tests/2785
- EC2:
http://fromm.arch.suse.de/tests/2770
http://fromm.arch.suse.de/tests/2771
http://fromm.arch.suse.de/tests/2772
http://fromm.arch.suse.de/tests/2773

- GCE:
http://fromm.arch.suse.de/tests/2778
http://fromm.arch.suse.de/tests/2781
http://fromm.arch.suse.de/tests/2779
http://fromm.arch.suse.de/tests/2780

- AZURE:
http://fromm.arch.suse.de/tests/2774
http://fromm.arch.suse.de/tests/2775
http://fromm.arch.suse.de/tests/2777
http://fromm.arch.suse.de/tests/2776