### PR TITLE
Add shortcut for aarch64 sles product selection

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -68,6 +68,7 @@ use constant {
           is_s390x
           is_livecd
           is_x86_64
+          is_aarch64
           has_product_selection
           has_license_on_welcome_screen
           )
@@ -293,6 +294,10 @@ sub is_s390x {
 
 sub is_x86_64 {
     return check_var('ARCH', 'x86_64');
+}
+
+sub is_aarch64 {
+    return check_var('ARCH', 'aarch64');
 }
 
 sub is_server {

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -51,7 +51,9 @@ sub get_product_shortcuts {
     # We got new products in SLE 15 SP1
     if (is_sle '15-SP1+') {
         return (
-            sles     => (get_var('OFW') || is_s390x) ? 'u' : 'i',
+            sles => (get_var('OFW') || is_s390x()) ? 'u'
+                : is_aarch64() ? 's'
+                : 'i',
             sled     => 'x',
             sles4sap => get_var('OFW') ? 'i' : 'p',
             hpc      => is_x86_64() ? 'g' : 'u',


### PR DESCRIPTION
The shortcut for SLES product on Product Selection Screen on aarch64
differs from other architectures.

The commit adds the appropriate shortcut.