### PR TITLE
[WIP] kubic: Fix adding new repository

### DIFF
--- a/tests/kubic/repositories.pm
+++ b/tests/kubic/repositories.pm
@@ -23,7 +23,7 @@ sub run {
         # Any pkg installation from now on, should come from the MIRROR_HTTP
         zypper_call("mr -da");
         my $mirror = get_required_var('MIRROR_HTTP');
-        zypper_call("--no-gpg-check ar -f '$mirror' mirror_http");
+        zypper_call("--no-gpg-check ar -f '$mirror' mirror_http2");
     }
     zypper_call('ref');
 }


### PR DESCRIPTION
The zypper repository "mirror_http" still exists, it was just disabled.
Fixing the test failure as seen in
https://openqa.opensuse.org/tests/828636#step/repositories/9 by
selecting a new name.

@openQA: Clone https://openqa.opensuse.org/tests/828636