### PR TITLE
Do not report on empty error

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -275,7 +275,7 @@ sub investigate_yast2_failure {
         }
         # remove empty lines
         $y2log_error_result =~ s/\n+/\n/gs;
-        $detected_errors_detailed .= "$y2log_error_result\n" if $y2log_error_result;
+        $detected_errors_detailed .= "$y2log_error_result\n" if $y2log_error_result !~ m/^(\n|\s)*$/;
     }
 
     # Send last lines to serial to copy in case of new critical bugs


### PR DESCRIPTION
Yet another regression while removing known errors from the logs, some
blank symbols still might remain, so remove those to make value empty.

[Verification run](http://f174.suse.de/tests/174).

Fixes https://openqa.suse.de/tests/2742594#step/logs_from_installation_system/423.
