### PR TITLE
SES5: fix deepsea_testsuite

### DIFF
--- a/variables.md
+++ b/variables.md
@@ -103,6 +103,7 @@ ROOTONLY | boolean | false | Request installation to create only the root accoun
 SCC_ADDONS | string | | Comma separated list of modules to be enabled using SCC/RMT.
 SELECT_FIRST_DISK | boolean | false | Enables test module to select first disk for the installation. Is used for baremetal machine tests with multiple disks available, including cases when server still has previous installation.
 SEPARATE_HOME | three-state | undef | Used for scheduling the test module where separate `/home` partition should be explicitly enabled (if `1` is set) or disabled (if `0` is set). If not specified, the test module is skipped.
+SES5_CEPH_QA_HEALTH_OK | string | | URL for repo containing ceph-qa-health-ok package.
 SKIP_CERT_VALIDATION | boolean | false | Enables linuxrc parameter to skip certificate validation of the remote source, e.g. when using self-signed https url.
 SKIP_SET_STANDARD_PROMPT | boolean | false | Skips setting the standard prompt in shells. Can save time.
 SLE_PRODUCT | string | | Defines SLE product. Possible values: `sles`, `sled`, `sles4sap`. Is mainly used for SLE 15 installation flow.


### PR DESCRIPTION
default url should be http://download.suse.de/ibs/SUSE:/SLE-12-SP3:/Update/standard/SUSE:SLE-12-SP3:Update.repo
deepsea_testsuite relies on `/usr/lib/deepsea` which is now provided by a sub-package

- Verification run: http://kif.qa.suse.cz/tests/8325#