### PR TITLE
Add test_flag to reboot_gnome.pm

### DIFF
--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -35,7 +35,7 @@ sub post_fail_hook {
 }
 
 sub test_flags {
-    return {milestone => 1};
+    return {fatal => 1, milestone => 1};
 }
 
 1;


### PR DESCRIPTION
we have problem with cleanup_before_shutdown when reboot_gnome failed
see https://progress.opensuse.org/issues/46280
So add test_flag 'fatal => 1' in reboot_gnome, tests after reboot_gnome
won't be triggered.
verification test run (change bootloader_timeout so that it fails):
http://f40.suse.de/tests/1250#step/reboot_gnome/7
