### PR TITLE
Increase ha/pacemaker_cts_regression timeout in aarch64

### DIFF
--- a/tests/ha/pacemaker_cts_regression.pm
+++ b/tests/ha/pacemaker_cts_regression.pm
@@ -21,12 +21,17 @@ sub run {
     my $cts_path     = '/usr/share/pacemaker/tests';
     my @tests_to_run = qw(cts-cli cts-exec cts-scheduler cts-fencing);
     my $log          = '/tmp/cts_regression.log';
+    my $timeout      = 600;
+
+    # Some of the tests take longer to complete in aarch64.
+    # This increases the timeout in that ARCH
+    $timeout *= 2 if check_var('ARCH', 'aarch64');
 
     zypper_call 'in pacemaker-cts';
 
     foreach my $cts_tests (@tests_to_run) {
         record_info("$cts_tests", "Starting $cts_tests");
-        assert_script_run "$cts_path/$cts_tests -V | tee -a $log 2>&1", timeout => 600;
+        assert_script_run "$cts_path/$cts_tests -V | tee -a $log 2>&1", timeout => $timeout;
         save_screenshot;
     }
 


### PR DESCRIPTION
Increase `ha/pacemaker_cts_regression` timeout when ARCH=aarch64.

- Related ticket: N/A
- Failing test: https://openqa.suse.de/tests/2857282#step/pacemaker_cts_regression/12
- Needles: N/A
- Verification run: N/A
