### PR TITLE
Slurm db accounting

### DIFF
--- a/tests/hpc/changelog
+++ b/tests/hpc/changelog
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file
 
+## [1.0.2] - 2019-06-26
+### Added
+Add slurm accounting tests
+### Changed
+changing the naming convention of the HPC/slurm nodes to master-node and
+slave-node
+
 ## [1.0.1] - 2019-06-11
 ### Added
 Add slurm failover test using NFS shared dir as the StateSaveLocation

--- a/tests/hpc/slurm_db.pm
+++ b/tests/hpc/slurm_db.pm
@@ -1,0 +1,88 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: slurm db node
+#    This tests only ensure the proper db is being set for the HPC cluster, so
+#    that the slurm db accounting can be configured
+# Maintainer: Sebastian Chlad <schlad@suse.de>
+
+use base "hpcbase";
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use utils;
+use version_utils 'is_sle';
+
+sub run {
+    my $self     = shift;
+    my $hostname = get_required_var("HOSTNAME");
+    $self->prepare_user_and_group();
+
+    # Install slurm
+    zypper_call("in slurm-munge slurm-slurmdbd");
+    # install slurm-node if sle15, not available yet for sle12
+    zypper_call('in slurm-node') if is_sle '15+';
+
+    zypper_call("in mariadb");
+    systemctl("start mariadb");
+    systemctl("is-active mariadb");
+
+    # allow hostnames other than localhost
+    my $config = << "EOF";
+sed -i "/^bind-address.*/c\\#bind-address" /etc/my.cnf
+EOF
+    assert_script_run($_) foreach (split /\n/, $config);
+    systemctl("restart mariadb");
+    systemctl("is-active mariadb");
+    record_info("mariadb conf", script_output("cat /etc/my.cnf"));
+
+    # handle db preparation
+    assert_script_run("mysql -uroot -e \"CREATE DATABASE slurm_acct_db;\"");
+    assert_script_run("mysql -uroot -e \"CREATE USER \'slurm\'@\'$hostname.openqa.test\' IDENTIFIED BY \'password\';\"");
+    assert_script_run("mysql -uroot -e \"GRANT ALL ON slurm_acct_db.* TO \'slurm\'@\'$hostname.openqa.test\';\"");
+    assert_script_run("mysql -uroot -e \"FLUSH PRIVILEGES;\"");
+
+    systemctl("restart mariadb");
+    systemctl("is-active mariadb");
+
+    $self->prepare_slurmdb_conf();
+    record_info("slurmdbd conf", script_output("cat /etc/slurm/slurmdbd.conf"));
+    $self->enable_and_start("slurmdbd");
+    systemctl "status slurmdbd";
+
+    barrier_wait("SLURM_SETUP_DONE");
+    barrier_wait("SLURM_MASTER_SERVICE_ENABLED");
+
+    # enable and start munge
+    $self->enable_and_start("munge");
+    record_info("munge is enabled as desired by slurmdbd");
+
+    # enable and start slurmd
+    $self->enable_and_start('slurmd');
+    systemctl 'status slurmd';
+
+    barrier_wait("SLURM_SLAVE_SERVICE_ENABLED");
+    barrier_wait("SLURM_MASTER_RUN_TESTS");
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+    $self->upload_service_log('slurmd');
+    $self->upload_service_log('munge');
+    $self->upload_service_log('slurmdbd');
+    upload_logs('/var/log/slurmdbd.log');
+}
+
+1;

--- a/tests/hpc/slurm_master_db.pm
+++ b/tests/hpc/slurm_master_db.pm
@@ -4,12 +4,12 @@
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved. This file is offered as-is,
+# notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: HPC_Module: slurm master
-#    This test is setting up slurm masters for checking failover
-#    for the ctl slurm nodes
+# Summary: Slurm accounting - database
+#    This test is setting up slurm ctl node with accounting configured
+#    (database)
 # Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
 
 use base "hpcbase";
@@ -22,50 +22,39 @@ use utils;
 sub run {
     my $self  = shift;
     my $nodes = get_required_var("CLUSTER_NODES");
-
     $self->prepare_user_and_group();
 
+    # provision HPC cluster, so the proper rpms are installed,
+    # munge key is distributed to all nodes, so is slurm.conf
+    # and proper services are enabled and started
     zypper_call('in slurm slurm-munge');
-    zypper_call('in nfs-client rpcbind');
 
+    zypper_call('in nfs-client rpcbind');
     systemctl 'start nfs';
     systemctl 'start rpcbind';
-    assert_script_run("showmount -e 10.0.2.1");
+    record_info('show mounts aviable on the supportserver', script_output('showmount -e 10.0.2.1'));
     assert_script_run("mkdir -p /shared/slurm");
     assert_script_run("chown -Rcv slurm:slurm /shared/slurm");
     assert_script_run("mount -t nfs -o nfsvers=3 10.0.2.1:/nfs/shared /shared/slurm");
-    $self->prepare_slurm_conf();
-    barrier_wait("SLURM_SETUP_DONE");
-    record_info('slurmctl conf', script_output('cat /etc/slurm/slurm.conf'));
 
+    $self->prepare_slurm_conf();
+    record_info('slurmctl conf', script_output('cat /etc/slurm/slurm.conf'));
+    barrier_wait("SLURM_SETUP_DONE");
     $self->distribute_munge_key();
     $self->distribute_slurm_conf();
-
-    # enable and start munge
     $self->enable_and_start('munge');
-
-    # enable and start slurmctld
     $self->enable_and_start('slurmctld');
     systemctl 'status slurmctld';
-
-    # enable and start slurmd since maester also acts as Node here
     $self->enable_and_start('slurmd');
     systemctl 'status slurmd';
 
+    # wait for slave to be ready
     barrier_wait("SLURM_MASTER_SERVICE_ENABLED");
     barrier_wait("SLURM_SLAVE_SERVICE_ENABLED");
 
-    assert_script_run("srun -N ${nodes} /bin/ls");
-    assert_script_run("sinfo -N -l");
-    assert_script_run("scontrol ping");
-
-    # backup ctl takes over
-    assert_script_run("scontrol takeover");
-    assert_script_run("scontrol ping");
-
+    # run basic test against first compute node
     assert_script_run("srun -w slave-node00 date");
-    assert_script_run("srun -w slave-node01 date");
-    assert_script_run("srun -N ${nodes} /bin/ls");
+
     barrier_wait('SLURM_MASTER_RUN_TESTS');
 }
 
@@ -79,6 +68,8 @@ sub post_fail_hook {
     $self->upload_service_log('slurmd');
     $self->upload_service_log('munge');
     $self->upload_service_log('slurmctld');
+    $self->upload_service_log('slurmdbd');
+    upload_logs('/var/log/slurmctld.log');
 }
 
 1;


### PR DESCRIPTION
Initial PR for testing slurm with DB configured.

- Related ticket: https://progress.opensuse.org/issues/52259

There are some underlying changes which goes into the direction of preparing/provisioning HPC cluster for testing, in more generic way. So for instance there is a change of the naming convention from slurm-master/slurm-slave to master-node/slave-node. This way stuff like distributing munge keys and similar, can be done in more generic code, so there will be less code in the test code and more generic functions in the hpcbase.pm
Also there is a change in the HPC tests variables, as the new variables are being added. The reasoning is that is should help with generalizing the code provisioning the HPC cluster, but also should help with this provisioning to be more flexible and rebust.  

It is the fact that some code of slurm testing could be better abstracted, but for now I keep it this way due to the plans to run some more specific tests against provisioned HPC clusters.

- Runs:
HPC slave node on which the db is configured:
http://10.160.66.198/tests/6934
Slurm ctl backup with NFS configured:
http://10.160.66.198/tests/6935
slurm ctl:
http://10.160.66.198/tests/6931
Slaves:
http://10.160.66.198/tests/6932
http://10.160.66.198/tests/6933
