### PR TITLE
Select sda if not selected in select_first_disk

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -353,7 +353,8 @@ sub wait_boot {
     # Reset the consoles after the reboot: there is no user logged in anywhere
     reset_consoles;
     # For IPMI machines PXE boot menu will appear first
-    if (check_var('BACKEND', 'ipmi')) {
+    # If KEEP_GRUB_TIMEOUT is set, SUT could be already in linux-login
+    if (check_var('BACKEND', 'ipmi') and !get_var('KEEP_GRUB_TIMEOUT')) {
         select_console 'sol', await_console => 0;
         # boot from harddrive
         assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu pxe-menu)], 200);

--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -373,7 +373,8 @@ sub select_first_hard_disk {
             }
         }
     }
-    assert_screen 'select-hard-disks-one-selected';
+    assert_screen [qw(select-hard-disks-one-selected hard-disk-dev-sda-not-selected)];
+    assert_and_click 'hard-disk-dev-sda-not-selected' if match_has_tag('hard-disk-dev-sda-not-selected');
     send_key $cmd{next};
 }
 


### PR DESCRIPTION
Some months ago, the default partitioner in SLES 15-SP1 selected all available block devices by default (Example 1: http://mango.suse.de/tests/740#step/partitioning_firstdisk/1), so the code in `lib/partition_setup` to select the first disk for installation, simply deselected the rest of the devices (pmem*, sdb, etc.) given the appropiate needles.

This default behavior is currently different in the installer, and only the first device is selected by default (Example 2: http://mango.suse.de/tests/778#step/partitioning_firstdisk/1)

So basically, on systems with several disk and non-disk block devices, it is possible that the installer pre-selects a device that does not correspond to the first disk (see example 2 above), and once the non-first-disk devices are deselected, the installer is left without a device selected for installation (Example 3: http://mango.suse.de/tests/778#step/partitioning_firstdisk/5).

This pull requests ensures that sda is selected even if it did not came pre-selected by the installer.

Also included in the pull request is a fix on `wait_boot` in `lib/opensusebasetest` for when the variable `KEEP_GRUB_TIMEOUT` is used over `IPMI`, which causes `tests/installation/grub_test` (which is called before `test/installation/first_boot`) to reach the `linux-login` needle, so the call to `wait_boot` in `test/installation/first_boot` should not wait for pxe related needles when that variable is set.

- Related ticket: N/A
- Failing test: http://mango.suse.de/tests/767#step/partitioning_firstdisk/5
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1069
- Verification run: http://mango.suse.de/tests/778 (disregard the failing SAP pattern test)
