### PR TITLE
Move dracut into its own extratest module

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1477,6 +1477,10 @@ sub load_extra_tests_zypper {
     loadtest 'console/validate_packages_and_patterns' if is_sle '12-sp2+';
 }
 
+sub load_extra_tests_dracut {
+    loadtest "console/dracut";
+}
+
 sub load_extra_tests_kdump {
     return unless kdump_is_applicable;
     loadtest "console/kdump_and_crash";
@@ -1557,7 +1561,6 @@ sub load_extra_tests_console {
     loadtest 'console/rpcbind' unless is_jeos;
     # sysauth test scenarios run in the console
     loadtest "sysauth/sssd" if get_var('SYSAUTHTEST');
-    loadtest "console/dracut";
     loadtest 'console/timezone';
     loadtest 'console/procps';
     loadtest "console/lshw" if ((is_sle('15+') && check_var('ARCH', 'ppc64le')) || is_opensuse);


### PR DESCRIPTION
As discussed in poo#47123, we are going to move dracut into its own module.

- requires `dracut` to be added to the `EXTRATEST` variable for the following test suites:
  - `extra_tests_in_textmode`
  - `mau-extratests`
- https://progress.opensuse.org/issues/47123

Verification still running.

SLE:
- 12.1: http://d502.qam.suse.de/tests/479
- 12.4: http://d502.qam.suse.de/tests/481
- 15.0: http://d502.qam.suse.de/tests/477

openSUSE:
- 15.1: http://d502.qam.suse.de/tests/493
- Tumbleweed: http://d502.qam.suse.de/tests/497