### PR TITLE
Chain up several virsh test modules with guest/dns setup

### DIFF
--- a/lib/virt_feature_test_base.pm
+++ b/lib/virt_feature_test_base.pm
@@ -1,0 +1,126 @@
+# VIRSH TEST MODULE BASE PACKAGE
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+#
+# Summary: This is the base package for virsh test modules, for example,
+# tests/virtualization/xen/hotplugging.pm
+# tests/virt_autotest/virsh_internal_snapshot.pm
+# tests/virt_autotest/virsh_external_snapshot.pm
+# and etc.
+# Maintainer: Wayne Chen <wchen@suse.com>
+
+package virt_feature_test_base;
+
+use base "consoletest";
+use strict;
+use warnings;
+use POSIX 'strftime';
+use File::Basename;
+use Data::Dumper;
+use XML::Writer;
+use IO::File;
+use testapi;
+use utils;
+use virt_utils;
+use xen;
+
+sub run_test {
+    die('Please override this subroutine in children modules to run desired tests.');
+}
+
+sub run {
+    my ($self) = @_;
+    $self->{"start_run"} = time();
+    $self->run_test;
+    $self->{"stop_run"} = time();
+    #(caller(0))[3] can help pass calling subroutine name into called subroutine
+    $self->junit_log_provision((caller(0))[3]) if get_var("VIRT_AUTOTEST");
+}
+
+sub junit_log_provision {
+    my ($self, $runsub) = @_;
+    my $status    = eval { $runsub =~ /post_fail_hook/img ? 'FAILED' : 'PASSED' };
+    my $tc_result = $self->analyzeResult($status);
+    $self->junit_log_params_provision($tc_result);
+    ###Load instance attributes into %stats
+    my %stats;
+    foreach (keys %{$self}) {
+        if (defined($self->{$_})) {
+            if (ref($self->{$_}) eq 'HASH') {
+                %{$stats{$_}} = %{$self->{$_}};
+            }
+            elsif (ref($self->{$_}) eq 'ARRAY') {
+                @{$stats{$_}} = @{$self->{$_}};
+            }
+            else {
+                $stats{$_} = $self->{$_};
+            }
+        }
+        else {
+            next;
+        }
+    }
+    print "The data to be used for xml generation:", Dumper(\%stats);
+    my $xml_result = generateXML_from_data($tc_result, \%stats);
+    script_run "echo \'$xml_result\' > /tmp/output.xml";
+    save_screenshot;
+    parse_junit_log("/tmp/output.xml");
+}
+
+sub junit_log_params_provision {
+    my ($self, $data) = @_;
+    my %my_hash   = %$data;
+    my $pass_nums = 0;
+    my $fail_nums = 0;
+    my $skip_nums = 0;
+    $self->{"product_tested_on"} = script_output("cat /etc/issue | grep -io \"SUSE.*\$(arch))\"");
+    $self->{"product_name"}      = ref($self);
+    $self->{"package_name"}      = ref($self);
+
+    foreach my $item (keys(%my_hash)) {
+        if ($my_hash{$item}->{status} =~ m/PASSED/) {
+            $pass_nums += 1;
+            push @{$self->{success_guest_list}}, $item;
+        }
+        elsif ($my_hash{$item}->{status} =~ m/SKIPPED/ && $item =~ m/iso/) {
+            $skip_nums += 1;
+        }
+        else {
+            $fail_nums += 1;
+        }
+    }
+    $self->{"pass_nums"} = $pass_nums;
+    $self->{"skip_nums"} = $skip_nums;
+    $self->{"fail_nums"} = $fail_nums;
+
+    diag '@{$self->{success_guest_list}} content is: ' . Dumper(@{$self->{success_guest_list}});
+}
+
+sub analyzeResult {
+    my ($self, $test_status) = @_;
+    my $result;
+    my $start_time = $self->{"start_run"};
+    my $stop_time  = $self->{"stop_run"};
+    foreach (keys %xen::guests) {
+        $result->{$_}{status} = $test_status;
+        $result->{$_}{time}   = strftime("\%H:\%M:\%S", gmtime($stop_time - $start_time));
+    }
+    delete $self->{"start_run"};
+    delete $self->{"stop_run"};
+    return $result;
+}
+
+sub post_fail_hook {
+    my ($self) = shift;
+    $self->{"stop_run"} = time();
+    $self->SUPER::post_fail_hook;
+    #(caller(0))[3] can help pass calling subroutine name into called subroutine
+    $self->junit_log_provision((caller(0))[3]) if get_var("VIRT_AUTOTEST");
+}
+
+1;

--- a/tests/virt_autotest/set_config_as_glue.pm
+++ b/tests/virt_autotest/set_config_as_glue.pm
@@ -31,7 +31,11 @@ sub fufill_guests_in_setting {
     my $get_vm_hostnames   = "virsh list  --all | grep sles | awk \'{print \$2}\'";
     my $vm_hostnames       = script_output($get_vm_hostnames, $wait_script, type_command => 0, proceed_on_failure => 0);
     my @vm_hostnames_array = split(/\n+/, $vm_hostnames);
-    foreach (@vm_hostnames_array) { $xen::guests{$_} = '1'; }
+    foreach (@vm_hostnames_array) {
+        my $get_vm_macaddress = "virsh domiflist --domain $_ | grep -oE \"([0-9|a-z]{2}:){5}[0-9|a-z]{2}\"";
+        my $vm_macaddress     = script_output($get_vm_macaddress, $wait_script, type_command => 0, proceed_on_failure => 0);
+        $xen::guests{$_}->{macaddress} = $vm_macaddress;
+    }
 }
 
 sub run {

--- a/tests/virt_autotest/virsh_external_snapshot.pm
+++ b/tests/virt_autotest/virsh_external_snapshot.pm
@@ -19,13 +19,17 @@
 # Maintainer: Leon Guo <xguo@suse.com>
 #
 
-use base "consoletest";
+use base "virt_feature_test_base";
 use strict;
 use warnings;
 use testapi;
 use set_config_as_glue;
+use utils;
+use virt_utils;
+use xen;
 
-sub run {
+sub run_test {
+    my ($self) = @_;
     #Snapshots are supported on KVM VM Host Servers only
     return unless check_var("REGRESSION", "qemu-hypervisor") || check_var("SYSTEM_ROLE", "kvm");
 

--- a/tests/virt_autotest/virsh_internal_snapshot.pm
+++ b/tests/virt_autotest/virsh_internal_snapshot.pm
@@ -18,13 +18,17 @@
 # Summary: Test VM internal snapshot using virsh (create - restore - delete)
 # Maintainer: Leon Guo <xguo@suse.com>
 
-use base "consoletest";
+use base "virt_feature_test_base";
 use strict;
 use warnings;
 use testapi;
 use set_config_as_glue;
+use utils;
+use virt_utils;
+use xen;
 
-sub run {
+sub run_test {
+    my ($self) = @_;
     #Snapshots are supported on KVM VM Host Servers only
     return unless check_var("REGRESSION", "qemu-hypervisor") || check_var("SYSTEM_ROLE", "kvm");
 
@@ -52,7 +56,6 @@ sub run {
         assert_script_run "virsh snapshot-delete $guest --snapshotname internal-snapshot-$guest-02";
         assert_script_run("! virsh snapshot-list $guest | grep internal-snapshot-$guest-02");
     }
-
 }
 
 1;

--- a/tests/virt_autotest/virt_autotest_base.pm
+++ b/tests/virt_autotest/virt_autotest_base.pm
@@ -31,17 +31,11 @@ sub get_script_run {
 
 sub generateXML {
     my ($self, $data) = @_;
-
     print Dumper($data);
-    my %my_hash = %$data;
-
-    my $case_num = scalar(keys %my_hash);
-    my $case_status;
-    my $xml_result;
+    my %my_hash   = %$data;
     my $pass_nums = 0;
     my $fail_nums = 0;
     my $skip_nums = 0;
-    my $writer    = XML::Writer->new(DATA_MODE => 'true', DATA_INDENT => 2, OUTPUT => 'self');
 
     foreach my $item (keys(%my_hash)) {
         if ($my_hash{$item}->{status} =~ m/PASSED/) {
@@ -55,67 +49,27 @@ sub generateXML {
             $fail_nums += 1;
         }
     }
-
     diag '@{$self->{success_guest_list}} content is: ' . Dumper(@{$self->{success_guest_list}});
-
-    my $count = $pass_nums + $fail_nums + $skip_nums;
-    $writer->startTag(
-        'testsuites',
-        error    => "0",
-        failures => "$fail_nums",
-        name     => $self->{product_name},
-        skipped  => "0",
-        tests    => "$count",
-        time     => ""
-    );
-    $writer->startTag(
-        'testsuite',
-        error     => "0",
-        failures  => "$fail_nums",
-        hostname  => "`hostname`",
-        id        => "0",
-        name      => $self->{product_tested_on},
-        package   => $self->{package_name},
-        skipped   => "0",
-        tests     => $case_num,
-        time      => "",
-        timestamp => "2016-02-16T02:50:00"
-    );
-
-    foreach my $item (keys(%my_hash)) {
-        if ($my_hash{$item}->{status} =~ m/PASSED/) {
-            $case_status = "success";
-        }
-        elsif ($my_hash{$item}->{status} =~ m/SKIPPED/ && $item =~ m/iso/) {
-            $case_status = "skipped";
+    ###Load instance attributes into %xmldata
+    my %xmldata;
+    foreach (keys %{$self}) {
+        if (defined($self->{$_})) {
+            if (ref($self->{$_}) eq 'HASH') {
+                %{$xmldata{$_}} = %{$self->{$_}};
+            }
+            elsif (ref($self->{$_}) eq 'ARRAY') {
+                @{$xmldata{$_}} = @{$self->{$_}};
+            }
+            else {
+                $xmldata{$_} = $self->{$_};
+            }
         }
         else {
-            $case_status = "failure";
+            next;
         }
-
-        $writer->startTag(
-            'testcase',
-            classname => $item,
-            name      => $item,
-            status    => $case_status,
-            time      => $my_hash{$item}->{time});
-        $writer->startTag('system-err');
-        my $system_err = ($my_hash{$item}->{error} ? $my_hash{$item}->{error} : 'None');
-        $writer->characters("$system_err");
-        $writer->endTag('system-err');
-
-        $writer->startTag('system-out');
-        $writer->characters($my_hash{$item}->{time});
-        $writer->endTag('system-out');
-
-        $writer->endTag('testcase');
     }
-
-    $writer->endTag('testsuite');
-    $writer->endTag('testsuites');
-
-    $writer->end();
-    $writer->to_string();
+    print "The data to be used for xml generation:", Dumper(\%xmldata);
+    generateXML_from_data($data, \%xmldata);
 }
 
 sub execute_script_run {

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -16,6 +16,7 @@ use base Exporter;
 use Exporter;
 use strict;
 use warnings;
+use Sys::Hostname;
 use File::Basename;
 use testapi;
 use Data::Dumper;
@@ -25,7 +26,7 @@ use proxymode;
 use version_utils 'is_sle';
 
 our @EXPORT
-  = qw(update_guest_configurations_with_daily_build repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd upload_virt_logs generate_guest_asset_name get_guest_disk_name_from_guest_xml compress_single_qcow2_disk upload_supportconfig_log download_guest_assets is_installed_equal_upgrade_major_release);
+  = qw(update_guest_configurations_with_daily_build repl_addon_with_daily_build_module_in_files repl_module_in_sourcefile handle_sp_in_settings handle_sp_in_settings_with_fcs handle_sp_in_settings_with_sp0 clean_up_red_disks lpar_cmd upload_virt_logs generate_guest_asset_name get_guest_disk_name_from_guest_xml compress_single_qcow2_disk upload_supportconfig_log download_guest_assets is_installed_equal_upgrade_major_release generateXML_from_data);
 
 sub get_version_for_daily_build_guest {
     my $version = '';
@@ -379,6 +380,74 @@ sub is_installed_equal_upgrade_major_release {
     my $host_upgrade_version = get_var('UPGRADE_PRODUCT', 'sles-1-sp0');                   #format sles-15-sp0
     ($host_upgrade_version) = $host_upgrade_version =~ /sles-(\d+)-sp/i;
     return $host_installed_version eq $host_upgrade_version;
+}
+
+#Generate XML to be consumed by junit log utilities
+sub generateXML_from_data {
+    my ($tc_data, $data) = @_;
+    my %my_hash  = %$tc_data;
+    my %xmldata  = %$data;
+    my $case_num = scalar(keys %my_hash);
+    my $case_status;
+    my $writer = XML::Writer->new(DATA_MODE => 'true', DATA_INDENT => 2, OUTPUT => 'self');
+
+    my $count = $xmldata{"pass_nums"} + $xmldata{"fail_nums"} + $xmldata{"skip_nums"};
+    $writer->startTag(
+        'testsuites',
+        error    => "0",
+        failures => $xmldata{"fail_nums"},
+        name     => $xmldata{"product_name"},
+        skipped  => "0",
+        tests    => "$count",
+        time     => ""
+    );
+    $writer->startTag(
+        'testsuite',
+        error     => "0",
+        failures  => $xmldata{"fail_nums"},
+        hostname  => hostname(),
+        id        => "0",
+        name      => $xmldata{"product_tested_on"},
+        package   => $xmldata{"package_name"},
+        skipped   => "0",
+        tests     => $case_num,
+        time      => "",
+        timestamp => "2016-02-16T02:50:00"
+    );
+
+    foreach my $item (keys(%my_hash)) {
+        if ($my_hash{$item}->{status} =~ m/PASSED/) {
+            $case_status = "success";
+        }
+        elsif ($my_hash{$item}->{status} =~ m/SKIPPED/ && $item =~ m/iso/) {
+            $case_status = "skipped";
+        }
+        else {
+            $case_status = "failure";
+        }
+        $writer->startTag(
+            'testcase',
+            classname => $item,
+            name      => $item,
+            status    => $case_status,
+            time      => $my_hash{$item}->{time});
+        $writer->startTag('system-err');
+        my $system_err = ($my_hash{$item}->{error} ? $my_hash{$item}->{error} : 'None');
+        $writer->characters("$system_err");
+        $writer->endTag('system-err');
+        $writer->startTag('system-out');
+        $writer->characters($my_hash{$item}->{time});
+        $writer->endTag('system-out');
+        $writer->dataElement(vmguest => $item);
+        $writer->endTag('testcase');
+    }
+
+    $writer->endTag('testsuite');
+    $writer->endTag('testsuites');
+    $writer->end();
+    $writer->to_string();
+
+    return $writer;
 }
 
 1;

--- a/tests/virtualization/xen/hotplugging.pm
+++ b/tests/virtualization/xen/hotplugging.pm
@@ -10,15 +10,15 @@
 # Summary: Virtual network and virtual block device hotplugging
 # Maintainer: Jan Baier <jbaier@suse.cz>
 
-use base "consoletest";
+use base "virt_feature_test_base";
 use xen;
 use strict;
 use warnings;
 use testapi;
 use utils;
-use version_utils 'is_sle';
+use virt_utils;
 
-sub run {
+sub run_test {
     my ($self) = @_;
     my $hypervisor = get_var('HYPERVISOR') // '127.0.0.1';
 
@@ -102,4 +102,3 @@ sub run {
 }
 
 1;
-


### PR DESCRIPTION
Chain up several virsh test modules with guest/dns setup:

1.Declare new base package virt_feature_test_base
2.Declare junit_log_provision, junit_log_params_provision and analyzeResult in virt_feature_test_base
3.Re-structure generateXML and declare new subroutine generateXML_from_data in virt_utils
4.Tweaks to all modules involved

- Related ticket: Virtualization Automation
- Needles: n/a
- Verification run: 
  - Hotplugging Passed: https://10.67.18.219/tests/311
  - Hotplugging Failed: https://10.67.18.219/tests/310
  - All Passed:https://10.67.18.219/tests/314
  - External snapshot Failed:https://10.67.18.219/tests/313
  - Run with guest installation: https://10.67.18.219/tests/317
