### PR TITLE
Fix selection of first hd when pre-selected

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -326,9 +326,19 @@ sub addboot {
     }
 }
 
+sub skip_select_first_hard_disk {
+    return 1 if match_has_tag 'existing-partitions';    # no selection of hard-disk is required
+    if (match_has_tag('select-hard-disks-one-selected')) {    # first hd is already pre-selected
+        send_key $cmd{next};
+        return 1;
+    }
+    return 0;
+}
+
 sub select_first_hard_disk {
-    my $matched_needle = assert_screen [qw(existing-partitions hard-disk-dev-sdb-selected hard-disk-dev-non-sda-selected)];
-    return if match_has_tag 'existing-partitions';
+    my @tags           = qw(existing-partitions hard-disk-dev-sdb-selected hard-disk-dev-non-sda-selected select-hard-disks-one-selected);
+    my $matched_needle = assert_screen \@tags;
+    return if skip_select_first_hard_disk;
     # SUT may have any number disks, only keep the first, unselect all other disks
     # In text mode, the needle has tag 'hard-disk-dev-non-sda-selected' and multiple hotkey_? tags as hints for unselecting
     if (check_var('VIDEOMODE', 'text') && match_has_tag('hard-disk-dev-non-sda-selected')) {


### PR DESCRIPTION
In case the first disk is pre-selected (is the only one selected), skip the logic for deselection of the rest of hds.
~Also increase timeout for ipmi due to partition proposal has change and it seems that we try to `check_screen` too fast.~ Agreed to pull out this for a better approach in future.

- Related ticket: https://progress.opensuse.org/issues/44024
- Verification run: [Tumbleweed-select_disk](http://dhcp42.suse.cz/tests/959#step/partitioning_firstdisk/6)
