### PR TITLE
Update salt test for JeOS

### DIFF
--- a/tests/console/salt.pm
+++ b/tests/console/salt.pm
@@ -16,11 +16,11 @@ use base "consoletest";
 use strict;
 use testapi;
 use utils qw(zypper_call pkcon_quit systemctl);
-use version_utils 'is_jeos';
+use version_utils qw(is_jeos is_opensuse);
 use registration 'add_suseconnect_product';
 
 sub run {
-    if (is_jeos) {
+    if (is_jeos && !is_opensuse) {
         select_console 'root-console';
         my $version = get_required_var('VERSION') =~ s/([0-9]+).*/$1/r;
         if ($version == '12') {


### PR DESCRIPTION
Update salt test so SUSEConnect is not called on opensuse

Progress ticket: https://progress.opensuse.org/issues/42956
Validation runs: http://ccret.suse.cz/tests/1566, http://ccret.suse.cz/tests/1564
