### PR TITLE
Add missing check_device_available to export array

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -47,6 +47,7 @@ our @EXPORT = qw(
   check_cluster_state
   wait_until_resources_started
   get_lun
+  check_device_available
   pre_run_hook
   post_run_hook
   post_fail_hook


### PR DESCRIPTION
New method `check_device_available` was not exported in the PR that introduced it (#6892).

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
