### PR TITLE
Add missing packages to the ay multipath profile

### DIFF
--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -394,6 +394,8 @@ pre init scripts feature. See poo#20818.
       <package>vsftpd</package>
       <package>xauth</package>
       <package>xterm</package>
+      <package>yast2-kdump</package>
+      <package>yast2-mail</package>
     </packages>
     <patterns config:type="list">
       <pattern>base</pattern>

--- a/data/autoyast_sle15/bug-879147_autoinst.xml
+++ b/data/autoyast_sle15/bug-879147_autoinst.xml
@@ -271,6 +271,9 @@
       <pattern>minimal_base</pattern>
       <pattern>x11</pattern>
     </patterns>
+    <packages config:type="list">
+      <package>yast2-kdump</package>
+    </packages>
     <image/>
     <instsource/>
     <products config:type="list">


### PR DESCRIPTION
Fixes https://openqa.suse.de/tests/3244310#
[Verification run](http://f174.suse.de/tests/287#step/installation/5). Fails on https://bugzilla.suse.com/show_bug.cgi?id=1146501