### PR TITLE
Get tcpdump only from QAM Update tests

### DIFF
--- a/tests/installation/add_update_test_repo.pm
+++ b/tests/installation/add_update_test_repo.pm
@@ -49,7 +49,7 @@ sub run() {
 }
 
 sub pre_run_hook {
-    if (is_sle('15+') && get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/) {
+    if (is_sle('15+') && get_var('FLAVOR', '') =~ /-Updates$/) {
         select_console 'install-shell';
         wait_still_screen;
         type_string "tcpdump -i eth0 -nn -s0 -vv -w openqa_tcpdump.pcap &>/dev/$serialdev &\n";
@@ -60,7 +60,7 @@ sub pre_run_hook {
 }
 
 sub post_run_hook {
-    if (is_sle('15+') && get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/) {
+    if (is_sle('15+') && get_var('FLAVOR', '') =~ /-Updates$/) {
         select_console 'install-shell';
         script_run 'killall tcpdump', 0;
         script_run 'rm -f openqa_tcpdump.pcap, 0';
@@ -69,7 +69,7 @@ sub post_run_hook {
 }
 
 sub post_fail_hook {
-    if (is_sle('15+') && get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/) {
+    if (is_sle('15+') && get_var('FLAVOR', '') =~ /-Updates$/) {
         select_console 'install-shell';
         script_run 'killall tcpdump', 0;
         upload_logs 'openqa_tcpdump.pcap';

--- a/tests/qa_automation/patch_and_reboot.pm
+++ b/tests/qa_automation/patch_and_reboot.pm
@@ -46,7 +46,7 @@ sub run {
 }
 
 sub pre_run_hook {
-    if (get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/) {
+    if (get_var('FLAVOR', '') =~ /-Updates$/) {
         select_console 'root-console';
         zypper_call 'in tcpdump';
         type_string "tcpdump -i eth0 -nn -s0 -vv -w openqa_tcpdump.pcap &>/dev/$serialdev &\n";
@@ -54,7 +54,7 @@ sub pre_run_hook {
 }
 
 sub post_run_hook {
-    if (get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/) {
+    if (get_var('FLAVOR', '') =~ /-Updates$/) {
         select_console 'root-console';
         script_run 'killall tcpdump', 0;
         script_run 'rm -f openqa_tcpdump.pcap, 0';
@@ -62,7 +62,7 @@ sub post_run_hook {
 }
 
 sub post_fail_hook {
-    if (get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/) {
+    if (get_var('FLAVOR', '') =~ /-Updates$/) {
         select_console 'root-console';
         script_run 'killall tcpdump', 0;
         upload_logs 'openqa_tcpdump.pcap';


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/52319
- Verification run:
http://10.100.12.155/tests/12205
http://10.100.12.155/tests/12207
