### PR TITLE
Fix menu handling on new gnote version

### DIFF
--- a/tests/x11/gnote/gnote_link_note.pm
+++ b/tests/x11/gnote/gnote_link_note.pm
@@ -31,10 +31,7 @@ sub run {
 
     # click the menu button on the tool bar
     assert_and_click 'gnote-new-note-menu';
-    wait_screen_change { send_key 'down' };
-    if (get_var('SP2ORLATER') || is_tumbleweed) {
-        wait_screen_change { send_key 'ret' };
-    }
+    assert_and_click 'gnote-new-note-menu-what-link-here';
     assert_screen 'gnote-what-link-here';
     wait_screen_change { send_key 'esc' };
     #close the note "Start Here"


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/49814
- **Merge needles first**: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/537
- Verification runs: Tumbleweed: http://slindomansilla-vm.qa.suse.de/tests/1277

The code mentions SLE, but I didn't find any job executing that module.