### PR TITLE
Fix typo for PR #7275 Get around of Bug 1131811

### DIFF
--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -19,7 +19,7 @@ use virt_utils;
 sub install_package {
 
     # Get around the bug on sles15sp1 host: Bug 1131811 - [XEN] internal error: libxenlight failed to create new domain
-    if (check_var('SYSTEM_ROLE', 'xen') && (get_var('VERSION_TO_INSTALL', get_var('VERSION', '') eq '15-SP1'))) {
+    if (check_var('SYSTEM_ROLE', 'xen') && (get_var('VERSION_TO_INSTALL', get_var('VERSION', '')) eq '15-SP1')) {
         assert_script_run("sed -i 's/^After=local-fs.target/After=timers.target/' /usr/lib/systemd/system/btrfsmaintenance-refresh.service");
     }
 


### PR DESCRIPTION
typo in previous pr. which will fail the tests running on hosts with non-sles15sp1.

- Related ticket: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7275
- Verification run: http://10.67.18.247/tests/overview?distri=sle&version=15-SP1&build=213.2&groupid=3

@alice-suse @xguo @waynechen55