### PR TITLE
Add libzzip regression test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1594,7 +1594,8 @@ sub load_extra_tests_console {
     loadtest 'console/timezone';
     loadtest 'console/procps';
     loadtest "console/lshw" if ((is_sle('15+') && (check_var('ARCH', 'ppc64le') || check_var('ARCH', 'x86_64'))) || is_opensuse);
-    loadtest 'console/quota' unless is_jeos;
+    loadtest 'console/quota'   unless is_jeos;
+    loadtest 'console/zziplib' unless is_jeos;
 }
 
 sub load_extra_tests_docker {

--- a/tests/console/zziplib.pm
+++ b/tests/console/zziplib.pm
@@ -1,0 +1,53 @@
+# SUSE"s openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: test that uses zip command line tool to regression test.
+# If succeed, the test passes without error.
+#
+# Maintainer: Marcelo Martins <mmartins@suse.cz>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $filezip = "files.zip";
+    select_console "root-console";
+    # create a tmp dir/files to work
+    assert_script_run "mkdir /tmp/zip; cp /usr/share/doc/* /tmp/zip -R";
+    assert_script_run "cd /tmp";
+
+    # install requirements
+    zypper_call "in libzzip-0-13 zziplib-devel zip";
+
+    # create a zip file
+    assert_script_run "zip -9 $filezip -xi zip/*";
+    # Use unzip-mem on zip file to list archived files (-l)
+    assert_script_run "unzip-mem -l $filezip";
+
+    # Use unzip-mem on zip file to get a verbose list archived files (-v)
+    # Option -v  creates a core dump(bsc#1129403), create a soft-failure
+    my $RETURN_CODE = script_run("unzip-mem -v $filezip");
+    if (($RETURN_CODE) eq "0") {
+        assert_script_run("unzip-mem -v $filezip");
+    } else {
+        record_soft_failure "bsc#1129403 - Option -v creates a core dump";
+        save_screenshot;
+    }
+    # Use unzip-mem on zip file to list archived files (-t)
+    assert_script_run "unzip-mem -t $filezip";
+    # Use unzip on archive to extract the files
+    assert_script_run "unzzip $filezip";
+    #Clean files used:
+    assert_script_run "cd ; rm -rf /tmp/zip ; rm /tmp/$filezip";
+}
+
+1;


### PR DESCRIPTION
This script fixes poo#49082 - [qam] Regression test zziplib
Create regression test for zziplib:
- create compressed file(backup of any directory) by zip command
- use unzip-mem with options -l, -v, -t

Expected result:
Simple scenario for zziplib is created.

Related ticket: https://progress.opensuse.org/issues/49082
Verification run:
SLES 12 SP4 - http://10.161.229.197/tests/261#step/zziplib/1
SLES 12 SP3 - http://10.161.229.197/tests/265#step/zziplib/1
SLES 15 - http://10.161.229.197/tests/264#step/zziplib/1
Opensuse Leap 15 - http://10.161.229.197/tests/262#step/zziplib/1