### PR TITLE
Remove soft-failure for bsc#1011815

### DIFF
--- a/tests/console/snapper_cleanup.pm
+++ b/tests/console/snapper_cleanup.pm
@@ -23,16 +23,9 @@ my $btrfs_fs_usage = 'btrfs filesystem usage / --raw';
 sub get_space {
     my ($script) = @_;
     my $script_output = script_output($script);
-    # Problem is that sometimes we get kernel messages or other output when execute the script
-    # So we assume that biggest number returned is size we are looking for
-    if ($script_output =~ /^(\d+)$/) {
-        return $script_output;
-    }
-    record_soft_failure('bsc#1011815');
-    my @numbers = $script_output =~ /(\d+)/g;
-
-    return max(@numbers);
+    return $script_output;
 }
+
 sub snapper_cleanup {
     my ($scratch_size_gb, $scratchfile_mb) = @_;
     my $snaps_numb = "snapper list | grep number | wc -l";

--- a/tests/console/yast2_ntpclient.pm
+++ b/tests/console/yast2_ntpclient.pm
@@ -33,11 +33,6 @@ sub run {
     # if support-server is used
     my $ntp_server = check_var('USE_SUPPORT_SERVER', 1) ? 'ns' : '0.opensuse.pool.ntp.org';
 
-    # test often fails due to info kernel messages disrupting screen
-    # decrease logging level to warning to avoid this
-    assert_script_run 'dmesg -n 4';
-    record_soft_failure 'bsc#1011815';
-
     # check network at first
     assert_script_run('if ! systemctl -q is-active network; then systemctl -q start network; fi');
 

--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -103,9 +103,6 @@ sub setup_yast2_ldap_server {
 }
 
 sub setup_yast2_auth_server {
-    # workaround kernel message floating over console
-    assert_script_run "dmesg -n 4";
-    record_soft_failure 'bsc#1011815';
 
     # check network at first
     assert_script_run("if ! systemctl -q is-active network; then systemctl -q start network; fi");


### PR DESCRIPTION
It seems like that workaround is no longer necessary, I could not reproduce it nor manually nor with 1000 verification runs (literally).

- Related ticket: https://progress.opensuse.org/issues/51374
- Verification runs:
sle 12, console/snapper_cleanup.pm: http://waaa-amazing.suse.cz/tests/582#next_previous
sle 12, ncurses test suite: http://waaa-amazing.suse.cz/tests/583#next_previous
sle 15, ncurses test suite: http://waaa-amazing.suse.cz/tests/1325#next_previous
sle 15, console/snapper_cleanup.pm: http://waaa-amazing.suse.cz/tests/1085#next_previous

sle 15/s390, ncurses https://openqa.suse.de/tests/2979359
sle 12/s390, ncurses https://openqa.suse.de/tests/2979358
sle 15/ppc, extra_tests_filesystem:  https://openqa.suse.de/tests/2979047