### PR TITLE
Fix resolv.conf configuration in network utils

### DIFF
--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -29,7 +29,7 @@ sub setup_static_network {
     $args{ip} ||= '10.0.2.15';
     $args{gw} ||= testapi::host_ip();
     assert_script_run('echo default ' . $args{gw} . ' - - > /etc/sysconfig/network/routes');
-    assert_script_run('echo "nameserver 10.160.0.1" >> /etc/resolv.conf');
+    assert_script_run('echo "NETCONFIG_DNS_STATIC_SERVERS=10.160.0.1" >> /etc/sysconfig/network/config');
     my $iface = iface();
     assert_script_run qq(echo -e "\\nSTARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$args{ip}'">/etc/sysconfig/network/ifcfg-$iface);
     assert_script_run 'rcnetwork restart';


### PR DESCRIPTION
This fixes bug since build 156.1.

"rcnetwork restart" removes the content of /etc/resolv.conf and replaces it by the config given in /etc/sysconfig/network/config. 
Instead of adding the config to /etc/resolv.conf, we need to place the /etc/sysconfig/network/config in the with the appropriate syntax. "rcnetwork restart" will then fill /etc/resolv.conf according to this config.

- Related ticket: https://progress.opensuse.org/issues/46970
- Verification runs:

SLES15 SP1 beta3:
    - SUT: http://fromm.arch.suse.de/tests/5050
    - REF: http://fromm.arch.suse.de/tests/5047
SP12-SP5:
    - SUT: http://fromm.arch.suse.de/tests/5050
    - REF: http://fromm.arch.suse.de/tests/5049
