### PR TITLE
Double sync wait time for some low performance machine

### DIFF
--- a/tests/qa_automation/execute_test_run.pm
+++ b/tests/qa_automation/execute_test_run.pm
@@ -34,7 +34,7 @@ sub run {
 
     #output result to serial0 and upload test log
     if (get_var("QA_TESTSUITE")) {
-        assert_script_run("sync");
+        assert_script_run('sync', 180);
         my $tarball = "/tmp/testlog.tar.bz2";
         assert_script_run("tar cjf $tarball -C /var/log/qa/ctcs2 `ls /var/log/qa/ctcs2/`");
         upload_logs($tarball, timeout => 600);


### PR DESCRIPTION
After stress tests some low performance machine need more time for sync, in around 10% chance it will time out by default 90 second for sync. Double time for this process, will not influence those fast machine, and will adapt those slow machine.
To solve some problem like: https://openqa.suse.de/tests/2296759#step/execute_test_run/6