### PR TITLE
Fix failure and unify gpg key import

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -59,6 +59,7 @@ our @EXPORT = qw(
   handle_relogin
   handle_emergency
   handle_grub_zvm
+  handle_untrusted_gpg_key
   service_action
   assert_gui_app
   run_scripted_command_slow
@@ -137,6 +138,17 @@ sub handle_grub_zvm {
     }
     else {
         $console->sequence_3270("ENTER", "ENTER", "ENTER", "ENTER");
+    }
+}
+
+sub handle_untrusted_gpg_key {
+    if (match_has_tag('import-known-untrusted-gpg-key')) {
+        record_info('Import', 'Known untrusted gpg key is imported');
+        wait_screen_change { send_key 'alt-t' };    # import
+    }
+    else {
+        record_info('Cancel import', 'Untrusted gpg key is NOT imported');
+        wait_screen_change { send_key 'alt-c' };    # cancel
     }
 }
 

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -14,7 +14,7 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use utils 'addon_license';
+use utils qw(addon_license handle_untrusted_gpg_key);
 use version_utils qw(is_sle sle_version_at_least);
 use qam 'advance_installer_window';
 use registration qw(%SLE15_DEFAULT_MODULES rename_scc_addons @SLE15_ADDONS_WITHOUT_LICENSE);
@@ -110,7 +110,10 @@ sub handle_addon {
     # SES6 on SLE15 in development has untrusted key warning
     addon_license($addon) unless is_sle('15+') && $addon !~ /^ses$|^rt$/;
     # might involve some network lookup of products, licenses, etc.
-    assert_screen 'addon-products', 90;
+    assert_screen ['addon-products', 'import-untrusted-gpg-key'], 90;
+    if (match_has_tag('import-untrusted-gpg-key')) {
+        handle_untrusted_gpg_key;
+    }
     send_key 'tab';    # select addon-products-$addon
     wait_still_screen 10;
     if (check_var('VIDEOMODE', 'text')) {    # textmode need more tabs, depends on add-on count
@@ -207,7 +210,7 @@ sub run {
                 assert_screen 'addon-products', 90;
             }
             elsif (match_has_tag('import-untrusted-gpg-key')) {
-                send_key 'alt-t';
+                handle_untrusted_gpg_key;
             }
             send_key "tab";                                        # select addon-products-$addon
             wait_still_screen 10;                                  # wait until repo is added and list is initialized


### PR DESCRIPTION
Create import-known-untrusted-gpg-key tag for trusted keys like nvidia,
thus drop redudant IMPORT_UNTRUSTED_KEY variable.
With import-known-untrusted-gpg-key use match_has_tag instead of check_screen
which can cause failure because of new needle instead of matched needle.

- Failure: https://openqa.suse.de/tests/2274555#step/scc_registration/38
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1011
- Verification run: 
http://10.100.12.155/tests/8928#step/register_system/7
http://10.100.12.155/tests/8935#step/patch_sle/21
http://10.100.12.155/tests/8937#step/register_system/6
http://10.100.12.155/tests/8939#step/patch_sle/21
http://10.100.12.155/tests/8940
http://10.100.12.155/tests/8941
Cancel import (nvidia needle did not have import-known-untrusted-gpg-key to simulate warning for unknown untrusted gpg key):
http://10.100.12.155/tests/8933#step/scc_registration/33

