### PR TITLE
Take dracut back in functional tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1611,6 +1611,7 @@ sub load_extra_tests_console {
     loadtest 'console/journalctl';
     loadtest 'console/vhostmd';
     loadtest 'console/rpcbind' unless is_jeos;
+    loadtest 'console/dracut' if is_sle('12-SP5+');
     # sysauth test scenarios run in the console
     loadtest "sysauth/sssd" if get_var('SYSAUTHTEST') || is_sle('12-SP5+');
     loadtest 'console/timezone';


### PR DESCRIPTION
see https://progress.opensuse.org/issues/51023
verification test
http://f40.suse.de/tests/4350#step/dracut/29 (sles 12 sp5)
more than 50 test runs on osd shows stable results:
https://progress.opensuse.org/issues/51023
http://f40.suse.de/tests/4390#step/dracut/29 (sles 15 SP1)