### PR TITLE
yast2_http: upload apache2 logs on failure

### DIFF
--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -127,4 +127,11 @@ sub run {
     wait_serial("$module_name-0", 240) || die "'yast2 http-server' didn't finish";
 }
 
+sub post_fail_hook {
+    my ($self) = @_;
+    select_console 'log-console';
+    $self->save_and_upload_systemd_unit_log('apache2');
+    $self->SUPER::post_fail_hook;
+}
+
 1;


### PR DESCRIPTION
- Verification run: https://openqa.opensuse.org/t944783