### PR TITLE
[WIP] kontact: do not redirect std and error outputs to /dev/null 

### DIFF
--- a/tests/x11/kontact.pm
+++ b/tests/x11/kontact.pm
@@ -20,7 +20,7 @@ use version_utils 'is_pre_15';
 sub run {
     select_console 'user-console';
     # start akonadi server to avoid the self-test running when we launch kontact
-    assert_script_run 'DISPLAY=:0 akonadictl start >& /dev/null';
+    assert_script_run 'DISPLAY=:0 akonadictl start';
 
     # Workaround: sometimes the account assistant behind of mainwindow or tips window
     # To disable it run at first time start


### PR DESCRIPTION
to be able to debug

- Related ticket: https://progress.opensuse.org/issues/49406
- Verification run: https://openqa.opensuse.org/t892459
