### PR TITLE
LTP: Use upload_system_logs() for uploading logs

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -21,6 +21,7 @@ use bootloader_setup qw(add_custom_grub_entries add_grub_cmdline_settings);
 use main_common 'get_ltp_tag';
 use power_action_utils 'power_action';
 use serial_terminal 'add_serial_console';
+use upload_system_log;
 use version_utils qw(is_sle sle_version_at_least is_opensuse is_jeos);
 
 sub add_repos {
@@ -318,8 +319,7 @@ sub run {
 sub post_fail_hook {
     my $self = shift;
 
-    script_run("dmesg > /tmp/dmesg.txt");
-    upload_logs("/tmp/dmesg.txt", failok => 1);
+    upload_system_logs();
 
     # bsc#1024050
     script_run('pkill pidstat');

--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -16,6 +16,7 @@ use base 'opensusebasetest';
 use testapi;
 use utils;
 use power_action_utils 'power_action';
+use upload_system_log;
 
 sub export_to_json {
     my ($test_result_export) = @_;
@@ -40,11 +41,9 @@ sub run {
         upload_logs($ver_linux_log, failok => 1);
     }
 
-    script_run("dmesg > /tmp/dmesg.txt");
-    upload_logs("/tmp/dmesg.txt", failok => 1);
-
     script_run('[ "$ENABLE_WICKED" ] && systemctl enable wicked');
-    script_run('journalctl --no-pager -p warning');
+    upload_system_logs();
+
     power_action('poweroff');
 }
 


### PR DESCRIPTION
As it adds properly journalctl logs (missing in install_ltp.pm and only
end of journalctl in shutdown_ltp.pm) + some basic system info.

NOTE: journalctl logs are needed for tirpc logs.