### PR TITLE
Fix end session of the tests (closing xterm at the end)

### DIFF
--- a/tests/x11/exiv2.pm
+++ b/tests/x11/exiv2.pm
@@ -107,7 +107,7 @@ sub run {
     # clean-up
     assert_script_run "rm 20190201_154421.jpg";
     assert_script_run "rm 20190201_154421-preview1.jpg";
-    type_string "exit\n";
+    send_key "alt-f4";
 }
 
 1;


### PR DESCRIPTION
    Related ticket: https://progress.opensuse.org/issues/50063
    Fix end part of the exiv2 test closing xterm, which was affecting other tests.

    No changes in needles. 

    Verification run: http://10.161.229.244/tests/341