### PR TITLE
Add kiwi test for kiwi images generated at buildsystem.

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1106,6 +1106,11 @@ else {
         load_boot_tests();
         loadtest "remote/remote_target";
     }
+    elsif (get_var("KIWI_IMAGE_TESTS")) {
+        loadtest "kiwi_images_test/kiwi_boot";
+        loadtest "kiwi_images_test/login_reboot";
+        loadtest "kiwi_images_test/validate_build";
+    }
     else {
         if (get_var('BOOT_EXISTING_S390')) {
             loadtest 'installation/boot_s390';

--- a/tests/kiwi_images_test/kiwi_boot.pm
+++ b/tests/kiwi_images_test/kiwi_boot.pm
@@ -1,0 +1,49 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Boot kiwi live or oem image
+# Maintainer: Ednilson Miura <emiura@suse.com>
+
+use base "installbasetest";
+use strict;
+use testapi;
+use utils;
+use version_utils "is_sle";
+
+sub run {
+    my $iso_name = get_var('ISO');
+    # bootloader screen is too fast to openqa
+    sleep(10);
+    send_key 'down';
+    send_key 'up';
+    # sle12sp3 oem installer does not work correctly on non interactive
+    if (is_sle('<=12-SP3') && ($iso_name =~ /OEM/)) {
+        assert_screen('kiwi_boot', 15);
+        send_key 'ret';
+        # choose last option on installer screen
+        assert_screen('kiwi_oem_install_installer', 300);
+        my $count = 0;
+        while ($count < 16) {
+            send_key 'down';
+            $count++;
+        }
+        sleep 2;
+        send_key 'spc';
+        send_key 'ret';
+        assert_screen('kiwi_oem_install_confirm', 1200);
+        send_key 'ret';
+        assert_screen('kiwi_login', 1200);
+    }
+    else {
+        assert_screen('kiwi_boot', 15);
+        send_key 'ret';
+        assert_screen('kiwi_login', 600);
+    }
+}
+1;

--- a/tests/kiwi_images_test/login_reboot.pm
+++ b/tests/kiwi_images_test/login_reboot.pm
@@ -1,0 +1,34 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Login and reboot a kiwi image
+# Maintainer: Ednilson Miura <emiura@suse.com>
+
+use base "installbasetest";
+use strict;
+use testapi;
+use utils;
+use version_utils "is_sle";
+
+sub run {
+    # login
+    type_string("root\n");
+    sleep(2);
+    type_password("linux\n");
+    # and reboot
+    type_string("reboot\n");
+    # bootloader screen is too fast for openqa
+    sleep(10);
+    send_key 'down';
+    send_key 'up';
+    assert_screen('kiwi_boot', 120);
+    send_key 'ret';
+    assert_screen('kiwi_login', 120);
+}
+1;

--- a/tests/kiwi_images_test/validate_build.pm
+++ b/tests/kiwi_images_test/validate_build.pm
@@ -1,0 +1,77 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: validate kiwi online build status from buildsystem
+# Maintainer: Ednilson Miura <emiura@suse.com>
+
+use base "installbasetest";
+use strict;
+use testapi;
+use utils;
+use version_utils "is_sle";
+my $sle_version = get_var('VERSION');
+my @files_list  = ('build.log');
+
+# check kiwi build status
+sub check_status {
+    my @builds = ("test-image-docker", "test-image-iso", "test-image-oem", "test-image-pxe", "test-image-vmx");
+    script_run("curl -k https://build.suse.de/project/monitor/QA:Maintenance:Images:$sle_version:kiwi-ng-testing > kiwi_out.html");
+    # sle12sp3 has 2 different builds
+    if (is_sle('<=12-SP3')) {
+        script_run("curl -k https://build.suse.de/project/monitor/QA:Maintenance:Images:$sle_version:kiwi-testing > kiwi_out2.html");
+        push @files_list, 'build2.log';
+    }
+    # parse build.log
+    foreach my $kiwi_build (@builds) {
+        script_run("(grep $kiwi_build kiwi_out.html | grep -q succeeded && echo \"SLE-$sle_version $kiwi_build PASSED\" || 
+        echo \"SLE-$sle_version $kiwi_build FAILED\") >> build.log");
+    }
+
+    # check run if old kiwi
+    if (is_sle('<=12-SP3')) {
+        script_run("(grep test-image-oem kiwi_out2.html | grep -q succeeded && echo \"SLE-$sle_version test-image-oem PASSED\" || 
+        echo \"SLE-$sle_version test-image-oem FAILED\") >> build2.log");
+        # show contents before check
+        script_run("cat build2.log");
+    }
+    # show contents before check
+    script_run("cat build.log");
+
+    # reverse grep output (exit 1 if errors found)
+    foreach my $fname (@files_list) {
+        if (script_run("grep -q FAILED $fname")) {
+            assert_script_run '$(exit 0)';
+        }
+        else {
+            assert_script_run '$(exit 1)';
+        }
+    }
+}
+
+sub run {
+    assert_screen('kiwi_login', 120);
+    type_string("root\n");
+    sleep(2);
+    type_password("linux\n");
+    # validate build
+    check_status();
+    # upload logs anyway
+    foreach my $l (@files_list) {
+        upload_logs $l;
+    }
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    foreach my $l (@files_list) {
+        upload_logs $l;
+    }
+}
+
+1;


### PR DESCRIPTION
Add a testsuite for 3 tests: kiwi_boot, login_reboot and validate_build.

kiwi_boot does boot the kiwi image (live or oem) and check for the login prompt.
Also on SLE12SP3 OEM images, kiwi boot handles the installation procedures.

login_reboot does a simple check if it is possible to login in the image (oem or
live), reboot and login again afterwards.

validate_build parses the build results page on the buildsystem and check if any
test have failed.

Fixes poo#43625 [QAM] Add new openqa test for kiwi

Test run at http://10.161.229.249/tests/416

Requires needles from 


There are 5 images being generated to test: docker, iso, oem, pxe and vmx.
This testsuite only works for iso and oem type of images. ISO type is a
live image. OEM is a installer. Also, SLES12SP3 is special, there are 2
differente builds of kiwi, "kiwi" and "kiwi-ng". "kiwi" only have oem
images, "kiwi-ng" has all 5 types.

- Related ticket: https://progress.opensuse.org/issues/43625
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1059
- Verification run: http://10.161.229.249/tests/416
