### PR TITLE
Restore container tests to Kubic

### DIFF
--- a/products/kubic/main.pm
+++ b/products/kubic/main.pm
@@ -35,8 +35,13 @@ sub load_feature_tests {
     loadtest 'caasp/services_enabled';
     load_transactional_role_tests;
     loadtest 'caasp/journal_check';
+    loadtest 'console/podman';
     if (check_var 'SYSTEM_ROLE', 'kubeadm') {
         loadtest 'console/kubeadm';
+    }
+    else {
+        # Docker only present on MicroOS, not kubeadm roles
+        loadtest 'console/docker';
     }
 }
 

--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -53,7 +53,7 @@ sub run {
     test_seccomp();
 
     # images can be searched on the Docker Hub
-    validate_script_output("docker search --no-trunc opensuse", sub { m/This project contains the stable releases of the openSUSE distribution/ }, 120);
+    validate_script_output("docker search --no-trunc opensuse", sub { m/This project contains the stable releases of the openSUSE distribution/ });
 
     # images can be pulled from the Docker Hub
     #   - pull minimalistic alpine image of declared version using tag
@@ -64,8 +64,7 @@ sub run {
     #   - https://store.docker.com/images/hello-world
     assert_script_run("docker image pull hello-world", timeout => 300);
     #   - pull image of last released version of openSUSE Leap
-    my $last_released_leap_version = '42.3';
-    assert_script_run("docker image pull opensuse:$last_released_leap_version", timeout => 600);
+    assert_script_run("docker image pull opensuse/leap", timeout => 600);
     #   - pull image of openSUSE Tumbleweed
     assert_script_run('docker image pull opensuse/tumbleweed', timeout => 600);
 
@@ -77,8 +76,8 @@ sub run {
     assert_script_run(qq{docker image ls hello-world | grep "hello-world\\s*latest"});
     #   - all local images
     my $local_images_list = script_output('docker image ls');
-    die('docker image opensuse/tumbleweed not found')                  unless ($local_images_list =~ /opensuse\/tumbleweed\s*latest/);
-    die("docker image opensuse:$last_released_leap_version not found") unless ($local_images_list =~ /opensuse\s*\Q$last_released_leap_version\E/);
+    die('docker image opensuse/tumbleweed not found') unless ($local_images_list =~ /opensuse\/tumbleweed\s*latest/);
+    die("docker image opensuse/leap not found")       unless ($local_images_list =~ /opensuse\/leap\s*latest/);
 
     # containers can be spawned
     #   - using 'run'
@@ -148,13 +147,13 @@ sub run {
     die("error: container was not removed: $cmd_docker_container_prune") if ($output_containers =~ m/test_2/);
 
     # images can be deleted
-    my $cmd_docker_rmi = "docker image rm alpine:$alpine_image_version hello-world opensuse:$last_released_leap_version opensuse/tumbleweed tw:saved";
+    my $cmd_docker_rmi = "docker image rm alpine:$alpine_image_version hello-world opensuse/leap opensuse/tumbleweed tw:saved";
     my $output_deleted = script_output($cmd_docker_rmi);
-    die("error: docker image rm opensuse:$last_released_leap_version") unless ($output_deleted =~ m/Untagged: opensuse:$last_released_leap_version/);
-    die('error: docker image rm opensuse/tumbleweed')                  unless ($output_deleted =~ m/Untagged: opensuse\/tumbleweed/);
-    die('error: docker image rm tw:saved')                             unless ($output_deleted =~ m/Untagged: tw:saved/);
-    die("error: docker image rm alpine:$alpine_image_version")         unless ($output_deleted =~ m/Untagged: alpine:$alpine_image_version/);
-    die('error: docker image rm hello-world:latest')                   unless ($output_deleted =~ m/Untagged: hello-world:latest/);
+    die("error: docker image rm opensuse/leap")                unless ($output_deleted =~ m/Untagged: opensuse\/leap/);
+    die('error: docker image rm opensuse/tumbleweed')          unless ($output_deleted =~ m/Untagged: opensuse\/tumbleweed/);
+    die('error: docker image rm tw:saved')                     unless ($output_deleted =~ m/Untagged: tw:saved/);
+    die("error: docker image rm alpine:$alpine_image_version") unless ($output_deleted =~ m/Untagged: alpine:$alpine_image_version/);
+    die('error: docker image rm hello-world:latest')           unless ($output_deleted =~ m/Untagged: hello-world:latest/);
 }
 
 1;

--- a/tests/console/podman.pm
+++ b/tests/console/podman.pm
@@ -1,0 +1,122 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test podman installation and extended usage in a Kubic system
+#    Cover the following aspects of podman:
+#      * podman daemon can be started
+#      * images can be searched on the default registry
+#      * images can be pulled from the default registry
+#      * local images can be listed
+#      * containers can be spawned
+#      * containers state can be saved to an image
+#      * network is working inside of the containers
+#      * containers can be stopped
+#      * containers can be deleted
+#      * images can be deleted
+# Maintainer: Richard Brown <rbrown@suse.com>
+
+use base "consoletest";
+use testapi;
+use utils;
+use strict;
+use registration;
+use version_utils qw(is_sle is_leap);
+
+sub run {
+    select_console("root-console");
+
+    # images can be searched on the default registry
+    validate_script_output("podman search --no-trunc opensuse", sub { m/This project contains the stable releases of the openSUSE distribution/ });
+
+    # images can be pulled from the default registry
+    #   - pull minimalistic alpine image of declared version using tag
+    #   - https://store.docker.com/images/alpine
+    my $alpine_image_version = '3.6';
+    assert_script_run("podman image pull alpine:$alpine_image_version", timeout => 300);
+    #   - pull typical podman demo image without tag. Should be latest.
+    #   - https://store.docker.com/images/hello-world
+    assert_script_run("podman image pull hello-world", timeout => 300);
+    #   - pull image of last released version of openSUSE Leap
+    assert_script_run("podman image pull opensuse/leap", timeout => 600);
+    #   - pull image of openSUSE Tumbleweed
+    assert_script_run('podman image pull opensuse/tumbleweed', timeout => 600);
+
+    # local images can be listed
+    assert_script_run('podman image ls');
+    #   - filter with tag
+    assert_script_run(qq{podman image ls alpine:$alpine_image_version | grep "alpine\\s*$alpine_image_version"});
+    #   - filter without tag
+    assert_script_run(qq{podman image ls hello-world | grep "hello-world\\s*latest"});
+    #   - all local images
+    my $local_images_list = script_output('podman image ls');
+    die('podman image opensuse/tumbleweed not found') unless ($local_images_list =~ /opensuse\/tumbleweed\s*latest/);
+    die("podman image opensuse/leap not found")       unless ($local_images_list =~ /opensuse\/leap\s*latest/);
+
+    # containers can be spawned
+    #   - using 'run'
+    assert_script_run('podman container run --name test_1 hello-world | grep "Hello from Docker\!"');
+    #   - using 'create', 'start' and 'logs' (background container)
+    assert_script_run("podman container create --name test_2 alpine:$alpine_image_version /bin/echo Hello world");
+    assert_script_run('podman container start test_2 | grep "test_2"');
+    assert_script_run('podman container logs test_2 | grep "Hello world"');
+    #   - using 'run --rm'
+    assert_script_run(qq{podman container run --name test_ephemeral --rm alpine:$alpine_image_version /bin/echo Hello world | grep "Hello world"});
+    #   - using 'run -d' and 'inspect' (background container)
+    my $container_name = 'tw';
+    assert_script_run("podman container run -d --name $container_name opensuse/tumbleweed tail -f /dev/null");
+    assert_script_run("podman container inspect --format='{{.State.Running}}' $container_name | grep true");
+    my $output_containers = script_output('podman container ls -a');
+    die('error: missing container test_1') unless ($output_containers =~ m/test_1/);
+    die('error: missing container test_2') unless ($output_containers =~ m/test_2/);
+    die('error: ephemeral container was not removed') if ($output_containers =~ m/test_ephemeral/);
+    die("error: missing container $container_name") unless ($output_containers =~ m/$container_name/);
+
+    # containers state can be saved to a podman image
+    my $exit_code = script_run("podman container exec $container_name zypper -n in curl", 300);
+    if ($exit_code) {
+        record_info('poo#40958 - curl install failure, try with force-resolution.');
+        my $output = script_output("podman container exec $container_name zypper in --force-resolution -y -n curl", 300);
+        die('error: curl not installed in the container') unless ($output =~ m/Installing: curl.*done/);
+    }
+    assert_script_run("podman container commit $container_name tw:saved");
+
+    # network is working inside of the containers
+    my $output = script_output('podman container run tw:saved curl -I google.de');
+    die("network is not working inside of the container tw:saved") unless ($output =~ m{Location: http://www\.google\.de/});
+
+    if (script_run('command -v man') == 0) {
+        assert_script_run('man -P cat podman build | grep "podman-build - Build a container image using a Dockerfile"');
+    }
+
+    # containers can be stopped
+    assert_script_run("podman container stop $container_name");
+    assert_script_run("podman container inspect --format='{{.State.Running}}' $container_name | grep false");
+
+    # containers can be deleted
+    my $cmd_podman_rm = 'podman container rm test_1';
+    assert_script_run("$cmd_podman_rm");
+    $output_containers = script_output('podman container ls -a');
+    die("error: container was not removed: $cmd_podman_rm") if ($output_containers =~ m/test_1/);
+    my $cmd_podman_container_prune = 'podman container prune';
+    assert_script_run("$cmd_podman_container_prune");
+    $output_containers = script_output('podman container ls -a');
+    die("error: container was not removed: $cmd_podman_container_prune") if ($output_containers =~ m/test_2/);
+
+    # images can be deleted
+    my $cmd_podman_rmi = "podman rmi -a";
+    $output_containers = script_output('podman container ls -a');
+    die('error: podman rmi -a did not remove opensuse/leap')                if ($output_containers =~ m/Untagged: opensuse\/leap/);
+    die('error: podman rmi -a did not remove opensuse/tumbleweed')          if ($output_containers =~ m/Untagged: opensuse\/tumbleweed/);
+    die('error: podman rmi -a did not remove tw:saved')                     if ($output_containers =~ m/Untagged: tw:saved/);
+    die("error: podman rmi -a did not remove alpine:$alpine_image_version") if ($output_containers =~ m/Untagged: alpine:$alpine_image_version/);
+    die('error: podman rmi -a did not remove hello-world:latest')           if ($output_containers =~ m/Untagged: hello-world:latest/);
+}
+
+1;


### PR DESCRIPTION
Kubic needs tests for both podman and docker. These were used in the past but were removed due to stability issues in both the tests and the product

These product is now stable, and this PR makes the tests stable and restores them to active duty for Kubic

- Verification run: http://ibrokeit.suse.de/tests/63
