### PR TITLE
Workaround for long yast2_console_exec magic string

### DIFF
--- a/lib/y2logsstep.pm
+++ b/lib/y2logsstep.pm
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 use version_utils qw(is_sle is_caasp);
 use ipmi_backend_utils;
+use Utils::Backends 'is_hyperv';
 use network_utils;
 use utils 'zypper_call';
 
@@ -380,6 +381,12 @@ sub yast2_console_exec {
       $args{yast2_opts} . ' ' . $args{yast2_module} . ';' :
       $args{yast2_module} . ';';
 
+    # poo#40715: Hyper-V 2012 R2 serial console is unstable (a Hyper-V product bug)
+    # and is in many cases loosing the 15th character, so e.g. instead of the expected
+    # 'yast2-scc-status-0' we get 'yast2-scc-statu-0' (sic, see the missing 's').
+    # Kepp only the first 10 characters of a magic string plus a dash ('-')
+    # and up to a three digit exit code.
+    $module_name = substr($module_name, 0, 10) if is_hyperv('2012r2');
     if (!script_run($y2_start . " echo $module_name-\$? > /dev/$serialdev", 0)) {
         return $module_name;
     } else {


### PR DESCRIPTION
https://trello.com/c/vBm1HWQk/417-p2-tests-on-hyper-v-2012-r2-fail-frequently-due-to-serial-console-hyper-v-bug

This is workaround for [poo#40715](https://progress.opensuse.org/issues/40715) on Hyper-V 2012 R2.

Fails:
* https://openqa.suse.de/tests/2866160#step/patch_sle/54
* https://openqa.suse.de/tests/2866161#step/yast2_i/28

Validation run:
* http://nilgiri.suse.cz/tests/723#step/patch_sle/54

@mloviska, it shouldn't affect anything but Hyper-V 2012 R2 platform, but I'd appreciate if you give me go with this.