### PR TITLE
CaaSP migration and update  improvements

### DIFF
--- a/data/caasp/update.sh
+++ b/data/caasp/update.sh
@@ -102,7 +102,7 @@ elif [ ! -z "${UPDATE:-}" ]; then
 
     # Manually Trigger Transactional Update (or wait up to 24 hours for it run by itself)
     $runner 'systemctl disable --now transactional-update.timer'
-    $runner '/usr/sbin/transactional-update cleanup dup salt'
+    $runner '/usr/sbin/transactional-update cleanup dup reboot'
 
     refresh_grains
     exit 100

--- a/data/caasp/update.sh
+++ b/data/caasp/update.sh
@@ -70,16 +70,9 @@ function refresh_grains {
 }
 
 if [ ! -z "${SETUP:-}" ]; then
-    # Remove non-existent ISO repository
-    $runner "zypper rr 1"
-    if [ "$SETUP" == "dup" ]; then
-        # Deregister system before update
-        $runner "SUSEConnect -d"
-    else
-        # Add repository to system vendors
-        $runner 'echo -e "[main]\nvendors = suse,opensuse,obs://build.suse.de,obs://build.opensuse.org" > /etc/zypp/vendors.d/vendors.conf'
-        $runner "zypper ar --refresh --no-gpgcheck $SETUP UPDATE"
-    fi
+    $runner 'zypper mr -d -l'
+    $runner 'echo -e "[main]\nvendors = suse,opensuse,obs://build.suse.de,obs://build.opensuse.org" > /etc/zypp/vendors.d/vendors.conf'
+    $runner "zypper ar --refresh --no-gpgcheck $SETUP UPDATE"
     $runner "zypper lr -U"
 
 elif [ ! -z "${TEST:-}" ]; then

--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -163,10 +163,10 @@ sub get_admin_job {
 sub get_delayed {
     my $role = shift;
 
-    my ($drole, $count);
-    my @jobs = get_cluster_jobs;
+    my $count = 0;
+    my @jobs  = get_cluster_jobs;
     for my $job_id (@jobs) {
-        if ($drole = get_job_info($job_id)->{settings}->{DELAYED}) {
+        if (my $drole = get_job_info($job_id)->{settings}->{DELAYED}) {
             if ($role) {
                 return $job_id if $role eq $drole;
             } else {

--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -177,7 +177,7 @@ sub get_delayed {
 
 
 # Return update repository without parameters
-# Optional filter for update type [qam|fake|dup]
+# Optional filter for update type [qam|fake|migration]
 sub update_scheduled {
     my $type = shift;
 
@@ -193,11 +193,7 @@ sub update_scheduled {
     return $repo unless $type;
     return $repo =~ 'Maintenance' if $type eq 'qam';
     return $repo =~ 'TestUpdate'  if $type eq 'fake';
-    if ($type eq 'dup') {
-        my $extracted_iso = get_var('REPO_0');
-        return 0 unless $extracted_iso;
-        return $repo =~ $extracted_iso;
-    }
+    return $repo =~ 'SCC-proxy'   if $type eq 'migration';
     die "Unrecognized type: '$type'";
 }
 

--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -71,6 +71,8 @@ sub export_cluster_logs {
         upload_logs('/var/log/transactional-update.log', failok => 1);
         upload_logs('/var/log/YaST2/y2log-1.gz') if get_var 'AUTOYAST';
     }
+    # Requested by SCC team
+    script_run 'SUSEConnect -d';
 }
 
 # Weak password warning should be displayed only once - bsc#1025835

--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -21,7 +21,7 @@ use power_action_utils qw(power_action assert_shutdown_and_restore_system);
 
 our @EXPORT = qw(
   process_reboot microos_login send_alt
-  handle_simple_pw export_cluster_logs script_retry script_run0 script_assert0
+  handle_simple_pw script_retry script_run0 script_assert0
   get_delayed update_scheduled
   pause_until unpause);
 
@@ -54,25 +54,6 @@ sub send_alt {
         $keys{password}  = ['a', 'a'];
     }
     send_key "alt-$keys{$key}[$txt]";
-}
-
-# Export logs from cluster admin/workers
-sub export_cluster_logs {
-    if (is_caasp 'local') {
-        record_info 'Logs skipped', 'Log export skipped because of LOCAL DEVENV';
-    }
-    else {
-        script_run "journalctl > journal.log", 60;
-        upload_logs "journal.log";
-
-        script_run 'supportconfig -b -B supportconfig', 500;
-        upload_logs '/var/log/nts_supportconfig.tbz';
-
-        upload_logs('/var/log/transactional-update.log', failok => 1);
-        upload_logs('/var/log/YaST2/y2log-1.gz') if get_var 'AUTOYAST';
-    }
-    # Requested by SCC team
-    script_run 'SUSEConnect -d';
 }
 
 # Weak password warning should be displayed only once - bsc#1025835

--- a/lib/caasp_clusternode.pm
+++ b/lib/caasp_clusternode.pm
@@ -4,6 +4,7 @@ use base "opensusebasetest";
 use strict;
 use testapi;
 use version_utils 'is_caasp';
+use autotest 'query_isotovideo';
 
 # Export logs from cluster admin/workers
 sub export_cluster_logs {
@@ -35,6 +36,9 @@ sub deregister {
 }
 
 sub post_run_hook {
+    # Some nodes were removed & powered off during test run
+    return if query_isotovideo('backend_is_shutdown');
+
     export_cluster_logs;
     deregister;
 }

--- a/lib/caasp_clusternode.pm
+++ b/lib/caasp_clusternode.pm
@@ -1,0 +1,50 @@
+package caasp_clusternode;
+use base "opensusebasetest";
+
+use strict;
+use testapi;
+use version_utils 'is_caasp';
+
+# Export logs from cluster admin/workers
+sub export_cluster_logs {
+    if (is_caasp 'local') {
+        record_info 'Logs skipped', 'Log export skipped because of LOCAL DEVENV';
+    }
+    else {
+        script_run "journalctl > journal.log", 60;
+        upload_logs "journal.log";
+
+        script_run 'supportconfig -b -B supportconfig', 500;
+        upload_logs '/var/log/nts_supportconfig.tbz';
+
+        upload_logs('/var/log/transactional-update.log', failok => 1);
+        upload_logs('/var/log/YaST2/y2log-1.gz') if get_var 'AUTOYAST';
+    }
+}
+
+# Requested by SCC team
+sub deregister {
+    if (get_var('REGISTER')) {
+        assert_script_run 'SUSEConnect --status-text | tee /dev/tty | grep -q "Status: ACTIVE"';
+        assert_script_run 'test -f /etc/zypp/credentials.d/SCCcredentials';
+        assert_script_run 'SUSEConnect -d';
+    } else {
+        # For sneaky autoyast nodes
+        script_run 'SUSEConnect -d';
+    }
+}
+
+sub post_run_hook {
+    export_cluster_logs;
+    deregister;
+}
+
+sub post_fail_hook {
+    if (check_var('STACK_ROLE', 'admin')) {
+        sleep if check_var('DEBUG_SLEEP', 'admin');
+        export_cluster_logs;
+    }
+    deregister;
+}
+
+1;

--- a/lib/caasp_controller.pm
+++ b/lib/caasp_controller.pm
@@ -10,7 +10,7 @@ use version_utils 'is_caasp';
 
 use Exporter 'import';
 our @EXPORT = qw($admin_fqdn $master_fqdn salt
-  confirm_insecure_https velum_login switch_to download_kubeconfig click_click xy);
+  velum_login switch_to download_kubeconfig click_click xy);
 
 our $admin_fqdn = 'admin.openqa.test';
 # Extra space to check for bsc#1087447
@@ -82,14 +82,6 @@ sub salt {
 
     record_info './update.sh exec', "ssh $admin_fqdn './update.sh $update_args'";
     script_assert0("ssh $admin_fqdn './update.sh $update_args' | tee /dev/$serialdev", $args{timeout});
-}
-
-# Users have to confirm certificate 3 times during deployment
-sub confirm_insecure_https {
-    wait_still_screen 3;
-    assert_and_click 'velum-https-advanced';
-    assert_and_click 'velum-https-add_exception';
-    assert_and_click 'velum-https-confirm';
 }
 
 # Base class for CaaSP tests

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -178,7 +178,6 @@ sub load_stack_tests {
     }
     else {
         loadtest 'caasp/stack_' . get_var('STACK_ROLE');
-        loadtest 'caasp/register_and_check' if is_caasp('qam');
     }
 }
 

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -75,7 +75,7 @@ sub load_caasp_inst_tests {
     }
     else {
         # One Click Installer removed in CaaSP 4.0
-        if (is_caasp('4.0+') && !update_scheduled('dup')) {
+        if (is_caasp('4.0+') && !update_scheduled('migration')) {
             loadtest 'caasp/oci_overview';
             loadtest 'caasp/oci_keyboard';
             loadtest 'installation/accept_license';
@@ -146,7 +146,7 @@ sub load_feature_tests {
 
 sub load_stack_tests {
     if (check_var 'STACK_ROLE', 'controller') {
-        if (update_scheduled 'dup') {
+        if (update_scheduled 'migration') {
             loadtest 'caasp/shift_version', name => 'ver=dec';
         }
         loadtest 'caasp/stack_initialize';
@@ -164,7 +164,7 @@ sub load_stack_tests {
         } else {
             loadtest 'caasp/stack_reboot';
         }
-        if (update_scheduled 'dup') {
+        if (update_scheduled 'migration') {
             loadtest 'caasp/shift_version', name => 'ver=inc';
         }
         # Add and remove cluster nodes
@@ -213,7 +213,7 @@ if (get_var('STACK_ROLE')) {
         loadtest "support_server/setup";
     }
     else {
-        if (update_scheduled 'dup') {
+        if (update_scheduled 'migration') {
             loadtest 'caasp/shift_version', name => 'ver=dec';
         }
         load_caasp_boot_tests;

--- a/tests/caasp/register_and_check.pm
+++ b/tests/caasp/register_and_check.pm
@@ -24,7 +24,6 @@ sub run {
     # Check that registration was succeeded
     assert_script_run 'SUSEConnect --status-text | tee /dev/tty | grep -q "Status: ACTIVE"';
     assert_script_run 'test -f /etc/zypp/credentials.d/SCCcredentials';
-    # validate_repos; - needs modifications for CaaSP
 }
 
 1;

--- a/tests/caasp/stack_admin.pm
+++ b/tests/caasp/stack_admin.pm
@@ -29,7 +29,7 @@ sub set_autoyast_password {
 
 sub run() {
     # Admin node needs long time to start web interface - bsc#1031682
-    script_retry 'curl -kLI localhost | grep _velum_session', retry => 15, delay => 15;
+    script_retry 'curl -kLI localhost | grep _velum_session', retry => 15, delay => 30;
     # Enable salt debug
     if (get_var 'DEBUG_SLEEP') {
         script_run 'id=$(docker ps | grep salt-master | awk \'{print $1}\')';

--- a/tests/caasp/stack_admin.pm
+++ b/tests/caasp/stack_admin.pm
@@ -10,7 +10,7 @@
 # Summary: Start admin node (velum)
 # Maintainer: Martin Kravec <mkravec@suse.com>
 
-use base "opensusebasetest";
+use base "caasp_clusternode";
 use strict;
 use testapi;
 use caasp;
@@ -52,13 +52,6 @@ sub run() {
     }
 
     set_autoyast_password if is_caasp 'DVD';
-    export_cluster_logs;
-}
-
-sub post_fail_hook {
-    # Variable to enable failed cluster debug
-    sleep if check_var('DEBUG_SLEEP', 'admin');
-    export_cluster_logs;
 }
 
 1;

--- a/tests/caasp/stack_configure.pm
+++ b/tests/caasp/stack_configure.pm
@@ -58,8 +58,6 @@ sub run {
     send_key 'f11';
     wait_still_screen 3;
 
-    confirm_insecure_https if is_caasp('VMX');
-
     # Check that footer has proper tag
     my $v = get_var('VERSION');
     $v .= '-dev' if check_var('BETA', 'DEV');

--- a/tests/caasp/stack_update.pm
+++ b/tests/caasp/stack_update.pm
@@ -11,7 +11,7 @@
 #   SSH keys are already generated
 #   SSH config was modified to not check identity
 #   Script is not run on admin to avoid mutex hell
-# Maintainer: Martin Kravec <mkravec@suse.com>, Panagiotis Georgiadis <pgeorgiadis@suse.com>
+# Maintainer: Martin Kravec <mkravec@suse.com>, Georgios Gkioulis <ggkioulis@suse.com>
 
 use parent 'caasp_controller';
 use caasp_controller;
@@ -40,7 +40,7 @@ sub orchestrate_velum_reboot {
 
     # Update all nodes - this part takes long time (~2 minutes per node)
     my @needles_array = ('velum-sorry', "velum-$n-nodes-outdated");
-    assert_screen [@needles_array], 900;
+    assert_screen [@needles_array], 600;
     if (match_has_tag 'velum-sorry') {
         record_soft_failure('bnc#1074836 - delay caused due to Meltdown');
         # workaround for meltdown
@@ -160,7 +160,7 @@ sub update_perform_update {
     $ret == 100 ? orchestrate_velum_reboot : die('Update process failed');
 }
 
-# Bug#1121797 - Nodes change IP address after migration from v3->v4
+# bug#1121797 - Nodes change IP address after v3->v4 migration (feature)
 sub setup_static_dhcp {
     switch_to 'xterm';
     become_root;

--- a/tests/caasp/stack_update.pm
+++ b/tests/caasp/stack_update.pm
@@ -95,11 +95,6 @@ sub update_setup_repos {
     record_info 'Repo', 'Add the testing repository into each node of the cluster';
     switch_to 'xterm';
 
-    # Deregister before distribution update
-    if (update_scheduled 'dup') {
-        script_assert0 "ssh $admin_fqdn './update.sh -s dup' | tee /dev/$serialdev", 120;
-    }
-
     # Add UPDATE repository
     my $repo = update_scheduled;
     script_assert0 "ssh $admin_fqdn './update.sh -s $repo' | tee /dev/$serialdev", 120;

--- a/tests/caasp/stack_worker.pm
+++ b/tests/caasp/stack_worker.pm
@@ -15,7 +15,18 @@ use strict;
 use testapi;
 use lockapi 'barrier_wait';
 use autotest 'query_isotovideo';
+use version_utils 'is_caasp';
 use caasp;
+
+# Updated from incident repo before adding to cluster
+sub incident_repo_dup {
+    my $repo = get_required_var('INCIDENT_REPO');
+    assert_script_run 'echo -e "[main]\nvendors = suse,opensuse,obs://build.suse.de,obs://build.opensuse.org" > /etc/zypp/vendors.d/vendors.conf';
+    assert_script_run "zypper ar --refresh --no-gpgcheck $repo UPDATE";
+    assert_script_run 'zypper lr -U';
+    assert_script_run 'transactional-update cleanup dup', 300;
+    process_reboot 1;
+}
 
 sub run {
     # Enable salt debug
@@ -25,6 +36,7 @@ sub run {
     }
     # Notify others that installation finished
     if (get_var 'DELAYED') {
+        incident_repo_dup if is_caasp('qam');
         barrier_wait 'DELAYED_NODES_ONLINE';
     }
     else {

--- a/tests/caasp/stack_worker.pm
+++ b/tests/caasp/stack_worker.pm
@@ -10,7 +10,7 @@
 # Summary: Start worker nodes
 # Maintainer: Martin Kravec <mkravec@suse.com>
 
-use base "opensusebasetest";
+use base "caasp_clusternode";
 use strict;
 use testapi;
 use lockapi 'barrier_wait';
@@ -31,9 +31,7 @@ sub run {
         barrier_wait "NODES_ONLINE";
     }
     pause_until 'CNTRL_FINISHED';
-}
 
-sub post_run_hook {
     # Some nodes were removed & powered off during test run
     return if query_isotovideo('backend_is_shutdown');
 
@@ -48,7 +46,6 @@ sub post_run_hook {
         reset_consoles;
         select_console 'root-console';
     }
-    export_cluster_logs;
 }
 
 1;


### PR DESCRIPTION
Required rsync.pl change: https://gitlab.suse.de/openqa/scripts/merge_requests/285

Local runs:
 - http://dhcp126.suse.cz/tests/13004 - Migration 3.0 -> 4.0
 - http://dhcp126.suse.cz/tests/12996 - QAM 3.0
 - http://dhcp126.suse.cz/tests/13017 - QA 4.0

Update script was designed to test fake updates. Later it was hacked to test QAM updates and DUP  migrations. At this point it's quite messy, this PR should clean up a little.

Notable changes:
 - cleaner stack_update::run workflow (decouple `QAM`, `FAKE`, `MIGRATION`), remove `DUP`
 - added migration test `perform_migration` (with `setup_static_dhcp`)
 - added `salt` sub to execute remote salt commands from controller on selected cluster nodes

I can rebase before merge - keeping commit history for reviewer.