### PR TITLE
Increase stability ncurses tests

### DIFF
--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -47,6 +47,7 @@ sub run {
         assert_screen 'yast2-dns-server-start-named-now';
     }
     else {
+        assert_screen 'yast2-dns-server-open-port-firewall-focused';    # ensure dialog content loaded
         change_service_configuration(
             after_writing => {start         => 'alt-t'},
             after_reboot  => {start_on_boot => 'alt-a'}

--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -213,7 +213,7 @@ sub setup_samba_share {
 
     # Identification
     assert_screen 'yast2_samba-server_new-share';
-    send_key $actions{name}->{shortcut};
+    send_key_until_needlematch 'yast2_samba-share-name-focused', $actions{name}->{shortcut}, 5;    # ensure responsive
     type_string $actions{name}->{value};
     wait_screen_change { send_key $actions{description}->{shortcut} };
     type_string $actions{description}->{value};


### PR DESCRIPTION
#### Description
Increase stability for ncurses tests:
  * Ensure that the dialog is loaded via verifying that the first control to be focus is focused in yast2_dns_server.
  * Ensure that focus is on the first text box when creating share in yast2_samba.
#### Related ticket
https://progress.opensuse.org/issues/42413
#### Needles
[needles opensuse](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/470) [needles sle](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/985)
#### Verification run
  * Tumbleweed-yast2_ncurses@64bit:
    * [yast2_dns_server](http://dhcp42.suse.cz/tests/833#step/yast2_dns_server/10) | [yast2_samba](http://dhcp42.suse.cz/tests/833#step/yast2_samba/52)
  * Tumbleweed-yast2_ncurses@aarch64
    * [yast2_dns_server](http://dhcp42.suse.cz/tests/836#step/yast2_dns_server/10) | [yast2_samba](http://dhcp42.suse.cz/tests/836#step/yast2_samba/52)
  * Leap-15.1-yast2_ncurses:
    * [yast2_dns_server](http://dhcp42.suse.cz/tests/834#step/yast2_dns_server/10) | [yast2_samba](http://dhcp42.suse.cz/tests/834#step/yast2_samba/52)
  * sle-15-SP1-yast2_ncurses
    * [yast2_dns_server](http://dhcp42.suse.cz/tests/837#step/yast2_dns_server/9) | [yast2_samba](http://dhcp42.suse.cz/tests/837#step/yast2_samba/52)