### PR TITLE
Add profile for autoyast test in staging

### DIFF
--- a/data/autoyast_sle15/mini_staging.xml
+++ b/data/autoyast_sle15/mini_staging.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <!-- minimal autoyast profile for staging (using urls for addons)-->
+    <bootloader>
+        <global>
+            <timeout config:type="integer">-1</timeout>
+        </global>
+    </bootloader>
+    <add-on>
+        <add_on_products config:type="list">
+             <listentry>
+                <media_url>{{ADDONURL_BASE}}</media_url>
+                <product>sle-module-basesystem</product>
+             </listentry>
+             <listentry>
+                <media_url>{{ADDONURL_SERVERAPP}}</media_url>
+                <product>sle-module-serverapplications</product>
+             </listentry>
+        </add_on_products>
+    </add-on>
+    <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <software>
+        <products config:type="list">
+            <product>SLES</product>
+        </products>
+    </software>
+    <users config:type="list">
+        <user>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <report>
+      <errors>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </errors>
+      <messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </messages>
+      <warnings>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </warnings>
+      <yesno_messages>
+        <log config:type="boolean">true</log>
+        <show config:type="boolean">true</show>
+        <timeout config:type="integer">0</timeout>
+      </yesno_messages>
+    </report>
+</profile>

--- a/tests/autoyast/prepare_profile.pm
+++ b/tests/autoyast/prepare_profile.pm
@@ -48,6 +48,9 @@ sub run {
 
     # Expand other variables
     my @vars = qw(SCC_REGCODE SCC_REGCODE_HA SCC_REGCODE_GEO SCC_URL ARCH LOADER_TYPE);
+    # Push more variables to expand from the job setting
+    my @extra_vars = push @vars, split(/,/, get_var('AY_EXPAND_VARS', ''));
+
     for my $var (@vars) {
         # Skip if value is not defined
         next unless my ($value) = get_var($var);

--- a/variables.md
+++ b/variables.md
@@ -16,6 +16,7 @@ AUTOYAST        | string    |               | Full url to the AY profile or rela
 AUTOYAST_PREPARE_PROFILE | boolean | false | Enable variable expansion in the autoyast profile.
 AUTOYAST_VERIFY | string | | Script to be executed to validate installation. Can be url, relative path if in [data directory of os-autoinst-distri-opensuse repo](https://github.com/os-autoinst/os-autoinst-distri-opensuse/tree/master/data) or test module name to be scheduled after installation is conducted.
 AUTOYAST_VERIFY_TIMEOUT  | boolean | false | Enable validation of pop-up windows timeout.
+AY_EXPAND_VARS | string | | Commas separated list of variable names to be expanded in the provided autoyast profile. For example: REPO_SLE_MODULE_BASESYSTEM,DESKTOP,... Provided variables will replace `{{VAR}}` in the profile with the value of given variable. See also `AUTOYAST_PREPARE_PROFILE`.
 BASE_VERSION | string | | |
 BETA | boolean | false | Enables checks and processing of beta warnings. Defines current stage of the product under test.
 BTRFS | boolean | false | Indicates btrfs filesystem. Deprecated, use FILESYSTEM instead.


### PR DESCRIPTION
See [poo#45893](https://progress.opensuse.org/issues/45893).

Test suite for SLES 15 should have following settings:
```
INSTALLONLY=1 
AUTOYAST=autoyast_sle15/mini_staging.xml
AUTOYAST_CONFIRM=1
AUTOYAST_PREPARE_PROFILE=1
AY_EXPAND_VARS=ADDONURL_BASE,ADDONURL_SERVERAPP
```
[Verification run](http://f174.suse.de/tests/166#)
