### PR TITLE
Disable serial-getty before running commands in xterm

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -2,8 +2,17 @@ package susedistribution;
 use base 'distribution';
 use serial_terminal ();
 use strict;
-use utils
-  qw(type_string_slow ensure_unlocked_desktop save_svirt_pty get_root_console_tty get_x11_console_tty ensure_serialdev_permissions pkcon_quit zypper_call);
+use utils qw(
+  disable_serial_getty
+  ensure_serialdev_permissions
+  ensure_unlocked_desktop
+  get_root_console_tty
+  get_x11_console_tty
+  pkcon_quit
+  save_svirt_pty
+  type_string_slow
+  zypper_call
+);
 use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x);
 use ipmi_backend_utils 'use_ssh_serial_console';
 
@@ -331,6 +340,7 @@ sub become_root {
     my ($self) = @_;
 
     $self->script_sudo('bash', 0);
+    disable_serial_getty;
     type_string "whoami > /dev/$testapi::serialdev\n";
     wait_serial('root') || die "Root prompt not there";
     type_string "cd /tmp\n";

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -75,6 +75,7 @@ our @EXPORT = qw(
   zypper_ar
   show_tasks_in_blocked_state
   svirt_host_basedir
+  disable_serial_getty
 );
 
 
@@ -871,6 +872,22 @@ sub ensure_serialdev_permissions {
     else {
         assert_script_run "chown $testapi::username /dev/$testapi::serialdev && gpasswd -a $testapi::username \$(stat -c %G /dev/$testapi::serialdev)";
     }
+}
+
+=head2 disable_serial_getty
+Serial getty service pollutes serial output with login propmt, which
+interferes with the output, e.g. when calling script_output.
+Login prompt messages on serial are used on some remote backend to
+identify that system has been booted, so do not mask on non-qemu backends
+=cut
+sub disable_serial_getty {
+    my ($self) = @_;
+    # Stop serial-getty on serial console to avoid serial output pollution with login prompt
+    # Doing early due to bsc#1103199 and bsc#1112109
+    systemctl "stop serial-getty\@$testapi::serialdev", ignore_failure => 1;
+    systemctl "disable serial-getty\@$testapi::serialdev";
+    # Mask if is qemu backend as use serial in remote installations e.g. during reboot
+    systemctl "mask serial-getty\@$testapi::serialdev" if check_var('BACKEND', 'qemu');
 }
 
 =head2 exec_and_insert_password

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -25,12 +25,7 @@ sub run {
     save_screenshot;
     check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
 
-    # Stop serial-getty on serial console to avoid serial output pollution with login prompt
-    # Doing early due to bsc#1103199 and bsc#1112109
-    systemctl "stop serial-getty\@$testapi::serialdev", ignore_failure => 1;
-    systemctl "disable serial-getty\@$testapi::serialdev";
-    # Mask if is qemu backend as use serial in remote installations e.g. during reboot
-    systemctl "mask serial-getty\@$testapi::serialdev" if check_var('BACKEND', 'qemu');
+    disable_serial_getty;
     # init
     check_console_font;
 


### PR DESCRIPTION
Mitigation to
[bsc#1112109](https://bugzilla.opensuse.org/show_bug.cgi?id=1112109), we
have applied it to console tests, but x11 also get affected when
running commands in the xterm. Therefore, we need to run it there too.

See [poo#42359](https://progress.opensuse.org/issues/42359).

I've triggered 50+ runs, most of them are still in progress.
- [Verification run](http://g226.suse.de/tests/3030#step/gnuhealth_install/5).
