### PR TITLE
[WIP] JeOS: Fix aarch64 openSUSE images

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -548,6 +548,11 @@ sub load_jeos_tests {
         return;
     }
     unless (get_var('LTP_COMMAND_FILE')) {
+        if (check_var('ARCH', 'aarch64') && is_opensuse()) {
+            # Enable jeos-firstboot, due to boo#1020019
+            load_boot_tests();
+            loadtest "jeos/prepare_firstboot";
+        }
         load_boot_tests();
         loadtest "jeos/firstrun";
         loadtest "jeos/record_machine_id";

--- a/tests/jeos/prepare_firstboot.pm
+++ b/tests/jeos/prepare_firstboot.pm
@@ -1,0 +1,43 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Enable jeos-firstboot as required by openQA testsuite
+# Maintainer: Guillaume GARDET <guillaume@opensuse.org>
+
+use base "opensusebasetest";
+use strict;
+use testapi;
+use utils 'zypper_call';
+
+sub run {
+    # Login with default credentials (root:linux)
+    assert_screen('linux-login', 300);
+    type_string("root\n", wait_still_screen => 5);
+    type_string("linux\n", wait_still_screen => 5);
+
+    # Ensure YaST2-Firstboot is disabled, as we use jeos-firstboot in openQA
+    script_run("systemctl disable YaST2-Firstboot");
+
+    # Ensure jeos-firstboot is installed
+    zypper_call('in jeos-firstboot');
+
+    # Enable jeos-firstboot for next boot
+    assert_script_run("touch /var/lib/YaST2/reconfig_system");
+    assert_script_run("systemctl enable jeos-firstboot");
+
+    # Remove current root password
+    assert_script_run("sed -i 's/^root:[^:]*:/root:*:/' /etc/shadow", 600);
+
+    # Reboot
+    type_string("reboot\n");
+
+    return;
+}
+
+1;


### PR DESCRIPTION
Still WIP, but feedback welcomed!

JeOS images on openSUSE ARM have no `jeos-firstboot` enabled by default (see: https://bugzilla.opensuse.org/show_bug.cgi?id=1020019), so boot it once to enable `jeos-firstboot` and reboot to usual JeOS test.

Tested with `isotovideo` with:
```
"HDDSIZEGB_1" : 24,
"HDD_1" : "/home/guillaume/openQA_tests/jeos_tw/openSUSE-Tumbleweed-ARM-JeOS-efi.aarch64-2019.02.12-Build.raw.xz",
```
and first tests passed just fine (firstrun, record_machine_id, etc.).