### PR TITLE
Do not wait for boot in baremetal LTP installation

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -245,7 +245,7 @@ sub update_kgraft {
 
 sub boot_to_console {
     my ($self) = @_;
-    $self->wait_boot;
+    $self->wait_boot unless check_var('BACKEND', 'ipmi') && get_var('LTP_BAREMETAL');
     if (check_var('BACKEND', 'ipmi')) {
         use_ssh_serial_console;
     }


### PR DESCRIPTION
The baremetal machine is already booted during LTP installation phase.

- Related ticket: https://progress.opensuse.org/issues/45722
- Verification run: http://panigale.suse.cz/tests/1347#step/update_kernel/1
