### PR TITLE
Fix Python interpreter version

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -148,7 +148,7 @@ sub check_rollback_system {
     assert_script_run("zypper mr -d -m cd -m dvd");
     # Verify registration status matches current system version
     # system is un-registered during media based upgrade
-    assert_script_run('curl -s ' . data_url('console/check_registration_status.py') . ' | python3') unless get_var('MEDIA_UPGRADE');
+    assert_script_run('curl -s ' . data_url('console/check_registration_status.py') . ' | python') unless get_var('MEDIA_UPGRADE');
 }
 
 # Reset tty for x11 and root consoles


### PR DESCRIPTION
In test https://openqa.suse.de/tests/2274134#step/snapper_rollback/43 got `TypeError:  the JSON object must be str, not 'bytes'`

**Cause**: 
- The test failed in line [#32](https://docs.python.org/3/whatsnew/3.6.html#json)
- In early SLE releases (SLES 12 for example), Python versions are outdated (3.4 or even below).
- In Python [3.5 and below, including Py 2](https://docs.python.org/3/whatsnew/3.6.html#json) `json.loads` could only deserialize `str`, not `bytes`.
- In Python 2, there's no `bytes` type, the `output` variable would be in `str` type, therefore interpreted via Py2 worked fine.

As @mitiao said in [comment](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6209#discussion_r235874602), pipe the script to the default Py interpreter would be fine. This would also be forward-compatible when in SLE 15, Py3 would be default.


- Related ticket: https://progress.opensuse.org/issues/44279

