### PR TITLE
Save testing ressources on travis CI with static checks on only one perl version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: perl
-perl:
-  - "5.18"
-  - "5.26"
+matrix:
+  include:
+  - name: "openSUSE/SUSE production perl version, only compile check"
+    perl: "5.18"
+    env: TESTS=compile
+  - name: "testing perl version, all tests"
+    perl: "5.26"
+    env: TESTS=all
 addons:
   apt:
     packages:

--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,15 @@ test-dry:
 test-no-wait_idle:
 	@! git grep wait_idle lib/ tests/
 
+.PHONY: test-static
+test-static: tidy test-merge test-dry test-no-wait_idle test-unused-modules test-record_soft_failure-no-reference
+
 .PHONY: test
-test: tidy test-compile test-merge test-dry test-no-wait_idle test-unused-modules test-record_soft_failure-no-reference
+ifeq ($(TESTS),compile)
+test: test-compile
+else
+test: test-static test-compile
+endif
 
 PERLCRITIC=PERL5LIB=tools/lib/perlcritic:$$PERL5LIB perlcritic --quiet --gentle --include Perl::Critic::Policy::HashKeyQuote --include Perl::Critic::Policy::ConsistentQuoteLikeWords
 


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/42953