### PR TITLE
Do not schedule zypper_lifecycle on Hyper-V 2012 R2

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1202,7 +1202,7 @@ sub load_consoletests {
         loadtest "console/xfce_gnome_deps";
     }
     if (!is_staging() && is_sle('12-SP2+')) {
-        loadtest "console/zypper_lifecycle";
+        loadtest "console/zypper_lifecycle" unless is_hyperv('2012r2');
         if (check_var_array('SCC_ADDONS', 'tcm') && is_sle('<15')) {
             loadtest "console/zypper_lifecycle_toolchain";
         }

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -96,7 +96,8 @@ sub is_vmware {
 }
 
 sub is_hyperv {
-    return check_var('VIRSH_VMM_FAMILY', 'hyperv');
+    my $hyperv_version = shift;
+    return check_var('VIRSH_VMM_FAMILY', 'hyperv') && (defined($hyperv_version) && check_var('HYPERV_VERSION', $hyperv_version));
 }
 
 sub is_hyperv_in_gui {


### PR DESCRIPTION
https://trello.com/c/DBvapQje/389-p2-do-not-schedule-console-zypperlifecycle-on-hyper-v-2012-r2

* `HYPERV_VERSION` not set: `zypper_lifecycle` scheduled: http://nilgiri.suse.cz/tests/578
* `HYPERV_VERSION=2012r2`: `zypper_lifecycle` not scheduled: http://nilgiri.suse.cz/tests/580
* `HYPERV_VERSION=2016`: `zypper_lifecycle` scheduled: http://nilgiri.suse.cz/tests/579