### PR TITLE
[SLE-12-SP5 Preparation] Host upgrade from SLE-11-SP4 to SLE-12-SP5 needs the same treatment as to SLE-15

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -120,7 +120,7 @@ sub login_to_console {
             my $host_upgrade_version = get_required_var('UPGRADE_PRODUCT');         #format sles-15-sp0
             my $host_upgrade_relver  = $host_upgrade_version =~ /sles-(\d+)-sp/i;
             my $host_upgrade_spver   = $host_upgrade_version =~ /sp(\d+)$/im;
-            if (($host_installed_version eq '11') && ($host_upgrade_relver eq '15') && ($host_upgrade_spver eq '0')) {
+            if (($host_installed_version eq '11') && (($host_upgrade_relver eq '15' && $host_upgrade_spver eq '0') || ($host_upgrade_relver eq '12' && $host_upgrade_spver eq '5'))) {
                 assert_screen('sshd-server-started-config', 180);
                 use_ssh_serial_console;
                 save_screenshot;


### PR DESCRIPTION
1st time configuration step after upgrade is needed for SLE-12-SP5 as upgraded product

- Related ticket: 
  https://openqa.suse.de/tests/2952779
  https://openqa.suse.de/tests/2952674
- Needles: n/a
- Verification run: Might not be needed for this case