### PR TITLE
[WIP] Add hard failures from QEMU to the main.pm

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -671,6 +671,11 @@ testapi::set_distribution(susedistribution->new());
 
 # Set serial failures
 my $serial_failures = [];
+# Detect general problems with qemu, we can simply die hard
+push @$serial_failures, {type => 'hard', message => 'poo#44432', pattern => quotemeta 'VCPU can only run on primary'};
+push @$serial_failures, {type => 'hard', message => 'poo#36559', pattern => quotemeta 'kvm run failed Device or resource busy'};
+
+push @$serial_failures, {type => 'hard', message => 'bsc#1093797', pattern => quotemeta 'Internal error: Oops: 96000006'};
 # Detect bsc#1093797 on aarch64
 if (is_sle('=12-SP4') && check_var('ARCH', 'aarch64')) {
     push @$serial_failures, {type => 'hard', message => 'bsc#1093797', pattern => quotemeta 'Internal error: Oops: 96000006'};


### PR DESCRIPTION
There are failures in the backend that we know what do they mean, specially for QEMU, in these cases, there's no reason into even trying to keep the test running for any longer, since it's a  waste of time.

For the time being the serial detection does not support checking the autoinst-log.txt but we should extend that... 

Check [poo#44432](https://progress.opensuse.org/issues/44432)  for part of the motivation, check [poo#45011](https://progress.opensuse.org/issues/45011) for more details.