### PR TITLE
Add PoC for scheduling with YAML files

### DIFF
--- a/schedule/lvm_thin_provisioning.yml
+++ b/schedule/lvm_thin_provisioning.yml
@@ -1,0 +1,77 @@
+name:           lvm_thin_provisioning
+description:    >
+    Complete OS deployment with unencrypted LVM drive management.
+    Test creates 2 LVM and BIOS boot partitions.
+    Thin pool and thin lv resides on the second LVM partition,
+    where /home (XFS) is being mounted. Maintainer: mloviska, poo#39023
+conditional_schedule:
+    bootloader:
+        ARCH:
+            x86_64:
+                - installation/isosize
+                - installation/bootloader
+            s390x:
+                - installation/bootloader_zkvm
+            aarch64:
+                - installation/isosize
+                - installation/bootloader_uefi
+    addons_repos:
+        DISTRI:
+            opensuse:
+                - installation/online_repos
+                - installation/installation_mode
+                - installation/logpackages
+            sle:
+                - installation/scc_registration
+                - installation/addon_products_sle
+    hostname_inst:
+        DISTRI:
+            sle:
+                - installation/hostname_inst
+    user_settings_root:
+        DISTRI:
+            sle:
+                - installation/user_settings_root
+    reconnect_mgmt_console:
+        ARCH:
+            s390x:
+                - boot/reconnect_mgmt_console
+    sle15_workarounds:
+        DISTRI:
+            sle:
+                - console/sle15_workarounds
+    opensuse_repos:
+        DISTRI:
+            opensuse:
+                - update/zypper_clear_repos
+                - update/zypper_ar
+                - update/zypper_ref
+
+schedule:
+    - {{bootloader}}
+    - installation/welcome
+    - {{addons_repos}}
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_lvm_thin_provisioning
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - {{hostname_inst}}
+    - installation/user_settings
+    - {{user_settings_root}}
+    - installation/installation_overview
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - installation/grub_test
+    - {{reconnect_mgmt_console}}
+    - installation/first_boot
+    - {{sle15_workarounds}}
+    - console/hostname
+    - console/system_prepare
+    - console/force_scheduled_tasks
+    - {{opensuse_repos}}
+    - shutdown/grub_set_bootargs
+    - '%INSTALLATION_VALIDATION%'


### PR DESCRIPTION
As a part of [poo44420](https://progress.opensuse.org/issues/44420) we
continue to look for a solution for main.pm mess. This approach
simplifies what @okurz did in #6329.
As of now it forbids any conditions which are more complex than ingle
variable match.
This solution won't work straight away for bootloaders, as we have 7 of
them and only combination of 3 of them can decide which one to use. I
believe that's a good indicator that we either should separate those
schedules e.g. by using variable in the file name or having separate
test suite. I strongly believe if we use DASD in the installation it's
not the same test suite as on 64bit qemu. So this approach will force us
to answer those questions.
When trying to combine multiple things (like I did for TW and SLE), we
also will be forced to come up with namings for the conditions, which
will help us to ask ourselves why we have this difference at all and if
it should be there.

Approach can be easily extended to use single file for multiple test
suites, separate file for conditions (to reuse them).

If this solution will get positive feedback, we can start moving some
scenarios to use new scheduling mechanism and start solving issues which
prevent us from migration (e.g. "default" test suite is a mess and has
minor differences in ~10 setups we have for it).

I have intentionally not explained yml file structure to get the feedback how intuitive is it when someone will see it without any explanation.

This is ready to go solution, here if [Verification run](http://f174.suse.de/tests/59#).