### PR TITLE
[WIP][SLE-12-SP5 Preparation] Update package needs dependency repository for SLES11SP4

### DIFF
--- a/tests/virt_autotest/install_package.pm
+++ b/tests/virt_autotest/install_package.pm
@@ -61,10 +61,13 @@ sub install_package {
             lpar_cmd("zypper --non-interactive rr dependency_repo");
         }
         else {
+            my $host_installed_version = get_var('VERSION_TO_INSTALL', get_var('VERSION', ''));
+            my ($host_installed_relver) = $host_installed_version =~ /^(\d+)/im;
+            my ($host_installed_spver)  = $host_installed_version =~ /sp(\d+)$/im;
             zypper_call("--no-gpg-check ar -f ${dependency_repo} dependency_repo");
             zypper_call("--gpg-auto-import-keys ref", 180);
             zypper_call("in $dependency_rpms");
-            zypper_call("rr dependency_repo");
+            zypper_call("rr dependency_repo") unless ($host_installed_relver eq '11' && $host_installed_spver eq '4');
         }
     }
 


### PR DESCRIPTION
It seems that there are something new being added into "update repo" around Beta2, which causes the following failures in "Related ticket". So update package needs dependency repository for SLES11SP4

- Related ticket: https://openqa.suse.de/tests/3040715#step/update_package/1
                         https://openqa.suse.de/tests/3040766#step/update_package/1
- Needles: n/a
- Verification run: 1) source /usr/share/qa/virtautolib/lib/virtlib;update_virt_rpms off on off on local machine 2) Use online tool:https://www.tutorialspoint.com/execute_perl_online.php
