### PR TITLE
Fix btrfs dump image issue for xfs test

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -281,7 +281,7 @@ sub run {
                 copy_log($category, $num, 'out.bad');
                 copy_log($category, $num, 'full');
                 copy_log($category, $num, 'dmesg');
-                if ($category == "btrfs") { dump_btrfs_img($category, $num); }
+                if (check_var 'XFSTESTS', 'btrfs') { dump_btrfs_img($category, $num); }
             }
             next;
         }


### PR DESCRIPTION
Fix below issue:
if xfs test failed will still trigger "dump_btrfs_img" procedure

- Verification run: http://10.67.133.10/tests/71#step/1_/1 (xfs test failed but not trigger "dump_btrfs_img")
