### PR TITLE
Return back to X11 console after disabling GNOME screensaver

### DIFF
--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -27,6 +27,7 @@ sub setup_system {
 
     if (check_var("DESKTOP", "gnome")) {
         turn_off_gnome_screensaver;
+        select_console 'x11';
     }
     else {
         script_run("xscreensaver-command -exit");


### PR DESCRIPTION
After pr#6792, disabling gnome screensaver happens on a VT, and update-packages-gpk then expects to be back on X11 to continue its tasks - but since we never switched back, this failed

Failures were like: https://openqa.opensuse.org/tests/873659#step/updates_packagekit_gpk/45
Verification run: https://openqa.opensuse.org/tests/873729 (running)