### PR TITLE
Fix nfsidmap part of the autofs tests to work on SLE12.

### DIFF
--- a/tests/network/autofs_client.pm
+++ b/tests/network/autofs_client.pm
@@ -41,7 +41,8 @@ sub run {
 
     # nfsidmap
     assert_script_run("rpm -q nfsidmap");
-    assert_script_run("nfsidmap -c");
+    # Allow failing, it's to clear the keyring if one exists
+    assert_script_run("nfsidmap -c || true");
     assert_script_run("mkdir -p $test_mount_dir_nfsidmap");
 
     barrier_wait 'AUTOFS_SUITE_READY';
@@ -59,7 +60,7 @@ sub run {
     validate_script_output("cat $test_mount_dir_nfsidmap/tux.txt",   sub { m/Hi tux/ });
     assert_script_run("umount $test_mount_dir_nfsidmap");
     assert_script_run("useradd -m tux");
-    assert_script_run("nfsidmap -c");
+    assert_script_run("nfsidmap -c || true");
     assert_script_run("mount -t nfs4 $nfs_server:$remote_mount_nfsidmap $test_mount_dir_nfsidmap");
     # Now 'tux' should be shown instead
     validate_script_output("ls -l $test_mount_dir_nfsidmap/tux.txt", sub { m/tux.*users.*tux.txt/ });

--- a/tests/network/autofs_server.pm
+++ b/tests/network/autofs_server.pm
@@ -41,7 +41,7 @@ sub run {
     assert_script_run "echo N > /sys/module/nfsd/parameters/nfs4_disable_idmapping";
     zypper_call('in nfsidmap');
     systemctl 'restart nfs-idmapd';
-    assert_script_run "nfsidmap -c";
+    assert_script_run "nfsidmap -c || true";
     assert_script_run "useradd -m tux";
     assert_script_run "echo Hi tux > $nfsidmap_share_dir/tux.txt";
     assert_script_run "chown tux:users $nfsidmap_share_dir/tux.txt";


### PR DESCRIPTION
Fix nfsidmap part of the autofs tests to work on SLE12 by allowing failing the nfsidmap -c command.

- Related ticket: https://progress.opensuse.org/issues/50867
- Verification run: http://d403.qam.suse.de/tests/112 (SLE15) http://d403.qam.suse.de/tests/114 (SLE12)
