### PR TITLE
Ensure loopback entry is actually selected

### DIFF
--- a/tests/console/yast2_lan_device_settings.pm
+++ b/tests/console/yast2_lan_device_settings.pm
@@ -70,9 +70,8 @@ sub run {
     if (is_sle('<=15') || is_leap('<=15.0')) {
         open_yast2_lan();
 
-        send_key "alt-s";              # move to hostname/DNS tab
-        send_key "alt-a";              # assign hostname to loopback IP
-        assert_screen 'loopback-assigned';
+        send_key 'alt-s';              # move to hostname/DNS tab
+        send_key_until_needlematch 'loopback-assigned', 'alt-a';    # assign hostname to loopback IP
         close_yast2_lan();
 
         # verify that loopback has been set
@@ -81,9 +80,8 @@ sub run {
         open_yast2_lan();
 
         # unassign back from loopback IP
-        send_key "alt-s";
-        send_key "alt-a";
-        assert_screen 'loopback-unassigned';
+        send_key 'alt-s';
+        send_key_until_needlematch 'loopback-unassigned', 'alt-a';
         close_yast2_lan();
     }
 


### PR DESCRIPTION
yast2_lan_device_settings is a fairly new module, that depends a lot on
send_key, so for certain hotkeys, it seems to be failing more or less
consistently, specially for the assigned loopback part. Switching to
send_key_until_needlematch should solve the problem for now.

VF (1 time): https://openqa.suse.de/t3288475
VF (20 times): https://openqa.suse.de/tests/3290645