### PR TITLE
Fix apparrmor regression introduced in #7263

### DIFF
--- a/tests/console/yast2_apparmor.pm
+++ b/tests/console/yast2_apparmor.pm
@@ -33,9 +33,10 @@ sub run {
 
     # start apparmor configuration
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'apparmor');
+    # assert that app was opened appeared
+    assert_screen 'yast2_apparmor';
     #SLES <15 extra packages are needed after main window:
     if (is_pre_15()) {
-        assert_screen 'yast2_apparmor';    #this window does not appear on >=15
         send_key 'ret';
         install_extra_packages_requested;
     } else {


### PR DESCRIPTION
Problem is that in case of SLE/Leap 15 and TW, in case we have all
packages available, we press enter too early. So bringing back assertion
that module was opened.

[Verification run](https://openqa.suse.de/tests/2950965#settings)
