### PR TITLE
Improve the salt multimachine scenario

### DIFF
--- a/tests/network/setup_multimachine.pm
+++ b/tests/network/setup_multimachine.pm
@@ -24,8 +24,14 @@ sub run {
     my $hostname = get_var('HOSTNAME');
     select_console 'root-console';
 
+    # Do not use external DNS for our internal hostnames
+    assert_script_run('echo "10.0.2.101 server master" >> /etc/hosts');
+    assert_script_run('echo "10.0.2.102 client minion" >> /etc/hosts');
+
     # Configure static network, disable firewall
     disable_and_stop_service($self->firewall);
+
+    # Configure the internal network an  try it
     if ($hostname =~ /server|master/) {
         setup_static_mm_network('10.0.2.101/24');
     }
@@ -40,3 +46,4 @@ sub run {
 }
 
 1;
+


### PR DESCRIPTION
Hello,

I spent a lot of time debugging the Salt scenario:
 * It has been discussed on [bsc#1135756](https://bugzilla.suse.com/show_bug.cgi?id=1135756) 
 * But also previously on [bsc#1069711](https://bugzilla.suse.com/show_bug.cgi?id=1069711)

- Verification runs:
    [SLES15sp1@salt-master](http://pdostal-server.suse.cz/tests/3613) [SLES15sp1@salt-minion](http://pdostal-server.suse.cz/tests/3614)
    [SLES15@salt-master](http://pdostal-server.suse.cz/tests/3615) [SLES15@salt-minion](http://pdostal-server.suse.cz/tests/3616)
    [SLES12sp4@salt-master](http://pdostal-server.suse.cz/tests/3617) [SLES12sp4@salt-minion](http://pdostal-server.suse.cz/tests/3618)
    [SLES12sp3@salt-master](http://pdostal-server.suse.cz/tests/3619) [SLES12sp3@salt-minion](http://pdostal-server.suse.cz/tests/3620)