### PR TITLE
[WIP] Add a function to check if /etc/hosts is properly updated by yast2 lan

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -17,9 +17,9 @@ sub post_fail_hook {
 
     show_tasks_in_blocked_state if ($defer_blocked_task_info);
 
+    $self->remount_tmp_if_ro;
     $self->save_upload_y2logs;
     upload_logs('/var/log/zypper.log');
-    $self->remount_tmp_if_ro;
     $self->save_system_logs;
     $self->save_strace_gdb_output('yast');
 }

--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -17,9 +17,9 @@ sub post_fail_hook {
 
     show_tasks_in_blocked_state if ($defer_blocked_task_info);
 
+    $self->save_upload_y2logs;
     upload_logs('/var/log/zypper.log');
     $self->remount_tmp_if_ro;
-    $self->save_upload_y2logs;
     $self->save_system_logs;
     $self->save_strace_gdb_output('yast');
 }

--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -47,7 +47,7 @@ sub initialize_y2lan {
 sub open_network_settings {
     type_string "yast2 lan\n";
     accept_warning_network_manager_default;
-    assert_screen 'yast2_lan', 100;       # yast2 lan overview tab
+    assert_screen 'yast2_lan', 180;       # yast2 lan overview tab
     send_key 'home';                      # select first device
     wait_still_screen(2);
 }
@@ -56,7 +56,7 @@ sub close_network_settings {
     wait_still_screen;
     send_key 'alt-o';
     # new: warning pops up for firewall, alt-y for assign it to zone
-    assert_screen([qw(yast2-lan-restart_firewall_active_warning yast2_closed_xterm_visible yast2_lan_packages_need_to_be_installed)], 120);
+    assert_screen([qw(yast2-lan-restart_firewall_active_warning yast2_closed_xterm_visible yast2_lan_packages_need_to_be_installed)], 180);
     if (match_has_tag 'yast2-lan-restart_firewall_active_warning') {
         send_key 'alt-y';
         wait_still_screen 1;
@@ -67,7 +67,7 @@ sub close_network_settings {
     elsif (match_has_tag 'yast2_lan_packages_need_to_be_installed') {
         send_key 'alt-i';
     }
-    assert_screen 'yast2_closed_xterm_visible', 120;    # ensure coming back to root console
+    assert_screen 'yast2_closed_xterm_visible', 180;    # ensure coming back to root console
     type_string "\n\n";                                 # make space for better readability of the console
 }
 
@@ -94,13 +94,13 @@ sub check_network_status {
 }
 
 sub verify_network_configuration {
-    my ($fn, $dev_name, $expected_status, $workaround) = @_;
+    my ($fn, $dev_name, $expected_status, $workaround, $no_network_check) = @_;
     open_network_settings;
 
     $fn->($dev_name) if $fn;                                          # verify specific action
 
     close_network_settings;
-    check_network_status($expected_status, $workaround);
+    check_network_status($expected_status, $workaround) unless defined $no_network_check;
 }
 
 1;

--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -34,18 +34,83 @@ sub handle_dhcp_popup {
     }
 }
 
+
+sub set_network {
+    my ($loop, $param) = @_;
+    script_run("yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev", 0);
+    assert_screen "yast2_lan";
+    send_key 'alt-i';    # edit NIC
+    assert_screen 'yast_ncurses_network_card_setup';
+    if ("$param" eq "set_static_ip") {
+        send_key 'alt-t';    # set to static ip
+        assert_screen 'yast_ncurses_set_static_ip';
+        send_key 'tab';
+        if ($loop != 2) {
+            send_key_until_needlematch('NICsetup_ncurses_IP_empty', 'backspace');    # delete existing IP if any
+            type_string "192.168.122.10";
+        }
+        send_key 'tab';
+        if ($loop != 2) {
+            send_key_until_needlematch('NICsetup_ncurses_mask_empty', 'backspace');    # delete existing netmask if any
+            type_string "/24";
+        }
+        send_key 'tab';
+        send_key_until_needlematch('NICsetup_ncurses_host_empty', 'backspace');
+        type_string "tst-$loop.com";
+        assert_screen 'yast_ncurses_static_ip_set';
+    }
+    else {
+        send_key 'alt-y';                                                              # set back to DHCP
+        assert_screen 'yast_ncurses_set_dhcp';
+    }
+    # Exit
+    send_key 'alt-n';
+    assert_screen "yast2_lan";
+    send_key 'alt-o';
+    wait_serial("yast2-lan-status-0", 180) || die "'yast2 lan' didn't finish";
+}
+
+
+sub check_etc_hosts_update {
+
+=head2
+
+In order to targer bugs bsc#1115644 and bsc#1052042, we want to :
+- Set static IP and fqdn for first NIC in the list and check /etc/hosts formatting
+- Open yast2 lan again and change the fqdn, check if /etc/hosts is changed correctly ( bsc#1052042 )
+- Set it to DHCP
+- Set it again to static with  new FQDN and check if /etc/hosts is changed correctly ( bsc#1115644 )
+
+=cut
+
+    my $looprun = 1;
+    script_run "cat /etc/hosts";
+    until ($looprun == 4) {
+        set_network($looprun, "set_static_ip");
+        script_run("egrep \"192.168.122.10\\stst-$looprun.com\\stst-$looprun\" /etc/hosts", 30)
+          && record_soft_failure "bsc#1115644 Expected entry : \"192.168.1.10    tst-$looprun.com tst-$looprun\" was not found in /etc/hosts";
+        if ($looprun == 2) {
+            set_network;    # Without parameter, set as dhcp
+        }
+        script_run "cat /etc/hosts";
+        $looprun++;
+    }
+    set_network;
+}
+
+
 sub run {
     my $self = shift;
 
-    select_console 'user-console';
-    assert_script_sudo "zypper -n in yast2-network";    # make sure yast2 lan module installed
+    select_console 'root-console';
+    assert_script_run "zypper -n in yast2-network";    # make sure yast2 lan module installed
 
     # those two are for debugging purposes only
     script_run('ip a');
     script_run('ls -alF /etc/sysconfig/network/');
     save_screenshot;
 
-    script_sudo("yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev", 0);
+    script_run("yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev", 0);
 
     assert_screen [qw(Networkmanager_controlled yast2_lan install-susefirewall2 install-firewalld dhcp-popup)], 120;
     handle_dhcp_popup;
@@ -71,10 +136,10 @@ sub run {
     assert_screen [qw(yast2_lan-hostname-tab dhcp-popup)];
     handle_dhcp_popup;
     send_key "tab";
-    for (1 .. 15) { send_key "backspace" }
+    send_key_until_needlematch 'hostname_ncurses_hostname_empty', 'backspace';
     type_string $hostname;
     send_key "tab";
-    for (1 .. 15) { send_key "backspace" }
+    send_key_until_needlematch 'hostname_ncurses_domain_empty', 'backspace';
     type_string $domain;
     assert_screen 'test-yast2_lan-1';
 
@@ -82,6 +147,7 @@ sub run {
     wait_serial("yast2-lan-status-0", 180) || die "'yast2 lan' didn't finish";
 
     wait_still_screen;
+    check_etc_hosts_update if (check_var('BACKEND', 'qemu'));
     $self->clear_and_verify_console;
     assert_script_run "hostname|grep $hostname";
 
@@ -91,5 +157,8 @@ sub run {
     assert_script_run('getent ahosts ' . get_var("OPENQA_HOSTNAME"));
 }
 
-1;
+sub test_flags {
+    return {always_rollback => 1} if (check_var('BACKEND', 'qemu'));
+}
 
+1;

--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -46,12 +46,12 @@ sub set_network {
         send_key 'alt-t';    # set to static ip
         assert_screen 'yast_ncurses_set_static_ip';
         send_key 'tab';
-        if ($args{ip}) {  # To spare time, no update what to is already filled from previous run
+        if ($args{ip}) {     # To spare time, no update what to is already filled from previous run
             send_key_until_needlematch('NICsetup_ncurses_IP_empty', 'backspace');    # delete existing IP if any
             type_string $args{ip};
         }
         send_key 'tab';
-        if ($args{mask}) {  # To spare time, no update what to is already filled from previous run
+        if ($args{mask}) {                                                           # To spare time, no update what to is already filled from previous run
             send_key_until_needlematch('NICsetup_ncurses_mask_empty', 'backspace');    # delete existing netmask if any
             type_string $args{mask};
         }
@@ -91,7 +91,7 @@ In order to targer bugs bsc#1115644 and bsc#1052042, we want to :
     script_run "cat /etc/hosts";
     until ($looprun == 4) {
         $hostname = "tst-$looprun";
-        $fqdn = $hostname . '.com';
+        $fqdn     = $hostname . '.com';
         set_network(static => 1, fqdn => $fqdn, ip => $ip, mask => '/24');
         script_run("egrep \"$ip\\s$fqdn\\s$hostname\" /etc/hosts", 30)
           && record_soft_failure "bsc#1115644 Expected entry : \"192.168.1.10    $fqdn $hostname\" was not found in /etc/hosts";
@@ -163,5 +163,8 @@ sub run {
     assert_script_run('getent ahosts ' . get_var("OPENQA_HOSTNAME"));
 }
 
+sub test_flags {
+    return {always_rollback => 1};    # Should only affect backends that have snapshot feature
+}
 
 1;

--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -147,4 +147,8 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
 }
 
+sub test_flags {
+    return {always_rollback => 1};    # Should only affect backends that have snapshot feature
+}
+
 1;

--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -70,11 +70,68 @@ sub change_hw_device_name {
     send_key $cmd{next};
 }
 
+sub set_static_ip {
+    my $loop = shift;
+    send_key 'alt-i';
+    assert_screen 'yast2_lan_network_card_setup';
+    send_key 'alt-t';
+    send_key 'tab';
+    type_string '192.168.1.10';
+    send_key 'tab';
+    type_string '255.255.255.0';
+    send_key 'tab';
+    type_string "test-$loop.susetest.com";
+    wait_still_screen;    # yes, necessary.
+    assert_screen "gnome_static_IP_set";
+    send_key 'alt-n';
+}
+
+sub set_dhcp {
+    send_key 'alt-i';
+    send_key 'alt-y';
+    assert_screen 'yast2_lan_restart_dhcp_set';
+    send_key 'alt-n';
+}
+
+
+sub check_etc_hosts_update {
+
+=head2 Description
+
+    In order to targer bugs bsc#1115644 and bsc#1052042, we want to :
+    - Set static IP and fqdn for first NIC in the list and check /etc/hosts formatting
+    - Open yast2 lan again and change the fqdn, check if /etc/hosts is changed correctly ( bsc#1052042 )
+    - Set it to DHCP
+    - Set it again to static with  new FQDN and check if /etc/hosts is changed correctly ( bsc#1115644 )
+    - Revert changes to allow next functions and tests to run normally
+
+=cut
+
+    script_run "cat /etc/hosts";
+    # wait_still_screen;
+    my $looprun = 1;
+    until ($looprun == 4) {
+        verify_network_configuration(sub { set_static_ip($looprun) }, undef, undef, undef, 'no_network_check');
+        script_run("egrep \"192.168.1.10\\stest-$looprun.susetest.com\\stest-$looprun\" /etc/hosts", 30)
+          && record_soft_failure "bsc#1115644 Expected entry : \"192.168.1.10    test-$looprun.susetest.com test-$looprun\" was not found in /etc/hosts";
+        script_run "cat /etc/hosts";
+        if ($looprun == 2) {
+            verify_network_configuration(\&set_dhcp, undef, 'restart');
+            script_run "cat /etc/hosts";
+        }
+        $looprun++;
+    }
+
+    # Revert changes to allow next functions and tests to run normally
+    verify_network_configuration(\&set_dhcp, undef, 'restart');
+}
+
 sub run {
     initialize_y2lan;
-    verify_network_configuration;               # check simple access to Overview tab
+    verify_network_configuration;    # check simple access to Overview tab
     verify_network_configuration(\&check_network_settings_tabs);
     unless (is_network_manager_default) {
+        check_etc_hosts_update if (check_var('BACKEND', 'qemu'));
         verify_network_configuration(\&check_network_card_setup_tabs);
         verify_network_configuration(\&check_default_gateway);
         verify_network_configuration(\&change_hw_device_name, 'dyn0', 'restart');
@@ -88,6 +145,10 @@ sub post_fail_hook {
     assert_script_run 'journalctl -b > /tmp/journal', 90;
     upload_logs '/tmp/journal';
     $self->SUPER::post_fail_hook;
+}
+
+sub test_flags {
+    return {always_rollback => 1} if (check_var('BACKEND', 'qemu'));
 }
 
 1;

--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -147,8 +147,4 @@ sub post_fail_hook {
     $self->SUPER::post_fail_hook;
 }
 
-sub test_flags {
-    return {always_rollback => 1} if (check_var('BACKEND', 'qemu'));
-}
-
 1;


### PR DESCRIPTION
### Description :
Progress ticket : https://progress.opensuse.org/issues/26008
Add a function in  yast2_lan and yast2_lan_restart modules.
In order to targer bugs bsc#1115644 and bsc#1052042, we want to :

- Set static IP and fqdn for first NIC in the list and check /etc/hosts formatting
- Open yast2 lan again and change the fqdn, check if /etc/hosts is changed correctly ( bsc#1052042 )
- Set it to DHCP
- Set it again to static with  new FQDN and check if /etc/hosts is changed correctly ( bsc#1115644 )

### Verification runs: 
**yast2_lan** 
Tumbleweed : http://dhcp51.suse.cz./tests/2252
sle 15 sp1 : http://dhcp51.suse.cz./tests/2251
sle 12 sp4 : http://dhcp51.suse.cz./tests/2250
**yast2_lan_restart**
sle 15 sp1 : http://dhcp51.suse.cz./tests/2752
sle 12 sp4 : http://dhcp51.suse.cz./tests/2751




