### PR TITLE
Service check for y2nfs

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -21,6 +21,7 @@ use warnings;
 use version_utils 'is_sle';
 use services::apache;
 use services::dhcpd;
+use nfs_common;
 
 our @EXPORT = qw(
   $hdd_base_version
@@ -80,18 +81,14 @@ our $default_services = {
         support_ver   => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1'
     },
     nfs => {
-        srv_pkg_name  => 'yast2-nfs-server',
-        srv_proc_name => 'nfs',
-        support_ver   => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1'
+        srv_pkg_name       => 'yast2-nfs-server',
+        srv_proc_name      => 'nfs',
+        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1',
+        service_check_func => \&check_y2_nfs_func
     },
     rpcbind => {
         srv_pkg_name  => 'rpcbind',
         srv_proc_name => 'rpcbind',
-        support_ver   => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1'
-    },
-    nfs => {
-        srv_pkg_name  => 'yast2-nfs-server',
-        srv_proc_name => 'nfs',
         support_ver   => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1'
     },
     rpcbind => {


### PR DESCRIPTION
[Add y2nfs service check before/after migration]

- Related ticket: https://progress.opensuse.org/issues/55004
- Needles: n/a
- Verification run: 
latest run2109-8-19:
http://openqa.suse.de/tests/3264435 for service check on  migration scenario case
http://openqa.suse.de/tests/3264436 for function server check
run2019-08-20
http://openqa.suse.de/tests/3270133#
http://openqa.suse.de/tests/3270134#