### PR TITLE
Add check for invalid syntax is_sle and is_leap

### DIFF
--- a/tools/check_invalid_syntax
+++ b/tools/check_invalid_syntax
@@ -1,11 +1,37 @@
 #!/bin/sh
+
+let exit_code=0
+GIT_CMD="git --no-pager grep --break  --color -n -P"
+
 check_loadtest() {
-    CHECK_LOADTEST_RESULT=$(git --no-pager grep --break -P "\sloadtest\s?\(?(?:\"|')?[\w\/]+\.pm(?:\"|'),?.*\)?")
+    CHECK_LOADTEST_RESULT=$(${GIT_CMD} "\sloadtest\s?\(?(?:\"|')?[\w\/]+\.pm(?:\"|'),?.*\)?")
     if [ ! -z "$CHECK_LOADTEST_RESULT" ]; then
-        echo $CHECK_LOADTEST_RESULT
+        echo "${CHECK_LOADTEST_RESULT}"
         echo "Invalid syntax found for loadtest call. '.pm' extensions are not allowed at test distribution level"
-        return $?
+        let "exit_code++"
     fi
+    echo "Finished checking loadtests"
 }
 
+check_versions(){
+    CHECK_IS_LEAP_RESULT=$(${GIT_CMD} "is_leap.*(\"|')\d{2,}(?!>\.\d)\1")
+    if [ ! -z "$CHECK_IS_LEAP_RESULT" ]; then
+        echo "${CHECK_IS_LEAP_RESULT}"
+        echo "Invalid  call for is_leap"
+        let "exit_code++"
+    fi
+
+    CHECK_IS_SLE_RESULT=$(${GIT_CMD} "is_sle[\(\s](\"|')\d{2,}(?:\.\d\+)\1")
+    if [ ! -z "$CHECK_IS_SLE_RESULT" ]; then
+        echo "${CHECK_IS_SLE_RESULT}"
+        echo "Invalid  call for is_sle"
+        let "exit_code++"
+    fi
+    echo "Finished checking for invalid version syntax"
+}
+
+check_versions
 check_loadtest
+
+echo "All checks finished: $exit_code."
+exit $exit_code;

--- a/tools/check_invalid_syntax
+++ b/tools/check_invalid_syntax
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-let exit_code=0
+exit_code=0
 GIT_CMD="git --no-pager grep --break  --color -n -P"
 
 check_loadtest() {
@@ -8,7 +8,7 @@ check_loadtest() {
     if [ ! -z "$CHECK_LOADTEST_RESULT" ]; then
         echo "${CHECK_LOADTEST_RESULT}"
         echo "Invalid syntax found for loadtest call. '.pm' extensions are not allowed at test distribution level"
-        let "exit_code++"
+        exit_code=$(($exit_code+1))
     fi
     echo "Finished checking loadtests"
 }
@@ -18,14 +18,14 @@ check_versions(){
     if [ ! -z "$CHECK_IS_LEAP_RESULT" ]; then
         echo "${CHECK_IS_LEAP_RESULT}"
         echo "Invalid  call for is_leap"
-        let "exit_code++"
+        exit_code=$(($exit_code+1))
     fi
 
     CHECK_IS_SLE_RESULT=$(${GIT_CMD} "is_sle[\(\s](\"|')\d{2,}(?:\.\d\+)\1")
     if [ ! -z "$CHECK_IS_SLE_RESULT" ]; then
         echo "${CHECK_IS_SLE_RESULT}"
         echo "Invalid  call for is_sle"
-        let "exit_code++"
+        exit_code=$(($exit_code+1))
     fi
     echo "Finished checking for invalid version syntax"
 }

--- a/tools/check_invalid_syntax
+++ b/tools/check_invalid_syntax
@@ -14,7 +14,8 @@ check_loadtest() {
 }
 
 check_versions(){
-    CHECK_IS_LEAP_RESULT=$(${GIT_CMD} "is_leap.*(\"|')\d{2,}(?!>\.\d)\1")
+    # Check for patterns that will be likely rejected by is_leap or is_sle calls
+    CHECK_IS_LEAP_RESULT=$(${GIT_CMD} "is_leap[\(\s](\"|')\d{2}(?!\.\d)\1")
     if [ ! -z "$CHECK_IS_LEAP_RESULT" ]; then
         echo "${CHECK_IS_LEAP_RESULT}"
         echo "Invalid  call for is_leap"


### PR DESCRIPTION
Often we have the problem a new branch in the code is added and some usage of functions like is_sle and is_leap is not entirely consistent. While this is fixed, we can simply stop from merging PR's that have such invalid syntax

[![asciicast](https://asciinema.org/a/MiitxuogQk0NyKByEV1YMFFWJ.svg)](https://asciinema.org/a/MiitxuogQk0NyKByEV1YMFFWJ)