### PR TITLE
Add check whether Hostnames window is closed

### DIFF
--- a/lib/y2x11test.pm
+++ b/lib/y2x11test.pm
@@ -41,7 +41,8 @@ sub launch_yast2_module_x11 {
         script_run('pkill -TERM -e yast2');
         select_console('x11');
     }
-    x11_start_program("xdg-su -c '/sbin/yast2 $module'", target_match => @tags, match_timeout => $args{match_timeout});
+    # the command started with 'sh -c' to be able to execute 'echo' in Desktop Runner on Gnome
+    x11_start_program("sh -c 'xdg-su -c \"/sbin/yast2 $module\"; echo \"yast2-$module-status-\$?\" > /dev/$serialdev'", target_match => @tags, match_timeout => $args{match_timeout});
     foreach ($args{target_match}) {
         return if match_has_tag($_);
     }

--- a/tests/yast2_gui/yast2_hostnames.pm
+++ b/tests/yast2_gui/yast2_hostnames.pm
@@ -17,8 +17,7 @@
 use base "y2x11test";
 use strict;
 use testapi;
-use utils 'type_string_slow';
-
+use utils qw(type_string_slow clear_console);
 
 sub run {
     my $self   = shift;
@@ -27,8 +26,9 @@ sub run {
     select_console 'root-console';
     #	add 1 entry to /etc/hosts and edit it later
     script_run "echo '80.92.65.53    n-tv.de ntv' >> /etc/hosts";
-    select_console 'x11', await_console => 0;
-    $self->launch_yast2_module_x11('host', match_timeout => 90);
+    clear_console;
+    select_console 'x11';
+    $self->launch_yast2_module_x11($module, match_timeout => 90);
     assert_and_click "yast2_hostnames_added";
     wait_still_screen 1;
     wait_screen_change { send_key 'alt-i'; };
@@ -43,7 +43,8 @@ sub run {
     assert_and_click 'yast2_hostnames_changed_ok';
     assert_screen "yast2-$module-ui", 30;
     #	OK => Exit
-    wait_screen_change { send_key "alt-o"; };
+    send_key "alt-o";
+    wait_serial("yast2-$module-status-0") || die 'Fail! YaST2 - Hostnames dialog is not closed or non-zero code returned.';
     # Check that entry was correctly edited in /etc/hosts
     select_console "root-console";
     assert_script_run q#grep '195\.135\.221\.134\s*download\.opensuse\.org\s*download-srv' /etc/hosts#;
@@ -56,8 +57,8 @@ sub post_run_hook {
 
 sub post_fail_hook {
     my ($self) = shift;
-    upload_logs('/etc/hosts');
     $self->SUPER::post_fail_hook;
+    upload_logs('/etc/hosts');
 }
 
 1;


### PR DESCRIPTION
The test continued execution even if the 'YaST2 - Hostnames' window was
not closed (e.g. due to error) after pressing 'Ok' to save changes in
hosts configuration.

The commit adds additional check if the window is closed or not in order
to make the fail more obvious.

- Related ticket:  [poo#46232](https://progress.opensuse.org/issues/46232)
- Verification run: http://oorlov-vm.qa.suse.de/tests/758