### PR TITLE
publiccloud: Detailed boottime measurement

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2490,7 +2490,7 @@ sub load_publiccloud_tests {
     if (get_var('PUBLIC_CLOUD_PREPARE_TOOLS')) {
         loadtest "publiccloud/prepare_tools";
     }
-    elsif (get_var('PUBLIC_CLOUD_IPA_TESTS') or get_var('PUBLIC_CLOUD_CHECK_BOOT_TIME')) {
+    elsif (get_var('PUBLIC_CLOUD_IPA_TESTS')) {
         loadtest "publiccloud/ipa";
     }
     elsif (get_var('PUBLIC_CLOUD_LTP')) {
@@ -2498,6 +2498,9 @@ sub load_publiccloud_tests {
     }
     elsif (get_var('PUBLIC_CLOUD_ACCNET')) {
         loadtest 'publiccloud/az_accelerated_net';
+    }
+    elsif (get_var('PUBLIC_CLOUD_CHECK_BOOT_TIME')) {
+        loadtest "publiccloud/boottime";
     }
     elsif (get_var('PUBLIC_CLOUD_IMAGE_LOCATION')) {
         loadtest "publiccloud/upload_image";

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -13,7 +13,9 @@
 
 package publiccloud::instance;
 use testapi;
+use Carp croak;
 use Mojo::Base -base;
+use Mojo::Util 'trim';
 use File::Basename;
 
 use constant SSH_TIMEOUT => 90;
@@ -46,8 +48,10 @@ sub run_ssh_command {
 
     my $ssh_cmd = sprintf('ssh %s -i "%s" "%s@%s" -- %s',
         $self->ssh_opts, $self->ssh_key, $self->username, $self->public_ip, $args{cmd});
-    record_info('CMD', $ssh_cmd);
-    return script_output($ssh_cmd, $args{timeout}, %args);
+    record_info('SSH CMD', $ssh_cmd);
+    delete($args{cmd});
+    $args{quiet} //= 1;
+    return script_output($ssh_cmd, %args);
 }
 
 =head2 scp
@@ -61,6 +65,7 @@ C<<<$instance->scp('remote:/var/log/cloudregister', '/tmp');>>>
 =cut
 sub scp {
     my ($self, $from, $to, %args) = @_;
+    $args{timeout} //= SSH_TIMEOUT;
 
     my $url = sprintf('%s@%s:', $self->username, $self->public_ip);
     $from =~ s/^remote:/$url/;
@@ -69,7 +74,7 @@ sub scp {
     my $ssh_cmd = sprintf('scp %s -i "%s" "%s" "%s"',
         $self->ssh_opts, $self->ssh_key, $from, $to);
 
-    return script_run($ssh_cmd, $args{timeout});
+    return script_run($ssh_cmd, %args);
 }
 
 =head2 upload_log
@@ -89,6 +94,113 @@ sub upload_log {
         upload_logs($dest);
     }
     assert_script_run("test -d '$tmpdir' && rm -rf '$tmpdir'");
+}
+
+=head2 wait_fo_guestregister
+
+    wait_for_guestregister([timeout => 300]);
+
+Run command C<systemctl is-active guestregister> on the instance in a loop
+for max C<timeout> seconds until it will return inactive.
+=cut
+sub wait_for_guestregister
+{
+    my ($self, %args) = @_;
+    $args{timeout} //= 300;
+    my $start_time = time();
+    my $last_info  = 0;
+
+    while (time() - $start_time < $args{timeout}) {
+        my $out = $self->run_ssh_command(cmd => 'sudo systemctl is-active guestregister', proceed_on_failure => 1, quiet => 1);
+        if ($out eq 'inactive') {
+            return time() - $start_time;
+        }
+        if (time() - $last_info > 10) {
+            record_info('WAIT', 'Wait for guest register: ' . $out);
+            $last_info = time();
+        }
+        sleep 1;
+    }
+    die('guestregister didn\'t end in expected timeout=' . $args{timeout});
+}
+
+=head2 check_ssh_port
+
+    check_ssh_port([timeout => 600] [, proceed_on_failure => 0])
+
+Check if the SSH port of the instance is reachable and open.
+=cut
+sub check_ssh_port
+{
+    my ($self, %args) = @_;
+    $args{timeout}            //= 600;
+    $args{proceed_on_failure} //= 0;
+    my $start_time = time();
+
+    while ((my $duration = time() - $start_time) < $args{timeout}) {
+        return $duration if (script_run('nc -vz -w 1 ' . $self->{public_ip} . ' 22', quiet => 1) == 0);
+        sleep 1;
+    }
+    croak(sprintf("Unable to reach SSH port of instance %s with public IP:%s within %d seconds",
+            $self->{instance_id}, $self->{public_ip}, $self->{timeout}))
+      unless ($args{proceed_on_failure});
+    return;
+}
+
+=head2 softreboot
+
+    ($shutdown_time, $bootup_time) = softreboot([timeout => 600]);
+
+Does a softreboot of the instance by running the command C<shutdown -r>.
+Return an array of two values, first one is the time till the instance isn't
+reachable anymore. The second one is the estimated bootup time.
+=cut
+sub softreboot
+{
+    my ($self, %args) = @_;
+    $args{timeout} //= 600;
+
+    my $duration;
+
+    $self->run_ssh_command(cmd => 'sudo shutdown -r +1');
+    # skip the one minute waiting
+    sleep 60;
+    my $start_time = time();
+
+    # wait till ssh disappear
+    while (($duration = time() - $start_time) < $args{timeout}) {
+        last unless (defined($self->check_ssh_port(timeout => 1, proceed_on_failure => 1)));
+    }
+    my $shutdown_time = time() - $start_time;
+    die("Waiting for system down failed!") unless ($shutdown_time < $args{timeout});
+    my $bootup_time = $self->check_ssh_port(timeout => $args{timeout} - $shutdown_time);
+    return ($shutdown_time, $bootup_time);
+}
+
+=head2 stop
+
+    stop();
+
+Stop the instance using the CSP api calls.
+=cut
+sub stop
+{
+    my $self = shift;
+    $self->provider->stop_instance($self, @_);
+}
+
+=head2 start
+
+    start([timeout => ?]);
+
+Start the instance and check SSH connectivity. Return the number of seconds
+till the SSH port was available.
+=cut
+sub start
+{
+    my ($self, %args) = @_;
+    $self->provider->start_instance($self, @_);
+    return $self->check_ssh_port(timeout => $args{timeout});
 }
 
 1;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -225,16 +225,16 @@ C<instance_type> defines the flavor of the instance. If not specified, it will l
 =cut
 sub create_instance {
     my ($self, %args) = @_;
+    $args{check_connectivity} //= 1;
 
     my @vms      = $self->terraform_apply();
     my $instance = $vms[0];
     record_info('INSTANCE', Dumper($instance));
 
-    for (1 .. 60) {
-        return $instance if script_run("nc -vz -w 1 $instance->{public_ip} 22") == 0;
-        sleep 5;
+    if ($args{check_connectivity}) {
+        $instance->check_ssh_port();
     }
-    die('Cannot reach port 22 on IP ' . $instance->{public_ip});
+    return $instance;
 }
 
 =head2 on_terraform_timeout
@@ -416,5 +416,26 @@ sub cleanup {
     $self->terraform_destroy() if ($self->terraform_applied);
     $self->vault_revoke();
 }
+
+=head2 stop_instance
+
+This function implements a provider specifc stop call for a given instance.
+
+=cut
+sub stop_instance
+{
+    die('stop_instance() isn\'t implemented');
+}
+
+=head2 start_instance
+
+This function implements a provider specifc start call for a given instance.
+
+=cut
+sub start_instance
+{
+    die('start_instance() isn\'t implemented');
+}
+
 
 1;

--- a/tests/publiccloud/boottime.pm
+++ b/tests/publiccloud/boottime.pm
@@ -1,0 +1,197 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Collect/store bootup time from publiccloud instances.
+#
+# Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+
+sub extract_startup_timings {
+    my $string = shift;
+    my $res    = {};
+    $string =~ s/Startup finished in\s*//;
+    $string =~ s/=(.+)$/+$1 (overall)/;
+    for my $time (split(/\s*\+\s*/, $string)) {
+        if ($time =~ /((\d{1,2})min\s*)?(\d{1,2}\.\d{1,3})s\s*\((\w+)\)/) {
+            my $sec = $3;
+            $sec += $2 * 60 if (defined($1));
+            $res->{$4} = $sec;
+        }
+    }
+    map { die("Fail to detect $_ timing") unless exists($res->{$_}) } qw(kernel initrd userspace overall);
+    return $res;
+}
+
+sub do_systemd_analyze {
+    my ($instance, %args) = @_;
+    $args{timeout} = 120;
+    my $start_time = time();
+    my $output     = "";
+
+    # Wait for guest register, before calling syastemd-analyze
+    $instance->wait_for_guestregister();
+    while ($output !~ /Startup finished in/ && time() - $start_time < $args{timeout}) {
+        $output = $instance->run_ssh_command(cmd => 'systemd-analyze', quiet => 1, proceed_on_failure => 1);
+        sleep 5;
+    }
+
+    die("Unable to get system-analyze in $args{timeout} seconds") unless (time() - $start_time < $args{timeout});
+    return extract_startup_timings($output);
+}
+
+=head2 build_influx_kv
+Build a influx-db key value pair with all needed escapings see doc:
+    https://docs.influxdata.com/influxdb/v1.7/write_protocols/line_protocol_tutorial/#special-characters-and-keywords
+=cut
+sub build_influx_kv {
+    my $hash = shift;
+    my $req  = '';
+    for my $k (keys(%{$hash})) {
+        my $v = $hash->{$k};
+        $v =~ s/,/\\,/g;
+        $v =~ s/ /\\ /g;
+        $v =~ s/=/\\=/g;
+        $req .= $k . '=' . $v . ',';
+    }
+    return substr($req, 0, -1);
+}
+
+sub build_influx_query {
+    my $data = shift;
+    my $req  = $data->{table} . ',';
+    $req .= build_influx_kv($data->{tags});
+    $req .= ' ';
+    $req .= build_influx_kv($data->{values});
+    return $req;
+}
+
+sub run {
+    my ($self) = @_;
+
+    $self->select_serial_terminal;
+
+    # $tags and $startup_timings are the key/values which get stored in influxdb.
+    my $tags = {
+        instance_type     => get_required_var('PUBLIC_CLOUD_INSTANCE_TYPE'),
+        os_flavor         => get_required_var('FLAVOR'),
+        os_version        => get_required_var('VERSION'),
+        os_build          => get_required_var('BUILD'),
+        os_pc_build       => get_required_var('PUBLIC_CLOUD_BUILD'),
+        os_pc_kiwi_build  => get_required_var('PUBLIC_CLOUD_BUILD_KIWI'),
+        os_kernel_release => undef,
+        os_kernel_version => undef,
+    };
+    my $startup_timings = {};
+
+    # Is used to specify thresholds per measurement. If one value is exceeded
+    # the test is set to fail.
+    my $thresholds = {
+        # First boot after provisioning
+        kernel     => 15,
+        userspace  => 60,
+        initrd     => 10,
+        overall    => 120,
+        ssh_access => 60,
+
+        # Values after soft reboot
+        kernel_soft     => 15,
+        userspace_soft  => 60,
+        initrd_soft     => 10,
+        overall_soft    => 120,
+        ssh_access_soft => 70,
+
+        # Values after hard reboot
+        kernel_hard     => 15,
+        userspace_hard  => 60,
+        initrd_hard     => 10,
+        overall_hard    => 120,
+        ssh_access_hard => 60,
+    };
+
+    my $provider = $self->provider_factory();
+
+    # Provision the instance
+    my $instance = $provider->create_instance(check_connectivity => 0);
+    $startup_timings->{ssh_access} = $instance->check_ssh_port(timeout => 300);
+
+    my $systemd_analyze = do_systemd_analyze($instance);
+    $startup_timings->{$_} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));
+
+    # Collect kernel version
+    $tags->{os_kernel_release} = $instance->run_ssh_command(cmd => 'uname -r');
+    $tags->{os_kernel_version} = $instance->run_ssh_command(cmd => 'uname -v');
+
+    # Do soft reboot
+    my ($shutdown_time, $startup_time) = $instance->softreboot();
+    $startup_timings->{ssh_access_soft} = $startup_time;
+
+    $systemd_analyze = do_systemd_analyze($instance);
+    $startup_timings->{$_ . '_soft'} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));
+
+    # Do hard reboot
+    $instance->stop();
+    $startup_timings->{ssh_access_hard} = $instance->start();
+
+    $systemd_analyze = do_systemd_analyze($instance);
+    $startup_timings->{$_ . '_hard'} = $systemd_analyze->{$_} foreach (keys(%{$systemd_analyze}));
+
+    # Do logging to openqa UI
+    my $msg = "Bootup timeings:$/";
+    for my $key (sort(keys(%{$startup_timings}))) {
+        $msg .= sprintf("%-16s => %s$/", $key, $startup_timings->{$key});
+    }
+    record_info("RESULTS", $msg);
+
+    # Store values in influx-db
+    my $url = get_var('PUBLIC_CLOUD_PERF_DB_URI');
+    if ($url) {
+        my $data = {
+            table  => 'bootup',
+            tags   => $tags,
+            values => $startup_timings
+        };
+        $data = build_influx_query($data);
+        assert_script_run(sprintf("curl -i -X POST '%s/write?db=publiccloud' --data-binary '%s'", $url, $data), quiet => 1);
+    }
+
+    # Validate bootup timeing against hard limits
+    for my $key (keys(%{$thresholds})) {
+        my $limit = $thresholds->{$key};
+        my $value = $startup_timings->{$key};
+        die("Missing measurment $key") unless (defined($value));
+        if ($value > $limit) {
+            record_info('ERROR', "$key:$value exceed limit of $limit", result => 'fail');
+            $self->result('fail');
+        }
+    }
+}
+
+1;
+
+=head1 Discussion
+
+This module collect boot time statistics from publiccloud images.
+It collect systemd_analyze and ssh access time for three states:
+1) After first deployment
+2) After a soft reboot
+3) After hard reboot
+
+All values are stored in a influx db.
+
+=head1 Configuration
+
+=head2 PUBLIC_CLOUD_PERF_DB_URI
+
+If this variable is set, the bootup timings get stored inside the influx
+database. The database name is 'publiccloud'.
+(e.g. PUBLIC_CLOUD_PERF_DB_URI=http://openqa-perf.qa.suse.de:8086)
+
+=cut


### PR DESCRIPTION
Collect boottime information for
1. First boot using terraform provider
2. After softreboot using 'shutdown -r'
3. After hard reboot using CSP tools

- Related ticket: https://progress.opensuse.org/issues/51785
- Verification run: 
  - http://cfconrad-vm.qa.suse.de/tests/4889 (GCE)
  - http://cfconrad-vm.qa.suse.de/tests/4890 (Azure)
  - http://cfconrad-vm.qa.suse.de/tests/4891 (EC2)
