### PR TITLE
Extended apache server testing - migration

### DIFF
--- a/lib/services/apache.pm
+++ b/lib/services/apache.pm
@@ -1,0 +1,64 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Package for apache2 service tests
+#
+# Maintainer: Huajian Luo <hluo@suse.com>
+
+package services::apache;
+use base 'opensusebasetest';
+use testapi;
+use utils;
+use strict;
+use warnings;
+
+sub install_service {
+    zypper_call('in apache2');
+}
+
+sub enable_service {
+    systemctl 'enable apache2';
+}
+
+sub start_service {
+    systemctl 'start apache2';
+}
+
+# check service is running and enabled
+sub check_service {
+    systemctl 'is-enabled apache2.service';
+    systemctl 'is-active apache2';
+}
+
+# check httpd function
+sub check_function {
+    # verify httpd serves index.html
+    type_string "echo Lorem ipsum dolor sit amet > /srv/www/htdocs/index.html\n";
+    assert_script_run(
+        "curl -f http://localhost/ | grep 'Lorem ipsum dolor sit amet'",
+        timeout      => 90,
+        fail_message => 'Could not access local apache2 instance'
+    );
+}
+
+# check apache service before and after migration
+# stage is 'before' or 'after' system migration.
+sub full_apache_check {
+    my ($stage) = @_;
+    $stage //= '';
+    if ($stage eq 'before') {
+        install_service();
+        enable_service();
+        start_service();
+    }
+    check_service();
+    check_function();
+}
+
+1;

--- a/tests/console/http_srv.pm
+++ b/tests/console/http_srv.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -11,42 +11,32 @@
 # Summary: Simple apache server test
 # Maintainer: Oliver Kurz <okurz@suse.de>
 
+package http_srv;
+use services::apache;
 use strict;
 use warnings;
-use base "consoletest";
+use base 'consoletest';
 use testapi;
 use utils;
 
 sub run {
+    my ($self) = @_;
     select_console 'root-console';
-    # Log space available before installation, see poo#19834
     script_run("df -h > /dev/$serialdev", 0);
-    # Install apache2
-    zypper_call("in apache2");
-    # After installation, apache2 is disabled
-    systemctl 'show -p UnitFileState apache2.service|grep UnitFileState=disabled';
 
-    # let's try to run it
-    systemctl 'start apache2.service';
-    systemctl 'show -p ActiveState apache2.service|grep ActiveState=active';
-    systemctl 'show -p SubState apache2.service|grep SubState=running';
-
-    # verify httpd serves index.html
-    type_string "echo Lorem ipsum dolor sit amet > /srv/www/htdocs/index.html\n";
-    assert_script_run(
-        "curl -f http://localhost/ | grep 'Lorem ipsum dolor sit amet'",
-        timeout      => 90,
-        fail_message => 'Could not access local apache2 instance'
-    );
+    services::apache::install_service();
+    services::apache::enable_service();
+    services::apache::start_service();
+    services::apache::check_service();
+    services::apache::check_function();
 }
 
 sub post_fail_hook {
-    my ($self) = shift;
+    my ($self) = @_;
     $self->SUPER::post_fail_hook;
     select_console('log-console');
     # Log disk usage if test failed, see poo#19834
     script_run("df -h > /dev/$serialdev", 0);
-
 }
 
 1;


### PR DESCRIPTION
Extended apache server testing for migration test. We reconstruct http_srv.pm to be checked at 
install_service and check_service in service_check.pm.

- Related ticket: https://progress.opensuse.org/issues/52589
- Needles: N/A
- Verification run: http://openqa-apac1.suse.de/tests/4393
                            http://10.161.8.44/tests/94