### PR TITLE
publiccloud: Ensure ntp is installed

### DIFF
--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -36,7 +36,7 @@ sub run {
     for my $repo (split(/\s+/, $tools_repo)) {
         zypper_call('ar ' . $repo);
     }
-    zypper_call('--gpg-auto-import-keys -q in python3-ipa python3-ipa-tests git-core');
+    zypper_call('--gpg-auto-import-keys -q in python3-ipa python3-ipa-tests git-core ntp');
 
     # Install AWS cli
     zypper_call('-q in gcc python3-pip');


### PR DESCRIPTION
We need ntpdate when using google cloud service. Make sure it is
installed.

I moved to SLE15 as helper VM. But it seems ntp isn't installed as default: https://openqa.suse.de/tests/2551458#step/upload_image/37

- Verification run: http://cfconrad-vm.qa.suse.de/tests/3604
