### PR TITLE
Fix false-positives to bsc#1124294 on focussed password prompt

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -151,11 +151,10 @@ sub handle_login {
             select_user_gnome($myuser);
         }
     }
-    assert_screen [qw(displaymanager-password-prompt displaymanager-focused-password-textbox)];
-    if (check_var('DESKTOP', 'kde') && !match_has_tag('displaymanager-focused-password-textbox')) {
-        record_soft_failure('bsc#1122664 - password textbox is not focused');
-        assert_and_click 'displaymanager-password-prompt';
-        assert_screen 'displaymanager-focused-password-textbox';
+    assert_screen [qw(displaymanager-password-prompt displaymanager-unfocused-password-prompt)];
+    if (check_var('DESKTOP', 'kde') && match_has_tag('displaymanager-unfocused-password-prompt')) {
+        record_soft_failure('bsc#1122664 - password prompt is not focused');
+        wait_screen_change { assert_and_click 'displaymanager-password-prompt' };
     }
     type_password;
     send_key "ret";


### PR DESCRIPTION
By looking for the *unfocussed* password prompt explicitly we can avoid
matching both focussed prompt as well as the generic needle tag that is
just looking for *any* password prompt as in this case we would regard
the match of the generic needle as not matching the focussed password
prompt needle and therefore wrongly referencing the bug.

Verification runs:
* http://lord.arch.suse.de/tests/2016 (focussed password field from the beginning, no soft-fail)
* http://lord.arch.suse.de/tests/2020#step/user_gui_login/5 (unfocussed password field detected and worked around)
Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/512

Related progress issue: https://progress.opensuse.org/issues/46223