### PR TITLE
Wait longer for grub2

### DIFF
--- a/tests/boot/grub2_test.pm
+++ b/tests/boot/grub2_test.pm
@@ -26,7 +26,7 @@ use version_utils 'is_sle';
 sub reboot {
     type_string "reboot\n";
     reset_consoles;
-    assert_screen 'grub2';
+    assert_screen 'grub2', 90;
     stop_grub_timeout;
 }
 


### PR DESCRIPTION
Reboot can sometimes take longer than expected

- Fail: https://openqa.suse.de/tests/3127748#step/grub2_test/23
- Verification run: https://openqa.suse.de/tests/3129278
