### PR TITLE
Add SLE12SP4 to docker_image and increase some timeouts

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1539,7 +1539,7 @@ sub load_extra_tests_docker {
     return unless is_sle('12-SP3+') || !is_sle;
     loadtest "console/docker";
     loadtest "console/docker_runc";
-    if (is_sle('=12-SP3')) {
+    if (is_sle('12-SP3+')) {
         loadtest "console/sle2docker";
         loadtest "console/docker_image";
     }

--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -53,7 +53,7 @@ sub run {
     test_seccomp();
 
     # images can be searched on the Docker Hub
-    validate_script_output("docker search --no-trunc opensuse", sub { m/This project contains the stable releases of the openSUSE distribution/ });
+    validate_script_output("docker search --no-trunc opensuse", sub { m/This project contains the stable releases of the openSUSE distribution/ }, 120);
 
     # images can be pulled from the Docker Hub
     #   - pull minimalistic alpine image of declared version using tag


### PR DESCRIPTION
The *SLE 12 SP 4 docker base image* is here so we need to test it:
 * Internal repository: `registry.suse.de/suse/sle-12-sp4/docker/update/cr/images/suse/sles12sp4:latest`
 * Public repository: `registry.suse.com/suse/sles12sp4:latest`

- Related ticket: [poo#36775](https://progress.opensuse.org/issues/36775)
- Needles: No need for those.
- Verification run: [SLE12SP4](http://pdostal-server.suse.cz/tests/481) [SLE15](http://pdostal-server.suse.cz/tests/483) [Leap15](http://pdostal-server.suse.cz/tests/489) [42.3](http://pdostal-server.suse.cz/tests/488) [Tumbleweed](http://pdostal-server.suse.cz/tests/491)
