### PR TITLE
Limit lshw runs to SLE 15 or newer, or openSUSE

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1550,7 +1550,7 @@ sub load_extra_tests_console {
     loadtest "console/dracut";
     loadtest 'console/timezone';
     loadtest 'console/procps';
-    loadtest "console/lshw";
+    loadtest "console/lshw" if (is_sle('15+') || is_opensuse);
 }
 
 sub load_extra_tests_docker {


### PR DESCRIPTION
Limit lshw runs to SLE 15 or newer, or openSUSE

- Related ticket: https://progress.opensuse.org/issues/47165
- Verification run: http://d403.qam.suse.de/tests/22
