### PR TITLE
Enable cache for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,11 @@ addons:
       - libdbus-1-dev
       - libssh2-1-dev
       - parallel
+cache:
+  directories:
+    - $HOME/perl5
 before_install:
-  - eval $(curl https://travis-perl.github.io/init) --perl
+  - eval $(curl https://travis-perl.github.io/init) --perl --always-upgrade-modules
   - echo "requires 'Code::DRY';" >> cpanfile
   - echo "requires 'Perl::Tidy', '== 20181120';" >> cpanfile
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ matrix:
   - name: "openSUSE/SUSE production perl version, only compile check"
     perl: "5.18"
     env: TESTS=compile
-  - name: "testing perl version, all tests"
+  - name: "testing perl version, static checks"
     perl: "5.26"
-    env: TESTS=all
+    env: TESTS=static
+  - name: "testing perl version, unit tests"
+    perl: "5.26"
+    env: TESTS=unit
 env:
   global:
     - COMMIT_AUTHOR_EMAIL=skynet@open.qa

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,10 @@ test-static: tidy-check test-yaml-valid test-merge test-dry test-no-wait_idle te
 .PHONY: test
 ifeq ($(TESTS),compile)
 test: test-compile
+else ifeq ($(TESTS),static)
+test: test-static
+else ifeq ($(TESTS),unit)
+test: unit-test perlcritic
 else
 test: unit-test test-static test-compile perlcritic
 endif


### PR DESCRIPTION
Reduce build time on each PR by using travis cache (travis uses local::Lib)

The time gain is a bit marginal (~3 mins), which means we could add even more unit tests :D (as they only take 3 minutes now)