### PR TITLE
wicked: drop usage of non-existing files in data folder

### DIFF
--- a/tests/wicked/advanced/sut/t17_aggregate_both_cards_legacy.pm
+++ b/tests/wicked/advanced/sut/t17_aggregate_both_cards_legacy.pm
@@ -29,9 +29,7 @@ sub run {
     $self->wicked_command('ifup', $sut_iface);
     validate_script_output('ip a s dev ' . $ctx->iface(),  sub { /SLAVE/ });
     validate_script_output('ip a s dev ' . $ctx->iface2(), sub { /SLAVE/ });
-    my $remote_ip = $self->get_remote_ip(type => 'host');
-    $self->ping_with_timeout(ip => $remote_ip, interface => $sut_iface);
-    validate_script_output("ping -c30 $remote_ip -I $sut_iface", sub { /0% packet loss/ });
+    $self->ping_with_timeout(type => 'host', interface => $sut_iface, count_success => 30, timeout => 4);
 }
 
 sub test_flags {

--- a/tests/wicked/advanced/sut/t18_aggregate_both_cards_xml.pm
+++ b/tests/wicked/advanced/sut/t18_aggregate_both_cards_xml.pm
@@ -29,9 +29,7 @@ sub run {
     $self->wicked_command('ifup', $sut_iface);
     validate_script_output('ip a s dev ' . $ctx->iface(),  sub { /SLAVE/ });
     validate_script_output('ip a s dev ' . $ctx->iface2(), sub { /SLAVE/ });
-    my $remote_ip = $self->get_remote_ip(type => 'host');
-    $self->ping_with_timeout(ip => $remote_ip, interface => $sut_iface);
-    validate_script_output("ping -c30 $remote_ip -I $sut_iface", sub { /0% packet loss/ });
+    $self->ping_with_timeout(type => 'host', interface => $sut_iface, count_success => 30, timeout => 4);
 }
 
 sub test_flags {

--- a/tests/wicked/startandstop/sut/t04_bridge_ifup_remove_all_config_ifreload.pm
+++ b/tests/wicked/startandstop/sut/t04_bridge_ifup_remove_all_config_ifreload.pm
@@ -23,9 +23,9 @@ sub run {
     my $iface  = '/etc/sysconfig/network/ifcfg-' . $ctx->iface();
     my $config = '/etc/sysconfig/network/ifcfg-br0';
     my $dummy  = '/etc/sysconfig/network/ifcfg-dummy0';
-    $self->get_from_data('wicked/teaming/ifcfg-eth0', $iface);
-    $self->get_from_data('wicked/ifcfg/br0',          $config);
-    $self->get_from_data('wicked/ifcfg/dummy0',       $dummy);
+    $self->get_from_data('wicked/ifcfg/ifcfg-eth0-hotplug', $iface);
+    $self->get_from_data('wicked/ifcfg/br0',                $config);
+    $self->get_from_data('wicked/ifcfg/dummy0',             $dummy);
     $self->setup_bridge($config, $dummy, 'ifup');
     assert_script_run("rm $iface $config $dummy");
     $self->wicked_command('ifreload', 'all');


### PR DESCRIPTION
drop usage of non-existing files in data folder

VR : 
http://kimball.arch.suse.de/tests/1206 - startandstop 
http://kimball.arch.suse.de/tests/1208 - advanced 