### PR TITLE
Fix yast2_nfs_client to be run on single machine

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -76,6 +76,7 @@ NAME | string | | Name of the test run including distribution, build, machine na
 NET | boolean | false | Indicates net installation.
 NETBOOT | boolean | false | Indicates net boot.
 NETDEV | string | | Network device to be used when adding interface on zKVM.
+NFSCLIENT | boolean | false | Indicates/enables nfs client in `console/yast2_nfs_client` for multi-machine test.
 NFSSERVER | boolean | false | Indicates/enables nfs server in `console/yast2_nfs_server`.
 NICEVIDEO |||
 NOAUTOLOGIN | boolean | false | Indicates disabled auto login.


### PR DESCRIPTION
The commit returns back the code for test nfs client on single machine
setup, but still keeps the ability to run multi-machine test.

- Related ticket: [poo#52580](https://progress.opensuse.org/issues/52580)
- Verification run: http://oorlov-vm.qa.suse.de/tests/1008
