### PR TITLE
dump btrfs image if got inconsistent error

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -245,6 +245,14 @@ sub copy_log {
     script_run($cmd);
 }
 
+sub dump_btrfs_img {
+    my ($category, $num) = @_;
+    my $cmd = "echo \"no inconsistent error, skip btrfs image dump\"";
+    my $ret = script_output("egrep -m 1 \"filesystem on .+ is inconsistent\" $LOG_DIR/$category/$num");
+    if ($ret =~ /filesystem on (.+) is inconsistent/) { $cmd = "umount $1;btrfs-image $1 $LOG_DIR/$category/$num.img"; }
+    script_run($cmd);
+}
+
 sub run {
     my $self = shift;
     select_console('root-console');
@@ -273,6 +281,7 @@ sub run {
                 copy_log($category, $num, 'out.bad');
                 copy_log($category, $num, 'full');
                 copy_log($category, $num, 'dmesg');
+                if ($category == "btrfs") { dump_btrfs_img($category, $num); }
             }
             next;
         }


### PR DESCRIPTION
Signed-off-by: An Long <lan@suse.com>

dump btrfs image if got inconsistent error under xfstest

- Related ticket: https://progress.opensuse.org/issues/45986
- Verification run: 
http://10.67.133.10/tests/51#step/1_/1 (pass)
http://10.67.133.10/tests/70#downloads (failed, and img file in log-btrfs.tar.xz)

