### PR TITLE
Move vsftp service check to service_check.pm

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -116,6 +116,11 @@ our $default_services = {
         srv_proc_name => 'apparmor',
         support_ver   => '12-SP3,12-SP4,12-SP5,15,15-SP1'
     },
+    vsftp => {
+        srv_pkg_name  => 'vsftpd',
+        srv_proc_name => 'vsftpd',
+        support_ver   => '12-SP3,12-SP4,12-SP5,15,15-SP1'
+    },
 };
 
 sub install_services {
@@ -125,6 +130,7 @@ sub install_services {
         my $srv_pkg_name  = $service->{$s}->{srv_pkg_name};
         my $srv_proc_name = $service->{$s}->{srv_proc_name};
         my $support_ver   = $service->{$s}->{support_ver};
+        record_info($srv_pkg_name, "service check before migration");
         if (grep { $_ eq $hdd_base_version } split(',', $support_ver)) {
             if (exists $service->{$s}->{service_check_func}) {
                 $service->{$s}->{service_check_func}->('before');
@@ -147,8 +153,10 @@ sub install_services {
 sub check_services {
     my ($service) = @_;
     foreach my $s (keys %$service) {
+        my $srv_pkg_name  = $service->{$s}->{srv_pkg_name};
         my $srv_proc_name = $service->{$s}->{srv_proc_name};
         my $support_ver   = $service->{$s}->{support_ver};
+        record_info($srv_pkg_name, "service check after migration");
         if (grep { $_ eq $hdd_base_version } split(',', $support_ver)) {
             # service check after migration. if we've set up service check
             # function, we don't need following actions to check the service.

--- a/tests/console/check_upgraded_service.pm
+++ b/tests/console/check_upgraded_service.pm
@@ -21,10 +21,6 @@ use main_common 'is_desktop';
 
 sub run {
     select_console 'root-console';
-    systemctl 'start vsftpd';
-    systemctl 'status vsftpd';
-    save_screenshot;
-    assert_script_run 'systemctl status vsftpd --no-pager | grep active';
     check_services($default_services) if (is_sle && !is_desktop && !is_sles4sap && !get_var('MEDIA_UPGRADE') && !get_var('ZDUP') && !get_var('INSTALLONLY'));
 }
 

--- a/tests/installation/install_service.pm
+++ b/tests/installation/install_service.pm
@@ -29,11 +29,6 @@ use main_common 'is_desktop';
 sub run {
 
     select_console 'root-console';
-    zypper_call 'in vsftpd';
-    systemctl 'start vsftpd';
-    systemctl 'status vsftpd';
-    save_screenshot;
-    assert_script_run 'systemctl status vsftpd --no-pager | grep active';
 
     install_services($default_services)
       if is_sle


### PR DESCRIPTION
move ftp check to service_check.pm, also add record_info in script, then we have more clear view which service has checked and more easy for debugging.

- Related ticket: https://progress.opensuse.org/issues/53981
- Needles: n/a
- Verification run: http://openqa.suse.de/tests/3071771#step/check_upgraded_service/11
