### PR TITLE
Collect log for vino_server test case

### DIFF
--- a/tests/x11/remote_desktop/vino_server.pm
+++ b/tests/x11/remote_desktop/vino_server.pm
@@ -53,12 +53,21 @@ sub run {
     send_key 'alt-f4';
     assert_screen 'gcc-sharing-activate';
 
+    # The following section opens a terminal to print vino-server log
+    # to help debug poo#49811
+    x11_start_program('xterm');
+    assert_script_run('killall vino-server');
+    type_string("/usr/lib/vino/vino-server | tee /tmp/vino-server.log\n");
+    send_key 'alt-tab';
+
     # Notice vino server is ready for remote access
     mutex_create 'vino_server_ready';
 
     # Wait until vino client finishes remote access
     wait_for_children;
 
+    save_screenshot;
+    wait_screen_change { send_key 'alt-f4' };
     wait_screen_change { send_key 'alt-f4' };
 }
 


### PR DESCRIPTION
To collect log from vino-server, I have to kill the running process first, then run it inside a terminal to see its debug output.

- Related ticket: https://progress.opensuse.org/issues/49811
- Needles: none
- Verification run: http://147.2.212.139/tests/244#step/vino_server/39