### PR TITLE
Always try esc in post fail hook

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -626,7 +626,7 @@ sub post_fail_hook {
             record_info("no $program", "Could not find '$program' on the system", result => 'fail') && die "$program does not exist on the system";
         }
     }
-    return unless ($self->{in_wait_boot} || $self->{in_boot_desktop});
+
     if ($self->{in_wait_boot}) {
         record_info('shutdown', 'At least we reached target Shutdown') if (wait_serial 'Reached target Shutdown');
     }


### PR DESCRIPTION
It appears that we exit before trying to escape during a shutdown
scenario (or any other for that matter). @okurz's original comment even says
pressing esc may be useful during shutdown, but we have never done it.

In particular if the system refuses to shutdown and sysrq-d is pressed, we
need to delay for a little bit anyway so that QEMU is not closed before the
stuck tasks can be written to the serial. (see https://openqa.suse.de/tests/2315531/file/serial_terminal.txt)

For instances where it doesn't make sense to press escape, I don't think it
matters if we press it anyway. In fact we could randomly mash the keyboard (like
a real user) after failure, it might be useful.

