### PR TITLE
Handle short URLs like cd:/?devices in zypper repos

### DIFF
--- a/tests/console/enable_usb_repo.pm
+++ b/tests/console/enable_usb_repo.pm
@@ -19,7 +19,7 @@ use utils;
 
 sub run {
     select_console 'root-console';
-    my $repo_num = script_output 'zypper lr --uri | grep "hd:///?device=/dev/disk/by-id/usb-" | awk \'{print $1}\'';
+    my $repo_num = script_output 'zypper lr --uri | awk \'$0 ~ /hd:\/(\/\/)?\?device=\/dev\/disk\/by-id\/usb-/ {print $1}\'';
     if ($repo_num !~ /^\d+$/) {
         record_info("Serial polluted", "Serial output was polluted: Assuming first repo is USB", result => 'fail');
         $repo_num = 1;

--- a/tests/update/zypper_clear_repos.pm
+++ b/tests/update/zypper_clear_repos.pm
@@ -35,7 +35,7 @@ sub run {
         # With FATE#320494 the local repository would be disabled after installation
         # in Staging, enable it here.
         clear_console;
-        assert_script_run("grep -rl 'baseurl=cd:///?devices' $repos_folder | xargs --no-run-if-empty sed -i 's/^enabled=0/enabled=1/g'");
+        assert_script_run("grep -rlE 'baseurl=cd:/(//)?\\?devices' $repos_folder | xargs --no-run-if-empty sed -i 's/^enabled=0/enabled=1/g'");
         script_run("zypper lr -d");
         save_screenshot;    # take a screenshot after repo enabled
     }


### PR DESCRIPTION
This is used in newer versions of zypper.

Verification runs:
USB: http://10.160.67.86/tests/308
DVD: http://10.160.67.86/tests/309 (still running)