### PR TITLE
Mupltiple fixes for autoyast tests

### DIFF
--- a/data/autoyast_sle12/bug-887126_autoinst.xml
+++ b/data/autoyast_sle12/bug-887126_autoinst.xml
@@ -510,22 +510,6 @@
       <pattern>gnome-basic</pattern>
     </patterns>
     <remove-packages config:type="list">
-      <package>glibc-32bit</package>
-      <package>libXaw3d6</package>
-      <package>libXaw3d7</package>
-      <package>libbz2-1-32bit</package>
-      <package>libdb-4_8-32bit</package>
-      <package>libgcc_s1-32bit</package>
-      <package>libgdbm4-32bit</package>
-      <package>libpython3_4m1_0</package>
-      <package>libqt4-sql-sqlite</package>
-      <package>libstdc++6-32bit</package>
-      <package>libz1-32bit</package>
-      <package>perl-32bit</package>
-      <package>perl-Test-Simple</package>
-      <package>python3</package>
-      <package>python3-base</package>
-      <package>xaw3dd</package>
       <package>yast2-control-center-qt</package>
     </remove-packages>
   </software>

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -273,7 +273,10 @@ sub run {
     $stage   = 'stage2';
 
     check_screen \@needles, $check_time;
-    @needles = qw(reboot-after-installation autoyast-postinstall-error autoyast-boot warning-pop-up autoyast-error inst-bootmenu lang_and_keyboard);
+    @needles = qw(reboot-after-installation autoyast-postinstall-error autoyast-boot warning-pop-up inst-bootmenu lang_and_keyboard);
+    # Do not try to fail early in case of autoyast_error_dialog scenario
+    # where we test that certain error are properly handled
+    push @needles, 'autoyast-error' unless get_var('AUTOYAST_EXPECT_ERRORS');
     # There will be another reboot for IPMI backend
     push @needles, qw(prague-pxe-menu qa-net-selection) if check_var('BACKEND', 'ipmi');
     until (match_has_tag 'reboot-after-installation') {


### PR DESCRIPTION
Last time I've provided a fix for first stage only.
This commit fixes it for second stage too.

[Verification run](https://openqa.suse.de/tests/2982558).

Adjust packages section of bug-887126_autoinst AY profile
[Verification run](https://openqa.suse.de/t2982559).
