### PR TITLE
network_utils: replace wotan with internal openQA DNS server

### DIFF
--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -29,7 +29,7 @@ sub setup_static_network {
     $args{ip} ||= '10.0.2.15';
     $args{gw} ||= testapi::host_ip();
     assert_script_run('echo default ' . $args{gw} . ' - - > /etc/sysconfig/network/routes');
-    assert_script_run('echo "NETCONFIG_DNS_STATIC_SERVERS=10.160.0.1" >> /etc/sysconfig/network/config');
+    assert_script_run('echo "NETCONFIG_DNS_STATIC_SERVERS=10.0.2.3" >> /etc/sysconfig/network/config');
     my $iface = iface();
     assert_script_run qq(echo -e "\\nSTARTMODE='auto'\\nBOOTPROTO='static'\\nIPADDR='$args{ip}'">/etc/sysconfig/network/ifcfg-$iface);
     assert_script_run 'rcnetwork restart';


### PR DESCRIPTION
network_utils: replace wotan with internal openQA DNS server

verification run : 
SLE 15 SP1 - http://kimball.arch.suse.de/tests/480  http://kimball.arch.suse.de/tests/479
TW: - http://kimball.arch.suse.de/tests/475 http://kimball.arch.suse.de/tests/476 