### PR TITLE
Revert "sles4sap: Disable shm test on SAP note 941735 on ppc64le / qemu"

### DIFF
--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -42,10 +42,6 @@ sub setup {
         # Ignore disk_elevator on VM's
         assert_script_run "sed -ri '/:scripts\\/disk_elevator/s/^/#/' \$(fgrep -rl :scripts/disk_elevator Pattern/)";
     }
-    if (get_var('OFW') && check_var('BACKEND', 'qemu')) {
-        # This test pattern fails on ppc64le on QEMU.
-        assert_script_run "sed -i '/^kernel.shm/s/^/#/' Pattern/SLE12/testpattern_note_941735_a_override";
-    }
     $self->reboot;
 }
 


### PR DESCRIPTION
This reverts commit 46df7907ec8078257cec8046db0ed70280fdf8fa.

The fix was done on the test patterns for mr_test.