### PR TITLE
Fix the handle_login function

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -731,7 +731,9 @@ sub handle_login {
     $myuser //= $username;
     $user_selected //= 0;
 
-    assert_screen 'displaymanager', 90;    # wait for DM, then try to login
+    save_screenshot();
+    # wait for DM, avoid screensaver and try to login
+    send_key_until_needlematch('displaymanager', 'esc', 30, 3);
     wait_still_screen;
     if (get_var('ROOTONLY')) {
         if (check_screen 'displaymanager-username-notlisted', 10) {


### PR DESCRIPTION
I fixed the `handle_login` function so even if a password is already prefilled (my case) I try to press ESCAPE until desired screen is matched. Plus this also solves the problem with screen saver.

- Related ticket: [poo#37342](https://progress.opensuse.org/issues/37342) [poo#44822](https://progress.opensuse.org/issues/44822) [poo#44915](https://progress.opensuse.org/issues/44915)
- Needles: [#1025](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1025)
- Verification run: [SLE15](http://pdostal-server.suse.cz/tests/439)
