### PR TITLE
publiccloud: Use dynamic repo url for LTP

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -15,11 +15,11 @@ use base "publiccloud::basetest";
 use strict;
 use testapi;
 use utils;
-use Data::Dumper;
+use repo_tools 'generate_version';
 
 sub run {
     my ($self) = @_;
-    my $ltp_repo = get_var('LTP_REPO', 'https://download.opensuse.org/repositories/home:/metan/SLE_12_SP3/home:metan.repo');
+    my $ltp_repo = get_var('LTP_REPO', 'https://download.opensuse.org/repositories/home:/metan/' . generate_version() . '/home:metan.repo');
     $self->select_serial_terminal;
 
     my $provider = $self->provider_factory();


### PR DESCRIPTION
Use the given VERSION and DISTRI to calculate the repo url, with the
help of repo_tools::generate_version().

- Related ticket: https://progress.opensuse.org/issues/45800
- Verification run: http://cfconrad-vm.qa.suse.de/tests/3196

@asmorodskyi @jlausuch 