### PR TITLE
gnuhealth: Remove super_PWD

### DIFF
--- a/tests/gnuhealth/gnuhealth_setup.pm
+++ b/tests/gnuhealth/gnuhealth_setup.pm
@@ -24,23 +24,12 @@ sub run() {
     wait_screen_change { script_run 'su postgres', 0 };
     script_run 'sed -i -e \'s/\(\(local\|host\).*all.*all.*\)\(md5\|ident\)/\1trust/g\' /var/lib/pgsql/data/pg_hba.conf', 0;
     script_run 'psql -c "CREATE USER tryton WITH CREATEDB;"',                                                             0;
-    if (is_tumbleweed || is_leap('42.3+')) {
-        script_run 'createdb gnuhealth --encoding=\'UTF8\' --owner=tryton', 0;
-    }
+    script_run 'createdb gnuhealth --encoding=\'UTF8\' --owner=tryton', 0;
     script_run 'exit', 0;
     systemctl 'restart postgresql';
-    # generate the crypted password as described in /etc/tryton/trytond.conf
-    # but with no randomness for easier testing and preventing a stray '/' to
-    # destroy the sed call
-    script_run 'pw=$(python -c \'import getpass,crypt; print(crypt.crypt(getpass.getpass(), str(123456789)))\')', 0;
-    wait_still_screen(1);
-    type_string "susetesting\n";
-    assert_script_run 'sed -i -e "s/^.*super_pwd.*\$/super_pwd = ${pw}/g" /etc/tryton/trytond.conf';
-    if (is_tumbleweed || is_leap('42.3+')) {
-        assert_script_run 'echo susetesting > /tmp/pw';
-        assert_script_run 'sudo -u tryton env TRYTONPASSFILE=/tmp/pw trytond-admin -c /etc/tryton/trytond.conf --all -d gnuhealth --password', 600;
-    }
-    systemctl 'start trytond';
+    assert_script_run 'echo susetesting > /tmp/pw';
+    assert_script_run 'sudo -u tryton env TRYTONPASSFILE=/tmp/pw trytond-admin -c /etc/tryton/trytond.conf --all -d gnuhealth --password', 600;
+    systemctl 'start gnuhealth';
     # exit from root session
     send_key 'ctrl-d';
     # exit xterm


### PR DESCRIPTION
gnuhealth - super-PWD not required anymore, as db-creation from GNU Health Client is not supported anymore
Check on TW or Leap > 42.3 removed, as we have no older versions anymore
changed call for systemctl start gnuhealth

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
