### PR TITLE
Assert inst-addon for migration from SLE15

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -22,7 +22,7 @@ use strict;
 
 use testapi;
 use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key);
-use version_utils qw(is_sle is_caasp is_sle12_hdd_in_upgrade);
+use version_utils qw(is_sle is_caasp is_upgrade);
 use constant ADDONS_COUNT => 50;
 
 our @EXPORT = qw(
@@ -399,7 +399,7 @@ sub fill_in_registration_data {
         }
         # The "Extension and Module Selection" won't be shown during upgrade to sle15, refer to:
         # https://bugzilla.suse.com/show_bug.cgi?id=1070031#c11
-        push @tags, 'inst-addon' if is_sle('15+') && is_sle12_hdd_in_upgrade;
+        push @tags, 'inst-addon' if is_sle('15+') && is_upgrade;
         while ($counter--) {
             die 'Registration repeated too much. Check if SCC is down.' if ($counter eq 1);
             assert_screen(\@tags);


### PR DESCRIPTION
We need assert inst-addon for migration from SLE15, so just modify the judgment from is_upgrade && is_sle('<15', get_var('HDDVERSION')) to just is_upgrade, then it can support all base system , not only SLE12 but also SLE15.

- Related ticket: https://progress.opensuse.org/issues/45110
- Verification run: http://openqa-apac1.suse.de/tests/2795#step/scc_registration/7
