### PR TITLE
Improve the QAM Xen testing on physical hypervisor

### DIFF
--- a/data/autoyast_xen/xen-SLES12-SP3-FV.xml
+++ b/data/autoyast_xen/xen-SLES12-SP3-FV.xml
@@ -1110,6 +1110,13 @@ DefaultPolicy default
     <copy_config config:type="boolean">false</copy_config>
     <import config:type="boolean">false</import>
   </ssh_import>
+  <firewall>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+    <FW_ALLOW_PING_FW>yes</FW_ALLOW_PING_FW>
+    <FW_DEV_EXT>eth0</FW_DEV_EXT>
+    <FW_SERVICES_ACCEPT_EXT>0/0,tcp,22</FW_SERVICES_ACCEPT_EXT>
+  </firewall>
   <timezone>
     <hwclock>UTC</hwclock>
     <timezone>Europe/Prague</timezone>

--- a/data/autoyast_xen/xen-SLES12-SP3-PV.xml
+++ b/data/autoyast_xen/xen-SLES12-SP3-PV.xml
@@ -1013,6 +1013,13 @@ DefaultPolicy default
     <copy_config config:type="boolean">false</copy_config>
     <import config:type="boolean">false</import>
   </ssh_import>
+  <firewall>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+    <FW_ALLOW_PING_FW>yes</FW_ALLOW_PING_FW>
+    <FW_DEV_EXT>eth0</FW_DEV_EXT>
+    <FW_SERVICES_ACCEPT_EXT>0/0,tcp,22</FW_SERVICES_ACCEPT_EXT>
+  </firewall>
   <timezone>
     <hwclock>UTC</hwclock>
     <timezone>Europe/Prague</timezone>

--- a/data/autoyast_xen/xen-SLES15-FV.xml
+++ b/data/autoyast_xen/xen-SLES15-FV.xml
@@ -552,6 +552,24 @@
     <copy_config config:type="boolean">false</copy_config>
     <import config:type="boolean">false</import>
   </ssh_import>
+  <firewall>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+    <zones>
+      <zone>
+        <name>public</name>
+        <interfaces>
+          <interface>eth0</interface>
+        </interfaces>
+        <services config:type="list">
+          <service>ssh</service>
+        </services>
+        <ports config:type="list">
+          <port>22/tcp</port>
+        </ports>
+      </zone>
+    </zones>
+  </firewall>
   <timezone>
     <hwclock>UTC</hwclock>
     <timezone>Europe/Prague</timezone>

--- a/data/autoyast_xen/xen-SLES15-PV.xml
+++ b/data/autoyast_xen/xen-SLES15-PV.xml
@@ -552,6 +552,24 @@
     <copy_config config:type="boolean">false</copy_config>
     <import config:type="boolean">false</import>
   </ssh_import>
+  <firewall>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+    <zones>
+      <zone>
+        <name>public</name>
+        <interfaces>
+          <interface>eth0</interface>
+        </interfaces>
+        <services config:type="list">
+          <service>ssh</service>
+        </services>
+        <ports config:type="list">
+          <port>22/tcp</port>
+        </ports>
+      </zone>
+    </zones>
+  </firewall>
   <timezone>
     <hwclock>UTC</hwclock>
     <timezone>Europe/Prague</timezone>

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -693,8 +693,9 @@ elsif (get_var("NFV")) {
 }
 elsif (get_var("REGRESSION")) {
     load_common_x11;
-    load_xen_tests         if check_var("REGRESSION", "xen");
-    load_suseconnect_tests if check_var("REGRESSION", "suseconnect");
+    load_xen_hypervisor_tests if check_var("REGRESSION", "xen-hypervisor");
+    load_xen_client_tests     if check_var("REGRESSION", "xen-client");
+    load_suseconnect_tests    if check_var("REGRESSION", "suseconnect");
 }
 elsif (get_var("FEATURE")) {
     prepare_target();

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -33,7 +33,7 @@ sub run {
     if (check_var('BACKEND', 'ipmi')) {
         select_console 'sol', await_console => 0;
     }
-    assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu prague-icecream-pxe-menu pxe-menu)], 300);
+    assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu pxe-menu)], 300);
     #detect pxe location
     if (match_has_tag("virttest-pxe-menu")) {
         #BeiJing

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -21,13 +21,13 @@ use ipmi_backend_utils;
 
 sub login_to_console {
     my ($self, $timeout) = @_;
-    $timeout //= 120;
+    $timeout //= 240;
 
     reset_consoles;
     select_console 'sol', await_console => 0;
 
     # Wait for bootload for the first time.
-    assert_screen([qw(grub2 grub1)], 120);
+    assert_screen([qw(grub2 grub1)], 150);
 
     if (!get_var("reboot_for_upgrade_step")) {
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
@@ -89,8 +89,9 @@ sub login_to_console {
     save_screenshot;
     send_key 'ret';
 
-    assert_screen(['linux-login', 'virttest-displaymanager'], $timeout);
+    send_key_until_needlematch(['linux-login', 'virttest-displaymanager'], 'ret', $timeout / 5, 5);
     #use console based on ssh to avoid unstable ipmi
+    save_screenshot;
     use_ssh_serial_console;
 }
 

--- a/tests/virtualization/xen/dom_install.pm
+++ b/tests/virtualization/xen/dom_install.pm
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
-# Summary: Obtain the dom0 metrics
+# Summary: Prepare the dom0 metrics environment
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
 
 
@@ -31,14 +31,13 @@ sub run {
 
     x11_start_program('xterm');
     send_key 'super-up';
-    assert_script_run "ssh root\@$hypervisor 'vhostmd'";
+
+    assert_script_run "ssh root\@$hypervisor 'zypper -n in vhostmd'";
 
     foreach my $guest (keys %xen::guests) {
-        record_info "$guest", "Obtaining dom0 metrics on xl-$guest";
+        record_info "$guest", "Install vm-dump-metrics on xl-$guest";
 
-        assert_script_run "ssh root\@$hypervisor 'xl block-attach xl-$guest /dev/shm/vhostmd0,,xvdc,ro'";
-        assert_script_run "ssh root\@$guest.$domain 'vm-dump-metrics' | grep 'SUSE LLC'";
-        assert_script_run "ssh root\@$hypervisor 'xl block-detach xl-$guest xvdc'";
+        assert_script_run "ssh root\@$guest.$domain 'zypper -n in vm-dump-metrics'";
 
         clear_console;
     }

--- a/tests/virtualization/xen/guest_management.pm
+++ b/tests/virtualization/xen/guest_management.pm
@@ -1,6 +1,6 @@
 # XEN regression tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -10,36 +10,56 @@
 # Summary: Test basic VM guest management
 # Maintainer: Jan Baier <jbaier@suse.cz>
 
-use base 'xen';
-
+use base "x11test";
+use xen;
 use strict;
 use testapi;
 use utils;
 
 sub run {
-    my $self = shift;
+    my ($self) = @_;
+    select_console 'x11';
+    my $hypervisor = get_required_var('QAM_XEN_HYPERVISOR');
 
-    # Start, Stop, Reboot, Autostart, Suspend and Listing should work
-    assert_script_run "virsh shutdown $_" foreach (keys %xen::guests);
-    assert_script_run 'virsh list --all';
+    x11_start_program('xterm');
+    send_key 'super-up';
 
-    assert_script_run "virsh start $_" foreach (keys %xen::guests);
-    assert_script_run 'virsh list --all';
+    record_info "SHUTDOWN", "Shut all guests down";
+    assert_script_run "ssh root\@$hypervisor 'virsh shutdown $_'" foreach (keys %xen::guests);
+    assert_script_run "ssh root\@$hypervisor 'virsh list --all'";
 
-    assert_script_run "virsh reboot $_" foreach (keys %xen::guests);
-    assert_script_run 'virsh list --all';
+    record_info "START", "Start all guests";
+    assert_script_run "ssh root\@$hypervisor 'virsh start $_'" foreach (keys %xen::guests);
+    assert_script_run "ssh root\@$hypervisor 'virsh list --all'";
 
-    assert_script_run "virsh autostart $_" foreach (keys %xen::guests);
-    assert_script_run 'virsh list --all';
+    record_info "REBOOT", "Reboot all guests";
+    sleep 60;
+    assert_script_run "ssh root\@$hypervisor 'virsh reboot $_'" foreach (keys %xen::guests);
+    assert_script_run "ssh root\@$hypervisor 'virsh list --all'";
 
-    assert_script_run "virsh autostart --disable $_" foreach (keys %xen::guests);
-    assert_script_run 'virsh list --all';
+    record_info "AUTOSTART ENABLE", "Enable autostart for all guests";
+    assert_script_run "ssh root\@$hypervisor 'virsh autostart $_'" foreach (keys %xen::guests);
+    assert_script_run "ssh root\@$hypervisor 'virsh list --all'";
 
-    assert_script_run "virsh suspend $_" foreach (keys %xen::guests);
-    assert_script_run 'virsh list --all';
+    record_info "AUTOSTART DISABLE", "Disable autostart for all guests";
+    assert_script_run "ssh root\@$hypervisor 'virsh autostart --disable $_'" foreach (keys %xen::guests);
+    assert_script_run "ssh root\@$hypervisor 'virsh list --all'";
 
-    assert_script_run "virsh resume $_" foreach (keys %xen::guests);
-    assert_script_run 'virsh list --all';
+    record_info "SUSPEND", "Suspend all guests";
+    assert_script_run "ssh root\@$hypervisor 'virsh suspend $_'" foreach (keys %xen::guests);
+    assert_script_run "ssh root\@$hypervisor 'virsh list --all'";
+
+    record_info "RESUME", "Resume all guests";
+    assert_script_run "ssh root\@$hypervisor 'virsh resume $_'" foreach (keys %xen::guests);
+    assert_script_run "ssh root\@$hypervisor 'virsh list --all'";
+    clear_console;
+
+    wait_screen_change { send_key 'alt-f4'; };
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 0};
 }
 
 1;
+

--- a/tests/virtualization/xen/hotplugging.pm
+++ b/tests/virtualization/xen/hotplugging.pm
@@ -1,6 +1,6 @@
 # XEN regression tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -10,44 +10,60 @@
 # Summary: Virtual network and virtual block device hotplugging
 # Maintainer: Jan Baier <jbaier@suse.cz>
 
-use base 'xen';
-
+use base "x11test";
+use xen;
 use strict;
 use testapi;
 use utils;
 
 sub run {
-    my $self = shift;
+    my ($self) = @_;
+    select_console 'x11';
+    my $hypervisor = get_required_var('QAM_XEN_HYPERVISOR');
+    my $domain     = get_required_var('QAM_XEN_DOMAIN');
+
+    x11_start_program('xterm');
+    send_key 'super-up';
 
     # Ensure virsh is installed
-    zypper_call('-t in libvirt-client');
+    assert_script_run "ssh root\@$hypervisor 'zypper -n in libvirt-client'", 180;
 
     foreach my $guest (keys %xen::guests) {
+        record_info "$guest", "Processing $guest now";
+
         # Virtual network
-        assert_script_run "virsh attach-interface --domain $guest --type bridge --source br0 --live";
-        assert_script_run "virsh domiflist $guest";
-        ## TODO: Check "ip l" inside the guest
+        assert_script_run "ssh root\@$hypervisor 'virsh attach-interface --domain $guest --type bridge --source br0 --live'";
+        assert_script_run "ssh root\@$hypervisor 'virsh domiflist $guest'";
+        assert_script_run "ssh root\@$guest.$domain 'ip l'";
 
         # Disk
-        assert_script_run 'mkdir -p /var/lib/libvirt/images/add/';
-        assert_script_run "qemu-img create -f raw /var/lib/libvirt/images/add/$guest.raw 10G";
-        assert_script_run "virsh attach-disk --domain $guest --source /var/lib/libvirt/images/add/$guest.raw --target xvdb";
-        assert_script_run "virsh domblklist $guest";
-        ## TODO: Check "lsblk" inside the guest
-        assert_script_run "virsh detach-disk $guest xvdb";
+        assert_script_run "ssh root\@$hypervisor 'mkdir -p /var/lib/libvirt/images/add/'";
+        assert_script_run "ssh root\@$hypervisor 'qemu-img create -f raw /var/lib/libvirt/images/add/$guest.raw 10G'";
+        assert_script_run "ssh root\@$hypervisor 'virsh attach-disk --domain $guest --source /var/lib/libvirt/images/add/$guest.raw --target xvdb'";
+        assert_script_run "ssh root\@$hypervisor 'virsh domblklist $guest'";
+        assert_script_run "ssh root\@$guest.$domain 'lsblk'";
+        assert_script_run "ssh root\@$hypervisor 'virsh detach-disk $guest xvdb'";
 
         # CPU
-        assert_script_run "virsh vcpucount $guest";
-        assert_script_run "virsh setvcpus --domain $guest --count 1 --live";
-        ## TODO: Check "lscpu" inside the guest
-        assert_script_run "virsh vcpucount $guest";
+        assert_script_run "ssh root\@$hypervisor 'virsh vcpucount $guest'";
+        assert_script_run "ssh root\@$hypervisor 'virsh setvcpus --domain $guest --count 1 --live'";
+        assert_script_run "ssh root\@$guest.$domain 'lscpu'";
+        assert_script_run "ssh root\@$hypervisor 'virsh vcpucount $guest'";
 
         # Memory
-        assert_script_run 'xl list';
-        assert_script_run "virsh setmem --domain $guest --size 1024M --live";
-        ## TODO: Check "free" inside the guest
-        assert_script_run 'xl list';
+        assert_script_run "ssh root\@$hypervisor 'xl list'";
+        assert_script_run "ssh root\@$hypervisor 'virsh setmem --domain $guest --size 1024M --live'";
+        assert_script_run "ssh root\@$guest.$domain 'free'";
+        assert_script_run "ssh root\@$hypervisor 'xl list'";
+        clear_console;
     }
+
+    wait_screen_change { send_key 'alt-f4'; };
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 0};
 }
 
 1;
+

--- a/tests/virtualization/xen/install_virtmanager.pm
+++ b/tests/virtualization/xen/install_virtmanager.pm
@@ -13,12 +13,10 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
-# Summary: Obtain the dom0 metrics
+# Summary: This test install the virt-manager libvirt GUI
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
 
-
 use base "x11test";
-use xen;
 use strict;
 use testapi;
 use utils;
@@ -26,23 +24,13 @@ use utils;
 sub run {
     my ($self) = @_;
     select_console 'x11';
-    my $hypervisor = get_required_var('QAM_XEN_HYPERVISOR');
-    my $domain     = get_required_var('QAM_XEN_DOMAIN');
 
     x11_start_program('xterm');
     send_key 'super-up';
-    assert_script_run "ssh root\@$hypervisor 'vhostmd'";
-
-    foreach my $guest (keys %xen::guests) {
-        record_info "$guest", "Obtaining dom0 metrics on xl-$guest";
-
-        assert_script_run "ssh root\@$hypervisor 'xl block-attach xl-$guest /dev/shm/vhostmd0,,xvdc,ro'";
-        assert_script_run "ssh root\@$guest.$domain 'vm-dump-metrics' | grep 'SUSE LLC'";
-        assert_script_run "ssh root\@$hypervisor 'xl block-detach xl-$guest xvdc'";
-
-        clear_console;
-    }
-
+    become_root;
+    zypper_call 'in virt-manager';
+    systemctl 'stop ' . $self->firewall;
+    systemctl 'disable ' . $self->firewall;
     wait_screen_change { send_key 'alt-f4'; };
 
 }

--- a/tests/virtualization/xen/list_guests.pm
+++ b/tests/virtualization/xen/list_guests.pm
@@ -1,0 +1,31 @@
+# XEN regression tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: List all guests so they're running
+# Maintainer: Jan Baier <jbaier@suse.cz>
+
+use base 'xen';
+
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+
+    foreach my $guest (keys %xen::guests) {
+        record_info "$guest", "Listing $guest guest";
+
+        assert_script_run "xl list $guest";
+
+        clear_console;
+    }
+}
+
+1;

--- a/tests/virtualization/xen/patch_and_reboot.pm
+++ b/tests/virtualization/xen/patch_and_reboot.pm
@@ -1,6 +1,6 @@
 # XEN regression tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -11,19 +11,43 @@
 # Maintainer: Jan Baier <jbaier@suse.cz>
 
 use base 'xen';
-
+use warnings;
 use strict;
+use power_action_utils 'power_action';
+use ipmi_backend_utils;
 use testapi;
 use utils;
+use qam;
 
 sub run {
     my $self = shift;
 
-    ## TODO
-    #    * install patches
-    #    * check that the guests are still running
-    #    * reboot
-    #    * check that the guests are still running
+    add_test_repositories;
+    fully_patch_system;
+
+    #leave ssh console and switch to sol console
+    switch_from_ssh_to_sol_console(reset_console_flag => 'off');
+    #login
+    send_key_until_needlematch('text-login', 'ret', 360, 5);
+    type_string "root\n";
+    assert_screen "password-prompt";
+    type_password;
+    send_key('ret');
+    assert_screen "text-logged-in-root";
+
+    #type reboot
+    type_string("reboot\n");
+    save_screenshot;
+    #switch to sut console
+    reset_consoles;
+}
+
+sub post_run_hook {
+}
+
+sub test_flags {
+    return {fatal => 1};
 }
 
 1;
+

--- a/tests/virtualization/xen/prepare_guests.pm
+++ b/tests/virtualization/xen/prepare_guests.pm
@@ -1,6 +1,6 @@
 # XEN regression tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,6 +19,11 @@ use utils;
 sub run {
     my $self = shift;
 
+    assert_script_run qq(echo 'log_level = 1
+    log_filters="3:remote 4:event 3:json 3:rpc"
+    log_outputs="1:file:/var/log/libvirt/libvirtd.log"' >> /etc/libvirt/libvirtd.conf);
+    systemctl 'restart libvirtd';
+
     # Ensure additional package is installed
     zypper_call '-t in libvirt-client';
 
@@ -27,6 +32,7 @@ sub run {
     save_screenshot;
 
     # Install every defined guest
+    # TODO: It will be nice to run this in parallel
     foreach my $guest (keys %xen::guests) {
         $self->create_guest($guest, 'virt-install');
         # Show guest details

--- a/tests/virtualization/xen/save_and_restore.pm
+++ b/tests/virtualization/xen/save_and_restore.pm
@@ -1,6 +1,6 @@
 # XEN regression tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -10,26 +10,48 @@
 # Summary: Test if the guests can be saved and restored
 # Maintainer: Jan Baier <jbaier@suse.cz>
 
-use base 'xen';
-
+use base "x11test";
+use xen;
 use strict;
 use testapi;
 use utils;
 
 sub run {
-    my $self = shift;
+    my ($self) = @_;
+    select_console 'x11';
+    my $hypervisor = get_required_var('QAM_XEN_HYPERVISOR');
+
+    x11_start_program('xterm');
+    send_key 'super-up';
 
     # Ensure virsh is installed
-    zypper_call('-t in libvirt-client');
+    assert_script_run "ssh root\@$hypervisor 'zypper -n in libvirt-client'";
+    assert_script_run "ssh root\@$hypervisor 'mkdir -p /var/lib/libvirt/images/saves/'";
 
-    assert_script_run "mkdir -p /var/lib/libvirt/images/saves/";
-    # Save the machine states
-    assert_script_run "virsh save $_ /var/lib/libvirt/images/saves/$_.vmsave" foreach (keys %xen::guests);
-    # Check saved states
-    assert_script_run "virsh list --all";
-    assert_script_run "virsh list --all --with-managed-save";
-    # Restore guests
-    assert_script_run "virsh restore /var/lib/libvirt/images/saves/$_.vmsave" foreach (keys %xen::guests);
+    foreach my $guest (keys %xen::guests) {
+        record_info "$guest", "Processing $guest now";
+
+        # Remove previous attempt (if there was any)
+        script_run "ssh root\@$hypervisor 'rm /var/lib/libvirt/images/saves/$guest.vmsave' || true";
+
+        # Save the machine states
+        assert_script_run "ssh root\@$hypervisor 'virsh save $guest /var/lib/libvirt/images/saves/$guest.vmsave'", 300;
+        sleep 15;
+
+        # Check saved states
+        assert_script_run "ssh root\@$hypervisor 'virsh list --all'";
+
+        # Restore guests
+        assert_script_run "ssh root\@$hypervisor 'virsh restore /var/lib/libvirt/images/saves/$guest.vmsave'", 300;
+
+        clear_console;
+    }
+
+    wait_screen_change { send_key 'alt-f4'; };
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 0};
 }
 
 1;

--- a/tests/virtualization/xen/ssh_hypervisor.pm
+++ b/tests/virtualization/xen/ssh_hypervisor.pm
@@ -13,9 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
-# Summary: Obtain the dom0 metrics
+# Summary: This test connects to hypervisor using SSH
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
-
 
 use base "x11test";
 use xen;
@@ -27,24 +26,14 @@ sub run {
     my ($self) = @_;
     select_console 'x11';
     my $hypervisor = get_required_var('QAM_XEN_HYPERVISOR');
-    my $domain     = get_required_var('QAM_XEN_DOMAIN');
 
     x11_start_program('xterm');
-    send_key 'super-up';
-    assert_script_run "ssh root\@$hypervisor 'vhostmd'";
 
-    foreach my $guest (keys %xen::guests) {
-        record_info "$guest", "Obtaining dom0 metrics on xl-$guest";
-
-        assert_script_run "ssh root\@$hypervisor 'xl block-attach xl-$guest /dev/shm/vhostmd0,,xvdc,ro'";
-        assert_script_run "ssh root\@$guest.$domain 'vm-dump-metrics' | grep 'SUSE LLC'";
-        assert_script_run "ssh root\@$hypervisor 'xl block-detach xl-$guest xvdc'";
-
-        clear_console;
-    }
+    assert_script_run "ssh-keygen -t rsa -P '' -C 'localhost' -f ~/.ssh/id_rsa";
+    assert_script_run "ssh-keyscan $hypervisor > ~/.ssh/known_hosts";
+    exec_and_insert_password "ssh-copy-id root\@$hypervisor";
 
     wait_screen_change { send_key 'alt-f4'; };
-
 }
 
 sub test_flags {

--- a/tests/virtualization/xen/virsh_start.pm
+++ b/tests/virtualization/xen/virsh_start.pm
@@ -13,9 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
-# Summary: Obtain the dom0 metrics
+# Summary: This starts libvirt guests again
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
-
 
 use base "x11test";
 use xen;
@@ -27,18 +26,14 @@ sub run {
     my ($self) = @_;
     select_console 'x11';
     my $hypervisor = get_required_var('QAM_XEN_HYPERVISOR');
-    my $domain     = get_required_var('QAM_XEN_DOMAIN');
 
     x11_start_program('xterm');
     send_key 'super-up';
-    assert_script_run "ssh root\@$hypervisor 'vhostmd'";
 
     foreach my $guest (keys %xen::guests) {
-        record_info "$guest", "Obtaining dom0 metrics on xl-$guest";
+        record_info "$guest", "Starting $guest again";
 
-        assert_script_run "ssh root\@$hypervisor 'xl block-attach xl-$guest /dev/shm/vhostmd0,,xvdc,ro'";
-        assert_script_run "ssh root\@$guest.$domain 'vm-dump-metrics' | grep 'SUSE LLC'";
-        assert_script_run "ssh root\@$hypervisor 'xl block-detach xl-$guest xvdc'";
+        assert_script_run "ssh root\@$hypervisor 'virsh start $guest'";
 
         clear_console;
     }

--- a/tests/virtualization/xen/virsh_stop.pm
+++ b/tests/virtualization/xen/virsh_stop.pm
@@ -13,9 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
-# Summary: Obtain the dom0 metrics
+# Summary: Stop all libvirt guests
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
-
 
 use base "x11test";
 use xen;
@@ -27,20 +26,15 @@ sub run {
     my ($self) = @_;
     select_console 'x11';
     my $hypervisor = get_required_var('QAM_XEN_HYPERVISOR');
-    my $domain     = get_required_var('QAM_XEN_DOMAIN');
 
     x11_start_program('xterm');
     send_key 'super-up';
-    assert_script_run "ssh root\@$hypervisor 'vhostmd'";
 
     foreach my $guest (keys %xen::guests) {
-        record_info "$guest", "Obtaining dom0 metrics on xl-$guest";
+        record_info "$guest", "Stopping the $guest";
 
-        assert_script_run "ssh root\@$hypervisor 'xl block-attach xl-$guest /dev/shm/vhostmd0,,xvdc,ro'";
-        assert_script_run "ssh root\@$guest.$domain 'vm-dump-metrics' | grep 'SUSE LLC'";
-        assert_script_run "ssh root\@$hypervisor 'xl block-detach xl-$guest xvdc'";
-
-        clear_console;
+        # Stop the original VM we created using virsh
+        assert_script_run "ssh root\@$hypervisor 'virsh shutdown $guest'";
     }
 
     wait_screen_change { send_key 'alt-f4'; };

--- a/tests/virtualization/xen/virtmanager.pm
+++ b/tests/virtualization/xen/virtmanager.pm
@@ -1,0 +1,75 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: This test connects to hypervisor and check our VMs
+# Maintainer: Pavel Dostál <pdostal@suse.cz>
+
+use base "x11test";
+use xen;
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+    select_console 'x11';
+    my $hypervisor = get_required_var('QAM_XEN_HYPERVISOR');
+
+    x11_start_program 'virt-manager', target_match => 'virt-manager';
+
+    assert_screen "virt-manager_add-connection";
+    send_key 'spc';
+    send_key 'down';
+    send_key 'down';
+    send_key 'spc';
+    save_screenshot;    # XEN selected
+    send_key 'tab';
+    send_key 'spc';
+    save_screenshot;    # Connect to remote host ticked
+    send_key 'tab';
+    send_key 'tab';
+    type_string 'root';
+    save_screenshot;    # root written
+    send_key 'tab';
+    type_string "$hypervisor";
+    save_screenshot;    # $hypervisor written
+    send_key 'tab';
+    send_key 'spc';
+    save_screenshot;    # autoconnect ticked
+    send_key 'ret';
+    assert_screen "virt-manager_connected";
+
+    foreach my $guest (keys %xen::guests) {
+        record_info "$guest", "Going to check $guest console";
+
+        assert_and_dclick "virt-manager_list-$guest";
+        if (!check_screen 'virt-manager_login-screen', 30) {
+            send_key 'backspace';    # In case screen is off
+            assert_and_click 'virt-manager_send-key';
+            assert_and_click 'virt-manager_ctrl-alt-f2';
+            assert_screen "virt-manager_login-screen";
+        }
+        wait_screen_change { send_key 'alt-f4'; };
+    }
+
+    wait_screen_change { send_key 'alt-f4'; };
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 0};
+}
+
+1;
+

--- a/tests/virtualization/xen/xl_create.pm
+++ b/tests/virtualization/xen/xl_create.pm
@@ -1,0 +1,68 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Export XML from virsh and create new guests in xl stack
+# Maintainer: Pavel Dostál <pdostal@suse.cz>
+
+use base "x11test";
+use xen;
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+    select_console 'x11';
+    my $hypervisor = get_required_var('QAM_XEN_HYPERVISOR');
+    my $domain     = get_required_var('QAM_XEN_DOMAIN');
+
+    x11_start_program('xterm');
+    send_key 'super-up';
+
+    foreach my $guest (keys %xen::guests) {
+        record_info "$guest", "Starting to clone $guest to xl-$guest";
+
+        # Export the XML from virsh and convert it into Xen config file
+        assert_script_run "ssh root\@$hypervisor 'virsh dumpxml $guest > $guest.xml'";
+        assert_script_run "ssh root\@$hypervisor 'virsh domxml-to-native xen-xl $guest.xml > $guest.xml.cfg'";
+
+        # Change the name by adding suffix _xl
+        assert_script_run "ssh root\@$hypervisor \"sed -rie 's/(name = \\W)/\\1xl-/gi' $guest.xml.cfg\"";
+        assert_script_run "ssh root\@$hypervisor 'cat $guest.xml.cfg | grep name'";
+
+        # Change the UUID by using f00 as three first characters
+        assert_script_run "ssh root\@$hypervisor \"sed -rie 's/(uuid = \\W)(...)/\\1f00/gi' $guest.xml.cfg\"";
+        assert_script_run "ssh root\@$hypervisor 'cat $guest.xml.cfg | grep uuid'";
+
+        # Start the new VM
+        assert_script_run "ssh root\@$hypervisor xl create $guest.xml.cfg";
+        assert_script_run "ssh root\@$hypervisor xl list xl-$guest";
+
+        # Test that the new VM listens on SSH
+        assert_script_run "while true; do ssh root\@$guest.$domain hostname 2> /dev/null && break; done";
+
+        clear_console;
+    }
+
+    wait_screen_change { send_key 'alt-f4'; };
+
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 0};
+}
+
+1;
+

--- a/tests/virtualization/xen/xl_stop.pm
+++ b/tests/virtualization/xen/xl_stop.pm
@@ -13,9 +13,8 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
-# Summary: Obtain the dom0 metrics
+# Summary: This stops all xl VMs
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
-
 
 use base "x11test";
 use xen;
@@ -27,18 +26,14 @@ sub run {
     my ($self) = @_;
     select_console 'x11';
     my $hypervisor = get_required_var('QAM_XEN_HYPERVISOR');
-    my $domain     = get_required_var('QAM_XEN_DOMAIN');
 
     x11_start_program('xterm');
     send_key 'super-up';
-    assert_script_run "ssh root\@$hypervisor 'vhostmd'";
 
     foreach my $guest (keys %xen::guests) {
-        record_info "$guest", "Obtaining dom0 metrics on xl-$guest";
+        record_info "$guest", "Stopping xl-$guest guests";
 
-        assert_script_run "ssh root\@$hypervisor 'xl block-attach xl-$guest /dev/shm/vhostmd0,,xvdc,ro'";
-        assert_script_run "ssh root\@$guest.$domain 'vm-dump-metrics' | grep 'SUSE LLC'";
-        assert_script_run "ssh root\@$hypervisor 'xl block-detach xl-$guest xvdc'";
+        assert_script_run "ssh root\@$hypervisor xl shutdown -w xl-$guest";
 
         clear_console;
     }


### PR DESCRIPTION
Hello,

I've two new testsuites - they are for Xen testing on bare metal in QAM.
The physical hypervisor is controlled by IPMI and SSH. Right now, we use standard graphical installer to install the hypervisor and then we also install guest machines using autoyast profiles.
Second testsuite will be started after the first one and this one uses SSH and the virt-manager tool and that's why it is graphical.

- Related ticket: [poo#40610](https://progress.opensuse.org/issues/40610) [poo#43739](https://progress.opensuse.org/issues/43739)
- Needles: [os-autoinst-needles-sles#1042](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1042)
- Verification run: [qam-regression-xen-hypervisor@12-SP3](http://pdostal-server.suse.cz/tests/827) [qam-regression-xen-hypervisor@12-SP4](http://pdostal-server.suse.cz/tests/837) [qam-regression-xen-client@12-SP3](http://pdostal-server.suse.cz/tests/834) [qam-regression-xen-client@12-SP4](http://pdostal-server.suse.cz/tests/839)
