### PR TITLE
Use specific needle tag to avoid false match

### DIFF
--- a/tests/x11/firefox/firefox_changesaving.pm
+++ b/tests/x11/firefox/firefox_changesaving.pm
@@ -59,7 +59,7 @@ sub run {
     assert_script_run 'cp dfa dfb';
     assert_script_run 'rm -vf df*';    #Clear
 
-    send_key_until_needlematch 'firefox-url-loaded', 'alt-tab';    #Switch to firefox
+    send_key_until_needlematch 'firefox-preferences', 'alt-tab';    #Switch to firefox
 
     $self->exit_firefox;
 }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/43061
- Verification run: http://10.100.12.155/tests/8508#step/firefox_changesaving/21
