### PR TITLE
Public Cloud: Add timeout for remote ssh commands

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -15,6 +15,8 @@ package publiccloud::instance;
 use testapi;
 use Mojo::Base -base;
 
+use constant SSH_TIMEOUT => 90;
+
 has instance_id => undef;               # unique CSP instance id
 has public_ip   => undef;               # public IP of instance
 has username    => undef;               # username for ssh connection
@@ -25,22 +27,25 @@ has provider    => undef, weak => 1;    # back reference to the provider
 
 =head2 run_ssh_command
 
-    run_ssh_command($cmd);
+    run_ssh_command(cmd => 'command', timeout => 90);
 
 Runs a command C<cmd> via ssh in the given VM. Retrieves the output.
-If the command retrieves not zero, a exception is thrown.
+If the command retrieves not zero, a exception is thrown..
+Timeout can be set by C<timeout> or 90 sec by default.
 TODO Do not raise exception on error
 TODO Be aware of special shell letters like ';'
 =cut
 sub run_ssh_command {
-    my ($self, $cmd) = @_;
+    my ($self, %args) = @_;
 
-    die('Argument <cmd> missing') unless ($cmd);
+    die('Argument <cmd> missing') unless ($args{cmd});
+
+    $args{timeout} //= SSH_TIMEOUT;
 
     my $ssh_cmd = sprintf('ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "%s" "%s@%s" -- %s',
-        $self->ssh_key, $self->username, $self->public_ip, $cmd);
+        $self->ssh_key, $self->username, $self->public_ip, $args{cmd});
     record_info('CMD', $ssh_cmd);
-    return script_output($ssh_cmd);
+    return script_output($ssh_cmd, $args{timeout});
 }
 
 1;

--- a/tests/publiccloud/az_accelerated_net.pm
+++ b/tests/publiccloud/az_accelerated_net.pm
@@ -30,8 +30,8 @@ sub prepare_vm {
     my $instance = $provider->create_instance();
     record_info('Instance', 'Instance ' . $instance->instance_id . ' created');
     record_info('Iperf',    'Install IPerf binaries in VM');
-    $instance->run_ssh_command("wget https://iperf.fr/download/opensuse/$iperf");
-    $instance->run_ssh_command("sudo rpm -i  $iperf");
+    $instance->run_ssh_command(cmd => "wget https://iperf.fr/download/opensuse/$iperf");
+    $instance->run_ssh_command(cmd => "sudo rpm -i  $iperf");
     return $instance;
 }
 
@@ -78,8 +78,8 @@ ethtool |grep vf_ must show numbers different than 0 if SR-IOV is enabled.
 sub check_sriov {
     my ($self, $instance) = @_;
     record_info('sr-iov', 'Checking SRIOV feature for instance ' . $instance->instance_id);
-    my $lspci_output   = $instance->run_ssh_command("sudo lspci");
-    my $ethtool_output = $instance->run_ssh_command("sudo ethtool -S eth0 | grep vf_");
+    my $lspci_output   = $instance->run_ssh_command(cmd => "sudo lspci");
+    my $ethtool_output = $instance->run_ssh_command(cmd => "sudo ethtool -S eth0 | grep vf_");
     record_info('lspci',   $lspci_output);
     record_info('ethtool', $ethtool_output);
     if ($lspci_output =~ m/Mellanox/ && $ethtool_output !~ m/vf_rx_bytes: 0/) {
@@ -99,10 +99,10 @@ test on the client side. The test runs TEST_TIME seconds.
 sub run_test {
     my ($self, $client, $server) = @_;
     record_info('server', 'Start IPERF in server' . $server->public_ip);
-    $server->run_ssh_command('nohup iperf -s -D &');
+    $server->run_ssh_command(cmd => 'nohup iperf -s -D &');
     sleep 60;    # Wait 60 seconds so that the server starts up safely and the clinet can connect to it
     record_info('client', 'Start IPERF in client');
-    my $output = $client->run_ssh_command('iperf -t ' . get_required_var('TEST_TIME') . ' -c ' . $server->public_ip);
+    my $output = $client->run_ssh_command(cmd => 'iperf -t ' . get_required_var('TEST_TIME') . ' -c ' . $server->public_ip);
     record_info('RESULTS', $output);
 }
 

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -32,9 +32,9 @@ sub run {
     assert_script_run('git clone -q --single-branch -b runltp_ng_openqa --depth 1 https://github.com/cfconrad/ltp.git');
 
     # Install ltp from package on remote
-    $instance->run_ssh_command('sudo zypper ar ' . $ltp_repo);
-    $instance->run_ssh_command('sudo zypper -q --gpg-auto-import-keys in -y ltp');
-    $instance->run_ssh_command('sudo CREATE_ENTRIES=1 /opt/ltp/IDcheck.sh');
+    $instance->run_ssh_command(cmd => 'sudo zypper ar ' . $ltp_repo);
+    $instance->run_ssh_command(cmd => 'sudo zypper -q --gpg-auto-import-keys in -y ltp', timeout => 300);
+    $instance->run_ssh_command(cmd => 'sudo CREATE_ENTRIES=1 /opt/ltp/IDcheck.sh');
 
     my $reset_cmd = '~/restart_instance.sh ' . get_required_var('PUBLIC_CLOUD_PROVIDER') . ' ';
     $reset_cmd .= $instance->instance_id . ' ' . $instance->public_ip;


### PR DESCRIPTION
Sometimes, remote ssh commands on CSPs VMs time out, for instance installing LTP on Azure:
https://openqa.suse.de/tests/2518138/#step/run_ltp/122

This adds a optional timeout to the function, and also sets 300 seconds timeout for LTP installation.


