### PR TITLE
Add post fail hook for kernel performance cases

### DIFF
--- a/tests/kernel_performance/full_run.pm
+++ b/tests/kernel_performance/full_run.pm
@@ -19,24 +19,39 @@ use warnings;
 use testapi;
 use base 'y2_installbase';
 use File::Basename;
+use Utils::Backends 'use_ssh_serial_console';
 
 sub full_run {
-    #my $case   = get_var("CASE_NAME");
-    #my $repeat = get_var("CASE_REPEAT");
-    my $timeout //= 180;
-    my $i           = 1;
+    my $time_out //= 6;
     my $list_path   = "/root/qaset";
     my $remote_list = get_var("FULL_LIST");
+    my $hostname    = script_output "hostname";
     #setup run list
     assert_script_run("wget -N -P $list_path $remote_list 2>&1");
     assert_script_run("cp $list_path/default.list $list_path/list");
 
     assert_script_run("/usr/share/qa/qaset/qaset reset");
     assert_script_run("/usr/share/qa/qaset/run/performance-run.upload_Beijing");
+    while (1) {
+        if (script_run("cat /var/log/qaset/control/NEXT_RUN | grep '_'") == 0) {
+            last;
+        }
+        if ($time_out == 0) {
+            die "Full run failed,please rerun.";
+        }
+        sleep 30;
+        --$time_out;
+    }
 }
 
 sub run {
     full_run;
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+    my $screenlog = script_output("ls -rt /var/log/qaset/calls | tail -n 1");
+    upload_logs "/var/log/qaset/calls/$screenlog";
 }
 
 sub test_flags {

--- a/tests/kernel_performance/install_qatestset.pm
+++ b/tests/kernel_performance/install_qatestset.pm
@@ -42,6 +42,11 @@ sub run {
     setup_environment;
     power_action('poweroff', keepconsole => 1, textmode => 1);
 }
+
+sub post_fail_hook {
+    my ($self) = @_;
+}
+
 sub test_flags {
     return {fatal => 1};
 }

--- a/tests/kernel_performance/run_perf_case.pm
+++ b/tests/kernel_performance/run_perf_case.pm
@@ -70,6 +70,10 @@ sub run {
     run_one_by_one;
 }
 
+sub post_fail_hook {
+    my ($self) = @_;
+}
+
 sub test_flags {
     return {fatal => 1};
 }


### PR DESCRIPTION
Add post fail hook for kernel performance cases.

Purpose 1: get more log help us debug;
               2: avoid some network issue; 

- Related ticket: N/A
- Needles: N/A
- Verification run:  http://10.67.134.117/tests/14180
                             http://10.67.134.117/tests/14179
