### PR TITLE
Disable kvm test on aarch64

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1501,7 +1501,7 @@ sub load_extra_tests_opensuse {
 sub load_extra_tests_qemu {
     loadtest "qemu/info";
     loadtest "qemu/qemu";
-    loadtest "qemu/kvm";
+    loadtest "qemu/kvm" unless check_var('ARCH', 'aarch64');    # nested kvm is not yet supported on ARM
     loadtest "qemu/user" if is_opensuse;
 }
 


### PR DESCRIPTION
Nested virt doesn't yet seem to be supported on ARM