### PR TITLE
Replace script_run("zypper") with zypper_call

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -20,7 +20,7 @@ use y2_module_consoletest;
 our @EXPORT = qw(install_kernel_debuginfo prepare_for_kdump activate_kdump activate_kdump_without_yast kdump_is_active do_kdump);
 
 sub install_kernel_debuginfo {
-    assert_script_run 'zypper ref', 600;
+    zypper_call 'ref';
     # JeOS uses kernel-default-base, except on aarch64 openSUSE
     my $kernel    = is_jeos() && (!is_opensuse() && !check_var('ARCH', 'aarch64')) ? 'kernel-default-base' : 'kernel-default';
     my $debuginfo = script_output('rpmquery --queryformat="%{NAME}-%{VERSION}-%{RELEASE}\n" ' . $kernel . '| sort --version-sort | tail -n 1');

--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -154,7 +154,7 @@ sub check_rollback_system {
     systemctl('is-active rollback');
 
     # Disable the obsolete cd and dvd repos to avoid zypper error
-    assert_script_run("zypper mr -d -m cd -m dvd");
+    zypper_call("mr -d -m cd -m dvd");
     # Verify registration status matches current system version
     # system is un-registered during media based upgrade
     assert_script_run('curl -s ' . data_url('console/check_registration_status.py') . ' | python') unless get_var('MEDIA_UPGRADE');

--- a/tests/caasp/one_line_checks.pm
+++ b/tests/caasp/one_line_checks.pm
@@ -15,6 +15,7 @@ use strict;
 use warnings;
 use testapi;
 use version_utils 'is_caasp';
+use utils;
 
 sub run_rcshell_checks {
     # Check that system is using UTC timezone
@@ -60,13 +61,13 @@ sub run_caasp_checks {
 sub run_microos_checks {
     # Should not include kubernetes
     if (check_var('SYSTEM_ROLE', 'microos')) {
-        assert_script_run '! zypper se -i kubernetes';
+        zypper_call 'se -i kubernetes', exitcode => 104;
         assert_script_run '! rpm -q etcd';
     }
     # Should have unconfigured Kubernetes & container runtime environment
     if (check_var('SYSTEM_ROLE', 'kubeadm')) {
         assert_script_run 'which crio';
-        assert_script_run 'zypper se -i kubernetes';
+        zypper_call 'se -i kubernetes';
     }
 }
 

--- a/tests/caasp/stack_worker.pm
+++ b/tests/caasp/stack_worker.pm
@@ -18,13 +18,14 @@ use lockapi 'barrier_wait';
 use autotest 'query_isotovideo';
 use version_utils 'is_caasp';
 use caasp;
+use utils;
 
 # Updated from incident repo before adding to cluster
 sub incident_repo_dup {
     my $repo = get_required_var('INCIDENT_REPO');
     assert_script_run 'echo -e "[main]\nvendors = suse,opensuse,obs://build.suse.de,obs://build.opensuse.org" > /etc/zypp/vendors.d/vendors.conf';
-    assert_script_run "zypper ar --refresh --no-gpgcheck $repo UPDATE";
-    assert_script_run 'zypper lr -U';
+    zypper_call "ar --refresh --no-gpgcheck $repo UPDATE";
+    zypper_call 'lr -U';
     assert_script_run 'transactional-update cleanup dup', 300;
     microos_reboot 1;
 }

--- a/tests/console/a2ps.pm
+++ b/tests/console/a2ps.pm
@@ -14,10 +14,11 @@ use strict;
 use warnings;
 use base "consoletest";
 use testapi;
+use utils;
 
 sub run {
     select_console 'root-console';
-    assert_script_run("zypper -n in a2ps");
+    zypper_call "in a2ps";
     assert_script_run("curl https://www.suse.com > /tmp/suse.html");
     validate_script_output "a2ps -o /tmp/suse.ps /tmp/suse.html 2>&1", sub { m/saved into the file/ }, 3;
 }

--- a/tests/console/aide_check.pm
+++ b/tests/console/aide_check.pm
@@ -21,12 +21,13 @@
 
 use base "consoletest";
 use testapi;
+use utils;
 use strict;
 use warnings;
 
 sub run {
     select_console 'root-console';
-    assert_script_run "zypper -n in aide", 90;
+    zypper_call "in aide";
     assert_script_run "cp /etc/aide.conf /etc/aide.conf.bak";
     assert_script_run "sed -i 's:^/:!/:g' /etc/aide.conf && sed -i 's:!/var/log:/var/log:g' /etc/aide.conf";
     assert_script_run "aide -i", 60;

--- a/tests/console/dns_srv.pm
+++ b/tests/console/dns_srv.pm
@@ -14,13 +14,13 @@ use strict;
 use warnings;
 use base "consoletest";
 use testapi;
-use utils qw(is_bridged_networking systemctl);
+use utils qw(is_bridged_networking systemctl zypper_call);
 
 sub run {
     select_console 'root-console';
 
     # Install bind
-    assert_script_run "zypper -n -q in bind";
+    zypper_call "-q in bind";
 
     # check that it can be enabled and disabled;
     systemctl 'enable named';

--- a/tests/console/install_otherDE_pattern.pm
+++ b/tests/console/install_otherDE_pattern.pm
@@ -29,7 +29,7 @@ sub run {
     if (check_var("DE_IS_PKG", 1)) {
         $zypp_type = "package";
     }
-    assert_script_run("zypper -n in -t $zypp_type $pattern", 600);
+    zypper_call "in -t $zypp_type $pattern";
 
     # Reset the state of lightdm, to have the new default in use (lightdm saves what the user's last session was)
     assert_script_run("rm -f ~lightdm/.cache/lightdm-gtk-greeter/state /var/lib/AccountsService/users/*");

--- a/tests/console/lock_package.pm
+++ b/tests/console/lock_package.pm
@@ -15,6 +15,7 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
+use utils;
 
 our $locked_pkg_info = [];
 
@@ -29,7 +30,7 @@ sub run {
         push @$locked_pkg_info, {name => $pkg, fullname => $fullname};
 
         # Add a lock for each package
-        assert_script_run "zypper al $pkg";
+        zypper_call "al $pkg";
     }
 }
 

--- a/tests/console/rabbitmq.pm
+++ b/tests/console/rabbitmq.pm
@@ -17,14 +17,14 @@ use base "consoletest";
 use strict;
 use warnings;
 use testapi;
-use utils 'systemctl';
+use utils;
 
 sub run {
     select_console 'root-console';
-    assert_script_run('zypper -n in rabbitmq-server');
+    zypper_call 'in rabbitmq-server';
     systemctl 'start rabbitmq-server';
     systemctl 'status rabbitmq-server';
-    assert_script_run('zypper -n in python-pika wget');
+    zypper_call 'in python-pika wget';
     my $cmd = <<'EOF';
 mkdir rabbitmq
 cd rabbitmq

--- a/tests/console/yast2_cmdline.pm
+++ b/tests/console/yast2_cmdline.pm
@@ -24,8 +24,8 @@ sub run_yast_cli_test {
     my ($packname) = @_;
     my $PACKDIR = '/usr/src/packages';
 
-    assert_script_run "zypper -n in $packname";
-    assert_script_run "zypper -n si $packname";
+    zypper_call "in $packname";
+    zypper_call "si $packname";
     assert_script_run "rpmbuild -bp $PACKDIR/SPECS/$packname.spec";
     script_run "pushd $PACKDIR/BUILD/$packname-*";
 
@@ -48,10 +48,10 @@ sub run {
     prepare_source_repo;
 
     # Install test requirement
-    assert_script_run 'zypper -n in rpm-build';
+    zypper_call 'in rpm-build';
 
     # Enable source repo
-    assert_script_run 'zypper mr -e repo-source';
+    zypper_call 'mr -e repo-source';
 
     # Run YaST CLI tests
     run_yast_cli_test('yast2-network');

--- a/tests/console/yast2_lan_hostname.pm
+++ b/tests/console/yast2_lan_hostname.pm
@@ -63,7 +63,7 @@ sub hostname_via_dhcp {
 
 sub run {
     select_console 'root-console';
-    assert_script_run 'zypper -n in yast2-network';    # make sure yast2 lan module installed
+    zypper_call 'in yast2-network';    # make sure yast2 lan module installed
     hostname_via_dhcp('no');
     hostname_via_dhcp('yes-any');
     hostname_via_dhcp('yes-eth0');

--- a/tests/feature/feature_console/zypper_crit_sec_fix_only.pm
+++ b/tests/feature/feature_console/zypper_crit_sec_fix_only.pm
@@ -16,6 +16,7 @@ use strict;
 use warnings;
 use testapi;
 use registration;
+use utils;
 
 sub run {
     select_console 'root-console';
@@ -32,14 +33,14 @@ sub run {
         }
     }
 
-    assert_script_run "zypper ref", 120;
+    zypper_call "ref";
 
     my $zypper_patches = "zypper -n patches 2>/dev/null";
     # List all critical security fixes available, exclude "Not Needed" ones
     script_run "$zypper_patches | grep \"security .* critical\" | grep -v \"Not Needed\" | tee available_sec_crit_fixes", 60;
 
     # Install critical security fixes only
-    assert_script_run 'zypper -n patch --category security --severity critical', 600;
+    zypper_call 'patch --category security --severity critical';
 
     # Make sure all critical security fixes are installed
     script_run "$zypper_patches | grep \"security .* critical\" | grep Installed | tee installed_sec_crit_fixes", 60;

--- a/tests/installation/post_zdup.pm
+++ b/tests/installation/post_zdup.pm
@@ -21,7 +21,7 @@ use power_action_utils 'power_action';
 sub run {
     clear_console;
 
-    assert_script_run("zypper lr -d");
+    zypper_call "lr -d";
     # Remove the --force when this is fixed: https://bugzilla.redhat.com/1075131
     # Because of poo#32458 Hyper-V can't switch from VT to X11 and has to use
     # whatever the default in the image is.

--- a/tests/migration/sle12_online_migration/pre_migration.pm
+++ b/tests/migration/sle12_online_migration/pre_migration.pm
@@ -32,13 +32,13 @@ sub check_or_install_packages {
         my $output = script_output "rpm -qa yast2-migration zypper-migration-plugin rollback-helper | sort";
         if ($output !~ /rollback-helper.*?yast2-migration.*?zypper-migration-plugin/s) {
             record_soft_failure 'bsc#982150: migration packages were not installed along with system update. Installing missed package to continue the test';
-            assert_script_run "zypper -n in yast2-migration zypper-migration-plugin rollback-helper snapper", 190;
+            zypper_call "in yast2-migration zypper-migration-plugin rollback-helper snapper";
         }
     }
     else {
         # install necessary packages for online migration if system is not updated
         # also update snapper to ensure rollback service work properly after migration
-        assert_script_run "zypper -n in yast2-migration zypper-migration-plugin rollback-helper snapper", 190;
+        zypper_call "in yast2-migration zypper-migration-plugin rollback-helper snapper";
     }
 }
 

--- a/tests/s390x_tests/consoletest_MEMORY_memtester.pm
+++ b/tests/s390x_tests/consoletest_MEMORY_memtester.pm
@@ -22,7 +22,7 @@ use strict;
 sub run {
     my $self = shift;
     $self->copy_testsuite('MEMORY_memtester');
-    assert_script_run "zypper in -y gcc";
+    zypper_call "in gcc";
     assert_script_run "tar -xzf memtester*tar.gz && rm -rf memtester*tar.gz";
     assert_script_run "cd memtester*&& make && make install && cd ..";
 

--- a/tests/s390x_tests/consoletest_TOOL_s390_vmconvert.pm
+++ b/tests/s390x_tests/consoletest_TOOL_s390_vmconvert.pm
@@ -27,7 +27,7 @@ sub run {
     assert_script_run "echo -e \"$REPO_SUSE\" > /etc/zypp/repos.d/sles.repo";
     assert_script_run "cat /etc/zypp/repos.d/sles.repo";
 
-    assert_script_run("zypper in -y kernel-default-debuginfo", timeout => 900);
+    zypper_call "in kernel-default-debuginfo";
     assert_script_run "[ -f /boot/vmlinux-4.4.73-5-default.gz ] && gunzip /boot/vmlinux-4.4.73-5-default.gz || true";
 
     $self->execute_script('vmcon.sh', '', 3000);

--- a/tests/slepos/zypper_add_repo.pm
+++ b/tests/slepos/zypper_add_repo.pm
@@ -27,13 +27,13 @@ sub run {
     if (get_var('VERSION') =~ /^11/) {
         $slepos_repo         //= 'dvd:///?devices=/dev/sr1';
         $slepos_updates_repo //= 'http://' . $smt . '/repo/$RCE/SLE11-POS-SP3-Updates/sle-11-x86_64/';
-        assert_script_run "zypper ar '$slepos_repo' SLE-11-POS";
-        assert_script_run "zypper ar '$slepos_updates_repo' SLE-11-POS-UPDATES";
+        zypper_call "ar '$slepos_repo' SLE-11-POS";
+        zypper_call "ar '$slepos_updates_repo' SLE-11-POS-UPDATES";
     }
     elsif (get_var('VERSION') =~ /^12/) {
         # FIXME: no standard repos yet
-        assert_script_run "zypper ar '$slepos_repo' SLE-12-POS";
-        assert_script_run "zypper ar '$slepos_updates_repo' SLE-12-POS-UPDATES";
+        zypper_call "ar '$slepos_repo' SLE-12-POS";
+        zypper_call "ar '$slepos_updates_repo' SLE-12-POS-UPDATES";
     }
 
     save_screenshot;

--- a/tests/sysauth/sssd.pm
+++ b/tests/sysauth/sssd.pm
@@ -50,9 +50,10 @@ sub run {
 
     disable_and_stop_service('packagekit.service', mask_service => 1, ignore_failure => 1);
     if (check_var('DESKTOP', 'textmode')) {    # sssd test suite depends on killall, which is part of psmisc (enhanced_base pattern)
-        assert_script_run "zypper -n in psmisc";
+        zypper_call "in psmisc";
     }
-    assert_script_run "zypper -n refresh && zypper -n in @test_subjects", 200;
+    zypper_call "refresh";
+    zypper_call "in @test_subjects";
     assert_script_run "cd; curl -L -v " . autoinst_url . "/data/lib/version_utils.sh > /usr/local/bin/version_utils.sh";
     assert_script_run "cd; curl -L -v " . autoinst_url . "/data/sssd-tests > sssd-tests.data && cpio -id < sssd-tests.data && mv data sssd && ls sssd";
 

--- a/tests/toolchain/install.pm
+++ b/tests/toolchain/install.pm
@@ -31,8 +31,8 @@ sub run {
         # toolchain channels
         if (!check_var('ADDONS', 'tcm')) {
             my $arch = get_var('ARCH');
-            assert_script_run "zypper ar -f http://download.suse.de/ibs/SUSE/Products/SLE-Module-Toolchain/12/$arch/product/ SLE-Module-Toolchain12-Pool";
-            assert_script_run "zypper ar -f http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Toolchain/12/$arch/update/ SLE-Module-Toolchain12-Updates";
+            zypper_call "ar -f http://download.suse.de/ibs/SUSE/Products/SLE-Module-Toolchain/12/$arch/product/ SLE-Module-Toolchain12-Pool";
+            zypper_call "ar -f http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Toolchain/12/$arch/update/ SLE-Module-Toolchain12-Updates";
         }
         zypper_call('in -t pattern gcc5');
         zypper_call('up');

--- a/tests/transactional/transactional_update.pm
+++ b/tests/transactional/transactional_update.pm
@@ -20,6 +20,7 @@ use base "opensusebasetest";
 use testapi;
 use version_utils qw(is_caasp is_staging is_opensuse is_leap);
 use transactional;
+use utils;
 
 # Download files needed for transactional update test
 sub get_utt_packages {
@@ -87,7 +88,7 @@ sub run {
     unless (is_opensuse && is_staging) {
         record_info 'Update #1', 'Add repository and update - snapshot #2';
         # openSUSE does not need additional repo
-        assert_script_run 'zypper ar utt.repo' unless is_opensuse;
+        zypper_call 'ar utt.repo' unless is_opensuse;
         trup_call 'cleanup up';
         check_reboot_changes;
         check_package 'up';

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -41,10 +41,11 @@ sub patching_sle {
             set_var('HDD_SP2ORLATER', 1);
         }
         # disable existing repos temporary
-        assert_script_run("zypper lr && zypper mr --disable --all");
+        zypper_call "lr";
+        zypper_call "mr --disable --all";
         save_screenshot;
         sle_register("register");
-        assert_script_run('zypper lr -d');
+        zypper_call('lr -d');
     }
 
     # add test repositories and logs the required patches
@@ -102,7 +103,7 @@ sub patching_sle {
 
     # RMT didn't mirror all repos, cannot use enable all
     if (!get_var("SMT_URL")) {
-        assert_script_run("zypper mr --enable --all");
+        zypper_call("mr --enable --all");
     }
 
     # Disable old repositories during AutoYaST driven upgrade

--- a/tests/update/zypper_clear_repos.pm
+++ b/tests/update/zypper_clear_repos.pm
@@ -24,12 +24,12 @@ sub run {
 
     # remove Factory repos
     my $repos_folder = '/etc/zypp/repos.d';
-    script_run("zypper lr -d");
+    zypper_call 'lr -d';
     assert_script_run(
 "find $repos_folder/*.repo -type f -exec grep -q 'baseurl=http://download.opensuse.org/' {} \\; -delete && echo 'unneed_repos_removed' > /dev/$serialdev",
         15
     );
-    script_run("zypper lr -d");
+    zypper_call 'lr -d';
     save_screenshot;    # take a screenshot after repos removed
 
     if (get_var("STAGING")) {
@@ -37,7 +37,7 @@ sub run {
         # in Staging, enable it here.
         clear_console;
         assert_script_run("grep -rlE 'baseurl=cd:/(//)?\\?devices' $repos_folder | xargs --no-run-if-empty sed -i 's/^enabled=0/enabled=1/g'");
-        script_run("zypper lr -d");
+        zypper_call 'lr -d';
         save_screenshot;    # take a screenshot after repo enabled
     }
 }

--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -15,6 +15,7 @@ use warnings;
 use base "virt_autotest_base";
 use testapi;
 use virt_utils;
+use utils;
 
 sub install_package {
 
@@ -31,7 +32,7 @@ sub install_package {
     }
     else {
         script_run "zypper --non-interactive rr server-repo";
-        assert_script_run("zypper --non-interactive --no-gpg-check ar -f '$qa_server_repo' server-repo");
+        zypper_call("--no-gpg-check ar -f '$qa_server_repo' server-repo");
     }
 
     #workaround for dependency on xmlstarlet for qa_lib_virtauto on sles11sp4 and sles12sp1
@@ -60,17 +61,17 @@ sub install_package {
             lpar_cmd("zypper --non-interactive rr dependency_repo");
         }
         else {
-            assert_script_run("zypper --non-interactive --no-gpg-check ar -f ${dependency_repo} dependency_repo");
-            assert_script_run("zypper --non-interactive --gpg-auto-import-keys ref", 180);
-            assert_script_run("zypper --non-interactive in $dependency_rpms");
-            assert_script_run("zypper --non-interactive rr dependency_repo");
+            zypper_call("--no-gpg-check ar -f ${dependency_repo} dependency_repo");
+            zypper_call("--gpg-auto-import-keys ref", 180);
+            zypper_call("in $dependency_rpms");
+            zypper_call("rr dependency_repo");
         }
     }
 
     ###SLE-12-SP4 arm64 installation has no KVM role selection
     if (($repo_0_to_install =~ /SLE-12-SP4/m) && check_var('ARCH', 'aarch64')) {
-        assert_script_run("zypper --non-interactive --gpg-auto-import-keys ref",         180);
-        assert_script_run("zypper --non-interactive in -t pattern kvm_server kvm_tools", 300);
+        zypper_call("--gpg-auto-import-keys ref",         180);
+        zypper_call("in -t pattern kvm_server kvm_tools", 300);
     }
 
     #install qa_lib_virtauto
@@ -85,13 +86,13 @@ sub install_package {
         lpar_cmd("zypper --non-interactive in qa_lib_virtauto");
     }
     else {
-        assert_script_run("zypper --non-interactive --gpg-auto-import-keys ref", 180);
-        assert_script_run("zypper --non-interactive in qa_lib_virtauto",         1800);
+        zypper_call("--gpg-auto-import-keys ref", 180);
+        zypper_call("in qa_lib_virtauto",         1800);
     }
 
     if (get_var("PROXY_MODE")) {
         if (get_var("XEN")) {
-            assert_script_run("zypper --non-interactive in -t pattern xen_server", 1800);
+            zypper_call("in -t pattern xen_server", 1800);
         }
     }
 }

--- a/tests/virtualization/syscontainer_image_test.pm
+++ b/tests/virtualization/syscontainer_image_test.pm
@@ -15,6 +15,7 @@ use testapi;
 use strict;
 use warnings;
 use version_utils 'is_sle';
+use utils;
 
 sub run() {
     select_console 'root-console';
@@ -22,7 +23,7 @@ sub run() {
     return if is_sle && !(get_var('SCC_REGCODE') || get_var('HDD_SCC_REGISTERED'));
 
     # Check the repositories on the host first
-    assert_script_run("zypper lr");
+    zypper_call("lr");
 
     my $url    = get_required_var('SYSCONTAINER_IMAGE_URL');
     my $rootfs = '/tmp/rootfs';

--- a/tests/virtualization/yast_virtualization.pm
+++ b/tests/virtualization/yast_virtualization.pm
@@ -24,7 +24,7 @@ sub run {
     pkcon_quit;
     if (script_run('zypper se -i yast2-vm') == 104) {
         record_soft_failure 'bsc#1083398 - YaST2-virtualization provides wrong components for SLED';
-        assert_script_run 'zypper in -y yast2-vm';
+        zypper_call 'in yast2-vm';
     }
     $self->launch_yast2_module_x11('virtualization');
     # select everything

--- a/tests/x11/chrome.pm
+++ b/tests/x11/chrome.pm
@@ -41,8 +41,7 @@ sub run {
     script_run "rpm -qi gpg-pubkey-7fac5991-*";
     assert_screen 'google-key-installed';
 
-    # google chrome is a big package and might take some time
-    assert_script_run "zypper -n install $chrome_url", 300;
+    zypper_call "in $chrome_url";
     save_screenshot;
     # closing xterm
     send_key "alt-f4";

--- a/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
@@ -113,8 +113,8 @@ sub run {
         x11_start_program('xterm');
         script_run("gsettings set org.gnome.desktop.session idle-delay 0", 0);    #value=0 means never blank screen
         become_root;
-        script_run("zypper in -y libreoffice-base",                          900);
-        script_run("gsettings set org.gnome.desktop.session idle-delay 900", 0);     #default value=900
+        zypper_call("in libreoffice-base", timeout => 900);
+        script_run("gsettings set org.gnome.desktop.session idle-delay 900", 0);    #default value=900
         send_key 'alt-f4';
         $self->open_overview();
         type_string "base";
@@ -124,20 +124,20 @@ sub run {
     select_base_and_cleanup;
 
     $self->open_overview();
-    type_string "calc";                                                              #open calc
+    type_string "calc";                                                             #open calc
     assert_and_click 'overview-office-calc';
     assert_screen 'test-oocalc-1';
-    send_key "ctrl-q";                                                               #close calc
+    send_key "ctrl-q";                                                              #close calc
 
     $self->open_overview();
-    type_string "draw";                                                              #open draw
+    type_string "draw";                                                             #open draw
     assert_screen 'overview-office-draw';
     send_key "ret";
     assert_screen 'oodraw-launched';
-    send_key "ctrl-q";                                                               #close draw
+    send_key "ctrl-q";                                                              #close draw
 
     $self->open_overview();
-    type_string "impress";                                                           #open impress
+    type_string "impress";                                                          #open impress
     assert_screen 'overview-office-impress';
     send_key "ret";
     assert_screen [qw(ooimpress-select-a-template ooimpress-select-template-nofocus ooimpress-launched)];
@@ -147,18 +147,18 @@ sub run {
         assert_screen 'ooimpress-launched';
     }
     elsif (match_has_tag 'ooimpress-select-a-template') {
-        send_key 'alt-f4';                                                           # close impress template window
+        send_key 'alt-f4';                                                          # close impress template window
         assert_screen 'ooimpress-launched';
     }
-    send_key "ctrl-q";                                                               #close impress
+    send_key "ctrl-q";                                                              #close impress
 
     $self->open_overview();
-    type_string "writer";                                                            #open writer
+    type_string "writer";                                                           #open writer
     assert_screen 'overview-office-writer';
     send_key "ret";
     assert_screen 'test-ooffice-1';
     assert_and_click('ooffice-writing-area', timeout => 10);
-    send_key "ctrl-q";                                                               #close writer
+    send_key "ctrl-q";                                                              #close writer
 }
 
 1;

--- a/tests/x11/nis_client.pm
+++ b/tests/x11/nis_client.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 use testapi;
 use lockapi 'mutex_lock';
-use utils 'systemctl';
+use utils;
 use version_utils 'is_sle';
 use mm_network 'setup_static_mm_network';
 use y2_module_guitest '%setup_nis_nfs_x11';
@@ -99,7 +99,7 @@ sub run {
     turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
     become_root;
     setup_static_mm_network($setup_nis_nfs_x11{client_address});
-    assert_script_run 'zypper -n in yast2-nis-server';
+    zypper_call 'in yast2-nis-server';
 
     if ($self->firewall eq 'firewalld') {
         record_soft_failure('bsc#1083487');

--- a/tests/x11/nis_server.pm
+++ b/tests/x11/nis_server.pm
@@ -17,7 +17,7 @@ use warnings;
 use testapi;
 use lockapi 'mutex_create';
 use mmapi 'wait_for_children';
-use utils 'systemctl';
+use utils;
 use mm_network 'setup_static_mm_network';
 use y2_module_guitest '%setup_nis_nfs_x11';
 use version_utils 'is_sle';
@@ -119,7 +119,7 @@ sub run {
     turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
     become_root;
     setup_static_mm_network($setup_nis_nfs_x11{server_address});
-    assert_script_run 'zypper -n in yast2-nis-server yast2-nfs-server';
+    zypper_call 'in yast2-nis-server yast2-nfs-server';
     # Workarounds:
     # Yast2 does not open ports for SuseFirewall2 (bsc#999873)
     # Missing firewalld service files for NFS/NIS -> lack of support for RPC (bsc#1083486)


### PR DESCRIPTION
Ticket: https://progress.opensuse.org/issues/51467

Verification:

File | Verification |
--- | --- |
`tests/console/rabbitmq.pm` | http://artemis.suse.de/tests/1351 |
`tests/virtualization/syscontainer_image_test.pm` | Seems orphaned |
`tests/virtualization/yast_virtualization.pm` | https://openqa.opensuse.org/t957524 |
`tests/x11/chrome.pm` | http://artemis.suse.de/tests/1352#step/chrome/26 |
`tests/x11/libreoffice/libreoffice_mainmenu_components.pm` | Unable to verify because [reason](https://openqa.suse.de/tests/2976407#next_previous) |
`tests/x11/nis_client.pm` | https://openqa.suse.de/tests/2977934 |
`tests/x11/nis_server.pm` | https://openqa.suse.de/tests/2977932#step/nis_server/50 |