### PR TITLE
Modify interactive command for AppArmor, fix for SLE12 SP4

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -55,7 +55,7 @@ sub aa_tmp_prof_prepare {
         assert_script_run "mkdir $prof_dir_tmp";
         assert_script_run "cp -r $prof_dir/{tunables,abstractions} $prof_dir_tmp/";
         if (is_sle('<15') or is_leap('<15.0')) {    # apparmor < 2.8.95
-            assert_script_run "cp -r $prof_dir/program-chunks $prof_dir_tmp/";
+            assert_script_run "cp -r $prof_dir/program-chunks $prof_dir/disable $prof_dir_tmp/";
         }
     }
     else {

--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -31,17 +31,6 @@ our @EXPORT = qw (
 
 our $audit_log = "/var/log/audit/audit.log";
 
-# Disable stdout buffering to make pipe works
-sub aa_disable_stdout_buf {
-    my ($self, $app) = @_;
-    if (is_sle('<15') or is_leap('<15.0')) {    # apparmor < 2.8.95
-        assert_script_run "sed -i '/use strict;/a \$|=1;' $app";
-    }
-    else {                                      # apparmor >= 2.8.95
-        assert_script_run "export PYTHONUNBUFFERED=1";
-    }
-}
-
 # $prof_dir_tmp: The target temporary directory
 # $type:
 # 0  - Copy only the basic structure of profile directory
@@ -82,45 +71,6 @@ sub aa_tmp_prof_clean {
     my ($self, $prof_dir_tmp) = @_;
 
     assert_script_run "rm -rf $prof_dir_tmp";
-}
-
-# For interactive command, answer the question according to the contents
-# matched. Need an arrayref to pass the contents to be filtered and the
-# Answer send_key
-sub aa_interactive_run {
-    my ($self, $cmd, $scan, $timeout) = @_;
-    my $output;
-    my @words;
-    $timeout //= 180;
-
-    for my $k (@$scan) {
-        push(@words, $k->{word});
-    }
-
-    if ($cmd) {
-        script_run("(" . $cmd . ")| tee /dev/$serialdev", 0);
-    }
-
-  LOOP: {
-        do {
-            $output = wait_serial(\@words, $timeout) || die "Uknown Options!";
-            for my $i (@$scan) {
-                if ($output =~ $i->{word}) {
-                    if ($i->{key}) {
-                        send_key $i->{key};
-                        last LOOP if ($i->{end});
-                        last;
-                    }
-                    elsif ($i->{end}) {
-                        last LOOP;
-                    }
-                    else {
-                        die "$i->{word} - 'key' or 'end' should be specified";
-                    }
-                }
-            }
-        } while ($output);
-    }
 }
 
 # Get the named profile for an executable program

--- a/tests/security/apparmor/aa_autodep.pm
+++ b/tests/security/apparmor/aa_autodep.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2018 SUSE LLC
+# Copyright (C) 2018-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +15,7 @@
 #
 # Summary: Guess basic AppArmor profile requirements with aa_autodep
 # Maintainer: Wes <whdu@suse.com>
-# Tags: poo#36889, tc#1621141
+# Tags: poo#36889, poo#45803
 
 use base 'apparmortest';
 use strict;
@@ -26,18 +26,7 @@ sub run {
     my ($self) = @_;
 
     my $aa_tmp_prof = "/tmp/apparmor.d";
-    my $scan_ans    = [
-        {
-            word => qr/Inactive local profile/m,
-            key  => 'c',
-        },
-        {
-            word => qr/AUTODEP-DONE/m,
-            end  => 1,
-        },
-    ];
 
-    $self->aa_disable_stdout_buf("/usr/sbin/aa-autodep");
     $self->aa_tmp_prof_prepare($aa_tmp_prof, 0);
 
     assert_script_run "aa-autodep -d $aa_tmp_prof/ nscd";
@@ -51,7 +40,16 @@ sub run {
             \}/sxx
     };
 
-    $self->aa_interactive_run("aa-autodep -d $aa_tmp_prof /usr/bin/pam* ; echo AUTODEP-DONE", $scan_ans, 300);
+    script_run_interactive(
+        "aa-autodep -d $aa_tmp_prof /usr/bin/pam*",
+        [
+            {
+                prompt => qr/Inactive local profile/m,
+                key    => 'c',
+            },
+        ],
+        30
+    );
 
     # Output generated profiles list to serial console
     assert_script_run "ls -1 $aa_tmp_prof/*pam* > tee /dev/$serialdev";

--- a/tests/security/apparmor/aa_genprof.pm
+++ b/tests/security/apparmor/aa_genprof.pm
@@ -15,7 +15,7 @@
 #
 # Summary: Test the profile generation utility of Apparmor
 # Maintainer: Wes <whdu@suse.com>
-# Tags: poo#36886, tc#1621140
+# Tags: poo#36886, poo#45803
 
 use strict;
 use base "apparmortest";
@@ -25,50 +25,61 @@ use utils;
 sub run {
     my ($self) = @_;
 
-    my $aa_tmp_prof           = "/tmp/apparmor.d";
-    my $aa_genprof_filter_pre = [
-        {
-            word => qr/\(S\)can system.*\(F\)inish/m,
-            key  => 's',
-            end  => 1,
-        },
-    ];
-    my $aa_genprof_filter = [
-        {
-            word => qr/\(A\)llow.*\(D\)eny/m,
-            key  => 'a',
-        },
-        {
-            word => qr/\(S\)ave Changes/m,
-            key  => 's',
-        },
-        {
-            word => qr/\(S\)can system.*\(F\)inish/m,
-            key  => 'f',
-            end  => 1,
-        },
-    ];
+    my $aa_tmp_prof = "/tmp/apparmor.d";
+    my $sc_dtch_msg = "Screen detached";
+    my $sc_term_msg = "Screen terminated";
 
     systemctl('start auditd');
 
-    $self->aa_disable_stdout_buf("/usr/sbin/aa-genprof");
     $self->aa_tmp_prof_prepare("$aa_tmp_prof");
 
     assert_script_run("rm -f  $aa_tmp_prof/usr.sbin.nscd");
 
-    # Run the command in background so that we could run other commands
-    script_run("(aa-genprof -d $aa_tmp_prof nscd|tee /dev/$serialdev) &", 0);
-    sleep 5;
-    send_key 'ret';    # Back to the shell prompt
+    # Run aa-genprof command in screen so that we could restart nscd at the
+    # same time while it is waiting for scan
+    script_run("screen -m ; echo '$sc_dtch_msg' > /dev/$serialdev", 0);
+
+    # Confirm it is in the screen
+    validate_script_output "echo \$TERM", sub { m/screen/ };
+
+    script_run("script -c 'aa-genprof -d $aa_tmp_prof nscd' /dev/null |& tee /dev/$serialdev", 0);
+    wait_serial("Please start the application", 20);
+
+    # Detach screen
+    send_key 'ctrl-a';
+    sleep 1;
+    send_key 'd';
+    wait_serial("$sc_dtch_msg", 10);    # confirm detached
 
     systemctl('restart nscd');
+    sleep 3;
 
-    # Call the job to the front ground
-    script_run("fg", 0);
-    send_key 'ret';    # Work around for Tumblweed
+    # reattach screen
+    script_run("screen -r ; echo '$sc_term_msg' > /dev/$serialdev", 0);
+    send_key 's';
 
-    $self->aa_interactive_run(undef, $aa_genprof_filter_pre);
-    $self->aa_interactive_run(undef, $aa_genprof_filter);
+    script_run_interactive(
+        undef,
+        [
+            {
+                prompt => qr/\(A\)llow.*\(D\)eny/m,
+                key    => 'a',
+            },
+            {
+                prompt => qr/\(S\)ave Changes/m,
+                key    => 's',
+            },
+            {
+                prompt => qr/\(S\)can system.*\(F\)inish/m,
+                key    => 'f',
+            },
+        ],
+        30
+    );
+
+    # Exit screen
+    send_key 'ctrl-d';
+    wait_serial("$sc_term_msg", 10);    # confirm terminated
 
     # Not all rules will be checked here, only the critical ones.
     validate_script_output "cat $aa_tmp_prof/usr.sbin.nscd", sub {

--- a/tests/security/apparmor/aa_logprof.pm
+++ b/tests/security/apparmor/aa_logprof.pm
@@ -50,7 +50,7 @@ sub run {
     $self->aa_disable_stdout_buf("/usr/sbin/aa-logprof");
     $self->aa_tmp_prof_prepare("$aa_tmp_prof", 1);
 
-    my @aa_logprof_items = ('\/usr.*\/nscd mrix', 'nscd\.conf');
+    my @aa_logprof_items = ('\/usr.*\/nscd mrix', 'nscd\.conf r');
 
     # Remove some rules from profile
     foreach my $item (@aa_logprof_items) {
@@ -72,14 +72,9 @@ sub run {
 
     $self->aa_interactive_run("aa-logprof -d $aa_tmp_prof", $scan_ans);
 
-    validate_script_output "cat $aa_tmp_prof/usr.sbin.nscd", sub {
-        m/
-            include\s+<tunables\/global>.*
-            .*nscd\s+flags=\(complain\)\s*\{.*
-            \/usr\/.*bin.*\/nscd\s+mrix.*
-            \/etc\/nscd\.conf\s+r.*
-            \}/sxx
-    };
+    foreach my $item (@aa_logprof_items) {
+        validate_script_output "cat $aa_tmp_prof/usr.sbin.nscd", sub { m/$item/ };
+    }
 
     $self->aa_tmp_prof_verify("$aa_tmp_prof", 'nscd');
     $self->aa_tmp_prof_clean("$aa_tmp_prof");


### PR DESCRIPTION
### Modify interactive command function for AppArmor
A more robust subroution for interactive command has been already added to the util.pm. Modify AppArmor cases with this one to replace legacy function which is for AppArmor cases only in _lib/apparmortest.pm._ At the same time, change the method of running `aa-genprof` in background with the `screen` command, to make the test process more stable.
- Related ticket: https://progress.opensuse.org/issues/45803

### Fix behaviour of aa-autodep aa-logprof for SLE12
Copy the directory 'disable' to temporary profile as well to make `aa-disable` working for `aa-autodep` on SLE12. Modify the pattern to be matched for _aa-logprof_ to compatible with SLE12.
- Related ticket: https://progress.opensuse.org/issues/44912

### Verification run
- SLE15 SP1: http://10.67.17.9/tests/337
- SLE12 SP4: http://10.67.17.9/tests/338
- Tumbleweed: http://10.67.17.9/tests/339
