### PR TITLE
Add ability to softfail for known LTP issues

### DIFF
--- a/lib/LTP/WhiteList.pm
+++ b/lib/LTP/WhiteList.pm
@@ -1,0 +1,76 @@
+# Copyright © 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Override known failures for QAM
+# Maintainer: Jan Baier <jbaier@suse.cz>
+
+package LTP::WhiteList;
+
+use base Exporter;
+use strict;
+use warnings;
+use testapi;
+use bmwqemu;
+use Exporter;
+use Mojo::UserAgent;
+use Mojo::JSON;
+use Mojo::File 'path';
+
+our @EXPORT = qw(download_whitelist override_known_failures);
+
+sub download_whitelist {
+    my $path = get_required_var('LTP_KNOWN_ISSUES');
+    my $res  = Mojo::UserAgent->new->get($path)->result;
+    unless ($res->is_success) {
+        record_info("File not downloaded!", $res->message, result => 'softfail');
+        set_var('LTP_KNOWN_ISSUES', undef);
+    }
+    my $basename = $path =~ s#.*/([^/]+)#$1#r;
+    save_tmp_file($basename, $res->body);
+    set_var('LTP_KNOWN_ISSUES', hashed_string($basename));
+    mkdir('ulogs') if (!-d 'ulogs');
+    bmwqemu::save_json_file($res->json, "ulogs/$basename");
+}
+
+sub override_known_failures {
+    my ($self, $env, $suite, $test) = @_;
+
+    my $content = path(get_required_var('LTP_KNOWN_ISSUES'))->slurp;
+    my $issues  = Mojo::JSON::decode_json($content);
+    return unless $issues;
+    return unless exists $issues->{$suite};
+
+    my @issues;
+    if (ref($issues->{$suite}) eq 'ARRAY') {
+        @issues = @{$issues->{$suite}};
+    }
+    else {
+        return unless exists $issues->{$suite}->{$test};
+        @issues = @{$issues->{$suite}->{$test}};
+    }
+
+  ISSUE:
+    foreach my $cond (@issues) {
+        foreach my $filter (qw(product ltp_version revision arch kernel)) {
+            next ISSUE if exists $cond->{$filter} and $env->{$filter} !~ m/$cond->{$filter}/;
+        }
+
+        bmwqemu::diag("Failure in LTP:$suite:$test is known, overriding to softfail");
+        $self->{result} = 'softfail';
+        last;
+    }
+}
+
+1;

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -16,6 +16,7 @@ use base 'opensusebasetest';
 use testapi;
 use bootloader_setup 'boot_grub_item';
 use Utils::Backends 'use_ssh_serial_console';
+use LTP::WhiteList 'download_whitelist';
 
 sub run {
     my ($self, $tinfo) = @_;
@@ -39,6 +40,8 @@ sub run {
     else {
         $self->select_serial_terminal;
     }
+
+    download_whitelist if get_var('LTP_KNOWN_ISSUES');
 
     assert_script_run('export LTPROOT=/opt/ltp; export LTP_COLORIZE_OUTPUT=n TMPDIR=/tmp PATH=$LTPROOT/testcases/bin:$PATH');
 

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -20,6 +20,7 @@ use Time::HiRes qw(clock_gettime CLOCK_MONOTONIC);
 use serial_terminal;
 use Mojo::File 'path';
 use Mojo::JSON;
+use LTP::WhiteList 'override_known_failures';
 require bmwqemu;
 
 sub start_result {
@@ -307,6 +308,8 @@ sub run {
     }
     my $test_log = wait_serial(qr/$fin_msg\d+/, $timeout, 0, record_output => 1);
     my ($timed_out, $result_export) = $self->record_ltp_result($cmd_file, $test, $test_log, $fin_msg, thetime() - $start_time, $is_posix);
+
+    override_known_failures($self, $test_result_export->{environment}, $cmd_file, $test->{name}) if get_var('LTP_KNOWN_ISSUES') and $self->{result} eq 'fail';
 
     push(@{$test_result_export->{results}}, $result_export);
     if ($timed_out) {


### PR DESCRIPTION
Variable ``LTP_KNOWN_ISSUES`` can be contain an url to a JSON whitelist file. In case of a failure in specified test case and conditions, the fail will be overridden to a softfail.

- Related ticket: https://progress.opensuse.org/issues/40472
- Verification runs:
  - http://panigale.suse.cz/tests/2071 (variable not set)
  - http://panigale.suse.cz/tests/2136 (explicitly whitelisted tests)
```JSON
   "net.ipv6" : {
      "dhcpd6" : [
         {
            "product" : "sle:15"
         }
      ],
      "dnsmasq6" : [
         {
            "product" : "sle:15"
         }
      ]
   }
```
  - http://panigale.suse.cz/tests/2140 (whole testsuite whitelisted)
```JSON
   "net_stress.ipsec_udp" : [
      {
         "product" : "sle:15"
      }
   ]
````