### PR TITLE
Remove softfail for fixed grub issue

### DIFF
--- a/tests/shutdown/grub_set_bootargs.pm
+++ b/tests/shutdown/grub_set_bootargs.pm
@@ -27,10 +27,6 @@ sub run {
         }
     }
     push @cmds, 'sed -i "s#GRUB_CMDLINE_LINUX_DEFAULT=\"[^\"]*\"#GRUB_CMDLINE_LINUX_DEFAULT=\"$new_cmdline\"#" /etc/default/grub';
-    if (script_run('! grep -q resume=.*by-path /proc/cmdline')) {
-        record_soft_failure "boo#1079537 - kernel argument noresume ignored - resume from suspend failing when the image started on different VM";
-        push @cmds, 'sed -i "s/# GRUB_DISABLE_LINUX_UUID=true/GRUB_DISABLE_LINUX_UUID=true/" /etc/default/grub';
-    }
     push @cmds, 'grub2-mkconfig -o /boot/grub2/grub.cfg';
 
     # Slow type for 12-SP2 aarch64 image creation test to try to avoid filling up the key event queue


### PR DESCRIPTION
Soft-fail in grub is no longer needed, boo#1079537 should be fixed.

- Related ticket: https://progress.opensuse.org/issues/52436
- Verification run:
  - http://panigale.suse.cz/tests/2146 (15GA)
  - http://panigale.suse.cz/tests/2148 (15SP1)
