### PR TITLE
Wait for reboot after kernel update

### DIFF
--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -296,6 +296,7 @@ sub run {
     }
 
     power_action('reboot', textmode => 1);
+    $self->wait_boot if get_var('LTP_BAREMETAL');
 }
 
 sub test_flags {


### PR DESCRIPTION
There is another reboot after kernel update, over ipmi we need to handle it.

- Verification run: http://panigale.suse.cz/tests/1364#step/update_kernel/27