### PR TITLE
Don't require QA web repository

### DIFF
--- a/lib/repo_tools.pm
+++ b/lib/repo_tools.pm
@@ -42,6 +42,7 @@ our @EXPORT = qw(
     add_qa_head_repo();
 
 Helper to add QA:HEAD repository repository (usually from IBS).
+This repository *is* mandatory.
 =cut
 sub add_qa_head_repo {
     zypper_ar(get_required_var('QA_HEAD_REPO'), name => 'qa-head', no_gpg_check => 1);
@@ -52,9 +53,11 @@ sub add_qa_head_repo {
     add_qa_web_repo();
 
 Helper to add QA web repository repository.
+This repository is *not* mandatory.
 =cut
 sub add_qa_web_repo {
-    zypper_ar(get_required_var('QA_WEB_REPO'), name => 'qa-web', no_gpg_check => 1);
+    my $repo = get_var('QA_WEB_REPO');
+    zypper_ar($repo, name => 'qa-web', no_gpg_check => 1) if ($repo);
 }
 
 =head2 get_repo_var_name


### PR DESCRIPTION
Unlike QA head repository, QA web repository is not mandatory.
Thus we cannot require QA_WEB_REPO.

Fixes: f1c4edc7e repo_tools: Add add_qa_{head,web}_repo() and use it

Reported-by: Petr Cervinka <pcervinka@suse.com>