### PR TITLE
lxqt: Handle pop-up due to qemu cd-rom mount tentative (bsc#1137230)

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -126,10 +126,19 @@ sub poweroff_x11 {
     }
 
     if (check_var("DESKTOP", "lxqt")) {
+        # Handle bsc#1137230
+        if (check_screen 'authorization_failed') {
+            record_soft_failure 'bsc#1137230 - "Authorization failed" pop-up shown';
+            assert_and_click 'authorization_failed_ok_btn';
+        }
+        elsif (check_screen 'authentication-required') {
+            record_soft_failure 'bsc#1137230 - "Authentication required" pop-up shown';
+            assert_and_click 'authentication-required_cancel_btn';
+        }
         # opens logout dialog
         x11_start_program('shutdown', target_match => [qw(authentication-required authorization_failed lxqt_shutdowndialog)], match_timeout => 60);
         # we have typing issue because of poor performance, to record this if happens.
-        # close authorization failed dialog caused by bsc#1137230
+        # Double check for bsc#1137230
         if (match_has_tag 'authorization_failed' || 'authentication-required') {
             croak "bsc#1137230, CD-ROM pop-up displayed at shutdown, authorization failed";
         }


### PR DESCRIPTION
This PR follows-up https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/7617 to avoid a hard failure of the test and just have a soft-failure.

- Related ticket: https://progress.opensuse.org/issues/46703
- Verification runs: 
  * https://openqa.opensuse.org/tests/996694#step/shutdown/3 (soft failed)
  * https://openqa.opensuse.org/tests/996695#step/shutdown/3 (soft failed)
  * https://openqa.opensuse.org/tests/996696#step/shutdown/4 (passed normally)
  * https://openqa.opensuse.org/tests/996697#step/shutdown/3 (soft failed)
  * https://openqa.opensuse.org/tests/996698#step/shutdown/3 (soft failed)
