### PR TITLE
Reduce the cycles for bootloader bounce back on ppc64le

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -194,14 +194,11 @@ sub boot_local_disk {
         wait_screen_change { send_key 'ret' };
         # Currently the bootloader would bounce back to inst-bootmenu screen after pressing 'ret'
         # on 'local' menu-item, we have to check it and send 'ret' again to make booting properly
-        my $counter = 3;
-        while (check_screen(['bootloader', 'inst-bootmenu'], 3) && $counter) {
+        if (check_screen(['bootloader', 'inst-bootmenu'], 30)) {
             record_info 'bounce back to inst-bootmenu, send ret again';
             send_key 'ret';
-            wait_still_screen(1);
-            $counter--;
         }
-        my @tags = qw(inst-slof bootloader grub2 inst-bootmenu);
+        my @tags = qw(inst-slof grub2);
         push @tags, 'encrypted-disk-password-prompt' if (get_var('ENCRYPT'));
         assert_screen(\@tags);
         if (match_has_tag 'grub2') {


### PR DESCRIPTION
Sometimes the check for the bounce back will waste time to catch the bootloader 'grub2', I think we can check it one time to save time to catch tag 'grub2'.  

- Related ticket: https://progress.opensuse.org/issues/53723
- Needles: N/A
- Verification run: will run on o.s.d.
