### PR TITLE
Escape / in file_content_replace() searcher

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1299,6 +1299,7 @@ sub file_content_replace {
         $value =~ s/'/'"'"'/g;
         $value =~ s'/'\/'g;
         $key   =~ s/'/'"'"'/g;
+        $key   =~ s'/'\/'g;
         assert_script_run(sprintf("sed -E 's/%s/%s/%s' -i %s", $key, $value, $sed_modifier, $filename));
     }
     script_run("cat $filename");

--- a/tests/wicked/startandstop/sut/t11_vlan_ifdown_modify_one_config.pm
+++ b/tests/wicked/startandstop/sut/t11_vlan_ifdown_modify_one_config.pm
@@ -23,7 +23,6 @@ sub run {
     my ($self, $ctx) = @_;
     my $config      = '/etc/sysconfig/network/ifcfg-' . $ctx->iface() . '.42';
     my $previous_ip = $self->get_ip(type => 'vlan', netmask => 1);
-    $previous_ip =~ s'/'\\/';
     file_content_replace($config, $previous_ip => $self->get_ip(type => 'vlan_changed', netmask => 1));
     $self->wicked_command('ifreload', 'all');
     assert_script_run('ip a');


### PR DESCRIPTION
The caller of file_content_replace() should not care about internal
implementations. So we escape all special characters used by sed|bash,
which is / for sed regex and ' for bash.

- Verification run: 
  - http://cfconrad-vm.qa.suse.de/tests/4158 (advanced sut)
