### PR TITLE
Remove create_autoyast test from MicroOS

### DIFF
--- a/products/microos/main.pm
+++ b/products/microos/main.pm
@@ -29,7 +29,6 @@ sub load_boot_from_disk_tests {
 
 sub load_feature_tests {
     # Feature tests for Micro OS operating system
-    loadtest 'caasp/create_autoyast' unless check_var('VIRSH_VMM_FAMILY', 'hyperv');
     loadtest 'caasp/libzypp_config';
     loadtest 'caasp/one_line_checks';
     loadtest 'caasp/services_enabled';


### PR DESCRIPTION
We don't use it on Kubic/MicroOS, so we shouldn't test it

Needed to allow https://build.opensuse.org/request/show/722653 to pass
