### PR TITLE
Handle sles4sap selection in textmode

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -97,7 +97,7 @@ sub run {
             my %hotkey = (
                 sles     => 's',
                 sled     => 'u',
-                sles4sap => get_var('OFW') ? 'u' : 'i',
+                sles4sap => get_var('OFW') ? 'u' : 'x',
                 hpc      => check_var('ARCH', 'x86_64') ? 'x' : 'u'
             );
             send_key 'alt-' . $hotkey{$product};


### PR DESCRIPTION
Starting from Build 70.3, an additional product (RT) is shown on Product
Selection screen. The key combination for the sles4sap is changed from
'alt+i' to 'alt+x' in textmode for x64 installations.

The commit changes the key combination to the actual one.

- Related ticket: https://progress.opensuse.org/issues/42965
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/977
- Verification run: http://oorlov-vm.qa.suse.de/tests/489#step/welcome/5

**Please, don't forget to merge [needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/977) before merging the PR.**

**For the Reviewers:** The change should affect only the failing modules. So that I've changed only the key combination without additional conditions.

The sles4sap is selected in the tests only in case if it has Product Selection screen (it is SLE15+ but not UPGRADE  and not s380). And also only in case if `"VIDEOMODE\" : "text"` and `"SLE_PRODUCT" : "sles4sap"` and only for x64 installations.

There are only 5 modules, that meet this condition in the last build:

https://openqa.suse.de/tests/2232513
https://openqa.suse.de/tests/2232640
https://openqa.suse.de/tests/2228493
https://openqa.suse.de/tests/2232633
https://openqa.suse.de/tests/2232617

And also two ppc64le scenarios (that actually passed, as RT product is not appeared for them):
https://openqa.suse.de/tests/2228467
https://openqa.suse.de/tests/2228505

The PR will fix all the failed modules.