### PR TITLE
Unlock encrypted disk after kdump

### DIFF
--- a/tests/console/kdump_and_crash.pm
+++ b/tests/console/kdump_and_crash.pm
@@ -8,7 +8,7 @@
 # without any warranty.
 
 # Summary: Run 'crash' utility on a kernel memory dump
-# Maintainer: Michal Nowak <mnowak@suse.com>
+# Maintainer: Petr Cervinka <pcervinka@suse.com>
 
 use base "y2_module_consoletest";
 use strict;
@@ -60,6 +60,7 @@ sub run {
     else {
         power_action('reboot', observe => 1, keepconsole => 1);
     }
+    unlock_if_encrypted;
     # Wait for system's reboot; more time for Hyper-V as it's slow.
     $self->wait_boot(bootloader_time => check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 200 : undef);
     select_console 'root-console';


### PR DESCRIPTION
Enhancement poo#54596: Add additional unlock of encrypted filesystem after kdump before boot. Change maintainer of kdump test.

- Related ticket: https://progress.opensuse.org/issues/54596
- Needles: none
- Verification run:
With encryption:
12-SP5 http://10.100.12.105/tests/2596
Without encryption:
12-SP5 http://10.100.12.105/tests/2597
15-SP1 http://10.100.12.105/tests/2593
12-SP4 http://10.100.12.105/tests/2594
12-SP3 http://10.100.12.105/tests/2591