### PR TITLE
Wait before clicking on rss subscribe icon

### DIFF
--- a/tests/x11/firefox/firefox_rss.pm
+++ b/tests/x11/firefox/firefox_rss.pm
@@ -35,8 +35,8 @@ sub run {
 
     $self->firefox_open_url('https://linux.slashdot.org/');
     assert_and_click("slashdot-cookies-agree") if check_screen("slashdot-cookies", 0);
-
-    assert_and_click "firefox-rss-button_enabled", "left", 30;
+    wait_still_screen 3;
+    assert_and_click "firefox-rss-button_enabled", "left";
     assert_screen("firefox-rss-page", 60);
 
     # Exit


### PR DESCRIPTION
It possibly causes occasional failures, when for some reason wrong URL
is loaded for subscription + remove default timeout

- Related ticket: https://progress.opensuse.org/issues/42938
- Verification run: http://10.100.12.155/tests/8515
