### PR TITLE
Add bash regression test

### DIFF
--- a/data/bash_regression_test/failed_tests_database_sle12-sp1
+++ b/data/bash_regression_test/failed_tests_database_sle12-sp1
@@ -1,0 +1,4 @@
+run-builtins.sh
+run-execscript.sh
+run-read.sh
+run-trap.sh

--- a/data/bash_regression_test/failed_tests_database_sle12-sp2
+++ b/data/bash_regression_test/failed_tests_database_sle12-sp2
@@ -1,0 +1,8 @@
+run-appendop.sh
+run-builtins.sh
+run-errors.sh
+run-execscript.sh
+run-posix2.sh
+run-read.sh
+run-shopt.sh
+run-trap.sh

--- a/data/bash_regression_test/failed_tests_database_sle12-sp3
+++ b/data/bash_regression_test/failed_tests_database_sle12-sp3
@@ -1,0 +1,8 @@
+run-appendop.sh
+run-builtins.sh
+run-errors.sh
+run-execscript.sh
+run-posix2.sh
+run-read.sh
+run-shopt.sh
+run-trap.sh

--- a/data/bash_regression_test/failed_tests_database_sle12-sp4
+++ b/data/bash_regression_test/failed_tests_database_sle12-sp4
@@ -1,0 +1,7 @@
+run-appendop.sh
+run-builtins.sh
+run-errors.sh
+run-posix2.sh
+run-read.sh
+run-shopt.sh
+run-trap.sh

--- a/data/bash_regression_test/failed_tests_database_sle15
+++ b/data/bash_regression_test/failed_tests_database_sle15
@@ -1,0 +1,12 @@
+run-appendop.sh
+run-array.sh
+run-builtins.sh
+run-errors.sh
+run-execscript.sh 
+run-herestr.sh
+run-jobs.sh
+run-nquote4.sh
+run-posix2.sh
+run-read.sh
+run-shopt.sh
+run-trap.sh

--- a/data/bash_regression_test/failed_tests_database_sle15-sp1
+++ b/data/bash_regression_test/failed_tests_database_sle15-sp1
@@ -1,0 +1,11 @@
+run-appendop.sh
+run-array.sh
+run-errors.sh
+run-execscript.sh 
+run-herestr.sh
+run-jobs.sh
+run-nquote4.sh
+run-posix2.sh
+run-read.sh
+run-shopt.sh
+run-trap.sh

--- a/data/bash_regression_test/test_run_script
+++ b/data/bash_regression_test/test_run_script
@@ -1,0 +1,25 @@
+ #!/bin/bash
+ #count how many lines in regressions file, meaning how many tests failed.
+ repeat=$(awk 'END {print NR}' possible_regressions)
+ for (( i=1; i<=$repeat; i++)); do
+         results=0;
+         #take the name of the test that failed from the regressions file and run it 20 times
+         testname=$(awk -v var=$i 'NR==var{print}' possible_regressions);
+         for (( j=1; j<=20 ; j++));
+                 do bash /usr/share/qa/qa_test_bash/qa_$testname > /dev/null 2>&1;
+#                do bash /home/orestis87/Documents/BASH_SCRIPT/TESTS/$testname > /dev/null 2>&1;
+                 if [ $? -eq 0 ]; then
+			 #everytime the test runs succesfully increase the value of results by 1 
+			 results=$(($results+1));
+			 fi
+		 done
+			 if [ $results -eq 20 ]; then
+				 echo -e " \n Test $testname  run succesfully 20 out of 20 times.False positive regression";
+			 elif [ $results -lt 20 -a $results -ge 15 ] ; then
+				 echo -e " \n Test $testname run succesfully $results out of 20 times. No regression but this test is unreliable.";
+			 else
+				 echo -e " \n Test $testname run succesfully $results out of 20 times. Its a regression " ;
+                fi
+         done
+ 
+

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1581,6 +1581,7 @@ sub load_extra_tests_console {
     loadtest "console/ant" if is_sle('<15-sp1');
     loadtest "console/gdb";
     loadtest "console/perf" if is_sle('<15-sp1');
+    loadtest "console/bash";
     loadtest "console/sysctl";
     loadtest "console/sysstat";
     loadtest "console/curl_ipv6";

--- a/tests/console/bash.pm
+++ b/tests/console/bash.pm
@@ -1,0 +1,80 @@
+# SUSE's openQA tests
+#
+# Copyright (C) 2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+# Summary: Bash regression test (https://progress.opensuse.org/issues/50747)
+# Maintainer: Nalmpantis Orestis (onalmpantis)
+ 
+use base "consoletest";
+use strict;
+use testapi;
+use utils 'zypper_call';
+use version_utils 'is_sle'; 
+
+sub run {
+    # Declaring repo and database variables that change depending on the product tested	
+    my $repo="";
+    my $database="";
+    if (is_sle('=12-sp1')) {
+	    $repo = "http://download.suse.de/ibs/QA:/SLE12SP1/update/QA:SLE12SP1.repo";
+	    $database = "failed_tests_database_sle12-sp1";
+    } 
+    if (is_sle('=12-sp2')) {
+	    $repo = "http://download.suse.de/ibs/QA:/SLE12SP2/update/QA:SLE12SP2.repo";
+	    $database = "failed_tests_database_sle12-sp2";
+    } 
+    if (is_sle('=12-sp3')) {
+	    $repo = "http://download.suse.de/ibs/QA:/SLE12SP3/update/QA:SLE12SP3.repo";
+	    $database = "failed_tests_database_sle12-sp3";
+    } 
+    if (is_sle('=12-sp4')) {
+	    $repo = "http://download.suse.de/ibs/QA:/SLE12SP4/update/QA:SLE12SP4.repo";
+	    $database = "failed_tests_database_sle12-sp4";
+    } 
+    if (is_sle('=15')) {
+	    $repo = "http://download.suse.de/ibs/QA:/SLE15/update/QA:SLE15.repo";
+	    $database = "failed_tests_database_sle15";
+    }
+    if (is_sle('=15-sp1')) {
+            $repo = "http://download.suse.de/ibs/QA:/SLE15SP1/update/QA:SLE15SP1.repo";
+            $database = "failed_tests_database_sle15-sp1";
+    }
+ 
+    select_console "root-console";
+    # Adding the testsuite repository
+    assert_script_run "zypper ar --no-gpgcheck $repo";
+    # Installing the testsuite
+    assert_script_run "zypper --non-interactive --no-gpg-checks in qa_test_bash";
+    # Running the testsuite
+    assert_script_run "/usr/share/qa/tools/test_bash-run", timeout => 1200;	    
+    # Locating the folder with testsuite results
+    assert_script_run "cd /var/log/qa/ctcs2/";
+    # Making sure the newest created folder is picked
+    assert_script_run 'cd `ls -th|head -n 1`';
+    # Locating Failed tests and put them on failed_tests file
+    assert_script_run 'grep -l "FAILED: bash" * > failed_tests';
+    # Sort them just in case they are not sorted
+    assert_script_run 'sort -o failed_tests failed_tests';
+    # Downloading the corresponding database of previous failed tests on this specific product
+    assert_script_run 'curl -O ' . data_url("bash_regression_test/$database");
+    # Display all the previous failed tests
+    assert_script_run "cat $database";
+    # Display all the current failed tests
+    assert_script_run "cat failed_tests";
+    # Comparing current fails with previous fails.
+    assert_script_run('while read line; do grep $line '.$database.' > NULL; if [ $? -eq 1 ]; then echo $line; fi; done < failed_tests > possible_regressions'); 
+    # Display the tests that failed only on this run and not on the previous run
+    assert_script_run "cat possible_regressions";
+    # Download the script that runs each failed test 20 times
+    assert_script_run 'curl -O ' . data_url("bash_regression_test/test_run_script");
+    assert_script_run 'bash test_run_script > results', timeout => 1200;
+    # If there is a regression, show the test and a corresponding message
+    assert_script_run '! grep "Its a regression" results'; 
+}
+ 
+ 
+1;


### PR DESCRIPTION
The scope of this test is to run the qa-bash testsuite. The test will fail every time a new test fails. It will be successful if we have no failed tests or if the failed tests are known failures. By known failures, I mean failures that are known to fail on the specific product and are gathered from previous runs of the testsuite, run from our testers. Different databases with known failures have been build from previous runs on all the different product and the results of the new run of a testsuite is always compared to these databases

Example of failure: http://10.161.229.209/tests/201#

- Related ticket: https://progress.opensuse.org/issues/50747
- Needles: None
- Verification run: 

Successful Job runs

SLE15SP1 http://10.161.229.209/tests/226
SLE15 - http://10.161.229.209/tests/227
SLE12SP4 http://10.161.229.209/tests/208
SLE12SP3 http://10.161.229.209/tests/223
SLE12SP2 http://10.161.229.209/tests/219
SLE12SP1 http://10.161.229.209/tests/216
