### PR TITLE
[WIP] Enlarge timeout for scc_registration when handle addons.

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -475,7 +475,7 @@ sub fill_in_registration_data {
         push @tags, 'inst-addon' if is_sle('15+') && is_upgrade;
         while ($counter--) {
             die 'Registration repeated too much. Check if SCC is down.' if ($counter eq 1);
-            assert_screen(\@tags, 60);
+            assert_screen(\@tags, timeout => 360);
             if (match_has_tag('import-untrusted-gpg-key')) {
                 handle_untrusted_gpg_key;
                 next;


### PR DESCRIPTION
When migration from sle12sp5 to sle15sp1, in scc_registration module we need more time to wait
each module to be updated from repositories.

- Related ticket: https://progress.opensuse.org/issues/54461
- Needles: None.
- Verification run: https://openqa.suse.de/tests/3114658
