### PR TITLE
Wait while screen changes after send_key home

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -266,7 +266,9 @@ sub addlv {
 
     assert_screen 'expert-partitioner';
     send_key $cmd{system_view};
-    send_key 'home';
+    assert_screen_change(sub {
+            send_key 'home';
+    }, 5);
     send_key_until_needlematch('volume_management_feature', 'down');
     wait_still_screen(stilltime => 2, timeout => 4);
     # Expand collapsed list with VGs


### PR DESCRIPTION
- Related ticket: [[sle][functional][y][aarch64][sporadic] test fails in partitioning_full_lvm - Volume Management list stays collapsed](https://progress.opensuse.org/issues/43568)
- Verification run: [lvm-encrypt-separate-boot](http://eris.suse.cz/tests/11694#step/partitioning_full_lvm/45)
