### PR TITLE
Detect typos in boot parameters in bootloader.pm

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1,7 +1,7 @@
 package opensusebasetest;
 use base 'basetest';
 
-use bootloader_setup qw(stop_grub_timeout boot_local_disk tianocore_enter_menu zkvm_add_disk zkvm_add_pty zkvm_add_interface type_hyperv_fb_video_resolution);
+use bootloader_setup qw(stop_grub_timeout boot_local_disk tianocore_enter_menu zkvm_add_disk zkvm_add_pty zkvm_add_interface);
 use testapi;
 use strict;
 use warnings;
@@ -355,37 +355,6 @@ sub upload_packagekit_logs {
 sub set_standard_prompt {
     my ($self, $user) = @_;
     $testapi::distri->set_standard_prompt($user);
-}
-
-sub select_bootmenu_more {
-    my ($self, $tag, $more) = @_;
-
-    # do not waste time waiting when we already matched
-    assert_screen 'inst-bootmenu', 15 unless match_has_tag 'inst-bootmenu';
-    stop_grub_timeout;
-
-    # after installation-images 14.210 added a submenu
-    if ($more && check_screen 'inst-submenu-more', 0) {
-        send_key_until_needlematch('inst-onmore', get_var('OFW') ? 'up' : 'down', 10, 5);
-        send_key "ret";
-    }
-    send_key_until_needlematch($tag, get_var('OFW') ? 'up' : 'down', 10, 3);
-    if (get_var('UEFI')) {
-        send_key 'e';
-        send_key 'down' for (1 .. 4);
-        send_key 'end';
-        # newer versions of qemu on arch automatically add 'console=ttyS0' so
-        # we would end up nowhere. Setting console parameter explicitly
-        # See https://bugzilla.suse.com/show_bug.cgi?id=1032335 for details
-        type_string_slow ' console=tty1' if get_var('MACHINE') =~ /aarch64/;
-        # Hyper-V defaults to 1280x1024, we need to fix it here
-        type_hyperv_fb_video_resolution if check_var('VIRSH_VMM_FAMILY', 'hyperv');
-        send_key 'f10';
-    }
-    else {
-        type_hyperv_fb_video_resolution if check_var('VIRSH_VMM_FAMILY', 'hyperv');
-        send_key 'ret';
-    }
 }
 
 sub export_kde_logs {

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -564,8 +564,11 @@ sub registration_bootloader_cmdline {
 sub registration_bootloader_params {
     my ($max_interval) = @_;    # see 'type_string'
     $max_interval //= 13;
-    type_string registration_bootloader_cmdline, $max_interval;
+    my @params;
+    push @params, split ' ', registration_bootloader_cmdline;
+    type_string "@params ", $max_interval;
     save_screenshot;
+    return @params;
 }
 
 sub yast_scc_registration {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -64,6 +64,7 @@ our @EXPORT = qw(
   get_x11_console_tty
   OPENQA_FTP_URL
   arrays_differ
+  arrays_subset
   ensure_serialdev_permissions
   assert_and_click_until_screen_change
   exec_and_insert_password
@@ -753,6 +754,28 @@ sub arrays_differ {
         return 1 if !grep($item eq $_, @array2);
     }
     return 0;
+}
+
+=head2 arrays_subset
+
+    arrays_subset(\@array1, \@array2);
+
+Compares two arrays passed by reference to identify if array1 is a subset of
+array2.
+
+Returns resulting array containing items of array1 that do not exist in array2.
+If all the items of array1 exist in array2, returns an empty array (which means
+array1 is a subset of array2).
+
+=cut
+
+sub arrays_subset {
+    my ($array1_ref, $array2_ref) = @_;
+    my @result;
+    foreach my $item (@{$array1_ref}) {
+        push(@result, $item) if !grep($item eq $_, @{$array2_ref});
+    }
+    return @result;
 }
 
 =head2 ensure_serialdev_permissions

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -27,11 +27,12 @@ sub run {
     return boot_spvm if check_var('BACKEND', 'spvm');
     return           if pre_bootmenu_setup == 3;
     return           if select_bootmenu_option == 3;
-    bootmenu_default_params;
-    bootmenu_network_source;
-    specific_bootmenu_params;
+    my @params;
+    push @params, bootmenu_default_params;
+    push @params, bootmenu_network_source;
+    push @params, specific_bootmenu_params;
     specific_caasp_params;
-    registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
+    push @params, registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);
     mutex_wait 'support_server_ready' if get_var('USE_SUPPORT_SERVER');
     # on ppc64le boot have to be confirmed with ctrl-x or F10
     # and it doesn't have nice graphical menu with video and language options
@@ -45,6 +46,7 @@ sub run {
         # boot
         send_key 'ctrl-x';
     }
+    compare_bootparams(\@params, [parse_bootparams_in_serial]);
 }
 
 1;

--- a/tests/installation/mediacheck.pm
+++ b/tests/installation/mediacheck.pm
@@ -15,7 +15,7 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
-use bootloader_setup qw(ensure_shim_import pre_bootmenu_setup);
+use bootloader_setup qw(ensure_shim_import pre_bootmenu_setup select_bootmenu_more);
 
 sub run {
     my $self       = shift;
@@ -27,7 +27,7 @@ sub run {
     }
 
     ensure_shim_import;
-    $self->select_bootmenu_more('inst-onmediacheck', 1);
+    select_bootmenu_more('inst-onmediacheck', 1);
 
     while ($iterations++ < 3) {
         # the timeout is insane - but some old DVDs took almost forever, could

--- a/tests/installation/memtest.pm
+++ b/tests/installation/memtest.pm
@@ -15,12 +15,12 @@ use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
-use bootloader_setup 'ensure_shim_import';
+use bootloader_setup qw(ensure_shim_import select_bootmenu_more);
 
 sub run {
     my $self = shift;
     ensure_shim_import;
-    $self->select_bootmenu_more('inst-onmemtest', 1);
+    select_bootmenu_more('inst-onmemtest', 1);
     assert_screen('pass-complete', 1000);
 }
 

--- a/tests/installation/rescuesystem.pm
+++ b/tests/installation/rescuesystem.pm
@@ -15,7 +15,7 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
-use bootloader_setup 'ensure_shim_import';
+use bootloader_setup qw(ensure_shim_import select_bootmenu_more);
 
 sub run {
     my $self = shift;
@@ -24,7 +24,7 @@ sub run {
     # does the job to get us into rescue mode.
     unless (check_var('VIRSH_VMM_TYPE', 'linux')) {
         ensure_shim_import;
-        $self->select_bootmenu_more('inst-rescuesystem', 1);
+        select_bootmenu_more('inst-rescuesystem', 1);
     }
 
     assert_screen 'keyboardmap-list', 120;


### PR DESCRIPTION
Compare boot parameters that are expected to be entered with the actual
ones in the serial output in bootloader.pm module.

Does not fail a job but just produces a notification to openQA using
record_info.

Added to make the review of typos in bootloader parameters more simple.

- Related ticket: [poo#48572](https://progress.opensuse.org/issues/48572)
- Verification runs:
   - Passed check: http://oorlov-vm.qa.suse.de/tests/815
   - Failed check (just to show how it looks in case when parameters are mistyped): http://oorlov-vm.qa.suse.de/tests/816;
   - Additional check on another bootloader test module, that is using same functions to type boot parameters: http://oorlov-vm.qa.suse.de/tests/816
