### PR TITLE
Add md2 and rmd160 into invalid hash in fips mode

### DIFF
--- a/tests/fips/openssl/openssl_fips_hash.pm
+++ b/tests/fips/openssl/openssl_fips_hash.pm
@@ -1,6 +1,6 @@
 # openssl fips test
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -9,12 +9,15 @@
 #
 # Test description: In fips mode, openssl only works with the FIPS
 # approved HASH algorithms: SHA1 and SHA2 (224, 256, 384, 512)
-
+#
 # Summary: Add Hash and Cipher test cases for openssl-fips
-#    A new test suite "core" is created, which contains all the basic
-#    test cases for fips verificaton when FIPS_ENABLED is set, like
-#    the cases to verify opessl hash, cipher, or public key algorithms
-# Maintainer: Qingming Su <qingming.su@suse.com>
+#          A new test suite "core" is created, which contains all the basic
+#          test cases for fips verificaton when FIPS_ENABLED is set, like
+#          the cases to verify opessl hash, cipher, or public key algorithms
+#
+# Original Author: Qingming Su <qingming.su@suse.com>
+# Maintainer: Ben Chou <bchou@suse.com>
+# Tags: poo#44834
 
 use base "consoletest";
 use testapi;
@@ -35,9 +38,10 @@ sub run {
     }
 
     # With non-approved HASH algorithms, openssl will report failure
-    my @invalid_hash = ("md4", "md5", "mdc2", "ripemd160", "whirlpool", "sha");
+    # Add md2 and rmd160 into invalid hash in fips mode
+    my @invalid_hash = ("md2", "md4", "md5", "mdc2", "rmd160", "ripemd160", "whirlpool", "sha");
     for my $hash (@invalid_hash) {
-        validate_script_output "openssl dgst -$hash $tmp_file 2>&1 || true", sub { m/disabled for fips|unknown option/ };
+        validate_script_output "openssl dgst -$hash $tmp_file 2>&1 || true", sub { m/disabled for fips|unknown option|Unknown digest/ };
     }
 
     script_run 'rm -f $tmp_file';


### PR DESCRIPTION
1. Add md2 and rmd160 as invalid hash in fips mode
2. Add "Unknown digest" after validate_script_output check

- Related ticket: https://progress.opensuse.org/issues/44834
- Needles: N/A
- Verification run: http://147.2.211.155/tests/217#step/openssl_fips_hash/14