### PR TITLE
Increase timeout for systemd test suite

### DIFF
--- a/tests/console/systemd_testsuite.pm
+++ b/tests/console/systemd_testsuite.pm
@@ -34,7 +34,7 @@ sub run {
 
     # run the testsuite test scripts
     assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh --all 2>&1 | tee /tmp/testsuite.log', 2100;
+    assert_script_run './run-tests.sh --all 2>&1 | tee /tmp/testsuite.log', 3600;
     assert_script_run 'grep "# FAIL:  0" /tmp/testsuite.log';
     assert_script_run 'grep "# ERROR: 0" /tmp/testsuite.log';
 }


### PR DESCRIPTION
systemd tests are becoming more heavy load.
tblume already remove the nested VM to avoid the timeout there. Now the tests pass, but they take more time than 35 minutes. Timeout increased to 1 hour.

- Related ticket: https://progress.opensuse.org/issues/36754
- Verification run: http://slindomansilla-vm.qa.suse.de/tests/723
