### PR TITLE
Wait for yast to finish and remove workaround

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1438,7 +1438,7 @@ sub load_extra_tests_desktop {
         loadtest 'x11/vnc_two_passwords';
         # TODO: check why this is not called on opensuse
         # poo#35574 - Excluded for Xen PV as it was never passed due to the fail while interacting with grub.
-        loadtest 'x11/user_defined_snapshot' unless (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux'));
+        loadtest 'x11/user_defined_snapshot' unless is_s390x || (check_var('VIRSH_VMM_FAMILY', 'xen') && check_var('VIRSH_VMM_TYPE', 'linux'));
     }
     elsif (check_var('DISTRI', 'opensuse')) {
         if (gnomestep_is_applicable()) {

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -652,10 +652,14 @@ sub wait_boot {
         if (get_var('TEST') !~ /extra_tests_on_gnome/) {
             assert_screen $textmode_needles, $ready_time;
         }
-        elsif (!check_screen $textmode_needles, $ready_time) {
+        elsif (is_sle('<15') && !check_screen $textmode_needles, $ready_time / 2) {
             # We are not able to boot due to bsc#980337
             record_soft_failure 'bsc#980337';
             # Switch to root console and continue
+            select_console 'root-console';
+        }
+        elsif (check_screen 'displaymanager', 90) {
+            # due to workaround on sle15+ is test user_defined_snapshot expecting to boot textmode despite snapshot booted properly
             select_console 'root-console';
         }
 

--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2018 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -56,7 +56,7 @@ sub run {
     send_key "alt-l";
     $self->{in_wait_boot} = 1;
     power_action('reboot', keepconsole => 1, textmode => 1);
-    $self->wait_grub(bootloader_time => 90);
+    $self->wait_grub;
     send_key_until_needlematch("boot-menu-snapshot", 'down', 10, 5);
     send_key 'ret';
     $self->{in_wait_boot} = 0;

--- a/tests/x11/user_defined_snapshot.pm
+++ b/tests/x11/user_defined_snapshot.pm
@@ -41,7 +41,7 @@ sub run {
     script_run "cd";
 
     # Start the yast2 snapper module and wait until it is started
-    type_string "yast2 snapper\n";
+    my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'snapper');
     assert_screen 'yast2_snapper-snapshots', 100;
     # ensure the last screenshots are visible
     wait_screen_change { send_key 'end' };
@@ -54,6 +54,7 @@ sub run {
     send_key_until_needlematch([qw(grub_comment)], 'pgdn');
     # C'l'ose  the snapper module
     send_key "alt-l";
+    wait_serial("$module_name-0", 200) || die "'yast2 $module_name' didn't finish";
     $self->{in_wait_boot} = 1;
     power_action('reboot', keepconsole => 1, textmode => 1);
     $self->wait_grub;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/52217
- Verification run:
aarch64 https://openqa.suse.de/tests/3049573
s390x https://openqa.suse.de/tests/3048812
x86_64 https://openqa.suse.de/tests/3049574
http://10.100.12.155/tests/12682#step/user_defined_snapshot/44
15sp1
ppc64le https://openqa.suse.de/tests/3049571
aarch64 https://openqa.suse.de/tests/3049572
