### PR TITLE
Fixed Travis condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,5 +40,6 @@ deploy:
     local-dir: $TRAVIS_BUILD_DIR/docs/
     on:
         branch: master
+        condition: $NEW_DEPLOY_NEEDED
     target_branch: gh-pages
 

--- a/script/generateUtilsDoc.sh
+++ b/script/generateUtilsDoc.sh
@@ -14,8 +14,26 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+NEW_DEPLOY_NEEDED=0
+
+if [ -z $GITHUB_TOKEN  ]
+then
+    NEW_DEPLOY_NEEDED=0
+    exit 0
+fi
+
 cd $TRAVIS_BUILD_DIR
 
 touch docs/utils.html
 pod2html --infile=lib/utils.pm --outfile=docs/utils.html
+
+#checkout old docs and compare to new ones, then toggle flag accordingly
+git diff gh-pages -- docs/utils.html
+ret_val=$?
+if [ ${ret_val} -ne 0 ]
+then
+    NEW_DEPLOY_NEEDED=1
+else
+    NEW_DEPLOY_NEEDED=0
+fi
 


### PR DESCRIPTION
Travis now only deploy conditional when something has changed in the
lib/utils.
For this a DEPLOY_NEEDED global variable is needed in the travis
settings

- Related ticket: https://progress.opensuse.org/issues/30862
- Verification run: https://travis-ci.org/DrMullings/os-autoinst-distri-opensuse/jobs/525980294
