### PR TITLE
Fix dracut -f regression test

### DIFF
--- a/tests/console/dracut.pm
+++ b/tests/console/dracut.pm
@@ -23,7 +23,7 @@ sub run {
     assert_script_run("rpm -q dracut");
 
     validate_script_output("lsinitrd", sub { m/Image:(.*\n)+( ?)Version: dracut(-|\d+|\.|\w+)+(\n( ?))+( ?)Arguments(.*\n)+( ?)dracut modules:(\w+|-|\d+|\n|( ?))+\=+\n(l|d|r|w|x|-|( ?))+\s+\d+ root\s+root(.*\n)+( ?)\=+/ });
-    validate_script_output("dracut -f", sub { m/.*Executing: \/usr\/bin\/dracut -f\n( ?)(((dracut: |)dracut module.*\n( ?))|((dracut: |)\*+ Including module:.*\n( ?))|((dracut: |)Skipping.*\n( ?))|((dracut: |)Could not find.*\n)|((dracut: |)Possible missing firmware.*\n( ?))|((dracut: |)95nfs).*\n( ?))+(dracut: |)\*+ Including modules done \*+(.+|\n)+/ });
+    validate_script_output("dracut -f", sub { m/.*Executing: \/usr\/bin\/dracut -f\n|\b(?:Skipping|Including modules done|Including|Creating image|Creating initramfs)\b/ });
     validate_script_output("dracut --list-modules", sub { m/.*Executing: \/usr\/bin\/dracut --list-modules\n(\w+|\n|-|d+)+/ });
 
     power_action('reboot', textmode => 1);


### PR DESCRIPTION
Regex has been refactored because it was becoming bigger and bigger trying to catch all possible cases.
Now it is looking only for some well known words. This will still provide a good coverage, but will reduce the possibility of failure of the test

- Related ticket: https://progress.opensuse.org/issues/48251
- Verification runs: 
  - SLE 12.1: http://d502.qam.suse.de/tests/627 :heavy_check_mark: 
  - SLE 12.4: http://d502.qam.suse.de/tests/628 :heavy_check_mark: 
  - SLE 15.0: http://d502.qam.suse.de/tests/629 :heavy_check_mark: 
  - oS 15.1: http://d502.qam.suse.de/tests/631  :heavy_check_mark: 
  - oS TW: http://d502.qam.suse.de/tests/630 :heavy_check_mark: 
