### PR TITLE
Improve function name to load_transactional_role_tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -75,7 +75,7 @@ our @EXPORT = qw(
   load_nfv_master_tests
   load_nfv_trafficgen_tests
   load_public_cloud_patterns_validation_tests
-  load_readonly_fs_tests
+  load_transactional_role_tests
   load_reboot_tests
   load_rescuecd_tests
   load_rollback_tests
@@ -2301,7 +2301,7 @@ sub load_public_cloud_patterns_validation_tests {
     loadtest "console/consoletest_finish";
 }
 
-sub load_readonly_fs_tests {
+sub load_transactional_role_tests {
     loadtest 'caasp/filesystem_ro';
     loadtest 'caasp/transactional_update';
     loadtest 'caasp/rebootmgr';

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -128,7 +128,7 @@ sub load_feature_tests {
     loadtest 'caasp/one_line_checks';
     loadtest 'caasp/nfs_client' if get_var('NFS_SHARE');
 
-    load_readonly_fs_tests;
+    load_transactional_role_tests;
 
     # Tests that require registered system
     if (get_var 'REGISTER') {

--- a/products/kubic/main.pm
+++ b/products/kubic/main.pm
@@ -33,7 +33,7 @@ sub load_feature_tests {
     loadtest 'caasp/libzypp_config';
     loadtest 'caasp/one_line_checks';
     loadtest 'caasp/services_enabled';
-    load_readonly_fs_tests;
+    load_transactional_role_tests;
     loadtest 'caasp/journal_check';
 }
 


### PR DESCRIPTION
As suggested in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6321#issuecomment-443629179

- Related ticket: https://progress.opensuse.org/issues/42929
- Verification run: http://slindomansilla-vm.qa.suse.de/tests/995
