### PR TITLE
Wait screen when test navigates to search text field

### DIFF
--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -49,7 +49,7 @@ sub run {
         } else {
             wait_screen_change { send_key 'esc' };
         }
-        send_key 'alt-p';
+        wait_screen_change { send_key 'alt-p' };
     }
     # Testcase according to https://fate.suse.com/318099
     # UC1:


### PR DESCRIPTION
set a timeout before the send_key with the use of wait_screen_change

- Related ticket: https://progress.opensuse.org/issues/47138
- Needles: N/A
- Verification run: http://dhcp131.suse.cz/tests/99#step/yast2_i/11
