### PR TITLE
In scc_registration we send wrong key for local smt migration server.

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -679,7 +679,7 @@ sub fill_in_reg_server {
     else {
         send_key "alt-i";
         # Fresh install sles12sp2/3/4/5 shortcut is different with upgrade version
-        if ((is_sle('12-sp2+') && is_sle('<15') && (get_var('UPGRADE') || get_var('ONLINE_MIGRATION'))) || is_sle('>=15')) {
+        if ((is_sle('12-sp2+') && is_sle('<12-sp5') && (get_var('UPGRADE') || get_var('ONLINE_MIGRATION'))) || is_sle('>=15')) {
             send_key "alt-l";
         }
         else {


### PR DESCRIPTION
In sle12sp4 to sle12sp5 migration, we send wrong key 'alt-l' to trigger the release note{alt-l}, 
which should be 'alt-o'.

- Related ticket: https://progress.opensuse.org/issues/54164
- Needles: No.
- Verification run: http://openqa.suse.de/tests/3082796#step/scc_registration/3
