### PR TITLE
Fix issue that aa-genprof does not parse audit log

### DIFF
--- a/tests/security/apparmor/aa_autodep.pm
+++ b/tests/security/apparmor/aa_autodep.pm
@@ -51,13 +51,12 @@ sub run {
             \}/sxx
     };
 
-    assert_script_run "rm -f $aa_tmp_prof/usr.sbin.nscd";
-
     $self->aa_interactive_run("aa-autodep -d $aa_tmp_prof /usr/bin/pam* ; echo AUTODEP-DONE", $scan_ans, 300);
 
     # Output generated profiles list to serial console
     assert_script_run "ls -1 $aa_tmp_prof/*pam* > tee /dev/$serialdev";
 
+    assert_script_run "aa-disable -d $aa_tmp_prof usr.sbin.nscd";
     $self->aa_tmp_prof_clean("$aa_tmp_prof");
 }
 

--- a/tests/security/apparmor/aa_logprof.pm
+++ b/tests/security/apparmor/aa_logprof.pm
@@ -50,7 +50,7 @@ sub run {
     $self->aa_disable_stdout_buf("/usr/sbin/aa-logprof");
     $self->aa_tmp_prof_prepare("$aa_tmp_prof", 1);
 
-    my @aa_logprof_items = ('capability setuid', '\/var\/log\/nscd.log');
+    my @aa_logprof_items = ('\/usr.*\/nscd mrix', 'nscd\.conf');
 
     # Remove some rules from profile
     foreach my $item (@aa_logprof_items) {
@@ -76,8 +76,8 @@ sub run {
         m/
             include\s+<tunables\/global>.*
             .*nscd\s+flags=\(complain\)\s*\{.*
-            \/etc\/nscd\.conf\s+r.*
             \/usr\/.*bin.*\/nscd\s+mrix.*
+            \/etc\/nscd\.conf\s+r.*
             \}/sxx
     };
 


### PR DESCRIPTION
Apparmor generate the audit log items which include file path in the profile name after recent update. aa-logprof can not recognize it. It is turn out that usr.sbin.nscd has not been disabled in previous step (aa_autodep.pm).

- Related ticket: https://progress.opensuse.org/issues/46736
- Verification run:
  - SLE15 SP1: http://10.67.17.9/tests/302#step/aa_logprof/28
  - openSUSE Tumblweed: http://10.67.17.9/tests/306#step/aa_logprof/28