### PR TITLE
Fix t key from "touch" cmd being eaten up

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -852,6 +852,9 @@ sub post_fail_hook {
     # see any interesting console logs.
     send_key 'esc';
     save_screenshot;
+    # the space prevents the esc from eating up the next alphanumerical
+    # character typed into the console
+    send_key 'spc';
 }
 
 1;


### PR DESCRIPTION
The `esc` will put bash into some command mode that will eat up the next character.
The `spc` will be sacrificed to prevent this.

Verification: http://artemis.suse.de/tests/1300#step/prepare_test_data/36