### PR TITLE
yast2_i: only install new drivers (not all recommends)

### DIFF
--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -31,7 +31,7 @@ sub run {
         record_soft_failure 'bsc#1127212 - `zypper inr` produces conflicting packages for migrations from SLES12';
     }
     else {
-        zypper_call "-i inr";
+        zypper_call "-i inr --no-recommends";
     }
     zypper_call "-i rm $pkgname $recommended";
     zypper_call "in yast2-packager";    # make sure yast2 sw_single module installed


### PR DESCRIPTION
the 'zypper inr' call was added as yast2 sw_management would ask to
install new recommended packages, prompted by a change in libzypp
where hardware supplements are handled independent of regular
recommends (on an RPM-level, both use the same tags)

zypper inr (install-new-recommends) allows to pass --no-recommends
to only trigger the new path for driver installation

- Related ticket: https://progress.opensuse.org/issues/48512
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/879035 (not ready)
