### PR TITLE
Rename back registration module

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -845,7 +845,7 @@ sub load_inst_tests {
     }
     if (is_sle) {
         loadtest 'installation/network_configuration' if get_var('NETWORK_CONFIGURATION');
-        loadtest "installation/registration";
+        loadtest "installation/scc_registration";
         if (is_sles4sap and is_sle('<15') and !is_upgrade()) {
             loadtest "installation/sles4sap_product_installation_mode";
         }

--- a/products/caasp/main.pm
+++ b/products/caasp/main.pm
@@ -79,7 +79,7 @@ sub load_caasp_inst_tests {
             loadtest 'caasp/oci_overview';
             loadtest 'caasp/oci_keyboard';
             loadtest 'installation/accept_license';
-            loadtest 'installation/registration';
+            loadtest 'installation/scc_registration';
             loadtest 'installation/system_role';
             loadtest 'installation/caasp_roleconf' unless check_var('SYSTEM_ROLE', 'plain');
             loadtest 'installation/user_settings_root';

--- a/schedule/RAID1.yaml
+++ b/schedule/RAID1.yaml
@@ -9,7 +9,7 @@ schedule:
   - installation/bootloader
   - installation/welcome
   - installation/accept_license
-  - installation/registration
+  - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning

--- a/tests/installation/scc_registration.pm
+++ b/tests/installation/scc_registration.pm
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# Summary: Do the registration against SCC
+# Summary: Do the registration against SCC or skip it
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
 use strict;


### PR DESCRIPTION
In order to avoid that in INC the name for the packages is the same, it is better rename even if it works adding to functions (), but in case of same names of functions perl only will give us the first found, so it is a bad idea to have a  lib and a test using the same name.

- Related ticket: https://progress.opensuse.org/issues/50666
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/929159
