### PR TITLE
wicked: Add test case "teaming roundrobin"

### DIFF
--- a/data/wicked/teaming/ifcfg-eth0
+++ b/data/wicked/teaming/ifcfg-eth0
@@ -1,0 +1,2 @@
+STARTMODE='hotplug'
+BOOTPROTO='none'

--- a/data/wicked/teaming/ifcfg-eth1
+++ b/data/wicked/teaming/ifcfg-eth1
@@ -1,0 +1,2 @@
+STARTMODE='hotplug'
+BOOTPROTO='none'

--- a/data/wicked/teaming/ifcfg-team0-roundrobin
+++ b/data/wicked/teaming/ifcfg-team0-roundrobin
@@ -1,0 +1,9 @@
+STARTMODE=auto
+BOOTPROTO=static
+
+TEAM_RUNNER=roundrobin
+TEAM_PORT_DEVICE=port0
+TEAM_PORT_DEVICE_1=port1
+
+IPADDR='ipaddr4'
+IPADDR6='ipaddr6'

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1285,7 +1285,7 @@ sub create_btrfs_subvolume {
         'another^&&*(textToFind' => "replacement")
 
   generify sed usage as config file modification tool.
-  allow to modify several items in one function call 
+  allow to modify several items in one function call
   by providing  regex_to_find / text_to_replace as hash key/value pairs
 
   special key '--sed-modifier' allowing to add modifiers to expression
@@ -1297,6 +1297,7 @@ sub file_content_replace {
     foreach my $key (keys %to_replace) {
         my $value = $to_replace{$key};
         $value =~ s/'/'"'"'/g;
+        $value =~ s'/'\/'g;
         $key   =~ s/'/'"'"'/g;
         assert_script_run(sprintf("sed -E 's/%s/%s/%s' -i %s", $key, $value, $sed_modifier, $filename));
     }

--- a/tests/wicked/aggregate/ref/t11_teaming_roundrobin.pm
+++ b/tests/wicked/aggregate/ref/t11_teaming_roundrobin.pm
@@ -1,0 +1,24 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Teaming, roundrobin
+# Maintainer: Anton Smorodskyi <asmorodskyi@suse.com>
+#             Jose Lausuch <jalausuch@suse.com>
+#             Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+
+
+use Mojo::Base 'wickedbase';
+use testapi;
+
+
+sub run {
+    record_info('INFO', 'Teaming, roundrobin');
+}
+
+1;

--- a/tests/wicked/aggregate/sut/t11_teaming_roundrobin.pm
+++ b/tests/wicked/aggregate/sut/t11_teaming_roundrobin.pm
@@ -1,0 +1,43 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Teaming, roundrobin
+# Maintainer: Anton Smorodskyi <asmorodskyi@suse.com>
+#             Jose Lausuch <jalausuch@suse.com>
+#             Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+
+use Mojo::Base 'wickedbase';
+use utils;
+use network_utils 'ifc_exists';
+use testapi;
+
+
+sub run {
+    my ($self, $ctx) = @_;
+
+    my $cfg_team0 = '/etc/sysconfig/network/ifcfg-team0';
+    my $cfg_ifc0  = '/etc/sysconfig/network/ifcfg-' . $ctx->iface();
+    my $cfg_ifc1  = '/etc/sysconfig/network/ifcfg-' . $ctx->iface2();
+
+    zypper_call('-q in libteam-tools libteamdctl0 python-libteam');
+
+    $self->get_from_data('wicked/teaming/ifcfg-eth0',             $cfg_ifc0);
+    $self->get_from_data('wicked/teaming/ifcfg-eth1',             $cfg_ifc1);
+    $self->get_from_data('wicked/teaming/ifcfg-team0-roundrobin', $cfg_team0);
+    file_content_replace($cfg_team0, ipaddr4 => $self->get_ip(type => 'host', netmask => 1), ipaddr6 => $self->get_ip(type => 'host6', netmask => 1), port0 => $ctx->iface(), port1 => $ctx->iface2());
+
+    $self->wicked_command('ifup', 'team0');
+    die('Missing interface team0') unless ifc_exists('team0');
+    validate_script_output('ip a s dev ' . $ctx->iface(),  sub { /master team0/ });
+    validate_script_output('ip a s dev ' . $ctx->iface2(), sub { /master team0/ });
+
+    $self->ping_with_timeout(type => 'host', interface => 'team0', count_success => 30, timeout => 4);
+}
+
+1;


### PR DESCRIPTION
Introduce new test for teaming:

```
@teams
Scenario: Teaming, roundrobin
When I team together eth0 and eth1 in roundrobin mode
Then there should be a new team0 card
And both cards should be enslaved to team0
And I should be able to ping the other side of the aggregated link
```

- Related ticket: https://progress.opensuse.org/issues/50909
- Verification run: 
  - http://cfconrad-vm.qa.suse.de/tests/4120 (SUT)
  - http://cfconrad-vm.qa.suse.de/tests/4119 (REF)
