### PR TITLE
Load version_switch* to ensure upgrade to expected target for online migration

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -454,6 +454,11 @@ sub load_feature_tests {
 sub load_online_migration_tests {
     # stop packagekit service and more
     loadtest "migration/sle12_online_migration/online_migration_setup";
+    # switch VERSION to ensure migrate to expected target for online migration
+    set_var('ORIGIN_SYSTEM_VERSION',  get_var('HDDVERSION'));
+    set_var('UPGRADE_TARGET_VERSION', get_var('VERSION')) if (!get_var('UPGRADE_TARGET_VERSION'));
+    loadtest "migration/version_switch_origin_system";
+
     loadtest "migration/sle12_online_migration/register_system";
     # do full/minimal update before migration
     if (get_var("FULL_UPDATE")) {
@@ -465,6 +470,7 @@ sub load_online_migration_tests {
     if (get_var('SCC_ADDONS', '') =~ /ltss/) {
         loadtest "migration/sle12_online_migration/register_without_ltss";
     }
+    loadtest "migration/version_switch_upgrade_target";
     loadtest "migration/sle12_online_migration/pre_migration";
     loadtest 'installation/install_service' if (is_sle && !is_desktop && !get_var('INSTALLONLY'));
     if (get_var("LOCK_PACKAGE")) {


### PR DESCRIPTION
If the target of online migration is not the developing version 12SP5 while is 12SP4, ex: migration from SLE12SP3 to SLE12SP4 (continuous migration test 12SP3->12SP4->12SP5), we need to switch the VERSION from 12SP5 to 12SP4.

- Related ticket: https://progress.opensuse.org/issues/55466
- Needles: N/A
- Verification run: http://10.161.8.44/tests/384
Besides, I have run two daily job group online migration test cases to verify:
http://10.161.8.44/tests/399
http://10.161.8.44/tests/394