### PR TITLE
wicked: Change IP range used for VLAN test cases

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -121,10 +121,10 @@ sub get_ip {
         $ip = $args{is_wicked_ref} ? '10.0.2.10' : '10.0.2.11';
     }
     elsif ($args{type} eq 'vlan') {
-        $ip = $args{is_wicked_ref} ? '42.42.42.10/24' : '42.42.42.11/24';
+        $ip = $args{is_wicked_ref} ? '192.0.2.10/24' : '192.0.2.11/24';
     }
     elsif ($args{type} eq 'vlan_changed') {
-        $ip = $args{is_wicked_ref} ? '42.42.42.110/24' : '42.42.42.111/24';
+        $ip = $args{is_wicked_ref} ? '192.0.2.110/24' : '192.0.2.111/24';
     }
     else {
         croak('Unknown ip type ' . ($args{type} || 'undef'));


### PR DESCRIPTION
Previous version was using Public IP range which is
generally bad practise. So it got replaced by special
IP range dedicated for network testing according to
RFC5737 ( TEST-NET-1 ).

prove run - http://kimball.arch.suse.de/tests/381
http://kimball.arch.suse.de/tests/382

Fixing issue - https://progress.opensuse.org/issues/45461