### PR TITLE
Fail faster in case of update error

### DIFF
--- a/tests/caasp/stack_update.pm
+++ b/tests/caasp/stack_update.pm
@@ -61,9 +61,11 @@ sub orchestrate_velum_reboot {
     my @tags = qw(velum-retry velum-bootstrap-done);
     assert_screen \@tags, $n * 900;
     if (match_has_tag 'velum-retry') {
-        record_soft_failure 'bsc#000000 - Should have passed first time';
+        record_soft_failure 'bsc#000000 - Update failed once, retrying';
         assert_and_click 'velum-retry';
-        assert_screen 'velum-bootstrap-done', $n * 900;
+
+        assert_screen \@tags, $n * 900;
+        die 'Update failed twice' unless match_has_tag('velum-bootstrap-done');
     }
     die "Nodes should be updated already" if check_screen "velum-0-nodes-outdated", 0;
 }


### PR DESCRIPTION
If update fails then we wait 75 min (on 5 node cluster = 15 minutes per node).
When we will test bigger cluster it would be even more.

Fix for: https://openqa.suse.de/tests/2476435#step/stack_update/25
Local run: http://dhcp126.suse.cz/tests/14212#step/stack_update/24

Run time decreased from 02:18 hours to 46:35 minutes.