### PR TITLE
[WIP,RFC] LTP: Do not change kernel on LTP tests

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -134,15 +134,6 @@ sub load_kernel_tests {
         shutdown_ltp();
     }
     elsif (get_var('LTP_COMMAND_FILE')) {
-        if (get_var('INSTALL_KOTD')) {
-            loadtest 'install_kotd';
-        }
-        elsif (get_var('CHANGE_KERNEL_REPO') ||
-            get_var('CHANGE_KERNEL_PKG') ||
-            get_var('ASSET_CHANGE_KERNEL_RPM')) {
-            loadtest 'change_kernel';
-        }
-
         loadtest_from_runtest_file();
     }
     elsif (get_var('QA_TEST_KLP_REPO')) {


### PR DESCRIPTION
IMHO installing KOTD or other kernel (install_kotd loaded via
INSTALL_KOTD and change_kernel via CHANGE_KERNEL_REPO) aren't needed for
specific LTP test. These changes should be done only in install_ltp as
LTP tests jobs normally does not publish image.

And if the reason for this was IPMI and poo#40805, than it should still
be done via install_ltp (but maybe not as a separate job).