### PR TITLE
Add another line to detect missing icons in the YaST logs

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -147,10 +147,11 @@ sub investigate_yast2_failure {
         'No textdomain configured',                      # Detecting missing translations
         'nothing provides',                              # Detecting missing required packages
         'but this requirement cannot be provided',       # and package conflicts
-        'Could not load icon'                            # Detecting missing icons
+        'Could not load icon',                           # Detecting missing icons
+        'Couldn\'t load pixmap'                          # additionally with this line, but if not caught with the message above
     );
     for my $y2log_error (@y2log_errors) {
-        if (my $y2log_error_result = script_output 'grep -B 3 \'' . $y2log_error . '\' /var/log/YaST2/y2log | tail -n 20 || true') {
+        if (my $y2log_error_result = script_output 'grep -B 3 "' . $y2log_error . '" /var/log/YaST2/y2log | tail -n 20 || true') {
             record_info 'YaST2 log error detected', "Details:\n\n$y2log_error_result", result => 'fail';
             $error_detected = 1;
         }


### PR DESCRIPTION
Fixed and issue on non escaped single quote introduced in #6438.

[Verification run](http://g226.suse.de/tests/3291)
