### PR TITLE
publiccloud: ipa - let define ipa tests always

### DIFF
--- a/tests/publiccloud/ipa.pm
+++ b/tests/publiccloud/ipa.pm
@@ -39,7 +39,7 @@ sub run {
 
     my $provider = $self->provider_factory();
     my $instance = $provider->create_instance();
-    my $tests    = get_var('PUBLIC_CLOUD_CHECK_BOOT_TIME') ? '' : get_required_var('PUBLIC_CLOUD_IPA_TESTS');
+    my $tests    = get_var('PUBLIC_CLOUD_IPA_TESTS', '');
 
     my $ipa = $provider->ipa(
         instance    => $instance,


### PR DESCRIPTION
Allow to specify the PUBLIC_CLOUD_IPA_TESTS also if we run the
ipa.pm module with PUBLIC_CLOUD_CHECK_BOOT_TIME.

This helps, if we need to make a reboot before measure the boottime.

- Related ticket: https://progress.opensuse.org/issues/47006
- Verification run: http://cfconrad-vm.qa.suse.de/tests/3626 (GCE on-demand)
- Verification run: http://cfconrad-vm.qa.suse.de/tests/3628 (GCE BYOS)


@asmorodskyi  WDYT?