### PR TITLE
Add aarch64 and ppc64le for docker tests on openSUSE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1529,7 +1529,7 @@ sub load_extra_tests_console {
 }
 
 sub load_extra_tests_docker {
-    return unless check_var('ARCH', 'x86_64');
+    return unless check_var('ARCH', 'x86_64') || (is_opensuse && get_var('ARCH', '') =~ /aarch64|ppc64le/);
     return unless is_sle('12-SP3+') || !is_sle;
     loadtest "console/docker";
     loadtest "console/docker_runc";


### PR DESCRIPTION
docker on aarch64 SLE is not supported. On ppc64le SLE docker is
supported from the containers module and working in principle, see
https://openqa.suse.de/tests/2392577# however fails within the container
failing to install curl so this commit is not adding ppc64le SLE for
now, only enabling the docker tests on both ppc64le and aarch64.

See https://openqa.opensuse.org/tests/798397 for last correct state on
openSUSE Tumbleweed ppc64le.

Related progress issue: https://progress.opensuse.org/issues/46466