### PR TITLE
Small fix for the rpm test module

### DIFF
--- a/tests/console/rpm.pm
+++ b/tests/console/rpm.pm
@@ -67,6 +67,7 @@ sub run {
     assert_script_run 'rpm -qp --requires /tmp/aaa_base.rpm';
 
     # Prepare test rpm file of missing package
+    assert_script_run('rpm -e sysstat') if (script_run("rpm -q sysstat") == 0);
     zypper_call 'in -fy --download-only sysstat';
     assert_script_run 'mv `find /var/cache/zypp/packages/ | grep sysstat | head -n1` /tmp/sysstat.rpm';
 
@@ -81,6 +82,9 @@ sub run {
 
     # Uninstall an already installed package
     assert_script_run 'rpm -evh sysstat';
+
+    # Install the package again
+    assert_script_run 'rpm -ivh /tmp/sysstat.rpm';
 }
 
 1;


### PR DESCRIPTION
This fix removes the `sysstat` package if it already exists. This is because the package is being installed later on again.

- Verification run: [SLES15sp1](http://pdostal-server.suse.cz/tests/3672) [SLES15](http://pdostal-server.suse.cz/tests/3673) [SLES12sp4](http://pdostal-server.suse.cz/tests/3675) [SLES12sp3](http://pdostal-server.suse.cz/tests/3669) [SLES12sp2](http://pdostal-server.suse.cz/tests/3670) [SLES12sp1](http://pdostal-server.suse.cz/tests/3671) [Leap15.1](http://pdostal-server.suse.cz/tests/3676) [Tumbleweed](http://pdostal-server.suse.cz/tests/3677)