### PR TITLE
kubic: Fix sporadic failures to match boot screen

### DIFF
--- a/tests/kubic/disk_boot.pm
+++ b/tests/kubic/disk_boot.pm
@@ -17,8 +17,7 @@ use testapi;
 use caasp "microos_login";
 
 sub run {
-    assert_screen 'grub2';
-    send_key 'ret';
+    shift->wait_boot(bootloader_time => 300);
     microos_login;
 }
 


### PR DESCRIPTION
Recently kubic/disk_boot failed to reach the grub menu in time a lot. It is
not exactly clear if product changes have a significant impact here or the
load on the workers has changed. "imagetester" regularly succeeded to pass
this step but "openqaworker1" and "openqaworker4" did not, taking longer to
execute the jobs and therefore regularly hitting the default `assert_screen`
timeout of 30s. Other test modules use the `wait_boot`-method from the
opensusetest base-class so kubic/disk_boot should just do the same which is
basically doing the same as in before but with a higher timeout. Additionally
the bootloader-time has been set to a higher value to cover potentially longer
boot-times because the current openQA-tests should not try to assert too
strict shutdown-/reboot-/bootup-times when the product expectations are not
that clear. However, one can still gather the actually needed times from the
logs.

Verification run: http://lord.arch/tests/1969

Related progress issue: https://progress.opensuse.org/issues/45938