### PR TITLE
Minimal patch update also need remove ltss

### DIFF
--- a/tests/migration/sle12_online_migration/minimal_patch.pm
+++ b/tests/migration/sle12_online_migration/minimal_patch.pm
@@ -15,10 +15,12 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use migration;
 
 sub run {
     select_console 'root-console';
     minimal_patch_system(version_variable => 'HDDVERSION');
+    remove_ltss;
 }
 
 sub test_flags {


### PR DESCRIPTION
Minimal patch update also need remove ltss, as ltss cannot do migration 

- Related ticket: https://progress.opensuse.org/issues/54377
- Verification run: 
http://10.161.8.44/tests/203#step/minimal_patch/7
[autoinst-log.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/3416529/autoinst-log.txt)
