### PR TITLE
Enable refactored raid in opensuse

### DIFF
--- a/schedule/yast/raid/raid0_gpt_opensuse.yaml
+++ b/schedule/yast/raid/raid0_gpt_opensuse.yaml
@@ -1,0 +1,101 @@
+name:           RAID0_gpt_opensuse
+description:    >
+  Configure RAID 0 on the disks with GPT partition tables using Expert Partitioner.
+  Creates BIOS boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 0.
+vars:
+  RAIDLEVEL: 0
+schedule:
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/online_repos
+  - installation/installation_mode
+  - installation/logpackages
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/raid_gpt
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/resolve_dependency_issues
+  - installation/select_patterns_and_packages
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - console/validate_raid
+test_data:
+  disks:
+    - name: vda
+      partitions:
+        - size: 2mb
+          id: bios-boot
+          role: raw-volume
+        - size: 8000mb
+          role: raw-volume
+          id: linux-raid
+        - size: 100mb
+          role: raw-volume
+          id: linux-raid
+    - name: vdb
+      partitions:
+        - size: 2mb
+          id: bios-boot
+          role: raw-volume
+        - size: 8000mb
+          role: raw-volume
+          id: linux-raid
+        - size: 100mb
+          role: raw-volume
+          id: linux-raid
+    - name: vdc
+      partitions:
+        - size: 2mb
+          id: bios-boot
+          role: raw-volume
+        - size: 8000mb
+          role: raw-volume
+          id: linux-raid
+        - size: 100mb
+          role: raw-volume
+          id: linux-raid
+    - name: vdd
+      partitions:
+        - size: 2mb
+          id: bios-boot
+          role: raw-volume
+        - size: 8000mb
+          role: raw-volume
+          id: linux-raid
+        - size: 100mb
+          role: raw-volume
+          id: linux-raid
+  mds:
+    - raid_level: 0
+      chunk_size: 64
+      device_selection_step: 2
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
+    - raid_level: 0
+      chunk_size: 64
+      device_selection_step: 1
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+          filesystem: swap
+        mounting_options:
+          should_mount: 1

--- a/schedule/yast/raid/raid10_gpt_opensuse.yaml
+++ b/schedule/yast/raid/raid10_gpt_opensuse.yaml
@@ -1,0 +1,101 @@
+name:           RAID10_gpt_opensuse
+description:    >
+  Configure RAID 10 on the disks with GPT partition tables using Expert Partitioner.
+  Creates BIOS boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 10.
+vars:
+  RAIDLEVEL: 10
+schedule:
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/online_repos
+  - installation/installation_mode
+  - installation/logpackages
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/raid_gpt
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/resolve_dependency_issues
+  - installation/select_patterns_and_packages
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - console/validate_raid
+test_data:
+  disks:
+    - name: vda
+      partitions:
+        - size: 2mb
+          id: bios-boot
+          role: raw-volume
+        - size: 8000mb
+          role: raw-volume
+          id: linux-raid
+        - size: 100mb
+          role: raw-volume
+          id: linux-raid
+    - name: vdb
+      partitions:
+        - size: 2mb
+          id: bios-boot
+          role: raw-volume
+        - size: 8000mb
+          role: raw-volume
+          id: linux-raid
+        - size: 100mb
+          role: raw-volume
+          id: linux-raid
+    - name: vdc
+      partitions:
+        - size: 2mb
+          id: bios-boot
+          role: raw-volume
+        - size: 8000mb
+          role: raw-volume
+          id: linux-raid
+        - size: 100mb
+          role: raw-volume
+          id: linux-raid
+    - name: vdd
+      partitions:
+        - size: 2mb
+          id: bios-boot
+          role: raw-volume
+        - size: 8000mb
+          role: raw-volume
+          id: linux-raid
+        - size: 100mb
+          role: raw-volume
+          id: linux-raid
+  mds:
+    - raid_level: 10
+      chunk_size: 64
+      device_selection_step: 2
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
+    - raid_level: 10
+      chunk_size: 64
+      device_selection_step: 1
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+          filesystem: swap
+        mounting_options:
+          should_mount: 1

--- a/schedule/yast/raid/raid1_gpt_opensuse.yaml
+++ b/schedule/yast/raid/raid1_gpt_opensuse.yaml
@@ -1,0 +1,101 @@
+name:           RAID1_gpt_opensuse
+description:    >
+  Configure RAID 1 on the disks with GPT partition tables using Expert Partitioner.
+  Creates BIOS boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 1.
+vars:
+  RAIDLEVEL: 1
+schedule:
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/online_repos
+  - installation/installation_mode
+  - installation/logpackages
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/raid_gpt
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/resolve_dependency_issues
+  - installation/select_patterns_and_packages
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - console/validate_raid
+test_data:
+  disks:
+    - name: vda
+      partitions:
+        - size: 2mb
+          id: bios-boot
+          role: raw-volume
+        - size: 8000mb
+          role: raw-volume
+          id: linux-raid
+        - size: 100mb
+          role: raw-volume
+          id: linux-raid
+    - name: vdb
+      partitions:
+        - size: 2mb
+          id: bios-boot
+          role: raw-volume
+        - size: 8000mb
+          role: raw-volume
+          id: linux-raid
+        - size: 100mb
+          role: raw-volume
+          id: linux-raid
+    - name: vdc
+      partitions:
+        - size: 2mb
+          id: bios-boot
+          role: raw-volume
+        - size: 8000mb
+          role: raw-volume
+          id: linux-raid
+        - size: 100mb
+          role: raw-volume
+          id: linux-raid
+    - name: vdd
+      partitions:
+        - size: 2mb
+          id: bios-boot
+          role: raw-volume
+        - size: 8000mb
+          role: raw-volume
+          id: linux-raid
+        - size: 100mb
+          role: raw-volume
+          id: linux-raid
+  mds:
+    - raid_level: 1
+      chunk_size: 64
+      device_selection_step: 2
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
+    - raid_level: 1
+      chunk_size: 64
+      device_selection_step: 1
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+          filesystem: swap
+        mounting_options:
+          should_mount: 1

--- a/schedule/yast/raid/raid5_gpt_opensuse.yaml
+++ b/schedule/yast/raid/raid5_gpt_opensuse.yaml
@@ -1,0 +1,101 @@
+name:           RAID5_gpt_opensuse
+description:    >
+  Configure RAID 5 on the disks with GPT partition tables using Expert Partitioner.
+  Creates BIOS boot, root and swap partitions on each of the 4 disks and then uses
+  them for RAID 5.
+vars:
+  RAIDLEVEL: 5
+schedule:
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/online_repos
+  - installation/installation_mode
+  - installation/logpackages
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning/raid_gpt
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/resolve_dependency_issues
+  - installation/select_patterns_and_packages
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - console/validate_raid
+test_data:
+  disks:
+    - name: vda
+      partitions:
+        - size: 2mb
+          id: bios-boot
+          role: raw-volume
+        - size: 8000mb
+          role: raw-volume
+          id: linux-raid
+        - size: 100mb
+          role: raw-volume
+          id: linux-raid
+    - name: vdb
+      partitions:
+        - size: 2mb
+          id: bios-boot
+          role: raw-volume
+        - size: 8000mb
+          role: raw-volume
+          id: linux-raid
+        - size: 100mb
+          role: raw-volume
+          id: linux-raid
+    - name: vdc
+      partitions:
+        - size: 2mb
+          id: bios-boot
+          role: raw-volume
+        - size: 8000mb
+          role: raw-volume
+          id: linux-raid
+        - size: 100mb
+          role: raw-volume
+          id: linux-raid
+    - name: vdd
+      partitions:
+        - size: 2mb
+          id: bios-boot
+          role: raw-volume
+        - size: 8000mb
+          role: raw-volume
+          id: linux-raid
+        - size: 100mb
+          role: raw-volume
+          id: linux-raid
+  mds:
+    - raid_level: 5
+      chunk_size: 64
+      device_selection_step: 2
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+        mounting_options:
+          should_mount: 1
+    - raid_level: 5
+      chunk_size: 64
+      device_selection_step: 1
+      partition:
+        role: operating-system
+        formatting_options:
+          should_format: 1
+          filesystem: swap
+        mounting_options:
+          should_mount: 1


### PR DESCRIPTION
Enable refactored raid in openSUSE. Test suites already created in O3.

- Related ticket: https://progress.opensuse.org/issues/53027
- Needles: [needles opensuse](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/572)
- Verification run: 
  - [opensuse-Tumbleweed-DVD-x86_64-Build20190711-RAID0@64bit](https://openqa.opensuse.org/t982950)
  - [opensuse-Tumbleweed-DVD-x86_64-Build20190711-RAID1@64bit](https://openqa.opensuse.org/t982947)
  - [opensuse-Tumbleweed-DVD-x86_64-Build20190711-RAID10@64bit](https://openqa.opensuse.org/t982948)
  - [opensuse-Tumbleweed-DVD-x86_64-Build20190711-RAID5@64bit](https://openqa.opensuse.org/t982949)
  - [opensuse-Staging:B-Staging-DVD-x86_64-Build202.1-RAID0@64bit](https://openqa.opensuse.org/t982951)
  - [opensuse-Staging:B-Staging-DVD-x86_64-Build202.1-RAID1@64bit](https://openqa.opensuse.org/t982952)
