### PR TITLE
handle_uefi_boot_disk_workaround: make use of send_key_until_needlematch

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -301,20 +301,20 @@ sub handle_uefi_boot_disk_workaround {
     wait_screen_change { send_key 'ret' };
     send_key_until_needlematch 'tianocore-boot_from_file', 'down';
     wait_screen_change { send_key 'ret' };
-    save_screenshot;
+    # Device selection: HD or CDROM
+    send_key_until_needlematch 'tianocore-select_HD', 'down';
     wait_screen_change { send_key 'ret' };
     # cycle to last entry by going up in the next steps
     # <EFI>
     send_key 'up';
     save_screenshot;
     wait_screen_change { send_key 'ret' };
-    # <sles>
+    # <sles> or <opensuse>
     send_key 'up';
     save_screenshot;
     wait_screen_change { send_key 'ret' };
     # efi file
-    send_key 'up';
-    save_screenshot;
+    send_key_until_needlematch 'tianocore-select_grubaa64_efi', 'up';
     wait_screen_change { send_key 'ret' };
 }
 


### PR DESCRIPTION
It fixes https://openqa.opensuse.org/tests/849413

- Related ticket: https://progress.opensuse.org/issues/46868
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/511
- Verification run: update_Leap_15.0_gnome@aarch64 with os-autoinst locally on my aarch64 system
