### PR TITLE
Fix error message in wait_boot() if KEEP_GRUB_TIMEOUT is set

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -445,7 +445,8 @@ sub wait_boot {
         # If KEEP_GRUB_TIMEOUT is set, SUT may be at linux-login already, so no need to abort in that case
         elsif (!match_has_tag("grub2") and !match_has_tag('linux-login')) {
             # check_screen timeout
-            die "needle 'grub2' not found";
+            my $failneedle = get_var('KEEP_GRUB_TIMEOUT') ? 'linux-login' : 'grub2';
+            die "needle '$failneedle' not found";
         }
         mutex_wait 'support_server_ready' if get_var('USE_SUPPORT_SERVER');
         # confirm default choice


### PR DESCRIPTION
Follow up to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6282

- Related ticket: N/A, check https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6282
- Needles: N/A
- Verification run: http://mango.suse.de/tests/756
