### PR TITLE
Add missing is_s390x from Utils:Architectures

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -23,6 +23,7 @@ use testapi qw(check_var get_var set_var);
 use version 'is_lax';
 use Carp 'croak';
 use Utils::Backends qw(is_hyperv is_hyperv_in_gui is_svirt_except_s390x);
+use Utils::Architectures 'is_s390x';
 
 use constant {
     VERSION => [


### PR DESCRIPTION
- Fail: http://openqa.qam.suse.cz/tests/776
- Verification run: http://openqa.qam.suse.cz/tests/777