### PR TITLE
Add yast2-storage-ng test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1405,6 +1405,7 @@ sub load_extra_tests_y2uitest_gui {
     loadtest "yast2_gui/yast2_network_settings";
     loadtest "yast2_gui/yast2_software_management";
     loadtest "yast2_gui/yast2_users";
+    loadtest "yast2_gui/yast2_storage_ng" if is_sle("12-SP2+");
 }
 
 sub load_extra_tests_y2uitest_cmd {

--- a/tests/yast2_gui/yast2_storage_ng.pm
+++ b/tests/yast2_gui/yast2_storage_ng.pm
@@ -108,6 +108,10 @@ sub run {
     wait_screen_change { send_key "alt-n" };
     wait_screen_change { send_key "alt-f" };
 
+    select_console "root-console";
+    validate_script_output("fdisk -l | grep /dev/vdb1", sub { m/\/dev\/vdb1\s+\d+\s+\d+\s+\d+.*/ });
+    select_console "x11";
+
     ### RESIZE PARTITION ###
     wait_still_screen 3;
     start_y2sn $self;
@@ -133,6 +137,11 @@ sub run {
     wait_still_screen 1;
     wait_screen_change { send_key "alt-f" };
 
+    # check that the partion is ~170MiB (output is: /dev/vdb1     2048 355477  353430 172.6M 83 Linux)
+    select_console "root-console";
+    validate_script_output("fdisk -l | grep /dev/vdb1", sub { m/\/dev\/vdb1\s+\d+\s+\d+\s+\d+\s+17.*/ });
+    select_console "x11";
+
     ### DELETE PARTITION ###
     wait_still_screen 3;
     start_y2sn $self;
@@ -143,6 +152,11 @@ sub run {
     wait_screen_change { send_key "alt-n" };
     wait_still_screen 1;
     wait_screen_change { send_key "alt-f" };
+
+    # check that /dev/vdb1 has been deleted
+    select_console "root-console";
+    validate_script_output("fdisk -l |grep -c /dev/vdb1", sub { m/0/ });
+    select_console "x11";
 
     ### CREATE VOLUME GROUP ###
     wait_still_screen 3;

--- a/tests/yast2_gui/yast2_storage_ng.pm
+++ b/tests/yast2_gui/yast2_storage_ng.pm
@@ -108,9 +108,12 @@ sub run {
     wait_screen_change { send_key "alt-n" };
     wait_screen_change { send_key "alt-f" };
 
-    select_console "root-console";
+    x11_start_program('xterm');
+    become_root;
+    wait_still_screen 3;
     validate_script_output("fdisk -l | grep /dev/vdb1", sub { m/\/dev\/vdb1\s+\d+\s+\d+\s+\d+.*/ });
-    select_console "x11";
+    send_key "ctrl-d";
+    wait_screen_change { send_key "ctrl-d" };
 
     ### RESIZE PARTITION ###
     wait_still_screen 3;
@@ -138,9 +141,12 @@ sub run {
     wait_screen_change { send_key "alt-f" };
 
     # check that the partion is ~170MiB (output is: /dev/vdb1     2048 355477  353430 172.6M 83 Linux)
-    select_console "root-console";
+    x11_start_program('xterm');
+    become_root;
+    wait_still_screen 3;
     validate_script_output("fdisk -l | grep /dev/vdb1", sub { m/\/dev\/vdb1\s+\d+\s+\d+\s+\d+\s+17.*/ });
-    select_console "x11";
+    send_key "ctrl-d";
+    wait_screen_change { send_key "ctrl-d" };
 
     ### DELETE PARTITION ###
     wait_still_screen 3;
@@ -152,11 +158,6 @@ sub run {
     wait_screen_change { send_key "alt-n" };
     wait_still_screen 1;
     wait_screen_change { send_key "alt-f" };
-
-    # check that /dev/vdb1 has been deleted
-    select_console "root-console";
-    validate_script_output("fdisk -l |grep -c /dev/vdb1", sub { m/0/ });
-    select_console "x11";
 
     ### CREATE VOLUME GROUP ###
     wait_still_screen 3;
@@ -215,13 +216,17 @@ sub run {
 
     # check that all logical volumes have been created
     wait_still_screen 5;
-    select_console "root-console";
+    x11_start_program('xterm');
+    become_root;
+    wait_still_screen 3;
     for (my $i = 1; $i <= 4; $i++) {
         assert_script_run "lvdisplay /dev/vgtest/lv$i";
     }
+    send_key "ctrl-d";
+    wait_screen_change { send_key "ctrl-d" };
 
     # Remove the volume group and all its logical volumes
-    select_console "x11";
+    wait_still_screen 1;
     start_y2sn $self;
     assert_and_click "yast2_storage_ng-select-vol-management";
     wait_screen_change { send_key(is_sle() ? "alt-l" : "alt-d") };

--- a/tests/yast2_gui/yast2_storage_ng.pm
+++ b/tests/yast2_gui/yast2_storage_ng.pm
@@ -224,7 +224,7 @@ sub run {
     select_console "x11";
     start_y2sn $self;
     assert_and_click "yast2_storage_ng-select-vol-management";
-    wait_screen_change { send_key(is_sle ? "alt-l" : "alt-d") };
+    wait_screen_change { send_key(is_sle() ? "alt-l" : "alt-d") };
     wait_screen_change { send_key "alt-t" };
     wait_screen_change { send_key "alt-n" };
     wait_still_screen 1;

--- a/tests/yast2_gui/yast2_storage_ng.pm
+++ b/tests/yast2_gui/yast2_storage_ng.pm
@@ -1,0 +1,242 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: YaST2 ...
+# Maintainer: Paolo Stivanin <pstivanin@suse.com>
+
+use base "y2x11test";
+use strict;
+use warnings;
+use testapi;
+use version_utils qw(is_sle is_tumbleweed is_opensuse);
+
+sub add_logical_volume {
+    my ($lvname, $role) = shift;
+    sleep 1;
+    wait_screen_change { send_key "alt-a" };
+    wait_screen_change { type_string "$lvname" };
+    wait_screen_change { send_key "alt-n" };
+    # custom size
+    if (is_sle('<=12-sp4')) {
+        send_key "alt-c";
+    } else {
+        send_key "alt-t";
+    }
+    sleep 1;
+    send_key "alt-s";
+    wait_screen_change { type_string "400MiB" };
+    wait_screen_change { send_key "alt-n" };
+    send_key "$role";
+    wait_screen_change { send_key "alt-n" };
+}
+
+sub encrypt_partition {
+    sleep 1;
+    if (is_sle('<=12-sp4')) {
+        send_key "alt-c";
+    } else {
+        send_key "alt-y";
+    }
+    wait_screen_change { send_key "alt-n" };
+    send_key "alt-t";
+    wait_screen_change { type_string "susetesting" };
+    send_key "alt-v";
+    wait_screen_change { type_string "susetesting" };
+    wait_screen_change {
+        if (is_sle('<=12-sp4')) {
+            send_key "alt-f";
+        } else {
+            send_key "alt-n";
+        }
+    };
+}
+
+sub select_vdb {
+    if (is_sle('<=12-sp4')) {
+        assert_and_dclick "yast2_storage_ng-select-vdb";
+    } else {
+        assert_and_click "yast2_storage_ng-select-vdb";
+        wait_screen_change { send_key "alt-p" } if is_opensuse;
+    }
+}
+
+sub start_y2sn {
+    my $self = shift;
+    $self->launch_yast2_module_x11("storage", match_timeout => 120);
+
+    wait_screen_change { send_key "alt-y" };
+    wait_still_screen 5;
+}
+
+sub run {
+    my $self = shift;
+    select_console "x11";
+
+    ensure_installed 'lvm2' if is_tumbleweed;
+
+    start_y2sn $self;
+    select_vdb;
+
+    ### ADD PARTITION ###
+    # /dev/vdb is unpartitioned, now we have to add a new partition
+    wait_screen_change { send_key "alt-a" };
+    if (is_sle('<=12-sp4')) {
+        wait_screen_change { send_key "alt-n" };
+        # custom size
+        send_key "alt-c";
+    } else {
+        # custom size
+        send_key "alt-o";
+    }
+    sleep 1;
+    # select entry and type partition size
+    send_key "alt-s";
+    wait_screen_change { type_string "200MiB" };
+    # next
+    wait_screen_change { send_key "alt-n" };
+    # select 'data and isv applications'
+    send_key "alt-d";
+    # next
+    wait_screen_change { send_key "alt-n" };
+    assert_and_click "yast2_storage_ng-filesystem-dropdown";
+    # XFS is the default filesystem, so we have to move up
+    send_key_until_needlematch("yast2_storage_ng-ext4", "up");
+    send_key "ret";
+    # encrypt the partition
+    sleep 1;
+    # on SLE 12.x it's not possible to resize an ext4 encrypted filesystem,
+    if (is_sle("<=12-sp4")) {
+        wait_screen_change { send_key "alt-f" };
+    } else {
+        encrypt_partition;
+    }
+    assert_screen "yast2_storage_ng-partition-created";
+    wait_screen_change { send_key "alt-n" };
+    wait_screen_change { send_key "alt-f" };
+
+    ### RESIZE PARTITION ###
+    sleep 3;
+    start_y2sn $self;
+    select_vdb;
+    # resize partition
+    if (is_opensuse) {
+        wait_screen_change { send_key "alt-m" };
+        wait_screen_change { send_key "alt-r" };
+    } else {
+        wait_screen_change { send_key "alt-i" };
+    }
+    sleep 1;
+    # custom size
+    send_key "alt-u";
+    sleep 1;
+    # select entry and type partition size
+    send_key "alt-s";
+    wait_screen_change { type_string "170MiB" };
+    if (is_sle("<=12-sp4")) {
+        wait_screen_change { send_key "alt-o" };
+    } else {
+        wait_screen_change { send_key "alt-n" };
+    }
+    assert_screen "yast2_storage_ng-partition-resized";
+    wait_screen_change { send_key "alt-n" };
+    sleep 1;
+    wait_screen_change { send_key "alt-f" };
+
+    ### DELETE PARTITION ###
+    sleep 3;
+    start_y2sn $self;
+    select_vdb;
+    wait_screen_change { send_key "alt-l" };
+    wait_screen_change { send_key "alt-y" };
+    assert_screen "yast2_storage_ng-unpartitioned";
+    wait_screen_change { send_key "alt-n" };
+    sleep 1;
+    wait_screen_change { send_key "alt-f" };
+
+    ### CREATE VOLUME GROUP ###
+    sleep 3;
+    start_y2sn $self;
+    assert_and_click "yast2_storage_ng-select-vol-management";
+    wait_screen_change { send_key "alt-a" };
+    # alt-v doesn't work reliably, so we have to use assert_and_click
+    assert_and_click "yast2_storage_ng-add-volume-group" if is_sle;
+    wait_screen_change { type_string "vgtest" };
+    assert_and_click "yast2_storage_ng-vg-select-device";
+    send_key "alt-a";
+    if (is_sle("<=12-sp4")) {
+        wait_screen_change { send_key "alt-f" };
+    } else {
+        wait_screen_change { send_key "alt-n" };
+    }
+    #  go to system view
+    send_key "alt-s";
+    assert_and_dclick "yast2_storage_ng-select-vgtest";
+
+    my $fs_page_shortcut = is_sle("<=12-sp4") ? "alt-f" : "alt-n";
+    wait_screen_change { send_key "alt-i" } if is_opensuse;
+
+    # XFS, non encrypted
+    add_logical_volume "lv1", "alt-d";
+    wait_screen_change { send_key $fs_page_shortcut };
+
+    # EXT4, encrypted
+    add_logical_volume "lv2", "alt-d";
+    assert_and_click "yast2_storage_ng-filesystem-dropdown";
+    send_key_until_needlematch("yast2_storage_ng-ext4", "up");
+    send_key "ret";
+    encrypt_partition;
+
+    # BtrFS, encrypted
+    add_logical_volume "lv3", "alt-d";
+    assert_and_click "yast2_storage_ng-filesystem-dropdown";
+    send_key_until_needlematch("yast2_storage_ng-btrfs", "up");
+    send_key "ret";
+    # BtrFS encryption fails on SLE 12.x, therefore we skip it
+    if (is_sle("<=12-sp4")) {
+        wait_screen_change { send_key $fs_page_shortcut };
+    } else {
+        encrypt_partition;
+    }
+
+    # Raw, non encrypted
+    my $raw_shortcut = is_sle("<=12-sp4") ? "alt-a" : "alt-r";
+    add_logical_volume "lv4", $raw_shortcut;
+    # on SLE 12.x the alt-a shortcut doesn't seem to work reliably, so here we 'force' the raw format
+    send_key "alt-d" if is_sle("<=12-sp4");
+    sleep 1;
+    wait_screen_change { send_key $fs_page_shortcut };
+
+    # summary and finish
+    wait_screen_change { send_key "alt-n" };
+    sleep 1;
+    wait_screen_change { send_key "alt-f" };
+
+    # check that all logical volumes have been created
+    sleep 5;
+    select_console "root-console";
+    assert_script_run 'for i in {1..4}; do lvdisplay "/dev/vgtest/lv${i}"; done';
+
+    # Remove the volume group and all its logical volumes
+    select_console "x11";
+    start_y2sn $self;
+    assert_and_click "yast2_storage_ng-select-vol-management";
+    wait_screen_change {
+        if (is_sle) {
+            send_key "alt-l";
+        } else {
+            send_key "alt-d";
+        }
+    };
+    wait_screen_change { send_key "alt-t" };
+    wait_screen_change { send_key "alt-n" };
+    sleep 1;
+    wait_screen_change { send_key "alt-f" };
+}
+
+1;

--- a/tests/yast2_gui/yast2_storage_ng.pm
+++ b/tests/yast2_gui/yast2_storage_ng.pm
@@ -20,13 +20,13 @@ use version_utils qw(is_sle is_tumbleweed is_opensuse);
 
 sub add_logical_volume {
     my ($lvname, $role) = shift;
-    sleep 1;
+    wait_still_screen 1;
     wait_screen_change { send_key "alt-a" };
     wait_screen_change { type_string "$lvname" };
     wait_screen_change { send_key "alt-n" };
     # custom size
     send_key(is_sle('<=12-sp4') ? "alt-c" : "alt-t");
-    sleep 1;
+    wait_still_screen 1;
     send_key "alt-s";
     wait_screen_change { type_string "400MiB" };
     wait_screen_change { send_key "alt-n" };
@@ -35,7 +35,7 @@ sub add_logical_volume {
 }
 
 sub encrypt_partition {
-    sleep 1;
+    wait_still_screen 1;
     send_key(is_sle('<=12-sp4') ? "alt-c" : "alt-y");
     wait_screen_change { send_key "alt-n" };
     send_key "alt-t";
@@ -82,7 +82,7 @@ sub run {
         # custom size
         send_key "alt-o";
     }
-    sleep 1;
+    wait_still_screen 1;
     # select entry and type partition size
     send_key "alt-s";
     wait_screen_change { type_string "200MiB" };
@@ -97,7 +97,7 @@ sub run {
     send_key_until_needlematch("yast2_storage_ng-ext4", "up");
     send_key "ret";
     # encrypt the partition
-    sleep 1;
+    wait_still_screen 1;
     # on SLE 12.x it's not possible to resize an ext4 encrypted filesystem,
     if (is_sle("<=12-sp4")) {
         wait_screen_change { send_key "alt-f" };
@@ -109,7 +109,7 @@ sub run {
     wait_screen_change { send_key "alt-f" };
 
     ### RESIZE PARTITION ###
-    sleep 3;
+    wait_still_screen 3;
     start_y2sn $self;
     select_vdb;
     # resize partition
@@ -119,10 +119,10 @@ sub run {
     } else {
         wait_screen_change { send_key "alt-i" };
     }
-    sleep 1;
+    wait_still_screen 1;
     # custom size
     send_key "alt-u";
-    sleep 1;
+    wait_still_screen 1;
     # select entry and type partition size
     send_key "alt-s";
     wait_screen_change { type_string "170MiB" };
@@ -130,22 +130,22 @@ sub run {
 
     assert_screen "yast2_storage_ng-partition-resized";
     wait_screen_change { send_key "alt-n" };
-    sleep 1;
+    wait_still_screen 1;
     wait_screen_change { send_key "alt-f" };
 
     ### DELETE PARTITION ###
-    sleep 3;
+    wait_still_screen 3;
     start_y2sn $self;
     select_vdb;
     wait_screen_change { send_key "alt-l" };
     wait_screen_change { send_key "alt-y" };
     assert_screen "yast2_storage_ng-unpartitioned";
     wait_screen_change { send_key "alt-n" };
-    sleep 1;
+    wait_still_screen 1;
     wait_screen_change { send_key "alt-f" };
 
     ### CREATE VOLUME GROUP ###
-    sleep 3;
+    wait_still_screen 3;
     start_y2sn $self;
     assert_and_click "yast2_storage_ng-select-vol-management";
     wait_screen_change { send_key "alt-a" };
@@ -191,16 +191,16 @@ sub run {
     add_logical_volume "lv4", $raw_shortcut;
     # on SLE 12.x the alt-a shortcut doesn't seem to work reliably, so here we 'force' the raw format
     send_key "alt-d" if is_sle("<=12-sp4");
-    sleep 1;
+    wait_still_screen 1;
     wait_screen_change { send_key $fs_page_shortcut };
 
     # summary and finish
     wait_screen_change { send_key "alt-n" };
-    sleep 1;
+    wait_still_screen 1;
     wait_screen_change { send_key "alt-f" };
 
     # check that all logical volumes have been created
-    sleep 5;
+    wait_still_screen 5;
     select_console "root-console";
     assert_script_run 'for i in {1..4}; do lvdisplay "/dev/vgtest/lv${i}"; done';
 
@@ -211,7 +211,7 @@ sub run {
     wait_screen_change { send_key(is_sle ? "alt-l" : "alt-d") };
     wait_screen_change { send_key "alt-t" };
     wait_screen_change { send_key "alt-n" };
-    sleep 1;
+    wait_still_screen 1;
     wait_screen_change { send_key "alt-f" };
 }
 

--- a/tests/yast2_gui/yast2_storage_ng.pm
+++ b/tests/yast2_gui/yast2_storage_ng.pm
@@ -7,7 +7,9 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: YaST2 ...
+# Summary: This test will check that creating, resizing, encrypting and
+#          deleting a partition, a volume group and some logical volumes work as
+#          intended.
 # Maintainer: Paolo Stivanin <pstivanin@suse.com>
 
 use base "y2x11test";
@@ -23,11 +25,7 @@ sub add_logical_volume {
     wait_screen_change { type_string "$lvname" };
     wait_screen_change { send_key "alt-n" };
     # custom size
-    if (is_sle('<=12-sp4')) {
-        send_key "alt-c";
-    } else {
-        send_key "alt-t";
-    }
+    send_key(is_sle('<=12-sp4') ? "alt-c" : "alt-t");
     sleep 1;
     send_key "alt-s";
     wait_screen_change { type_string "400MiB" };
@@ -38,23 +36,13 @@ sub add_logical_volume {
 
 sub encrypt_partition {
     sleep 1;
-    if (is_sle('<=12-sp4')) {
-        send_key "alt-c";
-    } else {
-        send_key "alt-y";
-    }
+    send_key(is_sle('<=12-sp4') ? "alt-c" : "alt-y");
     wait_screen_change { send_key "alt-n" };
     send_key "alt-t";
     wait_screen_change { type_string "susetesting" };
     send_key "alt-v";
     wait_screen_change { type_string "susetesting" };
-    wait_screen_change {
-        if (is_sle('<=12-sp4')) {
-            send_key "alt-f";
-        } else {
-            send_key "alt-n";
-        }
-    };
+    wait_screen_change { send_key(is_sle('<=12-sp4') ? "alt-f" : "alt-n") };
 }
 
 sub select_vdb {
@@ -138,11 +126,8 @@ sub run {
     # select entry and type partition size
     send_key "alt-s";
     wait_screen_change { type_string "170MiB" };
-    if (is_sle("<=12-sp4")) {
-        wait_screen_change { send_key "alt-o" };
-    } else {
-        wait_screen_change { send_key "alt-n" };
-    }
+    wait_screen_change { send_key(is_sle('<=12-sp4') ? "alt-o" : "alt-n") };
+
     assert_screen "yast2_storage_ng-partition-resized";
     wait_screen_change { send_key "alt-n" };
     sleep 1;
@@ -169,11 +154,8 @@ sub run {
     wait_screen_change { type_string "vgtest" };
     assert_and_click "yast2_storage_ng-vg-select-device";
     send_key "alt-a";
-    if (is_sle("<=12-sp4")) {
-        wait_screen_change { send_key "alt-f" };
-    } else {
-        wait_screen_change { send_key "alt-n" };
-    }
+    wait_screen_change { send_key(is_sle('<=12-sp4') ? "alt-f" : "alt-n") };
+
     #  go to system view
     send_key "alt-s";
     assert_and_dclick "yast2_storage_ng-select-vgtest";
@@ -226,13 +208,7 @@ sub run {
     select_console "x11";
     start_y2sn $self;
     assert_and_click "yast2_storage_ng-select-vol-management";
-    wait_screen_change {
-        if (is_sle) {
-            send_key "alt-l";
-        } else {
-            send_key "alt-d";
-        }
-    };
+    wait_screen_change { send_key(is_sle ? "alt-l" : "alt-d") };
     wait_screen_change { send_key "alt-t" };
     wait_screen_change { send_key "alt-n" };
     sleep 1;

--- a/tests/yast2_gui/yast2_storage_ng.pm
+++ b/tests/yast2_gui/yast2_storage_ng.pm
@@ -202,7 +202,9 @@ sub run {
     # check that all logical volumes have been created
     wait_still_screen 5;
     select_console "root-console";
-    assert_script_run 'for i in {1..4}; do lvdisplay "/dev/vgtest/lv${i}"; done';
+    for (my $i = 1; $i <= 4; $i++) {
+        assert_script_run "lvdisplay /dev/vgtest/lv$i";
+    }
 
     # Remove the volume group and all its logical volumes
     select_console "x11";


### PR DESCRIPTION
This PR adds a new regression test for yast2-storage-ng that will check the following features:

```
create ext4 partition
    resize partition
    encrypt partition
delete partition
create Volume Group
    create Logical Volume
        raw
        encrypted ext4
        encrypted btrfs
        XFS
```

- Related ticket: https://progress.opensuse.org/issues/50132
- Needles:
  - SLE: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1125
  - oS Leap and TW: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/547
- Verification runs:
  - oS TW: http://d502.qam.suse.de/tests/1768 :heavy_check_mark: 
  - oS Leap: http://d502.qam.suse.de/tests/1767 :heavy_check_mark: 
  - SLE 15: http://d502.qam.suse.de/tests/1769 :heavy_check_mark: 
  - SLE 12.4: http://d502.qam.suse.de/tests/1770 :heavy_check_mark: 
  - SLE 12.3: http://d502.qam.suse.de/tests/1771 :heavy_check_mark: 
  - SLE 12.2: http://d502.qam.suse.de/tests/1772 :heavy_check_mark: 
