### PR TITLE
VMware: Add serial terminal for GRUB

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -774,6 +774,7 @@ sub boot_hdd_image {
 sub load_common_installation_steps_tests {
     loadtest 'installation/await_install';
     unless (get_var('REMOTE_CONTROLLER') || is_caasp || is_hyperv_in_gui) {
+        loadtest "installation/add_serial_console" if is_vmware;
         loadtest 'installation/logs_from_installation_system';
     }
     loadtest 'installation/reboot_after_installation';

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -729,9 +729,6 @@ sub console_selected {
     $args{await_console} //= 1;
     $args{tags}          //= $console;
     $args{ignore}        //= qr{sut|root-virtio-terminal|iucvconn|svirt|root-ssh|hyperv-intermediary};
-    # If we connect to 'sut' VNC display "too early" the VNC server won't be
-    # ready and we will be left with a blank screen.
-    sleep 5 if check_var('VIRSH_VMM_FAMILY', 'vmware') && $console eq 'sut';
 
     if ($args{tags} =~ $args{ignore} || !$args{await_console}) {
         set_var('CONSOLE_JUST_ACTIVATED', 0);

--- a/tests/installation/add_serial_console.pm
+++ b/tests/installation/add_serial_console.pm
@@ -1,0 +1,55 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Set serial terminal in GRUB for VMware
+# Maintainer: Michal Nowak <mnowak@suse.com>
+
+use strict;
+use base 'y2logsstep';
+use testapi;
+
+sub run {
+    select_console 'install-shell';
+
+    my $device = 'sda';
+    # Find installed OS root device, mount it, and chroot into it
+    assert_script_run("for part in /dev/${device}[1-4]; do
+            mount \$part /mnt &> /dev/null &&
+            test -e /mnt/etc/default/grub &&
+                break ||
+                umount /mnt &> /dev/null
+        done");
+    assert_script_run('mount -o bind /dev /mnt/dev');
+    assert_script_run('mount -o bind /proc /mnt/proc');
+    type_string("chroot /mnt\n");
+    wait_still_screen;
+
+    # Configure GRUB with serial terminal (in addition to gfxterm)
+    assert_script_run('sed -ie \'s/GRUB_TERMINAL.*//\' /etc/default/grub');
+    assert_script_run('echo GRUB_TERMINAL_OUTPUT=\"serial gfxterm\" >> /etc/default/grub');
+    assert_script_run('echo GRUB_SERIAL_COMMAND=\"serial\" >> /etc/default/grub');
+    assert_script_run('grub2-mkconfig -o /boot/grub2/grub.cfg');
+
+    # Exit chroot
+    type_string "exit\n";
+    wait_still_screen;
+
+    # Clean-up
+    assert_script_run('umount /mnt/dev');
+    assert_script_run('umount /mnt/proc');
+    assert_script_run('umount /mnt');
+
+    select_console 'installation' unless get_var('REMOTE_CONTROLLER');
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
https://progress.opensuse.org/issues/47150
https://trello.com/c/ABvmLsIh/346-p1-vmware-cant-connect-via-vnc-properly-to-guest-after-restart

On VMware, VNC connection is dropped on guest restart. We are able to
connect afterwards, but if we connect when the guest is not ready yet,
we get black screen, which won't refresh.

The solution is to add GRUB on serial console and checking for GRUB's
presence there. Once we detect GRUB on serial console, we know VNC is
ready as well and we can connect to `sut` console.

So that VNC output is not stalled, we need to "look aside" around the
time of restart (`svirt` console seems to be a good place to look at as
it's always present on svirt backend).

Validation runs:
* `default_install`: http://nilgiri.suse.cz/tests/229
* `textmode`: http://nilgiri.suse.cz/tests/230