### PR TITLE
Add sdk module for soundtouch test and exlude test on LTSS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1551,7 +1551,7 @@ sub load_extra_tests_console {
     # Audio device is not supported on ppc64le, s390x, JeOS, and Xen PV
     if (!get_var("OFW") && !is_jeos && !check_var('VIRSH_VMM_FAMILY', 'xen') && !check_var('ARCH', 's390x')) {
         loadtest "console/aplay";
-        loadtest "console/soundtouch" if is_sle('<15');
+        loadtest "console/soundtouch" if is_opensuse || (is_sle('12-sp4+') && is_sle('<15'));
         # wavpack is available only sle12sp4 onwards
         if (is_opensuse || is_sle '12-sp4+') {
             loadtest "console/wavpack";

--- a/tests/console/soundtouch.pm
+++ b/tests/console/soundtouch.pm
@@ -18,9 +18,25 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use registration qw(cleanup_registration register_product add_suseconnect_product get_addon_fullname remove_suseconnect_product);
+use version_utils 'is_sle';
 
 sub run {
     select_console 'root-console';
+    # development module needed for dependencies, released products are tested with sdk module
+    if (is_sle) {
+        if (get_var('BETA')) {
+            my $sdk_repo = is_sle('15+') ? get_var('REPO_SLE_MODULE_DEVELOPMENT_TOOLS') : get_var('REPO_SLE_SDK');
+            zypper_ar 'http://' . get_var('OPENQA_URL') . "/assets/repo/$sdk_repo", name => 'SDK';
+        }
+        # maintenance updates are registered with sdk module
+        elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
+            cleanup_registration;
+            register_product;
+            add_suseconnect_product('sle-module-desktop-applications') if is_sle('15+');
+            add_suseconnect_product(get_addon_fullname('sdk'));
+        }
+    }
     zypper_call "in soundtouch";
     zypper_call "in alsa-utils";
 
@@ -37,5 +53,15 @@ sub run {
     assert_script_run 'aplay soundtouch/1d5d9dD_rate.wav soundtouch/1d5d9dD_tempo-and-pitch.wav soundtouch/bar_bpm.wav';
     assert_recorded_sound 'soundtouch';
     assert_script_run 'rm -rf soundtouch';
+    # unregister SDK
+    if (is_sle) {
+        select_console 'root-console';
+        if (get_var('BETA')) {
+            zypper_call "rr SDK";
+        }
+        elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
+            remove_suseconnect_product(get_addon_fullname('sdk'));
+        }
+    }
 }
 1;


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/55184
- Verification run:
[TW](http://10.100.12.155/tests/13044#step/soundtouch/23)
[Leap](http://10.100.12.155/tests/13042#step/soundtouch/23)
[12sp5](http://10.100.12.155/tests/13045#step/soundtouch/32)
[12sp3](http://10.100.12.155/tests/13028) test not sheduled