### PR TITLE
Make possible to select not standard PXE image

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -87,6 +87,7 @@ sub run {
             my $device = check_var('BACKEND', 'ipmi') ? "?device=$interface" : '';
             my $release = get_var('BETA') ? 'LATEST' : 'GM';
             $image_name = get_var('ISO') =~ s/.*\/(.*)-DVD-${arch}-.*\.iso/$1-$release/r;
+            $image_name = get_var('PXE_PRODUCT_NAME') if get_var('PXE_PRODUCT_NAME');
             $image_path = "/mounts/dist/install/SLP/${image_name}/${arch}/DVD1/boot/${arch}/loader/linux ";
             $image_path .= "initrd=/mounts/dist/install/SLP/${image_name}/${arch}/DVD1/boot/${arch}/loader/initrd ";
             $image_path .= "install=http://mirror.suse.cz/install/SLP/${image_name}/${arch}/DVD1$device ";

--- a/variables.md
+++ b/variables.md
@@ -76,6 +76,7 @@ PERF_KERNEL | boolean | false | Enables kernel performance testing.
 PERF_INSTALL | boolean | false | Enables kernel performance testing installation part.
 PERF_SETUP | boolean | false | Enables kernel performance testing deployment part.
 PERF_RUNCASE | boolean | false | Enables kernel performance testing run case part.
+PXE_PRODUCT_NAME | string | false | Defines image name for PXE booting
 RAIDLEVEL | integer | | Define raid level to be configured. Possible values: 0,1,5,6,10.
 REGRESSION | string | | Define scope of regression testing, including ibus, gnome, documentation and other.
 REMOTE_REPOINST | boolean | | Use linuxrc features to install OS from specified repository (install) while booting installer from DVD (instsys)


### PR DESCRIPTION
Sometimes, the product name and its corresponding directory in the tftp
tree cannot be derived from the ISO variable. Provide a variable to set
this folder directly.

- Verification run: http://panigale.suse.cz/tests/1423#step/boot_from_pxe/4