### PR TITLE
Add autoyast keyboard layout test

### DIFF
--- a/data/autoyast_sle15/autoyast_keyboard_layout.xml
+++ b/data/autoyast_sle15/autoyast_keyboard_layout.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <!-- autoyast profile which performs an unattended installation using
+    different keyboard layout and language than default us -->
+    <suse_register>
+      <do_registration config:type="boolean">true</do_registration>
+      <email/>
+      <reg_code>{{SCC_REGCODE}}</reg_code>
+      <install_updates config:type="boolean">true</install_updates>
+      <reg_server>{{SCC_URL}}</reg_server>
+      <addons config:type="list">
+        <addon>
+          <name>sle-module-basesystem</name>
+          <version>{{VERSION}}</version>
+          <arch>{{ARCH}}</arch>
+        </addon>
+      </addons>
+    </suse_register>
+    <bootloader>
+        <global>
+            <timeout config:type="integer">-1</timeout>
+        </global>
+    </bootloader>
+    <general>
+        <mode>
+            <confirm config:type="boolean">false</confirm>
+        </mode>
+    </general>
+    <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <software>
+        <products config:type="list">
+            <product>SLES</product>
+        </products>
+    </software>
+    <users config:type="list">
+        <user>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <language>
+         <language>cs_CZ</language>
+    </language>
+    <keyboard>
+         <keymap>czech</keymap>
+    </keyboard>
+    <report>
+      <errors>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">false</show>
+      </errors>
+      <messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">false</show>
+      </messages>
+      <warnings>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">false</show>
+      </warnings>
+      <yesno_messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">false</show>
+      </yesno_messages>
+    </report>
+</profile>

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -414,7 +414,8 @@ sub load_reboot_tests {
     if (installyaststep_is_applicable()) {
         # test makes no sense on s390 because grub2 can't be captured
         if (!(check_var("ARCH", "s390x") or (check_var('VIRSH_VMM_FAMILY', 'xen') and check_var('VIRSH_VMM_TYPE', 'linux')))) {
-            loadtest "installation/grub_test";
+            # exclude this scenario for autoyast test with switched keyboard layaout
+            loadtest "installation/grub_test" unless get_var('INSTALL_KEYBOARD_LAYOUT');
             if ((snapper_is_applicable()) && get_var("BOOT_TO_SNAPSHOT")) {
                 loadtest "installation/boot_into_snapshot";
             }
@@ -426,7 +427,8 @@ sub load_reboot_tests {
                 loadtest "boot/reconnect_mgmt_console";
             }
         }
-        loadtest "installation/first_boot";
+        # exclude this scenario for autoyast test with switched keyboard layaout
+        loadtest "installation/first_boot" unless get_var('INSTALL_KEYBOARD_LAYOUT');
         if (check_var('ARCH', 'aarch64') && !get_var('INSTALLONLY')) {
             loadtest "installation/system_workarounds";
         }
@@ -467,6 +469,8 @@ sub load_zdup_tests {
 sub load_autoyast_tests {
     #    init boot in load_boot_tests
     loadtest("autoyast/installation");
+    #   library function like send_key or reboot will not work, therefore exiting earlier
+    return loadtest "locale/keymap_or_locale" if get_var('INSTALL_KEYBOARD_LAYOUT');
     loadtest("autoyast/console");
     loadtest("autoyast/login");
     loadtest("autoyast/wicked");

--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -15,9 +15,23 @@ use strict;
 use testapi;
 use utils;
 
+sub verify_default_keymap_textmode_non_us {
+    my ($test_string, $tag) = @_;
+    # Installation with different keyboard layout is not feature ready but
+    # in case of autoyast scenarios we can simply test on login prompt without changing tty
+    type_string $test_string;
+    assert_screen ["${tag}", "${tag}_not_ready"];
+    if (match_has_tag "${tag}_not_ready") {
+        # i.e: in cz keyboard the first half in the keystroke list is not displayed in 1st login'
+        send_key 'ret' for (1 .. 2);
+        record_soft_failure 'bsc#1125886 - Special characters when switching keyboard layout only available after 2nd login';
+        assert_screen([qw(linux-login cleared-console)]);
+        type_string $test_string;
+        assert_screen "${tag}";
+    }
+}
 sub verify_default_keymap_textmode {
     my ($test_string, $tag, %tty) = @_;
-
     if (defined($tty{console})) {
         select_console($tty{console});
     }
@@ -30,7 +44,6 @@ sub verify_default_keymap_textmode {
         # cleared console as well.
         assert_screen([qw(linux-login cleared-console)]);
     }
-
     type_string($test_string);
     assert_screen($tag);
     # clear line in order to add user bernhard to tty group
@@ -48,7 +61,6 @@ sub list_locale_settings {
 
 sub list_locale_etc_settings {
     my $self = shift;
-
     select_console('user-console');
     $self->save_and_upload_log('cat /etc/X11/xorg.conf.d/00-keyboard.conf', '/tmp/xorg.00-keyboard.conf.out');
     $self->save_and_upload_log('cat /etc/vconsole.conf',                    '/tmp/vconsole.conf.out');
@@ -56,14 +68,12 @@ sub list_locale_etc_settings {
 
 sub notification_handler {
     my ($feature, $state) = @_;
-
     select_console('user-console');
     assert_script_run("(gsettings get $feature && gsettings set $feature $state) 2>/dev/null || true");
 }
 
 sub verify_default_keymap_x11 {
     my ($test_string, $tag, $program) = @_;
-
     notification_handler('org.gnome.DejaDup periodic', 'false') if (check_var('DESKTOP', 'gnome'));
     select_console('x11');
     x11_start_program($program);
@@ -76,19 +86,16 @@ sub verify_default_keymap_x11 {
 }
 
 sub run {
-    # uncomment in case of different keyboard than us is used during installation ( feature not ready yet )
-    # my $expected   = get_var('INSTALL_KEYBOARD_LAYOUT','us');
-    my $expected       = 'us';
-    my %keystroke_list = (
-        us => '`1234567890-=~!@#$%^&*()_+',
-        fr => '²&é"(-è_çà)=~1234567890°+',
-        de => '1234567890ß°!"§$%&/()=?',
-        cz => ';+ěščřžýáíé=1234567890%'
-    );
-    my $keystrokes = $keystroke_list{$expected};
+    my $expected = get_var('INSTALL_KEYBOARD_LAYOUT', 'us');
+    # Feature of switching keyboard during installation is not ready yet,
+    # so if another language is used it needs to be verfied that the needle represents properly
+    # characters on that language.
+    my $keystrokes = '`1234567890-=!@6~!@#$%^&*()_+';
 
     if (check_var('DESKTOP', 'textmode')) {
         assert_screen([qw(linux-login cleared-console)]);
+        # We don't run further tests while switching keyboard feature not ready
+        return verify_default_keymap_textmode_non_us($keystrokes, "${expected}_keymap") if ($expected ne 'us');
         verify_default_keymap_textmode($keystrokes, "${expected}_keymap");
         verify_default_keymap_textmode($keystrokes, "${expected}_keymap", console => 'root-console');
         ensure_serialdev_permissions;
@@ -102,5 +109,5 @@ sub run {
 sub test_flags {
     return {milestone => 1};
 }
-1;
 
+1;

--- a/variables.md
+++ b/variables.md
@@ -44,6 +44,7 @@ HASLICENSE | boolean | true if SLE, false otherwise | Enables processing and val
 HDDVERSION | string | | Indicates version of the system installed on the HDD.
 HTTPPROXY  |||
 EXPECTED_INSTALL_HOSTNAME | string | | Contains expected hostname YaST installer got from the environment (DHCP, 'hostname=' as a kernel cmd line argument)
+INSTALL_KEYBOARD_LAYOUT | string | | Specify one of the supported keyboard layout to switch to during installation or to be used in autoyast scenarios e.g.: cz, fr
 INSTALL_SOURCE | string | | Specify network protocol to be used as installation source e.g. MIRROR_HTTP
 INSTALLATION_VALIDATION | string | | Comma separated list of modules to be used for installed system validation, should be used in combination with INSTALLONLY, to schedule only relevant test modules.
 INSTALLONLY | boolean | false | Indicates that test suite conducts only installation. Is recommended to be used for all jobs which create and publish images


### PR DESCRIPTION
Add autoyast keyboard layout test

- Related ticket: https://progress.opensuse.org/issues/47996
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1073
- Verification run: [sle-15-SP1-autoyast_keyboard_layout](http://rivera-workstation.suse.cz/tests/1764)

Requires new test suite `autoyast_keyboard_layout` similar to `autoyast_mini` except for the following params:
`AUTOYAST=autoyast_sle15/autoyast_keyboard_layout.xml`
`INSTALL_KEYBOARD_LAYOUT=cz`
`AUTOYAST_CONFIRM=`