### PR TITLE
Fix the vino_screensharing_available test

### DIFF
--- a/tests/x11/remote_desktop/vino_screensharing_available.pm
+++ b/tests/x11/remote_desktop/vino_screensharing_available.pm
@@ -24,10 +24,15 @@ use utils;
 
 sub run {
     # Run the gnome-control-center - the sharing section
-    x11_start_program("gnome-control-center sharing", target_match => 'vino_screensharing_available-gnome-control-center-sharing');
+    x11_start_program "gnome-control-center sharing", target_match => 'vino_screensharing_available-gnome-control-center-sharing';
+
+    # Always check the common sharing functionality is enabled
+    if (check_screen 'disabled_sharing') {
+        assert_and_click 'disabled_sharing';
+    }
 
     # It may happen that the screen sharing is not available
-    assert_screen [qw(with_screensharing without_screensharing disabled_screensharing)];
+    assert_screen [qw(with_screensharing without_screensharing)];
     if (match_has_tag 'without_screensharing') {
         record_info 'vino missing', 'After the installation the screen sharing is not available - vino is missing and we need to install it now.';
         send_key 'ctrl-q';
@@ -35,17 +40,20 @@ sub run {
         # Install the vino package which is probably the case of missing screen sharing option
         ensure_installed 'vino';
 
+        # Log of and back in to ensure the vino feature gets enabled
         handle_relogin;
 
         # Run the gnome-control-center to ensure the same state as we were while entering this if block
-        x11_start_program("gnome-control-center sharing", target_match => 'vino_screensharing_available-gnome-control-center-sharing');
-    }
-    if (match_has_tag 'disabled_screensharing') {
-        assert_and_click 'disabled_screensharing';
+        x11_start_program "gnome-control-center sharing", target_match => 'vino_screensharing_available-gnome-control-center-sharing';
+
+        # Always check the common sharing functionality is enabled
+        if (check_screen 'disabled_sharing') {
+            assert_and_click 'disabled_sharing';
+        }
     }
 
     # Finally ensure that the screen sharing is available
-    assert_screen 'with_screensharing';
+    assert_screen "with_screensharing";
     record_info 'vino present', 'Vino and the screen sharing are present';
     send_key 'ctrl-q';
 }


### PR DESCRIPTION
The Sharing part of Gnome Settings can be in disabled state and that's why every option seems like disabled or without focus then. This is a fix for that issue and a follow-up of #6381.

- Related ticket: [poo#37342](https://progress.opensuse.org/issues/37342) [poo#44822](https://progress.opensuse.org/issues/44822) [poo#44915](https://progress.opensuse.org/issues/44915)
- Needles: [SLE](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1025)
- Verification run: [SLE12SP1](http://pdostal-server.suse.cz/tests/560) [SLES12SP3](http://pdostal-server.suse.cz/tests/561) [SLE15](http://pdostal-server.suse.cz/tests/562)