### PR TITLE
Replace nfsserver.service with nfs-server.service

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -27,15 +27,15 @@ sub server_configure_network {
 
 sub try_nfsv2 {
     # Try that NFSv2 is disabled by default
-    systemctl 'start nfsserver';
+    systemctl 'start nfs-server';
     assert_script_run "cat /proc/fs/nfsd/versions | grep '\\-2'";
     file_content_replace("/etc/sysconfig/nfs", "MOUNTD_OPTIONS=.*" => "MOUNTD_OPTIONS=\"-V2\"", "NFSD_OPTIONS=.*" => "NFSD_OPTIONS=\"-V2\"");
-    systemctl 'restart nfsserver';
+    systemctl 'restart nfs-server';
     assert_script_run "cat /proc/fs/nfsd/versions | grep '+2'";
 
     # Disable NFSv2 again
     file_content_replace("/etc/sysconfig/nfs", "MOUNTD_OPTIONS=.*" => "MOUNTD_OPTIONS=\"\"", "NFSD_OPTIONS=.*" => "NFSD_OPTIONS=\"\"");
-    systemctl 'stop nfsserver';
+    systemctl 'stop nfs-server';
 }
 
 sub prepare_exports {
@@ -163,13 +163,13 @@ sub check_nfs_ready {
     assert_script_run "cat /etc/exports | tr -d ' \\t\\r' | grep '${rw}\\*(rw,\\|${ro}\\*(ro,'";
     assert_script_run "cat /proc/fs/nfsd/exports";
 
-    if ((script_run('systemctl is-enabled nfsserver')) != 0) {
-        record_info 'disabled', 'The nfsserver unit is disabled';
-        systemctl 'enable nfsserver';
+    if ((script_run('systemctl is-enabled nfs-server')) != 0) {
+        record_info 'disabled', 'The nfs-server unit is disabled';
+        systemctl 'enable nfs-server';
     }
-    if ((script_run('systemctl is-active nfsserver')) != 0) {
-        record_info 'stopped', 'The nfsserver unit is stopped';
-        systemctl 'start nfsserver';
+    if ((script_run('systemctl is-active nfs-server')) != 0) {
+        record_info 'stopped', 'The nfs-server unit is stopped';
+        systemctl 'start nfs-server';
     }
 }
 

--- a/tests/console/rpcbind.pm
+++ b/tests/console/rpcbind.pm
@@ -30,8 +30,8 @@ sub run {
     # create and start nfs export
     assert_script_run 'echo "/mnt *(ro,root_squash,sync,no_subtree_check)" >/etc/exports';
     assert_script_run 'echo "nfs is working" >/mnt/test';
-    systemctl 'start nfsserver';
-    systemctl 'status nfsserver';
+    systemctl 'start nfs-server';
+    systemctl 'status nfs-server';
 
     # wait for updated rpcinfo
     sleep 5;
@@ -45,7 +45,7 @@ sub run {
 
 sub post_run_hook {
     # stop started services
-    systemctl 'stop rpcbind.socket rpcbind.service nfsserver';
+    systemctl 'stop rpcbind.socket rpcbind.service nfs-server';
 }
 
 1;

--- a/tests/console/yast2_nfs4_server.pm
+++ b/tests/console/yast2_nfs4_server.pm
@@ -66,7 +66,7 @@ sub run {
     clear_console;
 
     # Server is up and running, client can use it now!
-    script_run "( journalctl -fu nfsserver > /dev/$serialdev & )";
+    script_run "( journalctl -fu nfs-server > /dev/$serialdev & )";
     mutex_create('nfs4_ready');
     check_nfs_ready($rw, $ro);
 

--- a/tests/console/yast2_nfs_server.pm
+++ b/tests/console/yast2_nfs_server.pm
@@ -72,7 +72,7 @@ sub run {
     clear_console;
 
     # Server is up and running, client can use it now!
-    script_run "( journalctl -fu nfsserver > /dev/$serialdev & )";
+    script_run "( journalctl -fu nfs-server > /dev/$serialdev & )";
     mutex_create('nfs_ready');
     check_nfs_ready($rw, $ro);
 

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -250,7 +250,7 @@ sub setup_network {
     # SLE12GA uses too many old style services
     my $action = check_var('VERSION', '12') ? "enable" : "reenable";
 
-    foreach my $service (qw(auditd dnsmasq nfsserver rpcbind vsftpd)) {
+    foreach my $service (qw(auditd dnsmasq nfs-server rpcbind vsftpd)) {
         if (is_sle('12+') || is_opensuse || is_jeos) {
             systemctl($action . " " . $service);
             assert_script_run("systemctl start $service || { systemctl status --no-pager $service; journalctl -xe --no-pager; false; }");

--- a/tests/virt_autotest/guest_migration_source_nfs_setup.pm
+++ b/tests/virt_autotest/guest_migration_source_nfs_setup.pm
@@ -37,7 +37,7 @@ sub run {
     $self->execute_script_run($cmd_write_exports, 500);
 
     #Restart the nfs service
-    $self->execute_script_run("rcnfsserver restart", 500);
+    $self->execute_script_run("rcnfs-server restart", 500);
     set_var('NFS_DONE', 1);
     bmwqemu::save_vars();
 

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -322,7 +322,7 @@ sub download_guest_assets {
 
     # mount the remote NFS location of guest assets
     # OPENQA_URL="localhost" in local openQA instead of the IP, so the line below need to be turned on and set to the webUI IP when you are using local openQA
-    # Tips: Using local openQA, you need "rcnfsserver start & vi /etc/exports; exportfs -r")
+    # Tips: Using local openQA, you need "rcnfs-server start & vi /etc/exports; exportfs -r")
     # set_var('OPENQA_URL', "your_ip");
     my $openqa_server = get_required_var('OPENQA_URL');
     $openqa_server =~ s/^http:\/\///;

--- a/tests/virtualization/virtman_storage.pm
+++ b/tests/virtualization/virtman_storage.pm
@@ -69,7 +69,7 @@ sub create_nfs_share {
     become_root();
     assert_script_run "mkdir -p $dir";
     assert_script_run "echo '$dir *(rw,sync)' >> /etc/exports";
-    systemctl 'restart nfsserver';
+    systemctl 'restart nfs-server';
     assert_script_run "exportfs";
     type_string 'exit';
     send_key 'ret';


### PR DESCRIPTION
This service has been called nfs-server ever since SLE12SP1, with nfsserver being an
alias that has been carried around for legacy reasons.

Starting with nfs-utils 2.3.x, this alias will be dropped and only nfs-server will
remain valid.

Switch the tests to using the correct name for the service, without relying on
alias hacks.

- Related ticket: N/A - fix based on staging errors
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/950074 [running]
