### PR TITLE
Public Cloud: Fix LTP package installation

### DIFF
--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -55,7 +55,7 @@ sub run_ssh_command {
     scp($from, $to, timeout => 90);
 
 Use scp to copy a file from or to this instance. A url starting with
-C<remote:> is replaces with the IP from this instance. E.g. a call to copy
+C<remote:> is replaced with the IP from this instance. E.g. a call to copy
 the file I</var/log/cloudregister> to I</tmp> looks like:
 C<<<$instance->scp('remote:/var/log/cloudregister', '/tmp');>>>
 =cut

--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -152,7 +152,7 @@ sub rmt_mirror_repo {
 
 =head2 rmt_import_data
     rmt_import_data($datafile);
-RMT server import data about available repositories and the mirrored packages 
+RMT server import data about available repositories and the mirrored packages
 from disconnected RMT server, then verify imported repos on new RMT server.
 =cut
 sub rmt_import_data {
@@ -229,17 +229,19 @@ sub disable_source_repo {
 }
 
 sub generate_version {
-    my $dist    = get_required_var('DISTRI');
-    my $version = get_required_var('VERSION');
+    my ($separator) = @_;
+    my $dist        = get_required_var('DISTRI');
+    my $version     = get_required_var('VERSION');
+    $separator //= '_';
     if (is_sle) {
         $dist = 'SLE';
-        $version =~ s/-/_/;
+        $version =~ s/-/$separator/;
     } elsif (is_tumbleweed) {
         $dist = 'openSUSE';
     } elsif (is_leap) {
         $dist = 'openSUSE_Leap';
     }
-    return $dist . "_" . $version;
+    return $dist . $separator . $version;
 }
 
 1;


### PR DESCRIPTION
1) Download LTP package from http://download.suse.de/ibs/QA:/Head/ 
2) Transfer it to the PC VM
3) Install LTP with zypper, it will also install dependencies thanks to registering the system and activate SDK repo.

- Related ticket: https://progress.opensuse.org/issues/53039
- Verification runs:
    GCE: http://fromm.arch.suse.de/tests/6515
    EC2: http://fromm.arch.suse.de/tests/6517
    Azure: http://fromm.arch.suse.de/tests/6516

Tests are red, but not due to test code, there are 2 test cases failing (preadv203, preadv203_64), but nothing to do with this PR.
