### PR TITLE
Various small fixes to allow tests on a Dell PowerEdge R460 over IPMI

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -388,9 +388,10 @@ sub wait_boot {
     elsif (!(check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux') && check_var('BACKEND', 'svirt'))) {
         my @tags = ('grub2');
         push @tags, 'bootloader-shim-import-prompt'   if get_var('UEFI');
-        push @tags, 'boot-live-' . get_var('DESKTOP') if get_var('LIVETEST');    # LIVETEST won't to do installation and no grub2 menu show up
+        push @tags, 'boot-live-' . get_var('DESKTOP') if get_var('LIVETEST');             # LIVETEST won't to do installation and no grub2 menu show up
         push @tags, 'bootloader'                      if get_var('OFW');
         push @tags, 'encrypted-disk-password-prompt'  if get_var('ENCRYPT');
+        push @tags, 'linux-login'                     if get_var('KEEP_GRUB_TIMEOUT');    # Also wait for linux-login if grub timeout was not disabled
         if (get_var('ONLINE_MIGRATION')) {
             push @tags, 'migration-source-system-grub2';
         }
@@ -440,7 +441,8 @@ sub wait_boot {
             workaround_type_encrypted_passphrase;
             assert_screen "grub2", 15;
         }
-        elsif (!match_has_tag("grub2")) {
+        # If KEEP_GRUB_TIMEOUT is set, SUT may be at linux-login already, so no need to abort in that case
+        elsif (!match_has_tag("grub2") and !match_has_tag('linux-login')) {
             # check_screen timeout
             die "needle 'grub2' not found";
         }

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -429,12 +429,16 @@ sub workaround_type_encrypted_passphrase {
 sub select_user_gnome {
     my ($myuser) = @_;
     $myuser //= $username;
-    assert_screen [qw(displaymanager-user-selected displaymanager-user-notselected)];
+    assert_screen [qw(displaymanager-user-selected displaymanager-user-notselected dm-nousers)];
     if (match_has_tag('displaymanager-user-notselected')) {
         assert_and_click "displaymanager-$myuser";
         record_soft_failure 'bsc#1086425- user account not selected by default, have to use mouse to login';
     }
     elsif (match_has_tag('displaymanager-user-selected')) {
+        send_key 'ret';
+    }
+    elsif (match_has_tag('dm-nousers')) {
+        type_string $myuser;
         send_key 'ret';
     }
 }

--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -86,7 +86,9 @@ sub run {
     workaround_type_encrypted_passphrase;
     # 60 due to rare slowness e.g. multipath poo#11908
     # 90 as a workaround due to the qemu backend fallout
-    assert_screen 'grub2', $timeout;
+    # If grub timeout was not disabled, we wait for linux-login instead
+    my $tag = get_var('KEEP_GRUB_TIMEOUT') ? 'linux-login' : 'grub2';
+    assert_screen $tag, $timeout;
     stop_grub_timeout;
     set_vmware_videomode if check_var('VIRSH_VMM_FAMILY', 'vmware');
     boot_into_snapshot if get_var("BOOT_TO_SNAPSHOT");


### PR DESCRIPTION
As documented on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6068, there are some machine configurations and/or specific hardware where disabling the grub timeout can lead to the system not booting once installation is completed. Following up on that, if `KEEP_GRUB_TIMEOUT` is set, tests can wait for `linux-login` during `installation/first_boot` and `installation/grub_test` instead of only waiting for `grub2`.

Also adds support in `select_gnome_user` to needles with tag `dm-nousers`, so autotest can type in the user name on the display manager login screen. This is required when testing SLES4SAP on the same hardware.

- Related ticket: https://progress.opensuse.org/issues/42026
- Needles: N/A
- Verification run: http://mango.suse.de/tests/680
