### PR TITLE
Enhance VMware support

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1049,7 +1049,7 @@ sub load_consoletests {
     loadtest 'qa_automation/patch_and_reboot' if is_updates_tests && !get_var('QAM_MINIMAL');
     loadtest "console/system_prepare";
     loadtest "console/consoletest_setup";
-    loadtest 'console/integration_services' if is_hyperv;
+    loadtest 'console/integration_services' if is_hyperv || is_vmware;
     loadtest "locale/keymap_or_locale";
     loadtest "console/repo_orphaned_packages_check" if is_jeos;
     loadtest "console/force_scheduled_tasks" unless is_jeos;
@@ -1322,7 +1322,7 @@ sub load_yast2_ncurses_tests {
     boot_hdd_image;
     # setup $serialdev permission and so on
     loadtest "console/consoletest_setup";
-    loadtest 'console/integration_services' if is_hyperv;
+    loadtest 'console/integration_services' if is_hyperv || is_vmware;
     loadtest "console/hostname";
     loadtest "console/zypper_lr";
     loadtest "console/zypper_ref";
@@ -1551,7 +1551,7 @@ sub load_extra_tests {
 
     # setup $serialdev permission and so on
     loadtest "console/consoletest_setup";
-    loadtest 'console/integration_services' if is_hyperv;
+    loadtest 'console/integration_services' if is_hyperv || is_vmware;
     loadtest "console/hostname";
     # Extra tests are too long, split the test into subtest according to the
     # EXTRATEST variable; to maintain compatibility, run all tests if the
@@ -1622,7 +1622,7 @@ sub load_filesystem_tests {
     # setup $serialdev permission and so on
     loadtest "console/system_prepare";
     loadtest "console/consoletest_setup";
-    loadtest 'console/integration_services' if is_hyperv;
+    loadtest 'console/integration_services' if is_hyperv || is_vmware;
     loadtest "console/hostname";
     if (get_var("FILESYSTEM", "btrfs") eq "btrfs") {
         loadtest "console/snapper_jeos_cli" if is_jeos;
@@ -2061,7 +2061,7 @@ sub load_system_prepare_tests {
     loadtest 'ses/install_ses' if check_var_array('ADDONS', 'ses') || check_var_array('SCC_ADDONS', 'ses');
     # temporary adding test modules which applies hacks for missing parts in sle15
     loadtest 'console/sle15_workarounds' if is_sle('15+');
-    loadtest 'console/integration_services' if is_hyperv;
+    loadtest 'console/integration_services' if is_hyperv || is_vmware;
     loadtest 'console/hostname' unless is_bridged_networking;
     loadtest 'console/system_prepare';
     loadtest 'console/force_scheduled_tasks' unless is_jeos;

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -121,7 +121,8 @@ done", "binaries-with-missing-libraries.txt", {timeout => 60, noupload => 1});
 
     # VMware specific
     if (check_var('VIRSH_VMM_FAMILY', 'vmware')) {
-        $self->save_and_upload_log('systemctl status vmtoolsd vgauthd', "vmware-services.txt", {screenshot => 1, noupload => 1});
+        assert_script_run('vm-support');
+        upload_logs('vm-*.*.tar.gz');
         clear_console;
     }
 

--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -312,7 +312,7 @@ sub assert_shutdown_with_soft_timeout {
     $args->{soft_timeout} //= 0;
     $args->{bugref}       //= "No bugref specified";
     if ($args->{soft_timeout}) {
-        diag($args->{soft_timeout});
+        diag("assert_shutdown_with_soft_timeout(): soft_timeout=" . $args->{soft_timeout});
         die "soft timeout has to be smaller than timeout" unless ($args->{soft_timeout} < $args->{timeout});
         my $ret = check_shutdown $args->{soft_timeout};
         return if $ret;

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -719,6 +719,10 @@ sub console_selected {
     $args{await_console} //= 1;
     $args{tags}          //= $console;
     $args{ignore}        //= qr{sut|root-virtio-terminal|iucvconn|svirt|root-ssh|hyperv-intermediary};
+    # If we connect to 'sut' VNC display "too early" the VNC server won't be
+    # ready and we will be left with a blank screen.
+    sleep 5 if check_var('VIRSH_VMM_FAMILY', 'vmware') && $console eq 'sut';
+
     if ($args{tags} =~ $args{ignore} || !$args{await_console}) {
         set_var('CONSOLE_JUST_ACTIVATED', 0);
         return;

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -46,6 +46,7 @@ use constant {
     ],
     BACKEND => [
         qw(
+          is_vmware
           is_hyperv
           is_hyperv_in_gui
           is_aarch64_uefi_boot_hdd
@@ -85,6 +86,10 @@ sub is_leap;
 
 sub is_jeos {
     return get_var('FLAVOR', '') =~ /^JeOS/;
+}
+
+sub is_vmware {
+    return check_var('VIRSH_VMM_FAMILY', 'vmware');
 }
 
 sub is_hyperv {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -17,7 +17,7 @@ use registration;
 use utils;
 use mmapi 'get_parents';
 use version_utils
-  qw(is_hyperv is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem is_desktop_installed is_jeos is_sle is_staging is_upgrade);
+  qw(is_vmware is_hyperv is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem is_desktop_installed is_jeos is_sle is_staging is_upgrade);
 use File::Find;
 use File::Basename;
 use LWP::Simple 'head';
@@ -1110,7 +1110,7 @@ else {
         if (get_var("INSTALLONLY")) {
             loadtest "console/system_prepare";
             loadtest "console/consoletest_setup";
-            loadtest 'console/integration_services' if is_hyperv;
+            loadtest 'console/integration_services' if is_hyperv || is_vmware;
             loadtest "console/zypper_lr";
         }
     }

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -38,6 +38,12 @@ sub run {
     my $name  = $svirt->name;
     my $repo;
 
+    # Clear datastore on VMware host
+    if (check_var('VIRSH_VMM_FAMILY', 'vmware')) {
+        my $vmware_openqa_datastore = "/vmfs/volumes/" . get_required_var('VMWARE_DATASTORE') . "/openQA/";
+        $svirt->get_cmd_output("set -x; rm -f ${vmware_openqa_datastore}*${name}*", {domain => 'sshVMwareServer'});
+    }
+
     # Workaround before fix in svirt (https://github.com/os-autoinst/os-autoinst/pull/901) is deployed
     my $n = get_var('NUMDISKS', 1);
     set_var('NUMDISKS', defined get_var('RAIDLEVEL') ? 4 : $n);
@@ -60,6 +66,7 @@ sub run {
     }
 
     # Unless os-autoinst PR#956 is deployed we have to remove 'on_reboot' first
+    # This has no effect on VMware ('restart' is kept).
     $svirt->change_domain_element(on_reboot => undef);
     $svirt->change_domain_element(on_reboot => 'destroy');
 
@@ -260,6 +267,10 @@ sub run {
 
     # connects to a guest VNC session
     select_console('sut', await_console => 0);
+}
+
+sub test_flags {
+    return {fatal => 1};
 }
 
 1;

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -79,7 +79,7 @@ sub run {
         $svirt->add_disk(
             {
                 cdrom  => 1,
-                file   => ($vmm_family eq 'vmware') ? basename($isopath) : $isopath,
+                file   => $isopath,
                 dev_id => $dev_id
             });
         $dev_id = chr((ord $dev_id) + 1);    # return next letter in alphabet
@@ -91,7 +91,7 @@ sub run {
             $svirt->add_disk(
                 {
                     cdrom  => 1,
-                    file   => ($vmm_family eq 'vmware') ? basename($addon_isopath) : $addon_isopath,
+                    file   => $addon_isopath,
                     dev_id => $dev_id
                 });
             $dev_id = chr((ord $dev_id) + 1);    # return next letter in alphabet
@@ -107,7 +107,7 @@ sub run {
                 {
                     backingfile => 1,
                     dev_id      => $dev_id,
-                    file        => ($vmm_family eq 'vmware') ? basename($hddpath) : $hddpath
+                    file        => $hddpath
                 });
         }
         else {

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -258,10 +258,6 @@ sub run {
         save_screenshot;
     }
 
-    # If we connect to 'sut' VNC display "too early" the VNC server won't be
-    # ready we will be left with a blank screen.
-    sleep 2 if $vmm_family eq 'vmware';
-
     # connects to a guest VNC session
     select_console('sut', await_console => 0);
 }

--- a/tests/jeos/revive_xen_domain.pm
+++ b/tests/jeos/revive_xen_domain.pm
@@ -22,7 +22,6 @@ sub run {
     power_action('reboot');
     # If we connect to 'sut' VNC display "too early" the VNC server won't be
     # ready we will be left with a blank screen.
-    sleep 2 if check_var('VIRSH_VMM_FAMILY', 'vmware');
     if (check_var('VIRSH_VMM_TYPE', 'hvm')) {
         $self->wait_boot;
     }


### PR DESCRIPTION
https://trello.com/c/O104uCeQ/178-p1-vmware-guest-install-support-in-openqa

This brings VMware via svirt support up-to-date.

Validation runs (it's enough that VM boots):
* default_install@svirt-vmware: http://nilgiri.suse.cz/tests/1951
* jeos-extratest@svirt-vmware: http://nilgiri.suse.cz/tests/1999
* jeos-main@svirt-vmware: http://nilgiri.suse.cz/tests/1998

Regression testing (it's enough that VM boots):
* jeos-extratest@svirt-xen-pv: http://nilgiri.suse.cz/tests/2003
* allpatterns@svirt-xen-hvm: http://nilgiri.suse.cz/tests/2002

Backend changes (but this can be merged independently): 