### PR TITLE
Don't require success in 'touch' for dhcpd6

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -268,7 +268,8 @@ sub setup_network {
     assert_script_run('which ping6 >/dev/null 2>&1 || ln -s `which ping` /usr/local/bin/ping6');
 
     # dhcpd
-    assert_script_run('touch /var/lib/dhcp/db/dhcpd.leases /var/lib/dhcp6/db/dhcpd6.leases');
+    assert_script_run('touch /var/lib/dhcp/db/dhcpd.leases');
+    script_run('touch /var/lib/dhcp6/db/dhcpd6.leases');
 
     # echo/echoes, getaddrinfo_01
     assert_script_run('sed -i \'s/^\(hosts:\s+files\s\+dns$\)/\1 myhostname/\' /etc/nsswitch.conf');


### PR DESCRIPTION
On SLE11SP1TD isn't dhcp6

