### PR TITLE
sles12sp2 ltss registration page key shortcut is changed

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -646,9 +646,8 @@ sub fill_in_reg_server {
     }
     else {
         send_key "alt-i";
-        # Fresh install sles12sp3/4 shortcut is different with upgrade version
-        # Refer https://progress.opensuse.org/issues/47327
-        if ((is_sle('12-sp3+') && is_sle('<15') && get_var('UPGRADE')) || is_sle('>=15')) {
+        # Fresh install sles12sp2/3/4 shortcut is different with upgrade version
+        if ((is_sle('12-sp2+') && is_sle('<15') && get_var('UPGRADE')) || is_sle('>=15')) {
             send_key "alt-l";
         }
         else {


### PR DESCRIPTION
When sles12sp2 LTSS registration server is RMT, and do migration test, the key short is alt-l

- Related ticket: https://progress.opensuse.org/issues/53282
- Verification run: http://10.161.8.44/tests/35#step/patch_sle/19
[autoinst-log.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/3308980/autoinst-log.txt)

