### PR TITLE
Parse snapper list output in perl

### DIFF
--- a/tests/console/snapper_create.pm
+++ b/tests/console/snapper_create.pm
@@ -20,9 +20,8 @@ use utils;
 # but other data which was written to serial device. We have to ensure
 # that we got what we expect. See poo#25716
 sub get_last_snap_number {
-    # get snapshot id column, tail before head to avoid SIGPIPE
-    my $snap_head = script_output("snapper list | tail -n +1 | head -n1");
-
+    # get snapshot id column, parse output in perl to avoid SIGPIPE
+    my $snap_head = (split(/\n/, script_output("snapper list")))[0];
     # strip kernel messages - for some reason we always get something like this at this very position:
     # [ 1248.663412] BTRFS info (device vda2): qgroup scan completed (inconsistency flag cleared)
     my @lines = split(/\n/, $snap_head);


### PR DESCRIPTION
- Related ticket: [[jeos] test fails in snapper_create](https://progress.opensuse.org/issues/54029)
- Verification run: [sle-12-SP5-JeOS-for-kvm-and-xen-x86_64-Build4.8-jeos-filesystem@64bit-virtio-vga](http://eris.suse.cz/tests/16453)
