### PR TITLE
upload_system_log: Add output of vmstat and w command

### DIFF
--- a/lib/upload_system_log.pm
+++ b/lib/upload_system_log.pm
@@ -33,6 +33,8 @@ sub system_status {
         repos                      => "zypper repos -u",
         lspci                      => "lspci",
         lsmod                      => "lsmod",
+        vmstat                     => "vmstat -w",
+        w                          => "w",
         '/proc/sys/kernel/tainted' => "cat /proc/sys/kernel/tainted",
     );
 


### PR DESCRIPTION
Useful for load average.

Verification run: http://quasar.suse.cz/tests/3605/file/shutdown_ltp-system-status.log