### PR TITLE
Update scheduling of yast2 ui tests for QAM

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1401,17 +1401,13 @@ sub load_extra_tests_y2uitest_gui {
         && is_desktop_installed()
         && !get_var("DUALBOOT")
         && !get_var("RESCUECD"));
-    loadtest 'yast2_gui/yast2_control_center';
-    loadtest "x11/yast2_lan_restart";
-    loadtest "yast2_gui/yast2_bootloader";
-    loadtest "yast2_gui/yast2_datetime";
-    loadtest "yast2_gui/yast2_firewall";
-    loadtest "yast2_gui/yast2_hostnames";
-    loadtest "yast2_gui/yast2_lang";
-    loadtest "yast2_gui/yast2_network_settings";
-    loadtest "yast2_gui/yast2_software_management";
-    loadtest "yast2_gui/yast2_users";
-    loadtest "yast2_gui/yast2_storage_ng" if is_sle("12-SP2+");
+    # YaST2 ui tests currently run only for openSUSE >= 15.1.
+    # We (QAM) need to validate whether those tests work also
+    # on older SLE versions and, if so, add them here.
+    # On openSUSE, the scheduling happens in schedule/yast2_gui.yaml
+    if (get_var("QAM_YAST2UI")) {
+        loadtest "yast2_gui/yast2_storage_ng" if is_sle("12-SP2+");
+    }
 }
 
 sub load_extra_tests_y2uitest_cmd {

--- a/schedule/yast2_gui.yaml
+++ b/schedule/yast2_gui.yaml
@@ -29,3 +29,4 @@ schedule:
     - yast2_gui/yast2_network_settings
     - yast2_gui/yast2_software_management
     - yast2_gui/yast2_users
+    - yast2_gui/yast2_storage_ng


### PR DESCRIPTION
As we have just created a new test suite for QAM called mau-extratests-yast2ui, we need to control whether a yast2 gui test should be executed or not. As far as I can see, those tests are currently being tested only on SLE-devel (e.g. SLE 15.1), so they probably won't run successfully on older SLE versions.

Verification run: http://d250.qam.suse.de/tests/1947 :heavy_check_mark: 