### PR TITLE
Adding test for supportutils.

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1538,6 +1538,7 @@ sub load_extra_tests_console {
         loadtest 'console/mutt';
     }
     loadtest 'console/systemd_testsuite' if is_sle('15+') && get_var('QA_HEAD_REPO');
+    loadtest 'console/supportutils' if is_sle;
     loadtest 'console/mdadm' unless is_jeos;
     loadtest 'console/journalctl';
     # sysauth test scenarios run in the console

--- a/tests/console/supportutils.pm
+++ b/tests/console/supportutils.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test is files created by supportconfig are readable and contain some basic data.
+# Maintainer: Juraj Hura <jhura@suse.com>
+
+use base "consoletest";
+use strict;
+use testapi;
+
+sub run {
+    select_console 'root-console';
+
+    assert_script_run "rm -rf nts_* ||:";
+    assert_script_run "supportconfig -t . -B test", 300;
+    assert_script_run "cd nts_test";
+
+    # Check few file whether expected content is there.
+    assert_script_run "diff <(awk '/\\/proc\\/cmdline/{getline; print}' boot.txt) /proc/cmdline";
+    assert_script_run "grep -q -f /etc/os-release basic-environment.txt";
+    assert_script_run "grep -q -f /etc/passwd pam.txt";
+
+    assert_script_run "cd ..";
+    assert_script_run "rm -rf nts_* ||:";
+}
+
+1;


### PR DESCRIPTION
Simple test for supportcongif to be used for regression testing in QAM.

- Related ticket: https://progress.opensuse.org/issues/45773
- Verification run: 
    SLE 15: http://hoorhay.suse.cz/tests/135
    SLE 12 SP4: http://hoorhay.suse.cz/tests/136
    SLE 12 SP3: http://hoorhay.suse.cz/tests/137