### PR TITLE
Get sonobuoy repo from settings variable

### DIFF
--- a/tests/caasp/stack_conformance.pm
+++ b/tests/caasp/stack_conformance.pm
@@ -29,7 +29,7 @@ EOF
 
 sub run {
     # The repository for the sonobuoy package
-    my $repo = "https://download.opensuse.org/repositories/devel:/kubic/openSUSE_Tumbleweed/devel:kubic.repo";
+    my $repo = get_var('SONOBUOY_REPO');
 
     my $json_name = "sonobuoy.json";
     my $logs_dir  = "sonobuoy_logs";


### PR DESCRIPTION
Gets the sonobuoy repo from the Setting variable, instead of having it in code.

- Related ticket: https://progress.opensuse.org/issues/44303
- Needles: No new needles
- Verification run: http://skyrim.qam.suse.de/tests/5346#step/stack_conformance/155
