### PR TITLE
Get rid of wait_still_screen calls

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -200,6 +200,7 @@ sub select_user_gnome {
 }
 
 sub turn_off_kde_screensaver {
+    select_console 'x11';
     x11_start_program('kcmshell5 screenlocker', target_match => [qw(kde-screenlock-enabled screenlock-disabled)]);
     if (match_has_tag('kde-screenlock-enabled')) {
         assert_and_click('kde-disable-screenlock');
@@ -217,6 +218,7 @@ Disable screensaver in gnome. To be called from a command prompt, for example an
 
 =cut
 sub turn_off_gnome_screensaver {
+    select_console 'user-console';
     script_run 'gsettings set org.gnome.desktop.session idle-delay 0';
 }
 

--- a/tests/yast2_gui/yast2_hostnames.pm
+++ b/tests/yast2_gui/yast2_hostnames.pm
@@ -17,12 +17,23 @@
 use base "y2x11test";
 use strict;
 use testapi;
-use utils qw(type_string_slow clear_console);
+use utils 'clear_console';
+use x11utils qw(turn_off_kde_screensaver turn_off_gnome_screensaver);
 
 sub run {
-    my $self   = shift;
-    my $module = "host";
-
+    my $self         = shift;
+    my $module       = "host";
+    my $dm           = lc get_var('DESKTOP');
+    my $hosts_params = {
+        ip    => '195.135.221.134',
+        fqdn  => 'download.opensuse.org',
+        alias => 'download-srv'
+    };
+    my %execute = (
+        gnome => \&turn_off_gnome_screensaver,
+        kde   => \&turn_off_kde_screensaver
+    );
+    $execute{$dm}->();
     select_console 'root-console';
     #	add 1 entry to /etc/hosts and edit it later
     script_run "echo '80.92.65.53    n-tv.de ntv' >> /etc/hosts";
@@ -30,24 +41,23 @@ sub run {
     select_console 'x11';
     $self->launch_yast2_module_x11($module, match_timeout => 90);
     assert_and_click "yast2_hostnames_added";
-    wait_still_screen 1;
-    wait_screen_change { send_key 'alt-i'; };
-    send_key 'alt-t';
-    type_string 'download-srv';
-    wait_still_screen 1;
-    send_key 'alt-h';
-    type_string 'download.opensuse.org';
-    wait_still_screen 1;
     send_key 'alt-i';
-    type_string_slow '195.135.221.134';
-    assert_and_click 'yast2_hostnames_changed_ok';
+    assert_screen 'yast2_hostnames_edit_popup';
+    send_key 'alt-i';
+    type_string($hosts_params->{ip}, max_interval => 13, wait_still_screen => 0.05, timeout => 5, similarity_level => 38);
+    send_key 'tab';
+    type_string($hosts_params->{fqdn}, max_interval => 13, wait_still_screen => 0.05, timeout => 5, similarity_level => 38);
+    send_key 'tab';
+    type_string($hosts_params->{alias}, max_interval => 13, wait_still_screen => 0.05, timeout => 5, similarity_level => 38);
+    assert_screen 'yast2_hostnames_changed_ok';
+    send_key 'alt-o';
     assert_screen "yast2-$module-ui", 30;
     #	OK => Exit
     send_key "alt-o";
     wait_serial("yast2-$module-status-0") || die 'Fail! YaST2 - Hostnames dialog is not closed or non-zero code returned.';
     # Check that entry was correctly edited in /etc/hosts
     select_console "root-console";
-    assert_script_run q#grep '195\.135\.221\.134\s*download\.opensuse\.org\s*download-srv' /etc/hosts#;
+    assert_script_run qq{grep -E '$hosts_params->{ip}\\s+$hosts_params->{fqdn}\\s+$hosts_params->{alias}' /etc/hosts};
 }
 
 # Test ends in root-console, default post_run_hook does not work here


### PR DESCRIPTION
- Pre-requisite: [Extend arguments for type_string #1106](https://github.com/os-autoinst/os-autoinst/pull/1106)
- Related ticket: [[functional][y] Reduce waiting timeout in yast2_hostnames while cursor is blinking](https://progress.opensuse.org/issues/46679)
- Needles: 
   - [OSD](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1070)
   - [o3](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/514)
- Verification runs: 
  - [sle-12-SP5-Server-DVD-x86_64-Build0122-yast2_gui@64bit](http://eris.suse.cz/tests/12055)
  - [sle-15-SP1-Installer-DVD-x86_64-Build162.2-yast2_gui@64bit](http://eris.suse.cz/tests/12056)
  - [opensuse-15.1-DVD-x86_64-Build411.4-yast2_gui@64bit](http://eris.suse.cz/tests/12044#step/yast2_hostnames/1)
  - [opensuse-Tumbleweed-DVD-x86_64-Build20190209-yast2_gui@64bit](http://eris.suse.cz/tests/12042#step/yast2_hostnames/1)
  - [Failure](http://eris.suse.cz/tests/11922#step/yast2_hostnames/31)