### PR TITLE
Add description of PKGMGR_ACTION_AT_EXIT to variables.md

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -84,6 +84,7 @@ PERF_KERNEL | boolean | false | Enables kernel performance testing.
 PERF_INSTALL | boolean | false | Enables kernel performance testing installation part.
 PERF_SETUP | boolean | false | Enables kernel performance testing deployment part.
 PERF_RUNCASE | boolean | false | Enables kernel performance testing run case part.
+PKGMGR_ACTION_AT_EXIT | string | "" | Set the default behavior of the package manager when package installation has finished. Possible actions are: close, restart, summary. If PKGMGR_ACTION_AT_EXIT is not set in openQA, test module will read the default value from /etc/sysconfig/yast2.
 PXE_PRODUCT_NAME | string | false | Defines image name for PXE booting
 RAIDLEVEL | integer | | Define raid level to be configured. Possible values: 0,1,5,6,10.
 REGRESSION | string | | Define scope of regression testing, including ibus, gnome, documentation and other.


### PR DESCRIPTION
- Related tickets: 
  * [[functional][y] Review the yast2_i module] 
                            (https://progress.opensuse.org/issues/49688)
  * [[aarch64][jeos][y] test fails in yast2_i](https://progress.opensuse.org/issues/49640)

The code was merged in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7222