### PR TITLE
Apply declarative scheduling to ext4 testsuite

### DIFF
--- a/schedule/ext4.yaml
+++ b/schedule/ext4.yaml
@@ -1,0 +1,43 @@
+---
+name:           ext4
+description:    >
+  Test for ext4 filesystem.
+vars:
+  FILESYSTEM: ext4
+  FORMAT_DASD: install
+conditional_schedule:
+    disk_activation:
+        BACKEND:
+            s390x:
+                - installation/disk_activation
+    system_role:
+        SYSTEM_ROLE:
+            default:
+                - installation/system_role
+    reconnect_mgmt_console:
+        ARCH:
+            s390x:
+                - boot/reconnect_mgmt_console
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - {{disk_activation}}
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - {{system_role}}
+  - installation/partitioning
+  - installation/partitioning_filesystem
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - {{reconnect_mgmt_console}}
+  - installation/first_boot

--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -289,7 +289,7 @@ sub run {
         for (1 .. $max_retries) {
             eval {
                 # connect to zVM, login to the guest
-                $self->get_to_yast();
+                get_to_yast();
             };
             last unless ($@);
             diag "It looks like CTC network connection is unstable. Retry: $_ of $max_retries";
@@ -298,7 +298,7 @@ sub run {
     else {
         eval {
             # connect to zVM, login to the guest
-            $self->get_to_yast();
+            get_to_yast();
         };
     }
 

--- a/tests/installation/bootloader_start.pm
+++ b/tests/installation/bootloader_start.pm
@@ -23,6 +23,8 @@ use bootloader;
 use bootloader_uefi;
 use bootloader_hyperv;
 use bootloader_svirt;
+use bootloader_zkvm;
+use bootloader_s390;
 use version_utils qw(:SCENARIO :BACKEND);
 use Utils::Architectures;
 use File::Basename;
@@ -32,38 +34,39 @@ BEGIN {
 use boot_from_pxe;
 
 sub run {
+    my $self = shift;
     if (uses_qa_net_hardware() || get_var("PXEBOOT")) {
-        boot_from_pxe::run;
+        $self->boot_from_pxe::run;
         return;
     }
     if (is_s390x()) {
         if (check_var("BACKEND", "s390x")) {
-            bootloader_s390::run();
+            $self->bootloader_s390::run();
             return;
         }
         else {
-            bootloader_zkvm::run();
+            $self->bootloader_zkvm::run();
             return;
         }
     }
     if (check_var('BACKEND', 'svirt') && is_x86_64()) {
         set_bridged_networking();
         if (is_hyperv()) {
-            bootloader_hyperv::run();
+            $self->bootloader_hyperv::run();
         }
         else {
-            bootloader_svirt::run();
+            $self->bootloader_svirt::run();
         }
     }
     # Load regular bootloader for all qemu backends and for x84_86 systems,
     # except Xen PV as id does not have VNC (bsc#961638).
     if (check_var('BACKEND', 'qemu') || (check_var('BACKEND', 'svirt') && !(check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux')))) {
         if (get_var('UEFI')) {
-            bootloader_uefi::run();
+            $self->bootloader_uefi::run();
             return;
         }
         else {
-            bootloader::run();
+            $self->bootloader::run();
             return;
         }
     }


### PR DESCRIPTION
Apply delarative scheduling to ext4

- Related ticket: https://progress.opensuse.org/issues/50666
- Needles: N/A
- Verification run:
  - [sle-12-SP5-ext4@uefi-staging](https://openqa.suse.de/t2887859)
  - [sle-15-SP1-ext4@uefi-staging](https://openqa.suse.de/t2887849)
  - [sle-12-SP5-ext4@aarch64](https://openqa.suse.de/t2887870)
  - [sle-12-SP5-ext4@s390x-kvm-sle12](https://openqa.suse.de/t2888850)
  - [sle-12-SP5-ext4@64bit](https://openqa.suse.de/t2887872)
  - [sle-15-SP1-ext4@aarch64](https://openqa.suse.de/t2887873)
  - [sle-15-SP1-ext4@ppc64le](https://openqa.suse.de/t2887874)
  - [sle-15-SP1-ext4@s390x-kvm-sle12](https://openqa.suse.de/t2888851)
  - [sle-15-SP1-ext4@s390x-zVM-vswitch-l3](https://openqa.suse.de/t2889305) (running)
  - [sle-15-SP1-ext4@64bit](https://openqa.suse.de/t2887898)
  - [sle-15-SP1-ext4@uefi](https://openqa.suse.de/t2887899)
