### PR TITLE
Fix yast2_samba new hearders in LDAP conf

### DIFF
--- a/tests/console/yast2_samba.pm
+++ b/tests/console/yast2_samba.pm
@@ -66,13 +66,12 @@ sub smb_conf_checker {
 sub setup_yast2_ldap_server {
     my %ldap_options_to_dirs = (
         f => 'fqdn',
-        i => 'dir_instance',
-        t => 'dir_suffix',
-        d => 'dir_manager_dn',
+        d => 'dir_instance',
+        i => 'dir_suffix',
+        n => 'dir_manager_passwd',
         r => 'dir_manager_passwd',
-        e => 'dir_manager_passwd',
         s => 'ca_cert_pem',
-        v => 'srv_cert_key_pkcs12'
+        e => 'srv_cert_key_pkcs12'
     );
     assert_script_run 'wget ' . data_url('console/samba_ca_cert.pem');
     assert_script_run 'wget ' . data_url('console/samba_server_cert.p12');


### PR DESCRIPTION
Fix yast2_samba new hearders in LDAP configuration.

- Related ticket: https://progress.opensuse.org/issues/55532
- Needles: [needles-opensuse](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/585) [needles-sle](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1206)
- Verification run:
  - [Leap-15.2-yast2_ncurses@64bit](http://rivera-workstation.suse.cz/tests/125#step/yast2_samba/25) -> Bug to be created about internal error when creating new directory instance.
  - [sle-15-SP2-Installer-DVD-x86_64-Build16.1-yast2_ncurses](http://rivera-workstation.suse.cz/tests/124#step/yast2_samba/25) -> Bug to be created about internal error when creating new directory instance.
  - [Tumbleweed-yast2_ncurses@64bit](http://rivera-workstation.suse.cz/tests/126#step/yast2_samba/78) -> Bug to be created about failing to connect to LDAP server.
