### PR TITLE
wicked: Store data/wicked on SUT

### DIFF
--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -41,6 +41,8 @@ sub run {
     systemctl('is-active network');
     systemctl('is-active wicked');
 
+    $self->download_data_dir();
+
     if (check_var('IS_WICKED_REF', '1')) {
         record_info('INFO', 'Setup DHCP server');
         zypper_call('--quiet in dhcp-server', timeout => 200);


### PR DESCRIPTION
Store all files from data/wicked on SUT. So we do not need network
during test, to get some files from this folder.

- Verification run: http://cfconrad-vm.qa.suse.de/tests/4551 (Shorten VR others are running)
  - http://cfconrad-vm.qa.suse.de/tests/4562 (advanced)
  - http://cfconrad-vm.qa.suse.de/tests/4560 (startandstop)
  - http://cfconrad-vm.qa.suse.de/tests/4564 (basic)

@asmorodskyi @jlausuch 