### PR TITLE
IMA appraisal with hashes and digital signatures

### DIFF
--- a/data/ima/ima_appraise_ds_policy
+++ b/data/ima/ima_appraise_ds_policy
@@ -1,0 +1,45 @@
+# PROC_SUPER_MAGIC
+dont_measure fsmagic=0x9fa0
+dont_appraise fsmagic=0x9fa0
+# SYSFS_MAGIC
+dont_measure fsmagic=0x62656572
+dont_appraise fsmagic=0x62656572
+# DEBUGFS_MAGIC
+dont_measure fsmagic=0x64626720
+dont_appraise fsmagic=0x64626720
+# TMPFS_MAGIC
+dont_measure fsmagic=0x01021994
+dont_appraise fsmagic=0x01021994
+# RAMFS_MAGIC
+dont_appraise fsmagic=0x858458f6
+# DEVPTS_SUPER_MAGIC
+dont_measure fsmagic=0x1cd1
+dont_appraise fsmagic=0x1cd1
+# BINFMTFS_MAGIC
+dont_measure fsmagic=0x42494e4d
+dont_appraise fsmagic=0x42494e4d
+# SECURITYFS_MAGIC
+dont_measure fsmagic=0x73636673
+dont_appraise fsmagic=0x73636673
+# SELINUX_MAGIC
+dont_measure fsmagic=0xf97cff8c
+dont_appraise fsmagic=0xf97cff8c
+# CGROUP_SUPER_MAGIC
+dont_measure fsmagic=0x27e0eb
+dont_appraise fsmagic=0x27e0eb
+# CGROUP2_SUPER_MAGIC
+dont_measure fsmagic=0x63677270
+dont_appraise fsmagic=0x63677270
+# NSFS_MAGIC
+dont_measure fsmagic=0x6e736673
+dont_appraise fsmagic=0x6e736673
+
+appraise func=BPRM_CHECK fowner=0 appraise_type=imasig
+appraise func=BPRM_CHECK euid=0 appraise_type=imasig
+appraise func=FILE_MMAP fowner=0 mask=MAY_EXEC appraise_type=imasig
+appraise func=FILE_MMAP euid=0 mask=MAY_EXEC appraise_type=imasig
+appraise func=MODULE_CHECK appraise_type=imasig
+appraise func=FIRMWARE_CHECK appraise_type=imasig
+# this is only for newer kernels that support loading policies
+# from file by writing the file path to the ima sysfs node
+appraise func=POLICY_CHECK appraise_type=imasig

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2212,6 +2212,12 @@ sub load_security_tests_ima_measurement {
     loadtest "security/ima/ima_measurement_audit";
 }
 
+sub load_security_tests_ima_appraisal {
+    loadtest "security/ima/ima_setup";
+    loadtest "security/ima/ima_appraisal_hashes";
+    loadtest "security/ima/ima_appraisal_digital_signatures";
+}
+
 sub load_security_tests_system_check {
     loadtest "security/nproc_limits";
 }
@@ -2222,7 +2228,7 @@ sub load_security_tests {
       ipsec mmtest
       apparmor apparmor_profile selinux
       openscap
-      mok_enroll ima_measurement
+      mok_enroll ima_measurement ima_appraisal
       system_check
       /;
 

--- a/tests/security/ima/ima_appraisal_digital_signatures.pm
+++ b/tests/security/ima/ima_appraisal_digital_signatures.pm
@@ -1,0 +1,93 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test IMA appraisal using digital signatures
+# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Tags: poo#49154
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
+use power_action_utils "power_action";
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    my $fstype     = 'ext4';
+    my $sample_app = '/usr/bin/yes';
+    my $sample_cmd = 'yes --version';
+
+    my $mok_priv = '/root/certs/key.asc';
+    my $cert_der = "/root/certs/ima_cert.der";
+    my $mok_pass = "suse";
+
+    add_grub_cmdline_settings("ima_appraise=fix", 1);
+
+    power_action('reboot', textmode => 1);
+    $self->wait_boot(textmode => 1);
+    $self->select_serial_terminal;
+
+    my @sign_cmd = (
+        "/usr/bin/find / -fstype $fstype -type f -executable -uid 0 -exec evmctl -a sha256 ima_sign -p$mok_pass -k $mok_priv '{}' \\;",
+"for D in /lib /lib64 /usr/lib /usr/lib64; do /usr/bin/find \"\$D\" -fstype $fstype -\\! -executable -type f -name '*.so*' -uid 0 -exec evmctl -a sha256 ima_sign -p$mok_pass -k $mok_priv '{}' \\; ; done",
+        "/usr/bin/find /lib/modules -fstype $fstype -type f -name '*.ko' -uid 0 -exec evmctl -a sha256 ima_sign -p$mok_pass -k $mok_priv '{}' \\;",
+        "/usr/bin/find /lib/firmware -fstype $fstype -type f -uid 0 -exec evmctl -a sha256 ima_sign -p$mok_pass -k $mok_priv '{}' \\;"
+    );
+
+    for my $s (@sign_cmd) {
+        my $findret = script_output($s, 900, proceed_on_failure => 1);
+
+        # Allow "No such file" message for the files in /proc because they are mutable
+        my @finds = split /\n/, $findret;
+        $_ =~ m/\/proc\/.*No such file/ or die "Failed to create security.ima for $_" foreach (@finds);
+    }
+
+    validate_script_output "getfattr -m security.ima -d $sample_app", sub {
+        # Base64 armored security.ima content (358 chars), we do not match the
+        # last three ones here for simplicity
+        m/security\.ima=[0-9a-zA-Z+\/]{355}/;
+    };
+
+    # Prepare mok ceritificate file
+    assert_script_run "mkdir -p /etc/keys/ima";
+    assert_script_run "cp $cert_der /etc/keys/ima/";
+
+    assert_script_run "wget --quiet " . data_url("ima/ima_appraisal_ds_policy" . " -O /etc/sysconfig/ima-policy");
+
+    replace_grub_cmdline_settings('ima_appraise=fix', '', 1);
+
+    power_action('reboot', textmode => 1);
+    $self->wait_boot(textmode => 1);
+    $self->select_serial_terminal;
+
+    assert_script_run "dmesg | grep IMA:.*completed";
+
+    # Remove security.ima attribute manually, and verify it is empty
+    assert_script_run "setfattr -x security.ima $sample_app";
+    validate_script_output "getfattr -m security.ima -d $sample_app", sub { m/^$/ };
+
+    my $ret = script_output($sample_cmd, 30, proceed_on_failure => 1);
+    die "$sample_app should not have permission to run" if ($ret !~ "\Q$sample_app\E: *Permission denied");
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/security/ima/ima_appraisal_hashes.pm
+++ b/tests/security/ima/ima_appraisal_hashes.pm
@@ -1,0 +1,76 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test IMA appraisal using hashes
+# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Tags: poo#49151
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use bootloader_setup qw(add_grub_cmdline_settings replace_grub_cmdline_settings);
+use power_action_utils "power_action";
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    my $fstype     = 'ext4';
+    my $sample_app = '/usr/bin/yes';
+    my $sample_cmd = 'yes --version';
+
+    my ($kver) = script_output('uname -r') =~ /(\d+\.\d+)\.\d+-*/;
+    assert_script_run "echo $kver";
+    my $tcb_cmdline = ($kver lt 4.13) ? 'ima_appraise_tcb' : 'ima_policy=appraise_tcb';
+
+    add_grub_cmdline_settings("ima_appraise=fix $tcb_cmdline", 1);
+
+    power_action('reboot', textmode => 1);
+    $self->wait_boot(textmode => 1);
+    $self->select_serial_terminal;
+
+    my $findret = script_output("find / -fstype $fstype -type f -uid 0 -exec sh -c \"< '{}'\" \\;", 900, proceed_on_failure => 1);
+
+    # Allow "No such file" message for the files in /proc because they are mutable
+    my @finds = split /\n/, $findret;
+    $_ =~ m/\/proc\/.*No such file/ or die "Failed to create security.ima for $_" foreach (@finds);
+
+    validate_script_output "getfattr -m security.ima -d $sample_app", sub {
+        # Base64 armored security.ima content (50 chars), we do not match the last
+        # three ones here for simplicity
+        m/security\.ima=[0-9a-zA-Z+\/]{47}/;
+    };
+
+    # Remove security.ima attribute manually, and verify it is empty
+    assert_script_run "setfattr -x security.ima $sample_app";
+    validate_script_output "getfattr -m security.ima -d $sample_app", sub { m/^$/ };
+
+    replace_grub_cmdline_settings('ima_appraise=fix', '', 1);
+
+    power_action('reboot', textmode => 1);
+    $self->wait_boot(textmode => 1);
+    $self->select_serial_terminal;
+
+    my $ret = script_output($sample_cmd, 30, proceed_on_failure => 1);
+    die "$sample_app should not have permission to run" if ($ret !~ "\Q$sample_app\E: *Permission denied");
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
Test IMA appraisal using both hashes and digital signatures. Add
ima-policy to data/. And also create testsuite 'ima_appraisal'.

Fix poo#49154, poo#49151

- Related ticket:
  - https://progress.opensuse.org/issues/49154
  - https://progress.opensuse.org/issues/49151
- Verification run:
  - http://10.67.17.9/tests/763