### PR TITLE
Flag console/sshd test as milestone

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -61,4 +61,8 @@ sub run {
     assert_screen "ssh-login-ok";
 }
 
+sub test_flags {
+    return {milestone => 1};
+}
+
 1;


### PR DESCRIPTION
Other tests rely on the ssh server being started by this test.
When only one (even non-ssh related test) fails after this one,
openQA will otherwise revert to the last milestone before this test
which will result in strange behaviour.

Verification: http://artemis.suse.de/tests/1018