### PR TITLE
Ignore ZYPPER_EXIT_NO_REPOS at repo cleanup

### DIFF
--- a/tests/update/zypper_clear_repos.pm
+++ b/tests/update/zypper_clear_repos.pm
@@ -24,12 +24,12 @@ sub run {
 
     # remove Factory repos
     my $repos_folder = '/etc/zypp/repos.d';
-    zypper_call 'lr -d';
+    zypper_call 'lr -d', exitcode => [0, 6];
     assert_script_run(
 "find $repos_folder/*.repo -type f -exec grep -q 'baseurl=http://download.opensuse.org/' {} \\; -delete && echo 'unneed_repos_removed' > /dev/$serialdev",
         15
     );
-    zypper_call 'lr -d';
+    zypper_call 'lr -d', exitcode => [0, 6];
     save_screenshot;    # take a screenshot after repos removed
 
     if (get_var("STAGING")) {
@@ -37,7 +37,7 @@ sub run {
         # in Staging, enable it here.
         clear_console;
         assert_script_run("grep -rlE 'baseurl=cd:/(//)?\\?devices' $repos_folder | xargs --no-run-if-empty sed -i 's/^enabled=0/enabled=1/g'");
-        zypper_call 'lr -d';
+        zypper_call 'lr -d', exitcode => [0, 6];
         save_screenshot;    # take a screenshot after repo enabled
     }
 }


### PR DESCRIPTION
https://progress.opensuse.org/issues/51467
Verification: https://openqa.opensuse.org/t962429