### PR TITLE
YaST online_update: use the right update repo for non-x86 archs

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -75,7 +75,17 @@ sub start_online_update {
         select_console 'root-console';
         my $version     = lc get_required_var('VERSION');
         my $update_name = is_tumbleweed() ? $version : 'leap/' . $version . '/oss';
-        zypper_call("ar -f http://download.opensuse.org/update/$update_name repo-update");
+        my $repo_arch   = get_required_var('ARCH');
+        $repo_arch = 'ppc' if ($repo_arch =~ /ppc64|ppc64le/);
+        if ($repo_arch =~ /i586|i686|x86_64/) {
+            zypper_call("ar -f http://download.opensuse.org/update/$update_name repo-update");
+        } else {
+            if (is_tumbleweed()) {
+                zypper_call("ar -f http://download.opensuse.org/ports/$repo_arch/update/tumbleweed repo-update");
+            } else {
+                zypper_call("ar -f http://download.opensuse.org/ports/update/$update_name repo-update");
+            }
+        }
         select_console 'x11', await_console => 0;
     }
     assert_and_click 'yast2_control-center_online-update';


### PR DESCRIPTION
Tested on https://openqa.opensuse.org/tests/928823 (current failure is unrelated)