### PR TITLE
Add a workaround for bsc#1076817

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2349,6 +2349,7 @@ sub load_common_opensuse_sle_tests {
     load_toolchain_tests                if get_var("TCM") || check_var("ADDONS", "tcm");
     loadtest 'console/network_hostname' if get_var('NETWORK_CONFIGURATION');
     load_installation_validation_tests  if get_var('INSTALLATION_VALIDATION');
+    load_shutdown_tests if check_var('DESKTOP', 'minimalx');
 }
 
 sub load_ssh_key_import_tests {

--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -155,6 +155,12 @@ sub poweroff_x11 {
         send_key "alt-d";              # shut_d_own
         assert_screen 'logout-confirm-dialog', 10;
         send_key "alt-o";              # _o_k
+
+        if (!check_shutdown()) {
+            record_soft_failure 'bsc#1076817 manually shutting down';
+            select_console 'root-console';
+            systemctl 'poweroff';
+        }
     }
 
     if (check_var('BACKEND', 's390x')) {


### PR DESCRIPTION
When detecting a password prompt on minimalx, the test now shuts down
via systemctl poweroff

- Related ticket: https://progress.opensuse.org/issues/46076
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1044
- Verification run: http://pinky.arch.suse.de/tests/40#step/shutdown/6
