### PR TITLE
shell: disable ksh test on Leap/aarch64 as it does not build

### DIFF
--- a/tests/console/shells.pm
+++ b/tests/console/shells.pm
@@ -14,12 +14,16 @@ use base "consoletest";
 use strict;
 use testapi;
 use utils 'zypper_call';
+use version_utils 'is_leap';
 
 sub run() {
     select_console 'root-console';
-    zypper_call 'in ksh tcsh zsh';
+    my @packages = qw(tcsh zsh);
+    # ksh does not build for Leap 15.x on aarch64, so, skip it
+    push @packages, qw(ksh) unless (is_leap('15.0+') and check_var('ARCH', 'aarch64'));
+    zypper_call("in @packages");
     select_console 'user-console';
-    assert_script_run 'ksh -c "print hello" | grep hello';
+    assert_script_run 'ksh -c "print hello" | grep hello' unless (is_leap('15.0+') and check_var('ARCH', 'aarch64'));
     assert_script_run 'tcsh -c "printf \'hello\n\'" | grep hello';
     assert_script_run 'csh -c "printf \'hello\n\'" | grep hello';
     assert_script_run 'zsh -c "echo hello" | grep hello';


### PR DESCRIPTION
It fixes https://openqa.opensuse.org/tests/825202#step/shells/6