### PR TITLE
Add new yast lan cli test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1415,6 +1415,10 @@ sub load_extra_tests_y2uitest_gui {
     loadtest "yast2_gui/yast2_users";
 }
 
+sub load_extra_tests_y2uitest_cmd {
+    loadtest 'yast2_cmd/yast_lan';
+}
+
 sub load_extra_tests_openqa_bootstrap {
     if (get_var 'BOOTSTRAP_CONTAINER') {
         loadtest 'openqa/install/openqa_bootstrap_container';

--- a/tests/yast2_cmd/yast_lan.pm
+++ b/tests/yast2_cmd/yast_lan.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: yast lan in cli, creates, edits and deletes device and lists and
+# shows details of the device
+# Maintainer: Vit Pelcak <vpelcak@suse.cz>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    select_console 'root-console';
+    zypper_call "in yast2-network";
+    validate_script_output 'yast lan add name=vlan50 ethdevice=eth0 2>&1', sub { m/Virtual/ };
+    validate_script_output 'yast lan show id=1 2>&1',                      sub { m/vlan50/ };
+    validate_script_output 'yast lan edit id=1 bootproto=dhcp 2>&1',       sub { m/IP address assigned using DHCP/ }, 60;
+    validate_script_output 'yast lan delete id=1 2>&1',                    sub { m/deleted/ };
+    validate_script_output 'yast lan list 2>&1',                           sub { !m/Virtual/ };
+}
+1;


### PR DESCRIPTION
New test poo#49250: tests add, edit, delete, list and status of network
interfaces.

- Related ticket: https://progress.opensuse.org/issues/49250
- Needles: none
- Verification run: http://deva.suse.cz/tests/35
