### PR TITLE
Add flag to mutt test to continue in case of failure

### DIFF
--- a/tests/console/mutt.pm
+++ b/tests/console/mutt.pm
@@ -73,4 +73,8 @@ sub run {
     select_console "root-console";
 }
 
+sub test_flags {
+    return {fatal => 0};
+}
+
 1;


### PR DESCRIPTION
This change adds a flag to the mutt test so in case of failure the tests following this one will run.

- Related ticket: https://progress.opensuse.org/issues/45788#change-178688
- Validation run: http://ccret.suse.cz/tests/2372#
