### PR TITLE
Add assert_screen to make test more robust

### DIFF
--- a/tests/console/yast2_registration.pm
+++ b/tests/console/yast2_registration.pm
@@ -39,8 +39,10 @@ sub register_system_and_add_extension {
     }
     send_key "alt-a";
     wait_still_screen 2;
+    assert_screen 'yast2-sw_automatic-changes';
     send_key "alt-o";
-    wait_still_screen 5;
+    wait_still_screen 2;
+    assert_screen 'installation-report';
     wait_screen_change { send_key "alt-f" };
 }
 


### PR DESCRIPTION
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1171
- Verification run: http://10.100.12.155/tests/12201#step/yast2_registration/11