### PR TITLE
Fix too early timeout when shutting down minimalx

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -156,7 +156,7 @@ sub poweroff_x11 {
         assert_screen 'logout-confirm-dialog', 10;
         send_key "alt-o";              # _o_k
 
-        if (!check_shutdown()) {
+        if (!check_shutdown(timeout => 120)) {
             record_soft_failure 'bsc#1076817 manually shutting down';
             select_console 'root-console';
             systemctl 'poweroff';


### PR DESCRIPTION
Increased the timeout of check_shutdown to avoid a false positive
when trying to detect the bug

- Related ticket: https://openqa.suse.de/tests/2482827#step/shutdown/27
- Verification run: http://pinky.arch.suse.de/tests/96#
