### PR TITLE
Do not trigger YaST investigation in all scenarios

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -277,7 +277,9 @@ sub save_upload_y2logs {
         script_run("cat /var/log/YaST/y2log > /dev/$serialdev");
     }
     save_screenshot();
-    $self->investigate_yast2_failure();
+    # We skip parsing yast2 logs in each installation scenario, but only if
+    # test has failed or we want to explicitly identify failures
+    $self->investigate_yast2_failure() unless $args{skip_logs_investigation};
 }
 
 sub get_available_compression {

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -43,7 +43,8 @@ sub run {
         $self->get_ip_address();
     }
     # We don't change network setup here, so should work
-    $self->save_upload_y2logs(no_ntwrk_recovery => 1);
+    # We don't parse logs unless it's detect_yast2_failures scenario
+    $self->save_upload_y2logs(no_ntwrk_recovery => 1, skip_logs_investigation => !get_var('ASSERT_Y2LOGS'));
 }
 
 sub test_flags {

--- a/variables.md
+++ b/variables.md
@@ -10,6 +10,7 @@ Variable        | Type      | Default value | Details
 ADDONS          | string    |               | Comma separated list of addons to be added using DVD. Also used to indicate addons in the SUT.
 ADDONURL        | string    |               | Comma separated list of addons. Includes addon names to get url defined in ADDONURL_*. For example: ADDONURL=sdk,we ADDONURL_SDK=https://url ADDONURL_WE=ftp://url
 ADDONURL_*      | string    |               | Define url for the addons list defined in ADDONURL
+ASSERT_Y2LOGS   | boolean   | false         | If set to true, we will parse YaST logs after installation and fail test suite in case unknown errors were detected.
 AUTOCONF        | boolean   | false         | Toggle automatic configuration
 AUTOYAST        | string    |               | Full url to the AY profile or relative path if in [data directory of os-autoinst-distri-opensuse repo](https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/data). If value starts with `aytests/`, these profiles are provided by suport server, source code is available in [aytests repo](https://github.com/yast/aytests-tests)
 AUTOYAST_PREPARE_PROFILE | boolean | false | Enable variable expansion in the autoyast profile.


### PR DESCRIPTION
We don't actually need to parse logs in all tests, unless it fails or scenario requires aims it.

See [poo#47102](https://progress.opensuse.org/issues/47102).

#### Verification runs:
 * [detect_yast2_failures](http://f174.suse.de/tests/61)
 * [USB_install](http://f174.suse.de/tests/63)
