### PR TITLE
bootloader: grub is the loader on Tumbleweed non-32bit livecd

### DIFF
--- a/lib/Utils/Architectures.pm
+++ b/lib/Utils/Architectures.pm
@@ -25,6 +25,8 @@ use constant {
     ARCH => [
         qw(
           is_s390x
+          is_i586
+          is_i686
           is_x86_64
           is_aarch64
           is_ppc64le
@@ -42,6 +44,12 @@ our %EXPORT_TAGS = (
 
 sub is_s390x {
     return check_var('ARCH', 's390x');
+}
+sub is_i586 {
+    return check_var('ARCH', 'i586');
+}
+sub is_i686 {
+    return check_var('ARCH', 'i686');
 }
 sub is_x86_64 {
     return check_var('ARCH', 'x86_64');


### PR DESCRIPTION
With updated kiwi, now the loader switched to grub rather than isolinux for Tumbleweed non-32bit livecd.

Fixes poo#53993

- Related ticket: https://progress.opensuse.org/issues/53993
- Verification run
* GNOME-Live.i686 : http://10.163.1.11/tests/68
* GNOME-Live.x86_64 : http://10.163.1.11/tests/71
* Standard xfce installation with normal TW iso: http://10.163.1.11/tests/70
