### PR TITLE
Test 2nd page in chromium for better TLS coverage

### DIFF
--- a/tests/x11/chromium.pm
+++ b/tests/x11/chromium.pm
@@ -36,6 +36,11 @@ sub run {
     wait_screen_change { send_key 'ctrl-l' };
     type_string "https://html5test.opensuse.org\n";
     assert_screen 'chromium-html-test', 90;
+
+    # check a site with different ssl configuration (boo#1144625)
+    wait_screen_change { send_key 'ctrl-l' };
+    type_string("https://upload.wikimedia.org/wikipedia/commons/d/d0/OpenSUSE_Logo.svg\n");
+    assert_screen 'chromium-opensuse-logo', 90;
     send_key 'alt-f4';
 }
 


### PR DESCRIPTION
Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/579
Related bug: https://bugzilla.opensuse.org/show_bug.cgi?id=1144625

Verification:

* Leap: http://artemis.suse.de/tests/1580
* TW: http://artemis.suse.de/tests/1578 (expected fail due to boo#1144625)