### PR TITLE
Add more logs and config files on HA tests failures

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -214,6 +214,8 @@ sub ha_export_logs {
     my $corosync_conf = '/etc/corosync/corosync.conf';
     my $hb_log        = '/var/log/hb_report';
     my $packages_list = '/tmp/packages.list';
+    my $iscsi_devs    = '/tmp/iscsi_devices.list';
+    my $mdadm_conf    = '/etc/mdadm.conf';
     my $report_opt    = !is_sle('12-sp4+') ? '-f0' : '';
     my @y2logs;
 
@@ -230,6 +232,14 @@ sub ha_export_logs {
     # Generate the packages list
     script_run "rpm -qa > $packages_list";
     upload_logs("$packages_list", failok => 1);
+
+    # iSCSI devices and their real paths
+    script_run "ls -l /dev/disk/by-path/ > $iscsi_devs";
+    upload_logs($iscsi_devs, failok => 1);
+
+    # mdadm conf
+    script_run "touch $mdadm_conf";
+    upload_logs($mdadm_conf, failok => 1);
 }
 
 sub check_cluster_state {


### PR DESCRIPTION
This pull request adds the list of iSCSI devices connected to the host and the contents of `/etc/mdadm.conf` on failures of HA tests that use `lib/hacluster`.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
