### PR TITLE
Hyper-V in GUI: No switch to VT allowed

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
-use version_utils 'is_caasp';
+use version_utils qw(is_caasp is_hyperv_in_gui);
 use Utils::Backends 'is_remote_backend';
 
 
@@ -71,7 +71,7 @@ sub run {
         ensure_ssh_unblocked;
         # Check the systemd target, see poo#45020
         return if (is_caasp || check_var('MACHINE', 'svirt-hyperv'));
-        if (get_var('DESKTOP')) {
+        if (get_var('DESKTOP') && !is_hyperv_in_gui) {
             my $target = check_var('DESKTOP', 'textmode') ? "multi-user" : "graphical";
             select_console 'install-shell';
             # The default.target is not yet linked, so we have to parse the logs.


### PR DESCRIPTION
On Hyper-V if we are in X in YaST, we can't switch to VT easily. Need to disable it.

Regression: d44674ff701bb6c54acbf43719c6b3470be26f27.

Fails:
* https://openqa.suse.de/tests/2707402#step/installation_overview/1
* https://openqa.suse.de/tests/2709687#step/installation_overview/4

Validation run:
* http://nilgiri.suse.cz/tests/695