### PR TITLE
Add tests for wavpack file compression format

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1545,6 +1545,10 @@ sub load_extra_tests_console {
     # Audio device is not supported on ppc64le, s390x, JeOS, and Xen PV
     if (!get_var("OFW") && !is_jeos && !check_var('VIRSH_VMM_FAMILY', 'xen') && !check_var('ARCH', 's390x')) {
         loadtest "console/aplay";
+        # wavpack is available only sle12sp3 onwards
+        if (is_opensuse || is_sle '12-sp3+') {
+            loadtest "console/wavpack";
+        }
     }
     loadtest "console/command_not_found";
     if (is_sle '12-sp2+') {

--- a/tests/console/wavpack.pm
+++ b/tests/console/wavpack.pm
@@ -1,0 +1,46 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test basic functionality of wavpack audio compression format.
+# Maintainer: Ednilson Miura <emiura@suse.com>
+
+use base "consoletest";
+use testapi;
+use strict;
+use warnings;
+use utils;
+
+sub run {
+    # setup
+    select_console 'root-console';
+    zypper_call 'in alsa alsa-utils wavpack';
+    assert_script_run("cp /usr/share/sounds/alsa/Noise.wav .");
+    assert_script_run("cp /usr/share/sounds/alsa/test.wav .");
+    assert_script_run("cp /usr/share/sounds/alsa/Side_Left.wav .");
+
+    # test wavpack functions
+    assert_script_run("wavpack Noise.wav -o Noise.wv 2>&1 | grep \"created Noise.wv\"");
+    assert_script_run("wavpack -f test.wav 2>&1 | grep \"created test.wv\"");
+    assert_script_run("wavpack -hh test.wav -o test1.wv 2>&1 | grep \"created test1.wv\"");
+    assert_script_run("ls Side_Left.wav");
+    assert_script_run("wavpack -d Side_Left.wav 2>&1 | grep -Pzo \"deleted source file Side_Left.wav(.|\\n)*created Side_Left.wv\"");
+
+    # test wavunpack functions
+    assert_script_run("wvunpack Noise.wv -o Noise2.wav 2>&1 | grep  \"restored Noise2.wav\"");
+    assert_script_run("aplay Noise2.wav 2>&1 | grep \"Signed 16 bit Little Endian, Rate 48000 Hz, Mono\"");
+    assert_script_run("wvunpack -v Noise.wv 2>&1 | grep  \"verified Noise.wv\"");
+
+    # test wavgain functions
+    assert_script_run("wvgain -d Noise.wv 2>&1 | grep -Pzo \"replaygain_track_gain = \\+11.06 dB(.|\\n)*replaygain_track_peak = 0.126251\"");
+    assert_script_run("wvgain -s Noise.wv 2>&1 | grep \"no ReplayGain values found\"");
+    assert_script_run("wvgain Noise.wv 2>&1 | grep -Pzo \"replaygain_track_gain = \\+11.06 dB(.|\\n)*replaygain_track_peak = 0.126251(.|\\n)*2 ReplayGain values appended\"");
+    assert_script_run("wvgain -s Noise.wv 2>&1 | grep -Pzo \"replaygain_track_gain = \\+11.06 dB(.|\\n)*replaygain_track_peak = 0.126251\"");
+}
+
+1;


### PR DESCRIPTION
Tests for wavpack, wvunpack and wvgain to test manipulation of wav files using
  wavpack compression file format.

Fix poo#50663 - [qam][blue] Regression test wavpack

Test run:
SLE15: http://10.161.229.180/tests/1626
SLE12SP3: http://10.161.229.180/tests/1625
SLE12SP4: http://10.161.229.180/tests/1564
TW: http://10.161.229.180/tests/1623
LEAP: http://10.161.229.180/tests/1626

Also added test on main_common, but only for supported archs and distro versions.

grep used without "-q" to easy debug in case of failures.

