### PR TITLE
xfstests: Separate installation and kdump process

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -723,18 +723,19 @@ elsif (get_var("QA_TESTSUITE")) {
     loadtest "qa_automation/execute_test_run";
 }
 elsif (get_var("XFSTESTS")) {
-    #Workaround bsc#1101787
-    if (check_var('ARCH', 'aarch64') && check_var('VERSION', '12-SP4')) {
-        set_var('NO_KDUMP', 1);
-    }
     prepare_target;
-    unless (get_var('NO_KDUMP')) {
-        loadtest "xfstests/enable_kdump";
+    if (check_var('XFSTESTS', 'installation')) {
+        loadtest "xfstests/install";
+        unless (get_var('NO_KDUMP')) {
+            loadtest "xfstests/enable_kdump";
+        }
+        loadtest "shutdown/shutdown";
     }
-    loadtest "xfstests/install";
-    loadtest "xfstests/partition";
-    loadtest "xfstests/run";
-    loadtest "xfstests/generate_report";
+    else {
+        loadtest "xfstests/partition";
+        loadtest "xfstests/run";
+        loadtest "xfstests/generate_report";
+    }
 }
 elsif (get_var("BTRFS_PROGS")) {
     prepare_target;


### PR DESCRIPTION
This PR including two changes
- Remove workaround for bsc#1101787, since it fixed.
- Separate install.pm and enable_kdump.pm from each tests

The benefit to separate those two process is that it could save a lot of resources to run all xfstests.
  As before those two steps run  "xfstests tests number"  times(for now the number is 115);
  After that it will be only 1. This change will save 10~20 hours in each build.
The only cost is 80GB storage in osd for HDD that I created for the new status (with kdump enabled and xfstests installed).

New test need to add in osd
```
BOOT_HDD_IMAGE=1
DESKTOP=textmode
HDD_1=SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed_withhome.qcow2
MAX_JOB_TIME=32400
NO_KDUMP=0
PUBLISH_HDD_1=SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed_withhome_xfstests.qcow2
QA_HEAD_REPO=http://149.44.176.2/ibs/QA:/Head/SLE-%VERSION%
VIRTIO_CONSOLE=1
XFSTESTS=installation
```
this test will start after "create_hdd_minimal_base+sdk_withhome", and all xfstests will start after this one.

- Related ticket: https://progress.opensuse.org/issues/52847
- Verification run: 
    Installation: http://10.67.133.102/tests/967
    Test run: http://10.67.133.102/tests/988 
