### PR TITLE
Add test to verify autoyast ext4 profile

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2141,6 +2141,7 @@ sub load_installation_validation_tests {
     # - autoyast/verify_btrfs: validates installation using autoyast_btrfs.xml profile
     # - autoyast/verify_btrfs_clone: validates enerated profile when cloning system
     #                                      installed using autoyast_btrfs.xml profile
+    # - autoyast/verify_ext4: validate installation using autoyast_ext4 profile
     for my $module (split(',', get_var('INSTALLATION_VALIDATION'))) {
         loadtest $module;
     }

--- a/tests/autoyast/verify_ext4.pm
+++ b/tests/autoyast/verify_ext4.pm
@@ -1,0 +1,45 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Validate autoyast_ext4 profile.
+#          * Verify registration (only 15+)
+#          * Verify partitioning: ext4 and swap
+#          * Verify users
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.com>
+
+use base 'basetest';
+use strict;
+use testapi;
+use version_utils 'is_sle';
+
+sub verify_registration {
+    my $output = script_output 'SUSEConnect --list-extensions';
+    unless ($output =~ /Basesystem.*Activated/ && $output =~ /Server Applications.*Activated/) {
+        die 'Registered system does not contains Basesystem and/or Applications Server';
+    }
+}
+
+sub verify_partitioning {
+    assert_script_run 'findmnt -S /dev/vda2 | grep "/.*ext4"';                    # generic search
+    assert_script_run 'findmnt -s | grep "swap\s\+UUID.*swap"';                   # search for swap only in /etc/fstab
+    assert_script_run 'findmnt -s | grep "/\s\+UUID.*ext4\s\+acl,user_xattr"';    # Search for attr. only in /etc/fstab
+}
+
+sub verify_user {
+    assert_script_run 'grep "bernhard:x:1000:100:Bernhard M. Wiedemann:/home/bernhard:/bin/bash" /etc/passwd';
+}
+
+sub run {
+    select_console 'root-console';
+    verify_registration if is_sle('15+');
+    verify_partitioning;
+    verify_user;
+}
+
+1;


### PR DESCRIPTION
Add test to verify different sections of autoyast ext4 profile: registration, partitioning, software packages/patterns, users
- Related ticket: https://progress.opensuse.org/issues/43796
- Verification run (on-going):
  * [sle-15-SP1-Installer-autoyast_ext4](http://dhcp42.suse.cz/tests/1003#step/verify_ext4/10)
  * [sle-12-SP4-autoyast_ext4_no_product_reg](http://dhcp42.suse.cz/tests/1004#step/verify_ext4/8)

After merged `INSTALLATION_VALIDATION=autoyast/verify_ext4` needs to be added to corresponding test suite.