### PR TITLE
Fix validate_lvm_encrypt on aarch64+sle12

### DIFF
--- a/tests/console/validate_lvm_encrypt.pm
+++ b/tests/console/validate_lvm_encrypt.pm
@@ -17,6 +17,8 @@ use testapi;
 use utils;
 use y2logsstep;
 use Test::Assert ':all';
+use version_utils qw(is_aarch64 is_storage_ng);
+
 
 sub run {
     my $self              = shift;
@@ -81,10 +83,10 @@ sub run {
     }
 
     record_info('INFO', 'Check partitions');
-    if (get_var('NAME') =~ m/separate/) {
+    if ((get_var('NAME') =~ m/separate/) || is_aarch64 && !is_storage_ng) {    # Separate boot partition, not encrypted. aarch64+!storage_ng: see poo#49718
         assert_script_run q[df | grep -P "^\/dev\/.{3}\d{1}"| grep boot];
     }
-    else {
+    else {                                                                     # Encrypted boot partition with lvm
         assert_script_run q[df | grep -P "^\/dev/\mapper\/\w+"| grep boot];
     }
 }


### PR DESCRIPTION
On sle12+aarch64 (and only in that case), there is an EFI partition and no /boot/grub/<arch.-efi, it makes the test fail. See https://progress.opensuse.org/issues/49718#note-10

- Related ticket: https://progress.opensuse.org/issues/49718
- Verification run: https://openqa.suse.de/tests/2770373#step/validate_lvm_encrypt/129