### PR TITLE
wicked : Increase timeout to cover osd slowness

### DIFF
--- a/tests/wicked/startandstop/sut/t11_vlan_ifdown_modify_one_config.pm
+++ b/tests/wicked/startandstop/sut/t11_vlan_ifdown_modify_one_config.pm
@@ -32,7 +32,7 @@ sub run {
     assert_script_run('ip a');
     die('VLAN interface does not exists') if (!ifc_exists($iface . '.42'));
     die('IP is unreachable')
-      if (!$self->ping_with_timeout(ip => $self->get_remote_ip(type => 'vlan_changed'), timeout => '5'));
+      if (!$self->ping_with_timeout(ip => $self->get_remote_ip(type => 'vlan_changed'), timeout => '50'));
     $self->wicked_command('ifdown', "all");
     die('VLAN interface exists') if (ifc_exists($iface . '.42'));
 }


### PR DESCRIPTION
old version of code works perfect on kimball : 
http://kimball.arch.suse.de/tests/341
http://kimball.arch.suse.de/tests/340 

and fails on osd : 
https://openqa.suse.de/tests/2344035 

only sane reason for this is slow environment so let's try to increase timeout for failing command 
no reason to do a prove run 