### PR TITLE
Fix virtio graphics freeze

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -385,11 +385,9 @@ sub bootmenu_default_params {
         # gfxpayload variable replaced vga option in grub2
         if (!is_jeos && !is_caasp && (check_var('ARCH', 'i586') || check_var('ARCH', 'x86_64'))) {
             push @params, "vga=791";
-            if (check_var("INSTALL_TO_OTHERS", 1) || !$args{pxe}) {
-                push @params, "video=1024x768-16";
-            } else {
-                push @params, "xvideo=1024x768";
-            }
+            my $video = 'video=1024x768';
+            $video .= '-16' if check_var('QEMUVGA', 'cirrus');
+            push @params, $video;
         }
 
     }


### PR DESCRIPTION
For ages we instructed the kernel to load the graphics display in mode
"1024x768-16" with 16 bit color depth which was needed for cirrus driver
due to a qemu problem, but it is not needed for other graphics backends.
According to the description in the bug:
"16bpp should be seen rather harmful, and better to drop that unless you
must need it by some reason."

Verification runs:

opensuse-5.12.80-Krypton-Live-x86_64-Build8.152-krypton-live-wayland@64bit_virtio-3G -> https://openqa.opensuse.org/tests/961895
opensuse-Tumbleweed-NET-x86_64-Build20190614-xfce@64bit -> https://openqa.opensuse.org/t961650 ok
opensuse-Tumbleweed-DVD-i586-Build20190614-textmode@32bit -> https://openqa.opensuse.org/t961651 ok
opensuse-Tumbleweed-NET-x86_64-Build20190614-otherDE_awesome@64bit -> https://openqa.opensuse.org/t961652 ok
opensuse-Tumbleweed-NET-x86_64-Build20190614-kde_dual_windows10@uefi_win -> https://openqa.opensuse.org/t961653 ok
opensuse-Tumbleweed-NET-x86_64-Build20190614-kde@64bit -> https://openqa.opensuse.org/t961654 ok
opensuse-42.3-DVD-Updates-x86_64-Build20190617-1-gnome@64bit-2G -> https://openqa.opensuse.org/t961655 ok (fails in adding repos after login into graphical session, assuming qam specific problem)
opensuse-42.3-DVD-Updates-x86_64-Build20190617-1-install_with_updates_kde@uefi-2G -> https://openqa.opensuse.org/t961656 ok (fails in adding repos after login into graphical session, assuming qam specific problem)
sle-12-Server-DVD-Updates-x86_64-Build20190617-1-qam-gnome@64bit -> https://openqa.suse.de/t2987853 ok
sle-12-SP1-Server-DVD-Updates-x86_64-Build20190617-1-mru-install-minimal-with-addons@uefi -> https://openqa.suse.de/t2987854 ok
sle-12-SP5-Server-DVD-x86_64-Build0198-gnome@64bit -> https://openqa.suse.de/t2987855 ok
sle-12-SP5-Server-DVD-x86_64-Build0198-default@uefi -> https://openqa.suse.de/t2987856 ok
sle-12-SP5-Server-DVD-x86_64-Build0198-default@svirt-xen-pv -> https://openqa.suse.de/t2987857 ok
sle-12-SP5-Server-DVD-x86_64-Build0198-default@64bit-ipmi -> https://openqa.suse.de/tests/2988493 ok (reached same error as in before, "first_boot")
sle-12-SP5-Server-DVD-s390x-Build0198-default@s390x-kvm-sle12 -> https://openqa.suse.de/t2987859 ok
sle-12-SP5-Server-DVD-x86_64-Build0198-default@64bit -> https://openqa.suse.de/t2987860 ok

Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1135865