### PR TITLE
Update install_ltp for JeOS

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -120,7 +120,6 @@ sub add_custom_grub_entries {
     upload_logs($script_new, failok => 1);
     grub_mkconfig();
     upload_logs(GRUB_CFG_FILE, failok => 1);
-    assert_script_run("cp " . GRUB_CFG_FILE . " $cfg_old") if is_jeos;
 
     my $distro      = (is_sle() ? "SLES" : "openSUSE") . ' \\?' . get_required_var('VERSION');
     my $section_old = "sed -e '1,/$script_old_esc/d' -e '/$script_old_esc/,\$d' $cfg_old";

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -292,9 +292,7 @@ sub run {
         add_grub_cmdline_settings($grub_param);
     }
 
-    if (is_sle('12+') || is_opensuse) {
-        add_custom_grub_entries;
-    }
+    add_custom_grub_entries if (is_sle('12+') || is_opensuse) && !is_jeos;
     install_runtime_dependencies;
     install_runtime_dependencies_network;
 


### PR DESCRIPTION
Remove redundant line that copies the old grub config file and 
don't run add_custom_grub_entries for JeOS

- Progress ticket: https://progress.opensuse.org/issues/45851
- Verification run: http://ccret.suse.cz/tests/2345#
