### PR TITLE
Disable service test since SLED dont support to install vsftpd

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1089,7 +1089,7 @@ sub load_consoletests {
 
     loadtest "locale/keymap_or_locale";
     loadtest "console/orphaned_packages_check" if is_jeos;
-    loadtest "console/check_upgraded_service" if (is_sle && !get_var('MEDIA_UPGRADE') && !get_var('ZDUP') && is_upgrade);
+    loadtest "console/check_upgraded_service" if (is_sle && !get_var('MEDIA_UPGRADE') && !get_var('ZDUP') && is_upgrade && !is_desktop && !get_var('INSTALLONLY'));
     loadtest "console/force_scheduled_tasks" unless is_jeos;
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/check_locked_package";

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -464,7 +464,7 @@ sub load_online_migration_tests {
         loadtest "migration/sle12_online_migration/register_without_ltss";
     }
     loadtest "migration/sle12_online_migration/pre_migration";
-    loadtest 'installation/install_service';
+    loadtest 'installation/install_service' if (is_sle && !is_desktop && !get_var('INSTALLONLY'));
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/lock_package";
     }
@@ -499,7 +499,7 @@ sub load_patching_tests {
         }
         loadtest 'migration/record_disk_info';
         # Install service for offline migration by zypper
-        loadtest 'installation/install_service' if (is_sle && !get_var('MEDIA_UPGRADE') && !get_var('ZDUP'));
+        loadtest 'installation/install_service' if (is_sle && !is_desktop && !get_var('MEDIA_UPGRADE') && !get_var('ZDUP') && !get_var('INSTALLONLY'));
         # Reboot from DVD and perform upgrade
         loadtest "migration/reboot_to_upgrade";
         # After original system patched, switch to UPGRADE_TARGET_VERSION


### PR DESCRIPTION
On SLED the basesystem doesn't support to install vsftpd, so disable to load install_service and check_upgraded_service on SLED. 

- Related ticket: https://progress.opensuse.org/issues/49607
- Needles: N/A
- Verification run: Online sled: http://openqa-apac1.suse.de/tests/3647
                             Online sles: http://openqa-apac1.suse.de/tests/3646
                             offline sled: http://openqa-apac1.suse.de/tests/3644
