### PR TITLE
Make fail obvious on window close in yast2_snapper

### DIFF
--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -73,8 +73,9 @@ sub y2snapper_show_changes_and_delete {
     }
     # Make sure it shows the new files from the unpacked tarball
     send_key_until_needlematch 'yast2_snapper-show_testdata', 'up';
-    send_key_until_needlematch('yast2_snapper-new_snapshot', 'alt-c', 5, 10);
     # Close the dialog and make sure it is closed
+    send_key 'alt-c';
+    die '"Selected Snapshot Overview" window is not closed after sending alt-c' unless check_screen('yast2_snapper-new_snapshot', 100);
     wait_screen_change { send_key 'end' };
     send_key_until_needlematch('yast2_snapper-new_snapshot_selected', 'up');
     # Dele't'e the snapshot


### PR DESCRIPTION
The yast2_snapper module fails on window close on the systems with high
load. In order to make the review simpler, the additional message is
added.

The commit shows message on fail if "Selected Snapshot Overview" dialog
is not closed after sending 'alt-c' key combination.

- Related ticket: https://progress.opensuse.org/issues/43784
- Verification run: http://oorlov-vm.qa.suse.de/tests/704#step/yast2_snapper/66
