### PR TITLE
Extract method to clean installation up and run for sles4sap

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -29,6 +29,8 @@ use constant ADDONS_COUNT => 50;
 our @EXPORT = qw(
   add_suseconnect_product
   remove_suseconnect_product
+  cleanup_registration
+  register_product
   assert_registration_screen_present
   fill_in_registration_data
   registration_bootloader_cmdline
@@ -157,6 +159,31 @@ sub remove_suseconnect_product {
     $arch    //= get_required_var('ARCH');
     $params  //= '';
     assert_script_run("SUSEConnect -d -p $name/$version/$arch $params");
+}
+
+=head2 cleanup_registration
+
+    cleanup_registration();
+
+Wrapper for SUSEConnect --cleanup. Resets proxy SCC url if job has SCC_URL
+variable set.
+=cut
+sub cleanup_registration {
+    # Remove registration from the system
+    assert_script_run 'SUSEConnect --clean';
+    # Define proxy SCC if provided
+    my $proxyscc = get_var('SCC_URL');
+    assert_script_run "echo \"url: $proxyscc\" > /etc/SUSEConnect" if $proxyscc;
+}
+
+=head2 register_product
+
+    register_product();
+
+Wrapper for SUSEConnect -r <regcode>. Requires SCC_REGCODE variable.
+=cut
+sub register_product {
+    assert_script_run 'SUSEConnect -r ' . get_required_var('SCC_REGCODE');
 }
 
 sub register_addons {

--- a/tests/installation/addon_products_via_SCC_yast2.pm
+++ b/tests/installation/addon_products_via_SCC_yast2.pm
@@ -15,7 +15,7 @@ use base qw(y2logsstep y2x11test);
 use strict;
 use warnings;
 use testapi;
-use registration 'fill_in_registration_data';
+use registration qw(fill_in_registration_data cleanup_registration);
 use version_utils 'is_sle';
 use x11utils 'turn_off_gnome_screensaver';
 
@@ -25,14 +25,13 @@ Define proxy SCC. For SLE 15 we need to clean existing registration
 sub test_setup {
     select_console 'root-console';
     if (is_sle('>=15')) {
-        assert_script_run 'SUSEConnect --clean';                                          # Remove registration from the system
-        assert_script_run 'echo "url: ' . get_var('SCC_URL') . '" > /etc/SUSEConnect';    # Define proxy SCC
+        cleanup_registration();
     }
     elsif (get_var('SCC_ADDONS')) {
         # Add every used addon to regurl for proxy SCC
         my @addon_proxy = ("url: http://server-" . get_var('BUILD_SLE'));
         for my $addon (split(/,/, get_var('SCC_ADDONS', ''))) {
-            my $uc_addon = uc $addon;                                                     # change to uppercase to match variable
+            my $uc_addon = uc $addon;    # change to uppercase to match variable
             push(@addon_proxy, "\b.$addon-" . get_var("BUILD_$uc_addon"));
         }
         assert_script_run "echo \"@addon_proxy.proxy.scc.suse.de\" > /etc/SUSEConnect";    # Define proxy SCC

--- a/tests/sles4sap/migrate_sles_to_sles4sap.pm
+++ b/tests/sles4sap/migrate_sles_to_sles4sap.pm
@@ -16,6 +16,7 @@ use warnings;
 use testapi;
 use utils;
 use version_utils 'is_sle';
+use registration qw(cleanup_registration register_product);
 
 sub run {
     my ($self)  = @_;
@@ -24,7 +25,11 @@ sub run {
 
     select_console 'root-console';
     zypper_call "in -y migrate-sles-to-sles4sap";
-    if (!is_sle("15+")) {
+    if (is_sle("15+")) {
+        # Clean up and re-register not to affect other job which are sharing same qcow2
+        cleanup_registration();
+        register_product();
+    } else {
         $cmd = "/usr/sbin/Migrate_SLES_to_SLES-for-SAP-12.sh";
     }
     type_string "$cmd && touch /tmp/OK\n";


### PR DESCRIPTION
sles4sap_horizontal_migration test suite de-registers system using shared
qcow image, which means that all tests running after that have
unregistered system too.

See [poo#48539](https://progress.opensuse.org/issues/48539).

## Verification runs
[sles4sap migration](http://f174.suse.de/tests/123#)
[yast2 scc](http://localhost/tests/122)