### PR TITLE
Enlarge check_screen timeout for module-selection in scc_registration.

### DIFF
--- a/tests/installation/scc_registration.pm
+++ b/tests/installation/scc_registration.pm
@@ -71,7 +71,7 @@ sub run {
         if (match_has_tag('registration-online-repos')) {
             if (is_sle('=12-SP5') && check_var('KEEP_REGISTERED', '1')) {
                 wait_screen_change { send_key('alt-y') };
-                assert_screen('module-selection');
+                assert_screen('module-selection', 300);
                 return wait_screen_change { send_key('alt-n') };
             }
         }


### PR DESCRIPTION
In sle12sp4 to sle12sp5 regression test we need enlarge the check_screen timeout for module-
selection in scc_registration, because we have so many ADDONS to update which will need 100 
seconds before it shows the module-selection screen. 

- Related ticket: https://progress.opensuse.org/issues/53426
- Needles: None.
- Verification run: https://openqa.suse.de/tests/3062354
