### PR TITLE
Remove soft-failure for bsc#1108669

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -317,9 +317,8 @@ sub run {
     my $self = shift;
     select_console 'x11';
     if (is_sle '15+') {
-        # kdump is disabled by default, so ensure that it's installed
+        # kdump is disabled by default in the installer, so ensure that it's installed
         ensure_installed 'yast2-kdump';
-        record_soft_failure 'bsc#1108669';
         # see bsc#1062331, sound is not added to the yast2 pattern
         # also add missing yast2-ca-management and yast2-auth-server
         ensure_installed 'yast2-boot-server yast2-sound yast2-ca-management yast2-auth-server';


### PR DESCRIPTION
As mentioned in the bug, kdump is installed in the
system if enabled on the overview. So this is expected behavior.
