### PR TITLE
Move multipath to separate step for ZFCP

### DIFF
--- a/tests/installation/disk_activation.pm
+++ b/tests/installation/disk_activation.pm
@@ -111,12 +111,6 @@ sub run {
     }
     assert_screen 'disk-activation', 15;
     send_key $cmd{next};
-
-    # check for multipath popup
-    if (check_screen('detected-multipath', 10)) {
-        wait_screen_change { send_key 'alt-y' };
-        send_key 'alt-n';
-    }
 }
 
 1;

--- a/tests/installation/multipath.pm
+++ b/tests/installation/multipath.pm
@@ -17,7 +17,7 @@ use strict;
 use testapi;
 
 sub run {
-    assert_screen "enable-multipath", 15;
+    assert_screen "enable-multipath";
     send_key "alt-y";
 }
 


### PR DESCRIPTION
We have MULTIPATH variable, which is always the case for ZFCP. So
removing static check and modifying test suite to have this setting.

See [poo#43850](https://progress.opensuse.org/issues/43850).

[Verification run](http://g226.suse.de/tests/3258#).
[Needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1016).

Currently fails due to [bsc#1117975](https://bugzilla.suse.com/show_bug.cgi?id=1117975), but modified step passes and we are able to click yes.
