### PR TITLE
xfstests: remove zero size logs in tarball

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -241,7 +241,7 @@ sub shuffle {
 # Copy log to ready to save
 sub copy_log {
     my ($category, $num, $log_type) = @_;
-    my $cmd = "cat /opt/xfstests/results/$category/$num.$log_type | tee $LOG_DIR/$category/$num.$log_type";
+    my $cmd = "if [ -e /opt/xfstests/results/$category/$num.$log_type ]; then cat /opt/xfstests/results/$category/$num.$log_type | tee $LOG_DIR/$category/$num.$log_type; fi";
     script_run($cmd);
 }
 


### PR DESCRIPTION
An one line fix, don't create zero size log into tarball.

- Related ticket: https://progress.opensuse.org/issues/39239
- Verification run: http://10.67.133.102/tests/689
(The test btrfs/170 suppose to create a zero size log 170.dmesg, but in this verify run it didn't created this useless log)