### PR TITLE
Do not remove DVD drive on Hyper-V 2012 R2 UEFI

### DIFF
--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -177,7 +177,7 @@ sub run {
         # the default is 'Production' (i.e. snapshot on guest level).
         hyperv_cmd("$ps Set-VM -VMName $name -CheckpointType Standard") if $winserver eq '2016';
         if ($iso) {
-            hyperv_cmd("$ps Remove-VMDvdDrive -VMName $name -ControllerNumber 1 -ControllerLocation 0");
+            hyperv_cmd("$ps Remove-VMDvdDrive -VMName $name -ControllerNumber 1 -ControllerLocation 0") unless $winserver eq '2012' and get_var('UEFI');
             hyperv_cmd("$ps Add-VMDvdDrive -VMName $name -Path $iso");
         }
         foreach my $disk_path (@disk_paths) {


### PR DESCRIPTION
https://trello.com/c/TYaG8wdk/325-p3-do-not-remove-dvd-on-hyper-v-2012-r2-uefi-its-not-there
https://progress.opensuse.org/issues/44756

On Hyper-V 2012 with UEFI the DVD drive is not there, so attempt on
removing it fails.

Validation runs:
* 2012 R2 UEFI: http://nilgiri.suse.cz/tests/32
* 2012 R2 BIOS: http://nilgiri.suse.cz/tests/36
* 2016 UEFI: http://nilgiri.suse.cz/tests/35