### PR TITLE
sles4sap: Add missing use in saptune

### DIFF
--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -13,7 +13,7 @@
 use base "sles4sap";
 use testapi;
 use utils "zypper_call";
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_upgrade);
 use strict;
 use warnings;
 


### PR DESCRIPTION
This PR fixes this error:

\# Test died: Undefined subroutine &saptune::is_upgrade called at /var/lib/openqa/cache/openqa.suse.de/tests/sle/tests/sles4sap/saptune.pm line 52.
