### PR TITLE
Drop public schema before importing dvdrental database

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -233,6 +233,10 @@ EOF
     assert_script_run 'unzip dvdrental.zip';
     assert_script_run 'p -c "CREATE DATABASE dvdrental"';
     assert_script_run 'psql -a -E -c "\l"|grep dvdrental';
+    # Since we want everything to work on a single transaction
+    # drop schema public as it's an schema that comes with postgresql by
+    # default and then restore the database
+    assert_script_run 'p -d dvdrental -c "DROP SCHEMA PUBLIC CASCADE"';
     assert_script_run 'pg_restore -d dvdrental -1 dvdrental.tar';
     assert_script_run 'p -d dvdrental -c "\dt"';
     assert_script_run 'p -d dvdrental -c "SELECT * FROM customer"|grep Davidson';


### PR DESCRIPTION
The dvdrental database comes with a 'create schema public' operation,
which is a bit redundant as postgresql creates a public schema by
default, however the database should be able to be imported regardless
the case, since the pg_restore is using -1 switch, one transaction is
done and when errors are found a rollback is done.

- Related ticket: https://progress.opensuse.org/issues/49187
- Verification run: http://phobos.suse.de/tests/1747353