### PR TITLE
Fix dracut version regex

### DIFF
--- a/tests/console/dracut.pm
+++ b/tests/console/dracut.pm
@@ -23,7 +23,7 @@ sub run {
 
     assert_script_run("rpm -q dracut");
 
-    validate_script_output("lsinitrd", sub { m/Image:(.*\n)+( ?)Version: dracut(-|\d+|\.|\w+)+(\n( ?))+( ?)Arguments(.*\n)+( ?)dracut modules:(\w+|-|\d+|\n|( ?))+\=+\n(l|d|r|w|x|-|( ?))+\s+\d+ root\s+root(.*\n)+( ?)\=+/ });
+    validate_script_output("lsinitrd", sub { m/Image:(.*\n)+( ?)Version: dracut(-|\d+|\.|\+|\w+)+(\n( ?))+( ?)Arguments(.*\n)+( ?)dracut modules:(\w+|-|\d+|\n|( ?))+\=+\n(l|d|r|w|x|-|( ?))+\s+\d+ root\s+root(.*\n)+( ?)\=+/ });
     validate_script_output("dracut -f 2>&1", sub { m/.*Executing: \/usr\/bin\/dracut -f\n|\b(?:Skipping|Including modules done|Including|Creating image|Creating initramfs)\b/ }, 180);
     validate_script_output("dracut --list-modules 2>&1", sub { m/.*Executing: \/usr\/bin\/dracut --list-modules\n(\w+|\n|-|d+)+/ });
 


### PR DESCRIPTION
Update regex to match also git revisions.

- Related ticket: https://progress.opensuse.org/issues/52400
- Verification runs:
  - oS TW: http://d250.qam.suse.de/tests/2036 :heavy_check_mark: 
  - SLE 15.0: http://d250.qam.suse.de/tests/2038 :heavy_check_mark: 
