### PR TITLE
lsof regression tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1648,6 +1648,7 @@ sub load_rollback_tests {
 
 sub load_extra_tests_filesystem {
     loadtest "console/system_prepare";
+    loadtest "console/lsof";
     if (get_var("FILESYSTEM", "btrfs") eq "btrfs") {
         loadtest "console/snapper_jeos_cli" if is_jeos;
         loadtest "console/btrfs_autocompletion";

--- a/tests/console/lsof.pm
+++ b/tests/console/lsof.pm
@@ -1,0 +1,58 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Test lsof command
+# Maintainer: Antonio Caristia <acaristia@suse.com>
+
+use base 'consoletest';
+use strict;
+use testapi;
+use utils 'zypper_call';
+
+sub run {
+    my ($self) = @_;
+    select_console('root-console');
+    zypper_call('in netcat');
+    assert_script_run("lsof");
+    assert_script_run("lsof -u root");
+    assert_script_run("lsof -i");
+    assert_script_run("lsof -i :22");
+    assert_script_run("lsof -p 1");
+
+    assert_script_run("exec 3>testoutput && echo 'random words' >&3");
+    assert_script_run('lsof +D . |grep testoutput || test $? -eq 1');
+    validate_script_output('lsof -a -p $$ -d 3 | grep testoutput', sub { m/testoutput/ }, 200);
+    assert_script_run('exec 3>&-');
+    assert_script_run('lsof -a -p $$ -d 3 | grep testoutput || test $? -eq 1');
+    
+    assert_script_run('exec 4<> testoutput && read line <&4 && echo $line');
+    validate_script_output('lsof -a -p $$ -d 4 |grep testoutput', sub { m/testoutput/ }, 200);
+    assert_script_run('exec 4>&-');
+    assert_script_run('lsof -a -p $$ -d 4 | grep testoutput || test $? -eq 1');
+    
+    type_string("netcat -l 5555 &");
+    validate_script_output("lsof -i :5555 |grep netcat", sub { m/TCP/ });
+    assert_script_run("killall netcat");
+    assert_script_run('lsof -i :5555|grep netcat || test $? -eq 1');
+
+    type_string("netcat -ul 5555 &");
+    validate_script_output("lsof -i UDP:5555 |grep netcat", sub { m/UDP/ });
+    assert_script_run("killall netcat");
+    assert_script_run('lsof -i UDP:5555|grep netcat || test $? -eq 1');
+
+}
+
+1;
+


### PR DESCRIPTION
Testing usual lsof options and specific commands for regular files and TCP/UDP sockets

Both tests for sle and opensuse are scheduled in `load_extra_tests_filesystem` function ( `lib/main_common.pm` )

- Related ticket: https://progress.opensuse.org/issues/48194
- Needles: 
- Verification run: 

sle15: http://10.161.229.206/tests/301
sle12sp4: http://10.161.229.206/tests/306
sle12sp3: http://10.161.229.206/tests/307
opensuseTW: http://10.161.229.206/tests/308
