### PR TITLE
Disable MTA test on JeOS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1489,7 +1489,7 @@ sub load_extra_tests_textmode {
     unless (is_sle '<15') {
         loadtest "console/ntp_client";
     }
-    loadtest "console/mta";
+    loadtest "console/mta" unless is_jeos;
     if (get_var("IPSEC")) {
         loadtest "console/ipsec_tools_h2h";
     }


### PR DESCRIPTION
Breaks: https://openqa.suse.de/tests/2240732#step/mta/7

JeOS does not have MTA.

@asdil12 