### PR TITLE
Argon is based on Leap 15.1 now, so no role selection anymore

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -355,7 +355,8 @@ sub is_using_system_role_first_flow {
 
 # If there is only one role, there is no selection offered
 sub requires_role_selection {
-    return get_var('FLAVOR', '') !~ /Krypton/;
+    # Applies to Krypton and Argon based on Leap 15.1+
+    return !is_krypton_argon;
 }
 
 =head2 has_product_selection


### PR DESCRIPTION
See also https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7608

- Related ticket: https://progress.opensuse.org/issues/52445
- Verification run: http://10.160.67.86/tests/342
