### PR TITLE
Add timeout on zypper install -  zypper_lifecycle_toolchain

### DIFF
--- a/tests/console/zypper_lifecycle_toolchain.pm
+++ b/tests/console/zypper_lifecycle_toolchain.pm
@@ -40,7 +40,7 @@ sub run {
     # Create list by removing blank symbols and new lines
     $gcc_packages =~ s/(\R|\s)+/ /g;
     # Install gcc packages
-    zypper_call("in $gcc_packages");
+    zypper_call("in $gcc_packages", timeout => 1200);
     # Get lifecycle information for installed toolchain packages
     my $output = script_output "zypper lifecycle $gcc_packages", 300;
     diag($output);


### PR DESCRIPTION
This script fixes poo#48467 - [qam][sle] test fails in
zypper_lifecycle_toolchain - increase timeout for installation
This script update zypper install adding timeout complete install.
--- zypper_call("in $gcc_packages");
+++ zypper_call("in $gcc_packages", timeout => 1200);

Related ticket: https://progress.opensuse.org/issues/48467
Verification run:
SLES 12 SP4 - http://10.161.229.197/tests/174#step/zypper_lifecycle_toolchain/8
