### PR TITLE
Allow failing for matching regex in autoinst log

### DIFF
--- a/lib/known_bugs.pm
+++ b/lib/known_bugs.pm
@@ -25,6 +25,7 @@ use version_utils;
 
 our @EXPORT = qw(
   create_list_of_serial_failures
+  create_list_of_autoinst_failures
   upload_journal
 );
 
@@ -81,6 +82,20 @@ sub create_list_of_serial_failures {
     push @$serial_failures, {type => 'hard', message => 'CPU soft lockup detected', pattern => quotemeta 'soft lockup - CPU'} unless check_var('ARCH', 'aarch64');
 
     return $serial_failures;
+}
+
+=head2 create_list_of_autoinst_failures
+
+To add a known bug simply copy and adapt the following line:
+C<push @$autoinst_failures, {type => soft/hard, message => 'Errormsg', pattern => quotemeta 'ErrorPattern' };>
+type=soft will force the testmodule result to softfail
+type=hard will just emit a soft fail message but the module will do a normal fail
+
+=cut
+sub create_list_of_autoinst_failures {
+    my $autoinst_failures = [];
+
+    return $autoinst_failures;
 }
 
 =head2 create_list_of_journal_failures

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -73,8 +73,9 @@ set_var('WINTER_IS_THERE', 1) if ($time[4] == 11 || $time[4] == 0);
 
 testapi::set_distribution(DistributionProvider->provide());
 
-# Set serial failures
+# Set failures
 $testapi::distri->set_expected_serial_failures(create_list_of_serial_failures());
+$testapi::distri->set_expected_autoinst_failures(create_list_of_autoinst_failures());
 
 unless (get_var("DESKTOP")) {
     if (check_var("VIDEOMODE", "text")) {

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -615,8 +615,9 @@ sub load_yast2_registration_tests {
 
 testapi::set_distribution(DistributionProvider->provide());
 
-# set serial failures
+# set failures
 $testapi::distri->set_expected_serial_failures(create_list_of_serial_failures());
+$testapi::distri->set_expected_autoinst_failures(create_list_of_autoinst_failures());
 
 return 1 if load_yaml_schedule;
 


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/45011
**Requires (please, merge that first):** https://github.com/os-autoinst/os-autoinst/pull/1149

Verification:
http://artemis.suse.de/tests/1323#step/info/22
http://artemis.suse.de/tests/1318#step/qemu/10