### PR TITLE
Add regression tests for cups

### DIFF
--- a/data/console/sample.ps
+++ b/data/console/sample.ps
@@ -1,0 +1,17089 @@
+%!PS-Adobe-2.0
+%%Creator: dvips(k) 5.85 Copyright 1999 Radical Eye Software
+%%Title: JACoWA4.dvi
+%%Pages: 3
+%%PageOrder: Ascend
+%%BoundingBox: 0 0 596 842
+%%DocumentFonts: Times-Bold CMSY10 Times-Roman CMSY8 Times-Italic CMSY6
+%%+ CMMI10 CMMI7 CMR10 CMR7 CMTT10
+%%EndComments
+%DVIPSWebPage: (www.radicaleye.com)
+%DVIPSCommandLine: dvips JACoWA4 -o sample.ps
+%DVIPSParameters: dpi=600, compressed, comments removed
+%DVIPSSource:  TeX output 2003.03.20:1231
+%%BeginProcSet: texc.pro
+/TeXDict 300 dict def TeXDict begin/N{def}def/B{bind def}N/S{exch}N/X{S
+N}B/A{dup}B/TR{translate}N/isls false N/vsize 11 72 mul N/hsize 8.5 72
+mul N/landplus90{false}def/@rigin{isls{[0 landplus90{1 -1}{-1 1}ifelse 0
+0 0]concat}if 72 Resolution div 72 VResolution div neg scale isls{
+landplus90{VResolution 72 div vsize mul 0 exch}{Resolution -72 div hsize
+mul 0}ifelse TR}if Resolution VResolution vsize -72 div 1 add mul TR[
+matrix currentmatrix{A A round sub abs 0.00001 lt{round}if}forall round
+exch round exch]setmatrix}N/@landscape{/isls true N}B/@manualfeed{
+statusdict/manualfeed true put}B/@copies{/#copies X}B/FMat[1 0 0 -1 0 0]
+N/FBB[0 0 0 0]N/nn 0 N/IEn 0 N/ctr 0 N/df-tail{/nn 8 dict N nn begin
+/FontType 3 N/FontMatrix fntrx N/FontBBox FBB N string/base X array
+/BitMaps X/BuildChar{CharBuilder}N/Encoding IEn N end A{/foo setfont}2
+array copy cvx N load 0 nn put/ctr 0 N[}B/sf 0 N/df{/sf 1 N/fntrx FMat N
+df-tail}B/dfs{div/sf X/fntrx[sf 0 0 sf neg 0 0]N df-tail}B/E{pop nn A
+definefont setfont}B/Cw{Cd A length 5 sub get}B/Ch{Cd A length 4 sub get
+}B/Cx{128 Cd A length 3 sub get sub}B/Cy{Cd A length 2 sub get 127 sub}
+B/Cdx{Cd A length 1 sub get}B/Ci{Cd A type/stringtype ne{ctr get/ctr ctr
+1 add N}if}B/id 0 N/rw 0 N/rc 0 N/gp 0 N/cp 0 N/G 0 N/CharBuilder{save 3
+1 roll S A/base get 2 index get S/BitMaps get S get/Cd X pop/ctr 0 N Cdx
+0 Cx Cy Ch sub Cx Cw add Cy setcachedevice Cw Ch true[1 0 0 -1 -.1 Cx
+sub Cy .1 sub]/id Ci N/rw Cw 7 add 8 idiv string N/rc 0 N/gp 0 N/cp 0 N{
+rc 0 ne{rc 1 sub/rc X rw}{G}ifelse}imagemask restore}B/G{{id gp get/gp
+gp 1 add N A 18 mod S 18 idiv pl S get exec}loop}B/adv{cp add/cp X}B
+/chg{rw cp id gp 4 index getinterval putinterval A gp add/gp X adv}B/nd{
+/cp 0 N rw exit}B/lsh{rw cp 2 copy get A 0 eq{pop 1}{A 255 eq{pop 254}{
+A A add 255 and S 1 and or}ifelse}ifelse put 1 adv}B/rsh{rw cp 2 copy
+get A 0 eq{pop 128}{A 255 eq{pop 127}{A 2 idiv S 128 and or}ifelse}
+ifelse put 1 adv}B/clr{rw cp 2 index string putinterval adv}B/set{rw cp
+fillstr 0 4 index getinterval putinterval adv}B/fillstr 18 string 0 1 17
+{2 copy 255 put pop}for N/pl[{adv 1 chg}{adv 1 chg nd}{1 add chg}{1 add
+chg nd}{adv lsh}{adv lsh nd}{adv rsh}{adv rsh nd}{1 add adv}{/rc X nd}{
+1 add set}{1 add clr}{adv 2 chg}{adv 2 chg nd}{pop nd}]A{bind pop}
+forall N/D{/cc X A type/stringtype ne{]}if nn/base get cc ctr put nn
+/BitMaps get S ctr S sf 1 ne{A A length 1 sub A 2 index S get sf div put
+}if put/ctr ctr 1 add N}B/I{cc 1 add D}B/bop{userdict/bop-hook known{
+bop-hook}if/SI save N @rigin 0 0 moveto/V matrix currentmatrix A 1 get A
+mul exch 0 get A mul add .99 lt{/QV}{/RV}ifelse load def pop pop}N/eop{
+SI restore userdict/eop-hook known{eop-hook}if showpage}N/@start{
+userdict/start-hook known{start-hook}if pop/VResolution X/Resolution X
+1000 div/DVImag X/IEn 256 array N 2 string 0 1 255{IEn S A 360 add 36 4
+index cvrs cvn put}for pop 65781.76 div/vsize X 65781.76 div/hsize X}N
+/p{show}N/RMat[1 0 0 -1 0 0]N/BDot 260 string N/Rx 0 N/Ry 0 N/V{}B/RV/v{
+/Ry X/Rx X V}B statusdict begin/product where{pop false[(Display)(NeXT)
+(LaserWriter 16/600)]{A length product length le{A length product exch 0
+exch getinterval eq{pop true exit}if}{pop}ifelse}forall}{false}ifelse
+end{{gsave TR -.1 .1 TR 1 1 scale Rx Ry false RMat{BDot}imagemask
+grestore}}{{gsave TR -.1 .1 TR Rx Ry scale 1 1 false RMat{BDot}
+imagemask grestore}}ifelse B/QV{gsave newpath transform round exch round
+exch itransform moveto Rx 0 rlineto 0 Ry neg rlineto Rx neg 0 rlineto
+fill grestore}B/a{moveto}B/delta 0 N/tail{A/delta X 0 rmoveto}B/M{S p
+delta add tail}B/b{S p tail}B/c{-4 M}B/d{-3 M}B/e{-2 M}B/f{-1 M}B/g{0 M}
+B/h{1 M}B/i{2 M}B/j{3 M}B/k{4 M}B/w{0 rmoveto}B/l{p -4 w}B/m{p -3 w}B/n{
+p -2 w}B/o{p -1 w}B/q{p 1 w}B/r{p 2 w}B/s{p 3 w}B/t{p 4 w}B/x{0 S
+rmoveto}B/y{3 2 roll p a}B/bos{/SS save N}B/eos{SS restore}B end
+
+%%EndProcSet
+%%BeginProcSet: 8r.enc
+% @@psencodingfile@{
+%   author = "S. Rahtz, P. MacKay, Alan Jeffrey, B. Horn, K. Berry",
+%   version = "0.6",
+%   date = "1 July 1998",
+%   filename = "8r.enc",
+%   email = "tex-fonts@@tug.org",
+%   docstring = "Encoding for TrueType or Type 1 fonts
+%                to be used with TeX."
+% @}
+% 
+% Idea is to have all the characters normally included in Type 1 fonts
+% available for typesetting. This is effectively the characters in Adobe
+% Standard Encoding + ISO Latin 1 + extra characters from Lucida.
+% 
+% Character code assignments were made as follows:
+% 
+% (1) the Windows ANSI characters are almost all in their Windows ANSI
+% positions, because some Windows users cannot easily reencode the
+% fonts, and it makes no difference on other systems. The only Windows
+% ANSI characters not available are those that make no sense for
+% typesetting -- rubout (127 decimal), nobreakspace (160), softhyphen
+% (173). quotesingle and grave are moved just because it's such an
+% irritation not having them in TeX positions.
+% 
+% (2) Remaining characters are assigned arbitrarily to the lower part
+% of the range, avoiding 0, 10 and 13 in case we meet dumb software.
+% 
+% (3) Y&Y Lucida Bright includes some extra text characters; in the
+% hopes that other PostScript fonts, perhaps created for public
+% consumption, will include them, they are included starting at 0x12.
+% 
+% (4) Remaining positions left undefined are for use in (hopefully)
+% upward-compatible revisions, if someday more characters are generally
+% available.
+% 
+% (5) hyphen appears twice for compatibility with both 
+% ASCII and Windows.
+% 
+/TeXBase1Encoding [
+% 0x00 (encoded characters from Adobe Standard not in Windows 3.1)
+  /.notdef /dotaccent /fi /fl
+  /fraction /hungarumlaut /Lslash /lslash
+  /ogonek /ring /.notdef
+  /breve /minus /.notdef 
+% These are the only two remaining unencoded characters, so may as
+% well include them.
+  /Zcaron /zcaron 
+% 0x10
+ /caron /dotlessi 
+% (unusual TeX characters available in, e.g., Lucida Bright)
+ /dotlessj /ff /ffi /ffl 
+ /.notdef /.notdef /.notdef /.notdef
+ /.notdef /.notdef /.notdef /.notdef
+ % very contentious; it's so painful not having quoteleft and quoteright
+ % at 96 and 145 that we move the things normally found there to here.
+ /grave /quotesingle 
+% 0x20 (ASCII begins)
+ /space /exclam /quotedbl /numbersign
+ /dollar /percent /ampersand /quoteright
+ /parenleft /parenright /asterisk /plus /comma /hyphen /period /slash
+% 0x30
+ /zero /one /two /three /four /five /six /seven
+ /eight /nine /colon /semicolon /less /equal /greater /question
+% 0x40
+ /at /A /B /C /D /E /F /G /H /I /J /K /L /M /N /O
+% 0x50
+ /P /Q /R /S /T /U /V /W
+ /X /Y /Z /bracketleft /backslash /bracketright /asciicircum /underscore
+% 0x60
+ /quoteleft /a /b /c /d /e /f /g /h /i /j /k /l /m /n /o
+% 0x70
+ /p /q /r /s /t /u /v /w
+ /x /y /z /braceleft /bar /braceright /asciitilde
+ /.notdef % rubout; ASCII ends
+% 0x80
+ /.notdef /.notdef /quotesinglbase /florin
+ /quotedblbase /ellipsis /dagger /daggerdbl
+ /circumflex /perthousand /Scaron /guilsinglleft
+ /OE /.notdef /.notdef /.notdef
+% 0x90
+ /.notdef /.notdef /.notdef /quotedblleft
+ /quotedblright /bullet /endash /emdash
+ /tilde /trademark /scaron /guilsinglright
+ /oe /.notdef /.notdef /Ydieresis
+% 0xA0
+ /.notdef % nobreakspace
+ /exclamdown /cent /sterling
+ /currency /yen /brokenbar /section
+ /dieresis /copyright /ordfeminine /guillemotleft
+ /logicalnot
+ /hyphen % Y&Y (also at 45); Windows' softhyphen
+ /registered
+ /macron
+% 0xD0
+ /degree /plusminus /twosuperior /threesuperior
+ /acute /mu /paragraph /periodcentered
+ /cedilla /onesuperior /ordmasculine /guillemotright
+ /onequarter /onehalf /threequarters /questiondown
+% 0xC0
+ /Agrave /Aacute /Acircumflex /Atilde /Adieresis /Aring /AE /Ccedilla
+ /Egrave /Eacute /Ecircumflex /Edieresis
+ /Igrave /Iacute /Icircumflex /Idieresis
+% 0xD0
+ /Eth /Ntilde /Ograve /Oacute
+ /Ocircumflex /Otilde /Odieresis /multiply
+ /Oslash /Ugrave /Uacute /Ucircumflex
+ /Udieresis /Yacute /Thorn /germandbls
+% 0xE0
+ /agrave /aacute /acircumflex /atilde
+ /adieresis /aring /ae /ccedilla
+ /egrave /eacute /ecircumflex /edieresis
+ /igrave /iacute /icircumflex /idieresis
+% 0xF0
+ /eth /ntilde /ograve /oacute
+ /ocircumflex /otilde /odieresis /divide
+ /oslash /ugrave /uacute /ucircumflex
+ /udieresis /yacute /thorn /ydieresis
+] def
+
+%%EndProcSet
+%%BeginProcSet: texps.pro
+TeXDict begin/rf{findfont dup length 1 add dict begin{1 index/FID ne 2
+index/UniqueID ne and{def}{pop pop}ifelse}forall[1 index 0 6 -1 roll
+exec 0 exch 5 -1 roll VResolution Resolution div mul neg 0 0]/Metrics
+exch def dict begin Encoding{exch dup type/integertype ne{pop pop 1 sub
+dup 0 le{pop}{[}ifelse}{FontMatrix 0 get div Metrics 0 get div def}
+ifelse}forall Metrics/Metrics currentdict end def[2 index currentdict
+end definefont 3 -1 roll makefont/setfont cvx]cvx def}def/ObliqueSlant{
+dup sin S cos div neg}B/SlantFont{4 index mul add}def/ExtendFont{3 -1
+roll mul exch}def/ReEncodeFont{CharStrings rcheck{/Encoding false def
+dup[exch{dup CharStrings exch known not{pop/.notdef/Encoding true def}
+if}forall Encoding{]exch pop}{cleartomark}ifelse}if/Encoding exch def}
+def end
+
+%%EndProcSet
+%%BeginProcSet: special.pro
+TeXDict begin/SDict 200 dict N SDict begin/@SpecialDefaults{/hs 612 N
+/vs 792 N/ho 0 N/vo 0 N/hsc 1 N/vsc 1 N/ang 0 N/CLIP 0 N/rwiSeen false N
+/rhiSeen false N/letter{}N/note{}N/a4{}N/legal{}N}B/@scaleunit 100 N
+/@hscale{@scaleunit div/hsc X}B/@vscale{@scaleunit div/vsc X}B/@hsize{
+/hs X/CLIP 1 N}B/@vsize{/vs X/CLIP 1 N}B/@clip{/CLIP 2 N}B/@hoffset{/ho
+X}B/@voffset{/vo X}B/@angle{/ang X}B/@rwi{10 div/rwi X/rwiSeen true N}B
+/@rhi{10 div/rhi X/rhiSeen true N}B/@llx{/llx X}B/@lly{/lly X}B/@urx{
+/urx X}B/@ury{/ury X}B/magscale true def end/@MacSetUp{userdict/md known
+{userdict/md get type/dicttype eq{userdict begin md length 10 add md
+maxlength ge{/md md dup length 20 add dict copy def}if end md begin
+/letter{}N/note{}N/legal{}N/od{txpose 1 0 mtx defaultmatrix dtransform S
+atan/pa X newpath clippath mark{transform{itransform moveto}}{transform{
+itransform lineto}}{6 -2 roll transform 6 -2 roll transform 6 -2 roll
+transform{itransform 6 2 roll itransform 6 2 roll itransform 6 2 roll
+curveto}}{{closepath}}pathforall newpath counttomark array astore/gc xdf
+pop ct 39 0 put 10 fz 0 fs 2 F/|______Courier fnt invertflag{PaintBlack}
+if}N/txpose{pxs pys scale ppr aload pop por{noflips{pop S neg S TR pop 1
+-1 scale}if xflip yflip and{pop S neg S TR 180 rotate 1 -1 scale ppr 3
+get ppr 1 get neg sub neg ppr 2 get ppr 0 get neg sub neg TR}if xflip
+yflip not and{pop S neg S TR pop 180 rotate ppr 3 get ppr 1 get neg sub
+neg 0 TR}if yflip xflip not and{ppr 1 get neg ppr 0 get neg TR}if}{
+noflips{TR pop pop 270 rotate 1 -1 scale}if xflip yflip and{TR pop pop
+90 rotate 1 -1 scale ppr 3 get ppr 1 get neg sub neg ppr 2 get ppr 0 get
+neg sub neg TR}if xflip yflip not and{TR pop pop 90 rotate ppr 3 get ppr
+1 get neg sub neg 0 TR}if yflip xflip not and{TR pop pop 270 rotate ppr
+2 get ppr 0 get neg sub neg 0 S TR}if}ifelse scaleby96{ppr aload pop 4
+-1 roll add 2 div 3 1 roll add 2 div 2 copy TR .96 dup scale neg S neg S
+TR}if}N/cp{pop pop showpage pm restore}N end}if}if}N/normalscale{
+Resolution 72 div VResolution 72 div neg scale magscale{DVImag dup scale
+}if 0 setgray}N/psfts{S 65781.76 div N}N/startTexFig{/psf$SavedState
+save N userdict maxlength dict begin/magscale true def normalscale
+currentpoint TR/psf$ury psfts/psf$urx psfts/psf$lly psfts/psf$llx psfts
+/psf$y psfts/psf$x psfts currentpoint/psf$cy X/psf$cx X/psf$sx psf$x
+psf$urx psf$llx sub div N/psf$sy psf$y psf$ury psf$lly sub div N psf$sx
+psf$sy scale psf$cx psf$sx div psf$llx sub psf$cy psf$sy div psf$ury sub
+TR/showpage{}N/erasepage{}N/copypage{}N/p 3 def @MacSetUp}N/doclip{
+psf$llx psf$lly psf$urx psf$ury currentpoint 6 2 roll newpath 4 copy 4 2
+roll moveto 6 -1 roll S lineto S lineto S lineto closepath clip newpath
+moveto}N/endTexFig{end psf$SavedState restore}N/@beginspecial{SDict
+begin/SpecialSave save N gsave normalscale currentpoint TR
+@SpecialDefaults count/ocount X/dcount countdictstack N}N/@setspecial{
+CLIP 1 eq{newpath 0 0 moveto hs 0 rlineto 0 vs rlineto hs neg 0 rlineto
+closepath clip}if ho vo TR hsc vsc scale ang rotate rwiSeen{rwi urx llx
+sub div rhiSeen{rhi ury lly sub div}{dup}ifelse scale llx neg lly neg TR
+}{rhiSeen{rhi ury lly sub div dup scale llx neg lly neg TR}if}ifelse
+CLIP 2 eq{newpath llx lly moveto urx lly lineto urx ury lineto llx ury
+lineto closepath clip}if/showpage{}N/erasepage{}N/copypage{}N newpath}N
+/@endspecial{count ocount sub{pop}repeat countdictstack dcount sub{end}
+repeat grestore SpecialSave restore end}N/@defspecial{SDict begin}N
+/@fedspecial{end}B/li{lineto}B/rl{rlineto}B/rc{rcurveto}B/np{/SaveX
+currentpoint/SaveY X N 1 setlinecap newpath}N/st{stroke SaveX SaveY
+moveto}N/fil{fill SaveX SaveY moveto}N/ellipse{/endangle X/startangle X
+/yrad X/xrad X/savematrix matrix currentmatrix N TR xrad yrad scale 0 0
+1 startangle endangle arc savematrix setmatrix}N end
+
+%%EndProcSet
+%%BeginFont: CMTT10
+%!PS-AdobeFont-1.1: CMTT10 1.00B
+%%CreationDate: 1992 Apr 26 10:42:42
+
+% Copyright (C) 1997 American Mathematical Society.  All Rights Reserved.
+
+11 dict begin
+/FontInfo 7 dict dup begin
+/version (1.00B) readonly def
+/Notice (Copyright (C) 1997 American Mathematical Society. All Rights Reserved) readonly def
+/FullName (CMTT10) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle 0 def
+/isFixedPitch true def
+end readonly def
+/FontName /CMTT10 def
+/PaintType 0 def
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0] readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 98 /b put
+dup 105 /i put
+dup 111 /o put
+dup 116 /t put
+dup 120 /x put
+readonly def
+/FontBBox{-4 -235 731 800}readonly def
+/UniqueXX 5000832 def
+currentdict end
+currentfile eexec
+8053514d28ec28da1630165fab262882d3fca78881823c5537fe6c3dda8ee5b8
+97e17cb027f5c73fdbb56b0a7c25fc3512b55fe8f3acfbffcc7f4a382d8299cc
+8fd37d3cea49dabdca92847af0560b404ef71134b0f3d99934fc9d0b4e602011
+b9cfb856c23f958f3c5a2fbe0ef8587d1f5774879c324e51fcb22888b74f2415
+50d7401eb990d4f3a7af635198422283cac1b6cd446ddbcbd915db9bff88844e
+784c6bf7389803d9450b0c21756a017306462c563d51ecefaacd079732f12c29
+315e4b9623a5752c6f1d8145869e120d910b2644887cea7e30b15676a92537c2
+9d3aa80dc30082aba94b40990b82fb1a877e805e0c8c48f61e9f2edac05b944e
+e4d8084ec1d5cc517aaeec5b3ea379dd011eeb454cecab3ad2443c887c582789
+72355673e503affe0394fc7db31de364e4f56c24033c7df2265c56445ec63a1d
+5695a6041ea1b94407e1cdb7c5635603a4fd047e6edcaeb2d0da6c9e0e9396d5
+1a4a58e8fdc1578730f992435560a6e2d3e3687703ee2f78f5896389ac8470bc
+806169eb01762e89b6dc9adf857ead656620e2589aae722c37a2ed7a2941c360
+b067ee34d8d5ca3bf68db725614d936bcb207781f4d4ec2ac67b13a5ad161f3f
+059add7b5e3d904831e31c20c04546fae83ca93a35989e65c201756888f727b9
+7e5313c9870ec96e4cec3901ea03a5c744754485e7d169bbc98bf872d0796e18
+9d43b712950c3786257d8be06ab6080b9d9392313298327549a8a41c00a2cea3
+690b4a333e45aa815a64facae1c2b44640860b8b8687afbefdbd5b4a541a7251
+4ee7d3e0752af3e96a88c95d31fa16d34ba2f02fdb0088b165844f02611c734a
+dbcc2037bf741fdea7e8bcdc130c70c33772f777d8bcddf4611db99001ccff14
+d7af2bb05defc3480bdab312a0eff2f375afb4e0df2f803c594b7c93f71ca4af
+861ae1711932fef19bfe2f9b7adb69d68e5a70ea4d1a3d5bd85231b16993f65e
+fb37a15590c31e6e629e0d6d425fd2ddfe4024c3bd62e7c85590cd70c911ed9f
+c1bb169122d105aa201b48b756e125867acc39fe3468184e7cc6f5eb5e4ec45b
+c97ac79f5f083db926c632b0102be5eb56f17bc152885537ac78beb31e56de0c
+04e6483bc4b80968ad209222d9345e2407f7cc68ed6f3a22aa943b45f8518497
+a507d01178f57bb24ba3525b4315efe72760eff221bdfedd59fe6777d6a7914f
+35c6b9258788171e9ba4d021754d3e4e8ee9d561fff9b110f589080fae02ecd4
+c52ea6c4dbf7826a6204583357bc142f632e79ddcb01a0517b548048ab0ec846
+bc7cce69839f19d6005a5a02a86f5fe173566bca55e542219302b279a8aa4513
+5be88da6688008b11efc82733f26de883ce8a0e8d4ab856ba86585059160381e
+4b095d3d73a32c8f81b6c9278020b7396fe0e8104a02cec231b5f47a86659ded
+1de0844d994f9395be58382ad640211c2b4dd033e709824c81b8bacd452308da
+4f92945bbadf07cdb94792605dba45b0da2f8c645229bd0c94b0305a303f005a
+533aedcd990346084307968b75818149ab59c110104bdf564ac9a45751642e62
+ec7af36de1b4fa6a71d7bfe32961374b68d887ccb8c93dc00c470592014039e0
+f1c462c6b420e8bb0a9929e7216cbca393c37c7086c64f7b9ef42b5f14f4be1c
+922007d4b631dbc5b1a3361e49ce1d68752010a18fbbe6f540ef6820b39ab354
+fa61c81caf8441bf432f39b5df60b4ac307ab8d231ea339818c444d36fb6b7c7
+70880eefb96373ffff360e7abf07fb4c1c083c9b287501c3a9a678e498b319e1
+e5e30cb02c07e9bdb741d364edc874033d1eb8038220db948e491f96170c2e50
+52bdbc8e512429d8f37a3eeca8f26acefefa4e372dc39dac3436bf5f0d735bed
+2ed818c0be4f4fdbe95dade3662076d84c22050817eeed02a12ed86ce9d22fe5
+b93198df3a4d6fc352b79f39f61b0b27b4065e73fdee5d7358f41b8bd15f8ae9
+250ea8ac296548e154b0f020148df46a53e49da0d92769417939a9df1a48d784
+bc0a5aac2a3e66e98afe342b89cd942d72d47d576a19057cf5b2c10780f65df7
+6cbb8ce2ae4d9c6682be4b4def206e61c5f596a365c96f78ede03d2aecf4fd12
+5de670e5c971ddfca0061da3e3ebbc51966a04b7995b6918ebd12bd03fa2cd03
+3ad0f0342076c0021bcf188ad9d52244efede0bc73797efb3f94e82d40357772
+5ca897090ca8d0d9b23e28767d64b074d3acc7c645907b722ad7ba385e7c715f
+6730feee5bc2911b05a905f34d754a4f571145fe3d77c1b684ff6f33328757d3
+3d4f5c97b678ec588840299f921deebb77a394cad6d5af7d1120464f6f56aa0c
+69ec2d65a70c76c805f3bca050515495bb3cfb43f283e08f639a0a58d6042fb1
+a5b3163994ea1425ce085520c10f28c1c9455d011c313b377d7b25385074779f
+73b8267877a80820639e66ffb2ed45b1e9d8755b52a63cd54c877d0a327e277b
+76b061fc89
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+
+%%EndFont 
+%%BeginFont: CMR7
+%!PS-AdobeFont-1.1: CMR7 1.0
+%%CreationDate: 1991 Aug 20 16:39:21
+
+% Copyright (C) 1997 American Mathematical Society.  All Rights Reserved.
+
+11 dict begin
+/FontInfo 7 dict dup begin
+/version (1.0) readonly def
+/Notice (Copyright (C) 1997 American Mathematical Society. All Rights Reserved) readonly def
+/FullName (CMR7) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle 0 def
+/isFixedPitch false def
+end readonly def
+/FontName /CMR7 def
+/PaintType 0 def
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0] readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 48 /zero put
+dup 51 /three put
+readonly def
+/FontBBox{-27 -250 1122 750}readonly def
+/UniqueXX 5000790 def
+currentdict end
+currentfile eexec
+9b9c1569015f2c1d2bf560f4c0d52257bacdd6500abda5ed9835f6a016cfc8f0
+0b6c052ed76a87856b50f4d80dfaeb508c97f8281f3f88b17e4d3b90c0f65ec3
+79791aacdc162a66cbbc5be2f53aad8de72dd113b55a022fbfee658cb95f5bb3
+2ba0357b5e050fddf264a07470bef1c52119b6fbd5c77ebed964ac5a2bbec9d8
+b3e48ae5bb003a63d545774b922b9d5ff6b0066ece43645a131879b032137d6d
+823385fe55f3402d557fd3b448685940729e6e22f4be0e08c6505cba868f7950
+93f556b64b808dd710eb936d3ac83e5783b5f7e56d363a59a026a5619a357d21
+c4e77bea121eb24b09027d1aad93158edf912940e91cd2f17922b35885894644
+7773730bb19af9e70453e1b78d5edc123b273a979891d6d5e624f4a388f3897e
+13b045e34b4ee2f5e4fc5e996d3549640010c671de14d18b0b3cd300e57dac03
+22e59bfbf7b29422230870f5897fcfaad4b50c7c1c58edcd119218163d6f6e56
+25ccb882db7b6d09a1586508e8cb642a11c29a46915e4a96e282079cb21922c1
+c2e360b487a45302fd22ec8c5fab63e54b5e844d4b17ca2fff37c69c366dd72a
+d02922c14c0932f65ed03e4219c117962edbad2dcdeaa9c10ce8af38a4ae52e2
+b377245b0be19a77d6c936e7530cc4d0b78d0cc4a92698fa2870fa54f2d8503e
+2d17b3d52fb2febb09f2b2af0c2a1892039ebe19a690098799a858e3d39631bd
+6925a154d161df3918074ada6bd52baddd0adc3f07e2d9f15e27cbf7fe8b98c4
+07205c811121fa91e059f2f99322fed63f359ac9da97aec383f067f23e5de331
+51e80f0a88ab50fe8fdae4a5de93c1ae2fdca06150b37246140c0e87cb2325a6
+0d2349162ae3ac93144eee1e665a1289105318fdfe86b6e76251cb25adc967d3
+d0b97fe5e279e1161736ab22b4ca510b964342383a840defd38f96a7280e6ac1
+34e48d740607ff2e7804164a16d47735864db847c97335e6d4215cb99911a1ec
+015a3edaac1f28fedd56d2467130d07bae9416c15f0827d27c6c79f59054282a
+418c12c157c91223a829947f47592f7cafd93ca182b25a73a9419127e3b12a9e
+5167ac3963f2b019b338ac46d63880f94dda4b538835884d2a5538c85528d6bd
+977f844d32b43b0e48caed5a4bdabcefe71695d69ca784dd32fbf3ff701f6b07
+72c3661e0561ac614e9d740eb4110eafa55602e8c4f911d8b0544f58874da528
+a1939170286f6a8e58bad2f816c8e05bc78d75233013d48da642b86915ae5436
+61d8d3307e624f4e599050c18cef12da0d2bdf3dddedf972f85b68a676b02eed
+e9356c9fe499fa0d3e25388a8ef1285d7a4e1ede3b4e4d76348a1c9143f7c121
+28634e3d94ab1c3a778040fc6da162c10c2eeec91ddf3f0c8fdce401b9d971d6
+d0df00bb3ca7060a838121474fcb622b857eaa3129e631a18515f5d58328ae3f
+217326ef3e42c1bb3708bc926ce2df807d40b96dc48917aa02418659abe4dd18
+ef27c36dcd42829677d504da8d4bdfb49640375fdd95e77a5d1e7c606ce77905
+72b150a26c864548674e830f95f689b46346b7982e620219cfa86c0f1f5a2c09
+36f227822027e54e725792d4f3542203232ce3a14bda4318d62126457dd39f3e
+013990bbaabcd046c96bbe6f4e98205d3e8f6d96ab6ad4303e68e26acf09cf8e
+6f240c1ab2f31af61ce64a71f03f0ab426bd2ead945fa99c2ac74e0b6635ecef
+12a2609f0d7f84dbed98a01a2a4bc00458003d7489631a3a2fdea1355e518f05
+cef4a36dee6a38c2ef7a9ff0363061c545ae69ee977d84ce7b15ea415ab46a9e
+e88f24627bc51bca4eb6f1747abd74de8d82273a93ffb7f17d22f0aeeb47073e
+50f7af33f402cc9e89975593
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+
+%%EndFont 
+%%BeginFont: CMR10
+%!PS-AdobeFont-1.1: CMR10 1.00B
+%%CreationDate: 1992 Feb 19 19:54:52
+
+% Copyright (C) 1997 American Mathematical Society.  All Rights Reserved.
+
+11 dict begin
+/FontInfo 7 dict dup begin
+/version (1.00B) readonly def
+/Notice (Copyright (C) 1997 American Mathematical Society. All Rights Reserved) readonly def
+/FullName (CMR10) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle 0 def
+/isFixedPitch false def
+end readonly def
+/FontName /CMR10 def
+/PaintType 0 def
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0] readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 51 /three put
+dup 52 /four put
+dup 53 /five put
+dup 61 /equal put
+readonly def
+/FontBBox{-251 -250 1009 969}readonly def
+/UniqueXX 5000793 def
+currentdict end
+currentfile eexec
+8053514d28ec28da1630165fab262882d3fca78881823c5537fe6c3dda8ee5b8
+97e17cb027f5c73fdbb56b0a7c25fc3512b55fe8f3acfbffcc7f4a382d8299cc
+8fd37d3cea49dabdca92847af0560b404ef71134b0f3d99934fc9d0b4e602011
+b9cfb856c23f958f3c5a2fbe0ef8587d1f5774879c324e51fcb22888b74f2415
+50d7401eb990d4f3a7af635198422283cac1b6cd446ddbcbd915db9bff88844e
+784c6bf7389803d9450b0c21756a017306457c7e62c1d269f306bd3402e266de
+fc3b5e7d8a8d2f5bf0fe6ddd40d07391df4fad4a6018dce29a2b8f692b29f202
+3a7c0e66de8ed85c14f1f8492167357f51a7e84cc5d92e0fee4d81cf7fbc8de5
+2d2e7bb57142033993f9c08c315abade8dbc4a732e84e142d3bee51557910e12
+cd8aa37c459a5e6b7f5269f59078aba3be4641a11ac48d0b625c8325b38ec08e
+4c9e5e7fed976a5650d99d82114f449b9ca14c4ec957702295a39a93ef93f618
+99b8ea06b092c3c1e503e6e436e0a9fa22576c8930ab3dc8c20f5d82b69cddf8
+ff4dacfa9c54bed5a3aa3ea5b129fe96be632843b9b6bc91b615581a985db56b
+1e01ca60ee69ca92cf5c0882ece62edad3e106d835348822400f0b66af658f2a
+e56ed08f8b0010571807009b73ab12a8cf14ca6c71f03c2a48c500f9d62266af
+154a6375ff600d9bac3f05ce34142d6867a79581c533176bb2f3117336671e2e
+44638a97167e2ea9644e31ea16c2ad2990ea33c54001e0c8156e6de8ab6a4d40
+a7137ba275f39589fea2e2db8256adc103d6f9cc038037a47e8fd469c5f98a5e
+3c15bd4ace40d340018b1cff7d1ed8abb0ac57b5b5a2c20a51957b96c453edb7
+dae5affd91a46d938fe0a13363001d844ded4323f1ee6d30012aea19b024a552
+315505535c85dc26bad31e09c50e6512802976d298c4e90d0044c362e6bf3ab3
+62a454ee93de25ce54411090c29e9d75c80ce26a84404bd9de3aee0e3f921ac5
+87f907572b8354a5c3165eea7e8b2ba4e15afe87b29fad635269be1fb27f071e
+2c305d4132797e2404f2e35f5884a48489f20b24ff014e8c9fb44f4260042a59
+97986154e747a52ef7f07202c3d17998c836b87ff3df515acbd3c870a1a7c3fd
+d5bc042eb4e70979d6facc7f38dffd8bd27c78f097a9ac5993f588745f562f36
+a0d91aa1346e0c6fe1cf273daeb1e5e851ca88f954f2220fe5707fd9fab57dd9
+965b15ab79bc5008cf809746ff932b76800b083b520d7b10cf2ef3747d73a875
+0a683cdfaaacc2c63413899a1220ded44c3bafe9db93d895bcd63ab7eeb8038a
+1ee9028b1ae374d1c60ba9aa5eabd57be9dd9181c8295a53b9711c046169283e
+80ba61ed7e326acbba0a370df0c0c902e41db58271cec2741b842e3b574fef49
+264362a7c898231a71c1ca3d473f8e68ed9813d20e57951603058d8269ab459a
+ddf7689b1988b354d81e42145bdd9a5c26aebf9105d93bd8f6b2c3b66b72ffd3
+1775aa04449af3e8ac03315e9262de0d92815967d88266593d9fde6b37331fa3
+e14c2c97a9ee8b5230b9e94f7316bd0c73a3e8efa7de03b843ef8bfdceb59fff
+5bdce4a16fb91fc20d38ffd3c19cc510ccb0031117c42e211cee409d36f51819
+4c7d0f5e9b4caac44e03a3a2bd97833bf5da35a78b783c175d3e57646182bc63
+26ecf1522ff4133c9f14a161dfad6159d868b6db98887e58ad6da4f519a85d75
+a3ab0d0152b1dd53c432a340fc9e63c81f27c8eeb717dee81ee60cb2dcacb8f8
+ad863566c0ccaabd230669f0bcdfe647e7ef9aaff0ce3e6b30610fe6db1782e5
+b2d73623def80362a4f655c889cd93b5cbd3f01e724682fc3287face27ed32dc
+83b35eea6ae12529b7254dab63bded83d1b71d08c7194d9afec2660ebe6ad324
+60dde1534d9c4afae89ea848b0ac63d01ee099c9b4910786a0c60afbfb8f0bae
+c0dc156afd6ea0898a57f731b901a6362e4ecb7f76c8e31b50fc512222488a4b
+4f98e3db7f3a04e726cb22660c76654ca54a0fb7e7e820d2922a02e0f3081fc7
+42366cfe0b8a9589c47b3f41d9d69ba17f1fa36d62d95c4ef2c85defdeffa70e
+b96b8a05ed82a5696e97f2bd9e5170ebb2c82630a11a2c8d538e749249750ccc
+2d698c565d141eb1a02d0612bf22cb088f18d1c8225cdb2c45ec8b6ee93ce16d
+e5dacd78db4702164042f08fbce60e16fff2476a8ad2e73341d3b3ecbed4824e
+f7f099507ca4b85336c60069468ffe79c50f1f45005fa7974053da99bd00ae18
+cbab44af38b7c598bd43efc28eae50057e84a06a6f119a33eac7b318f0ad7d9c
+cf4650583914a44eddd59d01e78f7131136c68885553f156d7bdb223b8f02bbd
+9979a1201e96ffb2af426d6840f1b18728cd8e6ebbb2c9b48ce2273413e883d0
+9a2b30d4a83a573ff9d19731e49b8e4dfd87a11fd14fa4116c0993c648b97b8f
+3045b24618b809733a57ab0540aa3d5ef7f7af9019e5e3b0b2b19acf92c18906
+fa4ff95a776221a9c7df6273a450669ed1a43af99d010b4c6c76a05421d890cf
+e1e0ddd79f54b6503c1fea54dbed45b22a1444bfaa0f78e48bf0824c9150
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+
+%%EndFont 
+%%BeginFont: CMMI7
+%!PS-AdobeFont-1.1: CMMI7 1.100
+%%CreationDate: 1996 Jul 23 07:53:53
+
+% Copyright (C) 1997 American Mathematical Society.  All Rights Reserved.
+
+11 dict begin
+/FontInfo 7 dict dup begin
+/version (1.100) readonly def
+/Notice (Copyright (C) 1997 American Mathematical Society. All Rights Reserved) readonly def
+/FullName (CMMI7) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle -14.04 def
+/isFixedPitch false def
+end readonly def
+/FontName /CMMI7 def
+/PaintType 0 def
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0] readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 66 /B put
+readonly def
+/FontBBox{0 -250 1171 750}readonly def
+/UniqueXX 5087382 def
+currentdict end
+currentfile eexec
+80347982ab3942d930e069a70d0d48311d725e830d1c76fba12e12486e989c98
+74c2b527f0925722787027f44470d484262c360cdfdddf3657533a57bb16f730
+48bfbbfcb73a650484015441fdc837add94ac8fbd2022e3ec8f115d4b4bb7b7f
+15388f22cc6198efe768bd9fceb3446ee4a8dc27d6cd152485384ef5f59381ff
+da43f2d20c8fb08aa27ab2015b774db10dacfdcd33e60f178c461553146ab427
+bdd7da12534ba078ad3d780414930f01bdaae649990604a33aa9eaffbe5b5489
+e5c7c9ff9d9be01b08220832c41caac64816b53bbc087ae4b621d2b44b21ae5e
+3f7fe4ddb05c675abfe30510eee4a7c874bb57b2ffe521a6875eddfdfd18c781
+25bfca5a097aad361dd94df46f14026c25ea988194899b95001209cb7009cead
+4b4ea03473ea120e7a7e341d4e3926796347fdb3a124c29660ac09f4648b313c
+b58e824884382f24ce08d2edc686923acace1201c16a07a42803288cd0b946f7
+546510e95b1fa1cc96f0bf72aa823d8e83d7c68c752c82a54c752eed2b1e699d
+e9db1830272ffbf2f4996ccc2d6fe2ae272798989525ef3b67b0d09bffcef749
+a805e5f76578222b9c4a8a09b13189a16ab746ddef7875f1ecf83e568f493d82
+ff729baa1e0834dbec30a35d3c49c9b10c5e1d90c6e3c8fb737df5ceb3299d96
+0fb79632f91f257753b4d2e34e3f54a26c7b950981fb7fe4dee3315db63e75b0
+24b4d318baec8aac9cde186f6d65767df1dba35124287c2e805bc660a3a22772
+0ae4fa097f1d75107441c0a0fbb9eec17d5516fa03b98756b7df7ac7eff9c7a2
+364b9f691ed5cb692dfff9dd80c761e9c4d5d6061782b327302c053ce1cd09ba
+0605ebf761cf9b730524e1994e7dfaa956799d522ec53d5acba27a35c4d28279
+617771938ece58c5ab664aa00c1bc4efba2d15504247a68e3af0f9bd59a387b3
+80db88cca083b06f5af70d768d1699826fb12ce12efc2b4c70923e052dbb964f
+5fa957c3ce225c0fda64d9b5321ee1ade207c1cc93105096cc73118f4082594c
+8ecddeb0d7bfde6f70bc62f10407c26a476ed88be7999d64a15912493829a9de
+62c71f5a34fbf5a843e311873cd98817dc9f8a4aeb7e0738b5de10043f5cfea7
+147f31c39019afacba581f8351d51c8da6e4e29942579f50d5d392e3b0afb372
+f35f77cd48a1df5091b129ccc29965077ab27ae42cbe53dd61e9f23ac80609d8
+c9edde7de61584c1a6f1ccb4d057a3d9950e13d8b17422b5bb5dc9c2aa92562d
+c4229a0c5a6906b79cfec23fd71ed71c58e7871417e981ece6f9f4a97657ae56
+2d274847286ee660725e6e129319d304c727a0113f1efbd015697b0ddcd48ebf
+ea800624fa20f6ad7222fa345209d16c0ef175b0452ca27f8140f660320861f7
+689051115c38638831aeeec41e03dba3703d3bda9587321bf9cf941678876e20
+7bd330a9c86c34befe1ffc6a6c1f29fd0af9d7095c96a31e4fdbe91d109c32ce
+d2cfda50464e853291b2cbf7820acbb27106bb731c9022300f7742d0ce2524ed
+3240466510454c21ea79e22168dbe55115eda22de3352fd988b692835c28a3e2
+7ddfc00d79e7a3f99928be006490cac82107dc83303d476e7f22fe
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+
+%%EndFont 
+%%BeginFont: CMMI10
+%!PS-AdobeFont-1.1: CMMI10 1.100
+%%CreationDate: 1996 Jul 23 07:53:57
+
+% Copyright (C) 1997 American Mathematical Society.  All Rights Reserved.
+
+11 dict begin
+/FontInfo 7 dict dup begin
+/version (1.100) readonly def
+/Notice (Copyright (C) 1997 American Mathematical Society. All Rights Reserved) readonly def
+/FullName (CMMI10) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle -14.04 def
+/isFixedPitch false def
+end readonly def
+/FontName /CMMI10 def
+/PaintType 0 def
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0] readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 15 /epsilon1 put
+dup 22 /mu put
+dup 34 /epsilon put
+dup 58 /period put
+dup 67 /C put
+dup 99 /c put
+dup 109 /m put
+dup 113 /q put
+readonly def
+/FontBBox{-32 -250 1048 750}readonly def
+/UniqueXX 5087385 def
+currentdict end
+currentfile eexec
+80347982ab3942d930e069a70d0d48311d725e830d1c76fba12e12486e989c98
+74c2b527f0925722787027f44470d484262c360cdfdddf3657533a57bb16f730
+48bfbbfcb73a650484015441fdc837add94ac8fbd2022e3ec8f115d4b4bb7b7f
+15388f22cc6198efe768bd9fceb3446ee4a8dc27d6cd152485384ef5f59381ff
+da43f2d20c8fb08aa27ab2015b774db10dacfdcd33e60f178c461553146ab427
+bdd7da12534ba078ad3d780414930da4f8d58abefd45db119b10eb409dd89792
+3c6e705479464a4b310b58348c4b42393988fef4925cf984423aaf65fea9f0e6
+4629953bcf50b919d968d99bd185f83112b2759cc411764e9bde677f57c5ee5a
+c555448d5f81a16259ded1e11bf4119d53e8ab07a802df900d3a2d5ccc1c6876
+d29c5e9effb7af3ef83400b0910c07873a8c56fa7b1eb1ba426043b00cc95dbe
+dc6e136cbbbcb3f67509964f9f281ebf81fe5b018122eaf66c4a838487e82e18
+6e006093042848a903efb3469ab6b4049767aadb95c30408dfd58d8a10f4cb22
+168decd9f3ee100f07b49aa44c92139b669cc312ba20192454eb2375be6284b0
+26659d964b96ae82d4942e758027fcf23c25ed01115af27ce7f20efe2a822bb6
+84004f20243a49c9e93301fc21b80815c033c3e2ba58ef53da2157d524b395f2
+b37abca13bc6a2f42e824ab7e47106176b0d6db267fbb795ac7425582df2e3dc
+55863468a9200742bd7b552c48f8cf58bc21343bd3b95abfa140f33f37c6f3f7
+8b0d8a5154eb7c1f62ec598267f13e841a3e64172663935ac8b665d86540d316
+ddece329c008049c5e74b27d59022c5515059bc3b89370b1bc6a169c888bb325
+e0b74282d6f053a50da4024ed1e433271a32ab8c17d41c632b41cf9f3ecd5fe1
+24daf7aea7ce8a63047b245822930d517df7baaafa69d2d17f7d93cebd45416d
+f3459365434123a76ccf883a4973bab19807e1f0c4bab03a45f7ed69ff2660ff
+3963e4def11001eec4238c368a39d874fd30b3c14f4186ec7700fbce22abe468
+eb32baf7b0164f8f21a9b5e706b91411faaa44467cb2180ab03de375c1ab93e9
+76e11ab92fdd4a7280a6d1a8dc65c4c89d04c8ed6988045a2a3de9a4c7b1efd3
+75bce6f6c324a1d23c449f0e6826680f5d1e59b9a957d2d9b831aaaac833652d
+7a35a06b7c5ae7af4b462d500181698e9a6db622b7d975e0ae2e416401491d74
+b2fe721cb8756ddef3387760e0d50c64808af0937742954e689950e2324e27ca
+f4815de38a73dbb9f7d286fb6cb865caee66e0c26ad9c22f85a3fd08468dc899
+775b65559b872109de4ea91abdb66501f56beab0e44817eb50ce1e1b8dbb48d6
+c61b1fcf97a545471f2e85445ed526a09f9587a1ba234876dd262a836880620f
+2715beb056055ffb56550c8202e8ae4636953de35334fbd1f85ae74e667679ac
+a52aebf23eb978487903293eebe647fd1d42d91790eb7ac800f678ba842611ec
+0646d9af430b9873fbc08e038a87e7adbf5f506ed91b7f0f34b03c6770ad33b5
+e93d5e457f2d1c68510dbe2e94de8abf882c4363cb232abf1e1c71cabc3e4242
+0bfabd18b8ffb7f4858bea5cbad14c209a2804da3088ad3148d6e7e8da810682
+8421c9bd3d9dd61e3ce1b86e3059be9e86b059634d9e36df2384d8eb7be1ec48
+a4cb6d3ab486aa67cfcf7503d926761d5a8ba375aea180c0ff57eb3b853f25ea
+c3fc4955ba375b279bc8175fac48c9d6cdb8254ba2ce3ded9b159d167bc6689d
+9227bfdeabab7d74a22c87a6d2dc909339872684ce0fb39f3ccebfcd684a26fb
+218482e3d9834acb5c68f751e4b2b82883370b2c3af23a5766e22a14e8bd0983
+998c3abe7e5b3742819d38f993855f77ff4839ebb28b5df5a87470b56e1f1e7b
+02126bee9ae458a0628d72f175f4705c195df4867f77d871b67472572a3e0169
+d893bb4c0a27bfc7efd7112280ca5518960026d03f655a33d6825924265fd62d
+c57ec1aee3e01ec3f9368360d913402e6bf74ed0ecfca6527c2c94b2886c3aef
+4b5b7532e9806ba771bdea5ffb09c419d24f9c75473cefb9a1823573851ad2db
+e32a7df0b4f55bd530983ff58768a1c5dc0d7d2a5c10f9bdd270c2a7b96782a2
+3649dcf4421449e4a7e36c4fa002150e6482f0f37e631d7b45abbe1913f96522
+ac088e6376a876b32a306f402bf280fea632945ba8856c315985793c217b458d
+95ad828183b135ef8b9c6ee4ea575485a0b4048a9ba2002fe67acae8736258a8
+1a2616734b6ae3c96e636c34250eca49d3301a6d44191ce386929e71355c7a59
+19586711758e364614f7b51ab8a667ff74c3daa100be17cb60dd5fc1e9ab747f
+93b2f0a4b2cd3f7a7f64af1c5d53f55d78778bbcf959dc65afea8490e556806e
+d211771d0e2dcf242930dcc985c62ecd3ac8824c12a686e96b46e61ab9d3d21f
+b705a91cac25240880a6c4d03586ef7579a542b8333088d89d5b9034e09e8111
+77d27a5a75405f1c1126050e513d57edeb4cda4b8fac84902f881b3cb5b50cc2
+d5b550828eb1d1c667583f91275cbfe41e02639274c8dbaead6095a75df423a7
+5736b30c1f749aa1d88c274176eeca03fc5dc99fc9bc6c0e9c91e5860d43a675
+dd0143f172a16a3db32d9d95de455a2bd493dfebda4406a1a6be09c5f2caf57d
+dca42369eb98b359dca39e36b9a6c1f7e6ab4fe9a45e771dd4d3f5bf7415eb24
+13462a0e9aa67dbf6e5f395e5d2f1a3da6daf3c9604f5db826e61ae0d227e415
+f5e0c78a280b5c0af8c223d14b1dba7d363b86b22dfc923807b381a37a77e1d9
+2463805cacb430cd9c57530a0220bcaf572803623ff8b9b5314bfa4e320bc6a5
+d86b53738e3ee4370e1d2da664419538c692eff1198d75841698b2ba81917e5f
+33b02c45269b67167d3fc9e2d5e6ddcb842c7fdd11ac3c212346efade7b2d832
+20e33ed12645887c67c43596f94f572cfcb51427102307ff5de304ac31c350d7
+7005f1b27e47c693b328bd8f0ddcf3a925f344e8cce6d63bf9964c3dcf614e12
+ef1d11a3005c7ab18214316474cb77188419c8d6200c3504ff040223cdd9b80a
+0c0ab34ff45a8bfe9e5397d5b1da2c9261c5dd373ed02f3863daf9a32c170ed9
+6bbc3e26e61ead7adfe4f5d0bdef450c91a6521c64d76f3ab4a05413d7c911b6
+7b9199979cc6c9fd9ff431738f35f715a662fae03920e8a8539e0b9ba729b315
+53c30eda39f79e6e9d2f0f014b46083585c395fa5514e03745afca77b5f98ff8
+fa9fe7de1e7dab7b072b05b4c07b90c253c58ba4fa01c2679b4846f6a8d566bb
+1e8845e78c86159988fdefc07ffa86c76d60f348204ebf58f380cab708da7f4b
+10035e42764d3322e2ca0fa4c0e49ad6b8d7b0df7740a134ea5b05ed1fc29c3f
+8a7f1a23a88df3b885ce17bb3e97b4f0b17a7186bc6b5393132c3249415f
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+
+%%EndFont 
+%%BeginFont: CMSY6
+%!PS-AdobeFont-1.1: CMSY6 1.0
+%%CreationDate: 1991 Aug 15 07:21:34
+
+% Copyright (C) 1997 American Mathematical Society.  All Rights Reserved.
+
+11 dict begin
+/FontInfo 7 dict dup begin
+/version (1.0) readonly def
+/Notice (Copyright (C) 1997 American Mathematical Society. All Rights Reserved) readonly def
+/FullName (CMSY6) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle -14.035 def
+/isFixedPitch false def
+end readonly def
+/FontName /CMSY6 def
+/PaintType 0 def
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0] readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 3 /asteriskmath put
+dup 121 /dagger put
+readonly def
+/FontBBox{-4 -948 1329 786}readonly def
+/UniqueXX 5000816 def
+currentdict end
+currentfile eexec
+9b9c1569015f2c1d2bf560f4c0d52257bac8ced9b09a275ab231194ecf829352
+05826f4e975dcecec72b2cf3a18899ccde1fd935d09d813b096cc6b83cdf4f23
+b9a60db41f9976ac333263c908dcefcdbd4c8402ed00a36e7487634d089fd45a
+f4a38a56a4412c3b0baffaeb717bf0de9ffb7a8460bf475a6718b0c73c571145
+d026957276530530a2fbefc6c8f059084178f5ab59e11b6a18979f258b8c6ed3
+ccafbc21aca420c9c83eea371adc20e038b4d7b8ac303004b0aa205f04135140
+76407216032fdd22e6219da8f16b28ca12524deb7bca073cc5eba65c102a5e85
+fd48e6d062cd4283ee570a7774597e5bf0e3400b6be72db0115f3cb12db70ce0
+83722870cddfadee715f10f1fcaf20e06f3c54afe5ca238539bfe2b596116e83
+f5371ff18fa5003d8543226cfd4025f9940365b392a858d27f078d3abcffe4a1
+54e78c7692d1a32bf935967c64f01b24788ff8325d61145e2d4a489fd986fb77
+38e6b254522c77ca2797a504a9ce4676a77ebacb026eca94dde5922c936f8e90
+c43e2851973f31a3280c08220536dd2c2de1ffd15fc7390913427ab78eb6d43b
+8063223d65fd28ff3d1247f681b2b45681509b57ddc243e6cb03cc2ca12bab7a
+e851b881f9bdd89fcffa4f8091bd827649a5b36353db09f98c8c02ce4d952a03
+b627a8e3a463bbab6dd9b6d37bef0d0b80a8eccadd52569152625253d39d9d51
+a7d9f6b731bed1f2b2446ed069bc913fdf127bb1f1ead88b0e31d4b96c31d371
+5135ef273e1f19fde6a48695c0ec0dc75a9be460b057704adf3d59cf65ed666b
+0cfac98391d5df064100a0afe65339786504e6475faa102489d0cf4e53b6e7db
+2f1d9adf662bcea1d4e141c924a2f2ee310ca66093cca2448d5341c3840bf846
+8d0e9da55154ce2023c25c6f8c7ed1556c12f310e49fec8673ba71e1f1de4301
+90121e072fcde7bb807d107d94d98a449e8bf022c1ef0e5f28e54eb9b58f9f44
+464b9d859869fb43bf35b2e311bddc4e4f7356eaae39a9e42013328bca7445e7
+487fbd4932181016896d0bbbd85ec2b9021c012aa8aa7cfa8ed89156711e39e9
+b4a2a56188096b990a6008f8ba10b193ea09f323fdd1be6f86448cca98982a67
+aef978431afd96e43a57d64a20507305a174f6624c12e251014af09501714210
+e9d11dabe913e5b93e591ca0a220d551f431087a39bdbf12ebff76fa99774777
+e5e83e755355e8d643dbd062c6eec55e99ca5f9d67639125e04da9e5da65a1ad
+0dfab673b971bd1bd9f222657a9754e3bdba89177c15791f330a8675ba6cfb25
+7a7b281226ad29d2fffa9b783143aa32f8c0b532fe59ce0cbeb85d7b0381701f
+32006cf6f3cabc941288cfa0eed982d44484c865489743
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+
+%%EndFont 
+%%BeginFont: CMSY8
+%!PS-AdobeFont-1.1: CMSY8 1.0
+%%CreationDate: 1991 Aug 15 07:22:10
+
+% Copyright (C) 1997 American Mathematical Society.  All Rights Reserved.
+
+11 dict begin
+/FontInfo 7 dict dup begin
+/version (1.0) readonly def
+/Notice (Copyright (C) 1997 American Mathematical Society. All Rights Reserved) readonly def
+/FullName (CMSY8) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle -14.035 def
+/isFixedPitch false def
+end readonly def
+/FontName /CMSY8 def
+/PaintType 0 def
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0] readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 121 /dagger put
+readonly def
+/FontBBox{-30 -955 1185 779}readonly def
+/UniqueXX 5000818 def
+currentdict end
+currentfile eexec
+9b9c1569015f2c1d2bf560f4c0d52257bac8ced9b09a275ab231194ecf829352
+05826f4e975dcecec72b2cf3a18899ccde1fd935d09d813b096cc6b83cdf4f23
+b9a60db41f9976ac333263c908dcefcdbd4c8402ed00a36e7487634d089fd45a
+f4a38a56a4412c3b0baffaeb717bf0de9ffb7a8460bf475a6718b0c73c571145
+d026957276530530a2fbefc6c8f059084178f5ab59e11b66566ca5ba42b1911a
+5d7f1bf343015eece988b7a93bce0c7aa61344d48aed9c92c8698d4b7c9951c8
+7d103f2414b39e1437f9d2e50c4ee5f218f2e6716926a79ea978f13b1f855345
+191dd7d31d8f82c2e3343c7a5894d95bdc492c28226834efcb5c12fea36ac5cc
+430e0aa604961e34888adf6c1f3954cbc2498e225d953cf5685852162346f474
+5a2a7087d5d7ad486de16d2ca8e15cee26e012671ba3bdc7d95cc8c98bb774f5
+08625e968aee27ff7d1a06e63bcfb5aa4876c3f8f13b30ccccee73c3caf4e70d
+98e6ed2f422dbb4950bf789680e064150995941a9f4dd68a575949847a7d012b
+b910bf03a7a227d51386469ec9ef415f3bb849d30411890d95001ce5637b4f97
+8a16fa43ae5874785b8e6102ff7a73ba07567d3110c1e4efd61e20b63e85df77
+b4cc1119febbcd990e70cd780f3bbb1a76b41880ac8df7e56ba343cf6624f72f
+5a56aab4a99779629e194aa358f68fffa95637cac1ec64873c4f1a02e84ea216
+0378851789ac9413248e2159091b8a58c47a7f7b5a27f9a738cf020d5439b0bd
+2b30b75e48796a9f4dc4611e209b79e9974831dd8425e5d7feb034724e9e712b
+4da8501eab203404f487ababe7581f179db60be0f44b8cb85f1cecb66ef6747f
+c0446e216e0c40dbb65f57407ec671311de2e650d7b0b5d20a041738a0eeb9cb
+8faaee08d41580283ae85ab3b9fdd56cb6c68dd5a47bd7fcdec9dad07187d2c7
+ec9ad3406458107459228ac0b0b9cccf9656ed0935383351358e6d7588c87729
+6d020759cdd221a4f65f9c7d1859f955089b45b4bb68275effebe176a7baf0f0
+9e9e7548c2424e45b081fa909c4a452da52df071b27e5fa7754f
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+
+%%EndFont 
+%%BeginFont: CMSY10
+%!PS-AdobeFont-1.1: CMSY10 1.0
+%%CreationDate: 1991 Aug 15 07:20:57
+
+% Copyright (C) 1997 American Mathematical Society.  All Rights Reserved.
+
+11 dict begin
+/FontInfo 7 dict dup begin
+/version (1.0) readonly def
+/Notice (Copyright (C) 1997 American Mathematical Society. All Rights Reserved) readonly def
+/FullName (CMSY10) readonly def
+/FamilyName (Computer Modern) readonly def
+/Weight (Medium) readonly def
+/ItalicAngle -14.035 def
+/isFixedPitch false def
+end readonly def
+/FontName /CMSY10 def
+/PaintType 0 def
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0] readonly def
+/Encoding 256 array
+0 1 255 {1 index exch /.notdef put} for
+dup 2 /multiply put
+dup 3 /asteriskmath put
+dup 6 /plusminus put
+dup 15 /bullet put
+dup 36 /arrowboth put
+dup 120 /section put
+dup 121 /dagger put
+dup 122 /daggerdbl put
+readonly def
+/FontBBox{-29 -960 1116 775}readonly def
+/UniqueXX 5000820 def
+currentdict end
+currentfile eexec
+9b9c1569015f2c1d2bf560f4c0d52257bac8ced9b09a275ab231194ecf829352
+05826f4e975dcecec72b2cf3a18899ccde1fd935d09d813b096cc6b83cdf4f23
+b9a60db41f9976ac333263c908dcefcdbd4c8402ed00a36e7487634d089fd45a
+f4a38a56a4412c3b0baffaeb717bf0de9ffb7a8460bf475a6718b0c73c571145
+d026957276530530a2fbefc6c8f67052788e6703bb5ee49533870bca1f113ad8
+3750d597b842d8d96c423ba1273ddd32f3a54a912a443fcd44f7c3a6fe3956b0
+aa1e784aaec6fce08dae0c76da9d0a3eba57b98a6233d9e9f0c3f00fcc6b2c6a
+9ba23af389e6dfff4efec3de05d6276c6be417703ce508377f25960ef4ed83b4
+9b01b873f3a639ce00f356229b6477a081933fef3bb80e2b9dffa7f75567b1fa
+4d739b772f8d674e567534c6c5bbf1cf615372be20b18472f7aa58be8c216dbd
+df81cc0a86b6d8318ca68fe22c8af13b54d7576fe4ca5a7af9005ea5cc4edb79
+c0ab668e4fec4b7f5a9eb5f0e4c088cd818ecc4feb4b40ec8bd2981bf2336074
+b64c430a05cba0221dbc83ae38c6183e5a3f9e0ccbf759ac9304b40a127a9e78
+bf0728a52e4183d3d8f1b6d1cb42cafa4c453dcc566c223e8322bfdd0e473972
+5ad5a8111e2e2deade3e8c9360fa7c36f075b5e2e36f8eb693b194afefaf10a5
+c453580dfde7507e518b9d897da36396d19d69df2721933db2618d0675314ff4
+5bd648ef6ac194bf858e171f65650473a36c324077f0508108c957027604f57d
+bd0b6e9344c02d38546dbc576075e3f2e1f8ac4371f33c31a188fc556f7e7eb3
+35b172a232afba11a870001e42eeb3ae7d1b9bfe5847d122e09bdc2ec278196d
+d70697b1dc7ccb76a2cb7382f61c9b1b821cda812f08069da5614e4aa0707f2d
+0657c353c1a4bfb5683c223808a1170ff03fe511416026e9e253364fd63ea2a4
+0de7146f6969719335636a2ceada35cb5016085d5968df4c86cc454441e67063
+fbd893b370dc1f1a46f30fac62d3a417b242b57d4cfbf8d6d55b133d4449f2e8
+fc0d6267eb8e18b639aed5be19e86ff23c402be084aa955363b949b3ea63373e
+5c391f071471d201496c5f1b544ad28ec0e08e505298564c9b7f80715bce3ea2
+812b4c1182bb03f1ea72e16546d93581384ae5cca7a4b8c307a8f0de507f69da
+095603e6597602485aec4fec946cb645737e4e5d7c1d8d75152c99a1392a6510
+863276490191e59d7f982cba3fbb4cab85e78e4263e77d594a9c9ea6a79b312d
+bcb9618db054ac2cc418bb17b9efcfff5f69d6b1aa62c0d354ddd3fa427893fd
+de863e5b6f1ef448d9e1f53fe177aa42c68dd9a31a838635a84da7328197ac54
+1da5491db8dfc9558a11ae84e1f20916807a513f441cff561d340210e0513129
+268342bcb96ce6068a70c2370f9daa124ab323f8bd91439dabf5727616ee51aa
+5e46c8833e26ee4e22c8ce7269e72e0a9ab39319c4a4eddcb94825c5fcf65e83
+45903cb7d31ef9bd752e06914cf3f0b37bd46b77761780cb7b45fe91bc6233a5
+6965b6fad8a43050fee9ed14c1315e337df0f979b81837b971c518f9f5be46ff
+86d9258ef28afcf2cb4cb5f3c082ee2a8483030502606eef692332f28b09f1e3
+238c9b9c90bbdd8eb4a95261935b031a570806270410aeef3795cc3d5898f194
+b644e11f4425c038161ad9756e02e60a8bd71609a7d6dcf54c2438627d6c798a
+69876a1a2331b3337fbf9243829750acda26c3621deaa4d2e0bcf6523bf66cfd
+ca2284724ed60a43aa8d04f9610a41a0bc884c5829d7ccf3917dda6bc95138d1
+e36d498292d512d292b3848960175fc0fa67e89997a670023e5382d45a2011c3
+2d3e0e084b06a638ec95149a1dee6a7b64ac472e778270e6066508635b5d1c07
+20ebfbd7faf421cb9468a4559c13f8280a260caf8fcee47c99fcd4da57802440
+97ceee6a76c6bc69a329d969b0356a1d7080855bfdaa76971b0f08f53fabb408
+609fc4e323d558762eba877698ff29cb21081830449bcb4ebc3f8742fb7e27b8
+291a906502109dd1f5505644b180f163ef7f69d82cc4f3031026ade542c7f8db
+e8e0dde2e491a77736b8c50f7856b1fe0c6a0254061fe5f24f819e40366dd2ce
+f087093eb0c8d13d99e24f80a24e4d111db5a416f0c8559a473ecd44a6efd146
+2f093a8aff9ce952a5f25ea37d41b741fc068219df56df78e9fd16d0e5694897
+52e59b42316712b289b84b5baaba998d554f95641ae7e34472b9c9aecff76b0a
+befc1e6f579d512b94950b913bc5f4bdb70dfb45faf21e85ce048f4ce27e379b
+36f0c923aaaaa4a9ddf04f9efb0d6084556ac72ff32a05e70509e05cd1e44b59
+589507915c2688cd5f927ad985f4c493286604d1eda9d446f700bc80f343f99b
+d1bcd9ab3f7e62158c09e05cc513f97fe3c48304df79f65a4c22c8630114bc9d
+8e66b7fc2a294ea6a5f3cdb4073a9b44cffc60a2b01339341e150afd77a25d31
+27f1e3b0eb701537efc5b160b2c30a9e602ef5bc16eefaa62c4e4ac8a0b9a72c
+70af450e5d26b2f2d221c6840a901c31f7cf530bdf12d636cf2bd6a73180ad5b
+b970049a939d031b740ed0ed0455c6e361ef948e394a49c24f77e5d8b60b2c35
+1d2373456688662455b890b68e071b672841b31f38bfecf26efd366a5259dfa3
+3bea01948cabc740c0cd5f61d5c181b1c5c54fe9b9af06542cdc2c409e2362b3
+cd6885289d9c626679da880b789cd1649013e345e1544abdad001985966dfe6b
+c7331277f175d0195867150e669888b46871f258302333ccdb78629f2a2ee02f
+e85a151cee8029167decf2655cc0183d707d0a6d8398cf0b6a18761afbf7aec6
+2cda6ea094753bb7d8abcdef416037b7042e5abbb93d4118e8d88bad4fc45fcb
+a9b9b3c5abe0f5ea1cba4e0f62e4765ae2c169e397af41170af46aa80e7a27e1
+d9c50ffaf903d94393a9e79259d9962100bb2882f5f75daa369e8570d85ac187
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+0000000000000000000000000000000000000000000000000000000000000000
+cleartomark
+
+%%EndFont 
+TeXDict begin 39158280 55380996 1000 600 600 (JACoWA4.dvi)
+@start /Fa 107[33 33 25[37 1[54 1[37 21 29 25 1[37 37
+37 58 21 2[21 37 37 1[33 37 2[33 3[25 1[25 3[71 54 2[42
+2[42 54 54 66 2[29 25 3[46 54 50 1[54 6[21 37 1[37 37
+37 1[37 37 37 1[21 19 1[19 2[25 25 25 39[{TeXBase1Encoding ReEncodeFont}
+48 74.7198 /Times-Roman rf /Fb 135[44 3[44 4[44 5[44
+6[44 98[{}5 83.022 /CMTT10 rf /Fc 204[33 2[33 48[{}2
+58.1154 /CMR7 rf /Fd 194[65 7[42 42 42 51[{}4 83.022
+/CMR10 rf /Fe 189[50 66[{}1 58.1154 /CMMI7 rf /Ff 142[37
+3[73 9[36 31[59 8[23 23[39 11[50 6[34 15[{}8 83.022 /CMMI10
+rf /Fg 190[42 65[{TeXBase1Encoding ReEncodeFont}1 58.1154
+/Times-Roman rf /Fh 134[33 2[33 33 1[26 22 2[33 33 1[18
+2[18 1[33 22 29 33 29 33 29 9[63 3[37 44 3[48 1[41 1[26
+3[37 4[48 61 12[33 33 1[33 1[17 1[17 44[{TeXBase1Encoding ReEncodeFont}
+30 66.4176 /Times-Roman rf /Fi 134[29 117[32 3[{}2 49.8132
+/CMSY6 rf /Fj 134[42 2[42 46 28 32 37 1[46 1[46 69 3[23
+46 42 1[37 2[46 42 11[60 55 46 2[51 65 60 78 55 7[60
+2[60 12[42 52[{TeXBase1Encoding ReEncodeFont}26 83.022
+/Times-Bold rf /Fk 170[72 66 55 72 1[61 78 72 94 66 78
+1[39 78 78 61 66 1[72 66 72 65[{TeXBase1Encoding ReEncodeFont}18
+99.6264 /Times-Bold rf /Fl 104[83 42 1[37 37 24[37 42
+42 60 42 42 23 32 28 42 42 42 42 65 23 42 23 23 42 42
+28 37 42 37 42 37 3[28 1[28 2[60 78 60 60 51 46 55 1[46
+1[60 74 51 1[32 28 2[46 51 60 55 55 60 5[23 23 42 42
+42 42 42 42 42 42 42 42 23 21 28 21 1[42 28 28 28 35[46
+46 2[{TeXBase1Encoding ReEncodeFont}73 83.022 /Times-Roman
+rf /Fm 134[44 44 2[50 28 39 39 50 50 50 50 72 28 2[28
+50 50 28 44 50 44 50 50 12[55 50 61 1[61 3[55 3[72 72
+61 61 3[61 20[25 44[{TeXBase1Encoding ReEncodeFont}32
+99.6264 /Times-Italic rf /Fn 134[31 121[{}1 66.4176 /CMSY8
+rf /Fo 133[44 2[72 50 50 28 39 33 2[50 50 1[28 2[28 3[44
+50 44 1[44 11[72 1[55 66 1[55 1[72 1[61 1[39 33 1[72
+55 61 1[66 66 72 10[50 50 3[50 50 1[25 33 25 44[{
+TeXBase1Encoding ReEncodeFont}36 99.6264 /Times-Roman
+rf /Fp 133[37 37 37 83[83 20[42 8[65 2[42 65 2[{}8 83.022
+/CMSY10 rf /Fq 171[80 66 86 1[73 93 86 1[80 2[47 2[73
+80 1[86 1[86 65[{TeXBase1Encoding ReEncodeFont}12 119.552
+/Times-Bold rf end
+%%EndProlog
+%%BeginSetup
+%%Feature: *Resolution 600dpi
+TeXDict begin
+%%PaperSize: A4
+
+%%EndSetup
+%%Page: 1 1
+1 0 bop 13 358 a Fq(PREP)-9 b(ARA)e(TION)30 b(OF)g(P)-9
+b(APERS)31 b(FOR)f(A)-7 b(CCELERA)c(T)n(OR)31 b(CONFERENCES)3705
+314 y Fp(\003)704 640 y Fo(J.)25 b(Poole,)f(C.)i(Petit-Jean-Genaz,)f
+(CERN,)h(Gene)n(v)n(a,)e(Switzerland)1031 757 y(P)-11
+b(.)25 b(Lucas)1363 721 y Fn(y)1404 757 y Fo(,)g(FN)m(AL,)g(Bata)n
+(via,)g(IL)g(60510,)f(USA)-128 924 y Fm(Abstr)o(act)-45
+1077 y Fl(AP)-8 b(A)m(C,)21 b(EP)-8 b(A)m(C)20 b(and)f(P)-8
+b(A)m(C)21 b(ha)n(v)o(e)e(adopted)e(the)j(same)g(standards)-128
+1177 y(for)31 b(electronic)e(publication)g(and)h(ha)n(v)o(e)g(created)g
+(the)h(Joint)g(Ac-)-128 1276 y(celerator)d(Conference)e(W)-7
+b(ebsite)30 b(\(J)-5 b(A)m(CoW\))28 b([1)o(])h(for)f(the)g(publi-)-128
+1376 y(cation)g(of)f(their)g(proceedings.)45 b(This)28
+b(document)e(describes)h(the)-128 1475 y(common)k(requirements)g(for)h
+(submission)g(of)h(papers)f(to)h(these)-128 1575 y(conferences.)59
+b(Please)33 b(consult)e(indi)n(vidual)f(conference)g(pages)-128
+1675 y(for)20 b(information)e(on)i(numbers)e(of)i(pages,)g(method)f(of)
+h(electronic)-128 1774 y(submission,)d(etc.)24 b(It)18
+b(is)f(not)g(intended)f(that)h(this)g(should)f(be)h(a)g(tuto-)-128
+1874 y(rial)22 b(in)f(w)o(ord)f(processing;)h(the)g(aim)g(is)h(to)f(e)o
+(xplain)f(the)h(particular)-128 1974 y(requirements)d(for)i(electronic)
+f(publication)f(at)i(these)g(conference)-128 2073 y(series.)250
+2316 y Fk(SUBMISSION)25 b(OF)g(P)-7 b(APERS)-45 2481
+y Fl(Each)31 b(author)e(should)g(submit)i(all)g(of)f(the)h(source)f
+(\002les)h(\(te)o(xt)-128 2581 y(and)23 b(\002gures\),)f(the)h
+(PostScript)f(v)o(ersion)g(and)g(a)h(hard)f(cop)o(y)f(of)i(the)-128
+2680 y(paper)-5 b(.)39 b(This)25 b(will)g(allo)n(w)g(the)g(editors)f
+(to)h(reconstruct)e(the)i(paper)-128 2780 y(in)i(case)f(of)g
+(processing)f(dif)n(\002culties)h(and)f(compare)g(the)h(v)o(ersion)-128
+2879 y(produced)18 b(for)i(publication)e(with)i(the)h(hard)e(cop)o(y)-5
+b(.)482 3122 y Fk(MANUSCRIPTS)-45 3287 y Fl(Authors)20
+b(are)g(advised)f(to)i(use)f(the)g(templates)g(pro)o(vided.)-128
+3522 y Fm(Gener)o(al)k(Layout)-45 3675 y Fl(These)32
+b(instructions)e(are)i(a)f(typical)g(implementation)f(of)h(the)-128
+3775 y(requirements.)23 b(Manuscripts)18 b(should)g(be)h(prepared)e
+(for)i(one)g(side)-128 3875 y(of)h(the)h(paper)e(and)g(ha)n(v)o(e:)-45
+4055 y Fp(\017)41 b Fl(Either)20 b(A4)g(\(21.0)f(cm)h
+Fp(\002)g Fl(29.7)f(cm;)h(8.27)f(in)h Fp(\002)g Fl(11.69)e(in\))i(or)38
+4155 y(US)25 b(letter)f(size)h(\(21.6)e(cm)h Fp(\002)g
+Fl(27.9)f(cm;)j(8.5)e(in)g Fp(\002)g Fl(11.0)f(in\))38
+4254 y(paper)-5 b(.)-45 4354 y Fp(\017)41 b Fl(Single)51
+b(spaced)f(te)o(xt)g(in)h(tw)o(o)f(columns)g(of)g(82.5)f(mm)38
+4454 y(\(3.25)19 b(in\))h(with)h(5.0)e(mm)h(\(0.2)f(in\))h(separation.)
+-45 4553 y Fp(\017)41 b Fl(The)50 b(te)o(xt)f(located)g(within)h(the)f
+(mar)o(gins)f(speci\002ed)i(in)38 4653 y(T)-7 b(able)50
+b(1)g(to)g(f)o(acilitate)g(electronic)e(processing)g(of)i(the)38
+4752 y(PostScript)21 b(\002le.)342 5095 y(T)-7 b(able)20
+b(1:)26 b(Mar)o(gin)18 b(speci\002cations)p 97 5125 1480
+4 v 95 5224 4 100 v 147 5195 a Fj(Mar)o(gin)p 462 5224
+V 99 w(A4)i(P)o(aper)p 895 5224 V 99 w(US)h(Letter)f(P)o(aper)p
+1574 5224 V 97 5228 1480 4 v 95 5327 4 100 v 147 5298
+a Fl(T)-7 b(op)p 462 5327 V 288 w(37)20 b(mm)p 895 5327
+V 169 w(19)g(mm)g(\(0.75)f(in\))p 1574 5327 V 95 5427
+V 147 5397 a(Bottom)p 462 5427 V 166 w(19)h(mm)p 895
+5427 V 169 w(19)g(mm)g(\(0.75)f(in\))p 1574 5427 V 95
+5527 V 147 5497 a(Left)p 462 5527 V 277 w(20)h(mm)p 895
+5527 V 169 w(20)g(mm)g(\(0.79)f(in\))p 1574 5527 V 95
+5626 V 147 5596 a(Right)p 462 5626 V 231 w(20)h(mm)p
+895 5626 V 169 w(26)g(mm)g(\(1.02)f(in\))p 1574 5626
+V 97 5630 1480 4 v -128 5785 780 4 v -50 5838 a Fi(\003)-8
+5862 y Fh(Re)n(vised)g(by)e(Sara)h(W)-5 b(ebber)m(,)17
+b(FN)n(AL,)e(January)j(20,)f(2003)-50 5920 y Fi(y)-8
+5943 y Fh(lucas@fnal.go)o(v)2022 924 y Fl(The)j(layout)f(of)h(the)g(te)
+o(xt)g(on)g(the)g(page)g(is)h(illustrated)e(in)i(Fig.)f(1.)1939
+1024 y(Note)43 b(that)g(the)f(paper')-5 b(s)42 b(title)h(should)f(be)h
+(the)f(width)g(of)h(the)1939 1123 y(full)29 b(page)f(and)g(that)h
+(tables)g(and)f(\002gures)h(may)f(span)h(the)f(whole)1939
+1223 y(170)20 b(mm)g(page)f(width,)h(if)g(desired)g(\(see)g(Fig.)g
+(2\).)2146 3416 y @beginspecial 136 @llx 202 @lly 459
+@urx 641 @ury 1842 @rwi @clip @setspecial
+%%BeginDocument: JACpic_mc.eps
+%AI5_FileFormat 3.0
+%AI3_ColorUsage: Black&White
+%AI3_IncludePlacedImages
+%AI7_ImageSettings: 1
+%AI3_TemplateBox: 306 396 306 396
+%AI3_TileBox: 30 32 582 759
+%AI3_DocumentPreview: PC_ColorTIFF
+%AI5_ArtSize: 612 792
+%AI5_RulerUnits: 2
+%AI5_ArtFlags: 1 1 0 1 0 1 1 0 0
+%AI5_TargetResolution: 800
+%AI5_NumLayers: 1
+%AI5_OpenToView: -450 900 -1.5 1016 703 18 0 1 6 63 0 0
+%AI5_OpenViewLayers: 7
+%AI7_GridSettings: 72 8 72 8 1 0 0.8 0.8 0.8 0.9 0.9 0.9
+%AI7_Thumbnail: 96 128 8
+%0000330000660000990000CC0033000033330033660033990033CC0033FF
+%0066000066330066660066990066CC0066FF009900009933009966009999
+%0099CC0099FF00CC0000CC3300CC6600CC9900CCCC00CCFF00FF3300FF66
+%00FF9900FFCC3300003300333300663300993300CC3300FF333300333333
+%3333663333993333CC3333FF3366003366333366663366993366CC3366FF
+%3399003399333399663399993399CC3399FF33CC0033CC3333CC6633CC99
+%33CCCC33CCFF33FF0033FF3333FF6633FF9933FFCC33FFFF660000660033
+%6600666600996600CC6600FF6633006633336633666633996633CC6633FF
+%6666006666336666666666996666CC6666FF669900669933669966669999
+%6699CC6699FF66CC0066CC3366CC6666CC9966CCCC66CCFF66FF0066FF33
+%66FF6666FF9966FFCC66FFFF9900009900339900669900999900CC9900FF
+%9933009933339933669933999933CC9933FF996600996633996666996699
+%9966CC9966FF9999009999339999669999999999CC9999FF99CC0099CC33
+%99CC6699CC9999CCCC99CCFF99FF0099FF3399FF6699FF9999FFCC99FFFF
+%CC0000CC0033CC0066CC0099CC00CCCC00FFCC3300CC3333CC3366CC3399
+%CC33CCCC33FFCC6600CC6633CC6666CC6699CC66CCCC66FFCC9900CC9933
+%CC9966CC9999CC99CCCC99FFCCCC00CCCC33CCCC66CCCC99CCCCCCCCCCFF
+%CCFF00CCFF33CCFF66CCFF99CCFFCCCCFFFFFF0033FF0066FF0099FF00CC
+%FF3300FF3333FF3366FF3399FF33CCFF33FFFF6600FF6633FF6666FF6699
+%FF66CCFF66FFFF9900FF9933FF9966FF9999FF99CCFF99FFFFCC00FFCC33
+%FFCC66FFCC99FFCCCCFFCCFFFFFF33FFFF66FFFF99FFFFCC110000001100
+%000011111111220000002200000022222222440000004400000044444444
+%550000005500000055555555770000007700000077777777880000008800
+%000088888888AA000000AA000000AAAAAAAABB000000BB000000BBBBBBBB
+%DD000000DD000000DDDDDDDDEE000000EE000000EEEEEEEE0000000000FF
+%00FF0000FFFFFF0000FF00FFFFFF00FFFFFF
+%524C45FD15FFA8FD07FFA8A8FFFFA8FD44FFA87D52A87DA87DA87DA8A87D
+%A87DFF7D27FF527D7DA8FF7D527DFF7DA8A8527DA87DFD3EFF7D5252FD04
+%7D527DF8A852FF7DFF5252FF7D7D52A8FF527DA8A87DFF525227A87DFD42
+%FF52FFFFFF52FDB1FFFD57F8FD09FFF8FD55FFF8FD09FFF8FD55FFF8FD09
+%FFF8FD55FFF8FD09FFF8FD55FFF8FD09FFF8FD55FFF8FD09FFF8FD55FFF8
+%FD09FFFD4DF8FFFD0CF8FD06FFF8FD55FFF8FFFFF8FD06FFF8FD55FFF8FF
+%FFF8FD06FFF8FD55FFF8FFFFF8FD06FFF8FD55FFF8FFFFF8FD06FFF8FD55
+%FFF8FFFFF8FD06FFF8FD55FFF8FFFFF8FD06FFF8FD07FFFD23F8FFFFFFFD
+%23F8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD0FFFF8F8FD10FFF8FFFFFFF8
+%FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD0FFFF8F8FD10FFF8FFFF
+%FFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD
+%21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8
+%FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FF
+%F8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFF
+%F8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06
+%FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD
+%07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8
+%FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FF
+%F8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFF
+%FFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD
+%21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8
+%FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FF
+%F8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFF
+%F8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06
+%FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD
+%07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8
+%FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FF
+%F8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFF
+%FFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD
+%21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD12FFA8FFFFA8FD0BFFF8FF
+%FFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD12FF7D7D7D52FF
+%FD047DFD06FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8
+%FD12FF7D277D52FF5227F8527DFD05FFF8FFFFFFF8FD21FFF8FD05FFF8FF
+%FFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD
+%06FFF8FD07FFF8FD12FFA8FFFFA8FFA8FD09FFF8FFFFFFF8FD21FFF8FD05
+%FFF8FFFFF8FD06FFF8FD07FFF8FD12FF7D7DFF52A87DA8FD08FFF8FFFFFF
+%F8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD12FF7DA8A852A8527D
+%FD08FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FF
+%F8FFFFFFF8FD21FFF8FD05FFF8FD09FFF8FD07FFF8FD21FFF8FFFFFFF8FD
+%21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8
+%FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FF
+%F8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFF
+%F8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06
+%FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD
+%07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8
+%FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FF
+%F8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFF
+%FFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD
+%21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8
+%FD05FFF8FFFFF8FFA87DFFFFFFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8
+%FD05FFF8FFFFF8FFA8FFA8FFFFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8
+%FD05FFF8FFFFF8FFFF527DFFFFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8
+%FD05FFF8FFFFF8FFA87DA8FFFFF8FFFFA87DA8FFFFF8FD21FFF8FFFFFFF8
+%FD21FFF8FD05FFF8FFFFF8FFA8A8A8FFFFF8FD04FFA8FFFFF8FD21FFF8FF
+%FFFFF8FD21FFF8FD05FFF8FFFFF8FF7D52A8FFFFF8FFFFA8F87DFFFFF8FD
+%21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FFFFA87DA8FFFFF8
+%FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FF7D52A8FFFFF8FD07FFF8
+%FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FFA8FD04FFF8FFFF7D52FF
+%FFFFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FD05FF527DFFFFF8FFFFF8
+%7DA8FFFFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FFFFA8A8FFFF
+%F8FFFFA8FD04FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FF5252
+%A8FFFFF8FD04FFA8FFFFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8
+%FFA8FFA8FFFFF8FFFF7D52A8FFFFF8FD21FFF8FFFFFFF8FD21FFF8FD05FF
+%F8FFFFF8FFFFFFA8FFFFF8FFFF7D7DA8FFFFF8FD21FFF8FFFFFFF8FD21FF
+%F8FD05FFF8FFFFF8FF527DA8FFFFF8FFFFFF52FFFFFFF8FD21FFF8FFFFFF
+%F8FD21FFF8FD05FFF8FFFFF8FF7D7DA8FFFFF8FFFFFF7D7DFFFFF8FD21FF
+%F8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FFA87DFFFFFFF8FFFFFF277DFFFF
+%F8FD21FFF8FFFFFFF8FD0DFFA8FFA8FFA8FFA8FD0DFFF8FD05FFF8FFFFF8
+%FFFF52A8FFFFF8FFFFFFA8A8FFFFF8FD21FFF8FFFFFFF8FD0DFF7DA87DA8
+%52A87D7DFD0CFFF8FD05FFF8FFFFF8FFFF277DFFFFF8FFFFFF52A8FFFFF8
+%FD21FFF8FFFFFFF8FD0DFF7DA827A852A8525252FD0BFFF8FD05FFF8FFFF
+%F8FFFF52A8FFFFF8FFFFFF527DFFFFF8FD21FFF8FFFFFFF8F8F8FD1CFFFD
+%04F8FD05FFF8FFFFF8FFFF5252FFFFF8FFFF7D52A8FFFFF8FD21FFF8FFFF
+%FFF8F8F8FD1CFFFD04F8FD05FFF8FFFFF8FFFF7D7DA8FFF8FFFF7D7DFFFF
+%FFF8FD21FFF8FFFFFFF8FD0DFFA8FFFFFFA8FD0FFFF8FD05FFF8FFFFF8FF
+%FF527DFFFFF8FFFF5252A8FFFFF8FD21FFF8FFFFFFF8FD0DFF527D52A827
+%7D7DFF7D7DA8FD09FFF8FD05FFF8FFFFF8FFFFF87DA8FFF8FFFFA8FD04FF
+%F8FD21FFF8FFFFFFF8FD0DFF7D7D7D527D27527D7D27A8FD09FFF8FD05FF
+%F8FFFFF8FFFFA8A8FFFFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FF
+%F8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFF
+%F8FFFF7DA8FFFFF8F8F8FFFFFD04F8FD21FFF8FFFFFFF8FD21FFF8FD05FF
+%F8FFFFF8FFFFF87DFFFFF8FFF8FFFFF8F8FFF8FD21FFF8FFFFFFF8FD21FF
+%F8FD05FFF8FFFFF8FF7D7DA8FFFFF8FD07FFF8FD21FFF8FFFFFFF8FD21FF
+%F8FD05FFF8FFFFF8FF7D7DFFFFFFF8FD07FFF8FD21FFF8FFFFFFF8FD21FF
+%F8FD05FFF8FD04FFA8277DFFFFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8
+%FD05FFF8FFFFF8FFA87DA8FFFFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8
+%FD05FFF8FFFFF8FF7DA8A8FFFFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8
+%FD05FFF8FFFFF8FFFFA8FFFFFFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8
+%FD05FFF8FFFFF8FF7D7DA8FFFFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8
+%FD05FFF8FFFFF8FF7D7DFFFFFFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8
+%FD05FFF8FFFFF8FF7DA8A8FFFFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8
+%FD05FFF8FFFFF8FF7DA8FFFFFFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8
+%FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FF
+%F8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD04FFA8FFA8FD1AFFF8
+%FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FF527DFF7DA87D
+%A8FD19FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FF7D
+%7DA852FF527DFD19FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FF
+%FFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD1EFFFD04F8FFFF
+%FFF8F8F8FD1FFFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD1EFFF8F8FFF8
+%FFFFFFF8F8F8FD1FFFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FF
+%FFFFF8FFA8FD1FFFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFF
+%FFF8FF27A852A87D7D527DA8FD17FFF8FD05FFF8FFFFF8FD06FFF8FD07FF
+%F8FD21FFF8FFFFFFF8FF7DA87D7D7D272727A8FD17FFF8FD05FFF8FFFFF8
+%FD06FFF8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FF
+%F8FD07FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07
+%FFF8FD21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD
+%21FFF8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8
+%FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD21FFF8FFFFFF
+%F8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD0FFFF8F8FD10FFF8FF
+%FFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFF8FD0FFFF8F8FD10FF
+%F8FFFFFFF8FD21FFF8FD05FFF8FFFFF8FD06FFF8FD07FFFD23F8FFFFFFFD
+%23F8FD05FFF8FFFFF8FD06FFF8FD34FFF8F8FD1FFFF8FFFFF8FD06FFF8FD
+%34FFF8F8FD1FFFF8FFFFF8FD06FFF8FD34FFF8F8FFFFA8FD07FFA8FFFFA8
+%A8A8FD0FFFF8FFFFF8FD06FFF8FD37FF527D52FD047DFFFF7D527D7DA827
+%FF527DA87DFD0AFFF8FFFFF8FD06FFF8FD37FF7D7DFF5252F8527DFF7D7D
+%7DA8FF7DA87D527D7DFD0AFFF8FFFFF8FD06FFF8FD34FFF8F8FD0AFFA8FD
+%14FFF8FFFFF8FD06FFF8FD34FFF8F8FD1FFFF8FFFFF8FD06FFFD5AF8FD05
+%FFFF
+userdict /Adobe_level2_AI5 25 dict dup begin
+	put
+	/packedarray where not
+	{
+		userdict begin
+		/packedarray
+		{
+			array astore readonly
+		} bind def
+		/setpacking /pop load def
+		/currentpacking false def
+	 end
+		0
+	} if
+	pop
+	userdict /defaultpacking currentpacking put true setpacking
+	/initialize
+	{
+		Adobe_level2_AI5 begin
+	} bind def
+	/terminate
+	{
+		currentdict Adobe_level2_AI5 eq
+		{
+		 end
+		} if
+	} bind def
+	mark
+	/setcustomcolor where not
+	{
+		/findcmykcustomcolor
+		{
+			0
+			6 packedarray
+		} bind def
+		/findrgbcustomcolor
+		{
+			1
+			5 packedarray
+		} bind def
+		/setcustomcolor
+		{
+			exch 
+			aload pop 
+			0 eq
+			{
+				pop
+				4
+				{
+					4 index mul
+					4 1 roll
+				} repeat
+				5 -1 roll pop
+				setcmykcolor
+			}
+			{
+				pop
+				3
+				{
+					1 exch sub
+					3 index mul 
+					1 exch sub
+					3 1 roll
+				} repeat
+				4 -1 roll pop
+				setrgbcolor
+			} ifelse
+		}
+		def
+	} if
+	
+	/gt38? mark {version cvr cvx exec} stopped {cleartomark true} {38 gt exch pop} ifelse def
+	userdict /deviceDPI 72 0 matrix defaultmatrix dtransform dup mul exch dup mul add sqrt put
+	userdict /level2?
+	systemdict /languagelevel known dup
+	{
+		pop systemdict /languagelevel get 2 ge
+	} if
+	put
+/level2ScreenFreq
+{
+ begin
+		60
+		HalftoneType 1 eq
+		{
+			pop Frequency
+		} if
+		HalftoneType 2 eq
+		{
+			pop GrayFrequency
+		} if
+		HalftoneType 5 eq
+		{
+			pop Default level2ScreenFreq
+		} if
+ end
+} bind def
+userdict /currentScreenFreq  
+	level2? {currenthalftone level2ScreenFreq} {currentscreen pop pop} ifelse put
+level2? not
+	{
+		/setcmykcolor where not
+		{
+			/setcmykcolor
+			{
+				exch .11 mul add exch .59 mul add exch .3 mul add
+				1 exch sub setgray
+			} def
+		} if
+		/currentcmykcolor where not
+		{
+			/currentcmykcolor
+			{
+				0 0 0 1 currentgray sub
+			} def
+		} if
+		/setoverprint where not
+		{
+			/setoverprint /pop load def
+		} if
+		/selectfont where not
+		{
+			/selectfont
+			{
+				exch findfont exch
+				dup type /arraytype eq
+				{
+					makefont
+				}
+				{
+					scalefont
+				} ifelse
+				setfont
+			} bind def
+		} if
+		/cshow where not
+		{
+			/cshow
+			{
+				[
+				0 0 5 -1 roll aload pop
+				] cvx bind forall
+			} bind def
+		} if
+	} if
+	cleartomark
+	/anyColor?
+	{
+		add add add 0 ne
+	} bind def
+	/testColor
+	{
+		gsave
+		setcmykcolor currentcmykcolor
+		grestore
+	} bind def
+	/testCMYKColorThrough
+	{
+		testColor anyColor?
+	} bind def
+	userdict /composite?
+	level2?
+	{
+		gsave 1 1 1 1 setcmykcolor currentcmykcolor grestore
+		add add add 4 eq
+	}
+	{
+		1 0 0 0 testCMYKColorThrough
+		0 1 0 0 testCMYKColorThrough
+		0 0 1 0 testCMYKColorThrough
+		0 0 0 1 testCMYKColorThrough
+		and and and
+	} ifelse
+	put
+	composite? not
+	{
+		userdict begin
+		gsave
+		/cyan? 1 0 0 0 testCMYKColorThrough def
+		/magenta? 0 1 0 0 testCMYKColorThrough def
+		/yellow? 0 0 1 0 testCMYKColorThrough def
+		/black? 0 0 0 1 testCMYKColorThrough def
+		grestore
+		/isCMYKSep? cyan? magenta? yellow? black? or or or def
+		/customColor? isCMYKSep? not def
+	 end
+	} if
+ end defaultpacking setpacking
+currentpacking true setpacking
+userdict /Adobe_typography_AI5 68 dict dup begin
+put
+/initialize
+{
+ begin
+ begin
+	Adobe_typography_AI5 begin
+	Adobe_typography_AI5
+	{
+		dup xcheck
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+ end
+ end
+	Adobe_typography_AI5 begin
+} def
+/terminate
+{
+	currentdict Adobe_typography_AI5 eq
+	{
+	 end
+	} if
+} def
+/modifyEncoding
+{
+	/_tempEncode exch ddef
+	/_pntr 0 ddef
+	{
+		counttomark -1 roll
+		dup type dup /marktype eq
+		{
+			pop pop exit
+		}
+		{
+			/nametype eq
+			{
+				_tempEncode /_pntr dup load dup 3 1 roll 1 add ddef 3 -1 roll
+				put
+			}
+			{
+				/_pntr exch ddef
+			} ifelse
+		} ifelse
+	} loop
+	_tempEncode
+} def
+/havefont
+{
+	systemdict /languagelevel known
+		{
+		/Font resourcestatus dup
+			{ exch pop exch pop }
+		if
+		}
+		{
+		systemdict /FontDirectory get 1 index known
+			{ pop true }
+			{
+			systemdict /fileposition known
+				{
+				dup length 6 add exch
+				Ss 6 250 getinterval
+				cvs pop
+				Ss exch 0 exch getinterval
+				status
+					{ pop pop pop pop true }
+					{ false }
+				ifelse
+				}
+				{
+				pop false
+				}
+			ifelse
+			}
+		ifelse
+		}
+	ifelse
+} def
+/TE
+{
+	StandardEncoding 256 array copy modifyEncoding
+	/_nativeEncoding exch def
+} def
+/subststring {
+	exch 2 index exch search
+	{
+		exch pop
+		exch dup () eq
+		{
+			pop exch concatstring
+		}
+		{
+			3 -1 roll
+			exch concatstring
+			concatstring
+		} ifelse
+		exch pop true
+	}
+	{
+		pop pop false
+	} ifelse
+} def
+/concatstring {
+	1 index length 1 index length
+	1 index add
+	string
+	dup 0 5 index putinterval
+	dup 2 index 4 index putinterval
+	4 1 roll pop pop pop
+} def
+%
+/TZ
+{
+	dup type /arraytype eq
+	{
+		/_wv exch def
+	}
+	{
+		/_wv 0 def
+	} ifelse
+	/_useNativeEncoding exch def
+	2 index havefont
+	{
+		3 index
+		255 string
+		cvs
+		
+		dup
+		(_Symbol_)
+		eq
+		{
+			pop
+			2 index
+			findfont
+			
+		}
+		{
+			dup length 1 sub
+			1 exch
+			getinterval
+			
+			cvn
+			findfont
+		} ifelse
+	}
+	{
+		dup 1 eq
+		{
+			2 index 64 string cvs
+			dup (-90pv-RKSJ-) (-83pv-RKSJ-) subststring
+			{
+				exch pop dup havefont
+				{
+					findfont false
+				}
+				{
+					pop true
+				} ifelse
+			}
+			{
+				pop	dup
+				(-90ms-RKSJ-) (-Ext-RKSJ-) subststring
+				{
+					exch pop dup havefont
+					{
+						findfont false
+					}
+					{
+						pop true
+					} ifelse
+				}
+				{
+					pop pop true
+				} ifelse
+			} ifelse
+			{
+				/Ryumin-Light-83pv-RKSJ-H havefont
+					{/Ryumin-Light-83pv-RKSJ-H}
+					{/Courier}
+					ifelse
+					findfont
+					[1 0 0.5 1 0 0] makefont
+			} if
+		}
+		{
+			/Courier findfont
+		} ifelse
+	} ifelse
+	_wv type /arraytype eq
+	{
+		_wv makeblendedfont
+	} if
+	dup length 10 add dict
+ begin
+	mark exch
+	{
+		1 index /FID ne
+		{
+			def
+		} if
+		cleartomark mark
+	} forall
+	pop
+	/FontScript exch def
+	/FontDirection exch def
+	/FontRequest exch def
+	/FontName exch def
+	counttomark 0 eq
+	{
+		1 _useNativeEncoding eq
+		{
+			/Encoding _nativeEncoding def
+		} if
+		cleartomark
+	}
+	{
+		/Encoding load 256 array copy
+		modifyEncoding /Encoding exch def
+	} ifelse
+	FontName currentdict
+ end
+	definefont pop
+} def
+/tr
+{
+	_ax _ay 3 2 roll
+} def
+/trj
+{
+	_cx _cy _sp _ax _ay 6 5 roll
+} def
+/a0
+{
+	/Tx
+	{
+		dup
+		currentpoint 3 2 roll
+		tr _psf
+		newpath moveto
+		tr _ctm _pss
+	} ddef
+	/Tj
+	{
+		dup
+		currentpoint 3 2 roll
+		trj _pjsf
+		newpath moveto
+		trj _ctm _pjss
+	} ddef
+} def
+/a1
+{
+W B
+} def
+/e0
+{
+	/Tx
+	{
+		tr _psf
+	} ddef
+	/Tj
+	{
+		trj _pjsf
+	} ddef
+} def
+/e1
+{
+W F 
+} def
+/i0
+{
+	/Tx
+	{
+		tr sp
+	} ddef
+	/Tj
+	{
+		trj jsp
+	} ddef
+} def
+/i1
+{
+	W N
+} def
+/o0
+{
+	/Tx
+	{
+		tr sw rmoveto
+	} ddef
+	/Tj
+	{
+		trj swj rmoveto
+	} ddef
+} def
+/r0
+{
+	/Tx
+	{
+		tr _ctm _pss
+	} ddef
+	/Tj
+	{
+		trj _ctm _pjss
+	} ddef
+} def
+/r1
+{
+W S
+} def
+/To
+{
+	pop _ctm currentmatrix pop
+} def
+/TO
+{
+	iTe _ctm setmatrix newpath
+} def
+/Tp
+{
+	pop _tm astore pop _ctm setmatrix
+	_tDict begin
+	/W
+	{
+	} def
+	/h
+	{
+	} def
+} def
+/TP
+{
+ end
+	iTm 0 0 moveto
+} def
+/Tr
+{
+	_render 3 le
+	{
+		currentpoint newpath moveto
+	} if
+	dup 8 eq
+	{
+		pop 0
+	}
+	{
+		dup 9 eq
+		{
+			pop 1
+		} if
+	} ifelse
+	dup /_render exch ddef
+	_renderStart exch get load exec
+} def
+/iTm
+{
+	_ctm setmatrix _tm concat
+	_shift aload pop _lineorientation 1 eq { exch } if translate
+	_scale aload pop _lineorientation 1 eq _yokoorientation 1 eq or { exch } if scale
+} def
+/Tm
+{
+	_tm astore pop iTm 0 0 moveto
+} def
+/Td
+{
+	_mtx translate _tm _tm concatmatrix pop iTm 0 0 moveto
+} def
+/iTe
+{
+	_render -1 eq
+	{
+	}
+	{
+		_renderEnd _render get dup null ne
+		{
+			load exec
+		}
+		{
+			pop
+		} ifelse
+	} ifelse
+	/_render -1 ddef
+} def
+/Ta
+{
+	pop
+} def
+/Tf
+{
+	1 index type /nametype eq
+	{
+		dup 0.75 mul 1 index 0.25 mul neg
+	} if
+	/_fontDescent exch ddef
+	/_fontAscent exch ddef
+	/_fontSize exch ddef
+	/_fontRotateAdjust _fontAscent _fontDescent add 2 div neg ddef
+	/_fontHeight _fontSize ddef
+	findfont _fontSize scalefont setfont
+} def
+/Tl
+{
+	pop neg 0 exch
+	_leading astore pop
+} def
+/Tt
+{
+	pop
+} def
+/TW
+{
+	3 npop
+} def
+/Tw
+{
+	/_cx exch ddef
+} def
+/TC
+{
+	3 npop
+} def
+/Tc
+{
+	/_ax exch ddef
+} def
+/Ts
+{
+	0 exch
+	_shift astore pop
+	currentpoint
+	iTm
+	moveto
+} def
+/Ti
+{
+	3 npop
+} def
+/Tz
+{
+	count 1 eq { 100 } if
+	100 div exch 100 div exch
+	_scale astore pop
+	iTm
+} def
+/TA
+{
+	pop
+} def
+/Tq
+{
+	pop
+} def
+/Tg
+{
+	pop
+} def
+/TG
+{
+	pop
+} def
+/Tv
+{
+	/_lineorientation exch ddef
+} def
+/TV
+{
+	/_charorientation exch ddef
+} def
+/Ty
+{
+	dup /_yokoorientation exch ddef 1 sub neg Tv
+} def
+/TY
+{
+	pop
+} def
+/T~
+{
+	Tx
+} def
+/Th
+{
+	pop pop pop pop pop
+} def
+/TX
+{
+	pop
+} def
+/Tk
+{
+	_fontSize mul 1000 div
+	_lineorientation 0 eq { neg 0 } { 0 exch } ifelse
+	rmoveto
+	pop
+} def
+/TK
+{
+	2 npop
+} def
+/T*
+{
+	_leading aload pop
+	_lineorientation 0 ne { exch } if
+	Td
+} def
+/T*-
+{
+	_leading aload pop
+	_lineorientation 0 ne { exch } if
+	exch neg exch neg
+	Td
+} def
+/T-
+{
+	_ax neg 0 rmoveto
+	_lineorientation 1 eq _charorientation 0 eq and { 1 TV _hyphen Tx 0 TV } { _hyphen Tx } ifelse
+} def
+/T+
+{
+} def
+/TR
+{
+	_ctm currentmatrix pop
+	_tm astore pop
+	iTm 0 0 moveto
+} def
+/TS
+{
+	currentfont 3 1 roll
+	/_Symbol_ findfont _fontSize scalefont setfont
+	
+	0 eq
+	{
+		Tx
+	}
+	{
+		Tj
+	} ifelse
+	setfont
+} def
+/Xb
+{
+	pop pop
+} def
+/Tb /Xb load def
+/Xe
+{
+	pop pop pop pop
+} def
+/Te /Xe load def
+/XB
+{
+} def
+/TB /XB load def
+currentdict readonly pop
+end
+setpacking
+%
+/X^
+{
+	currentfont 5 1 roll
+	dup havefont
+		{
+		findfont _fontSize scalefont setfont
+		}
+		{
+		pop
+		exch
+		} ifelse
+	2 index 0 eq
+	{
+		Tx
+	}
+	{
+		Tj
+	} ifelse
+	pop	pop
+	setfont
+} def
+/T^	/X^	load def
+userdict /Adobe_ColorImage_AI6 known not
+{
+	userdict /Adobe_ColorImage_AI6 24 dict put 
+} if
+userdict /Adobe_ColorImage_AI6 get begin
+/initialize
+{ 
+	Adobe_ColorImage_AI6 begin
+	Adobe_ColorImage_AI6
+	{
+		dup type /arraytype eq
+		{
+			dup xcheck
+			{
+				bind
+			} if
+		} if
+		pop pop
+	} forall
+} def
+/terminate { end } def
+currentdict /Adobe_ColorImage_AI6_Vars known not
+{
+	/Adobe_ColorImage_AI6_Vars 15 dict def
+} if
+Adobe_ColorImage_AI6_Vars begin
+	/channelcount 0 def
+	/sourcecount 0 def
+	/sourcearray 4 array def
+	/plateindex -1 def
+	/XIMask 0 def
+	/XIBinary 0 def
+	/XIChannelCount 0 def
+	/XIBitsPerPixel 0 def
+	/XIImageHeight 0 def
+	/XIImageWidth 0 def
+	/XIImageMatrix null def
+	/XIBuffer null def
+	/XIDataProc null def
+	/XIVersion 6 def
+end
+/WalkRGBString null def
+/WalkCMYKString null def
+/StuffRGBIntoGrayString null def
+/RGBToGrayImageProc null def
+/StuffCMYKIntoGrayString null def
+/CMYKToGrayImageProc null def
+/ColorImageCompositeEmulator null def
+/SeparateCMYKImageProc null def
+/FourEqual null def
+/TestPlateIndex null def
+currentdict /_colorimage known not
+{
+	/colorimage where
+	{
+		/colorimage get /_colorimage exch def
+	}
+	{
+		/_colorimage null def
+	} ifelse
+} if
+/_currenttransfer systemdict /currenttransfer get def
+/colorimage null def
+/XI null def
+/WalkRGBString
+{
+	0 3 index
+	dup length 1 sub 0 3 3 -1 roll
+	{
+		3 getinterval { } forall
+		5 index exec
+		3 index
+	} for
+	
+	 5 { pop } repeat
+} def
+/WalkCMYKString
+{
+	0 3 index
+	dup length 1 sub 0 4 3 -1 roll
+	{
+		4 getinterval { } forall
+		
+		6 index exec
+		
+		3 index
+		
+	} for
+	
+	5 { pop } repeat
+	
+} def
+/StuffRGBIntoGrayString
+{
+	.11 mul exch
+	
+	.59 mul add exch
+	
+	.3 mul add
+	
+	cvi 3 copy put
+	
+	pop 1 add
+} def
+/RGBToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin 
+		sourcearray 0 get exec
+		dup length 3 idiv string
+		dup 3 1 roll 
+		
+		/StuffRGBIntoGrayString load exch
+		WalkRGBString
+ end
+} def
+/StuffCMYKIntoGrayString
+{
+	exch .11 mul add
+	
+	exch .59 mul add
+	
+	exch .3 mul add
+	
+	dup 255 gt { pop 255 } if
+	
+	255 exch sub cvi 3 copy put
+	
+	pop 1 add
+} def
+/CMYKToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcearray 0 get exec
+		dup length 4 idiv string
+		dup 3 1 roll 
+		
+		/StuffCMYKIntoGrayString load exch
+		WalkCMYKString
+ end
+} def
+/ColorImageCompositeEmulator
+{
+	pop true eq
+	{
+		Adobe_ColorImage_AI6_Vars /sourcecount get 5 add { pop } repeat
+	}
+	{
+		Adobe_ColorImage_AI6_Vars /channelcount get 1 ne
+		{
+			Adobe_ColorImage_AI6_Vars begin
+				sourcearray 0 3 -1 roll put
+			
+				channelcount 3 eq 
+				{ 
+					/RGBToGrayImageProc 
+				}
+				{ 
+					/CMYKToGrayImageProc
+				} ifelse
+				load
+		 end
+		} if
+		image
+	} ifelse
+} def
+/SeparateCMYKImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcecount 0 ne
+		{
+			sourcearray plateindex get exec
+		}
+		{			
+			sourcearray 0 get exec
+			
+			dup length 4 idiv string
+			
+			0 2 index
+			
+			plateindex 4 2 index length 1 sub
+			{
+				get 255 exch sub
+				
+				3 copy put pop 1 add
+				
+				2 index
+			} for
+			pop pop exch pop
+		} ifelse
+ end
+} def
+	
+/FourEqual
+{
+	4 index ne
+	{
+		pop pop pop false
+	}
+	{
+		4 index ne
+		{
+			pop pop false
+		}
+		{
+			4 index ne
+			{
+				pop false
+			}
+			{
+				4 index eq
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/TestPlateIndex
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/plateindex -1 def
+		/setcmykcolor where
+		{
+			pop
+			gsave
+			1 0 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 1 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 1 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 0 1 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			grestore
+			1 0 0 0 FourEqual 
+			{ 
+				/plateindex 0 def
+			}
+			{
+				0 1 0 0 FourEqual
+				{ 
+					/plateindex 1 def
+				}
+				{
+					0 0 1 0 FourEqual
+					{
+						/plateindex 2 def
+					}
+					{
+						0 0 0 1 FourEqual
+						{ 
+							/plateindex 3 def
+						}
+						{
+							0 0 0 0 FourEqual
+							{
+								/plateindex 5 def
+							} if
+						} ifelse
+					} ifelse
+				} ifelse
+			} ifelse
+			pop pop pop pop
+		} if
+		plateindex
+ end
+} def
+/colorimage
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/channelcount 1 index def
+		/sourcecount 2 index 1 eq { channelcount 1 sub } { 0 } ifelse def
+		4 sourcecount add index dup 
+		8 eq exch 1 eq or not
+ end
+	
+	{
+		/_colorimage load null ne
+		{
+			_colorimage
+		}
+		{
+			Adobe_ColorImage_AI6_Vars /sourcecount get
+			7 add { pop } repeat
+		} ifelse
+	}
+	{
+		dup 3 eq
+		TestPlateIndex
+		dup -1 eq exch 5 eq or or
+		{
+			/_colorimage load null eq
+			{
+				ColorImageCompositeEmulator
+			}
+			{
+				dup 1 eq
+				{
+					pop pop image
+				}
+				{
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						gsave
+						
+						0 _currenttransfer exec
+						1 _currenttransfer exec
+						eq
+						{ 0 _currenttransfer exec 0.5 lt }
+						{ 0 _currenttransfer exec 1 _currenttransfer exec gt } ifelse
+						
+						{ { pop 0 } } { { pop 1 } } ifelse
+						systemdict /settransfer get exec
+					} if
+					
+					_colorimage
+					
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						grestore
+					} if
+				} ifelse
+			} ifelse
+		}
+		{
+			dup 1 eq
+			{
+				pop pop
+				image
+			}
+			{
+				pop pop
+				Adobe_ColorImage_AI6_Vars begin
+					sourcecount -1 0
+					{			
+						exch sourcearray 3 1 roll put
+					} for
+					/SeparateCMYKImageProc load
+			 end
+				systemdict /image get exec
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/XG
+{
+	pop pop
+} def
+/XF
+{
+	13 {pop} repeat
+} def
+/Xh
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		/XIImageMatrix exch def
+		0 0 moveto
+		XIImageMatrix concat
+		XIImageWidth XIImageHeight scale
+		
+		XIMask
+		{
+			/_lp /null ddef
+			_fc
+			/_lp /imagemask ddef
+		}
+		if
+		/XIVersion 7 def
+ end
+} def
+/XH
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/XIVersion 6 def
+		grestore
+ end
+} def
+/XI
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIBinary exch 0 ne def
+		pop
+		pop
+		/XIChannelCount exch def
+		/XIBitsPerPixel exch def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		pop pop pop pop
+		/XIImageMatrix exch def
+		XIBitsPerPixel 1 eq
+		{
+			XIImageWidth 8 div ceiling cvi
+		}
+		{
+			XIImageWidth XIChannelCount mul
+		} ifelse
+		/XIBuffer exch string def
+		XIBinary
+		{
+			/XIDataProc { currentfile XIBuffer readstring pop } def
+			XIVersion 6 le
+			{
+				currentfile 128 string readline pop pop
+			}
+			if
+		}
+		{
+			/XIDataProc { currentfile XIBuffer readhexstring pop } def
+		} ifelse
+		
+		XIVersion 6 le
+		{
+			0 0 moveto
+			XIImageMatrix concat
+			XIImageWidth XIImageHeight scale
+			XIMask
+			{
+				/_lp /null ddef
+				_fc
+				/_lp /imagemask ddef
+			} if
+		} if
+		
+		XIMask
+		{
+			XIImageWidth XIImageHeight
+			false
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			imagemask
+		}
+		{
+			XIImageWidth XIImageHeight
+			XIBitsPerPixel
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			
+			XIChannelCount 1 eq
+			{
+				gsave
+				0 setgray
+				image
+				grestore
+			}
+			{
+				false
+				XIChannelCount
+				colorimage
+			} ifelse
+		} ifelse
+		grestore
+ end
+} def
+end
+currentpacking true setpacking
+userdict /Adobe_Illustrator_AI5_vars 107 dict dup begin
+put
+/_eo false def
+/_lp /none def
+/_pf
+{
+} def
+/_ps
+{
+} def
+/_psf
+{
+} def
+/_pss
+{
+} def
+/_pjsf
+{
+} def
+/_pjss
+{
+} def
+/_pola 0 def
+/_doClip 0 def
+/cf currentflat def
+/_lineorientation 0 def
+/_charorientation 0 def
+/_yokoorientation 0 def
+/_tm matrix def
+/_renderStart
+[
+/e0 /r0 /a0 /o0 /e1 /r1 /a1 /i0
+] def
+/_renderEnd
+[
+null null null null /i1 /i1 /i1 /i1
+] def
+/_render -1 def
+/_shift [0 0] def
+/_ax 0 def
+/_ay 0 def
+/_cx 0 def
+/_cy 0 def
+/_leading
+[
+0 0
+] def
+/_ctm matrix def
+/_mtx matrix def
+/_sp 16#020 def
+/_hyphen (-) def
+/_fontSize 0 def
+/_fontAscent 0 def
+/_fontDescent 0 def
+/_fontHeight 0 def
+/_fontRotateAdjust 0 def
+/Ss 256 string def
+Ss 0 (fonts/) putinterval
+/_cnt 0 def
+/_scale [1 1] def
+/_nativeEncoding 0 def
+/_useNativeEncoding 0 def
+/_tempEncode 0 def
+/_pntr 0 def
+/_tDict 2 dict def
+/_hfname 100 string def
+/_hffound false def
+/Tx
+{
+} def
+/Tj
+{
+} def
+/CRender
+{
+} def
+/_AI3_savepage
+{
+} def
+/_gf null def
+/_cf 4 array def
+/_rgbf 3 array def
+/_if null def
+/_of false def
+/_fc
+{
+} def
+/_gs null def
+/_cs 4 array def
+/_rgbs 3 array def
+/_is null def
+/_os false def
+/_sc
+{
+} def
+/_pd 1 dict def
+/_ed 15 dict def
+/_pm matrix def
+/_fm null def
+/_fd null def
+/_fdd null def
+/_sm null def
+/_sd null def
+/_sdd null def
+/_i null def
+/_lobyte 0 def
+/_hibyte 0 def
+/_cproc null def
+/_cscript 0 def
+/_hvax 0 def
+/_hvay 0 def
+/_hvwb 0 def
+/_hvcx 0 def
+/_hvcy 0 def
+/_bitfont null def
+/_bitlobyte 0 def
+/_bithibyte 0 def
+/_bitkey null def
+/_bitdata null def
+/_bitindex 0 def
+/discardSave null def
+/buffer 256 string def
+/beginString null def
+/endString null def
+/endStringLength null def
+/layerCnt 1 def
+/layerCount 1 def
+/perCent (%) 0 get def
+/perCentSeen? false def
+/newBuff null def
+/newBuffButFirst null def
+/newBuffLast null def
+/clipForward? false def
+end
+userdict /Adobe_Illustrator_AI5 known not {
+	userdict /Adobe_Illustrator_AI5 95 dict put
+} if
+userdict /Adobe_Illustrator_AI5 get begin
+/initialize
+{
+	Adobe_Illustrator_AI5 dup begin
+	Adobe_Illustrator_AI5_vars begin
+	discardDict
+	{
+		bind pop pop
+	} forall
+	dup /nc get begin
+	{
+		dup xcheck 1 index type /operatortype ne and
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	newpath
+} def
+/terminate
+{
+ end
+ end
+} def
+/_
+null def
+/ddef
+{
+	Adobe_Illustrator_AI5_vars 3 1 roll put
+} def
+/xput
+{
+	dup load dup length exch maxlength eq
+	{
+		dup dup load dup
+		length 2 mul dict copy def
+	} if
+	load begin
+	def
+ end
+} def
+/npop
+{
+	{
+		pop
+	} repeat
+} def
+/hswj
+{
+	dup stringwidth 3 2 roll
+	{
+		_hvwb eq { exch _hvcx add exch _hvcy add } if
+		exch _hvax add exch _hvay add
+	} cforall
+} def
+/vswj
+{
+	0 0 3 -1 roll
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			dup cstring stringwidth 5 2 roll
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			4 -1 roll sub exch
+			3 -1 roll sub exch
+		}
+		{
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			_fontHeight sub
+		} ifelse
+	} cforall
+} def
+/swj
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hswj } { vswj } ifelse
+} def
+/sw
+{
+	0 0 0 6 3 roll swj
+} def
+/vjss
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			5 index setmatrix stroke
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			gsave
+			2 index false charpath
+			6 index setmatrix stroke
+			grestore
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjss
+{
+	4 1 roll
+	{
+		dup cstring
+		gsave
+		false charpath currentpoint
+		5 index setmatrix stroke
+		grestore
+		moveto
+		_sp eq
+		{
+			5 index 5 index rmoveto
+		} if
+		2 copy rmoveto
+	} cforall
+	6 npop
+} def
+/jss
+{
+	_lineorientation 0 eq { hjss } { vjss } ifelse
+} def
+/ss
+{
+	0 0 0 7 3 roll jss
+} def
+/vjsp
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			false charpath
+            currentpoint
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			2 index false charpath
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjsp
+{
+    4 1 roll
+    {
+        dup cstring
+        false charpath
+        _sp eq
+        {
+            5 index 5 index rmoveto
+        } if
+        2 copy rmoveto
+    } cforall
+    6 npop
+} def
+/jsp
+{
+	matrix currentmatrix
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/sp
+{
+    matrix currentmatrix
+    0 0 0 7 3 roll
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/pl
+{
+	transform
+	0.25 sub round 0.25 add exch
+	0.25 sub round 0.25 add exch
+	itransform
+} def
+/setstrokeadjust where
+{
+	pop true setstrokeadjust
+	/c
+	{
+		curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		moveto
+	} def
+}
+{
+	/c
+	{
+		pl curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll pl curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		pl 2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		pl lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		pl moveto
+	} def
+} ifelse
+/d
+{
+	setdash
+} def
+/cf
+{
+} def
+/i
+{
+	dup 0 eq
+	{
+		pop cf
+	} if
+	setflat
+} def
+/j
+{
+	setlinejoin
+} def
+/J
+{
+	setlinecap
+} def
+/M
+{
+	setmiterlimit
+} def
+/w
+{
+	setlinewidth
+} def
+/XR
+{
+	0 ne
+	/_eo exch ddef
+} def
+/H
+{
+} def
+/h
+{
+	closepath
+} def
+/N
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			_eo {eoclip} {clip} ifelse /_doClip 0 ddef
+		} if
+		newpath
+	}
+	{
+		/CRender
+		{
+			N
+		} ddef
+	} ifelse
+} def
+/n
+{
+	N
+} def
+/F
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _pf grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _fc
+			/_doClip 0 ddef
+		}
+		{
+			_pf
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			F
+		} ddef
+	} ifelse
+} def
+/f
+{
+	closepath
+	F
+} def
+/S
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _ps grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			_ps
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			S
+		} ddef
+	} ifelse
+} def
+/s
+{
+	closepath
+	S
+} def
+/B
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		gsave F grestore
+		{
+			gsave S grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			S
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			B
+		} ddef
+	} ifelse
+} def
+/b
+{
+	closepath
+	B
+} def
+/W
+{
+	/_doClip 1 ddef
+} def
+/*
+{
+	count 0 ne
+	{
+		dup type /stringtype eq
+		{
+			pop
+		} if
+	} if
+	newpath
+} def
+/u
+{
+} def
+/U
+{
+} def
+/q
+{
+	_pola 0 eq
+	{
+		gsave
+	} if
+} def
+/Q
+{
+	_pola 0 eq
+	{
+		grestore
+	} if
+} def
+/*u
+{
+	_pola 1 add /_pola exch ddef
+} def
+/*U
+{
+	_pola 1 sub /_pola exch ddef
+	_pola 0 eq
+	{
+		CRender
+	} if
+} def
+/D
+{
+	pop
+} def
+/*w
+{
+} def
+/*W
+{
+} def
+/`
+{
+	/_i save ddef
+	clipForward?
+	{
+		nulldevice
+	} if
+	6 1 roll 4 npop
+	concat pop
+	userdict begin
+	/showpage
+	{
+	} def
+	0 setgray
+	0 setlinecap
+	1 setlinewidth
+	0 setlinejoin
+	10 setmiterlimit
+	[] 0 setdash
+	/setstrokeadjust where {pop false setstrokeadjust} if
+	newpath
+	0 setgray
+	false setoverprint
+} def
+/~
+{
+ end
+	_i restore
+} def
+/O
+{
+	0 ne
+	/_of exch ddef
+	/_lp /none ddef
+} def
+/R
+{
+	0 ne
+	/_os exch ddef
+	/_lp /none ddef
+} def
+/g
+{
+	/_gf exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_gf setgray
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/G
+{
+	/_gs exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_gs setgray
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/k
+{
+	_cf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_cf aload pop setcmykcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/K
+{
+	_cs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_cs aload pop setcmykcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/Xa
+{
+	_rgbf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_rgbf aload pop setrgbcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XA
+{
+	_rgbs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_rgbs aload pop setrgbcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/_rgbtocmyk
+{
+3
+	{
+	1 exch sub 3 1 roll
+	} repeat
+3 copy 1 4 1 roll
+3
+	{
+	3 index 2 copy gt
+		{
+		exch
+		} if
+	pop 4 1 roll
+	} repeat
+pop pop pop
+4 1 roll
+3
+	{
+	3 index sub
+	3 1 roll
+	} repeat
+4 -1 roll
+} def
+/Xx
+{
+	exch
+	/_gf exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XX
+{
+	exch
+	/_gs exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/x
+{
+	/_gf exch ddef
+	findcmykcustomcolor
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/X
+{
+	/_gs exch ddef
+	findcmykcustomcolor
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/A
+{
+	pop
+} def
+/annotatepage
+{
+userdict /annotatepage 2 copy known {get exec} {pop pop} ifelse
+} def
+/XT {
+	pop pop
+} def
+/discard
+{
+	save /discardSave exch store
+	discardDict begin
+	/endString exch store
+	gt38?
+	{
+		2 add
+	} if
+	load
+	stopped
+	pop
+ end
+	discardSave restore
+} bind def
+userdict /discardDict 7 dict dup begin
+put
+/pre38Initialize
+{
+	/endStringLength endString length store
+	/newBuff buffer 0 endStringLength getinterval store
+	/newBuffButFirst newBuff 1 endStringLength 1 sub getinterval store
+	/newBuffLast newBuff endStringLength 1 sub 1 getinterval store
+} def
+/shiftBuffer
+{
+	newBuff 0 newBuffButFirst putinterval
+	newBuffLast 0
+	currentfile read not
+	{
+	stop
+	} if
+	put
+} def
+0
+{
+	pre38Initialize
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff endString eq
+			{
+				cleartomark stop
+			} if
+			shiftBuffer
+		} loop
+	}
+	{
+	stop
+	} ifelse
+} def
+1
+{
+	pre38Initialize
+	/beginString exch store
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff beginString eq
+			{
+				/layerCount dup load 1 add store
+			}
+			{
+				newBuff endString eq
+				{
+					/layerCount dup load 1 sub store
+					layerCount 0 eq
+					{
+						cleartomark stop
+					} if
+				} if
+			} ifelse
+			shiftBuffer
+		} loop
+	} if
+} def
+2
+{
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		endString eq
+		{
+			cleartomark stop
+		} if
+	} loop
+} def
+3
+{
+	/beginString exch store
+	/layerCnt 1 store
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		dup beginString eq
+		{
+			pop /layerCnt dup load 1 add store
+		}
+		{
+			endString eq
+			{
+				layerCnt 1 eq
+				{
+					cleartomark stop
+				}
+				{
+					/layerCnt dup load 1 sub store
+				} ifelse
+			} if
+		} ifelse
+	} loop
+} def
+end
+userdict /clipRenderOff 15 dict dup begin
+put
+{
+	/n /N /s /S /f /F /b /B
+}
+{
+	{
+		_doClip 1 eq
+		{
+			/_doClip 0 ddef _eo {eoclip} {clip} ifelse
+		} if
+		newpath
+	} def
+} forall
+/Tr /pop load def
+/Bb {} def
+/BB /pop load def
+/Bg {12 npop} def
+/Bm {6 npop} def
+/Bc /Bm load def
+/Bh {4 npop} def
+end
+/Lb
+{
+	4 npop
+	6 1 roll
+	pop
+	4 1 roll
+	pop pop pop
+	0 eq
+	{
+		0 eq
+		{
+			(%AI5_BeginLayer) 1 (%AI5_EndLayer--) discard
+		}
+		{
+			
+			/clipForward? true def
+			
+			/Tx /pop load def
+			/Tj /pop load def
+			
+			currentdict end clipRenderOff begin begin
+		} ifelse
+	}
+	{
+		0 eq
+		{
+			save /discardSave exch store
+		} if
+	} ifelse
+} bind def
+/LB
+{
+	discardSave dup null ne
+	{
+		restore
+	}
+	{
+		pop
+		clipForward?
+		{
+			currentdict
+		 end
+		 end
+		 begin
+					
+			/clipForward? false ddef
+		} if
+	} ifelse
+} bind def
+/Pb
+{
+	pop pop
+	0 (%AI5_EndPalette) discard
+} bind def
+/Np
+{
+	0 (%AI5_End_NonPrinting--) discard
+} bind def
+/Ln /pop load def
+/Ap
+/pop load def
+/Ar
+{
+	72 exch div
+	0 dtransform dup mul exch dup mul add sqrt
+	dup 1 lt
+	{
+		pop 1
+	} if
+	setflat
+} def
+/Mb
+{
+	q
+} def
+/Md
+{
+} def
+/MB
+{
+	Q
+} def
+/nc 4 dict def
+nc begin
+/setgray
+{
+	pop
+} bind def
+/setcmykcolor
+{
+	4 npop
+} bind def
+/setrgbcolor
+{
+	3 npop
+} bind def
+/setcustomcolor
+{
+	2 npop
+} bind def
+currentdict readonly pop
+end
+end
+setpacking
+currentpacking true setpacking
+userdict /Adobe_cshow 14 dict dup begin put
+/initialize
+{
+	Adobe_cshow begin
+	Adobe_cshow
+	{
+		dup xcheck
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	Adobe_cshow begin
+} def
+/terminate
+{
+currentdict Adobe_cshow eq
+	{
+ end
+	} if
+} def
+/cforall
+{
+	/_lobyte 0 ddef
+	/_hibyte 0 ddef
+	/_cproc exch ddef
+	/_cscript currentfont /FontScript known { currentfont /FontScript get } { -1 } ifelse ddef
+	{
+		/_lobyte exch ddef
+		_hibyte 0 eq
+		_cscript 1 eq
+		_lobyte 129 ge _lobyte 159 le and
+		_lobyte 224 ge _lobyte 252 le and or and
+		_cscript 2 eq
+		_lobyte 161 ge _lobyte 254 le and and
+		_cscript 3 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript 25 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript -1 eq
+		or or or or and
+		{
+			/_hibyte _lobyte ddef
+		}
+		{
+			_hibyte 256 mul _lobyte add
+			_cproc
+			/_hibyte 0 ddef
+		} ifelse
+	} forall
+} def
+/cstring
+{
+	dup 256 lt
+	{
+		(s) dup 0 4 3 roll put
+	}
+	{
+		dup 256 idiv exch 256 mod
+		(hl) dup dup 0 6 5 roll put 1 4 3 roll put
+	} ifelse
+} def
+/clength
+{
+	0 exch
+	{ 256 lt { 1 } { 2 } ifelse add } cforall
+} def
+/hawidthshow
+{
+	{
+		dup cstring
+		show
+		_hvax _hvay rmoveto
+		_hvwb eq { _hvcx _hvcy rmoveto } if
+	} cforall
+} def
+/vawidthshow
+{
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			0 _fontRotateAdjust rmoveto
+			cstring
+			_hvcx _hvcy _hvwb _hvax _hvay 6 -1 roll awidthshow
+			0 _fontRotateAdjust neg rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			exch _hvay sub exch _hvax sub
+			2 index _hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			3 2 roll
+			cstring
+			dup stringwidth pop 2 div neg _fontAscent neg rmoveto
+			show
+			moveto
+		} ifelse
+	} cforall
+} def
+/hvawidthshow
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hawidthshow } { vawidthshow } ifelse
+} def
+/hvwidthshow
+{
+	0 0 3 -1 roll hvawidthshow
+} def
+/hvashow
+{
+	0 0 0 6 -3 roll hvawidthshow
+} def
+/hvshow
+{
+	0 0 0 0 0 6 -1 roll hvawidthshow
+} def
+currentdict readonly pop end
+setpacking
+Adobe_level2_AI5 /initialize get exec
+Adobe_cshow /initialize get exec
+Adobe_Illustrator_AI5_vars Adobe_Illustrator_AI5 Adobe_typography_AI5 /initialize get exec
+Adobe_ColorImage_AI6 /initialize get exec
+Adobe_Illustrator_AI5 /initialize get exec
+[
+39/quotesingle 96/grave 130/quotesinglbase/florin/quotedblbase/ellipsis
+/dagger/daggerdbl/circumflex/perthousand/Scaron/guilsinglleft/OE 145/quoteleft
+/quoteright/quotedblleft/quotedblright/bullet/endash/emdash/tilde/trademark
+/scaron/guilsinglright/oe/dotlessi 159/Ydieresis 164/currency 166/brokenbar
+168/dieresis/copyright/ordfeminine 172/logicalnot 174/registered/macron/ring
+/plusminus/twosuperior/threesuperior/acute/mu 183/periodcentered/cedilla
+/onesuperior/ordmasculine 188/onequarter/onehalf/threequarters 192/Agrave
+/Aacute/Acircumflex/Atilde/Adieresis/Aring/AE/Ccedilla/Egrave/Eacute
+/Ecircumflex/Edieresis/Igrave/Iacute/Icircumflex/Idieresis/Eth/Ntilde
+/Ograve/Oacute/Ocircumflex/Otilde/Odieresis/multiply/Oslash/Ugrave
+/Uacute/Ucircumflex/Udieresis/Yacute/Thorn/germandbls/agrave/aacute
+/acircumflex/atilde/adieresis/aring/ae/ccedilla/egrave/eacute/ecircumflex
+/edieresis/igrave/iacute/icircumflex/idieresis/eth/ntilde/ograve/oacute
+/ocircumflex/otilde/odieresis/divide/oslash/ugrave/uacute/ucircumflex
+/udieresis/yacute/thorn/ydieresis
+TE
+%AI55J_Tsume: None
+%AI3_BeginEncoding: _Times-Bold Times-Bold
+[/_Times-Bold/Times-Bold 0 0 1 TZ
+%AI3_EndEncoding AdobeType
+%AI5_Begin_NonPrinting
+Np
+%AI3_BeginPattern: (Arrow1.2.out/in)
+(Arrow1.2.out/in) 1 1 39.4039 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+33.9039 15.6187 m
+39.4247 20.202 L
+39.4247 20.202 L
+33.8869 24.6252 L
+S
+39.2997 20.202 m
+24.5706 20.202 l
+20.4039 20.4792 20.4039 16.8125 v
+20.4039 13.1458 20.4039 12.5625 y
+S
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Arrow1.2.side)
+(Arrow1.2.side) 1 1 39.404 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+20.202 20.202 m
+39.404 20.202 l
+S
+33.904 15.6187 m
+39.4248 20.202 L
+39.4248 20.202 L
+33.887 24.6252 L
+S
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Bricks)
+(Bricks) 1.6 1.6 73.6 73.6 [
+%AI3_Tile
+(0 O 0 R  0.3 0.85 0.85 0 k
+ 0.3 0.85 0.85 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+1.6 1.6 m
+1.6 73.6 L
+73.6 73.6 L
+73.6 1.6 L
+1.6 1.6 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+1.6 70.01 m
+73.6 70.01 l
+S
+1.6 62.809 m
+73.6 62.809 L
+S
+1.6 55.609 m
+73.6 55.609 L
+S
+1.6 48.408 m
+73.6 48.408 L
+S
+1.6 41.208 m
+73.6 41.208 L
+S
+1.6 34.007 m
+73.6 34.007 L
+S
+1.6 26.807 m
+73.6 26.807 L
+S
+1.6 19.606 m
+73.6 19.606 L
+S
+1.6 12.406 m
+73.6 12.406 L
+S
+1.6 5.206 m
+73.6 5.206 L
+S
+70.01 70.01 m
+70.01 62.822 l
+S
+55.61 70.01 m
+55.61 62.822 L
+S
+41.21 70.01 m
+41.21 62.822 L
+S
+26.81 70.01 m
+26.81 62.822 L
+S
+12.41 70.01 m
+12.41 62.822 L
+S
+70.01 55.572 m
+70.01 48.385 l
+S
+55.61 55.572 m
+55.61 48.385 L
+S
+41.21 55.572 m
+41.21 48.385 L
+S
+26.81 55.572 m
+26.81 48.385 L
+S
+12.41 55.572 m
+12.41 48.385 L
+S
+70.01 41.197 m
+70.01 34.01 l
+S
+55.61 41.197 m
+55.61 34.01 L
+S
+41.21 41.197 m
+41.21 34.01 L
+S
+26.81 41.197 m
+26.81 34.01 L
+S
+12.41 41.197 m
+12.41 34.01 L
+S
+70.01 26.822 m
+70.01 19.635 l
+S
+55.61 26.822 m
+55.61 19.635 L
+S
+41.21 26.822 m
+41.21 19.635 L
+S
+26.81 26.822 m
+26.81 19.635 L
+S
+12.41 26.822 m
+12.41 19.635 L
+S
+70.01 12.385 m
+70.01 5.197 l
+S
+55.61 12.385 m
+55.61 5.197 L
+S
+41.21 12.385 m
+41.21 5.197 L
+S
+26.81 12.385 m
+26.81 5.197 L
+S
+12.41 12.385 m
+12.41 5.197 L
+S
+62.797 5.197 m
+62.797 1.6 L
+S
+48.397 5.197 m
+48.397 1.6 L
+S
+33.997 5.197 m
+33.997 1.6 L
+S
+19.597 5.197 m
+19.597 1.6 L
+S
+5.197 5.197 m
+5.197 1.6 l
+S
+62.797 19.635 m
+62.797 12.447 L
+S
+48.397 19.635 m
+48.397 12.447 L
+S
+33.997 19.635 m
+33.997 12.447 L
+S
+19.597 19.635 m
+19.597 12.447 L
+S
+5.197 19.635 m
+5.197 12.447 l
+S
+62.797 34.01 m
+62.797 26.822 L
+S
+48.397 34.01 m
+48.397 26.822 L
+S
+19.597 34.01 m
+19.597 26.822 L
+S
+5.197 34.01 m
+5.197 26.822 l
+S
+62.797 48.385 m
+62.797 41.197 L
+S
+48.397 48.385 m
+48.397 41.197 L
+S
+33.997 48.385 m
+33.997 41.197 L
+S
+19.597 48.385 m
+19.597 41.197 L
+S
+5.197 48.385 m
+5.197 41.197 l
+S
+62.797 62.822 m
+62.797 55.635 L
+S
+48.397 62.822 m
+48.397 55.635 L
+S
+33.997 62.822 m
+33.997 55.635 L
+S
+19.597 62.822 m
+19.597 55.635 L
+S
+5.197 62.822 m
+5.197 55.635 l
+S
+62.797 73.5589 m
+62.797 70.072 L
+S
+48.397 73.5589 m
+48.397 70.072 L
+S
+33.997 73.5589 m
+33.997 70.072 L
+S
+19.597 73.5589 m
+19.597 70.072 L
+S
+5.197 73.5589 m
+5.197 70.072 l
+S
+33.997 34.01 m
+33.997 26.822 L
+S
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Checks)
+(Checks) 1 1 31.3995 31.3995 [
+%AI3_Tile
+(0 O 0 R  0 0.91 1 0 k
+ 0 0.91 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+1 XR
+19.9995 4.8 m
+27.5995 4.8 L
+27.5995 12.3995 L
+19.9995 12.3995 L
+19.9995 4.8 L
+f
+31.3995 27.5995 m
+31.3995 31.3995 L
+27.5995 31.3995 L
+27.5995 27.5995 L
+31.3995 27.5995 L
+f
+19.9995 27.5995 m
+19.9995 19.9995 L
+27.5995 19.9995 L
+27.5995 27.5995 L
+19.9995 27.5995 L
+f
+0 XR
+12.3995 12.3995 m
+19.9995 12.3995 L
+19.9995 19.9995 L
+12.3995 19.9995 L
+12.3995 12.3995 L
+f
+1 XR
+12.3995 27.5995 m
+4.8 27.5995 L
+4.8 19.9995 L
+12.3995 19.9995 L
+12.3995 27.5995 L
+f
+4.8 12.3995 m
+4.8 4.8 L
+12.3995 4.8 L
+12.3995 12.3995 L
+4.8 12.3995 L
+f
+19.9995 27.5995 m
+19.9995 31.3995 L
+12.3995 31.3995 L
+12.3995 27.5995 L
+19.9995 27.5995 L
+f
+12.3995 4.8 m
+12.3995 1 L
+19.9995 1 L
+19.9995 4.8 L
+12.3995 4.8 L
+f
+4.8 19.9995 m
+1 19.9995 L
+1 12.3995 L
+4.8 12.3995 L
+4.8 19.9995 L
+f
+27.5995 19.9995 m
+27.5995 12.3995 L
+31.3995 12.3995 L
+31.3995 19.9995 L
+27.5995 19.9995 L
+f
+4.8 31.3995 m
+1 31.3995 L
+1 27.5995 L
+4.8 27.5995 L
+4.8 31.3995 L
+f
+27.5995 1 m
+31.3995 1 L
+31.3995 4.8 L
+27.5995 4.8 L
+27.5995 1 L
+f
+1 4.8 m
+1 1 L
+4.8 1 L
+4.8 4.8 L
+1 4.8 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.05 0.2 0 k
+ 0 0.05 0.2 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+1 XR
+4.8 4.8 m
+4.8 1 L
+12.3995 1 L
+12.3995 4.8 L
+4.8 4.8 L
+f
+4.8 12.3995 m
+1 12.3995 L
+1 4.8 L
+4.8 4.8 L
+4.8 12.3995 L
+f
+19.9995 4.8 m
+19.9995 1 L
+27.5995 1 L
+27.5995 4.8 L
+19.9995 4.8 L
+f
+12.3995 12.3995 m
+12.3995 4.8 L
+19.9995 4.8 L
+19.9995 12.3995 L
+12.3995 12.3995 L
+f
+27.5995 4.8 m
+31.3995 4.8 L
+31.3995 12.3995 L
+27.5995 12.3995 L
+27.5995 4.8 L
+f
+12.3995 19.9995 m
+4.8 19.9995 L
+4.8 12.3995 L
+12.3995 12.3995 L
+12.3995 19.9995 L
+f
+4.8 27.5995 m
+1 27.5995 L
+1 19.9995 L
+4.8 19.9995 L
+4.8 27.5995 L
+f
+19.9995 12.3995 m
+27.5995 12.3995 L
+27.5995 19.9995 L
+19.9995 19.9995 L
+19.9995 12.3995 L
+f
+19.9995 19.9995 m
+19.9995 27.5995 L
+12.3995 27.5995 L
+12.3995 19.9995 L
+19.9995 19.9995 L
+f
+27.5995 19.9995 m
+31.3995 19.9995 L
+31.3995 27.5995 L
+27.5995 27.5995 L
+27.5995 19.9995 L
+f
+12.3995 27.5995 m
+12.3995 31.3995 L
+4.8 31.3995 L
+4.8 27.5995 L
+12.3995 27.5995 L
+f
+27.5995 27.5995 m
+27.5995 31.3995 L
+19.9995 31.3995 L
+19.9995 27.5995 L
+27.5995 27.5995 L
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Confetti)
+(Confetti) 4.85 3.617 76.85 75.617 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+4.85 3.617 m
+4.85 75.617 L
+76.85 75.617 L
+76.85 3.617 L
+4.85 3.617 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+10.6 64.867 m
+7.85 62.867 l
+S
+9.1 8.617 m
+6.85 6.867 l
+S
+78.1 68.617 m
+74.85 67.867 l
+S
+76.85 56.867 m
+74.35 55.117 l
+S
+79.6 51.617 m
+76.6 51.617 l
+S
+76.35 44.117 m
+73.6 45.867 l
+S
+78.6 35.867 m
+76.6 34.367 l
+S
+76.1 23.867 m
+73.35 26.117 l
+S
+78.1 12.867 m
+73.85 13.617 l
+S
+68.35 14.617 m
+66.1 12.867 l
+S
+76.6 30.617 m
+73.6 30.617 l
+S
+62.85 58.117 m
+60.956 60.941 l
+S
+32.85 59.617 m
+31.196 62.181 l
+S
+47.891 64.061 m
+49.744 66.742 l
+S
+72.814 2.769 m
+73.928 5.729 l
+S
+67.976 2.633 m
+67.35 5.909 l
+S
+61.85 27.617 m
+59.956 30.441 l
+S
+53.504 56.053 m
+51.85 58.617 l
+S
+52.762 1.779 m
+52.876 4.776 l
+S
+45.391 5.311 m
+47.244 7.992 l
+S
+37.062 3.375 m
+35.639 5.43 l
+S
+55.165 34.828 m
+57.518 37.491 l
+S
+20.795 3.242 m
+22.12 5.193 l
+S
+14.097 4.747 m
+15.008 8.965 l
+S
+9.736 1.91 m
+8.073 4.225 l
+S
+31.891 5.573 m
+32.005 8.571 l
+S
+12.1 70.367 m
+15.6 68.867 l
+S
+9.35 54.867 m
+9.6 58.117 l
+S
+12.85 31.867 m
+14.35 28.117 l
+S
+10.1 37.367 m
+12.35 41.117 l
+S
+34.1 71.117 m
+31.85 68.617 l
+S
+38.35 71.117 m
+41.6 68.367 l
+S
+55.1 71.117 m
+58.35 69.117 l
+S
+57.35 65.117 m
+55.35 61.867 l
+S
+64.35 66.367 m
+69.35 68.617 l
+S
+71.85 62.867 m
+69.35 61.117 l
+S
+23.6 70.867 m
+23.6 67.867 l
+S
+20.6 65.867 m
+17.35 65.367 l
+S
+24.85 61.367 m
+25.35 58.117 l
+S
+25.85 65.867 m
+29.35 66.617 l
+S
+14.1 54.117 m
+16.85 56.117 l
+S
+12.35 11.617 m
+12.6 15.617 l
+S
+12.1 19.867 m
+14.35 22.367 l
+S
+26.1 9.867 m
+23.6 13.367 l
+S
+34.6 47.117 m
+32.1 45.367 l
+S
+62.6 41.867 m
+59.85 43.367 l
+S
+31.6 35.617 m
+27.85 36.367 l
+S
+36.35 26.117 m
+34.35 24.617 l
+S
+33.85 14.117 m
+31.1 16.367 l
+S
+37.1 9.867 m
+35.1 11.117 l
+S
+34.35 20.867 m
+31.35 20.867 l
+S
+44.6 56.617 m
+42.1 54.867 l
+S
+47.35 51.367 m
+44.35 51.367 l
+S
+44.1 43.867 m
+41.35 45.617 l
+S
+43.35 33.117 m
+42.6 30.617 l
+S
+43.85 23.617 m
+41.1 25.867 l
+S
+44.35 15.617 m
+42.35 16.867 l
+S
+67.823 31.1 m
+64.823 31.1 l
+S
+27.1 32.617 m
+29.6 30.867 l
+S
+31.85 55.117 m
+34.85 55.117 l
+S
+19.6 40.867 m
+22.1 39.117 l
+S
+16.85 35.617 m
+19.85 35.617 l
+S
+20.1 28.117 m
+22.85 29.867 l
+S
+52.1 42.617 m
+54.484 44.178 l
+S
+52.437 50.146 m
+54.821 48.325 l
+S
+59.572 54.133 m
+59.35 51.117 l
+S
+50.185 10.055 m
+53.234 9.928 l
+S
+51.187 15.896 m
+53.571 14.075 l
+S
+58.322 19.883 m
+59.445 16.823 l
+S
+53.1 32.117 m
+50.6 30.367 l
+S
+52.85 24.617 m
+49.6 25.617 l
+S
+61.85 9.117 m
+59.1 10.867 l
+S
+69.35 34.617 m
+66.6 36.367 l
+S
+67.1 23.617 m
+65.1 22.117 l
+S
+24.435 46.055 m
+27.484 45.928 l
+S
+25.437 51.896 m
+27.821 50.075 l
+S
+62.6 47.117 m
+65.321 46.575 l
+S
+19.85 19.867 m
+20.35 16.617 l
+S
+21.85 21.867 m
+25.35 22.617 l
+S
+37.6 62.867 m
+41.6 62.117 l
+S
+38.323 42.1 m
+38.823 38.6 l
+S
+69.35 52.617 m
+66.85 53.867 l
+S
+14.85 62.117 m
+18.1 59.367 l
+S
+9.6 46.117 m
+7.1 44.367 l
+S
+20.6 51.617 m
+18.6 50.117 l
+S
+46.141 70.811 m
+47.994 73.492 l
+S
+69.391 40.561 m
+71.244 43.242 l
+S
+38.641 49.311 m
+39.35 52.117 l
+S
+25.141 16.811 m
+25.85 19.617 l
+S
+36.6 32.867 m
+34.6 31.367 l
+S
+6.1 68.617 m
+2.85 67.867 l
+S
+4.85 56.867 m
+2.35 55.117 l
+S
+7.6 51.617 m
+4.6 51.617 l
+S
+6.6 35.867 m
+4.6 34.367 l
+S
+6.1 12.867 m
+1.85 13.617 l
+S
+4.6 30.617 m
+1.6 30.617 l
+S
+72.814 74.769 m
+73.928 77.729 l
+S
+67.976 74.633 m
+67.35 77.909 l
+S
+52.762 73.779 m
+52.876 76.776 l
+S
+37.062 75.375 m
+35.639 77.43 l
+S
+20.795 75.242 m
+22.12 77.193 l
+S
+9.736 73.91 m
+8.073 76.225 l
+S
+10.1 23.617 m
+6.35 24.367 l
+S
+73.217 18.276 m
+71.323 21.1 l
+S
+28.823 39.6 m
+29.505 42.389 l
+S
+49.6 38.617 m
+47.6 37.117 l
+S
+60.323 73.6 m
+62.323 76.6 l
+S
+60.323 1.6 m
+62.323 4.6 l
+S
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (DblLine1.2.inner)
+(DblLine1.2.inner) 1 1 39.2705 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+39.2702 22.175 m
+39.2702 13.6108 L
+26.66 13.6108 L
+26.66 1.0003 L
+18.0958 1.0003 L
+18.0948 22.175 L
+18.0958 22.175 L
+18.0958 22.1752 L
+39.2702 22.175 L
+f
+39.2708 24.6929 m
+15.5779 24.6929 L
+15.5779 1.0003 L
+14.9037 1.0003 L
+14.9032 25.3675 L
+39.2708 25.3675 L
+39.2708 24.6929 L
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (DblLine1.2.outer)
+(DblLine1.2.outer) 1 1.0003 39.2706 39.271 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+39.2708 26.6602 m
+13.6111 26.6602 L
+13.6111 1.0005 L
+22.1751 1 L
+22.1751 18.096 L
+39.2708 18.096 L
+39.2708 26.6602 L
+f
+39.2708 15.578 m
+24.6928 15.578 L
+24.6928 1 L
+25.367 1 L
+25.367 14.9038 L
+39.2708 14.9038 L
+39.2708 15.578 L
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (DblLine1.2.side)
+(DblLine1.2.side) 1 1 39.2706 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+39.2704 18.0958 m
+39.2704 26.6598 L
+1.0001 26.6598 L
+1.0001 18.0958 L
+39.2704 18.0958 L
+f
+39.2704 14.9037 m
+39.2704 15.5776 L
+1.0001 15.5776 L
+1.0001 14.9037 L
+39.2704 14.9037 L
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Diamonds)
+(Diamonds) 1 1 37.1865 41.9411 [
+%AI3_Tile
+(0 O 0 R  0.21 0 1 0 k
+ 0.21 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+1.0002 1.0004 m
+1.0002 41.9411 L
+37.1865 41.9411 L
+37.1865 1.0004 L
+1.0002 1.0004 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+1 XR
+19.0936 41.9408 m
+19.0929 41.9408 L
+19.0933 41.9402 L
+19.0936 41.9408 L
+f
+7.0311 41.9408 m
+7.0304 41.9408 L
+7.0308 41.9402 L
+7.0311 41.9408 L
+f
+31.1556 41.9408 m
+31.1548 41.9408 L
+31.1552 41.9402 L
+31.1556 41.9408 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.76 0.9 0 0 k
+ 0.76 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+1 XR
+37.1865 1 m
+37.1865 11.2349 L
+31.1552 1 L
+37.1865 1 L
+f
+19.0933 1 m
+31.1552 1 L
+25.124 11.2349 L
+19.0933 1 L
+f
+7.0308 1 m
+19.0933 1 L
+13.062 11.2349 L
+7.0308 1 L
+f
+1 1 m
+7.0308 1 L
+1 11.2349 L
+1 1 L
+f
+37.1859 11.2349 m
+37.1865 11.236 L
+37.1865 31.7059 L
+31.1552 21.4704 L
+37.1859 11.2349 L
+f
+19.0933 21.4704 m
+25.124 11.2349 L
+31.1552 21.4704 L
+25.124 31.7059 L
+19.0933 21.4704 L
+f
+7.0308 21.4704 m
+13.062 11.2349 L
+19.0933 21.4704 L
+13.062 31.7059 L
+7.0308 21.4704 L
+f
+1 31.7059 m
+1 11.2349 L
+7.0308 21.4704 L
+1 31.7059 L
+f
+37.1859 31.7059 m
+37.1865 31.707 L
+37.1865 41.9408 L
+31.1556 41.9408 L
+31.1552 41.9402 L
+37.1859 31.7059 L
+f
+25.124 31.7059 m
+31.1552 41.9402 L
+31.1548 41.9408 L
+19.0936 41.9408 L
+19.0933 41.9402 L
+25.124 31.7059 L
+f
+13.062 31.7059 m
+19.0933 41.9402 L
+19.0929 41.9408 L
+7.0311 41.9408 L
+7.0308 41.9402 L
+13.062 31.7059 L
+f
+7.0304 41.9408 m
+1 41.9408 L
+1 31.7059 L
+7.0308 41.9402 L
+7.0304 41.9408 L
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Hexagon)
+(Hexagon) 4 1.6 70.151 77.983 [
+%AI3_Tile
+(0 O 0 R  0 1 0.35 0 k
+ 0 1 0.35 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+70.151 77.983 m
+70.151 1.6 L
+4 1.6 L
+4 77.983 L
+70.151 77.983 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.9921 1 0 0 k
+ 0.9921 1 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+20.538 30.244 m
+S
+26.05 20.696 m
+15.025 20.696 L
+9.513 30.244 L
+15.025 39.792 L
+26.05 39.792 L
+31.564 30.244 L
+26.05 20.696 L
+s
+20.537 11.148 m
+S
+26.05 1.6 m
+15.024 1.6 L
+9.512 11.148 L
+15.024 20.696 L
+26.05 20.696 L
+31.563 11.148 L
+26.05 1.6 L
+s
+53.614 30.244 m
+S
+59.126 20.696 m
+48.101 20.696 L
+42.589 30.244 L
+48.101 39.792 L
+59.126 39.792 L
+64.639 30.244 L
+59.126 20.696 L
+s
+53.614 11.148 m
+S
+59.126 1.6 m
+48.101 1.6 L
+42.588 11.148 L
+48.101 20.696 L
+59.126 20.696 L
+64.638 11.148 L
+59.126 1.6 L
+s
+20.538 68.436 m
+S
+26.051 58.888 m
+15.025 58.888 L
+9.513 68.436 L
+15.025 77.984 L
+26.051 77.984 L
+31.564 68.436 L
+26.051 58.888 L
+s
+20.538 49.34 m
+S
+26.051 39.792 m
+15.025 39.792 L
+9.513 49.34 L
+15.025 58.888 L
+26.05 58.888 L
+31.564 49.34 L
+26.051 39.792 L
+s
+53.614 68.436 m
+S
+59.127 58.888 m
+48.102 58.888 L
+42.589 68.436 L
+48.101 77.985 L
+59.127 77.985 L
+64.639 68.436 L
+59.127 58.888 L
+s
+53.614 49.34 m
+S
+59.127 39.792 m
+48.101 39.792 L
+42.589 49.34 L
+48.101 58.888 L
+59.127 58.888 L
+64.639 49.341 L
+59.127 39.792 L
+s
+4 20.696 m
+S
+3.876 30.244 m
+9.512 30.244 L
+15.024 20.696 L
+9.512 11.147 L
+3.876 11.147 L
+S
+37.075 20.696 m
+S
+42.588 11.148 m
+31.563 11.148 L
+26.05 20.696 L
+31.563 30.244 L
+42.589 30.244 L
+48.101 20.696 L
+42.588 11.148 L
+s
+37.076 58.888 m
+S
+42.589 49.34 m
+31.564 49.34 L
+26.05 58.888 L
+31.564 68.436 L
+42.589 68.436 L
+48.101 58.888 L
+42.589 49.34 L
+s
+70.151 20.696 m
+S
+70.2094 11.147 m
+64.639 11.147 L
+59.127 20.696 L
+64.639 30.244 L
+70.2094 30.244 L
+S
+70.152 58.888 m
+S
+70.0427 49.34 m
+64.639 49.34 L
+59.127 58.888 L
+64.639 68.436 L
+70.0427 68.436 L
+S
+4 58.888 m
+S
+3.876 68.436 m
+9.513 68.436 L
+15.025 58.888 L
+9.513 49.34 L
+3.876 49.34 L
+S
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Laurel.inner)
+(Laurel.inner) 1 1 28.5392 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+19.2768 15.3585 m
+28.9144 15.3585 L
+28.9144 14.2335 L
+19.2768 14.2335 L
+19.2768 15.3585 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+14.7461 18.9624 m
+13.0264 17.8486 11.3273 14.4193 11.3273 10.0362 c
+11.3273 5.6547 12.9768 2.1518 14.744 1.1112 C
+14.7443 1.1112 L
+16.4707 2.1518 18.1679 5.6547 18.1679 10.0362 c
+18.1679 14.4143 16.432 17.8633 14.7461 18.9624 C
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Laurel.outer)
+(Laurel.outer) 1 1.3751 28.5393 28.9143 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+14.2395 10.6375 m
+14.2395 1 L
+15.3645 1 L
+15.3645 10.6375 L
+14.2395 10.6375 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+10.5769 15.124 m
+11.6906 16.8438 15.1198 18.5429 19.503 18.5429 c
+23.8844 18.5429 27.3874 16.8935 28.428 15.1262 C
+28.428 15.1259 L
+27.3874 13.3995 23.8844 11.7023 19.503 11.7023 c
+15.1249 11.7023 11.676 13.4382 10.5769 15.124 C
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Laurel.side)
+(Laurel.side) 1.3972 1 28.9364 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+29.1571 15.2998 m
+1 15.2998 L
+1 14.1748 L
+29.1571 14.1748 L
+29.1571 15.2998 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+2.0183 27.4787 m
+1.5899 25.4751 2.8132 21.8488 5.9125 18.7494 c
+9.0107 15.6513 12.654 14.3407 14.6395 14.8545 C
+14.6398 14.8547 L
+15.1246 16.8113 13.8478 20.4883 10.7496 23.5865 c
+7.6538 26.6824 3.9876 27.8936 2.0183 27.4787 C
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+2.0183 2.0091 m
+1.5899 4.0126 2.8132 7.6389 5.9125 10.7382 c
+9.0107 13.8365 12.654 15.147 14.6395 14.6332 C
+14.6398 14.633 L
+15.1246 12.6765 13.8478 8.9993 10.7496 5.9011 c
+7.6538 2.8054 3.9876 1.5941 2.0183 2.0091 C
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+15.821 2.0091 m
+15.3925 4.0126 16.6159 7.6389 19.7152 10.7382 c
+22.8134 13.8365 26.4567 15.147 28.4422 14.6332 C
+28.4424 14.633 L
+28.9273 12.6765 27.6505 8.9993 24.5523 5.9011 c
+21.4565 2.8054 17.7903 1.5941 15.821 2.0091 C
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+15.821 27.4787 m
+15.3925 25.4751 16.6159 21.8488 19.7152 18.7494 c
+22.8134 15.6513 26.4567 14.3407 28.4422 14.8545 C
+28.4424 14.8547 L
+28.9273 16.8113 27.6505 20.4883 24.5523 23.5865 c
+21.4565 26.6824 17.7903 27.8936 15.821 27.4787 C
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Leaves-fall)
+(Leaves-fall) 1 1 52.733 89.816 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 1 0 k
+ 0.05 0.2 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+52.733 89.816 m
+52.733 1 L
+1 1 L
+1 89.816 L
+52.733 89.816 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.83 0 1 0 k
+ 0.83 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+1 D
+0 XR
+25.317 2.083 m
+25.994 2.283 26.284 2.435 V
+24.815 5.147 29.266 9.428 30.186 10.168 C
+30.787 9.943 30.907 7.41 30.23 6.073 C
+31.073 6.196 33.262 4.818 34.02 3.529 C
+34.085 4.217 35.655 7.158 36.481 7.535 C
+35.561 7.933 34.896 9.406 34.134 10.854 C
+35.156 11.021 36.555 10.1 38.026 9.195 C
+38.541 9.996 39.915 10.968 41.174 11.484 C
+40.086 12.171 39.591 12.912 39.094 14.372 C
+38.052 13.806 35.865 13.657 35.336 13.944 C
+35.85 15.057 38.096 15.6 38.827 15.547 C
+38.573 16.409 38.425 18.562 38.598 21.155 C
+36.939 19.839 35.393 18.522 33.734 18.58 C
+34.003 17.158 33.367 15.353 32.99 14.86 C
+32.417 15.604 32.006 16.431 32.361 18.408 C
+30.908 18.893 29.671 19.439 28.297 20.697 C
+28.297 18.866 27.725 17.664 26.857 16.388 C
+28.117 15.9 29.389 14.697 29.385 13.658 C
+28.537 13.81 26.845 14.554 26.352 15.547 C
+25.634 14.8 23.95 13.491 22.346 13.487 C
+23.534 12.632 24.454 11.598 24.549 9.686 C
+25.802 10.657 28.255 11.272 29.635 10.674 C
+24.794 6.438 25.262 3.405 25.317 2.083 C
+f
+12.412 33.743 m
+11.887 33.272 11.691 33.01 V
+14.182 31.192 11.928 25.366 11.415 24.303 C
+10.776 24.247 9.369 26.988 9.405 28.486 C
+8.273 27.73 6.608 27.851 5.006 28.137 C
+5.578 27.049 5.177 25.104 4.376 24.303 C
+5.378 24.339 6.729 23.624 8.038 22.643 C
+7.203 21.823 5.376 21.984 3.46 22.643 C
+3.46 21.27 2.638 19.533 1.801 18.351 C
+3.117 18.408 4.262 17.722 5.12 16.691 C
+5.785 18.26 7.819 19.373 8.725 19.324 C
+8.742 17.959 7.169 15.869 6.147 15.47 C
+6.747 14.801 7.766 13.27 8.725 10.854 C
+9.524 12.78 10.694 14.022 11.927 14.955 C
+10.785 16.517 10.959 17.388 11.358 18.866 C
+12.101 18.325 13.132 17.893 13.303 15.89 C
+15.02 16.176 16.156 16.104 17.653 15.203 C
+17.198 16.865 17.195 18.466 17.515 20.166 C
+15.665 20.026 14.105 20.239 13.075 21.728 C
+13.905 21.955 16.165 22.014 17.039 21.082 C
+17.366 22.064 18.261 23.47 19.707 24.164 C
+18.267 24.424 17.282 25.523 16.373 27.209 C
+15.66 25.793 13.433 24.128 11.93 24.073 C
+13.933 28.137 13.933 31.055 12.412 33.743 C
+f
+31.125 30.5 m
+31.445 31.128 31.648 31.385 V
+34.045 29.444 38.851 32.752 39.746 33.521 C
+39.636 34.153 37.511 35.29 35.794 34.26 C
+36.234 35.549 35.332 37.51 34.134 38.552 C
+35.873 38.451 38.019 39.813 38.541 40.555 C
+38.763 39.577 39.946 38.307 41.231 37.293 C
+41.582 38.266 40.887 40.384 39.971 41.986 C
+41.206 42.487 42.318 43.417 42.776 44.676 C
+43.233 43.359 44.236 42.685 45.58 41.929 C
+44.421 40.502 43.64 38.328 43.92 37.465 C
+45.243 37.8 46.814 40.518 46.937 41.607 C
+47.812 40.841 49.366 40.154 51.947 39.848 C
+50.246 38.77 49.884 36.778 49.3 35.347 C
+48.152 35.794 45.983 35.853 45.008 35.29 C
+45.721 34.711 47.061 34.16 49.071 34.146 C
+49.071 32.601 49.534 31.469 50.788 30.254 C
+49.065 30.267 46.965 29.781 45.469 29.389 C
+45.221 30.718 44.378 32.314 43.233 32.715 C
+43.227 31.854 43.493 29.605 44.378 28.938 C
+43.513 28.37 42.26 26.993 41.803 25.276 C
+41.181 26.601 40.32 27.906 38.457 28.35 C
+39.642 29.403 40.477 31.42 40.143 32.887 C
+35.091 28.905 32.414 30.203 31.125 30.5 C
+f
+25.317 46.491 m
+25.994 46.691 26.284 46.843 V
+24.815 49.556 29.266 53.837 30.186 54.576 C
+30.787 54.351 30.907 51.818 30.23 50.482 C
+31.073 50.605 33.262 49.227 34.02 47.938 C
+34.085 48.625 35.655 51.566 36.481 51.944 C
+35.561 52.341 34.896 53.814 34.134 55.263 C
+35.156 55.43 36.555 54.508 38.026 53.603 C
+38.541 54.404 39.915 55.377 41.174 55.892 C
+40.086 56.579 39.591 57.321 39.094 58.78 C
+38.052 58.215 35.865 58.065 35.336 58.353 C
+35.85 59.465 38.096 60.008 38.827 59.955 C
+38.573 60.817 38.425 62.97 38.598 65.563 C
+36.939 64.247 35.393 62.931 33.734 62.988 C
+34.003 61.567 33.367 59.761 32.99 59.268 C
+32.417 60.012 32.006 60.839 32.361 62.817 C
+30.908 63.302 29.671 63.847 28.297 65.106 C
+28.297 63.274 27.725 62.073 26.857 60.796 C
+28.117 60.308 29.389 59.106 29.385 58.067 C
+28.537 58.219 26.845 58.963 26.352 59.955 C
+25.634 59.209 23.95 57.899 22.346 57.895 C
+23.534 57.041 24.454 56.006 24.549 54.094 C
+25.802 55.065 28.255 55.68 29.635 55.083 C
+24.794 50.846 25.262 47.814 25.317 46.491 C
+f
+12.412 78.151 m
+11.887 77.68 11.691 77.418 V
+14.182 75.601 11.928 69.774 11.415 68.711 C
+10.776 68.655 9.369 71.396 9.405 72.894 C
+8.273 72.138 6.608 72.259 5.006 72.545 C
+5.578 71.458 5.177 69.512 4.376 68.711 C
+5.378 68.747 6.729 68.032 8.038 67.052 C
+7.203 66.231 5.376 66.393 3.46 67.052 C
+3.46 65.678 2.638 63.941 1.801 62.759 C
+3.117 62.817 4.262 62.13 5.12 61.1 C
+5.785 62.669 7.819 63.781 8.725 63.732 C
+8.742 62.367 7.169 60.277 6.147 59.878 C
+6.747 59.209 7.766 57.678 8.725 55.263 C
+9.524 57.189 10.694 58.431 11.927 59.364 C
+10.785 60.925 10.959 61.796 11.358 63.274 C
+12.101 62.734 13.132 62.301 13.303 60.298 C
+15.02 60.584 16.156 60.512 17.653 59.612 C
+17.198 61.273 17.195 62.874 17.515 64.574 C
+15.665 64.434 14.105 64.648 13.075 66.136 C
+13.905 66.363 16.165 66.422 17.039 65.49 C
+17.366 66.472 18.261 67.878 19.707 68.572 C
+18.267 68.832 17.282 69.931 16.373 71.617 C
+15.66 70.202 13.433 68.536 11.93 68.482 C
+13.933 72.545 13.933 75.464 12.412 78.151 C
+f
+31.125 74.908 m
+31.445 75.537 31.648 75.794 V
+34.045 73.853 38.851 77.161 39.746 77.929 C
+39.636 78.562 37.511 79.698 35.794 78.668 C
+36.234 79.957 35.332 81.918 34.134 82.96 C
+35.873 82.86 38.019 84.221 38.541 84.963 C
+38.763 83.986 39.946 82.716 41.231 81.701 C
+41.582 82.675 40.887 84.792 39.971 86.394 C
+41.206 86.895 42.318 87.825 42.776 89.084 C
+43.233 87.768 44.236 87.093 45.58 86.337 C
+44.421 84.91 43.64 82.736 43.92 81.873 C
+45.243 82.208 46.814 84.926 46.937 86.016 C
+47.812 85.249 49.366 84.563 51.947 84.257 C
+50.246 83.179 49.884 81.187 49.3 79.756 C
+48.152 80.203 45.983 80.262 45.008 79.698 C
+45.721 79.119 47.061 78.569 49.071 78.554 C
+49.071 77.009 49.534 75.877 50.788 74.663 C
+49.065 74.675 46.965 74.189 45.469 73.798 C
+45.221 75.126 44.378 76.723 43.233 77.123 C
+43.227 76.262 43.493 74.013 44.378 73.347 C
+43.513 72.779 42.26 71.401 41.803 69.684 C
+41.181 71.009 40.32 72.314 38.457 72.759 C
+39.642 73.812 40.477 75.829 40.143 77.295 C
+35.091 73.313 32.414 74.611 31.125 74.908 C
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Polka dots)
+(Polka dots) 1 1 29.8 29.8 [
+%AI3_Tile
+(0 O 0 R  0.45 0.9 0 0 k
+ 0.45 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+1 1 m
+1 29.8 L
+29.8 29.8 L
+29.8 1 L
+1 1 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.09 0.18 0 0 k
+ 0.09 0.18 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+11.08 8.2 m
+11.08 9.791 9.79 11.08 8.2 11.08 c
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+f
+11.08 22.6 m
+11.08 24.191 9.79 25.48 8.2 25.48 c
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+f
+18.28 15.4 m
+18.28 16.991 16.99 18.28 15.4 18.28 c
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+f
+25.48 8.2 m
+25.48 9.791 24.19 11.08 22.6 11.08 c
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+f
+25.48 22.6 m
+25.48 24.191 24.19 25.48 22.6 25.48 c
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+f
+*U
+26.92 1 m
+29.8 1 L
+29.8 3.88 L
+28.209 3.88 26.92 2.591 26.92 1 C
+f
+15.4 3.88 m
+13.809 3.88 12.52 2.591 12.52 1 C
+18.28 1 L
+18.28 2.591 16.99 3.88 15.4 3.88 c
+f
+1 3.88 m
+1 1 L
+3.88 1 L
+3.88 2.591 2.59 3.88 1 3.88 C
+f
+1 XR
+26.92 15.4 m
+26.92 13.81 28.209 12.52 29.8 12.52 C
+29.8 18.28 L
+28.209 18.28 26.92 16.991 26.92 15.4 c
+f
+0 XR
+15.4 18.28 m
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+18.28 16.991 16.99 18.28 15.4 18.28 c
+f
+1 XR
+3.88 15.4 m
+3.88 16.991 2.59 18.28 1 18.28 C
+1 12.52 L
+2.59 12.52 3.88 13.81 3.88 15.4 c
+f
+0 XR
+29.8 26.92 m
+29.8 29.8 L
+26.92 29.8 L
+26.92 28.21 28.209 26.92 29.8 26.92 C
+f
+15.4 26.92 m
+16.99 26.92 18.28 28.21 18.28 29.8 C
+12.52 29.8 L
+12.52 28.21 13.809 26.92 15.4 26.92 c
+f
+3.88 29.8 m
+1 29.8 L
+1 26.92 L
+2.59 26.92 3.88 28.21 3.88 29.8 C
+f
+1 XR
+8.2 11.08 m
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+11.08 9.791 9.79 11.08 8.2 11.08 c
+f
+22.6 11.08 m
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+25.48 9.791 24.19 11.08 22.6 11.08 c
+f
+8.2 25.48 m
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+11.08 24.191 9.79 25.48 8.2 25.48 c
+f
+22.6 25.48 m
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+25.48 24.191 24.19 25.48 22.6 25.48 c
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Random circles)
+(Random circles) 4.365 3.849 51.13 57.85 [
+%AI3_Tile
+(0 O 0 R  0 0.1125 0.45 0 k
+ 0 0.1125 0.45 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+4.365 3.849 m
+4.365 57.85 L
+51.13 57.85 L
+51.13 3.849 L
+4.365 3.849 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.41 0.7 1 0 k
+ 0.41 0.7 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+45.429 36.274 m
+45.843 36.991 45.598 37.908 44.88 38.323 c
+44.163 38.737 43.245 38.491 42.831 37.774 c
+42.417 37.056 42.663 36.139 43.38 35.725 c
+44.098 35.31 45.015 35.556 45.429 36.274 c
+s
+44.179 27.926 m
+43.765 28.643 42.848 28.889 42.13 28.475 c
+41.413 28.06 41.167 27.143 41.581 26.425 c
+41.995 25.708 42.913 25.462 43.63 25.876 c
+44.348 26.291 44.593 27.208 44.179 27.926 c
+s
+35.929 41.024 m
+35.515 41.741 34.598 41.987 33.88 41.573 c
+33.163 41.158 32.917 40.241 33.331 39.524 c
+33.745 38.806 34.663 38.56 35.38 38.975 c
+36.098 39.389 36.343 40.306 35.929 41.024 c
+s
+28.38 34.225 m
+28.794 34.942 28.549 35.859 27.831 36.274 c
+27.114 36.688 26.196 36.442 25.782 35.725 c
+25.368 35.007 25.614 34.09 26.331 33.675 c
+27.049 33.261 27.966 33.507 28.38 34.225 c
+s
+31.179 28.024 m
+30.765 28.741 29.848 28.987 29.13 28.573 c
+28.413 28.158 28.167 27.241 28.581 26.524 c
+28.995 25.806 29.913 25.56 30.63 25.975 c
+31.348 26.389 31.593 27.306 31.179 28.024 c
+s
+36.792 23.349 m
+35.963 23.349 35.292 22.678 35.292 21.849 c
+35.292 21.021 35.963 20.349 36.792 20.349 c
+37.62 20.349 38.292 21.021 38.292 21.849 c
+38.292 22.678 37.62 23.349 36.792 23.349 c
+s
+10.888 34.175 m
+10.474 34.893 10.72 35.81 11.437 36.225 c
+12.155 36.639 13.072 36.393 13.486 35.675 c
+13.901 34.958 13.655 34.041 12.937 33.626 c
+12.22 33.212 11.303 33.458 10.888 34.175 c
+s
+11.517 26.601 m
+11.931 27.318 12.848 27.564 13.566 27.15 c
+14.283 26.735 14.529 25.818 14.115 25.1 c
+13.701 24.383 12.783 24.137 12.066 24.551 c
+11.348 24.966 11.103 25.883 11.517 26.601 c
+s
+16.782 41.426 m
+17.196 42.143 18.114 42.389 18.831 41.975 c
+19.549 41.56 19.794 40.643 19.38 39.926 c
+18.966 39.208 18.049 38.962 17.331 39.377 c
+16.614 39.791 16.368 40.708 16.782 41.426 c
+s
+22.365 24.35 m
+23.194 24.35 23.865 23.678 23.865 22.85 c
+23.865 22.021 23.194 21.35 22.365 21.35 c
+21.537 21.35 20.865 22.021 20.865 22.85 c
+20.865 23.678 21.537 24.35 22.365 24.35 c
+s
+45.385 7.849 m
+44.971 7.132 44.053 6.886 43.336 7.3 c
+42.619 7.714 42.373 8.632 42.787 9.349 c
+43.201 10.067 44.119 10.312 44.836 9.898 c
+45.553 9.484 45.799 8.567 45.385 7.849 c
+s
+29.679 7.774 m
+29.265 7.056 28.348 6.81 27.63 7.225 c
+26.913 7.639 26.667 8.556 27.081 9.274 c
+27.495 9.991 28.413 10.237 29.13 9.823 c
+29.848 9.408 30.093 8.491 29.679 7.774 c
+s
+35.542 11.349 m
+34.713 11.349 34.042 12.021 34.042 12.849 c
+34.042 13.678 34.713 14.349 35.542 14.349 c
+36.37 14.349 37.042 13.678 37.042 12.849 c
+37.042 12.021 36.37 11.349 35.542 11.349 c
+s
+10.13 7.475 m
+10.544 6.757 11.462 6.511 12.179 6.926 c
+12.897 7.34 13.142 8.257 12.728 8.975 c
+12.314 9.692 11.397 9.938 10.679 9.524 c
+9.962 9.109 9.716 8.192 10.13 7.475 c
+s
+20.203 13.349 m
+21.031 13.349 21.703 14.021 21.703 14.849 c
+21.703 15.678 21.031 16.349 20.203 16.349 c
+19.375 16.349 18.703 15.678 18.703 14.849 c
+18.703 14.021 19.375 13.349 20.203 13.349 c
+s
+44.635 54.1 m
+45.049 53.382 44.803 52.465 44.086 52.051 c
+43.369 51.636 42.451 51.882 42.037 52.6 c
+41.623 53.317 41.869 54.234 42.586 54.649 c
+43.303 55.063 44.221 54.817 44.635 54.1 c
+s
+36.841 48.1 m
+36.427 47.382 35.509 47.136 34.792 47.551 c
+34.074 47.965 33.828 48.882 34.243 49.6 c
+34.657 50.317 35.574 50.563 36.292 50.149 c
+37.009 49.734 37.255 48.817 36.841 48.1 c
+s
+29.728 54.725 m
+30.143 54.007 29.897 53.09 29.179 52.675 c
+28.462 52.261 27.544 52.507 27.13 53.225 c
+26.716 53.942 26.962 54.859 27.679 55.274 c
+28.397 55.688 29.314 55.442 29.728 54.725 c
+s
+10.86 54.1 m
+10.446 53.382 10.691 52.465 11.409 52.051 c
+12.126 51.636 13.044 51.882 13.458 52.6 c
+13.872 53.317 13.626 54.234 12.909 54.649 c
+12.191 55.063 11.274 54.817 10.86 54.1 c
+s
+19.154 49.1 m
+19.568 48.382 20.486 48.136 21.203 48.551 c
+21.92 48.965 22.166 49.882 21.752 50.6 c
+21.338 51.317 20.42 51.563 19.703 51.149 c
+18.986 50.734 18.74 49.817 19.154 49.1 c
+s
+51.88 38.85 m
+51.052 38.85 50.38 39.521 50.38 40.35 c
+50.38 41.178 51.052 41.85 51.88 41.85 c
+52.709 41.85 53.38 41.178 53.38 40.35 c
+53.38 39.521 52.709 38.85 51.88 38.85 c
+s
+51.865 11.349 m
+52.693 11.349 53.365 12.021 53.365 12.849 c
+53.365 13.678 52.693 14.349 51.865 14.349 c
+51.036 14.349 50.365 13.678 50.365 12.849 c
+50.365 12.021 51.036 11.349 51.865 11.349 c
+s
+30.179 18.524 m
+29.765 19.241 28.848 19.487 28.13 19.073 c
+27.413 18.658 27.167 17.741 27.581 17.024 c
+27.995 16.306 28.913 16.06 29.63 16.475 c
+30.348 16.889 30.593 17.806 30.179 18.524 c
+s
+21.679 31.524 m
+21.265 32.241 20.348 32.487 19.63 32.073 c
+18.913 31.658 18.667 30.741 19.081 30.024 c
+19.495 29.306 20.413 29.06 21.13 29.475 c
+21.848 29.889 22.093 30.806 21.679 31.524 c
+s
+37.914 33.399 m
+37.5 34.116 36.583 34.362 35.865 33.948 c
+35.148 33.533 34.902 32.616 35.316 31.899 c
+35.73 31.181 36.648 30.935 37.365 31.35 c
+38.083 31.764 38.328 32.681 37.914 33.399 c
+s
+28.929 45.024 m
+28.515 45.741 27.598 45.987 26.88 45.573 c
+26.163 45.158 25.917 44.241 26.331 43.524 c
+26.745 42.806 27.663 42.56 28.38 42.975 c
+29.098 43.389 29.343 44.306 28.929 45.024 c
+s
+12.429 45.524 m
+12.015 46.241 11.098 46.487 10.38 46.073 c
+9.663 45.658 9.417 44.741 9.831 44.024 c
+10.245 43.306 11.163 43.06 11.88 43.475 c
+12.598 43.889 12.843 44.806 12.429 45.524 c
+s
+44.49 45.6 m
+44.075 46.317 43.158 46.563 42.441 46.149 c
+41.723 45.734 41.477 44.817 41.891 44.1 c
+42.306 43.382 43.223 43.136 43.941 43.55 c
+44.658 43.965 44.904 44.882 44.49 45.6 c
+s
+12.679 18.524 m
+12.265 19.241 11.348 19.487 10.63 19.073 c
+9.913 18.658 9.667 17.741 10.081 17.024 c
+10.495 16.306 11.413 16.06 12.13 16.475 c
+12.848 16.889 13.093 17.806 12.679 18.524 c
+s
+21.179 5.774 m
+20.765 6.491 19.848 6.737 19.13 6.323 c
+18.413 5.908 18.167 4.991 18.581 4.274 c
+18.995 3.557 19.913 3.311 20.63 3.725 c
+21.348 4.139 21.593 5.056 21.179 5.774 c
+s
+38.929 5.274 m
+38.515 5.991 37.598 6.237 36.88 5.823 c
+36.163 5.408 35.917 4.491 36.331 3.774 c
+36.745 3.057 37.663 2.811 38.38 3.225 c
+39.098 3.639 39.343 4.556 38.929 5.274 c
+s
+43.865 18.1 m
+44.694 18.1 45.365 17.429 45.365 16.6 c
+45.365 15.772 44.694 15.1 43.865 15.1 c
+43.037 15.1 42.365 15.772 42.365 16.6 c
+42.365 17.429 43.037 18.1 43.865 18.1 c
+s
+51.13 4.6 m
+50.302 4.6 49.63 3.928 49.63 3.1 c
+49.63 2.272 50.302 1.6 51.13 1.6 c
+51.959 1.6 52.63 2.272 52.63 3.1 c
+52.63 3.928 51.959 4.6 51.13 4.6 c
+s
+52.163 31.649 m
+51.748 32.366 50.831 32.612 50.114 32.198 c
+49.396 31.783 49.15 30.866 49.565 30.149 c
+49.979 29.431 50.896 29.185 51.614 29.6 c
+52.331 30.014 52.577 30.931 52.163 31.649 c
+s
+51.85 51.35 m
+51.021 51.35 50.35 50.678 50.35 49.85 c
+50.35 49.021 51.021 48.35 51.85 48.35 c
+52.678 48.35 53.35 49.021 53.35 49.85 c
+53.35 50.678 52.678 51.35 51.85 51.35 c
+s
+49.85 23.1 m
+50.679 23.1 51.35 22.428 51.35 21.6 c
+51.35 20.771 50.679 20.1 49.85 20.1 c
+49.022 20.1 48.35 20.771 48.35 21.6 c
+48.35 22.428 49.022 23.1 49.85 23.1 c
+s
+5.13 38.85 m
+4.302 38.85 3.63 39.521 3.63 40.35 c
+3.63 41.178 4.302 41.85 5.13 41.85 c
+5.959 41.85 6.63 41.178 6.63 40.35 c
+6.63 39.521 5.959 38.85 5.13 38.85 c
+s
+5.115 11.349 m
+5.943 11.349 6.615 12.021 6.615 12.849 c
+6.615 13.678 5.943 14.349 5.115 14.349 c
+4.286 14.349 3.615 13.678 3.615 12.849 c
+3.615 12.021 4.286 11.349 5.115 11.349 c
+s
+4.38 4.6 m
+3.552 4.6 2.88 3.928 2.88 3.1 c
+2.88 2.272 3.552 1.6 4.38 1.6 c
+5.209 1.6 5.88 2.272 5.88 3.1 c
+5.88 3.928 5.209 4.6 4.38 4.6 c
+s
+5.413 31.649 m
+4.998 32.366 4.081 32.612 3.364 32.198 c
+2.646 31.783 2.4 30.866 2.815 30.149 c
+3.229 29.431 4.146 29.185 4.864 29.6 c
+5.581 30.014 5.827 30.931 5.413 31.649 c
+s
+5.1 51.35 m
+4.271 51.35 3.6 50.678 3.6 49.85 c
+3.6 49.021 4.271 48.35 5.1 48.35 c
+5.928 48.35 6.6 49.021 6.6 49.85 c
+6.6 50.678 5.928 51.35 5.1 51.35 c
+s
+3.1 23.1 m
+3.929 23.1 4.6 22.428 4.6 21.6 c
+4.6 20.771 3.929 20.1 3.1 20.1 c
+2.272 20.1 1.6 20.771 1.6 21.6 c
+1.6 22.428 2.272 23.1 3.1 23.1 c
+s
+21.194 59.775 m
+20.78 60.492 19.863 60.738 19.145 60.324 c
+18.428 59.909 18.182 58.992 18.596 58.275 c
+19.01 57.558 19.928 57.312 20.645 57.726 c
+21.363 58.14 21.608 59.057 21.194 59.775 c
+s
+38.944 59.275 m
+38.53 59.992 37.613 60.238 36.895 59.824 c
+36.178 59.409 35.932 58.492 36.346 57.775 c
+36.76 57.058 37.678 56.812 38.395 57.226 c
+39.113 57.64 39.358 58.557 38.944 59.275 c
+s
+51.145 58.601 m
+50.317 58.601 49.645 57.929 49.645 57.101 c
+49.645 56.273 50.317 55.601 51.145 55.601 c
+51.974 55.601 52.645 56.273 52.645 57.101 c
+52.645 57.929 51.974 58.601 51.145 58.601 c
+s
+4.395 58.601 m
+3.567 58.601 2.895 57.929 2.895 57.101 c
+2.895 56.273 3.567 55.601 4.395 55.601 c
+5.224 55.601 5.895 56.273 5.895 57.101 c
+5.895 57.929 5.224 58.601 4.395 58.601 c
+s
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Rope.side)
+(Rope.side) 1 4.6 60.9998 33.3999 [
+%AI3_Tile
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 1 j 0.6 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+24.9999 7 m
+15.6521 4.663 8.125 8.6981 1 14.1407 C
+S
+36.9999 7 m
+22.3477 3.337 12.168 15.3276 1 23.859 C
+S
+48.9999 7 m
+29.3464 2.0866 17.7386 25.3332 1 30.6213 C
+S
+1 30.9999 m
+24.9999 36.9999 36.9999 1 60.9998 7 C
+S
+13 30.9999 m
+32.6534 35.9133 44.2611 12.6667 60.9998 7.3786 C
+S
+24.9999 30.9999 m
+39.652 34.6629 49.8317 22.6722 60.9998 14.1407 C
+S
+36.9999 30.9999 m
+46.3476 33.3369 53.8749 29.3018 60.9998 23.859 C
+S
+48.9999 30.9999 m
+53.3464 32.0865 57.2978 31.7908 60.9998 30.6213 C
+S
+13 7 m
+8.6535 5.9134 4.7019 6.2091 1 7.3786 C
+S
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Scales)
+(Scales) 1.6 9.3475 48.088 55.8355 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+1.6 9.3475 m
+1.6 55.8355 L
+48.088 55.8355 L
+48.088 9.3475 L
+1.6 9.3475 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+17.0956 9.3475 m
+12.8162 9.3475 9.3475 5.8787 9.3475 1.6 C
+9.3475 5.8787 5.8787 9.3475 1.6 9.3475 C
+1.6 13.6262 5.0687 17.095 9.3475 17.095 c
+13.6268 17.095 17.0956 13.6262 17.0956 9.3475 C
+s
+32.5918 9.3475 m
+28.3125 9.3475 24.8437 5.8787 24.8437 1.6 C
+24.8437 5.8787 21.3743 9.3475 17.0956 9.3475 C
+17.0956 13.6262 20.5644 17.095 24.8437 17.095 c
+29.1224 17.095 32.5918 13.6262 32.5918 9.3475 C
+s
+48.088 9.3475 m
+43.8087 9.3475 40.3399 5.8787 40.3399 1.6 C
+40.3399 5.8787 36.8705 9.3475 32.5918 9.3475 C
+32.5918 13.6262 36.0606 17.095 40.3399 17.095 c
+44.6186 17.095 48.088 13.6262 48.088 9.3475 C
+s
+17.0956 40.3393 m
+12.8162 40.3393 9.3475 36.8699 9.3475 32.5912 C
+9.3475 36.8699 5.8787 40.3393 1.6 40.3393 C
+1.6 44.6181 5.0687 48.0874 9.3475 48.0874 c
+13.6268 48.0874 17.0956 44.6181 17.0956 40.3393 C
+s
+17.0956 24.8431 m
+12.8162 24.8431 9.3475 21.3743 9.3475 17.095 C
+9.3475 21.3743 5.8787 24.8431 1.6 24.8431 C
+1.6 29.1218 5.0687 32.5912 9.3475 32.5912 c
+13.6268 32.5912 17.0956 29.1218 17.0956 24.8431 C
+s
+32.5918 24.8431 m
+28.3125 24.8431 24.8437 21.3743 24.8437 17.095 C
+24.8437 21.3743 21.3743 24.8431 17.0956 24.8431 C
+17.0956 29.1218 20.5644 32.5912 24.8437 32.5912 c
+29.1224 32.5912 32.5918 29.1218 32.5918 24.8431 C
+s
+48.088 24.8431 m
+43.8087 24.8431 40.3399 21.3743 40.3399 17.095 C
+40.3399 21.3743 36.8705 24.8431 32.5918 24.8431 C
+32.5918 29.1218 36.0606 32.5912 40.3399 32.5912 c
+44.6186 32.5912 48.088 29.1218 48.088 24.8431 C
+s
+32.5918 40.3393 m
+28.3125 40.3393 24.8437 36.8699 24.8437 32.5912 C
+24.8437 36.8699 21.3743 40.3393 17.0956 40.3393 C
+17.0956 44.6181 20.5644 48.0874 24.8437 48.0874 c
+29.1224 48.0874 32.5918 44.6181 32.5918 40.3393 C
+s
+48.088 40.3393 m
+43.8087 40.3393 40.3399 36.8699 40.3399 32.5912 C
+40.3399 36.8699 36.8705 40.3393 32.5918 40.3393 C
+32.5918 44.6181 36.0606 48.0874 40.3399 48.0874 c
+44.6186 48.0874 48.088 44.6181 48.088 40.3393 C
+s
+17.0956 55.8355 m
+12.8162 55.8355 9.3475 52.3662 9.3475 48.0874 C
+9.3475 52.3662 5.8787 55.8355 1.6 55.8355 C
+1.6 60.1143 5.0687 63.5836 9.3475 63.5836 c
+13.6268 63.5836 17.0956 60.1143 17.0956 55.8355 C
+s
+32.5918 55.8355 m
+28.3125 55.8355 24.8437 52.3662 24.8437 48.0874 C
+24.8437 52.3662 21.3743 55.8355 17.0956 55.8355 C
+17.0956 60.1143 20.5644 63.5836 24.8437 63.5836 c
+29.1224 63.5836 32.5918 60.1143 32.5918 55.8355 C
+s
+48.088 55.8355 m
+43.8087 55.8355 40.3399 52.3662 40.3399 48.0874 C
+40.3399 52.3662 36.8705 55.8355 32.5918 55.8355 C
+32.5918 60.1143 36.0606 63.5836 40.3399 63.5836 c
+44.6186 63.5836 48.088 60.1143 48.088 55.8355 C
+s
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (SolidStar.side)
+(SolidStar.side) 1 1 33.0117 33.0117 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 0.95 0 k
+ 0.05 0.2 0.95 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+1 D
+0 XR
+7.9689 26.0458 m
+14.5331 22.9874 l
+17.0095 29.7904 L
+19.4859 22.9874 l
+26.0473 26.0458 l
+22.9889 19.4815 l
+29.792 17.0052 l
+22.9889 14.5288 l
+26.0473 7.9674 l
+19.4859 11.0257 l
+17.0095 4.2226 l
+14.5305 11.0257 l
+7.9689 7.9674 l
+11.0273 14.5288 l
+4.2242 17.0052 l
+11.0273 19.4843 L
+7.9689 26.0458 l
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Stars)
+(Stars) 1 1 63.384 84.766 [
+%AI3_Tile
+(0 O 0 R  1 0.9 0.1 0 k
+ 1 0.9 0.1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+1 1 m
+1 84.766 L
+63.384 84.766 L
+63.384 1 L
+1 1 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.25 1 0 k
+ 0 0.25 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+37.668 67.113 m
+43.924 62.567 L
+41.535 55.213 L
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+f
+16.596 59.757 m
+22.851 55.212 L
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+f
+20.462 20.683 m
+26.719 25.229 L
+18.985 25.229 L
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+f
+38.447 34.271 m
+36.058 41.625 L
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+f
+51.657 20.683 m
+57.914 25.229 L
+50.18 25.229 L
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+f
+*U
+1 XR
+34.581 4.288 m
+32.192 11.643 L
+29.803 4.289 L
+22.069 4.289 L
+26.5962 1 L
+37.7885 1 L
+42.315 4.288 L
+34.581 4.288 L
+f
+53.261 4.289 m
+57.7882 1 L
+63.384 1 L
+63.384 11.643 L
+60.995 4.289 L
+53.261 4.289 L
+f
+4.866 41.625 m
+11.123 46.171 L
+3.389 46.171 L
+1 53.526 L
+1 38.816 L
+7.255 34.271 L
+4.866 41.625 L
+f
+36.058 41.625 m
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+36.058 41.625 L
+f
+53.261 46.172 m
+59.517 41.626 L
+57.128 34.272 L
+63.384 38.816 L
+63.384 53.526 L
+60.995 46.172 L
+53.261 46.172 L
+f
+4.866 83.508 m
+6.5974 84.766 L
+1 84.766 L
+1 80.699 L
+7.255 76.154 L
+4.866 83.508 L
+f
+25.936 76.155 m
+32.192 80.699 L
+38.447 76.154 L
+36.058 83.508 L
+37.7895 84.766 L
+26.5951 84.766 L
+28.325 83.509 L
+25.936 76.155 L
+f
+22.851 55.212 m
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+22.851 55.212 L
+f
+41.535 55.213 m
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+43.924 62.567 L
+41.535 55.213 L
+f
+50.18 25.229 m
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+57.914 25.229 L
+50.18 25.229 L
+f
+18.985 25.229 m
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+26.719 25.229 L
+18.985 25.229 L
+f
+3.388 4.289 m
+1 11.643 L
+1 1 L
+6.5948 1 L
+11.122 4.289 L
+3.388 4.289 L
+f
+57.128 76.154 m
+63.384 80.699 L
+63.384 84.766 L
+57.7855 84.766 L
+59.517 83.508 L
+57.128 76.154 L
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Stripes)
+(Stripes) 8.45 4.6001 80.45 76.6001 [
+%AI3_Tile
+(0 O 0 R  1 0.07 1 0 k
+ 1 0.07 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 3.6 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+8.2 8.2 m
+80.7 8.2 L
+S
+8.2 22.6001 m
+80.7 22.6001 L
+S
+8.2 37.0002 m
+80.7 37.0002 L
+S
+8.2 51.4 m
+80.7 51.4 L
+S
+8.2 65.8001 m
+80.7 65.8001 L
+S
+8.2 15.4 m
+80.7 15.4 L
+S
+8.2 29.8001 m
+80.7 29.8001 L
+S
+8.2 44.2 m
+80.7 44.2 L
+S
+8.2 58.6001 m
+80.7 58.6001 L
+S
+8.2 73.0002 m
+80.7 73.0002 L
+S
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (TriBevel.outer)
+(TriBevel.outer) 1 1.0004 31.6124 31.6127 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+31.6118 5.4917 m
+27.1221 5.4917 L
+27.1205 1.0011 L
+27.8031 1.0011 L
+27.8031 4.8091 L
+31.6118 4.8091 L
+31.6118 5.4917 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+31.6149 9.5062 m
+23.1111 9.5062 L
+23.1111 1.0015 L
+27.1205 1.0015 L
+27.1205 5.493 L
+31.6144 5.493 L
+31.6149 9.5062 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+31.6124 10.485 m
+22.1297 10.485 L
+22.1292 1.0015 L
+23.1084 1.0015 L
+23.1084 9.5049 L
+31.6124 9.5049 L
+31.6124 10.485 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+31.6129 17.2066 m
+15.4064 17.2085 L
+15.4064 1 L
+22.1301 1 L
+22.1301 10.4868 L
+31.6129 10.4868 L
+31.6129 17.2066 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+31.6149 18.3658 m
+14.2517 18.3658 L
+14.2515 1.0009 L
+15.4043 1.0009 L
+15.4043 17.2093 L
+31.6149 17.2093 L
+31.6149 18.3658 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+31.6124 30.4755 m
+2.1395 30.4755 L
+2.1395 1.0015 L
+14.249 1 L
+14.249 18.366 L
+31.6149 18.366 L
+31.6124 30.4755 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.6 k
+ 0 0 0 0.6 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+15.4066 16.847 m
+14.2778 18.3257 l
+15.4066 17.2057 l
+15.4066 16.847 l
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+23.1095 9.1906 m
+22.1759 10.4392 l
+23.1082 9.505 l
+23.1095 9.1906 l
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+27.8039 4.6026 m
+27.1619 5.4533 l
+27.8029 4.8093 l
+27.8039 4.6026 l
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (TriBevel.side)
+(TriBevel.side) 1.0006 1 29.0006 31.6124 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+29 4.8087 m
+29 4.8087 L
+29.0026 5.4927 L
+1.0026 5.4927 L
+1 4.8087 L
+1 4.8087 L
+29 4.8087 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+29.0026 5.4927 m
+29.0005 9.5045 L
+1.0005 9.5045 L
+1.0026 5.4927 L
+29.0026 5.4927 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+29.0005 9.5045 m
+29.0011 10.4865 L
+1.0011 10.4865 L
+1.0005 9.5045 L
+29.0005 9.5045 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+29.0011 10.4865 m
+29.003 17.209 L
+1.003 17.209 L
+1.0011 10.4865 L
+29.0011 10.4865 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+29.003 17.209 m
+29.0031 18.3656 L
+1.0031 18.3656 L
+1.003 17.209 L
+29.003 17.209 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+29.0031 18.3656 m
+29.0006 30.4752 L
+1.0006 30.4752 L
+1.0031 18.3656 L
+29.0031 18.3656 L
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Waves-scroll)
+(Waves-scroll) 17.926 10.516 68.663 69.012 [
+%AI3_Tile
+(0 O 0 R  1 0 0.3 0 k
+ 1 0 0.3 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+1 D
+0 XR
+17.926 69.012 m
+17.926 10.516 L
+68.663 10.516 L
+68.663 69.012 L
+17.926 69.012 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.55 0 0 0 k
+ 0.55 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.75 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+65.335 70.465 m
+65.881 68.746 67.444 68.168 68.663 69.012 C
+67.538 69.668 68.011 71.255 69.686 70.933 c
+72.124 70.464 71.894 67.213 70.53 65.589 c
+68.561 63.245 64.565 60.995 53.241 71.117 C
+S
+39.964 70.465 m
+40.511 68.746 42.074 68.168 43.293 69.012 C
+42.168 69.668 42.64 71.255 44.316 70.933 c
+46.753 70.464 46.524 67.213 45.16 65.589 c
+43.191 63.245 39.195 60.995 27.87 71.117 c
+S
+14.594 70.465 m
+15.141 68.746 16.704 68.168 17.923 69.012 C
+16.798 69.668 17.27 71.255 18.945 70.933 c
+21.382 70.464 21.153 67.213 19.789 65.589 c
+17.821 63.245 13.825 60.995 2.5 71.117 c
+S
+10.959 51.619 m
+22.282 41.497 26.278 43.747 28.247 46.09 c
+29.611 47.715 29.841 50.965 27.403 51.434 c
+25.728 51.757 25.255 50.169 26.38 49.513 C
+25.161 48.669 23.599 49.248 23.052 50.966 c
+22.723 51.997 23.38 53.966 24.872 54.903 c
+27.267 56.406 31.371 56.05 36.328 51.619 c
+47.653 41.497 51.649 43.746 53.618 46.09 c
+54.982 47.715 55.212 50.965 52.774 51.434 c
+51.099 51.757 50.626 50.169 51.751 49.513 C
+50.532 48.669 48.97 49.248 48.423 50.966 c
+48.094 51.997 48.751 53.966 50.243 54.903 c
+52.638 56.406 56.742 56.05 61.699 51.619 C
+73.024 41.497 77.02 43.747 78.988 46.09 c
+S
+70.156 32.12 m
+65.199 36.551 61.095 36.907 58.7 35.404 c
+57.208 34.468 56.552 32.499 56.88 31.468 c
+57.427 29.749 58.99 29.171 60.208 30.015 C
+59.083 30.671 59.556 32.258 61.231 31.936 c
+63.669 31.467 63.439 28.216 62.075 26.592 c
+60.106 24.248 56.11 21.998 44.786 32.12 C
+39.829 36.551 35.725 36.907 33.33 35.404 c
+31.838 34.468 31.182 32.499 31.51 31.468 c
+32.056 29.749 33.619 29.171 34.838 30.015 C
+33.713 30.671 34.186 32.258 35.861 31.936 c
+38.299 31.467 38.069 28.216 36.705 26.592 c
+34.737 24.248 30.74 21.998 19.415 32.12 c
+14.458 36.551 10.354 36.907 7.96 35.404 c
+S
+19.792 7.094 m
+21.157 8.719 21.386 11.968 18.949 12.437 c
+17.274 12.76 16.801 11.172 17.926 10.516 C
+16.708 9.673 15.145 10.252 14.598 11.969 c
+14.27 13 14.926 14.969 16.418 15.906 c
+18.812 17.409 22.916 17.053 27.874 12.622 c
+39.199 2.5 43.195 4.75 45.163 7.094 c
+46.528 8.719 46.757 11.968 44.32 12.437 c
+42.644 12.76 42.172 11.172 43.297 10.516 C
+42.078 9.673 40.515 10.252 39.968 11.969 c
+39.64 13 40.297 14.969 41.788 15.906 c
+44.183 17.409 48.287 17.053 53.245 12.622 C
+64.569 2.5 68.565 4.75 70.534 7.094 c
+71.898 8.719 72.127 11.968 69.69 12.437 c
+68.014 12.76 67.542 11.172 68.667 10.516 C
+67.448 9.673 65.885 10.252 65.338 11.969 c
+65.011 13 65.667 14.969 67.159 15.906 c
+69.553 17.409 73.657 17.053 78.615 12.622 c
+S
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI5_End_NonPrinting--
+%AI5_Begin_NonPrinting
+Np
+12 Bn
+%AI5_BeginGradient: (Black, White)
+(Black, White) 0 2 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Chrome)
+(Chrome) 0 6 Bd
+[
+0
+<
+464646454545444444444343434342424241414141404040403F3F3F3E3E3E3E3D3D3D3C3C3C3C3B
+3B3B3B3A3A3A39393939383838383737373636363635353535343434333333333232323131313130
+3030302F2F2F2E2E2E2E2D2D2D2D2C2C2C2B2B2B2B2A2A2A2A292929282828282727272726262625
+2525252424242323232322222222212121202020201F1F1F1F1E1E1E1D1D1D1D1C1C1C1B1B1B1B1A
+1A1A1A1919191818181817171717161616151515151414141413131312121212111111101010100F
+0F0F0F0E0E0E0D0D0D0D0C0C0C0C0B0B0B0A0A0A0A09090909080808070707070606060505050504
+04040403030302020202010101010000
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+1F1E1E1E1E1E1E1E1E1E1D1D1D1D1D1D1D1D1C1C1C1C1C1C1C1C1B1B1B1B1B1B1B1B1B1A1A1A1A1A
+1A1A1A19191919191919191818181818181818181717171717171717161616161616161615151515
+15151515151414141414141414131313131313131312121212121212121211111111111111111010
+1010101010100F0F0F0F0F0F0F0F0F0E0E0E0E0E0E0E0E0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C
+0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A090909090909090909080808080808080807070707070707
+07060606060606060606050505050505050504040404040404040303030303030303030202020202
+02020201010101010101010000000000
+>
+1 %_Br
+0
+0.275
+1
+<
+6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544
+434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F
+>
+1 %_Br
+0
+<
+00000101010102020202030303040404040505050506060607070707080808090909090A0A0A0A0B
+0B0B0C0C0C0C0D0D0D0D0E0E0E0F0F0F0F1010101011111112121212131313141414141515151516
+161617171717181818181919191A1A1A1A1B1B1B1B1C1C1C1D1D1D1D1E1E1E1F1F1F1F2020202021
+212122222222232323232424242525252526262627272727282828282929292A2A2A2A2B2B2B2B2C
+2C2C2D2D2D2D2E2E2E2E2F2F2F303030303131313132323233333333343434353535353636363637
+373738383838393939393A3A3A3B3B3B3B3C3C3C3C3D3D3D3E3E3E3E3F3F3F404040404141414142
+42424343434344444444454545464646
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+00000101020203030304040505050606070708080809090A0A0A0B0B0C0C0D0D0D0E0E0F0F101010
+1111121212131314141515151616171718181819191A1A1A1B1B1C1C1D1D1D1E1E1F1F1F20202121
+222222232324242525252626272727282829292A2A2A2B2B2C2C2D2D2D2E2E2F2F2F303031313232
+32333334343435353636373737383839393A3A3A3B3B3C3C3C3D3D3E3E3F3F3F4040414142424243
+4344444445454646474747484849494A4A4A4B4B4C4C4C4D4D4E4E4F4F4F50505151515252535354
+54545555565657575758585959595A5A5B5B5C5C5C5D5D5E5E5F5F5F606061616162626363646464
+6565666666676768686969696A6A6B6B
+>
+1 %_Br
+1
+0 %_Br
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+4D4C4C4C4B4B4B4A4A4A4A4949494848484747474746464645454544444444434343424242414141
+414040403F3F3F3E3E3E3E3D3D3D3C3C3C3B3B3B3B3A3A3A39393938383838373737363636353535
+35343434333333323232323131313030302F2F2F2F2E2E2E2D2D2D2C2C2C2C2B2B2B2A2A2A292929
+292828282727272626262625252524242423232323222222212121202020201F1F1F1E1E1E1D1D1D
+1D1C1C1C1B1B1B1A1A1A1A1919191818181717171716161615151514141414131313121212111111
+111010100F0F0F0E0E0E0E0D0D0D0C0C0C0B0B0B0B0A0A0A09090908080808070707060606050505
+05040404030303020202020101010000
+>
+0
+0
+1 %_Br
+[
+1 0 50 92 %_Bs
+0 0.275 1 0.12 1 50 59 %_Bs
+0 0.275 1 0.42 1 50 50 %_Bs
+1 0 50 49 %_Bs
+1 0 50 41 %_Bs
+1 0.3 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Green, Blue)
+(Green, Blue) 0 2 Bd
+[
+<
+99999A9A9B9B9B9C9C9D9D9D9E9E9F9F9FA0A0A1A1A1A2A2A3A3A3A4A4A5A5A5A6A6A7A7A7A8A8A9
+A9A9AAAAABABABACACADADADAEAEAFAFAFB0B0B1B1B1B2B2B3B3B3B4B4B5B5B5B6B6B7B7B7B8B8B9
+B9B9BABABBBBBBBCBCBDBDBDBEBEBFBFBFC0C0C1C1C1C2C2C3C3C3C4C4C5C5C5C6C6C7C7C7C8C8C9
+C9C9CACACBCBCBCCCCCDCDCDCECECFCFCFD0D0D1D1D1D2D2D3D3D3D4D4D5D5D5D6D6D7D7D7D8D8D9
+D9D9DADADBDBDBDCDCDDDDDDDEDEDFDFDFE0E0E1E1E1E2E2E3E3E3E4E4E5E5E5E6E6E7E7E7E8E8E9
+E9E9EAEAEBEBEBECECEDEDEDEEEEEFEFEFF0F0F1F1F1F2F2F3F3F3F4F4F5F5F5F6F6F7F7F7F8F8F9
+F9F9FAFAFBFBFBFCFCFDFDFDFEFEFFFF
+>
+<
+000102020304050506070808090A0B0B0C0D0E0E0F101111121314141516171718191A1A1B1C1D1D
+1E1F20202122232324252626272829292A2B2C2C2D2E2F2F303132323334353536373838393A3B3B
+3C3D3E3E3F404141424344444546474748494A4A4B4C4D4D4E4F5050515253535455565657585959
+5A5B5C5C5D5E5F5F606162626364656566676868696A6B6B6C6D6E6E6F7071717273747475767777
+78797A7A7B7C7D7D7E7F80808182828384858586878888898A8B8B8C8D8E8E8F9091919293949495
+96979798999A9A9B9C9D9D9E9FA0A0A1A2A3A3A4A5A6A6A7A8A9A9AAABACACADAEAFAFB0B1B2B2B3
+B4B5B5B6B7B8B8B9BABBBBBCBDBEBEBF
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+[
+1 0.75 0 0 1 50 100 %_Bs
+0.6 0 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Orange, Green, Violet)
+(Orange, Green, Violet) 0 3 Bd
+[
+<
+F0EFEFEFEEEEEEEDEDEDECECECEBEBEBEAEAEAE9E9E9E8E8E8E7E7E7E6E6E6E5E5E5E4E4E4E3E3E3
+E3E2E2E2E1E1E1E0E0E0DFDFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADAD9D9D9D8D8D8D7D7D7D6D6D6
+D5D5D5D4D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCCCCCBCBCBCACACAC9C9C9C8
+C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C1C0C0C0BFBFBFBEBEBEBDBDBDBCBCBCBB
+BBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B2B1B1B1B0B0B0AFAFAFAEAE
+AEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A7A6A6A6A5A5A5A4A4A4A3A3A3A2A2A2A1A1A1
+A0A0A0A09F9F9F9E9E9E9D9D9D9C9C9C
+>
+<
+5455555657575859595A5A5B5C5C5D5E5E5F5F6061616263636465656666676868696A6A6B6B6C6D
+6D6E6F6F707171727273747475767677777879797A7B7B7C7C7D7E7E7F8080818282838384858586
+87878888898A8A8B8C8C8D8D8E8F8F909191929393949495969697989899999A9B9B9C9D9D9E9E9F
+A0A0A1A2A2A3A4A4A5A5A6A7A7A8A9A9AAAAABACACADAEAEAFB0B0B1B1B2B3B3B4B5B5B6B6B7B8B8
+B9BABABBBBBCBDBDBEBFBFC0C1C1C2C2C3C4C4C5C6C6C7C7C8C9C9CACBCBCCCCCDCECECFD0D0D1D2
+D2D3D3D4D5D5D6D7D7D8D8D9DADADBDCDCDDDDDEDFDFE0E1E1E2E3E3E4E4E5E6E6E7E8E8E9E9EAEB
+EBECEDEDEEEFEFF0F0F1F2F2F3F4F4F5
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000000000101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020303030303
+>
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0
+>
+<
+A1A0A0A09F9F9F9E9E9E9D9D9D9D9C9C9C9B9B9B9A9A9A9999999898989797979696969595959594
+94949393939292929191919090908F8F8F8E8E8E8E8D8D8D8C8C8C8B8B8B8A8A8A89898988888887
+878787868686858585848484838383828282818181808080807F7F7F7E7E7E7D7D7D7C7C7C7B7B7B
+7A7A7A79797978787878777777767676757575747474737373727272717171717070706F6F6F6E6E
+6E6D6D6D6C6C6C6B6B6B6A6A6A6A6969696868686767676666666565656464646363636262626261
+61616060605F5F5F5E5E5E5D5D5D5C5C5C5B5B5B5B5A5A5A59595958585857575756565655555554
+54
+>
+<
+F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6
+F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8
+F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFA
+FAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFD
+FDFDFDFDFDFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFFFFFFFFFFFFFFFFFFFFFF
+FF
+>
+0
+1 %_Br
+[
+0.61 0.96 0 0.01 1 50 100 %_Bs
+0.94 0.33 1 0 1 50 50 %_Bs
+0 0.63 0.96 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Pink, Yellow, Green )
+(Pink, Yellow, Green ) 0 3 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4D4E4F50
+5152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717273
+>
+<
+05050505050505050505050505050404040404040404040404040404040404040404040403030303
+03030303030303030303030303030303030303020202020202020202020202020202020202020202
+0201010101010101010101010101010101010101010101000000000000000000000000
+>
+<
+CCCCCCCCCCCBCBCBCBCBCBCBCBCBCACACACACACACACACAC9C9C9C9C9C9C9C9C9C8C8C8C8C8C8C8C8
+C8C7C7C7C7C7C7C7C7C7C6C6C6C6C6C6C6C6C6C5C5C5C5C5C5C5C5C5C4C4C4C4C4C4C4C4C3C3C3C3
+C3C3C3C3C3C2C2C2C2C2C2C2C2C2C1C1C1C1C1C1C1C1C1C0C0C0C0C0C0C0C0C0BFBFBF
+>
+0
+1 %_Br
+<
+0D0D0D0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0B
+0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A
+0A0A0A09090909090909090909090909090909090909090808080808080808080808080808080808
+08080807070707070707070707070707070707070706060606060606060606060606060606060605
+05050505050505050505050505050505050404040404040404040404040404040404030303030303
+03030303030303030303030202020202020202020202020202020201010101010101010101010101
+010101000000000000000000
+>
+<
+B2B2B2B2B1B1B1B0B0B0AFAFAEAEAEADADACACABABAAAAA9A9A8A8A7A7A6A6A5A5A4A4A3A3A2A2A1
+A0A09F9F9E9E9D9D9C9B9B9A9A999898979796959594949392929190908F8F8E8D8D8C8B8B8A8989
+88888786868584848382828180807F7E7D7D7C7B7B7A7979787777767575747372727170706F6E6D
+6D6C6B6B6A69686867666565646363626160605F5E5D5D5C5B5A5A59585757565554545352515150
+4F4E4D4D4C4B4A4A4948474646454443434241403F3F3E3D3C3B3B3A393837373635343333323130
+2F2F2E2D2C2B2B2A2928272726252423222221201F1E1D1D1C1B1A1918181716151413131211100F
+0E0E0D0C0B0A090908070605
+>
+<
+0000010101020202030304040505060607070808090A0A0B0B0C0C0D0E0E0F0F1011111213131415
+151616171818191A1B1B1C1D1D1E1F1F202122222324242526272728292A2A2B2C2C2D2E2F303031
+323333343536363738393A3A3B3C3D3E3E3F4041424243444546464748494A4B4B4C4D4E4F505051
+5253545556565758595A5B5B5C5D5E5F6061626263646566676869696A6B6C6D6E6F707171727374
+75767778797A7B7B7C7D7E7F80818283848586868788898A8B8C8D8E8F9091929394949596979899
+9A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAAAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0
+C1C2C3C4C5C6C7C8C9CACBCC
+>
+0
+1 %_Br
+[
+0.45 0 0.75 0 1 50 100 %_Bs
+0 0.02 0.8 0 1 50 64 %_Bs
+0.05 0.7 0 0 1 57 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Purple, Red, Yellow)
+(Purple, Red, Yellow) 0 3 Bd
+[
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A
+>
+<
+CCCCCCCDCDCDCDCDCECECECECECFCFCFCFD0D0D0D0D0D1D1D1D1D1D2D2D2D2D2D3D3D3D3D3D4D4D4
+D4D5D5D5D5D5D6D6D6D6D6D7D7D7D7D7D8D8D8D8D8D9D9D9D9DADADADADADBDBDBDBDBDCDCDCDCDC
+DDDDDDDDDDDEDEDEDEDFDFDFDFDFE0E0E0E0E0E1E1E1E1E1E2E2E2E2E2E3E3E3E3E4E4E4E4E4E5E5
+E5E5E5E6E6E6E6E6E7E7E7E7E7E8E8E8E8E9E9E9E9E9EAEAEAEAEAEBEBEBEBEBECECECECECEDEDED
+EDEEEEEEEEEEEFEFEFEFEFF0F0F0F0F0F1F1F1F1F1F2F2F2F2F3F3F3F3F3F4F4F4F4F4F5F5F5F5F5
+F6F6F6F6F6F7F7F7F7F8F8F8F8F8F9F9F9F9F9FAFAFAFAFAFBFBFBFBFBFCFCFCFCFDFDFDFDFDFEFE
+FEFEFEFFFFFF
+>
+0
+1 %_Br
+<
+E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBE
+BDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A99989796
+9594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B7A797877767574737271706F6E
+6D6C6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A49484746
+4544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F1E
+1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403020100
+>
+<
+E5E6E6E6E6E6E6E6E6E7E7E7E7E7E7E7E7E7E8E8E8E8E8E8E8E8E8E9E9E9E9E9E9E9E9E9EAEAEAEA
+EAEAEAEAEAEBEBEBEBEBEBEBEBEBECECECECECECECECECEDEDEDEDEDEDEDEDEDEEEEEEEEEEEEEEEE
+EEEFEFEFEFEFEFEFEFEFF0F0F0F0F0F0F0F0F0F1F1F1F1F1F1F1F1F1F2F2F2F2F2F2F2F2F2F3F3F3
+F3F3F3F3F3F3F4F4F4F4F4F4F4F4F4F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F7F7F7F7F7F7F7
+F7F7F8F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFEFEFEFEFEFEFEFEFEFFFFFFFFFF
+>
+<
+00010203040405060708090A0B0C0C0D0E0F10111213141415161718191A1B1C1D1D1E1F20212223
+242525262728292A2B2C2D2D2E2F30313233343535363738393A3B3C3D3D3E3F4041424344454546
+4748494A4B4C4D4E4E4F50515253545556565758595A5B5C5D5E5E5F60616263646566666768696A
+6B6C6D6E6E6F70717273747576767778797A7B7C7D7E7F7F80818283848586878788898A8B8C8D8E
+8F8F90919293949596979798999A9B9C9D9E9F9FA0A1A2A3A4A5A6A7A7A8A9AAABACADAEAFAFB0B1
+B2B3B4B5B6B7B8B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C8C9CACBCC
+>
+0
+1 %_Br
+[
+0 0.04 1 0 1 50 100 %_Bs
+0 1 0.8 0 1 50 50 %_Bs
+0.9 0.9 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Rainbow)
+(Rainbow) 0 6 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+0
+1 %_Br
+1
+<
+0708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F50515253545556
+5758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E
+7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6
+A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCE
+CFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6
+F7F8F9FAFBFCFDFEFF
+>
+0
+0
+1 %_Br
+1
+<
+00000000000000000000000000000000000001010101010101010101010101010101010101010101
+01010101010101010101010101010202020202020202020202020202020202020202020202020202
+02020202020202020202030303030303030303030303030303030303030303030303030303030303
+03030303030304040404040404040404040404040404040404040404040404040404040404040404
+04040505050505050505050505050505050505050505050505050505050505050505050505050606
+06060606060606060606060606060606060606060606060606060606060606060606070707070707
+07070707070707070707070707070707
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+1 %_Br
+[
+0 1 0 0 1 50 100 %_Bs
+1 1 0 0 1 50 80 %_Bs
+1 0.0279 0 0 1 50 60 %_Bs
+1 0 1 0 1 50 40 %_Bs
+0 0 1 0 1 50 20 %_Bs
+0 1 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Steel Bar)
+(Steel Bar) 0 3 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 70 %_Bs
+0 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (White & Red Radial)
+(White & Red Radial) 1 18 Bd
+[
+0
+1
+1
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+[
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 25 %_Bs
+0 1 1 0 1 50 25 %_Bs
+0 1 1 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 50 %_Bs
+0 1 1 0 1 50 50 %_Bs
+0 1 1 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 75 %_Bs
+0 1 1 0 1 50 75 %_Bs
+0 1 1 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 100 %_Bs
+0 1 1 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Yellow & Orange Radial)
+(Yellow & Orange Radial) 1 2 Bd
+[
+0
+<
+0001010203040506060708090A0B0C0C0D0E0F10111213131415161718191A1B1C1D1D1E1F202122
+232425262728292A2B2B2C2D2E2F303132333435363738393A3B3C3D3E3E3F404142434445464748
+494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F60606162636465666768696A6B6C6D6E6F
+707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C
+>
+<
+FFFFFFFFFEFEFEFEFEFEFEFDFDFDFDFDFDFCFCFCFCFCFCFBFBFBFBFBFBFAFAFAFAFAFAF9F9F9F9F9
+F9F8F8F8F8F8F8F7F7F7F7F7F7F6F6F6F6F6F6F5F5F5F5F5F5F4F4F4F4F4F3F3F3F3F3F3F2F2F2F2
+F2F2F1F1F1F1F1F0F0F0F0F0F0EFEFEFEFEFEFEEEEEEEEEEEDEDEDEDEDEDECECECECECEBEBEBEBEB
+EBEAEAEAEAEAE9E9E9E9E9E9E8E8E8E8E8E8E7E7E7E7E7E6E6E6E6E6E5
+>
+0
+1 %_Br
+[
+0 0 1 0 1 52 19 %_Bs
+0 0.55 0.9 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Yellow & Purple Radial)
+(Yellow & Purple Radial) 1 2 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+1415161718191A1B1C1D1E1F1F202122232425262728292A2A2B2C2D2E2F30313233343536363738
+393A3B3C3D3E3F40414142434445464748494A4B4C4D4D4E4F50515253545556575858595A5B5C5D
+5E5F60616263646465666768696A6B6C6D6E6F6F707172737475767778797A7B7B7C7D7E7F808182
+83848586868788898A8B8C8D8E8F90919292939495969798999A9B9C9D9D9E9FA0A1A2A3A4A5A6A7
+A8A9A9AAABACADAEAFB0B1B2B3B4B4B5B6B7B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C9CACBCB
+CCCDCECFD0D1D2D3D4D5D6D7D7D8D9DADBDCDDDEDFE0E1E2E2E3E4E5E6E7E8E9EAEBECEDEEEEEFF0
+F1F2F3F4F5F6F7F8F9F9FAFBFCFDFEFF
+>
+<
+ABAAAAA9A8A7A7A6A5A5A4A3A3A2A1A1A09F9F9E9D9D9C9B9B9A9999989797969595949393929191
+908F8F8E8D8D8C8B8B8A8989888787868585848383828181807F7F7E7D7D7C7B7B7A797978777776
+7575747373727171706F6F6E6D6D6C6B6B6A6969686767666565646362626160605F5E5E5D5C5C5B
+5A5A5958585756565554545352525150504F4E4E4D4C4C4B4A4A4948484746464544444342424140
+403F3E3E3D3C3C3B3A3A3938383736363534343332323130302F2E2E2D2C2C2B2A2A292828272626
+25242423222121201F1F1E1D1D1C1B1B1A1919181717161515141313121111100F0F0E0D0D0C0B0B
+0A090908070706050504030302010100
+>
+0
+1 %_Br
+[
+0 0.08 0.67 0 1 50 14 %_Bs
+1 1 0 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Yellow, Violet, Orange, Blue)
+(Yellow, Violet, Orange, Blue) 0 4 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+A1A1A1A1A2A2A2A2A3A3A3A3A4A4A4A4A4A5A5A5A5A6A6A6A6A7A7A7A7A8A8A8A8A9A9A9A9AAAAAA
+AAAAABABABABACACACACADADADADAEAEAEAEAFAFAFAFB0B0B0B0B0B1B1B1B1B2B2B2B2B3B3B3B3B4
+B4B4B4B5B5B5B5B6B6B6B6B6B7B7B7B7B8B8B8B8B9B9B9B9BABABABABBBBBBBBBCBCBCBCBCBDBDBD
+BDBEBEBEBEBFBFBFBFC0C0C0C0C1C1C1C1C2C2C2C2C2C3C3C3C3C4C4C4C4C5C5C5C5C6C6C6C6C7C7
+C7C7C8C8C8C8C8C9C9C9C9CACACACACBCBCBCBCCCCCCCCCDCDCDCDCECECECECECFCFCFCFD0D0D0D0
+D1D1D1D1D2D2D2D2D3D3D3D3D4D4D4D4D4D5D5D5D5D6D6D6D6D7D7D7D7D8D8D8D8D9D9D9D9DADADA
+DADADBDBDBDBDCDCDCDCDDDDDDDDDEDE
+>
+<
+F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CF
+CECDCCCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B4B3B2B1B0AFAEADACABAAA9
+A8A7A6A5A4A3A2A1A09F9E9D9C9C9B9A999897969594939291908F8E8D8C8B8A8988878685848483
+8281807F7E7D7C7B7A797877767574737271706F6E6D6C6C6B6A696867666564636261605F5E5D5C
+5B5A59585756555454535251504F4E4D4C4B4A494847464544434241403F3E3D3C3C3B3A39383736
+3534333231302F2E2D2C2B2A29282726252424232221201F1E1D1C1B1A191817161514131211100F
+0E0D0C0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+9C9B9A9A9998989796969595949393929191908F8F8E8E8D8C8C8B8A8A8989888787868585848383
+82828180807F7E7E7D7C7C7B7B7A797978777776757574747372727170706F6E6E6D6D6C6B6B6A69
+6968676766666564646362626161605F5F5E5D5D5C5B5B5A5A595858575656555454535352515150
+4F4F4E4D4D4C4C4B4A4A4948484746464545444343424141403F3F3E3E3D3C3C3B3A3A3939383737
+36353534333332323130302F2E2E2D2C2C2B2B2A292928272726252524242322222120201F1E1E1D
+1D1C1B1B1A191918171716161514141312121111100F0F0E0D0D0C0B0B0A0A090808070606050404
+030302010100
+>
+<
+F5F4F4F4F3F3F3F2F2F2F1F1F1F0F0F0EFEFEFEEEEEEEDEDEDECECECEBEBEAEAEAE9E9E9E8E8E8E7
+E7E7E6E6E6E5E5E5E4E4E4E3E3E3E2E2E2E1E1E1E0E0E0DFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADA
+D9D9D9D8D8D8D7D7D7D6D6D6D5D5D5D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCC
+CCCBCBCBCACACAC9C9C8C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C0C0C0BFBFBFBE
+BEBEBDBDBCBCBCBBBBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B1B1B1B0
+B0B0AFAFAFAEAEAEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A6A6A6A5A5A5A4A4A4A3A3A3
+A2A2A2A1A1A1
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5
+>
+<
+03030303030202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020201010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101000000
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+000000000000
+>
+1 %_Br
+<
+0D0D0E0F0F10101111121313141415161617171819191A1A1B1C1C1D1D1E1E1F2020212122232324
+2425262627272828292A2A2B2B2C2D2D2E2E2F30303131323333343435353637373838393A3A3B3B
+3C3D3D3E3E3F3F404141424243444445454647474848494A4A4B4B4C4C4D4E4E4F4F505151525253
+54545555565757585859595A5B5B5C5C5D5E5E5F5F60616162626363646565666667686869696A6B
+6B6C6C6D6E6E6F6F70707172727373747575767677787879797A7B7B7C7C7D7D7E7F7F8080818282
+8383848585868687878889898A8A8B8C8C8D8D8E8F8F90909192929393949495969697979899999A
+9A9B9C
+>
+<
+08090A0B0C0D0E0F0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F40404142434445464748494A4B4C4D4E4F505152535455
+565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717172737475767778797A7B7C
+7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A2A3
+A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACB
+CCCDCECFD0D1D2D3D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2
+F3F4F5
+>
+<
+F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCB
+CAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3
+A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B
+7A797877767574737271706F6E6D6C6B6A696867666564636261605F5E5D5C5B5A59585756555453
+5251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B
+2A292827262524232221201F1E1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403
+020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020303
+030303
+>
+1 %_Br
+[
+1 0.87 0 0 1 50 95 %_Bs
+0 0.63 0.96 0 1 50 65 %_Bs
+0.61 0.96 0 0.01 1 50 35 %_Bs
+0.05 0.03 0.95 0 1 50 5 %_Bs
+BD
+%AI5_EndGradient
+%AI5_End_NonPrinting--
+%AI5_BeginPalette
+0 0 Pb
+0 0 0 0 k
+(C=0 M=0 Y=0 K=0) Pc
+0 0 0 1 k
+(C=0 M=0 Y=0 K=100) Pc
+0 0.45 0.6 0 k
+(C=0 M=45 Y=60 K=0) Pc
+0 0.5 0.05 0 k
+(C=0 M=50 Y=5 K=0) Pc
+0 0.9 1 0 k
+(C=0 M=90 Y=100 K=0) Pc
+1 0.2 1 0 k
+(C=100 M=20 Y=100 K=0) Pc
+1 0.4 0.15 0 k
+(C=100 M=40 Y=15 K=0) Pc
+0.2 0 1 0 k
+(C=20 M=0 Y=100 K=0) Pc
+0.25 1 0.25 0 k
+(C=25 M=100 Y=25 K=0) Pc
+0.4 0.4 0.4 0 k
+(C=40 M=40 Y=40 K=0) Pc
+0.4 0.7 1 0 k
+(C=40 M=70 Y=100 K=0) Pc
+0.75 0.9 0 0 k
+(C=75 M=90 Y=0 K=0) Pc
+1 0 0.55 0 (Aqua) 0 x
+(Aqua) Pc
+1 0.5 0 0 (Blue) 0 x
+(Blue) Pc
+0.5 0.4 0.3 0 (Blue Gray) 0 x
+(Blue Gray) Pc
+0.8 0.05 0 0 (Blue Sky) 0 x
+(Blue Sky) Pc
+0.5 0.85 1 0 (Brown) 0 x
+(Brown) Pc
+1 0.9 0.1 0 (Dark Blue) 0 x
+(Dark Blue) Pc
+1 0.55 1 0 (Forest Green) 0 x
+(Forest Green) Pc
+0.05 0.2 0.95 0 (Gold) 0 x
+(Gold) Pc
+0.75 0.05 1 0 (Grass Green) 0 x
+(Grass Green) Pc
+0 0.45 1 0 (Orange) 0 x
+(Orange) Pc
+0.15 1 1 0 (Red) 0 x
+(Red) Pc
+0.45 0.9 0 0 (Violet) 0 x
+(Violet) Pc
+Bb
+2 (Black, White) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Black, White) Pc
+Bb
+2 (Chrome) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Chrome) Pc
+Bb
+2 (Green, Blue) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Green, Blue) Pc
+Bb
+2 (Orange, Green, Violet) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Orange, Green, Violet) Pc
+Bb
+2 (Pink, Yellow, Green ) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Pink, Yellow, Green ) Pc
+Bb
+2 (Purple, Red, Yellow) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Purple, Red, Yellow) Pc
+Bb
+2 (Rainbow) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Rainbow) Pc
+Bb
+2 (Steel Bar) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Steel Bar) Pc
+Bb
+0 0 0 0 Bh
+2 (White & Red Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(White & Red Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Yellow & Orange Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Yellow & Orange Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Yellow & Purple Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Yellow & Purple Radial) Pc
+Bb
+2 (Yellow, Violet, Orange, Blue) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Yellow, Violet, Orange, Blue) Pc
+(Arrow1.2.out/in) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Arrow1.2.out/in) Pc
+(Arrow1.2.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Arrow1.2.side) Pc
+(Bricks) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Bricks) Pc
+(Checks) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Checks) Pc
+(Confetti) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Confetti) Pc
+(DblLine1.2.inner) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(DblLine1.2.inner) Pc
+(DblLine1.2.outer) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(DblLine1.2.outer) Pc
+(DblLine1.2.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(DblLine1.2.side) Pc
+(Diamonds) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Diamonds) Pc
+(Hexagon) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Hexagon) Pc
+(Laurel.inner) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Laurel.inner) Pc
+(Laurel.outer) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Laurel.outer) Pc
+(Laurel.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Laurel.side) Pc
+(Leaves-fall) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Leaves-fall) Pc
+(Polka dots) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Polka dots) Pc
+(Random circles) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Random circles) Pc
+(Rope.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Rope.side) Pc
+(Scales) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Scales) Pc
+(SolidStar.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(SolidStar.side) Pc
+(Stars) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Stars) Pc
+(Stripes) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Stripes) Pc
+(TriBevel.outer) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(TriBevel.outer) Pc
+(TriBevel.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(TriBevel.side) Pc
+(Waves-scroll) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Waves-scroll) Pc
+PB
+%AI5_EndPalette
+%AI5_BeginLayer
+1 1 1 1 0 0 0 79 128 255 Lb
+(Layer 1) Ln
+0 A
+u
+q
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+323.3 211.82 m
+321.5 204.62 l
+319.7 211.82 l
+319.7 202.1 l
+323.3 202.1 l
+323.3 211.82 l
+h
+W
+n
+319.7 221.18 m
+321.5 228.38 l
+323.3 221.18 l
+323.3 230.9 l
+319.7 230.9 l
+H
+W
+N
+*U
+0 R
+0 0 0 XA
+0.45 w 10 M
+321.5 230 m
+321.5 203 l
+S
+Q
+U
+0 A
+0 O
+0 g
+0 R
+0 0 0 XA
+800 Ar
+0 J 0 j 0.45 w 10 M []0 d
+%AI3_Note:
+0 D
+1 XR
+319.7 221.18 m
+321.5 228.38 l
+323.3 221.18 l
+319.7 221.18 l
+b
+323.3 211.82 m
+321.5 204.62 l
+319.7 211.82 l
+323.3 211.82 l
+b
+u
+q
+*u
+1 w 4 M
+402.68 357.8 m
+409.88 356 l
+402.68 354.2 l
+412.4 354.2 l
+412.4 357.8 l
+402.68 357.8 l
+h
+W
+n
+303.32 354.2 m
+296.12 356 l
+303.32 357.8 l
+293.6 357.8 l
+293.6 354.2 l
+H
+W
+N
+*U
+0 R
+0 0 0 XA
+0.45 w 10 M
+294.5 356 m
+411.5 356 l
+S
+Q
+U
+0 A
+0 O
+0 g
+0 R
+0 0 0 XA
+800 Ar
+0 J 0 j 0.45 w 10 M []0 d
+%AI3_Note:
+0 D
+1 XR
+303.32 354.2 m
+296.12 356 l
+303.32 357.8 l
+303.32 354.2 l
+b
+402.68 357.8 m
+409.88 356 l
+402.68 354.2 l
+402.68 357.8 l
+b
+u
+q
+*u
+1 w 4 M
+272.18 276.8 m
+279.38 275 l
+272.18 273.2 l
+281.9 273.2 l
+281.9 276.8 l
+H
+W
+N
+*U
+0 R
+0 0 0 XA
+0.45 w 10 M
+257 275 m
+281 275 l
+S
+Q
+U
+0 A
+0 O
+0 g
+0 R
+0 0 0 XA
+800 Ar
+0 J 0 j 0.45 w 10 M []0 d
+%AI3_Note:
+0 D
+1 XR
+272.18 276.8 m
+279.38 275 l
+272.18 273.2 l
+272.18 276.8 l
+b
+u
+q
+*u
+1 w 4 M
+303.32 273.2 m
+296.12 275 l
+303.32 276.8 l
+293.6 276.8 l
+293.6 273.2 l
+H
+W
+N
+*U
+0 R
+0 0 0 XA
+0.45 w 10 M
+294.5 275 m
+317 275 l
+S
+Q
+U
+0 A
+0 O
+0 g
+0 R
+0 0 0 XA
+800 Ar
+0 J 0 j 0.45 w 10 M []0 d
+%AI3_Note:
+0 D
+1 XR
+303.32 273.2 m
+296.12 275 l
+303.32 276.8 l
+303.32 273.2 l
+b
+u
+q
+*u
+1 w 4 M
+155.18 335.3 m
+162.38 333.5 l
+155.18 331.7 l
+164.9 331.7 l
+164.9 335.3 l
+155.18 335.3 l
+h
+W
+n
+145.82 331.7 m
+138.62 333.5 l
+145.82 335.3 l
+136.1 335.3 l
+136.1 331.7 l
+H
+W
+N
+*U
+0 R
+0 0 0 XA
+0.45 w 10 M
+137 333.5 m
+164 333.5 l
+S
+Q
+U
+0 A
+0 O
+0 g
+0 R
+0 0 0 XA
+800 Ar
+0 J 0 j 0.45 w 10 M []0 d
+%AI3_Note:
+0 D
+1 XR
+145.82 331.7 m
+138.62 333.5 l
+145.82 335.3 l
+145.82 331.7 l
+b
+155.18 335.3 m
+162.38 333.5 l
+155.18 331.7 l
+155.18 335.3 l
+b
+*u
+164 575 m
+281 575 l
+281 230 l
+164 230 l
+164 575 l
+s
+294.5 575 m
+411.5 575 l
+411.5 230 l
+294.5 230 l
+294.5 575 l
+s
+137 621.5 m
+434 621.5 l
+434 203 l
+137 203 l
+137 621.5 l
+s
+*U
+[3.6 ]0 d
+137 599 m
+443 599 l
+443 203 l
+137 203 l
+137 599 l
+s
+u
+q
+*u
+1 w 4 M []0 d
+220.7 566.18 m
+222.5 573.38 l
+224.3 566.18 l
+224.3 575.9 l
+220.7 575.9 l
+220.7 566.18 l
+h
+W
+n
+224.3 238.82 m
+222.5 231.62 l
+220.7 238.82 l
+220.7 229.1 l
+224.3 229.1 l
+H
+W
+N
+*U
+0 R
+0 0 0 XA
+0.45 w 10 M
+222.5 230 m
+222.5 575 l
+S
+Q
+U
+0 A
+0 O
+0 g
+0 R
+0 0 0 XA
+800 Ar
+0 J 0 j 0.45 w 10 M []0 d
+%AI3_Note:
+0 D
+1 XR
+224.3 238.82 m
+222.5 231.62 l
+220.7 238.82 l
+224.3 238.82 l
+b
+220.7 566.18 m
+222.5 573.38 l
+224.3 566.18 l
+220.7 566.18 l
+b
+0 To
+1 0 0 1 227 482 0 Tp
+0 Tv
+TP
+0 Tr
+0 0 0 Xa
+1 w 4 M
+%_ 0 50 XQ
+/_Times-Bold 10.8 10.098 -2.3543 Tf
+0 Ts
+100 100 Tz
+0 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 100 TC
+100 100 100 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0 Tc
+0 Tw
+(241mm) Tx 
+(\r) TX 
+TO
+0 To
+1 0 0 1 154.9966 630.4998 0 Tp
+0 Tv
+TP
+0 Tr
+0.1 0 Tl
+(A4 paper \(21.0 x 29.7 cm\)) Tx 
+(\r) TX 
+TO
+0 To
+0 1 -1 0 456.5 297.5 0 Tp
+0 Tv
+TP
+0 Tr
+(US letter paper \(8.5 x 11 in\)) Tx 
+(\r) TX 
+TO
+0 To
+1 0 0 1 299 279.5 0 Tp
+0 Tv
+TP
+0 Tr
+(0.2 in) Tx 
+(\r) TX 
+TO
+0 To
+1 0 0 1 339.5 360.4999 0 Tp
+0 Tv
+TP
+0 Tr
+(3.25 in) Tx 
+(\r) TX 
+TO
+0 To
+1 0 0 1 226.9966 468.4998 0 Tp
+0 Tv
+TP
+0 Tr
+(9.5 in) Tx 
+(\r) TX 
+TO
+0 To
+1 0 0 1 326 212.0001 0 Tp
+0 Tv
+TP
+0 Tr
+256.4997 0 Tl
+(19mm \(0.75 in\)) Tx 
+(\r) TX 
+TO
+0 To
+0 1 -1 0 155 342.5 0 Tp
+0 Tv
+TP
+0 Tr
+(20mm \(0.79 in\)) Tx 
+(\r) TX 
+TO
+0 To
+1 0 0 1 339.5 342.5 0 Tp
+0 Tv
+TP
+0 Tr
+(82.5mm) Tx 
+(\r) TX 
+TO
+0 To
+1 0 0 1 299 260.6038 0 Tp
+0 Tv
+TP
+0 Tr
+81.8962 0 Tl
+(5.0mm) Tx 
+(\r) TX 
+TO
+LB
+%AI5_EndLayer--
+gsave annotatepage grestore showpage
+Adobe_Illustrator_AI5 /terminate get exec
+Adobe_ColorImage_AI6 /terminate get exec
+Adobe_typography_AI5 /terminate get exec
+Adobe_cshow /terminate get exec
+Adobe_level2_AI5 /terminate get exec
+
+%%EndDocument
+ @endspecial 2458 3599 a(Figure)g(1:)25 b(Layout)19 b(of)h(papers.)1939
+3896 y Fm(F)-10 b(onts)2022 4041 y Fl(In)24 b(order)f(to)h(produce)e
+(good)g(Adobe)h(Acrobat)g(PDF)i(\002les,)h(the)1939 4140
+y(editorial)j(staf)n(f)h(asks)g(authors)f(to)h(use)g(only)f(T)m(imes)h
+(\(in)f(bold)g(or)1939 4240 y(italic\))18 b(and)f(Symbol)f(from)h(the)g
+(standard)f(postscript)h(set)h(of)f(fonts.)1939 4340
+y(The)27 b(editorial)f(staf)n(f)h(is)h(a)o(w)o(are)e(of)h(problems)e
+(processing)h(Asian)1939 4439 y(and)31 b(Cyrillic)h(fonts)f(and)g(will)
+h(ha)n(v)o(e)f(e)o(xperts)g(in)g(these)h(matters)1939
+4539 y(a)n(v)n(ailable)20 b(at)h(the)f(conference.)1939
+4748 y Fm(T)-5 b(itle)2022 4892 y Fl(The)27 b(title)h(should)d(use)j
+(14pt)e(bold)g(uppercase)f(letters)i(and)g(be)1939 4992
+y(centered)e(on)g(the)h(page.)40 b(The)25 b(names)g(of)h(the)f(authors)
+g(and)g(their)1939 5092 y(or)o(ganisations/af)n(\002liations)f(and)j
+(mailing)g(addresses)g(should)g(be)1939 5191 y(grouped)d(by)i(af)n
+(\002liation)f(and)g(listed)i(in)f(12pt)f(upper)g(and)g(lo)n(wer)n(-)
+1939 5291 y(case)d(letters.)29 b(The)21 b(name)f(of)h(the)g(submitting)
+f(or)h(primary)f(author)1939 5391 y(should)k(be)h(\002rst,)i(follo)n
+(wed)c(by)i(the)g(co-authors)e(in)i(alphabetical)1939
+5490 y(order)19 b(by)h(af)n(\002liation.)1939 5699 y
+Fm(Section)25 b(Headings)2022 5844 y Fl(Section)e(headings)e(should)h
+(not)g(be)g(numbered.)30 b(The)o(y)22 b(should)1939 5943
+y(use)27 b(12pt)f(bold)f(uppercase)g(letters)i(and)f(be)h(centred)e(in)
+i(the)f(col-)p eop
+%%Page: 2 2
+2 1 bop 168 2766 a @beginspecial 23 @llx 185 @lly 599
+@urx 608 @ury 4110 @rwi @clip @setspecial
+%%BeginDocument: JACpic2.eps
+%AI5_FileFormat 3.0
+%AI3_ColorUsage: Color
+%AI3_IncludePlacedImages
+%AI7_ImageSettings: 1
+%AI3_TemplateBox: 306 396 306 396
+%AI3_TileBox: 30 31 582 758
+%AI3_DocumentPreview: PC_ColorTIFF
+%AI5_ArtSize: 612 792
+%AI5_RulerUnits: 2
+%AI5_ArtFlags: 1 0 0 1 0 0 1 1 0
+%AI5_TargetResolution: 800
+%AI5_NumLayers: 1
+%AI5_OpenToView: -450 900 -1.5 1016 703 18 0 1 4 61 0 0
+%AI5_OpenViewLayers: 7
+%AI7_GridSettings: 72 8 72 8 1 0 0.8 0.8 0.8 0.9 0.9 0.9
+%AI7_Thumbnail: 128 80 8
+%0000330000660000990000CC0033000033330033660033990033CC0033FF
+%0066000066330066660066990066CC0066FF009900009933009966009999
+%0099CC0099FF00CC0000CC3300CC6600CC9900CCCC00CCFF00FF3300FF66
+%00FF9900FFCC3300003300333300663300993300CC3300FF333300333333
+%3333663333993333CC3333FF3366003366333366663366993366CC3366FF
+%3399003399333399663399993399CC3399FF33CC0033CC3333CC6633CC99
+%33CCCC33CCFF33FF0033FF3333FF6633FF9933FFCC33FFFF660000660033
+%6600666600996600CC6600FF6633006633336633666633996633CC6633FF
+%6666006666336666666666996666CC6666FF669900669933669966669999
+%6699CC6699FF66CC0066CC3366CC6666CC9966CCCC66CCFF66FF0066FF33
+%66FF6666FF9966FFCC66FFFF9900009900339900669900999900CC9900FF
+%9933009933339933669933999933CC9933FF996600996633996666996699
+%9966CC9966FF9999009999339999669999999999CC9999FF99CC0099CC33
+%99CC6699CC9999CCCC99CCFF99FF0099FF3399FF6699FF9999FFCC99FFFF
+%CC0000CC0033CC0066CC0099CC00CCCC00FFCC3300CC3333CC3366CC3399
+%CC33CCCC33FFCC6600CC6633CC6666CC6699CC66CCCC66FFCC9900CC9933
+%CC9966CC9999CC99CCCC99FFCCCC00CCCC33CCCC66CCCC99CCCCCCCCCCFF
+%CCFF00CCFF33CCFF66CCFF99CCFFCCCCFFFFFF0033FF0066FF0099FF00CC
+%FF3300FF3333FF3366FF3399FF33CCFF33FFFF6600FF6633FF6666FF6699
+%FF66CCFF66FFFF9900FF9933FF9966FF9999FF99CCFF99FFFFCC00FFCC33
+%FFCC66FFCC99FFCCCCFFCCFFFFFF33FFFF66FFFF99FFFFCC110000001100
+%000011111111220000002200000022222222440000004400000044444444
+%550000005500000055555555770000007700000077777777880000008800
+%000088888888AA000000AA000000AAAAAAAABB000000BB000000BBBBBBBB
+%DD000000DD000000DDDDDDDDEE000000EE000000EEEEEEEE0000000000FF
+%00FF0000FFFFFF0000FF00FFFFFF00FFFFFF
+%524C45FDA3FFFD53F8FD2CFFF8FFF8FD50FFF8FD29FF7DF8F8F8FFF8FD50
+%FFF8FD2BFFF8FFFFF8FD50FFF8FD2BFFF8FFFFFD07F8FD4AFFF8FD2BFFF8
+%FFFFFD05F828F8FD4AFFF8FD2BFFF8FFFFF8F87F7FF853FD4CF8FD29FFA8
+%FFFD05F87F7FF828F8FD4AFFF8FD29FF7DF8F8F8FFF8F87F7FF853F8FD4A
+%FFF8FD2BFFF8FFFFF8F87F7FF828F8FD4AFFF8FD2BFFF8FFFFF8F87F7FF8
+%53F8FD4AFFF8FD2BFFF8FFFFF8F87F7FF828F8FD4AFFF8FD2BFFF8FFFFF8
+%F87F7FF853FD4CF8FD29FFA8FFFD05F87F7FF828F8FD4AFFF8FD29FF7DF8
+%F8F8FFF8F87F7FF853F8FD4AFFF8FD2BFFF8FFFFF8F87F7FF828F8FD4AFF
+%F8FD2BFFF8FFFFF8F87F7FF853F8FD4AFFF8FD2BFFF8FFFFF8F87F7FF828
+%F8FD4AFFF8FD2BFFF8FFFFF8F87F7FF853FD4CF8FD2BFFFD05F87F7FF828
+%F8FD4AFFF8FD2AFFF8F8F8FFF8F87F7FF853F8FD4AFFF8FD29FF7D7DF8FF
+%FFF8F87F7FF828F8FD4AFFF8FD2BFFF8FFFFF8F87F7FF853F8FD4AFFF8FD
+%2BFFF8FFFFF8F87F7FF828F8FD4AFFF8FD2BFFF8FFFFF8F87F7FF853FD4C
+%F8FD2BFFFD05F87F7FF828F8FD4AFFF8FD2AFFF8F8F8FFF8F87F7FF853F8
+%FFFFFFFD06F8FD41FFF8FD29FF527DF8FFFFF8F87F7FF828F8FFFFFFFD06
+%F8FD41FFF8FD2BFFF8FFFFF8F87F7FF853F8FFFFFFF87F7FF828F8FD41FF
+%F8FD2BFFF8FFFFF8F87F7FF828F8FFFFFFF87F7FF853F8FD41FFF8FD2BFF
+%F8FFFFF8F87F7FF853FD05F87F7FF828FD43F8FD2BFFF8FFF8F8F87F7FF8
+%28F8FFFFFFF87F7FF853F8FD41FFF8FD29FFA8A8F8F8FFF8F87F7FF853F8
+%FFFFFFF87F7FF828F8FFFFFFFD06F8FD38FFF8FD29FF7DF8F8FFFFF8F87F
+%7FF828F8FFFFFFF87F7FF853F8FFFFFFF87F7FF828F8FD04FFFD04F8FD30
+%FFF8FD2BFFF8FFFFF8F87F7FF853F8FFFFFFF87F7FF828F8FFFFFFF87F7F
+%F853F8FFFFFFFD05F8FD30FFF8FD2BFFF8FFFFF8F87F7FF828F8FFFFFFF8
+%7F7FF853F8FFFFFFF87F7FF828F8FFFFFFF87F7FF8F8FD30FFF8FD2BFFF8
+%FFFFF8F87F7FF853FD05F87F7FF828FD05F87F7FF853FD05F87F7FFD33F8
+%FD2BFFF8FFF8F8F87F7FF828F8FFFFFFF87F7FF853F8FFFFFFF87F7FF828
+%F8FFFFFFF87F7FF8F8FD30FFF8FD2AFFA8F8F8FFF8F87F7FF853F8FFFFFF
+%F87F7FF828F8FFFFFFF87F7FF853F8FFFFFFF87F7FF8F8FD30FFF8FD29FF
+%7DF8F8FFFFF8F87F7FF828F8FFFFFFF87F7FF853F8FFFFFFF87F7FF828F8
+%FFFFFFF87F7FF8F8FD04FFFD05F8FD27FFF8FD2BFFF8FFFFF8F87F7FF853
+%F8FFFFFFF87F7FF828F8FFFFFFF87F7FF853F8FFFFFFF87F7FF8F8FD04FF
+%FD05F8FD27FFF8FD2BFFF8FFFFF8F87F7FF828F8FFFFFFF87F7FF853F8FF
+%FFFFF87F7FF828F8FFFFFFF87F7FF8F8FD04FFF87F7FF8F8FD27FFF8FD2B
+%FFF8FFFFF8F87F7FF853FD05F87F7FF828FD05F87F7FF853FD05F87F7FFD
+%07F87F7FFD2AF8FD2BFFF8FFF8F8F87F7FF828F8FFFFFFF87F7FF853F8FF
+%FFFFF87F7FF828F8FFFFFFF87F7FF8F8FD04FFF87F7FF8F8FD04FFFD05F8
+%FD1EFFF8FD2AFFA8F8F8FFF8F87F7FF853F8FFFFFFF87F7FF828F8FFFFFF
+%F87F7FF853F8FFFFFFF87F7FF8F8FD04FFF87F7FF8F8FD04FFFD05F8FD04
+%FFFD05F8FD04FFFD05F8FD0CFFF8FD29FF7DF8F8FFFFF8F87F7FF828F8FF
+%FFFFF87F7FF853F8FFFFFFF87F7FF828F8FFFFFFF87F7FF8F8FD04FFF87F
+%7FF8F8FD04FFF87F7FF8F8FD04FFFD05F8FD04FFFD05F8FD0CFFF8FD2BFF
+%F8FFFFF8F87F7FF853F8FFFFFFF87F7FF828F8FFFFFFF87F7FF853F8FFFF
+%FFF87F7FF8F8FD04FFF87F7FF8F8FD04FFF87F7FF8F8FD04FFF87F7FF8F8
+%FD04FFF87F7FF8F8FD04FFFD05F8FFFFFFF8FD2BFFF8FFFFF8F87F7FF828
+%F8FFFFFFF87F7FF853F8FFFFFFF87F7FF828F8FFFFFFF87F7FF8F8FD04FF
+%F87F7FF8F8FD04FFF87F7FF8F8FD04FFF87F7FF8F8FD04FFF87F7FF8F8FF
+%FFFFFD06F8FFFFFFF8FD2BFFF8FFFFF8F87F7FF853FD05F87F7FF828FD05
+%F87F7FF853FD05F87F7FFD07F87F7FFD07F87F7FFD07F87F7FFD07F87F7F
+%FD06F87F7F7FFD06F8FD2BFFF8FFF8F8F87F7FF8F8F8E7E7E3F87F7FF8F8
+%F8E7E3E7F87F7FF8F8F8E3E7E7F87F7FF8F8E3E7E7E7F87F7FF8F8E7E7E7
+%E3F87F7FF8F8E7E7E3E7F87F7FF8F8E7E3E7E7F87F7FF8F8E3E7E7F87F7F
+%7FF8F8E7E7F8F8FD2AFFA8F8F8F8E3FD05F8E3E7E3E7FD05F8E7E3E7E3FD
+%05F8E3E7E3E7FD05F8E7E3E7E3FD05F8E3E7E3E7FD05F8E7E3E7E3FD05F8
+%E3E7E3E7FD05F8E7E3E7FD06F8E3F8FD2CFFFD53F8FD2EFFF8FD08FFF8FD
+%08FFF8FD08FFF8FD08FFF8FD08FFF8FD08FFF8FD08FFF8FD08FFF8FD08FF
+%F8FD31FFA8FD11FFA8FD08FFA8FD11FFA8FD11FFA8FD08FFA8FD36FFA87D
+%A8FD06FF7D7DFD08FF52FD07FFA87DFD06FFA8A852FD07FFA87DA8FD06FF
+%A852FD07FFA87DFD08FF7DFD36FF7D7DFD06FFA87DA8FD07FF7DA8FD06FF
+%A8A87DFD06FF7DA87DFD06FFA87DA8FD05FFA8FF7DA8FD06FFA87D7DFD06
+%FFA87DFD36FF52A8FD06FFA8A8A8FD06FF7D52FD07FFA8A852FD07FF7DFD
+%07FFA8A852FD06FFA852FD07FFA8A8A8FD07FF7DA8FD35FF52A8A8FD05FF
+%A87D7DFD06FFA8A8A8FD08FF7DFD07FF52A8FD06FFA87DFD07FFA8A8A8FD
+%06FFA87DA8FD07FF7DFD36FF52FD08FF7DA8FD07FF7DA8FD05FF7DA87D52
+%FD07FF52A8FD07FF7DA8FD06FFA852FD08FF7D7DFD06FFA87DA87DFD35FF
+%A8FD06FF7DFF7DFD06FFA8A87DFD06FFA8FD09FF7DFD11FF7DA8FD07FFA8
+%FD08FF7DA8FD34FFA87D7DA8FD05FFA8A87DFD07FFA87DFD06FFA87DFD07
+%FFA852A8FD06FFA87D7DFD07FFA8FFA8FD05FFA87D7DA8FD05FF7D7DFD36
+%FF7DFD06FFA8A87D52FD0FFFA8A8FD08FF7DA8FD07FFA87DFD07FF52A8A8
+%FD05FFA87DFD08FF7DA8FD36FF7DFD06FFA8A8FD10FFA87DA8FD06FFA852
+%FD07FF7D7DA8FD07FF52A8FD06FFA87DFD08FF7DFD35FFA87DFD07FFA8FD
+%11FF7DA87DFD07FF7D7DFD08FFA8FD07FF7DFD07FFA8A8A8FD06FFA87DFD
+%34FFA8FF7DA8A8FD05FFA87D52FD10FFA87DFD07FF52A8FD10FF52A8FD06
+%FFA87DA8FD06FFA87D7DFD34FFA852FD07FFA8A8FD1AFFA8A8A8FD0EFF7D
+%A87DA8FD06FFA8A8FD06FFA87DA8FD35FFA87DFD06FF7D7DFD19FFA8A87D
+%FD10FFA87DFD06FFA87DA8FD07FF7DA8FD35FF7DFD08FFA8A8FD19FFA8A8
+%FD18FFA87DFD08FF7DA8A8FD33FF7DA8A8A8FD05FF7D7DA8FD19FF7D7DA8
+%FD17FFA87D7DFD06FFA852FD36FF7DA8FD07FFA87DFD19FF7DA8A8FD17FF
+%7DA8A8FD07FF7DA8FD34FFA852FD23FF52FD1AFF7DA8FD06FF7D52FD36FF
+%7DA8FD22FFA8A8FD22FFA8FD36FF52FD22FFA8A87DA8FD57FF7DA87DFD22
+%FFA8A8FD59FFA8A8FDFCFFFDFCFFFD75FFFF
+userdict /Adobe_level2_AI5 25 dict dup begin
+	put
+	/packedarray where not
+	{
+		userdict begin
+		/packedarray
+		{
+			array astore readonly
+		} bind def
+		/setpacking /pop load def
+		/currentpacking false def
+	 end
+		0
+	} if
+	pop
+	userdict /defaultpacking currentpacking put true setpacking
+	/initialize
+	{
+		Adobe_level2_AI5 begin
+	} bind def
+	/terminate
+	{
+		currentdict Adobe_level2_AI5 eq
+		{
+		 end
+		} if
+	} bind def
+	mark
+	/setcustomcolor where not
+	{
+		/findcmykcustomcolor
+		{
+			0
+			6 packedarray
+		} bind def
+		/findrgbcustomcolor
+		{
+			1
+			5 packedarray
+		} bind def
+		/setcustomcolor
+		{
+			exch 
+			aload pop 
+			0 eq
+			{
+				pop
+				4
+				{
+					4 index mul
+					4 1 roll
+				} repeat
+				5 -1 roll pop
+				setcmykcolor
+			}
+			{
+				pop
+				3
+				{
+					1 exch sub
+					3 index mul 
+					1 exch sub
+					3 1 roll
+				} repeat
+				4 -1 roll pop
+				setrgbcolor
+			} ifelse
+		}
+		def
+	} if
+	
+	/gt38? mark {version cvr cvx exec} stopped {cleartomark true} {38 gt exch pop} ifelse def
+	userdict /deviceDPI 72 0 matrix defaultmatrix dtransform dup mul exch dup mul add sqrt put
+	userdict /level2?
+	systemdict /languagelevel known dup
+	{
+		pop systemdict /languagelevel get 2 ge
+	} if
+	put
+/level2ScreenFreq
+{
+ begin
+		60
+		HalftoneType 1 eq
+		{
+			pop Frequency
+		} if
+		HalftoneType 2 eq
+		{
+			pop GrayFrequency
+		} if
+		HalftoneType 5 eq
+		{
+			pop Default level2ScreenFreq
+		} if
+ end
+} bind def
+userdict /currentScreenFreq  
+	level2? {currenthalftone level2ScreenFreq} {currentscreen pop pop} ifelse put
+level2? not
+	{
+		/setcmykcolor where not
+		{
+			/setcmykcolor
+			{
+				exch .11 mul add exch .59 mul add exch .3 mul add
+				1 exch sub setgray
+			} def
+		} if
+		/currentcmykcolor where not
+		{
+			/currentcmykcolor
+			{
+				0 0 0 1 currentgray sub
+			} def
+		} if
+		/setoverprint where not
+		{
+			/setoverprint /pop load def
+		} if
+		/selectfont where not
+		{
+			/selectfont
+			{
+				exch findfont exch
+				dup type /arraytype eq
+				{
+					makefont
+				}
+				{
+					scalefont
+				} ifelse
+				setfont
+			} bind def
+		} if
+		/cshow where not
+		{
+			/cshow
+			{
+				[
+				0 0 5 -1 roll aload pop
+				] cvx bind forall
+			} bind def
+		} if
+	} if
+	cleartomark
+	/anyColor?
+	{
+		add add add 0 ne
+	} bind def
+	/testColor
+	{
+		gsave
+		setcmykcolor currentcmykcolor
+		grestore
+	} bind def
+	/testCMYKColorThrough
+	{
+		testColor anyColor?
+	} bind def
+	userdict /composite?
+	level2?
+	{
+		gsave 1 1 1 1 setcmykcolor currentcmykcolor grestore
+		add add add 4 eq
+	}
+	{
+		1 0 0 0 testCMYKColorThrough
+		0 1 0 0 testCMYKColorThrough
+		0 0 1 0 testCMYKColorThrough
+		0 0 0 1 testCMYKColorThrough
+		and and and
+	} ifelse
+	put
+	composite? not
+	{
+		userdict begin
+		gsave
+		/cyan? 1 0 0 0 testCMYKColorThrough def
+		/magenta? 0 1 0 0 testCMYKColorThrough def
+		/yellow? 0 0 1 0 testCMYKColorThrough def
+		/black? 0 0 0 1 testCMYKColorThrough def
+		grestore
+		/isCMYKSep? cyan? magenta? yellow? black? or or or def
+		/customColor? isCMYKSep? not def
+	 end
+	} if
+ end defaultpacking setpacking
+currentpacking true setpacking
+userdict /Adobe_typography_AI5 68 dict dup begin
+put
+/initialize
+{
+ begin
+ begin
+	Adobe_typography_AI5 begin
+	Adobe_typography_AI5
+	{
+		dup xcheck
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+ end
+ end
+	Adobe_typography_AI5 begin
+} def
+/terminate
+{
+	currentdict Adobe_typography_AI5 eq
+	{
+	 end
+	} if
+} def
+/modifyEncoding
+{
+	/_tempEncode exch ddef
+	/_pntr 0 ddef
+	{
+		counttomark -1 roll
+		dup type dup /marktype eq
+		{
+			pop pop exit
+		}
+		{
+			/nametype eq
+			{
+				_tempEncode /_pntr dup load dup 3 1 roll 1 add ddef 3 -1 roll
+				put
+			}
+			{
+				/_pntr exch ddef
+			} ifelse
+		} ifelse
+	} loop
+	_tempEncode
+} def
+/havefont
+{
+	systemdict /languagelevel known
+		{
+		/Font resourcestatus dup
+			{ exch pop exch pop }
+		if
+		}
+		{
+		systemdict /FontDirectory get 1 index known
+			{ pop true }
+			{
+			systemdict /fileposition known
+				{
+				dup length 6 add exch
+				Ss 6 250 getinterval
+				cvs pop
+				Ss exch 0 exch getinterval
+				status
+					{ pop pop pop pop true }
+					{ false }
+				ifelse
+				}
+				{
+				pop false
+				}
+			ifelse
+			}
+		ifelse
+		}
+	ifelse
+} def
+/TE
+{
+	StandardEncoding 256 array copy modifyEncoding
+	/_nativeEncoding exch def
+} def
+/subststring {
+	exch 2 index exch search
+	{
+		exch pop
+		exch dup () eq
+		{
+			pop exch concatstring
+		}
+		{
+			3 -1 roll
+			exch concatstring
+			concatstring
+		} ifelse
+		exch pop true
+	}
+	{
+		pop pop false
+	} ifelse
+} def
+/concatstring {
+	1 index length 1 index length
+	1 index add
+	string
+	dup 0 5 index putinterval
+	dup 2 index 4 index putinterval
+	4 1 roll pop pop pop
+} def
+%
+/TZ
+{
+	dup type /arraytype eq
+	{
+		/_wv exch def
+	}
+	{
+		/_wv 0 def
+	} ifelse
+	/_useNativeEncoding exch def
+	2 index havefont
+	{
+		3 index
+		255 string
+		cvs
+		
+		dup
+		(_Symbol_)
+		eq
+		{
+			pop
+			2 index
+			findfont
+			
+		}
+		{
+			dup length 1 sub
+			1 exch
+			getinterval
+			
+			cvn
+			findfont
+		} ifelse
+	}
+	{
+		dup 1 eq
+		{
+			2 index 64 string cvs
+			dup (-90pv-RKSJ-) (-83pv-RKSJ-) subststring
+			{
+				exch pop dup havefont
+				{
+					findfont false
+				}
+				{
+					pop true
+				} ifelse
+			}
+			{
+				pop	dup
+				(-90ms-RKSJ-) (-Ext-RKSJ-) subststring
+				{
+					exch pop dup havefont
+					{
+						findfont false
+					}
+					{
+						pop true
+					} ifelse
+				}
+				{
+					pop pop true
+				} ifelse
+			} ifelse
+			{
+				/Ryumin-Light-83pv-RKSJ-H havefont
+					{/Ryumin-Light-83pv-RKSJ-H}
+					{/Courier}
+					ifelse
+					findfont
+					[1 0 0.5 1 0 0] makefont
+			} if
+		}
+		{
+			/Courier findfont
+		} ifelse
+	} ifelse
+	_wv type /arraytype eq
+	{
+		_wv makeblendedfont
+	} if
+	dup length 10 add dict
+ begin
+	mark exch
+	{
+		1 index /FID ne
+		{
+			def
+		} if
+		cleartomark mark
+	} forall
+	pop
+	/FontScript exch def
+	/FontDirection exch def
+	/FontRequest exch def
+	/FontName exch def
+	counttomark 0 eq
+	{
+		1 _useNativeEncoding eq
+		{
+			/Encoding _nativeEncoding def
+		} if
+		cleartomark
+	}
+	{
+		/Encoding load 256 array copy
+		modifyEncoding /Encoding exch def
+	} ifelse
+	FontName currentdict
+ end
+	definefont pop
+} def
+/tr
+{
+	_ax _ay 3 2 roll
+} def
+/trj
+{
+	_cx _cy _sp _ax _ay 6 5 roll
+} def
+/a0
+{
+	/Tx
+	{
+		dup
+		currentpoint 3 2 roll
+		tr _psf
+		newpath moveto
+		tr _ctm _pss
+	} ddef
+	/Tj
+	{
+		dup
+		currentpoint 3 2 roll
+		trj _pjsf
+		newpath moveto
+		trj _ctm _pjss
+	} ddef
+} def
+/a1
+{
+W B
+} def
+/e0
+{
+	/Tx
+	{
+		tr _psf
+	} ddef
+	/Tj
+	{
+		trj _pjsf
+	} ddef
+} def
+/e1
+{
+W F 
+} def
+/i0
+{
+	/Tx
+	{
+		tr sp
+	} ddef
+	/Tj
+	{
+		trj jsp
+	} ddef
+} def
+/i1
+{
+	W N
+} def
+/o0
+{
+	/Tx
+	{
+		tr sw rmoveto
+	} ddef
+	/Tj
+	{
+		trj swj rmoveto
+	} ddef
+} def
+/r0
+{
+	/Tx
+	{
+		tr _ctm _pss
+	} ddef
+	/Tj
+	{
+		trj _ctm _pjss
+	} ddef
+} def
+/r1
+{
+W S
+} def
+/To
+{
+	pop _ctm currentmatrix pop
+} def
+/TO
+{
+	iTe _ctm setmatrix newpath
+} def
+/Tp
+{
+	pop _tm astore pop _ctm setmatrix
+	_tDict begin
+	/W
+	{
+	} def
+	/h
+	{
+	} def
+} def
+/TP
+{
+ end
+	iTm 0 0 moveto
+} def
+/Tr
+{
+	_render 3 le
+	{
+		currentpoint newpath moveto
+	} if
+	dup 8 eq
+	{
+		pop 0
+	}
+	{
+		dup 9 eq
+		{
+			pop 1
+		} if
+	} ifelse
+	dup /_render exch ddef
+	_renderStart exch get load exec
+} def
+/iTm
+{
+	_ctm setmatrix _tm concat
+	_shift aload pop _lineorientation 1 eq { exch } if translate
+	_scale aload pop _lineorientation 1 eq _yokoorientation 1 eq or { exch } if scale
+} def
+/Tm
+{
+	_tm astore pop iTm 0 0 moveto
+} def
+/Td
+{
+	_mtx translate _tm _tm concatmatrix pop iTm 0 0 moveto
+} def
+/iTe
+{
+	_render -1 eq
+	{
+	}
+	{
+		_renderEnd _render get dup null ne
+		{
+			load exec
+		}
+		{
+			pop
+		} ifelse
+	} ifelse
+	/_render -1 ddef
+} def
+/Ta
+{
+	pop
+} def
+/Tf
+{
+	1 index type /nametype eq
+	{
+		dup 0.75 mul 1 index 0.25 mul neg
+	} if
+	/_fontDescent exch ddef
+	/_fontAscent exch ddef
+	/_fontSize exch ddef
+	/_fontRotateAdjust _fontAscent _fontDescent add 2 div neg ddef
+	/_fontHeight _fontSize ddef
+	findfont _fontSize scalefont setfont
+} def
+/Tl
+{
+	pop neg 0 exch
+	_leading astore pop
+} def
+/Tt
+{
+	pop
+} def
+/TW
+{
+	3 npop
+} def
+/Tw
+{
+	/_cx exch ddef
+} def
+/TC
+{
+	3 npop
+} def
+/Tc
+{
+	/_ax exch ddef
+} def
+/Ts
+{
+	0 exch
+	_shift astore pop
+	currentpoint
+	iTm
+	moveto
+} def
+/Ti
+{
+	3 npop
+} def
+/Tz
+{
+	count 1 eq { 100 } if
+	100 div exch 100 div exch
+	_scale astore pop
+	iTm
+} def
+/TA
+{
+	pop
+} def
+/Tq
+{
+	pop
+} def
+/Tg
+{
+	pop
+} def
+/TG
+{
+	pop
+} def
+/Tv
+{
+	/_lineorientation exch ddef
+} def
+/TV
+{
+	/_charorientation exch ddef
+} def
+/Ty
+{
+	dup /_yokoorientation exch ddef 1 sub neg Tv
+} def
+/TY
+{
+	pop
+} def
+/T~
+{
+	Tx
+} def
+/Th
+{
+	pop pop pop pop pop
+} def
+/TX
+{
+	pop
+} def
+/Tk
+{
+	_fontSize mul 1000 div
+	_lineorientation 0 eq { neg 0 } { 0 exch } ifelse
+	rmoveto
+	pop
+} def
+/TK
+{
+	2 npop
+} def
+/T*
+{
+	_leading aload pop
+	_lineorientation 0 ne { exch } if
+	Td
+} def
+/T*-
+{
+	_leading aload pop
+	_lineorientation 0 ne { exch } if
+	exch neg exch neg
+	Td
+} def
+/T-
+{
+	_ax neg 0 rmoveto
+	_lineorientation 1 eq _charorientation 0 eq and { 1 TV _hyphen Tx 0 TV } { _hyphen Tx } ifelse
+} def
+/T+
+{
+} def
+/TR
+{
+	_ctm currentmatrix pop
+	_tm astore pop
+	iTm 0 0 moveto
+} def
+/TS
+{
+	currentfont 3 1 roll
+	/_Symbol_ findfont _fontSize scalefont setfont
+	
+	0 eq
+	{
+		Tx
+	}
+	{
+		Tj
+	} ifelse
+	setfont
+} def
+/Xb
+{
+	pop pop
+} def
+/Tb /Xb load def
+/Xe
+{
+	pop pop pop pop
+} def
+/Te /Xe load def
+/XB
+{
+} def
+/TB /XB load def
+currentdict readonly pop
+end
+setpacking
+%
+/X^
+{
+	currentfont 5 1 roll
+	dup havefont
+		{
+		findfont _fontSize scalefont setfont
+		}
+		{
+		pop
+		exch
+		} ifelse
+	2 index 0 eq
+	{
+		Tx
+	}
+	{
+		Tj
+	} ifelse
+	pop	pop
+	setfont
+} def
+/T^	/X^	load def
+userdict /Adobe_ColorImage_AI6 known not
+{
+	userdict /Adobe_ColorImage_AI6 24 dict put 
+} if
+userdict /Adobe_ColorImage_AI6 get begin
+/initialize
+{ 
+	Adobe_ColorImage_AI6 begin
+	Adobe_ColorImage_AI6
+	{
+		dup type /arraytype eq
+		{
+			dup xcheck
+			{
+				bind
+			} if
+		} if
+		pop pop
+	} forall
+} def
+/terminate { end } def
+currentdict /Adobe_ColorImage_AI6_Vars known not
+{
+	/Adobe_ColorImage_AI6_Vars 15 dict def
+} if
+Adobe_ColorImage_AI6_Vars begin
+	/channelcount 0 def
+	/sourcecount 0 def
+	/sourcearray 4 array def
+	/plateindex -1 def
+	/XIMask 0 def
+	/XIBinary 0 def
+	/XIChannelCount 0 def
+	/XIBitsPerPixel 0 def
+	/XIImageHeight 0 def
+	/XIImageWidth 0 def
+	/XIImageMatrix null def
+	/XIBuffer null def
+	/XIDataProc null def
+	/XIVersion 6 def
+end
+/WalkRGBString null def
+/WalkCMYKString null def
+/StuffRGBIntoGrayString null def
+/RGBToGrayImageProc null def
+/StuffCMYKIntoGrayString null def
+/CMYKToGrayImageProc null def
+/ColorImageCompositeEmulator null def
+/SeparateCMYKImageProc null def
+/FourEqual null def
+/TestPlateIndex null def
+currentdict /_colorimage known not
+{
+	/colorimage where
+	{
+		/colorimage get /_colorimage exch def
+	}
+	{
+		/_colorimage null def
+	} ifelse
+} if
+/_currenttransfer systemdict /currenttransfer get def
+/colorimage null def
+/XI null def
+/WalkRGBString
+{
+	0 3 index
+	dup length 1 sub 0 3 3 -1 roll
+	{
+		3 getinterval { } forall
+		5 index exec
+		3 index
+	} for
+	
+	 5 { pop } repeat
+} def
+/WalkCMYKString
+{
+	0 3 index
+	dup length 1 sub 0 4 3 -1 roll
+	{
+		4 getinterval { } forall
+		
+		6 index exec
+		
+		3 index
+		
+	} for
+	
+	5 { pop } repeat
+	
+} def
+/StuffRGBIntoGrayString
+{
+	.11 mul exch
+	
+	.59 mul add exch
+	
+	.3 mul add
+	
+	cvi 3 copy put
+	
+	pop 1 add
+} def
+/RGBToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin 
+		sourcearray 0 get exec
+		dup length 3 idiv string
+		dup 3 1 roll 
+		
+		/StuffRGBIntoGrayString load exch
+		WalkRGBString
+ end
+} def
+/StuffCMYKIntoGrayString
+{
+	exch .11 mul add
+	
+	exch .59 mul add
+	
+	exch .3 mul add
+	
+	dup 255 gt { pop 255 } if
+	
+	255 exch sub cvi 3 copy put
+	
+	pop 1 add
+} def
+/CMYKToGrayImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcearray 0 get exec
+		dup length 4 idiv string
+		dup 3 1 roll 
+		
+		/StuffCMYKIntoGrayString load exch
+		WalkCMYKString
+ end
+} def
+/ColorImageCompositeEmulator
+{
+	pop true eq
+	{
+		Adobe_ColorImage_AI6_Vars /sourcecount get 5 add { pop } repeat
+	}
+	{
+		Adobe_ColorImage_AI6_Vars /channelcount get 1 ne
+		{
+			Adobe_ColorImage_AI6_Vars begin
+				sourcearray 0 3 -1 roll put
+			
+				channelcount 3 eq 
+				{ 
+					/RGBToGrayImageProc 
+				}
+				{ 
+					/CMYKToGrayImageProc
+				} ifelse
+				load
+		 end
+		} if
+		image
+	} ifelse
+} def
+/SeparateCMYKImageProc
+{	
+	Adobe_ColorImage_AI6_Vars begin
+		sourcecount 0 ne
+		{
+			sourcearray plateindex get exec
+		}
+		{			
+			sourcearray 0 get exec
+			
+			dup length 4 idiv string
+			
+			0 2 index
+			
+			plateindex 4 2 index length 1 sub
+			{
+				get 255 exch sub
+				
+				3 copy put pop 1 add
+				
+				2 index
+			} for
+			pop pop exch pop
+		} ifelse
+ end
+} def
+	
+/FourEqual
+{
+	4 index ne
+	{
+		pop pop pop false
+	}
+	{
+		4 index ne
+		{
+			pop pop false
+		}
+		{
+			4 index ne
+			{
+				pop false
+			}
+			{
+				4 index eq
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/TestPlateIndex
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/plateindex -1 def
+		/setcmykcolor where
+		{
+			pop
+			gsave
+			1 0 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 1 0 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 1 0 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			0 0 0 1 setcmykcolor systemdict /currentgray get exec 1 exch sub
+			grestore
+			1 0 0 0 FourEqual 
+			{ 
+				/plateindex 0 def
+			}
+			{
+				0 1 0 0 FourEqual
+				{ 
+					/plateindex 1 def
+				}
+				{
+					0 0 1 0 FourEqual
+					{
+						/plateindex 2 def
+					}
+					{
+						0 0 0 1 FourEqual
+						{ 
+							/plateindex 3 def
+						}
+						{
+							0 0 0 0 FourEqual
+							{
+								/plateindex 5 def
+							} if
+						} ifelse
+					} ifelse
+				} ifelse
+			} ifelse
+			pop pop pop pop
+		} if
+		plateindex
+ end
+} def
+/colorimage
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/channelcount 1 index def
+		/sourcecount 2 index 1 eq { channelcount 1 sub } { 0 } ifelse def
+		4 sourcecount add index dup 
+		8 eq exch 1 eq or not
+ end
+	
+	{
+		/_colorimage load null ne
+		{
+			_colorimage
+		}
+		{
+			Adobe_ColorImage_AI6_Vars /sourcecount get
+			7 add { pop } repeat
+		} ifelse
+	}
+	{
+		dup 3 eq
+		TestPlateIndex
+		dup -1 eq exch 5 eq or or
+		{
+			/_colorimage load null eq
+			{
+				ColorImageCompositeEmulator
+			}
+			{
+				dup 1 eq
+				{
+					pop pop image
+				}
+				{
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						gsave
+						
+						0 _currenttransfer exec
+						1 _currenttransfer exec
+						eq
+						{ 0 _currenttransfer exec 0.5 lt }
+						{ 0 _currenttransfer exec 1 _currenttransfer exec gt } ifelse
+						
+						{ { pop 0 } } { { pop 1 } } ifelse
+						systemdict /settransfer get exec
+					} if
+					
+					_colorimage
+					
+					Adobe_ColorImage_AI6_Vars /plateindex get 5 eq
+					{
+						grestore
+					} if
+				} ifelse
+			} ifelse
+		}
+		{
+			dup 1 eq
+			{
+				pop pop
+				image
+			}
+			{
+				pop pop
+				Adobe_ColorImage_AI6_Vars begin
+					sourcecount -1 0
+					{			
+						exch sourcearray 3 1 roll put
+					} for
+					/SeparateCMYKImageProc load
+			 end
+				systemdict /image get exec
+			} ifelse
+		} ifelse
+	} ifelse
+} def
+/XG
+{
+	pop pop
+} def
+/XF
+{
+	13 {pop} repeat
+} def
+/Xh
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		/XIImageMatrix exch def
+		0 0 moveto
+		XIImageMatrix concat
+		XIImageWidth XIImageHeight scale
+		
+		XIMask
+		{
+			/_lp /null ddef
+			_fc
+			/_lp /imagemask ddef
+		}
+		if
+		/XIVersion 7 def
+ end
+} def
+/XH
+{
+	Adobe_ColorImage_AI6_Vars begin
+		/XIVersion 6 def
+		grestore
+ end
+} def
+/XI
+{
+	Adobe_ColorImage_AI6_Vars begin
+		gsave
+		/XIMask exch 0 ne def
+		/XIBinary exch 0 ne def
+		pop
+		pop
+		/XIChannelCount exch def
+		/XIBitsPerPixel exch def
+		/XIImageHeight exch def
+		/XIImageWidth exch def
+		pop pop pop pop
+		/XIImageMatrix exch def
+		XIBitsPerPixel 1 eq
+		{
+			XIImageWidth 8 div ceiling cvi
+		}
+		{
+			XIImageWidth XIChannelCount mul
+		} ifelse
+		/XIBuffer exch string def
+		XIBinary
+		{
+			/XIDataProc { currentfile XIBuffer readstring pop } def
+			XIVersion 6 le
+			{
+				currentfile 128 string readline pop pop
+			}
+			if
+		}
+		{
+			/XIDataProc { currentfile XIBuffer readhexstring pop } def
+		} ifelse
+		
+		XIVersion 6 le
+		{
+			0 0 moveto
+			XIImageMatrix concat
+			XIImageWidth XIImageHeight scale
+			XIMask
+			{
+				/_lp /null ddef
+				_fc
+				/_lp /imagemask ddef
+			} if
+		} if
+		
+		XIMask
+		{
+			XIImageWidth XIImageHeight
+			false
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			imagemask
+		}
+		{
+			XIImageWidth XIImageHeight
+			XIBitsPerPixel
+			[ XIImageWidth 0 0 XIImageHeight neg 0 0 ]
+			/XIDataProc load
+			
+			XIChannelCount 1 eq
+			{
+				gsave
+				0 setgray
+				image
+				grestore
+			}
+			{
+				false
+				XIChannelCount
+				colorimage
+			} ifelse
+		} ifelse
+		grestore
+ end
+} def
+end
+currentpacking true setpacking
+userdict /Adobe_Illustrator_AI5_vars 107 dict dup begin
+put
+/_eo false def
+/_lp /none def
+/_pf
+{
+} def
+/_ps
+{
+} def
+/_psf
+{
+} def
+/_pss
+{
+} def
+/_pjsf
+{
+} def
+/_pjss
+{
+} def
+/_pola 0 def
+/_doClip 0 def
+/cf currentflat def
+/_lineorientation 0 def
+/_charorientation 0 def
+/_yokoorientation 0 def
+/_tm matrix def
+/_renderStart
+[
+/e0 /r0 /a0 /o0 /e1 /r1 /a1 /i0
+] def
+/_renderEnd
+[
+null null null null /i1 /i1 /i1 /i1
+] def
+/_render -1 def
+/_shift [0 0] def
+/_ax 0 def
+/_ay 0 def
+/_cx 0 def
+/_cy 0 def
+/_leading
+[
+0 0
+] def
+/_ctm matrix def
+/_mtx matrix def
+/_sp 16#020 def
+/_hyphen (-) def
+/_fontSize 0 def
+/_fontAscent 0 def
+/_fontDescent 0 def
+/_fontHeight 0 def
+/_fontRotateAdjust 0 def
+/Ss 256 string def
+Ss 0 (fonts/) putinterval
+/_cnt 0 def
+/_scale [1 1] def
+/_nativeEncoding 0 def
+/_useNativeEncoding 0 def
+/_tempEncode 0 def
+/_pntr 0 def
+/_tDict 2 dict def
+/_hfname 100 string def
+/_hffound false def
+/Tx
+{
+} def
+/Tj
+{
+} def
+/CRender
+{
+} def
+/_AI3_savepage
+{
+} def
+/_gf null def
+/_cf 4 array def
+/_rgbf 3 array def
+/_if null def
+/_of false def
+/_fc
+{
+} def
+/_gs null def
+/_cs 4 array def
+/_rgbs 3 array def
+/_is null def
+/_os false def
+/_sc
+{
+} def
+/_pd 1 dict def
+/_ed 15 dict def
+/_pm matrix def
+/_fm null def
+/_fd null def
+/_fdd null def
+/_sm null def
+/_sd null def
+/_sdd null def
+/_i null def
+/_lobyte 0 def
+/_hibyte 0 def
+/_cproc null def
+/_cscript 0 def
+/_hvax 0 def
+/_hvay 0 def
+/_hvwb 0 def
+/_hvcx 0 def
+/_hvcy 0 def
+/_bitfont null def
+/_bitlobyte 0 def
+/_bithibyte 0 def
+/_bitkey null def
+/_bitdata null def
+/_bitindex 0 def
+/discardSave null def
+/buffer 256 string def
+/beginString null def
+/endString null def
+/endStringLength null def
+/layerCnt 1 def
+/layerCount 1 def
+/perCent (%) 0 get def
+/perCentSeen? false def
+/newBuff null def
+/newBuffButFirst null def
+/newBuffLast null def
+/clipForward? false def
+end
+userdict /Adobe_Illustrator_AI5 known not {
+	userdict /Adobe_Illustrator_AI5 95 dict put
+} if
+userdict /Adobe_Illustrator_AI5 get begin
+/initialize
+{
+	Adobe_Illustrator_AI5 dup begin
+	Adobe_Illustrator_AI5_vars begin
+	discardDict
+	{
+		bind pop pop
+	} forall
+	dup /nc get begin
+	{
+		dup xcheck 1 index type /operatortype ne and
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	newpath
+} def
+/terminate
+{
+ end
+ end
+} def
+/_
+null def
+/ddef
+{
+	Adobe_Illustrator_AI5_vars 3 1 roll put
+} def
+/xput
+{
+	dup load dup length exch maxlength eq
+	{
+		dup dup load dup
+		length 2 mul dict copy def
+	} if
+	load begin
+	def
+ end
+} def
+/npop
+{
+	{
+		pop
+	} repeat
+} def
+/hswj
+{
+	dup stringwidth 3 2 roll
+	{
+		_hvwb eq { exch _hvcx add exch _hvcy add } if
+		exch _hvax add exch _hvay add
+	} cforall
+} def
+/vswj
+{
+	0 0 3 -1 roll
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			dup cstring stringwidth 5 2 roll
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			4 -1 roll sub exch
+			3 -1 roll sub exch
+		}
+		{
+			_hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			exch _hvay sub exch _hvax sub
+			_fontHeight sub
+		} ifelse
+	} cforall
+} def
+/swj
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hswj } { vswj } ifelse
+} def
+/sw
+{
+	0 0 0 6 3 roll swj
+} def
+/vjss
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			gsave
+			false charpath currentpoint
+			5 index setmatrix stroke
+			grestore
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			gsave
+			2 index false charpath
+			6 index setmatrix stroke
+			grestore
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjss
+{
+	4 1 roll
+	{
+		dup cstring
+		gsave
+		false charpath currentpoint
+		5 index setmatrix stroke
+		grestore
+		moveto
+		_sp eq
+		{
+			5 index 5 index rmoveto
+		} if
+		2 copy rmoveto
+	} cforall
+	6 npop
+} def
+/jss
+{
+	_lineorientation 0 eq { hjss } { vjss } ifelse
+} def
+/ss
+{
+	0 0 0 7 3 roll jss
+} def
+/vjsp
+{
+	4 1 roll
+	{
+		dup cstring
+		dup length 1 eq
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			currentpoint
+			_fontRotateAdjust add
+			moveto
+			false charpath
+            currentpoint
+			_fontRotateAdjust sub
+			moveto
+			_sp eq
+			{
+				5 index 5 index rmoveto
+			} if
+			2 copy rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			5 index sub
+			3 index _sp eq
+			{
+				9 index sub
+			} if
+	
+			currentpoint
+			exch 4 index stringwidth pop 2 div sub
+			exch _fontAscent sub
+			moveto
+	
+			2 index false charpath
+	
+			moveto pop pop
+		} ifelse
+	} cforall
+	6 npop
+} def
+/hjsp
+{
+    4 1 roll
+    {
+        dup cstring
+        false charpath
+        _sp eq
+        {
+            5 index 5 index rmoveto
+        } if
+        2 copy rmoveto
+    } cforall
+    6 npop
+} def
+/jsp
+{
+	matrix currentmatrix
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/sp
+{
+    matrix currentmatrix
+    0 0 0 7 3 roll
+    _lineorientation 0 eq {hjsp} {vjsp} ifelse
+} def
+/pl
+{
+	transform
+	0.25 sub round 0.25 add exch
+	0.25 sub round 0.25 add exch
+	itransform
+} def
+/setstrokeadjust where
+{
+	pop true setstrokeadjust
+	/c
+	{
+		curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		moveto
+	} def
+}
+{
+	/c
+	{
+		pl curveto
+	} def
+	/C
+	/c load def
+	/v
+	{
+		currentpoint 6 2 roll pl curveto
+	} def
+	/V
+	/v load def
+	/y
+	{
+		pl 2 copy curveto
+	} def
+	/Y
+	/y load def
+	/l
+	{
+		pl lineto
+	} def
+	/L
+	/l load def
+	/m
+	{
+		pl moveto
+	} def
+} ifelse
+/d
+{
+	setdash
+} def
+/cf
+{
+} def
+/i
+{
+	dup 0 eq
+	{
+		pop cf
+	} if
+	setflat
+} def
+/j
+{
+	setlinejoin
+} def
+/J
+{
+	setlinecap
+} def
+/M
+{
+	setmiterlimit
+} def
+/w
+{
+	setlinewidth
+} def
+/XR
+{
+	0 ne
+	/_eo exch ddef
+} def
+/H
+{
+} def
+/h
+{
+	closepath
+} def
+/N
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			_eo {eoclip} {clip} ifelse /_doClip 0 ddef
+		} if
+		newpath
+	}
+	{
+		/CRender
+		{
+			N
+		} ddef
+	} ifelse
+} def
+/n
+{
+	N
+} def
+/F
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _pf grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _fc
+			/_doClip 0 ddef
+		}
+		{
+			_pf
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			F
+		} ddef
+	} ifelse
+} def
+/f
+{
+	closepath
+	F
+} def
+/S
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		{
+			gsave _ps grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			_ps
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			S
+		} ddef
+	} ifelse
+} def
+/s
+{
+	closepath
+	S
+} def
+/B
+{
+	_pola 0 eq
+	{
+		_doClip 1 eq
+		gsave F grestore
+		{
+			gsave S grestore _eo {eoclip} {clip} ifelse newpath /_lp /none ddef _sc
+			/_doClip 0 ddef
+		}
+		{
+			S
+		} ifelse
+	}
+	{
+		/CRender
+		{
+			B
+		} ddef
+	} ifelse
+} def
+/b
+{
+	closepath
+	B
+} def
+/W
+{
+	/_doClip 1 ddef
+} def
+/*
+{
+	count 0 ne
+	{
+		dup type /stringtype eq
+		{
+			pop
+		} if
+	} if
+	newpath
+} def
+/u
+{
+} def
+/U
+{
+} def
+/q
+{
+	_pola 0 eq
+	{
+		gsave
+	} if
+} def
+/Q
+{
+	_pola 0 eq
+	{
+		grestore
+	} if
+} def
+/*u
+{
+	_pola 1 add /_pola exch ddef
+} def
+/*U
+{
+	_pola 1 sub /_pola exch ddef
+	_pola 0 eq
+	{
+		CRender
+	} if
+} def
+/D
+{
+	pop
+} def
+/*w
+{
+} def
+/*W
+{
+} def
+/`
+{
+	/_i save ddef
+	clipForward?
+	{
+		nulldevice
+	} if
+	6 1 roll 4 npop
+	concat pop
+	userdict begin
+	/showpage
+	{
+	} def
+	0 setgray
+	0 setlinecap
+	1 setlinewidth
+	0 setlinejoin
+	10 setmiterlimit
+	[] 0 setdash
+	/setstrokeadjust where {pop false setstrokeadjust} if
+	newpath
+	0 setgray
+	false setoverprint
+} def
+/~
+{
+ end
+	_i restore
+} def
+/O
+{
+	0 ne
+	/_of exch ddef
+	/_lp /none ddef
+} def
+/R
+{
+	0 ne
+	/_os exch ddef
+	/_lp /none ddef
+} def
+/g
+{
+	/_gf exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_gf setgray
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/G
+{
+	/_gs exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_gs setgray
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/k
+{
+	_cf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_cf aload pop setcmykcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/K
+{
+	_cs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_cs aload pop setcmykcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/Xa
+{
+	_rgbf astore pop
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_rgbf aload pop setrgbcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XA
+{
+	_rgbs astore pop
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_rgbs aload pop setrgbcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/_rgbtocmyk
+{
+3
+	{
+	1 exch sub 3 1 roll
+	} repeat
+3 copy 1 4 1 roll
+3
+	{
+	3 index 2 copy gt
+		{
+		exch
+		} if
+	pop 4 1 roll
+	} repeat
+pop pop pop
+4 1 roll
+3
+	{
+	3 index sub
+	3 1 roll
+	} repeat
+4 -1 roll
+} def
+/Xx
+{
+	exch
+	/_gf exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/XX
+{
+	exch
+	/_gs exch ddef
+	0 eq
+	{
+		findcmykcustomcolor
+	}
+	{
+		/findrgbcustomcolor where not {
+			4 1 roll _rgbtocmyk
+			5 -1 roll
+			findcmykcustomcolor
+		}
+		{
+			pop
+			findrgbcustomcolor
+		} ifelse
+	} ifelse
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/x
+{
+	/_gf exch ddef
+	findcmykcustomcolor
+	/_if exch ddef
+	/_fc
+	{
+		_lp /fill ne
+		{
+			_of setoverprint
+			_if _gf 1 exch sub setcustomcolor
+			/_lp /fill ddef
+		} if
+	} ddef
+	/_pf
+	{
+		_fc
+		_eo {eofill} {fill} ifelse
+	} ddef
+	/_psf
+	{
+		_fc
+		hvashow
+	} ddef
+	/_pjsf
+	{
+		_fc
+		hvawidthshow
+	} ddef
+	/_lp /none ddef
+} def
+/X
+{
+	/_gs exch ddef
+	findcmykcustomcolor
+	/_is exch ddef
+	/_sc
+	{
+		_lp /stroke ne
+		{
+			_os setoverprint
+			_is _gs 1 exch sub setcustomcolor
+			/_lp /stroke ddef
+		} if
+	} ddef
+	/_ps
+	{
+		_sc
+		stroke
+	} ddef
+	/_pss
+	{
+		_sc
+		ss
+	} ddef
+	/_pjss
+	{
+		_sc
+		jss
+	} ddef
+	/_lp /none ddef
+} def
+/A
+{
+	pop
+} def
+/annotatepage
+{
+userdict /annotatepage 2 copy known {get exec} {pop pop} ifelse
+} def
+/XT {
+	pop pop
+} def
+/discard
+{
+	save /discardSave exch store
+	discardDict begin
+	/endString exch store
+	gt38?
+	{
+		2 add
+	} if
+	load
+	stopped
+	pop
+ end
+	discardSave restore
+} bind def
+userdict /discardDict 7 dict dup begin
+put
+/pre38Initialize
+{
+	/endStringLength endString length store
+	/newBuff buffer 0 endStringLength getinterval store
+	/newBuffButFirst newBuff 1 endStringLength 1 sub getinterval store
+	/newBuffLast newBuff endStringLength 1 sub 1 getinterval store
+} def
+/shiftBuffer
+{
+	newBuff 0 newBuffButFirst putinterval
+	newBuffLast 0
+	currentfile read not
+	{
+	stop
+	} if
+	put
+} def
+0
+{
+	pre38Initialize
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff endString eq
+			{
+				cleartomark stop
+			} if
+			shiftBuffer
+		} loop
+	}
+	{
+	stop
+	} ifelse
+} def
+1
+{
+	pre38Initialize
+	/beginString exch store
+	mark
+	currentfile newBuff readstring exch pop
+	{
+		{
+			newBuff beginString eq
+			{
+				/layerCount dup load 1 add store
+			}
+			{
+				newBuff endString eq
+				{
+					/layerCount dup load 1 sub store
+					layerCount 0 eq
+					{
+						cleartomark stop
+					} if
+				} if
+			} ifelse
+			shiftBuffer
+		} loop
+	} if
+} def
+2
+{
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		endString eq
+		{
+			cleartomark stop
+		} if
+	} loop
+} def
+3
+{
+	/beginString exch store
+	/layerCnt 1 store
+	mark
+	{
+		currentfile buffer readline not
+		{
+		stop
+		} if
+		dup beginString eq
+		{
+			pop /layerCnt dup load 1 add store
+		}
+		{
+			endString eq
+			{
+				layerCnt 1 eq
+				{
+					cleartomark stop
+				}
+				{
+					/layerCnt dup load 1 sub store
+				} ifelse
+			} if
+		} ifelse
+	} loop
+} def
+end
+userdict /clipRenderOff 15 dict dup begin
+put
+{
+	/n /N /s /S /f /F /b /B
+}
+{
+	{
+		_doClip 1 eq
+		{
+			/_doClip 0 ddef _eo {eoclip} {clip} ifelse
+		} if
+		newpath
+	} def
+} forall
+/Tr /pop load def
+/Bb {} def
+/BB /pop load def
+/Bg {12 npop} def
+/Bm {6 npop} def
+/Bc /Bm load def
+/Bh {4 npop} def
+end
+/Lb
+{
+	4 npop
+	6 1 roll
+	pop
+	4 1 roll
+	pop pop pop
+	0 eq
+	{
+		0 eq
+		{
+			(%AI5_BeginLayer) 1 (%AI5_EndLayer--) discard
+		}
+		{
+			
+			/clipForward? true def
+			
+			/Tx /pop load def
+			/Tj /pop load def
+			
+			currentdict end clipRenderOff begin begin
+		} ifelse
+	}
+	{
+		0 eq
+		{
+			save /discardSave exch store
+		} if
+	} ifelse
+} bind def
+/LB
+{
+	discardSave dup null ne
+	{
+		restore
+	}
+	{
+		pop
+		clipForward?
+		{
+			currentdict
+		 end
+		 end
+		 begin
+					
+			/clipForward? false ddef
+		} if
+	} ifelse
+} bind def
+/Pb
+{
+	pop pop
+	0 (%AI5_EndPalette) discard
+} bind def
+/Np
+{
+	0 (%AI5_End_NonPrinting--) discard
+} bind def
+/Ln /pop load def
+/Ap
+/pop load def
+/Ar
+{
+	72 exch div
+	0 dtransform dup mul exch dup mul add sqrt
+	dup 1 lt
+	{
+		pop 1
+	} if
+	setflat
+} def
+/Mb
+{
+	q
+} def
+/Md
+{
+} def
+/MB
+{
+	Q
+} def
+/nc 4 dict def
+nc begin
+/setgray
+{
+	pop
+} bind def
+/setcmykcolor
+{
+	4 npop
+} bind def
+/setrgbcolor
+{
+	3 npop
+} bind def
+/setcustomcolor
+{
+	2 npop
+} bind def
+currentdict readonly pop
+end
+end
+setpacking
+currentpacking true setpacking
+userdict /Adobe_cshow 14 dict dup begin put
+/initialize
+{
+	Adobe_cshow begin
+	Adobe_cshow
+	{
+		dup xcheck
+		{
+			bind
+		} if
+		pop pop
+	} forall
+ end
+	Adobe_cshow begin
+} def
+/terminate
+{
+currentdict Adobe_cshow eq
+	{
+ end
+	} if
+} def
+/cforall
+{
+	/_lobyte 0 ddef
+	/_hibyte 0 ddef
+	/_cproc exch ddef
+	/_cscript currentfont /FontScript known { currentfont /FontScript get } { -1 } ifelse ddef
+	{
+		/_lobyte exch ddef
+		_hibyte 0 eq
+		_cscript 1 eq
+		_lobyte 129 ge _lobyte 159 le and
+		_lobyte 224 ge _lobyte 252 le and or and
+		_cscript 2 eq
+		_lobyte 161 ge _lobyte 254 le and and
+		_cscript 3 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript 25 eq
+		_lobyte 161 ge _lobyte 254 le and and
+    	_cscript -1 eq
+		or or or or and
+		{
+			/_hibyte _lobyte ddef
+		}
+		{
+			_hibyte 256 mul _lobyte add
+			_cproc
+			/_hibyte 0 ddef
+		} ifelse
+	} forall
+} def
+/cstring
+{
+	dup 256 lt
+	{
+		(s) dup 0 4 3 roll put
+	}
+	{
+		dup 256 idiv exch 256 mod
+		(hl) dup dup 0 6 5 roll put 1 4 3 roll put
+	} ifelse
+} def
+/clength
+{
+	0 exch
+	{ 256 lt { 1 } { 2 } ifelse add } cforall
+} def
+/hawidthshow
+{
+	{
+		dup cstring
+		show
+		_hvax _hvay rmoveto
+		_hvwb eq { _hvcx _hvcy rmoveto } if
+	} cforall
+} def
+/vawidthshow
+{
+	{
+		dup 255 le
+		_charorientation 1 eq
+		and
+		{
+			-90 rotate
+			0 _fontRotateAdjust rmoveto
+			cstring
+			_hvcx _hvcy _hvwb _hvax _hvay 6 -1 roll awidthshow
+			0 _fontRotateAdjust neg rmoveto
+			90 rotate
+		}
+		{
+			currentpoint
+			_fontHeight sub
+			exch _hvay sub exch _hvax sub
+			2 index _hvwb eq { exch _hvcy sub exch _hvcx sub } if
+			3 2 roll
+			cstring
+			dup stringwidth pop 2 div neg _fontAscent neg rmoveto
+			show
+			moveto
+		} ifelse
+	} cforall
+} def
+/hvawidthshow
+{
+	6 1 roll
+	/_hvay exch ddef
+	/_hvax exch ddef
+	/_hvwb exch ddef
+	/_hvcy exch ddef
+	/_hvcx exch ddef
+	_lineorientation 0 eq { hawidthshow } { vawidthshow } ifelse
+} def
+/hvwidthshow
+{
+	0 0 3 -1 roll hvawidthshow
+} def
+/hvashow
+{
+	0 0 0 6 -3 roll hvawidthshow
+} def
+/hvshow
+{
+	0 0 0 0 0 6 -1 roll hvawidthshow
+} def
+currentdict readonly pop end
+setpacking
+Adobe_level2_AI5 /initialize get exec
+Adobe_cshow /initialize get exec
+Adobe_Illustrator_AI5_vars Adobe_Illustrator_AI5 Adobe_typography_AI5 /initialize get exec
+Adobe_ColorImage_AI6 /initialize get exec
+Adobe_Illustrator_AI5 /initialize get exec
+[
+39/quotesingle 96/grave 130/quotesinglbase/florin/quotedblbase/ellipsis
+/dagger/daggerdbl/circumflex/perthousand/Scaron/guilsinglleft/OE 145/quoteleft
+/quoteright/quotedblleft/quotedblright/bullet/endash/emdash/tilde/trademark
+/scaron/guilsinglright/oe/dotlessi 159/Ydieresis 164/currency 166/brokenbar
+168/dieresis/copyright/ordfeminine 172/logicalnot 174/registered/macron/ring
+/plusminus/twosuperior/threesuperior/acute/mu 183/periodcentered/cedilla
+/onesuperior/ordmasculine 188/onequarter/onehalf/threequarters 192/Agrave
+/Aacute/Acircumflex/Atilde/Adieresis/Aring/AE/Ccedilla/Egrave/Eacute
+/Ecircumflex/Edieresis/Igrave/Iacute/Icircumflex/Idieresis/Eth/Ntilde
+/Ograve/Oacute/Ocircumflex/Otilde/Odieresis/multiply/Oslash/Ugrave
+/Uacute/Ucircumflex/Udieresis/Yacute/Thorn/germandbls/agrave/aacute
+/acircumflex/atilde/adieresis/aring/ae/ccedilla/egrave/eacute/ecircumflex
+/edieresis/igrave/iacute/icircumflex/idieresis/eth/ntilde/ograve/oacute
+/ocircumflex/otilde/odieresis/divide/oslash/ugrave/uacute/ucircumflex
+/udieresis/yacute/thorn/ydieresis
+TE
+%AI55J_Tsume: None
+%AI3_BeginEncoding: _Times-Bold Times-Bold
+[/_Times-Bold/Times-Bold 0 0 1 TZ
+%AI3_EndEncoding AdobeType
+%AI55J_Tsume: None
+%AI3_BeginEncoding: _Times-Roman Times-Roman
+[/_Times-Roman/Times-Roman 0 0 1 TZ
+%AI3_EndEncoding AdobeType
+%AI5_Begin_NonPrinting
+Np
+%AI3_BeginPattern: (Arrow1.2.out/in)
+(Arrow1.2.out/in) 1 1 39.4039 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+33.9039 15.6187 m
+39.4247 20.202 L
+39.4247 20.202 L
+33.8869 24.6252 L
+S
+39.2997 20.202 m
+24.5706 20.202 l
+20.4039 20.4792 20.4039 16.8125 v
+20.4039 13.1458 20.4039 12.5625 y
+S
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Arrow1.2.side)
+(Arrow1.2.side) 1 1 39.404 39.4039 [
+%AI3_Tile
+(0 O 0 R  0.75 0.75 0.375 0 k
+ 0.75 0.75 0.375 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+20.202 20.202 m
+39.404 20.202 l
+S
+33.904 15.6187 m
+39.4248 20.202 L
+39.4248 20.202 L
+33.887 24.6252 L
+S
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Bricks)
+(Bricks) 1.6 1.6 73.6 73.6 [
+%AI3_Tile
+(0 O 0 R  0.3 0.85 0.85 0 k
+ 0.3 0.85 0.85 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+1.6 1.6 m
+1.6 73.6 L
+73.6 73.6 L
+73.6 1.6 L
+1.6 1.6 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+1.6 70.01 m
+73.6 70.01 l
+S
+1.6 62.809 m
+73.6 62.809 L
+S
+1.6 55.609 m
+73.6 55.609 L
+S
+1.6 48.408 m
+73.6 48.408 L
+S
+1.6 41.208 m
+73.6 41.208 L
+S
+1.6 34.007 m
+73.6 34.007 L
+S
+1.6 26.807 m
+73.6 26.807 L
+S
+1.6 19.606 m
+73.6 19.606 L
+S
+1.6 12.406 m
+73.6 12.406 L
+S
+1.6 5.206 m
+73.6 5.206 L
+S
+70.01 70.01 m
+70.01 62.822 l
+S
+55.61 70.01 m
+55.61 62.822 L
+S
+41.21 70.01 m
+41.21 62.822 L
+S
+26.81 70.01 m
+26.81 62.822 L
+S
+12.41 70.01 m
+12.41 62.822 L
+S
+70.01 55.572 m
+70.01 48.385 l
+S
+55.61 55.572 m
+55.61 48.385 L
+S
+41.21 55.572 m
+41.21 48.385 L
+S
+26.81 55.572 m
+26.81 48.385 L
+S
+12.41 55.572 m
+12.41 48.385 L
+S
+70.01 41.197 m
+70.01 34.01 l
+S
+55.61 41.197 m
+55.61 34.01 L
+S
+41.21 41.197 m
+41.21 34.01 L
+S
+26.81 41.197 m
+26.81 34.01 L
+S
+12.41 41.197 m
+12.41 34.01 L
+S
+70.01 26.822 m
+70.01 19.635 l
+S
+55.61 26.822 m
+55.61 19.635 L
+S
+41.21 26.822 m
+41.21 19.635 L
+S
+26.81 26.822 m
+26.81 19.635 L
+S
+12.41 26.822 m
+12.41 19.635 L
+S
+70.01 12.385 m
+70.01 5.197 l
+S
+55.61 12.385 m
+55.61 5.197 L
+S
+41.21 12.385 m
+41.21 5.197 L
+S
+26.81 12.385 m
+26.81 5.197 L
+S
+12.41 12.385 m
+12.41 5.197 L
+S
+62.797 5.197 m
+62.797 1.6 L
+S
+48.397 5.197 m
+48.397 1.6 L
+S
+33.997 5.197 m
+33.997 1.6 L
+S
+19.597 5.197 m
+19.597 1.6 L
+S
+5.197 5.197 m
+5.197 1.6 l
+S
+62.797 19.635 m
+62.797 12.447 L
+S
+48.397 19.635 m
+48.397 12.447 L
+S
+33.997 19.635 m
+33.997 12.447 L
+S
+19.597 19.635 m
+19.597 12.447 L
+S
+5.197 19.635 m
+5.197 12.447 l
+S
+62.797 34.01 m
+62.797 26.822 L
+S
+48.397 34.01 m
+48.397 26.822 L
+S
+19.597 34.01 m
+19.597 26.822 L
+S
+5.197 34.01 m
+5.197 26.822 l
+S
+62.797 48.385 m
+62.797 41.197 L
+S
+48.397 48.385 m
+48.397 41.197 L
+S
+33.997 48.385 m
+33.997 41.197 L
+S
+19.597 48.385 m
+19.597 41.197 L
+S
+5.197 48.385 m
+5.197 41.197 l
+S
+62.797 62.822 m
+62.797 55.635 L
+S
+48.397 62.822 m
+48.397 55.635 L
+S
+33.997 62.822 m
+33.997 55.635 L
+S
+19.597 62.822 m
+19.597 55.635 L
+S
+5.197 62.822 m
+5.197 55.635 l
+S
+62.797 73.5589 m
+62.797 70.072 L
+S
+48.397 73.5589 m
+48.397 70.072 L
+S
+33.997 73.5589 m
+33.997 70.072 L
+S
+19.597 73.5589 m
+19.597 70.072 L
+S
+5.197 73.5589 m
+5.197 70.072 l
+S
+33.997 34.01 m
+33.997 26.822 L
+S
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Checks)
+(Checks) 1 1 31.3995 31.3995 [
+%AI3_Tile
+(0 O 0 R  0 0.91 1 0 k
+ 0 0.91 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+1 XR
+19.9995 4.8 m
+27.5995 4.8 L
+27.5995 12.3995 L
+19.9995 12.3995 L
+19.9995 4.8 L
+f
+31.3995 27.5995 m
+31.3995 31.3995 L
+27.5995 31.3995 L
+27.5995 27.5995 L
+31.3995 27.5995 L
+f
+19.9995 27.5995 m
+19.9995 19.9995 L
+27.5995 19.9995 L
+27.5995 27.5995 L
+19.9995 27.5995 L
+f
+0 XR
+12.3995 12.3995 m
+19.9995 12.3995 L
+19.9995 19.9995 L
+12.3995 19.9995 L
+12.3995 12.3995 L
+f
+1 XR
+12.3995 27.5995 m
+4.8 27.5995 L
+4.8 19.9995 L
+12.3995 19.9995 L
+12.3995 27.5995 L
+f
+4.8 12.3995 m
+4.8 4.8 L
+12.3995 4.8 L
+12.3995 12.3995 L
+4.8 12.3995 L
+f
+19.9995 27.5995 m
+19.9995 31.3995 L
+12.3995 31.3995 L
+12.3995 27.5995 L
+19.9995 27.5995 L
+f
+12.3995 4.8 m
+12.3995 1 L
+19.9995 1 L
+19.9995 4.8 L
+12.3995 4.8 L
+f
+4.8 19.9995 m
+1 19.9995 L
+1 12.3995 L
+4.8 12.3995 L
+4.8 19.9995 L
+f
+27.5995 19.9995 m
+27.5995 12.3995 L
+31.3995 12.3995 L
+31.3995 19.9995 L
+27.5995 19.9995 L
+f
+4.8 31.3995 m
+1 31.3995 L
+1 27.5995 L
+4.8 27.5995 L
+4.8 31.3995 L
+f
+27.5995 1 m
+31.3995 1 L
+31.3995 4.8 L
+27.5995 4.8 L
+27.5995 1 L
+f
+1 4.8 m
+1 1 L
+4.8 1 L
+4.8 4.8 L
+1 4.8 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.05 0.2 0 k
+ 0 0.05 0.2 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+1 XR
+4.8 4.8 m
+4.8 1 L
+12.3995 1 L
+12.3995 4.8 L
+4.8 4.8 L
+f
+4.8 12.3995 m
+1 12.3995 L
+1 4.8 L
+4.8 4.8 L
+4.8 12.3995 L
+f
+19.9995 4.8 m
+19.9995 1 L
+27.5995 1 L
+27.5995 4.8 L
+19.9995 4.8 L
+f
+12.3995 12.3995 m
+12.3995 4.8 L
+19.9995 4.8 L
+19.9995 12.3995 L
+12.3995 12.3995 L
+f
+27.5995 4.8 m
+31.3995 4.8 L
+31.3995 12.3995 L
+27.5995 12.3995 L
+27.5995 4.8 L
+f
+12.3995 19.9995 m
+4.8 19.9995 L
+4.8 12.3995 L
+12.3995 12.3995 L
+12.3995 19.9995 L
+f
+4.8 27.5995 m
+1 27.5995 L
+1 19.9995 L
+4.8 19.9995 L
+4.8 27.5995 L
+f
+19.9995 12.3995 m
+27.5995 12.3995 L
+27.5995 19.9995 L
+19.9995 19.9995 L
+19.9995 12.3995 L
+f
+19.9995 19.9995 m
+19.9995 27.5995 L
+12.3995 27.5995 L
+12.3995 19.9995 L
+19.9995 19.9995 L
+f
+27.5995 19.9995 m
+31.3995 19.9995 L
+31.3995 27.5995 L
+27.5995 27.5995 L
+27.5995 19.9995 L
+f
+12.3995 27.5995 m
+12.3995 31.3995 L
+4.8 31.3995 L
+4.8 27.5995 L
+12.3995 27.5995 L
+f
+27.5995 27.5995 m
+27.5995 31.3995 L
+19.9995 31.3995 L
+19.9995 27.5995 L
+27.5995 27.5995 L
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Confetti)
+(Confetti) 4.85 3.617 76.85 75.617 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+4.85 3.617 m
+4.85 75.617 L
+76.85 75.617 L
+76.85 3.617 L
+4.85 3.617 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+10.6 64.867 m
+7.85 62.867 l
+S
+9.1 8.617 m
+6.85 6.867 l
+S
+78.1 68.617 m
+74.85 67.867 l
+S
+76.85 56.867 m
+74.35 55.117 l
+S
+79.6 51.617 m
+76.6 51.617 l
+S
+76.35 44.117 m
+73.6 45.867 l
+S
+78.6 35.867 m
+76.6 34.367 l
+S
+76.1 23.867 m
+73.35 26.117 l
+S
+78.1 12.867 m
+73.85 13.617 l
+S
+68.35 14.617 m
+66.1 12.867 l
+S
+76.6 30.617 m
+73.6 30.617 l
+S
+62.85 58.117 m
+60.956 60.941 l
+S
+32.85 59.617 m
+31.196 62.181 l
+S
+47.891 64.061 m
+49.744 66.742 l
+S
+72.814 2.769 m
+73.928 5.729 l
+S
+67.976 2.633 m
+67.35 5.909 l
+S
+61.85 27.617 m
+59.956 30.441 l
+S
+53.504 56.053 m
+51.85 58.617 l
+S
+52.762 1.779 m
+52.876 4.776 l
+S
+45.391 5.311 m
+47.244 7.992 l
+S
+37.062 3.375 m
+35.639 5.43 l
+S
+55.165 34.828 m
+57.518 37.491 l
+S
+20.795 3.242 m
+22.12 5.193 l
+S
+14.097 4.747 m
+15.008 8.965 l
+S
+9.736 1.91 m
+8.073 4.225 l
+S
+31.891 5.573 m
+32.005 8.571 l
+S
+12.1 70.367 m
+15.6 68.867 l
+S
+9.35 54.867 m
+9.6 58.117 l
+S
+12.85 31.867 m
+14.35 28.117 l
+S
+10.1 37.367 m
+12.35 41.117 l
+S
+34.1 71.117 m
+31.85 68.617 l
+S
+38.35 71.117 m
+41.6 68.367 l
+S
+55.1 71.117 m
+58.35 69.117 l
+S
+57.35 65.117 m
+55.35 61.867 l
+S
+64.35 66.367 m
+69.35 68.617 l
+S
+71.85 62.867 m
+69.35 61.117 l
+S
+23.6 70.867 m
+23.6 67.867 l
+S
+20.6 65.867 m
+17.35 65.367 l
+S
+24.85 61.367 m
+25.35 58.117 l
+S
+25.85 65.867 m
+29.35 66.617 l
+S
+14.1 54.117 m
+16.85 56.117 l
+S
+12.35 11.617 m
+12.6 15.617 l
+S
+12.1 19.867 m
+14.35 22.367 l
+S
+26.1 9.867 m
+23.6 13.367 l
+S
+34.6 47.117 m
+32.1 45.367 l
+S
+62.6 41.867 m
+59.85 43.367 l
+S
+31.6 35.617 m
+27.85 36.367 l
+S
+36.35 26.117 m
+34.35 24.617 l
+S
+33.85 14.117 m
+31.1 16.367 l
+S
+37.1 9.867 m
+35.1 11.117 l
+S
+34.35 20.867 m
+31.35 20.867 l
+S
+44.6 56.617 m
+42.1 54.867 l
+S
+47.35 51.367 m
+44.35 51.367 l
+S
+44.1 43.867 m
+41.35 45.617 l
+S
+43.35 33.117 m
+42.6 30.617 l
+S
+43.85 23.617 m
+41.1 25.867 l
+S
+44.35 15.617 m
+42.35 16.867 l
+S
+67.823 31.1 m
+64.823 31.1 l
+S
+27.1 32.617 m
+29.6 30.867 l
+S
+31.85 55.117 m
+34.85 55.117 l
+S
+19.6 40.867 m
+22.1 39.117 l
+S
+16.85 35.617 m
+19.85 35.617 l
+S
+20.1 28.117 m
+22.85 29.867 l
+S
+52.1 42.617 m
+54.484 44.178 l
+S
+52.437 50.146 m
+54.821 48.325 l
+S
+59.572 54.133 m
+59.35 51.117 l
+S
+50.185 10.055 m
+53.234 9.928 l
+S
+51.187 15.896 m
+53.571 14.075 l
+S
+58.322 19.883 m
+59.445 16.823 l
+S
+53.1 32.117 m
+50.6 30.367 l
+S
+52.85 24.617 m
+49.6 25.617 l
+S
+61.85 9.117 m
+59.1 10.867 l
+S
+69.35 34.617 m
+66.6 36.367 l
+S
+67.1 23.617 m
+65.1 22.117 l
+S
+24.435 46.055 m
+27.484 45.928 l
+S
+25.437 51.896 m
+27.821 50.075 l
+S
+62.6 47.117 m
+65.321 46.575 l
+S
+19.85 19.867 m
+20.35 16.617 l
+S
+21.85 21.867 m
+25.35 22.617 l
+S
+37.6 62.867 m
+41.6 62.117 l
+S
+38.323 42.1 m
+38.823 38.6 l
+S
+69.35 52.617 m
+66.85 53.867 l
+S
+14.85 62.117 m
+18.1 59.367 l
+S
+9.6 46.117 m
+7.1 44.367 l
+S
+20.6 51.617 m
+18.6 50.117 l
+S
+46.141 70.811 m
+47.994 73.492 l
+S
+69.391 40.561 m
+71.244 43.242 l
+S
+38.641 49.311 m
+39.35 52.117 l
+S
+25.141 16.811 m
+25.85 19.617 l
+S
+36.6 32.867 m
+34.6 31.367 l
+S
+6.1 68.617 m
+2.85 67.867 l
+S
+4.85 56.867 m
+2.35 55.117 l
+S
+7.6 51.617 m
+4.6 51.617 l
+S
+6.6 35.867 m
+4.6 34.367 l
+S
+6.1 12.867 m
+1.85 13.617 l
+S
+4.6 30.617 m
+1.6 30.617 l
+S
+72.814 74.769 m
+73.928 77.729 l
+S
+67.976 74.633 m
+67.35 77.909 l
+S
+52.762 73.779 m
+52.876 76.776 l
+S
+37.062 75.375 m
+35.639 77.43 l
+S
+20.795 75.242 m
+22.12 77.193 l
+S
+9.736 73.91 m
+8.073 76.225 l
+S
+10.1 23.617 m
+6.35 24.367 l
+S
+73.217 18.276 m
+71.323 21.1 l
+S
+28.823 39.6 m
+29.505 42.389 l
+S
+49.6 38.617 m
+47.6 37.117 l
+S
+60.323 73.6 m
+62.323 76.6 l
+S
+60.323 1.6 m
+62.323 4.6 l
+S
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (DblLine1.2.inner)
+(DblLine1.2.inner) 1 1 39.2705 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+39.2702 22.175 m
+39.2702 13.6108 L
+26.66 13.6108 L
+26.66 1.0003 L
+18.0958 1.0003 L
+18.0948 22.175 L
+18.0958 22.175 L
+18.0958 22.1752 L
+39.2702 22.175 L
+f
+39.2708 24.6929 m
+15.5779 24.6929 L
+15.5779 1.0003 L
+14.9037 1.0003 L
+14.9032 25.3675 L
+39.2708 25.3675 L
+39.2708 24.6929 L
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (DblLine1.2.outer)
+(DblLine1.2.outer) 1 1.0003 39.2706 39.271 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+39.2708 26.6602 m
+13.6111 26.6602 L
+13.6111 1.0005 L
+22.1751 1 L
+22.1751 18.096 L
+39.2708 18.096 L
+39.2708 26.6602 L
+f
+39.2708 15.578 m
+24.6928 15.578 L
+24.6928 1 L
+25.367 1 L
+25.367 14.9038 L
+39.2708 14.9038 L
+39.2708 15.578 L
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (DblLine1.2.side)
+(DblLine1.2.side) 1 1 39.2706 39.2706 [
+%AI3_Tile
+(0 O 0 R  1 0.14 0.09 0 k
+ 1 0.14 0.09 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+39.2704 18.0958 m
+39.2704 26.6598 L
+1.0001 26.6598 L
+1.0001 18.0958 L
+39.2704 18.0958 L
+f
+39.2704 14.9037 m
+39.2704 15.5776 L
+1.0001 15.5776 L
+1.0001 14.9037 L
+39.2704 14.9037 L
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Diamonds)
+(Diamonds) 1 1 37.1865 41.9411 [
+%AI3_Tile
+(0 O 0 R  0.21 0 1 0 k
+ 0.21 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+1.0002 1.0004 m
+1.0002 41.9411 L
+37.1865 41.9411 L
+37.1865 1.0004 L
+1.0002 1.0004 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+1 XR
+19.0936 41.9408 m
+19.0929 41.9408 L
+19.0933 41.9402 L
+19.0936 41.9408 L
+f
+7.0311 41.9408 m
+7.0304 41.9408 L
+7.0308 41.9402 L
+7.0311 41.9408 L
+f
+31.1556 41.9408 m
+31.1548 41.9408 L
+31.1552 41.9402 L
+31.1556 41.9408 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.76 0.9 0 0 k
+ 0.76 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+1 XR
+37.1865 1 m
+37.1865 11.2349 L
+31.1552 1 L
+37.1865 1 L
+f
+19.0933 1 m
+31.1552 1 L
+25.124 11.2349 L
+19.0933 1 L
+f
+7.0308 1 m
+19.0933 1 L
+13.062 11.2349 L
+7.0308 1 L
+f
+1 1 m
+7.0308 1 L
+1 11.2349 L
+1 1 L
+f
+37.1859 11.2349 m
+37.1865 11.236 L
+37.1865 31.7059 L
+31.1552 21.4704 L
+37.1859 11.2349 L
+f
+19.0933 21.4704 m
+25.124 11.2349 L
+31.1552 21.4704 L
+25.124 31.7059 L
+19.0933 21.4704 L
+f
+7.0308 21.4704 m
+13.062 11.2349 L
+19.0933 21.4704 L
+13.062 31.7059 L
+7.0308 21.4704 L
+f
+1 31.7059 m
+1 11.2349 L
+7.0308 21.4704 L
+1 31.7059 L
+f
+37.1859 31.7059 m
+37.1865 31.707 L
+37.1865 41.9408 L
+31.1556 41.9408 L
+31.1552 41.9402 L
+37.1859 31.7059 L
+f
+25.124 31.7059 m
+31.1552 41.9402 L
+31.1548 41.9408 L
+19.0936 41.9408 L
+19.0933 41.9402 L
+25.124 31.7059 L
+f
+13.062 31.7059 m
+19.0933 41.9402 L
+19.0929 41.9408 L
+7.0311 41.9408 L
+7.0308 41.9402 L
+13.062 31.7059 L
+f
+7.0304 41.9408 m
+1 41.9408 L
+1 31.7059 L
+7.0308 41.9402 L
+7.0304 41.9408 L
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Hexagon)
+(Hexagon) 4 1.6 70.151 77.983 [
+%AI3_Tile
+(0 O 0 R  0 1 0.35 0 k
+ 0 1 0.35 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+70.151 77.983 m
+70.151 1.6 L
+4 1.6 L
+4 77.983 L
+70.151 77.983 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.9921 1 0 0 k
+ 0.9921 1 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+20.538 30.244 m
+S
+26.05 20.696 m
+15.025 20.696 L
+9.513 30.244 L
+15.025 39.792 L
+26.05 39.792 L
+31.564 30.244 L
+26.05 20.696 L
+s
+20.537 11.148 m
+S
+26.05 1.6 m
+15.024 1.6 L
+9.512 11.148 L
+15.024 20.696 L
+26.05 20.696 L
+31.563 11.148 L
+26.05 1.6 L
+s
+53.614 30.244 m
+S
+59.126 20.696 m
+48.101 20.696 L
+42.589 30.244 L
+48.101 39.792 L
+59.126 39.792 L
+64.639 30.244 L
+59.126 20.696 L
+s
+53.614 11.148 m
+S
+59.126 1.6 m
+48.101 1.6 L
+42.588 11.148 L
+48.101 20.696 L
+59.126 20.696 L
+64.638 11.148 L
+59.126 1.6 L
+s
+20.538 68.436 m
+S
+26.051 58.888 m
+15.025 58.888 L
+9.513 68.436 L
+15.025 77.984 L
+26.051 77.984 L
+31.564 68.436 L
+26.051 58.888 L
+s
+20.538 49.34 m
+S
+26.051 39.792 m
+15.025 39.792 L
+9.513 49.34 L
+15.025 58.888 L
+26.05 58.888 L
+31.564 49.34 L
+26.051 39.792 L
+s
+53.614 68.436 m
+S
+59.127 58.888 m
+48.102 58.888 L
+42.589 68.436 L
+48.101 77.985 L
+59.127 77.985 L
+64.639 68.436 L
+59.127 58.888 L
+s
+53.614 49.34 m
+S
+59.127 39.792 m
+48.101 39.792 L
+42.589 49.34 L
+48.101 58.888 L
+59.127 58.888 L
+64.639 49.341 L
+59.127 39.792 L
+s
+4 20.696 m
+S
+3.876 30.244 m
+9.512 30.244 L
+15.024 20.696 L
+9.512 11.147 L
+3.876 11.147 L
+S
+37.075 20.696 m
+S
+42.588 11.148 m
+31.563 11.148 L
+26.05 20.696 L
+31.563 30.244 L
+42.589 30.244 L
+48.101 20.696 L
+42.588 11.148 L
+s
+37.076 58.888 m
+S
+42.589 49.34 m
+31.564 49.34 L
+26.05 58.888 L
+31.564 68.436 L
+42.589 68.436 L
+48.101 58.888 L
+42.589 49.34 L
+s
+70.151 20.696 m
+S
+70.2094 11.147 m
+64.639 11.147 L
+59.127 20.696 L
+64.639 30.244 L
+70.2094 30.244 L
+S
+70.152 58.888 m
+S
+70.0427 49.34 m
+64.639 49.34 L
+59.127 58.888 L
+64.639 68.436 L
+70.0427 68.436 L
+S
+4 58.888 m
+S
+3.876 68.436 m
+9.513 68.436 L
+15.025 58.888 L
+9.513 49.34 L
+3.876 49.34 L
+S
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Laurel.inner)
+(Laurel.inner) 1 1 28.5392 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+19.2768 15.3585 m
+28.9144 15.3585 L
+28.9144 14.2335 L
+19.2768 14.2335 L
+19.2768 15.3585 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+14.7461 18.9624 m
+13.0264 17.8486 11.3273 14.4193 11.3273 10.0362 c
+11.3273 5.6547 12.9768 2.1518 14.744 1.1112 C
+14.7443 1.1112 L
+16.4707 2.1518 18.1679 5.6547 18.1679 10.0362 c
+18.1679 14.4143 16.432 17.8633 14.7461 18.9624 C
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Laurel.outer)
+(Laurel.outer) 1 1.3751 28.5393 28.9143 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+14.2395 10.6375 m
+14.2395 1 L
+15.3645 1 L
+15.3645 10.6375 L
+14.2395 10.6375 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+10.5769 15.124 m
+11.6906 16.8438 15.1198 18.5429 19.503 18.5429 c
+23.8844 18.5429 27.3874 16.8935 28.428 15.1262 C
+28.428 15.1259 L
+27.3874 13.3995 23.8844 11.7023 19.503 11.7023 c
+15.1249 11.7023 11.676 13.4382 10.5769 15.124 C
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Laurel.side)
+(Laurel.side) 1.3972 1 28.9364 28.5392 [
+%AI3_Tile
+(0 O 0 R  0 0.55 1 0.12 k
+ 0 0.55 1 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+29.1571 15.2998 m
+1 15.2998 L
+1 14.1748 L
+29.1571 14.1748 L
+29.1571 15.2998 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+2.0183 27.4787 m
+1.5899 25.4751 2.8132 21.8488 5.9125 18.7494 c
+9.0107 15.6513 12.654 14.3407 14.6395 14.8545 C
+14.6398 14.8547 L
+15.1246 16.8113 13.8478 20.4883 10.7496 23.5865 c
+7.6538 26.6824 3.9876 27.8936 2.0183 27.4787 C
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+2.0183 2.0091 m
+1.5899 4.0126 2.8132 7.6389 5.9125 10.7382 c
+9.0107 13.8365 12.654 15.147 14.6395 14.6332 C
+14.6398 14.633 L
+15.1246 12.6765 13.8478 8.9993 10.7496 5.9011 c
+7.6538 2.8054 3.9876 1.5941 2.0183 2.0091 C
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.55 1 0.3 k
+ 0 0.55 1 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+15.821 2.0091 m
+15.3925 4.0126 16.6159 7.6389 19.7152 10.7382 c
+22.8134 13.8365 26.4567 15.147 28.4422 14.6332 C
+28.4424 14.633 L
+28.9273 12.6765 27.6505 8.9993 24.5523 5.9011 c
+21.4565 2.8054 17.7903 1.5941 15.821 2.0091 C
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.39 0.7 0.12 k
+ 0 0.39 0.7 0.12 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+15.821 27.4787 m
+15.3925 25.4751 16.6159 21.8488 19.7152 18.7494 c
+22.8134 15.6513 26.4567 14.3407 28.4422 14.8545 C
+28.4424 14.8547 L
+28.9273 16.8113 27.6505 20.4883 24.5523 23.5865 c
+21.4565 26.6824 17.7903 27.8936 15.821 27.4787 C
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Leaves-fall)
+(Leaves-fall) 1 1 52.733 89.816 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 1 0 k
+ 0.05 0.2 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+52.733 89.816 m
+52.733 1 L
+1 1 L
+1 89.816 L
+52.733 89.816 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.83 0 1 0 k
+ 0.83 0 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+1 D
+0 XR
+25.317 2.083 m
+25.994 2.283 26.284 2.435 V
+24.815 5.147 29.266 9.428 30.186 10.168 C
+30.787 9.943 30.907 7.41 30.23 6.073 C
+31.073 6.196 33.262 4.818 34.02 3.529 C
+34.085 4.217 35.655 7.158 36.481 7.535 C
+35.561 7.933 34.896 9.406 34.134 10.854 C
+35.156 11.021 36.555 10.1 38.026 9.195 C
+38.541 9.996 39.915 10.968 41.174 11.484 C
+40.086 12.171 39.591 12.912 39.094 14.372 C
+38.052 13.806 35.865 13.657 35.336 13.944 C
+35.85 15.057 38.096 15.6 38.827 15.547 C
+38.573 16.409 38.425 18.562 38.598 21.155 C
+36.939 19.839 35.393 18.522 33.734 18.58 C
+34.003 17.158 33.367 15.353 32.99 14.86 C
+32.417 15.604 32.006 16.431 32.361 18.408 C
+30.908 18.893 29.671 19.439 28.297 20.697 C
+28.297 18.866 27.725 17.664 26.857 16.388 C
+28.117 15.9 29.389 14.697 29.385 13.658 C
+28.537 13.81 26.845 14.554 26.352 15.547 C
+25.634 14.8 23.95 13.491 22.346 13.487 C
+23.534 12.632 24.454 11.598 24.549 9.686 C
+25.802 10.657 28.255 11.272 29.635 10.674 C
+24.794 6.438 25.262 3.405 25.317 2.083 C
+f
+12.412 33.743 m
+11.887 33.272 11.691 33.01 V
+14.182 31.192 11.928 25.366 11.415 24.303 C
+10.776 24.247 9.369 26.988 9.405 28.486 C
+8.273 27.73 6.608 27.851 5.006 28.137 C
+5.578 27.049 5.177 25.104 4.376 24.303 C
+5.378 24.339 6.729 23.624 8.038 22.643 C
+7.203 21.823 5.376 21.984 3.46 22.643 C
+3.46 21.27 2.638 19.533 1.801 18.351 C
+3.117 18.408 4.262 17.722 5.12 16.691 C
+5.785 18.26 7.819 19.373 8.725 19.324 C
+8.742 17.959 7.169 15.869 6.147 15.47 C
+6.747 14.801 7.766 13.27 8.725 10.854 C
+9.524 12.78 10.694 14.022 11.927 14.955 C
+10.785 16.517 10.959 17.388 11.358 18.866 C
+12.101 18.325 13.132 17.893 13.303 15.89 C
+15.02 16.176 16.156 16.104 17.653 15.203 C
+17.198 16.865 17.195 18.466 17.515 20.166 C
+15.665 20.026 14.105 20.239 13.075 21.728 C
+13.905 21.955 16.165 22.014 17.039 21.082 C
+17.366 22.064 18.261 23.47 19.707 24.164 C
+18.267 24.424 17.282 25.523 16.373 27.209 C
+15.66 25.793 13.433 24.128 11.93 24.073 C
+13.933 28.137 13.933 31.055 12.412 33.743 C
+f
+31.125 30.5 m
+31.445 31.128 31.648 31.385 V
+34.045 29.444 38.851 32.752 39.746 33.521 C
+39.636 34.153 37.511 35.29 35.794 34.26 C
+36.234 35.549 35.332 37.51 34.134 38.552 C
+35.873 38.451 38.019 39.813 38.541 40.555 C
+38.763 39.577 39.946 38.307 41.231 37.293 C
+41.582 38.266 40.887 40.384 39.971 41.986 C
+41.206 42.487 42.318 43.417 42.776 44.676 C
+43.233 43.359 44.236 42.685 45.58 41.929 C
+44.421 40.502 43.64 38.328 43.92 37.465 C
+45.243 37.8 46.814 40.518 46.937 41.607 C
+47.812 40.841 49.366 40.154 51.947 39.848 C
+50.246 38.77 49.884 36.778 49.3 35.347 C
+48.152 35.794 45.983 35.853 45.008 35.29 C
+45.721 34.711 47.061 34.16 49.071 34.146 C
+49.071 32.601 49.534 31.469 50.788 30.254 C
+49.065 30.267 46.965 29.781 45.469 29.389 C
+45.221 30.718 44.378 32.314 43.233 32.715 C
+43.227 31.854 43.493 29.605 44.378 28.938 C
+43.513 28.37 42.26 26.993 41.803 25.276 C
+41.181 26.601 40.32 27.906 38.457 28.35 C
+39.642 29.403 40.477 31.42 40.143 32.887 C
+35.091 28.905 32.414 30.203 31.125 30.5 C
+f
+25.317 46.491 m
+25.994 46.691 26.284 46.843 V
+24.815 49.556 29.266 53.837 30.186 54.576 C
+30.787 54.351 30.907 51.818 30.23 50.482 C
+31.073 50.605 33.262 49.227 34.02 47.938 C
+34.085 48.625 35.655 51.566 36.481 51.944 C
+35.561 52.341 34.896 53.814 34.134 55.263 C
+35.156 55.43 36.555 54.508 38.026 53.603 C
+38.541 54.404 39.915 55.377 41.174 55.892 C
+40.086 56.579 39.591 57.321 39.094 58.78 C
+38.052 58.215 35.865 58.065 35.336 58.353 C
+35.85 59.465 38.096 60.008 38.827 59.955 C
+38.573 60.817 38.425 62.97 38.598 65.563 C
+36.939 64.247 35.393 62.931 33.734 62.988 C
+34.003 61.567 33.367 59.761 32.99 59.268 C
+32.417 60.012 32.006 60.839 32.361 62.817 C
+30.908 63.302 29.671 63.847 28.297 65.106 C
+28.297 63.274 27.725 62.073 26.857 60.796 C
+28.117 60.308 29.389 59.106 29.385 58.067 C
+28.537 58.219 26.845 58.963 26.352 59.955 C
+25.634 59.209 23.95 57.899 22.346 57.895 C
+23.534 57.041 24.454 56.006 24.549 54.094 C
+25.802 55.065 28.255 55.68 29.635 55.083 C
+24.794 50.846 25.262 47.814 25.317 46.491 C
+f
+12.412 78.151 m
+11.887 77.68 11.691 77.418 V
+14.182 75.601 11.928 69.774 11.415 68.711 C
+10.776 68.655 9.369 71.396 9.405 72.894 C
+8.273 72.138 6.608 72.259 5.006 72.545 C
+5.578 71.458 5.177 69.512 4.376 68.711 C
+5.378 68.747 6.729 68.032 8.038 67.052 C
+7.203 66.231 5.376 66.393 3.46 67.052 C
+3.46 65.678 2.638 63.941 1.801 62.759 C
+3.117 62.817 4.262 62.13 5.12 61.1 C
+5.785 62.669 7.819 63.781 8.725 63.732 C
+8.742 62.367 7.169 60.277 6.147 59.878 C
+6.747 59.209 7.766 57.678 8.725 55.263 C
+9.524 57.189 10.694 58.431 11.927 59.364 C
+10.785 60.925 10.959 61.796 11.358 63.274 C
+12.101 62.734 13.132 62.301 13.303 60.298 C
+15.02 60.584 16.156 60.512 17.653 59.612 C
+17.198 61.273 17.195 62.874 17.515 64.574 C
+15.665 64.434 14.105 64.648 13.075 66.136 C
+13.905 66.363 16.165 66.422 17.039 65.49 C
+17.366 66.472 18.261 67.878 19.707 68.572 C
+18.267 68.832 17.282 69.931 16.373 71.617 C
+15.66 70.202 13.433 68.536 11.93 68.482 C
+13.933 72.545 13.933 75.464 12.412 78.151 C
+f
+31.125 74.908 m
+31.445 75.537 31.648 75.794 V
+34.045 73.853 38.851 77.161 39.746 77.929 C
+39.636 78.562 37.511 79.698 35.794 78.668 C
+36.234 79.957 35.332 81.918 34.134 82.96 C
+35.873 82.86 38.019 84.221 38.541 84.963 C
+38.763 83.986 39.946 82.716 41.231 81.701 C
+41.582 82.675 40.887 84.792 39.971 86.394 C
+41.206 86.895 42.318 87.825 42.776 89.084 C
+43.233 87.768 44.236 87.093 45.58 86.337 C
+44.421 84.91 43.64 82.736 43.92 81.873 C
+45.243 82.208 46.814 84.926 46.937 86.016 C
+47.812 85.249 49.366 84.563 51.947 84.257 C
+50.246 83.179 49.884 81.187 49.3 79.756 C
+48.152 80.203 45.983 80.262 45.008 79.698 C
+45.721 79.119 47.061 78.569 49.071 78.554 C
+49.071 77.009 49.534 75.877 50.788 74.663 C
+49.065 74.675 46.965 74.189 45.469 73.798 C
+45.221 75.126 44.378 76.723 43.233 77.123 C
+43.227 76.262 43.493 74.013 44.378 73.347 C
+43.513 72.779 42.26 71.401 41.803 69.684 C
+41.181 71.009 40.32 72.314 38.457 72.759 C
+39.642 73.812 40.477 75.829 40.143 77.295 C
+35.091 73.313 32.414 74.611 31.125 74.908 C
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Polka dots)
+(Polka dots) 1 1 29.8 29.8 [
+%AI3_Tile
+(0 O 0 R  0.45 0.9 0 0 k
+ 0.45 0.9 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+1 1 m
+1 29.8 L
+29.8 29.8 L
+29.8 1 L
+1 1 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.09 0.18 0 0 k
+ 0.09 0.18 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+11.08 8.2 m
+11.08 9.791 9.79 11.08 8.2 11.08 c
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+f
+11.08 22.6 m
+11.08 24.191 9.79 25.48 8.2 25.48 c
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+f
+18.28 15.4 m
+18.28 16.991 16.99 18.28 15.4 18.28 c
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+f
+25.48 8.2 m
+25.48 9.791 24.19 11.08 22.6 11.08 c
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+f
+25.48 22.6 m
+25.48 24.191 24.19 25.48 22.6 25.48 c
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+f
+*U
+26.92 1 m
+29.8 1 L
+29.8 3.88 L
+28.209 3.88 26.92 2.591 26.92 1 C
+f
+15.4 3.88 m
+13.809 3.88 12.52 2.591 12.52 1 C
+18.28 1 L
+18.28 2.591 16.99 3.88 15.4 3.88 c
+f
+1 3.88 m
+1 1 L
+3.88 1 L
+3.88 2.591 2.59 3.88 1 3.88 C
+f
+1 XR
+26.92 15.4 m
+26.92 13.81 28.209 12.52 29.8 12.52 C
+29.8 18.28 L
+28.209 18.28 26.92 16.991 26.92 15.4 c
+f
+0 XR
+15.4 18.28 m
+13.809 18.28 12.52 16.991 12.52 15.4 c
+12.52 13.81 13.809 12.52 15.4 12.52 c
+16.99 12.52 18.28 13.81 18.28 15.4 c
+18.28 16.991 16.99 18.28 15.4 18.28 c
+f
+1 XR
+3.88 15.4 m
+3.88 16.991 2.59 18.28 1 18.28 C
+1 12.52 L
+2.59 12.52 3.88 13.81 3.88 15.4 c
+f
+0 XR
+29.8 26.92 m
+29.8 29.8 L
+26.92 29.8 L
+26.92 28.21 28.209 26.92 29.8 26.92 C
+f
+15.4 26.92 m
+16.99 26.92 18.28 28.21 18.28 29.8 C
+12.52 29.8 L
+12.52 28.21 13.809 26.92 15.4 26.92 c
+f
+3.88 29.8 m
+1 29.8 L
+1 26.92 L
+2.59 26.92 3.88 28.21 3.88 29.8 C
+f
+1 XR
+8.2 11.08 m
+6.609 11.08 5.32 9.791 5.32 8.2 c
+5.32 6.61 6.609 5.32 8.2 5.32 c
+9.79 5.32 11.08 6.61 11.08 8.2 c
+11.08 9.791 9.79 11.08 8.2 11.08 c
+f
+22.6 11.08 m
+21.009 11.08 19.72 9.791 19.72 8.2 c
+19.72 6.61 21.009 5.32 22.6 5.32 c
+24.19 5.32 25.48 6.61 25.48 8.2 c
+25.48 9.791 24.19 11.08 22.6 11.08 c
+f
+8.2 25.48 m
+6.609 25.48 5.32 24.191 5.32 22.6 c
+5.32 21.01 6.609 19.72 8.2 19.72 c
+9.79 19.72 11.08 21.01 11.08 22.6 c
+11.08 24.191 9.79 25.48 8.2 25.48 c
+f
+22.6 25.48 m
+21.009 25.48 19.72 24.191 19.72 22.6 c
+19.72 21.01 21.009 19.72 22.6 19.72 c
+24.19 19.72 25.48 21.01 25.48 22.6 c
+25.48 24.191 24.19 25.48 22.6 25.48 c
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Random circles)
+(Random circles) 4.365 3.849 51.13 57.85 [
+%AI3_Tile
+(0 O 0 R  0 0.1125 0.45 0 k
+ 0 0.1125 0.45 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+4.365 3.849 m
+4.365 57.85 L
+51.13 57.85 L
+51.13 3.849 L
+4.365 3.849 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.41 0.7 1 0 k
+ 0.41 0.7 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+45.429 36.274 m
+45.843 36.991 45.598 37.908 44.88 38.323 c
+44.163 38.737 43.245 38.491 42.831 37.774 c
+42.417 37.056 42.663 36.139 43.38 35.725 c
+44.098 35.31 45.015 35.556 45.429 36.274 c
+s
+44.179 27.926 m
+43.765 28.643 42.848 28.889 42.13 28.475 c
+41.413 28.06 41.167 27.143 41.581 26.425 c
+41.995 25.708 42.913 25.462 43.63 25.876 c
+44.348 26.291 44.593 27.208 44.179 27.926 c
+s
+35.929 41.024 m
+35.515 41.741 34.598 41.987 33.88 41.573 c
+33.163 41.158 32.917 40.241 33.331 39.524 c
+33.745 38.806 34.663 38.56 35.38 38.975 c
+36.098 39.389 36.343 40.306 35.929 41.024 c
+s
+28.38 34.225 m
+28.794 34.942 28.549 35.859 27.831 36.274 c
+27.114 36.688 26.196 36.442 25.782 35.725 c
+25.368 35.007 25.614 34.09 26.331 33.675 c
+27.049 33.261 27.966 33.507 28.38 34.225 c
+s
+31.179 28.024 m
+30.765 28.741 29.848 28.987 29.13 28.573 c
+28.413 28.158 28.167 27.241 28.581 26.524 c
+28.995 25.806 29.913 25.56 30.63 25.975 c
+31.348 26.389 31.593 27.306 31.179 28.024 c
+s
+36.792 23.349 m
+35.963 23.349 35.292 22.678 35.292 21.849 c
+35.292 21.021 35.963 20.349 36.792 20.349 c
+37.62 20.349 38.292 21.021 38.292 21.849 c
+38.292 22.678 37.62 23.349 36.792 23.349 c
+s
+10.888 34.175 m
+10.474 34.893 10.72 35.81 11.437 36.225 c
+12.155 36.639 13.072 36.393 13.486 35.675 c
+13.901 34.958 13.655 34.041 12.937 33.626 c
+12.22 33.212 11.303 33.458 10.888 34.175 c
+s
+11.517 26.601 m
+11.931 27.318 12.848 27.564 13.566 27.15 c
+14.283 26.735 14.529 25.818 14.115 25.1 c
+13.701 24.383 12.783 24.137 12.066 24.551 c
+11.348 24.966 11.103 25.883 11.517 26.601 c
+s
+16.782 41.426 m
+17.196 42.143 18.114 42.389 18.831 41.975 c
+19.549 41.56 19.794 40.643 19.38 39.926 c
+18.966 39.208 18.049 38.962 17.331 39.377 c
+16.614 39.791 16.368 40.708 16.782 41.426 c
+s
+22.365 24.35 m
+23.194 24.35 23.865 23.678 23.865 22.85 c
+23.865 22.021 23.194 21.35 22.365 21.35 c
+21.537 21.35 20.865 22.021 20.865 22.85 c
+20.865 23.678 21.537 24.35 22.365 24.35 c
+s
+45.385 7.849 m
+44.971 7.132 44.053 6.886 43.336 7.3 c
+42.619 7.714 42.373 8.632 42.787 9.349 c
+43.201 10.067 44.119 10.312 44.836 9.898 c
+45.553 9.484 45.799 8.567 45.385 7.849 c
+s
+29.679 7.774 m
+29.265 7.056 28.348 6.81 27.63 7.225 c
+26.913 7.639 26.667 8.556 27.081 9.274 c
+27.495 9.991 28.413 10.237 29.13 9.823 c
+29.848 9.408 30.093 8.491 29.679 7.774 c
+s
+35.542 11.349 m
+34.713 11.349 34.042 12.021 34.042 12.849 c
+34.042 13.678 34.713 14.349 35.542 14.349 c
+36.37 14.349 37.042 13.678 37.042 12.849 c
+37.042 12.021 36.37 11.349 35.542 11.349 c
+s
+10.13 7.475 m
+10.544 6.757 11.462 6.511 12.179 6.926 c
+12.897 7.34 13.142 8.257 12.728 8.975 c
+12.314 9.692 11.397 9.938 10.679 9.524 c
+9.962 9.109 9.716 8.192 10.13 7.475 c
+s
+20.203 13.349 m
+21.031 13.349 21.703 14.021 21.703 14.849 c
+21.703 15.678 21.031 16.349 20.203 16.349 c
+19.375 16.349 18.703 15.678 18.703 14.849 c
+18.703 14.021 19.375 13.349 20.203 13.349 c
+s
+44.635 54.1 m
+45.049 53.382 44.803 52.465 44.086 52.051 c
+43.369 51.636 42.451 51.882 42.037 52.6 c
+41.623 53.317 41.869 54.234 42.586 54.649 c
+43.303 55.063 44.221 54.817 44.635 54.1 c
+s
+36.841 48.1 m
+36.427 47.382 35.509 47.136 34.792 47.551 c
+34.074 47.965 33.828 48.882 34.243 49.6 c
+34.657 50.317 35.574 50.563 36.292 50.149 c
+37.009 49.734 37.255 48.817 36.841 48.1 c
+s
+29.728 54.725 m
+30.143 54.007 29.897 53.09 29.179 52.675 c
+28.462 52.261 27.544 52.507 27.13 53.225 c
+26.716 53.942 26.962 54.859 27.679 55.274 c
+28.397 55.688 29.314 55.442 29.728 54.725 c
+s
+10.86 54.1 m
+10.446 53.382 10.691 52.465 11.409 52.051 c
+12.126 51.636 13.044 51.882 13.458 52.6 c
+13.872 53.317 13.626 54.234 12.909 54.649 c
+12.191 55.063 11.274 54.817 10.86 54.1 c
+s
+19.154 49.1 m
+19.568 48.382 20.486 48.136 21.203 48.551 c
+21.92 48.965 22.166 49.882 21.752 50.6 c
+21.338 51.317 20.42 51.563 19.703 51.149 c
+18.986 50.734 18.74 49.817 19.154 49.1 c
+s
+51.88 38.85 m
+51.052 38.85 50.38 39.521 50.38 40.35 c
+50.38 41.178 51.052 41.85 51.88 41.85 c
+52.709 41.85 53.38 41.178 53.38 40.35 c
+53.38 39.521 52.709 38.85 51.88 38.85 c
+s
+51.865 11.349 m
+52.693 11.349 53.365 12.021 53.365 12.849 c
+53.365 13.678 52.693 14.349 51.865 14.349 c
+51.036 14.349 50.365 13.678 50.365 12.849 c
+50.365 12.021 51.036 11.349 51.865 11.349 c
+s
+30.179 18.524 m
+29.765 19.241 28.848 19.487 28.13 19.073 c
+27.413 18.658 27.167 17.741 27.581 17.024 c
+27.995 16.306 28.913 16.06 29.63 16.475 c
+30.348 16.889 30.593 17.806 30.179 18.524 c
+s
+21.679 31.524 m
+21.265 32.241 20.348 32.487 19.63 32.073 c
+18.913 31.658 18.667 30.741 19.081 30.024 c
+19.495 29.306 20.413 29.06 21.13 29.475 c
+21.848 29.889 22.093 30.806 21.679 31.524 c
+s
+37.914 33.399 m
+37.5 34.116 36.583 34.362 35.865 33.948 c
+35.148 33.533 34.902 32.616 35.316 31.899 c
+35.73 31.181 36.648 30.935 37.365 31.35 c
+38.083 31.764 38.328 32.681 37.914 33.399 c
+s
+28.929 45.024 m
+28.515 45.741 27.598 45.987 26.88 45.573 c
+26.163 45.158 25.917 44.241 26.331 43.524 c
+26.745 42.806 27.663 42.56 28.38 42.975 c
+29.098 43.389 29.343 44.306 28.929 45.024 c
+s
+12.429 45.524 m
+12.015 46.241 11.098 46.487 10.38 46.073 c
+9.663 45.658 9.417 44.741 9.831 44.024 c
+10.245 43.306 11.163 43.06 11.88 43.475 c
+12.598 43.889 12.843 44.806 12.429 45.524 c
+s
+44.49 45.6 m
+44.075 46.317 43.158 46.563 42.441 46.149 c
+41.723 45.734 41.477 44.817 41.891 44.1 c
+42.306 43.382 43.223 43.136 43.941 43.55 c
+44.658 43.965 44.904 44.882 44.49 45.6 c
+s
+12.679 18.524 m
+12.265 19.241 11.348 19.487 10.63 19.073 c
+9.913 18.658 9.667 17.741 10.081 17.024 c
+10.495 16.306 11.413 16.06 12.13 16.475 c
+12.848 16.889 13.093 17.806 12.679 18.524 c
+s
+21.179 5.774 m
+20.765 6.491 19.848 6.737 19.13 6.323 c
+18.413 5.908 18.167 4.991 18.581 4.274 c
+18.995 3.557 19.913 3.311 20.63 3.725 c
+21.348 4.139 21.593 5.056 21.179 5.774 c
+s
+38.929 5.274 m
+38.515 5.991 37.598 6.237 36.88 5.823 c
+36.163 5.408 35.917 4.491 36.331 3.774 c
+36.745 3.057 37.663 2.811 38.38 3.225 c
+39.098 3.639 39.343 4.556 38.929 5.274 c
+s
+43.865 18.1 m
+44.694 18.1 45.365 17.429 45.365 16.6 c
+45.365 15.772 44.694 15.1 43.865 15.1 c
+43.037 15.1 42.365 15.772 42.365 16.6 c
+42.365 17.429 43.037 18.1 43.865 18.1 c
+s
+51.13 4.6 m
+50.302 4.6 49.63 3.928 49.63 3.1 c
+49.63 2.272 50.302 1.6 51.13 1.6 c
+51.959 1.6 52.63 2.272 52.63 3.1 c
+52.63 3.928 51.959 4.6 51.13 4.6 c
+s
+52.163 31.649 m
+51.748 32.366 50.831 32.612 50.114 32.198 c
+49.396 31.783 49.15 30.866 49.565 30.149 c
+49.979 29.431 50.896 29.185 51.614 29.6 c
+52.331 30.014 52.577 30.931 52.163 31.649 c
+s
+51.85 51.35 m
+51.021 51.35 50.35 50.678 50.35 49.85 c
+50.35 49.021 51.021 48.35 51.85 48.35 c
+52.678 48.35 53.35 49.021 53.35 49.85 c
+53.35 50.678 52.678 51.35 51.85 51.35 c
+s
+49.85 23.1 m
+50.679 23.1 51.35 22.428 51.35 21.6 c
+51.35 20.771 50.679 20.1 49.85 20.1 c
+49.022 20.1 48.35 20.771 48.35 21.6 c
+48.35 22.428 49.022 23.1 49.85 23.1 c
+s
+5.13 38.85 m
+4.302 38.85 3.63 39.521 3.63 40.35 c
+3.63 41.178 4.302 41.85 5.13 41.85 c
+5.959 41.85 6.63 41.178 6.63 40.35 c
+6.63 39.521 5.959 38.85 5.13 38.85 c
+s
+5.115 11.349 m
+5.943 11.349 6.615 12.021 6.615 12.849 c
+6.615 13.678 5.943 14.349 5.115 14.349 c
+4.286 14.349 3.615 13.678 3.615 12.849 c
+3.615 12.021 4.286 11.349 5.115 11.349 c
+s
+4.38 4.6 m
+3.552 4.6 2.88 3.928 2.88 3.1 c
+2.88 2.272 3.552 1.6 4.38 1.6 c
+5.209 1.6 5.88 2.272 5.88 3.1 c
+5.88 3.928 5.209 4.6 4.38 4.6 c
+s
+5.413 31.649 m
+4.998 32.366 4.081 32.612 3.364 32.198 c
+2.646 31.783 2.4 30.866 2.815 30.149 c
+3.229 29.431 4.146 29.185 4.864 29.6 c
+5.581 30.014 5.827 30.931 5.413 31.649 c
+s
+5.1 51.35 m
+4.271 51.35 3.6 50.678 3.6 49.85 c
+3.6 49.021 4.271 48.35 5.1 48.35 c
+5.928 48.35 6.6 49.021 6.6 49.85 c
+6.6 50.678 5.928 51.35 5.1 51.35 c
+s
+3.1 23.1 m
+3.929 23.1 4.6 22.428 4.6 21.6 c
+4.6 20.771 3.929 20.1 3.1 20.1 c
+2.272 20.1 1.6 20.771 1.6 21.6 c
+1.6 22.428 2.272 23.1 3.1 23.1 c
+s
+21.194 59.775 m
+20.78 60.492 19.863 60.738 19.145 60.324 c
+18.428 59.909 18.182 58.992 18.596 58.275 c
+19.01 57.558 19.928 57.312 20.645 57.726 c
+21.363 58.14 21.608 59.057 21.194 59.775 c
+s
+38.944 59.275 m
+38.53 59.992 37.613 60.238 36.895 59.824 c
+36.178 59.409 35.932 58.492 36.346 57.775 c
+36.76 57.058 37.678 56.812 38.395 57.226 c
+39.113 57.64 39.358 58.557 38.944 59.275 c
+s
+51.145 58.601 m
+50.317 58.601 49.645 57.929 49.645 57.101 c
+49.645 56.273 50.317 55.601 51.145 55.601 c
+51.974 55.601 52.645 56.273 52.645 57.101 c
+52.645 57.929 51.974 58.601 51.145 58.601 c
+s
+4.395 58.601 m
+3.567 58.601 2.895 57.929 2.895 57.101 c
+2.895 56.273 3.567 55.601 4.395 55.601 c
+5.224 55.601 5.895 56.273 5.895 57.101 c
+5.895 57.929 5.224 58.601 4.395 58.601 c
+s
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Rope.side)
+(Rope.side) 1 4.6 60.9998 33.3999 [
+%AI3_Tile
+(0 O 0 R  0 0 0 1 k
+ 0 0 0 1 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+1 J 1 j 0.6 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+24.9999 7 m
+15.6521 4.663 8.125 8.6981 1 14.1407 C
+S
+36.9999 7 m
+22.3477 3.337 12.168 15.3276 1 23.859 C
+S
+48.9999 7 m
+29.3464 2.0866 17.7386 25.3332 1 30.6213 C
+S
+1 30.9999 m
+24.9999 36.9999 36.9999 1 60.9998 7 C
+S
+13 30.9999 m
+32.6534 35.9133 44.2611 12.6667 60.9998 7.3786 C
+S
+24.9999 30.9999 m
+39.652 34.6629 49.8317 22.6722 60.9998 14.1407 C
+S
+36.9999 30.9999 m
+46.3476 33.3369 53.8749 29.3018 60.9998 23.859 C
+S
+48.9999 30.9999 m
+53.3464 32.0865 57.2978 31.7908 60.9998 30.6213 C
+S
+13 7 m
+8.6535 5.9134 4.7019 6.2091 1 7.3786 C
+S
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Scales)
+(Scales) 1.6 9.3475 48.088 55.8355 [
+%AI3_Tile
+(0 O 0 R  1 g
+ 1 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+1.6 9.3475 m
+1.6 55.8355 L
+48.088 55.8355 L
+48.088 9.3475 L
+1.6 9.3475 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 g
+ 0 G
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+17.0956 9.3475 m
+12.8162 9.3475 9.3475 5.8787 9.3475 1.6 C
+9.3475 5.8787 5.8787 9.3475 1.6 9.3475 C
+1.6 13.6262 5.0687 17.095 9.3475 17.095 c
+13.6268 17.095 17.0956 13.6262 17.0956 9.3475 C
+s
+32.5918 9.3475 m
+28.3125 9.3475 24.8437 5.8787 24.8437 1.6 C
+24.8437 5.8787 21.3743 9.3475 17.0956 9.3475 C
+17.0956 13.6262 20.5644 17.095 24.8437 17.095 c
+29.1224 17.095 32.5918 13.6262 32.5918 9.3475 C
+s
+48.088 9.3475 m
+43.8087 9.3475 40.3399 5.8787 40.3399 1.6 C
+40.3399 5.8787 36.8705 9.3475 32.5918 9.3475 C
+32.5918 13.6262 36.0606 17.095 40.3399 17.095 c
+44.6186 17.095 48.088 13.6262 48.088 9.3475 C
+s
+17.0956 40.3393 m
+12.8162 40.3393 9.3475 36.8699 9.3475 32.5912 C
+9.3475 36.8699 5.8787 40.3393 1.6 40.3393 C
+1.6 44.6181 5.0687 48.0874 9.3475 48.0874 c
+13.6268 48.0874 17.0956 44.6181 17.0956 40.3393 C
+s
+17.0956 24.8431 m
+12.8162 24.8431 9.3475 21.3743 9.3475 17.095 C
+9.3475 21.3743 5.8787 24.8431 1.6 24.8431 C
+1.6 29.1218 5.0687 32.5912 9.3475 32.5912 c
+13.6268 32.5912 17.0956 29.1218 17.0956 24.8431 C
+s
+32.5918 24.8431 m
+28.3125 24.8431 24.8437 21.3743 24.8437 17.095 C
+24.8437 21.3743 21.3743 24.8431 17.0956 24.8431 C
+17.0956 29.1218 20.5644 32.5912 24.8437 32.5912 c
+29.1224 32.5912 32.5918 29.1218 32.5918 24.8431 C
+s
+48.088 24.8431 m
+43.8087 24.8431 40.3399 21.3743 40.3399 17.095 C
+40.3399 21.3743 36.8705 24.8431 32.5918 24.8431 C
+32.5918 29.1218 36.0606 32.5912 40.3399 32.5912 c
+44.6186 32.5912 48.088 29.1218 48.088 24.8431 C
+s
+32.5918 40.3393 m
+28.3125 40.3393 24.8437 36.8699 24.8437 32.5912 C
+24.8437 36.8699 21.3743 40.3393 17.0956 40.3393 C
+17.0956 44.6181 20.5644 48.0874 24.8437 48.0874 c
+29.1224 48.0874 32.5918 44.6181 32.5918 40.3393 C
+s
+48.088 40.3393 m
+43.8087 40.3393 40.3399 36.8699 40.3399 32.5912 C
+40.3399 36.8699 36.8705 40.3393 32.5918 40.3393 C
+32.5918 44.6181 36.0606 48.0874 40.3399 48.0874 c
+44.6186 48.0874 48.088 44.6181 48.088 40.3393 C
+s
+17.0956 55.8355 m
+12.8162 55.8355 9.3475 52.3662 9.3475 48.0874 C
+9.3475 52.3662 5.8787 55.8355 1.6 55.8355 C
+1.6 60.1143 5.0687 63.5836 9.3475 63.5836 c
+13.6268 63.5836 17.0956 60.1143 17.0956 55.8355 C
+s
+32.5918 55.8355 m
+28.3125 55.8355 24.8437 52.3662 24.8437 48.0874 C
+24.8437 52.3662 21.3743 55.8355 17.0956 55.8355 C
+17.0956 60.1143 20.5644 63.5836 24.8437 63.5836 c
+29.1224 63.5836 32.5918 60.1143 32.5918 55.8355 C
+s
+48.088 55.8355 m
+43.8087 55.8355 40.3399 52.3662 40.3399 48.0874 C
+40.3399 52.3662 36.8705 55.8355 32.5918 55.8355 C
+32.5918 60.1143 36.0606 63.5836 40.3399 63.5836 c
+44.6186 63.5836 48.088 60.1143 48.088 55.8355 C
+s
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (SolidStar.side)
+(SolidStar.side) 1 1 33.0117 33.0117 [
+%AI3_Tile
+(0 O 0 R  0.05 0.2 0.95 0 k
+ 0.05 0.2 0.95 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+1 D
+0 XR
+7.9689 26.0458 m
+14.5331 22.9874 l
+17.0095 29.7904 L
+19.4859 22.9874 l
+26.0473 26.0458 l
+22.9889 19.4815 l
+29.792 17.0052 l
+22.9889 14.5288 l
+26.0473 7.9674 l
+19.4859 11.0257 l
+17.0095 4.2226 l
+14.5305 11.0257 l
+7.9689 7.9674 l
+11.0273 14.5288 l
+4.2242 17.0052 l
+11.0273 19.4843 L
+7.9689 26.0458 l
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Stars)
+(Stars) 1 1 63.384 84.766 [
+%AI3_Tile
+(0 O 0 R  1 0.9 0.1 0 k
+ 1 0.9 0.1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.3 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+1 1 m
+1 84.766 L
+63.384 84.766 L
+63.384 1 L
+1 1 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0.25 1 0 k
+ 0 0.25 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+*u
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+37.668 67.113 m
+43.924 62.567 L
+41.535 55.213 L
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+f
+16.596 59.757 m
+22.851 55.212 L
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+f
+20.462 20.683 m
+26.719 25.229 L
+18.985 25.229 L
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+f
+38.447 34.271 m
+36.058 41.625 L
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+f
+51.657 20.683 m
+57.914 25.229 L
+50.18 25.229 L
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+f
+*U
+1 XR
+34.581 4.288 m
+32.192 11.643 L
+29.803 4.289 L
+22.069 4.289 L
+26.5962 1 L
+37.7885 1 L
+42.315 4.288 L
+34.581 4.288 L
+f
+53.261 4.289 m
+57.7882 1 L
+63.384 1 L
+63.384 11.643 L
+60.995 4.289 L
+53.261 4.289 L
+f
+4.866 41.625 m
+11.123 46.171 L
+3.389 46.171 L
+1 53.526 L
+1 38.816 L
+7.255 34.271 L
+4.866 41.625 L
+f
+36.058 41.625 m
+42.315 46.171 L
+34.581 46.171 L
+32.192 53.526 L
+29.803 46.172 L
+22.069 46.172 L
+28.325 41.626 L
+25.936 34.272 L
+32.192 38.816 L
+38.447 34.271 L
+36.058 41.625 L
+f
+53.261 46.172 m
+59.517 41.626 L
+57.128 34.272 L
+63.384 38.816 L
+63.384 53.526 L
+60.995 46.172 L
+53.261 46.172 L
+f
+4.866 83.508 m
+6.5974 84.766 L
+1 84.766 L
+1 80.699 L
+7.255 76.154 L
+4.866 83.508 L
+f
+25.936 76.155 m
+32.192 80.699 L
+38.447 76.154 L
+36.058 83.508 L
+37.7895 84.766 L
+26.5951 84.766 L
+28.325 83.509 L
+25.936 76.155 L
+f
+22.851 55.212 m
+20.462 62.566 L
+26.719 67.112 L
+18.985 67.112 L
+16.596 74.467 L
+14.207 67.113 L
+6.473 67.113 L
+12.729 62.567 L
+10.34 55.213 L
+16.596 59.757 L
+22.851 55.212 L
+f
+41.535 55.213 m
+47.791 59.757 L
+54.046 55.212 L
+51.657 62.566 L
+57.914 67.112 L
+50.18 67.112 L
+47.791 74.467 L
+45.402 67.113 L
+37.668 67.113 L
+43.924 62.567 L
+41.535 55.213 L
+f
+50.18 25.229 m
+47.791 32.584 L
+45.402 25.23 L
+37.668 25.23 L
+43.924 20.684 L
+41.535 13.33 L
+47.791 17.874 L
+54.046 13.329 L
+51.657 20.683 L
+57.914 25.229 L
+50.18 25.229 L
+f
+18.985 25.229 m
+16.596 32.584 L
+14.207 25.23 L
+6.473 25.23 L
+12.729 20.684 L
+10.34 13.33 L
+16.596 17.874 L
+22.851 13.329 L
+20.462 20.683 L
+26.719 25.229 L
+18.985 25.229 L
+f
+3.388 4.289 m
+1 11.643 L
+1 1 L
+6.5948 1 L
+11.122 4.289 L
+3.388 4.289 L
+f
+57.128 76.154 m
+63.384 80.699 L
+63.384 84.766 L
+57.7855 84.766 L
+59.517 83.508 L
+57.128 76.154 L
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Stripes)
+(Stripes) 8.45 4.6001 80.45 76.6001 [
+%AI3_Tile
+(0 O 0 R  1 0.07 1 0 k
+ 1 0.07 1 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 3.6 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+8.2 8.2 m
+80.7 8.2 L
+S
+8.2 22.6001 m
+80.7 22.6001 L
+S
+8.2 37.0002 m
+80.7 37.0002 L
+S
+8.2 51.4 m
+80.7 51.4 L
+S
+8.2 65.8001 m
+80.7 65.8001 L
+S
+8.2 15.4 m
+80.7 15.4 L
+S
+8.2 29.8001 m
+80.7 29.8001 L
+S
+8.2 44.2 m
+80.7 44.2 L
+S
+8.2 58.6001 m
+80.7 58.6001 L
+S
+8.2 73.0002 m
+80.7 73.0002 L
+S
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (TriBevel.outer)
+(TriBevel.outer) 1 1.0004 31.6124 31.6127 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+31.6118 5.4917 m
+27.1221 5.4917 L
+27.1205 1.0011 L
+27.8031 1.0011 L
+27.8031 4.8091 L
+31.6118 4.8091 L
+31.6118 5.4917 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+31.6149 9.5062 m
+23.1111 9.5062 L
+23.1111 1.0015 L
+27.1205 1.0015 L
+27.1205 5.493 L
+31.6144 5.493 L
+31.6149 9.5062 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+31.6124 10.485 m
+22.1297 10.485 L
+22.1292 1.0015 L
+23.1084 1.0015 L
+23.1084 9.5049 L
+31.6124 9.5049 L
+31.6124 10.485 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+31.6129 17.2066 m
+15.4064 17.2085 L
+15.4064 1 L
+22.1301 1 L
+22.1301 10.4868 L
+31.6129 10.4868 L
+31.6129 17.2066 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+31.6149 18.3658 m
+14.2517 18.3658 L
+14.2515 1.0009 L
+15.4043 1.0009 L
+15.4043 17.2093 L
+31.6149 17.2093 L
+31.6149 18.3658 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+31.6124 30.4755 m
+2.1395 30.4755 L
+2.1395 1.0015 L
+14.249 1 L
+14.249 18.366 L
+31.6149 18.366 L
+31.6124 30.4755 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.6 k
+ 0 0 0 0.6 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+15.4066 16.847 m
+14.2778 18.3257 l
+15.4066 17.2057 l
+15.4066 16.847 l
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+23.1095 9.1906 m
+22.1759 10.4392 l
+23.1082 9.505 l
+23.1095 9.1906 l
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+27.8039 4.6026 m
+27.1619 5.4533 l
+27.8029 4.8093 l
+27.8039 4.6026 l
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (TriBevel.side)
+(TriBevel.side) 1.0006 1 29.0006 31.6124 [
+%AI3_Tile
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+29 4.8087 m
+29 4.8087 L
+29.0026 5.4927 L
+1.0026 5.4927 L
+1 4.8087 L
+1 4.8087 L
+29 4.8087 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.2 k
+ 0 0 0 0.2 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+29.0026 5.4927 m
+29.0005 9.5045 L
+1.0005 9.5045 L
+1.0026 5.4927 L
+29.0026 5.4927 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+29.0005 9.5045 m
+29.0011 10.4865 L
+1.0011 10.4865 L
+1.0005 9.5045 L
+29.0005 9.5045 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.3 k
+ 0 0 0 0.3 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+29.0011 10.4865 m
+29.003 17.209 L
+1.003 17.209 L
+1.0011 10.4865 L
+29.0011 10.4865 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.5 k
+ 0 0 0 0.5 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+29.003 17.209 m
+29.0031 18.3656 L
+1.0031 18.3656 L
+1.003 17.209 L
+29.003 17.209 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0 0 0 0.4 k
+ 0 0 0 0.4 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+29.0031 18.3656 m
+29.0006 30.4752 L
+1.0006 30.4752 L
+1.0031 18.3656 L
+29.0031 18.3656 L
+f
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI3_BeginPattern: (Waves-scroll)
+(Waves-scroll) 17.926 10.516 68.663 69.012 [
+%AI3_Tile
+(0 O 0 R  1 0 0.3 0 k
+ 1 0 0.3 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+1 D
+0 XR
+17.926 69.012 m
+17.926 10.516 L
+68.663 10.516 L
+68.663 69.012 L
+17.926 69.012 L
+f
+%AI6_EndPatternLayer
+) &
+(0 O 0 R  0.55 0 0 0 k
+ 0.55 0 0 0 K
+) @
+(
+%AI6_BeginPatternLayer
+800 Ar
+0 J 0 j 0.75 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+65.335 70.465 m
+65.881 68.746 67.444 68.168 68.663 69.012 C
+67.538 69.668 68.011 71.255 69.686 70.933 c
+72.124 70.464 71.894 67.213 70.53 65.589 c
+68.561 63.245 64.565 60.995 53.241 71.117 C
+S
+39.964 70.465 m
+40.511 68.746 42.074 68.168 43.293 69.012 C
+42.168 69.668 42.64 71.255 44.316 70.933 c
+46.753 70.464 46.524 67.213 45.16 65.589 c
+43.191 63.245 39.195 60.995 27.87 71.117 c
+S
+14.594 70.465 m
+15.141 68.746 16.704 68.168 17.923 69.012 C
+16.798 69.668 17.27 71.255 18.945 70.933 c
+21.382 70.464 21.153 67.213 19.789 65.589 c
+17.821 63.245 13.825 60.995 2.5 71.117 c
+S
+10.959 51.619 m
+22.282 41.497 26.278 43.747 28.247 46.09 c
+29.611 47.715 29.841 50.965 27.403 51.434 c
+25.728 51.757 25.255 50.169 26.38 49.513 C
+25.161 48.669 23.599 49.248 23.052 50.966 c
+22.723 51.997 23.38 53.966 24.872 54.903 c
+27.267 56.406 31.371 56.05 36.328 51.619 c
+47.653 41.497 51.649 43.746 53.618 46.09 c
+54.982 47.715 55.212 50.965 52.774 51.434 c
+51.099 51.757 50.626 50.169 51.751 49.513 C
+50.532 48.669 48.97 49.248 48.423 50.966 c
+48.094 51.997 48.751 53.966 50.243 54.903 c
+52.638 56.406 56.742 56.05 61.699 51.619 C
+73.024 41.497 77.02 43.747 78.988 46.09 c
+S
+70.156 32.12 m
+65.199 36.551 61.095 36.907 58.7 35.404 c
+57.208 34.468 56.552 32.499 56.88 31.468 c
+57.427 29.749 58.99 29.171 60.208 30.015 C
+59.083 30.671 59.556 32.258 61.231 31.936 c
+63.669 31.467 63.439 28.216 62.075 26.592 c
+60.106 24.248 56.11 21.998 44.786 32.12 C
+39.829 36.551 35.725 36.907 33.33 35.404 c
+31.838 34.468 31.182 32.499 31.51 31.468 c
+32.056 29.749 33.619 29.171 34.838 30.015 C
+33.713 30.671 34.186 32.258 35.861 31.936 c
+38.299 31.467 38.069 28.216 36.705 26.592 c
+34.737 24.248 30.74 21.998 19.415 32.12 c
+14.458 36.551 10.354 36.907 7.96 35.404 c
+S
+19.792 7.094 m
+21.157 8.719 21.386 11.968 18.949 12.437 c
+17.274 12.76 16.801 11.172 17.926 10.516 C
+16.708 9.673 15.145 10.252 14.598 11.969 c
+14.27 13 14.926 14.969 16.418 15.906 c
+18.812 17.409 22.916 17.053 27.874 12.622 c
+39.199 2.5 43.195 4.75 45.163 7.094 c
+46.528 8.719 46.757 11.968 44.32 12.437 c
+42.644 12.76 42.172 11.172 43.297 10.516 C
+42.078 9.673 40.515 10.252 39.968 11.969 c
+39.64 13 40.297 14.969 41.788 15.906 c
+44.183 17.409 48.287 17.053 53.245 12.622 C
+64.569 2.5 68.565 4.75 70.534 7.094 c
+71.898 8.719 72.127 11.968 69.69 12.437 c
+68.014 12.76 67.542 11.172 68.667 10.516 C
+67.448 9.673 65.885 10.252 65.338 11.969 c
+65.011 13 65.667 14.969 67.159 15.906 c
+69.553 17.409 73.657 17.053 78.615 12.622 c
+S
+%AI6_EndPatternLayer
+) &
+] E
+%AI3_EndPattern
+%AI5_End_NonPrinting--
+%AI5_Begin_NonPrinting
+Np
+12 Bn
+%AI5_BeginGradient: (Black, White)
+(Black, White) 0 2 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Chrome)
+(Chrome) 0 6 Bd
+[
+0
+<
+464646454545444444444343434342424241414141404040403F3F3F3E3E3E3E3D3D3D3C3C3C3C3B
+3B3B3B3A3A3A39393939383838383737373636363635353535343434333333333232323131313130
+3030302F2F2F2E2E2E2E2D2D2D2D2C2C2C2B2B2B2B2A2A2A2A292929282828282727272726262625
+2525252424242323232322222222212121202020201F1F1F1F1E1E1E1D1D1D1D1C1C1C1B1B1B1B1A
+1A1A1A1919191818181817171717161616151515151414141413131312121212111111101010100F
+0F0F0F0E0E0E0D0D0D0D0C0C0C0C0B0B0B0A0A0A0A09090909080808070707070606060505050504
+04040403030302020202010101010000
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+1F1E1E1E1E1E1E1E1E1E1D1D1D1D1D1D1D1D1C1C1C1C1C1C1C1C1B1B1B1B1B1B1B1B1B1A1A1A1A1A
+1A1A1A19191919191919191818181818181818181717171717171717161616161616161615151515
+15151515151414141414141414131313131313131312121212121212121211111111111111111010
+1010101010100F0F0F0F0F0F0F0F0F0E0E0E0E0E0E0E0E0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C
+0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A090909090909090909080808080808080807070707070707
+07060606060606060606050505050505050504040404040404040303030303030303030202020202
+02020201010101010101010000000000
+>
+1 %_Br
+0
+0.275
+1
+<
+6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544
+434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F
+>
+1 %_Br
+0
+<
+00000101010102020202030303040404040505050506060607070707080808090909090A0A0A0A0B
+0B0B0C0C0C0C0D0D0D0D0E0E0E0F0F0F0F1010101011111112121212131313141414141515151516
+161617171717181818181919191A1A1A1A1B1B1B1B1C1C1C1D1D1D1D1E1E1E1F1F1F1F2020202021
+212122222222232323232424242525252526262627272727282828282929292A2A2A2A2B2B2B2B2C
+2C2C2D2D2D2D2E2E2E2E2F2F2F303030303131313132323233333333343434353535353636363637
+373738383838393939393A3A3A3B3B3B3B3C3C3C3C3D3D3D3E3E3E3E3F3F3F404040404141414142
+42424343434344444444454545464646
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+00000101020203030304040505050606070708080809090A0A0A0B0B0C0C0D0D0D0E0E0F0F101010
+1111121212131314141515151616171718181819191A1A1A1B1B1C1C1D1D1D1E1E1F1F1F20202121
+222222232324242525252626272727282829292A2A2A2B2B2C2C2D2D2D2E2E2F2F2F303031313232
+32333334343435353636373737383839393A3A3A3B3B3C3C3C3D3D3E3E3F3F3F4040414142424243
+4344444445454646474747484849494A4A4A4B4B4C4C4C4D4D4E4E4F4F4F50505151515252535354
+54545555565657575758585959595A5A5B5B5C5C5C5D5D5E5E5F5F5F606061616162626363646464
+6565666666676768686969696A6A6B6B
+>
+1 %_Br
+1
+0 %_Br
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+4D4C4C4C4B4B4B4A4A4A4A4949494848484747474746464645454544444444434343424242414141
+414040403F3F3F3E3E3E3E3D3D3D3C3C3C3B3B3B3B3A3A3A39393938383838373737363636353535
+35343434333333323232323131313030302F2F2F2F2E2E2E2D2D2D2C2C2C2C2B2B2B2A2A2A292929
+292828282727272626262625252524242423232323222222212121202020201F1F1F1E1E1E1D1D1D
+1D1C1C1C1B1B1B1A1A1A1A1919191818181717171716161615151514141414131313121212111111
+111010100F0F0F0E0E0E0E0D0D0D0C0C0C0B0B0B0B0A0A0A09090908080808070707060606050505
+05040404030303020202020101010000
+>
+0
+0
+1 %_Br
+[
+1 0 50 92 %_Bs
+0 0.275 1 0.12 1 50 59 %_Bs
+0 0.275 1 0.42 1 50 50 %_Bs
+1 0 50 49 %_Bs
+1 0 50 41 %_Bs
+1 0.3 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Green, Blue)
+(Green, Blue) 0 2 Bd
+[
+<
+99999A9A9B9B9B9C9C9D9D9D9E9E9F9F9FA0A0A1A1A1A2A2A3A3A3A4A4A5A5A5A6A6A7A7A7A8A8A9
+A9A9AAAAABABABACACADADADAEAEAFAFAFB0B0B1B1B1B2B2B3B3B3B4B4B5B5B5B6B6B7B7B7B8B8B9
+B9B9BABABBBBBBBCBCBDBDBDBEBEBFBFBFC0C0C1C1C1C2C2C3C3C3C4C4C5C5C5C6C6C7C7C7C8C8C9
+C9C9CACACBCBCBCCCCCDCDCDCECECFCFCFD0D0D1D1D1D2D2D3D3D3D4D4D5D5D5D6D6D7D7D7D8D8D9
+D9D9DADADBDBDBDCDCDDDDDDDEDEDFDFDFE0E0E1E1E1E2E2E3E3E3E4E4E5E5E5E6E6E7E7E7E8E8E9
+E9E9EAEAEBEBEBECECEDEDEDEEEEEFEFEFF0F0F1F1F1F2F2F3F3F3F4F4F5F5F5F6F6F7F7F7F8F8F9
+F9F9FAFAFBFBFBFCFCFDFDFDFEFEFFFF
+>
+<
+000102020304050506070808090A0B0B0C0D0E0E0F101111121314141516171718191A1A1B1C1D1D
+1E1F20202122232324252626272829292A2B2C2C2D2E2F2F303132323334353536373838393A3B3B
+3C3D3E3E3F404141424344444546474748494A4A4B4C4D4D4E4F5050515253535455565657585959
+5A5B5C5C5D5E5F5F606162626364656566676868696A6B6B6C6D6E6E6F7071717273747475767777
+78797A7A7B7C7D7D7E7F80808182828384858586878888898A8B8B8C8D8E8E8F9091919293949495
+96979798999A9A9B9C9D9D9E9FA0A0A1A2A3A3A4A5A6A6A7A8A9A9AAABACACADAEAFAFB0B1B2B2B3
+B4B5B5B6B7B8B8B9BABBBBBCBDBEBEBF
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+[
+1 0.75 0 0 1 50 100 %_Bs
+0.6 0 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Orange, Green, Violet)
+(Orange, Green, Violet) 0 3 Bd
+[
+<
+F0EFEFEFEEEEEEEDEDEDECECECEBEBEBEAEAEAE9E9E9E8E8E8E7E7E7E6E6E6E5E5E5E4E4E4E3E3E3
+E3E2E2E2E1E1E1E0E0E0DFDFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADAD9D9D9D8D8D8D7D7D7D6D6D6
+D5D5D5D4D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCCCCCBCBCBCACACAC9C9C9C8
+C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C1C0C0C0BFBFBFBEBEBEBDBDBDBCBCBCBB
+BBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B2B1B1B1B0B0B0AFAFAFAEAE
+AEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A7A6A6A6A5A5A5A4A4A4A3A3A3A2A2A2A1A1A1
+A0A0A0A09F9F9F9E9E9E9D9D9D9C9C9C
+>
+<
+5455555657575859595A5A5B5C5C5D5E5E5F5F6061616263636465656666676868696A6A6B6B6C6D
+6D6E6F6F707171727273747475767677777879797A7B7B7C7C7D7E7E7F8080818282838384858586
+87878888898A8A8B8C8C8D8D8E8F8F909191929393949495969697989899999A9B9B9C9D9D9E9E9F
+A0A0A1A2A2A3A4A4A5A5A6A7A7A8A9A9AAAAABACACADAEAEAFB0B0B1B1B2B3B3B4B5B5B6B6B7B8B8
+B9BABABBBBBCBDBDBEBFBFC0C1C1C2C2C3C4C4C5C6C6C7C7C8C9C9CACBCBCCCCCDCECECFD0D0D1D2
+D2D3D3D4D5D5D6D7D7D8D8D9DADADBDCDCDDDDDEDFDFE0E1E1E2E3E3E4E4E5E6E6E7E8E8E9E9EAEB
+EBECEDEDEEEFEFF0F0F1F2F2F3F4F4F5
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000000000101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020303030303
+>
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0
+>
+<
+A1A0A0A09F9F9F9E9E9E9D9D9D9D9C9C9C9B9B9B9A9A9A9999999898989797979696969595959594
+94949393939292929191919090908F8F8F8E8E8E8E8D8D8D8C8C8C8B8B8B8A8A8A89898988888887
+878787868686858585848484838383828282818181808080807F7F7F7E7E7E7D7D7D7C7C7C7B7B7B
+7A7A7A79797978787878777777767676757575747474737373727272717171717070706F6F6F6E6E
+6E6D6D6D6C6C6C6B6B6B6A6A6A6A6969696868686767676666666565656464646363636262626261
+61616060605F5F5F5E5E5E5D5D5D5C5C5C5B5B5B5B5A5A5A59595958585857575756565655555554
+54
+>
+<
+F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6F6
+F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F7F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8F8
+F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFA
+FAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFDFD
+FDFDFDFDFDFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFFFFFFFFFFFFFFFFFFFFFF
+FF
+>
+0
+1 %_Br
+[
+0.61 0.96 0 0.01 1 50 100 %_Bs
+0.94 0.33 1 0 1 50 50 %_Bs
+0 0.63 0.96 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Pink, Yellow, Green )
+(Pink, Yellow, Green ) 0 3 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4D4E4F50
+5152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717273
+>
+<
+05050505050505050505050505050404040404040404040404040404040404040404040403030303
+03030303030303030303030303030303030303020202020202020202020202020202020202020202
+0201010101010101010101010101010101010101010101000000000000000000000000
+>
+<
+CCCCCCCCCCCBCBCBCBCBCBCBCBCBCACACACACACACACACAC9C9C9C9C9C9C9C9C9C8C8C8C8C8C8C8C8
+C8C7C7C7C7C7C7C7C7C7C6C6C6C6C6C6C6C6C6C5C5C5C5C5C5C5C5C5C4C4C4C4C4C4C4C4C3C3C3C3
+C3C3C3C3C3C2C2C2C2C2C2C2C2C2C1C1C1C1C1C1C1C1C1C0C0C0C0C0C0C0C0C0BFBFBF
+>
+0
+1 %_Br
+<
+0D0D0D0D0D0D0D0D0D0D0D0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0C0B
+0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0B0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A0A
+0A0A0A09090909090909090909090909090909090909090808080808080808080808080808080808
+08080807070707070707070707070707070707070706060606060606060606060606060606060605
+05050505050505050505050505050505050404040404040404040404040404040404030303030303
+03030303030303030303030202020202020202020202020202020201010101010101010101010101
+010101000000000000000000
+>
+<
+B2B2B2B2B1B1B1B0B0B0AFAFAEAEAEADADACACABABAAAAA9A9A8A8A7A7A6A6A5A5A4A4A3A3A2A2A1
+A0A09F9F9E9E9D9D9C9B9B9A9A999898979796959594949392929190908F8F8E8D8D8C8B8B8A8989
+88888786868584848382828180807F7E7D7D7C7B7B7A7979787777767575747372727170706F6E6D
+6D6C6B6B6A69686867666565646363626160605F5E5D5D5C5B5A5A59585757565554545352515150
+4F4E4D4D4C4B4A4A4948474646454443434241403F3F3E3D3C3B3B3A393837373635343333323130
+2F2F2E2D2C2B2B2A2928272726252423222221201F1E1D1D1C1B1A1918181716151413131211100F
+0E0E0D0C0B0A090908070605
+>
+<
+0000010101020202030304040505060607070808090A0A0B0B0C0C0D0E0E0F0F1011111213131415
+151616171818191A1B1B1C1D1D1E1F1F202122222324242526272728292A2A2B2C2C2D2E2F303031
+323333343536363738393A3A3B3C3D3E3E3F4041424243444546464748494A4B4B4C4D4E4F505051
+5253545556565758595A5B5B5C5D5E5F6061626263646566676869696A6B6C6D6E6F707171727374
+75767778797A7B7B7C7D7E7F80818283848586868788898A8B8C8D8E8F9091929394949596979899
+9A9B9C9D9E9FA0A1A2A3A4A5A6A7A8A9AAAAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0
+C1C2C3C4C5C6C7C8C9CACBCC
+>
+0
+1 %_Br
+[
+0.45 0 0.75 0 1 50 100 %_Bs
+0 0.02 0.8 0 1 50 64 %_Bs
+0.05 0.7 0 0 1 57 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Purple, Red, Yellow)
+(Purple, Red, Yellow) 0 3 Bd
+[
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A
+>
+<
+CCCCCCCDCDCDCDCDCECECECECECFCFCFCFD0D0D0D0D0D1D1D1D1D1D2D2D2D2D2D3D3D3D3D3D4D4D4
+D4D5D5D5D5D5D6D6D6D6D6D7D7D7D7D7D8D8D8D8D8D9D9D9D9DADADADADADBDBDBDBDBDCDCDCDCDC
+DDDDDDDDDDDEDEDEDEDFDFDFDFDFE0E0E0E0E0E1E1E1E1E1E2E2E2E2E2E3E3E3E3E4E4E4E4E4E5E5
+E5E5E5E6E6E6E6E6E7E7E7E7E7E8E8E8E8E9E9E9E9E9EAEAEAEAEAEBEBEBEBEBECECECECECEDEDED
+EDEEEEEEEEEEEFEFEFEFEFF0F0F0F0F0F1F1F1F1F1F2F2F2F2F3F3F3F3F3F4F4F4F4F4F5F5F5F5F5
+F6F6F6F6F6F7F7F7F7F8F8F8F8F8F9F9F9F9F9FAFAFAFAFAFBFBFBFBFBFCFCFCFCFDFDFDFDFDFEFE
+FEFEFEFFFFFF
+>
+0
+1 %_Br
+<
+E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBE
+BDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A99989796
+9594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B7A797877767574737271706F6E
+6D6C6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A49484746
+4544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F1E
+1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403020100
+>
+<
+E5E6E6E6E6E6E6E6E6E7E7E7E7E7E7E7E7E7E8E8E8E8E8E8E8E8E8E9E9E9E9E9E9E9E9E9EAEAEAEA
+EAEAEAEAEAEBEBEBEBEBEBEBEBEBECECECECECECECECECEDEDEDEDEDEDEDEDEDEEEEEEEEEEEEEEEE
+EEEFEFEFEFEFEFEFEFEFF0F0F0F0F0F0F0F0F0F1F1F1F1F1F1F1F1F1F2F2F2F2F2F2F2F2F2F3F3F3
+F3F3F3F3F3F3F4F4F4F4F4F4F4F4F4F5F5F5F5F5F5F5F5F5F6F6F6F6F6F6F6F6F6F7F7F7F7F7F7F7
+F7F7F8F8F8F8F8F8F8F8F8F9F9F9F9F9F9F9F9F9FAFAFAFAFAFAFAFAFAFBFBFBFBFBFBFBFBFBFCFC
+FCFCFCFCFCFCFCFDFDFDFDFDFDFDFDFDFEFEFEFEFEFEFEFEFEFFFFFFFFFF
+>
+<
+00010203040405060708090A0B0C0C0D0E0F10111213141415161718191A1B1C1D1D1E1F20212223
+242525262728292A2B2C2D2D2E2F30313233343535363738393A3B3C3D3D3E3F4041424344454546
+4748494A4B4C4D4E4E4F50515253545556565758595A5B5C5D5E5E5F60616263646566666768696A
+6B6C6D6E6E6F70717273747576767778797A7B7C7D7E7F7F80818283848586878788898A8B8C8D8E
+8F8F90919293949596979798999A9B9C9D9E9F9FA0A1A2A3A4A5A6A7A7A8A9AAABACADAEAFAFB0B1
+B2B3B4B5B6B7B8B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C8C9CACBCC
+>
+0
+1 %_Br
+[
+0 0.04 1 0 1 50 100 %_Bs
+0 1 0.8 0 1 50 50 %_Bs
+0.9 0.9 0 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Rainbow)
+(Rainbow) 0 6 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+0
+1 %_Br
+1
+<
+0708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F50515253545556
+5758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F707172737475767778797A7B7C7D7E
+7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A3A4A5A6
+A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACBCCCDCE
+CFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2F3F4F5F6
+F7F8F9FAFBFCFDFEFF
+>
+0
+0
+1 %_Br
+1
+<
+00000000000000000000000000000000000001010101010101010101010101010101010101010101
+01010101010101010101010101010202020202020202020202020202020202020202020202020202
+02020202020202020202030303030303030303030303030303030303030303030303030303030303
+03030303030304040404040404040404040404040404040404040404040404040404040404040404
+04040505050505050505050505050505050505050505050505050505050505050505050505050606
+06060606060606060606060606060606060606060606060606060606060606060606070707070707
+07070707070707070707070707070707
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+1
+0
+1 %_Br
+[
+0 1 0 0 1 50 100 %_Bs
+1 1 0 0 1 50 80 %_Bs
+1 0.0279 0 0 1 50 60 %_Bs
+1 0 1 0 1 50 40 %_Bs
+0 0 1 0 1 50 20 %_Bs
+0 1 1 0 1 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Steel Bar)
+(Steel Bar) 0 3 Bd
+[
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0 %_Br
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0 %_Br
+[
+0 0 50 100 %_Bs
+1 0 50 70 %_Bs
+0 0 50 0 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (White & Red Radial)
+(White & Red Radial) 1 18 Bd
+[
+0
+1
+1
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+0
+1
+1
+0
+1 %_Br
+0
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+<
+FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8
+D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0
+AFAEADACABAAA9A8A7A6A5A4A3A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A8988
+87868584838281807F7E7D7C7B7A797877767574737271706F6E6D6C6B6A69686766656463626160
+5F5E5D5C5B5A595857565554535251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A3938
+37363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A19181716151413121110
+0F0E0D0C0B0A09080706050403020100
+>
+0
+1 %_Br
+1
+0 %_Br
+0
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+0
+1 %_Br
+[
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 0 %_Bs
+0 1 1 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 12.5 %_Bs
+0 0 0 0 1 50 25 %_Bs
+0 1 1 0 1 50 25 %_Bs
+0 1 1 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 37.5 %_Bs
+0 0 0 0 1 50 50 %_Bs
+0 1 1 0 1 50 50 %_Bs
+0 1 1 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 62.5 %_Bs
+0 0 0 0 1 50 75 %_Bs
+0 1 1 0 1 50 75 %_Bs
+0 1 1 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 87.5 %_Bs
+0 0 0 0 1 50 100 %_Bs
+0 1 1 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Yellow & Orange Radial)
+(Yellow & Orange Radial) 1 2 Bd
+[
+0
+<
+0001010203040506060708090A0B0C0C0D0E0F10111213131415161718191A1B1C1D1D1E1F202122
+232425262728292A2B2B2C2D2E2F303132333435363738393A3B3C3D3E3E3F404142434445464748
+494A4B4C4D4E4F505152535455565758595A5B5C5D5E5F60606162636465666768696A6B6C6D6E6F
+707172737475767778797A7B7C7D7E7F808182838485868788898A8B8C
+>
+<
+FFFFFFFFFEFEFEFEFEFEFEFDFDFDFDFDFDFCFCFCFCFCFCFBFBFBFBFBFBFAFAFAFAFAFAF9F9F9F9F9
+F9F8F8F8F8F8F8F7F7F7F7F7F7F6F6F6F6F6F6F5F5F5F5F5F5F4F4F4F4F4F3F3F3F3F3F3F2F2F2F2
+F2F2F1F1F1F1F1F0F0F0F0F0F0EFEFEFEFEFEFEEEEEEEEEEEDEDEDEDEDEDECECECECECEBEBEBEBEB
+EBEAEAEAEAEAE9E9E9E9E9E9E8E8E8E8E8E8E7E7E7E7E7E6E6E6E6E6E5
+>
+0
+1 %_Br
+[
+0 0 1 0 1 52 19 %_Bs
+0 0.55 0.9 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Yellow & Purple Radial)
+(Yellow & Purple Radial) 1 2 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+1415161718191A1B1C1D1E1F1F202122232425262728292A2A2B2C2D2E2F30313233343536363738
+393A3B3C3D3E3F40414142434445464748494A4B4C4D4D4E4F50515253545556575858595A5B5C5D
+5E5F60616263646465666768696A6B6C6D6E6F6F707172737475767778797A7B7B7C7D7E7F808182
+83848586868788898A8B8C8D8E8F90919292939495969798999A9B9C9D9D9E9FA0A1A2A3A4A5A6A7
+A8A9A9AAABACADAEAFB0B1B2B3B4B4B5B6B7B8B9BABBBCBDBEBFC0C0C1C2C3C4C5C6C7C8C9CACBCB
+CCCDCECFD0D1D2D3D4D5D6D7D7D8D9DADBDCDDDEDFE0E1E2E2E3E4E5E6E7E8E9EAEBECEDEEEEEFF0
+F1F2F3F4F5F6F7F8F9F9FAFBFCFDFEFF
+>
+<
+ABAAAAA9A8A7A7A6A5A5A4A3A3A2A1A1A09F9F9E9D9D9C9B9B9A9999989797969595949393929191
+908F8F8E8D8D8C8B8B8A8989888787868585848383828181807F7F7E7D7D7C7B7B7A797978777776
+7575747373727171706F6F6E6D6D6C6B6B6A6969686767666565646362626160605F5E5E5D5C5C5B
+5A5A5958585756565554545352525150504F4E4E4D4C4C4B4A4A4948484746464544444342424140
+403F3E3E3D3C3C3B3A3A3938383736363534343332323130302F2E2E2D2C2C2B2A2A292828272626
+25242423222121201F1F1E1D1D1C1B1B1A1919181717161515141313121111100F0F0E0D0D0C0B0B
+0A090908070706050504030302010100
+>
+0
+1 %_Br
+[
+0 0.08 0.67 0 1 50 14 %_Bs
+1 1 0 0 1 50 100 %_Bs
+BD
+%AI5_EndGradient
+%AI5_BeginGradient: (Yellow, Violet, Orange, Blue)
+(Yellow, Violet, Orange, Blue) 0 4 Bd
+[
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF
+>
+<
+A1A1A1A1A2A2A2A2A3A3A3A3A4A4A4A4A4A5A5A5A5A6A6A6A6A7A7A7A7A8A8A8A8A9A9A9A9AAAAAA
+AAAAABABABABACACACACADADADADAEAEAEAEAFAFAFAFB0B0B0B0B0B1B1B1B1B2B2B2B2B3B3B3B3B4
+B4B4B4B5B5B5B5B6B6B6B6B6B7B7B7B7B8B8B8B8B9B9B9B9BABABABABBBBBBBBBCBCBCBCBCBDBDBD
+BDBEBEBEBEBFBFBFBFC0C0C0C0C1C1C1C1C2C2C2C2C2C3C3C3C3C4C4C4C4C5C5C5C5C6C6C6C6C7C7
+C7C7C8C8C8C8C8C9C9C9C9CACACACACBCBCBCBCCCCCCCCCDCDCDCDCECECECECECFCFCFCFD0D0D0D0
+D1D1D1D1D2D2D2D2D3D3D3D3D4D4D4D4D4D5D5D5D5D6D6D6D6D7D7D7D7D8D8D8D8D9D9D9D9DADADA
+DADADBDBDBDBDCDCDCDCDDDDDDDDDEDE
+>
+<
+F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CF
+CECDCCCCCBCAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B4B3B2B1B0AFAEADACABAAA9
+A8A7A6A5A4A3A2A1A09F9E9D9C9C9B9A999897969594939291908F8E8D8C8B8A8988878685848483
+8281807F7E7D7C7B7A797877767574737271706F6E6D6C6C6B6A696867666564636261605F5E5D5C
+5B5A59585756555454535251504F4E4D4C4B4A494847464544434241403F3E3D3C3C3B3A39383736
+3534333231302F2E2D2C2B2A29282726252424232221201F1E1D1C1B1A191817161514131211100F
+0E0D0C0C0B0A09080706050403020100
+>
+0
+1 %_Br
+<
+9C9B9A9A9998989796969595949393929191908F8F8E8E8D8C8C8B8A8A8989888787868585848383
+82828180807F7E7E7D7C7C7B7B7A797978777776757574747372727170706F6E6E6D6D6C6B6B6A69
+6968676766666564646362626161605F5F5E5D5D5C5B5B5A5A595858575656555454535352515150
+4F4F4E4D4D4C4C4B4A4A4948484746464545444343424141403F3F3E3E3D3C3C3B3A3A3939383737
+36353534333332323130302F2E2E2D2C2C2B2B2A292928272726252524242322222120201F1E1E1D
+1D1C1B1B1A191918171716161514141312121111100F0F0E0D0D0C0B0B0A0A090808070606050404
+030302010100
+>
+<
+F5F4F4F4F3F3F3F2F2F2F1F1F1F0F0F0EFEFEFEEEEEEEDEDEDECECECEBEBEAEAEAE9E9E9E8E8E8E7
+E7E7E6E6E6E5E5E5E4E4E4E3E3E3E2E2E2E1E1E1E0E0E0DFDFDEDEDEDDDDDDDCDCDCDBDBDBDADADA
+D9D9D9D8D8D8D7D7D7D6D6D6D5D5D5D4D4D3D3D3D2D2D2D1D1D1D0D0D0CFCFCFCECECECDCDCDCCCC
+CCCBCBCBCACACAC9C9C8C8C8C7C7C7C6C6C6C5C5C5C4C4C4C3C3C3C2C2C2C1C1C1C0C0C0BFBFBFBE
+BEBEBDBDBCBCBCBBBBBBBABABAB9B9B9B8B8B8B7B7B7B6B6B6B5B5B5B4B4B4B3B3B3B2B2B1B1B1B0
+B0B0AFAFAFAEAEAEADADADACACACABABABAAAAAAA9A9A9A8A8A8A7A7A6A6A6A5A5A5A4A4A4A3A3A3
+A2A2A2A1A1A1
+>
+<
+000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F2021222324252627
+28292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F404142434445464748494A4B4C4D4E4F
+505152535455565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F7071727374757677
+78797A7B7C7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9F
+A0A1A2A3A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7
+C8C9CACBCCCDCECFD0D1D2D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEF
+F0F1F2F3F4F5
+>
+<
+03030303030202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020201010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101000000
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+000000000000
+>
+1 %_Br
+<
+0D0D0E0F0F10101111121313141415161617171819191A1A1B1C1C1D1D1E1E1F2020212122232324
+2425262627272828292A2A2B2B2C2D2D2E2E2F30303131323333343435353637373838393A3A3B3B
+3C3D3D3E3E3F3F404141424243444445454647474848494A4A4B4B4C4C4D4E4E4F4F505151525253
+54545555565757585859595A5B5B5C5C5D5E5E5F5F60616162626363646565666667686869696A6B
+6B6C6C6D6E6E6F6F70707172727373747575767677787879797A7B7B7C7C7D7D7E7F7F8080818282
+8383848585868687878889898A8A8B8C8C8D8D8E8F8F90909192929393949495969697979899999A
+9A9B9C
+>
+<
+08090A0B0C0D0E0F0F101112131415161718191A1B1C1D1E1F202122232425262728292A2B2C2D2E
+2F303132333435363738393A3B3C3D3E3F40404142434445464748494A4B4C4D4E4F505152535455
+565758595A5B5C5D5E5F606162636465666768696A6B6C6D6E6F70717172737475767778797A7B7C
+7D7E7F808182838485868788898A8B8C8D8E8F909192939495969798999A9B9C9D9E9FA0A1A2A2A3
+A4A5A6A7A8A9AAABACADAEAFB0B1B2B3B4B5B6B7B8B9BABBBCBDBEBFC0C1C2C3C4C5C6C7C8C9CACB
+CCCDCECFD0D1D2D3D3D4D5D6D7D8D9DADBDCDDDEDFE0E1E2E3E4E5E6E7E8E9EAEBECEDEEEFF0F1F2
+F3F4F5
+>
+<
+F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCB
+CAC9C8C7C6C5C4C3C2C1C0BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3
+A2A1A09F9E9D9C9B9A999897969594939291908F8E8D8C8B8A898887868584838281807F7E7D7C7B
+7A797877767574737271706F6E6D6C6B6A696867666564636261605F5E5D5C5B5A59585756555453
+5251504F4E4D4C4B4A494847464544434241403F3E3D3C3B3A393837363534333231302F2E2D2C2B
+2A292827262524232221201F1E1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403
+020100
+>
+<
+00000000000000000000000000000000000000000000000000000000000000000000000000000000
+00000000000000000101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010101010101010101010101010101010101
+01010101010101010101010101010101010101010101010202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020202
+02020202020202020202020202020202020202020202020202020202020202020202020202020303
+030303
+>
+1 %_Br
+[
+1 0.87 0 0 1 50 95 %_Bs
+0 0.63 0.96 0 1 50 65 %_Bs
+0.61 0.96 0 0.01 1 50 35 %_Bs
+0.05 0.03 0.95 0 1 50 5 %_Bs
+BD
+%AI5_EndGradient
+%AI5_End_NonPrinting--
+%AI5_BeginPalette
+0 0 Pb
+0 0 0 0 k
+(C=0 M=0 Y=0 K=0) Pc
+0 0 0 1 k
+(C=0 M=0 Y=0 K=100) Pc
+0 0.45 0.6 0 k
+(C=0 M=45 Y=60 K=0) Pc
+0 0.5 0.05 0 k
+(C=0 M=50 Y=5 K=0) Pc
+0 0.9 1 0 k
+(C=0 M=90 Y=100 K=0) Pc
+1 0.2 1 0 k
+(C=100 M=20 Y=100 K=0) Pc
+1 0.4 0.15 0 k
+(C=100 M=40 Y=15 K=0) Pc
+0.2 0 1 0 k
+(C=20 M=0 Y=100 K=0) Pc
+0.25 1 0.25 0 k
+(C=25 M=100 Y=25 K=0) Pc
+0.4 0.4 0.4 0 k
+(C=40 M=40 Y=40 K=0) Pc
+0.4 0.7 1 0 k
+(C=40 M=70 Y=100 K=0) Pc
+0.75 0.9 0 0 k
+(C=75 M=90 Y=0 K=0) Pc
+1 0 0.55 0 (Aqua) 0 x
+(Aqua) Pc
+1 0.5 0 0 (Blue) 0 x
+(Blue) Pc
+0.5 0.4 0.3 0 (Blue Gray) 0 x
+(Blue Gray) Pc
+0.8 0.05 0 0 (Blue Sky) 0 x
+(Blue Sky) Pc
+0.5 0.85 1 0 (Brown) 0 x
+(Brown) Pc
+1 0.9 0.1 0 (Dark Blue) 0 x
+(Dark Blue) Pc
+1 0.55 1 0 (Forest Green) 0 x
+(Forest Green) Pc
+0.05 0.2 0.95 0 (Gold) 0 x
+(Gold) Pc
+0.75 0.05 1 0 (Grass Green) 0 x
+(Grass Green) Pc
+0 0.45 1 0 (Orange) 0 x
+(Orange) Pc
+0.15 1 1 0 (Red) 0 x
+(Red) Pc
+0.45 0.9 0 0 (Violet) 0 x
+(Violet) Pc
+Bb
+2 (Black, White) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Black, White) Pc
+Bb
+2 (Chrome) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Chrome) Pc
+Bb
+2 (Green, Blue) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Green, Blue) Pc
+Bb
+2 (Orange, Green, Violet) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Orange, Green, Violet) Pc
+Bb
+2 (Pink, Yellow, Green ) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Pink, Yellow, Green ) Pc
+Bb
+2 (Purple, Red, Yellow) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Purple, Red, Yellow) Pc
+Bb
+2 (Rainbow) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Rainbow) Pc
+Bb
+2 (Steel Bar) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Steel Bar) Pc
+Bb
+0 0 0 0 Bh
+2 (White & Red Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(White & Red Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Yellow & Orange Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Yellow & Orange Radial) Pc
+Bb
+0 0 0 0 Bh
+2 (Yellow & Purple Radial) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Yellow & Purple Radial) Pc
+Bb
+2 (Yellow, Violet, Orange, Blue) -4014 4716 0 0 1 0 0 1 0 0 Bg
+0 BB
+(Yellow, Violet, Orange, Blue) Pc
+(Arrow1.2.out/in) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Arrow1.2.out/in) Pc
+(Arrow1.2.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Arrow1.2.side) Pc
+(Bricks) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Bricks) Pc
+(Checks) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Checks) Pc
+(Confetti) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Confetti) Pc
+(DblLine1.2.inner) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(DblLine1.2.inner) Pc
+(DblLine1.2.outer) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(DblLine1.2.outer) Pc
+(DblLine1.2.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(DblLine1.2.side) Pc
+(Diamonds) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Diamonds) Pc
+(Hexagon) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Hexagon) Pc
+(Laurel.inner) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Laurel.inner) Pc
+(Laurel.outer) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Laurel.outer) Pc
+(Laurel.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Laurel.side) Pc
+(Leaves-fall) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Leaves-fall) Pc
+(Polka dots) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Polka dots) Pc
+(Random circles) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Random circles) Pc
+(Rope.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Rope.side) Pc
+(Scales) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Scales) Pc
+(SolidStar.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(SolidStar.side) Pc
+(Stars) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Stars) Pc
+(Stripes) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Stripes) Pc
+(TriBevel.outer) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(TriBevel.outer) Pc
+(TriBevel.side) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(TriBevel.side) Pc
+(Waves-scroll) 0 0 1 1 0 0 0 0 0 [1 0 0 1 0 0] p
+(Waves-scroll) Pc
+PB
+%AI5_EndPalette
+%AI5_BeginLayer
+1 1 1 1 0 0 0 79 128 255 Lb
+(Layer 1) Ln
+0 A
+0 O
+0.502 0.502 0.502 Xa
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+1 XR
+124.64 319.1201 m
+141.92 332.32 l
+598.8799 332.32 l
+581.5999 319.1201 l
+124.6399 319.1201 l
+124.64 319.1201 l
+f
+q
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 319.1201 m
+141.92 332.32 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+141.92 332.32 m
+598.8799 332.32 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 353.44 m
+141.92 366.64 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+141.92 366.64 m
+598.8799 366.64 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 387.76 m
+141.92 400.96 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+141.92 400.96 m
+598.8799 400.96 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 422.08 m
+141.92 435.28 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+141.92 435.28 m
+598.8799 435.28 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 456.4 m
+141.92 469.36 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+141.92 469.36 m
+598.8799 469.36 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 490.48 m
+141.92 503.68 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+141.92 503.68 m
+598.8799 503.68 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 524.8 m
+141.92 538 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+141.92 538 m
+598.8799 538 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 559.12 m
+141.92 572.32 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+141.92 572.32 m
+598.8799 572.32 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 593.44 m
+141.92 606.64 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+141.92 606.64 m
+598.8799 606.64 l
+S
+Q
+0 A
+0 R
+0 0 0 XA
+300 Ar
+1 J 1 j 0.24 w 10 M []0 d
+%AI3_Note:
+0 D
+0 XR
+598.8799 332.32 m
+581.6 319.1201 l
+124.64 319.1201 l
+141.92 332.32 l
+598.8799 332.32 l
+598.8799 332.32 l
+s
+124.64 319.1201 m
+124.64 593.44 l
+141.92 606.64 l
+141.92 332.32 l
+124.64 319.1201 l
+124.64 319.1201 l
+s
+0 J 0 j
+141.92 332.32 m
+598.8799 332.32 l
+598.8799 606.64 l
+141.9199 606.64 l
+141.92 332.32 l
+s
+0 O
+0.302 0.302 0.502 Xa
+1 J 1 j 0.96 w
+1 XR
+165.44 323.2 m
+165.44 580.24 l
+172.4 585.52 l
+172.4 328.48 l
+165.44 323.2 l
+165.44 323.2 l
+b
+0.6 0.6 1 Xa
+0 J 0 j
+145.04 323.2 m
+165.44 323.2 l
+165.44 580.24 l
+145.04 580.24 l
+145.04 323.2 l
+b
+0.451 0.451 0.749 Xa
+1 J 1 j
+165.44 580.24 m
+172.4 585.52 l
+152 585.52 l
+145.04 580.24 l
+165.44 580.24 l
+165.44 580.24 l
+b
+0.302 0.302 0.502 Xa
+216.08 323.2 m
+216.08 453.28 l
+223.04 458.56 l
+223.04 328.48 l
+216.08 323.2 l
+216.08 323.2 l
+b
+0.6 0.6 1 Xa
+0 J 0 j
+195.92 323.2 m
+216.08 323.2 l
+216.08 453.28 l
+195.92 453.28 l
+195.92 323.2 l
+b
+0.451 0.451 0.749 Xa
+1 J 1 j
+216.08 453.28 m
+223.04 458.56 l
+202.88 458.56 l
+195.92 453.28 l
+216.08 453.28 l
+216.08 453.28 l
+b
+0.302 0.302 0.502 Xa
+266.96 323.2 m
+266.96 422.56 l
+273.92 427.84 l
+273.92 328.48 l
+266.96 323.2 l
+266.96 323.2 l
+b
+0.6 0.6 1 Xa
+0 J 0 j
+246.56 323.2 m
+266.96 323.2 l
+266.96 422.56 l
+246.56 422.56 l
+246.56 323.2 l
+b
+0.451 0.451 0.749 Xa
+1 J 1 j
+266.96 422.56 m
+273.92 427.84 l
+253.52 427.84 l
+246.56 422.56 l
+266.96 422.56 l
+266.96 422.56 l
+b
+0.302 0.302 0.502 Xa
+317.6 323.2 m
+317.6 412.24 l
+324.56 417.52 l
+324.56 328.48 l
+317.6 323.2 l
+317.6 323.2 l
+b
+0.6 0.6 1 Xa
+0 J 0 j
+297.44 323.2 m
+317.6 323.2 l
+317.6 412.24 l
+297.44 412.24 l
+297.44 323.2 l
+b
+0.451 0.451 0.749 Xa
+1 J 1 j
+317.6 412.24 m
+324.56 417.52 l
+304.4 417.52 l
+297.44 412.24 l
+317.6 412.24 l
+317.6 412.24 l
+b
+0.302 0.302 0.502 Xa
+368.48 323.2 m
+368.48 381.52 l
+375.44 386.8 l
+375.44 328.48 l
+368.48 323.2 l
+368.48 323.2 l
+b
+0.6 0.6 1 Xa
+0 J 0 j
+348.08 323.2 m
+368.48 323.2 l
+368.48 381.52 l
+348.08 381.52 l
+348.08 323.2 l
+b
+0.451 0.451 0.749 Xa
+1 J 1 j
+368.48 381.52 m
+375.44 386.8 l
+355.04 386.8 l
+348.08 381.52 l
+368.48 381.52 l
+368.48 381.52 l
+b
+0.302 0.302 0.502 Xa
+419.1199 323.2 m
+419.1199 357.52 l
+426.08 362.8 l
+426.08 328.48 l
+419.1199 323.2 l
+419.1199 323.2 l
+b
+0.6 0.6 1 Xa
+0 J 0 j
+398.9599 323.2 m
+419.1199 323.2 l
+419.1199 357.52 l
+398.9599 357.52 l
+398.9599 323.2 l
+b
+0.451 0.451 0.749 Xa
+1 J 1 j
+419.1199 357.52 m
+426.08 362.8 l
+405.9199 362.8 l
+398.9599 357.52 l
+419.1199 357.52 l
+419.1199 357.52 l
+b
+0.302 0.302 0.502 Xa
+469.9999 323.2 m
+469.9999 353.92 l
+476.9599 359.2 l
+476.9599 328.48 l
+469.9999 323.2 l
+469.9999 323.2 l
+b
+0.6 0.6 1 Xa
+0 J 0 j
+449.5999 323.2 m
+469.9999 323.2 l
+469.9999 353.92 l
+449.5999 353.92 l
+449.5999 323.2 l
+b
+0.451 0.451 0.749 Xa
+1 J 1 j
+469.9999 353.92 m
+476.9599 359.2 l
+456.5599 359.2 l
+449.5999 353.92 l
+469.9999 353.92 l
+469.9999 353.92 l
+b
+0.302 0.302 0.502 Xa
+520.6399 323.2 m
+520.6399 353.92 l
+527.6 359.2 l
+527.6 328.48 l
+520.6399 323.2 l
+520.6399 323.2 l
+b
+0.6 0.6 1 Xa
+0 J 0 j
+500.48 323.2 m
+520.6399 323.2 l
+520.6399 353.92 l
+500.48 353.92 l
+500.48 323.2 l
+b
+0.451 0.451 0.749 Xa
+1 J 1 j
+520.6399 353.92 m
+527.6 359.2 l
+507.44 359.2 l
+500.48 353.92 l
+520.6399 353.92 l
+520.6399 353.92 l
+b
+0.302 0.302 0.502 Xa
+571.52 323.2 m
+571.52 340.24 l
+578.48 345.52 l
+578.48 328.48 l
+571.52 323.2 l
+571.52 323.2 l
+b
+0.6 0.6 1 Xa
+0 J 0 j
+551.12 323.2 m
+571.52 323.2 l
+571.52 340.24 l
+551.12 340.24 l
+551.12 323.2 l
+b
+0.451 0.451 0.749 Xa
+1 J 1 j
+571.52 340.24 m
+578.48 345.52 l
+558.08 345.52 l
+551.12 340.24 l
+571.52 340.24 l
+571.52 340.24 l
+b
+q
+0 J 0 j 1 w 4 M
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 319.1201 m
+124.64 593.44 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 319.1201 m
+118.64 319.1201 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 353.44 m
+118.64 353.44 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 387.76 m
+118.64 387.76 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 422.08 m
+118.64 422.08 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 456.4 m
+118.64 456.4 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 490.48 m
+118.64 490.48 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 524.8 m
+118.64 524.8 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 559.12 m
+118.64 559.12 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 593.44 m
+118.64 593.44 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 To
+1.008 0 0 1.008 112.16 315.7576 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Roman 10 8.9799 -2.1799 Tf
+0 Ts
+100 100 Tz
+0 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0 Tc
+0 Tw
+(0) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 To
+1.008 0 0 1.008 107.12 350.0776 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Roman 10 8.9799 -2.1799 Tf
+0 Ts
+100 100 Tz
+0 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0 Tc
+0 Tw
+(10) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 To
+1.008 0 0 1.008 107.12 384.3977 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Roman 10 8.9799 -2.1799 Tf
+0 Ts
+100 100 Tz
+0 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0 Tc
+0 Tw
+(20) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 To
+1.008 0 0 1.008 107.12 418.7176 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Roman 10 8.9799 -2.1799 Tf
+0 Ts
+100 100 Tz
+0 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0 Tc
+0 Tw
+(30) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 To
+1.008 0 0 1.008 107.12 453.0376 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Roman 10 8.9799 -2.1799 Tf
+0 Ts
+100 100 Tz
+0 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0 Tc
+0 Tw
+(40) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 To
+1.008 0 0 1.008 107.12 487.1176 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Roman 10 8.9799 -2.1799 Tf
+0 Ts
+100 100 Tz
+0 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0 Tc
+0 Tw
+(50) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 To
+1.008 0 0 1.008 107.12 521.4376 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Roman 10 8.9799 -2.1799 Tf
+0 Ts
+100 100 Tz
+0 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0 Tc
+0 Tw
+(60) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 To
+1.008 0 0 1.008 107.12 555.7576 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Roman 10 8.9799 -2.1799 Tf
+0 Ts
+100 100 Tz
+0 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0 Tc
+0 Tw
+(70) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 To
+1.008 0 0 1.008 107.12 590.0776 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Roman 10 8.9799 -2.1799 Tf
+0 Ts
+100 100 Tz
+0 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0 Tc
+0 Tw
+(80) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 319.1201 m
+581.5999 319.1201 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+124.64 319.1201 m
+124.64 313.1201 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+175.28 319.1201 m
+175.28 313.1201 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+226.16 319.1201 m
+226.16 313.1201 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+277.04 319.1201 m
+277.04 313.1201 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+327.68 319.1201 m
+327.68 313.1201 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+378.5599 319.1201 m
+378.5599 313.1201 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+429.1999 319.1201 m
+429.1999 313.1201 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+480.0799 319.1201 m
+480.0799 313.1201 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+530.72 319.1201 m
+530.72 313.1201 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+-65.92 614.8 m
+658.8799 614.8 l
+658.8799 172.96 l
+-65.92 172.96 l
+H
+W
+N
+0 R
+0 0 0 XA
+1 J 1 j 0.24 w 10 M
+581.6 319.1201 m
+581.6 313.1201 l
+S
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+19.76 313.1201 m
+150.08 313.1201 l
+150.08 180.8801 l
+19.76 180.8801 l
+H
+W
+N
+0 To
+0.7071 0.7071 -0.7071 0.7071 29.4161 185.3839 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Bold 12 11.22 -2.6158 Tf
+0 Ts
+100 100 Tz
+2 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0.024 Tc
+0 Tw
+(Format Problems, source edited) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+97.04 313.1201 m
+200.72 313.1201 l
+200.72 207.52 l
+97.04 207.52 l
+H
+W
+N
+0 To
+0.7071 0.7071 -0.7071 0.7071 106.6961 212.0239 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Bold 12 11.22 -2.6158 Tf
+0 Ts
+100 100 Tz
+2 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0.024 Tc
+0 Tw
+(Bad or no PostScript file) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+200.48 313.1201 m
+251.6 313.1201 l
+251.6 260.08 l
+200.48 260.08 l
+H
+W
+N
+0 To
+0.7071 0.7071 -0.7071 0.7071 210.1361 264.5839 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Bold 12 11.22 -2.6158 Tf
+0 Ts
+100 100 Tz
+2 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0.024 Tc
+0 Tw
+(Bad Fonts) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+227.6 313.1201 m
+302.24 313.1201 l
+302.24 236.56 l
+227.6 236.56 l
+H
+W
+N
+0 To
+0.7071 0.7071 -0.7071 0.7071 237.2561 241.0639 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Bold 12 11.22 -2.6158 Tf
+0 Ts
+100 100 Tz
+1 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0.0121 Tc
+0 Tw
+(Figure Problems) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+229.76 313.1201 m
+353.12 313.1201 l
+353.12 187.8401 l
+229.76 187.8401 l
+H
+W
+N
+0 To
+0.7071 0.7071 -0.7071 0.7071 239.4161 192.3439 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Bold 12 11.22 -2.6158 Tf
+0 Ts
+100 100 Tz
+0 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0 Tc
+0 Tw
+(Unreadable disks/missing files) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+336.56 313.1201 m
+403.76 313.1201 l
+403.76 244 l
+336.56 244 l
+H
+W
+N
+0 To
+0.7071 0.7071 -0.7071 0.7071 346.2161 248.5039 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Bold 12 11.22 -2.6158 Tf
+0 Ts
+100 100 Tz
+3 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0.0361 Tc
+0 Tw
+(Paper too long) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+370.88 313.1201 m
+454.64 313.1201 l
+454.64 227.44 l
+370.88 227.44 l
+H
+W
+N
+0 To
+0.7071 0.7071 -0.7071 0.7071 380.5361 231.9439 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Bold 12 11.22 -2.6158 Tf
+0 Ts
+100 100 Tz
+1 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0.0121 Tc
+0 Tw
+(Equation problems) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+396.3199 313.1201 m
+505.2799 313.1201 l
+505.2799 202.24 l
+396.3199 202.24 l
+H
+W
+N
+0 To
+0.7071 0.7071 -0.7071 0.7071 405.9761 206.7439 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Bold 12 11.22 -2.6158 Tf
+0 Ts
+100 100 Tz
+1 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0.0121 Tc
+0 Tw
+(Author requested changes) Tx 
+(\r) TX 
+TO
+Q
+0 A
+q
+300 Ar
+0 J 0 j 1 w 4 M []0 d
+%AI3_Note:
+0 D
+0 XR
+444.3199 313.1201 m
+556.1599 313.1201 l
+556.1599 199.36 l
+444.3199 199.36 l
+H
+W
+N
+0 To
+0.7071 0.7071 -0.7071 0.7071 453.9761 203.8639 0 Tp
+0 Tv
+TP
+0 Tr
+0 O
+0 0 0 Xa
+%_ 0 50 XQ
+/_Times-Bold 12 11.22 -2.6158 Tf
+0 Ts
+100 100 Tz
+2 Tt
+%_0 0 100 100 Xu
+%AI55J_GlyphSubst: GlyphSubstNone 
+0 TA
+%_ 0 XL
+0 TY
+0 TV
+36 0 Xb
+XB
+0 0 5 TC
+100 100 200 TW
+25 TG
+0 0 0 Ti
+0 Ta
+0 0 2 2 3 Th
+0 Tq
+0 Tg
+0 0 Tl
+0.024 Tc
+0 Tw
+(Pages numbered/empty etc) Tx 
+(\r) TX 
+TO
+Q
+LB
+%AI5_EndLayer--
+gsave annotatepage grestore showpage
+Adobe_Illustrator_AI5 /terminate get exec
+Adobe_ColorImage_AI6 /terminate get exec
+Adobe_typography_AI5 /terminate get exec
+Adobe_cshow /terminate get exec
+Adobe_level2_AI5 /terminate get exec
+
+%%EndDocument
+ @endspecial -128 2948 a Fl(Figure)26 b(2:)36 b(Example)24
+b(of)i(full)f(width)h(\002gure)f(sho)n(wing)g(the)g(distrib)n(ution)g
+(of)g(problems)g(commonly)e(encountered)g(during)h(paper)h(pro-)-128
+3048 y(cessing.)-128 3315 y(umn.)58 b(All)33 b(section)e(headings)f
+(should)h(appear)f(directly)g(abo)o(v)o(e)-128 3415 y(the)23
+b(te)o(xt\227there)f(should)g(ne)n(v)o(er)f(be)i(a)g(column)f(break)f
+(between)h(a)-128 3514 y(heading)d(and)h(the)g(follo)n(wing)e
+(paragraph.)-128 3766 y Fm(Subsection)24 b(Headings)-45
+3926 y Fl(Subsection)38 b(headings)g(should)f(not)i(be)g(numbered.)78
+b(The)o(y)-128 4025 y(should)22 b(use)g(12pt)g(italic)h(letters)f(and)g
+(be)h(left)f(aligned)f(in)i(the)f(col-)-128 4125 y(umn.)62
+b(Subsection)31 b(headings)h(should)f(appear)h(directly)f(abo)o(v)o(e)
+-128 4224 y(the)23 b(te)o(xt\227there)f(should)g(ne)n(v)o(er)f(be)i(a)g
+(column)f(break)f(between)h(a)-128 4324 y(heading)d(and)h(the)g(follo)n
+(wing)e(paragraph.)-128 4576 y Fm(P)-8 b(ar)o(a)o(gr)o(aph)23
+b(T)-9 b(e)n(xt)-45 4735 y Fl(P)o(aragraphs)24 b(should)g(use)i(10pt)e
+(font)h(and)f(be)i(justi\002ed)f(\(touch)-128 4835 y(each)20
+b(side\))f(in)h(the)f(column.)24 b(The)19 b(be)o(ginning)e(of)i(each)g
+(paragraph)-128 4934 y(should)25 b(be)g(indented)f(approximately)f(3mm)
+i(\(.13)f(in\).)41 b(The)25 b(last)-128 5034 y(line)19
+b(of)f(a)h(paragraph)d(should)i(not)g(be)g(printed)g(by)g(itself)h(at)g
+(the)f(be-)-128 5134 y(ginning)g(of)g(a)i(column)d(nor)i(should)f(the)g
+(\002rst)i(line)f(of)g(a)g(paragraph)-128 5233 y(be)i(printed)e(by)g
+(itself)i(at)g(the)f(end)g(of)g(a)g(column.)-128 5485
+y Fm(F)l(igur)l(es,)k(T)-9 b(ables)24 b(and)h(Equations)-45
+5645 y Fl(Place)35 b(\002gures)e(and)g(tables)h(as)h(close)f(to)g(the)g
+(place)g(of)f(their)-128 5744 y(mention)21 b(as)h(possible.)29
+b(Lettering)20 b(in)i(\002gures)f(and)g(tables)h(should)-128
+5844 y(be)e(lar)o(ge)f(enough)e(to)j(reproduce)d(clearly)-5
+b(.)24 b(Use)c(of)g(non-appro)o(v)o(ed)-128 5943 y(fonts)25
+b(in)g(\002gures)g(often)f(leads)h(to)h(problems)d(when)i(the)g
+(\002les)h(are)1939 3315 y(processed.)36 b(Please)25
+b(use)g(the)f(appro)o(v)o(ed)d(fonts)j(whene)n(v)o(er)e(possi-)1939
+3415 y(ble.)38 b(L)2121 3398 y Fg(A)2151 3415 y Fl(T)2188
+3433 y(E)2228 3415 y(X)12 b(2)2342 3427 y Ff(")2410 3415
+y Fl(users\227please)24 b(be)g(sure)h(to)f(use)h(non)f(bitmapped)1939
+3514 y(v)o(ersions)30 b(of)g(Computer)f(Modern)g(fonts)h(in)h
+(equations)e(\(type)h(1)1939 3614 y(PostScript)d(fonts)f(are)g
+(required)f(and)g(their)i(use)f(is)i(described)d(in)1939
+3714 y(the)c(J)-5 b(A)m(CoW)21 b(help)e(pages[2)n(]\).)2022
+3816 y(All)k(\002gures)e(and)g(tables)g(must)h(be)f(gi)n(v)o(en)g
+(sequential)f(numbers)1939 3916 y(\(1,)h(2,)h(3,)f(etc.\))28
+b(and)21 b(ha)n(v)o(e)f(a)i(captions)f(\(10pt)f(font\))g(placed)g(belo)
+n(w)1939 4015 y(the)h(\002gure)e(or)h(abo)o(v)o(e)e(the)j(table)f
+(being)f(described.)2022 4118 y(T)-6 b(e)o(xt)20 b(should)f(not)h(be)g
+(obscured)f(by)h(\002gures.)2022 4221 y(If)32 b(a)f(displayed)f
+(equation)g(needs)h(a)h(number)m(,)g(place)f(it)h(\003ush)1939
+4320 y(with)i(the)g(right)f(mar)o(gin)f(of)h(the)g(column)g(\(see)g
+(Eq.)g(1\).)65 b(Units)1939 4420 y(should)20 b(be)g(written)g(using)f
+(the)h(roman)f(font,)h(not)f(the)i(italic)f(font.)2433
+4663 y Ff(C)2492 4675 y Fe(B)2573 4663 y Fd(=)2742 4607
+y Ff(q)2782 4577 y Fc(3)p 2670 4644 222 4 v 2670 4720
+a Fd(3)p Ff(\017)2746 4732 y Fc(0)2783 4720 y Ff(mc)2925
+4663 y Fd(=)i(3)p Ff(:)p Fd(54)14 b Ff(\026)p Fl(eV/T)395
+b(\(1\))1939 4919 y Fm(Refer)l(ences)2022 5069 y Fl(All)27
+b(bibliographical)22 b(and)j(web)h(references)e(should)g(be)i(num-)1939
+5169 y(bered)d(and)h(listed)g(at)g(the)g(end)g(of)f(the)h(paper)f(in)h
+(a)g(section)g(called)1939 5268 y(\223References\224.)56
+b(When)31 b(referring)d(to)j(a)g(reference)e(in)i(the)g(te)o(xt,)1939
+5368 y(place)20 b(the)f(corresponding)e(reference)h(number)f(in)j
+(square)f(brack-)1939 5467 y(ets)i([3].)1939 5694 y Fm(F)-10
+b(ootnotes)2022 5844 y Fl(F)o(ootnotes)25 b(on)h(the)g(title)h(and)f
+(author)e(lines)j(may)e(be)i(used)e(for)1939 5943 y(ackno)n
+(wledgements,)35 b(af)n(\002liations)e(and)h(e-mail)g(addresses.)66
+b(A)p eop
+%%Page: 3 3
+3 2 bop -128 334 a Fl(nonnumeric)27 b(sequence)g(of)i(characters)f
+(\(*,)j Fp(y)p Fl(,)g Fp(z)p Fl(,)h Fp(x)p Fl(\))d(should)f(be)-128
+433 y(used.)36 b(All)24 b(other)f(notes)h(should)f(be)g(included)g(in)g
+(the)h(references)-128 533 y(section)c(and)g(use)g(the)h(normal)e
+(numeric)f(sequencing.)-128 746 y Fm(Acr)l(onyms)-45
+891 y Fl(Acron)o(yms)h(should)g(be)h(de\002ned)f(the)i(\002rst)f(time)h
+(the)o(y)e(appear)-5 b(.)453 1111 y Fk(P)e(A)i(GE)24
+b(NUMBERS)-45 1267 y Fj(DO)i(NO)m(T)f(ha)n(v)o(e)g(any)g(page)g
+(numbers)p Fl(.)41 b(The)24 b(editorial)h(staf)n(f)-128
+1367 y(will)c(add)f(them)g(when)f(the)o(y)h(produce)e(the)i(\002nal)h
+(proceedings.)544 1588 y Fk(TEMPLA)-9 b(TES)-45 1743
+y Fl(T)j(emplates)28 b(and)f(e)o(xamples)g(can)h(be)g(retrie)n(v)o(ed)e
+(through)g(W)-7 b(eb)-128 1843 y(bro)n(wsers)19 b(lik)o(e)g(Netscape)g
+(and)g(Internet)f(Explorer)f(by)i(loading)f(to)-128 1942
+y(disk.)25 b(See)18 b(your)f(local)h(documentation)d(for)i(details)h
+(of)g(ho)n(w)f(to)h(do)-128 2042 y(this.)-45 2142 y(T)-6
+b(emplate)36 b(documents)f(for)h(the)g(recommended)d(w)o(ord)j(pro-)
+-128 2241 y(cessing)d(softw)o(are)g(are)g(a)n(v)n(ailable)f(from)g(the)
+h(J)-5 b(A)m(CoW)34 b(W)-7 b(ebsite)-128 2341 y(and)26
+b(e)o(xist)g(for)f(L)345 2324 y Fg(A)375 2341 y Fl(T)412
+2360 y(E)452 2341 y(X)12 b(2)566 2353 y Ff(")635 2341
+y Fl(and)25 b(Microsoft)g(W)-7 b(ord)26 b(\(Mac)g(and)f(PC\))-128
+2441 y(for)20 b(US)h(letter)f(and)g(A4)g(paper)f(sizes.)-45
+2540 y(Authors)h(are)h(required)e(to)i(use)g(templates)f(for)h(the)f
+(correct)g(pa-)-128 2640 y(per)26 b(size)g(and)g(advised)f(to)h(use)g
+(the)g(template)f(corresponding)e(to)-128 2739 y(the)31
+b(correct)e(v)o(ersion)g(of)h(W)-7 b(ord.)55 b(Do)30
+b(not)g(transport)f(Microsoft)-128 2839 y(W)-7 b(ord)21
+b(documents)d(across)i(platforms,)f(e.g.)25 b(Mac)20
+b Fp($)h Fl(PC.)-45 2939 y(Please)e(see)g(the)g(help)f(\002les)h(for)f
+(instructions)f(on)h(ho)n(w)g(to)g(install)-128 3038
+y(templates)i(in)h(your)e(Microsoft)g(templates)h(folder)-5
+b(.)87 3259 y Fk(CHECKLIST)25 b(FOR)g(ELECTR)m(ONIC)500
+3375 y(PUBLICA)-9 b(TION)-45 3531 y Fp(\017)41 b Fl(Use)25
+b(only)f(T)m(imes)g(\(bold)f(or)h(italic\))g(and)g(Symbol)f(fonts)g
+(for)38 3631 y(te)o(xt\22710)d(pt)g(minimum.)-45 3730
+y Fp(\017)41 b Fl(Figure)16 b(labelling)f(should)g(be)h(in)g(T)m(imes)g
+(\(bold)f(or)g(italic\))h(and)38 3830 y(Symbol)k(fonts)f(whene)n(v)o
+(er)g(possible\2276pt)g(minimum.)-45 3930 y Fp(\017)41
+b Fl(Check)20 b(that)h(the)f(PostScript)g(\002le)h(prints)f(correctly)
+-5 b(.)-45 4029 y Fp(\017)41 b Fl(Check)20 b(that)h(there)e(are)h(no)g
+(page)g(numbers.)-45 4129 y Fp(\017)41 b Fl(Check)21
+b(that)h(the)f(mar)o(gins)f(are)h(correct)f(on)h(the)g(printed)g(v)o
+(er)n(-)38 4228 y(sion.)k(There)18 b(may)g(be)g(dif)n(ferences)f(of)i
+Fp(\006)p Fl(1)f(mm)g(on)h(the)f(mar)n(-)38 4328 y(gins)j(from)e(one)g
+(printer)h(to)g(another)-5 b(.)-45 4428 y Fp(\017)41
+b Fl(L)59 4411 y Fg(A)89 4428 y Fl(T)126 4446 y(E)166
+4428 y(X)12 b(2)280 4440 y Ff(")355 4428 y Fl(users)32
+b(can)g(check)f(their)h(mar)o(gins)e(by)i(in)m(v)n(oking)38
+4527 y(the)21 b Fb(boxit)d Fl(option.)-45 4627 y Fp(\017)41
+b Fl(Check)22 b(the)f(size)h(of)f(the)h(PostScript)f(\002le\227an)h(a)n
+(v)o(erage)e(size)38 4727 y(is)29 b(about)d(100\226300)f(kbytes.)45
+b(If)27 b(the)h(\002le)g(size)g(is)g(o)o(v)o(er)e(300)38
+4826 y(kbytes,)20 b(please)g(try)g(to)g(mak)o(e)g(it)h(smaller)-5
+b(.)512 5047 y Fk(REFERENCES)-128 5194 y Fa([1])42 b(http://www)-5
+b(.J)l(A)m(CoW)e(.or)o(g.)-128 5319 y([2])42 b(A.)22
+b(Name)i(and)f(D.)g(Person,)g(Modern)i(Editor)l(.s)d(Journal)i(25)f
+(\(1997\))1 5410 y(56.)-128 5535 y([3])42 b(A.N.)30 b(Other)m(,)k(\223)
+-6 b(A)31 b(V)-8 b(ery)31 b(Interesting)h(P)o(aper\224,)i(EP)-7
+b(A)m(C'96,)33 b(Sitges,)1 5626 y(June)20 b(1996.)p eop
+%%Trailer
+end
+userdict /end-hook known{end-hook}if
+%%EOF

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1505,6 +1505,7 @@ sub load_extra_tests_console {
     loadtest "console/check_default_network_manager";
     loadtest "console/ipsec_tools_h2h" if get_var("IPSEC");
     loadtest "console/git";
+    loadtest "console/cups";
     loadtest "console/java";
     loadtest "console/ant" if is_sle('<15-sp1');
     loadtest "console/sysctl";

--- a/tests/console/cups.pm
+++ b/tests/console/cups.pm
@@ -1,0 +1,74 @@
+# SUSE's openQA tests
+#
+# Copyright 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test basic capabilities of cups
+# Maintainer: Jan Baier <jbaier@suse.cz>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    script_run 'echo FileDevice Yes >> /etc/cups/cups-files.conf';
+    validate_script_output 'cupsd -t', sub { m/is OK/ };
+    systemctl 'enable cups.service';
+    systemctl 'start cups.service';
+    validate_script_output 'systemctl status cups.service', sub { m/Active:\s*active/ };
+
+    # Add printers
+    record_info "lpadmin", "Try to add printers and enable them";
+    validate_script_output 'lpstat -p -d -o 2>&1 || test $? -eq 1', sub { m/lpstat: No destinations added/ };
+    assert_script_run 'lpadmin -p printer_tmp -v file:/tmp/test_cups -m raw -E';
+    assert_script_run 'lpadmin -p printer_null -v file:/dev/null -m raw -E';
+    assert_script_run 'cupsenable printer_tmp printer_null';
+    assert_script_run 'lpoptions -d printer_tmp';
+    validate_script_output 'lpstat -p -d -o', sub { m/printer_tmp is idle/ };
+
+    assert_script_run 'wget ' . data_url('console/sample.ps');
+
+    # Submit print job to the queue, list them and cancel them
+    record_info "lp, lpstat, cancel", "Submitting and canceling jobs";
+    foreach my $printer (qw/printer_tmp printer_null/) {
+        assert_script_run "cupsdisable $printer";
+        assert_script_run "lp -d $printer -o cpi=12 -o lpi=8 sample.ps";
+        validate_script_output 'lpstat -o',          sub { m/$printer-\d+/ };
+        validate_script_output 'ls /var/spool/cups', sub { m/d\d+/ };
+        assert_script_run "cancel -a $printer";
+    }
+
+    systemctl 'restart cups.service';
+    validate_script_output 'systemctl status cups.service', sub { m/Active:\s*active/ };
+
+    # Do the printing
+    record_info "lp, lpq", "Printing jobs";
+    foreach my $printer (qw/printer_tmp printer_null/) {
+        assert_script_run "cupsenable $printer";
+        assert_script_run "lp -d $printer /usr/share/cups/data/default-testpage.pdf";
+        validate_script_output "lpq $printer", sub { m/is ready/ };
+    }
+
+    # Check logs
+    record_info "access_log", "Access log should containt successful job submits";
+    assert_script_run 'grep "Send-Document successful-ok" /var/log/cups/access_log';
+
+    # Remove printers
+    record_info "lpadmin -x", "Removing printers";
+    assert_script_run "lpadmin -x $_" foreach (qw/printer_tmp printer_null/);
+    validate_script_output 'lpstat -p -d -o 2>&1 || test $? -eq 1', sub { m/No destinations added/ };
+    systemctl 'stop cups.service';
+    systemctl 'disable cups.service';
+    validate_script_output 'systemctl status cups.service || test $? -eq 3', sub { m/Active:\s*inactive/ };
+}
+
+1;


### PR DESCRIPTION
Enable cups regression testing during mau-extratests.

- Related ticket: https://progress.opensuse.org/issues/43133
- Verification run: 
  - http://panigale.suse.cz/tests/1050 (12-SP3)
  - http://panigale.suse.cz/tests/1052 (12-SP4)
  - http://panigale.suse.cz/tests/1051 (15)
  - http://panigale.suse.cz/tests/1053 (Leap 15.1)
  - http://panigale.suse.cz/tests/1054 (TW)