### PR TITLE
Remove condition to fail bootloader module load

### DIFF
--- a/tests/installation/bootloader_start.pm
+++ b/tests/installation/bootloader_start.pm
@@ -36,7 +36,7 @@ use boot_from_pxe;
 sub run {
     my $self = shift;
     if (uses_qa_net_hardware() || get_var("PXEBOOT")) {
-        $self->boot_from_pxe::run;
+        $self->boot_from_pxe::run();
         return;
     }
     if (is_s390x()) {
@@ -69,9 +69,6 @@ sub run {
             $self->bootloader::run();
             return;
         }
-    }
-    else {
-        die 'No bootloader found for the current job settings.';
     }
 }
 


### PR DESCRIPTION
The condition does not make sense as decision on loading the module
should be made on scheduling level.

- Verification Run: http://oorlov-vm.qa.suse.de/tests/903
- Related ticket: https://progress.opensuse.org/issues/50666
