### PR TITLE
Completely disable ntp_client for sle

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1487,10 +1487,8 @@ sub load_extra_tests_textmode {
     }
     loadtest "console/cron";
     loadtest "console/syslog";
-    unless (is_sle '<15') {
-        loadtest "console/ntp_client";
-    }
-    loadtest "console/mta" unless is_jeos;
+    loadtest "console/ntp_client" unless is_sle;
+    loadtest "console/mta"        unless is_jeos;
     if (get_var("IPSEC")) {
         loadtest "console/ipsec_tools_h2h";
     }


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/43052
Chrony on sle needs to be manually enabled