### PR TITLE
Virtualization: correct addon link for sle15sp1

### DIFF
--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -70,6 +70,7 @@ sub repl_module_in_sourcefile {
 
     my $replaced_item = "(source.(Basesystem|Desktop-Applications|Legacy|Server-Applications|Development-Tools|Web-Scripting).sles-" . $version . "-64=)";
     $version =~ s/-sp0//;
+    $version = uc($version);
     my $daily_build_module = "http://openqa.suse.de/assets/repo/SLE-${version}-Module-\\2-POOL-x86_64-Build" . get_required_var('BUILD') . "-Media1/";
     my $source_file        = "/usr/share/qa/virtautolib/data/sources.*";
     my $command            = "sed -ri 's#^.*${replaced_item}.*\$#\\1$daily_build_module#g' $source_file";


### PR DESCRIPTION
Currently in 15sp1 job group sle15sp1 guest installation  fails due to incorrect addon link used, this PR is to fix it.
Failure job link: https://openqa.suse.de/tests/2227284#step/update_package/41

- Verification run: http://10.67.18.220/tests/405#step/update_package/41
