### PR TITLE
Make myhostname explicit

### DIFF
--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -63,6 +63,7 @@ sub run() {
     assert_script_run "postconf -e 'smtpd_sasl_auth_enable = yes'";
     assert_script_run "postconf -e 'smtpd_sasl_path = private/auth'";
     assert_script_run "postconf -e 'smtpd_sasl_type = dovecot'";
+    assert_script_run "postconf -e 'myhostname = localhost'";
 
     # start/restart services
     systemctl 'start dovecot';


### PR DESCRIPTION
Sometimes, the hostname of the machine is not properly set during postfix initial configuration. Make sure it accepts mail for localhost.

- Related ticket: https://progress.opensuse.org/issues/48407
- Verification run: http://panigale.suse.cz/tests/1465
