### PR TITLE
Accept the selected patterns to continue the installation

### DIFF
--- a/tests/installation/select_patterns_and_packages.pm
+++ b/tests/installation/select_patterns_and_packages.pm
@@ -239,6 +239,9 @@ sub select_specific_patterns_by_iteration {
     # check if we have processed all patterns mentioned in the test suite settings
     my @unseen = keys %patterns;
     die "Not all patterns given in the job settings were processed:" . join(", ", @unseen) if @unseen;
+
+    # accept the patterns and conninue for virtualization tests
+    wait_screen_change { send_key $cmd{acceptlicense} } if (check_var('VIRT_AUTOTEST', '1'));
 }
 
 sub process_patterns {


### PR DESCRIPTION
The sles12sp1 kvm or xen installation hung when all the patterns finished to be selected, refer to http://10.67.129.4/tests/20539 and http://10.67.129.4/tests/20534.  Fix this issue by sending 'accept' key when patterns are selected for virtualization tests.

@alice-suse @xguo @waynechen55

- Needles: 
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1185
- Verification run:
sles12sp1-kvm(with patterns selection): http://10.67.18.247/tests/757
sles12sp1-xen(with patterns selection): http://10.67.18.247/tests/755
sles12sp2-kvm(with system_role): http://10.67.18.247/tests/756
