### PR TITLE
Boot with kernel/initrd from repository if needed

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -518,11 +518,6 @@ sub bootmenu_network_source {
             }
         }
     }
-
-    if (check_var("LINUXRC_KEXEC", "1")) {
-        type_string_slow " kexec=1";
-        record_soft_failure "boo#990374 - pass kexec to installer to use initrd from FTP";
-    }
 }
 
 sub autoyast_boot_params {
@@ -594,9 +589,9 @@ sub specific_bootmenu_params {
         $args .= " fips=1";
     }
 
-    if (check_var("LINUXRC_KEXEC", "1")) {
-        $args .= " kexec=1";
-        record_soft_failure "boo#990374 - pass kexec to installer to use initrd from FTP";
+    if (my $kexec_value = get_var("LINUXRC_KEXEC")) {
+        $args .= " kexec=$kexec_value";
+        record_info('Info', 'boo#990374 - pass kexec to installer to use initrd from FTP');
     }
 
     if (get_var("DUD")) {

--- a/variables.md
+++ b/variables.md
@@ -59,6 +59,7 @@ ISO_MAXSIZE | integer | | Max size of the iso, used in `installation/isosize.pm`
 KEEP_ONLINE_REPOS | boolean | false | openSUSE specific variable, not to replace original repos in the installed system with snapshot mirrors which are not yet published.
 LAPTOP |||
 LINUX_BOOT_IPV6_DISABLE | boolean | false | If set, boots linux kernel with option named "ipv6.disable=1" which disables IPv6 from startup.
+LINUXRC_KEXEC | integer | | linuxrc has the capability to download and run a new kernel and initrd pair from the repository.<br> There are four settings for the kexec option:<br> 0: feature disabled;<br> 1: always restart with kernel/initrd from repository (without bothering to check if it's necessary);<br>2: restart only if needed - that is, if linuxrc detects that the booted initrd is outdated (this is the default);<br>3: like kexec=2 but without user interaction.<br> *More details [here](https://en.opensuse.org/SDB:Linuxrc)*. 
 LIVECD | boolean | false | Indicates live image being used.
 LIVE_INSTALLATION | boolean | false | If set, boots the live media and starts the builtin NET installer.
 LIVE_UPGRADE | boolean | false | If set, boots the live media and starts the builtin NET installer in upgrade mode.


### PR DESCRIPTION
The commit removes soft-fail for boo#990374 and turns it into
record_info to just highlight entering kexec=3 parameter to bootloader.

The parameter is entered for the test, that is using LATEST TW snapshot
NET installer (to be tested, not yet published) and installs the
'previous' (currently published TW snapshot).

kexec=3 means that if linuxrc detects that the booted inird is outdated,
kernel/initrd will be downloaded from the repository without showing
a user the dialog asking for confirmation before the download.

Please, see the documentation for linuxrc and kexec usage
[here](https://en.opensuse.org/SDB:Linuxrc)

- Related ticket: https://progress.opensuse.org/issues/46727
- Verification run: http://oorlov-vm.qa.suse.de/tests/789#step/bootloader/9
