### PR TITLE
Fix remove_grub_cmdline_settings() joining two strings

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1046,7 +1046,7 @@ Remove C<$remove> from /etc/default/grub (using sed) and regenerate /boot/grub2/
 =cut
 sub remove_grub_cmdline_settings {
     my $remove = shift;
-    replace_grub_cmdline_settings('[[:blank:]]*' . $remove . '[[:blank:]]*', "", "g");
+    replace_grub_cmdline_settings('[[:blank:]]*' . $remove . '[[:blank:]]*', " ", "g");
 }
 
 =head2 grub_mkconfig


### PR DESCRIPTION
This fixes issue when removed string is in the middle of the text:

GRUB_CMDLINE_LINUX_DEFAULT="Hello foo world"

remove_grub_cmdline_settings("foo");
GRUB_CMDLINE_LINUX_DEFAULT="Helloworld"

This adds extra space, but that's not a problem for grub configuration.
We could be precise and not adding this space, but code simplicity wins.