### PR TITLE
Remove dracut test from extra test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1608,7 +1608,6 @@ sub load_extra_tests_console {
     loadtest 'console/quota' unless is_jeos;
     loadtest 'console/vhostmd';
     loadtest 'console/rpcbind' unless is_jeos;
-    loadtest 'console/dracut' if is_sle('12-SP5+');
     # sysauth test scenarios run in the console
     loadtest "sysauth/sssd" if get_var('SYSAUTHTEST') || is_sle('12-SP5+');
     loadtest 'console/timezone';


### PR DESCRIPTION
because we cannot fix the issue https://progress.opensuse.org/issues/46394
and we don't want dracut test blocking futher tests on remote backend.
dracut extra got scheduled already on osd.
see https://progress.opensuse.org/issues/55115 for more details
verification test:
https://progress.opensuse.org/issues/55115
