### PR TITLE
Substitute lib64 from ant.pm

### DIFF
--- a/tests/console/ant.pm
+++ b/tests/console/ant.pm
@@ -82,7 +82,8 @@ sub run {
     zypper_call 'in ant';
 
     # Set JAVA_HOME to the jdk installation directory
-    assert_script_run("export JAVA_HOME=`update-alternatives --list javac| awk -F 'bin' '{split(\$0, a); print a[1]}'`");
+    assert_script_run("export JAVA_HOME=`update-alternatives --list javac| awk -F 'java' '{split(\$0, a); print a[1]; exit}'`'java'");
+    assert_script_run("export ANT_HOME=/usr/share/ant");
 
     # Set up
     assert_script_run "mkdir $dir";


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/44453#change-169544
- Needles: No needles
- Verification run:
sle15: http://morgoth.suse.cz/tests/447#step/ant/22
sle12sp4: http://morgoth.suse.cz/tests/446#step/ant/22
sle12sp3: http://morgoth.suse.cz/tests/445#step/ant/22
sle12sp2: http://morgoth.suse.cz/tests/444#step/ant/22
sle12sp1: http://morgoth.suse.cz/tests/443#step/ant/22