### PR TITLE
publiccloud: fix gce upload

### DIFF
--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -26,6 +26,7 @@ has private_key_id      => undef;
 has private_key         => undef;
 has service_acount_name => undef;
 has client_id           => undef;
+has storage_name        => undef;
 
 sub init {
     my ($self) = @_;


### PR DESCRIPTION
missing `storage_name` member variable somehow...

See failed run in https://openqa.suse.de/tests/2340651#step/upload_image/52

- Verification run: http://cfconrad-vm.qa.suse.de/tests/3157
