### PR TITLE
Update autofs test

### DIFF
--- a/tests/console/autofs.pm
+++ b/tests/console/autofs.pm
@@ -14,12 +14,13 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use version_utils;
 use autofs_utils qw(setup_autofs_server check_autofs_service);
 use utils qw(systemctl zypper_call);
 
 sub run {
     select_console 'root-console';
-    zypper_call("in autofs mkisofs");
+    zypper_call("in autofs mkisofs") if is_sle('15+');
     my $autofs_conf_file       = '/etc/auto.master';
     my $autofs_map_file        = '/etc/auto.master.d/autofs_regression_test.autofs';
     my $test_conf_file         = '/etc/auto.iso';


### PR DESCRIPTION
mkisofs is not available on SLE 12. This change is needed to have the packages installed on SLE15 only.

- Related ticket: https://progress.opensuse.org/issues/50516#
- Verification run: 
   JeOS: http://ccret.suse.cz/tests/3342
   SLE12SP4: http://ccret.suse.cz/tests/3343
