### PR TITLE
s390x: Add capability of multiple disks to s390x-kvm

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -796,9 +796,15 @@ sub zkvm_add_disk {
         }
     }
     else {
-        # For some tests we need more than the default 4GB
+        # Add new disks according to NUMDISKS
         my $size_i = get_var('HDDSIZEGB') || '4';
-        $svirt->add_disk({size => $size_i . "G", create => 1, dev_id => 'a'});
+        my $numdisks = get_var('NUMDISKS') || '1';
+        my $dev_id = 'a';
+        foreach my $n (1 .. $numdisks) {
+            $svirt->add_disk({size => $size_i . "G", create => 1, dev_id => $dev_id});
+            # apply next letter as dev_id
+            $dev_id = chr((ord $dev_id) + 1);
+        }
     }
 }
 


### PR DESCRIPTION
[progress ticket](https://progress.opensuse.org/issues/48071)
[Verification run](http://opeth.suse.de/tests/4083/file/autoinst-log.txt):

```
[2019-02-19T09:30:18.644 CET] [debug] /var/lib/openqa/share/tests/sle/tests/installation/bootloader_zkvm.pm:70 called bootloader_setup::zkvm_add_disk
[2019-02-19T09:30:18.644 CET] [debug] <<< backend::console_proxy::__ANON__(wrapped_call={
  'function' => 'add_disk',
  'args' => [
              {
                'create' => 1,
                'size' => '40G',
                'dev_id' => 'a'
              }
            ],
  'console' => 'svirt'
})
[2019-02-19T09:30:18.647 CET] [debug] Command executed: qemu-img create /var/lib/libvirt/images/openQA-SUT-5a.img 40G -f qcow2
[2019-02-19T09:30:18.680 CET] [debug] Command's stdout:
Formatting '/var/lib/libvirt/images/openQA-SUT-5a.img', fmt=qcow2 size=42949672960 cluster_size=65536 lazy_refcounts=off refcount_bits=16
[2019-02-19T09:30:18.896 CET] [debug] /var/lib/openqa/share/tests/sle/tests/installation/bootloader_zkvm.pm:70 called bootloader_setup::zkvm_add_disk
[2019-02-19T09:30:18.897 CET] [debug] <<< backend::console_proxy::__ANON__(wrapped_call={
  'console' => 'svirt',
  'args' => [
              {
                'create' => 1,
                'size' => '40G',
                'dev_id' => 'b'
              }
            ],
  'function' => 'add_disk'
})
[2019-02-19T09:30:18.899 CET] [debug] Command executed: qemu-img create /var/lib/libvirt/images/openQA-SUT-5b.img 40G -f qcow2
[2019-02-19T09:30:18.930 CET] [debug] Command's stdout:
Formatting '/var/lib/libvirt/images/openQA-SUT-5b.img', fmt=qcow2 size=42949672960 cluster_size=65536 lazy_refcounts=off refcount_bits=16
```