### PR TITLE
install_package: follow-up to 7080f41 #6399, handle ghostscript-mini

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -181,8 +181,8 @@ sub problem_can_be_skipped {
     return 1 if $pkg =~ /^python3-ldb-devel/;
     # conflict with the non-debug counterparts
     return 1 if $pkg =~ /^dapl-debug(|-devel|-libs|-utils)/;
-    # conflict with ghostscript-devel
-    return 1 if $pkg =~ /^ghostscript-devel-mini/;
+    # conflict with ghostscript,-devel
+    return 1 if $pkg =~ /^ghostscript(-devel)?-mini/;
 
     return;
 }


### PR DESCRIPTION
follow-up to 7080f41 #6399, handle `ghostscript-mini`


- https://openqa.opensuse.org/tests/814588#step/install_packages/9
- https://openqa.opensuse.org/tests/814589#step/install_packages/9
- https://openqa.opensuse.org/tests/814590#step/install_packages/9