### PR TITLE
Split locale test for x11 and non-x11

### DIFF
--- a/lib/locale.pm
+++ b/lib/locale.pm
@@ -1,0 +1,77 @@
+package locale;
+use base "opensusebasetest";
+
+use strict;
+use warnings;
+use testapi;
+use utils;
+use Utils::Backends 'has_ttys';
+
+sub verify_default_keymap_textmode_non_us {
+    my ($self, $test_string, $tag) = @_;
+    # Installation with different keyboard layout is not feature ready but
+    # in case of autoyast scenarios we can simply test on login prompt without changing tty
+    type_string $test_string;
+    assert_screen ["${tag}", "${tag}_not_ready"];
+    if (match_has_tag "${tag}_not_ready") {
+        # i.e: in cz keyboard the first half in the keystroke list is not displayed in 1st login'
+        send_key 'ret' for (1 .. 2);
+        record_soft_failure 'bsc#1125886 - Special characters when switching keyboard layout only available after 2nd login';
+        assert_screen([qw(linux-login cleared-console)]);
+        type_string $test_string;
+        assert_screen "${tag}";
+    }
+}
+
+sub verify_default_keymap_textmode {
+    my ($self, $test_string, $tag, %tty) = @_;
+
+    if (defined($tty{console})) {
+        select_console($tty{console});
+    }
+    else {
+        send_key('alt-f3');
+        # remote backends can not provide a "not logged in console" so we use
+        # a cleared remote terminal instead
+        assert_screen(has_ttys() ? 'linux-login' : 'cleared_console');
+    }
+
+    type_string($test_string);
+    assert_screen($tag);
+    # clear line in order to add user bernhard to tty group
+    # clear line to avoid possible failures in following console tests if scheduled
+    send_key("ctrl-w");
+}
+
+sub notification_handler {
+    my ($feature, $state) = @_;
+
+    select_console('user-console');
+    assert_script_run("(gsettings get $feature && gsettings set $feature $state) 2>/dev/null || true");
+}
+
+sub verify_default_keymap_x11 {
+    my ($self, $test_string, $tag, $program) = @_;
+    notification_handler('org.gnome.DejaDup periodic', 'false') if (check_var('DESKTOP', 'gnome'));
+    select_console('x11');
+    x11_start_program($program);
+    type_string($test_string);
+    assert_screen($tag);
+    # clear line to avoid possible failures in following tests (eg. updates_packagekit_gpk)
+    send_key("ctrl-w");
+    # close xterm
+    send_key("ctrl-d");
+}
+
+sub get_keystroke_list {
+    my ($self, $layout) = @_;
+    my %keystrokes = (
+        us => '`1234567890-=~!@#$%^&*()_+',
+        fr => '²&é"(-è_çà)=~1234567890°+',
+        de => '1234567890ß°!"§$%&/()=?',
+        cz => ';+ěščřžýáíé=1234567890%'
+    );
+    return $keystrokes{$layout};
+}
+
+1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1240,6 +1240,7 @@ sub load_x11tests {
         loadtest "x11/xfce4_terminal";
     }
     loadtest "x11/xterm";
+    loadtest "locale/keymap_or_locale_x11";
     loadtest "x11/sshxterm" unless get_var("LIVETEST");
     if (gnomestep_is_applicable()) {
         load_system_update_tests();

--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -10,99 +10,27 @@
 # Summary: Keyboard layout test in console and display manager after boot
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
-use base "opensusebasetest";
+use base "locale";
 use strict;
 use warnings;
-use testapi;
-use utils;
 use Utils::Backends 'has_ttys';
-
-sub verify_default_keymap_textmode_non_us {
-    my ($test_string, $tag) = @_;
-    # Installation with different keyboard layout is not feature ready but
-    # in case of autoyast scenarios we can simply test on login prompt without changing tty
-    type_string $test_string;
-    assert_screen ["${tag}", "${tag}_not_ready"];
-    if (match_has_tag "${tag}_not_ready") {
-        # i.e: in cz keyboard the first half in the keystroke list is not displayed in 1st login'
-        send_key 'ret' for (1 .. 2);
-        record_soft_failure 'bsc#1125886 - Special characters when switching keyboard layout only available after 2nd login';
-        assert_screen([qw(linux-login cleared-console)]);
-        type_string $test_string;
-        assert_screen "${tag}";
-    }
-}
-sub verify_default_keymap_textmode {
-    my ($test_string, $tag, %tty) = @_;
-    if (defined($tty{console})) {
-        select_console($tty{console});
-    }
-    else {
-        send_key('alt-f3');
-        # some remote backends can not provide a "not logged in console" so we
-        # use a cleared remote terminal instead
-        assert_screen(has_ttys() ? 'linux-login' : 'cleared-console');
-    }
-    type_string($test_string);
-    assert_screen($tag);
-    # clear line in order to add user bernhard to tty group
-    # clear line to avoid possible failures in following console tests if scheduled
-    send_key("ctrl-w");
-}
-
-sub list_locale_settings {
-    my ($self, $console) = @_;
-    # locale variables might differ from user to user
-    select_console($console);
-    $self->save_and_upload_log('localectl status', '/tmp/localectl.status.out');
-    $self->save_and_upload_log('locale',           '/tmp/locale.out');
-}
-
-sub list_locale_etc_settings {
-    my $self = shift;
-    select_console('user-console');
-    $self->save_and_upload_log('cat /etc/X11/xorg.conf.d/00-keyboard.conf', '/tmp/xorg.00-keyboard.conf.out');
-    $self->save_and_upload_log('cat /etc/vconsole.conf',                    '/tmp/vconsole.conf.out');
-}
-
-sub notification_handler {
-    my ($feature, $state) = @_;
-    select_console('user-console');
-    assert_script_run("(gsettings get $feature && gsettings set $feature $state) 2>/dev/null || true");
-}
-
-sub verify_default_keymap_x11 {
-    my ($test_string, $tag, $program) = @_;
-    notification_handler('org.gnome.DejaDup periodic', 'false') if (check_var('DESKTOP', 'gnome'));
-    select_console('x11');
-    x11_start_program($program);
-    type_string($test_string);
-    assert_screen($tag);
-    # clear line to avoid possible failures in following tests (eg. updates_packagekit_gpk)
-    send_key("ctrl-w");
-    # close xterm
-    send_key("ctrl-d");
-}
+use testapi qw(assert_screen get_var);
+use utils 'ensure_serialdev_permissions';
 
 sub run {
+    my ($self) = @_;
     my $expected = get_var('INSTALL_KEYBOARD_LAYOUT', 'us');
     # Feature of switching keyboard during installation is not ready yet,
     # so if another language is used it needs to be verfied that the needle represents properly
     # characters on that language.
-    my $keystrokes = '`1234567890-=~!@#$%^&*()_+';
+    my $keystrokes = $self->get_keystroke_list($expected);
 
-    if (check_var('DESKTOP', 'textmode')) {
-        assert_screen([qw(linux-login cleared-console)]);
-        # We don't run further tests while switching keyboard feature not ready
-        return verify_default_keymap_textmode_non_us($keystrokes, "${expected}_keymap") if ($expected ne 'us');
-        verify_default_keymap_textmode($keystrokes, "${expected}_keymap");
-        verify_default_keymap_textmode($keystrokes, "${expected}_keymap", console => 'root-console');
-        ensure_serialdev_permissions;
-        verify_default_keymap_textmode($keystrokes, "${expected}_keymap", console => 'user-console');
-    }
-    elsif (get_var('DESKTOP') && (!check_var('DESKTOP', 'textmode'))) {
-        verify_default_keymap_x11($keystrokes, "${expected}_keymap_logged_x11", 'xterm');
-    }
+    assert_screen([qw(linux-login cleared-console)]);
+    return $self->verify_default_keymap_textmode_non_us($keystrokes, "${expected}_keymap") if ($expected ne 'us');
+    $self->verify_default_keymap_textmode($keystrokes, "${expected}_keymap");
+    $self->verify_default_keymap_textmode($keystrokes, "${expected}_keymap", console => 'root-console');
+    ensure_serialdev_permissions;
+    $self->verify_default_keymap_textmode($keystrokes, "${expected}_keymap", console => 'user-console');
 }
 
 sub test_flags {

--- a/tests/locale/keymap_or_locale_x11.pm
+++ b/tests/locale/keymap_or_locale_x11.pm
@@ -1,0 +1,32 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Keyboard layout test in console and display manager after boot
+# Maintainer: Oliver Kurz <okurz@suse.com>
+
+use base "locale";
+use strict;
+use warnings;
+use testapi;
+
+
+sub run {
+    my ($self) = @_;
+    # uncomment in case of different keyboard than us is used during installation ( feature not ready yet )
+    # my $expected   = get_var('INSTALL_KEYBOARD_LAYOUT','us');
+    my $expected   = 'us';
+    my $keystrokes = $self->get_keystroke_list($expected);
+
+    $self->verify_default_keymap_x11($keystrokes, "${expected}_keymap_logged_x11", 'xterm');
+}
+
+sub test_flags {
+    return {milestone => 1};
+}
+1;


### PR DESCRIPTION
[related progress ticket](https://progress.opensuse.org/issues/46532)
<del>[x11 verification, custom schedule](http://opeth.suse.de/tests/4003#step/keymap_or_locale_x11/7)
[x11 verification, full schedule](http://opeth.suse.de/tests/4004)
[textmode verification, full schedule](http://opeth.suse.de/tests/4007)</del>

updated verification runs:
[TW KDE-Live](https://openqa.opensuse.org/tests/877951)
[TW textmode](https://openqa.opensuse.org/tests/877952)
[SLES textmode x86](https://openqa.suse.de/tests/2537514)
[SLES textmode aarch64](https://openqa.suse.de/tests/2537515)