### PR TITLE
Add support for VPN+SSH based remote test execution for poo#49901

### DIFF
--- a/lib/Utils/Backends.pm
+++ b/lib/Utils/Backends.pm
@@ -128,7 +128,7 @@ sub is_svirt_except_s390x {
     return !get_var('S390_ZKVM') && check_var('BACKEND', 'svirt');
 }
 
-=head2 is_spvm 
+=head2 is_spvm
 
 Returns true if the current instance is running as PowerVM backend 'spvm'
 

--- a/schedule/remote_lab_poc.yaml
+++ b/schedule/remote_lab_poc.yaml
@@ -1,0 +1,7 @@
+name:           remote_lab_poc
+description:    >
+    https://progress.opensuse.org/issues/49901
+schedule:
+     - remote_lab/setup_vpn
+     - remote_lab/connect_vpn
+     - remote_lab/poc

--- a/tests/remote_lab/connect_vpn.pm
+++ b/tests/remote_lab/connect_vpn.pm
@@ -1,0 +1,38 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Connect VPN to a remote lab using openconnect
+# Maintainer: Oliver Kurz <okurz@suse.de>
+# Tags: https://progress.opensuse.org/issues/49901
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+    my $vpn_username = get_required_var('VPN_USERNAME');
+    my $vpn_endpoint = get_var('VPN_ENDPOINT', 'asa003b.centers.ihost.com');
+    my $vpn_group    = get_var('VPN_GROUP',    'ACC');
+    # nohup should already go to background but during test development I
+    # observed that it still blocked the terminal – regardless of e.g. using a
+    # virtio serial terminal or VNC based – so let's force it to the
+    # background.
+    # accessing shell variables for the (secret) passwords defined in setup_vpn.
+    script_run "(echo \$vpn_password | nohup openconnect --user=$vpn_username --passwd-on-stdin --authgroup=$vpn_group $vpn_endpoint > vpn.log &)", 0;
+    wait_serial 'Welcome to the IBM Systems WW Client Experience Center';
+}
+
+sub post_fail_hook {
+    upload_logs 'vpn.log';
+}
+
+1;

--- a/tests/remote_lab/poc.pm
+++ b/tests/remote_lab/poc.pm
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Proof-of-concept of connecting to a remote lab hardware for test
+#   execution
+# Maintainer: Oliver Kurz <okurz@suse.de>
+# Tags: https://progress.opensuse.org/issues/49901
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+    zypper_call '--no-refresh in --no-recommends sshpass';
+    script_run 'read -s jumpbox_password', 0;
+    type_password get_required_var('_SECRET_JUMPBOX_PASSWORD') . "\n";
+    script_run 'read -s sut_password', 0;
+    type_password get_required_var('_SECRET_SUT_PASSWORD') . "\n";
+    assert_script_run 'ssh-keygen -t ed25519 -N \'\' -f ~/.ssh/id_ed25519';
+    type_string 'cat - > .ssh/config <<EOF
+Host jumpbox
+    HostName 129.40.13.66
+    StrictHostKeyChecking no
+
+Host sut
+    HostName 10.3.1.111
+    ProxyJump jumpbox
+    StrictHostKeyChecking no
+EOF
+';
+    my $cmd = <<'EOF';
+cat ~/.ssh/id_ed25519.pub | sshpass -p $jumpbox_password ssh jumpbox "cat - >> .ssh/authorized_keys"
+cat ~/.ssh/id_ed25519.pub | sshpass -p $sut_password ssh sut "cat - >> .ssh/authorized_keys"
+time ssh sut hostname
+EOF
+    assert_script_run($_) foreach (split /\n/, $cmd);
+    assert_script_run('time ssh sut supportconfig', 600);
+    assert_script_run('ssh sut "cat /var/log/*.tbz" > sut_supportconfig.tbz');
+    upload_logs('sut_supportconfig.tbz');
+}
+
+1;

--- a/tests/remote_lab/setup_vpn.pm
+++ b/tests/remote_lab/setup_vpn.pm
@@ -1,0 +1,33 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Setup VPN to a remote lab using openconnect compatible with Cisco
+#  AnyConnect VPN
+# Maintainer: Oliver Kurz <okurz@suse.de>
+# Tags: https://progress.opensuse.org/issues/49901
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use registration 'add_suseconnect_product';
+use utils;
+use version_utils 'is_sle';
+
+sub run {
+    my ($self) = @_;
+    $self->wait_boot;
+    select_console 'root-console';
+    add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1) if is_sle;
+    zypper_call 'in --no-recommends openconnect';
+    script_run 'read -s vpn_password', 0;
+    type_password get_required_var('_SECRET_VPN_PASSWORD') . "\n";
+}
+
+1;


### PR DESCRIPTION
Necessary test variables:

* HDD_1, e.g. SLES-15-SP1-x86_64-mru-install-minimal-with-addons-Build20190720-1-64bit.qcow2
* VERSION matching the HDD variable, e.g. 15-SP1
* DESKTOP=textmode
* VPN_USERNAME
* _SECRET_VPN_PASSWORD
* _SECRET_JUMPBOX_PASSWORD
* _SECRET_SUT_PASSWORD
* YAML_SCHEDULE=schedule/remote_lab_poc.yaml

Verification run: http://lord.arch.suse.de/tests/2430

Related progress issue: https://progress.opensuse.org/issues/49901