### PR TITLE
susedistribution: Fix wrong parameter in is_leap() and changed the condition to is_opensuse

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -14,7 +14,7 @@ use utils qw(
   type_string_very_slow
   zypper_call
 );
-use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x is_tumbleweed);
+use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x is_tumbleweed is_opensuse);
 use x11utils qw(desktop_runner_hotkey ensure_unlocked_desktop);
 use Utils::Backends 'use_ssh_serial_console';
 
@@ -308,7 +308,7 @@ sub ensure_installed {
     }
     wait_still_screen 1;
     send_key("alt-f4");    # close xterm
-    assert_screen 'generic-desktop' if is_tumbleweed || is_leap('=>15.1');
+    assert_screen 'generic-desktop' if is_opensuse;
 }
 
 sub script_sudo {


### PR DESCRIPTION
Fix regression in 02092d5a32c3019cd2d6cf728b9635a4f03660e1, => is a wrong parameter, correct it to >=. According the poo ticket, that assert_screen() should apply to all openSUSE cases, changed the
condition to is_opensuse instead.

- Related ticket: https://progress.opensuse.org/issues/49988
- See also: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7211