### PR TITLE
Workaround issue with send_key for quit evolution

### DIFF
--- a/tests/x11/evolution.pm
+++ b/tests/x11/evolution.pm
@@ -41,7 +41,7 @@ sub run {
 
     assert_screen(['generic-desktop', 'evolution-main-window'], timeout => 30);
     if (match_has_tag 'evolution-main-window') {
-        send_key 'alt-f4';
+        assert_and_click "close_evolution";
     }
 }
 


### PR DESCRIPTION
we have sometimes problem with send_key 'alt-f4' to
close evolution.
create a new needle for assert_and_click to workaround
this issue
verification run:
http://e13.suse.de/tests/9907#step/evolution (SLES)
http://e13.suse.de/tests/9950#step/evolution (TW)

needle PR:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/991
