### PR TITLE
Increase bootloader timeout to fix sporadic issue with gnome_reboot

### DIFF
--- a/tests/x11/reboot_gnome.pm
+++ b/tests/x11/reboot_gnome.pm
@@ -16,6 +16,7 @@ use strict;
 use warnings;
 use testapi;
 use power_action_utils 'power_action';
+use utils 'is_boot_encrypted';
 
 sub run {
     my ($self) = @_;
@@ -25,7 +26,8 @@ sub run {
     # In 88388900d2dfe267230972c6905b3cc18fb288cf the wait timeout was
     # bumped, due to tianocore being a bit slower, this brings this module
     # in sync
-    my $bootloader_timeout = check_var('ARCH', 'aarch64') ? 400 : 300;
+    my $bootloader_timeout = (is_boot_encrypted || check_var('ARCH', 'aarch64')) ? 400 : 300;
+
     $self->wait_boot(bootloader_time => $bootloader_timeout);
 }
 


### PR DESCRIPTION
we have 1 or 2 failure for 100 test runs at moment. To make reboot
gnome from encrpted partition more stable, we need to increase
bootloader timeout to 400 as we already did for aarch64.

verification test runs more than 200:
http://f40.suse.de/tests/2807#next_previous
see https://progress.opensuse.org/issues/43676