### PR TITLE
Add post_fail_hook for boot_to_desktop

### DIFF
--- a/lib/bootbasetest.pm
+++ b/lib/bootbasetest.pm
@@ -1,0 +1,27 @@
+package bootbasetest;
+use testapi;
+use base 'opensusebasetest';
+use strict;
+
+sub post_fail_hook {
+    # check for text login to check if X has failed
+    if (check_screen('generic-login')) {
+        record_info 'Seems that the display manager failed';
+    }
+
+    # if we found a shell, we do not need the memory dump
+    if (!(match_has_tag('emergency-shell') or match_has_tag('emergency-mode'))) {
+        die "save_memory_dump not implemented, no way to save memory_dump" unless check_var('BACKEND', 'qemu');
+        select_console 'root-console';
+        diag 'Save memory dump to debug bootup problems, e.g. for bsc#1005313';
+        save_memory_dump;
+    }
+
+    # crosscheck for text login on tty1
+    select_console 'root-console';
+
+    # collect and upload some stuff
+    export_logs();
+}
+
+1;

--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -11,7 +11,7 @@
 # Summary: Boot from existing image to desktop
 # Maintainer: mitiao <mitiao@gmail.com>
 
-use base 'opensusebasetest';
+use base 'bootbasetest';
 use strict;
 use testapi;
 use version_utils qw(is_upgrade is_sles4sap);

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -15,6 +15,7 @@
 
 use strict;
 use base "y2logsstep";
+use bootbasetest;
 use testapi;
 use utils 'handle_emergency';
 use version_utils qw(is_sle is_leap is_desktop_installed is_upgrade is_sles4sap);
@@ -102,24 +103,7 @@ sub test_flags {
 }
 
 sub post_fail_hook {
-    my $self = shift;
-
-    # Reveal what is behind Plymouth splash screen
-    wait_screen_change {
-        send_key 'esc';
-    };
-    # save a screenshot before trying further measures which might fail
-    save_screenshot;
-    # if we found a shell, we do not need the memory dump
-    if (!(match_has_tag('emergency-shell') or match_has_tag('emergency-mode'))) {
-        die "save_memory_dump is temporarily unavailable, see https://progress.opensuse.org/issues/19390";
-        die "save_memory_dump not implemented, no way to save memory_dump" unless check_var('BACKEND', 'qemu');
-        diag 'Save memory dump to debug bootup problems, e.g. for bsc#1005313';
-        save_memory_dump;
-    }
-
-    # try to save logs as a last resort
-    $self->export_logs();
+    bootbasetest->post_fail_hook();
 }
 
 1;


### PR DESCRIPTION
Added a basic post_fail_hook for boot_to_desktop

- Related ticket: https://progress.opensuse.org/issues/32683

Opened for discussion what other steps we could introduce here