### PR TITLE
Removed warnings in yast firewall

### DIFF
--- a/tests/yast2_gui/yast2_firewall.pm
+++ b/tests/yast2_gui/yast2_firewall.pm
@@ -170,8 +170,6 @@ sub configure_zone {
     }
     if ($args{port}) {
         send_key $fw{zones_ports};
-        assert_screen 'yast2_firewall_zone_service_warning';
-        send_key $fw{yes};
         assert_screen 'yast2_firewall_zone_ports_tab_selected';
         send_key $fw{tcp};
         type_string '7777';


### PR DESCRIPTION
Warnings have been removed in yast2-firewall, in qt UI only (so not in ncurses) for recent distributions using firewalld.

- Related ticket: https://progress.opensuse.org/issues/45254
- Verification runs:
Tumbleweed http://dhcp115.suse.cz/tests/2907
sle15sp1 http://dhcp115.suse.cz/tests/2910
sle12sp4 http://dhcp115.suse.cz/tests/2911
leap15.1 http://dhcp115.suse.cz/tests/2912

Note : it does not work yet on leap 15.1, the package on it being older than on sle 15 sp1 (...but why ?)  yast2-firewall-4.1.0-lp151.1.1.noarch versus yast2-firewall-4.1.2-8.1.noarch.

