### PR TITLE
Add service check for cups

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -23,6 +23,7 @@ use services::apparmor;
 use services::dhcpd;
 use nfs_common;
 use services::ntpd;
+use services::cups;
 
 our @EXPORT = qw(
   $hdd_base_version
@@ -104,9 +105,10 @@ our $default_services = {
         support_ver   => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1'
     },
     cups => {
-        srv_pkg_name  => 'cups',
-        srv_proc_name => 'cups',
-        support_ver   => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1'
+        srv_pkg_name       => 'cups',
+        srv_proc_name      => 'cups',
+        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1',
+        service_check_func => \&services::cups::full_cups_check
     },
     radvd => {
         srv_pkg_name  => 'radvd',

--- a/lib/services/cups.pm
+++ b/lib/services/cups.pm
@@ -1,0 +1,106 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Package for cups service tests
+#
+# Maintainer: Jan Baier <jbaier@suse.cz>, Lemon Li <leli@suse.com>
+
+package services::cups;
+use base 'opensusebasetest';
+use testapi;
+use utils;
+use Utils::Systemd 'disable_and_stop_service';
+use strict;
+use warnings;
+
+sub install_service {
+    zypper_call("in cups", exitcode => [0, 102, 103]);
+}
+
+sub config_service {
+    script_run 'echo FileDevice Yes >> /etc/cups/cups-files.conf';
+    validate_script_output 'cupsd -t', sub { m/is OK/ };
+}
+
+sub enable_service {
+    systemctl 'enable cups.service';
+}
+
+sub start_service {
+    systemctl 'start cups.service';
+}
+
+# check service is running and enabled
+sub check_service {
+    systemctl 'is-enabled cups.service';
+    systemctl 'is-active cups';
+}
+
+# check cups function
+sub check_function {
+    # Add printers
+    record_info "lpadmin",                                          "Try to add printers and enable them";
+    validate_script_output 'lpstat -p -d -o 2>&1 || test $? -eq 1', sub { m/lpstat: No destinations added/ };
+    assert_script_run 'lpadmin -p printer_tmp -v file:/tmp/test_cups -m raw -E';
+    assert_script_run 'lpadmin -p printer_null -v file:/dev/null -m raw -E';
+    assert_script_run 'cupsenable printer_tmp printer_null';
+    assert_script_run 'lpoptions -d printer_tmp';
+    validate_script_output 'lpstat -p -d -o', sub { m/printer_tmp is idle/ };
+
+    assert_script_run 'curl --fail -s -O -L ' . data_url('console/sample.ps');
+    assert_script_run 'curl --fail -s -O -L ' . data_url('console/testpage.pdf');
+
+    # Submit print job to the queue, list them and cancel them
+    record_info "lp, lpstat, cancel", "Submitting and canceling jobs";
+    foreach my $printer (qw(printer_tmp printer_null)) {
+        assert_script_run "cupsdisable $printer";
+        assert_script_run "lp -d $printer -o cpi=12 -o lpi=8 sample.ps";
+        validate_script_output 'lpstat -o',          sub { m/$printer-\d+/ };
+        validate_script_output 'ls /var/spool/cups', sub { m/d\d+/ };
+        assert_script_run "cancel -a $printer";
+    }
+
+    systemctl 'restart cups.service';
+    validate_script_output 'systemctl --no-pager status cups.service | cat', sub { m/Active:\s*active/ };
+
+    # Do the printing
+    record_info "lp, lpq", "Printing jobs";
+    foreach my $printer (qw(printer_tmp printer_null)) {
+        assert_script_run "cupsenable $printer";
+        assert_script_run "lp -d $printer testpage.pdf";
+        validate_script_output "lpq $printer", sub { m/is ready/ };
+    }
+
+    # Check logs
+    record_info "access_log", "Access log should containt successful job submits";
+    assert_script_run 'grep "Send-Document successful-ok" /var/log/cups/access_log';
+
+    # Remove printers
+    record_info "lpadmin -x", "Removing printers";
+    assert_script_run "lpadmin -x $_" foreach (qw(printer_tmp printer_null));
+    validate_script_output 'lpstat -p -d -o 2>&1 || test $? -eq 1', sub { m/No destinations added/ };
+}
+
+# check apache service before and after migration
+# stage is 'before' or 'after' system migration.
+sub full_cups_check {
+    my ($stage) = @_;
+    $stage //= '';
+    if ($stage eq 'before') {
+        install_service();
+        config_service();
+        enable_service();
+        start_service();
+    }
+    check_service();
+    check_function();
+    check_service();
+}
+
+1;

--- a/tests/console/cups.pm
+++ b/tests/console/cups.pm
@@ -28,61 +28,19 @@ use utils qw(systemctl zypper_call);
 use Utils::Systemd 'disable_and_stop_service';
 use version_utils;
 use Utils::Architectures;
+use services::cups;
 
 sub run {
     my $self = shift;
     $self->select_serial_terminal unless (is_s390x);
 
-    zypper_call("in cups",         exitcode => [0, 102, 103]);
-    zypper_call("in cups-filters", exitcode => [0, 102, 103]) if is_jeos;
+    services::cups::install_service();
+    services::cups::config_service();
+    services::cups::enable_service();
+    services::cups::start_service();
+    services::cups::check_service();
+    services::cups::check_function();
 
-    script_run 'echo FileDevice Yes >> /etc/cups/cups-files.conf';
-    validate_script_output 'cupsd -t', sub { m/is OK/ };
-    systemctl 'enable cups.service';
-    systemctl 'start cups.service';
-    validate_script_output 'systemctl --no-pager status cups.service | cat', sub { m/Active:\s*active/ };
-
-    # Add printers
-    record_info "lpadmin",                                          "Try to add printers and enable them";
-    validate_script_output 'lpstat -p -d -o 2>&1 || test $? -eq 1', sub { m/lpstat: No destinations added/ };
-    assert_script_run 'lpadmin -p printer_tmp -v file:/tmp/test_cups -m raw -E';
-    assert_script_run 'lpadmin -p printer_null -v file:/dev/null -m raw -E';
-    assert_script_run 'cupsenable printer_tmp printer_null';
-    assert_script_run 'lpoptions -d printer_tmp';
-    validate_script_output 'lpstat -p -d -o', sub { m/printer_tmp is idle/ };
-
-    assert_script_run 'curl --fail -s -O -L ' . data_url('console/sample.ps');
-    assert_script_run 'curl --fail -s -O -L ' . data_url('console/testpage.pdf');
-
-    # Submit print job to the queue, list them and cancel them
-    record_info "lp, lpstat, cancel", "Submitting and canceling jobs";
-    foreach my $printer (qw(printer_tmp printer_null)) {
-        assert_script_run "cupsdisable $printer";
-        assert_script_run "lp -d $printer -o cpi=12 -o lpi=8 sample.ps";
-        validate_script_output 'lpstat -o',          sub { m/$printer-\d+/ };
-        validate_script_output 'ls /var/spool/cups', sub { m/d\d+/ };
-        assert_script_run "cancel -a $printer";
-    }
-
-    systemctl 'restart cups.service';
-    validate_script_output 'systemctl --no-pager status cups.service | cat', sub { m/Active:\s*active/ };
-
-    # Do the printing
-    record_info "lp, lpq", "Printing jobs";
-    foreach my $printer (qw(printer_tmp printer_null)) {
-        assert_script_run "cupsenable $printer";
-        assert_script_run "lp -d $printer testpage.pdf";
-        validate_script_output "lpq $printer", sub { m/is ready/ };
-    }
-
-    # Check logs
-    record_info "access_log", "Access log should containt successful job submits";
-    assert_script_run 'grep "Send-Document successful-ok" /var/log/cups/access_log';
-
-    # Remove printers
-    record_info "lpadmin -x", "Removing printers";
-    assert_script_run "lpadmin -x $_" foreach (qw(printer_tmp printer_null));
-    validate_script_output 'lpstat -p -d -o 2>&1 || test $? -eq 1', sub { m/No destinations added/ };
     disable_and_stop_service('cups.service');
     validate_script_output '{ systemctl --no-pager status cups.service | cat; } || test $? -eq 3', sub { m/Active:\s*inactive/ };
 }


### PR DESCRIPTION
Add service check include enable, config, start for cups before and after migration. 

- Related ticket: https://progress.opensuse.org/issues/55013
- Needles: N/A
- Verification run: http://10.161.8.44/tests/387#step/check_upgraded_service/16  The failure is for bsc#1145696.
