### PR TITLE
No need to remove "test" user

### DIFF
--- a/tests/x11/gnomecase/change_password.pm
+++ b/tests/x11/gnomecase/change_password.pm
@@ -157,11 +157,6 @@ sub run {
     type_password "$password\n";
     assert_screen "password-changed-terminal";
 
-    #delete the added user: test
-    # We should kill the active user test in SLE15
-    assert_script_run 'loginctl terminate-user test' if is_sle('15+') || is_tumbleweed;
-    wait_still_screen;
-    assert_script_run 'userdel -f test';
     send_key "alt-f4";
     send_key "ret";
 


### PR DESCRIPTION
There is no need to remove "test" user after the "change_password" test.

Current approach has introduced many workarounds, so remove them.

https://progress.opensuse.org/issues/53225
https://bugzilla.opensuse.org/show_bug.cgi?id=1138372

- Related ticket: https://progress.opensuse.org/issues/53225
- Needles: no need
- Verification run: http://147.2.212.139/tests/196#step/change_password/74
