### PR TITLE
Stop using wait_boot in boot_grub_item()

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -182,8 +182,6 @@ sub boot_grub_item {
     }
     save_screenshot;
     send_key 'ret';
-
-    $self->wait_boot(in_grub => 1);
 }
 
 


### PR DESCRIPTION
After commit e1c0176ce ("wait_boot: Simplify the initial bootloader
check with assert_screen") boot_grub_item() stop working as wait_grub()
is now using assert_screen() instead of check_screen().

IMHO needles matching in boot_grub_item() was never working, but
check_screen() tolerate it. Let's stop using wait_boot until proper
solution is find.

Fixes: poo#48515

- Verification run: http://quasar.suse.cz/tests/1920
