### PR TITLE
Add new LTSS regcode variables

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -205,7 +205,7 @@ sub register_addons {
         push @addons_with_code, 'we' unless (check_var('SLE_PRODUCT', 'sled'));
         # HA doesn't need code on SLES4SAP
         push @addons_with_code, 'ha' unless (check_var('SLE_PRODUCT', 'sles4sap'));
-        if (my $regcode = get_var("SCC_REGCODE_$uc_addon")) {
+        if ((my $regcode = get_var("SCC_REGCODE_$uc_addon")) or ($addon eq "ltss")) {
             # skip addons which doesn't need to input scc code
             next unless grep { $addon eq $_ } @addons_with_code;
             if (check_var('VIDEOMODE', 'text')) {
@@ -213,6 +213,12 @@ sub register_addons {
             }
             else {
                 assert_and_click("scc-code-field-$addon", timeout => 240);
+            }
+            # avoid duplicated tests to manage LTSS regcode by integrating new variables
+            if ($addon eq "ltss") {
+                my $os_sp_version = get_var("HDDVERSION");
+                $os_sp_version =~ s/-/_/g;
+                $regcode = get_var("SCC_REGCODE_LTSS_$os_sp_version", $regcode);
             }
             type_string $regcode;
             save_screenshot;


### PR DESCRIPTION
As LTSS regcodes are specific by architecture and os version, it's not possible to easily manage them in Test suites or Medium types.

To avoid duplicated tests, it's better to use different variables in the Medium section in openQA.
Ex: SCC_REGCODE_LTSS_12_SP2, SCC_REGCODE_LTSS_12_SP3

That means you can have multi infrastructure tests in one line and avoid a line only for 12SP2 LTSS x86_64, another one only for 12SP2 LTSS ppcl64le and so on. 

- Related ticket: N/A
- Needles: N/A
- Verification run:
With the new variables set in Medium types:
[migration_offline_sle12sp2_ltss](http://1a102.qa.suse.de/tests/1214)
[migration_offline_sle12sp3_ltss](http://1a102.qa.suse.de/tests/1215)
[migration_zypper_sle12sp2_ltss](http://1a102.qa.suse.de/tests/1216)
[migration_zypper_sle12sp3_ltss](http://1a102.qa.suse.de/tests/1217)
Without the new variables set (regression test):
[migration_offline_sle12sp2_ltss](http://1a102.qa.suse.de/tests/1218)
[migration_zypper_sle12sp2_ltss](http://1a102.qa.suse.de/tests/1219)

