### PR TITLE
Increase default boot time

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -320,7 +320,7 @@ sub wait_boot {
     my ($self, %args) = @_;
     my $bootloader_time = $args{bootloader_time} // 100;
     my $textmode        = $args{textmode};
-    my $ready_time      = $args{ready_time} // 200;
+    my $ready_time      = $args{ready_time} // 300;
     my $in_grub         = $args{in_grub} // 0;
     my $nologin         = $args{nologin};
     my $forcenologin    = $args{forcenologin};


### PR DESCRIPTION
Waiting two more minutes for grub to show up, if the test runs
on ppc64le

- Related ticket: https://progress.opensuse.org/issues/43064 https://progress.opensuse.org/issues/46385
- Verification run: still needed