### PR TITLE
Fix remove_node test to be called by a variable

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2679,7 +2679,8 @@ sub load_ha_cluster_tests {
     loadtest 'ha/remove_rsc' if get_var('HA_REMOVE_RSC');
 
     # Remove a node both by its hostname and ip address
-    loadtest 'ha/remove_node' if is_sle('>12-SP2');
+    # This test doesn't work before SLES12SP3 version
+    loadtest 'ha/remove_node' if get_var('HA_REMOVE_NODE');
 
     # Check logs to find error and upload all needed logs if we are not
     # in installation/publishing mode


### PR DESCRIPTION
At the moment, remove_node test is always triggered in all the tests.
This PR adds a variable to execute it on demand.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
