### PR TITLE
s390x: Don't generate tar files on every run

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1077,11 +1077,9 @@ sub load_consoletests {
         # prepare tarballs for the testcase
         # the path below should be reworked to be universal for any distribution, now it's for openQA deployed on opensuse
         my $tcs_path = "/var/lib/openqa/share/tests/sle/data/s390x/";
-        system("cd ${tcs_path}lib && rm -f common.tgz && tar -czf common.tgz ./*.sh");
 
         my $testset = get_var('IBM_TESTSET');    # e.g. "KERNEL or TOOL or MEMORY"
         foreach my $tc (split(',', get_var('IBM_TESTS'))) {
-            system("cd ${tcs_path}${testset}${tc} && rm -f ${testset}${tc}.tgz && tar -czf ${testset}${tc}.tgz ./*");
             loadtest "s390x_tests/consoletest_${testset}${tc}";
         }
         return 1;


### PR DESCRIPTION
verification: opeth.suse.de/tests/4130#step/consoletest_TOOL_s390_vmcp/4

reasoning is, that we cannot generate tar files, because of read only filesystem on the workers
that's why I generated them manually for now - with future improvements regarding cronjob or git hook