### PR TITLE
Schedule ntp_client test on JeOS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1529,7 +1529,7 @@ sub load_extra_tests_console {
     }
     loadtest "console/cron" unless is_jeos;
     loadtest "console/syslog";
-    loadtest "console/ntp_client" if (!is_sle && !is_jeos);
+    loadtest "console/ntp_client" if (!is_sle || is_jeos);
     loadtest "console/mta" unless is_jeos;
     loadtest "console/check_default_network_manager";
     loadtest "console/ipsec_tools_h2h" if get_var("IPSEC");


### PR DESCRIPTION
JeOS will use chrony so the existing test can be run.

- Related ticket: https://progress.opensuse.org/issues/46901
- Verification run: http://ccret.suse.cz/tests/2839#
