### PR TITLE
publiccloud: Cleanup includes

### DIFF
--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -15,8 +15,6 @@ use base "publiccloud::basetest";
 use strict;
 use testapi;
 use utils;
-use version_utils 'is_sle';
-use registration 'add_suseconnect_product';
 use publiccloud::ec2;
 use publiccloud::azure;
 use publiccloud::gce;


### PR DESCRIPTION
Fixes: bdbc58d04 ("publiccloud: avoid running upload_img in ipa and ltp tests")