### PR TITLE
Fix superfluous non-existing method export

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -65,7 +65,6 @@ our @EXPORT = qw(
   load_consoletests
   load_create_hdd_tests
   load_extra_tests
-  load_toolkit_tests
   load_extra_tests_docker
   load_filesystem_tests
   load_inst_tests


### PR DESCRIPTION
See https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6232/files#r235895606