### PR TITLE
Remove redundant 'if is_upgrade' from sles4sap/netweaver_test_instance

### DIFF
--- a/tests/sles4sap/netweaver_test_instance.pm
+++ b/tests/sles4sap/netweaver_test_instance.pm
@@ -28,7 +28,7 @@ sub run {
     # installation of NetWeaver. This ensures the current hostname can be resolved
     if (is_upgrade) {
         assert_script_run 'sed -i /$(hostname)/d /etc/hosts';
-        $self->add_hostname_to_hosts if is_upgrade;
+        $self->add_hostname_to_hosts;
     }
 
     # The SAP Admin was set in sles4sap/netweaver_install


### PR DESCRIPTION
PR #8223 left a dangling and redundant `if is_upgrade` in `tests/sles4sap/netweaver_test_instance`.

This removes it.

- Related ticket: https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8223#commitcomment-34738629
- Needles: N/A
- Verification run: N/A
