### PR TITLE
HPC: Check if nodes are accessible

### DIFF
--- a/tests/hpc/slurm_master_db.pm
+++ b/tests/hpc/slurm_master_db.pm
@@ -52,9 +52,7 @@ sub run {
     barrier_wait("SLURM_MASTER_SERVICE_ENABLED");
     barrier_wait("SLURM_SLAVE_SERVICE_ENABLED");
 
-    # run basic test against first compute node
-    # add sleep; bugzilla#1140403
-    sleep(5);
+    $self->check_nodes_availability();
     assert_script_run("srun -w slave-node00 date");
 
     ## TODO provide more comprehensive checks for slurm


### PR DESCRIPTION
Instead of requesting some checks in the test code, it make sense to
do some generic checks to see if all nodes are accessible/reachable.
This is very first idea of providing generic function to ping all
nodes in the cluster

- Verification run:
http://10.160.65.14/tests/1072

See:
http://10.160.65.14/tests/1072/file/serial_terminal.txt
http://localhost/tests/1072#step/slurm_master_db/139