### PR TITLE
Wait for "New folder" dialog to appear

### DIFF
--- a/tests/x11/dolphin.pm
+++ b/tests/x11/dolphin.pm
@@ -26,6 +26,7 @@ sub run {
 
     # Create a new folder
     send_key 'f10';
+    assert_screen 'dolphin_new_folder_dialog';
     type_string 'stuff';
     assert_screen 'dolphin_new_folder';
     send_key 'ret';


### PR DESCRIPTION
Do not start to type the folder name if the dialog is not yet there.

- Related ticket: https://progress.opensuse.org/issues/53117
- Verification run: https://openqa.opensuse.org/tests/962628#step/dolphin/7
