### PR TITLE
Fix ssh forward failure for sometimes the key was not attached.

### DIFF
--- a/tests/x11/sshxterm.pm
+++ b/tests/x11/sshxterm.pm
@@ -22,7 +22,8 @@ sub run {
     mouse_hide(1);
     x11_start_program('xterm');
     prepare_ssh_localhost_key_login $username;
-    type_string("ssh -XC root\@localhost xterm\n");
+    # add SSH_AUTH_SOCK=0 to fix 'sign_and_send_pubkey: signing failed: agent refused operation'
+    type_string("SSH_AUTH_SOCK=0 ssh -XC root\@localhost xterm\n");
     assert_screen([qw(ssh-xterm-host-key-authentication ssh-second-xterm)]);
     # if ssh asks for authentication of the key accept it
     if (match_has_tag('ssh-xterm-host-key-authentication')) {


### PR DESCRIPTION
 In some cases the ssh can not find any keys attached, we need add SSH_AUTH_SOCK=0 to workaround this. 

- Related ticket: https://progress.opensuse.org/issues/48494
- Verification run: http://openqa-apac1.suse.de/tests/3639#step/sshxterm/17
