### PR TITLE
Kubic: all roles now have a NTP configuration dialog

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -981,7 +981,7 @@ sub load_inst_tests {
             loadtest 'installation/user_import';
         }
         elsif (is_caasp 'microos') {
-            loadtest "installation/kubeadm_settings" if check_var('SYSTEM_ROLE', 'kubeadm');
+            loadtest "installation/ntp_config_settings";
         } else {
             loadtest "installation/user_settings" unless check_var('SYSTEM_ROLE', 'hpc-node');
         }

--- a/tests/installation/ntp_config_settings.pm
+++ b/tests/installation/ntp_config_settings.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Kubic kubeadm role configuration
+# Summary: YaST/Installation screen: NTP Configuration
 # Maintainer: Martin Kravec <mkravec@suse.com>
 
 use base 'y2_installbase';
@@ -16,7 +16,7 @@ use warnings;
 use testapi;
 
 sub run {
-    assert_screen 'kubeadm-settings';
+    assert_screen ['ntp_config_settings', 'kubeadm-settings'];
     if (check_screen 'kubeadm-ntp-empty') {
         record_soft_failure 'bsc#1114818';
     }


### PR DESCRIPTION
All kubic/microos roles now have a NTP Configuration dialog

- Related ticket: N/A
- Needles: N/A
- Verification run:
* https://openqa.opensuse.org/tests/1013709
* https://openqa.opensuse.org/tests/1013710
