### PR TITLE
HPC: Add sleep before srun jobs are scheduled

### DIFF
--- a/tests/hpc/slurm_master_db.pm
+++ b/tests/hpc/slurm_master_db.pm
@@ -57,6 +57,13 @@ sub run {
     sleep(5);
     assert_script_run("srun -w slave-node00 date");
 
+    ## TODO provide more comprehensive checks for slurm
+    # job scheduling
+    for (my $i = 0; $i < 20; $i++) {
+        assert_script_run("srun -w slave-node00 date");
+        assert_script_run("srun -w slave-node01 date");
+    }
+
     barrier_wait('SLURM_MASTER_RUN_TESTS');
 }
 

--- a/tests/hpc/slurm_master_db.pm
+++ b/tests/hpc/slurm_master_db.pm
@@ -53,6 +53,8 @@ sub run {
     barrier_wait("SLURM_SLAVE_SERVICE_ENABLED");
 
     # run basic test against first compute node
+    # add sleep; bugzilla#1140403
+    sleep(5);
     assert_script_run("srun -w slave-node00 date");
 
     barrier_wait('SLURM_MASTER_RUN_TESTS');


### PR DESCRIPTION
At times the node with the DB isn't responding, despite exisiting
barriers in the test code. The sleep is meant as the measure to
ensure the testing env is ready for specific HPC tests

Without the sleep there is am occasional problem with the test. I checked this on the local instance - with the sleep I did not see the problem. 

- Some verification runs: 
http://10.160.65.14/tests/682
http://10.160.65.14/tests/682/file/serial_terminal.txt
http://10.160.65.14/tests/653#step/hpc_master/132