### PR TITLE
finish_desktop: post_fail_hook: Also list branding packages

### DIFF
--- a/tests/installation/finish_desktop.pm
+++ b/tests/installation/finish_desktop.pm
@@ -35,6 +35,9 @@ sub post_fail_hook {
     my $self = shift;
 
     $self->export_logs();
+
+    # Also list branding packages (help to debug desktop branding issues)
+    $self->save_and_upload_log('zypper --no-refresh se *branding*', '/tmp/list_branding_packages.txt', {screenshot => 1});
 }
 
 1;


### PR DESCRIPTION
This will help to debug branding problems.

- Verification run: https://openqa.opensuse.org/t985745