### PR TITLE
Disable soft-failure for bsc#1079399 on storage-ng

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -211,7 +211,9 @@ sub addpart {
     if ($args{fsid}) {                                        # $args{fsid} will describe needle tag below
         send_key 'alt-i';                                     # select File system ID
         send_key 'home';                                      # start from the top of the list
-        if ($args{role} eq 'raw' && !check_var('VIDEOMODE', 'text')) {
+
+        # Bug is applicable for pre storage-ng only
+        if ($args{role} eq 'raw' && !check_var('VIDEOMODE', 'text') && !is_storage_ng()) {
             record_soft_failure('bsc#1079399 - Combobox is writable');
             for (1 .. 10) { send_key 'up'; }
         }


### PR DESCRIPTION
This bug is relevant for the old storage stack only, so should not be
reported against SLE 15, TW and Leap 15.

See [poo#51026](https://progress.opensuse.org/issues/51026).

[Verification run](http://f174.suse.de/tests/229).
