### PR TITLE
Increate timeout value for installation-settings-overview-loaded

### DIFF
--- a/tests/installation/resolve_dependency_issues.pm
+++ b/tests/installation/resolve_dependency_issues.pm
@@ -17,7 +17,7 @@ use testapi;
 
 sub run {
     my ($self) = @_;
-    assert_screen('installation-settings-overview-loaded', 90);
+    assert_screen('installation-settings-overview-loaded', 250);
 
     if (check_screen('manual-intervention', 0)) {
         $self->deal_with_dependency_issues;


### PR DESCRIPTION
It need more time for resolve_dependency_issues module to wait tag 'installation-settings-overview-loaded', set 250s instead of 90s.

- Related ticket: https://progress.opensuse.org/issues/51947
- Needles: N/A
- Verification run: N/A.
