### PR TITLE
Sync the cached filesystem and solve the timeout issue

### DIFF
--- a/tests/console/validate_lvm_encrypt.pm
+++ b/tests/console/validate_lvm_encrypt.pm
@@ -76,7 +76,9 @@ sub run {
     assert_script_run 'df -h  | tee original_usage';
     assert_script_run "dd if=/dev/zero of=$test_file count=1024 bs=1M";
     assert_script_run "ls -lah $test_file";
-    script_retry "diff <(cat original_usage) <(df -h)", delay => 3, retry => 5, expect => 1;
+    if ((script_run "sync && diff <(cat original_usage) <(df -h)") != 1) {
+        die "LVM usage stats do not differ!";
+    }
 
     record_info('INFO', 'Check partitions');
     if (get_var('NAME') =~ m/separate/) {


### PR DESCRIPTION
This is a follow up patch for https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6853.
Using sync to update the storage is more efficient than the use of script_retry as the timeouts might be random. calling sync explicitly the storage is asked to get update immediately and the checks can occur staight away.

- Related ticket: https://progress.opensuse.org/issues/42941
- Needles: N/A
- Verification run: http://dhcp131.suse.cz/tests/492#step/validate_lvm_encrypt/129
