### PR TITLE
Fix additional ant issues

### DIFF
--- a/tests/console/ant.pm
+++ b/tests/console/ant.pm
@@ -82,7 +82,8 @@ sub run {
     zypper_call 'in ant';
 
     # Set JAVA_HOME to the jdk installation directory
-    assert_script_run("export JAVA_HOME=`update-alternatives --list javac| awk -F 'bin' '{split(\$0, a); print a[1]}'`");
+    assert_script_run("export JAVA_HOME=/usr/lib64/jvm/java");
+    assert_script_run("export ANT_HOME=/usr/share/ant");
 
     # Set up
     assert_script_run "mkdir $dir";


### PR DESCRIPTION
Fixes additional issues for the apache ant regression test.

- Related ticket: https://progress.opensuse.org/issues/44453#change-169544
- Needles: No needles
- Verification run:
sle 15: http://morgoth.suse.cz/tests/404#step/ant/22
sle 12sp4: http://morgoth.suse.cz/tests/405#step/ant/22
sle 12sp3: http://morgoth.suse.cz/tests/406#step/ant/22
sle 12sp2: http://morgoth.suse.cz/tests/407#step/ant/22
sle 12sp1: http://morgoth.suse.cz/tests/408#step/ant/22
