### PR TITLE
[Urgent][SLE-15-SP1 Beta1] Host Upgrade from SLE-11-SP4 does not need post-installation system configuration

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -64,8 +64,11 @@ sub login_to_console {
             #assert_screen([qw(grub2 grub1)], 120);
 
             my $host_installed_version = get_var('VERSION_TO_INSTALL', get_var('VERSION', ''));
-            ($host_installed_version) = $host_installed_version =~ /^(\d+)/;
-            if ($host_installed_version eq '11') {
+            ($host_installed_version) = $host_installed_version =~ /^(\d+)/im;
+            my $host_upgrade_version = get_required_var('UPGRADE_PRODUCT');         #format sles-15-sp0
+            my $host_upgrade_relver  = $host_upgrade_version =~ /sles-(\d+)-sp/i;
+            my $host_upgrade_spver   = $host_upgrade_version =~ /sp(\d+)$/im;
+            if (($host_installed_version eq '11') && ($host_upgrade_relver eq '15') && ($host_upgrade_spver eq '0')) {
                 assert_screen('sshd-server-started-config', 180);
                 use_ssh_serial_console;
                 save_screenshot;


### PR DESCRIPTION
SLE-11-SP4 to SLE-15-SP1 host upgrade completes without post-installation/upgrade configuration step. So incorporating minor release version into decision-making of either advance to linux login step or wait for first-time system config happen. SLE-11-SP4 GM with update and SLE-15-SP1 Build 125.1 were being used to do verification run.

- Related ticket:
  https://openqa.suse.de/tests/2332158#step/reboot_and_wait_up_upgrade/1
  https://openqa.suse.de/tests/2329750#step/reboot_and_wait_up_upgrade/1
- Needles: n/a
- Verification run:
  https://10.67.17.5/tests/378

@alice-suse @guoxuguang @Julie-CAO 
