### PR TITLE
Fix post_fail_hooks to show empty eula info

### DIFF
--- a/lib/console_yasttest.pm
+++ b/lib/console_yasttest.pm
@@ -20,7 +20,7 @@ sub post_fail_hook {
 
     $self->remount_tmp_if_ro;
     $self->save_upload_y2logs;
-    upload_logs('/var/log/zypper.log');
+    upload_logs('/var/log/zypper.log', failok => 1);
     $self->save_system_logs;
     $self->save_strace_gdb_output('yast');
 }

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -749,14 +749,12 @@ sub install_docker_when_needed {
 }
 
 sub verify_scc {
-    select_console 'root-console';
     record_info('proxySCC/SCC', 'Verifying that proxySCC and SCC can be accessed');
     assert_script_run("curl ${\(get_var('SCC_URL'))}/login") if get_var('SCC_URL');
     assert_script_run("curl https://scc.suse.com/login");
 }
 
 sub investigate_log_empty_license {
-    select_console 'root-console';
     my $filter_products   = "grep -Po '<SUSE::Connect::Remote::Product.*?(extensions|isbase=(true|false)>)'";
     my $y2log_file        = '/var/log/YaST2/y2log';
     my $filter_empty_eula = qq[grep '.*eula_url="".*'];

--- a/tests/console/suseconnect_scc.pm
+++ b/tests/console/suseconnect_scc.pm
@@ -18,10 +18,9 @@
 # Summary: Register system against SCC after installation
 # Maintainer: Michal Nowak <mnowak@suse.com>
 
+use base 'consoletest';
 use strict;
 use warnings;
-use base 'y2logsstep';
-
 use testapi;
 use utils 'zypper_call';
 use version_utils 'is_sle';
@@ -46,6 +45,13 @@ sub run {
     }
     # Check that repos actually work
     zypper_call('refresh');
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    $self->SUPER::post_fail_hook;
+    verify_scc;
+    investigate_log_empty_license;
 }
 
 sub test_flags {

--- a/tests/console/yast2_scc.pm
+++ b/tests/console/yast2_scc.pm
@@ -33,9 +33,9 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = shift;
+    $self->SUPER::post_fail_hook;
     verify_scc;
     investigate_log_empty_license;
-    $self->SUPER::post_fail_hook;
 }
 
 1;

--- a/tests/installation/addon_products_via_SCC_yast2.pm
+++ b/tests/installation/addon_products_via_SCC_yast2.pm
@@ -55,9 +55,9 @@ sub run {
 
 sub post_fail_hook {
     my ($self) = @_;
+    $self->SUPER::post_fail_hook;
     verify_scc;
     investigate_log_empty_license;
-    $self->SUPER::post_fail_hook;
 }
 
 1;


### PR DESCRIPTION
Fix post_fail_hooks chain to show empty eula info:
- Add `failok => 1` in `console_yasttest` when not finding `/var/log/zypper.log` (aka funny value).
- Check for system management locked and not use `assert_script_run` in subsequent lines.
- Not force selecting `root-console` on eula investigation, instead ~select `log-console`~(keep log-console where is already selected) where works: on `yast2_scc` is fine but in `scc_registration` is not, so it is not added due to the console switch has some problem and from the first `curl` that is sent after switching the console and even with the cursor blinking (apparently input ready) only hit the console `url` missing the first letter. Regarding ` addon_products_via_SCC_yast2` I don't plan to incorporate it here as there is no `post_fail_hook` catching anything in this module, not even a simple `print`.
- ~Remove `tail -n 150` due it is creating non-response of subsequent commands, i.e.: `btrfs filesystem df /mnt | tee /tmp/btrfs-filesystem-df-mnt.txt`.~ Covered in #7059
- Switch base in `suseconnect_scc` from `y2logsstep` to `consoletest` to add `post_fail_hook` and add check for eula.
#### Related ticket: 
https://progress.opensuse.org/issues/48128
#### Verification runs: 
- [sle-12-SP5-minimal+base+sdk+proxy_SCC-postreg](http://rivera-workstation.suse.cz/tests/2182#step/yast2_scc/174)
- [sle-15-SP1-create_hdd_gnome](http://rivera-workstation.suse.cz/tests/2173#step/scc_registration/193)
- [sle-15-SP1-minimal+proxy_SCC-postreg_SUSEconnect](http://rivera-workstation.suse.cz/tests/2180#step/suseconnect_scc/60)
- [sle-15-SP1-sles+sdk+proxy_SCC_via_YaST](http://rivera-workstation.suse.cz/tests/2185#step/addon_products_via_SCC_yast2/206)