### PR TITLE
Add workaround for Libre Office Impress starting without focus on 12-SP4

### DIFF
--- a/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
@@ -77,8 +77,13 @@ sub run {
 
         $self->open_mainmenu();
         assert_and_click 'mainmenu-office-impress';    #open impress
-        assert_screen [qw(ooimpress-select-a-template ooimpress-launched)];
-        if (match_has_tag 'ooimpress-select-a-template') {
+        assert_screen [qw(ooimpress-select-a-template ooimpress-select-template-nofocus ooimpress-launched)];
+        if (match_has_tag 'ooimpress-select-template-nofocus') {
+            assert_and_click 'ooimpress-select-template-nofocus';
+            send_key 'alt-f4';
+            assert_screen 'ooimpress-launched';
+        }
+        elsif (match_has_tag 'ooimpress-select-a-template') {
             send_key 'alt-f4';                         # close impress template window
             assert_screen 'ooimpress-launched';
         }
@@ -128,8 +133,13 @@ sub run {
     type_string "impress";                                                           #open impress
     assert_screen 'overview-office-impress';
     send_key "ret";
-    assert_screen [qw(ooimpress-select-a-template ooimpress-launched)];
-    if (match_has_tag 'ooimpress-select-a-template') {
+    assert_screen [qw(ooimpress-select-a-template ooimpress-select-template-nofocus ooimpress-launched)];
+    if (match_has_tag 'ooimpress-select-template-nofocus') {
+        assert_and_click 'ooimpress-select-template-nofocus';
+        send_key 'alt-f4';
+        assert_screen 'ooimpress-launched';
+    }
+    elsif (match_has_tag 'ooimpress-select-a-template') {
         send_key 'alt-f4';                                                           # close impress template window
         assert_screen 'ooimpress-launched';
     }


### PR DESCRIPTION
This workaround detects whether Libre Office Impress has started up with an inactive pop up dialog, and if so, clicks into the window to facilitate its closing.

Context: Upon starting Libre Office Impress, it shows a pop up dialog offering to select a template. With the new Libre Office version (on 12-SP4), this dialog shows up greyed out without focus and requires user to interact with it first, even just to be able to simply close it.

The issue will be reported upstream so they can decide how/if they want to fix it. This test code adjustment is supposed to mark the test soft-failed until then (the soft failure is recorded via the soft-fail-marked needle).

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1117194
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1017/
- Verification run: 
   - Softfailing on SP4 (without focus): http://dreamyhamster.suse.cz/tests/244#step/libreoffice_mainmenu_components/33
   - Passing normally on SLE15: http://dreamyhamster.suse.cz/tests/246#step/libreoffice_mainmenu_components/22