### PR TITLE
Schedule orphaned_packages_check in more scenarios

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1081,7 +1081,6 @@ sub load_consoletests {
     loadtest "console/consoletest_setup";
     loadtest 'console/integration_services' if is_hyperv || is_vmware;
     loadtest "locale/keymap_or_locale";
-    loadtest "console/orphaned_packages_check" if is_jeos;
     loadtest "console/force_scheduled_tasks" unless is_jeos;
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/check_locked_package";
@@ -1203,7 +1202,8 @@ sub load_consoletests {
     if (check_var_array('SCC_ADDONS', 'tcm') && get_var('PATTERNS') && is_sle('<15') && !get_var("MEDIA_UPGRADE")) {
         loadtest "feature/feature_console/deregister";
     }
-    loadtest 'console/orphaned_packages_check' if get_var('UPGRADE');
+
+    loadtest 'console/orphaned_packages_check';
     loadtest "console/consoletest_finish";
 }
 
@@ -1585,6 +1585,7 @@ sub load_extra_tests_console {
     loadtest 'console/timezone';
     loadtest 'console/procps';
     loadtest "console/lshw" if ((is_sle('15+') && check_var('ARCH', 'ppc64le')) || is_opensuse);
+    loadtest 'console/orphaned_packages_check';
 }
 
 sub load_extra_tests_docker {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -472,7 +472,6 @@ sub load_online_migration_tests {
     if (check_var("MIGRATION_METHOD", 'zypper')) {
         loadtest "migration/sle12_online_migration/zypper_migration";
     }
-    loadtest 'console/orphaned_packages_check';
     loadtest "migration/sle12_online_migration/post_migration";
 }
 


### PR DESCRIPTION
orphaned_packages_check should be part of general installation
validation and not only for upgrades or migrations.

It now runs in more scenarios (default, extra_tests_in_textmode) but
there is also one that it does not run in anymore:
sle-15-SP1-Installer-DVD-x86_64-Build175.4-online_sles15_pscc_basesys+srv_def_full_y@64bit.
It still runs in other migration scenarios, so this should not be an
issue.

- Related ticket: https://progress.opensuse.org/issues/47339

I checked the schedules of                                                                                          
sle-15-SP1-Installer-DVD-x86_64-Build178.3-default@64bit,
sle-15-SP1-Installer-DVD-x86_64-Build178.3-extra_tests_in_textmode@64bit,                                                                                     
sle-15-SP1-JeOS-for-kvm-and-xen-x86_64-Build33.12-jeos-main@uefi-virtio-vga,                                                                                  
sle-15-SP1-Installer-DVD-x86_64-Build175.4-online_sled15_pscc_basesys+desk+dev+we_all_full_y@64bit,                                                    
opensuse-Tumbleweed-DVD-x86_64-Build20190220-update_Leap_15.0_gnome@64bit locally with isotovideo but did not upload the results anywhere.
