### PR TITLE
Handle gnucash-tip-close after assistant-show-again-no

### DIFF
--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -29,7 +29,10 @@ sub run {
     if (match_has_tag('gnucash-assistant-close')) {
         assert_and_click 'gnucash-assistant-close';
         assert_and_click 'gnucash-assistant-show-again-no';
-        assert_screen('gnucash');
+        assert_screen([qw(gnucash gnucash-tip-close)]);
+        if (match_has_tag('gnucash-tip-close')) {
+            send_key 'esc';
+        }
     }
     # < gnucash 3.3
     else {


### PR DESCRIPTION
required at least for TW ppc64le 20190426
https://openqa.opensuse.org/tests/919514#step/gnucash/27