### PR TITLE
Fix message matching if gpg gen key failed in FIPS

### DIFF
--- a/tests/console/gpg.pm
+++ b/tests/console/gpg.pm
@@ -89,7 +89,7 @@ EOF
     # 2048 and 4096 key length should be supported. See bsc#1125740 comment#15
     # for details
     if (get_var('FIPS') || get_var('FIPS_ENABLED') && ($key_size == '1024' || $key_size == '4096')) {
-        wait_serial("gpg: agent_genkey failed: Invalid value", 90) || die "It should failed with invalid value!";
+        wait_serial("failed: Invalid value", 90) || die "It should failed with invalid value!";
         return;
     }
 


### PR DESCRIPTION
The return message is not same between different gpg versions. So, here we simply match all situation with a minimal pattern.

- Related ticket: https://progress.opensuse.org/issues/52412
- Verification run:
  - Failed case: https://openqa.suse.de/tests/2935312#step/gpg/19
  - Fix applied: http://10.67.17.9/tests/1353#step/gpg/19
