### PR TITLE
Fix operator precedence for call to match_has_tag

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -45,7 +45,7 @@ sub run {
         wait_still_screen 5;
         assert_screen(\@welcome_tags, 500);
         # Normal exit condition
-        if (match_has_tag 'inst-betawarning' || match_has_tag 'inst-welcome' || match_has_tag 'inst-welcome-no-product-list') {
+        if ((match_has_tag 'inst-betawarning') || (match_has_tag 'inst-welcome') || (match_has_tag 'inst-welcome-no-product-list')) {
             last;
         }
         if (match_has_tag 'scc-invalid-url') {


### PR DESCRIPTION
Without parentheses, "foo 'bar' || foo 'baz'" is evaluated as
"foo ('bar' || (foo 'baz'))", which is obviously not wanted here.
See https://perldoc.perl.org/perlop.html for operator precedence.

The current check typically evaluates as false, and the assert_screen is run scalar(@welcome_tags) times.
Example: https://openqa.opensuse.org/tests/794685#step/welcome/1