### PR TITLE
Autoyast profile detect profile directory

### DIFF
--- a/tests/autoyast/prepare_profile.pm
+++ b/tests/autoyast/prepare_profile.pm
@@ -30,7 +30,25 @@ sub run {
     my $path = get_required_var('AUTOYAST');
     # Get file from data directory
     my $profile = get_test_data($path);
-    # Return if profile is not available
+
+    # try to detect directory (autoyast_opensuse/, autoyast_sle{12,15}/, autoyast_sles11/)
+    # TODO: autoyast_{caasp,kvm,qam,xen}
+    my $dir    = "autoyast_";
+    my $regexp = $dir . '\E[^/]+\/';
+
+    if (!$profile && $path !~ /\Q$regexp/) {
+        my $distri = get_required_var('DISTRI');
+        if (is_sle) {
+            $distri .= "s" if is_sle('<12');    # sles11
+            my $major_version = get_required_var('VERSION');
+            $major_version =~ s/-SP.*//;
+            $distri .= $major_version;
+        }
+        $path = "$dir${distri}/$path";
+        record_info('INFO', "Trying to use path with detected folder: '$path'");
+        $profile = get_test_data($path);
+    }
+
     return unless $profile;
 
     # Profile is a template, expand and rename


### PR DESCRIPTION
autoyast: Detect profile directory

If profile path does not exist and path not already containing autoyast
directory.

This allows to have single test suite used for different SLES / openSUSE
versions, e.g.:
install_ltp_baremetal_mlx
AUTOYAST=autoyast_mlx_con5.xml
AUTOYAST_PREPARE_PROFILE=1
...

instead of having 2 (or more) test suites, which differs just with
different autoyast directory, e.g.:

install_ltp_baremetal_mlx_sle12
AUTOYAST=autoyast_sle12/autoyast_mlx_con5.xml
AUTOYAST_PREPARE_PROFILE=1
...

install_ltp_baremetal_mlx_sle15
AUTOYAST=autoyast_sle15/autoyast_mlx_con5.xml
AUTOYAST_PREPARE_PROFILE=1
Needles: N/A

Verification run:
* SLE15 (install_ltp_baremetal_mlx)
https://openqa.suse.de/tests/3331220
* SLE12 (install_ltp_baremetal_mlx)
https://openqa.suse.de/tests/3330160
