### PR TITLE
Change firefox loading velum target_match

### DIFF
--- a/tests/caasp/one_line_checks.pm
+++ b/tests/caasp/one_line_checks.pm
@@ -32,7 +32,7 @@ sub run_common_checks {
 }
 
 sub run_caasp_checks {
-    unless (check_var('SYSTEM_ROLE', 'plain')) {
+    if (get_var('SYSTEM_ROLE', '') =~ /admin|worker/) {
         # poo#18668 - Check ntp client configuration
         assert_script_run 'grep "^pool ns.openqa.test" /etc/chrony.conf';
     }

--- a/tests/caasp/one_line_checks.pm
+++ b/tests/caasp/one_line_checks.pm
@@ -13,7 +13,6 @@
 use base "opensusebasetest";
 use strict;
 use testapi;
-use caasp 'script_retry';
 use version_utils 'is_caasp';
 
 sub run_rcshell_checks {

--- a/tests/caasp/stack_configure.pm
+++ b/tests/caasp/stack_configure.pm
@@ -47,15 +47,14 @@ sub velum_config {
 
 # Upload autoyast profile
 sub upload_autoyast {
-    send_key 'alt-tab';    # switch to xterm
-    assert_screen 'xterm';
+    switch_to 'xterm';
     assert_script_run "curl --location $admin_fqdn/autoyast --output autoyast.xml";
     upload_logs('autoyast.xml');
-    send_key 'alt-tab';    # switch to xterm
+    switch_to 'velum';
 }
 
 sub run {
-    x11_start_program("firefox $admin_fqdn", target_match => 'firefox');
+    x11_start_program("firefox $admin_fqdn", target_match => 'firefox-url-loaded');
     send_key 'f11';
     wait_still_screen 3;
 
@@ -71,11 +70,8 @@ sub run {
     assert_screen 'velum-signup';
     velum_login(1);
 
-    # Login and configure cluster
-    velum_config;
-
-    # Upload the logs of autoyast (if any)
-    upload_autoyast;
+    velum_config;       # Login and configure cluster
+    upload_autoyast;    # Upload the logs of autoyast (if any)
 }
 
 1;


### PR DESCRIPTION
Changed `firefox` target for `firefox-url-loaded` after firefox tests cleanup.
PR includes minor style changes.

Local run:
 - http://dhcp126.suse.cz/tests/11982 - DVD
 - http://dhcp126.suse.cz/tests/11987 - VMX
 - http://dhcp126.suse.cz/tests/12002 - QAM 3.0
 - http://dhcp126.suse.cz/tests/12018 - MicroOS

Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1035