### PR TITLE
Prevent race condition poo#48947

### DIFF
--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -19,9 +19,10 @@ use testapi;
 use utils;
 use y2lan_restart_common;
 use version_utils ':VERSION';
-use utils 'zypper_call';
+
 
 sub handle_Networkmanager_controlled {
+    assert_screen "Networkmanager_controlled";
     send_key "ret";    # confirm networkmanager popup
     assert_screen "Networkmanager_controlled-approved";
     send_key "alt-c";
@@ -49,23 +50,23 @@ sub run {
     script_run('ls -alF /etc/sysconfig/network/');
     save_screenshot;
 
+    my $is_nm = !script_run("! systemctl is-active NetworkManager");    # Revert boolean because of bash vs perl's return code.
+
     script_run("yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev", 0);
 
-    assert_screen [qw(Networkmanager_controlled yast2_lan install-susefirewall2 install-firewalld dhcp-popup)], 120;
-    handle_dhcp_popup;
-    if (match_has_tag('Networkmanager_controlled')) {
+    if ($is_nm) {
         handle_Networkmanager_controlled;
-        return;    # don't change any settings
+        return;                                                         # don't change any settings
     }
+
+    assert_screen [qw(yast2_lan install-susefirewall2 install-firewalld dhcp-popup)], 120;
+    handle_dhcp_popup;
+
     if (match_has_tag('install-susefirewall2') || match_has_tag('install-firewalld')) {
         # install firewall
         send_key "alt-i";
         # check yast2_lan again after firewall is installed
-        assert_screen [qw(Networkmanager_controlled yast2_lan)], 90;
-        if (match_has_tag('Networkmanager_controlled')) {
-            handle_Networkmanager_controlled;
-            return;
-        }
+        assert_screen('yast2_lan', 90);
     }
 
     my $hostname = get_var('HOSTNAME', 'susetest');
@@ -77,14 +78,15 @@ sub run {
     send_key "tab";
     for (1 .. 15) { send_key "backspace" }
     type_string $hostname;
+
     # Starting from SLE 15 SP1, we don't have domain field
     if (is_sle('<=15') || is_leap('<=15.0')) {
         send_key "tab";
         for (1 .. 15) { send_key "backspace" }
         type_string $domain;
     }
-    assert_screen 'test-yast2_lan-1';
 
+    assert_screen 'test-yast2_lan-1';
     send_key "alt-o";    # OK=>Save&Exit
     wait_serial("yast2-lan-status-0", 180) || die "'yast2 lan' didn't finish";
     wait_still_screen;


### PR DESCRIPTION
Fix a rare race condition in which the wrong needle gets detected, see ticket.

- Related ticket: https://progress.opensuse.org/issues/48947
- Verification run: 
[TW/NM](http://amazing.suse.cz/tests/5960)
[TW/Wicked](http://amazing.suse.cz/tests/5957)
[SLE12/Wicked](http://amazing.suse.cz/tests/5956)

