### PR TITLE
Avoid to enable kdump service if no CONFIG_RELOCATABLE kernel for PowerPC

### DIFF
--- a/tests/console/kdump_and_crash.pm
+++ b/tests/console/kdump_and_crash.pm
@@ -37,6 +37,13 @@ sub run {
     $self->wait_boot;
     select_console 'root-console';
 
+    if (check_var('ARCH', 'ppc64le') || check_var('ARCH', 'ppc64')) {
+        if (script_run('kver=$(uname -r); kconfig="/boot/config-$kver"; [ -f $kconfig ] && grep ^CONFIG_RELOCATABLE $kconfig')) {
+            record_soft_failure 'poo#49466 -- No kdump if no CONFIG_RELOCATABLE in kernel config';
+            return 1;
+        }
+    }
+
     # often kdump could not be enabled: bsc#1022064
     return 1 unless kdump_is_active;
     do_kdump;


### PR DESCRIPTION
Avoid to enable kdump service if no CONFIG_RELOCATABLE kernel for PowerPC
to bypass issue https://progress.opensuse.org/issues/49466

code change validated for ppc64le at
https://openqa.opensuse.org/tests/930182#step/kdump_and_crash/49  (with return 0)
https://openqa.opensuse.org/tests/933734  (with return 1)