### PR TITLE
Fix lifecycle expiration for toolchain module

### DIFF
--- a/tests/console/zypper_lifecycle_toolchain.pm
+++ b/tests/console/zypper_lifecycle_toolchain.pm
@@ -29,7 +29,7 @@ sub run {
         gcc6      => 'Now',
         gcc7      => '2019-04-30',
         libada7   => '2019-04-30',
-        toolchain => '2024-10-30',
+        toolchain => '2024-10-31',
     );
 
     select_console 'root-console';


### PR DESCRIPTION
Fix poo#44210:  Expiration was set to new date 2024-10-31.

- Related ticket: https://progress.opensuse.org/issues/44210
- Needles: none
- Verification run: none
