### PR TITLE
init_desktop_runner: Prevent gnome activity screen on mouse_hide

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -171,7 +171,7 @@ sub init_desktop_runner {
 
     send_key($hotkey);
 
-    mouse_hide(1);
+    mouse_hide(200);
     if (!check_screen('desktop-runner', $timeout)) {
         record_info('workaround', "desktop-runner does not show up on $hotkey, retrying up to three times (see bsc#978027)");
         send_key 'esc';    # To avoid failing needle on missing 'alt' key - poo#20608

--- a/tests/x11/hexchat.pm
+++ b/tests/x11/hexchat.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 SUSE LLC
+# Copyright (C) 2015-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -25,36 +25,24 @@ use utils;
 sub run {
     my $name = ref($_[0]);
     ensure_installed($name);
-    # we need to move the mouse in the top left corner as xchat
-    # opens it's window where the mouse is. mouse_hide() would move
-    # it to the lower right where the pk-update-icon's passive popup
-    # may suddenly cover parts of the dialog ... o_O
-    mouse_set(0, 10);
-    if (my $url = get_var('XCHAT_URL')) {
-        x11_start_program("$name --url=$url", target_match => "$name-main-window");
-    }
-    else {
-        x11_start_program($name, target_match => "$name-network-select");
-        type_string "freenode\n";
-        assert_and_click "hexchat-nick-$username";
-        send_key 'ctrl-a';
-        send_key 'delete';
-        assert_screen "hexchat-nick-empty";
-        type_string "openqa" . random_string(5);
-        assert_and_click "$name-connect-button";
-        assert_screen "$name-connection-complete-dialog";
-        assert_and_click "$name-join-channel";
-        type_string "openqa\n";
-        send_key 'ret';
-    }
+    x11_start_program($name, target_match => "$name-network-select");
+    type_string "freenode\n";
+    assert_and_click "hexchat-nick-$username";
+    send_key 'ctrl-a';
+    send_key 'delete';
+    assert_screen "hexchat-nick-empty";
+    type_string "openqa" . random_string(5);
+    assert_and_click "$name-connect-button";
+    assert_screen "$name-connection-complete-dialog";
+    assert_and_click "$name-join-channel";
+    type_string "openqa\n";
+    send_key 'ret';
     assert_screen "$name-main-window";
     type_string "hello, this is openQA running $name!\n";
     assert_screen "$name-message-sent-to-channel";
     type_string "/quit I'll be back\n";
     assert_screen "$name-quit";
     send_key 'alt-f4';
-    # now hide the mouse again
-    mouse_hide;
 }
 
 1;


### PR DESCRIPTION
Moving the mouse to a border but not a corner should prevent any special
action to be triggered.

Verification run: https://openqa.opensuse.org/tests/984499#step/hexchat/22

Related progress issue: https://progress.opensuse.org/issues/53750