### PR TITLE
Slurm failover with nfs shared directory

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -3,7 +3,7 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
-use utils 'systemctl';
+use utils;
 
 sub enable_and_start {
     my ($self, $arg) = @_;
@@ -33,17 +33,29 @@ sub switch_user {
     assert_screen 'user-nobody';
 }
 
-sub prepare_slurm_conf {
+## Prepare ctl node names, so those names could be reused, for instance
+## in config preparation, munge key distribution, etc.
+## TODO: make it generic, once it is needed
+sub ctl_node_names {
     my $ctl_nodes = get_required_var("CLUSTER_CTL_FAILOVER");
-    my $nodes = get_required_var("CLUSTER_NODES");
-
     my @ctl_node_names;
-    my @compute_node_names;
 
     for (my $node = 0; $node <= $ctl_nodes; $node++) {
         my $name = sprintf("slurm-master%02d", $node);
         push @ctl_node_names, $name;
     }
+
+    return @ctl_node_names;
+}
+
+## Prepare compute node names, so those names could be reused, for
+## instance in config preparation, munge key distribution, etc.
+## TODO: make it generic, once it is needed
+sub compute_node_names {
+    my $ctl_nodes = get_required_var("CLUSTER_CTL_FAILOVER");
+    my $nodes     = get_required_var("CLUSTER_NODES");
+
+    my @compute_node_names;
 
     #adjust node value, so slurm.conf could account for correct count of slaves
     $nodes = $nodes - $ctl_nodes;
@@ -52,26 +64,62 @@ sub prepare_slurm_conf {
         push @compute_node_names, $name;
     }
 
-    my $cluster_ctl_nodes = join(',', @ctl_node_names);
-    my $cluster_compute_nodes = join(',', @compute_node_names);
+    return @compute_node_names;
+}
+
+## Prepare all node names, so those names could be reused
+sub cluster_names {
+    my @cluster_names;
+
+    my @cluster_ctl_nodes     = ctl_node_names();
+    my @cluster_compute_nodes = compute_node_names();
+
+    push(@cluster_ctl_nodes, @cluster_compute_nodes);
+    @cluster_names = @cluster_ctl_nodes;
+
+    return @cluster_names;
+}
+
+sub prepare_slurm_conf {
+    my $ctl_nodes = get_required_var("CLUSTER_CTL_FAILOVER");
+
+    my @cluster_ctl_nodes     = ctl_node_names();
+    my @cluster_compute_nodes = compute_node_names();
+    my $cluster_ctl_nodes     = join(',', @cluster_ctl_nodes);
+    my $cluster_compute_nodes = join(',', @cluster_compute_nodes);
 
     if ($ctl_nodes) {
         my $config = << "EOF";
-sed -i "/^ControlMachine.*/c\\ControlMachine=@ctl_node_names[0]" /etc/slurm/slurm.conf
-sed -i "/^#BackupController.*/c\\BackupController=@ctl_node_names[1]" /etc/slurm/slurm.conf
+sed -i "/^ControlMachine.*/c\\ControlMachine=$cluster_ctl_nodes[0]" /etc/slurm/slurm.conf
+sed -i "/^#BackupController.*/c\\BackupController=$cluster_ctl_nodes[1]" /etc/slurm/slurm.conf
+sed -i "/^StateSaveLocation.*/c\\StateSaveLocation=/shared/slurm/" /etc/slurm/slurm.conf
 sed -i "/^NodeName.*/c\\NodeName=$cluster_ctl_nodes,$cluster_compute_nodes Sockets=1 CoresPerSocket=1 ThreadsPerCore=1 State=unknown" /etc/slurm/slurm.conf
 sed -i "/^PartitionName.*/c\\PartitionName=normal Nodes=$cluster_ctl_nodes,$cluster_compute_nodes Default=YES MaxTime=24:00:00 State=UP" /etc/slurm/slurm.conf
 sed -i "/^SlurmctldTimeout.*/c\\SlurmctldTimeout=15" /etc/slurm/slurm.conf
 sed -i "/^SlurmdTimeout.*/c\\SlurmdTimeout=60" /etc/slurm/slurm.conf
 EOF
-    assert_script_run($_) foreach (split /\n/, $config);
+        assert_script_run($_) foreach (split /\n/, $config);
     } else {
         my $config = << "EOF";
-sed -i "/^ControlMachine.*/c\\ControlMachine=@ctl_node_names[0]" /etc/slurm/slurm.conf
+sed -i "/^ControlMachine.*/c\\ControlMachine=$cluster_ctl_nodes[0]" /etc/slurm/slurm.conf
 sed -i "/^NodeName.*/c\\NodeName=$cluster_ctl_nodes,$cluster_compute_nodes Sockets=1 CoresPerSocket=1 ThreadsPerCore=1 State=unknown" /etc/slurm/slurm.conf
 sed -i "/^PartitionName.*/c\\PartitionName=normal Nodes=$cluster_ctl_nodes,$cluster_compute_nodes Default=YES MaxTime=24:00:00 State=UP" /etc/slurm/slurm.conf
 EOF
-    assert_script_run($_) foreach (split /\n/, $config);
+        assert_script_run($_) foreach (split /\n/, $config);
+    }
+}
+
+sub distribute_munge_key {
+    my @cluster_nodes = cluster_names();
+    foreach (@cluster_nodes) {
+        exec_and_insert_password("scp -o StrictHostKeyChecking=no /etc/munge/munge.key root\@$_:/etc/munge/munge.key");
+    }
+}
+
+sub distribute_slurm_conf {
+    my @cluster_nodes = cluster_names();
+    foreach (@cluster_nodes) {
+        exec_and_insert_password("scp -o StrictHostKeyChecking=no /etc/slurm/slurm.conf root\@$_:/etc/slurm/slurm.conf");
     }
 }
 

--- a/tests/hpc/slurm_master_backup.pm
+++ b/tests/hpc/slurm_master_backup.pm
@@ -1,16 +1,14 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2019 SUSE LLC
+# Copyright © 2017-2018 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: HPC_Module: slurm master
-#    This test is setting up slurm master and starts the control node
+# Summary: slurm cluster initialization
 # Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
-# Tags: https://fate.suse.com/316379, https://progress.opensuse.org/issues/20308
 
 use base "hpcbase";
 use strict;
@@ -22,16 +20,23 @@ use utils;
 sub run {
     my $self  = shift;
     my $nodes = get_required_var("CLUSTER_NODES");
-    $self->prepare_user_and_group();
 
-    # install slurm
+    $self->prepare_user_and_group();
+    zypper_call('in nfs-client rpcbind');
+
+    systemctl 'start nfs';
+    systemctl 'start rpcbind';
+
+    assert_script_run("showmount -e 10.0.2.1");
+
+    assert_script_run("mkdir -p /shared/slurm");
+    assert_script_run("chown -Rcv slurm:slurm /shared/slurm");
+    assert_script_run("mount -t nfs -o nfsvers=3 10.0.2.1:/nfs/shared /shared/slurm");
+
     zypper_call('in slurm slurm-munge');
 
-    $self->prepare_slurm_conf();
     barrier_wait("SLURM_SETUP_DONE");
-
-    $self->distribute_munge_key();
-    $self->distribute_slurm_conf();
+    barrier_wait("SLURM_MASTER_SERVICE_ENABLED");
 
     # enable and start munge
     $self->enable_and_start('munge');
@@ -44,14 +49,12 @@ sub run {
     $self->enable_and_start('slurmd');
     systemctl 'status slurmd';
 
-    # wait for slave to be ready
-    barrier_wait("SLURM_MASTER_SERVICE_ENABLED");
-    barrier_wait("SLURM_SLAVE_SERVICE_ENABLED");
-
-    # run the actual test against both nodes
     assert_script_run("srun -N ${nodes} /bin/ls");
+    assert_script_run("sinfo -N -l");
+    assert_script_run("scontrol ping");
 
-    barrier_wait('SLURM_MASTER_RUN_TESTS');
+    barrier_wait("SLURM_SLAVE_SERVICE_ENABLED");
+    barrier_wait("SLURM_MASTER_RUN_TESTS");
 }
 
 sub test_flags {


### PR DESCRIPTION
- Related ticket: 
https://progress.opensuse.org/issues/40718
- Verification run

(1) new tests for CTL failover:
supportserver:
http://10.160.66.198/tests/4725
ctl main
http://10.160.66.198/tests/4726
ctl backup:
http://10.160.66.198/tests/4727
compute nodes:
http://10.160.66.198/tests/4728
http://10.160.66.198/tests/4729

(2) the test does use the same barriers so here is the run demonstrating nothing is broken:
supportserver:
http://10.160.66.198/tests/4720
ctl:
http://10.160.66.198/tests/4724
compute nodes:
http://10.160.66.198/tests/4722
http://10.160.66.198/tests/4723
http://10.160.66.198/tests/4724

