### PR TITLE
Allow upgrade from SLE-N-1 to SLE-N

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -37,6 +37,7 @@ our @EXPORT = qw(
   check_rollback_system
   reset_consoles_tty
   boot_into_ro_snapshot
+  set_scc_proxy_url
 );
 
 sub setup_sle {
@@ -186,6 +187,14 @@ sub boot_into_ro_snapshot {
         }
         die "Boot into read-only snapshot failed over 5 minutes, considering a product issue";
     }
+}
+
+# Register the already installed system on a specific SCC server/proxy if needed
+sub set_scc_proxy_url {
+    if (my $u = get_var('SCC_PROXY_URL')) {
+        type_string "echo 'url: $u' > /etc/SUSEConnect\n";
+    }
+    save_screenshot;
 }
 
 1;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -121,7 +121,7 @@ sub is_desktop_module_available {
 
 # SLE specific variables
 set_var('NOAUTOLOGIN', 1) unless check_var('NOAUTOLOGIN', '0');
-set_var('HASLICENSE', 1);
+set_var('HASLICENSE',  1) unless check_var('HASLICENSE',  '0');    # Only if we specifically set HASLICENSE to 0 in test, for upgrade case for example
 set_var('SLE_PRODUCT', get_var('SLE_PRODUCT', 'sles'));
 # Always register against SCC if SLE 15
 if (is_sle('15+')) {
@@ -484,8 +484,11 @@ sub load_patching_tests {
     if (is_upgrade) {
         # Save HDDVERSION to ORIGIN_SYSTEM_VERSION
         set_var('ORIGIN_SYSTEM_VERSION', get_var('HDDVERSION'));
-        # Save VERSION to UPGRADE_TARGET_VERSION
-        set_var('UPGRADE_TARGET_VERSION', get_var('VERSION'));
+        # Save VERSION to UPGRADE_TARGET_VERSION if it is not already set
+        set_var('UPGRADE_TARGET_VERSION', get_var('VERSION')) if (!get_var('UPGRADE_TARGET_VERSION'));
+        # Save the original target version, needed for testing upgrade from a beta version to a non-beta
+        # SLE12-SP5 to SLE15-SP1 for example
+        set_var('ORIGINAL_TARGET_VERSION', get_var('VERSION'));
         # Always boot from installer DVD in upgrade test
         set_var('BOOTFROM', 'd');
         loadtest "migration/version_switch_origin_system" if (!get_var('ONLINE_MIGRATION'));
@@ -1048,7 +1051,7 @@ else {
         # Set origin and target version
         set_var('DESKTOP',                'gnome');
         set_var('ORIGIN_SYSTEM_VERSION',  get_var('BASE_VERSION'));
-        set_var('UPGRADE_TARGET_VERSION', get_var('VERSION'));
+        set_var('UPGRADE_TARGET_VERSION', get_var('VERSION')) if (!get_var('UPGRADE_TARGET_VERSION'));
         loadtest "migration/version_switch_origin_system";
         # Use autoyast to perform origin system installation
         load_default_autoyast_tests;

--- a/tests/migration/sle12_online_migration/pre_migration.pm
+++ b/tests/migration/sle12_online_migration/pre_migration.pm
@@ -18,13 +18,6 @@ use utils;
 use migration;
 use version_utils 'is_sle';
 
-sub set_scc_proxy_url {
-    if (my $u = get_var('SCC_PROXY_URL')) {
-        type_string "echo 'url: $u' > /etc/SUSEConnect\n";
-    }
-    save_screenshot;
-}
-
 sub check_or_install_packages {
     if (get_var("FULL_UPDATE") || get_var("MINIMAL_UPDATE")) {
         # if system is fully updated or even minimal patch applied, all necessary packages for online migration should be installed

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -44,6 +44,8 @@ sub patching_sle {
         zypper_call "lr";
         zypper_call "mr --disable --all";
         save_screenshot;
+        # Set SCC_PROXY_URL if needed
+        set_scc_proxy_url if ((check_var('HDDVERSION', get_var('ORIGINAL_TARGET_VERSION')) && is_upgrade()));
         sle_register("register");
         zypper_call('lr -d');
     }


### PR DESCRIPTION
In 12-SP5 we have to test upgrade from 12-SP5 to 15-SP1.

Multiple tweaks can be done but we wanted to keep the test in the same VERSION level and in that case some minor modifications are needed.

This PR enables this without breaking current migration tests.

- Related ticket: n/a
- Needles: n/a
- Verification tests: [offline+scc_12sp5_to_15sp1](http://1b147.qa.suse.de/tests/5573), [offline+dvd_12sp5_to_15sp1](http://1b147.qa.suse.de/tests/5574),
- Regression tests: [current-offline+scc_12sp4_to_12sp5](http://1b147.qa.suse.de/tests/5575), [current-offline+dvd_12sp4_to_12sp5](http://1b147.qa.suse.de/tests/5576)

`Note:` the failure in the 12sp5-to-15sp1 tests are not because of this PR, it's "just" because no migration product seems to be found in 15sp1 for 12sp5.

The test needs to be defined like this one:
+ISO=SLE-%UPGRADE_TARGET_VERSION%-Installer-DVD-%ARCH%-GM-DVD1.iso
BETA=0
BOOT_HDD_IMAGE=1
HASLICENSE=0
HDDVERSION=12-SP5
HDD_1=sle-%HDDVERSION%-%ARCH%-sap-nw-noscc.qcow2
KEEP_REGISTERED=1
PATCH=1
ROOTONLY=1
SCC_PROXY_URL=http://sap-%BUILD%.proxy.scc.suse.de
SCC_REGISTER=installation
SCC_URL=
UPGRADE=1
UPGRADE_TARGET_VERSION=15-SP1

Note on some specific variables:
- `+ISO` is used to force the use of the SLE-15-SP1 iso
- `BETA` should be set to 0, because 15-SP1 is not beta anymore
- `HASLICENSE` should be set to 0, because no license is shown during upgrade on SLE-15+ (and VERSION is not set to 15-SP1 in this test of course!)
- `HDDVERSION` should be set to the current OS version, because we want to test upgrade to a newer OS version
- `SCC_PROXY_URL` and `SCC_URL` must be inverted in this test (upgrade to a newer OS version), so `SCC_URL` should be set to default and `SCC_PROXY_URL` should be set to proxy-SCC
- `UPGRADE_TARGET_VERSION` is used and should be set to the target version (15-SP1 here).