### PR TITLE
Use different VAR separator

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -716,7 +716,7 @@ sub map_incidents_to_repo {
     for my $i (keys %$incidents) {
         for my $j (split(/,/, $incidents->{$i})) {
             if ($j) {
-                push @maint_repos, join($j, split('%INCIDENTNR%', $templates->{$i}));
+                push @maint_repos, join($j, split('@INCIDENTNR@', $templates->{$i}));
             }
         }
     }


### PR DESCRIPTION
The new version of OpenQA expands all %VAR%, so we need to avoid this
