### PR TITLE
Adjust dss1 digest sign and verify method for openssl-1.1.x

### DIFF
--- a/tests/fips/openssl/openssl_pubkey_dsa.pm
+++ b/tests/fips/openssl/openssl_pubkey_dsa.pm
@@ -12,16 +12,18 @@
 # According to FIPS 186-4, approved DSA key sizes: 1024/2048/3072
 #
 # Summary: Add RSA/DSA public key tests for openssl-fips
-#    For RSA public key, test 2048/3072/4096 bits key pair generation,
-#    file encrypt/decrypt and message signing/verification.
+#          For RSA public key, test 2048/3072/4096 bits key pair generation,
+#          file encrypt/decrypt and message signing/verification.
 #
-#    For DSA public key, test 1024/2048/3072 bits key pair generation,
-#    and message signing/verification.
-#    By openssl-1.1.0-fips.patch, remove 1024 bits DSA keysize generate check in fips mode
+#          For DSA public key, test 1024/2048/3072 bits key pair generation,
+#          and message signing/verification.
+#          By openssl-1.1.0-fips.patch, remove 1024 bits DSA keysize generate check in fips mode
+#
+#          According to openssl wiki, "dss1" digest method is not available in openssl-1.1-x any more
 #
 # Original Author: Qingming Su <qingming.su@suse.com>
 # Maintainer: Ben Chou <bchou@suse.com>
-# Tags: poo#47471
+# Tags: poo#47471, poo#48020
 
 use base "consoletest";
 use testapi;
@@ -35,6 +37,10 @@ sub run {
     my $file_dgt      = $file_raw . ".$dgst_alg";
     my $file_sig      = $file_dgt . ".sig";
     my @dsa_key_sizes = (2048, 3072);
+
+    # Add the openssl version check
+    my $openssl_version_output = script_output("openssl version | awk '{print $2}'");
+    my ($openssl_version) = $openssl_version_output =~ /(\d\.\d)/;
 
     # Prepare temp directory and file for testing
     assert_script_run "mkdir fips-test && cd fips-test && echo Hello > $file_raw";
@@ -50,11 +56,13 @@ sub run {
         # A source of random numbers is required for DSA, so get message digest first
         assert_script_run "openssl dgst -$dgst_alg $file_raw | awk '{print $2}' > $file_dgt";
 
-        # Sign message digest with private key
-        assert_script_run "openssl dgst -dss1 -sign $dsa_prikey $file_dgt > $file_sig";
+        # Sign message digest with private key and verify signature with public key
+        # openssl >= 1.1.x (sha256)
+        # openssl >= 1.0.x (dss1)
+        my $algo = ($openssl_version >= "1.1") ? "sha256" : "dss1";
 
-        # Verify signature with public key
-        validate_script_output "openssl dgst -dss1 -verify $dsa_pubkey -signature $file_sig $file_dgt", sub { m/Verified OK/ };
+        assert_script_run "openssl dgst -$algo -sign $dsa_prikey $file_dgt > $file_sig";
+        validate_script_output "openssl dgst -$algo -verify $dsa_pubkey -signature $file_sig $file_dgt", sub { m/Verified OK/ };
 
         # Clean up temp files
         script_run "rm -f $file_dgt $file_sig dsaparam.pem";


### PR DESCRIPTION
1. dss1 digest method is not available in openssl-1.1.x any more
2. Separate the digest testing to dss1 and sha256
3. Related to bsc#1125515 - [FIPS] Fail to sign message digest by dss1 with private key

- Related ticket: https://progress.opensuse.org/issues/48020
- Needles: N/A
- Verification run: 
 SLE15 SP1: http://10.100.210.39/tests/249#step/openssl_pubkey_dsa/16
 SLE12 SP4: http://10.100.210.39/tests/248#step/openssl_pubkey_dsa/16
