### PR TITLE
Update mutt test for JeOS

### DIFF
--- a/tests/console/mutt.pm
+++ b/tests/console/mutt.pm
@@ -21,6 +21,7 @@ sub run {
     $self->select_serial_terminal;
 
     zypper_call("in mutt", exitcode => [0, 102, 103]) if (is_tumbleweed || is_jeos);
+    zypper_call("in wget", exitcode => [0, 102, 103]) if is_jeos;
 
     # Mutt is Mutt (bsc#1094717) and has build in support for IMAP and SMTP
     validate_script_output 'mutt -v', sub { m/\+USE_IMAP/ && m/\+USE_SMTP/ && not m/NeoMutt/ };


### PR DESCRIPTION
Install wget since it doesn't come with the JeOS images.

- Related ticket: https://progress.opensuse.org/issues/45788
- Verification run: http://ccret.suse.cz/tests/2801#
