### PR TITLE
Remove perf testing from SLE15-SP1

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1511,7 +1511,7 @@ sub load_extra_tests_console {
     loadtest "console/cups";
     loadtest "console/java";
     loadtest "console/ant" if is_sle('<15-sp1');
-    loadtest "console/perf";
+    loadtest "console/perf" if is_sle('<15-sp1');
     loadtest "console/sysctl";
     loadtest "console/sysstat";
     loadtest "console/curl_ipv6";


### PR DESCRIPTION
This commit removes the perf test from SLE15-SP1 and on. 


