### PR TITLE
Add CNI variable for flannel

### DIFF
--- a/tests/console/kubeadm.pm
+++ b/tests/console/kubeadm.pm
@@ -30,8 +30,10 @@ sub run {
     record_info 'Test #3', 'Test: Configure CNI';
     if (check_var('CNI', 'cilium')) {
         assert_script_run('kubectl apply -f /usr/share/k8s-yaml/cilium/cilium.yaml');
-    } else {
+    } elsif (check_var('CNI', 'flannel')) {
         assert_script_run('kubectl apply -f /usr/share/k8s-yaml/flannel/kube-flannel.yaml');
+    } else {
+        die('CNI variable not set, or set to unknown value');
     }
 
     record_info 'Test #4', 'Test: Record cluster info';


### PR DESCRIPTION
The kubeadm test now checks multiple different cluster network interface (CNI) providers.

These CNI providers are incompatible with podman's default cni config.

We have podman tests which are going to check for the presence of the CNI variable to know if it can use it's config or not

Therefore we need to be using the variable consistently in this test
