### PR TITLE
Check for qcow2 on SUT host when svirt backend

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -768,7 +768,8 @@ sub zkvm_add_disk {
         my $basename = basename($hdd);
         my $basedir  = svirt_host_basedir();
         my $hdd_dir  = "$basedir/openqa/share/factory/hdd";
-        chomp(my $hdd_path = `find $hdd_dir -name $basename | head -n1`);
+        my $hdd_path = $svirt->get_cmd_output("find $hdd_dir -name $basename | head -n1 | tr -d '\n'");
+        die "Unable to find image $basename in $hdd_dir" unless $hdd_path;
         diag("HDD path found: $hdd_path");
         if (get_var('PATCHED_SYSTEM')) {
             diag('in patched systems just load the patched image');


### PR DESCRIPTION
Fix from: #6191

- Related ticket: https://progress.opensuse.org/issues/44468
- Verification run: http://slindomansilla-vm.qa.suse.de/tests/986#step/bootloader_zkvm/9 (this fail is expected after this PR, because more actions need to be taken in the infrastructure side of [poo#44468](https://progress.opensuse.org/issues/44468))