### PR TITLE
Creating documentation for lib/utils using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ matrix:
   - name: "testing perl version, all tests"
     perl: "5.26"
     env: TESTS=all
+env:
+  global:
+    - COMMIT_AUTHOR_EMAIL=skynet@open.qa
 addons:
   apt:
     packages:
@@ -22,3 +25,16 @@ install:
 script:
   - git checkout cpanfile
   - make test
+  - script/generateUtilsDoc.sh
+before_deploy:
+  - script/generateUtilsDoc.sh
+deploy:
+    provider: pages
+    skip_cleanup: true
+    github_token: $GITHUB_TOKEN
+    local-dir: $TRAVIS_BUILD_DIR/docs/
+    on:
+        branch: master
+        condition: [ "$(git -C os-autoinst-distri-opensuse diff 'lib/utils.pm')"  ]
+    target_branch: gh-pages
+

--- a/script/generateUtilsDoc.sh
+++ b/script/generateUtilsDoc.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+cd $TRAVIS_BUILD_DIR
+
+touch docs/utils.html
+pod2html --infile=lib/utils.pm --outfile=docs/utils.html
+


### PR DESCRIPTION
Using pod2html to create a documentation for lib/utils.pm
Every time lib/utils is changed the documentation for it will be
recreated and redeployed

Preconditions:
- It needs gh-pages enabled and set to gh-pages branch as source (already done)
- Needs a Github Token set up in Travis as 'GITHUB_TOKEN'

@foursixnine 
