### PR TITLE
Fix remove node function

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2664,7 +2664,7 @@ sub load_ha_cluster_tests {
     loadtest 'ha/check_after_reboot';
 
     # Remove a node both by its hostname and ip address
-    loadtest 'ha/remove_node';
+    loadtest 'ha/remove_node' if is_sle('>12-SP2');
 
     # Check logs to find error and upload all needed logs if we are not
     # in installation/publishing mode


### PR DESCRIPTION
This test must not be executed before 12SP3 due to a difference between crmsh major version.

- Related ticket: N/A
- Needles: N/A
- Verification run: [Node 01](http://1a102.qa.suse.de/tests/650)
