### PR TITLE
Revise module "selinux_setup" with softfail

### DIFF
--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -32,7 +32,16 @@ sub run {
     }
 
     # program 'sestatus' can be found in policycoreutils pkgs
-    zypper_call("in policycoreutils policycoreutils-python");
+    zypper_call("in policycoreutils");
+    my $ret = script_run('zypper -n in policycoreutils-python');
+    if ($ret) {
+        if (defined $ret && $ret == 104) {
+            record_soft_failure 'bsc#1116288 - package policycoreutils-python not found in module SLE-Module-Development-Tools';
+        }
+        else {
+            die "Package policycoreutils-python installation failed";
+        }
+    }
 
     my $pkgs = script_output("echo `zypper se selinux | grep -i selinux | grep -v -w srcpackage | cut -d '|' -f 2`");
     zypper_call("in $pkgs", timeout => 3000);


### PR DESCRIPTION
Revise module "selinux_setup" with softfail as it will block the following test case's run.

- Related ticket: https://progress.opensuse.org/issues/44567
- Needles: no
- Verification run: http://10.67.19.89/tests/399
   "selinux_setup" is soft failed now and tracked by bsc#1116288
   "sestatus" and "selinux_smoke" are failed and both are tracked by bsc#1118288
