### PR TITLE
xorg_vt: Generalize needle tag to cover any tty

### DIFF
--- a/tests/console/xorg_vt.pm
+++ b/tests/console/xorg_vt.pm
@@ -1,27 +1,24 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Rework the tests layout.
-# Maintainer: Alberto Planas <aplanas@suse.com>
+# Summary: Check for correct tty used by X
+# Maintainer: Oliver Kurz <okurz@suse.de>
 
 use base "consoletest";
 use strict;
 use warnings;
 use testapi;
-use utils;
 
 sub run {
-    # permissions don't matter
-
-    script_run('ps -ef | grep bin/X');
-    assert_screen("xorg-tty7");    # suppose used terminal is tty7
+    assert_script_run('ps -ef | grep bin/X');
+    assert_screen('xorg-tty');
 }
 
 1;


### PR DESCRIPTION
Previously the needle stated the assumption that we would be on tty7
however this has not been true for quite some time on many systems
already so let's generalize.

Needs https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/565

Related progress issue: https://progress.opensuse.org/issues/53339