### PR TITLE
Add yast2-security regression test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1407,6 +1407,7 @@ sub load_extra_tests_y2uitest_gui {
     # On openSUSE, the scheduling happens in schedule/yast2_gui.yaml
     if (get_var("QAM_YAST2UI")) {
         loadtest "yast2_gui/yast2_storage_ng" if is_sle("12-SP2+");
+        loadtest "yast2_gui/yast2_security"   if is_sle("12-SP2+");
     }
 }
 

--- a/schedule/yast2_gui.yaml
+++ b/schedule/yast2_gui.yaml
@@ -30,3 +30,4 @@ schedule:
     - yast2_gui/yast2_software_management
     - yast2_gui/yast2_users
     - yast2_gui/yast2_storage_ng
+    - yast2_gui/yast2_security

--- a/tests/yast2_gui/yast2_security.pm
+++ b/tests/yast2_gui/yast2_security.pm
@@ -1,0 +1,62 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: this test checks that YaST2's Security module is behaving
+#          correctly by changing some valules and verifying that they
+#          have been successfully set.
+# Maintainer: Paolo Stivanin <pstivanin@suse.com>
+
+use base "y2_module_guitest";
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    my $self = shift;
+    select_console "x11";
+
+    # Password Settings
+    $self->launch_yast2_module_x11("security", match_timeout => 120);
+    assert_and_click "yast2_security-pwd-settings";
+    send_key "alt-m";
+    wait_still_screen 1;
+    wait_screen_change { type_string "8" };
+    send_key "alt-d";
+    wait_still_screen 1;
+    wait_screen_change { type_string "30" };
+    wait_screen_change { send_key "alt-o" };
+
+    # Check previously set values + Login Settings
+    $self->launch_yast2_module_x11("security", match_timeout => 120);
+    assert_and_click "yast2_security-pwd-settings";
+    assert_screen "yast2_security-check-min-pwd-len-and-exp-days";
+    assert_and_click "yast2_security-login-settings";
+    send_key "alt-d";
+    wait_still_screen 1;
+    wait_screen_change { type_string "5" };
+    wait_screen_change { send_key "alt-o" };
+
+    # Check previously set values + Miscellaneous Settings
+    $self->launch_yast2_module_x11("security", match_timeout => 120);
+    assert_and_click "yast2_security-login-settings";
+    assert_screen "yast2_security-login-attempts";
+    # set file permissions to 'secure'
+    assert_and_click "yast2_security-misc-settings";
+    send_key "alt-f";
+    wait_screen_change { send_key "down" };
+    wait_screen_change { send_key "alt-o" };
+
+    # Check previously set values
+    $self->launch_yast2_module_x11("security", match_timeout => 120);
+    assert_and_click "yast2_security-misc-settings";
+    assert_screen "yast2_security-file-perms-secure";
+    wait_screen_change { send_key "alt-o" };
+}
+
+1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/49331
- Needles:
  - oS: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/553
  - SLE: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1130
- Verification runs:
  - oS TW: http://d502.qam.suse.de/tests/1884 :heavy_check_mark: 
  - oS Leap: http://d502.qam.suse.de/tests/1885  :heavy_check_mark: 
  - SLE 15: http://d502.qam.suse.de/tests/1883  :heavy_check_mark: 
  - SLE 12.4: http://d502.qam.suse.de/tests/1880  :heavy_check_mark: 
  - SLE 12.3: http://d502.qam.suse.de/tests/1882  :heavy_check_mark: 
  - SLE 12.2: http://d502.qam.suse.de/tests/1881  :heavy_check_mark: 

The test will reside on the newly created `mau-extratests-yast2ui` (for `osd`)