### PR TITLE
Public Cloud: skip SUSEConnect for on-demand images

### DIFF
--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -71,9 +71,9 @@ sub run {
     assert_script_run('git clone -q --single-branch -b runltp_ng_openqa --depth 1 https://github.com/cfconrad/ltp.git');
 
     # Install ltp from package on remote
-    $instance->run_ssh_command(cmd => 'sudo SUSEConnect -r ' . $REG_CODE,                                                timeout => 600);
+    $instance->run_ssh_command(cmd => 'sudo SUSEConnect -r ' . $REG_CODE, timeout => 600) if (get_required_var('FLAVOR') !~ m/On-Demand/);
     $instance->run_ssh_command(cmd => 'sudo zypper --no-gpg-checks --gpg-auto-import-keys -q in -y ' . $remote_rpm_path, timeout => 600);
-    $instance->run_ssh_command(cmd => 'sudo CREATE_ENTRIES=1 /opt/ltp/IDcheck.sh',                                       timeout => 300);
+    $instance->run_ssh_command(cmd => 'sudo CREATE_ENTRIES=1 /opt/ltp/IDcheck.sh', timeout => 300);
 
     my $reset_cmd = '~/restart_instance.sh ' . get_required_var('PUBLIC_CLOUD_PROVIDER') . ' ';
     $reset_cmd .= $instance->instance_id . ' ' . $instance->public_ip;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/54878
- Verification run: 

GCE-BYOS: http://fromm.arch.suse.de/tests/6846
GCE-On-Demand: http://fromm.arch.suse.de/tests/6848

EC2-BYOS: http://fromm.arch.suse.de/tests/6851
EC2-On-Demand: http://fromm.arch.suse.de/tests/6850
