### PR TITLE
Apply send_key_until_needle for uncollpapsed VGs and LVs

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -268,11 +268,11 @@ sub addlv {
     send_key $cmd{system_view};
     send_key 'home';
     send_key_until_needlematch('volume_management_feature', 'down');
-    wait_still_screen(stilltime => 3, timeout => 4);
+    wait_still_screen(stilltime => 2, timeout => 4);
     # Expand collapsed list with VGs
-    send_key 'right' if is_sle('<15');
+    send_key_until_needlematch('lvm_uncollapse_vgs', 'right') if is_sle('<15');
     send_key_until_needlematch 'partition-select-vg-' . "$args{vg}", 'down';
-    wait_still_screen(stilltime => 3, timeout => 4);
+    wait_still_screen(stilltime => 2, timeout => 4);
     # Expand collapsed list with LVs
     send_key 'right' if is_sle('<15');
     send_key 'alt-i' if (is_storage_ng_newui);


### PR DESCRIPTION
- Related ticket: [[sle][functional][y][aarch64][sporadic] test fails in partitioning_full_lvm - Volume Management list stays collapsed](https://progress.opensuse.org/issues/43568)
- Needles: [Uncollapse VGs for sle12 partitioner](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1061)
- Verification run: [sle-12-SP5-Server-DVD-aarch64-Build0120-lvm-encrypt-separate-boot@aarch64](http://eris.suse.cz/tests/11406#step/partitioning_full_lvm/1)
