### PR TITLE
Refactor docker tests to allow operation on non-x86_64 platforms

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -16,6 +16,7 @@ use File::Basename;
 use File::Find;
 use Exporter;
 use testapi qw(check_var get_var get_required_var set_var check_var_array diag);
+use suse_container_urls qw(get_suse_container_urls);
 use autotest;
 use utils;
 use version_utils qw(:VERSION :BACKEND :SCENARIO);
@@ -1546,8 +1547,9 @@ sub load_extra_tests_console {
 }
 
 sub load_extra_tests_docker {
-    return unless check_var('ARCH', 'x86_64') || (is_opensuse && get_var('ARCH', '') =~ /aarch64|ppc64le/);
-    return unless is_sle('12-SP3+') || !is_sle;
+    my ($image_names, $stable_names) = get_suse_container_urls();
+    return unless @$image_names;
+
     loadtest "console/docker";
     loadtest "console/docker_runc";
     if (is_sle('12-SP3+') && is_sle('<15')) {

--- a/lib/suse_container_urls.pm
+++ b/lib/suse_container_urls.pm
@@ -1,0 +1,76 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Database for URLs of docker images to be tested
+# Maintainer: Fabian Vogt <fvogt@suse.com>
+
+package suse_container_urls;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use warnings;
+use testapi;
+use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap);
+
+our @EXPORT = qw(
+  get_suse_container_urls
+);
+
+# Returns a tuple of image urls and their matching released "stable" counterpart.
+# If empty, no images available.
+sub get_suse_container_urls {
+    my $version = get_required_var('VERSION');
+    my $dotversion = $version =~ s/-SP/./r; # 15 -> 15, 15-SP1 -> 15.1
+    $dotversion = "${dotversion}.0" if $dotversion !~ /\./; # 15 -> 15.0
+
+    my @image_names  = ();
+    my @stable_names = ();
+    if (is_sle(">=12-SP3")) {
+        my $lowerversion = lc $version;
+        my $nodashversion = $version =~ s/-//r;
+        if (get_var("ARCH") ~~ ["ppc64le", "s390x", "x86_64"]) {
+            push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/docker/update/cr/images/suse/${nodashversion}";
+            push @stable_names, "registry.suse.com/suse/${nodashversion}";
+        }
+    }
+    elsif (is_sle(">=15")) {
+        my $lowerversion = lc $version;
+        if (get_var("ARCH") ~~ ["ppc64le", "s390x", "x86_64"]) {
+            push @image_names,  "registry.suse.de/suse/sle-${lowerversion}/update/cr/images/suse/sle15:${dotversion}";
+            push @stable_names, "registry.suse.com/suse/sle15:${dotversion}";
+        }
+    }
+    elsif (is_tumbleweed && get_var("ARCH") ~~ ["i586", "x86_64"]) {
+        push @image_names,  "registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed";
+        push @stable_names, "docker.io/opensuse/tumbleweed";
+    }
+    elsif (is_tumbleweed && check_var("ARCH", "aarch64")) {
+        push @image_names,  "registry.opensuse.org/opensuse/factory/arm/totest/containers/opensuse/tumbleweed";
+        push @stable_names, "docker.io/opensuse/tumbleweed";
+    }
+    elsif (is_tumbleweed && check_var("ARCH", "ppc64le")) {
+        push @image_names,  "registry.opensuse.org/opensuse/factory/powerpc/totest/containers/opensuse/tumbleweed";
+        push @stable_names, "docker.io/opensuse/tumbleweed";
+    }
+    elsif (is_leap(">15.0") && check_var("ARCH", "x86_64")) {
+        push @image_names,  "registry.opensuse.org/opensuse/leap/${version}/images/totest/containers/opensuse/leap:${version}";
+        push @stable_names, "docker.io/opensuse/leap:${version}";
+    }
+    elsif (is_leap(">15.0") && get_var("ARCH") ~~ ["aarch64", "ppc64le"]) {
+        # No image set up yet :-(
+    }
+    else {
+        die("Unknown combination of distro/arch.");
+    }
+
+    return (\@image_names, \@stable_names);
+}
+

--- a/tests/console/docker_image.pm
+++ b/tests/console/docker_image.pm
@@ -52,7 +52,7 @@ sub run {
 
     for my $i (0 .. $#$image_names) {
         # Load the image
-        assert_script_run("docker pull $image_names->[$i]", 900);
+        assert_script_run("docker pull $image_names->[$i]", 1000);
         # Running executables works
         assert_script_run qq{docker container run --entrypoint '/bin/bash' --rm $image_names->[$i] -c 'echo "I work" | grep "I work"'};
         # It is the right version

--- a/tests/console/docker_image.pm
+++ b/tests/console/docker_image.pm
@@ -15,37 +15,13 @@ use testapi;
 use utils;
 use strict;
 use registration qw(add_suseconnect_product install_docker_when_needed);
+use suse_container_urls qw(get_suse_container_urls);
 use version_utils qw(is_sle is_opensuse is_tumbleweed is_leap);
 
 sub run {
     select_console "root-console";
 
-    my $version      = get_required_var('VERSION');
-    my @image_names  = ();
-    my @stable_names = ();
-    if (is_sle("=12-SP3")) {
-        push @image_names,  "registry.suse.de/suse/sle-12-sp3/docker/update/cr/images/suse/sles12sp3:latest";
-        push @stable_names, "registry.suse.com/suse/sles12sp3:latest";
-    }
-    elsif (is_sle("=12-SP4")) {
-        push @image_names,  "registry.suse.de/suse/sle-12-sp4/docker/update/cr/images/suse/sles12sp4:latest";
-        push @stable_names, "registry.suse.com/suse/sles12sp4:latest";
-    }
-    elsif (is_sle("=15")) {
-        push @image_names,  "registry.suse.de/suse/sle-15/update/cr/images/suse/sle15:latest";
-        push @stable_names, "registry.suse.com/suse/sle15:latest";
-    }
-    elsif (is_tumbleweed) {
-        push @image_names,  "registry.opensuse.org/opensuse/factory/totest/containers/opensuse/tumbleweed:latest";
-        push @stable_names, "docker.io/opensuse/tumbleweed";
-    }
-    elsif (is_leap(">15.0")) {
-        push @image_names,  "registry.opensuse.org/opensuse/leap/${version}/images/totest/containers/opensuse/leap:${version}";
-        push @stable_names, "docker.io/opensuse/leap:${version}";
-    }
-    else {
-        die("No image locations defined for this distro.");
-    }
+    my ($image_names, $stable_names) = get_suse_container_urls();
 
     if (is_sle) {
         my $SCC_REGCODE = get_required_var("SCC_REGCODE");
@@ -53,7 +29,7 @@ sub run {
         if (script_run("SUSEConnect --status-text") != 0) {
             assert_script_run("SUSEConnect --cleanup");
             assert_script_run("SUSEConnect -r $SCC_REGCODE");
-            add_suseconnect_product("sle-module-containers", substr($version, 0, 2));
+            add_suseconnect_product("sle-module-containers", substr(get_required_var('VERSION'), 0, 2));
         }
     }
 
@@ -69,45 +45,45 @@ sub run {
         systemctl('restart docker');
     }
 
-    assert_script_run('curl -LO https://storage.googleapis.com/container-diff/latest/container-diff-linux-amd64', 240);
-    assert_script_run('chmod +x container-diff-linux-amd64 && sudo mv container-diff-linux-amd64 /usr/local/bin/container-diff');
+    if (check_var("ARCH", "x86_64")) {
+        assert_script_run('curl -LO https://storage.googleapis.com/container-diff/latest/container-diff-linux-amd64', 240);
+        assert_script_run('chmod +x container-diff-linux-amd64 && sudo mv container-diff-linux-amd64 /usr/local/bin/container-diff');
+    }
 
-    for my $i (0 .. $#image_names) {
+    for my $i (0 .. $#$image_names) {
         # Load the image
-        assert_script_run("docker pull $image_names[$i]", 900);
+        assert_script_run("docker pull $image_names->[$i]", 900);
         # Running executables works
-        assert_script_run qq{docker container run --entrypoint '/bin/bash' --rm $image_names[$i] -c 'echo "I work" | grep "I work"'};
+        assert_script_run qq{docker container run --entrypoint '/bin/bash' --rm $image_names->[$i] -c 'echo "I work" | grep "I work"'};
         # It is the right version
-        if (is_sle("=12-SP3")) {
-            validate_script_output("docker container run --entrypoint '/bin/bash' --rm $image_names[$i] -c 'cat /etc/os-release'", sub { /PRETTY_NAME="SUSE Linux Enterprise Server 12 SP3"/ });
-        }
-        elsif (is_sle("=12-SP4")) {
-            validate_script_output("docker container run --entrypoint '/bin/bash' --rm $image_names[$i] -c 'cat /etc/os-release'", sub { /PRETTY_NAME="SUSE Linux Enterprise Server 12 SP4"/ });
-        }
-        elsif (is_sle("=15")) {
-            validate_script_output("docker container run --entrypoint '/bin/bash' --rm $image_names[$i] -c 'cat /etc/os-release'", sub { /PRETTY_NAME="SUSE Linux Enterprise Server 15"/ });
+        if (is_sle) {
+            my $osversion = get_required_var("VERSION") =~ s/-SP/ SP/r;    # 15 -> 15, 15-SP1 -> 15 SP1
+            validate_script_output("docker container run --entrypoint '/bin/bash' --rm $image_names->[$i] -c 'cat /etc/os-release'", sub { /PRETTY_NAME="SUSE Linux Enterprise Server $osversion"/ });
         }
         elsif (is_opensuse) {
-            validate_script_output qq{docker container run --rm $image_names[$i] cat /etc/os-release}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };
+            my $version = get_required_var('VERSION');
+            validate_script_output qq{docker container run --rm $image_names->[$i] cat /etc/os-release}, sub { /PRETTY_NAME="openSUSE (Leap )?${version}.*"/ };
         }
         # zypper lr
-        assert_script_run("docker container run --entrypoint '/bin/bash' --rm $image_names[$i] -c 'zypper lr -s'", 120);
+        assert_script_run("docker container run --entrypoint '/bin/bash' --rm $image_names->[$i] -c 'zypper lr -s'", 120);
         # zypper ref
-        assert_script_run("docker container run --entrypoint '/bin/bash' --rm $image_names[$i] -c 'zypper -v ref | grep \"All repositories have been refreshed\"'", 120);
+        assert_script_run("docker container run --entrypoint '/bin/bash' --rm $image_names->[$i] -c 'zypper -v ref | grep \"All repositories have been refreshed\"'", 120);
 
-        # container-diff
-        my $image_file = $image_names[$i] =~ s/\/|:/-/gr;
-        if (script_run("docker pull $stable_names[$i]", 600) == 0) {
-            assert_script_run("container-diff diff daemon://$image_names[$i] daemon://$stable_names[$i] --type=rpm --type=file --type=history > /tmp/container-diff-$image_file.txt", 300);
-            upload_logs("/tmp/container-diff-$image_file.txt");
-            assert_script_run("docker image rm --force $stable_names[$i]");
-        }
-        else {
-            record_soft_failure("Could not compare $image_names[$i] to $stable_names[$i] as $stable_names[$i] could not be downloaded");
+        if (check_var("ARCH", "x86_64")) {
+            # container-diff
+            my $image_file = $image_names->[$i] =~ s/\/|:/-/gr;
+            if (script_run("docker pull $stable_names->[$i]", 600) == 0) {
+                assert_script_run("container-diff diff daemon://$image_names->[$i] daemon://$stable_names->[$i] --type=rpm --type=file --type=history > /tmp/container-diff-$image_file.txt", 300);
+                upload_logs("/tmp/container-diff-$image_file.txt");
+                assert_script_run("docker image rm --force $stable_names->[$i]");
+            }
+            else {
+                record_soft_failure("Could not compare $image_names->[$i] to $stable_names->[$i] as $stable_names->[$i] could not be downloaded");
+            }
         }
 
         # Remove the image again to save space
-        assert_script_run("docker image rm --force $image_names[$i]");
+        assert_script_run("docker image rm --force $image_names->[$i]");
     }
 }
 


### PR DESCRIPTION
As the logic to determine whether a distro/arch has a base image (and
thus should run the docker tests) is rather complex, it's split into a
library and called from main_common as well.

I only have a verification run for x86_64 for now, I'll have to wait until others can test other platforms.

http://10.160.67.86/tests/287