### PR TITLE
Add soft fail for bsc#1132123

### DIFF
--- a/tests/ha/check_logs.pm
+++ b/tests/ha/check_logs.pm
@@ -29,7 +29,7 @@ sub run {
     ha_export_logs;
 
     # Looking for segfault during the test
-    assert_script_run '(( $(grep -sR segfault /var/log | wc -l) == 0 ))';
+    record_soft_failure "bsc#1132123" if (script_run '(( $(grep -sR segfault /var/log | wc -l) == 0 ))');
 }
 
 # Specific test_flags for this test module


### PR DESCRIPTION
Bug has been opened for when segfault is detected in `ha/check_logs`. This PR adds a soft fail referencing the bug in the code.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1132123
- Needles: N/A
- Verification run: N/A
