### PR TITLE
Run investigation empty eula before

### DIFF
--- a/tests/installation/scc_registration.pm
+++ b/tests/installation/scc_registration.pm
@@ -31,9 +31,9 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = @_;
-    $self->SUPER::post_fail_hook;
     verify_scc;
     investigate_log_empty_license;
+    $self->SUPER::post_fail_hook;  
 }
 
 1;


### PR DESCRIPTION
Run investigation empty eula before post_fail_hook due to it has been encountered multiple errors unrelated with this task.

- Related ticket: https://progress.opensuse.org/issues/48128
- Needles: N/A
- Verification run: Already tested in #6989
