### PR TITLE
Check /etc/os-release contents

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1537,6 +1537,7 @@ sub load_extra_tests_qemu {
 }
 
 sub load_extra_tests_console {
+    loadtest "console/check_os_release";
     # JeOS kernel is missing 'openvswitch' kernel module
     loadtest "console/openvswitch" unless is_jeos;
     # dependency of git test
@@ -2533,6 +2534,7 @@ sub load_ssh_key_import_tests {
 
 sub load_sles4sap_tests {
     return if get_var('INSTALLONLY');
+    loadtest "console/check_os_release";
     loadtest "sles4sap/desktop_icons" if (is_desktop_installed());
     loadtest "sles4sap/patterns";
     loadtest "sles4sap/sapconf";
@@ -2569,6 +2571,7 @@ sub load_ha_cluster_tests {
     loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
     loadtest "console/system_prepare";
     loadtest 'console/consoletest_setup';
+    loadtest 'console/check_os_release';
     loadtest 'console/hostname';
 
     # If HAWKGUI_TEST_ROLE is set to client, only load client side test

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -42,6 +42,7 @@ use constant {
           is_sles4sap_standard
           is_released
           is_rt
+          is_hpc
           is_staging
           is_storage_ng
           is_using_system_role
@@ -247,6 +248,10 @@ sub is_sles4sap_standard {
 
 sub is_rt {
     return check_var('SLE_PRODUCT', 'rt');
+}
+
+sub is_hpc {
+    return check_var('SLE_PRODUCT', 'hpc');
 }
 
 sub is_released {

--- a/tests/console/check_os_release.pm
+++ b/tests/console/check_os_release.pm
@@ -1,0 +1,79 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: check contents of /etc/os-release per the current settings
+# Maintainer: Alvaro Carvajal <acarvajal@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use version_utils qw(is_sle is_leap is_tumbleweed is_sles4sap is_rt is_hpc);
+use main_common 'is_desktop';
+
+sub run {
+    my ($self) = @_;
+
+    select_console 'root-console';
+
+    my %checker = ();
+    $checker{VERSION}    = get_required_var('VERSION');
+    $checker{VERSION_ID} = $checker{VERSION};
+
+    if (is_sle) {
+        my $product = get_required_var('SLE_PRODUCT');
+        $product = 'sles_sap' if (is_sles4sap and is_sle('<15'));
+        $product = 'sles'     if (is_sles4sap and is_sle('>=15'));
+        $product = 'sle_' . $product if is_rt or is_hpc;
+        $checker{NAME} = uc($product);
+        $checker{NAME} = 'SLES' if ($product =~ /^sles/);
+        $checker{VERSION_ID} =~ s/\-SP/./;
+        $checker{PRETTY_NAME} = "SUSE Linux Enterprise Server $checker{VERSION}";
+        $checker{PRETTY_NAME} =~ s/\-SP/ SP/;
+        $checker{PRETTY_NAME} =~ s/Server/Server for SAP Applications/ if (is_sles4sap and is_sle('<=12-SP2'));
+        $checker{PRETTY_NAME} =~ s/Server/Desktop/                    if is_desktop;
+        $checker{PRETTY_NAME} =~ s/Server/Real Time/                  if is_rt;
+        $checker{PRETTY_NAME} =~ s/Server/High Performance Computing/ if is_hpc;
+        $checker{ID}       = lc($checker{NAME});
+        $checker{CPE_NAME} = "cpe:/o:suse:$product:$checker{VERSION}";
+        $checker{CPE_NAME} =~ s/\-SP/:sp/;
+    }
+    if (is_leap) {
+        $checker{NAME}        = "openSUSE Leap";
+        $checker{ID}          = "opensuse";
+        $checker{PRETTY_NAME} = $checker{NAME} . " " . $checker{VERSION};
+        $checker{CPE_NAME}    = "cpe:/o:opensuse:leap:$checker{VERSION}";
+    }
+    if (is_tumbleweed) {
+        $checker{VERSION}     = get_required_var('BUILD');
+        $checker{VERSION_ID}  = $checker{VERSION};
+        $checker{NAME}        = "openSUSE Tumbleweed";
+        $checker{ID}          = "opensuse-tumbleweed";
+        $checker{CPE_NAME}    = "cpe:/o:opensuse:tumbleweed:$checker{VERSION}";
+        $checker{PRETTY_NAME} = $checker{NAME};
+    }
+
+    my $release = script_output "cat /etc/os-release";
+
+    foreach my $key (keys %checker) {
+        record_info $key, "Checking $key in /etc/os-release";
+        my $regexp = "$key=\"?$checker{$key}\"?";
+        if ($release !~ m|$regexp|) {
+            record_info "Wrong $key value", "Wrong $key value in /etc/os-release. Expected $checker{$key}", result => 'fail';
+            if (is_sle('=15-SP1') and is_sles4sap) {
+                record_soft_failure "bsc#1135637";
+            }
+            else {
+                $self->result('fail');
+            }
+        }
+    }
+}
+
+1;


### PR DESCRIPTION
This PR adds a test module to check the contents of `/etc/os-release` in the different SLES-related products, as well as Leap and Tumbleweed.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1135637
- Needles: N/A
- Verification runs:

Test module's verification runs with regression in SLES for SAP Applications:

1. 12-SP2: http://mango.suse.de/tests/918#step/check_os_release/2
2. 12-SP3: http://mango.suse.de/tests/919#step/check_os_release/2
3. 12-SP4: http://mango.suse.de/tests/920#step/check_os_release/2
4. 15-GM: http://mango.suse.de/tests/921#step/check_os_release/2
5. 15-SP1: http://mango.suse.de/tests/922#step/check_os_release/2 (soft failing due to bsc#1135637)

Verification runs with test module scheduled as part of console tests or HDD creation tasks using 15-SP1:

1. create_hdd_gnome (SLES): http://mango.suse.de/tests/909#step/check_os_release/2
2. create_hdd_ha_textmode (SLES+HAE): http://mango.suse.de/tests/911#step/check_os_release/2
3. create_hdd_sles4sap_gnome (SLES for SAP): http://mango.suse.de/tests/910#step/check_os_release/2 (soft failing due to bsc#1135637)
4. create_hdd_sled_gnome (SLED): http://mango.suse.de/tests/916#step/check_os_release/2
5. create_hdd_hpc_textmode (HPC): http://mango.suse.de/tests/913#step/check_os_release/2
6. gnome (SLES): http://mango.suse.de/tests/908#step/check_os_release/2 (rest of the test canceled after clearing `console/check_os_release`)

opensuse verification runs:

1. create_hdd_gnome (Leap 15.1): http://mango.suse.de/tests/915#step/check_os_release/2
2. create_hdd_gnome (Tumbleweed): http://mango.suse.de/tests/917#step/check_os_release/2

Verification runs after review:

1. SLED: http://mango.suse.de/tests/923#step/check_os_release/2
2. SLES4SAP: http://mango.suse.de/tests/931#step/check_os_release/9