### PR TITLE
[WIP] CaaSP controller rebased on SLES-15

### DIFF
--- a/lib/caasp_controller.pm
+++ b/lib/caasp_controller.pm
@@ -74,6 +74,7 @@ sub velum_login {
 sub confirm_insecure_https {
     wait_still_screen 3;
     assert_and_click 'velum-https-advanced';
+    send_key 'end';
     assert_and_click 'velum-https-add_exception';
     assert_and_click 'velum-https-confirm';
 }

--- a/tests/caasp/stack_initialize.pm
+++ b/tests/caasp/stack_initialize.pm
@@ -7,15 +7,38 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Initialize testing environment
-# Manual modifications to controller node:
-#   Installed packages for DHCP, DNS and enable them in firewall
-#   Installed kubernetes-client from virtualization repo
-#   Installed mozilla-nss-tools to import certificate
-#   Firefox:
-#     - disabled readerview, password remember, bookmarks bar
-#     - blank startup page, search tips, auto-save to disk
+# Summary: Initialize controller node
 # Maintainer: Martin Kravec <mkravec@suse.com>
+
+## OS installation
+# Basesystem Module
+# Desktop Applications Module (gnome,firefox)
+# Server Applications Module (dhcp-server,bind)
+# user: Bernhard M. Wiedemann
+# - ext4 fs without swap/home (minimize size & avoid btrfs balance)
+# - disable firewall
+# - disable kdump
+# - install dhcp,dns server
+# - don't install apparmor
+
+## Firefox - make default, show blank page on startup
+# don't show "open or save" dialog
+# about:config browser.download.forbid_open_with true
+# don't show password saving dialog
+# about:config signon.rememberSignons false
+
+## General setup
+# mkdir .kube
+# hostnamectl set-hostname susetest
+
+## Repositories for extra packages
+# SUSEConnect -d
+# zypper ar -f -G http://download.suse.de/ibs/SUSE:/SLE-15:/Update/standard/SUSE:SLE-15:Update.repo
+# zypper ar -f -G https://download.opensuse.org/repositories/devel:/CaaSP:/Head:/ControllerNode/SLE_15/devel:CaaSP:Head:ControllerNode.repo
+# zypper in kubernetes-client (kubectl) mozilla-nss-tools
+
+## Before poweroff
+# rm /etc/udev/rules.d/70-persistent-net.rules
 
 use parent 'caasp_controller';
 use caasp_controller;
@@ -25,14 +48,22 @@ use testapi;
 use caasp 'pause_until';
 use utils qw(ensure_serialdev_permissions turn_off_gnome_screensaver zypper_call);
 
-sub firefox_import_ca {
-    # Setup ssh
+# Setup key-based access to admin node
+sub setup_ssh {
+    assert_script_run 'ssh-keygen -N "" -t ecdsa -f ~/.ssh/id_ecdsa';
+    assert_script_run 'echo -e "host *
+\tUser root
+\tStrictHostKeyChecking no
+\tUserKnownHostsFile /dev/null
+\tLogLevel ERROR" > ~/.ssh/config';
+
     script_run "ssh-copy-id -f $admin_fqdn", 0;
     assert_screen 'ssh-password-prompt';
     type_password;
     send_key 'ret';
+}
 
-    # Install certificate
+sub setup_firefox_ca {
     assert_script_run "scp $admin_fqdn:/etc/pki/ca.crt .";
     assert_script_run 'certutil -A -n CaaSP -d .mozilla/firefox/*.default -i ca.crt -t "C,,"';
 }
@@ -40,21 +71,23 @@ sub firefox_import_ca {
 sub run {
     select_console 'x11';
     x11_start_program('xterm');
+    send_key 'super-up';
 
+    # Setup as root
     become_root;
     ensure_serialdev_permissions;
     zypper_call 'up kubernetes-client';
     type_string "exit\n";
+
+    # Setup as user
     turn_off_gnome_screensaver;
+    pause_until 'VELUM_STARTED';
+    setup_ssh;
+    setup_firefox_ca;
 
     # Leave xterm open for kubernetes tests
     save_screenshot;
     send_key "ctrl-l";
-    send_key 'super-up';
-
-    pause_until 'VELUM_STARTED';
-    firefox_import_ca;
 }
 
 1;
-

--- a/tests/caasp/stack_reboot.pm
+++ b/tests/caasp/stack_reboot.pm
@@ -39,6 +39,7 @@ sub run {
     assert_script_run "kubectl get nodes --no-headers | wc -l | grep $nodes_count";
 
     switch_to 'velum';
+    assert_screen 'velum-bootstrap-done';
 }
 
 1;


### PR DESCRIPTION
[WIP] - change ntpd server config to chronyd

Code changes for CaaSO support server migrated from 12-sp3 to 15-sp0

Local runs:
 - http://dhcp126.suse.cz/tests/12378 - 3.0
 - http://dhcp126.suse.cz/tests/12361 - 4.0 (5 nodes)
 - http://dhcp126.suse.cz/tests/12432 - 4.0 (9 nodes)

Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1039

New controller image uploaded: sle-15-SP0-Server-DVD-x86_64-gnome-CaaSP.qcow2