### PR TITLE
xfstests: Remove useless cat in front of pipeline

### DIFF
--- a/lib/ctcs2_to_junit.pm
+++ b/lib/ctcs2_to_junit.pm
@@ -100,7 +100,7 @@ sub generateXML {
         if ((get_var('XFSTESTS') || get_var('QA_TESTSET')) && ($case_status eq 'failure' || $case_status eq 'skipped')) {
             (my $test_path = $test) =~ s/-/\//;
             $test_path = '/opt/log/' . $test_path;
-            my $test_out_content = script_output("if [ -f $test_path ]; then cat $test_path| sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176' | tail -n 200; else echo 'Test Crashed, find log in serial0.txt'; fi", 600);
+            my $test_out_content = script_output("if [ -f $test_path ]; then tail -n 200 $test_path | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176'; else echo 'Test Crashed, find log in serial0.txt'; fi", 600);
             $writer->startTag('system-out');
             $writer->characters($test_out_content);
             $writer->endTag('system-out');
@@ -108,12 +108,12 @@ sub generateXML {
                 my $test_err_content = script_output("
                     echo '====out.bad log====';
                     if [ -f $test_path.out.bad ];
-                        then cat $test_path.out.bad | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176' | tail -n 200;
+                        then tail -n 200 $test_path.out.bad | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176';
                     else echo '$test_path.out.bad not exist';
                     fi;
                     echo '====full log====';
                     if [ -f $test_path.full ];
-                        then cat $test_path.full | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176' | tail -n 200;
+                        then tail -n 200 $test_path.full | sed \"s/'//g\" | tr -cd '\\11\\12\\15\\40-\\176';
                     else echo '$test_path.full not exist';
                     fi;
                 ", 600);


### PR DESCRIPTION
This lib/ctcs2_to_junit.pm is use to pass test result by xml and print in web. Then the front `cat` in pipeline is duplicate, because the `tail -n 200` in the end part could also do this. And it takes more time to print whole file if this file longer than 200 lines.

- Verification run: http://10.67.133.102/tests/1052#step/1_test_result/2
