### PR TITLE
Fix boot from cdrom for svirt/libvirt using qemu

### DIFF
--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -82,11 +82,13 @@ sub run {
     if (check_var('BOOTFROM', 'c')) {
         $boot_device = 'hd';
     }
-    elsif (check_var('BOOTFROM', 'd')) {
+    elsif (check_var('BOOTFROM', 'd') || (get_var('ISO') && !get_var('BOOT_HDD_IMAGE'))) {
         $boot_device = 'cdrom';
-    }
-    else {
-        get_var('ISO') ? $boot_device = 'cdrom' : $boot_device = 'hd';
+    } else {
+        record_info("No boot medium", "Failed to select a bootable medium, please check ISO,"
+              . "BOOT_FROM and BOOT_HDD_IMAGE settings",
+            result => 'fail'
+        );
     }
     # Does not make any difference on VMware. For ad hoc device selection
     # see vmware_select_boot_device_from_menu().

--- a/tests/installation/bootloader_svirt.pm
+++ b/tests/installation/bootloader_svirt.pm
@@ -82,7 +82,7 @@ sub run {
     if (check_var('BOOTFROM', 'c')) {
         $boot_device = 'hd';
     }
-    elsif (check_var('BOOTFROM', 'd') || (get_var('ISO') && !get_var('BOOT_HDD_IMAGE'))) {
+    elsif (check_var('BOOTFROM', 'd') || get_var('ISO')) {
         $boot_device = 'cdrom';
     } else {
         record_info("No boot medium", "Failed to select a bootable medium, please check ISO,"


### PR DESCRIPTION
When starting a job that will boot from cdrom using svirt but with qemu instead of xen or hyperv, the SUT will try to still boot from HDD, somehow removing the ternary operator fixes the problem... I guess that it has to do somehow with the hdd being a virtio device and not a the more traditional ide device. 

Before: http://phobos.suse.de/tests/1747939#step/bootloader/2

Passing (booting from ISO): http://phobos.suse.de/tests/1747959
Failing (Neither HDD nor ISO defined): http://phobos.suse.de/tests/1747961

Progress ticket: https://progress.opensuse.org/issues/45326
