### PR TITLE
Use different keyboard shortcut for options tab on 12sp1

### DIFF
--- a/tests/boot/grub2_test.pm
+++ b/tests/boot/grub2_test.pm
@@ -91,17 +91,18 @@ sub run {
     record_info 'grub2 password',                                                    'set password to boot';
     script_run "yast bootloader; echo yast-bootloader-status-\$? > /dev/$serialdev", 0;
     assert_screen 'test-yast2_bootloader-1';
-    send_key 'alt-l';    # bootloader options tab
+    my $options_key = is_sle('=12-sp1') ? 't' : 'l';
+    send_key "alt-$options_key";    # bootloader options tab
     assert_screen 'installation-bootloader-options';
-    send_key 'alt-e';    # check protect boot loader with pw
-    send_key 'alt-r';    # uncheck protect entry modification only
-    send_key 'alt-p';    # selecet password field
+    send_key 'alt-e';               # check protect boot loader with pw
+    send_key 'alt-r';               # uncheck protect entry modification only
+    send_key 'alt-p';               # selecet password field
     type_password;
     send_key 'tab';
     type_password;
     sleep 2;
     save_screenshot;
-    send_key 'alt-o';    # OK
+    send_key 'alt-o';               # OK
     wait_serial 'yast-bootloader-status-0', 60 || die "'yast bootloader' didn't finish";
     reboot;
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/53009
- Verification run: http://10.100.12.155/tests/12046#step/grub2_test/95
