### PR TITLE
publiccloud: Fix systemd_analyze output parsing

### DIFF
--- a/tests/publiccloud/boottime.pm
+++ b/tests/publiccloud/boottime.pm
@@ -21,10 +21,10 @@ sub extract_startup_timings {
     $string =~ s/Startup finished in\s*//;
     $string =~ s/=(.+)$/+$1 (overall)/;
     for my $time (split(/\s*\+\s*/, $string)) {
-        if ($time =~ /((\d{1,2})min\s*)?(\d{1,2}\.\d{1,3})s\s*\((\w+)\)/) {
-            my $sec = $3;
-            $sec += $2 * 60 if (defined($1));
-            $res->{$4} = $sec;
+        if ($time =~ /(?<check_min>(?<min>\d{1,2})\s*min\s*)?((?<sec>\d{1,2}\.\d{1,3})s|(?<ms>\d+)ms)\s*\((?<type>\w+)\)/) {
+            my $sec = $+{sec} // $+{ms} / 1000;
+            $sec += $+{min} * 60 if (defined($+{check_min}));
+            $res->{$+{type}} = $sec;
         }
     }
     map { die("Fail to detect $_ timing") unless exists($res->{$_}) } qw(kernel initrd userspace overall);


### PR DESCRIPTION
The regex wasn't aware of getting 666ms, like:
 (kernel) + 8.981s (initrd) + 1min 944ms (userspace) = 1min 17.708s

- Related ticket: https://progress.opensuse.org/issues/54923
- Verification run: https://openqa.suse.de/tests/3197489
