### PR TITLE
Schedule more tests as EXTRATESTs

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -67,7 +67,6 @@ our @EXPORT = qw(
   load_create_hdd_tests
   load_extra_tests
   load_extra_tests_docker
-  load_filesystem_tests
   load_inst_tests
   load_iso_in_external_tests
   load_jeos_tests
@@ -1608,8 +1607,10 @@ sub load_rollback_tests {
     }
 }
 
-sub load_filesystem_tests {
-    return unless get_var('FILESYSTEM_TEST');
+sub load_extra_tests_filesystem {
+    if (is_updates_tests) {
+        loadtest "qa_automation/patch_and_reboot";
+    }
     # pre-conditions for filesystem tests ie. the tests are running based on preinstalled image
     return if get_var("INSTALLONLY") || get_var("DUALBOOT") || get_var("RESCUECD");
 

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -103,7 +103,6 @@ our @EXPORT = qw(
   load_testdir
   load_toolchain_tests
   load_virtualization_tests
-  load_wicked_tests
   load_x11tests
   load_xen_tests
   load_yast2_gui_tests
@@ -1694,7 +1693,7 @@ sub wicked_init_locks {
     loadtest('wicked/locks_init', run_args => $args);
 }
 
-sub load_wicked_tests {
+sub load_extra_tests_wicked {
     wicked_init_locks();
     for my $test (get_wicked_tests()) {
         loadtest $test;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1366,13 +1366,12 @@ sub load_extra_tests_y2uitest_ncurses {
     loadtest "console/yast2_snapper_ncurses";
 }
 
-sub load_yast2_gui_tests {
+sub load_extra_tests_y2uitest_gui {
     return
       unless (!get_var("INSTALLONLY")
         && is_desktop_installed()
         && !get_var("DUALBOOT")
         && !get_var("RESCUECD"));
-    boot_hdd_image;
     loadtest 'yast2_gui/yast2_control_center';
     loadtest "yast2_gui/yast2_bootloader";
     loadtest "yast2_gui/yast2_datetime";

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -105,7 +105,6 @@ our @EXPORT = qw(
   load_x11tests
   load_xen_tests
   load_yast2_gui_tests
-  load_yast2_ncurses_tests
   load_zdup_tests
   logcurrentenv
   map_incidents_to_repo
@@ -1328,17 +1327,7 @@ sub load_x11tests {
     }
 }
 
-sub load_yast2_ncurses_tests {
-    boot_hdd_image;
-    # setup $serialdev permission and so on
-    loadtest "console/check_network";
-    loadtest "console/system_state";
-    loadtest "console/prepare_test_data";
-    loadtest "console/consoletest_setup";
-    loadtest 'console/integration_services' if is_hyperv || is_vmware;
-    loadtest "console/hostname";
-    loadtest "console/zypper_lr";
-    loadtest "console/zypper_ref";
+sub load_extra_tests_y2uitest_ncurses {
     # split YaST2 UI tests relying on external development controlled test
     # suites and self-contained ones
     if (get_var('Y2UITEST_DEVEL')) {
@@ -1375,8 +1364,6 @@ sub load_yast2_ncurses_tests {
         loadtest "console/yast2_nfs_client";
     }
     loadtest "console/yast2_snapper_ncurses";
-    # back to desktop
-    loadtest "console/consoletest_finish";
 }
 
 sub load_yast2_gui_tests {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -96,7 +96,6 @@ our @EXPORT = qw(
   load_ssh_key_import_tests
   load_svirt_boot_tests
   load_svirt_vm_setup_tests
-  load_syscontainer_tests
   load_systemd_patches_tests
   load_system_update_tests
   loadtest
@@ -2218,7 +2217,7 @@ sub load_xen_tests {
     loadtest 'virtualization/xen/guest_management';
 }
 
-sub load_syscontainer_tests() {
+sub load_extra_tests_syscontainer {
     return unless get_var('SYSCONTAINER_IMAGE_TEST');
     # pre-conditions for system container tests ie. the tests are running based on preinstalled image
     return if get_var("INSTALLONLY") || get_var("DUALBOOT") || get_var("RESCUECD");

--- a/lib/yast2_widget_utils.pm
+++ b/lib/yast2_widget_utils.pm
@@ -55,7 +55,7 @@ sub change_service_configuration_step {
     send_key $shortcut;
     send_key 'end';
     send_key_until_needlematch $needle_selection, 'up', 5, 1;
-    if (get_var('Y2UITEST_NCURSES')) {
+    if (check_var_array('EXTRATEST', 'y2uitest_ncurses')) {
         send_key 'ret';
         assert_screen $needle_check;
     }

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -300,10 +300,6 @@ elsif (get_var("NETWORKD")) {
     boot_hdd_image();
     load_networkd_tests();
 }
-elsif (get_var("WICKED")) {
-    boot_hdd_image();
-    load_wicked_tests();
-}
 elsif (get_var('NFV')) {
     load_nfv_tests();
 }

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -335,9 +335,6 @@ elsif (is_rescuesystem) {
 elsif (get_var("LINUXRC")) {
     loadtest "linuxrc/system_boot";
 }
-elsif (get_var('Y2UITEST_GUI')) {
-    load_yast2_gui_tests;
-}
 elsif (get_var("SUPPORT_SERVER")) {
     loadtest "support_server/boot";
     loadtest "support_server/login";

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -316,10 +316,6 @@ elsif (is_memtest) {
         loadtest "installation/memtest";
     }
 }
-elsif (get_var("FILESYSTEM_TEST")) {
-    boot_hdd_image;
-    load_filesystem_tests();
-}
 elsif (get_var('GNUHEALTH')) {
     boot_hdd_image;
     loadtest 'gnuhealth/gnuhealth_install';

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -335,9 +335,6 @@ elsif (is_rescuesystem) {
 elsif (get_var("LINUXRC")) {
     loadtest "linuxrc/system_boot";
 }
-elsif (get_var('Y2UITEST_NCURSES')) {
-    load_yast2_ncurses_tests;
-}
 elsif (get_var('Y2UITEST_GUI')) {
     load_yast2_gui_tests;
 }

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -320,10 +320,6 @@ elsif (get_var("FILESYSTEM_TEST")) {
     boot_hdd_image;
     load_filesystem_tests();
 }
-elsif (get_var("SYSCONTAINER_IMAGE_TEST")) {
-    boot_hdd_image;
-    load_syscontainer_tests();
-}
 elsif (get_var('GNUHEALTH')) {
     boot_hdd_image;
     loadtest 'gnuhealth/gnuhealth_install';

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -919,9 +919,6 @@ elsif (get_var("FILESYSTEM_TEST")) {
     }
     load_filesystem_tests();
 }
-elsif (get_var('Y2UITEST_NCURSES')) {
-    load_yast2_ncurses_tests;
-}
 elsif (get_var('Y2UITEST_GUI')) {
     load_yast2_gui_tests;
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -925,10 +925,6 @@ elsif (get_var('Y2UITEST_NCURSES')) {
 elsif (get_var('Y2UITEST_GUI')) {
     load_yast2_gui_tests;
 }
-elsif (get_var("SYSCONTAINER_IMAGE_TEST")) {
-    boot_hdd_image;
-    load_syscontainer_tests();
-}
 elsif (get_var("WINDOWS")) {
     loadtest "installation/win10_installation";
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -919,9 +919,6 @@ elsif (get_var("FILESYSTEM_TEST")) {
     }
     load_filesystem_tests();
 }
-elsif (get_var('Y2UITEST_GUI')) {
-    load_yast2_gui_tests;
-}
 elsif (get_var("WINDOWS")) {
     loadtest "installation/win10_installation";
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -912,13 +912,6 @@ elsif (get_var("EXTRATEST")) {
     }
     load_extra_tests();
 }
-elsif (get_var("FILESYSTEM_TEST")) {
-    boot_hdd_image;
-    if (is_updates_tests) {
-        loadtest "qa_automation/patch_and_reboot";
-    }
-    load_filesystem_tests();
-}
 elsif (get_var("WINDOWS")) {
     loadtest "installation/win10_installation";
 }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -687,10 +687,6 @@ elsif (get_var('IBTESTS')) {
     load_baremetal_tests();
     load_infiniband_tests();
 }
-elsif (get_var("WICKED")) {
-    boot_hdd_image();
-    load_wicked_tests();
-}
 elsif (get_var("NFV")) {
     load_baremetal_tests();
     load_nfv_tests();

--- a/variables.md
+++ b/variables.md
@@ -102,6 +102,5 @@ VIRSH_OPENQA_BASEDIR | string | /var/lib | The OPENQA_BASEDIR configured on the 
 UNENCRYPTED_BOOT | boolean | false | Indicates/defines existence of unencrypted boot partition in the SUT.
 WAYLAND | boolean | false | Enables wayland tests in the system.
 XDMUSED | boolean | false | Indicates availability of xdm.
-Y2UITEST_GUI | boolean | false | Enables yast2 tests of modules with x11.
 ZDUP | boolean | false | Prescribes zypper dup scenario.
 ZDUPREPOS | string | | Defines repo to be added/used for zypper dup call.

--- a/variables.md
+++ b/variables.md
@@ -102,7 +102,6 @@ VIRSH_OPENQA_BASEDIR | string | /var/lib | The OPENQA_BASEDIR configured on the 
 UNENCRYPTED_BOOT | boolean | false | Indicates/defines existence of unencrypted boot partition in the SUT.
 WAYLAND | boolean | false | Enables wayland tests in the system.
 XDMUSED | boolean | false | Indicates availability of xdm.
-Y2UITEST_NCURSES | boolean | false | Enables yast2 tests of modules with ncurses.
 Y2UITEST_GUI | boolean | false | Enables yast2 tests of modules with x11.
 ZDUP | boolean | false | Prescribes zypper dup scenario.
 ZDUPREPOS | string | | Defines repo to be added/used for zypper dup call.


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/44252

Todo after merge:

- [ ] Add `EXTRATEST=wicked` to every testsuite using the `WICKED` var
- [ ] Replace `Y2UITEST_NCURSES` with `EXTRATEST=prepare,y2uitest_ncurses`
- [ ] Replace `Y2UITEST_GUI` with `EXTRATEST=y2uitest_gui`
- [ ] Replace `FILESYSTEM_TEST` with `EXTRATEST=filesystem`

Verification:
- Wicked: http://artemis.suse.de/tests/1039
- [no existing testsuite found on o3/osd for `syscontainer_image_test`]
- y2uitest_ncurses: http://artemis.suse.de/tests/1046
- y2uitest_gui: http://artemis.suse.de/tests/1051
- filesystem: http://artemis.suse.de/tests/1052