### PR TITLE
Add test scenario to verify AY installation while using disk as MD member

### DIFF
--- a/data/autoyast_sle15/autoyast_disk_as_md_member.xml
+++ b/data/autoyast_sle15/autoyast_disk_as_md_member.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <suse_register>
+        <do_registration config:type="boolean">true</do_registration>
+        <email/>
+        <reg_code>{{SCC_REGCODE}}</reg_code>
+        <install_updates config:type="boolean">true</install_updates>
+        <reg_server>{{SCC_URL}}</reg_server>
+        <addons config:type="list">
+            <addon>
+                <name>sle-module-server-applications</name>
+                <version>{{VERSION}}</version>
+                <arch>{{ARCH}}</arch>
+            </addon>
+        </addons>
+    </suse_register>
+    <bootloader>
+        <global>
+            <timeout config:type="integer">-1</timeout>
+        </global>
+    </bootloader>
+    <networking>
+        <keep_install_network config:type="boolean">true</keep_install_network>
+    </networking>
+    <software>
+        <products config:type="list">
+            <product>SLES</product>
+        </products>
+    </software>
+    <users config:type="list">
+        <user>
+            <fullname>Bernhard M. Wiedemann</fullname>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>bernhard</username>
+        </user>
+        <user>
+            <encrypted config:type="boolean">false</encrypted>
+            <user_password>nots3cr3t</user_password>
+            <username>root</username>
+        </user>
+    </users>
+    <report>
+        <errors>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </errors>
+        <messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </messages>
+        <warnings>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </warnings>
+        <yesno_messages>
+            <log config:type="boolean">true</log>
+            <show config:type="boolean">true</show>
+            <timeout config:type="integer">0</timeout>
+        </yesno_messages>
+    </report>
+    <partitioning config:type="list">
+        <drive>
+            <type config:type="symbol">CT_DISK</type>
+            <device>/dev/sda</device>
+            <disklabel>gpt</disklabel>
+            <use>all</use>
+            <partitions config:type="list">
+                <partition>
+                    <create config:type="boolean">true</create>
+                    <partition_id config:type="integer">263</partition_id>
+                    <size>8MiB</size>
+                </partition>
+                <partition>
+                    <create config:type="boolean">true</create>
+                    <mount>/boot</mount>
+                    <size>400MiB</size>
+                </partition>
+                <partition>
+                    <raid_name>/dev/md/0</raid_name>
+                    <size>10GiB</size>
+                </partition>
+            </partitions>
+        </drive>
+        <drive>
+            <type config:type="symbol">CT_DISK</type>
+            <device>/dev/sdb</device>
+            <disklabel>none</disklabel>
+            <use>all</use>
+            <partitions config:type="list">
+                <partition>
+                    <raid_name>/dev/md/0</raid_name>
+                </partition>
+            </partitions>
+        </drive>
+        <drive>
+            <type config:type="symbol">CT_MD</type>
+            <device>/dev/md/0</device>
+            <disklabel>gpt</disklabel>
+            <use>all</use>
+            <raid_options>
+                <raid_type>raid1</raid_type>
+            </raid_options>
+            <partitions config:type="list">
+                <partition>
+                    <mount>/</mount>
+                    <size>5GiB</size>
+                </partition>
+                <partition>
+                    <mount>/data</mount>
+                    <filesystem config:type="symbol">ext4</filesystem>
+                    <size>max</size>
+                </partition>
+            </partitions>
+        </drive>
+    </partitioning>
+</profile>

--- a/lib/autoyast.pm
+++ b/lib/autoyast.pm
@@ -21,7 +21,7 @@ use testapi;
 use version_utils 'is_sle';
 use registration qw(scc_version get_addon_fullname);
 
-our @EXPORT = qw(expand_template);
+our @EXPORT = qw(expand_template init_autoyast_profile);
 
 sub expand_patterns {
     if (get_var('PATTERNS') =~ m/^\s*$/) {
@@ -132,5 +132,15 @@ sub expand_template {
     return $output;
 }
 
+sub init_autoyast_profile {
+    select_console('root-console');
+    my $profile_path = '/root/autoinst.xml';
+    # Generate profile if doesn't exist
+    if (script_run("[ -e $profile_path ]")) {
+        my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'clone_system');
+        wait_serial("$module_name-0", 60) || die "'yast2 clone_system' exited with non-zero code";
+    }
+    return script_output("cat $profile_path");
+}
 
 1;

--- a/lib/xml_utils.pm
+++ b/lib/xml_utils.pm
@@ -20,7 +20,7 @@ use Exporter 'import';
    Returns XPathContext for the dom build using the string, which contains xml.
 =cut
 
-our @EXPORT = qw(get_xpc verify_option);
+our @EXPORT = qw(get_xpc verify_option find_nodes);
 
 sub get_xpc {
     my ($string) = @_;
@@ -45,11 +45,7 @@ sub get_xpc {
 sub verify_option {
     my (%args) = @_;
 
-    my $nodeset = $args{xpc}->findnodes($args{xpath});
-    for my $node ($nodeset->get_nodelist) {
-        print $node->to_literal;
-    }
-    my @nodes = $nodeset->get_nodelist;
+    my @nodes = find_nodes(%args);
     ## Verify that there is node found by xpath and it's single one
     if (scalar @nodes != 1) {
         return "Generated autoinst.xml contains unexpected number of nodes for xpath: $args{xpath}. Found: " . scalar @nodes . ", expected: 1.";
@@ -60,6 +56,24 @@ sub verify_option {
 
     return '';
 
+}
+
+=head2 find_nodes
+   find_nodes(%args);
+
+   Finds all the nodes by xpath and returns the nodes as array.
+   C<xpc> - XPathContext object for the parsed xml,
+   C<xpath> - XPath to the target node
+
+=cut
+
+sub find_nodes {
+    my (%args) = @_;
+    my $nodeset = $args{xpc}->findnodes($args{xpath});
+    for my $node ($nodeset->get_nodelist) {
+        print $node->to_literal;
+    }
+    return $nodeset->get_nodelist;
 }
 
 1;

--- a/schedule/yast/autoyast_disk_as_md_member.yaml
+++ b/schedule/yast/autoyast_disk_as_md_member.yaml
@@ -1,0 +1,34 @@
+name:           autoyast_disk_as_md_member
+description:    >
+  Test autoyast installation, while using a disk as a MD RAID member
+vars:
+  AUTOYAST: autoyast_sle15/autoyast_disk_as_md_member.xml
+  AUTOYAST_CONFIRM: 1
+schedule:
+  - autoyast/prepare_profile
+  - installation/isosize
+  - installation/bootloader_start
+  - autoyast/installation
+  - autoyast/console
+  - autoyast/login
+  - autoyast/wicked
+  - autoyast/repos
+  - autoyast/clone
+  - autoyast/logs
+  - autoyast/autoyast_reboot
+  - installation/grub_test
+  - installation/first_boot
+  - console/system_prepare
+  - autoyast/verify_disk_as_md_member
+  - autoyast/verify_disk_as_md_member_clone
+test_data:
+  disk: '/dev/md0'
+  partitions_count: 2
+  type_part: 'part'
+  raid_level: 'raid1'
+  mount_point:
+    root: '/'
+    data: '/data'
+  xpath:
+    mount: '//ns:partitioning/ns:drive[ns:device="/dev/md/0"]/ns:partitions/ns:partition/ns:mount'
+    raid_type: '//ns:partitioning/ns:drive[ns:device="/dev/md/0"]/ns:raid_options/ns:raid_type'

--- a/tests/autoyast/verify_disk_as_md_member.pm
+++ b/tests/autoyast/verify_disk_as_md_member.pm
@@ -1,0 +1,50 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Validate partitioning for autoyast installation when using disks as
+#          Multiple Device member. Uses two devices.
+#          The test verifies that the following configuration of the installed
+#          system match the parameters in autoyast profile:
+#             1. Number of partitions on MD RAID;
+#             2. RAID level;
+#             3. Mount points for MD partitions.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+use strict;
+use warnings;
+use testapi;
+use base 'basetest';
+use scheduler 'get_test_data';
+use Test::Assert ':all';
+
+sub collect_disk_data {
+    my ($disk) = @_;
+    return script_output("lsblk $disk -l --noheading --output NAME,TYPE,MOUNTPOINT");
+}
+
+sub run {
+    my $test_data = get_test_data();
+    my $disk_data = collect_disk_data($test_data->{disk});
+
+    my @partitions = ($disk_data =~ /$test_data->{type_part}/g);
+
+    record_info('Partitions count', 'Verify that MD RAID contains correct number of partitions.');
+    assert_equals($test_data->{partitions_count}, scalar @partitions, 'MD RAID contains wrong number of partitions.');
+
+    record_info('RAID level', 'Verify that RAID level on the installed system corresponds to the expected one.');
+    assert_true($disk_data =~ m/$test_data->{raid_level}/, 'Wrong raid level is shown for the MD.');
+
+    record_info('Mount points', 'Verify that MD contains all the expected mount points.');
+    assert_true($disk_data =~ m/$test_data->{mount_point}->{root}/,
+        "\"$test_data->{mount_point}->{root}\" mount point is not found among MD RAID partitions.");
+    assert_true($disk_data =~ m/$test_data->{mount_point}->{data}/,
+        "\"$test_data->{mount_point}->{data}\" mount point is not found among MD RAID partitions.");
+}
+
+1;

--- a/tests/autoyast/verify_disk_as_md_member_clone.pm
+++ b/tests/autoyast/verify_disk_as_md_member_clone.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Validate if generated autoyast profile corresponds to the expected one
+#          when using disks as Multiple Device member.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+use strict;
+use warnings;
+use base 'basetest';
+use testapi;
+use xml_utils;
+use scheduler 'get_test_data';
+use Test::Assert ':all';
+use autoyast 'init_autoyast_profile';
+
+sub run {
+    my $test_data = get_test_data();                     # get test data from scheduling yaml file
+    my $xpc       = get_xpc(init_autoyast_profile());    # get XPathContext
+
+    record_info('RAID level', 'Verify that raid level in the generated autoyast profile corresponds to the expected one.');
+    my @raid_level_nodes = find_nodes(xpc => $xpc, xpath => $test_data->{xpath}->{raid_type});
+    assert_equals($test_data->{raid_level}, $raid_level_nodes[0]->to_literal, 'Wrong raid level is specified for the MD.');
+
+    record_info('Mount points', 'Verify that generated autoyast profile contains the the expected number of mount points.');
+    my @mount_point_nodes = find_nodes(xpc => $xpc, xpath => $test_data->{xpath}->{mount});
+    assert_equals($test_data->{partitions_count}, scalar @mount_point_nodes, 'MD RAID contains wrong number of mount points.');
+}
+
+1;

--- a/tests/autoyast/verify_disk_as_pv_clone.pm
+++ b/tests/autoyast/verify_disk_as_pv_clone.pm
@@ -16,19 +16,13 @@ use base 'basetest';
 use testapi;
 use xml_utils;
 use y2_module_consoletest;
+use autoyast 'init_autoyast_profile';
 
 #Xpath parser
 my $xpc;
 
 sub test_setup {
-    select_console('root-console');
-    my $profile_path = '/root/autoinst.xml';
-    # Generate pofile if doesn't exist
-    if (script_run("[ -e $profile_path ]")) {
-        my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'clone_system');
-        wait_serial("$module_name-0", 60) || die "'yast2 clone_system' exited with non-zero code";
-    }
-    my $autoinst = script_output("cat $profile_path");
+    my $autoinst = init_autoyast_profile();
     # get XPathContext
     $xpc = get_xpc($autoinst);
 }


### PR DESCRIPTION
The PR adds all the required perl modules and the yaml schedule to test autoyast installation while using disk as MD member.

- Related ticket: https://progress.opensuse.org/issues/42731
- Verification run: http://oorlov-vm.qa.suse.de/tests/1035
- Verification run for autoyast_disk_as_pv (as the changes may affect the scenario): http://10.160.65.138/tests/1122

**After being merged, the PR requires the following configuration to be updated on openQA:**

Test Suites:

- Name: `autoyast_disk_as_md_member`
- Settings:

```
HDDMODEL=scsi-hd
NUMDISKS=2
YAML_SCHEDULE=schedule/yast/autoyast_disk_as_md_member.yaml
```

Job Groups->SLE15->YaST->new test:

- Test: `autoyast_disk_as_md_member`
- x86_64
