### PR TITLE
serial_terminal: Fix odd number warning

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -89,7 +89,7 @@ sub login {
     wait_serial(qr/PS1="$serial_term_prompt"/);
     # TODO: Send 'tput rmam' instead/also
     assert_script_run('export TERM=dumb; stty cols 2048');
-    assert_script_run('echo Logged into $(tty)', $bmwqemu::default_timeout, result_title => 'vconsole_login');
+    assert_script_run('echo Logged into $(tty)', timeout => $bmwqemu::default_timeout, result_title => 'vconsole_login');
 }
 
 sub serial_term_prompt {


### PR DESCRIPTION
Odd number of arguments at /var/lib/openqa/share/tests/sle/lib/serial_terminal.pm line 92.
Odd number of elements in hash assignment at /usr/lib/os-autoinst/testapi.pm line 2121.

https://openqa.opensuse.org/tests/953641/file/autoinst-log.txt

Verification run:
http://quasar.suse.cz/tests/2963
http://quasar.suse.cz/tests/2962
