### PR TITLE
Fix schedule for autoyast_reinstall in s390x

### DIFF
--- a/schedule/yast/autoyast_reinstall_s390x.yaml
+++ b/schedule/yast/autoyast_reinstall_s390x.yaml
@@ -1,0 +1,24 @@
+name:           autoyast_reinstall_s390x
+description:    >
+    Parent job produces autoyast profile after successful completion. 
+    This test uses generated profile to do autoyast installation.
+schedule:
+    - installation/bootloader_start
+    - autoyast/installation
+    - autoyast/console
+    - autoyast/login
+    - autoyast/verify_imported_users
+    - autoyast/wicked
+    - autoyast/repos
+    - autoyast/clone
+    - autoyast/logs
+    - autoyast/autoyast_reboot
+    - boot/reconnect_mgmt_console
+    - installation/first_boot
+test_data:
+  paths:
+    - /var/lib/gdm/.bashrc
+    - /var/lib/empty/.bashrc
+    - /var/lib/polkit/.bashrc
+    - /var/lib/nobody/.bashrc
+    - /var/lib/pulseaudio/.bashrc


### PR DESCRIPTION
Fix schedule for autoyast_reinstall in s390x. Test suites already configured in OSD.

- Related ticket:  https://progress.opensuse.org/issues/50396
- Needles: n/a
- Verification run: [sle-12-SP5-Server-DVD-s390x-Build0248-autoyast_reinstall@s390x-kvm-sle12](https://openqa.suse.de/t3161966)