### PR TITLE
Reenable fixed svirt serial backend

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -21,6 +21,8 @@ use version_utils qw(is_caasp is_jeos is_leap is_sle);
 use caasp 'pause_until';
 use mm_network;
 
+use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT SERIAL_CONSOLE_DEFAULT_DEVICE SERIAL_CONSOLE_DEFAULT_PORT);
+
 our @EXPORT = qw(
   add_custom_grub_entries
   boot_grub_item
@@ -901,8 +903,20 @@ sub zkvm_add_disk {
 
 sub zkvm_add_pty {
     my ($svirt) = shift;
-    # need that for s390
-    $svirt->add_pty({pty_dev => 'console', pty_dev_type => 'pty', target_type => 'sclp', target_port => '0'});
+
+    # serial console used for the serial log
+    $svirt->add_pty({
+            pty_dev      => SERIAL_CONSOLE_DEFAULT_DEVICE,
+            pty_dev_type => 'pty',
+            target_type  => 'sclp',
+            target_port  => SERIAL_CONSOLE_DEFAULT_PORT});
+
+    # sut-serial (serial terminal: emulation of QEMU's virtio console for svirt)
+    $svirt->add_pty({
+            pty_dev      => SERIAL_TERMINAL_DEFAULT_DEVICE,
+            pty_dev_type => 'pty',
+            target_type  => 'virtio',
+            target_port  => SERIAL_TERMINAL_DEFAULT_PORT});
 }
 
 sub zkvm_add_interface {

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -768,10 +768,12 @@ sub select_serial_terminal {
         } else {
             $console = $root ? 'root-virtio-terminal' : 'virtio-terminal';
         }
-    } elsif (get_var('S390_ZKVM')) {
-        $console = $root ? 'root-console' : 'user-console';
     } elsif ($backend eq 'svirt') {
-        $console = $root ? 'root-console' : 'user-console';
+        if (check_var('SERIAL_CONSOLE', 0)) {
+            $console = $root ? 'root-console' : 'user-console';
+        } else {
+            $console = $root ? 'root-sut-serial' : 'sut-serial';
+        }
     } elsif ($backend =~ /^(ikvm|ipmi|spvm)$/) {
         $console = 'root-ssh';
     }

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -751,7 +751,7 @@ sub console_selected {
     my ($self, $console, %args) = @_;
     $args{await_console} //= 1;
     $args{tags}          //= $console;
-    $args{ignore}        //= qr{sut|root-virtio-terminal|iucvconn|svirt|root-ssh|hyperv-intermediary};
+    $args{ignore}        //= qr{sut|root-virtio-terminal|root-sut-serial|iucvconn|svirt|root-ssh|hyperv-intermediary};
 
     if ($args{tags} =~ $args{ignore} || !$args{await_console}) {
         set_var('CONSOLE_JUST_ACTIVATED', 0);

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -17,6 +17,7 @@ use utils qw(
 use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x is_tumbleweed is_opensuse);
 use x11utils qw(desktop_runner_hotkey ensure_unlocked_desktop);
 use Utils::Backends 'use_ssh_serial_console';
+use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT);
 
 # Base class implementation of distribution class necessary for testapi
 
@@ -400,6 +401,11 @@ sub init_consoles {
                 password => $testapi::password
             });
         set_var('SVIRT_VNC_CONSOLE', 'sut');
+    } else {
+        # sut-serial (serial terminal: emulation of QEMU's virtio console for svirt)
+        $self->add_console('root-sut-serial', 'ssh-virtsh-serial', {
+                pty_dev     => SERIAL_TERMINAL_DEFAULT_DEVICE,
+                target_port => SERIAL_TERMINAL_DEFAULT_PORT});
     }
 
     if (get_var('BACKEND', '') =~ /qemu|ikvm|generalhw/
@@ -588,7 +594,7 @@ Return console VT number with regards to it's name.
 =cut
 sub console_nr {
     my ($console) = @_;
-    $console =~ m/^(\w+)-(console|virtio-terminal|ssh|shell)/;
+    $console =~ m/^(\w+)-(console|virtio-terminal|sut-serial|ssh|shell)/;
     my ($name) = ($1) || return;
     my $nr = 4;
     $nr = get_root_console_tty if ($name eq 'root');
@@ -636,7 +642,7 @@ sub activate_console {
         return;
     }
 
-    $console =~ m/^(\w+)-(console|virtio-terminal|ssh|shell)/;
+    $console =~ m/^(\w+)-(console|virtio-terminal|sut-serial|ssh|shell)/;
     my ($name, $user, $type) = ($1, $1, $2);
     $name = $user //= '';
     $type //= '';
@@ -680,7 +686,7 @@ sub activate_console {
         $self->set_standard_prompt($user, skip_set_standard_prompt => $args{skip_set_standard_prompt});
         assert_screen $console;
     }
-    elsif ($type eq 'virtio-terminal') {
+    elsif ($type =~ /^(virtio-terminal|sut-serial)$/) {
         serial_terminal::login($user, $self->{serial_term_prompt});
     }
     elsif ($console eq 'novalink-ssh') {


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/51725

Verification run:
s390p7.suse.de guest (SLES 15 => s390x-kvm-sle15)
* default
http://quasar.suse.cz/tests/2758
* btrfs
http://quasar.suse.cz/tests/2746
* ltp_net_ipv6_lib
http://quasar.suse.cz/tests/2742

s390p8.suse.de (SLE 12 SP4 => s390x-kvm-sle12)
* default
http://quasar.suse.cz/tests/2756
* create_hdd_gnome.s390
http://quasar.suse.cz/tests/2759

zkvm (QAM)
* ltp_net_ipv6_lib
http://quasar.suse.cz/tests/2748
* btrfs
http://quasar.suse.cz/tests/2745

s390zp13.suse.de guest (SLES 12 SP3, not much relevant now)
* ltp_net_ipv6_lib
http://quasar.suse.cz/tests/2738
* btrfs
http://quasar.suse.cz/tests/2747

Hyper-v (shouldn't affect, it's just a test for mnowak)
* textmode@svirt-hyperv2012r2-uefi
http://quasar.suse.cz/tests/2740
* proxyscc_upgrade_sles12sp4_allpatterns_minipatch_hyperv@svirt-hyperv
http://quasar.suse.cz/tests/2749