### PR TITLE
Expect firewalld in leap upgrade scenarios

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -555,7 +555,9 @@ under test, the version and if the SUT is an upgrade.
 =cut
 sub firewall {
     my $old_product_versions = is_sle('<15') || is_leap('<15.0');
-    my $upgrade_from_susefirewall = is_upgrade && get_var('HDD_1') =~ /\b(1[123]|42)[\.-]/;
+    # Leap 15 doesn't have SuSEfirewall in the DVD anymore, so doesn't get updagraded
+    # and we should check firewalld instead
+    my $upgrade_from_susefirewall = is_upgrade && get_var('HDD_1') =~ /\b(1[123]|42)[\.-]/ && !is_leap();
     return ($old_product_versions || $upgrade_from_susefirewall) ? 'SuSEfirewall2' : 'firewalld';
 }
 

--- a/tests/console/firewall_enabled.pm
+++ b/tests/console/firewall_enabled.pm
@@ -15,11 +15,19 @@
 use base 'consoletest';
 use strict;
 use testapi;
+use version_utils qw(:VERSION :SCENARIO);
 
 sub run {
     my ($self) = @_;
     if ($self->firewall eq 'firewalld') {
-        assert_script_run('firewall-cmd --state');
+        if (script_run('firewall-cmd --state') != 0) {
+            # soft-fail for leap upgrade scenarios (see poo#46127)
+            if (is_upgrade() && is_leap('15.0+')) {
+                record_soft_failure 'bsc#1122769';
+            } else {
+                die "firewalld is not running";
+            }
+        }
     }
     else {
         assert_script_run('SuSEfirewall2 status');


### PR DESCRIPTION
After we have disabled official online repos for upgrade scenarios,
SuSEfirewall is not existing in the DVD.

See [poo#46127](https://progress.opensuse.org/issues/46127).

- [Verification run](http://g226.suse.de/tests/3361).
