### PR TITLE
Fix live desktop login

### DIFF
--- a/tests/installation/finish_desktop.pm
+++ b/tests/installation/finish_desktop.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,7 +22,11 @@ sub run {
 
     # live may take ages to boot
     my $timeout = 600;
-    assert_screen "generic-desktop", $timeout;
+    assert_screen ["generic-desktop", "displaymanager"], $timeout;
+    if (match_has_tag "displaymanager") {
+        assert_and_click "displaymanager";
+        assert_screen "generic-desktop";
+    }
 
     ## duplicated from second stage, combine!
     if (check_var('DESKTOP', 'kde')) {


### PR DESCRIPTION
A click on the user is needed to login to the desktop.

- Related ticket: https://progress.opensuse.org/issues/49391
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/532
- Verification run: http://panigale.suse.cz/tests/1536