### PR TITLE
Ignore failure when stopping serial-getty service

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -215,7 +215,12 @@ sub unlock_if_encrypted {
 sub systemctl {
     my ($command, %args) = @_;
     my $expect_false = $args{expect_false} ? '!' : '';
-    assert_script_run "$expect_false systemctl --no-pager $command", timeout => $args{timeout}, fail_message => $args{fail_message};
+    my @script_params = ("$expect_false systemctl --no-pager $command", timeout => $args{timeout}, fail_message => $args{fail_message});
+    if ($args{ignore_failure}) {
+        script_run(@script_params);
+    } else {
+        assert_script_run(@script_params);
+    }
 }
 
 sub turn_off_kde_screensaver {

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -27,7 +27,7 @@ sub run {
 
     # Stop serial-getty on serial console to avoid serial output pollution with login prompt
     # Doing early due to bsc#1103199 and bsc#1112109
-    systemctl "stop serial-getty\@$testapi::serialdev";
+    systemctl "stop serial-getty\@$testapi::serialdev", ignore_failure => 1;
     systemctl "disable serial-getty\@$testapi::serialdev";
     # Mask if is qemu backend as use serial in remote installations e.g. during reboot
     systemctl "mask serial-getty\@$testapi::serialdev" if check_var('BACKEND', 'qemu');


### PR DESCRIPTION
Introduced mitigation still fails, but as it's first command issued for
the console setup we can force it's execution without failing test
module and trying to proceed further.

See [poo#42359](https://progress.opensuse.org/issues/42359).

[Verification run](http://g226.suse.de/tests/2995).