### PR TITLE
Enable Desktop Applications Module for wavepack tests

### DIFF
--- a/tests/console/wavpack.pm
+++ b/tests/console/wavpack.pm
@@ -11,14 +11,17 @@
 # Maintainer: Ednilson Miura <emiura@suse.com>
 
 use base "consoletest";
-use testapi;
 use strict;
 use warnings;
+use testapi;
 use utils;
+use version_utils 'is_sle';
+use registration 'add_suseconnect_product';
 
 sub run {
     # setup
     select_console 'root-console';
+    add_suseconnect_product('sle-module-desktop-applications') if is_sle("15-sp1+");
     zypper_call 'in alsa alsa-utils wavpack';
     assert_script_run("cp /usr/share/sounds/alsa/Noise.wav .");
     assert_script_run("cp /usr/share/sounds/alsa/test.wav .");


### PR DESCRIPTION
The wavepack tests were introduced by 196819810c, that at the time was passing for sle15-sp1, however the package got moved to a different product. 

Progress ticket: https://progress.opensuse.org/issues/51482