### PR TITLE
Fix dracut test on SLE 12.1

### DIFF
--- a/tests/console/dracut.pm
+++ b/tests/console/dracut.pm
@@ -23,7 +23,7 @@ sub run {
     assert_script_run("rpm -q dracut");
 
     validate_script_output("lsinitrd", sub { m/Image:(.*\n)+Version: dracut(-|\d+|\.|\w+)+(\n)+Arguments(.*\n)+dracut modules:(\w+|-|\d+|\n)+\=+\n(l|d|r|w|x|-)+\s+1 root\s+root(.*\n)+\=+/ });
-    validate_script_output("dracut -f", sub { m/.* Executing: \/usr\/bin\/dracut -f\n((dracut: dracut module.*\n)|(dracut: \*+ Including module:.*\n)|(dracut: Skipping.*\n)|(dracut: Could not find.*\n))+dracut: \*+ Including modules done \*+(.+|\n)+/ });
+    validate_script_output("dracut -f", sub { m/.*Executing: \/usr\/bin\/dracut -f\n(((dracut: |)dracut module.*\n)|((dracut: |)\*+ Including module:.*\n)|((dracut: |)Skipping.*\n)|((dracut: |)Could not find.*\n))+(dracut: |)\*+ Including modules done \*+(.+|\n)+/ });
     validate_script_output("dracut --list-modules", sub { m/.*Executing: \/usr\/bin\/dracut --list-modules\n(\w+|\n|-|d+)+/ });
 
     power_action('reboot', textmode => 1);


### PR DESCRIPTION
dracut on SLE 12.1 outputs a different output compared to dracut on SLE 12.2 and greater.

- Related ticket: https://progress.opensuse.org/issues/46607
- Test execution result for:
  - sle 12.1: http://d502.qam.suse.de/tests/286
  - sle 12.4: http://d502.qam.suse.de/tests/287
  - sle 15: http://d502.qam.suse.de/tests/288

