### PR TITLE
[WIP] Add error detection for journalctl

### DIFF
--- a/lib/known_bugs.pm
+++ b/lib/known_bugs.pm
@@ -22,6 +22,7 @@ use version_utils;
 
 our @EXPORT = qw(
   create_list_of_serial_failures
+  check_journal
 );
 
 sub create_list_of_serial_failures {
@@ -52,6 +53,17 @@ sub create_list_of_serial_failures {
     push @$serial_failures, {type => 'hard', message => 'CPU soft lockup detected', pattern => quotemeta 'soft lockup - CPU'} unless check_var('ARCH', 'aarch64');
 
     return $serial_failures;
+}
+
+
+# check_journal module=>'sshd'
+sub check_journal {
+    my (%args) = @_;
+    my $module = $args{module};
+    my $command = ($module ? "journalctl -u $module" : "journalctl" );
+
+    select_console 'root-console';
+    assert_script_run "$command >> /dev/$serialdev \n";
 }
 
 1;

--- a/tests/console/prepare_test_data.pm
+++ b/tests/console/prepare_test_data.pm
@@ -15,8 +15,10 @@ use testapi;
 use utils;
 use Utils::Backends 'use_ssh_serial_console';
 use strict;
+use known_bugs 'check_journal';
 
 sub run {
+    check_journal (module => 'sshd');
     check_var("BACKEND", "ipmi") ? use_ssh_serial_console : select_console 'root-console';
 
     select_console 'user-console';


### PR DESCRIPTION
Printing journalctl output to $serialdev for debugging in
post_fail_hook

- Related ticket: https://progress.opensuse.org/issues/46988
- Verification run: tbd
