### PR TITLE
Boot partition is not encrypted for LVM installation on Leap 42.3

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -430,8 +430,10 @@ sub workaround_type_encrypted_passphrase {
     # nothing to do if the boot partition is not encrypted in FULL_LVM_ENCRYPT
     return if get_var('UNENCRYPTED_BOOT');
     return if !get_var('ENCRYPT') && !get_var('FULL_LVM_ENCRYPT');
+    # for Leap 42.3 and SLE 12 codestream the boot partition is not encrypted
+    # Only aarch64 needs separate handling
     # ppc64le on pre-storage-ng boot was part of encrypted LVM
-    return if !get_var('FULL_LVM_ENCRYPT') && !is_storage_ng && !get_var('OFW') && !get_var('UEFI');
+    return if !get_var('FULL_LVM_ENCRYPT') && !is_storage_ng && !get_var('OFW') && !check_var('ARCH', 'aarch64');
     # If the encrypted disk is "just activated" it does not mean that the
     # installer would propose an encrypted installation again
     return if get_var('ENCRYPT_ACTIVATE_EXISTING') && !get_var('ENCRYPT_FORCE_RECOMPUTE');


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/47264
Verification run 
  * Leap 42.3: http://phobos.suse.de/tests/1747030#step/boot_encrypt/3
  * SLE-12-SP5 x86: http://phobos.suse.de/tests/1747031
 