### PR TITLE
In scc_registration we send wrong key for local smt migration server.

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -678,8 +678,12 @@ sub fill_in_reg_server {
     }
     else {
         send_key "alt-i";
-        # Fresh install sles12sp2/3/4/5 shortcut is different with upgrade version
-        if ((is_sle('12-sp2+') && is_sle('<15') && (get_var('UPGRADE') || get_var('ONLINE_MIGRATION'))) || is_sle('>=15')) {
+        # Fresh install sles12sp2/3/4/5 shortcut is different with upgrade version.
+        # We add a workaround for bug bsc#1141962, which was caused by different shortcuts for
+        # patch_sle and scc_register for local smt scenario. So we add IN_PATCH_SLE check for this.
+        send_key "alt-l" if is_sle('>=15');
+        if (is_sle('12-sp2+') && is_sle('<15') && (get_var('UPGRADE') || get_var('ONLINE_MIGRATION'))
+            && check_var('IN_PATCH_SLE', '1')) {
             send_key "alt-l";
         }
         else {


### PR DESCRIPTION
In sle12sp4 to sle12sp5 migration, we send wrong key 'alt-l' to trigger the release note{alt-l},
which should be 'alt-o' for offline SMT tests.

- Related ticket: https://progress.opensuse.org/issues/54164
- Needles: No.
- Verification run: http://openqa.suse.de/tests/3110294 && https://openqa.suse.de/tests/3110293