### PR TITLE
Support the openSUSE AArch64 JeOS flavor

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -544,6 +544,11 @@ sub load_jeos_tests {
         return;
     }
     unless (get_var('LTP_COMMAND_FILE')) {
+        if (check_var('ARCH', 'aarch64') && is_opensuse()) {
+            # Enable jeos-firstboot, due to boo#1020019
+            load_boot_tests();
+            loadtest "jeos/prepare_firstboot";
+        }
         load_boot_tests();
         loadtest "jeos/firstrun";
         loadtest "jeos/record_machine_id";

--- a/tests/jeos/prepare_firstboot.pm
+++ b/tests/jeos/prepare_firstboot.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Enable jeos-firstboot as required by openQA testsuite
+# Maintainer: Guillaume GARDET <guillaume@opensuse.org>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use utils 'zypper_call';
+
+sub run {
+    # Login with default credentials (root:linux)
+    assert_screen('linux-login', 300);
+    type_string("root\n",  wait_still_screen => 5);
+    type_string("linux\n", wait_still_screen => 5);
+
+    # Ensure YaST2-Firstboot is disabled, as we use jeos-firstboot in openQA
+    assert_script_run("systemctl disable YaST2-Firstboot");
+
+    # Install and enable jeos-firstboot
+    zypper_call('in jeos-firstboot');
+    assert_script_run("touch /var/lib/YaST2/reconfig_system");
+    assert_script_run("systemctl enable jeos-firstboot");
+
+    # Remove current root password
+    assert_script_run("sed -i 's/^root:[^:]*:/root:*:/' /etc/shadow", 600);
+
+    type_string("reboot\n");
+}
+
+1;

--- a/tests/jeos/prepare_rpi_image.pm
+++ b/tests/jeos/prepare_rpi_image.pm
@@ -17,9 +17,8 @@ use testapi;
 use utils 'zypper_call';
 
 sub run {
-    my $version       = get_var('VERSION');
-    my $build         = get_var('BUILD');
-    my $rpi_image_url = "http://openqa.suse.de/assets/hdd/SLES$version-JeOS.aarch64-15.1-RaspberryPi-Build$build.raw.xz";
+    my $rawname       = get_required_var('HDD_1_NAME');
+    my $rpi_image_url = autoinst_url("/assets/hdd/$rawname");
 
     (my $rpi_image_rawxz = $rpi_image_url) =~ s/.*\///;
     (my $rpi_image_raw   = $rpi_image_rawxz) =~ s/\.[^.]+$//;
@@ -27,7 +26,6 @@ sub run {
 
     select_console('root-console');
 
-    # System should be registered already - we need qemu-img binary
     zypper_call('ref');
     zypper_call('in --no-recommends qemu-tools');
 


### PR DESCRIPTION
Using an unfortunately complex test suite setup, a test converts the image, and the chained tests boot from it and install jeos-firstboot for proper JeOS testing.

It already found a product bug!

Verification runs:
http://10.161.32.77/tests/31
http://10.161.32.77/tests/32
