### PR TITLE
Add ppc64le for load_extra_tests_docker

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1529,7 +1529,7 @@ sub load_extra_tests_console {
 }
 
 sub load_extra_tests_docker {
-    return unless check_var('ARCH', 'x86_64');
+    return unless get_var('ARCH', '') =~ /x86_64/ppc64le/aarch64/;
     return unless is_sle('12-SP3+') || !is_sle;
     loadtest "console/docker";
     loadtest "console/docker_runc";


### PR DESCRIPTION
This is a slight change versus previous pr#5877
that limited load_extra_tests_docker to x86_64 for TW

eg for ppc64le TW: https://openqa.opensuse.org/tests/801738  there is no docker tests

I verified  in my local openQA ppc64le instance for TW not for sle12sp3 or sle15.
