### PR TITLE
Take into account the Prague PXE setup

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -912,7 +912,7 @@ sub reconnect_mgmt_console {
     elsif (check_var('ARCH', 'x86_64')) {
         if (check_var('BACKEND', 'ipmi')) {
             select_console 'sol', await_console => 0;
-            assert_screen "qa-net-selection", 300;
+            assert_screen [qw(qa-net-selection prague-pxe-menu)], 300;
             # boot to hard disk is default
             send_key 'ret';
         }


### PR DESCRIPTION
We have a little bit different setup in Prague and the PXE needles have another tag.

- Verification run: http://panigale.suse.cz/tests/1428#step/reconnect_mgmt_console/1
