### PR TITLE
Don't try ProxyJump on older Leap

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -18,7 +18,7 @@ use base "consoletest";
 use strict;
 use testapi qw(is_serial_terminal :DEFAULT);
 use utils qw(systemctl exec_and_insert_password zypper_call);
-use version_utils qw(is_virtualization_server is_upgrade is_sle is_opensuse);
+use version_utils qw(is_virtualization_server is_upgrade is_sle is_tumbleweed is_leap);
 
 sub run {
     my $self = shift;
@@ -107,8 +107,8 @@ sub run {
 
     assert_script_run "ssh -p 4242 -tt $ssh_testman\@localhost ssh -tt $ssh_testman\@localhost whoami";
     assert_script_run "ssh -t -o ProxyCommand='ssh $ssh_testman\@localhost nc localhost 4242' $ssh_testman\@localhost whoami";
-    if (is_opensuse || is_sle('15+')) {
-        assert_script_run "ssh -J $ssh_testman\@localhost:4242 $ssh_testman\@localhost whoami";
+    if (is_leap('15+') || is_tumbleweed || is_sle('15+')) {
+        assert_script_run("ssh -J $ssh_testman\@localhost:4242 $ssh_testman\@localhost whoami");
     }
 
     # SCP (poo#46937)


### PR DESCRIPTION
Option '-J' isn't supported on Leap 42.x openssh version
