### PR TITLE
Fix double assertion in addon_products_sle - 2nd try

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -60,21 +60,25 @@ sub get_to_console {
     }
 }
 
+# Process unsigned files:
+# - return value 0 (false) when expected screen is present, regardless files were found or not
+# - return value 1 (true) when rearching number of retries or when this check does not apply.
 sub process_unsigned_files {
     my ($self, $expected_screens) = @_;
     # SLE 15 has unsigned file errors, workaround them - rbrown 04/07/2017
-    return unless (is_sle('15+'));
+    return 1 unless (is_sle('15+'));
     my $counter = 0;
     while ($counter++ < 5) {
         if (check_screen 'sle-15-unsigned-file', 0) {
             record_soft_failure 'bsc#1047304';
             send_key 'alt-y';
+            wait_still_screen;
         }
         elsif (check_screen $expected_screens, 0) {
-            last;
+            return 0;
         }
-        wait_still_screen;
     }
+    return 1;
 }
 
 # to deal with dependency issues, either work around it, or break dependency to continue with installation

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -157,8 +157,13 @@ sub run {
         advance_installer_window('inst-addon');
         set_var('SKIP_INSTALLER_SCREEN', 0);
     }
-    $self->process_unsigned_files([qw(inst-addon addon-products)]);
-    assert_screen_with_soft_timeout([qw(inst-addon addon-products)], timeout => 60, soft_timeout => 30, bugref => 'bsc#1123963');
+    if ($self->process_unsigned_files([qw(inst-addon addon-products)])) {
+        assert_screen_with_soft_timeout(
+            [qw(inst-addon addon-products)],
+            timeout      => 60,
+            soft_timeout => 30,
+            bugref       => 'bsc#1123963');
+    }
     if (get_var("ADDONS")) {
         send_key match_has_tag('inst-addon') ? 'alt-k' : 'alt-a';
         # the ISO_X variables must match the ADDONS list


### PR DESCRIPTION
Fix double assertion in `addon_products_sle`. Second try after #7670 where I missed the return code when it is a different product.
- Related ticket: https://progress.opensuse.org/issues/48410
- Needles: N/A
- Verification run:
  - [sle-15-SP1-Installer-DVD-s390x-Build228.2-skip_registration@s390x-kvm-sle12](https://openqa.suse.de/t2986907)
  - [sle-12-SP5-Server-DVD-x86_64-Build0198-virt-pvusb-developing-pv-on-developing-xen@virt-pvusb-64bit-ipmi](https://openqa.suse.de/t2986908)
