### PR TITLE
Enable service for all not implemented services

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -145,6 +145,7 @@ sub install_services {
                 next;
             }
 
+            systemctl 'enable ' . $srv_proc_name;
             systemctl 'start ' . $srv_proc_name;
             systemctl 'is-active ' . $srv_proc_name;
         }


### PR DESCRIPTION
Enable service for all not implemented services

- Related ticket: https://progress.opensuse.org/issues/55973
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/3293267
