### PR TITLE
Increase TO for yast2 clone_system execution

### DIFF
--- a/tests/console/yast2_clone_system.pm
+++ b/tests/console/yast2_clone_system.pm
@@ -27,15 +27,7 @@ sub run {
     zypper_call "in autoyast2";
 
     my $module_name = y2logsstep::yast2_console_exec(yast2_module => 'clone_system');
-
-    # workaround for bsc#1013605
-    my $timeout = 600;
-    assert_screen([qw(dhcp-popup yast2_console-finished)], $timeout);
-    if (match_has_tag('dhcp-popup')) {
-        wait_screen_change { send_key 'alt-o' };
-        assert_screen 'yast2_console-finished', $timeout;
-    }
-    wait_serial("$module_name-0") || die "'yast2 clone_system' didn't finish";
+    wait_serial("$module_name-0", 150) || die "'yast2 clone_system' didn't finish";
 
     $self->select_serial_terminal;
     # Replace unitialized email variable - bsc#1015158


### PR DESCRIPTION
* Increased TO for yast2 clone_system
* removed workaround for [ [Build 20161203] openQA test fails: Hostname Error Pop-Up During Installation](https://bugzilla.suse.com/show_bug.cgi?id=1013605)

- Related ticket: [[sle][functional][y][timebox:4h] test fails in yast2_clone_system 'yast2 clone_system' didn't finish](https://progress.opensuse.org/issues/51308)
- Verification runs: 
   * [sle-15-SP1-Installer-DVD-aarch64-Build225.1-clone_system@aarch64
](http://eris.suse.cz/tests/13788)
   * [sle-12-SP5-Server-DVD-aarch64-Build0158-clone_system@aarch64](http://eris.suse.cz/tests/13790#)
