### PR TITLE
Missing tide cause a lots of PR code check failed

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -145,7 +145,7 @@ sub install_services {
                 record_soft_failure('workaround for bug#1132292 zypper in apparmor failed msg popup');
             }
 
-	    # SLE12-SP2 doesn't support systemctl to enable apparmor
+            # SLE12-SP2 doesn't support systemctl to enable apparmor
             unless ($srv_pkg_name eq 'apparmor' && is_sle('<12-SP3')) {
                 assert_script_run 'systemctl enable ' . $srv_proc_name;
             }


### PR DESCRIPTION
Missing tidy on lib/serice_check.pm.