### PR TITLE
publiccloud: Do not die in ipa tests on failure

### DIFF
--- a/tests/publiccloud/ipa.pm
+++ b/tests/publiccloud/ipa.pm
@@ -114,7 +114,6 @@ sub run {
             $instance->upload_log('/var/log/cloudregister');
             last;
         }
-        die;
     }
 }
 


### PR DESCRIPTION
Don't die(), if some ipa tests fail. The overall result will be
calculated from the extra_results.
This will avoid missing tag notifications from JDP and differ between
ipa environment failures to test failures.

- Related ticket: https://progress.opensuse.org/issues/51101
- Verification run: http://cfconrad-vm.qa.suse.de/tests/4266
