### PR TITLE
Remove KEEP_GRUB_TIMEOUT from wait_grub related test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -416,7 +416,7 @@ sub load_reboot_tests {
         # test makes no sense on s390 because grub2 can't be captured
         if (!(is_s390x or (check_var('VIRSH_VMM_FAMILY', 'xen') and check_var('VIRSH_VMM_TYPE', 'linux')))) {
             # exclude this scenario for autoyast test with switched keyboard layaout
-            loadtest "installation/grub_test" unless get_var('INSTALL_KEYBOARD_LAYOUT');
+            loadtest "installation/grub_test" unless get_var('INSTALL_KEYBOARD_LAYOUT') || get_var('KEEP_GRUB_TIMEOUT');
             if ((snapper_is_applicable()) && get_var("BOOT_TO_SNAPSHOT")) {
                 loadtest "installation/boot_into_snapshot";
             }

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -439,10 +439,9 @@ sub wait_grub {
     my $in_grub         = $args{in_grub}         // 0;
     my @tags            = ('grub2');
     push @tags, 'bootloader-shim-import-prompt'   if get_var('UEFI');
-    push @tags, 'boot-live-' . get_var('DESKTOP') if get_var('LIVETEST');             # LIVETEST won't to do installation and no grub2 menu show up
+    push @tags, 'boot-live-' . get_var('DESKTOP') if get_var('LIVETEST');    # LIVETEST won't to do installation and no grub2 menu show up
     push @tags, 'bootloader'                      if get_var('OFW');
     push @tags, 'encrypted-disk-password-prompt'  if get_var('ENCRYPT');
-    push @tags, 'linux-login'                     if get_var('KEEP_GRUB_TIMEOUT');    # Also wait for linux-login if grub timeout was not disabled
     if (get_var('ONLINE_MIGRATION')) {
         push @tags, 'migration-source-system-grub2';
     }
@@ -480,12 +479,6 @@ sub wait_grub {
         # unlock encrypted disk before grub
         workaround_type_encrypted_passphrase;
         assert_screen "grub2", 15;
-    }
-    # If KEEP_GRUB_TIMEOUT is set, SUT may be at linux-login already, so no need to abort in that case
-    elsif (!match_has_tag("grub2") and !match_has_tag('linux-login')) {
-        # check_screen timeout
-        my $failneedle = get_var('KEEP_GRUB_TIMEOUT') ? 'linux-login' : 'grub2';
-        die "needle '$failneedle' not found";
     }
     mutex_wait 'support_server_ready' if get_var('USE_SUPPORT_SERVER');
 }

--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -68,9 +68,7 @@ sub run {
     workaround_type_encrypted_passphrase;
     # 60 due to rare slowness e.g. multipath poo#11908
     # 90 as a workaround due to the qemu backend fallout
-    # If grub timeout was not disabled, we wait for linux-login instead
-    my $tag = get_var('KEEP_GRUB_TIMEOUT') ? 'linux-login' : 'grub2';
-    assert_screen_with_soft_timeout($tag, timeout => 2 * $timeout, soft_timeout => $timeout, bugref => 'boo#1120256');
+    assert_screen_with_soft_timeout('grub2', timeout => 2 * $timeout, soft_timeout => $timeout, bugref => 'boo#1120256');
     stop_grub_timeout;
     boot_into_snapshot if get_var("BOOT_TO_SNAPSHOT");
     send_key_until_needlematch("bootmenu-xen-kernel", 'down', 10, 5) if get_var('XEN');


### PR DESCRIPTION
Remove KEEP_GRUB_TIMEOUT from wait_grub related test

code cleanup after merging #8142 . 