### PR TITLE
xfstests: Clear screen before next step

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -334,6 +334,7 @@ sub run {
     script_run("NUM=0; while [ ! -f $local_file ]; do sleep 10; NUM=\$(( \$NUM + 1 )); if [ \$NUM -gt 5 ]; then break; fi; done");
     my $tar_content = script_output("cat $local_file");
     save_tmp_file('opt_logs.tar.gz', $tar_content);
+    script_run('clear');
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
In the last step of run.pm, screen has lot's output, and it block the next step (generate_report.pm) catch needle, in the first step. (e.g. https://openqa.suse.de/tests/2959323#step/generate_report/2).
So clear screen in the end of run.pm.

- Verification run: http://10.67.133.102/tests/990