### PR TITLE
Replace sle_version_at_least by is_sle

### DIFF
--- a/lib/installsummarystep.pm
+++ b/lib/installsummarystep.pm
@@ -2,7 +2,6 @@ package installsummarystep;
 use base "y2logsstep";
 use testapi;
 use strict;
-use version_utils 'sle_version_at_least';
 
 
 sub accept3rdparty {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -560,7 +560,7 @@ sub load_jeos_tests {
             loadtest "console/suseconnect_scc";
         }
     }
-    loadtest "jeos/glibc_locale" if sle_version_at_least('15') && get_var('JEOSINSTLANG');
+    loadtest "jeos/glibc_locale" if is_sle('15+') && get_var('JEOSINSTLANG');
 }
 
 sub installzdupstep_is_applicable {
@@ -654,7 +654,7 @@ sub lxdestep_is_applicable {
 
 sub is_smt {
     # Smt is replaced with rmt in SLE 15, see bsc#1061291
-    return ((get_var("PATTERNS", '') || get_var('HDD_1', '')) =~ /smt/) && !sle_version_at_least('15');
+    return ((get_var("PATTERNS", '') || get_var('HDD_1', '')) =~ /smt/) && is_sle('<15');
 }
 
 sub is_rmt {
@@ -795,7 +795,7 @@ sub load_inst_tests {
         if (check_var('BACKEND', 's390x')) {
             loadtest "installation/disk_activation";
         }
-        elsif (!sle_version_at_least('12-SP2')) {
+        elsif (is_sle('<12-SP2')) {
             loadtest "installation/skip_disk_activation";
         }
     }
@@ -824,7 +824,7 @@ sub load_inst_tests {
     if (is_sle) {
         loadtest 'installation/network_configuration' if get_var('NETWORK_CONFIGURATION');
         # SCC registration is not required in media based upgrade since SLE15
-        unless (sle_version_at_least('15') && get_var('MEDIA_UPGRADE')) {
+        unless (is_sle('15+') && get_var('MEDIA_UPGRADE')) {
             if (check_var('SCC_REGISTER', 'installation')) {
                 loadtest "installation/scc_registration";
             }
@@ -832,7 +832,7 @@ sub load_inst_tests {
                 loadtest "installation/skip_registration" unless check_var('SLE_PRODUCT', 'leanos');
             }
         }
-        if (is_sles4sap and !sle_version_at_least('15') and !is_upgrade()) {
+        if (is_sles4sap and is_sle('<15') and !is_upgrade()) {
             loadtest "installation/sles4sap_product_installation_mode";
         }
         if (get_var('MAINT_TEST_REPO')) {
@@ -850,7 +850,7 @@ sub load_inst_tests {
         if (is_using_system_role_first_flow) {
             load_system_role_tests;
         }
-        if (is_sles4sap() and sle_version_at_least('15') and check_var('SYSTEM_ROLE', 'default') and !is_upgrade()) {
+        if (is_sles4sap() and is_sle('15+') and check_var('SYSTEM_ROLE', 'default') and !is_upgrade()) {
             loadtest "installation/sles4sap_product_installation_mode";
         }
         # Kubic doesn't have a partitioning step
@@ -918,7 +918,7 @@ sub load_inst_tests {
     # need to be able to do installations on it. The release notes
     # functionality needs to be covered by other backends
     # Skip release notes test on sle 15 if have addons
-    if (is_sle && !check_var('BACKEND', 'generalhw') && !check_var('BACKEND', 'ipmi') && !(sle_version_at_least('15') && get_var('ADDONURL'))) {
+    if (is_sle && !check_var('BACKEND', 'generalhw') && !check_var('BACKEND', 'ipmi') && !(is_sle('15+') && get_var('ADDONURL'))) {
         loadtest "installation/releasenotes";
     }
 
@@ -945,7 +945,7 @@ sub load_inst_tests {
         if (is_sles4sap()) {
             if (
                 is_sles4sap_standard()    # Schedule module only for SLE15 with non-default role
-                || sle_version_at_least('15') && get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'))
+                || is_sle('15+') && get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'))
             {
                 loadtest "installation/user_settings";
             }    # sles4sap wizard installation doesn't have user_settings step
@@ -968,7 +968,7 @@ sub load_inst_tests {
         elsif (
             is_sle
             && (!check_var('DESKTOP', default_desktop)
-                && (!sle_version_at_least('15') || check_var('DESKTOP', 'minimalx'))))
+                && (is_sle('<15') || check_var('DESKTOP', 'minimalx'))))
         {
             # With SLE15 we change desktop using role and not by unselecting packages (Use SYSTEM_ROLE variable),
             # If we have minimalx, as there is no such a role, there we use old approach
@@ -1022,7 +1022,7 @@ sub load_console_server_tests {
     loadtest "console/dns_srv";
     loadtest "console/postgresql_server" unless (is_leap('<15.0'));
     # TODO test on openSUSE https://progress.opensuse.org/issues/31972
-    if (is_sle && sle_version_at_least('12-SP1')) {    # shibboleth-sp not available on SLES 12 GA
+    if (is_sle('12-SP1+')) {    # shibboleth-sp not available on SLES 12 GA
         loadtest "console/shibboleth";
     }
     if (!is_staging && (is_opensuse || get_var('ADDONS', '') =~ /wsm/ || get_var('SCC_ADDONS', '') =~ /wsm/)) {
@@ -1109,7 +1109,7 @@ sub load_consoletests {
     }
     # salt in SLE is only available for SLE12 ASMM or SLES15 and variants of
     # SLES but not SLED
-    if (is_opensuse || !is_staging && (check_var_array('SCC_ADDONS', 'asmm') || sle_version_at_least('15') && !is_desktop)) {
+    if (is_opensuse || !is_staging && (check_var_array('SCC_ADDONS', 'asmm') || is_sle('15+') && !is_desktop)) {
         loadtest "console/salt";
     }
     if (check_var('ARCH', 'x86_64')
@@ -1125,7 +1125,7 @@ sub load_consoletests {
     if (!get_var("LIVETEST")) {
         loadtest "console/yast2_bootloader";
     }
-    loadtest "console/vim" if is_opensuse || !sle_version_at_least('15') || !get_var('PATTERNS') || check_var_array('PATTERNS', 'enhanced_base');
+    loadtest "console/vim" if is_opensuse || is_sle('<15') || !get_var('PATTERNS') || check_var_array('PATTERNS', 'enhanced_base');
 # textmode install comes without firewall by default atm on openSUSE. For virtualizatoin server xen and kvm is disabled by default: https://fate.suse.com/324207
     if ((is_sle || !check_var("DESKTOP", "textmode")) && !is_staging() && !is_krypton_argon && !is_virtualization_server) {
         loadtest "console/firewall_enabled";
@@ -1160,9 +1160,9 @@ sub load_consoletests {
     if (check_var("DESKTOP", "xfce")) {
         loadtest "console/xfce_gnome_deps";
     }
-    if (!is_staging() && is_sle && sle_version_at_least('12-SP2')) {
+    if (!is_staging() && is_sle('12-SP2+')) {
         loadtest "console/zypper_lifecycle";
-        if (check_var_array('SCC_ADDONS', 'tcm') && !sle_version_at_least('15')) {
+        if (check_var_array('SCC_ADDONS', 'tcm') && is_sle('<15')) {
             loadtest "console/zypper_lifecycle_toolchain";
         }
     }
@@ -1721,7 +1721,7 @@ sub load_x11_installation {
     load_reboot_tests();
     loadtest "x11/x11_setup";
     # temporary adding test modules which applies hacks for missing parts in sle15
-    loadtest "console/sle15_workarounds" if is_sle and sle_version_at_least('15');
+    loadtest "console/sle15_workarounds" if is_sle('15+');
     loadtest "console/hostname"              unless is_bridged_networking;
     loadtest "console/force_scheduled_tasks" unless is_jeos;
     loadtest "shutdown/grub_set_bootargs";
@@ -1800,7 +1800,7 @@ sub load_x11_other {
     if (get_var("DESKTOP") =~ /kde|gnome/) {
         loadtest "x11/tracker/prep_tracker";
         # tracker-gui/tracker-needle was dropped since version 1.99.0
-        if (!sle_version_at_least('15')) {
+        if (is_sle('<15')) {
             loadtest "x11/tracker/tracker_starts";
             loadtest "x11/tracker/tracker_searchall";
             loadtest "x11/tracker/tracker_pref_starts";

--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -24,7 +24,7 @@ use testapi;
 use utils;
 use registration;
 use qam qw/remove_test_repositories/;
-use version_utils qw(sle_version_at_least is_sle is_sles4sap);
+use version_utils qw(is_sle is_sles4sap);
 
 our @EXPORT = qw(
   setup_sle
@@ -77,7 +77,7 @@ sub register_system_in_textmode {
 
     # register system and addons in textmode for all archs
     set_var("VIDEOMODE", 'text');
-    if (sle_version_at_least('12-SP2', version_variable => 'HDDVERSION')) {
+    if (is_sle('12-SP2+', get_var('HDDVERSION'))) {
         set_var('HDD_SP2ORLATER', 1);
     }
     yast_scc_registration;

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -22,7 +22,7 @@ use strict;
 
 use testapi;
 use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key);
-use version_utils qw(is_sle is_caasp sle_version_at_least is_sle12_hdd_in_upgrade);
+use version_utils qw(is_sle is_caasp is_sle12_hdd_in_upgrade);
 use constant ADDONS_COUNT => 50;
 
 our @EXPORT = qw(
@@ -607,7 +607,7 @@ sub fill_in_reg_server {
 sub scc_deregistration {
     my (%args) = @_;
     $args{version_variable} //= 'VERSION';
-    if (sle_version_at_least('12-SP1', version_variable => $args{version_variable})) {
+    if (is_sle('12-SP1+', get_var($args{version_variable}))) {
         assert_script_run('SUSEConnect -d --cleanup', 200);
         my $output = script_output 'SUSEConnect -s';
         die "System is still registered" unless $output =~ /Not Registered/;

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -40,7 +40,6 @@ use constant {
           is_rt
           is_staging
           is_storage_ng
-          sle_version_at_least
           is_using_system_role
           is_using_system_role_first_flow
           )
@@ -259,52 +258,7 @@ sub is_upgrade {
 }
 
 sub is_sle12_hdd_in_upgrade {
-    return is_upgrade && !sle_version_at_least('15', version_variable => 'HDDVERSION');
-}
-
-# =====================================
-# Deprecated, please use is_sle instead
-# =====================================
-sub sle_version_at_least {
-    my ($version, %args) = @_;
-    my $version_variable = $args{version_variable} // 'VERSION';
-
-    if ($version eq '12') {
-        return !(
-            check_var($version_variable, '11-SP1')
-            or check_var($version_variable, '11-SP2')
-            or check_var($version_variable, '11-SP3')
-            or check_var($version_variable, '11-SP4'));
-    }
-
-    if ($version eq '12-SP1') {
-        return sle_version_at_least('12', version_variable => $version_variable) && !check_var($version_variable, '12');
-    }
-
-    if ($version eq '12-SP2') {
-        return sle_version_at_least('12-SP1', version_variable => $version_variable)
-          && !check_var($version_variable, '12-SP1');
-    }
-
-    if ($version eq '12-SP3') {
-        return sle_version_at_least('12-SP2', version_variable => $version_variable)
-          && !check_var($version_variable, '12-SP2');
-    }
-
-    if ($version eq '12-SP4') {
-        return sle_version_at_least('12-SP3', version_variable => $version_variable)
-          && !check_var($version_variable, '12-SP3');
-    }
-
-    if ($version eq '15') {
-        return sle_version_at_least('12-SP4', version_variable => $version_variable)
-          && !check_var($version_variable, '12-SP4');
-    }
-    if ($version eq '15-SP1') {
-        return sle_version_at_least('15', version_variable => $version_variable)
-          && !check_var($version_variable, '15');
-    }
-    die "unsupported SLE $version_variable $version in check";
+    return is_upgrade && is_sle('<15', get_var('HDDVERSION'));
 }
 
 sub is_desktop_installed {
@@ -370,7 +324,7 @@ sub install_to_other_at_least {
     set_var("REAL_INSTALLED_VERSION", $real_installed_version);
     bmwqemu::save_vars();
 
-    return sle_version_at_least($version, version_variable => "REAL_INSTALLED_VERSION");
+    return is_sle(">=$version", $real_installed_version);
 }
 
 sub is_using_system_role {

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -8,7 +8,7 @@ use testapi;
 use LWP::Simple;
 use Config::Tiny;
 use utils;
-use version_utils qw(is_sle is_tumbleweed sle_version_at_least);
+use version_utils qw(is_sle is_tumbleweed);
 use POSIX 'strftime';
 
 sub post_fail_hook {
@@ -33,11 +33,11 @@ sub switch_wm {
     assert_and_click "user-logout-sector";
     assert_and_click "logout-system";
     assert_screen "logout-dialogue";
-    send_key 'tab' if sle_version_at_least('15');
+    send_key 'tab' if is_sle('15+');
     send_key "ret";
     assert_screen "displaymanager";
     # The keyboard focus was losing in gdm of SLE15 bgo#657996
-    mouse_set(520, 350) if sle_version_at_least('15');
+    mouse_set(520, 350) if is_sle('15+');
     send_key "ret";
     assert_screen "originUser-login-dm";
     type_password;
@@ -59,7 +59,7 @@ sub prepare_sle_classic {
     # Log out and switch back to default session
     $self->switch_wm;
     assert_and_click "displaymanager-settings";
-    if (sle_version_at_least('15')) {
+    if (is_sle('15+')) {
         assert_and_click 'dm-gnome-shell';
         send_key 'ret';
         assert_screen 'desktop-gnome-shell', 120;
@@ -225,7 +225,7 @@ sub check_new_mail_evolution {
     assert_screen "evolution_mail-online", 240;
     assert_and_click "evolution-send-receive";
     if (check_screen "evolution_mail-auth", 30) {
-        if (sle_version_at_least('12-SP2')) {
+        if (is_sle('12-SP2+')) {
             send_key "alt-p";
         }
         type_password $mail_passwd;
@@ -282,7 +282,7 @@ sub send_meeting_request {
     wait_still_screen;
     type_string "$mail_box";
     send_key "alt-s";
-    if (sle_version_at_least('12-SP2')) {
+    if (is_sle('12-SP2+')) {
         send_key "alt-s";    #only need in sp2
     }
     type_string "$mail_subject this is a evolution test meeting";
@@ -293,7 +293,7 @@ sub send_meeting_request {
     assert_screen "evolution_mail-sendinvite_meeting", 60;
     send_key "ret";
     if (check_screen "evolution_mail-auth", 30) {
-        if (sle_version_at_least('12-SP2')) {
+        if (is_sle('12-SP2+')) {
             send_key "alt-a";    #disable keyring option, only need in SP2 or later
             send_key "alt-p";
         }
@@ -328,7 +328,7 @@ sub start_evolution {
     my ($self, $mail_box) = @_;
 
     $self->{next} = "alt-o";
-    if (sle_version_at_least('12-SP2')) {
+    if (is_sle('12-SP2+')) {
         $self->{next} = "alt-n";
     }
     mouse_hide(1);
@@ -372,7 +372,7 @@ sub evolution_add_self_signed_ca {
     else {
         send_key $self->{next};
     }
-    if (sle_version_at_least('12-SP2')) {
+    if (is_sle('12-SP2+')) {
         send_key "ret";    #only need in SP2 or later
     }
 }
@@ -436,7 +436,7 @@ sub setup_mail_account {
     save_screenshot;
     assert_screen "evolution_wizard-receiving-opts";
     send_key $self->{next};
-    if (sle_version_at_least('12-SP2')) {
+    if (is_sle('12-SP2+')) {
         send_key "ret";    #only need in SP2 or later
     }
 
@@ -486,14 +486,14 @@ sub setup_mail_account {
     send_key "ret";
     assert_screen "evolution_wizard-account-summary";
     send_key $self->{next};
-    if (sle_version_at_least('12-SP2')) {
+    if (is_sle('12-SP2+')) {
         send_key "alt-n";    #only in sp2
         send_key "ret";
     }
     assert_screen "evolution_wizard-done";
     send_key "alt-a";
     if (check_screen "evolution_mail-auth", 30) {
-        if (sle_version_at_least('12-SP2')) {
+        if (is_sle('12-SP2+')) {
             send_key "alt-a";    #disable keyring option, only in SP2
             send_key "alt-p";
         }
@@ -504,7 +504,7 @@ sub setup_mail_account {
         send_key "super-up";
     }
     if (check_screen "evolution_mail-auth", 30) {
-        if (sle_version_at_least('12-SP2')) {
+        if (is_sle('12-SP2+')) {
             send_key "alt-p";
         }
         type_password $mail_passwd;
@@ -832,13 +832,13 @@ sub evolution_send_message {
     assert_and_click "evolution_mail-message-body";
     type_string "Test email send and receive.";
     send_key "ctrl-ret";
-    if (sle_version_at_least('12-SP2')) {
+    if (is_sle('12-SP2+')) {
         if (check_screen "evolution_mail_send_mail_dialog", 30) {
             send_key "ret";
         }
     }
     if (check_screen "evolution_mail-auth", 30) {
-        if (sle_version_at_least('12-SP2')) {
+        if (is_sle('12-SP2+')) {
             send_key "alt-a";    #disable keyring option, only in SP2
             send_key "alt-p";
         }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -17,7 +17,7 @@ use registration;
 use utils;
 use mmapi 'get_parents';
 use version_utils
-  qw(is_hyperv is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem sle_version_at_least is_desktop_installed is_jeos is_sle is_staging is_upgrade);
+  qw(is_hyperv is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem is_desktop_installed is_jeos is_sle is_staging is_upgrade);
 use File::Find;
 use File::Basename;
 use LWP::Simple 'head';
@@ -59,19 +59,19 @@ sub cleanup_needles {
         unregister_needle_tags("ENV-VERSION-11-SP4");
     }
 
-    my $tounregister = sle_version_at_least('12') ? '0' : '1';
+    my $tounregister = is_sle('12+') ? '0' : '1';
     unregister_needle_tags("ENV-12ORLATER-$tounregister");
 
-    $tounregister = sle_version_at_least('12-SP2') ? '0' : '1';
+    $tounregister = is_sle('12-SP2+') ? '0' : '1';
     unregister_needle_tags("ENV-SP2ORLATER-$tounregister");
 
-    $tounregister = sle_version_at_least('12-SP3') ? '0' : '1';
+    $tounregister = is_sle('12-SP3+') ? '0' : '1';
     unregister_needle_tags("ENV-SP3ORLATER-$tounregister");
 
-    $tounregister = sle_version_at_least('15') ? '0' : '1';
+    $tounregister = is_sle('15+') ? '0' : '1';
     unregister_needle_tags("ENV-15ORLATER-$tounregister");
 
-    $tounregister = sle_version_at_least('15-SP1') ? '0' : '1';
+    $tounregister = is_sle('15-SP1+') ? '0' : '1';
     unregister_needle_tags("ENV-15SP1ORLATER-$tounregister");
 
     if (!is_server) {
@@ -119,7 +119,7 @@ set_var('NOAUTOLOGIN', 1);
 set_var('HASLICENSE',  1);
 set_var('SLE_PRODUCT', get_var('SLE_PRODUCT', 'sles'));
 # Always register against SCC if SLE 15
-if (sle_version_at_least('15')) {
+if (is_sle('15+')) {
     set_var('SCC_REGISTER', get_var('SCC_REGISTER', 'installation'));
     # depending on registration only limited system roles are available
     set_var('SYSTEM_ROLE', get_var('SYSTEM_ROLE', is_desktop_module_available() ? 'default' : 'minimal'));
@@ -132,7 +132,7 @@ if (sle_version_at_least('15')) {
 }
 diag('default desktop: ' . default_desktop);
 set_var('DESKTOP', get_var('DESKTOP', default_desktop));
-if (sle_version_at_least('15')) {
+if (is_sle('15+')) {
     if (check_var('ARCH', 's390x') and get_var('DESKTOP', '') =~ /gnome|minimalx/) {
         diag 'BUG: bsc#1058071 - No VNC server available in SUT, disabling X11 tests. Re-enable after bug is fixed';
         set_var('DESKTOP', 'textmode');
@@ -148,7 +148,7 @@ set_var('REMOTE_CONNECTION', 'vnc') if get_var('BACKEND', '') =~ /s390x|svirt|ip
 
 # Set serial console for Xen PV
 if (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')) {
-    if (sle_version_at_least('12-SP2')) {
+    if (is_sle('12-SP2+')) {
         set_var('SERIALDEV', 'hvc0');
     }
     else {
@@ -156,11 +156,11 @@ if (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')
     }
 }
 
-if (sle_version_at_least('12-SP2')) {
+if (is_sle('12-SP2+')) {
     set_var('SP2ORLATER', 1);
 }
 
-if (sle_version_at_least('12-SP3')) {
+if (is_sle('12-SP3+')) {
     set_var('SP3ORLATER', 1);
 }
 
@@ -193,7 +193,7 @@ if (check_var('DESKTOP', 'minimalx')) {
 # This setting is used to set veriables properly when SDK or Development-Tools are required.
 # For SLE 15 we add Development-Tools during using SCC, and using ftp url in case of other versions.
 if (get_var('DEV_IMAGE')) {
-    if (sle_version_at_least('15')) {
+    if (is_sle('15+')) {
         # On SLE 15 activate Development-Tools module with SCC
         my $addons = (get_var('SCC_ADDONS') ? get_var('SCC_ADDONS') . ',' : '') . 'sdk';
         set_var('SCC_ADDONS', $addons);
@@ -255,7 +255,7 @@ if (check_var('SCC_REGISTER', 'installation') && get_var('ALL_ADDONS') && !get_v
 
 # This is workaround setting which will be removed once SCC add repos and allows adding modules
 # TODO: place it somewhere else since test module suseconnect_scc will use it
-if (sle_version_at_least('15') && !check_var('SCC_REGISTER', 'installation')) {
+if (is_sle('15+') && !check_var('SCC_REGISTER', 'installation')) {
     my @modules;
     if (get_var('ALL_MODULES')) {
         # By default add all modules
@@ -362,7 +362,7 @@ if (is_updates_test_repo && !get_var('MAINT_TEST_REPO')) {
 }
 
 if (get_var('ENABLE_ALL_SCC_MODULES') && !get_var('SCC_ADDONS')) {
-    if (sle_version_at_least('15')) {
+    if (is_sle('15+')) {
         # Add only modules which are not pre-selected
         # 'pcm' should be treated special as it is only applicable to cloud
         # installations

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -21,7 +21,7 @@ use base 'y2logsstep';
 use testapi;
 use utils;
 use power_action_utils 'prepare_system_shutdown';
-use version_utils qw(is_caasp is_released);
+use version_utils qw(is_sle is_caasp is_released);
 
 my $confirmed_licenses = 0;
 my $stage              = 'stage1';
@@ -177,7 +177,7 @@ sub run {
         }
         elsif (match_has_tag('warning-pop-up')) {
             # Softfail only on sle, as timeout is there on CaaSP
-            if (check_var('DISTRI', 'sle') && check_screen('warning-partition-reduced', 0)) {
+            if (is_sle && check_screen('warning-partition-reduced', 0)) {
                 # See poo#19978, no timeout on partition warning, hence need to click OK button to soft-fail
                 record_info('bsc#1045470',
                     "There is no timeout on sle for reduced partition screen by default.\n"

--- a/tests/console/docker_runc.pm
+++ b/tests/console/docker_runc.pm
@@ -18,7 +18,7 @@
 use base "consoletest";
 use testapi;
 use utils;
-use version_utils qw(is_caasp is_sle sle_version_at_least);
+use version_utils qw(is_caasp is_sle);
 use registration;
 use strict;
 

--- a/tests/console/snapper_jeos_cli.pm
+++ b/tests/console/snapper_jeos_cli.pm
@@ -15,7 +15,7 @@ use testapi;
 use utils;
 use strict;
 use power_action_utils 'power_action';
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
@@ -28,7 +28,7 @@ sub run {
     my $openqalatest = 'openqalatest';
     assert_script_run("snapper create -d $openqalatest");
     assert_script_run("snapper list");
-    my $snap_id             = sle_version_at_least('15') ? "'{ print \$1 }'" : "'{ print \$3 }'";
+    my $snap_id             = is_sle('15+') ? "'{ print \$1 }'" : "'{ print \$3 }'";
     my $openqainit_snapshot = script_output("snapper list | grep -w $openqainit | awk $snap_id | tr -d '\\n'");
     my $latest_snapshot     = script_output("snapper list | grep -w $openqalatest | awk $snap_id | tr -d '\\n'");
     my $init_snapshot       = script_output("snapper list | grep 'single.*$openqainit' | awk $snap_id | tr -d '\\n'");

--- a/tests/fips/openssl/openssl_fips_cipher.pm
+++ b/tests/fips/openssl/openssl_fips_cipher.pm
@@ -15,7 +15,7 @@ use base "consoletest";
 use testapi;
 use strict;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
     select_console 'root-console';
@@ -40,7 +40,7 @@ sub run {
 
     # With FIPS non-approved Cipher algorithms, openssl shall report failure
     my @invalid_cipher = ("bf", "cast5", "rc4", "seed", "des", "desx");
-    if (sle_version_at_least('12-SP2')) {
+    if (is_sle('12-SP2+')) {
         push @invalid_cipher, "des-ede";
     }
     for my $cipher (@invalid_cipher) {

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -15,7 +15,7 @@ use strict;
 use base "y2logsstep";
 use testapi;
 use utils qw(addon_license handle_untrusted_gpg_key);
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 use qam 'advance_installer_window';
 use registration qw(%SLE15_DEFAULT_MODULES rename_scc_addons @SLE15_ADDONS_WITHOUT_LICENSE);
 use LWP::Simple 'head';
@@ -45,7 +45,7 @@ sub handle_all_packages_medium {
     push @addons, 'legacy' if get_var('UPGRADE') && !grep(/^legacy$/, @addons);
 
     # For SLES12SPx and SLES11SPx to SLES15 migration, need add the demand module at least for media migration manually
-    if (get_var('MEDIA_UPGRADE') && !sle_version_at_least('15', version_variable => 'HDDVERSION') && !check_var('SLE_PRODUCT', 'sled')) {
+    if (get_var('MEDIA_UPGRADE') && is_sle('<15', get_var('HDDVERSION')) && !check_var('SLE_PRODUCT', 'sled')) {
         my @demand_addon = qw(desktop legacy serverapp script);
         for my $a (@demand_addon) {
             push @addons, $a if !grep(/^$a$/, @addons);

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils qw(is_jeos is_caasp is_installcheck is_rescuesystem sle_version_at_least);
+use version_utils qw(is_jeos is_caasp is_installcheck is_rescuesystem is_sle);
 use registration 'registration_bootloader_cmdline';
 use File::Basename;
 
@@ -245,7 +245,7 @@ sub run {
         }
         type_string "echo -en '\\033[K' > \$pty\n";                         # end of line
         type_string "echo -en ' $cmdline' > \$pty\n";
-        if (sle_version_at_least('12-SP2') or is_caasp) {
+        if (is_sle('12-SP2+') or is_caasp) {
             type_string "echo -en ' xen-fbfront.video=32,1024,768 xen-kbdfront.ptr_size=1024,768 ' > \$pty\n";    # set kernel framebuffer
             type_string "echo -en ' console=hvc console=tty ' > \$pty\n";                                         # set consoles
         }

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -17,7 +17,7 @@ use strict;
 use base "y2logsstep";
 use testapi;
 use utils qw(handle_login handle_emergency);
-use version_utils qw(sle_version_at_least is_sle is_leap is_desktop_installed is_upgrade is_sles4sap);
+use version_utils qw(is_sle is_leap is_desktop_installed is_upgrade is_sles4sap);
 use base 'opensusebasetest';
 
 sub run {
@@ -32,7 +32,7 @@ sub run {
     }
     my $boot_timeout = (get_var('SES5_DEPLOY') || check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('BACKEND', 'ipmi')) ? 450 : 200;
     # SLE >= 15 s390x does not offer auto-started VNC server in SUT, only login prompt as in textmode
-    return if check_var('ARCH', 's390x') && sle_version_at_least('15');
+    return if check_var('ARCH', 's390x') && is_sle('15+');
     if (check_var('WORKER_CLASS', 'hornet')) {
         # hornet does not show the console output
         diag "waiting $boot_timeout seconds to let hornet boot and finish initial script";

--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -15,14 +15,14 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
-use version_utils qw(is_leap is_storage_ng is_sle sle_version_at_least is_tumbleweed);
+use version_utils qw(is_leap is_storage_ng is_sle is_tumbleweed);
 use partition_setup qw(%partition_roles is_storage_ng_newui);
 
 sub run {
     assert_screen 'partitioning-edit-proposal-button', 40;
 
     if (get_var("DUALBOOT")) {
-        if (is_sle && sle_version_at_least('15')) {
+        if (is_sle('15+')) {
             record_soft_failure('bsc#1089723 Make sure keep the existing windows partition');
             assert_screen "delete-partition";
             send_key "alt-g";

--- a/tests/installation/partitioning_lvm.pm
+++ b/tests/installation/partitioning_lvm.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 use parent qw(installation_user_settings y2logsstep);
 use testapi;
-use version_utils qw(sle_version_at_least is_storage_ng);
+use version_utils 'is_storage_ng';
 use partition_setup 'enable_encryption_guided_setup';
 
 sub save_logs_and_resume {

--- a/tests/installation/sles4sap_product_installation_mode.pm
+++ b/tests/installation/sles4sap_product_installation_mode.pm
@@ -13,10 +13,10 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
-    if (sle_version_at_least('15')) {
+    if (is_sle('15+')) {
         my $expected_needle = check_var('SLES4SAP_MODE', 'sles4sap_wizard') ? "sles4sap-wizard-option-selected" : "sles4sap-wizard-option-not-selected";
         assert_screen [qw(sles4sap-wizard-option-selected sles4sap-wizard-option-not-selected)];
         send_key "alt-a" unless (match_has_tag($expected_needle));

--- a/tests/installation/start_install.pm
+++ b/tests/installation/start_install.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
-use version_utils qw(sle_version_at_least is_upgrade);
+use version_utils 'is_upgrade';
 
 sub check_bsc982138 {
     if (check_screen('installation-details-view-remaining-time-gt2h', 5)) {

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -33,7 +33,7 @@ sub run {
     # Add tag for untrusted-ca-cert with SMT
     push @welcome_tags, 'untrusted-ca-cert' if get_var('SMT_URL');
     # Add tag for sle15 upgrade mode, where product list should NOT be shown
-    push @welcome_tags, 'inst-welcome-no-product-list' if sle_version_at_least('15') and get_var('UPGRADE');
+    push @welcome_tags, 'inst-welcome-no-product-list' if is_sle('15+') and get_var('UPGRADE');
     # Add tag to check for https://progress.opensuse.org/issues/30823 "test is
     # stuck in linuxrc asking if dhcp should be used"
     push @welcome_tags, 'linuxrc-dhcp-question';

--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -13,7 +13,7 @@
 use base "opensusebasetest";
 use strict;
 use testapi;
-use version_utils qw(is_sle sle_version_at_least);
+use version_utils 'is_sle';
 use utils qw(assert_screen_with_soft_timeout ensure_serialdev_permissions);
 
 sub post_fail_hook {
@@ -26,7 +26,7 @@ sub post_fail_hook {
 sub verify_user_info {
     my (%args) = @_;
     my $user = $args{user_is_root};
-    my $lang = sle_version_at_least('15') ? 'en_US' : get_var('JEOSINSTLANG', 'en_US');
+    my $lang = is_sle('15+') ? 'en_US' : get_var('JEOSINSTLANG', 'en_US');
 
     my %tz_data = ('en_US' => 'UTC', 'de_DE' => 'Europe/Berlin');
     assert_script_run("timedatectl | awk '\$1 ~ /Time/ { print \$3 }' | grep ^" . $tz_data{$lang} . "\$");
@@ -44,7 +44,7 @@ sub verify_user_info {
 }
 
 sub run {
-    my $lang = sle_version_at_least('15') ? 'en_US' : get_var('JEOSINSTLANG', 'en_US');
+    my $lang = is_sle('15+') ? 'en_US' : get_var('JEOSINSTLANG', 'en_US');
 
     my %keylayout_key = ('en_US' => 'e', 'de_DE' => 'd');
     # For 'en_US' pick 'en_US', for 'de_DE' select 'de_DE'

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -22,7 +22,7 @@ use main_common 'get_ltp_tag';
 use power_action_utils 'power_action';
 use serial_terminal 'add_serial_console';
 use upload_system_log;
-use version_utils qw(is_sle sle_version_at_least is_opensuse is_jeos);
+use version_utils qw(is_sle is_opensuse is_jeos);
 
 sub add_repos {
     my $qa_head_repo = get_required_var('QA_HEAD_REPO');
@@ -35,7 +35,7 @@ sub add_we_repo_if_available {
 
     my $ar_url;
     my $we_repo = get_var('REPO_SLE_WE_POOL');
-    if ($we_repo && check_var('DISTRI', 'sle') && sle_version_at_least('15')) {
+    if ($we_repo && is_sle('15+')) {
         $ar_url = "http://openqa.suse.de/assets/repo/$we_repo";
     }
     # productQA test with enabled we as iso_2

--- a/tests/shutdown/cleanup_before_shutdown.pm
+++ b/tests/shutdown/cleanup_before_shutdown.pm
@@ -31,7 +31,7 @@ sub run {
     if (get_var('DROP_PERSISTENT_NET_RULES')) {
         type_string "rm -f /etc/udev/rules.d/70-persistent-net.rules\n";
     }
-    if (!sle_version_at_least('12-SP2') && !check_var('VIRTIO_CONSOLE', 0)) {
+    if (is_sle('<12-SP2') && !check_var('VIRTIO_CONSOLE', 0)) {
         add_serial_console('hvc0');
     }
     # Proceed with dhcp cleanup on qemu backend only.

--- a/tests/slenkins/slenkins_node.pm
+++ b/tests/slenkins/slenkins_node.pm
@@ -22,7 +22,6 @@ use testapi;
 use lockapi;
 use mmapi;
 use mm_network;
-use version_utils 'sle_version_at_least';
 use opensusebasetest 'firewall';
 
 sub run {

--- a/tests/sles4sap/desktop_icons.pm
+++ b/tests/sles4sap/desktop_icons.pm
@@ -12,7 +12,7 @@
 
 use base "sles4sap";
 use testapi;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 use strict;
 
 sub run {
@@ -30,7 +30,7 @@ sub run {
         # Verify that there is at least a generic desktop and
         # fail unless we're in SLE-15 where there are no icons
         assert_screen 'generic-desktop';
-        record_soft_failure 'bsc#1072646' unless sle_version_at_least('15');
+        record_soft_failure 'bsc#1072646' unless is_sle('15+');
     }
 }
 

--- a/tests/virtualization/syscontainer_image_test.pm
+++ b/tests/virtualization/syscontainer_image_test.pm
@@ -13,11 +13,12 @@
 use base "basetest";
 use testapi;
 use strict;
+use version_utils 'is_sle';
 
 sub run() {
     select_console 'root-console';
 
-    return if check_var('DISTRI', 'sle') && !(get_var('SCC_REGCODE') || get_var('HDD_SCC_REGISTERED'));
+    return if is_sle && !(get_var('SCC_REGCODE') || get_var('HDD_SCC_REGISTERED'));
 
     # Check the repositories on the host first
     assert_script_run("zypper lr");
@@ -28,7 +29,7 @@ sub run() {
     # Create XML file
     assert_script_run('curl -f ' . autoinst_url . '/data/virtualization/syscontainer.xml -o /tmp/test.xml');
 
-    if (check_var('DISTRI', 'sle')) {
+    if (is_sle) {
         my $scccredentials_mount
           = '<filesystem type=\"mount\" accessmode=\"passthrough\">'
           . '  <source dir=\"/etc/zypp/credentials.d/SCCcredentials\"/>'

--- a/tests/x11/evolution/evolution_smoke.pm
+++ b/tests/x11/evolution/evolution_smoke.pm
@@ -14,7 +14,7 @@ use strict;
 use base "x11test";
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub evolution_wizard {
     my ($self, $mail_box) = @_;
@@ -22,7 +22,7 @@ sub evolution_wizard {
     # Follow the wizard to setup mail account
     $self->start_evolution($mail_box);
     assert_screen "evolution_wizard-account-summary", 60;
-    if (sle_version_at_least('12-SP2')) {
+    if (is_sle('12-SP2+')) {
         assert_and_click "evolution-option-next";
     }
     else {

--- a/tests/x11/firefox/firefox_emaillink.pm
+++ b/tests/x11/firefox/firefox_emaillink.pm
@@ -15,13 +15,13 @@ use strict;
 use base "x11test";
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
     my $next_key = "alt-o";
 
-    if (sle_version_at_least('12-SP2')) {
+    if (is_sle('12-SP2+')) {
         $next_key = "alt-n";
     }
 
@@ -31,7 +31,7 @@ sub run {
     send_key "alt-f";
     wait_still_screen 3;
     send_key "e";
-    unless (sle_version_at_least('15')) {
+    unless (is_sle('15+')) {
         assert_screen(['firefox-email_link-welcome', 'firefox-email-mutt'], 90);
         if (match_has_tag('firefox-email-mutt')) {
             # if evolution is not installed, e.g. when WE is not pressent, mutt in terminal is used poo#42500
@@ -57,7 +57,7 @@ sub run {
         type_string "imap.suse.com";
         send_key "alt-n";    #Username
         type_string "test";
-        if (sle_version_at_least('12-SP2')) {
+        if (is_sle('12-SP2+')) {
             assert_and_click "evolution-option-next";
             wait_still_screen 3;
             assert_and_click "evolution-option-next";
@@ -76,7 +76,7 @@ sub run {
         };
 
         wait_still_screen 3;
-        if (sle_version_at_least('12-SP2')) {
+        if (is_sle('12-SP2+')) {
             assert_and_click "evolution-option-next";
         }
         else {

--- a/tests/x11/firefox/firefox_extcontent.pm
+++ b/tests/x11/firefox/firefox_extcontent.pm
@@ -14,7 +14,7 @@
 use strict;
 use base "x11test";
 use testapi;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
@@ -34,7 +34,7 @@ sub run {
     sleep 1;
     send_key "ret";
 
-    assert_screen((sle_version_at_least('15')) ? 'firefox-extcontent-nautils' : 'firefox-extcontent-archive_manager');
+    assert_screen(is_sle('15+') ? 'firefox-extcontent-nautils' : 'firefox-extcontent-archive_manager');
 
     send_key "ctrl-q";
 

--- a/tests/x11/firefox/firefox_plugins.pm
+++ b/tests/x11/firefox/firefox_plugins.pm
@@ -16,7 +16,6 @@
 use strict;
 use base "x11test";
 use testapi;
-use version_utils 'sle_version_at_least';
 
 sub run {
     my ($self) = @_;

--- a/tests/x11/gnomecase/application_starts_on_login.pm
+++ b/tests/x11/gnomecase/application_starts_on_login.pm
@@ -14,11 +14,11 @@ use base "x11test";
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_leap sle_version_at_least);
+use version_utils qw(is_leap is_sle);
 
 sub tweak_startupapp_menu {
     my ($self) = @_;
-    unless (sle_version_at_least('15')) {
+    unless (is_sle('15+')) {
         $self->start_gnome_settings;
         type_string "tweak";
         assert_screen "settings-tweak-selected";
@@ -35,7 +35,7 @@ sub tweak_startupapp_menu {
 
 sub start_dconf {
     my ($self) = @_;
-    unless (sle_version_at_least('15')) {
+    unless (is_sle('15+')) {
         $self->start_gnome_settings;
         type_string "dconf";
         assert_screen "settings-dconf";
@@ -59,7 +59,7 @@ sub alter_status_auto_save_session {
     my ($self) = @_;
     $self->start_dconf;
     # Old behavior for non SLE15 or non TW
-    if (!sle_version_at_least('15') && !is_leap('15.0+')) {
+    if (!is_sle('15+') && !is_leap('15.0+')) {
         send_key_until_needlematch "dconf-org", "down";
         assert_and_click "unfold";
         send_key_until_needlematch "dconf-org-gnome", "down";
@@ -88,7 +88,7 @@ sub alter_status_auto_save_session {
 sub restore_status_auto_save_session {
     my ($self) = @_;
     $self->start_dconf;
-    assert_and_click "auto-save-session" unless (sle_version_at_least('15'));
+    assert_and_click "auto-save-session" unless is_sle('15+');
     assert_and_click "auto-save-session-alter-use-default";
     assert_and_click "auto-save-session-apply";
     send_key "alt-f4";
@@ -103,7 +103,7 @@ sub run {
     $self->tweak_startupapp_menu;
     assert_and_click "tweak-startapp-add";
     assert_screen "tweak-startapp-applist";
-    if (sle_version_at_least('12-SP2')) {
+    if (is_sle('12-SP2+')) {
         assert_and_click "startupApp-searching";
         wait_still_screen;
         assert_screen "focused-on-search";
@@ -147,7 +147,7 @@ sub run {
     ##auto-save-session functionality has been abandoned;
     ##current status: just firefox works
     ##so in the future will consider remove openqa code for this session
-    unless (sle_version_at_least('15')) {
+    unless (is_sle('15+')) {
         # Install dconf-editor for TW
         if (check_var('VERSION', 'Tumbleweed')) {
             select_console('root-console');
@@ -169,7 +169,7 @@ sub run {
         send_key "ret";
         wait_still_screen;
 
-        if (sle_version_at_least('12-SP2')) {
+        if (is_sle('12-SP2+')) {
             $self->restore_status_auto_save_session;
         }
         else {

--- a/tests/x11/gnomecase/change_password.pm
+++ b/tests/x11/gnomecase/change_password.pm
@@ -53,7 +53,7 @@ sub reboot_system {
         assert_screen "displaymanager", 200;
         $self->{await_reboot} = 0;
         # The keyboard focus is different between SLE15 and SLE12
-        send_key 'up' if sle_version_at_least('15');
+        send_key 'up' if is_sle('15+');
         send_key "ret";
         wait_still_screen;
         type_string "$newpwd\n";
@@ -150,7 +150,7 @@ sub run {
 
     #delete the added user: test
     # We should kill the active user test in SLE15
-    assert_script_run 'loginctl terminate-user test' if (sle_version_at_least('15'));
+    assert_script_run 'loginctl terminate-user test' if is_sle('15+');
     wait_still_screen;
     type_string "userdel -f test\n";
     assert_screen "user-test-deleted";

--- a/tests/x11/gnomecase/gnome_default_applications.pm
+++ b/tests/x11/gnomecase/gnome_default_applications.pm
@@ -15,7 +15,7 @@ use base "x11test";
 use strict;
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
     # Prepare test files
@@ -78,17 +78,17 @@ sub open_default_apps {
     wait_still_screen;
     assert_and_dclick "gnomecase-defaultapps-bz2file";    #open bzip
     assert_screen 'gnomecase-defaultapps-bz2open';
-    send_key "ctrl-w" unless sle_version_at_least('15');    #close fileroller
+    send_key "ctrl-w" unless is_sle('15+');               #close fileroller
     wait_still_screen;
-    assert_and_dclick "gnomecase-defaultapps-gzfile";       #open gzip
+    assert_and_dclick "gnomecase-defaultapps-gzfile";     #open gzip
     assert_screen 'gnomecase-defaultapps-gzopen';
-    send_key "ctrl-w" unless sle_version_at_least('15');    #close fileroller
+    send_key "ctrl-w" unless is_sle('15+');               #close fileroller
     wait_still_screen;
-    assert_and_dclick "gnomecase-defaultapps-htmlfile";     #open html
+    assert_and_dclick "gnomecase-defaultapps-htmlfile";    #open html
     assert_screen 'gnomecase-defaultapps-firefoxopen';
-    send_key "alt-f4";                                      #close firefox
+    send_key "alt-f4";                                     #close firefox
     wait_still_screen;
-    send_key "ctrl-w";                                      #close nautilus
+    send_key "ctrl-w";                                     #close nautilus
 }
 
 # For each element, will check if the mimetype will open with the correct application
@@ -99,7 +99,7 @@ sub check_default_apps {
     my $returnCode = 1;
     my @message    = ();
     for my $app (@apps) {
-        if (sle_version_at_least('15')) {
+        if (is_sle('15+')) {
             $returnCode = script_run("[ '$app->[1]' == \$(gio mime '$app->[0]' |  awk 'NR==1{print \$NF}' | sed 's/[[:space:]]//' ) ]");
         }
         else {

--- a/tests/x11/gnomecase/nautilus_open_ftp.pm
+++ b/tests/x11/gnomecase/nautilus_open_ftp.pm
@@ -16,7 +16,7 @@
 use base 'x11test';
 use strict;
 use testapi;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
     x11_start_program('nautilus');
@@ -25,7 +25,7 @@ sub run {
     assert_screen 'nautilus-ftp-login';
     send_key 'ret';
     assert_screen 'nautilus-ftp-suse-com';
-    if (sle_version_at_least('12-SP2')) {
+    if (is_sle('12-SP2+')) {
         assert_and_click 'unselected-pub';
         assert_and_click 'ftp-path-selected';
         wait_still_screen(2);

--- a/tests/x11/tracker/tracker_by_command.pm
+++ b/tests/x11/tracker/tracker_by_command.pm
@@ -16,12 +16,12 @@ use base "x11test";
 use strict;
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 
 sub run {
     x11_start_program('xterm');
-    if (sle_version_at_least('12-SP2')) {
+    if (is_sle('12-SP2+')) {
         script_run 'tracker search emtpyfile';
         record_soft_failure 'bsc#1074582 tracker can not index empty file automatically' if check_screen 'tracker-cmdsearch-noemptyfile', 30;
         # Wait 20s for tracker to index the test file

--- a/tests/x11/tracker/tracker_info.pm
+++ b/tests/x11/tracker/tracker_info.pm
@@ -16,12 +16,12 @@ use base "x11test";
 use strict;
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 
 sub run {
     x11_start_program('xterm');
-    if (sle_version_at_least('12-SP2')) {
+    if (is_sle('12-SP2+')) {
         script_run "tracker info newpl.pl";
     }
     else {

--- a/tests/x11/tracker/tracker_searchall.pm
+++ b/tests/x11/tracker/tracker_searchall.pm
@@ -15,11 +15,11 @@ use base "x11test";
 use strict;
 use testapi;
 use utils;
-use version_utils 'sle_version_at_least';
+use version_utils 'is_sle';
 
 sub run {
     x11_start_program("tracker-needle", target_match => 'tracker-needle-launched');
-    if (!sle_version_at_least('12-SP2')) {
+    if (is_sle('<12-SP2')) {
         wait_screen_change { send_key 'tab' };
         wait_screen_change { send_key 'tab' };
         wait_screen_change { send_key 'right' };

--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -18,7 +18,7 @@ use base 'y2x11test';
 use strict;
 use testapi;
 use utils;
-use version_utils qw(is_opensuse is_sle sle_version_at_least is_leap is_tumbleweed is_storage_ng);
+use version_utils qw(is_opensuse is_sle is_leap is_tumbleweed is_storage_ng);
 
 sub search {
     my ($name) = @_;
@@ -108,7 +108,7 @@ sub start_printer {
     search('printer');
     # for now only test on SLE as openSUSE looks different. Can be extended
     # later
-    if (check_var('DISTRI', 'sle')) {
+    if (is_sle) {
         search('print');
         assert_and_click 'yast2_control-center_printer';
         assert_screen 'yast2_control-center_printer_running-cups-daemon', timeout => 60;
@@ -146,7 +146,7 @@ sub start_printer {
         send_key 'alt-o';
         assert_screen 'yast2-control-center-ui', timeout => 60;
     }
-    elsif (check_var('DISTRI', 'opensuse')) {
+    elsif (is_opensuse) {
         search('print');
         assert_and_click 'yast2_control-center_printer';
         assert_screen 'yast2_control-center_printer_configurations', timeout => 180;
@@ -343,7 +343,7 @@ sub run {
         start_kernel_dump;
         # YaST2 CA management has been dropped from SLE15, see
         # https://bugzilla.suse.com/show_bug.cgi?id=1059569#c14
-        if (sle_version_at_least('15')) {
+        if (is_sle('15+')) {
             start_directory_server;
         }
         else {
@@ -352,7 +352,7 @@ sub run {
         }
         start_wake_on_lan;
     }
-    if (check_var('DISTRI', 'opensuse')) {
+    if (is_opensuse) {
         start_kernel_settings;
     }
     # only available on openSUSE or at least not SLES


### PR DESCRIPTION
Replaces `sle_version_at_least` with `is_sle`. It uses second param (version to check against) of is_sle instead of `version_variable` args.
```perl
# Old example
if (sle_version_at_least('12-SP1', version_variable => $args{version_variable})) {
if (sle_version_at_least($version, version_variable => "REAL_INSTALLED_VERSION")) {

# New example
if (is_sle('12-SP1+', get_var($args{version_variable}))) {
if (is_sle(">=$version", $real_installed_version)) {
```

I also removed `sle_version_at_least` sub, because
 - it returned true for all non-sle products, which is confusing considering it's name
 - it implemented only `>=` comparison, not `> < = <=` cases
 - it was spaghetti code