### PR TITLE
Increase timeout for dracut initrd generation

### DIFF
--- a/tests/console/dracut.pm
+++ b/tests/console/dracut.pm
@@ -24,7 +24,7 @@ sub run {
     assert_script_run("rpm -q dracut");
 
     validate_script_output("lsinitrd", sub { m/Image:(.*\n)+( ?)Version: dracut(-|\d+|\.|\w+)+(\n( ?))+( ?)Arguments(.*\n)+( ?)dracut modules:(\w+|-|\d+|\n|( ?))+\=+\n(l|d|r|w|x|-|( ?))+\s+\d+ root\s+root(.*\n)+( ?)\=+/ });
-    validate_script_output("dracut -f", sub { m/.*Executing: \/usr\/bin\/dracut -f\n|\b(?:Skipping|Including modules done|Including|Creating image|Creating initramfs)\b/ });
+    validate_script_output("dracut -f", sub { m/.*Executing: \/usr\/bin\/dracut -f\n|\b(?:Skipping|Including modules done|Including|Creating image|Creating initramfs)\b/ }, 180);
     validate_script_output("dracut --list-modules", sub { m/.*Executing: \/usr\/bin\/dracut --list-modules\n(\w+|\n|-|d+)+/ });
 
     power_action('reboot', textmode => 1);


### PR DESCRIPTION
Increase timeout from default 90s to 180s. This should suffice also on slower archs (eg aarch64).

- Related ticket: https://progress.opensuse.org/issues/49778
- Verification run: http://d502.qam.suse.de/tests/1438
