### PR TITLE
Fix is_boot_encrypted for grub_test on aarch64

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -454,7 +454,9 @@ sub is_boot_encrypted {
     # for Leap 42.3 and SLE 12 codestream the boot partition is not encrypted
     # Only aarch64 needs separate handling
     # ppc64le on pre-storage-ng boot was part of encrypted LVM
-    return 0 if !get_var('FULL_LVM_ENCRYPT') && !is_storage_ng && !get_var('OFW') && !check_var('ARCH', 'aarch64');
+    return 0 if !get_var('FULL_LVM_ENCRYPT') && !is_storage_ng && !get_var('OFW');
+    # SLES 15: we don't have scenarios for cryptlvm which boot partion is unencrypted.
+    return 0 if is_sle('15+') && !get_var('ENCRYPT');
     # If the encrypted disk is "just activated" it does not mean that the
     # installer would propose an encrypted installation again
     return 0 if get_var('ENCRYPT_ACTIVATE_EXISTING') && !get_var('ENCRYPT_FORCE_RECOMPUTE');


### PR DESCRIPTION
The problem with not booting from GRUB exists quite long time.
The reason for failure is send_key 'ret' not triggered at GRUB Menu.

We introduced new function 'is_boot_encrypted' in utils.pm 2 weeks ago:
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7115/

Related ticket: https://progress.opensuse.org/issues/49757

Verification test run:
http://f40.suse.de/tests/3167#step/grub_test/1 (SLES 12 SP5 cryptlvm@aarch64)
http://f40.suse.de/tests/3151#step/grub_test/5 (SLES 15 SP1 cryptlvm@64bit)
http://f40.suse.de/tests/3159#step/grub_test/1 (SLES 15 SP1 default@64bit)
http://f40.suse.de/tests/3165#step/grub_test/4 (TW lvm-full-encrypt@64bit)
