### PR TITLE
Do not run syslog checks on JeOS

### DIFF
--- a/tests/console/syslog.pm
+++ b/tests/console/syslog.pm
@@ -22,7 +22,7 @@ sub run {
 
     assert_script_run '! rpm -q syslog-ng';
 
-    if (!is_tumbleweed) {
+    if (!is_tumbleweed && !is_jeos) {
         # check if rsyslogd is installed, enabled and running
         assert_script_run 'rpm -q rsyslog';
         systemctl 'is-enabled rsyslog';


### PR DESCRIPTION
Breaks: https://openqa.suse.de/tests/2242457#step/syslog/8

JeOS does not ship syslog, nor has requirement to do so.

Validation run:
* http://nilgiri.suse.cz/tests/1761