### PR TITLE
Allow import of several test_data in yaml schedule

### DIFF
--- a/declarative-schedule-doc.md
+++ b/declarative-schedule-doc.md
@@ -172,6 +172,31 @@ schedule:
 test_data:
   !include: schedule/path/to/scenario_name_test_data.yaml
 ```
+-  it is allowed to use multiple `!include` tags in yaml scheduling
+   file. In the case they should be provided as list:
+   
+```
+...
+test_data:
+  - !include: path/to/first_test_data.yaml
+  - !include: path/to/second_test_data.yaml
+```
+
+- `!include` tag can be mixed with the test data that is defined in
+  scheduling file directly:
+  
+> **_IMPORTANT:_** Test data in scheduling file has priority over the
+> same data from the imported file (i.e. it allows to override imported
+> data).
+```
+...
+test_data:
+  disks:
+    - name: vdb
+      partitions:
+        - size: 3mb
+  !include: path/to/test_data.yaml
+```
 
 ### 2. Enable scheduler in settings
 

--- a/lib/scheduler.pm
+++ b/lib/scheduler.pm
@@ -29,6 +29,7 @@ use YAML::Tiny;
 our @EXPORT = qw(load_yaml_schedule get_test_data);
 
 my $test_data;
+my $include_tag = "!include";
 
 sub parse_vars {
     my ($schedule) = shift;
@@ -77,14 +78,23 @@ in the same file than the schedule or in a dedicated file only for data.
 
 sub parse_test_data {
     my ($schedule) = shift;
-    $test_data = $schedule->{test_data};
-    my $include_tag = "!include";
-    if (exists $test_data->{$include_tag}) {
-        $test_data = YAML::Tiny::LoadFile(dirname(__FILE__) . '/../' . $test_data->{$include_tag});
-        if (exists $test_data->{schedule}) {
-            die "Error: test_data can only be defined in a dedicated file for data\n";
+    $test_data = {};
+    # return if section is not defined
+    return unless exists $schedule->{test_data};
+
+    if (defined(my $import = $schedule->{test_data}->{$include_tag})) {
+        # Allow both lists and scalar value for import "!include" key
+        if (ref $import eq 'ARRAY') {
+            for my $include (@{$import}) {
+                _import_test_data_from_yaml($include);
+            }
+        }
+        else {
+            _import_test_data_from_yaml($import);
         }
     }
+    # test_data from schedule file has priority over imported one
+    $test_data = {%$test_data, %{$schedule->{test_data}}};
 }
 
 =head2 load_yaml_schedule
@@ -104,6 +114,15 @@ sub load_yaml_schedule {
         return 1;
     }
     return 0;
+}
+
+sub _import_test_data_from_yaml {
+    my ($yaml_file) = @_;
+    my $include_yaml = YAML::Tiny::LoadFile(dirname(__FILE__) . '/../' . $yaml_file);
+    if (exists $include_yaml->{$include_tag}) {
+        die "Error: test_data can only be defined in a dedicated file for data\n";
+    }
+    $test_data = {%$test_data, %{$include_yaml}};
 }
 
 1;

--- a/t/02_yaml_schedule.t
+++ b/t/02_yaml_schedule.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Test::Warnings;
+use FindBin;
+use YAML::Tiny;
+use File::Basename;
+
+# This is required to be able to read
+# packages in distri's lib/ folder.
+# Alternatively it can be supplied as -I option
+# while running prove.
+use lib ("$FindBin::Bin/lib", "$FindBin::Bin/../lib");
+
+subtest 'parse_yaml_test_data_single_import' => sub {
+    use scheduler;
+    # compare versions if possible
+    my $schedule = YAML::Tiny::LoadFile(dirname(__FILE__) . '/data/test_schedule_single_import.yaml');
+    scheduler::parse_test_data($schedule);
+    my $testdata = scheduler::get_test_data();
+    ok $testdata->{test_in_yaml_schedule} eq 'test_in_yaml_schedule_value', "Value from schedule file was overwritten by yaml import";
+    ok $testdata->{test_in_yaml_import_1} eq 'test_in_yaml_import_value_1', "Value from single imported yaml were not parsed properly";
+
+};
+
+subtest 'parse_yaml_test_data_multiple_imports' => sub {
+    use scheduler;
+    # compare versions if possible
+    my $schedule = YAML::Tiny::LoadFile(dirname(__FILE__) . '/data/test_schedule_multi_imports.yaml');
+    scheduler::parse_test_data($schedule);
+    my $testdata = scheduler::get_test_data();
+    ok $testdata->{test_in_yaml_schedule} eq 'test_in_yaml_schedule_value', "Value from schedule file was overwritten by yaml import";
+    ok $testdata->{test_in_yaml_import_1} eq 'test_in_yaml_import_value_1', "Value from the first imported yaml were not parsed properly";
+    ok $testdata->{test_in_yaml_import_2} eq 'test_in_yaml_import_value_2', "Value from the second imported yaml were not parsed properly";
+
+};
+
+subtest 'do_not_allow_nested_imports' => sub {
+    my $schedule = YAML::Tiny::LoadFile(dirname(__FILE__) . '/data/test_schedule_nested_import.yaml');
+    dies_ok { scheduler::parse_test_data($schedule) } "Error: test_data can only be defined in a dedicated file for data\n";
+};
+
+done_testing;

--- a/t/data/test_data_1.yaml
+++ b/t/data/test_data_1.yaml
@@ -1,0 +1,2 @@
+test_in_yaml_schedule: test_in_yaml_import_value_1
+test_in_yaml_import_1: test_in_yaml_import_value_1

--- a/t/data/test_data_2.yaml
+++ b/t/data/test_data_2.yaml
@@ -1,0 +1,2 @@
+test_in_yaml_schedule: test_in_yaml_import_value_2
+test_in_yaml_import_2: test_in_yaml_import_value_2

--- a/t/data/test_data_nested_import.yaml
+++ b/t/data/test_data_nested_import.yaml
@@ -1,0 +1,2 @@
+test_in_yaml_schedule: test_in_yaml_import_value_1
+!include: this_is_not_allowed

--- a/t/data/test_schedule_multi_imports.yaml
+++ b/t/data/test_schedule_multi_imports.yaml
@@ -1,0 +1,5 @@
+test_data:
+    test_in_yaml_schedule: test_in_yaml_schedule_value
+    !include:
+        - t/data/test_data_1.yaml
+        - t/data/test_data_2.yaml

--- a/t/data/test_schedule_nested_import.yaml
+++ b/t/data/test_schedule_nested_import.yaml
@@ -1,0 +1,3 @@
+test_data:
+    test_in_yaml_schedule: test_in_yaml_schedule_value
+    !include: t/data/test_data_nested_import.yaml

--- a/t/data/test_schedule_single_import.yaml
+++ b/t/data/test_schedule_single_import.yaml
@@ -1,0 +1,3 @@
+test_data:
+    test_in_yaml_schedule: test_in_yaml_schedule_value
+    !include: t/data/test_data_1.yaml


### PR DESCRIPTION
The commit adds ability to use multiple !include tags in yaml scheduling
files as well as mixing !include tag with the test data that is defined
in the scheduling file directly. In case of the latter, the keys from
scheduling file have priority over imported ones with !include tag (i.e.
it is allowed to override the values defined in test data imported file)
