### PR TITLE
Relocate x11 test cases into the same group test sequences

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2123,15 +2123,14 @@ sub load_security_tests_crypt_x11 {
     set_var('SECTEST_REQUIRE_WE', 1);
     load_security_console_prepare;
 
-    loadtest "x11/x3270_ssl";
-    loadtest "fips/mozilla_nss/firefox_nss" if get_var('FIPS_ENABLED');
-
     # In SLE, hexchat and seahorse are provided only in WE addon which is for
     # x86_64 platform only.
     if (is_x86_64) {
         loadtest "x11/seahorse_sshkey";
         loadtest "x11/hexchat_ssl";
     }
+    loadtest "x11/x3270_ssl";
+    loadtest "fips/mozilla_nss/firefox_nss" if get_var('FIPS_ENABLED');
 }
 
 sub load_security_tests_crypt_tool {


### PR DESCRIPTION
Relocate x11 test cases into the same group test sequences to avoid
the random select_console 'root-console' fail.

Error : https://openqa.suse.de/tests/3029979#step/seahorse_sshkey/2

- Related ticket: https://progress.opensuse.org/issues/53651
- Needles: NA
- Verification run: http://10.163.2.52/tests/278
