### PR TITLE
keymap_or_locale: make sure screen switched to tty3 before starting to type

### DIFF
--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -22,7 +22,9 @@ sub verify_default_keymap_textmode {
         select_console($tty{console});
     }
     else {
-        send_key('alt-f3');
+        wait_screen_change {
+            send_key('alt-f3');
+        }
         assert_screen([qw(linux-login cleared-console)]);
     }
 


### PR DESCRIPTION
It fixes https://openqa.opensuse.org/tests/795067#step/keymap_or_locale/4 where we start to type too early.
Tested locally on textmode@aarch64 with os-autoinst.