### PR TITLE
Fix post_fail_hook in y2_module_consoletest module

### DIFF
--- a/lib/y2_module_consoletest.pm
+++ b/lib/y2_module_consoletest.pm
@@ -2,7 +2,7 @@
 
 package y2_module_consoletest;
 use parent 'y2_module_basetest';
-use y2_installbase qw(save_upload_y2logs save_system_logs save_strace_gdb_output);
+use y2_installbase;
 use strict;
 use warnings;
 use testapi;
@@ -43,10 +43,10 @@ sub post_fail_hook {
     show_tasks_in_blocked_state if ($defer_blocked_task_info);
 
     $self->remount_tmp_if_ro;
-    $self->save_upload_y2logs;
+    y2_installbase::save_upload_y2logs();
     upload_logs('/var/log/zypper.log', failok => 1);
-    $self->save_system_logs;
-    $self->save_strace_gdb_output('yast');
+    y2_installbase::save_system_logs();
+    y2_installbase::save_strace_gdb_output('yast');
 }
 
 sub post_run_hook {


### PR DESCRIPTION
The commit fixes function calls from y2_installbase module.

Previously, y2logs were not uploaded in post_fail_hook due to

```
post_fail_hook failed: Can't locate object method "save_upload_y2logs" via package 
"yast2_clone_system" at 
/var/lib/openqa/cache/openqa.suse.de/tests/sle/lib/y2_module_consoletest.pm line 46.
```
e.g. https://openqa.suse.de/tests/3205919


- Verification run (to show that y2logs uploaded in case of test failure): http://oorlov-vm.qa.suse.de/tests/1041
