### PR TITLE
Add a simple test case for Vagrant

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2376,6 +2376,10 @@ sub load_virtualization_tests {
     loadtest "virtualization/virt_top";
     loadtest "virtualization/virtman_install";
     loadtest "virtualization/virtman_view";
+
+    # reboot the machine to kill the previously started virtual machines
+    loadtest "console/console_reboot";
+    loadtest "virtualization/vagrant/add_box";
     return 1;
 }
 

--- a/tests/virtualization/vagrant/add_box.pm
+++ b/tests/virtualization/vagrant/add_box.pm
@@ -1,0 +1,43 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Test for vagrant and packaged addons
+# Maintainer: dancermak <dcermak@suse.com>
+
+use strict;
+use warnings;
+use base "basetest";
+use testapi;
+use utils;
+
+sub run() {
+    select_console('root-console');
+
+    zypper_call('in vagrant virtualbox');
+    assert_script_run('systemctl start vboxdrv');
+    assert_script_run('systemctl start vboxautostart');
+    assert_script_run('usermod -a -G vboxusers bernhard');
+
+    select_console('user-console');
+    assert_script_run('echo "test" > testfile');
+
+    assert_script_run('vagrant init ubuntu/xenial64');
+    assert_script_run('vagrant up --provider virtualbox', timeout => 1200);
+
+    assert_script_run('vagrant ssh -c "[ $(cat testfile) = \"test\" ]"');
+    assert_script_run('vagrant halt');
+}
+
+1;


### PR DESCRIPTION
Add a simple test case for Vagrant that checks whether a simple vagrant invocation works as expected with a box from Vagrant Cloud. Note that this test needs nested virtualization to be enabled and the variable `QEMUCPU` set to `host` on the worker. (EDIT: this seems to be the case for the test cases in `VIRTUALIZATION`).

- Verification run: https://openqa.opensuse.org/tests/958996
