### PR TITLE
[SLE-12-SP5 Preparation] Include parentheses to increase matching accuracy

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -117,9 +117,9 @@ sub login_to_console {
             }
             my $host_installed_version = get_var('VERSION_TO_INSTALL', get_var('VERSION', ''));
             ($host_installed_version) = $host_installed_version =~ /^(\d+)/im;
-            my $host_upgrade_version = get_required_var('UPGRADE_PRODUCT');         #format sles-15-sp0
-            my $host_upgrade_relver  = $host_upgrade_version =~ /sles-(\d+)-sp/i;
-            my $host_upgrade_spver   = $host_upgrade_version =~ /sp(\d+)$/im;
+            my $host_upgrade_version  = get_required_var('UPGRADE_PRODUCT');         #format sles-15-sp0
+            my ($host_upgrade_relver) = $host_upgrade_version =~ /sles-(\d+)-sp/i;
+            my ($host_upgrade_spver)  = $host_upgrade_version =~ /sp(\d+)$/im;
             if (($host_installed_version eq '11') && (($host_upgrade_relver eq '15' && $host_upgrade_spver eq '0') || ($host_upgrade_relver eq '12' && $host_upgrade_spver eq '5'))) {
                 assert_screen('sshd-server-started-config', 180);
                 use_ssh_serial_console;


### PR DESCRIPTION
It seems that the matching logic changes somehow, probably changed perl version or added perl feature. Parentheses need to be included to make sure variable gets assigned the matched value.

- Related ticket: https://openqa.nue.suse.com/tests/2981926#step/reboot_and_wait_up_normal#2/5
                          https://openqa.nue.suse.com/tests/2981927#step/reboot_and_wait_up_normal#2/5
- Needles: n/a 
- Verification run: Please use this online tool to see expected and actual output
                            https://www.learn-perl.org/en/Conditional_Decisions
