### PR TITLE
Improve post_fail_hook of force_schedule_tasks

### DIFF
--- a/tests/console/force_scheduled_tasks.pm
+++ b/tests/console/force_scheduled_tasks.pm
@@ -61,4 +61,12 @@ sub test_flags {
     return {milestone => 1, fatal => 1};
 }
 
+
+sub post_fail_hook {
+    my $self = shift;
+    $self->SUPER::post_fail_hook();
+    $self->export_logs();
+    $self->export_logs_locale();
+}
+
 1;


### PR DESCRIPTION
Now exporting more hopefully useful logs

- Related ticket: https://progress.opensuse.org/issues/49763
- Verification run: https://openqa.suse.de/tests/2787042

