### PR TITLE
Softfail for missing license in JeOS

### DIFF
--- a/tests/jeos/firstrun.pm
+++ b/tests/jeos/firstrun.pm
@@ -66,10 +66,14 @@ sub run {
 
     # Accept license
     if (is_sle) {
-        assert_screen 'jeos-license', 60;
-        send_key 'ret';
-        assert_screen 'jeos-doyouaccept';
-        send_key 'ret';
+        if (check_screen 'jeos-license', 60) {
+            send_key 'ret';
+            assert_screen 'jeos-doyouaccept';
+            send_key 'ret';
+        }
+        else {
+            record_soft_failure 'bsc#1127166 - License moved to another location';
+        }
     }
 
     # Select timezone


### PR DESCRIPTION
License file has changed its location in jeos image due a known bug https://bugzilla.suse.com/show_bug.cgi?id=1127166

- Related ticket: https://progress.opensuse.org/issues/48713
- Needles: none
- Verification run: http://dhcp105.suse.cz/tests/1253#step/firstrun/7
- Run when the license is available: http://dhcp105.suse.cz/tests/1257#step/firstrun/7
- Failure run: https://openqa.suse.de/tests/2518859#step/firstrun/6