### PR TITLE
Make jeos/root_fs_size.pm on RPi happy

### DIFF
--- a/tests/jeos/prepare_rpi_image.pm
+++ b/tests/jeos/prepare_rpi_image.pm
@@ -33,7 +33,7 @@ sub run {
     # Download, prepare and upload the image
     assert_script_run("time curl --fail -s -O -L $rpi_image_url");
     assert_script_run("time unxz $rpi_image_rawxz",                                            600);
-    assert_script_run("time qemu-img resize -f raw $rpi_image_raw 16G",                        600);
+    assert_script_run("time qemu-img resize -f raw $rpi_image_raw 24G",                        600);
     assert_script_run("time qemu-img convert -f raw -O qcow2 $rpi_image_raw $rpi_image_qcow2", 600);
     upload_asset("$rpi_image_qcow2", 1);
 }


### PR DESCRIPTION
Currently JeOS test on RPi is failing due different size of rootfs than on other target platforms. This commit will change RPi qcow2 image size to be 24G as other JeOS images. Previous value was meant like size of 16G SD card but we would still need to test it manually so we can use any size here.

The failure is visible at https://openqa.suse.de/tests/2256873#step/root_fs_size/3