### PR TITLE
PublicCloud: Add variable timeout for LTP tests

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -90,7 +90,7 @@ sub run {
     $cmd .= ':ssh_opts=\'-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no\' ';
     $cmd .= '--json-format=openqa ';
 
-    assert_script_run($cmd, timeout => 30 * 60);
+    assert_script_run($cmd, timeout => get_var('LTP_TIMEOUT', 30 * 60));
 }
 
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/53615
- Failure in OSD: https://openqa.suse.de/tests/3055180
- Verification run: http://fromm.arch.suse.de/tests/6637
