### PR TITLE
Wait for DH param generation

### DIFF
--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -48,8 +48,8 @@ sub run() {
     # }
     assert_script_run "sed -i -e '/unix_listener .*postfix.* {/,/}/ s/#//g' /etc/dovecot/conf.d/10-master.conf";
 
-    # Generate SSL DH parameters
-    assert_script_run "openssl dhparam -out /etc/dovecot/dh.pem 2048", 300;
+    # Generate SSL DH parameters for Dovecot >=2.3
+    assert_script_run("openssl dhparam -out /etc/dovecot/dh.pem 2048", 300) unless is_sle('<15');
 
     # Generate default certificate for dovecot and postfix
     my $dovecot_path = is_jeos() ? '/usr/share/dovecot' : '/usr/share/doc/packages/dovecot';
@@ -67,6 +67,9 @@ sub run() {
     # start/restart services
     systemctl 'start dovecot';
     systemctl 'restart postfix';
+
+    # DH parameters are generated after start in Dovecot < 2.2.7
+    assert_script_run("( journalctl -f -u dovecot.service & ) | grep -q 'ssl-params: SSL parameters regeneration completed'", 300) if is_sle('<15');
 
     # create test users
     assert_script_run "useradd -m admin";


### PR DESCRIPTION
Dovecot in SLE12 does not support openssl generated dh parameters. Parameters are generated after start.

- Related ticket: https://progress.opensuse.org/issues/46271
- Verification run: http://panigale.suse.cz/tests/1288
