### PR TITLE
Fix dovecot install in evolution_prepare_servers

### DIFF
--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -16,12 +16,16 @@ use base "opensusebasetest";
 use testapi;
 use utils;
 use version_utils qw(is_sle is_jeos is_opensuse);
+use registration 'add_suseconnect_product';
 
 sub run() {
     select_console('root-console');
     pkcon_quit;
 
     if (check_var('SLE_PRODUCT', 'sled') || get_var('DOVECOT_REPO')) {
+        if (is_sle("15-sp1+")) {
+            add_suseconnect_product('sle-module-server-applications');
+        }
         my $dovecot_repo = get_required_var("DOVECOT_REPO");
         # Add dovecot repository and install dovecot
         zypper_call("ar ${dovecot_repo} dovecot_repo");


### PR DESCRIPTION
Previous openQA tests in scenario `sle-15-SP1-Desktop-DVD-Updates-x86_64-qam-regression-message@64bit` all [fails](https://openqa.suse.de/tests/latest?arch=x86_64&distri=sle&flavor=Desktop-DVD-Updates&machine=64bit&test=qam-regression-message&version=15-SP1#next_previous) in `evolution_prepare_servers` because `devocot` is missing its repo. This fix adds product `sle-module-server-applications` in SLE15SP1+ to enable dovecot install.

- Related ticket: https://progress.opensuse.org/issues/52640
- Needles: None
- Verification run: http://10.67.20.46/tests/317
