### PR TITLE
btrfs-progs: Compress testlogs to a tarball and upload

### DIFF
--- a/tests/btrfs-progs/generate_report.pm
+++ b/tests/btrfs-progs/generate_report.pm
@@ -9,8 +9,6 @@
 #
 # Summary: Upload logs and generate junit report
 # Maintainer: An Long <lan@suse.com>
-package generate_report;
-
 use strict;
 use warnings;
 use base 'opensusebasetest';
@@ -19,8 +17,9 @@ use testapi;
 use ctcs2_to_junit;
 use upload_system_log;
 
-my $STATUS_LOG = '/opt/status.log';
-my $JUNIT_FILE = '/opt/output.xml';
+use constant STATUS_LOG => '/opt/status.log';
+use constant LOG_DIR    => '/opt/logs/';
+use constant JUNIT_FILE => '/opt/output.xml';
 
 sub log_end {
     my $file = shift;
@@ -29,23 +28,37 @@ sub log_end {
     assert_script_run($cmd);
 }
 
+# Compress the directory and upload tarball.
+sub upload_tarball {
+    my $dir     = shift;
+    my $timeout = shift || 90;
+    my $output  = script_output("if [ -d $dir ]; then basename $dir; else echo $dir folder not exist; fi");
+    if ($output =~ /folder not exist/) { return; }
+    my $tarball = "/opt/$output.tar.xz";
+    assert_script_run("tar cJf $tarball -C " . dirname($dir) . " " . basename($dir), $timeout);
+    upload_logs($tarball, timeout => $timeout, log_name => 'upload');
+}
+
 sub run {
     my $self = shift;
     $self->select_serial_terminal;
 
     # Finalize status log and upload it
-    log_end($STATUS_LOG);
-    upload_logs($STATUS_LOG, timeout => 60, log_name => "test");
+    log_end STATUS_LOG;
+    upload_logs(STATUS_LOG, log_name => "test");
+
+    # Upload test logs
+    upload_tarball LOG_DIR;
 
     #upload system log
     upload_system_logs();
 
     # Junit xml report
-    my $script_output = script_output("cat $STATUS_LOG", 600);
+    my $script_output = script_output('cat ' . STATUS_LOG);
     my $tc_result     = analyzeResult($script_output);
     my $xml           = generateXML($tc_result);
-    assert_script_run("echo \'$xml\' > $JUNIT_FILE", 7200);
-    parse_junit_log($JUNIT_FILE);
+    assert_script_run("echo \'$xml\' > " . JUNIT_FILE);
+    parse_junit_log JUNIT_FILE;
 }
 
 1;


### PR DESCRIPTION
btrfs-progs save log file as xxx--tests-results.txt. But it will replaced with next test. This PR save each test log file to one tarball as upload-logs.tar.xz and upload it.

- Related ticket: https://progress.opensuse.org/issues/50105

- Verification run:
http://10.67.133.10/tests/381  (No var for CATEGORY)
http://10.67.133.10/tests/380  (Has CATEGORY var and passed)
