### PR TITLE
Add new nfsidmap regression test

### DIFF
--- a/tests/network/autofs_client.pm
+++ b/tests/network/autofs_client.pm
@@ -7,8 +7,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: It waits until a nfs server is ready and mounts a dir from that one
-# Maintainer: Antonio Caristia <acaristia@suse.com>
+# Summary: It waits until a nfs server is ready and mounts a dir from that one.
+#          It also mounts another dir to check nfsidmap functionality.
+#
+# Maintainer: Antonio Caristia <acaristia@suse.com> (autofs)
+# Maintainer: Timo Jyrinki <tjyrinki@suse.com> (nfsidmap)
 
 use base 'consoletest';
 use testapi;
@@ -20,21 +23,49 @@ use warnings;
 
 sub run {
     select_console "root-console";
-    my $nfs_server             = "10.0.2.101";
-    my $remote_mount           = "/tmp/nfs/server";
-    my $autofs_conf_file       = '/etc/auto.master';
-    my $autofs_map_file        = '/etc/auto.master.d/autofs_regression_test.autofs';
-    my $test_conf_file         = '/etc/auto.share';
-    my $test_mount_dir         = '/mnt/test';
-    my $test_conf_file_content = "echo  test    -ro,no_subtree_check              $nfs_server:$remote_mount > $test_conf_file";
+    my $nfs_server              = "10.0.2.101";
+    my $remote_mount            = "/tmp/nfs/server";
+    my $remote_mount_nfsidmap   = "/home/tux";
+    my $autofs_conf_file        = '/etc/auto.master';
+    my $autofs_map_file         = '/etc/auto.master.d/autofs_regression_test.autofs';
+    my $test_conf_file          = '/etc/auto.share';
+    my $test_mount_dir          = '/mnt/test';
+    my $test_mount_dir_nfsidmap = '/mnt/test_nfsidmap';
+    my $test_conf_file_content  = "echo  test    -ro,no_subtree_check              $nfs_server:$remote_mount > $test_conf_file";
+
+    # autofs
     check_autofs_service();
     setup_autofs_server(autofs_conf_file => $autofs_conf_file, autofs_map_file => $autofs_map_file, test_conf_file => $test_conf_file, test_conf_file_content => $test_conf_file_content, test_mount_dir => $test_mount_dir);
     systemctl 'restart autofs';
     validate_script_output("systemctl --no-pager status autofs", sub { m/Active:\s*active/ }, 180);
+
+    # nfsidmap
+    assert_script_run("rpm -q nfsidmap");
+    assert_script_run("nfsidmap -c");
+    assert_script_run("mkdir -p $test_mount_dir_nfsidmap");
+
     barrier_wait 'AUTOFS_SUITE_READY';
+
+    # autofs
     assert_script_run("ls $test_mount_dir/test");
     assert_script_run("mount | grep -e $test_mount_dir/test");
     validate_script_output("cat $test_mount_dir/test/file.txt", sub { m/It worked/ }, 200);
+
+    # nfsidmap
+    assert_script_run("mount -t nfs4 $nfs_server:$remote_mount_nfsidmap $test_mount_dir_nfsidmap");
+    assert_script_run("ls $test_mount_dir/test");
+    # Without existing user the nfsidmap should map the owner to 'nobody'
+    validate_script_output("ls -l $test_mount_dir_nfsidmap/tux.txt", sub { m/nobody.*users.*tux.txt/ });
+    validate_script_output("cat $test_mount_dir_nfsidmap/tux.txt",   sub { m/Hi tux/ });
+    assert_script_run("umount $test_mount_dir_nfsidmap");
+    assert_script_run("useradd -m tux");
+    assert_script_run("nfsidmap -c");
+    assert_script_run("mount -t nfs4 $nfs_server:$remote_mount_nfsidmap $test_mount_dir_nfsidmap");
+    # Now 'tux' should be shown instead
+    validate_script_output("ls -l $test_mount_dir_nfsidmap/tux.txt", sub { m/tux.*users.*tux.txt/ });
+    validate_script_output("cat $test_mount_dir_nfsidmap/tux.txt",   sub { m/Hi tux/ });
+    assert_script_run("umount $test_mount_dir_nfsidmap");
+
     barrier_wait 'AUTOFS_FINISHED';
 }
 

--- a/tests/network/autofs_server.pm
+++ b/tests/network/autofs_server.pm
@@ -7,8 +7,11 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: It shares a dir via nfs
-# Maintainer: Antonio Caristia <acaristia@suse.com>
+# Summary: It shares a dir via nfs for autofs testing, and another dir
+#          for testing nfsidmap functionality.
+#
+# Maintainer: Antonio Caristia <acaristia@suse.com> (autofs)
+# Maintainer: Timo Jyrinki <tjyrinki@suse.com> (nfsidmap)
 
 use base 'consoletest';
 use testapi;
@@ -20,18 +23,33 @@ use warnings;
 
 sub run {
     select_console "root-console";
-    my $test_share_dir = "/tmp/nfs/server";
+    my $test_share_dir     = "/tmp/nfs/server";
+    my $nfsidmap_share_dir = "/home/tux";
     if (is_opensuse) {
         zypper_call('modifyrepo -e 1');
         zypper_call('ref');
     }
+    # autofs
     zypper_call('in nfs-kernel-server');
     assert_script_run "mkdir -p $test_share_dir";
     assert_script_run "echo It worked > $test_share_dir/file.txt";
     assert_script_run "echo $test_share_dir *(ro) >> /etc/exports";
-    assert_script_run "cat /etc/exports";
     systemctl 'start nfs-server';
     validate_script_output("systemctl --no-pager status nfs-server", sub { m/Active:\s*active/ }, 180);
+
+    # nfsidmap
+    assert_script_run "echo N > /sys/module/nfsd/parameters/nfs4_disable_idmapping";
+    zypper_call('in nfsidmap');
+    systemctl 'restart nfs-idmapd';
+    assert_script_run "nfsidmap -c";
+    assert_script_run "useradd -m tux";
+    assert_script_run "echo Hi tux > $nfsidmap_share_dir/tux.txt";
+    assert_script_run "chown tux:users $nfsidmap_share_dir/tux.txt";
+    assert_script_run "echo '/home/tux *(ro)' >> /etc/exports";
+
+    # common
+    assert_script_run "cat /etc/exports";
+    systemctl 'restart nfs-server';
     barrier_wait 'AUTOFS_SUITE_READY';
     barrier_wait 'AUTOFS_FINISHED';
 }


### PR DESCRIPTION
Add nfsidmap related tests to the recently merged autofs tests.
Tests mounting a directory owned by an user both with and without that use existing on the client system.

- Related ticket: https://progress.opensuse.org/issues/46862
- Verification run: http://d403.qam.suse.de/tests/89
