### PR TITLE
Add post fail y2lan restart devices

### DIFF
--- a/tests/x11/yast2_lan_restart_devices.pm
+++ b/tests/x11/yast2_lan_restart_devices.pm
@@ -149,8 +149,10 @@ sub run {
 }
 
 sub post_fail_hook {
+    my ($self) = @_;
     assert_script_run 'journalctl -b > /tmp/journal', 90;
     upload_logs '/tmp/journal';
+    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
We need to add post fail hook also in `yast2_lan_restart_devices` in the same that in `yast2_lan_restart` so we can collect logs here for filing a bug for: https://openqa.suse.de/tests/2376533#step/yast2_lan_restart_devices/27 