### PR TITLE
kdump_utils: Add a function activate_kdump_without_yast

### DIFF
--- a/tests/xfstests/enable_kdump.pm
+++ b/tests/xfstests/enable_kdump.pm
@@ -34,15 +34,8 @@ sub run {
     }
 
     # Activate kdump
-    # x86_64 is infect with bsc#1116305, and aarcha64/ppc64le has different alloc_mem size.
-    # In case aarcha64/ppc64le works well with yast, I leave them setting by yast.
     prepare_for_kdump;
-    if (check_var('ARCH', 'x86_64')) {
-        script_run('yast2 kdump startup enable alloc_mem=72,174');
-    }
-    else {
-        activate_kdump;
-    }
+    activate_kdump_without_yast;
 
     # Reboot
     power_action('reboot');


### PR DESCRIPTION
As related ticket says yast has a issue to enable kdump, so the activate_kdump couldn't use in SLE15SP1(at least), then we need change to use grub and systemd to enable it.
I'm not sure if old product still need activate_kdump or not, so just leave it there and create a new function in lib/kdump_utils.pm to enable kdump.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1116305
- Verification run: http://10.67.133.102/tests/791#step/enable_kdump/48
  kdump could enable by grub now.