### PR TITLE
Fix search usb repo number when not first

### DIFF
--- a/tests/console/enable_usb_repo.pm
+++ b/tests/console/enable_usb_repo.pm
@@ -19,9 +19,12 @@ use utils;
 
 sub run {
     select_console 'root-console';
-    # actually not checking that the first repo is a USB repo but just
-    # assuming that the first repo is the install repo should be good enough.
-    zypper_call('mr -e 1');
+    my $repo_num = script_output 'zypper lr --uri | grep "hd:///?device=/dev/disk/by-id/usb-" | awk \'{print $1}\'';
+    if ($repo_num !~ /^\d+$/) {
+        record_info("Serial polluted", "Serial output was polluted: Assuming first repo is USB", result => 'fail');
+        $repo_num = 1;
+    }
+    zypper_call("mr -e $repo_num");
 }
 
 1;


### PR DESCRIPTION
Fix search usb repo number when not first and unscheduled unnecessary tests in this scenario.

- Related ticket: https://progress.opensuse.org/issues/42917
- Verification run: [sle-15-SP1-USBinstall](http://10.100.12.157/tests/1012#step/zypper_lr/3) | [sle-12-SP4-USBinstall](http://10.100.12.157/tests/1013#step/zypper_lr/3)

Requires to setup in the corresponding test suite after merging:
```
INSTALLATION_VALIDATION=console/enable_usb_repo,console/zypper_lr 
INSTALLONLY=1
```