### PR TITLE
LTP: Install bc

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -68,6 +68,7 @@ sub install_runtime_dependencies {
       apparmor-parser
       apparmor-utils
       audit
+      bc
       binutils
       dosfstools
       evmctl


### PR DESCRIPTION
bc is needed for LTP zram tests [1] (+ NUMA tests in numa01.sh as well):
zram01 7 TINFO: zram used 88M, zram disk sizes 104857600M
/opt/ltp/testcases/bin/zram01.sh: line 94: bc: command not found

While both zram and numa01.sh probably needs to be rewritten lets
install needed dependency for now.

[1] https://openqa.suse.de/tests/2535562#step/zram01/8