### PR TITLE
Apply declarative schedule:minimal+base & autoyast_mini_staging

### DIFF
--- a/schedule/autoyast_mini_staging.yaml
+++ b/schedule/autoyast_mini_staging.yaml
@@ -1,0 +1,17 @@
+name:           autoyast_mini_staging
+description:    >
+    Test verifies installation with minimal autoyast profile.
+    Same as autoyast_mini but with product defined using url and not as registered modules
+schedule:
+    - autoyast/prepare_profile
+    - installation/bootloader
+    - autoyast/installation
+    - autoyast/console
+    - autoyast/login
+    - autoyast/wicked
+    - autoyast/repos
+    - autoyast/clone
+    - autoyast/logs
+    - autoyast/autoyast_reboot
+    - installation/grub_test
+    - installation/first_boot

--- a/schedule/minimal+base.yaml
+++ b/schedule/minimal+base.yaml
@@ -1,0 +1,88 @@
+---
+name:           minimal+base
+description:    >
+  Select a minimal textmode installation by starting with the default and unselecting all patterns
+  except for "base" and "minimal". Not to be confused with the new system role "minimal" introduced with SLE15.
+vars:
+  PATTERNS: base,minimal
+conditional_schedule:
+    disk_activation:
+        BACKEND:
+            s390x:
+                - installation/disk_activation
+    system_role:
+        SYSTEM_ROLE:
+            default:
+                - installation/system_role
+    after_reboot:
+        ARCH:
+            s390x:
+                - boot/reconnect_mgmt_console
+            x86_64:
+                - installation/grub_test
+            aarch64:
+                - installation/grub_test
+            ppc64le:
+                - installation/grub_test
+    default_tests_installed_system:
+        MACHINE:
+            64bit-staging:
+                - console/system_prepare
+                - console/check_network
+                - console/system_state
+                - console/prepare_test_data
+                - console/consoletest_setup
+                - locale/keymap_or_locale
+                - console/force_scheduled_tasks
+                - console/textinfo
+                - console/hostname
+                - console/installation_snapshots
+                - console/zypper_lr
+                - console/zypper_ref
+                - console/ncurses
+                - console/yast2_lan
+                - console/curl_https
+                - console/glibc_sanity
+                - console/zypper_in
+                - console/yast2_i
+                - console/yast2_bootloader
+                - console/vim
+                - console/sshd
+                - console/ssh_cleanup
+                - console/mtab
+                - console/mysql_srv
+                - console/yast2_nfs_server
+                - console/rsync
+                - console/http_srv
+                - console/dns_srv
+                - console/postgresql_server
+                - console/shibboleth
+                - console/apache_ssl
+                - console/apache_nss
+                - console/orphaned_packages_check
+                - console/consoletest_finish
+
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - {{disk_activation}}
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - {{system_role}}
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/installation_overview_before
+  - installation/select_patterns_and_packages
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - {{after_reboot}}
+  - installation/first_boot
+  - {{default_tests_installed_system}}


### PR DESCRIPTION
Apply declarative schedule to minimal+base test suite in Staging and YaST openQA groups.
In both staging it is used exactly the same set of tests that corresponds with tests that are running after default test suite, so we can remove this redundancy from minimal+base executed in YaST groups (also there are some differences among architectures) and still keeps those tests for staging in case are needed in this test suite (perhaps because it only installs two patterns and is lighter).
Instead of using two test suite, one for staging and another one for YaST group we can trust 'for the moment' in setting `MACHINE=64bit-staging` due to it is present in both staging for sle12sp5 and sle15sp1 and we still don't have a clear path how to tackle regex in yaml (or even decided if we should) which could potentially use `STAGING` setting which has values 1 or different letters.

- Related ticket: https://progress.opensuse.org/issues/50666
- Needles: N/A
- Verification run:
  - [sle-12-SP5-minimal+base@64bit-staging](https://openqa.suse.de/t2900979)
  - [sle-15-SP1-minimal+base@64bit-staging](https://openqa.suse.de/t2900977)
  - [sle-15-SP1-minimal+base@64bit](https://openqa.suse.de/t2900978)
  - [sle-15-SP1-minimal+base@s390x-zVM-vswitch-l3](https://openqa.suse.de/t2900979)
  - [sle-15-SP1-autoyast_mini_staging@64bit-staging](https://openqa.suse.de/t2900635)
#### Note:
Requires in OSD:
  - Set `YAML_SCHEDULE=schedule/minimal+base.yaml` in existing test suite `minimal+base`
  - Set `YAML_SCHEDULE=schedule/autoyast_mini_staging.yaml ` in existing test suite `autoyast_mini_staging.yaml `