### PR TITLE
Fix installation/first_boot and x11 console selection for IPMI

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -416,7 +416,7 @@ sub load_reboot_tests {
     if (installyaststep_is_applicable()) {
         # test makes no sense on s390 because grub2 can't be captured
         if (!(is_s390x or (check_var('VIRSH_VMM_FAMILY', 'xen') and check_var('VIRSH_VMM_TYPE', 'linux')))) {
-            # exclude this scenario for autoyast test with switched keyboard layaout. also exlude on ipmi as installation/first_boot will call wait_grub
+            # exclude this scenario for autoyast test with switched keyboard layaout. also exclude on ipmi as installation/first_boot will call wait_grub
             loadtest "installation/grub_test" unless get_var('INSTALL_KEYBOARD_LAYOUT') || get_var('KEEP_GRUB_TIMEOUT') || check_var('BACKEND', 'ipmi');
             if ((snapper_is_applicable()) && get_var("BOOT_TO_SNAPSHOT")) {
                 loadtest "installation/boot_into_snapshot";

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -416,8 +416,8 @@ sub load_reboot_tests {
     if (installyaststep_is_applicable()) {
         # test makes no sense on s390 because grub2 can't be captured
         if (!(is_s390x or (check_var('VIRSH_VMM_FAMILY', 'xen') and check_var('VIRSH_VMM_TYPE', 'linux')))) {
-            # exclude this scenario for autoyast test with switched keyboard layaout
-            loadtest "installation/grub_test" unless get_var('INSTALL_KEYBOARD_LAYOUT') || get_var('KEEP_GRUB_TIMEOUT');
+            # exclude this scenario for autoyast test with switched keyboard layaout. also exlude on ipmi as installation/first_boot will call wait_grub
+            loadtest "installation/grub_test" unless get_var('INSTALL_KEYBOARD_LAYOUT') || get_var('KEEP_GRUB_TIMEOUT') || check_var('BACKEND', 'ipmi');
             if ((snapper_is_applicable()) && get_var("BOOT_TO_SNAPSHOT")) {
                 loadtest "installation/boot_into_snapshot";
             }

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -631,6 +631,7 @@ sub wait_boot {
     unlock_if_encrypted if !get_var('S390_ZKVM');
 
     if ($textmode || check_var('DESKTOP', 'textmode')) {
+        select_console('sol', await_console => 0) if check_var('BACKEND', 'ipmi');
         my $textmode_needles = [qw(linux-login emergency-shell emergency-mode)];
         # 2nd stage of autoyast can be considered as linux-login
         push @{$textmode_needles}, 'autoyast-init-second-stage' if get_var('AUTOYAST');

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -544,6 +544,7 @@ sub wait_boot {
 
     # Reset the consoles after the reboot: there is no user logged in anywhere
     reset_consoles;
+    select_console('sol', await_console => 0) if check_var('BACKEND', 'ipmi');
     # reconnect s390
     if (check_var('ARCH', 's390x')) {
         my $login_ready = get_login_message();
@@ -631,7 +632,6 @@ sub wait_boot {
     unlock_if_encrypted if !get_var('S390_ZKVM');
 
     if ($textmode || check_var('DESKTOP', 'textmode')) {
-        select_console('sol', await_console => 0) if check_var('BACKEND', 'ipmi');
         my $textmode_needles = [qw(linux-login emergency-shell emergency-mode)];
         # 2nd stage of autoyast can be considered as linux-login
         push @{$textmode_needles}, 'autoyast-init-second-stage' if get_var('AUTOYAST');

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -544,13 +544,6 @@ sub wait_boot {
 
     # Reset the consoles after the reboot: there is no user logged in anywhere
     reset_consoles;
-    # For IPMI machines PXE boot menu will appear first
-    if (check_var('BACKEND', 'ipmi')) {
-        select_console 'sol', await_console => 0;
-        # boot from harddrive
-        assert_screen([qw(virttest-pxe-menu qa-net-selection prague-pxe-menu pxe-menu)], 200);
-        send_key 'ret';
-    }
     # reconnect s390
     if (check_var('ARCH', 's390x')) {
         my $login_ready = get_login_message();

--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -51,7 +51,8 @@ sub ensure_unlocked_desktop {
                 type_string "$username";
                 save_screenshot;
             }
-            if (!check_var('DESKTOP', 'gnome') || (is_sle('<15') || is_leap('<15.0'))) {
+            # Always select user if DM_NEEDS_USERNAME is set
+            if ((!check_var('DESKTOP', 'gnome') || (is_sle('<15') || is_leap('<15.0'))) && !get_var('DM_NEEDS_USERNAME')) {
                 send_key 'ret';
             }
             # On gnome, user may not be selected and using 'ret' is not enough in this case


### PR DESCRIPTION
IPMI workers over SOL can get to the `linux-login` screen while in `wait_boot`, as can be seen in https://openqa.suse.de/tests/3238287#step/first_boot/8. This makes `wait_boot` check for `linux-login` on top of the rest of the needles, and finish if such a needle is found.

- Related ticket: N/A
- Needles: N/A
- Verification runs: https://openqa.suse.de/tests/3241098 (scenario: 
sles4sap_scc_gnome_sap_inst_wizard, failure is unrelated to this PR), https://openqa.suse.de/tests/3239318 (scenario: SLES default@64bit-ipmi, failure is unrelated to this PR)