### PR TITLE
wicked: Surround test with barriers

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -409,8 +409,9 @@ Used to syncronize the wicked tests for SUT and REF creating the corresponding m
 
 =cut
 sub do_mutex {
-    my ($self) = @_;
-    my $barrier_name = 'test_' . $self->{name} . '_ready';
+    my ($self, $type) = @_;
+    $type //= 'ready';
+    my $barrier_name = 'test_' . $self->{name} . '_' . $type;
     barrier_wait($barrier_name);
 }
 
@@ -562,10 +563,10 @@ sub post_run {
     my ($self) = @_;
     $self->{wicked_post_run} = 1;
 
+    $self->do_mutex();
     eval {
         $self->upload_wicked_logs('post');
     };
-    $self->do_mutex();
 }
 
 sub pre_run_hook {
@@ -578,6 +579,7 @@ sub pre_run_hook {
         type_string("\n");
         $self->upload_wicked_logs('pre');
     }
+    $self->do_mutex('start');
 }
 
 sub post_fail_hook {

--- a/tests/wicked/locks_init.pm
+++ b/tests/wicked/locks_init.pm
@@ -28,6 +28,9 @@ sub run {
 
             record_info('barrier create', $barrier_name . ' num_children: 2');
             barrier_create($barrier_name, 2);
+            $barrier_name = 'test_' . $test . '_start';
+            barrier_create($barrier_name, 2);
+            record_info('barrier create', $barrier_name . ' num_children: 2');
         }
         mutex_create('wicked_barriers_created');
     }


### PR DESCRIPTION
The REF must live as long as the SUT is running.
We synchronize this with a barrier just before starting the
actual test and afterwards.
The later was moved before upload log, so upload logs do not mess
up the network connection.

- Related ticket: https://progress.opensuse.org/issues/54197
- Verification run: https://openqa.suse.de/tests/3062398 (wicked_basic)

@asmorodskyi @jlausuch 
