### PR TITLE
Check registered addons before&after migration

### DIFF
--- a/tests/console/zypper_lr.pm
+++ b/tests/console/zypper_lr.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017 SUSE LLC
+# Copyright © 2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -13,12 +13,23 @@
 use base "consoletest";
 use strict;
 use warnings;
+use registration;
 use testapi;
 use utils 'zypper_call';
 
 sub run {
     select_console 'root-console';
     assert_script_run "zypper lr --uri | tee /dev/$serialdev";
+    # Check system version
+    if (get_var('VERSION')) {
+        check_registered_system(get_var('VERSION'));
+    }
+
+    if (get_var('SCC_ADDONS')) {
+        my $myaddons = get_var('SCC_ADDONS');
+        $myaddons =~ s/ltss,?//g;
+        check_registered_addons($myaddons);
+    }
 }
 
 1;

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -48,6 +48,11 @@ sub patching_sle {
         set_scc_proxy_url if ((check_var('HDDVERSION', get_var('ORIGINAL_TARGET_VERSION')) && is_upgrade()));
         sle_register("register");
         zypper_call('lr -d');
+        # Check system version
+        if (get_var('ORIGIN_SYSTEM_VERSION')) {
+            check_registered_system(get_var('ORIGIN_SYSTEM_VERSION'));
+        }
+        check_registered_addons();
     }
 
     # add test repositories and logs the required patches


### PR DESCRIPTION
Check registered addons before and after migration

- Related ticket: https://progress.opensuse.org/issues/54254
- Verification run: 
Before migration: http://10.161.8.44/tests/312#step/patch_sle/128
After migration: http://10.161.8.44/tests/312#step/zypper_lr/4