### PR TITLE
Fetch for NICMAC in run subrutine in ibft.pm

### DIFF
--- a/tests/installation/validation/ibft.pm
+++ b/tests/installation/validation/ibft.pm
@@ -28,7 +28,7 @@ my $ibft_expected = {
         subnet_mask => '255.255.255.0',
         gateway     => '10.0.2.2',
         ip_addr     => '10.0.2.15',
-        mac         => get_required_var('NICMAC'),
+        mac         => '',
     },
     initiator => {
         initiator_name => 'iqn.2010-04.org.ipxe:00000000-0000-0000-0000-000000000000',
@@ -107,6 +107,8 @@ sub run {
     my $self   = shift;
     my $reg_tx = qr/txdata_octets:\s+\d+/;
     my $reg_rx = qr/rxdata_octets:\s+\d+/;
+    # Requires NICTYPE=user and backend/qemu.pm code to run
+    $ibft_expected->{ethernet}->{mac} = get_required_var('NICMAC');
 
     select_console 'root-console';
     # find iscsi drive


### PR DESCRIPTION
- Related ticket: [poo#48401](https://progress.opensuse.org/issues/48401)
- Verification runs: 
* [sle-15-SP1-Installer-DVD-x86_64-Build200.1-iscsi_ibft@64bit](http://eris.suse.cz/tests/12929#step/ibft/57)
* [sle-12-SP5-Server-DVD-x86_64-Build0134-iscsi_ibft@64bit](http://eris.suse.cz/tests/12927#step/ibft/57)
