### PR TITLE
Enable all can enable unused repos which RMT server didn't mirror

### DIFF
--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -1,4 +1,4 @@
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -97,7 +97,10 @@ sub patching_sle {
         sle_register("unregister");
     }
 
-    assert_script_run("zypper mr --enable --all");
+    # RMT didn't mirror all repos, cannot use enable all
+    if (!get_var("SMT_URL")) {
+        assert_script_run("zypper mr --enable --all");
+    }
 
     # Disable old repositories during AutoYaST driven upgrade
     if (get_var('AUTOUPGRADE')) {


### PR DESCRIPTION
When use RMT as registration server, we cannot use enable all command, as it will enable all the repos which RMT didn't mirror.

- Related ticket: https://progress.opensuse.org/issues/49727
- Verification run:
RMT: http://openqa-apac1.suse.de/tests/3719
SMT: http://openqa-apac1.suse.de/tests/3717
[autoinst-log_RMT.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/3027861/autoinst-log_RMT.txt)
