### PR TITLE
Remove code duplication for enabling DVD repositories

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -39,6 +39,7 @@ our @EXPORT = qw(
   unlock_if_encrypted
   get_netboot_mirror
   zypper_call
+  zypper_enable_install_dvd
   zypper_ar
   fully_patch_system
   ssh_fully_patch_system
@@ -400,6 +401,13 @@ sub zypper_call {
         die "'zypper -n $command' failed with code $ret";
     }
     return $ret;
+}
+
+sub zypper_enable_install_dvd {
+    # If DVD Packages is used we need to (re-)enable the local repos
+    # see FATE#325541
+    zypper_call 'mr -e -l' if is_sle('15+') and get_var('ISO_1', '') =~ /SLE-.*-Packages-.*\.iso/;
+    zypper_call 'ref';
 }
 
 sub zypper_ar {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -39,6 +39,7 @@ our @EXPORT = qw(
   unlock_if_encrypted
   get_netboot_mirror
   zypper_call
+  zypper_ar
   fully_patch_system
   ssh_fully_patch_system
   minimal_patch_system
@@ -71,7 +72,6 @@ our @EXPORT = qw(
   shorten_url
   reconnect_mgmt_console
   set_hostname
-  zypper_ar
   show_tasks_in_blocked_state
   svirt_host_basedir
   prepare_ssh_localhost_key_login
@@ -400,6 +400,13 @@ sub zypper_call {
         die "'zypper -n $command' failed with code $ret";
     }
     return $ret;
+}
+
+sub zypper_ar {
+    my ($url, $name) = @_;
+
+    zypper_call("ar $url $name",                           dumb_term => 1);
+    zypper_call("--gpg-auto-import-keys ref --repo $name", dumb_term => 1);
 }
 
 sub fully_patch_system {
@@ -971,13 +978,6 @@ sub reconnect_mgmt_console {
     else {
         diag 'nothing special needed to reconnect management console';
     }
-}
-
-sub zypper_ar {
-    my ($url, $name) = @_;
-
-    zypper_call("ar $url $name",                           dumb_term => 1);
-    zypper_call("--gpg-auto-import-keys ref --repo $name", dumb_term => 1);
 }
 
 sub show_tasks_in_blocked_state {

--- a/tests/autoyast/repos.pm
+++ b/tests/autoyast/repos.pm
@@ -26,9 +26,7 @@ sub run {
     # sles12_minimal.xml profile does not install "ip"
     assert_script_run 'ip a || ifstatus all';
     pkcon_quit;
-    # Enable local repositories if needed
-    zypper_call 'mr -el';    # Returns 0 even if repos are already enabled
-    zypper_call 'ref';
+    zypper_enable_install_dvd;
     # make sure that save_y2logs from yast2 package, tar and bzip2 are installed
     # even on minimal system
     zypper_call 'in yast2 tar bzip2';

--- a/tests/console/zypper_ref.pm
+++ b/tests/console/zypper_ref.pm
@@ -16,17 +16,12 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
-use utils 'zypper_call';
+use utils qw(zypper_call zypper_enable_install_dvd);
 use version_utils 'is_sle';
 
 sub run {
     select_console 'root-console';
-
-    # see FATE#325541
-    zypper_call 'mr -e -l'
-      if is_sle('15+')
-      and get_var('ISO_1', '') =~ /SLE-.*-Packages-.*\.iso/;
-
+    zypper_enable_install_dvd;
     zypper_call '--gpg-auto-import-keys ref';
 }
 

--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -32,11 +32,7 @@ sub run {
 
     my $base_pattern = is_sle('>=15') ? 'patterns-server-enterprise-sap_server' : 'patterns-sles-sap_server';
 
-    # If DVD Packages is used we need to (re-)enable the local repos
-    zypper_call 'mr -e -l'
-      if is_sle('15+')
-      and get_var('ISO_1', '') =~ /SLE-.*-Packages-.*\.iso/;
-
+    zypper_enable_install_dvd;
     # First check pattern sap_server which is installed by default in SLES4SAP
     # when 'SLES for SAP Applications' system role is selected
     $output = script_output("zypper info -t pattern sap_server");


### PR DESCRIPTION
While working on #6847 @rwx788 and I noticed that there's some code duplicated, so this is the follow up.

As an idea I might create later Lib::Utils::Zypper and move zypper related functions there, in an attempt to clean up a bit the lib/utils.pm

- [AUTOYAST=1](https://openqa.suse.de/tests/2794244)
- [SLES4SAP](https://openqa.suse.de/tests/2794296)
- [Tumbleweed](https://openqa.opensuse.org/tests/903835)
- [Leap](https://openqa.opensuse.org/t903886)