### PR TITLE
Combine stderr and stdout for dracut in validate_script_output

### DIFF
--- a/tests/console/dracut.pm
+++ b/tests/console/dracut.pm
@@ -24,8 +24,8 @@ sub run {
     assert_script_run("rpm -q dracut");
 
     validate_script_output("lsinitrd", sub { m/Image:(.*\n)+( ?)Version: dracut(-|\d+|\.|\w+)+(\n( ?))+( ?)Arguments(.*\n)+( ?)dracut modules:(\w+|-|\d+|\n|( ?))+\=+\n(l|d|r|w|x|-|( ?))+\s+\d+ root\s+root(.*\n)+( ?)\=+/ });
-    validate_script_output("dracut -f", sub { m/.*Executing: \/usr\/bin\/dracut -f\n|\b(?:Skipping|Including modules done|Including|Creating image|Creating initramfs)\b/ }, 180);
-    validate_script_output("dracut --list-modules", sub { m/.*Executing: \/usr\/bin\/dracut --list-modules\n(\w+|\n|-|d+)+/ });
+    validate_script_output("dracut -f 2>&1", sub { m/.*Executing: \/usr\/bin\/dracut -f\n|\b(?:Skipping|Including modules done|Including|Creating image|Creating initramfs)\b/ }, 180);
+    validate_script_output("dracut --list-modules 2>&1", sub { m/.*Executing: \/usr\/bin\/dracut --list-modules\n(\w+|\n|-|d+)+/ });
 
     power_action('reboot', textmode => 1);
     $self->wait_boot;


### PR DESCRIPTION
dracut writes its output to stderr, but validate_script_output() seems
to check stdout. So we have issue on svirt-xen.

see https://progress.opensuse.org/issues/47417
verification test runs:
https://openqa.suse.de/tests/2814438#step/dracut/36
http://f40.suse.de/tests/3368
