### PR TITLE
Use root-console for KOTD installation on svirt backend

### DIFF
--- a/tests/kernel/install_kotd.pm
+++ b/tests/kernel/install_kotd.pm
@@ -21,7 +21,8 @@ use power_action_utils 'power_action';
 sub run {
     my $self = shift;
     $self->wait_boot;
-    $self->select_serial_terminal;
+    # Use root-console for KOTD installation on svirt instead of root-sut-serial poo#54275
+    check_var('BACKEND', 'svirt') ? select_console('root-console') : $self->select_serial_terminal;
     # Get url of kotd/kmp repositories
     my $kotd_repo = get_required_var('KOTD_REPO');
     my $kmp_repo  = get_var('KMP_REPO');


### PR DESCRIPTION
Fix poo#54275: If is root-sut-serial used for installation, it is not
possible activate it again after system reboot.

- Related ticket: https://progress.opensuse.org/issues/54275
- Needles: None
- Verification run:
s390x-svirt: https://openqa.suse.de/tests/3107764  <- root-console selected
x86_64: https://openqa.suse.de/tests/3107631
ppc64le: https://openqa.suse.de/tests/3107634
aarch64: https://openqa.suse.de/tests/3107635