### PR TITLE
Fix regexp for pidstat

### DIFF
--- a/tests/console/sysstat.pm
+++ b/tests/console/sysstat.pm
@@ -35,7 +35,7 @@ sub run {
     assert_script_run '/usr/lib64/sa/sa1 5 5';
 
     #Set 24h clock(removes AM/PM extra column), extract a pid number, confirm its an integer
-    validate_script_output "LC_TIME='C' pidstat  |awk '{print \$3}' |head |tail -n 1", sub { m/[1-999]/ };
+    validate_script_output "LC_TIME='C' pidstat  |awk '{print \$3}' |head |tail -n 1", sub { /\d+/ };
 
     #run 5 pidstat iterations, we confirm success counting the UID column spawns
     validate_script_output "pidstat 2 5 |grep  UID |wc -l", sub { /6/ };


### PR DESCRIPTION
The output could be 0 in other architectures
Verification runs: 
- ~~https://openqa.suse.de/tests/2464393 s390x (using custom casedir)~~
- http://phobos.suse.de/tests/1747255 x86

Progress ticket
- https://progress.opensuse.org/issues/44594
