### PR TITLE
Add SDK on developed products for libzzip dependencies

### DIFF
--- a/tests/console/zziplib.pm
+++ b/tests/console/zziplib.pm
@@ -17,10 +17,23 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use registration qw(cleanup_registration register_product add_suseconnect_product get_addon_fullname);
+use version_utils 'is_sle';
 
 sub run {
     my $filezip = "files.zip";
     select_console "root-console";
+    # development module needed for dependencies, released products are tested with sdk module
+    if (get_var('BETA')) {
+        my $sdk_repo = is_sle('15+') ? get_var('REPO_SLE_MODULE_DEVELOPMENT_TOOLS') : get_var('REPO_SLE_SDK');
+        zypper_ar 'http://' . get_var('OPENQA_URL') . "/assets/repo/$sdk_repo", 'SDK';
+    }
+    # maintenance updates are registered with sdk module
+    elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
+        cleanup_registration;
+        register_product;
+        add_suseconnect_product(get_addon_fullname('sdk'));
+    }
     # create a tmp dir/files to work
     assert_script_run "mkdir /tmp/zip; cp /usr/share/doc/* /tmp/zip -R";
     assert_script_run "cd /tmp";


### PR DESCRIPTION
At some point developed product will lose BETA variable but he will still need SDK, the reason of elsif.

- Related ticket: https://openqa.suse.de/tests/2865428#step/zziplib/10
- Verification run:
[12SP5](http://10.100.12.155/tests/11669#step/zziplib/4)
[15SP1](http://10.100.12.155/tests/11668#step/zziplib/4)
[Unaffected maintenance](http://10.100.12.155/tests/11670#step/zziplib/6)