### PR TITLE
Add templated autoyast installation for QAM tests

### DIFF
--- a/data/autoyast_qam/12-SP1_installation.xml.ep
+++ b/data/autoyast_qam/12-SP1_installation.xml.ep
@@ -1,0 +1,1 @@
+basic_installation.xml.ep

--- a/data/autoyast_qam/12-SP2_installation.xml.ep
+++ b/data/autoyast_qam/12-SP2_installation.xml.ep
@@ -1,0 +1,1 @@
+basic_installation.xml.ep

--- a/data/autoyast_qam/12-SP3_installation.xml.ep
+++ b/data/autoyast_qam/12-SP3_installation.xml.ep
@@ -1,0 +1,1 @@
+basic_installation.xml.ep

--- a/data/autoyast_qam/12-SP4_installation.xml.ep
+++ b/data/autoyast_qam/12-SP4_installation.xml.ep
@@ -1,0 +1,1 @@
+basic_installation.xml.ep

--- a/data/autoyast_qam/12_installation.xml.ep
+++ b/data/autoyast_qam/12_installation.xml.ep
@@ -1,0 +1,1 @@
+basic_installation.xml.ep

--- a/data/autoyast_qam/15_installation.xml.ep
+++ b/data/autoyast_qam/15_installation.xml.ep
@@ -1,0 +1,1 @@
+basic_installation.xml.ep

--- a/data/autoyast_qam/basic_installation.xml.ep
+++ b/data/autoyast_qam/basic_installation.xml.ep
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <email><%= $get_var->('SCC_EMAIL') %></email>
+    <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_server><%= $get_var->('SCC_URL') %></reg_server>
+    % if (keys %$addons) {
+    <addons config:type="list">
+      % while (my ($key, $addon) = each (%$addons)) {
+      <addon>
+        <name><%= $addon->{name} %></name>
+        <version><%= $addon->{version} %></version>
+        <arch><%= $addon->{arch} %></arch>
+        % if ($key eq 'we') {
+        <reg_code><%= $get_var->('SCC_REGCODE_WE') %></reg_code>
+        % }
+        % if ($key eq 'ltss') {
+        <reg_code><%= $get_var->('SCC_REGCODE_LTSS') %></reg_code>
+        % }
+      </addon>
+      % }
+    </addons>
+    %}
+  </suse_register>
+  <add-on>
+    <add_on_products config:type="list">
+      % for my $repo (@$repos) {
+      <listentry>
+        <media_url><%= $repo %></media_url>
+      </listentry>
+      % }
+    </add_on_products>
+  </add-on>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">-1</timeout>
+    </global>
+  </bootloader>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <signature-handling>
+      <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+  </general>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <keyboard>
+    <keyboard_values>
+      <delay/>
+      <discaps config:type="boolean">false</discaps>
+      <numlock>bios</numlock>
+      <rate/>
+    </keyboard_values>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+  </ntp-client>
+  <software>
+    <products config:type="list">
+      <product><%= uc $get_var->('SLE_PRODUCT') %></product>
+    </products>
+    <patterns config:type="list">
+      % for my $pattern (@$patterns) {
+      <pattern><%= $pattern %></pattern>
+      % }
+    </patterns>
+  </software>
+  <networking>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <startmode>auto</startmode>
+      </interface>
+    </interfaces>
+  </networking>
+  <firewall>
+    <enable_firewall config:type="boolean">true</enable_firewall>
+    <start_firewall config:type="boolean">true</start_firewall>
+  </firewall>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Berlin</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact>-1</inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -1,0 +1,109 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Provide translations for autoyast XML file
+# Maintainer: Jan Baier <jbaier@suse.cz>
+
+package autoyast;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use warnings;
+use testapi;
+use version_utils 'is_sle';
+use registration qw(scc_version get_addon_fullname);
+
+our @EXPORT = qw(expand_template);
+
+sub expand_patterns {
+    if (get_var('PATTERNS') =~ m/^\s*$/) {
+        return [qw(base minimal_base enhanced_base apparmor sw_management
+              yast2_basis)] if check_var('DESKTOP', 'textmode');
+        return [qw(base minimal_base enhanced_base apparmor sw_management
+              yast2_basis x11 gnome_basic)] if check_var('DESKTOP', 'gnome');
+    }
+    if (check_var('PATTERNS', 'all')) {
+        my @all;
+        if (is_sle('15+')) {
+            push @all, qw(base minimal_base enhanced_base documentation 32bit
+              apparmor x11 x11_enhanced yast2_basis sw_management fonts) if
+              get_var('SCC_ADDONS') =~ m/base/;
+            push @all, qw(xen_tools kvm_tools file_server mail_server gnome_basic
+              lamp_server gateway_server dhcp_dns_server directory_server
+              kvm_server xen_server fips sap_server oracle_server ofed) if
+              get_var('SCC_ADDONS') =~ m/serverapp/;
+            push @all, qw(devel_basis devel_kernel devel_yast) if
+              get_var('SCC_ADDONS') =~ m/sdk/;
+            push @all, qw(gnome_x11 gnome_multimedia gnome_imaging office
+              technical_writing books) if get_var('SCC_ADDONS') =~ m/we/;
+            push @all, qw(gnome_basic multimedia laptop imaging) if
+              get_var('SCC_ADDONS') =~ m/desktop/;
+        }
+        elsif (is_sle('12+')) {
+            push @all, qw(base Minimal documentation 32bit apparmor x11 WBEM
+              Basis-Devel laptop gnome-basic);
+            push @all, qw(yast2 smt) if
+              is_sle('12-sp3+');
+            push @all, qw(xen_tools kvm_tools file_server mail_server
+              gnome-basic lamp_server gateway_server dhcp_dns_server
+              directory_server kvm_server xen_server fips sap_server
+              oracle_server ofed printing) if
+              check_var('SLE_PRODUCT', 'sles');
+            push @all, qw(default desktop-base desktop-gnome fonts
+              desktop-gnome-devel desktop-gnome-laptop kernel-devel
+              virtualization-client) if
+              check_var('SLE_PRODUCT', 'sled');
+            push @all, qw(SDK-C-C++ SDK-Certification SDK-Doc SDK-YaST) if
+              get_var('SCC_ADDONS') =~ m/sdk/;
+        }
+        return [@all];
+    }
+    [split(/,/, get_var('PATTERNS') =~ s/\bminimal\b/minimal_base/r)];
+}
+
+my @unversioned_products = qw(asmm contm lgm tcm wsm);
+
+sub get_product_version {
+    my ($name) = @_;
+    my $version = scc_version(get_var('VERSION', ''));
+    return $version =~ s/^(\d*)\.\d$/$1/r if is_sle('<15') && grep(/^$name$/, @unversioned_products);
+    return $version;
+}
+
+sub expand_addons {
+    my %addons;
+    my @addons = grep { defined $_ } split(/,/, get_var('SCC_ADDONS'));
+    foreach my $addon (@addons) {
+        $addons{$addon} = {
+            name    => get_addon_fullname($addon),
+            version => get_product_version($addon),
+            arch    => get_var('ARCH'),
+        };
+    }
+    return \%addons;
+}
+
+sub expand_template {
+    my ($profile) = @_;
+    my $template = Mojo::Template->new(vars => 1);
+    my $vars = {
+        addons   => expand_addons,
+        repos    => [split(/,/, get_var('MAINT_TEST_REPO'))],
+        patterns => expand_patterns,
+        # pass reference to get_var function to be able to fetch other variables
+        get_var => \&get_var,
+    };
+    my $output = $template->render($profile, $vars);
+    return $output;
+}
+
+
+1;

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -562,6 +562,7 @@ sub get_addon_fullname {
         'hpcm'      => 'sle-module-hpc',
         'legacy'    => 'sle-module-legacy',
         'lgm'       => 'sle-module-legacy',
+        'ltss'      => 'SLES-LTSS',
         'pcm'       => 'sle-module-public-cloud',
         'script'    => 'sle-module-web-scripting',
         'serverapp' => 'sle-module-server-applications',

--- a/tests/autoyast/prepare_profile.pm
+++ b/tests/autoyast/prepare_profile.pm
@@ -16,6 +16,7 @@ use base "opensusebasetest";
 use testapi;
 use version_utils 'is_sle';
 use registration 'scc_version';
+use autoyast 'expand_template';
 use File::Copy 'copy';
 use File::Path 'make_path';
 
@@ -25,6 +26,9 @@ sub run {
     my $profile = get_test_data($path);
     # Return if profile is not available
     return unless $profile;
+
+    # Profile is a template, expand and rename
+    $profile = expand_template($profile) if $path =~ s/^(.*\.xml)\.ep$/$1/;
 
     # Expand VERSION, as e.g. 15-SP1 has to be mapped to 15.1
     if (my $version = scc_version(get_var('VERSION', ''))) {


### PR DESCRIPTION
Add ability for more complex autoyast templates. Needs variables `AUTOYAST_PREPARE_PROFILE=1` and AUTOYAST=`autoyast_qam/%VERSION%_installation.xml.ep`

- Related ticket: https://progress.opensuse.org/issues/41921
- Verification runs:
  - SLE15:
    - http://panigale.suse.cz/tests/886 (qam-minimal)
    - http://panigale.suse.cz/tests/887 (qam-allpatterns)
    - http://panigale.suse.cz/tests/903 (qam-gnome)
    - http://panigale.suse.cz/tests/908 (qam-textmode)
    - http://panigale.suse.cz/tests/911 (qam-allpatterns+addons)
  - SLE12-SP4
    - http://panigale.suse.cz/tests/982 (qam-allpatterns)
    - http://panigale.suse.cz/tests/987 (qam-allpatterns+addons)
  - SLE12-SP3
    - http://panigale.suse.cz/tests/967 (qam-allpatterns)
    - http://panigale.suse.cz/tests/958 (qam-allpatterns+addons)
  - SLE12-SP2
    - http://panigale.suse.cz/tests/986 (qam-allpatterns)
  - SLE12-SP1
    - http://panigale.suse.cz/tests/985 (qam-allpatterns)
  - SLE12
    - http://panigale.suse.cz/tests/984 (qam-allpatterns)