### PR TITLE
Add suse-build-key test for JeOS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -570,6 +570,7 @@ sub load_jeos_tests {
             loadtest "jeos/diskusage";
             loadtest "jeos/root_fs_size";
             loadtest "jeos/mount_by_label";
+            loadtest "jeos/build_key";
         }
         if (is_sle) {
             loadtest "console/suseconnect_scc";

--- a/tests/jeos/build_key.pm
+++ b/tests/jeos/build_key.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Check that suse build key is installed and the key exists
+# Maintainer: Ciprian Cret <ccret@suse.com>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+
+sub run {
+    # check that suse-build-key is installed
+    my $zypper_output = script_output('zypper search suse-build-key');
+    die 'suse-build-key is not installed' unless $zypper_output =~ /i\+(.*)suse-build-key/;
+
+    assert_script_run('ls /usr/lib/rpm/gnupg/keys | grep suse_ptf_key.asc');
+
+    # check that the key is not empty or has invalid content
+    validate_script_output("cat /usr/lib/rpm/gnupg/keys/suse_ptf_key.asc", sub {
+            /(----BEGIN PGP PUBLIC KEY BLOCK-----)\s*|(.*)(-----END PGP PUBLIC KEY BLOCK-----)/;
+    });
+}
+
+1;


### PR DESCRIPTION
Add test for suse-build-key, checking that the package is installed and the key is not empty

- Related ticket: https://progress.opensuse.org/issues/45005
- Verification run: http://ccret.suse.cz/tests/2898#
