### PR TITLE
Fix "keymap_or_locale" on svirt backends which are not s390x-kvm

### DIFF
--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -25,6 +25,7 @@ use constant {
     BACKEND => [
         qw(
           is_remote_backend
+          has_ttys
           )
     ],
     CONSOLES => [
@@ -57,6 +58,13 @@ sub is_remote_backend {
       check_var('BACKEND', 'svirt') ||
       check_var('BACKEND', 'ipmi')  ||
       check_var('BACKEND', 'spvm');
+}
+
+# In some cases we are using a VNC connection provided by the hypervisor that
+# allows access to the ttys same as for accessing any remote libvirt instance
+# but not what we use for s390x-kvm.
+sub has_ttys {
+    return ((get_var('BACKEND', '') !~ /ipmi|s390x|spvm/) && !get_var('S390_ZKVM'));
 }
 
 1;

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -19,7 +19,6 @@ use Time::HiRes 'sleep';
 
 use testapi;
 use utils;
-use Utils::Backends 'is_remote_backend';
 use version_utils qw(is_caasp is_jeos is_leap is_sle);
 use caasp 'pause_until';
 use mm_network;

--- a/tests/autoyast/login.pm
+++ b/tests/autoyast/login.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 SUSE LLC
+# Copyright (C) 2015-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
 # Summary: Log into system installed with autoyast
-# Maintainer: Pavel Sladek <psladek@suse.cz>
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
 use strict;
 use base 'y2logsstep';

--- a/tests/autoyast/login.pm
+++ b/tests/autoyast/login.pm
@@ -19,7 +19,7 @@
 use strict;
 use base 'y2logsstep';
 use testapi;
-use Utils::Backends qw(use_ssh_serial_console is_remote_backend);
+use Utils::Backends 'use_ssh_serial_console';
 
 sub run {
     my $self = shift;

--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -8,13 +8,13 @@
 # without any warranty.
 
 # Summary: Keyboard layout test in console and display manager after boot
-# Maintainer: Martin Loviska <mloviska@suse.com>
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "opensusebasetest";
 use strict;
 use testapi;
 use utils;
-use Utils::Backends 'is_remote_backend';
+use Utils::Backends 'has_ttys';
 
 sub verify_default_keymap_textmode {
     my ($test_string, $tag, %tty) = @_;
@@ -24,9 +24,9 @@ sub verify_default_keymap_textmode {
     }
     else {
         send_key('alt-f3');
-        # remote backends can not provide a "not logged in console" so we use
-        # a cleared remote terminal instead
-        assert_screen(is_remote_backend() ? 'cleared-console' : 'linux-login');
+        # some remote backends can not provide a "not logged in console" so we
+        # use a cleared remote terminal instead
+        assert_screen(has_ttys() ? 'linux-login' : 'cleared-console');
     }
 
     type_string($test_string);


### PR DESCRIPTION
We tried to distinguish by "is_remote_backend" if there is a "tty" where
we can try out the keymap without being logged in or if we need to use a
"logged in terminal", e.g. a ssh session. However some backends which we
consider "remote" still do offer ttys: The svirt backends provide a complete
remote control of the VM instances including ttys with the notable exception
of s390x KVM which calls itself "svirt" itself but does not provide the ttys.
Hence this commit introduces another explicit backend check function which
we can use in the "keymap_or_locale" test module.

See for example:
* https://openqa.suse.de/tests/2401420#step/keymap_or_locale/2 on
  "svirt-hyperv" failing because we expect a cleared console but we do have
  a tty which was unexpected
* https://openqa.suse.de/tests/2401211#step/keymap_or_locale/3 on s390x-kvm
  where there is no tty but a terminal session provided by ssh
* https://openqa.suse.de/tests/2401491#step/keymap_or_locale/3 on the
  standard qemu backend showing the tty

Verification runs:

```
for i in https://openqa.suse.de/tests/2401420 https://openqa.suse.de/tests/2401211 https://openqa.suse.de/tests/2401491; \
do openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6642 $i ; done
```

Created job #2404376: sle-15-SP1-Installer-DVD-x86_64-Build149.2-default@svirt-hyperv -> https://openqa.suse.de/t2404376
Created job #2404377: sle-15-SP1-Installer-DVD-s390x-Build149.2-textmode@s390x-kvm-sle12 -> https://openqa.suse.de/t2404377
Created job #2404379: sle-15-SP1-Installer-DVD-x86_64-Build149.2-textmode@64bit -> https://openqa.suse.de/t2404379

Related progress issue: https://progress.opensuse.org/issues/46508