### PR TITLE
Close checksum error windows since this is caused by offload feature v2

### DIFF
--- a/tests/x11/wireshark.pm
+++ b/tests/x11/wireshark.pm
@@ -153,9 +153,9 @@ sub run {
     wait_still_screen 1;
     # QT menu requires user to place focus in the filter field
     send_key "ctrl-/" if $wireshark_gui_version eq "qt";
-    assert_screen "wireshark-filter-selected";
     # Sometimes checksum error window popup, then we need close this windows since this caused by offload feature
-    if (check_screen('wireshark-checksum-error', 5)) {
+    assert_screen([qw(wireshark-filter-selected wireshark-checksum-error)]);
+    if (match_has_tag('wireshark-checksum-error')) {
         send_key "alt-c";
         assert_screen "wireshark-filter-selected";
         send_key "ctrl-/" if $wireshark_gui_version eq "qt";


### PR DESCRIPTION
This is improvement PR base on Oliver's comment on  https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6799

* Related ticket: https://progress.opensuse.org/issues/45098
* Needles: n/a
* Verification run: n/a Not possible reproduce on local env.
