### PR TITLE
Enable chromium test on aarch64 opensuse

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -587,7 +587,7 @@ sub chromestep_is_applicable {
 }
 
 sub chromiumstep_is_applicable {
-    return chromestep_is_applicable();
+    return chromestep_is_applicable() || (is_opensuse && check_var('ARCH', 'aarch64'));
 }
 
 sub gnomestep_is_applicable {


### PR DESCRIPTION
Chromium is built for aarch64 in openSUSE, so there is no reason to not test it.

Chromium scheduled and passed on verification run: https://openqa.opensuse.org/tests/855184#step/chromium/21