### PR TITLE
Fix for kiwi builds.

### DIFF
--- a/tests/kiwi_images_test/kiwi_boot.pm
+++ b/tests/kiwi_images_test/kiwi_boot.pm
@@ -8,6 +8,12 @@
 # without any warranty.
 
 # Summary: Boot kiwi live or oem image
+# - at bootloader screen, manipulate grub to stop timeout
+# - checks if imagem is based on old kiwi and is oem type
+# - in this case, press down key 16 times and accept option (hard drive, not
+# ramdisk)
+# - confirm installation procedure and wait for login screen
+# - if not old kiwi & oem, just press ENTER and wait for login screen
 # Maintainer: Ednilson Miura <emiura@suse.com>
 
 use base "installbasetest";
@@ -40,12 +46,12 @@ sub run {
         send_key 'ret';
         assert_screen('kiwi_oem_install_confirm', 1200);
         send_key 'ret';
-        assert_screen('kiwi_login', 1200);
+        assert_screen('linux-login', 1200);
     }
     else {
         assert_screen('kiwi_boot', 15);
         send_key 'ret';
-        assert_screen('kiwi_login', 1000);
+        assert_screen('linux-login', 1000);
     }
 }
 1;

--- a/tests/kiwi_images_test/login_reboot.pm
+++ b/tests/kiwi_images_test/login_reboot.pm
@@ -8,6 +8,9 @@
 # without any warranty.
 
 # Summary: Login and reboot a kiwi image
+# - at login screen, type user and password
+# - after login, reboots machine
+# - makes sure image rebooted and is at login screen again
 # Maintainer: Ednilson Miura <emiura@suse.com>
 
 use base "installbasetest";
@@ -30,6 +33,6 @@ sub run {
     send_key 'up';
     assert_screen('kiwi_boot', 120);
     send_key 'ret';
-    assert_screen('kiwi_login', 120);
+    assert_screen('linux-login', 120);
 }
 1;


### PR DESCRIPTION
Requires needle from
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1191

Also fixed a newly found issue (after the needle above fixed the test failure) that
was caused by the build names not matching anymore.

Updated summary description as per manager request.

Test run at:
http://10.161.229.180/tests/2017
http://10.161.229.180/tests/2016
http://10.161.229.180/tests/2015

Fixes poo#54359 - [QAM] test fails in kiwi_boot
