### PR TITLE
Reduce the timeout value to catch grub2 on time

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -192,7 +192,7 @@ sub boot_local_disk {
         # Currently the bootloader would bounce back to inst-bootmenu screen after pressing 'ret'
         # on 'local' menu-item, we have to check it and send 'ret' again to make booting properly
         my $counter = 3;
-        while (check_screen(['bootloader', 'inst-bootmenu'], 30) && $counter) {
+        while (check_screen(['bootloader', 'inst-bootmenu'], 3) && $counter) {
             record_info 'bounce back to inst-bootmenu, send ret again';
             send_key 'ret';
             wait_still_screen(1);


### PR DESCRIPTION
The timeout value for tag 'bootloader', 'inst-bootmenu' is 30s, sometimes system shows the grub2 but test can't catch grub2 for it is still blocked in checking the 'bootloader', 'inst-bootmenu'. I'd like to reduce the timeout value and add more times for checking for such issue, so it can catch grub2 on time if can't match tag 'bootloader', 'inst-bootmenu'.

- Related ticket: https://progress.opensuse.org/issues/49850
- Needles: N/A
- Verification run: no ppcle64 resource to verify.
