### PR TITLE
Try to trim timeout for aarch64

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -268,11 +268,11 @@ sub addlv {
     send_key $cmd{system_view};
     send_key 'home';
     send_key_until_needlematch('volume_management_feature', 'down');
-    wait_still_screen 2;
+    wait_still_screen(stilltime => 3, timeout => 4);
     # Expand collapsed list with VGs
     send_key 'right' if is_sle('<15');
     send_key_until_needlematch 'partition-select-vg-' . "$args{vg}", 'down';
-    wait_still_screen 2;
+    wait_still_screen(stilltime => 3, timeout => 4);
     # Expand collapsed list with LVs
     send_key 'right' if is_sle('<15');
     send_key 'alt-i' if (is_storage_ng_newui);


### PR DESCRIPTION
I cannot reproduce the issue on my local aarch64 workers. Issues has been noticed only on worker openqaworker-arm-2 running sle12sp5. I would like to try whether any changes to the timeouts are going to make any difference.

- Related ticket: [poo#43568](https://progress.opensuse.org/issues/43568)
- Verification run: [sle-12-SP5-Server-DVD-aarch64-Build0114-lvm-encrypt-separate-boot@aarch64](http://eris.suse.cz/tests/10688)
