### PR TITLE
Use 'wait_grub' instead of custom grub2 handling

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -358,7 +358,7 @@ sub wait_grub {
       if (is_aarch64_uefi_boot_hdd
         && !$in_grub
         && (!(isotovideo::get_version() >= 12 && get_var('UEFI_PFLASH_VARS')) || get_var('ONLINE_MIGRATION')));
-    check_screen(\@tags, $bootloader_time);
+    assert_screen(\@tags, $bootloader_time);
     if (match_has_tag("bootloader-shim-import-prompt")) {
         send_key "down";
         send_key "ret";

--- a/tests/boot/grub_test_snapshot.pm
+++ b/tests/boot/grub_test_snapshot.pm
@@ -9,7 +9,7 @@
 # without any warranty.
 
 # Summary: Select 'snapshot' boot option from grub menu
-# Maintainer: dmaiocchi <dmaiocchi@suse.com>
+# Maintainer: okurz <okurz@suse.de>
 
 use strict;
 use base 'opensusebasetest';
@@ -24,16 +24,7 @@ sub run {
     select_console 'root-console';
     power_action('reboot', keepconsole => 1, textmode => 1);
     reset_consoles;
-    $self->handle_uefi_boot_disk_workaround if (get_var('MACHINE') =~ /aarch64/ && get_var('UEFI') && get_var('BOOT_HDD_IMAGE'));
-
-    my @tags = ('grub2');
-    push @tags, 'encrypted-disk-password-prompt' if get_var('ENCRYPT');
-    assert_screen(\@tags, 200);
-    if (match_has_tag('encrypted-disk-password-prompt')) {
-        workaround_type_encrypted_passphrase;
-        assert_screen 'grub2', 15;
-    }
-    stop_grub_timeout;
+    $self->wait_grub(bootloader_time => 200);
     boot_into_snapshot;
 }
 sub test_flags {

--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -42,7 +42,6 @@ sub handle_installer_medium_bootup {
 
 sub bug_workaround_bsc1005313 {
     record_soft_failure "Running with plymouth:debug to catch bsc#1005313" if get_var('PLYMOUTH_DEBUG');
-
     send_key 'e';
     # Move to end of kernel boot parameters line
     send_key_until_needlematch "linux-line-selected", "down";

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -27,7 +27,8 @@ sub login_to_console {
     select_console 'sol', await_console => 0;
 
     # Wait for bootload for the first time.
-    assert_screen([qw(grub2 grub1)], 210);
+    $self->wait_grub(bootloader_time => 210);
+    send_key 'ret';
 
     if (!get_var("reboot_for_upgrade_step")) {
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {

--- a/tests/virt_autotest/proxymode_login_proxy.pm
+++ b/tests/virt_autotest/proxymode_login_proxy.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -17,10 +17,11 @@ use base "opensusebasetest";
 use testapi;
 
 sub run {
+    my ($self) = @_;
     assert_screen "bootloader";
     send_key "ret";
-    assert_screen "grub2", 10;
-    send_key "ret";
+    $self->wait_for_boot_menu(bootloader_time => 10);
+    send_key 'ret';
     assert_screen "displaymanager", 300;
     select_console('root-console');
 }

--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -55,10 +55,7 @@ sub run {
     send_key "alt-l";
     $self->{in_wait_boot} = 1;
     power_action('reboot', keepconsole => 1, textmode => 1);
-    $self->handle_uefi_boot_disk_workaround() if get_var('MACHINE') =~ qr'aarch64';
-    assert_screen "grub2";
-    send_key 'up';
-
+    $self->wait_grub(bootloader_time => 90);
     send_key_until_needlematch("boot-menu-snapshot", 'down', 10, 5);
     send_key 'ret';
     $self->{in_wait_boot} = 0;


### PR DESCRIPTION
Reduce code duplication and use a common approach. This also fixes the use
of bootloader specific workaround code, e.g. as described in
https://progress.opensuse.org/issues/11948#note-47

Verification runs:
* extra_tests_on_gnome SLE: https://openqa.suse.de/t2496058
* extra_tests_in_textmode: https://openqa.opensuse.org/t862134
* minimalx@aarch64: https://openqa.opensuse.org/t862517

Related progress issue: https://progress.opensuse.org/issues/48008