### PR TITLE
Handle pmem devices in installation/partitioning_firstdisk

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -342,7 +342,7 @@ sub select_first_hard_disk {
     else {
         assert_and_click 'hard-disk-dev-sdb-selected' if match_has_tag('hard-disk-dev-sdb-selected');
         if (match_has_tag('hard-disk-dev-non-sda-selected')) {
-            foreach my $tag (grep { $_ =~ /hard-disk-dev-sd[a-z]/ } @{$matched_needle->{needle}->{tags}}) {
+            foreach my $tag (grep { $_ =~ /hard-disk-dev-(sd[a-z]|pmem[0-9])/ } @{$matched_needle->{needle}->{tags}}) {
                 assert_and_click "$tag-selected";
             }
         }


### PR DESCRIPTION
When running `installation/partitioning_firstdisk`, the test must deselect all devices with the exception of `/dev/sda` (or similarly named first disk device) to configure as the device where the OS
partition and swap will be located. This pull request and related needles allow the test to deselect pmem devices (`/dev/pmem0` and `/dev/pmem1` for the time being) so only `/dev/sda` is kept selected.

- Related ticket: https://progress.opensuse.org/issues/42026
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1007
- Verification run: http://mango.suse.de/tests/652#step/partitioning_firstdisk/1