### PR TITLE
Fix login_console failure for xen

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -35,10 +35,6 @@ sub login_to_console {
         assert_screen([qw(grub2 grub1)], 30);
     }
 
-    # Wait for bootload for the first time.
-    $self->wait_grub(bootloader_time => 210);
-    send_key 'ret';
-
     if (!get_var("reboot_for_upgrade_step")) {
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {
             #send key 'up' to stop grub timer counting down, to be more robust to select xen
@@ -104,13 +100,6 @@ sub login_to_console {
     save_screenshot;
     use_ssh_serial_console;
 
-    #workaround for bsc#1123942
-    if (check_var('XEN', '1')) {
-        script_run 'll /usr/share/grub2/x86_64-xen/grub.xen /usr/lib/grub2/x86_64-xen/grub.xen';
-        my $workaround_cmd = '(cat /etc/os-release | grep 15-SP1) && [ ! -e /usr/lib/grub2/x86_64-xen/grub.xen ] && mkdir -p /usr/lib/grub2/x86_64-xen && ln -s  /usr/share/grub2/x86_64-xen/grub.xen /usr/lib/grub2/x86_64-xen/grub.xen';
-        script_run($workaround_cmd);
-        script_run 'll /usr/lib/grub2/x86_64-xen/grub.xen';
-    }
 }
 
 sub run {


### PR DESCRIPTION
All virtualization xen tests fail at login_console, which does not select xen menuentry at all, see https://openqa.suse.de/tests/2503054#step/login_console/16. Besides latest 11sp4(with latest fix https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6920) still fail by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6862.

This is to fix both together. 

- Related ticket: 
https://progress.opensuse.org/issues/41960 and https://progress.opensuse.org/issues/48485
- Verification run: 
xen: http://10.67.18.220/tests/638
kvm: http://10.67.18.220/tests/639#