### PR TITLE
Implement NFSv4 and extend both v3 and v4 tests

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -1,0 +1,187 @@
+package nfs_common;
+use mmapi;
+use testapi;
+use strict;
+use warnings;
+use utils qw(systemctl file_content_replace);
+use Utils::Systemd 'disable_and_stop_service';
+use mm_network;
+use version_utils;
+
+
+our @ISA    = qw(Exporter);
+our @EXPORT = qw(server_configure_network try_nfsv2 prepare_exports yast_handle_firewall add_shares
+  mount_export client_common_tests check_nfs_ready yast2_server_initial);
+
+sub server_configure_network {
+    # Configure static IP for client/server test
+    configure_default_gateway;
+    configure_static_ip('10.0.2.101/24');
+    configure_static_dns(get_host_resolv_conf());
+
+    if (is_sle('15+')) {
+        record_soft_failure 'boo#1130093 No firewalld service for nfs-kernel-server';
+        disable_and_stop_service('firewalld');
+    }
+}
+
+sub try_nfsv2 {
+    # Try that NFSv2 is disabled by default
+    systemctl 'start nfsserver';
+    assert_script_run "cat /proc/fs/nfsd/versions | grep '\\-2'";
+    file_content_replace("/etc/sysconfig/nfs", "MOUNTD_OPTIONS=.*" => "MOUNTD_OPTIONS=\"-V2\"", "NFSD_OPTIONS=.*" => "NFSD_OPTIONS=\"-V2\"");
+    systemctl 'restart nfsserver';
+    assert_script_run "cat /proc/fs/nfsd/versions | grep '+2'";
+
+    # Disable NFSv2 again
+    file_content_replace("/etc/sysconfig/nfs", "MOUNTD_OPTIONS=.*" => "MOUNTD_OPTIONS=\"\"", "NFSD_OPTIONS=.*" => "NFSD_OPTIONS=\"\"");
+    systemctl 'stop nfsserver';
+}
+
+sub prepare_exports {
+    my ($rw, $ro) = @_;
+    my $ne = "/srv/dir/";
+
+    # Create a directory and place a test file in it
+    assert_script_run "mkdir ${rw} && echo success > ${rw}/file.txt";
+
+    # Create also hardlink, symlink and do bindmount
+    assert_script_run "( mkdir ${ne} ${rw}/bindmounteddir && ln -s ${ne} ${rw}/symlinkeddir && mount --bind ${ne} ${rw}/bindmounteddir )";
+    assert_script_run "( echo example > ${ne}/example && ln ${ne}/example ${rw}/hardlinkedfile & ln -s ${ne}example ${rw}/symlinkedfile )";
+    assert_script_run "echo secret > ${rw}/secret.txt && chmod 740 ${rw}/secret.txt";
+
+    # Create large file and count its md5sum
+    assert_script_run "fallocate -l 1G ${rw}/random";
+    assert_script_run "md5sum ${rw}/random | cut -d' ' -f1 > ${rw}/random.md5sum";
+
+    # Create read only directory - this is different between v3 and v4
+    assert_script_run "mkdir ${ro} && echo success > ${ro}/file.txt";
+}
+
+sub yast_handle_firewall {
+    if (is_sle('<15')) {
+        send_key 'alt-f';    # Open port in firewall
+        assert_screen 'nfs-firewall-open';
+    }
+    else {
+        save_screenshot;
+    }
+}
+
+sub add_shares {
+    my ($rw, $ro) = @_;
+
+    # Add rw share
+    send_key 'alt-d';
+    assert_screen 'nfs-new-share';
+    type_string $rw;
+    send_key 'alt-o';
+
+    # Permissions dialog
+    assert_screen 'nfs-share-host';
+    send_key 'tab';
+    # Change 'ro,root_squash' to 'rw,fsid=0,no_root_squash,...'
+    send_key 'home';
+    send_key 'delete';
+    send_key 'delete';
+    send_key 'delete';
+    type_string "rw,fsid=0,no_";
+    send_key 'alt-o';
+
+    # Saved
+    assert_screen 'nfs-share-saved';
+
+    # Add ro share
+    send_key 'alt-d';
+    assert_screen 'nfs-new-share';
+    type_string $ro;
+    send_key 'alt-o';
+
+    # Permissions dialog
+    assert_screen 'nfs-share-host';
+    send_key 'alt-o';
+
+    # Saved
+    assert_screen 'nfs-share-saved';
+}
+
+sub mount_export {
+    script_run 'mount|grep nfs';
+    assert_script_run 'cat /etc/fstab | grep nfs';
+
+    # script_run is using bash return logic not perl logic, 0 is true
+    if ((script_run('grep "success" /tmp/nfs/client/file.txt', 90)) != 0) {
+        record_soft_failure 'boo#1006815 nfs mount is not mounted';
+        assert_script_run 'mount /tmp/nfs/client';
+        assert_script_run 'grep "success" /tmp/nfs/client/file.txt';
+    }
+}
+
+sub client_common_tests {
+    # remove added nfs from /etc/fstab
+    assert_script_run 'sed -i \'/nfs/d\' /etc/fstab';
+
+    # compare saved and current fstab, should be same
+    assert_script_run 'diff -b /etc/fstab fstab_before';
+
+    # compare last line, should be not deleted
+    assert_script_run 'diff -b <(tail -n1 /etc/fstab) <(tail -n1 fstab_before)';
+
+    # Remote symlinked directory is visible, removable but not accessible
+    assert_script_run "ls -la /tmp/nfs/client/symlinkeddir";
+    assert_script_run "! ls -la /tmp/nfs/client/symlinkeddir/";
+    assert_script_run "! touch /tmp/nfs/client/symlinkeddir/x";
+    assert_script_run "rm /tmp/nfs/client/symlinkeddir";
+
+    # Remote bind-mounted directory is visible, accessible but isn't removable
+    assert_script_run "ls -la /tmp/nfs/client/bindmounteddir/";
+    assert_script_run "touch /tmp/nfs/client/bindmounteddir/x";
+    assert_script_run "! rm -rf /tmp/nfs/client/bindmounteddir";
+
+    # Remote hardlinks is visible, accessible and removable
+    assert_script_run "ls -la /tmp/nfs/client/hardlinkedfile";
+    assert_script_run "cat /tmp/nfs/client/hardlinkedfile";
+    assert_script_run "echo x > /tmp/nfs/client/hardlinkedfile";
+    assert_script_run "rm /tmp/nfs/client/hardlinkedfile";
+
+    # Remote symlink is visible but not readable, nor writable, nor removable
+    assert_script_run "ls -la /tmp/nfs/client/symlinkedfile";
+    assert_script_run "! cat /tmp/nfs/client/symlinkedfile";
+    assert_script_run "! echo x > /tmp/nfs/client/symlinkedfile";
+    assert_script_run "rm /tmp/nfs/client/symlinkedfile";
+
+    # Copy large file from NFS and test it's checksum
+    assert_script_run "time cp /tmp/nfs/client/random /tmp/", 120;
+    assert_script_run "md5sum /tmp/random | cut -d' ' -f1 > /tmp/random.md5sum";
+    assert_script_run "diff /tmp/nfs/client/random.md5sum /tmp/random.md5sum";
+}
+
+sub check_nfs_ready {
+    my ($rw, $ro) = @_;
+
+    assert_script_run "exportfs | grep '${rw}\\|${ro}'";
+    assert_script_run "cat /etc/exports | tr -d ' \\t\\r' | grep '${rw}\\*(rw,\\|${ro}\\*(ro,'";
+    assert_script_run "cat /proc/fs/nfsd/exports";
+
+    if ((script_run('systemctl is-enabled nfsserver')) != 0) {
+        record_info 'disabled', 'The nfsserver unit is disabled';
+        systemctl 'enable nfsserver';
+    }
+    if ((script_run('systemctl is-active nfsserver')) != 0) {
+        record_info 'stopped', 'The nfsserver unit is stopped';
+        systemctl 'start nfsserver';
+    }
+}
+
+sub yast2_server_initial {
+    do {
+        assert_screen([qw(nfs-server-not-installed nfs-firewall nfs-config)]);
+        # install missing packages as proposed
+        if (match_has_tag('nfs-server-not-installed') or match_has_tag('nfs-firewall')) {
+            send_key 'alt-i';
+        }
+    } while (not match_has_tag('nfs-config'));
+}
+
+1;
+

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1008,15 +1008,26 @@ else {
             loadtest "network/salt_minion";
         }
     }
-    elsif (get_var("NFSSERVER") or get_var("NFSCLIENT")) {
+    elsif (get_var("NFSSERVER") || get_var("NFSCLIENT")) {
         set_var('INSTALLONLY', 1);
         boot_hdd_image;
-        #loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
+        loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
         if (get_var("NFSSERVER")) {
             loadtest "console/yast2_nfs_server";
         }
         else {
             loadtest "console/yast2_nfs_client";
+        }
+    }
+    elsif (get_var("NFS4SERVER") || get_var("NFS4CLIENT")) {
+        set_var('INSTALLONLY', 1);
+        boot_hdd_image;
+        loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
+        if (get_var("NFS4SERVER")) {
+            loadtest "console/yast2_nfs4_server";
+        }
+        else {
+            loadtest "console/yast2_nfs4_client";
         }
     }
     elsif (get_var('QAM_VSFTPD')) {

--- a/tests/console/yast2_nfs4_client.pm
+++ b/tests/console/yast2_nfs4_client.pm
@@ -1,0 +1,115 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: yast2_nfs4_client module
+#   This is the client side of yast2_nfs4_server module.
+#   This uses the yast2 nfs-client module with NFS4 strictly enabled.
+# Maintainer: Pavel Dostal <pdostal@suse.cz>
+
+use base "y2_module_consoletest";
+
+use strict;
+use warnings;
+use utils qw(clear_console zypper_call systemctl);
+use version_utils;
+use testapi;
+use lockapi;
+use mm_network;
+use nfs_common;
+
+sub run {
+    #
+    # Preparation
+    #
+    select_console 'root-console';
+
+    # Configure static IP for client/server test
+    configure_default_gateway;
+    configure_static_ip('10.0.2.102/24');
+    configure_static_dns(get_host_resolv_conf());
+
+    zypper_call('in yast2-nfs-client nfs-client nfs4-acl-tools', timeout => 480, exitcode => [0, 106, 107]);
+
+    mutex_wait('nfs4_ready');
+    assert_script_run 'ping -c3 10.0.2.101';
+
+    # add comments into fstab and save current fstab bsc#429326
+    assert_script_run 'sed -i \'5i# test comment\' /etc/fstab';
+    assert_script_run 'cat /etc/fstab > fstab_before';
+
+    #
+    # YaST nfs-client execution
+    #
+    my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'nfs-client');
+
+    assert_screen 'yast2-nfs-client-shares';
+    send_key 'alt-a';
+    assert_screen 'yast2-nfs-client-add';
+    # Enable NFSv4
+    send_key 'alt-v';
+    if (is_sle('15+')) {
+        send_key 'down';
+        send_key 'down';
+        send_key 'ret';
+    }
+    # Type the nfs server hostname
+    send_key 'alt-n';
+    type_string '10.0.2.101';
+    # Explore the available shares and select the only available one
+    send_key 'alt-e';
+    assert_screen 'yast2-nfs-client-exported';
+    send_key 'alt-o';
+    # Set the local mount point
+    send_key 'alt-m';
+    type_string '/tmp/nfs/client';
+    sleep 1;
+    save_screenshot;
+    # Save the new connection and check it in table
+    wait_screen_change { send_key 'alt-o' };
+    sleep 1;
+    save_screenshot;
+    # Exit YaST
+    wait_screen_change { send_key 'alt-o' };
+
+    wait_serial("$module_name-0") or die "'yast2 $module_name' didn't finish";
+    clear_console;
+
+    mount_export();
+
+    # Check NFS version
+    assert_script_run "nfsstat -m | grep vers=4";
+
+    client_common_tests();
+
+    # Test NFSv4 POSIX permissions
+    assert_script_run "ls -la /tmp/nfs/client/secret.txt | grep '\\-rwxr\\-\\-\\-\\-\\-'";
+    assert_script_run "! sudo -u $testapi::username cat /tmp/nfs/client/secret.txt";
+
+    # Test NFSv4 ACL
+    assert_script_run "nfs4_getfacl /tmp/nfs/client/secret.txt";
+    assert_script_run "nfs4_setfacl -R -a A:df:$testapi::username\@localdomain:RX /tmp/nfs/client/secret.txt";
+    assert_script_run "nfs4_getfacl /tmp/nfs/client/secret.txt | grep \"A::`id -u $testapi::username`:rxtcy\"";
+    assert_script_run "sudo -u $testapi::username cat /tmp/nfs/client/secret.txt";
+
+    # Test NFSv4 ro export
+    assert_script_run "mkdir /tmp/nfs/ro";
+    assert_script_run "mount 10.0.2.101:/ro /tmp/nfs/ro";
+    assert_script_run "ls /tmp/nfs/ro";
+    assert_script_run "grep success /tmp/nfs/ro/file.txt";
+    assert_script_run "echo modified > /tmp/nfs/ro/file.txt";
+    assert_script_run "grep modified /tmp/nfs/ro/file.txt";
+
+    # Safely umount NFS4 share
+    assert_script_run 'umount /tmp/nfs/ro';
+    assert_script_run 'umount /tmp/nfs/client';
+}
+
+1;
+

--- a/tests/console/yast2_nfs_client.pm
+++ b/tests/console/yast2_nfs_client.pm
@@ -19,8 +19,9 @@ use strict;
 use warnings;
 use testapi;
 use lockapi;
-use utils;
+use utils qw(clear_console zypper_call systemctl);
 use mm_network;
+use nfs_common;
 
 sub run {
     #
@@ -33,20 +34,22 @@ sub run {
         configure_static_ip('10.0.2.102/24');
         configure_static_dns(get_host_resolv_conf());
 
-        zypper_call('in yast2-nfs-client nfs-client', timeout => 360, exitcode => [0, 106, 107]);
+        zypper_call('in yast2-nfs-client nfs-client', timeout => 480, exitcode => [0, 106, 107]);
 
         mutex_wait('nfs_ready');
         assert_script_run 'ping -c3 10.0.2.101';
+        assert_script_run "showmount -e 10.0.2.101";
     }
     else {
         # Make sure packages are installed
-        zypper_call('in yast2-nfs-client nfs-client nfs-kernel-server', timeout => 180, exitcode => [0, 106, 107]);
+        zypper_call('in yast2-nfs-client nfs-client nfs-kernel-server', timeout => 480, exitcode => [0, 106, 107]);
         # Prepare the test file structure
         assert_script_run 'mkdir -p /tmp/nfs/server';
         assert_script_run 'echo "success" > /tmp/nfs/server/file.txt';
         # Serve the share
         assert_script_run 'echo "/tmp/nfs/server *(ro)" >> /etc/exports';
         systemctl 'start nfs-server';
+        assert_script_run "showmount -e localhost";
     }
     # add comments into fstab and save current fstab bsc#429326
     assert_script_run 'sed -i \'5i# test comment\' /etc/fstab';
@@ -55,15 +58,20 @@ sub run {
     #
     # YaST nfs-client execution
     #
+
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'nfs-client');
+
     assert_screen 'yast2-nfs-client-shares';
-    # Open the dialog to add a connection to the share
     send_key 'alt-a';
     assert_screen 'yast2-nfs-client-add';
     type_string get_var('NFSCLIENT') ? '10.0.2.101' : 'localhost';
     # Explore the available shares and select the only available one
     send_key 'alt-e';
-    assert_screen 'yast2-nfs-client-exported';
+    check_screen('yast2-nfs-client-exported', 15);
+    if (not match_has_tag('yast2-nfs-client-exported')) {
+        send_key 'down';
+        assert_screen 'yast2-nfs-client-exported';
+    }
     send_key 'alt-o';
     # Set the local mount point
     send_key 'alt-m';
@@ -72,41 +80,41 @@ sub run {
     save_screenshot;
     # Save the new connection and close YaST
     wait_screen_change { send_key 'alt-o' };
+    sleep 1;
+    save_screenshot;
+    # Exit YaST
     wait_screen_change { send_key 'alt-o' };
 
-    wait_serial("$module_name-0") or die "'yast2 nfs-server' didn't finish";
-
+    wait_serial("$module_name-0") or die "'yast2 $module_name' didn't finish";
     clear_console;
 
     #
     # Check the result
     #
 
-    # check if nfs is mounted
-    script_run 'mount|grep nfs';
-    script_run 'cat /etc/fstab|grep nfs';
+    mount_export();
 
-    # Wait for more than 90 seconds due to NFSD's 90 second grace period.
-    diag 'waiting 90 second due NFS grace period';
-    sleep 90;
+    # Check NFS version
+    assert_script_run "nfsstat -m | grep vers=3";
 
-    # script_run is using bash return logic not perl logic, 0 is true
-    if ((script_run 'grep "success" /tmp/nfs/client/file.txt') != 0) {
-        record_soft_failure 'boo#1006815 nfs mount is not mounted';
-        assert_script_run 'mount /tmp/nfs/client';
-        assert_script_run 'grep "success" /tmp/nfs/client/file.txt';
-    }
+    client_common_tests();
 
-    # remove added nfs from /etc/fstab
-    assert_script_run 'sed -i \'/nfs/d\' /etc/fstab';
+    # Test NFSv3 POSIX permissions
+    assert_script_run "ls -la /tmp/nfs/client/secret.txt | grep '\\-rwxr\\-\\-\\-\\-\\-'";
+    assert_script_run "! sudo -u $testapi::username cat /tmp/nfs/client/secret.txt";
 
-    # compare saved and current fstab, should be same
-    if ((script_run 'diff -b /etc/fstab fstab_before') != 0) {
-        record_soft_failure 'bsc#429326 comments were deleted';
-    }
+    # Test NFSv3 ro export
+    assert_script_run "mkdir /tmp/nfs/ro";
+    assert_script_run "mount 10.0.2.101:/srv/ro /tmp/nfs/ro";
+    assert_script_run "ls /tmp/nfs/ro";
+    assert_script_run "grep success /tmp/nfs/ro/file.txt";
+    assert_script_run "! echo modified > /tmp/nfs/ro/file.txt";
+    assert_script_run "! grep modified /tmp/nfs/ro/file.txt";
 
-    # compare last line, should be not deleted
-    assert_script_run 'diff -b <(tail -n1 /etc/fstab) <(tail -n1 fstab_before)';
+    # Safely umount NFS share
+    assert_script_run 'umount /tmp/nfs/ro';
+    assert_script_run 'umount /tmp/nfs/client';
+
 }
 
 1;


### PR DESCRIPTION
* NFSv4 is used and checked
* Access rights are tested
* NFSv4 ACLs are tested 
* NFSv2 support is briefly tested

- Related ticket: [poo#44591](https://progress.opensuse.org/issues/44591)
- Needles: [os-autoinst-needles-sles#1133](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1133)
- Verification run: [nfs3-client@sles12sp3](http://pdostal-server.suse.cz/tests/2792) [nfs3-server@sles12sp3](http://pdostal-server.suse.cz/tests/2791) [nfs4-client@sles12sp4](http://pdostal-server.suse.cz/tests/2788) [nfs4-server@sles12sp4](http://pdostal-server.suse.cz/tests/2787) [nfs4-client@sles15](http://pdostal-server.suse.cz/tests/2774) [nfs4-server@sles15](http://pdostal-server.suse.cz/tests/2773)