### PR TITLE
Make test 'firefox_changesaving' more robust, fix poo#43958

### DIFF
--- a/tests/x11/firefox/firefox_changesaving.pm
+++ b/tests/x11/firefox/firefox_changesaving.pm
@@ -48,8 +48,11 @@ sub run {
         assert_and_click 'firefox-changesaving-showblankpage';
     }
 
-    send_key "alt-tab";     #Switch to xterm
+    wait_still_screen 2, 4;    #There might be a notification
+    send_key "alt-tab";        #Switch to xterm
     wait_still_screen 2, 4;
+    assert_screen 'xterm-left-open';
+
     assert_script_run "$changesaving_checktimestamp > dfb";
 
     # check and fail if timestamp is same


### PR DESCRIPTION
There might be a notification, so wait a few seconds before send key `alt-tab`, and check screen for `xterm-left-open` afterwords to make sure xterm appears.

- Related ticket: https://progress.opensuse.org/issues/43958
- Needles: none
- Verification run: http://10.67.18.141/tests/20
