### PR TITLE
Add needle before activating fullscreen

### DIFF
--- a/tests/installation/live_installation.pm
+++ b/tests/installation/live_installation.pm
@@ -18,6 +18,7 @@
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "installbasetest";
+use warnings;
 use testapi;
 use utils;
 use version_utils "is_upgrade";
@@ -55,6 +56,7 @@ sub run {
     assert_screen 'context-menu-more_actions';
     # more
     send_key_and_wait 'alt-m';
+    assert_screen 'more_actions-fullscreen_opt';
     # fullscreen
     send_key_and_wait 'alt-f';
     assert_screen 'fullscreen-mode-information_dialog', 180;


### PR DESCRIPTION
- Related ticket: [[opensuse][functional][y][sporadic] test fails in live_installation](https://progress.opensuse.org/issues/46700)
- Needles: [Check windows fullscreen option in KDE #509](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/509)
- Verification run: [opensuse-15.0-KDE-Live-x86_64-Build20.140-kde-live_installation@64bit-2G](http://eris.suse.cz/tests/11448#step/live_installation/14)
