### PR TITLE
Update build_key test for opensuse

### DIFF
--- a/tests/jeos/build_key.pm
+++ b/tests/jeos/build_key.pm
@@ -14,18 +14,20 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
+use version_utils "is_opensuse";
 
 sub run {
-    # check that suse-build-key is installed
-    my $zypper_output = script_output('zypper search suse-build-key');
-    die 'suse-build-key is not installed' unless $zypper_output =~ /i\+(.*)suse-build-key/;
+    if (is_opensuse) {
+        assert_script_run("rpm -qi openSUSE-build-key");
+    }
+    else {
+        assert_script_run("rpm -qi suse-build-key");
 
-    assert_script_run('ls /usr/lib/rpm/gnupg/keys | grep suse_ptf_key.asc');
-
-    # check that the key is not empty or has invalid content
-    validate_script_output("cat /usr/lib/rpm/gnupg/keys/suse_ptf_key.asc", sub {
-            /(----BEGIN PGP PUBLIC KEY BLOCK-----)\s*|(.*)(-----END PGP PUBLIC KEY BLOCK-----)/;
-    });
+        # check that the key is not empty or has invalid content
+        validate_script_output("cat /usr/lib/rpm/gnupg/keys/suse_ptf_key.asc", sub {
+                /(----BEGIN PGP PUBLIC KEY BLOCK-----)\s*|(.*)(-----END PGP PUBLIC KEY BLOCK-----)/;
+        });
+    }
 }
 
 1;


### PR DESCRIPTION
This change is needed to check the correct package name on opensuse.

- Related ticket: https://progress.opensuse.org/issues/48794
- Verification run: 
     openSUSE: http://ccret.suse.cz/tests/2906
     SLE15 SP1: http://ccret.suse.cz/tests/2907
