### PR TITLE
Close VLC first time wizard via click

### DIFF
--- a/tests/x11/vlc.pm
+++ b/tests/x11/vlc.pm
@@ -23,7 +23,7 @@ use testapi;
 sub run {
     ensure_installed('vlc');
     x11_start_program('vlc --no-autoscale', target_match => 'vlc-first-time-wizard', match_typed => 'target_match_vlc');
-    send_key "ret";
+    assert_and_click "vlc-first-time-wizard";
     assert_screen "vlc-main-window";
     send_key "ctrl-l";
     assert_and_click "vlc-playlist-empty";


### PR DESCRIPTION
Using "RET" to close the wizard is unreliable because a checkbox label
is sometimes selected.

- Related ticket: https://progress.opensuse.org/issues/47933
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/515
- Verification run: http://agraul-vm.qa.suse.de/tests/104
