### PR TITLE
select_serial_terminal(): cleanup for ikvm, ipmi, spvm backends

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -258,6 +258,7 @@ sub get_ltp_tag {
     } else {
         $tag = get_var('DISTRI') . '-' . get_var('VERSION') . '-' . get_var('ARCH') . '-' . get_var('BUILD') . '-' . get_var('FLAVOR') . '@' . get_var('MACHINE');
     }
+    $tag =~ s/[^a-zA-Z0-9_@]+/-/g;
     return $tag . '.txt';
 }
 

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -751,8 +751,21 @@ sub remount_tmp_if_ro {
 Select most suitable text console with root user. The choice is made by
 BACKEND and other variables.
 
+Purpose of this wrapper is to avoid if/else conditions when selecting console.
+
 Optional C<root> parameter specifies, whether use root user (C<root>=1, also
 default when parameter not specified) or prefer non-root user if available.
+
+Variables affecting behavior:
+C<VIRTIO_CONSOLE>=0 disables virtio console (use {root,user}-console instead
+of the default {root-,}virtio-terminal)
+
+C<SERIAL_CONSOLE>=0 disables serial console (use {root,user}-console instead
+of the default {root-,}sut-serial)
+
+On ikvm|ipmi|spvm it's expected, that use_ssh_serial_console() has been called
+(done via activate_console()) therefore SERIALDEV has been set and we can
+use root-ssh console directly.
 =cut
 sub select_serial_terminal {
     my ($self, $root) = @_;

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -18,7 +18,6 @@
 use base 'consoletest';
 use testapi;
 use utils;
-use Utils::Backends 'use_ssh_serial_console';
 use version_utils 'is_sle';
 use serial_terminal 'add_serial_console';
 use bootloader_setup qw(change_grub_config grub_mkconfig);

--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -15,7 +15,6 @@ use warnings;
 use base 'opensusebasetest';
 use testapi;
 use bootloader_setup 'boot_grub_item';
-use Utils::Backends 'use_ssh_serial_console';
 use LTP::WhiteList 'download_whitelist';
 
 sub run {
@@ -34,12 +33,7 @@ sub run {
         $self->wait_boot(ready_time => 500);
     }
 
-    if (check_var('BACKEND', 'ipmi')) {
-        use_ssh_serial_console;
-    }
-    else {
-        $self->select_serial_terminal;
-    }
+    $self->select_serial_terminal;
 
     download_whitelist if get_var('LTP_KNOWN_ISSUES');
 

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -27,7 +27,6 @@ use serial_terminal 'add_serial_console';
 use upload_system_log;
 use version_utils qw(is_jeos is_opensuse is_released is_sle);
 use Utils::Architectures qw(is_aarch64 is_ppc64le is_s390x is_x86_64);
-use Utils::Backends 'use_ssh_serial_console';
 
 sub add_we_repo_if_available {
     # opensuse doesn't have extensions
@@ -305,12 +304,7 @@ sub run {
         add_serial_console('hvc1');
     }
 
-    if (check_var('BACKEND', 'ipmi')) {
-        use_ssh_serial_console;
-    }
-    else {
-        $self->select_serial_terminal;
-    }
+    $self->select_serial_terminal;
 
     if (script_output('cat /sys/module/printk/parameters/time') eq 'N') {
         script_run('echo 1 > /sys/module/printk/parameters/time');


### PR DESCRIPTION
More enhance `use_ssh_serial_console()` for `ikvm|ipmi|spvm` backends:
* remove unneeded `use_ssh_serial_console` in `use_ssh_serial_console()` and in LTP tests.
* document variables in `use_ssh_serial_console()`
* fix `get_ltp_tag()` for github PR verifications
* system_prepare: remove unused import

NOTE: this was meant to be a fix for VNC error on install_ltp_baremetal_mlx@ipmi-64bit-mlx_con5
https://openqa.suse.de/tests/3236027#step/shutdown_ltp/30, but that turned out to be just a bad configuration (missing `DESKTOP=textmode` variable). Thus no big change, just a cleanup and improving documentation.

Verification run:
* install_ltp_baremetal_mlx (Michie's way through iPXE)
https://openqa.suse.de/tests/3241686
* install_ltp_baremetal (openQA traditional way, fails on grub, which is not related to this change, but to differences between PRG and NUE net)
https://openqa.suse.de/tests/3241765
* ibtest-{master,slave} (master fails, but that's not related to this change)
https://openqa.suse.de/tests/3241680
https://openqa.suse.de/tests/3241681

Tested also qemu intel based tests (just for sure):
* install_ltp+sle+Server-DVD@64bit
http://quasar.suse.cz/tests/3578
* install_ltp+opensuse+DVD@64bit
http://quasar.suse.cz/tests/3583

- Related ticket: https://progress.opensuse.org/issues/39665, https://progress.opensuse.org/issues/44843#note-4
- Needles: none