### PR TITLE
Confirm the screen has changed, exit the loop correctly

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -85,6 +85,8 @@ sub workaround_dependency_issues {
         while (check_screen('dependency-issue', 5)) {
             wait_screen_change { send_key 'alt-1' };
             select_conflict_resolution;
+            # Refer ticket https://progress.opensuse.org/issues/48266
+            wait_still_screen(2);
         }
     }
     return 1;
@@ -107,6 +109,8 @@ sub break_dependency {
             # 2 is the option to break dependency
             send_key 'alt-2';
             select_conflict_resolution;
+            # Refer ticket https://progress.opensuse.org/issues/48266
+            wait_still_screen(2);
         }
     }
 }


### PR DESCRIPTION
Did workaround for send key delay, unexpected screen showup

- Related ticket: https://progress.opensuse.org/issues/48266
- Verification run: http://openqa-apac1.suse.de/tests/3436
[autoinst-log.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/2917808/autoinst-log.txt)

