### PR TITLE
Remove shutdown tests from minimalx as still failing in some cases

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2422,7 +2422,6 @@ sub load_common_opensuse_sle_tests {
     load_toolchain_tests                if get_var("TCM") || check_var("ADDONS", "tcm");
     loadtest 'console/network_hostname' if get_var('NETWORK_CONFIGURATION');
     load_installation_validation_tests  if get_var('INSTALLATION_VALIDATION');
-    load_shutdown_tests                 if check_var('DESKTOP', 'minimalx') && !get_var('INSTALLONLY') && !get_var('DE_PATTERN');
 }
 
 sub load_ssh_key_import_tests {


### PR DESCRIPTION
See e.g.  https://openqa.suse.de/tests/2531374#step/shutdown/11 and
https://openqa.suse.de/tests/2531366#step/shutdown/11

Related progress issue: https://progress.opensuse.org/issues/46076