### PR TITLE
poo#51488: Fix thunderbird test

### DIFF
--- a/lib/thunderbird_common.pm
+++ b/lib/thunderbird_common.pm
@@ -155,8 +155,10 @@ sub tb_check_email {
     assert_screen "thunderbird_sent-message-received";
 
     # delete the message
-    assert_and_click("thunderbird_single-message-context-menu", "right");
-    assert_and_click "thunderbird_single-message-context-menu-delete";
+    assert_and_click "thunderbird_select-message";
+    wait_still_screen 1;
+    wait_screen_change { send_key "delete" };
+    wait_still_screen 1;
     send_key "ctrl-shift-k";
     wait_screen_change { send_key "delete" };
 }


### PR DESCRIPTION
Removing this no longer needed needle solves the issue reported on poo#51488

- Related ticket: https://progress.opensuse.org/issues/51488
- Removed needles:
  - openSUSE: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/557
  - SLE: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1145
- Verification runs:
  - http://d250.qam.suse.de/tests/1949
  - http://d250.qam.suse.de/tests/1951
