### PR TITLE
Call bootloader_more sub without $self

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -528,7 +528,7 @@ sub select_installation_source {
 }
 
 sub select_bootmenu_more {
-    my ($self, $tag, $more) = @_;
+    my ($tag, $more) = @_;
 
     my @params;
 


### PR DESCRIPTION
Fix for https://openqa.opensuse.org/tests/899494

The commit fixes the method to be called without using $self. The issue
appeared after refactoring of bootloader test module and moving the
method from opensusebasetest to bootloader_setup module.

- Verification run: http://oorlov-vm.qa.suse.de/tests/826
