### PR TITLE
Replace get_node_to_join with HA_CLUSTER_INIT

### DIFF
--- a/tests/ha/fencing.pm
+++ b/tests/ha/fencing.pm
@@ -28,7 +28,7 @@ sub run {
     # Fence the master node
     assert_script_run 'crm -F node fence ' . get_node_to_join if is_node(2);
 
-    # Wait for fencing to start only if running in get_node_to_join
+    # Wait for fencing to start only if running in the master node
     if (get_var('HA_CLUSTER_INIT')) {
         my $loop_count = 120;    # Wait at most for 120 seconds
         while (check_screen('root-console', 0, no_wait => 1)) {

--- a/tests/ha/fencing.pm
+++ b/tests/ha/fencing.pm
@@ -29,7 +29,7 @@ sub run {
     assert_script_run 'crm -F node fence ' . get_node_to_join if is_node(2);
 
     # Wait for fencing to start only if running in get_node_to_join
-    if (get_hostname eq get_node_to_join) {
+    if (get_var('HA_CLUSTER_INIT')) {
         my $loop_count = 120;    # Wait at most for 120 seconds
         while (check_screen('root-console', 0, no_wait => 1)) {
             sleep 1;


### PR DESCRIPTION
This is related to #7243.

The method `get_node_to_join()` is not usable in the master node as it requires the variable `HA_CLUSTER_JOIN` which should not be defined in master node tests. This instead will check with
`get_var('HA_CLUSTER_INIT')` which is the variable partnered to `HA_CLUSTER_JOIN` for the master node.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://1b147.qa.suse.de/tests/5290
