### PR TITLE
Check is_server for migration cases

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -40,6 +40,7 @@ use constant {
           is_rescuesystem
           is_sles4sap
           is_sles4sap_standard
+          is_sles4migration
           is_released
           is_rt
           is_hpc
@@ -238,6 +239,10 @@ sub is_transactional {
     return check_var('SYSTEM_ROLE', 'serverro');
 }
 
+sub is_sles4migration {
+    return get_var('FLAVOR', '') =~ /Migration|migrated/ && check_var('SLE_PRODUCT', 'sles');
+}
+
 sub is_sles4sap {
     return get_var('FLAVOR', '') =~ /SAP/ || check_var('SLE_PRODUCT', 'sles4sap');
 }
@@ -293,6 +298,7 @@ sub is_aarch64_uefi_boot_hdd {
 
 sub is_server {
     return 1 if is_sles4sap();
+    return 1 if is_sles4migration();
     return 1 if get_var('FLAVOR', '') =~ /^Server/;
     # If unified installer, we need to check SLE_PRODUCT
     return 0 if get_var('FLAVOR', '') !~ /^Installer-/;


### PR DESCRIPTION
Checked the code, as gnome-music should be implement only if product is not a server or product is a server but include WE.
But as our flavor name has changed, its not following the name rules. We need check our case with new condition for is_server function

- Related ticket: https://progress.opensuse.org/issues/54398
- Verification run: 
SLES without WE: http://10.161.8.44/tests/199#
SLES with WE: http://10.161.8.44/tests/198#
As the code:
if (is_sle && (!is_server || we_is_applicable)) {
            loadtest "x11/eog";
            loadtest(is_sle('<15') ? "x11/rhythmbox" : "x11/gnome_music");
            loadtest "x11/wireshark";
            loadtest "x11/ImageMagick";
            loadtest "x11/ghostscript";
}
SLES without WE will not include up cases (eog, gnome_music, wireshark,ImageMagick, ghostscript).
SLES with WE will include up cases  (eog, gnome_music, wireshark,ImageMagick, ghostscript).
