### PR TITLE
Revert "keymap_or_locale: handle tty3 properly"

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -392,7 +392,6 @@ sub init_consoles {
         $self->add_console('log-console',    'tty-console', {tty => 5});
         $self->add_console('displaymanager', 'tty-console', {tty => 7});
         $self->add_console('x11',            'tty-console', {tty => get_x11_console_tty});
-        $self->add_console('extra-console',  'tty-console', {tty => 3});
     }
 
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {
@@ -570,8 +569,7 @@ sub console_nr {
     my ($name) = ($1) || return;
     my $nr = 4;
     $nr = get_root_console_tty if ($name eq 'root');
-    $nr = 5                    if ($name eq 'log');
-    $nr = 3                    if ($name eq 'extra');
+    $nr = 5 if ($name eq 'log');
     return $nr;
 }
 

--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -84,7 +84,7 @@ sub run {
 
     if (check_var('DESKTOP', 'textmode')) {
         assert_screen([qw(linux-login cleared-console)]);
-        verify_default_keymap_textmode($keystrokes, "${expected}_keymap", console => 'extra-console');
+        verify_default_keymap_textmode($keystrokes, "${expected}_keymap");
         verify_default_keymap_textmode($keystrokes, "${expected}_keymap", console => 'root-console');
         ensure_serialdev_permissions;
         verify_default_keymap_textmode($keystrokes, "${expected}_keymap", console => 'user-console');


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#6220

Unfortunately we have to revert as many tests failed first due
to missing needles but now tests try to login as "extra" instead of "root".

E.g. see https://openqa.opensuse.org/tests/835513#step/keymap_or_locale/5