### PR TITLE
Add osinfo-db test console

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1626,6 +1626,7 @@ sub load_extra_tests_console {
     loadtest 'console/firewalld' if is_sle('15+') || is_leap('15.0+') || is_tumbleweed;
     loadtest 'console/aaa_base' unless is_jeos;
     loadtest 'console/libgpiod' if (is_leap('15.1+') || is_tumbleweed) && !(is_jeos && is_x86_64);
+    loadtest 'console/osinfo_db' if (is_sle('12-SP3+') && !is_jeos);
 }
 
 sub load_extra_tests_docker {

--- a/tests/console/osinfo_db.pm
+++ b/tests/console/osinfo_db.pm
@@ -1,0 +1,43 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Regression test osinfo-db:
+# use osinfo-query tool to query the OS database;
+# list all OSes in the database;
+# list all OSes from a specific vendor;
+# list all OSes drom a specific vendor and specified columns only;
+# If succeed, the test passes, proving All commands return without error.
+#
+# Maintainer: Marcelo Martins <mmartins@suse.cz>
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    select_console 'root-console';
+
+    #install osdbinfo packages
+    zypper_call 'in osinfo-db libosinfo';
+
+    # list all OSes in the database
+    assert_script_run "osinfo-query os";
+
+    # list all OSes from a *specific* vendor
+    assert_script_run 'osinfo-query os vendor="SUSE"';
+    assert_script_run 'osinfo-query os vendor="openSUSE"';
+
+    # list all OSes from a specific vendor *and* specified columns only
+    assert_script_run 'osinfo-query --fields=short-id,version os vendor="openSUSE"';
+    assert_script_run 'osinfo-query --fields=short-id,version os vendor="SUSE"';
+
+}
+
+1;


### PR DESCRIPTION
This script fixes poo#48473 - Regression test osinfo-db
It is using  osinfo-query tool to query the OS database
Verify osinfo-db was installed
list all OSes in the database
list all OSes from a specific vendor
list all OSes drom a specific vendor and specified columns only
Expected results:
All commands return without error

Related ticket: https://progress.opensuse.org/issues/48473
Verification run:
SLES 12 SP4 - http://10.161.229.197/tests/873
SLES 12 SP3 - http://10.161.229.197/tests/874
SLES 15 - http://10.161.229.197/tests/872
SLES 15 SP1 - http://10.161.229.197/tests/870
