### PR TITLE
keymap_or_locale_x11: ensure we have a clean desktop before leaving

### DIFF
--- a/tests/locale/keymap_or_locale_x11.pm
+++ b/tests/locale/keymap_or_locale_x11.pm
@@ -24,6 +24,8 @@ sub run {
     my $keystrokes = $self->get_keystroke_list($expected);
 
     $self->verify_default_keymap_x11($keystrokes, "${expected}_keymap_logged_x11", 'xterm');
+
+    assert_screen("generic-desktop");
 }
 
 sub test_flags {


### PR DESCRIPTION
- Verification run: https://openqa.opensuse.org/tests/929234
It fixes the next test (sshxterm here).