### PR TITLE
Fix yast2_lan_restart_devices for sle15

### DIFF
--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -74,6 +74,7 @@ sub close_network_settings {
 sub check_network_status {
     my ($expected_status, $device) = @_;
     $expected_status //= 'no_restart';
+    assert_screen 'yast2_closed_xterm_visible';
     assert_script_run 'ip a';
     if ($device eq 'bond') {
         record_soft_failure 'bsc#992113';

--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -62,20 +62,17 @@ sub change_hw_device_name {
     assert_screen 'yast2_lan_hardware_tab';
     send_key 'alt-e';        # Change device name
     assert_screen 'yast2_lan_device_name';
-    send_key 'alt-m';        # Udev rule based on MAC
-    send_key 'tab';
-    send_key 'tab';
-    send_key 'tab';
-    send_key 'tab';
-    type_string "$dev_name";
+    send_key 'tab' for (1 .. 2);
+    type_string $dev_name;
+    wait_screen_change { send_key 'alt-m' };    # Udev rule based on MAC
     save_screenshot;
-    send_key 'alt-o';
-    send_key 'alt-n';
+    send_key $cmd{ok};
+    send_key $cmd{next};
 }
 
 sub run {
     initialize_y2lan;
-    verify_network_configuration;    # check simple access to Overview tab
+    verify_network_configuration;               # check simple access to Overview tab
     verify_network_configuration(\&check_network_settings_tabs);
     unless (is_network_manager_default) {
         verify_network_configuration(\&check_network_card_setup_tabs);

--- a/tests/x11/yast2_lan_restart_devices.pm
+++ b/tests/x11/yast2_lan_restart_devices.pm
@@ -91,7 +91,7 @@ sub select_special_device_tab {
     send_key 'tab';
     send_key 'tab';
     send_key 'home';
-    send_key_until_needlematch ["yast2_lan_device_${device}_selected", "yast2_lan_device_workaround-bsc1004643"], 'down', 5;
+    send_key_until_needlematch ["yast2_lan_device_${device}_selected", "yast2_lan_device_bsc1111483"], 'down', 5;
     return if check_bsc1111483;
     send_key 'alt-i';                     # Edit NIC
     assert_screen 'yast2_lan_network_card_setup';
@@ -109,6 +109,8 @@ sub select_special_device_tab {
     }
     wait_still_screen;
     send_key 'alt-n';
+    assert_screen 'yast2_lan';
+    send_key $cmd{ok};
 }
 
 sub delete_device {
@@ -118,7 +120,7 @@ sub delete_device {
     send_key 'tab';
     send_key 'tab';
     send_key 'home';
-    send_key_until_needlematch ["yast2_lan_device_${device}_selected", "yast2_lan_device_workaround-bsc1004643"], 'down', 5;
+    send_key_until_needlematch ["yast2_lan_device_${device}_selected", "yast2_lan_device_bsc1111483"], 'down', 5;
     return if check_bsc1111483;
     send_key 'alt-t';    # Delete NIC
     wait_still_screen;


### PR DESCRIPTION
#### Description
Fix several issues in test modules yast2_lan_restart_devices and yast2_lan_restart:
 * Avoid `ip a` command syntax error (broken due to incorrect sequences of shortcuts) by ensuring to assert Network Setting dialog when we come back from Network Card Setup dialog and click OK and also to verify that we are in the xterm before issuing the command.
 * Select network interface in bridged devices tab adding needles for that and subsequent warning.
 * Fix bug ref on workaround for bsc#1111483
 * Ensure we exit properly dialog to change the device name using a different sequence (without extra needles) to avoid issues in workers with lower speed, i.e.: ppc64le, aarch64.
#### Related ticket
https://progress.opensuse.org/issues/42782
#### Needles
[needles sle](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/998)
#### Verification run
[sle-15-SP1-extra_tests_on_gnome@64bit](http://dhcp42.suse.cz/tests/897#step/yast2_lan_restart_devices/140)
[sle-15-SP1-extra_tests_on_gnome@ppc64le](http://dhcp42.suse.cz/tests/902#step/yast2_lan_restart_devices/120)
[sle-12-SP4-extra_tests_on_gnome@64bit](http://dhcp42.suse.cz/tests/898#step/yast2_lan_restart_devices/163)
[sle-15-SP1-extra_tests_on_gnome@aarch64](http://dhcp42.suse.cz/tests/903#step/yast2_lan_restart_devices/156)