### PR TITLE
Validate the user created with YaST Firstboot

### DIFF
--- a/schedule/autoyast_y2_firstboot.yaml
+++ b/schedule/autoyast_y2_firstboot.yaml
@@ -1,12 +1,12 @@
 name:           autoyast_y2_firstboot
 description:    >
     Smoke test for YaST2 firstboot module
+vars:
+    YAST2_FIRSTBOOT_USERNAME: y2_firstboot_tester
 schedule:
     - autoyast/prepare_profile
     - installation/isosize
     - installation/bootloader
     - autoyast/installation
     - installation/yast2_firstboot
-
-
-
+    - console/validate_yast2_firstboot_configuration

--- a/schedule/yast2_firstboot.yaml
+++ b/schedule/yast2_firstboot.yaml
@@ -2,6 +2,8 @@
 name:           yast2_fistboot
 description:    >
     Smoke test for YaST2 firstboot module
+vars:
+    YAST2_FIRSTBOOT_USERNAME: y2_firstboot_tester
 schedule:
     - boot/boot_to_desktop
     - console/prepare_test_data
@@ -11,3 +13,4 @@ schedule:
     - autoyast/autoyast_reboot
     - installation/grub_test
     - installation/yast2_firstboot
+    - console/validate_yast2_firstboot_configuration

--- a/tests/console/validate_yast2_firstboot_configuration.pm
+++ b/tests/console/validate_yast2_firstboot_configuration.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Test module to validate YaST Firstboot configuration settings are
+# applied to the SUT.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package validate_yast2_firstboot_configuration;
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+
+sub assert_user_exist {
+    my ($username) = @_;
+    assert_script_run("id $username", fail_message => "User $username not found in the system, though it is expected to be created by YaST Firstboot");
+}
+
+sub pre_run_hook {
+    select_console 'root-console';
+}
+
+sub run {
+    assert_user_exist(get_var('YAST2_FIRSTBOOT_USERNAME'));
+}
+
+1;

--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -72,7 +72,7 @@ sub clock_and_timezone {
 sub user_setup {
     my $is_not_shared_passwd = shift;
     assert_screen 'local_user';
-    enter_userinfo(username => 'y2_firstboot_tester');
+    enter_userinfo(username => get_var('YAST2_FIRSTBOOT_USERNAME'));
     if (defined($is_not_shared_passwd)) {
         send_key 'alt-t' if (is_opensuse);
     }

--- a/variables.md
+++ b/variables.md
@@ -120,5 +120,6 @@ UNENCRYPTED_BOOT | boolean | false | Indicates/defines existence of unencrypted 
 WAYLAND | boolean | false | Enables wayland tests in the system.
 XDMUSED | boolean | false | Indicates availability of xdm.
 YAML_SCHEDULE | string | | Defines yaml file containing test suite schedule.
+YAST2_FIRSTBOOT_USERNAME | string | | Defines username for the user to be created with YaST Firstboot
 ZDUP | boolean | false | Prescribes zypper dup scenario.
 ZDUPREPOS | string | | Defines repo to be added/used for zypper dup call.


### PR DESCRIPTION
The PR adds validation module to check that user is created with
YaST Firstboot.

Related ticket: [poo#49511](https://progress.opensuse.org/issues/49511)
Verification run: http://oorlov-vm.qa.suse.de/tests/865#step/validate_yast2_firstboot_configuration/10
