### PR TITLE
Wait longer for firefox to start and load the page

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -605,7 +605,7 @@ sub restart_firefox {
 sub firefox_check_default {
     # needle can sometimes match before firefox start to load page
     # svirt is special case with TIMEOUT_SCALE=3 which does not affect wait_still_screen
-    my $stilltime = get_var('TIMEOUT_SCALE') ? 30 : 5;
+    my $stilltime = get_var('TIMEOUT_SCALE') ? 60 : 5;
     wait_still_screen $stilltime;
     # Set firefox as default browser if asked
     assert_screen [qw(firefox_default_browser firefox-url-loaded)], 150;


### PR DESCRIPTION
On slow machines like svirt-hyperv2012r2 with TIMEOUT_SCALE=3

- Related ticket: https://progress.opensuse.org/issues/43277
