### PR TITLE
Enable kdump on aarch64 for SLE15 and newer

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -610,7 +610,7 @@ sub kdestep_is_applicable {
 
 # kdump is not supported on aarch64 (bsc#990418), and Xen PV (feature not implemented)
 sub kdump_is_applicable {
-    return !check_var('ARCH', 'aarch64') && !check_var('VIRSH_VMM_TYPE', 'linux');
+    return !(check_var('ARCH', 'aarch64') && is_sle('<15')) && !check_var('VIRSH_VMM_TYPE', 'linux');
 }
 
 sub consolestep_is_applicable {


### PR DESCRIPTION
Fix poo#49217: kdump test was disabled on aarch64 for all SLE versions.
It is oficially supported since SLE15.

- Related ticket: https://progress.opensuse.org/issues/49217
- Needles: none
- Verification run:
SLE12-SP3 x86_64 http://10.100.12.105/tests/1681
SLE15 x86_64  http://10.100.12.105/tests/1682
SLE15-SP1 aarch64 https://openqa.suse.de/tests/2567158#
