### PR TITLE
Add new test suite yast2_cmd

### DIFF
--- a/schedule/yast/yast2_cmd.yaml
+++ b/schedule/yast/yast2_cmd.yaml
@@ -1,0 +1,8 @@
+name:           yast2_cmd
+description:    >
+    Yast2 cmd interface tests.
+
+schedule:
+     - boot/boot_to_desktop
+     - yast2_cmd/yast_rdp
+     - yast2_cmd/yast_timezone


### PR DESCRIPTION
Add new test suite yast2_cmd.
QAM team has developed couple of tests using YaST cmd line, which is less costly to execute and maintain.
We should run them for the distributions we are responsible for.

- Related ticket: https://progress.opensuse.org/issues/54746
- Verification run: http://waaa-amazing.suse.cz/tests/6538 