### PR TITLE
Adjust bootloader_uefi for live installation

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -67,7 +67,7 @@ sub run {
         send_key_until_needlematch('inst-onupgrade', 'down', 10, 5);
     }
     else {
-        if (get_var("PROMO") || get_var('LIVETEST')) {
+        if (get_var("PROMO") || get_var('LIVETEST') || get_var('LIVECD')) {
             send_key_until_needlematch("boot-live-" . get_var("DESKTOP"), 'down', 10, 5);
         }
         elsif (!is_jeos && !is_caasp('VMX')) {


### PR DESCRIPTION
LIVECD is set, but not LIVETEST

- Verification run: http://10.160.67.86/tests/236
