### PR TITLE
Move barriers for Salt and openVPN to main.pm

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1035,10 +1035,18 @@ else {
         return 1;
     }
     elsif (get_var("QAM_OPENVPN")) {
+        set_var('INSTALLONLY', 1);
+        if (check_var('HOSTNAME', 'server')) {
+            barrier_create('OPENVPN_STATIC_START',    2);
+            barrier_create('OPENVPN_STATIC_STARTED',  2);
+            barrier_create('OPENVPN_STATIC_FINISHED', 2);
+            barrier_create('OPENVPN_CA_START',        2);
+            barrier_create('OPENVPN_CA_STARTED',      2);
+            barrier_create('OPENVPN_CA_FINISHED',     2);
+        }
         boot_hdd_image;
         loadtest 'network/setup_multimachine';
         loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
-        set_var('INSTALLONLY', 1);
         if (check_var('HOSTNAME', 'server')) {
             loadtest "network/openvpn_server";
         }
@@ -1047,10 +1055,14 @@ else {
         }
     }
     elsif (get_var("QAM_SALT")) {
+        set_var('INSTALLONLY', 1);
+        if (check_var('HOSTNAME', 'master')) {
+            barrier_create('SALT_MINIONS_READY', 2);
+            barrier_create('SALT_FINISHED',      2);
+        }
         boot_hdd_image;
         loadtest 'network/setup_multimachine';
         loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
-        set_var('INSTALLONLY', 1);
         if (check_var('HOSTNAME', 'master')) {
             loadtest "network/salt_master";
         }

--- a/tests/network/openvpn_server.pm
+++ b/tests/network/openvpn_server.pm
@@ -20,12 +20,6 @@ use utils qw(systemctl zypper_call exec_and_insert_password);
 use strict;
 
 sub run {
-    barrier_create('OPENVPN_STATIC_START',    2);
-    barrier_create('OPENVPN_STATIC_STARTED',  2);
-    barrier_create('OPENVPN_STATIC_FINISHED', 2);
-    barrier_create('OPENVPN_CA_START',        2);
-    barrier_create('OPENVPN_CA_STARTED',      2);
-    barrier_create('OPENVPN_CA_FINISHED',     2);
     select_console "root-console";
 
     my $qa_head_repo = get_var('QA_HEAD_REPO', '');

--- a/tests/network/salt_master.pm
+++ b/tests/network/salt_master.pm
@@ -19,8 +19,6 @@ use y2x11test 'setup_static_mm_network';
 use utils qw(zypper_call systemctl);
 
 sub run {
-    barrier_create('SALT_MINIONS_READY', 2);
-    barrier_create('SALT_FINISHED',      2);
     select_console 'root-console';
 
     # Install both salt master and minion and run the master daemon


### PR DESCRIPTION
Because of bad timing I had to move barriers used in `console/openvpn_*` and `console/salt_*` to `main.pm`.

- Related ticket: [poo#44270](https://progress.opensuse.org/issues/44270)
- Needles: No need
- Verification run: [salt_master](http://pdostal-server.suse.cz/tests/371) / [salt_minion](http://pdostal-server.suse.cz/tests/372) & [openvpn_server](http://pdostal-server.suse.cz/tests/373) / [openvpn_client](http://pdostal-server.suse.cz/tests/374)
