### PR TITLE
Disable serial-getty before running commands in xterm

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -2,8 +2,17 @@ package susedistribution;
 use base 'distribution';
 use serial_terminal ();
 use strict;
-use utils
-  qw(type_string_slow ensure_unlocked_desktop save_svirt_pty get_root_console_tty get_x11_console_tty ensure_serialdev_permissions pkcon_quit zypper_call);
+use utils qw(
+  disable_serial_getty
+  ensure_serialdev_permissions
+  ensure_unlocked_desktop
+  get_root_console_tty
+  get_x11_console_tty
+  pkcon_quit
+  save_svirt_pty
+  type_string_slow
+  zypper_call
+);
 use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x);
 use ipmi_backend_utils 'use_ssh_serial_console';
 
@@ -331,6 +340,7 @@ sub become_root {
     my ($self) = @_;
 
     $self->script_sudo('bash', 0);
+    disable_serial_getty;
     type_string "whoami > /dev/$testapi::serialdev\n";
     wait_serial('root') || die "Root prompt not there";
     type_string "cd /tmp\n";

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -32,11 +32,7 @@ sub run {
     # Prevent mail notification messages to show up in shell and interfere with running console tests
     disable_bash_mail_notification;
     # Stop serial-getty on serial console to avoid serial output pollution with login prompt
-    # Doing early due to bsc#1103199 and bsc#1112109
-    systemctl "stop serial-getty\@$testapi::serialdev", ignore_failure => 1;
-    systemctl "disable serial-getty\@$testapi::serialdev";
-    # Mask if is qemu backend as use serial in remote installations e.g. during reboot
-    systemctl "mask serial-getty\@$testapi::serialdev" if check_var('BACKEND', 'qemu');
+    disable_serial_getty;
     # init
     check_console_font;
 


### PR DESCRIPTION
Mitigation to
[bsc#1112109](https://bugzilla.opensuse.org/show_bug.cgi?id=1112109), we
have applied it to console tests, but x11 also get affected when
running commands in the xterm. Therefore, we need to run it there too.

See [poo#42359](https://progress.opensuse.org/issues/42359).

As this is workaround, now it's bulletproof in that sense, that we won't affect test if something doesn't work there.

[qam gnome](http://g226.suse.de/tests/3235)
[gnu health](http://g226.suse.de/tests/3236)