### PR TITLE
Increase timeout of zypper patch

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -410,10 +410,10 @@ sub minimal_patch_system {
     my (%args) = @_;
     $args{version_variable} //= 'VERSION';
     if (is_sle('12-SP1+', get_var($args{version_variable}))) {
-        zypper_call('patch --with-interactive -l --updatestack-only', exitcode => [0, 102, 103], timeout => 1500, log => 'minimal_patch.log');
+        zypper_call('patch --with-interactive -l --updatestack-only', exitcode => [0, 102, 103], timeout => 3000, log => 'minimal_patch.log');
     }
     else {
-        zypper_call('patch --with-interactive -l', exitcode => [0, 102, 103], timeout => 1500, log => 'minimal_patch.log');
+        zypper_call('patch --with-interactive -l', exitcode => [0, 102, 103], timeout => 3000, log => 'minimal_patch.log');
     }
 }
 


### PR DESCRIPTION
[Increase timeout of zypper patch command]

We also need update the patch timeout for func minimal_patch_system, the reason is same as 
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6829

* Related ticket: https://progress.opensuse.org/issues/48032
* Needles: n/a
* Verification run: n/a