### PR TITLE
Handle unexpected pop up in console/yast2_lan_device_settings

### DIFF
--- a/tests/console/yast2_lan_device_settings.pm
+++ b/tests/console/yast2_lan_device_settings.pm
@@ -90,15 +90,22 @@ sub run {
     open_yast2_lan();
 
     send_key "alt-a";    # add another device
+    assert_screen [qw(hardware-dialog device-setup-pop-up)];
+    if (match_has_tag 'device-setup-pop-up') {
+        send_key "alt-o";
+        assert_screen 'hardware-dialog';
+    }
     send_key "tab";
+
     # open device type drop down and select vlan
-    if (is_tumbleweed) {
+    if (is_tumbleweed || is_leap('15.2+')) {
         send_key "alt-v";
     }
     else {
         for (1 .. 3) { send_key "down" }
         send_key "ret";
     }
+
     assert_screen 'add-vlan-selected';
     send_key "alt-n";    # next
     assert_screen 'edit-network-card';


### PR DESCRIPTION
Adjust console/yast2_lan_device_settings to handle an unexpected pop up that appeared on Leap 15.1, and fix test to match behaviour on Leap 15.2

- Related ticket: https://progress.opensuse.org/issues/55517
- Needles:
  - SLE: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1203
      https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1204
  - openSUSE: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/582
- Verification run:
  - SLE 15-SP1: http://dreamyhamster.suse.cz/tests/782#step/yast2_lan_device_settings/30
  - Tumbleweed: http://dreamyhamster.suse.cz/tests/779#step/yast2_lan_device_settings/30
  - Leap 15.1: http://dreamyhamster.suse.cz/tests/777#step/yast2_lan_device_settings/30
  - Leap 15.2: http://dreamyhamster.suse.cz/tests/784#step/yast2_lan_device_settings/30
  - SLE12-SP5: http://dreamyhamster.suse.cz/tests/786#step/yast2_lan_device_settings/49
