### PR TITLE
[WIP] YaST users regression tests

### DIFF
--- a/tests/yast2_gui/yast2_users.pm
+++ b/tests/yast2_gui/yast2_users.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,11 +16,110 @@ use strict;
 use warnings;
 use testapi;
 
+use utils 'type_string_slow_extended';
+use version_utils qw(is_tumbleweed is_leap);
+
+sub write_change_now {
+    send_key 'alt-x';
+    send_key 'down';
+    send_key 'down';
+    send_key 'down';
+    assert_screen 'write_change_now_reached';
+    send_key 'ret';
+}
+
+sub check_with_xterm {
+    my (%args) = @_;
+    x11_start_program('xterm');
+    become_root;
+    validate_script_output($args{command}, sub { m/$args{expected}/ });
+    wait_screen_change { send_key 'alt-f4'; };
+}
+
+
+sub add_user {
+    my (%args) = @_;
+    send_key 'alt-a';    # add user tab
+    type_string_slow_extended($args{username});
+    send_key 'tab';
+    type_string_slow_extended($args{username});
+    send_key 'tab';
+    type_string_slow_extended($args{password});
+    send_key 'tab';
+    type_string_slow_extended($args{password});
+    assert_screen 'user_data_fields_filled_up';
+    send_key "alt-o";    # OK => Exit
+    if (is_leap || is_tumbleweed) {
+        assert_screen 'do_not_disable_auto_login';
+        send_key 'alt-n';
+    }
+    assert_screen 'new_user_has_been_created';
+}
+
+sub edit_user {
+    send_key 'alt-i';    # edit user tab
+    send_key 'tab';      # change user full name
+    send_key 'tab';      # we need 2 tabs
+    type_string_slow_extended('edited');
+    send_key 'tab';      # change username
+    type_string_slow_extended('edited');
+    send_key "alt-o";
+    assert_screen 'home_dir_popup__checking';
+    send_key 'ret';
+    assert_screen 'edited_user_checking';
+}
+
+sub show_user_info {
+    send_key 'alt-i';
+    send_key 'alt-d';
+    assert_screen 'show_user__checking';
+    send_key 'alt-o';
+}
+
+sub delete_user {
+    send_key 'alt-t';
+    assert_screen 'delete_user_popup__checking';
+    send_key 'alt-y';
+}
+
+sub show_help {
+    send_key 'alt-h';
+    assert_screen 'help_popup__checking';
+    send_key 'alt-c';
+}
+
+sub show_system_users {
+    send_key 'alt-s';
+    send_key 'down';
+    send_key 'down';
+    assert_screen 'system_user__checking';
+    send_key 'ret';
+    assert_screen 'list_users__checking';
+}
+
 sub run {
     my $self = shift;
     select_console 'x11';
+    my $username = 'joshua';
+    my $password = 'Sup3rS3cr3t!';
+
     $self->launch_yast2_module_x11('users', match_timeout => 60);
-    send_key "alt-o";    # OK => Exit
+    assert_screen 'yast2_users_main_screen';
+    add_user(username => $username, password => $password);
+    write_change_now;
+    check_with_xterm(command => "cat /etc/passwd|grep $username", expected => $username);
+    edit_user;
+    write_change_now;
+    check_with_xterm("cat /etc/passwd|grep edited", expected => "edited");
+    show_user_info;
+    delete_user;
+    write_change_now;
+    check_with_xterm("cat /etc/passwd | grep edited | test `wc -l` -eq 0", expected => "");
+    show_help;
+    show_system_users;
+    send_key "alt-o";
+    wait_serial("yast2-users-status-0") || die 'Fail! YaST2 - Users dialog is not closed or non-zero code returned.';
+
 }
 
 1;


### PR DESCRIPTION
YaST users regression tests.

Below tested functionalities: 

 show help
 add  user
 del  user
 edit user
 list users
 show user

- Related ticket: https://progress.opensuse.org/issues/49316
- Needles:
  sle: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1129
  opensuse: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/552

- Verification run: 

  sles15: http://10.161.229.206/tests/621
  sled15: http://10.161.229.206/tests/588
  sles12sp4: http://10.161.229.206/tests/622
  sled12sp4: http://10.161.229.206/tests/597
  sles12sp3: http://10.161.229.206/tests/623
  sled12sp3: http://10.161.229.206/tests/599
  opensuse: http://10.161.229.206/tests/624