### PR TITLE
xfstests: simplify kdump active process

### DIFF
--- a/tests/xfstests/enable_kdump.pm
+++ b/tests/xfstests/enable_kdump.pm
@@ -33,8 +33,15 @@ sub run {
     }
 
     # Activate kdump
+    # x86_64 is infect with bsc#1116305, and aarcha64/ppc64le has different alloc_mem size.
+    # In case aarcha64/ppc64le works well with yast, I leave them setting by yast.
     prepare_for_kdump;
-    activate_kdump;
+    if (check_var('ARCH', 'x86_64')) {
+        script_run('yast2 kdump startup enable alloc_mem=72,174');
+    }
+    else {
+        activate_kdump;
+    }
 
     # Reboot
     power_action('reboot');


### PR DESCRIPTION
The process kdump enable always fail in yast step in x86_64 recently. Actually this test is not for testing yast, we just need to enable kdump. Then in remove reuse active kdump steps from kdump_utils.pm, but only use one command line to do that. It's getting less influence by yast problem(will skip hardware check process).
Remain arches other than x86_64, since the memory set by yast is workable in those platform.

To solve problem like: https://openqa.suse.de/tests/2296571#step/enable_kdump/33

- Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1116305
- Verification run: http://10.67.133.102/tests/737