### PR TITLE
Fix supportconfig tarball filename in upload

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -268,8 +268,8 @@ sub ha_export_logs {
     upload_logs($mdadm_conf, failok => 1);
 
     # supportconfig
-    script_run "time supportconfig -B $clustername", 180;
-    upload_logs("/var/log/nts_$clustername.tbz", failok => 1);
+    script_run "supportconfig -g -B $clustername", 180;
+    upload_logs("/var/log/nts_$clustername.tgz", failok => 1);
 }
 
 sub check_cluster_state {


### PR DESCRIPTION
`supportconfig` file extension can be `.tbz` or `.txz` depending on the available compression utilities in the system. This PR fixes the calls to `supportconfig` and `upload_logs` so `.tgz` is used instead.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1114855
- Needles: N/A
- Verification run: http://mango.suse.de/tests/845#step/wait_barriers/31
