### PR TITLE
Add Y2DEBUG=1 ZYPP_MEDIA_CURL_DEBUG=1 to yast2 modules invocation

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -90,8 +90,8 @@ sub activate_kdump {
     # activate kdump
     type_string "echo \"remove potential harmful nokogiri package boo#1047449\"\n";
     zypper_call('rm -y ruby2.1-rubygem-nokogiri', exitcode => [0, 104]);
-    script_run 'yast2 kdump', 0;
-    my @tags = qw(yast2-kdump-disabled yast2-kdump-enabled yast2-kdump-restart-info yast2-missing_package yast2_console-finished);
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'kdump');
+    my @tags        = qw(yast2-kdump-disabled yast2-kdump-enabled yast2-kdump-restart-info yast2-missing_package yast2_console-finished);
     do {
         assert_screen \@tags, 300;
         # for ppc64le and aarch64 we need increase kdump memory, see bsc#957053 and bsc#1120566
@@ -109,6 +109,7 @@ sub activate_kdump {
         wait_screen_change { send_key 'alt-o' } if match_has_tag('yast2-kdump-restart-info');
         wait_screen_change { send_key 'alt-i' } if match_has_tag('yast2-missing_package');
     } until (match_has_tag('yast2_console-finished'));
+    wait_serial("$module_name-0", 240) || die "'yast2 kdump' didn't finish";
 }
 
 sub activate_kdump_without_yast {

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -562,7 +562,7 @@ sub registration_bootloader_params {
 }
 
 sub yast_scc_registration {
-    type_string "yast2 scc; echo sccreg-done-\$?- > /dev/$serialdev\n";
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'scc');
     assert_screen_with_soft_timeout(
         'scc-registration',
         timeout      => 90,
@@ -571,10 +571,7 @@ sub yast_scc_registration {
     );
 
     fill_in_registration_data;
-
-    my $ret = wait_serial "sccreg-done-\\d+-";
-    die "yast scc failed" unless (defined $ret && $ret =~ /sccreg-done-0-/);
-
+    wait_serial("$module_name-0", 150) || die "yast scc failed";
     # To check repos validity after registration, call 'validate_repos' as needed
 }
 

--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -46,7 +46,7 @@ sub get_repo_var_name {
 }
 
 sub smt_wizard {
-    type_string "yast2 smt-wizard;echo yast2-smt-wizard-\$? > /dev/$serialdev\n";
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'smt-wizard');
     assert_screen 'smt-wizard-1';
     send_key 'alt-u';
     wait_still_screen;
@@ -82,7 +82,7 @@ sub smt_wizard {
         assert_screen 'smt-sync-failed', 100;    # expect fail because there is no network
         send_key 'alt-o';
     }
-    wait_serial("yast2-smt-wizard-0", 800) || die 'smt wizard failed, it can be connection issue or credential issue';
+    wait_serial("$module_name-0", 800) || die 'smt wizard failed, it can be connection issue or credential issue';
 }
 
 sub smt_mirror_repo {

--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -30,6 +30,7 @@ our @EXPORT = qw(
   validate_etc_hosts_entry
   verify_network_configuration
 );
+my $module_name;
 
 sub initialize_y2lan
 {
@@ -49,7 +50,7 @@ sub initialize_y2lan
 }
 
 sub open_network_settings {
-    type_string "yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev\n";
+    $module_name = y2logsstep::yast2_console_exec(yast2_module => 'lan');
     accept_warning_network_manager_default;
     assert_screen 'yast2_lan', 180;       # yast2 lan overview tab
     send_key 'home';                      # select first device
@@ -60,7 +61,7 @@ sub close_network_settings {
     wait_still_screen 1, 1;
     send_key 'alt-o';
     # new: warning pops up for firewall, alt-y for assign it to zone
-    if (!wait_serial("yast2-lan-status-0", 180)) {
+    if (!wait_serial("$module_name-0", 180)) {
         check_screen([qw(yast2-lan-restart_firewall_active_warning yast2_lan_packages_need_to_be_installed)], 0);
         if (match_has_tag 'yast2-lan-restart_firewall_active_warning') {
             send_key 'alt-y';
@@ -72,7 +73,7 @@ sub close_network_settings {
         elsif (match_has_tag 'yast2_lan_packages_need_to_be_installed') {
             send_key 'alt-i';
         }
-        wait_serial("yast2-lan-status-0", 180) || die "'yast2 lan' didn't finish or exited with non-zero code";
+        wait_serial("$module_name-0", 180) || die "'yast2 lan' didn't finish or exited with non-zero code";
     }
 
     type_string "\n\n";    # make space for better readability of the console

--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -371,6 +371,22 @@ sub save_strace_gdb_output {
     }
 }
 
+sub yast2_console_exec {
+    my %args = @_;
+    die "Yast2 module has not been found among function arguments!\n" unless (defined($args{yast2_module}));
+    my $y2_start    = 'Y2DEBUG=1 ZYPP_MEDIA_CURL_DEBUG=1 yast2 ';
+    my $module_name = 'yast2-' . $args{yast2_module} . '-status';
+    $y2_start .= (defined($args{yast2_opts})) ?
+      $args{yast2_opts} . ' ' . $args{yast2_module} . ';' :
+      $args{yast2_module} . ';';
+
+    if (!script_run($y2_start . " echo $module_name-\$? > /dev/$serialdev", 0)) {
+        return $module_name;
+    } else {
+        die "Yast2 module failed to execute!\n";
+    }
+}
+
 sub post_fail_hook {
     my $self = shift;
     $self->SUPER::post_fail_hook;

--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -104,16 +104,15 @@ sub y2snapper_show_changes_and_delete {
 
 # Quit yast2-snapper and cleanup
 sub y2snapper_clean_and_quit {
-    my ($self, $ncurses) = @_;
-    $ncurses //= 0;
+    my ($self, $module_name) = @_;
 
     # Ensure yast2-snapper is not busy anymore
     wait_still_screen;
     # C'l'ose the snapper module
     wait_screen_change { send_key "alt-l"; };
 
-    if ($ncurses) {
-        wait_serial("yast2-snapper-status-0", 240) || die "yast2 snapper failed";
+    if (defined($module_name)) {
+        wait_serial("$module_name-0", 240) || die "yast2 snapper failed";
     }
     else {
         # Wait until root gnome terminal is focussed, delete the directory and close window
@@ -122,7 +121,7 @@ sub y2snapper_clean_and_quit {
 
     script_run 'rm -rf testdata';
     script_run "ls";
-    if (!$ncurses) {
+    unless (defined($module_name)) {
         type_string "exit\n";
         save_screenshot;
         type_string "exit\n";

--- a/lib/y2x11test.pm
+++ b/lib/y2x11test.pm
@@ -43,7 +43,7 @@ sub launch_yast2_module_x11 {
         select_console('x11');
     }
     # the command started with 'sh -c' to be able to execute 'echo' in Desktop Runner on Gnome
-    x11_start_program("sh -c 'xdg-su -c \"/sbin/yast2 $module\"; echo \"yast2-$module-status-\$?\" > /dev/$serialdev'", target_match => @tags, match_timeout => $args{match_timeout});
+    x11_start_program("sh -c 'xdg-su -c \"env Y2DEBUG=1 ZYPP_MEDIA_CURL_DEBUG=1 /sbin/yast2 $module\"; echo \"yast2-$module-status-\$?\" > /dev/$serialdev'", target_match => @tags, match_timeout => $args{match_timeout});
     foreach ($args{target_match}) {
         return if match_has_tag($_);
     }

--- a/tests/autoyast/clone.pm
+++ b/tests/autoyast/clone.pm
@@ -24,11 +24,11 @@ use testapi;
 sub run {
     my $self = shift;
     assert_script_run 'rm -f /root/autoinst.xml';
-    script_run("(yast2 --ncurses clone_system; echo yast2-clone_system-status-\$?) | tee /dev/$serialdev", 0);
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'clone_system', yast2_opts => '--ncurses');
     if (check_screen 'autoyast2-install-accept', 10) {
         send_key 'alt-i';    # confirm package installation
     }
-    wait_serial("yast2-clone_system-status-0", 400) || die "'yast2 clone_system' exited with non-zero code";
+    wait_serial("$module_name-0", 400) || die "'yast2 clone_system' exited with non-zero code";
     upload_logs '/root/autoinst.xml';
 
     # original autoyast on kernel cmdline

--- a/tests/autoyast/verify_btrfs_clone.pm
+++ b/tests/autoyast/verify_btrfs_clone.pm
@@ -31,9 +31,11 @@ my $xpc;
 sub test_setup {
     select_console('root-console');
     my $profile_path = '/root/autoinst.xml';
-    # Generate pofile if doesn't exist
-    assert_script_run("[ -e $profile_path ] | yast2 clone_system");
-
+    # Generate profile if doesn't exist
+    if (script_run("[ -e $profile_path ]")) {
+        my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'clone_system');
+        wait_serial("$module_name-0", 60) || die "'yast2 clone_system' exited with non-zero code";
+    }
     my $autoinst = script_output("cat $profile_path");
     # get XPathContext
     $xpc = get_xpc($autoinst);

--- a/tests/autoyast/verify_disk_as_pv_clone.pm
+++ b/tests/autoyast/verify_disk_as_pv_clone.pm
@@ -23,8 +23,10 @@ sub test_setup {
     select_console('root-console');
     my $profile_path = '/root/autoinst.xml';
     # Generate pofile if doesn't exist
-    assert_script_run("[ -e $profile_path ] | yast2 clone_system");
-
+    if (script_run("[ -e $profile_path ]")) {
+        my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'clone_system');
+        wait_serial("$module_name-0", 60) || die "'yast2 clone_system' exited with non-zero code";
+    }
     my $autoinst = script_output("cat $profile_path");
     # get XPathContext
     $xpc = get_xpc($autoinst);

--- a/tests/console/yast2_apparmor.pm
+++ b/tests/console/yast2_apparmor.pm
@@ -24,7 +24,7 @@ sub run {
     assert_script_run("/usr/bin/zypper -n -q in yast2-apparmor");
 
     # start apparmor configuration
-    script_run("yast2 apparmor; echo yast2-apparmor-status-\$? > /dev/$serialdev", 0);
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'apparmor');
     # check Apparmor Configuration is opened
     assert_screen 'yast2_apparmor';
     send_key 'ret';
@@ -82,7 +82,7 @@ sub run {
     # close apparmor configuration
     send_key(is_pre_15() ? 'alt-d' : 'alt-f');
     # increase value for timeout to 200 seconds
-    wait_serial("yast2-apparmor-status-0", 200) || die "'yast2 apparmor' didn't finish";
+    wait_serial("$module_name-0", 200) || die "'yast2 apparmor' didn't finish";
     systemctl 'show -p ActiveState apparmor.service | grep ActiveState=active';
     # currently not existing on sle15
     if (is_pre_15()) {
@@ -133,7 +133,7 @@ sub run {
 
         # close now AppArmor configuration
         send_key 'alt-n';
-        wait_serial("yast2-apparmor-status-0", 200) || die "'yast2 apparmor' didn't finish";
+        wait_serial("$module_name-0", 200) || die "'yast2 apparmor' didn't finish";
 
     }
 
@@ -142,7 +142,7 @@ sub run {
     assert_script_run("cp /etc/apparmor.d/sbin.syslogd /new_profile");
 
     # start apparmor configuration again
-    script_run("yast2 apparmor; echo yast2-apparmor-status-\$? > /dev/$serialdev", 0);
+    $module_name = y2logsstep::yast2_console_exec(yast2_module => 'apparmor');
     assert_screen 'yast2_apparmor';
     wait_screen_change { send_key 'down' };
     wait_screen_change { send_key 'down' };
@@ -171,7 +171,7 @@ sub run {
     # confirm to save changes to profile and finish test
     assert_screen 'yast2_apparmor_configuration_manage_existing_profiles_edit_file_changed_again';
     send_key 'alt-y';
-    wait_serial("yast2-apparmor-status-0", 200) || die "'yast2 apparmor' didn't finish";
+    wait_serial("$module_name-0", 200) || die "'yast2 apparmor' didn't finish";
 }
 
 sub post_fail_hook {

--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -23,7 +23,7 @@ sub run {
     # make sure yast2 bootloader module is installed
     zypper_call 'in yast2-bootloader';
 
-    script_run("yast2 bootloader; echo btld-status-\$? > /dev/$serialdev", 0);
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'bootloader');
     assert_screen "test-yast2_bootloader-1", 300;
     # OK => Close
     send_key "alt-o";
@@ -34,7 +34,7 @@ sub run {
         wait_screen_change { send_key 'alt-i'; };
     }
     assert_screen 'yast2_console-finished', $timeout;
-    wait_serial("btld-status-0") || die "'yast2 bootloader' didn't finish";
+    wait_serial("$module_name-0") || die "'yast2 bootloader' didn't finish";
 }
 
 1;

--- a/tests/console/yast2_clone_system.pm
+++ b/tests/console/yast2_clone_system.pm
@@ -25,7 +25,8 @@ sub run {
 
     # Install for TW and generate profile
     zypper_call "in autoyast2";
-    script_run("yast2 clone_system; echo yast2-clone-system-status-\$? > /dev/$serialdev", 0);
+
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'clone_system');
 
     # workaround for bsc#1013605
     my $timeout = 600;
@@ -34,7 +35,7 @@ sub run {
         wait_screen_change { send_key 'alt-o' };
         assert_screen 'yast2_console-finished', $timeout;
     }
-    wait_serial('yast2-clone-system-status-0') || die "'yast2 clone_system' didn't finish";
+    wait_serial("$module_name-0") || die "'yast2 clone_system' didn't finish";
 
     $self->select_serial_terminal;
     # Replace unitialized email variable - bsc#1015158

--- a/tests/console/yast2_dns_server.pm
+++ b/tests/console/yast2_dns_server.pm
@@ -32,8 +32,9 @@ sub run {
     # Pretend this is the 1st execution (could not be the case if yast2_cmdline was executed before)
     assert_script_run 'rm -f /var/lib/YaST2/dns_server';
 
-    record_info '1st run',         '[wizard-like interface] -> service active & enabled';
-    script_run 'yast2 dns-server', 0;
+    record_info '1st run', '[wizard-like interface] -> service active & enabled';
+    y2logsstep::yast2_console_exec(yast2_module => 'dns-server');
+
     continue_info_network_manager_default;
     assert_screen 'yast2-dns-server-step1';
     send_key 'alt-n';

--- a/tests/console/yast2_ftp.pm
+++ b/tests/console/yast2_ftp.pm
@@ -86,7 +86,7 @@ sub run {
     die "certificate does not exist" if assert_script_run("[[ -e $vsftpd_directives->{rsa_cert_file} ]]");
 
     # start yast2 ftp configuration
-    type_string "yast2 ftp-server; echo yast2-ftp-server-status-\$? > /dev/$serialdev\n";
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'ftp-server');
     assert_screen 'ftp-server';    # check ftp server configuration page
     if (is_sle('<15') || is_leap('<15.1')) {
         send_key 'alt-w';                           # make sure ftp start-up when booting
@@ -182,7 +182,7 @@ sub run {
     send_key 'alt-f';                                       # done and close the configuration page now
 
     # yast might take a while on sle12 due to suseconfig
-    die "'yast2 ftp-server' didn't exit with zero exit code in defined timeout" unless wait_serial("yast2-ftp-server-status-0", 180);
+    die "'yast2 ftp-server' didn't exit with zero exit code in defined timeout" unless wait_serial("$module_name-0", 180);
 
     # check /etc/vsftpd.conf whether it has been updated accordingly
     vsftd_setup_checker($vsftpd_directives);

--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -23,7 +23,7 @@ sub run {
     select_console 'root-console';
     # install http server
     zypper_call("-q in yast2-http-server");
-    script_run("yast2 http-server; echo yast2-http-server-status-\$? > /dev/$serialdev", 0);
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'http-server');
     continue_info_network_manager_default;
     assert_screen 'http-server', 180;    # check page "Initializing HTTP Server Configuration"
     wait_still_screen 1;
@@ -116,7 +116,7 @@ sub run {
     if (check_screen('http_enable_apache2', 10)) {
         wait_screen_change { send_key 'alt-o'; };
     }
-    wait_serial("yast2-http-server-status-0", 240) || die "'yast2 http-server' didn't finish";
+    wait_serial("$module_name-0", 240) || die "'yast2 http-server' didn't finish";
 }
 
 1;

--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -59,8 +59,7 @@ sub run {
             record_info("Required", "$1");
         }
     }
-
-    script_run("yast2 sw_single; echo y2-i-status-\$? > /dev/$serialdev", 0);
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'sw_single');
     assert_screen [qw(empty-yast2-sw_single yast2-preselected-driver)], 90;
 
     # we need to change filter to Search, in case yast2 reports available automatic update
@@ -147,7 +146,7 @@ sub run {
         die "PKGMGR_ACTION_AT_EXIT possible actions (summary|restart|close)!\n";
     }
 
-    wait_serial("y2-i-status-0", 120) || die "'yast2 sw_single' didn't finish";
+    wait_serial("$module_name-0", 120) || die "'yast2 sw_single' didn't finish";
 
     $self->clear_and_verify_console;         # clear screen to see that second update does not do any more
     assert_script_run("rpm -e $pkgname");    # erase $pkgname

--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils qw(is_tumbleweed is_jeos is_sle is_leap);
+use version_utils qw(is_tumbleweed is_sle is_leap);
 
 sub set_action {
     my $action = shift;
@@ -51,7 +51,7 @@ sub run {
     }
 
     # check required automatic updates, it is not scanned on sle12 codestream
-    if (is_sle('>=15-sp1') || is_tumbleweed || is_leap('>=15.1') || is_jeos) {
+    if (is_sle('>=15-sp1') || is_tumbleweed || is_leap('>=15.1')) {
         $output = script_output('zypper -n inr -D --no-recommends');
         my $zypper_regex = qr/The\s{1}following.*going\s{1}to\s{1}be\s{1}\w+:\s+([a-zA-Z0-9-_].*)/;
         if ($output =~ $zypper_regex) {

--- a/tests/console/yast2_lan.pm
+++ b/tests/console/yast2_lan.pm
@@ -20,6 +20,7 @@ use utils;
 use y2lan_restart_common;
 use version_utils ':VERSION';
 
+my $module_name;
 
 sub handle_Networkmanager_controlled {
     assert_screen "Networkmanager_controlled";
@@ -30,7 +31,7 @@ sub handle_Networkmanager_controlled {
         # SLED11...
         send_key 'alt-y';
     }
-    wait_serial("yast2-lan-status-0", 60) || die "'yast2 lan' didn't finish";
+    wait_serial("$module_name-0", 60) || die "'yast2 lan' didn't finish";
 }
 
 sub handle_dhcp_popup {
@@ -52,7 +53,7 @@ sub run {
 
     my $is_nm = !script_run('systemctl is-active NetworkManager');    # Revert boolean because of bash vs perl's return code.
 
-    script_run("yast2 lan; echo yast2-lan-status-\$? > /dev/$serialdev", 0);
+    $module_name = y2logsstep::yast2_console_exec(yast2_module => 'lan');
 
     if ($is_nm) {
         handle_Networkmanager_controlled;

--- a/tests/console/yast2_lan_hostname.pm
+++ b/tests/console/yast2_lan_hostname.pm
@@ -26,7 +26,8 @@ sub hostname_via_dhcp {
     $cmd{home}             = 'home';
     $cmd{spc}              = 'spc';
 
-    type_string "yast2 lan\n";
+    y2logsstep::yast2_console_exec(yast2_module => 'lan');
+    type_string "Y2DEBUG=1 ZYPP_MEDIA_CURL_DEBUG=1 yast2 \n";
     accept_warning_network_manager_default;
     assert_screen 'yast2_lan';
 

--- a/tests/console/yast2_nfs_client.pm
+++ b/tests/console/yast2_nfs_client.pm
@@ -54,7 +54,7 @@ sub run {
     #
     # YaST nfs-client execution
     #
-    type_string "yast2 nfs-client; echo YAST-DONE-\$?- > /dev/$serialdev\n";
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'nfs-client');
     assert_screen 'yast2-nfs-client-shares';
     # Open the dialog to add a connection to the share
     send_key 'alt-a';
@@ -73,7 +73,7 @@ sub run {
     wait_screen_change { send_key 'alt-o' };
     wait_screen_change { send_key 'alt-o' };
 
-    wait_serial('YAST-DONE-0-') or die "'yast2 nfs-server' didn't finish";
+    wait_serial("$module_name-0") or die "'yast2 nfs-server' didn't finish";
 
     clear_console;
 

--- a/tests/console/yast2_nfs_server.pm
+++ b/tests/console/yast2_nfs_server.pm
@@ -49,7 +49,7 @@ sub run {
     # Create a directory and place a test file in it
     assert_script_run 'mkdir /srv/nfs && echo success > /srv/nfs/file.txt';
 
-    type_string "yast2 nfs-server; echo YAST-DONE-\$?- > /dev/$serialdev\n";
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'nfs-server');
 
     do {
         assert_screen([qw(nfs-server-not-installed nfs-firewall nfs-config)]);
@@ -96,7 +96,7 @@ sub run {
     # Done
     assert_screen 'nfs-share-saved';
     send_key 'alt-f';
-    wait_serial('YAST-DONE-0-') or die "'yast2 nfs-server' didn't finish";
+    wait_serial("$module_name-0") or die "'yast2 nfs-server' didn't finish";
 
     # Back on the console, test mount locally
     clear_console;

--- a/tests/console/yast2_nis.pm
+++ b/tests/console/yast2_nis.pm
@@ -29,7 +29,7 @@ sub run() {
         assert_script_run 'firewall-cmd --permanent --service=ypbind --add-port=714/udp';
         assert_script_run 'firewall-cmd --reload';
     }
-    type_string "yast2 nis\n";
+    y2logsstep::yast2_console_exec(yast2_module => 'nis');
     assert_screen([qw(nis-client yast2_package_install)], 60);
     if (match_has_tag 'yast2_package_install') {
         send_key 'alt-i';

--- a/tests/console/yast2_ntpclient.pm
+++ b/tests/console/yast2_ntpclient.pm
@@ -44,7 +44,7 @@ sub run {
     zypper_call("in yast2-ntp-client", timeout => 180);
 
     # start NTP configuration
-    script_run("yast2 ntp-client; echo yast2-ntp-client-status-\$? > /dev/$serialdev", 0);
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'ntp-client');
 
     # check Advanced NTP Configuration is opened
     assert_screen([qw(yast2_ntp-client_configuration yast2_ntp-needs_install)], 90);
@@ -171,7 +171,7 @@ sub run {
 
     # press ok to finish configuration
     wait_screen_change { send_key 'alt-o'; };
-    wait_serial('yast2-ntp-client-status-0', 180);
+    wait_serial("$module_name-0", 180);
 
     # modify /etc/sysconfig/ntp (and not /etc/ntp.conf!!) to add NTPD_FORCE_SYNC_ON_STARTUP=yes
     script_run('sed -i \'s/^\\(NTPD_FORCE_SYNC_ON_STARTUP=\\).*$/\\1yes/\' /etc/sysconfig/ntp') if (!$is_chronyd);

--- a/tests/console/yast2_proxy.pm
+++ b/tests/console/yast2_proxy.pm
@@ -70,7 +70,7 @@ sub run {
     script_run 'echo "visible_hostname $HOSTNAME" >> /etc/squid/squid.conf';
 
     # start yast2 squid configuration
-    script_run("yast2 squid; echo yast2-squid-status-\$? > /dev/$serialdev", 0);
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'squid');
 
     # check that squid configuration page shows up
     assert_screen([qw(yast2_proxy_squid yast2_still_susefirewall2)], 60);
@@ -283,7 +283,7 @@ sub run {
     wait_screen_change { send_key 'alt-o'; };
 
     # yast might take a while on sle12 due to suseconfig
-    wait_serial("yast2-squid-status-0", 360) || die "'yast2 squid' didn't finish";
+    wait_serial("$module_name-0", 360) || die "'yast2 squid' didn't finish";
 
     # check squid proxy server status
     script_run 'systemctl show -p ActiveState squid.service|grep ActiveState=active';

--- a/tests/console/yast2_registration.pm
+++ b/tests/console/yast2_registration.pm
@@ -51,7 +51,7 @@ sub run {
     zypper_call "in yast2-registration";
 
     cleanup_registration;
-    script_run("yast registration", 0);
+    y2logsstep::yast2_console_exec(yast2_module => 'registration');
     assert_screen([qw(yast2_registration-overview yast2_registration-registration-page)]);
 
     send_key "alt-e" if (match_has_tag "yast2_registration-overview");

--- a/tests/console/yast2_rmt.pm
+++ b/tests/console/yast2_rmt.pm
@@ -17,8 +17,15 @@ use utils;
 use testapi;
 use repo_tools;
 
+sub password_twice {
+    type_password;
+    send_key "tab";
+    type_password;
+    send_key "alt-o";
+}
+
 sub test_ui {
-    script_run("yast2 rmt; echo yast2-rmt-server-status-\$? > /dev/$serialdev", 0);
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'rmt');
     assert_screen "yast2_rmt_registration";
     send_key "alt-n";
     assert_screen "yast2_rmt_ignore_registration_dialog";
@@ -52,7 +59,7 @@ sub test_ui {
     send_key "alt-n";
     assert_screen "yast2_rmt_config_summary";
     send_key "alt-f";
-    wait_serial('yast2-rmt-server-status-0', 60) || die "'yast2 rmt' didn't finish";
+    wait_serial("$module_name-0", 60) || die "'yast2 rmt' didn't finish";
 }
 
 sub test_config {

--- a/tests/console/yast2_snapper_ncurses.pm
+++ b/tests/console/yast2_snapper_ncurses.pm
@@ -21,15 +21,16 @@ sub run {
     select_console 'root-console';
     zypper_call('in yast2-snapper');
 
-    script_run("yast2 snapper; echo yast2-snapper-status-\$? > /dev/$serialdev", 0);
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'snapper');
+
     $self->y2snapper_new_snapshot(1);
-    wait_serial("yast2-snapper-status-0") || die "yast2 snapper failed";
+    wait_serial("$module_name-0") || die "yast2 snapper failed";
 
     $self->y2snapper_untar_testfile;
 
-    script_run("yast2 snapper; echo yast2-snapper-status-\$? > /dev/$serialdev", 0);
+    $module_name = y2logsstep::yast2_console_exec(yast2_module => 'snapper');
     $self->y2snapper_show_changes_and_delete(1);
-    $self->y2snapper_clean_and_quit(1);
+    $self->y2snapper_clean_and_quit($module_name);
 }
 
 sub post_fail_hook {

--- a/tests/console/yast2_tftp.pm
+++ b/tests/console/yast2_tftp.pm
@@ -21,7 +21,7 @@ use yast2_widget_utils 'change_service_configuration';
 sub run {
     select_console 'root-console';
     zypper_call("in tftp yast2-tftp-server", timeout => 240);
-    script_run("yast2 tftp-server; echo yast2-tftp-server-status-\$? > /dev/$serialdev", 0);
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'tftp-server');
     # make sure the module is loaded and any potential popups are there to be
     # asserted later
     wait_still_screen(3);
@@ -92,7 +92,7 @@ sub run {
     send_key 'alt-y';                               # approve creation of new directory
 
     # wait for yast2 tftp configuration completion
-    wait_serial("yast2-tftp-server-status-0", 180) || die "'yast2 tftp-server' failed";
+    wait_serial("$module_name-0", 180) || die "'yast2 tftp-server' failed";
 
     # create a test file for tftp server
     my $server_string = 'This is a QA tftp server';

--- a/tests/console/yast2_vnc.pm
+++ b/tests/console/yast2_vnc.pm
@@ -19,6 +19,7 @@ use registration 'add_suseconnect_product';
 use yast2_shortcuts qw($is_older_product %remote_admin %firewall_settings %firewall_details $confirm);
 
 sub configure_remote_admin {
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'remote');
     # Remote Administration Settings
     assert_screen 'yast2_vnc_remote_administration';
     return if check_var('ARCH', 's390x');
@@ -39,7 +40,7 @@ sub configure_remote_admin {
     send_key $confirm;
     assert_screen 'yast2_vnc_warning_text';
     send_key $cmd{ok};
-    wait_serial('yast2-remote-status-0', 60) || die "'yast2 remote' didn't finish";
+    wait_serial("$module_name-0", 60) || die "'yast2 remote' didn't finish";
 }
 
 sub check_service_listening {
@@ -60,7 +61,6 @@ sub test_setup {
         add_suseconnect_product('sle-module-desktop-applications', undef, undef, undef, 180);
     }
     zypper_call('in vncmanager xorg-x11' . ($is_older_product ? ' net-tools' : ''));
-    script_run("yast2 remote; echo yast2-remote-status-\$? > /dev/$serialdev", 0);
 }
 
 sub run {

--- a/tests/console/yast2_xinetd.pm
+++ b/tests/console/yast2_xinetd.pm
@@ -16,7 +16,6 @@ use base "console_yasttest";
 use testapi;
 use utils;
 
-
 sub run {
     my ($self) = @_;
     select_console 'root-console';
@@ -26,7 +25,7 @@ sub run {
     # install xinetd at first
     zypper_call("in xinetd yast2-inetd", timeout => 180);
 
-    script_run("yast2 xinetd; echo yast2-xinetd-status-\$? > /dev/$serialdev", 0);
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'xinetd');
 
     # check xinetd network configuration got started
     assert_screen([qw(yast2_xinetd_startup yast2_xinetd_core-dumped)], 90);
@@ -91,7 +90,7 @@ sub run {
     wait_screen_change { send_key 'alt-f'; };
 
     # wait till xinetd got closed
-    wait_serial('yast2-xinetd-status-0', 180) || die "'yast2 xinetd' didn't finish";
+    wait_serial("$module_name-0", 180) || die "'yast2 xinetd' didn't finish";
 
     # check xinetd configuration
     systemctl 'show -p ActiveState xinetd.service | grep ActiveState=active';

--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -26,7 +26,7 @@ sub run {
     configure_default_gateway;
     configure_static_ip('10.0.2.3/24');
     configure_static_dns(get_host_resolv_conf());
-    type_string "yast2 iscsi-client\n";
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'iscsi-client');
     assert_screen 'iscsi-client', 180;
     mutex_lock('iscsi_ready');    # wait for server setup
     send_key "alt-i";             # go to initiator name field
@@ -51,6 +51,7 @@ sub run {
     assert_screen 'iscsi-initiator-connected-targets';
     send_key "alt-o";                                     # OK
     wait_still_screen(2, 10);
+    wait_serial("$module_name-0", 180) || die "'yast2 iscsi-client ' didn't finish or exited with non-zero code";
     assert_script_run 'lsscsi';
     assert_script_run "echo -e \"n\\np\\n1\\n\\n\\nw\\n\" \| fdisk /dev/sda";    # create one partition
     assert_script_run 'mkfs.ext4 /dev/sda1';                                     # format partition to ext4

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -34,7 +34,7 @@ sub run {
     configure_static_dns(get_host_resolv_conf());
     zypper_call 'in yast2-iscsi-lio-server';
     assert_script_run 'dd if=/dev/zero of=/root/iscsi-disk seek=1M bs=8192 count=1';    # create iscsi LUN
-    type_string "yast2 iscsi-lio-server; echo yast2-iscsi-server-\$? > /dev/$serialdev\n";
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'iscsi-server');
     assert_screen 'iscsi-lio-server';
     unless (is_sle('<15') || is_leap('<15.1')) {
         change_service_configuration(
@@ -91,7 +91,7 @@ sub run {
     }
     assert_screen 'iscsi-target-overview-target-tab';
     send_key 'alt-f';                                                                   # finish
-    wait_serial("yast2-iscsi-server-0", 180) || die "'yast2 iscsi-lio ' didn't finish or exited with non-zero code";
+    wait_serial("$module_name-0", 180) || die "'yast2 iscsi-server ' didn't finish or exited with non-zero code";
     mutex_create('iscsi_ready');                                                        # setup is done client can connect
     type_string "killall xterm\n";
     wait_for_children;                                                                  # run till client is done

--- a/tests/x11/nis_client.pm
+++ b/tests/x11/nis_client.pm
@@ -112,12 +112,12 @@ sub run {
     }
 
     mutex_lock('nis_ready');    # wait for NIS server setup
-    script_run("yast2 nis; echo yast2-nis-status-\$? > /dev/$serialdev", 0);
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'nis');
     setup_nis_client();
     mutex_lock('nfs_ready');    # wait for NFS server setup
     nfs_settings_tab();
     nfs_shares_tab();
-    wait_serial("yast2-nis-status-0", 360) || die "'yast2 nis client' didn't finish";
+    wait_serial("$module_name-0", 360) || die "'yast2 nis client' didn't finish";
     setup_verification();
     type_string "killall xterm\n";    # game over -> xterm
 }

--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -133,15 +133,16 @@ sub run {
         systemctl 'stop ' . $self->firewall;
         record_soft_failure('bsc#999873');
     }
-    script_run("yast2 nis_server; echo yast2-nis-server-status-\$? > /dev/$serialdev", 0);
+    my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'nis_server');
     nis_server_configuration();
-    wait_serial("yast2-nis-server-status-0", 360) || die "'yast2 nis server' didn't finish";
+    wait_serial("$module_name-0", 360) || die "'yast2 nis server' didn't finish";
     assert_screen 'yast2_closed_xterm_visible';
     # NIS Server is configured and running, configuration continues on client side
     mutex_create('nis_ready');
+    $module_name = y2logsstep::yast2_console_exec(yast2_module => 'nfs_server');
     script_run("yast2 nfs_server; echo yast2-nfs-server-status-\$? > /dev/$serialdev", 0);
     nfs_server_configuration();
-    wait_serial("yast2-nfs-server-status-0", 360) || die "'yast2 nfs server' didn't finish";
+    wait_serial("$module_name-0", 360) || die "'yast2 nfs server' didn't finish";
     assert_screen 'yast2_closed_xterm_visible', 200;
     # NFS Server is configured and running, configuration continues on client side
     mutex_create('nfs_ready');

--- a/tests/x11/yast2_snapper.pm
+++ b/tests/x11/yast2_snapper.pm
@@ -36,13 +36,13 @@ sub run {
     x11_start_program('xterm');
     become_root;
     script_run "cd";
-    type_string "yast2 snapper\n";
+    y2logsstep::yast2_console_exec(yast2_module => 'snapper');
     $self->y2snapper_new_snapshot;
 
     wait_still_screen;
     $self->y2snapper_untar_testfile;
 
-    type_string "yast2 snapper; echo yast2-snapper-status-\$? > /dev/$serialdev\n";
+    y2logsstep::yast2_console_exec(yast2_module => 'snapper');
     $self->y2snapper_show_changes_and_delete;
     $self->y2snapper_clean_and_quit;
 }


### PR DESCRIPTION
`` ../tests/console/yast2_i.pm:75 called y2logsstep::yast2_console_exec
 testapi::script_run(cmd='Y2DEBUG=1 ZYPP_MEDIA_CURL_DEBUG=1 yast2 sw_single; echo yast2-sw_single-status-$? > /dev/ttyS0', wait=0)
``

and restricting ``zypper --no-recommends`` in yast_i module for tw, leap15.1+ and sle15.1+
http://eris.suse.cz/tests/13649#step/yast2_i/13

- Related ticket: [[functional][y] Enable Y2DEBUG for all yast module tests
](https://progress.opensuse.org/issues/45473)
- Verification runs:
   * console:
     - [opensuse-15.0-JeOS-for-kvm-and-xen-x86_64-Build20.214-jeos@64bit_virtio-2G](http://eris.suse.cz/tests/13659#step/yast2_i/1) 
     - [sle-15-SP1-Installer-DVD-x86_64-Build219.1-yast2_ncurses@64bit](http://eris.suse.cz/tests/13664)
     - [opensuse-15.1-DVD-x86_64-Build463.2-yast2_ncurses@64bit](http://eris.suse.cz/tests/13669)
     - [opensuse-Tumbleweed-DVD-x86_64-Build20190428-yast2_ncurses@64bit](http://eris.suse.cz/tests/13668)
     - []()
   * GUI:
     - [sle-12-SP5-Server-DVD-x86_64-Build0145-yast2_gui@64bit](http://eris.suse.cz/tests/13678#)
     - [sle-15-SP1-Installer-DVD-x86_64-Build219.1-yast2_gui@64bit](http://eris.suse.cz/tests/13683)
     - [http://eris.suse.cz/tests/13689#step/yast_virtualization/1](http://eris.suse.cz/tests/13689)
     - [opensuse-15.1-DVD-x86_64-Build463.2-yast2_gui@64bit](http://eris.suse.cz/tests/13687)
     - [opensuse-15.1-DVD-x86_64-Build464.1-yast2_gui@64bit](http://eris.suse.cz/tests/13688)
     - [opensuse-Tumbleweed-DVD-x86_64-Build20190428-yast2_gui@64bit](http://eris.suse.cz/tests/13692)
     - [opensuse-Tumbleweed-DVD-aarch64-Build20190428-yast2_gui@aarch64](http://eris.suse.cz/tests/13690)
     - [opensuse-15.1-DVD-aarch64-Build453.3-yast2_gui@aarch64](http://eris.suse.cz/tests/13691)
   * ay:
     - [sle-15-SP1-Installer-DVD-x86_64-Build220.3-autoyast_btrfs@64bit
](http://eris.suse.cz/tests/13682#)
