### PR TITLE
Update scsi id boot from slof for ppc64le

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -207,7 +207,9 @@ sub boot_local_disk {
         }
         if (match_has_tag 'inst-slof') {
             diag 'specifying local disk for boot from slof';
-            type_string_very_slow "boot /pci\t/sc\t5";
+            my $slof = 5;
+            $slof += 1 if get_var('VIRTIO_CONSOLE');
+            type_string_very_slow "boot /pci\t/sc\t$slof";
             save_screenshot;
         }
         if (match_has_tag 'encrypted-disk-password-prompt') {


### PR DESCRIPTION
This issue failed for openqa setting more argument for /usr/bin/qemu-system-ppc64 (such as +-device virtio +-serial), this may caused by VIRTIO_CONSOLE=1 since build 95.1, then new device serial will be added which caused the scsi device id changed from 5 to 6. So we need to updated the scsi boot id from 5 to 6.

- Related ticket: https://progress.opensuse.org/issues/43898
- Verification run: http://openqa-apac1.suse.de/tests/2446#step/boot_to_desktop/5
