### PR TITLE
Online migration case need check ONLINE_MIGRATION setting

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -646,8 +646,8 @@ sub fill_in_reg_server {
     }
     else {
         send_key "alt-i";
-        # Fresh install sles12sp2/3/4 shortcut is different with upgrade version
-        if ((is_sle('12-sp2+') && is_sle('<15') && get_var('UPGRADE')) || is_sle('>=15')) {
+        # Fresh install sles12sp2/3/4/5 shortcut is different with upgrade version
+        if ((is_sle('12-sp2+') && is_sle('<15') && (get_var('UPGRADE') || get_var('ONLINE_MIGRATION'))) || is_sle('>=15')) {
             send_key "alt-l";
         }
         else {


### PR DESCRIPTION
Online migration case need be checked with ONLINE_MIGRATION setting 

- Related ticket: https://progress.opensuse.org/issues/53879
- Verification run: http://openqa-apac1.suse.de/tests/4520#step/register_system/3
[autoinst-log.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/3371042/autoinst-log.txt)

