### PR TITLE
Revert "Wait a bit on tty switch to avoid false match on 'text-logged-in-$user'"

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -673,7 +673,6 @@ sub activate_console {
             # case the system is still booting (https://bugzilla.novell.com/show_bug.cgi?id=895602)
             # or when using remote consoles which can take some seconds, e.g.
             # just after ssh login
-            wait_still_screen 1;    # Wait a bit to avoid false match on 'text-logged-in-$user', if tty has not switched yet
             assert_screen \@tags, 60;
             if (match_has_tag("tty$nr-selected")) {
                 type_string "$user\n";


### PR DESCRIPTION
This reverts commit bed94ef77e9e96e400c6429fbade88ba239c8cba as it
should not be needed when all needles are correct, this is why we have
specific needles for each tty.