### PR TITLE
qa_test_klp fixes

### DIFF
--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -123,7 +123,7 @@ sub check_patch_variables {
     if ($patch && $incident_id) {
         die('It is not possible to have defined INCIDENT_PATCH and INCIDENT_ID at the same time');
     }
-    elsif (!($patch) && !($incident_id)) {
+    elsif (!$patch && !$incident_id) {
         die("Missing INCIDENT_PATCH or INCIDENT_ID");
     }
 }

--- a/tests/kernel/qa_test_klp.pm
+++ b/tests/kernel/qa_test_klp.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -30,15 +30,13 @@ sub run {
     # Set and check patch variables
     my $incident_id = get_var('INCIDENT_ID');
     my $patch       = get_var('INCIDENT_PATCH');
-    check_patch_variables($patch, $incident_id);
+    check_patch_variables($patch, $incident_id) if (!get_var('BETA'));
 
     select_console('root-console');
     zypper_call('ar -f -G ' . get_required_var('QA_HEAD_REPO') . ' qa_head');
     zypper_call('in -l bats hiworkload', exitcode => [0, 106, 107]);
 
-    if (is_sle('<15') and ($patch or $incident_id)) {
-        add_suseconnect_product("sle-sdk");
-    }
+    add_suseconnect_product("sle-sdk") if (is_sle('<15'));
 
     zypper_call('in -l git gcc kernel-devel make');
 

--- a/tests/kernel/qa_test_klp.pm
+++ b/tests/kernel/qa_test_klp.pm
@@ -20,6 +20,8 @@ use version_utils 'is_sle';
 use qam;
 
 sub run {
+    my $self = shift;
+
     if (get_var('AZURE')) {
         record_info("Azure don't have kGraft/LP infrastructure");
         return;
@@ -32,7 +34,7 @@ sub run {
     my $patch       = get_var('INCIDENT_PATCH');
     check_patch_variables($patch, $incident_id) if (!get_var('BETA'));
 
-    select_console('root-console');
+    is_sle(">12-sp1") ? $self->select_serial_terminal() : select_console('root-console');
     zypper_call('ar -f -G ' . get_required_var('QA_HEAD_REPO') . ' qa_head');
     zypper_call('in -l bats hiworkload', exitcode => [0, 106, 107]);
 


### PR DESCRIPTION
Fixes to enable qa_test_klp testing for product pre-releases

NOTE: SLE12 SP4 failure due failing SUSEConnect registration is not affected by this change (was already before (http://quasar.suse.cz/tests/1597). Other SLE12 versions are OK.

- Related ticket: https://progress.opensuse.org/issues/46352
- Verification run:
http://quasar.suse.cz/tests/1598
http://quasar.suse.cz/tests/1596
http://quasar.suse.cz/tests/1600
http://quasar.suse.cz/tests/1599
http://quasar.suse.cz/tests/1601
http://quasar.suse.cz/tests/1602
http://quasar.suse.cz/tests/1603
http://quasar.suse.cz/tests/1604
http://quasar.suse.cz/tests/1605
