### PR TITLE
Fix desktopapps-documentation

### DIFF
--- a/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
@@ -93,8 +93,9 @@ sub run {
     # launch components from Activities overview
     $self->open_overview();
     type_string "base";
+    assert_screen([qw(base-install overview-office-base)]);
     # tag is base-install means libreoffice-base not installed
-    if (check_screen 'base-install') {
+    if (match_has_tag 'base-install') {
         send_key 'esc';
         send_key 'esc';
         x11_start_program('xterm');


### PR DESCRIPTION
Regarding reason for the script change, `wait_still_screen;` failed before meanwhile only a longer wait for 10 seconds `wait_still_screen 10;` passed the test. As for now, `wait_still_screen` without specifying waiting time amazingly passed the test. 

- Related ticket: https://progress.opensuse.org/issues/23780
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/464
- Verification run: http://10.67.18.38/tests/106

Thank you for your patience. 