### PR TITLE
Schedule latexdiff test on 15+ & opensuse

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1413,7 +1413,7 @@ sub load_extra_tests_y2uitest_cmd {
 }
 
 sub load_extra_tests_texlive {
-    loadtest 'texlive/latexdiff';
+    loadtest 'texlive/latexdiff' if is_sle('15+') || is_opensuse;
 }
 
 sub load_extra_tests_openqa_bootstrap {


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/3162151#step/latexdiff/6
- Verification run: http://10.100.12.155/tests/12953