### PR TITLE
Add glibc-locale test for JeOS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -586,6 +586,7 @@ sub load_jeos_tests {
             loadtest "console/suseconnect_scc";
         }
     }
+    loadtest "jeos/glibc_locale" if sle_version_at_least('15') && get_var('JEOSINSTLANG');
 }
 
 sub installzdupstep_is_applicable {

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -8,12 +8,12 @@
 # without any warranty.
 
 # Summary: Configure JeOS
-# Maintainer: Michal Nowak <mnowak@suse.com>
+# Maintainer: Ciprian Cret <mnowak@suse.com>
 
 use base "opensusebasetest";
 use strict;
 use testapi;
-use version_utils 'is_sle';
+use version_utils qw(is_sle sle_version_at_least);
 use utils qw(assert_screen_with_soft_timeout ensure_serialdev_permissions);
 
 sub post_fail_hook {
@@ -26,7 +26,7 @@ sub post_fail_hook {
 sub verify_user_info {
     my (%args) = @_;
     my $user = $args{user_is_root};
-    my $lang = get_var('JEOSINSTLANG', 'en_US');
+    my $lang = sle_version_at_least('15') ? 'en_US' : get_var('JEOSINSTLANG', 'en_US');
 
     my %tz_data = ('en_US' => 'UTC', 'de_DE' => 'Europe/Berlin');
     assert_script_run("timedatectl | awk '\$1 ~ /Time/ { print \$3 }' | grep ^" . $tz_data{$lang} . "\$");
@@ -44,7 +44,8 @@ sub verify_user_info {
 }
 
 sub run {
-    my $lang = get_var('JEOSINSTLANG', 'en_US');
+    my $lang = sle_version_at_least('15') ? 'en_US' : get_var('JEOSINSTLANG', 'en_US');
+
     my %keylayout_key = ('en_US' => 'e', 'de_DE' => 'd');
     # For 'en_US' pick 'en_US', for 'de_DE' select 'de_DE'
     my %locale_key = ('en_US' => 'e', 'de_DE' => 'd');

--- a/tests/jeos/glibc_locale.pm
+++ b/tests/jeos/glibc_locale.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: This module tests glibc-locale
+# Maintainer: Ciprian Cret <ccret@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+use utils;
+use version_utils qw(is_opensuse is_sle is_jeos);
+
+sub run {
+    my (%args) = @_;
+
+    zypper_call('in glibc-locale');
+    my $locale = get_var('JEOSINSTLANG', 'en_US');
+    my $output = script_output("localectl list-locales | grep $locale.utf8");
+
+    die "Test locale not found in the available ones" unless ($output =~ $locale);
+
+    assert_script_run("localectl set-locale LANG=$locale.UTF-8");
+    assert_script_run("export LC_ALL='$locale.UTF-8'");
+
+    my $user = $args{user_is_root};
+    my $lang = get_var('JEOSINSTLANG', 'en_US');
+
+    my %tz_data = ('en_US' => 'UTC', 'de_DE' => 'Europe/Berlin');
+    assert_script_run("timedatectl set-timezone " . $tz_data{$lang});
+    assert_script_run("timedatectl | awk '\$1 ~ /Time/ { print \$3 }' | grep ^" . $tz_data{$lang} . "\$");
+
+    my %locale_data = ('en_US' => 'en_US.UTF-8', 'de_DE' => 'de_DE.UTF-8');
+    assert_script_run("locale | tr -d \\'\\\" | awk -F= '\$1 ~ /LC_CTYPE/ { print \$2 }' | grep ^" . $locale_data{$lang} . "\$");
+
+    my %lang_data = ('en_US' => 'For bug reporting', 'de_DE' => 'Eine Anleitung zum Melden');
+    my $proglang = $args{user_is_root} ? 'en_US' : $lang;
+    assert_script_run("ldd --help | grep '^" . $lang_data{$proglang} . "'");
+
+}
+
+1;


### PR DESCRIPTION
Installs glibc-locale, checks that the locale to be tested is available 
and switches to it

 Related ticket: https://progress.opensuse.org/issues/43682
 Validation runs: 
    - JeOS 15 de_DE: http://ccret.suse.cz/tests/1735
    - JeOS 15 en_US: http://ccret.suse.cz/tests/1736
    - JeOS 12: http://ccret.suse.cz/tests/1741#

