### PR TITLE
Migrate testcase 'regression-firefox' from SLE to Tumbleweed

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1931,7 +1931,10 @@ sub load_x11_webbrowser {
     loadtest "x11/firefox/firefox_passwd";
     loadtest "x11/firefox/firefox_html5";
     loadtest "x11/firefox/firefox_developertool";
-    loadtest "x11/firefox/firefox_rss";
+    ## RSS is removed since Firefox 64
+    if (is_sle('<=15-SP1') || is_leap('<=15.1')) {
+        loadtest "x11/firefox/firefox_rss";
+    }
     loadtest "x11/firefox/firefox_ssl";
     loadtest "x11/firefox/firefox_emaillink";
     loadtest "x11/firefox/firefox_plugins";

--- a/tests/x11/firefox/firefox_changesaving.pm
+++ b/tests/x11/firefox/firefox_changesaving.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -20,7 +20,10 @@ use version_utils 'is_sle';
 sub run {
 
     my ($self) = @_;
-    my $changesaving_checktimestamp = "ll --time-style=full-iso .mozilla/firefox/*.default/prefs.js | cut -d' ' -f7";
+    my $profilename = '*.default-*';
+    $profilename = '*.default' if $self->is_firefox_60;
+
+    my $changesaving_checktimestamp = "ll --time-style=full-iso .mozilla/firefox/" . $profilename . "/prefs.js | cut -d' ' -f7";
 
     $self->start_firefox_with_profile;
 

--- a/tests/x11/firefox/firefox_extensions.pm
+++ b/tests/x11/firefox/firefox_extensions.pm
@@ -47,10 +47,13 @@ sub run {
     assert_screen('firefox-extensions-show_flag');
 
     send_key "alt-2";
-    assert_and_click('firefox-extensions-flagfox_installed');
+    if ($self->is_firefox_60) {
+        assert_and_click('firefox-extensions-flagfox_installed');
 
-    send_key "alt-1";
-    assert_screen('firefox-extensions-no_flag', 90);
+        send_key "alt-1";
+        assert_screen('firefox-extensions-no_flag', 90);
+    }
+    # for firefox 68, it needs much more to disable the extension
 
     $self->exit_firefox;
 }

--- a/tests/x11/firefox/firefox_passwd.pm
+++ b/tests/x11/firefox/firefox_passwd.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -33,7 +33,7 @@ sub run {
 
     send_key "alt-shift-u";
     wait_still_screen 3;
-    send_key 'spc';
+    send_key 'spc' if $self->is_firefox_60;
 
     assert_screen('firefox-passwd-master_setting');
 
@@ -66,15 +66,18 @@ sub run {
     send_key "alt-e";
     send_key "n";    #Preferences
     assert_and_click('firefox-passwd-security');
-    send_key "alt-shift-p";    #"Saved Passwords..."
-    send_key "alt-shift-p";    #"Show Passwords"
-    type_string $masterpw. "\n";
-    send_key "alt-shift-l";
+    if ($self->is_firefox_60) {
+        send_key "alt-shift-l";    #"Saved Logins"
+    } else {
+        ## tweak for firefox 68
+        send_key "alt-shift-l";    #"Clear Data"
+        send_key "alt-shift-l";    #"Saved Logins"
+    }
     wait_still_screen 3;
     send_key 'spc';
     assert_screen('firefox-passwd-saved');
 
-    send_key "alt-shift-a";    #"Remove"
+    send_key "alt-shift-a";        #"Remove"
     wait_still_screen 3;
     send_key "alt-y";
     wait_still_screen 3;

--- a/tests/x11/firefox/firefox_smoke.pm
+++ b/tests/x11/firefox/firefox_smoke.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2016 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -16,9 +16,13 @@ use warnings;
 use base "x11test";
 use testapi;
 use utils 'type_string_slow';
+use version_utils 'is_tumbleweed';
 
 sub run {
     my ($self) = @_;
+
+    ## some w3m files will be used later in firefox tests.
+    ensure_installed 'w3m' if is_tumbleweed;
 
     $self->start_clean_firefox;
 

--- a/tests/x11/firefox/firefox_ssl.pm
+++ b/tests/x11/firefox/firefox_ssl.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -28,11 +28,17 @@ sub run {
     # go to advanced button and press it
     send_key "tab";
     send_key "ret";
-    for (1 .. 2) { send_key "tab"; }
-    send_key "ret";
+    if ($self->is_firefox_60) {
+        for (1 .. 2) { send_key "tab"; }
+        send_key "ret";
 
-    assert_screen('firefox-ssl-addexception', 60);
-    send_key "alt-c";
+        assert_screen('firefox-ssl-addexception', 60);
+        send_key "alt-c";
+    } else {
+        ## This is new behavior for firefox 68
+        for (1 .. 4) { send_key "tab"; }
+        send_key "ret";
+    }
 
     assert_screen('firefox-ssl-loadpage', 60);
 


### PR DESCRIPTION
This commit adapts firefox testcases for current ESR release 60.x and next ESR release 68.x .

This is preparation for 15SP2 testing, which will include firefox ESR 68 soon, so we test firefox 68 in advance in Tumbleweed.

- Related ticket: https://progress.opensuse.org/issues/54884
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/584
- Verification run:
TW X11: http://147.2.212.139/tests/317
TW wayland: http://147.2.212.139/tests/318
SLED 12SP5: http://147.2.212.139/tests/319
SLED 15SP1 QAM: http://147.2.212.139/tests/321

