### PR TITLE
Disable mail notifications in bash

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -19,12 +19,17 @@ use utils;
 use ipmi_backend_utils 'use_ssh_serial_console';
 use strict;
 
+sub disable_bash_mail_notification {
+    assert_script_run "unset MAILCHECK >> ~/.bashrc";
+    assert_script_run "unset MAILCHECK";
+}
+
 sub run {
     my $self = shift;
     # let's see how it looks at the beginning
     save_screenshot;
     check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
-
+    disable_bash_mail_notification;
     # Stop serial-getty on serial console to avoid serial output pollution with login prompt
     # Doing early due to bsc#1103199 and bsc#1112109
     systemctl "stop serial-getty\@$testapi::serialdev", ignore_failure => 1;
@@ -67,7 +72,7 @@ sub run {
     $self->clear_and_verify_console;
 
     select_console 'user-console';
-
+    disable_bash_mail_notification;
     assert_script_run "curl -L -v -f " . autoinst_url('/data') . " > test.data";
     assert_script_run " cpio -id < test.data";
     script_run "ls -al data";


### PR DESCRIPTION
```bash
MAILCHECK
Specifies  how  often  (in  seconds) bash checks for mail.  The default is 60 seconds.  
When it is time to check for mail, the shell does so before displaying the primary prompt.  
If this variable is unset, or set to a value that is not a number greater than or equal to zero, 
the shell disables mail checking.
```
- Related ticket: [[sle][functional][y] test fails in yast2_bootloader - mismatched needle due to mail notification in cli](https://progress.opensuse.org/issues/39491)
- Verification runs: 
[Send mail to root](http://dhcp128.suse.cz/tests/8673#step/yast2_bootloader/2)
[sle-12-SP4-Server-DVD-x86_64-Build0456-minimal+base+proxy_SCC@64bit](http://dhcp128.suse.cz/tests/8674)
