### PR TITLE
Close the checksum error window

### DIFF
--- a/tests/x11/wireshark.pm
+++ b/tests/x11/wireshark.pm
@@ -158,12 +158,16 @@ sub run {
     # Sometimes checksum error window popup, then we need close this windows since this caused by offload feature
     assert_screen([qw(wireshark-filter-applied wireshark-checksum-error)]);
     if (match_has_tag('wireshark-checksum-error')) {
-        # Close checksum-error window
+        # Close checksum-error window, when we hit this error, the show submenu was extended
+        # we need escape the submenu then send alt-c to close the checksum error page.
+        send_key "esc";
+        wait_still_screen 3;
+        send_key "esc";
         wait_screen_change { send_key 'alt-c' };
-        assert_screen "wireshark-filter-selected";
-        assert_screen "wireshark-filter-applied";
     }
-    assert_screen "wireshark-dns-response-list";
+    else {
+        assert_screen "wireshark-dns-response-list";
+    }
 
     # close capture
     assert_and_click "wireshark-close-capture";


### PR DESCRIPTION
Close the checksum-error window, when we hit this error, the Show submenu was extended.
We need escape the submenu first then send alt-c to close the window.

Related ticket: https://progress.opensuse.org/issues/45098
Needles: N/A
Verification run:
- with checksum error
    http://openqa-apac1.suse.de/tests/4239
    https://openqa.suse.de/tests/2867123
- without checksum error: 
   https://openqa.suse.de/tests/overview?distri=sle&version=12-SP5&build=0135&groupid=152
   http://openqa-apac1.suse.de/tests/4183
   http://openqa-apac1.suse.de/tests/4184
   http://openqa-apac1.suse.de/tests/4186
   http://openqa-apac1.suse.de/tests/4187
   http://openqa-apac1.suse.de/tests/4192
   http://openqa-apac1.suse.de/tests/4195
   http://openqa-apac1.suse.de/tests/4204
  

