### PR TITLE
Modify return value when inconsistent qgroup

### DIFF
--- a/tests/console/snapper_used_space.pm
+++ b/tests/console/snapper_used_space.pm
@@ -66,7 +66,7 @@ sub query_space_several_snapshot {
     # Create a new higher level qgroup
     assert_script_run 'btrfs qgroup create 1/1 /';
     # Add snapshots to the group
-    assert_script_run "! btrfs qgroup assign 0/$_ 1/1 /" foreach (@ids);
+    assert_script_run "btrfs qgroup assign 0/$_ 1/1 /" foreach (@ids);
     # run quota
     assert_script_run 'btrfs quota rescan -w /';
     # query the exclusive space


### PR DESCRIPTION
Modify return value when inconsistent qgroup according to [upstream commit](https://github.com/kdave/btrfs-progs/commit/51e1faee06ddfe14989282a8e3a1c8e0c6003268).

- Related ticket: https://progress.opensuse.org/issues/45035
- Verification run: 
  - [Tumbleweed-extra_tests_filesystem](http://rivera-workstation/tests/1020#step/snapper_used_space/38)
  - [sle-15-SP1-extra_tests_filesystem](http://rivera-workstation/tests/1021#step/snapper_used_space/38)