### PR TITLE
Fix has_license_on_welcome_screen

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -384,7 +384,7 @@ configuration, otherwise returns false (0).
 
 sub has_license_on_welcome_screen {
     return 1 if is_caasp('caasp');
-    return get_var('HASLICENSE') && ((is_sle('=15') || (is_sle('>=15-SP1') && get_var('BASE_VERSION') && !get_var('UPGRADE')) && is_s390x()) || is_sle('<15'));
+    return get_var('HASLICENSE') && (((is_sle('>=15-SP1') && get_var('BASE_VERSION') && !get_var('UPGRADE')) && is_s390x()) || is_sle('<15'));
 }
 
 sub has_license_to_accept {


### PR DESCRIPTION
Fix condition `has_license_on_welcome_screen`

- Related ticket: https://progress.opensuse.org/issues/50666
- Needles: N/A
- Verification run: 
  - [sle-15-qam-regression-installation-SLED](http://rivera-workstation.suse.cz/tests/2673)
  - [sle-12-SP5-RAID0](http://rivera-workstation.suse.cz/tests/2675)
  - [sle-12-SP1-qam-minimal+base](http://rivera-workstation.suse.cz/tests/2676)
  - [sle-12-SP1-qam-minimal+base](http://rivera-workstation.suse.cz/tests/2678) (on-going)