### PR TITLE
wicked: fixing issues after 975ce11

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -13,7 +13,7 @@
 package wickedbase;
 
 use base 'opensusebasetest';
-use utils qw(systemctl file_content_replace);
+use utils qw(systemctl file_content_replace zypper_call);
 use network_utils;
 use lockapi;
 use testapi qw(is_serial_terminal :DEFAULT);

--- a/tests/wicked/startandstop/sut/t04_bridge_ifup_remove_all_config_ifreload.pm
+++ b/tests/wicked/startandstop/sut/t04_bridge_ifup_remove_all_config_ifreload.pm
@@ -25,7 +25,7 @@ sub run {
     $self->get_from_data('wicked/ifcfg/br0',    $config);
     $self->get_from_data('wicked/ifcfg/dummy0', $dummy);
     $self->setup_bridge($config, $dummy, 'ifup');
-    assert_script_run('rm /etc/sysconfig/network/ifcfg-' . $ctx->iface() . "$config $dummy");
+    assert_script_run('rm /etc/sysconfig/network/ifcfg-' . $ctx->iface() . " $config $dummy");
     $self->wicked_command('ifreload', 'all');
     die if (ifc_exists('dummy0') || ifc_exists('br0'));
 }


### PR DESCRIPTION
wicked: fixing issues after 975ce11c948503ccd04f71ff9abc1df61feb6b44

verification runs : 
http://kimball.arch.suse.de/tests/756
http://kimball.arch.suse.de/tests/757
http://kimball.arch.suse.de/tests/758
http://kimball.arch.suse.de/tests/759