### PR TITLE
Service check before and after migration

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -1,0 +1,71 @@
+package service_check;
+use base Exporter;
+use Exporter;
+use testapi;
+use utils;
+use base 'opensusebasetest';
+use strict;
+use warnings;
+
+our @EXPORT = qw(
+  $default_services
+  install_services
+  check_services
+);
+
+our $default_services = {
+    susefirewall => {
+        srv_pkg_name  => 'SuSEfirewall2',
+        srv_proc_name => 'SuSEfirewall2',
+        support_ver   => '12-SP3,12-SP4'
+    },
+    firewall => {
+        srv_pkg_name  => 'firewalld',
+        srv_proc_name => 'firewalld.service',
+        support_ver   => '15,15-SP1'
+    },
+    ntp => {
+        srv_pkg_name  => 'ntp',
+        srv_proc_name => 'ntpd',
+        support_ver   => '12-SP3,12-SP4'
+    },
+    chrony => {
+        srv_pkg_name  => 'chrony',
+        srv_proc_name => 'chronyd',
+        support_ver   => '15,15-SP1'
+    },
+    postfix => {
+        srv_pkg_name  => 'postfix',
+        srv_proc_name => 'postfix',
+        support_ver   => '12-SP3,12-SP4,15'
+    },
+};
+
+sub install_services {
+    my $service = shift;
+    foreach my $s (keys %$service) {
+        my $srv_pkg_name  = $service->{$s}->{srv_pkg_name};
+        my $srv_proc_name = $service->{$s}->{srv_proc_name};
+        my $support_ver   = $service->{$s}->{support_ver};
+        if (grep { $_ eq get_var('HDDVERSION') } split(',', $support_ver)) {
+            zypper_call("in $srv_pkg_name");
+            assert_script_run 'systemctl enable ' . $srv_proc_name;
+            assert_script_run 'systemctl start ' . $srv_proc_name;
+        }
+    }
+}
+
+sub check_services {
+    my $service = shift;
+    foreach my $s (keys %$service) {
+        my $srv_proc_name = $service->{$s}->{srv_proc_name};
+        my $support_ver   = $service->{$s}->{support_ver};
+        if (grep { $_ eq get_var('HDDVERSION') } split(',', $support_ver)) {
+            assert_script_run 'systemctl status '
+              . $srv_proc_name
+              . ' --no-pager | grep active';
+        }
+    }
+}
+
+1;

--- a/tests/console/check_upgraded_service.pm
+++ b/tests/console/check_upgraded_service.pm
@@ -15,6 +15,9 @@ use testapi;
 use strict;
 use warnings;
 use utils 'systemctl';
+use service_check;
+use version_utils 'is_sle';
+use main_common 'is_desktop';
 
 sub run {
     select_console 'root-console';
@@ -22,6 +25,11 @@ sub run {
     systemctl 'status vsftpd';
     save_screenshot;
     assert_script_run 'systemctl status vsftpd --no-pager | grep active';
+    check_services($default_services) if (is_sle && !is_desktop && !get_var('MEDIA_UPGRADE') && !get_var('ZDUP') && !get_var('INSTALLONLY'));
+}
+
+sub test_flags {
+    return {fatal => 0};
 }
 
 1;

--- a/tests/installation/install_service.pm
+++ b/tests/installation/install_service.pm
@@ -22,6 +22,9 @@ use warnings;
 use base 'installbasetest';
 use testapi;
 use utils 'systemctl', 'zypper_call';
+use service_check;
+use version_utils 'is_sle';
+use main_common 'is_desktop';
 
 sub run {
 
@@ -31,6 +34,13 @@ sub run {
     systemctl 'status vsftpd';
     save_screenshot;
     assert_script_run 'systemctl status vsftpd --no-pager | grep active';
+
+    install_services($default_services) if (is_sle && !is_desktop && !get_var('MEDIA_UPGRADE') && !get_var('ZDUP') && !get_var('INSTALLONLY'));
+    check_services($default_services)   if (is_sle && !is_desktop && !get_var('MEDIA_UPGRADE') && !get_var('ZDUP') && !get_var('INSTALLONLY'));
+}
+
+sub test_flags {
+    return {fatal => 0};
 }
 
 1;


### PR DESCRIPTION
Add service check before and after migration, only check with systemctl status.

    Related ticket: https://progress.opensuse.org/issues/49472
    Needles: n/a
    Verification run: http://10.67.17.238/tests/174# You can see install_service & check_upgraded_service both start work