### PR TITLE
Fix select_serial_terminal() usage

### DIFF
--- a/tests/slenkins/login.pm
+++ b/tests/slenkins/login.pm
@@ -17,7 +17,7 @@
 # Maintainer: Vladimir Nadvornik <nadvornik@suse.cz>
 
 use strict;
-use base 'basetest';
+use base "opensusebasetest";
 use testapi;
 
 sub run {


### PR DESCRIPTION
Fixes: 13018da1b ("Remove select_virtio_console() and replace it with
select_serial_terminal()")