### PR TITLE
Add libgcrypt test

### DIFF
--- a/data/libgcrypt-selftest.c
+++ b/data/libgcrypt-selftest.c
@@ -1,0 +1,22 @@
+#include <stdio.h>
+#include <gcrypt.h>
+
+int main(void) {
+    if (!gcry_check_version (GCRYPT_VERSION)) {
+        fputs ("libgcrypt version mismatch\n", stderr);
+        exit (1);
+    }
+
+    gcry_control (GCRYCTL_DISABLE_SECMEM);
+
+    gcry_control (GCRYCTL_INITIALIZATION_FINISHED);
+
+    if (gcry_control (GCRYCTL_SELFTEST, 0)) {
+        fputs ("libgcrypt selftest failed\n", stderr);
+        exit (1);
+    } else {
+        fputs ("libgcrypt selftest successful\n", stdout);
+    }
+
+    return 0;
+}

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1645,6 +1645,7 @@ sub load_extra_tests_console {
     loadtest 'console/aaa_base' unless is_jeos;
     loadtest 'console/libgpiod' if (is_leap('15.1+') || is_tumbleweed) && !(is_jeos && is_x86_64);
     loadtest 'console/osinfo_db' if (is_sle('12-SP3+') && !is_jeos);
+    loadtest 'console/libgcrypt' if ((is_sle(">=12-SP4") && (check_var_array('ADDONS', 'sdk') || check_var_array('SCC_ADDONS', 'sdk'))) || is_opensuse);
 }
 
 sub load_extra_tests_docker {

--- a/tests/console/libgcrypt.pm
+++ b/tests/console/libgcrypt.pm
@@ -1,0 +1,44 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: test that libgcrypt works as intended by executing
+#          the selftest and by calling libgcrypt-config.
+#          In addition to this test, also the gpg test should be
+#          checked by tester because gpg uses libgcrypt.
+# - execute libgcrypt self test
+# - using libgcrypt-config, check some parameters
+# Maintainer: Paolo Stivanin <pstivanin@suse.com>
+
+use base "opensusebasetest";
+use testapi;
+use utils;
+use strict;
+use warnings;
+use version_utils qw(is_sle is_opensuse);
+use registration;
+
+sub run {
+    select_console 'root-console';
+    assert_script_run "rpm -q libgcrypt20";
+    if (script_run("rpm -q libgcrypt-devel") == 1) {
+        zypper_call "in gcc libgcrypt-devel";
+    }
+
+    select_console 'user-console';
+    assert_script_run("gcc ~/data/libgcrypt-selftest.c -lgcrypt -o libgcrypt-selftest");
+    validate_script_output("./libgcrypt-selftest", sub { /libgcrypt selftest successful/ });
+
+    assert_script_run "libgcrypt-config --prefix";
+    assert_script_run "libgcrypt-config --exec-prefix";
+    assert_script_run "libgcrypt-config --version";
+    assert_script_run "libgcrypt-config --api-version";
+    assert_script_run "libgcrypt-config --algorithms";
+}
+
+1;


### PR DESCRIPTION
For SLE 12.{3,4,5}, 15.{0.1} and openSUSE Leap,TW

Compile and execute the libgcrypt self test and call `libgcrypt-config` with some different parameters.
In addition to this test, the tester should also check the result of the `gpg` test, because gpg uses also libgcrypt.

The test has been added to `mau-extratests` for SLE and `extra-tests-in-textmode` for oS.

- Related ticket: https://progress.opensuse.org/issues/53375
- Verification runs:
  - SLE 15.1: http://d250.qam.suse.de/tests/2170 :heavy_check_mark: 
  - SLE 12.5: http://d250.qam.suse.de/tests/2169 :heavy_check_mark: 
  - SLE 12.3: http://d250.qam.suse.de/tests/2167 :heavy_check_mark: 
  - oS TW: http://d250.qam.suse.de/tests/2182 :heavy_check_mark: 

