### PR TITLE
install_packages: handle dapl-debug conflicts

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -179,6 +179,8 @@ sub problem_can_be_skipped {
     return 1 if $pkg =~ /^python3-tdb/;
     # conflicts python-ldb-devel
     return 1 if $pkg =~ /^python3-ldb-devel/;
+    # conflict with the non-debug counterparts
+    return 1 if $pkg =~ /^dapl-debug(|-devel|-libs|-utils)/;
 
     return;
 }


### PR DESCRIPTION
Handles conflict of dapl-debug packages with their non-debug counterparts


- https://build.opensuse.org/request/show/645769
- Fixes: https://openqa.opensuse.org/tests/784849#step/install_packages/9
- Fixes: https://openqa.opensuse.org/tests/784850#step/install_packages/9
- Fixes: https://openqa.opensuse.org/tests/784851#step/install_packages/9


```
+++ PROBLEMS: +++
package dapl-debug-2.1.10-lp150.1.32.x86_64 conflicts with dapl provided by dapl-2.1.10-lp150.1.32.x86_64
  + solution
    - do not ask to install dapl-debug-2.1.10-lp150.1.32.x86_64
PCBS 'dapl-debug-2.1.10-lp150.1.32.x86_64': 'package dapl-debug-2.1.10-lp150.1.32.x86_64 conflicts with dapl provided by dapl-2.1.10-lp150.1.32.x86_64'
  + solution
    - do not ask to install dapl-2.1.10-lp150.1.32.x86_64
PCBS 'dapl-2.1.10-lp150.1.32.x86_64': 'package dapl-debug-2.1.10-lp150.1.32.x86_64 conflicts with dapl provided by dapl-2.1.10-lp150.1.32.x86_64'
    - do not ask to install dapl-devel-32bit-2.1.10-lp150.1.32.x86_64
PCBS 'dapl-devel-32bit-2.1.10-lp150.1.32.x86_64': 'package dapl-debug-2.1.10-lp150.1.32.x86_64 conflicts with dapl provided by dapl-2.1.10-lp150.1.32.x86_64'
package dapl-devel-2.1.10-lp150.1.32.x86_64 conflicts with dapl-debug-devel provided by dapl-debug-devel-2.1.10-lp150.1.32.x86_64
  + solution
    - do not ask to install dapl-devel-2.1.10-lp150.1.32.x86_64
PCBS 'dapl-devel-2.1.10-lp150.1.32.x86_64': 'package dapl-devel-2.1.10-lp150.1.32.x86_64 conflicts with dapl-debug-devel provided by dapl-debug-devel-2.1.10-lp150.1.32.x86_64'
    - do not ask to install dapl-devel-32bit-2.1.10-lp150.1.32.x86_64
PCBS 'dapl-devel-32bit-2.1.10-lp150.1.32.x86_64': 'package dapl-devel-2.1.10-lp150.1.32.x86_64 conflicts with dapl-debug-devel provided by dapl-debug-devel-2.1.10-lp150.1.32.x86_64'
  + solution
    - do not ask to install dapl-debug-devel-2.1.10-lp150.1.32.x86_64
PCBS 'dapl-debug-devel-2.1.10-lp150.1.32.x86_64': 'package dapl-devel-2.1.10-lp150.1.32.x86_64 conflicts with dapl-debug-devel provided by dapl-debug-devel-2.1.10-lp150.1.32.x86_64'
package libdat2-2-2.1.10-lp150.1.32.x86_64 conflicts with dapl-debug-libs provided by dapl-debug-libs-2.1.10-lp150.1.32.x86_64
  + solution
    - do not ask to install libdat2-2-2.1.10-lp150.1.32.x86_64
PCBS 'libdat2-2-2.1.10-lp150.1.32.x86_64': 'package libdat2-2-2.1.10-lp150.1.32.x86_64 conflicts with dapl-debug-libs provided by dapl-debug-libs-2.1.10-lp150.1.32.x86_64'
    - do not ask to install dapl-devel-32bit-2.1.10-lp150.1.32.x86_64
PCBS 'dapl-devel-32bit-2.1.10-lp150.1.32.x86_64': 'package libdat2-2-2.1.10-lp150.1.32.x86_64 conflicts with dapl-debug-libs provided by dapl-debug-libs-2.1.10-lp150.1.32.x86_64'
  + solution
    - do not ask to install dapl-debug-libs-2.1.10-lp150.1.32.x86_64
PCBS 'dapl-debug-libs-2.1.10-lp150.1.32.x86_64': 'package libdat2-2-2.1.10-lp150.1.32.x86_64 conflicts with dapl-debug-libs provided by dapl-debug-libs-2.1.10-lp150.1.32.x86_64'
package dapl-utils-2.1.10-lp150.1.32.x86_64 conflicts with dapl-debug-utils provided by dapl-debug-utils-2.1.10-lp150.1.32.x86_64
  + solution
    - do not ask to install dapl-utils-2.1.10-lp150.1.32.x86_64
PCBS 'dapl-utils-2.1.10-lp150.1.32.x86_64': 'package dapl-utils-2.1.10-lp150.1.32.x86_64 conflicts with dapl-debug-utils provided by dapl-debug-utils-2.1.10-lp150.1.32.x86_64'
    - do not ask to install dapl-devel-32bit-2.1.10-lp150.1.32.x86_64
PCBS 'dapl-devel-32bit-2.1.10-lp150.1.32.x86_64': 'package dapl-utils-2.1.10-lp150.1.32.x86_64 conflicts with dapl-debug-utils provided by dapl-debug-utils-2.1.10-lp150.1.32.x86_64'
  + solution
    - do not ask to install dapl-debug-utils-2.1.10-lp150.1.32.x86_64
PCBS 'dapl-debug-utils-2.1.10-lp150.1.32.x86_64': 'package dapl-utils-2.1.10-lp150.1.32.x86_64 conflicts with dapl-debug-utils provided by dapl-debug-utils-2.1.10-lp150.1.32.x86_64'

```

To verify: `data/lsmfip --verbose libdat2-2-32bit dapl-utils dapl-debug-utils dapl-debugsource libdat2-2-debuginfo dapl-debug dapl-debug-debuginfo libdat2-2 dapl dapl-debug-devel dapl-debug-utils-debuginfo dapl-utils-debuginfo dapl-debug-debugsource dapl-debuginfo dapl-devel dapl-debug-libs dapl-devel-32bit libdat2-2-32bit-debuginfo dapl-debug-libs-debuginfo`

Test maintainer @coolo 
