### PR TITLE
Use is_upgrade in disable_grub_timeout and start_install

### DIFF
--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -16,7 +16,7 @@ use warnings;
 use base "y2logsstep";
 use testapi;
 use utils;
-use version_utils qw(is_sle is_leap);
+use version_utils qw(is_sle is_leap is_upgrade);
 
 sub run {
     my ($self) = shift;
@@ -38,7 +38,7 @@ sub run {
 
     # Config bootloader is not be supported during an upgrade
     # Add exception for SLES11SP4 base update, configure grub for this scenario
-    if (get_var('UPGRADE') && (!is_sle('<15') || !is_leap('<15.0')) && (!check_var('HDDVERSION', '11-SP4'))) {
+    if (is_upgrade && (!is_sle('<15') || !is_leap('<15.0')) && (!check_var('HDDVERSION', '11-SP4'))) {
         assert_screen([qw(bootloader-config-unsupport inst-bootloader-settings inst-bootloader-settings-first_tab_highlighted)]);
         if (match_has_tag 'bootloader-config-unsupport') {
             send_key 'ret';

--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
-use version_utils 'sle_version_at_least';
+use version_utils qw(sle_version_at_least is_upgrade);
 
 sub check_bsc982138 {
     if (check_screen('installation-details-view-remaining-time-gt2h', 5)) {
@@ -29,7 +29,7 @@ sub run {
     # installation seems to be exceptionally slow.
     # Also, virtual machines for testing can be really slow in this step
     my $started_timeout = get_var('LIVECD') ? 1200 : 300;
-    if (get_var("UPGRADE")) {
+    if (is_upgrade) {
         send_key $cmd{update};
         sleep 1;
         assert_screen [qw(startupdate startupdate-conflict license-popup)], 5;


### PR DESCRIPTION
This is needed for the `LIVE_UPGRADE=1` scenario.

(Previous test run didn't get as far due to a product issue)

Test run (still running, looking promising): http://10.160.67.86/tests/204