### PR TITLE
[AARCH64 Automation] Use vendor-specific serial console for offline upgrade

### DIFF
--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -16,6 +16,7 @@ use base "virt_autotest_base";
 use testapi;
 use virt_utils;
 use utils;
+use Utils::Backends 'is_remote_backend';
 
 sub install_package {
 
@@ -68,10 +69,10 @@ sub install_package {
         }
     }
 
-    ###SLE-12-SP4 arm64 installation has no KVM role selection
-    if (($repo_0_to_install =~ /SLE-12-SP4/m) && check_var('ARCH', 'aarch64')) {
-        zypper_call("--gpg-auto-import-keys ref",         180);
-        zypper_call("in -t pattern kvm_server kvm_tools", 300);
+    ###Install KVM role patterns for aarch64 virtualization host
+    if (is_remote_backend && check_var('ARCH', 'aarch64')) {
+        zypper_call("--gpg-auto-import-keys ref",         timeout => 180);
+        zypper_call("in -t pattern kvm_server kvm_tools", timeout => 300);
     }
 
     #install qa_lib_virtauto

--- a/tests/virt_autotest/reboot_and_wait_up_normal.pm
+++ b/tests/virt_autotest/reboot_and_wait_up_normal.pm
@@ -23,7 +23,7 @@ sub run {
     my $timeout = 180;
 
     #online upgrade actually
-    return if (is_remote_backend && check_var('ARCH', 'aarch64') && is_installed_equal_upgrade_major_release);
+    return if (is_remote_backend && check_var('ARCH', 'aarch64') && (is_installed_equal_upgrade_major_release || get_var("VIRT_PRJ1_GUEST_INSTALL") || get_var("VIRT_PRJ4_GUEST_UPGRADE")));
     $self->reboot_and_wait_up($timeout);
 }
 

--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -17,6 +17,7 @@ use testapi;
 use base "virt_autotest_base";
 use virt_utils;
 use ipmi_backend_utils;
+use Utils::Backends 'is_remote_backend';
 
 sub update_package {
     my $self           = shift;
@@ -54,8 +55,11 @@ sub run {
         set_serial_console_on_vh('', '', 'kvm') if (check_var("HOST_HYPERVISOR", "kvm") || check_var("SYSTEM_ROLE", "kvm"));
     }
     update_guest_configurations_with_daily_build();
+    if (is_remote_backend && check_var('ARCH', 'aarch64') && !check_var('LINUX_CONSOLE_OVERRIDE', 'ttyAMA0') && (get_var('VIRT_PRJ2_HOST_UPGRADE') || get_var('VIRT_PRJ4_GUEST_UPGRADE'))) {
+        my $ipmi_console = get_var('LINUX_CONSOLE_OVERRIDE', 'ttyAMA0');
+        assert_script_run("sed -irn \"s/console=ttyAMA0/console=$ipmi_console/g\" /usr/share/qa/virtautolib/lib/vh-update-lib.sh");
+    }
 }
-
 
 sub test_flags {
     return {fatal => 1};


### PR DESCRIPTION
Extend offline host upgrade support to broader range of vendor machines.

- Related ticket: AARCH64 Automation
- Needles: n/a
- Verification run: http://10.162.187.154/tests/2170
http://10.162.187.154/tests/2152