### PR TITLE
 Fix SLES4SAP XRDP test on ppc64le

### DIFF
--- a/tests/x11/remote_desktop/xrdp_server.pm
+++ b/tests/x11/remote_desktop/xrdp_server.pm
@@ -74,7 +74,13 @@ sub run {
     # Wait until xrdp client finishes remote access
     wait_for_children;
 
-    send_key_until_needlematch 'displaymanager', 'esc';
+    # Gnome on ppc64le needs a bigger timeout
+    if (get_var('OFW')) {
+        send_key_until_needlematch 'displaymanager', 'esc', 20, 5;
+    }
+    else {
+        send_key_until_needlematch 'displaymanager', 'esc';
+    }
 
     if (is_sles4sap) {
         # We don't have to test the reconnection and reboot part in SLES4SAP


### PR DESCRIPTION
Sometimes screensaver can appears on the XRDP server during the test and thus can avoid login at the end of the test.

This has already been fixed for x86_64, but it seems that a bigger timeout is needed on ppc64le.

This commit fix this.

- Verification run: not possible because we don't have multi-machine ppc64le worker in our lab... but the fix is easy, only for ppc64le so no impact (ppc64le test fails anyway!)
