### PR TITLE
Revert "Lower 'CPU soft lockup' error from hard to soft failure"

### DIFF
--- a/lib/known_bugs.pm
+++ b/lib/known_bugs.pm
@@ -48,7 +48,7 @@ sub create_list_of_serial_failures {
     }
 
 
-    push @$serial_failures, {type => 'soft', message => 'CPU soft lockup detected', pattern => quotemeta 'soft lockup - CPU'};
+    push @$serial_failures, {type => 'hard', message => 'CPU soft lockup detected', pattern => quotemeta 'soft lockup - CPU'};
 
     return $serial_failures;
 }


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#6444 as this is against our rule to only use soft-fails with bugrefs and also tooling for SLE milestone reporting relies on it.