### PR TITLE
Modify PXE boot to run LTP tests on ipmi, autoyast, cleanup

### DIFF
--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -29,7 +29,6 @@ use constant {
     ],
     CONSOLES => [
         qw(
-          use_ssh_serial_console
           )
       ]
 };
@@ -40,15 +39,6 @@ our %EXPORT_TAGS = (
     CONSOLES => (CONSOLES),
     BACKEND  => (BACKEND)
 );
-
-# Use it after SUT boot finish, as it requires ssh connection to SUT to
-# interact with SUT, including window and serial console
-sub use_ssh_serial_console {
-    select_console('root-ssh');
-    $serialdev = 'sshserial';
-    set_var('SERIALDEV', $serialdev);
-    bmwqemu::save_vars();
-}
 
 sub is_remote_backend {
 

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -558,8 +558,9 @@ sub specific_bootmenu_params {
             # due to BSC#932692 (SLE-12). 'SetHostname=0' has to be set because autoyast
             # profile has DHCLIENT_SET_HOSTNAME="yes" in /etc/sysconfig/network/dhcp,
             # 'ifcfg=*=dhcp' sets this variable in ifcfg-eth0 as well and we can't
-            # have them both as it's not deterministic.
-            $netsetup = get_var("NETWORK_INIT_PARAM", "ifcfg=*=dhcp SetHostname=0");
+            # have them both as it's not deterministic. Don't set on IPMI with net interface defined in SUT_NETDEVICE.
+            my $ifcfg = check_var('BACKEND', 'ipmi') ? '' : 'ifcfg=*=dhcp SetHostname=0';
+            $netsetup = get_var("NETWORK_INIT_PARAM", "$ifcfg");
             $args .= " $netsetup ";
             $args .= autoyast_boot_params;
         }

--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -21,7 +21,7 @@ use version_utils qw(is_storage_ng is_sle);
 use utils;
 use power_action_utils 'prepare_system_shutdown';
 
-our @EXPORT = qw(use_ssh_serial_console set_serial_console_on_vh switch_from_ssh_to_sol_console set_pxe_efiboot);
+our @EXPORT = qw(set_serial_console_on_vh switch_from_ssh_to_sol_console set_pxe_efiboot);
 
 #With the new ipmi backend, we only use the root-ssh console when the SUT boot up,
 #and no longer setup the real serial console for either kvm or xen.

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -386,6 +386,12 @@ sub wait_boot {
             select_console('x11', await_console => 0);
         }
     }
+    elsif (check_var('BACKEND', 'ipmi')) {
+        select_console 'sol', await_console => 0;
+        # boot from harddrive
+        assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu pxe-menu)], 200);
+        send_key 'ret';
+    }
     # On Xen PV and svirt we don't see a Grub menu
     elsif (!(check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux') && check_var('BACKEND', 'svirt'))) {
         my @tags = ('grub2');

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -599,7 +599,10 @@ sub select_serial_terminal {
     } elsif ($backend eq 'svirt') {
         $console = $root ? 'root-console' : 'user-console';
     } elsif ($backend =~ /^(ikvm|ipmi|spvm)$/) {
-        $console = 'root-ssh';
+        $console   = 'root-ssh';
+        $serialdev = 'sshserial';
+        set_var('SERIALDEV', $serialdev);
+        bmwqemu::save_vars();
     }
 
     die "No support for backend '$backend', add it" if ($console eq '');

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -14,7 +14,6 @@ use utils qw(
   zypper_call
 );
 use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x);
-use Utils::Backends 'use_ssh_serial_console';
 
 # Base class implementation of distribution class necessary for testapi
 
@@ -598,7 +597,7 @@ sub activate_console {
         }
         elsif (check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm')) {
             # Select configure serial and redirect to root-ssh instead
-            use_ssh_serial_console;
+            opensusebasetest::select_serial_terminal();
             return;
         }
         else {
@@ -609,7 +608,7 @@ sub activate_console {
     }
     elsif ($console =~ m/root-console$/ && check_var('BACKEND', 'spvm')) {
         # Select configure serial and redirect to root-ssh instead
-        use_ssh_serial_console;
+        opensusebasetest::select_serial_terminal();
         return;
     }
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1021,12 +1021,7 @@ elsif (get_var('VALIDATE_PCM_PATTERN')) {
     load_public_cloud_patterns_validation_tests;
 }
 else {
-    if (get_var("SES5_DEPLOY")) {
-        loadtest "boot/boot_from_pxe";
-        loadtest "autoyast/installation";
-        loadtest "installation/first_boot";
-    }
-    elsif (get_var("SES_NODE")) {
+    if (get_var("SES_NODE")) {
         boot_hdd_image;
         if (get_var("DEEPSEA_TESTSUITE")) {
             loadtest "ses/nodes_preparation";

--- a/tests/autoyast/console.pm
+++ b/tests/autoyast/console.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 SUSE LLC
+# Copyright (C) 2015-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@ use testapi;
 
 sub run {
     my ($self) = @_;
+    $self->wait_boot if check_var('BACKEND', 'ipmi');
     select_console 'root-console';
 }
 

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 SUSE Linux GmbH
+# Copyright (C) 2015-2019 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -119,14 +119,6 @@ sub verify_timeout_and_check_screen {
 sub run {
     my ($self) = @_;
 
-    if (check_var('BACKEND', 'ipmi') && get_var("SES5_DEPLOY")) {
-        assert_screen 'installation-done', 750;
-        reset_consoles;
-        select_console 'sol', await_console => 0;
-        assert_screen 'prague-pxe-menu', 400;
-        send_key 'ret';    # boot from hard disk
-        return;
-    }
     my @needles           = qw(bios-boot nonexisting-package reboot-after-installation linuxrc-install-fail scc-invalid-url warning-pop-up autoyast-boot);
     my $expected_licenses = get_var('AUTOYAST_LICENSE');
     push @needles, 'autoyast-confirm'        if get_var('AUTOYAST_CONFIRM');

--- a/tests/autoyast/login.pm
+++ b/tests/autoyast/login.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 SUSE LLC
+# Copyright (C) 2015-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,7 +19,6 @@
 use strict;
 use base 'y2logsstep';
 use testapi;
-use Utils::Backends qw(use_ssh_serial_console is_remote_backend);
 
 sub run {
     my $self = shift;
@@ -31,7 +30,7 @@ sub run {
     # too sure if it would make sense for svirt or s390 for example
     if (check_var('BACKEND', 'ipmi')) {
         #use console based on ssh to avoid unstable ipmi
-        use_ssh_serial_console;
+        opensusebasetest::select_serial_terminal();
     }
     assert_script_run 'echo "checking serial port"';
     type_string "cat /proc/cmdline\n";
@@ -44,4 +43,3 @@ sub test_flags {
 }
 
 1;
-

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -104,7 +104,7 @@ sub run {
     type_string ${image_path} . " ", $type_speed;
     bootmenu_default_params(pxe => 1, baud_rate => '115200');
 
-    if ((check_var('BACKEND', 'ipmi') && !get_var('AUTOYAST')) || get_var('SES5_DEPLOY')) {
+    if (check_var('BACKEND', 'ipmi') && !get_var('AUTOYAST')) {
         my $cmdline = '';
         if (check_var('VIDEOMODE', 'text')) {
             $cmdline .= 'ssh=1 ';    # trigger ssh-text installation
@@ -129,8 +129,8 @@ sub run {
     send_key 'ret';
     save_screenshot;
 
-    if ((check_var('BACKEND', 'ipmi') && !get_var('AUTOYAST')) || get_var('SES5_DEPLOY')) {
-        my $ssh_vnc_wait_time = get_var('SES5_DEPLOY') ? 300 : 210;
+    if (check_var('BACKEND', 'ipmi') && !get_var('AUTOYAST')) {
+        my $ssh_vnc_wait_time = 300;
         my $ssh_vnc_tag = eval { check_var('VIDEOMODE', 'text') ? 'sshd' : 'vnc' } . '-server-started';
         my @tags = ($ssh_vnc_tag, 'orthos-grub-boot-linux');
         assert_screen \@tags, $ssh_vnc_wait_time;

--- a/tests/console/check_network.pm
+++ b/tests/console/check_network.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -12,13 +12,13 @@
 
 use base "consoletest";
 use testapi;
-use Utils::Backends 'use_ssh_serial_console';
 use strict;
 
 sub run {
+    my $self = @_;
     # let's see how it looks at the beginning
     save_screenshot;
-    check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
+    $self->select_serial_terminal;
 
     # https://fate.suse.com/320347 https://bugzilla.suse.com/show_bug.cgi?id=988157
     if (check_var('NETWORK_INIT_PARAM', 'ifcfg=eth0=dhcp')) {

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,6 @@
 use base "consoletest";
 use testapi;
 use utils;
-use Utils::Backends 'use_ssh_serial_console';
 use strict;
 
 sub disable_bash_mail_notification {
@@ -28,7 +27,7 @@ sub run {
     my $self = shift;
     # let's see how it looks at the beginning
     save_screenshot;
-    check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
+    $self->select_serial_terminal;
     # Prevent mail notification messages to show up in shell and interfere with running console tests
     disable_bash_mail_notification;
     # Stop serial-getty on serial console to avoid serial output pollution with login prompt

--- a/tests/console/prepare_test_data.pm
+++ b/tests/console/prepare_test_data.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -13,13 +13,12 @@
 use base "consoletest";
 use testapi;
 use utils;
-use Utils::Backends 'use_ssh_serial_console';
 use strict;
 
 sub run {
-    check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
+    my $self = @_;
+    $self->select_serial_terminal(0);
 
-    select_console 'user-console';
     assert_script_run "curl -L -v -f " . autoinst_url('/data') . " > test.data";
     assert_script_run " cpio -id < test.data";
     script_run "ls -al data";

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2018-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -13,7 +13,6 @@
 use base 'consoletest';
 use testapi;
 use utils;
-use Utils::Backends 'use_ssh_serial_console';
 use version_utils qw(is_sle);
 use serial_terminal 'add_serial_console';
 use bootloader_setup qw(change_grub_config grub_mkconfig);
@@ -21,7 +20,7 @@ use strict;
 
 sub run {
     my ($self) = @_;
-    check_var('BACKEND', 'ipmi') ? use_ssh_serial_console : select_console 'root-console';
+    $self->select_serial_terminal;
 
     ensure_serialdev_permissions;
 

--- a/tests/console/system_state.pm
+++ b/tests/console/system_state.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -14,11 +14,11 @@
 use base "consoletest";
 use testapi;
 use utils;
-use Utils::Backends 'use_ssh_serial_console';
 use strict;
 
 sub run {
-    check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
+    my $self = @_;
+    $self->select_serial_terminal;
     script_run "ps axf > /tmp/psaxf.log";
     script_run "cat /proc/loadavg > /tmp/loadavg_consoletest_setup.txt";
 }

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -30,7 +30,7 @@ sub run {
         $self->wait_boot(textmode => 1);
         select_console('x11');
     }
-    my $boot_timeout = (get_var('SES5_DEPLOY') || check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('BACKEND', 'ipmi')) ? 450 : 200;
+    my $boot_timeout = (check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('BACKEND', 'ipmi')) ? 450 : 200;
     # SLE >= 15 s390x does not offer auto-started VNC server in SUT, only login prompt as in textmode
     return if check_var('ARCH', 's390x') && is_sle('15+');
     if (check_var('WORKER_CLASS', 'hornet')) {

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2018 SUSE LLC
+# Copyright © 2017-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,6 @@ use base 'y2logsstep';
 use testapi;
 use lockapi;
 use utils;
-use Utils::Backends 'use_ssh_serial_console';
 use ipmi_backend_utils;
 
 sub run {
@@ -32,7 +31,7 @@ sub run {
     # while technically SUT has a different network than the BMC
     # we require ssh installation anyway
     if (check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm')) {
-        use_ssh_serial_console;
+        opensusebasetest::select_serial_terminal();
         # set serial console for xen
         set_serial_console_on_vh('/mnt', '', 'xen') if (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen'));
         set_serial_console_on_vh('/mnt', '', 'kvm') if (check_var('HOST_HYPERVISOR', 'kvm') || check_var('SYSTEM_ROLE', 'kvm'));

--- a/tests/kernel/ib_tests.pm
+++ b/tests/kernel/ib_tests.pm
@@ -17,7 +17,6 @@ use testapi;
 use utils;
 use power_action_utils 'power_action';
 use lockapi;
-use Utils::Backends 'use_ssh_serial_console';
 use ipmi_backend_utils;
 
 
@@ -97,11 +96,12 @@ sub ibtest_master {
 }
 
 sub run {
+    my ($self) = @_;
     my $role = get_required_var('IBTEST_ROLE');
     $master = get_required_var('IBTEST_IP1');
     $slave  = get_required_var('IBTEST_IP2');
 
-    use_ssh_serial_console;
+    $self->select_serial_terminal;
 
     # Add the GA repository
     zypper_call("ar -f -G " . get_required_var('GA_REPO'));

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,7 +20,6 @@ use version_utils 'is_sle';
 use qam;
 use kernel 'remove_kernel_packages';
 use power_action_utils 'power_action';
-
 
 my $wk_ker = 0;
 
@@ -242,11 +241,15 @@ sub update_kgraft {
     }
 }
 
+sub boot_to_console {
+    my ($self) = @_;
+    $self->wait_boot;
+    $self->select_serial_terminal;
+}
+
 sub run {
     my $self = shift;
-    $self->wait_boot;
-
-    select_console('root-console');
+    boot_to_console($self);
 
     my $repo = get_required_var('INCIDENT_REPO');
 
@@ -256,8 +259,7 @@ sub run {
     if (get_var('KGRAFT')) {
         my $qa_head = get_required_var('QA_HEAD_REPO');
         prepare_kgraft($repo, $incident_id);
-        $self->wait_boot;
-        select_console('root-console');
+        boot_to_console($self);
 
         # dependencies for heavy load script
         if (!$wk_ker) {
@@ -274,8 +276,7 @@ sub run {
         }
         power_action('reboot', textmode => 1);
 
-        $self->wait_boot;
-        select_console('root-console');
+        boot_to_console($self);
 
         kgraft_state;
     }

--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -1,6 +1,6 @@
 # SUSE's SLES4SAP openQA tests
 #
-# Copyright (C) 2018 SUSE LLC
+# Copyright (C) 2018-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,7 +15,6 @@ use base 'sles4sap';
 use strict;
 use testapi;
 use utils qw(type_string_slow zypper_call turn_off_gnome_screensaver);
-use Utils::Backends 'use_ssh_serial_console';
 use version_utils 'is_sle';
 
 sub get_total_mem {
@@ -83,7 +82,7 @@ sub run {
     set_var('PASSWORD', $password);
     set_var('SAPADM',   lc($sid) . 'adm');
 
-    check_var('BACKEND', 'ipmi') ? use_ssh_serial_console : select_console 'root-console';
+    $self->select_serial_terminal;
     my $RAM = get_total_mem();
     die "RAM=$RAM. The SUT needs at least 32G of RAM" if $RAM < 32000;
 
@@ -154,7 +153,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = @_;
-    check_var('BACKEND', 'ipmi') ? use_ssh_serial_console : select_console 'root-console';
+    $self->select_serial_terminal;
     assert_script_run 'tar cf /tmp/logs.tar /var/adm/autoinstall/logs; xz -9v /tmp/logs.tar';
     upload_logs '/tmp/logs.tar.xz';
     assert_script_run "save_y2logs /tmp/y2logs.tar.xz";

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,7 +16,6 @@ use strict;
 use warnings;
 use File::Basename;
 use testapi;
-use Utils::Backends 'use_ssh_serial_console';
 use ipmi_backend_utils;
 
 sub login_to_console {
@@ -49,7 +48,7 @@ sub login_to_console {
             assert_screen('sshd-server-started', 180);
             save_screenshot;
             #switch to ssh console
-            use_ssh_serial_console;
+            opensusebasetest::select_serial_terminal();
             save_screenshot;
             #start upgrade
             type_string("DISPLAY= yast.ssh\n");
@@ -71,7 +70,7 @@ sub login_to_console {
             my $host_upgrade_spver   = $host_upgrade_version =~ /sp(\d+)$/im;
             if (($host_installed_version eq '11') && ($host_upgrade_relver eq '15') && ($host_upgrade_spver eq '0')) {
                 assert_screen('sshd-server-started-config', 180);
-                use_ssh_serial_console;
+                opensusebasetest::select_serial_terminal();
                 save_screenshot;
                 #start system first configuration after finishing upgrading from sles-11-sp4
                 type_string("yast.ssh\n");
@@ -91,7 +90,7 @@ sub login_to_console {
 
     assert_screen(['linux-login', 'virttest-displaymanager'], $timeout);
     #use console based on ssh to avoid unstable ipmi
-    use_ssh_serial_console;
+    opensusebasetest::select_serial_terminal();
 }
 
 sub run {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/43046
- Verification run:
[autoyast](http://10.100.12.155/tests/9606)
[install_ltp_baremetal](http://10.100.12.155/tests/9452)
[install_ltp+sle+Server-DVD-Incidents-Kernel](http://10.100.12.155/tests/9449)
[ltp_fs_ext4](http://10.100.12.155/tests/9435)
[gi-guest_developing-on-host_sles12sp3-kvm](http://10.100.12.155/tests/9458)
[virt-guest-migration-sles12sp4-from-sles12sp4-to-developing-xen-dst](http://10.100.12.155/tests/9478)