### PR TITLE
Fix order of online_repos

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -811,6 +811,8 @@ sub load_inst_tests {
         loadtest "installation/multipath";
     }
     if (is_opensuse && noupdatestep_is_applicable() && !is_livecd) {
+        # See https://github.com/yast/yast-packager/pull/385
+        loadtest "installation/online_repos";
         loadtest "installation/installation_mode";
     }
     if (is_upgrade) {
@@ -850,7 +852,7 @@ sub load_inst_tests {
             loadtest "installation/livecd_network_settings";
         }
         # See https://github.com/yast/yast-packager/pull/385
-        loadtest "installation/online_repos" if is_opensuse;
+        loadtest "installation/online_repos" if is_opensuse && is_livecd;
         # Run system_role/desktop selection tests if using the new openSUSE installation flow
         if (is_using_system_role_first_flow && requires_role_selection) {
             load_system_role_tests;


### PR DESCRIPTION
Apparently I didn't read the code correctly, so the move was not a noop.

Validation runs (canceled just after the failing part):

RAID0 DVD install: http://10.160.67.86/tests/268
DVD Upgrade: http://10.160.67.86/tests/266
Live installation: http://10.160.67.86/tests/269
Live upgrade: http://10.160.67.86/tests/270