### PR TITLE
publiccloud: Use vaultproject.io to create credentials

### DIFF
--- a/lib/publiccloud/basetest.pm
+++ b/lib/publiccloud/basetest.pm
@@ -33,22 +33,22 @@ sub provider_factory {
     }
     elsif (check_var('PUBLIC_CLOUD_PROVIDER', 'AZURE')) {
         $provider = publiccloud::azure->new(
-            key_id       => get_required_var('PUBLIC_CLOUD_KEY_ID'),
-            key_secret   => get_required_var('PUBLIC_CLOUD_KEY_SECRET'),
+            key_id       => get_var('PUBLIC_CLOUD_KEY_ID'),
+            key_secret   => get_var('PUBLIC_CLOUD_KEY_SECRET'),
             region       => get_var('PUBLIC_CLOUD_REGION', 'westeurope'),
-            tenantid     => get_required_var('PUBLIC_CLOUD_TENANT_ID'),
-            subscription => get_required_var('PUBLIC_CLOUD_SUBSCRIPTION_ID'),
+            tenantid     => get_var('PUBLIC_CLOUD_TENANT_ID'),
+            subscription => get_var('PUBLIC_CLOUD_SUBSCRIPTION_ID'),
             username     => 'azureuser'
         );
     }
     elsif (check_var('PUBLIC_CLOUD_PROVIDER', 'GCE')) {
         $provider = publiccloud::gce->new(
-            account             => get_required_var('PUBLIC_CLOUD_ACCOUNT'),
-            service_acount_name => get_required_var('PUBLIC_CLOUD_SERVICE_ACCOUNT'),
-            project_id          => get_required_var('PUBLIC_CLOUD_PROJECT_ID'),
-            private_key_id      => get_required_var('PUBLIC_CLOUD_KEY_ID'),
-            private_key         => get_required_var('PUBLIC_CLOUD_KEY'),
-            client_id           => get_required_var('PUBLIC_CLOUD_CLIENT_ID'),
+            account             => get_var('PUBLIC_CLOUD_ACCOUNT'),
+            service_acount_name => get_var('PUBLIC_CLOUD_SERVICE_ACCOUNT'),
+            project_id          => get_var('PUBLIC_CLOUD_PROJECT_ID'),
+            private_key_id      => get_var('PUBLIC_CLOUD_KEY_ID'),
+            private_key         => get_var('PUBLIC_CLOUD_KEY'),
+            client_id           => get_var('PUBLIC_CLOUD_CLIENT_ID'),
             region              => get_var('PUBLIC_CLOUD_REGION', 'europe-west1-b'),
             storage_name        => get_var('PUBLIC_CLOUD_STORAGE', 'openqa-storage'),
             username            => 'susetest'

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -14,6 +14,8 @@
 
 package publiccloud::gce;
 use Mojo::Base 'publiccloud::provider';
+use Mojo::Util 'b64_decode';
+use Mojo::JSON 'decode_json';
 use testapi;
 use strict;
 use utils;
@@ -31,26 +33,45 @@ has storage_name        => undef;
 sub init {
     my ($self) = @_;
     $self->SUPER::init();
-    my $credentials = "{" . $/
-      . '"type": "service_account", ' . $/
-      . '"project_id": "' . $self->project_id . '", ' . $/
-      . '"private_key_id": "' . $self->private_key_id . '", ' . $/
-      . '"private_key": "' . $self->private_key . '", ' . $/
-      . '"client_email": "' . $self->service_acount_name . '@' . $self->project_id . '.iam.gserviceaccount.com", ' . $/
-      . '"client_id": "' . $self->client_id . '", ' . $/
-      . '"auth_uri": "https://accounts.google.com/o/oauth2/auth", ' . $/
-      . '"token_uri": "https://oauth2.googleapis.com/token", ' . $/
-      . '"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs", ' . $/
-      . '"client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/' . $self->service_acount_name . '%40' . $self->project_id . '.iam.gserviceaccount.com"' . $/
-      . '}';
-    save_tmp_file(CREDENTIALS_FILE, $credentials);
-    assert_script_run('curl -O ' . autoinst_url . "/files/" . CREDENTIALS_FILE);
 
+    $self->create_credentials_file();
     assert_script_run('source ~/.bashrc');
     assert_script_run('ntpdate -s time.google.com');
     assert_script_run('gcloud config set account ' . $self->account);
     assert_script_run('gcloud auth activate-service-account --key-file=' . CREDENTIALS_FILE . ' --project=' . $self->project_id);
 }
+
+sub create_credentials_file {
+    my ($self) = @_;
+    my $credentials_file;
+
+    if ($self->private_key_id()) {
+        $credentials_file = "{" . $/
+          . '"type": "service_account", ' . $/
+          . '"project_id": "' . $self->project_id . '", ' . $/
+          . '"private_key_id": "' . $self->private_key_id . '", ' . $/
+          . '"private_key": "' . $self->private_key . '", ' . $/
+          . '"client_email": "' . $self->service_acount_name . '@' . $self->project_id . '.iam.gserviceaccount.com", ' . $/
+          . '"client_id": "' . $self->client_id . '", ' . $/
+          . '"auth_uri": "https://accounts.google.com/o/oauth2/auth", ' . $/
+          . '"token_uri": "https://oauth2.googleapis.com/token", ' . $/
+          . '"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs", ' . $/
+          . '"client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/' . $self->service_acount_name . '%40' . $self->project_id . '.iam.gserviceaccount.com"' . $/
+          . '}';
+    } else {
+        record_info('INFO', 'Get credentials from VAULT server.');
+        my $res = $self->vault_api('/v1/gcp/key/openqa-role', method => 'get');
+        $credentials_file = b64_decode($res->{data}->{private_key_data});
+        my $cf_json = decode_json($credentials_file);
+        $self->account($cf_json->{client_email});
+        $self->project_id($cf_json->{'project_id'});
+        $self->vault_lease_id($res->{lease_id});
+    }
+
+    save_tmp_file(CREDENTIALS_FILE, $credentials_file);
+    assert_script_run('curl -O ' . autoinst_url . "/files/" . CREDENTIALS_FILE);
+}
+
 
 sub file2name {
     my ($self, $file) = @_;


### PR DESCRIPTION
Use REST API of vault server to get temporal credentials. To make it
work you need to specify:
 _SECRET_PUBLIC_CLOUD_REST_URL
 _SECRET_PUBLIC_CLOUD_REST_USER
 _SECRET_PUBLIC_CLOUD_REST_PW

Each provider need a valid vault configuration in the following path:
AWS:   /aws/creds/openqa-role
GCE:   /gcp/key/openqa-role
AZURE: /azure/creds/openqa-role

- Related ticket: https://progress.opensuse.org/issues/42155
- Verification run:
  - Azure: http://cfconrad-vm.qa.suse.de/tests/3340
  - Google: http://cfconrad-vm.qa.suse.de/tests/3345
  - AWS: http://cfconrad-vm.qa.suse.de/tests/3342 

@asmorodskyi @jlausuch WDYT?