### PR TITLE
Generate string representing SUT version

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -21,7 +21,17 @@ use testapi;
 use utils;
 use version_utils qw(is_sle is_leap is_tumbleweed);
 
-our @EXPORT = qw(smt_wizard smt_mirror_repo rmt_wizard rmt_mirror_repo prepare_source_repo disable_source_repo get_repo_var_name prepare_oss_repo disable_oss_repo);
+our @EXPORT = qw(
+  smt_wizard
+  smt_mirror_repo
+  rmt_wizard
+  rmt_mirror_repo
+  prepare_source_repo
+  disable_source_repo
+  get_repo_var_name
+  prepare_oss_repo
+  disable_oss_repo
+  generate_version);
 
 =head2 get_repo_var_name
 This takes something like "MODULE_BASESYSTEM_SOURCE" as parameter
@@ -178,8 +188,18 @@ sub disable_source_repo {
     }
 }
 
-sub test_flags {
-    return {fatal => 1};
+sub generate_version {
+    my $dist    = get_required_var('DISTRI');
+    my $version = get_required_var('VERSION');
+    if (is_sle) {
+        $dist = 'SLE';
+        $version =~ s/-/_/;
+    } elsif (is_tumbleweed) {
+        $dist = 'openSUSE';
+    } elsif (is_leap) {
+        $dist = 'openSUSE_Leap';
+    }
+    return $dist . "_" . $version;
 }
 
 1;

--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -16,8 +16,8 @@ use strict;
 use testapi;
 use utils;
 use registration 'add_suseconnect_product';
-use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap);
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_opensuse);
+use repo_tools 'generate_version';
 
 sub run {
     my ($self) = @_;
@@ -32,19 +32,7 @@ sub run {
 
     my $tools_repo = get_var('PUBLIC_CLOUD_TOOLS_REPO', '');
     if ($tools_repo eq '') {
-        my $dist    = get_required_var('DISTRI');
-        my $version = get_required_var('VERSION');
-        if (is_sle) {
-            $dist = 'SLE';
-            $version =~ s/-/_/;
-        }
-        elsif (is_tumbleweed) {
-            $dist = 'openSUSE';
-        }
-        elsif (is_leap) {
-            $dist = 'openSUSE_Leap';
-        }
-        $tools_repo = 'http://download.opensuse.org/repositories/Cloud:/Tools/' . $dist . "_" . $version . '/Cloud:Tools.repo';
+        $tools_repo = 'http://download.opensuse.org/repositories/Cloud:/Tools/' . generate_version() . '/Cloud:Tools.repo';
     }
     zypper_call('ar ' . $tools_repo);
     zypper_call('--gpg-auto-import-keys -q in python3-ipa python3-ipa-tests git-core');


### PR DESCRIPTION
Based on $VERSION and $DISTRI variables generating current SUT version
in format usually used in repositories URL. This allowing us
to create generic code which would add correct repo based on current
job setup