### PR TITLE
Workround for disable service check on apache

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -53,11 +53,12 @@ our $default_services = {
         srv_proc_name => 'postfix',
         support_ver   => '12-SP3,12-SP4,15,15-SP1'
     },
-    apache => {
-        srv_pkg_name  => 'apache2',
-        srv_proc_name => 'apache2',
-        support_ver   => '12-SP3,12-SP4,15,15-SP1'
-    },
+    # Quick hack for poo 50576, we need this workround before full solution
+    #    apache => {
+    #    srv_pkg_name  => 'apache2',
+    #    srv_proc_name => 'apache2',
+    #    support_ver   => '12-SP3,12-SP4,15,15-SP1'
+    #},
     bind => {
         srv_pkg_name  => 'bind',
         srv_proc_name => 'named',


### PR DESCRIPTION
We encounter this issue on http_srv check, since we already enable the http service in new module check_service.pm, so http_srv already installed and enabled. This lead http_srv check failed at the very beginning.

- Related ticket: https://progress.opensuse.org/issues/50576
- Needles: n/a
- Verification run: just disable some code to do workround, no risk.
