### PR TITLE
Increase timeouts for bootloader for aarch64 as on cold start, it takes more time

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -945,7 +945,9 @@ sub set_extrabootparams_grub_conf {
 sub ensure_shim_import {
     my (%args) = @_;
     $args{tags} //= [qw(inst-bootmenu bootloader-shim-import-prompt)];
-    assert_screen($args{tags}, 30);
+    # aarch64 firmware 'tianocore' can take longer to load
+    my $bootloader_timeout = check_var('ARCH', 'aarch64') ? 60 : 30;
+    assert_screen($args{tags}, $bootloader_timeout);
     if (match_has_tag("bootloader-shim-import-prompt")) {
         send_key "down";
         send_key "ret";

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -46,7 +46,7 @@ sub run {
     }
 
     # aarch64 firmware 'tianocore' can take longer to load
-    my $bootloader_timeout = check_var('ARCH', 'aarch64') ? 45 : 15;
+    my $bootloader_timeout = check_var('ARCH', 'aarch64') ? 60 : 15;
     if (get_var('UEFI_HTTP_BOOT') || get_var('UEFI_HTTPS_BOOT')) {
         tianocore_http_boot;
     }


### PR DESCRIPTION
Test run: https://openqa.opensuse.org/tests/911664