### PR TITLE
application_starts_on_login: Fix auto-save-session search

### DIFF
--- a/tests/x11/gnomecase/application_starts_on_login.pm
+++ b/tests/x11/gnomecase/application_starts_on_login.pm
@@ -100,7 +100,7 @@ sub alter_status_auto_save_session {
     else {
         send_key 'ctrl-f';
         assert_screen 'dconf-search-bar';
-        type_string "auto-save-session\n", max_interval => 200;
+        type_string "auto-save-session", max_interval => 200;
     }
     assert_and_click "auto-save-session";
     if (check_screen("changing-scheme-popup", 5)) {


### PR DESCRIPTION
On aarch64, first occurence is pre-selected, so if you type `enter` key at the end of the search string, you open the setting window. On x86, it is not pre-selected, but removing the `enter` key does not change anything.
Verification runs:
* aarch64: https://openqa.opensuse.org/tests/994944
* x86_64: https://openqa.opensuse.org/tests/994933