### PR TITLE
Add repo instead of ISO for s390x security test

### DIFF
--- a/tests/security/test_repo_setup.pm
+++ b/tests/security/test_repo_setup.pm
@@ -96,6 +96,23 @@ sub run {
     foreach my $sr (split("\n", $sr_out)) {
         zypper_call("ar dvd:///?devices=/dev/$sr $sr");
     }
+
+    # It is usually no DVD available for s390x testing, so we add repository
+    if (check_var('ARCH', 's390x')) {
+        my $mirror_src = get_required_var('MIRROR_HTTP');
+        zypper_call("ar $mirror_src MIRROR_HTTP_SRC");
+
+        if (is_sle('>=15')) {
+            my $urlprefix = get_required_var('MIRROR_PREFIX');
+            foreach my $n ('SLE_PRODUCT_SLES', 'SLE_MODULE_BASESYSTEM',
+                'SLE_MODULE_SERVER_APPLICATIONS', 'SLE_MODULE_DESKTOP_APPLICATIONS') {
+                next unless get_var("REPO_$n");
+                my $repourl = $urlprefix . "/" . get_var("REPO_$n");
+                zypper_call("ar $repourl $n");
+            }
+        }
+    }
+
     zypper_call("--gpg-auto-import-keys ref");
 }
 


### PR DESCRIPTION
Issue: https://openqa.suse.de/tests/overview?distri=sle&version=12-SP5&build=0201&groupid=168

s390x testing usually do not use ISO image, instead, add repository directly. So add additional steps here for repo setup procedure for s390x only.

- Related ticket: https://progress.opensuse.org/issues/52808
- Verification run:
  - SLE12 FIPS Kernel mode: http://10.67.17.9/tests/2026#step/test_repo_setup/15
  - SLE15 FIPS ENV mode: http://10.67.17.9/tests/2023#step/test_repo_setup/24

Since I do not have a s390x worker for verification, I simply use x86_64 instead by temporary modified the code of `check_var`. The code has been push by this PR is for s390x.