### PR TITLE
Scroll Partition Id from top for filesystem-prep search

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -316,8 +316,8 @@ sub add_prep_boot_partition {
     assert_screen 'partitioning_raid-format_noformat';
     send_key 'alt-i';
     assert_screen 'partitioning_raid-file_system_id-selected';
-    my $direction_key = (is_storage_ng) ? 'up' : 'down';
-    send_key_until_needlematch 'filesystem-prep', $direction_key;
+    send_key 'home';
+    send_key_until_needlematch 'filesystem-prep', 'down';
     send_key $cmd{exp_part_finish};
     if (is_storage_ng) {
         send_key 'down';


### PR DESCRIPTION
This is required for ppc64le that seems to have different 'Partition Id' order
compared to ppc64 (BE), at least since TW 20190423.

passed with ppc64 (BE)
https://openqa.opensuse.org/tests/916880#step/partitioning_raid/20
failed with ppc64le
https://openqa.opensuse.org/tests/916927#step/partitioning_raid/57

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>
