### PR TITLE
publiccloud: Create groups/users needed to run LTP

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -33,6 +33,7 @@ sub run {
     # Install ltp from package on remote
     $instance->run_ssh_command('sudo zypper ar ' . $ltp_repo);
     $instance->run_ssh_command('sudo zypper -q --gpg-auto-import-keys in -y ltp');
+    $instance->run_ssh_command('sudo CREATE_ENTRIES=1 /opt/ltp/IDcheck.sh');
 
     my $reset_cmd = '~/restart_instance.sh ' . get_required_var('PUBLIC_CLOUD_PROVIDER') . ' ';
     $reset_cmd .= $instance->instance_id . ' ' . $instance->public_ip;


### PR DESCRIPTION
Create needed groups/users needed to run LTP tests.
Discovered with SLE15-SP1 that "bin" group isn't available by default.
This seems to be a problem of LTP and reported
https://github.com/linux-test-project/ltp/issues/468

- Related ticket: https://progress.opensuse.org/issues/45800
- Verification run: http://cfconrad-vm.qa.suse.de/tests/3239#step/setresuid01/1
   Remaining two failed tests, are related to other issues.
