### PR TITLE
pcloud: add terraform tool to public cloud openqa image

### DIFF
--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -83,6 +83,12 @@ sub run {
     assert_script_run("touch .config/ipa/config");
     assert_script_run("ipa list");
     assert_script_run("ipa --version");
+
+    # Download and Install Terraform
+    my $terraform_url = get_var('TERRAFORM_URL', 'https://releases.hashicorp.com/terraform/0.11.10/terraform_0.11.10_linux_amd64.zip');
+    assert_script_run("wget -q $terraform_url");
+    assert_script_run('unzip terraform_* terraform -d /usr/bin/');
+    assert_script_run('terraform -v');
 }
 
 sub test_flags {


### PR DESCRIPTION
Terraform comes as a binary [1] downloadable on a generic Linux distribution.

- Related ticket: https://progress.opensuse.org/issues/44207
- Verification run: http://fromm.arch.suse.de/tests/4206

[1] https://www.terraform.io/downloads.html