### PR TITLE
Add ibus tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1930,6 +1930,15 @@ sub load_common_x11 {
         loadtest "boot/boot_to_desktop";
         load_x11_webbrowser_extra();
     }
+    # Used by ibus tests
+    elsif (check_var("REGRESSION", "ibus")) {
+        loadtest "boot/boot_to_desktop";
+        loadtest "x11/ibus/ibus_installation";
+        loadtest "x11/ibus/ibus_test_ch";
+        loadtest "x11/ibus/ibus_test_jp";
+        loadtest "x11/ibus/ibus_test_kr";
+        loadtest "x11/ibus/ibus_clean";
+    }
 }
 
 # The function name load_security_tests_* is to avoid confusing since

--- a/tests/x11/ibus/ibus_clean.pm
+++ b/tests/x11/ibus/ibus_clean.pm
@@ -1,0 +1,56 @@
+# SUSE's openQA tests
+#
+# Author: Gao Zhiyuan <zgao@suse.com>
+# Copyright © SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: other ibus tests
+# Maintainer: Gao Zhiyuan <zgao@suse.com>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub remove_ch {
+    assert_and_click 'ibus-input-added-ch';
+    assert_and_click 'ibus-input-remove';
+}
+
+sub remove_jp {
+    assert_and_click 'ibus-input-added-jp';
+    assert_and_click 'ibus-input-remove';
+}
+
+sub remove_kr {
+    assert_and_click 'ibus-input-added-kr';
+    assert_and_click 'ibus-input-remove';
+}
+
+sub run {
+    my ($self) = @_;
+
+    assert_screen 'generic-desktop';
+    assert_and_click 'ibus-indicator';
+    send_key 'esc';
+
+    send_key 'super';
+    wait_still_screen;
+    type_string_slow ' region & language';
+    wait_still_screen;
+    send_key 'ret';
+
+    assert_screen 'ibus-region-language';
+    remove_ch;
+    remove_jp;
+    remove_kr;
+
+    assert_screen 'ibus-region-language-empty';
+    send_key 'alt-f4';
+}
+
+1;

--- a/tests/x11/ibus/ibus_installation.pm
+++ b/tests/x11/ibus/ibus_installation.pm
@@ -1,0 +1,71 @@
+# SUSE's openQA tests
+#
+# Author: Gao Zhiyuan <zgao@suse.com>
+# Copyright © SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: ibus installation
+# Maintainer: Gao Zhiyuan <zgao@suse.com>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub install_ibus {
+    x11_start_program("xterm");
+    become_root;
+    pkcon_quit;
+    wait_still_screen 1;
+    zypper_call('in ibus ibus-pinyin ibus-kkc ibus-hangul');
+    assert_screen 'ibus_installed';
+    send_key 'ctrl-d';
+    send_key 'ctrl-d';
+}
+
+sub override_i18n {
+    x11_start_program('gnome-terminal');
+    type_string "echo 'export INPUT_METHOD=ibus' > .i18n \n";
+    type_string "cat .i18n \n";
+    assert_screen 'ibus_i18n_overrided';
+    send_key 'ctrl-d';
+}
+
+sub logout_and_login {
+    handle_logout;
+    handle_login;
+}
+
+sub ibus_daemon_started {
+    x11_start_program('gnome-terminal');
+    wait_still_screen;
+
+    type_string_slow "env | grep ibus \n";
+    assert_screen 'ibus-daemon-started';
+
+    type_string_slow "ps aux | grep [i]bus \n";
+    assert_screen 'ibus-process-started';
+
+    send_key 'ctrl-d';
+    assert_screen 'generic-desktop';
+}
+
+sub run {
+    my ($self) = @_;
+
+    assert_screen "generic-desktop";
+    # Install ibus ibus-pinyin ibus-kkc ibus-hangul
+    install_ibus;
+    override_i18n;
+    # Re-login to start ibus demon
+    logout_and_login;
+
+    # check if ibus has successfully started
+    ibus_daemon_started;
+}
+
+1;

--- a/tests/x11/ibus/ibus_test_ch.pm
+++ b/tests/x11/ibus/ibus_test_ch.pm
@@ -1,0 +1,70 @@
+# SUSE's openQA tests
+#
+# Author: Gao Zhiyuan <zgao@suse.com>
+# Copyright © SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: test ibus chinese input
+# Maintainer: Gao Zhiyuan <zgao@suse.com>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub ibus_enable_source_ch {
+    send_key 'super';
+    wait_still_screen;
+    type_string_slow ' region & language';
+    wait_still_screen(3);
+    send_key 'ret';
+
+    assert_screen 'ibus-region-language';
+    assert_and_click 'ibus-input-source-options';
+    assert_and_click 'ibus-input-language-list';
+    type_string 'chinese';
+
+    assert_and_click 'ibus-input-chinese';
+    assert_and_dclick 'ibus-input-chinese-pinyin';
+    assert_screen 'ibus-input-added-ch';
+    send_key 'alt-f4';
+    assert_screen 'generic-desktop';
+}
+
+sub test_ch {
+    x11_start_program('gedit');
+    hold_key 'super';
+    send_key_until_needlematch 'ibus_switch_ch', 'spc', 6;
+    release_key 'super';
+
+    wait_still_screen(3);
+    type_string_slow 'nihao';
+    type_string_slow '1';
+    assert_screen 'ibus_ch_nihao';
+
+    hold_key 'super';
+    send_key_until_needlematch 'ibus_switch_en', 'spc', 6;
+    release_key 'super';
+
+    send_key 'alt-f4';
+    assert_and_click 'ibus-gedit-close';
+
+    assert_screen 'generic-desktop';
+}
+
+sub run {
+    my ($self) = @_;
+
+    assert_screen "generic-desktop";
+    # enable Chinese input sources
+    ibus_enable_source_ch;
+
+    # open gedit and test chinese
+    test_ch;
+}
+
+1;

--- a/tests/x11/ibus/ibus_test_jp.pm
+++ b/tests/x11/ibus/ibus_test_jp.pm
@@ -1,0 +1,70 @@
+# SUSE's openQA tests
+#
+# Author: Gao Zhiyuan <zgao@suse.com>
+# Copyright © SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: setup and test ibus japanese input
+# Maintainer: Gao Zhiyuan <zgao@suse.com>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub ibus_enable_source_jp {
+    send_key 'super';
+    wait_still_screen;
+    type_string_slow ' region & language';
+    wait_still_screen(3);
+    send_key 'ret';
+
+    assert_screen 'ibus-region-language';
+    assert_and_click 'ibus-input-source-options';
+    assert_and_click 'ibus-input-language-list';
+    type_string 'japanese';
+
+    assert_and_click 'ibus-input-japanese';
+    assert_and_dclick 'ibus-input-japanese-kkc';
+    assert_screen 'ibus-input-added-jp';
+    send_key 'alt-f4';
+    assert_screen 'generic-desktop';
+}
+
+sub test_jp {
+    x11_start_program('gedit');
+    hold_key('super');
+    send_key_until_needlematch 'ibus_switch_jp', 'spc', 6;
+    release_key('super');
+
+    wait_still_screen(3);
+    type_string_slow 'konnnichiha';
+    send_key 'ret';
+    assert_screen 'ibus_jp_hi';
+
+    hold_key 'super';
+    send_key_until_needlematch 'ibus_switch_en', 'spc', 6;
+    release_key 'super';
+
+    send_key 'alt-f4';
+    assert_and_click 'ibus-gedit-close';
+    assert_screen 'generic-desktop';
+}
+
+sub run {
+    my ($self) = @_;
+
+    assert_screen "generic-desktop";
+
+    # enable Japanses input sources
+    ibus_enable_source_jp;
+
+    # open gedit and test chinese
+    test_jp;
+}
+
+1;

--- a/tests/x11/ibus/ibus_test_kr.pm
+++ b/tests/x11/ibus/ibus_test_kr.pm
@@ -1,0 +1,72 @@
+# SUSE's openQA tests
+#
+# Author: Gao Zhiyuan <zgao@suse.com>
+# Copyright © SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: ibus enable and test korean language
+# Maintainer: Gao Zhiyuan <zgao@suse.com>
+
+use base "x11test";
+use strict;
+use testapi;
+use utils;
+
+sub ibus_enable_source_kr {
+    send_key 'super';
+    type_string_slow ' region & language';
+    wait_still_screen(3);
+    send_key 'ret';
+
+
+    assert_screen 'ibus-region-language';
+    assert_and_click 'ibus-input-source-options';
+    assert_and_click 'ibus-input-language-list';
+    type_string 'korean';
+
+    assert_and_click 'ibus-input-korean';
+    assert_and_dclick 'ibus-input-korean-hangul';
+    assert_screen 'ibus-input-added-kr';
+    send_key 'alt-f4';
+    assert_screen 'generic-desktop';
+}
+
+sub test_kr {
+    x11_start_program('gedit');
+    hold_key 'super';
+    send_key_until_needlematch 'ibus_switch_kr', 'spc', 6;
+    release_key 'super';
+
+    # turn on the hangul mode
+    assert_and_click 'ibus-indicator';
+    assert_and_click 'ibus-korean-switch-hangul';
+    type_string_slow 'dkssudgktpdy';
+    send_key 'ret';
+    assert_screen 'ibus_kr_hi';
+
+    hold_key('super');
+    send_key_until_needlematch 'ibus_switch_en', 'spc', 6;
+    release_key('super');
+
+    send_key 'alt-f4';
+    assert_and_click 'ibus-gedit-close';
+
+    assert_screen 'generic-desktop';
+}
+
+sub run {
+    my ($self) = @_;
+
+    assert_screen "generic-desktop";
+    # enable Korean input sources
+    ibus_enable_source_kr;
+
+    # open gedit and test korean
+    test_kr;
+}
+
+1;

--- a/variables.md
+++ b/variables.md
@@ -70,7 +70,7 @@ NOAUTOLOGIN | boolean | false | Indicates disabled auto login.
 NOIMAGES |||
 NOLOGS | boolean | false | Do not collect logs if set to true. Handy during development.
 RAIDLEVEL | integer | | Define raid level to be configured. Possible values: 0,1,5,6,10.
-REGRESSION | string | | Define scope of regression testing.
+REGRESSION | string | | Define scope of regression testing, including ibus, gnome, documentation and other.
 REPO_* | string | | Url pointing to the mirrored repo. REPO_0 contains installation iso.
 RESCUECD | boolean | false | Indicates rescue image to be used.
 RESCUESYSTEM | boolean | false | Indicates rescue system under test.


### PR DESCRIPTION
Add new tests for ibus

- Related ticket:  [https://progress.opensuse.org/issues/44087](https://progress.opensuse.org/issues/44087)
- Needles:          [https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/478](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/478)
- Verification run: [http://10.67.18.38/tests/346](http://10.67.18.38/tests/346)