### PR TITLE
Separate tidy targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,9 +43,9 @@ and additionally the following rules:
   `$self` object. Do not parse any parameter if you do not need any.
 * [DRY](https://en.wikipedia.org/wiki/Don't_repeat_yourself)
 * Every pull request is tested by the travis CI by calling the equivalent of
-  `make test` on the tests. It is recommended to call `tools/tidy` locally to
-  fix the style of your changes before providing a pull request. Call `make
-  test` to conduct all tests.
+  `make test` on the tests. It is recommended to call `tools/tidy` or
+  `make tidy` locally to fix the style of your changes before providing a
+  pull request. Call `make test` to conduct all tests.
 
 
 Also see the

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,12 @@ tools/lib/: os-autoinst/
 check-links: tools/tidy tools/lib/ os-autoinst/
 
 .PHONY: check-links
-tidy: check-links
+tidy-check: check-links
 	tools/tidy --check
+
+.PHONY: tidy
+tidy:
+	tools/tidy
 
 .PHONY: unit-test
 unit-test:
@@ -77,7 +81,7 @@ test-no-wait_idle:
 	@! git --no-pager grep wait_idle lib/ tests/
 
 .PHONY: test-static
-test-static: tidy test-merge test-dry test-no-wait_idle test-unused-modules test-soft_failure-no-reference
+test-static: tidy-check test-merge test-dry test-no-wait_idle test-unused-modules test-soft_failure-no-reference
 
 .PHONY: test
 ifeq ($(TESTS),compile)


### PR DESCRIPTION
Calling 'make tidy' seems more natural than tools/tidy.