### PR TITLE
Create profile for autoyast migration test SLE15+live patch via package media

### DIFF
--- a/data/autoyast_sle15/autoyast_media_up_live_gnome.xml
+++ b/data/autoyast_sle15/autoyast_media_up_live_gnome.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <add-on>
+    <add_on_products config:type="list">
+      <listentry>
+        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+        <product>sle-module-basesystem</product>
+        <product_dir>/Module-Basesystem</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+        <product>sle-module-desktop-applications</product>
+        <product_dir>/Module-Desktop-Applications</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+        <product>sle-module-server-applications</product>
+        <product_dir>/Module-Server-Applications</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+        <product>sle-module-legacy</product>
+        <product_dir>/Module-Legacy</product_dir>
+      </listentry>
+      <listentry>
+        <media_url><![CDATA[dvd:///?devices=/dev/sr1]]></media_url>
+        <product>sle-module-live-patching</product>
+        <product_dir>/Module-Live-Patching</product_dir>
+      </listentry>
+    </add_on_products>
+  </add-on>
+  <bootloader>
+    <global>
+      <activate>false</activate>
+      <boot_extended>false</boot_extended>
+      <boot_mbr>true</boot_mbr>
+      <boot_root>true</boot_root>
+      <generic_mbr>false</generic_mbr>
+      <timeout config:type="integer">5</timeout>
+    </global>
+    <loader_type>grub2</loader_type>
+  </bootloader>
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+      <second_stage config:type="boolean">false</second_stage>
+    </mode>
+    <signature-handling>
+      <accept_file_without_checksum config:type="boolean">true</accept_file_without_checksum>
+      <accept_non_trusted_gpg_key config:type="boolean">true</accept_non_trusted_gpg_key>
+      <accept_unknown_gpg_key config:type="boolean">true</accept_unknown_gpg_key>
+      <accept_unsigned_file config:type="boolean">false</accept_unsigned_file>
+      <accept_verification_failed config:type="boolean">false</accept_verification_failed>
+      <import_gpg_key config:type="boolean">true</import_gpg_key>
+    </signature-handling>
+  </general>
+  <keyboard>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages>en_US</languages>
+  </language>
+  <report>
+    <errors>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <warnings>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <messages>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <yesno_messages>
+      <show config:type="boolean">true</show>
+      <log config:type="boolean">true</log>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <software>
+    <products config:type="list">
+        <product>SLES</product>
+    </products>
+  </software>
+  <upgrade>
+    <only_installed_packages config:type="boolean">false</only_installed_packages>
+    <stop_on_solver_conflict config:type="boolean">true</stop_on_solver_conflict>
+  </upgrade>
+</profile>


### PR DESCRIPTION
Create the autoyast profile for autoyast migration test SLE15+live patch via package media.

- Related ticket: https://progress.opensuse.org/issues/44081
- Needles: N/A
- Verification run: http://openqa-apac1.suse.de/tests/3351#
