### PR TITLE
Terraform: enable qemu agent service

### DIFF
--- a/tests/terraform/create_image.pm
+++ b/tests/terraform/create_image.pm
@@ -38,6 +38,8 @@ sub run {
         assert_script_run('cp /etc/sysconfig/network/ifcfg-ens4 /etc/sysconfig/network/ifcfg-ens3');
     }
 
+    assert_script_run('systemctl enable qemu-ga@virtio\\\\x2dports-org.qemu.guest_agent.0.service');
+
     # Allow any connection to the VM (e.g. ICMP, SSH, ...)
     systemctl("disable " . opensusebasetest::firewall);
     systemctl("disable apparmor");


### PR DESCRIPTION
Some distris don't enable qemu agent by default. This makes user that it is running at boot time in any distri.

- Verification runs: 
15-SP1: http://fromm.arch.suse.de/tests/5518#
12-SP5: http://fromm.arch.suse.de/tests/5513
Leap: http://fromm.arch.suse.de/tests/5516#
Tumbleweed: http://fromm.arch.suse.de/tests/5517#

