### PR TITLE
Fix the issue with wait_screen_change on x86_64

### DIFF
--- a/tests/virtualization/virtman_view.pm
+++ b/tests/virtualization/virtman_view.pm
@@ -27,7 +27,7 @@ sub run {
     launch_virtmanager();
     # go to preferences
     wait_screen_change { send_key 'alt-e' };
-    send_key 'p';
+    wait_screen_change { send_key 'p' };
     assert_screen 'virtman-preferences';
     # go to polling
     wait_screen_change { send_key 'right' };
@@ -50,7 +50,7 @@ sub run {
     assert_screen 'virt-manager';
 
     # go to view now
-    wait_screen_change { send_key 'alt-v' };
+    send_key 'alt-v';
     wait_screen_change { send_key 'right' };
     # activate everything
     for (1 .. 4) {


### PR DESCRIPTION
the PR #7636 breaks virtman_view.pm on x86_64 because
wait_screen_change after assert_screen causes a new problem.
Also fix the issue with go to preferences which is sometimes not
working.
see https://progress.opensuse.org/issues/54056

test verification runs:
http://f40.suse.de/tests/4912#step/virtman_view/8 (64bit)
http://f40.suse.de/tests/4910#step/virtman_view/8 (aarch64)
