### PR TITLE
Slurm: abstract config preparation

### DIFF
--- a/tests/hpc/slurm_config.pm
+++ b/tests/hpc/slurm_config.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: HPC cluster helpers
+# Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
+
+use base "hpcbase";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub prepare_slurm_conf {
+    # Create proper /etc/hosts and /etc/slurm.conf for each node
+    my $nodes = get_required_var("CLUSTER_NODES");
+
+    my $slurm_slave_nodes = "";
+    for (my $node = 1; $node < $nodes; $node++) {
+        my $node_name = sprintf("slurm-slave%02d", $node);
+        $slurm_slave_nodes = "${slurm_slave_nodes},${node_name}";
+    }
+    my $config = << "EOF";
+sed -i "/^ControlMachine.*/c\\ControlMachine=slurm-master" /etc/slurm/slurm.conf
+sed -i "/^NodeName.*/c\\NodeName=slurm-master${slurm_slave_nodes} Sockets=1 CoresPerSocket=1 ThreadsPerCore=1 State=unknown" /etc/slurm/slurm.conf
+sed -i "/^PartitionName.*/c\\PartitionName=normal Nodes=slurm-master${slurm_slave_nodes} Default=YES MaxTime=24:00:00 State=UP" /etc/slurm/slurm.conf
+EOF
+    assert_script_run($_) foreach (split /\n/, $config);
+}
+
+1;

--- a/tests/hpc/slurm_master.pm
+++ b/tests/hpc/slurm_master.pm
@@ -18,6 +18,7 @@ use warnings;
 use testapi;
 use lockapi;
 use utils;
+require slurm_config;
 
 sub run {
     my $self = shift;
@@ -28,19 +29,7 @@ sub run {
     # install slurm
     zypper_call('in slurm slurm-munge');
 
-    # Create proper /etc/hosts and /etc/slurm.conf for each node
-    my $slurm_slave_nodes = "";
-    for (my $node = 1; $node < $nodes; $node++) {
-        my $node_name = sprintf("slurm-slave%02d", $node);
-        $slurm_slave_nodes = "${slurm_slave_nodes},${node_name}";
-    }
-    my $config = << "EOF";
-sed -i "/^ControlMachine.*/c\\ControlMachine=slurm-master" /etc/slurm/slurm.conf
-sed -i "/^NodeName.*/c\\NodeName=slurm-master${slurm_slave_nodes} Sockets=1 CoresPerSocket=1 ThreadsPerCore=1 State=unknown" /etc/slurm/slurm.conf
-sed -i "/^PartitionName.*/c\\PartitionName=normal Nodes=slurm-master${slurm_slave_nodes} Default=YES MaxTime=24:00:00 State=UP" /etc/slurm/slurm.conf
-EOF
-    assert_script_run($_) foreach (split /\n/, $config);
-
+    $self->prepare_slurm_conf();
     barrier_wait("SLURM_SETUP_DONE");
 
     # Copy munge key and slurm conf to all slave nodes


### PR DESCRIPTION
A simple move of a config preparation to a separate file.

This is an introduction to extending HPC cluster tests, so certain utility functions will be provided and eventually they might be added to /lib/hpc along with existing hpcbase.pm

- Related ticket: https://progress.opensuse.org/issues/51641
- Verification run:http://10.160.66.198/tests/tbd
