### PR TITLE
Reset consoles and connect sol console after ipmi power reset

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -64,6 +64,8 @@ sub login_to_console {
 
     if (!check_screen([qw(grub2 grub1 prague-pxe-menu)], 210)) {
         ipmitool("chassis power reset");
+        reset_consoles;
+        select_console 'sol', await_console => 0;
         assert_screen([qw(grub2 grub1 prague-pxe-menu)], 90);
     }
 


### PR DESCRIPTION
- Fail: http://openqa.qam.suse.cz/tests/934
- Verification run: http://10.100.12.155/tests/11835
