### PR TITLE
Fix ext4 schedule for xen-pv

### DIFF
--- a/schedule/ext4_xen-pv.yaml
+++ b/schedule/ext4_xen-pv.yaml
@@ -1,0 +1,29 @@
+---
+name:           ext4_xen-pv
+description:    >
+  Test for ext4 filesystem in svirt-xen-pv.
+  Test modules 'grub_disable_timeout' and 'grub_test' in xen-pv are not scheduled
+  due to grub2 doesnt support xfb console.
+vars:
+  FILESYSTEM: ext4
+  FORMAT_DASD: install
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_filesystem
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/first_boot


### PR DESCRIPTION
Adjust schedule for xen-pv. We need to apply simple solution at the moment duplicating test suite and revisit it in future if we can unify it.

- Related ticket: https://progress.opensuse.org/issues/50666#change-213749
- Needles: N/A
- Verification run:
  - [sle-15-Installer-DVD-QR-x86_64-Build0025-ext4@svirt-xen-pv](https://openqa.suse.de/t2910849)
  - [sle-15-SP1-Installer-DVD-x86_64-Build227.1-ext4@svirt-xen-pv](https://openqa.suse.de/t2910850)

It requires:
 - Create new test suite ext4_xen-pv with the same settings as ext4 except `YAML_SCHEDULE=schedule/ext4_xen-pv.yaml`
 - Schedule this test suite for groups "SLE 15 -> YaST" and "Maintenance: QR -> Maintenance - QR - SLE15GA"

