### PR TITLE
Run patch_and_reboot before apparmor test suites for QAM

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2106,7 +2106,10 @@ sub load_security_tests_mmtest {
 sub load_security_tests_apparmor {
     load_security_console_prepare;
 
-    loadtest "security/apparmor/aa_prepare" if (check_var('TEST', 'mau-apparmor'));
+    if (check_var('TEST', 'mau-apparmor')) {
+        loadtest "qa_automation/patch_and_reboot";
+        loadtest "security/apparmor/aa_prepare";
+    }
     loadtest "security/apparmor/aa_status";
     loadtest "security/apparmor/aa_enforce";
     loadtest "security/apparmor/aa_complain";
@@ -2120,7 +2123,10 @@ sub load_security_tests_apparmor {
 sub load_security_tests_apparmor_profile {
     load_security_console_prepare;
 
-    loadtest "security/apparmor/aa_prepare" if (check_var('TEST', 'mau-apparmor_profile'));
+    if (check_var('TEST', 'mau-apparmor_profile')) {
+        loadtest "qa_automation/patch_and_reboot";
+        loadtest "security/apparmor/aa_prepare";
+    }
     loadtest "security/apparmor_profile/usr_sbin_dovecot";
     loadtest "security/apparmor_profile/usr_sbin_traceroute";
     loadtest "security/apparmor_profile/usr_sbin_nscd";

--- a/tests/security/apparmor/aa_prepare.pm
+++ b/tests/security/apparmor/aa_prepare.pm
@@ -16,12 +16,12 @@ use testapi;
 use utils 'zypper_call';
 
 sub run {
+    select_console 'root-console';
     zypper_call 'in -t pattern apparmor';
     assert_script_run "systemctl start apparmor";
 }
 
 sub test_flags {
-    # 'milestone'      - after this test succeeds, update 'lastgood'
     return { milestone => 1 };
 }
 


### PR DESCRIPTION
Run patch_and_reboot in QAM scenarios before running whole apparmor test suites. And switch to root console before trying to run anything.

- Related ticket: https://progress.opensuse.org/issues/47465
- Verification run: http://hoorhay.suse.cz/tests/1059
                         http://hoorhay.suse.cz/tests/1060
