### PR TITLE
Partitioning: Add option to create root partition as ext4 and home partition as btrfs

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -20,6 +20,15 @@ use partition_setup qw(%partition_roles is_storage_ng_newui);
 
 sub run {
     assert_screen 'partitioning-edit-proposal-button', 40;
+    if (check_var('PARTITION_EDIT', 'ext4_btrfs')) {
+        send_key "alt-d";
+        send_key "alt-f";
+        send_key "e";
+        send_key "alt-i";
+        send_key "b";
+        assert_screen 'partitioning-ext4_root-btrfs_home';
+        send_key "alt-o";
+    }
 
     if (get_var("DUALBOOT")) {
         if (is_sle('15+')) {


### PR DESCRIPTION
Partitioning: Add option to create root partition as ext4 and home partition as btrfs

- Related ticket: https://progress.opensuse.org/issues/55118
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1202
- Verification run: 
http://10.67.133.10/tests/452    (with "PARTITION_EDIT" option)
http://10.67.133.10/tests/450    (without "PARTITION_EDIT" option)
