### PR TITLE
Ltp extra test results

### DIFF
--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -237,6 +237,15 @@ sub record_ltp_result {
         print $fh "Some test output could not be parsed: $results->{ignored_lines} lines were ignored.";
     }
 
+    push(@{$self->{extra_test_results}}, {
+            category => 'LTP',
+            name     => $export_details->{test_fqn},
+            flags    => {},
+            result   => $details->{result},
+            script   => 'tests/kernel/run_ltp.pm',
+            duration => $duration,
+            log      => $test_log});
+
     $self->commit_result($details, $fh);
     return (0, $export_details);
 }

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -238,8 +238,8 @@ sub record_ltp_result {
         print $fh "Some test output could not be parsed: $results->{ignored_lines} lines were ignored.";
     }
 
-    $self->write_extra_test_result($export_details);
     $self->commit_result($details, $fh);
+    $self->write_extra_test_result($export_details);
     return (0, $export_details);
 }
 
@@ -264,13 +264,7 @@ sub write_extra_test_result {
     path($dir, 'result-' . $filename . '.json')->spurt(Mojo::JSON::encode_json($result_file));
     path($dir, $filename . '.txt')->spurt($details->{test}->{log});
 
-    my $test = {
-        name     => $filename,
-        category => 'LTP',
-        script   => 'unk',
-        flags    => {}
-    };
-    $self->register_extra_test_results([$test]);
+    push @{$self->{details}}, $result_file->{details}->[0];
 }
 
 sub thetime {


### PR DESCRIPTION
Continue of PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6624

Register extra test results by creating needed files manually.

- Related ticket: https://progress.opensuse.org/issues/46559
- Verification run: http://cfconrad-vm.qa.suse.de/tests/3388#external

I would like to discuss a solution like this: https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/0f1412ff592930eab7e58975eee77c206d51d1e3
This would need a small change in os-autoinst as  well https://github.com/os-autoinst/os-autoinst/commit/cf34bd153efeb148ec65f1d8e8562910ae691957, but in general this looks more generic to me.

@richiejp WDYT?

