### PR TITLE
[ooffice] Close "Tip of the day" dialog in desktopapps-documentation-x11

### DIFF
--- a/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
@@ -127,6 +127,14 @@ sub run {
     type_string "calc";                                                             #open calc
     assert_and_click 'overview-office-calc';
     assert_screen 'test-oocalc-1';
+    if (match_has_tag('ooffice-tip-of-the-day')) {
+        # Unselect "_S_how tips on startup", select "_O_k"
+        send_key "alt-s";
+        send_key "alt-o";
+        while (match_has_tag('ooffice-tip-of-the-day')) {
+            assert_screen 'test-oocalc-1';
+        }
+    }
     send_key "ctrl-q";                                                              #close calc
 
     $self->open_overview();

--- a/tests/x11/libreoffice/libreoffice_open_specified_file.pm
+++ b/tests/x11/libreoffice/libreoffice_open_specified_file.pm
@@ -24,7 +24,7 @@ sub run {
     $self->upload_libreoffice_specified_file();
 
     # start libreoffice
-    x11_start_program('libreoffice');
+    $self->libreoffice_start_program('libreoffice');
 
     # open test files of different formats
     my $i = 0;
@@ -36,6 +36,11 @@ sub run {
         type_string_slow "/home/$username/Documents/ooo-test-doc-types/test.$tag\n";
         wait_still_screen 3;
         assert_screen("libreoffice-test-$tag", 120);
+        if (match_has_tag('ooffice-tip-of-the-day')) {
+            # Unselect "_S_how tips on startup", select "_O_k"
+            send_key "alt-s";
+            send_key "alt-o";
+        }
         # Close every 3 files to reduce the VM's burden
         if ($i % 3 == 0) { send_key_until_needlematch('libreoffice-test-doc', 'alt-f4', 5, 10); }
         $i++;

--- a/tests/x11/libreoffice/libreoffice_recent_documents.pm
+++ b/tests/x11/libreoffice/libreoffice_recent_documents.pm
@@ -19,8 +19,10 @@ use utils;
 use version_utils qw(is_sle is_tumbleweed);
 
 sub run {
+    my ($self) = shift;
+
     # Edit file hello.odt using oowriter
-    x11_start_program('oowriter');
+    $self->libreoffice_start_program('oowriter');
     # clicking the writing area to make sure the cursor addressed there
     assert_and_click('ooffice-writing-area', timeout => 10);
     wait_still_screen;


### PR DESCRIPTION
LibreOffice 6.3 shows a "Tip of the day" dialog. Unselect the
"Show tips on startup" checkbox and close it.

Related ticket: https://progress.opensuse.org/issues/54722
Verification run: https://openqa.opensuse.org/tests/1009986
Verification run: https://openqa.opensuse.org/tests/1020089
Verification run: https://openqa.opensuse.org/tests/1020095
