### PR TITLE
Install vagrant & start services before each vagrant test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2453,7 +2453,8 @@ sub load_virtualization_tests {
 
     # the tests currently require x86 & Tumbleweed
     if (is_x86_64 && is_tumbleweed) {
-        loadtest "virtualization/vagrant/add_box";
+        loadtest "virtualization/vagrant/add_box_virtualbox";
+        loadtest "virtualization/vagrant/add_box_libvirt";
         loadtest "virtualization/vagrant/boxes/tumbleweed";
     }
     return 1;

--- a/lib/vagrant.pm
+++ b/lib/vagrant.pm
@@ -1,0 +1,29 @@
+package vagrant;
+use testapi;
+use strict;
+use warnings;
+use utils;
+
+our @ISA    = qw(Exporter);
+our @EXPORT = qw(setup_vagrant_libvirt setup_vagrant_virtualbox);
+
+# - install vagrant and vagrant-libvirt
+# - launch the required daemons
+sub setup_vagrant_libvirt {
+    select_console('root-console');
+
+    zypper_call("in vagrant vagrant-libvirt");
+    assert_script_run("systemctl start libvirtd");
+    assert_script_run("usermod -a -G libvirt bernhard");
+}
+
+# - install vagrant and virtualbox
+# - launch the required daemons
+sub setup_vagrant_virtualbox {
+    select_console('root-console');
+
+    zypper_call("in vagrant virtualbox");
+    assert_script_run("systemctl start vboxdrv");
+    assert_script_run("systemctl start vboxautostart");
+    assert_script_run("usermod -a -G vboxusers bernhard");
+}

--- a/tests/virtualization/vagrant/add_box_libvirt.pm
+++ b/tests/virtualization/vagrant/add_box_libvirt.pm
@@ -1,0 +1,49 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: Test for vagrant with the libvirt plugin
+# Maintainer: dancermak <dcermak@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use vagrant;
+
+sub run() {
+    setup_vagrant_libvirt();
+
+    select_console('user-console');
+
+    # expect the output to contain the line if vagrant-libvirt has been
+    # correctly installed via the RPM:
+    # vagrant-libvirt (0.0.45, system)
+    assert_script_run('vagrant plugin list|grep libvirt|grep -q system');
+
+    assert_script_run('echo "test" > testfile');
+
+    assert_script_run('vagrant init centos/7');
+
+    assert_script_run('vagrant up', timeout => 1200);
+
+    assert_script_run('vagrant ssh -c "[ $(cat testfile) = \"test\" ]"');
+    assert_script_run('vagrant halt');
+    assert_script_run('vagrant destroy -f');
+
+    assert_script_run('rm -rf Vagrantfile testfile .vagrant');
+}
+
+1;

--- a/tests/virtualization/vagrant/add_box_virtualbox.pm
+++ b/tests/virtualization/vagrant/add_box_virtualbox.pm
@@ -13,38 +13,24 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# Summary: Test for vagrant and packaged addons
+# Summary: Test for vagrant
 # Maintainer: dancermak <dcermak@suse.com>
 
+use base "consoletest";
 use strict;
 use warnings;
-use base "basetest";
 use testapi;
 use utils;
+use vagrant;
 
 sub run() {
-    select_console('root-console');
-
-    zypper_call('in vagrant virtualbox vagrant-libvirt');
-
-    assert_script_run('systemctl start vboxdrv');
-    assert_script_run('systemctl start vboxautostart');
-    assert_script_run('systemctl start libvirtd');
-
-    assert_script_run('usermod -a -G vboxusers bernhard');
-    assert_script_run('usermod -a -G libvirt bernhard');
+    setup_vagrant_virtualbox();
 
     select_console('user-console');
     assert_script_run('echo "test" > testfile');
 
     assert_script_run('vagrant init centos/7');
     assert_script_run('vagrant up --provider virtualbox', timeout => 1200);
-
-    assert_script_run('vagrant ssh -c "[ $(cat testfile) = \"test\" ]"');
-    assert_script_run('vagrant halt');
-    assert_script_run('vagrant destroy -f');
-
-    assert_script_run('vagrant up', timeout => 1200);
 
     assert_script_run('vagrant ssh -c "[ $(cat testfile) = \"test\" ]"');
     assert_script_run('vagrant halt');

--- a/tests/virtualization/vagrant/boxes/tumbleweed.pm
+++ b/tests/virtualization/vagrant/boxes/tumbleweed.pm
@@ -13,18 +13,22 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 
-# Summary: Test for vagrant and packaged addons
+# Summary: Test for the openSUSE vagrant boxes
 # Maintainer: dancermak <dcermak@suse.com>
 
+use base "consoletest";
 use strict;
 use warnings;
-use base "basetest";
 use testapi;
 use utils;
+use vagrant;
 use File::Basename;
 
 
 sub run() {
+    setup_vagrant_libvirt();
+    setup_vagrant_virtualbox();
+
     select_console('root-console');
     zypper_call('in ansible');
 


### PR DESCRIPTION
Add a common function for vagrant that installs the required packages and starts the libvirt & virtualbox daemons => if the add_box test fails, then the tumbleweed test will not fail because of missing packages.

- Related ticket: n.a.
- Needles: none present
- Verification run: https://openqa.opensuse.org/tests/1004226 https://openqa.opensuse.org/tests/998940 ~~https://openqa.opensuse.org/tests/992202, https://openqa.opensuse.org/tests/992300 (fails due to a bug in Virtualbox)~~
