### PR TITLE
Die when $qa_head_repo is not set

### DIFF
--- a/tests/console/systemd_testsuite.pm
+++ b/tests/console/systemd_testsuite.pm
@@ -26,6 +26,7 @@ sub run {
         elsif (is_sle('15+')) {
             $qa_head_repo = 'http://download.suse.de/ibs/QA:/SLE15/standard/';
         }
+        die '$qa_head_repo is not set' unless ($qa_head_repo);
     }
 
     # install systemd testsuite


### PR DESCRIPTION
As suggested in: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6302#discussion_r236817199

- Related ticket: https://progress.opensuse.org/issues/40337
- Verification run: http://slindomansilla-vm.qa.suse.de/tests/958
