### PR TITLE
Add lshw regression tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1548,6 +1548,7 @@ sub load_extra_tests_console {
     loadtest "console/dracut";
     loadtest 'console/timezone';
     loadtest 'console/procps';
+    loadtest "console/lshw";
 }
 
 sub load_extra_tests_docker {

--- a/tests/console/lshw.pm
+++ b/tests/console/lshw.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test lshw installation and verify that the output seems properly formatted
+# Maintainer: Timo Jyrinki <tjyrinki@suse.com>
+
+use strict;
+use base 'consoletest';
+use testapi;
+use utils;
+
+sub run {
+    select_console 'root-console';
+
+    zypper_call('in lshw libxml2-tools');
+
+    # Check various output formats, -sanitize is used to not spill test machine serial numbers into public
+    # On some architectures fields like "product" or "vendor" or section "*-pci" might not exist, so trying a common base.
+    validate_script_output("lshw -sanitize", sub { m/description.*\*-memory\n.*\*-network\n/s });
+    assert_script_run("lshw -html -sanitize");
+    assert_script_run("lshw -xml -sanitize");
+    assert_script_run("lshw -json -sanitize");
+    assert_script_run("lshw -businfo");
+    # Check that XML is properly formatted (also empty output would cause an error)
+    assert_script_run("lshw -xml | xmllint -noout -");
+    # Check that variants of the class option are still supported
+    assert_script_run("lshw -class processor");
+    assert_script_run("lshw -c processor");
+    assert_script_run("lshw -C processor");
+}
+
+1;


### PR DESCRIPTION
- Run lshw with different output formats
- Check output to be sane ie that a few always existing sections are included
- Check XML output for being valid XML

- Related ticket: https://progress.opensuse.org/issues/46898
- Verification run: http://d403.qam.suse.de/tests/20
