### PR TITLE
[SLE-15-SP1 Prep] Add dependency repo and skip autoupg.xml uploading for host upgrade between SPs in SLES-15

### DIFF
--- a/tests/virt_autotest/host_upgrade_step2_run.pm
+++ b/tests/virt_autotest/host_upgrade_step2_run.pm
@@ -31,12 +31,13 @@ sub run {
         "no", "yes", "/var/log/qa/", "host-upgrade-prepAndUpgrade");
 
     #replace module url with openqa daily build modules link
-    my $upgrade_product = get_required_var('UPGRADE_PRODUCT');
-    my ($upgrade_release) = lc($upgrade_product) =~ /sles-([0-9]+)-sp/;
-    if ($upgrade_release >= 15) {
+    my $installed_product = get_var('VERSION_TO_INSTALL', get_var('VERSION', ''));
+    my ($installed_release) = $installed_product =~ /^(\d+)/;
+    my $upgrade_product     = get_required_var('UPGRADE_PRODUCT');
+    my ($upgrade_release)   = lc($upgrade_product) =~ /sles-([0-9]+)-sp/;
+    if (($upgrade_release >= 15) && ($installed_release ne $upgrade_release)) {
         upload_logs('/root/autoupg.xml');
     }
 }
 
 1;
-

--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -27,18 +27,26 @@ sub install_package {
     assert_script_run("zypper --non-interactive --no-gpg-check -n ar -f '$qa_server_repo' server-repo");
 
     #workaround for dependency on xmlstarlet for qa_lib_virtauto on sles11sp4 and sles12sp1
+    #workaround for dependency on bridge-utils for qa_lib_virtauto on sles15sp0
     my $repo_0_to_install = get_var("REPO_0_TO_INSTALL", '');
-    my $dependency_repo = '';
+    my $dependency_repo   = '';
+    my $dependency_rpms   = '';
     if ($repo_0_to_install =~ /SLES-11-SP4/m) {
         $dependency_repo = 'http://download.suse.de/ibs/SUSE:/SLE-11:/Update/standard/';
+        $dependency_rpms = 'xmlstarlet';
     }
     elsif ($repo_0_to_install =~ /SLE-12-SP1/m) {
         $dependency_repo = 'http://download.suse.de/ibs/SUSE:/SLE-12:/Update/standard/';
+        $dependency_rpms = 'xmlstarlet';
+    }
+    elsif ($repo_0_to_install =~ /SLE-15-Installer/m) {
+        $dependency_repo = 'http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/';
+        $dependency_rpms = 'bridge-utils';
     }
     if ($dependency_repo) {
         assert_script_run("zypper --non-interactive --no-gpg-check -n ar -f ${dependency_repo} dependency_repo");
         assert_script_run("zypper --non-interactive --gpg-auto-import-keys ref", 180);
-        assert_script_run("zypper --non-interactive -n in xmlstarlet");
+        assert_script_run("zypper --non-interactive -n in $dependency_rpms");
         assert_script_run("zypper --non-interactive -n rr dependency_repo");
     }
     #install qa_lib_virtauto


### PR DESCRIPTION
1. qa_lib_virtauto installation in install_package.pm requires bridge-utils, which can not be found on host installed with SLES-15. Repo http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/ can help fill the gap.
2. There is no /root/autoupg.xml file exists for host upgrade between SPs in SLES-15

- Related ticket: Host upgrade from SLES-15 to SLES-15-SP1
- Needles: n/a
- Verification run: https://10.67.17.5/tests/235   https://10.67.17.5/tests/269#

@alice-suse @XGWang0 @guoxuguang @Julie-CAO 