### PR TITLE
wicked: Common way on initialize $ctx->iface[X]()

### DIFF
--- a/lib/wicked/TestContext.pm
+++ b/lib/wicked/TestContext.pm
@@ -15,7 +15,7 @@
 package wicked::TestContext;
 use Mojo::Base 'OpenQA::Test::RunArgs';
 
-has 'iface';
-has 'iface2';
+has 'iface'  => undef;
+has 'iface2' => undef;
 
 1;

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -20,14 +20,11 @@ use network_utils qw(iface setup_static_network);
 sub run {
     my ($self, $ctx) = @_;
     $self->select_serial_terminal;
-    if (check_var('WICKED', '2nics') && check_var('IS_WICKED_REF', '0')) {
-        my @ifaces = split(' ', iface(2));
-        $ctx->iface($ifaces[0]);
-        $ctx->iface2($ifaces[1]);
-    }
-    else {
-        $ctx->iface(iface());
-    }
+    my @ifaces = split(' ', iface(2));
+    die("Missing at least one interface") unless (@ifaces);
+    $ctx->iface($ifaces[0]);
+    $ctx->iface2($ifaces[1]) if (@ifaces > 1);
+
     my $enable_command_logging = 'export PROMPT_COMMAND=\'logger -t openQA_CMD "$(history 1 | sed "s/^[ ]*[0-9]\+[ ]*//")"\'';
     my $escaped                = $enable_command_logging =~ s/'/'"'"'/gr;
     assert_script_run("echo '$escaped' >> /root/.bashrc");


### PR DESCRIPTION
Use same initializer for all wicked tests.

- Verification run: 
  - http://cfconrad-vm.qa.suse.de/tests/4087 (sut advanced)
  - http://cfconrad-vm.qa.suse.de/tests/4089 (sut 2nics)
