### PR TITLE
Retry bootstrap in case of failure

### DIFF
--- a/tests/caasp/stack_bootstrap.pm
+++ b/tests/caasp/stack_bootstrap.pm
@@ -73,8 +73,12 @@ sub bootstrap {
     type_string $admin_fqdn;
     assert_and_click "velum-bootstrap";
 
-    # Wait until bootstrap finishes
-    assert_screen 'velum-bootstrap-done', 900;
+    # Bootstrap & retry in case of failure
+    assert_screen ['velum-status-error', 'velum-bootstrap-done'], 900;
+    if (match_has_tag 'velum-status-error') {
+        assert_and_click 'velum-retry';
+        assert_screen 'velum-bootstrap-done', 900;
+    }
 }
 
 sub run {


### PR DESCRIPTION
With current network issues running bootstrap is unreliable, let's retry one time (since it's not considered a bug if retry works)

Fixes issues here:
 - https://openqa.suse.de/tests/2436795#step/stack_bootstrap/18 - original job fails
 - https://openqa.suse.de/tests/2439306#step/stack_bootstrap/16 - cloned job passes

Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1062
Local run: http://dhcp126.suse.cz/tests/13829#step/stack_bootstrap/16