### PR TITLE
Increase the timeout before pressing 'return' in x11_start_program

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -230,7 +230,7 @@ sub x11_start_program {
         send_key 'esc';
         init_desktop_runner($program, $timeout);
     }
-    wait_still_screen(1);
+    wait_still_screen(3);
     save_screenshot;
     send_key 'ret';
     # As above especially krunner seems to take some time before disappearing


### PR DESCRIPTION
When testing https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7288,
Santiago Zarate noticed that it failed at https://openqa.opensuse.org/tests/910574#settings.

There seems to be [1] a race condition, with krunner being too slow to
parse the command line being written and thus, when x11_start_program
"presses return", krunner actually runs the first autocompleted
suggestion instead of the command itself.

[1] https://openqa.opensuse.org/tests/910574#step/kontact/2

This commit increases the timeout from 1 to 3 seconds to try to improve
this behaviour on slow systems