### PR TITLE
Disable GNOME suspend

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -33,6 +33,7 @@ our @EXPORT = qw(
   select_user_gnome
   turn_off_kde_screensaver
   turn_off_gnome_screensaver
+  turn_off_gnome_suspend
 );
 
 
@@ -222,6 +223,17 @@ Disable screensaver in gnome. To be called from a command prompt, for example an
 =cut
 sub turn_off_gnome_screensaver {
     script_run 'gsettings set org.gnome.desktop.session idle-delay 0';
+}
+
+=head2 turn_off_gnome_suspend
+
+  turn_off_gnome_suspend()
+
+Disable suspend in gnome. To be called from a command prompt, for example an xterm window.
+
+=cut
+sub turn_off_gnome_suspend {
+    script_run 'gsettings set org.gnome.settings-daemon.plugins.power sleep-inactive-ac-type \'nothing\'';
 }
 
 1;

--- a/tests/update/updates_packagekit_gpk.pm
+++ b/tests/update/updates_packagekit_gpk.pm
@@ -17,7 +17,7 @@ use testapi;
 use utils;
 use power_action_utils 'power_action';
 use version_utils 'is_sle';
-use x11utils qw(ensure_unlocked_desktop turn_off_gnome_screensaver);
+use x11utils qw(ensure_unlocked_desktop turn_off_gnome_screensaver turn_off_gnome_suspend);
 
 sub setup_system {
     x11_start_program('xterm');
@@ -27,6 +27,7 @@ sub setup_system {
 
     if (check_var("DESKTOP", "gnome")) {
         turn_off_gnome_screensaver;
+        turn_off_gnome_suspend;
     }
     else {
         script_run("xscreensaver-command -exit");


### PR DESCRIPTION
Disable GNOME suspend with 'turn_off_gnome_suspend' to prevent the 'Automatic suspend' message shown in GNOME which breaks needles matching.

- Related ticket: https://progress.opensuse.org/issues/52481
- Verification run: 
  * https://openqa.opensuse.org/t956580
  * https://openqa.opensuse.org/t956581
