### PR TITLE
Repeat send 'ret' key to avoid bounce back

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -194,9 +194,12 @@ sub boot_local_disk {
         wait_screen_change { send_key 'ret' };
         # Currently the bootloader would bounce back to inst-bootmenu screen after pressing 'ret'
         # on 'local' menu-item, we have to check it and send 'ret' again to make booting properly
-        if (check_screen(['bootloader', 'inst-bootmenu'], 30)) {
+        my $counter = 3;
+        while (check_screen(['bootloader', 'inst-bootmenu'], 30) && $counter) {
             record_info 'bounce back to inst-bootmenu, send ret again';
             send_key 'ret';
+            wait_still_screen(1);
+            $counter--;
         }
         my @tags = qw(inst-slof bootloader grub2 inst-bootmenu);
         push @tags, 'encrypted-disk-password-prompt' if (get_var('ENCRYPT'));


### PR DESCRIPTION
The bootloader would bounce back to inst-bootmenu screen after pressing 'ret', to make it more stable, add max 3 times pressing 'ret' on 'local' menu-item.

- Related ticket: https://progress.opensuse.org/issues/44819
- Verification run: http://openqa-apac1.suse.de/tests/2908#step/addon_products_sle/83
