### PR TITLE
Call properly assert_screen_with_soft_timeout

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -536,7 +536,7 @@ sub assert_screen_with_soft_timeout {
     # as in assert_screen
     $args{timeout}             //= 30;
     $args{soft_timeout}        //= 0;
-    $args{soft_failure_reason} //= "$args{bugref}: needle(s) $mustmatch not found within $args{soft_timeout}";
+    $args{soft_failure_reason} //= $args{bugref} . ': needle(s) not found within ' . $args{soft_timeout};
     if ($args{soft_timeout}) {
         die "soft timeout has to be smaller than timeout" unless ($args{soft_timeout} < $args{timeout});
         my $ret = check_screen $mustmatch, $args{soft_timeout};

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -154,7 +154,7 @@ sub run {
         set_var('SKIP_INSTALLER_SCREEN', 0);
     }
     $self->process_unsigned_files([qw(inst-addon addon-products)]);
-    assert_screen_with_soft_timeout([qw(inst-addon addon-products)], timeout => 60, soft_timeout => 30, 'bsc#1123963');
+    assert_screen_with_soft_timeout([qw(inst-addon addon-products)], timeout => 60, soft_timeout => 30, bugref => 'bsc#1123963');
     if (get_var("ADDONS")) {
         send_key match_has_tag('inst-addon') ? 'alt-k' : 'alt-a';
         # the ISO_X variables must match the ADDONS list


### PR DESCRIPTION
Call properly assert_screen_with_soft_timeout to avoid: https://openqa.suse.de/tests/2494332#step/addon_products_sle/13

- Related ticket: https://progress.opensuse.org/issues/46814
- Needles: N/A
- Verification run: N/A (only visible in prod with some archs)
