### PR TITLE
Fix shibboleth and apache basic auth problem

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1045,6 +1045,7 @@ sub load_console_server_tests {
     }
     loadtest "console/rsync";
     loadtest "console/http_srv";
+    loadtest "console/apache";
     loadtest "console/dns_srv";
     loadtest "console/postgresql_server" unless (is_leap('<15.0'));
     # TODO test on openSUSE https://progress.opensuse.org/issues/31972

--- a/tests/console/apache.pm
+++ b/tests/console/apache.pm
@@ -129,7 +129,7 @@ sub run {
     assert_script_run 'touch /srv/www/vhosts/localhost/authtest/.htpasswd';
     assert_script_run 'chmod 640 /srv/www/vhosts/localhost/authtest/.htpasswd';
     assert_script_run 'chown root:www /srv/www/vhosts/localhost/authtest/.htpasswd';
-    assert_script_run 'htpasswd2 -b /srv/www/vhosts/localhost/authtest/.htpasswd joe secret';
+    assert_script_run 'htpasswd2 -s -b /srv/www/vhosts/localhost/authtest/.htpasswd joe secret';
 
     # Paste the .htaccess file
     assert_script_run "echo 'AuthType Basic

--- a/tests/console/shibboleth.pm
+++ b/tests/console/shibboleth.pm
@@ -26,5 +26,8 @@ sub run {
     assert_script_run "curl --no-buffer http://localhost/Shibboleth.sso/Status | grep 'Cannot connect to shibd process'";
 
     assert_script_run "curl --no-buffer http://localhost/Shibboleth.sso/Session | grep 'A valid session was not found.'";
+
+    assert_script_run "a2dismod shib";
 }
+
 1;


### PR DESCRIPTION
After installing Shibboleth into Apache the basic auth does not work correctly - this PR is fixing it.

- Verification run: [Tumbleweed](http://pdostal-server.suse.cz/tests/3565) [SLES12sp3](http://pdostal-server.suse.cz/tests/3567) [SLES12sp4](http://pdostal-server.suse.cz/tests/3566) [SLES15](http://pdostal-server.suse.cz/tests/3568) [SLES15sp1](http://pdostal-server.suse.cz/tests/3569)