### PR TITLE
Apparmor testcase fix

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -404,10 +404,13 @@ sub adminer_setup {
     assert_script_run("mv $adminer_file $adminer_dir");
 
     # Test Adminer can work
+    select_console 'x11';
     x11_start_program("firefox http://localhost/adminer/$adminer_file", target_match => "adminer-login", match_timeout => 300);
 
     # Exit x11 and turn to console
-    send_key_until_needlematch("generic-desktop", 'alt-f4', 2, 5);
+    send_key "alt-f4";
+    # Send "ret" key in case of any pop up message
+    send_key_until_needlematch("generic-desktop", 'ret', 5, 5);
     select_console("root-console");
     send_key "ctrl-c";
     clear_console;
@@ -415,6 +418,7 @@ sub adminer_setup {
 
 # Log in Adminer, seletct "test" database and delete it
 sub adminer_database_delete {
+    select_console 'x11';
     x11_start_program("firefox --setDefaultBrowser http://localhost/adminer/$adminer_file", target_match => "adminer-login", match_timeout => 300);
 
     # Do some operations on web, e.g., log in, select/delete a database

--- a/tests/security/apparmor_profile/usr_sbin_smbd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_smbd.pm
@@ -32,6 +32,7 @@ sub samba_server_setup {
     zypper_call("in samba samba-client yast2-samba-client yast2-samba-server");
     systemctl("restart smb");
 
+    select_console 'x11';
     y2x11test::launch_yast2_module_x11(module => "samba-server", target_match => "samba-server-installation", match_timeout => 200);
     send_key "alt-w";
     type_string("WORKGROUP");
@@ -70,6 +71,7 @@ sub samba_client_access {
     my $pw       = $apparmortest::pw;
 
     # Start "nautilus" to access the shares by "Windows Shares"
+    select_console 'x11';
     x11_start_program("nautilus", target_match => "nautilus-other-locations", match_timeout => 200);
 
     # Connect to samba server
@@ -126,6 +128,7 @@ sub run {
     $self->samba_server_setup();
 
     # Add a samba/linux common test user
+    zypper_call("in expect");
     script_run("userdel -rf $testuser");
     assert_script_run("useradd -m -d \/home\/$testuser $testuser");
     assert_script_run(


### PR DESCRIPTION
Enhance test cases apache2_changehat & usr_sbin_smbd to be run in Tumbleweed.
NOTE: There are 40 new opensuse needles added but the "Travis CI build fail" was not introduced by my needles.

- Related ticket: https://progress.opensuse.org/issues/49937
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/549
- Verification run: 
    Test results on Tumbelweed build 20190421: http://10.67.19.89/tests/884
    Test results on SLES15-SP1-b213.2: http://10.67.19.89/tests/883#
