### PR TITLE
[WIP] Stop packagekit before zypper ref

### DIFF
--- a/tests/console/zypper_ref.pm
+++ b/tests/console/zypper_ref.pm
@@ -26,7 +26,7 @@ sub run {
         if is_sle('15+')
         and get_var('ISO_1', '') =~ /SLE-.*-Packages-.*\.iso/;
 
-    systemctl 'stop packagekit.service' if (check_var('UPGRADE'));
+    systemctl('stop packagekit.service') if (check_var('UPGRADE'));
     zypper_call '--gpg-auto-import-keys ref';
 }
 

--- a/tests/console/zypper_ref.pm
+++ b/tests/console/zypper_ref.pm
@@ -26,6 +26,7 @@ sub run {
         if is_sle('15+')
         and get_var('ISO_1', '') =~ /SLE-.*-Packages-.*\.iso/;
 
+    systemctl 'stop packagekit.service' if (check_var('UPGRADE'));
     zypper_call '--gpg-auto-import-keys ref';
 }
 


### PR DESCRIPTION
- Reproducible on any upgrade from Leap 42.3 to Tumbleweed: https://openqa.opensuse.org/tests/859667#step/zypper_ref/12
- Related ticket: https://progress.opensuse.org/issues/40052
- Verification run: (coming soon)
