### PR TITLE
Add retry on zyppper failures on QAM tests

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -419,14 +419,17 @@ sub zypper_call {
 
     # Retrying workarounds
     my $ret;
-    for (1 .. 3) {
+    for (1 .. 5) {
         $ret = script_run("zypper -n $command $printer; ( exit \${PIPESTATUS[0]} )", $timeout);
         die "zypper did not finish in $timeout seconds" unless defined($ret);
         if ($ret == 4) {
             if (script_run('grep "Error code.*502" /var/log/zypper.log') == 0) {
                 record_soft_failure 'Retrying because of error 502 - bsc#1070851';
-                next;
             }
+        }
+        if (get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/ && ($ret == 4 || $ret == 8 || $ret == 106)) {
+            record_soft_failure 'Retry due to network problems poo#52319';
+            next;
         }
         last;
     }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/52670
- Verification run: http://10.100.12.155/tests/12144#step/patch_and_reboot/150
