### PR TITLE
Remove scheduler-specific params from yaml files

### DIFF
--- a/declarative-schedule-doc.md
+++ b/declarative-schedule-doc.md
@@ -85,6 +85,7 @@ There are a few exceptions:
   - `DESKTOP`: it produces wrong .json in openQA WebUI
   - `HDD_1`: if added, openQA will not publish the image in openQA WebUI due to it depends on os-autoinst.
   - `START_AFTER_TEST`: if added, openQA will not link dependencies on the corresponding tab in openQA WebUI due to it depends on os-autoinst.
+-   `UEFI_PFLASH_VARS`: if added, openQA will not publish in UI
 
 #### conditional_schedule
 Depending on different values of an environmental variable we can schedule different set of modules.

--- a/schedule/boot_to_snapshot.yaml
+++ b/schedule/boot_to_snapshot.yaml
@@ -2,9 +2,7 @@ name:           boot_to_snapshot
 description:    >
     Test booting to automatically created snapshots.
 vars:
-    BOOT_HDD_IMAGE: 1
     BOOT_TO_SNAPSHOT: 1
-    START_AFTER_TEST: create_hdd_textmode
 schedule:
     - installation/grub_test
     - installation/boot_into_snapshot

--- a/schedule/yast2_gui.yaml
+++ b/schedule/yast2_gui.yaml
@@ -6,13 +6,8 @@ description:    >
     as the gnome environment for the GUI tests.
 vars:
     BOOTFROM: c
-    BOOT_HDD_IMAGE: 1
-    # DESKTOP: gnome -> When added, an empty key appears first in the list
     HDDSIZEGB: 20
-    # HDD_1: SLES-%VERSION%-%ARCH%-Build%BUILD%@%MACHINE%-gnome.qcow2 -> if added, openQA will not publish in UI
     SOFTFAIL_BSC1063638: 1
-    START_AFTER_TEST: create_hdd_gnome
-    # UEFI_PFLASH_VARS: SLES-%VERSION%-%ARCH%-Build%BUILD%@%MACHINE%-gnome-uefi-vars.qcow2  -> if added, openQA will not publish in UI
     VALIDATE_ETC_HOSTS: 1
 schedule:
     - boot/boot_to_desktop


### PR DESCRIPTION
The commit removes the parameters like START_AFTER_TEST, because there is no sense to keep them in yaml files as the parameters required by openQA scheduler, and they simply will not be visible for the scheduler.

Also, I've removed commented lines to make the scheduling files more clear, and to avoid such doubtful practice when there will be even more commented lines in the further yaml files.

- Related ticket: https://progress.opensuse.org/issues/52580
- Verification run: https://openqa.opensuse.org/tests/974189
