### PR TITLE
Add yast2-keyboard regression test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1408,6 +1408,7 @@ sub load_extra_tests_y2uitest_gui {
     if (get_var("QAM_YAST2UI")) {
         loadtest "yast2_gui/yast2_storage_ng" if is_sle("12-SP2+");
         loadtest "yast2_gui/yast2_security"   if is_sle("12-SP2+");
+        loadtest "yast2_gui/yast2_keyboard"   if is_sle("12-SP2+");
     }
 }
 
@@ -1416,6 +1417,7 @@ sub load_extra_tests_y2uitest_cmd {
     loadtest 'yast2_cmd/yast_timezone';
     loadtest 'yast2_cmd/yast_tftp_server';
     loadtest 'yast2_cmd/yast_rdp', if is_sle('15+');
+    loadtest 'yast2_cmd/yast_keyboard';
 }
 
 sub load_extra_tests_texlive {

--- a/tests/yast2_cmd/yast_keyboard.pm
+++ b/tests/yast2_cmd/yast_keyboard.pm
@@ -1,0 +1,47 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: this test checks that YaST Command Line Keyboard module is behaving
+#          correctly by changing keyboard layout and verifying that
+#          they have been successfully set.
+# Maintainer: Ming Li <mli@suse.com>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+
+    # Set keyboard layout to korean and validate
+    select_console("root-console");
+    zypper_call("in yast2-country", timeout => 480);
+    assert_script_run("yast keyboard list");
+    assert_script_run("yast keyboard set layout=korean");
+    validate_script_output("yast keyboard summary 2>&1",                    sub { m/Current\s+Keyboard\s+Layout:/ });
+    validate_script_output("localectl",                                     sub { m/korean/ });
+    validate_script_output("grep -i YAST_KEYBOARD /etc/sysconfig/keyboard", sub { m/korean/ });
+
+    # Set keyboard layout to German and validate
+    assert_script_run("yast keyboard set layout=german");
+    type_string "`1234567890-=[;'";
+    assert_screen "yast2_keyboard_layout_cmd_test";
+    send_key 'ctrl-u';
+
+    # Restore keyboard settings to english-us(select root-virtio-terminal console here, otherwise openqa will not run properly in the german keyboard layout)
+    select_console('root-virtio-terminal');
+    assert_script_run("yast keyboard set layout=english-us");
+    validate_script_output("yast keyboard summary 2>&1", sub { m/english-us/ });
+
+    select_console("root-console");
+
+}
+
+1;

--- a/tests/yast2_gui/yast2_keyboard.pm
+++ b/tests/yast2_gui/yast2_keyboard.pm
@@ -1,0 +1,60 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: this test checks that YaST2's Keyboard module is behaving
+#          correctly by changing keyboard layout and verifying that
+#          they have been successfully set.
+# Maintainer: Ming Li <mli@suse.com>
+
+use base "y2_module_guitest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+
+    # CLI validate yast keyboard module
+    select_console("x11");
+    x11_start_program("xterm");
+    become_root;
+    assert_script_run("yast keyboard list");
+    assert_script_run("yast keyboard set layout=korean");
+    validate_script_output("yast keyboard summary 2>&1", sub { m/Current\s+Keyboard\s+Layout:/ });
+    validate_script_output("localectl",                  sub { m/korean/ });
+    send_key "alt-f4";
+
+    # Set keyboard layout to German with yast2
+    $self->launch_yast2_module_x11("keyboard", match_timeout => 120);
+    send_key "alt-k";
+    send_key "home";
+    send_key_until_needlematch("yast2_keyboard-layout-german", "down");
+    wait_screen_change { send_key "alt-o" };
+    assert_screen "generic-desktop";
+
+    # Use gedit to verify keyboard layout
+    x11_start_program("gedit", match_timeout => 120);
+    wait_screen_change { type_string "`1234567890-=[;'" };
+    assert_screen "yast2_keyboard_layout_gedit_test";
+    send_key "alt-f4";
+    assert_screen "gedit-save-changes";
+    send_key "alt-w";
+    assert_screen "generic-desktop";
+
+    # Restore keyboard settings to english-us(select root-virtio-terminal console here, otherwise openqa will not run properly in the german keyboard layout)
+    select_console('root-virtio-terminal');
+    assert_script_run("yast keyboard set layout=english-us");
+    validate_script_output("yast keyboard summary 2>&1", sub { m/english-us/ });
+
+    select_console("x11");
+
+}
+
+1;


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/49283 

Needles: SLE: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1173

Verification run(yast_gui):
SLE15:      http://10.67.20.165/tests/536
SLE15-SP1:  http://10.67.20.165/tests/543
SLE12-SP3:  http://10.67.20.165/tests/542
SLE12-SP4:  http://10.67.20.165/tests/541
SLED15:     http://10.67.20.165/tests/537
SLED15-SP1: http://10.67.20.165/tests/538
SLED12-SP3: http://10.67.20.165/tests/539
SLED12-SP4: http://10.67.20.165/tests/540
The test will reside on the newly created mau-extratests-yast2ui (for osd)

Verification run(yast_cmd):
SLE15:      http://10.67.20.165/tests/564
SLE15-SP1:  http://10.67.20.165/tests/565
SLE12-SP3:  http://10.67.20.165/tests/567
SLE12-SP4:  http://10.67.20.165/tests/568
The test will reside on the newly created mau-extratests-yast2ui-textmode (for osd)