### PR TITLE
Don't run libgpiod test on x86_64 JeOS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1606,7 +1606,7 @@ sub load_extra_tests_console {
     loadtest 'console/zziplib'   if (is_sle('12-SP3+') && !is_jeos);
     loadtest 'console/firewalld' if is_sle('15+') || is_leap('15.0+') || is_tumbleweed;
     loadtest 'console/aaa_base' unless is_jeos;
-    loadtest 'console/libgpiod' if is_leap('15.1+') || is_tumbleweed;
+    loadtest 'console/libgpiod' if (is_leap('15.1+') || is_tumbleweed) && !(is_jeos && is_x86_64);
 }
 
 sub load_extra_tests_docker {


### PR DESCRIPTION
It needs a kernel module which is not part of kernel-default-base.

Verification run: http://10.160.67.86/tests/357