### PR TITLE
Replace wait_boot_on_local_disk

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -365,7 +365,7 @@ sub wait_grub {
         }
     }
     elsif (match_has_tag('inst-bootmenu')) {
-        $self->wait_boot_on_local_disk;
+        $self->wait_grub_to_boot_on_local_disk;
     }
     elsif (match_has_tag('encrypted-disk-password-prompt')) {
         # unlock encrypted disk before grub


### PR DESCRIPTION
Regression from a42ed584bd400b0a37b6cb6df01b124cbb222edc.

Fails here:
* https://openqa.suse.de/tests/2478650#step/boot_to_desktop/3
* https://openqa.suse.de/tests/overview?distri=sle&version=15-SP1&build=173.1&groupid=111

Validation run: http://nilgiri.suse.cz/tests/300