### PR TITLE
[WIP]Enlarge the wait time for installation-settings-overview-loaded

### DIFF
--- a/tests/installation/resolve_dependency_issues.pm
+++ b/tests/installation/resolve_dependency_issues.pm
@@ -17,7 +17,7 @@ use testapi;
 
 sub run {
     my ($self) = @_;
-    assert_screen('installation-settings-overview-loaded', 90);
+    assert_screen('installation-settings-overview-loaded', 250);
     if (check_screen('dependency-issue', 0) && get_var("WORKAROUND_DEPS")) {
         $self->workaround_dependency_issues;
     }


### PR DESCRIPTION
We need enlarge the wait time for checking installation-settings-overview-loaded.
- Related ticket: https://progress.opensuse.org/issues/50819
- Needles: N/A
- Verification run: http://openqa-apac1.suse.de/tests/4038#step/resolve_dependency_issues/1