### PR TITLE
Collect logs on 2nd stage of autoyast installation

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -52,18 +52,6 @@ sub save_and_upload_stage_logs {
 }
 
 sub upload_autoyast_profile {
-    my ($self) = @_;
-    select_console 'install-shell';
-    # the network may be down with keep_install_network=false
-    # use static ip in that case if not on s390x
-    if (!check_var("BACKEND", "s390x")) {
-        type_string " if ! ping -c 1 10.0.2.2 ; then
-            ip addr add 10.0.2.200/24 dev eth0
-            ip link set eth0 up
-            route add default gw 10.0.2.2
-        fi
-        ";
-    }
     # Upload autoyast profile if file exists
     if (script_run '! test -e /tmp/profile/autoinst.xml') {
         upload_logs '/tmp/profile/autoinst.xml';
@@ -73,8 +61,6 @@ sub upload_autoyast_profile {
         upload_logs '/tmp/profile/modified.xml';
     }
     save_screenshot;
-    clear_console;
-    select_console 'installation';
 }
 
 sub handle_expected_errors {
@@ -289,8 +275,8 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = shift;
-    $self->upload_autoyast_profile;
     $self->SUPER::post_fail_hook;
+    $self->upload_autoyast_profile;
 }
 
 1;


### PR DESCRIPTION
**For reviewers: This PR requires the [needles](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1050) to be merged first.**

openQA failed to collect logs if autoyast installation failed on the
second stage.

It was happened, because in parent post_fail_hook (in y2logsstep), the
'root-console' was selected, but black screen was shown instead of it,
so it might be unavailable there.

The PR allows to collect logs from 'install-shell' console.

Also, it removes redundant network reconnect, as it is completed on the  
269th line of y2logsstep.pm  ( `if (can_upload_logs()` )

- Related ticket: https://progress.opensuse.org/issues/42710
- **Needles:** https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1050
- Verification run (the run is failed, which is valid for the case as it shows that the logs are uploaded on fail): http://oorlov-vm.qa.suse.de/tests/725#downloads
