### PR TITLE
Fix kernel version comparison for kdump

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -14,7 +14,6 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use List::Util 'maxstr';
 use version_utils qw(is_sle is_jeos);
 
 our @EXPORT = qw(install_kernel_debuginfo prepare_for_kdump activate_kdump activate_kdump_without_yast kdump_is_active do_kdump);
@@ -22,9 +21,7 @@ our @EXPORT = qw(install_kernel_debuginfo prepare_for_kdump activate_kdump activ
 sub install_kernel_debuginfo {
     assert_script_run 'zypper ref', 300;
     my $kernel    = is_jeos() ? 'kernel-default-base' : 'kernel-default';
-    my @kernels   = split(/\n/, script_output('rpmquery --queryformat="%{NAME}-%{VERSION}-%{RELEASE}\n" ' . $kernel));
-    my ($uname)   = script_output('uname -r') =~ /(\d+\.\d+\.\d+)-*/;
-    my $debuginfo = maxstr grep { $_ =~ /\Q$uname\E/ } @kernels;
+    my $debuginfo = script_output('rpmquery --queryformat="%{NAME}-%{VERSION}-%{RELEASE}\n" ' . $kernel . '| sort --version-sort | tail -n 1');
     $debuginfo =~ s/$kernel/kernel-default-debuginfo/g;
     zypper_call("-v in $debuginfo", timeout => 4000);
 }


### PR DESCRIPTION
Fix poo#49448: Kernel version comparison based on maxstr doesn't work
properly and incorrect kernel debuginfo is installed. Latest kernel
version is implemented by `sort --version-sort`.

- Related ticket: https://progress.opensuse.org/issues/49448
- Needles:none
- Verification run: 
12-SP1: http://10.100.12.105/tests/1702
12-SP3: http://10.100.12.105/tests/1705
15: http://10.100.12.105/tests/1701 <- was originally failing
15-SP1: http://10.100.12.105/tests/1703
15-SP1-JeOS: https://openqa.suse.de/tests/2575612#  failing due to other known issue (discussed with @ccret )