### PR TITLE
[ooffice] Close "Tip of the day" dialog

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -935,4 +935,16 @@ sub check_desktop_runner {
     x11_start_program('true', target_match => 'generic-desktop', no_wait => 1);
 }
 
+# Start one of the libreoffice components, close any first-run dialogs
+sub libreoffice_start_program {
+    my ($self, $program) = @_;
+
+    x11_start_program($program);
+    if (match_has_tag('ooffice-tip-of-the-day')) {
+        # Unselect "_S_how tips on startup", select "_O_k"
+        send_key "alt-s";
+        send_key "alt-o";
+    }
+}
+
 1;

--- a/tests/x11/oocalc.pm
+++ b/tests/x11/oocalc.pm
@@ -17,7 +17,9 @@ use warnings;
 use testapi;
 
 sub run {
-    x11_start_program('oocalc');
+    my ($self) = shift;
+
+    $self->libreoffice_start_program('oocalc');
     wait_still_screen;    # extra wait because oo sometimes appears to be idle during start
     wait_screen_change { assert_and_click('input-area-oocalc', timeout => 10) };
     type_string "Hello World!\n";

--- a/tests/x11/ooffice.pm
+++ b/tests/x11/ooffice.pm
@@ -18,7 +18,9 @@ use testapi;
 use utils 'type_string_slow';
 
 sub run {
-    x11_start_program('oowriter');
+    my ($self) = shift;
+
+    $self->libreoffice_start_program('oowriter');
     # clicking the writing area to make sure the cursor addressed there
     wait_screen_change { assert_and_click('ooffice-writing-area', timeout => 10) };
     # auto-correction does not handle super-fast typing well

--- a/tests/x11/oomath.pm
+++ b/tests/x11/oomath.pm
@@ -19,7 +19,9 @@ use testapi;
 use utils 'type_string_slow';
 
 sub run {
-    x11_start_program('oomath');
+    my ($self) = shift;
+
+    $self->libreoffice_start_program('oomath');
     # be more resilient during the automatic evaluation of formulas to prevent
     # mistyping
     type_string_slow "E %PHI = H %PHI\nnewline\n1 = 1";


### PR DESCRIPTION
LibreOffice 6.3 shows a "Tip of the day" dialog. Unselect the
"Show tips on startup" checkbox and close it.

- Related ticket: https://progress.opensuse.org/issues/54722
- Verification run: https://openqa.opensuse.org/tests/999090#step/ooffice/3
- Verification run: https://openqa.opensuse.org/tests/999091#step/ooffice/4
- Verification run: https://openqa.opensuse.org/tests/999094#step/ooffice/4