### PR TITLE
[WIP][AARCH64 Automation] Allow 'script' addon to be added into SLE-12-SP4 by using SCC_ADDONS

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -87,6 +87,7 @@ sub accept_addons_license {
     #   grep -l EULA SUSE:SLE-15:GA/000product/*.product | sed 's/.product//'
     # All shown products have a license that should be checked.
     my @addons_with_license = qw(geo rt idu ids);
+    push @addons_with_license, 'wsm' if is_sle('<15');
     # For the legacy module we do not need any additional subscription,
     # like all modules, it is included in the SLES subscription.
     push @addons_with_license, 'lgm' unless is_sle('15+');


### PR DESCRIPTION
If "Web and Scripting" addon needs to be added into SLE-12-SP4 new installation by using SCC_ADDON=script, the corresponding license downloading and asserting are indispensable.


- Related ticket: n/a
- Needles: n/a
- Verification run: http://10.162.187.154/tests/1026
                            http://10.162.187.154/tests/1024

@alice-suse @guoxuguang @Julie-CAO 
