### PR TITLE
Remove yast expert partitioner test from the schedule

### DIFF
--- a/schedule/yast2_gui.yaml
+++ b/schedule/yast2_gui.yaml
@@ -29,5 +29,4 @@ schedule:
     - yast2_gui/yast2_network_settings
     - yast2_gui/yast2_software_management
     - yast2_gui/yast2_users
-    - yast2_gui/yast2_storage_ng
     - yast2_gui/yast2_security


### PR DESCRIPTION
Test module never worked for SLE 15 SP1 and requires some adjustments.
As we are in GMC phase, I propose to disable it and address the problem.

Fixes https://openqa.suse.de/tests/2917639#
