### PR TITLE
Update rsync test to account for ssh permission changes

### DIFF
--- a/tests/console/rsync.pm
+++ b/tests/console/rsync.pm
@@ -40,7 +40,18 @@ sub run {
     if (script_run('! test -e ~/.ssh')) {
         assert_script_run('ssh-keygen -R localhost');
     }
+
+    if (is_opensuse) {
+        my $output = script_output('cat /etc/ssh/sshd_config | grep "#PermitRootLogin"');
+        if ($output =~ 'prohibit-password') {
+            clear_console;
+            assert_script_run("sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/g' /etc/ssh/sshd_config");
+            assert_script_run("systemctl restart sshd");
+        }
+    }
+
     type_string("rsync -avzr /tmp/rsync_test_folder_a/ root\@localhost:/tmp/rsync_test_folder_b; echo \$\? > /tmp/rsync_return_code.txt\n");
+
     if (is_jeos || is_sle) {
         assert_screen('remote-ssh-login');
     }
@@ -70,6 +81,14 @@ sub post_run_hook {
     assert_script_run('rm -rf /tmp/rsync_test_folder_a');
     assert_script_run('rm -rf /tmp/rsync_test_folder_b');
     assert_script_run('rm /tmp/rsync_return_code.txt');
+
+    if (is_opensuse) {
+        my $output = script_output('cat /etc/ssh/sshd_config | grep PermitRootLogin');
+        if ($output =~ 'yes') {
+            assert_script_run("sed -i 's/PermitRootLogin yes/#PermitRootLogin prohibit-password/g' /etc/ssh/sshd_config");
+            assert_script_run("systemctl restart sshd");
+        }
+    }
 }
 
 1;


### PR DESCRIPTION
The update changes PermitRootLogin to yes, restarts the service and reverts the change at the end of the test.

Related ticket: https://progress.opensuse.org/issues/43556, https://build.opensuse.org/request/show/645637
Validation runs: http://ccret.suse.cz/tests/1646, http://ccret.suse.cz/tests/1645#step/rsync/32, http://ccret.suse.cz/tests/1647#
