### PR TITLE
Enhance test case usr_lib_dovecot_imap

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -316,7 +316,11 @@ sub retrieve_mail_imap {
             },
             {
                 prompt => qr/.*$mail_subject.*/m,
-                string => "A08 logout\n",
+                key    => "ctrl-]",
+            },
+            {
+                prompt => qr/telnet>/m,
+                string => "quit\n",
             },
         ],
         300


### PR DESCRIPTION
Enhance test case usr_lib_dovecot_imap.
More, test case usr_lib_dovecot_imap is PASS, and the failed case is an old known issue.

- Related ticket: https://progress.opensuse.org/issues/49100
- Needles: NA
- Verification run: http://10.67.19.89/tests/658
