### PR TITLE
[Virtualization][hyperv] Delete downloaded images with wrong checksum

### DIFF
--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -122,6 +122,13 @@ sub run {
     # Verify checksums of the copied mediums
     my $errors = verify_checksum("$root\\cache\\");
     record_info("Checksum", $errors, result => 'fail') if $errors;
+    # Delete copied mediums with wrong checksum
+    foreach (split("\n", $errors)) {
+        next unless ($_ =~ m/SHA256 checksum does not match for (.*):/);
+        my $bad_image = basename(get_required_var($1));
+        record_info("Delete medium", "Trying to delete wrong checksum downloaded medium $bad_image...", result => 'fail');
+        hyperv_cmd_with_retry("del /F $root\\cache\\$bad_image");
+    }
 
     my $xvncport = get_required_var('VIRSH_INSTANCE');
     my $iso      = get_var('ISO') ? "$root\\cache\\" . basename(get_var('ISO')) : undef;


### PR DESCRIPTION
Recently,  hyperv tests usually fail by ISO checksum failure after downloading assets from osd. And for each build, when this issue happens, current code will not download any more in new tests although it is bad, so all tests fail.

It is hard to 100% avoid download issue, especially when network situation is bad. However from test code view, it can be enhanced to delete the downloaded ISOs with checksum failure and  download again with rerun. It is not implemented as repeated download immediately with purpose because bad network situation mostly last for some time. Better to try later.

- Related ticket: https://progress.opensuse.org/issues/55100
- Verification run:
successful jobs without iso checksum failure after download: https://openqa.suse.de/tests/3264335#
failure job with iso checksum failure after download:
https://openqa.suse.de/tests/3264200#step/bootloader_hyperv/12