### PR TITLE
Retry zypper command on QAM tests with exit code 4 or 106

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -424,8 +424,11 @@ sub zypper_call {
         if ($ret == 4) {
             if (script_run('grep "Error code.*502" /var/log/zypper.log') == 0) {
                 record_soft_failure 'Retrying because of error 502 - bsc#1070851';
-                next;
             }
+        }
+        if (get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/ && ($ret == 4 || $ret == 106)) {
+            record_soft_failure 'Retry due to network problems poo#52319';
+            next;
         }
         last;
     }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/52319
- Verification run: http://10.100.12.155/tests/12144#step/patch_and_reboot/150