### PR TITLE
Fix needle order in dconf for confirmation dialog

### DIFF
--- a/tests/x11/gnomecase/application_starts_on_login.pm
+++ b/tests/x11/gnomecase/application_starts_on_login.pm
@@ -50,13 +50,9 @@ sub start_dconf {
         send_key "ret";
     }
 
-    # dconf-editor can show the notice to be careful after the main window
-    # popped up so we have to wait for it to settle down
-    assert_screen([qw(dconf-editor will-be-careful)]);
-    if (match_has_tag('will-be-careful')) {
-        assert_and_click 'will-be-careful';
-        assert_screen 'dconf-editor';
-    }
+    # dconf-editor always show the notice to be careful after the main window
+    assert_and_click 'will-be-careful';
+    assert_screen 'dconf-editor';
 }
 
 sub alter_status_auto_save_session {


### PR DESCRIPTION
Fix poo#45869: Confirmation dialog is not sometimes matched after dconf
start. The multiple needle match is not correct and sometimes is dconf
needle matched before confirmation needle. Needle match was changed
to always match confirmation needle before dconf needle.

- Related ticket: https://progress.opensuse.org/issues/45869
- Needles: none
- Verification run: 
SLE12-SP3: http://10.100.12.105/tests/1397#step/application_starts_on_login/131
SLE12-SP4: http://10.100.12.105/tests/1395#step/application_starts_on_login/131
SLE15: http://10.100.12.105/tests/1396#step/application_starts_on_login/1
Tumbleweed: http://10.100.12.105/tests/1398#step/application_starts_on_login/1

SLE15 and Tumbleweed dont't use dconf in application_starts_on_login, but they are included as they use that module.