### PR TITLE
Fix glibc_sanity for live media

### DIFF
--- a/tests/console/glibc_sanity.pm
+++ b/tests/console/glibc_sanity.pm
@@ -23,7 +23,7 @@ sub run {
     zypper_call 'in -C libc.so.6';
     assert_script_run "/lib/libc.so.6 | tee /dev/$serialdev | grep --color '$libcstr'";
     assert_script_run '/lib/libc.so.6 | grep --color "i686-suse-linux"';
-    return if check_var('ARCH', 'i586');    # On Tumbleweed we still support 32-bit x86
+    return if !check_var('ARCH', 'x86_64');    # On Tumbleweed we still support 32-bit x86
     zypper_call 'in -C "libc.so.6()(64bit)"';
     assert_script_run "/lib64/libc.so.6 | tee /dev/$serialdev | grep --color '$libcstr'";
     assert_script_run '/lib64/libc.so.6 | grep --color "x86_64-suse-linux"';


### PR DESCRIPTION
The live media has ARCH=i686, so the check needs to account for that as
well.

- Verification run: https://10.160.67.86/tests/242
