### PR TITLE
Record isosize to fix rendering invalid result

### DIFF
--- a/tests/installation/isosize.pm
+++ b/tests/installation/isosize.pm
@@ -25,12 +25,17 @@ sub run {
     if (!$size || !$max || $size > $max) {
         $result = 'fail';
     }
+    my $result_text;
     if (!defined $size) {
-        diag("iso path invalid: $iso");
+        $result_text = "iso path invalid: $iso";
     }
     else {
-        diag("check if actual iso size $size fits $max: $result");
+        $result_text = "check if actual iso size $size fits $max: $result";
     }
+
+    diag($result_text);
+    record_info('isosize', $result_text, result => $result);
+
     $self->result($result);
 }
 


### PR DESCRIPTION
Otherwise on backends where no screenshot is available on startup (e.g. svirt, see https://openqa.suse.de/tests/2536487#step/isosize/1) os-autoinst would render an invalid result.