### PR TITLE
Add rpcbind service check

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -235,6 +235,7 @@ sub start_service {
 sub stop_service {
     systemctl('stop nfs-server');
     systemctl('stop rpcbind');
+    systemctl('stop rpcbind.socket');
 }
 
 sub check_service {

--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -234,6 +234,7 @@ sub start_service {
 
 sub stop_service {
     systemctl('stop nfs-server');
+    systemctl('stop rpcbind');
 }
 
 sub check_service {

--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -232,6 +232,10 @@ sub start_service {
     check_nfs_ready($rw, $ro);
 }
 
+sub stop_service {
+    systemctl('stop nfs-server');
+}
+
 sub check_service {
     my ($rw, $ro) = @_;
 
@@ -252,6 +256,9 @@ sub check_y2_nfs_func {
         start_service($rw, $ro);
     }
     check_service($rw, $ro);
+    if ($stage eq 'before') {
+        stop_service();
+    }
 }
 
 1;

--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -24,6 +24,7 @@ use services::dhcpd;
 use nfs_common;
 use services::ntpd;
 use services::cups;
+use services::rpcbind;
 
 our @EXPORT = qw(
   $hdd_base_version
@@ -90,14 +91,10 @@ our $default_services = {
         service_check_func => \&check_y2_nfs_func
     },
     rpcbind => {
-        srv_pkg_name  => 'rpcbind',
-        srv_proc_name => 'rpcbind',
-        support_ver   => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1'
-    },
-    rpcbind => {
-        srv_pkg_name  => 'rpcbind',
-        srv_proc_name => 'rpcbind',
-        support_ver   => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1'
+        srv_pkg_name       => 'rpcbind',
+        srv_proc_name      => 'rpcbind',
+        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1',
+        service_check_func => \&services::rpcbind::full_rpcbind_check
     },
     autofs => {
         srv_pkg_name  => 'autofs',

--- a/lib/services/rpcbind.pm
+++ b/lib/services/rpcbind.pm
@@ -1,0 +1,84 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Package for rpcbind service tests
+#
+# Maintainer: Alynx Zhou <alynx.zhou@suse.com>
+
+package services::rpcbind;
+use base 'opensusebasetest';
+use testapi;
+use utils;
+use strict;
+use warnings;
+
+sub install_service {
+    # rpcbind needs nfs-server for testing.
+    zypper_call('in rpcbind');
+    zypper_call('in nfs-kernel-server');
+}
+
+sub check_install {
+    assert_script_run("rpm -q rpcbind");
+    assert_script_run("rpm -q nfs-kernel-server");
+}
+
+sub config_service {
+    type_string("echo '/mnt *(ro,root_squash,sync,no_subtree_check)' > /etc/exports\n");
+    type_string("echo 'nfs is working' > /mnt/test\n");
+}
+
+sub enable_service {
+    systemctl('enable rpcbind');
+    systemctl('enable nfs-server');
+}
+
+sub start_service {
+    systemctl('start rpcbind');
+    systemctl('start nfs-server');
+}
+
+sub stop_service {
+    systemctl('stop rpcbind');
+    systemctl('stop nfs-server');
+}
+
+sub check_service {
+    systemctl('is-enabled rpcbind');
+    systemctl('is-active rpcbind');
+}
+
+sub check_function {
+    assert_script_run("rpcinfo");
+    # Wait for updated rpcinfo.
+    sleep(5);
+    assert_script_run('rpcinfo | grep nfs');
+    assert_script_run('mkdir -p /tmp/nfs');
+    assert_script_run('mount -t nfs localhost:/mnt /tmp/nfs');
+    sleep(3);
+    assert_script_run('grep working /tmp/nfs/test');
+    assert_script_run('umount -f /tmp/nfs');
+}
+
+# Check rpcbind service before and after migration.
+# Stage is 'before' or 'after' system migration.
+sub full_rpcbind_check {
+    my ($stage) = @_;
+    $stage //= '';
+    if ($stage eq 'before') {
+        install_service();
+        config_service();
+        enable_service();
+        start_service();
+    }
+    check_service();
+    check_function();
+}
+
+1;

--- a/lib/services/rpcbind.pm
+++ b/lib/services/rpcbind.pm
@@ -30,7 +30,7 @@ sub check_install {
 }
 
 sub config_service {
-    type_string("echo '/mnt *(ro,root_squash,sync,no_subtree_check)' > /etc/exports\n");
+    type_string("echo '/mnt *(ro,root_squash,sync,no_subtree_check)' >> /etc/exports\n");
     type_string("echo 'nfs is working' > /mnt/test\n");
 }
 


### PR DESCRIPTION
Add rpcbind service check (enable, config and test with nfs-server).

- Related ticket: https://progress.opensuse.org/issues/55007
- Needles: n/a
- Verification run: 
    + Migration service check(running): http://openqa.suse.de/tests/3293447
    + Console rpcbind check: http://openqa.suse.de/tests/3293288