### PR TITLE
Fix double assertion in addon_products_sle

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -60,6 +60,9 @@ sub get_to_console {
     }
 }
 
+# Process unsigned files:
+# - return value 0 (false) when expected screen is present, regardless files were found or not
+# - return value 1 (true) when rearching number of retries
 sub process_unsigned_files {
     my ($self, $expected_screens) = @_;
     # SLE 15 has unsigned file errors, workaround them - rbrown 04/07/2017
@@ -71,10 +74,11 @@ sub process_unsigned_files {
             send_key 'alt-y';
         }
         elsif (check_screen $expected_screens, 0) {
-            last;
+            return 0;
         }
         wait_still_screen;
     }
+    return 1;
 }
 
 # to deal with dependency issues, either work around it, or break dependency to continue with installation

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -152,13 +152,13 @@ sub test_addonurl {
 
 sub run {
     my ($self) = @_;
-
     if (get_var('SKIP_INSTALLER_SCREEN', 0)) {
         advance_installer_window('inst-addon');
         set_var('SKIP_INSTALLER_SCREEN', 0);
     }
-    $self->process_unsigned_files([qw(inst-addon addon-products)]);
-    assert_screen_with_soft_timeout([qw(inst-addon addon-products)], timeout => 60, soft_timeout => 30, bugref => 'bsc#1123963');
+    if ($self->process_unsigned_files([qw(inst-addon addon-products)])) { ;
+        assert_screen_with_soft_timeout([qw(inst-addon addon-products)], timeout => 60, soft_timeout => 30, bugref => 'bsc#1123963');
+    }
     if (get_var("ADDONS")) {
         send_key match_has_tag('inst-addon') ? 'alt-k' : 'alt-a';
         # the ISO_X variables must match the ADDONS list


### PR DESCRIPTION
Fix double assertion in `addon_products_sle`. I could not find a single case with unsigned files processed but the change seems to be safe. This module is used 110%! in openQA and for the use that we do in QSF-YaST team we agreed not to being modifying remaining code related with multiple `wait_still_screen` (as it would be more productive for us just to create a new module and free us of all that complexity that we don't need in the products that we cover). Nevertheless if something else reasonable to achieve here is possible I would be glad to include it along with this simple change.

- Related ticket: https://progress.opensuse.org/issues/48410
- Needles: N/A
- Verification run: 
  - [sle-15-SP1-Installer-DVD-s390x-Build228.2-skip_registration@s390x-kvm-sle12](https://openqa.suse.de/tests/2977476#step/addon_products_sle/4) -> only one assert instead of two
