### PR TITLE
[AARCH64 Automation] Add ipv6.disable=1 to kernel installation

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -98,6 +98,7 @@ sub run {
         send_key "tab";
     }
     if (check_var('BACKEND', 'ipmi')) {
+        $image_path .= "ipv6.disable=1 " if get_var('LINUX_BOOT_IPV6_DISABLE');
         $image_path .= "ifcfg=$interface=dhcp4 " unless get_var('NETWORK_INIT_PARAM');
         $image_path .= 'plymouth.enable=0 ';
     }

--- a/variables.md
+++ b/variables.md
@@ -53,6 +53,7 @@ IPXE | boolean | false | Indicates ipxe boot.
 ISO_MAXSIZE | integer | | Max size of the iso, used in `installation/isosize.pm`.
 KEEP_ONLINE_REPOS | boolean | false | openSUSE specific variable, not to replace original repos in the installed system with snapshot mirrors which are not yet published.
 LAPTOP |||
+LINUX_BOOT_IPV6_DISABLE | boolean | false | If set, boots linux kernel with option named "ipv6.disable=1" which disables IPv6 from startup.
 LIVECD | boolean | false | Indicates live image being used.
 LIVE_INSTALLATION | boolean | false | If set, boots the live media and starts the builtin NET installer.
 LIVE_UPGRADE | boolean | false | If set, boots the live media and starts the builtin NET installer in upgrade mode.


### PR DESCRIPTION
Some vendor machines can not locate installation media because its ethernet interface tries to communciate with IPv6 only.

- Related ticket: aarch64 automation
- Needles: n/a
- Verification run: http://10.162.187.154/tests/1089

@alice-suse @guoxuguang @Julie-CAO 