### PR TITLE
sysstat: Parse different log filenames, normalize headers check, increase checked pid int.

### DIFF
--- a/tests/console/sysstat.pm
+++ b/tests/console/sysstat.pm
@@ -49,19 +49,20 @@ sub run {
     #header integrity checks:
     if (is_sle('>=12-SP3')) {
         validate_script_output "sar -r", sub { /kbmemfree   kbavail kbmemused  %memused kbbuffers  kbcached  kbcommit   %commit  kbactive   kbinact   kbdirty/ };
-        validate_script_output "pidstat",    sub { /UID       PID    %usr %system  %guest   %wait    %CPU   CPU  Command/ };
-        validate_script_output "iostat",     sub { /avg-cpu:  %user   %nice %system %iowait  %steal   %idle/ };
-        validate_script_output "mpstat",     sub { /CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle/ };
-        validate_script_output "sar -u",     sub { /CPU     %user     %nice   %system   %iowait    %steal     %idle/ };
-        validate_script_output "sar -n DEV", sub { /IFACE   rxpck\/s   txpck\/s    rxkB\/s    txkB\/s   rxcmp\/s   txcmp\/s  rxmcst\/s   %ifutil/ };
-        validate_script_output "sar -b",     sub { /tps      rtps      wtps   bread\/s   bwrtn\/s/ };
-        validate_script_output "sar -B",     sub { /pgpgin\/s pgpgout\/s   fault\/s  majflt\/s  pgfree\/s pgscank\/s pgscand\/s pgsteal\/s    %vmeff/ };
-        validate_script_output "sar -H",     sub { /kbhugfree kbhugused  %hugused/ };
-        validate_script_output "sar -S",     sub { /kbswpfree kbswpused  %swpused  kbswpcad   %swpcad/ };
+        validate_script_output "pidstat", sub { /UID       PID    %usr %system  %guest   %wait    %CPU   CPU  Command/ };
     } else {
         validate_script_output "sar -r",  sub { /kbmemfree kbmemused  %memused kbbuffers  kbcached  kbcommit   %commit  kbactive   kbinact   kbdirty/ };
         validate_script_output "pidstat", sub { /UID       PID    %usr %system  %guest    %CPU   CPU  Command/ };
     }
+
+    validate_script_output "iostat",     sub { /avg-cpu:  %user   %nice %system %iowait  %steal   %idle/ };
+    validate_script_output "mpstat",     sub { /CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle/ };
+    validate_script_output "sar -u",     sub { /CPU     %user     %nice   %system   %iowait    %steal     %idle/ };
+    validate_script_output "sar -n DEV", sub { /IFACE   rxpck\/s   txpck\/s    rxkB\/s    txkB\/s   rxcmp\/s   txcmp\/s  rxmcst\/s   %ifutil/ };
+    validate_script_output "sar -b",     sub { /tps      rtps      wtps   bread\/s   bwrtn\/s/ };
+    validate_script_output "sar -B",     sub { /pgpgin\/s pgpgout\/s   fault\/s  majflt\/s  pgfree\/s pgscank\/s pgscand\/s pgsteal\/s    %vmeff/ };
+    validate_script_output "sar -H",     sub { /kbhugfree kbhugused  %hugused/ };
+    validate_script_output "sar -S",     sub { /kbswpfree kbswpused  %swpused  kbswpcad   %swpcad/ };
 }
 
 1;

--- a/tests/console/sysstat.pm
+++ b/tests/console/sysstat.pm
@@ -12,25 +12,30 @@
 
 use base 'consoletest';
 use utils qw(zypper_call systemctl);
+use version_utils 'is_sle';
 use strict;
 use testapi;
 
 sub run {
-    select_console('root-console');
-    zypper_call('in sysstat');
-    script_run 'rm /var/log/sa/sa*';
+    select_console 'root-console';
+    zypper_call 'in sysstat';
+    script_run 'rm -rf /var/log/sa/sa*';
     systemctl 'start sysstat.service';
     systemctl 'stop sysstat.service';
     systemctl 'restart sysstat.service';
 
-    #compare todays date with the date on the file generated when starting the service/systemd unit:
-    validate_script_output "if [ `date +'%Y%m%d'` -eq `ls -1 /var/log/sa/ | cut -c 3-` ]; then echo date_matched; fi", sub { /date_matched/ };
+    #compare todays date with todays generated file.
+    if (is_sle('>=12-SP3')) {
+        assert_script_run "test -e /var/log/sa/sa`date +'%Y%m%d'`";
+    } else {
+        assert_script_run "test -e /var/log/sa/sa`date +'%d'`";
+    }
 
     #Populate /var/log/sa/`date +'%Y%m%d'`, that data will be used on the next tests
     assert_script_run '/usr/lib64/sa/sa1 5 5';
 
     #Set 24h clock(removes AM/PM extra column), extract a pid number, confirm its an integer
-    validate_script_output "LC_TIME='C' pidstat  |awk '{print \$3}' |head |tail -n 1", sub { m/[1-99]/ };
+    validate_script_output "LC_TIME='C' pidstat  |awk '{print \$3}' |head |tail -n 1", sub { m/[1-999]/ };
 
     #run 5 pidstat iterations, we confirm success counting the UID column spawns
     validate_script_output "pidstat 2 5 |grep  UID |wc -l", sub { /6/ };
@@ -42,17 +47,21 @@ sub run {
     validate_script_output "mpstat -P ALL 2 5 |grep all |wc -l", sub { /6/ };
 
     #header integrity checks:
-    validate_script_output "pidstat",    sub { /UID       PID    %usr %system  %guest   %wait    %CPU   CPU  Command/ };
-    validate_script_output "iostat",     sub { /avg-cpu:  %user   %nice %system %iowait  %steal   %idle/ };
-    validate_script_output "iostat",     sub { /Device             tps    kB_read\/s    kB_wrtn\/s    kB_read    kB_wrtn/ };
-    validate_script_output "sar -u",     sub { /CPU     %user     %nice   %system   %iowait    %steal     %idle/ };
-    validate_script_output "sar -n DEV", sub { /IFACE   rxpck\/s   txpck\/s    rxkB\/s    txkB\/s   rxcmp\/s   txcmp\/s  rxmcst\/s   %ifutil/ };
-    validate_script_output "sar -b",     sub { /tps      rtps      wtps   bread\/s   bwrtn\/s/ };
-    validate_script_output "sar -B",     sub { /pgpgin\/s pgpgout\/s   fault\/s  majflt\/s  pgfree\/s pgscank\/s pgscand\/s pgsteal\/s    %vmeff/ };
-    validate_script_output "sar -r", sub { /kbmemfree   kbavail kbmemused  %memused kbbuffers  kbcached  kbcommit   %commit  kbactive   kbinact   kbdirty/ };
-    validate_script_output "sar -H", sub { /kbhugfree kbhugused  %hugused/ };
-    validate_script_output "sar -S", sub { /kbswpfree kbswpused  %swpused  kbswpcad   %swpcad/ };
-
+    if (is_sle('>=12-SP3')) {
+        validate_script_output "sar -r", sub { /kbmemfree   kbavail kbmemused  %memused kbbuffers  kbcached  kbcommit   %commit  kbactive   kbinact   kbdirty/ };
+        validate_script_output "pidstat",    sub { /UID       PID    %usr %system  %guest   %wait    %CPU   CPU  Command/ };
+        validate_script_output "iostat",     sub { /avg-cpu:  %user   %nice %system %iowait  %steal   %idle/ };
+        validate_script_output "mpstat",     sub { /CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle/ };
+        validate_script_output "sar -u",     sub { /CPU     %user     %nice   %system   %iowait    %steal     %idle/ };
+        validate_script_output "sar -n DEV", sub { /IFACE   rxpck\/s   txpck\/s    rxkB\/s    txkB\/s   rxcmp\/s   txcmp\/s  rxmcst\/s   %ifutil/ };
+        validate_script_output "sar -b",     sub { /tps      rtps      wtps   bread\/s   bwrtn\/s/ };
+        validate_script_output "sar -B",     sub { /pgpgin\/s pgpgout\/s   fault\/s  majflt\/s  pgfree\/s pgscank\/s pgscand\/s pgsteal\/s    %vmeff/ };
+        validate_script_output "sar -H",     sub { /kbhugfree kbhugused  %hugused/ };
+        validate_script_output "sar -S",     sub { /kbswpfree kbswpused  %swpused  kbswpcad   %swpcad/ };
+    } else {
+        validate_script_output "sar -r",  sub { /kbmemfree kbmemused  %memused kbbuffers  kbcached  kbcommit   %commit  kbactive   kbinact   kbdirty/ };
+        validate_script_output "pidstat", sub { /UID       PID    %usr %system  %guest    %CPU   CPU  Command/ };
+    }
 }
 
 1;


### PR DESCRIPTION
- SLE12.4 generates the logs collection in a different fashion, this update covers it.
- Despite the tests try to match a pid lower then 99 (ordering from lower to high) in some cases there still is a big initial low pid number so now we check to 999.
- Some sar commands output header have different layouts based on the installed version. This fix takes that into account and covers the different header layouts.

- Related ticket: https://progress.opensuse.org/issues/44312
- Needles: None
- Verification run:
SLES 12-SP1: http://deathstar.suse.cz/tests/923
SLES 12-SP2: http://deathstar.suse.cz/tests/925
SLES 12-SP3: http://deathstar.suse.cz/tests/922
SLES 12-SP4: http://deathstar.suse.cz/tests/921
SLES 15: http://deathstar.suse.cz/tests/924

