### PR TITLE
[blocker][Virtualization]: fix xen menuentry selection failure

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -37,11 +37,6 @@ sub login_to_console {
 
         assert_screen([qw(grub2 grub1)], 60);
     }
-    else {
-        # Wait for bootload for the first time.
-        $self->wait_grub(bootloader_time => 210);
-        send_key 'ret';
-    }
 
     if (!get_var("reboot_for_upgrade_step")) {
         if (get_var("XEN") || check_var("HOST_HYPERVISOR", "xen")) {


### PR DESCRIPTION
Xen tests fail again on login_console due to https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7005. This affects rc1 milestone candidates verification. 

- Verification run: 
xen: http://10.67.18.220/tests/641
kvm: http://10.67.18.220/tests/643
