### PR TITLE
Do not validate boot parameters for live images

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1088,12 +1088,12 @@ Does not fail the test module but just highlights the result of the comparison.
 =cut
 
 sub compare_bootparams {
-    my ($array1_ref, $array2_ref) = @_;
-    my @difference = arrays_subset($array1_ref, $array2_ref);
+    my ($expected_boot_params, $received_boot_params) = @_;
+    my @difference = arrays_subset($expected_boot_params, $received_boot_params);
     if (scalar @difference > 0) {
         record_info("params mismatch", "Actual bootloader params do not correspond to the expected ones. Mismatched params: @difference", result => 'fail');
     } else {
-        record_info("params ok", "Bootloader parameters are typed correctly.\nVerified parameters: @{$array1_ref}");
+        record_info("params ok", "Bootloader parameters are typed correctly.\nVerified parameters: @{$expected_boot_params}");
     }
 }
 

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -22,6 +22,7 @@ use lockapi 'mutex_wait';
 use bootloader_setup;
 use bootloader_spvm;
 use registration;
+use version_utils ':SCENARIO';
 use utils;
 use Utils::Backends 'is_spvm';
 
@@ -49,7 +50,9 @@ sub run {
         # boot
         send_key 'ctrl-x';
     }
-    compare_bootparams(\@params, [parse_bootparams_in_serial]);
+    # On the live images boot parameters are not printed on the serial,
+    # skip the check there
+    compare_bootparams(\@params, [parse_bootparams_in_serial]) if !is_livecd;
 }
 
 1;


### PR DESCRIPTION
See [poo#52031](https://progress.opensuse.org/issues/52031).

#### Verification runs
- [live cd](http://f174.suse.de/tests/244)
- [non live cd](http://f174.suse.de/tests/243)

