### PR TITLE
Fix QAM tests on SLES4SAP

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -961,6 +961,7 @@ sub load_inst_tests {
         if (is_sles4sap()) {
             if (
                 is_sles4sap_standard()    # Schedule module only for SLE15 with non-default role
+                || is_updates_test_repo()
                 || is_sle('15+') && get_var('SYSTEM_ROLE') && !check_var('SYSTEM_ROLE', 'default'))
             {
                 loadtest "installation/user_settings";

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -342,6 +342,7 @@ sub is_using_system_role {
       && is_server()
       && (!is_sles4sap() || is_sles4sap_standard())
       && (install_this_version() || install_to_other_at_least('12-SP2'))
+      || (is_sles4sap() && main_common::is_updates_test_repo())
       || is_sle('=15')
       || (is_sle('>15') && (check_var('SCC_REGISTER', 'installation') || get_var('ADDONS') || get_var('ADDONURL')))
       || (is_opensuse && !is_leap('<15.1'))    # Also on leap 15.1, TW, MicroOS


### PR DESCRIPTION
This PR fixes QAM tests on SLES4SAP that didn't run.

When a update repository is added as an add-on on SLES4SAP installation, the system role and user creation dialogs appear:
https://openqa.suse.de/group_overview/187

- Verification run: http://ix64hae1001.qa.suse.de./tests/416