### PR TITLE
Add XRDP test for SLES4SAP

### DIFF
--- a/tests/x11/remote_desktop/windows_client_remotelogin.pm
+++ b/tests/x11/remote_desktop/windows_client_remotelogin.pm
@@ -15,6 +15,7 @@ use strict;
 use base 'x11test';
 use testapi;
 use lockapi;
+use version_utils 'is_sles4sap';
 
 sub run {
     my $self = shift;
@@ -39,10 +40,16 @@ sub run {
     send_key "ret";
 
     assert_screen "xrdp-sharing-activate", 120;
-    assert_and_click "close-xrdp-sharing-window";
-    assert_and_click "confirm-close-remote-session";
+    if (is_sles4sap) {
+        x11_start_program('gnome-session-quit --logout --force', valid => 0);
+    }
+    else {
+        assert_and_click "close-xrdp-sharing-window";
+        assert_and_click "confirm-close-remote-session";
+    }
     assert_and_click "close-remote-desktop-connection";
 
     send_key "c";
 }
+
 1;

--- a/tests/x11/remote_desktop/xrdp_server.pm
+++ b/tests/x11/remote_desktop/xrdp_server.pm
@@ -18,31 +18,51 @@ use lockapi;
 use mmapi;
 use mm_tests;
 use base 'opensusebasetest';
-use utils 'zypper_call';
-use x11utils 'turn_off_gnome_screensaver';
+use utils qw(systemctl zypper_call);
+use x11utils qw(handle_login turn_off_gnome_screensaver);
+use version_utils qw(is_sle is_sles4sap);
 
 sub run {
     my ($self) = @_;
+    my $firewall = $self->firewall;
 
-    # Setup static NETWORK
+    # Open xterm session
     x11_start_program('xterm');
     turn_off_gnome_screensaver;
     become_root;
+
+    # Setup static NETWORK
     configure_static_network('10.0.2.17/24');
 
-    # Install xrdp
-    zypper_call('in xrdp');
+    if (is_sles4sap) {
+        # xrdp should already be installed in SLES4SAP
+        assert_script_run 'rpm -q xrdp';
 
-    # Add the firewall port for xrdp
-    x11_start_program('xterm');
-    become_root;
-    assert_script_run 'firewall-cmd --zone=public --permanent --add-port=3389/tcp';
-    assert_script_run 'firewall-cmd --reload';
-    type_string "exit\n";
-    wait_screen_change { send_key 'alt-f4' };
+        # xrdp should already be started in SLES4SAP
+        systemctl 'status xrdp';
 
-    # Start xrdp
-    assert_script_run "systemctl start xrdp";
+        # A bug currently exists in SLES4SAP 15-SP1 with firewall not opened
+        # during installation (bsc#1125529) - workaround it
+        if (is_sle '=15-sp1') {
+            record_soft_failure('workaround for bsc#1125529');
+            # Add rules and reload firewall (firewalld is used in sle15+)
+            assert_script_run 'firewall-cmd --zone=public --permanent --add-port=3389/tcp';
+            systemctl "reload $firewall";
+        }
+    }
+    else {
+        # Install xrdp
+        zypper_call('in xrdp');
+
+        # Add the firewall port for xrdp
+        assert_script_run 'firewall-cmd --zone=public --permanent --add-port=3389/tcp';
+        assert_script_run 'firewall-cmd --reload';
+
+        # Start xrdp
+        systemctl 'start xrdp';
+    }
+
+    # Terminate xterm session
     type_string "exit\n";
     wait_screen_change { send_key 'alt-f4' };
     x11_start_program('gnome-session-quit --logout --force', valid => 0);
@@ -53,26 +73,33 @@ sub run {
     # Wait until xrdp client finishes remote access
     wait_for_children;
 
-    send_key_until_needlematch 'displaymanager', 'esc';
-    send_key 'ret';
-    assert_screen "displaymanager-password-prompt";
-    type_password;
-    wait_still_screen 3;
-    send_key "ret";
-    assert_screen "multiple-logins-notsupport";
-
-    # Force restart on gdm to check if the active session number is correct
-    assert_and_click "status-bar";
-    assert_and_click "power-button";
-    assert_screen([qw(other-users-logged-in-1user other-users-logged-in-2users)]);
-
-    if (match_has_tag('other-users-logged-in-2users')) {
-        record_soft_failure 'bsc#1116281 GDM didnt behave correctly when the error message Multiple logins are not supported. is triggered';
+    if (is_sles4sap) {
+        # We don't have to test the reconnection and reboot part in SLES4SAP
+        handle_login;
     }
-    assert_and_click "force-restart";
-    type_password;
-    send_key "ret";
+    else {
+        send_key_until_needlematch 'displaymanager', 'esc';
+        send_key 'ret';
+        assert_screen "displaymanager-password-prompt";
+        type_password;
+        wait_still_screen 3;
+        send_key "ret";
+        assert_screen "multiple-logins-notsupport";
 
-    $self->wait_boot;
+        # Force restart on gdm to check if the active session number is correct
+        assert_and_click "status-bar";
+        assert_and_click "power-button";
+        assert_screen([qw(other-users-logged-in-1user other-users-logged-in-2users)]);
+
+        if (match_has_tag('other-users-logged-in-2users')) {
+            record_soft_failure 'bsc#1116281 GDM didnt behave correctly when the error message Multiple logins are not supported. is triggered';
+        }
+        assert_and_click "force-restart";
+        type_password;
+        send_key "ret";
+
+        $self->wait_boot;
+    }
 }
+
 1;


### PR DESCRIPTION
SLES4SAP has an option to configure and activate XRDP during installation.

This commit add the ability to test this from a Windows client (because most of customers uses this feature from Windows).

- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1080
- Verification run: [XRDP server](http://1b147.qa.suse.de/tests/5073), [Windows client](http://1b147.qa.suse.de/tests/5074), [existing XRDP server](http://1b147.qa.suse.de/tests/5084), [existing Windows client](http://1b147.qa.suse.de/tests/5085)
