### PR TITLE
Fix unlocking desktop on Plasma 5.16+

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -85,12 +85,12 @@ sub ensure_unlocked_desktop {
             }
             last;            # desktop is unlocked, mission accomplished
         }
+        wait_still_screen 2;    # slow down loop
         if (match_has_tag 'screenlock') {
             wait_screen_change {
                 send_key 'esc';    # end screenlock
             };
         }
-        wait_still_screen 2;       # slow down loop
         die 'ensure_unlocked_desktop repeated too much. Check for X-server crash.' if ($counter eq 1);    # die loop when generic-desktop not matched
     }
 }


### PR DESCRIPTION
In Plasma 5.16 (git master currently), the login and lock screen
behaviour changed, there's now a shorter timeout for the idle screen.

Previously, openQA would see the idle screen, press esc and then wait
for a screen change and then a still screen. This does not work with the
new behaviour as it practically waited for the idle screen again:
https://openqa.opensuse.org/tests/888171

Fix it by moving the delay before the esc keypress.

- Verification run: https://10.160.67.86/t325
