### PR TITLE
[WIP] Enable sle-module-python2 for multipath test

### DIFF
--- a/tests/qa_automation/kernel_multipath.pm
+++ b/tests/qa_automation/kernel_multipath.pm
@@ -15,11 +15,14 @@ use strict;
 use testapi;
 use utils;
 use iscsi;
+use registration 'add_suseconnect_product';
+use version_utils "is_sle";
 
 sub start_testrun {
     my $self = shift;
 
-    zypper_call("in open-iscsi qa_test_multipath");
+    add_suseconnect_product('sle-module-python2') if (is_sle(">15"));
+    zypper_call("in open-iscsi qa_test_multipath python-xml");
 
     systemctl 'start iscsid';
     systemctl 'start multipathd';


### PR DESCRIPTION
Fix poo#48308: python-xml was moved to legacy python2 module on SLE15-SP1.

- Related ticket: https://progress.opensuse.org/issues/48308
- Needles: none
- Verification run: http://10.100.12.105/tests/1586
