### PR TITLE
Fix SSH key creation if key already existing

### DIFF
--- a/tests/kernel/ib_tests.pm
+++ b/tests/kernel/ib_tests.pm
@@ -108,7 +108,8 @@ sub run {
     systemctl("stop " . opensusebasetest::firewall);
     barrier_wait('IBTEST_SETUP');
 
-    # create and distribute ssh key
+    # remove, if present, create and distribute ssh key
+    script_run('rm -f ~/.ssh/id_rsa ~/.ssh/id_rsa.pub');
     assert_script_run('ssh-keygen -b 2048 -t rsa -q -N "" -f ~/.ssh/id_rsa');
     exec_and_insert_password("ssh-copy-id -o StrictHostKeyChecking=no root\@$master");
     script_run("/usr/bin/clear");


### PR DESCRIPTION
Sometimes, there are already existing ssh keys on the machine (either from an old installation or from a previous test) and the creation of the keys for this test does fail.
However, we do want to create new keys anyway and we don't want to depend on the (non-)existance of ~/.ssh/id_rsa[.pub], we should just remove the file if it is present.