### PR TITLE
Enable debugging for boot_linuxrc test module

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -538,7 +538,7 @@ sub select_bootmenu_more {
     }
     send_key_until_needlematch($tag, get_var('OFW') ? 'up' : 'down', 10, 3);
     # Redirect linuxrc logs to console when booting from menu: "boot linux system"
-    push @params, "linuxrc.log=/dev/$serialdev" if get_var('LINUXRC_BOOT');
+    push @params, "linuxrc.log=/dev/$serialdev linuxrc.debug=4,trace linuxrc.core=/dev/$serialdev" if get_var('LINUXRC_BOOT');
     if (get_var('UEFI')) {
         send_key 'e';
         send_key 'down' for (1 .. 4);
@@ -550,11 +550,13 @@ sub select_bootmenu_more {
         # Hyper-V defaults to 1280x1024, we need to fix it here
         push @params, get_hyperv_fb_video_resolution if check_var('VIRSH_VMM_FAMILY', 'hyperv');
         type_string_very_slow(" @params ");
+        save_screenshot;
         send_key 'f10';
     }
     else {
         push @params, get_hyperv_fb_video_resolution if check_var('VIRSH_VMM_FAMILY', 'hyperv');
         type_string_very_slow(" @params ");
+        save_screenshot;
         send_key 'ret';
     }
     return @params;

--- a/tests/boot/boot_linuxrc.pm
+++ b/tests/boot/boot_linuxrc.pm
@@ -10,13 +10,14 @@
 # Summary: Test the ability to boot installed linux from cd with linuxrc.
 # Maintainer: Jonathan Rivrain <jrivrain@suse.com>
 
-use base "opensusebasetest";
+use base "bootbasetest";
 use strict;
 use warnings;
 use testapi;
 use bootloader_setup qw(select_bootmenu_more ensure_shim_import);
 
 sub run {
+    my ($self) = @_;
     ensure_shim_import;
     select_bootmenu_more('inst-boot_linuxrc', 1);
     for (1 .. 3) {
@@ -25,6 +26,16 @@ sub run {
     }
     assert_screen "edit_kernel_options";
     send_key "ret";
+    assert_screen "edit_kexec_options";
+    # The kexec step is triggered wnen we put debug options, and proposes a
+    # default option that never works, --real-mode. we have to remove it
+    if (check_screen "kexec_opt_realmode") {
+        record_soft_failure 'bsc#1141875';
+        for (0 .. 11) { send_key "backspace" }
+        save_screenshot;
+    }
+    send_key "ret";
+    $self->{in_boot_desktop} = 1;
     assert_screen([qw(linux-login displaymanager generic-desktop)], 180);
 }
 


### PR DESCRIPTION
As follow-up for poo#10654, a new test was created for linuxrc to boot from the installer's boot menu, see https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7823.
The current change adds:

Linuxrc debug output  sent to console 
Uses post_fail_hook from bootbasetest, like boot_to_desktop.
Workaround for https://bugzilla.suse.com/show_bug.cgi?id=1141875



- Related ticket: https://progress.opensuse.org/issues/54014
- Needles: 
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/573
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1192

- Verification runs:
[sle12sp5 x86_64](https://openqa.suse.de/tests/3130747)
[TW x86_64](https://openqa.opensuse.org/t991111)

