### PR TITLE
Fix kb shortcut on UEFI 12sp1 and check that password for boot

### DIFF
--- a/tests/boot/grub2_test.pm
+++ b/tests/boot/grub2_test.pm
@@ -104,6 +104,8 @@ sub run {
     save_screenshot;
     send_key 'alt-o';               # OK
     wait_serial 'yast-bootloader-status-0', 60 || die "'yast bootloader' didn't finish";
+    # verify password protect
+    assert_script_run 'grep \'password\' /boot/grub2/grub.cfg';
     reboot;
 
     record_info 'grub2 password', 'type login and password to boot';

--- a/tests/boot/grub2_test.pm
+++ b/tests/boot/grub2_test.pm
@@ -91,7 +91,7 @@ sub run {
     record_info 'grub2 password',                                                    'set password to boot';
     script_run "yast bootloader; echo yast-bootloader-status-\$? > /dev/$serialdev", 0;
     assert_screen 'test-yast2_bootloader-1';
-    my $options_key = is_sle('=12-sp1') ? 't' : 'l';
+    my $options_key = is_sle('=12-sp1') && get_var('UEFI') ? 't' : 'l';
     send_key "alt-$options_key";    # bootloader options tab
     assert_screen 'installation-bootloader-options';
     send_key 'alt-e';               # check protect boot loader with pw


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/53009
- Verification run:
http://10.100.12.155/tests/12064#step/grub2_test/103
http://10.100.12.155/tests/12065#step/grub2_test/99