### PR TITLE
Remove passwd pam check from supportutils

### DIFF
--- a/tests/console/supportutils.pm
+++ b/tests/console/supportutils.pm
@@ -24,7 +24,6 @@ sub run {
     # Check few file whether expected content is there.
     assert_script_run "diff <(awk '/\\/proc\\/cmdline/{getline; print}' boot.txt) /proc/cmdline";
     assert_script_run "grep -q -f /etc/os-release basic-environment.txt";
-    assert_script_run "grep -q -f /etc/passwd pam.txt";
 
     assert_script_run "cd ..";
     assert_script_run "rm -rf nts_* ||:";


### PR DESCRIPTION
Supportutils test is failing due to bsc#1112461, where with accordance to GDPR, PAM is no longer collected by default. Removing the check for pam.txt.

- Related ticket: https://progress.opensuse.org/issues/48362
- Failing run: https://openqa.suse.de/tests/2493266#step/supportutils/14
- Verification run: http://hoorhay.suse.cz/tests/970