### PR TITLE
Add procps test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1547,6 +1547,7 @@ sub load_extra_tests_console {
     loadtest "sysauth/sssd" if get_var('SYSAUTHTEST');
     loadtest "console/dracut";
     loadtest 'console/timezone';
+    loadtest 'console/procps';
 }
 
 sub load_extra_tests_docker {

--- a/tests/console/procps.pm
+++ b/tests/console/procps.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test procps installation and verify that its tools work as exepected
+# Maintainer: Paolo Stivanin <pstivanin@suse.com>
+
+use base 'opensusebasetest';
+use testapi;
+use utils;
+use strict;
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    zypper_call('in procps');
+
+    assert_script_run("rpm -q procps");
+
+    validate_script_output("free",    sub { m/total\s+used\s+free.*\nMem:\s+\d+\s+\d+\s+\d+.*(\n.*)+/ });
+    validate_script_output("pgrep 1", sub { m/\d+/ });
+    validate_script_output("pmap 1",  sub { m/1:\s+(.*systemd|init)/ });
+    validate_script_output("pwdx 1",  sub { m/1:\s+\// });
+    validate_script_output("vmstat",  sub { m/(procs\s-+memory-+\s-+swap-+\s-+io-+\s-+system-+\s-+cpu-+)\n.*\n(\s+|\d+)+/ });
+    validate_script_output("w", sub { m/\d+:\d+:\d+\sup\s+(\d+|:)+(\s\w+|),\s+\d\s\w+,\s+load average:.*\nUSER\s+TTY\s+FROM\s+LOGIN@\s+IDLE\s+JCPU\s+PCPU\s+WHAT(\n.*)+/ });
+    validate_script_output("sysctl kernel.random", sub { m/kernel\.random\.\w+\s=\s((\d+|\w+)|-)+/ });
+    validate_script_output("ps -p 1",              sub { m/PID\sTTY\s+TIME\sCMD\n\s+1\s\?\s+\d+:\d+:\d+\s(systemd|init)/ });
+    validate_script_output("top -b -n 1", sub { m/top - \d+:\d+:\d+ up\s+((\d+:\d+)|(\d+ \w+)),\s+\d+ \w+,\s+load average: \d+.\d+, \d+.\d+, \d+.\d+\nTasks: \d+ total,\s+\d+ running, \d+ sleeping(.*|\n)+/ });
+}
+
+1;
+


### PR DESCRIPTION
Description:
- install procps
- verify that procps is installed
- check that `free` works as expected
- check that `pgrep` works as expected
- check that `pmap` works as expected
- check that `pwdx` works as expected
- check that `vmstat` works as expected
- check that `w` works as expected
- check that `sysctl` works as expected
- check that `ps` works as expected
- check that `top` works as expected

- Related ticket: https://progress.opensuse.org/issues/46091
- Verification run:
  - http://d502.qam.suse.de/tests/242
  - http://d502.qam.suse.de/tests/241