### PR TITLE
xfstests: wait a few second to catch root-console needle

### DIFF
--- a/tests/xfstests/generate_report.pm
+++ b/tests/xfstests/generate_report.pm
@@ -47,6 +47,7 @@ sub upload_subdirs {
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
+    sleep 5;
 
     # Reload uploaded status log back to file
     script_run('curl -O ' . autoinst_url . "/files/status.log; cat status.log > $STATUS_LOG");


### PR DESCRIPTION
In the first step of generic_result.pm calls select_serial_terminal, and it calls root-console needle, but it may missing in a flush of out put in next step. And this cause 50% tests fail in this step, e.g: https://openqa.suse.de/tests/2946518#step/generate_report/1
For more stable, after select_serial_terminal take a short breath for 5 second, then goes to next step.

- Related ticket: https://openqa.suse.de/tests/2946518#step/generate_report/1
- Verification run: http://10.67.133.102/tests/971
