### PR TITLE
Scheduling yast2_gui with yaml scheduling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,14 @@ test-compile: check-links
 test-compile-changed: os-autoinst/
 	export PERL5LIB=${PERL5LIB_} ; for f in `git diff --name-only | grep '.pm'` ; do perl -c $$f 2>&1 | grep -v " OK$$" && exit 2; done ; true
 
+.PHONY: test-yaml-valid
+test-yaml-valid:
+	export PERL5LIB=${PERL5LIB_} ; tools/test_yaml_valid
+
+.PHONY: test-yamllint
+test-yamllint:
+	yamllint --strict $$(git ls-files "*.yaml")
+
 .PHONY: test-metadata
 test-metadata:
 	tools/check_metadata $$(git ls-files "tests/**.pm")
@@ -81,7 +89,7 @@ test-no-wait_idle:
 	@! git --no-pager grep wait_idle lib/ tests/
 
 .PHONY: test-static
-test-static: tidy-check test-merge test-dry test-no-wait_idle test-unused-modules test-soft_failure-no-reference
+test-static: tidy-check test-yaml-valid test-merge test-dry test-no-wait_idle test-unused-modules test-soft_failure-no-reference
 
 .PHONY: test
 ifeq ($(TESTS),compile)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ For more details see http://os-autoinst.github.io/openQA/
 
 Please, find test variables description [here](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/variables.md)
 
+For using using new mechanism to schedule modules:
+[sample yaml format](schedule.md)
+
 ## How to contribute
 Please, refer to [Contributing Guide](https://github.com/os-autoinst/os-autoinst-distri-opensuse/blob/master/CONTRIBUTING.md).
 

--- a/cpanfile
+++ b/cpanfile
@@ -14,6 +14,8 @@ requires 'Selenium::Chrome';
 requires 'Selenium::Waiter';
 requires 'Selenium::Remote::WDKeys';
 requires 'Digest::file';
+requires 'YAML::Tiny';
+requires 'Test::YAML::Valid';
 
 on 'test' => sub {
   requires 'Code::DRY';

--- a/lib/scheduler.pm
+++ b/lib/scheduler.pm
@@ -1,0 +1,82 @@
+# Copyright © 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package scheduler;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use warnings;
+
+use File::Basename;
+use testapi qw(get_var set_var);
+use main_common 'loadtest';
+use YAML::Tiny;
+
+# use lib '/usr/share/openqa/lib';
+# use OpenQA::Utils qw(asset_type_from_setting locate_asset);
+
+our @EXPORT = qw(load_yaml_schedule);
+
+sub parse_vars {
+    my ($schedule) = shift;
+    my %vars;
+    while (my ($var, $value) = each %{$schedule->{vars}}) {
+        $value =~ s/%(.*?)%/get_var($1)/eg;
+        # my $type = asset_type_from_setting($var, $value);
+        # $value = locate_asset($type, $value) if $type;
+        $vars{$var} = $value;
+    }
+    return %vars;
+}
+
+sub parse_schedule {
+    my ($schedule) = shift;
+    my @scheduled;
+    for my $module (@{$schedule->{schedule}}) {
+        push(@scheduled, $module) && next unless ($module =~ s/\{\{(.*)\}\}/$1/);
+        # Module is scheduled conditionally. Need to be parsed. Get condition hash
+        my $condition = $schedule->{conditional_schedule}->{$module};
+        # Iterate over variables in the condition
+        foreach my $var (keys %{$condition}) {
+            next unless my $val = get_var($var);
+            # If value of the variable matched the conditions
+            # Iterate over the list of the modules to be loaded
+            push(@scheduled, $_) for (@{$condition->{$var}->{$val}});
+        }
+    }
+    return @scheduled;
+}
+
+=head2 load_yaml_schedule
+
+Parse variables and test modules from a yaml file representing a test suite to be scheduled.
+
+=cut
+
+sub load_yaml_schedule {
+    if (my $yamlfile = get_var('YAML_SCHEDULE')) {
+        my $schedule      = YAML::Tiny::LoadFile(dirname(__FILE__) . '/../' . $yamlfile);
+        my %schedule_vars = parse_vars($schedule);
+        while (my ($var, $value) = each %schedule_vars) { set_var($var, $value) }
+        my @schedule_modules = parse_schedule($schedule);
+        loadtest($_) for (@schedule_modules);
+        return 1;
+    }
+    return 0;
+}
+
+1;

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -17,6 +17,7 @@ use version_utils ':VERSION';
 use File::Find;
 use File::Basename;
 use DistributionProvider;
+use scheduler 'load_yaml_schedule';
 
 BEGIN {
     unshift @INC, dirname(__FILE__) . '/../../lib';
@@ -149,6 +150,8 @@ logcurrentenv(
       ENCRYPT INSTLANG QEMUVGA DOCRUN UEFI DVD GNOME KDE ISO ISO_MAXSIZE
       LIVECD NETBOOT NOIMAGES QEMUVGA SPLITUSR VIDEOMODE)
 );
+
+return 1 if load_yaml_schedule;
 
 sub have_addn_repos {
     return !get_var("NET") && !get_var("EVERGREEN") && get_var("SUSEMIRROR") && !is_staging();

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -21,6 +21,7 @@ use version_utils
 use File::Find;
 use File::Basename;
 use LWP::Simple 'head';
+use scheduler 'load_yaml_schedule';
 
 use DistributionProvider;
 
@@ -579,6 +580,8 @@ testapi::set_distribution(DistributionProvider->provide());
 
 # set serial failures
 $testapi::distri->set_expected_serial_failures(create_list_of_serial_failures());
+
+return 1 if load_yaml_schedule;
 
 if (is_jeos) {
     load_jeos_tests();

--- a/schedule.md
+++ b/schedule.md
@@ -1,0 +1,16 @@
+### Sample of yaml file for declarative scheduling
+```
+---
+conditional_schedule:
+    <conditional_module_1>:
+        <VAR_NAME>:
+            <var_value_1>:
+                - <path_to_module>/<module_name_1>
+                - <path_to_module>/<module_name_2>
+            <var_value_2>:
+                - <path_to_module>/<module_name_1b>
+
+schedule:
+    - {{conditional_module_1}}
+    - <path_to_module>/<module_name_3>
+```

--- a/schedule/yast2_gui.yaml
+++ b/schedule/yast2_gui.yaml
@@ -1,0 +1,31 @@
+---
+name:           yast2_gui
+description:    >
+    Test for yast2 UI, GUI only.
+    Running on created gnome images which provides both text console for ncurses UI tests as well
+    as the gnome environment for the GUI tests.
+vars:
+    BOOTFROM: c
+    BOOT_HDD_IMAGE: 1
+    # DESKTOP: gnome -> When added, an empty key appears first in the list
+    HDDSIZEGB: 20
+    # HDD_1: SLES-%VERSION%-%ARCH%-Build%BUILD%@%MACHINE%-gnome.qcow2 -> if added, openQA will not publish in UI
+    SOFTFAIL_BSC1063638: 1
+    START_AFTER_TEST: create_hdd_gnome
+    # UEFI_PFLASH_VARS: SLES-%VERSION%-%ARCH%-Build%BUILD%@%MACHINE%-gnome-uefi-vars.qcow2  -> if added, openQA will not publish in UI
+    VALIDATE_ETC_HOSTS: 1
+schedule:
+    - boot/boot_to_desktop
+    - console/prepare_test_data
+    - console/consoletest_setup
+    - console/hostname
+    - yast2_gui/yast2_control_center
+    - x11/yast2_lan_restart
+    - yast2_gui/yast2_bootloader
+    - yast2_gui/yast2_datetime
+    - yast2_gui/yast2_firewall
+    - yast2_gui/yast2_hostnames
+    - yast2_gui/yast2_lang
+    - yast2_gui/yast2_network_settings
+    - yast2_gui/yast2_software_management
+    - yast2_gui/yast2_users

--- a/tools/test_yaml_valid
+++ b/tools/test_yaml_valid
@@ -1,0 +1,5 @@
+#!/usr/bin/env perl
+use Test::More tests => 1;
+use Test::YAML::Valid qw(-Tiny);
+
+yaml_files_ok('./schedule/*.yaml', 'all YAML files are valid');

--- a/variables.md
+++ b/variables.md
@@ -114,5 +114,6 @@ VIRSH_OPENQA_BASEDIR | string | /var/lib | The OPENQA_BASEDIR configured on the 
 UNENCRYPTED_BOOT | boolean | false | Indicates/defines existence of unencrypted boot partition in the SUT.
 WAYLAND | boolean | false | Enables wayland tests in the system.
 XDMUSED | boolean | false | Indicates availability of xdm.
+YAML_SCHEDULE | string | | Defines yaml file containing test suite schedule.
 ZDUP | boolean | false | Prescribes zypper dup scenario.
 ZDUPREPOS | string | | Defines repo to be added/used for zypper dup call.


### PR DESCRIPTION
Apply new scheduling mechanism for any installation scenario in YaST job group which is also executed on o3. Based on following POCs: #6741, #6329 & [Workshop](https://github.com/mudler/openqa_testloader_workshop)

- Related ticket: https://progress.opensuse.org/issues/47921
- Verification run: [sle-15-SP1-yast2_gui](http://rivera-workstation.suse.cz/tests/1995) | [tumbleweed-yast2_gui](http://rivera-workstation.suse.cz/tests/1996)

- In this particular case I opted for using `yast2_gui` that does not use conditional schedule to dedicate more time to other parts of the solution, nevertheless I tested that is still working fine with conditional scheduling.
- Now we can read variables directly from the declarative files so we can cleanup following parameters from O3 and OSD: `EXTRATEST= BOOT_HDD_IMAGE= HDDSIZEGB= START_AFTER_TEST=` 
I noticed that there are some differences in variables between both productions environments so I added only the common ones.
- A mechanism to resolve variable expansion is added and it is working but not used in this example (it is commented explaining why) because openQA webui needs .qcows and other assets to be publish through openqa itselft so we cannot still remove them from the the testsuite configuration (they would appear as a empty links in the web ui). The mechanism also includes a section where is able to locate the asset in the machine (I took that code from openqa) but Travis does not like this hack as it is not finding the [travis error](https://travis-ci.org/os-autoinst/os-autoinst-distri-opensuse/jobs/501389592) so I commented out the code, which is not needed for this example neither, although it passed `make test` in my local without problem.
- Perhaps we can re-use this mechanism of variable expansion to improve our syntax of the conditional scheduling part, for example,  `bootloader{%arch%}` and removing `ARCH:` from the conditional section, but it is just and idea for next iteration of scheduling, not related with this PR.
- I removed the possibility to use this kind of variables `'%INSTALLATION_VALIDATION%'` in the declarative schedule as they are hacks difficult to explain to newcomers to openQA and they doesn't make sense as with this new scheduling we can add/remove test module at our wish. But it is true that this magic variables might have some roles if we think better solution to reuse parts of test suites in the future (like the default part of an installation). In any case we can recover easily that idea later on from #6741.
- I opted for `Test::YAML::Valid` which only tries to load the file with Yaml Tiny lib and requires minimum deps. Besides I had issues with `yamllint `trying to make it work in my local env although it is more powerful and points better to errors according documentation.

Note: code resulting from investigation and commented out in .yaml file and in package `test_scheduler` might have some utility in the future, but let me know if it is better to exclude for now.