### PR TITLE
Do not assert release_notes when creating new partition table

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -69,7 +69,7 @@ sub create_new_partition_table {
         GPT   => 'alt-g',
     );
 
-    assert_screen('release-notes-button');
+    assert_screen 'partitioning-edit-proposal-button';
     send_key $cmd{expertpartitioner};
     if (is_storage_ng) {
         # start with existing configuration


### PR DESCRIPTION
We have separate scenario to validate release notes button, so should not
do that when creating new partition table. This creates more noise than
value.

[Verification run](http://f174.suse.de/tests/65).
