### PR TITLE
Revert libcamgm test since yast2-ca-management was obsoleted

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2098,7 +2098,6 @@ sub load_security_tests_crypt_misc {
     loadtest "x11/hexchat_ssl" if (check_var('ARCH', 'x86_64'));
     loadtest "x11/x3270_ssl";
     loadtest "x11/seahorse_sshkey";
-    loadtest "x11/libcamgm";
 }
 
 sub load_security_tests_crypt_tool {


### PR DESCRIPTION
According to PM, YaST team was unable to refresh/fix the code, and will not be in SLE15 product. The test case can be removed from FIPS test plan.

Related to bsc#1087857 - [FIPS] yast2-ca-management package is missing the SLE15 repository 

- Related ticket: https://progress.opensuse.org/issues/48431
- Needles: N/A
- Verification run: http://10.100.202.37/tests/258
