### PR TITLE
Upload vconsole.conf when consoletest_setup fails

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -343,8 +343,9 @@ sub export_logs {
 
 sub export_logs_locale {
     my ($self) = shift;
-    $self->save_and_upload_log('locale',           '/tmp/locale.log');
-    $self->save_and_upload_log('localectl status', '/tmp/localectl.log');
+    $self->save_and_upload_log('locale',                 '/tmp/locale.log');
+    $self->save_and_upload_log('localectl status',       '/tmp/localectl.log');
+    $self->save_and_upload_log('cat /etc/vconsole.conf', '/tmp/vconsole.conf');
 }
 
 sub upload_packagekit_logs {


### PR DESCRIPTION
- Related tickets:
  - https://bugzilla.suse.com/show_bug.cgi?id=1133607
  - https://bugzilla.suse.com/show_bug.cgi?id=1131974
- Verification run:
  - passed: http://slindomansilla-vm.qa.suse.de/tests/1400
  - failed: http://slindomansilla-vm.qa.suse.de/tests/1401/file/consoletest_setup-vconsole.conf