### PR TITLE
[WIP] Avoid needless wait still screen

### DIFF
--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -604,7 +604,7 @@ sub restart_firefox {
 sub firefox_check_default {
     # needle can sometimes match before firefox start to load page
     # svirt is special case with TIMEOUT_SCALE=3 which does not affect wait_still_screen
-    my $stilltime = get_var('TIMEOUT_SCALE') ? 100 : 10;
+    my $stilltime = 10 * get_var('TIMEOUT_SCALE', 1);
     wait_still_screen $stilltime, 100;
     # Set firefox as default browser if asked
     if (check_screen('firefox_default_browser')) {

--- a/tests/x11/amarok.pm
+++ b/tests/x11/amarok.pm
@@ -32,7 +32,8 @@ sub run {
     # do not playing audio file as we have not testdata if NICEVIDEO
     if (!get_var("NICEVIDEO")) {
         start_audiocapture;
-        x11_start_program('amarok -l ~/data/1d5d9dD.oga', target_match => 'test-amarok-3');
+        x11_start_program('amarok -l ~/data/1d5d9dD.oga', valid => 0, no_wait => 1);
+        assert_screen 'test-amarok-3';
         assert_recorded_sound('DTMF-159D');
     }
     send_key "ctrl-q";       # really quit (alt-f4 just backgrounds)

--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -22,7 +22,8 @@ sub run {
     ensure_installed 'chromium';
 
     # avoid async keyring popups
-    x11_start_program('chromium --password-store=basic', target_match => 'chromium-main-window', match_timeout => 50);
+    # do not wait for a still screen after hitting return, default homepage shows an animated geeko
+    x11_start_program('chromium --password-store=basic', target_match => 'chromium-main-window', match_timeout => 50, no_wait => 1);
 
     wait_screen_change { send_key 'esc' };       # get rid of popup (or abort loading)
     wait_screen_change { send_key 'ctrl-l' };    # select text in address bar

--- a/tests/x11/glxgears.pm
+++ b/tests/x11/glxgears.pm
@@ -18,8 +18,10 @@ use testapi;
 
 sub run {
     ensure_installed 'Mesa-demo-x';
-    # 'no_wait' for screen check because glxgears will be always moving
-    x11_start_program('glxgears', match_no_wait => 1);
+    # as glxgears is constantly moving:
+    # 'no_wait' to not wait for a still screen after the program has started
+    # 'match_no_wait' to check the screen as often as possible
+    x11_start_program('glxgears', match_no_wait => 1, no_wait => 1);
     send_key 'alt-f4';
 }
 


### PR DESCRIPTION
Avoid three 90 second timeouts during tests run under Plasma.

- Related ticket: https://progress.opensuse.org/issues/xyz
- Verification run: https://openqa.opensuse.org/tests/996072
