### PR TITLE
[Virtualization]  let guest migration dst log uploaded when migration test fails

### DIFF
--- a/tests/virt_autotest/guest_migration_dst.pm
+++ b/tests/virt_autotest/guest_migration_dst.pm
@@ -23,7 +23,7 @@ sub run {
     my $ip_out = $self->execute_script_run('ip route show | grep -Eo "src\s+([0-9.]*)\s+" | head -1 | cut -d\' \' -f 2', 30);
     set_var('DST_IP',   $ip_out);
     set_var('DST_USER', "root");
-    set_var('DST_PASS', "nots3cr3t");
+    set_var('DST_PASS', $password);
     bmwqemu::save_vars();
 
     #workaround for weird mount failure

--- a/tests/virt_autotest/guest_migration_src.pm
+++ b/tests/virt_autotest/guest_migration_src.pm
@@ -83,7 +83,7 @@ sub run {
     my $ip_out = $self->execute_script_run('ip route show | grep -Eo "src\s+([0-9.]*)\s+" | head -1 | cut -d\' \' -f 2', 30);
     set_var('SRC_IP',   $ip_out);
     set_var('SRC_USER', "root");
-    set_var('SRC_PASS', "nots3cr3t");
+    set_var('SRC_PASS', $password);
     bmwqemu::save_vars();
 
     #wait for destination to be ready

--- a/tests/virt_autotest/guest_migration_src.pm
+++ b/tests/virt_autotest/guest_migration_src.pm
@@ -98,14 +98,19 @@ sub run {
     $self->run_test($timeout, "", "no", "yes", "$log_dirs", "$upload_log_name");
 
     #display test result
-    my $cmd = "cd /tmp; zcat $upload_log_name.tar.gz | sed -n '/Executing check validation/,/[0-9]* fail [0-9]* succeed/p'";
-
+    my $cmd                       = "cd /tmp; zcat $upload_log_name.tar.gz | sed -n '/Executing check validation/,/[0-9]* fail [0-9]* succeed/p'";
     my $guest_migrate_log_content = &script_output("$cmd");
     save_screenshot;
 
     #upload junit log
     $self->{"package_name"} = "Guest Migration Test";
     $self->add_junit_log("$guest_migrate_log_content");
+
+    #let dst host upload logs
+    set_var('SRC_TEST_DONE', 1);
+    bmwqemu::save_vars();
+    mutex_lock('DST_UPLOAD_LOG_DONE');
+    mutex_unlock('DST_UPLOAD_LOG_DONE');
 
     #mark test result
     if ($guest_migrate_log_content =~ /0 succeed/m) {

--- a/tests/virt_autotest/virt_v2v_src.pm
+++ b/tests/virt_autotest/virt_v2v_src.pm
@@ -23,7 +23,7 @@ sub run {
     my $ip_out = $self->execute_script_run('ip route show|grep kernel|cut -d" " -f12|head -1', 30);
     set_var('SRC_IP',   $ip_out);
     set_var('SRC_USER', "root");
-    set_var('SRC_PASS', "nots3cr3t");
+    set_var('SRC_PASS', $password);
     bmwqemu::save_vars();
 
     $self->execute_script_run("rm -r /var/log/qa/ctcs2/* /tmp/virt-v2v/* -r", 30);


### PR DESCRIPTION
This PR aims to solve 2 separate things:
1) hide password for security
2)  let guest migration test dst host log uploaded when migration test fails


- Verification run: 
http://10.67.18.220/tests/540, src host
http://10.67.18.220/tests/539, dst host
