### PR TITLE
lshw: allow x86_64 again in addition to ppc64le

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1598,7 +1598,7 @@ sub load_extra_tests_console {
     loadtest "sysauth/sssd" if get_var('SYSAUTHTEST');
     loadtest 'console/timezone';
     loadtest 'console/procps';
-    loadtest "console/lshw" if ((is_sle('15+') && check_var('ARCH', 'ppc64le')) || is_opensuse);
+    loadtest "console/lshw" if ((is_sle('15+') && (check_var('ARCH', 'ppc64le') || check_var('ARCH', 'x86_64'))) || is_opensuse);
     loadtest 'console/quota' unless is_jeos;
 }
 


### PR DESCRIPTION
Bug #1124500 is now fixed. I've verified lshw is now available again on 15SP1 on x86_64 in addition to ppc64le, so the test can be run on both architectures now.

- Related ticket: https://progress.opensuse.org/issues/47165
- Verification run: http://d403.qam.suse.de/tests/71
