### PR TITLE
Limit lshw test to ppc64le for now.

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1553,7 +1553,7 @@ sub load_extra_tests_console {
     loadtest "console/dracut";
     loadtest 'console/timezone';
     loadtest 'console/procps';
-    loadtest "console/lshw" if (is_sle('15+') || is_opensuse);
+    loadtest "console/lshw" if ((is_sle('15+') && check_var('ARCH', 'ppc64le')) || is_opensuse);
 }
 
 sub load_extra_tests_docker {


### PR DESCRIPTION
Failure at: https://openqa.suse.de/tests/2441505#step/lshw/12

Starting with 15SP1 lshw is only available on ppc64le at the moment, so this would be needed until https://bugzilla.suse.com/show_bug.cgi?id=1124500 is closed again.

- Related ticket: https://progress.opensuse.org/issues/47165
- Verification run: http://d403.qam.suse.de//tests/23 - the test itself was however not modified, only main_common.pm
