### PR TITLE
Add ppc64 (BE) for validate_raid.pm

### DIFF
--- a/tests/console/validate_raid.pm
+++ b/tests/console/validate_raid.pm
@@ -76,7 +76,7 @@ my (
 );
 # Prepare test data depending on specific architecture/product
 sub prepare_test_data {
-    if (check_var('ARCH', 'ppc64le')) {
+    if (check_var('ARCH', 'ppc64le') || check_var('ARCH', 'ppc64')) {
         @partitioning = (
             $raid_partitions_3_arrays, $hard_disks, $linux_raid_member_3_arrays,
             $ext4_boot,


### PR DESCRIPTION
try correction of RAID0 test failure reported at 
https://openqa.opensuse.org/tests/916400#
