### PR TITLE
Add a specific console for setting up a remote VPN+SSH tunnel

### DIFF
--- a/lib/Remote/Lab.pm
+++ b/lib/Remote/Lab.pm
@@ -1,0 +1,116 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+=head1 Lab
+
+=head1 SYNOPSIS
+
+Setup VPN to a remote lab using openconnect compatible with Cisco AnyConnect
+VPN and connect.
+
+=cut
+
+package Remote::Lab;
+use strict;
+use warnings;
+use base 'Exporter';
+use Exporter;
+use registration 'add_suseconnect_product';
+use testapi;
+use utils;
+use version_utils 'is_sle';
+
+
+our @EXPORT = qw(setup_vpn connect_vpn setup_ssh_tunnels);
+
+
+sub setup_vpn {
+    my ($self) = @_;
+    add_suseconnect_product('PackageHub', undef, undef, undef, 300, 1) if is_sle;
+    zypper_call 'in --no-recommends openconnect';
+    script_run 'read -s vpn_password', 0;
+    type_password get_required_var('_SECRET_VPN_PASSWORD') . "\n";
+}
+
+sub connect_vpn {
+    my ($self) = @_;
+    my $vpn_username = get_required_var('VPN_USERNAME');
+    my $vpn_endpoint = get_var('VPN_ENDPOINT', 'asa003b.centers.ihost.com');
+    my $vpn_group    = get_var('VPN_GROUP',    'ACC');
+    # nohup should already go to background but during test development I
+    # observed that it still blocked the terminal – regardless of e.g. using a
+    # virtio serial terminal or VNC based – so let's force it to the
+    # background.
+    # accessing shell variables for the (secret) passwords defined in setup_vpn.
+    script_run "(echo \$vpn_password | nohup openconnect --user=$vpn_username --passwd-on-stdin --authgroup=$vpn_group $vpn_endpoint | tee /dev/$serialdev > vpn.log &)", 0;
+    wait_serial 'Welcome to the IBM Systems WW Client Experience Center';
+    send_key 'ret';
+    clear_console;
+}
+
+=head2 setup_ssh_tunnels
+
+    setup_ssh_tunnels()
+
+Setup tunnel(s) over SSH based on an openSSH configuration configuring a
+"jumpbox" including forwarding a port for remote log uploading.
+
+=cut
+sub setup_ssh_tunnels {
+    my ($self) = @_;
+    return if get_var('_SSH_TUNNELS_INITIALIZED');
+    zypper_call '--no-refresh in --no-recommends sshpass';
+    script_run 'read -s jumpbox_password', 0;
+    type_password get_required_var('_SECRET_JUMPBOX_PASSWORD') . "\n";
+    script_run 'read -s sut_password', 0;
+    type_password get_required_var('_SECRET_SUT_PASSWORD') . "\n";
+    assert_script_run 'ssh-keygen -t ed25519 -N \'\' -f ~/.ssh/id_ed25519';
+
+    # For the port we can reuse the same port that is used by "upload_logs"
+    # but on the remote host. The port is computed as QEMUPORT + 1
+    my $upload_port = get_required_var('QEMUPORT') + 1;
+    my $jumpbox     = get_var('JUMPBOX_HOSTNAME', '129.40.13.66');
+    my $sut         = get_var('SUT_HOSTNAME', '10.3.1.111');
+    my $upload_host = testapi::host_ip();
+    type_string "cat - > .ssh/config <<EOF
+Host jumpbox
+    HostName $jumpbox
+    StrictHostKeyChecking no
+
+Host sut
+    HostName $sut
+    ProxyJump jumpbox
+    StrictHostKeyChecking no
+EOF
+";
+    # we can switch '>>' to '>' to prevent piling up too many keys but
+    # that means overriding the keys manually added as well
+    assert_script_run 'cat ~/.ssh/id_ed25519.pub | sshpass -p $jumpbox_password ssh jumpbox "cat - >> .ssh/authorized_keys"';
+    assert_script_run 'cat ~/.ssh/id_ed25519.pub | sshpass -p $sut_password ssh sut "cat - >> .ssh/authorized_keys"';
+    # create a FIFO for serial port forwarding, reuse it when it is already
+    # there but we need to get exclusive access so terminating others
+    # potentially attached. Also use this connection for forwarding of a port
+    # for log uploading
+    script_run "ssh -t -R $upload_port:$upload_host:$upload_port sut 'mkfifo /dev/sshserial 2>/dev/null; lsof -t /dev/sshserial | xargs kill; tail -fn +1 /dev/sshserial' | tee /dev/$serialdev", 0;
+
+    # "upload_logs" uses "host_ip" which returns a host that is not available
+    # remotely but we can use an SSH tunnel for this as well so any connection
+    # from the remote SUT for uploading should reach localhost.
+    set_var('AUTOINST_URL_HOSTNAME',    'localhost');
+    set_var('_SSH_TUNNELS_INITIALIZED', 1);
+    # selecting the root console will now ensure we are connected to the
+    # remote SUT
+    select_console 'root-console';
+    # now we can redirect the serial output
+    $serialdev = 'sshserial';
+    set_var('SERIALDEV', $serialdev);
+    bmwqemu::save_vars();
+}
+
+1;

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -649,7 +649,7 @@ sub wait_boot {
         push @{$textmode_needles}, 'autoyast-init-second-stage' if get_var('AUTOYAST');
         # Soft-fail for user_defined_snapshot in extra_tests_on_gnome and extra_tests_on_gnome_on_ppc
         # if not able to boot from snapshot
-        if (get_var('EXTRATEST') !~ /desktop/) {
+        if (get_var('EXTRATEST', '') !~ /desktop/) {
             assert_screen $textmode_needles, $ready_time;
         }
         elsif (is_sle('<15') && !check_screen $textmode_needles, $ready_time / 2) {

--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -378,7 +378,7 @@ skip the entire routine.
 =cut
 sub set_standard_prompt {
     my ($self, $user, %args) = @_;
-    return if $args{skip_set_standard_prompt};
+    return if $args{skip_set_standard_prompt} || get_var('SKIP_SET_STANDARD_PROMPT');
     $user ||= $testapi::username;
     my $os_type     = $args{os_type} // 'linux';
     my $prompt_sign = $user eq 'root' ? '#' : '$';

--- a/schedule/remote_lab_poc.yaml
+++ b/schedule/remote_lab_poc.yaml
@@ -4,4 +4,5 @@ description:    >
 schedule:
      - remote_lab/setup_vpn
      - remote_lab/connect_vpn
+     - remote_lab/setup_ssh_tunnels
      - remote_lab/poc

--- a/tests/remote_lab/connect_vpn.pm
+++ b/tests/remote_lab/connect_vpn.pm
@@ -14,21 +14,13 @@
 use base 'opensusebasetest';
 use strict;
 use warnings;
+use Remote::Lab 'connect_vpn';
 use testapi;
-use utils;
+
 
 sub run {
-    my ($self) = @_;
-    my $vpn_username = get_required_var('VPN_USERNAME');
-    my $vpn_endpoint = get_var('VPN_ENDPOINT', 'asa003b.centers.ihost.com');
-    my $vpn_group    = get_var('VPN_GROUP',    'ACC');
-    # nohup should already go to background but during test development I
-    # observed that it still blocked the terminal – regardless of e.g. using a
-    # virtio serial terminal or VNC based – so let's force it to the
-    # background.
-    # accessing shell variables for the (secret) passwords defined in setup_vpn.
-    script_run "(echo \$vpn_password | nohup openconnect --user=$vpn_username --passwd-on-stdin --authgroup=$vpn_group $vpn_endpoint > vpn.log &)", 0;
-    wait_serial 'Welcome to the IBM Systems WW Client Experience Center';
+    select_console 'tunnel-console';
+    connect_vpn();
 }
 
 sub post_fail_hook {

--- a/tests/remote_lab/poc.pm
+++ b/tests/remote_lab/poc.pm
@@ -16,36 +16,15 @@ use base 'opensusebasetest';
 use strict;
 use warnings;
 use testapi;
-use utils;
+
 
 sub run {
     my ($self) = @_;
-    zypper_call '--no-refresh in --no-recommends sshpass';
-    script_run 'read -s jumpbox_password', 0;
-    type_password get_required_var('_SECRET_JUMPBOX_PASSWORD') . "\n";
-    script_run 'read -s sut_password', 0;
-    type_password get_required_var('_SECRET_SUT_PASSWORD') . "\n";
-    assert_script_run 'ssh-keygen -t ed25519 -N \'\' -f ~/.ssh/id_ed25519';
-    type_string 'cat - > .ssh/config <<EOF
-Host jumpbox
-    HostName 129.40.13.66
-    StrictHostKeyChecking no
-
-Host sut
-    HostName 10.3.1.111
-    ProxyJump jumpbox
-    StrictHostKeyChecking no
-EOF
-';
-    my $cmd = <<'EOF';
-cat ~/.ssh/id_ed25519.pub | sshpass -p $jumpbox_password ssh jumpbox "cat - >> .ssh/authorized_keys"
-cat ~/.ssh/id_ed25519.pub | sshpass -p $sut_password ssh sut "cat - >> .ssh/authorized_keys"
-time ssh sut hostname
-EOF
-    assert_script_run($_) foreach (split /\n/, $cmd);
-    assert_script_run('time ssh sut supportconfig', 600);
-    assert_script_run('ssh sut "cat /var/log/*.tbz" > sut_supportconfig.tbz');
-    upload_logs('sut_supportconfig.tbz');
+    select_console 'root-console';
+    assert_script_run('hostname | grep -q suse1', fail_message => 'It seems we are not on the right remote SUT host');
+    assert_script_run('supportconfig',            600);
+    assert_script_run('mv $(ls -t /var/log/*.tbz | head -1) supportconfig.tbz');
+    upload_logs('supportconfig.tbz');
 }
 
 1;

--- a/tests/remote_lab/setup_ssh_tunnels.pm
+++ b/tests/remote_lab/setup_ssh_tunnels.pm
@@ -7,23 +7,22 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Setup VPN to a remote lab using openconnect compatible with Cisco
-#  AnyConnect VPN
+# Summary: Setup a convenience SSH tunnel setup to a remote lab hardware for
+#  test execution
 # Maintainer: Oliver Kurz <okurz@suse.de>
 # Tags: https://progress.opensuse.org/issues/49901
 
 use base 'opensusebasetest';
 use strict;
 use warnings;
-use Remote::Lab 'setup_vpn';
 use testapi;
+use Remote::Lab 'setup_ssh_tunnels';
 
 
 sub run {
     my ($self) = @_;
-    $self->wait_boot;
     select_console 'tunnel-console';
-    setup_vpn();
+    setup_ssh_tunnels();
 }
 
 1;

--- a/variables.md
+++ b/variables.md
@@ -114,6 +114,7 @@ SUSEMIRROR | string | | Mirror url of the installation medium.
 SYSAUTHTEST | boolean | false | Enable system authentication test (`sysauth/sssd`)
 TEST | string | | Name of the test suite.
 TOGGLEHOME | boolean | false | Changes the state of partitioning to have or not to have separate home partition in the proposal.
+TUNNELED | boolean | false | Enables the use of normal consoles like "root-consoles" on a remote SUT while configuring the tunnel in a local "tunnel-console"
 UEFI | boolean | false | Indicates UEFI in the testing environment.
 UPGRADE | boolean | false | Indicates upgrade scenario.
 USBBOOT | boolean | false | Indicates booting to the usb device.

--- a/variables.md
+++ b/variables.md
@@ -104,6 +104,7 @@ SCC_ADDONS | string | | Comma separated list of modules to be enabled using SCC/
 SELECT_FIRST_DISK | boolean | false | Enables test module to select first disk for the installation. Is used for baremetal machine tests with multiple disks available, including cases when server still has previous installation.
 SEPARATE_HOME | three-state | undef | Used for scheduling the test module where separate `/home` partition should be explicitly enabled (if `1` is set) or disabled (if `0` is set). If not specified, the test module is skipped.
 SKIP_CERT_VALIDATION | boolean | false | Enables linuxrc parameter to skip certificate validation of the remote source, e.g. when using self-signed https url.
+SKIP_SET_STANDARD_PROMPT | boolean | false | Skips setting the standard prompt in shells. Can save time.
 SLE_PRODUCT | string | | Defines SLE product. Possible values: `sles`, `sled`, `sles4sap`. Is mainly used for SLE 15 installation flow.
 SOFTFAIL_BSC1063638 | boolean | false | Enable bsc#1063638 detection.
 STAGING | boolean | false | Indicates staging environment.


### PR DESCRIPTION
This selects another tty on the qemu backend to be used based on the new
test variable 'TUNNELED'. This tty is then used on a *local* VM to setup
a VPN and SSH tunnel over a jump host to a *remote* SUT which is
transparently interacted with over e.g. the "root-console". Log
uploading and usage of testapi commands using the serial port on the
remote SUT is all supported.

Needs https://github.com/os-autoinst/os-autoinst/pull/1186
and
https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1198

Verification run: http://lord.arch.suse.de/tests/2504

Related progress issue: https://progress.opensuse.org/issues/49901