### PR TITLE
Increase wait time for dovecot start on SLE12

### DIFF
--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -69,7 +69,7 @@ sub run() {
     systemctl 'restart postfix';
 
     # DH parameters are generated after start in Dovecot < 2.2.7
-    assert_script_run("( journalctl -f -u dovecot.service & ) | grep -q 'ssl-params: SSL parameters regeneration completed'", 300) if is_sle('<15');
+    assert_script_run("( journalctl -f -u dovecot.service & ) | grep -q 'ssl-params: SSL parameters regeneration completed'", 900) if is_sle('<15');
 
     # create test users
     assert_script_run "useradd -m admin";


### PR DESCRIPTION
Fix poo#46826: Dovecot server needs more time for initilization during
the start. Timeout was increased from 300s to 900s.

Sporadic issues which happens on aarch64 (which is slower).

- Related ticket: https://progress.opensuse.org/issues/46826
- Needles: none
- Verification run: none