### PR TITLE
Fix string for keyboard layout in keymap_or_locale

### DIFF
--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -90,7 +90,7 @@ sub run {
     # Feature of switching keyboard during installation is not ready yet,
     # so if another language is used it needs to be verfied that the needle represents properly
     # characters on that language.
-    my $keystrokes = '`1234567890-=!@6~!@#$%^&*()_+';
+    my $keystrokes = '`1234567890-=~!@#$%^&*()_+';
 
     if (check_var('DESKTOP', 'textmode')) {
         assert_screen([qw(linux-login cleared-console)]);


### PR DESCRIPTION
Fix wrong string which is used for testing the keyboard layout in keymap_or_locale, for which we already have needles in prod. It broke [staging test](https://openqa.suse.de/tests/2480780#step/keymap_or_locale/4) after this string was modified accidentally in #6833.

- Related ticket: https://progress.opensuse.org/issues/47996#change-191354
- Needles: [needles sle] ()
- Verification run:  (on-going)
  - [sle-15-SP1-BuildG.167.2-minimal+base](http://rivera-workstation.suse.cz/tests/1767)
  - [sle-15-SP1-autoyast_keyboard_layout](http://rivera-workstation.suse.cz/tests/1766)
