### PR TITLE
Public Cloud: increase timeout of first call to img-proof

### DIFF
--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -162,7 +162,7 @@ sub run_ipa {
     $args{distro}      //= 'sles';
     $args{tests} =~ s/,/ /g;
 
-    my $version = script_output('img-proof --version');
+    my $version = script_output('img-proof --version', 300);
     record_info("IPA version", $version);
 
     my $cmd = 'img-proof --no-color test ' . $args{provider};


### PR DESCRIPTION
We get timeouts in img-proof --version command which is executed right after instance creation.
After some tests measuring the time this command takes, it's random between 1 and 4 minutes and the reason is unknown, but not critical. It can be just fixed by increasing the timeout of the command execution.

- Related ticket: https://progress.opensuse.org/issues/54962
- Verification run: http://fromm.arch.suse.de/tests/6867#step/ipa/98

in the VR, I am running 5 times the same command. The first time it takes <1min. 