### PR TITLE
Fix SMT URL field selection for SLE12 registration

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -617,7 +617,7 @@ sub fill_in_reg_server {
     }
     else {
         send_key "alt-i";
-        if (is_sle('12-sp3+')) {
+        if (is_sle('>=15')) {
             send_key "alt-l";
         }
         else {


### PR DESCRIPTION
Fix the condition for selecting SMT URL input field in 'fill_in_reg_server' to make it work on SLE12 SP4 and SP5.

- Related ticket: https://progress.opensuse.org/issues/46853
- Verification run:
  - SLE12 SP4: http://10.67.17.9/tests/340
  - SLE15 SP1: http://10.67.17.9/tests/342
  - SLE12 SP3: http://10.67.17.9/tests/344
