### PR TITLE
Fix zypper_ar() GPG check and refresh

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -44,7 +44,7 @@ our @EXPORT = qw(
 Helper to add QA:HEAD repository repository (usually from IBS).
 =cut
 sub add_qa_head_repo {
-    zypper_ar(get_required_var('QA_HEAD_REPO'), name => 'qa-head');
+    zypper_ar(get_required_var('QA_HEAD_REPO'), name => 'qa-head', no_gpg_check => 1);
 }
 
 =head2 add_qa_web_repo
@@ -54,7 +54,7 @@ sub add_qa_head_repo {
 Helper to add QA web repository repository.
 =cut
 sub add_qa_web_repo {
-    zypper_ar(get_required_var('QA_WEB_REPO'), name => 'qa-web');
+    zypper_ar(get_required_var('QA_WEB_REPO'), name => 'qa-web', no_gpg_check => 1);
 }
 
 =head2 get_repo_var_name

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -458,13 +458,14 @@ sub zypper_enable_install_dvd {
 
     zypper_ar($url,[ name => NAME ], [ priority => N ]);
 
-Add repository (with zypper ar) unless it's already repo C<$name> already added.
+Add repository (with zypper ar) unless it's already repo C<$name> already added
+and refresh repositories.
 
 Options:
 
 C<$name> alias for repository, optional
 When used, additional check if repo not yet exists is done, and adding
-only if it doesn't exist.
+only if it doesn't exist. Also zypper ref is run only on this repository.
 NOTE: if not used, $url must be a URI pointing to a .repo file.
 
 C<$no_gpg_check> pass --no-gpgcheck for repos with not valid GPG key, optional
@@ -486,16 +487,19 @@ sub zypper_ar {
 
     $priority     = "-p $priority"  if ($priority);
     $no_gpg_check = "--no-gpgcheck" if ($no_gpg_check);
-    my $cmd = "--gpg-auto-import-keys ar -f $priority $no_gpg_check $params $url";
+    my $cmd_ar  = "--gpg-auto-import-keys ar -f $priority $no_gpg_check $params $url";
+    my $cmd_ref = "--gpg-auto-import-keys ref";
 
     # repo file
     if (!$name) {
-        return zypper_call($cmd, dumb_term => 1);
+        zypper_call($cmd_ar, dumb_term => 1);
+        return zypper_call($cmd_ref, dumb_term => 1);
     }
 
     # URI alias
     if (script_run("zypper lr $name")) {
-        return zypper_call("$cmd $name", dumb_term => 1);
+        zypper_call("$cmd_ar $name", dumb_term => 1);
+        return zypper_call("$cmd_ref --repo $name", dumb_term => 1);
     }
 }
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -467,22 +467,26 @@ When used, additional check if repo not yet exists is done, and adding
 only if it doesn't exist.
 NOTE: if not used, $url must be a URI pointing to a .repo file.
 
+C<$no_gpg_check> pass --no-gpgcheck for repos with not valid GPG key, optional
+
 C<$priority> set repo priority, optional
 
 C<$params> other ar subcommand parameters, optional
 
 Examples:
-    zypper_ar('https://download.opensuse.org/repositories/devel:/kubic/openSUSE_Tumbleweed/devel:kubic.repo', priority => 90);
     zypper_ar('http://dist.nue.suse.com/ibs/QA:/Head/SLE-15-SP1', name => 'qa-head);
+    zypper_ar('https://download.opensuse.org/repositories/devel:/kubic/openSUSE_Tumbleweed/devel:kubic.repo', no_gpg_check => priority => 90);
 =cut
 sub zypper_ar {
     my ($url, %args) = @_;
-    my $name     = $args{name}     // '';
-    my $priority = $args{priority} // '';
-    my $params   = $args{params}   // '';
+    my $name         = $args{name}         // '';
+    my $priority     = $args{priority}     // '';
+    my $params       = $args{params}       // '';
+    my $no_gpg_check = $args{no_gpg_check} // '';
 
-    $priority = "-p $priority" if ($priority);
-    my $cmd = "--gpg-auto-import-keys ar -f $priority $params $url";
+    $priority     = "-p $priority"  if ($priority);
+    $no_gpg_check = "--no-gpgcheck" if ($no_gpg_check);
+    my $cmd = "--gpg-auto-import-keys ar -f $priority $no_gpg_check $params $url";
 
     # repo file
     if (!$name) {

--- a/tests/caasp/stack_conformance.pm
+++ b/tests/caasp/stack_conformance.pm
@@ -42,7 +42,7 @@ sub run {
         assert_script_run 'tar -xzf sonobuoy_0.12.1_linux_amd64.tar.gz';
         assert_script_run 'mv sonobuoy /usr/bin/';
     } else {
-        my $repo = get_var('SONOBUOY_REPO', 'https://download.opensuse.org/repositories/devel:/kubic/openSUSE_Tumbleweed/devel:kubic.repo');
+        my $repo = get_var('SONOBUOY_REPO', 'https://download.opensuse.org/repositories/devel:/kubic/openSUSE_Tumbleweed/devel:kubic.repo', no_gpg_check => 1);
         zypper_ar($repo);
         zypper_call 'in sonobuoy';
     }

--- a/tests/kernel/ib_tests.pm
+++ b/tests/kernel/ib_tests.pm
@@ -64,7 +64,7 @@ sub ibtest_master {
     my $hpc_testing_branch = get_var('IBTEST_GITBRANCH', 'master');
 
     # do all test preparations and setup
-    zypper_ar(get_required_var('DEVEL_TOOLS_REPO'));
+    zypper_ar(get_required_var('DEVEL_TOOLS_REPO'), no_gpg_check => 1);
     zypper_call('in git-core twopence bc iputils python');
 
     # create symlinks, the package is (for now) broken

--- a/tests/kernel/install_kotd.pm
+++ b/tests/kernel/install_kotd.pm
@@ -33,8 +33,8 @@ sub run {
     # Remove all installed kernel and related packages
     remove_kernel_packages;
     # Enable kotd/kmp repositories
-    zypper_ar($kotd_repo, name => 'KOTD', priority => 90);
-    zypper_ar($kmp_repo,  name => 'KMP',  priority => 90) if $kmp_repo;
+    zypper_ar($kotd_repo, name => 'KOTD', priority => 90, no_gpg_check => 1);
+    zypper_ar($kmp_repo,  name => 'KMP',  priority => 90, no_gpg_check => 1) if $kmp_repo;
     # Install latest kernel
     zypper_call("in -l kernel-default");
     # Check for multiple kernel installation

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -252,7 +252,7 @@ sub install_kotd {
     my $repo = shift;
     fully_patch_system;
     remove_kernel_packages;
-    zypper_ar($repo, name => 'KOTD', priority => 90);
+    zypper_ar($repo, name => 'KOTD', priority => 90, no_gpg_check => 1);
     zypper_call("in -l kernel-default");
 }
 


### PR DESCRIPTION
Verification run:
* mau-qa_kernel_ltp_input@64bit
http://quasar.suse.cz/tests/3345
* SLE12 SP5 install_ltp+sle+Server-DVD+KOTD@64bit
http://quasar.suse.cz/tests/3346
* opensuse-Tumbleweed-DVD-x86_64-Build20190711-install_ltp+opensuse+DVD-m32@64bit
http://quasar.suse.cz/tests/3353

Question:
Should be `no_gpg_check` default?
Or, as `no_gpg_check => 1` might be needed for debugging, it might be good to add reading of some variable (`ZYPPER_AR_DEFAULT_OPTIONS` ?). But that's probably an overkill.