### PR TITLE
Modify SES license behavior when product is or is not BETA

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -96,8 +96,9 @@ sub accept_addons_license {
     # For the legacy module we do not need any additional subscription,
     # like all modules, it is included in the SLES subscription.
     push @addons_with_license, 'lgm' unless is_sle('15+');
-    if (is_sle('15+') && get_var('SCC_ADDONS') =~ /ses/) {
-        record_soft_failure 'bsc#1118497';
+    if (is_sle('15+') && get_var('SCC_ADDONS') =~ /ses/ && get_var('BETA')) {
+        # during development is license not shown as it was already been shown once
+        record_info 'bsc#1118497';
     }
     else {
         push @addons_with_license, 'ses';


### PR DESCRIPTION
License is not shown because while SES is BETA the license is same as license already shown, YaST feature is to not show same license twice bsc#1118497

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1118497
- Verification run: http://10.100.12.155/tests/11810