### PR TITLE
Fix order constraint in HA test

### DIFF
--- a/tests/ha/filesystem.pm
+++ b/tests/ha/filesystem.pm
@@ -94,11 +94,11 @@ sub run {
         else {
             if ($resource eq 'drbd_passive') {
                 assert_script_run "EDITOR=\"sed -ie '\$ a colocation colocation_$fs_rsc inf: $fs_rsc ms_$resource:Master'\" crm configure edit";
-                assert_script_run "EDITOR=\"sed -ie '\$ a order order_$fs_rsc inf: ms_$resource:promote $fs_rsc:start'\" crm configure edit";
+                assert_script_run "EDITOR=\"sed -ie '\$ a order order_$fs_rsc Mandatory: ms_$resource:promote $fs_rsc:start'\" crm configure edit";
             }
             else {
                 assert_script_run "EDITOR=\"sed -ie '\$ a colocation colocation_$fs_rsc inf: $fs_rsc vg_$resource'\" crm configure edit";
-                assert_script_run "EDITOR=\"sed -ie '\$ a order order_$fs_rsc inf: vg_$resource $fs_rsc'\" crm configure edit";
+                assert_script_run "EDITOR=\"sed -ie '\$ a order order_$fs_rsc Mandatory: vg_$resource $fs_rsc'\" crm configure edit";
             }
 
             # Sometimes we need to cleanup the resource


### PR DESCRIPTION
Since SLEHA-12 and last SLEHA-11-SP4, order constraint 'inf' score should be replaced by 'Mandatory' (see ClusterLabs [documentation](https://clusterlabs.org/pacemaker/doc/en-US/Pacemaker/1.1/html/Pacemaker_Explained/s-resource-ordering.html)).

- Verification run: http://1b147.qa.suse.de/tests/3986 and http://1b147.qa.suse.de/tests/3987.
