### PR TITLE
Fix dracut on SLE 15.1 and aarch64

### DIFF
--- a/tests/console/dracut.pm
+++ b/tests/console/dracut.pm
@@ -22,8 +22,8 @@ sub run {
 
     assert_script_run("rpm -q dracut");
 
-    validate_script_output("lsinitrd", sub { m/Image:(.*\n)+Version: dracut(-|\d+|\.|\w+)+(\n)+Arguments(.*\n)+dracut modules:(\w+|-|\d+|\n)+\=+\n(l|d|r|w|x|-)+\s+1 root\s+root(.*\n)+\=+/ });
-    validate_script_output("dracut -f", sub { m/.*Executing: \/usr\/bin\/dracut -f\n(((dracut: |)dracut module.*\n)|((dracut: |)\*+ Including module:.*\n)|((dracut: |)Skipping.*\n)|((dracut: |)Could not find.*\n))+(dracut: |)\*+ Including modules done \*+(.+|\n)+/ });
+    validate_script_output("lsinitrd", sub { m/Image:(.*\n)+Version: dracut(-|\d+|\.|\w+)+(\n)+Arguments(.*\n)+dracut modules:(\w+|-|\d+|\n)+\=+\n(l|d|r|w|x|-)+\s+1 root\s+root(.*\n)+\=+/ }, 300);
+    validate_script_output("dracut -f", sub { m/.*Executing: \/usr\/bin\/dracut -f\n(((dracut: |)dracut module.*\n)|((dracut: |)\*+ Including module:.*\n)|((dracut: |)Skipping.*\n)|(.*Could not find.*\n))+(dracut: |)\*+ Including modules done \*+(.+|\n)+/ }, 300);
     validate_script_output("dracut --list-modules", sub { m/.*Executing: \/usr\/bin\/dracut --list-modules\n(\w+|\n|-|d+)+/ });
 
     power_action('reboot', textmode => 1);


### PR DESCRIPTION
- on SLE 15.1 'dracut -f' output is a bit different compared to SLE <=
15.0 when a module can not be found. This is now fixed by matching
multiple times any character before the string "Could not find"

- on aarch64 'lsinitrd' and 'dracut -f' may longer than 90s, therefore the timeout
has to be increased.

- Related ticket: https://progress.opensuse.org/issues/46895
- Test results:
  - SLE 12.1: http://d502.qam.suse.de/tests/353
  - SLE 12.2: http://d502.qam.suse.de/tests/354
  - SLE 12.3: http://d502.qam.suse.de/tests/355
  - SLE 12.4: http://d502.qam.suse.de/tests/356
  - SLE 15.0: http://d502.qam.suse.de/tests/357
  - SLE 15.1: http://d502.qam.suse.de/tests/358
