### PR TITLE
yast2-registration: detect time out

### DIFF
--- a/tests/console/yast2_registration.pm
+++ b/tests/console/yast2_registration.pm
@@ -58,7 +58,15 @@ sub run {
     send_key "alt-e" if (match_has_tag "yast2_registration-overview");
     register_system_and_add_extension;
 
-    assert_script_run "SUSEConnect --status-text |grep -A3 -E 'SUSE Linux Enterprise Server|Web and Scripting Module' | grep -qE '^\\s+Registered'";
+    my $ret_val = script_run("SUSEConnect --status-text |grep -A3 -E 'SUSE Linux Enterprise Server|Web and Scripting Module' | grep -qE '^\\s+Registered'", 180);
+    if (defined $ret_val && $ret_val != 0) {
+        # SUSEConnect failed but did not timed out
+        die "SUSEConnect --status-text failed with code $ret_val";
+    }
+    if (!defined $ret_val) {
+        # SUSEConnect timed out and this may happen
+        record_soft_failure "bsc#1136566";
+    }
 }
 
 1;


### PR DESCRIPTION
It may happen that `SUSEConnect` times out under certain conditions (e.g. https://openqa.suse.de/tests/2926775#step/yast2_registration/19 . It can be network issues, heavy load on worker, etc).
This PR makes the test soft fail if the command times out or hard fail if the command fails for a different reason.
- Verification run: http://d250.qam.suse.de/tests/2030 :heavy_check_mark: 