### PR TITLE
Improve check_version and add travis check

### DIFF
--- a/t/01_version_utils.t
+++ b/t/01_version_utils.t
@@ -13,6 +13,25 @@ use lib ("$FindBin::Bin/lib", "$FindBin::Bin/../lib");
 
 use testapi qw(check_var get_var set_var);
 
+subtest 'check_version' => sub {
+    # compare versions if possible
+    ok version_utils::check_version($_, '15.5'), "check $_, 15.5" for qw[ >15.0 <15.10 ];
+    ok !version_utils::check_version($_, '15.5'), "check $_, 15.5" for qw[ =15.50 >=15.10 ];
+
+    # compare strings if not
+    ok version_utils::check_version($_, 'klm'), "check $_, klm" for qw[ abc+ 1+ =KLM ];
+
+    # die if regex does not match
+    for (qw[ 1.3+ 11-sp1+ ]) {
+        dies_ok { version_utils::check_version($_, '12-sp3', qr/^\d{2}/) } "check $_, 12-sp3, ^\\d{2}";
+    }
+
+    # die if compare symbols are wrong
+    for (qw[ =1.3+ >1.3+ <>1.3 > 12 abc ]) {
+        dies_ok { version_utils::check_version($_, '12-sp3') } "check $_, 12-sp3";
+    }
+};
+
 subtest 'is_caasp' => sub {
     use version_utils 'is_caasp';
 
@@ -33,7 +52,7 @@ subtest 'is_leap' => sub {
 
     set_var('VERSION', '42.3');
     ok is_leap, "check is_leap";
-    ok is_leap($_),  "check $_" for qw[ =42.3 <=15.0 >42.1 ];
+    ok is_leap($_),  "check $_" for qw[ =42.3 <=15.0 >42.1 >=42.3 ];
     ok !is_leap($_), "check $_" for qw[ =15.0 >42.3 <42.3 <13.0 ];
     dies_ok { is_leap $_ } "check $_" for (qw[ 13+ <=15 =42 42+ 42.1:S:A+ =42.3:S:A ]);
 


### PR DESCRIPTION
- extracted leap hacks from check_version to is_leap
- replace get_var('VERSION') with parameter to support `version_variable`
  - so we can remove sle_version_at_least
- regex for checking query parameter is now optional
- added travis check