### PR TITLE
Change script_run to assert_script_run

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -132,8 +132,8 @@ sub install_services {
                 record_soft_failure('workaround for bug#1132292 zypper in apparmor failed msg popup');
             }
 
-            script_run 'systemctl enable ' . $srv_proc_name;
-            script_run 'systemctl start ' . $srv_proc_name;
+            assert_script_run 'systemctl enable ' . $srv_proc_name;
+            assert_script_run 'systemctl start ' . $srv_proc_name;
         }
     }
 }
@@ -144,7 +144,7 @@ sub check_services {
         my $srv_proc_name = $service->{$s}->{srv_proc_name};
         my $support_ver   = $service->{$s}->{support_ver};
         if (grep { $_ eq $hdd_base_version } split(',', $support_ver)) {
-            script_run 'systemctl status '
+            assert_script_run 'systemctl status '
               . $srv_proc_name
               . ' --no-pager | grep active';
         }


### PR DESCRIPTION
Change script_run to assert_script_run in service_check.pm file.

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: https://openqa.suse.de/tests/2825106#

Run following command do some sanity check, and the result is ok.
/usr/share/openqa/script/openqa-clone-custom-git-refspec https://github.com/os-autoinst/ostri-opensuse/pull/7328 http://openqa.suse.de/tests/2824063
Created job #2825106: sle-15-SP1-Installer-DVD-x86_64-Build216.1-online_sles15_pscc_basesys+srv+wsm_def_full_y@64bit -> http://openqa.suse.de/t2825106
