### PR TITLE
Revert "Check if aarch64 test missed grub"

### DIFF
--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -69,30 +69,19 @@ sub run {
     # 60 due to rare slowness e.g. multipath poo#11908
     # 90 as a workaround due to the qemu backend fallout
     # If grub timeout was not disabled, we wait for linux-login instead
-
-    check_screen ['grub2', 'displaymanager', 'linux-login'], 120;
-
-    if (match_has_tag('displaymanager') or match_has_tag('linux-login')) {
-        record_soft_failure("poo#49751 - Grub2 not found, because system has already booted");
-    }
-    elsif (match_has_tag 'grub2')
+    my $tag = get_var('KEEP_GRUB_TIMEOUT') ? 'linux-login' : 'grub2';
+    assert_screen_with_soft_timeout($tag, timeout => 2 * $timeout, soft_timeout => $timeout, bugref => 'boo#1120256');
+    stop_grub_timeout;
+    boot_into_snapshot if get_var("BOOT_TO_SNAPSHOT");
+    send_key_until_needlematch("bootmenu-xen-kernel", 'down', 10, 5) if get_var('XEN');
+    if ((check_var('ARCH', 'aarch64') && is_sle && get_var('PLYMOUTH_DEBUG'))
+        || get_var('GRUB_KERNEL_OPTION_APPEND'))
     {
-        stop_grub_timeout;
-        boot_into_snapshot if get_var("BOOT_TO_SNAPSHOT");
-        send_key_until_needlematch("bootmenu-xen-kernel", 'down', 10, 5) if get_var('XEN');
-        if ((check_var('ARCH', 'aarch64') && is_sle && get_var('PLYMOUTH_DEBUG'))
-            || get_var('GRUB_KERNEL_OPTION_APPEND'))
-        {
-            $self->bug_workaround_bsc1005313 unless get_var("BOOT_TO_SNAPSHOT");
-        }
-        else {
-            # avoid timeout for booting to HDD
-            send_key 'ret';
-        }
+        $self->bug_workaround_bsc1005313 unless get_var("BOOT_TO_SNAPSHOT");
     }
-    else
-    {
-        die 'Neither grub, nor system found';
+    else {
+        # avoid timeout for booting to HDD
+        send_key 'ret';
     }
 }
 


### PR DESCRIPTION
This reverts commit 17bcb49da20b9f9e6e80b2b8894e4d6fdc17c5c3.
Because it is causing several failures:
- SLE15-GA: https://openqa.suse.de/tests/2912089#step/first_boot/1
- SLE12-SP4: https://openqa.suse.de/tests/2911772#step/first_boot/3
- SLE12-SP3: https://openqa.suse.de/tests/2911675#step/first_boot/3
- SLE12-SP2: https://openqa.suse.de/tests/2911490#step/first_boot/3
- 15.1-KDE-Live: https://openqa.opensuse.org/tests/940347#step/grub_test/1

- Related ticket: https://progress.opensuse.org/issues/49751