### PR TITLE
Revert "Set theme jekyll-theme-minimal"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-minimal


### PR DESCRIPTION
This reverts commit 254689004c8ad4479b721eb546882f49d8591537 that was
mistakenly introduced by an attempt to enable gh-pages