### PR TITLE
Patch first then run system prepare tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2191,11 +2191,13 @@ sub load_security_tests_apparmor {
 }
 
 sub load_security_tests_apparmor_profile {
-    load_security_console_prepare;
-
     if (check_var('TEST', 'mau-apparmor_profile')) {
         loadtest "qa_automation/patch_and_reboot";
+        load_security_console_prepare;
         loadtest "security/apparmor/aa_prepare";
+    }
+    else {
+        load_security_console_prepare;
     }
     loadtest "security/apparmor_profile/usr_sbin_smbd";
     loadtest "security/apparmor_profile/apache2_changehat";


### PR DESCRIPTION
It can happen that /dev/ttyS0 is in tty group and after patch it will be in dialout group then permission denied problems can occure for bernhard user.

- Related ticket: https://progress.opensuse.org/issues/52463
- Fail: http://10.100.12.155/tests/11899#step/apache2_changehat/62
- Verification run: http://10.100.12.155/tests/11901#step/apache2_changehat/62