### PR TITLE
Unschedule cron test on JeOS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1502,7 +1502,7 @@ sub load_extra_tests_console {
         loadtest 'console/openssl_alpn';
         loadtest 'console/autoyast_removed';
     }
-    loadtest "console/cron";
+    loadtest "console/cron" unless is_jeos;
     loadtest "console/syslog";
     loadtest "console/ntp_client" if (!is_sle && !is_jeos);
     loadtest "console/mta" unless is_jeos;


### PR DESCRIPTION
The change unschedules the cron test because on JeOS systemd timers is used instead.

- Related ticket: https://progress.opensuse.org/issues/46757
- Verification run: http://ccret.suse.cz/tests/2618
