### PR TITLE
Live upgrade + handle beta warning

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -280,7 +280,7 @@ sub select_bootmenu_option {
         send_key_until_needlematch 'inst-onupgrade', get_var('OFW') ? 'up' : 'down', 10, 5;
     }
     else {
-        if (get_var('PROMO') || get_var('LIVETEST') || get_var('LIVE_INSTALLATION')) {
+        if (get_var('PROMO') || get_var('LIVETEST') || get_var('LIVE_INSTALLATION') || get_var('LIVE_UPGRADE')) {
             send_key_until_needlematch 'boot-live-' . get_var('DESKTOP'), 'down', 10, 5;
         }
         elsif (get_var('OFW')) {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -826,7 +826,7 @@ sub load_inst_tests {
     if (is_opensuse && noupdatestep_is_applicable() && !get_var("LIVECD")) {
         loadtest "installation/installation_mode";
     }
-    if (!get_var("LIVECD") && get_var("UPGRADE")) {
+    if (is_upgrade) {
         loadtest "installation/upgrade_select";
         if (check_var("UPGRADE", "LOW_SPACE")) {
             loadtest "installation/disk_space_fill";

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -655,7 +655,7 @@ sub addon_products_is_applicable {
 }
 
 sub noupdatestep_is_applicable {
-    return !get_var("UPGRADE");
+    return !get_var("UPGRADE") && !get_var("LIVE_UPGRADE");
 }
 
 sub random_string {

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -237,7 +237,7 @@ sub is_storage_ng {
 }
 
 sub is_upgrade {
-    return get_var('UPGRADE') || get_var('ONLINE_MIGRATION') || get_var('ZDUP') || get_var('AUTOUPGRADE');
+    return get_var('UPGRADE') || get_var('ONLINE_MIGRATION') || get_var('ZDUP') || get_var('AUTOUPGRADE') || get_var('LIVE_UPGRADE');
 }
 
 sub is_sle12_hdd_in_upgrade {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -407,10 +407,10 @@ elsif (get_var('DOCKER_IMAGE_TEST')) {
     load_docker_tests;
 }
 else {
-    if (get_var("LIVETEST") || get_var('LIVE_INSTALLATION')) {
+    if (get_var("LIVETEST") || get_var('LIVE_INSTALLATION') || get_var('LIVE_UPGRADE')) {
         load_boot_tests();
         loadtest "installation/finish_desktop";
-        if (get_var('LIVE_INSTALLATION')) {
+        if (get_var('LIVE_INSTALLATION') || get_var('LIVE_UPGRADE')) {
             loadtest "installation/live_installation";
             load_inst_tests();
             load_reboot_tests();

--- a/tests/installation/live_installation.pm
+++ b/tests/installation/live_installation.pm
@@ -37,11 +37,14 @@ sub run {
     assert_and_click 'maximize';
     mouse_hide;
     # Wait until the first screen is shown, only way to make sure it's idle
-    assert_screen 'inst-welcome', 180;
+    assert_screen ["inst-welcome", "inst-betawarning"], 180;
     # To fully reuse installer screenshots we set to fullscreen. Unfortunately
     # it seems no default shortcut is configured in plasma but we can use the
-    # window context menu.
-    send_key 'alt-f3';
+    # window context menu. Right click at the top to not set the beta warning
+    # to fullscreen.
+    mouse_set 100, 0;
+    mouse_click 'right';
+    mouse_hide;
     assert_screen 'context-menu-more_actions';
     # more
     send_key_and_wait 'alt-m';

--- a/tests/installation/live_installation.pm
+++ b/tests/installation/live_installation.pm
@@ -20,6 +20,7 @@
 use base "installbasetest";
 use testapi;
 use utils;
+use version_utils "is_upgrade";
 use strict;
 
 sub send_key_and_wait {
@@ -33,7 +34,12 @@ sub run {
     # stop packagekit, root password is not needed on live system
     x11_start_program('systemctl stop packagekit.service', target_match => 'generic-desktop');
     turn_off_kde_screensaver;
-    assert_and_click 'live-installation';
+    if (is_upgrade) {
+        assert_and_click 'live-upgrade';
+    }
+    else {
+        assert_and_click 'live-installation';
+    }
     assert_and_click 'maximize';
     mouse_hide;
     # Wait until the first screen is shown, only way to make sure it's idle


### PR DESCRIPTION
LIVE_UPGRADE=1 works like LIVE_INSTALLATION=1, but it starts an upgrade
workflow.

With Leap 15.1, the beta warning appears, so that needs to be handled as well.

- Verification run: http://10.160.67.86/tests/177#