### PR TITLE
fix the sles11sp4 installation with autoyast profile on ipmi backend

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -250,7 +250,7 @@ sub run {
     }
 
     # If we didn't see pxe, the reboot is going now
-    $self->wait_boot if check_var('BACKEND', 'ipmi') and not $pxe_boot_done;
+    $self->wait_boot if check_var('BACKEND', 'ipmi') and not get_var('VIRT_AUTOTEST') and not $pxe_boot_done;
 
     # CaaSP does not have second stage
     return if is_caasp;


### PR DESCRIPTION
It is to fix action #41960: [sle] test fails in installation: Grub installation failed.

The autoyast installation for sles11sp4 finished but stopped after login due to wait for grub menu.
https://openqa.suse.de/tests/2499347#

Here skip the waiting for boot and continue with login in Virtualization tests to fix the problem.

- Related ticket: https://progress.opensuse.org/issues/41960
- Verification run: 
installation for kvm:  http://10.67.18.247/tests/296
installation for the xen: http://10.67.18.247/tests/307

