### PR TITLE
publiccloud: Add tags to CSP resources.

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -32,6 +32,12 @@ resource "random_id" "service" {
 resource "azurerm_resource_group" "openqa-group" {
     name     = "openqa-${random_id.service.hex}"
     location = "${var.region}"
+
+    tags = {
+        openqa_created_by = "${var.name}"
+        openqa_created_date = "${timestamp()}"
+        openqa_created_id = "${random_id.service.hex}"
+    }
 }
 
 resource "azurerm_virtual_network" "openqa-network" {
@@ -129,6 +135,12 @@ resource "azurerm_virtual_machine" "openqa-vm" {
             path     = "/home/azureuser/.ssh/authorized_keys"
             key_data = "${file("/root/.ssh/id_rsa.pub")}"
         }
+    }
+
+    tags = {
+        openqa_created_by = "${var.name}"
+        openqa_created_date = "${timestamp()}"
+        openqa_created_id = "${element(random_id.service.*.hex, count.index)}"
     }
 }
 

--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -46,6 +46,12 @@ resource "aws_security_group" "basic_sg" {
         protocol        = "-1"
         cidr_blocks     = ["0.0.0.0/0"]
     }
+
+    tags = {
+        openqa_created_by = "${var.name}"
+        openqa_created_date = "${timestamp()}"
+        openqa_created_id = "${random_id.service.hex}"
+    }
 }
 
 resource "aws_instance" "openqa" {
@@ -54,6 +60,12 @@ resource "aws_instance" "openqa" {
     instance_type   = "${var.type}"
     key_name        = "${aws_key_pair.openqa-keypair.key_name}"
     security_groups = ["${aws_security_group.basic_sg.name}"]
+
+    tags = {
+        openqa_created_by = "${var.name}"
+        openqa_created_date = "${timestamp()}"
+        openqa_created_id = "${element(random_id.service.*.hex, count.index)}"
+    }
 }
 
 output "public_ip" {

--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -49,6 +49,9 @@ resource "google_compute_instance" "openqa" {
 
     metadata {
         sshKeys = "susetest:${file("/root/.ssh/id_rsa.pub")}"
+        openqa_created_by = "${var.name}"
+        openqa_created_date = "${timestamp()}"
+        openqa_created_id = "${element(random_id.service.*.hex, count.index)}"
     }
 
     network_interface {
@@ -56,6 +59,7 @@ resource "google_compute_instance" "openqa" {
             access_config {
         }
     }
+
 }
 
 output "public_ip" {

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -263,18 +263,19 @@ sub terraform_apply {
     my $instance_type        = get_var('PUBLIC_CLOUD_INSTANCE_TYPE');
     my $image                = $self->get_image_id();
     my $ssh_private_key_file = '/root/.ssh/id_rsa';
+    my $name                 = get_var('PUBLIC_CLOUD_RESOURCE_NAME', 'openqa-vm');
 
     record_info('WARNING', 'Terraform apply has been run previously.') if ($self->terraform_applied);
 
     assert_script_run('cd ' . TERRAFORM_DIR);
     record_info('INFO', "Creating instance $instance_type from $image ...");
-    assert_script_run('terraform init', TERRAFORM_TIMEOUT);
+    assert_script_run('terraform init -no-color', TERRAFORM_TIMEOUT);
 
-    my $cmd = sprintf("terraform plan -var 'image_id=%s' -var 'count=%s' -var 'type=%s' -var 'region=%s' -out myplan",
-        $image, $args{count}, $instance_type, $self->region);
+    my $cmd = sprintf("terraform plan -no-color -var 'image_id=%s' -var 'count=%s' -var 'type=%s' -var 'region=%s' -var 'name=%s' -out myplan",
+        $image, $args{count}, $instance_type, $self->region, $name);
 
     assert_script_run($cmd);
-    my $ret = script_run('terraform apply myplan', TERRAFORM_TIMEOUT);
+    my $ret = script_run('terraform apply -no-color myplan', TERRAFORM_TIMEOUT);
     unless (defined $ret) {
         type_string(qq(\c\\));        # Send QUIT signal
         assert_script_run('true');    # make sure we have a prompt
@@ -316,7 +317,7 @@ sub terraform_destroy {
     my ($self) = @_;
     record_info('INFO', 'Removing terraform plan...');
     assert_script_run('cd ' . TERRAFORM_DIR);
-    script_run('terraform destroy -auto-approve', TERRAFORM_TIMEOUT);
+    script_run('terraform destroy -no-color -auto-approve', TERRAFORM_TIMEOUT);
 }
 
 =head2 vault_login


### PR DESCRIPTION
Add created_by, created_date, created_id, tags to resources on CSP.
This makes identify of left overs more easy.

created_by use the terraform variable 'name', which can be set via
`PUBLIC_CLOUD_RESOURCE_NAME`.

- Related ticket: https://progress.opensuse.org/issues/45752
- Verification run: http://cfconrad-vm.qa.suse.de/tests/3737 (GCE)
- Verification run: http://cfconrad-vm.qa.suse.de/tests/3735 (Azure)
- Verification run: http://cfconrad-vm.qa.suse.de/tests/3733 (aws)

The job 3737 and 3735 fail, but the reason is something different as `terraform apply` works. 

@jlausuch @asmorodskyi 
