### PR TITLE
Refresh repos before installing pkgs on RPi

### DIFF
--- a/tests/jeos/prepare_rpi_image.pm
+++ b/tests/jeos/prepare_rpi_image.pm
@@ -27,6 +27,7 @@ sub run {
     select_console('root-console');
 
     # System should be registered already - we need qemu-img binary
+    zypper_call('ref');
     zypper_call('in --no-recommends qemu-tools');
 
     # Download, prepare and upload the image


### PR DESCRIPTION
Related to prepare_RPi_image https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/5979

Issue visible at https://openqa.suse.de/tests/2255576#step/prepare_rpi_image/12

Once the -CURRENT repo on OSD is updated with a latest builds the product expects different versions/metadata of pkgs for the product. It can by fixed simply by "zypper ref" before running "zypper in"

- Related ticket: https://progress.opensuse.org/issues/40658