### PR TITLE
wait_boot: Add support for deleting characters from boot prompt on-the-fly

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -621,6 +621,8 @@ sub wait_boot {
             wait_screen_change { send_key 'e' };
             for (1 .. $linux_boot_entry) { send_key 'down' }
             wait_screen_change { send_key 'end' };
+            send_key_until_needlematch(get_var('EXTRABOOTPARAMS_DELETE_NEEDLE_TARGET'), 'left', 1000) if get_var('EXTRABOOTPARAMS_DELETE_NEEDLE_TARGET');
+            for (1 .. get_var('EXTRABOOTPARAMS_DELETE_CHARACTERS', 0)) { send_key 'backspace' }
             type_string_very_slow "$boot_params ";
             save_screenshot;
             send_key 'ctrl-x';

--- a/variables.md
+++ b/variables.md
@@ -42,6 +42,8 @@ EVERGREEN |||
 EXIT_AFTER_START_INSTALL | boolean | false | Indicates that test suite will be finished after `installation/start_install` test module. So that all the test modules after this one will not be scheduled and executed.
 EXTRABOOTPARAMS | string | | Concatenates content of the string as boot options applied to the installation bootloader.
 EXTRABOOTPARAMS_BOOT_LOCAL | string | | Boot options applied during the boot process of a local installation.
+EXTRABOOTPARAMS_DELETE_CHARACTERS | string | | Characters to delete from boot prompt.
+EXTRABOOTPARAMS_DELETE_NEEDLE_TARGET | string | | If specified, go back with the cursor until this needle is matched to delete characters from there. Needs EXTRABOOTPARAMS_BOOT_LOCAL and should be combined with EXTRABOOTPARAMS_DELETE_CHARACTERS.
 EXTRATEST | boolean | false | Enables execution of extra tests, see `load_extra_tests`
 FLAVOR | string | | Defines flavor of the product under test, e.g. `staging-.-DVD`, `Krypton`, `Argon`, `Gnome-Live`, `DVD`, `Rescue-CD`, etc.
 FULLURL | string | | Full url to the factory repo. Is relevant for openSUSE only.


### PR DESCRIPTION
Verification run: https://openqa.opensuse.org/tests/974429#step/boot_to_desktop/111

triggered with

```
openqa-clone-job --skip-chained-deps --within-instance https://openqa.opensuse.org 973405 \
_GROUP=0 TEST=external_iso@okurz/os-autoinst-distri-opensuse#fix/boot_std_cirrus \
BUILD=okurz/os-autoinst-distri-opensuse#7788 \
CASEDIR=https://github.com/okurz/os-autoinst-distri-opensuse.git#fix/boot_std_cirrus \
PRODUCTDIR=os-autoinst-distri-opensuse/products/opensuse \
NEEDLES_DIR=/var/lib/openqa/cache/openqa1-opensuse/tests/opensuse/products/opensuse/needles \
EXTRABOOTPARAMS_DELETE_CHARACTERS=3 \
EXTRABOOTPARAMS_BOOT_LOCAL=' ' \
EXTRABOOTPARAMS_DELETE_NEEDLE_TARGET=grub-prompt-video_16bit
```