### PR TITLE
Add remove node test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2623,6 +2623,9 @@ sub load_ha_cluster_tests {
     # Show HA cluster status *after* fencing test
     loadtest 'ha/check_after_reboot';
 
+    # Remove a node both by its hostname and ip address
+    loadtest 'ha/remove_node';
+
     # Check logs to find error and upload all needed logs if we are not
     # in installation/publishing mode
     loadtest 'ha/check_logs' if !get_var('INSTALLONLY');

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -67,6 +67,13 @@ sub run {
         barrier_create("SLE11_UPGRADE_DONE_$cluster_name",          $num_nodes);
         barrier_create("HAPROXY_INIT_$cluster_name",                $num_nodes);
         barrier_create("HAPROXY_DONE_$cluster_name",                $num_nodes);
+        barrier_create("REMOVE_NODE_BY_IP_INIT_$cluster_name",      $num_nodes);
+        barrier_create("REMOVE_NODE_BY_IP_DONE_$cluster_name",      $num_nodes);
+        barrier_create("REMOVE_NODE_BY_HOST_INIT_$cluster_name",    $num_nodes);
+        barrier_create("REMOVE_NODE_BY_HOST_DONE_$cluster_name",    $num_nodes);
+        barrier_create("JOIN_NODE_BY_HOST_DONE_$cluster_name",      $num_nodes);
+        barrier_create("JOIN_NODE_BY_IP_DONE_$cluster_name",        $num_nodes);
+        barrier_create("REMOVE_NODE_FINAL_JOIN_$cluster_name",      $num_nodes);
 
         # HAWK_GUI_ barriers also have to wait in the client
         barrier_create("HAWK_GUI_INIT_$cluster_name",    $num_nodes + 1);

--- a/tests/ha/remove_node.pm
+++ b/tests/ha/remove_node.pm
@@ -1,0 +1,71 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Remove a node both by its hostname and ip address
+# Maintainer: Julien Adamek <jadamek@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use hacluster;
+
+sub remove_state_join {
+    my ($method, $cluster_name, $node_01, $node_02) = @_;
+    my $remove_cmd = 'crm cluster remove -y -c';
+    my $join_cmd   = 'crm cluster join -y -w /dev/watchdog -i ' . get_var('SUT_NETDEVICE', 'eth0') . ' -c';
+    my $timer      = 5 * get_var('TIMEOUT_SCALE', 1);
+
+    # Waiting for the other nodes to be ready
+    barrier_wait("REMOVE_NODE_BY_" . "$method" . "_INIT_" . "$cluster_name");
+
+    # Remove the second node
+    assert_script_run("$remove_cmd $node_02") if is_node(1);
+    # Need to wait a bit for cluster configuration refresh
+    sleep $timer;
+
+    # Synchronize all the nodes after the remove
+    barrier_wait("REMOVE_NODE_BY_" . "$method" . "_DONE_" . "$cluster_name");
+
+    # Show cluster status
+    is_node(2) ? script_run "$crm_mon_cmd" : save_state;
+
+    # Second node needs to be reintegrated
+    assert_script_run("$join_cmd $node_01") if is_node(2);
+
+    # Synchronize all the nodes after the join
+    barrier_wait("JOIN_NODE_BY_" . "$method" . "_DONE_" . "$cluster_name");
+
+    # Need to wait a bit for cluster configuration refresh
+    sleep $timer;
+
+    # Show cluster status
+    save_state;
+}
+
+sub run {
+    my $cluster_name = get_cluster_name;
+    my $node_01_host = choose_node(1);
+    my $node_02_host = choose_node(2);
+    my $node_01_ip   = get_ip($node_01_host);
+    my $node_02_ip   = get_ip($node_02_host);
+
+    # Both remove and join the second node  by its hostname
+    remove_state_join('HOST', $cluster_name, $node_01_host, $node_02_host);
+
+    # Both remove and join the second node by its IP address
+    remove_state_join('IP', $cluster_name, $node_01_ip, $node_02_ip);
+
+    # Synchronize all the nodes and save cluster status
+    barrier_wait("REMOVE_NODE_FINAL_JOIN_$cluster_name");
+    save_state;
+}
+
+1;


### PR DESCRIPTION
Add a 'remove node' test after fencing (for 2 nodes cluster or more, so the node02 will always be removed), tested with both hostname and IP address.

- Related ticket: N/A
- Needles: N/A
- Verification run for 2 nodes cluster: [Node1](http://1a102.qa.suse.de/tests/460) [Node2](http://1a102.qa.suse.de/tests/461) 
- Verification run for 3 nodes cluster: [Node1](http://1a102.qa.suse.de/tests/464) [Node2](http://1a102.qa.suse.de/tests/465) [Node3](http://1a102.qa.suse.de/tests/463)
