### PR TITLE
Change the needle with others

### DIFF
--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -73,6 +73,9 @@ sub y2snapper_show_changes_and_delete {
     }
     # Make sure it shows the new files from the unpacked tarball
     send_key_until_needlematch 'yast2_snapper-show_testdata', 'up';
+    # Make sure 'alt-c' can go back to the origion page
+    # Refer ticket: https://progress.opensuse.org/issues/45107
+    send_key_until_needlematch('yast2_snapper-snapshots', 'alt-c', 5, 10);
     # Close the dialog and make sure it is closed
     send_key 'alt-c';
     die '"Selected Snapshot Overview" window is not closed after sending alt-c' unless check_screen('yast2_snapper-new_snapshot', 100);


### PR DESCRIPTION
Change the needle to which one can always show up

- Related ticket: https://progress.opensuse.org/issues/45107
- Verification run: http://openqa-apac1.suse.de/tests/2814#
[autoinst-log.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/2689119/autoinst-log.txt)

