### PR TITLE
Use root-console to avoid sporadic failures

### DIFF
--- a/tests/console/timezone.pm
+++ b/tests/console/timezone.pm
@@ -12,10 +12,10 @@
 # Maintainer: Paolo Stivanin <pstivanin@suse.com>
 
 use base 'opensusebasetest';
-use testapi;
-use utils;
 use strict;
 use warnings;
+use testapi;
+use utils;
 
 sub get_tz_data {
     my $save      = shift;

--- a/tests/console/timezone.pm
+++ b/tests/console/timezone.pm
@@ -37,7 +37,10 @@ sub set_data_and_validate {
 
 sub run {
     my ($self) = @_;
-    $self->select_serial_terminal;
+    # We used to select serial console here, but it was failing in 5% of cases
+    # So switching to root-console for the time being, which takes a bit longer, but
+    # seems to be more reliable for the time being.
+    select_console 'root-console';
 
     assert_script_run("rpm -q timezone");
 


### PR DESCRIPTION
For some reason serial_terminal ends up taking a bit long to show the
prompt properly (> ) and the regexp then fails trying to find the
gt character before for the mark.

Verification run:
    - x86 - http://phobos.suse.de/tests/1747981
    - aarch64 - https://openqa.suse.de/tests/3135856
Progress ticket: https://progress.opensuse.org/issues/53996