### PR TITLE
Improve clone test

### DIFF
--- a/tests/autoyast/clone.pm
+++ b/tests/autoyast/clone.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 SUSE Linux GmbH
+# Copyright (C) 2015-2019 SUSE Linux GmbH
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,12 +24,10 @@ sub run {
     my $self = shift;
     assert_script_run 'rm -f /root/autoinst.xml';
     script_run("(yast2 --ncurses clone_system; echo yast2-clone_system-status-\$?) | tee /dev/$serialdev", 0);
-    assert_screen(['yast2_console-finished', 'autoyast2-install-accept'], 400);
-    if (match_has_tag('autoyast2-install-accept')) {
-        assert_screen 'autoyast2-install-accept';
+    if (check_screen 'autoyast2-install-accept', 10) {
         send_key 'alt-i';    # confirm package installation
     }
-    wait_serial("yast2-clone_system-status-0", 120) || die "'yast2 clone_system' exited with non-zero code";
+    wait_serial("yast2-clone_system-status-0", 400) || die "'yast2 clone_system' exited with non-zero code";
     upload_logs '/root/autoinst.xml';
 
     # original autoyast on kernel cmdline


### PR DESCRIPTION
get rid of uselless yast2_console-finished assert when wait_serial is waiting for exit value
I would install the package before clone_system, but lets use default behavior.

- Fail: https://openqa.suse.de/tests/2382983#step/clone/6
- Verification run: http://10.100.12.155/tests/10052#step/clone/4
