### PR TITLE
Change VERSION for migration group specific flavor

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -192,6 +192,11 @@ sub setup_env {
         my $format_dasd = get_var('S390_DISK') || get_var('UPGRADE') || get_var('ENCRYPT_ACTIVATE_EXISTING') ? 'never' : 'pre_install';
         set_var('FORMAT_DASD', get_var('FORMAT_DASD', $format_dasd));
     }
+    # This is for 12-sp5 project specific flavor Migration-from-SLE12-SP5-to-SLE15-SPx, this flavor belong 12sp5 test group but the real
+    # action is migration from 12-sp5 to 15-sp1, so we need change VERSION to 15-SP1 before the test case start
+    if (check_var('FLAVOR', 'Migration-from-SLE12-SP5-to-SLE15-SPx')) {
+        set_var('VERSION', '15-SP1');
+    }
 }
 
 sub data_integrity_is_applicable {


### PR DESCRIPTION
For 12sp5 project, we introduce new migration automation scenario 12sp5->15sp1, so some specific change will happen.
We create new flavor Migration-from-SLE12-SP5-to-SLE15-SPx for this kind of test cases, and triggered by VERSION=12-SP5 FlAVOR=Migration-from-SLE12-SP5-to-SLE15-SPx together with other 12sp5 migration test group. And we will have 12sp5 group view on openqa UI once NB is trigger
BUT we need change VERSION to 15-SP1 since only this can let migration code handle correctly to upgrade to 15SP1 in stead of 12-SP5. 
This flavor will only using by migration group and will not impact any other group, once 12sp5 project finish, we can delete this special setting.
Welcome any comments.

- Related ticket: https://progress.opensuse.org/issues/52406
- Needles: n/a
- Verification run: n/a
