### PR TITLE
Makefile: Also check for 'force_soft_failure' with bugref

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ test-no-wait_idle:
 	@! git grep wait_idle lib/ tests/
 
 .PHONY: test-static
-test-static: tidy test-merge test-dry test-no-wait_idle test-unused-modules test-record_soft_failure-no-reference
+test-static: tidy test-merge test-dry test-no-wait_idle test-unused-modules test-soft_failure-no-reference
 
 .PHONY: test
 ifeq ($(TESTS),compile)
@@ -92,6 +92,6 @@ perlcritic: tools/lib/
 test-unused-modules:
 	tools/detect_unused_modules
 
-.PHONY: test-record_soft_failure-no-reference
-test-record_soft_failure-no-reference:
-	@! git grep -E -e 'record_soft_failure.*\;' --and --not -e '([$$0-9a-z]+#[$$0-9]+|fate.suse.com/[0-9]|\$$[a-z]+)' lib/ tests/
+.PHONY: test-soft_failure-no-reference
+test-soft_failure-no-reference:
+	@! git grep -E -e 'soft_failure\>.*\;' --and --not -e '([$$0-9a-z]+#[$$0-9]+|fate.suse.com/[0-9]|\$$[a-z]+)' lib/ tests/


### PR DESCRIPTION
'force_soft_failure' is a new os-autoinst test API method introduced
with https://github.com/os-autoinst/os-autoinst/pull/1052 that we should
also only use with valid bugrefs.