### PR TITLE
Increase timeout value for snapper list

### DIFF
--- a/tests/console/upgrade_snapshots.pm
+++ b/tests/console/upgrade_snapshots.pm
@@ -23,12 +23,12 @@ sub run {
 
     script_run("snapper list | tee /dev/$serialdev", 0);
     # Check if the snapshot called 'before update' is there
-    wait_serial('pre\s*(\|[^|]*){4,}\s*\|\s*number\s*\|\s*before (update|online migration)\s*\|\s*important=yes', 20)
+    wait_serial('pre\s*(\|[^|]*){4,}\s*\|\s*number\s*\|\s*before (update|online migration)\s*\|\s*important=yes', 40)
       || die 'upgrade snapshots test failed';
 
     script_run("snapper list | tee /dev/$serialdev", 0);
     # Check if the snapshot called 'after update' is there
-    wait_serial('post\s*(\|[^|]*){4,}\s*\|\s*number\s*\|\s*after (update|online migration)\s*\|\s*important=yes', 20)
+    wait_serial('post\s*(\|[^|]*){4,}\s*\|\s*number\s*\|\s*after (update|online migration)\s*\|\s*important=yes', 40)
       || die 'upgrade snapshots test failed';
 }
 


### PR DESCRIPTION
I cloned the job and set TIMEOUT_SCALE=2, this issue gone.
https://openqa.suse.de/tests/2348110/file/autoinst-log.txt
#################################
[2018-12-21T01:55:53.629 UTC] [debug] <<< testapi::type_string(string='snapper list | tee /dev/ttyAMA0', max_interval=250, wait_screen_changes=0, wait_still_screen=0)
[2018-12-21T01:55:54.604 UTC] [debug] <<< testapi::wait_serial(regexp='pre\s*(\|[|]*){4,}\s*\|\s*number\s*\|\s*before (update|online migration)\s*\|\s*important=yes', timeout=20)
[2018-12-21T01:56:19.872 UTC] [debug] >>> testapi::wait_serial: pre\s*(|[|]*){4,}\s*|\s*number\s*|\s*before (update|online migration)\s*|\s*important=yes: ok
##########################
From log it shown test wait 26s for the output of 'snapper list'.

So I think to increase the timeout value of 'snapper list' to 40s is ok.

- Related ticket: https://progress.opensuse.org/issues/45119
- Verification run: https://openqa.suse.de/tests/2348110/file/autoinst-log.txt
