### PR TITLE
[WIP][SLE-15-SP1 Virt][Urgent]Install guestfs-tools to provide vm utilities

### DIFF
--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -52,6 +52,8 @@ sub install_package {
     #install qa_lib_virtauto
     assert_script_run("zypper --non-interactive --gpg-auto-import-keys ref", 180);
     assert_script_run("zypper --non-interactive -n in qa_lib_virtauto",      1800);
+    #install guestfs-tools, which provides additional vm administration utilities
+    assert_script_run("zypper --non-interactive -n in guestfs-tools", 1800);
 
     if (get_var("PROXY_MODE")) {
         if (get_var("XEN")) {


### PR DESCRIPTION
Additional vm administration utility, for example, virt-cat is currently being used in qa_lib_virtauto. It is not installed by default. Package guestfs-tools provide such functionality.


- Related ticket: https://openqa.suse.de/tests/2374715#step/1_Guest_Upgrade_Test/1
- Needles: n/a
- Verification run: no need

@alice-suse @guoxuguang @Julie-CAO 

Please review asap. Hope this can be merged into master soon.
