### PR TITLE
Gracefully handle autoinst-log.txt 404

### DIFF
--- a/tests/openqa/webui/test_results.pm
+++ b/tests/openqa/webui/test_results.pm
@@ -22,8 +22,13 @@ sub upload_autoinst_log {
         last if (script_run('openqa-client jobs/1 | grep state | grep done', 40) == 0);
         sleep 5;
     }
-    assert_script_run 'wget http://localhost/tests/1/file/autoinst-log.txt';
-    upload_logs('autoinst-log.txt', log_name => "nested");
+    if (script_run('wget http://localhost/tests/1/file/autoinst-log.txt') != 0) {
+        record_info('Log download', 'Error downloading autoinst-log.txt from nested openQA webui. Consult journal for further information.', result => 'fail');
+        script_run 'find /var/lib/openqa/testresults/';
+    }
+    else {
+        upload_logs('autoinst-log.txt', log_name => "nested");
+    }
 }
 
 sub run {


### PR DESCRIPTION
Do a record_info and continue post_fail_hook
to get gather some infos from journal

Ticket: https://progress.opensuse.org/issues/51650
Verification (no 404): http://artemis.suse.de/tests/1327
Verification (on o3 so hopefully 404 ^^): https://openqa.opensuse.org/tests/938389