### PR TITLE
Fix for libvorbis on sle15sp1

### DIFF
--- a/tests/console/libvorbis.pm
+++ b/tests/console/libvorbis.pm
@@ -15,11 +15,14 @@ use testapi;
 use strict;
 use warnings;
 use utils;
+use version_utils 'is_sle';
+use registration 'add_suseconnect_product';
 
 sub run {
     # setup
     my ($self) = @_;
     $self->select_serial_terminal;
+    add_suseconnect_product('sle-module-desktop-applications') if is_sle("15-sp1+");
     zypper_call 'in vorbis-tools libvorbis0';
     # download ogg sample
     assert_script_run 'curl -v -o sample.ogg ' . data_url('libvorbis/glass.ogg');


### PR DESCRIPTION
Added a test condition on SLE15SP1 to add desktop package repository.

Fixes po0#51497 - [qam] test fails in libvorbis - test fails on xen backend

Test run:
Verification Run: https://openqa.suse.de/t2916112