### PR TITLE
Fix sles4sap_offline_gnome yaml scheduler file

### DIFF
--- a/schedule/sles4sap_offline_gnome.yaml
+++ b/schedule/sles4sap_offline_gnome.yaml
@@ -23,7 +23,7 @@ schedule:
   - installation/scc_registration
   - installation/addon_products_sle
   - installation/system_role
-  - sles4sap_product_installation_mode
+  - installation/sles4sap_product_installation_mode
   - installation/partitioning
   - installation/partitioning_finish
   - installation/installer_timezone


### PR DESCRIPTION
For some reason, a YaML file for the scheduler for the `sles4sap_offline_gnome` test has the wrong definition for the `sles4sap_product_installation_mode` test.

This fixes the problem.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/945
- Failing tests: https://openqa.suse.de/tests/2916509 and https://openqa.suse.de/tests/2919007
