### PR TITLE
publiccloud: Increase timeout for ipa to 30m

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -144,7 +144,7 @@ sub run_ipa {
     $args{cleanup}              //= 1;
     $args{ssh_private_key_file} //= '.ssh/id_rsa';
     $args{tests}                //= '';
-    $args{timeout}              //= 60 * 20;
+    $args{timeout}              //= 60 * 30;
     $args{results_dir}          //= 'ipa_results';
     $args{distro}               //= 'sles';
     $args{tests} =~ s/,/ /g;


### PR DESCRIPTION
Give ipa 10 minutes more time to do it work.
e.g https://openqa.suse.de/tests/2232360