### PR TITLE
[WIP] Specify console_num when adding virtio_terminal

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -424,9 +424,8 @@ sub init_consoles {
     }
 
     if (check_var('BACKEND', 'qemu')) {
-        $self->add_console('root-virtio-terminal', 'virtio-terminal', {});
-        for (my $num = 1; $num < get_var('VIRTIO_CONSOLE_NUM', 1); $num++) {
-            $self->add_console('root-virtio-terminal' . $num, 'virtio-terminal', {socked_path => cwd() . '/virtio_console' . $num});
+        for (my $num = 0; $num < get_var('VIRTIO_CONSOLE_NUM', 1); $num++) {
+            $self->add_console('root-virtio-terminal', 'virtio-terminal', {console_num => $num});
         }
     }
 


### PR DESCRIPTION
We just give virtio_terminal the console number and let the virtio_terminal
decide how to create the the needed information to connect to the
virtio console.

- Related ticket: https://progress.opensuse.org/issues/54260
- Verification run: http://cfconrad-vm.qa.suse.de/tests/5501
