### PR TITLE
Implement Salt multimachine test for QAM

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1033,13 +1033,27 @@ else {
         return 1;
     }
     elsif (get_var("QAM_OPENVPN")) {
-        loadtest "boot/boot_to_desktop";
+        boot_hdd_image;
+        loadtest 'network/setup_multimachine';
+        loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
         set_var('INSTALLONLY', 1);
         if (check_var('HOSTNAME', 'server')) {
             loadtest "network/openvpn_server";
         }
         else {
             loadtest "network/openvpn_client";
+        }
+    }
+    elsif (get_var("QAM_SALT")) {
+        boot_hdd_image;
+        loadtest 'network/setup_multimachine';
+        loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
+        set_var('INSTALLONLY', 1);
+        if (check_var('HOSTNAME', 'master')) {
+            loadtest "network/salt_master";
+        }
+        else {
+            loadtest "network/salt_minion";
         }
     }
     elsif (get_var('UPGRADE_ON_ZVM')) {

--- a/tests/network/openvpn_client.pm
+++ b/tests/network/openvpn_client.pm
@@ -19,12 +19,7 @@ use utils qw(systemctl zypper_call exec_and_insert_password);
 use strict;
 
 sub run {
-    my ($self) = @_;
     select_console "root-console";
-
-    # Configure static network, disable firewall
-    systemctl 'stop ' . $self->firewall;
-    setup_static_mm_network('10.0.2.102/24');
 
     # Install openvpn
     zypper_call('in openvpn');

--- a/tests/network/openvpn_server.pm
+++ b/tests/network/openvpn_server.pm
@@ -20,7 +20,6 @@ use utils qw(systemctl zypper_call exec_and_insert_password);
 use strict;
 
 sub run {
-    my ($self) = @_;
     barrier_create('OPENVPN_STATIC_START',    2);
     barrier_create('OPENVPN_STATIC_STARTED',  2);
     barrier_create('OPENVPN_STATIC_FINISHED', 2);
@@ -31,10 +30,6 @@ sub run {
 
     my $qa_head_repo = get_var('QA_HEAD_REPO', '');
     zypper_call("ar -Gf '$qa_head_repo'/ qa-ibs");
-
-    # Configure static network, disable firewall
-    systemctl 'stop ' . $self->firewall;
-    setup_static_mm_network('10.0.2.101/24');
 
     # Install openvpn, generate static key
     zypper_call('in openvpn easy-rsa');

--- a/tests/network/salt_master.pm
+++ b/tests/network/salt_master.pm
@@ -1,0 +1,91 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test Salt stack on two machines. Here we test mainly the
+#  master but minion is also present just for having more of those.
+# Maintainer: Pavel Dostal <pdostal@suse.cz>
+
+use base "consoletest";
+use strict;
+use testapi;
+use lockapi;
+use y2x11test 'setup_static_mm_network';
+use utils qw(zypper_call systemctl);
+
+sub run {
+    barrier_create('SALT_MINIONS_READY', 2);
+    barrier_create('SALT_FINISHED',      2);
+    select_console 'root-console';
+
+    # Install both salt master and minion and run the master daemon
+    zypper_call("in salt-master salt-minion");
+    systemctl("start salt-master");
+    systemctl("status salt-master");
+
+    # Set the right address of the salt master and run the minion
+    assert_script_run('sed -i -e "s/#master: salt/master: 10.0.2.101/" /etc/salt/minion');
+    systemctl("start salt-minion");
+    systemctl("status salt-minion");
+
+    # before accepting the key, wait until the minion is fully started (systemd might be not reliable)
+    assert_script_run('salt-run state.event tagmatch="salt/auth" quiet=True count=1', timeout => 300);
+    barrier_wait 'SALT_MINIONS_READY';
+
+    # List and accept both minions when they are ready
+    assert_script_run("salt-key -L");
+    assert_script_run("salt-key --accept-all -y");
+    assert_script_run "salt '*' test.ping";
+
+    # Run a command and wait for minion
+    assert_script_run("salt '*' cmd.run 'touch /tmp/salt_touch'", 180);
+    mutex_create 'SALT_TOUCH';
+
+    # Install a package and wait for the minion
+    assert_script_run(qq(echo "---
+sysstat:
+  pkg.installed" > /srv/salt/pkg.sls));
+    assert_script_run(qq(echo "---
+base:
+  '*':
+    - pkg" > /srv/salt/top.sls));
+    assert_script_run("salt '*' state.highstate", 180);
+    mutex_create 'SALT_STATES_PKG';
+
+    # Create user and group and wait for the minion
+    assert_script_run(qq(echo "---
+salttestgroup:
+  group.present
+
+salttestuser:
+  user.present:
+    - fullname: Salt Test
+    - shell: /usr/bin/sh
+    - home: /home/salttestuser
+    - groups:
+      - salttestgroup" > /srv/salt/user.sls));
+    assert_script_run("echo '    - user' >> /srv/salt/top.sls");
+    assert_script_run("salt '*' state.highstate", 180);
+    mutex_create 'SALT_STATES_USER';
+
+    # Set sysctl key and wait for the minion
+    assert_script_run(qq(echo "---
+net.ipv4.ip_forward:
+  sysctl.present:
+    - value: 1" > /srv/salt/sysctl.sls));
+    assert_script_run("echo '    - sysctl' >> /srv/salt/top.sls");
+    assert_script_run("salt '*' state.highstate", 180);
+    mutex_create 'SALT_STATES_SYSCTL';
+
+    # Stop both master and minion at the end
+    barrier_wait 'SALT_FINISHED';
+    systemctl 'stop salt-master';
+    systemctl 'stop salt-minion';
+}
+
+1;

--- a/tests/network/salt_minion.pm
+++ b/tests/network/salt_minion.pm
@@ -1,0 +1,56 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test Salt stack on two machines. This machine is running
+#  salt-minion only and here we test the end result of master operations.
+# Maintainer: Pavel Dostal <pdostal@suse.cz>
+
+use base "consoletest";
+use strict;
+use testapi;
+use lockapi;
+use y2x11test 'setup_static_mm_network';
+use utils qw(zypper_call systemctl);
+
+sub run {
+    select_console 'root-console';
+
+    # Install the salt minion, set the address of the master and start it
+    zypper_call('in salt-minion');
+    assert_script_run('sed -i -e "s/#master: salt/master: 10.0.2.101/" /etc/salt/minion');
+    systemctl("start salt-minion");
+    systemctl("status salt-minion");
+
+    # before accepting the key, wait until the minion is fully started (systemd might be not reliable)
+    barrier_wait 'SALT_MINIONS_READY';
+
+    # Check that the command executed from the master was successfully done
+    mutex_wait 'SALT_TOUCH';
+    assert_script_run("ls /tmp/salt_touch | grep salt_touch");
+
+    # Check that the package installed from the master is present
+    mutex_wait 'SALT_STATES_PKG';
+    assert_script_run("which pidstat");
+
+    # Check that the user and it's group created from the master are present
+    mutex_wait 'SALT_STATES_USER';
+    assert_script_run("sudo -iu salttestuser whoami");
+    assert_script_run("sudo -iu salttestuser pwd | grep /home/salttestuser");
+    assert_script_run("sudo -iu salttestuser groups | grep salttestgroup");
+
+    # Check that the sysctl value set from the master has right value
+    mutex_wait 'SALT_STATES_SYSCTL';
+    assert_script_run("sysctl -a | grep 'net.ipv4.ip_forward = 1'");
+
+    # Stop the minion at the end
+    barrier_wait 'SALT_FINISHED';
+    systemctl 'stop salt-minion';
+}
+
+1;

--- a/tests/network/setup_multimachine.pm
+++ b/tests/network/setup_multimachine.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test preparing the static IP and hostname for simple multimachine tests
+# Maintainer: Pavel Dostal <pdostal@suse.cz>
+
+use base "consoletest";
+use strict;
+use testapi;
+use lockapi;
+use y2x11test 'setup_static_mm_network';
+use utils qw(zypper_call systemctl);
+
+sub run {
+    my ($self) = @_;
+    my $hostname = get_var('HOSTNAME');
+    select_console 'root-console';
+
+    # Configure static network, disable firewall
+    systemctl 'stop ' . $self->firewall;
+    systemctl 'disable ' . $self->firewall;
+    if ($hostname =~ /server|master/) {
+        setup_static_mm_network('10.0.2.101/24');
+    }
+    else {
+        setup_static_mm_network('10.0.2.102/24');
+    }
+
+    # Set the hostname to identify both minions
+    assert_script_run "hostnamectl set-hostname $hostname";
+    assert_script_run "hostnamectl status|grep $hostname";
+    assert_script_run "hostname|grep $hostname";
+}
+
+1;


### PR DESCRIPTION
Good morning,

I wrote Salt stack multimachine test with **one master** and **two minions**.
The commands and states are called from master and verified on the other node.

- Related ticket: [poo#39137](https://progress.opensuse.org/issues/39137)
- Needles: 
- Verification run: 12-SP3=[master](http://pdostal-server.suse.cz/tests/168);[minion](http://pdostal-server.suse.cz/tests/169) 15=[master](http://pdostal-server.suse.cz/tests/170);[minion](http://pdostal-server.suse.cz/tests/171)
