### PR TITLE
wicked: Upload files via serial console

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -18,6 +18,7 @@ use version_utils qw(is_hyperv_in_gui is_sle is_leap is_svirt_except_s390x is_tu
 use x11utils qw(desktop_runner_hotkey ensure_unlocked_desktop);
 use Utils::Backends 'use_ssh_serial_console';
 use backend::svirt qw(SERIAL_TERMINAL_DEFAULT_DEVICE SERIAL_TERMINAL_DEFAULT_PORT);
+use Cwd;
 
 =head1 SUSEDISTRIBUTION
 
@@ -424,6 +425,9 @@ sub init_consoles {
 
     if (check_var('BACKEND', 'qemu')) {
         $self->add_console('root-virtio-terminal', 'virtio-terminal', {});
+        for (my $num = 1; $num < get_var('VIRTIO_CONSOLE_NUM', 1); $num++) {
+            $self->add_console('root-virtio-terminal' . $num, 'virtio-terminal', {socked_path => cwd() . '/virtio_console' . $num});
+        }
     }
 
     # svirt backend, except s390x ARCH

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -16,10 +16,12 @@ use warnings;
 use testapi;
 use utils qw(zypper_call systemctl file_content_replace);
 use network_utils qw(iface setup_static_network);
+use serial_terminal 'add_serial_console';
 
 sub run {
     my ($self, $ctx) = @_;
     $self->select_serial_terminal;
+    add_serial_console('hvc1') if (get_var('VIRTIO_CONSOLE_NUM', 1) > 1);
     my @ifaces = split(' ', iface(2));
     die("Missing at least one interface") unless (@ifaces);
     $ctx->iface($ifaces[0]);


### PR DESCRIPTION
In wicked testsuites, we often have the case, that we would like to transfer files between worker and SUT without having a working network connection network.
We are using a second virtio-terminal for it by adding `VIRTIO_CONSOLE_NUM=2`.

This PR needs following changes deployed:
 - https://github.com/os-autoinst/os-autoinst/pull/1151
 - https://github.com/os-autoinst/os-autoinst/pull/1156

- Related ticket: https://progress.opensuse.org/issues/51098
- Verification run: http://cfconrad-vm.qa.suse.de/tests/4666
