### PR TITLE
Add wicked to unused modules script

### DIFF
--- a/tools/detect_unused_modules
+++ b/tools/detect_unused_modules
@@ -6,10 +6,10 @@ for test in $(git ls-files "*tests/*.pm") ; do
     git grep -qE "($t|load_testdir.*$t_dir)" || echo $test
 done | \
     # fetchmail_ssl, mailx_ssl, mutt_ssl, postfix_tls: https://progress.opensuse.org/issues/31750
-    # qa_automation, hpc, caasp/stack_admin: Tests are loaded dynamically
+    # qa_automation, hpc, caasp/stack_admin, wicked: Tests are loaded dynamically
     # based on test variable content
     # slepos: Requested by nadvornik, used in sle11 tests
     # verify_firewalld: Loaded dynamically by AUTOYAST_VERIFY_MODULE
     # zypper_moo: https://progress.opensuse.org/issues/32302
-    grep -vE '(fetchmail_ssl|mailx_ssl|mutt_ssl|postfix_tls|qa_automation/|hpc/|slepos/|caasp/stack_admin)' \
+    grep -vE '(fetchmail_ssl|mailx_ssl|mutt_ssl|postfix_tls|qa_automation/|hpc/|slepos/|caasp/stack_admin|wicked)' \
     && { exit 1; } || { exit 0; }


### PR DESCRIPTION
Wicked tests are now loaded dynamically, Therefore, to make Travis pass, we need to exclude from this check. 