### PR TITLE
VMware console resolution, keymap_or_locale fix after rollback

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2018-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -9,6 +9,7 @@
 
 # Summary: The module provides base and helper functions for powering off or rebooting a machine under test.
 # Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
 package power_action_utils;
 
 use base Exporter;
@@ -42,7 +43,7 @@ sub prepare_system_shutdown {
         }
         console('installation')->disable_vnc_stalls;
     }
-    if (check_var('BACKEND', 'svirt')) {
+    if (check_var('VIRSH_VMM_FAMILY', 'xen')) {
         my $vnc_console = get_required_var('SVIRT_VNC_CONSOLE');
         console($vnc_console)->disable_vnc_stalls;
         console('svirt')->stop_serial_grab;
@@ -253,7 +254,7 @@ sub power_action {
         # Look aside before we are sure 'sut' console on VMware is ready, see poo#47150
         select_console('svirt') if is_vmware && $action eq 'reboot';
         reset_consoles;
-        if (check_var('BACKEND', 'svirt') && $action ne 'poweroff') {
+        if (check_var('VIRSH_VMM_FAMILY', 'xen') && $action ne 'poweroff') {
             console('svirt')->start_serial_grab;
         }
         # When 'sut' is ready, select it

--- a/tests/installation/add_serial_console.pm
+++ b/tests/installation/add_serial_console.pm
@@ -34,6 +34,11 @@ sub run {
     assert_script_run('sed -ie \'s/GRUB_TERMINAL.*//\' /etc/default/grub');
     assert_script_run('echo GRUB_TERMINAL_OUTPUT=\"serial gfxterm\" >> /etc/default/grub');
     assert_script_run('echo GRUB_SERIAL_COMMAND=\"serial\" >> /etc/default/grub');
+    # Set expected resolution for GRUB and kernel
+    assert_script_run('sed -ie \'s/GRUB_GFXMODE.*/GRUB_GFXMODE=\"1024x768x32\"/\' /etc/default/grub');
+    assert_script_run('echo GRUB_GFXPAYLOAD_LINUX=\"1024x768x32\" >> /etc/default/grub');
+    assert_script_run('grep ^[[:alpha:]] /etc/default/grub');
+    # Update GRUB
     assert_script_run('grub2-mkconfig -o /boot/grub2/grub.cfg');
 
     # Exit chroot

--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,24 +18,6 @@ use testapi;
 use utils;
 use version_utils 'is_sle';
 use bootloader_setup qw(stop_grub_timeout boot_into_snapshot);
-
-=head2 set_vmware_videomode
-
-bsc#997263 - VMware screen resolution defaults to 800x600
-By default VMware starts with Grub2 in 640x480 mode and then boots the system to
-800x600. To avoid that we need to reconfigure Grub's gfxmode and gfxpayload.
-Permanent - system-wise - solution is in console/consoletest_setup.pm.
-=cut
-sub set_vmware_videomode {
-    return unless check_var('VIRSH_VMM_FAMILY', 'vmware');
-    send_key 'c';
-    type_string 'gfxmode=1024x768x32; gfxpayload=1024x768x32; terminal_output console; terminal_output gfxterm';
-    save_screenshot;
-    send_key 'ret';
-    wait_still_screen;
-    save_screenshot;
-    send_key 'esc';
-}
 
 =head2 handle_installer_medium_bootup
 
@@ -90,7 +72,6 @@ sub run {
     my $tag = get_var('KEEP_GRUB_TIMEOUT') ? 'linux-login' : 'grub2';
     assert_screen_with_soft_timeout($tag, timeout => 2 * $timeout, soft_timeout => $timeout, bugref => 'boo#1120256');
     stop_grub_timeout;
-    set_vmware_videomode;
     boot_into_snapshot if get_var("BOOT_TO_SNAPSHOT");
     send_key_until_needlematch("bootmenu-xen-kernel", 'down', 10, 5) if get_var('XEN');
     if ((check_var('ARCH', 'aarch64') && is_sle && get_var('PLYMOUTH_DEBUG'))

--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -14,7 +14,6 @@ use base "opensusebasetest";
 use strict;
 use testapi;
 use utils;
-use Utils::Backends 'has_ttys';
 
 sub verify_default_keymap_textmode {
     my ($test_string, $tag, %tty) = @_;
@@ -24,9 +23,12 @@ sub verify_default_keymap_textmode {
     }
     else {
         send_key('alt-f3');
-        # some remote backends can not provide a "not logged in console" so we
-        # use a cleared remote terminal instead
-        assert_screen(has_ttys() ? 'linux-login' : 'cleared-console');
+        # Make sure the VT switch happened before matching VT content.
+        wait_still_screen;
+        # Some remote backends cannot provide a "not logged in console", so we
+        # also match cleared console. After snapshot rollback we may end up with
+        # cleared console as well.
+        assert_screen([qw(linux-login cleared-console)]);
     }
 
     type_string($test_string);


### PR DESCRIPTION
Fails here: https://openqa.suse.de/tests/2443252#step/keymap_or_locale/4
Validation run: http://nilgiri.suse.cz/tests/282