### PR TITLE
wicked: Croak in ping_with_timeout() on failure

### DIFF
--- a/tests/wicked/2nics/sut/t01_aggregate_both_cards_legacy.pm
+++ b/tests/wicked/2nics/sut/t01_aggregate_both_cards_legacy.pm
@@ -31,7 +31,7 @@ sub run {
     validate_script_output('ip a s dev ' . $ctx->iface(),  sub { /SLAVE/ });
     validate_script_output('ip a s dev ' . $ctx->iface2(), sub { /SLAVE/ });
     my $remote_ip = $self->get_remote_ip(type => 'host');
-    die "unable to ping $sut_iface" unless $self->ping_with_timeout(ip => $remote_ip, interface => $sut_iface);
+    $self->ping_with_timeout(ip => $remote_ip, interface => $sut_iface);
     validate_script_output("ping -c30 $remote_ip -I $sut_iface", sub { /0% packet loss/ });
 }
 

--- a/tests/wicked/2nics/sut/t02_aggregate_both_cards_xml.pm
+++ b/tests/wicked/2nics/sut/t02_aggregate_both_cards_xml.pm
@@ -31,7 +31,7 @@ sub run {
     validate_script_output('ip a s dev ' . $ctx->iface(),  sub { /SLAVE/ });
     validate_script_output('ip a s dev ' . $ctx->iface2(), sub { /SLAVE/ });
     my $remote_ip = $self->get_remote_ip(type => 'host');
-    die "unable to ping $sut_iface" unless $self->ping_with_timeout(ip => $remote_ip, interface => $sut_iface);
+    $self->ping_with_timeout(ip => $remote_ip, interface => $sut_iface);
     validate_script_output("ping -c30 $remote_ip -I $sut_iface", sub { /0% packet loss/ });
 }
 

--- a/tests/wicked/2nics/sut/t03_setup_second_card.pm
+++ b/tests/wicked/2nics/sut/t03_setup_second_card.pm
@@ -35,8 +35,8 @@ sub run {
     my $iface_ip2 = $self->get_ip(type => 'host');
     validate_script_output('ip a s dev ' . $ctx->iface(),  sub { /$iface_ip/ });
     validate_script_output('ip a s dev ' . $ctx->iface2(), sub { /$iface_ip2/ });
-    die "unable to ping " . $ctx->iface()  unless $self->ping_with_timeout(type => 'second_card', interface => $ctx->iface());
-    die "unable to ping " . $ctx->iface2() unless $self->ping_with_timeout(type => 'host',        interface => $ctx->iface2());
+    $self->ping_with_timeout(type => 'second_card', interface => $ctx->iface());
+    $self->ping_with_timeout(type => 'host',        interface => $ctx->iface2());
     my $static_gw = '10.0.2.2';
     if (script_output('ip r s | grep default | awk \'{print $3}\'') ne $static_gw) {
         record_soft_failure("Default gw not $static_gw");

--- a/tests/wicked/basic/sut/t01_basic.pm
+++ b/tests/wicked/basic/sut/t01_basic.pm
@@ -55,11 +55,11 @@ sub run {
     }
     record_info('Test 6', 'Bring an interface down with wicked');
     $self->wicked_command('ifdown', $ctx->iface());
-    die('IP should not be reachable') if ($self->ping_with_timeout(ip => '10.0.2.2', timeout => '2'));
+    die('IP should not be reachable') if ($self->ping_with_timeout(ip => '10.0.2.2', timeout => '2', proceed_on_failure => 1));
     die if ($self->get_current_ip($ctx->iface()));
     record_info('Test 7', 'Bring an interface up with wicked');
     $self->wicked_command('ifup', $ctx->iface());
-    die('IP is unreachable') if (!$self->ping_with_timeout(ip => '10.0.2.2'));
+    $self->ping_with_timeout(ip => '10.0.2.2');
     validate_script_output('ip address show dev ' . $ctx->iface(), sub { m/inet/g; });
     validate_script_output('wicked show dev ' . $ctx->iface(),     sub { m/\[dhcp\]/g; });
 }

--- a/tests/wicked/startandstop/sut/t11_vlan_ifdown_modify_one_config.pm
+++ b/tests/wicked/startandstop/sut/t11_vlan_ifdown_modify_one_config.pm
@@ -30,8 +30,7 @@ sub run {
     $self->wicked_command('ifreload', 'all');
     assert_script_run('ip a');
     die('VLAN interface does not exists') unless ifc_exists($ctx->iface() . '.42');
-    die('IP is unreachable')
-      unless $self->ping_with_timeout(type => 'vlan_changed', timeout => '50');
+    $self->ping_with_timeout(type => 'vlan_changed', timeout => '50');
     $self->wicked_command('ifdown', "all");
     die('VLAN interface exists') if (ifc_exists($ctx->iface() . '.42'));
 }

--- a/tests/wicked/startandstop/sut/t12_vlan_xml_config.pm
+++ b/tests/wicked/startandstop/sut/t12_vlan_xml_config.pm
@@ -31,8 +31,7 @@ sub run {
     $self->wicked_command('ifreload', 'all');
     assert_script_run('ip a');
     die('VLAN interface does not exists') unless ifc_exists($ctx->iface() . '.42');
-    die('IP is unreachable')
-      unless $self->ping_with_timeout(type => 'vlan', timeout => '50');
+    $self->ping_with_timeout(type => 'vlan', timeout => '50');
 }
 
 1;


### PR DESCRIPTION
Do a croak, when ping doesn't work. This is the most usage of this
method.
You can override it by passing proceed_on_failure => 1.

- Verification run: 
  - http://cfconrad-vm.qa.suse.de/tests/4107 (2nics sut)
  - http://cfconrad-vm.qa.suse.de/tests/4105 (startandstop sut)
  - http://cfconrad-vm.qa.suse.de/tests/4101 (basic sut)
