### PR TITLE
Fix gnome case due to is_sle api change

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -7,7 +7,7 @@ use strict;
 use utils;
 use lockapi 'mutex_wait';
 use serial_terminal 'get_login_message';
-use version_utils qw(is_sle is_leap is_upgrade is_aarch64_uefi_boot_hdd);
+use version_utils qw(is_sle is_leap is_upgrade is_aarch64_uefi_boot_hdd is_tumbleweed);
 use isotovideo;
 use IO::Socket::INET;
 
@@ -499,6 +499,9 @@ sub wait_boot {
             #assert_screen "dm-password-input", 10;
             elsif (check_var('DESKTOP', 'gnome')) {
                 # In GNOME/gdm, we do not have to enter a username, but we have to select it
+                if (is_tumbleweed) {
+                    send_key 'tab';
+                }
                 send_key 'ret';
             }
 

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -608,8 +608,7 @@ sub firefox_check_default {
     my $stilltime = get_var('TIMEOUT_SCALE') ? 100 : 10;
     wait_still_screen $stilltime, 100;
     # Set firefox as default browser if asked
-    assert_screen [qw(firefox_default_browser firefox-url-loaded)], 300;
-    if (match_has_tag('firefox_default_browser')) {
+    if (check_screen('firefox_default_browser')) {
         wait_screen_change {
             assert_and_click 'firefox_default_browser_yes';
         };

--- a/tests/x11/gnomecase/change_password.pm
+++ b/tests/x11/gnomecase/change_password.pm
@@ -157,7 +157,7 @@ sub run {
 
     #delete the added user: test
     # We should kill the active user test in SLE15
-    assert_script_run 'loginctl terminate-user test' if is_sle('15+');
+    assert_script_run 'loginctl terminate-user test' if is_sle('15+') || is_tumbleweed;
     wait_still_screen;
     type_string "userdel -f test\n";
     assert_screen "user-test-deleted";

--- a/tests/x11/gnomecase/nautilus_cut_file.pm
+++ b/tests/x11/gnomecase/nautilus_cut_file.pm
@@ -23,11 +23,19 @@ sub run {
     send_key "ctrl-x";
     send_key_until_needlematch 'nautilus-Downloads-matched', 'left', 5;
     send_key "ret";
-    send_key "ctrl-v";    #paste to dir ~/Downloads
-    assert_screen "nautilus-newfile-moved";
-    send_key "alt-up";                      #back to home dir from ~/Downloads
-    assert_screen 'nautilus-no-newfile';    #assure newfile moved
-    send_key "ctrl-w";                      #close nautilus
+    # paste to ~/Downloads
+    send_key "ctrl-v";
+    # assure file moved, no matter file is highlighted or not
+    assert_screen([qw(nautilus-newfile-moved nautilus-newfile-moved-no-focus)]);
+    if (match_has_tag('nautilus-newfile-moved-no-focus')) {
+        record_soft_failure 'poo#45527 [tw][desktop] pasted files not always highlighted in openqa';
+        save_screenshot;
+    }
+    # back to home dir
+    send_key "alt-up";
+    assert_screen 'nautilus-no-newfile';
+    # close nautilus
+    send_key "ctrl-w";
 
     #remove the newfile, rm via cmd to avoid file moving to trash
     x11_start_program("rm Downloads/newfile", valid => 0);

--- a/tests/x11/gnomecase/nautilus_open_ftp.pm
+++ b/tests/x11/gnomecase/nautilus_open_ftp.pm
@@ -16,7 +16,7 @@
 use base 'x11test';
 use strict;
 use testapi;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_tumbleweed);
 
 sub run {
     x11_start_program('nautilus');
@@ -25,7 +25,7 @@ sub run {
     assert_screen 'nautilus-ftp-login';
     send_key 'ret';
     assert_screen 'nautilus-ftp-suse-com';
-    if (is_sle('12-SP2+')) {
+    if (is_sle('12-SP2+') || is_tumbleweed) {
         assert_and_click 'unselected-pub';
         assert_and_click 'ftp-path-selected';
         wait_still_screen(2);


### PR DESCRIPTION
Fix gnome case due to is_sle api change. 

- Related ticket: https://progress.opensuse.org/issues/38969
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/490/
- Verification run: http://10.67.17.178/tests/505
