### PR TITLE
Remove soft-failure for bsc#1017558

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -229,7 +229,6 @@ sub boot_local_disk {
 sub boot_into_snapshot {
     send_key_until_needlematch('boot-menu-snapshot', 'down', 10, 5);
     send_key 'ret';
-    record_soft_failure 'bsc#1017558:Cannot view timestamp of read-only snapshots in GRUB as names truncated' if is_leap;
     # assert needle to avoid send down key early in grub_test_snapshot.
     assert_screen 'snap-default' if get_var('OFW');
     # in upgrade/migration scenario, we want to boot from snapshot 1 before migration.


### PR DESCRIPTION
Bug seems to be resolved for Leap 15.1. For the soft failure we should
use specific needle instead of hard-coded condition.
