### PR TITLE
Load install_service module for migration test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -448,8 +448,8 @@ sub load_zdup_tests {
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/lock_package";
     }
-    loadtest 'installation/zdup';
     loadtest 'installation/install_service';
+    loadtest 'installation/zdup';
     loadtest 'installation/post_zdup';
     # Restrict version switch to sle until opensuse adopts it
     loadtest "migration/version_switch_upgrade_target" if is_sle and get_var("UPGRADE_TARGET_VERSION");
@@ -1071,6 +1071,7 @@ sub load_consoletests {
     loadtest 'console/integration_services' if is_hyperv || is_vmware;
     loadtest "locale/keymap_or_locale";
     loadtest "console/orphaned_packages_check" if is_jeos;
+    loadtest "console/check_upgraded_service" if (!get_var('MEDIA_UPGRADE') && !get_var('ZDUP'));
     loadtest "console/force_scheduled_tasks" unless is_jeos;
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/check_locked_package";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -463,6 +463,7 @@ sub load_online_migration_tests {
         loadtest "migration/sle12_online_migration/register_without_ltss";
     }
     loadtest "migration/sle12_online_migration/pre_migration";
+    loadtest 'installation/install_service';
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/lock_package";
     }
@@ -496,6 +497,8 @@ sub load_patching_tests {
             loadtest 'console/lock_package';
         }
         loadtest 'migration/record_disk_info';
+        # Install service for offline migration by zypper
+        loadtest 'installation/install_service' if (!get_var('MEDIA_UPGRADE') && !get_var('ZDUP'));
         # Reboot from DVD and perform upgrade
         loadtest "migration/reboot_to_upgrade";
         # After original system patched, switch to UPGRADE_TARGET_VERSION


### PR DESCRIPTION
For the install_service module need system be registered, while migration via package media and zdup the patch_sle will de_register system at the end of module, since the test coverage will be enough so just run install_service via online migration but not zdup, run install_service via offline migration but not package media.

- Related ticket: https://progress.opensuse.org/issues/47348
- Needles: N/A
- Verification run: 
   online migration with install_service:     http://openqa-apac1.suse.de/tests/3347
   offline migration but not package media with install_service:     http://openqa-apac1.suse.de/tests/3352
   package media without install_service:      http://openqa-apac1.suse.de/tests/3353
   zdup without install_service:      http://openqa-apac1.suse.de/tests/3354