### PR TITLE
Fixed #52691 - undefined subroutine &gdb

### DIFF
--- a/tests/console/gdb.pm
+++ b/tests/console/gdb.pm
@@ -15,12 +15,12 @@ use warnings;
 use testapi;
 use utils 'zypper_call';
 
-sub wait_serial_or_croak {
+sub wait_serial_or_die {
     my $feedback = shift;
 
     my $e = wait_serial($feedback, 10);
     if (!defined $e) {
-        croak("Unexpected serial output");
+        die("Unexpected serial output");
     }
 }
 
@@ -29,35 +29,36 @@ sub run {
     #Setup console for text feedback.
     my ($self) = @_;
     $self->select_serial_terminal();
-
     zypper_call('in gcc glibc-devel gdb');    #Install test depedencies.
 
     #Test Case 1
     assert_script_run("curl -O " . data_url('gdb/test1.c'));
     assert_script_run("gcc -g -std=c99 test1.c -o test1");
-    script_run("gdb test1");
+    type_string("gdb test1\n");
+    wait_serial_or_die("GNU gdb");
     type_string("break main\n");
     type_string("run\n");
-    wait_serial_or_croak("Breakpoint 1, main");
+    wait_serial_or_die("Breakpoint 1, main");
     type_string("continue\n");
-    wait_serial_or_croak("exited normally");
+    wait_serial_or_die("exited normally");
     type_string("quit\n");
 
     #Test Case 2
     assert_script_run("curl -O " . data_url('gdb/test2.c'));
     assert_script_run("gcc -g -std=c99  test2.c -o test2");
-    script_run("gdb test2");
+    type_string("gdb test2\n");
+    wait_serial_or_die(qr/GNU gdb/);
     type_string("run\n");
-    wait_serial_or_croak("Program received signal SIGSEGV");
+    wait_serial_or_die("Program received signal SIGSEGV");
     type_string("backtrace\n");
-    wait_serial_or_croak(s.in main () at test2.c:16.);
+    wait_serial_or_die(s.in main () at test2.c:16.);
     type_string("info locals\n");
     type_string("up\n");
-    wait_serial_or_croak(s.1 0x000000000040117b in main () at test2.c:16\n16 char * newstr = str_dup(cstr, 5);.);
+    wait_serial_or_die(s.1 0x000000000040117b in main () at test2.c:16\n16 char * newstr = str_dup(cstr, 5);.);
     type_string("info locals\n");
-    wait_serial_or_croak("<error: Cannot access memory at ");
+    wait_serial_or_die("<error: Cannot access memory at ");
     type_string("quit\n");
-    wait_serial_or_croak("Inferior");
+    wait_serial_or_die("Inferior");
     type_string("y\n");
 
     #Test 3
@@ -65,14 +66,15 @@ sub run {
     assert_script_run("gcc -g  -std=c99 test3.c -o test3");
     script_run("./test3 & echo 'this is a workaround'");
     assert_script_run("pidof test3");    #Make sure the process was launched.
-    script_run('gdb -p $(pidof test3)');
-    wait_serial_or_croak("Attaching to process", 10);
+    type_string('gdb -p $(pidof test3)');
+    type_string("\n");
+    wait_serial_or_die("Attaching to process", 10);
     type_string("break test3.c:9\n");
-    wait_serial_or_croak("Breakpoint 1 at");
+    wait_serial_or_die("Breakpoint 1 at");
     type_string("continue\n");
-    wait_serial_or_croak(s.Breakpoint 1, main () at test3.c:9.);
+    wait_serial_or_die(s.Breakpoint 1, main () at test3.c:9.);
     type_string("quit\n");
-    wait_serial_or_croak("Quit anyway?");
+    wait_serial_or_die("Quit anyway?");
     type_string("y\n");
     assert_script_run("pkill -9 test3");
     select_console("root-console");


### PR DESCRIPTION
Replaced croak with die.

Replaced bad use of script_run with send_string

Perl tidy run.

Instead of using croak to stop the script I am now using die, so I dont need to import anything. I also fixed some incorrect uses of script run when I am calling gdb, so all test steps should be green.
The test will still fail on xen but won't bring Perl down with it. 

- Related ticket: https://progress.opensuse.org/issues/52691
- Verification run: 
SLE15SP1: http://10.161.229.249/tests/206#step/gdb/1
SLE15: http://10.161.229.249/tests/200#step/gdb/1
SLE12SP4: http://10.161.229.249/tests/202#step/gdb/1
SLE12SP3: http://10.161.229.249/tests/203#step/gdb/1
SLE12SP2: http://10.161.229.249/tests/201#step/gdb/1
Tumbleweed: http://10.161.229.249/tests/205#step/gdb/1