### PR TITLE
Add regression tests for mutt

### DIFF
--- a/data/console/muttrc
+++ b/data/console/muttrc
@@ -1,0 +1,35 @@
+set abort_nosubject = no
+set abort_unmodified = no
+set askbcc = no
+set askcc = no
+set delete = yes
+set editor = "vim"
+set fast_reply = yes
+set imap_keepalive = 300
+set imap_passive= no
+set include = yes
+set mail_check = 0
+set mbox_type = Maildir
+set print_command = ""
+set quit = yes
+set reply_to = yes
+set send_charset = "us-ascii:utf-8"
+set ssl_ca_certificates_file = /etc/ssl/private/dovecot.crt
+set ssl_starttls = yes
+set ssl_use_sslv3 = no
+set ssl_use_tlsv1 = no
+set ssl_use_tlsv1_1 = no
+set ssl_verify_host = no
+set use_from = yes
+set wait_key = no
+
+unset record
+unset postponed
+
+set from = "nimda@localhost"
+set imap_user = "nimda@localhost"
+set imap_pass = "password123"
+set folder = imaps://$imap_user:993
+set spoolfile = +INBOX
+
+set smtp_url = smtp://localhost:25

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1528,6 +1528,10 @@ sub load_extra_tests_console {
     }
     # bind need source package and legacy and development module on SLE15+
     loadtest 'console/bind' if get_var('MAINT_TEST_REPO');
+    unless (is_sle('<12-SP3')) {
+        loadtest 'x11/evolution/evolution_prepare_servers';
+        loadtest 'console/mutt';
+    }
     loadtest 'console/systemd_testsuite' if is_sle('15+') && get_var('QA_HEAD_REPO');
     loadtest 'console/mdadm' unless is_jeos;
     loadtest 'console/journalctl';

--- a/tests/console/mutt.pm
+++ b/tests/console/mutt.pm
@@ -1,0 +1,76 @@
+# SUSE's openQA tests
+#
+# Copyright 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Test basic capabilities of mutt
+# Maintainer: Jan Baier <jbaier@suse.cz>
+
+use base 'consoletest';
+use strict;
+use testapi;
+use version_utils qw(is_sle is_tumbleweed);
+use utils;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    zypper_call("in mutt", exitcode => [0, 102, 103]) if is_tumbleweed;
+
+    # Mutt is Mutt (bsc#1094717) and has build in support for IMAP and SMTP
+    validate_script_output 'mutt -v', sub { m/\+USE_IMAP/ && m/\+USE_SMTP/ && not m/NeoMutt/ };
+
+    # Create initial "sane" configuration and begin the test
+    assert_script_run 'wget -O ~/.muttrc ' . data_url('console/muttrc');
+    assert_script_run 'sed -i -e "s/nimda/admin/" ~/.muttrc';
+
+    record_info 'send mail', 'Write new mail from command line';
+    assert_script_run 'echo -e "Hello,\nthis is message from admin." | mutt -s "Hello from openQA" -- nimda@localhost';
+
+    record_info 'postfix log', 'Check if the mail was really send';
+    validate_script_output 'journalctl --no-pager -u postfix', sub { m/postfix\/qmgr.*<admin\@localhost>/ };
+
+    select_console "user-console";
+    assert_script_run 'wget -O ~/.muttrc ' . data_url('console/muttrc');
+    assert_script_run 'sed -i -e "/ssl_ca_certificates_file/d" ~/.muttrc' if is_sle('<=12-SP2');
+
+    record_info 'receive mail', 'Run mutt as a user to read the mail';
+    type_string "mutt\na";
+    assert_screen 'mutt-message-list';
+    type_string "\n";
+    assert_screen 'mutt-show-mail';
+
+    record_info 'reply', 'Send a reply to the mail';
+    type_string "rOHello,\nthanks for the message.\n:x\n";
+    assert_screen 'mutt-send-reply';
+    type_string "y";
+    assert_screen 'mutt-message-sent';
+
+    record_info 'move', 'Move mail to another mailbox';
+    type_string "sArchive\n\n";
+    assert_screen 'mutt-message-deleted';
+    type_string "q";
+
+    #select_console "user-console";
+    record_info 'open mailbox', 'Open local mailbox';
+    type_string "mutt -f ~/Archive\n";
+    assert_screen 'mutt-message-list';
+    type_string "q";
+
+    type_string "clear\n";
+    script_run 'rm -r ~/Archive';
+    save_screenshot;
+
+    $self->select_serial_terminal;
+    record_info 'postfix log', 'Check if the mail was really send';
+    validate_script_output 'journalctl --no-pager -u postfix', sub { m/postfix\/qmgr.*<nimda\@localhost>/ };
+
+    select_console "root-console";
+}
+
+1;


### PR DESCRIPTION
@czerw: I reused your `evolution_prepare_servers` slightly. I hope you are OK with that change.

- Related ticket: https://progress.opensuse.org/issues/43427
- Needles: 
    - https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1029
    - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/489
- Verification run: 
    - http://panigale.suse.cz/tests/1155 (Leap 15.1)
    - http://panigale.suse.cz/tests/1166 (TW)
    - http://panigale.suse.cz/tests/1170 (SLE15)
    - http://panigale.suse.cz/tests/1172 (SLE12SP4)
    - http://panigale.suse.cz/tests/1173 (SLE12SP3)
    - http://panigale.suse.cz/tests/1163 (SLED12SP4)
