### PR TITLE
Adapt different loader_type in autoyast profile

### DIFF
--- a/data/autoyast_sle15/autoyast_scc_up.xml
+++ b/data/autoyast_sle15/autoyast_scc_up.xml
@@ -10,7 +10,7 @@
       <generic_mbr>false</generic_mbr>
       <timeout config:type="integer">5</timeout>
     </global>
-    <loader_type>grub2</loader_type>
+    <loader_type>{{LOADER_TYPE}}</loader_type>
   </bootloader>
   <general>
     <mode>

--- a/tests/autoyast/prepare_profile.pm
+++ b/tests/autoyast/prepare_profile.pm
@@ -46,7 +46,7 @@ sub run {
     $profile =~ s/\{\{HostIP\}\}/$hostip/g if $hostip;
 
     # Expand other variables
-    my @vars = qw(SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_URL ARCH);
+    my @vars = qw(SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_URL ARCH LOADER_TYPE);
     for my $var (@vars) {
         # Skip if value is not defined
         next unless my ($value) = get_var($var);


### PR DESCRIPTION
This issue failed for the loader_type in profile is different on different arches, on aarch64 loader_type=grub2-efi, while others are loader_type=grub2.

- Related ticket: https://progress.opensuse.org/issues/45347
- Needles: N/A
- Verification run: http://openqa-apac1.suse.de/tests/3099#step/installation/43
