### PR TITLE
Remove extra fold in partitioner for libstorage-ng

### DIFF
--- a/tests/installation/partitioning_raid.pm
+++ b/tests/installation/partitioning_raid.pm
@@ -201,14 +201,13 @@ sub modify_uefi_boot_partition {
     assert_screen 'partitioning_raid-disk_vdd_with_partitions-selected';
     # fold the drive tree
     send_key 'left';
-    send_key 'left' if (is_storage_ng && !is_tumbleweed);    # With storage-ng first press folds vdd, except on Tumbleweed where vdd is now already folded
     assert_screen 'partitioning_raid-hard_disks-unfolded';
     # select first partition of the first disk (usually vda1), bit of a short-cut
     send_key 'right';
     # In storage ng other partition of the first disk can be selected, so select vda1 in the tree
     send_key 'right' if is_storage_ng;
-    # On Tumbleweed, an additional 'right' is needed as vda is folded
-    send_key 'right' if (is_storage_ng && is_tumbleweed);
+    # On storage ng, an additional 'right' is needed as vda is folded
+    send_key 'right' if is_storage_ng;
     assert_screen 'partitioning_raid-disk_vda_with_partitions-selected';
     # edit first partition
     send_key 'alt-e';


### PR DESCRIPTION
The commit removes a workaround for libstorage-ng as it started behaving
in the same way as on TW. Fold is not needed anymore, as the vdd disk
is folded already.

Fixes failed: https://openqa.suse.de/tests/3248410#step/partitioning_raid/158 and https://openqa.suse.de/tests/3247815#step/partitioning_raid/158

- Verification runs: 
osd: https://openqa.suse.de/tests/3250566
TW: https://openqa.opensuse.org/t1008677
Leap: https://openqa.opensuse.org/tests/1008734