### PR TITLE
Fix systemd-logind restart in NetWeaver tests

### DIFF
--- a/tests/sles4sap/netweaver_install.pm
+++ b/tests/sles4sap/netweaver_install.pm
@@ -43,24 +43,14 @@ sub prepare_profile {
         assert_script_run "tuned-adm profile $profile";
     }
 
+    # Restart systemd-logind to ensure that all new connections will have the
+    # SAP tuning activated
     systemctl 'restart systemd-logind.service';
-    # 'systemctl restart systemd-logind' is causing the X11 console to move
-    # out of tty2 on SLES4SAP-15, which in turn is causing the change back to
-    # the previous console in post_run_hook() to fail when running on systems
-    # with DESKTOP=gnome, which is a false positive as the test has already
-    # finished by that step. The following prevents post_run_hook from attempting
-    # to return to the console that was set before this test started. For more
-    # info on why X is running in tty2 on SLES4SAP-15, see bsc#1054782
-    $sles4sap::prev_console = undef;
 
-    # If running in DESKTOP=gnome, systemd-logind restart may cause the graphical console to
-    # reset and appear in SUD, so need to select 'root-console' again
-    assert_screen(
-        [
-            qw(root-console displaymanager displaymanager-password-prompt generic-desktop
-              text-login linux-login started-x-displaymanager-info)
-        ], 120);
-    select_console 'root-console' unless (match_has_tag 'root-console');
+    # If running in DESKTOP=gnome, systemd-logind restart may cause the graphical
+    # console to reset and appear in SUD, so need to select 'root-console' again
+    # 'root-console' can be re-selected safely even if DESKTOP=textmode
+    select_console 'root-console';
 
     if ($has_saptune) {
         assert_script_run "saptune daemon start";


### PR DESCRIPTION
In some cases with DESKTOP=gnome when we restart systemd-logind we can have some sporaric timeout issues because we wait for the GDM to restart, but that's not needed at all in our tests.

This commit remove the old logic and only select 'root-console'
after the service restart.

- Verification run: [Gnome](http://1b147.qa.suse.de/tests/5116), [textmode](http://1b147.qa.suse.de/tests/5118), with [forced error Gnome](http://1b147.qa.suse.de/tests/5119) and with [forced error textmode](http://1b147.qa.suse.de/tests/5120)
