### PR TITLE
Work key presses instability around in yast2 first boot test

### DIFF
--- a/lib/installation_user_settings.pm
+++ b/lib/installation_user_settings.pm
@@ -49,7 +49,7 @@ sub enter_rootinfo {
     assert_screen "inst-rootpassword";
     type_password_and_verification;
     assert_screen "rootpassword-typed";
-    send_key $cmd{next};
+    assert_and_click 'next-button';
     await_password_check;
 }
 

--- a/tests/installation/yast2_firstboot.pm
+++ b/tests/installation/yast2_firstboot.pm
@@ -47,7 +47,7 @@ sub license {
     }
     wait_screen_change(sub { send_key $cmd{next}; }, 7);
     # Workaround license checkbox, applicable for sle12sp5 only currently
-    assert_screen([qw(license-agreement inst-timezone)]);
+    assert_screen([qw(license-agreement inst-timezone)], 60);
     if (match_has_tag('license-agreement')) {
         record_soft_failure 'bsc#1131327 License checkbox was cleared! Re-check again!';
         send_key 'alt-a';
@@ -100,7 +100,7 @@ sub run {
     user_setup(1);
     root_setup;
     assert_screen 'installation_completed';
-    send_key $cmd{finish};
+    assert_and_click 'finish-button';
     assert_screen([qw(displaymanager generic-desktop)], 120);
 }
 


### PR DESCRIPTION
Fixes https://openqa.opensuse.org/tests/998969

Needles are created using openQA directly.

[Verification run](http://f174.suse.de/tests/279).