### PR TITLE
Fix hana cli installation for saptune v2

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -134,8 +134,17 @@ sub prepare_profile {
     }
 
     # Restart systemd-logind to ensure that all new connections will have the
-    # SAP tuning activated
-    systemctl 'restart systemd-logind.service';
+    # SAP tuning activated. Since saptune v2, the call to 'saptune solution apply'
+    # above can make the SUT change focus to the x11 console, which may not be ready
+    # for the systemctl command. If the systemctl command times out, change to
+    # root-console and try again. Run the first call to systemctl with
+    # ignore_failure => 1 to avoid stopping the test. Second call runs as usual
+    my $ret = systemctl('restart systemd-logind.service', ignore_failure => 1);
+    die "systemctl restart systemd-logind.service failed with retcode: [$ret]" if $ret;
+    if (!defined $ret) {
+        select_console 'root-console';
+        systemctl 'restart systemd-logind.service';
+    }
 
     # X11 workaround only on ppc64le
     if (get_var('OFW')) {
@@ -166,10 +175,23 @@ sub prepare_profile {
 
     if ($has_saptune) {
         assert_script_run "saptune daemon start";
-        if (script_run "saptune solution verify $profile") {
-            record_soft_failure("poo#54695: 'saptune solution verify' returned warnings or errors! Please check!");
+        $ret = script_run "saptune solution verify $profile";
+        if (!defined $ret) {
+            # Command timed out. 'saptune daemon start' could have caused the SUT to
+            # move out of root-console, so select root-console and try again
+            select_console 'root-console';
+            $ret = script_run "saptune solution verify $profile";
         }
-        my $output = script_output "saptune daemon status";
+        record_soft_failure("poo#54695: 'saptune solution verify' returned warnings or errors! Please check!")
+          if $ret;
+
+        my $output = script_output "saptune daemon status", proceed_on_failure => 1;
+        if (!defined $output) {
+            # Command timed out or failed. 'saptune solution verify' could have caused
+            # the SUT to move out of root-console, so select root-console and try again
+            select_console 'root-console';
+            $output = script_output "saptune daemon status";
+        }
         record_info("tuned status", $output);
     }
     else {

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -133,17 +133,19 @@ sub prepare_profile {
         assert_script_run 'tuned-adm profile $(tuned-adm recommend)';
     }
 
-    # Restart systemd-logind to ensure that all new connections will have the
-    # SAP tuning activated. Since saptune v2, the call to 'saptune solution apply'
-    # above can make the SUT change focus to the x11 console, which may not be ready
-    # for the systemctl command. If the systemctl command times out, change to
-    # root-console and try again. Run the first call to systemctl with
-    # ignore_failure => 1 to avoid stopping the test. Second call runs as usual
-    my $ret = systemctl('restart systemd-logind.service', ignore_failure => 1);
-    die "systemctl restart systemd-logind.service failed with retcode: [$ret]" if $ret;
-    if (!defined $ret) {
-        select_console 'root-console';
-        systemctl 'restart systemd-logind.service';
+    if (!$has_saptune) {
+        # Restart systemd-logind to ensure that all new connections will have the
+        # SAP tuning activated. Since saptune v2, the call to 'saptune solution apply'
+        # above can make the SUT change focus to the x11 console, which may not be ready
+        # for the systemctl command. If the systemctl command times out, change to
+        # root-console and try again. Run the first call to systemctl with
+        # ignore_failure => 1 to avoid stopping the test. Second call runs as usual
+        my $ret = systemctl('restart systemd-logind.service', ignore_failure => 1);
+        die "systemctl restart systemd-logind.service failed with retcode: [$ret]" if $ret;
+        if (!defined $ret) {
+            select_console 'root-console';
+            systemctl 'restart systemd-logind.service';
+        }
     }
 
     # X11 workaround only on ppc64le
@@ -175,7 +177,7 @@ sub prepare_profile {
 
     if ($has_saptune) {
         assert_script_run "saptune daemon start";
-        $ret = script_run "saptune solution verify $profile";
+        my $ret = script_run "saptune solution verify $profile";
         if (!defined $ret) {
             # Command timed out. 'saptune daemon start' could have caused the SUT to
             # move out of root-console, so select root-console and try again

--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -89,7 +89,13 @@ sub run {
         $hdblcm = "/sapinst/DATA_UNITS/HDB_SERVER_LINUX_PPC64/hdblcm";
         $ret    = script_run "ls $hdblcm";
     }
-    die "hdblcm is not in $hdblcm" unless (defined $ret and $ret == 0);
+    # hdblcm path can be different depending on the type of installation master in use
+    if ($ret) {
+        $hdblcm = "/sapinst/SAP_HANA_DATABASE/hdblcm";
+        $ret    = script_run "ls $hdblcm";
+    }
+    die "hdblcm is not in [/sapinst/DATA_UNITS/HDB_SERVER_LINUX_%ARCH%/hdblcm] nor in [/sapinst/SAP_HANA_DATABASE/hdblcm]"
+      unless (defined $ret and $ret == 0);
 
     # Install hana
     my @hdblcm_args = qw(--autostart=n --shell=/bin/sh --workergroup=default --system_usage=custom --batch

--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -82,20 +82,9 @@ sub run {
     assert_script_run "df -h";
 
     # Check we have an hdblcm
-    my $hdblcm = "/sapinst/DATA_UNITS/HDB_SERVER_LINUX_" . uc(get_required_var('ARCH')) . "/hdblcm";
-    my $ret    = script_run "ls $hdblcm";
-    if ($ret and get_var('OFW')) {
-        # Some older versions of hana for ppc64le have hdblcm in HDB_SERVER_LINUX_PPC64 instead
-        $hdblcm = "/sapinst/DATA_UNITS/HDB_SERVER_LINUX_PPC64/hdblcm";
-        $ret    = script_run "ls $hdblcm";
-    }
-    # hdblcm path can be different depending on the type of installation master in use
-    if ($ret) {
-        $hdblcm = "/sapinst/SAP_HANA_DATABASE/hdblcm";
-        $ret    = script_run "ls $hdblcm";
-    }
-    die "hdblcm is not in [/sapinst/DATA_UNITS/HDB_SERVER_LINUX_%ARCH%/hdblcm] nor in [/sapinst/SAP_HANA_DATABASE/hdblcm]"
-      unless (defined $ret and $ret == 0);
+    my $hdblcm = '/sapinst/' . get_var('HANA_HDBLCM', "DATA_UNITS/HDB_SERVER_LINUX_" . uc(get_required_var('ARCH')) . "/hdblcm");
+    die "hdblcm is not in [$hdblcm]. Set HANA_HDBLCM to the appropiate relative path. Example: DATA_UNITS/HDB_SERVER_LINUX_X86_64/hdblcm"
+      if (script_run "ls $hdblcm");
 
     # Install hana
     my @hdblcm_args = qw(--autostart=n --shell=/bin/sh --workergroup=default --system_usage=custom --batch


### PR DESCRIPTION
The new version of `saptune` can make the SUT change focus out of the `root-console` and back into `x11`, causing several calls with `assert_script_run`, `script_output` or `systemctl` to fail with timeouts ( http://mango.suse.de/tests/1221#step/hana_install/12 ). This PR changes those calls to `script_run`, `script_output` with `proceed_on_failure` and `systemctl` with `ignore_failure` to detect such timeouts and retry the commands after a `select_console 'root-console'.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/1264 (saptune v2), http://mango.suse.de/tests/1267 (regression), http://mango.suse.de/tests/1271 (regression without systemd-logind restart), http://mango.suse.de/tests/1273 (saptune v2 without systemd-logind restart)