### PR TITLE
Fix apparmor when switching profile mode

### DIFF
--- a/tests/console/yast2_apparmor.pm
+++ b/tests/console/yast2_apparmor.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright (c) 2016-2018 SUSE LLC
+# Copyright (c) 2016-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -51,11 +51,32 @@ sub run {
     #Show all configs
     send_key(is_pre_15() ? 'alt-o' : 'alt-s');
     assert_screen 'yast2_apparmor_profile_mode_configuration_show_all';
-    wait_screen_change { send_key 'tab' };
-    wait_screen_change { send_key 'down' };
-    send_key(is_pre_15() ? 'alt-t' : 'alt-c');
-    assert_screen 'yast2_apparmor_profile_mode_configuration_toggle';
-
+    wait_screen_change { send_key 'tab' };                              # focus on first element in the list
+    wait_screen_change { send_key(is_pre_15() ? 'alt-t' : 'alt-c') };
+    assert_screen [qw(
+          yast2_apparmor_profile_mode_configuration_toggle
+          yast2_apparmor_profile_mode_configuration_show_all
+          yast2_apparmor_profile_mode_not_visible
+          )];
+    if (match_has_tag 'yast2_apparmor_profile_mode_not_visible') {
+        record_soft_failure 'bsc#1127714 - yast2_apparmor does not display mode column when profile name is too long';
+        send_key_until_needlematch 'yast2_apparmor_profile_mode_configuration_show_all', 'tab';
+        wait_screen_change { send_key 'tab' };
+        send_key_until_needlematch('yast2_apparmor_profile_mode_configuration_toggle', 'right');
+    }
+    elsif (match_has_tag 'yast2_apparmor_profile_mode_configuration_show_all') {
+        record_soft_failure 'bsc#1126289 - yast2_apparmor - cannot toggle first profile in the list';
+        # try out with second element in the list
+        wait_screen_change { send_key 'tab' };
+        wait_screen_change { send_key 'down' };
+        save_screenshot;
+        send_key(is_pre_15() ? 'alt-t' : 'alt-c');
+        if (is_pre_15()) {
+            wait_screen_change { send_key 'tab' };
+            wait_screen_change { send_key 'end' };    # we need to search for recent toggled element at the of the list
+        }
+        assert_screen 'yast2_apparmor_profile_mode_configuration_toggle';
+    }
     wait_screen_change { send_key 'alt-b' } if is_pre_15();
 
     # close apparmor configuration
@@ -63,7 +84,6 @@ sub run {
     # increase value for timeout to 200 seconds
     wait_serial("yast2-apparmor-status-0", 200) || die "'yast2 apparmor' didn't finish";
     systemctl 'show -p ActiveState apparmor.service | grep ActiveState=active';
-
     # currently not existing on sle15
     if (is_pre_15()) {
         # part 2: start apparmor configuration again
@@ -162,4 +182,3 @@ sub post_fail_hook {
 }
 
 1;
-


### PR DESCRIPTION
Fix apparmor when switching profile mode. Add workarounds for [bsc#1127714](https://bugzilla.suse.com/show_bug.cgi?id=1127714) and [bsc#1126289](https://bugzilla.suse.com/show_bug.cgi?id=1126289)

- Related ticket: https://progress.opensuse.org/issues/46997
- Needles: 
  - [needles OSD](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1079) -> Merged
  - [needles O3](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/523)
- Verification run:
  - [sle-12-SP5-yast2_ncurses](http://rivera-workstation.suse.cz/tests/1985#step/yast2_apparmor/18)
  - [sle-15-SP1-yast2_ncurses](http://rivera-workstation.suse.cz/tests/1984)
  - [Tumbleweed-yast2_ncurses](http://rivera-workstation.suse.cz/tests/1983)
  - [Leap-15.1-yast2_ncurses](http://rivera-workstation.suse.cz/tests/1988)
