### PR TITLE
Create subvolume for aarch64 to make snapper rollback works

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -75,6 +75,7 @@ our @EXPORT = qw(
   disable_serial_getty
   script_retry
   script_run_interactive
+  create_btrfs_subvolume
 );
 
 
@@ -1068,6 +1069,16 @@ sub script_run_interactive {
             }
         } while ($output);
     }
+}
+
+# create btrfs subvolume for /boot/grub2/arm64-efi before migration.
+# ref:bsc#1122591
+sub create_btrfs_subvolume {
+    record_soft_failure 'bsc#1122591 - Create subvolume for aarch64 to make snapper rollback works';
+    assert_script_run("mv /boot/grub2/arm64-efi /boot/grub2/arm64-efi.bk");
+    assert_script_run("btrfs subvolume create /boot/grub2/arm64-efi");
+    assert_script_run("cp -r /boot/grub2/arm64-efi.bk/* /boot/grub2/arm64-efi/");
+    assert_script_run("rm -fr /boot/grub2/arm64-efi.bk");
 }
 
 1;

--- a/tests/migration/sle12_online_migration/pre_migration.pm
+++ b/tests/migration/sle12_online_migration/pre_migration.pm
@@ -66,6 +66,8 @@ sub run {
     # according to comment 19 of bsc#985647, uninstall all kgraft-patch* packages prior to migration as a workaround to
     # solve conflict during online migration with live patching addon
     remove_kgraft_patch if is_sle('<15');
+    # create btrfs subvolume for aarch64 before migration
+    create_btrfs_subvolume() if (check_var('ARCH', 'aarch64'));
 }
 
 sub test_flags {

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -81,6 +81,9 @@ sub patching_sle {
     # Install salt packages as required
     install_salt_packages() if (check_var_array('SCC_ADDONS', 'asmm'));
 
+    # create btrfs subvolume for aarch64
+    create_btrfs_subvolume() if (check_var('ARCH', 'aarch64'));
+
     # Remove test repos after system being patched
     remove_test_repositories;
 


### PR DESCRIPTION
We need to create btrfs subvolume for /boot/grub2/arm64-efi to make the snapper rollback works.

- Related ticket: https://progress.opensuse.org/issues/48995
- Verification run: http://openqa-apac1.suse.de/tests/3555
                              http://openqa-apac1.suse.de/tests/3570
