### PR TITLE
Run source validation when INSTALL_SOURCE

### DIFF
--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -113,9 +113,9 @@ sub run {
 
     # Verify install arguments passed by bootloader
     # Linuxrc writes its settings in /etc/install.inf
-    if (get_var('NETBOOT') && !check_var('BACKEND', 'ipmi')) {
+    if (get_var('NETBOOT') && !check_var('BACKEND', 'ipmi') && get_var('INSTALL_SOURCE')) {
         wait_screen_change { send_key 'ctrl-alt-shift-x' };
-        my $method     = uc get_required_var('INSTALL_SOURCE');
+        my $method     = uc get_var('INSTALL_SOURCE');
         my $mirror_src = get_var("MIRROR_$method");
         my $rc         = script_run 'grep -o --color=always install=' . $mirror_src . ' /proc/cmdline';
         die "Install source mismatch in boot parameters!\n" unless ($rc == 0);


### PR DESCRIPTION
- Related ticket: [bad side effect PR#6473](https://progress.opensuse.org/issues/45860)
- Verification runs: 
   * [sle-15-SP1-Installer-DVD-x86_64-Build131.4-gnome_http@64bit](http://eris.suse.cz/tests/9055#step/welcome/9)
  * [opensuse-Tumbleweed-NET-x86_64-Build20190108-RAID0@64bit](http://eris.suse.cz/tests/9059#step/welcome/2)
