### PR TITLE
Fix clamd starting timeout by systemctl

### DIFF
--- a/tests/console/clamav.pm
+++ b/tests/console/clamav.pm
@@ -40,8 +40,15 @@ sub run {
     assert_script_run 'sigtool -i /var/lib/clamav/bytecode.cvd';
     assert_script_run 'sigtool -i /var/lib/clamav/daily.cvd';
 
+    # Clamd start timeout sometimes. The default systemd timeout is 90s,
+    # override it with a longer duration in runtime.
+    my $runtime_dir = '/run/systemd/system/clamd.service.d';
+    assert_script_run "mkdir -p $runtime_dir";
+    assert_script_run "echo -e \'[Service]\\nTimeoutSec=400\' > $runtime_dir/override.conf";
+    systemctl('daemon-reload');
+
     # Start the deamons
-    systemctl('start clamd');
+    systemctl('start clamd', timeout => 400);
     systemctl('start freshclam');
 
     # Create md5, sha1 and sha256 Hash-based signatures


### PR DESCRIPTION
Clamd always start slow, which lead to a failure by systemctl. The default systemd timeout is 90s, override it with a longer duration in run time.

- Related ticket: https://progress.opensuse.org/issues/49133
- Verification run: http://10.67.17.9/tests/697#step/clamav/23
