### PR TITLE
Add new YaST2 UI firewalld

### DIFF
--- a/lib/yast2_shortcuts.pm
+++ b/lib/yast2_shortcuts.pm
@@ -15,11 +15,12 @@ package yast2_shortcuts;
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_leap is_sle is_opensuse);
+use version_utils qw(is_leap is_sle);
 
 use Exporter 'import';
-our @EXPORT_OK = qw($is_older_product %remote_admin %firewall_settings %firewall_details $confirm);
+our @EXPORT_OK = qw($is_older_product %remote_admin %firewall_settings %firewall_details $confirm %fw);
 
+# VNC configuration
 our $is_older_product = is_sle('<15') || is_leap('<15.0');
 our %remote_admin = (
     allow_remote_admin_with_session    => 'alt-a',
@@ -35,5 +36,18 @@ our %firewall_details = (
     select_all         => 'alt-a'
 );
 our $confirm = $is_older_product ? $cmd{ok} : $cmd{next};
+
+# firewalld UI
+our %fw = (
+    service_stop                => 'alt-s',    # Start-Up: Stop now (button)
+    service_start               => 'alt-s',    # Start-Up: Start now (button)
+    zones_set_as_default        => 'alt-s',    # Zones: Set As Default (button)
+    interfaces_change_zone      => 'alt-c',    # Interfaces: Change Zone (button)
+    interfaces_change_zone_zone => 'alt-z',    # Interfaces->Change Zone: Zone (drop-down)
+    zones_service_add           => 'alt-d',    # Zones->Services: Add (button)
+    zones_ports                 => 'alt-p',    # Zones->Ports: Ports (tab)
+    yes                         => 'alt-y',    # Yes
+    tcp                         => 'alt-t'     # TCP Ports (textbox)
+);
 
 1;

--- a/tests/yast2_gui/yast2_firewall.pm
+++ b/tests/yast2_gui/yast2_firewall.pm
@@ -10,13 +10,15 @@
 
 # Summary: YaST2 Firewall UI test checks verious configurations and settings of firewall
 # Make sure yast2 firewall can opened properly. Configurations can be changed and written correctly.
-# Maintainer: Zaoliang Luo <zluo@suse.com>
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.com>
 
 use base "y2x11test";
 use strict;
 use testapi;
 use utils;
 use version_utils qw(is_sle is_leap is_tumbleweed);
+use yast2_shortcuts '%fw';
+use network_utils 'iface';
 
 sub susefirewall2 {
     # 	enter page interfaces and change zone for network interface
@@ -68,41 +70,154 @@ sub susefirewall2 {
     send_key "alt-f";
 }
 
-sub firewalld {
-    # the inplementation of new firewall module is not completed yet.
-    # see bsc#1072659 for more details.
-    # So check layout and some basic stuffs only.
+sub verify_service_stopped {
+    my $self = shift;
 
-    # check menu entries
-    assert_and_click 'firewall-options-menu';
-    assert_and_click 'firewall-view-menu';
-    assert_and_click 'firewall-help-menu';
+    record_info('Start-Up', "Managing the firewalld service: Stop");
+    select_console 'x11', await_console => 0;
+    $self->launch_yast2_module_x11('firewall', target_match => 'firewall-start-page');
+    assert_screen 'yast2_firewall_start-up';
+    assert_screen 'yast2_firewall_service_status_running';
+    send_key $fw{service_stop};
+    assert_screen [qw(yast2_firewall_service_status_stopped generic-desktop)];
+    if (match_has_tag('generic-desktop')) {
+        record_soft_failure "bsc#1114677 - Dialog dissapear after switching service status";
+    }
+    assert_screen 'yast2_firewall_service_status_stopped';
+    wait_screen_change { send_key $cmd{accept} };
 
-    # check zones public and some details
-    # Todo: check services, Ports, Protocols, Source Ports, Masquerading, Port Forwarding etc.
-    # check configuration details for zones, services, ipsets, icmp types, helpers, direct configuration
-    assert_screen 'firewall-zones-public';
-    assert_and_click 'firewall-config-services';
-    assert_screen 'firewall-config-services-list';
-    assert_and_click 'firewall-ipsets';
-    assert_screen 'firewall-ipsets-entry';
+    select_console 'root-console';
+    if (script_run("firewall-cmd --state 2>&1 | grep 'not running'")) {
+        record_soft_failure "bsc#1114807 - service does not stop ";
+        return;
+    }
+}
 
-    # now close and exit
-    assert_and_click 'firewall-file-menu';
-    assert_and_click 'firewall-file-quit';
+sub verify_service_started {
+    my $self = shift;
+
+    record_info('Start-Up', "Managing the firewalld service: Start");
+    select_console 'x11', await_console => 0;
+    $self->launch_yast2_module_x11('firewall', target_match => 'firewall-start-page');
+    assert_screen 'yast2_firewall_start-up';
+    assert_screen 'yast2_firewall_service_status_stopped';
+    send_key $fw{service_start};
+    assert_screen [qw(yast2_firewall_service_status_running generic-desktop)];
+    if (match_has_tag('generic-desktop')) {
+        record_soft_failure "bsc#1114677 - Dialog dissapear after switching service status";
+    }
+    assert_screen 'yast2_firewall_service_status_running';
+    wait_screen_change { send_key $cmd{accept} };
+
+    select_console 'root-console';
+    assert_script_run "firewall-cmd --state | grep running";
+}
+
+sub verify_interface {
+    my (%args) = @_;
+
+    assert_and_click 'yast2_firewall_interfaces_menu';
+    assert_screen 'yast2_firewall_interfaces_' . $args{device} . '_' . $args{zone};
+}
+
+sub change_interface_zone {
+    my $zone = shift;
+
+    assert_and_click 'yast2_firewall_interfaces_menu';
+    assert_screen 'yast2_firewall_interfaces';
+    send_key $fw{interfaces_change_zone};
+    assert_screen 'yast2_firewall_interfaces_change_zone';
+    send_key $fw{interfaces_change_zone_zone};
+    type_string "$zone\n";
+}
+
+sub verify_zone {
+    my (%args) = @_;
+
+    my $interfaces = $args{interfaces} //= 'no_interfaces';
+    my $default    = $args{default}    //= 'no_default';
+
+    assert_and_click 'yast2_firewall_zones';
+    assert_screen 'yast2_firewall_' . $args{name} . '_' . $interfaces . '_' . $default;
+}
+
+sub set_default_zone {
+    my $zone = shift;
+
+    assert_and_click 'yast2_firewall_zone_' . $zone;
+    send_key $fw{zones_set_as_default};
+}
+
+sub configure_zone {
+    my (%args) = @_;
+
+    assert_and_click 'yast2_firewall_zones';
+    if ($args{service}) {
+        assert_and_click 'yast2_firewall_zone_' . $args{zone} . '_menu';
+        assert_and_click 'yast2_firewall_zone_service_known_scroll_on_top';    # assuming allowed list empty
+        send_key_until_needlematch 'yast2_firewall_zone_service_' . $args{service} . '_selected', 'down';
+        send_key $fw{zones_service_add};
+        assert_screen 'yast2_firewall_zone_service_' . $args{service} . '_allowed';
+    }
+    if ($args{port}) {
+        send_key $fw{zones_ports};
+        assert_screen 'yast2_firewall_zone_service_warning';
+        send_key $fw{yes};
+        assert_screen 'yast2_firewall_zone_ports_tab_selected';
+        send_key $fw{tcp};
+        type_string '7777';
+    }
+}
+
+sub configure_firewalld {
+    my $self = shift;
+
+    record_info('Interface/Zones ', "Verify zone info changing default zone when interface assigned to default zone");
+    my $iface = iface;
+
+    select_console 'x11', await_console => 0;
+    $self->launch_yast2_module_x11('firewall', target_match => 'firewall-start-page');
+
+    verify_interface(device => $iface, zone => 'default');
+    verify_zone(name => 'public', interfaces => $iface, default => 'default');
+    set_default_zone 'trusted';
+    verify_zone(name => 'trusted', interfaces => $iface, default => 'default');
+
+    record_info('Interface/Zones', "Verify zone info assigning interface to different zone");
+    change_interface_zone 'public';
+    verify_interface(device => $iface, zone => 'public');
+    verify_zone(name => 'public',  interfaces => $iface);
+    verify_zone(name => 'trusted', default    => 'default');
+
+    record_info('Zones', "Configure zone adding service and port");
+    configure_zone(zone => 'trusted', service => 'bitcoin', port => '7777');
+
+    send_key $cmd{accept};
+}
+
+sub verify_firewalld_configuration {
+    select_console 'root-console';
+    assert_script_run 'firewall-cmd --state | grep running';
+    if (script_run('firewall-cmd --list-interfaces --zone=public | grep ' . $fw{interface_device})) {
+        record_soft_failure "bsc#1114673 - Interface not assigned to the right zone in first run";
+    }
+    assert_script_run 'firewall-cmd --list-all --zone=trusted | grep -E \'services: bitcoin\'';
+    assert_script_run 'firewall-cmd --list-all --zone=trusted | grep -E \'ports: 7777/tcp\'';
 }
 
 sub run {
     my $self = shift;
-    select_console 'root-console';
-    zypper_call('in yast2-http-server apache2 apache2-prefork', timeout => 1200);
+
     if (is_sle('15+') || is_leap('15.0+') || is_tumbleweed) {
-        zypper_call('in firewall-config', timeout => 60);
+        if ($self->verify_service_stopped) {
+            $self->verify_service_started;
+        }
+        $self->configure_firewalld;
+        verify_firewalld_configuration;
         select_console 'x11', await_console => 0;
-        $self->launch_yast2_module_x11('firewall', target_match => 'firewall-start-page', match_timeout => 60);
-        firewalld;
     }
     else {
+        zypper_call('in yast2-http-server apache2 apache2-prefork', timeout => 1200);
         select_console 'x11', await_console => 0;
         $self->launch_yast2_module_x11('firewall', match_timeout => 60);
         susefirewall2;


### PR DESCRIPTION
Add new YaST2 UI firewalld: [fate#324662](https://fate.suse.com/324662):

- [X] Verify change of service status.
- [X] Verify change of default zone when the interface is assigned to default and when the interface is assigned to a different zone.
- [X] Add one service and one port.
- [X] Verify with firewall-cmd previous changes are applied.
- [X] Record corresponding soft-failures found: [bsc#1114677](https://bugzilla.suse.com/show_bug.cgi?id=1114677) [bsc#1114673](https://bugzilla.suse.com/show_bug.cgi?id=1114673) [bsc#1114807](https://bugzilla.suse.com/show_bug.cgi?id=1114807)

- Related ticket: https://progress.opensuse.org/issues/42482
- Needles: 
  - [~opensuse needles~](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/465)
  - [~sle needles~](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/976/)
- Verification run: 
  - [Leap-15.1-yast2_gui-yast2 yast2_firewall](http://dhcp42.suse.cz/tests/783#step/yast2_firewall/85)
  - [sle-15-SP1-yast2_gui yast2_firewall](http://dhcp42.suse.cz/tests/782#step/yast2_firewall/80)
  - [Tumbleweed-yast2_gui yast2_firewall](http://dhcp42.suse.cz/tests/784#step/yast2_firewall/82)