### PR TITLE
start_wayland_plasma5: Use 'handle_login' function to cover instabilities

### DIFF
--- a/tests/x11/start_wayland_plasma5.pm
+++ b/tests/x11/start_wayland_plasma5.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2017-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -15,6 +15,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use x11utils 'handle_login';
 
 sub run {
     my ($self) = @_;
@@ -41,11 +42,7 @@ sub run {
     assert_and_click 'sddm_desktopsession';            # Open session selection box
     assert_and_click 'sddm_session_plasma_wayland';    # Select Plasma 5 (Wayland) session
 
-    # Log in as usual
-    type_password;
-    send_key 'ret';
-
-    # Wait until logged in
+    handle_login;
     assert_screen 'generic-desktop', 60;
 
     # We're now in a wayland session, which is in a different VT


### PR DESCRIPTION
Verification runs: https://openqa.opensuse.org/tests/overview?distri=opensuse&build=poo35589_okurz_kde_wayland_mitigation_off_kernel-twvolun&version=Tumbleweed showing in 100 runs that start_wayland_plasma5 does not fail anywhere.

Related progress issue: https://progress.opensuse.org/issues/35589