### PR TITLE
Post_fail_hook should switch to log-console to avoid kernel error message

### DIFF
--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -51,7 +51,7 @@ sub run {
 
 sub post_fail_hook {
     my $self = shift;
-
+    select_console('log-console');
     $self->export_logs();
     $self->export_logs_locale();
 }


### PR DESCRIPTION
we have problem in general that kernel error message overfloating
on root-console.
see https://progress.opensuse.org/issues/50456
switch to log-console should avoid this problem for post_fail_hook
verification test run (with changes for assert_screen which of course
removed now):
https://openqa.suse.de/tests/2902908#step/consoletest_setup/192
