### PR TITLE
Revert "kontact: Use more stable user-console for shell commands"

### DIFF
--- a/tests/x11/kontact.pm
+++ b/tests/x11/kontact.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2019 SUSE LLC
+# Copyright © 2012-2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -18,17 +18,16 @@ use testapi;
 use version_utils 'is_pre_15';
 
 sub run {
-    select_console 'user-console';
     # start akonadi server to avoid the self-test running when we launch kontact
-    assert_script_run 'DISPLAY=:0 akonadictl start >& /dev/null';
+    x11_start_program('akonadictl start', valid => 0);
 
     # Workaround: sometimes the account assistant behind of mainwindow or tips window
     # To disable it run at first time start
     if (is_pre_15) {
-        assert_script_run 'echo -e "[General]\nfirst-start=false" >> ~/.kde4/share/config/kmail2rc';
+        x11_start_program('echo -e "[General]\nfirst-start=false" >> ~/.kde4/share/config/kmail2rc', valid => 0);
     }
-    assert_script_run 'echo -e "[General]\nfirst-start=false" >> ~/.config/kmail2rc';
-    select_console 'x11';
+    x11_start_program('echo -e "[General]\nfirst-start=false" >> ~/.config/kmail2rc', valid => 0);
+
     my @tags = qw(test-kontact-1 kontact-import-data-dialog kontact-window);
     x11_start_program('kontact', target_match => \@tags);
     do {


### PR DESCRIPTION
This reverts commit 0840318d3a29d8eb9477fc3f1c2ff34509456a35.

Setting DISPLAY=:0 is not a reliable method to get access to the X
server and session DBus. The number might be different for every
session and without `XAUTHLOCALHOSTNAME` it might not work
at all, see https://openqa.opensuse.org/tests/887823.

- Verification run: http://10.160.67.86/t324
