### PR TITLE
Detect hanging VLC and kill if necessary

### DIFF
--- a/tests/x11/vlc.pm
+++ b/tests/x11/vlc.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2017 SUSE LLC
+# Copyright (C) 2016-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 # Summary: Play some free video file with VLC
-# Maintainer: Ludwig Nussel <ludwig.nussel@suse.de>
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "x11test";
 use strict;
@@ -35,8 +35,14 @@ sub run {
     assert_and_click "vlc-play_button";
     # The video is actually 23 seconds long so give a bit of headroom for
     # startup
-    assert_screen "vlc-done-playing", 90;
-    assert_and_click "close_vlc";
+    assert_screen([qw(vlc-done-playing vlc-stuck-never-played)], 90);
+    if (match_has_tag('vlc-stuck-never-played')) {
+        record_soft_failure 'boo#1102838';
+        x11_start_program('killall -9 vlc', valid => 0);
+    }
+    else {
+        assert_and_click 'close_vlc';
+    }
 }
 
 1;


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/42671

Triggered verification run with:

```
 openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org 835278 \
    _GROUP=0 TEST=update_Leap_42.3_gnome@okurz//os-autoinst-distri-opensuse#fix/vlc \
    BUILD=okurz/os-autoinst-distri-opensuse#6614 \
    CASEDIR=https://github.com/okurz/os-autoinst-distri-opensuse.git#fix/vlc
```

-> https://openqa.opensuse.org/tests/840423#step/vlc/31