### PR TITLE
Revert "application_starts_on_login: Fix auto-save-session search"

### DIFF
--- a/tests/x11/gnomecase/application_starts_on_login.pm
+++ b/tests/x11/gnomecase/application_starts_on_login.pm
@@ -100,7 +100,7 @@ sub alter_status_auto_save_session {
     else {
         send_key 'ctrl-f';
         assert_screen 'dconf-search-bar';
-        type_string "auto-save-session", max_interval => 200;
+        type_string "auto-save-session\n", max_interval => 200;
     }
     assert_and_click "auto-save-session";
     if (check_screen("changing-scheme-popup", 5)) {


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#8051 to fix https://progress.opensuse.org/issues/54950