### PR TITLE
Wait more before typing string, after sending key

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -366,6 +366,7 @@ sub bootmenu_default_params {
         send_key "down";
         send_key "down";
         wait_screen_change { send_key "end" };
+        wait_still_screen(1);
         # load kernel manually with append
         if (check_var('VIDEOMODE', 'text')) {
             type_string_very_slow " textmode=1";


### PR DESCRIPTION
- Seen on: https://openqa.suse.de/tests/2228503
- Related ticket: https://progress.opensuse.org/issues/40670
- Verification run: http://slindomansilla-vm.qa.suse.de/tests/overview?build=poo40670_ppc_bootloader_mystyping (a few fail on welcome, but for other reasons. The space before Y2DEBUG is written properly)
