### PR TITLE
Fix syntax error and remove unnecessary bugref in kdump test

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -98,10 +98,10 @@ sub activate_kdump {
         assert_screen \@tags, 300;
         # for ppc64le and aarch64 we need increase kdump memory, see bsc#957053 and bsc#1120566
         if (check_var('ARCH', 'ppc64le') || check_var('ARCH', 'aarch64')) {
-            wait_screen_change { send_key ' alt-y' };
+            wait_screen_change { send_key 'alt-y' };
             type_string '640';
             send_key 'ret';
-            record_soft_failure 'increase kdump memory size or kdumptool gets killed by OOM, bsc#957053 and bsc#1120566';
+            record_soft_failure 'increase kdump memory size or kdumptool gets killed by OOM, bsc#1120566';
         }
         # enable kdump if it is not already
         wait_screen_change { send_key 'alt-u' } if match_has_tag('yast2-kdump-disabled');


### PR DESCRIPTION
see https://openqa.suse.de/tests/2440868/file/autoinst-log.txt
and https://progress.opensuse.org/issues/33376
