### PR TITLE
Temporarily revert svirt serial backend

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -21,8 +21,6 @@ use version_utils qw(is_caasp is_jeos is_leap is_sle);
 use caasp 'pause_until';
 use mm_network;
 
-use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT SERIAL_CONSOLE_DEFAULT_DEVICE SERIAL_CONSOLE_DEFAULT_PORT);
-
 our @EXPORT = qw(
   add_custom_grub_entries
   boot_grub_item
@@ -903,18 +901,8 @@ sub zkvm_add_disk {
 
 sub zkvm_add_pty {
     my ($svirt) = shift;
-
-    # serial console used for the serial log
-    $svirt->add_pty({
-            pty_dev      => SERIAL_CONSOLE_DEFAULT_DEVICE,
-            pty_dev_type => 'pty',
-            target_type  => 'sclp',
-            target_port  => SERIAL_CONSOLE_DEFAULT_PORT});
-
-    # sut-serial (serial terminal: emulation of QEMU's virtio console for svirt)
-    $svirt->add_serial_console({
-            pty_dev     => SERIAL_TERMINAL_DEFAULT_DEVICE,
-            target_port => SERIAL_TERMINAL_DEFAULT_PORT});
+    # need that for s390
+    $svirt->add_pty({pty_dev => 'console', pty_dev_type => 'pty', target_type => 'sclp', target_port => '0'});
 }
 
 sub zkvm_add_interface {

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -768,12 +768,10 @@ sub select_serial_terminal {
         } else {
             $console = $root ? 'root-virtio-terminal' : 'virtio-terminal';
         }
+    } elsif (get_var('S390_ZKVM')) {
+        $console = $root ? 'root-console' : 'user-console';
     } elsif ($backend eq 'svirt') {
-        if (check_var('SERIAL_CONSOLE', 0)) {
-            $console = $root ? 'root-console' : 'user-console';
-        } else {
-            $console = $root ? 'root-sut-serial' : 'sut-serial';
-        }
+        $console = $root ? 'root-console' : 'user-console';
     } elsif ($backend =~ /^(ikvm|ipmi|spvm)$/) {
         $console = 'root-ssh';
     }

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -17,7 +17,6 @@ use utils qw(
 use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x is_tumbleweed is_opensuse);
 use x11utils qw(desktop_runner_hotkey ensure_unlocked_desktop);
 use Utils::Backends 'use_ssh_serial_console';
-use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT);
 
 # Base class implementation of distribution class necessary for testapi
 
@@ -401,11 +400,6 @@ sub init_consoles {
                 password => $testapi::password
             });
         set_var('SVIRT_VNC_CONSOLE', 'sut');
-    } else {
-        # sut-serial (serial terminal: emulation of QEMU's virtio console for svirt)
-        $self->add_console('root-sut-serial', 'ssh-virtsh-serial', {
-                pty_dev     => SERIAL_TERMINAL_DEFAULT_DEVICE,
-                target_port => SERIAL_TERMINAL_DEFAULT_PORT});
     }
 
     if (get_var('BACKEND', '') =~ /qemu|ikvm|generalhw/
@@ -594,7 +588,7 @@ Return console VT number with regards to it's name.
 =cut
 sub console_nr {
     my ($console) = @_;
-    $console =~ m/^(\w+)-(console|virtio-terminal|sut-serial|ssh|shell)/;
+    $console =~ m/^(\w+)-(console|virtio-terminal|ssh|shell)/;
     my ($name) = ($1) || return;
     my $nr = 4;
     $nr = get_root_console_tty if ($name eq 'root');
@@ -642,7 +636,7 @@ sub activate_console {
         return;
     }
 
-    $console =~ m/^(\w+)-(console|virtio-terminal|sut-serial|ssh|shell)/;
+    $console =~ m/^(\w+)-(console|virtio-terminal|ssh|shell)/;
     my ($name, $user, $type) = ($1, $1, $2);
     $name = $user //= '';
     $type //= '';
@@ -686,7 +680,7 @@ sub activate_console {
         $self->set_standard_prompt($user, skip_set_standard_prompt => $args{skip_set_standard_prompt});
         assert_screen $console;
     }
-    elsif ($type =~ /virtio-terminal|sut-serial/) {
+    elsif ($type eq 'virtio-terminal') {
         serial_terminal::login($user, $self->{serial_term_prompt});
     }
     elsif ($console eq 'novalink-ssh') {

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -751,7 +751,7 @@ sub console_selected {
     my ($self, $console, %args) = @_;
     $args{await_console} //= 1;
     $args{tags}          //= $console;
-    $args{ignore}        //= qr{sut|root-virtio-terminal|root-sut-serial|iucvconn|svirt|root-ssh|hyperv-intermediary};
+    $args{ignore}        //= qr{sut|root-virtio-terminal|iucvconn|svirt|root-ssh|hyperv-intermediary};
 
     if ($args{tags} =~ $args{ignore} || !$args{await_console}) {
         set_var('CONSOLE_JUST_ACTIVATED', 0);


### PR DESCRIPTION
See poo#51725.
This fixes error: `virsh define failed at /usr/lib/os-autoinst/consoles/sshVirtsh.pm line 576.`
As this is (hopefully) a temporary solution, I reverted only needed commits from original PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6841.

Verification run:
s390x (directly affected)
* create_hdd_minimal_base+sdk@s390x-kvm-sle12
http://quasar.suse.cz/tests/2720
* install_ltp+sle+15-SP1+Installer-DVD@s390x-kvm-sle12
http://quasar.suse.cz/tests/2722
* ltp_net_ipv6_lib@s390x-kvm-sle12
http://quasar.suse.cz/tests/2736

64bit (not directly affected)
* install_ltp+sle+15-SP1+Installer-DVD@64bit
http://quasar.suse.cz/tests/2734
* ltp_ima@64bit
http://quasar.suse.cz/tests/2732
* ltp_cve@64bit
http://quasar.suse.cz/tests/2731
* install_ltp+opensuse+DVD@64bit
http://quasar.suse.cz/tests/2733

svirt hyperv (not directly affected)
* textmode@svirt-hyperv2012r2
http://quasar.suse.cz/tests/2715
* textmode@svirt-hyperv2012r2-uefi
http://quasar.suse.cz/tests/2724