### PR TITLE
Fix virtIO on some ppc64le and <12-SP2 machines

### DIFF
--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -14,6 +14,8 @@ use base 'consoletest';
 use testapi;
 use utils;
 use Utils::Backends 'use_ssh_serial_console';
+use version_utils qw(is_sle);
+use serial_terminal 'add_serial_console';
 use bootloader_setup qw(change_grub_config grub_mkconfig);
 use strict;
 
@@ -22,6 +24,18 @@ sub run {
     check_var('BACKEND', 'ipmi') ? use_ssh_serial_console : select_console 'root-console';
 
     ensure_serialdev_permissions;
+
+    # Configure serial consoles for virtio support
+    # poo#18860 Enable console on hvc0 on SLES < 12-SP2
+    # poo#44699 Enable console on hvc1 to fix login issues on ppc64le
+    if (get_var('VIRTIO_CONSOLE')) {
+        if (is_sle('<12-SP2')) {
+            add_serial_console('hvc0');
+        }
+        elsif (get_var('OFW')) {
+            add_serial_console('hvc1');
+        }
+    }
 
     # bsc#997263 - VMware screen resolution defaults to 800x600
     if (check_var('VIRSH_VMM_FAMILY', 'vmware')) {


### PR DESCRIPTION
This PR fixing issues with virtIO serial terminal on the PPC64le architecture.

- Related ticket: [poo#44696](https://progress.opensuse.org/issues/44696)
- Needles: No need
- Verification run: In progress

This is a follow up of #6360, #6351 and #6295.