### PR TITLE
Use arrayref instead of array in yast2_firstboot

### DIFF
--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -37,13 +37,13 @@ sub language_and_keyboard {
 
 sub license {
     my $self = shift;
-    return unless is_sle('>=12-sp4');
+    return if is_sle('<12-sp4');
     assert_screen('license-agreement');
     $self->verify_license_has_to_be_accepted;
     $self->accept_license;
     wait_screen_change(sub { send_key $cmd{next}; }, 7);
     # Workaround license checkbox
-    assert_screen(qw(license-agreement inst-timezone));
+    assert_screen([qw(license-agreement inst-timezone)]);
     if (match_has_tag('license-agreement')) {
         record_soft_failure 'bsc#1131327 License checkbox was cleared! Re-check again!';
         send_key 'alt-a';


### PR DESCRIPTION
Second needle tag was treated as a timeout.

[Verification run](http://f174.suse.de/tests/207#).
