### PR TITLE
Enable installation of kernel-rt

### DIFF
--- a/data/autoyast_qam/12_installation.xml.ep
+++ b/data/autoyast_qam/12_installation.xml.ep
@@ -19,6 +19,9 @@
         % if ($key eq 'we' and $check_var->('SLE_PRODUCT', 'sled')) {
         <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
         % }
+        % if ($key eq 'rt') {
+        <reg_code><%= $get_var->('SCC_REGCODE_RT') %></reg_code>
+        % }
         % if ($key eq 'ltss') {
         <reg_code><%= $get_var->('SCC_REGCODE_LTSS') %></reg_code>
         % }
@@ -94,6 +97,9 @@
     <products config:type="list">
       <product><%= uc $get_var->('SLE_PRODUCT') %></product>
     </products>
+    % if ($get_var->('SCC_ADDONS') =~ m/\brt\b/) {
+    <kernel>kernel-rt</kernel>
+    % }
     <patterns config:type="list">
       % for my $pattern (@$patterns) {
       <pattern><%= $pattern %></pattern>

--- a/data/autoyast_qam/15_installation.xml.ep
+++ b/data/autoyast_qam/15_installation.xml.ep
@@ -19,6 +19,9 @@
         % if ($key eq 'we' and $check_var->('SLE_PRODUCT', 'sled')) {
         <reg_code><%= $get_var->('SCC_REGCODE') %></reg_code>
         % }
+        % if ($key eq 'rt') {
+        <reg_code><%= $get_var->('SCC_REGCODE_RT') %></reg_code>
+        % }
         % if ($key eq 'ltss') {
         <reg_code><%= $get_var->('SCC_REGCODE_LTSS') %></reg_code>
         % }
@@ -94,6 +97,9 @@
     <products config:type="list">
       <product><%= uc $get_var->('SLE_PRODUCT') %></product>
     </products>
+    % if ($get_var->('SCC_ADDONS') =~ m/\brt\b/) {
+    <kernel>kernel-rt</kernel>
+    % }
     <patterns config:type="list">
       % for my $pattern (@$patterns) {
       <pattern><%= $pattern %></pattern>

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -585,6 +585,7 @@ sub get_addon_fullname {
         lgm       => 'sle-module-legacy',
         ltss      => 'SLES-LTSS',
         pcm       => 'sle-module-public-cloud',
+        rt        => 'SUSE-Linux-Enterprise-RT',
         script    => 'sle-module-web-scripting',
         serverapp => 'sle-module-server-applications',
         tcm       => 'sle-module-toolchain',


### PR DESCRIPTION
Definitions of RT product were missing.

- Verification run: http://panigale.suse.cz/tests/1456
