### PR TITLE
wicked: Use ping_with_timeout() on validation

### DIFF
--- a/lib/wickedbase.pm
+++ b/lib/wickedbase.pm
@@ -67,7 +67,7 @@ sub assert_wicked_state {
     systemctl('is-active wicked.service',  expect_false => $args{wicked_client_down});
     systemctl('is-active wickedd.service', expect_false => $args{wicked_daemon_down});
     assert_script_run(sprintf("grep -q \"%s\" /sys/class/net/%s/operstate", $args{interfaces_down} ? 'down' : 'up', $args{iface}));
-    assert_script_run("ping -c 4 $args{ping_ip}") if $args{ping_ip};
+    $self->ping_with_timeout(ip => $args{ping_ip}) if $args{ping_ip};
 }
 
 

--- a/tests/wicked/basic/sut/t05_dynamic_addresses_xml.pm
+++ b/tests/wicked/basic/sut/t05_dynamic_addresses_xml.pm
@@ -22,6 +22,7 @@ use utils 'file_content_replace';
 sub run {
     my ($self, $ctx) = @_;
     my $config = '/data/dynamic_address/dynamic-addresses.xml';
+    sleep 30;    # W/A give ovs some time for setup !?
     record_info('Info', 'Set up dynamic addresses from wicked XML files');
     $self->get_from_data('wicked/dynamic_address/dynamic-addresses.xml', $config);
     file_content_replace($config, '--sed-modifier' => 'g', xxx => $ctx->iface());


### PR DESCRIPTION
We encountered timing problems on verification ping. These problems only exists on OSD.

Also added a W/A sleep, as it seems the network-backend need some time
to realize there is a VM running. Otherwise we do not get the DHCP
OFFERS/REQUEST.

- Related ticket: https://progress.opensuse.org/issues/54197
- Verification run: https://openqa.suse.de/tests/3199646
