### PR TITLE
Revert "keymap_or_locale: make sure screen switched to tty3 before starting to type"

### DIFF
--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -22,9 +22,7 @@ sub verify_default_keymap_textmode {
         select_console($tty{console});
     }
     else {
-        wait_screen_change {
-            send_key('alt-f3');
-        }
+        send_key('alt-f3');
         assert_screen([qw(linux-login cleared-console)]);
     }
 


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#6205

See https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6205#issuecomment-439336012