### PR TITLE
PublicCloud: push storage results to influx db

### DIFF
--- a/tests/publiccloud/boottime.pm
+++ b/tests/publiccloud/boottime.pm
@@ -133,7 +133,7 @@ sub run {
             tags   => $tags,
             values => $startup_timings
         };
-        $data = influxdb_query($url, $data);
+        $data = influxdb_push_data($url, 'publiccloud', $data);
     }
 
     # Validate bootup timing against hard limits
@@ -164,7 +164,7 @@ All values are stored in a influx db.
 
 =head2 PUBLIC_CLOUD_PERF_DB_URI
 
-If this variable is set, the bootup timings get stored inside the influx
+Optional variable. If set, the bootup times get stored in the influx
 database. The database name is 'publiccloud'.
 (e.g. PUBLIC_CLOUD_PERF_DB_URI=http://openqa-perf.qa.suse.de:8086)
 


### PR DESCRIPTION
1) Fix db_utils when generating the curl command adding the database name. 
2) Fix call in boottime.pm to this function to include the database name as parameter
3) Parse FIO results and push them to Influx DB using the same mechanism.

- Related ticket: https://progress.opensuse.org/issues/51779
- VRs:
    GCE: http://fromm.arch.suse.de/tests/6717
    EC2: http://fromm.arch.suse.de/tests/6715
    Azure: http://fromm.arch.suse.de/tests/6716

Perf Dashboard: http://openqa-perf.qa.suse.de/d/hoRc37HWz/storage-performance