### PR TITLE
IPMI,LTP: Set again ADDONURL=sdk for not yet released SLE12

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -17,7 +17,7 @@ use registration;
 use utils;
 use mmapi 'get_parents';
 use version_utils
-  qw(is_vmware is_hyperv is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem is_desktop_installed is_jeos is_sle is_staging is_upgrade);
+  qw(is_vmware is_hyperv is_hyperv_in_gui is_caasp is_installcheck is_rescuesystem is_desktop_installed is_jeos is_released is_sle is_staging is_upgrade);
 use File::Find;
 use File::Basename;
 use LWP::Simple 'head';
@@ -531,6 +531,8 @@ sub mellanox_config {
 }
 
 sub load_baremetal_tests {
+    set_var('ADDONURL', 'sdk') if (is_sle('>=12') && is_sle('<15')) && !is_released;
+
     loadtest "autoyast/prepare_profile" if get_var "AUTOYAST_PREPARE_PROFILE";
     if (get_var('IPXE')) {
         loadtest 'installation/ipxe_install';


### PR DESCRIPTION
*Not yet released* versions of SLE12 need ADDONURL=sdk settings for SCC
registration. But this setting is conflicting for SLE15 (both released
and not released) and SLE12 *released* versions.

Because this single test suite setup cannot be used for both SLE12 and
SLE 15 commit 8a1a108b0 ("LTP: Set ADDONURL=sdk for SLE12 SP4") added
ADDONURL=sdk in code just for SLE12 SP4 (at the time not released).
Later 5c79a6d32 ("Boot and install LTP on baremetal") removed it to
fix SLE12 SP4 after it being released, but this broke SLE12 SP5 which
haven't been released. Therefore use is_released to detect non-released
SLE12 versions.

Adding it to load_baremetal_tests() so it should fix not only
install_ltp_baremetal [1], but also ibtest which use ipxe_install.pm [2].

[1] http://quasar.suse.cz/tests/2999
[2] https://openqa.suse.de/tests/2991216

Fixes: 5c79a6d32 ("Boot and install LTP on baremetal")