### PR TITLE
Fix fails in apache2_changehat & selinux_smoke

### DIFF
--- a/data/apparmor/usr.sbin.httpd-prefork-sle12
+++ b/data/apparmor/usr.sbin.httpd-prefork-sle12
@@ -1,4 +1,4 @@
-# Last Modified: Thu Mar 21 15:39:34 2019
+# Last Modified: Wed Jul 25 15:59:14 2018
 #include <tunables/global>
 
 /usr/sbin/httpd-prefork {
@@ -7,13 +7,10 @@
   #include <abstractions/php5>
 
   capability kill,
-  capability net_admin,
-  capability net_admin,
   capability setgid,
   capability setuid,
-
-  signal send set=term peer=/usr/sbin/httpd-prefork//HANDLING_UNTRUSTED_INPUT,
-  signal send set=usr1 peer=/usr/sbin/httpd-prefork//HANDLING_UNTRUSTED_INPUT,
+  capability net_admin,
+  capability net_admin,
 
   /etc/apache2/** r,
   /etc/mime.types r,
@@ -36,29 +33,16 @@
   /usr/lib{,32,64}/apache2*/** mr,
   /var/log/apache2/** rw,
 
-
   ^DEFAULT_URI {
     #include <abstractions/apache2-common>
-    #include <abstractions/base>
-    #include <abstractions/php5>
-    #include <abstractions/ubuntu-browsers.d/user-files>
-    #include <abstractions/user-tmp>
-
-    network unix stream,
 
     /var/log/apache2/** rw,
-
   }
 
   ^HANDLING_UNTRUSTED_INPUT {
     #include <abstractions/apache2-common>
-    #include <abstractions/base>
-
-    signal receive set=term peer=/usr/sbin/httpd-prefork,
-    signal receive set=usr1 peer=/usr/sbin/httpd-prefork,
 
     /var/log/apache2/** w,
-
   }
 
   ^adminer {
@@ -68,9 +52,8 @@
     /proc/meminfo r,
     /srv/www/htdocs/adminer/** r,
     /tmp/adminer.invalid rwk,
-    /var/lib/php7/** rwk,
+    /var/lib/php7/** krw,
     /var/log/apache2/access_log w,
     /var/log/apache2/error_log w,
-
   }
 }

--- a/tests/security/selinux/selinux_smoke.pm
+++ b/tests/security/selinux/selinux_smoke.pm
@@ -47,7 +47,14 @@ sub run {
     # for sle, register available extensions and modules, e.g., free addons
     if (is_sle) {
         register_product();
-        add_suseconnect_product("sle-module-web-scripting");
+        my $version = get_required_var('VERSION') =~ s/([0-9]+).*/$1/r;
+        if ($version == '15') {
+            $version = get_required_var('VERSION') =~ s/([0-9]+)-SP([0-9]+)/$1.$2/r;
+        }
+        my $arch    = get_required_var('ARCH');
+        my $params  = " ";
+        my $timeout = 180;
+        add_suseconnect_product("sle-module-web-scripting", "$version", "$arch", "$params", "$timeout");
     }
 
     # install & remove patterns, e.g., mail_server


### PR DESCRIPTION
Fix fails in apache2_changehat & selinux_smoke.
poo#49913 [qam] [sle][security][sle15sp1] test fails in apache2_changehat
poo#52013 [qam] [sle][security][sle12sp4 maintenance] selinux:selinux_smoke test fails on add_suseconnect_product()

Tested on 3 products, and introduce no issue, the failed case is a known issue.

- Related ticket: 
    https://progress.opensuse.org/issues/49913
- Needles: 
    https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/555
    https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1144
- Verification run: 
    http://10.67.19.89/tests/1027    (test cases: selinux)
    http://10.67.19.89/tests/1026    (sle15-sp1-b225.1)
    http://10.67.19.89/tests/1036    (Tumbleweed-b20190520)
    http://10.67.19.89/tests/1019    (sle12-sp4-20190509-1)
