### PR TITLE
Add bug reference to workqueue lockup detection

### DIFF
--- a/lib/known_bugs.pm
+++ b/lib/known_bugs.pm
@@ -33,7 +33,7 @@ sub create_list_of_serial_failures {
 
 
     # Detect rogue workqueue lockup
-    push @$serial_failures, {type => 'hard', message => 'rogue workqueue lockup', pattern => quotemeta 'BUG: workqueue lockup'};
+    push @$serial_failures, {type => 'hard', message => 'rogue workqueue lockup bsc#1126782', pattern => quotemeta 'BUG: workqueue lockup'};
 
     # Detect bsc#1093797 on aarch64
     if (is_sle('=12-SP4') && check_var('ARCH', 'aarch64')) {


### PR DESCRIPTION
Adding a bugzilla reference to the detection of workqueue lockup
detection to be able to better track this failure and provide
better feedback to developers

After ongoing discussion we agreed, that in this specific case it makes sense to provide a bug reference

- Related ticket: https://progress.opensuse.org/issues/48419
