### PR TITLE
Workaround dealing with proxy_scc in online migration

### DIFF
--- a/data/console/check_registration_status.py
+++ b/data/console/check_registration_status.py
@@ -28,27 +28,38 @@ if proc.returncode != 0:
 # or "Registered" products.
 # Return the account of missing matched product
 ret = 0
-for prod in json.loads(stdout, encoding="utf-8"):
-    prod['base_version'] = prod['version'].split('.')[0]
-    prod['result'] = 'match'
+try:
+    for prod in json.loads(stdout, encoding="utf-8"):
+        prod['base_version'] = prod['version'].split('.')[0]
+        prod['result'] = 'match'
 
-    # Module version is not service pack specific
-    if prod['identifier'].find('module') != -1:
-        if dist['BASE_VERSION'] != prod['base_version']:
-            prod['result'] = 'mismatch'
-    else:
-        if dist['VERSION_ID'] != prod['version']:
-            # Live Patching is seen as Module before SLE12SP3, then seen as extension since SLE12SP3
-            # So its version should equal the base product's base version before SLE12SP3, while equal 
-            # the base product's version since SLE12SP3. 
-            if dist['VERSION_ID'] >= '12.3':
+        # Module version is not service pack specific
+        if prod['identifier'].find('module') != -1:
+            if dist['BASE_VERSION'] != prod['base_version']:
                 prod['result'] = 'mismatch'
-            else:
-                if dist['BASE_VERSION'] != prod['version']:
-                   prod['result'] = 'mismatch'
+        else:
+            if dist['VERSION_ID'] != prod['version']:
+                # Live Patching is seen as Module before SLE12SP3, then seen as extension since SLE12SP3
+                # So its version should equal the base product's base version before SLE12SP3, while equal 
+                # the base product's version since SLE12SP3. 
+                if dist['VERSION_ID'] >= '12.3':
+                    prod['result'] = 'mismatch'
+                else:
+                    if dist['BASE_VERSION'] != prod['version']:
+                        prod['result'] = 'mismatch'
 
-    if prod['result'] == 'mismatch':
-        ret += 1
-    print("Product %(identifier)s with version %(version)s is %(status)s [%(result)s]" % prod)
+        if prod['result'] == 'mismatch':
+            ret += 1
+        print("Product %(identifier)s with version %(version)s is %(status)s [%(result)s]" % prod)
+except ValueError as err:
+    # Workaround of poo#42845
+    # In online migration tests using proxy SCC, repos' urls will be invalid
+    # after snapper rollback to the snapshot before migration.  In such case,
+    # stdout will not be in json but in xml format, causing ValueError in
+    # line 32.
+    # Lines below catches this exact error, preventing the script from crashing
+    invalid_url_warning = 'Valid metadata not found at specified URL'
+    if invalid_url_warning in stdout.decode('utf-8'):
+        print('Script exiting: %s\nInvalid repo URL, trigger proxy scc workaround' % err)
 
 sys.exit(ret)

--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -148,7 +148,7 @@ sub check_rollback_system {
     assert_script_run("zypper mr -d -m cd -m dvd");
     # Verify registration status matches current system version
     # system is un-registered during media based upgrade
-    assert_script_run('curl -s ' . data_url('console/check_registration_status.py') . ' | python') unless get_var('MEDIA_UPGRADE');
+    assert_script_run('curl -s ' . data_url('console/check_registration_status.py') . ' | python3') unless get_var('MEDIA_UPGRADE');
 }
 
 # Reset tty for x11 and root consoles


### PR DESCRIPTION
Repositories' URLs will be changed to invalid ones containing build number while using SCC proxy for online migration, making `snapper_rollback` fail.

This code catches a specific error and pass the test. Also, this code corrected the interpreter for a Python3 script. I strongly recommend paying special attention when piping a Python script to an interpreter. We should avoid using the default version value of Python interpreters, which could be unpredictable.

- Related ticket: https://progress.opensuse.org/issues/42845  (Please refer to it for further detailed information)
- Needles: None.
- Verification run: None. The error only happens on ppc ones, but I have no local ppc64le machines. However, tested the code separately on other architectures to ensure it works.
