### PR TITLE
Fix create terraform HDD test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -68,7 +68,6 @@ our @EXPORT = qw(
   load_common_x11
   load_consoletests
   load_create_hdd_tests
-  load_create_hdd_terraform
   load_extra_tests
   load_inst_tests
   load_iso_in_external_tests
@@ -2261,11 +2260,6 @@ sub load_create_hdd_tests {
     }
 }
 
-sub load_create_hdd_terraform {
-    boot_hdd_image;
-    loadtest "terraform/create_image";
-}
-
 sub load_virtualization_tests {
     return unless get_var('VIRTUALIZATION');
     # standalone suite to fit needed installation
@@ -2398,11 +2392,11 @@ sub load_installation_validation_tests {
 sub load_common_opensuse_sle_tests {
     load_autoyast_clone_tests           if get_var("CLONE_SYSTEM");
     load_publiccloud_tests              if get_var('PUBLIC_CLOUD');
+    loadtest "terraform/create_image"   if get_var('TERRAFORM');
     load_create_hdd_tests               if get_var("STORE_HDD_1") || get_var("PUBLISH_HDD_1");
     load_toolchain_tests                if get_var("TCM") || check_var("ADDONS", "tcm");
     loadtest 'console/network_hostname' if get_var('NETWORK_CONFIGURATION');
     load_installation_validation_tests  if get_var('INSTALLATION_VALIDATION');
-    load_create_hdd_terraform           if get_var('TERRAFORM');
 }
 
 sub load_ssh_key_import_tests {

--- a/tests/terraform/create_image.pm
+++ b/tests/terraform/create_image.pm
@@ -16,6 +16,7 @@ use base 'opensusebasetest';
 use strict;
 use testapi;
 use warnings;
+use utils 'systemctl';
 use version_utils qw(is_sle is_tumbleweed is_leap);
 
 sub run {
@@ -38,7 +39,7 @@ sub run {
     }
 
     # Allow any connection to the VM (e.g. ICMP, SSH, ...)
-    systemctl("disable firewalld");
+    systemctl("disable " . opensusebasetest::firewall);
     systemctl("disable apparmor");
 }
 


### PR DESCRIPTION
There was a problem with the order the tests are executed. I simplified a bit the code without creating a new sub.

This also fixes the problem disabling the SuSEFirewall2 for SLE12

- Verification runs:
SLE15-SP1 : http://fromm.arch.suse.de/tests/5430  (main target)
SLE12-SP5 :  http://fromm.arch.suse.de/tests/5432
Tumbleweed : http://fromm.arch.suse.de/tests/5434
Leap15.1: http://fromm.arch.suse.de/tests/5433