### PR TITLE
Build scc_url according to content of scc_addons on sle12

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -500,6 +500,14 @@ sub registration_bootloader_cmdline {
     # https://www.suse.com/documentation/smt11/book_yep/data/smt_client_parameters.html
     # SCC_URL=https://smt.example.com
     if (my $url = get_var('SMT_URL') || get_var('SCC_URL')) {
+        # build scc_url for sle12 from addons with different build no
+        # http://Server-0451.proxy.scc.suse.de -> http://Server-0451.wsm-0451.sdk-0351.proxy.scc.suse.de
+        if (is_sle('<15') && get_var('SCC_ADDONS')) {
+            my $sdk_num    = get_var('BUILD_SDK');
+            my $url_addons = '.';
+            $url_addons .= "sdk" . "-" . "$sdk_num." if (get_var('SCC_ADDONS') =~ m/sdk/);
+            $url =~ s/\./$url_addons/;
+        }
         my $cmdline = " regurl=$url";
         $cmdline .= " regcert=$url" if get_var('SCC_CERT');
         return $cmdline;


### PR DESCRIPTION
<del>Build numbers differ on most of sle12sp4 modules from the major build number, which puts extra requirements for regurl. In this case we need to specify each module with its build number to the scc explicitly, using ``http://<PRODUCT-NAME1>-<BUILD-NUMBER1>.<PRODUCT-NAME2>-<BUILD-NUMBER2>...<PRODUCT-NAMEn>-<BUILD-NUMBERn>.proxy.scc.suse.de`` pattern.
The list of additional products to be registered are taken from ``SCC_ADDONS`` variable. </del>

Works only for sdk

- Related ticket: [[functional][y] textmode+wsm on SLE12SP4 needs to use proxy-SCC for SDK repo as well](https://progress.opensuse.org/issues/41078)
- Verification run:
  * [sle-12-SP4-Server-DVD-x86_64-Build0451-wsm+textmode@64bit](http://dhcp128.suse.cz/tests/7472#step/zypper_lr/3)

