### PR TITLE
Update dracut test for JeOS

### DIFF
--- a/tests/console/dracut.pm
+++ b/tests/console/dracut.pm
@@ -22,8 +22,8 @@ sub run {
 
     assert_script_run("rpm -q dracut");
 
-    validate_script_output("lsinitrd", sub { m/Image:(.*\n)+Version: dracut(-|\d+|\.|\w+)+(\n)+Arguments(.*\n)+dracut modules:(\w+|-|\d+|\n)+\=+\n(l|d|r|w|x|-)+\s+1 root\s+root(.*\n)+\=+/ }, 300);
-    validate_script_output("dracut -f", sub { m/.*Executing: \/usr\/bin\/dracut -f\n(((dracut: |)dracut module.*\n)|((dracut: |)\*+ Including module:.*\n)|((dracut: |)Skipping.*\n)|(.*Could not find.*\n))+(dracut: |)\*+ Including modules done \*+(.+|\n)+/ }, 300);
+    validate_script_output("lsinitrd", sub { m/Image:(.*\n)+( ?)Version: dracut(-|\d+|\.|\w+)+(\n( ?))+( ?)Arguments(.*\n)+( ?)dracut modules:(\w+|-|\d+|\n|( ?))+\=+\n(l|d|r|w|x|-|( ?))+\s+\d+ root\s+root(.*\n)+( ?)\=+/ });
+    validate_script_output("dracut -f", sub { m/.*Executing: \/usr\/bin\/dracut -f\n( ?)(((dracut: |)dracut module.*\n( ?))|((dracut: |)\*+ Including module:.*\n( ?))|((dracut: |)Skipping.*\n( ?))|((dracut: |)Could not find.*\n)|((dracut: |)Possible missing firmware.*\n( ?))|((dracut: |)95nfs).*\n( ?))+(dracut: |)\*+ Including modules done \*+(.+|\n)+/ });
     validate_script_output("dracut --list-modules", sub { m/.*Executing: \/usr\/bin\/dracut --list-modules\n(\w+|\n|-|d+)+/ });
 
     power_action('reboot', textmode => 1);


### PR DESCRIPTION
Update regex used to also match the output on JeOS

- Related ticket: https://progress.opensuse.org/issues/47432
- Verification run:
  SLE 15: http://ccret.suse.cz/tests/2809
  JeOS: http://ccret.suse.cz/tests/2804
