### PR TITLE
[WIP] SLES4SAP: add NetWeaver cluster support

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -9,6 +9,7 @@ use isotovideo;
 use x11utils 'ensure_unlocked_desktop';
 
 our @EXPORT = qw (
+  fix_path
   set_ps_cmd
   set_sap_info
   become_sapadm
@@ -22,7 +23,23 @@ our @EXPORT = qw (
 our $prev_console;
 our $sapadmin;
 our $sid;
+our $instance;
 our $ps_cmd;
+
+sub fix_path {
+    my ($self, $var) = @_;
+    my ($proto, $path) = split m|://|, $var;
+    my @aux = split '/', $path;
+
+    $proto = 'cifs' if ($proto eq 'smb' or $proto eq 'smbfs');
+    die 'Currently only supported protocols are nfs and smb/smbfs/cifs'
+      unless ($proto eq 'nfs' or $proto eq 'cifs');
+
+    $aux[0] .= ':' if ($proto eq 'nfs');
+    $aux[0] = '//' . $aux[0] if ($proto eq 'cifs');
+    $path = join '/', @aux;
+    return ($proto, $path);
+}
 
 sub set_ps_cmd {
     my ($self, $procname) = @_;
@@ -31,11 +48,11 @@ sub set_ps_cmd {
 }
 
 sub set_sap_info {
-    my ($self, $sapadmin_env) = @_;
-    $sapadmin = $sapadmin_env;
-    die "Username of SAP Administrator must end with 'adm'" unless ($sapadmin =~ /adm$/);
-    $sid = uc(substr($sapadmin, 0, 3));
-    return ($sapadmin, $sid);
+    my ($self, $sid_env, $instance_env) = @_;
+    $sid      = uc($sid_env);
+    $instance = $instance_env;
+    $sapadmin = lc($sid_env) . 'adm';
+    return ($sapadmin);
 }
 
 sub become_sapadm {
@@ -52,12 +69,12 @@ sub become_sapadm {
 }
 
 sub test_version_info {
-    my $output = script_output "sapcontrol -nr 00 -function GetVersionInfo";
+    my $output = script_output "sapcontrol -nr $instance -function GetVersionInfo";
     die "sapcontrol: GetVersionInfo API failed\n\n$output" unless ($output =~ /GetVersionInfo[\r\n]+OK/);
 }
 
 sub test_instance_properties {
-    my $output = script_output "sapcontrol -nr 00 -function GetInstanceProperties | grep ^SAP";
+    my $output = script_output "sapcontrol -nr $instance -function GetInstanceProperties | grep ^SAP";
     die "sapcontrol: GetInstanceProperties API failed\n\n$output" unless ($output =~ /SAPSYSTEM.+SAPSYSTEMNAME.+SAPLOCALHOST/s);
 
     $output =~ /SAPSYSTEMNAME, Attribute, ([A-Z][A-Z0-9]{2})/m;
@@ -65,15 +82,15 @@ sub test_instance_properties {
 }
 
 sub test_stop {
-    my $output = script_output "sapcontrol -nr 00 -function Stop";
+    my $output = script_output "sapcontrol -nr $instance -function Stop";
     die "sapcontrol: Stop API failed\n\n$output" unless ($output =~ /Stop[\r\n]+OK/);
 
-    $output = script_output "sapcontrol -nr 00 -function StopService";
+    $output = script_output "sapcontrol -nr $instance -function StopService";
     die "sapcontrol: StopService API failed\n\n$output" unless ($output =~ /StopService[\r\n]+OK/);
 }
 
 sub test_start_service {
-    my $output = script_output "sapcontrol -nr 00 -function StartService $sid";
+    my $output = script_output "sapcontrol -nr $instance -function StartService $sid";
     die "sapcontrol: StartService API failed\n\n$output" unless ($output =~ /StartService[\r\n]+OK/);
 
     $output = script_output $ps_cmd;
@@ -83,7 +100,7 @@ sub test_start_service {
 }
 
 sub test_start_instance {
-    my $output = script_output "sapcontrol -nr 00 -function Start";
+    my $output = script_output "sapcontrol -nr $instance -function Start";
     die "sapcontrol: Start API failed\n\n$output" unless ($output =~ /Start[\r\n]+OK/);
 
     $output = script_output $ps_cmd;

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -79,6 +79,17 @@ sub run {
             barrier_create("FS_DATA_COPIED_${fs_tag}_$cluster_name",      $num_nodes);
             barrier_create("FS_CHECKED_${fs_tag}_$cluster_name",          $num_nodes);
         }
+
+        # Create barriers for SAP cluster
+        # Note: we always create these barries even if they are not used, mainly
+        # because it's not easy to know at this stage that we are testing a SAP cluster...
+        barrier_create("ASCS_INSTALLED_$cluster_name",     $num_nodes);
+        barrier_create("ERS_INSTALLED_$cluster_name",      $num_nodes);
+        barrier_create("NW_CLUSTER_HOSTS_$cluster_name",   $num_nodes);
+        barrier_create("NW_CLUSTER_INSTALL_$cluster_name", $num_nodes);
+        barrier_create("NW_INIT_CONF_$cluster_name",       $num_nodes);
+        barrier_create("NW_CREATED_CONF_$cluster_name",    $num_nodes);
+        barrier_create("NW_LOADED_CONF_$cluster_name",     $num_nodes);
     }
 
     # Wait for all children to start

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -15,6 +15,7 @@ use strict;
 use testapi;
 use lockapi;
 use hacluster;
+use version_utils 'is_sles4sap';
 
 sub run {
     my $cluster_name = get_cluster_name;
@@ -35,7 +36,12 @@ sub run {
     select_console 'root-console' if (get_var('HDDVERSION'));
 
     # Wait for resources to be started
-    wait_until_resources_started;
+    if (is_sles4sap) {
+        wait_until_resources_started(timeout => 300);
+    }
+    else {
+        wait_until_resources_started;
+    }
 
     # And check for the state of the whole cluster
     check_cluster_state;

--- a/tests/sles4sap/hana_test.pm
+++ b/tests/sles4sap/hana_test.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Checks HANA installation as performed by sles4sap/wizard_hana_install
-# Requires: sles4sap/wizard_hana_install, ENV variable SAPADM
+# Requires: sles4sap/wizard_hana_install, ENV variables INSTANCE_SID
 # Maintainer: Ricardo Branco <rbranco@suse.de>
 
 use base "sles4sap";
@@ -23,7 +23,9 @@ sub run {
     select_console 'root-console';
 
     # The SAP Admin was set in sles4sap/wizard_hana_install
-    my ($sapadm, $sid) = $self->set_sap_info(get_required_var('SAPADM'));
+    my $sid         = get_required_var('INSTANCE_SID');
+    my $instance_id = get_required_var('INSTANCE_ID');
+    my $sapadm      = $self->set_sap_info($sid, $instance_id);
     $self->become_sapadm;
 
     # Check HDB with a database query

--- a/tests/sles4sap/netweaver_cluster.pm
+++ b/tests/sles4sap/netweaver_cluster.pm
@@ -1,0 +1,124 @@
+# SUSE's SLES4SAP openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Configure NetWeaver cluster
+# Maintainer: Loic Devulder <ldevulder@suse.de>
+
+use base "sles4sap";
+use testapi;
+use lockapi;
+use hacluster;
+use utils qw(ensure_serialdev_permissions systemctl);
+use strict;
+
+sub run {
+    my ($self)       = @_;
+    my $instance_id  = get_required_var('INSTANCE_ID');
+    my $type         = get_required_var('INSTANCE_TYPE');
+    my $sid          = get_required_var('INSTANCE_SID');
+    my $alias        = get_required_var('INSTANCE_ALIAS');
+    my $lun          = get_required_var('INSTANCE_LUN');
+    my $cluster_name = get_cluster_name;
+    my ($ip, $netmask) = split '/', get_required_var('INSTANCE_IP');
+
+    # Set SAP variables
+    my $pscmd  = $self->set_ps_cmd("$type");
+    my $sapadm = $self->set_sap_info($sid, $instance_id);
+
+    # Synchronize the nodes
+    barrier_wait "NW_CLUSTER_INSTALL_$cluster_name";
+
+    select_console 'root-console';
+
+    # Do stuff with SAP account
+    $self->become_sapadm;
+    $self->test_version_info;
+    $self->test_instance_properties;
+    $self->test_stop;
+    script_run "$pscmd | wc -l ; $pscmd";
+    save_screenshot;
+
+    # Rollback changes to $testapi::serialdev and close the window
+    type_string "exit\n";
+    ensure_serialdev_permissions;
+
+    # Some file changes are needed for HA
+    select_console 'root-console';
+
+    my $profile_file = "/usr/sap/$sid/SYS/profile/${sid}_${type}${instance_id}_${alias}";
+
+    assert_script_run 'cp /sapinst/sapservices /usr/sap/';
+    assert_script_run "echo 'service/halib = \${DIR_CT_RUN}/saphascriptco.so' >> $profile_file";
+    assert_script_run "echo 'service/halib_cluster_connector = /usr/bin/sap_suse_cluster_connector' >> $profile_file";
+    assert_script_run "sed -i 's/^Restart_Program_\\(.*[[:blank:]]*=\\)/Start_Program_\\1/' $profile_file";
+
+    # Add SAP account into haclient group
+    assert_script_run "usermod -a -G haclient $sapadm";
+
+    # Removed uneeded(?) profile directory for ERS
+    if ($type eq 'ERS') {
+        assert_script_run "rm -rf /usr/sap/$sid/${type}${instance_id}/profile";
+        assert_script_run "ln -s /sapmnt/$sid/profile /usr/sap/$sid/${type}${instance_id}/profile";
+        assert_script_run "chown -h ha1adm:sapsys /usr/sap/$sid/${type}${instance_id}/profile";
+    }
+
+    # Create the resource configuration
+    my @sedoptions = undef;
+    push @sedoptions, "-e 's|%SID%|$sid|g'";
+    push @sedoptions, "-e 's|%${type}_INSTANCE%|$instance_id|g'";
+    push @sedoptions, "-e 's|%${type}_ALIAS%|$alias|g'";
+    push @sedoptions, "-e 's|%${type}_LUN%|$lun|g'";
+    push @sedoptions, "-e 's|%${type}_IP%|$ip|g'";
+
+    # We need to execute the sed command node by node
+    my $cmd             = undef;
+    my $nw_cluster_conf = '/sapmnt/nw_cluster.conf';
+    if (is_node(1)) {
+        # Initiate the template
+        $cmd = 'sed' . join(' ', @sedoptions) . " /sapinst/nw_cluster.conf > $nw_cluster_conf";
+        assert_script_run $cmd;
+
+        # Synchronize the nodes
+        barrier_wait "NW_INIT_CONF_$cluster_name";
+        barrier_wait "NW_CREATED_CONF_$cluster_name";
+
+        # Upload the configuration into the cluster
+        assert_script_run 'crm configure property maintenance-mode=true';
+        assert_script_run "crm configure load update $nw_cluster_conf";
+        assert_script_run 'crm configure property maintenance-mode=false';
+    }
+    else {
+        # Synchronize the nodes
+        barrier_wait "NW_INIT_CONF_$cluster_name";
+
+        # Use mutex to be sure that only *one* node at a time can access the file
+        mutex_lock 'support_server_ready';
+
+        # Modify the template
+        $cmd = 'sed -i' . join(' ', @sedoptions) . " $nw_cluster_conf";
+        assert_script_run $cmd;
+
+        # Release the lock and synchronize the nodes
+        mutex_unlock 'support_server_ready';
+
+        # Synchronize the nodes
+        barrier_wait "NW_CREATED_CONF_$cluster_name";
+    }
+
+    # Synchronize the nodes
+    barrier_wait "NW_LOADED_CONF_$cluster_name";
+
+    # Wait for resources to be started
+    wait_until_resources_started(timeout => 300);
+
+    # And check for the state of the whole cluster
+    check_cluster_state;
+}
+
+1;

--- a/tests/sles4sap/netweaver_filesystems.pm
+++ b/tests/sles4sap/netweaver_filesystems.pm
@@ -1,0 +1,52 @@
+# SUSE's SLES4SAP openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Configure NetWeaver filesystems
+# Maintainer: Loic Devulder <ldevulder@suse.de>
+
+use base "sles4sap";
+use testapi;
+use utils 'systemctl';
+use hacluster;
+use strict;
+
+sub run {
+    my ($self)      = @_;
+    my $type        = get_required_var('INSTANCE_TYPE');
+    my $instance_id = get_required_var('INSTANCE_ID');
+    my $sid         = get_required_var('INSTANCE_SID');
+    my $arch        = get_required_var('ARCH');
+    my $lun         = get_lun;
+    my $sap_dir     = "/usr/sap/$sid";
+    my ($proto, $path) = $self->fix_path(get_required_var('NW'));
+
+    # LUN information is needed after for the HA configuration
+    set_var('INSTANCE_LUN', "$lun");
+
+    select_console 'root-console';
+
+    # Create/format/mount local filesystems
+    assert_script_run "mkfs -t xfs -f $lun";
+    assert_script_run "mkdir -p $sap_dir/${type}${instance_id}";
+    assert_script_run "mount $lun $sap_dir/${type}${instance_id}";
+
+    # Mount NFS filesystem
+    assert_script_run "echo '$path/$arch/nfs_share/sapmnt /sapmnt $proto defaults,bg 0 0' >> /etc/fstab";
+    assert_script_run "echo '$path/$arch/nfs_share/usrsapsys $sap_dir/SYS $proto defaults,bg 0 0' >> /etc/fstab";
+    systemctl 'enable nfs';
+    systemctl 'start nfs';
+    foreach my $mountpoint ('/sapmnt', "$sap_dir/SYS") {
+        assert_script_run "mkdir -p $mountpoint && mount $mountpoint";
+
+        # NFS mounts need to be cleared before the NW installation
+        assert_script_run "rm -rf $mountpoint/*";
+    }
+}
+
+1;

--- a/tests/sles4sap/netweaver_install.pm
+++ b/tests/sles4sap/netweaver_install.pm
@@ -58,7 +58,7 @@ sub prepare_profile {
         [
             qw(root-console displaymanager displaymanager-password-prompt generic-desktop
               text-login linux-login started-x-displaymanager-info)
-        ]);
+        ], 120);
     select_console 'root-console' unless (match_has_tag 'root-console');
 
     if ($has_saptune) {

--- a/tests/sles4sap/netweaver_install.pm
+++ b/tests/sles4sap/netweaver_install.pm
@@ -1,29 +1,22 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2018 SUSE LLC
+# Copyright © 2017-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Perform an unattended installation of SAP NetWeaver ASCS
+# Summary: Perform an unattended installation of SAP NetWeaver
 # Requires: ENV variable NW pointing to installation media
-# Maintainer: Alvaro Carvajal <acarvajal@suse.de>
+# Maintainer: Alvaro Carvajal <acarvajal@suse.de> / Loic Devulder <ldevulder@suse.de>
 
 use base "sles4sap";
 use testapi;
+use lockapi;
+use utils 'systemctl';
+use hacluster;
 use strict;
-
-sub fix_path {
-    my $path  = shift;
-    my $proto = shift;
-    my @aux   = split '/', $path;
-
-    $aux[0] .= ':' if ($proto eq 'nfs');
-    $aux[0] = '//' . $aux[0] if ($proto eq 'cifs');
-    $path = join '/', @aux;
-}
 
 sub is_saptune_installed {
     my $ret = script_run "rpm -q saptune";
@@ -49,7 +42,7 @@ sub prepare_profile {
         assert_script_run "tuned-adm profile $profile";
     }
 
-    assert_script_run "systemctl restart systemd-logind.service";
+    systemctl 'restart systemd-logind.service';
     # 'systemctl restart systemd-logind' is causing the X11 console to move
     # out of tty2 on SLES4SAP-15, which in turn is causing the change back to
     # the previous console in post_run_hook() to fail when running on systems
@@ -84,20 +77,29 @@ sub prepare_profile {
 
 sub run {
     my ($self) = @_;
-    my ($proto, $path) = split m|://|, get_required_var('NW');
+    my ($proto, $path) = $self->fix_path(get_required_var('NW'));
+    my $instance_type = get_required_var('INSTANCE_TYPE');
+    my $instance_id   = get_required_var('INSTANCE_ID');
+    my $sid           = get_required_var('INSTANCE_SID');
+    my $hostname      = get_var('INSTANCE_ALIAS', '$(hostname)');
+    my $params_file   = "/sapinst/$instance_type.params";
+    my $nettout       = 900;                                        # Time out for NetWeaver's sources related commands
+    my $product_id    = undef;
+
+    # Set Product ID depending on the type of Instance
+    if ($instance_type eq 'ASCS') {
+        $product_id = 'NW_ABAP_ASCS';
+    }
+    elsif ($instance_type eq 'ERS') {
+        $product_id = 'NW_ERS';
+    }
+
     my @sapoptions = qw(
-      SAPINST_USE_HOSTNAME=$(hostname)
-      SAPINST_INPUT_PARAMETERS_URL=/sapinst/inifile.params
-      SAPINST_EXECUTE_PRODUCT_ID=NW_ABAP_ASCS:NW750.HDB.ABAPHA
+      SAPINST_START_GUISERVER=false SAPINST_SLP_MODE=false
       SAPINST_SKIP_DIALOGS=true SAPINST_SLP_MODE=false);
-    my $nettout = 900;    # Time out for NetWeaver's sources related commands
-
-    $proto = 'cifs' if ($proto eq 'smb' or $proto eq 'smbfs');
-    die "netweaver_ascs_install: currently only supported protocols are nfs and smb/smbfs/cifs"
-      unless ($proto eq 'nfs' or $proto eq 'cifs');
-
-    # Normalize path depending on the protocol
-    $path = fix_path($path, $proto);
+    push @sapoptions, "SAPINST_USE_HOSTNAME=$hostname";
+    push @sapoptions, "SAPINST_INPUT_PARAMETERS_URL=$params_file";
+    push @sapoptions, "SAPINST_EXECUTE_PRODUCT_ID=$product_id:NW750.ADA.ABAPHA";
 
     select_console 'root-console';
 
@@ -119,34 +121,55 @@ sub run {
     assert_script_run "umount /mnt";
     assert_script_run "md5sum -c /tmp/check-nw-media", $nettout;
 
-    # Define a valid hostname/IP address in /etc/hosts
-    assert_script_run "curl -f -v " . autoinst_url . "/data/sles4sap/add_ip_hostname2hosts.sh > /tmp/add_ip_hostname2hosts.sh";
-    assert_script_run "/bin/bash -ex /tmp/add_ip_hostname2hosts.sh";
+    # Define a valid hostname/IP address in /etc/hosts, but not in HA
+    if (!get_var('HA_CLUSTER')) {
+        assert_script_run "curl -f -v " . autoinst_url . "/data/sles4sap/add_ip_hostname2hosts.sh > /tmp/add_ip_hostname2hosts.sh";
+        assert_script_run "/bin/bash -ex /tmp/add_ip_hostname2hosts.sh";
+    }
 
-    # Use the correct hostname in SAP's inifile.params
-    $cmd = q|sed -i "s/MyHostname/"$(hostname)"/" /sapinst/inifile.params|;
-    assert_script_run $cmd;
+    # Use the correct Hostname and InstanceNumber in SAP's params file
+    # Note: $hostname can be '$(hostname)', so we need to protect with '"'
+    assert_script_run "sed -i -e \"s/%HOSTNAME%/$hostname/g\" -e 's/%INSTANCE_ID%/$instance_id/g' $params_file";
 
     # Create an appropiate start_dir.cd file and an unattended installation directory
     $cmd = 'ls | while read d; do if [ -d "$d" -a ! -h "$d" ]; then echo $d; fi ; done | sed -e "s@^@/sapinst/@"';
-    assert_script_run "$cmd > /tmp/start_dir.cd";
-    type_string "mkdir -p /sapinst/unattended\n";
-    assert_script_run "mv /tmp/start_dir.cd /sapinst/unattended/";
+    assert_script_run 'mkdir -p /sapinst/unattended';
+    assert_script_run "$cmd > /sapinst/unattended/start_dir.cd";
 
     # Create sapinst group
     assert_script_run "groupadd sapinst";
     assert_script_run "chgrp -R sapinst /sapinst/unattended";
-    assert_script_run "chmod -R 0775 /sapinst/unattended";
-
-    # Set SAPADM to the SAP Admin user for future use
-    my $sid = script_output q|awk '/NW_GetSidNoProfiles.sid/ {print $NF}' inifile.params|, 10;
-    set_var('SAPADM', lc($sid) . 'adm');
+    assert_script_run "chmod 0775 /sapinst/unattended";
 
     # Start the installation
     type_string "cd /sapinst/unattended\n";
-    $cmd = "../SWPM/sapinst" . ' ' . join(' ', @sapoptions);
+    $cmd = '../SWPM/sapinst ' . join(' ', @sapoptions);
 
-    assert_script_run $cmd, $nettout;
+    # Synchronize with other nodes
+    if (get_var('HA_CLUSTER') && !is_node(1)) {
+        my $cluster_name = get_cluster_name;
+        barrier_wait("ASCS_INSTALLED_$cluster_name");
+    }
+
+    if ($instance_type eq 'ASCS') {
+        assert_script_run $cmd, $nettout;
+    }
+    elsif ($instance_type eq 'ERS') {
+        # We have to workaround an installation issue:
+        # ERS installation try to stop the ASCS server on first node and that doesn't work
+        script_run $cmd, $nettout;
+
+        # So we have to check in the log file that's the installation goes well
+        # We simply checking for the ASCS stop error message!
+        # TODO: change this to something more robust!
+        assert_script_run "grep -q 'Cannot stop instance.*ASCS' /sapinst/unattended/sapinst.log";
+    }
+
+    # Synchronize with other nodes
+    if (get_var('HA_CLUSTER') && is_node(1)) {
+        my $cluster_name = get_cluster_name;
+        barrier_wait("ASCS_INSTALLED_$cluster_name");
+    }
 }
 
 sub post_fail_hook {
@@ -158,6 +181,7 @@ sub post_fail_hook {
     $self->save_and_upload_log('ls -alF /sbin/mount*',        '/tmp/sbin_mount_ls.log');
     upload_logs "/sapinst/unattended/sapinst.log";
     upload_logs "/sapinst/unattended/sapinst_dev.log";
+    upload_logs "/sapinst/unattended/start_dir.cd";
 }
 
 1;

--- a/tests/sles4sap/netweaver_network.pm
+++ b/tests/sles4sap/netweaver_network.pm
@@ -1,0 +1,57 @@
+# SUSE's SLES4SAP openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Configure NetWeaver network
+# Maintainer: Loic Devulder <ldevulder@suse.de>
+
+use base "sles4sap";
+use testapi;
+use lockapi;
+use hacluster;
+use strict;
+
+sub run {
+    my ($self)        = @_;
+    my $cluster_name  = get_cluster_name;
+    my $instance_type = get_required_var('INSTANCE_TYPE');
+    my ($ip, $netmask) = split '/', get_required_var('INSTANCE_IP');
+    my $sid   = get_required_var('INSTANCE_SID');
+    my $alias = lc("sap$sid" . substr($instance_type, 0, 2));
+
+    # Export needed variables
+    set_var('INSTANCE_ALIAS', "$alias");
+
+    select_console 'root-console';
+
+    # Get the network interface and add IP alias
+    my $eth = script_output "ip -o route | sed -rn '/^default/s/.+dev ([a-z]+[0-9]).+/\\1/p'";
+    assert_script_run "ip a a dev $eth $ip/$netmask";
+
+    # Add IP addresses in /etc/hosts
+    assert_script_run "echo '$ip $alias' >> /etc/hosts";
+
+    # Synchronize nodes
+    barrier_wait "NW_CLUSTER_HOSTS_$cluster_name";
+
+    # At this stage we have passwordless ssh access on all nodes
+    if (is_node(1)) {
+        # We have to do this for all nodes
+        foreach my $num_node (2 .. get_node_number) {
+            my $node = choose_node($num_node);
+            assert_script_run "scp -o StrictHostKeyChecking=no root\@$node:/etc/hosts /tmp/hosts.$num_node";
+        }
+        assert_script_run 'grep -Ehv \'^#|^[[:blank:]]*$\' /etc/hosts /tmp/hosts.* | sort -r -u > /tmp/hosts.nw';
+        assert_script_run 'mv /tmp/hosts.nw /etc/hosts';
+
+        # Synchronize the hosts file
+        add_file_in_csync(value => '/etc/hosts');
+    }
+}
+
+1;

--- a/tests/sles4sap/netweaver_test_instance.pm
+++ b/tests/sles4sap/netweaver_test_instance.pm
@@ -7,8 +7,8 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Checks NetWeaver's ASCS installation as performed by sles4sap/netweaver_ascs_install
-# Requires: sles4sap/netweaver_ascs_install, ENV variable SAPADM
+# Summary: Checks NetWeaver installation as performed by sles4sap/netweaver_install
+# Requires: sles4sap/netweaver_install, ENV variables INSTANCE_SID, INSTANCE_TYPE and INSTANCE_ID
 # Maintainer: Alvaro Carvajal <acarvajal@suse.de>
 
 use base "sles4sap";
@@ -18,12 +18,12 @@ use utils 'ensure_serialdev_permissions';
 
 sub run {
     my ($self) = @_;
-    my $pscmd = $self->set_ps_cmd('ASCS');
+    my $pscmd = $self->set_ps_cmd(get_required_var('INSTANCE_TYPE'));
 
     select_console 'root-console';
 
-    # The SAP Admin was set in sles4sap/netweaver_ascs_install
-    $self->set_sap_info(get_required_var('SAPADM'));
+    # The SAP Admin was set in sles4sap/netweaver_install
+    $self->set_sap_info(get_required_var('INSTANCE_SID'), get_required_var('INSTANCE_ID'));
     $self->become_sapadm;
 
     $self->test_version_info;

--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -26,6 +26,9 @@ sub run {
     # Disable packagekit
     pkcon_quit;
 
+    # Is HA pattern needed?
+    push @sappatterns, 'ha_sles' if get_var('HA_CLUSTER');
+
     my $base_pattern = is_sle('>=15') ? 'patterns-server-enterprise-sap_server' : 'patterns-sles-sap_server';
 
     # First check pattern sap_server which is installed by default in SLES4SAP
@@ -38,24 +41,29 @@ sub run {
         die "Pattern sap_server not installed by default"
           unless (check_var('SYSTEM_ROLE', 'textmode') or is_upgrade());
         record_info('install sap_server', 'Installing sap_server pattern and starting tuned');
-        assert_script_run("zypper in -y -t pattern sap_server");
-        assert_script_run("systemctl start tuned");
+        zypper_call('in -y -t pattern sap_server');
+        systemctl 'start tuned';
     }
 
     # Dry run of each pattern's installation before actual installation
     foreach my $pattern (@sappatterns) {
-        assert_script_run("zypper in -D -y -t pattern $pattern");
+        zypper_call("in -D -y -t pattern $pattern");
         $output = script_output("zypper info --requires $pattern");
         record_info("requirements pattern: $pattern", $output);
     }
 
     # Actual installation and verification
     foreach my $pattern (@sappatterns) {
-        assert_script_run("zypper in -y -t pattern $pattern", 100);
+        zypper_call("in -y -t pattern $pattern");
         $output = script_output "zypper info -t pattern $pattern";
+        # Name of HA pattern is weird...
+        $pattern = "ha-$pattern" if ($pattern =~ /ha_sles/) && get_var('HA_CLUSTER');
         die "SAP zypper pattern [$pattern] info check failed"
           unless ($output =~ /i\+\s\|\spatterns-$pattern\s+\|\spackage\s\|\sRequired/);
     }
+
+    # Some specific package may be needed in HA mode
+    zypper_call 'in sap-suse-cluster-connector' if get_var('HA_CLUSTER');
 }
 
 sub test_flags {

--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -78,11 +78,9 @@ sub run {
     my ($proto, $path) = split m|://|, get_required_var('MEDIA');
     die "Currently supported protocols are nfs and smb" unless $proto =~ /^(nfs|smb)$/;
 
-    # Don't change this. The needle has this SID.
-    my $sid      = 'NDB';
+    my $sid      = get_required_var('INSTANCE_SID');
     my $password = 'Qwerty_123';
     set_var('PASSWORD', $password);
-    set_var('SAPADM',   lc($sid) . 'adm');
 
     check_var('BACKEND', 'ipmi') ? use_ssh_serial_console : select_console 'root-console';
     my $RAM = get_total_mem();


### PR DESCRIPTION
Use the existing HA stack to create a NetWeaver cluster test.
Also re-use the existing NetWeaver ASCS test.

Note: some variables will have to be added in the existing tests to support these changes.

Verification runs:
- [existing NW test](http://1b147.qa.suse.de/tests/4917)
- existing HA tests: [node01](http://1b147.qa.suse.de/tests/4921), [node02](http://1b147.qa.suse.de/tests/4920), [node03](http://1b147.qa.suse.de/tests/4919)
- new NW HA tests: [NW node01](http://1b147.qa.suse.de/tests/4915), [NW node02](http://1b147.qa.suse.de/tests/4916)
