### PR TITLE
Create tests for sqlite3

### DIFF
--- a/data/sqlite3/.gitignore
+++ b/data/sqlite3/.gitignore
@@ -1,0 +1,1 @@
+/movies.db

--- a/data/sqlite3/alter-tables.sql
+++ b/data/sqlite3/alter-tables.sql
@@ -1,0 +1,12 @@
+ALTER TABLE movie ADD COLUMN mtime date;
+
+CREATE TRIGGER movie_update_trg AFTER UPDATE ON movie
+BEGIN
+UPDATE movie SET mtime = datetime('NOW') WHERE rowid = new.rowid;
+END;
+
+CREATE VIEW cinema AS SELECT m.name, m.year, GROUP_CONCAT(d.name, "+")
+AS directors
+FROM movie m JOIN director_movie dm
+ON m.mid=dm.mid JOIN director d ON dm.did=d.did GROUP by m.mid;
+

--- a/data/sqlite3/expect.sh
+++ b/data/sqlite3/expect.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set timeout 10
+spawn sqlite3 --list --header sqlite3/movies.db
+expect "sqlite> "
+send "SELECT name, year FROM movie LIMIT 2;\n"
+
+expect "sqlite> "
+send ".quit\n"
+
+expect eof
+

--- a/data/sqlite3/init-tables.sql
+++ b/data/sqlite3/init-tables.sql
@@ -1,0 +1,38 @@
+CREATE TABLE directors (did integer primary key, name varchar(32));
+CREATE TABLE movies (mid integer primary key, name varchar(64), year integer);
+
+--Rename tables here before adding FOREIGN KEYs. Older versions of sqlite3
+--don't update the FKs when renaming tables
+ALTER TABLE movies RENAME TO movie;
+ALTER TABLE directors RENAME TO director;
+
+CREATE TABLE director_movie (
+    did integer, mid integer,
+    FOREIGN KEY(did) REFERENCES director(did),
+    FOREIGN KEY(mid) REFERENCES movie(mid)
+);
+
+CREATE UNIQUE INDEX movie_dirx on director_movie(did,mid);
+
+INSERT INTO director (name) VALUES ("Jim Jarmusch"), ( "Tim Burton");
+INSERT INTO director VALUES(3,'Lana Wachowski');
+INSERT INTO director VALUES(4,'Lilly Wachowski');
+INSERT INTO director VALUES(5,'Alejandro González Iñárritu');
+
+INSERT INTO movie (name, year) VALUES
+    ("The Dead Dont Die", 2019),
+    ("Night on Earth", 1991),
+    ("Only Lovers Left Alive", 2013);
+INSERT INTO movie (name, year) VALUES
+    ("Ed Wood", 1994),
+    ("Sleepy Hollow", 1999),
+    ("Edward Scissorhands", 1990);
+INSERT INTO movie (name, year)
+    VALUES('The Matrix', 1999),
+    ('Amores Perros', 2000);
+
+INSERT INTO director_movie (did, mid) VALUES (1,1), (1,2), (1,3), (2,4), (2,5), (2,6);
+
+INSERT INTO director_movie VALUES(3,7), (4,7), (5,8);
+
+

--- a/data/sqlite3/rollback.sql
+++ b/data/sqlite3/rollback.sql
@@ -1,0 +1,9 @@
+SAVEPOINT major;
+
+INSERT INTO movie (name,year) VALUES("The Matrix Reloaded", 2003);
+SELECT * FROM movie WHERE year=2003 ORDER BY mid;
+
+ROLLBACK TO SAVEPOINT major;
+SELECT * FROM movie WHERE year=2003 ORDER BY mid;
+
+RELEASE SAVEPOINT major;

--- a/data/sqlite3/run-tests.t
+++ b/data/sqlite3/run-tests.t
@@ -1,0 +1,165 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use 5.010;
+
+use Test::More;
+use FindBin '$Bin';
+
+my $dbfile        = "$Bin/movies.db";
+my $sqlite_select = "sqlite3 --list --header $dbfile";
+
+-e $dbfile and unlink $dbfile;
+
+my $sqlite_version = qx{sqlite3 --version};
+note "sqlite3 version: $sqlite_version";
+
+subtest create_tables => sub {
+
+    call_sqlite_file("$Bin/init-tables.sql", "create tables");
+
+    my @output = sqlite_select("SELECT * FROM movie ORDER BY mid;");
+
+    my @expected = (
+        "mid|name|year",
+        "1|The Dead Dont Die|2019",
+        "2|Night on Earth|1991",
+        "3|Only Lovers Left Alive|2013",
+        "4|Ed Wood|1994",
+        "5|Sleepy Hollow|1999",
+        "6|Edward Scissorhands|1990",
+        "7|The Matrix|1999",
+        "8|Amores Perros|2000",
+    );
+    is_deeply(\@output, \@expected, "select from movies");
+};
+
+subtest test_alter_tables => sub {
+    call_sqlite_file("$Bin/alter-tables.sql", "alter tables");
+
+    my @output = sqlite_select(".schema");
+    note "Updated schema:";
+    note $_ for @output;
+
+    @output = sqlite_select("SELECT * FROM movie ORDER BY mid LIMIT 1;");
+    my @expected = (
+        "mid|name|year|mtime",
+        "1|The Dead Dont Die|2019|",
+    );
+    is_deeply(\@output, \@expected, "select from movie");
+
+};
+
+subtest test_view => sub {
+    my @output = sqlite_select("SELECT * FROM cinema ORDER BY year, name LIMIT 6;");
+
+    my @expected = (
+        "name|year|directors",
+        "Edward Scissorhands|1990|Tim Burton",
+        "Night on Earth|1991|Jim Jarmusch",
+        "Ed Wood|1994|Tim Burton",
+        "Sleepy Hollow|1999|Tim Burton",
+        "The Matrix|1999|Lana Wachowski+Lilly Wachowski",
+        "Amores Perros|2000|Alejandro González Iñárritu",
+    );
+    is_deeply(\@output, \@expected, "select from cinema (view)");
+};
+
+subtest test_trigger => sub {
+    my $cmd = sprintf q{echo '%s;' | sqlite3 %s},
+      q{UPDATE movie SET name="The Dead Don'"'"'t Die" WHERE mid=1},
+      $dbfile;
+    note "Command: '$cmd'";
+    my @output = qx{$cmd};
+    $? == 0 ? pass "update" : fail "update";
+
+    @output = sqlite_select(
+        "SELECT * FROM movie WHERE mtime >= datetime('NOW', '-1 minute');"
+    );
+    if (@output == 2) {
+        pass "one updated row";
+    }
+    else {
+        fail "one updated row";
+    }
+};
+
+subtest test_unique => sub {
+    my $cmd = sprintf q{echo '%s;' | sqlite3 %s 2>&1},
+      q{INSERT INTO director_movie (did, mid) VALUES (1,1)},
+      $dbfile;
+    note "Command: '$cmd'";
+    my $output = qx{$cmd};
+    if ($? != 0) {
+        pass "forbidden duplicate row";
+    }
+    else {
+        fail "forbidden duplicate row";
+    }
+    like($output, qr{UNIQUE}, "Error message like expected")
+      or diag "Output was: >>$output<<";
+
+};
+
+subtest test_foreign_key => sub {
+    my $cmd = sprintf q{echo '%s;' | sqlite3 --cmd "%s" %s 2>&1},
+      q{INSERT INTO director_movie (did, mid) VALUES (99,99)},
+      "PRAGMA foreign_keys = ON",
+      $dbfile;
+    note "Command: '$cmd'";
+    my $output = qx{$cmd};
+    if ($? != 0) {
+        pass "foreign key";
+    }
+    else {
+        fail "foreign key";
+    }
+    like($output, qr{FOREIGN KEY}, "Error message like expected")
+      or diag "Output was: >>$output<<";
+
+};
+
+subtest test_rollback => sub {
+    my @output = call_sqlite_file("$Bin/rollback.sql", "savepoint & rollback");
+
+    my @expected = (
+        "mid|name|year|mtime",
+        "9|The Matrix Reloaded|2003|",
+    );
+    is_deeply(\@output, \@expected, "output savepoint & rollback ok");
+};
+
+done_testing;
+
+# Helpers
+
+sub sqlite_select {
+    my ($select) = @_;
+
+    my $cmd = qq{echo "$select" | $sqlite_select };
+    note "Command: '$cmd'";
+    chomp(my @output = qx{$cmd});
+    return @output;
+}
+
+sub call_sqlite_file {
+    my ($file, $label) = @_;
+
+    my $cmd = qq{$sqlite_select < $file};
+    note "Command: '$cmd'";
+
+    my @output = qx{$sqlite_select < $file};
+    if ($? != 0) {
+        fail $label;
+        diag @output;
+        # BAIL_OUT isn't helpful, apparently the TAP output then only shows
+        # this error but none of the previous results
+        # BAIL_OUT("Command '$sqlite_select' exited with error, aborting");
+    }
+    else {
+        pass $label;
+    }
+    chomp @output;
+    return @output;
+}
+

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1573,6 +1573,7 @@ sub load_extra_tests_console {
     loadtest "console/git";
     loadtest "console/cups";
     loadtest "console/java";
+    loadtest "console/sqlite3";
     loadtest "console/ant" if is_sle('<15-sp1');
     loadtest "console/gdb";
     loadtest "console/perf" if is_sle('<15-sp1');

--- a/tests/console/sqlite3.pm
+++ b/tests/console/sqlite3.pm
@@ -1,0 +1,68 @@
+# SUSE's openQA tests
+#
+# Copyright (C) 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+# Summary: Test sqlite3 package
+#   These tests use the sqlite3 commandline tool to test various SQL:
+#   * CREATE/ALTER TABLE, CREATE INDEX, CREATE VIEW, CREATE TRIGGER
+#   * INSERT, UPDATE
+#   * SELECT (table and view)
+#   * Test violating foreign keys and unique index
+#   * Test trigger, view
+#   * SAVEPOINT, ROLLBACK
+#   * Interactive call with `expect`
+# Maintainer: Tina Müller <tina.mueller@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    zypper_call('install sqlite3 expect');
+
+    my $archive = "sqlite3-tests.data";
+    assert_script_run(
+        sprintf "cd; curl -L -v %s/data/sqlite3 > %s && cpio -id < %s && mv data sqlite3 && ls sqlite3",
+        autoinst_url(), $archive, $archive
+    );
+
+    # Test various commands
+    my $tap_results = "sqlite3/results.tap";
+
+    # --merge necessary so that STDERR doesn't accidentally land on top of
+    # the file
+    my $ret = script_run("prove --verbose --merge ./sqlite3/run-tests.t >$tap_results 2>&1");
+    parse_extra_log(TAP => $tap_results);
+
+    if ($ret) {
+        die "./sqlite3/run-tests.t failed, see sqlite3/results.tap for details";
+    }
+
+    # Test interactive mode
+    validate_script_output(
+        "expect sqlite3/expect.sh",
+        sub {
+            m/
+            sqlite>\ SELECT\ name,\ year\ FROM\ movie\ LIMIT\ 2;\r\n
+            name\|year\r\n
+            The\ Dead\ Don't\ Die\|2019\r\n
+            Night\ on\ Earth\|1991\r\n
+            sqlite>\ .quit
+            /x
+        },
+    );
+
+}
+
+1;
+


### PR DESCRIPTION
Creating regression tests for sqlite3.
The tests are using the sqlite3 commandline tool in batch mode and interactively.

- Related ticket: https://progress.opensuse.org/issues/53678
- Needles: none
- Verification run: http://10.161.229.247/tests/81

edit: updated link to test