### PR TITLE
Remove docker from Kubic tests

### DIFF
--- a/products/kubic/main.pm
+++ b/products/kubic/main.pm
@@ -38,10 +38,6 @@ sub load_feature_tests {
     if (check_var 'SYSTEM_ROLE', 'kubeadm') {
         loadtest 'console/kubeadm';
     }
-    else {
-        # Docker only present on MicroOS, not kubeadm roles
-        loadtest 'console/docker';
-    }
     loadtest 'console/podman';
 }
 


### PR DESCRIPTION
As explained in https://bugzilla.opensuse.org/show_bug.cgi?id=1125949
Kubic will not be installing docker by default nor will it be easily installable from the installation media
Therefore it shouldn't be tested in the Kubic tests