### PR TITLE
lshw: don't expect newline after 'network' to work with multiple adapters

### DIFF
--- a/tests/console/lshw.pm
+++ b/tests/console/lshw.pm
@@ -23,7 +23,7 @@ sub run {
 
     # Check various output formats, -sanitize is used to not spill test machine serial numbers into public
     # On some architectures fields like "product" or "vendor" or section "*-pci" might not exist, so trying a common base.
-    validate_script_output("lshw -sanitize", sub { m/description.*\*-memory\n.*\*-network\n/s });
+    validate_script_output("lshw -sanitize", sub { m/description.*\*-memory\n.*\*-network/s });
     assert_script_run("lshw -html -sanitize");
     assert_script_run("lshw -xml -sanitize");
     assert_script_run("lshw -json -sanitize");


### PR DESCRIPTION
Remove the requirement for the network adapter line the end with \n after the 'network', since on multi-adapter machines it's "network:0", "network:1" etc.

- Related ticket: https://progress.opensuse.org/issues/49004
- Verification run: http://d403.qam.suse.de/tests/76
