### PR TITLE
Minor changes for QAM virtualization

### DIFF
--- a/lib/virtmanager.pm
+++ b/lib/virtmanager.pm
@@ -638,7 +638,7 @@ sub close_guest {
 }
 
 sub establish_connection {
-    my $hypervisor = get_required_var('HYPERVISOR');
+    my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
     assert_screen ['virt-manager_connected', 'virt-manager_not-connected', 'virt-manager_add-connection'], 30;
     if (match_has_tag 'virt-manager_add-connection') {

--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -105,7 +105,7 @@ sub login_to_console {
     save_screenshot;
     send_key 'ret';
 
-    send_key_until_needlematch(['linux-login', 'virttest-displaymanager'], 'ret', $timeout / 5, 5);
+    send_key_until_needlematch(['linux-login', 'virttest-displaymanager'], 'ret', $timeout, 5);
     #use console based on ssh to avoid unstable ipmi
     save_screenshot;
     use_ssh_serial_console;

--- a/tests/virtualization/xen/dom_install.pm
+++ b/tests/virtualization/xen/dom_install.pm
@@ -26,7 +26,7 @@ use utils;
 sub run {
     select_console 'root-console';
     opensusebasetest::select_serial_terminal();
-    my $hypervisor = get_required_var('HYPERVISOR');
+    my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
     zypper_call '-t in vhostmd';
 

--- a/tests/virtualization/xen/dom_metrics.pm
+++ b/tests/virtualization/xen/dom_metrics.pm
@@ -24,7 +24,7 @@ use testapi;
 use utils;
 
 sub run {
-    my $hypervisor = get_required_var('HYPERVISOR');
+    my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
     assert_script_run 'vhostmd';
 

--- a/tests/virtualization/xen/guest_management.pm
+++ b/tests/virtualization/xen/guest_management.pm
@@ -18,7 +18,7 @@ use testapi;
 use utils;
 
 sub run {
-    my $hypervisor = get_required_var('HYPERVISOR');
+    my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
     record_info "REBOOT", "Reboot all guests";
     foreach my $guest (keys %xen::guests) {

--- a/tests/virtualization/xen/hotplugging.pm
+++ b/tests/virtualization/xen/hotplugging.pm
@@ -19,7 +19,7 @@ use utils;
 
 sub run {
     my ($self) = @_;
-    my $hypervisor = get_required_var('HYPERVISOR');
+    my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
     # TODO:
     record_info "Disk", "Adding another raw disk";

--- a/tests/virtualization/xen/save_and_restore.pm
+++ b/tests/virtualization/xen/save_and_restore.pm
@@ -18,7 +18,7 @@ use testapi;
 use utils;
 
 sub run {
-    my $hypervisor = get_required_var('HYPERVISOR');
+    my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
     assert_script_run "mkdir -p /var/lib/libvirt/images/saves/";
 

--- a/tests/virtualization/xen/ssh_final.pm
+++ b/tests/virtualization/xen/ssh_final.pm
@@ -25,7 +25,7 @@ use testapi;
 use utils;
 
 sub run {
-    my $hypervisor = get_required_var('HYPERVISOR');
+    my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
     foreach my $guest (keys %xen::guests) {
         record_info "$guest", "Establishing SSH connection to $guest";

--- a/tests/virtualization/xen/ssh_guests.pm
+++ b/tests/virtualization/xen/ssh_guests.pm
@@ -25,7 +25,7 @@ use utils;
 
 sub run {
     my ($self) = @_;
-    my $hypervisor = get_required_var('HYPERVISOR');
+    my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
     foreach my $guest (keys %xen::guests) {
         record_info "$guest", "Establishing SSH connection to $guest";

--- a/tests/virtualization/xen/ssh_guests_init.pm
+++ b/tests/virtualization/xen/ssh_guests_init.pm
@@ -24,7 +24,7 @@ use testapi;
 use utils;
 
 sub run {
-    my $hypervisor = get_required_var('HYPERVISOR');
+    my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
     foreach my $guest (keys %xen::guests) {
         record_info "$guest", "Establishing SSH connection to $guest";

--- a/tests/virtualization/xen/ssh_hypervisor.pm
+++ b/tests/virtualization/xen/ssh_hypervisor.pm
@@ -25,7 +25,7 @@ use utils;
 
 sub run {
     my ($self) = @_;
-    my $hypervisor = get_required_var('HYPERVISOR');
+    my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
     # Remove old files
     assert_script_run 'rm ~/.ssh/* || true';

--- a/tests/virtualization/xen/virsh_start.pm
+++ b/tests/virtualization/xen/virsh_start.pm
@@ -24,7 +24,7 @@ use testapi;
 use utils;
 
 sub run {
-    my $hypervisor = get_required_var('HYPERVISOR');
+    my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
     assert_script_run("virsh start $_", 120) foreach (keys %xen::guests);
     script_retry "ssh root\@$_ hostname -f", delay => 15, retry => 12 foreach (keys %xen::guests);

--- a/tests/virtualization/xen/virsh_stop.pm
+++ b/tests/virtualization/xen/virsh_stop.pm
@@ -24,7 +24,7 @@ use testapi;
 use utils;
 
 sub run {
-    my $hypervisor = get_required_var('HYPERVISOR');
+    my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
     # TODO:
     script_run "ssh root\@$_ poweroff" foreach (keys %xen::guests);

--- a/tests/virtualization/xen/virtmanager_init.pm
+++ b/tests/virtualization/xen/virtmanager_init.pm
@@ -26,7 +26,7 @@ use virtmanager;
 
 sub run {
     my ($self) = @_;
-    my $hypervisor = get_required_var('HYPERVISOR');
+    my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
     #x11_start_program 'virt-manager';
     type_string "virt-manager\n";

--- a/tests/virtualization/xen/xl_create.pm
+++ b/tests/virtualization/xen/xl_create.pm
@@ -24,7 +24,7 @@ use testapi;
 use utils;
 
 sub run {
-    my $hypervisor = get_required_var('HYPERVISOR');
+    my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
     record_info "XML", "Export the XML from virsh and convert it into Xen config file";
     assert_script_run "virsh dumpxml $_ > $_.xml"                         foreach (keys %xen::guests);

--- a/tests/virtualization/xen/xl_stop.pm
+++ b/tests/virtualization/xen/xl_stop.pm
@@ -24,7 +24,7 @@ use testapi;
 use utils;
 
 sub run {
-    my $hypervisor = get_required_var('HYPERVISOR');
+    my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
     foreach my $guest (keys %xen::guests) {
         record_info "$guest",                         "Stopping xl-$guest guests";


### PR DESCRIPTION
Those changes are fixing minor bugs which appeared on openqa.qam.suse.cz - there's one timeout, default value for `HYPERVISOR` variable and needles.

- Related ticket: [poo#40610](https://progress.opensuse.org/issues/40610) [poo#43739](https://progress.opensuse.org/issues/43739)
- Needles: [os-autoinst-needles-sles#1101](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1101)
