### PR TITLE
Extend rt validation test

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1013,46 +1013,29 @@ else {
         }
     }
     elsif (get_var("BOOT_HDD_IMAGE") && !is_jeos) {
-        if (get_var("RT_TESTS")) {
-            loadtest "rt/boot_rt_kernel";
-            loadtest "console/prepare_test_data";
-            loadtest "console/consoletest_setup";
-            loadtest "console/hostname";
-            loadtest "console/zypper_ref";
-            loadtest "console/zypper_lr";
-            loadtest "console/system_prepare";
-            loadtest "rt/rt_is_realtime";
-            loadtest "rt/rt_devel_packages";
-            loadtest "rt/rt_peak_pci";
-            loadtest "rt/rt_tests";
-            loadtest "rt/kmp_modules";
-            set_var('INSTALLONLY', 1);
+        load_bootloader_s390x();
+        loadtest "boot/boot_to_desktop";
+        if (get_var("ADDONS")) {
+            loadtest "installation/addon_products_yast2";
         }
-        else {
-            load_bootloader_s390x();
-            loadtest "boot/boot_to_desktop";
-            if (get_var("ADDONS")) {
-                loadtest "installation/addon_products_yast2";
-            }
-            if (get_var('SCC_ADDONS') && !get_var('SLENKINS_NODE')) {
-                loadtest "installation/addon_products_via_SCC_yast2";
-            }
-            if (get_var("ISCSI_SERVER")) {
-                set_var('INSTALLONLY', 1);
-                loadtest "iscsi/iscsi_server";
-            }
-            if (get_var("ISCSI_CLIENT")) {
-                set_var('INSTALLONLY', 1);
-                loadtest "iscsi/iscsi_client";
-            }
-            if (get_var("NIS_SERVER")) {
-                set_var('INSTALLONLY', 1);
-                loadtest "x11/nis_server";
-            }
-            if (get_var("NIS_CLIENT")) {
-                set_var('INSTALLONLY', 1);
-                loadtest "x11/nis_client";
-            }
+        if (get_var('SCC_ADDONS') && !get_var('SLENKINS_NODE')) {
+            loadtest "installation/addon_products_via_SCC_yast2";
+        }
+        if (get_var("ISCSI_SERVER")) {
+            set_var('INSTALLONLY', 1);
+            loadtest "iscsi/iscsi_server";
+        }
+        if (get_var("ISCSI_CLIENT")) {
+            set_var('INSTALLONLY', 1);
+            loadtest "iscsi/iscsi_client";
+        }
+        if (get_var("NIS_SERVER")) {
+            set_var('INSTALLONLY', 1);
+            loadtest "x11/nis_server";
+        }
+        if (get_var("NIS_CLIENT")) {
+            set_var('INSTALLONLY', 1);
+            loadtest "x11/nis_client";
         }
     }
     elsif (get_var("REMOTE_TARGET")) {

--- a/schedule/rt-validation_extra_tests.yaml
+++ b/schedule/rt-validation_extra_tests.yaml
@@ -1,0 +1,37 @@
+name:           rt-validation_extra_tests
+description:    >
+    Validation tests for RT product	
+schedule:
+    - rt/boot_rt_kernel
+    - console/prepare_test_data
+    - console/consoletest_setup
+    - console/system_prepare
+    - console/hostname
+    - console/zypper_lr
+    - console/zypper_ref
+    - rt/rt_is_realtime
+    - rt/rt_devel_packages
+    - rt/rt_peak_pci
+    - rt/rt_tests 
+    - rt/kmp_modules
+    - console/aplay
+    - console/glibc_sanity
+    - console/firewall_enabled
+    - console/gpt_ptable
+    - console/gpg
+    - console/journalctl
+    - console/rsync 
+    - console/http_srv
+    - console/sysctl
+    - console/sysstat
+    - console/cron
+    - console/yast2_lan
+    - console/yast2_i
+    - toolchain/gcc_compilation
+    - console/consoletest_finish
+    - x11/firefox 
+    - x11/yast2_snapper
+    - yast2_gui/yast2_hostnames 
+    - yast2_gui/yast2_firewall
+    - shutdown/cleanup_before_shutdown
+    - shutdown/shutdown

--- a/tests/console/aplay.pm
+++ b/tests/console/aplay.pm
@@ -14,10 +14,12 @@ use base "consoletest";
 use testapi;
 use strict;
 use warnings;
+use utils 'ensure_serialdev_permissions';
 
 sub run {
     my $self = shift;
     select_console 'root-console';
+    ensure_serialdev_permissions;
 
     my $script = <<EOS;
 

--- a/tests/rt/boot_rt_kernel.pm
+++ b/tests/rt/boot_rt_kernel.pm
@@ -14,13 +14,15 @@ use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
-use utils;
 use bootloader_setup 'boot_grub_item';
+use x11utils 'handle_login';
 
 sub run() {
     my $self = shift;
     $self->boot_grub_item(2, 3);
-    $self->wait_boot(bootloader_time => 120);
+    assert_screen 'displaymanager', 60;
+    handle_login;
+    assert_screen 'generic-desktop';
 }
 
 1;

--- a/tests/rt/kmp_modules.pm
+++ b/tests/rt/kmp_modules.pm
@@ -73,11 +73,9 @@ sub run {
         assert_script_run 'modprobe -v ' . $basename . ' 2>&1 | tee -a /var/log/modprobe.out';
         assert_script_run "modinfo $basename";
         save_screenshot;
-        clear_console;
     }
     lttng_test;
-    type_string "exit\n";
-    reset_consoles;
+    clear_console;
 }
 
 sub post_fail_hook {

--- a/tests/rt/rt_tests.pm
+++ b/tests/rt/rt_tests.pm
@@ -21,7 +21,7 @@ use utils 'zypper_call';
 
 sub run {
     zypper_call("in rt-tests ibmrtpkgs", log => 'rt_tests_zypper.log');
-    assert_script_run "cyclictest -a -n -t -p 99 -l 100 -v";
+    assert_script_run "cyclictest -a -t -p 99 -l 100 -v";
     assert_script_run "hackbench -l 100";
 }
 


### PR DESCRIPTION
- Related ticket: [[sle][functional][y][rt] extend test coverage of RT installation](https://progress.opensuse.org/issues/45152) && [[functional][y][sporadic][investigation] test fails in boot_rt_kernel, waiting for grub2 needle, however system is already booted](https://progress.opensuse.org/issues/49145)
- Verification runs: 
   * [sle-15-SP1-Installer-DVD-x86_64-Build190.3-rt-validation_extra_tests@64bit](http://eris.suse.cz/tests/12741)
   * [sle-15-SP1-Installer-DVD-x86_64-Build190.3-rt-validation_extra_tests@64bit](http://eris.suse.cz/tests/12743)
   * [sle-15-SP1-Installer-DVD-x86_64-Build190.3-rt-validation_extra_tests@64bit](http://eris.suse.cz/tests/12742)
   * [sle-15-SP1-Installer-DVD-x86_64-Build190.3-rt-validation_extra_tests@64bit](http://eris.suse.cz/tests/12744)
   * [sle-15-SP1-Installer-DVD-x86_64-Build190.3-rt-validation_extra_tests@64bit](http://eris.suse.cz/tests/12745)

Due to stability issues, I have excluded *sshd, kdump_and_crash, yast2_bootloader* for now

Note: After merging this PR, *RT_TESTS* openQA variable should be removed from *rt-validation_extra_tests* test suite