### PR TITLE
Add soft-failure bsc#1143205

### DIFF
--- a/tests/autoyast/verify_imported_users.pm
+++ b/tests/autoyast/verify_imported_users.pm
@@ -21,7 +21,12 @@ sub run {
     my $test_data = get_test_data();
     my $errors;
     foreach my $path (@{$test_data->{paths}}) {
-        $errors .= "$path should not exist\n" if (!script_run("test -f $path"));
+        if (!script_run("test -f $path")) {
+            if ($path eq '/var/lib/pulseaudio/.bashrc') {
+                return record_soft_failure("bsc#1143205 - pulseaudio bash profile shouldn't exist");
+            }
+            $errors .= "$path should not exist\n";
+        }
     }
     die "Bash profiles created instead of being imported (bsc#1130811):\n $errors" if ($errors);
     record_info("Import OK", "No wrong .bashrc files found in paths provided");


### PR DESCRIPTION
Add soft-failure bsc#1143205

- Related ticket: https://progress.opensuse.org/issues/54833
- Needles: n/a
- Verification run: [sle-12-SP5-Server-DVD-x86_64-Build0248-autoyast_reinstall@64bit](http://rivera-workstation.suse.cz/tests/86)
