### PR TITLE
Record soft failure bsc#1004643 & bsc#1111483

### DIFF
--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -48,6 +48,7 @@ sub open_network_settings {
     type_string "yast2 lan\n";
     accept_warning_network_manager_default;
     assert_screen 'yast2_lan', 100;       # yast2 lan overview tab
+    send_key 'home';                      # select first device
     wait_still_screen(2);
 }
 

--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -55,6 +55,7 @@ sub check_default_gateway {
 
 sub change_hw_device_name {
     my $dev_name = shift;
+
     send_key 'alt-i';        # Edit NIC
     assert_screen 'yast2_lan_network_card_setup';
     send_key 'alt-w';        # Hardware tab
@@ -86,6 +87,7 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = @_;
+
     assert_script_run 'journalctl -b > /tmp/journal', 90;
     upload_logs '/tmp/journal';
     $self->SUPER::post_fail_hook;


### PR DESCRIPTION
Record soft failure for bsc#1004643.
- Related ticket: https://progress.opensuse.org/issues/42782
- Needles: [~needles sle~](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/990)
- Verification run: Today due to low-performance in the ppc worker I cannot get verification (it is constantly failing in different steps of the test suite), but from last day I have [sle-15-SP1-extra_tests_on_gnome@ppc64le](http://dhcp42.suse.cz/tests/855#step/yast2_lan_restart_devices/31) to see the second soft-failure (as the first will be only visible in prod sporadically).
