### PR TITLE
[WIP] Fix adding custom grub entries when purging kernels

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -114,8 +114,6 @@ sub add_custom_grub_entries {
     assert_script_run("cp " . GRUB_CFG_FILE . " $cfg_old");
     upload_logs($cfg_old, failok => 1);
 
-    assert_script_run('cp /etc/grub.d/40_custom 40_custom.tmp');
-
     assert_script_run("cp $script_old $script_new");
 
     my $cmd = "sed -i -e 's/\\(args=.\\)\\(\\\$4\\)/\\1$grub_param \\2/'";

--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -108,6 +108,9 @@ sub add_custom_grub_entries {
     my $script_new_esc = $script_new =~ s~/~\\/~rg;
     my $cfg_old        = 'grub.cfg.old';
 
+    bmwqemu::diag("Trying to trigger purging old kernels before changing grub menu");
+    assert_script_run('[ -x /sbin/purge-kernels ] && /sbin/purge-kernels');
+
     assert_script_run("cp " . GRUB_CFG_FILE . " $cfg_old");
     upload_logs($cfg_old, failok => 1);
 


### PR DESCRIPTION
This fix issue when purge-kernels.service changes grub setup
in the middle of add_custom_grub_entries().

QAM LTP tests use also update_kernel.pm, which installs new kernel
packages. After boot, while install_ltp.pm calls
add_custom_grub_entries(), /sbin/purge-kernels (called via
purge-kernels.service) removes old kernels and therefore config check
correctly reports unexpected number of entries and dies:

Test died: Unexpected number of grub entries: 5, expected: 9 at lib/bootloader_setup.pm line 132.

Therefore trigger /sbin/purge-kernels before.

Verification run:
* sle-12-SP3-Server-DVD-TERADATA-Incidents-Kernel-x86_64-Build:11801:kernel-ec2-install_ltp+sle+Server-DVD-TERADATA-Incidents-Kernel@64bit (QAM)
http://quasar.suse.cz/tests/3136
* openSUSE Tumbleweed
http://quasar.suse.cz/tests/3137
* SLE12 SP5
http://quasar.suse.cz/tests/3138