### PR TITLE
Save /var/log/salt and /srv/pillar/ceph upon failures

### DIFF
--- a/tests/ses/deepsea_cluster_deploy.pm
+++ b/tests/ses/deepsea_cluster_deploy.pm
@@ -86,8 +86,13 @@ sub run {
 }
 
 sub post_fail_hook {
-    upload_logs '/var/log/salt/deepsea.log', failok => 1;
-    upload_logs '/var/log/zypper.log',       failok => 1;
+    select_console('log-console');
+    assert_script_run "tar czf /tmp/logs-salt.tar.bz2 /var/log/salt";
+    assert_script_run "tar czf /tmp/srv-pillar-ceph.tar.bz2 /srv/pillar/ceph";
+    upload_logs '/tmp/logs-salt.tar.bz2',	failok => 1;
+    upload_logs '/tmp/srv-pillar-ceph.tar.bz2', failok => 1;
+    upload_logs '/var/log/salt/deepsea.log',	failok => 1;
+    upload_logs '/var/log/zypper.log',		failok => 1;
 }
 
 sub test_flags {


### PR DESCRIPTION
Try to get more logs to track down cluster deployment issues
