### PR TITLE
Exclude unstable ncurses yast modules from schedule on s390x

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1354,29 +1354,31 @@ sub load_yast2_ncurses_tests {
         return;
     }
     # start extra yast console tests (self-contained only) from here
-    loadtest "console/yast2_proxy";
     loadtest "console/yast2_ntpclient";
     loadtest "console/yast2_tftp";
-    loadtest "console/yast2_vnc";
+    # We don't schedule some tests on s390x as they are unstable, see poo#42692
+    unless (is_s390x) {
+        loadtest "console/yast2_proxy";
+        loadtest "console/yast2_vnc";
+        loadtest "console/yast2_samba";
+        # internal nis server in suse network is used, but this is not possible for
+        # openqa.opensuse.org
+        loadtest "console/yast2_nis" if is_sle;
+        loadtest "console/yast2_http";
+        loadtest "console/yast2_ftp";
+        loadtest "console/yast2_apparmor";
+    }
     # TODO https://progress.opensuse.org/issues/20200
     # softfail record #bsc1049433 for samba and xinetd
-    loadtest "console/yast2_samba";
+
     loadtest "console/yast2_xinetd" if is_sle('<15') || is_leap('<15.0');
-    loadtest "console/yast2_apparmor";
     loadtest "console/yast2_lan_hostname";
-    # internal nis server in suse network is used, but this is not possible for
-    # openqa.opensuse.org
-    if (check_var('DISTRI', 'sle')) {
-        loadtest "console/yast2_nis";
-    }
     # yast-lan related tests do not work when using networkmanager.
     # (Livesystem and laptops do use networkmanager)
     if (!get_var("LIVETEST") && !get_var("LAPTOP")) {
         loadtest "console/yast2_dns_server";
         loadtest "console/yast2_nfs_client";
     }
-    loadtest "console/yast2_http";
-    loadtest "console/yast2_ftp";
     loadtest "console/yast2_snapper_ncurses";
     # back to desktop
     loadtest "console/consoletest_finish";

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -65,6 +65,7 @@ use constant {
           is_system_upgrading
           is_virtualization_server
           is_server
+          is_s390x
           has_product_selection
           has_license_on_welcome_screen
           )
@@ -311,10 +312,15 @@ sub is_svirt_except_s390x {
     return !get_var('S390_ZKVM') && check_var('BACKEND', 'svirt');
 }
 
+sub is_s390x {
+    return check_var('ARCH', 's390x');
+}
+
 sub is_remote_backend {
     # s390x uses only remote repos
-    return check_var('ARCH', 's390x') || check_var('BACKEND', 'svirt') || check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm');
+    return is_s390x() || check_var('BACKEND', 'svirt') || check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm');
 }
+
 
 sub is_server {
     return 1 if is_sles4sap();
@@ -388,7 +394,7 @@ configuration, otherwise returns false (0).
 =cut
 
 sub has_product_selection {
-    return is_sle('15+') && !(check_var('ARCH', 's390x') || get_var('UPGRADE'));
+    return is_sle('15+') && !(is_s390x() || get_var('UPGRADE'));
 }
 
 =head2 has_license_on_welcome_screen
@@ -403,5 +409,5 @@ configuration, otherwise returns false (0).
 =cut
 
 sub has_license_on_welcome_screen {
-    return get_var('HASLICENSE') && ((is_sle('15+') && check_var('ARCH', 's390x')) || is_sle('<15'));
+    return get_var('HASLICENSE') && ((is_sle('15+') && is_s390x()) || is_sle('<15'));
 }


### PR DESCRIPTION
See [poo#42692](https://progress.opensuse.org/issues/42692).

#6165 broke some tests as I've set `always_rollback` flag to all yast console tests. This PR contains just single commit which affects only the schedule.

#### Verification run
- [s390x](http://g226.suse.de/tests/3141#)
- [64bit](http://g226.suse.de/tests/3138#) (Extremely slow worker, loosing key presses, multiple failures due to timeouts while downloading packages, etc.).