### PR TITLE
QAM VIRT: Fix hotplugging, xl_create and virtmanager

### DIFF
--- a/tests/virtualization/xen/guest_management.pm
+++ b/tests/virtualization/xen/guest_management.pm
@@ -43,14 +43,6 @@ sub run {
     assert_script_run "virsh start $_" foreach (keys %xen::guests);
     script_retry "nmap $_ -PN -p ssh | grep open", delay => 15, retry => 12 foreach (keys %xen::guests);
 
-    # TODO:
-    record_info "AUTOSTART DISABLE", "Disable autostart for all guests";
-    assert_script_run "virsh autostart --disable $_" foreach (keys %xen::guests);
-
-    # TODO:
-    record_info "AUTOSTART ENABLE", "Enable autostart for all guests";
-    assert_script_run "virsh autostart $_" foreach (keys %xen::guests);
-
     record_info "SUSPEND", "Suspend all guests";
     assert_script_run "virsh suspend $_" foreach (keys %xen::guests);
     script_retry "virsh list --all | grep $_ | grep paused", delay => 15, retry => 12 foreach (keys %xen::guests);

--- a/tests/virtualization/xen/list_guests.pm
+++ b/tests/virtualization/xen/list_guests.pm
@@ -16,10 +16,10 @@ use testapi;
 use utils;
 
 sub run {
-    assert_script_run "virsh list --all";
+    assert_script_run "virsh list --all", 180;
     foreach my $guest (keys %xen::guests) {
         record_info "$guest", "Listing $guest";
-        if (script_run("virsh list --all | grep $guest | grep \"shut off\"") == 0) {
+        if (script_run("virsh list --all | grep $guest | grep \"shut off\"", 90) == 0) {
             record_soft_failure "Guest $guest should be on but is not";
             assert_script_run "virsh start $guest";
         }

--- a/tests/virtualization/xen/virsh_start.pm
+++ b/tests/virtualization/xen/virsh_start.pm
@@ -26,8 +26,12 @@ use utils;
 sub run {
     my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
-    assert_script_run("virsh start $_", 120) foreach (keys %xen::guests);
-    script_retry "ssh root\@$_ hostname -f", delay => 15, retry => 12 foreach (keys %xen::guests);
+    record_info "AUTOSTART ENABLE", "Enable autostart for all guests";
+    assert_script_run "virsh autostart $_" foreach (keys %xen::guests);
+
+    record_info "LIBVIRTD", "Restart libvirtd and expect all guests to boot up";
+    systemctl 'restart libvirtd';
+    script_retry "ssh root\@$_ hostname -f", delay => 30, retry => 6 foreach (keys %xen::guests);
 }
 
 sub test_flags {

--- a/tests/virtualization/xen/virsh_stop.pm
+++ b/tests/virtualization/xen/virsh_stop.pm
@@ -26,9 +26,15 @@ use utils;
 sub run {
     my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
-    # TODO:
+    record_info "POWEROFF", "Shut every guest down";
     script_run "ssh root\@$_ poweroff" foreach (keys %xen::guests);
     script_retry "virsh list --all | grep -v Domain-0 | grep running", delay => 3, retry => 60, expect => 1;
+
+    record_info "AUTOSTART DISABLE", "Disable autostart for all guests";
+    assert_script_run "virsh autostart --disable $_" foreach (keys %xen::guests);
+
+    record_info "LIBVIRTD", "Restart libvirtd and expect all guests to stay down";
+    systemctl 'restart libvirtd';
 }
 
 sub test_flags {

--- a/tests/virtualization/xen/virtmanager_add_devices.pm
+++ b/tests/virtualization/xen/virtmanager_add_devices.pm
@@ -40,6 +40,7 @@ sub run {
 
         mouse_set(0, 0);
         assert_and_click 'virt-manager_details';
+        send_key 'alt-f10';
         assert_and_click 'virt-manager_add-hardware';
         mouse_set(0, 0);
         assert_and_click 'virt-manager_add-storage';

--- a/tests/virtualization/xen/virtmanager_offon.pm
+++ b/tests/virtualization/xen/virtmanager_offon.pm
@@ -44,7 +44,7 @@ sub run {
 
         mouse_set(0, 0);
         assert_and_click 'virt-manager_shutdown';
-        if (!check_screen 'virt-manager_notrunning', 30) {
+        if (!check_screen 'virt-manager_notrunning', 60) {
             assert_and_click 'virt-manager_shutdown_menu';
             assert_and_click 'virt-manager_shutdown_item';
             # There migh me 'Are you sure' dialog window


### PR DESCRIPTION
- Related ticket: [poo#40610](https://progress.opensuse.org/issues/40610) [poo#43739](https://progress.opensuse.org/issues/43739)
- Needles: [os-autoinst-needles-sles#1123](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1123)
- Verification run: [virsh_*](http://pdostal-server.suse.cz/tests/2050) [hotplugging](http://pdostal-server.suse.cz/tests/2048) [virtmanager_*](http://pdostal-server.suse.cz/tests/2041)
