### PR TITLE
Test partitioning and destructive boot for lvm upon raid1

### DIFF
--- a/schedule/yast/lvm_raid1/lvm+raid1_opensuse.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_opensuse.yaml
@@ -1,0 +1,34 @@
+---
+name:           lvm+raid1@64bit
+description:    >
+  Validation of partitioning for raid1 on lvm
+  Installation of RAID1 using expert partitioner.
+vars:
+  RAIDLEVEL: 1
+  LVM: 1
+test_data:
+  !include: test_data/yast/lvm_raid1/lvm+raid1_opensuse.yaml
+schedule:
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/online_repos
+  - installation/installation_mode
+  - installation/logpackages
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_raid
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - installation/opensuse_welcome
+  - console/validate_lvm_raid1

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle12.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle12.yaml
@@ -1,0 +1,34 @@
+---
+name:           lvm+raid1@64bit
+description:    >
+  Validation of partitioning for raid1 on lvm
+  Installation of RAID1 using expert partitioner.
+vars:
+  RAIDLEVEL: 1
+  LVM: 1
+test_data:
+  !include: test_data/yast/lvm_raid1/lvm+raid1_sle12.yaml
+schedule:
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_raid
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_lvm_raid1

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv-uefi.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv-uefi.yaml
@@ -1,0 +1,35 @@
+---
+name : lvm +raid1 @64bit
+description : >
+  Validation of partitioning for raid1 on lvm
+  Installation of RAID1 using expert partitioner .
+vars :
+  RAIDLEVEL : 1
+  LVM       : 1
+test_data :
+  !include : test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv.yaml
+schedule :
+  - installation/isosize
+  - installation/bootloader_hyperv
+  - installation/bootloader_uefi
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_raid
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_lvm_raid1

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv.yaml
@@ -1,0 +1,33 @@
+---
+name:           lvm+raid1@64bit
+description:    >
+  Validation of partitioning for raid1 on lvm
+  Installation of RAID1 using expert partitioner.
+vars:
+  RAIDLEVEL: 1
+  LVM: 1
+test_data:
+  !include: test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv.yaml
+schedule:
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_raid
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_lvm_raid1

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen-hvm.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen-hvm.yaml
@@ -1,0 +1,34 @@
+---
+name:           lvm+raid1@64bit
+description:    >
+  Validation of partitioning for raid1 on lvm
+  Installation of RAID1 using expert partitioner.
+vars:
+  RAIDLEVEL: 1
+  LVM: 1
+test_data:
+  !include: test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen.yaml
+schedule:
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_raid
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_lvm_raid1

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen-pv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen-pv.yaml
@@ -1,0 +1,32 @@
+---
+name:           lvm+raid1@64bit
+description:    >
+  Validation of partitioning for raid1 on lvm
+  Installation of RAID1 using expert partitioner.
+vars:
+  RAIDLEVEL: 1
+  LVM: 1
+test_data:
+  !include: test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen.yaml
+schedule:
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_raid
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/first_boot
+  - console/validate_lvm_raid1

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15.yaml
@@ -1,0 +1,34 @@
+---
+name:           lvm+raid1@64bit
+description:    >
+  Validation of partitioning for raid1 on lvm
+  Installation of RAID1 using expert partitioner.
+vars:
+  RAIDLEVEL: 1
+  LVM: 1
+test_data:
+  !include: test_data/yast/lvm_raid1/lvm+raid1_sle15.yaml
+schedule:
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_raid
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_lvm_raid1

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv-uefi.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv-uefi.yaml
@@ -1,0 +1,35 @@
+---
+name : lvm +raid1 @64bit
+description : >
+  Validation of partitioning for raid1 on lvm
+  Installation of RAID1 using expert partitioner .
+vars :
+  RAIDLEVEL : 1
+  LVM       : 1
+test_data :
+  !include : test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+schedule :
+  - installation/isosize
+  - installation/bootloader_hyperv
+  - installation/bootloader_uefi
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_raid
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_lvm_raid1

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
@@ -1,0 +1,34 @@
+---
+name : lvm +raid1 @64bit
+description : >
+  Validation of partitioning for raid1 on lvm
+  Installation of RAID1 using expert partitioner .
+vars :
+  RAIDLEVEL : 1
+  LVM       : 1
+test_data :
+  !include : test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+schedule :
+  - installation/isosize
+  - installation/bootloader_hyperv
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_raid
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_lvm_raid1

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-hvm.yaml
@@ -1,0 +1,34 @@
+---
+name:           lvm+raid1@64bit
+description:    >
+  Validation of partitioning for raid1 on lvm
+  Installation of RAID1 using expert partitioner.
+vars:
+  RAIDLEVEL: 1
+  LVM: 1
+test_data:
+  !include: test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen.yaml
+schedule:
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_raid
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_lvm_raid1

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen-pv.yaml
@@ -1,0 +1,32 @@
+---
+name:           lvm+raid1@64bit
+description:    >
+  Validation of partitioning for raid1 on lvm
+  Installation of RAID1 using expert partitioner.
+vars:
+  RAIDLEVEL: 1
+  LVM: 1
+test_data:
+  !include: test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen.yaml
+schedule:
+  - installation/isosize
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_raid
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/first_boot
+  - console/validate_lvm_raid1

--- a/test_data/yast/lvm_raid1/lvm+raid1_opensuse.yaml
+++ b/test_data/yast/lvm_raid1/lvm+raid1_opensuse.yaml
@@ -1,0 +1,13 @@
+---
+disks:
+  - vda
+  - vdb
+  - vdc
+  - vdd
+lvm:
+  lvpath: /dev/root/root
+  pvname: /dev/md0p1
+raid1:
+  disk_to_fail: /dev/vdd2
+  level: raid1
+  name: /dev/md0

--- a/test_data/yast/lvm_raid1/lvm+raid1_sle12.yaml
+++ b/test_data/yast/lvm_raid1/lvm+raid1_sle12.yaml
@@ -1,0 +1,14 @@
+---
+disks:
+  - vda
+  - vdb
+  - vdc
+  - vdd
+lvm:
+  lvpath: /dev/root/root
+  pvname: /dev/md0
+raid1:
+  disk_to_fail: /dev/vdd2
+  level: raid1
+  name: /dev/md0
+

--- a/test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv.yaml
+++ b/test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv.yaml
@@ -1,0 +1,14 @@
+---
+disks:
+  - sda
+  - sdb
+  - sdc
+  - sdd
+lvm:
+  lvpath: /dev/root/root
+  pvname: /dev/md0
+raid1:
+  disk_to_fail: /dev/sdd2
+  level: raid1
+  name: /dev/md0
+

--- a/test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen.yaml
+++ b/test_data/yast/lvm_raid1/lvm+raid1_sle12_svirt-xen.yaml
@@ -1,0 +1,14 @@
+---
+disks:
+  - xvdb
+  - xvdc
+  - xvdd
+  - xvde
+lvm:
+  lvpath: /dev/root/root
+  pvname: /dev/md0
+raid1:
+  disk_to_fail: /dev/xvdd2
+  level: raid1
+  name: /dev/md0
+

--- a/test_data/yast/lvm_raid1/lvm+raid1_sle15.yaml
+++ b/test_data/yast/lvm_raid1/lvm+raid1_sle15.yaml
@@ -1,0 +1,13 @@
+---
+disks:
+  - vda
+  - vdb
+  - vdc
+  - vdd
+lvm:
+  lvpath: /dev/root/root
+  pvname: /dev/md0p1
+raid1:
+  disk_to_fail: /dev/vdd2
+  level: raid1
+  name: /dev/md0

--- a/test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+++ b/test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
@@ -1,0 +1,14 @@
+---
+disks:
+  - sda
+  - sdb
+  - sdc
+  - sdd
+lvm:
+  lvpath: /dev/root/root
+  pvname: /dev/md0p1
+raid1:
+  disk_to_fail: /dev/sdd2
+  level: raid1
+  name: /dev/md0
+

--- a/test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen.yaml
+++ b/test_data/yast/lvm_raid1/lvm+raid1_sle15_svirt-xen.yaml
@@ -1,0 +1,13 @@
+---
+disks:
+  - xvdb
+  - xvdbc
+  - xvdd
+  - xvde
+lvm:
+  lvpath: /dev/root/root
+  pvname: /dev/md0p1
+raid1:
+  disk_to_fail: /dev/xvdd2
+  level: raid1
+  name: /dev/md0

--- a/tests/console/validate_lvm_raid1.pm
+++ b/tests/console/validate_lvm_raid1.pm
@@ -1,0 +1,112 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: RAID1 on LVM partition validation
+# Maintainer: Yiannis Bonatakis <ybonatakis@suse.com>
+
+use strict;
+use warnings;
+use base "y2_module_consoletest";
+use testapi;
+use utils;
+use Test::Assert ':all';
+use scheduler 'get_test_data';
+use version_utils 'is_sle';
+use power_action_utils 'power_action';
+
+sub run {
+    my $self = shift;
+
+    select_console 'root-console';
+
+    my $config = get_test_data();
+    $config->{expected_num_devs} = scalar @{$config->{disks}};
+    # actual_num_devs is used to get the number of the disks in raid
+    # as we move in and out a disk during the test. This is because
+    # after the reboot sle15 can recover the missing disk and we need
+    # to compare with the expected_num_devs
+    my $actual_num_devs = $config->{expected_num_devs};
+    _check_lvm_partitioning($config);
+    _check_raid1_partitioning($config, $actual_num_devs);
+    _remove_raid_disk($config, $actual_num_devs);
+    _reboot();
+    $self->wait_boot;
+
+    _check_raid_disks_after_reboot($config, $actual_num_devs);
+    _restore_raid_disk($config);
+}
+
+sub _check_lvm_partitioning {
+    my ($config) = @_;
+    my $activelvm = script_output q[lvscan | awk '{print $2}' | sed s/\'//g];
+    assert_equals $config->{lvm}->{lvpath}, $activelvm, "lv name is not the same. \n" . script_output q[lvscan];
+    my $pvname = script_output q[pvscan -s | grep '/dev'];
+    assert_equals $config->{lvm}->{pvname}, $pvname, "pv name is not the same.";
+    record_info($config->{lvm}->{pvname});
+}
+
+sub _check_raid1_partitioning {
+    my ($config, $actual_num_devs) = @_;
+    record_info("raid1 name", $config->{raid1}->{name});
+    assert_script_run 'mdadm --detail ' . $config->{lvm}->{pvname};
+    assert_script_run 'grep \'md0 : active ' . $config->{raid1}->{level} . '\' /proc/mdstat';
+    my $active_devs = script_output("mdadm --detail " . $config->{raid1}->{name} . " |grep \"Active Devices\" |awk '{ print \$4 }'");
+    assert_equals($active_devs, $actual_num_devs, "Active devices are different");
+
+    for (@{$config->{disks}}) {
+        my $line = script_output "mdadm --detail " . $config->{raid1}->{name} . " | awk '{ if((/$_/) && (\$5 ~ /active/) && (\$6 ~ /sync/)) {print}}'";
+        assert_not_null($line, "$_ not active");
+    }
+}
+
+sub _remove_raid_disk {
+    my ($config, $actual_num_devs) = @_;
+    assert_script_run "mdadm --manage $config->{raid1}->{name} --set-faulty $config->{raid1}->{disk_to_fail}";
+    $actual_num_devs--;
+    my $active_devs = script_output("mdadm --detail " . $config->{raid1}->{name} . " |grep \"Active Devices\" |awk '{ print \$4 }'");
+    assert_equals($actual_num_devs, $active_devs, "Active devices are different after set faulty device");
+
+    assert_script_run 'mdadm --manage ' . $config->{raid1}->{name} . ' --remove ' . $config->{raid1}->{disk_to_fail};
+    script_retry "mdadm --detail " . $config->{raid1}->{name} . " | grep 'Active Devices : 3'";
+    my $removedDisk = script_output "mdadm --detail " . $config->{raid1}->{name} . " | awk '{ if((\$4 == " . $actual_num_devs . ") && (\$5 ~ /removed/)) {print}}'";
+    assert_not_null($removedDisk, "$removedDisk should have been removed");
+}
+
+sub _reboot {
+    record_info('system reboots');
+    power_action('reboot');
+}
+
+sub _check_raid_disks_after_reboot {
+    my ($config, $actual_num_devs) = @_;
+    record_info('get state after reboot');
+    select_console 'root-console';
+
+    assert_script_run 'mdadm --detail ' . $config->{raid1}->{name};
+    my $active_devs = script_output("mdadm --detail " . $config->{raid1}->{name} . " |grep \"Active Devices\" |awk '{ print \$4 }'");
+    # if the number of disk in raid1 list are not the same report a soft failure
+    if ($active_devs != $config->{actual_num_devs}) {
+        record_soft_failure 'bsc#1150370 - disk is restored during the booting' if is_sle('>=15');
+    }
+    else {
+        assert_equals($actual_num_devs, $active_devs, "Active devices should be still " . $config->{expected_num_devs});
+    }
+}
+
+sub _restore_raid_disk {
+    my ($config) = @_;
+    my $active_devs = script_output("mdadm --detail " . $config->{raid1}->{name} . " |grep \"Active Devices\" |awk '{ print \$4 }'");
+    if ($active_devs != $config->{expected_num_devs}) {
+        assert_script_run 'mdadm --manage ' . $config->{raid1}->{name} . ' --add ' . $config->{raid1}->{disk_to_fail};
+        script_retry "mdadm --detail $config->{raid1}->{name} | grep 'Active Devices : $config->{expected_num_devs}'";
+        assert_script_run 'mdadm --detail ' . $config->{raid1}->{name};
+    }
+}
+
+1;


### PR DESCRIPTION
Validate partitioning of lvm above raid1 and exercese destructive scenario for raid1 to ensure that system can boot after faulty disk and can sync after be added back.

- Related ticket: https://progress.opensuse.org/issues/52418
- Needles: N/A
- Verification run: 
arch:
[sle-12-SP5 @aarch64](https://openqa.suse.de/tests/3350362)
[ sle-15-SP2@aarch64](https://openqa.suse.de/tests/3352598)
TW:
[ opensuse-Tumbleweed@x86_64](https://openqa.opensuse.org/tests/1028862)
x86_64:
[sle-15-SP2 @x86_64](https://openqa.suse.de/t3380165)
[sle-12-SP5 @x86_64](https://openqa.suse.de/tests/3346251)
svirt-sle15:
[sle-15-SP2 svirt-xen-pv @x86_64](https://openqa.suse.de/tests/3392447)
[sle-15-SP2 svirt-xen-hvm @x86_64](https://openqa.suse.de/tests/3384830) 
[sle-15-SP2 svirt-hyperv @x86_64](https://openqa.suse.de/tests/3353395)
[sle-15-SP2 svirt-hyperv-uefi @x86_64](https://openqa.suse.de/tests/3367239)
svirt-sle12:
[sle-12-SP5 svirt-xen-pv @x86_64](https://openqa.suse.de/tests/3387132) 
[sle-12-SP5 svirt-xen-hvm @x86_64](https://openqa.suse.de/tests/3379032)
[sle-12-SP5 svirt-hyperv @x86_64](https://openqa.suse.de/t3380151)
[sle-12-SP5 svirt-hyperv-uefi @x86_64](https://openqa.suse.de/tests/3380117)