### PR TITLE
[AARCH64 Automation] Install SLE-12-SP4 KVM role on arm64

### DIFF
--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -50,6 +50,7 @@ sub install_package {
         $dependency_repo = 'http://download.suse.de/ibs/SUSE:/SLE-15:/GA/standard/';
         $dependency_rpms = 'bridge-utils';
     }
+
     if ($dependency_repo) {
         if (check_var('ARCH', 's390x')) {
             lpar_cmd("zypper --non-interactive --no-gpg-check ar -f ${dependency_repo} dependency_repo");
@@ -63,6 +64,12 @@ sub install_package {
             assert_script_run("zypper --non-interactive in $dependency_rpms");
             assert_script_run("zypper --non-interactive rr dependency_repo");
         }
+    }
+
+    ###SLE-12-SP4 arm64 installation has no KVM role selection
+    if (($repo_0_to_install =~ /SLE-12-SP4/m) && check_var('ARCH', 'aarch64')) {
+        assert_script_run("zypper --non-interactive --gpg-auto-import-keys ref",         180);
+        assert_script_run("zypper --non-interactive in -t pattern kvm_server kvm_tools", 300);
     }
 
     #install qa_lib_virtauto


### PR DESCRIPTION
SLE-12-SP4 ARM64 installation does not provide virtualization role selection. Install KVM server and tools by using zypper install and pattern.

- Related ticket: aarch64 automation
- Needles: n/a
- Verification run: http://10.162.187.154/tests/1391 
                            http://10.162.187.154/tests/1399
                            http://10.162.187.154/tests/1411
                            http://10.162.187.154/tests/1418

@alice-suse @guoxuguang @Julie-CAO 