### PR TITLE
Public Cloud: add storage disk type as parameter

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -24,6 +24,10 @@ variable "extra-disk-size" {
     default = "100"
 }
 
+variable "extra-disk-type" {
+    default = "Premium_LRS"
+}
+
 variable "create-extra-disk" {
     default=false
 }
@@ -154,7 +158,7 @@ resource "azurerm_virtual_machine" "openqa-vm" {
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "default" {
-    count              =  "${var.create-extra-disk ? var.instance_count: 0}"
+    count              = "${var.create-extra-disk ? var.instance_count: 0}"
     managed_disk_id    = "${element(azurerm_managed_disk.ssd_disk.*.id, count.index)}"
     virtual_machine_id = "${element(azurerm_virtual_machine.openqa-vm.*.id, count.index)}"
     lun                = "1"
@@ -162,11 +166,11 @@ resource "azurerm_virtual_machine_data_disk_attachment" "default" {
 }
 
 resource "azurerm_managed_disk" "ssd_disk" {
-  count                =  "${var.create-extra-disk ? var.instance_count: 0}"
+  count                = "${var.create-extra-disk ? var.instance_count: 0}"
   name                 = "ssd-disk-${element(random_id.service.*.hex, count.index)}"
   location             = "${azurerm_resource_group.openqa-group.location}"
   resource_group_name  = "${azurerm_resource_group.openqa-group.name}"
-  storage_account_type = "StandardSSD_LRS"
+  storage_account_type = "${var.extra-disk-type}"
   create_option        = "Empty"
   disk_size_gb         = "${var.extra-disk-size}"
 }

--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -21,7 +21,11 @@ variable "region" {
 }
 
 variable "extra-disk-size" {
-    default = "100"
+    default = "1000"
+}
+
+variable "extra-disk-type" {
+    default = "gp2"
 }
 
 variable "create-extra-disk" {
@@ -91,7 +95,7 @@ resource "aws_ebs_volume" "ssd_disk" {
     count             = "${var.create-extra-disk ? var.instance_count : 0}"
     availability_zone = "${element(aws_instance.openqa.*.availability_zone, count.index)}"
     size              = "${var.extra-disk-size}"
-    type              = "gp2"
+    type              = "${var.extra-disk-type}"
     tags = {
         openqa_created_by = "${var.name}"
         openqa_created_date = "${timestamp()}"

--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -37,7 +37,11 @@ variable "project" {
 }
 
 variable "extra-disk-size" {
-    default = "100"
+    default = "1000"
+}
+
+variable "extra-disk-type" {
+    default = "pd-ssd"
 }
 
 variable "create-extra-disk" {
@@ -92,7 +96,7 @@ resource "google_compute_attached_disk" "default" {
 resource "google_compute_disk" "default" {
     name                      = "ssd-disk-${element(random_id.service.*.hex, count.index)}"
     count                     = "${var.create-extra-disk ? var.instance_count : 0}"
-    type                      = "pd-ssd"
+    type                      = "${var.extra-disk-type}"
     zone                      = "${var.region}"
     size                      = "${var.extra-disk-size}"
     physical_block_size_bytes = 4096


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/51779

- Adds disk type as parameter in .tf files
- Changed terraform plan cmd to a more readable one
- Include additional disk variables only if needed (storage tests)
- Changed from 8k to 4k block size in fio tests

After this PR, we can enable the tests in OSD for storage.

NOTE: In Azure, I was able to use Premium SSD disk using a different VM type than normal (az_Standard_DS2_v2). I didn't manage to use Ultra SSDs in Azure cause it involves very unique configuration for region/vm type, etc. That will be included in a future PR. 