### PR TITLE
Add lvm_ignore_existing test module

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2560,7 +2560,13 @@ sub load_lvm_tests {
         }
     }
     else {
-        loadtest 'installation/partitioning/lvm';
+        if (get_var('ENCRYPT_CANCEL_EXISTING')) {
+            loadtest 'installation/partitioning/lvm_ignore_existing';
+        }
+        else {
+            loadtest 'installation/partitioning/lvm';
+        }
+
     }
 }
 

--- a/tests/installation/partitioning/lvm_ignore_existing.pm
+++ b/tests/installation/partitioning/lvm_ignore_existing.pm
@@ -1,0 +1,25 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The test module ignores a partition that was created on previous
+# installation and configures the partition with LVM. Then verifies that the
+# partition is shown in the partitioning list.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+use strict;
+use warnings FATAL => 'all';
+use parent "installbasetest";
+
+sub run {
+    my $partitioner = $testapi::distri->get_partitioner();
+    $partitioner->edit_proposal_for_existing_partition(is_lvm => 1, is_encrypted => 0);
+    $partitioner->get_suggested_partitioning_page()->assert_partition_with_lvm_shown_in_the_list();
+}
+
+1;


### PR DESCRIPTION
The commit adds the lvm_ignore_existing test module for
lvm+cancel_existing_cryptlvm scenario.

- Related ticket: https://progress.opensuse.org/issues/47384
- Verification Run: http://f174.suse.de/tests/66