### PR TITLE
Fix migrated scenarios to yaml: cryptlvm_minimal_x and gnome

### DIFF
--- a/schedule/cryptlvm_minimal_x@64bit-staging.yaml
+++ b/schedule/cryptlvm_minimal_x@64bit-staging.yaml
@@ -1,10 +1,13 @@
 ---
-name:           gnome
+name:           cryptlvm_minimal_x@64bit-staging
 description:    >
-  The standard scenario where we mainly just follow installation
-  suggestions without any adjustments as long as the default desktop is gnome.
+  Combination of "cryptlvm" and "minimal_x" for 64bit and staging.
+  (crypt-)LVM installations can take longer,
+  especially on non-x86_64 architectures.
 vars:
-  MAX_JOB_TIME: 10800
+  ENCRYPT: 1
+  LVM: 1
+  MAX_JOB_TIME: 14400
 schedule:
   - installation/bootloader
   - installation/welcome
@@ -13,11 +16,13 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
+  - installation/partitioning/encrypt_lvm
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
+  - installation/change_desktop
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
@@ -25,6 +30,7 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/grub_test
+  - installation/boot_encrypt
   - installation/first_boot
   - console/system_prepare
   - console/check_network
@@ -52,18 +58,3 @@ schedule:
   - console/mtab
   - console/orphaned_packages_check
   - console/consoletest_finish
-  - x11/desktop_runner
-  - x11/xterm
-  - locale/keymap_or_locale_x11
-  - x11/sshxterm
-  - x11/gnome_control_center
-  - x11/gnome_terminal
-  - x11/gedit
-  - x11/firefox
-  - x11/yast2_snapper
-  - x11/glxgears
-  - x11/nautilus
-  - x11/desktop_mainmenu
-  - x11/reboot_gnome
-  - shutdown/cleanup_before_shutdown
-  - shutdown/shutdown

--- a/schedule/gnome@64bit-staging.yaml
+++ b/schedule/gnome@64bit-staging.yaml
@@ -1,13 +1,10 @@
 ---
-name:           cryptlvm_minimal_x
+name:           gnome@64bit-staging
 description:    >
-  Combination of "cryptlvm" and "minimal_x" for sle12.
-  (crypt-)LVM installations can take longer,
-  especially on non-x86_64 architectures.
+  The standard scenario where we mainly just follow installation
+  suggestions without any adjustments as long as the default desktop is gnome.
 vars:
-  ENCRYPT: 1  
-  LVM: 1
-  MAX_JOB_TIME: 14400
+  MAX_JOB_TIME: 10800
 schedule:
   - installation/bootloader
   - installation/welcome
@@ -16,13 +13,11 @@ schedule:
   - installation/addon_products_sle
   - installation/system_role
   - installation/partitioning
-  - installation/partitioning/encrypt_lvm
   - installation/partitioning_finish
   - installation/installer_timezone
   - installation/user_settings
   - installation/user_settings_root
   - installation/resolve_dependency_issues
-  - installation/change_desktop
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
@@ -30,7 +25,6 @@ schedule:
   - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/grub_test
-  - installation/boot_encrypt
   - installation/first_boot
   - console/system_prepare
   - console/check_network
@@ -58,3 +52,18 @@ schedule:
   - console/mtab
   - console/orphaned_packages_check
   - console/consoletest_finish
+  - x11/desktop_runner
+  - x11/xterm
+  - locale/keymap_or_locale_x11
+  - x11/sshxterm
+  - x11/gnome_control_center
+  - x11/gnome_terminal
+  - x11/gedit
+  - x11/firefox
+  - x11/yast2_snapper
+  - x11/glxgears
+  - x11/nautilus
+  - x11/desktop_mainmenu
+  - x11/reboot_gnome
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown


### PR DESCRIPTION
Fix migrated scenarios to yaml: cryptlvm_minimal_x. 
There are differences among schedules, for example: `console/salt`, `installation/system_role`, `console/glibc_sanity`, `installation/system_workarounds`.
Added gnome as well.
~My concerns are about this 'kind of' duplication, where we loose to have a meaningful test suite in favor of avoiding breaking tests from other teams. Basically in these scenario there is one test more or one test less, always a different one, but those differences do no make the test suite different (system_role is due to a visualization of number of roles, salt perhaps someone missed or was not ready for that product, same for glibc_sanity, and workarounds). Therefore what we have are exceptions by architectures and products which are hard to determine how to fix due to is shared work with other teams.~

~I think the idea behind this implementation was in the good path https://github.com/os-autoinst/openQA/blob/master/docs/WritingTests.asciidoc#defining-a-custom-test-schedule-or-custom-test-modules regarding exclusion, but it has the problem that does not allow to include test in a particular position or that is using parameters instead of a file, which is a big limitation. For this case I would say we would need one file that could represent inclusions and exclusions (for us) according arch and products and one file for each different staging (leaving the rest of teams not affected using main.pm) but that would require that we agree in some implementation of this kind.~

~I missed here to have some kind of automation, because it is pretty easy to make a mistake manually writing the test, but I never thought that it would the idea.We can create it but still we will be loading all the mess from main.pm.~ 
(DISCUSSED WITH THE TEAM)

Another possible solution in this PR is just to push staging file and leave schedule to main.pm for the rest of the groups if we are not sure about creating many test suites.
In fact this is the right solution as this test suite is not in [Y] group but it worths the time investigating the differences which are presented in other scenarios as well.

- Related ticket: https://progress.opensuse.org/issues/51959#change-215345
- Needles: N/A
- Verification run:
  - [sle-15-SP1-Installer-DVD-Staging:A-x86_64-BuildA.249.3-cryptlvm_minimal_x@64bit-staging](https://openqa.suse.de/t2927431)
  - [sle-12-SP5-Server-DVD-Staging:V-x86_64-BuildV.18.7-cryptlvm_minimal_x@64bit-staging](https://openqa.suse.de/t2927432)
  - [sle-15-SP1-Installer-DVD-Staging:H-x86_64-BuildH.194.1-gnome@64bit-staging](https://openqa.suse.de/t2929318)
  - [sle-12-SP5-Server-DVD-Staging:Y-x86_64-BuildY.18.7-gnome@64bit-staging](https://openqa.suse.de/t2929317)