### PR TITLE
publiccloud: use terraform to manage VMs

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -1,0 +1,146 @@
+provider "azurerm" {}
+
+variable "count" {
+    default = "1"
+}
+
+variable "name" {
+    default = "openqa-vm"
+}
+
+variable "type" {
+    default = "Standard_A2_v2"
+}
+
+variable "region" {
+    default = "westeurope"
+}
+
+variable "image_id" {
+    default = ""
+}
+
+resource "random_id" "service" {
+    count = "${var.count}"
+    keepers {
+        name = "${var.name}"
+    }
+    byte_length = 8
+}
+
+
+resource "azurerm_resource_group" "openqa-group" {
+    name     = "openqa-${random_id.service.hex}"
+    location = "${var.region}"
+}
+
+resource "azurerm_virtual_network" "openqa-network" {
+    name                = "${azurerm_resource_group.openqa-group.name}-vnet"
+    address_space       = ["10.0.0.0/16"]
+    location            = "${var.region}"
+    resource_group_name = "${azurerm_resource_group.openqa-group.name}"
+}
+
+resource "azurerm_subnet" "openqa-subnet" {
+    name                 = "${azurerm_resource_group.openqa-group.name}-subnet"
+    resource_group_name  = "${azurerm_resource_group.openqa-group.name}"
+    virtual_network_name = "${azurerm_virtual_network.openqa-network.name}"
+    address_prefix       = "10.0.1.0/24"
+}
+
+resource "azurerm_public_ip" "openqa-publicip" {
+    name                         = "${azurerm_resource_group.openqa-group.name}-public-ip"
+    location                     = "${var.region}"
+    resource_group_name          = "${azurerm_resource_group.openqa-group.name}"
+    public_ip_address_allocation = "dynamic"
+}
+
+resource "azurerm_network_security_group" "openqa-nsg" {
+    name                = "${azurerm_resource_group.openqa-group.name}-nsg"
+    location            = "${var.region}"
+    resource_group_name = "${azurerm_resource_group.openqa-group.name}"
+
+    security_rule {
+        name                       = "SSH"
+        priority                   = 1001
+        direction                  = "Inbound"
+        access                     = "Allow"
+        protocol                   = "Tcp"
+        source_port_range          = "*"
+        destination_port_range     = "22"
+        source_address_prefix      = "*"
+        destination_address_prefix = "*"
+    }
+}
+
+resource "azurerm_network_interface" "openqa-nic" {
+    name                      = "${azurerm_resource_group.openqa-group.name}-nic"
+    location                  = "${var.region}"
+    resource_group_name       = "${azurerm_resource_group.openqa-group.name}"
+    network_security_group_id = "${azurerm_network_security_group.openqa-nsg.id}"
+
+    ip_configuration {
+        name                          = "openqa-nic-config"
+        subnet_id                     = "${azurerm_subnet.openqa-subnet.id}"
+        private_ip_address_allocation = "dynamic"
+        public_ip_address_id          = "${azurerm_public_ip.openqa-publicip.id}"
+    }
+}
+
+resource "azurerm_image" "image" {
+    name                      = "${azurerm_resource_group.openqa-group.name}-disk1"
+    location                  = "${var.region}"
+    resource_group_name       = "${azurerm_resource_group.openqa-group.name}"
+
+    os_disk {
+        os_type = "Linux"
+        os_state = "Generalized"
+        blob_uri = "https://openqa.blob.core.windows.net/sle-images/${var.image_id}"
+        size_gb = 30
+    }
+}
+
+resource "azurerm_virtual_machine" "openqa-vm" {
+    name                  = "${azurerm_resource_group.openqa-group.name}"
+    location              = "${var.region}"
+    resource_group_name   = "${azurerm_resource_group.openqa-group.name}"
+    network_interface_ids = ["${azurerm_network_interface.openqa-nic.id}"]
+    vm_size               = "${var.type}"
+
+    storage_image_reference {
+        id = "${azurerm_image.image.id}"
+    }
+
+    storage_os_disk {
+        name          = "${var.name}-${element(random_id.service.*.hex, count.index)}-osdisk"
+        caching           = "ReadWrite"
+        create_option     = "FromImage"
+        managed_disk_type = "Standard_LRS"
+    }
+
+    os_profile {
+        computer_name  = "${var.name}-${element(random_id.service.*.hex, count.index)}"
+        admin_username = "azureuser"
+    }
+
+    os_profile_linux_config {
+        disable_password_authentication = true
+        ssh_keys {
+            path     = "/home/azureuser/.ssh/authorized_keys"
+            key_data = "${file("/root/.ssh/id_rsa.pub")}"
+        }
+    }
+}
+
+output "vm_name" {
+    value = "${azurerm_virtual_machine.openqa-vm.*.name}"
+}
+
+data "azurerm_public_ip" "openqa-publicip" {
+    name                = "${azurerm_public_ip.openqa-publicip.name}"
+    resource_group_name = "${azurerm_virtual_machine.openqa-vm.resource_group_name}"
+}
+
+output "public_ip" {
+    value = "${data.azurerm_public_ip.openqa-publicip.*.ip_address}"
+}

--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -1,0 +1,65 @@
+provider "aws" {}
+
+variable "count" {
+    default = "1"
+}
+
+variable "name" {
+    default = "openqa-vm"
+}
+
+variable "type" {
+    default = "t2.large"
+}
+
+variable "image_id" {
+    default = ""
+}
+
+resource "random_id" "service" {
+    count = "${var.count}"
+    keepers {
+        name = "${var.name}"
+    }
+    byte_length = 8
+}
+
+resource "aws_key_pair" "openqa-keypair" {
+    key_name   = "openqa-${random_id.service.hex}"
+    public_key = "${file("/root/.ssh/id_rsa.pub")}"
+}
+
+resource "aws_security_group" "basic_sg" {
+    name        = "openqa-${random_id.service.hex}"
+    description = "Allow all inbound traffic"
+
+    ingress {
+        from_port   = 0
+        to_port     = 0
+        protocol    = "-1"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+    egress {
+        from_port       = 0
+        to_port         = 0
+        protocol        = "-1"
+        cidr_blocks     = ["0.0.0.0/0"]
+    }
+}
+
+resource "aws_instance" "openqa" {
+    count           = "${var.count}"
+    ami             = "${var.image_id}"
+    instance_type   = "${var.type}"
+    key_name        = "${aws_key_pair.openqa-keypair.key_name}"
+    security_groups = ["${aws_security_group.basic_sg.name}"]
+}
+
+output "public_ip" {
+    value = "${aws_instance.openqa.*.public_ip}"
+}
+
+output "vm_name" {
+    value = "${aws_instance.openqa.*.id}"
+}

--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -1,0 +1,67 @@
+provider "google" {
+    credentials = "/root/google_credentials.json"
+    project     = "${var.project}"
+}
+
+variable "count" {
+    default = "1"
+}
+
+variable "name" {
+    default = "openqa-vm"
+}
+
+variable "type" {
+    default = "n1-standard-2"
+}
+
+variable "region" {
+    default = "europe-west1-b"
+}
+
+variable "image_id" {
+    default = ""
+}
+
+variable "project" {
+    default = "suse-sle-qa"
+}
+
+resource "random_id" "service" {
+    count = "${var.count}"
+    keepers {
+        name = "${var.name}"
+    }
+    byte_length = 8
+}
+
+resource "google_compute_instance" "openqa" {
+    count        = "${var.count}"
+    name         = "${var.name}-${element(random_id.service.*.hex, count.index)}"
+    machine_type = "${var.type}"
+    zone         = "${var.region}"
+
+    boot_disk {
+        initialize_params {
+            image = "${var.image_id}"
+        }
+    }
+
+    metadata {
+        sshKeys = "susetest:${file("/root/.ssh/id_rsa.pub")}"
+    }
+
+    network_interface {
+        network = "default"
+            access_config {
+        }
+    }
+}
+
+output "public_ip" {
+    value = "${google_compute_instance.openqa.*.network_interface.0.access_config.0.nat_ip}"
+}
+
+output "vm_name" {
+    value = "${google_compute_instance.openqa.*.name}"
+}

--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -25,9 +25,15 @@ has container       => 'sle-images';
 
 sub init {
     my ($self) = @_;
-
+    $self->SUPER::init();
     assert_script_run('az login --service-principal -u ' . $self->key_id . ' -p '
           . $self->key_secret . ' -t ' . $self->tenantid);
+    assert_script_run("export ARM_SUBSCRIPTION_ID=" . $self->subscription);
+    assert_script_run("export ARM_CLIENT_ID=" . $self->key_id);
+    assert_script_run("export ARM_CLIENT_SECRET=" . $self->key_secret);
+    assert_script_run('export ARM_TENANT_ID="' . $self->tenantid . '"');
+    assert_script_run('export ARM_ENVIRONMENT="public"');
+    assert_script_run('export ARM_TEST_LOCATION="' . $self->region . '"');
 }
 
 sub resource_exist {

--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -26,7 +26,8 @@ sub provider_factory {
         $provider = publiccloud::ec2->new(
             key_id     => get_required_var('PUBLIC_CLOUD_KEY_ID'),
             key_secret => get_required_var('PUBLIC_CLOUD_KEY_SECRET'),
-            region     => get_var('PUBLIC_CLOUD_REGION', 'eu-central-1')
+            region     => get_var('PUBLIC_CLOUD_REGION', 'eu-central-1'),
+            username   => 'ec2-user'
         );
 
     }
@@ -36,7 +37,8 @@ sub provider_factory {
             key_secret   => get_required_var('PUBLIC_CLOUD_KEY_SECRET'),
             region       => get_var('PUBLIC_CLOUD_REGION', 'westeurope'),
             tenantid     => get_required_var('PUBLIC_CLOUD_TENANT_ID'),
-            subscription => get_required_var('PUBLIC_CLOUD_SUBSCRIPTION_ID')
+            subscription => get_required_var('PUBLIC_CLOUD_SUBSCRIPTION_ID'),
+            username     => 'azureuser'
         );
     }
     elsif (check_var('PUBLIC_CLOUD_PROVIDER', 'GCE')) {
@@ -48,7 +50,8 @@ sub provider_factory {
             private_key         => get_required_var('PUBLIC_CLOUD_KEY'),
             client_id           => get_required_var('PUBLIC_CLOUD_CLIENT_ID'),
             region              => get_var('PUBLIC_CLOUD_REGION', 'europe-west1-b'),
-            storage_name        => get_var('PUBLIC_CLOUD_STORAGE', 'openqa-storage')
+            storage_name        => get_var('PUBLIC_CLOUD_STORAGE', 'openqa-storage'),
+            username            => 'susetest'
         );
     }
     else {

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -20,7 +20,7 @@ has ssh_key_file => undef;
 
 sub init {
     my ($self, %params) = @_;
-
+    $self->SUPER::init();
     assert_script_run("export AWS_ACCESS_KEY_ID=" . $self->key_id);
     assert_script_run("export AWS_SECRET_ACCESS_KEY=" . $self->key_secret);
     assert_script_run('export AWS_DEFAULT_REGION="' . $self->region . '"');
@@ -38,7 +38,7 @@ sub find_img {
     return;
 }
 
-sub create_ssh_key {
+sub create_keypair {
     my ($self, $prefix, $out_file) = @_;
 
     return $self->ssh_key if ($self->ssh_key);
@@ -58,7 +58,7 @@ sub create_ssh_key {
     return;
 }
 
-sub delete_ssh_key {
+sub delete_keypair {
     my $self = shift;
     my $name = shift || $self->ssh_key;
 
@@ -71,7 +71,7 @@ sub delete_ssh_key {
 sub upload_img {
     my ($self, $file) = @_;
 
-    die("Create key-pair failed") unless ($self->create_ssh_key($self->prefix . time, 'QA_SSH_KEY.pem'));
+    die("Create key-pair failed") unless ($self->create_keypair($self->prefix . time, 'QA_SSH_KEY.pem'));
 
     my ($img_name) = $file =~ /([^\/]+)$/;
 
@@ -102,8 +102,6 @@ sub upload_img {
 sub ipa {
     my ($self, %args) = @_;
 
-    die("Create key-pair failed") unless ($self->create_ssh_key($self->prefix . time, 'QA_SSH_KEY.pem'));
-
     $args{instance_type}        //= 't2.large';
     $args{user}                 //= 'ec2-user';
     $args{provider}             //= 'ec2';
@@ -118,7 +116,7 @@ sub ipa {
 sub cleanup {
     my ($self) = @_;
     $self->SUPER::cleanup();
-    $self->delete_ssh_key;
+    $self->delete_keypair();
 }
 
 1;

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -18,7 +18,7 @@ use testapi;
 use strict;
 use utils;
 
-use constant CREDENTIALS_FILE => 'google_credentials.json';
+use constant CREDENTIALS_FILE => '/root/google_credentials.json';
 
 has account             => undef;
 has project_id          => undef;
@@ -26,10 +26,10 @@ has private_key_id      => undef;
 has private_key         => undef;
 has service_acount_name => undef;
 has client_id           => undef;
-has storage_name        => undef;
 
 sub init {
     my ($self) = @_;
+    $self->SUPER::init();
     my $credentials = "{" . $/
       . '"type": "service_account", ' . $/
       . '"project_id": "' . $self->project_id . '", ' . $/

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -19,6 +19,8 @@ has instance_id => undef;               # unique CSP instance id
 has public_ip   => undef;               # public IP of instance
 has username    => undef;               # username for ssh connection
 has ssh_key     => undef;               # path to ssh-key for connection
+has image_id    => undef;               # image from where the VM is booted
+has type        => undef;
 has provider    => undef, weak => 1;    # back reference to the provider
 
 =head2 run_ssh_command

--- a/tests/publiccloud/ipa.pm
+++ b/tests/publiccloud/ipa.pm
@@ -21,13 +21,12 @@ sub run {
     $self->select_serial_terminal;
 
     my $provider = $self->provider_factory();
+    my $instance = $provider->create_instance();
 
     my $ipa = $provider->ipa(
-        instance_type => get_var('PUBLIC_CLOUD_INSTANCE_TYPE'),
-        cleanup       => 1,
-        image_id      => $provider->get_image_id(),
-        tests         => get_required_var('PUBLIC_CLOUD_IPA_TESTS'),
-        results_dir   => 'ipa_results'
+        instance    => $instance,
+        tests       => get_required_var('PUBLIC_CLOUD_IPA_TESTS'),
+        results_dir => 'ipa_results'
     );
 
     upload_logs($ipa->{logfile});


### PR DESCRIPTION
Instead of using IPA tool to create VMs, it uses terraform along with a config file for each provider to create the resources needed by IPA to run the tests.

- Related ticket: https://progress.opensuse.org/issues/45002

IPA:
    Azure: http://fromm.arch.suse.de/tests/4504
    EC2: http://fromm.arch.suse.de/tests/4506 (red due to [1])
    GCE: http://fromm.arch.suse.de/tests/4502

LTP:
    Azure: http://fromm.arch.suse.de/tests/4505
    EC2: http://fromm.arch.suse.de/tests/4507
    GCE: http://fromm.arch.suse.de/tests/4503

[1] https://progress.opensuse.org/issues/43259