### PR TITLE
Update kerberos schema path

### DIFF
--- a/data/sssd-tests/krb/slapd.conf
+++ b/data/sssd-tests/krb/slapd.conf
@@ -3,7 +3,7 @@ include		/etc/openldap/schema/cosine.schema
 include		/etc/openldap/schema/inetorgperson.schema
 include		/etc/openldap/schema/rfc2307bis.schema
 include		/etc/openldap/schema/yast.schema
-include		/usr/share/doc/packages/krb5/kerberos.schema
+include		/usr/share/kerberos/ldap/kerberos.schema
 
 access to dn.base=""
         by * read


### PR DESCRIPTION
The kerberos schema was moved from /usr/share/doc/packages/krb5/ to
/usr/share/kerberos/ldap/ (bsc#1134217).

This fixes bsc#1135543.

Signed-off-by: Samuel Cabrero <scabrero@suse.de>