### PR TITLE
fix the infiniband tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -534,6 +534,7 @@ sub load_infiniband_tests {
     # here to ensure they are a) only created once and b) early enough
     # to be available when needed.
     if (get_var('IBTEST_ROLE') eq 'IBTEST_MASTER') {
+        barrier_create('IBTEST_SETUP', 2);
         barrier_create('IBTEST_BEGIN', 2);
         barrier_create('IBTEST_DONE',  2);
     }


### PR DESCRIPTION
There were some problems with the infiniband testsuite that are now solved. A third barrier is needed to synchronize the setup parts in order to avoid failures with copying ssh keys when one machine is not yet booted in time.
    
In addition, the documentation was updated and some dependencies we need for minimal installations were added.
    
Signed-off-by: Michael Moese <mmoese@suse.de>
