### PR TITLE
Add smoke test for YaST2 firstboot module

### DIFF
--- a/data/autoyast_opensuse/autoyast_firstboot.xml
+++ b/data/autoyast_opensuse/autoyast_firstboot.xml
@@ -7,25 +7,9 @@
             <confirm config:type="boolean">false</confirm>
         </mode>
     </general>
-    <suse_register>
-      <do_registration config:type="boolean">true</do_registration>
-      <email/>
-      <reg_code>{{SCC_REGCODE}}</reg_code>
-      <install_updates config:type="boolean">true</install_updates>
-      <reg_server>{{SCC_URL}}</reg_server>
-      <addons config:type="list">
-        <addon>
-          <name>sle-module-basesystem</name>
-          <version>{{VERSION}}</version>
-          <arch>{{ARCH}}</arch>
-        </addon>
-        <addon>
-          <name>sle-module-desktop-applications</name>
-          <version>{{VERSION}}</version>
-        <arch>{{ARCH}}</arch>
-      </addon>
-      </addons>
-    </suse_register>
+    <login_settings>
+      <autologin_user>bernhard</autologin_user>
+    </login_settings>
     <bootloader>
         <global>
             <timeout config:type="integer">-1</timeout>
@@ -35,26 +19,15 @@
         <keep_install_network config:type="boolean">true</keep_install_network>
     </networking>
     <software>
-        <products config:type="list">
-            <product>SLES</product>
-        </products>
-        <packages config:type="list">
-          <package>grub2</package>
-          <package>sles-release</package>
-          <package>yast2-firstboot</package>
-        </packages>
-        <patterns config:type="list">
-          <pattern>apparmor</pattern>
-          <pattern>base</pattern>
-          <pattern>basesystem</pattern>
-          <pattern>documentation</pattern>
-          <pattern>enhanced_base</pattern>
-          <pattern>gnome_basic</pattern>
-          <pattern>gnome_basis</pattern>
-          <pattern>minimal_base</pattern>
-          <pattern>x11</pattern>
-          <pattern>x11_enhanced</pattern>
-        </patterns>
+      <install_recommended config:type="boolean">true</install_recommended>
+      <packages config:type="list">
+        <package>yast2-firstboot</package>
+      </packages>
+      <patterns config:type="list">
+        <pattern>apparmor</pattern>
+        <pattern>base</pattern>
+        <pattern>gnome</pattern>
+      </patterns>
     </software>
     <users config:type="list">
         <user>

--- a/data/autoyast_sle12/autoyast_firstboot.xml
+++ b/data/autoyast_sle12/autoyast_firstboot.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <general>
+    <mode>
+      <confirm config:type="boolean">false</confirm>
+    </mode>
+  </general>
+  <report>
+    <errors>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </warnings>
+    <yesno_messages>
+      <log config:type="boolean">true</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">0</timeout>
+    </yesno_messages>
+  </report>
+  <bootloader>
+    <global>
+      <timeout config:type="integer">-1</timeout>
+    </global>
+  </bootloader>
+  <keyboard>
+    <keyboard_values>
+      <delay/>
+      <discaps config:type="boolean">false</discaps>
+      <numlock>bios</numlock>
+      <rate/>
+    </keyboard_values>
+    <keymap>english-us</keymap>
+  </keyboard>
+  <language>
+    <language>en_US</language>
+    <languages/>
+  </language>
+  <ntp-client>
+    <ntp_policy>auto</ntp_policy>
+    <peers config:type="list"/>
+  </ntp-client>
+  <software>
+    <packages config:type="list">
+      <package>grub2</package>
+      <package>sles-release</package>
+      <package>yast2-firstboot</package>
+    </packages>
+    <patterns config:type="list">
+      <pattern>Minimal</pattern>
+      <pattern>apparmor</pattern>
+      <pattern>base</pattern>
+      <pattern>documentation</pattern>
+      <pattern>gnome-basic</pattern>
+      <pattern>x11</pattern>
+    </patterns>
+  </software>
+  <networking>
+    <interfaces config:type="list">
+      <interface>
+        <bootproto>dhcp</bootproto>
+        <device>eth0</device>
+        <dhclient_set_default_route>yes</dhclient_set_default_route>
+        <startmode>auto</startmode>
+      </interface>
+    </interfaces>
+  </networking>
+  <firewall>
+    <enable_firewall config:type="boolean">true</enable_firewall>
+    <start_firewall config:type="boolean">true</start_firewall>
+  </firewall>
+  <timezone>
+    <hwclock>UTC</hwclock>
+    <timezone>Europe/Berlin</timezone>
+  </timezone>
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>Bernhard M. Wiedemann</fullname>
+      <gid>100</gid>
+      <home>/home/bernhard</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact>-1</inact>
+        <max>99999</max>
+        <min>0</min>
+        <warn>7</warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>1000</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>bernhard</username>
+    </user>
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire/>
+        <flag/>
+        <inact/>
+        <max/>
+        <min/>
+        <warn/>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+      <user_password>nots3cr3t</user_password>
+      <username>root</username>
+    </user>
+  </users>
+  <firstboot>
+    <firstboot_enabled config:type="boolean">true</firstboot_enabled>
+  </firstboot>
+</profile>
+
+
+

--- a/lib/installation_user_settings.pm
+++ b/lib/installation_user_settings.pm
@@ -11,10 +11,14 @@
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
 package installation_user_settings;
+use parent Exporter;
 use strict;
 use warnings;
 use testapi;
 use version_utils 'is_sle';
+use utils 'type_string_slow';
+
+our @EXPORT = qw(type_password_and_verification await_password_check enter_userinfo enter_rootinfo);
 
 sub type_password_and_verification {
     for (1 .. 2) {
@@ -29,6 +33,24 @@ sub await_password_check {
     assert_screen 'inst-userpasswdtoosimple';
     send_key 'ret';
 
+}
+
+sub enter_userinfo {
+    my (%args) = @_;
+    $args{username} //= $realname;
+    send_key 'alt-f';    # Select full name text field
+    wait_screen_change { $args{retry} ? type_string_slow $args{username} : type_string $args{username} };
+    send_key 'tab';      # Select password field
+    send_key 'tab';
+    type_password_and_verification;
+}
+
+sub enter_rootinfo {
+    assert_screen "inst-rootpassword";
+    type_password_and_verification;
+    assert_screen "rootpassword-typed";
+    send_key $cmd{next};
+    await_password_check;
 }
 
 1;

--- a/schedule/autoyast_y2_firstboot.yaml
+++ b/schedule/autoyast_y2_firstboot.yaml
@@ -1,0 +1,12 @@
+name:           autoyast_y2_firstboot
+description:    >
+    Smoke test for YaST2 firstboot module
+schedule:
+    - autoyast/prepare_profile
+    - installation/isosize
+    - installation/bootloader
+    - autoyast/installation
+    - installation/yast2_firstboot
+
+
+

--- a/schedule/yast2_firstboot.yaml
+++ b/schedule/yast2_firstboot.yaml
@@ -1,0 +1,13 @@
+---
+name:           yast2_fistboot
+description:    >
+    Smoke test for YaST2 firstboot module
+schedule:
+    - boot/boot_to_desktop
+    - console/prepare_test_data
+    - console/consoletest_setup
+    - console/hostname
+    - installation/enable_y2_firstboot
+    - autoyast/autoyast_reboot
+    - installation/grub_test
+    - installation/yast2_firstboot

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -146,7 +146,8 @@ sub run {
           || match_has_tag('bios-boot')
           || match_has_tag('autoyast-stage1-reboot-upcoming')
           || match_has_tag('linux-login-casp')
-          || match_has_tag('inst-bootmenu'))
+          || match_has_tag('inst-bootmenu')
+          || match_has_tag('lang_and_keyboard'))
     {
         #Verify timeout and continue if there was a match
         next unless verify_timeout_and_check_screen(($timer += $check_time), \@needles);
@@ -260,7 +261,7 @@ sub run {
     $stage   = 'stage2';
 
     check_screen \@needles, $check_time;
-    @needles = qw(reboot-after-installation autoyast-postinstall-error autoyast-boot warning-pop-up autoyast-error inst-bootmenu);
+    @needles = qw(reboot-after-installation autoyast-postinstall-error autoyast-boot warning-pop-up autoyast-error inst-bootmenu lang_and_keyboard);
     # There will be another reboot for IPMI backend
     push @needles, qw(prague-pxe-menu qa-net-selection) if check_var('BACKEND', 'ipmi');
     until (match_has_tag 'reboot-after-installation') {
@@ -286,6 +287,9 @@ sub run {
         }
         elsif (match_has_tag('inst-bootmenu')) {
             $self->wait_grub_to_boot_on_local_disk;
+        }
+        elsif (match_has_tag('lang_and_keyboard')) {
+            return;
         }
     }
 

--- a/tests/installation/enable_y2_firstboot.pm
+++ b/tests/installation/enable_y2_firstboot.pm
@@ -1,0 +1,27 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Enable YaST2 Firstboot module - Desktop workstation configuration utility
+# Doc: https://en.opensuse.org/YaST_Firstboot
+# Maintainer: Martin Loviska <mloviska@suse.com>
+
+use base "y2logsstep";
+use strict;
+use warnings;
+use testapi;
+use utils qw(zypper_call clear_console);
+
+sub run {
+    select_console 'root-console';
+    zypper_call "in yast2-firstboot";
+    assert_script_run 'touch /var/lib/YaST2/reconfig_system';
+    clear_console;
+}
+
+1;

--- a/tests/installation/user_settings.pm
+++ b/tests/installation/user_settings.pm
@@ -15,17 +15,6 @@ use strict;
 use warnings;
 use parent qw(installation_user_settings y2logsstep);
 use testapi;
-use utils qw(type_string_slow);
-
-
-sub enter_userinfo {
-    my ($self, %args) = @_;
-    send_key 'alt-f';    # Select full name text field
-    wait_screen_change { $args{retry} ? type_string_slow $realname : type_string $realname };
-    send_key 'tab';      # Select password field
-    send_key 'tab';
-    $self->type_password_and_verification;
-}
 
 sub run {
     my ($self) = @_;

--- a/tests/installation/user_settings_root.pm
+++ b/tests/installation/user_settings_root.pm
@@ -18,11 +18,7 @@ use testapi;
 
 sub run {
     my ($self) = @_;
-    assert_screen "inst-rootpassword";
-    $self->type_password_and_verification;
-    assert_screen "rootpassword-typed";
-    send_key $cmd{next};
-    $self->await_password_check;
+    $self->enter_rootinfo;
 }
 
 1;

--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -1,0 +1,103 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Utilize OS using YaST2 Firstboot module
+# Doc: https://en.opensuse.org/YaST_Firstboot
+# Maintainer: Martin Loviska <mloviska@suse.com>
+
+use base "y2logsstep";
+use strict;
+use warnings;
+use testapi;
+use utils qw(zypper_call clear_console);
+use installation_user_settings qw(await_password_check enter_userinfo enter_rootinfo);
+use version_utils qw(is_sle is_opensuse);
+
+sub language_and_keyboard {
+    my $shortcuts = {
+        l => 'lang',
+        k => 'keyboard'
+    };
+    assert_screen 'lang_and_keyboard';
+    mouse_hide(1);
+    foreach (sort keys %${shortcuts}) {
+        send_key 'alt-' . $_;
+        assert_screen $shortcuts->{$_} . '_selected';
+        send_key_until_needlematch 'expanded_list', 'spc', 5, 7;
+        wait_screen_change(sub { send_key 'ret'; }, 5);
+    }
+    wait_screen_change(sub { send_key $cmd{next}; }, 7);
+}
+
+sub license {
+    my $self = shift;
+    return unless is_sle('>=12-sp4');
+    assert_screen('license-agreement');
+    $self->verify_license_has_to_be_accepted;
+    $self->accept_license;
+    wait_screen_change(sub { send_key $cmd{next}; }, 7);
+    # Workaround license checkbox
+    assert_screen(qw(license-agreement inst-timezone));
+    if (match_has_tag('license-agreement')) {
+        record_soft_failure 'bsc#1131327 License checkbox was cleared! Re-check again!';
+        send_key 'alt-a';
+        assert_screen('license-agreement-accepted');
+        wait_screen_change(sub { send_key $cmd{next}; }, 7);
+    }
+    elsif (match_has_tag('inst-timezone')) {
+        return;
+    }
+    # End of WA
+}
+
+sub welcome {
+    assert_screen 'welcome';
+    wait_screen_change(sub { send_key $cmd{next}; }, 7);
+}
+
+sub clock_and_timezone {
+    assert_screen 'inst-timezone';
+    wait_screen_change(sub { send_key $cmd{next}; }, 7);
+}
+
+sub user_setup {
+    my $is_not_shared_passwd = shift;
+    assert_screen 'local_user';
+    enter_userinfo(username => 'y2_firstboot_tester');
+    if (defined($is_not_shared_passwd)) {
+        send_key 'alt-t' if (is_opensuse);
+    }
+    else {
+        send_key 'alt-t' if (is_sle('>=12-sp4'));
+    }
+    wait_screen_change(sub { send_key $cmd{next}; }, 7);
+    await_password_check;
+    wait_screen_change(sub { send_key $cmd{next}; }, 7) unless defined($is_not_shared_passwd);
+}
+
+sub root_setup {
+    assert_screen 'root_user';
+    enter_rootinfo;
+    wait_screen_change(sub { send_key $cmd{next}; }, 7);
+}
+
+sub run {
+    my $self = shift;
+    language_and_keyboard;
+    welcome;
+    $self->license;
+    clock_and_timezone;
+    user_setup(1);
+    root_setup;
+    assert_screen 'installation_completed';
+    send_key $cmd{finish};
+    assert_screen 'displaymanager';
+}
+
+1;


### PR DESCRIPTION
Initial PR to enable YaST2 Firstboot testing.

- Related ticket: [[functional][y] new yast2 firstboot wizard test](https://progress.opensuse.org/issues/40184)
- Needles: 
   * <del>[o3](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/536)</del>
   * [osd](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1105)
   * [leap15.1 - current state](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/538)
- Verification runs: 
  * firstboot VRs:
     * AY:
        * [autoyast_y2_firstboot@64bit-tw](http://eris.suse.cz/tests/12901)
        * [autoyast_y2_firstboot@64bit-12-SP5](http://eris.suse.cz/tests/12890)
        * [autoyast_y2_firstboot@64bit-15-SP1](http://eris.suse.cz/tests/12900)
    *  Classic:
        * [sle-15-SP1-yast2_firstboot@64bit](http://eris.suse.cz/tests/12891)
        * [sle-12-SP5-yast2_firstboot@64bit](http://eris.suse.cz/tests/12899)
        * [Tumbleweed-yast2_firstboot@64bit](http://eris.suse.cz/tests/12907)
  * regression:
    * [user_settings_root](http://eris.suse.cz/tests/12788#step/user_settings_root/1)
    * [user_settings](http://eris.suse.cz/tests/12789#step/user_settings/1)
  * bugs:
    * [boo#1105792 leap15.1 - branding and missing package in DVD](https://bugzilla.opensuse.org/show_bug.cgi?id=1105792)
    * [License Agreement view is shown in Leap15.1](https://bugzilla.opensuse.org/show_bug.cgi?id=1131301)
    * [ay leap15.1 - missing firstboot rpm in DVD](http://eris.suse.cz/tests/12941#step/installation/29)
    * [branding and license agreement view not skipped](http://eris.suse.cz/tests/12939#step/yast2_firstboot/25)
    * [Bug 1131327 - [Build 0134] openQA test fails in yast2_firstboot - license terms checkbox gets cleared after pressing next button](https://bugzilla.suse.com/show_bug.cgi?id=1131327)