### PR TITLE
Disable xfreerdp floatbar in fullscreen

### DIFF
--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -233,7 +233,7 @@ sub run {
       . get_var('HYPERV_USERNAME') . " /p:'"
       . get_var('HYPERV_PASSWORD') . "' /v:"
       . get_var('HYPERV_SERVER') . ' +auto-reconnect /auto-reconnect-max-retries:10'
-      . " /cert-ignore /vmconnect:$vmguid /f /log-level:DEBUG 2>&1 > $xfreerdp_log; echo $vmguid > xfreerdp_${name}_stop; done; ";
+      . " /cert-ignore /vmconnect:$vmguid /f -floatbar /log-level:DEBUG 2>&1 > $xfreerdp_log; echo $vmguid > xfreerdp_${name}_stop; done; ";
 
     hyperv_cmd_with_retry("$ps Start-VM $name");
 


### PR DESCRIPTION
FreeRDP 2.0.0 RC4 brought floatbar in fullscreen by default. We need it
disabled though.

Fails here:
* https://openqa.suse.de/tests/2274355#step/bootloader/3
* https://openqa.suse.de/tests/2274354#step/bootloader/3

Validation runs:
* http://nilgiri.suse.cz/tests/1824
* http://nilgiri.suse.cz/tests/1825