### PR TITLE
Rework "boot_into_snapshot" to boot from image

### DIFF
--- a/schedule/boot_to_snapshot.yaml
+++ b/schedule/boot_to_snapshot.yaml
@@ -1,0 +1,11 @@
+name:           boot_to_snapshot
+description:    >
+    Test booting to automatically created snapshots.
+vars:
+    BOOT_HDD_IMAGE: 1
+    BOOT_TO_SNAPSHOT: 1
+    START_AFTER_TEST: create_hdd_textmode
+schedule:
+    - installation/grub_test
+    - installation/boot_into_snapshot
+    - installation/first_boot


### PR DESCRIPTION
The commit adds yaml schedule which allows to use already published
qcow2 image and execute the boot_to_snapshot test module there.

Also, it requires the following variables to be specified in openQA
Test Suites menu:

YAML_SCHEDULE=schedule/boot_to_snapshot.yaml
HDD_1=%DISTRI%-%VERSION%-%ARCH%-%BUILD%-%DESKTOP%@%MACHINE%.qcow2

- Related ticket: [poo#44144](https://progress.opensuse.org/issues/44144)
- Verification run: http://oorlov-vm.qa.suse.de/tests/990
