### PR TITLE
Public Cloud: support UEFI images for GCE

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -58,6 +58,9 @@ sub find_img {
 
 Upload a image to the CSP. Required parameter is the
 location of the C<image> file.
+UEFI images are supported by giving the optional
+parameter C<type> = 'uefi'. This is only supported
+on GCE at the momment.
 
 Retrieves the image-id after upload or die.
 

--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -26,8 +26,9 @@ sub run {
 
     my $provider = $self->provider_factory();
 
-    my $img_url = get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION');
+    my $img_url    = get_required_var('PUBLIC_CLOUD_IMAGE_LOCATION');
     my ($img_name) = $img_url =~ /([^\/]+)$/;
+    my $img_type   = get_var('PUBLIC_CLOUD_IMAGE_TYPE');
 
     if (my $img_id = $provider->find_img($img_name)) {
         record_info('Info', "Image $img_id already exists!");
@@ -35,7 +36,7 @@ sub run {
     }
 
     assert_script_run("wget $img_url -O $img_name", timeout => 60 * 10);
-    $provider->upload_img($img_name);
+    $provider->upload_img($img_name, $img_type);
 }
 
 sub test_flags {


### PR DESCRIPTION
This PR adds the extra arguments needed for uploading UEFI enabled images in GCE.

- Related ticket: https://progress.opensuse.org/issues/54830
- Verification runs: 
upload: http://fromm.arch.suse.de/tests/6834
ipa: http://fromm.arch.suse.de/tests/6854
ltp-cve: http://fromm.arch.suse.de/tests/6858
ltp-syscall: http://fromm.arch.suse.de/tests/6857

