### PR TITLE
Adjust sles4sap/netweaver_test_instance for migration scenarios

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -19,6 +19,7 @@ our @EXPORT = qw(
   get_total_mem
   prepare_profile
   copy_media
+  add_hostname_to_hosts
   test_pids_max
   test_forkbomb
   test_version_info
@@ -220,6 +221,11 @@ sub copy_media {
     type_string "cd $target\n";
     assert_script_run "umount /mnt";
     assert_script_run "md5sum -c /tmp/check-nw-media", $nettout;
+}
+
+sub add_hostname_to_hosts {
+    my $netdevice = get_var('SUT_NETDEVICE', 'eth0');
+    assert_script_run "echo \$(ip -4 addr show dev $netdevice | sed -rne '/inet/s/[[:blank:]]*inet ([0-9\\.]*).*/\\1/p') \$(hostname) >> /etc/hosts";
 }
 
 sub test_pids_max {

--- a/tests/sles4sap/hana_install.pm
+++ b/tests/sles4sap/hana_install.pm
@@ -37,8 +37,7 @@ sub run {
     die "RAM=$RAM. The SUT needs at least 24G of RAM" if $RAM < 24000;
 
     # Add host's IP to /etc/hosts
-    my $netdevice = get_var('SUT_NETDEVICE', 'eth0');
-    assert_script_run "echo \$(ip -4 addr show dev $netdevice | sed -rne '/inet/s/[[:blank:]]*inet ([0-9\\.]*).*/\\1/p') \$(hostname) >> /etc/hosts";
+    $self->add_hostname_to_hosts;
 
     # This installs HANA. Start by configuring the appropiate SAP profile
     $self->prepare_profile('HANA');

--- a/tests/sles4sap/netweaver_install.pm
+++ b/tests/sles4sap/netweaver_install.pm
@@ -52,10 +52,7 @@ sub run {
     $self->copy_media($proto, $path, $timeout, '/sapinst');
 
     # Define a valid hostname/IP address in /etc/hosts, but not in HA
-    if (!get_var('HA_CLUSTER')) {
-        assert_script_run "curl -f -v " . autoinst_url . "/data/sles4sap/add_ip_hostname2hosts.sh > /tmp/add_ip_hostname2hosts.sh";
-        assert_script_run "/bin/bash -ex /tmp/add_ip_hostname2hosts.sh";
-    }
+    $self->add_hostname_to_hosts if (!get_var('HA_CLUSTER'));
 
     # Use the correct Hostname and InstanceNumber in SAP's params file
     # Note: $hostname can be '$(hostname)', so we need to protect with '"'

--- a/tests/sles4sap/netweaver_test_instance.pm
+++ b/tests/sles4sap/netweaver_test_instance.pm
@@ -16,12 +16,17 @@ use testapi;
 use strict;
 use warnings;
 use utils 'ensure_serialdev_permissions';
+use version_utils 'is_upgrade';
 
 sub run {
     my ($self) = @_;
     my $pscmd = $self->set_ps_cmd(get_required_var('INSTANCE_TYPE'));
 
     select_console 'root-console';
+
+    # On upgrade scenarios, hostname and IP address could have changed from the original
+    # installation of NetWeaver. This ensures the current hostname can be resolved
+    $self->add_hostname_to_hosts if is_upgrade;
 
     # The SAP Admin was set in sles4sap/netweaver_install
     $self->set_sap_info(get_required_var('INSTANCE_SID'), get_required_var('INSTANCE_ID'));

--- a/tests/sles4sap/netweaver_test_instance.pm
+++ b/tests/sles4sap/netweaver_test_instance.pm
@@ -26,7 +26,10 @@ sub run {
 
     # On upgrade scenarios, hostname and IP address could have changed from the original
     # installation of NetWeaver. This ensures the current hostname can be resolved
-    $self->add_hostname_to_hosts if is_upgrade;
+    if (is_upgrade) {
+        assert_script_run 'sed -i /$(hostname)/d /etc/hosts';
+        $self->add_hostname_to_hosts if is_upgrade;
+    }
 
     # The SAP Admin was set in sles4sap/netweaver_install
     $self->set_sap_info(get_required_var('INSTANCE_SID'), get_required_var('INSTANCE_ID'));

--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -83,8 +83,8 @@ sub run {
     try_reclaiming_space if (check_var('BACKEND', 'ipmi'));
 
     # Add host's IP to /etc/hosts
-    my $netdevice = get_var('SUT_NETDEVICE', 'eth0');
-    assert_script_run "echo \$(ip -4 addr show dev $netdevice | sed -rne '/inet/s/[[:blank:]]*inet ([0-9\\.]*).*/\\1/p') \$(hostname) >> /etc/hosts";
+    $self->add_hostname_to_hosts;
+
     select_console 'x11';
     # Hide the mouse so no needle will fail because of the mouse pointer appearing
     mouse_hide;


### PR DESCRIPTION
The new method to test for NetWeaver and Hana functionality after installation introduced in #8206 introduced false negatives on offline migration tests such as https://openqa.suse.de/tests/3253518#step/netweaver_test_instance/84. This is caused because the hostname and IP address from the original systems stored in the qcow2 image will not always match the one assigned during the migration test, which in turn causes some SAP services to fail to start due to name resolution problems with the old hostname.

This PR adds the current hostname to `/etc/hosts` when testing for NetWeaver on migration scenarios to workaround this issue.

Also included is a minor refactoring of the code used to add the hostname and IP address to `/etc/hosts` into `lib/sles4sap`.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://mango.suse.de/tests/1303 (migration scenario), http://mango.suse.de/tests/1305 (NetWeaver installation - failure is unrelated to this PR)