### PR TITLE
Exclude useless console font check on remote backends

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -16,7 +16,7 @@
 use base "consoletest";
 use testapi;
 use utils;
-use Utils::Backends 'use_ssh_serial_console';
+use Utils::Backends qw(has_ttys use_ssh_serial_console);
 use strict;
 
 sub disable_bash_mail_notification {
@@ -34,7 +34,7 @@ sub run {
     # Stop serial-getty on serial console to avoid serial output pollution with login prompt
     disable_serial_getty;
     # init
-    check_console_font;
+    check_console_font if has_ttys();
 
     script_run 'echo "set -o pipefail" >> /etc/bash.bashrc.local';
     script_run '. /etc/bash.bashrc.local';


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/48398
- Verification run: (coming soon)
