### PR TITLE
s390x: Use info file to boot from smb

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -66,6 +66,13 @@ sub split_lines {
 
 use backend::console_proxy;
 
+sub create_infofile {
+    my ($bootinfo) = @_;
+    my $path = 's390x_bootinfo';
+    save_tmp_file($path, $bootinfo);
+    return shorten_url(autoinst_url . "/files/$path");
+}
+
 sub prepare_parmfile {
     my ($repo) = @_;
     my $params = '';
@@ -78,9 +85,12 @@ sub prepare_parmfile {
     # create a too long parameter ;(
     my $instsrc = get_var('INSTALL_SOURCE', 'ftp') . '://' . get_var('REPO_HOST', 'openqa') . '/';
     if (check_var('INSTALL_SOURCE', 'smb')) {
-        $instsrc .= "inst/";
+        $instsrc .= "inst/" . $repo;
+        $params  .= " info=" . create_infofile("install: $instsrc");
     }
-    $params .= " install=" . $instsrc . $repo . " ";
+    else {
+        $params .= " install=" . $instsrc . $repo . " ";
+    }
 
     if (get_var('UPGRADE')) {
         $params .= 'upgrade=1 ';


### PR DESCRIPTION
so, this is fixing the "too long url" for s390x smb test... (https://progress.opensuse.org/issues/43655)
but I want to use this PR also as a discussion, if we should limit it to smb for now or come up with a more generic approach like e.g.
* move all the params to that info file, which makes the bootparams less transparent imo
* move only parameters there which are longer than 73 characters
* leave it like it is for now as smb is the only case which didn't work so far because of that (we don't have typing issues e.g. missing keys on s390x

verification run: http://opeth.suse.de/tests/3435