### PR TITLE
Improve detection of no license

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1121,7 +1121,7 @@ sub load_consoletests {
     }
     #have SCC repo for SLE product
     if (have_scc_repos()) {
-        loadtest "console/yast_scc";
+        loadtest "console/yast2_scc";
     }
     # If is_repo_replacement_required returns true, we already have added mirror repo and refreshed repos
     if (!is_repo_replacement_required()) {

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -43,6 +43,8 @@ our @EXPORT = qw(
   rename_scc_addons
   is_module
   install_docker_when_needed
+  verify_scc
+  investigate_log_empty_license
   %SLE15_MODULES
   %SLE15_DEFAULT_MODULES
   @SLE15_ADDONS_WITHOUT_LICENSE
@@ -741,6 +743,43 @@ sub install_docker_when_needed {
     systemctl('start docker');
     systemctl('status docker');
     assert_script_run('docker info');
+}
+
+sub verify_scc {
+    select_console 'root-console';
+    record_info('proxySCC/SCC', 'Verifying that proxySCC and SCC can be accessed');
+    assert_script_run("curl ${\(get_var('SCC_URL'))}/login") if get_var('SCC_URL');
+    assert_script_run("curl https://scc.suse.com/login");
+}
+
+sub investigate_log_empty_license {
+    select_console 'root-console';
+    my $filter_products   = "grep -Po '<SUSE::Connect::Remote::Product.*?(extensions|isbase=(true|false)>)'";
+    my $y2log_file        = '/var/log/YaST2/y2log';
+    my $filter_empty_eula = qq[grep '.*eula_url="".*'];
+    my $orderuniquebyid   = 'sort -u -t, -k1,1';
+    my $command           = "$filter_products $y2log_file | $filter_empty_eula | $orderuniquebyid";
+    my @products          = split(/\n/, script_output($command));
+    my %fields            = (
+        id            => qr/(?<id>(?<=id=)\d+)/,
+        friendly_name => qr/(?<friendly_name>(?<=friendly_name=").*?(?="))/
+    );
+    my $message;
+    for my $product (@products) {
+        if ($product =~ /$fields{id}.*?$fields{friendly_name}.*?$fields{asset_url}/) {
+            $message .= "$+{friendly_name}: https://scc.suse.com/admin/products/$+{id}\n";
+        }
+    }
+    if ($message) {
+        record_info(
+            'Empty eula_url',
+            "Empty EULA was found in YaST logs (eula_url=\"\") for the following products:\n" .
+              "$message\n" .
+              "Please, file Bugzilla ticket agains SCC if license is not properly set.\n" .
+              "In case of licence available, check if the asset for the license has been properly synchronized\n" .
+              "by taking a look in http://openqa.suse.de/assets/repo/ for the corresponding product/build\n" .
+              "and searching for a path ending in \'.license/license.txt\' .Otherwise, please file a Progress ticket.");
+    }
 }
 
 1;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -848,7 +848,7 @@ elsif (have_scc_repos()) {
         loadtest "console/suseconnect_scc";
     }
     else {
-        loadtest "console/yast_scc";
+        loadtest "console/yast2_scc";
     }
 }
 elsif (get_var('HPC')) {

--- a/tests/console/yast2_scc.pm
+++ b/tests/console/yast2_scc.pm
@@ -19,8 +19,6 @@
 use strict;
 use warnings;
 use base "console_yasttest";
-use base "consoletest";
-
 use testapi;
 use registration;
 
@@ -31,6 +29,13 @@ sub run {
         type_string "echo 'url: $u' > /etc/SUSEConnect\n";
     }
     yast_scc_registration;
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    verify_scc;
+    investigate_log_empty_license;
+    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/installation/addon_products_via_SCC_yast2.pm
+++ b/tests/installation/addon_products_via_SCC_yast2.pm
@@ -15,7 +15,7 @@ use base qw(y2logsstep y2x11test);
 use strict;
 use warnings;
 use testapi;
-use registration qw(fill_in_registration_data cleanup_registration);
+use registration;
 use version_utils 'is_sle';
 use x11utils 'turn_off_gnome_screensaver';
 
@@ -51,6 +51,13 @@ sub run {
     }
     fill_in_registration_data;
     assert_screen 'generic-desktop';
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    verify_scc;
+    investigate_log_empty_license;
+    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/installation/scc_registration.pm
+++ b/tests/installation/scc_registration.pm
@@ -32,9 +32,8 @@ sub run {
 sub post_fail_hook {
     my ($self) = @_;
     $self->SUPER::post_fail_hook;
-    # Verify that proxySCC and SCC can be accessed
-    assert_script_run("curl ${\(get_var('SCC_URL'))}/login") if get_var('SCC_URL');
-    assert_script_run("curl https://scc.suse.com/login");
+    verify_scc;
+    investigate_log_empty_license;
 }
 
 1;


### PR DESCRIPTION
Improve our automatic detection of "no license is shown but expected"
- Related ticket: https://progress.opensuse.org/issues/48128
- Needles: N/A
- Verification runs: (forcing `die` to simulate simulate [bsc#1123057](https://bugzilla.suse.com/show_bug.cgi?id=1123057)) 
  - [sle-12-SP5-minimal+base+sdk+proxy_SCC-postreg](http://rivera-workstation.suse.cz/tests/2088#step/yast2_scc/51)
  - [sle-15-SP1-sles+sdk+proxy_SCC_via_YaST](http://rivera-workstation.suse.cz/tests/2089#step/addon_products_via_SCC_yast2/58)
  - [sle-15-SP1-create_hdd_gnome](http://rivera-workstation.suse.cz/tests/2091#step/scc_registration/41)