### PR TITLE
fix tests/yast2_cmd/yast_keyboard.pm bug

### DIFF
--- a/tests/yast2_cmd/yast_keyboard.pm
+++ b/tests/yast2_cmd/yast_keyboard.pm
@@ -20,27 +20,21 @@ use utils;
 
 sub run {
 
-    # Set keyboard layout to korean and validate
     select_console("root-console");
+
+    # Set keyboard layout to korean and validate.
     zypper_call("in yast2-country", timeout => 480);
     assert_script_run("yast keyboard list");
     assert_script_run("yast keyboard set layout=korean");
-    validate_script_output("yast keyboard summary 2>&1",                    sub { m/Current\s+Keyboard\s+Layout:/ });
-    validate_script_output("localectl",                                     sub { m/korean/ });
-    validate_script_output("grep -i YAST_KEYBOARD /etc/sysconfig/keyboard", sub { m/korean/ });
+    validate_script_output("yast keyboard summary 2>&1", sub { m/korean/ });
 
-    # Set keyboard layout to German and validate
+    # Set keyboard layout to German.
     assert_script_run("yast keyboard set layout=german");
-    type_string "`1234567890-=[;'";
-    assert_screen "yast2_keyboard_layout_cmd_test";
-    send_key 'ctrl-u';
 
-    # Restore keyboard settings to english-us(select root-virtio-terminal console here, otherwise openqa will not run properly in the german keyboard layout)
-    select_console('root-virtio-terminal');
-    assert_script_run("yast keyboard set layout=english-us");
+    # Restore keyboard settings to english-us and verify(enter using german characters).
+    type_string("zast kezboard set lazout)english/us\n", wait_still_screen => 50, timeout => 80);
+
     validate_script_output("yast keyboard summary 2>&1", sub { m/english-us/ });
-
-    select_console("root-console");
 
 }
 


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/49283

Needles: none

Verification run(yast_cmd):
SLE15: http://10.67.20.165/tests/786
SLE12-SP4: http://10.67.20.165/tests/787
Fixed an issue where the English keyboard did not restore successfully.
