### PR TITLE
Turn off screensaver before check

### DIFF
--- a/tests/x11/yast2_snapper.pm
+++ b/tests/x11/yast2_snapper.pm
@@ -24,12 +24,16 @@ use x11utils 'turn_off_gnome_screensaver';
 
 sub run {
     my $self = shift;
+    # Turn off screensaver
+    x11_start_program('xterm');
+    turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
+    send_key("alt-f4");    # close xterm
+
     # Make sure yast2-snapper is installed (if not: install it)
     ensure_installed "yast2-snapper";
 
     # Start an xterm as root
     x11_start_program('xterm');
-    turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
     become_root;
     script_run "cd";
     type_string "yast2 snapper\n";


### PR DESCRIPTION
The issue seems happen within ensure_installed "yast2-snapper", base the test result you can see the screen saver already start so lead the case failed(alt+f2 can not take effect), so we need close screensaver before ensure-installed moudule. This issue can not easy reproduce, so validation link just make sure the code is workable.

- Related ticket: https://progress.opensuse.org/issues/45113
- Needles: na
- Verification run: http://10.67.17.238/tests/209#step/yast2_snapper/1
