### PR TITLE
HPC: Add code stream version as the variable

### DIFF
--- a/tests/hpc/product_migration.pm
+++ b/tests/hpc/product_migration.pm
@@ -21,12 +21,15 @@ use registration 'add_suseconnect_product';
 sub run {
     my $self            = shift;
     my $suseconnect_str = ' -e testing@suse.com -r ';
+    my $version         = get_required_var('VERSION');
+    ## replace SP-X with 12.X as this form is expected by SUSEConnect
+    $version =~ s/-SP/./;
     $self->select_serial_terminal;
 
     script_run('ls -la /etc/products.d/');
     my $out = script_output('SUSEConnect -s', 30, proceed_on_failure => 1);
     assert_script_run('SUSEConnect --cleanup', 200) if $out =~ /Error: Invalid system credentials/s;
-    add_suseconnect_product('SLES', '12.4', get_var('ARCH'), $suseconnect_str . get_required_var('SCC_REGCODE'));
+    add_suseconnect_product('SLES', $version, get_required_var('ARCH'), $suseconnect_str . get_required_var('SCC_REGCODE'));
     add_suseconnect_product('sle-module-hpc',           '12');
     add_suseconnect_product('sle-module-web-scripting', '12');
     zypper_call('in switch_sles_sle-hpc');


### PR DESCRIPTION
In this way, without hardcoded code steam version, the test could be
run on various code streams

- Related ticket: https://progress.opensuse.org/issues/52973
- Verification run: 
