### PR TITLE
Add uefi http boot test

### DIFF
--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -47,6 +47,9 @@ sub run {
 
     # aarch64 firmware 'tianocore' can take longer to load
     my $bootloader_timeout = check_var('ARCH', 'aarch64') ? 45 : 15;
+    if (get_var('UEFI_HTTP_BOOT') || get_var('UEFI_HTTPS_BOOT')) {
+        tianocore_http_boot;
+    }
     assert_screen([qw(bootloader-shim-import-prompt bootloader-grub2)], $bootloader_timeout);
     if (match_has_tag("bootloader-shim-import-prompt")) {
         send_key "down";


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/50348
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/541
- Verification run: tested locally on aarch64 (textmode), with HTTP server without http redirections
