### PR TITLE
Firefox_nss: Revert unnecessary x11utils::turn_off_gnome_screensaver call

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2126,6 +2126,7 @@ sub load_security_tests_crypt_x11 {
     set_var('SECTEST_REQUIRE_WE', 1);
     load_security_console_prepare;
 
+    loadtest "fips/mozilla_nss/firefox_nss" if get_var('FIPS_ENABLED');
     # In SLE, hexchat and seahorse are provided only in WE addon which is for
     # x86_64 platform only.
     if (is_x86_64) {
@@ -2133,7 +2134,6 @@ sub load_security_tests_crypt_x11 {
         loadtest "x11/hexchat_ssl";
     }
     loadtest "x11/x3270_ssl";
-    loadtest "fips/mozilla_nss/firefox_nss" if get_var('FIPS_ENABLED');
 }
 
 sub load_security_tests_crypt_tool {

--- a/tests/fips/mozilla_nss/firefox_nss.pm
+++ b/tests/fips/mozilla_nss/firefox_nss.pm
@@ -18,7 +18,6 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
-use x11utils 'turn_off_gnome_screensaver';
 
 sub quit_firefox {
     send_key "alt-f4";
@@ -28,7 +27,8 @@ sub quit_firefox {
 }
 
 sub run {
-    my ($self) = shift;
+    my ($self) = @_;
+    select_console 'root-console';
 
     # Define FIPS password for firefox, and it should be consisted by:
     # - at least 8 characters
@@ -36,8 +36,7 @@ sub run {
     # - at least one non-alphabet-non-number character (like: @-.=%)
     my $fips_password = 'openqa@SUSE';
 
-    # Turn off screensaver before launch firefox in order to avoid the screensaver block
-    turn_off_gnome_screensaver if check_var('DESKTOP', 'gnome');
+    select_console 'x11';
     x11_start_program('firefox https://html5test.opensuse.org', target_match => 'firefox-html-test', match_timeout => 360);
 
     # Firfox Preferences


### PR DESCRIPTION
Firefox_nss calls x11utils::turn_off_gnome_screensaver is a simple
script_run 'gsettings set org.gnome.desktop.session idle-delay 0';

1. In order to avoid no terminal is shown the string which is just typed "into the void"
   of the desktop session. Therefore there is also never an output on the serial port.
2. This patch can also fixed the side effect error about case running after firefox_nss.

Error run: https://openqa.suse.de/tests/3022911#step/firefox_nss/4

- Related ticket: 
https://progress.opensuse.org/issues/53978 
https://progress.opensuse.org/issues/53651
- Needles: NA
- Verification run: 
(firefox_nss -> **seahorse_sshkey**) http://10.163.2.52/tests/297
(firefox_nss -> **hexchat_ssl**) http://10.163.2.52/tests/298