### PR TITLE
Fix saptune upgrade issues

### DIFF
--- a/tests/sles4sap/saptune.pm
+++ b/tests/sles4sap/saptune.pm
@@ -48,8 +48,12 @@ sub run {
     die "Command 'saptune daemon start' didn't start tuned"
       unless (tuned_is 'running');
 
-    # Skip test if saptune version is 1
-    return if (is_upgrade() and script_output("saptune version") =~ m/current active saptune version is '1'/);
+    # Skip test if saptune version is 1 in case of upgrade only!
+    if (is_upgrade()) {
+        return if (script_output("rpm -q saptune") =~ m/saptune-1\./);
+        # saptune_v2 can run in v1 compat mode
+        return if (script_output("saptune version") =~ m/current active saptune version is '1'/);
+    }
 
     my $output = script_output "saptune solution list";
     my $regexp = join('.+', @solutions);


### PR DESCRIPTION
saptune_v1 is not supported anymore, so we should bypass v1 tests after an upgrade on sles4sap.

- Related ticket: N/A
- Needles: N/A
- Verification run: http://1b210.qa.suse.de/tests/5760
