### PR TITLE
Add milestone anchor for IMA setup and measurement

### DIFF
--- a/tests/security/ima/ima_measurement.pm
+++ b/tests/security/ima/ima_measurement.pm
@@ -61,7 +61,7 @@ sub run {
 }
 
 sub test_flags {
-    return {always_rollback => 1};
+    return {milestone => 1, fatal => 1};
 }
 
 1;

--- a/tests/security/ima/ima_setup.pm
+++ b/tests/security/ima/ima_setup.pm
@@ -46,7 +46,7 @@ sub run {
 }
 
 sub test_flags {
-    return {fatal => 1};
+    return {milestone => 1, fatal => 1};
 }
 
 1;


### PR DESCRIPTION
To fix IMA measurement audit failed issue, which caused by rollback to the point before IMA measurement and IMA setup. 

See the failed case: https://openqa.suse.de/tests/2550844#step/ima_measurement_audit/44

- Related ticket: https://progress.opensuse.org/issues/49334
- Verification run: http://10.67.17.9/tests/761
