### PR TITLE
qa_automation: Ensure bzip2 dependency is installed

### DIFF
--- a/tests/qa_automation/execute_test_run.pm
+++ b/tests/qa_automation/execute_test_run.pm
@@ -39,6 +39,7 @@ sub run {
     if (get_var("QA_TESTSUITE") && !is_jeos) {
         assert_script_run('sync', 180);
         my $tarball = "/tmp/testlog.tar.bz2";
+        zypper_call('in bzip2');
         assert_script_run("tar cjf $tarball -C /var/log/qa/ctcs2 `ls /var/log/qa/ctcs2/`");
         upload_logs($tarball, timeout => 600);
 


### PR DESCRIPTION
Verification run: https://openqa.suse.de/tests/2492920

Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1125452