### PR TITLE
Add raid validation test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2420,7 +2420,7 @@ sub load_installation_validation_tests {
     # - console/validate_lvm_encrypt: validate lvm encrypted partitioning
     # - console/autoyast_smoke: validate autoyast installation
     # - installation/validation/ibft: validate autoyast installation
-
+    # - console/validate_raid: validate raid layout partitioning
     for my $module (split(',', get_var('INSTALLATION_VALIDATION'))) {
         loadtest $module;
     }

--- a/tests/console/validate_raid.pm
+++ b/tests/console/validate_raid.pm
@@ -1,0 +1,146 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Simple RAID partitioning layout validation
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.com>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use version_utils 'is_sle';
+use Test::Assert ':all';
+
+#
+# Define blocks of expected data for partitioning layout in different products and architectures
+#
+# 4 btrfs partitions mounted on / in raid partition
+my $btrfs = qr/(md0(p1)?.+btrfs.+\/.*){4}/s;
+# 4 swap partitions in raid partition
+my $swap = qr/(md((1|2)p1)?.+swap.+\[SWAP\].*){4}/s;
+# 8 raid partitions
+my $raid_partitions_2_arrays = qr/(md(0|1).*){8}/s;
+# 12 raid partitions
+my $raid_partitions_3_arrays = qr/(md(0|1|2).*){12}/s;
+# 8 linux raid members
+my $linux_raid_member_2_arrays = qr/(vd(a|b|c|d)(2|3).+linux_raid_member.*){8}/s;
+# 12 linux raid members
+my $linux_raid_member_3_arrays = qr/(vd(a|b|c|d)(1|2|3|4).+linux_raid_member.*){12}/s;
+# 4 hard disks
+my $hard_disks = qr/(vd(a|b|c|d)\D+.*){4}/s;
+# 4 ext4 partitions mounted on /boot
+my $ext4_boot = qr/(md1(p1)?.+ext4.+\/boot.*){4}/s;
+# Unique vfat partition in first disk (mounted on /boot)
+my $vfat_efi = qr/vda1.+vfat.\s+\/boot\/efi.*(vd(b|c|d)1(?!.*vfat).*){3}/s;
+#
+# Define blocks of expected data for raid configuration in different products and architectures
+#
+# RAID arrays
+my @raid_arrays = qw(/dev/md0 /dev/md1);
+# Number of array devices
+my $num_raid_arrays = @raid_arrays;
+# RAID level from settings
+my $level = get_required_var('RAIDLEVEL');
+# RAID array with corresponding RAID level
+my $raid_level = qr/\/dev\/md0:.*?Raid Level : raid$level/s;
+# RAID array always with level 0
+my $raid0 = qr/\/dev\/md(1|2):.*?Raid Level : raid0/s;
+# RAID array always with level 1? why?
+my $raid1       = qr/\/dev\/md1:.*?Raid Level : raid1/s;
+my @raid_detail = (
+    # 4 RAID devices per RAID array
+    /(Raid Devices : 4.*){$num_raid_arrays}/s,
+    # 4 active RAID devices per RAID array
+    /(Active Devices : 4.*){$num_raid_arrays}/s,
+    # 4 working RAID devices per RAID array
+    /(Working Devices : 4.*){$num_raid_arrays}/s,
+    # 1st raid device per RAID array, i.e.: /dev/vda2
+    /(0.*\/dev\/\w{2}a\d.*){$num_raid_arrays}/s,
+    # 2nd raid device per RAID array, i.e.: /dev/vdb2
+    /(1.*\/dev\/\w{2}b\d.*){$num_raid_arrays}/s,
+    # 3rd raid device per RAID array, i.e.: /dev/vdc2
+    /(2.*\/dev\/\w{2}c\d.*){$num_raid_arrays}/s,
+    # 4th raid device per RAID array, i.e.: /dev/vdd2
+    /(3.*\/dev\/\w{2}d\d.*){$num_raid_arrays}/s,
+);
+# Store test data to test expected partitioning/raid in specific architecture/product
+my (
+    @partitioning,
+    @raid,
+);
+# Prepare test data depending on specific architecture/product
+sub prepare_test_data {
+    if (check_var('ARCH', 'ppc64le')) {
+        @partitioning = (
+            $raid_partitions_3_arrays, $hard_disks, $linux_raid_member_3_arrays,
+            $ext4_boot,
+            $btrfs, $swap,
+        );
+        # Additional RAID array (update num_raid_arrays to regenerate regex)
+        push(@raid_arrays, '/dev/md2');
+        $num_raid_arrays = @raid_arrays;
+        @raid            = (($raid_level, $raid0, $raid1), @raid_detail);
+    }
+    elsif (check_var('ARCH', 'aarch64')) {
+        @partitioning = @partitioning = (
+            $raid_partitions_2_arrays, $hard_disks, $linux_raid_member_2_arrays,
+            $vfat_efi,
+            $btrfs, $swap,
+        );
+    }
+    elsif (check_var('ARCH', 'x86_64')) {
+        if (is_sle('<15')) {
+            @partitioning = (
+                $btrfs, $ext4_boot, $swap,
+                $hard_disks, $linux_raid_member_3_arrays,
+            );
+            # Additional RAID array (update num_raid_arrays to regenerate regex)
+            push(@raid_arrays, '/dev/md2');
+            $num_raid_arrays = @raid_arrays;
+            @raid            = (($raid_level, $raid0, $raid1), @raid_detail);
+        }
+    }
+    else {
+        @partitioning = (
+            $raid_partitions_2_arrays, $hard_disks, $linux_raid_member_2_arrays,
+            $btrfs, $swap,
+        );
+        @raid = (($raid_level, $raid0), @raid_detail);
+    }
+}
+
+sub command_output {
+    my %args        = @_;
+    my $name        = $args{name};
+    my $options     = $args{options};
+    my $description = "$args{description}\n$name $options";
+    my @expected    = @{$args{matches}};
+    record_info($name, $description);
+    my $actual = script_output("$name $options");
+    assert_matches($_, $actual, "Partition not found") for (@expected);
+}
+
+sub run {
+    select_console 'root-console';
+    prepare_test_data;
+    command_output(
+        name        => 'lsblk',
+        options     => '--list --output NAME,FSTYPE,MOUNTPOINT',
+        description => 'Verify partitioning',
+        matches     => \@partitioning,
+    );
+    command_output(
+        name        => 'mdadm',
+        options     => "--detail " . join(' ', @raid_arrays),
+        description => 'Verify raid configuration',
+        matches     => \@raid,
+    );
+}
+
+1;


### PR DESCRIPTION
Implement test module to validate RAID0/1/5/6/10 partitioning.

- Related ticket: https://progress.opensuse.org/issues/49196
- Needles: N/A
- Verification runs:
  - sle15sp1: 
    - [sle-15-SP1-raid0_validation@64bit](http://rivera-workstation.suse.cz/tests/2477)
    - [sle-15-SP1-RAID5@64bit](https://openqa.suse.de/tests/2771704)
    - [sle-15-SP1-raid0_validation@ppc64le](http://rivera-workstation.suse.cz/tests/2492)
    - [sle-15-SP1-RAID1@ppc64le](https://openqa.suse.de/tests/2771703)
    - [sle-15-SP1-RAID0@aarch64](http://rivera-workstation.suse.cz/tests/2513)
    - [sle-15-SP1-RAID10@aarch64](https://openqa.suse.de/tests/2771702)
    - [sle-15-SP1-Staging:C.x86_64](http://rivera-workstation.suse.cz/tests/2511)
  - sle12sp5:
    - [sle-12-SP5-Server-DVD-x86_64-Build0134-RAID0@64bit](http://rivera-workstation.suse.cz/tests/2495)
    - [sle-12-SP5-Server-RAID6@ppc64le](https://openqa.suse.de/tests/2771714)
    - [sle-12-SP5-RAID10@aarch64](http://rivera-workstation.suse.cz/tests/2507)
    - [sle-12-SP5-RAID0@aarch64](https://openqa.suse.de/tests/2771700)
  - opensuse:
    - [Tumbleweed-RAID0@64bit](http://rivera-workstation.suse.cz/tests/2481)
    - [Leap-15.1-RAID0@64bit](http://rivera-workstation.suse.cz/tests/2480)
    - [opensuse-Staging:L-Staging-DVD.x86_64](http://rivera-workstation.suse.cz/tests/2510)

Required setting: `INSTALLATION_VALIDATION=console/validate_raid`