### PR TITLE
Process pop-up offering online repos for openSUSE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -529,7 +529,6 @@ sub load_system_role_tests {
         if (!get_var("REMOTE_CONTROLLER") && !check_var('BACKEND', 'ipmi') && !is_hyperv_in_gui && !get_var("LIVECD") && !check_var('BACKEND', 'spvm')) {
             loadtest "installation/logpackages";
         }
-        loadtest "installation/disable_online_repos" if get_var('DISABLE_ONLINE_REPOS') && !get_var('OFFLINE_SUT');
     }
     if (is_using_system_role) {
         loadtest "installation/system_role";
@@ -805,7 +804,9 @@ sub load_inst_tests {
     if (get_var('MULTIPATH')) {
         loadtest "installation/multipath";
     }
-    if (is_opensuse && noupdatestep_is_applicable() && !get_var("LIVECD")) {
+    if (is_opensuse && noupdatestep_is_applicable() && !is_livecd) {
+        # See https://github.com/yast/yast-packager/pull/385
+        loadtest "installation/online_repos";
         loadtest "installation/installation_mode";
     }
     if (is_upgrade) {
@@ -813,7 +814,11 @@ sub load_inst_tests {
         if (check_var("UPGRADE", "LOW_SPACE")) {
             loadtest "installation/disk_space_fill";
         }
-        loadtest "installation/upgrade_select_opensuse" if is_opensuse;
+        if (is_opensuse) {
+            # See https://github.com/yast/yast-packager/pull/385
+            loadtest "installation/online_repos";
+            loadtest "installation/upgrade_select_opensuse";
+        }
     }
     if (is_sle) {
         loadtest 'installation/network_configuration' if get_var('NETWORK_CONFIGURATION');

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -66,6 +66,7 @@ use constant {
           is_virtualization_server
           is_server
           is_s390x
+          is_livecd
           has_product_selection
           has_license_on_welcome_screen
           )
@@ -112,6 +113,10 @@ sub is_rescuesystem {
 
 sub is_virtualization_server {
     return get_var('SYSTEM_ROLE', '') =~ /(kvm|xen)/;
+}
+
+sub is_livecd {
+    return get_var("LIVECD");
 }
 
 # Works only for versions comparable by string (not leap 42.X)


### PR DESCRIPTION
See [poo#43835](https://progress.opensuse.org/issues/43835).

- [Needles](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/474)
#### Verification runs
* [gnome not staging](http://g226.suse.de/tests/3189)
* [update](http://g226.suse.de/tests/3184)
* [RAID](http://g226.suse.de/tests/3186) (Fails due to missing needles and [bsc#1116562](https://bugzilla.suse.com/show_bug.cgi?id=1116562))
* [crypt_lvm](http://g226.suse.de/tests/3192)
* [gnome](http://g226.suse.de/tests/3197#)
* [textmode](http://g226.suse.de/tests/3206#)
