### PR TITLE
Selinux testcase fix, "selinux-policy*" will not be released on sle15-sp1

### DIFF
--- a/tests/security/selinux/selinux_setup.pm
+++ b/tests/security/selinux/selinux_setup.pm
@@ -47,12 +47,13 @@ sub run {
     zypper_call("in $pkgs", timeout => 3000);
 
     # for opensuse, e.g, Tumbleweed install selinux_policy pkgs as needed
+    # for sle15 and sle15+ "selinux-policy-*" pkgs will not be released
     # NOTE: have to install "selinux-policy-minimum-*" pkg due to this bug: bsc#1108949
-    if (!is_sle && !is_leap) {
+    if (!is_sle && !is_leap || is_sle('>=15')) {
         my @files = ("selinux-policy-20140730-103.3.noarch.rpm", "selinux-policy-minimum-20140730-103.3.noarch.rpm");
         foreach my $file (@files) {
             assert_script_run "wget --quiet " . data_url("selinux/$file");
-            assert_script_run("rpm -ivh --nosignature $file");
+            assert_script_run("rpm -ivh --nosignature --nodeps --noplugins $file");
         }
     }
 }

--- a/tests/security/selinux/selinux_smoke.pm
+++ b/tests/security/selinux/selinux_smoke.pm
@@ -46,7 +46,7 @@ sub run {
     if (is_sle) {
         my $SCC_REGCODE = get_required_var("SCC_REGCODE");
         assert_script_run("SUSEConnect -r $SCC_REGCODE");
-        add_suseconnect_product("sle-sdk");
+        add_suseconnect_product("sle-module-web-scripting");
     }
 
     # install & remove patterns, e.g., mail_server


### PR DESCRIPTION
According to "Bug 1118288":
"selinux-policy*" will not be released on sle15-sp1, so test module "selinux_setup" in test case "selinux" should be updated accordingly. "selinux-policy*" was not released on sle15 either.
So we used old pkgs for testing.

- Related ticket: https://progress.opensuse.org/issues/44942
- Needles: no
- Verification run: http://10.67.19.89/tests/413
