### PR TITLE
Don't run system_role for Krypton

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -847,7 +847,7 @@ sub load_inst_tests {
             loadtest "installation/livecd_network_settings";
         }
         # Run system_role/desktop selection tests if using the new openSUSE installation flow
-        if (is_using_system_role_first_flow) {
+        if (is_using_system_role_first_flow && requires_role_selection) {
             load_system_role_tests;
         }
         if (is_sles4sap() and sle_version_at_least('15') and check_var('SYSTEM_ROLE', 'default') and !is_upgrade()) {
@@ -939,7 +939,7 @@ sub load_inst_tests {
             loadtest "installation/hostname_inst";
         }
         # Do not run system_role/desktop selection if using the new openSUSE installation flow
-        if (!is_using_system_role_first_flow) {
+        if (!is_using_system_role_first_flow && requires_role_selection) {
             load_system_role_tests;
         }
         if (is_sles4sap()) {

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -43,6 +43,7 @@ use constant {
           sle_version_at_least
           is_using_system_role
           is_using_system_role_first_flow
+          requires_role_selection
           )
     ],
     BACKEND => [
@@ -392,6 +393,11 @@ sub is_using_system_role {
 # On leap 15.0 we have desktop selection first, and everywhere, where we have system roles
 sub is_using_system_role_first_flow {
     return is_leap('=15.0') || is_using_system_role;
+}
+
+# If there is only one role, there is no selection offered
+sub requires_role_selection {
+    return get_var('FLAVOR', '') !~ /Krypton/;
 }
 
 =head2 has_product_selection


### PR DESCRIPTION
Krypton only has one option, so with current YaST the selection isn't
shown at all anymore.

Verification run: http://10.160.67.86/tests/227