### PR TITLE
Fix grub remove item cause wrong string connection

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1046,7 +1046,7 @@ Remove C<$remove> from /etc/default/grub (using sed) and regenerate /boot/grub2/
 =cut
 sub remove_grub_cmdline_settings {
     my $remove = shift;
-    replace_grub_cmdline_settings('[[:blank:]]*' . $remove . '[[:blank:]]*', "", "g");
+    replace_grub_cmdline_settings('[[:blank:]]*' . $remove . '[[:blank:]]*', " ", "g");
 }
 
 =head2 grub_mkconfig


### PR DESCRIPTION
CMDLINE="Hello foo world!";

remove_grub_cmdline_settings("foo");

CMDLINE="Helloworld!"; [wrong]

Expect:
CMDLINE="Hello world!";

The current function doesn't matter the position of the substring.

------------------------------------------------------------
Transfer line to a @list, and remove an item, Transfer @list
into String. Do substring.
