### PR TITLE
Expand volume management list on sle12

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -254,9 +254,11 @@ sub addlv {
     send_key $cmd{system_view};
     send_key 'home';
     send_key_until_needlematch('volume_management_feature', 'down');
+    wait_still_screen 2;
     # Expand collapsed list with VGs
     send_key 'right' if is_sle('<15');
     send_key_until_needlematch 'partition-select-vg-' . "$args{vg}", 'down';
+    wait_still_screen 2;
     # Expand collapsed list with LVs
     send_key 'right' if is_sle('<15');
     send_key 'alt-i' if (is_storage_ng_newui);


### PR DESCRIPTION
- Related ticket: [[sle][functional][y][aarch64][sporadic] test fails in partitioning_full_lvm - Volume Management list stays collapsed](https://progress.opensuse.org/issues/43568)
- Verification runs: 
  *[sle-12-SP4-Server-DVD-aarch64-Build0456-lvm-encrypt-separate-boot@aarch64](http://dhcp128.suse.cz/tests/8698)
  *[sle-15-SP1-Installer-DVD-aarch64-Build100.4-lvm-encrypt-separate-boot@aarch64](http://dhcp128.suse.cz/tests/8697)