### PR TITLE
Redirect log-console to ssh on spvm and ipmi

### DIFF
--- a/lib/susedistribution.pm
+++ b/lib/susedistribution.pm
@@ -665,7 +665,7 @@ sub activate_console {
     my ($self, $console, %args) = @_;
 
     # Select configure serial and redirect to root-ssh instead
-    return use_ssh_serial_console if (get_var('BACKEND', '') =~ /ikvm|ipmi|spvm/ && $console =~ m/root-console$|install-shell/);
+    return use_ssh_serial_console if (get_var('BACKEND', '') =~ /ikvm|ipmi|spvm/ && $console =~ m/root-console$|install-shell|log-console/);
     if ($console eq 'install-shell') {
         if (get_var("LIVECD")) {
             # LIVE CDa do not run inst-consoles as started by inst-linux (it's regular live run, auto-starting yast live installer)


### PR DESCRIPTION
With ssh installations, we will fail to switch to log console as it will simply try to switch tty instead of using ssh connection, which is the only one available for some scenarios.
This change makes it possible to collect logs in case installation fails on spvm.

[Verification run](https://openqa.suse.de/tests/3230826).
