### PR TITLE
Rework exit handling in yast2 sw_single

### DIFF
--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -16,19 +16,61 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils qw(is_tumbleweed is_jeos is_sle);
+use version_utils qw(is_tumbleweed is_jeos is_sle is_leap);
+
+sub set_action {
+    my $action = shift;
+    return unless defined($action);
+    assert_script_run qq{sed -i 's/PKGMGR_ACTION_AT_EXIT=.*/PKGMGR_ACTION_AT_EXIT="$action"/' /etc/sysconfig/yast2};
+}
 
 sub run {
     my $self        = shift;
     my $pkgname     = get_var("PACKAGETOINSTALL_RECOMMENDED", "yast2-nfs-client");
     my $recommended = get_var("PACKAGETOINSTALL_RECOMMENDED", "nfs-client");
+    my $output;
+    my $y2_exit_action;
+    my $is_inr_package;
 
     select_console 'root-console';
-
     zypper_call "-i rm $pkgname $recommended";
     zypper_call "in yast2-packager";    # make sure yast2 sw_single module installed
+
+    # get package manager's exit action
+    if (!script_run 'test -f /etc/sysconfig/yast2') {
+        set_action(get_var('PKGMGR_ACTION_AT_EXIT'));
+        $output = script_output 'cat /etc/sysconfig/yast2';
+        if ($output =~ qr/PKGMGR_ACTION_AT_EXIT=\"(\w+)\"/) {
+            $y2_exit_action = $1;
+            record_info("Exit action", "PKGMGR_ACTION_AT_EXIT=$y2_exit_action");
+        } else {
+            die "No action found in PKGMGR_ACTION_AT_EXIT!\n";
+        }
+    } else {
+        die "Configuration file /etc/sysconfig/yast2 is missing!\n";
+    }
+
+    # check required automatic updates, it is not scanned on sle12 codestream
+    if (is_sle('>=15') || is_tumbleweed || is_leap('>=15.0') || is_jeos) {
+        $output = script_output('zypper -n inr -D --no-recommends');
+        my $zypper_regex = qr/The\s{1}following.*going\s{1}to\s{1}be\s{1}\w+:\s+([a-zA-Z0-9-_].*)/;
+        if ($output =~ $zypper_regex) {
+            $is_inr_package = !!$1;
+            record_info("Required", "$1");
+        }
+    }
+
     script_run("yast2 sw_single; echo y2-i-status-\$? > /dev/$serialdev", 0);
     assert_screen [qw(empty-yast2-sw_single yast2-preselected-driver)], 90;
+
+    # we need to change filter to Search, in case yast2 reports available automatic update
+    if ($is_inr_package) {
+        send_key 'alt-f';
+        wait_still_screen(stilltime => 2, timeout => 4, similarity_level => 50);
+        wait_screen_change { send_key 'home' };
+        send_key_until_needlematch 'yast2-sw_install-go-to-search', 'down';
+        wait_screen_change { send_key 'ret' };
+    }
 
     # Check disk usage widget for not showing subvolumes (bsc#949945)
     # on SLE12SP0 hidden subvolume isn't supported
@@ -51,16 +93,6 @@ sub run {
             wait_screen_change { send_key 'esc' };
         }
         wait_screen_change { send_key 'alt-p' };
-    }
-
-    # in new yast2 sw_install we need to change filter to Search
-    if (is_tumbleweed) {
-        assert_screen 'yast2-sw_install-locate-filter';
-        send_key 'alt-f';
-        wait_still_screen(stilltime => 2, timeout => 4, similarity_level => 50);
-        wait_screen_change { send_key 'home' };
-        send_key_until_needlematch 'yast2-sw_install-go-to-search', 'down';
-        wait_screen_change { send_key 'ret' };
     }
 
     # Testcase according to https://fate.suse.com/318099
@@ -94,18 +126,25 @@ sub run {
     }
     send_key "alt-a";        # accept
 
+    # Expect Automatic changes view
+    if (check_screen('yast2-sw_automatic-changes', 5)) {
+        wait_screen_change { send_key 'alt-o' };
+    }
     # Whether summary is shown depends on PKGMGR_ACTION_AT_EXIT in /etc/sysconfig/yast2
-    until (get_var('YAST_SW_NO_SUMMARY')) {
-        assert_screen ['yast2-sw-packages-autoselected', 'yast2-sw_automatic-changes', 'yast2-sw_shows_summary'], 60;
-        # automatic changes for manual selections
-        if (match_has_tag('yast2-sw-packages-autoselected') or match_has_tag('yast2-sw_automatic-changes')) {
-            wait_screen_change { send_key 'alt-o' };
-            next;
-        }
-        elsif (match_has_tag('yast2-sw_shows_summary')) {
-            wait_screen_change { send_key 'alt-f' };
-            last;
-        }
+    # Possible actions are:
+    #   close - just finish the package manager
+    #   restart - go back to the package manager, install/remove more packages
+    #   summary - display an installation summary dialog, there user can decide whether to finish or restart
+    if ($y2_exit_action =~ m/summary/) {
+        assert_screen 'yast2-sw_shows_summary';
+        wait_screen_change { send_key 'alt-f' };
+    } elsif ($y2_exit_action =~ m/restart/) {
+        assert_screen 'empty-yast2-sw_single';
+        wait_screen_change { send_key 'alt-c' };
+    } elsif ($y2_exit_action =~ m/close/) {
+        save_screenshot;
+    } else {
+        die "PKGMGR_ACTION_AT_EXIT possible actions (summary|restart|close)!\n";
     }
 
     wait_serial("y2-i-status-0", 120) || die "'yast2 sw_single' didn't finish";


### PR DESCRIPTION
Summary is show according to value of PKGMGR_ACTION_AT_EXIT in /etc/sysconfig/yast2. We would no longer need YAST_SW_NO_SUMMARY openQA variable.

- Related tickets: 
  * [[functional][y] Review the yast2_i module] 
                            (https://progress.opensuse.org/issues/49688)
  * [[aarch64][jeos][y] test fails in yast2_i](https://progress.opensuse.org/issues/49640)
- Needles: 
   * [o3](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/539)
   * [o3 - additional](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/543)
   * [osd](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1112)
   * [osd-jeos](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1115)
- Verification runs: 
    - jeos:
      * [sle-15-SP1-JeOS-for-kvm-and-xen-x86_64-Build34.37-jeos-main@uefi-virtio-vga](http://eris.suse.cz/tests/13419#step/yast2_i/1)   
      * [opensuse-15.1-JeOS-for-AArch64-aarch64-Build1.5-jeos@aarch64-HD24G](http://eris.suse.cz/tests/13420#step/yast2_i/1)
    - leap42.3
      * [default](http://eris.suse.cz/tests/13448#step/yast2_i/1)
      * [PKGMGR_ACTION_AT_EXIT=restart](http://eris.suse.cz/tests/13450#step/yast2_i/1)
      * [PKGMGR_ACTION_AT_EXIT=close](http://eris.suse.cz/tests/13449#step/yast2_i/1)
      * [PKGMGR_ACTION_AT_EXIT=summary](http://eris.suse.cz/tests/13451#step/yast2_i/1)
   - sle12sp5
     * [PKGMGR_ACTION_AT_EXIT=restart](http://eris.suse.cz/tests/13441#step/yast2_i/1)
     * [PKGMGR_ACTION_AT_EXIT=summary](http://eris.suse.cz/tests/13440#step/yast2_i/1)
     * [PKGMGR_ACTION_AT_EXIT=close](http://eris.suse.cz/tests/13444#step/yast2_i/1)
   * leap15.1
     * [default](http://eris.suse.cz/tests/13445#step/yast2_i/1)
     * [PKGMGR_ACTION_AT_EXIT=restart](http://eris.suse.cz/tests/13421#step/yast2_i/1)
     * [PKGMGR_ACTION_AT_EXIT=close](http://eris.suse.cz/tests/13423#step/yast2_i/1)
     * [PKGMGR_ACTION_AT_EXIT=summary](http://eris.suse.cz/tests/13424#step/yast2_i/1)
   * tw
     * [default](http://eris.suse.cz/tests/13432#step/yast2_i/1)
     * [PKGMGR_ACTION_AT_EXIT=close](http://eris.suse.cz/tests/13431#step/yast2_i/1)
     * [PKGMGR_ACTION_AT_EXIT=restart](http://eris.suse.cz/tests/13430#step/yast2_i/1)
     * [PKGMGR_ACTION_AT_EXIT=summary](http://eris.suse.cz/tests/13429#step/yast2_i/1)
   * sle15sp1
     * [default](http://eris.suse.cz/tests/13427#step/yast2_i/1)
     * [PKGMGR_ACTION_AT_EXIT=close](http://eris.suse.cz/tests/13426#step/yast2_i/1)
     * [PKGMGR_ACTION_AT_EXIT=restart](http://eris.suse.cz/tests/13425#step/yast2_i/1)
     * [PKGMGR_ACTION_AT_EXIT=summary](http://eris.suse.cz/tests/13428#step/yast2_i/1)
* [sle-15-SP1-Installer-DVD-x86_64-Build210.1-wsm+dev_tools+textmode@64bit](http://eris.suse.cz/tests/13374#step/yast2_i/1)




   

NOTE: Clean up *YAST_SW_NO_SUMMARY* in openQA