### PR TITLE
Add assert_screen between blind key presses to avoid fail

### DIFF
--- a/tests/console/yast2_registration.pm
+++ b/tests/console/yast2_registration.pm
@@ -35,8 +35,9 @@ sub register_system_and_add_extension {
     if (check_screen "yast2_registration-license-agreement") {
         wait_screen_change { send_key "alt-a" };
         send_key "alt-n";
-        wait_still_screen 5;
+        wait_still_screen 2;
     }
+    assert_screen 'yast2-software-installation-summary';
     send_key "alt-a";
     wait_still_screen 2;
     assert_screen 'yast2-sw_automatic-changes';


### PR DESCRIPTION
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1172
- Verification run: http://dzedro.suse.cz/tests/12251#step/yast2_registration/13