### PR TITLE
opensuse_welcome: handle otherDE tests as well

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -109,6 +109,7 @@ our @EXPORT = qw(
   map_incidents_to_repo
   need_clear_repos
   noupdatestep_is_applicable
+  opensuse_welcome_applicable
   remove_common_needles
   remove_desktop_needles
   replace_opensuse_repos_tests
@@ -209,8 +210,9 @@ sub any_desktop_is_applicable {
 
 sub opensuse_welcome_applicable {
     # openSUSE-welcome is expected to show up on openSUSE Tumbleweed only (Leap possibly in the future)
-    # icewm (aka minimalx) does not honor /etc/xdg/autostart, thus opensuse-welcome does not autostart there
-    return get_var('DESKTOP', '') =~ /kde|gnome|xfce/ && is_tumbleweed;
+    # since not all DE's honr xdg/autostart, we are filtering based on desktop environments
+    my $desktop = shift // get_var('DESKTOP', '');
+    return $desktop =~ /gnome|kde|lxqt|mate|xfce/ && is_tumbleweed;
 }
 
 sub logcurrentenv {

--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -206,6 +206,7 @@ sub load_otherDE_tests {
         loadtest "console/consoletest_finish";
         loadtest "x11/${de}_reconfigure_openqa";
         loadtest "x11/reboot_icewm";
+        loadtest "installation/opensuse_welcome" if opensuse_welcome_applicable($de);
         # here comes the actual desktop specific test
         if ($de =~ /^awesome$/)       { load_awesome_tests(); }
         if ($de =~ /^enlightenment$/) { load_enlightenment_tests(); }


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/55808
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/1013603 (MATE desktop)
