### PR TITLE
Use own module for serial error detection

### DIFF
--- a/lib/known_bugs.pm
+++ b/lib/known_bugs.pm
@@ -1,0 +1,56 @@
+# Copyright (C) 2015-2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+use base Exporter;
+use Exporter;
+use strict;
+use testapi;
+use main_common;
+use version_utils;
+
+our @EXPORT = qw(
+  create_list_of_serial_failures
+);
+
+sub create_list_of_serial_failures {
+    my $serial_failures = [];
+
+    # To add a known bug simply copy and adapt the following line:
+    # push @$serial_failures, {type => soft/hard, message => 'Errormsg', pattern => quotemeta 'ErrorPattern' }
+
+    # Detect bsc#1093797 on aarch64
+    if (is_sle('=12-SP4') && check_var('ARCH', 'aarch64')) {
+        push @$serial_failures, {type => 'hard', message => 'bsc#1093797', pattern => quotemeta 'Internal error: Oops: 96000006'};
+    }
+
+    push @$serial_failures, {type => 'soft', message => 'bsc#1112109', pattern => qr/serial-getty.*service: Service hold-off time over, scheduling restart/};
+
+    if (is_kernel_test()) {
+        my $type = is_ltp_test() ? 'soft' : 'hard';
+        push @$serial_failures, {type => $type, message => 'Kernel Ooops found',             pattern => quotemeta 'Oops:'};
+        push @$serial_failures, {type => $type, message => 'Kernel BUG found',               pattern => qr/kernel BUG at/i};
+        push @$serial_failures, {type => $type, message => 'WARNING CPU in kernel messages', pattern => quotemeta 'WARNING: CPU'};
+        push @$serial_failures, {type => $type, message => 'Kernel stack is corrupted',      pattern => quotemeta 'stack-protector: Kernel stack is corrupted'};
+        push @$serial_failures, {type => $type, message => 'Kernel BUG found',               pattern => quotemeta 'BUG: failure at'};
+        push @$serial_failures, {type => $type, message => 'Kernel Ooops found',             pattern => quotemeta '-[ cut here ]-'};
+    }
+
+
+    push @$serial_failures, {typ => 'hard', message => 'CPU soft lockup detected', pattern => quotemeta 'soft lockup - CPU'};
+
+    return $serial_failures;
+}
+
+1;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -23,7 +23,7 @@ BEGIN {
 use utils;
 use version_utils qw(is_jeos is_gnome_next is_krypton_argon is_leap is_tumbleweed is_rescuesystem is_desktop_installed is_opensuse is_sle is_staging);
 use main_common;
-
+use known_bugs;
 init_main();
 
 sub cleanup_needles {
@@ -74,10 +74,7 @@ require $distri;
 testapi::set_distribution(susedistribution->new());
 
 # Set serial failures
-my $serial_failures = [];
-push @$serial_failures, {type => 'soft', message => 'bsc#1112109', pattern => qr/serial-getty.*service: Service RestartSec=.*ms expired, scheduling restart/};
-
-$testapi::distri->set_expected_serial_failures($serial_failures);
+$testapi::distri->set_expected_serial_failures(create_list_of_serial_failures());
 
 unless (get_var("DESKTOP")) {
     if (check_var("VIDEOMODE", "text")) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -27,6 +27,7 @@ BEGIN {
 }
 use utils;
 use main_common;
+use known_bugs;
 
 init_main();
 
@@ -669,23 +670,8 @@ my $distri = testapi::get_required_var('CASEDIR') . '/lib/susedistribution.pm';
 require $distri;
 testapi::set_distribution(susedistribution->new());
 
-# Set serial failures
-my $serial_failures = [];
-# Detect bsc#1093797 on aarch64
-if (is_sle('=12-SP4') && check_var('ARCH', 'aarch64')) {
-    push @$serial_failures, {type => 'hard', message => 'bsc#1093797', pattern => quotemeta 'Internal error: Oops: 96000006'};
-}
-push @$serial_failures, {type => 'soft', message => 'bsc#1112109', pattern => qr/serial-getty.*service: Service hold-off time over, scheduling restart/};
-if (is_kernel_test()) {
-    my $type = is_ltp_test() ? 'soft' : 'hard';
-    push @$serial_failures, {type => $type, message => 'Kernel Ooops found',             pattern => quotemeta 'Oops:'};
-    push @$serial_failures, {type => $type, message => 'Kernel BUG found',               pattern => qr/kernel BUG at/i};
-    push @$serial_failures, {type => $type, message => 'WARNING CPU in kernel messages', pattern => quotemeta 'WARNING: CPU'};
-    push @$serial_failures, {type => $type, message => 'Kernel stack is corrupted',      pattern => quotemeta 'stack-protector: Kernel stack is corrupted'};
-    push @$serial_failures, {type => $type, message => 'Kernel BUG found',               pattern => quotemeta 'BUG: failure at'};
-    push @$serial_failures, {type => $type, message => 'Kernel Ooops found',             pattern => quotemeta '-[ cut here ]-'};
-}
-$testapi::distri->set_expected_serial_failures($serial_failures);
+# set serial failures
+$testapi::distri->set_expected_serial_failures(create_list_of_serial_failures());
 
 if (is_jeos) {
     load_jeos_tests();


### PR DESCRIPTION
Separated the serial error patterns to an extra module to improve
readability and clean up main.pm

Now working!

- Related ticket: https://progress.opensuse.org/issues/34006
- Verification run: http://pinky.arch.suse.de/tests/1685#step/boot_to_desktop/4

Please note that I deleted the entry used for the verification run since we don't want errors for every 'Welcome' in productive code