### PR TITLE
Skip grub2 needle if system has already booted

### DIFF
--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -143,8 +143,16 @@ sub process_reboot {
     # caasp - grub2 needle is unreliable (stalls during timeout) - poo#28648
     # kubic - will risk occasional failure because it disabled grub2 timeout
     if (is_caasp 'kubic') {
-        assert_screen 'grub2';
-        send_key 'ret';
+        assert_screen [qw(grub2 linux-login-casp)], 150;
+        if (match_has_tag 'linux-login-casp') {
+            record_info('poo#28648', 'Skip looking for grub2 needle - the system has already been booted');
+        }
+        elsif (match_has_tag 'grub2') {
+            send_key 'ret';
+        }
+        else {
+            die 'Kubic did not manage to reboot properly';
+        }
     }
     microos_login;
 }

--- a/tests/caasp/rebootmgr.pm
+++ b/tests/caasp/rebootmgr.pm
@@ -16,6 +16,7 @@ use base "opensusebasetest";
 use testapi;
 use caasp;
 use utils;
+use version_utils 'is_caasp';
 
 # Optionally skip exit status check in case immediate reboot is expected
 sub rbm_call {


### PR DESCRIPTION
The `process_reboot` is unreliable due to the fact that grub2
splascreen does not have a countdown timer. As a result there
might be some case where openQA waits for the grub2, while the
system has already passed that step and it waiting at the login
prompt. This PR fixes this by skipping the test for grub2 in
case grub splashscreen was too fast to check for.

- Related ticket: poo#28648
- Needles: *not needed*
- Verification run: http://alfano.arch.suse.de/tests/278