### PR TITLE
yast2-registration regression tests

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -588,6 +588,13 @@ sub load_suseconnect_tests {
     loadtest "console/suseconnect";
 }
 
+sub load_yast2_registration_tests {
+    prepare_target;
+    loadtest "console/system_prepare";
+    loadtest "console/consoletest_setup";
+    loadtest "console/yast2_registration";
+}
+
 testapi::set_distribution(DistributionProvider->provide());
 
 # set serial failures
@@ -617,7 +624,8 @@ elsif (get_var("NFV")) {
 elsif (get_var("REGRESSION")) {
     load_common_x11;
     load_hypervisor_tests if (check_var("REGRESSION", "xen-hypervisor") || check_var("REGRESSION", "qemu-hypervisor"));
-    load_suseconnect_tests if check_var("REGRESSION", "suseconnect");
+    load_suseconnect_tests        if check_var("REGRESSION", "suseconnect");
+    load_yast2_registration_tests if check_var("REGRESSION", "yast2_registration");
 }
 elsif (get_var("FEATURE")) {
     prepare_target();

--- a/tests/console/yast2_registration.pm
+++ b/tests/console/yast2_registration.pm
@@ -1,0 +1,64 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: check if an unregistered system can be registered and if
+#          enabling and disabling extensions correctly work.
+# Maintainer: Paolo Stivanin <pstivanin@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use registration;
+use utils 'zypper_call';
+
+sub register_system_and_add_extension {
+    wait_screen_change { type_string get_var "SCC_EMAIL" };
+    send_key "tab";
+    wait_screen_change { type_string get_var "SCC_REGCODE" };
+    send_key "alt-n";
+    assert_screen("yast2_registration-ext-mod-selection", timeout => 60);
+    # enable Web and Scripting Module
+    for my $i (0 .. 25) {
+        send_key "down";
+    }
+    wait_screen_change { send_key "spc" };
+    send_key "alt-n";
+    wait_still_screen(stilltime => 7, timeout => 60);
+    if (check_screen "yast2_registration-license-agreement") {
+        wait_screen_change { send_key "alt-a" };
+        send_key "alt-n";
+        wait_still_screen 5;
+    }
+    send_key "alt-a";
+    wait_still_screen 2;
+    send_key "alt-o";
+    wait_still_screen 5;
+    wait_screen_change { send_key "alt-f" };
+}
+
+sub run {
+    my ($self) = @_;
+
+    select_console 'root-console';
+
+    zypper_call "in yast2-registration";
+
+    cleanup_registration;
+    script_run("yast registration", 0);
+    assert_screen([qw(yast2_registration-overview yast2_registration-registration-page)]);
+
+    send_key "alt-e" if (match_has_tag "yast2_registration-overview");
+    register_system_and_add_extension;
+
+    assert_script_run "SUSEConnect --status-text |grep -A3 -E 'SUSE Linux Enterprise Server|Web and Scripting Module' | grep -qE '^\\s+Registered'";
+}
+
+1;
+


### PR DESCRIPTION
Available for **SLE >= 12.2**, this test register a system and add an extension.

- Related ticket: https://progress.opensuse.org/issues/48569
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1104/
- Verification runs:
  - SLE 15.0: http://d502.qam.suse.de/tests/1427 :heavy_check_mark: 
  - SLE 12.4: http://d502.qam.suse.de/tests/1429 :heavy_check_mark: 
  - SLE 12.3: http://d502.qam.suse.de/tests/1431 :heavy_check_mark: 
  - SLE 12.2: http://d502.qam.suse.de/tests/1433 :heavy_check_mark: 

:warning: **Open question:** where should we put this test? The above runs where executed with `mau-extratests`, but I'm not sure that's the best place.