### PR TITLE
Fix Perl::Critic::Policy::Objects::ProhibitIndirectSyntax

### DIFF
--- a/lib/ctcs2_to_junit.pm
+++ b/lib/ctcs2_to_junit.pm
@@ -45,7 +45,7 @@ sub generateXML {
     my $pass_num = 0;
     my $fail_num = 0;
     my $skip_num = 0;
-    my $writer   = new XML::Writer(DATA_MODE => 'true', DATA_INDENT => 2, OUTPUT => "self");
+    my $writer   = XML::Writer->new(DATA_MODE => 'true', DATA_INDENT => 2, OUTPUT => "self");
 
     foreach my $test (keys(%test_results)) {
         if ($test_results{$test}->{status} =~ m/PASSED/) {

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -40,7 +40,7 @@ sub generateXML {
     my $pass_nums = 0;
     my $fail_nums = 0;
     my $skip_nums = 0;
-    my $writer    = new XML::Writer(DATA_MODE => 'true', DATA_INDENT => 2, OUTPUT => 'self');
+    my $writer    = XML::Writer->(DATA_MODE => 'true', DATA_INDENT => 2, OUTPUT => 'self');
 
     foreach my $item (keys(%my_hash)) {
         if ($my_hash{$item}->{status} =~ m/PASSED/) {


### PR DESCRIPTION
I guess that when https://github.com/os-autoinst/os-autoinst/pull/1070 got merged, the test distribution started to kinda take a hit, as it didn't happen when https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6365 was open but failed later when it got merged... 