### PR TITLE
Update rails test for JeOS

### DIFF
--- a/tests/console/rails.pm
+++ b/tests/console/rails.pm
@@ -14,9 +14,12 @@ use strict;
 use warnings;
 use base "consoletest";
 use testapi;
+use version_utils "is_jeos";
+use utils;
 
 sub run {
     select_console 'root-console';
+    zypper_call("in gcc make git zlib-devel ruby-devel sqlite3-devel nodejs") if is_jeos;
     # something like `test -f tmp/pids/server.pid; pumactl -P tmp/pids/server.pid stop; !test -f tmp/pids/server.pid`
     # is the correct test procedure on rails >= 5, for earlier versions we
     # need to handle this on our own
@@ -24,11 +27,12 @@ sub run {
 zypper -n in -C "rubygem(rails)"
 rails new mycoolapp --skip-bundle --skip-test
 cd mycoolapp
+bundle install
 (rails server -b 0.0.0.0 &)
 for i in {1..100} ; do sleep 0.1; curl -s http://localhost:3000 | grep "<title>Ruby on Rails" && break ; done
 pkill -f "rails server" || pumactl -P tmp/pids/server.pid stop
 EOF
-    assert_script_run($_) foreach (split /\n/, $cmd);
+    assert_script_run($_, timeout => 120) foreach (split /\n/, $cmd);
 }
 
 1;


### PR DESCRIPTION
There are a lot of headers that come from packages that are not in the image by default and also a few utilities needed for creating and starting the server. The change installs the packages and adds 'bundle install' to the list of commands.

- Related ticket: https://progress.opensuse.org/issues/49859
- Verification run: http://ccret.suse.cz/tests/3281#step/rails/2
