### PR TITLE
Use select-serial-terminal to select proper console

### DIFF
--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -24,16 +24,18 @@ use base 'y2logsstep';
 
 use testapi;
 use utils 'zypper_call';
+use Utils::Backends 'use_ssh_serial_console';
 use version_utils 'is_sle';
 use registration;
 
 sub run {
     return if get_var('HDD_SCC_REGISTERED');
+    my $self       = shift;
     my $reg_code   = get_required_var('SCC_REGCODE');
     my $scc_url    = get_required_var('SCC_URL');
     my $scc_addons = get_var('SCC_ADDONS', '');
 
-    select_console 'root-console';
+    $self->select_serial_terminal;
     assert_script_run "SUSEConnect --url $scc_url -r $reg_code";
     assert_script_run 'SUSEConnect --list-extensions';
 


### PR DESCRIPTION
When using an IPMI machine and an ssh connection, select_console()
does not work to run the commands. However, we can use
select_serial_terminal() to automatically select the right root console
to use.

Signed-off-by: Michael Moese <mmoese@suse.de>

 