### PR TITLE
Fix broken condition by 22eb7ccc748b

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -952,7 +952,8 @@ sub load_inst_tests {
             and !get_var("REMOTE_CONTROLLER")
             and !is_hyperv_in_gui
             and !is_bridged_networking
-            and (get_var('BACKEND', '') !~ /ipmi|s390x/ || !is_spvm)
+            and (get_var('BACKEND', '') !~ /ipmi|s390x/)
+            and !is_spvm
             and is_sle('12-SP2+'))
         {
             loadtest "installation/hostname_inst";


### PR DESCRIPTION
Looks like the reviewer of #7503  didn't read well a condition :) and a comment (https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7503#issuecomment-496186002) before merging

Verification: https://openqa.suse.de/tests/2947747/file/autoinst-log.txt
Waiting for: https://openqa.suse.de/tests/2947783

cc @mimi1vx @Zaoliang 