### PR TITLE
Improve stability of yast2_snapper on weak machine

### DIFF
--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -73,9 +73,8 @@ sub y2snapper_show_changes_and_delete {
     }
     # Make sure it shows the new files from the unpacked tarball
     send_key_until_needlematch 'yast2_snapper-show_testdata', 'up';
+    send_key_until_needlematch('yast2_snapper-new_snapshot', 'alt-c', 5, 10);
     # Close the dialog and make sure it is closed
-    send_key "alt-c";
-    send_key_until_needlematch([qw(yast2_snapper-new_snapshot yast2_snapper-new_snapshot_selected)], 'pgdn');
     wait_screen_change { send_key 'end' };
     send_key_until_needlematch('yast2_snapper-new_snapshot_selected', 'up');
     # Dele't'e the snapshot


### PR DESCRIPTION
yas2_snapper module failed on the systems with low performance because
the test tried to close "Filesystem Snapshots" window by just sending a
shortcut without actually verifying if the window is closed or not.

The commit adds several attempts to close the window and to check if it
is actually closed and only then proceed further.

Also, it removes redundant 'pgdn' key press, as the 'end' key press which is executed further is doing the same (selecting the last snapshot in the list). And actually, the 'pgdn' key press was never executed on the passed job runs as the needle was matched before the key press.

- Related ticket: [poo#43784](https://progress.opensuse.org/issues/43784)
- Verification run: http://oorlov-vm.qa.suse.de/tests/696#step/yast2_snapper/63
