### PR TITLE
Separate main.pm for kubic

### DIFF
--- a/products/kubic/main.pm
+++ b/products/kubic/main.pm
@@ -1,1 +1,73 @@
-../caasp/main.pm
+use strict;
+use warnings;
+use testapi qw(check_var get_var get_required_var);
+use needle;
+use File::Basename;
+BEGIN {
+    unshift @INC, dirname(__FILE__) . '/../../lib';
+}
+use utils;
+use main_common;
+
+init_main();
+
+my $distri = testapi::get_required_var('CASEDIR') . '/lib/susedistribution.pm';
+require $distri;
+testapi::set_distribution(susedistribution->new());
+
+sub loadtests {
+    my $filter = shift;
+    return 1 unless $filter;
+
+    if ($filter eq 'boot_from_dvd') {
+        loadtest 'installation/bootloader_uefi' if (get_var("UEFI"));
+        loadtest 'installation/bootloader' unless (get_var("UEFI"));
+    }
+
+    if ($filter eq 'boot_from_disk') {
+        # Preparation for start testing
+        loadtest 'kubic/disk_boot';
+        loadtest 'kubic/networking';
+        loadtest 'kubic/repositories';
+    }
+
+    if ($filter eq 'installation') {
+        # Full list of installation test-modules can be found at 'main_common.pm'
+        load_inst_tests;
+    }
+
+    if ($filter eq 'feature') {
+        # Feature tests for Micro OS operating system
+        loadtest 'caasp/create_autoyast' unless check_var('VIRSH_VMM_FAMILY', 'hyperv');
+        loadtest 'caasp/libzypp_config';
+        loadtest 'caasp/one_line_checks';
+        loadtest 'caasp/filesystem_ro';
+        loadtest 'caasp/services_enabled';
+        loadtest 'caasp/transactional_update';
+        loadtest 'caasp/rebootmgr';
+        loadtest 'caasp/journal_check';
+    }
+
+    if ($filter eq 'rcshell') {
+        # Tests before the YaST installation
+        loadtest 'caasp/rcshell_start';
+        loadtest 'caasp/libzypp_config';
+        loadtest 'caasp/one_line_checks';
+    }
+}
+
+#######################
+# Testing starts here #
+#######################
+loadtests 'boot_from_dvd';
+if (get_var 'SYSTEM_ROLE') {
+    loadtests 'installation';
+    loadtests 'boot_from_disk';
+    loadtests 'feature' if (check_var 'EXTRA', 'FEATURES');
+    loadtest 'shutdown/shutdown';
+}
+else {
+    loadtests('rcshell') if (check_var 'EXTRA', 'RCSHELL');
+}
+
+1;

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,35 @@
+# Testing Kubic
+
+This page will outline how to ensure that a Kubic-deployed Kubernetes cluster
+has stood up correctly and is ready to accept workloads.
+
+## Before you begin
+
+This page assumes you have a working openQA deployed instance.
+
+## Single-Node testing
+
+Single-node tests for Kubic provide a mechanism to test the behavior of the
+underlying operating-system, and is the last signal to ensure end-user
+operations match Kubernetes specifications. Although unit and integrations
+tests provide a good signal, it is not uncommon that a minor change
+may pass all unit and integration tests, but cause unforeseen changes at
+the final state of the product release.
+
+The primary objectives of single-node tests in openQA are to ensure a
+consistent and reliable behavior of Kubic code base, and catch hard-to-test
+bugs before users do, when unit and integration tests are insufficient.
+
+Single-Node tests will pass on properly running on KVM virtual-machines.
+
+#### Testsuites
+
+* kubeadm@64bit-4G-HD40G
+* microos@64bit-4G-HD40G
+* microos@uefi-4G-HD40G
+* microos_10G-disk
+* rcshell
+
+## Cluster testing
+
+*In progress...*

--- a/tests/caasp/first_boot.pm
+++ b/tests/caasp/first_boot.pm
@@ -27,12 +27,6 @@ sub run {
     }
 
     microos_login;
-    if (check_var('DISTRI', 'kubic')) {
-        zypper_call("mr -da");
-        my $mirror = get_required_var('MIRROR_HTTP');
-        zypper_call("--no-gpg-check ar -f '$mirror' mirror_http");
-        zypper_call('ref');
-    }
 
     if (is_caasp 'VMX') {
         # Help cloud-init on cluster tests

--- a/tests/kubic/disk_boot.pm
+++ b/tests/kubic/disk_boot.pm
@@ -1,21 +1,30 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Start feature tests before installation
-# Maintainer: Martin Kravec <mkravec@suse.com>
+# Summary: Boot from disk and login into Kubic
+# Maintainer: Panagiotis Georgiadis <pgeorgiadis@suse.com>
 
 use base "opensusebasetest";
 use strict;
 use testapi;
 
+use caasp "microos_login";
+
 sub run {
-    assert_screen 'startshell', 150;
+    assert_screen 'grub2';
+    send_key 'ret';
+    microos_login;
+}
+
+sub test_flags {
+    return {fatal => 1};
 }
 
 1;
+

--- a/tests/kubic/networking.pm
+++ b/tests/kubic/networking.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test network connectivity
+# Maintainer: Panagiotis Georgiadis <pgeorgiadis@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+
+sub run {
+    # ping
+    assert_script_run 'ping -c 1 127.0.0.1';
+    assert_script_run 'ping -c 1 ::1';
+
+    # curl
+    assert_script_run 'curl -L openqa.opensuse.org';    # openQA Networking (required for mirrors)
+    assert_script_run 'curl -L github.com';             # Required for kubeadm (behind the scenes)
+
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+

--- a/tests/kubic/repositories.pm
+++ b/tests/kubic/repositories.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Configure Kubic repositories
+# Maintainer: Panagiotis Georgiadis <pgeorgiadis@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+use utils "zypper_call";
+
+sub run {
+    # MIRROR_HTTP it's a mirror of the REPO including unreleased packages
+    # and it also contains everything from the current ISO under test
+    if (get_var('MIRROR_HTTP')) {
+        # Kubic repos might have *older* version of packages compared MIRROR_HTTP
+        # Any pkg installation from now on, should come from the MIRROR_HTTP
+        zypper_call("mr -da");
+        my $mirror = get_required_var('MIRROR_HTTP');
+        zypper_call("--no-gpg-check ar -f '$mirror' mirror_http");
+    }
+    zypper_call('ref');
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+


### PR DESCRIPTION
* Create a separate `main.pm` for Kubic
* Prepare the system after inst. (boot, login, network, repo, etc)
* Increase the timeout for `rcshell`

- Related ticket: *none*
- Needles: *not needed*
- Verification run: http://alfano.arch.suse.de/tests/overview?distri=kubic&version=Tumbleweed&build=new_main&groupid=2
