### PR TITLE
Autofs regression tests

### DIFF
--- a/lib/autofs_utils.pm
+++ b/lib/autofs_utils.pm
@@ -1,0 +1,30 @@
+use base Exporter;
+use Exporter;
+
+use strict;
+use warnings;
+use testapi;
+use utils 'systemctl';
+
+our @EXPORT = qw(setup_autofs_server check_autofs_service);
+
+sub setup_autofs_server {
+    my (%args) = @_;
+    my $grep_output = script_output("grep '#+dir' $args{autofs_conf_file}");
+    if ($grep_output =~ /\#\+dir/) {
+        assert_script_run("sed -i_bk 's:#+dir\\:/etc/auto\\.master\\.d:+dir\\:/etc/auto\\.master\\.d:' $args{autofs_conf_file}");
+    }
+    assert_script_run("echo $args{test_mount_dir} $args{test_conf_file} > $args{autofs_map_file}");
+    assert_script_run($args{test_conf_file_content}, fail_message => "File $args{test_conf_file} could not be created");
+}
+
+sub check_autofs_service {
+    systemctl 'start autofs';
+    systemctl 'is-active autofs';
+    systemctl 'stop autofs';
+    systemctl 'is-active autofs', expect_false => 1;
+    systemctl 'restart autofs';
+    systemctl 'is-active autofs';
+}
+
+1;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -373,6 +373,9 @@ elsif (get_var('SECURITY_TEST')) {
 elsif (get_var('SYSTEMD_TESTSUITE')) {
     load_systemd_patches_tests;
 }
+elsif (get_var('AUTOFS')) {
+    load_mm_autofs_tests;
+}
 else {
     if (get_var("LIVETEST") || get_var('LIVE_INSTALLATION') || get_var('LIVE_UPGRADE')) {
         load_boot_tests();

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -982,6 +982,9 @@ else {
         loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
         loadtest 'network/vsftpd';
     }
+    elsif (get_var('AUTOFS')) {
+        load_mm_autofs_tests;
+    }
     elsif (get_var('UPGRADE_ON_ZVM')) {
         # Set 'DESKTOP' for origin system to avoid SLE15 s390x bug: bsc#1058071 - No VNC server available in SUT
         # Set origin and target version

--- a/tests/console/autofs.pm
+++ b/tests/console/autofs.pm
@@ -1,0 +1,42 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Mount an iso file using autofs/automount
+# Maintainer: Antonio Caristia <acaristia@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use autofs_utils qw(setup_autofs_server check_autofs_service);
+use utils qw(systemctl);
+
+sub run {
+    select_console 'root-console';
+    my $autofs_conf_file       = '/etc/auto.master';
+    my $autofs_map_file        = '/etc/auto.master.d/autofs_regression_test.autofs';
+    my $test_conf_file         = '/etc/auto.iso';
+    my $test_mount_dir         = '/mnt/test_autofs_local';
+    my $file_to_mount          = '/tmp/test-iso.iso';
+    my $test_conf_file_content = "echo  iso     -fstype=auto,ro         :$file_to_mount > $test_conf_file";
+    assert_script_run("mkdir -p $test_mount_dir");
+    assert_script_run("dd if=/dev/urandom of=$test_mount_dir/README bs=4024 count=1");
+    assert_script_run("mkisofs -o $file_to_mount $test_mount_dir");
+    assert_script_run("ls -lh $file_to_mount");
+    check_autofs_service();
+    assert_script_run("test -f $autofs_conf_file");
+    setup_autofs_server(autofs_conf_file => $autofs_conf_file, autofs_map_file => $autofs_map_file, test_conf_file => $test_conf_file, test_conf_file_content => $test_conf_file_content, test_mount_dir => $test_mount_dir);
+    systemctl 'restart autofs';
+    assert_script_run("ls $test_mount_dir/iso");
+    my $mount_output_triggered = script_output("mount | grep -e $file_to_mount");
+    die "Something went wrong, target is already mounted" unless $mount_output_triggered =~ /$file_to_mount/;
+}
+
+1;
+

--- a/tests/network/autofs_client.pm
+++ b/tests/network/autofs_client.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: It waits until a nfs server is ready and mounts a dir from that one
+# Maintainer: Antonio Caristia <acaristia@suse.com>
+
+use base 'consoletest';
+use testapi;
+use lockapi;
+use autofs_utils qw(setup_autofs_server check_autofs_service);
+use utils qw(systemctl);
+use strict;
+use warnings;
+
+sub run {
+    select_console "root-console";
+    my $nfs_server             = "10.0.2.101";
+    my $remote_mount           = "/tmp/nfs/server";
+    my $autofs_conf_file       = '/etc/auto.master';
+    my $autofs_map_file        = '/etc/auto.master.d/autofs_regression_test.autofs';
+    my $test_conf_file         = '/etc/auto.share';
+    my $test_mount_dir         = '/mnt/test';
+    my $test_conf_file_content = "echo  test    -ro,no_subtree_check              $nfs_server:$remote_mount > $test_conf_file";
+    check_autofs_service();
+    setup_autofs_server(autofs_conf_file => $autofs_conf_file, autofs_map_file => $autofs_map_file, test_conf_file => $test_conf_file, test_conf_file_content => $test_conf_file_content, test_mount_dir => $test_mount_dir);
+    systemctl 'restart autofs';
+    validate_script_output("systemctl --no-pager status autofs", sub { m/Active:\s*active/ }, 180);
+    barrier_wait 'AUTOFS_SUITE_READY';
+    assert_script_run("ls $test_mount_dir/test");
+    assert_script_run("mount | grep -e $test_mount_dir/test");
+    validate_script_output("cat $test_mount_dir/test/file.txt", sub { m/It worked/ }, 200);
+    barrier_wait 'AUTOFS_FINISHED';
+}
+
+1;

--- a/tests/network/autofs_server.pm
+++ b/tests/network/autofs_server.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: It shares a dir via nfs
+# Maintainer: Antonio Caristia <acaristia@suse.com>
+
+use base 'consoletest';
+use testapi;
+use lockapi;
+use utils qw(systemctl zypper_call);
+use version_utils qw(is_opensuse);
+use strict;
+use warnings;
+
+sub run {
+    select_console "root-console";
+    my $test_share_dir = "/tmp/nfs/server";
+    if (is_opensuse) {
+        zypper_call('modifyrepo -e 1');
+        zypper_call('ref');
+    }
+    zypper_call('in nfs-kernel-server');
+    assert_script_run "mkdir -p $test_share_dir";
+    assert_script_run "echo It worked > $test_share_dir/file.txt";
+    assert_script_run "echo $test_share_dir *(ro) >> /etc/exports";
+    assert_script_run "cat /etc/exports";
+    systemctl 'start nfs-server';
+    validate_script_output("systemctl --no-pager status nfs-server", sub { m/Active:\s*active/ }, 180);
+    barrier_wait 'AUTOFS_SUITE_READY';
+    barrier_wait 'AUTOFS_FINISHED';
+}
+
+1;


### PR DESCRIPTION
This commit introduces two autofs reg tests.

1. single machine version

   console/autofs.pm

- Checking autofs service and configuration.
- Mounting an iso file with automout.
- Checking if the file is correctly mounted.

2. multi machine version (it needs a MM openqa setup)

    network/autofs_test_nfs_server.pm
    network/autofs_test_autofs_client.pm

- Checking autofs service and configuration
- Mounting a dir via nfs.
- Checking if dir is correctly mounted.

Note: MM version requires four new testsuites with the following variables.

testsuite: autofs_test-autofs_client

> BOOT_HDD_IMAGE=1
> DESKTOP=textmode
> HDD_1=SLES-%VERSION%-%ARCH%-mru-install-minimal-with-addons-Build%BUILD%.qcow2
> HOSTNAME=client
> INSTALLONLY=1
> NICTYPE=tap
> PARALLEL_WITH=autofs_test-nfs_server
> AUTOFS=1
> START_AFTER_TEST=mru-install-minimal-with-addons
> WORKER_CLASS=tap
 

testsuite: autofs_test-nfs_server

> BOOT_HDD_IMAGE=1
> DESKTOP=textmode
> HDD_1=SLES-%VERSION%-%ARCH%-mru-install-minimal-with-addons-Build%BUILD%.qcow2
> HOSTNAME=server
> INSTALLONLY=1
> NICTYPE=tap
> AUTOFS=1
> START_AFTER_TEST=mru-install-minimal-with-addons
> WORKER_CLASS=tap

testsuite: autofs_test-nfs_server_opensuse

> AUTOFS=1
> BOOT_HDD_IMAGE=1
> DESKTOP=textmode
> HDD_1=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2
> HOSTNAME=server
> INSTALLONLY=1
> NICTYPE=tap
> START_AFTER_TEST=create_hdd_textmode
> WORKER_CLASS=tap

testsuite: autofs_test-autofs_client_opensuse

> AUTOFS=1
> BOOT_HDD_IMAGE=1
> DESKTOP=textmode
> HDD_1=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2
> HOSTNAME=client
> INSTALLONLY=1
> NICTYPE=tap
> PARALLEL_WITH=autofs_test-nfs_server_opensuse
> START_AFTER_TEST=create_hdd_textmode
> WORKER_CLASS=tap
 

1. single machine version (_console/autofs.pm_) is called in _load_extra_tests_filesystem_ (_lib/main_common.pm_)

2. multi machine version (_network/autofs_client.pm_ _network/autofs_server.pm_ ) is called in _load_mm_autofs_tests_ (_lib/main_common.pm_)

- Related ticket: https://progress.opensuse.org/issues/47078
- Needles: 
- Verification run: 

client/server version

sle12sp3 : client http://10.161.229.206/tests/255 server http://10.161.229.206/tests/254
sle12sp4 : client http://10.161.229.206/tests/253 server http://10.161.229.206/tests/252
sle15       : client http://10.161.229.206/tests/257 server http://10.161.229.206/tests/256
opensuse: client http://10.161.229.206/tests/249 server http://10.161.229.206/tests/248

local version

sle15       : http://10.161.229.206/tests/258
opensuse: http://10.161.229.206/tests/251

UPDATE:

latest verification run

sle12sp3 : client http://10.161.229.206/tests/447 server http://10.161.229.206/tests/446
sle12sp4 : client http://10.161.229.206/tests/450 server http://10.161.229.206/tests/449
sle15 : client http://10.161.229.206/tests/444 server http://10.161.229.206/tests/443
opensuse: client http://10.161.229.206/tests/453 server http://10.161.229.206/tests/452