### PR TITLE
Add TIMEOUT_SCALE on installation steps

### DIFF
--- a/lib/installsummarystep.pm
+++ b/lib/installsummarystep.pm
@@ -18,6 +18,7 @@ sub accept3rdparty {
 
 sub accept_changes_with_3rd_party_repos {
     my ($self) = @_;
+    my $timeout = 30 * get_var('TIMEOUT_SCALE', 1);    # Default timeout
     if (check_var('VIDEOMODE', 'text')) {
         send_key $cmd{accept};
         accept3rdparty;
@@ -28,7 +29,7 @@ sub accept_changes_with_3rd_party_repos {
         send_key $cmd{ok};
         accept3rdparty;
     }
-    assert_screen 'inst-overview';
+    assert_screen 'inst-overview', $timeout;
 }
 
 1;

--- a/tests/installation/await_install.pm
+++ b/tests/installation/await_install.pm
@@ -115,6 +115,8 @@ sub run {
     $timeout *= 2 if check_var_array('PATTERNS', 'all');
     # multipath installations seem to take longer (failed some time)
     $timeout *= 2 if check_var('MULTIPATH', 1);
+    # Scale timeout
+    $timeout *= get_var('TIMEOUT_SCALE', 1);
     # on s390 we might need to install additional packages depending on the installation method
     if (check_var('ARCH', 's390x')) {
         push(@tags, 'additional-packages');


### PR DESCRIPTION
Slower workers (for example, slower s390x LPARs over zKVM), require more time to finish the installation. This PR adds `TIMEOUT_SCALE` to two of the installation steps:

1. Await for installation overview
2. Await install

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/1261
