### PR TITLE
Correct end of support date

### DIFF
--- a/tests/console/zypper_lifecycle_toolchain.pm
+++ b/tests/console/zypper_lifecycle_toolchain.pm
@@ -28,9 +28,9 @@ sub run {
         gcc6                              => 'Now',
         gcc7                              => 'Now',
         libada7                           => 'Now',
-        libada8                           => '2024-10-30',
-        cpp8                              => '2024-10-30',
-        'sle-module-toolchain-release-cd' => '2024-10-30',
+        libada8                           => '2024-10-31',
+        cpp8                              => '2024-10-31',
+        'sle-module-toolchain-release-cd' => '2024-10-31',
     );
 
     select_console 'root-console';


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/3166192#step/zypper_lifecycle_toolchain/16

https://bugzilla.suse.com/show_bug.cgi?id=1013847
https://www.suse.com/lifecycle/