### PR TITLE
Update lsof test for JeOS

### DIFF
--- a/tests/console/lsof.pm
+++ b/tests/console/lsof.pm
@@ -25,7 +25,7 @@ use utils 'zypper_call';
 sub run {
     my ($self) = @_;
     select_console('root-console');
-    zypper_call('in netcat');
+    zypper_call('in netcat lsof psmisc');
     assert_script_run("lsof");
     assert_script_run("lsof -u root");
     assert_script_run("lsof -i");
@@ -56,4 +56,3 @@ sub run {
 }
 
 1;
-


### PR DESCRIPTION
This change installs lsof and psmisc on JeOS.

- Related ticket: https://progress.opensuse.org/issues/49580
- Verification run: http://ccret.suse.cz/tests/3195#step/lsof/1
