### PR TITLE
Add test for the Tumbleweed vagrant box

### DIFF
--- a/data/virtualization/Vagrantfile
+++ b/data/virtualization/Vagrantfile
@@ -1,0 +1,34 @@
+# This is a Vagrantfile "template", you have to replace DISTRO, BOXNAME_LIBVIRT
+# and BOXNAME_VIRTUALBOX with the appropriate values
+Vagrant.configure("2") do |config|
+
+  config.vm.provider "virtualbox" do |virtbox|
+    virtbox.memory = 2048
+    virtbox.cpus = 4
+  end
+
+  config.vm.provider :libvirt do |libvirt|
+    libvirt.cpus = 4
+    libvirt.memory = 2048
+  end
+
+  config.vm.hostname = "vm-test"
+
+  config.vm.define "DISTRO-libvirt" do |tw|
+    tw.vm.box = "../BOXNAME_LIBVIRT"
+  end
+
+  config.vm.define "DISTRO-virtualbox" do |tw|
+    tw.vm.box = "../BOXNAME_VIRTUALBOX"
+  end
+
+  config.vm.provision "shell", path: "provision.sh"
+
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "ansible_playbook.yml"
+    ansible.become = true
+    ansible.become_user = "root"
+    ansible.verbose = "-vv"
+  end
+
+end

--- a/data/virtualization/ansible_playbook.yml
+++ b/data/virtualization/ansible_playbook.yml
@@ -1,0 +1,66 @@
+---
+- hosts: all
+
+  tasks:
+
+    - name: add a test user
+      user:
+        name: test
+        state: present
+
+    - name: cat the testfile
+      command: cat /vagrant/testfile.txt
+      changed_when: false
+      register: testfile_result
+
+    - name: grep for the zypper setting that only required packages get installed
+      command: grep '^\S*solver\.onlyRequires' /etc/zypp/zypp.conf
+      changed_when: false
+      register: only_reguires_grep
+
+    - name: grep for multiversion kernel settings (expected to fail)
+      command: grep '^\S*multiversion' /etc/zypp/zypp.conf
+      changed_when: false
+      ignore_errors: true  # grep should not find this but will then return 1
+      register: multiversion_grep
+
+    - name: get the list of installed packages
+      command: rpm -qa
+      args:
+        # we use rpm directly so silence the warning here
+        warn: false
+      changed_when: false
+      register: pkg_list
+
+    - name: find the ssh host keys
+      find:
+        paths: "/etc/ssh/"
+        recurse: no
+        patterns: "ssh_host_*key*"
+      register: ssh_host_keys
+
+    - name: stat the newly generated ssh keys
+      stat:
+        path: "{{ item.path }}"
+      loop: "{{ ssh_host_keys.files }}"
+      register: ssh_host_keys_stat
+
+    - name: try to install etags
+      zypper:
+        name:
+          - etags
+
+    - assert:
+        that:
+          # contents of testfile.txt
+          - "testfile_result.stdout == 'Nothing in here!'"
+          # hostname from the Vagrantfile (this is broken)
+          # - "ansible_hostname == 'vm-test'"
+          # expected setting from autoYast
+          - "only_reguires_grep.stdout == 'solver.onlyRequires = true'"
+          # multiversion should be turned off by default
+          - "(multiversion_grep.stdout == '') and (multiversion_grep.rc == 1)"
+          # ensure that no YaST packages are left
+          - "(pkg_list.stdout_lines | select('match','yast*') | list | length) == 0"
+          # check that the ssh keys are not older than the uptime
+          - "(ansible_date_time.epoch | float) - (ssh_host_keys_stat.results | map(attribute='stat') | selectattr('exists') | map(attribute='ctime') | min) <= (ansible_uptime_seconds)"

--- a/data/virtualization/provision.sh
+++ b/data/virtualization/provision.sh
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+
+if [ $(id -u) -ne 0 ]; then
+    echo "Not running as root!"
+    exit 1
+fi
+
+zypper --non-interactive refresh

--- a/data/virtualization/testfile.txt
+++ b/data/virtualization/testfile.txt
@@ -1,0 +1,1 @@
+Nothing in here!

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2389,7 +2389,12 @@ sub load_virtualization_tests {
 
     # reboot the machine to kill the previously started virtual machines
     loadtest "console/console_reboot";
-    loadtest "virtualization/vagrant/add_box";
+
+    # the tests currently require x86 & Tumbleweed
+    if (is_x86_64 && is_tumbleweed) {
+        loadtest "virtualization/vagrant/add_box";
+        loadtest "virtualization/vagrant/boxes/tumbleweed";
+    }
     return 1;
 }
 

--- a/tests/virtualization/vagrant/add_box.pm
+++ b/tests/virtualization/vagrant/add_box.pm
@@ -25,19 +25,32 @@ use utils;
 sub run() {
     select_console('root-console');
 
-    zypper_call('in vagrant virtualbox');
+    zypper_call('in vagrant virtualbox vagrant-libvirt');
+
     assert_script_run('systemctl start vboxdrv');
     assert_script_run('systemctl start vboxautostart');
+    assert_script_run('systemctl start libvirtd');
+
     assert_script_run('usermod -a -G vboxusers bernhard');
+    assert_script_run('usermod -a -G libvirt bernhard');
 
     select_console('user-console');
     assert_script_run('echo "test" > testfile');
 
-    assert_script_run('vagrant init ubuntu/xenial64');
+    assert_script_run('vagrant init centos/7');
     assert_script_run('vagrant up --provider virtualbox', timeout => 1200);
 
     assert_script_run('vagrant ssh -c "[ $(cat testfile) = \"test\" ]"');
     assert_script_run('vagrant halt');
+    assert_script_run('vagrant destroy -f');
+
+    assert_script_run('vagrant up', timeout => 1200);
+
+    assert_script_run('vagrant ssh -c "[ $(cat testfile) = \"test\" ]"');
+    assert_script_run('vagrant halt');
+    assert_script_run('vagrant destroy -f');
+
+    assert_script_run('rm -rf Vagrantfile testfile .vagrant');
 }
 
 1;

--- a/tests/virtualization/vagrant/boxes/tumbleweed.pm
+++ b/tests/virtualization/vagrant/boxes/tumbleweed.pm
@@ -1,0 +1,100 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Test for vagrant and packaged addons
+# Maintainer: dancermak <dcermak@suse.com>
+
+use strict;
+use warnings;
+use base "basetest";
+use testapi;
+use utils;
+use File::Basename;
+
+
+sub run() {
+    select_console('root-console');
+    zypper_call('in ansible');
+
+    select_console('user-console');
+
+    # version = Tumbleweed, Leap 15 etc
+    my $version = get_required_var('VERSION');
+    my $arch    = get_required_var('ARCH');
+    my $build   = get_required_var('BUILD');
+
+    my %boxes = (
+        # openSUSE-Tumbleweed-Vagrant.x86_64-1.0-{libvirt|virtualbox}-Snapshot20190704.vagrant.{libvirt|virtualbox}.box
+        libvirt    => "openSUSE-$version-Vagrant.$arch-1.0-libvirt-Snapshot$build.vagrant.libvirt.box",
+        virtualbox => "openSUSE-$version-Vagrant.$arch-1.0-virtualbox-Snapshot$build.vagrant.virtualbox.box"
+    );
+
+    my @providers = keys %boxes;
+
+    #
+    # get Vagrantfile template and replace the distro name & insert box filenames
+    #
+    assert_script_run("wget --quiet " . data_url("virtualization/Vagrantfile"));
+    assert_script_run("sed -i 's|DISTRO|$version|' Vagrantfile");
+
+    foreach my $provider (@providers) {
+        my $boxname = "$boxes{$provider}";
+        assert_script_run("wget --quiet " . autoinst_url("/assets/other/$boxname"));
+
+        my $upcase_provider = uc $provider;
+        assert_script_run("sed -i 's|BOXNAME_$upcase_provider|$boxname|' Vagrantfile");
+    }
+
+    # move the Vagrantfile into a empty subdirectory and invoke vagrant from
+    # there, so that we don't synchronize the huge .box files into the VM
+    assert_script_run("mkdir test_dir");
+    assert_script_run("mv Vagrantfile test_dir/");
+    assert_script_run("pushd test_dir");
+
+    #
+    # Grab the remaining test files and bring the boxes up, down and up again
+    # be sure to clean them up afterwards
+    #
+    assert_script_run("wget --quiet " . data_url('virtualization/testfile.txt'));
+    assert_script_run("wget --quiet " . data_url('virtualization/provision.sh'));
+    assert_script_run("wget --quiet " . data_url('virtualization/ansible_playbook.yml'));
+
+    foreach my $provider (@providers) {
+        my $boxname = "$version-$provider";
+
+        # Test the box *only*: bring it up and destroy it immediately afterwards
+        assert_script_run("vagrant up $boxname --provider $provider --no-provision", timeout => 1200);
+
+        # now run the actual tests via the Ansible test playbook
+        assert_script_run("vagrant provision $boxname", timeout => 1200);
+
+        # test if the box survives a reboot
+        assert_script_run("vagrant halt");
+        assert_script_run("vagrant up $boxname", timeout => 1200);
+
+        assert_script_run("vagrant destroy -f $boxname");
+    }
+
+    # cleanup after all the tests ran
+    foreach my $provider (@providers) {
+        my $boxname = "$boxes{$provider}";
+        assert_script_run("vagrant box remove --force --provider $provider ../$boxname");
+        assert_script_run("rm ../$boxname");
+    }
+
+    assert_script_run("popd");
+}
+
+1;


### PR DESCRIPTION
This PR adds a test run for the openSUSE-Tumbleweed Vagrant box, which has been ported from an internal Jenkins pipeline.

### TODO

- [x] Test run
- [x] modifications to `rsync.pl` so that the Vagrant box get's copied to openqa.opensuse.org
- [x] Depends on: https://build.opensuse.org/request/show/713057
- [x] Remove hardcoded `build` variable

- Related ticket: None
- Needles: None required
- Verification run: https://openqa.opensuse.org/tests/988490
