### PR TITLE
Disable packagekit to avoid blocking zypper in fips_setup

### DIFF
--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -27,6 +27,10 @@ use utils;
 sub run {
     select_console 'root-console';
 
+    # Disable Packagekit
+    systemctl 'mask packagekit.service';
+    systemctl 'stop packagekit.service';
+
     zypper_call('in -t pattern fips');
 
     # If FIPS_ENV_MODE, then set ENV for some FIPS modules. It is a


### PR DESCRIPTION
Disable packagekit to avoid blocking zypper in fips_setup

Test was fail in : http://10.160.2.14/tests/2544#step/fips_setup/12

- Related ticket: https://progress.opensuse.org/issues/44873
- Needles: N/A
- Verification run: http://147.2.211.155/tests/183
