### PR TITLE
Bump timeout to account for aarch64 being slower

### DIFF
--- a/tests/console/yast2_i.pm
+++ b/tests/console/yast2_i.pm
@@ -71,7 +71,7 @@ sub run {
         }
     }
     my $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'sw_single');
-    assert_screen [qw(empty-yast2-sw_single yast2-preselected-driver)], 90;
+    assert_screen [qw(empty-yast2-sw_single yast2-preselected-driver)], 120;
 
     # we need to change filter to Search, in case yast2 reports available automatic update
     if ($is_inr_package) {


### PR DESCRIPTION
System under test too more than 90 secs to display screen: https://openqa.suse.de/tests/3276020

So bump it a bit more. As this is load related (and only happened once so far), I don't see the need for a VF