### PR TITLE
Fix upgrade issue from SLEHA15 to SLEHA15-SP1

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -41,17 +41,12 @@ sub handle_all_packages_medium {
     # Refer to https://bugzilla.suse.com/show_bug.cgi?id=1078958#c4
     push @addons, 'we' if check_var('SLE_PRODUCT', 'sled') && !grep(/^we$/, @addons);
 
-    # The legacy module is required if upgrade from previous version (bsc#1066338)
-    # According to bsc#1089455, migrating from SLED12 to SLED15, legacy shouldn't be selected by the testcase.
-    push @addons, 'legacy' if get_var('UPGRADE') && !grep(/^legacy$/, @addons) && !check_var('SLE_PRODUCT', 'sled');
-
-    # The development-tool module is required if upgrade from previous version
-    # Refer to https://fate.suse.com/325293
-    push @addons, 'sdk' if get_var('UPGRADE') && !grep(/^sdk$/, @addons) && (check_var('SLE_PRODUCT', 'sles') || check_var('SLE_PRODUCT', 'rt') || check_var('SLE_PRODUCT', 'hpc'));
-
     # For SLES12SPx and SLES11SPx to SLES15 migration, need add the demand module at least for media migration manually
+    # Refer to https://fate.suse.com/325293
     if (get_var('MEDIA_UPGRADE') && is_sle('<15', get_var('HDDVERSION')) && !check_var('SLE_PRODUCT', 'sled')) {
-        my @demand_addon = qw(desktop legacy serverapp script);
+        my @demand_addon = qw(desktop serverapp script);
+        push @demand_addon, 'sdk'    if !check_var('SLE_PRODUCT', 'sles4sap');
+        push @demand_addon, 'legacy' if !check_var('SLE_PRODUCT', 'rt');
         for my $a (@demand_addon) {
             push @addons, $a if !grep(/^$a$/, @addons);
         }


### PR DESCRIPTION
PR #6382 breaks SLEHA15-SP1 upgrade tests from SLEHA15 because DevTools module was added in the wrong way.

Also, according to [FATE 325293](https://fate.suse.com/325293), Legacy module should only be added if product is not SLE-RT.

- Related ticket: https://progress.opensuse.org/issues/44825
- Failing test: https://openqa.suse.de/tests/2360691#step/addon_products_sle/78
- Verification run from SLES12-SP3: http://1b147.qa.suse.de/tests/4379#step/installation_overview/1
- Verification run from SLES15: http://1b147.qa.suse.de/tests/4380#step/installation_overview/1
- Verification run from SLES4SAP12-SP4: http://1b147.qa.suse.de/tests/4381#step/installation_overview/1
- Verification run from SLES4SAP15: http://1b147.qa.suse.de/tests/4382#step/installation_overview/1