### PR TITLE
Fail more gently so cluster nodes can export logs

### DIFF
--- a/lib/caasp_controller.pm
+++ b/lib/caasp_controller.pm
@@ -4,7 +4,7 @@ use base "opensusebasetest";
 use strict;
 use testapi;
 use caasp qw(unpause script_assert0);
-use lockapi 'barrier_destroy';
+use lockapi qw(barrier_try_wait barrier_destroy);
 use mmapi 'wait_for_children';
 use version_utils 'is_caasp';
 
@@ -97,7 +97,7 @@ sub post_fail_hook {
 
     # Destroy barriers and create mutexes to avoid deadlock
     barrier_destroy 'NODES_ONLINE';
-    barrier_destroy 'DELAYED_NODES_ONLINE';
+    barrier_try_wait 'DELAYED_NODES_ONLINE';
     unpause 'ALL';
 
     # Wait for log export from all nodes

--- a/tests/caasp/stack_admin.pm
+++ b/tests/caasp/stack_admin.pm
@@ -19,9 +19,9 @@ use version_utils 'is_caasp';
 
 # Set password on autoyast nodes - bsc#1030876
 sub set_autoyast_password {
-    assert_script_run q#id=$(docker ps -qf name=salt-master)#;
-    assert_script_run q#pw=$(grep root /etc/shadow | cut -d':' -f2)#;
-    assert_script_run 'docker exec $id salt -E ".{32}" shadow.set_password root "$pw"', 60;
+    script_run q#id=$(docker ps -qf name=salt-master)#;
+    script_run q#pw=$(grep root /etc/shadow | cut -d':' -f2)#;
+    script_run 'docker exec $id salt -E ".{32}" shadow.set_password root "$pw"', 60;
 
     # Unlock and wait for propagation
     unpause 'AUTOYAST_PW_SET';


### PR DESCRIPTION
Fix for: https://openqa.suse.de/tests/2474510#dependencies
Local run: http://dhcp126.suse.cz/tests/14203#dependencies

When controller node fails with and cluster contains delayed nodes then logs are not exported. What happens is:
 - controller job noticed error & destroyed barrier as prevention against "running forever"
 - delayed nodes failed because barrier was destroyed `lockapi mydie`
 - all other cluster jobs died `parallel_failed` without logs