### PR TITLE
Wait more time for analyzing system

### DIFF
--- a/tests/migration/sle12_online_migration/yast2_migration.pm
+++ b/tests/migration/sle12_online_migration/yast2_migration.pm
@@ -182,7 +182,7 @@ sub run {
     }
 
     send_key "alt-n";
-    assert_screen 'yast2-migration-startupgrade';
+    assert_screen 'yast2-migration-startupgrade', 90;
     send_key "alt-u";
     assert_screen "yast2-migration-upgrading";
 


### PR DESCRIPTION
Analyzing system will need more time than the default timeout value 30s on slow machines sometimes.

- Related ticket: https://progress.opensuse.org/issues/44423
- Verification run: http://openqa-apac1.suse.de/tests/2755#step/yast2_migration/18
