### PR TITLE
Bypass boo#1102076 machinery test for ppc64le

### DIFF
--- a/tests/console/machinery.pm
+++ b/tests/console/machinery.pm
@@ -44,8 +44,13 @@ sub run {
     }
     validate_script_output 'machinery --help', sub { m/machinery - A systems management toolkit for Linux/ }, 100;
     prepare_ssh_localhost_key_login 'root';
-    assert_script_run 'machinery inspect localhost',               300;
-    assert_script_run 'machinery show localhost | grep machinery', 100;
+    if (check_var('ARCH', 'ppc64le') && \
+        script_run "machinery inspect localhost | grep 'no machinery-helper for the remote system architecture'", 300) {
+        record_soft_failure 'boo#1125785 - no machinery-helper for this architecture.';
+    } else {
+        assert_script_run 'machinery inspect localhost',               300;
+        assert_script_run 'machinery show localhost | grep machinery', 100;
+    }
 }
 
 1;


### PR DESCRIPTION
reports soft failure as machinery-helper not available.
as per https://bugzilla.opensuse.org/show_bug.cgi?id=1125785

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>