### PR TITLE
To register system and modules after media upgrade

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -44,6 +44,8 @@ our @EXPORT = qw(
   install_docker_when_needed
   verify_scc
   investigate_log_empty_license
+  register_addons_cmd
+  register_product_proxyscc
   %SLE15_MODULES
   %SLE15_DEFAULT_MODULES
   @SLE15_ADDONS_WITHOUT_LICENSE
@@ -189,6 +191,31 @@ Wrapper for SUSEConnect -r <regcode>. Requires SCC_REGCODE variable.
 =cut
 sub register_product {
     assert_script_run 'SUSEConnect -r ' . get_required_var('SCC_REGCODE');
+}
+
+sub register_addons_cmd {
+    my ($addonlist) = @_;
+    $addonlist //= get_var('SCC_ADDONS');
+    my @addons = grep { defined $_ && $_ } split(/,/, $addonlist);
+    foreach my $addon (@addons) {
+        my $name = get_addon_fullname($addon);
+        if ($name =~ /module/) {
+            my @ver = split(/\./, scc_version());
+            add_suseconnect_product($name, $ver[0]);
+        }
+        elsif ($name =~ /live/) {
+            add_suseconnect_product($name, undef, undef, "-r " . get_var('SCC_REGCODE_LIVE'));
+        }
+        elsif ($name =~ /we/) {
+            add_suseconnect_product($name, undef, undef, "-r " . get_var('SCC_REGCODE_WE'));
+        }
+        elsif ($name =~ /LTSS/) {
+            add_suseconnect_product($name, undef, undef, "-r " . get_var('SCC_REGCODE_LTSS'));
+        }
+        else {
+            add_suseconnect_product($name);
+        }
+    }
 }
 
 sub register_addons {

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -35,6 +35,19 @@ sub run {
         }
         elsif (get_var('OFW')) {
             add_serial_console('hvc1');
+        }
+    }
+
+    # Register the modules after media migration, only for sle<15
+    # poo#54131 [SLE][Migration][SLE12SP5]test fails in system_prepare -
+    # media upgrade need add modules after migration
+    if (get_var('SCC_ADDONS') && is_sle('<15') && get_var('MEDIA_UPGRADE')) {
+        assert_script_run 'SUSEConnect --url ' . get_required_var('SCC_URL') . ' -r ' . get_required_var('SCC_REGCODE');
+        my $myaddons = get_var('SCC_ADDONS');
+        # After media upgrade, system don't include ltss extension
+        $myaddons =~ s/ltss,?//g;
+        if ($myaddons ne '') {
+            register_addons_cmd($myaddons);
         }
     }
 


### PR DESCRIPTION
To register system and modules after media upgrade, so after media upgrade, it can go on doing regression cases.

- Related ticket:https://progress.opensuse.org/issues/54131
- Verification run: 
For sle12sp4 to sle12sp5: http://10.161.8.44/tests/147
For sle12sp2 ltss to sle12sp5: http://10.161.8.44/tests/139
[autoinst-log_sle12sp2.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/3394824/autoinst-log_sle12sp2.txt)
[autoinst-log_sle12sp4.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/3394825/autoinst-log_sle12sp4.txt)


