### PR TITLE
Add post_fail_hook for podman

### DIFF
--- a/tests/console/podman.pm
+++ b/tests/console/podman.pm
@@ -123,4 +123,12 @@ sub run {
     die('error: podman rmi -a did not remove hello-world:latest')           if ($output_containers =~ m/Untagged: hello-world:latest/);
 }
 
+sub post_fail_hook {
+    my ($self) = @_;
+    select_console 'log-console';
+    script_run "podman version | tee /dev/$serialdev";
+    script_run "podman info --debug | tee /dev/$serialdev";
+    $self->SUPER::post_fail_hook;
+}
+
 1;


### PR DESCRIPTION
Podman upstream like the output of specific commands when Podman fails, have openQA capture those commands in a post_failure_hook
