### PR TITLE
oomath: Type slow in auto-evaluated text field to prevent mistyping

### DIFF
--- a/tests/x11/oomath.pm
+++ b/tests/x11/oomath.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -12,7 +12,7 @@
 # Maintainer: Oliver Kurz <okurz@suse.de>
 # Tags: https://bugs.freedesktop.org/show_bug.cgi?id=42301
 
-use base "x11test";
+use base 'x11test';
 use strict;
 use warnings;
 use testapi;
@@ -23,17 +23,16 @@ sub run {
     wait_still_screen(1);
 
     # test broken undo
-    send_key "shift-left";
-    send_key "2";
+    send_key 'shift-left';
+    send_key '2';
     # undo produces "12" instead of "1"
-    wait_screen_change { send_key "ctrl-z" };
-    assert_screen [qw(test-oomath-1 oomath-bsc1127895)], 3;
+    send_key 'ctrl-z';
+    assert_screen [qw(test-oomath-1 oomath-bsc1127895)];
     if (match_has_tag('oomath-bsc1127895')) {
         record_soft_failure 'bsc#1127895';
-        send_key "alt-f4";
+        send_key 'alt-f4';
     } else {
-        wait_screen_change { send_key "alt-f4" };
-        assert_screen 'oomath-prompt', 5;
+        send_key 'alt-f4';
         assert_and_click 'dont-save-libreoffice-btn';    # _Don't save
     }
 }

--- a/tests/x11/oomath.pm
+++ b/tests/x11/oomath.pm
@@ -16,10 +16,13 @@ use base 'x11test';
 use strict;
 use warnings;
 use testapi;
+use utils 'type_string_slow';
 
 sub run {
     x11_start_program('oomath');
-    type_string "E %PHI = H %PHI\nnewline\n1 = 1";
+    # be more resilient during the automatic evaluation of formulas to prevent
+    # mistyping
+    type_string_slow "E %PHI = H %PHI\nnewline\n1 = 1";
     wait_still_screen(1);
 
     # test broken undo


### PR DESCRIPTION
Verification run: https://openqa.opensuse.org/tests/984498#step/oomath/4

Related progress issue: https://progress.opensuse.org/issues/53795