### PR TITLE
Add CaaSP fake update based on grains hack

### DIFF
--- a/data/caasp/update.sh
+++ b/data/caasp/update.sh
@@ -86,7 +86,7 @@ elif [ ! -z "${EXECUTE:-}" ]; then
     if [[ $EXECUTE == cmd.run* ]]; then
         $srun -P "$TARGET" cmd.run "${EXECUTE#* }"
     else
-        $srun -P "$TARGET" "$EXECUTE"
+        $srun -P "$TARGET" $EXECUTE
     fi
 
 elif [ ! -z "${TEST:-}" ]; then

--- a/lib/caasp.pm
+++ b/lib/caasp.pm
@@ -160,7 +160,7 @@ sub get_delayed {
 
 
 # Return update repository without parameters
-# Optional filter for update type [qam|fake|migration]
+# Optional filter for update type [qam|fake|test|migration]
 sub update_scheduled {
     my $type = shift;
 
@@ -174,9 +174,10 @@ sub update_scheduled {
 
     # Filter for update types
     return $repo unless $type;
-    return $repo =~ 'Maintenance' if $type eq 'qam';
-    return $repo =~ 'TestUpdate'  if $type eq 'fake';
-    return $repo =~ 'SCC-proxy'   if $type eq 'migration';
+    return $repo =~ /Maintenance/ if $type eq 'qam';
+    return $repo =~ /FakeUpdate/i if $type eq 'fake';
+    return $repo =~ /TestUpdate/i if $type eq 'test';
+    return $repo =~ /Migration/i  if $type eq 'migration';
     die "Unrecognized type: '$type'";
 }
 

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -155,15 +155,12 @@ sub load_stack_tests {
         loadtest 'caasp/stack_kubernetes';
 
         # CAP deployment needs a lot of resources
-        if (check_var('MACHINE', 'cap_x86_64')) {
-            loadtest 'caasp/stack_cap';
-        }
-        # [Update or] Reboot to check cluster will survive
-        if (update_scheduled) {
-            loadtest 'caasp/stack_update';
-        } else {
-            loadtest 'caasp/stack_reboot';
-        }
+        loadtest 'caasp/stack_cap' if check_var('MACHINE', 'cap_x86_64');
+
+        # Update & Reboot to check cluster will survive
+        loadtest 'caasp/stack_update' if update_scheduled();
+        loadtest 'caasp/stack_reboot';
+
         if (update_scheduled 'migration') {
             loadtest 'caasp/shift_version', name => 'ver=inc';
         }


### PR DESCRIPTION
Original `FakeUpdate` renamed to `TestUpdate` because it is based on update repository.

Fake update will set grains manually and performs update process from velum.

Local run:
 - http://dhcp126.suse.cz/tests/14089#step/stack_update/24 - 4.0 (fails on bsc#1125444)
 - http://dhcp126.suse.cz/tests/14084#step/stack_reboot/36 - 3.0
