### PR TITLE
Modify PXE boot to run LTP tests on ipmi, autoyast, cleanup

### DIFF
--- a/data/ltp/ltp_15sp0.xml
+++ b/data/ltp/ltp_15sp0.xml
@@ -1,0 +1,320 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <add-on>
+    <add_on_products config:type="list">
+<!-- will be added in following update_kernel.pm
+      <listentry>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Products/SLE-Module-Live-Patching/15/x86_64/product]]></media_url>
+        <product>kgraft-pool</product>
+        <product_dir/>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Live-Patching/15/x86_64/update]]></media_url>
+        <product>kgraft-update</product>
+        <product_dir/>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://dist.nue.suse.com/ibs/QA:/Head/SLE-15]]></media_url>
+        <product>qa_repo</product>
+        <product_dir/>
+      </listentry>
+-->
+      <listentry>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15/x86_64/product]]></media_url>
+        <product>SLES:15::pool</product>
+        <product_dir/>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15/x86_64/update]]></media_url>
+        <product>SLES:15::update</product>
+        <product_dir/>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product]]></media_url>
+        <product>sle-module-basesystem:15::pool</product>
+        <product_dir/>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update]]></media_url>
+        <product>sle-module-basesystem:15::update</product>
+        <product_dir/>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Products/SLE-Module-Desktop-Applications/15/x86_64/product]]></media_url>
+        <product>sle-module-desktop-applications:15::pool</product>
+        <product_dir/>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Desktop-Applications/15/x86_64/update]]></media_url>
+        <product>sle-module-desktop-applications:15::update</product>
+        <product_dir/>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15/x86_64/product]]></media_url>
+        <product>sle-module-development-tools:15::pool</product>
+        <product_dir/>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15/x86_64/update]]></media_url>
+        <product>sle-module-development-tools:15::update</product>
+        <product_dir/>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Products/SLE-Module-Public-Cloud/15/x86_64/product]]></media_url>
+        <product>sle-module-public-cloud:15::pool</product>
+        <product_dir/>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Public-Cloud/15/x86_64/update]]></media_url>
+        <product>sle-module-public-cloud:15::update</product>
+        <product_dir/>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product]]></media_url>
+        <product>sle-module-server-applications:15::pool</product>
+        <product_dir/>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Server-Applications/15/x86_64/update]]></media_url>
+        <product>sle-module-server-applications:15::update</product>
+        <product_dir/>
+      </listentry>
+    </add_on_products>
+  </add-on>
+  <bootloader>
+    <global>
+      <activate>true</activate>
+      <boot_mbr>true</boot_mbr>
+      <append>splash=silent quiet console=tty1 console=ttyS1,115200</append>
+      <serial>serial --speed=115200 --unit=1</serial>
+      <terminal>serial</terminal>
+      <timeout config:type="integer">15</timeout>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <proposals config:type="list"/>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+  </general>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <networking>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+  </networking>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/sda</device>
+      <disklabel>gpt</disklabel>
+      <enable_snapshots config:type="boolean">true</enable_snapshots>
+      <initialize config:type="boolean">false</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <format config:type="boolean">false</format>
+          <partition_id config:type="integer">263</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <partition_type>primary</partition_type>
+          <resize config:type="boolean">false</resize>
+          <size>8M</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>swap</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <partition_type>primary</partition_type>
+          <resize config:type="boolean">false</resize>
+          <size>2G</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <create_subvolumes config:type="boolean">true</create_subvolumes>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">3</partition_nr>
+          <partition_type>primary</partition_type>
+          <resize config:type="boolean">false</resize>
+          <size>max</size>
+          <subvolumes config:type="list">
+            <subvolume>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>tmp</path>
+            </subvolume>
+            <subvolume>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>srv</path>
+            </subvolume>
+            <subvolume>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>root</path>
+            </subvolume>
+            <subvolume>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>opt</path>
+            </subvolume>
+            <subvolume>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>boot/grub2/x86_64-efi</path>
+            </subvolume>
+            <subvolume>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>boot/grub2/i386-pc</path>
+            </subvolume>
+            <subvolume>
+              <copy_on_write config:type="boolean">false</copy_on_write>
+              <path>var</path>
+            </subvolume>
+            <subvolume>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>usr/local</path>
+            </subvolume>
+          </subvolumes>
+          <subvolumes_prefix><![CDATA[@]]></subvolumes_prefix>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <filesystem config:type="symbol">xfs</filesystem>
+          <format config:type="boolean">true</format>
+          <mount>/home</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">4</partition_nr>
+          <partition_type>primary</partition_type>
+          <resize config:type="boolean">false</resize>
+          <size>5G</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+    <drive>
+      <device>/dev/sdb</device>
+      <disklabel>gpt</disklabel>
+      <enable_snapshots config:type="boolean">false</enable_snapshots>
+      <initialize config:type="boolean">false</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <format config:type="boolean">false</format>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <partition_type>primary</partition_type>
+          <resize config:type="boolean">false</resize>
+          <size>6G</size>
+        </partition>
+      </partitions>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <disable config:type="list"/>
+      <enable config:type="list">
+        <service>sshd</service>
+        <service>auditid</service>
+        <service>dnsmasq</service>
+        <service>nfsserver</service>
+        <service>rpcbind</service>
+        <service>vsftpd</service>
+      </enable>
+    </services>
+  </services-manager>
+  <software>
+    <image/>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <instsource/>
+    <packages config:type="list">
+      <package>screen</package>
+      <package>sysstat</package>
+      <package>iputils</package>
+      <package>acl</package>
+      <package>audit</package>
+      <package>binutils</package>
+      <package>dosfstools</package>
+      <package>evmctl</package>
+      <package>net-tools</package>
+      <package>nfs-kernel-server</package>
+      <package>numactl</package>
+      <package>psmisc</package>
+      <package>quota</package>
+      <package>sssd-tools</package>
+      <package>sudo</package>
+      <package>tpm-tools</package>
+      <package>wget</package>
+      <package>xfsprogs</package>
+      <package>iptables</package>
+      <package>tcpdump</package>
+      <package>dhcp-client</package>
+      <package>telnet</package>
+      <package>dhcp-server</package>
+      <package>dnsmasq</package>
+      <package>rpcbind</package>
+      <package>rsync</package>
+      <package>vsftpd</package>
+      <package>apparmor-utils</package>
+      <package>apparmor-parser</package>
+      <package>bzip2</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>base</pattern>
+      <pattern>minimal_base</pattern>
+    </patterns>
+    <products config:type="list">
+      <product>SLES</product>
+      <product>sle-module-live-patching</product>
+    </products>
+  </software>
+  <suse_register>
+    <do_registration config:type="boolean">true</do_registration>
+    <install_updates config:type="boolean">true</install_updates>
+    <reg_code>32d819432ec25403</reg_code>
+    <slp_discovery config:type="boolean">false</slp_discovery>
+  </suse_register>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>$6$Q7j41x6B/mnN$FA1mrMw4UjW9bBEgEoxDD9RRv6pau9sdUeSSfOwoC7ajssr83tVBDefYPnZ7jCamwqhCnXor6KABo5vDeva4k0</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$6$mjXHVqyFsxGB$aVnx8nBzUnFgyI9kXTBkQr9K/mN1GnWzPTmhJezemKdKB.qGAGgl35A6IwSOoTiOuIyvbFPGBreYmvFxkt4uq0</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -554,8 +554,9 @@ sub specific_bootmenu_params {
             # due to BSC#932692 (SLE-12). 'SetHostname=0' has to be set because autoyast
             # profile has DHCLIENT_SET_HOSTNAME="yes" in /etc/sysconfig/network/dhcp,
             # 'ifcfg=*=dhcp' sets this variable in ifcfg-eth0 as well and we can't
-            # have them both as it's not deterministic.
-            $netsetup = get_var("NETWORK_INIT_PARAM", "ifcfg=*=dhcp SetHostname=0");
+            # have them both as it's not deterministic. Don't set on IPMI with net interface defined in SUT_NETDEVICE.
+            my $ifcfg = check_var('BACKEND', 'ipmi') ? '' : 'ifcfg=*=dhcp SetHostname=0';
+            $netsetup = get_var("NETWORK_INIT_PARAM", "$ifcfg");
             $args .= " $netsetup ";
             $args .= autoyast_boot_params;
         }

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -385,6 +385,12 @@ sub wait_boot {
             select_console('x11', await_console => 0);
         }
     }
+    elsif (check_var('BACKEND', 'ipmi')) {
+        select_console 'sol', await_console => 0;
+        # boot from harddrive
+        assert_screen([qw(pxe-menu-bei pxe-menu-nue pxe-menu-prg pxe-menu)], 200);
+        send_key 'ret';
+    }
     # On Xen PV and svirt we don't see a Grub menu
     elsif (!(check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux') && check_var('BACKEND', 'svirt'))) {
         my @tags = ('grub2');

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1009,7 +1009,7 @@ elsif (get_var('VALIDATE_PCM_PATTERN')) {
     load_public_cloud_patterns_validation_tests;
 }
 else {
-    if (get_var("SES5_DEPLOY")) {
+    if (get_var('IPMI_AUTOYAST')) {
         loadtest "boot/boot_from_pxe";
         loadtest "autoyast/installation";
         loadtest "installation/first_boot";

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -119,7 +119,7 @@ sub verify_timeout_and_check_screen {
 sub run {
     my ($self) = @_;
 
-    if (check_var('BACKEND', 'ipmi') && get_var("SES5_DEPLOY")) {
+    if (check_var('BACKEND', 'ipmi') && get_var('IPMI_AUTOYAST')) {
         assert_screen 'installation-done', 750;
         reset_consoles;
         select_console 'sol', await_console => 0;

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -123,7 +123,7 @@ sub run {
         assert_screen 'installation-done', 750;
         reset_consoles;
         select_console 'sol', await_console => 0;
-        assert_screen 'prague-pxe-menu', 400;
+        assert_screen([qw(pxe-menu-bei pxe-menu-nue pxe-menu-prg pxe-menu)], 400);
         send_key 'ret';    # boot from hard disk
         return;
     }

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -32,21 +32,15 @@ sub run {
     if (check_var('BACKEND', 'ipmi')) {
         select_console 'sol', await_console => 0;
     }
-    assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu prague-icecream-pxe-menu pxe-menu)], 300);
     my $image_path = "";
+    assert_screen([qw(pxe-menu-bei pxe-menu-nue pxe-menu-prg pxe-menu)], 300);
     #detect pxe location
-    if (match_has_tag("virttest-pxe-menu")) {
-        #BeiJing
-        # Login to command line of pxe management
-        send_key_until_needlematch "virttest-pxe-edit-prompt", "esc", 60, 1;
-
+    if (match_has_tag('pxe-menu-bei')) {    # BeiJing
+        send_key_until_needlematch 'pxe-edit-prompt', 'esc', 60, 1;
         $image_path = get_var("HOST_IMG_URL");
     }
-    elsif (match_has_tag("qa-net-selection")) {
-        #Nuremberg
-        send_key_until_needlematch 'qa-net-boot', 'esc', 8, 3;
-
-        my $image_name = "";
+    elsif (match_has_tag('pxe-menu-nue')) {     # Nuremberg
+        send_key_until_needlematch 'pxe-edit-prompt', 'esc', 8, 3;
         if (check_var("INSTALL_TO_OTHERS", 1)) {
             $image_name = get_var("REPO_0_TO_INSTALL");
         }
@@ -64,22 +58,21 @@ sub run {
         }
         $image_path = "$path/linux initrd=$path/initrd install=$repo ";
     }
-    elsif (match_has_tag('prague-pxe-menu')) {
         send_key_until_needlematch 'pxe-stable-iso-entry', 'down';
         send_key 'ret';
         send_key_until_needlematch 'pxe-sle-12-sp3-entry', 'down';
         send_key 'tab';
         my $node = get_var('WORKER_CLASS');
     }
-    elsif (match_has_tag('prague-icecream-pxe-menu')) {
         # Fix problem with sol on ttyS2
         $testapi::serialdev = get_var('SERIALDEV') if get_var('SERIALDEV');
-        send_key_until_needlematch 'qa-net-boot', 'esc', 8, 3;
 
         my $arch = get_var('ARCH');
         my ($image_name) = get_var('ISO') =~ s/^.*?([^\/]+)-DVD-${arch}-([^-]+)-DVD1\.iso/$1-$2/r;
         $image_path .= "/mounts/dist/install/SLP/${image_name}/${arch}/DVD1/boot/${arch}/loader/linux ";
         $image_path .= "initrd=/mounts/dist/install/SLP/${image_name}/${arch}/DVD1/boot/${arch}/loader/initrd ";
+    elsif (match_has_tag('pxe-menu-prg')) {      # Prague
+        send_key_until_needlematch 'pxe-edit-prompt', 'esc', 8, 3;
             my $device = check_var('BACKEND', 'ipmi') ? "?device=$interface" : '';
             $image_path .= "install=http://mirror.suse.cz/install/SLP/${image_name}/${arch}/DVD1$device ";
     }

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -39,7 +39,7 @@ sub run {
         send_key_until_needlematch 'pxe-edit-prompt', 'esc', 60, 1;
         $image_path = get_var("HOST_IMG_URL");
     }
-    elsif (match_has_tag('pxe-menu-nue')) {     # Nuremberg
+    elsif (match_has_tag('pxe-menu-nue')) {    # Nuremberg
         send_key_until_needlematch 'pxe-edit-prompt', 'esc', 8, 3;
         if (check_var("INSTALL_TO_OTHERS", 1)) {
             $image_name = get_var("REPO_0_TO_INSTALL");
@@ -57,7 +57,7 @@ sub run {
         }
         $image_path = "$path/linux initrd=$path/initrd install=$repo ";
     }
-    elsif (match_has_tag('pxe-menu-prg')) {      # Prague
+    elsif (match_has_tag('pxe-menu-prg')) {    # Prague
         send_key_until_needlematch 'pxe-edit-prompt', 'esc', 8, 3;
         if (get_var('PXE_ENTRY')) {
             my $entry = get_var('PXE_ENTRY');

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -19,7 +19,7 @@ use File::Basename;
 use lockapi;
 use registration;
 use testapi;
-use utils 'type_string_very_slow';
+use utils 'type_string_slow';
 
 sub run {
     my $interface = get_var('SUT_NETDEVICE', 'eth0');
@@ -34,7 +34,6 @@ sub run {
     }
     assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu prague-icecream-pxe-menu pxe-menu)], 300);
     my $image_path = "";
-    my $type_speed = 20;
     #detect pxe location
     if (match_has_tag("virttest-pxe-menu")) {
         #BeiJing
@@ -90,7 +89,7 @@ sub run {
         send_key "tab";
     }
     # Execute installation command on pxe management cmd console
-    type_string ${image_path} . " ", $type_speed;
+    type_string_slow ${image_path};
     bootmenu_default_params(pxe => 1, baud_rate => '115200');
 
     if (check_var('BACKEND', 'ipmi')) {
@@ -106,15 +105,14 @@ sub run {
         # 'ssh=1' and 'sshd=1' are equal, both together don't work
         # so let's just set the password here
         $cmdline .= "sshpassword=$testapi::password ";
-        type_string $cmdline, $type_speed;
+        type_string_slow $cmdline;
     }
 
     if (check_var('SCC_REGISTER', 'installation') && !(check_var('VIRT_AUTOTEST', 1) && check_var('INSTALL_TO_OTHERS', 1))) {
-        type_string(registration_bootloader_cmdline, $type_speed);
+        type_string_slow(registration_bootloader_cmdline);
     }
 
     specific_bootmenu_params;
-
     send_key 'ret';
     save_screenshot;
 
@@ -125,8 +123,8 @@ sub run {
 
         # We have textmode installation via ssh and the default vnc installation so far
         if (check_var('VIDEOMODE', 'text') || check_var('VIDEOMODE', 'ssh-x')) {
-            type_string('DISPLAY= ', $type_speed) if check_var('VIDEOMODE', 'text');
-            type_string("yast.ssh\n", $type_speed);
+            type_string_slow('DISPLAY= ') if check_var('VIDEOMODE', 'text');
+            type_string_slow("yast.ssh\n");
         }
         wait_still_screen;
     }

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -14,17 +14,18 @@ use base 'opensusebasetest';
 
 use strict;
 use warnings;
-use bootloader_setup;
-use File::Basename;
 use lockapi;
-use registration;
 use testapi;
+use bootloader_setup qw(bootmenu_default_params specific_bootmenu_params);
+use registration 'registration_bootloader_cmdline';
 use utils 'type_string_slow';
 
 sub run {
+    my ($image_path, $image_name, $cmdline);
+    my $arch = get_var('ARCH');
     my $interface = get_var('SUT_NETDEVICE', 'eth0');
     # In autoyast tests we need to wait until pxe is available
-    if (get_var('AUTOYAST') && get_var('DELAYED_START')) {
+    if (get_var('AUTOYAST') && get_var('DELAYED_START') && !check_var('BACKEND', 'ipmi')) {
         mutex_lock('pxe');
         mutex_unlock('pxe');
         resume_vm();
@@ -32,7 +33,6 @@ sub run {
     if (check_var('BACKEND', 'ipmi')) {
         select_console 'sol', await_console => 0;
     }
-    my $image_path = "";
     assert_screen([qw(pxe-menu-bei pxe-menu-nue pxe-menu-prg pxe-menu)], 300);
     #detect pxe location
     if (match_has_tag('pxe-menu-bei')) {    # BeiJing
@@ -48,7 +48,6 @@ sub run {
             $image_name = get_var("REPO_0");
         }
 
-        my $arch       = get_var('ARCH');
         my $path       = "/mnt/openqa/repo/${image_name}/boot/${arch}/loader";
         my $openqa_url = get_required_var('OPENQA_URL');
         $openqa_url = 'http://' . $openqa_url unless $openqa_url =~ /http:\/\//;
@@ -58,23 +57,21 @@ sub run {
         }
         $image_path = "$path/linux initrd=$path/initrd install=$repo ";
     }
-        send_key_until_needlematch 'pxe-stable-iso-entry', 'down';
-        send_key 'ret';
-        send_key_until_needlematch 'pxe-sle-12-sp3-entry', 'down';
-        send_key 'tab';
-        my $node = get_var('WORKER_CLASS');
-    }
-        # Fix problem with sol on ttyS2
-        $testapi::serialdev = get_var('SERIALDEV') if get_var('SERIALDEV');
-
-        my $arch = get_var('ARCH');
-        my ($image_name) = get_var('ISO') =~ s/^.*?([^\/]+)-DVD-${arch}-([^-]+)-DVD1\.iso/$1-$2/r;
-        $image_path .= "/mounts/dist/install/SLP/${image_name}/${arch}/DVD1/boot/${arch}/loader/linux ";
-        $image_path .= "initrd=/mounts/dist/install/SLP/${image_name}/${arch}/DVD1/boot/${arch}/loader/initrd ";
     elsif (match_has_tag('pxe-menu-prg')) {      # Prague
         send_key_until_needlematch 'pxe-edit-prompt', 'esc', 8, 3;
+        if (get_var('PXE_ENTRY')) {
+            my $entry = get_var('PXE_ENTRY');
+            send_key_until_needlematch "pxe-$entry-entry", 'down';
+            send_key 'tab';
+        }
+        else {
             my $device = check_var('BACKEND', 'ipmi') ? "?device=$interface" : '';
+            my $release = get_var('BETA') ? 'LATEST' : 'GM';
+            $image_name = get_var('ISO') =~ s/.*\/(.*)-DVD-${arch}-.*\.iso/$1-$release/r;
+            $image_path = "/mounts/dist/install/SLP/${image_name}/${arch}/DVD1/boot/${arch}/loader/linux ";
+            $image_path .= "initrd=/mounts/dist/install/SLP/${image_name}/${arch}/DVD1/boot/${arch}/loader/initrd ";
             $image_path .= "install=http://mirror.suse.cz/install/SLP/${image_name}/${arch}/DVD1$device ";
+        }
     }
     elsif (match_has_tag('pxe-menu')) {
         # select network (second entry)
@@ -109,9 +106,8 @@ sub run {
     send_key 'ret';
     save_screenshot;
 
-    if ((check_var('BACKEND', 'ipmi') && !get_var('AUTOYAST')) || get_var('SES5_DEPLOY')) {
-        my $ssh_vnc_wait_time = 600;
-        assert_screen((check_var('VIDEOMODE', 'text') ? 'sshd' : 'vnc') . '-server-started', $ssh_vnc_wait_time);
+    if (check_var('BACKEND', 'ipmi')) {
+        assert_screen((check_var('VIDEOMODE', 'text') ? 'sshd' : 'vnc') . '-server-started', 600);
         select_console 'installation';
 
         # We have textmode installation via ssh and the default vnc installation so far

--- a/tests/boot/qa_net_boot_from_hdd.pm
+++ b/tests/boot/qa_net_boot_from_hdd.pm
@@ -18,7 +18,7 @@ sub run {
     if (check_var('BACKEND', 'ipmi')) {
         select_console 'sol', await_console => 0;
     }
-    assert_screen "qa-net-selection", 300;
+    assert_screen 'pxe-menu-nue', 300;
     # boot to hard disk is default
     send_key 'ret';
 

--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -55,7 +55,7 @@ sub run {
     # Select Timeout dropdown box and disable
     send_key 'alt-t';
     wait_still_screen(1);
-    my $timeout = "-1";
+    my $timeout = check_var('BACKEND', 'ipmi') ? '15' : '-1';
     # SLE-12 GA only accepts positive integers in range [0,300]
     $timeout = "60" if is_sle('<12-SP1');
     type_string $timeout;

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -22,6 +22,16 @@ use base 'opensusebasetest';
 
 sub run {
     my ($self) = @_;
+    if (get_var('IPMI_AUTOYAST')) {
+        reset_consoles;
+        select_console 'sol', await_console => 0;
+        # grub will show up if serial terminal is setup in autoyast profile
+        if (check_screen 'grub2', 30) {
+            send_key 'ret';
+        }
+        # second stage of autoyast installation can take some time
+        assert_screen 'linux-login', 300;
+    }
     # On IPMI, when selecting x11 console, we are connecting to the VNC server on the SUT.
     # select_console('x11'); also performs a login, so we should be at generic-desktop.
     my $gnome_ipmi = (check_var('BACKEND', 'ipmi') && check_var('DESKTOP', 'gnome'));

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -30,7 +30,7 @@ sub run {
         $self->wait_boot(textmode => 1);
         select_console('x11');
     }
-    my $boot_timeout = (get_var('SES5_DEPLOY') || check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('BACKEND', 'ipmi')) ? 450 : 200;
+    my $boot_timeout = (get_var('IPMI_AUTOYAST') || check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('BACKEND', 'ipmi')) ? 450 : 200;
     # SLE >= 15 s390x does not offer auto-started VNC server in SUT, only login prompt as in textmode
     return if check_var('ARCH', 's390x') && is_sle('15+');
     if (check_var('WORKER_CLASS', 'hornet')) {

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -15,6 +15,7 @@ use warnings;
 use base 'opensusebasetest';
 use testapi;
 use bootloader_setup 'boot_grub_item';
+use Utils::Backends 'use_ssh_serial_console';
 
 sub run {
     my ($self, $tinfo) = @_;
@@ -32,7 +33,12 @@ sub run {
         $self->wait_boot(ready_time => 500);
     }
 
-    $self->select_serial_terminal;
+    if (check_var('BACKEND', 'ipmi')) {
+        use_ssh_serial_console;
+    }
+    else {
+        $self->select_serial_terminal;
+    }
 
     assert_script_run('export LTPROOT=/opt/ltp; export LTP_COLORIZE_OUTPUT=n TMPDIR=/tmp PATH=$LTPROOT/testcases/bin:$PATH');
 

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -20,7 +20,7 @@ use version_utils 'is_sle';
 use qam;
 use kernel 'remove_kernel_packages';
 use power_action_utils 'power_action';
-
+use Utils::Backends 'use_ssh_serial_console';
 
 my $wk_ker = 0;
 
@@ -242,11 +242,20 @@ sub update_kgraft {
     }
 }
 
+sub boot_to_console {
+    my ($self) = @_;
+    $self->wait_boot;
+    if (check_var('BACKEND', 'ipmi')) {
+        use_ssh_serial_console;
+    }
+    else {
+        select_console('root-console');
+    }
+}
+
 sub run {
     my $self = shift;
-    $self->wait_boot;
-
-    select_console('root-console');
+    boot_to_console($self);
 
     my $repo = get_required_var('INCIDENT_REPO');
 
@@ -256,8 +265,7 @@ sub run {
     if (get_var('KGRAFT')) {
         my $qa_head = get_required_var('QA_HEAD_REPO');
         prepare_kgraft($repo, $incident_id);
-        $self->wait_boot;
-        select_console('root-console');
+        boot_to_console($self);
 
         # dependencies for heavy load script
         if (!$wk_ker) {
@@ -274,8 +282,7 @@ sub run {
         }
         power_action('reboot', textmode => 1);
 
-        $self->wait_boot;
-        select_console('root-console');
+        boot_to_console($self);
 
         kgraft_state;
     }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/43046
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1028
- Verification run:
[autoyast](http://10.100.12.155/tests/9439)
[install_ltp_baremetal](http://10.100.12.155/tests/9452)
[install_ltp+sle+Server-DVD-Incidents-Kernel](http://10.100.12.155/tests/9449)
[ltp_fs_ext4](http://10.100.12.155/tests/9435)
