### PR TITLE
Fix LTP on IPMI

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -33,9 +33,7 @@ sub run {
         $self->wait_boot(ready_time => 500);
     }
 
-    if (select_virtio_console()) {
-        script_run('dmesg --console-level 7');
-    }
+    select_virtio_console();
 
     assert_script_run('export LTPROOT=/opt/ltp; export LTP_COLORIZE_OUTPUT=n TMPDIR=/tmp PATH=$LTPROOT/testcases/bin:$PATH');
 

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -33,7 +33,8 @@ sub run {
         $self->wait_boot(ready_time => 500);
     }
 
-    select_virtio_console();
+    select_console 'root-ssh' if (check_var('BACKEND', 'ipmi'));
+    select_virtio_console()   if (check_var('BACKEND', 'qemu'));
 
     assert_script_run('export LTPROOT=/opt/ltp; export LTP_COLORIZE_OUTPUT=n TMPDIR=/tmp PATH=$LTPROOT/testcases/bin:$PATH');
 

--- a/tests/kernel/change_kernel.pm
+++ b/tests/kernel/change_kernel.pm
@@ -39,7 +39,8 @@ sub run {
     my $pkg  = get_var('CHANGE_KERNEL_PKG') || 'kernel-default';
 
     $self->wait_boot;
-    select_virtio_console();
+    select_console 'root-ssh' if (check_var('BACKEND', 'ipmi'));
+    select_virtio_console()   if (check_var('BACKEND', 'qemu'));
 
     # Avoid conflicts by removing any existing kernels
     remove_kernel_packages();

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -269,7 +269,8 @@ sub run {
         select_console('root-console');
         add_serial_console('hvc1');
     }
-    select_virtio_console();
+    select_console 'root-ssh' if (check_var('BACKEND', 'ipmi'));
+    select_virtio_console()   if (check_var('BACKEND', 'qemu'));
 
     if (script_output('cat /sys/module/printk/parameters/time') eq 'N') {
         script_run('echo 1 > /sys/module/printk/parameters/time');


### PR DESCRIPTION
Quick fix, as PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6073 takes long to be accepted. Both fixes the same thing, but this is just a fix, whereas https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6073 is also a proper cleanup.

Verification runs:
* ltp_net_ipv6_lib
http://quasar.suse.cz/tests/1222
* ltp_ima
http://quasar.suse.cz/tests/1223