### PR TITLE
Adjust yast2_hostnames module to simplify fails identifying

### DIFF
--- a/tests/yast2_gui/yast2_hostnames.pm
+++ b/tests/yast2_gui/yast2_hostnames.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -52,6 +52,12 @@ sub run {
 # Test ends in root-console, default post_run_hook does not work here
 sub post_run_hook {
     set_var('YAST2_GUI_TERMINATE_PREVIOUS_INSTANCES', 1);
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    upload_logs('/etc/hosts');
+    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/yast2_gui/yast2_hostnames.pm
+++ b/tests/yast2_gui/yast2_hostnames.pm
@@ -46,7 +46,7 @@ sub run {
     wait_screen_change { send_key "alt-o"; };
     # Check that entry was correctly edited in /etc/hosts
     select_console "root-console";
-    assert_script_run q#grep '195\.135\.221\.134\sdownload\.opensuse\.org\sdownload-srv' /etc/hosts#;
+    assert_script_run q#grep '195\.135\.221\.134\s*download\.opensuse\.org\s*download-srv' /etc/hosts#;
 }
 
 # Test ends in root-console, default post_run_hook does not work here


### PR DESCRIPTION
Changes:
* To simplify issues investigation for the yast2_hostname module,
the /etc/hosts file is uploaded on post fail hook;
* The grep pattern is changed to allow multiple spaces between the entries
in /etc/hosts file.

Related ticket: https://progress.opensuse.org/issues/46232

Verification run (the test fails, which is expected for the verification run, as it shows that [yast2_hostnames-hosts](http://oorlov-vm.qa.suse.de/tests/723/file/yast2_hostnames-hosts) file is uploaded): http://oorlov-vm.qa.suse.de/tests/723
