### PR TITLE
Shortcut is different between fresh install and upgrade

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2016 SUSE LLC
+# Copyright (C) 2015-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -617,7 +617,9 @@ sub fill_in_reg_server {
     }
     else {
         send_key "alt-i";
-        if (is_sle('>=15')) {
+        # Fresh install sles12sp3/4 shortcut is different with upgrade version
+        # Refer https://progress.opensuse.org/issues/47327
+        if ((is_sle('12-sp3+') && is_sle('<15') && get_var('UPGRADE')) || is_sle('>=15')) {
             send_key "alt-l";
         }
         else {


### PR DESCRIPTION
Shortcut is different between fresh install and upgrade

- Related ticket: https://progress.opensuse.org/issues/47327
- Verification run: http://openqa-apac1.suse.de/tests/3252#step/upgrade_select/12
[autoinst-log.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/2853674/autoinst-log.txt)

