### PR TITLE
[AARCH64 Automation] Use correct method to assign value to undefined or empty variable

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -207,7 +207,7 @@ sub get_installation_partition {
 
 sub set_pxe_efiboot {
     my ($root_prefix) = @_;
-    $root_prefix //= "/";
+    $root_prefix = "/" if (!defined $root_prefix) || ($root_prefix eq "");
     my $installation_disk = "";
 
     if ($root_prefix ne "/") {


### PR DESCRIPTION
The original $root_prefix //= "/" does not do what it is supposed to do under specific circumstance.
$root_prefix = "/" if ($root_prefix eq "") || (! defined $root_prefix) catches all exceptions.


- Related ticket: n/a
- Needles: n/a
- Verification run:
  http://10.162.187.154/tests/937
  http://10.162.187.154/tests/938

@alice-suse @guoxuguang @Julie-CAO 
