### PR TITLE
HA,WE have license, Live patching doesn't have license on SLE15 when calling yast2 SCC

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -80,7 +80,15 @@ sub register_system_in_textmode {
     if (is_sle('12-SP2+', get_var('HDDVERSION'))) {
         set_var('HDD_SP2ORLATER', 1);
     }
+    # Tag the test as being called from this module, so accept_addons_license
+    # (called by yast_scc_registration) can handle license agreements from modules
+    # that do not show license agreement during installation but do when registering
+    # after install
+    set_var('IN_PATCH_SLE', 1);
     yast_scc_registration;
+    # Once SCC registration is done, disable IN_PATCH_SLE so it does not interfere
+    # with further calls to accept_addons_license (in upgrade for example)
+    set_var('IN_PATCH_SLE', 0);
 }
 
 # Remove LTSS product and manually remove its relevant package before migration

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -68,7 +68,7 @@ our %SLE15_DEFAULT_MODULES = (
     sles4sap => 'base,desktop,serverapp,ha,sapapp',
 );
 
-our @SLE15_ADDONS_WITHOUT_LICENSE        = qw(ha sdk wsm we hpcm);
+our @SLE15_ADDONS_WITHOUT_LICENSE        = qw(ha sdk wsm we hpcm live);
 our @SLE15_ADDONS_WITH_LICENSE_NOINSTALL = qw(ha we);
 
 # Method to determine if a short name references a module based on what's defined
@@ -86,7 +86,7 @@ sub accept_addons_license {
     #   isc co SUSE:SLE-15:GA 000product
     #   grep -l EULA SUSE:SLE-15:GA/000product/*.product | sed 's/.product//'
     # All shown products have a license that should be checked.
-    my @addons_with_license = qw(geo live rt idu ids lgm);
+    my @addons_with_license = qw(geo rt idu ids lgm);
     if (is_sle('15+')) {
         record_soft_failure 'bsc#1118497';
     }


### PR DESCRIPTION
When I tried to do the migration test from SLE15GM to SLE15SP1, I found ha,we have license, live patching doesn't have license on registration on SLE15 via scc, while ha,we don't have license on proxySCC( http://all-668.1.proxy.scc.suse.de).
(I have contact SCC team about the difference of license behavior on SCC and proxySCC, they reply me that ha,we should have license)
## Thomas Schmidt's feedback in mail:
"those products (15HA and 15WE) do have a license, so I think the behavior on SCC is correct.
Maybe the licenses are not mirrored correctly on the openqa server for those products?"
So I add ha,we to the list of with license, remove live patching from the list on SLE15 to fix this issue.

- Related ticket: https://progress.opensuse.org/issues/43754
- Verification run: ha: http://openqa-apac1.suse.de/tests/1861#step/register_system/14
                            we:  http://openqa-apac1.suse.de/tests/1869#step/register_system/47                 
                            live patching: http://openqa-apac1.suse.de/tests/1872
   
                            