### PR TITLE
kdump: Modify memory reserve in aarch64 and ppc64le

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -113,7 +113,13 @@ sub activate_kdump {
 
 sub activate_kdump_without_yast {
     # activate kdump by grub, need a reboot to start kdump
-    my $cmd = "if [ -e /etc/default/grub ]; then sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT/ s/\"\$/ crashkernel=256M,high crashkernel=128M,low \"/' /etc/default/grub; fi";
+    my $cmd = "";
+    if (check_var('ARCH', 'ppc64le') || check_var('ARCH', 'aarch64')) {
+        $cmd = "if [ -e /etc/default/grub ]; then sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT/ s/\"\$/ crashkernel=256M \"/' /etc/default/grub; fi";
+    }
+    else {
+        $cmd = "if [ -e /etc/default/grub ]; then sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT/ s/\"\$/ crashkernel=256M,high crashkernel=128M,low \"/' /etc/default/grub; fi";
+    }
     script_run($cmd);
     script_run('cat /etc/default/grub');
     # sync changes from /etc/default/grub into /boot/grub2/grub.cfg


### PR DESCRIPTION
aarch64 and ppc64le new may have RAM reserve error when setting kdump with two level RAM. (Seems they only support fix RAM in one number).
They fails like this:
  https://openqa.suse.de/tests/2789058#step/enable_kdump/52
Shows: "Please reserve memory by passing crashkernel=X@Y parameter to kernel"

- Related ticket: https://progress.opensuse.org/issues/50174
- Verify run: http://10.67.133.102/tests/814 (Actually don't have aarch to run this verify, but it'll not influence x86_64 as shown)