### PR TITLE
QAM Virtualization fine-tuning

### DIFF
--- a/lib/virtmanager.pm
+++ b/lib/virtmanager.pm
@@ -620,11 +620,13 @@ sub select_guest {
     my $guest = shift;
     assert_and_click "virt-manager_connected";
     wait_still_screen 3;
-    assert_and_dclick "virt-manager_list-$guest";
+    assert_and_click "virt-manager_list-$guest";
+    send_key 'ret';
     if (check_screen('virt-manager_no-graphical-device', 3)) {
         wait_screen_change { send_key 'ctrl-q'; };
         assert_and_click "virt-manager_connected";
-        assert_and_dclick "virt-manager_list-$guest";
+        assert_and_click "virt-manager_list-$guest";
+        send_key 'ret';
     }
 }
 

--- a/tests/virtualization/xen/ssh_guests_init.pm
+++ b/tests/virtualization/xen/ssh_guests_init.pm
@@ -29,11 +29,6 @@ sub run {
     foreach my $guest (keys %xen::guests) {
         record_info "$guest", "Establishing SSH connection to $guest";
 
-        # Fill the current pairs of hostname & address into /etc/hosts file
-        assert_script_run "sed -i \"/$guest/d\" /etc/hosts";
-        assert_script_run qq(echo `virsh net-dhcp-leases default | awk "/$guest/ {print substr(\\\\\$5, 1, length(\\\\\$5)-3)}"` $guest >> /etc/hosts);
-        assert_script_run "cat /etc/hosts | grep $guest";
-
         # Establish the SSH connection and transfer client key
         script_retry "nmap $guest -PN -p ssh | grep open", delay => 15, retry => 12;
         assert_script_run "ssh-keyscan $guest >> ~/.ssh/known_hosts";

--- a/tests/virtualization/xen/ssh_hypervisor.pm
+++ b/tests/virtualization/xen/ssh_hypervisor.pm
@@ -36,15 +36,7 @@ sub run {
     # Configure the Master socket
     assert_script_run "echo 'ControlMaster auto
     ControlPath ~/.ssh/ssh_%r_%h_%p
-    ControlPersist 86400
-    
-    Host $hypervisor
-      Hostname $hypervisor
-      User root
-
-    Host sles*
-      ProxyJump $hypervisor
-    ' > ~/.ssh/config";
+    ControlPersist 86400' > ~/.ssh/config";
 
     # Exchange SSH keys
     assert_script_run "ssh-keyscan $hypervisor > ~/.ssh/known_hosts";

--- a/tests/virtualization/xen/waitfor_guests.pm
+++ b/tests/virtualization/xen/waitfor_guests.pm
@@ -20,7 +20,7 @@ use utils;
 sub run {
     zypper_call '-t in nmap iputils bind-utils virt-manager';
 
-    script_retry("nslookup $_ 192.168.122.1", delay => 60, retry => 60) foreach (keys %xen::guests);
+    script_retry("nslookup $_ 192.168.122.1", delay => 180, retry => 30) foreach (keys %xen::guests);
 
     # Fill the current pairs of hostname & address into /etc/hosts file
     assert_script_run "sed -i '/$_/d' /etc/hosts"                             foreach (keys %xen::guests);


### PR DESCRIPTION
This is a follow-up for #7005 (and #7009). The main reason is the X11 session forwarded over SSH which is not very stable (f.e. double clicks are not always working, etc.).

- Related ticket: [poo#43739](https://progress.opensuse.org/issues/43739)
- Needles: [os-autoinst-needles-sles#1093](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1093)
- Verification run: [QEMU](http://pdostal-server.suse.cz/tests/1600) [XEN](http://pdostal-server.suse.cz/tests/1598)
