### PR TITLE
Call parent log collenction for samba

### DIFF
--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -406,7 +406,7 @@ sub run {
 
 sub post_fail_hook {
     my $self = shift;
-    $self->save_upload_y2logs();
+    $self->SUPER::post_fail_hook;
     upload_logs('/etc/samba/smb.conf');
     upload_logs('/tmp/failed_smb_directives.log');
 }


### PR DESCRIPTION
We have an issue for samba module as it doesn't call post_fail_hook
defined in console_yasttest. There we have quite some useful things
implemented, so now call that one and collect samba specific files after
that.

[Verification run](http://g226.suse.de/tests/3286#).