### PR TITLE
Update rsync test to avoid needle mismatch

### DIFF
--- a/tests/console/rsync.pm
+++ b/tests/console/rsync.pm
@@ -42,12 +42,9 @@ sub run {
     }
 
     if (is_opensuse) {
-        my $output = script_output('cat /etc/ssh/sshd_config | grep "#PermitRootLogin"');
-        if ($output =~ 'prohibit-password') {
-            clear_console;
-            assert_script_run("sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/g' /etc/ssh/sshd_config");
-            assert_script_run("systemctl restart sshd");
-        }
+        clear_console;
+        assert_script_run("sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/g' /etc/ssh/sshd_config");
+        systemctl 'restart sshd';
     }
 
     type_string("rsync -avzr /tmp/rsync_test_folder_a/ root\@localhost:/tmp/rsync_test_folder_b; echo \$\? > /tmp/rsync_return_code.txt\n");
@@ -83,11 +80,8 @@ sub post_run_hook {
     assert_script_run('rm /tmp/rsync_return_code.txt');
 
     if (is_opensuse) {
-        my $output = script_output('cat /etc/ssh/sshd_config | grep PermitRootLogin');
-        if ($output =~ 'yes') {
-            assert_script_run("sed -i 's/PermitRootLogin yes/#PermitRootLogin prohibit-password/g' /etc/ssh/sshd_config");
-            assert_script_run("systemctl restart sshd");
-        }
+        assert_script_run("sed -i 's/PermitRootLogin yes/#PermitRootLogin prohibit-password/g' /etc/ssh/sshd_config");
+        systemctl 'restart sshd';
     }
 }
 


### PR DESCRIPTION
The update changes the place of  'clear_console' to have it run everytime.

Related ticket: https://progress.opensuse.org/issues/43613
Validation run: http://ccret.suse.cz/tests/1672#
