### PR TITLE
Fix Schedule for Leap 15.1

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1590,7 +1590,7 @@ sub load_extra_tests_console {
     loadtest "console/lshw" if ((is_sle('15+') && (check_var('ARCH', 'ppc64le') || check_var('ARCH', 'x86_64'))) || is_opensuse);
     loadtest 'console/quota' unless is_jeos;
     loadtest 'console/zziplib' if (is_sle('12-SP3+') && !is_jeos);
-    loadtest 'console/firewalld' if is_sle('15+') || is_leap('15.0+');
+    loadtest 'console/firewalld' if is_sle('15+') || is_leap('15.0+') || is_tumbleweed;
 }
 
 sub load_extra_tests_docker {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1590,7 +1590,7 @@ sub load_extra_tests_console {
     loadtest "console/lshw" if ((is_sle('15+') && (check_var('ARCH', 'ppc64le') || check_var('ARCH', 'x86_64'))) || is_opensuse);
     loadtest 'console/quota' unless is_jeos;
     loadtest 'console/zziplib' if (is_sle('12-SP3+') && !is_jeos);
-    loadtest 'console/firewalld' unless is_sle('<15') || is_leap('<15');
+    loadtest 'console/firewalld' if is_sle('15+') || is_leap('15.0+');
 }
 
 sub load_extra_tests_docker {

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -21,6 +21,7 @@ use strict;
 use warnings;
 use testapi qw(check_var get_var set_var);
 use version 'is_lax';
+use Carp 'croak';
 use Utils::Backends qw(is_hyperv is_hyperv_in_gui is_svirt_except_s390x);
 
 use constant {
@@ -146,7 +147,7 @@ sub check_version {
         return $pv eq $qv if $+{op} eq '=';
     }
     # Version should be matched and processed by now
-    die "Unsupported version parameter: $query";
+    croak "Unsupported version parameter for check_version: '$query'";
 }
 
 # Check if distribution is CaaSP or MicroOS with optional filter:


### PR DESCRIPTION
PR #7166 broke the schedule, [This](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7166/commits/8a3f66bed12f0eaa4bb803a1b2e302391ec4410c) is the only change relevant, as it seems that is_leap only supports 15.0+

* Proof run Leap 15.1 (Exit after schedule): https://openqa.opensuse.org/tests/921593/file/autoinst-log.txt
* Proof run SLE 15 (Exit after schedule): https://openqa.suse.de/tests/2848604/file/autoinst-log.txt
* Proof run Tumbleweed (Exit after schedule): https://openqa.opensuse.org/tests/921609/file/autoinst-log.txt

Firewalld is properly scheduled in both test runs.
