### PR TITLE
LiveCD Boot: shorten timeout on keypress

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -71,14 +71,14 @@ sub run {
 
     if (get_var("UPGRADE")) {
         # random magic numbers
-        send_key_until_needlematch('inst-onupgrade', 'down', 10, 5);
+        send_key_until_needlematch('inst-onupgrade', 'down', 10, 3);
     }
     else {
         if (get_var("PROMO") || get_var('LIVETEST') || get_var('LIVECD')) {
-            send_key_until_needlematch("boot-live-" . get_var("DESKTOP"), 'down', 10, 5);
+            send_key_until_needlematch("boot-live-" . get_var("DESKTOP"), 'down', 10, 3);
         }
         elsif (!is_jeos && !is_caasp('VMX')) {
-            send_key_until_needlematch('inst-oninstallation', 'down', 10, 5);
+            send_key_until_needlematch('inst-oninstallation', 'down', 10, 3);
         }
     }
 


### PR DESCRIPTION
At least for the first keypress, we have to make sure to land in the
timeout while grub is still counting down, otherwise the system starts
already booting and we are still waiting to match the right grub needle

- Verification run: https://openqa.opensuse.org/tests/878979 (ran far enough)
