### PR TITLE
Improve assertion when registration timeout

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -14,7 +14,7 @@
 use strict;
 use base "y2logsstep";
 use testapi;
-use utils qw(addon_license handle_untrusted_gpg_key);
+use utils qw(addon_license handle_untrusted_gpg_key assert_screen_with_soft_timeout);
 use version_utils 'is_sle';
 use qam 'advance_installer_window';
 use registration qw(%SLE15_DEFAULT_MODULES rename_scc_addons @SLE15_ADDONS_WITHOUT_LICENSE);
@@ -154,7 +154,7 @@ sub run {
         set_var('SKIP_INSTALLER_SCREEN', 0);
     }
     $self->process_unsigned_files([qw(inst-addon addon-products)]);
-    assert_screen [qw(inst-addon addon-products)];
+    assert_screen_with_soft_timeout([qw(inst-addon addon-products)], timeout => 60, soft_timeout => 30, 'bsc#1123963');
     if (get_var("ADDONS")) {
         send_key match_has_tag('inst-addon') ? 'alt-k' : 'alt-a';
         # the ISO_X variables must match the ADDONS list


### PR DESCRIPTION
Improve assertion when registration timeout by using `assert_screen_with_soft_timeout`.

- Related ticket: https://progress.opensuse.org/issues/46814
- Verification run: [100 sle-15-SP1-gnome_sled](http://rivera-workstation.suse.cz/tests/overview?distri=sle&version=15-SP1&build=161.1%40jrivera_tests_gnome_sled&groupid=2)
