### PR TITLE
Virtualization: add code to avoid blue screen issue on ipmi tests

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -131,6 +131,12 @@ sub run {
 
     specific_bootmenu_params;
 
+    # try to avoid blue screen issue on osd ipmi tests
+    # local test passes, if validated on osd, will switch on to all ipmi tests
+    if (check_var('BACKEND', 'ipmi') && check_var('VIDEOMODE', 'text') && check_var('VIRT_AUTOTEST', 1)) {
+        type_string_slow(" vt.color=0x07 ");
+    }
+
     send_key 'ret';
     save_screenshot;
 


### PR DESCRIPTION
This is to workaround one ipmi unstability issue that blue screen happens to screen and makes needle match not work. 
We suspect that blue screen issue is due to os probing color wrongly and makes the wrong display. We tried to run it locally in bj for hundreds of times and did not reproduce this issue. So try to put to osd to see whether it can eliminate happening of such issue.

- Verification run: http://10.67.18.220/tests/1627#step/boot_from_pxe/5
