### PR TITLE
Fix sporadic issues with key presses for yast2 tftf and samba test modules

### DIFF
--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -127,7 +127,8 @@ sub setup_yast2_auth_server {
 
     assert_screen 'yast2_ldap_configuration_stand-alone_tls';
     # move to next page basic database settings and set base dn, ldap admin password
-    wait_screen_change { send_key 'alt-n' };
+    send_key 'alt-n';
+    assert_screen 'yast2_ldap_basic_db_configuration';
     wait_screen_change { send_key 'alt-s' };
     type_string($ldap_directives{dn_container});
     wait_screen_change { send_key 'alt-a' };

--- a/tests/console/yast2_tftp.pm
+++ b/tests/console/yast2_tftp.pm
@@ -59,11 +59,12 @@ sub run {
         assert_screen 'yast2_tftp_open_port';
         send_key $firewall_detail_shortcut;    # open firewall details window
         assert_screen 'yast2_tftp_firewall_details';
-        send_key 'alt-o';                      # close the window
+        send_key 'alt-o';                        # close the window
+        assert_screen 'yast2_tftp_open_port';    # assert that window is closed
     }
 
     # view log
-    send_key 'alt-v';                          # open log window
+    send_key 'alt-v';                            # open log window
 
     # bsc#1008493 is still open, but error pop-up doesn't always appear immediately
     # so wait still screen before assertion


### PR DESCRIPTION
In #7802 we have removed `assert_screen` call after we open firewall
details dialog. After that we open logs dialog, but press key to early
as previous dialog is still open.
With this PR, we assert that we got to the original screen before the
key press.
For samba module we have `wait_screen_change` wrapper which is not solving the issue with key presses sync. Extra needle was created using openQA webui.

See [poo#53972](https://progress.opensuse.org/issues/53972).

#### Verification runs
* [yast2_tftp](http://f174.suse.de/tests/271#)
* [yast2_samba](http://f174.suse.de/tests/269)