### PR TITLE
Revert "Add a function to check if /etc/hosts is properly updated by yast2 lan"

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -17,9 +17,9 @@ sub post_fail_hook {
 
     show_tasks_in_blocked_state if ($defer_blocked_task_info);
 
+    upload_logs('/var/log/zypper.log');
     $self->remount_tmp_if_ro;
     $self->save_upload_y2logs;
-    upload_logs('/var/log/zypper.log');
     $self->save_system_logs;
     $self->save_strace_gdb_output('yast');
 }

--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -20,13 +20,11 @@ use utils 'systemctl';
 use version_utils qw(is_sle is_leap);
 use y2_common 'accept_warning_network_manager_default';
 
-our @EXPORT = qw(
-  check_etc_hosts_update
-  close_network_settings
-  check_network_status
+our @EXPORT_OK = qw(
   initialize_y2lan
   open_network_settings
-  validate_etc_hosts_entry
+  close_network_settings
+  check_network_status
   verify_network_configuration
 );
 
@@ -47,33 +45,30 @@ sub initialize_y2lan {
 }
 
 sub open_network_settings {
-    type_string "yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev\n";
+    type_string "yast2 lan\n";
     accept_warning_network_manager_default;
-    assert_screen 'yast2_lan', 180;       # yast2 lan overview tab
+    assert_screen 'yast2_lan', 100;       # yast2 lan overview tab
     send_key 'home';                      # select first device
-    wait_still_screen 1, 1;
+    wait_still_screen(2);
 }
 
 sub close_network_settings {
-    wait_still_screen 1, 1;
+    wait_still_screen;
     send_key 'alt-o';
     # new: warning pops up for firewall, alt-y for assign it to zone
-    if (!wait_serial("yast2-lan-status-0", 180)) {
-        check_screen([qw(yast2-lan-restart_firewall_active_warning yast2_lan_packages_need_to_be_installed)], 0);
-        if (match_has_tag 'yast2-lan-restart_firewall_active_warning') {
-            send_key 'alt-y';
-            wait_still_screen 1, 1;
-            send_key 'alt-n';
-            wait_still_screen 1, 1;
-            send_key 'alt-o';
-        }
-        elsif (match_has_tag 'yast2_lan_packages_need_to_be_installed') {
-            send_key 'alt-i';
-        }
-        wait_serial("yast2-lan-status-0", 180) || die "'yast2 lan' didn't finish or exited with non-zero code";
+    assert_screen([qw(yast2-lan-restart_firewall_active_warning yast2_closed_xterm_visible yast2_lan_packages_need_to_be_installed)], 120);
+    if (match_has_tag 'yast2-lan-restart_firewall_active_warning') {
+        send_key 'alt-y';
+        wait_still_screen 1;
+        send_key 'alt-n';
+        wait_still_screen 1;
+        send_key 'alt-o';
     }
-
-    type_string "\n\n";    # make space for better readability of the console
+    elsif (match_has_tag 'yast2_lan_packages_need_to_be_installed') {
+        send_key 'alt-i';
+    }
+    assert_screen 'yast2_closed_xterm_visible', 120;    # ensure coming back to root console
+    type_string "\n\n";                                 # make space for better readability of the console
 }
 
 sub check_network_status {
@@ -91,101 +86,21 @@ sub check_network_status {
     if ($expected_status eq 'restart') {
         assert_script_run '[ -s journal.log ]';                       # journal.log size is greater than zero (network restarted)
     }
-
+    elsif (is_sle('<15') || is_leap('<15.0')) {
+        assert_script_run '[ ! -s journal.log ]';
+    }
     assert_script_run '> journal.log';                                # clear journal.log
     type_string "\n\n";                                               # make space for better readability of the console
 }
 
 sub verify_network_configuration {
-    my ($fn, $dev_name, $expected_status, $workaround, $no_network_check) = @_;
+    my ($fn, $dev_name, $expected_status, $workaround) = @_;
     open_network_settings;
 
     $fn->($dev_name) if $fn;                                          # verify specific action
 
     close_network_settings;
-    check_network_status($expected_status, $workaround) unless defined $no_network_check;
-}
-
-sub validate_etc_hosts_entry {
-    my (%args) = @_;
-
-    script_run("egrep \"@{[$args{ip}]}\\s@{[$args{fqdn}]}\\s@{[$args{host}]}\" /etc/hosts", 30)
-      && record_soft_failure "bsc#1115644 Expected entry:\n \"@{[$args{ip}]}    @{[$args{fqdn}]} @{[$args{host}]}\" was not found in /etc/hosts";
-    script_run "cat /etc/hosts";
-}
-
-sub set_network {
-    my (%args) = @_;
-
-    open_network_settings;
-    send_key 'alt-i';    # edit NIC
-    assert_screen 'yast2_lan_network_card_setup';
-    if ($args{static}) {
-        send_key 'alt-t';    # set to static ip
-        assert_screen 'yast2_lan_static_ip_selected';
-        send_key 'tab';
-        if ($args{ip}) {     # To spare time, no update what to is already filled from previous run
-            send_key_until_needlematch('ip_textfield_empty', 'backspace');    # delete existing IP if any
-            type_string $args{ip};
-        }
-        send_key 'tab';
-        if ($args{mask}) {                                                    # To spare time, no update what to is already filled from previous run
-            send_key_until_needlematch('mask_textfield_empty', 'backspace');    # delete existing netmask if any
-            type_string $args{mask};
-        }
-        send_key 'tab';
-        send_key_until_needlematch('hostname_textfield_empty', 'backspace');
-        type_string $args{fqdn};
-        assert_screen 'yast2_lan_static_ip_set';
-    }
-    else {
-        send_key 'alt-y';                                                       # set back to DHCP
-        assert_screen 'yast2_lan_dhcp_set';
-    }
-    # Exit
-    send_key 'alt-n';
-    assert_screen "yast2_lan";
-    close_network_settings;
-}
-
-
-=head2 check_etc_hosts_update
-
-In order to target bugs bsc#1115644 and bsc#1052042, we want to :
-- Set static IP and fqdn for first NIC in the list and check /etc/hosts formatting
-- Open yast2 lan again and change the fqdn, check if /etc/hosts is changed correctly ( bsc#1052042 )
-- Set it to DHCP
-- Set it again to static with  new FQDN and check if /etc/hosts is changed correctly ( bsc#1115644 )
-=cut
-sub check_etc_hosts_update {
-
-    my $ip   = '192.168.122.10';
-    my $mask = '255.255.255.0';
-    script_run "cat /etc/hosts";
-
-    record_info 'Test', 'Set static ip, FQDN and validate /etc/hosts entry';
-    my $hostname = "test-1";
-    my $fqdn     = $hostname . '.susetest.com';
-    set_network(static => 1, fqdn => $fqdn, ip => $ip, mask => $mask);
-    validate_etc_hosts_entry(ip => $ip, host => $hostname, fqdn => $fqdn);
-
-    record_info 'Test', 'Change FQDN and validate /etc/hosts entry';
-    $hostname = "test-2";
-    $fqdn     = $hostname . '.susetest.com';
-    set_network(static => 1, fqdn => $fqdn, ip => $ip, mask => $mask);
-    validate_etc_hosts_entry(ip => $ip, host => $hostname, fqdn => $fqdn);
-
-    # Set back to dhcp
-    set_network(fqdn => $fqdn);
-
-    record_info 'Test', 'Set to static from dchp, set FQDN and validate /etc/hosts entry';
-    $hostname = "test-3";
-    $fqdn     = $hostname . '.susetest.com';
-    set_network(static => 1, fqdn => $fqdn, ip => $ip, mask => $mask);
-    validate_etc_hosts_entry(ip => $ip, host => $hostname, fqdn => $fqdn);
-
-    # Set back to dhcp
-    set_network;
+    check_network_status($expected_status, $workaround);
 }
 
 1;

--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -16,8 +16,6 @@ use base "console_yasttest";
 use strict;
 use testapi;
 use utils;
-use y2lan_restart_common;
-use version_utils ':VERSION';
 
 sub handle_Networkmanager_controlled {
     send_key "ret";    # confirm networkmanager popup
@@ -39,15 +37,15 @@ sub handle_dhcp_popup {
 sub run {
     my $self = shift;
 
-    select_console 'root-console';
-    assert_script_run "zypper -n in yast2-network";    # make sure yast2 lan module installed
+    select_console 'user-console';
+    assert_script_sudo "zypper -n in yast2-network";    # make sure yast2 lan module installed
 
     # those two are for debugging purposes only
     script_run('ip a');
     script_run('ls -alF /etc/sysconfig/network/');
     save_screenshot;
 
-    script_run("yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev", 0);
+    script_sudo("yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev", 0);
 
     assert_screen [qw(Networkmanager_controlled yast2_lan install-susefirewall2 install-firewalld dhcp-popup)], 120;
     handle_dhcp_popup;
@@ -73,21 +71,17 @@ sub run {
     assert_screen [qw(yast2_lan-hostname-tab dhcp-popup)];
     handle_dhcp_popup;
     send_key "tab";
-    send_key_until_needlematch 'hostname_ncurses_hostname_empty', 'backspace';
+    for (1 .. 15) { send_key "backspace" }
     type_string $hostname;
-    # Starting from SLE 15 SP1, we don't have domain field
-    if (is_sle('<=15') || is_leap('<=15.0')) {
-        send_key "tab";
-        for (1 .. 15) { send_key "backspace" }
-        type_string $domain;
-    }
+    send_key "tab";
+    for (1 .. 15) { send_key "backspace" }
+    type_string $domain;
     assert_screen 'test-yast2_lan-1';
 
     send_key "alt-o";    # OK=>Save&Exit
     wait_serial("yast2-lan-status-0", 180) || die "'yast2 lan' didn't finish";
 
     wait_still_screen;
-    check_etc_hosts_update if (check_var('BACKEND', 'qemu'));
     $self->clear_and_verify_console;
     assert_script_run "hostname|grep $hostname";
 
@@ -97,8 +91,5 @@ sub run {
     assert_script_run('getent ahosts ' . get_var("OPENQA_HOSTNAME"));
 }
 
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;
+

--- a/tests/console/yast2_lan_hostname.pm
+++ b/tests/console/yast2_lan_hostname.pm
@@ -7,6 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
+
 # Summary: yast2 lan hostname via DHCP test https://bugzilla.suse.com/show_bug.cgi?id=984890
 # Maintainer: Jozef Pupava <jpupava@suse.com>
 
@@ -14,7 +15,6 @@ use base "console_yasttest";
 use strict;
 use testapi;
 use utils;
-use version_utils ':VERSION';
 use y2_common 'accept_warning_network_manager_default';
 
 sub hostname_via_dhcp {
@@ -28,58 +28,42 @@ sub hostname_via_dhcp {
     type_string "yast2 lan\n";
     accept_warning_network_manager_default;
     assert_screen 'yast2_lan';
-
     # Hostname/DNS tab
     send_key $cmd{hostname_dns_tab};
     assert_screen "yast2_lan-hostname-tab";
-
-    # We have different postition for this control
-    # go to roll-down list
-    my $ntab = (is_sle('<=15') || is_leap('<=15.0')) ? 4 : 2;
-    for (1 .. $ntab) { send_key 'tab' }
-
+    for (1 .. 4) { send_key 'tab' }    # go to roll-down list
     wait_screen_change { send_key 'down'; };    # open roll-down list
     send_key $cmd{home};
-    assert_screen("yast2_lan-hostname-DHCP-no")
-      ;                                         # check that topmost option is selected
+    assert_screen("yast2_lan-hostname-DHCP-no");    # check that topmost option is selected
     send_key_until_needlematch "yast2_lan-hostname-DHCP-$dhcp", 'down';
     wait_screen_change { send_key $cmd{spc}; };
-    assert_screen "yast2_lan-hostname-DHCP-$dhcp-selected"
-      ;                                         # make sure that the option is actually selected
+    assert_screen "yast2_lan-hostname-DHCP-$dhcp-selected";    # make sure that the option is actually selected
     send_key $cmd{ok};
-    assert_screen 'console-visible';            # yast module exited
+    assert_screen 'console-visible';                           # yast module exited
     wait_still_screen;
-
     if ($dhcp eq 'no') {
-        assert_script_run
-          'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp|grep no';
+        assert_script_run 'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp|grep no';
     }
     elsif ($dhcp eq 'yes-eth0') {
-        assert_script_run
-          'iface=`ip -o addr show scope global | head -n1 | cut -d" " -f2`';
-        assert_script_run
-          'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/ifcfg-$iface|grep yes';
-        assert_script_run
-          'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp|grep no';
+        assert_script_run 'iface=`ip -o addr show scope global | head -n1 | cut -d" " -f2`';
+        assert_script_run 'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/ifcfg-$iface|grep yes';
+        assert_script_run 'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp|grep no';
     }
     elsif ($dhcp eq 'yes-any') {
-        assert_script_run
-          'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp|grep yes';
+        assert_script_run 'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp|grep yes';
     }
 }
 
 sub run {
     select_console 'root-console';
-    assert_script_run
-      'zypper -n in yast2-network';    # make sure yast2 lan module installed
+    assert_script_run 'zypper -n in yast2-network';    # make sure yast2 lan module installed
     hostname_via_dhcp('no');
     hostname_via_dhcp('yes-any');
     hostname_via_dhcp('yes-eth0');
 }
 
 sub post_fail_hook {
-    assert_script_run
-      'iface=`ip -o addr show scope global | head -n1 | cut -d" " -f2`';
+    assert_script_run 'iface=`ip -o addr show scope global | head -n1 | cut -d" " -f2`';
     upload_logs '/etc/sysconfig/network/ifcfg-$iface';
     upload_logs '/etc/sysconfig/network/dhcp';
 }

--- a/tests/console/yast_scc.pm
+++ b/tests/console/yast_scc.pm
@@ -17,7 +17,7 @@
 # Maintainer: Max Lin <mlin@suse.com>
 
 use strict;
-use base "console_yasttest";
+use base "consoletest";
 
 use testapi;
 use registration;

--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -15,7 +15,7 @@ use base 'y2logsstep';
 
 use strict;
 use testapi;
-use y2lan_restart_common;
+use y2lan_restart_common qw(initialize_y2lan verify_network_configuration);
 use y2_common 'is_network_manager_default';
 
 sub check_network_settings_tabs {
@@ -75,7 +75,6 @@ sub run {
     verify_network_configuration;               # check simple access to Overview tab
     verify_network_configuration(\&check_network_settings_tabs);
     unless (is_network_manager_default) {
-        check_etc_hosts_update() if (check_var('BACKEND', 'qemu'));
         verify_network_configuration(\&check_network_card_setup_tabs);
         verify_network_configuration(\&check_default_gateway);
         verify_network_configuration(\&change_hw_device_name, 'dyn0', 'restart');
@@ -89,10 +88,6 @@ sub post_fail_hook {
     assert_script_run 'journalctl -b > /tmp/journal', 90;
     upload_logs '/tmp/journal';
     $self->SUPER::post_fail_hook;
-}
-
-sub test_flags {
-    return {always_rollback => 1};
 }
 
 1;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#6648 to fix test regressions as reported in the PR.