### PR TITLE
Fix eula selection in welcome

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -243,11 +243,15 @@ sub accept_license {
 
 sub verify_license_translations {
     return if (is_sle && get_var("BETA") || check_var('VIDEOMODE', 'text'));
-    for my $language (split(/,/, get_var('EULA_LANGUAGES')), 'english-us') {
+    my $current_lang = 'english-us';
+    for my $lang (split(/,/, get_var('EULA_LANGUAGES')), 'english-us') {
         wait_screen_change { send_key 'alt-l' };
-        send_key 'home';
-        send_key_until_needlematch("license-language-selected-$language", 'down', 60, 3);
-        assert_screen "license-content-$language";    # needs wait for loading content
+        assert_and_click "license-language-selected-$current_lang";
+        wait_screen_change { type_string(substr($lang, 0, 1)) };
+        send_key_until_needlematch("license-language-selected-dropbox-$lang", 'down', 60);
+        send_key 'ret';
+        assert_screen "license-content-$lang";
+        $current_lang = $lang;
     }
 }
 


### PR DESCRIPTION
We need better strategy when checking for EULA in welcome due to some language take more time to load than others and instead of using welcome screen we can do the selection following another path safer for the automation to succeed.

- Related ticket: https://progress.opensuse.org/issues/43523
- Needles: [needles sle](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1008)
- Verification run: [sle-12-SP4-Server-installer_extended](http://dhcp42.suse.cz/tests/951#step/welcome/15)
