### PR TITLE
Enable license handling for sle15sp1 and opensuse distris

### DIFF
--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -37,13 +37,16 @@ sub language_and_keyboard {
 
 sub license {
     my $self = shift;
-    return unless is_sle('>=12-sp4');
-    assert_screen('license-agreement');
-    $self->verify_license_has_to_be_accepted;
-    $self->accept_license;
+    # default TO value was not sufficient
+    assert_screen('license-agreement', 60);
+    # Nothing to be accepted in opensuse
+    unless (is_opensuse) {
+        $self->verify_license_has_to_be_accepted;
+        $self->accept_license;
+    }
     wait_screen_change(sub { send_key $cmd{next}; }, 7);
-    # Workaround license checkbox
-    assert_screen(qw(license-agreement inst-timezone));
+    # Workaround license checkbox, applicable for sle12sp5 only currently
+    assert_screen([qw(license-agreement inst-timezone)]);
     if (match_has_tag('license-agreement')) {
         record_soft_failure 'bsc#1131327 License checkbox was cleared! Re-check again!';
         send_key 'alt-a';


### PR DESCRIPTION
- Needles:
  * [o3 - adding leap](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/551)
  * [osd -fix summary](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1127/)

- Verification runs:
    * opensuse
       * [TW-DVD-x86_64-Build20190424-yast2_firstboot@64bit](http://eris.suse.cz/tests/13640#step/yast2_firstboot/1) 
       * [TW-x86_64-Build20190424-autoyast_y2_firstboot@64bit
](http://eris.suse.cz/tests/13615#step/yast2_firstboot/1)
       * [opensuse-15.1-DVD-x86_64-Build462.1-yast2_firstboot@64bit](http://eris.suse.cz/tests/13635#step/yast2_firstboot/1)
       * [opensuse-15.1-DVD-x86_64-Build462.1-autoyast_y2_firstboot@64bit](http://eris.suse.cz/tests/13636#step/yast2_firstboot/1)

    * sle
      * [sle-15-SP1-Installer-DVD-x86_64-Build216.4-yast2_firstboot@64bit](http://eris.suse.cz/tests/13619#step/yast2_firstboot/1)
      * [sle-15-SP1-Installer-DVD-x86_64-Build216.4-autoyast_y2_firstboot@64bit](http://eris.suse.cz/tests/13633#step/yast2_firstboot/1)
      * [sle-12-SP5-Server-DVD-x86_64-Build0145-autoyast_y2_firstboot_sle12@64bit](http://eris.suse.cz/tests/13625#step/yast2_firstboot/1)
      * [sle-12-SP5-Server-DVD-x86_64-Build0145-yast2_firstboot@64bit](http://eris.suse.cz/tests/13638#step/yast2_firstboot/1)


