### PR TITLE
update libreoffice_mainmenu_components for poo#51425

### DIFF
--- a/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
@@ -1,6 +1,6 @@
 # LibreOffice tests
 #
-# Copyright © 2016-2017 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -37,6 +37,12 @@ sub open_overview {
 
 sub select_base_and_cleanup {
     assert_screen 'oobase-select-database', 45;
+    if (check_screen 'oobase-database-empty') {
+        # this is for libreoffice 6.2.x
+        send_key "tab";
+        send_key "tab";
+        send_key "up";
+    }
     send_key "ret";
     assert_screen 'oobase-save-database';
     send_key "ret";


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/51425
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/1140
- Verification run: http://147.2.212.251/tests/117#step/libreoffice_mainmenu_components/5

Libreoffice version updated to 6.2.x, the test step for libreoffice-base needs to adjust -- by `TAB TAB UP` to get to previous version default.
