### PR TITLE
wicked 2nics: before_test cleanup of config files

### DIFF
--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -77,6 +77,10 @@ sub run {
             assert_script_run("systemctl start openvswitch");
         }
     }
+    elsif (check_var('WICKED', '2nics')) {
+        assert_script_run('rm /etc/sysconfig/network/ifcfg-' . $ctx->iface());
+        assert_script_run("rcwickedd restart");
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
wicked 2nics: before_test cleanup of config files.
in case of 2nics scenario it is important to not have left overs which we using in before test 

verification runs : 
http://kimball.arch.suse.de/tests/912
http://kimball.arch.suse.de/tests/911