### PR TITLE
Add test condition to remove libmicrohttpd test scenario in SLE15

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2000,7 +2000,7 @@ sub load_security_tests_web {
     loadtest "console/apache_ssl";
     if (check_var('DISTRI', 'sle') && get_var('FIPS_ENABLED')) {
         loadtest "fips/mozilla_nss/apache_nssfips";
-        loadtest "console/libmicrohttpd";
+        loadtest "console/libmicrohttpd" if is_sle('<15');
     }
     loadtest "console/consoletest_finish";
     if (check_var('DISTRI', 'sle') && get_var('FIPS_ENABLED')) {


### PR DESCRIPTION
Add test condition to remove libmicrohttpd test scenario in SLE15 

The test was dropped from SLE15 but it will be still tested in SLE12-SPx
Related bsc#1087409

- Related ticket: https://progress.opensuse.org/issues/44930
- Needles: N/A
- Verification run: 
  SLE15 : http://147.2.211.155/tests/180
  SLE12SP4 : http://147.2.211.155/tests/181