### PR TITLE
klp: Don't run SUSEConnect for SLE 12 SP5

### DIFF
--- a/tests/kernel/qa_test_klp.pm
+++ b/tests/kernel/qa_test_klp.pm
@@ -38,7 +38,7 @@ sub run {
     zypper_call('ar -f -G ' . get_required_var('QA_HEAD_REPO') . ' qa_head');
     zypper_call('in -l bats hiworkload', exitcode => [0, 106, 107]);
 
-    add_suseconnect_product("sle-sdk") if (is_sle('<15'));
+    add_suseconnect_product("sle-sdk") if (is_sle('<12-SP5'));
 
     zypper_call('in -l git gcc kernel-devel make');
 


### PR DESCRIPTION
Fixes failure
https://openqa.suse.de/tests/2508291#step/qa_test_klp/11
Test died: command 'SUSEConnect -p sle-sdk/12.5/x86_64 ' failed

Verification run
* SLE12 SP5
http://quasar.suse.cz/tests/1926
* SLE15 SP1
http://quasar.suse.cz/tests/1927

Fixes: poo#48575