### PR TITLE
Collect y2logs on partitioning tests fail

### DIFF
--- a/tests/installation/partitioning/encrypt_lvm.pm
+++ b/tests/installation/partitioning/encrypt_lvm.pm
@@ -14,7 +14,7 @@
 use strict;
 use warnings FATAL => 'all';
 use testapi;
-use parent "installbasetest";
+use parent "y2logsstep";
 
 sub run {
     my $partitioner = $testapi::distri->get_partitioner();

--- a/tests/installation/partitioning/encrypt_lvm_ignore_existing.pm
+++ b/tests/installation/partitioning/encrypt_lvm_ignore_existing.pm
@@ -14,7 +14,7 @@
 
 use strict;
 use warnings FATAL => 'all';
-use parent "installbasetest";
+use parent "y2logsstep";
 
 sub run {
     my $partitioner = $testapi::distri->get_partitioner();

--- a/tests/installation/partitioning/encrypt_lvm_reuse_existing.pm
+++ b/tests/installation/partitioning/encrypt_lvm_reuse_existing.pm
@@ -13,7 +13,7 @@
 
 use strict;
 use warnings FATAL => 'all';
-use parent "installbasetest";
+use parent "y2logsstep";
 
 sub run {
     my $partitioner = $testapi::distri->get_partitioner();

--- a/tests/installation/partitioning/encrypt_no_lvm.pm
+++ b/tests/installation/partitioning/encrypt_no_lvm.pm
@@ -14,7 +14,7 @@
 use strict;
 use warnings FATAL => 'all';
 use testapi;
-use parent "installbasetest";
+use parent "y2logsstep";
 
 sub run {
     my $partitioner = $testapi::distri->get_partitioner();

--- a/tests/installation/partitioning/lvm.pm
+++ b/tests/installation/partitioning/lvm.pm
@@ -14,7 +14,7 @@
 use strict;
 use warnings FATAL => 'all';
 use testapi;
-use parent "installbasetest";
+use parent "y2logsstep";
 
 sub run {
     my $partitioner = $testapi::distri->get_partitioner();

--- a/tests/installation/partitioning/lvm_ignore_existing.pm
+++ b/tests/installation/partitioning/lvm_ignore_existing.pm
@@ -14,7 +14,7 @@
 
 use strict;
 use warnings FATAL => 'all';
-use parent "installbasetest";
+use parent "y2logsstep";
 
 sub run {
     my $partitioner = $testapi::distri->get_partitioner();

--- a/tests/installation/partitioning/lvm_no_separate_home.pm
+++ b/tests/installation/partitioning/lvm_no_separate_home.pm
@@ -13,7 +13,7 @@
 
 use strict;
 use warnings FATAL => 'all';
-use parent "installbasetest";
+use parent "y2logsstep";
 
 sub run {
     my $partitioner = $testapi::distri->get_partitioner();

--- a/tests/installation/partitioning/no_separate_home.pm
+++ b/tests/installation/partitioning/no_separate_home.pm
@@ -14,7 +14,7 @@
 
 use strict;
 use warnings FATAL => 'all';
-use parent "installbasetest";
+use parent "y2logsstep";
 
 sub run {
     my $partitioner = $testapi::distri->get_partitioner();

--- a/tests/installation/partitioning/separate_home.pm
+++ b/tests/installation/partitioning/separate_home.pm
@@ -14,7 +14,7 @@
 
 use strict;
 use warnings FATAL => 'all';
-use parent "installbasetest";
+use parent "y2logsstep";
 
 sub run {
     my $partitioner = $testapi::distri->get_partitioner();


### PR DESCRIPTION
Use y2logsstep as a parent module for partitioning test modules instead
of installbasetest, as in these modules it is required to collect y2logs
on fail, but installbasetest's post_fail_hook does not provide them.
