### PR TITLE
Wait for still screen after searching in YaST Control Center

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -39,6 +39,9 @@ sub search {
         send_key 'backspace';
     }
     wait_screen_change { type_string $name; } if $name;
+    # After typing some icons get detected before it's filetered
+    # Adding extra sync point before trying to click
+    wait_still_screen 3;
 }
 
 sub start_addon_products {


### PR DESCRIPTION
Fixes https://openqa.suse.de/tests/2240725#step/yast2_control_center/114
where we click on the icon before typing in the search field reached all
symbols and filter was applied.

- [Verification run](http://g226.suse.de/tests/3023)
