### PR TITLE
Add 2 new FIPS test cases for dirmngr and daemon

### DIFF
--- a/data/openssl/root-ca/root-ca.conf
+++ b/data/openssl/root-ca/root-ca.conf
@@ -1,0 +1,102 @@
+# Green Root CA
+# http://pki-tutorial.readthedocs.io/en/latest/advanced/root-ca.conf.html
+
+[ default ]
+ca                      = root-ca               # CA name
+dir                     = .                     # Top dir
+base_url                = http://green.no/ca    # CA base URL
+aia_url                 = $base_url/$ca.cer     # CA certificate URL
+crl_url                 = $base_url/$ca.crl     # CRL distribution point
+name_opt                = multiline,-esc_msb,utf8 # Display UTF-8 characters
+
+# CA certificate request
+
+[ req ]
+default_bits            = 2048                  # RSA key size
+encrypt_key             = yes                   # Protect private key
+default_md              = sha256                # MD to use
+utf8                    = yes                   # Input is UTF-8
+string_mask             = utf8only              # Emit UTF-8 strings
+prompt                  = no                    # Don't prompt for DN
+distinguished_name      = ca_dn                 # DN section
+req_extensions          = ca_reqext             # Desired extensions
+
+[ ca_dn ]
+countryName             = "NO"
+organizationName        = "Green AS"
+organizationalUnitName  = "Green Certificate Authority"
+commonName              = "Green Root CA"
+
+[ ca_reqext ]
+keyUsage                = critical,keyCertSign,cRLSign
+basicConstraints        = critical,CA:true
+subjectKeyIdentifier    = hash
+
+# CA operational settings
+
+[ ca ]
+default_ca              = root_ca               # The default CA section
+
+[ root_ca ]
+certificate             = $dir/ca/$ca.crt       # The CA cert
+private_key             = $dir/ca/$ca/private/$ca.key # CA private key
+new_certs_dir           = $dir/ca/$ca           # Certificate archive
+serial                  = $dir/ca/$ca/db/$ca.crt.srl # Serial number file
+crlnumber               = $dir/ca/$ca/db/$ca.crl.srl # CRL number file
+database                = $dir/ca/$ca/db/$ca.db # Index file
+unique_subject          = no                    # Require unique subject
+default_days            = 3652                  # How long to certify for
+default_md              = sha256                # MD to use
+policy                  = match_pol             # Default naming policy
+email_in_dn             = no                    # Add email to cert DN
+preserve                = no                    # Keep passed DN ordering
+name_opt                = $name_opt             # Subject DN display options
+cert_opt                = ca_default            # Certificate display options
+copy_extensions         = none                  # Copy extensions from CSR
+x509_extensions         = signing_ca_ext        # Default cert extensions
+default_crl_days        = 365                   # How long before next CRL
+crl_extensions          = crl_ext               # CRL extensions
+
+[ match_pol ]
+countryName             = match                 # Must match 'NO'
+stateOrProvinceName     = optional              # Included if present
+localityName            = optional              # Included if present
+organizationName        = match                 # Must match 'Green AS'
+organizationalUnitName  = optional              # Included if present
+commonName              = supplied              # Must be present
+
+[ any_pol ]
+domainComponent         = optional
+countryName             = optional
+stateOrProvinceName     = optional
+localityName            = optional
+organizationName        = optional
+organizationalUnitName  = optional
+commonName              = optional
+emailAddress            = optional
+
+# Extensions
+
+[ root_ca_ext ]
+keyUsage                = critical,keyCertSign,cRLSign
+basicConstraints        = critical,CA:true
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid:always
+
+[ signing_ca_ext ]
+keyUsage                = critical,keyCertSign,cRLSign
+basicConstraints        = critical,CA:true,pathlen:0
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid:always
+authorityInfoAccess     = @issuer_info
+crlDistributionPoints   = @crl_info
+
+[ crl_ext ]
+authorityKeyIdentifier  = keyid:always
+authorityInfoAccess     = @issuer_info
+
+[ issuer_info ]
+caIssuers;URI.0         = $aia_url
+
+[ crl_info ]
+URI.0                   = $crl_url

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2077,6 +2077,8 @@ sub load_security_tests_crypt_core {
         loadtest "fips/openssl/openssl_fips_alglist";
         loadtest "fips/openssl/openssl_fips_hash";
         loadtest "fips/openssl/openssl_fips_cipher";
+        loadtest "fips/openssl/dirmngr_setup";
+        loadtest "fips/openssl/dirmngr_daemon";    # dirmngr_daemon needs to be tested after dirmngr_setup
     }
     loadtest "fips/openssl/openssl_pubkey_rsa";
     loadtest "fips/openssl/openssl_pubkey_dsa";

--- a/tests/fips/openssl/dirmngr_daemon.pm
+++ b/tests/fips/openssl/dirmngr_daemon.pm
@@ -1,0 +1,77 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test dirmngr daemon and valid/revoked certificate
+#
+# Maintainer: Ben Chou <bchou@suse.com>
+# Tags: poo#52430, poo#52937, tc#1729313
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub dirmngr_daemon {
+
+    select_console 'root-console';
+
+    my $myca_dir = "/home/linux/myca";
+
+    # Create dirmngr required testing folder
+    assert_script_run('mkdir -p /etc/dirmngr/trusted-certs');
+    assert_script_run('mkdir -p /var/{run,log}/dirmngr /var/cache/dirmngr/crls.d /var/lib/dirmngr/extra-certs');
+
+    # Create an empty ldapservers.conf
+    assert_script_run "touch /etc/dirmngr/ldapservers.conf";
+
+    # Crete dirmngr config file
+    assert_script_run("echo 'log-file /var/log/dirmngr/dirmngr.log' > /etc/dirmngr/dirmngr.conf");
+
+    # Copy trusted CA certificates to /etc/dirmngr/trusted-certs
+    assert_script_run("cp $myca_dir/ca/root-ca.crt.der /etc/dirmngr/trusted-certs");
+
+    # Start dirmngr as daemon
+    validate_script_output("dirmngr --daemon --disable-ldap", sub { m/DIRMNGR_INFO=.*DIRMNGR_INFO;/ });
+
+    # Load CRL
+    assert_script_run("dirmngr-client --load-crl $myca_dir/crl/root-ca.crl.der");
+
+    # Verify certificate ( test2.crt.der certificate is valid)
+    if (script_run("dirmngr-client --validate $myca_dir/certs/test2.crt.der 2>&1 | tee -a /tmp/cert2.out") == 0) {
+        assert_script_run("grep -o \'dirmngr-client: certificate is valid\' /tmp/cert2.out");
+    }
+    else {
+        die "dirmngr-client did not exit with return 0";
+    }
+
+    # Verify certificate ( test1.crt.der certificate is revoked)
+    if (script_run("dirmngr-client --validate $myca_dir/certs/test1.crt.der 2>&1 | tee -a /tmp/cert1.out") == 1) {
+        assert_script_run("grep -o \'dirmngr-client: validation of certificate failed: Certificate revoked\' /tmp/cert1.out");
+    }
+    else {
+        die "dirmngr-client did not exit with return 1";
+    }
+}
+
+sub run {
+
+    my ($self) = @_;
+
+    # Test Dirmngr daemon
+    $self->dirmngr_daemon();
+}
+
+1;

--- a/tests/fips/openssl/dirmngr_setup.pm
+++ b/tests/fips/openssl/dirmngr_setup.pm
@@ -1,0 +1,162 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Setup dirmngr testing environment - create Root CA,
+#          testing ca, testing DER, and CRL
+#
+# Maintainer: Ben Chou <bchou@suse.com>
+# Tags: poo#52430, poo#52937, tc#1729313
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub dirmngr_setup {
+
+    my $myca_dir = "/home/linux/myca";
+
+    my $ca_cfg  = "$myca_dir/etc/root-ca.conf";
+    my $ca_csr  = "$myca_dir/ca/root-ca.csr";
+    my $ca_crt  = "$myca_dir/ca/root-ca.crt";
+    my $ca_key  = "$myca_dir/ca/root-ca/private/root-ca.key";
+    my $ca_crl  = "$myca_dir/crl/root-ca.crl";
+    my $ssl_pwd = "susetesting";
+
+    # Create myca directories
+    assert_script_run("mkdir -p $myca_dir && cd $myca_dir");
+
+    # Create the testing folder in myca
+    assert_script_run('mkdir -p ca/root-ca/private ca/root-ca/db crl certs etc');
+
+    # chmod 700 ca/root-ca/private
+    assert_script_run("chmod 700 ca/root-ca/private");
+
+    # Create root-ca database:
+    assert_script_run("cp /dev/null ca/root-ca/db/root-ca.db");
+    assert_script_run("cp /dev/null ca/root-ca/db/root-ca.db.attr");
+    assert_script_run 'echo 01 > ca/root-ca/db/root-ca.crt.srl';
+    assert_script_run 'echo 01 > ca/root-ca/db/root-ca.crl.srl';
+
+    # Use expect for openssl Interactive mode
+    zypper_call("--no-refresh in expect");
+
+    # Create and download the root-ca.conf file
+    assert_script_run "wget --quiet " . data_url('openssl/root-ca/root-ca.conf') . " -O $ca_cfg";
+
+    # Create root ca certificate
+    # assert_script_run("openssl req -new -config $ca_cfg -out $ca_csr -keyout $ca_key");
+    assert_script_run(
+        "expect -c 'spawn openssl req -new -config $ca_cfg -out $ca_csr -keyout $ca_key; \\
+        expect \"Enter PEM pass phrase:\"; send \"$ssl_pwd\\n\"; \\
+        expect \"Verifying - Enter PEM pass phrase:\"; send \"$ssl_pwd\\n\"; interact'"
+    );
+
+    # assert_script_run("openssl ca -selfsign -config $ca_cfg -in $ca_csr -out $ca_crt -extensions root_ca_ext -enddate 20301231235959Z");
+    assert_script_run(
+        "expect -c 'spawn openssl ca -selfsign -config $ca_cfg -in $ca_csr -out $ca_crt -extensions root_ca_ext -enddate 20301231235959Z; \\
+        expect \"Enter pass phrase\"; send \"$ssl_pwd\\n\"; \\
+        expect \"Sign the certificate\"; send \"y\\n\"; \\
+        expect \"1 out of 1 certificate requests certified\"; send \"y\\n\"; interact'"
+    );
+
+    # Create initial CRL
+    # assert_script_run("openssl ca -gencrl -config $ca_cfg -out $ca_crl");
+    assert_script_run(
+        "expect -c 'spawn openssl ca -gencrl -config $ca_cfg -out $ca_crl; \\
+        expect \"Enter pass phrase for\"; send \"$ssl_pwd\\n\"; interact'"
+    );
+
+    my $crt_csr_t1 = "$myca_dir/certs/test1.csr";
+    my $crt_key_t1 = "$myca_dir/certs/test1.key";
+    my $crt_t1     = "$myca_dir/certs/test1.crt";
+    my $crt_csr_t2 = "$myca_dir/certs/test2.csr";
+    my $crt_key_t2 = "$myca_dir/certs/test2.key";
+    my $crt_t2     = "$myca_dir/certs/test2.crt";
+
+    # Create test certificates (test1.crt)
+    #assert_script_run("openssl req -new -config $ca_cfg -out $crt_csr_t1 -keyout $crt_key_t1");
+    assert_script_run(
+        "expect -c 'spawn openssl req -new -config $ca_cfg -out $crt_csr_t1 -keyout $crt_key_t1; \\
+        expect \"Enter PEM pass phrase:\"; send \"$ssl_pwd\\n\"; \\
+        expect \"Verifying - Enter PEM pass phrase:\"; send \"$ssl_pwd\\n\"; interact'"
+    );
+
+    #assert_script_run("openssl ca -config $ca_cfg -in $crt_csr_t1 -out $crt_t1");
+    assert_script_run(
+        "expect -c 'spawn openssl ca -config $ca_cfg -in $crt_csr_t1 -out $crt_t1 ; \\
+        expect \"Enter pass phrase\"; send \"$ssl_pwd\\n\"; \\
+        expect \"Sign the certificate?\"; send \"y\\n\"; \\
+        expect \"1 out of 1 certificate requests certified\"; send \"y\\n\"; interact'"
+    );
+
+    # Create test certificates (test2.crt)
+    # assert_script_run("openssl req -new -config $ca_cfg -out $crt_csr_t2 -keyout $crt_key_t2");
+    assert_script_run(
+        "expect -c 'spawn openssl req -new -config $ca_cfg -out $crt_csr_t2 -keyout $crt_key_t2; \\
+        expect \"Enter PEM pass phrase:\"; send \"$ssl_pwd\\n\"; \\
+        expect \"Verifying - Enter PEM pass phrase:\"; send \"$ssl_pwd\\n\"; interact'"
+    );
+
+    # assert_script_run("openssl ca -config $ca_cfg -in $crt_csr_t2 -out $crt_t2");
+    assert_script_run(
+        "expect -c 'spawn openssl ca -config $ca_cfg -in $crt_csr_t2 -out $crt_t2 ; \\
+        expect \"Enter pass phrase for\"; send \"$ssl_pwd\\n\"; \\
+        expect \"Sign the certificate\"; send \"y\\n\"; \\
+        expect \"1 out of 1 certificate requests certified\"; send \"y\\n\"; interact'"
+    );
+
+    # Revoke test1.crt but keep test2.crt
+    # openssl ca -revoke certs/test1.crt -config etc/root-ca.conf
+    assert_script_run(
+        "expect -c 'spawn openssl ca -revoke $crt_t1 -config $ca_cfg; \\
+        expect \"Enter pass phrase\"; send \"$ssl_pwd\\n\"; interact'"
+    );
+
+    # Update the CRL
+    # assert_script_run("openssl ca -gencrl -config $ca_cfg -out $ca_crl");
+    assert_script_run(
+        "expect -c 'spawn openssl ca -gencrl -config $ca_cfg -out $ca_crl; \\
+        expect \"Enter pass phrase for\"; send \"$ssl_pwd\\n\"; interact'"
+    );
+
+    my $ca_der      = "$myca_dir/ca/root-ca.crt.der";
+    my $crt_crl_der = "$myca_dir/crl/root-ca.crl.der";
+    my $crt_der_t1  = "$myca_dir/certs/test1.crt.der";
+    my $crt_der_t2  = "$myca_dir/certs/test2.crt.der";
+
+    # Convert certificates to DER for dirmngr
+    assert_script_run("openssl x509 -in $ca_crt -outform der -out $ca_der");
+    assert_script_run("openssl crl -in $ca_crl -outform der -out $crt_crl_der");
+    assert_script_run("openssl x509 -in $crt_t1 -outform der -out $crt_der_t1");
+    assert_script_run("openssl x509 -in $crt_t2 -outform der -out $crt_der_t2");
+}
+
+sub run {
+
+    my ($self) = @_;
+    select_console 'root-console';
+
+    # Setup Dirmngr
+    $self->dirmngr_setup();
+
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Add 2 new FIPS tests: 
dirmngr_setup.pm and dirmngr_daemon.pm

New test case for dirmngr environment setup and dirmngr daemon.
Test cases are related to create Root CA, testing ca, der and crl.
Verify the valid and revoke certificate by dirmngr.

- Related ticket: 
  https://progress.opensuse.org/issues/52430 [dirmngr_setup.pm]
  https://progress.opensuse.org/issues/52937 [dirmngr_daemon.pm]

- Needles: NA
- Verification run: 
 http://10.163.2.52/tests/223 [SLES12-SP5 non-FIPS mode] - PASSED
 http://10.163.2.52/tests/224 [SLES12-SP5 FIPS mode]        - FAILED
 http://10.163.2.52/tests/225 [SLES15-SP1 FIPS mode]        - FAILED
 http://10.163.2.52/tests/227#step/dirmngr_setup/24 [`default_md=md5` in non-FIPS mode] - PASSED
 http://10.163.2.52/tests/226#step/dirmngr_setup/24 [`default_md=md5` in FIPS mode]     - FAILED
 http://10.163.2.52/tests/230#step/dirmngr_setup/24 [`default_md=sha256` in FIPS mode] - PASSED
 http://10.163.2.52/tests/231#step/dirmngr_setup/24 [`default_md=sha512` in FIPS mode] - PASSED

- Note: 
dirmngr daemon is fail to launch in fips mode.(bsc#994795)
The testing fail in dirmngr_daemon.pm is expected currently. 