### PR TITLE
Optimize masking/disabling getty and packagekit

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -404,9 +404,7 @@ sub become_root {
     my ($self) = @_;
 
     $self->script_sudo('bash', 0);
-    disable_serial_getty;
-    type_string "whoami > /dev/$testapi::serialdev\n";
-    wait_serial('root') || die "Root prompt not there";
+    disable_serial_getty() unless $self->script_run("systemctl is-enabled serial-getty\@$testapi::serialdev");
     type_string "cd /tmp\n";
     $self->set_standard_prompt('root');
     type_string "clear\n";


### PR DESCRIPTION
By using the combined systemctl commands we can save some typing in the
very common calls to enable/disable the serial getty services as well as
packagekit.

Also removing the "whoami" command which became useless already when we
introduced the call to disable the serial getty service before calling
"whoami".

Verification runs:

```
env MARKDOWN=1 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7084 https://openqa.opensuse.org/tests/1105660,https://openqa.opensuse.org/tests/1105386,https://openqa.opensuse.org/tests/1105605,https://openqa.opensuse.org/tests/1105370,https://openqa.opensuse.org/tests/1105365,https://openqa.opensuse.org/tests/1105379,https://openqa.opensuse.org/tests/1105663,https://openqa.opensuse.org/tests/1105674,https://openqa.suse.de/tests/3677094,https://openqa.suse.de/tests/3676594,https://openqa.suse.de/tests/3677102,https://openqa.suse.de/tests/3676622,https://openqa.suse.de/tests/3676628,https://openqa.suse.de/tests/3676658,https://openqa.suse.de/tests/3676702 EXCLUDE_MODULES=rails
```

* [opensuse-Tumbleweed-DVD-x86_64-Build20191206-kde-wayland@64bit_virtio](https://openqa.opensuse.org/t1105940)
* [opensuse-Tumbleweed-DVD-x86_64-Build20191206-extra_tests_on_kde@64bit](https://openqa.opensuse.org/t1105941)
* [opensuse-Tumbleweed-DVD-x86_64-Build20191206-extra_tests_in_textmode@64bit](https://openqa.opensuse.org/t1105942)
* [opensuse-Tumbleweed-DVD-x86_64-Build20191206-gnome@64bit](https://openqa.opensuse.org/t1105943)
* [opensuse-Tumbleweed-DVD-x86_64-Build20191206-textmode@64bit](https://openqa.opensuse.org/t1105944)
* [opensuse-Tumbleweed-DVD-x86_64-Build20191206-upgrade_13.1-gnome@64bit](https://openqa.opensuse.org/t1105945)
* [opensuse-Tumbleweed-DVD-x86_64-Build20191206-upgrade_Leap_42.3_cryptlvm@uefi](https://openqa.opensuse.org/t1105946)
* [opensuse-Tumbleweed-KDE-Live-x86_64-Build20191206-kde-live-wayland@64bit_virtio-3G](https://openqa.opensuse.org/t1105947)
* [sle-15-SP1-Server-DVD-Updates-x86_64-Build20191207-1-qam-minimal+base@64bit](https://openqa.suse.de/t3678042)
* [sle-12-SP4-Desktop-DVD-Updates-x86_64-Build20191207-1-qam-regression-gnome@64bit](https://openqa.suse.de/t3678041)
* [sle-15-SP1-Server-DVD-Updates-x86_64-Build20191207-1-qam-textmode+sle15@64bit](https://openqa.suse.de/t3678040)
* [sle-12-SP1-Server-DVD-Updates-x86_64-Build20191207-1-qam-textmode@64bit](https://openqa.suse.de/t3678039)
* [sle-12-SP1-Server-DVD-Updates-x86_64-Build20191207-1-mau-extratests@64bit](https://openqa.suse.de/t3678038)
* [sle-12-SP2-Server-DVD-Updates-x86_64-Build20191207-1-qam-minimal+base@64bit](https://openqa.suse.de/t3678036)
* [sle-12-SP3-Server-DVD-Updates-x86_64-Build20191207-1-qam-minimal+base@64bit](https://openqa.suse.de/t3678037)

Related progress issue: https://progress.opensuse.org/issues/48035