### PR TITLE
Stop/start serial grab only where necessary

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -43,7 +43,7 @@ sub prepare_system_shutdown {
         }
         console('installation')->disable_vnc_stalls;
     }
-    if (check_var('BACKEND', 'svirt')) {
+    if (check_var('VIRSH_VMM_FAMILY', 'xen') || get_var('S390_ZKVM')) {
         my $vnc_console = get_required_var('SVIRT_VNC_CONSOLE');
         console($vnc_console)->disable_vnc_stalls;
         console('svirt')->stop_serial_grab;
@@ -260,7 +260,7 @@ sub power_action {
         # Look aside before we are sure 'sut' console on VMware is ready, see poo#47150
         select_console('svirt') if is_vmware && $action eq 'reboot';
         reset_consoles;
-        if (check_var('BACKEND', 'svirt') && $action ne 'poweroff') {
+        if ((check_var('VIRSH_VMM_FAMILY', 'xen') || get_var('S390_ZKVM')) && $action ne 'poweroff') {
             console('svirt')->start_serial_grab;
         }
         # When 'sut' is ready, select it


### PR DESCRIPTION
Validation runs:
* `media_upgrade_sles15_allpatterns_hyperv@svirt-hyperv`: http://nilgiri.suse.cz/tests/326
* `default_install@svirt-hyperv`: https://openqa.suse.de/tests/2497685
* `default_install@svirt-vmware`: https://openqa.suse.de/tests/2497686
* `default_install@svirt-xen-pv`: https://openqa.suse.de/tests/2497687
* `default@s390x-kvm-sle12`: https://openqa.suse.de/tests/2497688 (fails after the critical section)