### PR TITLE
Check install recommended package enable or not

### DIFF
--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -39,6 +39,17 @@ sub run {
         wait_screen_change { send_key 'alt-p' };    # go back to search box
     }
 
+    # Check if enable 'install recommended package', if not, enable it
+    # Testcase according to https://progress.opensuse.org/issues/44864
+    send_key 'alt-d';
+    assert_screen [qw(yast2-sw_install_recommended_packages_enabled yast2-sw_install_recommended_packages_disabled)];
+    if (match_has_tag('yast2-sw_install_recommended_packages_disabled')) {
+        wait_screen_change { send_key 'alt-r' };
+    } else {
+        wait_screen_change { send_key 'esc' };
+    }
+    send_key 'alt-p';
+
     # Testcase according to https://fate.suse.com/318099
     # UC1:
     # Select a certain package, check that another gets selected/installed


### PR DESCRIPTION
Check if enable 'install recommended package', if not, enable it

- Related ticket: https://progress.opensuse.org/issues/44864
- Verification run: 
[autoinst-log-enablefirst.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/2679347/autoinst-log-enablefirst.txt)
[autoinst-log-disablefirst.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/2679391/autoinst-log-disablefirst.txt)
http://openqa-apac1.suse.de/tests/2801
http://openqa-apac1.suse.de/tests/2800#step/yast2_i/13
