### PR TITLE
Remove additional yast2 lan call

### DIFF
--- a/tests/console/yast2_lan_hostname.pm
+++ b/tests/console/yast2_lan_hostname.pm
@@ -27,7 +27,6 @@ sub hostname_via_dhcp {
     $cmd{spc}              = 'spc';
 
     y2logsstep::yast2_console_exec(yast2_module => 'lan');
-    type_string "Y2DEBUG=1 ZYPP_MEDIA_CURL_DEBUG=1 yast2 \n";
     accept_warning_network_manager_default;
     assert_screen 'yast2_lan';
 


### PR DESCRIPTION
- Related ticket: [[y][functional] test fails in yast2_i](https://progress.opensuse.org/issues/50495)
- failure: [yast2_lan_hostname](https://openqa.suse.de/tests/2858959#step/yast2_lan_hostname/10)