### PR TITLE
Add post_fail_hook in shutdown and provide debug logs before shutdown

### DIFF
--- a/tests/shutdown/cleanup_before_shutdown.pm
+++ b/tests/shutdown/cleanup_before_shutdown.pm
@@ -25,7 +25,14 @@ sub run {
     # Please see https://freedesktop.org/wiki/Software/systemd/Debugging/#index2h1 for the details.
     # Boot options that are required to make logs more detalized are located in 'bootloader_setup.pm'
     if (get_var('DEBUG_SHUTDOWN')) {
-        assert_script_run "echo -e '#!/bin/sh\\ndmesg > /dev/$serialdev' > /usr/lib/systemd/system-shutdown/debug.sh";
+        my $script = << "END_SCRIPT";
+             echo -e '#!/bin/sh
+             echo --- dmesg log ---  > /dev/$serialdev
+             dmesg  >> /dev/$serialdev
+             echo --- journactl log ---  >> /dev/$serialdev 
+             journalctl >> /dev/$serialdev'  > /usr/lib/systemd/system-shutdown/debug.sh \\
+END_SCRIPT
+        assert_script_run $script;
         assert_script_run "chmod +x /usr/lib/systemd/system-shutdown/debug.sh";
     }
     if (get_var('DROP_PERSISTENT_NET_RULES')) {

--- a/tests/shutdown/shutdown.pm
+++ b/tests/shutdown/shutdown.pm
@@ -20,6 +20,7 @@ use strict;
 use base "opensusebasetest";
 use testapi;
 use power_action_utils 'power_action';
+use utils;
 
 sub run {
     power_action('poweroff');
@@ -27,6 +28,15 @@ sub run {
 
 sub test_flags {
     return {fatal => 1};
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    $self->SUPER::post_fail_hook;
+    select_console('log-console');
+    # check systemd jobs still running in background, these jobs
+    # might slow down or block shutdown progress
+    systemctl 'list-jobs';
 }
 
 1;


### PR DESCRIPTION
we have problem with shutdown and we don't know what happened before
shutdown. For this we can add journal full log and dmesg log into
serial0.txt with seperation lines for better checking.

Add checking systemd jobs after power_action triggered so that we can at
least see whether these jobs still running or not.

see https://progress.opensuse.org/issues/42038
need to set DEBUG_SHUTDOWN and pass it to boot option for the test
full journal log and dmesg log collected before shutdown in
cleanup_before_shutdown

verification test run:
http://f40.suse.de/tests/1235
http://f40.suse.de/tests/1235/file/serial0.txt
verification test run for checking systemd jobs:
http://f40.suse.de/tests/1218#step/shutdown/9