### PR TITLE
[WIP] Schedule release notes when relevant

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -926,7 +926,9 @@ sub load_inst_tests {
     # need to be able to do installations on it. The release notes
     # functionality needs to be covered by other backends
     # Skip release notes test on sle 15 if have addons
-    if (is_sle && !check_var('BACKEND', 'generalhw') && !check_var('BACKEND', 'ipmi') && !(is_sle('15+') && get_var('ADDONURL'))) {
+    if (get_var('CHECK_RELEASENOTES') &&
+        is_sle && !check_var('BACKEND', 'generalhw') && !check_var('BACKEND', 'ipmi') &&
+        !(is_sle('15+') && get_var('ADDONURL'))) {
         loadtest "installation/releasenotes";
     }
 

--- a/variables.md
+++ b/variables.md
@@ -20,6 +20,7 @@ BETA | boolean | false | Enables checks and processing of beta warnings. Defines
 BTRFS | boolean | false | Indicates btrfs filesystem. Deprecated, use FILESYSTEM instead.
 BUILD | string  |       | Indicates build number of the product under test.
 CASEDIR | string | | Path to the directory which contains tests.
+CHECK_RELEASENOTES | boolean | false | Loads `installation/releasenotes` test module.
 CHECK_RELEASENOTES_ORIGIN | boolean | false | Loads `installation/releasenotes_origin` test module.
 DESKTOP | string | | Indicates expected DM, e.g. `gnome`, `kde`, `textmode`, `xfce`, `lxde`. Does NOT prescribe installation mode. Installation is controlled by `VIDEOMODE` setting
 DEV_IMAGE | boolean | false | This setting is used to set veriables properly when SDK or Development-Tools are required.


### PR DESCRIPTION
Schedule release notes in relevant scenarios

- Related ticket: https://progress.opensuse.org/issues/43856
- Verification run: (sle-15-SP1-create_hdd_gnome)[http://rivera-workstation/tests/1023/file/autoinst-log.txt]
