### PR TITLE
HPC: Correct the way SDK is added for SLE12

### DIFF
--- a/tests/hpc/mpi_master.pm
+++ b/tests/hpc/mpi_master.pm
@@ -18,23 +18,24 @@ use warnings;
 use testapi;
 use lockapi;
 use utils;
-use registration qw(add_suseconnect_product get_addon_fullname);
+use registration;
 use version_utils 'is_sle';
 
 sub run {
     my $self          = shift;
     my $version       = get_required_var("VERSION");
     my $arch          = get_required_var("ARCH");
-    my $nodes         = get_required_var("CLUSTER_NODES");
+    my $sdk_version   = get_required_var("BUILD_SDK");
     my $mpi           = get_required_var("MPI");
     my $mpi_c         = "simple_mpi.c";
     my @cluster_nodes = $self->cluster_names();
     my $cluster_nodes = join(',', @cluster_nodes);
-    $version =~ s/-SP/./;
 
-    add_suseconnect_product(get_addon_fullname('sdk'), $version, $arch);
-    ## as the test code requires compilation, it should be possible to install required compilers
+    ## adding required sdk and gcc
+    ##TODO: consider better ways of handling addons/modules etc
+    ## https://progress.opensuse.org/issues/54773
     if (is_sle '<15') {
+        zypper_call("ar -f ftp://openqa.suse.de/SLE-$version-SDK-POOL-$arch-Build$sdk_version-Media1/ SDK");
         zypper_call("ar -f http://download.suse.de/ibs/SUSE/Products/SLE-Module-Toolchain/12/$arch/product/ SLE-Module-Toolchain12-Pool");
         zypper_call("ar -f http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Toolchain/12/$arch/update/ SLE-Module-Toolchain12-Updates");
     } else {


### PR DESCRIPTION
This is needed as the lib/registration.pm does not take care of the
build version/number of the SDK

- (updated) Verification run: http://10.160.65.14/tests/3817#step/mpi_master/63
