### PR TITLE
Enable support server for ssh installation in opensuse

### DIFF
--- a/schedule/yast/remote_ssh_controller.yaml
+++ b/schedule/yast/remote_ssh_controller.yaml
@@ -1,0 +1,25 @@
+---
+name:           remote_ssh_controller
+description:    >
+  Install remote server (parallel job) with ssh.
+schedule:
+ - support_server/login
+ - support_server/setup
+ - remote/remote_controller
+ - installation/welcome
+ - installation/accept_license
+ - installation/scc_registration
+ - installation/addon_products_sle
+ - installation/system_role
+ - installation/partitioning
+ - installation/partitioning_finish
+ - installation/installer_timezone
+ - installation/user_settings
+ - installation/user_settings_root
+ - installation/resolve_dependency_issues
+ - installation/installation_overview
+ - installation/disable_grub_timeout
+ - installation/start_install
+ - installation/await_install
+ - installation/reboot_after_installation
+ - support_server/wait_children

--- a/schedule/yast/remote_ssh_target.yaml
+++ b/schedule/yast/remote_ssh_target.yaml
@@ -1,0 +1,9 @@
+---
+name:           remote_ssh_target
+description:    >
+  Boot with ssh=1 parameter and wait for parallel job (remote_ssh_controller) 
+  to install the system.
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - remote/remote_target

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -540,6 +540,7 @@ sub run {
     }
 
     if (exists $server_roles{dhcp}) {
+        zypper_call("in -t pattern dhcp_dns_server");
         setup_dhcp_server((exists $server_roles{dns}), 0);
     }
     if (exists $server_roles{qemuproxy}) {
@@ -553,6 +554,7 @@ sub run {
         $setup_script .= "systemctl restart apache2\n";
     }
     if (exists $server_roles{dns}) {
+        zypper_call("in -t pattern dhcp_dns_server");
         setup_dns_server();
     }
 


### PR DESCRIPTION
Add yaml schedule for remote ssh installation in opensuse.
Install pattern `dhcp_dns_server` to avoid to create additional custom images when there are already available ones that just need the pattern, in this case it is used `opensuse-42.3-x86_64-GM-gnome@64bit.qcow2`

- Related ticket: https://progress.opensuse.org/issues/52313
- Needles: N/A
- Verification run: http://rivera-workstation.suse.cz/tests/115#step/setup/45
