### PR TITLE
yast2_http: make sure http-server screen is displayed

### DIFF
--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -29,6 +29,8 @@ sub run {
     #if NetworkManager manager is in use a confirm command will be send to close the warning popup:
     if (match_has_tag 'yast2-lan-warning-network-manager') {
         send_key $cmd{continue};
+        # Make sure we do not hit 'alt-i' too early
+        assert_screen 'http-server';
     }
 
     send_key 'alt-i';    # Confirm apache2 and apache2-prefork installation


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/52241
- Verification run: https://openqa.opensuse.org/tests/952415#step/yast2_http/5