### PR TITLE
gnucash: make sure we are in X11

### DIFF
--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -17,6 +17,8 @@ use testapi;
 use version_utils 'is_leap';
 
 sub run {
+    select_console('x11');
+
     ensure_installed('gnucash gnucash-docs yelp');
     x11_start_program('gnucash', target_match => [qw(gnucash gnucash-tip-close gnucash-assistant-close)]);
     if (match_has_tag('gnucash-tip-close')) {


### PR DESCRIPTION
It will fix cases were gnucash is started after we rolled back to a previous snapshot which was not in X11.
E.g.: https://openqa.opensuse.org/tests/792259
