### PR TITLE
Detect systemd target in installation_overview

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -69,6 +69,15 @@ sub run {
         $self->deal_with_dependency_issues;
         assert_screen "inst-xen-pattern" if get_var('XEN');
         ensure_ssh_unblocked;
+        # Check the systemd target, see poo#45020
+        return if (is_caasp || check_var('MACHINE', 'svirt-hyperv'));
+        if (get_var('DESKTOP')) {
+            my $target = check_var('DESKTOP', 'textmode') ? "multi-user" : "graphical";
+            select_console 'install-shell';
+            # The default.target is not yet linked, so we have to parse the logs.
+            assert_script_run("grep 'target has been set' /var/log/YaST2/y2log |tail -1 |grep \"$target\"", fail_message => "Wrong systemd target detected, aborting");
+            select_console 'installation';
+        }
     }
 }
 


### PR DESCRIPTION
We want to verify if the right systemd target is activated at the earliest possible stage.

    Related ticket: https://progress.opensuse.org/issues/45020
    Needles: os-autoinst/os-autoinst-needles-opensuse#527
    Verification run:
    http://amazing.suse.cz/tests/3958 (graphical, sle12sp5)
    http://amazing.suse.cz/tests/3957 (text, sle15sp1)
    http://amazing.suse.cz/tests/3956 (graphical xfce, tumbleweed)
    
    Also tested on some exotic production cases
    https://openqa.suse.de/tests/2537187 (text, xen)
    https://openqa.suse.de/tests/2537189 (graphical)
    https://openqa.suse.de/tests/2537188 (graphical, IPMI)
    https://openqa.suse.de/tests/2558476 (graphical, s390x-kvm-sle12)
    https://openqa.suse.de/tests/2562376 (texmode, s390x-zVM-ctc)
    https://openqa.suse.de/tests/2565581 (excluded for hyperv)

More tests done 
http://amazing.suse.cz/tests/overview?distri=opensuse&version=15.1&build=433.1
http://amazing.suse.cz/tests/overview?distri=kubic&distri=opensuse&version=Tumbleweed&build=20190319&groupid=1 (all passed installation_overview)
https://openqa.opensuse.org/tests/886242 (Kubic, excluded)

### and more needles:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/534