### PR TITLE
publiccloud: Add instance type to influxdb

### DIFF
--- a/tests/publiccloud/ipa.pm
+++ b/tests/publiccloud/ipa.pm
@@ -82,6 +82,7 @@ sub run {
             my $data = {
                 table => 'bootup',
                 tags  => {
+                    instance_type     => get_required_var('PUBLIC_CLOUD_INSTANCE_TYPE'),
                     os_flavor         => get_required_var('FLAVOR'),
                     os_version        => get_required_var('VERSION'),
                     os_build          => get_required_var('BUILD'),


### PR DESCRIPTION
The bootuptime depends also on the machine type, so we store the
PUBLIC_CLOUD_INSTANCE_TYPE related to bootup timeings.

-  Verification run: http://cfconrad-vm.qa.suse.de/tests/3856
