### PR TITLE
Clean .ssh/known_hosts after openssh_fips test commands

### DIFF
--- a/tests/fips/openssh/openssh_fips.pm
+++ b/tests/fips/openssh/openssh_fips.pm
@@ -41,6 +41,11 @@ sub run {
 
     # Verify ssh doesn't support DSA public key in fips mode
     validate_script_output 'ssh-keygen -t dsa -f ~/.ssh/id_dsa -P "" 2>&1 || true', sub { m/Key type dsa not alowed in FIPS mode/ };
+
+    # Although there is StrictHostKeyChecking=no option, but the fingerprint
+    # for localhost was still added into ~/.ssh/known_hosts, which potentially
+    # lead to other cases failed. So remove it.
+    assert_script_run "rm -r ~/.ssh/";
 }
 
 1;


### PR DESCRIPTION
The fingerprint of localhost machine in .ssh/known_hosts will make other cases failed potentally. So we remove it with whole .ssh directory.

- Related ticket: https://progress.opensuse.org/issues/49532
- Verification run:
  - Clean in openssh_fips: http://10.67.17.9/tests/801#step/openssh_fips/26
  - Following sshd cases: http://10.67.17.9/tests/801#step/sshd/28
