### PR TITLE
Fix twice scheduling of shutdown tests on minimalx

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2349,7 +2349,8 @@ sub load_common_opensuse_sle_tests {
     load_toolchain_tests                if get_var("TCM") || check_var("ADDONS", "tcm");
     loadtest 'console/network_hostname' if get_var('NETWORK_CONFIGURATION');
     load_installation_validation_tests  if get_var('INSTALLATION_VALIDATION');
-    load_shutdown_tests if check_var('DESKTOP', 'minimalx');
+    # load shutdown tests for minimalx scenatios, except we have a creat_hdd scenario
+    load_shutdown_tests if (check_var('DESKTOP', 'minimalx') && !get_var('INSTALLONLY'));
 }
 
 sub load_ssh_key_import_tests {


### PR DESCRIPTION
Avoid the second scheduling of shutdown in case we have a
create_hdd scenario

Realted: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6551
- Verification runs:
SLE: http://pinky.arch.suse.de/tests/92
TW: http://pinky.arch.suse.de/tests/91
TW create_hdd: http://pinky.arch.suse.de/tests/90#
