### PR TITLE
Add aa_prepare to security apparmor test suites

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2109,6 +2109,7 @@ sub load_security_tests_mmtest {
 sub load_security_tests_apparmor {
     load_security_console_prepare;
 
+    loadtest "security/apparmor/aa_prepare" if (check_var('TEST', 'mau-apparmor'));
     loadtest "security/apparmor/aa_status";
     loadtest "security/apparmor/aa_enforce";
     loadtest "security/apparmor/aa_complain";
@@ -2122,6 +2123,7 @@ sub load_security_tests_apparmor {
 sub load_security_tests_apparmor_profile {
     load_security_console_prepare;
 
+    loadtest "security/apparmor/aa_prepare" if (check_var('TEST', 'mau-apparmor_profile'));
     loadtest "security/apparmor_profile/usr_sbin_dovecot";
     loadtest "security/apparmor_profile/usr_sbin_traceroute";
     loadtest "security/apparmor_profile/usr_sbin_nscd";

--- a/tests/security/apparmor/aa_prepare.pm
+++ b/tests/security/apparmor/aa_prepare.pm
@@ -1,0 +1,28 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Make sure apparmor is installed and running for later testing.
+# Maintainer: Juraj Hura <jhura@suse.com>
+
+use base "basetest";
+use strict;
+use testapi;
+use utils 'zypper_call';
+
+sub run {
+    zypper_call 'in -t pattern apparmor';
+    assert_script_run "systemctl start apparmor";
+}
+
+sub test_flags {
+    # 'milestone'      - after this test succeeds, update 'lastgood'
+    return { milestone => 1 };
+}
+
+1;


### PR DESCRIPTION
For apparmor and apparmor_profile test suites to run in QAM scenarios, apparmor needs to be installed and started first. Otherwise all tests will fail.

- Related ticket: https://progress.opensuse.org/issues/47465
- Verification run: http://hoorhay.suse.cz/tests/1022
                          http://hoorhay.suse.cz/tests/1023