### PR TITLE
Remove base Exporter from package y2x11test

### DIFF
--- a/lib/y2x11test.pm
+++ b/lib/y2x11test.pm
@@ -1,8 +1,6 @@
 package y2x11test;
-use Exporter;
-#use base "opensusebasetest";
+use base "opensusebasetest";
 use mm_network qw(configure_default_gateway configure_static_ip configure_static_dns get_host_resolv_conf);
-use base "Exporter";
 use strict;
 use utils;
 use testapi;
@@ -20,6 +18,7 @@ our %setup_nis_nfs_x11 = (
     # nfs mount options -> rw,no_root_squash
     nfs_opts => 'rw,no_'
 );
+use Exporter 'import';
 
 =head2 launch_yast2_module_x11
 


### PR DESCRIPTION
- Related ticket: [poo#43664](https://progress.opensuse.org/issues/43664)
- Verification runs: 
   * [opensuse-Tumbleweed-DVD-x86_64-Build20181110-virtualization@64bit](http://dhcp128.suse.cz/tests/8615)
   * [sle-15-SP1-Installer-DVD-x86_64-Build91.1-nis_client@64bit](http://dhcp128.suse.cz/tests/8612)
   * [sle-15-SP1-Installer-DVD-x86_64-Build91.1-nis_server@64bit](http://dhcp128.suse.cz/tests/8611)
