### PR TITLE
Enable sysauth sssd for sles

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1594,7 +1594,7 @@ sub load_extra_tests_console {
     loadtest 'console/vhostmd';
     loadtest 'console/rpcbind' unless is_jeos;
     # sysauth test scenarios run in the console
-    loadtest "sysauth/sssd" if get_var('SYSAUTHTEST');
+    loadtest "sysauth/sssd" if get_var('SYSAUTHTEST') || is_sle('12-SP5+');
     loadtest 'console/timezone';
     loadtest 'console/procps';
     loadtest "console/lshw" if ((is_sle('15+') && (check_var('ARCH', 'ppc64le') || check_var('ARCH', 'x86_64'))) || is_opensuse);


### PR DESCRIPTION
see related ticket:
https://progress.opensuse.org/issues/33082
test verification run:
http://f40.suse.de/tests/3359 (sles 15)
http://f40.suse.de/tests/3339 (sles 12)
http://f40.suse.de/tests/3347 (leap)
we still have problem with sssd for sles 12,
but this is another issue reported: bsc#1131989