### PR TITLE
Allow partition editing using combinations of data

### DIFF
--- a/lib/Installation/Partitioner/Libstorage/EditProposalSettingsController.pm
+++ b/lib/Installation/Partitioner/Libstorage/EditProposalSettingsController.pm
@@ -15,6 +15,7 @@
 package Installation::Partitioner::Libstorage::EditProposalSettingsController;
 use strict;
 use warnings FATAL => 'all';
+use testapi;
 
 use Installation::Partitioner::Libstorage::SuggestedPartitioningPage;
 use Installation::Partitioner::Libstorage::ProposalSettingsDialog;
@@ -44,30 +45,48 @@ sub get_password_dialog {
     return $self->{PasswordDialog};
 }
 
-sub create_encrypted_partition {
+sub edit_proposal {
     my ($self, %args) = @_;
-    my $password              = $args{password};
-    my $confirmation_password = $args{confirmation_password};
     $self->get_suggested_partitioning_page()->press_edit_proposal_settings_button();
+    $self->_set_partitioning(%args);
+}
+
+sub edit_proposal_for_existing_partition {
+    my ($self, %args) = @_;
+    $self->edit_proposal(%args);
+}
+
+# The method allows to select the required options in Proposed Settings Dialog
+# using method parameters.
+# This allows test to select the specified options, depending on the data that
+# it provides to the method, instead of making different set of methods for all
+# the required test combinations.
+sub _set_partitioning {
+    my ($self, %args) = @_;
+    my $is_lvm       = $args{is_lvm};
+    my $is_encrypted = $args{is_encrypted};
+    if ($is_lvm) {
+        if ($is_encrypted) {
+            $self->_encrypt_with_lvm();
+        }
+        else {
+            $self->get_proposal_settings_dialog()->select_lvm_based_proposal_radiobutton();
+        }
+    }
+    $self->get_proposal_settings_dialog()->press_ok();
+}
+
+sub _encrypt_with_lvm {
+    my ($self) = @_;
     $self->get_proposal_settings_dialog()->select_encrypted_lvm_based_proposal_radiobutton();
-    $self->get_password_dialog()->enter_password($password);
-    $self->get_password_dialog()->enter_password_confirmation($confirmation_password);
+    if (get_var('ENCRYPT_FORCE_RECOMPUTE')) {
+        record_soft_failure('bsc#1108790');
+        return;
+    }
+    $self->get_password_dialog()->enter_password();
+    $self->get_password_dialog()->enter_password_confirmation();
     $self->get_password_dialog()->press_ok();
-    $self->get_proposal_settings_dialog()->press_ok();
-}
 
-sub create_partition {
-    my ($self) = @_;
-    $self->get_suggested_partitioning_page()->press_edit_proposal_settings_button();
-    $self->get_proposal_settings_dialog()->select_lvm_based_proposal_radiobutton();
-    $self->get_proposal_settings_dialog()->press_ok();
-}
-
-sub configure_existing_encrypted_partition {
-    my ($self) = @_;
-    $self->get_suggested_partitioning_page()->press_edit_proposal_settings_button();
-    $self->get_proposal_settings_dialog()->select_encrypted_lvm_based_proposal_radiobutton();
-    $self->get_proposal_settings_dialog()->press_ok();
 }
 
 1;

--- a/lib/Installation/Partitioner/Libstorage/PasswordDialog.pm
+++ b/lib/Installation/Partitioner/Libstorage/PasswordDialog.pm
@@ -23,17 +23,15 @@ use constant {
 };
 
 sub enter_password {
-    my ($self, $password) = @_;
     assert_screen(ENTER_PASSWORD_DIALOG);
     send_key('alt-p');
-    type_password($password);
+    type_password();
 }
 
 sub enter_password_confirmation {
-    my ($self, $password) = @_;
     assert_screen(ENTER_PASSWORD_DIALOG);
     send_key('alt-r');
-    type_password($password);
+    type_password();
 }
 
 sub press_ok {

--- a/lib/Installation/Partitioner/LibstorageNG/PartitioningSchemePage.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/PartitioningSchemePage.pm
@@ -23,7 +23,7 @@ use constant {
     ENABLED_LVM_CHECKBOX     => 'inst-partitioning-lvm-enabled'
 };
 
-sub enable_logical_volume_management {
+sub select_logical_volume_management_checkbox {
     assert_screen(PARTITIONING_SCHEME_PAGE);
     send_key('alt-e');
 }
@@ -40,17 +40,15 @@ sub select_enable_disk_encryption_checkbox {
 }
 
 sub enter_password {
-    my ($self, $password) = @_;
     assert_screen(PARTITIONING_SCHEME_PAGE);
     send_key('alt-p');
-    type_password($password);
+    type_password();
 }
 
 sub enter_password_confirmation {
-    my ($self, $password) = @_;
     assert_screen(PARTITIONING_SCHEME_PAGE);
     send_key('alt-v');
-    type_password($password);
+    type_password();
 }
 
 1;

--- a/lib/Installation/Partitioner/LibstorageNG/TooSimplePasswordDialog.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/TooSimplePasswordDialog.pm
@@ -23,7 +23,7 @@ use constant {
     TOO_SIMPLE_PASSWORD_DIALOG => 'inst-userpasswdtoosimple'
 };
 
-sub agree_with_too_simple_password {
+sub press_ok {
     assert_screen(TOO_SIMPLE_PASSWORD_DIALOG);
     send_key('alt-y');
 }

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2557,18 +2557,16 @@ sub load_transactional_role_tests {
 # Tests to validate partitioning with LVM, both encrypted and not encrypted.
 # Also covered a case while installing on a system with a cryptlvm volume
 # present (e.g. previous clean installation using cryptlvm).
-# If 'ENCRYPT_FORCE_RECOMPUTE' variable is specified, call the test that
-# reconfigures lvm partition, otherwise partition suggestion based on existing
-# cryptlvm should compute encrypted system (currently it refers to bsc#993247).
 sub load_lvm_tests {
     if (get_var("ENCRYPT")) {
-        if (get_var('ENCRYPT_ACTIVATE_EXISTING')) {
-            if (get_var('ENCRYPT_FORCE_RECOMPUTE')) {
-                loadtest 'installation/partitioning/encrypt_lvm_ignore_existing';
-            }
-            else {
-                loadtest 'installation/partitioning/encrypt_lvm_reuse_existing';
-            }
+        # In case if encryption should be explicitly made on the system with
+        # already encrypted partition, the test ignores the existing
+        # partitioning settings and configures them again.
+        if (get_var('ENCRYPT_FORCE_RECOMPUTE') || get_var('ENCRYPT_CANCEL_EXISTING')) {
+            loadtest 'installation/partitioning/encrypt_lvm_ignore_existing';
+        }
+        elsif (get_var('ENCRYPT_ACTIVATE_EXISTING')) {
+            loadtest 'installation/partitioning/encrypt_lvm_reuse_existing';
         }
         else {
             loadtest 'installation/partitioning/encrypt_lvm';

--- a/tests/installation/partitioning/encrypt_lvm.pm
+++ b/tests/installation/partitioning/encrypt_lvm.pm
@@ -18,7 +18,7 @@ use parent "installbasetest";
 
 sub run {
     my $partitioner = $testapi::distri->get_partitioner();
-    $partitioner->create_encrypted_partition(is_lvm => 1);
+    $partitioner->edit_proposal(is_lvm => 1, is_encrypted => 1);
     $partitioner->get_suggested_partitioning_page()->assert_encrypted_partition_with_lvm_shown_in_the_list();
 }
 

--- a/tests/installation/partitioning/encrypt_lvm_ignore_existing.pm
+++ b/tests/installation/partitioning/encrypt_lvm_ignore_existing.pm
@@ -19,7 +19,7 @@ use parent "installbasetest";
 sub run {
     my $partitioner = $testapi::distri->get_partitioner();
     $partitioner->get_suggested_partitioning_page()->check_existing_encrypted_partition_ignored();
-    $partitioner->configure_existing_encrypted_partition(is_lvm => 1);
+    $partitioner->edit_proposal_for_existing_partition(is_lvm => 1, is_encrypted => 1);
     $partitioner->get_suggested_partitioning_page()->assert_encrypted_partition_with_lvm_shown_in_the_list();
 }
 

--- a/tests/installation/partitioning/encrypt_no_lvm.pm
+++ b/tests/installation/partitioning/encrypt_no_lvm.pm
@@ -18,7 +18,7 @@ use parent "installbasetest";
 
 sub run {
     my $partitioner = $testapi::distri->get_partitioner();
-    $partitioner->create_encrypted_partition(is_lvm => 0);
+    $partitioner->edit_proposal(is_lvm => 0, is_encrypted => 1);
     $partitioner->get_suggested_partitioning_page()->assert_encrypted_partition_without_lvm_shown_in_the_list();
 }
 

--- a/tests/installation/partitioning/lvm.pm
+++ b/tests/installation/partitioning/lvm.pm
@@ -18,7 +18,7 @@ use parent "installbasetest";
 
 sub run {
     my $partitioner = $testapi::distri->get_partitioner();
-    $partitioner->create_partition(is_lvm => 1);
+    $partitioner->edit_proposal(is_lvm => 1, is_encrypted => 0);
     $partitioner->get_suggested_partitioning_page()->assert_partition_with_lvm_shown_in_the_list();
 }
 


### PR DESCRIPTION
The commit adds ability to edit suggested partitioning by defining a
different set of data from the test module.

This allows a test to select the specified options, depending on the
data that it provides to the method, instead of making different set
of methods for all the required test combinations.

- Verification run: http://10.160.65.138/tests/839
