### PR TITLE
xfstests: Partition device size will use more free space

### DIFF
--- a/tests/xfstests/partition.pm
+++ b/tests/xfstests/partition.pm
@@ -18,6 +18,49 @@ use base 'opensusebasetest';
 use utils;
 use testapi;
 
+sub str_to_mb {
+    my $str = shift;
+    if ($str =~ /(\d+(\.\d+)?)K/) {
+        return $1 / 1024;
+    }
+    elsif ($str =~ /(\d+(\.\d+)?)M/) {
+        return $1;
+    }
+    elsif ($str =~ /(\d+(\.\d+)?)G/) {
+        return $1 * 1024;
+    }
+    else {
+        return;
+    }
+}
+
+# Number of SCRATCH disk in SCRATCH_DEV_POOL, other than btrfs has only 1 SCRATCH_DEV
+sub partition_size_num {
+    my $home_size = shift;
+    $home_size = str_to_mb($home_size);
+    my %ret;
+    if ($home_size && check_var('XFSTESTS', 'btrfs')) {
+        # If enough space, then have 5 disks in SCRATCH_DEV_POOL, or have 2 disks in SCRATCH_DEV_POOL
+        # At least 8 GB in each SCRATCH_DEV (SCRATCH_DEV_POOL only available for btrfs tests)
+        if ($home_size >= 49152) {
+            $ret{num}  = 5;
+            $ret{size} = 1024 * int($home_size / (($ret{num} + 1) * 1024));
+            return %ret;
+        }
+        else {
+            $ret{num}  = 2;
+            $ret{size} = 1024 * int($home_size / (($ret{num} + 1) * 1024));
+            return %ret;
+        }
+    }
+    elsif ($home_size) {
+        $ret{num}  = 1;
+        $ret{size} = int($home_size / 2);
+        return %ret;
+    }
+    return %ret;
+}
+
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
@@ -25,11 +68,19 @@ sub run {
     # Create partitions
     my $filesystem = get_required_var('XFSTESTS');
     my $device     = get_var('XFSTESTS_DEVICE');
+    my $home_size  = script_output("df -h | grep home | awk -F \" \" \'{print \$2}\'");
+    my %size_num   = partition_size_num($home_size);
     if ($device) {
         assert_script_run("parted $device --script -- mklabel gpt");
         assert_script_run("/usr/share/qa/qa_test_xfstests/partition.py --device $device $filesystem && sync", 600);
-    } else {
-        assert_script_run("/usr/share/qa/qa_test_xfstests/partition.py --delhome $filesystem && sync", 600);
+    }
+    else {
+        if (%size_num) {
+            assert_script_run("/usr/share/qa/qa_test_xfstests/partition.py --delhome $filesystem -t $size_num{size} -s $size_num{size} -n $size_num{num} && sync", 600);
+        }
+        else {
+            assert_script_run("/usr/share/qa/qa_test_xfstests/partition.py --delhome $filesystem && sync", 600);
+        }
     }
 }
 


### PR DESCRIPTION
Modify partition part. Use more free space than beforej.

- Related ticket: https://progress.opensuse.org/issues/37895
- Verification run: http://10.67.133.102/tests/988