### PR TITLE
Adjust needle info in assert_screen_with_soft_timeout

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -534,9 +534,10 @@ Example:
 sub assert_screen_with_soft_timeout {
     my ($mustmatch, %args) = @_;
     # as in assert_screen
-    $args{timeout}             //= 30;
-    $args{soft_timeout}        //= 0;
-    $args{soft_failure_reason} //= $args{bugref} . ': needle(s) not found within ' . $args{soft_timeout};
+    $args{timeout}      //= 30;
+    $args{soft_timeout} //= 0;
+    my $needle_info = ref($mustmatch) eq "ARRAY" ? join(',', @$mustmatch) : $mustmatch;
+    $args{soft_failure_reason} //= "$args{bugref}: needle(s) $needle_info not found within $args{soft_timeout}";
     if ($args{soft_timeout}) {
         die "soft timeout has to be smaller than timeout" unless ($args{soft_timeout} < $args{timeout});
         my $ret = check_screen $mustmatch, $args{soft_timeout};


### PR DESCRIPTION
Adjust needle info in assert_screen_with_soft_timeout

- Related ticket: https://progress.opensuse.org/issues/47387
- Needles: N/A
- Verification run: ~thinking how to test it...or where~
  - [sle-15-SP1-create_hdd_sled_gnome](http://rivera-workstation.suse.cz/tests/1824) calling it in this way: `assert_screen_with_soft_timeout([qw(inst-addon addon-products)], timeout => 0, soft_timeout => 0, bugref => 'bsc#1123963')`