### PR TITLE
Stop checking cloud-init & docker location on Kubic

### DIFF
--- a/tests/caasp/one_line_checks.pm
+++ b/tests/caasp/one_line_checks.pm
@@ -55,9 +55,8 @@ sub run_caasp_checks {
 }
 
 sub run_kubic_checks {
-    # Should not include docker or kubernetes
+    # Should not include kubernetes
     if (check_var('SYSTEM_ROLE', 'microos')) {
-        assert_script_run 'which docker';
         assert_script_run '! zypper se -i kubernetes';
         assert_script_run '! rpm -q etcd';
     }

--- a/tests/caasp/services_enabled.pm
+++ b/tests/caasp/services_enabled.pm
@@ -18,7 +18,8 @@ use testapi;
 use version_utils 'is_caasp';
 
 my %services_for = (
-    default => [qw(sshd cloud-init-local cloud-init cloud-config cloud-final issue-generator issue-add-ssh-keys transactional-update.timer)],
+    default => [qw(sshd issue-generator issue-add-ssh-keys transactional-update.timer)],
+    cloud   => [qw(cloud-init-local cloud-init cloud-config cloud-final)],
     cluster => [qw(chronyd)],
     admin   => [qw(docker kubelet etcd)],
     worker  => [qw(salt-minion systemd-timesyncd)],
@@ -36,6 +37,7 @@ sub run {
     my $role = get_var('SYSTEM_ROLE');
 
     check_services $services_for{default};
+    check_services $services_for{cloud}   if is_caasp('caasp');
     check_services $services_for{$role}   if $role;
     check_services $services_for{cluster} if $role =~ /admin|worker/;
 }


### PR DESCRIPTION
Kubic no longer has cloud-init installed by default, but it is still used by CaaSP, so check cloud-init services only on CaaSP.

Also, fix the one_line_check for docker

- Related ticket: https://openqa.opensuse.org/tests/862934#step/services_enabled/5

