### PR TITLE
Remove use of lib/selenium methods in ha/hawk_gui

### DIFF
--- a/tests/ha/hawk_gui.pm
+++ b/tests/ha/hawk_gui.pm
@@ -16,7 +16,6 @@ use warnings;
 use testapi;
 use lockapi;
 use hacluster;
-use selenium;
 use x11test;
 use x11utils;
 use version_utils 'is_desktop_installed';
@@ -81,7 +80,9 @@ sub run {
 
     my $python = install_required_python_pkgs;
     install_geckodriver;
-    enable_selenium_port;
+    # The line below can be changed for a call to lib/selenium.pm::enable_selenium_port()
+    # once Selenium::Remote::Driver it's available in the openqa.suse.de workers
+    assert_script_run('systemctl stop ' . opensusebasetest::firewall());
 
     select_console 'x11';
     x11_start_program('xterm');


### PR DESCRIPTION
`lib/selenium` uses `Selenium::Remote::Driver` which is not currently installed in openqa.suse.de workers. Since the only method from `lib/selenium` in use in the `ha/hawk_gui` module is `enable_selenium_port`, which in turns is only a call to `assert_script_run('systemctl stop ...')`, this substitutes that call instead of the call to the method.

- Related ticket: https://progress.opensuse.org/issues/30270
- Needles: N/A
- Verification run: http://mango.suse.de/tests/827
- Failing test: https://openqa.suse.de/tests/2743006