### PR TITLE
Detect missing icons in YaST logs

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -145,7 +145,8 @@ sub investigate_yast2_failure {
         '<3>',                                           # Detecting problems using error code
         'No textdomain configured',                      # Detecting missing translations
         'nothing provides',                              # Detecting missing required packages
-        'but this requirement cannot be provided'        # and package conflicts
+        'but this requirement cannot be provided',       # and package conflicts
+        'Could not load icon'                            # Detecting missing icons
     );
     for my $y2log_error (@y2log_errors) {
         if (my $y2log_error_result = script_output 'grep -B 3 \'' . $y2log_error . '\' /var/log/YaST2/y2log | tail -n 20 || true') {


### PR DESCRIPTION
The commit adds the search term to be parsed in YaST logs to detect
missing icons.

So that the errors will be reflected in the test run.

Related ticket: [poo#43457](https://progress.opensuse.org/issues/43457)
