### PR TITLE
Update password prompt for DE language on JeOS

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -68,8 +68,9 @@ escape sequences (i.e. a single #) and changes the terminal width.
 =cut
 sub login {
     die 'Login expects two arguments' unless @_ == 2;
-    my $user   = shift;
-    my $escseq = qr/(\e [\(\[] [\d\w]{1,2})/x;
+    my $user        = shift;
+    my $escseq      = qr/(\e [\(\[] [\d\w]{1,2})/x;
+    my $pass_prompt = (get_var('JEOSINSTLANG') == 'de_DE') ? 'Passwort' : 'Password';
 
     $serial_term_prompt = shift;
 
@@ -80,7 +81,7 @@ sub login {
     type_string("\n");
     wait_serial(qr/login:\s*$/i);
     type_string("$user\n");
-    wait_serial(qr/Password:\s*$/i);
+    wait_serial(qr/$pass_prompt:\s*$/i);
     type_password;
     type_string("\n");
     wait_serial(qr/$escseq* \w+:~\s\# $escseq* \s*$/x);


### PR DESCRIPTION
This updates the password prompt to match the DE output.

- Related ticket: https://progress.opensuse.org/issues/46130
- Verification run: http://ccret.suse.cz/tests/2411#
