### PR TITLE
sles4sap: Disable shm test on SAP note 941735 on ppc64le / qemu

### DIFF
--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -201,6 +201,7 @@ sub test_solutions {
 sub test_ppc64le {
     my ($self) = @_;
 
+    die "This test cannot be run on QEMU" if (check_var('BACKEND', 'qemu'));
     my $SLE = is_sle(">=15") ? "SLE15" : "SLE12";
 
     assert_script_run "mr_test verify Pattern/$SLE/testpattern_Cust#Power_1";

--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -42,6 +42,10 @@ sub setup {
         # Ignore disk_elevator on VM's
         assert_script_run "sed -ri '/:scripts\\/disk_elevator/s/^/#/' \$(fgrep -rl :scripts/disk_elevator Pattern/)";
     }
+    if (get_var('OFW') && check_var('BACKEND', 'qemu')) {
+        # This test pattern fails on ppc64le on QEMU.
+        assert_script_run "sed -i '/^kernel.shm/s/^/#/' Pattern/SLE12/testpattern_note_941735_a_override";
+    }
     $self->reboot;
 }
 


### PR DESCRIPTION
This PR disables the SHM test on SAP note 941735 on ppc64le when running on QEMU.