### PR TITLE
Fix kernel-default-extra, reiserfs-kmp-default collision

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -38,14 +38,16 @@ sub install_packages {
         if (my ($package) = $line =~ $pattern and $1 !~ /-devel$|-patch-/) {
             # uninstall conflicting packages to allow problemless install
             my %conflict = (
-                'kernel-default'      => 'kernel-default-base',
-                'kernel-default-base' => 'kernel-default',
-                'kernel-azure'        => 'kernel-azure-base',
-                'kernel-azure-base'   => 'kernel-azure',
-                'kernel-rt'           => 'kernel-rt-base',
-                'kernel-rt-base'      => 'kernel-rt',
-                'kernel-xen'          => 'kernel-xen-base',
-                'kernel-xen-base'     => 'kernel-xen',
+                'reiserfs-kmp-default' => 'kernel-default-base',
+                'kernel-default'       => 'kernel-default-base',
+                'kernel-default-extra' => 'kernel-default-base',
+                'kernel-default-base'  => 'kernel-default',
+                'kernel-azure'         => 'kernel-azure-base',
+                'kernel-azure-base'    => 'kernel-azure',
+                'kernel-rt'            => 'kernel-rt-base',
+                'kernel-rt-base'       => 'kernel-rt',
+                'kernel-xen'           => 'kernel-xen-base',
+                'kernel-xen-base'      => 'kernel-xen',
             );
             zypper_call("rm $conflict{$package}", exitcode => [0, 104]) if $conflict{$package};
             # install package


### PR DESCRIPTION
- Fail:
https://openqa.suse.de/tests/3199758#step/update_install/67
https://openqa.suse.de/tests/3200104#step/update_install/69
- Verification run:
http://10.100.12.155/tests/12997
http://10.100.12.155/tests/12998
