### PR TITLE
Virtualization: only enable UPLOAD_GUEST_ASSETS for x86_64

### DIFF
--- a/tests/virt_autotest/guest_installation_run.pm
+++ b/tests/virt_autotest/guest_installation_run.pm
@@ -57,12 +57,15 @@ sub run {
     my $self = shift;
 
     # Add option to keep guest after successful installation
-    assert_script_run("sed -i 's/vm-install.sh/vm-install\.sh -g /' /usr/share/qa/qa_test_virtualization/installos");
-    assert_script_run("sed -i 's/virt-install.sh/virt-install\.sh -u /' /usr/share/qa/qa_test_virtualization/virt_installos");
-    assert_script_run('cat /usr/share/qa/qa_test_virtualization/installos | grep vm-install');
-    save_screenshot;
-    assert_script_run('cat /usr/share/qa/qa_test_virtualization/virt_installos | grep virt-install');
-    save_screenshot;
+    # Only for x86_64 now
+    if (check_var('ARCH', 'x86_64')) {
+        assert_script_run("sed -i 's/vm-install.sh/vm-install\.sh -g /' /usr/share/qa/qa_test_virtualization/installos");
+        assert_script_run("sed -i 's/virt-install.sh/virt-install\.sh -u /' /usr/share/qa/qa_test_virtualization/virt_installos");
+        assert_script_run('cat /usr/share/qa/qa_test_virtualization/installos | grep vm-install');
+        save_screenshot;
+        assert_script_run('cat /usr/share/qa/qa_test_virtualization/virt_installos | grep virt-install');
+        save_screenshot;
+    }
 
     $self->{"product_tested_on"} = "SLES-12-SP2";
     $self->{"product_name"}      = "GuestIn_stallation";
@@ -70,7 +73,8 @@ sub run {
     $self->{success_guest_list}  = [];
 
     my $upload_guest_assets_flag = 'no';
-    if (check_var('UPLOAD_GUEST_ASSETS', '1')) {
+    # Only enable UPLOAD_GUEST_ASSETS for x86_64 now
+    if (check_var('UPLOAD_GUEST_ASSETS', '1') && check_var('ARCH', 'x86_64')) {
         $upload_guest_assets_flag = 'yes';
     }
 


### PR DESCRIPTION
UPLOAD_GUEST_ASSETS PR#7145 is only fully tested on x86_64, rather than aarch and s390, so only enable it on x86. When full test on other arches are done and maybe  some code changes needed, then can open a separate PR  to enable it on them.


- Verification run: 

x86: http://10.67.18.220/tests/697
s390x: http://10.67.18.220/tests/699