### PR TITLE
sles4sap/netweaver_test_instance: Do not test pids_max on migration

### DIFF
--- a/tests/sles4sap/netweaver_test_instance.pm
+++ b/tests/sles4sap/netweaver_test_instance.pm
@@ -25,7 +25,8 @@ sub run {
 
     # The SAP Admin was set in sles4sap/netweaver_install
     $self->set_sap_info(get_required_var('INSTANCE_SID'), get_required_var('INSTANCE_ID'));
-    $self->test_pids_max;
+    # Don't test pids_max on migration
+    $self->test_pids_max if !get_var('UPGRADE');
     $self->become_sapadm;
 
     $self->test_version_info;


### PR DESCRIPTION
Do not test pids_max on migration to avoid false positives when using images generated without the fix for bsc#1110700
