### PR TITLE
Virtualization: enhance workaround for bsc#1123942

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -93,18 +93,17 @@ sub login_to_console {
     #use console based on ssh to avoid unstable ipmi
     save_screenshot;
     use_ssh_serial_console;
-}
-
-sub run {
-    my $self = shift;
-    $self->login_to_console;
 
     #workaround for bsc#1123942
     script_run 'll /usr/share/grub2/x86_64-xen/grub.xen /usr/lib/grub2/x86_64-xen/grub.xen';
     my $workaround_cmd = '(cat /etc/os-release | grep 15-SP1) && [ ! -e /usr/lib/grub2/x86_64-xen/grub.xen ] && mkdir -p /usr/lib/grub2/x86_64-xen && ln -s  /usr/share/grub2/x86_64-xen/grub.xen /usr/lib/grub2/x86_64-xen/grub.xen';
     script_run($workaround_cmd);
     script_run 'll /usr/lib/grub2/x86_64-xen/grub.xen';
+}
 
+sub run {
+    my $self = shift;
+    $self->login_to_console;
 }
 
 1;


### PR DESCRIPTION
The workaround should also be used in other reboot_and_wait_up_xx.pm, so move to the function that they call for login, which is based on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6698.


