### PR TITLE
Increase timeouts for SAP HANA Wizard

### DIFF
--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -114,8 +114,8 @@ sub run {
     type_string_slow "$path", wait_still_screen => 1;
     send_key 'tab';
     send_key $cmd{next};
-    assert_screen 'sap-wizard-copying-media';
-    assert_screen 'sap-wizard-supplement-medium', 3000;
+    assert_screen 'sap-wizard-copying-media',     120;
+    assert_screen 'sap-wizard-supplement-medium', 4000;
     send_key $cmd{next};
     assert_screen 'sap-wizard-additional-repos';
     send_key $cmd{next};


### PR DESCRIPTION
Increase timeouts for the SAP HANA Wizard Installation.  The needles MR contains a fix for the Installation Summary that catched the SID that is now variable.

- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1116
- Verification run: http://ix64hae1001.qa.suse.de/tests/335