### PR TITLE
Get around of Bug 1131811 - [XEN] internal error: libxenlight failed …

### DIFF
--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -17,6 +17,12 @@ use testapi;
 use virt_utils;
 
 sub install_package {
+
+    # Get around the bug on sles15sp1 host: Bug 1131811 - [XEN] internal error: libxenlight failed to create new domain
+    if (check_var('SYSTEM_ROLE', 'xen') && (get_var('VERSION_TO_INSTALL', get_var('VERSION', '') eq '15-SP1'))) {
+        assert_script_run("sed -i 's/^After=local-fs.target/After=timers.target/' /usr/lib/systemd/system/btrfsmaintenance-refresh.service");
+    }
+
     my $qa_server_repo = get_var('QA_HEAD_REPO', '');
     if ($qa_server_repo eq '') {
         #default repo according to version if not set from testsuite


### PR DESCRIPTION
On sles15sp1 RC2 Xen, guest installation failed due to Bug 1131811 - [XEN] internal error: libxenlight failed to create new domain. This commit is to get around of the issue by modifing the service config file after system bootup. 

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1131811
- Verification run: http://10.67.18.247/tests/426

@alice-suse @xguo @waynechen55
