### PR TITLE
Allow REMOTE_TARGET without NETBOOT

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -38,6 +38,7 @@ our @EXPORT = qw(
   bootmenu_default_params
   get_hyperv_fb_video_resolution
   bootmenu_network_source
+  bootmenu_remote_target
   specific_bootmenu_params
   remote_install_bootmenu_params
   specific_caasp_params
@@ -472,15 +473,20 @@ sub bootmenu_network_source {
             }
 
             select_installation_source({m_protocol => $m_protocol, m_mirror => $m_mirror});
-
-            my $remote = get_var("REMOTE_TARGET");
-            if ($remote) {
-                my $dns = get_host_resolv_conf()->{nameserver};
-                push @params, get_var("NETSETUP") if get_var("NETSETUP");
-                push @params, "nameserver=" . join(",", @$dns);
-                push @params, ("$remote=1", "${remote}password=$password");
-            }
         }
+    }
+    type_string_very_slow(" @params ");
+    return @params;
+}
+
+sub bootmenu_remote_target {
+    my @params;
+    my $remote = get_var("REMOTE_TARGET");
+    if ($remote) {
+        my $dns = get_host_resolv_conf()->{nameserver};
+        push @params, get_var("NETSETUP") if get_var("NETSETUP");
+        push @params, "nameserver=" . join(",", @$dns);
+        push @params, ("$remote=1", "${remote}password=$password");
     }
     type_string_very_slow(" @params ");
     return @params;

--- a/tests/installation/bootloader.pm
+++ b/tests/installation/bootloader.pm
@@ -56,6 +56,7 @@ sub run {
     my @params;
     push @params, bootmenu_default_params;
     push @params, bootmenu_network_source;
+    push @params, bootmenu_remote_target;
     push @params, specific_bootmenu_params;
     specific_caasp_params;
     push @params, registration_bootloader_params(utils::VERY_SLOW_TYPING_SPEED);


### PR DESCRIPTION
Allow REMOTE_TARGET without NETBOOT

- Related ticket: https://progress.opensuse.org/issues/52313
- Verification run:
  - [Tumbleweed-remote_ssh_controller](https://openqa.opensuse.org/tests/1013761) -> failing (see [comment](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8262#issuecomment-524266100))
  - [Tumbleweed-remote_ssh_target](https://openqa.opensuse.org/tests/1013762)