### PR TITLE
[WIP] Fix too early timeout when shutting down minimalx

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -156,7 +156,7 @@ sub poweroff_x11 {
         assert_screen 'logout-confirm-dialog', 10;
         send_key "alt-o";              # _o_k
 
-        if (!check_shutdown(120)) {
+        if (!check_shutdown(360)) {
             record_soft_failure 'bsc#1076817 manually shutting down';
             select_console 'root-console';
             systemctl 'poweroff';

--- a/tests/caasp/one_line_checks.pm
+++ b/tests/caasp/one_line_checks.pm
@@ -50,8 +50,10 @@ sub run_caasp_checks {
         }
         # check if installation script was executed https://trello.com/c/PJqM8x0T
         assert_script_run 'zgrep manifests/activate.sh /var/log/YaST2/y2log-1.gz';
-        # bsc#1039863 - Check we are running only sles12 docker images
-        assert_script_run '! docker images | sed 1d | grep -v ^registry.suse.com/sles12';
+
+        # bsc#1039863 - Check we are running only caasp docker images
+        my $registry = 'registry.suse.com/caasp/v' . substr(get_var('VERSION'), 0, 1);
+        assert_script_run "test \$(docker images | tee /dev/$serialdev | sed 1d | grep -v $registry | wc -l) -eq 0";
     }
 }
 

--- a/tests/caasp/stack_conformance.pm
+++ b/tests/caasp/stack_conformance.pm
@@ -55,8 +55,8 @@ sub run {
     assert_script_run("sonobuoy run --config $json_name");
 
     # Checks every 2 minutes if the testsuite has finished
-    # Times out after 90m, testsuite takes around 60m
-    script_retry "sonobuoy status| grep complete", retry => 45, delay => 120;
+    # Times out after 120m, testsuite takes around 90m
+    script_retry "sonobuoy status| grep complete", retry => 60, delay => 120;
 
     assert_script_run("sonobuoy retrieve $logs_dir");
     assert_script_run("cd $logs_dir");

--- a/tests/transactional_system/filesystem_ro.pm
+++ b/tests/transactional_system/filesystem_ro.pm
@@ -18,7 +18,7 @@ use testapi;
 use version_utils 'is_caasp';
 
 sub run {
-    assert_script_run "! touch /should_fail";
+    die 'Should have failed' unless script_run('touch /should_fail');
     assert_script_run "touch /etc/should_succeed";
     assert_script_run "touch /var/log/should_succeed";
 


### PR DESCRIPTION
Increased the timeout of check_shutdown to avoid a false positive
when trying to detect the bug

testing reasons only