### PR TITLE
select_patterns_and_packages: moved to the end then top to instead of down/up

### DIFF
--- a/tests/installation/select_patterns_and_packages.pm
+++ b/tests/installation/select_patterns_and_packages.pm
@@ -46,6 +46,11 @@ sub move_down {
     check12qtbug if check_var('VERSION', '12');
 }
 
+sub move_end_and_top {
+    wait_screen_change { send_key 'end' };
+    wait_screen_change { send_key 'home' };
+}
+
 sub gotopatterns {
     my ($self) = @_;
     $self->deal_with_dependency_issues;
@@ -68,9 +73,8 @@ sub gotopatterns {
     else {
         send_key 'tab';
     }
-    # pressing up and down to have selection more visible
-    wait_screen_change { send_key 'down' };
-    wait_screen_change { send_key 'up' };
+    # pressing end and home to have selection more visible, and the scrollbar length is re-caculated
+    move_end_and_top;
     assert_screen 'patterns-list-selected';
 }
 


### PR DESCRIPTION
send 'end' and 'home' to instead of 'down' and 'up', still keeping the selector more visible, and this approach will trigger scrollbar re-caculation that avoiding pattern-too-low situation happens - amount
of patterns or incorrect scrollbar behavior on branding settings.

- Fail run: https://openqa.opensuse.org/tests/884317#step/select_patterns_and_packages/62
- Verification run: http://10.163.9.11/tests/41
