### PR TITLE
Fix raid1 for other archs

### DIFF
--- a/lib/scheduler.pm
+++ b/lib/scheduler.pm
@@ -47,8 +47,8 @@ sub parse_schedule {
         my $condition = $schedule->{conditional_schedule}->{$module};
         # Iterate over variables in the condition
         foreach my $var (keys %{$condition}) {
-            next unless (my $val = get_var($var, exists($condition->{$var}->{default}) ? 'default' : undef));
-            # If value of the variable matched the conditions or there is a default value represented by ~
+            next unless my $val = get_var($var);
+            # If value of the variable matched the conditions
             # Iterate over the list of the modules to be loaded
             push(@scheduled, $_) for (@{$condition->{$var}->{$val}});
         }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -134,6 +134,11 @@ if (is_sle('15+')) {
     # in the 'minimal' system role we can not execute many test modules
     set_var('INSTALLONLY', get_var('INSTALLONLY', check_var('SYSTEM_ROLE', 'minimal')));
 }
+elsif (is_sle('=12-SP5') && check_var('ARCH', 'x86_64')) {
+    # System Role dialog is displayed only for x86_64 in SLE-12-SP5 due to it has more than one role available,
+    # for the moment we are not handling available roles, so this make the trick for using new scheduling.
+    set_var('SYSTEM_ROLE', 'default');
+}
 diag('default desktop: ' . default_desktop);
 set_var('DESKTOP', get_var('DESKTOP', default_desktop));
 if (is_sle('15+')) {

--- a/schedule/RAID1.yaml
+++ b/schedule/RAID1.yaml
@@ -5,13 +5,18 @@ description:    >
   Installation of RAID1 using expert partitioner.
 vars:
   RAIDLEVEL: 1
+conditional_schedule:
+    system_role:
+        SYSTEM_ROLE:
+            default:
+                - installation/system_role
 schedule:
-  - installation/bootloader
+  - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration
   - installation/addon_products_sle
-  - installation/system_role
+  - {{system_role}}
   - installation/partitioning
   - installation/partitioning_raid
   - installation/partitioning_finish

--- a/tests/installation/bootloader_start.pm
+++ b/tests/installation/bootloader_start.pm
@@ -24,6 +24,7 @@ use bootloader_uefi;
 use bootloader_hyperv;
 use bootloader_svirt;
 use version_utils qw(:SCENARIO :BACKEND);
+use Utils::Architectures;
 use File::Basename;
 BEGIN {
     unshift @INC, dirname(__FILE__) . '/../boot';


### PR DESCRIPTION
Fix raid1 for other archs

- Related ticket: https://progress.opensuse.org/issues/50666
- Needles: N/A
- Verification run:
  - [sle-12-SP5-RAID1@64bit](https://openqa.suse.de/tests/2887601) (backward compatibility)
  - [sle-12-SP5-RAID1@aarch64](https://openqa.suse.de/tests/2887602)
  - [sle-12-SP5-RAID1@ppc64le](https://openqa.suse.de/tests/2887603)
  - [sle-15-SP1-RAID1@64bit](https://openqa.suse.de/tests/2887605) (backward compatibility)
  - [sle-15-SP1-RAID1@aarch64](https://openqa.suse.de/tests/2887606)
  - [sle-15-SP1-RAID1@ppc64le](https://openqa.suse.de/tests/2887607)