### PR TITLE
Fix declarative schedule ext4

### DIFF
--- a/schedule/ext4.yaml
+++ b/schedule/ext4.yaml
@@ -14,10 +14,16 @@ conditional_schedule:
         SYSTEM_ROLE:
             default:
                 - installation/system_role
-    reconnect_mgmt_console:
+    after_reboot:
         ARCH:
             s390x:
                 - boot/reconnect_mgmt_console
+            x86_64:
+                - installation/grub_test
+            aarch64:
+                - installation/grub_test
+            ppc64le:
+                - installation/grub_test
 schedule:
   - installation/bootloader_start
   - installation/welcome
@@ -38,6 +44,5 @@ schedule:
   - installation/await_install
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
-  - installation/grub_test
-  - {{reconnect_mgmt_console}}
+  - {{after_reboot}}
   - installation/first_boot


### PR DESCRIPTION
Fix declarative schedule ext4. Example of failure: https://openqa.suse.de/tests/2888850#step/grub_test/1

- Related ticket: https://progress.opensuse.org/issues/50666
- Needles: N/A
- Verification run:
  - [sle-12-SP5-ext4@uefi-staging](https://openqa.suse.de/t2899732)
  - [sle-12-SP5-ext4@s390x-kvm-sle12](https://openqa.suse.de/t2899730)
  - [sle-15-SP1-ext4@s390x-kvm-sle12](https://openqa.suse.de/t2899731)
  - [sle-15-SP1-ext4@s390x-zVM-vswitch-l3](https://openqa.suse.de/t2899733)