### PR TITLE
Change mouse position during hexchat test

### DIFF
--- a/tests/x11/hexchat.pm
+++ b/tests/x11/hexchat.pm
@@ -29,7 +29,7 @@ sub run {
     # opens it's window where the mouse is. mouse_hide() would move
     # it to the lower right where the pk-update-icon's passive popup
     # may suddenly cover parts of the dialog ... o_O
-    mouse_set(0, 0);
+    mouse_set(0, 10);
     if (my $url = get_var('XCHAT_URL')) {
         x11_start_program("$name --url=$url", target_match => "$name-main-window");
     }


### PR DESCRIPTION
Coordinates (0,0) are a little bit special in GNOME on Wayland.

- Related ticket: https://progress.opensuse.org/issues/53750
- Verification run:
  - http://panigale.suse.cz/tests/2198 (`QEMUVGA=cirrus` -> x11)
  - http://panigale.suse.cz/tests/2200 (`QEMUVGA=virtio` -> wayland)