### PR TITLE
Use python3 on Leap15 for sssd tests

### DIFF
--- a/data/lib/version_utils.sh
+++ b/data/lib/version_utils.sh
@@ -21,6 +21,24 @@ isTumbleweed(){
 }
 
 #########################################################################
+###
+### Returns 0 if script runs on Leap15
+###
+### Example:
+### isLeap15
+### echo $?
+
+isLeap15(){
+   if [ ! -f /etc/os-release ]; then
+      return 1
+   fi
+   if (grep -i -q "openSUSE Leap 15" /etc/os-release); then
+      return 0
+   fi
+   return 1
+}
+
+#########################################################################
 ### HINT: With SLES15 the /etc/SuSE-release file was abandoned
 ###                            os-release is now used
 ###

--- a/data/sssd-tests/testincl.sh
+++ b/data/sssd-tests/testincl.sh
@@ -105,7 +105,7 @@ test_abort() {
 ### echo $?
 
 usePython3(){
-   if ( isSles15 ) || ( isTumbleweed ); then
+   if ( isSles15 ) || ( isLeap15 ) || ( isTumbleweed ); then
       return 0
    fi
    return 1


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/50486
- Verification run: http://slindomansilla-vm.qa.suse.de/tests/1340
