### PR TITLE
Add validation test suite for RT

### DIFF
--- a/data/modprobe_kmp_modules.sh
+++ b/data/modprobe_kmp_modules.sh
@@ -3,7 +3,7 @@
 for pkg in $(rpm -qa \*-kmp-rt); do
   for mod in $(rpm -ql $pkg | grep '\.ko$'); do
     modname=$(basename $mod .ko)
-    modprobe $modname || fail=1
+    modprobe $modname &>> /var/log/modprobe.out || fail=1
   done
 done
 if [ $fail ] ; then exit 1 ; fi

--- a/lib/rt_utils.pm
+++ b/lib/rt_utils.pm
@@ -1,0 +1,35 @@
+package rt_utils;
+use base Exporter;
+use testapi;
+use strict;
+use Exporter;
+
+our @EXPORT = qw(
+  select_kernel
+);
+
+sub select_kernel {
+    my $kernel = shift;
+
+    assert_screen ['grub2', "grub2-$kernel-selected"], 100;
+    if (match_has_tag "grub2-$kernel-selected") {    # if requested kernel is selected continue
+        send_key 'ret';
+    }
+    else {                                           # else go to that kernel thru grub2 advanced options
+        send_key_until_needlematch 'grub2-advanced-options', 'down';
+        send_key 'ret';
+        send_key_until_needlematch "grub2-$kernel-selected", 'down';
+        send_key 'ret';
+    }
+    if (get_var('NOAUTOLOGIN')) {
+        assert_screen 'displaymanager', 200;
+        mouse_hide(1);
+        send_key 'ret';
+        assert_screen 'displaymanager-password-prompt', no_wait => 1;
+        type_password;
+        send_key 'ret';
+        assert_screen 'generic-desktop';
+    }
+}
+
+1;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1072,8 +1072,19 @@ else {
     }
     elsif (get_var("BOOT_HDD_IMAGE") && !is_jeos) {
         if (get_var("RT_TESTS")) {
-            set_var('INSTALLONLY', 1);
             loadtest "rt/boot_rt_kernel";
+            loadtest "console/prepare_test_data";
+            loadtest "console/consoletest_setup";
+            loadtest "console/hostname";
+            loadtest "console/zypper_ref";
+            loadtest "console/zypper_lr";
+            loadtest "console/system_prepare";
+            loadtest "rt/rt_is_realtime";
+            loadtest "rt/rt_devel_packages";
+            loadtest "rt/rt_peak_pci";
+            loadtest "rt/rt_preempt_test";
+            loadtest "rt/kmp_modules";
+            set_var('INSTALLONLY', 1);
         }
         else {
             load_bootloader_s390x();

--- a/tests/rt/boot_rt_kernel.pm
+++ b/tests/rt/boot_rt_kernel.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright Â© 2009-2013 Bernhard M. Wiedemann
+# Copyright Â© 2012-2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+# Summary: select and boot RT in grub menu
+# Maintainer: Martin Loviska <mloviska@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use testapi;
+use utils;
+use bootloader_setup 'boot_grub_item';
+
+sub run() {
+    my $self = shift;
+    $self->boot_grub_item(2, 3);
+}
+
+1;
+
+# vim: set sw=4 et:

--- a/tests/rt/rt_devel_packages.pm
+++ b/tests/rt/rt_devel_packages.pm
@@ -1,0 +1,24 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: RT installation media should contain devel packages
+# Maintainer: mkravec <mkravec@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+use utils;
+
+# https://fate.suse.com/316652
+sub run {
+    my $pkgs = "babeltrace-devel lttng-tools-devel kernel-rt-devel kernel-rt_debug-devel kernel-devel-rt libcpuset-devel";
+    zypper_call "in $pkgs";
+}
+
+1;

--- a/tests/rt/rt_is_realtime.pm
+++ b/tests/rt/rt_is_realtime.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Check that realtime kernel is running
+# Maintainer: mkravec <mkravec@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+
+sub run {
+    assert_script_run "uname -v | grep 'PREEMPT RT'";
+    assert_script_run "grep 1 /sys/kernel/realtime";
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+
+1;

--- a/tests/rt/rt_peak_pci.pm
+++ b/tests/rt/rt_peak_pci.pm
@@ -1,0 +1,23 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Can add SocketCAN kernel driver without problems
+# Maintainer: mkravec <mkravec@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+
+# https://fate.suse.com/317131
+sub run {
+    assert_script_run "modprobe peak_pci";
+    assert_script_run "lsmod | grep ^peak_pci";
+}
+
+1;

--- a/tests/rt/rt_preempt_test.pm
+++ b/tests/rt/rt_preempt_test.pm
@@ -1,0 +1,26 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: RT preempt test
+# Maintainer: mkravec <mkravec@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+
+# Run preempt test
+sub run {
+    script_run "zypper -q ar http://download.suse.de/ibs/Devel:/RTE:/SLE12SP1/standard/Devel:RTE:SLE12SP1.repo";
+    script_run "zypper -q --gpg-auto-import-keys refresh";
+    script_run "zypper -q --non-interactive install preempt-test";
+
+    assert_script_run "preempt-test | grep 'Test PASSED'";
+}
+
+1;


### PR DESCRIPTION
Initial attempt to add RT validation test suite for freshly installed RT product on sle15sp1

- Related ticket: [poo#45149](https://progress.opensuse.org/issues/45149)
- Needles: <del>[MR#1058](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1058)</del>
- Verification run:  [sle-15-SP1-Installer-DVD-x86_64-Build149.2-rt-extratests@64bit](http://eris.suse.cz/tests/11363)
- Issues:
   * [kmp_modules bug](https://bugzilla.suse.com/show_bug.cgi?id=1123696)
   * [preempt-test](https://progress.opensuse.org/issues/46874)