### PR TITLE
[Kvm_on_s390] Add pkg cleanup for s390x host

### DIFF
--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -76,6 +76,12 @@ sub install_package {
     #install qa_lib_virtauto
     if (check_var('ARCH', 's390x')) {
         lpar_cmd("zypper --non-interactive --gpg-auto-import-keys ref");
+        my $pkg_lib_data = "qa_lib_virtauto-data";
+        my $cmd          = "rpm -q $pkg_lib_data";
+        my $ret          = console('svirt')->run_cmd($cmd);
+        if ($ret == 0) {
+            lpar_cmd("zypper --non-interactive rm $pkg_lib_data");
+        }
         lpar_cmd("zypper --non-interactive in qa_lib_virtauto");
     }
     else {

--- a/tests/virt_autotest/reboot_and_wait_up.pm
+++ b/tests/virt_autotest/reboot_and_wait_up.pm
@@ -27,10 +27,6 @@ sub reboot_and_wait_up {
         record_info('INFO', 'Reboot LPAR');
         #Reboot s390x lpar
         power_action('reboot', observe => 1, keepconsole => 1);
-        #Wait for s390x lpar bootup
-        sleep 120;
-        #Switch to s390x lpar console
-        reset_consoles;
         my $svirt = select_console('svirt', await_console => 0);
         return;
     }


### PR DESCRIPTION
Before trigger guest installation, clean up existed qa_lib_virtauto-data pkg on s390x host

- Verification run: 
gi-guest_sles12sp5-on-host-sles12sp4-kvm
http://10.67.20.104/tests/12
gi-guest_sles12sp5-on-host-sles15sp1-kvm
http://10.67.20.104/tests/10
gi-guest_sles12sp5-on-host-sles12sp5-kvm
http://10.67.20.104/tests/11