### PR TITLE
Fix zypper_call in one_line_checks

### DIFF
--- a/tests/caasp/one_line_checks.pm
+++ b/tests/caasp/one_line_checks.pm
@@ -61,7 +61,7 @@ sub run_caasp_checks {
 sub run_microos_checks {
     # Should not include kubernetes
     if (check_var('SYSTEM_ROLE', 'microos')) {
-        zypper_call 'se -i kubernetes', exitcode => 104;
+        zypper_call 'se -i kubernetes', exitcode => [104];
         assert_script_run '! rpm -q etcd';
     }
     # Should have unconfigured Kubernetes & container runtime environment


### PR DESCRIPTION
https://progress.opensuse.org/issues/51467#change-221303
https://github.com/os-autoinst/os-autoinst-distri-opensuse/commit/346d7aaca096e98b73728ad07ebe47070b7a46bd#r33977494

Verification: https://openqa.opensuse.org/t962414