### PR TITLE
Fix timezone test

### DIFF
--- a/tests/console/timezone.pm
+++ b/tests/console/timezone.pm
@@ -40,8 +40,8 @@ sub run {
 
     assert_script_run("rpm -q timezone");
 
-    validate_script_output("zdump Europe/London", sub { m/Europe\/London\s+\w{3} \w{3} \d{2} (\d{2}|:){5} \d{4} GMT/ });
-    validate_script_output("date",                sub { m/\w{3} \w{3} \d{2} (\d{2}|:){5} \w{3} \d{4}/ });
+    validate_script_output("zdump Europe/London", sub { m/Europe\/London\s+\w{3} \w{3}\s+\d+ (\d{2}|:){5} \d{4} GMT/ });
+    validate_script_output("date",                sub { m/\w{3} \w{3}\s+\d+ (\d{2}|:){5} \w+ \d{4}/ });
 
     my $filename  = "testdata.zone";
     my $zdump_cmd = "zdump -v Europe/Rome | grep -E 'Sun Mar 25 [0-9]{2}:[0:9]{2}:[0-9]{2} 2018'";


### PR DESCRIPTION
the current regex is expecting 2 digits for the day of the month, but when the day is < 10 there's only 1 digit.

Related ticket: https://progress.opensuse.org/issues/47069
Test results:
- SLE 12.1: http://d502.qam.suse.de/tests/368
- SLE 12.2: http://d502.qam.suse.de/tests/369
- SLE 12.3: http://d502.qam.suse.de/tests/370
- SLE 12.4: http://d502.qam.suse.de/tests/371
- SLE 15.0: http://d502.qam.suse.de/tests/372
- SLE 15.1: http://d502.qam.suse.de/tests/373

