### PR TITLE
After migration, do re-register only for some particular modules

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -198,7 +198,7 @@ sub register_addons_cmd {
     my @addons = grep { defined $_ && $_ } split(/,/, $addonlist);
     foreach my $addon (@addons) {
         my $name = get_addon_fullname($addon);
-        if ($name =~ /module/) {
+        if ($name =~ /adv|containers|legacy|toolchain|web-scripting|public-cloud/) {
             my @ver = split(/\./, scc_version());
             add_suseconnect_product($name, $ver[0]);
         }
@@ -211,8 +211,11 @@ sub register_addons_cmd {
         elsif ($name =~ /LTSS/) {
             add_suseconnect_product($name, undef, undef, "-r " . get_var('SCC_REGCODE_LTSS'));
         }
-        else {
+        elsif ($name =~ /sdk/) {
             add_suseconnect_product($name);
+        }
+        else {
+            next;
         }
     }
 }

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -42,7 +42,7 @@ sub run {
     # Register the modules after media migration, only for sle<15
     # poo#54131 [SLE][Migration][SLE12SP5]test fails in system_prepare -
     # media upgrade need add modules after migration
-    if (get_var('SCC_ADDONS') && is_sle('<15') && get_var('MEDIA_UPGRADE')) {
+    if (get_var('SCC_ADDONS') && is_sle('<15') && get_var('MEDIA_UPGRADE') && get_var('KEEP_REGISTERED')) {
         assert_script_run 'SUSEConnect --url ' . get_required_var('SCC_URL') . ' -r ' . get_required_var('SCC_REGCODE');
         my $myaddons = get_var('SCC_ADDONS');
         # After media upgrade, system don't include ltss extension


### PR DESCRIPTION
After migration, do re-register only for sdk, live patching , WE, web-script, container, legacy, toolchain, public cloud, adv. System Mgmt 

- Related ticket: https://progress.opensuse.org/issues/54131
- Verification run: 
http://10.161.8.44/tests/197#
Not impact HA case: http://10.161.8.44/tests/196
