### PR TITLE
Schedule supportutils.pm into migration regression check

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1092,7 +1092,10 @@ sub load_consoletests {
     }
 
     loadtest "locale/keymap_or_locale";
-    loadtest "console/check_upgraded_service" if (is_sle && !get_var('MEDIA_UPGRADE') && !get_var('ZDUP') && is_upgrade && !is_desktop && !get_var('INSTALLONLY'));
+    if (is_sle && !get_var('MEDIA_UPGRADE') && !get_var('ZDUP') && is_upgrade && !is_desktop && !get_var('INSTALLONLY')) {
+        loadtest "console/check_upgraded_service";
+        loadtest "console/supportutils";
+    }
     loadtest "console/check_package_version" if check_var('ORIGINAL_TARGET_VERSION', '12-SP5');
     loadtest "console/force_scheduled_tasks" unless is_jeos;
     if (get_var("LOCK_PACKAGE")) {


### PR DESCRIPTION
Schedule supportutils.pm into migration regression check

- Related ticket: n/a
- Needles: https:n/a
- Verification run: http://openqa.suse.de/t3293279
