### PR TITLE
Avoid false positives on shutting down minimalx

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -246,7 +246,7 @@ sub power_action {
         assert_shutdown_and_restore_system($action, $shutdown_timeout *= 3);
     }
     else {
-        if (check_var('DESKTOP', 'minimalx') && check_screen('shutdown-auth', timeout => 30)) {
+        if (check_var('DESKTOP', 'minimalx') && check_screen('shutdown-wall', timeout => 30)) {
             record_soft_failure 'bsc#1076817 manually shutting down';
             select_console 'root-console';
             systemctl 'poweroff';


### PR DESCRIPTION
Now checking for an authentication screen for a wall message to avoid
false positives by a too generic shutdown auth needle

To avoid cases like: https://openqa.suse.de/tests/2525175#step/shutdown/6

- Related ticket: https://progress.opensuse.org/issues/46076
- Needles: created on webui

