### PR TITLE
Enable firewalld before running RMT wizard

### DIFF
--- a/tests/console/rmt.pm
+++ b/tests/console/rmt.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -22,6 +22,8 @@ use version_utils;
 sub run {
     select_console('root-console');
 
+    # We need ensure the firewalld is enabled for the requirement of RMT wizard
+    assert_script_run('systemctl enable firewalld');
     # No need to config rmt if the system upgraded from SLE12SPx with SMT
     rmt_wizard unless (is_upgrade && (get_var('HDD_1', '') =~ /smt/));
     # mirror and sync a base repo from SCC


### PR DESCRIPTION
RMT wizard require the firewalld should be enabled before setting RMT server, while after migration from SLE12*, the firewalld will be disabled state, so we need enable firewalld manually on this scenario. 

- Related ticket: https://progress.opensuse.org/issues/53726
- Needles: N/A
- Verification run: http://10.161.8.44/tests/268#step/rmt/15
