### PR TITLE
[WIP] Check_screen for grub2 on ppc64l1 for grub_test module

### DIFF
--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -31,7 +31,14 @@ sub handle_installer_medium_bootup {
     assert_screen 'inst-bootmenu';
 
     if (check_var("BOOTFROM", "d") && check_var("AUTOUPGRADE") && check_var("PATCH")) {
-        assert_screen 'grub2';
+        # poo#54218, on ppc64le the grub2 just show 1 second, so it's hard for openqa to
+        # catch this screen.
+        if (check_var('ARCH', 'ppc64le') && !check_screen('grub2')) {
+            record_info('softfail', 'grub2 screen was not catched.');
+        }
+        else {
+            assert_screen 'grub2';
+        }
     }
 
     send_key_until_needlematch 'inst-bootmenu-boot-harddisk', 'up';


### PR DESCRIPTION
When run grub_test module on ppc64le the grub2 menu just show 1 second, It's hard for
assert_screen to get that screen. We change it to use check_screen for ppc64le.

- Related ticket: https://progress.opensuse.org/issues/54218
- Needles: None.
- Verification run: https://openqa.suse.de/tests/3166113
