### PR TITLE
Further harmonize backend-checks

### DIFF
--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -52,12 +52,8 @@ sub use_ssh_serial_console {
 }
 
 sub is_remote_backend {
-
     # s390x uses only remote repos
-    return check_var('ARCH', 's390x') ||
-      check_var('BACKEND', 'svirt') ||
-      check_var('BACKEND', 'ipmi')  ||
-      check_var('BACKEND', 'spvm');
+    return check_var('ARCH', 's390x') || get_var('BACKEND', '') =~ /ipmi|spvm|svirt/;
 }
 
 # In some cases we are using a VNC connection provided by the hypervisor that

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -313,7 +313,7 @@ sub bootmenu_type_console_params {
 
     # See bsc#1011815, last console set as boot parameter is linked to /dev/console
     # and doesn't work if set to serial device. Don't want this on some backends.
-    type_string_very_slow "console=tty " unless (check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm'));
+    type_string_very_slow "console=tty " unless (get_var('BACKEND', '') =~ /ipmi|spvm/);
 }
 
 sub uefi_bootmenu_params {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -528,7 +528,7 @@ sub load_system_role_tests {
             loadtest "installation/setup_online_repos";
         }
         # Do not run on REMOTE_CONTROLLER, IPMI and on Hyper-V in GUI mode
-        if (!check_var('BACKEND', 'ipmi') && !is_hyperv_in_gui && !get_var("LIVECD") && !check_var('BACKEND', 'spvm')) {
+        if (get_var('BACKEND', '') !~ /ipmi|spvm/ && !is_hyperv_in_gui && !get_var("LIVECD")) {
             loadtest "installation/logpackages";
         }
     }
@@ -939,9 +939,7 @@ sub load_inst_tests {
             and !get_var("REMOTE_CONTROLLER")
             and !is_hyperv_in_gui
             and !is_bridged_networking
-            and !check_var('BACKEND', 's390x')
-            and !check_var('BACKEND', 'ipmi')
-            and !check_var('BACKEND', 'spvm')
+            and get_var('BACKEND', '') !~ /ipmi|s390x|spvm/
             and is_sle('12-SP2+'))
         {
             loadtest "installation/hostname_inst";

--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -32,7 +32,7 @@ our @EXPORT = qw(
 # in some backends we need to prepare the reboot/shutdown
 sub prepare_system_shutdown {
     # kill the ssh connection before triggering reboot
-    console('root-ssh')->kill_ssh if check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm');
+    console('root-ssh')->kill_ssh if get_var('BACKEND', '') =~ /ipmi|spvm/;
 
     if (check_var('ARCH', 's390x')) {
         if (check_var('BACKEND', 's390x')) {

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -403,7 +403,7 @@ sub init_consoles {
                 password => get_var('VIRSH_GUEST_PASSWORD')});
     }
 
-    if (check_var('BACKEND', 'ikvm') || check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm')) {
+    if (get_var('BACKEND', '') =~ /ikvm|ipmi|spvm/) {
         $self->add_console(
             'root-ssh',
             'ssh-xterm',
@@ -415,11 +415,11 @@ sub init_consoles {
             });
     }
 
-    if (check_var('BACKEND', 'ipmi') || check_var('BACKEND', 's390x') || get_var('S390_ZKVM') || check_var('BACKEND', 'spvm')) {
+    if (get_var('BACKEND', '') =~ /ipmi|s390x|spvm/ || get_var('S390_ZKVM')) {
         my $hostname;
 
         $hostname = get_var('VIRSH_GUEST')     if get_var('S390_ZKVM');
-        $hostname = get_required_var('SUT_IP') if check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm');
+        $hostname = get_required_var('SUT_IP') if get_var('BACKEND', '') =~ /ipmi|spvm/;
 
         if (check_var('BACKEND', 's390x')) {
 
@@ -596,7 +596,7 @@ sub activate_console {
             # login as root, who does not have a password on Live-CDs
             wait_screen_change { type_string "root\n" };
         }
-        elsif (check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm')) {
+        elsif (get_var('BACKEND', '') =~ /ipmi|spvm/) {
             # Select configure serial and redirect to root-ssh instead
             use_ssh_serial_console;
             return;
@@ -627,8 +627,8 @@ sub activate_console {
     diag "activate_console, console: $console, type: $type";
     if ($type eq 'console') {
         # different handling for ssh consoles on s390x zVM
-        if (check_var('BACKEND', 's390x') || get_var('S390_ZKVM') || check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm')) {
-            diag 'backend s390x || zkvm || ipmi || spvm';
+        if (get_var('BACKEND', '') =~ /ipmi|s390x|spvm/ || get_var('S390_ZKVM')) {
+            diag 'backend ipmi || spvm || s390x || zkvm';
             $user ||= 'root';
             handle_password_prompt;
             ensure_user($user);
@@ -683,8 +683,8 @@ sub activate_console {
     }
     elsif (
         $console eq 'installation'
-        && (((check_var('BACKEND', 's390x') || check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm') || get_var('S390_ZKVM')))
-            && (check_var('VIDEOMODE', 'text') || check_var('VIDEOMODE', 'ssh-x'))))
+        && ((get_var('BACKEND', '') =~ /ipmi|s390x|spvm/) || get_var('S390_ZKVM'))
+        && (get_var('VIDEOMODE', '') =~ /text|ssh-x/))
     {
         diag 'activate_console called with installation for ssh based consoles';
         $user ||= 'root';

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -294,7 +294,7 @@ sub assert_gui_app {
 # that
 sub check_console_font {
     # Does not make sense on ssh-based consoles
-    return if (check_var('BACKEND', 'spvm')) || (check_var('BACKEND', 'ipmi'));
+    return if get_var('BACKEND', '') =~ /ipmi|spvm/;
     # we do not await the console here, as we have to expect the font to be broken
     # for the needle to match
     select_console('root-console', await_console => 0);

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -16,14 +16,11 @@ use warnings;
 use base "y2logsstep";
 use testapi;
 use version_utils 'is_caasp';
+use Utils::Backends 'is_remote_backend';
 
 
 sub ensure_ssh_unblocked {
-    my $need_ssh = check_var('ARCH', 's390x');    # s390x always needs SSH
-    $need_ssh = 1 if check_var('BACKEND', 'ipmi');    # we better be able to login
-    $need_ssh = 1 if check_var('BACKEND', 'spvm');    # we better be able to login
-
-    if (!get_var('UPGRADE') && $need_ssh) {
+    if (!get_var('UPGRADE') && is_remote_backend) {
 
         send_key_until_needlematch [qw(ssh-blocked ssh-open)], 'tab';
         if (match_has_tag 'ssh-blocked') {

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -31,7 +31,7 @@ sub run {
     }
     # while technically SUT has a different network than the BMC
     # we require ssh installation anyway
-    if (check_var('BACKEND', 'ipmi') || check_var('BACKEND', 'spvm')) {
+    if (get_var('BACKEND', '') =~ /ipmi|spvm/) {
         use_ssh_serial_console;
         # set serial console for xen
         set_serial_console_on_vh('/mnt', '', 'xen') if (get_var('XEN') || check_var('HOST_HYPERVISOR', 'xen'));


### PR DESCRIPTION
This commit tries to harmonize more checks for backends and uses a
common format with a regex list of alternatives, alphanumerically sorted.

Related progress issue: https://progress.opensuse.org/issues/45008