### PR TITLE
Finish the multimachine support of console/yast2_nfs_(server/client) tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -959,6 +959,17 @@ else {
             loadtest "network/salt_minion";
         }
     }
+    elsif (get_var("NFSSERVER") or get_var("NFSCLIENT")) {
+        set_var('INSTALLONLY', 1);
+        boot_hdd_image;
+        #loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
+        if (get_var("NFSSERVER")) {
+            loadtest "console/yast2_nfs_server";
+        }
+        else {
+            loadtest "console/yast2_nfs_client";
+        }
+    }
     elsif (get_var('QAM_VSFTPD')) {
         set_var('INSTALLONLY', 1);
         if (check_var('HOSTNAME', 'server')) {

--- a/tests/console/yast2_nfs_client.pm
+++ b/tests/console/yast2_nfs_client.pm
@@ -17,34 +17,49 @@ use base "console_yasttest";
 use strict;
 use warnings;
 use testapi;
+use lockapi;
 use utils;
+use mm_network;
 
 sub run {
     #
     # Preparation
     #
     select_console 'root-console';
+    if (get_var('NFSCLIENT')) {
+        # Configure static IP for client/server test
+        configure_default_gateway;
+        configure_static_ip('10.0.2.102/24');
+        configure_static_dns(get_host_resolv_conf());
+
+        zypper_call('in yast2-nfs-client nfs-client', timeout => 360, exitcode => [0, 106, 107]);
+
+        mutex_wait('nfs_ready');
+        assert_script_run 'ping -c3 10.0.2.101';
+    }
+    else {
+        # Make sure packages are installed
+        zypper_call('in yast2-nfs-client nfs-client nfs-kernel-server', timeout => 180, exitcode => [0, 106, 107]);
+        # Prepare the test file structure
+        assert_script_run 'mkdir -p /tmp/nfs/server';
+        assert_script_run 'echo "success" > /tmp/nfs/server/file.txt';
+        # Serve the share
+        assert_script_run 'echo "/tmp/nfs/server *(ro)" >> /etc/exports';
+        systemctl 'start nfs-server';
+    }
     # add comments into fstab and save current fstab bsc#429326
     assert_script_run 'sed -i \'5i# test comment\' /etc/fstab';
     assert_script_run 'cat /etc/fstab > fstab_before';
-    # Make sure packages are installed
-    zypper_call('in yast2-nfs-client nfs-client nfs-kernel-server', timeout => 180);
-    # Prepare the test file structure
-    assert_script_run 'mkdir -p /tmp/nfs/server';
-    assert_script_run 'echo "It worked" > /tmp/nfs/server/file.txt';
-    # Serve the share
-    assert_script_run 'echo "/tmp/nfs/server *(ro)" >> /etc/exports';
-    systemctl 'start nfs-server';
 
     #
     # YaST nfs-client execution
     #
-    script_run 'yast2 nfs-client', 0;
+    type_string "yast2 nfs-client; echo YAST-DONE-\$?- > /dev/$serialdev\n";
     assert_screen 'yast2-nfs-client-shares';
     # Open the dialog to add a connection to the share
     send_key 'alt-a';
     assert_screen 'yast2-nfs-client-add';
-    type_string 'localhost';
+    type_string get_var('NFSCLIENT') ? '10.0.2.101' : 'localhost';
     # Explore the available shares and select the only available one
     send_key 'alt-e';
     assert_screen 'yast2-nfs-client-exported';
@@ -52,28 +67,43 @@ sub run {
     # Set the local mount point
     send_key 'alt-m';
     type_string '/tmp/nfs/client';
+    sleep 1;
+    save_screenshot;
     # Save the new connection and close YaST
     wait_screen_change { send_key 'alt-o' };
     wait_screen_change { send_key 'alt-o' };
 
+    wait_serial('YAST-DONE-0-') or die "'yast2 nfs-server' didn't finish";
+
+    clear_console;
+
     #
     # Check the result
     #
+
     # check if nfs is mounted
     script_run 'mount|grep nfs';
+    script_run 'cat /etc/fstab|grep nfs';
+
     # Wait for more than 90 seconds due to NFSD's 90 second grace period.
     diag 'waiting 90 second due NFS grace period';
     sleep 90;
+
     # script_run is using bash return logic not perl logic, 0 is true
-    if ((script_run 'grep "It worked" /tmp/nfs/client/file.txt') != 0) {
+    if ((script_run 'grep "success" /tmp/nfs/client/file.txt') != 0) {
         record_soft_failure 'boo#1006815 nfs mount is not mounted';
+        assert_script_run 'mount /tmp/nfs/client';
+        assert_script_run 'grep "success" /tmp/nfs/client/file.txt';
     }
+
     # remove added nfs from /etc/fstab
     assert_script_run 'sed -i \'/nfs/d\' /etc/fstab';
+
     # compare saved and current fstab, should be same
     if ((script_run 'diff -b /etc/fstab fstab_before') != 0) {
         record_soft_failure 'bsc#429326 comments were deleted';
     }
+
     # compare last line, should be not deleted
     assert_script_run 'diff -b <(tail -n1 /etc/fstab) <(tail -n1 fstab_before)';
 }


### PR DESCRIPTION
Hello,

the `console/yast2_nfs_server` test by @Vogtinator had already multimachine support.
The `console/yast2_nfs_client` test by @okurz I extended to support multimachine as well.

- Related ticket: [poo#44591](https://progress.opensuse.org/issues/44591)
- Needles: [os-autoinst-needles-sles#1099](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1099)
- Verification run: [qam-nfs[server](http://pdostal-server.suse.cz/tests/1653) [qam-nfs-client](http://pdostal-server.suse.cz/tests/1654)

My goal is of course to keep the compatibility with existing scenarios.

Thank you