### PR TITLE
Minor fixes for HA migration tests

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -118,10 +118,9 @@ sub check_rsc {
 
 sub ensure_process_running {
     my $process   = shift;
-    my $timeout   = 30;
+    my $timeout   = 30 * get_var('TIMEOUT_SCALE', 1);
     my $starttime = time;
     my $ret       = undef;
-    $timeout *= get_var('TIMEOUT_SCALE', 1);
 
     while ($ret = script_run "ps -A | grep -q '\\<$process\\>'") {
         my $timerun = time - $starttime;
@@ -139,10 +138,9 @@ sub ensure_process_running {
 
 sub ensure_resource_running {
     my ($rsc, $regex) = @_;
-    my $timeout   = 30;
+    my $timeout   = 30 * get_var('TIMEOUT_SCALE', 1);
     my $starttime = time;
     my $ret       = undef;
-    $timeout *= get_var('TIMEOUT_SCALE', 1);
 
     while ($ret = script_run "crm resource status $rsc | grep -E -q '$regex'") {
         my $timerun = time - $starttime;
@@ -252,9 +250,8 @@ sub check_cluster_state {
 sub wait_until_resources_started {
     my @cmds = ('crm cluster wait_for_startup');
     push @cmds, "$crm_mon_cmd | grep -i 'no inactive resources'" if is_sle '12-sp3+';
-    my $timeout = 120;
-    my $ret     = undef;
-    $timeout *= get_var('TIMEOUT_SCALE', 1);
+    my $timeout = 120 * get_var('TIMEOUT_SCALE', 1);
+    my $ret = undef;
 
     # Execute each comnmand to validate that the cluster is running
     # This can takes time, so a loop is a good idea here

--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -121,6 +121,7 @@ sub ensure_process_running {
     my $timeout   = 30;
     my $starttime = time;
     my $ret       = undef;
+    $timeout *= get_var('TIMEOUT_SCALE', 1);
 
     while ($ret = script_run "ps -A | grep -q '\\<$process\\>'") {
         my $timerun = time - $starttime;
@@ -141,6 +142,7 @@ sub ensure_resource_running {
     my $timeout   = 30;
     my $starttime = time;
     my $ret       = undef;
+    $timeout *= get_var('TIMEOUT_SCALE', 1);
 
     while ($ret = script_run "crm resource status $rsc | grep -E -q '$regex'") {
         my $timerun = time - $starttime;
@@ -252,6 +254,7 @@ sub wait_until_resources_started {
     push @cmds, "$crm_mon_cmd | grep -i 'no inactive resources'" if is_sle '12-sp3+';
     my $timeout = 120;
     my $ret     = undef;
+    $timeout *= get_var('TIMEOUT_SCALE', 1);
 
     # Execute each comnmand to validate that the cluster is running
     # This can takes time, so a loop is a good idea here

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -18,6 +18,8 @@ use hacluster;
 
 sub run {
     my $cluster_name = get_cluster_name;
+    # In ppc64le and aarch64, workers are slower
+    set_var('TIMEOUT_SCALE', 2) unless (check_var('ARCH', 'x86_64'));
 
     # Check cluster state *after* reboot
     barrier_wait("CHECK_AFTER_REBOOT_BEGIN_$cluster_name");

--- a/tests/ha/upgrade_from_sle11sp4_workarounds.pm
+++ b/tests/ha/upgrade_from_sle11sp4_workarounds.pm
@@ -35,9 +35,7 @@ sub run {
     # to /etc/hosts if name resolution is failing
     if (is_node(1) or is_node(2)) {
         my $hostname = get_hostname;
-        my $partner  = $hostname;
-        $partner =~ s/node([0-9]+)$/node/;
-        $partner = $1 eq '01' ? $partner . "02" : $partner . "01";
+        my $partner = is_node(1) ? choose_node(2) : choose_node(1);
 
         my $ret_q1 = script_run "host $hostname";
         my $ret_q2 = script_run "host $partner";

--- a/tests/ha/upgrade_from_sle11sp4_workarounds.pm
+++ b/tests/ha/upgrade_from_sle11sp4_workarounds.pm
@@ -44,10 +44,11 @@ sub run {
             record_info "Name resolution failing", "Cannot resolve own name or name of partner. Will attempt to add hosts to /etc/hosts", result => 'softfail';
             my $device = get_var('SUT_NETDEVICE', 'eth0');
             my $addr = script_output "ip -4 addr show dev $device | sed -rne '/inet/s/[[:blank:]]*inet ([0-9\\.]*).*/\\1/p'";
-            if ($addr =~ m/10\.0\.2/) {    # Expected addresses are 10.0.2.17 and 10.0.2.18
+            if ($addr =~ m/10\.0\.2/) {    # Expected addresses are in 10.0.2/24 and start with 10.0.2.15
                 assert_script_run "echo \"$addr  $hostname\" >> /etc/hosts";
                 $addr =~ s/\.([0-9]+)$/\./;
-                $addr = $1 eq '17' ? $addr . "18" : $addr . "17";
+                $addr = $addr . sprintf("%02d", $1 + 1) if ($1 % 2);
+                $addr = $addr . sprintf("%02d", $1 - 1) if (!($1 % 2));
                 assert_script_run "echo \"$addr  $partner\" >> /etc/hosts";
             }
             else {


### PR DESCRIPTION
This pull request addresses 2 problems with SLES+HA migration tests in openqa.suse.de:

1. In a 2-node cluster migration from SLES+HA 11-SP4, host name resolution is required earlier than in the same tests from SLES+HA 12 or 15, because some configuration tasks need to be performed  in the cluster right after migration due to the changes in the HA stack. Most HA tests rely on Multi Machine mode in openQA and perform name resolution via the DNS service provided by the support server, but in certain scenarios (see failing tests below) this service is not available or not responsive. This workaround adds the hostnames to `/etc/hosts` so that the test can continue when DNS name
resolution is failing.
2. `ppc64le` and `aarch64` workers in openqa.suse.de are slower than in `x86_64`, so this adds a `TIMEOUT_SCALE` of 2 for the tests in those architectures.

- Related ticket: N/A
- Failing tests: https://openqa.suse.de/tests/2296695#step/upgrade_from_sle11sp4_workarounds/19, https://openqa.suse.de/tests/2298579#step/upgrade_from_sle11sp4_workarounds/17, https://openqa.suse.de/tests/2298200#step/check_after_reboot/4 (ppc64le worker)
- Needles: N/A
- Verification run: http://1b147.qa.suse.de/tests/4175 (HA alpha-node01), http://1b147.qa.suse.de/tests/4174 (HA alpha-node02), http://1b147.qa.suse.de/tests/4173 (support server)
