### PR TITLE
publiccloud: Fix upload on demand images for EC2

### DIFF
--- a/data/publiccloud/ec2utils.conf
+++ b/data/publiccloud/ec2utils.conf
@@ -81,7 +81,8 @@ user = ec2-user
 # ssh_private_key =
 
 [region-eu-central-1]
-ami = ami-bc5b48d0
+# suse-sles-12-sp3-v20181004-hvm-ssd-x86_64
+ami = ami-0fa9bde3f3d40e5ae
 instance_type = t2.micro
 aki_i386 = aki-3e4c7a23
 aki_x86_64 = aki-184c7a05

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -84,6 +84,7 @@ sub upload_img {
           . "--machine 'x86_64' "
           . "-n '" . $self->prefix . '-' . $img_name . "' "
           . (($img_name =~ /hvm/i) ? "--virt-type hvm --sriov-support " : "--virt-type para ")
+          . (($img_name !~ /byos/i) ? '--use-root-swap ' : '')
           . "--verbose "
           . "--regions '" . $self->region . "' "
           . "--ssh-key-pair '" . $self->ssh_key . "' "


### PR DESCRIPTION
Uploading on demand images for EC2 need a helper VM which is
on-demand and the option --use-root-swap

- Related ticket: https://progress.opensuse.org/issues/43214
- Verification run: 
  - http://cfconrad-vm.qa.suse.de/tests/2414 (upload_image)
  - http://cfconrad-vm.qa.suse.de/tests/2415 (ipa)
