### PR TITLE
Adjust docker test to also recognize new docker init naming

### DIFF
--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -113,7 +113,7 @@ sub run {
     die("network is not working inside of the container tw:saved") unless ($output =~ m{Location: http://www\.google\.de/});
 
     # Using an init process as PID 1
-    assert_script_run 'docker run --rm --init opensuse/tumbleweed ps --no-headers -xo "pid args" | grep "1 /dev/init"';
+    assert_script_run 'docker run --rm --init opensuse/tumbleweed ps --no-headers -xo "pid args" | grep "1 .*init"';
 
     if (script_run('command -v man') == 0) {
         assert_script_run('man -P cat docker build | grep "docker-build - Build an image from a Dockerfile"');


### PR DESCRIPTION
It can be /sbin/docker-init now.

See boo#1143313

Verification run: http://10.160.67.86/t366