### PR TITLE
Enable docker_image test for all new SLE versions

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1555,14 +1555,12 @@ sub load_extra_tests_docker {
 
     loadtest "console/docker";
     loadtest "console/docker_runc";
-    if (is_sle(">=12-sp3") && is_sle('<=12-SP4')) {
-        loadtest "console/sle2docker";
-        loadtest "console/docker_image";
-    }
-    elsif (is_sle('=15') || is_opensuse) {
+    if (is_sle(">=12-sp3")) {
+        loadtest "console/sle2docker" if is_sle('<15');
         loadtest "console/docker_image";
     }
     if (is_opensuse) {
+        loadtest "console/docker_image";
         loadtest "console/podman_image" if is_tumbleweed;
         loadtest "console/docker_compose";
     }

--- a/lib/suse_container_urls.pm
+++ b/lib/suse_container_urls.pm
@@ -33,7 +33,7 @@ sub get_suse_container_urls {
 
     my @image_names  = ();
     my @stable_names = ();
-    if (is_sle(">=12-sp3") && is_sle('<=12-SP4')) {
+    if (is_sle(">=12-sp3") && is_sle('<15')) {
         my $lowerversion  = lc $version;
         my $nodashversion = $version =~ s/-sp/sp/ir;
         # No aarch64 image


### PR DESCRIPTION
It's necessary for 12 SP5+ and 15 SP1+ as well.

Untested.