### PR TITLE
Ensure cups is installed

### DIFF
--- a/tests/console/cups.pm
+++ b/tests/console/cups.pm
@@ -20,6 +20,8 @@ sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
+    zypper_call("in cups", exitcode => [0, 102, 103]);
+
     script_run 'echo FileDevice Yes >> /etc/cups/cups-files.conf';
     validate_script_output 'cupsd -t', sub { m/is OK/ };
     systemctl 'enable cups.service';


### PR DESCRIPTION
Unfortunately cupsd is not installed by default on SLE12-SP2 and older. Ensure it is installed before testing.

- Verification run: http://panigale.suse.cz/tests/1143