### PR TITLE
Disable t-u self-update during tests

### DIFF
--- a/lib/transactional_system.pm
+++ b/lib/transactional_system.pm
@@ -90,7 +90,7 @@ sub trup_call {
     $cmd .= " > /dev/$serialdev";
     $cmd .= " ; echo trup-\$?- > /dev/$serialdev" if $check;
 
-    script_run "transactional-update $cmd", 0;
+    script_run "transactional-update --no-selfupdate $cmd", 0;
     if ($cmd =~ /pkg |ptf /) {
         if (wait_serial "Continue?") {
             send_key "ret";


### PR DESCRIPTION
Stagings are broken because t-u self-updates and pulls through an already published update

There's no reason we should ever use self-updating on openQA, so disable it
