### PR TITLE
Adding new suseconnect test for QAM usage.

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -666,6 +666,14 @@ sub load_default_autoyast_tests {
     load_reboot_tests;
 }
 
+sub load_suseconnect_tests {
+    prepare_target;
+    loadtest "console/system_prepare";
+    loadtest "console/consoletest_setup";
+    loadtest "console/suseconnect";
+}
+
+
 my $distri = testapi::get_required_var('CASEDIR') . '/lib/susedistribution.pm';
 require $distri;
 testapi::set_distribution(susedistribution->new());
@@ -699,7 +707,8 @@ elsif (get_var("NFV")) {
 }
 elsif (get_var("REGRESSION")) {
     load_common_x11;
-    load_xen_tests if check_var("REGRESSION", "xen");
+    load_xen_tests         if check_var("REGRESSION", "xen");
+    load_suseconnect_tests if check_var("REGRESSION", "suseconnect");
 }
 elsif (get_var("FEATURE")) {
     prepare_target();

--- a/tests/console/suseconnect.pm
+++ b/tests/console/suseconnect.pm
@@ -1,0 +1,49 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test SUSEConnect by registering system, module and deregistration.
+# Maintainer: Juraj Hura <jhura@suse.com>
+
+use base "basetest";
+use strict;
+use testapi;
+use utils 'zypper_call';
+use registration;
+use version_utils 'is_sle';
+
+sub run {
+    my $reg_code      = get_required_var("SCC_REGCODE");
+    my $arch          = get_required_var("ARCH");
+    my $live_reg_code = get_required_var("SCC_REGCODE_LIVE");
+
+    select_console 'root-console';
+
+    # Make sure to start with de-registered system. In case the system is not registered this command will fail
+    assert_script_run "SUSEConnect -d ||:";
+    assert_script_run "SUSEConnect --cleanup";
+    assert_script_run "SUSEConnect --status-text";
+
+    zypper_call 'lr';
+    zypper_call 'services';
+    zypper_call 'products';
+
+    assert_script_run "SUSEConnect -r $reg_code";
+    assert_script_run "SUSEConnect --status-text| grep -v 'Not Registered'";
+    zypper_call 'ref';
+    assert_script_run "SUSEConnect --list-extensions";
+
+    add_suseconnect_product(is_sle('<15') ? 'sle-live-patching' : 'sle-module-live-patching', undef, undef, "-r $live_reg_code");
+
+    assert_script_run "SUSEConnect --status";
+    assert_script_run "SUSEConnect -d";
+    assert_script_run "SUSEConnect --status-text";
+
+}
+
+1;


### PR DESCRIPTION
Adding new test for SUSEConnect to be used as regression testing for QAM.

- Related ticket: https://progress.opensuse.org/issues/43136
- Needles:
- Verification run:
    SLE 15: http://hoorhay.suse.cz/tests/124#
    SLE 12 SP4: http://hoorhay.suse.cz/tests/125#
