### PR TITLE
Add test for service after distri upgrade

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -449,6 +449,7 @@ sub load_autoyast_clone_tests {
 
 sub load_zdup_tests {
     loadtest 'installation/setup_zdup';
+    loadtest 'installation/install_service';
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/lock_package";
     }
@@ -457,6 +458,7 @@ sub load_zdup_tests {
     # Restrict version switch to sle until opensuse adopts it
     loadtest "migration/version_switch_upgrade_target" if is_sle and get_var("UPGRADE_TARGET_VERSION");
     loadtest 'boot/boot_to_desktop';
+    loadtest 'console/check_upgraded_service';
 }
 
 sub load_autoyast_tests {

--- a/tests/console/check_upgraded_service.pm
+++ b/tests/console/check_upgraded_service.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright ©2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Checks an service after an upgrade
+# Maintainer: Joachim Rauch <jrauch@suse.com>
+
+use base 'consoletest';
+use testapi;
+use strict;
+use utils 'systemctl';
+
+sub run {
+    select_console 'root-console';
+    systemctl 'start vsftpd';
+    systemctl 'status vsftpd';
+    save_screenshot;
+    assert_script_run 'systemctl status vsftpd --no-pager | grep active';
+}
+
+1;

--- a/tests/installation/install_service.pm
+++ b/tests/installation/install_service.pm
@@ -1,0 +1,35 @@
+
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Installs and checks a service for migration scenarios
+# Maintainer: Joachim Rauch <jrauch@suse.com>
+
+use strict;
+use base 'installbasetest';
+use testapi;
+use utils 'systemctl', 'zypper_call';
+
+sub run {
+
+    select_console 'root-console';
+    zypper_call 'in vsftpd';
+    systemctl 'start vsftpd';
+    systemctl 'status vsftpd';
+    save_screenshot;
+    assert_script_run 'systemctl status vsftpd --no-pager | grep active';
+}
+
+1;


### PR DESCRIPTION
Adds a test, whether a service is still running after a system migration
As service vsftpd has been chosen

- Related ticket: https://progress.opensuse.org/issues/46082
- Verification run: http://pinky.arch.suse.de/tests/57#
