### PR TITLE
Fix Azure upload issue on Public Cloud

### DIFF
--- a/data/autoyast_sle15/pc_tools.xml
+++ b/data/autoyast_sle15/pc_tools.xml
@@ -99,7 +99,6 @@
             <package>ntp</package>
             <package>gcc</package>
             <package>python3-pip</package>
-            <package>aws-cli</package>
             <package>sudo</package>
             <package>wget</package>
             <package>python</package>

--- a/schedule/create_hdd_autoyast_pc.yaml
+++ b/schedule/create_hdd_autoyast_pc.yaml
@@ -1,5 +1,5 @@
 ---
-name: create_hdd_autoyast_wicked
+name: create_hdd_autoyast_pc
 vars:
   AUTOYAST: autoyast_sle15/pc_tools.xml
   DESKTOP: textmode

--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -55,12 +55,11 @@ sub run {
     assert_script_run("curl " . data_url('publiccloud/ec2utils.conf') . " -o /root/.ec2utils.conf");
     record_info('EC2', script_output('aws --version'));
 
-    # install azure cli
-    assert_script_run('sudo rpm --import https://packages.microsoft.com/keys/microsoft.asc');
-    zypper_call('addrepo --name "Azure CLI" --check https://packages.microsoft.com/yumrepos/azure-cli azure-cli');
-    zypper_call('-q in --from azure-cli -y azure-cli');
+    # Install Azure cli
+    zypper_call('-q in python3-devel');
+    assert_script_run("pip3 install -q --ignore-installed azure-cli", 240);
+    assert_script_run("sed -i 's/^python /python3 /' /usr/bin/az");    # Workaround to force the use of python3, needed for performance!
     record_info('Azure', script_output('az -v'));
-
 
     # Install Google Cloud SDK
     assert_script_run("export CLOUDSDK_CORE_DISABLE_PROMPTS=1");
@@ -68,7 +67,6 @@ sub run {
     assert_script_run("echo . /root/google-cloud-sdk/completion.bash.inc >> ~/.bashrc");
     assert_script_run("echo . /root/google-cloud-sdk/path.bash.inc >> ~/.bashrc");
     record_info('GCE', script_output('source ~/.bashrc && gcloud version'));
-
 
     # Create some directories, ipa will need them
     assert_script_run("mkdir -p ~/ipa/tests/");


### PR DESCRIPTION
Install the latest azure-cli version with pip3 and tweak it to be able to use python3. This python version is mandatory to avoid performance issue (mainly during upload)!

This PR also add 2 minor fixes:
- `aws_cli` is already and should be installed like others cloud tools in `prepare_tools.pm`, so removing it from the autoyast profile.
- YAML profile name

Verification runs: [Public Cloud image creation](http://1b147.qa.suse.de/tests/5672), [Azure upload test](http://1b147.qa.suse.de/tests/5674) and regression tests on [GCE upload test](http://1b147.qa.suse.de/tests/5682) and [EC2 upload test](http://1b147.qa.suse.de/tests/5681)
