### PR TITLE
Wait longer before clicking on subscribe icon

### DIFF
--- a/tests/x11/firefox/firefox_rss.pm
+++ b/tests/x11/firefox/firefox_rss.pm
@@ -35,7 +35,7 @@ sub run {
 
     $self->firefox_open_url('https://linux.slashdot.org/');
     assert_and_click("slashdot-cookies-agree") if check_screen("slashdot-cookies", 0);
-    wait_still_screen 3;
+    wait_still_screen;
     assert_and_click "firefox-rss-button_enabled", "left";
     assert_screen("firefox-rss-page", 60);
 


### PR DESCRIPTION
I run multiple tests and looks like waiting longer helps.

- Related ticket: https://progress.opensuse.org/issues/42938
- Verification run: http://10.100.12.155/tests/8605#step/firefox_rss/14
