### PR TITLE
Zypper extend regression test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1503,6 +1503,7 @@ sub load_extra_tests_zypper {
     }
     # Check for availability of packages and the corresponding repository, as of now only makes sense for SLE
     loadtest 'console/validate_packages_and_patterns' if is_sle '12-sp2+';
+    loadtest 'console/zypper_extend';
 }
 
 sub load_extra_tests_dracut {

--- a/tests/console/zypper_extend.pm
+++ b/tests/console/zypper_extend.pm
@@ -1,0 +1,97 @@
+#SUSE"s openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: This is a zypper extend regression tests. poo#51521.
+#   This test is based on https://gitlab.suse.de/ONalmpantis/scripts/blob/master/zypper_regression_test.sh.
+
+# Maintainer: Marcelo Martins <mmartins@suse.cz>
+# Tags: poo#51521
+#
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    select_console 'root-console';
+
+
+    #Search for a package (star
+    zypper_call 'se star';
+
+    #Get information about what a package provides:
+    zypper_call 'info --provides star';
+
+    #Get information about the requirements of a package:
+    zypper_call 'info --requires star';
+
+    #Only download a package for later installation, don't ask for permission:
+    zypper_call 'in -d star';
+
+    #Has the RPM actually been downloaded?
+    assert_script_run("find /var/cache/zypp/packages/ -name 'star*'");
+
+    # Disable auto-refresh, install star, don't ask for permission:
+    zypper_call '--no-refresh in star';
+
+    #Remove star, don't ask for permission:
+    zypper_call 'rm star';
+
+    #List all applicable patches:
+    zypper_call 'lu -t patch';
+
+    #List applicable patches for all CVE issues, or issues whose number matches the given string:
+    zypper_call 'lp --cve=--cve=CVE-2019-1010319';
+
+    #List applicable patches for all Bugzilla issues, or issues whose number matches the given string:
+    zypper_call 'lp -b=1129403';
+
+    #List all available released patches, no matter if they are applicable on our system or not:
+    zypper_call 'lp -a';
+
+    #Show packages which are without repository:
+    zypper_call 'pa --orphaned';
+
+    #Show packages which are installed but are not needed:
+    zypper_call 'pa --unneeded';
+
+    #List all available patterns:
+    zypper_call 'pt';
+
+    #List all available products:
+    zypper_call 'pd';
+
+    #List all defined repositories and corresponding URIs:
+    zypper_call 'lr -u';
+
+    #Disable a specific repository
+    zypper_call 'mr -d 1';
+
+    #Enable a specific repository
+    zypper_call 'mr -e 1';
+
+    #Disable rpm file caching for all the repositories.
+    zypper_call 'mr -Ka';
+
+    #Enable rpm file caching for all the repositories
+    zypper_call 'mr -ka';
+
+    #Disable rpm file caching for remote repositories
+    zypper_call 'mr -Kt';
+
+    #Disable rpm file caching for remote repositories
+    zypper_call 'mr -Kt';
+
+    #Enter zypper shell and run the lr command | echo lr
+    assert_script_run('echo lr |zypper shell');
+
+}
+
+1;


### PR DESCRIPTION
This script fixes poo#51521 [qam][urgent][blue] extend zypper regression
tests

Related ticket: https://progress.opensuse.org/issues/51521

Verification run:
SLES 12 SP1 - http://10.161.229.197/tests/820
SLES 12 SP2 - http://10.161.229.197/tests/819
SLES 12 SP3 - http://10.161.229.197/tests/818
SLES 12 SP4 - http://10.161.229.197/tests/817
SLES 15 -  http://10.161.229.197/tests/816
SLES 15 SP1 - http://10.161.229.197/tests/815