### PR TITLE
publiccloud: Make GCE storage name configurable

### DIFF
--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -44,7 +44,8 @@ sub provider_factory {
             private_key_id      => get_required_var('PUBLIC_CLOUD_KEY_ID'),
             private_key         => get_required_var('PUBLIC_CLOUD_KEY'),
             client_id           => get_required_var('PUBLIC_CLOUD_CLIENT_ID'),
-            region              => get_var('PUBLIC_CLOUD_REGION', 'europe-west1-b')
+            region              => get_var('PUBLIC_CLOUD_REGION', 'europe-west1-b'),
+            storage_name        => get_var('PUBLIC_CLOUD_STORAGE', 'openqa-storage')
         );
     }
     else {

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -26,6 +26,7 @@ has private_key_id      => undef;
 has private_key         => undef;
 has service_acount_name => undef;
 has client_id           => undef;
+has storage_name        => undef;
 
 sub init {
     my ($self) = @_;
@@ -71,7 +72,7 @@ sub find_img {
 sub upload_img {
     my ($self, $file) = @_;
     my $img_name = $self->file2name($file);
-    my $uri      = 'openqa-storage/' . $file;
+    my $uri      = $self->storage_name . '/' . $file;
 
     assert_script_run("gsutil cp $file gs://$uri",                                     timeout => 60 * 60);
     assert_script_run("gcloud compute images create $img_name --source-uri gs://$uri", timeout => 60 * 10);


### PR DESCRIPTION
The storage name needs to be world wide unique. This leads
to the requirement to make it configurable.

- Related ticket: https://progress.opensuse.org/issues/43223
- Verification run: http://cfconrad-vm.qa.suse.de/tests/2954

@jlausuch plz have a  look.
