### PR TITLE
LTP: Install attr package

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -98,6 +98,7 @@ sub install_runtime_dependencies {
 
 sub install_debugging_tools {
     my @maybe_deps = qw(
+      attr
       gdb
       ltrace
       strace


### PR DESCRIPTION
Useful for attributes debugging (getfattr)

Verification run:
* install_ltp+sle+15-SP1+Installer-DVD@64bit
http://quasar.suse.cz/tests/2827
* install_ltp+opensuse+DVD@64bit
http://quasar.suse.cz/tests/2826