### PR TITLE
Add support for TIMEOUT_SCALE in SAP tests

### DIFF
--- a/tests/sles4sap/netweaver_install.pm
+++ b/tests/sles4sap/netweaver_install.pm
@@ -27,7 +27,7 @@ sub run {
     my $sid           = get_required_var('INSTANCE_SID');
     my $hostname      = get_var('INSTANCE_ALIAS', '$(hostname)');
     my $params_file   = "/sapinst/$instance_type.params";
-    my $nettout       = 900;                                        # Time out for NetWeaver's sources related commands
+    my $timeout       = 900 * get_var('TIMEOUT_SCALE', 1);          # Time out for NetWeaver's sources related commands
     my $product_id    = undef;
 
     # Set Product ID depending on the type of Instance
@@ -50,7 +50,7 @@ sub run {
     $self->prepare_profile('NETWEAVER');
 
     # Copy media
-    $self->copy_media($proto, $path, $nettout, '/sapinst');
+    $self->copy_media($proto, $path, $timeout, '/sapinst');
 
     # Define a valid hostname/IP address in /etc/hosts, but not in HA
     if (!get_var('HA_CLUSTER')) {
@@ -83,7 +83,7 @@ sub run {
     }
 
     if ($instance_type eq 'ASCS') {
-        assert_script_run $cmd, $nettout;
+        assert_script_run $cmd, $timeout;
     }
     elsif ($instance_type eq 'ERS') {
         # We have to workaround an installation issue:
@@ -91,7 +91,7 @@ sub run {
         #  because ASCS is running on the first node!
         # It's "normal" and documentation says that we have to install ERS on the 2nd node
         #  in order to have the SAP environment correctly set-up.
-        script_run $cmd, $nettout;
+        script_run $cmd, $timeout;
 
         # So we have to check in the log file that's the installation goes well
         # We simply checking for the ASCS stop error message!

--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -71,6 +71,7 @@ sub run {
     my ($proto, $path) = split m|://|, get_required_var('MEDIA');
     die "Currently supported protocols are nfs and smb" unless $proto =~ /^(nfs|smb)$/;
 
+    my $timeout  = 3600 * get_var('TIMEOUT_SCALE', 1);
     my $sid      = get_required_var('INSTANCE_SID');
     my $password = 'Qwerty_123';
     set_var('PASSWORD', $password);
@@ -102,7 +103,7 @@ sub run {
     send_key 'tab';
     send_key $cmd{next};
     assert_screen 'sap-wizard-copying-media',     120;
-    assert_screen 'sap-wizard-supplement-medium', 4000;
+    assert_screen 'sap-wizard-supplement-medium', $timeout;
     send_key $cmd{next};
     assert_screen 'sap-wizard-additional-repos';
     send_key $cmd{next};
@@ -126,7 +127,7 @@ sub run {
     send_key 'alt-o' if (check_screen 'sap-wizard-partition-issues',      60);
     send_key 'alt-y' if (check_screen 'sap-wizard-continue-installation', 30);
     assert_screen 'sap-product-installation';
-    assert_screen [qw(sap-wizard-installation-summary sap-wizard-finished sap-wizard-failed sap-wizard-error)], 4000;
+    assert_screen [qw(sap-wizard-installation-summary sap-wizard-finished sap-wizard-failed sap-wizard-error)], $timeout;
     send_key $cmd{ok};
     if (match_has_tag 'sap-wizard-installation-summary') {
         assert_screen 'generic-desktop', 600;


### PR DESCRIPTION
Some SAP tests (mainly NW and HANA installation) doesn't support `TIMEOUT_SCALE` variable for the installation timeout.

This commit add this support.

- Related ticket: n/a
- Needles: n/a
- Verification run: n/a
