### PR TITLE
Remove live patching workaround for bsc#985647 on SLE15

### DIFF
--- a/tests/migration/sle12_online_migration/pre_migration.pm
+++ b/tests/migration/sle12_online_migration/pre_migration.pm
@@ -15,6 +15,7 @@ use strict;
 use testapi;
 use utils;
 use migration;
+use version_utils 'is_sle';
 
 sub set_scc_proxy_url {
     if (my $u = get_var('SCC_PROXY_URL')) {
@@ -63,7 +64,7 @@ sub run {
 
     # according to comment 19 of bsc#985647, uninstall all kgraft-patch* packages prior to migration as a workaround to
     # solve conflict during online migration with live patching addon
-    remove_kgraft_patch;
+    remove_kgraft_patch if is_sle('<15');
 }
 
 sub test_flags {


### PR DESCRIPTION
We do not need the workaround for live patching on online migration test on SLE15, so add judgement to escape the workaround on SLE15.

- Related ticket: https://progress.opensuse.org/issues/43961
- Verification run: http://openqa-apac1.suse.de/tests/1896#
