### PR TITLE
wicked: Fix regression of file_replace_content()

### DIFF
--- a/tests/wicked/advanced/sut/t15_macvtap_legacy.pm
+++ b/tests/wicked/advanced/sut/t15_macvtap_legacy.pm
@@ -23,12 +23,10 @@ our $macvtap_log = '/tmp/macvtap_results.txt';
 sub run {
     my ($self, $ctx) = @_;
     record_info('Info', 'Create a macvtap interface from legacy ifcfg files');
-    my $config     = '/etc/sysconfig/network/ifcfg-macvtap1';
-    my $ip_address = $self->get_ip(type => 'macvtap', netmask => 1);
-    $ip_address =~ s'/'\\/';
+    my $config = '/etc/sysconfig/network/ifcfg-macvtap1';
     $self->get_from_data('wicked/ifcfg/macvtap1',    $config);
     $self->get_from_data('wicked/ifcfg/macvtap_eth', '/etc/sysconfig/network/ifcfg-' . $ctx->iface());
-    $self->prepare_check_macvtap($config, $ctx->iface(), $ip_address);
+    $self->prepare_check_macvtap($config, $ctx->iface(), $self->get_ip(type => 'macvtap', netmask => 1));
     $self->wicked_command('ifreload', $ctx->iface());
     $self->wicked_command('ifup',     'macvtap1');
     $self->validate_macvtap($macvtap_log);

--- a/tests/wicked/advanced/sut/t16_macvtap_xml.pm
+++ b/tests/wicked/advanced/sut/t16_macvtap_xml.pm
@@ -24,11 +24,9 @@ our $macvtap_log = '/tmp/macvtap_results.txt';
 sub run {
     my ($self, $ctx) = @_;
     record_info('Info', 'Create a macvtap interface from wicked XML files');
-    my $config     = '/etc/wicked/ifconfig/macvtap.xml';
-    my $ip_address = $self->get_ip(type => 'macvtap', netmask => 1);
-    $ip_address =~ s'/'\\/';
+    my $config = '/etc/wicked/ifconfig/macvtap.xml';
     $self->get_from_data('wicked/xml/macvtap.xml', $config);
-    $self->prepare_check_macvtap($config, $ctx->iface(), $ip_address);
+    $self->prepare_check_macvtap($config, $ctx->iface(), $self->get_ip(type => 'macvtap', netmask => 1));
     $self->wicked_command('ifreload', $ctx->iface());
     $self->wicked_command('ifup',     'macvtap1');
     $self->validate_macvtap($macvtap_log);

--- a/tests/wicked/startandstop/sut/t10_vlan_ifup_all_ifdown_one_card.pm
+++ b/tests/wicked/startandstop/sut/t10_vlan_ifup_all_ifdown_one_card.pm
@@ -23,9 +23,7 @@ sub run {
     my ($self, $ctx) = @_;
     my $config = '/etc/sysconfig/network/ifcfg-' . $ctx->iface() . '.42';
     $self->get_from_data('wicked/ifcfg/eth0.42', $config);
-    my $local_ip = $self->get_ip(type => 'vlan', netmask => 1);
-    $local_ip =~ s'/'\\/';
-    file_content_replace($config, interface => $ctx->iface(), ip_address => $local_ip);
+    file_content_replace($config, interface => $ctx->iface(), ip_address => $self->get_ip(type => 'vlan', netmask => 1));
     $self->wicked_command('ifup', 'all');
     assert_script_run('ip a');
     die if (!ifc_exists($ctx->iface() . '.42'));

--- a/tests/wicked/startandstop/sut/t11_vlan_ifdown_modify_one_config.pm
+++ b/tests/wicked/startandstop/sut/t11_vlan_ifdown_modify_one_config.pm
@@ -21,12 +21,10 @@ use utils 'file_content_replace';
 
 sub run {
     my ($self, $ctx) = @_;
-    my $config   = '/etc/sysconfig/network/ifcfg-' . $ctx->iface() . '.42';
-    my $local_ip = $self->get_ip(type => 'vlan_changed', netmask => 1);
-    $local_ip =~ s'/'\\/';
+    my $config      = '/etc/sysconfig/network/ifcfg-' . $ctx->iface() . '.42';
     my $previous_ip = $self->get_ip(type => 'vlan', netmask => 1);
     $previous_ip =~ s'/'\\/';
-    file_content_replace($config, $previous_ip => $local_ip);
+    file_content_replace($config, $previous_ip => $self->get_ip(type => 'vlan_changed', netmask => 1));
     $self->wicked_command('ifreload', 'all');
     assert_script_run('ip a');
     die('VLAN interface does not exists') unless ifc_exists($ctx->iface() . '.42');

--- a/tests/wicked/startandstop/sut/t12_vlan_xml_config.pm
+++ b/tests/wicked/startandstop/sut/t12_vlan_xml_config.pm
@@ -24,9 +24,7 @@ sub run {
     my ($self, $ctx) = @_;
     my $config = '/etc/wicked/ifconfig/vlan.xml';
     $self->get_from_data('wicked/xml/vlan.xml', $config);
-    my $local_ip = $self->get_ip(type => 'vlan', netmask => 1);
-    $local_ip =~ s'/'\\/';
-    file_content_replace($config, iface => $ctx->iface(), ip_address => $local_ip);
+    file_content_replace($config, iface => $ctx->iface(), ip_address => $self->get_ip(type => 'vlan', netmask => 1));
     record_info('Info', 'VLAN - Create a VLAN from wicked XML files');
     $self->wicked_command('ifreload', 'all');
     assert_script_run('ip a');


### PR DESCRIPTION
The commit 44085bad changed file_replace_content() that it escape '/'
characters of the value. Previously we escaped them manually,
which isn't necessary anymore.


- Verification run: 
  - http://cfconrad-vm.qa.suse.de/tests/4152 (advanced sut)
  - http://cfconrad-vm.qa.suse.de/tests/4154 (startandstop sut)
