### PR TITLE
Improve autoyast template handling

### DIFF
--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -99,7 +99,7 @@ sub get_product_version {
 
 sub expand_addons {
     my %addons;
-    my @addons = grep { defined $_ } split(/,/, get_var('SCC_ADDONS'));
+    my @addons = grep { defined $_ && $_ } split(/,/, get_var('SCC_ADDONS'));
     foreach my $addon (@addons) {
         $addons{$addon} = {
             name    => get_addon_fullname($addon),

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -43,8 +43,8 @@ sub expand_patterns {
         # SLED12 has different patterns
         else {
             my @sled12;
-            push @sled12, qw(Minimal Minimal-32bit apparmor apparmor-32bit base base-32bit  desktop-base documentation documentation-32bit 32bit yast2 yast2-32bit);
-            push @sled12, qw(gnome gnome-basic desktop-gnome x11 x11-32bit ) if check_var('DESKTOP', 'gnome');
+            push @sled12, qw(Minimal apparmor desktop-base documentation 32bit);
+            push @sled12, qw(gnome-basic desktop-gnome x11) if check_var('DESKTOP', 'gnome');
             return [@sled12];
         }
     }

--- a/tests/autoyast/prepare_profile.pm
+++ b/tests/autoyast/prepare_profile.pm
@@ -29,6 +29,7 @@ sub run {
 
     # Profile is a template, expand and rename
     $profile = expand_template($profile) if $path =~ s/^(.*\.xml)\.ep$/$1/;
+    die $profile if $profile->isa('Mojo::Exception');
 
     # Expand VERSION, as e.g. 15-SP1 has to be mapped to 15.1
     if (my $version = scc_version(get_var('VERSION', ''))) {


### PR DESCRIPTION
Fix empty variable issue and exception handling.

- Verification run:
  - http://panigale.suse.cz/tests/989
  - http://panigale.suse.cz/tests/993
  - http://panigale.suse.cz/tests/991 (run with improper template)
  - http://panigale.suse.cz/tests/995 (patterns)