### PR TITLE
Fix registration::check_registered_system for sles4sap

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -232,7 +232,9 @@ sub register_addons_cmd {
 
 sub check_registered_system {
     my ($system) = @_;
-    my $version = get_var('SLE_PRODUCT') . $system;
+    my $version = get_var('SLE_PRODUCT');
+    $version = 'sles' if ($version eq 'sles4sap');
+    $version .= $system;
     assert_script_run "zypper lr --uri | grep -i $version";
 }
 


### PR DESCRIPTION
PR #8172 broke over 20 SLES for SAP Migration tests in https://openqa.suse.de/tests/overview?distri=sle&version=12-SP5&build=0254&groupid=183. This fixes the problem.

- Related ticket: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8172#issuecomment-521681258
- Needles: N/A
- Verification run: N/A
