### PR TITLE
Don't add python2 module on Maintenance tests

### DIFF
--- a/tests/qa_automation/qa_run.pm
+++ b/tests/qa_automation/qa_run.pm
@@ -82,7 +82,7 @@ sub prepare_repos {
 
     add_qa_head_repo;
     add_qa_web_repo;
-    add_suseconnect_product('sle-module-python2') if is_sle('>15');
+    add_suseconnect_product('sle-module-python2') if is_sle('>15') && get_var('FLAVOR') !~ /-Updates$|-Incidents/;
     zypper_call("in qa_testset_automation qa_tools python-base python-xml");
 }
 


### PR DESCRIPTION
Maintenance tests contain python2 module

- Fail: https://openqa.suse.de/tests/3113321#step/userspace_gzip/45
- Verification run: http://10.100.12.155/tests/12930
