### PR TITLE
Add new FIPS tests: links_https and lynx_https

### DIFF
--- a/lib/apachetest.pm
+++ b/lib/apachetest.pm
@@ -1,6 +1,6 @@
 # SUSE's Apache tests
 #
-# Copyright © 2016-2018 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -42,7 +42,7 @@ sub setup_apache2 {
     }
 
     # Make sure the packages are installed
-    zypper_call("in @packages");
+    zypper_call("--no-gpg-checks in @packages");
 
     # Enable php7
     if ($mode eq "PHP7") {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2105,6 +2105,10 @@ sub load_security_tests_crypt_web {
     loadtest "console/curl_https";
     loadtest "console/wget_https";
     loadtest "console/w3m_https";
+    if (is_sle('15+') || is_tumbleweed) {
+        loadtest "console/links_https";
+        loadtest "console/lynx_https";
+    }
     loadtest "console/apache_ssl";
     if (check_var('DISTRI', 'sle') && get_var('FIPS_ENABLED')) {
         loadtest "fips/mozilla_nss/apache_nssfips";

--- a/lib/web_browser.pm
+++ b/lib/web_browser.pm
@@ -1,0 +1,84 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: common functions for FIPS web browser tests
+# Maintainer: llzhao <llzhao@suse.com>
+
+package web_browser;
+
+use base Exporter;
+use Exporter;
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils 'is_sle';
+use registration qw(add_suseconnect_product register_product);
+
+our @EXPORT = qw(
+  setup_web_browser_env
+  run_web_browser_text_based
+);
+
+# Setup test envs: register PackageHub and check FIPS pattern installed
+sub setup_web_browser_env {
+    my $ret = 0;
+
+    if (is_sle) {
+        # Check the register status for reference
+        script_run("SUSEConnect --list-extension | grep 'SUSE Package Hub' | grep '(Activated)'");
+        $ret = script_run("output=`SUSEConnect -s | grep 'PackageHub'`; echo \${output##*PackageHub} | cut -d ':' -f4 | grep 'Registered'");
+        # Workaround: in some cases extensions may be in false "Activated" status,
+        # then just re-register it and do not check the return value
+        if ($ret ne 0) {
+            register_product();
+            my $version = get_required_var('VERSION') =~ s/([0-9]+)-SP([0-9]+)/$1.$2/r;
+            my $arch    = get_required_var('ARCH');
+            script_run("SUSEConnect -d -p PackageHub/$version/$arch", 300);
+            script_run("SUSEConnect -p PackageHub/$version/$arch",    300);
+        }
+    }
+    zypper_call("--no-refresh --no-gpg-checks search -it pattern fips") if get_var('FIPS_ENABLED');
+}
+
+# Run text based web browser with options
+# $browser: The name of text based web browser: w3m/links/lynx
+# $options: command line options
+sub run_web_browser_text_based {
+    my ($browser, $options) = @_;
+
+    my %https_url = (
+        google => "https://www.google.com/ncr",
+        suse   => "https://www.suse.com/",
+        OBS    => "https://build.opensuse.org/",
+    );
+
+    for my $p (keys %https_url) {
+        type_string "clear\n";
+        script_run "$browser $options $https_url{$p}", 0;
+
+        # Send key "o" ("OK" button) in case of any popup
+        # Note: key "o" can open "Option Setting Panel" in "w3m"
+        if ($browser ne "w3m") {
+            send_key "o";
+        }
+
+        assert_screen "$browser-connect-$p-webpage";
+        send_key "q";
+        send_key "y";
+    }
+}
+
+1;

--- a/tests/console/libmicrohttpd.pm
+++ b/tests/console/libmicrohttpd.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests - FIPS tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,7 +20,7 @@ sub run {
     select_console 'root-console';
 
     # Install greenbone-security-assistant
-    zypper_call("in greenbone-security-assistant");
+    zypper_call("--no-gpg-checks in greenbone-security-assistant");
 
     # Create self-signed certificates
     clear_console;

--- a/tests/console/links_https.pm
+++ b/tests/console/links_https.pm
@@ -1,0 +1,35 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test with "FIPS" installed and enabled, the WWW browser "links"
+#          can access https web pages successfully.
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#52289, tc#1621467
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+use web_browser qw(setup_web_browser_env run_web_browser_text_based);
+
+sub run {
+    select_console "root-console";
+    setup_web_browser_env();
+    zypper_call("--no-refresh --no-gpg-checks in links");
+    run_web_browser_text_based("links", undef);
+}
+
+1;

--- a/tests/console/lynx_https.pm
+++ b/tests/console/lynx_https.pm
@@ -1,0 +1,35 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test with "FIPS" installed and enabled, the WWW browser "lynx"
+#          can access https web pages successfully.
+# Maintainer: llzhao <llzhao@suse.com>
+# Tags: poo#52292, tc#1621466
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+use web_browser qw(setup_web_browser_env run_web_browser_text_based);
+
+sub run {
+    select_console("root-console");
+    setup_web_browser_env();
+    zypper_call("--no-refresh --no-gpg-checks in lynx");
+    run_web_browser_text_based("lynx", "-accept_all_cookies");
+}
+
+1;

--- a/tests/console/w3m_https.pm
+++ b/tests/console/w3m_https.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests - FIPS tests
 #
-# Copyright © 2016 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -19,26 +19,13 @@ use strict;
 use warnings;
 use testapi;
 use utils 'zypper_call';
+use web_browser qw(setup_web_browser_env run_web_browser_text_based);
 
 sub run {
-    select_console "root-console";
-
-    assert_script_run('rpm -q w3m');
-    zypper_call('--no-refresh search -it pattern fips');
-
-    my %https_url = (
-        google => "https://www.google.com/ncr",
-        suse   => "https://www.suse.com/",
-        OBS    => "https://build.opensuse.org/",
-    );
-
-    for my $p (keys %https_url) {
-        type_string "clear\n";
-        script_run "w3m $https_url{$p}", 0;
-        assert_screen "w3m-connect-$p-webpage";
-        send_key "q";
-        send_key "y";
-    }
+    select_console("root-console");
+    setup_web_browser_env();
+    zypper_call("--no-refresh --no-gpg-checks in w3m");
+    run_web_browser_text_based("w3m", undef);
 }
 
 1;


### PR DESCRIPTION
poo#52289 Implement test for FIPS - links
poo#52292 Implement test for FIPS - lynx

Add new FIPS tests: links_https and lynx_https.
All pass and introduced no issues.
NOTE: there is a needle MR.

- Related ticket: 
   https://progress.opensuse.org/issues/52289
   https://progress.opensuse.org/issues/52292

- Needles: 
   https://gitlab.suse.de/llzhao/os-autoinst-needles-sles/commit/670afd171a6bb7141bbec53c4633c6528b0e3b71
- Verification run: 
   sle15-sp1 (all pass): http://10.67.19.89/tests/1115
