### PR TITLE
Fix schedule for krypton live installation

### DIFF
--- a/schedule/krypton/krypton-live-installation.yaml
+++ b/schedule/krypton/krypton-live-installation.yaml
@@ -1,0 +1,27 @@
+name:           krypton-live-installation
+description:    >
+   Boots the openSUSE Krypton/Argon Live DVD and uses the installer to
+   install with default settings, then reboots into the installed system.
+vars:
+  DESKTOP: kde
+  LIVE_INSTALLATION: 1
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - installation/finish_desktop
+  - installation/live_installation
+  - installation/welcome
+  - installation/online_repos
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot


### PR DESCRIPTION
See [poo#52445](https://progress.opensuse.org/issues/52445).

- [Verification run](http://f174.suse.de/tests/258).
- [Needles](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/561)

Test suite will require setting `YAML_SCHEDULE=schedule/krypton/krypton-live-installation.yaml`
