### PR TITLE
Unschedule shutdown on minimalx due to many current failures

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2368,8 +2368,6 @@ sub load_common_opensuse_sle_tests {
     load_toolchain_tests                if get_var("TCM") || check_var("ADDONS", "tcm");
     loadtest 'console/network_hostname' if get_var('NETWORK_CONFIGURATION');
     load_installation_validation_tests  if get_var('INSTALLATION_VALIDATION');
-    # load shutdown tests for minimalx scenatios, except we have a creat_hdd scenario
-    load_shutdown_tests if (check_var('DESKTOP', 'minimalx') && !get_var('INSTALLONLY'));
 }
 
 sub load_ssh_key_import_tests {


### PR DESCRIPTION
Related progress issue: https://progress.opensuse.org/issues/46076