### PR TITLE
DRBD workaround for 12SP2

### DIFF
--- a/tests/ha/filesystem.pm
+++ b/tests/ha/filesystem.pm
@@ -160,6 +160,13 @@ sub run {
                 # Arbitrary choice, a cluster always has at least two nodes
                 $node = choose_node(2);
 
+                # Workaround needed before 12sp4
+                # Restart of master/slave rsc after fs_rsc configuration
+                foreach my $action ('stop', 'start') {
+                    assert_script_run "crm resource $action ms_$resource";
+                    sleep 5;
+                }
+
                 # Migrate resource on the node
                 assert_script_run "crm resource migrate ms_$resource $node";
                 ensure_resource_running("$fs_rsc", "is running on:[[:blank:]]*$node\[[:blank:]]*\$");


### PR DESCRIPTION
This workaround will be executed for each version
Cluster failed to migrate DRBD filesystem resource, a restart of master/slave resource is needed before migration.

- Related ticket: N/A
- Needles: N/A
- Verification run: 
[12SP2 node01](http://1a102.qa.suse.de/tests/999)
[12SP2 node02](http://1a102.qa.suse.de/tests/1000)
[12SP5 node01](http://1a102.qa.suse.de/tests/1027)
[12SP5 node02](http://1a102.qa.suse.de/tests/1028) 
[15SP1 node01](http://1a102.qa.suse.de/tests/1033)
[15SP1 node02](http://1a102.qa.suse.de/tests/1034)
