### PR TITLE
xfstests: Solve upload kdump log issue and enable to upload vmcore file

### DIFF
--- a/tests/xfstests/generate_report.pm
+++ b/tests/xfstests/generate_report.pm
@@ -35,7 +35,8 @@ sub log_end {
 # Compress all sub directories under $dir and upload them.
 sub upload_subdirs {
     my ($dir, $timeout) = @_;
-    my $output = script_output("find $dir -maxdepth 1 -mindepth 1 -type f -or -type d");
+    my $output = script_output("if [ -d $dir ]; then find $dir -maxdepth 1 -mindepth 1 -type f -or -type d; else echo $dir folder not exist; fi");
+    if ($output =~ /folder not exist/) { return; }
     for my $subdir (split(/\n/, $output)) {
         my $tarball = "$subdir.tar.xz";
         assert_script_run("tar cJf $tarball -C $dir " . basename($subdir), $timeout);

--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -302,7 +302,7 @@ sub run {
         select_console('root-console');
         # Save kdump data to KDUMP_DIR if not set "NO_KDUMP"
         unless (get_var('NO_KDUMP')) {
-            unless (save_kdump($test, $KDUMP_DIR)) {
+            unless (save_kdump($test, $KDUMP_DIR, "vmcore", "kernel")) {
                 # If no kdump data found, write warning to log
                 my $msg = "Warning: $test crashed SUT but has no kdump data";
                 script_run("echo '$msg' >> $LOG_DIR/$category/$num");


### PR DESCRIPTION
Sometime during log upload, it will complain folder not exist and cause following upload step not do. This PR fix it in commit1. e.g. http://10.67.133.102/tests/804#step/generate_report/14

Also, in commit2, it enable to upload vmcore and kernel files in test result.

- Related ticket: https://progress.opensuse.org/issues/49868
- Verification run: http://10.67.133.102/tests/805
  Peaceful end and log contain kdump logs.