### PR TITLE
Simplify and make gnome-regression tests robuster

### DIFF
--- a/tests/x11/gnomecase/application_starts_on_login.pm
+++ b/tests/x11/gnomecase/application_starts_on_login.pm
@@ -16,7 +16,7 @@ use warnings;
 use testapi;
 use utils;
 use version_utils qw(is_leap is_sle is_tumbleweed);
-use x11utils 'handle_relogin';
+use x11utils qw(handle_relogin turn_off_gnome_screensaver);
 
 sub tweak_startupapp_menu {
     my ($self) = @_;
@@ -43,17 +43,18 @@ sub start_dconf {
 
     if (is_tumbleweed || is_sle('15+')) {
         # dconf-editor entry is not in gnome-control-center of SLE15;
-        x11_start_program 'dconf-editor';
+        x11_start_program 'dconf-editor', target_match => 'will-be-careful';
     }
     else {
         $self->start_gnome_settings;
         type_string "dconf";
         assert_screen "settings-dconf";
         send_key "ret";
+        wait_still_screen 2, 4;
     }
 
     # dconf-editor always show the notice to be careful after the main window
-    assert_and_click 'will-be-careful';
+    assert_and_click 'will-be-careful' if check_screen 'will-be-careful';
     assert_screen 'dconf-editor';
 }
 
@@ -61,7 +62,7 @@ sub alter_status_auto_save_session {
     my ($self) = @_;
     $self->start_dconf;
     # Old behavior for non SLE15 or non TW
-    if (!is_sle('15+') && !is_leap('15.0+')) {
+    if (is_sle('<15')) {
         send_key_until_needlematch "dconf-org", "down";
         assert_and_click "unfold";
         send_key_until_needlematch "dconf-org-gnome", "down";
@@ -77,98 +78,94 @@ sub alter_status_auto_save_session {
         type_string "auto-save-session\n";
     }
     assert_and_click "auto-save-session";
-    if (check_screen("changing-scheme-popup", 30)) {
+    if (check_screen("changing-scheme-popup", 5)) {
         assert_and_click "auto-save-session-alter-use-default";
         assert_and_click "auto-save-session-true";
         assert_and_click "auto-save-session-apply";
+        send_key "alt-f4";
+        wait_still_screen 2, 4;
     }
-    send_key "alt-f4";
-    wait_still_screen;
     send_key "alt-f4";
 }
 
 sub restore_status_auto_save_session {
     my ($self) = @_;
     $self->start_dconf;
-    assert_and_click "auto-save-session" unless is_sle('15+');
-    assert_and_click "auto-save-session-alter-use-default";
-    assert_and_click "auto-save-session-apply";
-    send_key "alt-f4";
-    wait_still_screen;
+    assert_and_click "auto-save-session";
+    if (check_screen("changing-scheme-popup", 5)) {
+        assert_and_click "auto-save-session-alter-use-default";
+        assert_and_click "auto-save-session-apply";
+        send_key "alt-f4";
+        wait_still_screen 2, 4;
+    }
     send_key "alt-f4";
 }
 
 sub run {
     my ($self) = @_;
-    #add firefox to startup application
     assert_screen "generic-desktop";
+
+    # turn off screensaver
+    x11_start_program('xterm');
+    turn_off_gnome_screensaver;
+    send_key 'alt-f4';
+
+    #add xterm to startup application
     $self->tweak_startupapp_menu;
     assert_and_click "tweak-startapp-add";
     assert_screen "tweak-startapp-applist";
     if (is_sle('12-SP2+') || is_tumbleweed) {
         assert_and_click "startupApp-searching";
-        wait_still_screen;
+        wait_still_screen 2, 4;
         assert_screen "focused-on-search";
-        type_string "firefox";
-        assert_and_click "firefox-searched";
+        type_string 'xterm';
+        wait_still_screen 2, 4;
     }
     else {
-        send_key_until_needlematch "applicationstart-firefox", "down";
+        send_key_until_needlematch "applicationstart-xterm", "down";
     }
-    assert_and_click "tweak-addapp-2startup";
-    assert_screen "startapp-firefox-added";
+    send_key_until_needlematch 'tweak-addapp-2startup', 'tab';
+    send_key 'ret';
+    assert_screen "startapp-xterm-added";
     send_key "alt-f4";
     wait_still_screen;
     send_key "alt-f4";
 
     handle_relogin;
-    $self->firefox_check_default;
-    $self->firefox_check_popups;
-    assert_screen "firefox-gnome", 90;
+    assert_screen 'xterm';
     send_key "alt-f4";
     wait_still_screen;
     send_key "ret";
     wait_still_screen;
     assert_screen "generic-desktop";
 
-    #remove firefox from startup application
+    #remove xterm from startup application
     $self->tweak_startupapp_menu;
-    assert_screen "startapp-firefox-added";
+    assert_screen "startapp-xterm-added";
     assert_and_click "startapp-delete";
-    wait_still_screen;
+    wait_still_screen 2, 4;
     send_key "alt-f4";
     assert_screen "generic-desktop";
 
     handle_relogin;
     assert_screen "generic-desktop";
 
-    #set auto-save-session;
-    ##reference information: start from gnome 3,
-    ##for lacking maintainence,
-    ##auto-save-session functionality has been abandoned;
-    ##current status: just firefox works
-    ##so in the future will consider remove openqa code for this session
-    unless (is_sle('15+') || is_tumbleweed) {
+    # save session
+    $self->alter_status_auto_save_session;
+    x11_start_program('xterm');
+    assert_screen 'xterm';
+    handle_relogin;
+    wait_still_screen;
+    send_key 'alt-tab';    # select xterm if unselected
+    assert_screen 'xterm';
+    send_key 'alt-f4';
+    wait_still_screen 2, 4;
+
+    if (is_sle('12-SP2+')) {
+        $self->restore_status_auto_save_session;
+    }
+    else {
         $self->alter_status_auto_save_session;
-
-        x11_start_program('firefox');
-        wait_still_screen;
-        $self->firefox_check_popups;
-        assert_screen "firefox-gnome", 90;
-        handle_relogin;
-        $self->firefox_check_popups;
-        assert_screen "firefox-gnome", 90;
-        send_key "alt-f4";
-        wait_still_screen;
-        send_key "ret";
-        wait_still_screen;
-
-        if (is_sle('12-SP2+')) {
-            $self->restore_status_auto_save_session;
-        }
-        else {
-            $self->alter_status_auto_save_session;
-        }
     }
 }
 

--- a/tests/x11/gnomecase/change_password.pm
+++ b/tests/x11/gnomecase/change_password.pm
@@ -37,7 +37,7 @@ sub lock_screen {
 
 sub logout_and_login {
     handle_logout;
-    assert_screen 'displaymanager';
+    send_key_until_needlematch 'displaymanager', 'esc', 30, 3;
     mouse_hide();
     wait_still_screen;
     assert_and_click "displaymanager-$username";
@@ -161,8 +161,7 @@ sub run {
     # We should kill the active user test in SLE15
     assert_script_run 'loginctl terminate-user test' if is_sle('15+') || is_tumbleweed;
     wait_still_screen;
-    type_string "userdel -f test\n";
-    assert_screen "user-test-deleted";
+    assert_script_run 'userdel -f test';
     send_key "alt-f4";
     send_key "ret";
 

--- a/tests/x11/gnomecase/gnome_classic_switch.pm
+++ b/tests/x11/gnomecase/gnome_classic_switch.pm
@@ -25,14 +25,9 @@ sub application_test {
     send_key "ret";
     wait_still_screen;
 
-    x11_start_program('firefox');
-    $self->firefox_check_default;
-    $self->firefox_check_popups;
-    assert_screen "firefox-gnome", 150;
+    x11_start_program('xterm');
+    assert_screen 'xterm';
     send_key "alt-f4";
-    wait_still_screen;
-    send_key "ret";
-    wait_still_screen;
 
 }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/53306
- Needles:
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/564
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1176
- Verification run:
https://openqa.suse.de/tests/3016892
https://openqa.suse.de/tests/3016891
https://openqa.opensuse.org/tests/969805
http://10.100.12.155/tests/12399