### PR TITLE
Install apache2 with docs on jeos

### DIFF
--- a/schedule/jeos_sle/jeos-main.yaml
+++ b/schedule/jeos_sle/jeos-main.yaml
@@ -1,0 +1,53 @@
+---
+description: 'Main JeOS test suite. Maintainer: ccret.'
+name: 'jeos-main@uefi-virtio-vga ( qemu )'
+schedule:
+  - installation/bootloader_uefi
+  - jeos/firstrun
+  - jeos/record_machine_id
+  - console/force_scheduled_tasks
+  - jeos/grub2_gfxmode
+  - jeos/diskusage
+  - jeos/root_fs_size
+  - jeos/build_key
+  - console/suseconnect_scc
+  - console/apache
+  - console/apache_ssl
+  - console/apache_nss
+  - console/system_prepare
+  - console/check_network
+  - console/system_state
+  - console/prepare_test_data
+  - console/consoletest_setup
+  - locale/keymap_or_locale
+  - console/textinfo
+  - console/hostname
+  - console/installation_snapshots
+  - console/zypper_lr
+  - console/zypper_ref
+  - console/ncurses
+  - console/yast2_lan
+  - console/curl_https
+  - console/glibc_sanity
+  - update/zypper_up
+  - console/console_reboot
+  - console/zypper_in
+  - console/yast2_i
+  - console/yast2_bootloader
+  - console/vim
+  - console/firewall_enabled
+  - console/gpt_ptable
+  - console/kdump_disabled
+  - console/sshd_running
+  - console/sshd
+  - console/ssh_cleanup
+  - console/mtab
+  - console/mysql_srv
+  - console/rsync
+  - console/http_srv
+  - console/dns_srv
+  - console/postgresql_server
+  - console/shibboleth
+  - console/zypper_lifecycle
+  - console/orphaned_packages_check
+  - console/consoletest_finish


### PR DESCRIPTION
- Related ticket: [[jeos] test fails in apache - httpd.conf.default not found](https://progress.opensuse.org/issues/54584)
- Verification runs: 
   * [sle-12-SP5-JeOS-for-kvm-and-xen-x86_64-Build4.8-jeos-main@uefi-virtio-vga - fullschedule](http://eris.suse.cz/tests/16433)
   * [Build4.8-jeos-main@uefi-virtio-vga - modified schedule](http://eris.suse.cz/tests/16432)
