### PR TITLE
[virt_autotest] Support guest sles-12-sp5 for virt_v2v test

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -134,8 +134,10 @@ sub setup_console_in_grub {
         assert_script_run($cmd);
         save_screenshot;
 
-        $cmd = "sed -ri 's/^terminal.*\$/terminal_input console serial\\nterminal_output console serial\\nterminal console serial/g' $grub_cfg_file";
-        assert_script_run($cmd);
+        if (!script_run('grep HPE /sys/class/dmi/id/board_vendor') == 0) {
+            $cmd = "sed -ri 's/^terminal.*\$/terminal_input console serial\\nterminal_output console serial\\nterminal console serial/g' $grub_cfg_file";
+            assert_script_run($cmd);
+        }
         $cmd = "cat $grub_cfg_file $grub_default_file";
         assert_script_run($cmd);
         save_screenshot;

--- a/tests/virt_autotest/virt_v2v_dst.pm
+++ b/tests/virt_autotest/virt_v2v_dst.pm
@@ -17,6 +17,7 @@ use warnings;
 use testapi;
 use lockapi;
 use mmapi;
+use virt_utils;
 
 sub get_script_run {
     my ($self) = @_;
@@ -24,7 +25,8 @@ sub get_script_run {
     my $src_ip   = $self->get_var_from_parent('SRC_IP');
     my $src_user = $self->get_var_from_parent('SRC_USER');
     my $src_pass = $self->get_var_from_parent('SRC_PASS');
-    my $guests   = get_var("GUEST_LIST");
+    handle_sp_in_settings_with_sp0("GUEST_LIST");
+    my $guests = get_var("GUEST_LIST");
     our $virt_v2v_log;
 
     my $pre_test_cmd = "/usr/share/qa/virtautolib/lib/virt_v2v_test.sh -s $src_ip -u $src_user -p $src_pass -i \"$guests\" 2>&1 | tee $virt_v2v_log";

--- a/tests/virt_autotest/virt_v2v_src.pm
+++ b/tests/virt_autotest/virt_v2v_src.pm
@@ -21,7 +21,7 @@ use mmapi;
 sub run {
     my ($self) = @_;
 
-    my $ip_out = $self->execute_script_run('ip route show|grep kernel|cut -d" " -f12|head -1', 30);
+    my $ip_out = $self->execute_script_run('ip route show|grep kernel|cut -d" " -f9|head -1', 30);
     set_var('SRC_IP',   $ip_out);
     set_var('SRC_USER', "root");
     set_var('SRC_PASS', $password);


### PR DESCRIPTION
- Needles: 
[virt_autotest] Add needles for virt_v2v test
https://gitlab.suse.de/qa-testsuites/os-autoinst-needles-sles/merge_requests/2
- Verification run: 
SLES12SP5
virt-v2v-developing-from-developing-to-developing-xen-src
http://10.67.20.146/tests/21
virt-v2v-developing-from-developing-to-developing-kvm-dst
http://10.67.20.146/tests/22
