### PR TITLE
Remove duplicated bootloader section

### DIFF
--- a/data/autoyast_sle12/autoyast_multipath.xml
+++ b/data/autoyast_sle12/autoyast_multipath.xml
@@ -24,11 +24,6 @@ pre init scripts feature. See poo#20818.
       <import_gpg_key config:type="boolean">true</import_gpg_key>
     </signature-handling>
   </general>
-  <bootloader>
-    <global>
-      <timeout config:type="integer">-1</timeout>
-    </global>
-  </bootloader>
   <report>
     <errors>
       <log config:type="boolean">true</log>
@@ -75,6 +70,7 @@ pre init scripts feature. See poo#20818.
       <suse_btrfs config:type="boolean">false</suse_btrfs>
       <os_prober>false</os_prober>
       <terminal>console</terminal>
+      <timeout config:type="integer">-1</timeout>
     </global>
     <loader_type>grub2</loader_type>
   </bootloader>


### PR DESCRIPTION
Timeout for grub is not disabled, because in the profile we have 2
sections for it, so settings are overridden.
This PR will fix the issue and make test stable to sync on grub menu.

- [Verification run](http://f174.suse.de/tests/175#).
