### PR TITLE
Add test cases for RDP remote desktop (poo#33493)

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1838,6 +1838,21 @@ sub load_x11_remote {
     elsif (check_var('REMOTE_DESKTOP_TYPE', 'vino_client')) {
         loadtest 'x11/remote_desktop/vino_client';
     }
+    # load xrdp testing
+    elsif (check_var('REMOTE_DESKTOP_TYPE', 'win_client')) {
+        loadtest 'x11/remote_desktop/windows_network_setup';
+        loadtest 'x11/remote_desktop/windows_client_remotelogin';
+    }
+    elsif (check_var('REMOTE_DESKTOP_TYPE', 'xrdp_server')) {
+        loadtest 'x11/remote_desktop/xrdp_server';
+    }
+    elsif (check_var('REMOTE_DESKTOP_TYPE', 'xrdp_client')) {
+        loadtest 'x11/remote_desktop/xrdp_client';
+    }
+    elsif (check_var('REMOTE_DESKTOP_TYPE', 'win_server')) {
+        loadtest 'x11/remote_desktop/windows_network_setup';
+        loadtest 'x11/remote_desktop/windows_server_setup';
+    }
 }
 
 
@@ -1873,8 +1888,12 @@ sub load_common_x11 {
         load_x11_message();
     }
     elsif (check_var('REGRESSION', 'remote')) {
-        loadtest 'boot/boot_to_desktop';
-        loadtest "x11/window_system";
+        if (check_var("REMOTE_DESKTOP_TYPE", "win_client") || check_var('REMOTE_DESKTOP_TYPE', "win_server")) {
+            loadtest "x11/remote_desktop/windows_client_boot";
+        } else {
+            loadtest 'boot/boot_to_desktop';
+            loadtest "x11/window_system";
+        }
         load_x11_remote();
     }
     elsif (check_var("REGRESSION", "piglit")) {

--- a/tests/x11/remote_desktop/windows_client_boot.pm
+++ b/tests/x11/remote_desktop/windows_client_boot.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Boot into MS Windows from grub
+# Maintainer: GraceWang <gwang@suse.com>
+
+use base "y2logsstep";
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+    $self->{in_boot_desktop} = 1;
+
+    assert_screen "grub-boot-windows", 300;
+    send_key "esc";
+    assert_screen "windows-login", 300;
+    type_password;
+    send_key "ret";
+    assert_screen 'windows-desktop', 120;
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/x11/remote_desktop/windows_client_remotelogin.pm
+++ b/tests/x11/remote_desktop/windows_client_remotelogin.pm
@@ -1,0 +1,48 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Remote Login: Windows access openSUSE/SLE over RDP
+# Maintainer: GraceWang <gwang@suse.com>
+# Tags: tc#1610388
+
+use strict;
+use base 'x11test';
+use testapi;
+use lockapi;
+
+sub run {
+    my $self = shift;
+
+    mutex_lock 'xrdp_server_ready';
+
+    send_key "super-r";
+    assert_screen "windows-run";
+    type_string "mstsc\n";
+    assert_screen "remote-desktop-connection";
+    type_string '10.0.2.17';
+    assert_screen "remote-ip-filled";
+    send_key 'ret';
+    assert_screen "verify-identity", 90;
+    send_key 'y';
+
+    assert_screen "xrdp-login-screen";
+    type_string $username;    # input account name
+    send_key "tab";
+    type_password;
+    wait_still_screen 3;
+    send_key "ret";
+
+    assert_screen "xrdp-sharing-activate", 120;
+    assert_and_click "close-xrdp-sharing-window";
+    assert_and_click "confirm-close-remote-session";
+    assert_and_click "close-remote-desktop-connection";
+
+    send_key "c";
+}
+1;

--- a/tests/x11/remote_desktop/windows_network_setup.pm
+++ b/tests/x11/remote_desktop/windows_network_setup.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Remote Login: Windows access openSUSE/SLE over RDP
+# Maintainer: GraceWang <gwang@suse.com>
+# Tags: tc#1610388
+
+use strict;
+use base 'x11test';
+use testapi;
+use lockapi;
+
+sub run {
+    my $self = shift;
+
+    send_key "super-x";
+    assert_and_click "windows-powershell-admin";
+    assert_and_click "windows-powershell-yes";
+
+    type_string "netsh interface ip set address name=Ethernet static 10.0.2.18 255.255.255.0 10.0.2.2";
+    send_key "ret";
+
+    assert_screen "network-allow-discovered";
+    assert_and_click "network-discovered-yes";
+
+    type_string "netsh interface ip set dns Ethernet static 10.67.0.2";
+    send_key "ret";
+
+    type_string "ping 10.0.2.2";
+    send_key "ret";
+    type_string "exit";
+    send_key "ret";
+}
+1;

--- a/tests/x11/remote_desktop/windows_server_setup.pm
+++ b/tests/x11/remote_desktop/windows_server_setup.pm
@@ -1,0 +1,53 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Remote Login: SLED access Windows over RDP
+# Maintainer: GraceWang <gwang@suse.com>
+# Tags: tc#1610392
+
+use strict;
+use base 'x11test';
+use testapi;
+use lockapi;
+use mmapi 'wait_for_children';
+
+sub run {
+    my $self = shift;
+
+    assert_and_click "start";
+    type_string "remote access\n";
+
+    assert_and_click "allow-remote-connections";
+    assert_screen "allow-connections-with-nla-enabled";
+
+    if (!get_var('NLA')) {
+        send_key "alt-n";
+        assert_screen "allow-connections-without-nla-enabled";
+    }
+
+    assert_and_click "system-properties-ok";
+
+    mutex_create 'win_server_ready';
+    wait_for_children;
+
+    # In case execute the client job costs too much time
+    # Add this part to deal with the lock screen
+
+    assert_screen(['grub-boot-windows', 'update-required', 'generic-desktop']);
+    if (match_has_tag 'grub-boot-windows') {
+        send_key "esc";
+        assert_screen "windows-login";
+        type_password;
+        send_key "ret";
+    }
+    elsif (match_has_tag 'update-required') {
+        assert_and_click "close-update-required";
+    }
+}
+1;

--- a/tests/x11/remote_desktop/xrdp_client.pm
+++ b/tests/x11/remote_desktop/xrdp_client.pm
@@ -1,0 +1,62 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Remote Login: SLED access Windows over RDP
+# Maintainer: GraceWang <gwang@suse.com>
+# Tags: tc#1610392
+
+use strict;
+use base 'x11test';
+use testapi;
+use lockapi;
+use mmapi;
+use mm_tests;
+
+sub run {
+    my $self = shift;
+
+    # Setup static NETWORK
+    $self->configure_static_ip_nm('10.0.2.17/24');
+
+    mutex_lock 'win_server_ready';
+
+    # Start Remmina and login the remote server
+    x11_start_program('remmina', target_match => 'remmina-launched');
+    type_string '10.0.2.18';
+    send_key 'ret';
+    wait_still_screen 3;
+    send_key 'alt-o';
+
+    # input account name
+    wait_still_screen 3;
+
+    # We can not use the variable $realname here
+    # Since the windows username limit is 20 characters
+    # The username in windows is different from the $realname
+    type_string "Bernhard M. Wiedeman";
+    send_key "tab";
+    type_password;
+    wait_still_screen 3;
+    send_key "ret";
+
+    wait_still_screen 3;
+    assert_screen [qw(connection-failed windows-desktop-on-remmina)];
+    if (match_has_tag 'connection-failed') {
+        record_soft_failure 'bsc#1117402 - Remmina is not able to connect to the windows server';
+        send_key "alt-f4";
+    }
+    else {
+        assert_and_click "close-remote-connection";
+    }
+
+    # close remmina and clean the preferences file
+    send_key "alt-f4";
+    x11_start_program('rm ~/.config/remmina/remmina.pref', valid => 0);
+}
+1;

--- a/tests/x11/remote_desktop/xrdp_server.pm
+++ b/tests/x11/remote_desktop/xrdp_server.pm
@@ -1,0 +1,80 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Remote Login: Windows access SLES over RDP
+# Maintainer: GraceWang <gwang@suse.com>
+# Tags: tc#1610388
+
+use strict;
+use base 'x11test';
+use testapi;
+use lockapi;
+use mmapi;
+use mm_tests;
+use base 'opensusebasetest';
+use utils qw(zypper_call turn_off_gnome_screensaver);
+
+sub run {
+    my ($self) = @_;
+
+    # Setup static NETWORK
+    x11_start_program('xterm');
+    turn_off_gnome_screensaver;
+    become_root;
+    configure_static_network('10.0.2.17/24');
+
+    # Install xrdp
+    zypper_call('in xrdp');
+
+    # Add the firewall port for xrdp
+    x11_start_program('xterm');
+    become_root;
+    assert_script_run 'firewall-cmd --zone=public --permanent --add-port=3389/tcp';
+    assert_script_run 'firewall-cmd --reload';
+    type_string "exit\n";
+    wait_screen_change { send_key 'alt-f4' };
+
+    # Start xrdp
+    assert_script_run "systemctl start xrdp";
+    type_string "exit\n";
+    wait_screen_change { send_key 'alt-f4' };
+
+    # logout
+    wait_screen_change { send_key "alt-f2" };
+    type_string "gnome-session-quit --logout --force\n";
+
+    # Notice xrdp server is ready for remote access
+    mutex_create 'xrdp_server_ready';
+
+    # Wait until xrdp client finishes remote access
+    wait_for_children;
+
+    send_key_until_needlematch 'displaymanager', 'esc';
+    send_key 'ret';
+    assert_screen "displaymanager-password-prompt";
+    type_password;
+    wait_still_screen 3;
+    send_key "ret";
+    assert_screen "multiple-logins-notsupport";
+
+    # Force restart on gdm to check if the active session number is correct
+    assert_and_click "status-bar";
+    assert_and_click "power-button";
+    assert_screen([qw(other-users-logged-in-1user other-users-logged-in-2users)]);
+
+    if (match_has_tag('other-users-logged-in-2users')) {
+        record_soft_failure 'bsc#1116281 GDM didnt behave correctly when the error message Multiple logins are not supported. is triggered';
+    }
+    assert_and_click "force-restart";
+    type_password;
+    send_key "ret";
+
+    $self->wait_boot;
+}
+1;


### PR DESCRIPTION
Add test cases for RDP remote desktop. Below are the details:

1. Client: SLED15SP1; Server: Windows (NLA enabled)
2. Client: SLED15SP1; Server: Windows (NLA disable)
3. Client: Windows; Server: SLES15SP1

- Related ticket: https://progress.opensuse.org/issues/33493
- Needles: 
  https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1020
  https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1030
- Verification run:
desktopapps-remote-desktop-xrdp-server1 http://10.67.18.241/tests/1069
desktopapps-remote-desktop-xrdp-client1 http://10.67.18.241/tests/1070
desktopapps-remote-desktop-xrdp-client2 http://10.67.18.241/tests/1106
desktopapps-remote-desktop-xrdp-server2 http://10.67.18.241/tests/1105
remote-desktop-client4 http://10.67.18.241/tests/1126
remote-desktop-supportserver4 http://10.67.18.241/tests/1125
