### PR TITLE
Won't load grub_test_snapshot if filesystem is ext3

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1691,8 +1691,9 @@ sub load_extra_tests_toolkits {
 
 sub load_rollback_tests {
     return if check_var('ARCH', 's390x');
-    # On Xen PV we don't have GRUB
-    loadtest "boot/grub_test_snapshot" unless check_var('VIRSH_VMM_TYPE', 'linux');
+    # On Xen PV we don't have GRUB. 
+    # For continuous migration test from SLE11SP4, the filesystem is 'ext3' and btrfs snapshot is not supported.
+    loadtest "boot/grub_test_snapshot" unless check_var('VIRSH_VMM_TYPE', 'linux') || check_var('FILESYSTEM', 'ext3')
     # Skip load version switch for online migration
     loadtest "migration/version_switch_origin_system" if (!get_var("ONLINE_MIGRATION"));
     if (get_var('UPGRADE') || get_var('ZDUP')) {


### PR DESCRIPTION
For continuous migration test from SLE11, the filesystem is 'ext3' and btrfs snapshot is not supported. We can bypass the loading for grub_test_snapshot if the 'FILESYSTEM' is 'ext3'.

- Related ticket: https://progress.opensuse.org/issues/54941
- Needles: N/A
- Verification run: http://10.161.8.44/tests/256#
