### PR TITLE
Disable dump_btrfs_img as default to avoid disk exhaus

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -281,7 +281,7 @@ sub run {
                 copy_log($category, $num, 'out.bad');
                 copy_log($category, $num, 'full');
                 copy_log($category, $num, 'dmesg');
-                if (check_var 'XFSTESTS', 'btrfs') { dump_btrfs_img($category, $num); }
+                if (get_var('BTRFS_DUMP', 0) && (check_var 'XFSTESTS', 'btrfs')) { dump_btrfs_img($category, $num); }
             }
             next;
         }


### PR DESCRIPTION
Signed-off-by: An Long <lan@suse.com>

Disable dump_btrfs_img as default to avoid disk exhaus

- Verification run: 
http://10.67.133.10/tests/94 (enable dump_btrfs_img)
http://10.67.133.10/tests/95 (default, disable dump_btrfs_img)
