### PR TITLE
[RFC] Add distro version helpers

### DIFF
--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -18,8 +18,8 @@ use Exporter;
 use strict;
 use warnings;
 use testapi;
-use version_utils 'is_sle';
-use registration qw(scc_version get_addon_fullname);
+use version_utils qw(get_version is_sle);
+use registration 'get_addon_fullname';
 
 our @EXPORT = qw(expand_template);
 
@@ -98,7 +98,7 @@ my @unversioned_products = qw(asmm contm lgm tcm wsm);
 
 sub get_product_version {
     my ($name) = @_;
-    my $version = scc_version(get_var('VERSION', ''));
+    my $version = get_version();
     return $version =~ s/^(\d*)\.\d$/$1/r if is_sle('<15') && grep(/^$name$/, @unversioned_products);
     return $version;
 }

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -96,7 +96,7 @@ sub expand_patterns {
 
 my @unversioned_products = qw(asmm contm lgm tcm wsm);
 
-sub get_product_version {
+sub get_product_version_autoyast {
     my ($name) = @_;
     my $version = get_version();
     return $version =~ s/^(\d*)\.\d$/$1/r if is_sle('<15') && grep(/^$name$/, @unversioned_products);
@@ -109,7 +109,7 @@ sub expand_addons {
     foreach my $addon (@addons) {
         $addons{$addon} = {
             name    => get_addon_fullname($addon),
-            version => get_product_version($addon),
+            version => get_product_version_autoyast($addon),
             arch    => get_var('ARCH'),
         };
     }

--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -21,7 +21,7 @@ use strict;
 use warnings;
 use testapi;
 use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key);
-use version_utils qw(is_sle is_caasp is_upgrade);
+use version_utils qw(get_version is_sle is_caasp is_upgrade);
 use constant ADDONS_COUNT => 50;
 use y2_module_consoletest;
 
@@ -37,7 +37,6 @@ our @EXPORT = qw(
   yast_scc_registration
   skip_registration
   scc_deregistration
-  scc_version
   get_addon_fullname
   rename_scc_addons
   is_module
@@ -124,19 +123,6 @@ sub accept_addons_license {
     }
 }
 
-=head2 scc_version
-
-    scc_version([$version]);
-
-Helper for parsing SLE RC version into integer. It replaces SLE version
-in format X-SPY into X.Y.
-=cut
-sub scc_version {
-    my $version = shift;
-    $version //= get_required_var('VERSION');
-    return $version =~ s/-SP/./gr;
-}
-
 =head2 add_suseconnect_product
 
     add_suseconnect_product($name, [$version, [$arch, [$params]]]);
@@ -160,7 +146,7 @@ Wrapper for SUSEConnect -d $name.
 =cut
 sub remove_suseconnect_product {
     my ($name, $version, $arch, $params) = @_;
-    $version //= scc_version();
+    $version //= get_version();
     $arch    //= get_required_var('ARCH');
     $params  //= '';
     assert_script_run("SUSEConnect -d -p $name/$version/$arch $params");

--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils qw(is_sle is_leap is_tumbleweed);
+use version_utils qw(get_distro get_version is_sle is_leap is_tumbleweed);
 use y2_module_consoletest;
 
 our @EXPORT = qw(
@@ -34,6 +34,7 @@ our @EXPORT = qw(
   prepare_oss_repo
   disable_oss_repo
   generate_version);
+
 
 =head2 get_repo_var_name
 This takes something like "MODULE_BASESYSTEM_SOURCE" as parameter

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -19,7 +19,7 @@ use base Exporter;
 use Exporter;
 use strict;
 use warnings;
-use testapi qw(check_var get_var set_var);
+use testapi qw(check_var get_required_var get_var set_var);
 use version 'is_lax';
 use Carp 'croak';
 use Utils::Backends qw(is_hyperv is_hyperv_in_gui is_svirt_except_s390x);
@@ -29,6 +29,7 @@ use constant {
     VERSION => [
         qw(
           get_distro
+          get_version
           is_sle
           is_pre_15
           is_caasp
@@ -313,6 +314,20 @@ sub get_distro {
         return 'Tumbleweed' if (is_tumbleweed);
         return 'Leap';
     }
+}
+
+=head2 get_version
+
+    get_version([$version]);
+
+Helper for parsing openSUSE/SLE RC version into integer. It replaces version
+in format X-SPY into X.Y.
+Possible to use for openSUSE as well.
+=cut
+sub get_version {
+    my $version = shift;
+    $version //= get_required_var('VERSION');
+    return $version =~ s/-SP/./gr;
 }
 
 sub install_this_version {

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -29,6 +29,7 @@ use constant {
     VERSION => [
         qw(
           get_distro
+          get_product_version
           get_version
           is_sle
           is_pre_15
@@ -328,6 +329,19 @@ sub get_version {
     my $version = shift;
     $version //= get_required_var('VERSION');
     return $version =~ s/-SP/./gr;
+}
+
+=head2 get_product_version
+
+    get_product_version();
+
+Get product major version based on VERSION variable, e.g.:
+15.1 => 15
+Tumbleweed => Tumbleweed
+=cut
+sub get_product_version {
+    my $version = get_version();
+    return $version =~ s/^(\d*)\.\d$/$1/r;
 }
 
 sub install_this_version {

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -28,6 +28,7 @@ use Utils::Architectures 'is_s390x';
 use constant {
     VERSION => [
         qw(
+          get_distro
           is_sle
           is_pre_15
           is_caasp
@@ -297,6 +298,21 @@ sub is_server {
     # If unified installer, we need to check SLE_PRODUCT
     return 0 if get_var('FLAVOR', '') !~ /^Installer-/;
     return check_var('SLE_PRODUCT', 'sles');
+}
+
+=head2 get_distro
+
+    get_distro();
+
+Return distribution string (SLE, Tumbleweed, Leap)
+TODO: Add other distributions (i.e. caasp, jeos, ...)
+=cut
+sub get_distro {
+    return 'SLE' if (is_sle);
+    if (is_opensuse) {
+        return 'Tumbleweed' if (is_tumbleweed);
+        return 'Leap';
+    }
 }
 
 sub install_this_version {

--- a/tests/autoyast/prepare_profile.pm
+++ b/tests/autoyast/prepare_profile.pm
@@ -15,8 +15,7 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
-use version_utils 'is_sle';
-use registration 'scc_version';
+use version_utils qw(get_version is_sle);
 use autoyast 'expand_template';
 use File::Copy 'copy';
 use File::Path 'make_path';
@@ -33,7 +32,7 @@ sub run {
     die $profile if $profile->isa('Mojo::Exception');
 
     # Expand VERSION, as e.g. 15-SP1 has to be mapped to 15.1
-    if (my $version = scc_version(get_var('VERSION', ''))) {
+    if (my $version = get_version()) {
         $profile =~ s/\{\{VERSION\}\}/$version/g;
     }
     # For s390x and svirt backends need to adjust network configuration

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -25,7 +25,7 @@ use utils;
 use mm_network;
 use mm_tests;
 use opensusebasetest 'firewall';
-use registration 'scc_version';
+use version_utils 'get_version';
 use iscsi;
 
 my $pxe_server_set       = 0;
@@ -445,7 +445,7 @@ sub setup_aytests {
     # Expand variables
     sed -i -e 's|{{SCC_REGCODE}}|" . get_var('SCC_REGCODE') . "|g' \\
            -e 's|{{SCC_URL}}|" . get_var('SCC_URL') . "|g' \\
-           -e 's|{{VERSION}}|" . scc_version . "|g' \\
+           -e 's|{{VERSION}}|" . get_version . "|g' \\
            -e 's|{{ARCH}}|" . get_var('ARCH') . "|g' \\
            -e 's|{{MSG_TIMEOUT}}|0|g' \\
            -e 's|{{REPO1_URL}}|http://10.0.2.1/aytests/files/repos/sles12|g' \\


### PR DESCRIPTION
These changes were originally part of https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7837 (to be used in https://github.com/pevik/os-autoinst-distri-opensuse/commit/87e75b87a6c1eb0959064a6bd35267d560049c91#diff-4b1e32c78f48576bd01c7b2512a95718R21), not not (yet) used. Not sure if they are useful, please comment.