### PR TITLE
publiccloud: Fix cleanup in ipa.pm

### DIFF
--- a/tests/publiccloud/ipa.pm
+++ b/tests/publiccloud/ipa.pm
@@ -47,7 +47,7 @@ sub run {
     die if ($ipa->{fail} > 0);
 }
 
-sub post_fail_hook {
+sub cleanup {
     my ($self) = @_;
 
     # upload logs on unexpected failure
@@ -56,7 +56,6 @@ sub post_fail_hook {
         assert_script_run('tar -zcvf ipa_results.tar.gz ipa_results');
         upload_logs('ipa_results.tar.gz', failok => 1);
     }
-    $self->SUPER->post_fail_hook();
 }
 
 1;


### PR DESCRIPTION
Use the cleanup() method instead of post_fail_hook() as this is the
way to do a safe cleanup when using publiccloud::basetest as parent.

- Verification run: http://cfconrad-vm.qa.suse.de/tests/3396

Without this, we miss the `terraform destroy` like in https://openqa.suse.de/tests/2429153 .
