### PR TITLE
Fix saptune issues

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -166,7 +166,9 @@ sub prepare_profile {
 
     if ($has_saptune) {
         assert_script_run "saptune daemon start";
-        assert_script_run "saptune solution verify $profile";
+        if (script_run "saptune solution verify $profile") {
+            record_soft_failure("poo#54695: 'saptune solution verify' returned warnings or errors! Please check!");
+        }
         my $output = script_output "saptune daemon status";
         record_info("tuned status", $output);
     }

--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -61,7 +61,7 @@ sub run {
     die "Command 'saptune solution list' output is not recognized" unless ($output =~ m|$regexp|s);
 
     $output = script_output "saptune note list";
-    $regexp = 'All notes \(\+ denotes manually enabled notes, \* denotes notes enabled by solutions\):';
+    $regexp = 'All notes \(\+ denotes manually enabled notes, \* denotes notes enabled by solutions';
     die "Command 'saptune note list' output is not recognized" unless ($output =~ m|$regexp|);
 }
 


### PR DESCRIPTION
Fix issues with saptune_V2 on sles4sap tests.

- Verification run: http://1b210.qa.suse.de/tests/5711 and http://1b210.qa.suse.de/tests/5709

Edit: verification runs with the `record_soft_failure`: http://1b210.qa.suse.de/tests/5713