### PR TITLE
Increase timeout for check_shutdown on s390x

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -324,7 +324,7 @@ Example:
 
 sub assert_shutdown_with_soft_timeout {
     my ($args) = @_;
-    $args->{timeout}      //= 60;
+    $args->{timeout}      //= check_var('ARCH', 's390x') ? 600 : 60;
     $args->{soft_timeout} //= 0;
     $args->{bugref}       //= "No bugref specified";
     if ($args->{soft_timeout}) {


### PR DESCRIPTION
we have problem with sporadic issue for check_shutdown. default timeout
60 seconds are not enough so try to extend it to 600 seconds.
see https://progress.opensuse.org/issues/43880
test verification run on osd:
https://openqa.suse.de/t2508629

statistics(100) on my local server:
http://f40.suse.de/tests/1526#next_previous
testing now
