### PR TITLE
Add workaround for bsc#1129504

### DIFF
--- a/tests/installation/disable_grub_timeout.pm
+++ b/tests/installation/disable_grub_timeout.pm
@@ -44,7 +44,11 @@ sub run {
             send_key 'ret';
             return;
         }
-        record_info('Bootloader conf', 'Config bootloader should not be supported during upgrade', result => 'softfail');
+        if (!get_var('SOFTFAIL_1129504') && is_upgrade && is_sle) {
+            record_info('Bootloader conf', 'Workaround for bsc#1129504 grub2 timeout is too fast', result => 'softfail');
+            send_key 'alt-c';
+            return;
+        }
     }
     assert_screen([qw(inst-bootloader-settings inst-bootloader-settings-first_tab_highlighted)]);
     # Depending on an optional button "release notes" we need to press "tab"


### PR DESCRIPTION
Add the workaround to don't set 'timeout in seconds' = '-1' if not set variable SOFTFAIL_1129504. Use this  change we can verify bsc#1129504.

- Related ticket: https://progress.opensuse.org/issues/46577
- Needles: N/A
- Verification run: http://openqa-apac1.suse.de/tests/3774#step/disable_grub_timeout/16
