### PR TITLE
Add missing console/prepare_test_data.pm for textinfo

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -185,6 +185,7 @@ sub load_consoletests_minimal {
     return unless (is_staging() && get_var('UEFI') || is_gnome_next || is_krypton_argon);
     # Stagings should test yast2-bootloader in miniuefi at least but not all
     loadtest "console/system_prepare";
+    loadtest "console/prepare_test_data";
     loadtest "console/consoletest_setup";
     loadtest "console/textinfo";
     loadtest "console/hostname";


### PR DESCRIPTION
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6032
 breaks argon and krypton tests:
https://openqa.opensuse.org/tests/811474
https://openqa.opensuse.org/tests/811476

verification runs:
http://e13.suse.de/tests/11323
http://e13.suse.de/tests/11324
