### PR TITLE
Enable the migration path on aarch64 for grub_test_snapshot

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -453,10 +453,12 @@ sub wait_grub {
         || (check_var('ARCH', 'aarch64') && get_var('UEFI'))
         || get_var('OFW')
         || (check_var('BOOTFROM', 'd')));
+    # Special processing for aarch64 migration
+    # Refer to ticket: https://progress.opensuse.org/issues/49340
     $self->handle_uefi_boot_disk_workaround
       if (is_aarch64_uefi_boot_hdd
         && !$in_grub
-        && (!(isotovideo::get_version() >= 12 && get_var('UEFI_PFLASH_VARS')) || get_var('ONLINE_MIGRATION')));
+        && (!(isotovideo::get_version() >= 12 && get_var('UEFI_PFLASH_VARS')) || get_var('UPGRADE')));
     assert_screen(\@tags, $bootloader_time);
     if (match_has_tag("bootloader-shim-import-prompt")) {
         send_key "down";


### PR DESCRIPTION
For aarch64, grub page is different with other platform. For migration test, it doesn't just include online migration, so change it with UPGRADE.

- Related ticket: https://progress.opensuse.org/issues/49340
- Verification run: http://openqa-apac1.suse.de/tests/3591
[autoinst-log.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/2976087/autoinst-log.txt)

