### PR TITLE
Do not expect for addon's licenses when upgrading to 12-SP5

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -109,7 +109,7 @@ sub accept_addons_license {
 
     # In SLE 15 some modules do not have license or have the same
     # license (see bsc#1089163) and so are not be shown twice
-    push @addons_with_license, @SLE15_ADDONS_WITHOUT_LICENSE unless is_sle('15+');
+    push @addons_with_license, @SLE15_ADDONS_WITHOUT_LICENSE unless (is_sle('15+') || (is_upgrade && is_sle('12-sp5+')));
     # HA and WE have licenses when calling yast2 scc
     push @addons_with_license, @SLE15_ADDONS_WITH_LICENSE_NOINSTALL if (is_sle('15+') and get_var('IN_PATCH_SLE'));
 
@@ -273,7 +273,7 @@ sub register_addons {
         # WE doesn't need code on SLED
         push @addons_with_code, 'we' unless (check_var('SLE_PRODUCT', 'sled'));
         # HA doesn't need code on SLES4SAP
-        push @addons_with_code, 'ha' unless (check_var('SLE_PRODUCT', 'sles4sap'));
+        push @addons_with_code, 'ha' unless (check_var('SLE_PRODUCT', 'sles4sap') || (is_upgrade && is_sle('12-sp5+')));
         if ((my $regcode = get_var("SCC_REGCODE_$uc_addon")) or ($addon eq "ltss")) {
             # skip addons which doesn't need to input scc code
             next unless grep { $addon eq $_ } @addons_with_code;


### PR DESCRIPTION
Media migrations with SCC to 12-SP5 do not show license for addons that share the same EULA as the base product (see related ticket).

- Failing tests: https://openqa.suse.de/tests/3242401, https://openqa.suse.de/tests/3243002, https://openqa.suse.de/tests/3242963
- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1138131#c3
- Needles: N/A
- Verification run: http://mango.suse.de/tests/1283
