### PR TITLE
Rename magic string from sccreg-done to sccreg-done

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -529,7 +529,7 @@ sub registration_bootloader_params {
 }
 
 sub yast_scc_registration {
-    type_string "yast2 scc; echo yast-scc-done-\$?- > /dev/$serialdev\n";
+    type_string "yast2 scc; echo sccreg-done-\$?- > /dev/$serialdev\n";
     assert_screen_with_soft_timeout(
         'scc-registration',
         timeout      => 90,
@@ -539,8 +539,8 @@ sub yast_scc_registration {
 
     fill_in_registration_data;
 
-    my $ret = wait_serial "yast-scc-done-\\d+-";
-    die "yast scc failed" unless (defined $ret && $ret =~ /yast-scc-done-0-/);
+    my $ret = wait_serial "sccreg-done-\\d+-";
+    die "yast scc failed" unless (defined $ret && $ret =~ /sccreg-done-0-/);
 
     # To check repos validity after registration, call 'validate_repos' as needed
 }


### PR DESCRIPTION
There's an awkward bug in Hyper-V 2012 R2 product which makes 16th
character on the serial line to be lost. As a result migration tests
fail there very offen. Trimming the string prevent's the bug.

Fails here:
* https://openqa.suse.de/tests/2329670#step/patch_sle/91
* https://openqa.suse.de/tests/2329651#step/patch_sle/33
* https://openqa.suse.de/tests/2329632#step/patch_sle/35