### PR TITLE
Add apparmor service check

### DIFF
--- a/lib/services/apparmor.pm
+++ b/lib/services/apparmor.pm
@@ -1,0 +1,149 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Package for apparmor service tests
+#
+# Maintainer: Huajian Luo <hluo@suse.com>
+
+package services::apparmor;
+use base "apparmortest";
+use testapi;
+use utils;
+use version_utils 'is_sle';
+use warnings;
+use strict;
+
+sub install_service {
+    # apparmor need be installed by pattern
+    zypper_call 'in -t pattern apparmor';
+}
+
+sub enable_service {
+    # SLE12-SP2 doesn't support systemctl to enable apparmor
+    if (is_sle('12-SP3+', get_var('HDDVERSION'))) {
+        systemctl 'enable apparmor';
+    }
+}
+
+sub start_service {
+    systemctl 'start apparmor';
+}
+
+# check service is running and enabled
+sub check_service {
+    # SLE12-SP2 doesn't support systemctl to enable apparmor
+    if (is_sle('12-SP3+', get_var('HDDVERSION'))) {
+        systemctl 'is-enabled apparmor.service';
+    }
+    systemctl 'is-active apparmor';
+}
+
+# check aa_status
+sub check_aa_status {
+    my ($self) = @_;
+    diag 'check aa_status.';
+
+    validate_script_output "aa-status", sub {
+        m/
+        module\ is\ loaded.*
+        profiles\ are\ loaded.*
+        profiles\ are\ in\ enforce\ mode.*
+        profiles\ are\ in\ complain\ mode.*
+        processes\ are\ in\ enforce\ mode.*
+        processes\ are\ in\ complain\ mode.*
+        processes\ are\ unconfined/sxx
+    };
+}
+
+# check aa_enforce
+sub check_aa_enforce {
+    my ($self) = @_;
+    diag 'check aa_enforce.';
+
+    my $executable_name = "/usr/sbin/nscd";
+    my $profile_name    = "usr.sbin.nscd";
+    my $named_profile   = "";
+    systemctl('restart apparmor');
+
+    validate_script_output "aa-disable $executable_name", sub {
+        m/Disabling.*nscd/;
+    };
+
+    # Recalculate profile name in case
+    $named_profile = $self->get_named_profile($profile_name);
+
+    # Check if /usr/sbin/ntpd is really disabled
+    die "$executable_name should be disabled"
+      if (script_run("aa-status | sed 's/[ \t]*//g' | grep -x $named_profile") == 0);
+
+    validate_script_output "aa-enforce $executable_name", sub {
+        m/Setting.*nscd to enforce mode/;
+    };
+
+    # Check if $named_profile is in "enforce" mode
+    $self->aa_status_stdout_check($named_profile, "enforce");
+}
+
+# check aa_complain
+sub check_aa_complain {
+    my ($self) = @_;
+    diag 'check aa_complain.';
+    my $aa_tmp_prof = "/tmp/apparmor.d";
+
+    # Test both situation for default profiles location and the location
+    # specified with '-d'
+    my @aa_complain_cmds = ("aa-complain usr.sbin.nscd", "aa-complain -d $aa_tmp_prof usr.sbin.nscd");
+
+    systemctl('restart apparmor');
+
+    assert_script_run "cp -r /etc/apparmor.d $aa_tmp_prof";
+
+    foreach my $cmd (@aa_complain_cmds) {
+        validate_script_output $cmd, sub {
+            m/Setting.*nscd to complain mode/s;
+        };
+
+        # Restore to the enforce mode
+        assert_script_run "aa-enforce usr.sbin.nscd";
+    }
+
+    # Clean Up
+    assert_script_run "rm -rf $aa_tmp_prof";
+}
+
+#
+# check apparmor function
+# we check aa_status, aa_enforce and aa_complain
+# for apparmor function check.
+#
+sub check_function {
+    my ($self) = apparmortest->new();
+
+    select_console 'root-console';
+
+    check_aa_status($self);
+    check_aa_enforce($self);
+    check_aa_complain($self);
+}
+
+# check apparmor service before and after migration
+# stage is 'before' or 'after' system migration.
+sub full_apparmor_check {
+    my ($stage) = @_;
+    $stage //= '';
+    if ($stage eq 'before') {
+        install_service();
+        enable_service();
+        start_service();
+    }
+    check_service();
+    check_function();
+}
+
+1;

--- a/tests/security/apparmor/aa_complain.pm
+++ b/tests/security/apparmor/aa_complain.pm
@@ -28,34 +28,11 @@ use warnings;
 use base "consoletest";
 use testapi;
 use utils;
+use services::apparmor;
 
 sub run {
-
-    my $aa_tmp_prof = "/tmp/apparmor.d";
-
-    # Test both situation for default profiles location and the location
-    # specified with '-d'
-    my @aa_complain_cmds = ("aa-complain usr.sbin.nscd", "aa-complain -d $aa_tmp_prof usr.sbin.nscd");
-
     select_console 'root-console';
-
-    systemctl('restart apparmor');
-
-    assert_script_run "cp -r /etc/apparmor.d $aa_tmp_prof";
-
-    foreach my $cmd (@aa_complain_cmds) {
-        validate_script_output $cmd, sub {
-            m/Setting.*nscd to complain mode/s;
-        };
-        save_screenshot;
-
-        # Restore to the enforce mode
-        assert_script_run "aa-enforce usr.sbin.nscd";
-    }
-
-    # Clean Up
-    assert_script_run "rm -rf $aa_tmp_prof";
-
+    services::apparmor::check_aa_complain();
 }
 
 1;

--- a/tests/security/apparmor/aa_enforce.pm
+++ b/tests/security/apparmor/aa_enforce.pm
@@ -27,34 +27,12 @@ use warnings;
 use base "apparmortest";
 use testapi;
 use utils;
+use services::apparmor;
 
 sub run {
     my ($self) = @_;
-
-    my $executable_name = "/usr/sbin/nscd";
-    my $profile_name    = "usr.sbin.nscd";
-    my $named_profile   = "";
-    #select_console 'root-console';
-
-    systemctl('restart apparmor');
-
-    validate_script_output "aa-disable $executable_name", sub {
-        m/Disabling.*nscd/;
-    };
-
-    # Recalculate profile name in case
-    $named_profile = $self->get_named_profile($profile_name);
-
-    # Check if /usr/sbin/ntpd is really disabled
-    die "$executable_name should be disabled"
-      if (script_run("aa-status | sed 's/[ \t]*//g' | grep -x $named_profile") == 0);
-
-    validate_script_output "aa-enforce $executable_name", sub {
-        m/Setting.*nscd to enforce mode/;
-    };
-
-    # Check if $named_profile is in "enforce" mode
-    $self->aa_status_stdout_check($named_profile, "enforce");
+    select_console 'root-console';
+    services::apparmor::check_aa_enforce($self);
 }
 
 1;

--- a/tests/security/apparmor/aa_status.pm
+++ b/tests/security/apparmor/aa_status.pm
@@ -26,22 +26,12 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use services::apparmor;
 
 sub run {
     select_console 'root-console';
-
-    systemctl('is-active apparmor');
-
-    validate_script_output "aa-status", sub {
-        m/
-        module\ is\ loaded.*
-        profiles\ are\ loaded.*
-        profiles\ are\ in\ enforce\ mode.*
-        profiles\ are\ in\ complain\ mode.*
-        processes\ are\ in\ enforce\ mode.*
-        processes\ are\ in\ complain\ mode.*
-        processes\ are\ unconfined/sxx
-    };
+    services::apparmor::check_service();
+    services::apparmor::check_aa_status();
 }
 
 1;


### PR DESCRIPTION
Add apparmor service check.

- Related ticket: https://progress.opensuse.org/issues/55016
- Needles: None.
- Verification run: service_check:http://10.161.8.44/tests/389 http://10.161.8.44/tests/398
                             security/apparmor:https://openqa.suse.de/tests/3257550
                             verified on sle12sp2 to sle12sp5 http://10.161.8.44/tests/454/