### PR TITLE
Use check_var for WORKAROUND_DEPS and BREAK_DEPS in deal_with_dependency_issues

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -98,10 +98,10 @@ sub deal_with_dependency_issues {
         send_key_until_needlematch 'packages-section-selected', 'tab';
         send_key 'ret';
     }
-    if (get_var("WORKAROUND_DEPS")) {
+    if (check_var("WORKAROUND_DEPS", '1')) {
         y2_logs_helper::workaround_dependency_issues;
     }
-    elsif (get_var("BREAK_DEPS")) {
+    elsif (check_var("BREAK_DEPS", '1')) {
         y2_logs_helper::break_dependency;
     }
     else {

--- a/tests/autoyast/installation.pm
+++ b/tests/autoyast/installation.pm
@@ -125,7 +125,7 @@ sub run {
     # Workaround for removing package error during upgrade
     push(@needles, 'ERROR-removing-package') if get_var("AUTOUPGRADE");
     # resolve conflicts and this is a workaround during the update
-    push(@needles, 'manual-intervention') if get_var("BREAK_DEPS");
+    push(@needles, 'manual-intervention') if get_var("BREAK_DEPS", '1');
     # If it's beta, we may match license screen before pop-up shows, so check for pop-up first
     if (get_var('BETA')) {
         push(@needles, 'inst-betawarning');

--- a/tests/installation/change_desktop.pm
+++ b/tests/installation/change_desktop.pm
@@ -32,10 +32,10 @@ sub change_desktop {
         wait_screen_change { send_key 'ret'; };
     }
 
-    if (check_screen('dependency-issue', 5) && get_var("WORKAROUND_DEPS")) {
+    if (check_screen('dependency-issue', 5) && check_var("WORKAROUND_DEPS", '1')) {
         $self->workaround_dependency_issues;
     }
-    if (check_screen('dependency-issue', 0) && get_var("BREAK_DEPS")) {
+    if (check_screen('dependency-issue', 0) && check_var("BREAK_DEPS", '1')) {
         $self->break_dependency;
     }
 

--- a/tests/installation/zdup.pm
+++ b/tests/installation/zdup.pm
@@ -107,7 +107,7 @@ sub run {
     $out = wait_serial([$zypper_dup_continue, $zypper_dup_conflict, $zypper_dup_error], 240);
     while ($out) {
         if ($out =~ $zypper_dup_conflict) {
-            if (get_var("WORKAROUND_DEPS")) {
+            if (check_var("WORKAROUND_DEPS", '1')) {
                 record_info 'workaround dependencies';
                 send_key '1';
                 send_key 'ret';


### PR DESCRIPTION
We need use check_var for WORKAROUND_DEPS BREAK_DEPS in deal_with_dependency_issues

- Related ticket: https://progress.opensuse.org/issues/54668
- Needles: N/A
- Verification run: http://openqa.suse.de/tests/3249847
