### PR TITLE
Wicked: Failover function for bonding/teaming tests

### DIFF
--- a/tests/wicked/aggregate/sut/t08_bonding_ab_miimon.pm
+++ b/tests/wicked/aggregate/sut/t08_bonding_ab_miimon.pm
@@ -18,18 +18,10 @@ use testapi;
 
 sub run {
     my ($self, $ctx) = @_;
-    my $failover_timeout = get_var('FAILOVER_TIMEOUT', 60);
     record_info('INFO', 'Bonding, active-backup, miimon');
     $self->setup_bond('ab', $ctx->iface(), $ctx->iface2());
     $self->validate_interfaces('bond0', $ctx->iface(), $ctx->iface2());
-    my $active_link = $self->get_bond_active_link('bond0');
-    $self->ifbind('unbind', $active_link);
-    while ($failover_timeout >= 0) {
-        last if ($self->get_bond_active_link('bond0') ne $active_link);
-        $failover_timeout -= 1;
-        sleep 1;
-    }
-    die('Active Link is the same after interface cut') if ($failover_timeout == 0);
+    $self->check_fail_over('bond0');
     $self->ping_with_timeout(type => 'host', interface => 'bond0', count_success => 30, timeout => 4);
 }
 

--- a/tests/wicked/aggregate/sut/t10_bonding_ab_ping_2_ips.pm
+++ b/tests/wicked/aggregate/sut/t10_bonding_ab_ping_2_ips.pm
@@ -18,22 +18,10 @@ use testapi;
 
 sub run {
     my ($self, $ctx) = @_;
-    my $failover_timeout = get_var('FAILOVER_TIMEOUT', 60);
     record_info('INFO', 'Bonding, Active-Backup Ping 2 IPs');
-
     $self->setup_bond('alb', $ctx->iface(), $ctx->iface2());
     $self->validate_interfaces('bond0', $ctx->iface(), $ctx->iface2());
-    my $active_link = $self->get_bond_active_link('bond0');
-
-    $self->ifbind('unbind', $active_link);
-
-    while ($failover_timeout >= 0) {
-        last if ($self->get_bond_active_link('bond0') ne $active_link);
-        $failover_timeout -= 1;
-        sleep 1;
-    }
-    die('Active Link is the same after interface cut') if ($failover_timeout == 0);
-
+    $self->check_fail_over('bond0');
     $self->ping_with_timeout(type => 'host', interface => 'bond0', count_success => 30, timeout => 4);
 }
 

--- a/tests/wicked/aggregate/sut/t17_teaming_ab_ethtool.pm
+++ b/tests/wicked/aggregate/sut/t17_teaming_ab_ethtool.pm
@@ -21,10 +21,7 @@ sub run {
     record_info('INFO', 'Teaming, Active-Backup Ethtool');
     $self->setup_team('ab-ethtool', $ctx->iface(), $ctx->iface2());
     $self->validate_interfaces('team0', $ctx->iface(), $ctx->iface2(), 0);
-    my $active_link1 = $self->get_team_active_link('team0');
-    assert_script_run("ip link set dev $active_link1 down");
-    my $active_link2 = $self->get_team_active_link('team0');
-    die('Active Link is the same after interface cut') if ($active_link1 eq $active_link2);
+    $self->check_fail_over('team0');
     $self->ping_with_timeout(type => 'host', interface => 'team0', count_success => 30, timeout => 4);
 }
 

--- a/tests/wicked/aggregate/sut/t18_teaming_ab_arp_ping.pm
+++ b/tests/wicked/aggregate/sut/t18_teaming_ab_arp_ping.pm
@@ -21,10 +21,7 @@ sub run {
     record_info('INFO', 'Teaming, Active-Backup Arp Ping');
     $self->setup_team('ab-arp_ping', $ctx->iface(), $ctx->iface2());
     $self->validate_interfaces('team0', $ctx->iface(), $ctx->iface2(), 0);
-    my $active_link1 = $self->get_team_active_link('team0');
-    assert_script_run("ip link set dev $active_link1 down");
-    my $active_link2 = $self->get_team_active_link('team0');
-    die('Active Link is the same after interface cut') if ($active_link1 eq $active_link2);
+    $self->check_fail_over('team0');
     $self->ping_with_timeout(type => 'host', interface => 'team0', count_success => 30, timeout => 4);
 }
 

--- a/tests/wicked/aggregate/sut/t19_teaming_ab_nsna_ping.pm
+++ b/tests/wicked/aggregate/sut/t19_teaming_ab_nsna_ping.pm
@@ -21,10 +21,7 @@ sub run {
     record_info('INFO', 'Teaming, Active-Backup NSNA Ping');
     $self->setup_team('ab-nsna_ping', $ctx->iface(), $ctx->iface2());
     $self->validate_interfaces('team0', $ctx->iface(), $ctx->iface2(), 0);
-    my $active_link1 = $self->get_team_active_link('team0');
-    assert_script_run("ip link set dev $active_link1 down");
-    my $active_link2 = $self->get_team_active_link('team0');
-    die('Active Link is the same after interface cut') if ($active_link1 eq $active_link2);
+    $self->check_fail_over('team0');
     $self->ping_with_timeout(type => 'host', interface => 'team0', count_success => 30, timeout => 4);
 }
 

--- a/tests/wicked/aggregate/sut/t20_teaming_ab_all_link.pm
+++ b/tests/wicked/aggregate/sut/t20_teaming_ab_all_link.pm
@@ -21,10 +21,7 @@ sub run {
     record_info('INFO', 'Teaming, Active-Backup All Link');
     $self->setup_team('ab-all', $ctx->iface(), $ctx->iface2());
     $self->validate_interfaces('team0', $ctx->iface(), $ctx->iface2(), 0);
-    my $active_link1 = $self->get_team_active_link('team0');
-    assert_script_run("ip link set dev $active_link1 down");
-    my $active_link2 = $self->get_team_active_link('team0');
-    die('Active Link is the same after interface cut') if ($active_link1 eq $active_link2);
+    $self->check_fail_over('team0');
     $self->ping_with_timeout(type => 'host', interface => 'team0', count_success => 30, timeout => 4);
 }
 

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -53,7 +53,6 @@ sub run {
         systemctl 'start dhcpd.service';
     } else {
         # Common SUT Configuration
-        $self->get_from_data('wicked/ifbind.sh', 'ifbind.sh', executable => 1);
         my $package_list = 'openvswitch openvpn';
         $package_list .= ' libteam-tools libteamdctl0 python-libteam' if check_var('WICKED', 'advanced') || check_var('WICKED', 'aggregate');
         $package_list .= ' gcc' if check_var('WICKED', 'advanced');


### PR DESCRIPTION
Sometimes, when shutting down an interface in bond/team scenarios, the fail-over takes some time (miliseconds, or just a second). We should wait for it to happen to continue with the test steps, otherwise we can have a false negative. e.g. https://openqa.suse.de/tests/2960364#step/t18_teaming_ab_arp_ping/205

This adds a common function for team/bond test cases that brings down the current active interface with ifbind.sh and checks that the active interface has changed. 

http://fromm.arch.suse.de/tests/6439
