### PR TITLE
Fix missing lines in output of /dev/sshserial

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -425,7 +425,7 @@ sub init_consoles {
                 hostname => get_required_var('SUT_IP'),
                 password => $testapi::password,
                 user     => 'root',
-                serial   => 'mkfifo /dev/sshserial; tail -f /dev/sshserial',
+                serial   => 'mkfifo /dev/sshserial; tail -fn +1 /dev/sshserial',
                 gui      => 1
             });
     }


### PR DESCRIPTION
Fix poo#51365: Script output misses first lines of systemctl status
command on backends with named pipe /dev/sshserial. Tail command to
adjusted to read all line from beginning.

- Related ticket: https://progress.opensuse.org/issues/51365
- Needles: none
- Verification run: 
systemctl status kdump on spvm backend: http://10.100.12.105/tests/1990#step/kdump_and_crash/5
generic spvm installation job: https://openqa.suse.de/tests/2888929#