### PR TITLE
xfstests: Add filesystem run time status log

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -38,6 +38,7 @@ my $INST_DIR     = '/opt/xfstests';
 my $LOG_DIR      = '/opt/log';
 my $KDUMP_DIR    = '/opt/kdump';
 my $MAX_TIME     = 2400;
+my $FSTYPE       = get_required_var('XFSTESTS');
 
 # Create heartbeat script, directories(Call it only once)
 sub test_prepare {
@@ -261,6 +262,48 @@ sub dump_btrfs_img {
     script_run($cmd);
 }
 
+sub collect_fs_status {
+    my ($category, $num) = @_;
+    my $cmd = <<END_CMD;
+mount \$TEST_DEV \$TEST_DIR &> /dev/null
+if [[ -z "\$SCRATCH_DEV_POOL" ]]; then
+    mount \$SCRATCH_DEV \$SCRATCH_MNT &> /dev/null
+fi
+END_CMD
+    if ($FSTYPE eq 'xfs') {
+        $cmd = <<END_CMD;
+$cmd
+echo "==> /sys/fs/$FSTYPE/stats/stats <==" > $LOG_DIR/$category/$num.fs_stat
+cat /sys/fs/$FSTYPE/stats/stats >> $LOG_DIR/$category/$num.fs_stat
+tail -n +1 /sys/fs/$FSTYPE/*/log/* >> $LOG_DIR/$category/$num.fs_stat
+tail -n +1 /sys/fs/$FSTYPE/*/stats/stats >> $LOG_DIR/$category/$num.fs_stat
+END_CMD
+    }
+    elsif ($FSTYPE eq 'btrfs') {
+        $cmd = <<END_CMD;
+$cmd
+tail -n +1 /sys/fs/$FSTYPE/*/allocation/data/[bdft]* >> $LOG_DIR/$category/$num.fs_stat
+tail -n +1 /sys/fs/$FSTYPE/*/allocation/metadata/[bdft]* >> $LOG_DIR/$category/$num.fs_stat
+tail -n +1 /sys/fs/$FSTYPE/*/allocation/metadata/dup/* >> $LOG_DIR/$category/$num.fs_stat
+tail -n +1 /sys/fs/$FSTYPE/*/allocation/*/single/* >> $LOG_DIR/$category/$num.fs_stat
+END_CMD
+    }
+    elsif ($FSTYPE eq 'ext4') {
+        $cmd = <<END_CMD;
+$cmd
+tail -n +1 /sys/fs/$FSTYPE/*/* >> $LOG_DIR/$category/$num.fs_stat
+END_CMD
+    }
+    $cmd = <<END_CMD;
+$cmd
+umount \$TEST_DEV &> /dev/null
+if [[ -z "\$SCRATCH_DEV_POOL" ]]; then
+    umount \$SCRATCH_DEV &> /dev/null
+fi
+END_CMD
+    type_string("$cmd\n");
+}
+
 sub run {
     my $self = shift;
     select_console('root-console');
@@ -290,6 +333,7 @@ sub run {
                 copy_log($category, $num, 'out.bad');
                 copy_log($category, $num, 'full');
                 copy_log($category, $num, 'dmesg');
+                collect_fs_status($category, $num);
                 if (get_var('BTRFS_DUMP', 0) && (check_var 'XFSTESTS', 'btrfs')) { dump_btrfs_img($category, $num); }
             }
             next;


### PR DESCRIPTION
This PR comes from developers requirement, it add run time test log in log tarbal. Only failed case will add the log. This could use in btrfs, xfs and ext4. No new parameter needed.
Code just do following things:
1. mount test devices
2. Collect info depend on in which fs_type
3. umount test devices

- Related ticket: https://progress.opensuse.org/issues/55214
- Verification run: 
  Run xfs: http://10.67.133.102/tests/1092
  Run btrfs: http://10.67.133.102/tests/1091
  Run ext4: http://10.67.133.102/tests/1093
  Please check log tar ball, and it contain *.fs_stat log only in fail test log.