### PR TITLE
load_extra_tests_zypper: replace repos if needed

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1492,6 +1492,8 @@ sub load_extra_tests_desktop {
 }
 
 sub load_extra_tests_zypper {
+    # Add non-oss and debug repos for o3 and remove other by default (skipped, if already done)
+    replace_opensuse_repos_tests if is_repo_replacement_required;
     loadtest "console/zypper_lr_validate";
     loadtest "console/zypper_ref";
     unless (is_jeos) {


### PR DESCRIPTION
- Verification run: https://openqa.opensuse.org/t938250

it makes JeOS to use o3 repos, if defined, so for Tumbleweed only.
