### PR TITLE
fix a bug which broke the existing prj4 sles15sp0 tests

### DIFF
--- a/tests/virt_autotest/guest_upgrade_run.pm
+++ b/tests/virt_autotest/guest_upgrade_run.pm
@@ -31,7 +31,6 @@ sub get_script_run {
 
     handle_sp_in_settings_with_fcs("GUEST_LIST");
     my $guest_list = get_required_var("GUEST_LIST");
-    $guest_list =~ s/sp0/fcs/ig;
 
     $pre_test_cmd = "$pre_test_cmd -p $product_upgrade -r $product_upgrade_repo -t $max_test_time -g \"$guest_list\"";
     if (get_var("SKIP_GUEST_INSTALL") && is_x86_64) {


### PR DESCRIPTION
A bug was introduced from my previous PR: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7512. It broke the prj4 tests with sles15sp0 guests. Failing tests should be retriggered with this PR.

- Related ticket: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7512
- Verification run:
without skipping guest installation  ==>  http://10.67.18.247/tests/670
with skipping guest installation  ==> http://10.67.18.247/tests/671

@alice-suse @xguo @waynechen55
