### PR TITLE
correction to rrdtool_x11: "eog" command not found

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1481,6 +1481,7 @@ sub load_extra_tests_desktop {
     # test, checking the wifi applet, would make sense in other DEs as
     # well
     if (check_var('DESKTOP', 'gnome')) {
+        loadtest "x11/rrdtool_x11";
         loadtest 'x11/yast2_lan_restart';
         loadtest 'x11/yast2_lan_restart_devices' if (!is_opensuse || is_leap('<=15.0'));
         # we only have the test dependencies, e.g. hostapd available in

--- a/tests/x11/rrdtool_x11.pm
+++ b/tests/x11/rrdtool_x11.pm
@@ -46,7 +46,7 @@ sub run {
     # create a tmp dir/files to work
     assert_script_run "mkdir /tmp/rrdtool; cd /tmp/rrdtool";
     # install requirements
-    zypper_call "in rrdtool";
+    zypper_call "in rrdtool eog";
     # create a rrd file
     assert_script_run "rrdtool create test.rrd --start 920804400  DS:speed:COUNTER:600:U:U RRA:AVERAGE:0.5:1:24 RRA:AVERAGE:0.5:6:10";
     # update the rrd file


### PR DESCRIPTION
correction to  rrdtool_x11: "eog" command not found

Related ticket: https://progress.opensuse.org/issues/51341#change-211103
Verification run:
SLES 15 SP1 - http://10.161.229.197/tests/614
SLES 15 - http://10.161.229.197/tests/613
SLEs 12 Sp4 - http://10.161.229.197/tests/597

Needles to SLES 15 SP1:
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1139