### PR TITLE
Fix autologin test

### DIFF
--- a/tests/installation/user_settings.pm
+++ b/tests/installation/user_settings.pm
@@ -15,6 +15,7 @@ use strict;
 use warnings;
 use parent qw(installation_user_settings y2_installbase);
 use testapi;
+use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
@@ -38,7 +39,7 @@ sub run {
         send_key $cmd{noautologin};
         assert_screen 'autologindisabled';
     }
-    elsif (check_var('NOAUTOLOGIN', '0')) {
+    elsif (is_sle() && check_var('NOAUTOLOGIN', '0')) {
         send_key $cmd{noautologin};
         assert_screen 'autologinenabled';
     }


### PR DESCRIPTION
Crosschecking autologin enabled/disabled in #7546 for different products and scenarios I missed that `NOAUTOLOGIN="0"` is an option in openSUSE. New test is intended for SLE to add more test coverage due to in opensuse we already have both possibilities.

- Related ticket: https://progress.opensuse.org/issues/44069
- Needles: N/A
- Verification run:
  - [opensuse-Tumbleweed-DVD-aarch64-Build20190602-create_hdd_gnome-x11@aarch64](https://openqa.opensuse.org/t948764)
  - [opensuse-Tumbleweed-DVD-x86_64-Build20190602-create_hdd_gnome-x11@64bit](https://openqa.opensuse.org/t948769)
  - [sle-15-SP1-autologin](https://openqa.suse.de/tests/2945444)
  - [sle-12-SP5-autologin](https://openqa.suse.de/t2945445)
