### PR TITLE
Fix snapper_nodbus_restore console reset

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -61,7 +61,7 @@ sub snapper_nodbus_restore {
         script_run('systemctl default', 0);
         my $tty = get_root_console_tty;
         assert_screen "tty$tty-selected";
-        console('root-console')->reset;
+        reset_consoles;
         select_console 'root-console';
     }
     else {


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/46061
Verification: http://artemis.suse.de/tests/1084