### PR TITLE
In patch_sle we should wait a while to get the password.

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -483,6 +483,7 @@ sub wait_boot {
             type_line_svirt '', expect => $login_ready, timeout => $ready_time + 100, fail_message => 'Could not find login prompt';
             type_line_svirt "root", expect => 'Password';
             type_line_svirt "$testapi::password";
+	    sleep 10; 
             type_line_svirt "systemctl is-active network", expect => 'active';
             type_line_svirt 'systemctl is-active sshd',    expect => 'active';
 

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -483,7 +483,8 @@ sub wait_boot {
             type_line_svirt '', expect => $login_ready, timeout => $ready_time + 100, fail_message => 'Could not find login prompt';
             type_line_svirt "root", expect => 'Password';
             type_line_svirt "$testapi::password";
-	    sleep 10; 
+            # we need wait a while before we got the password, poo#45515
+            sleep 10;
             type_line_svirt "systemctl is-active network", expect => 'active';
             type_line_svirt 'systemctl is-active sshd',    expect => 'active';
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -754,7 +754,8 @@ sub ensure_serialdev_permissions {
         assert_script_run "chown $username /dev/$serialdev";
     }
     else {
-        assert_script_run "chown $testapi::username /dev/$testapi::serialdev && gpasswd -a $testapi::username \$(stat -c %G /dev/$testapi::serialdev)";
+        assert_script_run "chown $testapi::username /dev/$testapi::serialdev";
+        assert_script_run "gpasswd -a $testapi::username \$(stat -c %G /dev/$testapi::serialdev)";
     }
 }
 


### PR DESCRIPTION
in patch_sle we need to wait for a while to get the password, the following check for is-active network expect 'active' but it got the root password from the preceding step. the issue is change user and gpasswd cost too much time.

- Related ticket: https://progress.opensuse.org/issues/45515

- Verification run: http://openqa-apac1.suse.de/tests/3463