### PR TITLE
Fix Apparmor case "usr_sbin_smbd" fail

### DIFF
--- a/lib/apparmortest.pm
+++ b/lib/apparmortest.pm
@@ -123,7 +123,8 @@ sub aa_status_stdout_check {
 }
 
 sub ip_fetch {
-    my $ip = script_output("hostname -I | cut -d ' ' -f1");
+    # "# hostname -i/-I" can not work in some cases
+    my $ip = script_output("ip -4 -f inet -o a | grep -E \'eth0|ens\' | sed -n 's/\.*inet \\([0-9.]\\+\\)\.*/\\1/p'");
     return $ip;
 }
 

--- a/tests/security/apparmor_profile/usr_sbin_smbd.pm
+++ b/tests/security/apparmor_profile/usr_sbin_smbd.pm
@@ -37,8 +37,7 @@ sub samba_server_setup {
 
     send_key "alt-w";
     type_string("WORKGROUP");
-    send_key "alt-n";
-    assert_screen("samba-server-configuration");
+    send_key_until_needlematch("samba-server-configuration", 'alt-n', 10, 2);
     send_key "alt-s";
     assert_screen("samba-server-configuration-shares");
     send_key "alt-a";
@@ -102,7 +101,8 @@ sub samba_client_access {
 
     # Do some operations, e.g., create a test folder then delete it
     send_key "shift-ctrl-n";
-    type_string("sub-testdir");
+    wait_still_screen(2);
+    type_string("sub-testdir", wait_screen_changes => 10);
     send_key "ret";
     send_key_until_needlematch("nautilus-sharedir-delete", "delete", 5, 2);
     send_key "ret";


### PR DESCRIPTION
Fix Apparmor case "usr_sbin_smbd" fail: test case failed on needles mismatch and test procedures need to be revised
All verification runs are pass.
NOTE: There is a MR included

- Related ticket: https://progress.opensuse.org/issues/52397
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1169
- Verification run: 
    Tumbleweed build0614: http://10.67.19.89/tests/1174
    sle12sp5-Beta1: http://10.67.19.89/tests/1192
    sle15sp1-GM: http://10.67.19.89/tests/1160