### PR TITLE
Disable CPU soft lockup detection on aarch64

### DIFF
--- a/lib/known_bugs.pm
+++ b/lib/known_bugs.pm
@@ -48,7 +48,8 @@ sub create_list_of_serial_failures {
     }
 
 
-    push @$serial_failures, {type => 'hard', message => 'CPU soft lockup detected', pattern => quotemeta 'soft lockup - CPU'};
+    # Disable CPU soft lockup detection on aarch64 until https://progress.opensuse.org/issues/46502 get resolved
+    push @$serial_failures, {type => 'hard', message => 'CPU soft lockup detected', pattern => quotemeta 'soft lockup - CPU'} unless check_var('ARCH', 'aarch64');
 
     return $serial_failures;
 }


### PR DESCRIPTION
As setting it to soft fail without bugref breaks some rule. Once https://progress.opensuse.org/issues/46502 will be implemented, we can use `record_info` and enable it again for aarch64.

- Related ticket: https://progress.opensuse.org/issues/45530