### PR TITLE
Do not use shortcut for take_first_disk

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -473,7 +473,11 @@ sub take_first_disk {
         # depending on the scenario we get different screens
         # same can happen with ipmi installations
         assert_screen [qw(use-entire-disk preparing-disk-overview)];
-        wait_screen_change { send_key "alt-e" } if match_has_tag 'use-entire-disk';    # use entire disk
+        if (match_has_tag 'use-entire-disk') {
+            send_key_until_needlematch('use-entire-disk-selected', 'tab');
+            wait_screen_change { send_key 'ret' };
+            save_screenshot;
+        }
         send_key $cmd{next};
     }
 }


### PR DESCRIPTION
Use tab and enter instead of a shortcut in the function take_first_disk because they can be assigned randomly by libyui.

- Related ticket: https://progress.opensuse.org/issues/46622
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/commit/b016301954a7a42b53f2c8af1d02d5ff7aa0fbe9
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/commit/7b551363c2d10eb5b58e022855a89c2ff00cb13d
- Verification run: 
https://openqa.suse.de/tests/2504049#step/partitioning_firstdisk/6
https://openqa.suse.de/tests/2504048#step/partitioning_firstdisk/6
https://openqa.suse.de/tests/2504050#step/partitioning_iscsi/6