### PR TITLE
Fix firefox race conditions

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -599,11 +599,12 @@ sub restart_firefox {
     assert_screen 'xterm';
     type_string "$cmd\n";
     type_string "firefox $url >>firefox.log 2>&1 &\n";
-    sleep 5;
     $self->firefox_check_default;
 }
 
 sub firefox_check_default {
+    # needle can sometimes match before firefox start to load page
+    wait_still_screen;
     # Set firefox as default browser if asked
     assert_screen [qw(firefox_default_browser firefox_trackinfo firefox_readerview_window firefox-url-loaded)], 150;
     if (match_has_tag('firefox_default_browser')) {

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -606,7 +606,7 @@ sub firefox_check_default {
     # needle can sometimes match before firefox start to load page
     wait_still_screen;
     # Set firefox as default browser if asked
-    assert_screen [qw(firefox_default_browser firefox_trackinfo firefox_readerview_window firefox-url-loaded)], 150;
+    assert_screen [qw(firefox_default_browser firefox-url-loaded)], 150;
     if (match_has_tag('firefox_default_browser')) {
         wait_screen_change {
             assert_and_click 'firefox_default_browser_yes';

--- a/tests/x11/firefox.pm
+++ b/tests/x11/firefox.pm
@@ -20,6 +20,7 @@ sub run() {
     my ($self) = shift;
 
     $self->start_firefox;
+    wait_still_screen;
     send_key "alt-h";
     assert_screen 'firefox-help-menu';
     send_key "a";


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/43277
- Verification run: 
[sles12 sp4](http://10.100.12.155/tests/8617#step/firefox/3)
[sles15 sp1](http://10.100.12.155/tests/8616#step/firefox/3)
[sles15](http://10.100.12.155/tests/8622)
[TW](http://10.100.12.155/tests/8618#step/firefox/3)
[sled12 sp3](http://10.100.12.155/tests/8620)
[sles12 sp3](http://10.100.12.155/tests/8614)
[sled15](http://10.100.12.155/tests/8608)
[sles15](http://10.100.12.155/tests/8610)