### PR TITLE
Fix missing desktop runner hotkey on xfce

### DIFF
--- a/tests/x11/xfce4_appfinder.pm
+++ b/tests/x11/xfce4_appfinder.pm
@@ -18,7 +18,7 @@ use utils 'desktop_runner_hotkey';
 
 
 sub run {
-    wait_screen_change { desktop_runner_hotkey };
+    wait_screen_change { send_key desktop_runner_hotkey };
     send_key "down";
     type_string "about\n";
     assert_screen 'test-xfce4_appfinder-1';


### PR DESCRIPTION
Verified locally with isotovideo:

```
||| starting xfce4_appfinder tests/x11/xfce4_appfinder.pm
/var/lib/openqa/share/tests/opensuse/tests/x11/xfce4_appfinder.pm:21 called testapi::wait_screen_change
<<< testapi::wait_screen_change(timeout=10, similarity_level=50)
/var/lib/openqa/share/tests/opensuse/tests/x11/xfce4_appfinder.pm:21 called testapi::send_key
<<< testapi::send_key(key='alt-f2', do_wait=0)
waiting for screen change: 0 1000000
waiting for screen change: 1 16.1328100714206
>>> testapi::wait_screen_change: screen change seen at 1
```

Related progress issue: https://progress.opensuse.org/issues/47042