### PR TITLE
Do not run etcd tests for kubeadm

### DIFF
--- a/tests/caasp/rebootmgr.pm
+++ b/tests/caasp/rebootmgr.pm
@@ -110,7 +110,7 @@ sub run {
     record_info 'Maint-window', 'Test maint-window strategy';
     check_strategy_maint_window;
 
-    if (!check_var('SYSTEM_ROLE', 'microos')) {
+    if (!is_caasp('kubic')) {
         record_info 'Etcd', 'Test etcd locking strategy';
         check_strategy_etcd_lock;
     }


### PR DESCRIPTION
etcd is not installed in `kubeadm role`. As a result any tests related to that should be skipped.
> Fixes: https://openqa.opensuse.org/tests/789709#step/rebootmgr/70

- Related ticket: *none*
- Needles: *not needed*
- Verification run: http://alfano.arch.suse.de/tests/271
