### PR TITLE
Fix system_role for virtualization in sle12sp5

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -137,7 +137,7 @@ if (is_sle('15+')) {
 elsif (is_sle('=12-SP5') && check_var('ARCH', 'x86_64')) {
     # System Role dialog is displayed only for x86_64 in SLE-12-SP5 due to it has more than one role available,
     # for the moment we are not handling available roles, so this make the trick for using new scheduling.
-    set_var('SYSTEM_ROLE', 'default');
+    set_var('SYSTEM_ROLE', 'default') unless get_var('SYSTEM_ROLE');
 }
 diag('default desktop: ' . default_desktop);
 set_var('DESKTOP', get_var('DESKTOP', default_desktop));


### PR DESCRIPTION
We missed to not set default role in sle12sp5 when virtualization roles already have one set.

- Related ticket: https://progress.opensuse.org/issues/50666
- Needles: N/A
- Verification run:
  - [sle-12-SP5-gi-guest_sles15fcs-on-host_developing-xen@64bit-ipmi](https://openqa.suse.de/tests/2905149#step/system_role/2)
  - [sle-12-SP5-textmode+role_kvm@64bit](https://openqa.suse.de/tests/2905147#step/system_role/2)
  - [sle-12-SP5-textmode+role_xen@64bit](https://openqa.suse.de/tests/2905148#step/system_role/2)
  - [sle-12-SP5-RAID1@64bit](https://openqa.suse.de/tests/2905146#step/system_role/1)

  
