### PR TITLE
Work around a very delicate libreoffice problem

### DIFF
--- a/tests/x11/oomath.pm
+++ b/tests/x11/oomath.pm
@@ -27,10 +27,15 @@ sub run {
     send_key "2";
     # undo produces "12" instead of "1"
     wait_screen_change { send_key "ctrl-z" };
-    assert_screen 'test-oomath-1', 3;
-    wait_screen_change { send_key "alt-f4" };
-    assert_screen 'oomath-prompt', 5;
-    assert_and_click 'dont-save-libreoffice-btn';    # _Don't save
+    assert_screen [qw(test-oomath-1 oomath-bsc1127895)], 3;
+    if (match_has_tag('oomath-bsc1127895')) {
+        record_soft_failure 'bsc#1127895';
+        send_key "alt-f4";
+    } else {
+        wait_screen_change { send_key "alt-f4" };
+        assert_screen 'oomath-prompt', 5;
+        assert_and_click 'dont-save-libreoffice-btn';    # _Don't save
+    }
 }
 
 1;


### PR DESCRIPTION
It's happening when running oomath under KDE in openQA and we don't want to disable the oomath test in general, but we want to get libreoffice out of staging and find the nature of the problem, because the developer can't reproduce
