### PR TITLE
fix references to the methods for deal_with_dependency_issues

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -95,10 +95,10 @@ sub deal_with_dependency_issues {
         send_key 'ret';
     }
     if (get_var("WORKAROUND_DEPS")) {
-        $self->workaround_dependency_issues;
+        y2_logs_helper::workaround_dependency_issues;
     }
     elsif (get_var("BREAK_DEPS")) {
-        $self->break_dependency;
+        y2_logs_helper::break_dependency;
     }
     else {
         die 'Dependency problems';


### PR DESCRIPTION
set references to the methods that have been moved to y2_logs_helper

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/2911411
