### PR TITLE
Migrate desktopapps-message from SLE to tumbleweed

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1945,9 +1945,9 @@ sub load_x11_webbrowser {
 sub load_x11_message {
     if (check_var("DESKTOP", "gnome")) {
         loadtest "x11/empathy/empathy_irc" if is_sle("<15");
-        loadtest "x11/evolution/evolution_smoke" if !is_opensuse;
+        loadtest "x11/evolution/evolution_smoke" if is_sle || is_tumbleweed;
         loadtest "x11/evolution/evolution_prepare_servers";
-        if (!is_opensuse) {
+        if (is_sle || is_tumbleweed) {
             loadtest "x11/evolution/evolution_mail_imap";
             loadtest "x11/evolution/evolution_mail_pop";
             loadtest "x11/evolution/evolution_timezone_setup";
@@ -1959,9 +1959,9 @@ sub load_x11_message {
             loadtest "x11/thunderbird/thunderbird_imap";
             loadtest "x11/thunderbird/thunderbird_pop";
         }
-        loadtest "x11/groupwise/groupwise" if !is_opensuse;
+        loadtest "x11/groupwise/groupwise" if is_sle || is_tumbleweed;
     }
-    if (get_var("DESKTOP") =~ /kde|gnome/ && !is_opensuse) {
+    if (get_var("DESKTOP") =~ /kde|gnome/ && is_sle || is_tumbleweed) {
         loadtest "x11/pidgin/prep_pidgin";
         loadtest "x11/pidgin/pidgin_IRC";
         loadtest "x11/pidgin/clean_pidgin";

--- a/lib/thunderbird_common.pm
+++ b/lib/thunderbird_common.pm
@@ -129,6 +129,19 @@ sub tb_send_message {
         unless (check_screen("thunderbird_send-message-error")) {
             wait_screen_change { send_key "alt-`" };
         }
+        # buggy part, retrying window switch up to 3 times
+        if (check_screen("thunderbird-main-window", 5)) {
+            wait_screen_change { send_key "alt-`" };
+        }
+        if (check_screen("thunderbird-main-window", 5)) {
+            sleep 5;
+            wait_screen_change { send_key "alt-`" };
+        }
+        if (check_screen("thunderbird-main-window", 5)) {
+            sleep 5;
+            wait_screen_change { send_key "super" };
+            assert_and_click "thunderbird_select-compose-window";
+        }
         wait_screen_change { assert_and_click "thunderbird_send-message-error-ok-button" };
     }
 

--- a/tests/x11/evolution/evolution_smoke.pm
+++ b/tests/x11/evolution/evolution_smoke.pm
@@ -15,7 +15,7 @@ use warnings;
 use base "x11test";
 use testapi;
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_tumbleweed);
 
 sub evolution_wizard {
     my ($self, $mail_box) = @_;
@@ -23,12 +23,7 @@ sub evolution_wizard {
     # Follow the wizard to setup mail account
     $self->start_evolution($mail_box);
     assert_screen "evolution_wizard-account-summary", 60;
-    if (is_sle('12-SP2+')) {
-        assert_and_click "evolution-option-next";
-    }
-    else {
-        send_key $self->{next};
-    }
+    assert_and_click "evolution-option-next";
 
     assert_screen "evolution_wizard-done";
     send_key "alt-a";
@@ -65,6 +60,15 @@ sub run {
     send_key "ret";
     if (check_screen "evolution_mail-init-window", 30) {
         send_key "super-up";
+    }
+    # tumbleweed may pop another auth window
+    if (is_tumbleweed) {
+        if (check_screen "evolution_mail-auth", 30) {
+            send_key "alt-a";    #disable keyring option, in SP2 or tumbleweed
+            send_key "alt-p";
+            type_string "$mail_passwd";
+            send_key "ret";
+        }
     }
     assert_screen "evolution_mail-max-window";
 

--- a/tests/x11/evolution/evolution_timezone_setup.pm
+++ b/tests/x11/evolution/evolution_timezone_setup.pm
@@ -44,8 +44,9 @@ sub run {
         send_key_until_needlematch("timezone-shanghai", "up");
     }
     else {
-        send_key_until_needlematch("timezone-asia-shanghai", "up")
-          || send_key_until_needlematch("timezone-asia-shanghai", "down");
+        send_key_until_needlematch("timezone-asia", "down");
+        send_key "right";
+        send_key_until_needlematch("timezone-asia-shanghai", "up");
     }
     send_key "ret";
     assert_screen "asia-shanghai-timezone-setup";

--- a/tests/x11/pidgin/pidgin_IRC.pm
+++ b/tests/x11/pidgin/pidgin_IRC.pm
@@ -16,7 +16,7 @@ use base "x11test";
 use strict;
 use warnings;
 use testapi;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_tumbleweed);
 
 sub run {
     my ($self) = @_;
@@ -24,7 +24,7 @@ sub run {
     x11_start_program('pidgin');
 
     # Focus the welcome window in SLE15
-    assert_and_click("pidgin-welcome-not-focused") if is_sle('>=15');
+    assert_and_click("pidgin-welcome-not-focused") if is_sle('>=15') or is_tumbleweed;
 
     # Create account
     wait_screen_change { send_key "alt-a" };

--- a/tests/x11/pidgin/prep_pidgin.pm
+++ b/tests/x11/pidgin/prep_pidgin.pm
@@ -17,7 +17,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_tumbleweed);
 
 sub run {
     mouse_hide(1);
@@ -30,10 +30,10 @@ sub run {
     # pidgin main window is hidden in tray at first run
     # need to show up the main window (12-SP2 and SP3)
     # the main window is shown correctly in SLE15
-    if (is_sle('>=15')) {
+    if (is_sle('>=15') or is_tumbleweed) {
         wait_still_screen;
     }
-    elsif (is_sle('>=12-sp2')) {
+    else {
         hold_key "ctrl-alt";
         send_key "tab";
         wait_still_screen;
@@ -43,12 +43,6 @@ sub run {
         assert_screen "status-icons";
         release_key "ctrl-alt";
         assert_and_click "status-icons-pidgin";
-    }
-    else {
-        send_key "super-m";
-        wait_still_screen;
-        send_key "ret";
-        wait_still_screen;
     }
 
     # check showoffline status is off


### PR DESCRIPTION
Migrate testcase `desktopapps-message` from [SLE12](https://openqa.suse.de/tests/latest?arch=x86_64&distri=sle&flavor=Desktop-DVD&machine=64bit&test=regression-message&version=12-SP5) and [SLE15](https://openqa.suse.de/tests/latest?arch=x86_64&distri=sle&flavor=Desktop-DVD-Updates&machine=64bit&test=qam-regression-message&version=15-SP1#) to Tumbleweed.

See https://progress.opensuse.org/issues/54887

- Related ticket: https://progress.opensuse.org/issues/54887
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/583
- Verification run: 
  - wayland: http://10.67.20.46/tests/241
  - x11: http://10.67.20.46/tests/285
  - Previous tests are unaffected: [SLE12](http://10.67.20.46/tests/291) [SLE15](http://10.67.20.46/tests/293#)