### PR TITLE
Validate installation with btrfs

### DIFF
--- a/schedule/yast/opensuse/btrfs.yaml
+++ b/schedule/yast/opensuse/btrfs.yaml
@@ -1,0 +1,42 @@
+name:           btrfs
+description:    >
+  Validate default installation with btrfs.
+vars:
+  FILESYSTEM: btrfs
+schedule:
+  - installation/isosize
+  - installation/bootloader
+  - installation/welcome
+  - installation/online_repos
+  - installation/installation_mode
+  - installation/logpackages
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_filesystem
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/user_settings
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/validate_no_cow_attribute
+  - console/verify_no_separate_home
+test_data:
+  subvolume:
+    cow:
+      - /
+      - /home
+      - /root
+      - /tmp
+      - /usr/local
+      - /.snapshots
+      - /srv
+      - /opt
+    no_cow:
+      - /var

--- a/schedule/yast/sle/libstorage-ng/btrfs.yaml
+++ b/schedule/yast/sle/libstorage-ng/btrfs.yaml
@@ -1,0 +1,93 @@
+name:           btrfs
+description:    >
+  Validate default installation with btrfs and Libstorage NG.
+vars:
+  FILESYSTEM: btrfs
+schedule:
+  # Called on BACKEND: qemu
+  - {{isosize}}
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  # Called only on BACKEND: s390x
+  - {{disk_activation}}
+  - installation/scc_registration
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_filesystem
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  # Called on all, except BACKEND: s390x, ipmi
+  - {{hostname_inst}}
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  # Called on BACKEND: s390x, svirt, ipmi
+  - {{reconnect_mgmt_console}}
+  # Called on BACKEND: qemu
+  - {{grub_test}}
+  - installation/first_boot
+  - console/validate_no_cow_attribute
+  # On all the backends except s390x, /home is located on a separate partition
+  - {{validate_home_partition}}
+conditional_schedule:
+  isosize:
+    BACKEND:
+      qemu:
+        - installation/isosize
+  disk_activation:
+    BACKEND:
+      s390x:
+        - installation/disk_activation
+  reconnect_mgmt_console:
+    BACKEND:
+      s390x:
+        - boot/reconnect_mgmt_console
+      svirt:
+        - boot/reconnect_mgmt_console
+      ipmi:
+        - boot/reconnect_mgmt_console
+  grub_test:
+    BACKEND:
+      qemu:
+        - installation/grub_test
+  hostname_inst:
+    BACKEND:
+      qemu:
+        - installation/hostname_inst
+      svirt:
+        - installation/hostname_inst
+  validate_home_partition:
+    BACKEND:
+      qemu:
+        - console/verify_separate_home
+        - console/validate_file_system
+      svirt:
+        - console/verify_separate_home
+        - console/validate_file_system
+      ipmi:
+        - console/verify_separate_home
+        - console/validate_file_system
+      s390x:
+        - console/verify_no_separate_home
+test_data:
+  subvolume:
+    cow:
+      - /root
+      - /tmp
+      - /usr/local
+      - /.snapshots
+      - /srv
+      - /opt
+    no_cow:
+      - /var
+  file_system:
+    /home: xfs
+    /: btrfs

--- a/schedule/yast/sle/libstorage/btrfs.yaml
+++ b/schedule/yast/sle/libstorage/btrfs.yaml
@@ -1,0 +1,106 @@
+name:           btrfs
+description:    >
+  Validate default installation with btrfs and Libstorage.
+vars:
+  FILESYSTEM: btrfs
+schedule:
+  # Called on BACKEND: qemu
+  - {{isosize}}
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  # Called only on BACKEND: s390x
+  - {{disk_activation}}
+  - installation/scc_registration
+  - installation/addon_products_sle
+  # Called only on ARCH: x86_64
+  - {{system_role}}
+  - installation/partitioning
+  - installation/partitioning_filesystem
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  # Called on all, except BACKEND: s390x
+  - {{hostname_inst}}
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  # Called on ARCH: s390x
+  - {{reconnect_mgmt_console}}
+  # Called on BACKEND: qemu
+  - {{grub_test}}
+  - installation/first_boot
+  - console/validate_no_cow_attribute
+  # On all the architectures except s390x, /home is located on a separate partition
+  - {{validate_home_partition}}
+conditional_schedule:
+  isosize:
+    BACKEND:
+      qemu:
+        - installation/isosize
+  disk_activation:
+    BACKEND:
+      s390x:
+        - installation/disk_activation
+  system_role:
+    ARCH:
+      x86_64:
+        - installation/system_role
+  reconnect_mgmt_console:
+    ARCH:
+      s390x:
+        - boot/reconnect_mgmt_console
+  grub_test:
+    BACKEND:
+      qemu:
+        - installation/grub_test
+  hostname_inst:
+    BACKEND:
+      qemu:
+        - installation/hostname_inst
+      svirt:
+        - installation/hostname_inst
+  validate_home_partition:
+    ARCH:
+      s390x:
+        - console/verify_no_separate_home
+      x86_64:
+        - console/verify_separate_home
+        - console/validate_file_system
+      aarch64:
+        - console/verify_separate_home
+        - console/validate_file_system
+      ppc64le:
+        - console/verify_separate_home
+        - console/validate_file_system
+test_data:
+  subvolume:
+    cow:
+      - /opt
+      - /srv
+      - /tmp
+      - /usr/local
+      - /var/cache
+      - /var/crash
+      - /var/lib/machines
+      - /var/lib/mailman
+      - /var/lib/named
+      - /var/opt
+      - /var/spool
+      - /var/tmp
+      - /.snapshots
+    no_cow:
+      - /var/lib/libvirt/images
+      - /var/lib/mariadb
+      - /var/lib/mysql
+      - /var/lib/pgsql
+      - /var/log
+  file_system:
+     /home: xfs
+     /: btrfs
+     

--- a/tests/console/validate_file_system.pm
+++ b/tests/console/validate_file_system.pm
@@ -1,0 +1,36 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Validation module to check File system on partition(s).
+# Requires 'test_data->{file_system}' to be specified in yaml scheduling file,
+# so that it allows to check the File system on any amount of partitions
+# by iterating over the hash.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use scheduler 'get_test_data';
+use Test::Assert ':all';
+
+sub run {
+    my $test_data  = get_test_data();
+    my %partitions = %{$test_data->{file_system}};
+
+    foreach (keys %partitions) {
+        record_info("Check fs $_", "Verify the '$_' partition filesystem is '$partitions{$_}'");
+        my $fstype = script_output("df -PT $_ | grep -v \"Filesystem\" | awk '{print \$2}'");
+        assert_equals($partitions{$_}, $fstype,
+            "File system on '$_' partition does not correspond to the expected one");
+    }
+
+}
+
+1;

--- a/tests/console/validate_no_cow_attribute.pm
+++ b/tests/console/validate_no_cow_attribute.pm
@@ -1,0 +1,56 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: Validation module to check the following:
+#
+# 1. Verify the certain subvolumes should have No_Cow attribute.
+#    Requires 'test_data->{subvolume}->{no_cow}' with the list of subvolumes
+#    to be specified in yaml scheduling file.
+#
+# 2. Verify the certain subvolumes should NOT have No_Cow attribute.
+#    Requires 'test_data->{subvolume}->{cow}' with the list of subvolumes
+#    to be specified in yaml scheduling file.
+#
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+use strict;
+use warnings;
+use base "opensusebasetest";
+use testapi;
+use scheduler 'get_test_data';
+use Test::Assert ':all';
+
+sub run {
+    my $test_data = get_test_data();
+
+    select_console('root-console');
+
+    record_info('Test #1', "Verify the certain subvolumes should have No_COW attibute.");
+    foreach (@{$test_data->{subvolume}->{no_cow}}) {
+        my $lsattr = get_lsattr_for_subvolume($_);
+        assert_true($lsattr =~ /No_COW/i,
+            "No_COW attribute is NOT found for $_.\n
+            The output of 'lsattr -ld $_:\n$lsattr");
+    }
+
+    record_info('Test #2', "Verify the certain subvolumes should NOT have No_COW attribute.");
+    foreach (@{$test_data->{subvolume}->{cow}}) {
+        my $lsattr = get_lsattr_for_subvolume($_);
+        assert_false($lsattr =~ /No_COW/i,
+            "No_COW attribute is found for $_, though the subvolume should not has it.\n
+            The output of 'lsattr -ld $_:\n$lsattr");
+    }
+
+}
+
+sub get_lsattr_for_subvolume {
+    return script_output("lsattr -ld $_");
+}
+
+1;


### PR DESCRIPTION
The PR adds the validation for the following:
1. Verify '/home' is located on a separate partition for the installations where it is expected;
2. Verify '/home' file system is NOT btrfs for the installations where /home is on separate partition;
3. Verify the certain subvolumes should NOT have No_Cow attribute;
4. Verify the certain subvolumes should have No_Cow attribute.

- Related ticket: https://progress.opensuse.org/issues/53258
- Verification Runs: 
   - SLE 12: https://openqa.suse.de/tests/overview?distri=sle&version=12-SP5&build=0262_poo53258_investigation&groupid=132
   - SLE 15: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP1&build=228.2_poo53258_investigation&groupid=96
   - TW: https://openqa.opensuse.org/tests/1004981