### PR TITLE
Wait for EULA and SCC code for addons on ONLINE_MIGRATION

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -21,7 +21,7 @@ use strict;
 use warnings;
 use testapi;
 use utils qw(addon_decline_license assert_screen_with_soft_timeout zypper_call systemctl handle_untrusted_gpg_key);
-use version_utils qw(is_sle is_caasp is_upgrade);
+use version_utils qw(is_sle is_caasp is_upgrade is_online_migration);
 use constant ADDONS_COUNT => 50;
 use y2_module_consoletest;
 
@@ -109,7 +109,7 @@ sub accept_addons_license {
 
     # In SLE 15 some modules do not have license or have the same
     # license (see bsc#1089163) and so are not be shown twice
-    push @addons_with_license, @SLE15_ADDONS_WITHOUT_LICENSE unless (is_sle('15+') || (is_upgrade && is_sle('12-sp5+')));
+    push @addons_with_license, @SLE15_ADDONS_WITHOUT_LICENSE unless (is_sle('15+') || (is_upgrade && is_sle('12-sp5+') && !is_online_migration));
     # HA and WE have licenses when calling yast2 scc
     push @addons_with_license, @SLE15_ADDONS_WITH_LICENSE_NOINSTALL if (is_sle('15+') and get_var('IN_PATCH_SLE'));
 
@@ -274,7 +274,7 @@ sub register_addons {
         # WE doesn't need code on SLED
         push @addons_with_code, 'we' unless (check_var('SLE_PRODUCT', 'sled'));
         # HA doesn't need code on SLES4SAP
-        push @addons_with_code, 'ha' unless (check_var('SLE_PRODUCT', 'sles4sap') || (is_upgrade && is_sle('12-sp5+')));
+        push @addons_with_code, 'ha' unless (check_var('SLE_PRODUCT', 'sles4sap') || (is_upgrade && is_sle('12-sp5+') && !is_online_migration));
         if ((my $regcode = get_var("SCC_REGCODE_$uc_addon")) or ($addon eq "ltss")) {
             # skip addons which doesn't need to input scc code
             next unless grep { $addon eq $_ } @addons_with_code;

--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -65,6 +65,7 @@ use constant {
           install_this_version
           install_to_other_at_least
           is_upgrade
+          is_online_migration
           is_sle12_hdd_in_upgrade
           is_installcheck
           is_desktop_installed
@@ -370,7 +371,15 @@ sub is_storage_ng {
 Returns true in upgrade scenarios
 =cut
 sub is_upgrade {
-    return get_var('UPGRADE') || get_var('ONLINE_MIGRATION') || get_var('ZDUP') || get_var('AUTOUPGRADE') || get_var('LIVE_UPGRADE');
+    return get_var('UPGRADE') || is_online_migration() || get_var('ZDUP') || get_var('AUTOUPGRADE') || get_var('LIVE_UPGRADE');
+}
+
+=head2 is_online_migration
+
+Returns true in online migration scenario
+=cut
+sub is_online_migration {
+    return get_var('ONLINE_MIGRATION');
 }
 
 =head2 is_sle12_hdd_in_upgrade


### PR DESCRIPTION
PR #8205 broke online migrations as the same code is used in those scenarios to register the previous system before running `zypper migration`. 

This PR adds a method to check whether the job is in a online migration scenario, and adds a call to that method when checking for addons without license and/or without SCC code.

- Failing tests: https://openqa.suse.de/tests/3252466 (and others in https://openqa.suse.de/tests/overview?distri=sle&version=12-SP5&build=0116%400268&groupid=157)
- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/1297 (media + SCC migration), http://mango.suse.de/tests/1296 (zypper migration)
