### PR TITLE
Update yast_rdp.pm and add "xrdp" dependence of "yast2-rdp" package

### DIFF
--- a/tests/yast2_cmd/yast_rdp.pm
+++ b/tests/yast2_cmd/yast_rdp.pm
@@ -17,13 +17,12 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils 'is_sle';
 
 sub run {
     select_console 'root-console';
 
     # prepare the setup for test, this test just supports sle15+.
-    zypper_call("in yast2-rdp", exitcode => [0, 102, 103]);
+    zypper_call("in yast2-rdp xrdp", exitcode => [0, 102, 103]);
     systemctl("stop xrdp.service",    ignore_failure => 1);
     systemctl("disable xrdp.service", ignore_failure => 1);
 


### PR DESCRIPTION
running "yast rdp allow set=yes" command took more time (about 450s)
because it installed "xrdp" package automatically,
so I must add the argument "timeout=600" to avoid "test died".

this is the result after updating the code:
https://openqa.suse.de/tests/3105963