### PR TITLE
Increase timeout value for snapper list

### DIFF
--- a/tests/console/upgrade_snapshots.pm
+++ b/tests/console/upgrade_snapshots.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,14 +22,15 @@ use utils;
 sub run {
     select_console 'root-console';
 
+    my $waittime = 80 * get_var('TIMEOUT_SCALE', 1);
     script_run("snapper list | tee /dev/$serialdev", 0);
     # Check if the snapshot called 'before update' is there
-    wait_serial('pre\s*(\|[^|]*){4,}\s*\|\s*number\s*\|\s*before (update|online migration)\s*\|\s*important=yes', 40)
+    wait_serial('pre\s*(\|[^|]*){4,}\s*\|\s*number\s*\|\s*before (update|online migration)\s*\|\s*important=yes', $waittime)
       || die 'upgrade snapshots test failed';
 
     script_run("snapper list | tee /dev/$serialdev", 0);
     # Check if the snapshot called 'after update' is there
-    wait_serial('post\s*(\|[^|]*){4,}\s*\|\s*number\s*\|\s*after (update|online migration)\s*\|\s*important=yes', 40)
+    wait_serial('post\s*(\|[^|]*){4,}\s*\|\s*number\s*\|\s*after (update|online migration)\s*\|\s*important=yes', $waittime)
       || die 'upgrade snapshots test failed';
 }
 


### PR DESCRIPTION
The timeout value 40s is not enough for 'snapper list' on slow machines, increase it to 80s and multiple TIMEOUT_SCALE to enable debug it on o.s.d. 

- Related ticket: https://progress.opensuse.org/issues/45119
- Needles: N/A
- Verification run: http://openqa-apac1.suse.de/tests/3607#step/upgrade_snapshots/2
