### PR TITLE
Combine all bootloaders in one module

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -349,10 +349,6 @@ sub default_desktop {
     return 'gnome';
 }
 
-sub uses_qa_net_hardware {
-    return !check_var("IPXE", "1") && check_var("BACKEND", "ipmi") || check_var("BACKEND", "generalhw");
-}
-
 sub load_shutdown_tests {
     loadtest("shutdown/cleanup_before_shutdown");
     loadtest "shutdown/shutdown";

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -73,6 +73,7 @@ use constant {
           is_ppc64le
           has_product_selection
           has_license_on_welcome_screen
+          uses_qa_net_hardware
           )
     ]
 };
@@ -408,4 +409,8 @@ configuration, otherwise returns false (0).
 sub has_license_on_welcome_screen {
     return 1 if is_caasp('caasp');
     return get_var('HASLICENSE') && ((is_sle('=15') || (is_sle('>=15-SP1') && get_var('BASE_VERSION') && !get_var('UPGRADE')) && is_s390x()) || is_sle('<15'));
+}
+
+sub uses_qa_net_hardware {
+    return !check_var("IPXE", "1") && check_var("BACKEND", "ipmi") || check_var("BACKEND", "generalhw");
 }

--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -10,6 +10,8 @@
 # Summary: Boot systems from PXE
 # Maintainer: alice <xlai@suse.com>
 
+package boot_from_pxe;
+
 use base 'opensusebasetest';
 
 use strict;

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -11,6 +11,8 @@
 # Summary: Bootloader to setup boot process with arguments/options
 # Maintainer: Jozef Pupava <jpupava@suse.com>
 
+package bootloader;
+
 use base "installbasetest";
 use strict;
 use warnings;

--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -10,6 +10,8 @@
 # Summary: Hyper-V bootloader with asset downloading
 # Maintainer: Michal Nowak <mnowak@suse.com>
 
+package bootloader_hyperv;
+
 use base 'installbasetest';
 use testapi;
 use utils;

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -12,6 +12,9 @@
 #   terminal and an ssh connection
 # Maintainer: Matthias Griessmeier <mgriessmeier@suse.de>
 
+
+package bootloader_s390;
+
 use base "installbasetest";
 
 use testapi;

--- a/tests/installation/bootloader_start.pm
+++ b/tests/installation/bootloader_start.pm
@@ -1,0 +1,74 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Temporary solution to combine all the bootloader modules in one and
+# schedule them depending on the environment variables.
+# The solution is implemented to use in declarative scheduling which does not
+# allow to use complex conditions.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package bootloader_start;
+use strict;
+use warnings FATAL => 'all';
+use base "installbasetest";
+use testapi;
+use utils;
+use bootloader;
+use bootloader_uefi;
+use bootloader_hyperv;
+use bootloader_svirt;
+use version_utils qw(:SCENARIO :BACKEND);
+use File::Basename;
+BEGIN {
+    unshift @INC, dirname(__FILE__) . '/../boot';
+}
+use boot_from_pxe;
+
+sub run {
+    if (uses_qa_net_hardware() || get_var("PXEBOOT")) {
+        boot_from_pxe::run;
+        return;
+    }
+    if (is_s390x()) {
+        if (check_var("BACKEND", "s390x")) {
+            bootloader_s390::run();
+            return;
+        }
+        else {
+            bootloader_zkvm::run();
+            return;
+        }
+    }
+    if (check_var('BACKEND', 'svirt') && is_x86_64()) {
+        set_bridged_networking();
+        if (is_hyperv()) {
+            bootloader_hyperv::run();
+        }
+        else {
+            bootloader_svirt::run();
+        }
+    }
+    # Load regular bootloader for all qemu backends and for x84_86 systems,
+    # except Xen PV as id does not have VNC (bsc#961638).
+    if (check_var('BACKEND', 'qemu') || (check_var('BACKEND', 'svirt') && !(check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')))) {
+        if (get_var('UEFI')) {
+            bootloader_uefi::run();
+            return;
+        }
+        else {
+            bootloader::run();
+            return;
+        }
+    }
+    else {
+        die 'No bootloader found for the current job settings.';
+    }
+}
+
+1;

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -10,6 +10,8 @@
 # Summary: svirt bootloader
 # Maintainer: Michal Nowak <mnowak@suse.com>
 
+package bootloader_svirt;
+
 use base "installbasetest";
 use strict;
 use warnings;

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -11,6 +11,8 @@
 # Summary: Boot on UEFI systems with configuration of boot parameters
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
+package bootloader_uefi;
+
 use base "installbasetest";
 use strict;
 use warnings;

--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -11,6 +11,8 @@
 # Summary: Interface with the zKVM bootloader based on test settings
 # Maintainer: Matthias Grießmeier <mgriessmeier@suse.de>
 
+package bootloader_zkvm;
+
 use base "installbasetest";
 
 use strict;


### PR DESCRIPTION
Currently there are several bootloader test modules (bootloader, bootloader_zkvm,
bootloader_uefi etc.) that are scheduled in main.pm.

The conditional logic is too complex for declarative scheduling that is
planned to be applied to all YaST test suites.

In order to simplify migrating to declarative scheduling, as a simple and
straightforward workaround it is decided to extract the conditional logic to one
'bootloader' test module and use it there.

Related ticket: https://progress.opensuse.org/issues/50177
- Verification run: 
bootloader (qemu): http://oorlov-vm.qa.suse.de/tests/844
bootloader_svirt (svirt-xen): http://oorlov-vm.qa.suse.de/tests/847
