### PR TITLE
Show memory usage of virsh host and domains

### DIFF
--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -68,6 +68,9 @@ sub set_svirt_domain_elements {
 sub run {
     my $svirt = select_console('svirt', await_console => 0);
 
+    record_info('free -h',              $svirt->get_cmd_output('free -h'));
+    record_info('virsh freecell --all', $svirt->get_cmd_output('virsh freecell --all'));
+    record_info('virsh domstats',       $svirt->get_cmd_output('virsh domstats'));
     set_svirt_domain_elements $svirt;
     zkvm_add_disk $svirt;
     zkvm_add_pty $svirt;


### PR DESCRIPTION
This should help us to prevent the memory leak problem of libvirtd.

- Related ticket: https://progress.opensuse.org/issues/45326
- <s>Verification run: http://slindomansilla-vm.qa.suse.de/tests/1420/file/autoinst-log.txt</s> See https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7456#issuecomment-493050327