### PR TITLE
Use longer stilltime for super slow svirt2012r2

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -604,7 +604,9 @@ sub restart_firefox {
 
 sub firefox_check_default {
     # needle can sometimes match before firefox start to load page
-    wait_still_screen;
+    # svirt is special case with TIMEOUT_SCALE=3 which does not affect wait_still_screen
+    my $stilltime = get_var('TIMEOUT_SCALE') ? 30 : 5;
+    wait_still_screen $stilltime;
     # Set firefox as default browser if asked
     assert_screen [qw(firefox_default_browser firefox-url-loaded)], 150;
     if (match_has_tag('firefox_default_browser')) {


### PR DESCRIPTION
Using TIMEOUT_SCALE instead of e.g. BACKEND=svirt because only one svirt
machine is so slow and is using TIMEOUT_SCALE which does not affect
wait_still_screen. TIMEOUT_SCALE is also more universal

- Related ticket: https://progress.opensuse.org/issues/43277 https://progress.opensuse.org/issues/32926
- Verification run:
http://10.100.12.155/tests/8636
http://10.100.12.155/tests/8635
http://10.100.12.155/tests/8634
