### PR TITLE
Fix a wrong parameter postion.

### DIFF
--- a/tests/virt_autotest/login_console.pm
+++ b/tests/virt_autotest/login_console.pm
@@ -36,13 +36,16 @@ sub ipmitool {
 }
 
 sub login_to_console {
-    my ($self, $timeout) = @_;
-    $timeout //= 240;
+    my ($self, $timeout, $counter) = @_;
+    $timeout //= 5;
+    $counter //= 240;
+
+
 
     if (check_var('PERF_KERNEL', '1')) {
         reset_consoles;
         select_console 'sol', await_console => 0;
-        send_key_until_needlematch(['linux-login', 'virttest-displaymanager'], 'ret', $timeout, 5);
+        send_key_until_needlematch(['linux-login', 'virttest-displaymanager'], 'ret', $counter, $timeout);
         #use console based on ssh to avoid unstable ipmi
         save_screenshot;
         use_ssh_serial_console;


### PR DESCRIPTION
  send_key_until_needlematch($tag, $key [, $counter, $timeout]);

https://github.com/os-autoinst/os-autoinst/blob/eeddd44bb6701af1350a05bba7bdd5dbe57f6b59/testapi.pm#L1259
