### PR TITLE
Add perl-bootloader regression test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1513,6 +1513,10 @@ sub load_extra_tests_dracut {
     loadtest "console/dracut";
 }
 
+sub load_extra_tests_perl_bootloader {
+    loadtest "console/perl_bootloader";
+}
+
 sub load_extra_tests_kdump {
     return unless kdump_is_applicable;
     loadtest "console/kdump_and_crash";

--- a/tests/console/perl_bootloader.pm
+++ b/tests/console/perl_bootloader.pm
@@ -1,0 +1,40 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test the perl-Bootloader package by generating the initrd,
+#          calling update-bootloader and rebooting the host
+# Maintainer: Paolo Stivanin <pstivanin@suse.com>
+
+use base 'opensusebasetest';
+use testapi;
+use strict;
+use warnings;
+use utils 'zypper_call';
+use power_action_utils 'power_action';
+use version_utils 'is_sle';
+
+sub run {
+    my ($self) = @_;
+    $self->select_serial_terminal;
+
+    if (script_run 'rpm -q perl-Bootloader' == 1) {
+        zypper_call 'in perl-Bootloader';
+    }
+    assert_script_run 'mkinitrd';
+    assert_script_run 'update-bootloader';
+
+    if (is_sle('>=12-SP2')) {
+        validate_script_output('pbl --show', sub { /grub2/ });
+    }
+
+    power_action('reboot', textmode => 1);
+    $self->wait_boot;
+}
+
+1;


### PR DESCRIPTION
This test:
- generates initrd
- runs `update-bootloader`
- runs `pbl --show` if `is_sle >= 12.2`
- reboots the host

Info:
- Related ticket: https://progress.opensuse.org/issues/51527
- Verification runs:
  - oS TW: http://d250.qam.suse.de/tests/2142:heavy_check_mark: 
  - SLE 15.1: http://d250.qam.suse.de/tests/2141 :heavy_check_mark: 
  - SLE 12.2: http://d250.qam.suse.de/tests/2140 :heavy_check_mark: 

As the host is rebooted, this test should be added to its own test suite in order to prevent failures in other tests (we've seen such issue in the past with dracut).
:warning: the scheduling part is still missing because we need to decide where to put it