### PR TITLE
Add more debug log for boot_from_pxe.pm failure

### DIFF
--- a/tests/boot/boot_from_pxe.pm
+++ b/tests/boot/boot_from_pxe.pm
@@ -172,4 +172,19 @@ sub run {
     }
 }
 
+sub post_fail_hook {
+    my $self = shift;
+
+    if (check_var('BACKEND', 'ipmi') && check_var('VIDEOMODE', 'text')) {
+        select_console 'log-console';
+        save_screenshot;
+        script_run "save_y2logs /tmp/y2logs_clone.tar.bz2";
+        upload_logs "/tmp/y2logs_clone.tar.bz2";
+        save_screenshot;
+    }
+
+    $self->SUPER::post_fail_hook();
+}
+
+
 1;


### PR DESCRIPTION
One of the most reproducing failure of unstable ipmi is blue screen issue. But now there is no debug log uploaded when issue happens. So add logs in post_fail_hook.

- Related ticket: https://progress.opensuse.org/issues/36027
- Verification run: http://10.67.18.220/tests/1636#downloads
