### PR TITLE
Make module binary_test fatal

### DIFF
--- a/tests/systemd_testsuite/binary_tests.pm
+++ b/tests/systemd_testsuite/binary_tests.pm
@@ -26,7 +26,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1};
+    return {fatal => 1, milestone => 1};
 }
 
 


### PR DESCRIPTION
This module is installing and seting up the testsuite. All following tests will
fail if binary_tests fails

- Related ticket: https://progress.opensuse.org/issues/45158
- Verification run: http://openqa.slindomansilla-vm.qa.suse.de/tests/1499