### PR TITLE
install_packages: handle conflict between ghostscript-{,mini-}devel

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -181,6 +181,8 @@ sub problem_can_be_skipped {
     return 1 if $pkg =~ /^python3-ldb-devel/;
     # conflict with the non-debug counterparts
     return 1 if $pkg =~ /^dapl-debug(|-devel|-libs|-utils)/;
+    # conflict with ghostscript-devel
+    return 1 if $pkg =~ /^ghostscript-devel-mini/;
 
     return;
 }


### PR DESCRIPTION
```
+++ PROBLEMS: +++
package ghostscript-mini-9.25-lp150.2.6.1.x86_64 conflicts with ghostscript provided by ghostscript-9.25-lp150.2.6.1.x86_64
  + solution
    - do not ask to install ghostscript-mini-9.25-lp150.2.6.1.x86_64
PCBS 'ghostscript-mini-9.25-lp150.2.6.1.x86_64': 'package ghostscript-mini-9.25-lp150.2.6.1.x86_64 conflicts with ghostscript provided by ghostscript-9.25-lp150.2.6.1.x86_64'

```

Fixes:

- https://openqa.opensuse.org/tests/814199#step/install_packages/9
- https://openqa.opensuse.org/tests/814200#step/install_packages/1
- https://openqa.opensuse.org/tests/814201#step/install_packages/9

`data/lsmfip --verbose ghostscript-mini libspectre-devel ghostscript ghostscript-mini-debugsource ghostscript-debugsource libspectre1-debuginfo libspectre-debugsource ghostscript-devel ghostscript-x11-debuginfo ghostscript-debuginfo ghostscript-x11 ghostscript-mini-devel ghostscript-mini-debuginfo libspectre1`
