### PR TITLE
Extend email test when mutt is installed

### DIFF
--- a/tests/x11/firefox/firefox_emaillink.pm
+++ b/tests/x11/firefox/firefox_emaillink.pm
@@ -32,14 +32,41 @@ sub run {
     send_key "alt-f";
     wait_still_screen 3;
     send_key "e";
-    unless (is_sle('15+')) {
-        assert_screen(['firefox-email_link-welcome', 'firefox-email-mutt'], 90);
-        if (match_has_tag('firefox-email-mutt')) {
-            # if evolution is not installed, e.g. when WE is not pressent, mutt in terminal is used poo#42500
-            $self->exit_firefox;
-            return;
+    assert_screen(['firefox-email_link-welcome', 'firefox-email-mutt'], 90);
+    if (match_has_tag('firefox-email-mutt')) {
+        if (is_sle('<=12-sp2')) {
+            record_soft_failure 'bsc#1131297';
         }
+        else {
+            send_key 'y';    # yes
+            sleep 1;
+            type_string "test\@suse.com\n";
+            sleep 1;
+            send_key 'home';      # beginning of subject
+            sleep 1;
+            send_key 'ctrl-k';    # delete existing subject
+            sleep 1;
+            type_string "test subject\n";
+            sleep 1;
+            send_key 'd';
+            sleep 1;
+            send_key 'd';
+            sleep 1;
+            send_key 'i';         # enter vim insert mode
+            sleep 1;
+            type_string "test email\n";
+            sleep 1;
+            send_key 'esc';       # escape insert mode
+            sleep 1;
+            save_screenshot;
+            type_string ":wq\n";
+            sleep 1;
+            assert_screen('mutt-send');
+            send_key 'y';
+        }
+    }
 
+    if (match_has_tag('firefox-email_link-welcome')) {
         send_key $next_key;
 
         wait_still_screen 3;
@@ -86,8 +113,8 @@ sub run {
 
         wait_still_screen 3;
         send_key "alt-a";
+        assert_screen('firefox-email_link-send');
     }
-    assert_screen('firefox-email_link-send');
     wait_screen_change {
         send_key "esc";
     };


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/42500
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1110
- Verification run:
[SLES12-SP1](http://10.100.12.155/tests/11121#step/firefox_emaillink/7)
[SLES12-SP2](http://10.100.12.155/tests/11122#step/firefox_emaillink/7)
[SLES12-SP3](http://10.100.12.155/tests/11123#step/firefox_emaillink/7)
[SLES12-SP4](http://10.100.12.155/tests/11124#step/firefox_emaillink/7)
[SLES15](http://10.100.12.155/tests/11125#step/firefox_emaillink/7)
[SLED12-SP3](http://10.100.12.155/tests/11128#step/firefox_emaillink/11)
[SLED15](http://10.100.12.155/tests/11129#step/firefox_emaillink/6)
