### PR TITLE
Update autofs test

### DIFF
--- a/tests/console/autofs.pm
+++ b/tests/console/autofs.pm
@@ -15,10 +15,11 @@ use strict;
 use warnings;
 use testapi;
 use autofs_utils qw(setup_autofs_server check_autofs_service);
-use utils qw(systemctl);
+use utils qw(systemctl zypper_call);
 
 sub run {
     select_console 'root-console';
+    zypper_call("in autofs mkisofs");
     my $autofs_conf_file       = '/etc/auto.master';
     my $autofs_map_file        = '/etc/auto.master.d/autofs_regression_test.autofs';
     my $test_conf_file         = '/etc/auto.iso';
@@ -39,4 +40,3 @@ sub run {
 }
 
 1;
-


### PR DESCRIPTION
This change is needed to install autofs and mkisofs for cases where these packages are not installed before the test.

- Related ticket: https://progress.opensuse.org/issues/50516
- Verification run: http://ccret.suse.cz/tests/3336
