### PR TITLE
trinity: Use IBS repository only for SLE

### DIFF
--- a/tests/kernel/trinity.pm
+++ b/tests/kernel/trinity.pm
@@ -17,6 +17,7 @@ use strict;
 use warnings;
 use upload_system_log;
 use repo_tools 'generate_version';
+use version_utils 'is_sle';
 
 our $trinity_log;
 
@@ -25,9 +26,13 @@ sub run {
     $self->select_serial_terminal;
     $trinity_log = script_output("echo ~$testapi::username/trinity.log");
     my $syscall_cnt = 1000000;
-    my $repo_url    = 'http://download.suse.de/ibs/home:/asmorodskyi/' . generate_version() . '/';
-    zypper_ar($repo_url, 'trinity');
+
+    if (is_sle) {
+        my $repo_url = 'http://download.suse.de/ibs/home:/asmorodskyi/' . generate_version() . '/';
+        zypper_ar($repo_url, 'trinity');
+    }
     zypper_call('in trinity');
+
     assert_script_run("cd  ~$testapi::username");
     assert_script_run("sudo -u $testapi::username trinity -N$syscall_cnt", 2000);
     upload_system_logs();


### PR DESCRIPTION
as IBS is not visible for openqa.opensuse.org and trinity is available
as factory package in OBS (no need for special repository on openSUSE).

Verification run
* http://quasar.suse.cz/tests/2509 (opensuse-Tumbleweed-DVD-x86_64-Build20190414-trinity@64bit)
* http://quasar.suse.cz/tests/2510 (sle-15-SP1-Installer-DVD-x86_64-Build213.2-trinity@64bit)
* http://quasar.suse.cz/tests/2511 (sle-12-SP5-Server-DVD-x86_64-Build0140-trinity@64bit)