### PR TITLE
Apply yaml schedule only to staging tests

### DIFF
--- a/schedule/autoyast_mini_staging@64bit-staging.yaml
+++ b/schedule/autoyast_mini_staging@64bit-staging.yaml
@@ -1,10 +1,10 @@
-name:           autoyast_mini_staging
+name:           autoyast_mini_staging@64bit-staging
 description:    >
     Test verifies installation with minimal autoyast profile.
     Same as autoyast_mini but with product defined using url and not as registered modules
 schedule:
     - autoyast/prepare_profile
-    - installation/bootloader
+    - installation/bootloader_start
     - autoyast/installation
     - autoyast/console
     - autoyast/login

--- a/schedule/autoyast_y2_firstboot.yaml
+++ b/schedule/autoyast_y2_firstboot.yaml
@@ -6,7 +6,7 @@ vars:
 schedule:
     - autoyast/prepare_profile
     - installation/isosize
-    - installation/bootloader
+    - installation/bootloader_start
     - autoyast/installation
     - installation/yast2_firstboot
     - console/validate_yast2_firstboot_configuration

--- a/schedule/cryptlvm_minimal_x@64bit-staging.yaml
+++ b/schedule/cryptlvm_minimal_x@64bit-staging.yaml
@@ -9,7 +9,7 @@ vars:
   LVM: 1
   MAX_JOB_TIME: 14400
 schedule:
-  - installation/bootloader
+  - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration

--- a/schedule/default_install@64bit-staging.yaml
+++ b/schedule/default_install@64bit-staging.yaml
@@ -1,9 +1,9 @@
 ---
-name:           default_install
+name:           default_install@64bit-staging
 description:    >
   Test for default installation, with default options.
 schedule:
-  - installation/bootloader
+  - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration

--- a/schedule/gnome@64bit-staging.yaml
+++ b/schedule/gnome@64bit-staging.yaml
@@ -6,7 +6,7 @@ description:    >
 vars:
   MAX_JOB_TIME: 10800
 schedule:
-  - installation/bootloader
+  - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration

--- a/schedule/installcheck@64bit-staging.yaml
+++ b/schedule/installcheck@64bit-staging.yaml
@@ -1,5 +1,5 @@
 ---
-name:           installcheck
+name:           installcheck@64bit-staging
 description:    >
   Development support test. Execute the so called "installcheck" to
   check for package dependencies.

--- a/schedule/migration_zdup_offline_sle12sp2@64bit-staging.yaml
+++ b/schedule/migration_zdup_offline_sle12sp2@64bit-staging.yaml
@@ -1,5 +1,5 @@
 ---
-name:           migration_zdup_offline_sle12sp2_staging
+name:           migration_zdup_offline_sle12sp2@64bit-staging
 description:    >
   Test for zdup on sle12sp2 at staging.
 vars:

--- a/schedule/rescue_system_sle11sp4@64bit-staging.yaml
+++ b/schedule/rescue_system_sle11sp4@64bit-staging.yaml
@@ -1,5 +1,5 @@
 ---
-name:           rescue_system_sle11sp4
+name:           rescue_system_sle11sp4@64bit-staging
 description:    >
   Boot installation medium into rescue mode and test mounting
   a SLES 11 SP4 installation.

--- a/schedule/sles4sap_offline_gnome@64bit-staging.yaml
+++ b/schedule/sles4sap_offline_gnome@64bit-staging.yaml
@@ -1,5 +1,5 @@
 ---
-name:           sles4sap_offline_gnome
+name:           sles4sap_offline_gnome@64bit-staging
 description:    >
   Graphical installation tests for SLES for SAP Applications without
   SCC registration. Boot into Gnome.
@@ -17,7 +17,7 @@ vars:
   SYSTEM_ROLE: default
   WORKAROUND_MODULES: base,desktop,sapapp,serverapp,ha
 schedule:
-  - installation/bootloader
+  - installation/bootloader_start
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration


### PR DESCRIPTION
to fix issue introduced by the declarative scheduler. Make use of bootloader_start which picks the correct bootloader for each arch. Also apply yaml schedule only to staging tests

- Related ticket: https://progress.opensuse.org/issues/49064
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/2919058
