### PR TITLE
Send key until Filter options are displayed in yast2 packager

### DIFF
--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -65,7 +65,7 @@ sub run {
 
     # we need to change filter to Search, in case yast2 reports available automatic update
     if ($is_inr_package) {
-        send_key 'alt-f';
+        send_key_until_needlematch 'yast2-sw-filter-opts', 'alt-f';
         wait_still_screen(stilltime => 2, timeout => 4, similarity_level => 50);
         wait_screen_change { send_key 'home' };
         send_key_until_needlematch 'yast2-sw_install-go-to-search', 'down';


### PR DESCRIPTION
- Related ticket: [[y][functional] test fails in yast2_i](https://progress.opensuse.org/issues/50495)
- Needles: 
   - [o3](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/548)
   - [osd](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1126)
- Verification runs: 
   * [TW Build20190415-kde-wayland@aarch64](http://eris.suse.cz/tests/13518#step/yast2_i/16)
   * [TW Build20190422-kde@64bit](http://eris.suse.cz/tests/13548#step/yast2_i/16)
   * [opensuse-15.1-DVD-x86_64-Build460.1-kde@64bit-2G](http://eris.suse.cz/tests/13547)
   * [opensuse-15.1-DVD-x86_64-Build460.1-gnome@64bit-2G](http://eris.suse.cz/tests/13544)
   * [TW gnome@aarch64](http://eris.suse.cz/tests/13546#step/yast2_i/1)
   * [sle-15-SP1-JeOS-for-kvm-and-xen-x86_64-Build34.46-jeos-main@uefi-virtio-vga](http://eris.suse.cz/tests/13566#step/yast2_i/1)
   * [sle-15-SP1-JeOS-for-RaspberryPi-aarch64-Build34.46-jeos-main-RPi@aarch64
](http://eris.suse.cz/tests/13569#step/yast2_i/1)
   * [opensuse-Tumbleweed-DVD-aarch64-Build20190415-minimalx@aarch64](http://eris.suse.cz/tests/13570#step/yast2_i/1)
   * [opensuse-Tumbleweed-DVD-aarch64-Build20190415-lxde@aarch64](http://eris.suse.cz/tests/13571#step/yast2_i/1)
   * [opensuse-Tumbleweed-DVD-aarch64-Build20190415-update_Leap_15.0_kde@aarch64](http://eris.suse.cz/tests/13574#step/yast2_i/1)

