### PR TITLE
Move backend "spvm" to Utils::Backends

### DIFF
--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -13,6 +13,15 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
+=head1 Backends
+
+=head1 SYNOPSIS
+
+use Utils::Backends
+It defines various functions that allows to check for different backend or console types. It exports C<CONSOLES> and C<BACKEND> 
+
+=cut
+
 package Utils::Backends;
 use strict;
 use warnings;
@@ -29,6 +38,7 @@ use constant {
           is_hyperv
           is_hyperv_in_gui
           is_svirt_except_s390x
+          is_spvm
           )
     ],
     CONSOLES => [
@@ -47,6 +57,13 @@ our %EXPORT_TAGS = (
 
 # Use it after SUT boot finish, as it requires ssh connection to SUT to
 # interact with SUT, including window and serial console
+
+=head2 use_ssh_serial_console
+
+Selects the root-ssh and saves it to SERIALDEV
+
+=cut
+
 sub use_ssh_serial_console {
     select_console('root-ssh');
     $serialdev = 'sshserial';
@@ -54,19 +71,36 @@ sub use_ssh_serial_console {
     bmwqemu::save_vars();
 }
 
+=head2 is_remote_backend
+
+Returns true if the current instance is running as remote backend
+
+=cut
+
 sub is_remote_backend {
     # s390x uses only remote repos
-    return check_var('ARCH', 's390x') || get_var('BACKEND', '') =~ /ipmi|spvm|svirt/;
+    return check_var('ARCH', 's390x') || (get_var('BACKEND', '') =~ /ipmi|svirt/) || is_spvm();
 }
 
 # In some cases we are using a VNC connection provided by the hypervisor that
 # allows access to the ttys same as for accessing any remote libvirt instance
 # but not what we use for s390x-kvm.
+
+=head2 has_ttys
+
+Returns true if the current instance is using ttys for: ipmi, s390x, spvm, except S390_ZKVM
+
+=cut
+
 sub has_ttys {
     return ((get_var('BACKEND', '') !~ /ipmi|s390x|spvm/) && !get_var('S390_ZKVM'));
 }
 
-#  splitting backend code for is_hyperv, is_hyperv_in_gui, is_svirt_except_s390x
+=head2 is_hyperv
+
+Returns true if the current instance is running as hyperv backend
+
+=cut
 
 sub is_hyperv {
     my $hyperv_version = shift;
@@ -74,13 +108,34 @@ sub is_hyperv {
     return defined($hyperv_version) ? check_var('HYPERV_VERSION', $hyperv_version) : 1;
 }
 
+=head2 is_hyperv_in_gui
+
+Returns true if the current instance is running as hyperv gui backend
+
+=cut
+
 sub is_hyperv_in_gui {
     return is_hyperv && !check_var('VIDEOMODE', 'text');
 }
 
+=head2 is_svirt_except_s390x
+
+Returns true if the current instance is running as svirt backend except s390x
+
+=cut
+
 sub is_svirt_except_s390x {
     return !get_var('S390_ZKVM') && check_var('BACKEND', 'svirt');
+}
 
+=head2 is_spvm 
+
+Returns true if the current instance is running as PowerVM backend 'spvm'
+
+=cut
+
+sub is_spvm {
+    return check_var('BACKEND', 'spvm');
 }
 
 1;

--- a/tests/console/kdump_and_crash.pm
+++ b/tests/console/kdump_and_crash.pm
@@ -19,6 +19,7 @@ use power_action_utils 'power_action';
 use kdump_utils;
 use version_utils 'is_sle';
 use registration;
+use Utils::Backends 'is_spvm';
 
 sub run {
     my ($self) = @_;
@@ -33,8 +34,8 @@ sub run {
     activate_kdump;
 
     # restart to activate kdump
-    power_action('reboot', keepconsole => check_var('BACKEND', 'spvm'));
-    reconnect_mgmt_console if check_var('BACKEND', 'spvm');
+    power_action('reboot', keepconsole => is_spvm);
+    reconnect_mgmt_console if is_spvm;
     $self->wait_boot;
     select_console 'root-console';
 
@@ -53,7 +54,7 @@ sub run {
         assert_screen 'grub2', 180;
         wait_screen_change { send_key 'ret' };
     }
-    elsif (check_var('BACKEND', 'spvm')) {
+    elsif (is_spvm) {
         reconnect_mgmt_console;
     }
     else {

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -23,10 +23,11 @@ use bootloader_setup;
 use bootloader_spvm;
 use registration;
 use utils;
+use Utils::Backends 'is_spvm';
 
 # hint: press shift-f10 trice for highest debug level
 sub run {
-    return boot_spvm if check_var('BACKEND', 'spvm');
+    return boot_spvm if is_spvm;
     return           if pre_bootmenu_setup == 3;
     return           if select_bootmenu_option == 3;
     my @params;


### PR DESCRIPTION
see https://progress.opensuse.org/issues/33388
verification runs:
https://openqa.suse.de/tests/2915205 (s390x)
https://openqa.suse.de/tests/2915204 (ppc64le)
https://openqa.suse.de/tests/2912003 (aarch64)
https://openqa.suse.de/tests/2915206 (spvm)
https://openqa.suse.de/tests/2915201 (xen)
https://openqa.suse.de/tests/2912213 (svirt-xen-pv)
https://openqa.suse.de/tests/2915202 (s390x-kvm)
https://openqa.suse.de/tests/2915203 (svirt-hyperv)
failed at hostname_inst: it should not be there, compared with
related tests on osd