### PR TITLE
Add Pacemaker CTS regression tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2511,7 +2511,9 @@ sub load_ha_cluster_tests {
     set_var('USE_LVMLOCKD', 0) if (get_var('USE_LVMLOCKD') and is_sle('<15'));
 
     # Wait for barriers to be initialized except when testing HAWK as a client
-    loadtest 'ha/wait_barriers' unless (check_var('HAWKGUI_TEST_ROLE', 'client'));
+    # or Pacemaker CTS regression tests
+    loadtest 'ha/wait_barriers' unless (check_var('HAWKGUI_TEST_ROLE', 'client') or
+        (get_var('PACEMAKER_CTS_REG')));
 
     # Test HA after an upgrade, so no need to configure the HA stack
     if (get_var('HDDVERSION')) {
@@ -2530,6 +2532,12 @@ sub load_ha_cluster_tests {
     # If HAWKGUI_TEST_ROLE is set to client, only load client side test
     if (check_var('HAWKGUI_TEST_ROLE', 'client')) {
         loadtest 'ha/hawk_gui';
+        return 1;
+    }
+
+    # Only do pacemaker-cts regression tests if PACEMAKER_CTS_REG is set
+    if (get_var('PACEMAKER_CTS_REG')) {
+        loadtest 'ha/pacemaker_cts_regression';
         return 1;
     }
 

--- a/tests/ha/pacemaker_cts_regression.pm
+++ b/tests/ha/pacemaker_cts_regression.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Execute regression tests with pacemaker-cts
+# Maintainer: Julien Adamek <jadamek@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+use hacluster;
+
+sub run {
+    my $cts_path     = '/usr/share/pacemaker/tests';
+    my @tests_to_run = qw(cts-cli cts-exec cts-scheduler cts-fencing);
+    my $log          = '/tmp/cts_regression.log';
+
+    zypper_call 'in pacemaker-cts';
+
+    foreach my $cts_tests (@tests_to_run) {
+        record_info("$cts_tests", "Starting $cts_tests");
+        assert_script_run "$cts_path/$cts_tests -V | tee -a $log 2>&1", timeout => 600;
+        save_screenshot;
+    }
+
+    upload_logs $log;
+}
+
+1;


### PR DESCRIPTION
The integration of the Pacemaker CTS suite will be done though 2 PR:
**1.** This first PR includes the pacemaker CTS regression tests where only one server is necessary
**2.** The second PR will include the pacemaker CTS cluster exerciser where a Multi Machine setup is necessary.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://1a102.qa.suse.de/tests/126
