### PR TITLE
Fix a wrong  substring in detect unused module

### DIFF
--- a/tools/detect_unused_modules
+++ b/tools/detect_unused_modules
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 for test in $(git ls-files "*tests/*.pm") ; do
-    t=$(echo $test | sed -e 's@tests/.*/@@' -e 's@.pm@@')
+    t=$(echo $test | sed -e 's@tests/.*/@@' -e 's@\.pm$@@')
     t_dir=$(echo $test | sed -e 's@tests/\(.*\)/.*$@\1@')
     git grep -qE "($t|load_testdir.*$t_dir)" || echo $test
 done | \


### PR DESCRIPTION
E.g:

A=tests/cpu_bugs/ipmi_to_qemu.pm
echo $A | sed -e 's@tests/.*/@@' -e 's@.pm@@'

-e 's@.pm@@' will remove the first 'pm' in $A.

$A will be "i_to_qemu.pm".

".pm" suffix will keep.
