### PR TITLE
Update install step to test by system default binary

### DIFF
--- a/tests/btrfs-progs/install.pm
+++ b/tests/btrfs-progs/install.pm
@@ -29,14 +29,7 @@ sub log_create {
 
 sub install_dependencies {
     my @deps = qw(
-      autoconf
-      automake
-      python3-devel
-      lzo-devel
       git-core
-      gcc
-      libblkid-devel
-      zlib-devel
     );
     zypper_call('in ' . join(' ', @deps));
 }
@@ -48,11 +41,8 @@ sub run {
     # Install btrfs-progs
     install_dependencies;
     assert_script_run("git clone -q --depth 1 $git_url", timeout => 360);
-    assert_script_run 'cd btrfs-progs';
-    assert_script_run './autogen.sh';
-    assert_script_run './configure --disable-documentation --disable-convert --disable-zstd';
-    assert_script_run 'make', timeout => 1200;
-    assert_script_run 'cd tests';
+    assert_script_run 'cd btrfs-progs/tests';
+    assert_script_run 'cp $(which btrfs)* ..';
 
     # Create log file
     log_create($STATUS_LOG);


### PR DESCRIPTION
 Update install step to test by system default binary, such as btrfs, btrfs-image, btrfs-convert, but not which build with upstream code

- Related ticket: https://progress.opensuse.org/issues/50828
- Verification run: http://10.67.133.10/tests/341
