### PR TITLE
Revert changes introduced in #7559 and #7564

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -129,7 +129,7 @@ if (is_sle('15+')) {
     # depending on registration only limited system roles are available
     set_var('SYSTEM_ROLE', get_var('SYSTEM_ROLE', is_desktop_module_available() ? 'default' : 'minimal'));
     # set SYSTEM_ROLE to textmode for SLE15 if DESKTOP = textmode instead of triggering change_desktop (see poo#29589)
-    if (!is_desktop && check_var('SYSTEM_ROLE', 'default') && check_var('DESKTOP', 'textmode')) {
+    if (is_sles4sap && check_var('SYSTEM_ROLE', 'default') && check_var('DESKTOP', 'textmode')) {
         set_var('SYSTEM_ROLE', 'textmode');
     }
     # in the 'minimal' system role we can not execute many test modules


### PR DESCRIPTION
These changes broke all SLES4SAP tests, reverting to the original state.

@mimi1vx: FYI
