### PR TITLE
Increase timeout for wine installation

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -306,7 +306,9 @@ sub ensure_installed {
     elsif ($ret !~ /pkcon-status-0/) {
         die "pkcon install did not succeed, return code: $ret";
     }
+    wait_still_screen 1;
     send_key("alt-f4");    # close xterm
+    assert_screen 'generic-desktop';
 }
 
 sub script_sudo {

--- a/tests/x11/wine.pm
+++ b/tests/x11/wine.pm
@@ -33,7 +33,7 @@ EOF
     script_run 'wine timer.exe', 0;
     assert_screen([qw(wine-timer wine-package-install-mono-cancel)], 600);
     if (match_has_tag 'wine-package-install-mono-cancel') {
-        assert_and_click 'wine-package-install-mono-cancel';
+        send_key 'esc';
         assert_screen 'wine-timer', 600;
     }
     wait_screen_change { send_key 'alt-f4' };


### PR DESCRIPTION
fix sporadic issue with wine installation
and replace assert_and_click by send_key 'esc'
over 100 verification test runs on 3o are successfully:
https://openqa.opensuse.org/tests/892701#next_previous

Related ticket: https://progress.opensuse.org/issues/49358