### PR TITLE
Move specific architectures to Utils::Architectures

### DIFF
--- a/lib/Utils/Architectures.pm
+++ b/lib/Utils/Architectures.pm
@@ -1,0 +1,56 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+package Utils::Architectures;
+use strict;
+use warnings;
+
+use base qw(Exporter);
+use Exporter;
+use testapi 'check_var';
+
+use constant {
+    ARCH => [
+        qw(
+          is_s390x
+          is_x86_64
+          is_aarch64
+          is_ppc64le
+          )
+    ]
+};
+
+our @EXPORT = @{(+ARCH)};
+
+our %EXPORT_TAGS = (
+    ARCH => (ARCH),
+);
+
+# specific architectures
+
+sub is_s390x {
+    return check_var('ARCH', 's390x');
+}
+sub is_x86_64 {
+    return check_var('ARCH', 'x86_64');
+}
+sub is_aarch64 {
+    return check_var('ARCH', 'aarch64');
+}
+sub is_ppc64le {
+    return check_var('ARCH', 'ppc64le');
+}
+
+1;

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -69,11 +69,7 @@ use constant {
           is_virtualization_server
           is_server
           is_transactional
-          is_s390x
           is_livecd
-          is_x86_64
-          is_aarch64
-          is_ppc64le
           has_product_selection
           has_license_on_welcome_screen
           uses_qa_net_hardware
@@ -286,22 +282,6 @@ sub is_pre_15 {
 
 sub is_aarch64_uefi_boot_hdd {
     return get_var('MACHINE') =~ /aarch64/ && get_var('UEFI') && get_var('BOOT_HDD_IMAGE');
-}
-
-sub is_s390x {
-    return check_var('ARCH', 's390x');
-}
-
-sub is_x86_64 {
-    return check_var('ARCH', 'x86_64');
-}
-
-sub is_aarch64 {
-    return check_var('ARCH', 'aarch64');
-}
-
-sub is_ppc64le {
-    return check_var('ARCH', 'ppc64le');
 }
 
 sub is_server {

--- a/tests/console/validate_lvm_encrypt.pm
+++ b/tests/console/validate_lvm_encrypt.pm
@@ -18,7 +18,8 @@ use utils;
 use y2logsstep;
 use y2_common 'workaround_suppress_lvm_warnings';
 use Test::Assert ':all';
-use version_utils qw(is_aarch64 is_storage_ng);
+use version_utils 'is_storage_ng';
+use Utils::Architectures 'is_aarch64';
 
 
 sub run {

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -18,6 +18,7 @@ use testapi;
 use x11utils 'ensure_fullscreen';
 use version_utils qw(:VERSION :SCENARIO);
 use Utils::Backends 'is_remote_backend';
+use Utils::Architectures;
 
 sub switch_keyboard_layout {
     record_info 'keyboard layout', 'Check keyboard layout switching to another language';

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -13,6 +13,7 @@
 use base "sles4sap";
 use testapi;
 use version_utils 'is_sle';
+use Utils::Architectures 'is_ppc64le';
 use strict;
 use warnings;
 


### PR DESCRIPTION
see https://progress.opensuse.org/issues/50432
modified: lib/main_common.pm
modified: lib/version_utils.pm
modified: tests/installation/welcome.pm
modified: tests/console/validate_lvm_encrypt.pm
modified: tests/sles4sap/saptune.pm

verification test runs:
http://f40.suse.de/tests/3371 (s390x)
http://f40.suse.de/tests/3372 (aarch64)
http://f40.suse.de/tests/3370 (x86_64)
http://f40.suse.de/tests/3379 (ppc64le)
http://f40.suse.de/tests/3386 (YaST lvm-full-encrypt@aarch64)
http://f40.suse.de/tests/3387 (sles4sap saptune)
http://openqa.suse.de/tests/2845045 (lvm-full-encrypt@aarch64)
https://openqa.opensuse.org/tests/921396 (TW Gnome)
https://openqa.opensuse.org/tests/921397 (Leap lvm-full-encrypt)