### PR TITLE
Enable yast2-bootloader in y2uitest_gui extratest

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -118,6 +118,7 @@ our @EXPORT = qw(
   unregister_needle_tags
   updates_is_applicable
   we_is_applicable
+  load_extra_tests_y2uitest_gui
 );
 
 sub init_main {

--- a/tests/yast2_gui/yast2_bootloader.pm
+++ b/tests/yast2_gui/yast2_bootloader.pm
@@ -19,6 +19,7 @@ use base "y2x11test";
 use strict;
 use warnings;
 use testapi;
+use utils qw(type_string_slow_extended);
 
 sub run {
     my $self = shift;
@@ -55,10 +56,10 @@ sub run {
     #	proctect boot loader with password
     assert_and_click 'yast2-bootloader_protect-bootloader-with-password';
     send_key 'alt-p';
-    type_string 'dummy-password';
+    type_string_slow_extended('dummy-password');
+    assert_screen 'yast2-bootloader_pwd_filled_up';
     send_key 'alt-y';
-    type_string 'dummy-password';
-    wait_still_screen 3;
+    type_string_slow_extended('dummy-password');
 
     # OK => Exit
     send_key "alt-o";


### PR DESCRIPTION
it just enables load_extra_tests_y2uitest_gui to run yast2_bootloader.pm
it depends on create_hdd_gnome

- Related ticket: https://progress.opensuse.org/issues/50591

- Needles: 
opensuse https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/540
sle: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1114

- Verification run: 
opensuse tw: http://10.161.229.206/tests/483
sles15: http://10.161.229.206/tests/477
sled15: http://10.161.229.206/tests/478
sles12sp3: http://10.161.229.206/tests/494
sled12sp3: http://10.161.229.206/tests/495
sles12sp4: http://10.161.229.206/tests/496
sled12sp4: http://10.161.229.206/tests/499