### PR TITLE
Add more time to match needles after checked dependency issue

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -189,7 +189,8 @@ sub deal_with_dependency_issues {
     }
 
     # Installer need time to adapt the proposal after conflicts fixed
-    assert_screen([qw(installation-settings-overview-loaded adapting_proposal)]);
+    # Refer ticket: https://progress.opensuse.org/issues/48371
+    assert_screen([qw(installation-settings-overview-loaded adapting_proposal)], 90);
     if (match_has_tag('adapting_proposal')) {
         my $timeout  = 600;
         my $interval = 10;


### PR DESCRIPTION
Need more time to match needles after checked dependency issue

- Related ticket: https://progress.opensuse.org/issues/48371
- Verification run:  https://openqa.suse.de/tests/2493490
[autoinst-log.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/2903493/autoinst-log.txt)

