### PR TITLE
Fix console selection for remote backends

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -682,7 +682,7 @@ sub activate_console {
             assert_screen "inst-console";
         }
     }
-    elsif ($console =~ m/root-console$/ && get_var('BACKEND' =~ /ikvm|ipmi|spvm/)) {
+    elsif ($console =~ m/root-console$/ && get_var('BACKEND', '') =~ /ikvm|ipmi|spvm/) {
         # Select configure serial and redirect to root-ssh instead
         use_ssh_serial_console;
         return;


### PR DESCRIPTION
Fix poo#55166: PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8020  introduced regression by not proper matching
of BACKEND variable. Fix should match content of BACKEND variable
properly.

- Related ticket: https://progress.opensuse.org/issues/55166
- Needles: none
- Verification run: