### PR TITLE
adjust "get_x11_console_tty" to return "2" for gdm 3.32 on Tumbleweed

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -23,7 +23,7 @@ use warnings;
 use testapi qw(is_serial_terminal :DEFAULT);
 use lockapi 'mutex_wait';
 use mm_network;
-use version_utils qw(is_caasp is_leap is_sle is_sle12_hdd_in_upgrade is_storage_ng is_jeos);
+use version_utils qw(is_caasp is_leap is_sle is_sle12_hdd_in_upgrade is_storage_ng is_jeos is_tumbleweed);
 use Utils::Architectures 'is_aarch64';
 use Utils::Systemd 'systemctl';
 use Mojo::UserAgent;
@@ -867,7 +867,10 @@ sub get_x11_console_tty {
       && !check_var('VIRSH_VMM_FAMILY', 'hyperv')
       && !check_var('VIRSH_VMM_TYPE',   'linux')
       && !get_var('VERSION_LAYERED');
-    return (check_var('DESKTOP', 'gnome') && get_var('NOAUTOLOGIN') && $new_gdm) ? 2 : 7;
+    # starting with Tumbleweed build 20190614, we ship gdm 3.32 and gnome
+    # desktop runs on tty2 for both auto-login cases and non auto-login cases
+    my $gdm_3_32 = is_tumbleweed() && get_var('BUILD') ge "20190614";
+    return (check_var('DESKTOP', 'gnome') && (get_var('NOAUTOLOGIN') || $gdm_3_32) && $new_gdm) ? 2 : 7;
 }
 
 =head2  arrays_differ


### PR DESCRIPTION
As discussed in bsc#1138327, with gdm 3.32, gnome desktop will take tty2 even if this is an auto-login system.  So I make "get_x11_console_tty" to return "2" for gdm 3.32 on Tumbleweed.  The patch I submitted contains version comparison, so that it will not break test on older builds, this check can be simplified later.

See also: https://bugzilla.opensuse.org/show_bug.cgi?id=1138327

- Related ticket: https://progress.opensuse.org/issues/53246
- Needles: no need
- Verification run: http://147.2.212.139/tests/203#step/yast2_control_center/21