### PR TITLE
Drop yast2-fonts test from Tumbleweed

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -358,7 +358,7 @@ sub run {
     }
     # only available on openSUSE or at least not SLES
     # drop fonts test for leap 15.0, see poo#29292
-    if (is_tumbleweed || is_leap('<15.0')) {
+    if (is_leap('<15.0')) {
         start_fonts;
     }
 


### PR DESCRIPTION
yast2-fonts has been removed from Tumbleweed as it is no longer maintained.

https://progress.opensuse.org/issues/51110

