### PR TITLE
Fix s390x kvm incompletes with explicit connection disconnect on reboot

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -43,7 +43,7 @@ sub prepare_system_shutdown {
         }
         console('installation')->disable_vnc_stalls;
     }
-    if (check_var('VIRSH_VMM_FAMILY', 'xen')) {
+    if (check_var('BACKEND', 'svirt')) {
         my $vnc_console = get_required_var('SVIRT_VNC_CONSOLE');
         console($vnc_console)->disable_vnc_stalls;
         console('svirt')->stop_serial_grab;
@@ -260,7 +260,7 @@ sub power_action {
         # Look aside before we are sure 'sut' console on VMware is ready, see poo#47150
         select_console('svirt') if is_vmware && $action eq 'reboot';
         reset_consoles;
-        if (check_var('VIRSH_VMM_FAMILY', 'xen') && $action ne 'poweroff') {
+        if (check_var('BACKEND', 'svirt') && $action ne 'poweroff') {
             console('svirt')->start_serial_grab;
         }
         # When 'sut' is ready, select it


### PR DESCRIPTION
Partially reverts "Only Xen needs serial console start/stop on reboot"

This reverts commit 1ca2409820860d09935ce73635c9b2defcf6462b to fix
https://progress.opensuse.org/issues/48260 as well as help with
https://progress.opensuse.org/issues/46508