### PR TITLE
Remove return value logic from hawk_test

### DIFF
--- a/data/ha/hawk_test.py
+++ b/data/ha/hawk_test.py
@@ -48,17 +48,13 @@ mygroup = args.prefix.lower() + 'cool_group'
 # Tests to perform
 browser.test('test_set_stonith_maintenance', results)
 if args.secret:
-    ret = ssh.verify_stonith_in_maintenance(results)
-    if ret != 0:
-        browser.set_retval(ret)
+    ssh.verify_stonith_in_maintenance(results)
 browser.test('test_disable_stonith_maintenance', results)
 browser.test('test_view_details_first_node', results)
 browser.test('test_clear_state_first_node', results)
 browser.test('test_set_first_node_maintenance', results)
 if args.secret:
-    ret = ssh.verify_node_maintenance(results)
-    if ret != 0:
-        browser.set_retval(ret)
+    ssh.verify_node_maintenance(results)
 browser.test('test_disable_maintenance_first_node', results)
 browser.test('test_add_new_cluster', results, mycluster)
 browser.test('test_remove_cluster', results, mycluster)
@@ -68,14 +64,10 @@ browser.test('test_click_on_command_log', results)
 browser.test('test_click_on_status', results)
 browser.test('test_add_primitive', results, myprimitive)
 if args.secret:
-    ret = ssh.verify_primitive(myprimitive, args.test_version.lower(), results)
-    if ret != 0:
-        browser.set_reval(ret)
+    ssh.verify_primitive(myprimitive, args.test_version.lower(), results)
 browser.test('test_remove_primitive', results, myprimitive)
 if args.secret:
-    ret = ssh.verify_primitive_removed(results)
-    if ret != 0:
-        browser.set_retval(ret)
+    ssh.verify_primitive_removed(results)
 browser.test('test_add_clone', results, myclone)
 browser.test('test_remove_clone', results, myclone)
 browser.test('test_add_group', results, mygroup)
@@ -86,4 +78,4 @@ browser.test('test_click_around_edit_conf', results)
 if args.results:
     results.logresults(args.results)
 
-quit(browser.get_retval())
+quit(results.get_failed_tests_total())

--- a/data/ha/hawk_test_results.py
+++ b/data/ha/hawk_test_results.py
@@ -58,3 +58,5 @@ class resultSet:
         self.results_set['summary']['duration'] = time.process_time()
         self.results_set['info']['timestamp'] = time.time()
 
+    def get_failed_tests_total(self):
+        return self.results_set['summary']['num_tests'] - self.results_set['summary']['passed']

--- a/data/ha/hawk_test_ssh.py
+++ b/data/ha/hawk_test_ssh.py
@@ -65,19 +65,19 @@ class hawkTestSSH:
         if self.check_cluster_conf_ssh("crm status | grep stonith-sbd", "unmanaged"):
             print("INFO: stonith-sbd is unmanaged")
             self.set_test_status(results, 'verify_stonith_in_maintenance', 'passed')
-            return 0
+            return True
         print("ERROR: stonith-sbd is not unmanaged but should be")
         self.set_test_status(results, 'verify_stonith_in_maintenance', 'failed')
-        return 1    # return non zero value on error
+        return False
 
     def verify_node_maintenance(self, results):
         if self.check_cluster_conf_ssh("crm status | grep -i ^node", "maintenance"):
             print("INFO: cluster node set successfully in maintenance mode")
             self.set_test_status(results, 'verify_node_maintenance', 'passed')
-            return 0
+            return True
         print("ERROR: cluster node failed to switch to maintenance mode")
         self.set_test_status(results, 'verify_node_maintenance', 'failed')
-        return 1    # return non zero value on error
+        return False
 
     def verify_primitive(self, myprimitive, version, results):
         matches = ["%s anything" % str(myprimitive), "binfile=file", "op start timeout=35s",
@@ -90,17 +90,17 @@ class hawkTestSSH:
             print("INFO: primitive [%s] correctly defined in the cluster configuration" %
                   myprimitive)
             self.set_test_status(results, 'verify_primitive', 'passed')
-            return 0
+            return True
         print("ERROR: primitive [%s] missing from cluster configuration" % myprimitive)
         self.set_test_status(results, 'verify_primitive', 'failed')
-        return 1    # return non zero value on error
+        return False
 
     def verify_primitive_removed(self, results):
         if self.check_cluster_conf_ssh("crm resource list | grep ocf::heartbeat:anything", ''):
             print("INFO: primitive successfully removed")
             self.set_test_status(results, 'verify_primitive_removed', 'passed')
-            return 0
+            return True
         print("ERROR: primitive [%s] still present in the cluster while checking with SSH" %
               myprimitive)
         self.set_test_status(results, 'verify_primitive_removed', 'failed')
-        return 1    # return non zero value on error
+        return False


### PR DESCRIPTION
This removes the return value logic from `hawk_test.py` (and related modules) and instead makes the script return the total number of tests minus the total number of passed tests. This means the script still returns 0 on success, and a value greater than 0 if any of the tests fail, but the return value itself does not have
any other meaning.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/857
