### PR TITLE
Update suseconnect_scc for JeOS

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -70,7 +70,7 @@ sub login {
     die 'Login expects two arguments' unless @_ == 2;
     my $user        = shift;
     my $escseq      = qr/(\e [\(\[] [\d\w]{1,2})/x;
-    my $pass_prompt = get_var('JEOSINSTLANG') =~ 'DE' ? 'Passwort:' : 'Password:';
+    my $pass_prompt = get_var('JEOSINSTLANG', '') =~ 'DE' ? 'Passwort:' : 'Password:';
 
     $serial_term_prompt = shift;
 

--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -34,7 +34,7 @@ sub run {
     my $scc_url    = get_required_var('SCC_URL');
     my $scc_addons = get_var('SCC_ADDONS', '');
 
-    $self->select_serial_terminal;
+    get_var('JEOSINSTLANG', '') =~ 'DE' ? select_console('root-console') : $self->select_serial_terminal;
     assert_script_run "SUSEConnect --url $scc_url -r $reg_code";
     assert_script_run 'SUSEConnect --list-extensions';
 


### PR DESCRIPTION
The change updates suseconnect_scc to use select_console on JeOS for DE language. This is needed because select_serial_terminal looks for the DE version of the password prompt, but at the time is run here it is not available on JeOS since glibc-locale is installed after registering the system.

- Related ticket: https://progress.opensuse.org/issues/49208
- Verification run: 
   en_US: http://ccret.suse.cz/tests/3032
   de_DE: http://ccret.suse.cz/tests/3031#
