### PR TITLE
Increase the timeout for docker pull commands (poo#43598)

### DIFF
--- a/tests/console/docker_image.pm
+++ b/tests/console/docker_image.pm
@@ -60,7 +60,7 @@ sub run {
 
     for my $i (0 .. $#image_names) {
         # Load the image
-        assert_script_run("docker pull $image_names[$i]", 120);
+        assert_script_run("docker pull $image_names[$i]", 600);
         # Running executables works
         assert_script_run qq{docker container run --entrypoint '/bin/bash' --rm $image_names[$i] -c 'echo "I work" | grep "I work"'};
         # It is the right SLE version
@@ -77,9 +77,9 @@ sub run {
 
         # container-diff
         my $image_file = $image_names[$i] =~ s/\/|:/-/gr;
-        assert_script_run("docker pull $image_names[$i]");
-        assert_script_run("docker pull $stable_names[$i]");
-        assert_script_run("container-diff diff daemon://$image_names[$i] daemon://$stable_names[$i] --type=rpm --type=file --type=history > /tmp/container-diff-$image_file.txt");
+        assert_script_run("docker pull $image_names[$i]",  600);
+        assert_script_run("docker pull $stable_names[$i]", 600);
+        assert_script_run("container-diff diff daemon://$image_names[$i] daemon://$stable_names[$i] --type=rpm --type=file --type=history > /tmp/container-diff-$image_file.txt", 300);
         upload_logs("/tmp/container-diff-$image_file.txt");
 
         # Remove the image again to save space


### PR DESCRIPTION
Good morning,

the `docker_image` test is failing because of low timeouts. Our network can be quite slow, so that's why those numbers.

- Related ticket: [poo#43598](https://progress.opensuse.org/issues/43598)
- Needles: No need
- Verification run: [12-SP3](http://pdostal-server.suse.cz/tests/162) [15](http://pdostal-server.suse.cz/tests/163)
