### PR TITLE
Do not schedule enable_usb_repo when no usb repo is available

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1082,7 +1082,11 @@ sub load_consoletests {
         loadtest "console/xorg_vt";
     }
     loadtest "console/zypper_lr";
-    loadtest 'console/enable_usb_repo' if check_var('USBBOOT', 1);
+    # Enable installation repo from the usb, unless we boot from USB, but don't use it
+    # for the installation, like in case of LiveCDs and when using http/smb/ftp mirror
+    if (check_var('USBBOOT', 1) && !is_livecd && !get_var('NETBOOT')) {
+        loadtest 'console/enable_usb_repo';
+    }
 
     # Do not clear repos twice if replace repos for openSUSE
     # On staging repos are already removed, using CLEAR_REPOS flag variable


### PR DESCRIPTION
See [poo#44708](https://progress.opensuse.org/issues/44708).

### Verification runs:
* [kde live](http://g226.suse.de/tests/3269/file/autoinst-log.txt)
* [net boot](http://g226.suse.de/tests/3270/file/autoinst-log.txt)
* [gnome live](http://g226.suse.de/tests/3271/file/autoinst-log.txt)
* [kde@USBboot_64](http://g226.suse.de/tests/3272/file/autoinst-log.txt)
