### PR TITLE
Do not erase disks on IPMI textmode

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -406,7 +406,7 @@ sub take_first_disk_storage_ng {
     assert_screen [qw(existing-partitions partition-scheme)];
     # If drive(s) is/are not formatted, we have select hard disks page
     if (match_has_tag 'existing-partitions') {
-        if (check_var('BACKEND', 'ipmi')) {
+        if (check_var('BACKEND', 'ipmi') && !chech_var('DESKTOP', 'textmode')) {
             send_key_until_needlematch("remove-menu", "tab");
             while (check_screen('remove-menu', 3)) {
                 send_key 'spc';


### PR DESCRIPTION
Hello, this is regarding the IPMI text mode issue reported by @alice-suse on #6577.
We have still problems to boot this scenario so with @dzedro we decided to disable it.

- Related ticket: [poo#40610](https://progress.opensuse.org/issues/40610) [poo#43739](https://progress.opensuse.org/issues/43739)
- Needles: No need
- Verification run: In progress