### PR TITLE
Rollback use of select_serial_terminal in sles4sap tests

### DIFF
--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -16,6 +16,7 @@ use strict;
 use warnings;
 use testapi;
 use version_utils 'is_sle';
+use Utils::Backends 'use_ssh_serial_console';
 
 sub upload_install_log {
     script_run "tar -zcvf /tmp/hana_install.log.tgz /var/tmp/hdb*";
@@ -31,7 +32,7 @@ sub run {
     my $password = 'Qwerty_123';
     set_var('PASSWORD', $password);
 
-    $self->select_serial_terminal;
+    check_var('BACKEND', 'ipmi') ? use_ssh_serial_console : select_console 'root-console';
     my $RAM = $self->get_total_mem();
     die "RAM=$RAM. The SUT needs at least 24G of RAM" if $RAM < 24000;
 
@@ -113,7 +114,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = @_;
-    $self->select_serial_terminal();
+    check_var('BACKEND', 'ipmi') ? use_ssh_serial_console : select_console 'root-console';
     upload_install_log;
     assert_script_run "save_y2logs /tmp/y2logs.tar.xz";
     upload_logs "/tmp/y2logs.tar.xz";

--- a/tests/sles4sap/netweaver_install.pm
+++ b/tests/sles4sap/netweaver_install.pm
@@ -15,6 +15,7 @@ use base "sles4sap";
 use testapi;
 use lockapi;
 use hacluster;
+use Utils::Backends 'use_ssh_serial_console';
 use strict;
 use warnings;
 
@@ -42,7 +43,7 @@ sub run {
     push @sapoptions, "SAPINST_INPUT_PARAMETERS_URL=$params_file";
     push @sapoptions, "SAPINST_EXECUTE_PRODUCT_ID=$product_id:NW750.HDB.ABAPHA";
 
-    $self->select_serial_terminal;
+    check_var('BACKEND', 'ipmi') ? use_ssh_serial_console : select_console 'root-console';
 
     # This installs Netweaver's ASCS. Start by making sure the correct
     # SAP profile and solution are configured in the system

--- a/tests/sles4sap/patterns.pm
+++ b/tests/sles4sap/patterns.pm
@@ -14,6 +14,7 @@ use base "sles4sap";
 use testapi;
 use utils;
 use version_utils qw(is_sle is_upgrade);
+use Utils::Backends 'use_ssh_serial_console';
 use strict;
 use warnings;
 
@@ -22,7 +23,7 @@ sub run {
     my @sappatterns = qw(sap-nw sap-b1 sap-hana);
     my $output      = '';
 
-    $self->select_serial_terminal();
+    check_var('BACKEND', 'ipmi') ? use_ssh_serial_console : select_console 'root-console';
 
     # Disable packagekit
     pkcon_quit;

--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -16,6 +16,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Backends 'use_ssh_serial_console';
 use x11utils 'turn_off_gnome_screensaver';
 
 sub try_reclaiming_space {
@@ -74,7 +75,7 @@ sub run {
     my $password = 'Qwerty_123';
     set_var('PASSWORD', $password);
 
-    $self->select_serial_terminal();
+    check_var('BACKEND', 'ipmi') ? use_ssh_serial_console : select_console 'root-console';
     my $RAM = $self->get_total_mem();
     die "RAM=$RAM. The SUT needs at least 24G of RAM" if $RAM < 24000;
 
@@ -142,7 +143,7 @@ sub test_flags {
 
 sub post_fail_hook {
     my ($self) = @_;
-    $self->select_serial_terminal();
+    check_var('BACKEND', 'ipmi') ? use_ssh_serial_console : select_console 'root-console';
     assert_script_run 'tar cf /tmp/logs.tar /var/adm/autoinstall/logs /var/tmp/hdb*; xz -9v /tmp/logs.tar';
     upload_logs '/tmp/logs.tar.xz';
     assert_script_run "save_y2logs /tmp/y2logs.tar.xz";


### PR DESCRIPTION
The use of `opensusebasetest::select_serial_terminal` in sles4sap tests introduced in PR #7590  caused some failures in the tests particularly when `ARCH=ppc64le`, and when the sles4sap test modules are used together with the HA test modules which perform calls to `assert_screen` in the console. This PR rolls back the change to use either `select_console 'root-console'` or `Utils::Backends::use_ssh_serial_console` when over IPMI.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/1032 & http://mango.suse.de/tests/1033
- Failing tests: https://openqa.suse.de/tests/2952870, https://openqa.suse.de/tests/2952869, https://openqa.suse.de/tests/2952875, https://openqa.suse.de/tests/2952878, https://openqa.suse.de/tests/2952883, https://openqa.suse.de/tests/2953139
