### PR TITLE
Exit earlier only when default in pattern selection

### DIFF
--- a/tests/installation/select_patterns_and_packages.pm
+++ b/tests/installation/select_patterns_and_packages.pm
@@ -208,7 +208,8 @@ sub select_specific_patterns_by_iteration {
                 }
             }
         }
-        last unless (scalar keys %patterns);       # exit earlier if all patterns where processed
+        # exit earlier if default and all patterns were processed
+        last if ((get_var('PATTERNS', '') =~ /default/) && !(scalar keys %patterns));
 
         $needs_to_be_selected = 1 if get_var('PATTERNS', '') =~ /all/;
 


### PR DESCRIPTION
Exit earlier only when default in pattern selection.

- Related ticket: https://progress.opensuse.org/issues/46682\
- Verification run: [sle-15-Server-nginx-mru-install-minimal-with-addons](http://rivera-workstation.suse.cz/tests/1698)
