### PR TITLE
Type command to overcome problems with network

### DIFF
--- a/tests/x11/window_system.pm
+++ b/tests/x11/window_system.pm
@@ -19,7 +19,10 @@ sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
-    my $session_type = script_output "loginctl show-session \$(loginctl list-sessions | awk '/$testapi::username/ {print \$1};') -p Type | cut -f2 -d=";
+    my $session_type = script_output(
+        "loginctl show-session \$(loginctl list-sessions | awk '/$testapi::username/ {print \$1};') -p Type | cut -f2 -d=",
+        undef, type_command => 1,
+    );
 
     if ($session_type) {
         record_info("$session_type", "Current session type is $session_type");


### PR DESCRIPTION
Some tests have different network setup (like the VNC one) and cannot
handle downloading the script via curl. Make the script_output to type
the command as requested in the ticket.

- Related ticket: https://progress.opensuse.org/issues/45677
- Verification run: http://panigale.suse.cz/tests/1220