### PR TITLE
Add yast2-rdp autotest module in cmdline.

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1414,6 +1414,7 @@ sub load_extra_tests_y2uitest_cmd {
     loadtest 'yast2_cmd/yast_lan';
     loadtest 'yast2_cmd/yast_timezone';
     loadtest 'yast2_cmd/yast_tftp_server';
+    loadtest 'yast2_cmd/yast_rdp', if is_sle('15+');
 }
 
 sub load_extra_tests_openqa_bootstrap {

--- a/tests/yast2_cmd/yast_rdp.pm
+++ b/tests/yast2_cmd/yast_rdp.pm
@@ -1,0 +1,57 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: this test checks that YaST2's RDP module is behaving
+#          correctly in cmdline mode  and verifying that RDP service
+#          has been successfully set.
+# Maintainer: Jun Wang <jgwang@suse.com>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils 'is_sle';
+
+sub run {
+    select_console 'root-console';
+
+    # prepare the setup for test, this test just supports sle15+.
+    zypper_call("in yast2-rdp", exitcode => [0, 102, 103]);
+    systemctl("stop xrdp.service",    ignore_failure => 1);
+    systemctl("disable xrdp.service", ignore_failure => 1);
+
+    # start xrdp service
+    assert_script_run("yast rdp allow set=yes", fail_message => "yast rdp failed when starting xrdp service");
+
+    # check if xrdp service starts.
+    my $start  = systemctl('is-active xrdp.service',  ignore_failure => 1);
+    my $enable = systemctl('is-enabled xrdp.service', ignore_failure => 1);
+    if ($start or $enable) {
+        die "yast rdp failed to start xrdp service";
+    }
+
+    # check yast rdp list
+    validate_script_output 'yast rdp list 2>&1', sub { m/service is enabled/ };
+
+    # stop xrdp service
+    assert_script_run("yast rdp allow set=no", fail_message => "yast rdp failed when stopping xrdp service");
+
+    # check if xrdp service stops.
+    $start  = systemctl('is-active xrdp.service',  ignore_failure => 1);
+    $enable = systemctl('is-enabled xrdp.service', ignore_failure => 1);
+    if ($start != 3 or $enable != 1) {
+        die "yast rdp failed to stop xrdp service";
+    }
+
+    # check yast rdp list
+    validate_script_output 'yast rdp list 2>&1', sub { m/service is disabled/ };
+}
+
+1;


### PR DESCRIPTION
Add yast-rdp.pm.
yast-rdp.pm: this module will test yast rdp service in cmd mode, and just support SLE15+.

this is the verification run:
SLE15       : http://10.67.20.116/tests/212
SLE15SP1 : http://10.67.20.116/tests/215