### PR TITLE
NM_wpa2_enterprise: Increase wait_still_screen time to get more time

### DIFF
--- a/tests/x11/network/NM_wpa2_enterprise.pm
+++ b/tests/x11/network/NM_wpa2_enterprise.pm
@@ -26,7 +26,7 @@ sub run {
 
     # the root console will most likely be polluted with dmesg output
     select_console 'root-console', await_console => 0;
-    wait_still_screen 3;
+    wait_still_screen 6;
     clear_console;
     assert_screen 'root-console';
     $self->NM_disable_ip;


### PR DESCRIPTION
before cleaning the screen on slow worker, such as aarch64 worker

It should fix: https://openqa.opensuse.org/tests/787378#step/NM_wpa2_enterprise/16
