### PR TITLE
Hyper-V: Make sure ISO is the first DVD on IDE bus

### DIFF
--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -177,8 +177,8 @@ sub run {
         # the default is 'Production' (i.e. snapshot on guest level).
         hyperv_cmd("$ps Set-VM -VMName $name -CheckpointType Standard") if $winserver eq '2016';
         if ($iso) {
-            hyperv_cmd("$ps Add-VMDvdDrive -VMName $name") if get_var('UEFI');
-            hyperv_cmd("$ps Set-VMDvdDrive -VMName $name -Path $iso");
+            hyperv_cmd("$ps Remove-VMDvdDrive -VMName $name -ControllerNumber 1 -ControllerLocation 0");
+            hyperv_cmd("$ps Add-VMDvdDrive -VMName $name -Path $iso");
         }
         foreach my $disk_path (@disk_paths) {
             hyperv_cmd("$ps Add-VMHardDiskDrive -VMName $name -Path $disk_path");


### PR DESCRIPTION
https://trello.com/c/3TsuEshY/313-p1-cdrom-disk-ordering-should-mimic-qemu-backend
https://progress.opensuse.org/issues/37561

Previously `ISO` medium was connected to controller 1, location 0 on IDE
bus this diverges from logic QEMU implements and thus jobs break in
`addon_products_sle` as wrong DVD medium is selected.

Now, `ISO` is on IDE 0/1, being the first DVD attached, getting
`/dev/sr0` later.

Validation runs:
* media_upgrade_sles12sp4_hyperv@svirt-hyperv: http://nilgiri.suse.cz/tests/1831
* media_upgrade_sles15_allpatterns_hyperv@svirt-hyperv: http://nilgiri.suse.cz/tests/1836
* media_upgrade_sles12sp4_allpatterns_hyperv@svirt-hyperv: http://nilgiri.suse.cz/tests/1832
* lvm+RAID1@svirt-hyperv: http://nilgiri.suse.cz/tests/1852
* lvm+RAID1@svirt-hyperv-uefi: http://nilgiri.suse.cz/tests/1845
* jeos-main@svirt-hyperv: http://nilgiri.suse.cz/tests/1857
* default@svirt-hyperv: http://nilgiri.suse.cz/tests/1849
* default@svirt-hyperv-uefi: http://nilgiri.suse.cz/tests/1848
* memtest@svirt-hyperv: http://nilgiri.suse.cz/tests/1851