### PR TITLE
Update search string for yast2-vm module in YaST control center

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -243,7 +243,9 @@ sub start_user_and_group_management {
 }
 
 sub start_hypervisor {
-    search('hypervisor');
+    # Module title got changed in SLE 15 SP2
+    my $search_string = is_sle('15-SP2+') ? 'install vm' : 'hypervisor';
+    search($search_string);
     assert_and_click 'yast2_control-center_install-hypervisor-and-tools';
     assert_screen 'yast2-install-hypervisor-and-tools', timeout => 180;
     send_key 'alt-c';


### PR DESCRIPTION
We got new title for the module, changed from "Install hypervisor" to
"Install VM".

- [Verification run](https://openqa.suse.de/tests/3278125#)
