### PR TITLE
Minimal RAM requirement for HANA is 24GB

### DIFF
--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -85,7 +85,7 @@ sub run {
 
     check_var('BACKEND', 'ipmi') ? use_ssh_serial_console : select_console 'root-console';
     my $RAM = get_total_mem();
-    die "RAM=$RAM. The SUT needs at least 32G of RAM" if $RAM < 32000;
+    die "RAM=$RAM. The SUT needs at least 24G of RAM" if $RAM < 24000;
 
     # If on IPMI, let's try to reclaim some of the space from the system PV which may be needed for Hana
     try_reclaiming_space if (check_var('BACKEND', 'ipmi'));


### PR DESCRIPTION
Change the minimal RAM requirement for HANA, as according to the documentation it is 24GB and not 32GB:
- https://www.suse.com/documentation/sles-for-sap-12/book_s4s/data/sec_s4s_hardware.html
- https://www.suse.com/documentation/sles-for-sap-15/book_s4s/data/sec_s4s_hardware.html

- Verification run: http://1b147.qa.suse.de/tests/5305
