### PR TITLE
xfstests on another device

### DIFF
--- a/lib/ctcs2_to_junit.pm
+++ b/lib/ctcs2_to_junit.pm
@@ -102,7 +102,7 @@ sub generateXML {
         if (!get_var('QA_TESTSUITE') && ($case_status eq 'failure' || $case_status eq 'skipped')) {
             (my $test_path = $test) =~ s/-/\//;
             $test_path = '/opt/log/' . $test_path;
-            my $test_out_content = script_output("cat $test_path| sed \"s/'//g\" | sed \"s/[\\x00-\\x08\\x0B-\\x0C\\x0E-\\x1F]//g\"|tail -n 200", 600);
+            my $test_out_content = script_output("cat $test_path| sed \"s/'//g\" | sed \"s/[\\x00\\x01-\\x08\\x0B-\\x0C\\x0E-\\x1F]//g\"|tail -n 200", 600);
             $writer->startTag('system-out');
             $writer->characters($test_out_content);
             $writer->endTag('system-out');
@@ -110,12 +110,12 @@ sub generateXML {
                 my $test_err_content = script_output("
                     echo '====out.bad log====';
                     if [ -f $test_path.out.bad ];
-                        then cat $test_path.out.bad|sed \"s/'//g\"|sed \"s/[\\x00-\\x08\\x0B-\\x0C\\x0E-\\x1F]//g\"|tail -n 200;
+                        then cat $test_path.out.bad|sed \"s/'//g\"|sed \"s/[\\x00\\x01-\\x08\\x0B-\\x0C\\x0E-\\x1F]//g\"|tail -n 200;
                     else echo '$test_path.out.bad not exist';
                     fi;
                     echo '====full log====';
                     if [ -f $test_path.full ];
-                        then cat $test_path.full|sed \"s/'//g\"|sed \"s/[\\x00-\\x08\\x0B-\\x0C\\x0E-\\x1F]//g\"|tail -n 200;
+                        then cat $test_path.full|sed \"s/'//g\"|sed \"s/[\\x00\\x01-\\x08\\x0B-\\x0C\\x0E-\\x1F]//g\"|tail -n 200;
                     else echo '$test_path.full not exist';
                     fi;
                 ", 600);

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -775,7 +775,7 @@ elsif (get_var("XFSTESTS")) {
     if (check_var('ARCH', 'aarch64') && check_var('VERSION', '12-SP4')) {
         set_var('NO_KDUMP', 1);
     }
-    boot_hdd_image;
+    prepare_target;
     unless (get_var('NO_KDUMP')) {
         loadtest "xfstests/enable_kdump";
     }

--- a/tests/xfstests/enable_kdump.pm
+++ b/tests/xfstests/enable_kdump.pm
@@ -19,10 +19,11 @@ use utils 'zypper_call';
 use power_action_utils 'power_action';
 use kdump_utils;
 use testapi;
+use Utils::Backends 'use_ssh_serial_console';
 
 sub run {
     my $self = shift;
-    select_console('root-console');
+    check_var('BACKEND', 'ipmi') ? use_ssh_serial_console : select_console 'root-console';
 
     # Also panic when softlockup
     # workaround bsc#1104778, skip s390x in 12SP4

--- a/tests/xfstests/install.pm
+++ b/tests/xfstests/install.pm
@@ -31,9 +31,15 @@ sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
+    # Disable PackageKit
+    # This is done by the previous module (enable_kdump) only if NO_KDUMP is not set
+    pkcon_quit;
+
     # Add QA repo
-    my $qa_head_repo = get_var('QA_HEAD_REPO', '');
-    zypper_call("--no-gpg-check ar -f '$qa_head_repo' qa-ibs", timeout => 600);
+    if (script_run("zypper lr qa-ibs")) {
+        my $qa_head_repo = get_var('QA_HEAD_REPO', '');
+        zypper_call("--no-gpg-check ar -f '$qa_head_repo' qa-ibs", timeout => 600);
+    }
 
     # Install qa_test_xfstests
     zypper_call('--gpg-auto-import-keys ref', timeout => 600);

--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -24,7 +24,13 @@ sub run {
 
     # Create partitions
     my $filesystem = get_required_var('XFSTESTS');
-    assert_script_run("/usr/share/qa/qa_test_xfstests/partition.py --delhome $filesystem && sync", 600);
+    my $device     = get_var('XFSTESTS_DEVICE');
+    if ($device) {
+        assert_script_run("parted $device --script -- mklabel gpt");
+        assert_script_run("/usr/share/qa/qa_test_xfstests/partition.py --device $device $filesystem && sync", 600);
+    } else {
+        assert_script_run("/usr/share/qa/qa_test_xfstests/partition.py --delhome $filesystem && sync", 600);
+    }
 }
 
 sub test_flags {

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -136,7 +136,7 @@ sub test_name {
 sub log_add {
     my ($file, $test, $status, $time) = @_;
     my $name = test_name($test);
-    my $cmd  = "echo '$name ... ... $status (${time}s)' >> $file && sync";
+    my $cmd  = "echo '$name ... ... $status (${time}s)' >> $file && sync $file";
     type_string("\n");
     assert_script_run($cmd);
 }


### PR DESCRIPTION
This PR adds a XFSTESTS_DEVICE variable to run the tests on devices other than /dev/vda. 

It is needed to run the tests on NVDIMM setting XFSTESTS_DEVICE=/dev/pmem0

Also, support was added to run over IPMI.

Minor fixes:
 - Disable PackageKit also in `xfstests/run`.  It is done by the previous module (`xfstests/enable_kdump`) which doesn't run if the NO_KDUMP variable is set.
 - Check if the qa-ibs repository already exists.
 - Run sync on the written log file only to avoid a sync of the whole cache.

Verification run (with 10 tests instead of 100 until IPMI issues are finally solved).
http://ix64hae1001.qa.suse.de./tests/106

Verification run with XFSTESTS_DEVICE unset:
http://ix64hae1001.qa.suse.de/tests/100