### PR TITLE
Wicked: Clean environment of SUT

### DIFF
--- a/data/wicked/ifcfg/tap1_ref
+++ b/data/wicked/ifcfg/tap1_ref
@@ -1,4 +1,4 @@
-STARTMODE='manual'
+STARTMODE='auto'
 BOOTPROTO='static'
 TUNNEL='tap'
 TUNNEL_SET_OWNER='root'

--- a/data/wicked/ifcfg/tap1_sut
+++ b/data/wicked/ifcfg/tap1_sut
@@ -1,4 +1,4 @@
-STARTMODE='manual'
+STARTMODE='auto'
 BOOTPROTO='static'
 TUNNEL='tap'
 TUNNEL_SET_OWNER='root'

--- a/data/wicked/ifcfg/tun1_ref
+++ b/data/wicked/ifcfg/tun1_ref
@@ -1,4 +1,4 @@
-STARTMODE='manual'
+STARTMODE='auto'
 BOOTPROTO='static'
 TUNNEL='tun'
 TUNNEL_SET_OWNER='root'

--- a/data/wicked/ifcfg/tun1_sut
+++ b/data/wicked/ifcfg/tun1_sut
@@ -1,4 +1,4 @@
-STARTMODE='manual'
+STARTMODE='auto'
 BOOTPROTO='static'
 TUNNEL='tun'
 TUNNEL_SET_OWNER='root'

--- a/data/wicked/xml/gre.xml
+++ b/data/wicked/xml/gre.xml
@@ -13,3 +13,12 @@
     </address>
   </ipv4:static>
 </interface>
+
+<interface>
+  <name>iface</name>
+  <ipv4:static>
+    <address>
+      <local>local_ip/15</local>
+    </address>
+  </ipv4:static>
+</interface>

--- a/data/wicked/xml/ipip.xml
+++ b/data/wicked/xml/ipip.xml
@@ -13,3 +13,12 @@
     </address>
   </ipv4:static>
 </interface>
+
+<interface>
+  <name>iface</name>
+  <ipv4:static>
+    <address>
+      <local>local_ip/15</local>
+    </address>
+  </ipv4:static>
+</interface>

--- a/data/wicked/xml/sit.xml
+++ b/data/wicked/xml/sit.xml
@@ -13,3 +13,12 @@
     </address>
   </ipv6:static>
 </interface>
+
+<interface>
+  <name>iface</name>
+  <ipv4:static>
+    <address>
+      <local>local_ip/15</local>
+    </address>
+  </ipv4:static>
+</interface>

--- a/data/wicked/xml/tap.xml
+++ b/data/wicked/xml/tap.xml
@@ -28,3 +28,17 @@
     </address>
   </ipv6:static>
 </interface>
+
+<interface>
+  <name>iface</name>
+  <ipv4:static>
+    <address>
+      <local>host_ip/15</local>
+    </address>
+  </ipv4:static>
+  <ipv6:static>
+    <address>
+      <local>fd00:c0de:ba5e::123/48</local>
+    </address>
+  </ipv6:static>
+</interface>

--- a/data/wicked/xml/tun.xml
+++ b/data/wicked/xml/tun.xml
@@ -28,3 +28,17 @@
     </address>
   </ipv6:static>
 </interface>
+
+<interface>
+  <name>iface</name>
+  <ipv4:static>
+    <address>
+      <local>host_ip/15</local>
+    </address>
+  </ipv4:static>
+  <ipv6:static>
+    <address>
+      <local>fd00:c0de:ba5e::123/48</local>
+    </address>
+  </ipv6:static>
+</interface>

--- a/lib/network_utils.pm
+++ b/lib/network_utils.pm
@@ -58,6 +58,7 @@ sub can_upload_logs {
     return (script_run('ping -c 1 ' . $gw) == 0);
 }
 
+
 =head2 check_and_recover_network
 Recover network with static config if is feasible, returns if can ping GW
 Main use case is post_fail_hook, to be able to upload logs
@@ -65,17 +66,10 @@ accepts following parameters :
 C<ip> => allowing to specify certain IP which would be used for recovery
 in case skiped '10.0.2.15/24' will be used as fallback
 C<gw> => allowing to specify default gateway . Fallback to worker IP in case nothing specified
-C<reset_wicked> => wipe out all extra configuration in network folder . Currently only environments
-managed by wicked is supported
 =cut
 sub recover_network {
     my (%args) = @_;
 
-    if ($args{reset_wicked}) {
-        script_run('find /etc/sysconfig/network/ -name "ifcfg-*" | grep -v "ifcfg-lo" | xargs rm');
-        script_run('rcwickedd restart');
-        script_run('rcwicked restart');
-    }
     # We set static setup just to upload logs, so no permament setup
     # Set default values
     $args{ip} //= '10.0.2.15/24';

--- a/tests/wicked/advanced/sut/t01_gre_tunnel_legacy.pm
+++ b/tests/wicked/advanced/sut/t01_gre_tunnel_legacy.pm
@@ -19,11 +19,12 @@ use warnings;
 use testapi;
 
 sub run {
-    my ($self) = @_;
+    my ($self, $ctx) = @_;
     my $config = '/etc/sysconfig/network/ifcfg-gre1';
     record_info('Info', 'Create a GRE interface from legacy ifcfg files');
-    $self->get_from_data('wicked/ifcfg/gre1', $config);
-    $self->setup_tunnel($config, 'gre1');
+    $self->get_from_data('wicked/static_address/ifcfg-eth0', '/etc/sysconfig/network/ifcfg-' . $ctx->iface());
+    $self->get_from_data('wicked/ifcfg/gre1',                $config);
+    $self->setup_tunnel($config, 'gre1', $ctx->iface());
     my $res = $self->get_test_result('gre1');
     die if ($res eq 'FAILED');
 }

--- a/tests/wicked/advanced/sut/t02_gre_tunnel_xml.pm
+++ b/tests/wicked/advanced/sut/t02_gre_tunnel_xml.pm
@@ -19,11 +19,11 @@ use warnings;
 use testapi;
 
 sub run {
-    my ($self) = @_;
+    my ($self, $ctx) = @_;
     my $config = '/etc/wicked/ifconfig/gre.xml';
     record_info('Info', 'Create a GRE interface from wicked XML files');
     $self->get_from_data('wicked/xml/gre.xml', $config);
-    $self->setup_tunnel($config, 'gre1');
+    $self->setup_tunnel($config, 'gre1', $ctx->iface());
     my $res = $self->get_test_result('gre1');
     die if ($res eq 'FAILED');
 }

--- a/tests/wicked/advanced/sut/t03_sit_tunnel_legacy.pm
+++ b/tests/wicked/advanced/sut/t03_sit_tunnel_legacy.pm
@@ -19,11 +19,12 @@ use warnings;
 use testapi;
 
 sub run {
-    my ($self) = @_;
+    my ($self, $ctx) = @_;
     my $config = '/etc/sysconfig/network/ifcfg-sit1';
     record_info('Info', 'Create a SIT interface from legacy ifcfg files');
-    $self->get_from_data('wicked/ifcfg/sit1', $config);
-    $self->setup_tunnel($config, 'sit1');
+    $self->get_from_data('wicked/static_address/ifcfg-eth0', '/etc/sysconfig/network/ifcfg-' . $ctx->iface());
+    $self->get_from_data('wicked/ifcfg/sit1',                $config);
+    $self->setup_tunnel($config, 'sit1', $ctx->iface());
     my $res = $self->get_test_result('sit1', 'v6');
     die if ($res eq 'FAILED');
 }

--- a/tests/wicked/advanced/sut/t04_sit_tunnel_xml.pm
+++ b/tests/wicked/advanced/sut/t04_sit_tunnel_xml.pm
@@ -19,11 +19,11 @@ use warnings;
 use testapi;
 
 sub run {
-    my ($self) = @_;
+    my ($self, $ctx) = @_;
     my $config = '/etc/wicked/ifconfig/sit.xml';
     record_info('Info', 'Create a SIT interface from Wicked XML files');
     $self->get_from_data('wicked/xml/sit.xml', $config);
-    $self->setup_tunnel($config, 'sit1');
+    $self->setup_tunnel($config, 'sit1', $ctx->iface());
     my $res = $self->get_test_result('sit1', 'v6');
     die if ($res eq 'FAILED');
 }

--- a/tests/wicked/advanced/sut/t05_ipip_tunnel_legacy.pm
+++ b/tests/wicked/advanced/sut/t05_ipip_tunnel_legacy.pm
@@ -19,11 +19,12 @@ use warnings;
 use testapi;
 
 sub run {
-    my ($self) = @_;
+    my ($self, $ctx) = @_;
     my $config = '/etc/sysconfig/network/ifcfg-tunl1';
     record_info('Info', 'Create a IPIP  interface from legacy ifcfg files');
-    $self->get_from_data('wicked/ifcfg/tunl1', $config);
-    $self->setup_tunnel($config, 'tunl1');
+    $self->get_from_data('wicked/static_address/ifcfg-eth0', '/etc/sysconfig/network/ifcfg-' . $ctx->iface());
+    $self->get_from_data('wicked/ifcfg/tunl1',               $config);
+    $self->setup_tunnel($config, 'tunl1', $ctx->iface());
     my $res = $self->get_test_result('tunl1');
     die if ($res eq 'FAILED');
 }

--- a/tests/wicked/advanced/sut/t06_ipip_tunnel_xml.pm
+++ b/tests/wicked/advanced/sut/t06_ipip_tunnel_xml.pm
@@ -19,11 +19,11 @@ use warnings;
 use testapi;
 
 sub run {
-    my ($self) = @_;
+    my ($self, $ctx) = @_;
     my $config = '/etc/wicked/ifconfig/ipip.xml';
     record_info('Info', 'Create a IPIP interface from Wicked XML files');
     $self->get_from_data('wicked/xml/ipip.xml', $config);
-    $self->setup_tunnel($config, 'tunl1');
+    $self->setup_tunnel($config, 'tunl1', $ctx->iface());
     my $res = $self->get_test_result('tunl1');
     die if ($res eq 'FAILED');
 }

--- a/tests/wicked/advanced/sut/t07_tun_interface_legacy.pm
+++ b/tests/wicked/advanced/sut/t07_tun_interface_legacy.pm
@@ -19,12 +19,13 @@ use warnings;
 use testapi;
 
 sub run {
-    my ($self) = @_;
+    my ($self, $ctx) = @_;
     my $config = '/etc/sysconfig/network/ifcfg-tun1';
     record_info('Info', 'Create a tun interface from legacy ifcfg files');
-    $self->get_from_data('wicked/ifcfg/tun1_sut', $config);
+    $self->get_from_data('wicked/static_address/ifcfg-eth0', '/etc/sysconfig/network/ifcfg-' . $ctx->iface());
+    $self->get_from_data('wicked/ifcfg/tun1_sut',            $config);
     $self->setup_openvpn_client('tun1');
-    $self->setup_tuntap($config, 'tun1');
+    $self->setup_tuntap($config, 'tun1', $ctx->iface());
     my $res = $self->get_test_result('tun1');
     die if ($res eq 'FAILED');
 }

--- a/tests/wicked/advanced/sut/t08_tun_interface_xml.pm
+++ b/tests/wicked/advanced/sut/t08_tun_interface_xml.pm
@@ -19,12 +19,12 @@ use warnings;
 use testapi;
 
 sub run {
-    my ($self) = @_;
+    my ($self, $ctx) = @_;
     my $config = '/etc/wicked/ifconfig/tun.xml';
     record_info('Info', 'Create a tun interface from Wicked XML files');
     $self->get_from_data('wicked/xml/tun.xml', $config);
     $self->setup_openvpn_client('tun1');
-    $self->setup_tuntap($config, 'tun1');
+    $self->setup_tuntap($config, 'tun1', $ctx->iface());
     my $res = $self->get_test_result('tun1');
     die if ($res eq 'FAILED');
 }

--- a/tests/wicked/advanced/sut/t09_tap_interface_legacy.pm
+++ b/tests/wicked/advanced/sut/t09_tap_interface_legacy.pm
@@ -19,12 +19,13 @@ use warnings;
 use testapi;
 
 sub run {
-    my ($self) = @_;
+    my ($self, $ctx) = @_;
     my $config = '/etc/sysconfig/network/ifcfg-tap1';
     record_info('Info', 'Create a tap interface from legacy ifcfg files');
-    $self->get_from_data('wicked/ifcfg/tap1_sut', $config);
+    $self->get_from_data('wicked/static_address/ifcfg-eth0', '/etc/sysconfig/network/ifcfg-' . $ctx->iface());
+    $self->get_from_data('wicked/ifcfg/tap1_sut',            $config);
     $self->setup_openvpn_client('tap1');
-    $self->setup_tuntap($config, 'tap1');
+    $self->setup_tuntap($config, 'tap1', $ctx->iface());
     my $res = $self->get_test_result('tap1');
     die if ($res eq 'FAILED');
 }

--- a/tests/wicked/advanced/sut/t10_tap_interface_xml.pm
+++ b/tests/wicked/advanced/sut/t10_tap_interface_xml.pm
@@ -19,12 +19,12 @@ use warnings;
 use testapi;
 
 sub run {
-    my ($self) = @_;
+    my ($self, $ctx) = @_;
     my $config = '/etc/wicked/ifconfig/tap.xml';
     record_info('Info', 'Create a tap interface from Wicked XML files');
     $self->get_from_data('wicked/xml/tap.xml', $config);
     $self->setup_openvpn_client('tap1');
-    $self->setup_tuntap($config, 'tap1');
+    $self->setup_tuntap($config, 'tap1', $ctx->iface());
     my $res = $self->get_test_result('tap1');
     die if ($res eq 'FAILED');
 }

--- a/tests/wicked/advanced/sut/t11_bridge_interface_legacy.pm
+++ b/tests/wicked/advanced/sut/t11_bridge_interface_legacy.pm
@@ -19,12 +19,13 @@ use warnings;
 use testapi;
 
 sub run {
-    my ($self) = @_;
+    my ($self, $ctx) = @_;
     my $config = '/etc/sysconfig/network/ifcfg-br0';
     my $dummy  = '/etc/sysconfig/network/ifcfg-dummy0';
     record_info('Info', 'Create Bridge interface from legacy ifcfg files');
-    $self->get_from_data('wicked/ifcfg/br0',    $config);
-    $self->get_from_data('wicked/ifcfg/dummy0', $dummy);
+    $self->get_from_data('wicked/static_address/ifcfg-eth0', '/etc/sysconfig/network/ifcfg-' . $ctx->iface());
+    $self->get_from_data('wicked/ifcfg/br0',                 $config);
+    $self->get_from_data('wicked/ifcfg/dummy0',              $dummy);
     $self->setup_bridge($config, $dummy, 'ifup');
     my $res = $self->get_test_result('br0');
     die if ($res eq 'FAILED');

--- a/tests/wicked/advanced/sut/t12_bridge_interface_xml.pm
+++ b/tests/wicked/advanced/sut/t12_bridge_interface_xml.pm
@@ -23,8 +23,6 @@ sub run {
     my $config = '/etc/wicked/ifconfig/bridge.xml';
     record_info('Info', 'Create a Bridge interface from Wicked XML files');
     $self->get_from_data('wicked/xml/bridge.xml', $config);
-    assert_script_run('ifdown ' . $ctx->iface());
-    assert_script_run('rm /etc/sysconfig/network/ifcfg-' . $ctx->iface());
     $self->setup_bridge($config, '', 'ifup');
     my $res = $self->get_test_result('br0');
     die if ($res eq 'FAILED');

--- a/tests/wicked/advanced/sut/t13_ovs_bridge_legacy.pm
+++ b/tests/wicked/advanced/sut/t13_ovs_bridge_legacy.pm
@@ -17,14 +17,17 @@ use base 'wickedbase';
 use strict;
 use warnings;
 use testapi;
+use utils 'systemctl';
 
 sub run {
-    my ($self) = @_;
+    my ($self, $ctx) = @_;
     my $config = '/etc/sysconfig/network/ifcfg-br0';
     my $dummy  = '/etc/sysconfig/network/ifcfg-dummy0';
     record_info('Info', 'Create OVS Bridge interface from legacy ifcfg files');
-    $self->get_from_data('wicked/ifcfg/ovsbr0', $config);
-    $self->get_from_data('wicked/ifcfg/dummy0', $dummy);
+    systemctl('start openvswitch');
+    $self->get_from_data('wicked/static_address/ifcfg-eth0', '/etc/sysconfig/network/ifcfg-' . $ctx->iface());
+    $self->get_from_data('wicked/ifcfg/ovsbr0',              $config);
+    $self->get_from_data('wicked/ifcfg/dummy0',              $dummy);
     $self->setup_bridge($config, $dummy, 'ifup');
     record_info('INFO', script_output('ovs-vsctl show'));
     my $res = $self->get_test_result('br0');

--- a/tests/wicked/advanced/sut/t14_ovs_bridge_xml.pm
+++ b/tests/wicked/advanced/sut/t14_ovs_bridge_xml.pm
@@ -17,14 +17,14 @@ use base 'wickedbase';
 use strict;
 use warnings;
 use testapi;
+use utils 'systemctl';
 
 sub run {
     my ($self, $ctx) = @_;
     my $config = '/etc/wicked/ifconfig/ovs-bridge.xml';
     record_info('Info', 'Create a Bridge interface from Wicked XML files');
+    systemctl('start openvswitch');
     $self->get_from_data('wicked/xml/ovs-bridge.xml', $config);
-    assert_script_run('ifdown ' . $ctx->iface());
-    assert_script_run('rm /etc/sysconfig/network/ifcfg-' . $ctx->iface());
     $self->setup_bridge($config, '', 'ifup');
     record_info('INFO', script_output('ovs-vsctl show'));
     my $res = $self->get_test_result('br0');

--- a/tests/wicked/advanced/sut/t16_macvtap_xml.pm
+++ b/tests/wicked/advanced/sut/t16_macvtap_xml.pm
@@ -17,7 +17,6 @@ use base 'wickedbase';
 use strict;
 use warnings;
 use testapi;
-use utils 'zypper_call';
 
 our $macvtap_log = '/tmp/macvtap_results.txt';
 

--- a/tests/wicked/advanced/sut/t20_team_interface_xml.pm
+++ b/tests/wicked/advanced/sut/t20_team_interface_xml.pm
@@ -28,7 +28,6 @@ sub run {
     record_info('Info', 'Create a team interface from wicked XML files');
 
     $self->get_from_data('wicked/xml/teaming.xml', $cfg_team0);
-    assert_script_run('rm /etc/sysconfig/network/ifcfg-*');
     file_content_replace($cfg_team0, ipaddr4 => $self->get_ip(type => 'host', netmask => 1), ipaddr6 => $self->get_ip(type => 'host6', netmask => 1), iface0 => $ctx->iface(), iface1 => $ctx->iface2());
 
     $self->wicked_command('ifup', 'team0');

--- a/tests/wicked/basic/ref/t08_setup_second_card.pm
+++ b/tests/wicked/basic/ref/t08_setup_second_card.pm
@@ -22,6 +22,7 @@ use lockapi;
 sub run {
     my ($self, $ctx) = @_;
     record_info('Info', 'Set up a second card');
+    assert_script_run(sprintf("ip a a %s/15 dev %s", $self->get_ip(type => 'second_card'), $ctx->iface()));
     systemctl 'stop dhcpd.service';
     $self->get_from_data('wicked/dhcp/dhcpd_2nics.conf', '/etc/dhcpd.conf');
     systemctl 'start dhcpd.service';

--- a/tests/wicked/basic/sut/t01_basic.pm
+++ b/tests/wicked/basic/sut/t01_basic.pm
@@ -29,6 +29,8 @@ use utils qw(systemctl arrays_differ);
 
 sub run {
     my ($self, $ctx) = @_;
+    $self->get_from_data("wicked/dynamic_address/ifcfg-eth0", '/etc/sysconfig/network/ifcfg-' . $ctx->iface());
+
     record_info('Test 1', 'Bring down the wicked client service');
     systemctl('stop wicked.service');
     $self->assert_wicked_state(wicked_client_down => 1, interfaces_down => 1, iface => $ctx->iface());
@@ -59,7 +61,7 @@ sub run {
     die if ($self->get_current_ip($ctx->iface()));
     record_info('Test 7', 'Bring an interface up with wicked');
     $self->wicked_command('ifup', $ctx->iface());
-    $self->ping_with_timeout(ip => '10.0.2.2');
+    $self->ping_with_timeout(type => 'host', interface => $ctx->iface());
     validate_script_output('ip address show dev ' . $ctx->iface(), sub { m/inet/g; });
     validate_script_output('wicked show dev ' . $ctx->iface(),     sub { m/\[dhcp\]/g; });
 }

--- a/tests/wicked/basic/sut/t02_static_addresses_legacy.pm
+++ b/tests/wicked/basic/sut/t02_static_addresses_legacy.pm
@@ -23,7 +23,7 @@ sub run {
     record_info('Info', 'Set up static addresses from legacy ifcfg files');
     $self->get_from_data('wicked/static_address/ifcfg-eth0', '/etc/sysconfig/network/ifcfg-' . $ctx->iface());
     $self->wicked_command('ifup', $ctx->iface());
-    $self->assert_wicked_state(ping_ip => '10.0.2.2', iface => $ctx->iface());
+    $self->assert_wicked_state(ping_ip => $self->get_remote_ip(type => 'host'), iface => $ctx->iface());
 }
 
 sub test_flags {

--- a/tests/wicked/basic/sut/t03_static_addresses_xml.pm
+++ b/tests/wicked/basic/sut/t03_static_addresses_xml.pm
@@ -26,7 +26,7 @@ sub run {
     $self->get_from_data('wicked/static_address/static-addresses.xml', $config);
     file_content_replace($config, '--sed-modifier' => 'g', xxx => $ctx->iface());
     $self->wicked_command('ifup --ifconfig /data/static_address/static-addresses.xml', $ctx->iface());
-    $self->assert_wicked_state(ping_ip => '10.0.2.2', iface => $ctx->iface());
+    $self->assert_wicked_state(ping_ip => $self->get_remote_ip(type => 'host'), iface => $ctx->iface());
 }
 
 sub test_flags {

--- a/tests/wicked/basic/sut/t04_dynamic_addresses_legacy.pm
+++ b/tests/wicked/basic/sut/t04_dynamic_addresses_legacy.pm
@@ -23,7 +23,7 @@ sub run {
     record_info('Info', 'Set up dynamic addresses from legacy ifcfg files');
     $self->get_from_data('wicked/dynamic_address/ifcfg-eth0', '/etc/sysconfig/network/ifcfg-' . $ctx->iface());
     $self->wicked_command('ifup', $ctx->iface());
-    $self->assert_wicked_state(ping_ip => '10.0.2.2', iface => $ctx->iface());
+    $self->assert_wicked_state(ping_ip => $self->get_remote_ip(type => 'host'), iface => $ctx->iface());
 }
 
 sub test_flags {

--- a/tests/wicked/basic/sut/t05_dynamic_addresses_xml.pm
+++ b/tests/wicked/basic/sut/t05_dynamic_addresses_xml.pm
@@ -26,7 +26,7 @@ sub run {
     $self->get_from_data('wicked/dynamic_address/dynamic-addresses.xml', $config);
     file_content_replace($config, '--sed-modifier' => 'g', xxx => $ctx->iface());
     $self->wicked_command('ifup --ifconfig /data/dynamic_address/dynamic-addresses.xml', $ctx->iface());
-    $self->assert_wicked_state(ping_ip => '10.0.2.2', iface => $ctx->iface());
+    $self->assert_wicked_state(ping_ip => $self->get_remote_ip(type => 'host'), iface => $ctx->iface());
 }
 
 sub test_flags {

--- a/tests/wicked/basic/sut/t06_static_routes_legacy.pm
+++ b/tests/wicked/basic/sut/t06_static_routes_legacy.pm
@@ -24,7 +24,7 @@ sub run {
     $self->get_from_data('wicked/static_address/ifcfg-eth0',   '/etc/sysconfig/network/ifcfg-' . $ctx->iface());
     $self->get_from_data('wicked/static_address/ifroute-eth0', '/etc/sysconfig/network/ifroute-' . $ctx->iface());
     $self->wicked_command('ifup', $ctx->iface());
-    $self->assert_wicked_state(ping_ip => '10.0.2.2', iface => $ctx->iface());
+    $self->assert_wicked_state(ping_ip => $self->get_remote_ip(type => 'host'), iface => $ctx->iface());
     validate_script_output("ip -4 route show", sub { m/default via 10\.0\.2\.2/ });
     assert_script_run('ip -4 route show | grep "default" | grep -v "via' . $ctx->iface() . '"');
     validate_script_output("ip -6 route show", sub { m/default via fd00:cafe:babe::1/ });

--- a/tests/wicked/basic/sut/t07_static_routes_xml.pm
+++ b/tests/wicked/basic/sut/t07_static_routes_xml.pm
@@ -26,7 +26,7 @@ sub run {
     $self->get_from_data('wicked/static_address/static-addresses-and-routes.xml', $config);
     file_content_replace($config, '--sed-modifier' => 'g', xxx => $ctx->iface());
     $self->wicked_command('ifup --ifconfig /data/static_address/static-addresses-and-routes.xml', $ctx->iface());
-    $self->assert_wicked_state(ping_ip => '10.0.2.2', iface => $ctx->iface());
+    $self->assert_wicked_state(ping_ip => $self->get_remote_ip(type => 'host'), iface => $ctx->iface());
 }
 
 sub test_flags {

--- a/tests/wicked/basic/sut/t08_setup_second_card.pm
+++ b/tests/wicked/basic/sut/t08_setup_second_card.pm
@@ -25,7 +25,6 @@ sub run {
     record_info('Info', 'Set up a second card');
     $self->get_from_data('wicked/dynamic_address/ifcfg-eth0', $cfg_ifc1);
     $self->get_from_data('wicked/static_address/ifcfg-eth0',  $cfg_ifc2);
-    $self->wicked_command('ifdown', 'all');
     mutex_wait('t08_dhcpd_setup_complete');
     $self->wicked_command('ifup', $ctx->iface());
     $self->wicked_command('ifup', $ctx->iface2());

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -44,37 +44,19 @@ sub run {
     $self->download_data_dir();
 
     if (check_var('IS_WICKED_REF', '1')) {
+        # Common REF Configuration
         record_info('INFO', 'Setup DHCP server');
-        zypper_call('--quiet in dhcp-server', timeout => 200);
+        zypper_call('--quiet in dhcp-server openvpn', timeout => 200);
         $self->get_from_data('wicked/dhcp/dhcpd.conf', '/etc/dhcpd.conf');
-        if (check_var('WICKED', 'basic') || check_var('WICKED', '2nics')) {
-            assert_script_run(sprintf("ip a a %s dev %s", $self->get_ip(type => 'second_card'), $ctx->iface()));
-        }
         file_content_replace('/etc/sysconfig/dhcpd', '--sed-modifier' => 'g', '^DHCPD_INTERFACE=.*' => 'DHCPD_INTERFACE="' . $ctx->iface() . '"');
         systemctl 'enable dhcpd.service';
         systemctl 'start dhcpd.service';
-    }
-    if (check_var('WICKED', 'basic')) {
-        assert_script_run("rcwickedd restart");
-        unless (get_var('IS_WICKED_REF')) {
-            # Remove previous static config and leave dynamic one, only for SUT
-            assert_script_run('rm /etc/sysconfig/network/ifcfg-' . $ctx->iface());
-            $self->get_from_data("wicked/dynamic_address/ifcfg-eth0", '/etc/sysconfig/network/ifcfg-' . $ctx->iface());
-        }
-    }
-    elsif (check_var('WICKED', 'advanced') || check_var('WICKED', 'startandstop')) {
-        assert_script_run("rcwickedd restart");
-        record_info('INFO', 'Setup OpenVPN');
-        zypper_call('--quiet in openvpn', timeout => 200);
-        if (check_var('WICKED', 'advanced')) {
-            record_info('INFO', 'Setup OVS');
-            zypper_call('--quiet in openvswitch libteam-tools libteamdctl0 python-libteam', timeout => 200);
-            assert_script_run("systemctl start openvswitch");
-        }
-    }
-    elsif (check_var('WICKED', '2nics')) {
-        assert_script_run('rm /etc/sysconfig/network/ifcfg-' . $ctx->iface());
-        assert_script_run("rcwickedd restart");
+    } else {
+        # Common SUT Configuration
+        my $package_list = 'openvswitch openvpn';
+        $package_list .= ' libteam-tools libteamdctl0 python-libteam gcc' if check_var('WICKED', 'advanced');
+        zypper_call('-q in ' . $package_list, timeout => 400);
+        $self->reset_wicked();
     }
 }
 

--- a/tests/wicked/startandstop/sut/t04_bridge_ifup_remove_all_config_ifreload.pm
+++ b/tests/wicked/startandstop/sut/t04_bridge_ifup_remove_all_config_ifreload.pm
@@ -20,12 +20,14 @@ use network_utils 'ifc_exists';
 
 sub run {
     my ($self, $ctx) = @_;
+    my $iface  = '/etc/sysconfig/network/ifcfg-' . $ctx->iface();
     my $config = '/etc/sysconfig/network/ifcfg-br0';
     my $dummy  = '/etc/sysconfig/network/ifcfg-dummy0';
-    $self->get_from_data('wicked/ifcfg/br0',    $config);
-    $self->get_from_data('wicked/ifcfg/dummy0', $dummy);
+    $self->get_from_data('wicked/teaming/ifcfg-eth0', $iface);
+    $self->get_from_data('wicked/ifcfg/br0',          $config);
+    $self->get_from_data('wicked/ifcfg/dummy0',       $dummy);
     $self->setup_bridge($config, $dummy, 'ifup');
-    assert_script_run('rm /etc/sysconfig/network/ifcfg-' . $ctx->iface() . " $config $dummy");
+    assert_script_run("rm $iface $config $dummy");
     $self->wicked_command('ifreload', 'all');
     die if (ifc_exists('dummy0') || ifc_exists('br0'));
 }

--- a/tests/wicked/startandstop/sut/t07_bridge_ifdown_remove_one_config_ifreload_ifdown_ifup.pm
+++ b/tests/wicked/startandstop/sut/t07_bridge_ifdown_remove_one_config_ifreload_ifdown_ifup.pm
@@ -20,12 +20,13 @@ use network_utils 'ifc_exists';
 
 sub run {
     my ($self, $ctx) = @_;
+    my $iface  = '/etc/sysconfig/network/ifcfg-' . $ctx->iface();
     my $config = '/etc/sysconfig/network/ifcfg-br0';
     my $dummy  = '/etc/sysconfig/network/ifcfg-dummy0';
     my $res;
-    $config = '/etc/sysconfig/network/ifcfg-br0';
-    $self->get_from_data('wicked/ifcfg/br0',    $config);
-    $self->get_from_data('wicked/ifcfg/dummy0', $dummy);
+    $self->get_from_data('wicked/dynamic_address/ifcfg-eth0', $iface);
+    $self->get_from_data('wicked/ifcfg/br0',                  $config);
+    $self->get_from_data('wicked/ifcfg/dummy0',               $dummy);
     $self->setup_bridge($config, $dummy, 'ifup');
     $self->wicked_command('ifdown', 'br0');
     $self->wicked_command('ifdown', 'dummy0');

--- a/tests/wicked/startandstop/sut/t08_sit_tunnel_ifdown.pm
+++ b/tests/wicked/startandstop/sut/t08_sit_tunnel_ifdown.pm
@@ -19,9 +19,11 @@ use testapi;
 use network_utils 'ifc_exists';
 
 sub run {
-    my ($self) = @_;
+    my ($self, $ctx) = @_;
+    my $iface  = '/etc/sysconfig/network/ifcfg-' . $ctx->iface();
     my $config = '/etc/sysconfig/network/ifcfg-sit1';
-    $self->get_from_data('wicked/ifcfg/sit1', $config);
+    $self->get_from_data('wicked/static_address/ifcfg-eth0', $iface);
+    $self->get_from_data('wicked/ifcfg/sit1',                $config);
     $self->setup_tunnel($config, 'sit1');
     if ($self->get_test_result('sit1', 'v6') ne 'FAILED') {
         $self->wicked_command('ifdown', 'sit1');

--- a/tests/wicked/startandstop/sut/t09_openvpn_tunnel_ifdown.pm
+++ b/tests/wicked/startandstop/sut/t09_openvpn_tunnel_ifdown.pm
@@ -19,9 +19,11 @@ use testapi;
 use network_utils 'ifc_exists';
 
 sub run {
-    my ($self) = @_;
+    my ($self, $ctx) = @_;
+    my $iface  = '/etc/sysconfig/network/ifcfg-' . $ctx->iface();
     my $config = '/etc/sysconfig/network/ifcfg-tun1';
-    $self->get_from_data('wicked/ifcfg/tun1_sut', $config);
+    $self->get_from_data('wicked/static_address/ifcfg-eth0', $iface);
+    $self->get_from_data('wicked/ifcfg/tun1_sut',            $config);
     $self->setup_openvpn_client('tun1');
     $self->setup_tuntap($config, 'tun1');
     die if ($self->get_test_result('tun1') eq 'FAILED');

--- a/tests/wicked/startandstop/sut/t10_vlan_ifup_all_ifdown_one_card.pm
+++ b/tests/wicked/startandstop/sut/t10_vlan_ifup_all_ifdown_one_card.pm
@@ -25,12 +25,14 @@ sub run {
     $self->get_from_data('wicked/ifcfg/eth0.42', $config);
     file_content_replace($config, interface => $ctx->iface(), ip_address => $self->get_ip(type => 'vlan', netmask => 1));
     $self->wicked_command('ifup', 'all');
-    assert_script_run('ip a');
     die if (!ifc_exists($ctx->iface() . '.42'));
     $self->wicked_command('ifdown', $ctx->iface() . '.42');
     die if (ifc_exists($ctx->iface() . '.42'));
     die if (!ifc_exists($ctx->iface()));
 }
 
+sub test_flags {
+    return {always_rollback => 1};
+}
 
 1;

--- a/tests/wicked/startandstop/sut/t11_vlan_ifdown_modify_one_config.pm
+++ b/tests/wicked/startandstop/sut/t11_vlan_ifdown_modify_one_config.pm
@@ -21,11 +21,12 @@ use utils 'file_content_replace';
 
 sub run {
     my ($self, $ctx) = @_;
-    my $config      = '/etc/sysconfig/network/ifcfg-' . $ctx->iface() . '.42';
-    my $previous_ip = $self->get_ip(type => 'vlan', netmask => 1);
-    file_content_replace($config, $previous_ip => $self->get_ip(type => 'vlan_changed', netmask => 1));
+    my $config = '/etc/sysconfig/network/ifcfg-' . $ctx->iface() . '.42';
+    $self->get_from_data('wicked/ifcfg/eth0.42', $config);
+    file_content_replace($config, interface => $ctx->iface(), ip_address => $self->get_ip(type => 'vlan_changed', netmask => 1));
+    $self->wicked_command('ifup',     'all');
+    $self->wicked_command('ifdown',   $ctx->iface() . '.42');
     $self->wicked_command('ifreload', 'all');
-    assert_script_run('ip a');
     die('VLAN interface does not exists') unless ifc_exists($ctx->iface() . '.42');
     $self->ping_with_timeout(type => 'vlan_changed', timeout => '50');
     $self->wicked_command('ifdown', "all");


### PR DESCRIPTION
We need to leave SUT untouched and without network configured at the beginning of each test. 

The legacy suite says:
```
  Background:
    When the reference machine is set up correctly
    And the system under test is set up correctly     <--------
    And there is no core dump
    And the network services are started
    And the interfaces are in a basic state     <--------
    And the routing table is empty   
    And there is no virtual interface left on any machine
```


According to [L69](https://github.com/openSUSE/wicked-testsuite/blob/master/features/step_definitions/wicked_sanity.rb#L69)  and [L107](https://github.com/openSUSE/wicked-testsuite/blob/master/features/step_definitions/wicked_sanity.rb#L107)
- no ifcfg-* files present
- no ifroute-* files present
- eth0 and eth1 should be down


VF on OSD:
Basic suite: https://openqa.suse.de/tests/2934084
Advanced suite: https://openqa.suse.de/tests/2934159
Startandstop suite: https://openqa.suse.de/tests/2934161