### PR TITLE
hpc: update installation flow to SLE15 SP1

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -966,10 +966,10 @@ sub load_inst_tests {
         elsif (is_caasp 'kubic') {
             loadtest "installation/kubeadm_settings" if check_var('SYSTEM_ROLE', 'kubeadm');
         } else {
-            loadtest "installation/user_settings";
+            loadtest "installation/user_settings" unless check_var('SYSTEM_ROLE', 'hpc-node');
         }
         if (is_sle || get_var("DOCRUN") || get_var("IMPORT_USER_DATA") || get_var("ROOTONLY")) {    # root user
-            loadtest "installation/user_settings_root" unless check_var('SYSTEM_ROLE', 'hpc-node') || check_var('SYSTEM_ROLE', 'hpc-server');
+            loadtest "installation/user_settings_root" unless check_var('SYSTEM_ROLE', 'hpc-server');
         }
         if (get_var('PATTERNS') || get_var('PACKAGES')) {
             loadtest "installation/installation_overview_before";


### PR DESCRIPTION
update installation flow to SLE15 SP1 .
While installing HPC Node system role installer is asking for root credentials only this was not like this in SLE 15 

prove run -  http://kimball.arch.suse.de/tests/533