### PR TITLE
Fix SLES4SAP XRDP test on ppc64le - version 2

### DIFF
--- a/tests/x11/remote_desktop/xrdp_server.pm
+++ b/tests/x11/remote_desktop/xrdp_server.pm
@@ -74,13 +74,9 @@ sub run {
     # Wait until xrdp client finishes remote access
     wait_for_children;
 
-    # Gnome on ppc64le needs a bigger timeout
-    if (get_var('OFW')) {
-        send_key_until_needlematch 'displaymanager', 'esc', 20, 5;
-    }
-    else {
-        send_key_until_needlematch 'displaymanager', 'esc';
-    }
+    # We have to click on the mouse before on ppc64le (bug?)
+    mouse_click if get_var('OFW');
+    send_key_until_needlematch 'displaymanager', 'esc';
 
     if (is_sles4sap) {
         # We don't have to test the reconnection and reboot part in SLES4SAP


### PR DESCRIPTION
Sometimes screensaver can appears on the XRDP server during the test and thus can avoid login at the end of the test.

This has already been fixed for x86_64, but it seems that we have to click on the mouse before on ppc64le (bug? Will be investigated after).

This commit *tries* to fix this a second time.

- Verification run: https://openqa.suse.de/tests/2532814, manual test remotely from the SUT (because we don't have any ppc64le worker in our test lab...)
