### PR TITLE
Further separate backend specific or generic code

### DIFF
--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -26,6 +26,9 @@ use constant {
         qw(
           is_remote_backend
           has_ttys
+          is_hyperv
+          is_hyperv_in_gui
+          is_svirt_except_s390x
           )
     ],
     CONSOLES => [
@@ -61,6 +64,23 @@ sub is_remote_backend {
 # but not what we use for s390x-kvm.
 sub has_ttys {
     return ((get_var('BACKEND', '') !~ /ipmi|s390x|spvm/) && !get_var('S390_ZKVM'));
+}
+
+#  splitting backend code for is_hyperv, is_hyperv_in_gui, is_svirt_except_s390x
+
+sub is_hyperv {
+    my $hyperv_version = shift;
+    return 0 unless check_var('VIRSH_VMM_FAMILY', 'hyperv');
+    return defined($hyperv_version) ? check_var('HYPERV_VERSION', $hyperv_version) : 1;
+}
+
+sub is_hyperv_in_gui {
+    return is_hyperv && !check_var('VIDEOMODE', 'text');
+}
+
+sub is_svirt_except_s390x {
+    return !get_var('S390_ZKVM') && check_var('BACKEND', 'svirt');
+
 }
 
 1;

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -21,7 +21,7 @@ use autotest;
 use utils;
 use wicked::TestContext;
 use version_utils qw(:VERSION :BACKEND :SCENARIO);
-use Utils::Backends 'is_remote_backend';
+use Utils::Backends qw(is_remote_backend is_hyperv is_hyperv_in_gui is_svirt_except_s390x);
 use data_integrity_utils 'verify_checksum';
 use bmwqemu ();
 use strict;

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -21,6 +21,7 @@ use strict;
 use warnings;
 use testapi qw(check_var get_var set_var);
 use version 'is_lax';
+use Utils::Backends qw(is_hyperv is_hyperv_in_gui is_svirt_except_s390x);
 
 use constant {
     VERSION => [
@@ -93,16 +94,6 @@ sub is_jeos {
 
 sub is_vmware {
     return check_var('VIRSH_VMM_FAMILY', 'vmware');
-}
-
-sub is_hyperv {
-    my $hyperv_version = shift;
-    return 0 unless check_var('VIRSH_VMM_FAMILY', 'hyperv');
-    return defined($hyperv_version) ? check_var('HYPERV_VERSION', $hyperv_version) : 1;
-}
-
-sub is_hyperv_in_gui {
-    return is_hyperv && !check_var('VIDEOMODE', 'text');
 }
 
 sub is_krypton_argon {
@@ -287,10 +278,6 @@ sub is_pre_15 {
 
 sub is_aarch64_uefi_boot_hdd {
     return get_var('MACHINE') =~ /aarch64/ && get_var('UEFI') && get_var('BOOT_HDD_IMAGE');
-}
-
-sub is_svirt_except_s390x {
-    return !get_var('S390_ZKVM') && check_var('BACKEND', 'svirt');
 }
 
 sub is_s390x {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -22,7 +22,7 @@ use File::Find;
 use File::Basename;
 use LWP::Simple 'head';
 use scheduler 'load_yaml_schedule';
-
+use Utils::Backends qw(is_hyperv is_hyperv_in_gui);
 use DistributionProvider;
 
 BEGIN {

--- a/tests/installation/data_integrity.pm
+++ b/tests/installation/data_integrity.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use testapi;
 use data_integrity_utils 'verify_checksum';
-use version_utils 'is_svirt_except_s390x';
+use Utils::Backends 'is_svirt_except_s390x';
 
 sub run {
     # If variable is set, we only inform about it

--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -15,8 +15,8 @@ use strict;
 use warnings;
 use base "y2logsstep";
 use testapi;
-use version_utils qw(is_caasp is_hyperv is_upgrade);
-use Utils::Backends 'is_remote_backend';
+use version_utils qw(is_caasp is_upgrade);
+use Utils::Backends qw(is_remote_backend is_hyperv);
 
 
 sub ensure_ssh_unblocked {


### PR DESCRIPTION
see https://progress.opensuse.org/issues/50435 for details
verification test runs:

https://openqa.suse.de/tests/2809056 (hyperv)
https://openqa.suse.de/tests/2809620 (is_hyperv_in_gui)
https://openqa.suse.de/tests/2809129 (aarch64_uefi_boot_hdd)
https://openqa.suse.de/tests/2809371 (aarch64 default, installation)
https://openqa.suse.de/tests/2809609 (is_svirt_except_s390x)
https://openqa.suse.de/tests/2809612 (ppc64le-spvm)
https://openqa.suse.de/tests/2809621 (sles 12 sp5 boot_to_snapshot@aarch64)
https://openqa.suse.de/tests/2809622 (sles 12 sp5 ppc64le default)
https://openqa.suse.de/tests/2809623 (sles 12 sp5 default@64bit-ipmi)
https://openqa.suse.de/tests/2809791 (default s390x-zVM-vswitch-l3)
https://openqa.suse.de/tests/2811331 (raid0 YaST aarch64)
https://openqa.suse.de/tests/2811332 (btrfs YaST ppc64le)
https://openqa.suse.de/tests/2813890 (YaST minimal@s390x-kvm-sle12)
https://openqa.suse.de/tests/2811339 (yast_self_update@64bit)
https://openqa.opensuse.org/tests/910264 (TW ext3_textmode)
https://openqa.opensuse.org/tests/910265 (TW uefi)
https://openqa.opensuse.org/tests/910567 (TW autoyast gnome
https://openqa.opensuse.org/tests/910275 (Leap 15.1 GNOME-Live)
https://openqa.opensuse.org/tests/910611 (Leap 15.1 jeos)
