### PR TITLE
Add workaround for bsc#1124481

### DIFF
--- a/lib/y2_common.pm
+++ b/lib/y2_common.pm
@@ -18,11 +18,12 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
-use version_utils qw(is_opensuse is_leap);
+use version_utils qw(is_opensuse is_leap is_tumbleweed);
 
 our @EXPORT = qw(is_network_manager_default
   continue_info_network_manager_default
   accept_warning_network_manager_default
+  workaround_suppress_lvm_warnings
 );
 
 =head2 is_network_manager_default
@@ -52,6 +53,21 @@ sub accept_warning_network_manager_default {
         send_key $cmd{ok};
         assert_screen 'yast2_lan-global-tab';
         send_key $cmd{overview_tab};
+    }
+}
+
+=head2 workaround_suppress_lvm_warnings
+
+LVM is polluting stdout with leaked invocation warnings because of file descriptor 3 is assigned to /root/.bash_history.
+
+The workaround suppresses the warnings by setting the environment variable LVM_SUPPRESS_FD_WARNINGS.
+
+=cut
+
+sub workaround_suppress_lvm_warnings {
+    if (is_tumbleweed) {
+        record_soft_failure('bsc#1124481 - LVM is polluting stdout with leaked invocation warnings');
+        assert_script_run('export LVM_SUPPRESS_FD_WARNINGS=1');
     }
 }
 

--- a/tests/console/lvm_thin_check.pm
+++ b/tests/console/lvm_thin_check.pm
@@ -17,6 +17,7 @@ use base "opensusebasetest";
 use testapi;
 use utils;
 use y2logsstep;
+use y2_common 'workaround_suppress_lvm_warnings';
 
 sub run {
     my $self     = shift;
@@ -30,6 +31,7 @@ sub run {
 
     $self->select_serial_terminal;
     record_info('INFO', 'Print lvm setup');
+    workaround_suppress_lvm_warnings;
     assert_script_run 'lsblk';
     assert_script_run 'lvmdiskscan';
     assert_script_run 'lvscan';

--- a/tests/console/validate_lvm_encrypt.pm
+++ b/tests/console/validate_lvm_encrypt.pm
@@ -16,6 +16,7 @@ use base "opensusebasetest";
 use testapi;
 use utils;
 use y2logsstep;
+use y2_common 'workaround_suppress_lvm_warnings';
 use Test::Assert ':all';
 
 sub run {
@@ -30,6 +31,7 @@ sub run {
     };
 
     $self->select_serial_terminal;
+    workaround_suppress_lvm_warnings;
 
     record_info('INFO', 'Validate LVM config');
     assert_script_run "lvmconfig --mergedconfig --validate | grep \"LVM configuration valid.\"";


### PR DESCRIPTION
The PR adds workaround for Tumbleweed, where LVM is polluting stdout with leaked invocation warnings.

- Related ticket: [poo#47057](https://progress.opensuse.org/issues/47057)
- Verification run:
lvm_thin_provisioning: http://oorlov-vm.qa.suse.de/tests/828
validate_lvm_encrypt: http://oorlov-vm.qa.suse.de/tests/833
