### PR TITLE
Update mutt test for jeos

### DIFF
--- a/tests/console/mutt.pm
+++ b/tests/console/mutt.pm
@@ -13,14 +13,14 @@
 use base 'consoletest';
 use strict;
 use testapi;
-use version_utils qw(is_sle is_tumbleweed);
+use version_utils qw(is_sle is_tumbleweed is_jeos);
 use utils;
 
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
-    zypper_call("in mutt", exitcode => [0, 102, 103]) if is_tumbleweed;
+    zypper_call("in mutt", exitcode => [0, 102, 103]) if (is_tumbleweed || is_jeos);
 
     # Mutt is Mutt (bsc#1094717) and has build in support for IMAP and SMTP
     validate_script_output 'mutt -v', sub { m/\+USE_IMAP/ && m/\+USE_SMTP/ && not m/NeoMutt/ };

--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -14,7 +14,7 @@ use strict;
 use base "opensusebasetest";
 use testapi;
 use utils;
-use version_utils "is_sle";
+use version_utils qw(is_sle is_jeos);
 
 sub run() {
     select_console('root-console');
@@ -32,6 +32,7 @@ sub run() {
     }
     else {
         zypper_call("in dovecot", exitcode => [0, 102, 103]);
+        zypper_call("in postfix", exitcode => [0, 102, 103]) if is_jeos;
     }
 
     # configure dovecot
@@ -51,7 +52,8 @@ sub run() {
     assert_script_run "openssl dhparam -out /etc/dovecot/dh.pem 2048", 300;
 
     # Generate default certificate for dovecot and postfix
-    assert_script_run "cd /usr/share/doc/packages/dovecot;bash mkcert.sh";
+    my $dovecot_path = is_jeos() ? '/usr/share/dovecot' : '/usr/share/doc/packages/dovecot';
+    assert_script_run "cd $dovecot_path;bash mkcert.sh";
 
     # configure postfix
     assert_script_run "postconf -e 'smtpd_use_tls = yes'";


### PR DESCRIPTION
This change installs mutt and postfix on JeOS and it specifies a different path to mkcert.sh.

- Progress ticket: https://progress.opensuse.org/issues/45788
- Verification run: 
  - SLE: http://ccret.suse.cz/tests/2337
  - JeOS: http://ccret.suse.cz/tests/2338
