### PR TITLE
Add post_fail_hook to gather zypper logs for further inspection

### DIFF
--- a/tests/ses/deepsea_cluster_deploy.pm
+++ b/tests/ses/deepsea_cluster_deploy.pm
@@ -85,6 +85,11 @@ sub run {
     }
 }
 
+sub post_fail_hook {
+    upload_logs '/var/log/salt/deepsea.log';
+    upload_logs '/var/log/zypper.log';
+}
+
 sub test_flags {
     return {fatal => 1};
 }

--- a/tests/ses/deepsea_testsuite.pm
+++ b/tests/ses/deepsea_testsuite.pm
@@ -65,6 +65,7 @@ sub run {
 
 sub post_fail_hook {
     upload_logs '/var/log/salt/deepsea.log';
+    upload_logs '/var/log/zypper.log';
 }
 
 1;


### PR DESCRIPTION
Zypper logs should ease debugging cluster setup failures