### PR TITLE
Add Pacemaker cts cluster exerciser tests

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -253,6 +253,7 @@ sub ha_export_logs {
     my $mdadm_conf    = '/etc/mdadm.conf';
     my $clustername   = get_cluster_name;
     my $report_opt    = !is_sle('12-sp4+') ? '-f0' : '';
+    my $cts_log       = '/tmp/cts_cluster_exerciser.log';
     my @y2logs;
 
     # Extract HA logs and upload them
@@ -280,6 +281,9 @@ sub ha_export_logs {
     # supportconfig
     script_run "supportconfig -g -B $clustername", 180;
     upload_logs("/var/log/nts_$clustername.tgz", failok => 1);
+
+    # pacemaker cts log
+    upload_logs($cts_log, failok => 1) if (get_var('PACEMAKER_CTS_TEST_ROLE'));
 }
 
 sub check_cluster_state {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2554,7 +2554,7 @@ sub load_ha_cluster_tests {
     # Wait for barriers to be initialized except when testing HAWK as a client
     # or Pacemaker CTS regression tests
     loadtest 'ha/wait_barriers' unless (check_var('HAWKGUI_TEST_ROLE', 'client') or
-        (get_var('PACEMAKER_CTS_REG')));
+        (get_var('PACEMAKER_CTS_REG')) or (check_var('PACEMAKER_CTS_TEST_ROLE', 'client')));
 
     # Test HA after an upgrade, so no need to configure the HA stack
     if (get_var('HDDVERSION')) {
@@ -2573,6 +2573,12 @@ sub load_ha_cluster_tests {
     # If HAWKGUI_TEST_ROLE is set to client, only load client side test
     if (check_var('HAWKGUI_TEST_ROLE', 'client')) {
         loadtest 'ha/hawk_gui';
+        return 1;
+    }
+
+    # If PACEMAKER_CTS_TEST_ROLE is set to client, only load client side test
+    if (check_var('PACEMAKER_CTS_TEST_ROLE', 'client')) {
+        loadtest 'ha/pacemaker_cts_cluster_exerciser';
         return 1;
     }
 
@@ -2627,6 +2633,11 @@ sub load_ha_cluster_tests {
     else {
         # Test Hawk Web interface
         loadtest 'ha/check_hawk';
+
+        if (get_var('PACEMAKER_CTS_TEST_ROLE')) {
+            loadtest 'ha/pacemaker_cts_cluster_exerciser';
+            return 1;
+        }
 
         # Test Haproxy
         loadtest 'ha/haproxy' if (get_var('HA_CLUSTER_HAPROXY'));

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -75,6 +75,10 @@ sub run {
         barrier_create("JOIN_NODE_BY_IP_DONE_$cluster_name",        $num_nodes);
         barrier_create("REMOVE_NODE_FINAL_JOIN_$cluster_name",      $num_nodes);
 
+        # PACEMAKER_TEST_ barriers also have to wait in the client
+        barrier_create("PACEMAKER_CTS_INIT_$cluster_name",    $num_nodes + 1);
+        barrier_create("PACEMAKER_CTS_CHECKED_$cluster_name", $num_nodes + 1);
+
         # HAWK_GUI_ barriers also have to wait in the client
         barrier_create("HAWK_GUI_INIT_$cluster_name",    $num_nodes + 1);
         barrier_create("HAWK_GUI_CHECKED_$cluster_name", $num_nodes + 1);

--- a/tests/ha/pacemaker_cts_cluster_exerciser.pm
+++ b/tests/ha/pacemaker_cts_cluster_exerciser.pm
@@ -1,0 +1,109 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Execute the pacemaker-cts cluster exerciser to test a whole
+# cluster.
+# Maintainer: Julien Adamek <jadamek@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use Mojo::JSON 'encode_json';
+use lockapi;
+use testapi;
+use utils qw(systemctl zypper_call exec_and_insert_password);
+use hacluster;
+
+sub add_to_known_hosts {
+    my $hostname = shift;
+    assert_script_run "mkdir -p ~/.ssh";
+    assert_script_run "chmod 700 ~/.ssh";
+    assert_script_run "ssh-keyscan -H $hostname >> ~/.ssh/known_hosts";
+}
+
+sub run {
+    my $cts_bin      = '/usr/share/pacemaker/tests/cts/CTSlab.py';
+    my $log          = '/tmp/cts_cluster_exerciser.log';
+    my $cluster_name = get_cluster_name;
+    my $results_file = '/tmp/cts_cluster_exerciser.results';
+    my $node_01      = choose_node(1);
+    my $node_02      = choose_node(2);
+    my $stonith_type = 'external/sbd';
+    my $stonith_args = 'pcmk_delay_max=30,pcmk_off_action=reboot,action=reboot';
+    my $test_ip      = '10.0.2.20';
+    my $timeout      = 60 * 90;
+
+    # Wait until Pacemaker cts test is initialized
+    barrier_wait("PACEMAKER_CTS_INIT_$cluster_name");
+
+    zypper_call 'in pacemaker-cts';
+    save_screenshot;
+
+    # Pacemaker cts software must be started from the client server
+    if (check_var('PACEMAKER_CTS_TEST_ROLE', 'client')) {
+        assert_script_run 'ssh-keygen -f /root/.ssh/id_rsa -N ""';
+
+        foreach my $node ($node_01, $node_02) {
+            add_to_known_hosts($node);
+            exec_and_insert_password("ssh-copy-id -f root\@$node");
+        }
+
+        # Don't do stonith test since this one reboots a node randomly
+        # and it's very difficult to handle in MM scenario.
+        assert_script_run "sed -i '/AllTestClasses.append(StonithdTest)/ s/^/#/' \$(rpm -ql pacemaker-cts|grep CTStests.py)";
+
+        # Start pacemaker cts cluster exerciser
+        my $cts_start_time = time;
+        assert_script_run "$cts_bin --nodes '$node_01 $node_02' --stonith-type $stonith_type --stonith-args $stonith_args --test-ip-base $test_ip --no-loop-tests --no-unsafe-tests --at-boot 1 --outputfile $log --once", $timeout;
+        my $cts_end_time = time;
+
+        # Parse the logs to get a better overview in openQA
+        my $output = script_output "awk '(\$5 == \"Test\" && \$6 != \"Summary\") {print}' $log";
+
+        my %results;
+
+        $results{tests}   = [];
+        $results{info}    = {};
+        $results{summary} = {};
+
+        $results{info}->{timestamp}    = time;
+        $results{info}->{distro}       = "";
+        $results{info}->{results_file} = "";
+        $results{summary}->{num_tests} = 0;
+        $results{summary}->{passed}    = 0;
+        $results{summary}->{duration}  = $cts_end_time - $cts_start_time;
+
+        foreach my $line (split("\n", $output)) {
+            my %aux = ();
+            next unless ($line =~ /Test ([^:]+)/);
+            $results{summary}->{num_tests}++;
+            $aux{name} = lc($1);
+            $line =~ /'failure': ([0-9]+)/;
+            my $failure = $1;
+            $line =~ /'auditfail': ([0-9]+)/;
+            my $auditfail = $1;
+            $aux{outcome}    = ($failure == 0 and $auditfail == 0) ? 'passed' : 'failed';
+            $aux{test_index} = 0;
+            push @{$results{tests}}, \%aux;
+            $results{summary}->{passed}++ if ($aux{outcome} eq 'passed');
+        }
+
+        my $json = encode_json \%results;
+        assert_script_run "echo '$json' > $results_file";
+
+        # Upload pacemaker cts log
+        parse_extra_log(IPA => $results_file);
+        upload_logs $log;
+    }
+
+    # Synchronize all the nodes
+    barrier_wait("PACEMAKER_CTS_CHECKED_$cluster_name");
+}
+
+1;


### PR DESCRIPTION
Add a test to execute pacemaker CTS cluster exerciser in openQA.

- Related ticket: N/A
- Needles: N/A
- Verification run: [Node1](http://1a102.qa.suse.de/tests/643), [Node2](http://1a102.qa.suse.de/tests/642) and [Pacemaker client](http://1a102.qa.suse.de/tests/644)
