### PR TITLE
Fix patch_and_reboot addrepo

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -310,7 +310,7 @@ sub is_updates_tests {
 
 sub is_updates_test_repo {
     # mru stands for Maintenance Released Updates and skips unreleased updates
-    return get_var('TEST') !~ /^mru-/ && is_updates_tests && get_required_var('FLAVOR') !~ /-Minimal$/;
+    return get_var('TEST') =~ /-install/ && is_updates_tests && get_required_var('FLAVOR') !~ /-Minimal$/;
 }
 
 sub is_repo_replacement_required {


### PR DESCRIPTION
Patch_and_reboot was moved into installation tests instead each test after installation

- Verification run:
http://10.100.12.155/tests/12688