### PR TITLE
Adjust SLES product selection shortcut for aarch64

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -66,6 +66,7 @@ use constant {
           is_virtualization_server
           is_server
           is_s390x
+          is_aarch64
           is_livecd
           is_x86_64
           has_product_selection
@@ -289,6 +290,10 @@ sub is_svirt_except_s390x {
 
 sub is_s390x {
     return check_var('ARCH', 's390x');
+}
+
+sub is_aarch64 {
+    return check_var('ARCH', 'aarch64');
 }
 
 sub is_x86_64 {

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -51,7 +51,7 @@ sub get_product_shortcuts {
     # We got new products in SLE 15 SP1
     if (is_sle '15-SP1+') {
         return (
-            sles     => (get_var('OFW') || is_s390x) ? 'u' : 'i',
+            sles     => (get_var('OFW') || is_s390x) ? 'u' : (is_aarch64 ? 's' : 'i'),
             sled     => 'x',
             sles4sap => get_var('OFW') ? 'i' : 'p',
             hpc      => is_x86_64() ? 'g' : 'u',


### PR DESCRIPTION
Following up from #6842, this PR adjust the product selection shortcuts for aarch64.

- Related ticket: https://progress.opensuse.org/issues/47915
- Needles: N/A
- Verification run: N/A
- Failing test: https://openqa.suse.de/tests/2479558
