### PR TITLE
Fix installer hang at select_patterns_and_packages

### DIFF
--- a/tests/installation/select_patterns_and_packages.pm
+++ b/tests/installation/select_patterns_and_packages.pm
@@ -28,7 +28,11 @@ use testapi;
 sub accept3rdparty {
     #Third party licenses sometimes appear
     while (check_screen([qw(3rdpartylicense automatic-changes inst-overview)], 15)) {
-        last if match_has_tag("automatic-changes");
+        if (match_has_tag("automatic-changes")) {
+            send_key 'alt-o';
+            last;
+        }
+
         last if match_has_tag("inst-overview");
         wait_screen_change { send_key $cmd{acceptlicense} };
     }
@@ -174,7 +178,11 @@ sub switch_selection {
 }
 
 sub accept_changes {
-    send_key 'alt-o';
+    if (check_var('VIDEOMODE', 'text')) {
+        send_key 'alt-a';
+    } else {
+        send_key 'alt-o';
+    }
     accept3rdparty;
     assert_screen 'inst-overview';
 }


### PR DESCRIPTION
This is a regression in testcase, some of create_hdd testcase not running
in textmode. They didn't trigger this.

Bug: http://mitigations.qa2.suse.asia/tests/2223#step/select_patterns_and_packages/75

Verify: http://mitigations.qa2.suse.asia/tests/2061#step/select_patterns_and_packages/74