### PR TITLE
Fix product selection for s390x

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -364,9 +364,9 @@ Identify cases when Installer has to show Product Selection screen.
 Starting with SLE 15, all products are distributed using one medium, and Product
 to install has to be chosen explicitly.
 
-Though, there are some exceptions (like s390x) when there is only one Product,
-so that License agreement is shown directly, skipping the Product selection step.
-Also, Product Selection screen is not shown during upgrade.
+Though, there are some exceptions (like s390x on Sle15 SP0) when there is only
+one Product, so that License agreement is shown directly, skipping the Product
+selection step. Also, Product Selection screen is not shown during upgrade.
 
 Returns true (1) if Product Selection step has to be shown for the certain
 configuration, otherwise returns false (0).
@@ -374,7 +374,9 @@ configuration, otherwise returns false (0).
 =cut
 
 sub has_product_selection {
-    return is_sle('15+') && !(is_s390x() || get_var('UPGRADE'));
+    if (is_sle('15+') && !get_var('UPGRADE')) {
+        return is_sle('>=15-SP1') || !is_s390x();
+    }
 }
 
 =head2 has_license_on_welcome_screen
@@ -390,5 +392,5 @@ configuration, otherwise returns false (0).
 
 sub has_license_on_welcome_screen {
     return 1 if is_caasp('caasp');
-    return get_var('HASLICENSE') && ((is_sle('15+') && is_s390x()) || is_sle('<15'));
+    return get_var('HASLICENSE') && ((is_sle('=15') && is_s390x()) || is_sle('<15'));
 }


### PR DESCRIPTION
Product Selection screen started being shown for s390x on Sle SP1, as it
started containing more than one product.

The commit adjusts the appropriate condition to check if the product
selection screen should be shown.

- Verification run: 
Sle 15 sp1 s390x: http://10.160.65.138/tests/886
Sle 15 sp1 s390x (ncurses): http://10.160.65.138/tests/884

Just to be sure that there is no regression in other test suites with the welcome module:
Sle15 sp1 x64: http://10.160.65.138/tests/885
Sle 12 s390x: http://10.160.65.138/tests/887
