### PR TITLE
Remove one invalid call to diag

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -86,7 +86,6 @@ END_BOOTSCRIPT
     diag "setting iPXE bootscript to: $bootscript";
     my $response = HTTP::Tiny->new->request('POST', $url, {content => $bootscript, headers => {'content-type' => 'text/plain'}});
     diag "$response->{status} $response->{reason}\n";
-    diag $response->{content};
 }
 
 


### PR DESCRIPTION
In the latest version, the ipxe_http service does only return a status
code and omits the return of contents.
Anyway, no reasonable information could be transported anyway, so
better just remove the diag, because if there is no content in the
response, the test just dies.

Signed-off-by: Michael Moese <mmoese@suse.de>

