### PR TITLE
Add EVM setup and protection using hmacs cases

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2281,6 +2281,12 @@ sub load_security_tests_ima_appraisal {
     loadtest "security/ima/evmctl_ima_sign";
 }
 
+sub load_security_tests_evm_protection {
+    loadtest "security/ima/ima_setup";
+    loadtest "security/ima/evm_setup";
+    loadtest "security/ima/evm_protection_hmacs";
+}
+
 sub load_security_tests_system_check {
     loadtest "security/nproc_limits";
 }
@@ -2292,7 +2298,7 @@ sub load_security_tests {
       ipsec mmtest
       apparmor apparmor_profile selinux
       openscap
-      mok_enroll ima_measurement ima_appraisal
+      mok_enroll ima_measurement ima_appraisal evm_protection
       system_check
     );
 

--- a/tests/security/ima/evm_protection_hmacs.pm
+++ b/tests/security/ima/evm_protection_hmacs.pm
@@ -1,0 +1,67 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Test EVM protection using HMACs
+# Note: This case should come after 'evm_setup'
+# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Tags: poo#53579
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use bootloader_setup "replace_grub_cmdline_settings";
+use power_action_utils "power_action";
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    my $fstype     = 'ext4';
+    my $sample_app = '/usr/bin/yes';
+    my $sample_cmd = 'yes --version';
+
+    my $findret = script_output("/usr/bin/find / -fstype $fstype -type f -uid 0 -exec evmctl -a sha256 ima_hash '{}' \\;", 1800, proceed_on_failure => 1);
+    # Allow "No such file" message for the files in /proc because they are mutable
+    my @finds = split /\n/, $findret;
+    $_ =~ m/\/proc\/.*No such file/ or die "Failed to create security.evm for $_" foreach (@finds);
+
+    validate_script_output "getfattr -m . -d $sample_app", sub {
+        # Base64 armored security.evm and security.ima content (50 chars), we
+        # do not match the last three ones here for simplicity
+        m/security\.evm=[0-9a-zA-Z+\/]{27}.*
+          security\.ima=[0-9a-zA-Z+\/]{47}/sxx;
+    };
+
+    # Remove security.evm attribute manually, and verify it is empty
+    assert_script_run "setfattr -x security.ima $sample_app";
+    validate_script_output "getfattr -m security.evm -d $sample_app", sub { m/^$/ };
+
+    replace_grub_cmdline_settings('evm=fix ima_appraise=fix', '', 1);
+
+    power_action('reboot', textmode => 1);
+    $self->wait_boot(textmode => 1);
+    $self->select_serial_terminal;
+
+    my $ret = script_output($sample_cmd, 30, proceed_on_failure => 1);
+    die "$sample_app should not have permission to run" if ($ret !~ "\Q$sample_app\E: *Permission denied");
+}
+
+sub test_flags {
+    return {always_rollback => 1};
+}
+
+1;

--- a/tests/security/ima/evm_setup.pm
+++ b/tests/security/ima/evm_setup.pm
@@ -1,0 +1,64 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Setup environment for EVM protection testing
+# Note: This case should come after 'ima_setup'
+# Maintainer: wnereiz <wnereiz@member.fsf.org>
+# Tags: poo#53579
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use bootloader_setup "add_grub_cmdline_settings";
+use power_action_utils "power_action";
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    my $key_dir        = '/etc/keys';
+    my $userkey_blob   = "$key_dir/kmk-user.blob";
+    my $evmkey_blob    = "$key_dir/evm.blob";
+    my $masterkey_conf = '/etc/sysconfig/masterkey';
+    my $evm_conf       = '/etc/sysconfig/evm';
+
+    # Create Kernel Master Key
+    assert_script_run "keyctl add user kmk-user '`dd if=/dev/urandom bs=1 count=32 2>/dev/null`' \@u";
+    assert_script_run "mkdir $key_dir";
+    assert_script_run "keyctl pipe `/bin/keyctl search \@u user kmk-user` > $userkey_blob";
+
+    # Generate EVM key which will be used for HMACs
+    assert_script_run "keyctl add encrypted evm-key 'new user:kmk-user 64' \@u";
+    assert_script_run "keyctl pipe `/bin/keyctl search \@u encrypted evm-key` > $evmkey_blob";
+
+    assert_script_run "echo -e \"MASTERKEYTYPE='user'\\nMASTERKEY='$userkey_blob'\" > $masterkey_conf";
+    assert_script_run "echo -e \"EVMKEY='$evmkey_blob'\" > $evm_conf";
+
+    add_grub_cmdline_settings("evm=fix ima_appraise=fix ima_appraise_tcb", 1);
+
+    power_action('reboot', textmode => 1);
+    $self->wait_boot(textmode => 1);
+    $self->select_serial_terminal;
+
+    validate_script_output "cat /sys/kernel/security/evm", sub { m/^1$/ };
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;


### PR DESCRIPTION
Set EVM environment (prepare necessary evm key), then perform EVM protection testing using hmacs.

- Related ticket: https://progress.opensuse.org/issues/53579
- Verification run:
  - SLE15 SP1: http://10.67.17.9/tests/2053
(IMA/EVM testing is only available for SLE15 currently)