### PR TITLE
check_shutdown takes only one unnamed argument, which it interprets a…

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -156,7 +156,7 @@ sub poweroff_x11 {
         assert_screen 'logout-confirm-dialog', 10;
         send_key "alt-o";              # _o_k
 
-        if (!check_shutdown(timeout => 120)) {
+        if (!check_shutdown(120)) {
             record_soft_failure 'bsc#1076817 manually shutting down';
             select_console 'root-console';
             systemctl 'poweroff';


### PR DESCRIPTION
…s 'timeout'

Otherwise we see things like this in the logs:
  [2019-02-25T10:27:44.231 CET] [debug] <<< testapi::check_shutdown(timeout='timeout')
  Argument "timeout" isn't numeric in multiplication (*) at /usr/lib/os-autoinst/bmwqemu.pm line 328.
which resutls in a 0s timeout

