### PR TITLE
Register for SDK in toolkit tests for SLE12

### DIFF
--- a/tests/x11/toolkits/prepare.pm
+++ b/tests/x11/toolkits/prepare.pm
@@ -22,10 +22,16 @@ sub run {
     if (is_sle) {
         # enable sdk
         assert_script_run 'source /etc/os-release';
-        if (is_sle '>=15') {
+        if (get_var 'ADDONURL_SDK') {
+            zypper_call('ar ' . get_var('ADDONURL_SDK') . ' sdk-repo');
+            zypper_call('ref');
+        }
+        elsif (is_sle '>=15') {
             assert_script_run 'SUSEConnect -p sle-module-development-tools/${VERSION_ID}/${CPU}';
         }
         else {
+            # for historical reasons we don't register SLE12 systems in openqa by default
+            assert_script_run 'SUSEConnect -r ' . get_required_var('SCC_REGCODE');
             assert_script_run 'SUSEConnect -p sle-sdk/${VERSION_ID}/${CPU}';
         }
     }


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/46625
Verification: http://artemis.suse.de/tests/1158#step/prepare/8

Note that the test still fails to add the sdk repo.
While it is already advertised in SCC it doesn't seem to
by synced yet.