### PR TITLE
Split PXE and YaST2 installer

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -400,6 +400,7 @@ sub load_boot_tests {
     }
     elsif (uses_qa_net_hardware() || get_var("PXEBOOT")) {
         loadtest "boot/boot_from_pxe";
+        loadtest "installation/exec_yast2_installer";
         set_var("DELAYED_START", get_var("PXEBOOT"));
     }
     else {

--- a/schedule/btrfs_ipmi.yaml
+++ b/schedule/btrfs_ipmi.yaml
@@ -1,0 +1,28 @@
+name:           btrfs@64bit-ipmi
+description:    >
+      Test installation with explicit selection of btrfs filesystem during installation. Tests installation only.
+      Maintainers: mloviska@suse.com
+schedule:
+    - boot/boot_from_pxe
+    - installation/exec_yast2_installer
+    - installation/welcome
+    - installation/accept_license
+    - installation/scc_registration
+    - installation/addon_products_sle
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_filesystem
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/user_settings
+    - installation/user_settings_root
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - boot/reconnect_mgmt_console
+    - installation/grub_test
+    - installation/first_boot

--- a/tests/installation/exec_yast2_installer.pm
+++ b/tests/installation/exec_yast2_installer.pm
@@ -1,0 +1,43 @@
+# SUSE's openQA tests
+#
+# Copyright © 2012-2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Start YaST2 installer
+# Maintainer: mloviska@suse.com
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+use utils 'type_string_slow';
+
+sub run {
+    my $ssh_vnc_wait_time = 300;
+    my $ssh_vnc_tag       = eval { check_var('VIDEOMODE', 'text') ? 'sshd' : 'vnc' } . '-server-started';
+
+    assert_screen([$ssh_vnc_tag, 'media_error'], $ssh_vnc_wait_time);
+    if (match_has_tag('media_error')) {
+        set_var('_SKIP_POST_FAIL_HOOKS', 1);
+        die "Media error! Check the installation media!\n";
+    }
+
+    select_console 'installation';
+
+    # We have textmode installation via ssh and the default vnc installation so far
+    if (check_var('VIDEOMODE', 'text') || check_var('VIDEOMODE', 'ssh-x')) {
+        type_string_slow('DISPLAY= ') if check_var('VIDEOMODE', 'text');
+        type_string_slow("yast.ssh\n");
+        wait_still_screen(stilltime => 0.5, timeout => 5, similarity_level => 45);
+        save_screenshot;
+    }
+    assert_screen('yast-still-running', 120);
+}
+
+sub test_flags { return fatal => 1; }
+
+1;


### PR DESCRIPTION
- Related ticket: [[sle][functional][y][ipmi] isolate pxe part and installer boot from boot_from_pxe](https://progress.opensuse.org/issues/45161)
- Needles: []()
- Verification runs: 
   - ["IPMI_HOSTNAME" : "sp.scooter.qa.suse.de" - sle-15-SP1-Installer-DVD-x86_64-Build227.1-virt-guest-migration-developing-from-developing-to-developing-xen-dst@virt-mm-64bit-ipmi](http://eris.suse.cz/tests/14550)
   - ["IPMI_HOSTNAME" : "openqaw4-sp.qa.suse.de" - sle-15-SP1-Installer-DVD-x86_64-Build227.1-gi-guest_sles12sp4-on-host-developing-kvm@64bit-ipmi](http://eris.suse.cz/tests/14529#)
   - ["IPMI_HOSTNAME" : "huawei6-sp.arch.suse.de" - sle-15-SP1-Installer-DVD-aarch64-Build225.1-gi-guest_developing-on-host-developing-kvm@huawei6](http://eris.suse.cz/tests/14528)
  - [ "IPMI_HOSTNAME" : "openqaw4-sp.qa.suse.de", sle-15-SP1-Installer-DVD-x86_64-Build225.1-btrfs@64bit-ipmi](http://eris.suse.cz/tests/14370)
  - [with latest updates sle-12-SP5-Server-DVD-x86_64-Build0161-default@64bit-ipmi](http://eris.suse.cz/tests/14643)
* post_fail_hook is located in *[autoinst-log.txt](http://eris.suse.cz/tests/14543/file/autoinst-log.txt)* and starts with "IPMI post fail hook data" line