### PR TITLE
Adjust disk as pv autoyast test as per bsc#1115807

### DIFF
--- a/data/autoyast_sle15/autoyast_disk_as_pv.xml
+++ b/data/autoyast_sle15/autoyast_disk_as_pv.xml
@@ -65,9 +65,27 @@
     </report>
     <partitioning config:type="list">
         <drive>
+            <device>/dev/sda</device>
+            <disklabel>gpt</disklabel>
+            <initialize config:type="boolean">true</initialize>
+            <partitions config:type="list">
+                <partition>
+                    <create config:type="boolean">true</create>
+                    <format config:type="boolean">false</format>
+                    <size>8Mib</size>
+                </partition>
+                <partition>
+                    <format config:type="boolean">true</format>
+                    <create config:type="boolean">false</create>
+                    <mount>/boot</mount>
+                    <size>256M</size>
+                </partition>
+            </partitions>
+        </drive>
+        <drive>
             <type config:type="symbol">CT_DISK</type>
             <use>all</use>
-            <device>/dev/sda</device>
+            <device>/dev/sdb</device>
             <disklabel>none</disklabel>
             <partitions config:type="list">
                 <partition>
@@ -79,7 +97,7 @@
             </partitions>
         </drive>
         <drive>
-            <device>/dev/sdb</device>
+            <device>/dev/sdc</device>
             <disklabel>none</disklabel>
             <partitions config:type="list">
                 <partition>

--- a/tests/autoyast/verify_disk_as_pv.pm
+++ b/tests/autoyast/verify_disk_as_pv.pm
@@ -20,14 +20,14 @@ sub validate_disk_as_partition {
     my $errors = '';
     record_info('Verify root partition as disk');
     # Validate type of the partition
-    my $output = script_output('lsblk /dev/sda --noheading --output TYPE');
+    my $output = script_output('lsblk /dev/sdb --noheading --output TYPE');
     if ($output !~ 'disk') {
-        $errors .= "Expected type disk for /dev/vda, got: $output\n";
+        $errors .= "Expected type disk for /dev/sdb, got: $output\n";
     }
     # Validate mount point of the partition
-    $output = script_output('lsblk /dev/sda --noheading --output MOUNTPOINT');
+    $output = script_output('lsblk /dev/sdb --noheading --output MOUNTPOINT');
     if ($output !~ '/') {
-        $errors .= "Expected '/' mount point disk for /dev/vda, got: $output\n";
+        $errors .= "Expected '/' mount point disk for /dev/sdb, got: $output\n";
     }
     return $errors;
 }


### PR DESCRIPTION
Initial test used unsupported scenario, even though it worked.

See [poo#42605](https://progress.opensuse.org/issues/42605).

- [Verification run](http://g226.suse.de/tests/3215).
