### PR TITLE
Allow pamtest.py to work for older versions

### DIFF
--- a/data/sssd-tests/local/test.sh
+++ b/data/sssd-tests/local/test.sh
@@ -3,6 +3,23 @@
 set -e
 
 . ../testincl.sh
+
+isSles15(){
+   if [ ! -f /etc/os-release ]; then
+      return 1
+   fi
+   if (grep -i -q "SUSE Linux Enterprise Server 15" /etc/os-release); then
+      return 0
+   fi
+   return 1
+}
+
+if ( isSles15 ); then
+	PYTHON=python3
+else
+	PYTHON=python2
+fi
+
 trap sssd_test_common_cleanup EXIT SIGINT SIGTERM
 sssd_test_common_setup
 
@@ -51,15 +68,15 @@ test_ok
 
 echo 'testuser1@LOCAL:goodpass' | chpasswd
 test_case 'Authentication via PAM'
-../pamtest.py passwd testuser1 goodpass || test_fatal 'Failed to authentication testuser1'
-! ../pamtest.py passwd testuser1 badpass &> /dev/null || test_fatal 'Failed to deny false password for testuser1'
-! ../pamtest.py passwd testuser2 badpass &> /dev/null || test_fatal 'Failed to deny false username'
+$PYTHON ../pamtest.py passwd testuser1 goodpass || test_fatal 'Failed to authentication testuser1'
+! $PYTHON ../pamtest.py passwd testuser1 badpass &> /dev/null || test_fatal 'Failed to deny false password for testuser1'
+! $PYTHON ../pamtest.py passwd testuser2 badpass &> /dev/null || test_fatal 'Failed to deny false username'
 test_ok
 
 test_case 'Login via PAM'
-../pamtest.py login testuser1 goodpass || test_fatal 'Failed to login as testuser1'
-! ../pamtest.py login testuser1 badpass &> /dev/null || test_fatal 'Failed to deny login of incorrect password'
-! ../pamtest.py login testuser2 badpass &> /dev/null || test_fatal 'Failed to deny login of false username'
+$PYTHON ../pamtest.py login testuser1 goodpass || test_fatal 'Failed to login as testuser1'
+! $PYTHON ../pamtest.py login testuser1 badpass &> /dev/null || test_fatal 'Failed to deny login of incorrect password'
+! $PYTHON ../pamtest.py login testuser2 badpass &> /dev/null || test_fatal 'Failed to deny login of false username'
 test_ok
 
 test_suite_end

--- a/data/sssd-tests/pamtest.py
+++ b/data/sssd-tests/pamtest.py
@@ -6,7 +6,28 @@ Return status 0 on success, 1 on error.
 Invocation: <service_name> <user_name> <plain_password>
 '''
 
-import sys, pam
+import sys
+
+usePAM = True
+try:
+	import PAM as pam
+except ImportError:
+
+	usePAM = False
+	import pam
+
+if usePAM:
+	def pamconv(auth, qlist):
+		resp = []
+		for (query,hint) in qlist:
+			if hint == pam.PAM_PROMPT_ECHO_ON or hint == pam.PAM_PROMPT_ECHO_OFF:
+				resp.append((password, 0))
+			elif hint == pam.PAM_PROMPT_ERROR_MSG or hint == pam.PAM_PROMPT_TEXT_INFO:
+				print(query)
+				resp.append(('', 0));
+			else:
+				return None
+		return resp
 
 if len(sys.argv) != 1 + 3:
 	sys.exit(1)
@@ -14,11 +35,23 @@ if len(sys.argv) != 1 + 3:
 (_, service, user, password) = sys.argv
 
 p = pam.pam()
-try:
-	ret=p.authenticate(user, password, service)
-except Exception as e:
-	print(e)
-	sys.exit(1)
-if ret: sys.exit(0)
-else: sys.exit(1)
+
+if usePAM:
+	p.start(service)
+	p.set_item(pam.PAM_USER, user)
+	p.set_item(pam.PAM_CONV, pamconv)
+	try:
+		p.authenticate()
+		p.acct_mgmt()
+	except Exception as e:
+		print(e)
+		sys.exit(1)
+else:
+	try:
+		ret=p.authenticate(user, password, service)
+	except Exception as e:
+		print(e)
+		sys.exit(1)
+	if ret: sys.exit(0)
+	else: sys.exit(1)
 


### PR DESCRIPTION
Please see https://bugzilla.suse.com/show_bug.cgi?id=1131989#c11 for more info.

This patch:

1) detect if PAM is available and use that, else use the
   more modern python3-python-pam
2) if SLE15 run pamtest.py with python3 otherwise run with python2

Signed-off-by: Noel Power <noel.power@suse.com>
- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1131989
