### PR TITLE
Get logs from target machine in remote installation

### DIFF
--- a/tests/remote/remote_controller.pm
+++ b/tests/remote/remote_controller.pm
@@ -59,6 +59,8 @@ sub run {
         type_string "$password\n";
     }
     elsif (check_var("REMOTE_CONTROLLER", "ssh")) {
+        set_var 'TARGET_IP', $lease_ip;
+        set_var 'PASSWD',    $password;
         select_console 'user-console';
         clear_console;
         type_string "ssh root\@$lease_ip\n";


### PR DESCRIPTION
The switch to the console in remote installation is not possible. workarounds applied separately for VNC and ssh.
VNC: open a xterm which gives you access to the target machine
SSH: openqa fails uses ssh to reconnect back to the SUT and try to collect logs

- Related ticket: https://progress.opensuse.org/issues/50111
- Needles: N/A
- Verification run: 
[vnc success scenario](https://openqa.suse.de/tests/2986500)

[ssh fail - logs from target](http://aquarius.suse.cz/tests/366)
[vnc fail - logs from target](http://aquarius.suse.cz/tests/213)