### PR TITLE
Adapt Hawk Selenium test so it works on SLED 12-SP4

### DIFF
--- a/data/ha/hawk_test.py
+++ b/data/ha/hawk_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 """HAWK GUI interface Selenium test: tests hawk GUI with Selenium using firefox or chrome"""
 
-import argparse, re, hawk_test_driver, hawk_test_ssh, hawk_test_results
+import sys, argparse, re, hawk_test_driver, hawk_test_ssh, hawk_test_results
 
 ### MAIN
 
@@ -57,7 +57,10 @@ if args.secret:
     ssh.verify_node_maintenance(results)
 browser.test('test_disable_maintenance_first_node', results)
 browser.test('test_add_new_cluster', results, mycluster)
-browser.test('test_remove_cluster', results, mycluster)
+if sys.version_info[0] >= 3:
+    browser.test('test_remove_cluster', results, mycluster)
+else:
+    browser.skip('test_remove_cluster', results)
 browser.test('test_click_on_history', results)
 browser.test('test_generate_report', results)
 browser.test('test_click_on_command_log', results)

--- a/data/ha/hawk_test_driver.py
+++ b/data/ha/hawk_test_driver.py
@@ -167,7 +167,12 @@ class hawkTestDriver:
             print("ERROR: Couldn't find element '%s'" % text)
             self.test_status = False
             return False
-        elem.click()
+        try:
+            elem.click()
+        except ElementNotInteractableException:
+            # Element is obscured. Wait and click again
+            time.sleep(2*self.timeout_scale)
+            elem.click()
         time.sleep(self.timeout_scale)
         return True
 
@@ -229,6 +234,10 @@ class hawkTestDriver:
                 time.sleep(2*self.timeout_scale)
                 elem.click()
             time.sleep(2*self.timeout_scale)
+
+    # Test skip function
+    def skip(self, testname, results):
+        self.set_test_status(results, testname, 'skipped')
 
     # Generic function to perform the tests
     def test(self, testname, results, *extra):

--- a/data/ha/hawk_test_results.py
+++ b/data/ha/hawk_test_results.py
@@ -14,6 +14,7 @@ class resultSetError(Exception):
 class resultSet:
     def __init__(self):
         self.my_tests = []
+        self.start_time = time.time()
         for f in dir(hawk_test_driver.hawkTestDriver):
             if f.startswith('test_') and callable(getattr(hawk_test_driver.hawkTestDriver, f)):
                 self.my_tests.append(f)
@@ -46,7 +47,7 @@ class resultSet:
     def set_test_status(self, testname, status):
         status = str(status)
         testname = str(testname)
-        if status not in ['passed', 'failed']:
+        if status not in ['passed', 'failed', 'skipped']:
             raise resultSetError('test status must be either [passed] or [failed]')
         if (status == 'passed' and
                 self.results_set['tests'][self.my_tests.index(testname)]['outcome'] != 'passed'):
@@ -54,8 +55,11 @@ class resultSet:
         elif (status == 'failed' and
               self.results_set['tests'][self.my_tests.index(testname)]['outcome'] != 'failed'):
             self.results_set['summary']['passed'] -= 1
+        elif (status == 'skipped' and
+              self.results_set['tests'][self.my_tests.index(testname)]['outcome'] != 'skipped'):
+            self.results_set['summary']['num_tests'] -= 1
         self.results_set['tests'][self.my_tests.index(testname)]['outcome'] = status
-        self.results_set['summary']['duration'] = time.process_time()
+        self.results_set['summary']['duration'] = time.time() - self.start_time
         self.results_set['info']['timestamp'] = time.time()
 
     def get_failed_tests_total(self):

--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -264,6 +264,8 @@ sub ha_export_logs {
     my $cts_log       = '/tmp/cts_cluster_exerciser.log';
     my @y2logs;
 
+    select_console 'root-console';
+
     # Extract HA logs and upload them
     script_run "touch $corosync_conf";
     script_run "hb_report $report_opt -E $bootstrap_log $hb_log", 300;
@@ -292,6 +294,10 @@ sub ha_export_logs {
 
     # pacemaker cts log
     upload_logs($cts_log, failok => 1) if (get_var('PACEMAKER_CTS_TEST_ROLE'));
+
+    # HAWK test logs if present
+    upload_logs("/tmp/hawk_test.log", failok => 1);
+    upload_logs("/tmp/hawk_test.ret", failok => 1);
 }
 
 sub check_cluster_state {


### PR DESCRIPTION
This PR includes several changes to the python+selenium hawk test so it can run from systems using `python2` and `python-setuptools`. The current version of the test is failing while installing the python dependencies with `easy_install -U` as can be seen here:

https://openqa.suse.de/tests/3022578#step/hawk_gui/13

Up to now, the test has been run on SLED 15 using `python3` and `python3-pip` without major issues, but we hit several issues while doing validation of hawk in a SLES 12-SP5 HA cluster and testing from SLED 12-SP4:

- On SLES/SLED 15*, the hawk test runs from a SLED system that is installed at the same time and with the same version as the SLES+HA cluster nodes as both products share the same installation media, however for SLES 12* the same cannot be done, so we need to decide a fixed version of SLED from where to run the hawk test.
- It is problematic to run the python+selenium test in the same MM group with the cluster nodes when the clusters are using `VERSION=12*` and the SLED host is run with a 15* OS, as the default configuration for the tests share the same value for **VERSION**. Due to this, newer needles are unregistered, and the test running the SLED host fails. **VERSION** value can be forced for the hawk client test, but this messes with the dashboard and with the hawk test itself as the `ha/hawk_gui` test module expects to be testing a cluster node of a specific major version.
- On older SLED versions (12-SP4 and older), even though both `python2` and `python3` are installed, there is no `python3-pip` or `python-pip` packages present in the system, and they are also not available in the default repositories for installation. `python-setuputils` is present, so it is possible to install the python dependencies with `easy_install`. However, there are several issues when using `easy_install` to install the python dependencies for the test:

1. `selenium` requires `urllib3`, but the version that `easy_install` attempts to install (1.25) cannot be installed with `easy_install`. the test was modified to install fixed version 1.23 when using `easy_install` prior to the installation of selenium
2. `paramiko` cannot be installed as well; version 2.6.0 due to a data type mismatch issue while older versions (2.2.4 to 2.5.1) fail to install while compiling dependencies. However it is possible to install `paramiko` version 2.1.6, so this version will be used when installing with `easy_install`
3. The hawk selenium test is running without issues with `geckodriver` version 0.24.0 in SLED 15 and with `python3`, however with `python2` the script is [unable to connect to the selenium driver to perform the test (connection refused)](http://mango.suse.de/tests/1055/file/hawk_gui-hawk_test.log). With the older 0.17.0 version of `geckodriver`, the connection to the driver is possible, so the test was updated to use `geckodriver` version 0.17.0 when using `python2` and 0.24.0 when using `python3`.
4. As a consequence of using `geckodriver` 0.17.0, the selenium operations take a bit more time to start. Some timeouts were updated as a consequence, and one of the instances of `elem.click()` was also updated to catch the `ElementNotInteractableException` and perform a second attempt.
5. The change in the driver version also had the consequence that the test `test_remove_cluster` is able to find and click in the web element used to remove the cluster, but the pop up window is never shown. Since this is working with `python3` and `geckodriver` version 0.24.0 as well as manually, it was decided to skip the test when running under `python2`. The python code was updated to check under which version of python is running and a skip function was added to `hawk_test_driver.py` and to `hawk_test_results.py`.
6. Under `python2`, the `time` module does not have the `process_time()` function, so this was dropped from the python code and in its place a `time.time() - self.start_time was added`.
7. The method ha_export_logs in `lib/hacluster` was updated to include the logs from the hawk test, and also to run on the `root-console` to make sure that logs are uploaded on failures.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1182
- Verification run: http://mango.suse.de/tests/1076 (from SLED 12-SP4), http://mango.suse.de/tests/1067 (from SLED 15)
