### PR TITLE
Add AppArmor profile related test cases

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -25,6 +25,12 @@ use version_utils qw(is_sle is_leap);
 
 use base 'consoletest';
 
+our @EXPORT = qw (
+  $audit_log
+);
+
+our $audit_log = "/var/log/audit/audit.log";
+
 # Disable stdout buffering to make pipe works
 sub aa_disable_stdout_buf {
     my ($self, $app) = @_;
@@ -122,7 +128,14 @@ sub pre_run_hook {
     my ($self) = @_;
 
     select_console 'root-console';
+    systemctl('restart auditd');
     systemctl('restart apparmor');
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    upload_logs("$audit_log");
+    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -81,6 +81,7 @@ our @EXPORT = qw(
   load_rescuecd_tests
   load_rollback_tests
   load_security_tests_apparmor
+  load_security_tests_apparmor_profile
   load_security_tests_core
   load_security_tests_crypt
   load_security_tests_misc
@@ -2026,6 +2027,12 @@ sub load_security_tests_apparmor {
     loadtest "security/apparmor/aa_logprof";
     loadtest "security/apparmor/aa_easyprof";
     loadtest "security/apparmor/aa_notify";
+}
+
+sub load_security_tests_apparmor_profile {
+    loadtest "security/apparmor_profile/usr_sbin_dovecot";
+    loadtest "security/apparmor_profile/usr_sbin_traceroute";
+    loadtest "security/apparmor_profile/usr_sbin_nscd";
 }
 
 sub load_security_tests_openscap {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -400,6 +400,9 @@ elsif (get_var('SECURITY_TEST')) {
     elsif (check_var("SECURITY_TEST", "selinux")) {
         load_security_tests_selinux;
     }
+    elsif (check_var("SECURITY_TEST", "apparmor_profile")) {
+        load_security_tests_apparmor_profile;
+    }
 }
 elsif (get_var('SYSTEMD_TESTSUITE')) {
     load_systemd_patches_tests;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -793,6 +793,9 @@ elsif (get_var("SECURITY_TEST")) {
     elsif (check_var("SECURITY_TEST", "selinux")) {
         load_security_tests_selinux;
     }
+    elsif (check_var("SECURITY_TEST", "apparmor_profile")) {
+        load_security_tests_apparmor_profile;
+    }
 }
 elsif (get_var('SMT')) {
     prepare_target();

--- a/tests/security/apparmor_profile/usr_sbin_dovecot.pm
+++ b/tests/security/apparmor_profile/usr_sbin_dovecot.pm
@@ -1,0 +1,53 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test with "usr.sbin.dovecot" is in "enforce" mode and AppArmor is
+#          "enabled && active", stop and start the dovecot service have no error.
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#44999, tc#1695949
+
+use base "apparmortest";
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = shift;
+    my $log_file = $apparmortest::audit_log;
+
+    zypper_call("in dovecot");
+
+    # set the AppArmor security profile to enforce mode
+    my $profile_name = "usr.sbin.dovecot";
+    validate_script_output("aa-enforce $profile_name", sub { m/Setting .*$profile_name to enforce mode./ });
+
+    # cleanup audit log
+    assert_script_run("echo > $log_file");
+
+    # verify "dovecot" service
+    assert_script_run("systemctl stop dovecot.service");
+    assert_script_run("systemctl start dovecot.service");
+    assert_script_run("systemctl restart dovecot.service");
+    assert_script_run("systemctl status --no-pager dovecot.service", sub { m/Active: active (running)./ });
+
+    # verify audit log contains no related error
+    my $script_output = script_output "cat $log_file";
+    if ($script_output =~ m/type=AVC .*apparmor=.*DENIED.* profile=.*dovecot.* comm=.*dovecot.*/sx) {
+        record_info("ERROR", "There are errors found in $log_file", result => 'fail');
+        $self->result('fail');
+    }
+}
+
+1;

--- a/tests/security/apparmor_profile/usr_sbin_nscd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_nscd.pm
@@ -1,0 +1,53 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test with "usr.sbin.nscd" is in "enforce" mode and AppArmor is
+#          "enabled && active", stop and start the nscd service have no error.
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#44993, tc#1695951
+
+use base "apparmortest";
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = shift;
+    my $log_file = $apparmortest::audit_log;
+
+    zypper_call("in nscd");
+
+    # set the AppArmor security profile to enforce mode
+    my $profile_name = "usr.sbin.nscd";
+    validate_script_output("aa-enforce $profile_name", sub { m/Setting .*$profile_name to enforce mode./ });
+
+    # cleanup audit log
+    assert_script_run("echo > $log_file");
+
+    # verify "nscd" service
+    assert_script_run("systemctl stop nscd.service");
+    assert_script_run("systemctl start nscd.service");
+    assert_script_run("systemctl restart nscd.service");
+    assert_script_run("systemctl status --no-pager nscd.service", sub { m/Active: active (running)./ });
+
+    # verify audit log contains no related error
+    my $script_output = script_output "cat $log_file";
+    if ($script_output =~ m/type=AVC .*apparmor=.*DENIED.* profile=.*nscd.* comm=.*nscd.*/sx) {
+        record_info("ERROR", "There are errors found in $log_file", result => 'fail');
+        $self->result('fail');
+    }
+}
+
+1;

--- a/tests/security/apparmor_profile/usr_sbin_traceroute.pm
+++ b/tests/security/apparmor_profile/usr_sbin_traceroute.pm
@@ -1,0 +1,48 @@
+# Copyright (C) 2018 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test with "usr.sbin.traceroute" is in "enforce" mode and AppArmor is
+#          "enabled && active", the "/usr/sbin/traceroute" can work as usual.
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#44996, tc#1682587
+
+use base "apparmortest";
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = shift;
+    my $log_file = $apparmortest::audit_log;
+
+    # set the AppArmor security profile to enforce mode
+    my $profile_name = "usr.sbin.traceroute";
+    validate_script_output("aa-enforce $profile_name", sub { m/Setting .*$profile_name to enforce mode./ });
+
+    # cleanup audit log
+    assert_script_run("echo > $log_file");
+
+    # verify "/usr/sbin/traceroute" can work
+    assert_script_run("traceroute www.baidu.com");
+
+    # verify audit log contains no related error
+    my $script_output = script_output "cat $log_file";
+    if ($script_output =~ m/type=AVC .*apparmor=.*DENIED.* profile=.*traceroute.* comm=.*traceroute.*/sx) {
+        record_info("ERROR", "There are errors found in $log_file", result => 'fail');
+        $self->result('fail');
+    }
+}
+
+1;


### PR DESCRIPTION
Add AppArmor profile related test cases to openQA:
  verified on local x86_64 arch for "sle15-sp1-b115.1" and "tumble-weed-b20181213";
  verified the fail situations on purpose and got the expected fail and logs;
  re-ran "apparmor" test case (since modified the common lib file) and introduced no new issue;

  All are pass.

- Related ticket: 
  https://progress.opensuse.org/issues/44993
  https://progress.opensuse.org/issues/44999
  https://progress.opensuse.org/issues/44996
- Needles: no
- Verification run:
  Build20181213 of opensuse-Tumbleweed:  http://10.67.19.89/tests/454
  Build115.1 of sle-15-SP1:  http://10.67.19.89/tests/450
  Other test cases regression run:  http://10.67.19.89/tests/454