### PR TITLE
Handle command failure in script_run_interactive

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1011,35 +1011,47 @@ be matched (regex) and the answer with string or key to be typed. for example:
         string => "testpasspw\n",
       },]
 
-A "Script done." message comes from the typescript will be printed as a mark
+A "EOS~~~" message followed by return value will be printed as a mark
 for the end of interaction after the command finished running.
+
+If the first argument is undef, only the sencond part will be processed - to
+match output and react. If the second argument is undef, the first part will
+be processed - to run the command without interaction with terminal output.
+This is useful for some situation when you want to do more between inputing
+command and the following interaction, eg. switch TTYs or detach the screen.
+
 =cut
 sub script_run_interactive {
     my ($cmd, $scan, $timeout) = @_;
     my $output;
+    my $err_ret;
     my @words;
+    my $endmark = 'EOS~~~';    # EOS == "End of Script"
     $timeout //= 180;
 
     if ($cmd) {
-        script_run("script -c \'", 0);
-        script_run($cmd,           0);
-
-        # Write to /dev/null since we want not to leave file there
-        script_run("\' /dev/null |& tee /dev/$serialdev", 0);
+        script_run("(script -qe -a /dev/null -c \'", 0);
+        script_run($cmd,                             0);
+        # Can not get return value from script_run, so we have to do it in
+        # the shell with $? following the endmark.
+        script_run("\'; echo $endmark\$?) |& tee /dev/$serialdev", 0);
     }
+
+    return if (!$scan);
 
     for my $k (@$scan) {
         push(@words, $k->{prompt});
     }
 
-    my $endmark = "Script done.*\/dev\/null";
     push(@words, $endmark);
 
     {
         do {
             $output = wait_serial(\@words, $timeout) || die "No message matched!";
 
-            last if ($output =~ /$endmark/m);
+            last if ($output =~ /($endmark)0$/m);    # return value is 0
+            die  if ($output =~ /$endmark/m);        # other return values
+
             for my $i (@$scan) {
                 next if ($output !~ $i->{prompt});
                 if ($i->{string}) {

--- a/tests/security/apparmor/aa_genprof.pm
+++ b/tests/security/apparmor/aa_genprof.pm
@@ -43,7 +43,7 @@ sub run {
     # Confirm it is in the screen
     validate_script_output "echo \$TERM", sub { m/screen/ };
 
-    script_run("script -c 'aa-genprof -d $aa_tmp_prof nscd' /dev/null |& tee /dev/$serialdev", 0);
+    script_run_interactive("aa-genprof -d $aa_tmp_prof nscd", undef);
     wait_serial("Please start the application", 20);
 
     # Detach screen


### PR DESCRIPTION
`script_run_interactive` can not handle failure situation when running the command. Fix it by involving return value inside the `typescript`.

Also make it support running the command only - by passing undef at the second parameter. Change `aa_genprof` to adopt this method.

- Related ticket: https://progress.opensuse.org/issues/48521
- Verification run:
  - Handle failure example: http://10.67.17.9/tests/612#step/usr_lib_dovecot_pop3/38
  - Success example: http://10.67.17.9/tests/622#step/usr_lib_dovecot_pop3/44
  - Make sure the change will not make other depended cases failed:
    - MOK enrollment: http://10.67.17.9/tests/619#step/mokutil_sign/49
    - Apparmor: http://10.67.17.9/tests/628
