### PR TITLE
Improve IPXE select boot device robustness

### DIFF
--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -59,6 +59,16 @@ sub poweron_host {
     }
 }
 
+sub set_pxe_boot {
+    while (1) {
+        my $stdout = ipmitool('chassis bootparam get 5');
+        last if $stdout =~ m/Force PXE/;
+        diag "setting boot device to pxe";
+        ipmitool("chassis bootdev pxe");
+        sleep(3);
+    }
+}
+
 sub set_bootscript {
     my $host        = get_required_var('SUT_IP');
     my $ip          = inet_ntoa(inet_aton($host));
@@ -96,7 +106,7 @@ sub run {
 
     set_bootscript;
 
-    ipmitool('chassis bootdev pxe');
+    set_pxe_boot;
     poweron_host;
 
     select_console 'sol', await_console => 0;
@@ -104,7 +114,6 @@ sub run {
     # make sure to wait for a while befor changing the boot device again, in order to not change it too early
     sleep 120;
 
-    ipmitool('chassis bootdev disk');
     assert_screen('linux-login', 1800);
 }
 


### PR DESCRIPTION
It can happen, that ipmi commands get lost in the network. For power control we
already poll the ipmi device and set the desired state until it can be
confirmed.
However, the "force boot via PXE" did quite often not work as intended, and it
looks like a lost package or so. In order to avoid this in the future, we
should poll the ipmi device until the correct boot device is stored and set it
again until we can confirm success.