### PR TITLE
Fail znc test if makeconf call fails

### DIFF
--- a/tests/console/znc.pm
+++ b/tests/console/znc.pm
@@ -19,7 +19,7 @@ sub run {
 
     script_run("sudo -u znc znc --makeconf | tee /dev/$serialdev; echo zncconf-status-\$? > /dev/$serialdev", 0);
 
-    wait_serial('Listen on port');
+    wait_serial('Listen on port') || die "znc --makeconf failed";
     type_string("12345\n");
 
     wait_serial('Listen using SSL');


### PR DESCRIPTION
It ignored the return value and did weird stuff afterwards.

Untested.