### PR TITLE
Add tag for Mariadb notification for autoupgrade

### DIFF
--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -106,7 +106,7 @@ sub verify_timeout_and_check_screen {
 sub run {
     my ($self) = @_;
 
-    my @needles           = qw(bios-boot nonexisting-package reboot-after-installation linuxrc-install-fail scc-invalid-url warning-pop-up autoyast-boot);
+    my @needles = qw(bios-boot nonexisting-package reboot-after-installation linuxrc-install-fail scc-invalid-url warning-pop-up autoyast-boot package-notification);
     my $expected_licenses = get_var('AUTOYAST_LICENSE');
     push @needles, 'autoyast-confirm'        if get_var('AUTOYAST_CONFIRM');
     push @needles, 'autoyast-postpartscript' if get_var('USRSCR_DIALOG');
@@ -238,6 +238,9 @@ sub run {
         }
         elsif (match_has_tag('autoyast-error')) {
             die 'Error detected during first stage of the installation';
+        }
+        elsif (match_has_tag('package-notification')) {
+            send_key 'alt-o';
         }
     }
 


### PR DESCRIPTION
During the migration from SLE12SP5 to SLE15SP1 via autoyast, the Mariadb notification need to be deal by click 'ok' or it will hang there, so just add tag to deal it.

- Related ticket: https://progress.opensuse.org/issues/53627
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1186
- Verification run: http://10.161.8.44/tests/86#step/installation/15
