### PR TITLE
Wait for boot cycle to start after node fencing

### DIFF
--- a/tests/ha/fencing.pm
+++ b/tests/ha/fencing.pm
@@ -27,6 +27,16 @@ sub run {
 
     # Fence the master node
     assert_script_run 'crm -F node fence ' . get_node_to_join if is_node(2);
+
+    # Wait for fencing to start only if running in get_node_to_join
+    if (get_hostname eq get_node_to_join) {
+        my $loop_count = 30;    # Wait at most for 30*5 seconds
+        while (check_screen('root-console', 0, no_wait => 1)) {
+            sleep 5;
+            $loop_count--;
+            last if !$loop_count;
+        }
+    }
 }
 
 1;

--- a/tests/ha/fencing.pm
+++ b/tests/ha/fencing.pm
@@ -30,9 +30,9 @@ sub run {
 
     # Wait for fencing to start only if running in get_node_to_join
     if (get_hostname eq get_node_to_join) {
-        my $loop_count = 30;    # Wait at most for 30*5 seconds
+        my $loop_count = 120;    # Wait at most for 120 seconds
         while (check_screen('root-console', 0, no_wait => 1)) {
-            sleep 5;
+            sleep 1;
             $loop_count--;
             last if !$loop_count;
         }


### PR DESCRIPTION
During HA cluster tests, one of the nodes fences the other causing it to reboot. Until now this has been handled by loading the boot test modules after `ha/fencing` to handle the booting process before continuing the HA tests, but on occasions it is possible for the fencing action to take longer to be applied in the node, causing a timeout failure in `boot/boot_to_desktop` which has a timeout ranging from 80 to 140 seconds to wait for the grub2 or the boot screen.

This commit forces `ha/fencing` to wait until the `root-console` screen is gone from the fenced node before continuing into the boot tests, allowing the boot tests to actually only wait for the different booting screens.

- Related ticket: N/A
- Needles: N/A
- Failing tests: https://openqa.suse.de/tests/2793762#step/boot_to_desktop#1/2, https://openqa.suse.de/tests/2793695#step/boot_to_desktop#1/2, https://openqa.suse.de/tests/2793698#step/boot_to_desktop#1/2, https://openqa.suse.de/tests/2786671#step/boot_to_desktop#1/2
- Verification run: TBA
