### PR TITLE
Add python2 module for sle15

### DIFF
--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -43,7 +43,7 @@ sub handle_all_packages_medium {
     push @addons, 'we' if check_var('SLE_PRODUCT', 'sled') && !grep(/^we$/, @addons);
 
     # Add python2 module, refer to https://jira.suse.de/browse/SLE-3167
-    push @addons, 'python2' if get_var('MEDIA_UPGRADE') && is_sle('<15', get_var('HDDVERSION')) && !check_var('SLE_PRODUCT', 'rt');
+    push @addons, 'python2' if get_var('MEDIA_UPGRADE') && is_sle('<=15', get_var('HDDVERSION')) && !check_var('SLE_PRODUCT', 'rt');
 
     # For SLES12SPx and SLES11SPx to SLES15 migration, need add the demand module at least for media migration manually
     # Refer to https://fate.suse.com/325293
@@ -67,11 +67,6 @@ sub handle_all_packages_medium {
     # there will be problem to enable the same addon twice
     for my $a (split(/,/, get_var('SCC_ADDONS', ''))) {
         push @addons, $a if !grep(/^$a$/, @addons);
-    }
-
-    # Add python2 module, refer to https://jira.suse.de/browse/SLE-3167
-    if (get_var('MEDIA_UPGRADE') && check_var('HDDVERSION', '15') && grep(/^lgm$|^legacy$/, @addons)) {
-        push @addons, 'python2' if !grep(/^python2$/, @addons);
     }
 
     # Record the addons to be enabled for debugging


### PR DESCRIPTION
Add python2 module for sle15 migration whether with/without legacy module.

- Related ticket: https://progress.opensuse.org/issues/50504
As our local worker has some problem with media upgrade. Merge the code first, then do verify testing.
