### PR TITLE
Fix check_upgraded_service breaking following test

### DIFF
--- a/tests/fixup/network_configuration.pm
+++ b/tests/fixup/network_configuration.pm
@@ -25,6 +25,7 @@ use testapi;
 
 sub run {
 
+    select_console 'x11';
     # openSUSE 13.2's (and earlier) systemd has broken rules for virtio-net, not applying predictable names (despite being configured)
     # A maintenance update breaking networking names sounds worse than just accepting that 13.2 -> TW breaks with virtio-net
     # At this point, the system has been updated, but our network interface changed name (thus we lost network connection)


### PR DESCRIPTION
Now switching back to x11 as expected by the following tests

Followup to  https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6597

Verfication run: http://pinky.arch.suse.de/tests/62#