### PR TITLE
Revert "Do not schedule transactional behavior test when INSTALL_ONLY"

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2504,6 +2504,7 @@ sub load_installation_validation_tests {
 }
 
 sub load_transactional_role_tests {
+    return if is_sle && !check_var('ARCH', 'x86_64');
     loadtest 'transactional/filesystem_ro';
     loadtest 'transactional/transactional_update';
     loadtest 'transactional/rebootmgr';
@@ -2518,7 +2519,7 @@ sub load_common_opensuse_sle_tests {
     load_toolchain_tests                if get_var("TCM") || check_var("ADDONS", "tcm");
     loadtest 'console/network_hostname' if get_var('NETWORK_CONFIGURATION');
     load_installation_validation_tests  if get_var('INSTALLATION_VALIDATION');
-    load_transactional_role_tests       if is_transactional && !check_var('INSTALLONLY', '1');
+    load_transactional_role_tests       if is_transactional;
 }
 
 sub load_ssh_key_import_tests {


### PR DESCRIPTION
INSTALLONLY flag is used to skip all non-transactional tests. It's there by intention.