### PR TITLE
Add iSCSI disk import to initial installation

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -614,7 +614,7 @@ sub specific_bootmenu_params {
         push @params, ('systemd.log_level=debug', 'systemd.log_target=kmsg', 'log_buf_len=1M', 'printk.devkmsg=on', 'enforcing=0', 'plymouth.enable=0');
     }
 
-    if (get_var("IBFT")) {
+    if (get_var("IBFT") or get_var("WITHISCSI")) {
         push @params, "withiscsi=1";
     }
 

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -821,6 +821,9 @@ sub load_inst_tests {
     if (get_var('IBFT')) {
         loadtest "installation/iscsi_configuration";
     }
+    if (get_var('WITHISCSI')) {
+        loadtest "installation/disk_activation_iscsi";
+    }
     if (check_var('ARCH', 's390x')) {
         if (check_var('BACKEND', 's390x')) {
             loadtest "installation/disk_activation";
@@ -832,7 +835,7 @@ sub load_inst_tests {
     if (get_var('ENCRYPT_CANCEL_EXISTING') || get_var('ENCRYPT_ACTIVATE_EXISTING')) {
         loadtest "installation/encrypted_volume_activation";
     }
-    if (get_var('MULTIPATH')) {
+    if (get_var('MULTIPATH') or defined(get_var('MULTIPATH_DIALOG_YES'))) {
         loadtest "installation/multipath";
     }
     if (is_opensuse && noupdatestep_is_applicable() && !is_livecd) {

--- a/tests/installation/disk_activation_iscsi.pm
+++ b/tests/installation/disk_activation_iscsi.pm
@@ -1,0 +1,72 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: initial installation: iSCSI client for the supportserver
+#          supportserver to provide one iSCSI target which will 
+#          provide a multipathed second disk to the client.
+# Maintainer: Klaus Wagner <kgw@suse.com>
+
+use base 'y2_installbase';
+use strict;
+use warnings;
+use testapi;
+
+sub run {
+    my $self = shift;
+    my $iscsi_iqn = "iqn.2016-02.de.openqa";
+    my $iscsi_server_ip = "10.0.2.1";
+
+    if (get_var('WITHISCSI') and get_var('USE_SUPPORT_SERVER')) {
+        # Assumptions:
+        #   1) we are within an initial installation. Due to kernel parameter
+        #      "withiscsi=1" the YaST Disk Activation screen is expected
+        #      to come up.
+        #   2) the supportserver is already up at $iscsi_server_ip 
+        #      and running DHCP, DNS, iSCSI servers (needs a suitable
+        #      parallel job for the supportserver).
+        assert_screen 'disk-activation-iscsi', 180;
+        send_key "alt-i";             # "Configure iSCSI Disks"
+        # screen "iSCSI Initiator Overwiew", Tab "Service"
+        assert_screen 'iscsi-initiator-service-fs', 180;
+        send_key "alt-i";             # go to initiator name field
+        wait_still_screen(2, 10);
+        type_string "$iscsi_iqn";
+        wait_still_screen(2, 10);
+        send_key "alt-n";             # "Connected Targets" tab, empty list
+        assert_screen 'iscsi-initiator-connected-targets-none-fs';
+        send_key $cmd{add};           # go to "iSCSI Initiator Discovery" screen
+        assert_screen 'iscsi-discovery-fs';
+        send_key "alt-i";             # go to IP address field
+        wait_still_screen(2, 10);
+        type_string "$iscsi_server_ip";
+        send_key "alt-n";             # iSCSI Initiator Discovery: discovered targets list, first one is selected
+        send_key "alt-o";             # press Connect button
+        wait_still_screen(2, 10);
+        assert_screen 'iscsi-initiator-startup-and-authentication';
+        send_key "alt-s";             # startup mode. Selection list: *manual onboot automatic
+        send_key "down";              # Wanted: onboot
+        send_key $cmd{next};          # Now connect
+        assert_screen 'iscsi-client-target-connected-fs';
+        send_key $cmd{next};
+        assert_screen 'iscsi-initiator-service-fs';
+        send_key $cmd{ok};
+        assert_screen 'disk-activation-iscsi';
+        send_key $cmd{next};
+    }
+    else {
+	# future use cases might go here
+        record_info("Nothing to do","WITHISCSI or USE_SUPPORT_SERVER not set to a true value");
+    }
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/installation/multipath.pm
+++ b/tests/installation/multipath.pm
@@ -8,7 +8,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Test module to activate multipath
+# Summary: Test module to activate multipath during initial installation
 # Maintainer: Rodion Iafarov <riafarov@suse.com>
 
 use base 'y2_installbase';
@@ -19,7 +19,15 @@ use testapi;
 sub run {
     # Sometimes multipath detection takes longer
     assert_screen "enable-multipath", 60;
-    send_key "alt-y";
+    # This module is supposed to be invoked only if MULTIPATH is true
+    # or MULTIPATH_DIALOG_YES is set
+    if (get_var("MULTIPATH") or get_var("MULTIPATH_DIALOG_YES")) {
+        send_key "alt-y";
+    }
+    else {
+        # MULTIPATH_DIALOG_YES set to false
+        send_key "alt-n";
+    }
 }
 
 1;


### PR DESCRIPTION
* New module installation/disk_activation_iscsi.pm for importing
  one iSCSI target from a running supportserver
* New variable WITHISCSI to add boot parameter "withiscsi=1" to an
  initial installation and to later invoke module disk_activation_iscsi.pm
* Extend module installation/multipath.pm so as to allow to answer
  either "yes" or "no" in the multipath activation dialog via the
  new variable MULTIPATH_DIALOG_YES. This variable does nothing
  beyond trigger the invocation of multipath.pm, in contrast to
  existing variable MULTIPATH which also adds multipathed local
  disks to the SUT.

  Purpose is to have all options if non-local multipathed devices
  are added to the SUT (e.g., iSCSI imports from a support server).

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
