### PR TITLE
Re-arrange cases for FIPS testing

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -627,7 +627,7 @@ sub specific_bootmenu_params {
         diag "Explicitly enabling installer self update with $self_update_repo";
     }
 
-    if (get_var("FIPS")) {
+    if (get_var("FIPS_INSTALLATION")) {
         push @params, "fips=1";
     }
 

--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -23,7 +23,7 @@ sub get_ip_address {
     return if (get_var('NOLOGS'));
 
     # avoid known issue in FIPS mode: bsc#985969
-    return if get_var('FIPS');
+    return if get_var('FIPS_INSTALLATION');
 
     if (get_var('OLD_IFCONFIG')) {
         use_ifconfig;

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -13,43 +13,71 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
-# Summary: Setup fips mode for further testing
-#          Support both "global mode" (fips=1 in kernel command line)
-#          and "ENV mode" - selected by FIPS_ENV_MODE
-# Maintainer: Wes <whdu@suse.com>
+# Summary: Setup fips mode for further testing:
+#          Installation check - verify the setup of FIPS installation
+#          ENV mode - selected by FIPS_ENV_MODE
+#          Global mode - setup fips=1 in kernel command line
+# Maintainer: wnereiz <wnereiz@member.fsf.org>
 # Tags: poo#39071
 
 use strict;
 use warnings;
 use base "consoletest";
 use testapi;
-use utils 'zypper_call';
-use Utils::Systemd 'disable_and_stop_service';
+use utils "zypper_call";
+use bootloader_setup "add_grub_cmdline_settings";
+use power_action_utils "power_action";
 
 sub run {
-    select_console 'root-console';
+    my ($self) = @_;
+    select_console "root-console";
 
-    disable_and_stop_service('packagekit.service', mask_service => 1);
+    # For installation only. FIPS has already been setup during installation
+    # (DVD installer booted with fips=1), so we only do verification here.
+    if (get_var("FIPS_INSTALLATION")) {
+        assert_script_run("grep '^GRUB_CMDLINE_LINUX_DEFAULT.*fips=1' /etc/default/grub");
+        assert_script_run("grep '^1\$' /proc/sys/crypto/fips_enabled");
+        record_info 'Kernel Mode', 'FIPS kernel mode (for global) configured!';
 
-    zypper_call('in -t pattern fips');
+        # Make sure FIPS pattern is installed and there is no conflicts.
+        zypper_call("refresh");
+        zypper_call("search -si -t pattern fips");
+
+        return;
+    }
+
+    # FIPS_INSTALLATION is only applicable for system installaton
+    die "FIPS_INSTALLATION is require to run this script for installation" if get_var("!BOOT_HDD_IMAGE");
+    die "FIPS setup is only applicable for FIPS_ENABLED=1 image!"          if get_var("!FIPS_ENABLED");
 
     # If FIPS_ENV_MODE, then set ENV for some FIPS modules. It is a
     # workaround when fips=1 kernel cmdline is not working.
     # If FIPS_ENV_MODE does not set, global FIPS mode (fips=1 from
     # kernel command line) will be applied
     if (get_var("FIPS_ENV_MODE")) {
+        die 'FIPS kernel mode is required for this test!' if check_var('SECURITY_TEST', 'crypt_kernel');
+        zypper_call('in -t pattern fips');
         foreach my $env ('OPENSSL_FIPS', 'OPENSSL_FORCE_FIPS_MODE', 'LIBGCRYPT_FORCE_FIPS_MODE', 'NSS_FIPS') {
             assert_script_run "echo 'export $env=1' >> /etc/bash.bashrc";
         }
+
+        record_info 'ENV Mode', 'FIPS environment mode (for single modules) configured!';
     }
     else {
-        assert_script_run "sed -i '/^GRUB_CMDLINE_LINUX_DEFAULT/s/\\(\"\\)\$/ fips=1\\1/' /etc/default/grub";
-        assert_script_run "grub2-mkconfig -o /boot/grub2/grub.cfg";
+        zypper_call('in -t pattern fips');
+        add_grub_cmdline_settings('fips=1', 1);
+        record_info 'Kernel Mode', 'FIPS kernel mode configured!';
     }
+
+    power_action('reboot', textmode => 1);
+    $self->wait_boot;
+
+    # Workaround to resolve console switch issue
+    select_console 'root-console';
 }
 
 sub test_flags {
-    return {fatal => 1};
+    return {milestone => 1, fatal => 1};
 }
 
 1;

--- a/tests/security/test_repo_setup.pm
+++ b/tests/security/test_repo_setup.pm
@@ -1,0 +1,106 @@
+# Copyright © 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Setup online repos or dvd images for further testing
+# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Tags: poo#52808
+
+use strict;
+use warnings;
+use base "consoletest";
+use testapi;
+use utils;
+use version_utils "is_sle";
+use registration qw(cleanup_registration register_product add_suseconnect_product);
+
+sub repo_cleanup {
+    cleanup_registration;
+    assert_script_run "rm -f /etc/zypp/repos.d/*.repo";
+    # Make sure all repositories are cleaned
+    validate_script_output("zypper lr || true", sub { m/No repo/ });
+}
+
+sub run {
+    my ($self) = @_;
+    select_console 'root-console';
+
+    # Note: Check the ticket in p.o.o for detailed descriptions of the
+    #       repository setup logic.
+
+    if (!get_var('SECTEST_DVD_SRC') && is_sle) {
+        my $sc_out = script_output("SUSEConnect --status-text", proceed_on_failure => 1);
+
+        record_info "Not Registered", "System is not registered, add DVD image as repositories." if ($sc_out =~ /Not Registered/);
+
+        # If the the network is not available to check if it is registered.
+        # Then proceed following steps to add DVD repo.
+        record_info "Network Error", "SUSEConnect error: SocketError" if ($sc_out =~ /SocketError/);
+
+        if ($sc_out =~ /Status.*ACTIVE/) {
+            set_var('SCC_REGCODE', ($sc_out =~ /Regcode: (.*)/)) if (!get_var("SCC_REGCODE"));
+            die "SCC_REGCODE not specified" if (!get_var('SCC_REGCODE'));
+            repo_cleanup;
+            # Base system registration
+            register_product;
+
+            # WE addon registration (according to the conditions)
+            if (get_var("SECTEST_REQUIRE_WE") && check_var("ARCH", "x86_64")) {
+                # Register Desktop module as a dependency
+                add_suseconnect_product('sle-module-desktop-applications');
+
+                # Register WE with workaround if NVIDIA repository is (usually) not ready
+                my ($pd_no) = $sc_out =~ /\(SLES\/(.*)\/x86_64\)/;
+                die "WE registration failed" if
+                  (script_output("SUSEConnect -p sle-we/$pd_no/x86_64 -r " . get_required_var("SCC_REGCODE_WE"),
+                        proceed_on_failure => 1, timeout => 180)
+                    !~ m/NVIDIA-Driver.*not found|Successfully registered/);
+            }
+
+            zypper_call("--gpg-auto-import-keys refresh");
+            return;
+        }
+
+        # Invalid system credentials, it is possible has been de-registered on
+        # SCC. Perform re-registration, SCC_REGCODE is needed, or it will
+        # process following steps to add ISO image
+        if ($sc_out =~ /Invalid system credentials/) {
+            record_info "SCC Invalid", "Invalid system credentials, it is possible has been de-registered on SCC.";
+            my $regcode = get_var("SCC_REGCODE");
+            if ($regcode) {
+                repo_cleanup;
+                # Only base system will be registered here
+                assert_script_run "SUSEConnect -r $regcode";
+                return;
+            }
+        }
+    }
+
+    repo_cleanup;
+
+    # Add all available ISO images can be found
+    my $sr_out = script_output("cd /dev && ls -1 sr* && cd", proceed_on_failure => 1);
+    die "DVD images not found!" if ($sr_out =~ /No such file/);
+
+    foreach my $sr (split("\n", $sr_out)) {
+        zypper_call("ar dvd:///?devices=/dev/$sr $sr");
+    }
+    zypper_call("--gpg-auto-import-keys ref");
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;

--- a/tests/x11/seahorse_sshkey.pm
+++ b/tests/x11/seahorse_sshkey.pm
@@ -14,8 +14,13 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
+use utils 'zypper_call';
 
 sub run {
+    select_console 'root-console';
+    zypper_call "in seahorse";
+    select_console 'x11';
+
     x11_start_program('seahorse');
     send_key "ctrl-n";                            # New Keyring
     assert_screen 'seahorse-keyring-selector';    # Dialog "Select type to create"


### PR DESCRIPTION
Use existing image which is created in functional job group instead of create new one. Add necessary repositories and setup FIPS mode at the begining of each test suites. The old image creating case will be changed to installation only to test system installation with `fips=1` option.

`select_console` were added to some cases to make it better coped with the sequence in the new test suites.

Please check following p.o.o tickets for the detailed description.

- Related ticket:
  - https://progress.opensuse.org/issues/52808
  - https://progress.opensuse.org/issues/52817
- Verification run:
  - SLE12SP5 Kernel Mode: [Job Group](http://10.67.17.9/tests/overview?distri=sle&version=12-SP5&build=0198&groupid=3)
  - SLE15SP1 ENV Mode: [Job Group](http://10.67.17.9/tests/overview?distri=sle&version=15-SP1&build=228.2&groupid=2)

### To be noticed
1. Please ignore the failed cases in verification run, which are probably caused by my developing environment, or if it is real problem, we would like to fix it after this change.
2. **Marked as WIP, we should make change to the test suites immediately after the code merged, or it will lead to most of cases failed.**