### PR TITLE
Remove seahorse_sshkey case from s390x test group

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2132,7 +2132,8 @@ sub load_security_tests_crypt_misc {
     # appropriate for other arches.
     loadtest "x11/hexchat_ssl" if (is_x86_64);
     loadtest "x11/x3270_ssl";
-    loadtest "x11/seahorse_sshkey";
+    # seahorse_sshkey is provided in WE only for x86_64 platform
+    loadtest "x11/seahorse_sshkey" if (is_x86_64);
 }
 
 sub load_security_tests_crypt_tool {


### PR DESCRIPTION
Seahorse package is in WE extension not supported for s390x test group

- Related ticket: https://progress.opensuse.org/issues/52415
- Needles: NA
- Verification run: There is no s390x worker in local and this is a simple fix for removing seahorse from s390x test group