### PR TITLE
Schedule module preselection in installer_extended tests

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -468,7 +468,7 @@ sub fill_in_registration_data {
             }
         }
 
-        verify_preselected_modules($modules_needle);
+        verify_preselected_modules($modules_needle) if get_var('CHECK_PRESELECTED_MODULES');
         # Add desktop module for SLES if desktop is gnome
         # Need desktop application for minimalx to make change_desktop work
         if (check_var('SLE_PRODUCT', 'sles')


### PR DESCRIPTION
https://progress.opensuse.org/issues/43853

- Related ticket: https://progress.opensuse.org/issues/43853
- Verification run:
  - [sle-15-SP1-installer_extended](http://rivera-workstation/tests/1042#step/scc_registration/11)
  - [sle-15-SP1-gnome-dual-windows10](http://rivera-workstation/tests/1044#step/scc_registration/13)
  - [sle-15-SP1-Installer-DVD-x86_64-Build131.4-create_hdd_hpc_textmode@64bit ](http://rivera-workstation/tests/1040#step/scc_registration/10)
  - [sle-15-SP1-create_hdd_ha_textmode](http://rivera-workstation/tests/1041#step/scc_registration/10)
  - [sle-15-SP1-create_hdd_sles4sap_gnome](http://rivera-workstation/tests/1039#step/scc_registration/10)
  - [sle-15-SP1-Installer-allpatterns](http://rivera-workstation/tests/1038#step/scc_registration/19) * for back-compatibility.

I'll require adding `CHECK_PRESELECTED_MODULES=1` to corresponding test suites and creation of an additional test suite of the type `*_extended` for each products Desktop, HPC, HA  (for example with `EXIT_AFTER_START_INSTALL=1`)