### PR TITLE
Test SSH forwarding

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -18,7 +18,7 @@ use base "consoletest";
 use strict;
 use testapi qw(is_serial_terminal :DEFAULT);
 use utils qw(systemctl exec_and_insert_password);
-use version_utils qw(is_virtualization_server is_upgrade);
+use version_utils qw(is_virtualization_server is_upgrade is_sle is_opensuse);
 
 sub run {
     my $self = shift;
@@ -80,12 +80,31 @@ sub run {
     select_console 'root-console';
 
     # Generate RSA key for SSH and copy it to our new user's profile
-    assert_script_run "ssh-keygen -t rsa -P '' -C 'localhost' -f ~/.ssh/id_rsa";
-    assert_script_run "install -m 1700 -o $ssh_testman -d /home/$ssh_testman/.ssh";
+    assert_script_run "ssh-keygen -t rsa -P '' -C 'root\@localhost' -f ~/.ssh/id_rsa";
+    assert_script_run "sudo -u $ssh_testman ssh-keygen -t rsa -P '' -C '$ssh_testman\@localhost' -f /home/$ssh_testman/.ssh/id_rsa";
     assert_script_run "install -m 0644 -o $ssh_testman ~/.ssh/id_rsa.pub /home/$ssh_testman/.ssh/authorized_keys";
+    assert_script_run "cat /home/$ssh_testman/.ssh/id_rsa.pub >> /home/$ssh_testman/.ssh/authorized_keys";
 
     # Test non-interactive SSH and after that remove RSA keys
     assert_script_run "ssh -4v $ssh_testman\@localhost bash -c 'whoami | grep $ssh_testman'";
+
+    # Port forwarding (bsc#1131709 bsc#1133386)
+    assert_script_run "( ssh -vv -L 4242:localhost:22 $ssh_testman\@localhost sleep 9999 & )";
+    assert_script_run "( ssh -vv -R 0.0.0.0:5252:localhost:22 $ssh_testman\@localhost sleep 9999 & )";
+    assert_script_run "ssh-keyscan -p 4242 localhost >> ~/.ssh/known_hosts";
+    assert_script_run "ssh-keyscan -p 5252 localhost >> ~/.ssh/known_hosts";
+
+    assert_script_run "ssh -p 4242 $ssh_testman\@localhost whoami";
+    assert_script_run "ssh -p 5252 $ssh_testman\@localhost whoami";
+    assert_script_run "ssh -p 4242 $ssh_testman\@localhost 'ssh-keyscan -p 22 localhost 127.0.0.1 ::1 >> ~/.ssh/known_hosts'";
+    assert_script_run "ssh -p 4242 $ssh_testman\@localhost 'ssh-keyscan -p 4242 localhost 127.0.0.1 ::1 >> ~/.ssh/known_hosts'";
+    assert_script_run "ssh -p 4242 $ssh_testman\@localhost 'ssh-keyscan -p 5252 localhost 127.0.0.1 ::1 >> ~/.ssh/known_hosts'";
+
+    assert_script_run "ssh -p 4242 -tt $ssh_testman\@localhost ssh -tt $ssh_testman\@localhost whoami";
+    assert_script_run "ssh -t -o ProxyCommand='ssh $ssh_testman\@localhost nc localhost 4242' $ssh_testman\@localhost whoami";
+    if (is_opensuse || is_sle('15+')) {
+        assert_script_run "ssh -J $ssh_testman\@localhost:4242 $ssh_testman\@localhost whoami";
+    }
 
     # SCP (poo#46937)
     assert_script_run "scp -4v $ssh_testman\@localhost:/etc/resolv.conf /tmp";


### PR DESCRIPTION
This is extending the openssh test by using forwarding, proxy command, proxy jump and forced pseudo-terminal features. I use several methods to use ssh connection as a transport layer for another ssh connection.

- Related ticket: [poo#50768](https://progress.opensuse.org/issues/50768)
- Needles: None
- Verification run: [Tumbleweed](http://pdostal-server.suse.cz/tests/2494) [SLE 12-SP4](http://pdostal-server.suse.cz/tests/2495)
