### PR TITLE
Fix expert partitioner shortcut in sle15/old storage-ng stack

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -81,7 +81,8 @@ sub create_new_partition_table {
     send_key_until_needlematch "expert-partitioner-vda", 'right';
 
     # empty disk partitions by creating new partition table
-    my $expert_menu_key = (is_storage_ng) ? 'alt-r' : 'alt-x';    # expert menu keys
+    # in sle15sp1 is called Pa{r}tition Table
+    my $expert_menu_key = (is_storage_ng) ? ((is_storage_ng_newui) ? 'alt-r' : 'alt-e') : 'alt-x';    # expert menu keys
 
     if (is_storage_ng_newui) {
         # partition table management has been moved from Partitions tab to Overview
@@ -89,7 +90,8 @@ sub create_new_partition_table {
         assert_screen 'expert-partitioner-overview';
     }
 
-    wait_screen_change { send_key $expert_menu_key };             # enter Partition table menu
+    # enter Partition table menu
+    wait_screen_change { send_key $expert_menu_key };
     send_key 'down';
     wait_still_screen 2;
     save_screenshot;
@@ -109,7 +111,7 @@ sub create_new_partition_table {
         send_key((is_storage_ng) ? $cmd{next} : $cmd{ok});    # OK
         send_key 'alt-p' if (is_storage_ng);                  # return back to Partitions tab
     }
-    unless (is_storage_ng) {
+    unless (is_storage_ng_newui) {
         assert_screen 'partition-create-new-table';
         send_key 'alt-y';
     }


### PR DESCRIPTION
Fix of QR releases:
* [sle-15-Installer-DVD-QR-x86_64-Build0007-lvm-encrypt-separate-boot@64bit](https://openqa.suse.de/tests/2327172#step/partitioning_full_lvm/10)
* [sle-15-Installer-DVD-QR-x86_64-Build0007-lvm_thin_provisioning@64bit](https://openqa.suse.de/tests/2327171#step/partitioning_lvm_thin_provisioning/10)

- Verification runs:
   * [sle15sp0](http://dhcp128.suse.cz/tests/8855#step/partitioning_lvm_thin_provisioning/1)
   * [sle-15-Installer-DVD-QR-x86_64-Build0007-lvm-encrypt-separate-boot@64bit](http://dhcp128.suse.cz/tests/8854#step/partitioning_full_lvm/1)
   * [sle12sp4](http://dhcp128.suse.cz/tests/8853#step/partitioning_full_lvm/1)
   * [sle-15-Installer-DVD-QR-x86_64-Build0007-lvm_thin_provisioning@64bit](http://dhcp128.suse.cz/tests/8851#step/partitioning_lvm_thin_provisioning/1)
