### PR TITLE
Fix cups test

### DIFF
--- a/tests/console/cups.pm
+++ b/tests/console/cups.pm
@@ -16,11 +16,12 @@ use warnings;
 use testapi;
 use utils qw(systemctl zypper_call);
 use Utils::Systemd 'disable_and_stop_service';
-use version_utils 'is_jeos';
+use version_utils;
+use Utils::Architectures;
 
 sub run {
     my $self = shift;
-    $self->select_serial_terminal;
+    $self->select_serial_terminal unless (is_s390x);
 
     zypper_call("in cups",         exitcode => [0, 102, 103]);
     zypper_call("in cups-filters", exitcode => [0, 102, 103]) if is_jeos;


### PR DESCRIPTION
The serial console seems to have some problems but it works fine on a regular tty so I switched the test to use a regular tty.

Ticket: https://progress.opensuse.org/issues/52883
Verification: https://openqa.suse.de/tests/3051760