### PR TITLE
Implement the vino_screensharing_available for openSUSE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1434,8 +1434,7 @@ sub load_extra_tests_desktop {
         loadtest "x11/gnucash";
 
     }
-    # https://progress.opensuse.org/issues/37342
-    if (is_sle() && gnomestep_is_applicable()) {
+    if (gnomestep_is_applicable()) {
         loadtest "x11/remote_desktop/vino_screensharing_available";
     }
     # the following tests care about network and need some DE specific


### PR DESCRIPTION
Hello,

the `vino_screensharing_available` test now works and that's why I'd like to introduce it to openSUSE as well.

- Related ticket: [poo#45287](https://progress.opensuse.org/issues/45287)
- Needles: [#486](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/486)
- Verification run: [Tumbleweed](http://pdostal-server.suse.cz/tests/646) [15.1](http://pdostal-server.suse.cz/tests/647)