### PR TITLE
Add tgt to non_x86 supportserver autoyast profile

### DIFF
--- a/data/supportserver/autoyast_supportserver_non_x86.xml
+++ b/data/supportserver/autoyast_supportserver_non_x86.xml
@@ -60,9 +60,10 @@
 		<package>less</package>
 		<package>nfs-client</package>
 		<package>autofs</package>
-                <package>bind</package>
+		<package>bind</package>
 		<package>atftp</package>
 		<package>yast2-iscsi-lio-server</package>
+		<package>tgt</package>
     </packages>
    <patterns config:type="list">
           <pattern>base</pattern>


### PR DESCRIPTION
Enhancement poo#43274: Add installation of tgt package to supportserver
 autoyast profile for other architectures (aarch64, ppc64le).

- Related ticket: https://progress.opensuse.org/issues/43274
- Needles: none
- Verification run: none
