### PR TITLE
Add yast2_clone_system to autoyast_mini_staging job

### DIFF
--- a/schedule/autoyast_mini_staging.yaml
+++ b/schedule/autoyast_mini_staging.yaml
@@ -1,0 +1,20 @@
+name:           autoyast_mini_staging@64bit-staging
+description:    >
+    Test verifies installation with minimal autoyast profile. Same as autoyast_mini but with product defined using url and not as registered modules. 
+    Maintainer: riafarov@suse.com
+schedule:
+    - autoyast/prepare_profile
+    - installation/bootloader
+    - autoyast/installation
+    - autoyast/console
+    - autoyast/login
+    - console/yast2_clone_system
+    - autoyast/wicked
+    - autoyast/repos
+    - autoyast/clone
+    - autoyast/logs
+    - autoyast/autoyast_reboot
+    - installation/grub_test
+    - installation/first_boot
+ 
+   


### PR DESCRIPTION
- Related ticket: [[functional][y] Enable test to validate generated profile to staging](https://progress.opensuse.org/issues/49415)
- Verification run: [sle-15-SP1-Installer-DVD-Staging:Y-x86_64-BuildY.211.1-autoyast_mini_staging@64bit-staging](http://eris.suse.cz/tests/13710#step/yast2_clone_system/25)

As of now, only *xmllint* works in staging, *jings* cannot be installed due to unavailable development tools repo in staging Y.

TEST: http://eris.suse.cz/tests/13743#step/yast2_clone_system/1