### PR TITLE
Fix remote_ssh_controller yaml for opensuse

### DIFF
--- a/schedule/yast/remote_ssh_controller.yaml
+++ b/schedule/yast/remote_ssh_controller.yaml
@@ -7,19 +7,19 @@ schedule:
  - support_server/setup
  - remote/remote_controller
  - installation/welcome
- - installation/accept_license
- - installation/scc_registration
- - installation/addon_products_sle
+ - installation/online_repos
+ - installation/installation_mode
+ - installation/logpackages
  - installation/system_role
  - installation/partitioning
  - installation/partitioning_finish
  - installation/installer_timezone
  - installation/user_settings
- - installation/user_settings_root
  - installation/resolve_dependency_issues
  - installation/installation_overview
  - installation/disable_grub_timeout
  - installation/start_install
  - installation/await_install
+ - installation/logs_from_installation_system
  - installation/reboot_after_installation
  - support_server/wait_children


### PR DESCRIPTION
Fix remote_ssh_controller yaml schedule for opensuse

- Related ticket: https://progress.opensuse.org/issues/52313
- Needles: n/a
- Verification run: n/a
