### PR TITLE
Extract backend code to it's own package

### DIFF
--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -17,35 +17,32 @@ package Utils::Backends;
 use strict;
 use warnings;
 
-use base Exporter;
+use base qw(Exporter);
 use Exporter;
 use testapi qw(:DEFAULT);
 
 use constant {
     BACKEND => [
         qw(
-        #is_hyperv
-        #is_hyperv_in_gui
-        #is_aarch64_uefi_boot_hdd
           is_remote_backend
-        #is_svirt_except_s390x
           )
     ],
-    CONSOLES =>[
+    CONSOLES => [
         qw(
           use_ssh_serial_console
-    )
-    ]
+          )
+      ]
 };
 
 our @EXPORT = (@{(+CONSOLES)}, @{+BACKEND});
 
 our %EXPORT_TAGS = (
-    CONSOLES  => (CONSOLES),
+    CONSOLES => (CONSOLES),
     BACKEND  => (BACKEND)
 );
 
-#use it after SUT boot finish, as it requires ssh connection to SUT to interact with SUT, including window and serial console
+# Use it after SUT boot finish, as it requires ssh connection to SUT to
+# interact with SUT, including window and serial console
 sub use_ssh_serial_console {
     select_console('root-ssh');
     $serialdev = 'sshserial';
@@ -53,27 +50,13 @@ sub use_ssh_serial_console {
     bmwqemu::save_vars();
 }
 
-# defined in lib/version_utils.pm
-# sub is_s390x {
-#     return check_var('ARCH', 's390x');
-# }
-
-# sub is_x86_64 {
-#     return check_var('ARCH', 'x86_64');
-# }
-
 sub is_remote_backend {
-    # s390x uses only remote repos
 
-    return check_var('ARCH', 's390x')    ||
-           check_var('BACKEND', 'svirt') ||
-           check_var('BACKEND', 'ipmi')  ||
-           check_var('BACKEND', 'spvm');
+    # s390x uses only remote repos
+    return check_var('ARCH', 's390x') ||
+      check_var('BACKEND', 'svirt') ||
+      check_var('BACKEND', 'ipmi')  ||
+      check_var('BACKEND', 'spvm');
 }
 
 1;
-
-# 1035  ag -Q "check_var('ARCH', 'aarch64')" | wc -l
-# 1036  ag -Q "check_var('ARCH', 's390')" | wc -l
-# 1037  ag -Q "check_var('ARCH', 's390x')" | wc -l
-# 1038  ag -Q "check_var('ARCH', 'x86_64')" | wc -l

--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -1,0 +1,79 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package Utils::Backends;
+use strict;
+use warnings;
+
+use base Exporter;
+use Exporter;
+use testapi qw(:DEFAULT);
+
+use constant {
+    BACKEND => [
+        qw(
+        #is_hyperv
+        #is_hyperv_in_gui
+        #is_aarch64_uefi_boot_hdd
+          is_remote_backend
+        #is_svirt_except_s390x
+          )
+    ],
+    CONSOLES =>[
+        qw(
+          use_ssh_serial_console
+    )
+    ]
+};
+
+our @EXPORT = (@{(+CONSOLES)}, @{+BACKEND});
+
+our %EXPORT_TAGS = (
+    CONSOLES  => (CONSOLES),
+    BACKEND  => (BACKEND)
+);
+
+#use it after SUT boot finish, as it requires ssh connection to SUT to interact with SUT, including window and serial console
+sub use_ssh_serial_console {
+    select_console('root-ssh');
+    $serialdev = 'sshserial';
+    set_var('SERIALDEV', $serialdev);
+    bmwqemu::save_vars();
+}
+
+# defined in lib/version_utils.pm
+# sub is_s390x {
+#     return check_var('ARCH', 's390x');
+# }
+
+# sub is_x86_64 {
+#     return check_var('ARCH', 'x86_64');
+# }
+
+sub is_remote_backend {
+    # s390x uses only remote repos
+
+    return check_var('ARCH', 's390x')    ||
+           check_var('BACKEND', 'svirt') ||
+           check_var('BACKEND', 'ipmi')  ||
+           check_var('BACKEND', 'spvm');
+}
+
+1;
+
+# 1035  ag -Q "check_var('ARCH', 'aarch64')" | wc -l
+# 1036  ag -Q "check_var('ARCH', 's390')" | wc -l
+# 1037  ag -Q "check_var('ARCH', 's390x')" | wc -l
+# 1038  ag -Q "check_var('ARCH', 'x86_64')" | wc -l

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -19,7 +19,8 @@ use Time::HiRes 'sleep';
 
 use testapi;
 use utils;
-use version_utils qw(is_caasp is_jeos is_leap is_sle is_remote_backend);
+use Utils::Backends 'is_remote_backend';
+use version_utils qw(is_caasp is_jeos is_leap is_sle);
 use caasp 'pause_until';
 use mm_network;
 

--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -21,21 +21,13 @@ use version_utils qw(is_storage_ng is_sle);
 use utils;
 use power_action_utils 'prepare_system_shutdown';
 
-our @EXPORT = qw(use_ssh_serial_console set_serial_console_on_vh switch_from_ssh_to_sol_console);
+our @EXPORT = qw(set_serial_console_on_vh switch_from_ssh_to_sol_console);
 
 #With the new ipmi backend, we only use the root-ssh console when the SUT boot up,
 #and no longer setup the real serial console for either kvm or xen.
 #When needs reboot, we will switch back to sut console which relies on ipmi.
 #We will mostly rely on ikvm to continue the test flow.
 #TODO: we need the serial output to debug issues in reboot, coolo will help add it.
-
-#use it after SUT boot finish, as it requires ssh connection to SUT to interact with SUT, including window and serial console
-sub use_ssh_serial_console {
-    select_console('root-ssh');
-    $serialdev = 'sshserial';
-    set_var('SERIALDEV', $serialdev);
-    bmwqemu::save_vars();
-}
 
 sub switch_from_ssh_to_sol_console {
     my (%opts) = @_;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -19,6 +19,7 @@ use testapi qw(check_var get_var get_required_var set_var check_var_array diag);
 use autotest;
 use utils;
 use version_utils qw(:VERSION :BACKEND :SCENARIO);
+use Utils::Backends 'is_remote_backend';
 use bmwqemu ();
 use strict;
 use warnings;

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -14,7 +14,7 @@ use utils qw(
   zypper_call
 );
 use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x);
-use ipmi_backend_utils 'use_ssh_serial_console';
+use Utils::Backends 'use_ssh_serial_console';
 
 # Base class implementation of distribution class necessary for testapi
 

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -51,7 +51,6 @@ use constant {
           is_hyperv
           is_hyperv_in_gui
           is_aarch64_uefi_boot_hdd
-          is_remote_backend
           is_svirt_except_s390x
           )
     ],
@@ -294,11 +293,6 @@ sub is_s390x {
 
 sub is_x86_64 {
     return check_var('ARCH', 'x86_64');
-}
-
-sub is_remote_backend {
-    # s390x uses only remote repos
-    return is_s390x() || check_var('BACKEND', 'svirt') || check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm');
 }
 
 

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -295,7 +295,6 @@ sub is_x86_64 {
     return check_var('ARCH', 'x86_64');
 }
 
-
 sub is_server {
     return 1 if is_sles4sap();
     return 1 if get_var('FLAVOR', '') =~ /^Server/;

--- a/tests/autoyast/login.pm
+++ b/tests/autoyast/login.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 SUSE LLC
+# Copyright (C) 2015-2018 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,7 +19,9 @@
 use strict;
 use base 'y2logsstep';
 use testapi;
-use ipmi_backend_utils;
+# TODO: is_remote_backend we need to ensure if for autoyast we want this or
+# this also applies for other backends
+use Utils::Backends qw (use_ssh_serial_console is_remote_backend);
 
 sub run {
     my $self = shift;

--- a/tests/autoyast/login.pm
+++ b/tests/autoyast/login.pm
@@ -19,14 +19,16 @@
 use strict;
 use base 'y2logsstep';
 use testapi;
-# TODO: is_remote_backend we need to ensure if for autoyast we want this or
-# this also applies for other backends
-use Utils::Backends qw (use_ssh_serial_console is_remote_backend);
+use Utils::Backends qw(use_ssh_serial_console is_remote_backend);
 
 sub run {
     my $self = shift;
     assert_screen("autoyast-system-login-console", 20);
-    $self->result('fail');    # default result
+    # default result
+    $self->result('fail');
+
+    # TODO: is_remote_backend could be a better fit here, but not
+    # too sure if it would make sense for svirt or s390 for example
     if (check_var('BACKEND', 'ipmi')) {
         #use console based on ssh to avoid unstable ipmi
         use_ssh_serial_console;

--- a/tests/console/check_network.pm
+++ b/tests/console/check_network.pm
@@ -12,7 +12,7 @@
 
 use base "consoletest";
 use testapi;
-use ipmi_backend_utils 'use_ssh_serial_console';
+use Utils::Backends 'use_ssh_serial_console';
 use strict;
 
 sub run {

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -16,7 +16,7 @@
 use base "consoletest";
 use testapi;
 use utils;
-use ipmi_backend_utils 'use_ssh_serial_console';
+use Utils::Backends 'use_ssh_serial_console';
 use strict;
 
 sub disable_bash_mail_notification {

--- a/tests/console/prepare_test_data.pm
+++ b/tests/console/prepare_test_data.pm
@@ -13,7 +13,7 @@
 use base "consoletest";
 use testapi;
 use utils;
-use ipmi_backend_utils 'use_ssh_serial_console';
+use Utils::Backends 'use_ssh_serial_console';
 use strict;
 
 sub run {

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -13,7 +13,7 @@
 use base 'consoletest';
 use testapi;
 use utils;
-use ipmi_backend_utils 'use_ssh_serial_console';
+use Utils::Backends 'use_ssh_serial_console';
 use bootloader_setup qw(change_grub_config grub_mkconfig);
 use strict;
 

--- a/tests/console/system_state.pm
+++ b/tests/console/system_state.pm
@@ -14,7 +14,7 @@
 use base "consoletest";
 use testapi;
 use utils;
-use ipmi_backend_utils 'use_ssh_serial_console';
+use Utils::Backends 'use_ssh_serial_console';
 use strict;
 
 sub run {

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -16,6 +16,7 @@ use base 'y2logsstep';
 use testapi;
 use lockapi;
 use utils;
+use Utils::Backends 'use_ssh_serial_console';
 use ipmi_backend_utils;
 
 sub run {

--- a/tests/kernel/ib_tests.pm
+++ b/tests/kernel/ib_tests.pm
@@ -17,6 +17,7 @@ use testapi;
 use utils;
 use power_action_utils 'power_action';
 use lockapi;
+use Utils::Backends 'use_ssh_serial_console';
 use ipmi_backend_utils;
 
 

--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -15,7 +15,7 @@ use base 'sles4sap';
 use strict;
 use testapi;
 use utils qw(type_string_slow zypper_call turn_off_gnome_screensaver);
-use ipmi_backend_utils 'use_ssh_serial_console';
+use Utils::Backends 'use_ssh_serial_console';
 use version_utils 'is_sle';
 
 sub get_total_mem {

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,6 +16,7 @@ use strict;
 use warnings;
 use File::Basename;
 use testapi;
+use Utils::Backends 'use_ssh_serial_console';
 use ipmi_backend_utils;
 
 sub login_to_console {


### PR DESCRIPTION
As stated in [poo#33388](https://progress.opensuse.org/issues/33388), we have code that is being used across diferent modules (use_ssh_serial_console in this case), and that should have it's own module..

There are many other ocurrences, but for the time being let's introduce Utils::Backends and then start to grow from there

* use_ssh_serial_console is being moved to Utils::Backends
* is_remote_backend is being moved to Uils::Backends
* qemu backend http://phobos.suse.de/tests/1746770

~~I'm still pending to have this running on spvm, ipmi and svirt backends, just to make sure that stuff is not broken~~

Check [poo#45008](https://progress.opensuse.org/issues/45008) which should be a continuation of this one...