### PR TITLE
salt: use systemctl status --no-pager

### DIFF
--- a/tests/console/salt.pm
+++ b/tests/console/salt.pm
@@ -37,7 +37,7 @@ sub run {
     zypper_call('in salt-master salt-minion');
     my $cmd = <<'EOF';
 systemctl start salt-master
-systemctl status salt-master
+systemctl status --no-pager salt-master
 sed -i -e "s/#master: salt/master: localhost/" /etc/salt/minion
 systemctl start salt-minion
 systemctl status --no-pager salt-minion


### PR DESCRIPTION
By using --no-pager we guarantee that the length of the status log does
not make systemctl automatically present it using less, which would mean
the command does not quit without interaction

