### PR TITLE
Add y2logsstep to x11 yast2 tests

### DIFF
--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -18,6 +18,7 @@ use testapi;
 use mm_network;
 use lockapi;
 use x11utils 'turn_off_gnome_screensaver';
+use y2logsstep 'yast2_console_exec';
 
 sub run {
     x11_start_program('xterm -geometry 160x45+5+5', target_match => 'xterm');

--- a/tests/iscsi/iscsi_server.pm
+++ b/tests/iscsi/iscsi_server.pm
@@ -22,6 +22,7 @@ use mmapi;
 use utils 'zypper_call';
 use yast2_widget_utils 'change_service_configuration';
 use x11utils 'turn_off_gnome_screensaver';
+use y2logsstep 'yast2_console_exec';
 
 sub run {
     my $self = shift;

--- a/tests/x11/nis_client.pm
+++ b/tests/x11/nis_client.pm
@@ -20,6 +20,7 @@ use utils 'systemctl';
 use version_utils 'is_sle';
 use y2x11test qw(setup_static_mm_network %setup_nis_nfs_x11);
 use x11utils 'turn_off_gnome_screensaver';
+use y2logsstep 'yast2_console_exec';
 
 sub setup_nis_client {
     if (is_sle('>=15')) {

--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -21,6 +21,7 @@ use utils 'systemctl';
 use y2x11test qw(setup_static_mm_network %setup_nis_nfs_x11);
 use version_utils 'is_sle';
 use x11utils 'turn_off_gnome_screensaver';
+use y2logsstep 'yast2_console_exec';
 
 sub setup_verification {
     script_run 'rpcinfo -u localhost ypserv';    # ypserv is running


### PR DESCRIPTION
x11test does not inherit from y2logsstep, therefore we need to import y2logsstep in x11 yast2 tests.

https://openqa.suse.de/tests/2855528#step/nis_server/49

