### PR TITLE
HPC: Add basic MPI tests

### DIFF
--- a/data/simple_mpi.c
+++ b/data/simple_mpi.c
@@ -1,0 +1,17 @@
+#include <mpi.h>
+#include <stdio.h>
+
+int
+main(int argc, char *argv[])
+{
+    int rank, size;
+    MPI_Init(&argc, &argv);
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    printf("Hello, World.  I am %d of %d\n", rank, size);
+
+    MPI_Finalize();
+    return 0;
+}

--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -152,6 +152,14 @@ sub distribute_slurm_conf {
     }
 }
 
+sub generate_and_distribute_ssh {
+    my @cluster_nodes = cluster_names();
+    assert_script_run('ssh-keygen -b 2048 -t rsa -q -N "" -f ~/.ssh/id_rsa');
+    foreach (@cluster_nodes) {
+        exec_and_insert_password("ssh-copy-id -o StrictHostKeyChecking=no root\@$_");
+    }
+}
+
 sub check_nodes_availability {
     my @cluster_nodes = cluster_names();
     foreach (@cluster_nodes) {

--- a/tests/hpc/barrier_init.pm
+++ b/tests/hpc/barrier_init.pm
@@ -55,6 +55,11 @@ sub run {
         barrier_create("GANGLIA_GMETAD_STARTED", $nodes);
         barrier_create("GANGLIA_GMOND_STARTED",  $nodes);
     }
+    elsif (check_var("HPC", "mpi")) {
+        barrier_create("MPI_SETUP_READY",    $nodes);
+        barrier_create("MPI_BINARIES_READY", $nodes);
+        barrier_create("MPI_RUN_TEST",       $nodes);
+    }
     elsif (check_var("HPC", "hpc_comprehensive")) {
         barrier_create("HPC_MASTER_SERVICES_ENABLED", $nodes);
         barrier_create("HPC_SLAVE_SERVICES_ENABLED",  $nodes);

--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -1,0 +1,92 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017-2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Basic MPI integration test. Checking for installability and
+# usability of mpirun and mpicc. Using mpirun locally and across
+# available nodes
+# Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
+
+use base "hpcbase";
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use utils;
+use registration qw(add_suseconnect_product get_addon_fullname);
+use version_utils 'is_sle';
+
+sub run {
+    my $self          = shift;
+    my $version       = get_required_var("VERSION");
+    my $arch          = get_required_var("ARCH");
+    my $nodes         = get_required_var("CLUSTER_NODES");
+    my $mpi           = get_required_var("MPI");
+    my $mpi_c         = "simple_mpi.c";
+    my @cluster_nodes = $self->cluster_names();
+    my $cluster_nodes = join(',', @cluster_nodes);
+    $version =~ s/-SP/./;
+
+    add_suseconnect_product(get_addon_fullname('sdk'), $version, $arch);
+    ## as the test code requires compilation, it should be possible to install required compilers
+    if (is_sle '<15') {
+        zypper_call("ar -f http://download.suse.de/ibs/SUSE/Products/SLE-Module-Toolchain/12/$arch/product/ SLE-Module-Toolchain12-Pool");
+        zypper_call("ar -f http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Toolchain/12/$arch/update/ SLE-Module-Toolchain12-Updates");
+    } else {
+        add_suseconnect_product("sle-module-development-tools");
+    }
+
+    zypper_call("in gcc");
+    zypper_call("in $mpi $mpi-devel");
+    assert_script_run("export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:/usr/lib64/mpi/gcc/$mpi/lib64/");
+
+    ## all nodes should be able to ssh to each other, as MPIs requires so
+    $self->generate_and_distribute_ssh();
+
+    barrier_wait("MPI_SETUP_READY");
+    $self->check_nodes_availability();
+
+    assert_script_run("wget --quiet " . data_url($mpi_c) . " -O /tmp/$mpi_c");
+    assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpicc /tmp/simple_mpi.c -o /tmp/simple_mpi | tee /tmp/make.out");
+
+    ## distribute the binary
+    foreach (@cluster_nodes) {
+        assert_script_run("scp -o StrictHostKeyChecking=no /tmp/simple_mpi root\@$_\:/tmp/simple_mpi");
+    }
+    barrier_wait("MPI_BINARIES_READY");
+
+    record_info('Run MPI over single machine');
+    ## openmpi requires non-root usr to run program or special flag '--allow-run-as-root'
+    if ($mpi eq 'openmpi') {
+        assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpirun --allow-run-as-root /tmp/simple_mpi");
+    } else {
+        assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpirun /tmp/simple_mpi | tee /tmp/mpirun.out");
+    }
+
+    record_info('Run MPI over several nodes');
+    if ($mpi eq 'openmpi') {
+        assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpirun --allow-run-as-root --host $cluster_nodes  /tmp/simple_mpi");
+    } else {
+        assert_script_run("/usr/lib64/mpi/gcc/$mpi/bin/mpirun --host $cluster_nodes /tmp/simple_mpi");
+    }
+
+    barrier_wait("MPI_RUN_TEST");
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+sub post_fail_hook {
+    my $self = shift;
+    upload_logs('/tmp/make.out');
+    upload_logs('/tmp/mpirun.out');
+    $self->export_logs();
+}
+
+1;

--- a/tests/hpc/mpi_slave.pm
+++ b/tests/hpc/mpi_slave.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017-2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: openmpi mpirun check
+# Maintainer: Sebastian Chlad <sebastian.chlad@suse.com>
+
+use base "hpcbase";
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use utils;
+
+sub run {
+    my $self = shift;
+    my $mpi  = get_required_var("MPI");
+
+    zypper_call("in $mpi");
+
+    barrier_wait("MPI_SETUP_READY");
+    barrier_wait("MPI_BINARIES_READY");
+    barrier_wait("MPI_RUN_TEST");
+}
+
+sub test_flags {
+    return {fatal => 1, milestone => 1};
+}
+
+sub post_fail_hook {
+    my ($self) = @_;
+}
+
+1;


### PR DESCRIPTION
The tests are meant to check basic functionality of MPIs where the
respective, supported versions of MPIs are installed, very basic
C programm is compiled and executed

- Verification run:
http://10.160.65.14/tests/2350
http://10.160.65.14/tests/2351
http://10.160.65.14/tests/2352
http://10.160.65.14/tests/2349
