### PR TITLE
Zypper_migration should report failed when catch error message

### DIFF
--- a/tests/migration/sle12_online_migration/zypper_migration.pm
+++ b/tests/migration/sle12_online_migration/zypper_migration.pm
@@ -1,6 +1,6 @@
 # SLE12 online migration tests
 #
-# Copyright © 2016-2018 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -32,7 +32,7 @@ sub run {
     my $zypper_migration_failed       = qr/^Migration failed/m;
     my $zypper_migration_license      = qr/Do you agree with the terms of the license\? \[y/m;
     my $zypper_migration_urlerror     = qr/URI::InvalidURIError/m;
-    my $zypper_migration_reterror     = qr/^No migration available|^Can't get available migrations/m;
+    my $zypper_migration_reterror     = qr/^No migration available|Can't get available migrations/m;
 
     # start migration
     script_run("(zypper migration;echo ZYPPER-DONE) | tee /dev/$serialdev", 0);


### PR DESCRIPTION
Sometimes the wait_serial returns error message output following other strings and cause the judgement for '^XXX' failed then can't report the real failure. Just simple change the condition to remove '^' .

- Related ticket: https://progress.opensuse.org/issues/45506
- Needles: N/A
- Verification run: http://openqa-apac1.suse.de/tests/3316#step/zypper_migration/4
