### PR TITLE
Update for Tumbleweed JeOS

### DIFF
--- a/tests/console/java.pm
+++ b/tests/console/java.pm
@@ -58,7 +58,7 @@ sub run {
         else {
             diag "There are no java bootstrap packages";
             print "There are no java bootstrap packages\n";
-            zypper_call "in java-*";
+            zypper_call("in java-*", exitcode => [0, 107]);
         }
     }
 

--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -33,7 +33,7 @@ sub run() {
     }
     else {
         zypper_call("in dovecot", exitcode => [0, 102, 103]);
-        zypper_call("in postfix", exitcode => [0, 102, 103]) if is_jeos;
+        zypper_call("in --force-resolution postfix", exitcode => [0, 102, 103]) if is_jeos;
     }
 
     # configure dovecot


### PR DESCRIPTION
java.pm: The change is needed to ignore a post installation error in one of the scripts. The error is related to a repository path that doesn't exist and it doesn't affect the test.
evolution_prepare_server.pm: Installing postfix conflicts with emix. This change force installs it because postconf is not provided otherwise.

- Related ticket: https://progress.opensuse.org/issues/49859
- Verification run: http://ccret.suse.cz/tests/3234#
