### PR TITLE
 Do not switch consoles to disable ipv6 and ipv4 on NM tests

### DIFF
--- a/tests/x11/network/NM_wpa2_enterprise.pm
+++ b/tests/x11/network/NM_wpa2_enterprise.pm
@@ -28,7 +28,8 @@ sub run {
     become_root;
     # disable IPv4 and IPv6 so NM thinks we are online even without dhcp
     $self->NM_disable_ip;
-    wait_screen_change { send_key 'alt-f4' }
+    type_string "exit\n";
+    type_string "exit\n";
 
     # connect again to see if NM has a "connection" after we disabled v4 and v6
     $self->connect_to_network;


### PR DESCRIPTION
The test nm wpa enterprise tries to switch to root console at some point
so that it can disable ipv6 and ipv4 just to trick nm that we're online
switching makes the test fail from time to time, due to the wrong tty
being selected or passwords not matching somehow. Instead open a
terminal in the x11 console and do everything from there.

- Related ticket: [poo#45710](https://progress.opensuse.org/issues/45710)
- Verification:
  - [alt-f4 does not close](http://phobos.suse.de/tests/1747258#step/NM_wpa2_enterprise/30)
  - [type exit twice :)](http://phobos.suse.de/tests/1747259)