### PR TITLE
Fix double scheduling on other_de tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2404,7 +2404,7 @@ sub load_common_opensuse_sle_tests {
     load_toolchain_tests                if get_var("TCM") || check_var("ADDONS", "tcm");
     loadtest 'console/network_hostname' if get_var('NETWORK_CONFIGURATION');
     load_installation_validation_tests  if get_var('INSTALLATION_VALIDATION');
-    load_shutdown_tests                 if check_var('DESKTOP', 'minimalx') && !get_var('INSTALLONLY');
+    load_shutdown_tests                 if check_var('DESKTOP', 'minimalx') && !get_var('INSTALLONLY') && !get_var('DE_PATTERN');
 }
 
 sub load_ssh_key_import_tests {


### PR DESCRIPTION
Now checking for DE_PATTERN before scheduling shutdown tests

- Related ticket: https://progress.opensuse.org/issues/46076
- Verification runs: 

SLE15 normal to crosscheck that we don't break existing stuff:
http://pinky.arch.suse.de/tests/121

TW other_de:
http://pinky.arch.suse.de/tests/122
