### PR TITLE
yast_virtualization: xen_tools pattern only available on x86_64

### DIFF
--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -29,8 +29,8 @@ sub run {
     # select everything
     if (check_var('ARCH', 'x86_64')) {
         send_key 'alt-x';    # XEN Server, only available on x86_64: bsc#1088175
+        send_key 'alt-e';    # Xen tools
     }
-    send_key 'alt-e';        # Xen tools
     send_key 'alt-k';        # KVM Server
     send_key 'alt-v';        # KVM tools
     send_key 'alt-l';        # libvirt-lxc


### PR DESCRIPTION
`xen_tools` pattern is not available on non-x86_64, so do not select it on non-x86_64
This fix package installation in https://openqa.opensuse.org/tests/851248#step/yast_virtualization/38

Tested locally on aarch64.
