### PR TITLE
Fix console/sshd problem on s390x or svirt backend

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -585,6 +585,8 @@ sub select_serial_terminal {
         }
     } elsif (get_var('S390_ZKVM')) {
         $console = $root ? 'root-console' : 'user-console';
+    } elsif ($backend eq 'svirt') {
+        $console = $root ? 'root-console' : 'user-console';
     } elsif ($backend =~ /^(ikvm|ipmi|spvm)$/) {
         $console = 'root-ssh';
     }


### PR DESCRIPTION
 * Backend `svirt` implemented on `select_serial_terminal()`
 * Condition `if (is_serial_terminal())` used in `console/sshd`
 * Workaround implemented in case the `VirtIO` is missing

- Related ticket: [poo#44696](https://progress.opensuse.org/issues/44696)
- Needles: No need
- Verification run: [SLES12SP3](
http://pdostal-server.suse.cz/tests/424) [SLES12SP4](
http://pdostal-server.suse.cz/tests/425) [Tumbleweed](
http://pdostal-server.suse.cz/tests/426) [Tumbleweed-GNOME-Live](
http://pdostal-server.suse.cz/tests/427)

This is follow up of #6351 and #6295 reported by @OleksandrOrlov 