### PR TITLE
Add yast_users test module in cli mode.

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1417,6 +1417,7 @@ sub load_extra_tests_y2uitest_cmd {
     loadtest 'yast2_cmd/yast_tftp_server';
     loadtest 'yast2_cmd/yast_ftp_server';
     loadtest 'yast2_cmd/yast_rdp' if is_sle('15+');
+    loadtest 'yast2_cmd/yast_users';
     loadtest 'yast2_cmd/yast_sysconfig';
     loadtest 'yast2_cmd/yast_keyboard';
     loadtest 'yast2_cmd/yast_nfs_server';

--- a/tests/yast2_cmd/yast_users.pm
+++ b/tests/yast2_cmd/yast_users.pm
@@ -1,0 +1,51 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# All of cases is based on the reference:
+# https://www.suse.com/documentation/sles-15/singlehtml/book_sle_admin/book_sle_admin.html#id-1.3.3.6.13.6.34
+#
+# Summary: manages user accounts
+#     Requirement: external NIS server "wotan.suse.de"
+#     Key Steps:
+#       - adds a new user with a password and verifies
+#       - changes the passwd of the new user and homedir, and deletes this user
+#       - binds a nis server and starts ypbind service, and then lists all users from NIS server
+# Maintainer: Jun Wang <jgwang@suse.com>
+#
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    select_console 'root-console';
+    zypper_call("in yast2-users yast2-nis-client ypbind", exitcode => [0, 102, 103, 106]);
+
+    # adds a new user with a password and homedir and verifies
+    # bsc#1143516: exit code is always NOT zero when the yast command works successfully, so once ZERO, it means a bug
+    if (script_run("yast users add username=test_yast password=suse") != 0) {
+        record_soft_failure("bsc#1143516 for SLE15+: exit code is NOT zero");
+    }
+    validate_script_output("yast users list local 2>&1 || echo BUG#1143516", sub { (m/test_yast/) and ((m/^BUG#1143516$/m) ? (!record_soft_failure("bsc#1143516 for SLE12SP2: exit code is NOT zero")) : return 1) });
+
+    # changes the passwd of the new user and homedir, and delete this user
+    assert_script_run("yast users edit username=test_yast new_uid=44444 home=/tmp/test_yast");
+    validate_script_output("yast users show username=test_yast 2>&1", sub { m/44444/ and m/\/tmp\/test_yast/ }, timeout => 90, proceed_on_failure => 1);
+    assert_script_run("yast users delete username=test_yast delete_home");
+
+    # binds a nis server and start ypbind service, and then list all users from NIS server
+    assert_script_run("yast nis enable domain=suse.de server=wotan.suse.de");
+    validate_script_output("ypwhich 2>&1", sub { m/(wotan|dns2).suse.de/ });
+    validate_script_output("yast users list nis 2>&1 | wc -l", sub { m/^(\d+)$/m and $1 > 20 }, timeout => 180, proceed_on_failure => 1);
+    assert_script_run("yast nis disable");
+}
+
+1;


### PR DESCRIPTION
Regression test for Yast2 cmd users PM

- Related ticket: https://progress.opensuse.org/issues/49316
- Needles: no
- Verification run:
     - SLE12SP1: http://10.67.20.116/tests/564 :heavy_check_mark: 
     - SLE12SP2: http://10.67.20.116/tests/562 :heavy_check_mark: 
     - SLE12SP3: http://10.67.20.116/tests/561 :heavy_check_mark: 
     - SLE12SP4: http://10.67.20.116/tests/560 :heavy_check_mark: 
     - SLE15      : http://10.67.20.116/tests/563 :heavy_check_mark: 
     - SLE15SP1: http://10.67.20.116/tests/565 :heavy_check_mark: 