### PR TITLE
Fix linuxrc boot on aarch64

### DIFF
--- a/tests/boot/boot_linuxrc.pm
+++ b/tests/boot/boot_linuxrc.pm
@@ -14,9 +14,10 @@ use base "opensusebasetest";
 use strict;
 use warnings;
 use testapi;
-use bootloader_setup "select_bootmenu_more";
+use bootloader_setup qw(select_bootmenu_more ensure_shim_import);
 
 sub run {
+    ensure_shim_import;
     select_bootmenu_more('inst-boot_linuxrc', 1);
     for (1 .. 3) {
         assert_screen("OK_button_linuxrc", 120);


### PR DESCRIPTION
Added missing function to boot with UEFI

- Related ticket: https://progress.opensuse.org/issues/10654

failed test run, because of a [bug](https://bugzilla.suse.com/show_bug.cgi?id=1141038) that will be fixed by next build: 
https://openqa.suse.de/tests/3049224
with a (now useless) workaround, we can go further, but then there seems to be another bug:
https://openqa.suse.de/tests/3049464

So the runs failed, but the test is working.

