### PR TITLE
Assure focused password textbox

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -765,7 +765,12 @@ sub handle_login {
             select_user_gnome($myuser);
         }
     }
-    assert_screen 'displaymanager-password-prompt', no_wait => 1;
+    assert_screen [qw(displaymanager-password-prompt displaymanager-focused-password-textbox)];
+    if (!match_has_tag('displaymanager-focused-password-textbox')) {
+        record_soft_failure('bsc#1122664 - password textbox is not focused');
+        assert_and_click 'displaymanager-password-prompt';
+        assert_screen 'displaymanager-focused-password-textbox';
+    }
     type_password;
     send_key "ret";
 }

--- a/tests/x11/user_gui_login.pm
+++ b/tests/x11/user_gui_login.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2018 SUSE LLC
+# Copyright © 2017-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/46223
- Related bug: https://bugzilla.opensuse.org/show_bug.cgi?id=1122664
- **Merge needles first**:
  - <s>https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/499</s> reverted
  - https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/505
- Verification run: http://slindomansilla-vm.qa.suse.de/tests/1190
