### PR TITLE
Fix and simplify boot_grub_item function

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -168,20 +168,20 @@ Boot the default kernel recovery mode (goes through "Advanced options"):
 
 =cut
 sub boot_grub_item {
-    my ($self, $menu1, $menu2) = @_;
+    my ($menu1, $menu2) = @_;
     $menu1 = 3 unless defined($menu1);
     $menu2 = 1 unless defined($menu2);
-    die((caller(0))[3] . " expects integer arguments ($menu1, $menu2") unless ($menu1 =~ /^\d+\z/ && $menu2 =~ /^\d+\z/);
+    die((caller(0))[3] . " expects integer arguments ($menu1, $menu2)") unless ($menu1 =~ /^\d+\z/ && $menu2 =~ /^\d+\z/);
 
     assert_screen "grub2";
 
-    for my $i (1 .. ($menu1 - 1)) {
+    for (1 .. ($menu1 - 1)) {
         wait_screen_change { send_key 'down' };
     }
     save_screenshot;
     send_key 'ret';
 
-    for my $i (1 .. ($menu2 - 1)) {
+    for (1 .. ($menu2 - 1)) {
         wait_screen_change { send_key 'down' };
     }
     save_screenshot;

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2018 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -26,7 +26,7 @@ sub run {
 
     if ($is_ima) {
         # boot kernel with IMA parameters
-        $self->boot_grub_item();
+        boot_grub_item();
     }
     else {
         # during install_ltp, the second boot may take longer than usual

--- a/tests/rt/boot_rt_kernel.pm
+++ b/tests/rt/boot_rt_kernel.pm
@@ -18,8 +18,7 @@ use bootloader_setup 'boot_grub_item';
 use x11utils 'handle_login';
 
 sub run() {
-    my $self = shift;
-    $self->boot_grub_item(2, 3);
+    boot_grub_item(2, 3);
     assert_screen 'displaymanager', 60;
     handle_login;
     assert_screen 'generic-desktop';


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/50429
- Verification run:
with boot_grub_item(3, 1); http://10.100.12.155/tests/11511#step/boot_ltp/3
with default boot_grub_item(); http://10.100.12.155/tests/11512#step/boot_ltp/3
developed grub2 test http://10.100.12.155/tests/11513#step/grub2_test/3