### PR TITLE
trinity: add fallback which would upload logs even in case of failure

### DIFF
--- a/tests/kernel/trinity.pm
+++ b/tests/kernel/trinity.pm
@@ -17,18 +17,25 @@ use strict;
 use upload_system_log;
 use repo_tools 'generate_version';
 
+our $trinity_log;
+
 sub run {
     my ($self) = @_;
     $self->select_serial_terminal;
-    my $trinity_log = script_output("echo ~$testapi::username/trinity.log");
+    $trinity_log = script_output("echo ~$testapi::username/trinity.log");
     my $syscall_cnt = 1000000;
     my $repo_url    = 'http://download.suse.de/ibs/home:/asmorodskyi/' . generate_version() . '/';
     zypper_ar($repo_url, 'trinity');
     zypper_call('in trinity');
     assert_script_run("cd  ~$testapi::username");
-    assert_script_run("sudo -u $testapi::username trinity -N$syscall_cnt > $trinity_log", 2000);
+    assert_script_run("sudo -u $testapi::username trinity -N$syscall_cnt", 2000);
     upload_system_logs();
     upload_logs($trinity_log);
 }
 
+sub post_fail_hook {
+    my ($self) = shift;
+    upload_system_logs();
+    upload_logs($trinity_log);
+}
 1;


### PR DESCRIPTION
add fallback which would upload logs even in case of failure

verification run - http://kimball.arch.suse.de/tests/517