### PR TITLE
Don't continue when evolution setup fail

### DIFF
--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -108,7 +108,7 @@ sub run() {
 }
 
 sub test_flags() {
-    return {milestone => 1};
+    return {milestone => 1, fatal => 1};
 }
 
 1;


### PR DESCRIPTION
Comment is never taken over, just annoying.

- Fail: https://openqa.suse.de/tests/3011113#step/evolution_prepare_servers/12
