### PR TITLE
Add dracut test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1542,6 +1542,7 @@ sub load_extra_tests_console {
     loadtest 'console/vhostmd';
     # sysauth test scenarios run in the console
     loadtest "sysauth/sssd" if get_var('SYSAUTHTEST');
+    loadtest "console/dracut";
 }
 
 sub load_extra_tests_docker {

--- a/tests/console/dracut.pm
+++ b/tests/console/dracut.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test dracut installation and verify that it works as expected
+# Maintainer: Paolo Stivanin <pstivanin@suse.com>
+
+use base 'opensusebasetest';
+use testapi;
+use utils;
+use strict;
+use power_action_utils 'power_action';
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    assert_script_run("rpm -q dracut");
+
+    validate_script_output("lsinitrd", sub { m/Image:(.*\n)+Version: dracut(-|\d+|\.|\w+)+(\n)+Arguments(.*\n)+dracut modules:(\w+|-|\d+|\n)+\=+\n(l|d|r|w|x|-)+\s+1 root\s+root(.*\n)+\=+/ });
+    validate_script_output("dracut -f", sub { m/.* Executing: \/usr\/bin\/dracut -f\n((dracut: dracut module.*\n)|(dracut: \*+ Including module:.*\n)|(dracut: Skipping.*\n)|(dracut: Could not find.*\n))+dracut: \*+ Including modules done \*+(.+|\n)+/ });
+    validate_script_output("dracut --list-modules", sub { m/.*Executing: \/usr\/bin\/dracut --list-modules\n(\w+|\n|-|d+)+/ });
+
+    power_action('reboot', textmode => 1);
+    $self->wait_boot;
+}
+
+1;


### PR DESCRIPTION
- lists contents of image
- list available dracut modules
- generate and overwrite current image
- reboot system and check system status after the boot

- related ticket: https://progress.opensuse.org/issues/46607
- tested on both sles 12.4 (http://d502.qam.suse.de/tests/272) and sles 15 (http://d502.qam.suse.de/tests/274)