### PR TITLE
Provide test data as logs for sssd test module

### DIFF
--- a/tests/sysauth/sssd.pm
+++ b/tests/sysauth/sssd.pm
@@ -36,6 +36,9 @@ sub run {
     }
     script_run "zypper -n refresh && zypper -n in @test_subjects";
     script_run "cd; curl -L -v " . autoinst_url . "/data/sssd-tests > sssd-tests.data && cpio -id < sssd-tests.data && mv data sssd && ls sssd";
+    # save and upload sssd-tests.data
+    assert_script_run "tar czf /tmp/sssd-tests.data.tar.bz2 sssd-tests.data";
+    upload_logs "/tmp/sssd-tests.data.tar.bz2";
 
     # Get sssd version, as 2.0+ behaves differently
     my $sssd_version = script_output('rpm -q sssd --qf \'%{VERSION}\'');


### PR DESCRIPTION
we have issue with sssd which failed for quite long time.
I filed a bug which is not clear to developer because test data
is not available.
see https://bugzilla.opensuse.org/show_bug.cgi?id=1125277
and https://progress.opensuse.org/issues/47939

test verification run:
http://f40.suse.de/tests/1227
logs uploaded:
http://f40.suse.de/tests/1227/file/sssd-sssd-tests.data.tar.bz2