### PR TITLE
Disable zypper_info for src pkgs from SCC

### DIFF
--- a/tests/console/zypper_info.pm
+++ b/tests/console/zypper_info.pm
@@ -33,27 +33,6 @@ sub check_srcpackage_output {
 sub test_srcpackage_output {
     my $info_output_coreutils = script_output 'zypper info srcpackage:coreutils';
     check_srcpackage_output 'coreutils', $info_output_coreutils;
-
-    if (is_sle '>=12-SP3') {
-        if (get_var('FLAVOR') !~ /-Updates$|-Incidents$/) {
-            if (is_sle '<15') {
-                register_product;
-            }
-            else {
-                # only scc has update repos with src packages
-                cleanup_registration;
-                assert_script_run 'SUSEConnect -r ' . get_required_var('SCC_REGCODE') . ' --url https://scc.suse.com';
-            }
-            zypper_call 'ref';
-        }
-        my $reponame          = ((is_sle '15+') ? 'SLE-Module-Basesystem' : 'SLES') . get_var('VERSION') . '-Updates';
-        my $info_output_glib2 = script_output "zypper info -r $reponame srcpackage:glib2";
-        check_srcpackage_output 'glib2', $info_output_glib2;
-        if (get_var('FLAVOR') !~ /-Updates$|-Incidents$/) {
-            cleanup_registration if (is_sle);
-            register_product if (is_sle '15+');
-        }
-    }
 }
 
 sub test_package_output {


### PR DESCRIPTION
There is no SCC repo where src pkgs can be found reliably.
Related Ticket: https://progress.opensuse.org/issues/15932
Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1142033
Verification: http://artemis.suse.de/tests/1567#step/zypper_info/10