### PR TITLE
[WIP] Multi-Machine Terraform POC

### DIFF
--- a/data/terraform/poc/poc.tf
+++ b/data/terraform/poc/poc.tf
@@ -1,0 +1,75 @@
+variable "remote_ip" {}
+
+variable "count" {
+    default = "2"
+}
+
+provider "libvirt" {
+     uri = "qemu+ssh://root@${var.remote_ip}/system"
+}
+
+variable "hdd" {
+}
+
+resource "random_id" "service" {
+    count = "${var.count}"
+    byte_length = 4
+}
+
+resource "libvirt_volume" "myvdisk" {
+  name = "terraform-vdisk-${element(random_id.service.*.hex, count.index)}.qcow2"
+  count = "${var.count}"
+  pool = "default"
+  source = "${var.hdd}"
+  format = "qcow2"
+}
+
+resource "libvirt_network" "my_net" {
+   name = "terraform-net-${element(random_id.service.*.hex, count.index)}"
+   addresses = ["10.0.1.0/24"]
+   dhcp {
+		enabled = true
+	}
+}
+
+resource "libvirt_domain" "domain-sle" {
+  name = "terraform-vm-${element(random_id.service.*.hex, count.index)}"
+  memory = "4096"
+  vcpu = 4
+  count = "${var.count}"
+
+  network_interface {
+    network_id = "${libvirt_network.my_net.id}"
+    wait_for_lease = true
+  }
+
+  disk {
+   volume_id = "${libvirt_volume.myvdisk.*.id[count.index]}"
+  }
+
+  console {
+    type        = "pty"
+    target_port = "0"
+    target_type = "serial"
+  }
+
+  console {
+      type        = "pty"
+      target_type = "virtio"
+      target_port = "1"
+  }
+
+  graphics {
+    type = "vnc"
+    listen_type = "address"
+    autoport = "true"
+  }
+}
+
+output "vm_ips" {
+    value = "${libvirt_domain.domain-sle.*.network_interface.0.addresses}"
+}
+
+output "vm_names" {
+    value = "${libvirt_domain.domain-sle.*.name}"
+}

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -107,6 +107,7 @@ our @EXPORT = qw(
   load_xen_client_tests
   load_yast2_gui_tests
   load_zdup_tests
+  load_terraform_poc_tests
   logcurrentenv
   map_incidents_to_repo
   need_clear_repos
@@ -2535,6 +2536,13 @@ sub load_transactional_role_tests {
     loadtest 'transactional_system/filesystem_ro';
     loadtest 'transactional_system/transactional_update';
     loadtest 'transactional_system/rebootmgr';
+}
+
+sub load_terraform_poc_tests {
+    boot_hdd_image;
+    loadtest 'terraform/create_hdd_controller' if check_var('TERRAFORM', 'create_hdd_controller');
+    loadtest 'terraform/create_hdd_sut'        if check_var('TERRAFORM', 'create_hdd_sut');
+    loadtest 'terraform/poc'                   if check_var('TERRAFORM', 'test');
 }
 
 1;

--- a/lib/terraform/basetest.pm
+++ b/lib/terraform/basetest.pm
@@ -1,0 +1,138 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Base class for terraform tests
+#
+# Maintainer: Jose Lausuch <jalausuch@suse.de>
+
+package terraform::basetest;
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use terraform::libvirt_domain;
+use terraform::host;
+use Data::Dumper;
+use Mojo::JSON 'decode_json';
+use MIME::Base64;
+
+use constant TERRAFORM_TIMEOUT => 600;
+use constant WORKDIR           => '/root/terraform';
+
+=head2 _run_terraform_cmd
+
+    _run_terraform_cmd();
+
+Runs terraform command given by C<cmd>
+
+=cut
+sub _run_terraform_cmd {
+    my ($self, $cmd) = @_;
+    my $output = script_output($cmd, TERRAFORM_TIMEOUT);
+    record_info('TFM CMD', $cmd . "\n\n" . $output) if check_var('DEBUG', 1);
+    return $output;
+}
+
+=head2 _prepare_ssh
+
+    _prepare_ssh();
+
+Copy the private ssh key to access the remote host without password.
+The remote host must have the public key in authorized_keys
+
+=cut
+sub _prepare_ssh {
+    my ($self) = @_;
+    my $private_key = get_required_var('PRIVATE_KEY');
+    assert_script_run('echo "' . decode_base64($private_key) . '" > /root/.ssh/id_rsa');
+    assert_script_run('chmod 600 /root/.ssh/id_rsa');
+}
+
+=head2 deploy_test_env
+
+    deploy_test_env();
+
+Deploys the given Terraform C<tf_file> file on the Terraform VM which will create
+the environment on the remote host.
+
+=cut
+sub deploy_test_env {
+    my ($self, $tf_file) = @_;
+    my @domains;
+    $self->_prepare_ssh();
+    assert_script_run('mkdir -p ' . WORKDIR);
+    assert_script_run('cd ' . WORKDIR);
+    assert_script_run('curl ' . data_url($tf_file) . ' -o ./test.tf');
+
+    my $host = terraform::host->new(
+        ip   => get_required_var('REMOTE_HOST_IP'),
+        user => get_required_var('REMOTE_HOST_USER')
+    );
+    record_info('HOST', Dumper $host) if check_var('DEBUG', 1);
+
+    my $sut_hdd_url = get_required_var('SUT_HDD');
+    die("Invalid SUT_HDD url ") unless ($sut_hdd_url =~ m|([^/]+)/?$|);
+    my $hdd_name = $1;
+
+    #$host->run_ssh_command("wget -q $sut_hdd_url -O /root/$hdd_name");
+    assert_script_run("wget -q $sut_hdd_url");
+    $self->_run_terraform_cmd('terraform init');
+    $self->_run_terraform_cmd('terraform apply -auto-approve -var "hdd=' . WORKDIR . '/' . $hdd_name . '" -var "remote_ip=' . $host->{ip} . '"');
+
+    my $vms       = decode_json($self->_run_terraform_cmd('terraform output -json vm_names'))->{value};
+    my $ips       = decode_json($self->_run_terraform_cmd('terraform output -json vm_ips'))->{value};
+    my @ips_array = map { $_->[0] } @{$ips};
+
+    if (get_var('DEBUG')) {
+        record_info('IPS',   Dumper(\@ips_array));
+        record_info('NAMES', Dumper($vms));
+        for my $i (@ips_array) {
+            record_info("IP", $i);
+        }
+    }
+
+    foreach my $i (0 .. $#{$vms}) {
+        my $domain = terraform::libvirt_domain->new(
+            domain_name => @{$vms}[$i],
+            domain_ip   => $ips_array[$i],
+            host        => $host
+        );
+        record_info('INFO', "Domain created: " . @{$vms}[$i] . "\n" . Dumper $domain) if check_var('DEBUG', 1);
+        $domain->init();
+        record_info('INFO', "Domain initialized: " . @{$vms}[$i] . "\n" . Dumper $domain);
+        push @domains, $domain;
+    }
+    return @domains;
+}
+
+=head2 destroy_test_env
+
+    destroy_test_env();
+
+Destroys the Terraform environment on the remote host.
+
+=cut
+sub destroy_test_env {
+    my ($self) = @_;
+    my $sut_hdd_url = get_required_var('SUT_HDD');
+    $sut_hdd_url =~ m|([^/]+)/?$|;
+    my $hdd_name = $1;
+    $self->_run_terraform_cmd('terraform destroy -auto-approve -var "hdd=' . WORKDIR . '/' . $hdd_name . '" -var "remote_ip=' . get_required_var('REMOTE_HOST_IP') . '"');
+}
+
+
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->destroy_test_env();
+}
+
+sub post_run_hook {
+    my ($self) = @_;
+    $self->destroy_test_env();
+}
+
+1;

--- a/lib/terraform/host.pm
+++ b/lib/terraform/host.pm
@@ -1,0 +1,58 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Host (hypervisor) where the test VMs will be spawned
+#
+# Maintainer: Jose Lausuch <jalausuch@suse.de>
+#   Pre-requirements: - public ssh key in data dir must be set previously on the
+#                       host to run SSH commands on the host without password
+#                     - libvirt service must be running
+
+package terraform::host;
+use Mojo::Base -base;
+use testapi;
+use strict;
+
+has ip   => undef;    # IP for ssh access
+has user => undef;    # domain name
+
+
+=head2 run_ssh_command
+
+    run_ssh_command($cmd);
+
+    Runs a command C<cmd> via ssh on the Host. Retrieves the output.
+    If the command retrieves not zero, an exception is thrown.
+
+=cut
+sub run_ssh_command {
+    my ($self, $cmd) = @_;
+    die('Argument <cmd> missing') unless ($cmd);
+    my $ssh_cmd = sprintf("ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no %s@%s -- '%s'",
+        $self->user, $self->ip, $cmd);
+    my $output = script_output($ssh_cmd);
+    record_info('SSH CMD', 'HOST: ' . $self->ip . "\nCMD: $ssh_cmd\n\n$output") if check_var('DEBUG', 1);
+    return $output;
+}
+
+=head2 check_host
+
+    check_host();
+
+    Perform some checks on the host to see if it can run the tests
+
+=cut
+sub check_host {
+    my ($self) = @_;
+    my $output = $self->run_ssh_command('systemctl status libvirtd');
+    record_info('libvirt', "Status of libvirtd service:\n$output") if check_var('DEBUG', 1);
+    # TODO: more checks, such as kvm, lscpu, storage pool, etc
+}
+
+1;

--- a/lib/terraform/libvirt_domain.pm
+++ b/lib/terraform/libvirt_domain.pm
@@ -1,0 +1,139 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Base class for terraform domains (VMs)
+#
+# Maintainer: Jose Lausuch <jalausuch@suse.de>
+
+package terraform::libvirt_domain;
+use Mojo::Base -base;
+use testapi;
+use XML::Simple;
+use Data::Dumper;
+use Scalar::Util qw(looks_like_number);
+
+has domain_name   => undef;    # domain name
+has domain_ip     => undef;    # private IP of the VM
+has virtio_device => undef;    # host device that corresponds to virtio
+has host          => undef;    # host object where the VM is running
+
+use constant LOGIN_TIMEOUT => 30;    # (x 30)
+
+sub init {
+    my ($self) = @_;
+    $self->_set_virtio_device();
+    $self->_login();
+}
+
+
+=head2 login
+
+    login($cmd);
+
+Login to the VM on the console with the given user and password
+
+=cut
+sub _login {
+    my ($self, %args) = @_;
+    $args{user} //= 'root';
+    $args{pwd}  //= 'nots3cr3t';
+    my $timeout = LOGIN_TIMEOUT;
+    my $pid     = $self->host->run_ssh_command('cat ' . $self->virtio_device . ' > out.log & echo $!');
+    if (!looks_like_number($pid)) {
+        die("Failed to get the PID '$pid'.");
+    }
+    record_info('login', "pid=$pid") if check_var('DEBUG', 1);
+    $self->host->run_ssh_command('echo -e "\n" > ' . $self->virtio_device);    # trick for the login prompt to appear
+    while ($timeout > 0) {
+        my $prompt = $self->host->run_ssh_command("cat out.log");
+        record_info('PROMPT', $self->domain_name . " prompt :\n" . $prompt) if check_var('DEBUG', 1);
+        if ($prompt =~ /login/) {
+            $self->host->run_ssh_command('echo -e "' . $args{user} . '\n" > ' . $self->virtio_device);
+            sleep 10;
+            $self->host->run_ssh_command('echo -e "' . $args{pwd} . '\n" > ' . $self->virtio_device);
+            sleep 10;
+            last;
+        }
+        $timeout -= 1;
+        sleep 10;
+    }
+    $self->host->run_ssh_command('kill -9 ' . $pid);
+    die('Login prompt does not appear in VM "' . $self->domain_name . '"') if ($timeout == 0);
+}
+
+
+=head2 run_command
+
+    run_command($cmd, $wait_time);
+
+Runs a command C<cmd> via virtio device in the VM. Retrieves the output.
+
+=cut
+sub run_command {
+    my ($self, %args) = @_;
+
+    die('Argument <cmd> missing') unless ($args{cmd});
+    $args{wait_time} //= 1;
+
+    record_info('run_command', 'domain_name=' . $self->domain_name . "\ncmd=" . $args{cmd} . "\nwait_time=" . $args{wait_time}) if check_var('DEBUG', 1);
+    my $pid = $self->host->run_ssh_command('cat ' . $self->virtio_device . ' > out.log & echo $!');
+    if (!looks_like_number($pid)) {
+        die("Failed to get the PID '$pid'.");
+    }
+    record_info('run_command', "pid=$pid") if check_var('DEBUG', 1);
+    $self->host->run_ssh_command('echo -e "' . $args{cmd} . '" > ' . $self->virtio_device);
+    sleep $args{wait_time};
+    $self->host->run_ssh_command('kill -9 ' . $pid);
+    my $out = $self->host->run_ssh_command('cat out.log');
+    $out =~ s/^(?:.*\n){1}//;    # remove first line (command)
+    $out =~ s/\[1m.*//;          # remove prompt line
+    record_info('cmd out', Dumper $out) if check_var('DEBUG', 1);
+    $out =~ s/\e//g;
+    return $out;
+}
+
+
+=head2 _get_domain_xml
+
+    get_domain_xml();
+
+    Gets the XML dump of the libvirt domain
+
+=cut
+sub _get_domain_xml {
+    my ($self) = @_;
+    my $xml = $self->host->run_ssh_command('virsh dumpxml ' . $self->domain_name);
+    return XMLin($xml);
+}
+
+
+=head2 _set_virtio_device
+
+    _set_virtio_device();
+
+Gets the path to the virtio device in the host from the xml definition of the domain
+
+=cut
+sub _set_virtio_device {
+    my ($self) = @_;
+    my $device;
+    my $xml      = $self->_get_domain_xml();
+    my $consoles = $xml->{devices}->{console};
+    foreach my $console (@{$consoles}) {
+        if ($console->{target}->{type} eq 'virtio') {
+            $device = $console->{source}->{path};
+            last;
+        }
+    }
+    die('Failed to get virtio device of domain ' . $self->domain_name) if (!$device);
+    record_info('DEVICE', 'Domain ' . $self->domain_name . " uses virtio device mapped to : $device") if check_var('DEBUG', 1);
+    $self->virtio_device($device);
+}
+
+1;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -296,6 +296,9 @@ if (is_jeos) {
 if (is_kernel_test()) {
     load_kernel_tests();
 }
+elsif (get_var('TERRAFORM')) {
+    load_terraform_poc_tests();
+}
 elsif (get_var("NETWORKD")) {
     boot_hdd_image();
     load_networkd_tests();

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -591,6 +591,9 @@ if (is_kernel_test()) {
     }
     load_kernel_tests();
 }
+elsif (get_var('TERRAFORM')) {
+    load_terraform_poc_tests();
+}
 elsif (get_var('IBTESTS')) {
     load_baremetal_tests();
     load_infiniband_tests();

--- a/tests/terraform/create_hdd_controller.pm
+++ b/tests/terraform/create_hdd_controller.pm
@@ -1,0 +1,49 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: create a qcow2 image with all the needed tools for tests using
+#          Terraform.
+#
+# Maintainer: Jose Lausuch <jalausuch@suse.de>
+
+use Mojo::Base 'opensusebasetest';
+use testapi;
+use utils 'zypper_call';
+use version_utils 'is_sle';
+
+sub run {
+    my ($self) = @_;
+
+    $self->select_serial_terminal;
+
+    if (is_sle && (get_required_var('VERSION') eq '15-SP1')) {
+        zypper_call('-q ar -G  https://download.opensuse.org/repositories/systemsmanagement:/sumaform/SLE_15/systemsmanagement:sumaform.repo');
+    } else {
+        die("This HDD creation is to be done on SLE15-SP1 images");
+    }
+
+    zypper_call('-q in -y terraform-provider-libvirt');
+
+    my $version = get_var('TERRAFORM_VERSION', '0.11.11');
+    assert_script_run("wget -q https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_amd64.zip", 300);
+    assert_script_run("unzip terraform_${version}_linux_amd64.zip");
+    assert_script_run('mv terraform /usr/bin/terraform');
+    assert_script_run('terraform -v');
+
+    assert_script_run('mkdir -p /root/.ssh');
+    assert_script_run('chmod 700 /root/.ssh');
+    assert_script_run('echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config');
+    assert_script_run('echo "LogLevel ERROR" >> /etc/ssh/ssh_config');
+
+    # this is needed for the test 'sle15_workarounds' to work as it fails
+    # if the previous test has selected virtio console
+    select_console('root-console');
+}
+
+1;

--- a/tests/terraform/create_hdd_sut.pm
+++ b/tests/terraform/create_hdd_sut.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Make latest SUT (normally SLES) auto bootable. The first option
+#          in grub must be selected automatically witout user intervention
+#          This is also the place to add a second NIC if needed in the future.
+#
+# Maintainer: Jose Lausuch <jalausuch@suse.de>
+
+use base 'opensusebasetest';
+use strict;
+use testapi;
+
+sub run {
+    my ($self) = @_;
+
+    $self->select_serial_terminal;
+
+    assert_script_run('sed -i s/GRUB_TIMEOUT=-1/GRUB_TIMEOUT=0/ /etc/default/grub');
+    assert_script_run('grub2-mkconfig -o /boot/grub2/grub.cfg');
+
+    assert_script_run('cp /etc/sysconfig/network/ifcfg-eth0 /etc/sysconfig/network/ifcfg-eth1');
+
+    # this is needed for the test 'sle15_workarounds' to work as it fails
+    # if the previous test has selected virtio console
+    select_console('root-console');
+}
+
+1;

--- a/tests/terraform/poc.pm
+++ b/tests/terraform/poc.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Terraform POC
+#          It creates VMs on a remote machine and runs some commands it them
+#
+# Maintainer: Jose Lausuch <jalausuch@suse.de>
+
+use base "terraform::basetest";
+use testapi;
+use strict;
+
+sub run {
+    my ($self) = @_;
+
+    $self->select_serial_terminal;
+
+    my @vms = $self->deploy_test_env('terraform/poc/poc.tf');
+    record_info('INFO', 'VM1 : ' . $vms[0]->domain_name . "\nIP1:  " . $vms[0]->domain_ip . "\n\nVM2 " . $vms[1]->domain_name . "\nIP1:  " . $vms[1]->domain_ip);
+
+    my $output = $vms[0]->run_command(cmd => 'ls -lh');
+    record_info('CMD', 'Output of command "ls -lh" on vm ' . $vms[0]->domain_name . ":\n$output");
+
+    my $cmd = 'ping -c 1 ' . $vms[1]->domain_ip;
+    $output = $vms[0]->run_command(cmd => $cmd, wait_time => 10);
+    record_info('PING', "VM1 pings VM2\n\nCMD: $cmd\n\nOUTPUT:\n$output");
+
+    $cmd    = 'ping -c 1 ' . $vms[0]->domain_ip;
+    $output = $vms[1]->run_command(cmd => $cmd, wait_time => 10);
+    record_info('PING', "VM2 pings VM1\n\nCMD: $cmd\n\nOUTPUT:\n$output");
+}
+
+1;


### PR DESCRIPTION
This is not meant to be merge as it is now, at least not the example test case (poc.pm) or how to handle the main and main_common.pm, so forget about that for now. 

Files:
-  **poc.tf** : this is the input to terraform to create the environment on the remote host
-  **basetest.pm** : base class to be used by the terraform tests
-  **host.pm** : class to create 'remote host' objects
-  **libvirt_domain.pm** : class to create libvirt domain objects (VMs)
-  **create_hdd_controller.pm** : test to create the controller VM with Terraform package 
-  **create_hdd_sut.pm** : test to create the automatic bootable image from latest builds in OSD
-  **poc.pm** : example of test using of this library


Related ticket: https://progress.opensuse.org/issues/44207
Verification runs:
- Creation of controller VM: http://fromm.arch.suse.de/tests/5237
- Creation of SUT (SLES) VM: http://fromm.arch.suse.de/tests/5234
- Example of usage of the library: http://fromm.arch.suse.de/tests/5291
