### PR TITLE
Fix accept_license for sle15 in s390x

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -384,7 +384,10 @@ configuration, otherwise returns false (0).
 
 sub has_license_on_welcome_screen {
     return 1 if is_caasp('caasp');
-    return get_var('HASLICENSE') && (((is_sle('>=15-SP1') && get_var('BASE_VERSION') && !get_var('UPGRADE')) && is_s390x()) || is_sle('<15'));
+    return get_var('HASLICENSE') &&
+      (((is_sle('>=15-SP1') && get_var('BASE_VERSION') && !get_var('UPGRADE')) && is_s390x())
+        || is_sle('<15')
+        || (is_sle('=15') && is_s390x()));
 }
 
 sub has_license_to_accept {


### PR DESCRIPTION
Fix accept_license for sle15 in s390x. Condition was recently modified and we need to include also sle15 s390x. I didn't refactor the condition, as I'm not sure how to cover old products, but as it is, fix the issue seen and narrow for that particular case failing.

- Related ticket: https://progress.opensuse.org/issues/50666
- Needles: N/A
- Verification run:
  - [sle-15-Installer-DVD-QR-s390x-Build0025-btrfs@s390x-kvm-sle15](https://openqa.suse.de/t2906513)
  - [sle-15-Installer-DVD-QR-s390x-Build0025-btrfs@s390x-zVM-vswitch-l3](https://openqa.suse.de/t2906514)
  - [sle-15-Installer-DVD-QR-s390x-Build0025-ext4@s390x-zVM-vswitch-l3](https://openqa.suse.de/t2906515)
