### PR TITLE
 Exclude yast2_lan_device_settings from execution on s390x 

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1490,7 +1490,8 @@ sub load_extra_tests_desktop {
             loadtest 'x11/network/yast2_network_use_nm';
             loadtest 'x11/network/NM_wpa2_enterprise';
         }
-        loadtest "console/yast2_lan_device_settings";
+        # We cannot change network device settings as rely on ssh/vnc connection to the machine
+        loadtest "console/yast2_lan_device_settings" unless is_s390x();
         loadtest "console/check_default_network_manager";
     }
 }


### PR DESCRIPTION
After addressing [poo#54407](https://progress.opensuse.org/issues/54407) for zKVM, we got next module failing, so exclude it from the execution in the extra tests on gnome.

Coverage extension on s390 will be handled in [poo#33862](https://progress.opensuse.org/issues/33862).

VR to show that last module works: https://openqa.suse.de/tests/3264647#