### PR TITLE
Update lifecycle expiration date for gcc7

### DIFF
--- a/tests/console/zypper_lifecycle_toolchain.pm
+++ b/tests/console/zypper_lifecycle_toolchain.pm
@@ -27,8 +27,8 @@ sub run {
         gcc5      => 'Now',
         libada5   => 'Now',
         gcc6      => 'Now',
-        gcc7      => '2024-10-30',
-        libada7   => '2024-10-30',
+        gcc7      => '2019-04-30',
+        libada7   => '2019-04-30',
         toolchain => '2024-10-30',
     );
 


### PR DESCRIPTION
Fix poo#43217: Lifecycle expiration was recently changed for gcc7
in toolchain module. New date is 2019-04-30.

- Related ticket: https://progress.opensuse.org/issues/43217
- Needles: none
- Verification run: http://10.100.12.105/tests/1163#step/zypper_lifecycle_toolchain/23
Although verification failed, it actually discovered bug  https://bugzilla.suse.com/show_bug.cgi?id=1114275.
