### PR TITLE
Replace the invoke condition for SMT test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -677,7 +677,7 @@ sub lxdestep_is_applicable {
 
 sub is_smt {
     # Smt is replaced with rmt in SLE 15, see bsc#1061291
-    return ((get_var("PATTERNS", '') || get_var('HDD_1', '')) =~ /smt/) && is_sle('<15');
+    return (check_var('SMT_TEST', '1') && is_sle('<15'));
 }
 
 sub is_rmt {


### PR DESCRIPTION
We needn't run SMT test depend on the special image with SMT pattern, now change it to just use variable 'SMT_TEST' to control whether can load SMT test.

- Related ticket: https://progress.opensuse.org/issues/53207
- Needles: N/A
- Verification run: http://10.161.8.44/tests/171
