### PR TITLE
Don't start patch_and_reboot in REGRESSION gnome

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2000,7 +2000,6 @@ sub load_common_x11 {
     elsif (check_var("REGRESSION", "gnome")) {
         loadtest "boot/boot_to_desktop";
         loadtest "x11/window_system";
-        loadtest "qa_automation/patch_and_reboot" if is_updates_tests;
         load_x11_gnome();
     }
     elsif (check_var("REGRESSION", "documentation")) {


### PR DESCRIPTION
Unfortunately in this test suite has problems with `select_console('root')` and tests in this group don't use any `zypper_call` ->  not mandatory to run this test 
