### PR TITLE
Fix switch to console in welcome and addon_dud schedule

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -806,10 +806,10 @@ sub load_inst_tests {
         loadtest "installation/dud_addon";
     }
     loadtest "installation/welcome";
+    loadtest 'installation/accept_license' if has_license_to_accept;
     if (get_var('DUD_ADDONS') && is_sle('<15')) {
         loadtest "installation/dud_addon";
     }
-    loadtest 'installation/accept_license' if has_license_to_accept;
     loadtest 'installation/network_configuration' if get_var('OFFLINE_SUT');
     if (get_var('IBFT')) {
         loadtest "installation/iscsi_configuration";

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -149,10 +149,12 @@ sub run {
         }
         assert_screen('select-product-' . $product);
     }
-
     # Verify install arguments passed by bootloader
     # Linuxrc writes its settings in /etc/install.inf
     if (!is_remote_backend && get_var('VALIDATE_INST_SRC')) {
+        # Ensure to have the focus in some non-selectable control, i.e.: Keyboard Test
+        # before switching to console during installation
+        wait_screen_change { send_key 'alt-y' };
         wait_screen_change { send_key 'ctrl-alt-shift-x' };
         my $method     = uc get_required_var('INSTALL_SOURCE');
         my $mirror_src = get_required_var("MIRROR_$method");


### PR DESCRIPTION
After #7380 we are switching to console in a few scenarios in welcome module during installation before accepting the license and the combination of keys `ctrl-alt-shift-x` does not work when the focus is on a select box: https://openqa.suse.de/tests/2882740#step/welcome/5 producing strange effect that the following commands that are written in the terminal makes a search in the select box (Galician is selected when grep is typed).
Also related with the change in workflow after #7380, we need to schedule `addon_dud` after license acceptance.

- Related ticket: https://progress.opensuse.org/issues/50666
- Needles: N/A
- Verification run: 
  - [sle-12-SP5-MINI-ISO-gnome_http](http://rivera-workstation.suse.cz/tests/2680#step/welcome/6)
  - [sle-12-SP5-dud_sdk](http://rivera-workstation.suse.cz/tests/2682#step/dud_addon/5)
