### PR TITLE
Include UEFI in workaround_type_encrypted_passphrase

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -464,7 +464,7 @@ sub workaround_type_encrypted_passphrase {
     return if get_var('UNENCRYPTED_BOOT');
     return if !get_var('ENCRYPT') && !get_var('FULL_LVM_ENCRYPT');
     # ppc64le on pre-storage-ng boot was part of encrypted LVM
-    return if !get_var('FULL_LVM_ENCRYPT') && !is_storage_ng && !get_var('OFW');
+    return if !get_var('FULL_LVM_ENCRYPT') && !is_storage_ng && !get_var('OFW') && !get_var('UEFI');
     # If the encrypted disk is "just activated" it does not mean that the
     # installer would propose an encrypted installation again
     return if get_var('ENCRYPT_ACTIVATE_EXISTING') && !get_var('ENCRYPT_FORCE_RECOMPUTE');


### PR DESCRIPTION
- Related ticket: [[functional][y][aarch64] test fails in grub_test - test should expect password prompt before entering grub or should "cancel_existing" actually encrypt again?](https://progress.opensuse.org/issues/43154)
- Verification run: [sle-12-SP5-Server-DVD-aarch64-Build0116-cryptlvm+cancel_existing@aarch64](http://eris.suse.cz/tests/11407#step/grub_test/27)
