### PR TITLE
Fork bomb test for bsc#1031355

### DIFF
--- a/data/sles4sap/forkbomb.pl
+++ b/data/sles4sap/forkbomb.pl
@@ -1,0 +1,50 @@
+#!/usr/bin/perl
+#
+# Maintainer: Ricardo Branco <rbranco@suse.de>
+#
+# Creates an (un)specified number of child processes,
+# kills them all and patiently waits for them to die.
+#
+# Returns the number of child processes created.
+#
+# Useful to know how many processes we can create
+
+use POSIX qw(pause);
+use strict;
+use warnings;
+
+sub fork_bomb {
+    my $max  = shift;
+    my $pids = 0;
+
+    $SIG{TERM} = "DEFAULT";
+    # If explicitly ignored, wait() will wait for them all to die
+    $SIG{CHLD} = "IGNORE";
+    # Create our own process group so we can kill them all at once
+    setpgrp 0, 0;
+
+    for (my $i = 0; $i < $max || $max < 0; $i++) {
+        my $pid = fork;
+        last if !defined($pid);
+        if (!$pid) {
+            pause;
+            exit;
+        }
+        $pids++;
+    }
+
+    # Kill them all without accidentally killing ourselves...
+    $SIG{TERM} = "IGNORE";
+    kill "TERM", -getpgrp(0);
+    wait;
+
+    return $pids;
+}
+
+if ($ARGV[1]) {
+    print STDERR "Usage: $0 PROCESSES\n";
+    exit 1;
+}
+
+my $n = fork_bomb(defined($ARGV[0]) ? $ARGV[0] : -1);
+print "$n\n";

--- a/tests/sles4sap/hana_test.pm
+++ b/tests/sles4sap/hana_test.pm
@@ -28,6 +28,7 @@ sub run {
     my $instance_id = get_required_var('INSTANCE_ID');
     my $sapadm      = $self->set_sap_info($sid, $instance_id);
     $self->test_pids_max;
+    $self->test_forkbomb;
     $self->become_sapadm;
 
     # Check HDB with a database query

--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -100,6 +100,8 @@ sub run {
         zypper_call('in libopenssl1_0_0');
     }
     select_console 'x11';
+    # Hide the mouse so no needle will fail because of the mouse pointer appearing
+    mouse_hide;
 
     x11_start_program('xterm');
     turn_off_gnome_screensaver;


### PR DESCRIPTION
This PR:

- Adds a fork bomb test that must not be run on VM's.
- Adds the fork bomb test to the HANA installation (runs over IPMI).
- Fixes the test of the `nproc` limit vs. `threads-max` sysctl.
- Hides the mouse during the HANA installation wizard so no needle will fail because of the mouse pointer appearing.

- Verification run: http://ix64hae1001.qa.suse.de./tests/297
