### PR TITLE
bootloader: set parameters in grub instead of isolinux if Tumbleweed livecd

### DIFF
--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -22,7 +22,7 @@ use lockapi 'mutex_wait';
 use bootloader_setup;
 use bootloader_spvm;
 use registration;
-use version_utils ':SCENARIO';
+use version_utils qw(:VERSION :SCENARIO);
 use utils;
 use Utils::Backends 'is_spvm';
 
@@ -31,6 +31,9 @@ sub run {
     return boot_spvm if is_spvm;
     return           if pre_bootmenu_setup == 3;
     return           if select_bootmenu_option == 3;
+    my $boot_cmd = 'ctrl-x';
+    # on Tumbleweed LiveCD has been switched to grub with kiwi 9.17.41
+    uefi_bootmenu_params() if is_livecd && is_tumbleweed;
     my @params;
     push @params, bootmenu_default_params;
     push @params, bootmenu_network_source;
@@ -40,16 +43,13 @@ sub run {
     mutex_wait 'support_server_ready' if get_var('USE_SUPPORT_SERVER');
     # on ppc64le boot have to be confirmed with ctrl-x or F10
     # and it doesn't have nice graphical menu with video and language options
-    if (!get_var('OFW')) {
+    if (!get_var('OFW') && (!is_livecd && !is_tumbleweed)) {
         select_bootmenu_language;
         select_bootmenu_video_mode;
-        # boot
-        send_key 'ret';
+        $boot_cmd = 'ret';
     }
-    else {
-        # boot
-        send_key 'ctrl-x';
-    }
+    # boot
+    send_key $boot_cmd;
     # On the live images boot parameters are not printed on the serial,
     # skip the check there
     compare_bootparams(\@params, [parse_bootparams_in_serial]) if !is_livecd;


### PR DESCRIPTION
With updated kiwi, Tumbleweed's livecd has been switched to grub, therefore set parameters in grub editor rather than isolinux.

- Related ticket: https://progress.opensuse.org/issues/53993
- Verification run: http://10.163.1.11/tests/56
