### PR TITLE
Public Cloud: Force use HVM images

### DIFF
--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -118,7 +118,7 @@ sub upload_img {
           . "--grub2 "
           . "--machine 'x86_64' "
           . "-n '" . $self->prefix . '-' . $img_name . "' "
-          . (($img_name =~ /hvm/i) ? "--virt-type hvm --sriov-support " : "--virt-type para ")
+          . "--virt-type hvm --sriov-support "
           . (($img_name !~ /byos/i) ? '--use-root-swap ' : '--ena-support ')
           . "--verbose "
           . "--regions '" . $self->region . "' "


### PR DESCRIPTION
The new images produced for SLE12-SP5 will be only HVM, not PV images any more. However, 'HVM' string is not part of the image name any more. So, we can't check for that string to see if we need to add that flag. Instead, we force to use HVM. 

- Related ticket: https://progress.opensuse.org/issues/52646
- Failed test without this fix: https://openqa.suse.de/tests/2979012#step/upload_image/70