### PR TITLE
Fix random failure in setup_zdup

### DIFF
--- a/tests/installation/setup_zdup.pm
+++ b/tests/installation/setup_zdup.pm
@@ -20,6 +20,8 @@ use utils;
 sub run {
     my ($self) = @_;
 
+    # #7501: load_boot_tests is present, needs to confirm grub is up
+    sleep 2;
     $self->wait_boot(ready_time => 600);
     if (get_var('ZDUP_IN_X')) {
         x11_start_program('xterm');


### PR DESCRIPTION
This issue may be caused by quick transition between tests. In bootloader, a return key is sent to enter grub screen; in setup_zdup, screen is being immidiately evaluated. The os may not have reacted to this point, thus the wrong screen is being evaluated, causing an error. Adding sleep(2) will ensure the os can finish the reaction.

- Related ticket: https://progress.opensuse.org/issues/50804
- Needles: Not needed
- Verification run: http://10.67.17.131/tests/27#step/setup_zdup/1
