### PR TITLE
Add new test cases for krb5 cryptographic function

### DIFF
--- a/lib/krb5crypt.pm
+++ b/lib/krb5crypt.pm
@@ -1,0 +1,88 @@
+# Copyright © 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Public variables and functions for krb5 cryptographic testing
+# Maintainer: wnereiz <wnereiz@member.fsf.org>
+
+package krb5crypt;
+
+use base Exporter;
+use Exporter;
+
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+use base 'consoletest';
+
+our @EXPORT = qw(
+  $dom_kdc
+  $ip_kdc
+  $dom_server
+  $ip_server
+  $dom_client
+  $ip_client
+  $dom
+  $pass_db
+  $adm
+  $pass_a
+  $tst
+  $pass_t
+  $nfs_expdir
+  $nfs_mntdir
+  $nfs_fname
+
+  krb5_init
+);
+
+our $dom_kdc    = 'kdc.example.com';
+our $ip_kdc     = '10.0.2.31';
+our $dom_server = 'server.example.com';
+our $ip_server  = '10.0.2.32';
+our $dom_client = 'client.example.com';
+our $ip_client  = '10.0.2.33';
+
+our $dom     = 'EXAMPLE.COM';
+our $pass_db = 'DB_phrase';      # Database password
+our $adm     = 'joe/admin';
+our $pass_a  = 'Admin_pass';     # Admin user password
+our $tst     = 'tester';
+our $pass_t  = 'Tester_pass';    # Test user password
+
+# NFSv4 authentication with krb5 testing
+our $nfs_expdir = '/tmp/nfsdir';
+our $nfs_mntdir = '/tmp/mntdir';
+our $nfs_fname  = 'foo';
+
+# Common codes for krb5 server and client setup
+sub krb5_init {
+    script_run("kinit -p $adm |& tee /dev/$serialdev", 0);
+    wait_serial(qr/Password.*\Q$adm\E/) || die "Matching output failed";
+    type_string "$pass_a\n";
+    script_output "echo \$?", sub { m/^0$/ };
+
+    validate_script_output "klist", sub {
+        m/
+            Ticket\scache.*\/root\/kcache.*
+            Default\sprincipal.*\Q$adm\E\@\Q$dom\E.*
+            krbtgt\/\Q$dom\E\@\Q$dom\E.*
+            renew\suntil.*/sxx
+    };
+
+    validate_script_output "kadmin -p $adm -q listprincs -w $pass_a", sub {
+        m/\Q$adm\E\@\Q$dom\E/;
+    };
+}

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2082,7 +2082,7 @@ sub load_applicationstests {
 sub load_security_console_prepare {
     loadtest "console/system_prepare";
     loadtest "console/consoletest_setup";
-    loadtest "console/hostname";
+    loadtest "console/hostname" if get_var("SECURITY_TEST") !~ /crypt_krb5/;
 }
 
 # The function name load_security_tests_crypt_* is to avoid confusing
@@ -2153,6 +2153,28 @@ sub load_security_tests_crypt_tool {
     loadtest "security/dm_crypt" if not get_var('FIPS_ENV_MODE');
     loadtest "console/cryptsetup";
     loadtest "console/consoletest_finish";
+}
+
+sub load_security_tests_crypt_krb5kdc {
+    load_security_console_prepare;
+    loadtest "security/krb5/krb5_crypt_prepare";
+    loadtest "security/krb5/krb5_crypt_setup_kdc";
+}
+
+sub load_security_tests_crypt_krb5server {
+    load_security_console_prepare;
+    loadtest "security/krb5/krb5_crypt_prepare";
+    loadtest "security/krb5/krb5_crypt_setup_server";
+    loadtest "security/krb5/krb5_crypt_ssh_server";
+    loadtest "security/krb5/krb5_crypt_nfs_server";
+}
+
+sub load_security_tests_crypt_krb5client {
+    load_security_console_prepare;
+    loadtest "security/krb5/krb5_crypt_prepare";
+    loadtest "security/krb5/krb5_crypt_setup_client";
+    loadtest "security/krb5/krb5_crypt_ssh_client";
+    loadtest "security/krb5/krb5_crypt_nfs_client";
 }
 
 sub load_security_tests_fips_setup {
@@ -2267,6 +2289,7 @@ sub load_security_tests_system_check {
 sub load_security_tests {
     my @security_tests = qw(
       fips_setup crypt_core crypt_web crypt_misc crypt_tool
+      crypt_krb5kdc crypt_krb5server crypt_krb5client
       ipsec mmtest
       apparmor apparmor_profile selinux
       openscap

--- a/tests/security/krb5/krb5_crypt_nfs_client.pm
+++ b/tests/security/krb5/krb5_crypt_nfs_client.pm
@@ -1,0 +1,63 @@
+# Copyright © 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test NFS with krb5 authentication and GSS API - client
+# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Ticket: poo#51560, poo#52388
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use lockapi;
+use mmapi;
+use krb5crypt;    # Import public variables
+
+sub run {
+    select_console 'root-console';
+
+    mutex_wait('CONFIG_READY_NFS_SERVER');
+
+    # Add principal for NFS service and add it to client's keytable
+    assert_script_run "kadmin -p $adm -w $pass_a -q 'addprinc -randkey nfs/$dom_client'";
+    assert_script_run "kadmin -p $adm -w $pass_a -q 'ktadd nfs/$dom_client'";
+    systemctl("restart rpc-gssd.service");
+    assert_script_run "mkdir -p $nfs_mntdir";
+
+    # Test different sec options here:
+    # sec=sys (no Kerberos use, we do not test it)
+    # sec=krb5 (Kerberos user authentication only)
+    # sec=krb5i (Kerberos user authentication and integrity checking)
+    # sec=krb5p (Kerberos user authentication, integrity checking and NFS traffic encryption)
+    for my $sec ('sys', 'krb5', 'krb5i', 'krb5p') {
+        assert_script_run "mount -t nfs4 -o rw,sec=$sec $dom_server:$nfs_expdir $nfs_mntdir";
+        assert_script_run "mount |grep $dom_server.*$sec";
+
+        # Some simple operations with mounted directory
+        assert_script_run "ls $nfs_mntdir/";
+        assert_script_run "rm $nfs_mntdir/$nfs_fname", 150;    # Sometimes it takes long time.
+        assert_script_run "touch $nfs_mntdir/$nfs_fname";
+        assert_script_run "umount $nfs_mntdir";
+    }
+
+    mutex_create('TEST_DONE_NFS_CLIENT');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/security/krb5/krb5_crypt_nfs_server.pm
+++ b/tests/security/krb5/krb5_crypt_nfs_server.pm
@@ -1,0 +1,60 @@
+# Copyright © 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test NFS with krb5 authentication and GSS API - server
+# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Ticket: poo#51560, poo#52388
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use lockapi;
+use mmapi;
+use krb5crypt;    # Import public variables
+
+sub run {
+    select_console 'root-console';
+
+    zypper_call("in nfs-kernel-server nfs-client");
+
+    # Config NFS server
+    foreach my $i ('NFS4_SUPPORT', 'NFS_SECURITY_GSS', 'NFS_GSSD_AVOID_DNS') {
+        assert_script_run "sed -i 's/.*$i=.*\$/$i=\"yes\"/' /etc/sysconfig/nfs";
+    }
+    assert_script_run "cat /etc/sysconfig/nfs |& tee /dev/$serialdev";
+    assert_script_run "mkdir -p $nfs_expdir && touch $nfs_expdir/$nfs_fname ";
+    assert_script_run "chown -R 1000:100 $nfs_expdir";
+    assert_script_run "echo '$nfs_expdir *(rw,sec=sys:krb5:krb5i:krb5p,no_subtree_check,all_squash,anonuid=1000,anongid=100,sync)' >> /etc/exports";
+
+    # Add principal for NFS service and add it to server's keytable
+    assert_script_run "kadmin -p $adm -w $pass_a -q 'addprinc -randkey nfs/$dom_server'";
+    assert_script_run "kadmin -p $adm -w $pass_a -q 'ktadd nfs/$dom_server'";
+    systemctl("restart rpc-svcgssd nfs-server");
+
+    mutex_create('CONFIG_READY_NFS_SERVER');
+
+    # Waiting for the finishd of krb5 client
+    my $children = get_children();
+    mutex_wait('TEST_DONE_NFS_CLIENT', (keys %$children)[0]);
+    mutex_create('TEST_DONE_NFS_SERVER');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/security/krb5/krb5_crypt_prepare.pm
+++ b/tests/security/krb5/krb5_crypt_prepare.pm
@@ -1,0 +1,148 @@
+# Copyright © 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Prepare environment for cryptographic function testing of krb5
+# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Ticket: poo#51560
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use lockapi;
+use mmapi;
+use mm_tests;
+use mm_network;
+use Exporter;
+use version_utils "is_sle";
+use krb5crypt;    # Import public variables
+
+sub krb5_network_config {
+    my ($ip, $dom) = @_;
+
+    # The hostname should be fixed to "krb5kdc", "krb5server" and "krb5client"
+    my $hostname = 'krb5' . (split('\.', $dom))[0];
+    set_hostname($hostname);
+    assert_script_run("hostname");
+
+    # Append to /etc/hosts
+    assert_script_run("sed -i \"s/\\($ip.*\$\\)/\\1 $hostname/g\" /etc/hosts");
+    assert_script_run("cat /etc/hosts");
+
+    configure_static_network("$ip/24");
+}
+
+sub run {
+    my ($self) = @_;
+
+    select_console 'root-console';
+
+    my $children = get_children();
+
+    # Prepare hosts file for domains
+    assert_script_run(
+        "echo \"\$(cat <<EOF
+$ip_kdc $dom_kdc
+$ip_server $dom_server
+$ip_client $dom_client
+EOF
+        )\" >> /etc/hosts"
+    );
+
+    # Network configuration
+    # We do not only simply setup the network environment, but also ensure the
+    # Connections with lock api.
+    if (get_var('SECURITY_TEST') =~ /crypt_krb5kdc/) {
+        krb5_network_config($ip_kdc, $dom_kdc);
+
+        mutex_create "KRB5_KDC_NETWORK_READY";
+        # Make sure three machines finishing the network setting at almost
+        # same time for better modulization.
+        mutex_wait("KRB5_SERVER_NETWORK_READY", (keys %$children)[0]);
+    }
+    elsif (get_var('SECURITY_TEST') =~ /crypt_krb5server/) {
+        krb5_network_config($ip_server, $dom_server);
+
+        mutex_wait "KRB5_KDC_NETWORK_READY";
+        assert_script_run("ping -c1 $ip_kdc");
+
+        mutex_create "KRB5_SERVER_NETWORK_READY";
+        mutex_wait("KRB5_CLIENT_NETWORK_READY", (keys %$children)[0]);
+    }
+    elsif (get_var('SECURITY_TEST') =~ /crypt_krb5client/) {
+        krb5_network_config($ip_client, $dom_client);
+
+        mutex_wait "KRB5_SERVER_NETWORK_READY";
+        assert_script_run("ping -c1 $ip_kdc");
+        assert_script_run("ping -c1 $ip_server");
+
+        mutex_create "KRB5_CLIENT_NETWORK_READY";
+    }
+    else {    # Avoid misconfigration in lib/main_comman.pm
+        die "Unrecognized value of SECURITY_TEST";
+    }
+
+    (is_sle('<15')) ? systemctl('stop SuSEfirewall2') : systemctl('stop firewalld');
+
+    # Prepare krb5 application and config files
+    zypper_call('in krb5 krb5-server krb5-client');
+    assert_script_run("echo 'export KRB5CCNAME=/root/kcache' >> /etc/profile.d/krb5.sh");    # Make ticket permanent
+    assert_script_run("source /etc/profile.d/krb5.sh");
+
+    my $krb5_conf = '/etc/krb5.conf';
+    assert_script_run "cat $krb5_conf";
+    assert_script_run(
+        "echo \"\$(cat <<EOF
+[libdefaults]
+    dns_canonicalize_hostname = false
+    rdns = false
+    default_realm = EXAMPLE.COM
+    allow_week_crypto = true
+    ignore_acceptor_hostname = true
+
+[realms]
+        EXAMPLE.COM = {
+                kdc = kdc.example.com
+                admin_server = kdc.example.com
+        }
+
+[domain_realm]
+.example.com = EXAMPLE.COM
+
+[logging]
+    kdc = FILE:/var/log/krb5/krb5kdc.log
+    admin_server = FILE:/var/log/krb5/kadmind.log
+    default = SYSLOG:NOTICE:DAEMON
+EOF
+        )\" > $krb5_conf"
+    );
+    assert_script_run "cat $krb5_conf";
+
+    if (get_var('SECURITY_TEST') =~ /crypt_krb5kdc/) {
+
+        # KDC configuration
+        my $kdc_conf = "/var/lib/kerberos/krb5kdc/kdc.conf";
+        assert_script_run "cat $kdc_conf";
+        assert_script_run "sed -i 's/^#/ /g' $kdc_conf";
+        assert_script_run "cat $kdc_conf";
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/security/krb5/krb5_crypt_setup_client.pm
+++ b/tests/security/krb5/krb5_crypt_setup_client.pm
@@ -1,0 +1,41 @@
+# Copyright © 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Setup client system for krb5 cryptographic testing
+# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Ticket: poo#51560, poo#51569
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use lockapi;
+use mmapi;
+use krb5crypt;    # Import public variables
+
+sub run {
+    select_console 'root-console';
+
+    mutex_wait('CONFIG_READY_KRB5_SERVER');
+    krb5_init;
+    mutex_create('TEST_DONE_CLIENT');
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;

--- a/tests/security/krb5/krb5_crypt_setup_kdc.pm
+++ b/tests/security/krb5/krb5_crypt_setup_kdc.pm
@@ -1,0 +1,83 @@
+# Copyright © 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Setup KDC service for krb5 cryptographic testing
+# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Ticket: poo#51560, poo#51563
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use lockapi;
+use mmapi;
+use krb5crypt;    # Import public variables
+
+sub run {
+    select_console 'root-console';
+
+    # Create KDC database
+    validate_script_output "kdb5_util create -r $dom -s -P $pass_db", sub {
+        m/
+            Initializing\sdatabase.*for\srealm.*\Q$dom\E.*
+            master\skey\sname.*\Q$dom\E.*/sxx
+    };
+    validate_script_output "kadmin.local -q listprincs", sub {
+        m/krbtgt\/\Q$dom\E\@\Q$dom\E/;
+    };
+
+    # Add admin user
+    assert_script_run "kadmin.local -q 'addprinc -pw $pass_a $adm'";
+    validate_script_output "kadmin.local -q listprincs", sub {
+        m/\Q$adm\E\@\Q$dom\E/;
+    };
+
+    systemctl("start krb5kdc");
+    systemctl("enable krb5kdc");
+
+    script_run("kinit $adm |& tee /dev/$serialdev", 0);
+    wait_serial(qr/Password.*\Q$adm\E/) || die "Matching output failed";
+    type_string "$pass_a\n";
+    script_output "echo \$?", sub { m/^0$/ };
+    validate_script_output "klist", sub {
+        m/
+            Ticket\scache.*\/root\/kcache.*
+            Default\sprincipal.*\Q$adm\E\@\Q$dom\E.*
+            krbtgt\/\Q$dom\E\@\Q$dom\E.*
+            renew\suntil.*/sxx
+    };
+
+    my $kadm_conf = '/var/lib/kerberos/krb5kdc/kadm5.acl';
+    assert_script_run "sed -Ei 's/^#(.*\\/admin\@\Q$dom\E.*)/\\1/g' $kadm_conf";
+    assert_script_run "cat $kadm_conf";
+
+    systemctl("start kadmind");
+    systemctl("enable kadmind");
+
+    mutex_create('CONFIG_READY_KRB5_KDC');
+
+    # Waiting for the finish of krb5 and other testing server
+    my $children = get_children();
+    mutex_wait('TEST_DONE_SERVER',     (keys %$children)[0]);
+    mutex_wait('TEST_DONE_SSH_SERVER', (keys %$children)[0]);
+    mutex_wait('TEST_DONE_NFS_SERVER', (keys %$children)[0]);
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/security/krb5/krb5_crypt_setup_server.pm
+++ b/tests/security/krb5/krb5_crypt_setup_server.pm
@@ -1,0 +1,50 @@
+# Copyright © 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Setup server machine for krb5 cryptographic testing
+# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Ticket: poo#51560, poo#51566
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use lockapi;
+use mmapi;
+use krb5crypt;    # Import public variables
+
+sub run {
+    select_console 'root-console';
+
+    mutex_wait('CONFIG_READY_KRB5_KDC');
+    krb5_init;
+
+    # Add secret key in keytab file
+    assert_script_run "kadmin -p $adm -w $pass_a -q 'addprinc -randkey host/$dom_server'";
+    assert_script_run "kadmin -p $adm -w $pass_a -q 'ktadd host/$dom_server'";
+    mutex_create('CONFIG_READY_KRB5_SERVER');
+
+    # Waiting for the finishd of krb5 client
+    my $children = get_children();
+    mutex_wait('TEST_DONE_CLIENT', (keys %$children)[0]);
+    mutex_create('TEST_DONE_SERVER');
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;

--- a/tests/security/krb5/krb5_crypt_ssh_client.pm
+++ b/tests/security/krb5/krb5_crypt_ssh_client.pm
@@ -1,0 +1,63 @@
+# Copyright © 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test ssh with krb5 authentication - client
+# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Ticket: poo#51560, poo#51569
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use lockapi;
+use mmapi;
+use krb5crypt;    # Import public variables
+
+sub run {
+    select_console 'root-console';
+
+    foreach my $i ('GSSAPIAuthentication', 'GSSAPIDelegateCredentials') {
+        assert_script_run "sed -i 's/^.*$i .*\$/$i yes/' /etc/ssh/ssh_config";
+    }
+
+    mutex_wait('CONFIG_READY_SSH_SERVER');
+
+    script_run("kinit -p $tst |& tee /dev/$serialdev", 0);
+    wait_serial(qr/Password.*$tst/) || die "Matching output failed";
+    type_string "$pass_t\n";
+    script_output "echo \$?", sub { m/^0$/ };
+    validate_script_output "klist", sub {
+        m/Default principal.*$tst/;
+    };
+
+    # Try connecting to server
+    my $ssherr = "ssh login failed";
+    script_run("ssh -v -o StrictHostKeyChecking=no $tst\@$dom_server |& tee /dev/$serialdev", 0);
+    wait_serial "$tst\@.*~>" || die $ssherr;
+    validate_script_output "hostname", sub { m/krb5server/ };
+
+    # Exit the server
+    send_key 'ctrl-d';
+    validate_script_output "hostname", sub { m/krb5client/ };
+
+    mutex_create('TEST_DONE_SSH_CLIENT');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/security/krb5/krb5_crypt_ssh_server.pm
+++ b/tests/security/krb5/krb5_crypt_ssh_server.pm
@@ -1,0 +1,53 @@
+# Copyright © 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test ssh with krb5 authentication - server
+# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Ticket: poo#51560, poo#51566
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use lockapi;
+use mmapi;
+use krb5crypt;    # Import public variables
+
+sub run {
+    select_console 'root-console';
+
+    assert_script_run "kadmin -p $adm -w $pass_a -q 'addprinc -pw $pass_t $tst'";
+    assert_script_run "useradd -m $tst";
+
+    # Config sshd
+    foreach my $i ('GSSAPIAuthentication', 'GSSAPICleanupCredentials') {
+        assert_script_run "sed -i 's/^#$i .*\$/$i yes/' /etc/ssh/sshd_config";
+    }
+    systemctl("restart sshd");
+
+    mutex_create('CONFIG_READY_SSH_SERVER');
+
+    # Waiting for the finishd of krb5 client
+    my $children = get_children();
+    mutex_wait('TEST_DONE_SSH_CLIENT', (keys %$children)[0]);
+    mutex_create('TEST_DONE_SSH_SERVER');
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;


### PR DESCRIPTION
Multi-machine testings with at least three virtual machines: **KDC,** the **server** and the **client**. Test case include both _SSH login_ and _NFSv4 authentication with krb5_.

Please note that the testing only focus on the cryptography related process and DOES NOT cover the whole kerberos functions. There is a detail structure of test suite described in [poo#51560](https://progress.opensuse.org/issues/51560).

Related manual testing could be found in Testopia test cases:
[#1699118](https://bugzilla.suse.com/tr_show_case.cgi?case_id=1699118): _FIPS: krb5_ and
[#1699179](https://bugzilla.suse.com/tr_show_case.cgi?case_id=1699179): _FIPS: NFSv4 with krb5 authentication and gss api_

#### Related ticket:
* General: https://progress.opensuse.org/issues/51560
* KDC: https://progress.opensuse.org/issues/51563
* Server: https://progress.opensuse.org/issues/51566
* Client: https://progress.opensuse.org/issues/51569
* NFSv4: https://progress.opensuse.org/issues/52388

#### Verification run:
* SLE12: http://10.67.17.9/tests/overview?distri=sle&version=12-SP4&build=&groupid=1
* SLE12 FIPS: http://10.67.17.9/tests/overview?distri=sle&version=12-SP4&build=&groupid=1 (Failed, further investigation and bug report needed)
* SLE15: http://10.67.17.9/tests/overview?distri=sle&version=15-SP1&build=GMC&groupid=1
* Tumbleweed: http://10.67.17.9/tests/overview?distri=opensuse&version=tumbleweed&build=20190524&groupid=1