### PR TITLE
VMware migration support

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -378,7 +378,7 @@ sub load_svirt_vm_setup_tests {
         loadtest "installation/bootloader_hyperv" unless get_var('UPGRADE');
     }
     else {
-        loadtest "installation/bootloader_svirt";
+        loadtest "installation/bootloader_svirt" unless get_var('UPGRADE');
     }
     unless (is_installcheck || is_memtest || is_rescuesystem || is_mediacheck) {
         load_svirt_boot_tests;

--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -265,7 +265,7 @@ sub power_action {
         }
         # When 'sut' is ready, select it
         if (is_vmware && $action eq 'reboot') {
-            wait_serial('GNU GRUB') || die 'GRUB not found on serial console';
+            wait_serial('GNU GRUB', 180) || die 'GRUB not found on serial console';
             select_console('sut');
         }
     }

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -256,6 +256,11 @@ sub run {
 
     $svirt->define_and_start;
 
+    # Variable set only in console (here sshVirtsh console) does not propagate
+    # to test environment correctly and can be destroyed by bmwqemu::load_vars(),
+    # e.g. via set_var('...', ..., reload_needles => 1).
+    set_var('VMWARE_REMOTE_VMM', $svirt->get_remote_vmm) if is_vmware;
+
     # This sets kernel argument so needle-matching works on Xen PV. It's being
     # done via host's PTY device because we don't see anything unless kernel
     # sets framebuffer (this is a GRUB2's limitation bsc#961638).

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -76,16 +76,19 @@ sub run {
     }
 
     set_var('BOOTFROM', 'c') if get_var('BOOT_HDD_IMAGE');
+    my $boot_device = '';
     if (check_var('BOOTFROM', 'c')) {
-        $svirt->change_domain_element(os => boot => {dev => 'hd'});
+        $boot_device = 'hd';
     }
     elsif (check_var('BOOTFROM', 'd')) {
-        $svirt->change_domain_element(os => boot => {dev => 'cdrom'});
+        $boot_device = 'cdrom';
     }
     else {
-        $svirt->change_domain_element(os => boot => {dev => 'hd'});
-        $svirt->change_domain_element(os => boot => {dev => 'cdrom'}) if get_var('ISO');
+        get_var('ISO') ? $boot_device = 'cdrom' : $boot_device = 'hd';
     }
+    # Does not make any difference on VMware. For ad hoc device selection
+    # see vmware_select_boot_device_from_menu().
+    $svirt->change_domain_element(os => boot => {dev => $boot_device}) unless is_vmware;
 
     # Unless os-autoinst PR#956 is deployed we have to remove 'on_reboot' first
     # This has no effect on VMware ('restart' is kept).

--- a/tests/shutdown/svirt_upload_assets.pm
+++ b/tests/shutdown/svirt_upload_assets.pm
@@ -14,6 +14,7 @@ use base 'installbasetest';
 use strict;
 use warnings;
 use testapi;
+use version_utils 'is_vmware';
 
 sub extract_assets {
     my ($args) = @_;
@@ -41,6 +42,8 @@ sub extract_assets {
 }
 
 sub run {
+    # Not implemented on VMware
+    return 1 if is_vmware;
     # connect to VIRSH_HOSTNAME screen and upload asset from there
     my $svirt = select_console('svirt');
 


### PR DESCRIPTION
Needs to be merged after https://github.com/os-autoinst/os-autoinst/pull/1124 is merged and deployed to OSD.

Changes:
* Setup boot device in VMware BIOS Setup Utility
* Re-set `VMWARE_REMOTE_VMM` from test code

Validation:
* VMware migration: http://nilgiri.suse.cz/tests/411

Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1090