### PR TITLE
Remove export of use_ssh_serial_console from ipmi_backend_utils.pm

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -21,7 +21,7 @@ use version_utils qw(is_storage_ng is_sle);
 use utils;
 use power_action_utils 'prepare_system_shutdown';
 
-our @EXPORT = qw(use_ssh_serial_console set_serial_console_on_vh switch_from_ssh_to_sol_console set_pxe_efiboot);
+our @EXPORT = qw(set_serial_console_on_vh switch_from_ssh_to_sol_console set_pxe_efiboot);
 
 #With the new ipmi backend, we only use the root-ssh console when the SUT boot up,
 #and no longer setup the real serial console for either kvm or xen.


### PR DESCRIPTION
This fails https://openqa.suse.de/tests/2363065# at logs_from_installation_system. The function is actually moved to other places.

- Verification run: http://10.67.18.220/tests/543#
