### PR TITLE
Do not expect HA EULA/SCC regcode when upgrading to 12-SP5

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -112,6 +112,8 @@ sub accept_addons_license {
     push @addons_with_license, @SLE15_ADDONS_WITHOUT_LICENSE unless is_sle('15+');
     # HA and WE have licenses when calling yast2 scc
     push @addons_with_license, @SLE15_ADDONS_WITH_LICENSE_NOINSTALL if (is_sle('15+') and get_var('IN_PATCH_SLE'));
+    # HA does not show EULA when doing migration to 12-SP5
+    @addons_with_license = grep { $_ ne 'ha' } @addons_with_license if (is_sle('12-sp5+') && get_var('UPGRADE'));
 
     for my $addon (@scc_addons) {
         # most modules don't have license, skip them
@@ -275,8 +277,8 @@ sub register_addons {
         my @addons_with_code = qw(geo live rt ltss ses);
         # WE doesn't need code on SLED
         push @addons_with_code, 'we' unless (check_var('SLE_PRODUCT', 'sled'));
-        # HA doesn't need code on SLES4SAP
-        push @addons_with_code, 'ha' unless (check_var('SLE_PRODUCT', 'sles4sap'));
+        # HA doesn't need code on SLES4SAP or in migrations to 12-SP5
+        push @addons_with_code, 'ha' unless (check_var('SLE_PRODUCT', 'sles4sap') || (is_sle('12-sp5+') && get_var('UPGRADE')));
         if ((my $regcode = get_var("SCC_REGCODE_$uc_addon")) or ($addon eq "ltss")) {
             # skip addons which doesn't need to input scc code
             next unless grep { $addon eq $_ } @addons_with_code;


### PR DESCRIPTION
Rework of reverted PR #8205 to handle the offline with SCC migration scenario for SLES+HA.

Current code waits for HA's EULA as well as the SCC registration code for the addon, but on offline migrations with SCC to 12-SP5, this is not shown. Per the related ticket, this is a new feature and it should also impact other modules, but further testing showed that at least the SDK addon still shows the EULA and requests the SCC code in the offline with SCC migration scenario (see: https://openqa.suse.de/tests/3252684#step/scc_registration/19)

This PR is restricted to the HA module, so the tests do not wait for HA's EULA or its SCC registration code on offline migration with SCC. On online migrations and for other addons, everything should remain as is.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1138131#c3
- Needles: N/A
- Verification runs: (all test upgrade the system to SLES 12-SP5)
- SLES+HA 12-SP4 offline migration with SCC: http://mango.suse.de/tests/1318
- SLES+HA 12-SP4 online migration: http://mango.suse.de/tests/1324
- SLES+pscc_lp_all_full 12-SP2-LTSS online migration: http://mango.suse.de/tests/1348
- SLES+pscc_sdk+we+lp_def_full 12-SP4 offline migration with SCC: http://mango.suse.de/tests/1357
- SLES+pscc_sdk+we+lp_def_full 12-SP2-LTSS offline migration with SCC:  http://mango.suse.de/tests/1356 (failure is unrelated to this PR)