### PR TITLE
Rewrite service checking to avoid fd redirection

### DIFF
--- a/tests/yast2_gui/yast2_firewall.pm
+++ b/tests/yast2_gui/yast2_firewall.pm
@@ -83,7 +83,7 @@ sub verify_service_stopped {
     assert_screen 'generic-desktop';
 
     select_console 'root-console';
-    assert_script_run("firewall-cmd --state 2>&1 | grep 'not running'");
+    assert_script_run("! (firewall-cmd --state) | grep 'not running'");
 }
 
 sub verify_service_started {


### PR DESCRIPTION
Rewrite service checking to avoid file descriptor redirection.

- Related ticket: https://progress.opensuse.org/issues/46262#change-181310
- Verification run:  [sle-15-SP1-yast2_gui](http://rivera-workstation.suse.cz/tests/1105#step/consoletest_setup/46)
