### PR TITLE
Fix for poo#49856, force 'graphical' taget in qam SLE12 ay profile.

### DIFF
--- a/data/autoyast_qam/12_installation.xml.ep
+++ b/data/autoyast_qam/12_installation.xml.ep
@@ -110,6 +110,9 @@
     </patterns>
   </software>
   <services-manager>
+    % if ($check_var->('DESKTOP', 'gnome')) {
+    <default_target>graphical</default_target>
+    % }
     <services>
       <disable config:type="list"/>
       <enable config:type="list">


### PR DESCRIPTION
Autoyast has wrong behaviour on older SLE wheen are changed services but
not set default target.

https://openqa.suse.de/tests/2778337#
https://openqa.suse.de/tests/2778272#