### PR TITLE
publiccloud: create images in the same storage account in Azure Cloud

### DIFF
--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -31,7 +31,7 @@ sub run {
     my ($img_name) = $img_url =~ /([^\/]+)$/;
 
     if (my $img_id = $provider->find_img($img_name)) {
-        record_info('Info', "Image $img_name already exists!");
+        record_info('Info', "Image $img_id already exists!");
         return;
     }
 


### PR DESCRIPTION
Creating a new resource group every time we upload a new image is not efficient, because it consumes many resources in Azure, like creating also a storage account, container, etc. This way, we have a fixed resource group and storage accounts where we will upload our images. 

This will make easier to retrieve the needed images later on since all of them will be in the same storage container. For example, this will help the terraform integration.

upload image (create resources): http://fromm.arch.suse.de/tests/4352
upload image (existing image): http://fromm.arch.suse.de/tests/4361
ipa tests: http://fromm.arch.suse.de/tests/4362