### PR TITLE
Firefox_extensions test fix

### DIFF
--- a/tests/x11/firefox/firefox_extensions.pm
+++ b/tests/x11/firefox/firefox_extensions.pm
@@ -31,12 +31,8 @@ sub run {
     assert_and_click('firefox-extensions-add-to-firefox');
     wait_still_screen 6;
     send_key 'alt-a';
-    # close the flagfox relase notes tab
-    wait_still_screen 3;
-    save_screenshot;
-    send_key 'ctrl-w';
-    # close the flagfox search tab
-    send_key 'ctrl-w';
+    # close the flagfox relase notes tab and flagfox search tab
+    send_key_until_needlematch 'firefox-addons-plugins', 'ctrl-w', 3, 3;
     # refresh the page to see addon buttons
     send_key 'f5';
     assert_screen('firefox-extensions-flagfox_installed', 90);


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/45674
- Verification run:
[SLES12](http://10.100.12.155/tests/9573)
[SLES12SP1](http://10.100.12.155/tests/9571)
[SLES12SP2](http://10.100.12.155/tests/9569)
[SLES12SP3](http://10.100.12.155/tests/9567)
[SLED12SP3](http://10.100.12.155/tests/9565)
[SLES12SP4](http://10.100.12.155/tests/9563)
[SLED12SP4](http://10.100.12.155/tests/9561)
[SLES15](http://10.100.12.155/tests/9559)
[SLED15](http://10.100.12.155/tests/9557)
