### PR TITLE
Try harder to confirm YaST countdown

### DIFF
--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -145,7 +145,7 @@ sub run {
     }
 
     # Stop reboot countdown for e.g. uploading logs
-    unless (get_var("REMOTE_CONTROLLER") || is_caasp || is_hyperv_in_gui) {
+    unless (get_var("REMOTE_CONTROLLER") || is_caasp) {
         # Depending on the used backend the initial key press to stop the
         # countdown might not be evaluated correctly or in time. In these
         # cases we keep hitting the keys until the countdown stops.

--- a/tests/installation/reboot_after_installation.pm
+++ b/tests/installation/reboot_after_installation.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2018 SUSE LLC
+# Copyright © 2017-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -24,7 +24,11 @@ sub run {
         my $svirt = console('svirt');
         $svirt->change_domain_element(os => boot => {dev => 'hd'});
     }
-    send_key 'alt-o';    # Reboot
+    # Reboot
+    my $count = 0;
+    while (!wait_screen_change(sub { send_key 'alt-o' }, undef, similarity_level => 20)) {
+        $count < 5 ? $count++ : die "Reboot process won't start";
+    }
     power_action('reboot', observe => 1, keepconsole => 1, first_reboot => 1);
 }
 


### PR DESCRIPTION
**Validation runs**

Graphical:
* Restart key delivered: http://nilgiri.suse.cz/tests/308
* Restart key not delivered: http://nilgiri.suse.cz/tests/307#step/reboot_after_installation/9

Textual:
* Restart key delivered: http://nilgiri.suse.cz/tests/313
* Restart key not delivered: http://nilgiri.suse.cz/tests/312#step/reboot_after_installation/9