### PR TITLE
Regression test for Yast2 cmd nis client and nis server

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1432,6 +1432,8 @@ sub load_extra_tests_y2uitest_cmd {
     loadtest 'yast2_cmd/yast_nfs_server';
     loadtest 'yast2_cmd/yast_nfs_client';
     loadtest 'yast2_cmd/yast_dns_server';
+    loadtest 'tests/yast2_cmd/yast2_nis';
+    loadtest 'tests/yast2_cmd/yast2_nis_server';
 
     #temporary runs for QAM while tests under y2uitest_ncurses are being ported
     loadtest "console/yast2_apparmor";

--- a/tests/yast2_cmd/yast2_nis.pm
+++ b/tests/yast2_cmd/yast2_nis.pm
@@ -1,0 +1,50 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Setup nis client and bind nis server
+# Enviroment:
+# - external server: wotan.suse.de, hilbert.suse.de
+# - qemu user mode networking disables broadcast so that functionality is not covered.
+#
+# 1. Bind a nis server and veirfy it succeed.
+# 2. Change binding to another server, configure automount.
+# 3. Disable binding, automount
+# Maintainer: Tony Yuan <tyuan@suse.com>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils 'is_sle';
+
+sub run {
+    select_console 'root-console';
+    zypper_call("in yast2-nis-client ypbind", exitcode => [0, 102, 103, 106]);
+    my $flg = is_sle('=12-SP2') ? 1 : 0;    #"yast2 nis-server summary" return 16 on 12sp2 so set proceed_on_failure=1 to avoid throwing exception. BUG#1143516.
+
+    #Binding
+    assert_script_run("yast nis enable server=wotan.suse.de domain=suse.de");
+    validate_script_output("ypwhich 2>&1", sub { /wotan.suse.de|dns2.suse.de/ });
+
+    #Change binding, configure automount.
+    assert_script_run("yast nis configure server=hilbert.suse.de");
+    validate_script_output("ypwhich 2>&1", sub { /hilbert.suse.de/ });
+    assert_script_run("yast nis configure automounter=yes");
+    systemctl('is-enabled autofs.service');
+    validate_script_output("yast nis summary 2>&1", sub { m/Servers:\s(.*?)\n.*Automounter\senabled:\s(.*)/s && $1 eq "hilbert.suse.de" && $2 eq "Yes" }, timeout => 30, proceed_on_failure => $flg);
+
+    #Disable binding, automount
+    assert_script_run("yast nis disable");
+    assert_script_run("yast nis configure automounter=no");
+    validate_script_output("yast nis summary 2>&1", sub { m/Client\sEnabled:\s(.*?)\n.*Automounter\senabled:\s(.*)/s && $1 eq "No" && $2 eq "No" }, timeout => 30, proceed_on_failure => $flg);
+}
+
+1;

--- a/tests/yast2_cmd/yast2_nis_server.pm
+++ b/tests/yast2_cmd/yast2_nis_server.pm
@@ -1,0 +1,54 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Setup nis server
+# Enviroment:
+# - external server: wotan.suse.de, hilbert.suse.de
+# - qemu user mode networking disables broadcast so broadcast functionality is not covered.
+#
+# 1. Reproduce Bug 1146030
+# 2. Setup master server and bind locally.
+# 3. Setup slave server and bind locally.
+# Maintainer: Tony Yuan <tyuan@suse.com>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils 'is_sle';
+
+sub run {
+    select_console 'root-console';
+    zypper_call("in yast2-nis-server ypserv", exitcode => [0, 102, 103, 106]);
+    my $flg = is_sle('=12-SP2') ? 1 : 0;    #"yast2 nis-server summary" return 16 on 12sp2 so set proceed_on_failure=1 to avoid throwing exception. BUG#1143516.
+
+    # reproduce bug
+    my $out = script_output("yast2 nis-server summary 2>&1", proceed_on_failure => $flg);
+    record_soft_failure("Bug 1146030") if ($out =~ /A NIS slave server is configured/);
+
+    # master server test
+    assert_script_run("yast nis-server master domain=nismaster.test");
+    validate_script_output("yast2 nis-server summary 2>&1", sub { /A NIS master server is configured/ }, timeout => 30, proceed_on_failure => $flg);
+    assert_script_run("yast2 nis enable domain=nismaster.test server=10.0.2.15");
+    validate_script_output("ypwhich 2>&1", sub { /10.0.2.15/ });
+    assert_script_run("yast2 nis-server stop");
+    validate_script_output("yast2 nis-server summary 2>&1", sub { /NIS Master Server: Not configured yet/ }, timeout => 30, proceed_on_failure => $flg);
+
+    # slave server
+    assert_script_run("yast nis-server slave domain=suse.de master_ip=10.160.0.1");
+    validate_script_output("yast2 nis-server summary 2>&1", sub { /A NIS slave server is configured/ }, timeout => 30, proceed_on_failure => $flg);
+    assert_script_run("yast2 nis configure domain=suse.de server=10.0.2.15");
+    validate_script_output("ypwhich 2>&1", sub { /10.0.2.15/ });
+    assert_script_run("yast nis disable");
+    assert_script_run("yast2 nis-server stop");
+}
+
+1;


### PR DESCRIPTION
Regression test for Yast2 cmd nis and nis-server

- Related ticket: https://progress.opensuse.org/issues/49304
https://progress.opensuse.org/issues/49307
- Needles: no
- Verification run: 
sle-12-SP2: http://10.67.17.201/tests/173
sle-12-SP3: http://10.67.17.201/tests/172
sle-12-SP4: http://10.67.17.201/tests/179
sle-15-SP1: http://10.67.17.201/tests/178
sle-15: http://10.67.17.201/tests/177

