### PR TITLE
Utilize autoyast for baremetal testing

### DIFF
--- a/data/autoyast_qam/12_installation.xml.ep
+++ b/data/autoyast_qam/12_installation.xml.ep
@@ -43,6 +43,9 @@
   </bootloader>
   <general>
     <mode>
+      % if ($check_var->('BACKEND', 'ipmi') or $check_var->('BACKEND', 'svirt')) {
+      <final_reboot config:type="boolean">true</final_reboot>
+      % }
       <confirm config:type="boolean">false</confirm>
     </mode>
     <signature-handling>
@@ -100,6 +103,12 @@
       % }
     </patterns>
   </software>
+  <partitioning config:type="list">
+  <drive>
+    <initialize config:type="boolean">true</initialize>
+    <use>all</use>
+    </drive>
+  </partitioning>
   <networking>
     <interfaces config:type="list">
       <interface>

--- a/data/autoyast_qam/15_installation.xml.ep
+++ b/data/autoyast_qam/15_installation.xml.ep
@@ -43,6 +43,9 @@
   </bootloader>
   <general>
     <mode>
+      % if ($check_var->('BACKEND', 'ipmi') or $check_var->('BACKEND', 'svirt')) {
+      <final_reboot config:type="boolean">true</final_reboot>
+      % }
       <confirm config:type="boolean">false</confirm>
     </mode>
     <signature-handling>
@@ -99,15 +102,21 @@
       <pattern><%= $pattern %></pattern>
       % }
     </patterns>
-  <services-manager>
-    <services>
-      <disable config:type="list"/>
-      <enable config:type="list">
-        <service>sshd</service>
-      </enable>
-    </services>
-  </services-manager>
+    <services-manager>
+      <services>
+        <disable config:type="list"/>
+        <enable config:type="list">
+          <service>sshd</service>
+        </enable>
+      </services>
+    </services-manager>
   </software>
+  <partitioning config:type="list">
+  <drive>
+    <initialize config:type="boolean">true</initialize>
+    <use>all</use>
+    </drive>
+  </partitioning>
   <networking>
     <interfaces config:type="list">
       <interface>

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -59,6 +59,7 @@ our @EXPORT = qw(
   kdump_is_applicable
   load_autoyast_clone_tests
   load_autoyast_tests
+  load_ayinst_tests
   load_bootloader_s390x
   load_boot_tests
   load_common_installation_steps_tests
@@ -780,6 +781,13 @@ sub load_common_installation_steps_tests {
         loadtest 'installation/logs_from_installation_system';
     }
     loadtest 'installation/reboot_after_installation';
+}
+
+sub load_ayinst_tests {
+    loadtest("autoyast/installation");
+    loadtest("autoyast/console");
+    loadtest("autoyast/login");
+    loadtest("autoyast/autoyast_reboot");
 }
 
 sub load_inst_tests {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -523,8 +523,9 @@ sub mellanox_config {
 }
 
 sub load_baremetal_tests {
+    loadtest "autoyast/prepare_profile" if get_var "AUTOYAST_PREPARE_PROFILE";
     load_boot_tests();
-    load_inst_tests();
+    get_var("AUTOYAST") ? load_ayinst_tests() : load_inst_tests();
     load_reboot_tests();
 }
 


### PR DESCRIPTION
Speed up installation over IPMI by utilizing autoyast installation
procedure with QAM profiles. This should also fix issue with QR images
over svirt backend for s390x architecture.

- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1072
- Verification run: http://panigale.suse.cz/tests/1456
