### PR TITLE
wicked: Use :DEFAULT exports of serial_terminal

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -17,7 +17,7 @@ use utils qw(systemctl file_content_replace zypper_call);
 use network_utils;
 use lockapi;
 use testapi qw(is_serial_terminal :DEFAULT);
-use serial_terminal 'upload_file';
+use serial_terminal;
 use Carp;
 use Mojo::File 'path';
 

--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -16,7 +16,7 @@ use warnings;
 use testapi;
 use utils qw(zypper_call systemctl file_content_replace);
 use network_utils qw(iface setup_static_network);
-use serial_terminal 'add_serial_console';
+use serial_terminal;
 
 sub run {
     my ($self, $ctx) = @_;


### PR DESCRIPTION
We missed a include:
  Undefined subroutine &wickedbase::serial_term_prompt

Jobs failing on O3 https://openqa.opensuse.org/tests/984521#step/t01_basic/2

- Verification run: https://openqa.opensuse.org/t984673 (running)
