### PR TITLE
Add a workaround in accept_license. fix poo#49733

### DIFF
--- a/lib/y2_logs_helper.pm
+++ b/lib/y2_logs_helper.pm
@@ -97,7 +97,13 @@ Mark the test as failed if the checkbox is not selected after sending an appropr
 
 sub accept_license {
     send_key $cmd{accept};
-    assert_screen('license-agreement-accepted');
+    assert_screen [qw(license-agreement-accepted license-agreement)];
+    if (match_has_tag('license-agreement')) {
+        record_soft_failure 'bsc#1133728';
+        # to workaround bsc#1133728, move the mouse a little
+        mouse_hide();
+        assert_screen('license-agreement-accepted');
+    }
 }
 
 sub verify_license_translations {


### PR DESCRIPTION
This patch works around bsc#1133728: if the checkbox is not selected, moving the mouse a little will make it selected.

- Related ticket: https://progress.opensuse.org/issues/49733
- Needles: none
- Verification run: http://147.2.212.139/tests/188#step/accept_license/3