### PR TITLE
Use EXTRATESTS variable instead of TEST name

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -649,7 +649,7 @@ sub wait_boot {
         push @{$textmode_needles}, 'autoyast-init-second-stage' if get_var('AUTOYAST');
         # Soft-fail for user_defined_snapshot in extra_tests_on_gnome and extra_tests_on_gnome_on_ppc
         # if not able to boot from snapshot
-        if (get_var('TEST') !~ /extra_tests_on_gnome/) {
+        if (get_var('EXTRATEST') !~ /desktop/) {
             assert_screen $textmode_needles, $ready_time;
         }
         elsif (is_sle('<15') && !check_screen $textmode_needles, $ready_time / 2) {


### PR DESCRIPTION
QAM test is named mau-extratests-desktop and QA extra_tests_on_gnome, test name can be any

- Related ticket: https://progress.opensuse.org/issues/54599
- Verification run: http://10.100.12.155/tests/12938
https://openqa.suse.de/tests/3136625