### PR TITLE
Accept addon licenses in SLES15 if registering after install

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -68,7 +68,8 @@ our %SLE15_DEFAULT_MODULES = (
     sles4sap => 'base,desktop,serverapp,ha,sapapp',
 );
 
-our @SLE15_ADDONS_WITHOUT_LICENSE = qw(ha sdk wsm we hpcm);
+our @SLE15_ADDONS_WITHOUT_LICENSE        = qw(ha sdk wsm we hpcm);
+our @SLE15_ADDONS_WITH_LICENSE_NOINSTALL = qw(ha we);
 
 # Method to determine if a short name references a module based on what's defined
 # on %SLE15_MODULES
@@ -90,6 +91,8 @@ sub accept_addons_license {
     # In SLE 15 some modules do not have license or have the same
     # license (see bsc#1089163) and so are not be shown twice
     push @addons_with_license, @SLE15_ADDONS_WITHOUT_LICENSE unless is_sle('15+');
+    # HA and WE have licenses when calling yast2 scc
+    push @addons_with_license, @SLE15_ADDONS_WITH_LICENSE_NOINSTALL if (is_sle('15+') and get_var('IN_PATCH_SLE'));
 
     for my $addon (@scc_addons) {
         # most modules don't have license, skip them

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -173,7 +173,15 @@ sub sle_register {
     # SLE 12 and later use SCC, but SLE 11 uses NCC
     if ($action eq 'register') {
         if (is_sle('12+')) {
+            # Tag the test as being called from this module, so accept_addons_license
+            # (called by yast_scc_registration) can handle license agreements from modules
+            # that do not show license agreement during installation but do when registering
+            # after install
+            set_var('IN_PATCH_SLE', 1);
             yast_scc_registration();
+            # Once SCC registration is done, disable IN_PATCH_SLE so it does not interfere
+            # with further calls to accept_addons_license (in upgrade for example)
+            set_var('IN_PATCH_SLE', 0);
         }
         else {
             # Erase all local files created from a previous executed registration


### PR DESCRIPTION
When adding modules to SLES15 during installation, most addons do not show a license agreement and instead the process goes directly to the registration code screen. There is already code in place in
`lib/registration` to handle addons with licenses and an array `SLE15_ADDONS_WITHOUT_LICENSE` listing the addons that do not require a license agreement on SLES15; however, there are addons included in that array that do not require a license agreement during installation, but do require one if registering the system after installation with `yast2 scc`.

If registering after installation, license agreements are shown when selecting the HA and WE modules, so the current code fails to accept the licenses as it is using the same method for handling addons license agreements as the one used during installation which is not expecting a license agreement screen for these two modules.

In order to have a workaround so the same method can be used when adding modules during or after installation, this commit adds and sets the environment variable `IN_PATCH_SLE` before calling the `yast_scc_registration method` from `tests/update/patch_sle`, and also updates the `accept_addons_license` method (itself called by `yast_scc_registration`) depending on the value of
that variable, so if `yast_scc_registration` is called while patching a system, the code is able to properly handle the license screens from the HA and WE modules.

- Related ticket: N/A
- Failing test: https://openqa.suse.de/tests/2282655 & https://openqa.suse.de/tests/2282656
- Needles: N/A
- Verification run: http://mango.suse.de/tests/706 (upgrade test with patch_sle), http://mango.suse.de/tests/709 (installation, regression test)
