### PR TITLE
Return missing required space

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -96,7 +96,7 @@ sub run {
         $image_path .= 'plymouth.enable=0 ';
     }
     # Execute installation command on pxe management cmd console
-    type_string_slow ${image_path};
+    type_string_slow ${image_path} . " ";
     bootmenu_default_params(pxe => 1, baud_rate => '115200');
 
     if (check_var('BACKEND', 'ipmi') && !get_var('AUTOYAST')) {


### PR DESCRIPTION
Removed when replacint type_stinrg in https://github.com/dzedro/os-autoinst-distri-opensuse/commit/c01d2d4b415fd528e4a5b27499a018abef237027

-Fail: https://openqa.suse.de/tests/2367721#step/boot_from_pxe/2

