### PR TITLE
yast2-storage-ng: make test more reliable

### DIFF
--- a/tests/yast2_gui/yast2_storage_ng.pm
+++ b/tests/yast2_gui/yast2_storage_ng.pm
@@ -217,6 +217,7 @@ sub run {
     wait_screen_change { send_key $fs_page_shortcut };
 
     # summary and finish
+    wait_still_screen 1;
     wait_screen_change { send_key "alt-n" };
     wait_still_screen 1;
     wait_screen_change { send_key "alt-f" };
@@ -237,7 +238,9 @@ sub run {
     start_y2sn $self;
     assert_and_click "yast2_storage_ng-select-vol-management";
     wait_screen_change { send_key(is_sle() ? "alt-l" : "alt-d") };
+    wait_still_screen 1;
     wait_screen_change { send_key "alt-t" };
+    wait_still_screen 1;
     wait_screen_change { send_key "alt-n" };
     wait_still_screen 1;
     wait_screen_change { send_key "alt-f" };


### PR DESCRIPTION
Sometimes, having multiple wait_screen_change in a row without adding a wait_still_screen can make the test unstable (e.g. https://openqa.suse.de/tests/2924855#step/yast2_storage_ng/94).
I wasn't able to reproduce the issue on my local openQA instance, but this _should_ fix what seen on `osd`.

- Verification runs:
  - SLES 15.1: http://d250.qam.suse.de/tests/2026 :heavy_check_mark: 
  - SLES 15.0: http://d250.qam.suse.de/tests/2028 :heavy_check_mark: 