### PR TITLE
Add test for yast timezone

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1414,6 +1414,7 @@ sub load_extra_tests_y2uitest_gui {
 
 sub load_extra_tests_y2uitest_cmd {
     loadtest 'yast2_cmd/yast_lan';
+    loadtest 'yast2_cmd/yast_timezone';
 }
 
 sub load_extra_tests_openqa_bootstrap {

--- a/tests/yast2_cmd/yast_timezone.pm
+++ b/tests/yast2_cmd/yast_timezone.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: yast timezone, list, set and show summary
+# Maintainer: Katerina Lorenzova <klorenzova@suse.cz>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    select_console 'root-console';
+    zypper_call "in yast2-country";
+    my $timezone = script_output 'yast timezone summary 2>&1 | grep "Current Time Zone" | cut -d: -f2';
+    record_info 'default timezone', $timezone;
+    validate_script_output 'yast timezone list 2>&1', sub { m#Africa/Cairo# };
+    assert_script_run 'yast timezone set timezone=Africa/Cairo';
+    validate_script_output 'yast timezone summary 2>&1', sub { m#Africa/Cairo# };
+    assert_script_run "yast timezone set timezone=$timezone";
+}
+1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/49319
- Verification run:
http://10.100.51.129/tests/8
http://10.100.51.129/tests/7
