### PR TITLE
Public Cloud: Fix multiple issues on prepare tools

### DIFF
--- a/data/autoyast_sle15/pc_tools.xml
+++ b/data/autoyast_sle15/pc_tools.xml
@@ -93,12 +93,9 @@
         </products>
          <packages config:type="list">
             <package>netcat-openbsd</package>
-            <package>python3-img-proof</package>
-            <package>python3-img-proof-tests</package>
             <package>git-core</package>
             <package>ntp</package>
             <package>gcc</package>
-            <package>python3-pip</package>
             <package>sudo</package>
             <package>wget</package>
             <package>python</package>
@@ -116,8 +113,8 @@
                         sed -i 's/splash=silent\ quiet//' /etc/default/grub
                         sed -i '/GRUB_DISABLE_LINUX_UUID/s/^# //' /etc/default/grub
                         grub2-mkconfig -o /boot/grub2/grub.cfg
-                        cd /etc/alternatives/
-                        ln -fs /usr/bin/python3 python
+                        update-alternatives --install /usr/bin/python python /usr/bin/python2 1
+                        update-alternatives --install /usr/bin/python python /usr/bin/python3 2
                         ]]>
                 </source>
             </script>

--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -31,9 +31,12 @@ sub run {
         }
     }
 
+    # Install prerequesite packages
+    zypper_call('-q in python-xml python3-devel python3-pip python3-img-proof python3-img-proof-tests');
+    record_info('python', script_output('python --version'));
+
     # Install AWS cli
     if (is_opensuse) {
-        zypper_call('-q in python3-devel');
         assert_script_run("pip3 install -q pycrypto");
         assert_script_run("pip3 install -q awscli");
         assert_script_run("pip3 install -q keyring");
@@ -56,9 +59,7 @@ sub run {
     record_info('EC2', script_output('aws --version'));
 
     # Install Azure cli
-    zypper_call('-q in python3-devel');
     assert_script_run("pip3 install -q --ignore-installed azure-cli", 240);
-    assert_script_run("sed -i 's/^python /python3 /' /usr/bin/az");    # Workaround to force the use of python3, needed for performance!
     record_info('Azure', script_output('az -v'));
 
     # Install Google Cloud SDK


### PR DESCRIPTION
Issues fixed:
- fix broken GCE upload (introduce with the [last modification](#8015 ))
- install all PC tools in `prepare_tools.pm`
- remove dirty python3 workaround for Azure, something more elegant is now used

Verification runs:
- [Public Cloud image creation](http://1b210.qa.suse.de/tests/5695)
- [Azure upload test](http://1b210.qa.suse.de/tests/5703)
- [GCE upload test](http://1b210.qa.suse.de/tests/5704)
- [EC2 upload test](http://1b210.qa.suse.de/tests/5702)