### PR TITLE
Increase timeout for btrfs maintainance tasks

### DIFF
--- a/tests/console/force_scheduled_tasks.pm
+++ b/tests/console/force_scheduled_tasks.pm
@@ -47,7 +47,7 @@ sub run {
     record_soft_failure 'bsc#1063638 - review I/O scheduling parameters of btrfsmaintenance' if (time - $before) > 60 && get_var('SOFTFAIL_BSC1063638');
     # Disable cron jobs on older SLE12 by symlinking them to /bin/true
     if (!get_var('SOFTFAIL_BSC1063638') && script_run("! [ -d /usr/share/btrfsmaintenance/ ]")) {
-        assert_script_run('find /usr/share/btrfsmaintenance/ -type f -exec ln -fs /bin/true {} \;');
+        assert_script_run('find /usr/share/btrfsmaintenance/ -type f -exec ln -fs /bin/true {} \;', timeout => 210);
     }
     assert_script_run "sync";
     settle_load;


### PR DESCRIPTION
Increasing the timeout for btrfs tasks in force_scheduled_tasks
to avoid dying in the test on slower architectures

- Related ticket: https://progress.opensuse.org/issues/46397