### PR TITLE
 Allow sapconf to be used on jobs where VERSION changes

### DIFF
--- a/tests/security/apparmor/aa_autodep.pm
+++ b/tests/security/apparmor/aa_autodep.pm
@@ -15,7 +15,7 @@
 
 # Summary: Single testcase for AppArmor that guesses basic profile requirements
 # for nscd and pam using aa_autodep.
-# - Create a temporary profile for nscd in "/tmp/apparmor.d" using 
+# - Create a temporary profile for nscd in "/tmp/apparmor.d" using
 # "aa-autodep -d $aa_tmp_prof/ nscd"
 # - Check if "/tmp/apparmor.d/usr.sbin.nscd" contains required fields
 # - Create a temporaty profile for /usr/bin/pam*

--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -16,13 +16,6 @@ use version_utils qw(is_staging is_sle);
 use strict;
 use warnings;
 
-my @tuned_profiles = is_sle('>=15') ?
-  qw(balanced desktop latency-performance network-latency network-throughput
-  powersave sapconf saptune throughput-performance virtual-guest virtual-host)
-  : qw(balanced desktop latency-performance network-latency
-  network-throughput powersave sap-ase sap-bobj sap-hana sap-netweaver
-  throughput-performance virtual-guest virtual-host);
-
 my %sapconf_profiles = (
     hana   => 'sap-hana',
     b1     => 'sap-hana',
@@ -113,6 +106,12 @@ sub verify_sapconf_service {
 
 sub run {
     my ($self) = @_;
+    my @tuned_profiles = is_sle('>=15') ?
+      qw(balanced desktop latency-performance network-latency network-throughput
+      powersave sapconf saptune throughput-performance virtual-guest virtual-host)
+      : qw(balanced desktop latency-performance network-latency
+      network-throughput powersave sap-ase sap-bobj sap-hana sap-netweaver
+      throughput-performance virtual-guest virtual-host);
 
     select_console 'root-console';
 


### PR DESCRIPTION
The current version of `sles4sap/sapconf.pm` makes a decision regarding the list of sapconf profiles on load time, this makes it not compatible with tests where the value of `VERSION` changes due to `migration/version_switch_origin_system` or `migration/version_switch_upgrade_target`. This PR moves the list of sapconf profile definition within `run()` so the sapconf profiles are defined always with the current value of VERSION and fixes currently failing tests.

- Failing test: https://openqa.suse.de/tests/3210310#step/sapconf/16
- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/1220 (currently failing after profiles verification), http://mango.suse.de/tests/1183 (regression)

P.S.: also removed an unrelated trailing space in `security/apparmor/aa_autodep.pm` as perltidy was complaining.