### PR TITLE
 Add autoyast test for whole disk as PV

### DIFF
--- a/data/autoyast_sle15/autoyast_disk_as_pv.xml
+++ b/data/autoyast_sle15/autoyast_disk_as_pv.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <suse_register>
+        <do_registration config:type="boolean">true</do_registration>
+        <email/>
+        <reg_code>{{SCC_REGCODE}}</reg_code>
+        <install_updates config:type="boolean">true</install_updates>
+        <reg_server>{{SCC_URL}}</reg_server>
+        <addons config:type="list">
+            <addon>
+                <name>sle-module-server-applications</name>
+                <version>{{VERSION}}</version>
+                <arch>{{ARCH}}</arch>
+            </addon>
+        </addons>
+    </suse_register>
+    <bootloader>
+        <global>
+            <timeout config:type="integer">-1</timeout>
+        </global>
+    </bootloader>
+    <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <software>
+        <products config:type="list">
+            <product>SLES</product>
+        </products>
+    </software>
+    <users config:type="list">
+        <user>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <report>
+        <errors>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </errors>
+        <messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </messages>
+        <warnings>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </warnings>
+        <yesno_messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </yesno_messages>
+    </report>
+    <partitioning config:type="list">
+        <drive>
+            <type config:type="symbol">CT_DISK</type>
+            <use>all</use>
+            <device>/dev/sda</device>
+            <disklabel>none</disklabel>
+            <partitions config:type="list">
+                <partition>
+                    <format config:type="boolean">true</format>
+                    <create config:type="boolean">false</create>
+                    <mount>/</mount>
+                    <size>max</size>
+                </partition>
+            </partitions>
+        </drive>
+        <drive>
+            <device>/dev/sdb</device>
+            <disklabel>none</disklabel>
+            <partitions config:type="list">
+                <partition>
+                    <lvm_group>system</lvm_group>
+                </partition>
+            </partitions>
+            <type config:type="symbol">CT_DISK</type>
+            <use>all</use>
+        </drive>
+        <drive>
+            <device>/dev/system</device>
+            <type config:type="symbol">CT_LVM</type>
+            <partitions config:type="list">
+                <partition>
+                    <lv_name>swap</lv_name>
+                    <filesystem config:type="symbol">swap</filesystem>
+                    <mount>swap</mount>
+                    <size>2G</size>
+                </partition>
+                <partition>
+                    <lv_name>home</lv_name>
+                    <filesystem config:type="symbol">ext4</filesystem>
+                    <mount>/home</mount>
+                    <size>5GiB</size>
+                </partition>
+            </partitions>
+        </drive>
+    </partitioning>
+</profile>

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -473,13 +473,7 @@ sub load_autoyast_tests {
     else {
         loadtest("autoyast/repos");
         loadtest("autoyast/clone");
-        if (get_var('SP3ORLATER') && check_var('FILESYSTEM', 'btrfs')) {
-            loadtest "autoyast/verify_autoinst_btrfs";
-        }
         loadtest("autoyast/logs");
-    }
-    if (get_var('SP3ORLATER') && check_var('FILESYSTEM', 'btrfs')) {
-        loadtest "autoyast/verify_btrfs";
     }
     loadtest("autoyast/autoyast_reboot");
     #    next boot in load_reboot_tests
@@ -2117,6 +2111,9 @@ sub load_installation_validation_tests {
     # - autoyast/verify_disk_as_pv validates: installation using autoyast_disk_as_pv.xml profile
     # - autoyast/verify_disk_as_pv_clone: validates generated profile when cloning system
     #                                      installed using autoyast_disk_as_pv.xml profile
+    # - autoyast/verify_btrfs: validates installation using autoyast_btrfs.xml profile
+    # - autoyast/verify_btrfs_clone: validates enerated profile when cloning system
+    #                                      installed using autoyast_btrfs.xml profile
     for my $module (split(',', get_var('INSTALLATION_VALIDATION'))) {
         loadtest $module;
     }

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2113,7 +2113,10 @@ sub load_installation_validation_tests {
     load_system_prepare_tests;
     # See description of INSTALLATION_VALIDATION in variables.md
     # Possible values:
-    # - console/lvm_thin_check for thin LVM
+    # - console/lvm_thin_check: validate thin LVM installation
+    # - autoyast/verify_disk_as_pv validates: installation using autoyast_disk_as_pv.xml profile
+    # - autoyast/verify_disk_as_pv_clone: validates generated profile when cloning system
+    #                                      installed using autoyast_disk_as_pv.xml profile
     for my $module (split(',', get_var('INSTALLATION_VALIDATION'))) {
         loadtest $module;
     }

--- a/lib/xml_utils.pm
+++ b/lib/xml_utils.pm
@@ -1,0 +1,64 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Library for parsing xml files
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
+use strict;
+use XML::LibXML;
+use Exporter 'import';
+
+=head2 get_xpc
+   get_xpc($string);
+
+   Returns XPathContext for the dom build using the string, which contains xml.
+=cut
+
+our @EXPORT = qw(get_xpc verify_option);
+
+sub get_xpc {
+    my ($string) = @_;
+    my $dom = XML::LibXML->load_xml(string => $string);
+    # Init xml namespace
+    my $xpc = XML::LibXML::XPathContext->new($dom);
+    $xpc->registerNs('ns', 'http://www.suse.com/1.0/yast2ns');
+
+    return $xpc;
+}
+
+=head2 verify_option
+   verify_option(%args);
+
+   Verifies that node by given XPath is unique and has expected value. C<%args> is
+   a hash which must have following keys:
+   C<xpc> - XPathContext object for the parsed xml,
+   C<xpath> - XPath to the node which value we want to check
+   C<expected_val> - expected value for the node
+=cut
+
+sub verify_option {
+    my (%args) = @_;
+
+    my $nodeset = $args{xpc}->findnodes($args{xpath});
+    for my $node ($nodeset->get_nodelist) {
+        print $node->to_literal;
+    }
+    my @nodes = $nodeset->get_nodelist;
+    ## Verify that there is node found by xpath and it's single one
+    if (scalar @nodes != 1) {
+        return "Generated autoinst.xml contains unexpected number of nodes for xpath: $args{xpath}. Found: " . scalar @nodes . ", expected: 1.";
+    }
+    if ($nodes[0]->to_literal ne $args{expected_val}) {
+        return "Unexpected value for xpath $args{xpath}. Expected: '$args{expected_val}', got: '$nodes[0]'";
+    }
+
+    return '';
+
+}
+
+1;

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -263,7 +263,7 @@ sub run {
     $stage   = 'stage2';
 
     check_screen \@needles, $check_time;
-    @needles = qw(reboot-after-installation autoyast-postinstall-error autoyast-boot warning-pop-up);
+    @needles = qw(reboot-after-installation autoyast-postinstall-error autoyast-boot warning-pop-up autoyast-error);
     until (match_has_tag 'reboot-after-installation') {
         #Verify timeout and continue if there was a match
         next unless verify_timeout_and_check_screen(($timer += $check_time), \@needles);

--- a/tests/autoyast/verify_btrfs_clone.pm
+++ b/tests/autoyast/verify_btrfs_clone.pm
@@ -27,14 +27,22 @@ use XML::LibXML;
 #Xpath parser
 my $xpc;
 
+sub test_setup {
+    select_console('root-console');
+    my $profile_path = '/root/autoinst.xml';
+    # Generate pofile if doesn't exist
+    assert_script_run("[ -e $profile_path ] | yast2 clone_system");
+
+    my $autoinst = script_output("cat $profile_path");
+    # get XPathContext
+    $xpc = get_xpc($autoinst);
+}
 
 sub run {
     # Accumulate errors in this variable if any
     my $errors;
-    # Copy file content to variable
-    my $autoinst = script_output("cat /root/autoinst.xml");
-    # Init xml namespace
-    $xpc = get_xpc($autoinst);
+
+    test_setup;
 
     ### Verify mount options enable_snapshots
     my $result_str = verify_option(xpc => $xpc, xpath => '//ns:partitioning/ns:drive[ns:device="/dev/vda"]/ns:enable_snapshots', expected_val => 'true');

--- a/tests/autoyast/verify_disk_as_pv.pm
+++ b/tests/autoyast/verify_disk_as_pv.pm
@@ -1,0 +1,85 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Validate partitioning for autoyast installation when using whole disk as PV
+#          We have 2 disks, one contains bios boot and /boot partitions, second one
+#          is used for LVM group with root and swap logical volumes.
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
+
+use strict;
+use base 'basetest';
+use testapi;
+
+sub validate_disk_as_partition {
+    my $errors = '';
+    record_info('Verify root partition as disk');
+    # Validate type of the partition
+    my $output = script_output('lsblk /dev/sda --noheading --output TYPE');
+    if ($output !~ 'disk') {
+        $errors .= "Expected type disk for /dev/vda, got: $output\n";
+    }
+    # Validate mount point of the partition
+    $output = script_output('lsblk /dev/sda --noheading --output MOUNTPOINT');
+    if ($output !~ '/') {
+        $errors .= "Expected '/' mount point disk for /dev/vda, got: $output\n";
+    }
+    return $errors;
+}
+
+sub validate_vg_partitions {
+    my $errors = '';
+    record_info('Verify volume group on disk as PV');
+    # Validate volume group exists
+    assert_script_run('vgdisplay system');
+    # Validate logical volume
+    my $lmv_disk_scan = script_output('lvmdiskscan');
+    if ($lmv_disk_scan !~ '1 LVM physical volume whole disk') {
+        $errors .= "Disk is not detected as physical volume, but expected to be LVM PV\n";
+    }
+    for my $partition (qw(swap home)) {
+        if ($lmv_disk_scan !~ "/dev/system/$partition") {
+            $errors .= "$partition partition is not created as expected, expected /dev/system/$partition LV\n";
+        }
+    }
+    return $errors;
+}
+
+sub validate_mount_points {
+    my $errors = '';
+    record_info('Verify mount points');
+    for my $mount (qw(/ /home)) {
+        if (script_run("findmnt $mount") != 0) {
+            $errors .= "No mount point found for $mount\n";
+        }
+    }
+    return $errors;
+}
+
+sub validate_swap {
+    record_info('Verify swap partition');
+    my $swap_size = script_output('swapon --show=SIZE --noheadings');
+    if ($swap_size !~ '2G') {
+        return "Expected 2G size for the swap partition, got: $swap_size\n";
+    }
+    return '';
+}
+
+sub run {
+    my $errors = '';
+    select_console('root-console');
+    $errors .= validate_disk_as_partition;
+    $errors .= validate_vg_partitions;
+    $errors .= validate_mount_points;
+    $errors .= validate_swap;
+
+    die("Test failed:\n$errors") if $errors;
+
+}
+
+1;

--- a/tests/autoyast/verify_disk_as_pv_clone.pm
+++ b/tests/autoyast/verify_disk_as_pv_clone.pm
@@ -1,0 +1,84 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Validate generated autoyast profile generated for autoyast installation when using whole disk as PV
+# Maintainer: Rodion Iafarov <riafarov@suse.com>
+
+use strict;
+use base 'basetest';
+use testapi;
+use xml_utils;
+
+#Xpath parser
+my $xpc;
+
+sub test_setup {
+    select_console('root-console');
+    my $profile_path = '/root/autoinst.xml';
+    # Generate pofile if doesn't exist
+    assert_script_run("[ -e $profile_path ] | yast2 clone_system");
+
+    my $autoinst = script_output("cat $profile_path");
+    # get XPathContext
+    $xpc = get_xpc($autoinst);
+}
+
+sub validate_disk_labels {
+    my $errors = '';
+    my $result_str;
+    record_info 'Disk labels', 'Validate disk labels, should be set to none';
+    for my $disk (qw(sda sdb)) {
+        $result_str = verify_option(xpc => $xpc, xpath => "//ns:partitioning/ns:drive[ns:device=\"/dev/$disk\"]/ns:disklabel", expected_val => 'none');
+        $errors .= "/dev/$disk disk does NOT have disklabel set to none: $result_str\n" if $result_str;
+    }
+    return $errors;
+}
+
+sub validate_disk_as_lvm_vg {
+    my $errors = '';
+    record_info 'Test LVM', 'Validate lvm setup';
+    my $result_str = verify_option(xpc => $xpc, xpath => '//ns:partitioning/ns:drive[ns:device="/dev/sdb"]/ns:disklabel', expected_val => 'none');
+    $errors .= "/dev/sdb disk does NOT have disklabel set to none: $result_str\n" if $result_str;
+
+    $result_str = verify_option(xpc => $xpc, xpath => '//ns:partitioning/ns:drive[ns:device="/dev/sdb"]/ns:partitions/ns:partition/ns:lvm_group', expected_val => 'system');
+    $errors .= "No system lvm_group found for sdb device: $result_str\n" if $result_str;
+    # Verify swap and /home are listed with correct mount points
+    my %mounts = (swap => 'swap', home => '/home');
+    while (my ($lv_name, $mount_path) = each %mounts) {
+        $result_str = verify_option(xpc => $xpc, xpath => "//ns:partitioning/ns:drive[ns:device=\"/dev/system\"]/ns:partitions/ns:partition[ns:lv_name=\"$lv_name\"]/ns:mount", expected_val => $mount_path);
+        $errors .= "No $lv_name logical volume found for in system volume group with mount at $mount_path: $result_str\n" if $result_str;
+    }
+
+    return $errors;
+}
+
+sub validate_disk_as_partition {
+    my $errors = '';
+    record_info 'Test disk as PV', 'Validate whole disk as partition';
+    my $result_str = verify_option(xpc => $xpc, xpath => '//ns:partitioning/ns:drive[ns:device="/dev/sda"]/ns:partitions/ns:partition/ns:mount', expected_val => '/');
+    $errors .= "No mount point for / found for /dev/sda: $result_str\n" if $result_str;
+}
+
+sub run {
+    my $errors = '';
+    test_setup;
+    sleep 300;
+    $errors .= validate_disk_as_lvm_vg;
+    # Currently these will fail
+    if (validate_disk_labels) {
+        record_soft_failure('bsc#1115807');
+    }
+    if (validate_disk_as_partition) {
+        record_soft_failure('bsc#1115807');
+    }
+
+    die("Test failed:\n$errors") if $errors;
+}
+
+1;


### PR DESCRIPTION
See [poo#42605](https://progress.opensuse.org/issues/42605).

Test suite requires following settings:
```
AUTOYAST=autoyast_sle15/autoyast_disk_as_pv.xml 
NUMDISKS=2
INSTALLONLY=1
INSTALLATION_VALIDATION=autoyast/verify_disk_as_pv,autoyast/verify_disk_as_pv_clone
```

Change for btrfs ay test will require following settings for the test suite:
```
INSTALLONLY=1
INSTALLATION_VALIDATION=autoyast/verify_btrfs,autoyast/verify_btrfs_clone
```

####Verification runs
[Disk as PV](http://g226.suse.de/tests/3163#).
[Btrfs](http://g226.suse.de/tests/3166#)

