### PR TITLE
Enable clamav tests in extra tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1521,6 +1521,7 @@ sub load_extra_tests_console {
     loadtest "console/salt" if (is_jeos || is_opensuse);
     loadtest "console/gpg";
     loadtest "console/rsync";
+    loadtest "console/clamav";
     loadtest "console/shells";
     loadtest "console/repo_orphaned_packages_check" if is_jeos;
     # dstat is not in sle12sp1


### PR DESCRIPTION
Test is already implemented but not scheduled inside extra tests.

- Related ticket: https://progress.opensuse.org/issues/45779
- Verification runs:
  - http://panigale.suse.cz/tests/1195 (SLE15)
  - http://panigale.suse.cz/tests/1196 (SLE12SP1)
  - http://panigale.suse.cz/tests/1197 (SLE12SP2)
  - http://panigale.suse.cz/tests/1198 (SLE12SP3)
  - http://panigale.suse.cz/tests/1199 (SLE12SP4)
  - http://panigale.suse.cz/tests/1200 (TW)