### PR TITLE
Enhance force_scheduled_tasks by using assert_script "sync"

### DIFF
--- a/tests/console/force_scheduled_tasks.pm
+++ b/tests/console/force_scheduled_tasks.pm
@@ -49,7 +49,7 @@ sub run {
     if (!get_var('SOFTFAIL_BSC1063638') && script_run("! [ -d /usr/share/btrfsmaintenance/ ]")) {
         assert_script_run('find /usr/share/btrfsmaintenance/ -type f -exec ln -fs /bin/true {} \;');
     }
-    sleep 3;    # some head room for the load average to rise
+    assert_script_run "sync";
     settle_load;
 
     # return dmesg output to normal


### PR DESCRIPTION
replace sleep 3 by assert_script "sync"
see ticket: https://progress.opensuse.org/issues/43634
verification test runs:
http://e13.suse.de/tests/11303#next_previous
