### PR TITLE
Fix sporadic issue with closing Tip of Day (gnucash)

### DIFF
--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -23,7 +23,7 @@ sub run {
     ensure_installed('gnucash gnucash-docs yelp');
     x11_start_program('gnucash', target_match => [qw(gnucash gnucash-tip-close gnucash-assistant-close)]);
     if (match_has_tag('gnucash-tip-close')) {
-        assert_and_click 'gnucash-tip-close';
+        send_key 'esc';
         assert_screen([qw(gnucash gnucash-assistant-close)]);
     }
     if (match_has_tag('gnucash-assistant-close')) {


### PR DESCRIPTION
assert_and_click doesn't work sometimes because needle has 2 areas.
Since we just need to close dialogue 'Tip of Day', replace
assert_and_click by send_key 'esc'.

verification test runs:
http://f40.suse.de/tests/2332#next_previous
see https://progress.opensuse.org/issues/49355
