### PR TITLE
Remove invalid softfail

### DIFF
--- a/tests/installation/caasp_roleconf.pm
+++ b/tests/installation/caasp_roleconf.pm
@@ -35,8 +35,6 @@ sub run {
 
     # Both admin / worker have ntp now
     if (check_screen 'ntp-servers-empty') {
-        record_soft_failure 'bsc#1114818';
-
         # Try without ntp servers
         send_alt 'next';
         assert_screen 'ntp-servers-missing';


### PR DESCRIPTION
boo#1114818 is an openSUSE bug and ONLY an openSUSE bug

If any commercial product did autofill the NTP field, it would be in breach of the terms and conditions of the ntp.org services

Therefore, remove the invalid softfail in this CaaSP test.
