### PR TITLE
Update yast2_i test for JeOS

### DIFF
--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -15,6 +15,7 @@ use base "console_yasttest";
 use strict;
 use testapi;
 use utils;
+use version_utils "is_jeos";
 
 sub run {
     my $self        = shift;
@@ -25,6 +26,8 @@ sub run {
 
     zypper_call "-i rm $pkgname $recommended";
     zypper_call "in yast2-packager";    # make sure yast2 sw_single module installed
+
+    zypper_call "-i inr" if is_jeos; # install recommended drivers bsc#953522
 
     script_run("yast2 sw_single; echo y2-i-status-\$? > /dev/$serialdev", 0);
     assert_screen 'empty-yast2-sw_single', 90;


### PR DESCRIPTION
The change installs any recommended drivers before the test goes through 
specific packages

- Related ticket: https://progress.opensuse.org/issues/48314
- Verification run: http://ccret.suse.cz/tests/2834#
