### PR TITLE
Use REPO alias instead of name

### DIFF
--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -33,7 +33,7 @@ sub run {
 
     pkcon_quit unless check_var('DESKTOP', 'textmode');
 
-    zypper_call(q{mr -d $(zypper lr | awk -F '|' '/NVIDIA/ {print $3}')}, exitcode => [0, 3]);
+    zypper_call(q{mr -d $(zypper lr | awk -F '|' '/NVIDIA/ {print $2}')}, exitcode => [0, 3]);
 
     add_test_repositories;
 

--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -68,7 +68,7 @@ sub run {
 
     select_console 'root-console';
 
-    zypper_call(q{mr -d $(zypper lr | awk -F '|' '/NVIDIA/ {print $3}')}, exitcode => [0, 3]);
+    zypper_call(q{mr -d $(zypper lr | awk -F '|' '/NVIDIA/ {print $2}')}, exitcode => [0, 3]);
 
     fully_patch_system;
 


### PR DESCRIPTION
Repository name isn't unique identifier and zypper disables only first
found name.
