### PR TITLE
Increase timeout for bootloader for aarch64 as it is longer on cold start

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -975,7 +975,7 @@ sub ensure_shim_import {
     my (%args) = @_;
     $args{tags} //= [qw(inst-bootmenu bootloader-shim-import-prompt)];
     # aarch64 firmware 'tianocore' can take longer to load
-    my $bootloader_timeout = check_var('ARCH', 'aarch64') ? 60 : 30;
+    my $bootloader_timeout = check_var('ARCH', 'aarch64') ? 90 : 30;
     assert_screen($args{tags}, $bootloader_timeout);
     if (match_has_tag("bootloader-shim-import-prompt")) {
         send_key "down";

--- a/tests/installation/bootloader_uefi.pm
+++ b/tests/installation/bootloader_uefi.pm
@@ -48,7 +48,7 @@ sub run {
     }
 
     # aarch64 firmware 'tianocore' can take longer to load
-    my $bootloader_timeout = check_var('ARCH', 'aarch64') ? 60 : 15;
+    my $bootloader_timeout = check_var('ARCH', 'aarch64') ? 90 : 15;
     if (get_var('UEFI_HTTP_BOOT') || get_var('UEFI_HTTPS_BOOT')) {
         tianocore_http_boot;
     }


### PR DESCRIPTION
On cold start, all jobs are started together which lead to a slower start of the VM.
