### PR TITLE
xfstests: Add marks into serial0.txt to debug crash issue

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -263,6 +263,7 @@ sub run {
 
         # Run test and wait for it to finish
         my ($category, $num) = split(/\//, $test);
+        type_string("echo $test > /dev/$serialdev\n");
         test_run($test);
         my ($type, $status, $time) = test_wait($MAX_TIME);
         if ($type eq $HB_DONE) {


### PR DESCRIPTION
Simple change to tag test name as marks into serial0.txt to make sure crash issue happened in which test.

- Verification run: http://10.67.133.102/tests/756