### PR TITLE
Check AppArmor actived by default, fix poo#44912

### DIFF
--- a/tests/security/apparmor/aa_status.pm
+++ b/tests/security/apparmor/aa_status.pm
@@ -14,8 +14,9 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
 # Summary: Test the basic information output function for apparmor aa-status
+#          and whether AppArmor was enabled by default
 # Maintainer: Wes <whdu@suse.com>
-# Tags: poo#36874, tc#1621138
+# Tags: poo#36874, poo#44912
 
 use base "consoletest";
 use strict;
@@ -25,7 +26,7 @@ use utils;
 sub run {
     select_console 'root-console';
 
-    systemctl('restart apparmor');
+    systemctl('is-active apparmor');
 
     validate_script_output "aa-status", sub {
         m/


### PR DESCRIPTION
We should verify the AppArmor has already enabled and started by default, instead to start it manually.

- Related ticket: https://progress.opensuse.org/issues/44912
- Verification run: http://10.67.17.9/tests/1115#step/aa_status/2