### PR TITLE
yast2-storage-ng: workaround for slow vms

### DIFF
--- a/tests/yast2_gui/yast2_storage_ng.pm
+++ b/tests/yast2_gui/yast2_storage_ng.pm
@@ -180,6 +180,7 @@ sub run {
     start_y2sn $self;
     select_vdb;
     wait_screen_change { send_key "alt-l" };
+    wait_still_screen 1;
     wait_screen_change { send_key "alt-y" };
     assert_screen "yast2_storage_ng-unpartitioned";
     wait_screen_change { send_key "alt-n" };


### PR DESCRIPTION
Add a `wait_still_screen` between the two `wait_screen_change` methods (as it was done between lines 186 and 188).
This should fix https://progress.opensuse.org/issues/55493

Verification run: http://d250.qam.suse.de/tests/2187
