### PR TITLE
publiccloud: Refactor basetest, provider and instance

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Base class for public cloud instances
+#
+# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+
+package publiccloud::instance;
+use testapi;
+use Mojo::Base -base;
+
+has instance_id => undef;               # unique CSP instance id
+has public_ip   => undef;               # public IP of instance
+has username    => undef;               # username for ssh connection
+has ssh_key     => undef;               # path to ssh-key for connection
+has provider    => undef, weak => 1;    # back reference to the provider
+
+=head2 run_ssh_command
+
+    run_ssh_command($cmd);
+
+Runs a command C<cmd> via ssh in the given VM. Retrieves the output.
+If the command retrieves not zero, a exception is thrown.
+TODO Do not raise exception on error
+TODO Be aware of special shell letters like ';'
+=cut
+sub run_ssh_command {
+    my ($self, $cmd) = @_;
+
+    die('Argument <cmd> missing') unless ($cmd);
+
+    my $ssh_cmd = sprintf('ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "%s" "%s@%s" -- %s',
+        $self->ssh_key, $self->username, $self->public_ip, $cmd);
+    record_info('CMD', $ssh_cmd);
+    return script_output($ssh_cmd);
+}
+
+1;

--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -25,33 +25,18 @@ sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
 
-    my $provider = $self->{provider} = $self->provider_factory();
-    $provider->init;
+    my $provider = $self->provider_factory();
 
     my $img_url = get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION');
     my ($img_name) = $img_url =~ /([^\/]+)$/;
 
     if (my $img_id = $provider->find_img($img_name)) {
         record_info('Info', "Image $img_name already exists!");
-        set_var('PUBLIC_CLOUD_IMAGE_ID', $img_id);
         return;
     }
 
     assert_script_run("wget $img_url -O $img_name", timeout => 60 * 10);
-
-    my $img_id = $provider->upload_img($img_name);
-
-    set_var('PUBLIC_CLOUD_IMAGE_ID', $img_id);
-
-    $provider->cleanup();
-}
-
-sub post_fail_hook {
-    my ($self) = @_;
-
-    if ($self->{provider}) {
-        $self->{provider}->cleanup();
-    }
+    $provider->upload_img($img_name);
 }
 
 sub test_flags {


### PR DESCRIPTION
Move methods closer to the related objects.

The method get_image_id() was moved from publiccloud::basetest
to publiccloud::provider.

Instances are now perl objects. Currently we do not have special
implementation per CSP, but it should be possible.
run_ssh_command() is now a method of publiccloud::instance.

publiccloud::basetest remember all created provider objects and
do cleanup after test.
Test modules can overwrite the cleanup() method. This method is
called after run() always (failed, died or success).

- Related ticket: https://progress.opensuse.org/issues/44459
- Verification run: 
 - http://cfconrad-vm.qa.suse.de/tests/3062 (azure:upload_img)
 - http://cfconrad-vm.qa.suse.de/tests/3061 (azure:ipa)
 - http://cfconrad-vm.qa.suse.de/tests/3064 (azure:ltp)

@asmorodskyi @jlausuch plz have a look
