### PR TITLE
Add IMA measurement function test and re-organize the cases

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2153,13 +2153,13 @@ sub load_security_tests_selinux {
     loadtest "security/selinux/selinux_smoke";
 }
 
-sub load_security_tests_ima_setup {
-    load_security_console_prepare;
-
-    # Setup system environment for IMA testing
+sub load_security_tests_mok_enroll {
     loadtest "security/mokutil_sign";
+}
+
+sub load_security_tests_ima {
     loadtest "security/ima/ima_setup";
-    loadtest "shutdown/shutdown";
+    loadtest "security/ima/ima_measurement";
 }
 
 sub load_security_tests_system_check {
@@ -2172,7 +2172,7 @@ sub load_security_tests {
       ipsec mmtest
       apparmor apparmor_profile selinux
       openscap
-      ima_setup
+      mok_enroll ima
       system_check
       /;
 

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -280,6 +280,17 @@ sub load_slenkins_tests {
     return 0;
 }
 
+sub prepare_target {
+    if (get_var("BOOT_HDD_IMAGE")) {
+        boot_hdd_image;
+    }
+    else {
+        load_boot_tests();
+        load_inst_tests();
+        load_reboot_tests();
+    }
+}
+
 sub load_default_tests {
     load_boot_tests();
     load_inst_tests();
@@ -353,7 +364,7 @@ elsif (get_var("ISO_IN_EXTERNAL_DRIVE")) {
     load_reboot_tests();
 }
 elsif (get_var('SECURITY_TEST')) {
-    boot_hdd_image;
+    prepare_target();
     load_security_tests;
 }
 elsif (get_var('SYSTEMD_TESTSUITE')) {

--- a/tests/security/ima/ima_measurement.pm
+++ b/tests/security/ima/ima_measurement.pm
@@ -1,0 +1,67 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test IMA measurement function
+# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Tags: poo#48374
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use bootloader_setup 'add_grub_cmdline_settings';
+use power_action_utils "power_action";
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    my $meas_file    = "/sys/kernel/security/ima/ascii_runtime_measurements";
+    my $meas_tmpfile = "/tmp/ascii_runtime_measurements";
+    my $sample_file  = "/tmp/sample.txt";
+
+    add_grub_cmdline_settings('ima_policy=tcb', 1);
+
+    # Reboot to make settings work
+    power_action('reboot', textmode => 1);
+    $self->wait_boot;
+    $self->select_serial_terminal;
+
+    # Format verification
+    assert_script_run(
+        "head -n1 $meas_file |grep '^10\\s*[a-fA-F0-9]\\{40\\}\\s*ima-ng\\s*sha1:0\\{40\\}\\s*boot_aggregate'",
+        timeout      => '60',
+        fail_messege => 'boot_aggregate item check failed'
+    );
+
+    my $out = script_output("grep '^10\\s*[a-fA-F0-9]\\{40\\}\\s*ima-ng\\s*sha256:[a-fA-F0-9]\\{64\\}\\s*\\/' $meas_file |wc -l");
+    die('Too few sha256 items') if ($out < 800);
+
+    # Test a sample file created in run time
+    assert_script_run("echo 'This is a test!' > $sample_file");
+    my $sample_sha      = script_output("sha256sum $sample_file |cut -d' ' -f1");
+    my $sample_meas_sha = script_output("grep '$sample_file' $meas_file |awk -F'[ :]' '{print \$5}'");
+    die 'The SHA256 values does not match' if ($sample_sha ne $sample_meas_sha);
+
+    assert_script_run("cp $meas_file $meas_tmpfile");
+    upload_logs "$meas_tmpfile";
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
1. Implement IMA measurement function test 
2. Modify call function in lib/main_common to better organize cases.
3. Add prepare_target subrounte for openSUSE so that it is possbile to insert mok_enroll step during the image creating.

- Related ticket: https://progress.opensuse.org/issues/48374
- Verification run:
  - SLE 15 SP1: [Creating image](http://10.67.17.9/tests/489), [IMA testing](http://10.67.17.9/tests/506)
  - Tumbleweed: [Creating image](http://10.67.17.9/tests/514), [IMA testing](http://10.67.17.9/tests/515)