### PR TITLE
Lower 'CPU soft lockup' error from hard to soft failure

### DIFF
--- a/lib/known_bugs.pm
+++ b/lib/known_bugs.pm
@@ -48,7 +48,7 @@ sub create_list_of_serial_failures {
     }
 
 
-    push @$serial_failures, {type => 'hard', message => 'CPU soft lockup detected', pattern => quotemeta 'soft lockup - CPU'};
+    push @$serial_failures, {type => 'soft', message => 'CPU soft lockup detected', pattern => quotemeta 'soft lockup - CPU'};
 
     return $serial_failures;
 }


### PR DESCRIPTION
In qemu, 'CPU soft lockup' errors can be seen due to snapshots taking some time, especially on aarch64. So, do not abort the whole testsuite in this case and just record a soft failure.
Related ticket: https://progress.opensuse.org/issues/45530