### PR TITLE
Save original target version and load correct module

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -196,10 +196,10 @@ sub setup_env {
     # action is migration from 12-sp5 to 15-sp1, so we need change VERSION to 15-SP1 before the test case start
     if (check_var('FLAVOR', 'Migration-from-SLE12-SP5-to-SLE15-SPx') || check_var('FLAVOR', 'Migration-from-SLE12-SP5-to-SLE15-SPx-Milestone')
         || check_var('FLAVOR', 'Regression-on-SLE15-SPx-migrated-from-SLE12-SP5')) {
-        set_var('VERSION', '15-SP1');
-        if (check_var('ARCH', 's390x')) {
-            set_var('TAR_BUILD', get_var('TARGET_BUILD'));
-        }
+        # Save the original target version, needed for testing upgrade from a beta version to a non-beta
+        # SLE12-SP5 to SLE15-SP1 for example
+        set_var('ORIGINAL_TARGET_VERSION', get_var('VERSION'));
+        set_var('VERSION',                 '15-SP1');
     }
 }
 

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -487,8 +487,8 @@ sub load_patching_tests {
         # Save VERSION to UPGRADE_TARGET_VERSION if it is not already set
         set_var('UPGRADE_TARGET_VERSION', get_var('VERSION')) if (!get_var('UPGRADE_TARGET_VERSION'));
         # Save the original target version, needed for testing upgrade from a beta version to a non-beta
-        # SLE12-SP5 to SLE15-SP1 for example
-        set_var('ORIGINAL_TARGET_VERSION', get_var('VERSION'));
+        # SLE12-SP5 to SLE15-SP1 for example. Won't set ORIGINAL_TARGET_VERSION if already set in setup_env.
+        set_var('ORIGINAL_TARGET_VERSION', get_var('VERSION')) if (!get_var('ORIGINAL_TARGET_VERSION'));
         # Always boot from installer DVD in upgrade test
         set_var('BOOTFROM', 'd');
         loadtest "migration/version_switch_origin_system" if (!get_var('ONLINE_MIGRATION'));


### PR DESCRIPTION
We can save original target version as ORIGINAL_TARGET_VERSION = SLE12SP5 at setup_env, and keep VERSION=SLE15SP1 for loading correct modules. 

- Related ticket:   https://progress.opensuse.org/issues/53990
- Needles: None.
- Verification run: http://10.161.8.44/tests/124#
