### PR TITLE
Add 'ensure_serialdev_permissions_for_sap' for SAP tests

### DIFF
--- a/tests/sles4sap/netweaver_install.pm
+++ b/tests/sles4sap/netweaver_install.pm
@@ -104,6 +104,10 @@ sub run {
         my $cluster_name = get_cluster_name;
         barrier_wait("ASCS_INSTALLED_$cluster_name");
     }
+
+    # Allow SAP Admin user to inform status via $testapi::serialdev
+    $self->set_sap_info($sid, $instance_id);
+    $self->ensure_serialdev_permissions_for_sap;
 }
 
 {


### PR DESCRIPTION
This function is used during SAP tests because `ensure_serialdev_permissions` cannot be used, as ROOTONLY variable is set, but an SAP account has to be used at some point.

- Related ticket: n/a
- Needles: n/a
- Verification run: https://openqa.suse.de/tests/2987818
