### PR TITLE
yast2_nis test enablement for all supported SLES

### DIFF
--- a/tests/console/yast2_nis.pm
+++ b/tests/console/yast2_nis.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: create and delete nis client configuration and functionality
-# Maintainer: Zaoliang Luo <zluo@suse.de>
+# Maintainer: Sergio R Lemke <slemke@suse.com>
 
 use strict;
 use warnings;
@@ -19,7 +19,7 @@ use utils 'zypper_call';
 sub run() {
     my ($self) = @_;
     select_console 'root-console';
-    zypper_call 'in yast2-nis-client';    # make sure yast client module installed
+    zypper_call 'in yast2-nis-client yast2-nfs-client';    # make sure yast client module installed
 
     # Configure firewalld ypbind service (bsc#1083487)
     if ($self->firewall eq 'firewalld' && script_run 'firewall-offline-cmd --get-services | grep ypbind') {
@@ -62,34 +62,31 @@ sub run() {
     send_key 'alt-y';
     wait_screen_change { type_string "-c" };                             # only checks if the config file has syntax errors and exits
     wait_screen_change { send_key 'alt-o' };
-    wait_screen_change { send_key 'alt-s' };                             # enter NFS configuration,sometimes fails, retry
-    sleep(4);
-    send_key 'alt-s' if check_screen('nis-client');                      # Cannot use send_key_until_needlematch, see poo#48647
-    assert_screen 'nfs-client-configuration';
-    send_key 'alt-a';                                                    # add nfs share
-    assert_screen 'nfs-server-hostname';                                 # check that type string is sucessful
-    send_key 'alt-n';                                                    # from here enter some configurations...
+    send_key_until_needlematch('nfs-client-configuration', 'alt-s', 2, 5);    # enter NFS configuration, sometimes fails, retry
+    send_key 'alt-a';                                                         # add nfs settings
+    assert_screen 'nfs-server-hostname';                                      # check that type string is sucessful
+    send_key 'alt-n';                                                         # from here enter some configurations...
     type_string "nis.suse.de";
     send_key 'alt-r';
     type_string "/mounts";
     send_key 'alt-m';
     type_string "/mounts_local";
     send_key 'alt-o';
-    assert_screen 'nfs_server_added';                                    # check Mount point
-    wait_screen_change { send_key 'alt-t' };                             # go back to nfs configuration and delete configuration created before
-    assert_screen 'nis_server_delete';                                   # confirm to delete configuration
+    assert_screen 'nfs_server_added';                                         # check Mount point
+    wait_screen_change { send_key 'alt-t' };                                  # go back to nfs configuration and delete configuration created before
+    assert_screen 'nis_server_delete';                                        # confirm to delete configuration
     send_key 'alt-y';
     wait_still_screen 2;
     send_key 'alt-o';
     wait_still_screen 2;
-    send_key 'alt-f';                                                    # close the dialog...
+    send_key 'alt-f';                                                         # close the dialog...
     assert_screen([qw(nis_server_not_found ypbind_error)]);
     if (match_has_tag 'ypbind_error') {
         record_soft_failure 'bsc#1073281';
         send_key 'alt-o';
     }
     else {
-        send_key 'alt-o';                                                # close it now even when config is not valid
+        send_key 'alt-o';                                                     # close it now even when config is not valid
     }    # check error message for 'nis server not found'
 }
 1;


### PR DESCRIPTION
This changes do:
Make test backwards compatible with all supported SLE versions;

- Related ticket: https://progress.opensuse.org/issues/50363
- Needles: None
- Verification run: 

12.3: http://deathstar.suse.cz/tests/2302
12.4: http://deathstar.suse.cz/tests/2303
12.5: http://deathstar.suse.cz/tests/2304

15.0: http://deathstar.suse.cz/tests/2305
15.1: http://deathstar.suse.cz/tests/2306

