### PR TITLE
Switch sequence of mask and disable

### DIFF
--- a/lib/Utils/Systemd.pm
+++ b/lib/Utils/Systemd.pm
@@ -48,8 +48,8 @@ sub disable_and_stop_service {
     $args{mask_service}   //= 0;
     $args{ignore_failure} //= 0;
 
-    systemctl("mask $service_name", ignore_failure => $args{ignore_failure}) if ($args{mask_service});
-    systemctl("disable $service_name", ignore_failure => $args{ignore_failure});
+    systemctl("disable $service_name", ignore_failure => $args{ignore_failure}) if ($args{mask_service});
+    systemctl("mask $service_name", ignore_failure => $args{ignore_failure});
     systemctl("stop $service_name",    ignore_failure => $args{ignore_failure});
 }
 


### PR DESCRIPTION
Switch sequence of mask and disable due to the disable action being unsupported on masked services on SLE12-SP2 and lower.

Ref. bsc#1135080

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1135080
- Needles: N/A
- Verification run: TBA
