### PR TITLE
WiP Slurm: initial test for slurm configured with db

### DIFF
--- a/tests/hpc/slurm_master_backup_db.pm
+++ b/tests/hpc/slurm_master_backup_db.pm
@@ -1,0 +1,71 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017-2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: HPC_Module: slurm failover - database
+#    This test is setting up slurm control backup nodes with accounting
+#    configured (database) so that the failover of the ctls can be tested
+# Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
+
+use base "hpcbase";
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use utils;
+
+sub run {
+    my $self  = shift;
+    my $nodes = get_required_var("CLUSTER_NODES");
+    $self->prepare_user_and_group();
+
+    ## TO BE REMOVED
+    zypper_call('in nfs-client rpcbind');
+    systemctl 'start nfs';
+    systemctl 'start rpcbind';
+    assert_script_run("showmount -e 10.0.2.1");
+    assert_script_run("mkdir -p /shared/slurm");
+    assert_script_run("chown -Rcv slurm:slurm /shared/slurm");
+    assert_script_run("mount -t nfs -o nfsvers=3 10.0.2.1:/nfs/shared /shared/slurm");
+    ## TO BE REMOVED
+
+    # provision HPC cluster, so the proper rpms are installed
+    # and proper services are enabled and started
+    zypper_call('in slurm slurm-munge');
+    barrier_wait("SLURM_SETUP_DONE");
+    barrier_wait("SLURM_MASTER_SERVICE_ENABLED");
+    assert_script_run("cat /etc/slurm/slurm.conf");
+    $self->enable_and_start('munge');
+    $self->enable_and_start('slurmctld');
+    systemctl 'status slurmctld';
+    $self->enable_and_start('slurmd');
+    systemctl 'status slurmd';
+
+    # wait for slave to be ready
+    barrier_wait("SLURM_SLAVE_SERVICE_ENABLED");
+
+    # run the actual test against both nodes
+    assert_script_run("srun -N ${nodes} /bin/ls");
+
+    barrier_wait('SLURM_MASTER_RUN_TESTS');
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+    $self->upload_service_log('slurmd');
+    $self->upload_service_log('munge');
+    $self->upload_service_log('slurmctld');
+}
+
+1;
+

--- a/tests/hpc/slurm_master_db.pm
+++ b/tests/hpc/slurm_master_db.pm
@@ -1,0 +1,75 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017-2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: HPC_Module: slurm failover - database
+#    This test is setting up slurm controle nodes with accounting configured
+#    (database) so that the failover of the ctls can be tested
+# Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
+
+use base "hpcbase";
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use utils;
+
+sub run {
+    my $self  = shift;
+    my $nodes = get_required_var("CLUSTER_NODES");
+    $self->prepare_user_and_group();
+
+    # provision HPC cluster, so the proper rpms are installed,
+    # munge key is distributed to all nodes, so is slurm.conf
+    # and proper services are enabled and started
+    zypper_call('in slurm slurm-munge');
+
+    ##TO BE REMOVED
+    zypper_call('in nfs-client rpcbind');
+    systemctl 'start nfs';
+    systemctl 'start rpcbind';
+    assert_script_run("showmount -e 10.0.2.1");
+    assert_script_run("mkdir -p /shared/slurm");
+    assert_script_run("chown -Rcv slurm:slurm /shared/slurm");
+    assert_script_run("mount -t nfs -o nfsvers=3 10.0.2.1:/nfs/shared /shared/slurm");
+    ##TO BE REMOVED
+
+    $self->prepare_slurm_conf();
+    assert_script_run("cat /etc/slurm/slurm.conf");
+    barrier_wait("SLURM_SETUP_DONE");
+    $self->distribute_munge_key();
+    $self->distribute_slurm_conf();
+    $self->enable_and_start('munge');
+    $self->enable_and_start('slurmctld');
+    systemctl 'status slurmctld';
+    $self->enable_and_start('slurmd');
+    systemctl 'status slurmd';
+
+    # wait for slave to be ready
+    barrier_wait("SLURM_MASTER_SERVICE_ENABLED");
+    barrier_wait("SLURM_SLAVE_SERVICE_ENABLED");
+
+    # run the actual test against both nodes
+    assert_script_run("srun -N ${nodes} /bin/ls");
+
+    barrier_wait('SLURM_MASTER_RUN_TESTS');
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+    $self->upload_service_log('slurmd');
+    $self->upload_service_log('munge');
+    $self->upload_service_log('slurmctld');
+}
+
+1;


### PR DESCRIPTION
Slurm can be configured with the database for 'accounting' and this
tests is meant to test this functionality of the slurm and the HPC
product

- Related ticket: https://progress.opensuse.org/issues/52259