### PR TITLE
Autoyast: Fix string concatenation in prepare profile

### DIFF
--- a/tests/autoyast/prepare_profile.pm
+++ b/tests/autoyast/prepare_profile.pm
@@ -57,7 +57,7 @@ sub run {
         $profile =~ s/\{\{$var\}\}/$value/g;
     }
     if (check_var('IPXE', '1')) {
-        $path = get_required_var('SUT_IP') + $path;
+        $path = get_required_var('SUT_IP') . $path;
     }
     # Upload modified profile
     save_tmp_file($path, $profile);


### PR DESCRIPTION
It fixes this error:

```
Argument "autoyast_sle12/autoyast_sdk.xml" isn't numeric in addition (+) at /var/lib/openqa/cache/openqa.suse.de/tests/sle/tests/autoyast/prepare_profile.pm line 60.
Argument "sonic-1.qa.suse.de" isn't numeric in addition (+) at /var/lib/openqa/cache/openqa.suse.de/tests/sle/tests/autoyast/prepare_profile.pm line 60.
```
https://openqa.suse.de/tests/2988100/file/autoinst-log.txt
