### PR TITLE
Remove always_rollback flag from yast2_lan

### DIFF
--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -100,9 +100,4 @@ sub run {
     assert_script_run('getent ahosts ' . get_var("OPENQA_HOSTNAME"));
 }
 
-
-sub test_flags {
-    return {always_rollback => 1};
-}
-
 1;


### PR DESCRIPTION
always_rollback caused failures, as we have installed SuSEfirewall in
yast2_lan, it never had milestone flag, so it just exposed this issue
which always had, as sshd relies on it. Remove that change and schedule
making tests independent from yast2_lan.

See [poo#47318](https://progress.opensuse.org/issues/47318).