### PR TITLE
Do not schedule transactional behavior test when INSTALL_ONLY

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2499,7 +2499,7 @@ sub load_common_opensuse_sle_tests {
     load_toolchain_tests                if get_var("TCM") || check_var("ADDONS", "tcm");
     loadtest 'console/network_hostname' if get_var('NETWORK_CONFIGURATION');
     load_installation_validation_tests  if get_var('INSTALLATION_VALIDATION');
-    load_transactional_role_tests       if is_transactional;
+    load_transactional_role_tests       if is_transactional && !check_var('INSTALLONLY', '1');
 }
 
 sub load_ssh_key_import_tests {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/51296
- Verification run (`_EXIT_AFTER_SCHEDULE=1`): http://slindomansilla-vm.qa.suse.de/tests/1386/file/autoinst-log.txt
