### PR TITLE
Add record_info call to easily track desktop unlock attempts

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -92,6 +92,7 @@ sub ensure_unlocked_desktop {
         }
         wait_still_screen 2;       # slow down loop
         die 'ensure_unlocked_desktop repeated too much. Check for X-server crash.' if ($counter eq 1);    # die loop when generic-desktop not matched
+        record_info('Desktop unlock attempt', "Count: $counter");  # mark attempts to check for unlocked desktop
     }
 }
 


### PR DESCRIPTION
Motivated by [poo#47321](https://progress.opensuse.org/issues/47321) investigation
Demo run: http://phobos.suse.de/tests/1747268#step/brasero_launch/14