### PR TITLE
Add autoyast-error tag to the set of AY needles

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -106,7 +106,7 @@ sub verify_timeout_and_check_screen {
 sub run {
     my ($self) = @_;
 
-    my @needles           = qw(bios-boot nonexisting-package reboot-after-installation linuxrc-install-fail scc-invalid-url warning-pop-up autoyast-boot);
+    my @needles = qw(bios-boot nonexisting-package reboot-after-installation linuxrc-install-fail scc-invalid-url warning-pop-up autoyast-boot autoyast-error);
     my $expected_licenses = get_var('AUTOYAST_LICENSE');
     push @needles, 'autoyast-confirm'        if get_var('AUTOYAST_CONFIRM');
     push @needles, 'autoyast-postpartscript' if get_var('USRSCR_DIALOG');


### PR DESCRIPTION
We have `autoyast-error` tag handling in the loop, but tag is not added
for the first stage which prevents jobs from failing immediately and
wasting resources instead.
