### PR TITLE
Add a new test for haproxy

### DIFF
--- a/data/ha/haproxy.cfg.template
+++ b/data/ha/haproxy.cfg.template
@@ -1,0 +1,35 @@
+global
+  maxconn 256
+  daemon
+
+defaults
+  log     global
+  mode    http
+  option  httplog
+  option  dontlognull
+  retries 3
+  option redispatch
+  maxconn 2000
+  timeout connect   5000
+  timeout client    50s
+  timeout server    50000
+
+frontend LB
+  bind %VIP_IP%:8080
+  reqadd X-Forwarded-Proto:\ http
+  default_backend LB
+
+backend LB
+  mode http
+  stats enable
+  stats hide-version
+  stats uri /stats
+  stats realm Haproxy\ Statistics
+  stats auth haproxy:password
+  balance roundrobin
+  option  httpclose
+  option forwardfor
+  cookie LB insert
+  option httpchk GET /robots.txt HTTP/1.0
+  server %NODE_01% %NODE_01_IP%:80 cookie %NODE_01%
+  server %NODE_02% %NODE_02_IP%:80 cookie %NODE_02%

--- a/data/ha/haproxy_apache.template
+++ b/data/ha/haproxy_apache.template
@@ -1,0 +1,4 @@
+<html>
+This is server %NODE% !!!
+IP: %IP%
+</html>

--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -95,8 +95,8 @@ sub get_node_to_join {
 
 sub get_ip {
     my $node_hostname = shift;
-    $_ = script_output "host -t A $node_hostname";
-    if ($_ =~ /(\d+\.\d+\.\d+\.\d+)/) {
+    my $node_ip       = script_output "host -t A $node_hostname";
+    if ($node_ip =~ /(\d+\.\d+\.\d+\.\d+)/) {
         return $1;
     }
     return 0;

--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -27,6 +27,7 @@ our @EXPORT = qw(
   add_file_in_csync
   get_cluster_name
   get_hostname
+  get_ip
   get_node_to_join
   get_node_number
   is_node
@@ -90,6 +91,15 @@ sub get_hostname {
 
 sub get_node_to_join {
     return get_required_var('HA_CLUSTER_JOIN');
+}
+
+sub get_ip {
+    my $node_hostname = shift;
+    $_ = script_output "host -t A $node_hostname";
+    if ($_ =~ /(\d+\.\d+\.\d+\.\d+)/) {
+        return $1;
+    }
+    return 0;
 }
 
 sub get_node_number {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2591,9 +2591,12 @@ sub load_ha_cluster_tests {
         # Test Hawk Web interface
         loadtest 'ha/check_hawk';
 
-        # If testing HAWK's GUI, skip the rest of the cluster
+        # Test Haproxy
+        loadtest 'ha/haproxy' if (get_var('HA_CLUSTER_HAPROXY'));
+
+        # If testing HAWK's GUI or HAPROXY, skip the rest of the cluster
         # setup tests and only check logs
-        if (get_var('HAWKGUI_TEST_ROLE')) {
+        if (get_var('HAWKGUI_TEST_ROLE') or get_var('HA_CLUSTER_HAPROXY')) {
             loadtest 'ha/check_logs' if !get_var('INSTALLONLY');
             return 1;
         }

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -65,6 +65,8 @@ sub run {
         barrier_create("SLE11_UPGRADE_INIT_$cluster_name",          $num_nodes);
         barrier_create("SLE11_UPGRADE_START_$cluster_name",         $num_nodes);
         barrier_create("SLE11_UPGRADE_DONE_$cluster_name",          $num_nodes);
+        barrier_create("HAPROXY_INIT_$cluster_name",                $num_nodes);
+        barrier_create("HAPROXY_DONE_$cluster_name",                $num_nodes);
 
         # HAWK_GUI_ barriers also have to wait in the client
         barrier_create("HAWK_GUI_INIT_$cluster_name",    $num_nodes + 1);

--- a/tests/ha/drbd_passive.pm
+++ b/tests/ha/drbd_passive.pm
@@ -37,8 +37,8 @@ sub run {
     # arbitrary choose the first two
     my $node_01    = choose_node(1);
     my $node_02    = choose_node(2);
-    my $node_01_ip = script_output "host -t A $node_01 | awk '{ print \$NF }'";
-    my $node_02_ip = script_output "host -t A $node_02 | awk '{ print \$NF }'";
+    my $node_01_ip = get_ip($node_01);
+    my $node_02_ip = get_ip($node_02);
 
     # At this time, we only test DRBD on a 2 nodes cluster
     # And if the cluster has more than 2 nodes, we only use the first 2 nodes

--- a/tests/ha/haproxy.pm
+++ b/tests/ha/haproxy.pm
@@ -1,0 +1,111 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test haproxy resource agent
+# Maintainer: Julien Adamek <jadamek@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use utils qw(zypper_call systemctl);
+use hacluster;
+
+sub run {
+    my $cluster_name = get_cluster_name;
+    my $haproxy_rsc  = 'haproxy';
+    my $haproxy_cfg  = '/etc/haproxy/haproxy.cfg';
+    my $apache_file  = '/srv/www/htdocs/index.html';
+    my $vip_ip       = '10.0.2.20';
+    my $vip_rsc      = 'vip';
+    my $node_01      = choose_node(1);
+    my $node_02      = choose_node(2);
+    my $node_01_ip   = script_output "host -t A $node_01 | awk '{ print \$NF }'";
+    my $node_02_ip   = script_output "host -t A $node_02 | awk '{ print \$NF }'";
+
+    # Waiting for the other nodes to be ready
+    barrier_wait("HAPROXY_INIT_$cluster_name");
+
+    # Installation of haproxy and apache2 packages
+    zypper_call 'in haproxy apache2';
+    save_screenshot;
+
+    # Get apache file template from the openQA server
+    assert_script_run "curl -f -v " . autoinst_url . "/data/ha/haproxy_apache.template -o $apache_file";
+
+    if (is_node(1)) {
+        # Get haproxy configuration file template from the openQA server
+        assert_script_run "curl -f -v " . autoinst_url . "/data/ha/haproxy.cfg.template -o $haproxy_cfg";
+
+        # And modify the template according to our needs
+        assert_script_run "sed -i 's/%NODE_01%/$node_01/g' $haproxy_cfg";
+        assert_script_run "sed -i 's/%NODE_01_IP%/$node_01_ip/g' $haproxy_cfg";
+        assert_script_run "sed -i 's/%NODE_02%/$node_02/g' $haproxy_cfg";
+        assert_script_run "sed -i 's/%NODE_02_IP%/$node_02_ip/g' $haproxy_cfg";
+        assert_script_run "sed -i 's/%VIP_IP%/$vip_ip/g' $haproxy_cfg";
+
+        add_file_in_csync(value => "$haproxy_cfg");
+
+        # Execute csync2 to synchronise the configuration files
+        exec_csync;
+
+        # Modify the apache template file according to our needs
+        assert_script_run "sed -i 's/%NODE%/$node_01/g' $apache_file";
+        assert_script_run "sed -i 's/%IP%/$node_01_ip/g' $apache_file";
+    }
+    elsif (is_node(2)) {
+        # Modify the apache template file according to our needs
+        assert_script_run "sed -i 's/%NODE%/$node_02/g' $apache_file";
+        assert_script_run "sed -i 's/%IP%/$node_02_ip/g' $apache_file";
+    }
+
+    # Apache have to be started on the both nodes for load balancing
+    # TODO: Add apache2 in the HA configuration
+    systemctl 'enable --now apache2';
+
+    if (is_node(1)) {
+        # Create vip resource
+        assert_script_run "EDITOR=\"sed -ie '\$ a primitive $vip_rsc IPaddr2 params ip='$vip_ip' nic='eth0' cidr_netmask='24' broadcast='10.0.2.255''\" crm configure edit";
+
+        # Just to be sure that vip resource is started
+        sleep 5;
+        save_state;
+
+        # Create haproxy resource
+        assert_script_run "EDITOR=\"sed -ie '\$ a primitive $haproxy_rsc systemd:haproxy'\" crm configure edit";
+
+        # Vip must be started before haproxy
+        assert_script_run "EDITOR=\"sed -ie '\$ a order order_vip_haproxy Mandatory: $vip_rsc $haproxy_rsc'\" crm configure edit";
+
+        # Vip must be started where haproxy is live
+        assert_script_run "EDITOR=\"sed -ie '\$ a colocation colocation_vip_haproxy inf: $haproxy_rsc $vip_rsc'\" crm configure edit";
+
+        # Sometimes we need to cleanup the resource
+        rsc_cleanup $haproxy_rsc;
+    }
+
+    # Do a check of the cluster with a screenshot
+    save_state;
+
+    if (is_node(2)) {
+        # Test if the HTML content is the one expected on both nodes
+        assert_script_run "curl -s $node_02_ip | grep $node_02";
+    }
+    elsif (is_node(1)) {
+        assert_script_run "curl -s $node_01_ip | grep $node_01";
+        # Check if haproxy round-robin mode is working
+        # The output of the both curl commands must be different
+        assert_script_run "[[ \$(curl -s $vip_ip:8080) != \$(curl -s $vip_ip:8080) ]]";
+    }
+
+    barrier_wait("HAPROXY_DONE_$cluster_name");
+}
+
+1;

--- a/tests/ha/haproxy.pm
+++ b/tests/ha/haproxy.pm
@@ -27,8 +27,8 @@ sub run {
     my $vip_rsc      = 'vip';
     my $node_01      = choose_node(1);
     my $node_02      = choose_node(2);
-    my $node_01_ip   = script_output "host -t A $node_01 | awk '{ print \$NF }'";
-    my $node_02_ip   = script_output "host -t A $node_02 | awk '{ print \$NF }'";
+    my $node_01_ip   = get_ip($node_01);
+    my $node_02_ip   = get_ip($node_02);
 
     # Waiting for the other nodes to be ready
     barrier_wait("HAPROXY_INIT_$cluster_name");
@@ -101,7 +101,7 @@ sub run {
     elsif (is_node(1)) {
         assert_script_run "curl -s $node_01_ip | grep $node_01";
         # Check if haproxy round-robin mode is working
-        # The output of the both curl commands must be different
+        # The output of both curl commands must be different
         assert_script_run "[[ \$(curl -s $vip_ip:8080) != \$(curl -s $vip_ip:8080) ]]";
     }
 


### PR DESCRIPTION
Add haproxy test.

1. Install & configure apache / haproxy
2. Configure an IPaddr2 and haproxy resource agent
3. Add a collocation and order constraint
4. Test round-robin load balancing mode using the both cluster nodes as HTTP servers
5. Add get_ip function and using it for haproxy and DRBD test.

- Related ticket: N/A
- Needles: N/A
- Verification run for haproxy: [Node1](http://1a102.qa.suse.de/tests/282) & [Node2](http://1a102.qa.suse.de/tests/283)
- Verification run for DRBD with get_ip function: [Node1](http://1a102.qa.suse.de/tests/298#step/drbd_passive/58)