### PR TITLE
add_suseconnect_product should handle retries

### DIFF
--- a/tests/console/machinery.pm
+++ b/tests/console/machinery.pm
@@ -25,10 +25,7 @@ sub run {
     if (is_sle) {
         assert_script_run 'source /etc/os-release';
         if (is_sle '>=15') {
-            if (script_run('SUSEConnect -p PackageHub/${VERSION_ID}/${CPU}', 300) != 0) {
-                record_soft_failure 'bsc#1124318 - Fail to get PackageHub Pool Metadata - running the command again as a workaround';
-                add_suseconnect_product('PackageHub', undef, undef, undef, 300);
-            }
+            add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1);
         }
         else {
             register_product();

--- a/tests/sysauth/sssd.pm
+++ b/tests/sysauth/sssd.pm
@@ -29,10 +29,7 @@ sub run {
     if (is_sle) {
         assert_script_run 'source /etc/os-release';
         if (is_sle '>=15') {
-            if (script_run('SUSEConnect -p PackageHub/${VERSION_ID}/${CPU}', 300) != 0) {
-                record_soft_failure 'bsc#1124318 - Fail to get PackageHub Pool Metadata - running the command again as a workaround';
-                assert_script_run 'SUSEConnect -p PackageHub/${VERSION_ID}/${CPU}', 300;
-            }
+            add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1);
             add_suseconnect_product('sle-module-legacy');
         }
     }


### PR DESCRIPTION
see https://progress.opensuse.org/issues/50336
verification run:

http://f40.suse.de/tests/4388#step/product_migration/ (still working)
http://f40.suse.de/tests/4338#step/sssd/8 (code change works for sssd which
is the original test case)
http://f40.suse.de/tests/4388#step/prepare/4
