### PR TITLE
Solve fails in aaa_base on /boot/vmlinuz

### DIFF
--- a/tests/console/aaa_base.pm
+++ b/tests/console/aaa_base.pm
@@ -18,6 +18,7 @@ use warnings;
 use testapi;
 
 sub run {
+    select_console 'root-console';
     #create work dir
     assert_script_run "mkdir /tmp/aaa_base_test ; cd /tmp/aaa_base_test; touch test-file.txt ; mkdir test_dir";
 
@@ -25,7 +26,7 @@ sub run {
     assert_script_run "old test-file.txt ; ls -lah test-file*";
     assert_script_run "safe-rm /tmp/aaa_base_test/test-file.txt; ls -lah";
     assert_script_run "safe-rmdir /tmp/aaa_base_test/test_dir; ls -lah";
-    assert_script_run "get_kernel_version /boot/vmlinuz";
+    assert_script_run "get_kernel_version \$(ls /boot/vmlinu*-* | sort | tail -1)";
     assert_script_run "rpmlocate aaa_base";
     assert_script_run "/usr/sbin/sysconf_addword /etc/sysconfig/console CONSOLE_ENCODING ISO-8859-1 ; grep CONSOLE_ENCODING /etc/sysconfig/console";
     assert_script_run "/usr/sbin/sysconf_addword -r /etc/sysconfig/console CONSOLE_ENCODING ISO-8859-1; grep CONSOLE_ENCODING /etc/sysconfig/console";


### PR DESCRIPTION
Solve tests fails in aaa_base on /boot/vmlinuz for PowerPC/aarch64

- Related ticket:
https://progress.opensuse.org/issues/52016
https://progress.opensuse.org/issues/51980

-Results:
SLES 12 SP3 - http://10.161.229.197/tests/692
SLES 12 SP4 - http://10.161.229.197/tests/686
SLEs 15 - http://10.161.229.197/tests/691
SLES 15 SP1 - http://10.161.229.197/tests/685#
Opensuse tw - http://10.161.229.197/tests/69
