### PR TITLE
LTP: Install AppArmor related packages

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -64,6 +64,8 @@ sub install_runtime_dependencies {
     # ntfsprogs are for SLE in WE, openSUSE has it in default repository
     my @maybe_deps = qw(
       acl
+      apparmor-parser
+      apparmor-utils
       audit
       binutils
       dosfstools


### PR DESCRIPTION
Fixes: b96b5afda ("LTP: Print AppArmor status")

Verification run
- http://quasar.suse.cz/tests/1540
- http://quasar.suse.cz/tests/1541
