### PR TITLE
Increase timeout of zypper patch

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -392,7 +392,7 @@ sub zypper_call {
 
 sub fully_patch_system {
     # first run, possible update of packager -- exit code 103
-    zypper_call('patch --with-interactive -l', exitcode => [0, 102, 103], timeout => 1500);
+    zypper_call('patch --with-interactive -l', exitcode => [0, 102, 103], timeout => 3000);
     # second run, full system update
     zypper_call('patch --with-interactive -l', exitcode => [0, 102], timeout => 6000);
 }


### PR DESCRIPTION
[Increase timeout of zypper patch command]

NOTE:if you look result of https://openqa.suse.de/tests/overview?distri=sle&version=15-SP1&build=169.1&groupid=111, many test cases failed on patch_sle.
After rerun the test case, the issue not reproduce, so i suspect the env performance issue happen during busy timing, to avoid this kind of failed cases, i increase the timeout value.

- Related ticket: https://progress.opensuse.org/issues/47366
- Needles: n/a
- Verification run: n/a
