### PR TITLE
[AARCH64 Automation] Certain vendor machines need password inputting and boot entry selecting from setup utility when boot from local disk

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -21,7 +21,7 @@ use version_utils qw(is_storage_ng is_sle);
 use utils;
 use power_action_utils 'prepare_system_shutdown';
 
-our @EXPORT = qw(set_serial_console_on_vh switch_from_ssh_to_sol_console set_pxe_efiboot);
+our @EXPORT = qw(set_serial_console_on_vh switch_from_ssh_to_sol_console set_pxe_efiboot boot_local_disk_arm_huawei);
 
 #With the new ipmi backend, we only use the root-ssh console when the SUT boot up,
 #and no longer setup the real serial console for either kvm or xen.
@@ -315,6 +315,26 @@ sub set_serial_console_on_vh {
         &umount_installation_disk("$mount_point");
     }
 
+}
+
+#Huawei arm machines require password login after "boot from local disk" is selected.
+#Before the desired grub menu is shown, you need to navigate into the boot menu and
+#select the "sles" boot item.
+sub boot_local_disk_arm_huawei {
+    assert_screen('input-password-huawei', 180);
+    type_string_slow "Huawei12#\$";
+    send_key 'ret';
+    assert_screen('default-password-huawei', 180);
+    send_key 'ret';
+
+    assert_screen('setup-menu-huawei', 180);
+    save_screenshot;
+    send_key_until_needlematch('exit-menu-huawei', 'right', 10, 5);
+    save_screenshot;
+    send_key_until_needlematch('boot-sles-huawei', 'down', 10, 5);
+    save_screenshot;
+    send_key 'ret';
+    save_screenshot;
 }
 
 1;

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 use File::Basename;
 use testapi;
-use Utils::Backends 'use_ssh_serial_console';
+use Utils::Backends qw(use_ssh_serial_console is_remote_backend);
 use ipmi_backend_utils;
 
 sub login_to_console {
@@ -25,6 +25,9 @@ sub login_to_console {
 
     reset_consoles;
     select_console 'sol', await_console => 0;
+
+    my $sut_machine = get_var('SUT_IP', 'nosutip');
+    boot_local_disk_arm_huawei if (is_remote_backend && check_var('ARCH', 'aarch64') && ($sut_machine =~ /huawei/img));
 
     assert_screen([qw(grub2 grub1 prague-pxe-menu)], 210);
 


### PR DESCRIPTION
Huawei aarch64 machines require you to input default password to enter into setup utility if boot from local disk is selected from pxe menu. Next you need to navigate into "Exit" section then down to "sles" boot entry, from which the normal boot procedure can be triggered and grub2/grub menu can be shown.

- Related ticket: n/a
- Needles: n/a
- Verification run: http://10.162.187.154/tests/917

@alice-suse @guoxuguang @Julie-CAO 
