### PR TITLE
Revert "Check registered addons before&after migration"

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -45,8 +45,6 @@ our @EXPORT = qw(
   verify_scc
   investigate_log_empty_license
   register_addons_cmd
-  check_registered_system
-  check_registered_addons
   %SLE15_MODULES
   %SLE15_DEFAULT_MODULES
   @SLE15_ADDONS_WITHOUT_LICENSE
@@ -226,39 +224,6 @@ sub register_addons_cmd {
         }
         else {
             next;
-        }
-    }
-}
-
-sub check_registered_system {
-    my ($system) = @_;
-    my $version = get_var('SLE_PRODUCT');
-    $version = 'sles' if ($version eq 'sles4sap');
-    $version .= $system;
-    assert_script_run "zypper lr --uri | grep -i $version";
-}
-
-sub check_registered_addons {
-    my ($addonlist) = @_;
-    $addonlist //= get_var('SCC_ADDONS');
-    # Check auto-select modules after migration only for sle15-sp1
-    if (is_sle('=15-sp1') and !get_var('IN_PATCH_SLE')) {
-        $addonlist = $addonlist . ",base,desktop,sdk,lgm,python2,serverapp,wsm";
-    }
-    my @addons = grep { defined $_ && $_ } split(/,/, $addonlist);
-    foreach my $addon (@addons) {
-        $addon =~ s/(^\s+|\s+$)//g;
-        my $name = get_addon_fullname($addon);
-        if ($name =~ /LTSS/) {
-            $name = 'LTSS';
-        }
-        if ($name =~ /sle-ha/) {
-            next;
-        }
-        assert_script_run "zypper lr --uri | grep -i $name";
-        # If has WE addon, need check nvidia repo
-        if ($name =~ /sle-we/) {
-            assert_script_run "zypper lr --uri | grep -i NVIDIA";
         }
     }
 }

--- a/tests/console/zypper_lr.pm
+++ b/tests/console/zypper_lr.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2019 SUSE LLC
+# Copyright © 2017 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -48,11 +48,6 @@ sub patching_sle {
         set_scc_proxy_url if ((check_var('HDDVERSION', get_var('ORIGINAL_TARGET_VERSION')) && is_upgrade()));
         sle_register("register");
         zypper_call('lr -d');
-        # Check system version
-        if (get_var('ORIGIN_SYSTEM_VERSION')) {
-            check_registered_system(get_var('ORIGIN_SYSTEM_VERSION'));
-        }
-        check_registered_addons();
     }
 
     # add test repositories and logs the required patches


### PR DESCRIPTION
This reverts commit 8f3086649314e85a4d2a2d37181f2fb93e38823b.

Since the original ticket cause a lot of issue, so we decide move the logic to other module. So first we revert it.

- Related ticket: n/a
- Needles: n/a
- Verification run: 
Opensuse: https://openqa.opensuse.org/tests/1011332#step/zypper_lr/2
sles12sp3 to sles12sp5: https://openqa.suse.de/tests/3272605#step/patch_sle/51
sles4sap: https://openqa.suse.de/tests/3272606#step/patch_sle/31