### PR TITLE
Add yast2_lan_device_settings test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1489,6 +1489,7 @@ sub load_extra_tests_desktop {
             loadtest 'x11/network/yast2_network_use_nm';
             loadtest 'x11/network/NM_wpa2_enterprise';
         }
+        loadtest 'console/yast2_lan_device_settings';
         loadtest "console/check_default_network_manager";
     }
 }
@@ -1554,6 +1555,7 @@ sub load_extra_tests_console {
     loadtest "console/syslog";
     loadtest "console/ntp_client" if (!is_sle || is_jeos);
     loadtest "console/mta" unless is_jeos;
+    loadtest "console/yast2_lan_device_settings";
     loadtest "console/check_default_network_manager";
     loadtest "console/ipsec_tools_h2h" if get_var("IPSEC");
     loadtest "console/git";

--- a/lib/y2lan_utils.pm
+++ b/lib/y2lan_utils.pm
@@ -1,27 +1,32 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2018 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: YaST logic on Network Restart while no config changes were made
-# Maintainer: Joaquín Rivera <jeriveramoya@suse.com>
-# Tags: fate#318787 poo#11450
+# Summary: Useful subroutines for yast2_lan related test modules
+# Maintainer: Veronika Svecova <vsvecova@suse.com>
 
-package y2lan_restart_common;
+package y2lan_utils;
 
+use base "opensusebasetest";
 use strict;
 use warnings;
-use Exporter 'import';
+use utils;
 use testapi;
-use utils 'systemctl';
+use Exporter 'import';
 use version_utils qw(is_sle is_leap);
 use y2_common 'accept_warning_network_manager_default';
 
 our @EXPORT = qw(
+  open_yast2_lan_first_time
+  open_yast2_lan_again
+  close_yast2_lan
+  handle_Networkmanager_controlled
+  handle_dhcp_popup
   check_etc_hosts_update
   close_network_settings
   check_network_status
@@ -31,8 +36,102 @@ our @EXPORT = qw(
   verify_network_configuration
 );
 
-sub initialize_y2lan
-{
+=head2 handle_Networkmanager_controlled
+
+Confirms the network manager pop up and closes off yast2 lan.
+
+=cut
+
+sub handle_Networkmanager_controlled {
+    send_key "ret";    # confirm networkmanager popup
+    assert_screen "Networkmanager_controlled-approved";
+    send_key "alt-c";
+    if (check_screen('yast2-lan-really', 3)) {
+        # SLED11...
+        send_key 'alt-y';
+    }
+    wait_serial("yast2-lan-status-0", 60) || die "'yast2 lan' didn't finish";
+}
+
+=head2 handle_dhcp_popup
+
+Closes DHCP pop up window when dhcp-popup needle is matched.
+
+=cut
+
+sub handle_dhcp_popup {
+    if (match_has_tag('dhcp-popup')) {
+        wait_screen_change { send_key 'alt-o' };
+    }
+}
+
+=head2 open_yast2_lan_first_time
+
+Opens yast2 lan and checks for DHCP, firewall and network manager pop ups. Installs firewall in case there is a requirement to do so.
+
+To open yast2 lan again within the same module, open_yast2_lan_again should be used, as it skips the pop up checks that are only relevant the first time.
+
+Requires a root console to be open first.
+
+=cut
+
+sub open_yast2_lan_first_time {
+    script_run("yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev", 0);
+    assert_screen [qw(Networkmanager_controlled yast2_lan install-susefirewall2 install-firewalld dhcp-popup)], 120;
+    handle_dhcp_popup;
+    if (match_has_tag('Networkmanager_controlled')) {
+        handle_Networkmanager_controlled;
+        return "Controlled by network manager";
+    }
+    if (match_has_tag('install-susefirewall2') || match_has_tag('install-firewalld')) {
+        # install firewall
+        send_key "alt-i";
+        # check yast2_lan again after firewall is installed
+        assert_screen [qw(Networkmanager_controlled yast2_lan)], 90;
+        if (match_has_tag('Networkmanager_controlled')) {
+            handle_Networkmanager_controlled;
+            return "Controlled by network manager";
+        }
+    }
+}
+
+=head2 open_yast2_lan_again
+
+Opens yast2 lan for second time or more within the same module.
+Does not check for any pop ups, therefore it is advisable to use it after the pop ups have been handled, for example by open_yast2_lan_first_time.
+
+Needs to be run in a root console.
+
+=cut
+
+sub open_yast2_lan_again {
+    script_run("yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev", 0);
+    assert_screen [qw(yast2_lan dhcp-popup)], 90;
+    handle_dhcp_popup;
+}
+
+=head2 close_yast2_lan
+
+Closes yast2 lan.
+
+=cut
+
+sub close_yast2_lan {
+    send_key "alt-o";    # OK=>Save&Exit
+    wait_serial("yast2-lan-status-0", 180) || die "'yast2 lan' didn't finish";
+    wait_still_screen;
+    clear_console;
+}
+
+=head2 initialize_y2lan
+
+Prepares the SUT for working with yast2 lan.
+
+Disables firewall to avoid firewall pop ups and enables the debug setting in network config.
+
+=cut
+
+sub initialize_y2lan {
     select_console 'x11';
     x11_start_program("xterm -geometry 155x50+5+5", target_match => 'xterm');
     become_root;
@@ -48,6 +147,12 @@ sub initialize_y2lan
     assert_script_run '> journal.log';    # clear journal.log
 }
 
+=head2 open_network_settings
+
+Opens yast2 lan, selects the first available device and opens its settings.
+
+=cut
+
 sub open_network_settings {
     type_string "yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev\n";
     accept_warning_network_manager_default;
@@ -55,6 +160,12 @@ sub open_network_settings {
     send_key 'home';                      # select first device
     wait_still_screen 1, 1;
 }
+
+=head2 close_network_settings
+
+Closes yast2 lan and handles a firewall warning pop up, if applicable.
+
+=cut
 
 sub close_network_settings {
     wait_still_screen 1, 1;
@@ -78,6 +189,12 @@ sub close_network_settings {
     type_string "\n\n";    # make space for better readability of the console
 }
 
+=head2 check_network_status
+
+Checks that connection and DNS are working without issues on a selected $device.
+
+=cut
+
 sub check_network_status {
     my ($expected_status, $device) = @_;
     $expected_status //= 'no_restart';
@@ -87,7 +204,7 @@ sub check_network_status {
         record_soft_failure 'bsc#992113';
     }
     else {
-        assert_script_run 'dig suse.com|grep \'status: NOERROR\'';    # test if conection and DNS is working
+        assert_script_run 'dig suse.com|grep \'status: NOERROR\'';    # test if connection and DNS is working
     }
     assert_script_run 'cat journal.log';                              # print journal.log
     if ($expected_status eq 'restart') {
@@ -98,15 +215,27 @@ sub check_network_status {
     type_string "\n\n";                                               # make space for better readability of the console
 }
 
+=head2 verify_network_configuration
+
+Verifies that a specific defined action $fn is performed correctly on $device.
+
+=cut
+
 sub verify_network_configuration {
     my ($fn, $dev_name, $expected_status, $workaround, $no_network_check) = @_;
     open_network_settings;
 
-    $fn->($dev_name) if $fn;                                          # verify specific action
+    $fn->($dev_name) if $fn;    # verify specific action
 
     close_network_settings;
     check_network_status($expected_status, $workaround) unless defined $no_network_check;
 }
+
+=head2 validate_etc_hosts_entry
+
+Verifies that a specific string is present in /etc/hosts.
+
+=cut
 
 sub validate_etc_hosts_entry {
     my (%args) = @_;
@@ -115,6 +244,13 @@ sub validate_etc_hosts_entry {
       && record_soft_failure "bsc#1115644 Expected entry:\n \"@{[$args{ip}]}    @{[$args{fqdn}]} @{[$args{host}]}\" was not found in /etc/hosts";
     script_run "cat /etc/hosts";
 }
+
+=head2 set_network
+
+Opens yast2 lan, sets network according to defined settings and closes yast2 lan.
+By default assigns networks settings to DHCP. Alternatively, it can be set to a specified static IP or mask.
+
+=cut
 
 sub set_network {
     my (%args) = @_;
@@ -126,12 +262,12 @@ sub set_network {
         send_key 'alt-t';    # set to static ip
         assert_screen 'yast2_lan_static_ip_selected';
         send_key 'tab';
-        if ($args{ip}) {     # To spare time, no update what to is already filled from previous run
+        if ($args{ip}) {     # To spare time, no update to what is already filled from previous run
             send_key_until_needlematch('ip_textfield_empty', 'backspace');    # delete existing IP if any
             type_string $args{ip};
         }
         send_key 'tab';
-        if ($args{mask}) {                                                    # To spare time, no update what to is already filled from previous run
+        if ($args{mask}) {                                                    # To spare time, no update to what is already filled from previous run
             send_key_until_needlematch('mask_textfield_empty', 'backspace');    # delete existing netmask if any
             type_string $args{mask};
         }
@@ -157,8 +293,10 @@ In order to target bugs bsc#1115644 and bsc#1052042, we want to :
 - Set static IP and fqdn for first NIC in the list and check /etc/hosts formatting
 - Open yast2 lan again and change the fqdn, check if /etc/hosts is changed correctly ( bsc#1052042 )
 - Set it to DHCP
-- Set it again to static with  new FQDN and check if /etc/hosts is changed correctly ( bsc#1115644 )
+- Set it again to static with new FQDN and check if /etc/hosts is changed correctly ( bsc#1115644 )
+
 =cut
+
 sub check_etc_hosts_update {
 
     my $ip   = '192.168.122.10';

--- a/tests/console/yast2_lan_device_settings.pm
+++ b/tests/console/yast2_lan_device_settings.pm
@@ -1,0 +1,128 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Device setup test for yast2-lan/yast2-network
+# Maintainer: Veronika Svecova <vsvecova@suse.com>
+
+use base "console_yasttest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils qw(is_sle is_leap);
+use y2lan_utils;
+
+sub run {
+    my $self      = shift;
+    my $static_ip = "192.168.1.119";
+
+    select_console 'root-console';
+    assert_script_run "zypper -n in yast2-network";    # make sure yast2 lan module is installed
+
+    # for debugging purposes only
+    script_run('ip a');
+    script_run('ls -alF /etc/sysconfig/network/');
+    save_screenshot;
+
+    my $opened = open_yast2_lan_first_time;
+    wait_still_screen;
+    if ($opened eq "Controlled by network manager") {
+        return;
+    }
+
+    send_key "alt-i";    # open edit device dialog
+    assert_screen 'edit-network-card';
+    send_key "alt-t";    # select static IP address option
+    send_key "tab";
+    type_string $static_ip;
+    send_key "alt-n";    # next
+    assert_screen 'static-ip-address-set';
+    close_yast2_lan;
+
+    # verify that static IP has been set
+    assert_script_run "ip a | grep $static_ip";
+
+    open_yast2_lan_again;
+    for (1 .. 2) { send_key "tab" }    # move to device list
+    send_key "alt-i";                  # open edit device dialog
+    wait_still_screen;
+    assert_screen 'edit-network-card';
+    send_key "alt-y";                  # select dynamic address option
+    send_key "alt-n";                  # next
+    assert_screen 'dynamic-ip-address-set';
+    close_yast2_lan;
+
+    # verify that dynamic IP address has been set
+    assert_script_run "ip r s | grep dhcp";
+
+    # on SLE15-SP1+ / Leap 15.1+ the assign loopback checkbox has been dropped
+    if (is_sle('<=15') || is_leap('<= 15.0')) {
+        open_yast2_lan_again;
+
+        send_key "alt-s";              # move to hostname/DNS tab
+        send_key "alt-a";              # assign hostname to loopback IP
+        assert_screen 'loopback-assigned';
+        close_yast2_lan;
+
+        # verify that loopback has been set
+        assert_script_run "cat /etc/hosts | grep 127.0.0.2";
+
+        open_yast2_lan_again;
+
+        # unassign back from loopback IP
+        send_key "alt-s";
+        send_key "alt-a";
+        assert_screen 'loopback-unassigned';
+        close_yast2_lan;
+    }
+
+    open_yast2_lan_again;
+
+    send_key "alt-a";    # add another device
+    send_key "tab";
+    for (1 .. 3) { send_key "down" }    # open device type drop down and select vlan
+    send_key "ret";
+    assert_screen 'add-vlan-selected';
+    send_key "alt-n";                   # next
+    assert_screen 'edit-network-card';
+    send_key "alt-y";                   # set dynamic address
+    assert_screen 'dynamic-address-selected';
+    send_key "alt-n";                   # next
+    assert_screen 'vlan-added';
+    close_yast2_lan;
+
+    # verify that VLAN device has been added
+    assert_script_run "ls -l /etc/sysconfig/network/ | grep vlan";
+
+    open_yast2_lan_again;
+
+    for (1 .. 2) { send_key "tab" }     # move to device list
+    send_key "down";                    # move to vlan
+    assert_screen 'vlan-selected';
+    send_key "alt-t";                   # remove vlan
+    assert_screen 'vlan-deleted';
+    close_yast2_lan;
+    wait_still_screen;
+
+    # check that correct module comes up as well when yast2 network is run
+    script_run("yast2 network; echo yast2-network-status-\$? > /dev/$serialdev", 0);
+    assert_screen 'yast2-network';
+    send_key "alt-l";                   # launch available network module
+    assert_screen [qw(yast2_lan dhcp-popup)], 90;
+    handle_dhcp_popup;
+    send_key "alt-o";                   # OK=>Save&Exit
+    wait_serial("yast2-network-status-0", 180) || die "'yast2 network' didn't finish";
+
+    clear_console;
+    script_run('ip -o a s');
+    script_run('ip r s');
+    assert_script_run('getent ahosts ' . get_var("OPENQA_HOSTNAME"));
+}
+
+1;

--- a/tests/x11/yast2_lan_restart.pm
+++ b/tests/x11/yast2_lan_restart.pm
@@ -16,7 +16,7 @@ use base 'y2logsstep';
 use strict;
 use warnings;
 use testapi;
-use y2lan_restart_common;
+use y2lan_utils;
 use y2_common 'is_network_manager_default';
 
 sub check_network_settings_tabs {

--- a/tests/x11/yast2_lan_restart_devices.pm
+++ b/tests/x11/yast2_lan_restart_devices.pm
@@ -16,7 +16,7 @@ use base 'y2logsstep';
 use strict;
 use warnings;
 use testapi;
-use y2lan_restart_common qw(initialize_y2lan open_network_settings close_network_settings check_network_status);
+use y2lan_utils qw(initialize_y2lan open_network_settings close_network_settings check_network_status);
 
 sub check_bsc1111483 {
     return 0 unless match_has_tag('yast2_lan_device_bsc1111483');


### PR DESCRIPTION
Based on feedback to previous PR#6724, I have removed the changes from the yast2_lan test module into a new separate test module.

I have also reworked the functions that open yast2-lan and moved them to a library module.

- Related ticket: https://progress.opensuse.org/issues/43139
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1063
- Verification run:
  - yast2_lan_device_settings:
    - SLE12-SP3
      - http://dreamyhamster.suse.cz/tests/614#step/yast2_lan_device_settings/9
      - http://dreamyhamster.suse.cz/tests/615#step/yast2_lan_device_settings/15
    - SLE12-SP4
      - http://dreamyhamster.suse.cz/tests/613#step/yast2_lan_device_settings/11
    - SLE15-GA
      - http://dreamyhamster.suse.cz/tests/612#step/yast2_lan_device_settings/11
    - SLE12-SP5
      - http://dreamyhamster.suse.cz/tests/628#step/yast2_lan_device_settings/15
    - SLE15-SP1
      - http://dreamyhamster.suse.cz/tests/629#step/yast2_lan_device_settings/15
    - openSUSE
      - http://dreamyhamster.suse.cz/tests/639#step/yast2_lan_device_settings/9
  - yast2_lan:
    - SLE12-SP3
      - http://dreamyhamster.suse.cz/tests/616#step/yast2_lan/9
    - SLE12-SP4
      - http://dreamyhamster.suse.cz/tests/617#step/yast2_lan/9
    - SLE15-GA
      - http://dreamyhamster.suse.cz/tests/622#step/yast2_lan/9
    - SLE12-SP5
      - http://dreamyhamster.suse.cz/tests/625#step/yast2_lan/10
    - SLE15-SP1
      - http://dreamyhamster.suse.cz/tests/621#step/yast2_lan/10
    - openSUSE
