### PR TITLE
Unschedule rrdtool because test is not working on all products

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1300,7 +1300,6 @@ sub load_x11tests {
         loadtest "x11/evolution"      if (!is_server() || we_is_applicable());
         load_testdir('x11/gnomeapps') if is_gnome_next;
     }
-    loadtest "x11/rrdtool_x11";
     loadtest "x11/desktop_mainmenu";
     load_sles4sap_tests() if (is_sles4sap() and !is_sles4sap_standard());
     if (xfcestep_is_applicable()) {


### PR DESCRIPTION
breaks staging: https://openqa.suse.de/tests/2877714#step/rrdtool_x11/36
unscheduling for now and informing maintainer in a progress ticket