### PR TITLE
Add disconnect RMT test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -667,7 +667,7 @@ sub is_smt {
 }
 
 sub is_rmt {
-    return ((get_var("PATTERNS", '') || get_var('HDD_1', '')) =~ /rmt/) && is_sle('>=15');
+    return (check_var('RMT_TEST', '1') && is_sle('>=15'));
 }
 
 sub remove_common_needles {

--- a/tests/console/yast2_rmt.pm
+++ b/tests/console/yast2_rmt.pm
@@ -15,14 +15,7 @@ use strict;
 use warnings;
 use utils;
 use testapi;
-
-
-sub password_twice {
-    type_password;
-    send_key "tab";
-    type_password;
-    send_key "alt-o";
-}
+use repo_tools;
 
 sub test_ui {
     script_run("yast2 rmt; echo yast2-rmt-server-status-\$? > /dev/$serialdev", 0);
@@ -36,7 +29,7 @@ sub test_ui {
     type_password;
     send_key "alt-n";
     assert_screen "yast2_rmt_db_root_password";
-    password_twice;
+    type_password_twice;
     assert_screen "yast2_rmt_config_written_successfully";
     send_key "alt-o";
     assert_screen "yast2_rmt_ssl";
@@ -51,7 +44,7 @@ sub test_ui {
     send_key "alt-o";
     send_key "alt-n";
     assert_screen "yast2_rmt_ssl_CA_password";
-    password_twice;
+    type_password_twice;
     assert_screen "yast2_rmt_firewall";
     send_key "spc";
     send_key "alt-n";

--- a/tests/x11/rmt.pm
+++ b/tests/x11/rmt.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Add rmt configuration test and disconnect RMT test
+#    test basic configuration via rmt-wizard, test disconnect RMT
+#    via import RMT data and repos from an existing RMT server,
+#    then verify enabled repos are shown on new RMT server.
+# Maintainer: Lemon Li <leli@suse.com>
+
+use strict;
+use warnings;
+use testapi;
+use base 'x11test';
+use repo_tools;
+use utils;
+use x11utils 'turn_off_gnome_screensaver';
+
+sub run {
+    x11_start_program('xterm -geometry 150x35+5+5', target_match => 'xterm');
+    # Avoid blank screen since smt sync needs time
+    turn_off_gnome_screensaver;
+    become_root;
+    rmt_wizard();
+    # mirror and sync a base repo from SCC
+    rmt_mirror_repo();
+    # import data and repos from an existing RMT server
+    rmt_import_data("rmt_external.tar.gz");
+    type_string "killall xterm\n";
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
We add the disconnect RMT test to fullfill the test for feature of 'disconnect RMT' .
Test steps follow below link:
https://www.suse.com/documentation/sles-15/singlehtml/book_rmt/book_rmt.html#sec.rmt_mirroring.export_import
I used a stored RMT export data file to test the RMT import to avoid two much data flow on o.s.d. and complicated multi machines test. 

- Related ticket: https://progress.opensuse.org/issues/28465
- Needles: N/A
- Verification run: http://openqa-apac1.suse.de/tests/3921#step/rmt/14
