### PR TITLE
Fix missing keys alt-v + alt-s in nfs shares tab

### DIFF
--- a/tests/x11/nis_client.pm
+++ b/tests/x11/nis_client.pm
@@ -64,7 +64,8 @@ sub nfs_shares_tab {
     assert_screen 'nis-client-nfs-client-shares-conf';
     send_key 'alt-a';          # add
     wait_still_screen 4;
-    send_key 'alt-v';          # NFSV4 share checkbox
+    send_key 'alt-v';          # NFSV4 share checkbox (selectable box for newer products)
+    wait_still_screen 2;       # Requires refresh for newer products
     send_key 'alt-s';          # choose NFS server button
     assert_screen 'nis-client-nfs-server';
     send_key 'alt-o';          # OK


### PR DESCRIPTION
Fix missing keys alt-v + alt-s in nfs shares tab.
VRs for sle-15-SP2-Installer-DVD-x86_64-Build16.1-nis_client@64bit:
    - https://openqa.suse.de/t3272703
    - https://openqa.suse.de/t3272716
    - https://openqa.suse.de/t3272718
    - https://openqa.suse.de/t3272720
    - https://openqa.suse.de/t3272722

