### PR TITLE
Disable workaround for fixed boo#1105302

### DIFF
--- a/tests/installation/system_workarounds.pm
+++ b/tests/installation/system_workarounds.pm
@@ -18,12 +18,7 @@ use base 'opensusebasetest';
 sub run {
     select_console('root-console');
 
-    # boo#1105302 - Disable kernel watchdog on aarch64 (for running system and for next boot)
-    if (check_var('ARCH', 'aarch64')) {
-        record_info('boo#1105302', "Disable kernel watchdog to avoid test failures due to 'watchdog: BUG: soft lockup - CPU#0 stuck for XXs!'");
-        assert_script_run('echo 0 > /proc/sys/kernel/watchdog_thresh');
-        assert_script_run('echo "kernel.watchdog_thresh = 0" > /etc/sysctl.d/watchdog.conf');
-    }
+    # Add your workarounds here
 }
 
 sub test_flags {


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/47849
- Verification run: https://openqa.opensuse.org/tests/overview?build=20190520%3Aboo1105302&version=Tumbleweed&distri=opensuse&groupid=38

Controlgroup job without this patch: https://openqa.opensuse.org/tests/overview?distri=opensuse&groupid=38&version=Tumbleweed&build=20190520%3Aboo1105302_controlgroup