### PR TITLE
Increase timeout for supportconfig on aarch64

### DIFF
--- a/tests/console/supportutils.pm
+++ b/tests/console/supportutils.pm
@@ -19,7 +19,8 @@ sub run {
     select_console 'root-console';
 
     assert_script_run "rm -rf nts_* ||:";
-    assert_script_run "supportconfig -t . -B test", 300;
+    my $timeout = check_var('ARCH', 'aarch64') ? '400' : '300';
+    assert_script_run "supportconfig -t . -B test", $timeout;
     assert_script_run "cd nts_test";
 
     # Check few file whether expected content is there.


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/2521363#step/supportutils/4
- Verification run: http://10.100.12.155/tests/10658
