### PR TITLE
Fix virtio console on ppc64le

### DIFF
--- a/tests/shutdown/cleanup_before_shutdown.pm
+++ b/tests/shutdown/cleanup_before_shutdown.pm
@@ -31,8 +31,16 @@ sub run {
     if (get_var('DROP_PERSISTENT_NET_RULES')) {
         type_string "rm -f /etc/udev/rules.d/70-persistent-net.rules\n";
     }
-    if (is_sle('<12-SP2') && !check_var('VIRTIO_CONSOLE', 0)) {
-        add_serial_console('hvc0');
+    # Configure serial consoles for virtio support
+    # poo#18860 Enable console on hvc0 on SLES < 12-SP2
+    # poo#44699 Enable console on hvc1 to fix login issues on ppc64le
+    if (!check_var('VIRTIO_CONSOLE', 0)) {
+        if (is_sle('<12-SP2')) {
+            add_serial_console('hvc0');
+        }
+        elsif (get_var('OFW')) {
+            add_serial_console('hvc1');
+        }
     }
     # Proceed with dhcp cleanup on qemu backend only.
     # Cleanup is made, because if same hdd image used in multimachine scenario


### PR DESCRIPTION
Fix poo#44699: Virtio console doesn't work on images for ppc64le,
because hvc1 is not enabled as console. Configuration of console was
added to image creation.
Images without hvc1  couldn't login:
http://10.100.12.105/tests/1310

- Related ticket: https://progress.opensuse.org/issues/44699
- Needles: none
- Verification run of image generation:
http://10.100.12.105/tests/1336#step/cleanup_before_shutdown/2
- Verification of working console:
http://10.100.12.105/tests/1337

