### PR TITLE
Add a function to check if /etc/hosts is properly updated by yast2 lan

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -17,9 +17,9 @@ sub post_fail_hook {
 
     show_tasks_in_blocked_state if ($defer_blocked_task_info);
 
-    upload_logs('/var/log/zypper.log');
     $self->remount_tmp_if_ro;
     $self->save_upload_y2logs;
+    upload_logs('/var/log/zypper.log');
     $self->save_system_logs;
     $self->save_strace_gdb_output('yast');
 }

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1352,6 +1352,7 @@ sub load_extra_tests_y2uitest_ncurses {
         loadtest "console/yast2_http";
         loadtest "console/yast2_ftp";
         loadtest "console/yast2_apparmor";
+        loadtest "console/yast2_lan";
     }
     # TODO https://progress.opensuse.org/issues/20200
     # softfail record #bsc1049433 for samba and xinetd
@@ -1374,6 +1375,7 @@ sub load_extra_tests_y2uitest_gui {
         && !get_var("DUALBOOT")
         && !get_var("RESCUECD"));
     loadtest 'yast2_gui/yast2_control_center';
+    loadtest "x11/yast2_lan_restart";
     loadtest "yast2_gui/yast2_bootloader";
     loadtest "yast2_gui/yast2_datetime";
     loadtest "yast2_gui/yast2_firewall";

--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -47,7 +47,7 @@ sub initialize_y2lan {
 sub open_network_settings {
     type_string "yast2 lan\n";
     accept_warning_network_manager_default;
-    assert_screen 'yast2_lan', 100;       # yast2 lan overview tab
+    assert_screen 'yast2_lan', 180;       # yast2 lan overview tab
     send_key 'home';                      # select first device
     wait_still_screen(2);
 }
@@ -56,7 +56,7 @@ sub close_network_settings {
     wait_still_screen;
     send_key 'alt-o';
     # new: warning pops up for firewall, alt-y for assign it to zone
-    assert_screen([qw(yast2-lan-restart_firewall_active_warning yast2_closed_xterm_visible yast2_lan_packages_need_to_be_installed)], 120);
+    assert_screen([qw(yast2-lan-restart_firewall_active_warning yast2_closed_xterm_visible yast2_lan_packages_need_to_be_installed)], 180);
     if (match_has_tag 'yast2-lan-restart_firewall_active_warning') {
         send_key 'alt-y';
         wait_still_screen 1;
@@ -67,7 +67,7 @@ sub close_network_settings {
     elsif (match_has_tag 'yast2_lan_packages_need_to_be_installed') {
         send_key 'alt-i';
     }
-    assert_screen 'yast2_closed_xterm_visible', 120;    # ensure coming back to root console
+    assert_screen 'yast2_closed_xterm_visible', 180;    # ensure coming back to root console
     type_string "\n\n";                                 # make space for better readability of the console
 }
 
@@ -94,13 +94,13 @@ sub check_network_status {
 }
 
 sub verify_network_configuration {
-    my ($fn, $dev_name, $expected_status, $workaround) = @_;
+    my ($fn, $dev_name, $expected_status, $workaround, $no_network_check) = @_;
     open_network_settings;
 
     $fn->($dev_name) if $fn;                                          # verify specific action
 
     close_network_settings;
-    check_network_status($expected_status, $workaround);
+    check_network_status($expected_status, $workaround) unless defined $no_network_check;
 }
 
 1;

--- a/tests/console/yast2_ftp.pm
+++ b/tests/console/yast2_ftp.pm
@@ -204,8 +204,4 @@ sub post_fail_hook {
     $self->save_upload_y2logs;
 }
 
-sub test_flags {
-    return {milestone => 1};
-}
-
 1;

--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -16,6 +16,9 @@ use base "console_yasttest";
 use strict;
 use testapi;
 use utils;
+use y2lan_restart_common;
+use version_utils ':VERSION';
+use utils 'zypper_call';
 
 sub handle_Networkmanager_controlled {
     send_key "ret";    # confirm networkmanager popup
@@ -34,18 +37,89 @@ sub handle_dhcp_popup {
     }
 }
 
+
+sub set_network {
+    my (%args) = @_;
+    my ($loop, $param) = @_;
+    script_run("yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev", 0);
+    assert_screen "yast2_lan";
+    send_key 'alt-i';    # edit NIC
+    assert_screen 'yast_ncurses_network_card_setup';
+    if ($args{static}) {
+        send_key 'alt-t';    # set to static ip
+        assert_screen 'yast_ncurses_set_static_ip';
+        send_key 'tab';
+        if ($args{ip}) {     # To spare time, no update what to is already filled from previous run
+            send_key_until_needlematch('NICsetup_ncurses_IP_empty', 'backspace');    # delete existing IP if any
+            type_string $args{ip};
+        }
+        send_key 'tab';
+        if ($args{mask}) {                                                           # To spare time, no update what to is already filled from previous run
+            send_key_until_needlematch('NICsetup_ncurses_mask_empty', 'backspace');    # delete existing netmask if any
+            type_string $args{mask};
+        }
+        send_key 'tab';
+        send_key_until_needlematch('NICsetup_ncurses_host_empty', 'backspace');
+        type_string $args{fqdn};
+        assert_screen 'yast_ncurses_static_ip_set';
+    }
+    else {
+        send_key 'alt-y';                                                              # set back to DHCP
+        assert_screen 'yast_ncurses_set_dhcp';
+    }
+    # Exit
+    send_key 'alt-n';
+    assert_screen "yast2_lan";
+    send_key 'alt-o';
+    wait_serial("yast2-lan-status-0", 180) || die "'yast2 lan' didn't finish";
+}
+
+
+sub check_etc_hosts_update {
+
+=head2
+
+In order to targer bugs bsc#1115644 and bsc#1052042, we want to :
+- Set static IP and fqdn for first NIC in the list and check /etc/hosts formatting
+- Open yast2 lan again and change the fqdn, check if /etc/hosts is changed correctly ( bsc#1052042 )
+- Set it to DHCP
+- Set it again to static with  new FQDN and check if /etc/hosts is changed correctly ( bsc#1115644 )
+
+=cut
+
+    my $looprun = 1;
+    my $hostname;
+    my $fqdn;
+    my $ip = '192.168.122.10';
+    script_run "cat /etc/hosts";
+    until ($looprun == 4) {
+        $hostname = "tst-$looprun";
+        $fqdn     = $hostname . '.com';
+        set_network(static => 1, fqdn => $fqdn, ip => $ip, mask => '/24');
+        script_run("egrep \"$ip\\s$fqdn\\s$hostname\" /etc/hosts", 30)
+          && record_soft_failure "bsc#1115644 Expected entry : \"192.168.1.10    $fqdn $hostname\" was not found in /etc/hosts";
+        if ($looprun == 2) {
+            set_network(fqdn => $fqdn);    # Without parameter, set as dhcp, step is necessary to make sure
+        }
+        script_run "cat /etc/hosts";
+        $looprun++;
+    }
+    set_network;
+}
+
+
 sub run {
     my $self = shift;
 
-    select_console 'user-console';
-    assert_script_sudo "zypper -n in yast2-network";    # make sure yast2 lan module installed
+    select_console 'root-console';
+    zypper_call "in yast2-network";    # make sure yast2 lan module installed
 
     # those two are for debugging purposes only
     script_run('ip a');
     script_run('ls -alF /etc/sysconfig/network/');
     save_screenshot;
 
-    script_sudo("yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev", 0);
+    script_run("yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev", 0);
 
     assert_screen [qw(Networkmanager_controlled yast2_lan install-susefirewall2 install-firewalld dhcp-popup)], 120;
     handle_dhcp_popup;
@@ -80,8 +154,11 @@ sub run {
 
     send_key "alt-o";    # OK=>Save&Exit
     wait_serial("yast2-lan-status-0", 180) || die "'yast2 lan' didn't finish";
-
     wait_still_screen;
+
+    # Run detailed check only if explicitly configured in the test suite
+    check_etc_hosts_update() if get_var('VALIDATE_ETC_HOSTS');
+
     $self->clear_and_verify_console;
     assert_script_run "hostname|grep $hostname";
 
@@ -91,5 +168,9 @@ sub run {
     assert_script_run('getent ahosts ' . get_var("OPENQA_HOSTNAME"));
 }
 
-1;
 
+sub test_flags {
+    return {always_rollback => 1};    # Should only affect backends that have snapshot feature
+}
+
+1;

--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -37,77 +37,6 @@ sub handle_dhcp_popup {
     }
 }
 
-
-sub set_network {
-    my (%args) = @_;
-    my ($loop, $param) = @_;
-    script_run("yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev", 0);
-    assert_screen "yast2_lan";
-    send_key 'alt-i';    # edit NIC
-    assert_screen 'yast_ncurses_network_card_setup';
-    if ($args{static}) {
-        send_key 'alt-t';    # set to static ip
-        assert_screen 'yast_ncurses_set_static_ip';
-        send_key 'tab';
-        if ($args{ip}) {     # To spare time, no update what to is already filled from previous run
-            send_key_until_needlematch('NICsetup_ncurses_IP_empty', 'backspace');    # delete existing IP if any
-            type_string $args{ip};
-        }
-        send_key 'tab';
-        if ($args{mask}) {                                                           # To spare time, no update what to is already filled from previous run
-            send_key_until_needlematch('NICsetup_ncurses_mask_empty', 'backspace');    # delete existing netmask if any
-            type_string $args{mask};
-        }
-        send_key 'tab';
-        send_key_until_needlematch('NICsetup_ncurses_host_empty', 'backspace');
-        type_string $args{fqdn};
-        assert_screen 'yast_ncurses_static_ip_set';
-    }
-    else {
-        send_key 'alt-y';                                                              # set back to DHCP
-        assert_screen 'yast_ncurses_set_dhcp';
-    }
-    # Exit
-    send_key 'alt-n';
-    assert_screen "yast2_lan";
-    send_key 'alt-o';
-    wait_serial("yast2-lan-status-0", 180) || die "'yast2 lan' didn't finish";
-}
-
-
-sub check_etc_hosts_update {
-
-=head2
-
-In order to targer bugs bsc#1115644 and bsc#1052042, we want to :
-- Set static IP and fqdn for first NIC in the list and check /etc/hosts formatting
-- Open yast2 lan again and change the fqdn, check if /etc/hosts is changed correctly ( bsc#1052042 )
-- Set it to DHCP
-- Set it again to static with  new FQDN and check if /etc/hosts is changed correctly ( bsc#1115644 )
-
-=cut
-
-    my $looprun = 1;
-    my $hostname;
-    my $fqdn;
-    my $ip = '192.168.122.10';
-    script_run "cat /etc/hosts";
-    until ($looprun == 4) {
-        $hostname = "tst-$looprun";
-        $fqdn     = $hostname . '.com';
-        set_network(static => 1, fqdn => $fqdn, ip => $ip, mask => '/24');
-        script_run("egrep \"$ip\\s$fqdn\\s$hostname\" /etc/hosts", 30)
-          && record_soft_failure "bsc#1115644 Expected entry : \"192.168.1.10    $fqdn $hostname\" was not found in /etc/hosts";
-        if ($looprun == 2) {
-            set_network(fqdn => $fqdn);    # Without parameter, set as dhcp, step is necessary to make sure
-        }
-        script_run "cat /etc/hosts";
-        $looprun++;
-    }
-    set_network;
-}
-
-
 sub run {
     my $self = shift;
 
@@ -173,7 +102,7 @@ sub run {
 
 
 sub test_flags {
-    return {always_rollback => 1};    # Should only affect backends that have snapshot feature
+    return {always_rollback => 1};
 }
 
 1;

--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -147,9 +147,12 @@ sub run {
     send_key "tab";
     for (1 .. 15) { send_key "backspace" }
     type_string $hostname;
-    send_key "tab";
-    for (1 .. 15) { send_key "backspace" }
-    type_string $domain;
+    # Starting from SLE 15 SP1, we don't have domain field
+    if (is_sle('<=15') || is_leap('<=15.0')) {
+        send_key "tab";
+        for (1 .. 15) { send_key "backspace" }
+        type_string $domain;
+    }
     assert_screen 'test-yast2_lan-1';
 
     send_key "alt-o";    # OK=>Save&Exit

--- a/tests/console/yast2_lan_hostname.pm
+++ b/tests/console/yast2_lan_hostname.pm
@@ -7,7 +7,6 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-
 # Summary: yast2 lan hostname via DHCP test https://bugzilla.suse.com/show_bug.cgi?id=984890
 # Maintainer: Jozef Pupava <jpupava@suse.com>
 
@@ -29,16 +28,16 @@ sub hostname_via_dhcp {
     type_string "yast2 lan\n";
     accept_warning_network_manager_default;
     assert_screen 'yast2_lan';
+
     # Hostname/DNS tab
     send_key $cmd{hostname_dns_tab};
     assert_screen "yast2_lan-hostname-tab";
+
     # We have different postition for this control
     # go to roll-down list
-    if (is_sle('<=15') || is_leap('<=15.0')) {
-        for (1 .. 4) { send_key 'tab' }
-    } else {
-        for (1 .. 2) { send_key 'tab' }
-    }
+    my $ntab = (is_sle('<=15') || is_leap('<=15.0')) ? 4 : 2;
+    for (1 .. $ntab) { send_key 'tab' }
+
     wait_screen_change { send_key 'down'; };    # open roll-down list
     send_key $cmd{home};
     assert_screen("yast2_lan-hostname-DHCP-no");    # check that topmost option is selected
@@ -48,6 +47,7 @@ sub hostname_via_dhcp {
     send_key $cmd{ok};
     assert_screen 'console-visible';                           # yast module exited
     wait_still_screen;
+
     if ($dhcp eq 'no') {
         assert_script_run 'grep DHCLIENT_SET_HOSTNAME /etc/sysconfig/network/dhcp|grep no';
     }
@@ -70,7 +70,9 @@ sub run {
 }
 
 sub post_fail_hook {
-    assert_script_run 'iface=`ip -o addr show scope global | head -n1 | cut -d" " -f2`';
+    my ($self) = @_;
+    $self->SUPER::post_fail_hook;
+    script_run 'iface=`ip -o addr show scope global | head -n1 | cut -d" " -f2`';
     upload_logs '/etc/sysconfig/network/ifcfg-$iface';
     upload_logs '/etc/sysconfig/network/dhcp';
 }

--- a/tests/console/yast2_lan_hostname.pm
+++ b/tests/console/yast2_lan_hostname.pm
@@ -15,6 +15,7 @@ use base "console_yasttest";
 use strict;
 use testapi;
 use utils;
+use version_utils ':VERSION';
 use y2_common 'accept_warning_network_manager_default';
 
 sub hostname_via_dhcp {
@@ -31,7 +32,13 @@ sub hostname_via_dhcp {
     # Hostname/DNS tab
     send_key $cmd{hostname_dns_tab};
     assert_screen "yast2_lan-hostname-tab";
-    for (1 .. 4) { send_key 'tab' }    # go to roll-down list
+    # We have different postition for this control
+    # go to roll-down list
+    if (is_sle('<=15') || is_leap('<=15.0')) {
+        for (1 .. 4) { send_key 'tab' }
+    } else {
+        for (1 .. 2) { send_key 'tab' }
+    }
     wait_screen_change { send_key 'down'; };    # open roll-down list
     send_key $cmd{home};
     assert_screen("yast2_lan-hostname-DHCP-no");    # check that topmost option is selected

--- a/tests/console/yast_scc.pm
+++ b/tests/console/yast_scc.pm
@@ -17,7 +17,7 @@
 # Maintainer: Max Lin <mlin@suse.com>
 
 use strict;
-use base "consoletest";
+use base "console_yasttest";
 
 use testapi;
 use registration;

--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -15,7 +15,7 @@ use base 'y2logsstep';
 
 use strict;
 use testapi;
-use y2lan_restart_common qw(initialize_y2lan verify_network_configuration);
+use y2lan_restart_common;
 use y2_common 'is_network_manager_default';
 
 sub check_network_settings_tabs {
@@ -75,6 +75,8 @@ sub run {
     verify_network_configuration;               # check simple access to Overview tab
     verify_network_configuration(\&check_network_settings_tabs);
     unless (is_network_manager_default) {
+        # Run detailed check only if explicitly configured in the test suite
+        check_etc_hosts_update() if get_var('VALIDATE_ETC_HOSTS');
         verify_network_configuration(\&check_network_card_setup_tabs);
         verify_network_configuration(\&check_default_gateway);
         verify_network_configuration(\&change_hw_device_name, 'dyn0', 'restart');
@@ -82,12 +84,21 @@ sub run {
     type_string "killall xterm\n";
 }
 
+
 sub post_fail_hook {
     my ($self) = @_;
 
     assert_script_run 'journalctl -b > /tmp/journal', 90;
     upload_logs '/tmp/journal';
     $self->SUPER::post_fail_hook;
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+sub test_flags {
+    return {always_rollback => 1};    # Should only affect backends that have snapshot feature
 }
 
 1;

--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -84,10 +84,8 @@ sub run {
     type_string "killall xterm\n";
 }
 
-
 sub post_fail_hook {
     my ($self) = @_;
-
     assert_script_run 'journalctl -b > /tmp/journal', 90;
     upload_logs '/tmp/journal';
     $self->SUPER::post_fail_hook;
@@ -95,10 +93,6 @@ sub post_fail_hook {
 
 sub test_flags {
     return {always_rollback => 1};
-}
-
-sub test_flags {
-    return {always_rollback => 1};    # Should only affect backends that have snapshot feature
 }
 
 1;

--- a/variables.md
+++ b/variables.md
@@ -97,6 +97,7 @@ UEFI | boolean | false | Indicates UEFI in the testing environment.
 UPGRADE | boolean | false | Indicates upgrade scenario.
 USBBOOT | boolean | false | Indicates booting to the usb device.
 USEIMAGES |||
+VALIDATE_ETC_HOSTS | boolean | false | Validate changes in /etc/hosts when using YaST network module. Is used in yast2_lan and yast2_lan_restart test modules which test module in ncurses and x11 respectively.
 VALIDATE_INST_SRC | boolean | false | Validate installation source in /etc/install.inf
 VERSION | string | | Contains major version of the product. E.g. 15-SP1 or 15.1
 VIDEOMODE | string | | Indicates/defines video mode used for the installation. Empty value uses default, other possible values `text`, `ssh-x` for installation ncurses and x11 over ssh respectivelyю


### PR DESCRIPTION
Reopened #6648, where I did a mistake assuming that changes won't affect TW, but we have wicked there in text installations. So now, limit execution scope by additional variable, which we will enable in yast2_gui and yast2_ncurses test suites.

See [poo#44450](https://progress.opensuse.org/issues/44450).

#### Verification runs
[sle 15 sp1 x11](http://f174.suse.de/tests/26)
[sle 15 sp1 ncurses](http://f174.suse.de/tests/34)
[openSUSE x11](http://f174.suse.de/tests/29)
[openSUSE ncurses](http://f174.suse.de/tests/35)