### PR TITLE
Add python2 module for media upgrade

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -50,6 +50,7 @@ our @EXPORT = qw(
 
 # We already have needles with names which are different we would use here
 # As it's only workaround, better not to create another set of needles.
+# Add python2 module, refer to https://jira.suse.de/browse/SLE-3167
 our %SLE15_MODULES = (
     base      => 'Basesystem',
     sdk       => 'Development-Tools',
@@ -60,6 +61,7 @@ our %SLE15_MODULES = (
     contm     => 'Containers',
     pcm       => 'Public-Cloud',
     sapapp    => 'SAP-Applications',
+    python2   => 'Python2',
 );
 
 # The expected modules of a default installation per product. Use them if they

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -42,6 +42,9 @@ sub handle_all_packages_medium {
     # Refer to https://bugzilla.suse.com/show_bug.cgi?id=1078958#c4
     push @addons, 'we' if check_var('SLE_PRODUCT', 'sled') && !grep(/^we$/, @addons);
 
+    # Add python2 module, refer to https://jira.suse.de/browse/SLE-3167
+    push @addons, 'python2' if get_var('MEDIA_UPGRADE') && is_sle('<15', get_var('HDDVERSION')) && !check_var('SLE_PRODUCT', 'rt');
+
     # For SLES12SPx and SLES11SPx to SLES15 migration, need add the demand module at least for media migration manually
     # Refer to https://fate.suse.com/325293
     if (get_var('MEDIA_UPGRADE') && is_sle('<15', get_var('HDDVERSION')) && !check_var('SLE_PRODUCT', 'sled')) {
@@ -64,6 +67,11 @@ sub handle_all_packages_medium {
     # there will be problem to enable the same addon twice
     for my $a (split(/,/, get_var('SCC_ADDONS', ''))) {
         push @addons, $a if !grep(/^$a$/, @addons);
+    }
+
+    # Add python2 module, refer to https://jira.suse.de/browse/SLE-3167
+    if (get_var('MEDIA_UPGRADE') && check_var('HDDVERSION', '15') && grep(/^lgm$|^legacy$/, @addons)) {
+        push @addons, 'python2' if !grep(/^python2$/, @addons);
     }
 
     # Record the addons to be enabled for debugging


### PR DESCRIPTION
For sle<15 migration test, python2 module will add by default.
For sle15 migration test with legacy module, python2 will be added, without legacy, python2 will not be added.
- Related fate: https://jira.suse.de/browse/SLE-3167
- Related ticket: https://progress.opensuse.org/issues/48563 
- Verification run: 
    sle15 with legacy: http://openqa-apac1.suse.de/tests/3525#
    sled12sp4: http://openqa-apac1.suse.de/tests/3516#step/installation_overview/1
[autoinst-log.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/2939865/autoinst-log.txt)

