### PR TITLE
Add autologin test for sle

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -120,8 +120,8 @@ sub is_desktop_module_available {
 }
 
 # SLE specific variables
-set_var('NOAUTOLOGIN', 1);
-set_var('HASLICENSE',  1);
+set_var('NOAUTOLOGIN', 1) unless check_var('NOAUTOLOGIN', '0');
+set_var('HASLICENSE', 1);
 set_var('SLE_PRODUCT', get_var('SLE_PRODUCT', 'sles'));
 # Always register against SCC if SLE 15
 if (is_sle('15+')) {

--- a/schedule/autologin.yaml
+++ b/schedule/autologin.yaml
@@ -1,0 +1,25 @@
+---
+name:           autologin
+description:    >
+  Test automatic login when selected for local user during installation.
+schedule:
+  - installation/bootloader
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot

--- a/tests/installation/user_settings.pm
+++ b/tests/installation/user_settings.pm
@@ -38,6 +38,10 @@ sub run {
         send_key $cmd{noautologin};
         assert_screen 'autologindisabled';
     }
+    elsif (check_var('NOAUTOLOGIN', '0')) {
+        send_key $cmd{noautologin};
+        assert_screen 'autologinenabled';
+    }
     if (get_var('DOCRUN')) {
         send_key $cmd{otherrootpw};
         assert_screen 'rootpwdisabled';


### PR DESCRIPTION
Select Automatic Login in Local User screen and login without password through display manager.

- Related ticket: https://progress.opensuse.org/issues/44069
- Needles: [needles sle](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1158)
- Verification run:
  - [sle-15-SP1-autologin](http://rivera-workstation.suse.cz/tests/2811#step/first_boot/2)
  - [sle-12-SP5-autologin](http://rivera-workstation.suse.cz/tests/2810#step/first_boot/2)

Requires to create new test suite `autologin` with params below and assign to corresponding test suites in sle12 and sle15:
 ```
DESKTOP=gnome
YAML_SCHEDULE=schedule/autologin.yaml
NOAUTOLOGIN=0
```