### PR TITLE
Make the Xen bare metal test compatible with SLE 15

### DIFF
--- a/data/autoyast_xen/xen-SLES11-SP4-FV32.xml
+++ b/data/autoyast_xen/xen-SLES11-SP4-FV32.xml
@@ -1,0 +1,1341 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <add-on>
+    <add_on_products config:type="list"/>
+  </add-on>
+  <bootloader>
+    <device_map config:type="list">
+      <device_map_entry>
+        <firmware>hd0</firmware>
+        <linux>/dev/hda</linux>
+      </device_map_entry>
+    </device_map>
+    <global>
+      <activate>true</activate>
+      <default>SUSE Linux Enterprise Server 11 SP4 - 3.0.101-108.84</default>
+      <generic_mbr>true</generic_mbr>
+      <gfxmenu>(hd0,1)/boot/message</gfxmenu>
+      <lines_cache_id>2</lines_cache_id>
+      <timeout config:type="integer">8</timeout>
+    </global>
+    <initrd_modules config:type="list">
+      <initrd_module>
+        <module>ata_piix</module>
+      </initrd_module>
+      <initrd_module>
+        <module>xen-vbd</module>
+      </initrd_module>
+      <initrd_module>
+        <module>ata_generic</module>
+      </initrd_module>
+      <initrd_module>
+        <module>xen-vnif</module>
+      </initrd_module>
+    </initrd_modules>
+    <loader_type>grub</loader_type>
+    <sections config:type="list">
+      <section>
+        <append>resume=/dev/hda1 splash=silent showopts</append>
+        <image>(hd0,1)/boot/vmlinuz-3.0.101-108.84-pae</image>
+        <initial>1</initial>
+        <initrd>(hd0,1)/boot/initrd-3.0.101-108.84-pae</initrd>
+        <lines_cache_id>0</lines_cache_id>
+        <name>SUSE Linux Enterprise Server 11 SP4 - 3.0.101-108.84</name>
+        <original_name>linux</original_name>
+        <root>/dev/hda2</root>
+        <type>image</type>
+      </section>
+      <section>
+        <append>showopts ide=nodma apm=off noresume nosmp maxcpus=0 edd=off powersaved=off nohz=off highres=off processor.max_cstate=1 nomodeset x11failsafe console=ttyS0</append>
+        <image>(hd0,1)/boot/vmlinuz-3.0.101-108.84-pae</image>
+        <initrd>(hd0,1)/boot/initrd-3.0.101-108.84-pae</initrd>
+        <lines_cache_id>1</lines_cache_id>
+        <name>Failsafe -- SUSE Linux Enterprise Server 11 SP4 - 3.0.101-108.84</name>
+        <original_name>failsafe</original_name>
+        <root>/dev/hda2</root>
+        <type>image</type>
+      </section>
+    </sections>
+  </bootloader>
+  <ca_mgm>
+    <CAName>YaST_Default_CA</CAName>
+    <ca_commonName>YaST Default CA (dhcp229)</ca_commonName>
+    <country>CZ</country>
+    <locality></locality>
+    <organisation></organisation>
+    <organisationUnit></organisationUnit>
+    <password>ENTER PASSWORD HERE</password>
+    <server_commonName>dhcp229.suse.cz</server_commonName>
+    <server_email>postmaster@suse.cz</server_email>
+    <state></state>
+    <takeLocalServerName config:type="boolean">false</takeLocalServerName>
+  </ca_mgm>
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <firewall>
+    <FW_ALLOW_FW_BROADCAST_DMZ>no</FW_ALLOW_FW_BROADCAST_DMZ>
+    <FW_ALLOW_FW_BROADCAST_EXT>no</FW_ALLOW_FW_BROADCAST_EXT>
+    <FW_ALLOW_FW_BROADCAST_INT>no</FW_ALLOW_FW_BROADCAST_INT>
+    <FW_CONFIGURATIONS_DMZ></FW_CONFIGURATIONS_DMZ>
+    <FW_CONFIGURATIONS_EXT></FW_CONFIGURATIONS_EXT>
+    <FW_CONFIGURATIONS_INT></FW_CONFIGURATIONS_INT>
+    <FW_DEV_DMZ></FW_DEV_DMZ>
+    <FW_DEV_EXT>any eth0</FW_DEV_EXT>
+    <FW_DEV_INT></FW_DEV_INT>
+    <FW_FORWARD_ALWAYS_INOUT_DEV></FW_FORWARD_ALWAYS_INOUT_DEV>
+    <FW_FORWARD_MASQ></FW_FORWARD_MASQ>
+    <FW_IGNORE_FW_BROADCAST_DMZ>no</FW_IGNORE_FW_BROADCAST_DMZ>
+    <FW_IGNORE_FW_BROADCAST_EXT>yes</FW_IGNORE_FW_BROADCAST_EXT>
+    <FW_IGNORE_FW_BROADCAST_INT>no</FW_IGNORE_FW_BROADCAST_INT>
+    <FW_IPSEC_TRUST>no</FW_IPSEC_TRUST>
+    <FW_LOAD_MODULES>nf_conntrack_netbios_ns</FW_LOAD_MODULES>
+    <FW_LOG_ACCEPT_ALL>no</FW_LOG_ACCEPT_ALL>
+    <FW_LOG_ACCEPT_CRIT>yes</FW_LOG_ACCEPT_CRIT>
+    <FW_LOG_DROP_ALL>no</FW_LOG_DROP_ALL>
+    <FW_LOG_DROP_CRIT>yes</FW_LOG_DROP_CRIT>
+    <FW_MASQUERADE>no</FW_MASQUERADE>
+    <FW_PROTECT_FROM_INT>no</FW_PROTECT_FROM_INT>
+    <FW_ROUTE>no</FW_ROUTE>
+    <FW_SERVICES_ACCEPT_DMZ></FW_SERVICES_ACCEPT_DMZ>
+    <FW_SERVICES_ACCEPT_EXT></FW_SERVICES_ACCEPT_EXT>
+    <FW_SERVICES_ACCEPT_INT></FW_SERVICES_ACCEPT_INT>
+    <FW_SERVICES_ACCEPT_RELATED_DMZ></FW_SERVICES_ACCEPT_RELATED_DMZ>
+    <FW_SERVICES_ACCEPT_RELATED_EXT></FW_SERVICES_ACCEPT_RELATED_EXT>
+    <FW_SERVICES_ACCEPT_RELATED_INT></FW_SERVICES_ACCEPT_RELATED_INT>
+    <FW_SERVICES_DMZ_IP></FW_SERVICES_DMZ_IP>
+    <FW_SERVICES_DMZ_RPC></FW_SERVICES_DMZ_RPC>
+    <FW_SERVICES_DMZ_TCP></FW_SERVICES_DMZ_TCP>
+    <FW_SERVICES_DMZ_UDP></FW_SERVICES_DMZ_UDP>
+    <FW_SERVICES_EXT_IP></FW_SERVICES_EXT_IP>
+    <FW_SERVICES_EXT_RPC></FW_SERVICES_EXT_RPC>
+    <FW_SERVICES_EXT_TCP></FW_SERVICES_EXT_TCP>
+    <FW_SERVICES_EXT_UDP></FW_SERVICES_EXT_UDP>
+    <FW_SERVICES_INT_IP></FW_SERVICES_INT_IP>
+    <FW_SERVICES_INT_RPC></FW_SERVICES_INT_RPC>
+    <FW_SERVICES_INT_TCP></FW_SERVICES_INT_TCP>
+    <FW_SERVICES_INT_UDP></FW_SERVICES_INT_UDP>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+  </firewall>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <mouse>
+      <id>none</id>
+    </mouse>
+    <proposals config:type="list"/>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+    <storage/>
+  </general>
+  <groups config:type="list">
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>100</gid>
+      <group_password>x</group_password>
+      <groupname>users</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>19</gid>
+      <group_password>x</group_password>
+      <groupname>floppy</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>1</gid>
+      <group_password>x</group_password>
+      <groupname>bin</groupname>
+      <userlist>daemon</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>41</gid>
+      <group_password>x</group_password>
+      <groupname>xok</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>65533</gid>
+      <group_password>x</group_password>
+      <groupname>nobody</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>43</gid>
+      <group_password>x</group_password>
+      <groupname>modem</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>5</gid>
+      <group_password>x</group_password>
+      <groupname>tty</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>7</gid>
+      <group_password>x</group_password>
+      <groupname>lp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>105</gid>
+      <group_password>!</group_password>
+      <groupname>uuidd</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>51</gid>
+      <group_password>!</group_password>
+      <groupname>postfix</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>65534</gid>
+      <group_password>x</group_password>
+      <groupname>nogroup</groupname>
+      <userlist>nobody</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>112</gid>
+      <group_password>!</group_password>
+      <groupname>winbind</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>101</gid>
+      <group_password>!</group_password>
+      <groupname>messagebus</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>59</gid>
+      <group_password>!</group_password>
+      <groupname>maildrop</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>33</gid>
+      <group_password>x</group_password>
+      <groupname>video</groupname>
+      <userlist>slemke</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>3</gid>
+      <group_password>x</group_password>
+      <groupname>sys</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>15</gid>
+      <group_password>x</group_password>
+      <groupname>shadow</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>20</gid>
+      <group_password>x</group_password>
+      <groupname>cdrom</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>21</gid>
+      <group_password>x</group_password>
+      <groupname>console</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>42</gid>
+      <group_password>x</group_password>
+      <groupname>trusted</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>102</gid>
+      <group_password>!</group_password>
+      <groupname>haldaemon</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>106</gid>
+      <group_password>!</group_password>
+      <groupname>puppet</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>16</gid>
+      <group_password>x</group_password>
+      <groupname>dialout</groupname>
+      <userlist>slemke</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>107</gid>
+      <group_password>!</group_password>
+      <groupname>polkituser</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>10</gid>
+      <group_password>x</group_password>
+      <groupname>wheel</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>109</gid>
+      <group_password>!</group_password>
+      <groupname>pulse</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>8</gid>
+      <group_password>x</group_password>
+      <groupname>www</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>40</gid>
+      <group_password>x</group_password>
+      <groupname>games</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>6</gid>
+      <group_password>x</group_password>
+      <groupname>disk</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>17</gid>
+      <group_password>x</group_password>
+      <groupname>audio</groupname>
+      <userlist>pulse</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>49</gid>
+      <group_password>x</group_password>
+      <groupname>ftp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>111</gid>
+      <group_password>!</group_password>
+      <groupname>suse-ncc</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>104</gid>
+      <group_password>!</group_password>
+      <groupname>tape</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>25</gid>
+      <group_password>!</group_password>
+      <groupname>at</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>9</gid>
+      <group_password>x</group_password>
+      <groupname>kmem</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>32</gid>
+      <group_password>x</group_password>
+      <groupname>public</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>12</gid>
+      <group_password>x</group_password>
+      <groupname>mail</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>0</gid>
+      <group_password>x</group_password>
+      <groupname>root</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>2</gid>
+      <group_password>x</group_password>
+      <groupname>daemon</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>108</gid>
+      <group_password>!</group_password>
+      <groupname>ntp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>14</gid>
+      <group_password>x</group_password>
+      <groupname>uucp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>110</gid>
+      <group_password>!</group_password>
+      <groupname>pulse-access</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>62</gid>
+      <group_password>x</group_password>
+      <groupname>man</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>22</gid>
+      <group_password>x</group_password>
+      <groupname>utmp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>13</gid>
+      <group_password>x</group_password>
+      <groupname>news</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>103</gid>
+      <group_password>!</group_password>
+      <groupname>sshd</groupname>
+      <userlist></userlist>
+    </group>
+  </groups>
+  <host>
+    <hosts config:type="list">
+      <hosts_entry>
+        <host_address>127.0.0.1</host_address>
+        <names config:type="list">
+          <name>localhost</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>::1</host_address>
+        <names config:type="list">
+          <name>localhost ipv6-localhost ipv6-loopback</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>fe00::0</host_address>
+        <names config:type="list">
+          <name>ipv6-localnet</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff00::0</host_address>
+        <names config:type="list">
+          <name>ipv6-mcastprefix</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::1</host_address>
+        <names config:type="list">
+          <name>ipv6-allnodes</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::2</host_address>
+        <names config:type="list">
+          <name>ipv6-allrouters</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::3</host_address>
+        <names config:type="list">
+          <name>ipv6-allhosts</name>
+        </names>
+      </hosts_entry>
+    </hosts>
+  </host>
+  <kdump>
+    <add_crash_kernel config:type="boolean">false</add_crash_kernel>
+    <crash_kernel>256M-:128M</crash_kernel>
+    <general>
+      <KDUMPTOOL_FLAGS></KDUMPTOOL_FLAGS>
+      <KDUMP_COMMANDLINE></KDUMP_COMMANDLINE>
+      <KDUMP_COMMANDLINE_APPEND></KDUMP_COMMANDLINE_APPEND>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_CPUS>1</KDUMP_CPUS>
+      <KDUMP_DUMPFORMAT>compressed</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_HOST_KEY></KDUMP_HOST_KEY>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>5</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_KERNELVER></KDUMP_KERNELVER>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NOTIFICATION_CC></KDUMP_NOTIFICATION_CC>
+      <KDUMP_NOTIFICATION_TO></KDUMP_NOTIFICATION_TO>
+      <KDUMP_POSTSCRIPT></KDUMP_POSTSCRIPT>
+      <KDUMP_PRESCRIPT></KDUMP_PRESCRIPT>
+      <KDUMP_REQUIRED_PROGRAMS></KDUMP_REQUIRED_PROGRAMS>
+      <KDUMP_SAVEDIR>file:///var/crash</KDUMP_SAVEDIR>
+      <KDUMP_SMTP_PASSWORD></KDUMP_SMTP_PASSWORD>
+      <KDUMP_SMTP_SERVER></KDUMP_SMTP_SERVER>
+      <KDUMP_SMTP_USER></KDUMP_SMTP_USER>
+      <KDUMP_TRANSFER></KDUMP_TRANSFER>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+      <KEXEC_OPTIONS></KEXEC_OPTIONS>
+    </general>
+  </kdump>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages>en_US</languages>
+  </language>
+  <ldap>
+    <base_config_dn></base_config_dn>
+    <bind_dn></bind_dn>
+    <create_ldap config:type="boolean">false</create_ldap>
+    <file_server config:type="boolean">false</file_server>
+    <ldap_domain>dc=suse,dc=cz</ldap_domain>
+    <ldap_server>ldap.suse.cz</ldap_server>
+    <ldap_tls config:type="boolean">true</ldap_tls>
+    <ldap_v2 config:type="boolean">false</ldap_v2>
+    <login_enabled config:type="boolean">true</login_enabled>
+    <member_attribute>member</member_attribute>
+    <mkhomedir config:type="boolean">false</mkhomedir>
+    <pam_password>exop</pam_password>
+    <sssd config:type="boolean">false</sssd>
+    <sssd_with_krb config:type="boolean">false</sssd_with_krb>
+    <start_autofs config:type="boolean">false</start_autofs>
+    <start_ldap config:type="boolean">false</start_ldap>
+  </ldap>
+  <login_settings/>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id></dhclient_client_id>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>suse.cz</domain>
+      <hostname>dhcp229</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <searchlist config:type="list">
+        <search>suse.cz</search>
+      </searchlist>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp4</bootproto>
+        <device>eth0</device>
+        <name>Virtual Ethernet Card 0</name>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <aliases>
+          <alias2>
+            <IPADDR>127.0.0.2</IPADDR>
+            <NETMASK>255.0.0.0</NETMASK>
+            <PREFIXLEN>8</PREFIXLEN>
+          </alias2>
+          <alias_>
+            <IPADDR>127.0.0.2</IPADDR>
+            <NETMASK>255.0.0.0</NETMASK>
+            <PREFIXLEN>8</PREFIXLEN>
+          </alias_>
+        </aliases>
+        <broadcast>127.255.255.255</broadcast>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>auto</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>ATTR{address}</rule>
+        <value>00:16:3e:e7:d2:a3</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ip_forward config:type="boolean">false</ip_forward>
+    </routing>
+  </networking>
+  <nis>
+    <netconfig_policy>auto</netconfig_policy>
+    <nis_broadcast config:type="boolean">false</nis_broadcast>
+    <nis_broken_server config:type="boolean">false</nis_broken_server>
+    <nis_domain></nis_domain>
+    <nis_local_only config:type="boolean">false</nis_local_only>
+    <nis_options></nis_options>
+    <nis_other_domains config:type="list"/>
+    <nis_servers config:type="list"/>
+    <slp_domain/>
+    <start_autofs config:type="boolean">false</start_autofs>
+    <start_nis config:type="boolean">false</start_nis>
+  </nis>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list">
+      <peer>
+        <address>127.127.1.0</address>
+        <comment>################################################################################
+## /etc/ntp.conf
+##
+## Sample NTP configuration file.
+## See package 'ntp-doc' for documentation, Mini-HOWTO and FAQ.
+## Copyright (c) 1998 S.u.S.E. GmbH Fuerth, Germany.
+##
+## Author: Michael Andres,  &lt;ma@suse.de&gt;
+##         Michael Skibbe,  &lt;mskibbe@suse.de&gt;
+##
+################################################################################
+
+##
+## Radio and modem clocks by convention have addresses in the 
+## form 127.127.t.u, where t is the clock type and u is a unit 
+## number in the range 0-3. 
+##
+## Most of these clocks require support in the form of a 
+## serial port or special bus peripheral. The particular  
+## device is normally specified by adding a soft link 
+## /dev/device-u to the particular hardware device involved, 
+## where u correspond to the unit number above. 
+## 
+## Generic DCF77 clock on serial port (Conrad DCF77)
+## Address:     127.127.8.u
+## Serial Port: /dev/refclock-u
+##  
+## (create soft link /dev/refclock-0 to the particular ttyS?)
+##
+# server 127.127.8.0 mode 5 prefer
+
+##
+## Undisciplined Local Clock. This is a fake driver intended for backup
+## and when no outside source of synchronized time is available.
+##
+</comment>
+        <fudge_comment># local clock (LCL)
+</fudge_comment>
+        <fudge_options> stratum 10</fudge_options>
+        <options></options>
+        <type>__clock</type>
+      </peer>
+      <peer>
+        <address>mode7 </address>
+        <comment>
+# Allow ntpdc to stay backwards compatible with SLE-11 before SP4.
+</comment>
+        <options></options>
+        <type>enable</type>
+      </peer>
+      <peer>
+        <address>/var/lib/ntp/drift/ntp.drift  </address>
+        <comment>
+# Clients from this (example!) subnet have unlimited access, but only if
+# cryptographically authenticated.
+#restrict 192.168.123.0 mask 255.255.255.0 notrust
+
+##
+## Miscellaneous stuff
+##
+
+</comment>
+        <options></options>
+        <type>driftfile</type>
+      </peer>
+      <peer>
+        <address>/var/log/ntp		 </address>
+        <comment># path for drift file
+
+</comment>
+        <options></options>
+        <type>logfile</type>
+      </peer>
+      <peer>
+        <address>/etc/ntp.keys		 </address>
+        <comment># alternate log file
+# logconfig =syncstatus + sysevents
+# logconfig =all
+
+# statsdir /tmp/		# directory for statistics files
+# filegen peerstats  file peerstats  type day enable
+# filegen loopstats  file loopstats  type day enable
+# filegen clockstats file clockstats type day enable
+
+#
+# Authentication stuff
+#
+</comment>
+        <options></options>
+        <type>keys</type>
+      </peer>
+      <peer>
+        <address>1			 </address>
+        <comment># path for keys file
+</comment>
+        <options></options>
+        <type>trustedkey</type>
+      </peer>
+      <peer>
+        <address>1			 </address>
+        <comment># define trusted keys
+</comment>
+        <options></options>
+        <type>requestkey</type>
+      </peer>
+      <peer>
+        <address>1                    </address>
+        <comment># key (7) for accessing server variables
+# controlkey 15			# key (6) for accessing server variables
+#
+</comment>
+        <options></options>
+        <type>controlkey</type>
+      </peer>
+    </peers>
+    <start_at_boot config:type="boolean">false</start_at_boot>
+    <start_in_chroot config:type="boolean">false</start_in_chroot>
+  </ntp-client>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/hda</device>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>swap</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>1553104384</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">ext3</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>acl,user_xattr</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>6711787520</size>
+        </partition>
+      </partitions>
+      <pesize></pesize>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <printer>
+    <cups_remote_server/>
+    <server_settings/>
+  </printer>
+  <proxy>
+    <enabled config:type="boolean">false</enabled>
+    <ftp_proxy></ftp_proxy>
+    <http_proxy></http_proxy>
+    <https_proxy></https_proxy>
+    <no_proxy></no_proxy>
+    <proxy_password></proxy_password>
+    <proxy_user></proxy_user>
+  </proxy>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <runlevel>
+    <default>5</default>
+  </runlevel>
+  <software>
+    <packages config:type="list">
+      <package>desktop-translations</package>
+      <package>gconf2-branding-SLES</package>
+      <package>gstreamer-0_10-plugins-base</package>
+      <package>gstreamer-0_10-plugins-base-lang</package>
+      <package>libcdda_interface0</package>
+      <package>libcdda_paranoia0</package>
+      <package>libgstapp-0_10-0</package>
+      <package>libgstinterfaces-0_10-0</package>
+      <package>liborc-0_4-0</package>
+      <package>libproxy0-config-gnome</package>
+      <package>libtheora0</package>
+      <package>libvisual</package>
+      <package>sles-manuals_en</package>
+      <package>xen-kmp-pae</package>
+      <package>xorg-x11-driver-video-radeonhd</package>
+      <package>yast2-trans-en_US</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>Minimal</pattern>
+      <pattern>base</pattern>
+      <pattern>jeos</pattern>
+      <pattern>laptop</pattern>
+      <pattern>x11</pattern>
+    </patterns>
+    <remove-packages config:type="list">
+      <package>libqt4-sql-sqlite</package>
+      <package>lprng</package>
+      <package>pcmciautils</package>
+      <package>sendmail</package>
+      <package>susehelp_de</package>
+      <package>yast2-control-center-qt</package>
+    </remove-packages>
+  </software>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Prague</timezone>
+  </timezone>
+  <user_defaults>
+    <expire></expire>
+    <group>100</group>
+    <groups>video,dialout</groups>
+    <home>/home</home>
+    <inactive>-1</inactive>
+    <shell>/bin/bash</shell>
+    <skel>/etc/skel</skel>
+    <umask>022</umask>
+  </user_defaults>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>slemke</fullname>
+      <gid>100</gid>
+      <home>/home/slemke</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>$2y$05$UjsX7s5xUq8iH2eo4NGJ6.n/0pcQNZtKoRvEdQlCvdCayMC37PkHq</user_password>
+      <username>slemke</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Games account</fullname>
+      <gid>100</gid>
+      <home>/var/games</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>12</uid>
+      <user_password>*</user_password>
+      <username>games</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>bin</fullname>
+      <gid>1</gid>
+      <home>/bin</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1</uid>
+      <user_password>*</user_password>
+      <username>bin</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>nobody</fullname>
+      <gid>65533</gid>
+      <home>/var/lib/nobody</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>65534</uid>
+      <user_password>*</user_password>
+      <username>nobody</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Printing daemon</fullname>
+      <gid>7</gid>
+      <home>/var/spool/lpd</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>4</uid>
+      <user_password>*</user_password>
+      <username>lp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for uuidd</fullname>
+      <gid>105</gid>
+      <home>/var/run/uuidd</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>103</uid>
+      <user_password>*</user_password>
+      <username>uuidd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Postfix Daemon</fullname>
+      <gid>51</gid>
+      <home>/var/spool/postfix</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>51</uid>
+      <user_password>*</user_password>
+      <username>postfix</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Novell Customer Center User</fullname>
+      <gid>111</gid>
+      <home>/var/lib/YaST2/suse-ncc-fakehome</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>107</uid>
+      <user_password>*</user_password>
+      <username>suse-ncc</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>FTP account</fullname>
+      <gid>49</gid>
+      <home>/srv/ftp</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>40</uid>
+      <user_password>*</user_password>
+      <username>ftp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Batch jobs daemon</fullname>
+      <gid>25</gid>
+      <home>/var/spool/atjobs</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>25</uid>
+      <user_password>*</user_password>
+      <username>at</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$2y$10$haap.Dr3FtI.mOsU3hnYre.pKUEVXl0D36viZZ4MdMnFoITc.VK7.</user_password>
+      <username>root</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Mailer daemon</fullname>
+      <gid>12</gid>
+      <home>/var/spool/clientmqueue</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>8</uid>
+      <user_password>*</user_password>
+      <username>mail</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Daemon</fullname>
+      <gid>2</gid>
+      <home>/sbin</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>2</uid>
+      <user_password>*</user_password>
+      <username>daemon</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>NTP daemon</fullname>
+      <gid>108</gid>
+      <home>/var/lib/ntp</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>74</uid>
+      <user_password>*</user_password>
+      <username>ntp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Unix-to-Unix CoPy system</fullname>
+      <gid>14</gid>
+      <home>/etc/uucp</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>10</uid>
+      <user_password>*</user_password>
+      <username>uucp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for D-Bus</fullname>
+      <gid>101</gid>
+      <home>/var/run/dbus</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max></max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>100</uid>
+      <user_password>*</user_password>
+      <username>messagebus</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for haldaemon</fullname>
+      <gid>102</gid>
+      <home>/var/run/hald</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max></max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>101</uid>
+      <user_password>*</user_password>
+      <username>haldaemon</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>WWW daemon apache</fullname>
+      <gid>8</gid>
+      <home>/var/lib/wwwrun</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>30</uid>
+      <user_password>*</user_password>
+      <username>wwwrun</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Puppet daemon</fullname>
+      <gid>106</gid>
+      <home>/var/lib/puppet</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>104</uid>
+      <user_password>*</user_password>
+      <username>puppet</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Manual pages viewer</fullname>
+      <gid>62</gid>
+      <home>/var/cache/man</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>13</uid>
+      <user_password>*</user_password>
+      <username>man</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>PolicyKit</fullname>
+      <gid>107</gid>
+      <home>/var/run/PolicyKit</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>105</uid>
+      <user_password>*</user_password>
+      <username>polkituser</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>News system</fullname>
+      <gid>13</gid>
+      <home>/etc/news</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>9</uid>
+      <user_password>*</user_password>
+      <username>news</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>SSH daemon</fullname>
+      <gid>103</gid>
+      <home>/var/lib/sshd</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>102</uid>
+      <user_password></user_password>
+      <username>sshd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>PulseAudio daemon</fullname>
+      <gid>109</gid>
+      <home>/var/lib/pulseaudio</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>106</uid>
+      <user_password>*</user_password>
+      <username>pulse</username>
+    </user>
+  </users>
+  <x11>
+    <color_depth config:type="integer">16</color_depth>
+    <display_manager>xdm</display_manager>
+    <enable_3d config:type="boolean">true</enable_3d>
+    <monitor>
+      <display>
+        <max_hsync config:type="integer">94</max_hsync>
+        <max_vsync config:type="integer">75</max_vsync>
+        <min_hsync config:type="integer">31</min_hsync>
+        <min_vsync config:type="integer">50</min_vsync>
+      </display>
+      <monitor_device>Unknown</monitor_device>
+      <monitor_vendor>Unknown</monitor_vendor>
+    </monitor>
+    <resolution>800x600 (SVGA)</resolution>
+    <window_manager>twm</window_manager>
+  </x11>
+</profile>

--- a/data/autoyast_xen/xen-SLES11-SP4-FV64.xml
+++ b/data/autoyast_xen/xen-SLES11-SP4-FV64.xml
@@ -1,0 +1,1741 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <add-on>
+    <add_on_products config:type="list"/>
+  </add-on>
+  <bootloader>
+    <device_map config:type="list">
+      <device_map_entry>
+        <firmware>hd0</firmware>
+        <linux>/dev/hda</linux>
+      </device_map_entry>
+    </device_map>
+    <global>
+      <activate>true</activate>
+      <default>SUSE Linux Enterprise Server 11 SP4 - 3.0.101-108.84</default>
+      <generic_mbr>true</generic_mbr>
+      <gfxmenu>(hd0,1)/boot/message</gfxmenu>
+      <lines_cache_id>2</lines_cache_id>
+      <timeout config:type="integer">8</timeout>
+    </global>
+    <initrd_modules config:type="list">
+      <initrd_module>
+        <module>ata_piix</module>
+      </initrd_module>
+      <initrd_module>
+        <module>xen-vbd</module>
+      </initrd_module>
+      <initrd_module>
+        <module>ata_generic</module>
+      </initrd_module>
+      <initrd_module>
+        <module>xen-vnif</module>
+      </initrd_module>
+    </initrd_modules>
+    <loader_type>grub</loader_type>
+    <sections config:type="list">
+      <section>
+        <append>resume=/dev/hda1 splash=silent console=ttyS0 showopts</append>
+        <image>(hd0,1)/boot/vmlinuz-3.0.101-108.84-default</image>
+        <initial>1</initial>
+        <initrd>(hd0,1)/boot/initrd-3.0.101-108.84-default</initrd>
+        <lines_cache_id>0</lines_cache_id>
+        <name>SUSE Linux Enterprise Server 11 SP4 - 3.0.101-108.84</name>
+        <original_name>linux</original_name>
+        <root>/dev/hda2</root>
+        <type>image</type>
+      </section>
+      <section>
+        <append>showopts ide=nodma apm=off noresume edd=off powersaved=off nohz=off highres=off processor.max_cstate=1 nomodeset x11failsafe console=ttyS0</append>
+        <image>(hd0,1)/boot/vmlinuz-3.0.101-108.84-default</image>
+        <initrd>(hd0,1)/boot/initrd-3.0.101-108.84-default</initrd>
+        <lines_cache_id>1</lines_cache_id>
+        <name>Failsafe -- SUSE Linux Enterprise Server 11 SP4 - 3.0.101-108.84</name>
+        <original_name>failsafe</original_name>
+        <root>/dev/hda2</root>
+        <type>image</type>
+      </section>
+    </sections>
+  </bootloader>
+  <ca_mgm>
+    <CAName>YaST_Default_CA</CAName>
+    <ca_commonName>YaST Default CA (suse.cz)</ca_commonName>
+    <country>CZ</country>
+    <locality></locality>
+    <organisation></organisation>
+    <organisationUnit></organisationUnit>
+    <password>ENTER PASSWORD HERE</password>
+    <server_commonName>dhcp55.suse.cz</server_commonName>
+    <server_email>postmaster@suse.cz</server_email>
+    <state></state>
+    <takeLocalServerName config:type="boolean">false</takeLocalServerName>
+  </ca_mgm>
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <firewall>
+    <FW_ALLOW_FW_BROADCAST_DMZ>no</FW_ALLOW_FW_BROADCAST_DMZ>
+    <FW_ALLOW_FW_BROADCAST_EXT>no</FW_ALLOW_FW_BROADCAST_EXT>
+    <FW_ALLOW_FW_BROADCAST_INT>no</FW_ALLOW_FW_BROADCAST_INT>
+    <FW_CONFIGURATIONS_DMZ></FW_CONFIGURATIONS_DMZ>
+    <FW_CONFIGURATIONS_EXT></FW_CONFIGURATIONS_EXT>
+    <FW_CONFIGURATIONS_INT></FW_CONFIGURATIONS_INT>
+    <FW_DEV_DMZ></FW_DEV_DMZ>
+    <FW_DEV_EXT>any eth0</FW_DEV_EXT>
+    <FW_DEV_INT></FW_DEV_INT>
+    <FW_FORWARD_ALWAYS_INOUT_DEV></FW_FORWARD_ALWAYS_INOUT_DEV>
+    <FW_FORWARD_MASQ></FW_FORWARD_MASQ>
+    <FW_IGNORE_FW_BROADCAST_DMZ>no</FW_IGNORE_FW_BROADCAST_DMZ>
+    <FW_IGNORE_FW_BROADCAST_EXT>yes</FW_IGNORE_FW_BROADCAST_EXT>
+    <FW_IGNORE_FW_BROADCAST_INT>no</FW_IGNORE_FW_BROADCAST_INT>
+    <FW_IPSEC_TRUST>no</FW_IPSEC_TRUST>
+    <FW_LOAD_MODULES>nf_conntrack_netbios_ns</FW_LOAD_MODULES>
+    <FW_LOG_ACCEPT_ALL>no</FW_LOG_ACCEPT_ALL>
+    <FW_LOG_ACCEPT_CRIT>yes</FW_LOG_ACCEPT_CRIT>
+    <FW_LOG_DROP_ALL>no</FW_LOG_DROP_ALL>
+    <FW_LOG_DROP_CRIT>yes</FW_LOG_DROP_CRIT>
+    <FW_MASQUERADE>no</FW_MASQUERADE>
+    <FW_PROTECT_FROM_INT>no</FW_PROTECT_FROM_INT>
+    <FW_ROUTE>no</FW_ROUTE>
+    <FW_SERVICES_ACCEPT_DMZ></FW_SERVICES_ACCEPT_DMZ>
+    <FW_SERVICES_ACCEPT_EXT></FW_SERVICES_ACCEPT_EXT>
+    <FW_SERVICES_ACCEPT_INT></FW_SERVICES_ACCEPT_INT>
+    <FW_SERVICES_ACCEPT_RELATED_DMZ></FW_SERVICES_ACCEPT_RELATED_DMZ>
+    <FW_SERVICES_ACCEPT_RELATED_EXT></FW_SERVICES_ACCEPT_RELATED_EXT>
+    <FW_SERVICES_ACCEPT_RELATED_INT></FW_SERVICES_ACCEPT_RELATED_INT>
+    <FW_SERVICES_DMZ_IP></FW_SERVICES_DMZ_IP>
+    <FW_SERVICES_DMZ_RPC></FW_SERVICES_DMZ_RPC>
+    <FW_SERVICES_DMZ_TCP></FW_SERVICES_DMZ_TCP>
+    <FW_SERVICES_DMZ_UDP></FW_SERVICES_DMZ_UDP>
+    <FW_SERVICES_EXT_IP></FW_SERVICES_EXT_IP>
+    <FW_SERVICES_EXT_RPC></FW_SERVICES_EXT_RPC>
+    <FW_SERVICES_EXT_TCP></FW_SERVICES_EXT_TCP>
+    <FW_SERVICES_EXT_UDP></FW_SERVICES_EXT_UDP>
+    <FW_SERVICES_INT_IP></FW_SERVICES_INT_IP>
+    <FW_SERVICES_INT_RPC></FW_SERVICES_INT_RPC>
+    <FW_SERVICES_INT_TCP></FW_SERVICES_INT_TCP>
+    <FW_SERVICES_INT_UDP></FW_SERVICES_INT_UDP>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+  </firewall>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <mouse>
+      <id>none</id>
+    </mouse>
+    <proposals config:type="list"/>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+    <storage/>
+  </general>
+  <groups config:type="list">
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>100</gid>
+      <group_password>x</group_password>
+      <groupname>users</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>19</gid>
+      <group_password>x</group_password>
+      <groupname>floppy</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>1</gid>
+      <group_password>x</group_password>
+      <groupname>bin</groupname>
+      <userlist>daemon</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>41</gid>
+      <group_password>x</group_password>
+      <groupname>xok</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>65533</gid>
+      <group_password>x</group_password>
+      <groupname>nobody</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>43</gid>
+      <group_password>x</group_password>
+      <groupname>modem</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>5</gid>
+      <group_password>x</group_password>
+      <groupname>tty</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>7</gid>
+      <group_password>x</group_password>
+      <groupname>lp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>105</gid>
+      <group_password>!</group_password>
+      <groupname>uuidd</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>51</gid>
+      <group_password>!</group_password>
+      <groupname>postfix</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>113</gid>
+      <group_password>!</group_password>
+      <groupname>gdm</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>65534</gid>
+      <group_password>x</group_password>
+      <groupname>nogroup</groupname>
+      <userlist>nobody</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>114</gid>
+      <group_password>!</group_password>
+      <groupname>winbind</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>101</gid>
+      <group_password>!</group_password>
+      <groupname>messagebus</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>59</gid>
+      <group_password>!</group_password>
+      <groupname>maildrop</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>33</gid>
+      <group_password>x</group_password>
+      <groupname>video</groupname>
+      <userlist>slemke</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>3</gid>
+      <group_password>x</group_password>
+      <groupname>sys</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>15</gid>
+      <group_password>x</group_password>
+      <groupname>shadow</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>20</gid>
+      <group_password>x</group_password>
+      <groupname>cdrom</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>21</gid>
+      <group_password>x</group_password>
+      <groupname>console</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>42</gid>
+      <group_password>x</group_password>
+      <groupname>trusted</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>102</gid>
+      <group_password>!</group_password>
+      <groupname>haldaemon</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>107</gid>
+      <group_password>!</group_password>
+      <groupname>puppet</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>16</gid>
+      <group_password>x</group_password>
+      <groupname>dialout</groupname>
+      <userlist>slemke</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>108</gid>
+      <group_password>!</group_password>
+      <groupname>polkituser</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>10</gid>
+      <group_password>x</group_password>
+      <groupname>wheel</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>110</gid>
+      <group_password>!</group_password>
+      <groupname>pulse</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>8</gid>
+      <group_password>x</group_password>
+      <groupname>www</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>40</gid>
+      <group_password>x</group_password>
+      <groupname>games</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>6</gid>
+      <group_password>x</group_password>
+      <groupname>disk</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>17</gid>
+      <group_password>x</group_password>
+      <groupname>audio</groupname>
+      <userlist>pulse</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>112</gid>
+      <group_password>!</group_password>
+      <groupname>suse-ncc</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>49</gid>
+      <group_password>x</group_password>
+      <groupname>ftp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>104</gid>
+      <group_password>!</group_password>
+      <groupname>tape</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>25</gid>
+      <group_password>!</group_password>
+      <groupname>at</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>9</gid>
+      <group_password>x</group_password>
+      <groupname>kmem</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>32</gid>
+      <group_password>x</group_password>
+      <groupname>public</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>12</gid>
+      <group_password>x</group_password>
+      <groupname>mail</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>0</gid>
+      <group_password>x</group_password>
+      <groupname>root</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>2</gid>
+      <group_password>x</group_password>
+      <groupname>daemon</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>106</gid>
+      <group_password>!</group_password>
+      <groupname>sfcb</groupname>
+      <userlist>root</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>109</gid>
+      <group_password>!</group_password>
+      <groupname>ntp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>14</gid>
+      <group_password>x</group_password>
+      <groupname>uucp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>111</gid>
+      <group_password>!</group_password>
+      <groupname>pulse-access</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>71</gid>
+      <group_password>!</group_password>
+      <groupname>ntadmin</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>62</gid>
+      <group_password>x</group_password>
+      <groupname>man</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>22</gid>
+      <group_password>x</group_password>
+      <groupname>utmp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>13</gid>
+      <group_password>x</group_password>
+      <groupname>news</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>103</gid>
+      <group_password>!</group_password>
+      <groupname>sshd</groupname>
+      <userlist></userlist>
+    </group>
+  </groups>
+  <host>
+    <hosts config:type="list">
+      <hosts_entry>
+        <host_address>127.0.0.1</host_address>
+        <names config:type="list">
+          <name>localhost</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>::1</host_address>
+        <names config:type="list">
+          <name>localhost ipv6-localhost ipv6-loopback</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>fe00::0</host_address>
+        <names config:type="list">
+          <name>ipv6-localnet</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff00::0</host_address>
+        <names config:type="list">
+          <name>ipv6-mcastprefix</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::1</host_address>
+        <names config:type="list">
+          <name>ipv6-allnodes</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::2</host_address>
+        <names config:type="list">
+          <name>ipv6-allrouters</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::3</host_address>
+        <names config:type="list">
+          <name>ipv6-allhosts</name>
+        </names>
+      </hosts_entry>
+    </hosts>
+  </host>
+  <kdump>
+    <add_crash_kernel config:type="boolean">false</add_crash_kernel>
+    <crash_kernel>256M-:128M</crash_kernel>
+    <general>
+      <KDUMPTOOL_FLAGS></KDUMPTOOL_FLAGS>
+      <KDUMP_COMMANDLINE></KDUMP_COMMANDLINE>
+      <KDUMP_COMMANDLINE_APPEND></KDUMP_COMMANDLINE_APPEND>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_CPUS>1</KDUMP_CPUS>
+      <KDUMP_DUMPFORMAT>compressed</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_HOST_KEY></KDUMP_HOST_KEY>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>5</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_KERNELVER></KDUMP_KERNELVER>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NOTIFICATION_CC></KDUMP_NOTIFICATION_CC>
+      <KDUMP_NOTIFICATION_TO></KDUMP_NOTIFICATION_TO>
+      <KDUMP_POSTSCRIPT></KDUMP_POSTSCRIPT>
+      <KDUMP_PRESCRIPT></KDUMP_PRESCRIPT>
+      <KDUMP_REQUIRED_PROGRAMS></KDUMP_REQUIRED_PROGRAMS>
+      <KDUMP_SAVEDIR>file:///var/crash</KDUMP_SAVEDIR>
+      <KDUMP_SMTP_PASSWORD></KDUMP_SMTP_PASSWORD>
+      <KDUMP_SMTP_SERVER></KDUMP_SMTP_SERVER>
+      <KDUMP_SMTP_USER></KDUMP_SMTP_USER>
+      <KDUMP_TRANSFER></KDUMP_TRANSFER>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+      <KEXEC_OPTIONS></KEXEC_OPTIONS>
+    </general>
+  </kdump>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages>en_US</languages>
+  </language>
+  <ldap>
+    <base_config_dn></base_config_dn>
+    <bind_dn></bind_dn>
+    <create_ldap config:type="boolean">false</create_ldap>
+    <file_server config:type="boolean">false</file_server>
+    <ldap_domain>dc=suse,dc=cz</ldap_domain>
+    <ldap_server>ldap.suse.cz</ldap_server>
+    <ldap_tls config:type="boolean">true</ldap_tls>
+    <ldap_v2 config:type="boolean">false</ldap_v2>
+    <login_enabled config:type="boolean">true</login_enabled>
+    <member_attribute>member</member_attribute>
+    <mkhomedir config:type="boolean">false</mkhomedir>
+    <pam_password>exop</pam_password>
+    <sssd config:type="boolean">false</sssd>
+    <sssd_with_krb config:type="boolean">false</sssd_with_krb>
+    <start_autofs config:type="boolean">false</start_autofs>
+    <start_ldap config:type="boolean">false</start_ldap>
+  </ldap>
+  <login_settings/>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id></dhclient_client_id>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>suse.cz</domain>
+      <hostname>dhcp78</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <searchlist config:type="list">
+        <search>suse.cz</search>
+      </searchlist>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp4</bootproto>
+        <device>eth0</device>
+        <name>Virtual Ethernet Card 0</name>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <aliases>
+          <alias2>
+            <IPADDR>127.0.0.2</IPADDR>
+            <NETMASK>255.0.0.0</NETMASK>
+            <PREFIXLEN>8</PREFIXLEN>
+          </alias2>
+          <alias_>
+            <IPADDR>127.0.0.2</IPADDR>
+            <NETMASK>255.0.0.0</NETMASK>
+            <PREFIXLEN>8</PREFIXLEN>
+          </alias_>
+        </aliases>
+        <broadcast>127.255.255.255</broadcast>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>auto</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">false</ipv6>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>ATTR{address}</rule>
+        <value>00:16:3e:f0:6b:b9</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ip_forward config:type="boolean">false</ip_forward>
+    </routing>
+  </networking>
+  <nis>
+    <netconfig_policy>auto</netconfig_policy>
+    <nis_broadcast config:type="boolean">false</nis_broadcast>
+    <nis_broken_server config:type="boolean">false</nis_broken_server>
+    <nis_domain></nis_domain>
+    <nis_local_only config:type="boolean">false</nis_local_only>
+    <nis_options></nis_options>
+    <nis_other_domains config:type="list"/>
+    <nis_servers config:type="list"/>
+    <slp_domain/>
+    <start_autofs config:type="boolean">false</start_autofs>
+    <start_nis config:type="boolean">false</start_nis>
+  </nis>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list">
+      <peer>
+        <address>127.127.1.0</address>
+        <comment>################################################################################
+## /etc/ntp.conf
+##
+## Sample NTP configuration file.
+## See package 'ntp-doc' for documentation, Mini-HOWTO and FAQ.
+## Copyright (c) 1998 S.u.S.E. GmbH Fuerth, Germany.
+##
+## Author: Michael Andres,  &lt;ma@suse.de&gt;
+##         Michael Skibbe,  &lt;mskibbe@suse.de&gt;
+##
+################################################################################
+
+##
+## Radio and modem clocks by convention have addresses in the 
+## form 127.127.t.u, where t is the clock type and u is a unit 
+## number in the range 0-3. 
+##
+## Most of these clocks require support in the form of a 
+## serial port or special bus peripheral. The particular  
+## device is normally specified by adding a soft link 
+## /dev/device-u to the particular hardware device involved, 
+## where u correspond to the unit number above. 
+## 
+## Generic DCF77 clock on serial port (Conrad DCF77)
+## Address:     127.127.8.u
+## Serial Port: /dev/refclock-u
+##  
+## (create soft link /dev/refclock-0 to the particular ttyS?)
+##
+# server 127.127.8.0 mode 5 prefer
+
+##
+## Undisciplined Local Clock. This is a fake driver intended for backup
+## and when no outside source of synchronized time is available.
+##
+</comment>
+        <fudge_comment># local clock (LCL)
+</fudge_comment>
+        <fudge_options> stratum 10</fudge_options>
+        <options></options>
+        <type>__clock</type>
+      </peer>
+      <peer>
+        <address>mode7 </address>
+        <comment>
+# Allow ntpdc to stay backwards compatible with SLE-11 before SP4.
+</comment>
+        <options></options>
+        <type>enable</type>
+      </peer>
+      <peer>
+        <address>/var/lib/ntp/drift/ntp.drift  </address>
+        <comment>
+# Clients from this (example!) subnet have unlimited access, but only if
+# cryptographically authenticated.
+#restrict 192.168.123.0 mask 255.255.255.0 notrust
+
+##
+## Miscellaneous stuff
+##
+
+</comment>
+        <options></options>
+        <type>driftfile</type>
+      </peer>
+      <peer>
+        <address>/var/log/ntp		 </address>
+        <comment># path for drift file
+
+</comment>
+        <options></options>
+        <type>logfile</type>
+      </peer>
+      <peer>
+        <address>/etc/ntp.keys		 </address>
+        <comment># alternate log file
+# logconfig =syncstatus + sysevents
+# logconfig =all
+
+# statsdir /tmp/		# directory for statistics files
+# filegen peerstats  file peerstats  type day enable
+# filegen loopstats  file loopstats  type day enable
+# filegen clockstats file clockstats type day enable
+
+#
+# Authentication stuff
+#
+</comment>
+        <options></options>
+        <type>keys</type>
+      </peer>
+      <peer>
+        <address>1			 </address>
+        <comment># path for keys file
+</comment>
+        <options></options>
+        <type>trustedkey</type>
+      </peer>
+      <peer>
+        <address>1			 </address>
+        <comment># define trusted keys
+</comment>
+        <options></options>
+        <type>requestkey</type>
+      </peer>
+      <peer>
+        <address>1                    </address>
+        <comment># key (7) for accessing server variables
+# controlkey 15			# key (6) for accessing server variables
+#
+</comment>
+        <options></options>
+        <type>controlkey</type>
+      </peer>
+    </peers>
+    <start_at_boot config:type="boolean">false</start_at_boot>
+    <start_in_chroot config:type="boolean">false</start_in_chroot>
+  </ntp-client>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/hda</device>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>swap</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>1553104384</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">ext3</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>acl,user_xattr</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>6711787520</size>
+        </partition>
+      </partitions>
+      <pesize></pesize>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <printer>
+    <cups_remote_server/>
+    <server_settings>
+      <BrowseAllow config:type="list">
+        <listentry>all</listentry>
+      </BrowseAllow>
+      <BrowseOrder config:type="list">
+        <listentry>allow,deny</listentry>
+      </BrowseOrder>
+      <Browsing config:type="list">
+        <listentry>On</listentry>
+      </Browsing>
+      <DefaultAuthType config:type="list">
+        <listentry>Basic</listentry>
+      </DefaultAuthType>
+      <DefaultPolicy config:type="list">
+        <listentry>default</listentry>
+      </DefaultPolicy>
+      <Listen config:type="list">
+        <listentry>localhost:631</listentry>
+        <listentry>/var/run/cups/cups.sock</listentry>
+      </Listen>
+      <LogLevel config:type="list">
+        <listentry>info</listentry>
+      </LogLevel>
+      <SystemGroup config:type="list">
+        <listentry>root</listentry>
+      </SystemGroup>
+      <sections config:type="list">
+        <section>
+          <Allow config:type="list">
+            <listentry>127.0.0.2</listentry>
+          </Allow>
+          <Key>Location</Key>
+          <Order config:type="list">
+            <listentry>allow,deny</listentry>
+          </Order>
+          <Value>/</Value>
+        </section>
+        <section>
+          <Encryption config:type="list">
+            <listentry>Required</listentry>
+          </Encryption>
+          <Key>Location</Key>
+          <Order config:type="list">
+            <listentry>allow,deny</listentry>
+          </Order>
+          <Value>/admin</Value>
+        </section>
+        <section>
+          <AuthType config:type="list">
+            <listentry>Default</listentry>
+          </AuthType>
+          <Key>Location</Key>
+          <Order config:type="list">
+            <listentry>allow,deny</listentry>
+          </Order>
+          <Require config:type="list">
+            <listentry>user @SYSTEM</listentry>
+          </Require>
+          <Value>/admin/conf</Value>
+        </section>
+        <section>
+          <Key>Policy</Key>
+          <Value>default</Value>
+          <sections config:type="list">
+            <section>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @OWNER @SYSTEM</listentry>
+              </Require>
+              <Value>Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job CUPS-Move-Job</Value>
+            </section>
+            <section>
+              <AuthType config:type="list">
+                <listentry>Default</listentry>
+              </AuthType>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @SYSTEM</listentry>
+              </Require>
+              <Value>CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default</Value>
+            </section>
+            <section>
+              <AuthType config:type="list">
+                <listentry>Default</listentry>
+              </AuthType>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @SYSTEM</listentry>
+              </Require>
+              <Value>Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After CUPS-Accept-Jobs CUPS-Reject-Jobs</Value>
+            </section>
+            <section>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @OWNER @SYSTEM</listentry>
+              </Require>
+              <Value>Cancel-Job CUPS-Authenticate-Job</Value>
+            </section>
+            <section>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Value>All</Value>
+            </section>
+          </sections>
+        </section>
+        <section>
+          <Key>Policy</Key>
+          <Value>easy</Value>
+          <sections config:type="list">
+            <section>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>allow,deny</listentry>
+              </Order>
+              <Satisfy config:type="list">
+                <listentry>any</listentry>
+              </Satisfy>
+              <Value>All</Value>
+            </section>
+          </sections>
+        </section>
+        <section>
+          <Key>Policy</Key>
+          <Value>paranoid</Value>
+          <sections config:type="list">
+            <section>
+              <Allow config:type="list">
+                <listentry>from 127.0.0.0/8</listentry>
+              </Allow>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @OWNER</listentry>
+              </Require>
+              <Value>Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job CUPS-Move-Job</Value>
+            </section>
+            <section>
+              <Allow config:type="list">
+                <listentry>from 127.0.0.0/8</listentry>
+              </Allow>
+              <AuthType config:type="list">
+                <listentry>Default</listentry>
+              </AuthType>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @SYSTEM</listentry>
+              </Require>
+              <Value>CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default</Value>
+            </section>
+            <section>
+              <Allow config:type="list">
+                <listentry>from 127.0.0.0/8</listentry>
+              </Allow>
+              <AuthType config:type="list">
+                <listentry>Default</listentry>
+              </AuthType>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @SYSTEM</listentry>
+              </Require>
+              <Value>Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After CUPS-Accept-Jobs CUPS-Reject-Jobs</Value>
+            </section>
+            <section>
+              <Allow config:type="list">
+                <listentry>from 127.0.0.0/8</listentry>
+              </Allow>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @OWNER</listentry>
+              </Require>
+              <Value>Cancel-Job CUPS-Authenticate-Job</Value>
+            </section>
+            <section>
+              <Allow config:type="list">
+                <listentry>from 127.0.0.0/8</listentry>
+              </Allow>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @OWNER @SYSTEM</listentry>
+              </Require>
+              <Value>All</Value>
+            </section>
+          </sections>
+        </section>
+      </sections>
+    </server_settings>
+  </printer>
+  <proxy>
+    <enabled config:type="boolean">false</enabled>
+    <ftp_proxy></ftp_proxy>
+    <http_proxy></http_proxy>
+    <https_proxy></https_proxy>
+    <no_proxy></no_proxy>
+    <proxy_password></proxy_password>
+    <proxy_user></proxy_user>
+  </proxy>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <runlevel>
+    <default>5</default>
+  </runlevel>
+  <software>
+    <packages config:type="list">
+      <package>ConsoleKit-32bit</package>
+      <package>Mesa-32bit</package>
+      <package>PolicyKit-32bit</package>
+      <package>PolicyKit-gnome-libs-32bit</package>
+      <package>aspell-32bit</package>
+      <package>at-spi-32bit</package>
+      <package>audiofile-32bit</package>
+      <package>audit-libs-32bit</package>
+      <package>bind-libs-32bit</package>
+      <package>cpufrequtils-32bit</package>
+      <package>cracklib-32bit</package>
+      <package>cryptconfig-32bit</package>
+      <package>cyrus-sasl-32bit</package>
+      <package>cyrus-sasl-gssapi-32bit</package>
+      <package>cyrus-sasl-plain-32bit</package>
+      <package>dbus-1-32bit</package>
+      <package>dbus-1-glib-32bit</package>
+      <package>desktop-translations</package>
+      <package>device-mapper-32bit</package>
+      <package>evolution-data-server-32bit</package>
+      <package>fam-32bit</package>
+      <package>file-32bit</package>
+      <package>freeglut-32bit</package>
+      <package>freetype-32bit</package>
+      <package>fribidi-32bit</package>
+      <package>gconf2-32bit</package>
+      <package>gconf2-branding-SLES</package>
+      <package>gdbm-32bit</package>
+      <package>gettext-runtime-32bit</package>
+      <package>giflib-32bit</package>
+      <package>glibc-locale-32bit</package>
+      <package>gnome-keyring-32bit</package>
+      <package>gnome-panel-32bit</package>
+      <package>gnome-vfs2-32bit</package>
+      <package>gpm-32bit</package>
+      <package>gstreamer-0_10-plugins-base</package>
+      <package>gstreamer-0_10-plugins-base-lang</package>
+      <package>hal-32bit</package>
+      <package>hunspell-32bit</package>
+      <package>libFLAC8-32bit</package>
+      <package>libHX13-32bit</package>
+      <package>libacl-32bit</package>
+      <package>libaio-32bit</package>
+      <package>libart_lgpl-32bit</package>
+      <package>libattr-32bit</package>
+      <package>libavahi-client3-32bit</package>
+      <package>libavahi-common3-32bit</package>
+      <package>libavahi-glib1-32bit</package>
+      <package>libblkid1-32bit</package>
+      <package>libbonobo-32bit</package>
+      <package>libbonoboui-32bit</package>
+      <package>libbz2-1-32bit</package>
+      <package>libcanberra-gtk-32bit</package>
+      <package>libcanberra-gtk0-32bit</package>
+      <package>libcanberra0-32bit</package>
+      <package>libcap2-32bit</package>
+      <package>libcdda_interface0</package>
+      <package>libcdda_paranoia0</package>
+      <package>libcroco-0_6-3-32bit</package>
+      <package>libcurl4-32bit</package>
+      <package>libdb-4_5-32bit</package>
+      <package>libdrm-32bit</package>
+      <package>libesd0-32bit</package>
+      <package>libfreebl3-32bit</package>
+      <package>libgcc43-32bit</package>
+      <package>libgcc46-32bit</package>
+      <package>libgcrypt11-32bit</package>
+      <package>libglade2-32bit</package>
+      <package>libgnome-32bit</package>
+      <package>libgnome-desktop-2-11-32bit</package>
+      <package>libgnomecanvas-32bit</package>
+      <package>libgnutls26-32bit</package>
+      <package>libgpg-error0-32bit</package>
+      <package>libgsf-1-114-32bit</package>
+      <package>libgstapp-0_10-0</package>
+      <package>libgstinterfaces-0_10-0</package>
+      <package>libgstreamer-0_10-0-32bit</package>
+      <package>libgweather1-32bit</package>
+      <package>libical0-32bit</package>
+      <package>libidl-32bit</package>
+      <package>libidn-32bit</package>
+      <package>libiniparser0-32bit</package>
+      <package>liblcms1-32bit</package>
+      <package>libldap-2_4-2-32bit</package>
+      <package>libltdl7-32bit</package>
+      <package>liblzma5-32bit</package>
+      <package>libmng-32bit</package>
+      <package>libnetpbm10-32bit</package>
+      <package>libnscd-32bit</package>
+      <package>libnsssharedhelper0-32bit</package>
+      <package>libogg0-32bit</package>
+      <package>libopenct1-32bit</package>
+      <package>libopensc2-32bit</package>
+      <package>liborc-0_4-0</package>
+      <package>libpciaccess0-32bit</package>
+      <package>libproxy0-32bit</package>
+      <package>libproxy0-config-gnome</package>
+      <package>libpulse0-32bit</package>
+      <package>libpython2_6-1_0-32bit</package>
+      <package>libqt4-32bit</package>
+      <package>libqt4-qt3support-32bit</package>
+      <package>libqt4-sql-32bit</package>
+      <package>libqt4-x11-32bit</package>
+      <package>libreiserfs-32bit</package>
+      <package>librsvg-32bit</package>
+      <package>libsepol1-32bit</package>
+      <package>libsmbclient0-32bit</package>
+      <package>libsmbios2-32bit</package>
+      <package>libsndfile-32bit</package>
+      <package>libsoftokn3-32bit</package>
+      <package>libsoup-2_4-1-32bit</package>
+      <package>libsqlite3-0-32bit</package>
+      <package>libstdc++33-32bit</package>
+      <package>libstdc++43-32bit</package>
+      <package>libstdc++46-32bit</package>
+      <package>libtalloc2-32bit</package>
+      <package>libtasn1-3-32bit</package>
+      <package>libtdb1-32bit</package>
+      <package>libtevent0-32bit</package>
+      <package>libtheora0</package>
+      <package>libtool-32bit</package>
+      <package>libudev0-32bit</package>
+      <package>libvisual</package>
+      <package>libvorbis-32bit</package>
+      <package>libwbclient0-32bit</package>
+      <package>libwnck-1-22-32bit</package>
+      <package>libxcrypt-32bit</package>
+      <package>libxml2-32bit</package>
+      <package>libxslt-32bit</package>
+      <package>mozilla-nspr-32bit</package>
+      <package>mozilla-nss-32bit</package>
+      <package>mozilla-xulrunner192-32bit</package>
+      <package>nautilus-32bit</package>
+      <package>nautilus-cd-burner-32bit</package>
+      <package>opensc-32bit</package>
+      <package>openslp-32bit</package>
+      <package>opie-32bit</package>
+      <package>orbit2-32bit</package>
+      <package>pam-32bit</package>
+      <package>pam-modules-32bit</package>
+      <package>pam_mount-32bit</package>
+      <package>parted-32bit</package>
+      <package>pciutils-32bit</package>
+      <package>pcsc-lite-32bit</package>
+      <package>perl-32bit</package>
+      <package>popt-32bit</package>
+      <package>qt3-32bit</package>
+      <package>rpm-32bit</package>
+      <package>samba-32bit</package>
+      <package>samba-client-32bit</package>
+      <package>samba-winbind-32bit</package>
+      <package>sles-manuals_en</package>
+      <package>sssd-32bit</package>
+      <package>startup-notification-32bit</package>
+      <package>strace-32bit</package>
+      <package>sysfsutils-32bit</package>
+      <package>tcl-32bit</package>
+      <package>tcpd-32bit</package>
+      <package>tk-32bit</package>
+      <package>utempter-32bit</package>
+      <package>xaw3d-32bit</package>
+      <package>xen-kmp-default</package>
+      <package>xorg-x11-driver-video-radeonhd</package>
+      <package>yast2-trans-en_US</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>Minimal</pattern>
+      <pattern>base</pattern>
+      <pattern>jeos</pattern>
+      <pattern>laptop</pattern>
+      <pattern>x11</pattern>
+    </patterns>
+    <remove-packages config:type="list">
+      <package>libqt4-sql-sqlite</package>
+      <package>lprng</package>
+      <package>pcmciautils</package>
+      <package>sendmail</package>
+      <package>susehelp_de</package>
+      <package>yast2-control-center-qt</package>
+    </remove-packages>
+  </software>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Prague</timezone>
+  </timezone>
+  <user_defaults>
+    <expire></expire>
+    <group>100</group>
+    <groups>video,dialout</groups>
+    <home>/home</home>
+    <inactive>-1</inactive>
+    <shell>/bin/bash</shell>
+    <skel>/etc/skel</skel>
+    <umask>022</umask>
+  </user_defaults>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>slemke</fullname>
+      <gid>100</gid>
+      <home>/home/slemke</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>$2y$05$zmmEWH0K2bSFmnqt9LZuR.vtlzOfyCCRMYmioLCVtEIlYtQ/AbJEa</user_password>
+      <username>slemke</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Games account</fullname>
+      <gid>100</gid>
+      <home>/var/games</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>12</uid>
+      <user_password>*</user_password>
+      <username>games</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>bin</fullname>
+      <gid>1</gid>
+      <home>/bin</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1</uid>
+      <user_password>*</user_password>
+      <username>bin</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>nobody</fullname>
+      <gid>65533</gid>
+      <home>/var/lib/nobody</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>65534</uid>
+      <user_password>*</user_password>
+      <username>nobody</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Printing daemon</fullname>
+      <gid>7</gid>
+      <home>/var/spool/lpd</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>4</uid>
+      <user_password>*</user_password>
+      <username>lp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for uuidd</fullname>
+      <gid>105</gid>
+      <home>/var/run/uuidd</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>103</uid>
+      <user_password>*</user_password>
+      <username>uuidd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Postfix Daemon</fullname>
+      <gid>51</gid>
+      <home>/var/spool/postfix</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>51</uid>
+      <user_password>*</user_password>
+      <username>postfix</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Novell Customer Center User</fullname>
+      <gid>112</gid>
+      <home>/var/lib/YaST2/suse-ncc-fakehome</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>107</uid>
+      <user_password>*</user_password>
+      <username>suse-ncc</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>FTP account</fullname>
+      <gid>49</gid>
+      <home>/srv/ftp</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>40</uid>
+      <user_password>*</user_password>
+      <username>ftp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Gnome Display Manager daemon</fullname>
+      <gid>113</gid>
+      <home>/var/lib/gdm</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>108</uid>
+      <user_password>*</user_password>
+      <username>gdm</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Batch jobs daemon</fullname>
+      <gid>25</gid>
+      <home>/var/spool/atjobs</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>25</uid>
+      <user_password>*</user_password>
+      <username>at</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$2y$10$uQ9p8thJeZTyHYanz7snC.rIJKxVUKNfSqTnGgtbaq165f07q7FcG</user_password>
+      <username>root</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Mailer daemon</fullname>
+      <gid>12</gid>
+      <home>/var/spool/clientmqueue</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>8</uid>
+      <user_password>*</user_password>
+      <username>mail</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Daemon</fullname>
+      <gid>2</gid>
+      <home>/sbin</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>2</uid>
+      <user_password>*</user_password>
+      <username>daemon</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>NTP daemon</fullname>
+      <gid>109</gid>
+      <home>/var/lib/ntp</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>74</uid>
+      <user_password>*</user_password>
+      <username>ntp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Unix-to-Unix CoPy system</fullname>
+      <gid>14</gid>
+      <home>/etc/uucp</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>10</uid>
+      <user_password>*</user_password>
+      <username>uucp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for D-Bus</fullname>
+      <gid>101</gid>
+      <home>/var/run/dbus</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max></max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>100</uid>
+      <user_password>*</user_password>
+      <username>messagebus</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for haldaemon</fullname>
+      <gid>102</gid>
+      <home>/var/run/hald</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max></max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>101</uid>
+      <user_password>*</user_password>
+      <username>haldaemon</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>WWW daemon apache</fullname>
+      <gid>8</gid>
+      <home>/var/lib/wwwrun</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>30</uid>
+      <user_password>*</user_password>
+      <username>wwwrun</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Puppet daemon</fullname>
+      <gid>107</gid>
+      <home>/var/lib/puppet</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>104</uid>
+      <user_password>*</user_password>
+      <username>puppet</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Manual pages viewer</fullname>
+      <gid>62</gid>
+      <home>/var/cache/man</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>13</uid>
+      <user_password>*</user_password>
+      <username>man</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>PolicyKit</fullname>
+      <gid>108</gid>
+      <home>/var/run/PolicyKit</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>105</uid>
+      <user_password>*</user_password>
+      <username>polkituser</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>News system</fullname>
+      <gid>13</gid>
+      <home>/etc/news</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>9</uid>
+      <user_password>*</user_password>
+      <username>news</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>SSH daemon</fullname>
+      <gid>103</gid>
+      <home>/var/lib/sshd</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>102</uid>
+      <user_password></user_password>
+      <username>sshd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>PulseAudio daemon</fullname>
+      <gid>110</gid>
+      <home>/var/lib/pulseaudio</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>106</uid>
+      <user_password>*</user_password>
+      <username>pulse</username>
+    </user>
+  </users>
+  <x11>
+    <color_depth config:type="integer">16</color_depth>
+    <display_manager>gdm</display_manager>
+    <enable_3d config:type="boolean">true</enable_3d>
+    <monitor>
+      <display>
+        <max_hsync config:type="integer">94</max_hsync>
+        <max_vsync config:type="integer">75</max_vsync>
+        <min_hsync config:type="integer">31</min_hsync>
+        <min_vsync config:type="integer">50</min_vsync>
+      </display>
+      <monitor_device>Unknown</monitor_device>
+      <monitor_vendor>Unknown</monitor_vendor>
+    </monitor>
+    <resolution>800x600 (SVGA)</resolution>
+    <window_manager>gnome</window_manager>
+  </x11>
+</profile>

--- a/data/autoyast_xen/xen-SLES11-SP4-PV32.xml
+++ b/data/autoyast_xen/xen-SLES11-SP4-PV32.xml
@@ -1,0 +1,1325 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <add-on>
+    <add_on_products config:type="list"/>
+  </add-on>
+  <bootloader>
+    <device_map config:type="list">
+      <device_map_entry>
+        <firmware>hd0</firmware>
+        <linux>/dev/xvda</linux>
+      </device_map_entry>
+    </device_map>
+    <global>
+      <activate>true</activate>
+      <default>Xen -- SUSE Linux Enterprise Server 11 SP4 - 3.0.101-108.84</default>
+      <generic_mbr>true</generic_mbr>
+      <gfxmenu>(hd0,1)/boot/message</gfxmenu>
+      <lines_cache_id>1</lines_cache_id>
+      <timeout config:type="integer">8</timeout>
+    </global>
+    <initrd_modules config:type="list">
+      <initrd_module>
+        <module>xenblk</module>
+      </initrd_module>
+    </initrd_modules>
+    <loader_type>grub</loader_type>
+    <sections config:type="list">
+      <section>
+        <append>resume=/dev/xvda1 splash=silent showopts</append>
+        <image>(hd0,1)/boot/vmlinuz-3.0.101-108.84-xen</image>
+        <initial>1</initial>
+        <initrd>(hd0,1)/boot/initrd-3.0.101-108.84-xen</initrd>
+        <lines_cache_id>0</lines_cache_id>
+        <name>Xen -- SUSE Linux Enterprise Server 11 SP4 - 3.0.101-108.84</name>
+        <original_name>linux</original_name>
+        <root>/dev/xvda2</root>
+        <type>image</type>
+      </section>
+    </sections>
+  </bootloader>
+  <ca_mgm>
+    <CAName>YaST_Default_CA</CAName>
+    <ca_commonName>YaST Default CA (dhcp64)</ca_commonName>
+    <country>CZ</country>
+    <locality></locality>
+    <organisation></organisation>
+    <organisationUnit></organisationUnit>
+    <password>ENTER PASSWORD HERE</password>
+    <server_commonName>dhcp64.suse.cz</server_commonName>
+    <server_email>postmaster@suse.cz</server_email>
+    <state></state>
+    <takeLocalServerName config:type="boolean">false</takeLocalServerName>
+  </ca_mgm>
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <firewall>
+    <FW_ALLOW_FW_BROADCAST_DMZ>no</FW_ALLOW_FW_BROADCAST_DMZ>
+    <FW_ALLOW_FW_BROADCAST_EXT>no</FW_ALLOW_FW_BROADCAST_EXT>
+    <FW_ALLOW_FW_BROADCAST_INT>no</FW_ALLOW_FW_BROADCAST_INT>
+    <FW_CONFIGURATIONS_DMZ></FW_CONFIGURATIONS_DMZ>
+    <FW_CONFIGURATIONS_EXT></FW_CONFIGURATIONS_EXT>
+    <FW_CONFIGURATIONS_INT></FW_CONFIGURATIONS_INT>
+    <FW_DEV_DMZ></FW_DEV_DMZ>
+    <FW_DEV_EXT>any</FW_DEV_EXT>
+    <FW_DEV_INT></FW_DEV_INT>
+    <FW_FORWARD_ALWAYS_INOUT_DEV></FW_FORWARD_ALWAYS_INOUT_DEV>
+    <FW_FORWARD_MASQ></FW_FORWARD_MASQ>
+    <FW_IGNORE_FW_BROADCAST_DMZ>no</FW_IGNORE_FW_BROADCAST_DMZ>
+    <FW_IGNORE_FW_BROADCAST_EXT>yes</FW_IGNORE_FW_BROADCAST_EXT>
+    <FW_IGNORE_FW_BROADCAST_INT>no</FW_IGNORE_FW_BROADCAST_INT>
+    <FW_IPSEC_TRUST>no</FW_IPSEC_TRUST>
+    <FW_LOAD_MODULES>nf_conntrack_netbios_ns</FW_LOAD_MODULES>
+    <FW_LOG_ACCEPT_ALL>no</FW_LOG_ACCEPT_ALL>
+    <FW_LOG_ACCEPT_CRIT>yes</FW_LOG_ACCEPT_CRIT>
+    <FW_LOG_DROP_ALL>no</FW_LOG_DROP_ALL>
+    <FW_LOG_DROP_CRIT>yes</FW_LOG_DROP_CRIT>
+    <FW_MASQUERADE>no</FW_MASQUERADE>
+    <FW_PROTECT_FROM_INT>no</FW_PROTECT_FROM_INT>
+    <FW_ROUTE>no</FW_ROUTE>
+    <FW_SERVICES_ACCEPT_DMZ></FW_SERVICES_ACCEPT_DMZ>
+    <FW_SERVICES_ACCEPT_EXT></FW_SERVICES_ACCEPT_EXT>
+    <FW_SERVICES_ACCEPT_INT></FW_SERVICES_ACCEPT_INT>
+    <FW_SERVICES_ACCEPT_RELATED_DMZ></FW_SERVICES_ACCEPT_RELATED_DMZ>
+    <FW_SERVICES_ACCEPT_RELATED_EXT></FW_SERVICES_ACCEPT_RELATED_EXT>
+    <FW_SERVICES_ACCEPT_RELATED_INT></FW_SERVICES_ACCEPT_RELATED_INT>
+    <FW_SERVICES_DMZ_IP></FW_SERVICES_DMZ_IP>
+    <FW_SERVICES_DMZ_RPC></FW_SERVICES_DMZ_RPC>
+    <FW_SERVICES_DMZ_TCP></FW_SERVICES_DMZ_TCP>
+    <FW_SERVICES_DMZ_UDP></FW_SERVICES_DMZ_UDP>
+    <FW_SERVICES_EXT_IP></FW_SERVICES_EXT_IP>
+    <FW_SERVICES_EXT_RPC></FW_SERVICES_EXT_RPC>
+    <FW_SERVICES_EXT_TCP></FW_SERVICES_EXT_TCP>
+    <FW_SERVICES_EXT_UDP></FW_SERVICES_EXT_UDP>
+    <FW_SERVICES_INT_IP></FW_SERVICES_INT_IP>
+    <FW_SERVICES_INT_RPC></FW_SERVICES_INT_RPC>
+    <FW_SERVICES_INT_TCP></FW_SERVICES_INT_TCP>
+    <FW_SERVICES_INT_UDP></FW_SERVICES_INT_UDP>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+  </firewall>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <mouse>
+      <id>none</id>
+    </mouse>
+    <proposals config:type="list"/>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+    <storage/>
+  </general>
+  <groups config:type="list">
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>100</gid>
+      <group_password>x</group_password>
+      <groupname>users</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>19</gid>
+      <group_password>x</group_password>
+      <groupname>floppy</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>1</gid>
+      <group_password>x</group_password>
+      <groupname>bin</groupname>
+      <userlist>daemon</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>41</gid>
+      <group_password>x</group_password>
+      <groupname>xok</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>65533</gid>
+      <group_password>x</group_password>
+      <groupname>nobody</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>43</gid>
+      <group_password>x</group_password>
+      <groupname>modem</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>5</gid>
+      <group_password>x</group_password>
+      <groupname>tty</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>7</gid>
+      <group_password>x</group_password>
+      <groupname>lp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>105</gid>
+      <group_password>!</group_password>
+      <groupname>uuidd</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>51</gid>
+      <group_password>!</group_password>
+      <groupname>postfix</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>65534</gid>
+      <group_password>x</group_password>
+      <groupname>nogroup</groupname>
+      <userlist>nobody</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>112</gid>
+      <group_password>!</group_password>
+      <groupname>winbind</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>101</gid>
+      <group_password>!</group_password>
+      <groupname>messagebus</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>59</gid>
+      <group_password>!</group_password>
+      <groupname>maildrop</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>33</gid>
+      <group_password>x</group_password>
+      <groupname>video</groupname>
+      <userlist>slemke</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>3</gid>
+      <group_password>x</group_password>
+      <groupname>sys</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>15</gid>
+      <group_password>x</group_password>
+      <groupname>shadow</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>20</gid>
+      <group_password>x</group_password>
+      <groupname>cdrom</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>21</gid>
+      <group_password>x</group_password>
+      <groupname>console</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>42</gid>
+      <group_password>x</group_password>
+      <groupname>trusted</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>102</gid>
+      <group_password>!</group_password>
+      <groupname>haldaemon</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>106</gid>
+      <group_password>!</group_password>
+      <groupname>puppet</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>16</gid>
+      <group_password>x</group_password>
+      <groupname>dialout</groupname>
+      <userlist>slemke</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>107</gid>
+      <group_password>!</group_password>
+      <groupname>polkituser</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>10</gid>
+      <group_password>x</group_password>
+      <groupname>wheel</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>109</gid>
+      <group_password>!</group_password>
+      <groupname>pulse</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>8</gid>
+      <group_password>x</group_password>
+      <groupname>www</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>40</gid>
+      <group_password>x</group_password>
+      <groupname>games</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>6</gid>
+      <group_password>x</group_password>
+      <groupname>disk</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>17</gid>
+      <group_password>x</group_password>
+      <groupname>audio</groupname>
+      <userlist>pulse</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>49</gid>
+      <group_password>x</group_password>
+      <groupname>ftp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>111</gid>
+      <group_password>!</group_password>
+      <groupname>suse-ncc</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>104</gid>
+      <group_password>!</group_password>
+      <groupname>tape</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>25</gid>
+      <group_password>!</group_password>
+      <groupname>at</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>9</gid>
+      <group_password>x</group_password>
+      <groupname>kmem</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>32</gid>
+      <group_password>x</group_password>
+      <groupname>public</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>12</gid>
+      <group_password>x</group_password>
+      <groupname>mail</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>0</gid>
+      <group_password>x</group_password>
+      <groupname>root</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>2</gid>
+      <group_password>x</group_password>
+      <groupname>daemon</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>108</gid>
+      <group_password>!</group_password>
+      <groupname>ntp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>14</gid>
+      <group_password>x</group_password>
+      <groupname>uucp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>110</gid>
+      <group_password>!</group_password>
+      <groupname>pulse-access</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>62</gid>
+      <group_password>x</group_password>
+      <groupname>man</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>22</gid>
+      <group_password>x</group_password>
+      <groupname>utmp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>13</gid>
+      <group_password>x</group_password>
+      <groupname>news</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>103</gid>
+      <group_password>!</group_password>
+      <groupname>sshd</groupname>
+      <userlist></userlist>
+    </group>
+  </groups>
+  <host>
+    <hosts config:type="list">
+      <hosts_entry>
+        <host_address>127.0.0.1</host_address>
+        <names config:type="list">
+          <name>localhost</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>::1</host_address>
+        <names config:type="list">
+          <name>localhost ipv6-localhost ipv6-loopback</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>fe00::0</host_address>
+        <names config:type="list">
+          <name>ipv6-localnet</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff00::0</host_address>
+        <names config:type="list">
+          <name>ipv6-mcastprefix</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::1</host_address>
+        <names config:type="list">
+          <name>ipv6-allnodes</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::2</host_address>
+        <names config:type="list">
+          <name>ipv6-allrouters</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::3</host_address>
+        <names config:type="list">
+          <name>ipv6-allhosts</name>
+        </names>
+      </hosts_entry>
+    </hosts>
+  </host>
+  <kdump>
+    <add_crash_kernel config:type="boolean">false</add_crash_kernel>
+    <crash_kernel>256M-:128M</crash_kernel>
+    <general>
+      <KDUMPTOOL_FLAGS></KDUMPTOOL_FLAGS>
+      <KDUMP_COMMANDLINE></KDUMP_COMMANDLINE>
+      <KDUMP_COMMANDLINE_APPEND></KDUMP_COMMANDLINE_APPEND>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_CPUS>1</KDUMP_CPUS>
+      <KDUMP_DUMPFORMAT>compressed</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_HOST_KEY></KDUMP_HOST_KEY>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>5</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_KERNELVER></KDUMP_KERNELVER>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NOTIFICATION_CC></KDUMP_NOTIFICATION_CC>
+      <KDUMP_NOTIFICATION_TO></KDUMP_NOTIFICATION_TO>
+      <KDUMP_POSTSCRIPT></KDUMP_POSTSCRIPT>
+      <KDUMP_PRESCRIPT></KDUMP_PRESCRIPT>
+      <KDUMP_REQUIRED_PROGRAMS></KDUMP_REQUIRED_PROGRAMS>
+      <KDUMP_SAVEDIR>file:///var/crash</KDUMP_SAVEDIR>
+      <KDUMP_SMTP_PASSWORD></KDUMP_SMTP_PASSWORD>
+      <KDUMP_SMTP_SERVER></KDUMP_SMTP_SERVER>
+      <KDUMP_SMTP_USER></KDUMP_SMTP_USER>
+      <KDUMP_TRANSFER></KDUMP_TRANSFER>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+      <KEXEC_OPTIONS></KEXEC_OPTIONS>
+    </general>
+  </kdump>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages>en_US</languages>
+  </language>
+  <ldap>
+    <base_config_dn></base_config_dn>
+    <bind_dn></bind_dn>
+    <create_ldap config:type="boolean">false</create_ldap>
+    <file_server config:type="boolean">false</file_server>
+    <ldap_domain>dc=suse,dc=cz</ldap_domain>
+    <ldap_server>ldap.suse.cz</ldap_server>
+    <ldap_tls config:type="boolean">true</ldap_tls>
+    <ldap_v2 config:type="boolean">false</ldap_v2>
+    <login_enabled config:type="boolean">true</login_enabled>
+    <member_attribute>member</member_attribute>
+    <mkhomedir config:type="boolean">false</mkhomedir>
+    <pam_password>exop</pam_password>
+    <sssd config:type="boolean">false</sssd>
+    <sssd_with_krb config:type="boolean">false</sssd_with_krb>
+    <start_autofs config:type="boolean">false</start_autofs>
+    <start_ldap config:type="boolean">false</start_ldap>
+  </ldap>
+  <login_settings/>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id></dhclient_client_id>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>suse.cz</domain>
+      <hostname>dhcp64</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <searchlist config:type="list">
+        <search>suse.cz</search>
+      </searchlist>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp4</bootproto>
+        <device>eth0</device>
+        <name>Virtual Ethernet Card 0</name>
+        <startmode>auto</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+      <interface>
+        <aliases>
+          <alias2>
+            <IPADDR>127.0.0.2</IPADDR>
+            <NETMASK>255.0.0.0</NETMASK>
+            <PREFIXLEN>8</PREFIXLEN>
+          </alias2>
+          <alias_>
+            <IPADDR>127.0.0.2</IPADDR>
+            <NETMASK>255.0.0.0</NETMASK>
+            <PREFIXLEN>8</PREFIXLEN>
+          </alias_>
+        </aliases>
+        <broadcast>127.255.255.255</broadcast>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>auto</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>ATTR{address}</rule>
+        <value>00:16:3e:bf:fe:3d</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ip_forward config:type="boolean">false</ip_forward>
+    </routing>
+  </networking>
+  <nis>
+    <netconfig_policy>auto</netconfig_policy>
+    <nis_broadcast config:type="boolean">false</nis_broadcast>
+    <nis_broken_server config:type="boolean">false</nis_broken_server>
+    <nis_domain></nis_domain>
+    <nis_local_only config:type="boolean">false</nis_local_only>
+    <nis_options></nis_options>
+    <nis_other_domains config:type="list"/>
+    <nis_servers config:type="list"/>
+    <slp_domain/>
+    <start_autofs config:type="boolean">false</start_autofs>
+    <start_nis config:type="boolean">false</start_nis>
+  </nis>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list">
+      <peer>
+        <address>127.127.1.0</address>
+        <comment>################################################################################
+## /etc/ntp.conf
+##
+## Sample NTP configuration file.
+## See package 'ntp-doc' for documentation, Mini-HOWTO and FAQ.
+## Copyright (c) 1998 S.u.S.E. GmbH Fuerth, Germany.
+##
+## Author: Michael Andres,  &lt;ma@suse.de&gt;
+##         Michael Skibbe,  &lt;mskibbe@suse.de&gt;
+##
+################################################################################
+
+##
+## Radio and modem clocks by convention have addresses in the 
+## form 127.127.t.u, where t is the clock type and u is a unit 
+## number in the range 0-3. 
+##
+## Most of these clocks require support in the form of a 
+## serial port or special bus peripheral. The particular  
+## device is normally specified by adding a soft link 
+## /dev/device-u to the particular hardware device involved, 
+## where u correspond to the unit number above. 
+## 
+## Generic DCF77 clock on serial port (Conrad DCF77)
+## Address:     127.127.8.u
+## Serial Port: /dev/refclock-u
+##  
+## (create soft link /dev/refclock-0 to the particular ttyS?)
+##
+# server 127.127.8.0 mode 5 prefer
+
+##
+## Undisciplined Local Clock. This is a fake driver intended for backup
+## and when no outside source of synchronized time is available.
+##
+</comment>
+        <fudge_comment># local clock (LCL)
+</fudge_comment>
+        <fudge_options> stratum 10</fudge_options>
+        <options></options>
+        <type>__clock</type>
+      </peer>
+      <peer>
+        <address>mode7 </address>
+        <comment>
+# Allow ntpdc to stay backwards compatible with SLE-11 before SP4.
+</comment>
+        <options></options>
+        <type>enable</type>
+      </peer>
+      <peer>
+        <address>/var/lib/ntp/drift/ntp.drift  </address>
+        <comment>
+# Clients from this (example!) subnet have unlimited access, but only if
+# cryptographically authenticated.
+#restrict 192.168.123.0 mask 255.255.255.0 notrust
+
+##
+## Miscellaneous stuff
+##
+
+</comment>
+        <options></options>
+        <type>driftfile</type>
+      </peer>
+      <peer>
+        <address>/var/log/ntp		 </address>
+        <comment># path for drift file
+
+</comment>
+        <options></options>
+        <type>logfile</type>
+      </peer>
+      <peer>
+        <address>/etc/ntp.keys		 </address>
+        <comment># alternate log file
+# logconfig =syncstatus + sysevents
+# logconfig =all
+
+# statsdir /tmp/		# directory for statistics files
+# filegen peerstats  file peerstats  type day enable
+# filegen loopstats  file loopstats  type day enable
+# filegen clockstats file clockstats type day enable
+
+#
+# Authentication stuff
+#
+</comment>
+        <options></options>
+        <type>keys</type>
+      </peer>
+      <peer>
+        <address>1			 </address>
+        <comment># path for keys file
+</comment>
+        <options></options>
+        <type>trustedkey</type>
+      </peer>
+      <peer>
+        <address>1			 </address>
+        <comment># define trusted keys
+</comment>
+        <options></options>
+        <type>requestkey</type>
+      </peer>
+      <peer>
+        <address>1                    </address>
+        <comment># key (7) for accessing server variables
+# controlkey 15			# key (6) for accessing server variables
+#
+</comment>
+        <options></options>
+        <type>controlkey</type>
+      </peer>
+    </peers>
+    <start_at_boot config:type="boolean">false</start_at_boot>
+    <start_in_chroot config:type="boolean">false</start_in_chroot>
+  </ntp-client>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/xvda</device>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>swap</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>1726119424</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">ext3</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>acl,user_xattr</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>6711787520</size>
+        </partition>
+      </partitions>
+      <pesize></pesize>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <printer>
+    <cups_remote_server/>
+    <server_settings/>
+  </printer>
+  <proxy>
+    <enabled config:type="boolean">false</enabled>
+    <ftp_proxy></ftp_proxy>
+    <http_proxy></http_proxy>
+    <https_proxy></https_proxy>
+    <no_proxy></no_proxy>
+    <proxy_password></proxy_password>
+    <proxy_user></proxy_user>
+  </proxy>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <runlevel>
+    <default>5</default>
+  </runlevel>
+  <software>
+    <packages config:type="list">
+      <package>desktop-translations</package>
+      <package>gconf2-branding-SLES</package>
+      <package>gstreamer-0_10-plugins-base</package>
+      <package>gstreamer-0_10-plugins-base-lang</package>
+      <package>libcdda_interface0</package>
+      <package>libcdda_paranoia0</package>
+      <package>libgstapp-0_10-0</package>
+      <package>libgstinterfaces-0_10-0</package>
+      <package>liborc-0_4-0</package>
+      <package>libproxy0-config-gnome</package>
+      <package>libtheora0</package>
+      <package>libvisual</package>
+      <package>libyajl1</package>
+      <package>sles-manuals_en</package>
+      <package>xen-libs</package>
+      <package>xen-tools-domU</package>
+      <package>xorg-x11-driver-video-radeonhd</package>
+      <package>yast2-trans-en_US</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>Minimal</pattern>
+      <pattern>base</pattern>
+      <pattern>jeos</pattern>
+      <pattern>laptop</pattern>
+      <pattern>x11</pattern>
+    </patterns>
+    <remove-packages config:type="list">
+      <package>libqt4-sql-sqlite</package>
+      <package>lprng</package>
+      <package>pcmciautils</package>
+      <package>sendmail</package>
+      <package>susehelp_de</package>
+      <package>yast2-control-center-qt</package>
+    </remove-packages>
+  </software>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Prague</timezone>
+  </timezone>
+  <user_defaults>
+    <expire></expire>
+    <group>100</group>
+    <groups>video,dialout</groups>
+    <home>/home</home>
+    <inactive>-1</inactive>
+    <shell>/bin/bash</shell>
+    <skel>/etc/skel</skel>
+    <umask>022</umask>
+  </user_defaults>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>slemke</fullname>
+      <gid>100</gid>
+      <home>/home/slemke</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>$2y$05$fyZ8IF1jEWNeXjm3ZhWhEOmq55lV2YCM84UvGIYwdLqR0WLOhGEHi</user_password>
+      <username>slemke</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Games account</fullname>
+      <gid>100</gid>
+      <home>/var/games</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>12</uid>
+      <user_password>*</user_password>
+      <username>games</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>bin</fullname>
+      <gid>1</gid>
+      <home>/bin</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1</uid>
+      <user_password>*</user_password>
+      <username>bin</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>nobody</fullname>
+      <gid>65533</gid>
+      <home>/var/lib/nobody</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>65534</uid>
+      <user_password>*</user_password>
+      <username>nobody</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Printing daemon</fullname>
+      <gid>7</gid>
+      <home>/var/spool/lpd</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>4</uid>
+      <user_password>*</user_password>
+      <username>lp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for uuidd</fullname>
+      <gid>105</gid>
+      <home>/var/run/uuidd</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>103</uid>
+      <user_password>*</user_password>
+      <username>uuidd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Postfix Daemon</fullname>
+      <gid>51</gid>
+      <home>/var/spool/postfix</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>51</uid>
+      <user_password>*</user_password>
+      <username>postfix</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Novell Customer Center User</fullname>
+      <gid>111</gid>
+      <home>/var/lib/YaST2/suse-ncc-fakehome</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>107</uid>
+      <user_password>*</user_password>
+      <username>suse-ncc</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>FTP account</fullname>
+      <gid>49</gid>
+      <home>/srv/ftp</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>40</uid>
+      <user_password>*</user_password>
+      <username>ftp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Batch jobs daemon</fullname>
+      <gid>25</gid>
+      <home>/var/spool/atjobs</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>25</uid>
+      <user_password>*</user_password>
+      <username>at</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$2y$10$fzw/Koa/FYFz0tcHN1dZVuAahw6KbU11i3ivDgkJT2nODIPEzLeta</user_password>
+      <username>root</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Mailer daemon</fullname>
+      <gid>12</gid>
+      <home>/var/spool/clientmqueue</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>8</uid>
+      <user_password>*</user_password>
+      <username>mail</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Daemon</fullname>
+      <gid>2</gid>
+      <home>/sbin</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>2</uid>
+      <user_password>*</user_password>
+      <username>daemon</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>NTP daemon</fullname>
+      <gid>108</gid>
+      <home>/var/lib/ntp</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>74</uid>
+      <user_password>*</user_password>
+      <username>ntp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Unix-to-Unix CoPy system</fullname>
+      <gid>14</gid>
+      <home>/etc/uucp</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>10</uid>
+      <user_password>*</user_password>
+      <username>uucp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for D-Bus</fullname>
+      <gid>101</gid>
+      <home>/var/run/dbus</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max></max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>100</uid>
+      <user_password>*</user_password>
+      <username>messagebus</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for haldaemon</fullname>
+      <gid>102</gid>
+      <home>/var/run/hald</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max></max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>101</uid>
+      <user_password>*</user_password>
+      <username>haldaemon</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>WWW daemon apache</fullname>
+      <gid>8</gid>
+      <home>/var/lib/wwwrun</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>30</uid>
+      <user_password>*</user_password>
+      <username>wwwrun</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Puppet daemon</fullname>
+      <gid>106</gid>
+      <home>/var/lib/puppet</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>104</uid>
+      <user_password>*</user_password>
+      <username>puppet</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Manual pages viewer</fullname>
+      <gid>62</gid>
+      <home>/var/cache/man</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>13</uid>
+      <user_password>*</user_password>
+      <username>man</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>PolicyKit</fullname>
+      <gid>107</gid>
+      <home>/var/run/PolicyKit</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>105</uid>
+      <user_password>*</user_password>
+      <username>polkituser</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>News system</fullname>
+      <gid>13</gid>
+      <home>/etc/news</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>9</uid>
+      <user_password>*</user_password>
+      <username>news</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>SSH daemon</fullname>
+      <gid>103</gid>
+      <home>/var/lib/sshd</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>102</uid>
+      <user_password></user_password>
+      <username>sshd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>PulseAudio daemon</fullname>
+      <gid>109</gid>
+      <home>/var/lib/pulseaudio</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>106</uid>
+      <user_password>*</user_password>
+      <username>pulse</username>
+    </user>
+  </users>
+  <x11>
+    <color_depth config:type="integer">32</color_depth>
+    <display_manager>xdm</display_manager>
+    <enable_3d config:type="boolean">true</enable_3d>
+    <monitor>
+      <display>
+        <max_hsync config:type="integer">94</max_hsync>
+        <max_vsync config:type="integer">75</max_vsync>
+        <min_hsync config:type="integer">31</min_hsync>
+        <min_vsync config:type="integer">50</min_vsync>
+      </display>
+      <monitor_device>Unknown</monitor_device>
+      <monitor_vendor>Unknown</monitor_vendor>
+    </monitor>
+    <resolution>800x600</resolution>
+    <window_manager>twm</window_manager>
+  </x11>
+</profile>

--- a/data/autoyast_xen/xen-SLES11-SP4-PV64.xml
+++ b/data/autoyast_xen/xen-SLES11-SP4-PV64.xml
@@ -1,0 +1,1724 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <add-on>
+    <add_on_products config:type="list"/>
+  </add-on>
+  <bootloader>
+    <device_map config:type="list">
+      <device_map_entry>
+        <firmware>hd0</firmware>
+        <linux>/dev/xvda</linux>
+      </device_map_entry>
+    </device_map>
+    <global>
+      <activate>true</activate>
+      <default>Xen -- SUSE Linux Enterprise Server 11 SP4 - 3.0.101-108.84</default>
+      <generic_mbr>true</generic_mbr>
+      <gfxmenu>(hd0,1)/boot/message</gfxmenu>
+      <lines_cache_id>1</lines_cache_id>
+      <timeout config:type="integer">8</timeout>
+    </global>
+    <initrd_modules config:type="list">
+      <initrd_module>
+        <module>xenblk</module>
+      </initrd_module>
+    </initrd_modules>
+    <loader_type>grub</loader_type>
+    <sections config:type="list">
+      <section>
+        <append>console=ttyS0</append>
+        <image>(hd0,1)/boot/vmlinuz-3.0.101-108.84-xen</image>
+        <initial>1</initial>
+        <initrd>(hd0,1)/boot/initrd-3.0.101-108.84-xen</initrd>
+        <lines_cache_id>0</lines_cache_id>
+        <name>Xen -- SUSE Linux Enterprise Server 11 SP4 - 3.0.101-108.84</name>
+        <original_name>linux</original_name>
+        <root>/dev/xvda2</root>
+        <type>image</type>
+      </section>
+    </sections>
+  </bootloader>
+  <ca_mgm>
+    <CAName>YaST_Default_CA</CAName>
+    <ca_commonName>YaST Default CA (suse.cz)</ca_commonName>
+    <country>CZ</country>
+    <locality></locality>
+    <organisation></organisation>
+    <organisationUnit></organisationUnit>
+    <password>ENTER PASSWORD HERE</password>
+    <server_commonName>dhcp72.suse.cz</server_commonName>
+    <server_email>postmaster@suse.cz</server_email>
+    <state></state>
+    <takeLocalServerName config:type="boolean">false</takeLocalServerName>
+  </ca_mgm>
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <firewall>
+    <FW_ALLOW_FW_BROADCAST_DMZ>no</FW_ALLOW_FW_BROADCAST_DMZ>
+    <FW_ALLOW_FW_BROADCAST_EXT>no</FW_ALLOW_FW_BROADCAST_EXT>
+    <FW_ALLOW_FW_BROADCAST_INT>no</FW_ALLOW_FW_BROADCAST_INT>
+    <FW_CONFIGURATIONS_DMZ></FW_CONFIGURATIONS_DMZ>
+    <FW_CONFIGURATIONS_EXT>sshd</FW_CONFIGURATIONS_EXT>
+    <FW_CONFIGURATIONS_INT></FW_CONFIGURATIONS_INT>
+    <FW_DEV_DMZ></FW_DEV_DMZ>
+    <FW_DEV_EXT>any eth0</FW_DEV_EXT>
+    <FW_DEV_INT></FW_DEV_INT>
+    <FW_FORWARD_ALWAYS_INOUT_DEV></FW_FORWARD_ALWAYS_INOUT_DEV>
+    <FW_FORWARD_MASQ></FW_FORWARD_MASQ>
+    <FW_IGNORE_FW_BROADCAST_DMZ>no</FW_IGNORE_FW_BROADCAST_DMZ>
+    <FW_IGNORE_FW_BROADCAST_EXT>yes</FW_IGNORE_FW_BROADCAST_EXT>
+    <FW_IGNORE_FW_BROADCAST_INT>no</FW_IGNORE_FW_BROADCAST_INT>
+    <FW_IPSEC_TRUST>no</FW_IPSEC_TRUST>
+    <FW_LOAD_MODULES>nf_conntrack_netbios_ns</FW_LOAD_MODULES>
+    <FW_LOG_ACCEPT_ALL>no</FW_LOG_ACCEPT_ALL>
+    <FW_LOG_ACCEPT_CRIT>yes</FW_LOG_ACCEPT_CRIT>
+    <FW_LOG_DROP_ALL>no</FW_LOG_DROP_ALL>
+    <FW_LOG_DROP_CRIT>yes</FW_LOG_DROP_CRIT>
+    <FW_MASQUERADE>no</FW_MASQUERADE>
+    <FW_PROTECT_FROM_INT>no</FW_PROTECT_FROM_INT>
+    <FW_ROUTE>no</FW_ROUTE>
+    <FW_SERVICES_ACCEPT_DMZ></FW_SERVICES_ACCEPT_DMZ>
+    <FW_SERVICES_ACCEPT_EXT></FW_SERVICES_ACCEPT_EXT>
+    <FW_SERVICES_ACCEPT_INT></FW_SERVICES_ACCEPT_INT>
+    <FW_SERVICES_ACCEPT_RELATED_DMZ></FW_SERVICES_ACCEPT_RELATED_DMZ>
+    <FW_SERVICES_ACCEPT_RELATED_EXT></FW_SERVICES_ACCEPT_RELATED_EXT>
+    <FW_SERVICES_ACCEPT_RELATED_INT></FW_SERVICES_ACCEPT_RELATED_INT>
+    <FW_SERVICES_DMZ_IP></FW_SERVICES_DMZ_IP>
+    <FW_SERVICES_DMZ_RPC></FW_SERVICES_DMZ_RPC>
+    <FW_SERVICES_DMZ_TCP></FW_SERVICES_DMZ_TCP>
+    <FW_SERVICES_DMZ_UDP></FW_SERVICES_DMZ_UDP>
+    <FW_SERVICES_EXT_IP></FW_SERVICES_EXT_IP>
+    <FW_SERVICES_EXT_RPC></FW_SERVICES_EXT_RPC>
+    <FW_SERVICES_EXT_TCP></FW_SERVICES_EXT_TCP>
+    <FW_SERVICES_EXT_UDP></FW_SERVICES_EXT_UDP>
+    <FW_SERVICES_INT_IP></FW_SERVICES_INT_IP>
+    <FW_SERVICES_INT_RPC></FW_SERVICES_INT_RPC>
+    <FW_SERVICES_INT_TCP></FW_SERVICES_INT_TCP>
+    <FW_SERVICES_INT_UDP></FW_SERVICES_INT_UDP>
+    <enable_firewall config:type="boolean">false</enable_firewall>
+    <start_firewall config:type="boolean">false</start_firewall>
+  </firewall>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <mouse>
+      <id>none</id>
+    </mouse>
+    <proposals config:type="list"/>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+    <storage/>
+  </general>
+  <groups config:type="list">
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>100</gid>
+      <group_password>x</group_password>
+      <groupname>users</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>19</gid>
+      <group_password>x</group_password>
+      <groupname>floppy</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>1</gid>
+      <group_password>x</group_password>
+      <groupname>bin</groupname>
+      <userlist>daemon</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>41</gid>
+      <group_password>x</group_password>
+      <groupname>xok</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>65533</gid>
+      <group_password>x</group_password>
+      <groupname>nobody</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>43</gid>
+      <group_password>x</group_password>
+      <groupname>modem</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>5</gid>
+      <group_password>x</group_password>
+      <groupname>tty</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>7</gid>
+      <group_password>x</group_password>
+      <groupname>lp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>105</gid>
+      <group_password>!</group_password>
+      <groupname>uuidd</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>51</gid>
+      <group_password>!</group_password>
+      <groupname>postfix</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>113</gid>
+      <group_password>!</group_password>
+      <groupname>gdm</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>65534</gid>
+      <group_password>x</group_password>
+      <groupname>nogroup</groupname>
+      <userlist>nobody</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>114</gid>
+      <group_password>!</group_password>
+      <groupname>winbind</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>101</gid>
+      <group_password>!</group_password>
+      <groupname>messagebus</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>59</gid>
+      <group_password>!</group_password>
+      <groupname>maildrop</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>33</gid>
+      <group_password>x</group_password>
+      <groupname>video</groupname>
+      <userlist>slemke</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>3</gid>
+      <group_password>x</group_password>
+      <groupname>sys</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>15</gid>
+      <group_password>x</group_password>
+      <groupname>shadow</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>20</gid>
+      <group_password>x</group_password>
+      <groupname>cdrom</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>21</gid>
+      <group_password>x</group_password>
+      <groupname>console</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>42</gid>
+      <group_password>x</group_password>
+      <groupname>trusted</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>102</gid>
+      <group_password>!</group_password>
+      <groupname>haldaemon</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>107</gid>
+      <group_password>!</group_password>
+      <groupname>puppet</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>16</gid>
+      <group_password>x</group_password>
+      <groupname>dialout</groupname>
+      <userlist>slemke</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>108</gid>
+      <group_password>!</group_password>
+      <groupname>polkituser</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>10</gid>
+      <group_password>x</group_password>
+      <groupname>wheel</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>110</gid>
+      <group_password>!</group_password>
+      <groupname>pulse</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>8</gid>
+      <group_password>x</group_password>
+      <groupname>www</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>40</gid>
+      <group_password>x</group_password>
+      <groupname>games</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>6</gid>
+      <group_password>x</group_password>
+      <groupname>disk</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>17</gid>
+      <group_password>x</group_password>
+      <groupname>audio</groupname>
+      <userlist>pulse</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>112</gid>
+      <group_password>!</group_password>
+      <groupname>suse-ncc</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>49</gid>
+      <group_password>x</group_password>
+      <groupname>ftp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>104</gid>
+      <group_password>!</group_password>
+      <groupname>tape</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>25</gid>
+      <group_password>!</group_password>
+      <groupname>at</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>9</gid>
+      <group_password>x</group_password>
+      <groupname>kmem</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>32</gid>
+      <group_password>x</group_password>
+      <groupname>public</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>12</gid>
+      <group_password>x</group_password>
+      <groupname>mail</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>0</gid>
+      <group_password>x</group_password>
+      <groupname>root</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>2</gid>
+      <group_password>x</group_password>
+      <groupname>daemon</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>106</gid>
+      <group_password>!</group_password>
+      <groupname>sfcb</groupname>
+      <userlist>root</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>109</gid>
+      <group_password>!</group_password>
+      <groupname>ntp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>14</gid>
+      <group_password>x</group_password>
+      <groupname>uucp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>111</gid>
+      <group_password>!</group_password>
+      <groupname>pulse-access</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>71</gid>
+      <group_password>!</group_password>
+      <groupname>ntadmin</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>62</gid>
+      <group_password>x</group_password>
+      <groupname>man</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>22</gid>
+      <group_password>x</group_password>
+      <groupname>utmp</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>13</gid>
+      <group_password>x</group_password>
+      <groupname>news</groupname>
+      <userlist></userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>103</gid>
+      <group_password>!</group_password>
+      <groupname>sshd</groupname>
+      <userlist></userlist>
+    </group>
+  </groups>
+  <host>
+    <hosts config:type="list">
+      <hosts_entry>
+        <host_address>127.0.0.1</host_address>
+        <names config:type="list">
+          <name>localhost</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>::1</host_address>
+        <names config:type="list">
+          <name>localhost ipv6-localhost ipv6-loopback</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>fe00::0</host_address>
+        <names config:type="list">
+          <name>ipv6-localnet</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff00::0</host_address>
+        <names config:type="list">
+          <name>ipv6-mcastprefix</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::1</host_address>
+        <names config:type="list">
+          <name>ipv6-allnodes</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::2</host_address>
+        <names config:type="list">
+          <name>ipv6-allrouters</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::3</host_address>
+        <names config:type="list">
+          <name>ipv6-allhosts</name>
+        </names>
+      </hosts_entry>
+    </hosts>
+  </host>
+  <kdump>
+    <add_crash_kernel config:type="boolean">false</add_crash_kernel>
+    <crash_kernel>256M-:128M</crash_kernel>
+    <general>
+      <KDUMPTOOL_FLAGS></KDUMPTOOL_FLAGS>
+      <KDUMP_COMMANDLINE></KDUMP_COMMANDLINE>
+      <KDUMP_COMMANDLINE_APPEND></KDUMP_COMMANDLINE_APPEND>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_CPUS>1</KDUMP_CPUS>
+      <KDUMP_DUMPFORMAT>compressed</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_HOST_KEY></KDUMP_HOST_KEY>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>5</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_KERNELVER></KDUMP_KERNELVER>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NOTIFICATION_CC></KDUMP_NOTIFICATION_CC>
+      <KDUMP_NOTIFICATION_TO></KDUMP_NOTIFICATION_TO>
+      <KDUMP_POSTSCRIPT></KDUMP_POSTSCRIPT>
+      <KDUMP_PRESCRIPT></KDUMP_PRESCRIPT>
+      <KDUMP_REQUIRED_PROGRAMS></KDUMP_REQUIRED_PROGRAMS>
+      <KDUMP_SAVEDIR>file:///var/crash</KDUMP_SAVEDIR>
+      <KDUMP_SMTP_PASSWORD></KDUMP_SMTP_PASSWORD>
+      <KDUMP_SMTP_SERVER></KDUMP_SMTP_SERVER>
+      <KDUMP_SMTP_USER></KDUMP_SMTP_USER>
+      <KDUMP_TRANSFER></KDUMP_TRANSFER>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+      <KEXEC_OPTIONS></KEXEC_OPTIONS>
+    </general>
+  </kdump>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages>en_US</languages>
+  </language>
+  <ldap>
+    <base_config_dn></base_config_dn>
+    <bind_dn></bind_dn>
+    <create_ldap config:type="boolean">false</create_ldap>
+    <file_server config:type="boolean">false</file_server>
+    <ldap_domain>dc=suse,dc=cz</ldap_domain>
+    <ldap_server>ldap.suse.cz</ldap_server>
+    <ldap_tls config:type="boolean">true</ldap_tls>
+    <ldap_v2 config:type="boolean">false</ldap_v2>
+    <login_enabled config:type="boolean">true</login_enabled>
+    <member_attribute>member</member_attribute>
+    <mkhomedir config:type="boolean">false</mkhomedir>
+    <pam_password>exop</pam_password>
+    <sssd config:type="boolean">false</sssd>
+    <sssd_with_krb config:type="boolean">false</sssd_with_krb>
+    <start_autofs config:type="boolean">false</start_autofs>
+    <start_ldap config:type="boolean">false</start_ldap>
+  </ldap>
+  <login_settings/>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id></dhclient_client_id>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>suse.cz</domain>
+      <hostname>dhcp76</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <searchlist config:type="list">
+        <search>suse.cz</search>
+      </searchlist>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp4</bootproto>
+        <device>eth0</device>
+        <name>Virtual Ethernet Card 0</name>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <aliases>
+          <alias2>
+            <IPADDR>127.0.0.2</IPADDR>
+            <NETMASK>255.0.0.0</NETMASK>
+            <PREFIXLEN>8</PREFIXLEN>
+          </alias2>
+          <alias_>
+            <IPADDR>127.0.0.2</IPADDR>
+            <NETMASK>255.0.0.0</NETMASK>
+            <PREFIXLEN>8</PREFIXLEN>
+          </alias_>
+        </aliases>
+        <broadcast>127.255.255.255</broadcast>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>auto</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>ATTR{address}</rule>
+        <value>00:16:3e:06:80:8b</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ip_forward config:type="boolean">false</ip_forward>
+    </routing>
+  </networking>
+  <nis>
+    <netconfig_policy>auto</netconfig_policy>
+    <nis_broadcast config:type="boolean">false</nis_broadcast>
+    <nis_broken_server config:type="boolean">false</nis_broken_server>
+    <nis_domain></nis_domain>
+    <nis_local_only config:type="boolean">false</nis_local_only>
+    <nis_options></nis_options>
+    <nis_other_domains config:type="list"/>
+    <nis_servers config:type="list"/>
+    <slp_domain/>
+    <start_autofs config:type="boolean">false</start_autofs>
+    <start_nis config:type="boolean">false</start_nis>
+  </nis>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list">
+      <peer>
+        <address>127.127.1.0</address>
+        <comment>################################################################################
+## /etc/ntp.conf
+##
+## Sample NTP configuration file.
+## See package 'ntp-doc' for documentation, Mini-HOWTO and FAQ.
+## Copyright (c) 1998 S.u.S.E. GmbH Fuerth, Germany.
+##
+## Author: Michael Andres,  &lt;ma@suse.de&gt;
+##         Michael Skibbe,  &lt;mskibbe@suse.de&gt;
+##
+################################################################################
+
+##
+## Radio and modem clocks by convention have addresses in the 
+## form 127.127.t.u, where t is the clock type and u is a unit 
+## number in the range 0-3. 
+##
+## Most of these clocks require support in the form of a 
+## serial port or special bus peripheral. The particular  
+## device is normally specified by adding a soft link 
+## /dev/device-u to the particular hardware device involved, 
+## where u correspond to the unit number above. 
+## 
+## Generic DCF77 clock on serial port (Conrad DCF77)
+## Address:     127.127.8.u
+## Serial Port: /dev/refclock-u
+##  
+## (create soft link /dev/refclock-0 to the particular ttyS?)
+##
+# server 127.127.8.0 mode 5 prefer
+
+##
+## Undisciplined Local Clock. This is a fake driver intended for backup
+## and when no outside source of synchronized time is available.
+##
+</comment>
+        <fudge_comment># local clock (LCL)
+</fudge_comment>
+        <fudge_options> stratum 10</fudge_options>
+        <options></options>
+        <type>__clock</type>
+      </peer>
+      <peer>
+        <address>mode7 </address>
+        <comment>
+# Allow ntpdc to stay backwards compatible with SLE-11 before SP4.
+</comment>
+        <options></options>
+        <type>enable</type>
+      </peer>
+      <peer>
+        <address>/var/lib/ntp/drift/ntp.drift  </address>
+        <comment>
+# Clients from this (example!) subnet have unlimited access, but only if
+# cryptographically authenticated.
+#restrict 192.168.123.0 mask 255.255.255.0 notrust
+
+##
+## Miscellaneous stuff
+##
+
+</comment>
+        <options></options>
+        <type>driftfile</type>
+      </peer>
+      <peer>
+        <address>/var/log/ntp		 </address>
+        <comment># path for drift file
+
+</comment>
+        <options></options>
+        <type>logfile</type>
+      </peer>
+      <peer>
+        <address>/etc/ntp.keys		 </address>
+        <comment># alternate log file
+# logconfig =syncstatus + sysevents
+# logconfig =all
+
+# statsdir /tmp/		# directory for statistics files
+# filegen peerstats  file peerstats  type day enable
+# filegen loopstats  file loopstats  type day enable
+# filegen clockstats file clockstats type day enable
+
+#
+# Authentication stuff
+#
+</comment>
+        <options></options>
+        <type>keys</type>
+      </peer>
+      <peer>
+        <address>1			 </address>
+        <comment># path for keys file
+</comment>
+        <options></options>
+        <type>trustedkey</type>
+      </peer>
+      <peer>
+        <address>1			 </address>
+        <comment># define trusted keys
+</comment>
+        <options></options>
+        <type>requestkey</type>
+      </peer>
+      <peer>
+        <address>1                    </address>
+        <comment># key (7) for accessing server variables
+# controlkey 15			# key (6) for accessing server variables
+#
+</comment>
+        <options></options>
+        <type>controlkey</type>
+      </peer>
+    </peers>
+    <start_at_boot config:type="boolean">false</start_at_boot>
+    <start_in_chroot config:type="boolean">false</start_in_chroot>
+  </ntp-client>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/xvda</device>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>swap</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>1751285248</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">ext3</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>acl,user_xattr</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/</mount>
+          <mountby config:type="symbol">device</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <resize config:type="boolean">false</resize>
+          <size>6711787520</size>
+        </partition>
+      </partitions>
+      <pesize></pesize>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <printer>
+    <cups_remote_server/>
+    <server_settings>
+      <BrowseAllow config:type="list">
+        <listentry>all</listentry>
+      </BrowseAllow>
+      <BrowseOrder config:type="list">
+        <listentry>allow,deny</listentry>
+      </BrowseOrder>
+      <Browsing config:type="list">
+        <listentry>On</listentry>
+      </Browsing>
+      <DefaultAuthType config:type="list">
+        <listentry>Basic</listentry>
+      </DefaultAuthType>
+      <DefaultPolicy config:type="list">
+        <listentry>default</listentry>
+      </DefaultPolicy>
+      <Listen config:type="list">
+        <listentry>localhost:631</listentry>
+        <listentry>/var/run/cups/cups.sock</listentry>
+      </Listen>
+      <LogLevel config:type="list">
+        <listentry>info</listentry>
+      </LogLevel>
+      <SystemGroup config:type="list">
+        <listentry>root</listentry>
+      </SystemGroup>
+      <sections config:type="list">
+        <section>
+          <Allow config:type="list">
+            <listentry>127.0.0.2</listentry>
+          </Allow>
+          <Key>Location</Key>
+          <Order config:type="list">
+            <listentry>allow,deny</listentry>
+          </Order>
+          <Value>/</Value>
+        </section>
+        <section>
+          <Encryption config:type="list">
+            <listentry>Required</listentry>
+          </Encryption>
+          <Key>Location</Key>
+          <Order config:type="list">
+            <listentry>allow,deny</listentry>
+          </Order>
+          <Value>/admin</Value>
+        </section>
+        <section>
+          <AuthType config:type="list">
+            <listentry>Default</listentry>
+          </AuthType>
+          <Key>Location</Key>
+          <Order config:type="list">
+            <listentry>allow,deny</listentry>
+          </Order>
+          <Require config:type="list">
+            <listentry>user @SYSTEM</listentry>
+          </Require>
+          <Value>/admin/conf</Value>
+        </section>
+        <section>
+          <Key>Policy</Key>
+          <Value>default</Value>
+          <sections config:type="list">
+            <section>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @OWNER @SYSTEM</listentry>
+              </Require>
+              <Value>Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job CUPS-Move-Job</Value>
+            </section>
+            <section>
+              <AuthType config:type="list">
+                <listentry>Default</listentry>
+              </AuthType>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @SYSTEM</listentry>
+              </Require>
+              <Value>CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default</Value>
+            </section>
+            <section>
+              <AuthType config:type="list">
+                <listentry>Default</listentry>
+              </AuthType>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @SYSTEM</listentry>
+              </Require>
+              <Value>Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After CUPS-Accept-Jobs CUPS-Reject-Jobs</Value>
+            </section>
+            <section>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @OWNER @SYSTEM</listentry>
+              </Require>
+              <Value>Cancel-Job CUPS-Authenticate-Job</Value>
+            </section>
+            <section>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Value>All</Value>
+            </section>
+          </sections>
+        </section>
+        <section>
+          <Key>Policy</Key>
+          <Value>easy</Value>
+          <sections config:type="list">
+            <section>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>allow,deny</listentry>
+              </Order>
+              <Satisfy config:type="list">
+                <listentry>any</listentry>
+              </Satisfy>
+              <Value>All</Value>
+            </section>
+          </sections>
+        </section>
+        <section>
+          <Key>Policy</Key>
+          <Value>paranoid</Value>
+          <sections config:type="list">
+            <section>
+              <Allow config:type="list">
+                <listentry>from 127.0.0.0/8</listentry>
+              </Allow>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @OWNER</listentry>
+              </Require>
+              <Value>Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job CUPS-Move-Job</Value>
+            </section>
+            <section>
+              <Allow config:type="list">
+                <listentry>from 127.0.0.0/8</listentry>
+              </Allow>
+              <AuthType config:type="list">
+                <listentry>Default</listentry>
+              </AuthType>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @SYSTEM</listentry>
+              </Require>
+              <Value>CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default</Value>
+            </section>
+            <section>
+              <Allow config:type="list">
+                <listentry>from 127.0.0.0/8</listentry>
+              </Allow>
+              <AuthType config:type="list">
+                <listentry>Default</listentry>
+              </AuthType>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @SYSTEM</listentry>
+              </Require>
+              <Value>Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After CUPS-Accept-Jobs CUPS-Reject-Jobs</Value>
+            </section>
+            <section>
+              <Allow config:type="list">
+                <listentry>from 127.0.0.0/8</listentry>
+              </Allow>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @OWNER</listentry>
+              </Require>
+              <Value>Cancel-Job CUPS-Authenticate-Job</Value>
+            </section>
+            <section>
+              <Allow config:type="list">
+                <listentry>from 127.0.0.0/8</listentry>
+              </Allow>
+              <Key>Limit</Key>
+              <Order config:type="list">
+                <listentry>deny,allow</listentry>
+              </Order>
+              <Require config:type="list">
+                <listentry>user @OWNER @SYSTEM</listentry>
+              </Require>
+              <Value>All</Value>
+            </section>
+          </sections>
+        </section>
+      </sections>
+    </server_settings>
+  </printer>
+  <proxy>
+    <enabled config:type="boolean">false</enabled>
+    <ftp_proxy></ftp_proxy>
+    <http_proxy></http_proxy>
+    <https_proxy></https_proxy>
+    <no_proxy></no_proxy>
+    <proxy_password></proxy_password>
+    <proxy_user></proxy_user>
+  </proxy>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <runlevel>
+    <default>5</default>
+  </runlevel>
+  <software>
+    <packages config:type="list">
+      <package>ConsoleKit-32bit</package>
+      <package>Mesa-32bit</package>
+      <package>PolicyKit-32bit</package>
+      <package>PolicyKit-gnome-libs-32bit</package>
+      <package>aspell-32bit</package>
+      <package>at-spi-32bit</package>
+      <package>audiofile-32bit</package>
+      <package>audit-libs-32bit</package>
+      <package>bind-libs-32bit</package>
+      <package>cpufrequtils-32bit</package>
+      <package>cracklib-32bit</package>
+      <package>cryptconfig-32bit</package>
+      <package>cyrus-sasl-32bit</package>
+      <package>cyrus-sasl-gssapi-32bit</package>
+      <package>cyrus-sasl-plain-32bit</package>
+      <package>dbus-1-32bit</package>
+      <package>dbus-1-glib-32bit</package>
+      <package>desktop-translations</package>
+      <package>device-mapper-32bit</package>
+      <package>evolution-data-server-32bit</package>
+      <package>fam-32bit</package>
+      <package>file-32bit</package>
+      <package>freeglut-32bit</package>
+      <package>freetype-32bit</package>
+      <package>fribidi-32bit</package>
+      <package>gconf2-32bit</package>
+      <package>gconf2-branding-SLES</package>
+      <package>gdbm-32bit</package>
+      <package>gettext-runtime-32bit</package>
+      <package>giflib-32bit</package>
+      <package>glibc-locale-32bit</package>
+      <package>gnome-keyring-32bit</package>
+      <package>gnome-panel-32bit</package>
+      <package>gnome-vfs2-32bit</package>
+      <package>gpm-32bit</package>
+      <package>gstreamer-0_10-plugins-base</package>
+      <package>gstreamer-0_10-plugins-base-lang</package>
+      <package>hal-32bit</package>
+      <package>hunspell-32bit</package>
+      <package>libFLAC8-32bit</package>
+      <package>libHX13-32bit</package>
+      <package>libacl-32bit</package>
+      <package>libaio-32bit</package>
+      <package>libart_lgpl-32bit</package>
+      <package>libattr-32bit</package>
+      <package>libavahi-client3-32bit</package>
+      <package>libavahi-common3-32bit</package>
+      <package>libavahi-glib1-32bit</package>
+      <package>libblkid1-32bit</package>
+      <package>libbonobo-32bit</package>
+      <package>libbonoboui-32bit</package>
+      <package>libbz2-1-32bit</package>
+      <package>libcanberra-gtk-32bit</package>
+      <package>libcanberra-gtk0-32bit</package>
+      <package>libcanberra0-32bit</package>
+      <package>libcap2-32bit</package>
+      <package>libcdda_interface0</package>
+      <package>libcdda_paranoia0</package>
+      <package>libcroco-0_6-3-32bit</package>
+      <package>libcurl4-32bit</package>
+      <package>libdb-4_5-32bit</package>
+      <package>libdrm-32bit</package>
+      <package>libesd0-32bit</package>
+      <package>libfreebl3-32bit</package>
+      <package>libgcc43-32bit</package>
+      <package>libgcc46-32bit</package>
+      <package>libgcrypt11-32bit</package>
+      <package>libglade2-32bit</package>
+      <package>libgnome-32bit</package>
+      <package>libgnome-desktop-2-11-32bit</package>
+      <package>libgnomecanvas-32bit</package>
+      <package>libgnutls26-32bit</package>
+      <package>libgpg-error0-32bit</package>
+      <package>libgsf-1-114-32bit</package>
+      <package>libgstapp-0_10-0</package>
+      <package>libgstinterfaces-0_10-0</package>
+      <package>libgstreamer-0_10-0-32bit</package>
+      <package>libgweather1-32bit</package>
+      <package>libical0-32bit</package>
+      <package>libidl-32bit</package>
+      <package>libidn-32bit</package>
+      <package>libiniparser0-32bit</package>
+      <package>liblcms1-32bit</package>
+      <package>libldap-2_4-2-32bit</package>
+      <package>libltdl7-32bit</package>
+      <package>liblzma5-32bit</package>
+      <package>libmng-32bit</package>
+      <package>libnetpbm10-32bit</package>
+      <package>libnscd-32bit</package>
+      <package>libnsssharedhelper0-32bit</package>
+      <package>libogg0-32bit</package>
+      <package>libopenct1-32bit</package>
+      <package>libopensc2-32bit</package>
+      <package>liborc-0_4-0</package>
+      <package>libpciaccess0-32bit</package>
+      <package>libproxy0-32bit</package>
+      <package>libproxy0-config-gnome</package>
+      <package>libpulse0-32bit</package>
+      <package>libpython2_6-1_0-32bit</package>
+      <package>libqt4-32bit</package>
+      <package>libqt4-qt3support-32bit</package>
+      <package>libqt4-sql-32bit</package>
+      <package>libqt4-x11-32bit</package>
+      <package>libreiserfs-32bit</package>
+      <package>librsvg-32bit</package>
+      <package>libsepol1-32bit</package>
+      <package>libsmbclient0-32bit</package>
+      <package>libsmbios2-32bit</package>
+      <package>libsndfile-32bit</package>
+      <package>libsoftokn3-32bit</package>
+      <package>libsoup-2_4-1-32bit</package>
+      <package>libsqlite3-0-32bit</package>
+      <package>libstdc++33-32bit</package>
+      <package>libstdc++43-32bit</package>
+      <package>libstdc++46-32bit</package>
+      <package>libtalloc2-32bit</package>
+      <package>libtasn1-3-32bit</package>
+      <package>libtdb1-32bit</package>
+      <package>libtevent0-32bit</package>
+      <package>libtheora0</package>
+      <package>libtool-32bit</package>
+      <package>libudev0-32bit</package>
+      <package>libvisual</package>
+      <package>libvorbis-32bit</package>
+      <package>libwbclient0-32bit</package>
+      <package>libwnck-1-22-32bit</package>
+      <package>libxcrypt-32bit</package>
+      <package>libxml2-32bit</package>
+      <package>libxslt-32bit</package>
+      <package>libyajl1</package>
+      <package>mozilla-nspr-32bit</package>
+      <package>mozilla-nss-32bit</package>
+      <package>mozilla-xulrunner192-32bit</package>
+      <package>nautilus-32bit</package>
+      <package>nautilus-cd-burner-32bit</package>
+      <package>opensc-32bit</package>
+      <package>openslp-32bit</package>
+      <package>opie-32bit</package>
+      <package>orbit2-32bit</package>
+      <package>pam-32bit</package>
+      <package>pam-modules-32bit</package>
+      <package>pam_mount-32bit</package>
+      <package>parted-32bit</package>
+      <package>pciutils-32bit</package>
+      <package>pcsc-lite-32bit</package>
+      <package>perl-32bit</package>
+      <package>popt-32bit</package>
+      <package>qt3-32bit</package>
+      <package>rpm-32bit</package>
+      <package>samba-32bit</package>
+      <package>samba-client-32bit</package>
+      <package>samba-winbind-32bit</package>
+      <package>sles-manuals_en</package>
+      <package>sssd-32bit</package>
+      <package>startup-notification-32bit</package>
+      <package>strace-32bit</package>
+      <package>sysfsutils-32bit</package>
+      <package>tcl-32bit</package>
+      <package>tcpd-32bit</package>
+      <package>tk-32bit</package>
+      <package>utempter-32bit</package>
+      <package>xaw3d-32bit</package>
+      <package>xen-libs</package>
+      <package>xen-tools-domU</package>
+      <package>xorg-x11-driver-video-radeonhd</package>
+      <package>yast2-trans-en_US</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>Minimal</pattern>
+      <pattern>base</pattern>
+      <pattern>jeos</pattern>
+      <pattern>laptop</pattern>
+      <pattern>x11</pattern>
+    </patterns>
+    <remove-packages config:type="list">
+      <package>libqt4-sql-sqlite</package>
+      <package>lprng</package>
+      <package>pcmciautils</package>
+      <package>sendmail</package>
+      <package>susehelp_de</package>
+      <package>yast2-control-center-qt</package>
+    </remove-packages>
+  </software>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Prague</timezone>
+  </timezone>
+  <user_defaults>
+    <expire></expire>
+    <group>100</group>
+    <groups>video,dialout</groups>
+    <home>/home</home>
+    <inactive>-1</inactive>
+    <shell>/bin/bash</shell>
+    <skel>/etc/skel</skel>
+    <umask>022</umask>
+  </user_defaults>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>slemke</fullname>
+      <gid>100</gid>
+      <home>/home/slemke</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>$2y$05$C4cWBDrwghelu2Dv1uzg8e6v/ftIYZK8Zx16btQL6LO6Vrs0ACSW.</user_password>
+      <username>slemke</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Games account</fullname>
+      <gid>100</gid>
+      <home>/var/games</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>12</uid>
+      <user_password>*</user_password>
+      <username>games</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>bin</fullname>
+      <gid>1</gid>
+      <home>/bin</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1</uid>
+      <user_password>*</user_password>
+      <username>bin</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>nobody</fullname>
+      <gid>65533</gid>
+      <home>/var/lib/nobody</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>65534</uid>
+      <user_password>*</user_password>
+      <username>nobody</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Printing daemon</fullname>
+      <gid>7</gid>
+      <home>/var/spool/lpd</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>4</uid>
+      <user_password>*</user_password>
+      <username>lp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for uuidd</fullname>
+      <gid>105</gid>
+      <home>/var/run/uuidd</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>103</uid>
+      <user_password>*</user_password>
+      <username>uuidd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Postfix Daemon</fullname>
+      <gid>51</gid>
+      <home>/var/spool/postfix</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>51</uid>
+      <user_password>*</user_password>
+      <username>postfix</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Novell Customer Center User</fullname>
+      <gid>112</gid>
+      <home>/var/lib/YaST2/suse-ncc-fakehome</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>107</uid>
+      <user_password>*</user_password>
+      <username>suse-ncc</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>FTP account</fullname>
+      <gid>49</gid>
+      <home>/srv/ftp</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>40</uid>
+      <user_password>*</user_password>
+      <username>ftp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Gnome Display Manager daemon</fullname>
+      <gid>113</gid>
+      <home>/var/lib/gdm</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>108</uid>
+      <user_password>*</user_password>
+      <username>gdm</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Batch jobs daemon</fullname>
+      <gid>25</gid>
+      <home>/var/spool/atjobs</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>25</uid>
+      <user_password>*</user_password>
+      <username>at</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$2y$10$Cgc3GCy//IIKYgtqd2SVa.OJ.ycYw.Lgus/N7s8wRTbCzxc0JcTpu</user_password>
+      <username>root</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Mailer daemon</fullname>
+      <gid>12</gid>
+      <home>/var/spool/clientmqueue</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>8</uid>
+      <user_password>*</user_password>
+      <username>mail</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Daemon</fullname>
+      <gid>2</gid>
+      <home>/sbin</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>2</uid>
+      <user_password>*</user_password>
+      <username>daemon</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>NTP daemon</fullname>
+      <gid>109</gid>
+      <home>/var/lib/ntp</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>74</uid>
+      <user_password>*</user_password>
+      <username>ntp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Unix-to-Unix CoPy system</fullname>
+      <gid>14</gid>
+      <home>/etc/uucp</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>10</uid>
+      <user_password>*</user_password>
+      <username>uucp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for D-Bus</fullname>
+      <gid>101</gid>
+      <home>/var/run/dbus</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max></max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>100</uid>
+      <user_password>*</user_password>
+      <username>messagebus</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for haldaemon</fullname>
+      <gid>102</gid>
+      <home>/var/run/hald</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max></max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>101</uid>
+      <user_password>*</user_password>
+      <username>haldaemon</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>WWW daemon apache</fullname>
+      <gid>8</gid>
+      <home>/var/lib/wwwrun</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>30</uid>
+      <user_password>*</user_password>
+      <username>wwwrun</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Puppet daemon</fullname>
+      <gid>107</gid>
+      <home>/var/lib/puppet</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>104</uid>
+      <user_password>*</user_password>
+      <username>puppet</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Manual pages viewer</fullname>
+      <gid>62</gid>
+      <home>/var/cache/man</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>13</uid>
+      <user_password>*</user_password>
+      <username>man</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>PolicyKit</fullname>
+      <gid>108</gid>
+      <home>/var/run/PolicyKit</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>105</uid>
+      <user_password>*</user_password>
+      <username>polkituser</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>News system</fullname>
+      <gid>13</gid>
+      <home>/etc/news</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>9</uid>
+      <user_password>*</user_password>
+      <username>news</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>SSH daemon</fullname>
+      <gid>103</gid>
+      <home>/var/lib/sshd</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>102</uid>
+      <user_password></user_password>
+      <username>sshd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>PulseAudio daemon</fullname>
+      <gid>110</gid>
+      <home>/var/lib/pulseaudio</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>106</uid>
+      <user_password>*</user_password>
+      <username>pulse</username>
+    </user>
+  </users>
+  <x11>
+    <color_depth config:type="integer">32</color_depth>
+    <display_manager>gdm</display_manager>
+    <enable_3d config:type="boolean">true</enable_3d>
+    <monitor>
+      <display>
+        <max_hsync config:type="integer">94</max_hsync>
+        <max_vsync config:type="integer">75</max_vsync>
+        <min_hsync config:type="integer">31</min_hsync>
+        <min_vsync config:type="integer">50</min_vsync>
+      </display>
+      <monitor_device>Unknown</monitor_device>
+      <monitor_vendor>Unknown</monitor_vendor>
+    </monitor>
+    <resolution>800x600</resolution>
+    <window_manager>gnome</window_manager>
+  </x11>
+</profile>

--- a/data/autoyast_xen/xen-SLES12-SP4-FV.xml
+++ b/data/autoyast_xen/xen-SLES12-SP4-FV.xml
@@ -1,0 +1,1801 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url><![CDATA[http://download.suse.de/ibs/QA:/SLE12SP4/update/]]></media_url>
+        <product>qa</product>
+        <product_dir/>
+      </listentry>
+    </add_on_products>
+  </add-on>
+  <bootloader>
+    <global>
+      <activate>true</activate>
+      <append>resume=/dev/xvda1 splash=silent quiet showopts crashkernel=172M,high</append>
+      <boot_boot>false</boot_boot>
+      <boot_extended>false</boot_extended>
+      <boot_mbr>false</boot_mbr>
+      <boot_root>true</boot_root>
+      <generic_mbr>true</generic_mbr>
+      <gfxmode>auto</gfxmode>
+      <hiddenmenu>false</hiddenmenu>
+      <os_prober>false</os_prober>
+      <terminal>gfxterm</terminal>
+      <timeout config:type="integer">8</timeout>
+      <trusted_grub>false</trusted_grub>
+      <xen_append>crashkernel=172M,high</xen_append>
+      <xen_kernel_append>vga=gfx-1024x768x16 crashkernel=172M\&lt;4G</xen_kernel_append>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <ca_mgm>
+    <CAName>YaST_Default_CA</CAName>
+    <ca_commonName>YaST Default CA (suse.cz)</ca_commonName>
+    <country>US</country>
+    <locality/>
+    <organisation/>
+    <organisationUnit/>
+    <password>ENTER PASSWORD HERE</password>
+    <server_email>postmaster@suse.cz</server_email>
+    <state/>
+    <takeLocalServerName config:type="boolean">true</takeLocalServerName>
+  </ca_mgm>
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <firewall>
+    <FW_ALLOW_FW_BROADCAST_DMZ>no</FW_ALLOW_FW_BROADCAST_DMZ>
+    <FW_ALLOW_FW_BROADCAST_EXT>no</FW_ALLOW_FW_BROADCAST_EXT>
+    <FW_ALLOW_FW_BROADCAST_INT>no</FW_ALLOW_FW_BROADCAST_INT>
+    <FW_BOOT_FULL_INIT>no</FW_BOOT_FULL_INIT>
+    <FW_CONFIGURATIONS_DMZ>sshd</FW_CONFIGURATIONS_DMZ>
+    <FW_CONFIGURATIONS_EXT>hamsta sshd</FW_CONFIGURATIONS_EXT>
+    <FW_CONFIGURATIONS_INT>sshd</FW_CONFIGURATIONS_INT>
+    <FW_DEV_DMZ/>
+    <FW_DEV_EXT/>
+    <FW_DEV_INT/>
+    <FW_FORWARD_ALWAYS_INOUT_DEV/>
+    <FW_FORWARD_MASQ/>
+    <FW_IGNORE_FW_BROADCAST_DMZ>no</FW_IGNORE_FW_BROADCAST_DMZ>
+    <FW_IGNORE_FW_BROADCAST_EXT>yes</FW_IGNORE_FW_BROADCAST_EXT>
+    <FW_IGNORE_FW_BROADCAST_INT>no</FW_IGNORE_FW_BROADCAST_INT>
+    <FW_IPSEC_TRUST>no</FW_IPSEC_TRUST>
+    <FW_LOAD_MODULES>nf_conntrack_netbios_ns</FW_LOAD_MODULES>
+    <FW_LOG_ACCEPT_ALL>no</FW_LOG_ACCEPT_ALL>
+    <FW_LOG_ACCEPT_CRIT>yes</FW_LOG_ACCEPT_CRIT>
+    <FW_LOG_DROP_ALL>no</FW_LOG_DROP_ALL>
+    <FW_LOG_DROP_CRIT>yes</FW_LOG_DROP_CRIT>
+    <FW_MASQUERADE>no</FW_MASQUERADE>
+    <FW_PROTECT_FROM_INT>no</FW_PROTECT_FROM_INT>
+    <FW_ROUTE>no</FW_ROUTE>
+    <FW_SERVICES_ACCEPT_DMZ/>
+    <FW_SERVICES_ACCEPT_EXT/>
+    <FW_SERVICES_ACCEPT_INT/>
+    <FW_SERVICES_ACCEPT_RELATED_DMZ/>
+    <FW_SERVICES_ACCEPT_RELATED_EXT/>
+    <FW_SERVICES_ACCEPT_RELATED_INT/>
+    <FW_SERVICES_DMZ_IP/>
+    <FW_SERVICES_DMZ_RPC/>
+    <FW_SERVICES_DMZ_TCP/>
+    <FW_SERVICES_DMZ_UDP/>
+    <FW_SERVICES_EXT_IP/>
+    <FW_SERVICES_EXT_RPC/>
+    <FW_SERVICES_EXT_TCP/>
+    <FW_SERVICES_EXT_UDP/>
+    <FW_SERVICES_INT_IP/>
+    <FW_SERVICES_INT_RPC/>
+    <FW_SERVICES_INT_TCP/>
+    <FW_SERVICES_INT_UDP/>
+    <FW_STOP_KEEP_ROUTING_STATE>no</FW_STOP_KEEP_ROUTING_STATE>
+    <enable_firewall config:type="boolean">true</enable_firewall>
+    <start_firewall config:type="boolean">true</start_firewall>
+  </firewall>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <proposals config:type="list"/>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+    <storage>
+      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
+      <start_multipath config:type="boolean">false</start_multipath>
+    </storage>
+  </general>
+  <groups config:type="list">
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>100</gid>
+      <group_password>x</group_password>
+      <groupname>users</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>492</gid>
+      <group_password>x</group_password>
+      <groupname>systemd-timesync</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>33</gid>
+      <group_password>x</group_password>
+      <groupname>video</groupname>
+      <userlist>gdm</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>486</gid>
+      <group_password>x</group_password>
+      <groupname>pulse</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>17</gid>
+      <group_password>x</group_password>
+      <groupname>audio</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>495</gid>
+      <group_password>x</group_password>
+      <groupname>polkitd</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>22</gid>
+      <group_password>x</group_password>
+      <groupname>utmp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>485</gid>
+      <group_password>x</group_password>
+      <groupname>pulse-access</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>16</gid>
+      <group_password>x</group_password>
+      <groupname>dialout</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>2</gid>
+      <group_password>x</group_password>
+      <groupname>daemon</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>6</gid>
+      <group_password>x</group_password>
+      <groupname>disk</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>487</gid>
+      <group_password>x</group_password>
+      <groupname>brlapi</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>10</gid>
+      <group_password>x</group_password>
+      <groupname>wheel</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>42</gid>
+      <group_password>x</group_password>
+      <groupname>trusted</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>493</gid>
+      <group_password>x</group_password>
+      <groupname>systemd-journal</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>3</gid>
+      <group_password>x</group_password>
+      <groupname>sys</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>20</gid>
+      <group_password>x</group_password>
+      <groupname>cdrom</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>40</gid>
+      <group_password>x</group_password>
+      <groupname>games</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>491</gid>
+      <group_password>x</group_password>
+      <groupname>kvm</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>488</gid>
+      <group_password>x</group_password>
+      <groupname>rtkit</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>65534</gid>
+      <group_password>x</group_password>
+      <groupname>nogroup</groupname>
+      <userlist>nobody</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>21</gid>
+      <group_password>x</group_password>
+      <groupname>console</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>49</gid>
+      <group_password>x</group_password>
+      <groupname>ftp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>489</gid>
+      <group_password>x</group_password>
+      <groupname>scard</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>71</gid>
+      <group_password>x</group_password>
+      <groupname>ntadmin</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>15</gid>
+      <group_password>x</group_password>
+      <groupname>shadow</groupname>
+      <userlist>vnc</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>54</gid>
+      <group_password>x</group_password>
+      <groupname>lock</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>496</gid>
+      <group_password>x</group_password>
+      <groupname>input</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>59</gid>
+      <group_password>x</group_password>
+      <groupname>maildrop</groupname>
+      <userlist>postfix</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>41</gid>
+      <group_password>x</group_password>
+      <groupname>xok</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>25</gid>
+      <group_password>x</group_password>
+      <groupname>at</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>8</gid>
+      <group_password>x</group_password>
+      <groupname>www</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>498</gid>
+      <group_password>x</group_password>
+      <groupname>sshd</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>12</gid>
+      <group_password>x</group_password>
+      <groupname>mail</groupname>
+      <userlist>postfix</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>484</gid>
+      <group_password>x</group_password>
+      <groupname>vnc</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>14</gid>
+      <group_password>x</group_password>
+      <groupname>uucp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>9</gid>
+      <group_password>x</group_password>
+      <groupname>kmem</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>98</gid>
+      <group_password>x</group_password>
+      <groupname>tss</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>65533</gid>
+      <group_password>x</group_password>
+      <groupname>nobody</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>1</gid>
+      <group_password>x</group_password>
+      <groupname>bin</groupname>
+      <userlist>daemon</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>13</gid>
+      <group_password>x</group_password>
+      <groupname>news</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>499</gid>
+      <group_password>x</group_password>
+      <groupname>messagebus</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>43</gid>
+      <group_password>x</group_password>
+      <groupname>modem</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>7</gid>
+      <group_password>x</group_password>
+      <groupname>lp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>494</gid>
+      <group_password>x</group_password>
+      <groupname>nscd</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>19</gid>
+      <group_password>x</group_password>
+      <groupname>floppy</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>32</gid>
+      <group_password>x</group_password>
+      <groupname>public</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>482</gid>
+      <group_password>x</group_password>
+      <groupname>adm</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>51</gid>
+      <group_password>x</group_password>
+      <groupname>postfix</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>497</gid>
+      <group_password>x</group_password>
+      <groupname>tape</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>483</gid>
+      <group_password>x</group_password>
+      <groupname>gdm</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>490</gid>
+      <group_password>x</group_password>
+      <groupname>ntp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>0</gid>
+      <group_password>x</group_password>
+      <groupname>root</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>62</gid>
+      <group_password>x</group_password>
+      <groupname>man</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>5</gid>
+      <group_password>x</group_password>
+      <groupname>tty</groupname>
+      <userlist/>
+    </group>
+  </groups>
+  <host>
+    <hosts config:type="list">
+      <hosts_entry>
+        <host_address>127.0.0.1</host_address>
+        <names config:type="list">
+          <name>localhost</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>::1</host_address>
+        <names config:type="list">
+          <name>localhost ipv6-localhost ipv6-loopback</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>fe00::0</host_address>
+        <names config:type="list">
+          <name>ipv6-localnet</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff00::0</host_address>
+        <names config:type="list">
+          <name>ipv6-mcastprefix</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::1</host_address>
+        <names config:type="list">
+          <name>ipv6-allnodes</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::2</host_address>
+        <names config:type="list">
+          <name>ipv6-allrouters</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::3</host_address>
+        <names config:type="list">
+          <name>ipv6-allhosts</name>
+        </names>
+      </hosts_entry>
+    </hosts>
+  </host>
+  <kdump>
+    <add_crash_kernel config:type="boolean">true</add_crash_kernel>
+    <crash_kernel>172M,high</crash_kernel>
+    <crash_xen_kernel>172M\&lt;4G</crash_xen_kernel>
+    <general>
+      <KDUMPTOOL_FLAGS/>
+      <KDUMP_COMMANDLINE/>
+      <KDUMP_COMMANDLINE_APPEND/>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_CPUS/>
+      <KDUMP_DUMPFORMAT>lzo</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_HOST_KEY/>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>5</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_KERNELVER/>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NET_TIMEOUT>30</KDUMP_NET_TIMEOUT>
+      <KDUMP_NOTIFICATION_CC/>
+      <KDUMP_NOTIFICATION_TO/>
+      <KDUMP_POSTSCRIPT/>
+      <KDUMP_PRESCRIPT/>
+      <KDUMP_REQUIRED_PROGRAMS/>
+      <KDUMP_SAVEDIR>/var/crash</KDUMP_SAVEDIR>
+      <KDUMP_SMTP_PASSWORD/>
+      <KDUMP_SMTP_SERVER/>
+      <KDUMP_SMTP_USER/>
+      <KDUMP_TRANSFER/>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+      <KEXEC_OPTIONS/>
+    </general>
+  </kdump>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <login_settings/>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id/>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>suse.cz</domain>
+      <hostname>dhcp50</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>ATTR{address}</rule>
+        <value>00:16:3e:de:48:cf</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+    </routing>
+  </networking>
+  <nis>
+    <netconfig_policy>auto</netconfig_policy>
+    <nis_broadcast config:type="boolean">false</nis_broadcast>
+    <nis_broken_server config:type="boolean">false</nis_broken_server>
+    <nis_domain/>
+    <nis_local_only config:type="boolean">false</nis_local_only>
+    <nis_options/>
+    <nis_other_domains config:type="list"/>
+    <nis_servers config:type="list"/>
+    <slp_domain/>
+    <start_autofs config:type="boolean">false</start_autofs>
+    <start_nis config:type="boolean">false</start_nis>
+  </nis>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list">
+      <peer>
+        <address>/var/lib/ntp/drift/ntp.drift</address>
+        <comment># path for drift file</comment>
+        <options/>
+        <type>driftfile</type>
+      </peer>
+      <peer>
+        <address>/var/log/ntp</address>
+        <comment># alternate log file</comment>
+        <options/>
+        <type>logfile</type>
+      </peer>
+      <peer>
+        <address>/etc/ntp.keys</address>
+        <comment># path for keys file</comment>
+        <options/>
+        <type>keys</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># define trusted keys</comment>
+        <options/>
+        <type>trustedkey</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># key (7) for accessing server variables</comment>
+        <options/>
+        <type>requestkey</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># key (6) for accessing server variables</comment>
+        <options/>
+        <type>controlkey</type>
+      </peer>
+      <peer>
+        <address>ntp.suse.cz</address>
+        <comment/>
+        <options/>
+        <type>server</type>
+      </peer>
+    </peers>
+    <restricts config:type="list">
+      <restrict>
+        <comment/>
+        <mask/>
+        <options>ipv6 notrap nomodify nopeer noquery</options>
+        <target>default</target>
+      </restrict>
+      <restrict>
+        <comment/>
+        <mask/>
+        <options/>
+        <target>127.0.0.1</target>
+      </restrict>
+      <restrict>
+        <comment/>
+        <mask/>
+        <options/>
+        <target>::1</target>
+      </restrict>
+    </restricts>
+    <start_at_boot config:type="boolean">true</start_at_boot>
+    <start_in_chroot config:type="boolean">false</start_in_chroot>
+    <sync_interval config:type="integer">5</sync_interval>
+    <synchronize_time config:type="boolean">false</synchronize_time>
+  </ntp-client>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/xvda</device>
+      <disklabel>msdos</disklabel>
+      <enable_snapshots config:type="boolean">true</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>swap</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <partition_type>primary</partition_type>
+          <resize config:type="boolean">false</resize>
+          <size>2145549824</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <partition_type>primary</partition_type>
+          <resize config:type="boolean">false</resize>
+          <size>6711787520</size>
+          <subvolumes config:type="list">
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>boot/grub2/i386-pc</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>boot/grub2/x86_64-efi</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>home</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>opt</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>srv</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>tmp</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>usr/local</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/cache</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/crash</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">false</copy_on_write>
+              <path>var/lib/libvirt/images</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/lib/machines</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/lib/mailman</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">false</copy_on_write>
+              <path>var/lib/mariadb</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">false</copy_on_write>
+              <path>var/lib/mysql</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/lib/named</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">false</copy_on_write>
+              <path>var/lib/pgsql</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/log</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/opt</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/spool</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/tmp</path>
+            </listentry>
+          </subvolumes>
+        </partition>
+      </partitions>
+      <pesize/>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <printer>
+    <client_conf_content>
+      <file_contents><![CDATA[# CUPS client configuration file (optional).
+
+# You may use /etc/cups/client.conf (system wide)
+# or ~/.cups/client.conf (per user).
+# For more information see "man 5 client.conf".
+
+# The ServerName directive specifies the remote server
+# that is to be used for all client operations. That is, it
+# redirects all client requests directly to that remote server
+# so that a local running cupsd is not used in this case.
+# The default is to use the local server ("localhost") or domain socket.
+# Only one ServerName directive may appear.
+# If multiple names are present, only the last one is used.
+# The default port number is 631 but can be overridden by adding
+# a colon followed by the desired port number.
+# The default IPP version is 2.0 but can be overridden by adding
+# a slash followed by version=V where V is 1.0 or 1.1 or 2.0 or 2.1 or 2.2.
+# IPP version 2.0 does do not work with CUPS 1.3 or older servers.
+# If an CUPS 1.3 or older server is used, its older IPP version
+# must be specified as .../version=1.1 or .../version=1.0.
+
+# Examples:
+# ServerName sever.example.com
+# ServerName 192.0.2.10
+# ServerName sever.example.com:8631
+# ServerName older.server.example.com/version=1.1
+# ServerName older.server.example.com:8631/version=1.1
+
+]]></file_contents>
+    </client_conf_content>
+    <cupsd_conf_content>
+      <file_contents><![CDATA[#
+# "$Id: cupsd.conf.in 11025 2013-06-07 01:00:33Z msweet $"
+#
+# Configuration file for the CUPS scheduler.  See "man cupsd.conf" for a
+# complete description of this file.
+#
+
+# Log general information in error_log - change "warn" to "debug"
+# for troubleshooting...
+LogLevel warn
+
+# Only listen for connections from the local machine.
+Listen localhost:631
+Listen /run/cups/cups.sock
+
+# Show shared printers on the local network.
+Browsing On
+BrowseLocalProtocols dnssd
+
+# Default authentication type, when authentication is required...
+DefaultAuthType Basic
+
+# Web interface setting...
+WebInterface Yes
+
+# Restrict access to the server...
+<Location />
+  Order allow,deny
+</Location>
+
+# Restrict access to the admin pages...
+<Location /admin>
+  Order allow,deny
+</Location>
+
+# Restrict access to configuration files...
+<Location /admin/conf>
+  AuthType Default
+  Require user @SYSTEM
+  Order allow,deny
+</Location>
+
+# Set the default printer/job policies...
+<Policy default>
+  # Job/subscription privacy...
+  JobPrivateAccess default
+  JobPrivateValues default
+  SubscriptionPrivateAccess default
+  SubscriptionPrivateValues default
+
+  # Job-related operations must be done by the owner or an administrator...
+  <Limit Create-Job Print-Job Print-URI Validate-Job>
+    Order deny,allow
+  </Limit>
+
+  <Limit Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job Cancel-My-Jobs Close-Job CUPS-Move-Job CUPS-Get-Document>
+    Require user @OWNER @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # All administration operations require an administrator to authenticate...
+  <Limit CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default CUPS-Get-Devices>
+    AuthType Default
+    Require user @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # All printer operations require a printer operator to authenticate...
+  <Limit Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After Cancel-Jobs CUPS-Accept-Jobs CUPS-Reject-Jobs>
+    AuthType Default
+    Require user @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # Only the owner or an administrator can cancel or authenticate a job...
+  <Limit Cancel-Job CUPS-Authenticate-Job>
+    Require user @OWNER @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  <Limit All>
+    Order deny,allow
+  </Limit>
+</Policy>
+
+# Set the authenticated printer/job policies...
+<Policy authenticated>
+  # Job/subscription privacy...
+  JobPrivateAccess default
+  JobPrivateValues default
+  SubscriptionPrivateAccess default
+  SubscriptionPrivateValues default
+
+  # Job-related operations must be done by the owner or an administrator...
+  <Limit Create-Job Print-Job Print-URI Validate-Job>
+    AuthType Default
+    Order deny,allow
+  </Limit>
+
+  <Limit Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job Cancel-My-Jobs Close-Job CUPS-Move-Job CUPS-Get-Document>
+    AuthType Default
+    Require user @OWNER @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # All administration operations require an administrator to authenticate...
+  <Limit CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default>
+    AuthType Default
+    Require user @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # All printer operations require a printer operator to authenticate...
+  <Limit Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After Cancel-Jobs CUPS-Accept-Jobs CUPS-Reject-Jobs>
+    AuthType Default
+    Require user @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # Only the owner or an administrator can cancel or authenticate a job...
+  <Limit Cancel-Job CUPS-Authenticate-Job>
+    AuthType Default
+    Require user @OWNER @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  <Limit All>
+    Order deny,allow
+  </Limit>
+</Policy>
+
+# The policy below is added by SUSE during build of our cups package.
+# The policy 'allowallforanybody' is totally open and insecure and therefore
+# it can only be used within an internal network where only trused users exist
+# and where the cupsd is not accessible at all from any external host, see
+# http://en.opensuse.org/SDB:CUPS_and_SANE_Firewall_settings
+# Have in mind that any user who is allowed to do printer admin tasks
+# can change the print queues as he likes - e.g. send copies of confidental
+# print jobs from an internal network to any external destination, see
+# http://en.opensuse.org/SDB:CUPS_in_a_Nutshell
+# For documentation regarding 'Managing Operation Policies' see
+# http://www.cups.org/documentation.php/doc-1.7/policies.html
+<Policy allowallforanybody>
+  # Allow anybody to access job's private values:
+  JobPrivateAccess all
+  # Make none of the job values to be private:
+  JobPrivateValues none
+  # Allow anybody to access subscription's private values:
+  SubscriptionPrivateAccess all
+  # Make none of the subscription values to be private:
+  SubscriptionPrivateValues none
+  # Allow anybody to do all IPP operations:
+  # Currently the IPP operations Validate-Job Cancel-Jobs Cancel-My-Jobs Close-Job CUPS-Get-Document
+  # must be additionally exlicitly specified because those IPP operations are not included
+  # in the "All" wildcard value - otherwise cupsd prints error messages of the form
+  # "No limit for Validate-Job defined in policy allowallforanybody and no suitable template found."
+  <Limit All Validate-Job Cancel-Jobs Cancel-My-Jobs Close-Job CUPS-Get-Document>
+    Order deny,allow
+    Allow from all
+  </Limit>
+</Policy>
+# Explicitly set the CUPS 'default' policy to be used by default:
+DefaultPolicy default
+
+#
+# End of "$Id: cupsd.conf.in 11025 2013-06-07 01:00:33Z msweet $".
+#
+]]></file_contents>
+    </cupsd_conf_content>
+  </printer>
+  <proxy>
+    <enabled config:type="boolean">false</enabled>
+    <ftp_proxy/>
+    <http_proxy/>
+    <https_proxy/>
+    <no_proxy>localhost, 127.0.0.1</no_proxy>
+    <proxy_password/>
+    <proxy_user/>
+  </proxy>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <services-manager>
+    <default_target>graphical</default_target>
+    <services>
+      <disable config:type="list"/>
+      <enable config:type="list">
+        <service>apparmor</service>
+        <service>btrfsmaintenance-refresh</service>
+        <service>cron</service>
+        <service>display-manager</service>
+        <service>haveged</service>
+        <service>irqbalance</service>
+        <service>iscsi</service>
+        <service>kdump-early</service>
+        <service>kdump</service>
+        <service>mcelog</service>
+        <service>nscd</service>
+        <service>ntpd</service>
+        <service>postfix</service>
+        <service>purge-kernels</service>
+        <service>rollback</service>
+        <service>rsyslog</service>
+        <service>smartd</service>
+        <service>sshd</service>
+        <service>SuSEfirewall2</service>
+        <service>SuSEfirewall2_init</service>
+        <service>wicked</service>
+        <service>wickedd-auto4</service>
+        <service>wickedd-dhcp4</service>
+        <service>wickedd-dhcp6</service>
+        <service>wickedd-nanny</service>
+        <service>YaST2-Firstboot</service>
+        <service>YaST2-Second-Stage</service>
+        <service>getty@tty1</service>
+      </enable>
+    </services>
+  </services-manager>
+  <software>
+    <image/>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <instsource/>
+    <packages config:type="list">
+      <package>snapper</package>
+      <package>sles-release</package>
+      <package>qa_test_ltp</package>
+      <package>qa-release</package>
+      <package>openssh</package>
+      <package>numactl</package>
+      <package>kexec-tools</package>
+      <package>kernel-source</package>
+      <package>kdump</package>
+      <package>irqbalance</package>
+      <package>grub2</package>
+      <package>glibc</package>
+      <package>e2fsprogs</package>
+      <package>btrfsprogs</package>
+      <package>SuSEfirewall2</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>32bit</pattern>
+      <pattern>Minimal</pattern>
+      <pattern>apparmor</pattern>
+      <pattern>base</pattern>
+      <pattern>documentation</pattern>
+      <pattern>gnome-basic</pattern>
+      <pattern>sles-Minimal-32bit</pattern>
+      <pattern>sles-apparmor-32bit</pattern>
+      <pattern>sles-base-32bit</pattern>
+      <pattern>sles-documentation-32bit</pattern>
+      <pattern>sles-x11-32bit</pattern>
+      <pattern>sles-yast2</pattern>
+      <pattern>x11</pattern>
+      <pattern>yast2</pattern>
+    </patterns>
+  </software>
+  <ssh_import>
+    <copy_config config:type="boolean">false</copy_config>
+    <import config:type="boolean">false</import>
+  </ssh_import>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Prague</timezone>
+  </timezone>
+  <user_defaults>
+    <expire/>
+    <group>100</group>
+    <groups/>
+    <home>/home</home>
+    <inactive>-1</inactive>
+    <no_groups config:type="boolean">true</no_groups>
+    <shell>/bin/bash</shell>
+    <skel>/etc/skel</skel>
+    <umask>022</umask>
+  </user_defaults>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>bhavel</fullname>
+      <gid>100</gid>
+      <home>/home/bhavel</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>$6$sbiMjflPp89o$i9YqD.rpfRPzRFFBoKMbIgvQ1JCL31MzTaGWEcQc.yGm8/ateImCWXc3OCucHYfKeyIkxeSGhiiW5gYclSZNR0</user_password>
+      <username>bhavel</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Batch jobs daemon</fullname>
+      <gid>25</gid>
+      <home>/var/spool/atjobs</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>25</uid>
+      <user_password>!</user_password>
+      <username>at</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Unix-to-Unix CoPy system</fullname>
+      <gid>14</gid>
+      <home>/etc/uucp</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>10</uid>
+      <user_password>*</user_password>
+      <username>uucp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>user for VNC</fullname>
+      <gid>484</gid>
+      <home>/var/lib/empty</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>485</uid>
+      <user_password>!</user_password>
+      <username>vnc</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Daemon</fullname>
+      <gid>2</gid>
+      <home>/sbin</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>2</uid>
+      <user_password>*</user_password>
+      <username>daemon</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Mailer daemon</fullname>
+      <gid>12</gid>
+      <home>/var/spool/clientmqueue</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>8</uid>
+      <user_password>*</user_password>
+      <username>mail</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>SSH daemon</fullname>
+      <gid>498</gid>
+      <home>/var/lib/sshd</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>498</uid>
+      <user_password>!</user_password>
+      <username>sshd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Secure FTP User</fullname>
+      <gid>65534</gid>
+      <home>/var/lib/empty</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>491</uid>
+      <user_password>!</user_password>
+      <username>ftpsecure</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>NFS statd daemon</fullname>
+      <gid>65534</gid>
+      <home>/var/lib/nfs</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>490</uid>
+      <user_password>!</user_password>
+      <username>statd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>FTP account</fullname>
+      <gid>49</gid>
+      <home>/srv/ftp</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>40</uid>
+      <user_password>*</user_password>
+      <username>ftp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>systemd Time Synchronization</fullname>
+      <gid>492</gid>
+      <home>/</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>492</uid>
+      <user_password>!!</user_password>
+      <username>systemd-timesync</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for polkitd</fullname>
+      <gid>495</gid>
+      <home>/var/lib/polkit</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>497</uid>
+      <user_password>!</user_password>
+      <username>polkitd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Smart Card Reader</fullname>
+      <gid>489</gid>
+      <home>/var/run/pcscd</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/usr/sbin/nologin</shell>
+      <uid>489</uid>
+      <user_password>!</user_password>
+      <username>scard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>PulseAudio daemon</fullname>
+      <gid>486</gid>
+      <home>/var/lib/pulseaudio</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>487</uid>
+      <user_password>!</user_password>
+      <username>pulse</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>openslp daemon</fullname>
+      <gid>2</gid>
+      <home>/var/lib/empty</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>494</uid>
+      <user_password>!</user_password>
+      <username>openslp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Games account</fullname>
+      <gid>100</gid>
+      <home>/var/games</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>12</uid>
+      <user_password>*</user_password>
+      <username>games</username>
+    </user>
+    <user>
+      <authorized_keys config:type="list">
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCXhKcpQFoQj3Abcwwohg3+L4OTe+kkavn8+kbHWfHeONgUs/azZzZ3aqtzxJ/7BILnGtAUPThfQaaDeTTUqcsihSZMNB820s0GC7Qifp/qVF41+G074Fx0iCyEytNNXWZqMNcDfhuU5GfoBvDImJaUVkXRyRg8GKiWbY66WFyczuXhIn86S1b5X/HdguQv54wlIjrak7YeXMylQHsber5JiLhb4gR3Th1s248GdFXHs116+lrXTwXoMVLbSJIpg3x+8jYV9oAhcAloY8ODnDVqv0+re+6P4DUuQr9dnOH+x9sTo8okjhJ/P9kyForKvLQtmbuopOWr46dhhaqNxuIv abodry@linkpad</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDzPeDKJW0N7OlFxVPEcnm5ThrtkjhA81wCA6DwKY667zJN1QCjzeWHn2cPwgB/WBMg+w9ovNBa0fUyogbFWMl+m0d9wX8+aMCqTyw/EhqUgyKfy1OxdNpF+BS5gpEueb0gX9tNVuWpfUnhtqInQOByYuCbkH4gbnw28pTCc2Fa1ngq0ZkhN1bctN9clf4hV/KOVGn9IvRdcSYyUsQKl0knLEX2ePxTjnLkdixjT7fUM8yfXWbxJcnlWUuPrTx0jBOQV3AKjFPD8JS9Oz+58J7UJoYpAx82D8mv9sC4Z2FNVhTnULeozDNE3HYEK55oy/aEXquSpmF08iQ4g5t2nfst antonio@linux-pnjx</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAtF9QjP13xfNCy4ClpnUCNNFslY/MxXI8OlL/2BIb4v6gXN1iZ1/VOVIjpGKiPl/rIH4xXED+QH8//dbPqz93dIP5HtL6YFazQ+IQKCs3VVSq+kl+fP5Rei8KuqF/EX6Loss6FSJXxovfnV+MmD9JU03zkqb2Z19cBHqtCPMRn9ReAPG6LvcAN/NatgOuVY1IQe3XTyZwfRq+CY+DE3KXManezLuo6ydMKBLjjeGG/I1HmcmRbl4HwQSkGkjsTI9UloDmkhLcMpivY2TCPcJUnM/cqvftmctzcdyxg2RsekSlST7dRf7z52ExJsqzAHoT/FhGbOOsNyakhA1iGawLaw== akong</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4bJFzZoGkEl67WQjrIPm2LdDKyrRzUrspv3NcxcztHkZaT8b9hy5CYSEk46biDyhbfjjH+QVXOVTOd+fXkGt22MRlhWMtRztowFQfKGiLFeJGaPu9mqcFAVjNJ3FljjLBxfieYWf1Q+GInsSlEoV246Kuj0GqZbfGSbjDnAmmDwWlL1e/x76QItdp90En68RhXMVjfQKDoPTzY5O+wQRGgtvJ3h9wuPCMDdhkPjcdcUzsiaDbYI7JrB3bHmz8LlqXF2mKjO4Xb1QMAQIFM0DrDHsLCKIJB74sDN+GRtpuH5rnbA+GqOWcBSthxx3xyVrwO73RcntndMkXpF7edaM1 aliouliaki@dhcp108.suse.cz</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC4wxEXPwOvpnnnbOVuEQMSJbjo8hGwEtJl8lugFTWVNpK/rIln3L+pyIwIdJuuti1fVpEIr9GqyI408/nqqEtRmIyMzrspC8FddIgRSMI6/lFU5WKojoIb+op5myuZMKzlk7h+EOsF+TFADokhgeTsHkr2HWbkGTj8oLgh6Wnz1DakY48cqlJemlWJWHTLavFBuYxEe12hrGumy89D1Wv16prnZ8pthH9tpdvxTJ9js26MnjoZf+MWQ0arFi2ZBL26zqgR0VOSTIEuzvP5OjBIMwjOG429ZM6HmpzFJCcPGT419OjO5jIOVHn7Kn1wqu75RVb96Ru4jfW07E30e6x/Vv0dc8HR04tIeX2pmAgQHGxZ2lbuI4bw+7YlbaxTlfiBGgKtHv2sNXyCheg7VLi/1fHrgXrP3X2MkfOKV+GTKw2VsEhZA6e5cM996OoPrY7T+h2gbNCFM/Acjmr/ECVIaBV4nJbKTld/ouikeM9ggUS35uWd5v3mwg6gEG3RyoUD7v4kMPSE/kfAoTqksxQsZFnEwO1ZmGiHPaHGT48EKbyzZBw0IXqdfhe8Aro33tnlyY7LtRpuHLeLE8/CCNlINw7aLoB8GYVc0F3Db1pEgyY4zDOSL6kZi22OaqJmsjYpJguZhWY3Kb8wJDPB/MUCSfeo5pz1n/iV4AyMQhJi6Q== apappas</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDM2zzv4kHo2Qnka0dn/02QEQhFwMnvzX1CGPh3cC+uK4okPHqusClRvEZGbAGMIQsv7N3t16B1wix3NeQGRsGhzE0zP/9OHyjzPicKx9lrZl+vqqFxUXT8s19uFt77B/q06k3ooqwc7t16y9PNASq8HJlX3ZPDls/f6YlT+oNpHShj5n5j9O1uac4fgAYNl7+SeNVkO8CP2D9zcdXRun69ojCNr5HOSaQte+Hjd5gTXpiLKhg2pU3HDR8TFogJmpiU9dbbZRwXPYFzGvEli1In0cIsdjx4Pk//Vx3vF31TiiKlcq5HZp91OoaUK6IZF//P60UAY3m7yi7AiVhqATNt atanno@linux-617q</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAD1XS+3hC5iITnHoj3Pgk+x+vPt2Qdm3hJ4/v24usyFFUmEom5B2LUannpB0ttUfFSSZ9XDpsGCIihyokenJMO3juW4qxJK39BeAOTl2TAA8ZT4jcww5cQxVk91u6Kh/ymGA0JBf5ya2BWZ/hc2MThajf/ICEhbtN60Bx3JTXhy2ULvsGiC3vbEXczWh3bhQGlP+agf1bmFIJVHDh9ZAsE9wHnUA47mPyUMvLbJkAn0GOR2OYO3UyGT+MNDqeNPJ87ohD3Ha5dVRDQFiRHSRE+jRlRFTG0Vl9PDmMp6/YNmHe72WduG8FVSF0IrtGz3736Zth4ozkO/4B1HHuKBUz atighineanu@e152</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDC96KGkd2pJUGTu9Jcz97lEiNs9uAhte+waY2grbA0+lOw+sPC/RlO4jgNPBAQd8LXYYLuCJBHw98mwcx0cb+BR4eidfq077u8/NbFEYVtzl0y8RWz4jksQHuLNhq6koEsndFhruakWbzULCwOzoe5KnmD/gjLiZqEEApB8MmekX/ffDeqZs4lDyT1SSdpFRDCgkhdiOnkFiBmI7KlT/Y8mrqKb0oiqKbF2qcvDFkV6JRh5qBIVv8Pbau98j3jHwtWP5wDP/pKDG7+kn1RmccxB4/sDrAxqY8psc3TyUIW6ElK1g3ABaYXxHk/DfksYvqX13YAv87HiRVskvI45dUJ jwbruno@linux-akhv</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDEfz0lP5oO03Rw8vSyzqwt06VIEFA4x478DERaSWHPTD5ULqqdZQS1vsFpTtAm1eT4Ix4njXvSh4T2d2aXYyCgB+ElJI1h0tpbtX7OtenJ7c3rUows61jqmXLFrnIfWbZL2uhomTsOziQwxKoXS3PRxFgoRaZGzHGD4J4HOEfiP8YHQ53igUKbmmDY8yVZya/dyEtKe8bukcbZbGIosKgMoaLsdpbNkln7bU1oLqMuogHGtqRdZ9gQLz2mz5I7Ml/lSeCEdbkqVbOjydVhF2Qm4bvbVjyER+n0VqhXOmeKcauEOQbEafYrJjWvDetMY4j8NwWCeJq0QA7gYRd7967 bhavel@blackbird.suse.cz</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAxs7poCgBwC6s753zkBVBQNdHjlbOJdlAuANbedPLqWWhftaNfej9TUlvL2YuO0rEwUIfVhmfQ2nH37Kyu4KP4Lo9A/PwvGGPpgKJfi2SOrt+r/oo6bIexmeehdLasIAuwmLzziT7r/3EQ22mNcoFaIn7YzWxjno6wHmsTYOxGshzPeJGpAnJp3xhjzUWd8asvBuqCMTMy/uhXEt8UTCwGW4jbRmdM7zWByXSsdQl+NSa995IpUY2TQ8NAdJ0MLH2Ztn5RX8qZpNuMuC4/+IHb96N2vAP4xvJfb3LIILmLmmvJ9s+a/QC9+kQecRf0gSoEkhKfcMxPrrU82ZoMskaqw== bootcrit@qam</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC+YVLmgvFkop8f+fAKbcWMaqL6NXgjPTRy9qerM9NT1oaTa/AW+5geUYCF80HLoS8ajNgcgcqcu9irRFCv/h5ycXOdApidcpsx3n2XtAt3AiLW74LVmLzQKgzFkcUBe7awYqNYuX7oMFgfSB4KVPfr6JvYh/X/vl9oT5mIgHkYmMYLZPzuAWUqPxv6gs2MhLHTRsY+SA2Yn8hcK2P0VrGzassqdAlvUxpZ1TXOdEqS1rcZrPogf1olY4d2ubApZM5Nop2OSmxdSZNtoy6n7SIUHeGo5MZxE5JV6FafnVg2Tvapgb9Rq051r0FIwuRzv7uP4unib16RF5zrjM+JsKSYO8brNoO6somT4OaTrc96UDWPyWiNkdZ8KfM+nr3prUPPt1EqFfzOOySjCiWdtdkNRQnEMxmHXIFD1OebovQICxDm+ZgvSMNOXkrt1Yxm1K6Edze+Qjfel8lM9HDGPLawpCUsIWrslUc/8fbSUK9eRg9OZC63Bwqb0DFUVAhLaacVWNcpFXVgyA4LUKTEeFPyIlBE8645YQSKugXpcwxTbKByJQWpim5839W5TCDy35GGznWg2GFYh466Rfy1k6CVqPJ4eHXrUxZWYyWTaCHX0OTHSS4V3Tx8X+TkuvsqCBedFlNvjaw7mklRJdDw0k3ujTWsX0+E7xGSriKDPK9ruQ== cdywan@suse.de</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDb3u+zG7OoUAX5h9PTaTuK6/R5AxsO4mw23IChgpUMp9HOTVkBtDpRViSiLwuHjUnMHA42Do3lNFAI0VzimX3MD/eyZwq9SdgWcjnJr8Ha/bpTvYOpV9l1OJZ1CnP1LyN71Kdg4ionzxPWidAT+hXEqsXgnOO06aEZ8KLftdg+gJGtbIusyTKb6JHJ6ppFGDXAQSFH/gpPlYADAKWvXpmLUr/IvFxXdXLIuF5DKMHpL+bi4WNVEJtV0daCKxiRUr0A6cIuIBVXi/Vsb78KcJi/4Iq+h68iGHgArH7FBD7japmA+RT45ZXpHtGH1PhKcxa+YMmHqKYyzTirHpkpDmrn cvarelas@</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCiHsIuHvNOAdNFc31JXBGzOdnnQM2a9Wnoe3oIC1vxL61rY01dj7lJbscku8UiX5Ju7LCxAcIesZ3mkhSpomNfMv+bf6p03KZZJtSZnZPJbM4df6K0mjbNBuX4frMPieBz3SDuUtLgEk7PSHWay7snClwXRR4fL4vN9j5NbuEvKAHUsUCz1r0ARIsWVWD1mVKLCIP6N3530iTUBGlTTOfMhhYLfy+EBDbShWxXQ3NQNo5WbjZP4sy9xDootxNQL+6GJnvt1fSc1V0X/0cYg6GxUomRBJlAqgHDvNxdSFxqzJIjwGMyTda1QD7pHpEJScR2cdQ/ROcA+89JZ5BF1rtt dabatianni@krystal.suse.de</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDI7nyw0aXrCv3QbdLpBA1PQ3mogiSFKIZbmwvk0ujtEaQUZIokV8de8E2xF11xFTOekqoMSYgDFFc9ECWy+WP7H484Pmc2k1R5t7WA3jKL52CuhUEvsB2oN8OzVRE4zy7l8OdNt8Vgh1q+Hv89IMgEF49jm69vIOZW4X5+SMSyNwGM5mJEnWWR/dM3wodW3rLy6XwejIsTUtsgQ3qLuSBK4xgmu+X+kstQVAnBn+ltwCWrAMYe/pr50cEt3HZEsjNo5u11A78sLbav9QluLdi8UYVjtg5aQMiIk4b09wwgXtmhzt4XP5NDcIgVpUO+YygIjW0bCiUMju2Ama0EesAB miura@linux-wixp</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDZym9EN2vPysSZzBr7iqu1ZPJp4C2vCRSSKpSLw1xgLU46ONKfUMTnXCZvz4CfBQPowJdawa6d0kHnq3goURPhQLfsVfpancamumCvbwOpnKmun881CG2MWHFS1LxmUjhbfjW4dwz1lq9L1tpO2QCOD8Xqk2OL0xDgFujGANREaWFPE9+6oHcNWCP2CPDm+X62QEhcqDHXBUlHz/OrEmWbEz2rKgGLyNAhStYpDG2I+jAVz2DCWnOlktzNeqmElh33ggLoFpC1wYcvVvB35/5x/wu1NH8w49MYAALdq4J3S5O+ZD1Ykz2eE53ER9xYzyqPwY7ybUUsstGZrfxWn8iZ fbergmann@suse.de</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDhfydsGzD3Pv4V8R/eJjNbV8e1bDH+NduoP1RJk8xvhd5z7+SpYIxH+g3HW4KQ0JLND5U31IiCPjfhe50aehCMAy7P2dQD618gOun34ow0HMd8vK+l+7u+7EZz/Q7Vm9puUjOdSCcV3d0dAT8dQTgqiBLJFBXV6q2MWxhvr15BRMqMy0o4CqhXUn7KVxQZb4BGnIyMK25n5jJ/6rzhUnjGf+mWSgM6z12W52UUwn3ZOUc4sNfD7juOcSsdw9ZRTvuZ1Skd+wARcW9eGdO0lq36nIpVSuBZlhpkl5M8dElrwFQkDRYGB2C7iueIcFqXFKlp4U2u7/X5IU2K0Fdvhe+iwipTywLAg2APlrVK1Rb2v7XEzBg6Ow1rrUudRqz+8Q+shGRKqBR0sYmoY1AT5cUS4RXCq/T1yPHIGmF/D5mFVhp//pg6hMe87VggEJKzPAIgR853lECKgwJmsjyey0Q1PGoTzBIKvyiI5Un/3Awu64IWPKzg9oCTYKsALjpMwbpVUpuvzAUag4Zb3zno7NNAf2F83yWga/XUtGi+gUHcfzCSf9n4libQTzy4DKPKYxkrLCP61gKZKs8Rb4tqTy6D9H0fOjmfyq6M0CaejY6dD5rGSoQJtYR4RYNk27hrmekYsUzhMXbdki7ghpGj1GTjVDEkF76G74t769e95ATrZQ== fschilling@g116</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC708wsMUXeEtcHN5r+YrXPj3FCMosPstPnja4O7Izmp/uoheBNo0i4npg8RtnhWg0fTgBUdN5PIHmev2TUO6xaHR70IVQx4RLIxqG5T0ELLHk9/NjX5wn8S61jZS3cAauJ1ZanBId6Ilw4VBlWFj/Blyo4zh6yV/uSiZMNH4sYK8OFUVbNP9dTCKeTSPbzpxRm0JmN6ykne+DvDq0OOxc7ZuzFPheYXanc2A1CTXF2XRbb3nFtvxZ8PmeIuNoWRsuRvf76moIkLPDqWbLqzPdqrmB84gGeWB+FP0Hh6CYWkb/tIOnD72HdipllqFq6Akzg56EyQ9QkWw52Pw2l3D5/ geor@linux-75e7</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCdI/gXp/Clv0eP8WzIdWXTfi4r/Sfx+00bxTm3gKq/WEAh0MY9KwIVBOyvhzKWhdU3p851I2A3kXj0j0/DiLV5AEoUHSFiFGRkSSVaiTpN1U47ch5vHuLAjER6vZtXsyvYqFUNYQbFEhNGCt6ROqte2NvEeFbb0BOABUYQMXPtsChf65AvxBnKtXs2cb4tTPYNCx5yYWJ7+gS3Zi8ueO80YiegC2XJ2kwKi11rOy00NjlnLmcRsj2nxJjP9p1XyCbjXASouXcAoN4FlQ97f4tRPXDc7kKOwmRQdos3eXrbEn6T57zTg19SBdhku9NdiYnuJeGT6EtYi1pi9No1eQsr jbaier@linux-ibbd</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCugQ3nxA5Zd3fZ0f4nZ81F3rsC9NULwUQe+Xabw6sPriXkFwfeKpqx9Rg21byMh7k7MCMFItIYIBYCxyHGbYlXiktiAkOxLyi3563huJ7JOtlpGZRF5F377z+1rAZqCJHZGZpQD+kZ3TbihfIYx2g+3QhSqjHzOGDNY3y8Rt8fu4EpRUPQhbP8vELs/ZelcugKrZfMMSVVi7qjV/KU1eoDqunmvsoi7AlMLWNqqZDJrimR3Wgegut9Gz8u1gf6FzZ78vB5O+QpyT/epFIIf/SKpbtdsqhWAShhfXA5pzFQzTXJj7RvKp71HhG7rrlQh5F62tifjh0H2fDoU7L5jYK5 jgwang@myhost</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3WEVRd5LeiiXJ0VMI6n+0gAmCFgYJD2HZkd+EK/4QnMIVGsZKDyLQzv+Asv7TlhKLwlxmpbs5spVKf0+BiEQ+kvP4m48BOo4IkLYYWB82VHG/m99FKhIvHypPj+TtF5/53Hn9acDNj8gXd2eAbnz2Bu7lli7ANOwQQadRkV4lvp42AQQ7rQ7gJJXiCwORnH2l+nHZ9FqDxXWFIiz/y3SJaltXVS0ELNtCH7D1zxDTjcy0HsMgmm9CBA97NhlAAzdr2GXbyHXCxUf7OaUHlOOg//wcturB7fd2ElH/ftJMz67PKwBfaW/mH/kJqgK5i68TzWo+ARULVu+dG9bavt3F jhura@ezkaton.suse.cz</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDP8+VZEZWcVDfUAmhuo97W+D//X1ztpXefdHDkXp+NTh7OJbvumqW5xNwNYlTprN7pAh3sDI2WAOKQtq27ZyBSiTJIr7N2XBbPgsQGtE30jA7E5LqwsLpJ9UFZEEHyvwfwNoOsloLlD6YYnVID8W1LL46MJ8mgdb1cHXZIQ+8I48Ok2y+HPilq5C57zQmKtw4ZLb/8X7TA4SW8n+N1ayO3VIdXlq+z+kA129AM4dQr9tuNgucKeQ3CeKSqYQ+suhI7k8GBYcZ7JpLGQTm1eoJLwXVkt1xRfVSCOAUbuMHLNixnEl3Nq5c/itg/mePx4FEkq0kUdHGKD+di4p5YEV97rYxLOb9QQB0EnCj5YbT+l/sd8AHRR61TZzxh6zsEoLCyr9BKTQ83bNY1V682Wff+Mjl35/e2qxCuUeICdY57BvzJ5/MB95pGkyMfzpyXBiN1s+zjazPGH5cCN5o5yWZPa2OkiSi11LbAcwWoh4cZGKBC4U2l3kgQEob9m+QTSCq8ND2ZiMqGXTpE33vfNQU3ZUlsvHpFrUCpWQPd1plchS3UBlr28B1zJLk3r8kVOd5FRKaHzOhxwm350wIPyCSK7LhIeVLgSwDU0cAIFEVWFJs4DF3UA/uzjW9m3rTem4D3FGHwNeRxXLaR+ogk6v8rgluJobX2fV3FjeCHtDhHXw== jkohoutek@linux-eye8.suse</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCm/z0MRb/MVoFeC0lCA45XIbUxyaZ+DTpMEEjQ30/PH2DFSdu4izguNyog+qMHmKAgBQWZWHr1DwXYTjZ4ZiQR6YShxb269S6QO0uqQ6U6SFBHwEyoaY1ooZgcPdCyjXKRSPieTHI1VojxiReDVNnDgrCObac4RWi5EU0JDSgKJI5HT+LjW9NLJGu+ikPuXbr479F6DFET5uV1ht09g5ppvkF2fDLojobaWf1og2JD7EPOg1E4MKX2juxrxSyhLFNaD1esBchKIryymQqIwAMqJsFeiU9YuAQ/N3xkvVUq3DSjeRU2okcpuo/FPP5ulHOTrRoyLQMkKl+BntCh5Sxj jpupava</listentry>
+        <listentry>ssh-dss AAAAB3NzaC1kc3MAAACBAPk04bTq/zI0tvb6yLy0aeC6+NDFpfRpNa7lw+lY13KphiAY9rq5qCv2mSxfQ4ZQjUzglEY5kmdPZUBT7McDl/UjQs/xvXmAhk6sBfX1fNoQGlGziwNIEjborwdC+SHHDu9F/bhGhMWfMuJ/jzKvBUXGAS8KoBm22o0fsVbZnsEXAAAAFQDvAq+kwDScccd2snfvERgFGIVjZwAAAIEA4Q5mk8/tFDDz2Ye1JOL0+oKpYmDzbeSla2MY9VyA18TUNgmIddVUdWdN6Exvx8wTwK9qIdsR3nE3+2np71fSljcHPmvEacByyxrGILqdId7ATtnl8ISC+3IT6DHqBGhMbx/Y9R/t00HwFilCvOxTHg/ObIwHPTH0to8VK3LI1PoAAACAPxxUSHpkSCxS1g0s2p9fAbOR/f7UcdzogagM2dGp8RlDfZcZXbSg/HpbePHtijxZaPpbogtJGf7PQhzNdGB2QF9Jy2kmVhzUX8HIEp/gBDs4RqONjuczvplgOssjgDWIjhaJK9hmNjkTQcCnf/PjcmapOA2rZpoauvx/B7oYImE= kgw@Zert180</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDO21pGr5lXFi1L3Xfnm5vkHLPCcLNsklgdiiZDKCSncrWDeQNtkgd7D6EEfX8FlsaWmIeN/UCHDQk6ZTwBUpGkwSAyD3B85nrZUkau1/gFdCsADktpo5TMzN5XYkOCRmAuVZ4OrofFYoJOFbh1WxNLovqT8qQll4Ytx97+SOFvl5lmHVnzLFj8wXr0GNNv8pvbUHcHbVaHrJo8JU+T2StO8cIo5Tcr0fOXwD9tvEM8orSzrluOXqz5mse2MtCA79dT1GeMV/eQ7kG8sQrMymQQAn8ce6xfl2IUd3lBXjkhFUH+7/2PdAKkH6ZCY3QanWxsA5Z8pJ8AIA2qPXDiYZGl kickstart@localhost</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDN9q3uKjv+E8uChhbxrKuWRa3KHAjGzVFDW+EwFixs5rQhX3BLnmHs49rYMlIg5nfPHIgk2zch9paQHC3LY9JMNOOk1WKhaz2XKHTlnsmxNAF3tAaJ3tHvgOIabHWtJS2YdaH9Sp3bEsLSEKm74g+19bGEUfDfNPLLFM/Zohj1SUAs+NAkNqvjgh2rMGCgR52RXf64upH6Lkym6+2CvKY2Wje4gfbUrfy8FRPsiBspotEs9rxTuzWe4isrhcvn1Ugw2wVMbCF1HG/sZXNWU+Uc3eOXOzuh5DYGneLYzL0uamPIAWmCWyE397XOLnL4q/NSoBUyZBhkzeEN5K0JJNzV ktsamis</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCz0BkomTEgbSmwCdB2JKaGaR1hOuTB8z59Q+JZYtzBPxYTpOCZFNgFUNKteGZgDhIfrqRWTuENbCX28EDI+Ds7pqrRgyLxt2SQpZYl6FL2g+5Se1l0Tnw3lbOGdkSC5QXRVrJWhLQMRm5z3rKrSUtbMttJUfOolUuv+p+9LLWPrY5Ts/uTlBA67Si+hhKIq+gEAg/iDQRbXn7VpBWJGNvrsBh2fDBPPm+cerqPWpMceqSa0pP/7m0wzSS8UvRxvgDd2no06g7XnrptGHdquIQN1zNWP3aui/HgpPnQW+X20jSWCpAOSvJfvp5iA1r89JGBBneULMWTcgFxwALMotQ7 lpalovsky</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCoatVX9uqgiaDBPbfkU5rRTj1JaK7eUqXyMzM4tFVWBemMbO4VZYcfiJIVHDCypJaAzSZjmI7tvJMyLU0osGGGpbwshi4MTOLTC8W2aS652LsYnvot5gonaXgl9IY9HW2oWDZUCJNVG3rUYzXiulVajCdGmqQY+2Hu3g7n92fIu6Tu7j/ho2vaLeHqe2YIU5Br//WZQiJjJ/Ln2Tmsoj2YPcMKrDjfI8MPt3I5N60vdCHWQIZSXIwRXFF79QIDNErnKS3zNbwHsR5LRA0ymfFV6vefhlBN9vR9G7L5AXGe4yKTl1Aq5mnOrYZL2F5debDIw3E4pg/1Q5twieE19olN mli@simonmachine</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCz1IkJsGdejHECkCQFZOHaYrOzte5AdAbG+Xwo/jxrAvrXhC/8hXSTDk9mdvGSpAmtg3ATM5jNd7uKEc2c4f2gNAvLmiAYz9faxqk1ay87zbkVaN9lgtjT/hCDbR7d5mweVlOeSE4iMzVIJU8/06vYhEhWT8U6j6T+O6VPqlnlyg613ZiGEIvghW+qB7I1qMa/MT95nPB5v3h8pAeJF6jagsxvOUcTs+WqBpIBpSwjbiP7TppjII2M/ZS+pFwOZFh/OA7xt4SKxzzov3mhEvbtkVX2tFGUbEjGonB4psmrMGulHCJG5Kw/uU2vNoZG2uCIBtZbXm4vuOsyJIUdFQx7 martins@moya.casa</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCrFEV4FE1duRdfgMg3X+VON6vDUfO5UX328huK4hosXDfsLdBK0ip99dFBnXLVRjx0dMDnxwFnFLR1Rr3HJBO5KaY4Ml0DXQ1djDQDAZkQ5ljVe4x49ZgFzsaaAUuP0yKNEeozPv0kZmx1Bet2MiOkFHod7igtHlk3O53Lmi7AmlaOxpy8Yuegt4nmCMEAcLkSpm3uXye2gfB0JgaTNzu2TsfERtOo6mM6vngZAn+xqKwLQF4Ktgeb/R2tNj/GCGRQ9QupB9Sw39RmC3J3vDELajQ8q7S+a2Q8lUVrNUD7z3Zxp7g1Qy6XxnZixaAfGutk5TpLv8MlQdAkC116U/Ul mpluskal@daredevil.suse.cz</listentry>
+        <listentry>ssh-dss AAAAB3NzaC1kc3MAAACBAI7hS4HYQ+Uh6ylBWSZ7mNcVitvDERqRANEdSFeubMo/QsHcwlV+g8PIg+Cn72lhlU2B7ZJUDIvHTj7ciqsG45+g4D5MWVKWZqkZzEA3ofbmf/bB7iJv9uAQXB+D0uriZVJGij1lqwKNxT3BLN0mKMoWhjFPY7kYz/3SvIxkOsWjAAAAFQDc41ylTBQXiCpLijVN5UENS4tqTQAAAIAtyoOgrD8Tc+40vNWpJEB0Yc0m/lJDaxq8Ack5+QqP/XQOIEjRS0IIUFonbnrtq1v5oe2FIpxoLuSZHqnbuy/OfoyFnn2QEFCM7+oE5967nlBY18iyQal4xELkYk3Q7S1IghMtoJizdcUhTrlVFz9CFOILu8roE+07pklUmn2WyAAAAIAefJdsAFT9b2SvNwBf/smBUoZ1Ji49u0VD63Z9m9y0lJwOw6oAhyRQmbqceLV4dcH1ttK4eG2xttvsqspZKVT6Mpmjry6TjRcrvHt7kMvuFCKREaJBz8ZyUmNS1TbJnjzqqj0puJgToNk16eUkCa9JUo3xG0CI1bywLsv0h9Q+Uw== nagios@monitor</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAp0LjAk5qTRtNLX7s0AV2FVzC87m8iLCgRLpRO6m0lFIalATpi+pUZ7uSUPfpXtnJQ68lsVTl/ClMe1siCs8BUuUgsLYwYxeSboz3YxcZOG0QbkWGppKJd+qB8RAS/OLQ1kfycq6XiombMq3V5X7Yh+3ShrNmlWuItn9e2X3NdPwpcG8fCOTEOKOBl7nRpkLr4mptsGlVHoRda8Tv/HDLB2OoFbFTsww5DoG02kh3G/fN8sF42sxBztFtz+YSGPgSeYUSFuzPrA0RKu/s2uOR8wWTBtHlq1/WSAk5/HQZO7flAl9HCiu+A5/JxcYgCAs6jPUp4+gO3Bf2mNBzSTi3Xw== nagios@monitor</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtOQSI+PPZ97XvvxAFbL06DngIAL3yptiF8UTPChqlMDvuaSoafREQRITMT2jRpiPjNWN3YqQXiQu8+ckBR3tD2KaJ+UOq74JUaSU1TrmydLJNeLcOUMB1JKJVb67xhO2E3EAltd3hGXLy9s1TLkRmI34/cfDM9spAZekhfREr4nbs5lSRVGDILeg6yE4+T/XJatRwxWOevdvS/JUvmMGCrjoOkt8Fl44ry5Ifw7vp7jMzp2ZsrFmGLEjZTXqYaONVHG+V+UlL+AOdKucvKkWJx/utlgndw0QCJ29Clpk8W64En5WReoepW7z2G8qJFsNEiw+W7sp5e875JkVQ2SwP onalmpantis@linux-g901</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDIoE9o0u46QDGEmZUwa+1ZDGaGCopYv8uauQqt3d5mCaLGFw6t2z6Lv8rw9Nwa+iH9a7Uc7K7TdeoIrywio2LsjAstvcdOjAqFmY0Lc2Tds1vr2DIJuVEfrkwgZc9sCJgWeQm5NKQ+/dlPw64OieWFYVAHt9KCWk9YuDw/I7o5oGgICbQbtAOd2ecl5ECrIqUZjakWPmwldPOOQ3aToLsTGLJqWNsAU4sopkv2JaozBrFoe60g5B3qEviNZKKVwNj9FEzb1rC0sLqGHb7lvecGKWsVfat9aV1Lt6hY8hLKpLWGMo0qIHkWA5PRrKDE9rzpEJ6rVLrZ5IKCTp9n+lqT osukup@argus</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYh2YTtJ/3pzfH4aU3DH8WEkudgSLe/W6cekDSQLFiG5DqD8kpW1vPpyf14tF4Z/XG49ssYx7amZnP3S96O5LRxEYcA/2kvCOhz3piLQbhSMqCEXUEl2YQN7CVhxJzSAKWxTyHg67FSeHkUlAfd5xLTe1bJjfwn673nLSQTxE5IzqWagC6d4TctkDCg86C4E793FOOWc7J5mb2M3BG059onSasN0I3iXh41LSPPuzrCycchV7n8q2KmutllMJb87akL8XICKFoD6c55/mwSyb/F01KyhLKl/IuAS3B5COR+SzBN6VIyqAGta+5//QxKKrNVxMkvnowVexMPD6zMxND petr@pc-pha-base-1</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2beiZY6ugIsKQwP075ds/IxqR65vluwzD/fCjjMNCaiXQJap8WhSRAOv8BMfqzSQbuRFIRr+a8YLbQqMw/kEieVSATfhx9DM4GUVDTMvDho81No4nqe7aC+3U48wyeGy9LZGTGNEzt2zoPhxqAho8g4+9rc8VaYH01O21xW2Ep02vYystCc8/bAFbB7XsYo8YTlHGxtIHoLCGEEtqO4qkd9rYLHs8Hc0y7GGGMGhbDEskooGaMJeEzkUzzNf8qFCjGF6jZmaZgQsd7CMwAeIRZTcdhPHkviBCvQ/sNFtEH+Oo7PMTr4wtySt4z75otfsJkFUdNLOgiEaceZYsJ7VD pdostal@suse.com</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDDMSmC0GfUo4Q3mA5JT9j4K+rIXbwraIAmmFIsd0lKANzQ4u8+OmaA19O/OrtEd+AZJpeLxHO2O8Q0swS53i8PNlS4PQ8hxElFAYmaV+CqDx3VccBcCwclTGHnsx2bo3ofzVsR3VSciJ/uLFE2ToSO5mTYuh5MC+t+RbhfILka5QZqL0atscsCKymMse9Wix3cZ11qpatWRHnXLXg+AK3Pb8ZaMQ8AOR8lIF+c5RChD3F1sJ+CyQ7R20GqJs1QEnHbUzWq/grugEAS8SaV33WjYD1p7WAIvcrEOGfdicnIFRvOZGzggJzPxUaMbwuLyHrOQJEN0gHQbeR29qpqtP1uVHgbScnV017CTCUa4aNiXKFlwAPyD7gPiDBIQilmxMXiGmIzoqcYkxWEuirsJHdiVcTzToalbJ265Xec3zACrD/AYRLxtvyNjE11NIC2OnsJYw3hv5Vv1DRxWZMYVDmtyHyzkj/+emPWK5dgGs7ZvAswBVpmuYjAXEcddN+OvnbEmNl1nAJOgItALYNAw1rPaJVmO+1ZjtauvVArtXco31DkZL569kklzVAcE6k8heXX5hEGcqMNP5UEVmBO0LOpSGZJRhhmxss8e78jFKXrscJNZetKc36Cjj8faL562j2326SpjQOHLzlogvmXuqq6xkaUWLmphX8hvby61fhioQ== pstivanin@suse.com</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCofCLD4g+p+RrGhdJUZQYOzu4v5pFLPg+Cg/sGWld0Ym1hEtiF89nxep9oJIGub1qAIP9lDJDZMs4Avx3n7ufjKaH5l8G9RKs3VEtV0lLgQq0luSaOAZ8koqqN0Sadymg9vxbuI3pUmxCYBCfy8MiEd9xsSSP9iSbN+nRz638KhBBmJ1VXJzX7jkwarfdxBhKHwKf3E/DqobqKUBEjSA/DY7E21EYCY0I8d8JZVEczRP8U4Os2H2LlfSxU5q2TQ1vD9Gy9mfKUCY4tMIxWvY5TeDHauPq/FUZAEHHW7kF8OZyYoxNcVEVbPVfYSh17+Sxrin7RFHkyVgAeVV1ghJo5 RMaliska@dhcp198.suse.cz</listentry>
+        <listentry>ssh-dss AAAAB3NzaC1kc3MAAACBAOhSfaq8WQuOgdDFCnvF0/7Bi1GQEobcxvQm1RgV/4TOsxmEtgRC9plhTGUjmWly5R5T0g23/CLw3UGMM7T5CK9/QGhuCC5Bm2qXD0/JnuAKrtE+k/ILXx0cX9gEjfWCnAefQpNTlJUzhnO9OwiR9o+e/HIBQRnZF3lXwyUvuCO7AAAAFQCNxioVFXvOoJtudJ9P566SiU2BFQAAAIEAkLxeu8ra1075k/4zR+2cCEFEf0uXUfnYr4IR4O4PEyvkmPV9QYyQ4sy4py/4eMVY+TfHMQjrm5LOP3dH1zRCNiOODlETtZg/WSqAguIHr71ZRHorbEICXMWm9JG5kAwDsgI1N6h2leSg+yBYu9Fy5/KtLcuxQ1IdYigaCcj0fQgAAACAQ1lr/YH5I2gPsCu5apI2lSEu7NjGJY4/BOzcXV3+YMx925C5UraOYqGsniylv/TJwfDpUsUk0ea3DPNG1C0ln4WXPlmCZPCxGhNO7kWB1LsBUmKvyde9qkgREVd9JMVN0+NhHeXE5A9vhXOvVM2c510q3iW338xVMVey/OVbLGA= rommel@poincare</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEAr5b6cWBzXLXprUTfpYmEIrN4UyC9YAS46zzilRhb6LUKijiWvfdb0d6j+iRV2hn679jvWb8g0pLilHI3S/VDyTWxUVt/cSsEXmC1x6vG9el/PIf2HdvUZtQvDweK3Qrv9oQ3nK3x+rkOW2Oxmstl760wTnhQW47cTah6mpJWHZM= rommel@poincare</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAvd/c+UtfvqICJarSw59GUrq4DwCQlw17KV//vVXfhmnyS5p+Z9S6WEEkRh7F89SkT5/zZfpITVezPz8XGwjh7jFOlzx6NSHMT4msMN2wJNa3ntQLNYPZEgvZHyKp+A0CcIgmBzRKFw1XTvvFUJyf2ucpyeQoJtR3HO4WJdgDrIezjZpkaoVf9pctxf6sV0TAKhODqw0WRpCAwN/utvAKLf6vSggrXvI3Qeoh0VKZstcu/kSktpRIG0kinNAjpNfH/AVIcoSPYLJzCUFHk7C4FooAmBHQwea9OUxQLeX4jqJMLUrZdSjREThRWx7+WeriqPmxx1nRMzwzJvcZE1vAHQ== shchang@linux-dwx7</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCqhWVTosH12864VGY5S3/k0yKc59GbV0m2WxD28gAf+uvJ1/y8gekD2wDzBv0DWqEekYLV7L68gpapDXyGosQeZ6n5OO/NZFZmW+Xq1P7P1QHJil6kVpwk927lzX440pwNf3+PRvTbLzlbuVFWJRpiykv+juJyIFjzXLJRF67wB2qgZVm5cRs/GOi4fnvTaou/Ae51mvsO8M3JL5cphApFKD/AO/X+3pHBhLjvaW33cYsp0Z4Rce1nm8wxSmvuJRF+HAfjBlknhDl5ZaJGA96RYA+g9WbAXimFprg4xeiRp7liPExQwtVgackJweoC4MahC1glmjC3eOh9dvrrxLnALOLMOkyCSK/tOF/iq2PJaLViObanPI8mnNkMLbdJyzUBf8hRGdSLcw98qxaf0sSZ+vz4VQS6e9CwX7ikkNNsTeYXjnJ+1yU3mfCW1CXJDr7kBDVG2OTLefCpMY8WBAYDiEaK0RW83cBcFIKfecKYd0qStHRaOsvmyWdFYgBh2vM1UWjro5WXlb+7aJPrUp8ZruapkUXUwhjHA7FwGA4ysE0tsOVVFm0Dw8tvyVVkVNm/9EObG28dWctioZ2+ZEzTWgMJU26Q+wOJ/U4qZyIvpMRUgPZc5nM9J8kcmvNWtb6DV9k/6p8h28kiOxPkxLtPP+3TlBCHjq//mhEnJZ/d8w== shshyukriev@suse.com</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAviz9q47QXlocFuD3qvy4Yw4yMHebHuokGK2kjpDSUOREBIqhBwOJysuDqU5PNQpJNG85C8+eM5/bS7YyIHR3hOF32daGb922g3bZcUgixrJC0Qwq1xHO7uf+/48It6BBcaG11F0uKzEzYJCayQRbSWUIGCF4EgDpDWNrR67pUh2n+U+rxY+Ll671a3lr2fwPrilXPy126EWBFJUxcxo1eet73fRKKfd38nYABT/elZKKveg6PJAvnDSB08lUpmYJ5S68rRdu1K6xGJy+Rga/ECFZLoO4JmYW4z9XnDc9s41TpS7pCIN12M7dPMHgww3zFsRfsXpKwrlnL2crEz47dw== skliu@tux</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqQ+zJeaCMN3F83/2sYUeG0CTqLRLw3jLtTNunfm2nP4hidH9Kg4ZhT4s+gXYGOKkAsIc6YbqG5nfq11LpwMY8GBglFHWGo8dkHrb9GqdcEfXJBAM6neEHtNu8aQ7eJT8ePvAqpgi7/6RTD+aIw1PQ09aiqgjn6wZDXengm2Ug93evd6PoyvIa3jFCnJr9jD5GhMz+QnY09U3Is5mDHQNH7C23zDiuBm5dWQ82UN2bRkhbIzFRl/09HWQHYlCwAlKu8vj9fSjwH9MCIRu4CoCF6CgKiC9MrH8l+VUMswhWhjp7uJYr0zGK1N3YGPIXYccPJn98ya5kXKfC236U9USZ slemke@</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCj4Kt1ioJt+s6bh9/4KvogqPsoRcauF06ocv19GjKw3sNwFRcR/hrP7OyIYtw7XxJ8TKJkJOvy3+H0CgTXdXG9uUamBMMNjrEPf0MBXMq/pR3zpT8I9V3Q2lk2l6vtGu//+KVTlBp16RJDMUA6Y1afXuavYGCb4nSueRP/hyrG84oSMWzGLAoAQfVHbZYXTSxj2MCZshvvPgxg62H67hjl+zmK0C/b6gcn9tenQzzCSuEzx2WoJ/B4R/opLKtM2FLAsJnp+DMyjnE23uw2RBWzsxklWHFkSDjT5eD3S2dNMz+whwoqtQDGiP7wxAmrIy9usNuAWJ4rODwYGsd6+g+frCKuxiBFWxBlB1wdLsd6s2jiKlj1Mq648/EcbdlTlMPs5RjXcw82sksaKmxdD5FjoLND5r85X/nRO8Ymc2Z7MVOjcW4SBxgRY4BB3N0384uZPILlL2SbMqlcejEMxeGWOF6NtnNgqlsLrfp4AsYmDAqZL0cnP750K91O5ON05O21XVnD7FjKA6IXKHEX62Sizao/f24s6aP5ROWX81GsNlcAm59rz7wk1gSxjoaUtSrJ6ZVd9v17ICr+bGgjGksf+1UMfATjjIBb/JW0YhzbBB2r7KHtyThmGJTSk85OFkMFp+e425RgjWa76WtIEQ/1W3y4Mq4DHOSPKs8dNre5eQ== tjyrinki@duuni</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEApPAl5qwDZNMJ2rfGPOPqcfZImhQgY2EoXqMGzPanxLqr9+NOrRjkBZjA7TK8v15dcLHR6KyhZKzrhyH3ZEKiOZPUStaxL1dBBKQvNBXODBcUrGCmBJ9pbswrNRVYXeD1J8l+7EZc6dNDntM+qvpuREKc9SHWB+IsFyJO2ZX3Ol2NbL+x+ajrtJIPbIUyI2ofxJX8xkO1VOVvn4eGWi1AZcNDhIbC9NoaIhwTcV/bKOuDxPxbB+H7NUKkzLJXomm/gpOxQH83/BY5DI49EKs4dNEs4BfzBQbOnS2T9ruL+ysf53dVugfmNjhNYMj50PJQSuU3fRtWwm1tjhjC88s5gw== tyuan@sles-11-sp1</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA5awrD4By2sc7cyYTQQ00EoAj3HN/uNAbN6artg2j8GQ8E8cD7a6rogTaoR1Awmb/QcvYEwf6l9C5i10PvA/T77D5kUAch9NGBiLlKcPkJb3luJ5OUJZp7z8gFJHhTJzhcClUN9HGEPdsctRfP8rdAAdefO/4vB+nv4u8SU3TeMRHTD2g3qJUN+PP46p2zLgSHb+lP/1qnPhlOHAD0pjCpla4MzMdQ2vH64DJvjRHAy2j+uS/Lsh8Puqv9Wjc1CecAuVo/CHSWKMuwLOF13tMSKqR1U513hYjN0HK37TYPzzObCLHFFbfZ6sRdORDhkADAtYQQqqdvLCmxY0hmPzv vcuadradojuan@suse.de</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA0SvnKlJU4QDg/F5nTV6JdTigJ/8nluhdk7i85p0b7FA/PXhrjbLxE1DjSwp7GoFVOoYw7GABzc8xucQteaq/96qDGvPhK6DSKkn+mFaxekBvKoaKMJ//SZtX4kdrvV2BozddsJBt2SkessEfZ7MddgmIxzRJRskzeaXWv3sB0aNIWPMq4dl8iMeapkjazX+OtcmeqCqW5YrLNKpH0ECuzylbku0AOblX+EJsd1dP/QbHOrUn+CXhonDtHKyY3lE04H4qqj9u2fyK9eZ/8ReCqvg1vhWsqr0xcmhzf30Mt9FdA4lW/gk6ibP7MxnQLgzcnO4oP1+3lxa7/ZDeBiQDyQ== vpelcak@vini</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDINt0FdONw9xs1VoD54m20DbFbb2ZywrZlkAqz7KZajPx3FDTwdKeIg46RemjvCp0JS1Y/Seg1Trgy5/4mcz7NgL29fE8+8tY6YcRptApBmJBZqM+GxnYtonOTW+rILvDCLJFgwsa2vqqIkoKzYDGuAhriR85EvbZ8hUl7kw3zHG5hAGo8DLDdKLh2Qwmd82V0GwCOqeWicF2P7ybspZT967oYQlIONhokGfcJG+k/BEJ2nSICgz07WGpdewiqmpGighoK356Lb7S/EnQin2ON+fDSlStuIMqYq0OBQaq8Ow2l7lZybEwcyqTLmhJ7K+NYwoQtQ0RKXtPZSfir9pwX vsistek@kobe.suse.cz</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/btcgaiVrttV5k27lKVobH7ovpM5b2PKM3oOJIg9aEnpZ+56xuwJ+W1y8lX7SwRdjLOX1FhX6bR6oKSb5FdcWEF1r6Wx/DR7GEDiKiPxRBKI6Es2G0IshoJ1LhBlCdIfOHym3nD1p9IyQWIBuySbSpnBlKV/F2DrNF2twVdZf+eX6LPtDGwFVwzAV07+SktR8eRET+O6Io+WNEnK4RshwM7rqDEkBbPoXpnbRaTZeJiaS4vIZX+sHwXKQ3+pExknFqglszOVys/hCLY5wzA0qh3GTx+rEU2Lyqhtj1w8G/PSf0CXEnR/bvwzGjvj9FP3OKgCdCo5+4alnHY7ipezV vsvecova</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDRCckXwmjSPFDPc72OyQdTDzXlMfLvnXd7871dCXCbmJu0Kz39yICB15+rjquN0xdykvG+Wc1E8kT5wepTSMd2rQDiUJKU6CnEu1zQ3g9Pm8RI5F0bcomQgxGKGgR+GeiiycdIhnqVz2R1HoovWUW9g0vB9qXdQBZcT0Y3aE9EqpgyJNW8pwqJ4/8d8gMMy5bfKvVjI7c+713JVFHAyaFq5FvOfP3Hkuc4WNyzbJKwgLeVW1IdFN6kNp0clLZrtq9RMC8kL+K9Sf0wzEuF/Zq/tiuwFakRk5cfmvG3nWNiw2VwmNf59VmPjGjWcLMEz0sRpxYzXjfePpAG0x1lqru5 balogh@wurst</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDESLvddZq3NEvG8aGNBYKBdB8cTnE8EZS/giVhjXr0R+GJbbTKHhWFT2fToK6qbYtLWRPh2Ep5kA9gfj1I2J+XBbkDjDVCgqRUs1dY00bkf7Hej1RdivNbUT27p4Qzm+eePU22gymVKgR5cgEtgZ6h5XCZEMfUdD49YIRv6PiNmms5ik8kKaEUi0MkfCL3tUivE5cFgGI8pANyde3vJThbpoZFVMEz9ddjg+j3N7SLVFZVX+HAAR8oY2wg6q82yUHCTxbM5DP1ier27uost+d8KsBBiI/hJ7XAndO/NE9HFz6Jb0YQrNYeIBqS7lsTe4EGDfeZ6HPHbcFq4RBl+vp3 zkubala</listentry>
+      </authorized_keys>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$6$0j9BcmPB$GiYIY25FbnEPQIL8Rs/ShAAm3UzN0ZunHQCW0e0hDzS.xT69dmNsAJI6gatBEskzeXT2hUkQUo8LnFB2JqlXW.</user_password>
+      <username>root</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Manual pages viewer</fullname>
+      <gid>62</gid>
+      <home>/var/cache/man</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>13</uid>
+      <user_password>*</user_password>
+      <username>man</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>NTP daemon</fullname>
+      <gid>490</gid>
+      <home>/var/lib/ntp</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>74</uid>
+      <user_password>!</user_password>
+      <username>ntp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Gnome Display Manager daemon</fullname>
+      <gid>483</gid>
+      <home>/var/lib/gdm</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>484</uid>
+      <user_password>!</user_password>
+      <username>gdm</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Postfix Daemon</fullname>
+      <gid>51</gid>
+      <home>/var/spool/postfix</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>51</uid>
+      <user_password>!</user_password>
+      <username>postfix</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>WWW daemon apache</fullname>
+      <gid>8</gid>
+      <home>/var/lib/wwwrun</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>30</uid>
+      <user_password>*</user_password>
+      <username>wwwrun</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>RealtimeKit</fullname>
+      <gid>488</gid>
+      <home>/proc</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>488</uid>
+      <user_password>!</user_password>
+      <username>rtkit</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for GeoClue D-Bus service</fullname>
+      <gid>65534</gid>
+      <home>/var/lib/srvGeoClue</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>486</uid>
+      <user_password>!</user_password>
+      <username>srvGeoClue</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for D-Bus</fullname>
+      <gid>499</gid>
+      <home>/var/run/dbus</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>499</uid>
+      <user_password>!</user_password>
+      <username>messagebus</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Printing daemon</fullname>
+      <gid>7</gid>
+      <home>/var/spool/lpd</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>4</uid>
+      <user_password>*</user_password>
+      <username>lp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>News system</fullname>
+      <gid>13</gid>
+      <home>/etc/news</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>9</uid>
+      <user_password>*</user_password>
+      <username>news</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>user for rpcbind</fullname>
+      <gid>65534</gid>
+      <home>/var/lib/empty</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>495</uid>
+      <user_password>!</user_password>
+      <username>rpc</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>bin</fullname>
+      <gid>1</gid>
+      <home>/bin</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1</uid>
+      <user_password>*</user_password>
+      <username>bin</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>TSS daemon</fullname>
+      <gid>98</gid>
+      <home>/var/lib/tpm</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>98</uid>
+      <user_password>!</user_password>
+      <username>tss</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>nobody</fullname>
+      <gid>65533</gid>
+      <home>/var/lib/nobody</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>65534</uid>
+      <user_password>*</user_password>
+      <username>nobody</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for nscd</fullname>
+      <gid>494</gid>
+      <home>/run/nscd</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>496</uid>
+      <user_password>!</user_password>
+      <username>nscd</username>
+    </user>
+  </users>
+</profile>

--- a/data/autoyast_xen/xen-SLES12-SP4-PV.xml
+++ b/data/autoyast_xen/xen-SLES12-SP4-PV.xml
@@ -1,0 +1,1798 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url><![CDATA[http://download.suse.de/ibs/QA:/SLE12SP4/update/]]></media_url>
+        <product>qa</product>
+        <product_dir/>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[http://smt-scc.nue.suse.com/repo/SUSE/Products/SLE-SDK/12-SP4/x86_64/product?credentials=SMT-http_smt-scc_nue_suse_com]]></media_url>
+        <product>sle-sdk</product>
+        <product_dir/>
+      </listentry>
+    </add_on_products>
+  </add-on>
+  <bootloader>
+    <global>
+      <activate>true</activate>
+      <append>resume=/dev/xvda1 splash=silent quiet showopts</append>
+      <boot_boot>false</boot_boot>
+      <boot_extended>false</boot_extended>
+      <boot_mbr>false</boot_mbr>
+      <boot_root>true</boot_root>
+      <generic_mbr>true</generic_mbr>
+      <gfxmode>auto</gfxmode>
+      <hiddenmenu>false</hiddenmenu>
+      <os_prober>false</os_prober>
+      <terminal>gfxterm</terminal>
+      <timeout config:type="integer">8</timeout>
+      <trusted_grub>false</trusted_grub>
+      <xen_kernel_append>vga=gfx-1024x768x16</xen_kernel_append>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <ca_mgm>
+    <CAName>YaST_Default_CA</CAName>
+    <ca_commonName>YaST Default CA (suse.cz)</ca_commonName>
+    <country>US</country>
+    <locality/>
+    <organisation/>
+    <organisationUnit/>
+    <password>ENTER PASSWORD HERE</password>
+    <server_email>postmaster@suse.cz</server_email>
+    <state/>
+    <takeLocalServerName config:type="boolean">true</takeLocalServerName>
+  </ca_mgm>
+  <deploy_image>
+    <image_installation config:type="boolean">false</image_installation>
+  </deploy_image>
+  <firewall>
+    <FW_ALLOW_FW_BROADCAST_DMZ>no</FW_ALLOW_FW_BROADCAST_DMZ>
+    <FW_ALLOW_FW_BROADCAST_EXT>no</FW_ALLOW_FW_BROADCAST_EXT>
+    <FW_ALLOW_FW_BROADCAST_INT>no</FW_ALLOW_FW_BROADCAST_INT>
+    <FW_BOOT_FULL_INIT>no</FW_BOOT_FULL_INIT>
+    <FW_CONFIGURATIONS_DMZ>sshd</FW_CONFIGURATIONS_DMZ>
+    <FW_CONFIGURATIONS_EXT>hamsta sshd</FW_CONFIGURATIONS_EXT>
+    <FW_CONFIGURATIONS_INT>sshd</FW_CONFIGURATIONS_INT>
+    <FW_DEV_DMZ/>
+    <FW_DEV_EXT/>
+    <FW_DEV_INT/>
+    <FW_FORWARD_ALWAYS_INOUT_DEV/>
+    <FW_FORWARD_MASQ/>
+    <FW_IGNORE_FW_BROADCAST_DMZ>no</FW_IGNORE_FW_BROADCAST_DMZ>
+    <FW_IGNORE_FW_BROADCAST_EXT>yes</FW_IGNORE_FW_BROADCAST_EXT>
+    <FW_IGNORE_FW_BROADCAST_INT>no</FW_IGNORE_FW_BROADCAST_INT>
+    <FW_IPSEC_TRUST>no</FW_IPSEC_TRUST>
+    <FW_LOAD_MODULES>nf_conntrack_netbios_ns</FW_LOAD_MODULES>
+    <FW_LOG_ACCEPT_ALL>no</FW_LOG_ACCEPT_ALL>
+    <FW_LOG_ACCEPT_CRIT>yes</FW_LOG_ACCEPT_CRIT>
+    <FW_LOG_DROP_ALL>no</FW_LOG_DROP_ALL>
+    <FW_LOG_DROP_CRIT>yes</FW_LOG_DROP_CRIT>
+    <FW_MASQUERADE>no</FW_MASQUERADE>
+    <FW_PROTECT_FROM_INT>no</FW_PROTECT_FROM_INT>
+    <FW_ROUTE>no</FW_ROUTE>
+    <FW_SERVICES_ACCEPT_DMZ/>
+    <FW_SERVICES_ACCEPT_EXT/>
+    <FW_SERVICES_ACCEPT_INT/>
+    <FW_SERVICES_ACCEPT_RELATED_DMZ/>
+    <FW_SERVICES_ACCEPT_RELATED_EXT/>
+    <FW_SERVICES_ACCEPT_RELATED_INT/>
+    <FW_SERVICES_DMZ_IP/>
+    <FW_SERVICES_DMZ_RPC/>
+    <FW_SERVICES_DMZ_TCP/>
+    <FW_SERVICES_DMZ_UDP/>
+    <FW_SERVICES_EXT_IP/>
+    <FW_SERVICES_EXT_RPC/>
+    <FW_SERVICES_EXT_TCP/>
+    <FW_SERVICES_EXT_UDP/>
+    <FW_SERVICES_INT_IP/>
+    <FW_SERVICES_INT_RPC/>
+    <FW_SERVICES_INT_TCP/>
+    <FW_SERVICES_INT_UDP/>
+    <FW_STOP_KEEP_ROUTING_STATE>no</FW_STOP_KEEP_ROUTING_STATE>
+    <enable_firewall config:type="boolean">true</enable_firewall>
+    <start_firewall config:type="boolean">true</start_firewall>
+  </firewall>
+  <general>
+    <ask-list config:type="list"/>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+    <proposals config:type="list"/>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">true</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+    <storage>
+      <partition_alignment config:type="symbol">align_optimal</partition_alignment>
+      <start_multipath config:type="boolean">false</start_multipath>
+    </storage>
+  </general>
+  <groups config:type="list">
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>100</gid>
+      <group_password>x</group_password>
+      <groupname>users</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>17</gid>
+      <group_password>x</group_password>
+      <groupname>audio</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>485</gid>
+      <group_password>x</group_password>
+      <groupname>vnc</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>54</gid>
+      <group_password>x</group_password>
+      <groupname>lock</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>3</gid>
+      <group_password>x</group_password>
+      <groupname>sys</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>496</gid>
+      <group_password>x</group_password>
+      <groupname>input</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>49</gid>
+      <group_password>x</group_password>
+      <groupname>ftp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>487</gid>
+      <group_password>x</group_password>
+      <groupname>pulse</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>8</gid>
+      <group_password>x</group_password>
+      <groupname>www</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>40</gid>
+      <group_password>x</group_password>
+      <groupname>games</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>493</gid>
+      <group_password>x</group_password>
+      <groupname>systemd-journal</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>62</gid>
+      <group_password>x</group_password>
+      <groupname>man</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>65534</gid>
+      <group_password>x</group_password>
+      <groupname>nogroup</groupname>
+      <userlist>nobody</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>483</gid>
+      <group_password>x</group_password>
+      <groupname>adm</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>1</gid>
+      <group_password>x</group_password>
+      <groupname>bin</groupname>
+      <userlist>daemon</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>492</gid>
+      <group_password>x</group_password>
+      <groupname>systemd-timesync</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>494</gid>
+      <group_password>x</group_password>
+      <groupname>nscd</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>19</gid>
+      <group_password>x</group_password>
+      <groupname>floppy</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>33</gid>
+      <group_password>x</group_password>
+      <groupname>video</groupname>
+      <userlist>gdm</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>495</gid>
+      <group_password>x</group_password>
+      <groupname>polkitd</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>98</gid>
+      <group_password>x</group_password>
+      <groupname>tss</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>489</gid>
+      <group_password>x</group_password>
+      <groupname>rtkit</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>21</gid>
+      <group_password>x</group_password>
+      <groupname>console</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>486</gid>
+      <group_password>x</group_password>
+      <groupname>pulse-access</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>51</gid>
+      <group_password>x</group_password>
+      <groupname>postfix</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>0</gid>
+      <group_password>x</group_password>
+      <groupname>root</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>499</gid>
+      <group_password>x</group_password>
+      <groupname>messagebus</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>488</gid>
+      <group_password>x</group_password>
+      <groupname>brlapi</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>20</gid>
+      <group_password>x</group_password>
+      <groupname>cdrom</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>16</gid>
+      <group_password>x</group_password>
+      <groupname>dialout</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>22</gid>
+      <group_password>x</group_password>
+      <groupname>utmp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>13</gid>
+      <group_password>x</group_password>
+      <groupname>news</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>42</gid>
+      <group_password>x</group_password>
+      <groupname>trusted</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>41</gid>
+      <group_password>x</group_password>
+      <groupname>xok</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>490</gid>
+      <group_password>x</group_password>
+      <groupname>scard</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>32</gid>
+      <group_password>x</group_password>
+      <groupname>public</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>7</gid>
+      <group_password>x</group_password>
+      <groupname>lp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>14</gid>
+      <group_password>x</group_password>
+      <groupname>uucp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>491</gid>
+      <group_password>x</group_password>
+      <groupname>ntp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>59</gid>
+      <group_password>x</group_password>
+      <groupname>maildrop</groupname>
+      <userlist>postfix</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>6</gid>
+      <group_password>x</group_password>
+      <groupname>disk</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>12</gid>
+      <group_password>x</group_password>
+      <groupname>mail</groupname>
+      <userlist>postfix</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>9</gid>
+      <group_password>x</group_password>
+      <groupname>kmem</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>25</gid>
+      <group_password>x</group_password>
+      <groupname>at</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>5</gid>
+      <group_password>x</group_password>
+      <groupname>tty</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>484</gid>
+      <group_password>x</group_password>
+      <groupname>gdm</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>65533</gid>
+      <group_password>x</group_password>
+      <groupname>nobody</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>71</gid>
+      <group_password>x</group_password>
+      <groupname>ntadmin</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>15</gid>
+      <group_password>x</group_password>
+      <groupname>shadow</groupname>
+      <userlist>vnc</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>497</gid>
+      <group_password>x</group_password>
+      <groupname>tape</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>498</gid>
+      <group_password>x</group_password>
+      <groupname>sshd</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>2</gid>
+      <group_password>x</group_password>
+      <groupname>daemon</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>10</gid>
+      <group_password>x</group_password>
+      <groupname>wheel</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>43</gid>
+      <group_password>x</group_password>
+      <groupname>modem</groupname>
+      <userlist/>
+    </group>
+  </groups>
+  <host>
+    <hosts config:type="list">
+      <hosts_entry>
+        <host_address>127.0.0.1</host_address>
+        <names config:type="list">
+          <name>localhost</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>::1</host_address>
+        <names config:type="list">
+          <name>localhost ipv6-localhost ipv6-loopback</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>fe00::0</host_address>
+        <names config:type="list">
+          <name>ipv6-localnet</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff00::0</host_address>
+        <names config:type="list">
+          <name>ipv6-mcastprefix</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::1</host_address>
+        <names config:type="list">
+          <name>ipv6-allnodes</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::2</host_address>
+        <names config:type="list">
+          <name>ipv6-allrouters</name>
+        </names>
+      </hosts_entry>
+      <hosts_entry>
+        <host_address>ff02::3</host_address>
+        <names config:type="list">
+          <name>ipv6-allhosts</name>
+        </names>
+      </hosts_entry>
+    </hosts>
+  </host>
+  <kdump>
+    <add_crash_kernel config:type="boolean">false</add_crash_kernel>
+    <crash_kernel config:type="list"/>
+    <crash_xen_kernel config:type="list"/>
+    <general>
+      <KDUMPTOOL_FLAGS/>
+      <KDUMP_COMMANDLINE/>
+      <KDUMP_COMMANDLINE_APPEND/>
+      <KDUMP_CONTINUE_ON_ERROR>true</KDUMP_CONTINUE_ON_ERROR>
+      <KDUMP_COPY_KERNEL>yes</KDUMP_COPY_KERNEL>
+      <KDUMP_CPUS>1</KDUMP_CPUS>
+      <KDUMP_DUMPFORMAT>compressed</KDUMP_DUMPFORMAT>
+      <KDUMP_DUMPLEVEL>31</KDUMP_DUMPLEVEL>
+      <KDUMP_FREE_DISK_SIZE>64</KDUMP_FREE_DISK_SIZE>
+      <KDUMP_HOST_KEY/>
+      <KDUMP_IMMEDIATE_REBOOT>yes</KDUMP_IMMEDIATE_REBOOT>
+      <KDUMP_KEEP_OLD_DUMPS>5</KDUMP_KEEP_OLD_DUMPS>
+      <KDUMP_KERNELVER/>
+      <KDUMP_NETCONFIG>auto</KDUMP_NETCONFIG>
+      <KDUMP_NET_TIMEOUT>30</KDUMP_NET_TIMEOUT>
+      <KDUMP_NOTIFICATION_CC/>
+      <KDUMP_NOTIFICATION_TO/>
+      <KDUMP_POSTSCRIPT/>
+      <KDUMP_PRESCRIPT/>
+      <KDUMP_REQUIRED_PROGRAMS/>
+      <KDUMP_SAVEDIR>file:///var/crash</KDUMP_SAVEDIR>
+      <KDUMP_SMTP_PASSWORD/>
+      <KDUMP_SMTP_SERVER/>
+      <KDUMP_SMTP_USER/>
+      <KDUMP_TRANSFER/>
+      <KDUMP_VERBOSE>3</KDUMP_VERBOSE>
+      <KEXEC_OPTIONS/>
+    </general>
+  </kdump>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <login_settings/>
+  <networking>
+    <dhcp_options>
+      <dhclient_client_id/>
+      <dhclient_hostname_option>AUTO</dhclient_hostname_option>
+    </dhcp_options>
+    <dns>
+      <dhcp_hostname config:type="boolean">true</dhcp_hostname>
+      <domain>suse.cz</domain>
+      <hostname>dhcp147</hostname>
+      <resolv_conf_policy>auto</resolv_conf_policy>
+      <write_hostname config:type="boolean">false</write_hostname>
+    </dns>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <startmode>auto</startmode>
+      </interface>
+      <interface>
+        <bootproto>static</bootproto>
+        <device>lo</device>
+        <firewall>no</firewall>
+        <ipaddr>127.0.0.1</ipaddr>
+        <netmask>255.0.0.0</netmask>
+        <network>127.0.0.0</network>
+        <prefixlen>8</prefixlen>
+        <startmode>nfsroot</startmode>
+        <usercontrol>no</usercontrol>
+      </interface>
+    </interfaces>
+    <ipv6 config:type="boolean">true</ipv6>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+    <managed config:type="boolean">false</managed>
+    <net-udev config:type="list">
+      <rule>
+        <name>eth0</name>
+        <rule>ATTR{address}</rule>
+        <value>00:16:3e:b9:07:bd</value>
+      </rule>
+    </net-udev>
+    <routing>
+      <ipv4_forward config:type="boolean">false</ipv4_forward>
+      <ipv6_forward config:type="boolean">false</ipv6_forward>
+    </routing>
+  </networking>
+  <nis>
+    <netconfig_policy>auto</netconfig_policy>
+    <nis_broadcast config:type="boolean">false</nis_broadcast>
+    <nis_broken_server config:type="boolean">false</nis_broken_server>
+    <nis_domain/>
+    <nis_local_only config:type="boolean">false</nis_local_only>
+    <nis_options/>
+    <nis_other_domains config:type="list"/>
+    <nis_servers config:type="list"/>
+    <slp_domain/>
+    <start_autofs config:type="boolean">false</start_autofs>
+    <start_nis config:type="boolean">false</start_nis>
+  </nis>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list">
+      <peer>
+        <address>/var/lib/ntp/drift/ntp.drift</address>
+        <comment># path for drift file</comment>
+        <options/>
+        <type>driftfile</type>
+      </peer>
+      <peer>
+        <address>/var/log/ntp</address>
+        <comment># alternate log file</comment>
+        <options/>
+        <type>logfile</type>
+      </peer>
+      <peer>
+        <address>/etc/ntp.keys</address>
+        <comment># path for keys file</comment>
+        <options/>
+        <type>keys</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># define trusted keys</comment>
+        <options/>
+        <type>trustedkey</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># key (7) for accessing server variables</comment>
+        <options/>
+        <type>requestkey</type>
+      </peer>
+      <peer>
+        <address>1</address>
+        <comment># key (6) for accessing server variables</comment>
+        <options/>
+        <type>controlkey</type>
+      </peer>
+      <peer>
+        <address>ntp.suse.cz</address>
+        <comment/>
+        <options/>
+        <type>server</type>
+      </peer>
+    </peers>
+    <restricts config:type="list">
+      <restrict>
+        <comment/>
+        <mask/>
+        <options>ipv6 notrap nomodify nopeer noquery</options>
+        <target>default</target>
+      </restrict>
+      <restrict>
+        <comment/>
+        <mask/>
+        <options/>
+        <target>127.0.0.1</target>
+      </restrict>
+      <restrict>
+        <comment/>
+        <mask/>
+        <options/>
+        <target>::1</target>
+      </restrict>
+    </restricts>
+    <start_at_boot config:type="boolean">true</start_at_boot>
+    <start_in_chroot config:type="boolean">false</start_in_chroot>
+    <sync_interval config:type="integer">5</sync_interval>
+    <synchronize_time config:type="boolean">false</synchronize_time>
+  </ntp-client>
+  <partitioning config:type="list">
+    <drive>
+      <device>/dev/xvda</device>
+      <disklabel>msdos</disklabel>
+      <enable_snapshots config:type="boolean">true</enable_snapshots>
+      <initialize config:type="boolean">true</initialize>
+      <partitions config:type="list">
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">swap</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>swap</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">130</partition_id>
+          <partition_nr config:type="integer">1</partition_nr>
+          <partition_type>primary</partition_type>
+          <resize config:type="boolean">false</resize>
+          <size>2145549824</size>
+        </partition>
+        <partition>
+          <create config:type="boolean">true</create>
+          <crypt_fs config:type="boolean">false</crypt_fs>
+          <filesystem config:type="symbol">btrfs</filesystem>
+          <format config:type="boolean">true</format>
+          <fstopt>defaults</fstopt>
+          <loop_fs config:type="boolean">false</loop_fs>
+          <mount>/</mount>
+          <mountby config:type="symbol">uuid</mountby>
+          <partition_id config:type="integer">131</partition_id>
+          <partition_nr config:type="integer">2</partition_nr>
+          <partition_type>primary</partition_type>
+          <resize config:type="boolean">false</resize>
+          <size>6711787520</size>
+          <subvolumes config:type="list">
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>boot/grub2/i386-pc</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>boot/grub2/x86_64-efi</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>home</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>opt</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>srv</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>tmp</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>usr/local</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/cache</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/crash</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">false</copy_on_write>
+              <path>var/lib/libvirt/images</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/lib/machines</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/lib/mailman</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">false</copy_on_write>
+              <path>var/lib/mariadb</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">false</copy_on_write>
+              <path>var/lib/mysql</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/lib/named</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">false</copy_on_write>
+              <path>var/lib/pgsql</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/log</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/opt</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/spool</path>
+            </listentry>
+            <listentry>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>var/tmp</path>
+            </listentry>
+          </subvolumes>
+        </partition>
+      </partitions>
+      <pesize/>
+      <type config:type="symbol">CT_DISK</type>
+      <use>all</use>
+    </drive>
+  </partitioning>
+  <printer>
+    <client_conf_content>
+      <file_contents><![CDATA[# CUPS client configuration file (optional).
+
+# You may use /etc/cups/client.conf (system wide)
+# or ~/.cups/client.conf (per user).
+# For more information see "man 5 client.conf".
+
+# The ServerName directive specifies the remote server
+# that is to be used for all client operations. That is, it
+# redirects all client requests directly to that remote server
+# so that a local running cupsd is not used in this case.
+# The default is to use the local server ("localhost") or domain socket.
+# Only one ServerName directive may appear.
+# If multiple names are present, only the last one is used.
+# The default port number is 631 but can be overridden by adding
+# a colon followed by the desired port number.
+# The default IPP version is 2.0 but can be overridden by adding
+# a slash followed by version=V where V is 1.0 or 1.1 or 2.0 or 2.1 or 2.2.
+# IPP version 2.0 does do not work with CUPS 1.3 or older servers.
+# If an CUPS 1.3 or older server is used, its older IPP version
+# must be specified as .../version=1.1 or .../version=1.0.
+
+# Examples:
+# ServerName sever.example.com
+# ServerName 192.0.2.10
+# ServerName sever.example.com:8631
+# ServerName older.server.example.com/version=1.1
+# ServerName older.server.example.com:8631/version=1.1
+
+]]></file_contents>
+    </client_conf_content>
+    <cupsd_conf_content>
+      <file_contents><![CDATA[#
+# "$Id: cupsd.conf.in 11025 2013-06-07 01:00:33Z msweet $"
+#
+# Configuration file for the CUPS scheduler.  See "man cupsd.conf" for a
+# complete description of this file.
+#
+
+# Log general information in error_log - change "warn" to "debug"
+# for troubleshooting...
+LogLevel warn
+
+# Only listen for connections from the local machine.
+Listen localhost:631
+Listen /run/cups/cups.sock
+
+# Show shared printers on the local network.
+Browsing On
+BrowseLocalProtocols dnssd
+
+# Default authentication type, when authentication is required...
+DefaultAuthType Basic
+
+# Web interface setting...
+WebInterface Yes
+
+# Restrict access to the server...
+<Location />
+  Order allow,deny
+</Location>
+
+# Restrict access to the admin pages...
+<Location /admin>
+  Order allow,deny
+</Location>
+
+# Restrict access to configuration files...
+<Location /admin/conf>
+  AuthType Default
+  Require user @SYSTEM
+  Order allow,deny
+</Location>
+
+# Set the default printer/job policies...
+<Policy default>
+  # Job/subscription privacy...
+  JobPrivateAccess default
+  JobPrivateValues default
+  SubscriptionPrivateAccess default
+  SubscriptionPrivateValues default
+
+  # Job-related operations must be done by the owner or an administrator...
+  <Limit Create-Job Print-Job Print-URI Validate-Job>
+    Order deny,allow
+  </Limit>
+
+  <Limit Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job Cancel-My-Jobs Close-Job CUPS-Move-Job CUPS-Get-Document>
+    Require user @OWNER @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # All administration operations require an administrator to authenticate...
+  <Limit CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default CUPS-Get-Devices>
+    AuthType Default
+    Require user @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # All printer operations require a printer operator to authenticate...
+  <Limit Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After Cancel-Jobs CUPS-Accept-Jobs CUPS-Reject-Jobs>
+    AuthType Default
+    Require user @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # Only the owner or an administrator can cancel or authenticate a job...
+  <Limit Cancel-Job CUPS-Authenticate-Job>
+    Require user @OWNER @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  <Limit All>
+    Order deny,allow
+  </Limit>
+</Policy>
+
+# Set the authenticated printer/job policies...
+<Policy authenticated>
+  # Job/subscription privacy...
+  JobPrivateAccess default
+  JobPrivateValues default
+  SubscriptionPrivateAccess default
+  SubscriptionPrivateValues default
+
+  # Job-related operations must be done by the owner or an administrator...
+  <Limit Create-Job Print-Job Print-URI Validate-Job>
+    AuthType Default
+    Order deny,allow
+  </Limit>
+
+  <Limit Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job Cancel-My-Jobs Close-Job CUPS-Move-Job CUPS-Get-Document>
+    AuthType Default
+    Require user @OWNER @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # All administration operations require an administrator to authenticate...
+  <Limit CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default>
+    AuthType Default
+    Require user @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # All printer operations require a printer operator to authenticate...
+  <Limit Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs Deactivate-Printer Activate-Printer Restart-Printer Shutdown-Printer Startup-Printer Promote-Job Schedule-Job-After Cancel-Jobs CUPS-Accept-Jobs CUPS-Reject-Jobs>
+    AuthType Default
+    Require user @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  # Only the owner or an administrator can cancel or authenticate a job...
+  <Limit Cancel-Job CUPS-Authenticate-Job>
+    AuthType Default
+    Require user @OWNER @SYSTEM
+    Order deny,allow
+  </Limit>
+
+  <Limit All>
+    Order deny,allow
+  </Limit>
+</Policy>
+
+# The policy below is added by SUSE during build of our cups package.
+# The policy 'allowallforanybody' is totally open and insecure and therefore
+# it can only be used within an internal network where only trused users exist
+# and where the cupsd is not accessible at all from any external host, see
+# http://en.opensuse.org/SDB:CUPS_and_SANE_Firewall_settings
+# Have in mind that any user who is allowed to do printer admin tasks
+# can change the print queues as he likes - e.g. send copies of confidental
+# print jobs from an internal network to any external destination, see
+# http://en.opensuse.org/SDB:CUPS_in_a_Nutshell
+# For documentation regarding 'Managing Operation Policies' see
+# http://www.cups.org/documentation.php/doc-1.7/policies.html
+<Policy allowallforanybody>
+  # Allow anybody to access job's private values:
+  JobPrivateAccess all
+  # Make none of the job values to be private:
+  JobPrivateValues none
+  # Allow anybody to access subscription's private values:
+  SubscriptionPrivateAccess all
+  # Make none of the subscription values to be private:
+  SubscriptionPrivateValues none
+  # Allow anybody to do all IPP operations:
+  # Currently the IPP operations Validate-Job Cancel-Jobs Cancel-My-Jobs Close-Job CUPS-Get-Document
+  # must be additionally exlicitly specified because those IPP operations are not included
+  # in the "All" wildcard value - otherwise cupsd prints error messages of the form
+  # "No limit for Validate-Job defined in policy allowallforanybody and no suitable template found."
+  <Limit All Validate-Job Cancel-Jobs Cancel-My-Jobs Close-Job CUPS-Get-Document>
+    Order deny,allow
+    Allow from all
+  </Limit>
+</Policy>
+# Explicitly set the CUPS 'default' policy to be used by default:
+DefaultPolicy default
+
+#
+# End of "$Id: cupsd.conf.in 11025 2013-06-07 01:00:33Z msweet $".
+#
+]]></file_contents>
+    </cupsd_conf_content>
+  </printer>
+  <proxy>
+    <enabled config:type="boolean">false</enabled>
+    <ftp_proxy/>
+    <http_proxy/>
+    <https_proxy/>
+    <no_proxy>localhost, 127.0.0.1</no_proxy>
+    <proxy_password/>
+    <proxy_user/>
+  </proxy>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <services-manager>
+    <default_target>graphical</default_target>
+    <services>
+      <disable config:type="list"/>
+      <enable config:type="list">
+        <service>apparmor</service>
+        <service>btrfsmaintenance-refresh</service>
+        <service>cron</service>
+        <service>display-manager</service>
+        <service>haveged</service>
+        <service>irqbalance</service>
+        <service>iscsi</service>
+        <service>mcelog</service>
+        <service>nscd</service>
+        <service>ntpd</service>
+        <service>postfix</service>
+        <service>purge-kernels</service>
+        <service>rollback</service>
+        <service>rsyslog</service>
+        <service>smartd</service>
+        <service>sshd</service>
+        <service>SuSEfirewall2</service>
+        <service>SuSEfirewall2_init</service>
+        <service>wicked</service>
+        <service>wickedd-auto4</service>
+        <service>wickedd-dhcp4</service>
+        <service>wickedd-dhcp6</service>
+        <service>wickedd-nanny</service>
+        <service>YaST2-Firstboot</service>
+        <service>YaST2-Second-Stage</service>
+        <service>getty@tty1</service>
+      </enable>
+    </services>
+  </services-manager>
+  <software>
+    <image/>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <instsource/>
+    <packages config:type="list">
+      <package>xen-tools-domU</package>
+      <package>xen-libs</package>
+      <package>snapper</package>
+      <package>sles-release</package>
+      <package>sle-sdk-release</package>
+      <package>qa_test_ltp</package>
+      <package>qa-release</package>
+      <package>openssh</package>
+      <package>numactl</package>
+      <package>kexec-tools</package>
+      <package>kernel-source</package>
+      <package>irqbalance</package>
+      <package>grub2</package>
+      <package>glibc</package>
+      <package>e2fsprogs</package>
+      <package>btrfsprogs</package>
+      <package>SuSEfirewall2</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>32bit</pattern>
+      <pattern>Minimal</pattern>
+      <pattern>apparmor</pattern>
+      <pattern>base</pattern>
+      <pattern>documentation</pattern>
+      <pattern>gnome-basic</pattern>
+      <pattern>sles-Minimal-32bit</pattern>
+      <pattern>sles-apparmor-32bit</pattern>
+      <pattern>sles-base-32bit</pattern>
+      <pattern>sles-documentation-32bit</pattern>
+      <pattern>sles-x11-32bit</pattern>
+      <pattern>sles-yast2</pattern>
+      <pattern>x11</pattern>
+      <pattern>yast2</pattern>
+    </patterns>
+  </software>
+  <ssh_import>
+    <copy_config config:type="boolean">false</copy_config>
+    <import config:type="boolean">false</import>
+  </ssh_import>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Prague</timezone>
+  </timezone>
+  <user_defaults>
+    <expire/>
+    <group>100</group>
+    <groups/>
+    <home>/home</home>
+    <inactive>-1</inactive>
+    <no_groups config:type="boolean">true</no_groups>
+    <shell>/bin/bash</shell>
+    <skel>/etc/skel</skel>
+    <umask>022</umask>
+  </user_defaults>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>bhavel</fullname>
+      <gid>100</gid>
+      <home>/home/bhavel</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>$6$Z1//mRRi4Wi7$pj542CN2mF9osrp.Nh1s/8humD9Cv0GR3l7wPQ5vvVpGF6HqButz08w4Ilu4oM3vqr3i3LfsrSIvjh4yoozar1</user_password>
+      <username>bhavel</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>TSS daemon</fullname>
+      <gid>98</gid>
+      <home>/var/lib/tpm</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>98</uid>
+      <user_password>!</user_password>
+      <username>tss</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Daemon</fullname>
+      <gid>2</gid>
+      <home>/sbin</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>2</uid>
+      <user_password>*</user_password>
+      <username>daemon</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>NFS statd daemon</fullname>
+      <gid>65534</gid>
+      <home>/var/lib/nfs</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>490</uid>
+      <user_password>!</user_password>
+      <username>statd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>RealtimeKit</fullname>
+      <gid>489</gid>
+      <home>/proc</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>488</uid>
+      <user_password>!</user_password>
+      <username>rtkit</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Secure FTP User</fullname>
+      <gid>65534</gid>
+      <home>/var/lib/empty</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>491</uid>
+      <user_password>!</user_password>
+      <username>ftpsecure</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for polkitd</fullname>
+      <gid>495</gid>
+      <home>/var/lib/polkit</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>497</uid>
+      <user_password>!</user_password>
+      <username>polkitd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>SSH daemon</fullname>
+      <gid>498</gid>
+      <home>/var/lib/sshd</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>498</uid>
+      <user_password>!</user_password>
+      <username>sshd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>systemd Time Synchronization</fullname>
+      <gid>492</gid>
+      <home>/</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>492</uid>
+      <user_password>!!</user_password>
+      <username>systemd-timesync</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>WWW daemon apache</fullname>
+      <gid>8</gid>
+      <home>/var/lib/wwwrun</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>30</uid>
+      <user_password>*</user_password>
+      <username>wwwrun</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for nscd</fullname>
+      <gid>494</gid>
+      <home>/run/nscd</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>496</uid>
+      <user_password>!</user_password>
+      <username>nscd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>bin</fullname>
+      <gid>1</gid>
+      <home>/bin</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1</uid>
+      <user_password>*</user_password>
+      <username>bin</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>user for rpcbind</fullname>
+      <gid>65534</gid>
+      <home>/var/lib/empty</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>495</uid>
+      <user_password>!</user_password>
+      <username>rpc</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>openslp daemon</fullname>
+      <gid>2</gid>
+      <home>/var/lib/empty</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>494</uid>
+      <user_password>!</user_password>
+      <username>openslp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>nobody</fullname>
+      <gid>65533</gid>
+      <home>/var/lib/nobody</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>65534</uid>
+      <user_password>*</user_password>
+      <username>nobody</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Gnome Display Manager daemon</fullname>
+      <gid>484</gid>
+      <home>/var/lib/gdm</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>484</uid>
+      <user_password>!</user_password>
+      <username>gdm</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Manual pages viewer</fullname>
+      <gid>62</gid>
+      <home>/var/cache/man</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>13</uid>
+      <user_password>*</user_password>
+      <username>man</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Games account</fullname>
+      <gid>100</gid>
+      <home>/var/games</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>12</uid>
+      <user_password>*</user_password>
+      <username>games</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>PulseAudio daemon</fullname>
+      <gid>487</gid>
+      <home>/var/lib/pulseaudio</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>487</uid>
+      <user_password>!</user_password>
+      <username>pulse</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Batch jobs daemon</fullname>
+      <gid>25</gid>
+      <home>/var/spool/atjobs</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>25</uid>
+      <user_password>!</user_password>
+      <username>at</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>FTP account</fullname>
+      <gid>49</gid>
+      <home>/srv/ftp</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>40</uid>
+      <user_password>*</user_password>
+      <username>ftp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Mailer daemon</fullname>
+      <gid>12</gid>
+      <home>/var/spool/clientmqueue</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>8</uid>
+      <user_password>*</user_password>
+      <username>mail</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>NTP daemon</fullname>
+      <gid>491</gid>
+      <home>/var/lib/ntp</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>74</uid>
+      <user_password>!</user_password>
+      <username>ntp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Unix-to-Unix CoPy system</fullname>
+      <gid>14</gid>
+      <home>/etc/uucp</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>10</uid>
+      <user_password>*</user_password>
+      <username>uucp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for GeoClue D-Bus service</fullname>
+      <gid>65534</gid>
+      <home>/var/lib/srvGeoClue</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>486</uid>
+      <user_password>!</user_password>
+      <username>srvGeoClue</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Smart Card Reader</fullname>
+      <gid>490</gid>
+      <home>/var/run/pcscd</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/usr/sbin/nologin</shell>
+      <uid>489</uid>
+      <user_password>!</user_password>
+      <username>scard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Printing daemon</fullname>
+      <gid>7</gid>
+      <home>/var/spool/lpd</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>4</uid>
+      <user_password>*</user_password>
+      <username>lp</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>News system</fullname>
+      <gid>13</gid>
+      <home>/etc/news</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>9</uid>
+      <user_password>*</user_password>
+      <username>news</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for D-Bus</fullname>
+      <gid>499</gid>
+      <home>/var/run/dbus</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>499</uid>
+      <user_password>!</user_password>
+      <username>messagebus</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>user for VNC</fullname>
+      <gid>485</gid>
+      <home>/var/lib/empty</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>485</uid>
+      <user_password>!</user_password>
+      <username>vnc</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Postfix Daemon</fullname>
+      <gid>51</gid>
+      <home>/var/spool/postfix</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>51</uid>
+      <user_password>!</user_password>
+      <username>postfix</username>
+    </user>
+    <user>
+      <authorized_keys config:type="list">
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCXhKcpQFoQj3Abcwwohg3+L4OTe+kkavn8+kbHWfHeONgUs/azZzZ3aqtzxJ/7BILnGtAUPThfQaaDeTTUqcsihSZMNB820s0GC7Qifp/qVF41+G074Fx0iCyEytNNXWZqMNcDfhuU5GfoBvDImJaUVkXRyRg8GKiWbY66WFyczuXhIn86S1b5X/HdguQv54wlIjrak7YeXMylQHsber5JiLhb4gR3Th1s248GdFXHs116+lrXTwXoMVLbSJIpg3x+8jYV9oAhcAloY8ODnDVqv0+re+6P4DUuQr9dnOH+x9sTo8okjhJ/P9kyForKvLQtmbuopOWr46dhhaqNxuIv abodry@linkpad</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDzPeDKJW0N7OlFxVPEcnm5ThrtkjhA81wCA6DwKY667zJN1QCjzeWHn2cPwgB/WBMg+w9ovNBa0fUyogbFWMl+m0d9wX8+aMCqTyw/EhqUgyKfy1OxdNpF+BS5gpEueb0gX9tNVuWpfUnhtqInQOByYuCbkH4gbnw28pTCc2Fa1ngq0ZkhN1bctN9clf4hV/KOVGn9IvRdcSYyUsQKl0knLEX2ePxTjnLkdixjT7fUM8yfXWbxJcnlWUuPrTx0jBOQV3AKjFPD8JS9Oz+58J7UJoYpAx82D8mv9sC4Z2FNVhTnULeozDNE3HYEK55oy/aEXquSpmF08iQ4g5t2nfst antonio@linux-pnjx</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAtF9QjP13xfNCy4ClpnUCNNFslY/MxXI8OlL/2BIb4v6gXN1iZ1/VOVIjpGKiPl/rIH4xXED+QH8//dbPqz93dIP5HtL6YFazQ+IQKCs3VVSq+kl+fP5Rei8KuqF/EX6Loss6FSJXxovfnV+MmD9JU03zkqb2Z19cBHqtCPMRn9ReAPG6LvcAN/NatgOuVY1IQe3XTyZwfRq+CY+DE3KXManezLuo6ydMKBLjjeGG/I1HmcmRbl4HwQSkGkjsTI9UloDmkhLcMpivY2TCPcJUnM/cqvftmctzcdyxg2RsekSlST7dRf7z52ExJsqzAHoT/FhGbOOsNyakhA1iGawLaw== akong</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4bJFzZoGkEl67WQjrIPm2LdDKyrRzUrspv3NcxcztHkZaT8b9hy5CYSEk46biDyhbfjjH+QVXOVTOd+fXkGt22MRlhWMtRztowFQfKGiLFeJGaPu9mqcFAVjNJ3FljjLBxfieYWf1Q+GInsSlEoV246Kuj0GqZbfGSbjDnAmmDwWlL1e/x76QItdp90En68RhXMVjfQKDoPTzY5O+wQRGgtvJ3h9wuPCMDdhkPjcdcUzsiaDbYI7JrB3bHmz8LlqXF2mKjO4Xb1QMAQIFM0DrDHsLCKIJB74sDN+GRtpuH5rnbA+GqOWcBSthxx3xyVrwO73RcntndMkXpF7edaM1 aliouliaki@dhcp108.suse.cz</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC4wxEXPwOvpnnnbOVuEQMSJbjo8hGwEtJl8lugFTWVNpK/rIln3L+pyIwIdJuuti1fVpEIr9GqyI408/nqqEtRmIyMzrspC8FddIgRSMI6/lFU5WKojoIb+op5myuZMKzlk7h+EOsF+TFADokhgeTsHkr2HWbkGTj8oLgh6Wnz1DakY48cqlJemlWJWHTLavFBuYxEe12hrGumy89D1Wv16prnZ8pthH9tpdvxTJ9js26MnjoZf+MWQ0arFi2ZBL26zqgR0VOSTIEuzvP5OjBIMwjOG429ZM6HmpzFJCcPGT419OjO5jIOVHn7Kn1wqu75RVb96Ru4jfW07E30e6x/Vv0dc8HR04tIeX2pmAgQHGxZ2lbuI4bw+7YlbaxTlfiBGgKtHv2sNXyCheg7VLi/1fHrgXrP3X2MkfOKV+GTKw2VsEhZA6e5cM996OoPrY7T+h2gbNCFM/Acjmr/ECVIaBV4nJbKTld/ouikeM9ggUS35uWd5v3mwg6gEG3RyoUD7v4kMPSE/kfAoTqksxQsZFnEwO1ZmGiHPaHGT48EKbyzZBw0IXqdfhe8Aro33tnlyY7LtRpuHLeLE8/CCNlINw7aLoB8GYVc0F3Db1pEgyY4zDOSL6kZi22OaqJmsjYpJguZhWY3Kb8wJDPB/MUCSfeo5pz1n/iV4AyMQhJi6Q== apappas</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDM2zzv4kHo2Qnka0dn/02QEQhFwMnvzX1CGPh3cC+uK4okPHqusClRvEZGbAGMIQsv7N3t16B1wix3NeQGRsGhzE0zP/9OHyjzPicKx9lrZl+vqqFxUXT8s19uFt77B/q06k3ooqwc7t16y9PNASq8HJlX3ZPDls/f6YlT+oNpHShj5n5j9O1uac4fgAYNl7+SeNVkO8CP2D9zcdXRun69ojCNr5HOSaQte+Hjd5gTXpiLKhg2pU3HDR8TFogJmpiU9dbbZRwXPYFzGvEli1In0cIsdjx4Pk//Vx3vF31TiiKlcq5HZp91OoaUK6IZF//P60UAY3m7yi7AiVhqATNt atanno@linux-617q</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAD1XS+3hC5iITnHoj3Pgk+x+vPt2Qdm3hJ4/v24usyFFUmEom5B2LUannpB0ttUfFSSZ9XDpsGCIihyokenJMO3juW4qxJK39BeAOTl2TAA8ZT4jcww5cQxVk91u6Kh/ymGA0JBf5ya2BWZ/hc2MThajf/ICEhbtN60Bx3JTXhy2ULvsGiC3vbEXczWh3bhQGlP+agf1bmFIJVHDh9ZAsE9wHnUA47mPyUMvLbJkAn0GOR2OYO3UyGT+MNDqeNPJ87ohD3Ha5dVRDQFiRHSRE+jRlRFTG0Vl9PDmMp6/YNmHe72WduG8FVSF0IrtGz3736Zth4ozkO/4B1HHuKBUz atighineanu@e152</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDC96KGkd2pJUGTu9Jcz97lEiNs9uAhte+waY2grbA0+lOw+sPC/RlO4jgNPBAQd8LXYYLuCJBHw98mwcx0cb+BR4eidfq077u8/NbFEYVtzl0y8RWz4jksQHuLNhq6koEsndFhruakWbzULCwOzoe5KnmD/gjLiZqEEApB8MmekX/ffDeqZs4lDyT1SSdpFRDCgkhdiOnkFiBmI7KlT/Y8mrqKb0oiqKbF2qcvDFkV6JRh5qBIVv8Pbau98j3jHwtWP5wDP/pKDG7+kn1RmccxB4/sDrAxqY8psc3TyUIW6ElK1g3ABaYXxHk/DfksYvqX13YAv87HiRVskvI45dUJ jwbruno@linux-akhv</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDEfz0lP5oO03Rw8vSyzqwt06VIEFA4x478DERaSWHPTD5ULqqdZQS1vsFpTtAm1eT4Ix4njXvSh4T2d2aXYyCgB+ElJI1h0tpbtX7OtenJ7c3rUows61jqmXLFrnIfWbZL2uhomTsOziQwxKoXS3PRxFgoRaZGzHGD4J4HOEfiP8YHQ53igUKbmmDY8yVZya/dyEtKe8bukcbZbGIosKgMoaLsdpbNkln7bU1oLqMuogHGtqRdZ9gQLz2mz5I7Ml/lSeCEdbkqVbOjydVhF2Qm4bvbVjyER+n0VqhXOmeKcauEOQbEafYrJjWvDetMY4j8NwWCeJq0QA7gYRd7967 bhavel@blackbird.suse.cz</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAxs7poCgBwC6s753zkBVBQNdHjlbOJdlAuANbedPLqWWhftaNfej9TUlvL2YuO0rEwUIfVhmfQ2nH37Kyu4KP4Lo9A/PwvGGPpgKJfi2SOrt+r/oo6bIexmeehdLasIAuwmLzziT7r/3EQ22mNcoFaIn7YzWxjno6wHmsTYOxGshzPeJGpAnJp3xhjzUWd8asvBuqCMTMy/uhXEt8UTCwGW4jbRmdM7zWByXSsdQl+NSa995IpUY2TQ8NAdJ0MLH2Ztn5RX8qZpNuMuC4/+IHb96N2vAP4xvJfb3LIILmLmmvJ9s+a/QC9+kQecRf0gSoEkhKfcMxPrrU82ZoMskaqw== bootcrit@qam</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC+YVLmgvFkop8f+fAKbcWMaqL6NXgjPTRy9qerM9NT1oaTa/AW+5geUYCF80HLoS8ajNgcgcqcu9irRFCv/h5ycXOdApidcpsx3n2XtAt3AiLW74LVmLzQKgzFkcUBe7awYqNYuX7oMFgfSB4KVPfr6JvYh/X/vl9oT5mIgHkYmMYLZPzuAWUqPxv6gs2MhLHTRsY+SA2Yn8hcK2P0VrGzassqdAlvUxpZ1TXOdEqS1rcZrPogf1olY4d2ubApZM5Nop2OSmxdSZNtoy6n7SIUHeGo5MZxE5JV6FafnVg2Tvapgb9Rq051r0FIwuRzv7uP4unib16RF5zrjM+JsKSYO8brNoO6somT4OaTrc96UDWPyWiNkdZ8KfM+nr3prUPPt1EqFfzOOySjCiWdtdkNRQnEMxmHXIFD1OebovQICxDm+ZgvSMNOXkrt1Yxm1K6Edze+Qjfel8lM9HDGPLawpCUsIWrslUc/8fbSUK9eRg9OZC63Bwqb0DFUVAhLaacVWNcpFXVgyA4LUKTEeFPyIlBE8645YQSKugXpcwxTbKByJQWpim5839W5TCDy35GGznWg2GFYh466Rfy1k6CVqPJ4eHXrUxZWYyWTaCHX0OTHSS4V3Tx8X+TkuvsqCBedFlNvjaw7mklRJdDw0k3ujTWsX0+E7xGSriKDPK9ruQ== cdywan@suse.de</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDb3u+zG7OoUAX5h9PTaTuK6/R5AxsO4mw23IChgpUMp9HOTVkBtDpRViSiLwuHjUnMHA42Do3lNFAI0VzimX3MD/eyZwq9SdgWcjnJr8Ha/bpTvYOpV9l1OJZ1CnP1LyN71Kdg4ionzxPWidAT+hXEqsXgnOO06aEZ8KLftdg+gJGtbIusyTKb6JHJ6ppFGDXAQSFH/gpPlYADAKWvXpmLUr/IvFxXdXLIuF5DKMHpL+bi4WNVEJtV0daCKxiRUr0A6cIuIBVXi/Vsb78KcJi/4Iq+h68iGHgArH7FBD7japmA+RT45ZXpHtGH1PhKcxa+YMmHqKYyzTirHpkpDmrn cvarelas@</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCiHsIuHvNOAdNFc31JXBGzOdnnQM2a9Wnoe3oIC1vxL61rY01dj7lJbscku8UiX5Ju7LCxAcIesZ3mkhSpomNfMv+bf6p03KZZJtSZnZPJbM4df6K0mjbNBuX4frMPieBz3SDuUtLgEk7PSHWay7snClwXRR4fL4vN9j5NbuEvKAHUsUCz1r0ARIsWVWD1mVKLCIP6N3530iTUBGlTTOfMhhYLfy+EBDbShWxXQ3NQNo5WbjZP4sy9xDootxNQL+6GJnvt1fSc1V0X/0cYg6GxUomRBJlAqgHDvNxdSFxqzJIjwGMyTda1QD7pHpEJScR2cdQ/ROcA+89JZ5BF1rtt dabatianni@krystal.suse.de</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDI7nyw0aXrCv3QbdLpBA1PQ3mogiSFKIZbmwvk0ujtEaQUZIokV8de8E2xF11xFTOekqoMSYgDFFc9ECWy+WP7H484Pmc2k1R5t7WA3jKL52CuhUEvsB2oN8OzVRE4zy7l8OdNt8Vgh1q+Hv89IMgEF49jm69vIOZW4X5+SMSyNwGM5mJEnWWR/dM3wodW3rLy6XwejIsTUtsgQ3qLuSBK4xgmu+X+kstQVAnBn+ltwCWrAMYe/pr50cEt3HZEsjNo5u11A78sLbav9QluLdi8UYVjtg5aQMiIk4b09wwgXtmhzt4XP5NDcIgVpUO+YygIjW0bCiUMju2Ama0EesAB miura@linux-wixp</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDZym9EN2vPysSZzBr7iqu1ZPJp4C2vCRSSKpSLw1xgLU46ONKfUMTnXCZvz4CfBQPowJdawa6d0kHnq3goURPhQLfsVfpancamumCvbwOpnKmun881CG2MWHFS1LxmUjhbfjW4dwz1lq9L1tpO2QCOD8Xqk2OL0xDgFujGANREaWFPE9+6oHcNWCP2CPDm+X62QEhcqDHXBUlHz/OrEmWbEz2rKgGLyNAhStYpDG2I+jAVz2DCWnOlktzNeqmElh33ggLoFpC1wYcvVvB35/5x/wu1NH8w49MYAALdq4J3S5O+ZD1Ykz2eE53ER9xYzyqPwY7ybUUsstGZrfxWn8iZ fbergmann@suse.de</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDhfydsGzD3Pv4V8R/eJjNbV8e1bDH+NduoP1RJk8xvhd5z7+SpYIxH+g3HW4KQ0JLND5U31IiCPjfhe50aehCMAy7P2dQD618gOun34ow0HMd8vK+l+7u+7EZz/Q7Vm9puUjOdSCcV3d0dAT8dQTgqiBLJFBXV6q2MWxhvr15BRMqMy0o4CqhXUn7KVxQZb4BGnIyMK25n5jJ/6rzhUnjGf+mWSgM6z12W52UUwn3ZOUc4sNfD7juOcSsdw9ZRTvuZ1Skd+wARcW9eGdO0lq36nIpVSuBZlhpkl5M8dElrwFQkDRYGB2C7iueIcFqXFKlp4U2u7/X5IU2K0Fdvhe+iwipTywLAg2APlrVK1Rb2v7XEzBg6Ow1rrUudRqz+8Q+shGRKqBR0sYmoY1AT5cUS4RXCq/T1yPHIGmF/D5mFVhp//pg6hMe87VggEJKzPAIgR853lECKgwJmsjyey0Q1PGoTzBIKvyiI5Un/3Awu64IWPKzg9oCTYKsALjpMwbpVUpuvzAUag4Zb3zno7NNAf2F83yWga/XUtGi+gUHcfzCSf9n4libQTzy4DKPKYxkrLCP61gKZKs8Rb4tqTy6D9H0fOjmfyq6M0CaejY6dD5rGSoQJtYR4RYNk27hrmekYsUzhMXbdki7ghpGj1GTjVDEkF76G74t769e95ATrZQ== fschilling@g116</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC708wsMUXeEtcHN5r+YrXPj3FCMosPstPnja4O7Izmp/uoheBNo0i4npg8RtnhWg0fTgBUdN5PIHmev2TUO6xaHR70IVQx4RLIxqG5T0ELLHk9/NjX5wn8S61jZS3cAauJ1ZanBId6Ilw4VBlWFj/Blyo4zh6yV/uSiZMNH4sYK8OFUVbNP9dTCKeTSPbzpxRm0JmN6ykne+DvDq0OOxc7ZuzFPheYXanc2A1CTXF2XRbb3nFtvxZ8PmeIuNoWRsuRvf76moIkLPDqWbLqzPdqrmB84gGeWB+FP0Hh6CYWkb/tIOnD72HdipllqFq6Akzg56EyQ9QkWw52Pw2l3D5/ geor@linux-75e7</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCdI/gXp/Clv0eP8WzIdWXTfi4r/Sfx+00bxTm3gKq/WEAh0MY9KwIVBOyvhzKWhdU3p851I2A3kXj0j0/DiLV5AEoUHSFiFGRkSSVaiTpN1U47ch5vHuLAjER6vZtXsyvYqFUNYQbFEhNGCt6ROqte2NvEeFbb0BOABUYQMXPtsChf65AvxBnKtXs2cb4tTPYNCx5yYWJ7+gS3Zi8ueO80YiegC2XJ2kwKi11rOy00NjlnLmcRsj2nxJjP9p1XyCbjXASouXcAoN4FlQ97f4tRPXDc7kKOwmRQdos3eXrbEn6T57zTg19SBdhku9NdiYnuJeGT6EtYi1pi9No1eQsr jbaier@linux-ibbd</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCugQ3nxA5Zd3fZ0f4nZ81F3rsC9NULwUQe+Xabw6sPriXkFwfeKpqx9Rg21byMh7k7MCMFItIYIBYCxyHGbYlXiktiAkOxLyi3563huJ7JOtlpGZRF5F377z+1rAZqCJHZGZpQD+kZ3TbihfIYx2g+3QhSqjHzOGDNY3y8Rt8fu4EpRUPQhbP8vELs/ZelcugKrZfMMSVVi7qjV/KU1eoDqunmvsoi7AlMLWNqqZDJrimR3Wgegut9Gz8u1gf6FzZ78vB5O+QpyT/epFIIf/SKpbtdsqhWAShhfXA5pzFQzTXJj7RvKp71HhG7rrlQh5F62tifjh0H2fDoU7L5jYK5 jgwang@myhost</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3WEVRd5LeiiXJ0VMI6n+0gAmCFgYJD2HZkd+EK/4QnMIVGsZKDyLQzv+Asv7TlhKLwlxmpbs5spVKf0+BiEQ+kvP4m48BOo4IkLYYWB82VHG/m99FKhIvHypPj+TtF5/53Hn9acDNj8gXd2eAbnz2Bu7lli7ANOwQQadRkV4lvp42AQQ7rQ7gJJXiCwORnH2l+nHZ9FqDxXWFIiz/y3SJaltXVS0ELNtCH7D1zxDTjcy0HsMgmm9CBA97NhlAAzdr2GXbyHXCxUf7OaUHlOOg//wcturB7fd2ElH/ftJMz67PKwBfaW/mH/kJqgK5i68TzWo+ARULVu+dG9bavt3F jhura@ezkaton.suse.cz</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDP8+VZEZWcVDfUAmhuo97W+D//X1ztpXefdHDkXp+NTh7OJbvumqW5xNwNYlTprN7pAh3sDI2WAOKQtq27ZyBSiTJIr7N2XBbPgsQGtE30jA7E5LqwsLpJ9UFZEEHyvwfwNoOsloLlD6YYnVID8W1LL46MJ8mgdb1cHXZIQ+8I48Ok2y+HPilq5C57zQmKtw4ZLb/8X7TA4SW8n+N1ayO3VIdXlq+z+kA129AM4dQr9tuNgucKeQ3CeKSqYQ+suhI7k8GBYcZ7JpLGQTm1eoJLwXVkt1xRfVSCOAUbuMHLNixnEl3Nq5c/itg/mePx4FEkq0kUdHGKD+di4p5YEV97rYxLOb9QQB0EnCj5YbT+l/sd8AHRR61TZzxh6zsEoLCyr9BKTQ83bNY1V682Wff+Mjl35/e2qxCuUeICdY57BvzJ5/MB95pGkyMfzpyXBiN1s+zjazPGH5cCN5o5yWZPa2OkiSi11LbAcwWoh4cZGKBC4U2l3kgQEob9m+QTSCq8ND2ZiMqGXTpE33vfNQU3ZUlsvHpFrUCpWQPd1plchS3UBlr28B1zJLk3r8kVOd5FRKaHzOhxwm350wIPyCSK7LhIeVLgSwDU0cAIFEVWFJs4DF3UA/uzjW9m3rTem4D3FGHwNeRxXLaR+ogk6v8rgluJobX2fV3FjeCHtDhHXw== jkohoutek@linux-eye8.suse</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCm/z0MRb/MVoFeC0lCA45XIbUxyaZ+DTpMEEjQ30/PH2DFSdu4izguNyog+qMHmKAgBQWZWHr1DwXYTjZ4ZiQR6YShxb269S6QO0uqQ6U6SFBHwEyoaY1ooZgcPdCyjXKRSPieTHI1VojxiReDVNnDgrCObac4RWi5EU0JDSgKJI5HT+LjW9NLJGu+ikPuXbr479F6DFET5uV1ht09g5ppvkF2fDLojobaWf1og2JD7EPOg1E4MKX2juxrxSyhLFNaD1esBchKIryymQqIwAMqJsFeiU9YuAQ/N3xkvVUq3DSjeRU2okcpuo/FPP5ulHOTrRoyLQMkKl+BntCh5Sxj jpupava</listentry>
+        <listentry>ssh-dss AAAAB3NzaC1kc3MAAACBAPk04bTq/zI0tvb6yLy0aeC6+NDFpfRpNa7lw+lY13KphiAY9rq5qCv2mSxfQ4ZQjUzglEY5kmdPZUBT7McDl/UjQs/xvXmAhk6sBfX1fNoQGlGziwNIEjborwdC+SHHDu9F/bhGhMWfMuJ/jzKvBUXGAS8KoBm22o0fsVbZnsEXAAAAFQDvAq+kwDScccd2snfvERgFGIVjZwAAAIEA4Q5mk8/tFDDz2Ye1JOL0+oKpYmDzbeSla2MY9VyA18TUNgmIddVUdWdN6Exvx8wTwK9qIdsR3nE3+2np71fSljcHPmvEacByyxrGILqdId7ATtnl8ISC+3IT6DHqBGhMbx/Y9R/t00HwFilCvOxTHg/ObIwHPTH0to8VK3LI1PoAAACAPxxUSHpkSCxS1g0s2p9fAbOR/f7UcdzogagM2dGp8RlDfZcZXbSg/HpbePHtijxZaPpbogtJGf7PQhzNdGB2QF9Jy2kmVhzUX8HIEp/gBDs4RqONjuczvplgOssjgDWIjhaJK9hmNjkTQcCnf/PjcmapOA2rZpoauvx/B7oYImE= kgw@Zert180</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDO21pGr5lXFi1L3Xfnm5vkHLPCcLNsklgdiiZDKCSncrWDeQNtkgd7D6EEfX8FlsaWmIeN/UCHDQk6ZTwBUpGkwSAyD3B85nrZUkau1/gFdCsADktpo5TMzN5XYkOCRmAuVZ4OrofFYoJOFbh1WxNLovqT8qQll4Ytx97+SOFvl5lmHVnzLFj8wXr0GNNv8pvbUHcHbVaHrJo8JU+T2StO8cIo5Tcr0fOXwD9tvEM8orSzrluOXqz5mse2MtCA79dT1GeMV/eQ7kG8sQrMymQQAn8ce6xfl2IUd3lBXjkhFUH+7/2PdAKkH6ZCY3QanWxsA5Z8pJ8AIA2qPXDiYZGl kickstart@localhost</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDN9q3uKjv+E8uChhbxrKuWRa3KHAjGzVFDW+EwFixs5rQhX3BLnmHs49rYMlIg5nfPHIgk2zch9paQHC3LY9JMNOOk1WKhaz2XKHTlnsmxNAF3tAaJ3tHvgOIabHWtJS2YdaH9Sp3bEsLSEKm74g+19bGEUfDfNPLLFM/Zohj1SUAs+NAkNqvjgh2rMGCgR52RXf64upH6Lkym6+2CvKY2Wje4gfbUrfy8FRPsiBspotEs9rxTuzWe4isrhcvn1Ugw2wVMbCF1HG/sZXNWU+Uc3eOXOzuh5DYGneLYzL0uamPIAWmCWyE397XOLnL4q/NSoBUyZBhkzeEN5K0JJNzV ktsamis</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCz0BkomTEgbSmwCdB2JKaGaR1hOuTB8z59Q+JZYtzBPxYTpOCZFNgFUNKteGZgDhIfrqRWTuENbCX28EDI+Ds7pqrRgyLxt2SQpZYl6FL2g+5Se1l0Tnw3lbOGdkSC5QXRVrJWhLQMRm5z3rKrSUtbMttJUfOolUuv+p+9LLWPrY5Ts/uTlBA67Si+hhKIq+gEAg/iDQRbXn7VpBWJGNvrsBh2fDBPPm+cerqPWpMceqSa0pP/7m0wzSS8UvRxvgDd2no06g7XnrptGHdquIQN1zNWP3aui/HgpPnQW+X20jSWCpAOSvJfvp5iA1r89JGBBneULMWTcgFxwALMotQ7 lpalovsky</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCoatVX9uqgiaDBPbfkU5rRTj1JaK7eUqXyMzM4tFVWBemMbO4VZYcfiJIVHDCypJaAzSZjmI7tvJMyLU0osGGGpbwshi4MTOLTC8W2aS652LsYnvot5gonaXgl9IY9HW2oWDZUCJNVG3rUYzXiulVajCdGmqQY+2Hu3g7n92fIu6Tu7j/ho2vaLeHqe2YIU5Br//WZQiJjJ/Ln2Tmsoj2YPcMKrDjfI8MPt3I5N60vdCHWQIZSXIwRXFF79QIDNErnKS3zNbwHsR5LRA0ymfFV6vefhlBN9vR9G7L5AXGe4yKTl1Aq5mnOrYZL2F5debDIw3E4pg/1Q5twieE19olN mli@simonmachine</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCz1IkJsGdejHECkCQFZOHaYrOzte5AdAbG+Xwo/jxrAvrXhC/8hXSTDk9mdvGSpAmtg3ATM5jNd7uKEc2c4f2gNAvLmiAYz9faxqk1ay87zbkVaN9lgtjT/hCDbR7d5mweVlOeSE4iMzVIJU8/06vYhEhWT8U6j6T+O6VPqlnlyg613ZiGEIvghW+qB7I1qMa/MT95nPB5v3h8pAeJF6jagsxvOUcTs+WqBpIBpSwjbiP7TppjII2M/ZS+pFwOZFh/OA7xt4SKxzzov3mhEvbtkVX2tFGUbEjGonB4psmrMGulHCJG5Kw/uU2vNoZG2uCIBtZbXm4vuOsyJIUdFQx7 martins@moya.casa</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCrFEV4FE1duRdfgMg3X+VON6vDUfO5UX328huK4hosXDfsLdBK0ip99dFBnXLVRjx0dMDnxwFnFLR1Rr3HJBO5KaY4Ml0DXQ1djDQDAZkQ5ljVe4x49ZgFzsaaAUuP0yKNEeozPv0kZmx1Bet2MiOkFHod7igtHlk3O53Lmi7AmlaOxpy8Yuegt4nmCMEAcLkSpm3uXye2gfB0JgaTNzu2TsfERtOo6mM6vngZAn+xqKwLQF4Ktgeb/R2tNj/GCGRQ9QupB9Sw39RmC3J3vDELajQ8q7S+a2Q8lUVrNUD7z3Zxp7g1Qy6XxnZixaAfGutk5TpLv8MlQdAkC116U/Ul mpluskal@daredevil.suse.cz</listentry>
+        <listentry>ssh-dss AAAAB3NzaC1kc3MAAACBAI7hS4HYQ+Uh6ylBWSZ7mNcVitvDERqRANEdSFeubMo/QsHcwlV+g8PIg+Cn72lhlU2B7ZJUDIvHTj7ciqsG45+g4D5MWVKWZqkZzEA3ofbmf/bB7iJv9uAQXB+D0uriZVJGij1lqwKNxT3BLN0mKMoWhjFPY7kYz/3SvIxkOsWjAAAAFQDc41ylTBQXiCpLijVN5UENS4tqTQAAAIAtyoOgrD8Tc+40vNWpJEB0Yc0m/lJDaxq8Ack5+QqP/XQOIEjRS0IIUFonbnrtq1v5oe2FIpxoLuSZHqnbuy/OfoyFnn2QEFCM7+oE5967nlBY18iyQal4xELkYk3Q7S1IghMtoJizdcUhTrlVFz9CFOILu8roE+07pklUmn2WyAAAAIAefJdsAFT9b2SvNwBf/smBUoZ1Ji49u0VD63Z9m9y0lJwOw6oAhyRQmbqceLV4dcH1ttK4eG2xttvsqspZKVT6Mpmjry6TjRcrvHt7kMvuFCKREaJBz8ZyUmNS1TbJnjzqqj0puJgToNk16eUkCa9JUo3xG0CI1bywLsv0h9Q+Uw== nagios@monitor</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAp0LjAk5qTRtNLX7s0AV2FVzC87m8iLCgRLpRO6m0lFIalATpi+pUZ7uSUPfpXtnJQ68lsVTl/ClMe1siCs8BUuUgsLYwYxeSboz3YxcZOG0QbkWGppKJd+qB8RAS/OLQ1kfycq6XiombMq3V5X7Yh+3ShrNmlWuItn9e2X3NdPwpcG8fCOTEOKOBl7nRpkLr4mptsGlVHoRda8Tv/HDLB2OoFbFTsww5DoG02kh3G/fN8sF42sxBztFtz+YSGPgSeYUSFuzPrA0RKu/s2uOR8wWTBtHlq1/WSAk5/HQZO7flAl9HCiu+A5/JxcYgCAs6jPUp4+gO3Bf2mNBzSTi3Xw== nagios@monitor</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtOQSI+PPZ97XvvxAFbL06DngIAL3yptiF8UTPChqlMDvuaSoafREQRITMT2jRpiPjNWN3YqQXiQu8+ckBR3tD2KaJ+UOq74JUaSU1TrmydLJNeLcOUMB1JKJVb67xhO2E3EAltd3hGXLy9s1TLkRmI34/cfDM9spAZekhfREr4nbs5lSRVGDILeg6yE4+T/XJatRwxWOevdvS/JUvmMGCrjoOkt8Fl44ry5Ifw7vp7jMzp2ZsrFmGLEjZTXqYaONVHG+V+UlL+AOdKucvKkWJx/utlgndw0QCJ29Clpk8W64En5WReoepW7z2G8qJFsNEiw+W7sp5e875JkVQ2SwP onalmpantis@linux-g901</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDIoE9o0u46QDGEmZUwa+1ZDGaGCopYv8uauQqt3d5mCaLGFw6t2z6Lv8rw9Nwa+iH9a7Uc7K7TdeoIrywio2LsjAstvcdOjAqFmY0Lc2Tds1vr2DIJuVEfrkwgZc9sCJgWeQm5NKQ+/dlPw64OieWFYVAHt9KCWk9YuDw/I7o5oGgICbQbtAOd2ecl5ECrIqUZjakWPmwldPOOQ3aToLsTGLJqWNsAU4sopkv2JaozBrFoe60g5B3qEviNZKKVwNj9FEzb1rC0sLqGHb7lvecGKWsVfat9aV1Lt6hY8hLKpLWGMo0qIHkWA5PRrKDE9rzpEJ6rVLrZ5IKCTp9n+lqT osukup@argus</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDYh2YTtJ/3pzfH4aU3DH8WEkudgSLe/W6cekDSQLFiG5DqD8kpW1vPpyf14tF4Z/XG49ssYx7amZnP3S96O5LRxEYcA/2kvCOhz3piLQbhSMqCEXUEl2YQN7CVhxJzSAKWxTyHg67FSeHkUlAfd5xLTe1bJjfwn673nLSQTxE5IzqWagC6d4TctkDCg86C4E793FOOWc7J5mb2M3BG059onSasN0I3iXh41LSPPuzrCycchV7n8q2KmutllMJb87akL8XICKFoD6c55/mwSyb/F01KyhLKl/IuAS3B5COR+SzBN6VIyqAGta+5//QxKKrNVxMkvnowVexMPD6zMxND petr@pc-pha-base-1</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2beiZY6ugIsKQwP075ds/IxqR65vluwzD/fCjjMNCaiXQJap8WhSRAOv8BMfqzSQbuRFIRr+a8YLbQqMw/kEieVSATfhx9DM4GUVDTMvDho81No4nqe7aC+3U48wyeGy9LZGTGNEzt2zoPhxqAho8g4+9rc8VaYH01O21xW2Ep02vYystCc8/bAFbB7XsYo8YTlHGxtIHoLCGEEtqO4qkd9rYLHs8Hc0y7GGGMGhbDEskooGaMJeEzkUzzNf8qFCjGF6jZmaZgQsd7CMwAeIRZTcdhPHkviBCvQ/sNFtEH+Oo7PMTr4wtySt4z75otfsJkFUdNLOgiEaceZYsJ7VD pdostal@suse.com</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDDMSmC0GfUo4Q3mA5JT9j4K+rIXbwraIAmmFIsd0lKANzQ4u8+OmaA19O/OrtEd+AZJpeLxHO2O8Q0swS53i8PNlS4PQ8hxElFAYmaV+CqDx3VccBcCwclTGHnsx2bo3ofzVsR3VSciJ/uLFE2ToSO5mTYuh5MC+t+RbhfILka5QZqL0atscsCKymMse9Wix3cZ11qpatWRHnXLXg+AK3Pb8ZaMQ8AOR8lIF+c5RChD3F1sJ+CyQ7R20GqJs1QEnHbUzWq/grugEAS8SaV33WjYD1p7WAIvcrEOGfdicnIFRvOZGzggJzPxUaMbwuLyHrOQJEN0gHQbeR29qpqtP1uVHgbScnV017CTCUa4aNiXKFlwAPyD7gPiDBIQilmxMXiGmIzoqcYkxWEuirsJHdiVcTzToalbJ265Xec3zACrD/AYRLxtvyNjE11NIC2OnsJYw3hv5Vv1DRxWZMYVDmtyHyzkj/+emPWK5dgGs7ZvAswBVpmuYjAXEcddN+OvnbEmNl1nAJOgItALYNAw1rPaJVmO+1ZjtauvVArtXco31DkZL569kklzVAcE6k8heXX5hEGcqMNP5UEVmBO0LOpSGZJRhhmxss8e78jFKXrscJNZetKc36Cjj8faL562j2326SpjQOHLzlogvmXuqq6xkaUWLmphX8hvby61fhioQ== pstivanin@suse.com</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCofCLD4g+p+RrGhdJUZQYOzu4v5pFLPg+Cg/sGWld0Ym1hEtiF89nxep9oJIGub1qAIP9lDJDZMs4Avx3n7ufjKaH5l8G9RKs3VEtV0lLgQq0luSaOAZ8koqqN0Sadymg9vxbuI3pUmxCYBCfy8MiEd9xsSSP9iSbN+nRz638KhBBmJ1VXJzX7jkwarfdxBhKHwKf3E/DqobqKUBEjSA/DY7E21EYCY0I8d8JZVEczRP8U4Os2H2LlfSxU5q2TQ1vD9Gy9mfKUCY4tMIxWvY5TeDHauPq/FUZAEHHW7kF8OZyYoxNcVEVbPVfYSh17+Sxrin7RFHkyVgAeVV1ghJo5 RMaliska@dhcp198.suse.cz</listentry>
+        <listentry>ssh-dss AAAAB3NzaC1kc3MAAACBAOhSfaq8WQuOgdDFCnvF0/7Bi1GQEobcxvQm1RgV/4TOsxmEtgRC9plhTGUjmWly5R5T0g23/CLw3UGMM7T5CK9/QGhuCC5Bm2qXD0/JnuAKrtE+k/ILXx0cX9gEjfWCnAefQpNTlJUzhnO9OwiR9o+e/HIBQRnZF3lXwyUvuCO7AAAAFQCNxioVFXvOoJtudJ9P566SiU2BFQAAAIEAkLxeu8ra1075k/4zR+2cCEFEf0uXUfnYr4IR4O4PEyvkmPV9QYyQ4sy4py/4eMVY+TfHMQjrm5LOP3dH1zRCNiOODlETtZg/WSqAguIHr71ZRHorbEICXMWm9JG5kAwDsgI1N6h2leSg+yBYu9Fy5/KtLcuxQ1IdYigaCcj0fQgAAACAQ1lr/YH5I2gPsCu5apI2lSEu7NjGJY4/BOzcXV3+YMx925C5UraOYqGsniylv/TJwfDpUsUk0ea3DPNG1C0ln4WXPlmCZPCxGhNO7kWB1LsBUmKvyde9qkgREVd9JMVN0+NhHeXE5A9vhXOvVM2c510q3iW338xVMVey/OVbLGA= rommel@poincare</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAIEAr5b6cWBzXLXprUTfpYmEIrN4UyC9YAS46zzilRhb6LUKijiWvfdb0d6j+iRV2hn679jvWb8g0pLilHI3S/VDyTWxUVt/cSsEXmC1x6vG9el/PIf2HdvUZtQvDweK3Qrv9oQ3nK3x+rkOW2Oxmstl760wTnhQW47cTah6mpJWHZM= rommel@poincare</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAvd/c+UtfvqICJarSw59GUrq4DwCQlw17KV//vVXfhmnyS5p+Z9S6WEEkRh7F89SkT5/zZfpITVezPz8XGwjh7jFOlzx6NSHMT4msMN2wJNa3ntQLNYPZEgvZHyKp+A0CcIgmBzRKFw1XTvvFUJyf2ucpyeQoJtR3HO4WJdgDrIezjZpkaoVf9pctxf6sV0TAKhODqw0WRpCAwN/utvAKLf6vSggrXvI3Qeoh0VKZstcu/kSktpRIG0kinNAjpNfH/AVIcoSPYLJzCUFHk7C4FooAmBHQwea9OUxQLeX4jqJMLUrZdSjREThRWx7+WeriqPmxx1nRMzwzJvcZE1vAHQ== shchang@linux-dwx7</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCqhWVTosH12864VGY5S3/k0yKc59GbV0m2WxD28gAf+uvJ1/y8gekD2wDzBv0DWqEekYLV7L68gpapDXyGosQeZ6n5OO/NZFZmW+Xq1P7P1QHJil6kVpwk927lzX440pwNf3+PRvTbLzlbuVFWJRpiykv+juJyIFjzXLJRF67wB2qgZVm5cRs/GOi4fnvTaou/Ae51mvsO8M3JL5cphApFKD/AO/X+3pHBhLjvaW33cYsp0Z4Rce1nm8wxSmvuJRF+HAfjBlknhDl5ZaJGA96RYA+g9WbAXimFprg4xeiRp7liPExQwtVgackJweoC4MahC1glmjC3eOh9dvrrxLnALOLMOkyCSK/tOF/iq2PJaLViObanPI8mnNkMLbdJyzUBf8hRGdSLcw98qxaf0sSZ+vz4VQS6e9CwX7ikkNNsTeYXjnJ+1yU3mfCW1CXJDr7kBDVG2OTLefCpMY8WBAYDiEaK0RW83cBcFIKfecKYd0qStHRaOsvmyWdFYgBh2vM1UWjro5WXlb+7aJPrUp8ZruapkUXUwhjHA7FwGA4ysE0tsOVVFm0Dw8tvyVVkVNm/9EObG28dWctioZ2+ZEzTWgMJU26Q+wOJ/U4qZyIvpMRUgPZc5nM9J8kcmvNWtb6DV9k/6p8h28kiOxPkxLtPP+3TlBCHjq//mhEnJZ/d8w== shshyukriev@suse.com</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAviz9q47QXlocFuD3qvy4Yw4yMHebHuokGK2kjpDSUOREBIqhBwOJysuDqU5PNQpJNG85C8+eM5/bS7YyIHR3hOF32daGb922g3bZcUgixrJC0Qwq1xHO7uf+/48It6BBcaG11F0uKzEzYJCayQRbSWUIGCF4EgDpDWNrR67pUh2n+U+rxY+Ll671a3lr2fwPrilXPy126EWBFJUxcxo1eet73fRKKfd38nYABT/elZKKveg6PJAvnDSB08lUpmYJ5S68rRdu1K6xGJy+Rga/ECFZLoO4JmYW4z9XnDc9s41TpS7pCIN12M7dPMHgww3zFsRfsXpKwrlnL2crEz47dw== skliu@tux</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqQ+zJeaCMN3F83/2sYUeG0CTqLRLw3jLtTNunfm2nP4hidH9Kg4ZhT4s+gXYGOKkAsIc6YbqG5nfq11LpwMY8GBglFHWGo8dkHrb9GqdcEfXJBAM6neEHtNu8aQ7eJT8ePvAqpgi7/6RTD+aIw1PQ09aiqgjn6wZDXengm2Ug93evd6PoyvIa3jFCnJr9jD5GhMz+QnY09U3Is5mDHQNH7C23zDiuBm5dWQ82UN2bRkhbIzFRl/09HWQHYlCwAlKu8vj9fSjwH9MCIRu4CoCF6CgKiC9MrH8l+VUMswhWhjp7uJYr0zGK1N3YGPIXYccPJn98ya5kXKfC236U9USZ slemke@</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCj4Kt1ioJt+s6bh9/4KvogqPsoRcauF06ocv19GjKw3sNwFRcR/hrP7OyIYtw7XxJ8TKJkJOvy3+H0CgTXdXG9uUamBMMNjrEPf0MBXMq/pR3zpT8I9V3Q2lk2l6vtGu//+KVTlBp16RJDMUA6Y1afXuavYGCb4nSueRP/hyrG84oSMWzGLAoAQfVHbZYXTSxj2MCZshvvPgxg62H67hjl+zmK0C/b6gcn9tenQzzCSuEzx2WoJ/B4R/opLKtM2FLAsJnp+DMyjnE23uw2RBWzsxklWHFkSDjT5eD3S2dNMz+whwoqtQDGiP7wxAmrIy9usNuAWJ4rODwYGsd6+g+frCKuxiBFWxBlB1wdLsd6s2jiKlj1Mq648/EcbdlTlMPs5RjXcw82sksaKmxdD5FjoLND5r85X/nRO8Ymc2Z7MVOjcW4SBxgRY4BB3N0384uZPILlL2SbMqlcejEMxeGWOF6NtnNgqlsLrfp4AsYmDAqZL0cnP750K91O5ON05O21XVnD7FjKA6IXKHEX62Sizao/f24s6aP5ROWX81GsNlcAm59rz7wk1gSxjoaUtSrJ6ZVd9v17ICr+bGgjGksf+1UMfATjjIBb/JW0YhzbBB2r7KHtyThmGJTSk85OFkMFp+e425RgjWa76WtIEQ/1W3y4Mq4DHOSPKs8dNre5eQ== tjyrinki@duuni</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEApPAl5qwDZNMJ2rfGPOPqcfZImhQgY2EoXqMGzPanxLqr9+NOrRjkBZjA7TK8v15dcLHR6KyhZKzrhyH3ZEKiOZPUStaxL1dBBKQvNBXODBcUrGCmBJ9pbswrNRVYXeD1J8l+7EZc6dNDntM+qvpuREKc9SHWB+IsFyJO2ZX3Ol2NbL+x+ajrtJIPbIUyI2ofxJX8xkO1VOVvn4eGWi1AZcNDhIbC9NoaIhwTcV/bKOuDxPxbB+H7NUKkzLJXomm/gpOxQH83/BY5DI49EKs4dNEs4BfzBQbOnS2T9ruL+ysf53dVugfmNjhNYMj50PJQSuU3fRtWwm1tjhjC88s5gw== tyuan@sles-11-sp1</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA5awrD4By2sc7cyYTQQ00EoAj3HN/uNAbN6artg2j8GQ8E8cD7a6rogTaoR1Awmb/QcvYEwf6l9C5i10PvA/T77D5kUAch9NGBiLlKcPkJb3luJ5OUJZp7z8gFJHhTJzhcClUN9HGEPdsctRfP8rdAAdefO/4vB+nv4u8SU3TeMRHTD2g3qJUN+PP46p2zLgSHb+lP/1qnPhlOHAD0pjCpla4MzMdQ2vH64DJvjRHAy2j+uS/Lsh8Puqv9Wjc1CecAuVo/CHSWKMuwLOF13tMSKqR1U513hYjN0HK37TYPzzObCLHFFbfZ6sRdORDhkADAtYQQqqdvLCmxY0hmPzv vcuadradojuan@suse.de</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA0SvnKlJU4QDg/F5nTV6JdTigJ/8nluhdk7i85p0b7FA/PXhrjbLxE1DjSwp7GoFVOoYw7GABzc8xucQteaq/96qDGvPhK6DSKkn+mFaxekBvKoaKMJ//SZtX4kdrvV2BozddsJBt2SkessEfZ7MddgmIxzRJRskzeaXWv3sB0aNIWPMq4dl8iMeapkjazX+OtcmeqCqW5YrLNKpH0ECuzylbku0AOblX+EJsd1dP/QbHOrUn+CXhonDtHKyY3lE04H4qqj9u2fyK9eZ/8ReCqvg1vhWsqr0xcmhzf30Mt9FdA4lW/gk6ibP7MxnQLgzcnO4oP1+3lxa7/ZDeBiQDyQ== vpelcak@vini</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDINt0FdONw9xs1VoD54m20DbFbb2ZywrZlkAqz7KZajPx3FDTwdKeIg46RemjvCp0JS1Y/Seg1Trgy5/4mcz7NgL29fE8+8tY6YcRptApBmJBZqM+GxnYtonOTW+rILvDCLJFgwsa2vqqIkoKzYDGuAhriR85EvbZ8hUl7kw3zHG5hAGo8DLDdKLh2Qwmd82V0GwCOqeWicF2P7ybspZT967oYQlIONhokGfcJG+k/BEJ2nSICgz07WGpdewiqmpGighoK356Lb7S/EnQin2ON+fDSlStuIMqYq0OBQaq8Ow2l7lZybEwcyqTLmhJ7K+NYwoQtQ0RKXtPZSfir9pwX vsistek@kobe.suse.cz</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/btcgaiVrttV5k27lKVobH7ovpM5b2PKM3oOJIg9aEnpZ+56xuwJ+W1y8lX7SwRdjLOX1FhX6bR6oKSb5FdcWEF1r6Wx/DR7GEDiKiPxRBKI6Es2G0IshoJ1LhBlCdIfOHym3nD1p9IyQWIBuySbSpnBlKV/F2DrNF2twVdZf+eX6LPtDGwFVwzAV07+SktR8eRET+O6Io+WNEnK4RshwM7rqDEkBbPoXpnbRaTZeJiaS4vIZX+sHwXKQ3+pExknFqglszOVys/hCLY5wzA0qh3GTx+rEU2Lyqhtj1w8G/PSf0CXEnR/bvwzGjvj9FP3OKgCdCo5+4alnHY7ipezV vsvecova</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDRCckXwmjSPFDPc72OyQdTDzXlMfLvnXd7871dCXCbmJu0Kz39yICB15+rjquN0xdykvG+Wc1E8kT5wepTSMd2rQDiUJKU6CnEu1zQ3g9Pm8RI5F0bcomQgxGKGgR+GeiiycdIhnqVz2R1HoovWUW9g0vB9qXdQBZcT0Y3aE9EqpgyJNW8pwqJ4/8d8gMMy5bfKvVjI7c+713JVFHAyaFq5FvOfP3Hkuc4WNyzbJKwgLeVW1IdFN6kNp0clLZrtq9RMC8kL+K9Sf0wzEuF/Zq/tiuwFakRk5cfmvG3nWNiw2VwmNf59VmPjGjWcLMEz0sRpxYzXjfePpAG0x1lqru5 balogh@wurst</listentry>
+        <listentry>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDESLvddZq3NEvG8aGNBYKBdB8cTnE8EZS/giVhjXr0R+GJbbTKHhWFT2fToK6qbYtLWRPh2Ep5kA9gfj1I2J+XBbkDjDVCgqRUs1dY00bkf7Hej1RdivNbUT27p4Qzm+eePU22gymVKgR5cgEtgZ6h5XCZEMfUdD49YIRv6PiNmms5ik8kKaEUi0MkfCL3tUivE5cFgGI8pANyde3vJThbpoZFVMEz9ddjg+j3N7SLVFZVX+HAAR8oY2wg6q82yUHCTxbM5DP1ier27uost+d8KsBBiI/hJ7XAndO/NE9HFz6Jb0YQrNYeIBqS7lsTe4EGDfeZ6HPHbcFq4RBl+vp3 zkubala</listentry>
+      </authorized_keys>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>$6$2amJU8so$Xs4fGIL8NL6P.E3IvT00MGGCJFQcCpCK8zpM/cV4ISENFjuM/I95RfTcSjmCSMY6xgtPvEJ7LH2OStkZttM4s.</user_password>
+      <username>root</username>
+    </user>
+  </users>
+</profile>

--- a/data/autoyast_xen/xen-SLES15-FV.xml
+++ b/data/autoyast_xen/xen-SLES15-FV.xml
@@ -24,7 +24,7 @@
         <product_dir/>
       </listentry>
       <listentry>
-        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product/]]></media_url>
+        <media_url><![CDATA[http://smt-scc.nue.suse.com/repo/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product?credentials=SMT-http_smt-scc_nue_suse_com]]></media_url>
         <product>sle-module-server-applications</product>
         <product_dir/>
       </listentry>
@@ -34,12 +34,12 @@
         <product_dir/>
       </listentry>
       <listentry>
-        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Products/SLE-Module-Legacy/15/x86_64/product/]]></media_url>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Legacy/15/x86_64/update/]]></media_url>
         <product>sle-module-legacy</product>
         <product_dir/>
       </listentry>
       <listentry>
-        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product/]]></media_url>
+        <media_url><![CDATA[http://smt-scc.nue.suse.com/repo/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product?credentials=SMT-http_smt-scc_nue_suse_com]]></media_url>
         <product>sle-module-basesystem</product>
         <product_dir/>
       </listentry>
@@ -47,14 +47,14 @@
   </add-on>
   <bootloader>
     <global>
-      <append>splash=silent quiet showopts</append>
+      <append>splash=silent quiet showopts console=ttyS0</append>
       <gfxmode>auto</gfxmode>
       <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <terminal>gfxterm</terminal>
       <timeout config:type="integer">8</timeout>
       <trusted_grub>false</trusted_grub>
-      <xen_kernel_append>vga=gfx-1024x768x16</xen_kernel_append>
+      <xen_kernel_append>vga=gfx-1024x768x16 vga=gfx-1024x768x16</xen_kernel_append>
     </global>
     <loader_type>grub2</loader_type>
   </bootloader>
@@ -89,107 +89,44 @@
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>480</gid>
+      <gid>5</gid>
       <group_password>x</group_password>
-      <groupname>polkitd</groupname>
+      <groupname>tty</groupname>
       <userlist/>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>488</gid>
+      <gid>495</gid>
       <group_password>x</group_password>
-      <groupname>lp</groupname>
+      <groupname>lock</groupname>
       <userlist/>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>482</gid>
+      <gid>491</gid>
       <group_password>x</group_password>
-      <groupname>chrony</groupname>
+      <groupname>dialout</groupname>
       <userlist/>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>489</gid>
+      <gid>494</gid>
       <group_password>x</group_password>
-      <groupname>kvm</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>498</gid>
-      <group_password>x</group_password>
-      <groupname>wheel</groupname>
+      <groupname>utmp</groupname>
       <userlist/>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
       <gid>483</gid>
       <group_password>x</group_password>
-      <groupname>systemd-timesync</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>65533</gid>
-      <group_password>x</group_password>
-      <groupname>nogroup</groupname>
-      <userlist>nobody</userlist>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>484</gid>
-      <group_password>x</group_password>
       <groupname>systemd-coredump</groupname>
       <userlist/>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>15</gid>
+      <gid>488</gid>
       <group_password>x</group_password>
-      <groupname>shadow</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>65534</gid>
-      <group_password>x</group_password>
-      <groupname>nobody</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>42</gid>
-      <group_password>x</group_password>
-      <groupname>trusted</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>2</gid>
-      <group_password>x</group_password>
-      <groupname>daemon</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>490</gid>
-      <group_password>x</group_password>
-      <groupname>input</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>486</gid>
-      <group_password>x</group_password>
-      <groupname>video</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>497</gid>
-      <group_password>x</group_password>
-      <groupname>kmem</groupname>
+      <groupname>kvm</groupname>
       <userlist/>
     </group>
     <group>
@@ -201,38 +138,80 @@
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>0</gid>
+      <gid>42</gid>
       <group_password>x</group_password>
-      <groupname>root</groupname>
+      <groupname>trusted</groupname>
       <userlist/>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>481</gid>
+      <gid>493</gid>
+      <group_password>x</group_password>
+      <groupname>audio</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>482</gid>
+      <group_password>x</group_password>
+      <groupname>systemd-timesync</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>2</gid>
+      <group_password>x</group_password>
+      <groupname>daemon</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>484</gid>
+      <group_password>x</group_password>
+      <groupname>systemd-journal</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>51</gid>
+      <group_password>x</group_password>
+      <groupname>postfix</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>485</gid>
+      <group_password>x</group_password>
+      <groupname>video</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>479</gid>
       <group_password>x</group_password>
       <groupname>sshd</groupname>
       <userlist/>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>487</gid>
+      <gid>498</gid>
+      <group_password>!</group_password>
+      <groupname>mail</groupname>
+      <userlist>postfix</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>497</gid>
       <group_password>x</group_password>
-      <groupname>tape</groupname>
+      <groupname>wheel</groupname>
       <userlist/>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>496</gid>
+      <gid>65533</gid>
       <group_password>x</group_password>
-      <groupname>lock</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>495</gid>
-      <group_password>x</group_password>
-      <groupname>utmp</groupname>
-      <userlist/>
+      <groupname>nogroup</groupname>
+      <userlist>nobody</userlist>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
@@ -243,44 +222,86 @@
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>5</gid>
+      <gid>481</gid>
       <group_password>x</group_password>
-      <groupname>tty</groupname>
+      <groupname>chrony</groupname>
       <userlist/>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>494</gid>
+      <gid>15</gid>
       <group_password>x</group_password>
-      <groupname>audio</groupname>
+      <groupname>shadow</groupname>
       <userlist/>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>491</gid>
+      <gid>489</gid>
       <group_password>x</group_password>
-      <groupname>disk</groupname>
+      <groupname>input</groupname>
       <userlist/>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>485</gid>
+      <gid>59</gid>
       <group_password>x</group_password>
-      <groupname>systemd-journal</groupname>
-      <userlist/>
+      <groupname>maildrop</groupname>
+      <userlist>postfix</userlist>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>493</gid>
+      <gid>492</gid>
       <group_password>x</group_password>
       <groupname>cdrom</groupname>
       <userlist/>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>492</gid>
+      <gid>0</gid>
       <group_password>x</group_password>
-      <groupname>dialout</groupname>
+      <groupname>root</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>486</gid>
+      <group_password>x</group_password>
+      <groupname>tape</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>496</gid>
+      <group_password>x</group_password>
+      <groupname>kmem</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>480</gid>
+      <group_password>x</group_password>
+      <groupname>polkitd</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>487</gid>
+      <group_password>x</group_password>
+      <groupname>lp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>490</gid>
+      <group_password>x</group_password>
+      <groupname>disk</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>65534</gid>
+      <group_password>x</group_password>
+      <groupname>nobody</groupname>
       <userlist/>
     </group>
   </groups>
@@ -335,7 +356,7 @@
   </keyboard>
   <language>
     <language>en_US</language>
-    <languages/>
+    <languages>en_US</languages>
   </language>
   <login_settings/>
   <networking>
@@ -346,7 +367,7 @@
     <dns>
       <dhcp_hostname config:type="boolean">true</dhcp_hostname>
       <domain>suse.cz</domain>
-      <hostname>dhcp26</hostname>
+      <hostname>dhcp169</hostname>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <write_hostname config:type="boolean">false</write_hostname>
     </dns>
@@ -375,7 +396,7 @@
       <rule>
         <name>eth0</name>
         <rule>ATTR{address}</rule>
-        <value>00:16:3e:58:b1:f7</value>
+        <value>00:16:3e:39:f8:58</value>
       </rule>
     </net-udev>
     <routing>
@@ -419,27 +440,7 @@
           <subvolumes config:type="list">
             <subvolume>
               <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>home</path>
-            </subvolume>
-            <subvolume>
-              <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>root</path>
-            </subvolume>
-            <subvolume>
-              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>usr/local</path>
-            </subvolume>
-            <subvolume>
-              <copy_on_write config:type="boolean">false</copy_on_write>
-              <path>var</path>
-            </subvolume>
-            <subvolume>
-              <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>srv</path>
-            </subvolume>
-            <subvolume>
-              <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>opt</path>
             </subvolume>
             <subvolume>
               <copy_on_write config:type="boolean">true</copy_on_write>
@@ -447,11 +448,31 @@
             </subvolume>
             <subvolume>
               <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>root</path>
+            </subvolume>
+            <subvolume>
+              <copy_on_write config:type="boolean">true</copy_on_write>
               <path>tmp</path>
+            </subvolume>
+            <subvolume>
+              <copy_on_write config:type="boolean">false</copy_on_write>
+              <path>var</path>
             </subvolume>
             <subvolume>
               <copy_on_write config:type="boolean">true</copy_on_write>
               <path>boot/grub2/i386-pc</path>
+            </subvolume>
+            <subvolume>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>opt</path>
+            </subvolume>
+            <subvolume>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>home</path>
+            </subvolume>
+            <subvolume>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>srv</path>
             </subvolume>
           </subvolumes>
           <subvolumes_prefix><![CDATA[@]]></subvolumes_prefix>
@@ -497,23 +518,27 @@
     <services>
       <disable config:type="list"/>
       <enable config:type="list">
+        <service>YaST2-Firstboot</service>
+        <service>YaST2-Second-Stage</service>
+        <service>auditd</service>
         <service>btrfsmaintenance-refresh</service>
         <service>ca-certificates</service>
         <service>cron</service>
-        <service>issue-generator</service>
-        <service>kbdsettings</service>
-        <service>purge-kernels</service>
-        <service>rollback</service>
-        <service>sshd</service>
-        <service>wicked</service>
         <service>wickedd-auto4</service>
         <service>wickedd-dhcp4</service>
         <service>wickedd-dhcp6</service>
         <service>wickedd-nanny</service>
-        <service>YaST2-Firstboot</service>
-        <service>YaST2-Second-Stage</service>
         <service>getty@tty1</service>
+        <service>irqbalance</service>
+        <service>issue-generator</service>
+        <service>kbdsettings</service>
+        <service>wicked</service>
+        <service>postfix</service>
+        <service>purge-kernels</service>
+        <service>rollback</service>
         <service>serial-getty@hvc0</service>
+        <service>serial-getty@ttyS0</service>
+        <service>sshd</service>
       </enable>
     </services>
   </services-manager>
@@ -522,6 +547,14 @@
     <install_recommended config:type="boolean">true</install_recommended>
     <instsource/>
     <packages config:type="list">
+      <package>yast2-users</package>
+      <package>yast2-services-manager</package>
+      <package>yast2-proxy</package>
+      <package>yast2-ntp-client</package>
+      <package>yast2-network</package>
+      <package>yast2-country</package>
+      <package>yast2-bootloader</package>
+      <package>yast2-add-on</package>
       <package>sles-release</package>
       <package>sle-module-web-scripting-release</package>
       <package>sle-module-server-applications-release</package>
@@ -532,11 +565,14 @@
       <package>sle-module-containers-release</package>
       <package>sle-module-basesystem-release</package>
       <package>openssh</package>
+      <package>numactl</package>
       <package>kexec-tools</package>
+      <package>irqbalance</package>
       <package>grub2</package>
       <package>glibc</package>
       <package>e2fsprogs</package>
       <package>btrfsprogs</package>
+      <package>autoyast2-installation</package>
       <package>autoyast2</package>
     </packages>
     <patterns config:type="list">
@@ -552,24 +588,6 @@
     <copy_config config:type="boolean">false</copy_config>
     <import config:type="boolean">false</import>
   </ssh_import>
-  <firewall>
-    <enable_firewall config:type="boolean">false</enable_firewall>
-    <start_firewall config:type="boolean">false</start_firewall>
-    <zones>
-      <zone>
-        <name>public</name>
-        <interfaces>
-          <interface>eth0</interface>
-        </interfaces>
-        <services config:type="list">
-          <service>ssh</service>
-        </services>
-        <ports config:type="list">
-          <port>22/tcp</port>
-        </ports>
-      </zone>
-    </zones>
-  </firewall>
   <timezone>
     <hwclock>UTC</hwclock>
     <timezone>Europe/Prague</timezone>
@@ -605,10 +623,15 @@
       <username>slemke</username>
     </user>
     <user>
+      <authorized_keys config:type="list">
+        <authorized_key>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqQ+zJeaCMN3F83/2sYUeG0CTqLRLw3jLtTNunfm2nP4hidH9Kg4ZhT4s+gXYGOKkAsIc6YbqG5nfq11LpwMY8GBglFHWGo8dkHrb9GqdcEfXJBAM6neEHtNu8aQ7eJT8ePvAqpgi7/6RTD+aIw1PQ09aiqgjn6wZDXengm2Ug93evd6PoyvIa3jFCnJr9jD5GhMz+QnY09U3Is5mDHQNH7C23zDiuBm5dWQ82UN2bRkhbIzFRl/09HWQHYlCwAlKu8vj9fSjwH9MCIRu4CoCF6CgKiC9MrH8l+VUMswhWhjp7uJYr0zGK1N3YGPIXYccPJn98ya5kXKfC236U9USZ /home/slemke/.ssh/id_rsa</authorized_key>
+        <authorized_key>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDEfz0lP5oO03Rw8vSyzqwt06VIEFA4x478DERaSWHPTD5ULqqdZQS1vsFpTtAm1eT4Ix4njXvSh4T2d2aXYyCgB+ElJI1h0tpbtX7OtenJ7c3rUows61jqmXLFrnIfWbZL2uhomTsOziQwxKoXS3PRxFgoRaZGzHGD4J4HOEfiP8YHQ53igUKbmmDY8yVZya/dyEtKe8bukcbZbGIosKgMoaLsdpbNkln7bU1oLqMuogHGtqRdZ9gQLz2mz5I7Ml/lSeCEdbkqVbOjydVhF2Qm4bvbVjyER+n0VqhXOmeKcauEOQbEafYrJjWvDetMY4j8NwWCeJq0QA7gYRd7967 /home/bhavel/.ssh/id_rsa</authorized_key>
+        <authorized_key>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2beiZY6ugIsKQwP075ds/IxqR65vluwzD/fCjjMNCaiXQJap8WhSRAOv8BMfqzSQbuRFIRr+a8YLbQqMw/kEieVSATfhx9DM4GUVDTMvDho81No4nqe7aC+3U48wyeGy9LZGTGNEzt2zoPhxqAho8g4+9rc8VaYH01O21xW2Ep02vYystCc8/bAFbB7XsYo8YTlHGxtIHoLCGEEtqO4qkd9rYLHs8Hc0y7GGGMGhbDEskooGaMJeEzkUzzNf8qFCjGF6jZmaZgQsd7CMwAeIRZTcdhPHkviBCvQ/sNFtEH+Oo7PMTr4wtySt4z75otfsJkFUdNLOgiEaceZYsJ7VD /home/pdostal/.ssh/id_rsa</authorized_key>
+      </authorized_keys>
       <encrypted config:type="boolean">true</encrypted>
-      <fullname>nobody</fullname>
-      <gid>65534</gid>
-      <home>/var/lib/nobody</home>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
       <password_settings>
         <expire/>
         <flag/>
@@ -618,68 +641,32 @@
         <warn/>
       </password_settings>
       <shell>/bin/bash</shell>
-      <uid>65534</uid>
-      <user_password>!</user_password>
-      <username>nobody</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>Daemon</fullname>
-      <gid>2</gid>
-      <home>/sbin</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/sbin/nologin</shell>
-      <uid>2</uid>
-      <user_password>!</user_password>
-      <username>daemon</username>
+      <uid>0</uid>
+      <user_password>$6$qNRD776zQR5GZWwA$bqcr7tjA9KOsfPXCkOpxWrZSbEuLayT0ze9RTb3IIvYf04PnBtiAAW50gNfVEk1NPmxS6EqkMoMYJssa3SUZR.</user_password>
+      <username>root</username>
     </user>
     <user>
       <encrypted config:type="boolean">true</encrypted>
       <fullname>systemd Core Dumper</fullname>
-      <gid>484</gid>
+      <gid>483</gid>
       <home>/</home>
       <password_settings>
         <expire/>
         <flag/>
         <inact/>
-        <max/>
-        <min/>
-        <warn/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
       </password_settings>
       <shell>/sbin/nologin</shell>
-      <uid>484</uid>
+      <uid>483</uid>
       <user_password>!!</user_password>
       <username>systemd-coredump</username>
     </user>
     <user>
       <encrypted config:type="boolean">true</encrypted>
-      <fullname>User for D-Bus</fullname>
-      <gid>499</gid>
-      <home>/run/dbus</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/usr/bin/false</shell>
-      <uid>499</uid>
-      <user_password>!</user_password>
-      <username>messagebus</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
       <fullname>Chrony Daemon</fullname>
-      <gid>482</gid>
+      <gid>481</gid>
       <home>/var/lib/chrony</home>
       <password_settings>
         <expire/>
@@ -690,9 +677,81 @@
         <warn/>
       </password_settings>
       <shell>/bin/false</shell>
-      <uid>482</uid>
+      <uid>481</uid>
       <user_password>!</user_password>
       <username>chrony</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>bin</fullname>
+      <gid>1</gid>
+      <home>/bin</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>1</uid>
+      <user_password>!</user_password>
+      <username>bin</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>SSH daemon</fullname>
+      <gid>479</gid>
+      <home>/var/lib/sshd</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>479</uid>
+      <user_password>!</user_password>
+      <username>sshd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>nobody</fullname>
+      <gid>65534</gid>
+      <home>/var/lib/nobody</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>65534</uid>
+      <user_password>!</user_password>
+      <username>nobody</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Mailer daemon</fullname>
+      <gid>498</gid>
+      <home>/var/spool/clientmqueue</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>498</uid>
+      <user_password>!</user_password>
+      <username>mail</username>
     </user>
     <user>
       <encrypted config:type="boolean">true</encrypted>
@@ -714,63 +773,9 @@
     </user>
     <user>
       <encrypted config:type="boolean">true</encrypted>
-      <fullname>root</fullname>
-      <gid>0</gid>
-      <home>/root</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/bin/bash</shell>
-      <uid>0</uid>
-      <user_password>$5$fRX4.aZdaVU/Crn3$Ng.mgbwEtWdFfyg/54AC3ifRR2qr5jdEVSWO54FRF03</user_password>
-      <username>root</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>bin</fullname>
-      <gid>1</gid>
-      <home>/bin</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/sbin/nologin</shell>
-      <uid>1</uid>
-      <user_password>!</user_password>
-      <username>bin</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>systemd Time Synchronization</fullname>
-      <gid>483</gid>
-      <home>/</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/sbin/nologin</shell>
-      <uid>483</uid>
-      <user_password>!!</user_password>
-      <username>systemd-timesync</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>SSH daemon</fullname>
-      <gid>481</gid>
-      <home>/var/lib/sshd</home>
+      <fullname>Postfix Daemon</fullname>
+      <gid>51</gid>
+      <home>/var/spool/postfix</home>
       <password_settings>
         <expire/>
         <flag/>
@@ -780,9 +785,63 @@
         <warn/>
       </password_settings>
       <shell>/bin/false</shell>
-      <uid>481</uid>
+      <uid>51</uid>
       <user_password>!</user_password>
-      <username>sshd</username>
+      <username>postfix</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Daemon</fullname>
+      <gid>2</gid>
+      <home>/sbin</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>2</uid>
+      <user_password>!</user_password>
+      <username>daemon</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>systemd Time Synchronization</fullname>
+      <gid>482</gid>
+      <home>/</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>482</uid>
+      <user_password>!!</user_password>
+      <username>systemd-timesync</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>User for D-Bus</fullname>
+      <gid>499</gid>
+      <home>/run/dbus</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/usr/bin/false</shell>
+      <uid>499</uid>
+      <user_password>!</user_password>
+      <username>messagebus</username>
     </user>
   </users>
 </profile>

--- a/data/autoyast_xen/xen-SLES15-PV.xml
+++ b/data/autoyast_xen/xen-SLES15-PV.xml
@@ -24,7 +24,7 @@
         <product_dir/>
       </listentry>
       <listentry>
-        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product/]]></media_url>
+        <media_url><![CDATA[http://smt-scc.nue.suse.com/repo/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product?credentials=SMT-http_smt-scc_nue_suse_com]]></media_url>
         <product>sle-module-server-applications</product>
         <product_dir/>
       </listentry>
@@ -34,12 +34,12 @@
         <product_dir/>
       </listentry>
       <listentry>
-        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Products/SLE-Module-Legacy/15/x86_64/product/]]></media_url>
+        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Legacy/15/x86_64/update/]]></media_url>
         <product>sle-module-legacy</product>
         <product_dir/>
       </listentry>
       <listentry>
-        <media_url><![CDATA[http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product/]]></media_url>
+        <media_url><![CDATA[http://smt-scc.nue.suse.com/repo/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product?credentials=SMT-http_smt-scc_nue_suse_com]]></media_url>
         <product>sle-module-basesystem</product>
         <product_dir/>
       </listentry>
@@ -47,14 +47,14 @@
   </add-on>
   <bootloader>
     <global>
-      <append>splash=silent quiet showopts</append>
+      <append>splash=silent quiet showopts console=ttyS0</append>
       <gfxmode>auto</gfxmode>
       <hiddenmenu>false</hiddenmenu>
       <os_prober>false</os_prober>
       <terminal>gfxterm</terminal>
       <timeout config:type="integer">8</timeout>
       <trusted_grub>false</trusted_grub>
-      <xen_kernel_append>vga=gfx-1024x768x16</xen_kernel_append>
+      <xen_kernel_append>vga=gfx-1024x768x16 vga=gfx-1024x768x16</xen_kernel_append>
     </global>
     <loader_type>grub2</loader_type>
   </bootloader>
@@ -89,13 +89,6 @@
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>488</gid>
-      <group_password>x</group_password>
-      <groupname>lp</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
       <gid>1</gid>
       <group_password>x</group_password>
       <groupname>bin</groupname>
@@ -103,170 +96,37 @@
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>42</gid>
-      <group_password>x</group_password>
-      <groupname>trusted</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>5</gid>
-      <group_password>x</group_password>
-      <groupname>tty</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>498</gid>
-      <group_password>x</group_password>
-      <groupname>wheel</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>0</gid>
-      <group_password>x</group_password>
-      <groupname>root</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>493</gid>
-      <group_password>x</group_password>
-      <groupname>cdrom</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>491</gid>
-      <group_password>x</group_password>
-      <groupname>disk</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>484</gid>
-      <group_password>x</group_password>
-      <groupname>systemd-coredump</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>2</gid>
-      <group_password>x</group_password>
-      <groupname>daemon</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>485</gid>
-      <group_password>x</group_password>
-      <groupname>systemd-journal</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>492</gid>
-      <group_password>x</group_password>
-      <groupname>dialout</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>487</gid>
+      <gid>486</gid>
       <group_password>x</group_password>
       <groupname>tape</groupname>
       <userlist/>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>15</gid>
+      <gid>59</gid>
       <group_password>x</group_password>
-      <groupname>shadow</groupname>
-      <userlist/>
+      <groupname>maildrop</groupname>
+      <userlist>postfix</userlist>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>65534</gid>
-      <group_password>x</group_password>
-      <groupname>nobody</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>483</gid>
-      <group_password>x</group_password>
-      <groupname>systemd-timesync</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>496</gid>
-      <group_password>x</group_password>
-      <groupname>lock</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>490</gid>
-      <group_password>x</group_password>
-      <groupname>input</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>482</gid>
-      <group_password>x</group_password>
-      <groupname>chrony</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>65533</gid>
-      <group_password>x</group_password>
-      <groupname>nogroup</groupname>
-      <userlist>nobody</userlist>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>494</gid>
-      <group_password>x</group_password>
-      <groupname>audio</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>481</gid>
+      <gid>479</gid>
       <group_password>x</group_password>
       <groupname>sshd</groupname>
       <userlist/>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
-      <gid>489</gid>
+      <gid>482</gid>
       <group_password>x</group_password>
-      <groupname>kvm</groupname>
+      <groupname>systemd-coredump</groupname>
       <userlist/>
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
       <gid>495</gid>
       <group_password>x</group_password>
-      <groupname>utmp</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>497</gid>
-      <group_password>x</group_password>
-      <groupname>kmem</groupname>
-      <userlist/>
-    </group>
-    <group>
-      <encrypted config:type="boolean">true</encrypted>
-      <gid>486</gid>
-      <group_password>x</group_password>
-      <groupname>video</groupname>
+      <groupname>lock</groupname>
       <userlist/>
     </group>
     <group>
@@ -278,9 +138,170 @@
     </group>
     <group>
       <encrypted config:type="boolean">true</encrypted>
+      <gid>42</gid>
+      <group_password>x</group_password>
+      <groupname>trusted</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>490</gid>
+      <group_password>x</group_password>
+      <groupname>disk</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>493</gid>
+      <group_password>x</group_password>
+      <groupname>audio</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>484</gid>
+      <group_password>x</group_password>
+      <groupname>systemd-journal</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>488</gid>
+      <group_password>x</group_password>
+      <groupname>kvm</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>65533</gid>
+      <group_password>x</group_password>
+      <groupname>nogroup</groupname>
+      <userlist>nobody</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>0</gid>
+      <group_password>x</group_password>
+      <groupname>root</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>485</gid>
+      <group_password>x</group_password>
+      <groupname>video</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>51</gid>
+      <group_password>x</group_password>
+      <groupname>postfix</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>2</gid>
+      <group_password>x</group_password>
+      <groupname>daemon</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
       <gid>480</gid>
       <group_password>x</group_password>
       <groupname>polkitd</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>5</gid>
+      <group_password>x</group_password>
+      <groupname>tty</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>489</gid>
+      <group_password>x</group_password>
+      <groupname>input</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>65534</gid>
+      <group_password>x</group_password>
+      <groupname>nobody</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>492</gid>
+      <group_password>x</group_password>
+      <groupname>cdrom</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>491</gid>
+      <group_password>x</group_password>
+      <groupname>dialout</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>487</gid>
+      <group_password>x</group_password>
+      <groupname>lp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>497</gid>
+      <group_password>x</group_password>
+      <groupname>wheel</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>494</gid>
+      <group_password>x</group_password>
+      <groupname>utmp</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>496</gid>
+      <group_password>x</group_password>
+      <groupname>kmem</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>481</gid>
+      <group_password>x</group_password>
+      <groupname>chrony</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>483</gid>
+      <group_password>x</group_password>
+      <groupname>systemd-timesync</groupname>
+      <userlist/>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>498</gid>
+      <group_password>!</group_password>
+      <groupname>mail</groupname>
+      <userlist>postfix</userlist>
+    </group>
+    <group>
+      <encrypted config:type="boolean">true</encrypted>
+      <gid>15</gid>
+      <group_password>x</group_password>
+      <groupname>shadow</groupname>
       <userlist/>
     </group>
   </groups>
@@ -335,7 +356,7 @@
   </keyboard>
   <language>
     <language>en_US</language>
-    <languages/>
+    <languages>en_US</languages>
   </language>
   <login_settings/>
   <networking>
@@ -346,7 +367,7 @@
     <dns>
       <dhcp_hostname config:type="boolean">true</dhcp_hostname>
       <domain>suse.cz</domain>
-      <hostname>dhcp180</hostname>
+      <hostname>dhcp43</hostname>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <write_hostname config:type="boolean">false</write_hostname>
     </dns>
@@ -375,7 +396,7 @@
       <rule>
         <name>eth0</name>
         <rule>ATTR{address}</rule>
-        <value>00:16:3e:8e:78:e6</value>
+        <value>00:16:3e:4f:42:c1</value>
       </rule>
     </net-udev>
     <routing>
@@ -418,12 +439,12 @@
           <size>10727964160</size>
           <subvolumes config:type="list">
             <subvolume>
-              <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>root</path>
+              <copy_on_write config:type="boolean">false</copy_on_write>
+              <path>var</path>
             </subvolume>
             <subvolume>
               <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>srv</path>
+              <path>usr/local</path>
             </subvolume>
             <subvolume>
               <copy_on_write config:type="boolean">true</copy_on_write>
@@ -431,19 +452,11 @@
             </subvolume>
             <subvolume>
               <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>boot/grub2/x86_64-efi</path>
+              <path>srv</path>
             </subvolume>
             <subvolume>
               <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>home</path>
-            </subvolume>
-            <subvolume>
-              <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>boot/grub2/i386-pc</path>
-            </subvolume>
-            <subvolume>
-              <copy_on_write config:type="boolean">false</copy_on_write>
-              <path>var</path>
+              <path>root</path>
             </subvolume>
             <subvolume>
               <copy_on_write config:type="boolean">true</copy_on_write>
@@ -451,7 +464,15 @@
             </subvolume>
             <subvolume>
               <copy_on_write config:type="boolean">true</copy_on_write>
-              <path>usr/local</path>
+              <path>home</path>
+            </subvolume>
+            <subvolume>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>boot/grub2/x86_64-efi</path>
+            </subvolume>
+            <subvolume>
+              <copy_on_write config:type="boolean">true</copy_on_write>
+              <path>boot/grub2/i386-pc</path>
             </subvolume>
           </subvolumes>
           <subvolumes_prefix><![CDATA[@]]></subvolumes_prefix>
@@ -497,23 +518,26 @@
     <services>
       <disable config:type="list"/>
       <enable config:type="list">
+        <service>YaST2-Firstboot</service>
+        <service>YaST2-Second-Stage</service>
+        <service>auditd</service>
         <service>btrfsmaintenance-refresh</service>
         <service>ca-certificates</service>
         <service>cron</service>
-        <service>issue-generator</service>
-        <service>kbdsettings</service>
-        <service>purge-kernels</service>
-        <service>rollback</service>
-        <service>sshd</service>
-        <service>wicked</service>
         <service>wickedd-auto4</service>
         <service>wickedd-dhcp4</service>
         <service>wickedd-dhcp6</service>
         <service>wickedd-nanny</service>
-        <service>YaST2-Firstboot</service>
-        <service>YaST2-Second-Stage</service>
         <service>getty@tty1</service>
+        <service>irqbalance</service>
+        <service>issue-generator</service>
+        <service>kbdsettings</service>
+        <service>wicked</service>
+        <service>postfix</service>
+        <service>purge-kernels</service>
+        <service>rollback</service>
         <service>serial-getty@hvc0</service>
+        <service>sshd</service>
       </enable>
     </services>
   </services-manager>
@@ -522,6 +546,14 @@
     <install_recommended config:type="boolean">true</install_recommended>
     <instsource/>
     <packages config:type="list">
+      <package>yast2-users</package>
+      <package>yast2-services-manager</package>
+      <package>yast2-proxy</package>
+      <package>yast2-ntp-client</package>
+      <package>yast2-network</package>
+      <package>yast2-country</package>
+      <package>yast2-bootloader</package>
+      <package>yast2-add-on</package>
       <package>sles-release</package>
       <package>sle-module-web-scripting-release</package>
       <package>sle-module-server-applications-release</package>
@@ -532,11 +564,14 @@
       <package>sle-module-containers-release</package>
       <package>sle-module-basesystem-release</package>
       <package>openssh</package>
+      <package>numactl</package>
       <package>kexec-tools</package>
+      <package>irqbalance</package>
       <package>grub2</package>
       <package>glibc</package>
       <package>e2fsprogs</package>
       <package>btrfsprogs</package>
+      <package>autoyast2-installation</package>
       <package>autoyast2</package>
     </packages>
     <patterns config:type="list">
@@ -552,24 +587,6 @@
     <copy_config config:type="boolean">false</copy_config>
     <import config:type="boolean">false</import>
   </ssh_import>
-  <firewall>
-    <enable_firewall config:type="boolean">false</enable_firewall>
-    <start_firewall config:type="boolean">false</start_firewall>
-    <zones>
-      <zone>
-        <name>public</name>
-        <interfaces>
-          <interface>eth0</interface>
-        </interfaces>
-        <services config:type="list">
-          <service>ssh</service>
-        </services>
-        <ports config:type="list">
-          <port>22/tcp</port>
-        </ports>
-      </zone>
-    </zones>
-  </firewall>
   <timezone>
     <hwclock>UTC</hwclock>
     <timezone>Europe/Prague</timezone>
@@ -606,42 +623,6 @@
     </user>
     <user>
       <encrypted config:type="boolean">true</encrypted>
-      <fullname>systemd Time Synchronization</fullname>
-      <gid>483</gid>
-      <home>/</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/sbin/nologin</shell>
-      <uid>483</uid>
-      <user_password>!!</user_password>
-      <username>systemd-timesync</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>bin</fullname>
-      <gid>1</gid>
-      <home>/bin</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/sbin/nologin</shell>
-      <uid>1</uid>
-      <user_password>!</user_password>
-      <username>bin</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
       <fullname>nobody</fullname>
       <gid>65534</gid>
       <home>/var/lib/nobody</home>
@@ -649,9 +630,9 @@
         <expire/>
         <flag/>
         <inact/>
-        <max/>
-        <min/>
-        <warn/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>65534</uid>
@@ -659,45 +640,11 @@
       <username>nobody</username>
     </user>
     <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>systemd Core Dumper</fullname>
-      <gid>484</gid>
-      <home>/</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/sbin/nologin</shell>
-      <uid>484</uid>
-      <user_password>!!</user_password>
-      <username>systemd-coredump</username>
-    </user>
-    <user>
-      <encrypted config:type="boolean">true</encrypted>
-      <fullname>Chrony Daemon</fullname>
-      <gid>482</gid>
-      <home>/var/lib/chrony</home>
-      <password_settings>
-        <expire/>
-        <flag/>
-        <inact/>
-        <max/>
-        <min/>
-        <warn/>
-      </password_settings>
-      <shell>/bin/false</shell>
-      <uid>482</uid>
-      <user_password>!</user_password>
-      <username>chrony</username>
-    </user>
-    <user>
-		<!--<authorized_keys config:type="list">
+      <authorized_keys config:type="list">
         <authorized_key>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCqQ+zJeaCMN3F83/2sYUeG0CTqLRLw3jLtTNunfm2nP4hidH9Kg4ZhT4s+gXYGOKkAsIc6YbqG5nfq11LpwMY8GBglFHWGo8dkHrb9GqdcEfXJBAM6neEHtNu8aQ7eJT8ePvAqpgi7/6RTD+aIw1PQ09aiqgjn6wZDXengm2Ug93evd6PoyvIa3jFCnJr9jD5GhMz+QnY09U3Is5mDHQNH7C23zDiuBm5dWQ82UN2bRkhbIzFRl/09HWQHYlCwAlKu8vj9fSjwH9MCIRu4CoCF6CgKiC9MrH8l+VUMswhWhjp7uJYr0zGK1N3YGPIXYccPJn98ya5kXKfC236U9USZ /home/slemke/.ssh/id_rsa</authorized_key>
-	</authorized_keys>-->
+        <authorized_key>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDDEfz0lP5oO03Rw8vSyzqwt06VIEFA4x478DERaSWHPTD5ULqqdZQS1vsFpTtAm1eT4Ix4njXvSh4T2d2aXYyCgB+ElJI1h0tpbtX7OtenJ7c3rUows61jqmXLFrnIfWbZL2uhomTsOziQwxKoXS3PRxFgoRaZGzHGD4J4HOEfiP8YHQ53igUKbmmDY8yVZya/dyEtKe8bukcbZbGIosKgMoaLsdpbNkln7bU1oLqMuogHGtqRdZ9gQLz2mz5I7Ml/lSeCEdbkqVbOjydVhF2Qm4bvbVjyER+n0VqhXOmeKcauEOQbEafYrJjWvDetMY4j8NwWCeJq0QA7gYRd7967 /home/bhavel/.ssh/id_rsa</authorized_key>
+        <authorized_key>ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC2beiZY6ugIsKQwP075ds/IxqR65vluwzD/fCjjMNCaiXQJap8WhSRAOv8BMfqzSQbuRFIRr+a8YLbQqMw/kEieVSATfhx9DM4GUVDTMvDho81No4nqe7aC+3U48wyeGy9LZGTGNEzt2zoPhxqAho8g4+9rc8VaYH01O21xW2Ep02vYystCc8/bAFbB7XsYo8YTlHGxtIHoLCGEEtqO4qkd9rYLHs8Hc0y7GGGMGhbDEskooGaMJeEzkUzzNf8qFCjGF6jZmaZgQsd7CMwAeIRZTcdhPHkviBCvQ/sNFtEH+Oo7PMTr4wtySt4z75otfsJkFUdNLOgiEaceZYsJ7VD /home/pdostal/.ssh/id_rsa</authorized_key>
+      </authorized_keys>
       <encrypted config:type="boolean">true</encrypted>
       <fullname>root</fullname>
       <gid>0</gid>
@@ -712,14 +659,32 @@
       </password_settings>
       <shell>/bin/bash</shell>
       <uid>0</uid>
-      <user_password>$5$fRX4.aZdaVU/Crn3$Ng.mgbwEtWdFfyg/54AC3ifRR2qr5jdEVSWO54FRF03</user_password>
+      <user_password>$6$2ZlAtV2XO9WiTcdG$a2E2rF5IE7j.hQOvAXaz8dtSn5mI2lxVJLwxXqLIDfiM1QX.nf2/ICqSjbmMNndTjSuXRyjkGEL3n5GwZV1/o0</user_password>
       <username>root</username>
     </user>
     <user>
       <encrypted config:type="boolean">true</encrypted>
-      <fullname>Daemon</fullname>
-      <gid>2</gid>
-      <home>/sbin</home>
+      <fullname>systemd Time Synchronization</fullname>
+      <gid>483</gid>
+      <home>/</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>483</uid>
+      <user_password>!!</user_password>
+      <username>systemd-timesync</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Mailer daemon</fullname>
+      <gid>498</gid>
+      <home>/var/spool/clientmqueue</home>
       <password_settings>
         <expire/>
         <flag/>
@@ -729,15 +694,15 @@
         <warn/>
       </password_settings>
       <shell>/sbin/nologin</shell>
-      <uid>2</uid>
+      <uid>498</uid>
       <user_password>!</user_password>
-      <username>daemon</username>
+      <username>mail</username>
     </user>
     <user>
       <encrypted config:type="boolean">true</encrypted>
-      <fullname>SSH daemon</fullname>
+      <fullname>Chrony Daemon</fullname>
       <gid>481</gid>
-      <home>/var/lib/sshd</home>
+      <home>/var/lib/chrony</home>
       <password_settings>
         <expire/>
         <flag/>
@@ -749,7 +714,43 @@
       <shell>/bin/false</shell>
       <uid>481</uid>
       <user_password>!</user_password>
+      <username>chrony</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>SSH daemon</fullname>
+      <gid>479</gid>
+      <home>/var/lib/sshd</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>479</uid>
+      <user_password>!</user_password>
       <username>sshd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>bin</fullname>
+      <gid>1</gid>
+      <home>/bin</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>1</uid>
+      <user_password>!</user_password>
+      <username>bin</username>
     </user>
     <user>
       <encrypted config:type="boolean">true</encrypted>
@@ -768,6 +769,60 @@
       <uid>480</uid>
       <user_password>!</user_password>
       <username>polkitd</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Postfix Daemon</fullname>
+      <gid>51</gid>
+      <home>/var/spool/postfix</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/false</shell>
+      <uid>51</uid>
+      <user_password>!</user_password>
+      <username>postfix</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>Daemon</fullname>
+      <gid>2</gid>
+      <home>/sbin</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>2</uid>
+      <user_password>!</user_password>
+      <username>daemon</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">true</encrypted>
+      <fullname>systemd Core Dumper</fullname>
+      <gid>482</gid>
+      <home>/</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/sbin/nologin</shell>
+      <uid>482</uid>
+      <user_password>!!</user_password>
+      <username>systemd-coredump</username>
     </user>
     <user>
       <encrypted config:type="boolean">true</encrypted>

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2214,6 +2214,7 @@ sub load_xen_hypervisor_tests {
     }
     # Load guest installation tests
     loadtest 'virtualization/xen/prepare_guests';
+    loadtest 'virtualization/xen/waitfor_guests';
     # Apply updates and reboot
     loadtest 'virtualization/xen/patch_and_reboot';
     loadtest "virt_autotest/login_console";
@@ -2227,10 +2228,14 @@ sub load_xen_client_tests() {
     loadtest 'virtualization/xen/install_virtmanager';
     # Connect to hypervisor using SSH
     loadtest 'virtualization/xen/ssh_hypervisor';
-    # Connect to guests using SSH
-    loadtest 'virtualization/xen/ssh_guests';
     # Connect to the Xen hypervisor using virt-manager
     loadtest 'virtualization/xen/virtmanager';
+    # Exchange SSH keys with guests
+    loadtest 'virtualization/xen/ssh_guests_init';
+    # Connect to guests using SSH
+    loadtest 'virtualization/xen/ssh_guests';
+    # Add test repositories and patch our guests
+    loadtest 'virtualization/xen/patch_guests';
     # Try to save and restore the state of the guest
     loadtest 'virtualization/xen/save_and_restore';
     # Try to change properties of guests
@@ -2249,6 +2254,10 @@ sub load_xen_client_tests() {
     loadtest 'virtualization/xen/xl_stop';
     # Start virsh guests again
     loadtest 'virtualization/xen/virsh_start';
+    # Connect to the Xen hypervisor using virt-manager
+    loadtest 'virtualization/xen/virtmanager';
+    # Connect to guests using SSH
+    loadtest 'virtualization/xen/ssh_guests';
 }
 
 sub load_extra_tests_syscontainer {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -38,6 +38,7 @@ our @EXPORT = qw(
   get_netboot_mirror
   zypper_call
   fully_patch_system
+  ssh_fully_patch_system
   minimal_patch_system
   workaround_type_encrypted_passphrase
   select_user_gnome
@@ -420,6 +421,14 @@ sub fully_patch_system {
     zypper_call('patch --with-interactive -l', exitcode => [0, 102, 103], timeout => 1500);
     # second run, full system update
     zypper_call('patch --with-interactive -l', exitcode => [0, 102], timeout => 6000);
+}
+
+sub ssh_fully_patch_system {
+    my $host = shift;
+    # first run, possible update of packager -- exit code 103
+    assert_script_run("ssh root\@$host 'zypper -n patch --with-interactive -l'", exitcode => [0, 102, 103], timeout => 1500);
+    # second run, full system update
+    assert_script_run("ssh root\@$host 'zypper -n patch --with-interactive -l'", exitcode => [0, 102], timeout => 6000);
 }
 
 # zypper doesn't offer --updatestack-only option before 12-SP1, use patch for sp0 to update packager

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -27,7 +27,7 @@ sub login_to_console {
     select_console 'sol', await_console => 0;
 
     # Wait for bootload for the first time.
-    assert_screen([qw(grub2 grub1)], 150);
+    assert_screen([qw(grub2 grub1)], 210);
 
     if (!get_var("reboot_for_upgrade_step")) {
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {

--- a/tests/virtualization/xen/dom_install.pm
+++ b/tests/virtualization/xen/dom_install.pm
@@ -16,34 +16,23 @@
 # Summary: Prepare the dom0 metrics environment
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
 
-
-use base "x11test";
+use base "consoletest";
 use xen;
 use strict;
 use testapi;
 use utils;
 
 sub run {
-    my ($self) = @_;
-    select_console 'x11';
+    my ($self)     = @_;
     my $hypervisor = get_required_var('QAM_XEN_HYPERVISOR');
     my $domain     = get_required_var('QAM_XEN_DOMAIN');
-
-    x11_start_program('xterm');
-    send_key 'super-up';
 
     assert_script_run "ssh root\@$hypervisor 'zypper -n in vhostmd'";
 
     foreach my $guest (keys %xen::guests) {
         record_info "$guest", "Install vm-dump-metrics on xl-$guest";
-
         assert_script_run "ssh root\@$guest.$domain 'zypper -n in vm-dump-metrics'";
-
-        clear_console;
     }
-
-    wait_screen_change { send_key 'alt-f4'; };
-
 }
 
 sub test_flags {

--- a/tests/virtualization/xen/dom_metrics.pm
+++ b/tests/virtualization/xen/dom_metrics.pm
@@ -16,21 +16,17 @@
 # Summary: Obtain the dom0 metrics
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
 
-
-use base "x11test";
+use base "consoletest";
 use xen;
 use strict;
 use testapi;
 use utils;
 
 sub run {
-    my ($self) = @_;
-    select_console 'x11';
+    my ($self)     = @_;
     my $hypervisor = get_required_var('QAM_XEN_HYPERVISOR');
     my $domain     = get_required_var('QAM_XEN_DOMAIN');
 
-    x11_start_program('xterm');
-    send_key 'super-up';
     assert_script_run "ssh root\@$hypervisor 'vhostmd'";
 
     foreach my $guest (keys %xen::guests) {
@@ -39,12 +35,7 @@ sub run {
         assert_script_run "ssh root\@$hypervisor 'xl block-attach xl-$guest /dev/shm/vhostmd0,,xvdc,ro'";
         assert_script_run "ssh root\@$guest.$domain 'vm-dump-metrics' | grep 'SUSE LLC'";
         assert_script_run "ssh root\@$hypervisor 'xl block-detach xl-$guest xvdc'";
-
-        clear_console;
     }
-
-    wait_screen_change { send_key 'alt-f4'; };
-
 }
 
 sub test_flags {

--- a/tests/virtualization/xen/hotplugging.pm
+++ b/tests/virtualization/xen/hotplugging.pm
@@ -10,23 +10,16 @@
 # Summary: Virtual network and virtual block device hotplugging
 # Maintainer: Jan Baier <jbaier@suse.cz>
 
-use base "x11test";
+use base "consoletest";
 use xen;
 use strict;
 use testapi;
 use utils;
 
 sub run {
-    my ($self) = @_;
-    select_console 'x11';
+    my ($self)     = @_;
     my $hypervisor = get_required_var('QAM_XEN_HYPERVISOR');
     my $domain     = get_required_var('QAM_XEN_DOMAIN');
-
-    x11_start_program('xterm');
-    send_key 'super-up';
-
-    # Ensure virsh is installed
-    assert_script_run "ssh root\@$hypervisor 'zypper -n in libvirt-client'", 180;
 
     foreach my $guest (keys %xen::guests) {
         record_info "$guest", "Processing $guest now";
@@ -34,7 +27,12 @@ sub run {
         # Virtual network
         assert_script_run "ssh root\@$hypervisor 'virsh attach-interface --domain $guest --type bridge --source br0 --live'";
         assert_script_run "ssh root\@$hypervisor 'virsh domiflist $guest'";
-        assert_script_run "ssh root\@$guest.$domain 'ip l'";
+        for (my $i = 0; $i <= 120; $i++) {
+            if (script_run("ssh root\@$guest.$domain 'ip l'") == 0) {
+                last;
+            }
+            sleep 3;
+        }
 
         # Disk
         assert_script_run "ssh root\@$hypervisor 'mkdir -p /var/lib/libvirt/images/add/'";
@@ -55,10 +53,7 @@ sub run {
         assert_script_run "ssh root\@$hypervisor 'virsh setmem --domain $guest --size 1024M --live'";
         assert_script_run "ssh root\@$guest.$domain 'free'";
         assert_script_run "ssh root\@$hypervisor 'xl list'";
-        clear_console;
     }
-
-    wait_screen_change { send_key 'alt-f4'; };
 }
 
 sub test_flags {

--- a/tests/virtualization/xen/patch_guests.pm
+++ b/tests/virtualization/xen/patch_guests.pm
@@ -1,0 +1,37 @@
+# XEN regression tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Apply patches to the all of our guests
+# Maintainer: Pavel Dostál <pdostal@suse.cz>
+
+use base "consoletest";
+use warnings;
+use strict;
+use testapi;
+use qam 'ssh_add_test_repositories';
+use utils 'ssh_fully_patch_system';
+use xen;
+
+sub run {
+    my ($self) = @_;
+    my $domain = get_required_var('QAM_XEN_DOMAIN');
+
+    foreach my $guest (keys %xen::guests) {
+        record_info "$guest", "Patching $guest";
+        ssh_add_test_repositories "$guest.$domain";
+        ssh_fully_patch_system "$guest.$domain";
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+

--- a/tests/virtualization/xen/prepare_guests.pm
+++ b/tests/virtualization/xen/prepare_guests.pm
@@ -29,19 +29,13 @@ sub run {
 
     # Show all guests
     assert_script_run 'xl list';
+    assert_script_run "mkdir -p /var/lib/libvirt/images/xen/";
     save_screenshot;
 
     # Install every defined guest
-    # TODO: It will be nice to run this in parallel
     foreach my $guest (keys %xen::guests) {
         $self->create_guest($guest, 'virt-install');
-        # Show guest details
-        assert_script_run "xl list $guest";
     }
-
-    # All guests should be now installed, show them
-    assert_script_run 'xl list';
-    save_screenshot;
 }
 
 1;

--- a/tests/virtualization/xen/ssh_guests.pm
+++ b/tests/virtualization/xen/ssh_guests.pm
@@ -16,7 +16,7 @@
 # Summary: This tries to ping and SSH to every guest we created.
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
 
-use base "x11test";
+use base "consoletest";
 use xen;
 use strict;
 use testapi;
@@ -24,24 +24,16 @@ use utils;
 
 sub run {
     my ($self) = @_;
-    select_console 'x11';
+    select_console 'root-console';
+    opensusebasetest::select_serial_terminal();
     my $hypervisor = get_required_var('QAM_XEN_HYPERVISOR');
     my $domain     = get_required_var('QAM_XEN_DOMAIN');
 
-    x11_start_program('xterm');
-    send_key 'super-up';
-
     foreach my $guest (keys %xen::guests) {
         record_info "$guest", "Establishing SSH connection to $guest";
-        assert_script_run "ssh root\@$hypervisor 'ping -c5 -W1 $guest.$domain'";
-        assert_script_run "ssh-keyscan $guest.$domain >> ~/.ssh/known_hosts";
-        exec_and_insert_password "ssh-copy-id root\@$guest.$domain";
-        assert_script_run "ssh root\@$guest.$domain hostname";
-        clear_console;
+        assert_script_run "ssh root\@$hypervisor 'ping -c3 -W1 $guest.$domain'";
+        assert_script_run "ssh root\@$guest.$domain hostname -f";
     }
-
-    wait_screen_change { send_key 'alt-f4'; };
-
 }
 
 sub test_flags {

--- a/tests/virtualization/xen/virtmanager.pm
+++ b/tests/virtualization/xen/virtmanager.pm
@@ -26,45 +26,71 @@ sub run {
     my ($self) = @_;
     select_console 'x11';
     my $hypervisor = get_required_var('QAM_XEN_HYPERVISOR');
+    my $firstrun   = 0;
 
     x11_start_program 'virt-manager', target_match => 'virt-manager';
 
-    assert_screen "virt-manager_add-connection";
-    send_key 'spc';
-    send_key 'down';
-    send_key 'down';
-    send_key 'spc';
-    save_screenshot;    # XEN selected
-    send_key 'tab';
-    send_key 'spc';
-    save_screenshot;    # Connect to remote host ticked
-    send_key 'tab';
-    send_key 'tab';
-    type_string 'root';
-    save_screenshot;    # root written
-    send_key 'tab';
-    type_string "$hypervisor";
-    save_screenshot;    # $hypervisor written
-    send_key 'tab';
-    send_key 'spc';
-    save_screenshot;    # autoconnect ticked
-    send_key 'ret';
-    assert_screen "virt-manager_connected";
-
+    assert_screen([qw(virt-manager_connected virt-manager_add-connection)]);
+    if (match_has_tag 'virt-manager_add-connection') {
+        $firstrun = 1;
+        send_key 'spc';
+        send_key 'down';
+        send_key 'down';
+        send_key 'spc';
+        save_screenshot;    # XEN selected
+        send_key 'tab';
+        send_key 'spc';
+        save_screenshot;    # Connect to remote host ticked
+        send_key 'tab';
+        send_key 'tab';
+        type_string 'root';
+        save_screenshot;    # root written
+        send_key 'tab';
+        type_string "$hypervisor";
+        save_screenshot;    # $hypervisor written
+        send_key 'tab';
+        send_key 'spc';
+        save_screenshot;    # autoconnect ticked
+        send_key 'ret';
+        assert_screen "virt-manager_connected";
+    }
     foreach my $guest (keys %xen::guests) {
         record_info "$guest", "Going to check $guest console";
 
         assert_and_dclick "virt-manager_list-$guest";
-        if (!check_screen 'virt-manager_login-screen', 30) {
-            send_key 'backspace';    # In case screen is off
-            assert_and_click 'virt-manager_send-key';
-            assert_and_click 'virt-manager_ctrl-alt-f2';
-            assert_screen "virt-manager_login-screen";
+        wait_still_screen 3;
+        mouse_set(30, 200);
+        mouse_click();
+        save_screenshot();
+        hold_key "ctrl-alt";
+        release_key "ctrl-alt";
+        if ($firstrun == 1) {
+            assert_and_click 'virt-manager_view';
+            assert_and_click 'virt-manager_resizetovm';
+            mouse_set(300, 70);
         }
-        wait_screen_change { send_key 'alt-f4'; };
+        detect_login_screen();
+        assert_and_click 'virt-manager_shutdown';
+        assert_and_click 'virt-manager_poweron';
+        detect_login_screen(120);
+        assert_and_click 'virt-manager_file';
+        assert_and_click 'virt-manager_close';
     }
 
     wait_screen_change { send_key 'alt-f4'; };
+}
+
+sub detect_login_screen {
+    my $timeout = shift // 5;
+    if (!check_screen 'virt-manager_login-screen', $timeout) {
+        send_key 'esc';
+        send_key 'backspace';
+    }
+    if (!check_screen 'virt-manager_login-screen', 5) {
+        assert_and_click 'virt-manager_send-key';
+        assert_and_click 'virt-manager_ctrl-alt-f2';
+        assert_screen "virt-manager_login-screen";
+    }
 }
 
 sub test_flags {

--- a/tests/virtualization/xen/waitfor_guests.pm
+++ b/tests/virtualization/xen/waitfor_guests.pm
@@ -1,0 +1,47 @@
+# XEN regression tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Wait for guests so they finish the installation
+# Maintainer: Jan Baier <jbaier@suse.cz>
+
+use base 'xen';
+
+use strict;
+use testapi;
+use utils;
+
+sub run {
+    my $self   = shift;
+    my $domain = get_required_var('QAM_XEN_DOMAIN');
+
+    zypper_call '-t in nmap';
+
+    foreach my $guest (keys %xen::guests) {
+        for (my $i = 1; $i <= 60; $i++) {
+            if (script_run("nmap $guest.$domain -PN -p ssh | grep open") == 0) {
+                last;
+            }
+            sleep 60;
+        }
+    }
+
+    # All guests should be now installed, show them
+    assert_script_run 'xl list';
+    save_screenshot;
+
+    assert_script_run "virsh shutdown $_" foreach (keys %xen::guests);
+    for (my $i = 0; $i <= 120; $i++) {
+        if (script_run("virsh list --all | grep -v Domain-0 | grep running") == 1) {
+            last;
+        }
+        sleep 1;
+    }
+}
+
+1;

--- a/tests/virtualization/xen/xl_stop.pm
+++ b/tests/virtualization/xen/xl_stop.pm
@@ -16,7 +16,7 @@
 # Summary: This stops all xl VMs
 # Maintainer: Pavel Dostál <pdostal@suse.cz>
 
-use base "x11test";
+use base "consoletest";
 use xen;
 use strict;
 use testapi;
@@ -24,22 +24,12 @@ use utils;
 
 sub run {
     my ($self) = @_;
-    select_console 'x11';
     my $hypervisor = get_required_var('QAM_XEN_HYPERVISOR');
-
-    x11_start_program('xterm');
-    send_key 'super-up';
 
     foreach my $guest (keys %xen::guests) {
         record_info "$guest", "Stopping xl-$guest guests";
-
         assert_script_run "ssh root\@$hypervisor xl shutdown -w xl-$guest";
-
-        clear_console;
     }
-
-    wait_screen_change { send_key 'alt-f4'; };
-
 }
 
 sub test_flags {


### PR DESCRIPTION
Hello, after #6511 I've this pull request which enables the test also for SLE 15. I fixed the disk issue on a physical machine with multiple hard drives and I changed autoyast profiles for our guests.

- Related ticket: [poo#40610](https://progress.opensuse.org/issues/40610) [poo#43739](https://progress.opensuse.org/issues/43739)
- Needles: [os-autoinst-needles-sles#1048](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1048)
- Verification run: [SLE12sp3@IPMI](
http://pdostal-server.suse.cz/tests/1041)+[client](
http://pdostal-server.suse.cz/tests/1048), [SLE12sp4@IPMI](
http://pdostal-server.suse.cz/tests/1036)+[client](http://pdostal-server.suse.cz/tests/1038), [SLE15@IPMI](http://pdostal-server.suse.cz/tests/996)+[client](http://pdostal-server.suse.cz/tests/1007)
- Different testsuites: [SLE12sp3@64bit](http://pdostal-server.suse.cz/tests/964), [SLE12sp4@64bit](http://pdostal-server.suse.cz/tests/966), [SLE15@64bit](http://pdostal-server.suse.cz/tests/984)