### PR TITLE
xfstests: Upload y2logs if enable kdump fail

### DIFF
--- a/tests/xfstests/enable_kdump.pm
+++ b/tests/xfstests/enable_kdump.pm
@@ -55,4 +55,16 @@ sub test_flags {
     return {fatal => 1};
 }
 
+sub enable_kdump_failure_analysis {
+    # Upload y2log for analysis if enable kdump fails
+    assert_script_run 'save_y2logs /tmp/y2logs.tar.bz2';
+    upload_logs '/tmp/y2logs.tar.bz2';
+    save_screenshot;
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->enable_kdump_failure_analysis;
+}
+
 1;


### PR DESCRIPTION
Add y2log upload, when enable kdump process fail. Since this process will call yast2 to check hardware and then enable kdump. Some bugs may happen during this process. 
e.g.https://bugzilla.suse.com/show_bug.cgi?id=1116305 

- Related ticket: https://progress.opensuse.org/issues/43895
- Verification run: http://10.67.133.102/tests/758#downloads
(After enable_kdump fail it upload y2logs success)
