### PR TITLE
Fix SLES4SAP XRDP test

### DIFF
--- a/tests/x11/remote_desktop/xrdp_server.pm
+++ b/tests/x11/remote_desktop/xrdp_server.pm
@@ -74,12 +74,13 @@ sub run {
     # Wait until xrdp client finishes remote access
     wait_for_children;
 
+    send_key_until_needlematch 'displaymanager', 'esc';
+
     if (is_sles4sap) {
         # We don't have to test the reconnection and reboot part in SLES4SAP
         handle_login;
     }
     else {
-        send_key_until_needlematch 'displaymanager', 'esc';
         send_key 'ret';
         assert_screen "displaymanager-password-prompt";
         type_password;


### PR DESCRIPTION
Sometimes screensaver can appears on the XRDP server during the test and thus can avoid login at the end of the test.

This commit fix this.

- Verification run: http://1b147.qa.suse.de/tests/5094
