### PR TITLE
'SysRq' can also be written in lower case 'sysrq'

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1125,7 +1125,7 @@ sub show_tasks_in_blocked_state {
     if (!check_var('BACKEND', 'svirt')) {
         send_key 'alt-sysrq-w';
         # info will be sent to serial tty
-        wait_serial('SysRq : Show Blocked State', 1);
+        wait_serial(('SysRq : Show Blocked State', 'sysrq : Show Blocked State'), 1);
     }
 }
 


### PR DESCRIPTION
- Verification run: https://openqa.opensuse.org/t939227
