### PR TITLE
Refactor device existence check and add it for drbd and cluster_md

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -354,6 +354,23 @@ sub get_lun {
     return block_device_real_path "$lun";
 }
 
+# This method checks for the presence of a device in the system for up to a defined timeout (defaults to 20seconds)
+sub check_device_available {
+    my ($dev, $tout) = @_;
+    my $ret;
+    my $tries = $tout ? int($tout / 2) : 10;
+
+    die "Must provide a device for check_device_available" unless (defined $dev);
+
+    while ($tries and $ret = script_run "ls -la $dev") {
+        --$tries;
+        sleep 2;
+    }
+    die "Test timed out while checking $dev" unless (defined $ret);
+    die "Nonexistent $dev after $tout seconds" unless ($tries > 0 or $ret == 0);
+    return $ret;
+}
+
 sub pre_run_hook {
     my ($self) = @_;
     if (isotovideo::get_version() == 12) {

--- a/tests/ha/cluster_md.pm
+++ b/tests/ha/cluster_md.pm
@@ -86,7 +86,17 @@ sub run {
     ensure_resource_running("$clustermd_rsc", "is running on:[[:blank:]]*$node\[[:blank:]]*\$");
 
     # Test if cluster-md device is present on all nodes
-    assert_script_run "ls -la $clustermd_device";
+    # Sometimes in high performance virtual scenarios, it takes some seconds for the cluster_md
+    # device to be present in /dev, so this will check for some number of tries before failing
+    my $ret;
+    my $tries = 5;
+
+    while ($tries and $ret = script_run "ls -la $clustermd_device") {
+        --$tries;
+        sleep 2;
+    }
+    die "Test timed out while checking $clustermd_device" unless (defined $ret);
+    die "Nonexistent $clustermd_device after 10 seconds" unless ($tries > 0 or $ret == 0);
 
     # Wait until R/W state is checked
     barrier_wait("CLUSTER_MD_CHECKED_$cluster_name");

--- a/tests/ha/cluster_md.pm
+++ b/tests/ha/cluster_md.pm
@@ -88,15 +88,7 @@ sub run {
     # Test if cluster-md device is present on all nodes
     # Sometimes in high performance virtual scenarios, it takes some seconds for the cluster_md
     # device to be present in /dev, so this will check for some number of tries before failing
-    my $ret;
-    my $tries = 5;
-
-    while ($tries and $ret = script_run "ls -la $clustermd_device") {
-        --$tries;
-        sleep 2;
-    }
-    die "Test timed out while checking $clustermd_device" unless (defined $ret);
-    die "Nonexistent $clustermd_device after 10 seconds" unless ($tries > 0 or $ret == 0);
+    check_device_available($clustermd_device);
 
     # Wait until R/W state is checked
     barrier_wait("CLUSTER_MD_CHECKED_$cluster_name");

--- a/tests/ha/drbd_passive.pm
+++ b/tests/ha/drbd_passive.pm
@@ -150,6 +150,9 @@ sub run {
 
         # Check for result
         ensure_resource_running("ms_$drbd_rsc", ":[[:blank:]]*$node_01\[[:blank:]]*[Mm]aster\$");
+
+        # Check device
+        check_device_available("/dev/$drbd_rsc");
     }
     else {
         diag 'Wait until drbd resource is created/activated...';
@@ -169,6 +172,9 @@ sub run {
 
         # Node01 should be the Master
         ensure_resource_running("ms_$drbd_rsc", ":[[:blank:]]*$node_01\[[:blank:]]*[Mm]aster\$");
+
+        # Check device
+        check_device_available("/dev/$drbd_rsc");
     }
     else {
         diag 'Wait until drbd resource is restarted...';
@@ -195,6 +201,9 @@ sub run {
 
         # Check for result
         ensure_resource_running("ms_$drbd_rsc", ":[[:blank:]]*$node_02\[[:blank:]]*[Mm]aster\$");
+
+        # Check device
+        check_device_available("/dev/$drbd_rsc");
     }
 
     # Wait for DRBD resrouce migration to be done
@@ -218,6 +227,9 @@ sub run {
 
         # Check for result
         ensure_resource_running("ms_$drbd_rsc", ":[[:blank:]]*$node_01\[[:blank:]]*[Mm]aster\$");
+
+        # Check device
+        check_device_available("/dev/$drbd_rsc");
     }
 
     # Wait for DRBD resrouce migration to be done


### PR DESCRIPTION
Sometimes in high performance virtual scenarios, it takes some seconds for the cluster_md device to be present in `/dev` while running the `test/ha/cluster_md` test module.

This PR adds the method `check_device_available` to `lib/hacluster` to use instead of the call to `assert_script_run("ls -la $clustermd_device")` in the `test/ha/cluster_md` module; this method will check for some configurable number of tries for the existence of the device before failing.

Also part of the PR is the inclusion of a call to the method in the `ha/drbd_passive` module to check for the `/dev/drbd_passive` device.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
- Failed test: https://openqa.suse.de/tests/2495081#step/cluster_md/55
- Successful test: https://openqa.suse.de/tests/2495162 (same build, same test code)
