### PR TITLE
Apply declarative scheduling for staging group tests

### DIFF
--- a/schedule/cryptlvm_minimal_x.yaml
+++ b/schedule/cryptlvm_minimal_x.yaml
@@ -1,0 +1,60 @@
+---
+name:           cryptlvm_minimal_x
+description:    >
+  Combination of "cryptlvm" and "minimal_x" for sle12.
+  (crypt-)LVM installations can take longer,
+  especially on non-x86_64 architectures.
+vars:
+  ENCRYPT: 1  
+  LVM: 1
+  MAX_JOB_TIME: 14400
+schedule:
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/encrypt_lvm
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/change_desktop
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/boot_encrypt
+  - installation/first_boot
+  - console/system_prepare
+  - console/check_network
+  - console/system_state
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - locale/keymap_or_locale
+  - console/force_scheduled_tasks
+  - console/textinfo
+  - console/hostname
+  - console/installation_snapshots
+  - console/xorg_vt
+  - console/zypper_lr
+  - console/zypper_ref
+  - console/ncurses
+  - console/yast2_lan
+  - console/curl_https
+  - console/glibc_sanity
+  - console/zypper_in
+  - console/yast2_i
+  - console/yast2_bootloader
+  - console/vim
+  - console/sshd
+  - console/ssh_cleanup
+  - console/mtab
+  - console/orphaned_packages_check
+  - console/consoletest_finish

--- a/schedule/default_install.yaml
+++ b/schedule/default_install.yaml
@@ -1,24 +1,15 @@
 ---
-name:           RAID1
+name:           default_install
 description:    >
-  Test for RAID1
-  Installation of RAID1 using expert partitioner.
-vars:
-  RAIDLEVEL: 1
-conditional_schedule:
-    system_role:
-        SYSTEM_ROLE:
-            default:
-                - installation/system_role
+  Test for default installation, with default options.
 schedule:
-  - installation/bootloader_start
+  - installation/bootloader
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
   - installation/addon_products_sle
-  - {{system_role}}
+  - installation/system_role
   - installation/partitioning
-  - installation/partitioning_raid
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/hostname_inst
@@ -33,8 +24,3 @@ schedule:
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot
-  - console/hostname
-  - console/system_prepare
-  - console/force_scheduled_tasks
-  - shutdown/grub_set_bootargs
-  - console/validate_raid

--- a/schedule/ext4.yaml
+++ b/schedule/ext4.yaml
@@ -38,6 +38,7 @@ schedule:
   - installation/installer_timezone
   - installation/user_settings
   - installation/user_settings_root
+  - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install

--- a/schedule/gnome.yaml
+++ b/schedule/gnome.yaml
@@ -1,0 +1,69 @@
+---
+name:           gnome
+description:    >
+  The standard scenario where we mainly just follow installation
+  suggestions without any adjustments as long as the default desktop is gnome.
+vars:
+  MAX_JOB_TIME: 10800
+schedule:
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - console/check_network
+  - console/system_state
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - locale/keymap_or_locale
+  - console/force_scheduled_tasks
+  - console/textinfo
+  - console/hostname
+  - console/installation_snapshots
+  - console/xorg_vt
+  - console/zypper_lr
+  - console/zypper_ref
+  - console/ncurses
+  - console/yast2_lan
+  - console/curl_https
+  - console/glibc_sanity
+  - console/zypper_in
+  - console/yast2_i
+  - console/yast2_bootloader
+  - console/vim
+  - console/sshd
+  - console/ssh_cleanup
+  - console/mtab
+  - console/orphaned_packages_check
+  - console/consoletest_finish
+  - x11/desktop_runner
+  - x11/xterm
+  - locale/keymap_or_locale_x11
+  - x11/sshxterm
+  - x11/gnome_control_center
+  - x11/gnome_terminal
+  - x11/gedit
+  - x11/firefox
+  - x11/yast2_snapper
+  - x11/glxgears
+  - x11/nautilus
+  - x11/desktop_mainmenu
+  - x11/reboot_gnome
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown

--- a/schedule/installcheck.yaml
+++ b/schedule/installcheck.yaml
@@ -1,0 +1,8 @@
+---
+name:           installcheck
+description:    >
+  Development support test. Execute the so called "installcheck" to
+  check for package dependencies.
+schedule:
+  - installation/rescuesystem
+  - installation/installcheck

--- a/schedule/migration_zdup_offline_sle12sp2.yaml
+++ b/schedule/migration_zdup_offline_sle12sp2.yaml
@@ -1,0 +1,14 @@
+---
+name:           migration_zdup_offline_sle12sp2_staging
+description:    >
+  Test for zdup on sle12sp2 at staging.
+vars:
+  HDDVERSION: 12-SP2
+  ZDUP: 1
+schedule:
+  - installation/setup_zdup
+  - installation/install_service
+  - installation/zdup
+  - installation/post_zdup
+  - boot/boot_to_desktop
+  - console/check_upgraded_service

--- a/schedule/minimal+base.yaml
+++ b/schedule/minimal+base.yaml
@@ -75,7 +75,7 @@ schedule:
   - installation/installer_timezone
   - installation/user_settings
   - installation/user_settings_root
-  - installation/installation_overview_before
+  - installation/resolve_dependency_issues
   - installation/select_patterns_and_packages
   - installation/installation_overview
   - installation/disable_grub_timeout

--- a/schedule/rescue_system_sle11sp4.yaml
+++ b/schedule/rescue_system_sle11sp4.yaml
@@ -1,0 +1,10 @@
+---
+name:           rescue_system_sle11sp4
+description:    >
+  Boot installation medium into rescue mode and test mounting
+  a SLES 11 SP4 installation.
+vars:
+  RESCUESYSTEM: 1
+schedule:
+  - installation/rescuesystem
+  - installation/rescuesystem_validate_sle

--- a/schedule/sles4sap_offline_gnome.yaml
+++ b/schedule/sles4sap_offline_gnome.yaml
@@ -1,0 +1,41 @@
+---
+name:           sles4sap_offline_gnome
+description:    >
+  Graphical installation tests for SLES for SAP Applications without
+  SCC registration. Boot into Gnome.
+  Test SLES for SAP specific applications.
+vars:
+  APPTESTS: sles4sap/patterns,sles4sap/sapconf,sles4sap/saptune
+  DM_NEEDS_USERNAME: 1
+  HDDSIZEGB: 60
+  ROOTONLY: 1
+  SCC_REGISTER: never
+  SCC_URL:
+  SHUTDOWN_NEEDS_AUTH: 0
+  SLES4SAP_MODE: sles4sap
+  SLE_PRODUCT: sles4sap
+  SYSTEM_ROLE: default
+  WORKAROUND_MODULES: base,desktop,sapapp,serverapp,ha
+schedule:
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - sles4sap_product_installation_mode
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - sles4sap/patterns
+  - sles4sap/sapconf
+  - sles4sap/saptune


### PR DESCRIPTION
yaml files added for scheduling on staging. 


- Related ticket: https://progress.opensuse.org/issues/49064
- Needles: N/A
- Verification run: 
[default_install sle15](http://aquarius.suse.cz/tests/943)	
[ext4 sle15](http://aquarius.suse.cz/tests/941)
[gnome sle15](http://aquarius.suse.cz/tests/594)
[installcheck sle15](http://aquarius.suse.cz/tests/940)
[rescue_system sle15](http://aquarius.suse.cz/tests/944)
[cryptlvm_minimal_x](http://aquarius.suse.cz/tests/945)