### PR TITLE
For sles12-sp2 apparmor enable by default

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -18,6 +18,7 @@ use utils;
 use base 'opensusebasetest';
 use strict;
 use warnings;
+use version_utils 'is_sle';
 use services::apache;
 
 our @EXPORT = qw(
@@ -144,7 +145,11 @@ sub install_services {
                 record_soft_failure('workaround for bug#1132292 zypper in apparmor failed msg popup');
             }
 
-            assert_script_run 'systemctl enable ' . $srv_proc_name;
+	    # SLE12-SP2 doesn't support systemctl to enable apparmor
+            unless ($srv_pkg_name eq 'apparmor' && is_sle('<12-SP3')) {
+                assert_script_run 'systemctl enable ' . $srv_proc_name;
+            }
+
             assert_script_run 'systemctl start ' . $srv_proc_name;
         }
     }


### PR DESCRIPTION
For sles12-sp2, apparmor was enabled by /etc/init.d, it cannot use systemctl to do enable operation.

- Related ticket: https://progress.opensuse.org/issues/54734
- Verification run: 
Before migration (Don't enable apparmor):
http://10.161.8.44/tests/231#step/install_service/69
After migration (Apparmor can be started by default)
http://10.161.8.44/tests/231#step/check_upgraded_service/32