### PR TITLE
Wait for pass incorrect in autoyast keymap_or_locale

### DIFF
--- a/lib/locale.pm
+++ b/lib/locale.pm
@@ -16,6 +16,7 @@ sub verify_default_keymap_textmode_non_us {
     if (match_has_tag "${tag}_not_ready") {
         # i.e: in cz keyboard the first half in the keystroke list is not displayed in 1st login'
         send_key 'ret' for (1 .. 2);
+        assert_screen 'login-incorrect';
         record_soft_failure 'bsc#1125886 - Special characters when switching keyboard layout only available after 2nd login';
         assert_screen([qw(linux-login cleared-console)]);
         type_string $test_string;

--- a/tests/locale/keymap_or_locale.pm
+++ b/tests/locale/keymap_or_locale.pm
@@ -22,8 +22,8 @@ sub run {
     my $expected = get_var('INSTALL_KEYBOARD_LAYOUT', 'us');
     # Feature of switching keyboard during installation is not ready yet,
     # so if another language is used it needs to be verfied that the needle represents properly
-    # characters on that language.
-    my $keystrokes = $self->get_keystroke_list($expected);
+    # characters on that language. Therefore we use 'us' instead of $expected
+    my $keystrokes = $self->get_keystroke_list('us');
 
     assert_screen([qw(linux-login cleared-console)]);
     return $self->verify_default_keymap_textmode_non_us($keystrokes, "${expected}_keymap") if ($expected ne 'us');


### PR DESCRIPTION
Wait for password incorrect in autoyast `keymap_or_locale`. Two-area needle for login was replaced by a one-area needle which makes test execution goes faster and consequently the password is not ready. Reproducible in local.
Besides that, it fix back (it is was forgotten to include in  #6634) that we are only using one string in us language because there is not mapping to any other language (feature not ready)
- Related ticket: https://progress.opensuse.org/issues/48956
- Needles: [needles sle](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1096)
- Verification run: [sle-15-SP1-autoyast_keyboard_layout](http://rivera-workstation.suse.cz/tests/2105)
~Note: it will need to rebase after #6634 has been merged due to code has been moved to `lib/locale.pm`~ -> rebased