### PR TITLE
Fix wrong hotkey used on icewm screen unlock check

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -3,6 +3,7 @@ use base 'distribution';
 use serial_terminal ();
 use strict;
 use utils qw(
+  desktop_runner_hotkey
   disable_serial_getty
   ensure_serialdev_permissions
   ensure_unlocked_desktop
@@ -139,18 +140,18 @@ sub init_cmd {
     ## keyboard cmd vars end
 }
 
-
 sub init_desktop_runner {
     my ($program, $timeout) = @_;
     $timeout //= 30;
+    my $hotkey = desktop_runner_hotkey;
 
-    send_key(check_var('DESKTOP', 'minimalx') ? 'super-spc' : 'alt-f2');
+    send_key($hotkey);
 
     mouse_hide(1);
     if (!check_screen('desktop-runner', $timeout)) {
-        record_info('workaround', 'desktop-runner does not show up on alt-f2, retrying up to three times (see bsc#978027)');
+        record_info('workaround', "desktop-runner does not show up on $hotkey, retrying up to three times (see bsc#978027)");
         send_key 'esc';    # To avoid failing needle on missing 'alt' key - poo#20608
-        send_key_until_needlematch 'desktop-runner', 'alt-f2', 3, 10;
+        send_key_until_needlematch 'desktop-runner', $hotkey, 3, 10;
     }
     # krunner may use auto-completion which sometimes gets confused by
     # too fast typing or looses characters because of the load caused (also

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2018 SUSE LLC
+# Copyright (C) 2015-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,6 +28,7 @@ use Mojo::UserAgent;
 our @EXPORT = qw(
   check_console_font
   clear_console
+  desktop_runner_hotkey
   type_string_slow
   type_string_very_slow
   save_svirt_pty
@@ -298,6 +299,8 @@ sub clear_console {
     type_string "clear\n";
 }
 
+sub desktop_runner_hotkey { check_var('DESKTOP', 'minimalx') ? 'super-spc' : 'alt-f2' }
+
 # assert_gui_app (optionally installs and) starts an application, checks it started
 # and closes it again. It's the most minimalistic way to test a GUI application
 # Mandatory parameter: application: the name of the application.
@@ -514,7 +517,7 @@ sub ensure_unlocked_desktop {
                 # responsiveness.
                 # open run command prompt (if screen isn't locked)
                 mouse_hide(1);
-                send_key 'alt-f2';
+                send_key desktop_runner_hotkey;
                 if (check_screen 'desktop-runner', 30) {
                     send_key 'esc';
                     assert_screen 'generic-desktop';

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -858,11 +858,7 @@ sub pidgin_remove_account {
 
 sub tomboy_logout_and_login {
     wait_screen_change { send_key 'alt-f4' };
-
-    # logout
-    wait_screen_change { send_key "alt-f2" };
-    type_string "gnome-session-quit --logout --force\n";
-    wait_still_screen;
+    x11_start_program('gnome-session-quit --logout --force', valid => 0);
 
     # login
     send_key "ret";

--- a/tests/x11/libreoffice/libreoffice_pyuno_bridge.pm
+++ b/tests/x11/libreoffice/libreoffice_pyuno_bridge.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -25,13 +25,7 @@ sub run {
     my $mail_passwd   = $config->{internal_account_A}->{passwd};
     my $mail_sendport = $config->{internal_account_A}->{sendport};
 
-    #Open LibreOffice
-    send_key "alt-f2";
-    wait_screen_change {
-        type_string "libreoffice --writer";
-        send_key "ret";
-    };
-    assert_screen 'test-ooffice-1';
+    x11_start_program('libreoffice --writer', target_match => 'test-ooffice-1');
     #Open the mail Merge Email dialog
     send_key "alt-t";
     assert_screen('libreoffice-tool-droplist', 30);

--- a/tests/x11/remote_desktop/xrdp_server.pm
+++ b/tests/x11/remote_desktop/xrdp_server.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2018-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -44,10 +44,7 @@ sub run {
     assert_script_run "systemctl start xrdp";
     type_string "exit\n";
     wait_screen_change { send_key 'alt-f4' };
-
-    # logout
-    wait_screen_change { send_key "alt-f2" };
-    type_string "gnome-session-quit --logout --force\n";
+    x11_start_program('gnome-session-quit --logout --force', valid => 0);
 
     # Notice xrdp server is ready for remote access
     mutex_create 'xrdp_server_ready';

--- a/tests/x11/xfce4_appfinder.pm
+++ b/tests/x11/xfce4_appfinder.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -14,10 +14,11 @@
 use base 'x11test';
 use strict;
 use testapi;
+use utils 'desktop_runner_hotkey';
 
 
 sub run {
-    wait_screen_change { send_key "alt-f2"; };
+    wait_screen_change { desktop_runner_hotkey };
     send_key "down";
     type_string "about\n";
     assert_screen 'test-xfce4_appfinder-1';


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/46682

Verification run: https://openqa.opensuse.org/t840814