### PR TITLE
Fix tests/yast2_cmd/yast_keyboard.pm bug issue.

### DIFF
--- a/tests/yast2_cmd/yast_keyboard.pm
+++ b/tests/yast2_cmd/yast_keyboard.pm
@@ -12,6 +12,17 @@
 #          they have been successfully set.
 # Maintainer: Ming Li <mli@suse.com>
 
+=head1 Create regression test for keyboard layout and verify
+
+Reference:
+https://www.suse.com/documentation/sles-15/singlehtml/book_sle_admin/book_sle_admin.html#id-1.3.3.6.13.6.17
+
+1. Set keyboard layout to korean and validate.
+2. Set keyboard layout to german.
+3. Restore keyboard settings to english-us and verify (enter using german characters).
+
+=cut
+
 use base 'consoletest';
 use strict;
 use warnings;
@@ -28,7 +39,7 @@ sub run {
     assert_script_run("yast keyboard set layout=korean");
     validate_script_output("yast keyboard summary 2>&1", sub { m/korean/ });
 
-    # Set keyboard layout to German.
+    # Set keyboard layout to german.
     assert_script_run("yast keyboard set layout=german");
 
     # Restore keyboard settings to english-us and verify(enter using german characters).


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/49283

Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1196

Verification run(yast_gui):
SLE15-SP1: http://10.67.20.151/tests/836
SLE12-SP4: http://10.67.20.151/tests/837
Fixed an issue where the English keyboard did not restore successfully.
