### PR TITLE
Work around send_key problem for worker with low performance

### DIFF
--- a/tests/x11/tracker/tracker_search_in_nautilus.pm
+++ b/tests/x11/tracker/tracker_search_in_nautilus.pm
@@ -28,8 +28,8 @@ sub run {
     save_screenshot;
     send_key 'ret';
     assert_screen 'gedit-launched';    # should open file newfile
-    wait_screen_change { send_key 'alt-f4' };
-    send_key "alt-f4";
+    send_key 'alt-f4';
+    send_key_until_needlematch('generic-desktop', 'alt-f4', 3, 10);
 }
 
 1;


### PR DESCRIPTION
we have sporadic issue with closing application by
send_key alt-f4. Work around this by send_key_until_needlematch.
see https://progress.opensuse.org/issues/53639
test verification run:
http://f40.suse.de/tests/4936
