### PR TITLE
Create HDD for Terraform

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -67,6 +67,7 @@ our @EXPORT = qw(
   load_common_x11
   load_consoletests
   load_create_hdd_tests
+  load_create_hdd_terraform
   load_extra_tests
   load_inst_tests
   load_iso_in_external_tests
@@ -2245,6 +2246,11 @@ sub load_create_hdd_tests {
     }
 }
 
+sub load_create_hdd_terraform {
+    boot_hdd_image;
+    loadtest "terraform/create_image";
+}
+
 sub load_virtualization_tests {
     return unless get_var('VIRTUALIZATION');
     # standalone suite to fit needed installation
@@ -2381,6 +2387,7 @@ sub load_common_opensuse_sle_tests {
     load_toolchain_tests                if get_var("TCM") || check_var("ADDONS", "tcm");
     loadtest 'console/network_hostname' if get_var('NETWORK_CONFIGURATION');
     load_installation_validation_tests  if get_var('INSTALLATION_VALIDATION');
+    load_create_hdd_terraform           if get_var('TERRAFORM');
 }
 
 sub load_ssh_key_import_tests {

--- a/tests/terraform/create_image.pm
+++ b/tests/terraform/create_image.pm
@@ -1,0 +1,45 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Create HDD image that boots automatically and add a second
+#          interface config file.
+# Maintainer: Jose Lausuch <jalausuch@suse.com>
+
+
+use base 'opensusebasetest';
+use strict;
+use testapi;
+use warnings;
+use version_utils qw(is_sle is_tumbleweed is_leap);
+
+sub run {
+    my ($self) = @_;
+
+    select_console('root-console');
+
+    # Don't wait for user to press enter, boot the system automatically
+    assert_script_run('sed -i s/GRUB_TIMEOUT=-1/GRUB_TIMEOUT=0/ /etc/default/grub');
+    assert_script_run('grub2-mkconfig -o /boot/grub2/grub.cfg');
+
+    # Allow having a second NIC configurable
+    if (is_sle || is_leap) {
+        assert_script_run('cp /etc/sysconfig/network/ifcfg-eth0 /etc/sysconfig/network/ifcfg-eth1');
+        # Force eth0 as main NIC at first boot
+        assert_script_run('rm /etc/udev/rules.d/70-persistent-net.rules');
+    }
+    if (is_tumbleweed) {
+        assert_script_run('cp /etc/sysconfig/network/ifcfg-ens4 /etc/sysconfig/network/ifcfg-ens3');
+    }
+
+    # Allow any connection to the VM (e.g. ICMP, SSH, ...)
+    systemctl("disable firewalld");
+    systemctl("disable apparmor");
+}
+
+1;


### PR DESCRIPTION
Create a new qcow2 HDD based on the one created by create_hdd_textmode.
This will be consumed by Terraform, which basically needs:

- OS boots automatically (no user/needle interaction)
- Allow having a configuration for a second NIC (needed in some network tests)
- Disable Firewall to allow ping and ssh to the VMs (if firewall is needed by any test, it can be re-enabled or started by the test as such)

- Related ticket: https://progress.opensuse.org/issues/44207
- Verification runs: 
    SLE15-SP1: http://fromm.arch.suse.de/tests/5415
    Leap 15.1: http://fromm.arch.suse.de/tests/5414
    Tumbleweed: http://fromm.arch.suse.de/tests/5413
