### PR TITLE
Verify imported users in autoyast by .bashrc

### DIFF
--- a/schedule/yast/autoyast_reinstall.yaml
+++ b/schedule/yast/autoyast_reinstall.yaml
@@ -1,0 +1,25 @@
+name:           autoyast_reinstall
+description:    >
+    Parent job produces autoyast profile after successful completion. 
+    This test uses generated profile to do autoyast installation.
+schedule:
+    - installation/isosize
+    - installation/bootloader_start
+    - autoyast/installation
+    - autoyast/console
+    - autoyast/login
+    - autoyast/verify_imported_users
+    - autoyast/wicked
+    - autoyast/repos
+    - autoyast/clone
+    - autoyast/logs
+    - autoyast/autoyast_reboot
+    - installation/grub_test
+    - installation/first_boot
+test_data:
+  paths:
+    - /var/lib/gdm/.bashrc
+    - /var/lib/empty/.bashrc
+    - /var/lib/polkit/.bashrc
+    - /var/lib/nobody/.bashrc
+    - /var/lib/pulseaudio/.bashrc

--- a/tests/autoyast/verify_imported_users.pm
+++ b/tests/autoyast/verify_imported_users.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Verify that users are imported and not created when a system is re-installed with autoyast
+# by checking for non-existence of .bashrc in /var/lib/{gdm,empty,polkit,nobody,pulseaudio}.
+# Maintainer: Joaquín Rivera <jeriveramoya@suse.com>
+
+use strict;
+use warnings;
+use base 'consoletest';
+use testapi;
+use scheduler 'get_test_data';
+
+sub run {
+    my $test_data = get_test_data();
+    my $errors;
+    foreach my $path (@{$test_data->{paths}}) {
+        $errors .= "$path should not exist\n" if (!script_run("test -f $path"));
+    }
+    die "Bash profiles created instead of being imported (bsc#1130811):\n $errors" if ($errors);
+    record_info("Import OK", "No wrong .bashrc files found in paths provided");
+}
+
+1;
+


### PR DESCRIPTION
Verify imported users in autoyast by .bashrc.

- Related ticket: https://progress.opensuse.org/issues/50396
- Needles: n/A
- Verification run (on-going): 
  - [sle-15-SP1-Installer-DVD-x86_64-Build228.2-autoyast_reinstall](http://rivera-workstation.suse.cz/tests/81#step/verify_imported_users/11)
  - [sle-15-SP1-Installer-DVD-x86_64-Build228.2-autoyast_reinstall](http://rivera-workstation.suse.cz/tests/82#step/verify_imported_users/14) => Simulating failure