### PR TITLE
Fix extended search interaction issue when using zypper search

### DIFF
--- a/tests/console/w3m_https.pm
+++ b/tests/console/w3m_https.pm
@@ -17,12 +17,13 @@
 use base "consoletest";
 use strict;
 use testapi;
+use utils 'zypper_call';
 
 sub run {
     select_console "root-console";
 
     assert_script_run('rpm -q w3m');
-    script_run("zypper --no-refresh se -it pattern fips");
+    zypper_call('--no-refresh search -it pattern fips');
 
     my %https_url = (
         google => "https://www.google.com/ncr",


### PR DESCRIPTION
Fix extended search interaction issue by ~~adding --non-interactive~~ using zypper_call
[poo#44867] w3m_https test fail due to zypper search fail and Needles outdated

- Related ticket: https://progress.opensuse.org/issues/44867
- Verification run: http://10.67.17.9/tests/25#step/w3m_https/4
