### PR TITLE
Fix setup of online repositories in Leap 15.1

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -632,10 +632,6 @@ sub we_is_applicable {
       && get_var('MIGRATION_REMOVE_ADDONS', '') !~ /we/;
 }
 
-sub installwithaddonrepos_is_applicable {
-    return get_var("HAVE_ADDON_REPOS") && !get_var("UPGRADE") && !get_var("NET");
-}
-
 sub need_clear_repos {
     return !get_var('ZDUP')
       && (!get_var('INSTALLONLY') || get_var('PUBLISH_HDD_1'))

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -55,6 +55,7 @@ our @EXPORT = qw(
   addon_license
   addon_products_is_applicable
   noupdatestep_is_applicable
+  installwithaddonrepos_is_applicable
   random_string
   handle_emergency
   handle_grub_zvm
@@ -640,6 +641,10 @@ sub addon_products_is_applicable {
 
 sub noupdatestep_is_applicable {
     return !get_var("UPGRADE") && !get_var("LIVE_UPGRADE");
+}
+
+sub installwithaddonrepos_is_applicable {
+    return get_var("HAVE_ADDON_REPOS") && !get_var("UPGRADE") && !get_var("NET");
 }
 
 sub random_string {

--- a/tests/installation/installation_mode.pm
+++ b/tests/installation/installation_mode.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,8 +19,8 @@ use testapi;
 sub run {
     # autoconf phase
     # includes downloads
-    assert_screen [qw(partitioning-edit-proposal-button before-role-selection inst-instmode)], 120;
-    if (match_has_tag("partitioning-edit-proposal-button") || match_has_tag("before-role-selection")) {
+    assert_screen [qw(partitioning-edit-proposal-button before-role-selection inst-instmode online-repos)], 120;
+    if (match_has_tag("partitioning-edit-proposal-button") || match_has_tag("before-role-selection") || match_has_tag("online-repos")) {
         # new desktop selection workflow
         set_var('NEW_DESKTOP_SELECTION', 1);
         return;

--- a/tests/installation/online_repos.pm
+++ b/tests/installation/online_repos.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2018 SUSE LLC
+# Copyright © 2017-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,6 +23,7 @@ use warnings;
 use base "y2logsstep";
 use testapi;
 use version_utils qw(:VERSION :SCENARIO);
+use utils 'installwithaddonrepos_is_applicable';
 
 sub open_online_repos_dialog {
     wait_screen_change { send_key 'alt-y' };
@@ -62,6 +63,9 @@ sub run {
     # Test online repos dialog explicitly
     if (get_var('DISABLE_ONLINE_REPOS')) {
         disable_online_repos_explicitly;
+    } elsif (installwithaddonrepos_is_applicable() && !get_var("LIVECD")) {
+        # Acivate online repositories
+        wait_screen_change { send_key 'alt-y' };
     } else {
         # If click No, step is skipped, which is default behavior
         wait_screen_change { send_key 'alt-n' };

--- a/tests/installation/setup_online_repos.pm
+++ b/tests/installation/setup_online_repos.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,8 +20,13 @@ use version_utils;
 
 sub run {
     # ordered according to real repos lists
-    my @default_repos = qw(update-non-oss update-oss main-non-oss main-oss debug-main untested-update debug-update source);
-
+    my @default_repos;
+    if (is_leap('<15.1')) {
+        @default_repos = qw(update-non-oss update-oss main-non-oss main-oss debug-main untested-update debug-update source);
+    }
+    else {
+        @default_repos = qw(update-non-oss main-non-oss update-oss main-oss debug-update untested-update source debug-main);
+    }
     # maybe slow due to network connectivity
     assert_screen [qw(setup_online_repos-configure setup_online_repos-configure-text online-repos)], 200;
 


### PR DESCRIPTION
Fix poo#50309: Leap 15.1 changed behavior in setup of online
repositories. It is triggered earlier in online_repos. Step
installation_mode had to be updated too, to pass screen to next step.
Order of repositories in setup_online_repos was changed.

- Related ticket: https://progress.opensuse.org/issues/50309
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/546
- Verification run: 
Leap 15.1 with updates: http://10.100.12.105/tests/1888#step/online_repos/1
Leap 15.1 without updates: http://10.100.12.105/tests/1889#step/online_repos/1
Tumbleweed: http://10.100.12.105/tests/1892#step/online_repos/1
Leap 15.0 with updates: http://10.100.12.105/tests/1891#
Leap 15.0 without updates: http://10.100.12.105/tests/1890#step/online_repos/1
Leap 42.3 with updates: http://10.100.12.105/tests/1895#step/online_repos/1
Leap 42.3 without updates: http://10.100.12.105/tests/1893#step/online_repos/1
