### PR TITLE
Fix service check module(double func run)

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -151,6 +151,7 @@ sub install_services {
             }
 
             assert_script_run 'systemctl start ' . $srv_proc_name;
+            systemctl 'is-active ' . $srv_proc_name;
         }
     }
 }
@@ -170,9 +171,7 @@ sub check_services {
                 next;
             }
 
-            assert_script_run 'systemctl status '
-              . $srv_proc_name
-              . ' --no-pager | grep -w active';
+            systemctl 'is-active ' . $srv_proc_name;
         }
     }
 }

--- a/tests/installation/install_service.pm
+++ b/tests/installation/install_service.pm
@@ -38,14 +38,6 @@ sub run {
       && !get_var('MEDIA_UPGRADE')
       && !get_var('ZDUP')
       && !get_var('INSTALLONLY');
-    check_services($default_services)
-      if is_sle
-      && !is_desktop
-      && !is_sles4sap
-      && !is_hyperv
-      && !get_var('MEDIA_UPGRADE')
-      && !get_var('ZDUP')
-      && !get_var('INSTALLONLY');
 }
 
 sub test_flags {


### PR DESCRIPTION
Currently, the install_service will call the full_function_check and service check which will cause the function check to run twice. we need to delete the service_check  in install_service module.
 
- Related ticket: https://progress.opensuse.org/issues/55274
- Needles: None.
- Verification run: http://10.161.8.44/tests/304
                             http://openqa.suse.de/tests/3229487#step/install_service/41
