### PR TITLE
Cleanup svirt::run_cmd_output(wantarray=>1) usage

### DIFF
--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -41,11 +41,9 @@ sub hyperv_cmd_with_retry {
         'The operation cannot be performed while the object is in use',
         'The process cannot access the file because it is being used by another process');
     for my $retry (1 .. $attempts) {
-        my @out    = (console('svirt')->get_cmd_output($cmd, {wantarray => 1}))[0];
-        my $stderr = $out[0][1] || '';
-        chomp($stderr);
-        # Command succeeded, we are done here
-        return unless $stderr;
+        my $stderr = console('svirt')->get_cmd_output($cmd, {wantarray => 1})->[1];
+        return if $stderr =~ m/^\s*$/;    # no output on STDERR, so we are done
+
         diag "Attempt $retry/$attempts: Command failed";
         my $msg_found = 0;
         foreach my $msg (@msgs) {


### PR DESCRIPTION
Changed the usage of the return value.
Replace chomp by `s/\s*$//` as the output was created on a different
system then our `$/` and might have no affect.

- Verification run: https://openqa.suse.de/tests/2997996
