### PR TITLE
Adjust iscsi MM test according to  bsc#1115648

### DIFF
--- a/lib/y2_mm_common.pm
+++ b/lib/y2_mm_common.pm
@@ -1,0 +1,22 @@
+package y2_mm_common;
+
+use strict;
+use warnings;
+use Exporter 'import';
+use testapi;
+use mm_tests 'configure_static_network';
+use x11utils 'turn_off_gnome_screensaver';
+
+our @EXPORT = qw(prepare_xterm_and_setup_static_network);
+
+sub prepare_xterm_and_setup_static_network {
+    my %args = @_;
+    die "Static network configuration failed, no IP specified!\n" unless defined($args{ip});
+    x11_start_program('xterm -geometry 160x45+5+5', target_match => 'xterm');
+    turn_off_gnome_screensaver;
+    become_root;
+    record_info 'Network', $args{message} if defined($args{message});
+    configure_static_network($args{ip});
+}
+
+1;

--- a/schedule/MM/iscsi/iscsi_normal_auth_backstore_fileio.yaml
+++ b/schedule/MM/iscsi/iscsi_normal_auth_backstore_fileio.yaml
@@ -1,0 +1,28 @@
+name:           iscsi-normal-auth-only
+description:    >
+    iSCSI multimachine test suite with normal authentication, fileIO backstore, simple static network
+test_data:
+  common:
+    password: 'susetesting'
+  target_conf:
+    backstore_type: 'fileio'
+    backstore: '/root/iscsi-disk'
+    user: 'test_target'
+    name: 'iqn.2016-02.de.openqa'
+    ip: '10.0.2.1/24'
+    id: 'target'
+  initiator_conf:
+    ip: '10.0.2.3/24'
+    user: 'test_initiator'
+    id: 'init'
+    name: 'iqn.2016-02.de.openqa'
+conditional_schedule:
+    iscsi:
+        FUNCTION:
+            target:
+                - iscsi/iscsi_server
+            initiator:
+                - iscsi/iscsi_client
+schedule:
+    - boot/boot_to_desktop
+    - {{iscsi}}

--- a/schedule/MM/iscsi/iscsi_normal_auth_backstore_hdd.yaml
+++ b/schedule/MM/iscsi/iscsi_normal_auth_backstore_hdd.yaml
@@ -1,0 +1,28 @@
+name:           iscsi-normal-auth-only
+description:    >
+    iSCSI multimachine test suite with normal authentication, lvm backstore, simple static network
+test_data:
+  common:
+    password: 'susetesting'
+  target_conf:
+    backstore_type: 'hdd'
+    backstore: '/dev/vdb'
+    user: 'test_target'
+    name: 'iqn.2016-02.de.openqa'
+    ip: '10.0.2.1/24'
+    id: 'target'
+  initiator_conf:
+    ip: '10.0.2.3/24'
+    user: 'test_initiator'
+    id: 'init'
+    name: 'iqn.2016-02.de.openqa'
+conditional_schedule:
+    iscsi:
+        FUNCTION:
+            target:
+                - iscsi/iscsi_server
+            initiator:
+                - iscsi/iscsi_client
+schedule:
+    - boot/boot_to_desktop
+    - {{iscsi}}

--- a/schedule/MM/iscsi/iscsi_normal_auth_backstore_lvm.yaml
+++ b/schedule/MM/iscsi/iscsi_normal_auth_backstore_lvm.yaml
@@ -1,0 +1,28 @@
+name:           iscsi-normal-auth-only
+description:    >
+    iSCSI multimachine test suite with normal authentication, lvm backstore, simple static network
+test_data:
+  common:
+    password: 'susetesting'
+  target_conf:
+    backstore_type: 'lvm'
+    backstore: '/dev/mapper/vg_iscsi-remote_lv'
+    user: 'test_target'
+    name: 'iqn.2016-02.de.openqa'
+    ip: '10.0.2.1/24'
+    id: 'target'
+  initiator_conf:
+    ip: '10.0.2.3/24'
+    user: 'test_initiator'
+    id: 'init'
+    name: 'iqn.2016-02.de.openqa'
+conditional_schedule:
+    iscsi:
+        FUNCTION:
+            target:
+                - iscsi/iscsi_server
+            initiator:
+                - iscsi/iscsi_client
+schedule:
+    - boot/boot_to_desktop
+    - {{iscsi}}

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -11,96 +11,242 @@
 #    Multimachine testsuites, server test creates iscsi target and client test uses it
 # Maintainer: Jozef Pupava <jpupava@suse.com>
 
-use base "x11test";
+use base "y2_module_guitest";
 use strict;
 use warnings;
 use testapi;
-use mm_network;
-use lockapi;
+use lockapi qw(mutex_create mutex_wait);
 use version_utils qw(is_sle is_leap);
-use mmapi;
-use utils 'zypper_call';
+use mmapi qw(get_children wait_for_children);
+use utils qw(zypper_call systemctl type_string_slow_extended);
 use yast2_widget_utils 'change_service_configuration';
-use x11utils 'turn_off_gnome_screensaver';
-use y2_module_consoletest;
+use scheduler 'get_test_data';
+use y2_mm_common 'prepare_xterm_and_setup_static_network';
 
-sub run {
-    my $self = shift;
+# load expected test data from yaml
+# common for both iscsi MM modules
+my $test_data = get_test_data();
 
-    x11_start_program('xterm -geometry 160x45+5+5', target_match => 'xterm');
-    turn_off_gnome_screensaver;
-    become_root;
-    configure_default_gateway;
-    configure_static_ip('10.0.2.1/24');
-    configure_static_dns(get_host_resolv_conf());
-    zypper_call 'in yast2-iscsi-lio-server';
-    assert_script_run 'dd if=/dev/zero of=/root/iscsi-disk seek=1M bs=8192 count=1';    # create iscsi LUN
-    my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'iscsi-lio-server');
-    assert_screen 'iscsi-lio-server';
+sub create_fileio {
+    if (defined($test_data->{target_conf}->{backstore})) {
+        assert_script_run 'dd if=/dev/zero of=' . $test_data->{target_conf}->{backstore} . ' seek=1M bs=8192 count=1';
+    } else {
+        die "FileIO path has not been defined!\n";
+    }
+}
+
+sub create_lvm {
+    # get last empty disk
+    my $pv = script_output("lsblk -p | awk 'END {print \$1}'");
+    if ($pv =~ /\/dev\/vdb/) {
+        assert_script_run("pvcreate $pv");
+        assert_script_run("vgcreate vg_iscsi $pv");
+        assert_script_run("lvcreate -n remote_lv -L 10G vg_iscsi");
+    } else {
+        die "Missing secondary drive!\n";
+    }
+}
+
+# install open-iscsi, yast2 modules
+# create backstore
+# iscsi considers lvm and hdd as iblocks
+sub prepare_iscsi_deps {
+    zypper_call 'in yast2-iscsi-lio-server targetcli';
+    die "No backstore defined in the yaml schedule!\n" unless defined($test_data->{target_conf}->{backstore_type});
+    if ($test_data->{target_conf}->{backstore_type} eq 'fileio') {
+        create_fileio;
+    } elsif ($test_data->{target_conf}->{backstore_type} eq 'lvm') {
+        create_lvm;
+    } elsif ($test_data->{target_conf}->{backstore_type} eq 'hdd') {
+        die "No secondary drive attached to target system!\n"
+          if (script_output("lsblk -p | awk 'END {print \$1}'") !~ $test_data->{target_conf}->{backstore});
+    } else {
+        die "Unknow backstore type -> $test_data->{target_conf}->{backstore_type}\nAllowed values: fileio|hdd|lvm";
+    }
+}
+
+sub target_service_tab {
     unless (is_sle('<15') || is_leap('<15.1')) {
         change_service_configuration(
             after_writing => {start         => 'alt-w'},
             after_reboot  => {start_on_boot => 'alt-a'}
         );
     }
-    send_key 'alt-o';                                                                   # open port in firewall
-    wait_still_screen(2, 10);
+    # open port in firewall
+    send_key 'alt-o';
     assert_screen 'iscsi-target-overview-service-tab';
-    send_key 'alt-g';                                                                   # go to global tab
-    assert_screen 'iscsi-target-overview-global-tab';
-    send_key 'alt-t';                                                                   # go to target tab
-    wait_still_screen(2, 10);
-    send_key 'alt-a';                                                                   # add target
-    wait_still_screen(2, 10);
-    send_key 'alt-t';                                                                   # select target field
-    wait_still_screen(2, 10);
-    send_key 'ctrl-a';                                                                  # select all text inside target field
-    wait_still_screen(2, 10);
-    send_key 'delete';                                                                  # text it is automatically selected after tab, delete
-    type_string 'iqn.2016-02.de.openqa';
-    wait_still_screen(2, 10);
-    send_key 'tab';                                                                     # tab to identifier field
-    wait_still_screen(2, 10);
-    send_key 'delete';
-    wait_still_screen(2, 10);
-    type_string '132';
-    wait_still_screen(2, 10);
+}
+
+sub config_2way_authentication {
+    assert_screen 'iscsi-target-modify-acls';
+    send_key 'alt-a';
+    assert_screen 'iscsi-target-modify-acls-initiator-popup';
     if (is_sle('>=15')) {
-        send_key 'alt-l';                                                               # un-check bind all IPs
+        send_key 'alt-i';
+    } else {
+        send_key_until_needlematch 'iscsi-client-name-selected', 'tab';
     }
-    else {
-        send_key 'alt-u';                                                               # un-check use authentication
+    type_string_slow_extended $test_data->{initiator_conf}->{name} . ':' . $test_data->{initiator_conf}->{id};
+    send_key 'alt-o';
+    assert_screen 'iscsi-target-modify-acls';
+    send_key 'alt-u';
+    assert_screen 'iscsi-target-modify-acls-authentication';
+    # initiator & target credential fields are swapped in sle12 and sle15
+    my %key_shortcuts;
+    if (is_sle('>=15')) {
+        $key_shortcuts{enable_auth_init}   = 'alt-h';
+        $key_shortcuts{auth_init_user}     = 'alt-m';
+        $key_shortcuts{auth_init_pass}     = 'alt-t';
+        $key_shortcuts{enable_auth_target} = 'alt-e';
+        $key_shortcuts{auth_target_user}   = 'alt-u';
+        $key_shortcuts{auth_target_pass}   = 'alt-p';
+
+    } else {
+        $key_shortcuts{enable_auth_init}   = 'alt-t';
+        $key_shortcuts{auth_init_user}     = 'alt-s';
+        $key_shortcuts{auth_init_pass}     = 'alt-a';
+        $key_shortcuts{enable_auth_target} = 'alt-h';
+        $key_shortcuts{auth_target_user}   = 'alt-u';
+        $key_shortcuts{auth_target_pass}   = 'alt-p';
     }
-    wait_still_screen(2, 10);
-    send_key 'alt-a';                                                                   # add LUN
-    my $lunpath_key = is_sle('>=15') ? 'alt-l' : 'alt-p';
-    send_key_until_needlematch 'iscsi-target-LUN-path-selected', $lunpath_key, 5, 5;    # send $lunpath_key until LUN path is selected
-    type_string '/root/iscsi-disk';
+    send_key $key_shortcuts{enable_auth_init};
+    assert_screen 'iscsi-target-acl-auth-initiator-enable-auth';
+    send_key $key_shortcuts{auth_init_user};
+    type_string_slow_extended $test_data->{initiator_conf}->{user};
+    assert_screen 'iscsi-target-acl-auth-initiator-username';
+    send_key $key_shortcuts{auth_init_pass};
+    my $init_pass = reverse $test_data->{common}->{password};
+    type_string_slow_extended($init_pass);
+    assert_screen 'iscsi-target-acl-auth-initiator-pass' if is_sle('>=15');
+    send_key $key_shortcuts{enable_auth_target};
+    assert_screen 'iscsi-target-acl-auth-target-enable-auth';
+    send_key $key_shortcuts{auth_target_user};
+    type_string_slow_extended $test_data->{target_conf}->{user};
+    assert_screen 'iscsi-target-acl-auth-target-username';
+    send_key $key_shortcuts{auth_target_pass};
+    type_string_slow_extended $test_data->{common}->{password};
+    assert_screen 'iscsi-target-acl-auth-target-pass' if is_sle('>=15');
+    send_key 'alt-o';
+    assert_screen 'iscsi-target-modify-acls';
+    send_key 'alt-n';
+    if (is_sle('>=15')) {
+        assert_screen 'iscsi-target-acl-warning';
+        send_key 'alt-y';
+    }
+}
+
+sub target_backstore_tab {
+    send_key 'alt-t';    # go to target tab
+    assert_screen 'iscsi-target-targets-tab';
+    send_key 'alt-a';    # add target
+                         # we need to wait while YaST generates Identifier value
+    wait_still_screen(stilltime => 1, timeout => 5, similarity_level => 44);
+    send_key 'alt-t';    # select target field
+    wait_still_screen(stilltime => 1, timeout => 5, similarity_level => 44);
+    send_key 'ctrl-a';    # select all text inside target field
+    wait_still_screen(stilltime => 1, timeout => 5, similarity_level => 45);
+    send_key 'delete';    # text it is automatically selected after tab, delete
+    type_string_slow_extended $test_data->{target_conf}->{name};
+    send_key 'tab';       # tab to identifier field
+    wait_still_screen(stilltime => 1, timeout => 5, similarity_level => 44);
+    send_key 'delete';
+    type_string_slow_extended $test_data->{target_conf}->{id};
+    # un-check bind all IPs
+    # explicitly check use authentication only on sle15
+    # checked by default in sle12
+    if (is_sle('>=15')) {
+        wait_still_screen(stilltime => 1, timeout => 5, similarity_level => 45);
+        send_key 'alt-l';
+        wait_still_screen(stilltime => 1, timeout => 5, similarity_level => 45);
+        send_key 'alt-u';
+    }
+    wait_still_screen(stilltime => 1, timeout => 5, similarity_level => 44);
+    send_key 'alt-a';    # add LUN
+    assert_and_click('iscsi-target-LUN-path-selected', timeout => 20);
+    type_string_slow_extended $test_data->{target_conf}->{backstore};
     assert_screen 'iscsi-target-LUN';
-    send_key 'alt-o';                                                                   # OK
+    send_key 'alt-o';    # OK
     assert_screen 'iscsi-target-overview';
-    send_key 'alt-n';                                                                   # next
-    wait_still_screen(2, 10);
-    if (is_sle('<15')) {
-        send_key 'alt-a';                                                               # add client
-        send_key_until_needlematch 'iscsi-client-name-selected', 'tab';                 # there is no field shortcut, so tab till client name field is selected
-        type_string 'iqn.2016-02.de.openqa';
-        assert_screen 'iscsi-target-client-name';
-        send_key 'alt-o';                                                               # OK
-        assert_screen 'iscsi-target-client-setup';
-        send_key 'alt-n';                                                               # next
-    }
+    send_key 'alt-n';    # next
+    config_2way_authentication;
     assert_screen 'iscsi-target-overview-target-tab';
-    send_key 'alt-f';                                                                   # finish
-    wait_serial("$module_name-0", 180) || die "'yast2 iscsi-server ' didn't finish or exited with non-zero code";
-    mutex_create('iscsi_ready');                                                        # setup is done client can connect
+    send_key 'alt-f';               # finish
+    mutex_create('iscsi_ready');    # setup is done client can connect
+}
+
+sub display_targets {
+    my (%args) = @_;
+    my $cmd = 'targetcli sessions list | tee -a ' . "/dev/$serialdev";
+    assert_script_run 'targetcli ls';
+    # targetcli does not support sessions option in sle12
+    return if (is_sle '<15');
+    $cmd .= '| grep -i ' . $args{expected} if defined($args{expected}) . ' | tee -a ' . "/dev/$serialdev";
+    assert_script_run $cmd;
+}
+
+sub run {
+    my $self = shift;
+    # open xterm, configure server network and create drive for iscsi
+    prepare_xterm_and_setup_static_network(ip => $test_data->{target_conf}->{ip}, message => 'Configure MM network - server');
+    prepare_iscsi_deps;
+    # verify iscsi connection before setup
+    record_info 'iSCSI Sessions', 'Display target sessions & settings before iscsi configuration';
+    display_targets(expected => qq('no open sessions'));
+    # start yast2 wizard
+    record_info 'iSCSI target', 'Start target configuration';
+    my $module_name = $self->launch_yast2_module_x11('iscsi-lio-server', target_match => 'iscsi-lio-server');
+    target_service_tab;
+    target_backstore_tab;
+    wait_serial("$module_name-0", 180) || die "'yast2 iscsi-lio-server' didn't finish or exited with non-zero code";
+    # verify systemd services after configuration
+    record_info 'Systemd - after', 'Verify status of iscsi services and sockets';
+    my $service = (is_sle('>=15') ? 'targetcli.service' : 'target.service');
+    systemctl("is-active $service");
+    # create mutex for child job -> triggers start of initiator configuration
+    # setup is done client can connect
+    mutex_create('iscsi_target_ready');
+    my $children = get_children();
+    my $child_id = (keys %$children)[0];
+    # wait for child mutex, initiator is being configured
+    mutex_wait("iscsi_initiator_ready", $child_id, 'Initiator configuration in progress!');
+    # verify iscsi connections, ACL must be set!
+    record_info 'iSCSI Sessions', 'Display target sessions & settings after setup';
+    display_targets(expected => 'LOGGED_IN');
+    # initiator can continue to test iscsi drive
+    mutex_create('iscsi_display_sessions');
+    # wait idle while initiator finishes its execution
+    wait_for_children;
     type_string "killall xterm\n";
-    wait_for_children;                                                                  # run till client is done
+    # run till client is done
+    wait_for_children;
     $self->result('ok');
 }
 
 sub test_flags {
     return {fatal => 1};
+}
+
+sub post_fail_hook {
+    my $self            = shift;
+    my $target_label    = $test_data->{target_conf}->{name} . '\\:' . $test_data->{target_conf}->{id};
+    my $initiator_label = $test_data->{initiator_conf}->{name} . '\\:' . $test_data->{initiator_conf}->{id};
+    select_console 'root-console';
+    display_targets;
+    unless (script_run('ls -la /sys/kernel/config/iscsi')) {
+        # show amount of normal logouts
+        script_run 'cat /sys/kernel/config/target/iscsi/' . $target_label . '/fabric_statistics/iscsi_logout_stats/normal_logouts';
+        # show amount of abnormal logouts
+        script_run 'cat /sys/kernel/config/target/iscsi/' . $target_label . '/fabric_statistics/iscsi_logout_stats/abnormal_logouts';
+        # show amount of active sessions
+        script_run 'cat /sys/kernel/config/target/iscsi/' . $target_label . '/fabric_statistics/iscsi_instance/sessions';
+        # show ACL information
+        script_run 'cat /sys/kernel/config/target/iscsi/' . $target_label . '/tpgt_1/acls/' . $initiator_label . '/info';
+        # show auth credentials and configuration
+        script_run 'cat /sys/kernel/config/target/iscsi/' . $target_label . '/tpgt_1/acls/' . $initiator_label . '/tpgt_1/auth/*';
+        # show auth credentials and acls configuration
+        script_run 'cat /sys/kernel/config/target/iscsi/' . $target_label . '/tpgt_1/acls/' . $initiator_label . '/tpgt_1/acls/auth/*';
+    }
+    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
* add ACLs
* configure target and initiator 2 way authentication 
* adapt test suite according to hints from bsc#1115648

- Related ticket: [[sle][functional][y] - adapt iscsi MM test according to hints from bsc#1115648](https://progress.opensuse.org/issues/46316) & 
[[sle][functional][y][bsc#1123316] - iscsi MM test with LVM backstore](https://progress.opensuse.org/issues/48329)
- Needles: 
   * <del>[Add authentication to iscsi MM](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1056)</del>
   * [another needle MR](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1187)
- Verification runs:
   * sle12-sp5:
      * [iscsi_client_normal_auth_backstore_lvm@64bit](http://eris.suse.cz/tests/15729)
      * [iscsi_server_normal_auth_backstore_lvm@64bit](http://eris.suse.cz/tests/15724)
      * [iscsi_client_normal_auth_backstore_fileio@64bit](http://eris.suse.cz/tests/15727)
      * [iscsi_server_normal_auth_backstore_fileio@64bit](http://eris.suse.cz/tests/15725)
      * [iscsi_server_normal_auth_backstore_hdd@64bit](http://eris.suse.cz/tests/15726)
      * [iscsi_client_normal_auth_backstore_hdd@64bit](http://eris.suse.cz/tests/15728)
   * sle15-sp1:
      * [iscsi_client_normal_auth_backstore_lvm@64bit](http://eris.suse.cz/tests/15721)
      * [iscsi_server_normal_auth_backstore_lvm@64bit](http://eris.suse.cz/tests/15718)
      * [iscsi_client_normal_auth_backstore_fileio](http://eris.suse.cz/tests/15722)
      * [iscsi_server_normal_auth_backstore_fileio](http://eris.suse.cz/tests/15719)
      * [iscsi_client_normal_auth_backstore_hdd](http://eris.suse.cz/tests/15723)
      * [iscsi_server_normal_auth_backstore_hdd](http://eris.suse.cz/tests/15720)
- <del>Sle12SP5 is currently blocked by [bsc#1123381](https://bugzilla.suse.com/show_bug.cgi?id=1123381)</del>