### PR TITLE
Increase timeout value for tag addon-products-nonempty

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -93,7 +93,7 @@ sub handle_all_packages_medium {
     my $counter           = 2 + (scalar @addons_license_tags);
     my $addon_license_num = 0;
     while ($counter--) {
-        assert_screen([qw(addon-products-nonempty sle-product-license-agreement)], 60);
+        assert_screen([qw(addon-products-nonempty sle-product-license-agreement)], 180);
         last if (match_has_tag 'addon-products-nonempty');
         if (match_has_tag 'sle-product-license-agreement') {
             if (@addons_license_tags && check_screen(\@addons_license_tags, 30)) {


### PR DESCRIPTION
Sometimes the timeout value 60s is not enough when running on slow arches such as aarch64, so increase it to 180s.

- Related ticket: https://progress.opensuse.org/issues/50159
- Needles: N/A
- Verification run: Can't reproduce on local worker.
