### PR TITLE
Workaround for poo#44771

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -153,6 +153,9 @@ sub handle_untrusted_gpg_key {
 Check that guest IP address that host and guest see is the same.
 =cut
 sub integration_services_check_ip {
+    # Workaround for poo#44771 "Can't call method "exec" on an undefined value"
+    select_console('svirt');
+    select_console('sut');
     # Host-side of Integration Services
     my $vmname = console('svirt')->name;
     my $ips_host_pov;


### PR DESCRIPTION
This is a workaround for poo#44771 "Can't call method "exec" on an
undefined value". It seems that 'svirt' console is not initialized at
this point (perhaps due to a previous `reset_console`) and thus may not
be used.

Validated by three runs on VMware and 2 runs on Hyper-V 2012 R2, where
it always fails (for me and OSD anyway).