### PR TITLE
Zypper migration tests: add support for SLES4SAP

### DIFF
--- a/tests/migration/sle12_online_migration/online_migration_setup.pm
+++ b/tests/migration/sle12_online_migration/online_migration_setup.pm
@@ -14,16 +14,20 @@ use base "consoletest";
 use strict;
 use warnings;
 use utils;
-use version_utils 'is_desktop_installed';
+use version_utils qw(is_desktop_installed is_sles4sap);
 use testapi;
 use migration;
 
 sub run {
     my ($self) = @_;
 
-    # if source system is minimal installation then boot to textmode
+    # Do not attempt to log into the desktop of a system installed with SLES4SAP
+    # being prepared for upgrade, as it does not have an unprivileged user to test
+    # with other than the SAP Administrator
+    #
+    # If source system is minimal installation then boot to textmode
     # we don't care about source system start time because our SUT is upgraded one
-    $self->wait_boot(textmode => !is_desktop_installed(), ready_time => 600);
+    $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 300, ready_time => 600, nologin => is_sles4sap);
     $self->setup_migration();
 }
 

--- a/tests/migration/sle12_online_migration/post_migration.pm
+++ b/tests/migration/sle12_online_migration/post_migration.pm
@@ -15,7 +15,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils 'is_desktop_installed';
+use version_utils qw(is_desktop_installed is_sles4sap is_sle);
 use qam qw(add_test_repositories remove_test_repositories);
 use x11utils 'ensure_unlocked_desktop';
 
@@ -27,7 +27,7 @@ sub run {
 
     add_maintenance_repos() if (get_var('MAINT_TEST_REPO'));
 
-    if (is_desktop_installed) {
+    if (is_desktop_installed && (!is_sles4sap || is_sle('15+'))) {
         select_console 'x11', await_console => 0;
         ensure_unlocked_desktop;
         mouse_hide(1);

--- a/tests/migration/sle12_online_migration/zypper_migration.pm
+++ b/tests/migration/sle12_online_migration/zypper_migration.pm
@@ -16,6 +16,7 @@ use warnings;
 use testapi;
 use utils;
 use power_action_utils 'power_action';
+use version_utils qw(is_desktop_installed is_sles4sap);
 
 sub run {
     my $self = shift;
@@ -104,8 +105,12 @@ sub run {
     }
     power_action('reboot', keepconsole => 1, textmode => 1);
 
+    # Do not attempt to log into the desktop of a system installed with SLES4SAP
+    # being prepared for upgrade, as it does not have an unprivileged user to test
+    # with other than the SAP Administrator
+    #
     # sometimes reboot takes longer time after online migration, give more time
-    $self->wait_boot(bootloader_time => 300);
+    $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 300, ready_time => 600, nologin => is_sles4sap);
 }
 
 1;

--- a/tests/migration/sle12_online_migration/zypper_patch.pm
+++ b/tests/migration/sle12_online_migration/zypper_patch.pm
@@ -16,7 +16,7 @@ use warnings;
 use testapi;
 use utils;
 use power_action_utils 'power_action';
-use version_utils 'is_desktop_installed';
+use version_utils qw(is_desktop_installed is_sles4sap);
 use migration;
 use qam;
 
@@ -28,7 +28,11 @@ sub run {
     fully_patch_system;
     remove_ltss;
     power_action('reboot', keepconsole => 1, textmode => 1);
-    $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 300, ready_time => 600);
+
+    # Do not attempt to log into the desktop of a system installed with SLES4SAP
+    # being prepared for upgrade, as it does not have an unprivileged user to test
+    # with other than the SAP Administrator
+    $self->wait_boot(textmode => !is_desktop_installed, bootloader_time => 300, ready_time => 600, nologin => is_sles4sap);
     $self->setup_migration;
 }
 


### PR DESCRIPTION
Little changes are needed in current zypper migration tests to support SLES4SAP.

Verification runs with SAP and HA:
- [SLES4SAP from 12-SP4 to 12-SP5](http://1b147.qa.suse.de/tests/5343)
- [SLES4SAP from 15 to 15-SP1](http://1b147.qa.suse.de/tests/5325)
- [HA from 15 to 15-SP1](http://1b147.qa.suse.de/tests/5348)
- [HA from 15 to 15-SP1 aarch64](http://1b147.qa.suse.de/tests/5349)

Verification runs with existing #qa-sle tests, to validate that changes not break anything:
- [from 12-SP3 to 12-SP5](http://1b147.qa.suse.de/tests/5344)
- [from 15 to 15-SP1](http://1b147.qa.suse.de/tests/5350)
