### PR TITLE
Move module install_service after zdup

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -450,11 +450,11 @@ sub load_autoyast_clone_tests {
 
 sub load_zdup_tests {
     loadtest 'installation/setup_zdup';
-    loadtest 'installation/install_service';
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/lock_package";
     }
     loadtest 'installation/zdup';
+    loadtest 'installation/install_service';
     loadtest 'installation/post_zdup';
     # Restrict version switch to sle until opensuse adopts it
     loadtest "migration/version_switch_upgrade_target" if is_sle and get_var("UPGRADE_TARGET_VERSION");


### PR DESCRIPTION
After the zdup_setup, some repos are removed so "no provider for 'vsftpd'". Move the module after zdup then repos are set ready and can install package 'vsftpd'.

- Related ticket: https://progress.opensuse.org/issues/47348
- Needles: N/A
- Verification run: http://openqa-apac1.suse.de/tests/3275#
