### PR TITLE
[WIP]IPMI: Support ipmi main board reset during test

### DIFF
--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -28,8 +28,16 @@ sub reboot_and_wait_up {
         $self->reboot($test_machine, $reboot_timeout);
     }
     else {
-        #leave ssh console and switch to sol console
-        switch_from_ssh_to_sol_console(reset_console_flag => 'off');
+        # leave ssh console and switch to sol console
+        # Now we support resetting ipmi main board during test via
+        # a testsuite setting switch MC_RESET_BEFORE_REBOOT.
+        # Reboot is a weak point which suffers ipmi sol unstability
+        # So do ipmi mc reset before reboot can increase stability
+        my $mc_reset_flag = 'off';
+        if (check_var('MC_RESET_BEFORE_REBOOT', 1)) {
+            $mc_reset_flag = 'on';
+        }
+        switch_from_ssh_to_sol_console(mc_reset_flag => $mc_reset_flag);
         #login
         #The timeout can't be too small since autoyast installation
         #need to wait 2nd phase install to finish


### PR DESCRIPTION
This PR aims to increase ipmi job's stability via resetting ipmi main board thru 'mc reset' command.

* Background:
Detailed discussions are in https://progress.opensuse.org/issues/36027.
Shortly speaking, currently openqa jobs on ipmi backend is unstable because ipmi sol console itself is unstable after long time of job running or high work load. Resetting the ipmi main board can recover the sol console stability. 

  Where to reset and how to reset sol?
  Reset via external tools like jenkins jobs or reset based on given time or given frequency is very likely to break running openqa jobs because syncing is not easy. So doing it in openqa jobs and backend becomes preferred.

  How often to reset?
  Reset once before test start, and reset at weak points where sol unstability is likely to happen  like around reboot or power on.

* What it provides:
a) provide api in lib/ipmi_backend_utils.pm to call the console provided mc reset api 
b) virtualization reboot related test files is likely to meet unstable sol issues, so add code to call mc reset before reboot
c) boot_from_pxe issues is likely to be fixed by the related backend PR#1078 already, since it will do mc reset before load test, and boot_from_pxe is the first test file for baremetal machine ipmi jobs
d) if other ipmi jobs also have test codes that suffer from unstable ipmi, then can refer to b) by using a). This is not covered in this PR. Relevant testers can add by themselves. 

* Related tickets:
This PR relies on backend change https://github.com/os-autoinst/os-autoinst/pull/1078

* Verification run:
  http://10.67.18.220/tests/494:  guest installation test
  http://10.67.18.220/tests/498: offline host upgrade
  Both with mc reset before test and mc reset during test (before reboot,  in reboot_and_wait_up_normal.pm and reboot_and_wait_up_upgrade.pm)

