### PR TITLE
Revert "Disable workaround for fixed boo#1105302"

### DIFF
--- a/tests/installation/system_workarounds.pm
+++ b/tests/installation/system_workarounds.pm
@@ -18,7 +18,12 @@ use base 'opensusebasetest';
 sub run {
     select_console('root-console');
 
-    # Add your workarounds here
+    # boo#1105302 - Disable kernel watchdog on aarch64 (for running system and for next boot)
+    if (check_var('ARCH', 'aarch64')) {
+        record_info('boo#1105302', "Disable kernel watchdog to avoid test failures due to 'watchdog: BUG: soft lockup - CPU#0 stuck for XXs!'");
+        assert_script_run('echo 0 > /proc/sys/kernel/watchdog_thresh');
+        assert_script_run('echo "kernel.watchdog_thresh = 0" > /etc/sysctl.d/watchdog.conf');
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
This reverts commit 3a308865a30571a497bad15cf8f6c320e24b91a7.

Revert #7525 as it seems that the workaround is still needed.

See https://openqa.opensuse.org/tests/973642#step/system_workarounds/7

Ticket: https://progress.opensuse.org/issues/47849