### PR TITLE
Increase timeout for long stilltime on svirt-hyperv2012r2

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -606,7 +606,7 @@ sub firefox_check_default {
     # needle can sometimes match before firefox start to load page
     # svirt is special case with TIMEOUT_SCALE=3 which does not affect wait_still_screen
     my $stilltime = get_var('TIMEOUT_SCALE') ? 100 : 10;
-    wait_still_screen $stilltime;
+    wait_still_screen $stilltime, 100;
     # Set firefox as default browser if asked
     assert_screen [qw(firefox_default_browser firefox-url-loaded)], 150;
     if (match_has_tag('firefox_default_browser')) {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/43526
- Verification run: http://10.100.12.155/tests/8651#step/firefox/3
