### PR TITLE
Move early exit in pattern selection

### DIFF
--- a/tests/installation/select_patterns_and_packages.pm
+++ b/tests/installation/select_patterns_and_packages.pm
@@ -208,9 +208,6 @@ sub select_specific_patterns_by_iteration {
                 }
             }
         }
-        # exit earlier if default and all patterns were processed
-        last if ((get_var('PATTERNS', '') =~ /default/) && !(scalar keys %patterns));
-
         $needs_to_be_selected = 1 if get_var('PATTERNS', '') =~ /all/;
 
         my $selected = check_screen([qw(current-pattern-selected on-category)], 0);
@@ -228,6 +225,10 @@ sub select_specific_patterns_by_iteration {
         if (!$needs_to_be_selected && $selected) {
             switch_selection(action => 'unselect', needles => [qw(current-pattern-unselected current-pattern-autoselected)]);
         }
+
+        # exit earlier if default and all patterns were processed
+        last if ((get_var('PATTERNS', '') =~ /default/) && !(scalar keys %patterns));
+
         move_down;
     }
     # check if we have processed all patterns mentioned in the test suite settings


### PR DESCRIPTION
Move early exit in pattern selection after select/unselect has been performed.

- Related ticket: https://progress.opensuse.org/issues/46682
- Verification run: (on-going)
  - Reported breaks
    - [Leap-15.1-create_hdd_xfce](http://rivera-workstation.suse.cz/tests/1702)
    - [sle-15-Server-DVD-Incidents-x86_64-Build:10097:systemd-presets-branding-SLE-mru-install-minimal-with-addons@64bit](http://rivera-workstation.suse.cz/tests/1706)

  - Previous verification
    - [Tumbleweed-lvm](http://rivera-workstation.suse.cz/tests/1704)
    - [sle-15-SP1-allpatterns](http://rivera-workstation.suse.cz/tests/1705)
   ~- [Tumbleweed-ext4](http://rivera-workstation.suse.cz/tests/1713)~ (ignore, unrelated failure)
    - [sle-15-SP1-package-dependency](http://rivera-workstation.suse.cz/tests/1708)
    - [sle-12-SP5-create_hdd_minimal_base+sdk_withhome](http://rivera-workstation.suse.cz/tests/1709)
    - [Tumbleweed-create_hdd_gnome-x11](http://rivera-workstation.suse.cz/tests/1710)
    - [Leap-15.1-minimalx](http://rivera-workstation.suse.cz/tests/1712)
    ~- [sle-15-SP1-hpc_installation_dev](http://rivera-workstation.suse.cz/tests/1711)~ (ignore, unrelated failure)