### PR TITLE
btrfs-progs: Add info into failed and skipped log

### DIFF
--- a/lib/ctcs2_to_junit.pm
+++ b/lib/ctcs2_to_junit.pm
@@ -122,6 +122,19 @@ sub generateXML {
                 $writer->endTag('system-err');
             }
         }
+        if ((get_var('BTRFS_PROGS')) && ($case_status eq 'failure' || $case_status eq 'skipped')) {
+            (my $test_path = $test) =~ s/-/\//;
+            $test_path = '/opt/logs/' . $test_path . '.txt';
+            my $test_out_content = script_output("
+                if [ -f $test_path ];
+                    then sed -n -e \"s/'//g\" -e 's/[^[:print:]\\r\\t\\n]//g' -e '1!H;/====== RUN /h;\${g;p;}' $test_path | head -n 100;
+                else echo 'Test Crashed, find log in serial0.txt';
+                fi
+            ", 600);
+            $writer->startTag('system-out');
+            $writer->characters($test_out_content);
+            $writer->endTag('system-out');
+        }
         $writer->endTag('testcase');
     }
 


### PR DESCRIPTION
Check out test result from test log file is inconvenient. So this PR do as below:
Get last 100 lines from btrfs-progs log file for failed and skipped test, and generate junit xml report.

- Verification run: http://10.67.133.10/tests/425
