### PR TITLE
openqa: test_results: Do not hit 'f5' too early

### DIFF
--- a/tests/openqa/webui/test_results.pm
+++ b/tests/openqa/webui/test_results.pm
@@ -50,6 +50,9 @@ sub run {
     }
     assert_and_click 'openqa-job-minimalx';
 
+    # Do not hit 'f5' too early
+    wait_still_screen;
+
     # wait for result
     for (1 .. 5) {
         send_key 'f5';


### PR DESCRIPTION
- Verification run: https://openqa.opensuse.org/t944480
