### PR TITLE
Update KMP module handling

### DIFF
--- a/tests/rt/boot_rt_kernel.pm
+++ b/tests/rt/boot_rt_kernel.pm
@@ -20,6 +20,7 @@ use bootloader_setup 'boot_grub_item';
 sub run() {
     my $self = shift;
     $self->boot_grub_item(2, 3);
+    $self->wait_boot(bootloader_time => 120);
 }
 
 1;

--- a/tests/rt/rt_devel_packages.pm
+++ b/tests/rt/rt_devel_packages.pm
@@ -18,7 +18,7 @@ use utils;
 
 # https://fate.suse.com/316652
 sub run {
-    my $pkgs = "babeltrace-devel lttng-tools-devel kernel-rt-devel kernel-rt_debug-devel kernel-devel-rt libcpuset-devel";
+    my $pkgs = "babeltrace-devel lttng-tools-devel kernel-rt-devel kernel-rt_debug-devel kernel-devel-rt libcpuset-devel lttng-tools";
     zypper_call "in $pkgs";
 }
 


### PR DESCRIPTION
- Related ticket: [[sle][functional][y] - clarify which modules needs to be loaded manually in test module kmp_modules](https://progress.opensuse.org/issues/47390)
- Verification runs: 
   * [rt-validation_extra_tests@64bit](http://eris.suse.cz/tests/12184#step/kmp_modules/126)
   * [rt-validation_extra_tests@64bit](http://eris.suse.cz/tests/12310#step/kmp_modules/126)
