### PR TITLE
Unschedule rpcbind test on jeos

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1545,7 +1545,7 @@ sub load_extra_tests_console {
     loadtest 'console/mdadm' unless is_jeos;
     loadtest 'console/journalctl';
     loadtest 'console/vhostmd';
-    loadtest 'console/rpcbind';
+    loadtest 'console/rpcbind' unless is_jeos;
     # sysauth test scenarios run in the console
     loadtest "sysauth/sssd" if get_var('SYSAUTHTEST');
     loadtest "console/dracut";


### PR DESCRIPTION
kernel-default-base does not come with the nfsd module needed for the 
test

- Related ticket: https://progress.opensuse.org/issues/46913
- Verification run: http://ccret.suse.cz/tests/2800#
