### PR TITLE
download guest assets from openQA factory

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -23,6 +23,7 @@ use File::Basename;
 use LWP::Simple 'head';
 use scheduler 'load_yaml_schedule';
 use Utils::Backends qw(is_hyperv is_hyperv_in_gui);
+use Utils::Architectures;
 use DistributionProvider;
 
 BEGIN {
@@ -776,6 +777,7 @@ elsif (get_var("VIRT_AUTOTEST")) {
         loadtest "virt_autotest/install_package";
         loadtest "virt_autotest/update_package";
         loadtest "virt_autotest/reboot_and_wait_up_normal";
+        loadtest "virt_autotest/download_guest_assets" if (get_var("SKIP_GUEST_INSTALL") && is_x86_64);
     }
     if (get_var("VIRT_PRJ1_GUEST_INSTALL")) {
         loadtest "virt_autotest/guest_installation_run";

--- a/tests/virt_autotest/download_guest_assets.pm
+++ b/tests/virt_autotest/download_guest_assets.pm
@@ -1,0 +1,35 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: download specified guest vm images and xml configuration files from the NFS share location in openQA
+#          the guest assets are uploaded by the guest installation tests and named based on the host OS, guest OS, hypervisor and build.
+# Maintainer: Julie CAO <jcao@suse.com>
+package download_guest_assets;
+
+use strict;
+use warnings;
+use base "virt_autotest_base";
+use testapi;
+use virt_utils;
+
+sub run {
+    # download vm image and xml file from NFS location to skip installing guest
+    my $vm_xml_dir = "/tmp/download_vm_xml";
+    handle_sp_in_settings_with_fcs("GUEST_LIST");
+    my $guest_list = get_required_var("GUEST_LIST");
+    if (download_guest_assets($guest_list, $vm_xml_dir)) {
+        die "Fatal Error: The guest assets for $guest_list were not downloaded successfully!";
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/virt_autotest/guest_upgrade_run.pm
+++ b/tests/virt_autotest/guest_upgrade_run.pm
@@ -18,19 +18,25 @@ use warnings;
 use base "virt_autotest_base";
 use virt_utils;
 use testapi;
+use Utils::Architectures;
 
 sub get_script_run {
     my $pre_test_cmd         = "/usr/share/qa/tools/test_virtualization-guest-upgrade-run";
     my $product_upgrade_repo = get_var("PRODUCT_UPGRADE_REPO", "");
     my $max_test_time        = get_var("MAX_TEST_TIME", "36000");
+    my $vm_xml_dir           = "/tmp/download_vm_xml";
 
     handle_sp_in_settings_with_sp0("PRODUCT_UPGRADE");
-    my $product_upgrade = get_var("PRODUCT_UPGRADE", "sles-12-sp2-64");
+    my $product_upgrade = get_required_var("PRODUCT_UPGRADE");
 
     handle_sp_in_settings_with_fcs("GUEST_LIST");
-    my $guest_list = get_var("GUEST_LIST", "sles-12-sp1-64");
+    my $guest_list = get_required_var("GUEST_LIST");
+    $guest_list =~ s/sp0/fcs/ig;
 
     $pre_test_cmd = "$pre_test_cmd -p $product_upgrade -r $product_upgrade_repo -t $max_test_time -g \"$guest_list\"";
+    if (get_var("SKIP_GUEST_INSTALL") && is_x86_64) {
+        $pre_test_cmd .= " -k $vm_xml_dir";
+    }
     return $pre_test_cmd;
 }
 
@@ -39,8 +45,9 @@ sub analyzeResult {
     my $result;
     # In the case the log does not tell the exact failure
     if ($text !~ /Overall guest upgrade result is:(.*)Test done/s) {
-        $result->{subtest}->{status} = 'FAILED';
-        $result->{subtest}->{error}  = 'Please check the guest_upgrade_test log in the guest_upgrade_run-guest-upgrade-logs.tar.gz';
+        my $subtest = get_var('GUEST_LIST');
+        $result->{$subtest}->{status} = 'FAILED';
+        $result->{$subtest}->{error}  = 'Please check the guest_upgrade_test log in the guest_upgrade_run-guest-upgrade-logs.tar.gz';
         return $result;
     }
     my $rough_result = $1;
@@ -53,14 +60,15 @@ sub analyzeResult {
         }
     }
 
-    # if there are failing guest installation
-    unless ($text =~ /Congratulations! No guest failed in installation/) {
-        $text =~ /The guests failed in guest installation phase before core test are:(.*)Installation failed guest list done./s;
+    # if there are failing guest installation or in restoration
+    unless ($text =~ /Congratulations! No guest failed in (\w+)/) {
+        $text =~ /The guests failed in guest \w+ phase before core test are:(.*)\n(\w+) failed guest list done./s;
         my $installation_failed_guests = $1;
+        my $failing_phase              = $2;
         foreach my $guest (split('\n', $installation_failed_guests)) {
             next unless $guest !~ /^\s*$/;
             $result->{$guest}->{status} = 'FAILED';
-            $result->{$guest}->{error}  = "Guest $guest installation failed.";
+            $result->{$guest}->{error}  = "Guest $failing_phase failed.";
         }
     }
     return $result;
@@ -82,8 +90,7 @@ sub run {
 
     # display test result
     # print the test output to the openQA output
-    my $cmd                       = "cd /tmp; zcat $upload_log_name.tar.gz | sed -n '/Overall guest upgrade result/,/[0-9]* fail [0-9]* succeed/p'";
-    my $guest_upgrade_log_content = script_output($cmd);
+    my $guest_upgrade_log_content = script_output "cd /tmp; zcat $upload_log_name.tar.gz | sed -n '/Overall guest upgrade result/,/[0-9]* fail [0-9]* succeed/p'";
     save_screenshot;
 
     # print the sub test junit log


### PR DESCRIPTION
This is a re-created PR of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7405 as there are messy commits. 

- Related ticket: 
https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7405
https://github.com/SUSE/qa-automation/pull/690
https://github.com/SUSE/qa-testsuites/pull/717
- Verification run:
 === @@@sles11sp4 KVM  ===     http://10.67.18.247/tests/649
 === @@@sles15 XEN  ===     http://10.67.18.247/tests/650
 === @@@sles12sp4 XEN ===   http://10.67.18.247/tests/651  running
*** 1 guest fails to download guest xml, the other fail to download image file from openQA factory => expected to fail with download_guest_assets module ***
 === @@@sles11sp4 XEN  ===     http://10.67.18.247/tests/653
*** guests with incorrect guest patterns => expecting fail with download_guest_assets module ****
 === @@@sles15  ===     http://10.67.18.247/tests/648

@alice-suse @guoxuguang @waynechen55