### PR TITLE
 publiccloud: Fix run_ltp on on-demand images

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -42,10 +42,10 @@ sub run_ssh_command {
 
     $args{timeout} //= SSH_TIMEOUT;
 
-    my $ssh_cmd = sprintf('ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "%s" "%s@%s" -- %s',
+    my $ssh_cmd = sprintf('ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -oLogLevel=ERROR -i "%s" "%s@%s" -- %s',
         $self->ssh_key, $self->username, $self->public_ip, $args{cmd});
     record_info('CMD', $ssh_cmd);
-    return script_output($ssh_cmd, $args{timeout});
+    return script_output($ssh_cmd, $args{timeout}, %args);
 }
 
 1;


### PR DESCRIPTION
From time to time, zypper fail, cause there was an zypper instance
already running.
The reason is, the guestregister service use zypper to register
additional repos.
Solution is to wait til guestregister is ready.

- Related ticket: https://progress.opensuse.org/issues/48839
- Verification run:http://cfconrad-vm.qa.suse.de/tests/3589#step/run_ltp/106
