### PR TITLE
Continuous migration test need set correct version

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -188,11 +188,11 @@ sub setup_env {
     # This is for 12-sp5 project specific flavor Migration-from-SLE12-SP5-to-SLE15-SPx, this flavor belong 12sp5 test group but the real
     # action is migration from 12-sp5 to 15-sp1, so we need change VERSION to 15-SP1 before the test case start
     if (check_var('FLAVOR', 'Migration-from-SLE12-SP5-to-SLE15-SPx') || check_var('FLAVOR', 'Migration-from-SLE12-SP5-to-SLE15-SPx-Milestone')
-        || check_var('FLAVOR', 'Regression-on-SLE15-SPx-migrated-from-SLE12-SP5')) {
+        || check_var('FLAVOR', 'Regression-on-SLE15-SPx-migrated-from-SLE12-SP5') || check_var('UPGRADE_TARGET_RELEASED_VERSION', 1)) {
         # Save the original target version, needed for testing upgrade from a beta version to a non-beta
         # SLE12-SP5 to SLE15-SP1 for example
         set_var('ORIGINAL_TARGET_VERSION', get_var('VERSION'));
-        set_var('VERSION',                 '15-SP1');
+        set_var('VERSION',                 get_var('UPGRADE_TARGET_VERSION'));
     }
 }
 


### PR DESCRIPTION
In fact, the module accept_license shouldn't be loaded when target is SLE15SP1 while it loaded unexpected for the VERSION=12SP5. We have workaround for such scenario in main_common.pm which will change VERSION to 15SP1 if flavor is Migration-from-SLE12-SP5-to-SLE15-SPx, Migration-from-SLE12-SP5-to-SLE15-SPx-Milestone, Regression-on-SLE15-SPx-migrated-from-SLE12-SP5. But it is not suitable to simply add Migration-Continuous-Upgrade-s390x to the checking condition, because continuous migration test has two phase test suites and both in this job group. 

- Related ticket: https://progress.opensuse.org/issues/55742
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/3272700#step/addon_products_sle/19
   The accept_license module is not loaded, the addon_products_sle failure is no relation with this PR.
