### PR TITLE
Select acl group regardless of the position in the list

### DIFF
--- a/tests/console/yast2_proxy.pm
+++ b/tests/console/yast2_proxy.pm
@@ -26,7 +26,7 @@ my %sub_menu_needles = (
     cache_dir     => 'yast2_proxy_http_cache_directory_selected',
     access_ctrl   => 'yast2_proxy_http_access_control_selected',
     log_timeouts  => 'yast2_proxy_logging_timeouts_selected',
-    miscellaneous  => 'yast2_proxy_miscellaneous_selected'
+    miscellaneous => 'yast2_proxy_miscellaneous_selected'
 );
 
 sub select_sub_menu {
@@ -205,9 +205,7 @@ sub run {
     wait_still_screen 1;
     # change subnet for 192.168.0.0/16 to 192.168.0.0/18
     wait_screen_change { send_key 'tab'; };
-    wait_screen_change { send_key 'down'; };
-    wait_screen_change { send_key 'down'; };
-    assert_screen 'yast2_proxy_acl_group_localnet';
+    send_key_until_needlematch 'yast2_proxy_acl_group_localnet', 'down';
     wait_still_screen 1;
     send_key 'alt-i';
     assert_screen 'yast2_proxy_acl_group_edit';
@@ -269,7 +267,7 @@ sub run {
     # move to Start-Up and start proxy server now
     #	for (1..35) {send_key 'tab'; save_screenshot;}
     send_key_until_needlematch 'yast2_proxy_miscellaneous_selected', 'shift-tab';
-    send_key_until_needlematch 'yast2_proxy_start-up',              'up';
+    send_key_until_needlematch 'yast2_proxy_start-up',               'up';
     wait_still_screen 1;
     send_key 'ret';
 

--- a/tests/console/yast2_proxy.pm
+++ b/tests/console/yast2_proxy.pm
@@ -7,11 +7,12 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Test thast squid proxy can be started after setup with YaST
+# Summary: Test that squid proxy can be started after setup with YaST
 # Maintainer: Zaoliang Luo <zluo@suse.de>
 
 use strict;
 use base "console_yasttest";
+use warnings;
 use testapi;
 use utils;
 use version_utils qw(is_sle is_leap);
@@ -25,7 +26,7 @@ my %sub_menu_needles = (
     cache_dir     => 'yast2_proxy_http_cache_directory_selected',
     access_ctrl   => 'yast2_proxy_http_access_control_selected',
     log_timeouts  => 'yast2_proxy_logging_timeouts_selected',
-    miscellanous  => 'yast2_proxy_miscellanous_selected'
+    miscellaneous  => 'yast2_proxy_miscellaneous_selected'
 );
 
 sub select_sub_menu {
@@ -251,8 +252,8 @@ sub run {
     # check above changes for logging and timeouts
     assert_screen 'yast2_proxy_logging_timeouts_new';
 
-    #	move to miscellanous now for change language into de-de and admin email
-    select_sub_menu 'log_timeouts', 'miscellanous';
+    #	move to miscellaneous now for change language into de-de and admin email
+    select_sub_menu 'log_timeouts', 'miscellaneous';
     wait_screen_change { send_key 'alt-l'; };
     for (1 .. 5) {
         wait_screen_change { send_key 'up'; };
@@ -263,11 +264,11 @@ sub run {
     type_string 'webmaster@localhost';
 
     # check language and email now
-    assert_screen 'yast2_proxy_miscellanous';
+    assert_screen 'yast2_proxy_miscellaneous';
 
     # move to Start-Up and start proxy server now
     #	for (1..35) {send_key 'tab'; save_screenshot;}
-    send_key_until_needlematch 'yast2_proxy_miscellanous_selected', 'shift-tab';
+    send_key_until_needlematch 'yast2_proxy_miscellaneous_selected', 'shift-tab';
     send_key_until_needlematch 'yast2_proxy_start-up',              'up';
     wait_still_screen 1;
     send_key 'ret';


### PR DESCRIPTION
**For Reviewers: Please merge [needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/989) before merging the PR.**

ACL group selection was failed because of relying on the position of the
group in the list.

The commit uses assert_until_needle_match subroutine to select the acl
group without relying on it's position in the list.

Also, the PR fixes some typos.

- Related ticket: https://progress.opensuse.org/issues/43289
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/989
- Verification run 
   - SLE15, s390x: http://oorlov-vm.qa.suse.de/tests/516
   - SLE12: http://oorlov-vm.qa.suse.de/tests/628
