### PR TITLE
qa_automation: make log process in execute_test_run stable

### DIFF
--- a/tests/qa_automation/execute_test_run.pm
+++ b/tests/qa_automation/execute_test_run.pm
@@ -34,6 +34,7 @@ sub run {
 
     #output result to serial0 and upload test log
     if (get_var("QA_TESTSUITE")) {
+        assert_script_run("sync");
         my $tarball = "/tmp/testlog.tar.bz2";
         assert_script_run("tar cjf $tarball -C /var/log/qa/ctcs2 `ls /var/log/qa/ctcs2/`");
         upload_logs($tarball, timeout => 600);


### PR DESCRIPTION
Add a short sleep(2 second) in case:
1) previous step contain fs_stress
2) previous log writing stream too much in /tmp and not finish yet
Tried with write new log into another direction, but still could reproduce this issue, so a necessary sleep here not cost much time.

- Related ticket: https://progress.opensuse.org/issues/37782
- Verification run: http://10.67.133.102/tests/691