### PR TITLE
Test reboot and IceWM in gdm_session_switch

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1871,6 +1871,9 @@ sub load_x11_documentation {
 
 sub load_x11_gnome {
     return unless check_var('DESKTOP', 'gnome');
+    if (is_sle('12-SP2+')) {
+        loadtest "x11/gdm_session_switch";
+    }
     loadtest "x11/gnomecase/nautilus_cut_file";
     loadtest "x11/gnomecase/nautilus_permission";
     loadtest "x11/gnomecase/nautilus_open_ftp";

--- a/tests/x11/gdm_session_switch.pm
+++ b/tests/x11/gdm_session_switch.pm
@@ -10,6 +10,7 @@
 # Summary: Add a case for gdm session switch
 #    openSUSE has shipped SLE-Classic since Leap 42.2, this case will test
 #    gdm session switch among sle-classic, gnome-classic, icewm and gnome.
+#    Also test rebooting from login screen.
 # Maintainer: Chingkai Chu <chuchingkai@gmail.com>
 
 use base "x11test";

--- a/tests/x11/gdm_session_switch.pm
+++ b/tests/x11/gdm_session_switch.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2017 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -33,12 +33,31 @@ sub run {
     $self->prepare_sle_classic;
     $self->application_test;
 
+    # Reboot and log in
+    $self->switch_wm;
+    assert_and_click "displaymanager-systembutton";
+    assert_and_click "displaymanager-system-powerbutton";
+    assert_and_click "displaymanager-reboot";
+
+    if (get_var("SHUTDOWN_NEEDS_AUTH")) {
+        assert_screen 'reboot-auth', 15;
+        type_password;
+        send_key "ret";
+    }
+
+    $self->wait_boot(bootloader_time => 300);
+
+    # Log out and log in again
+    $self->switch_wm;
+    send_key "ret";
+    assert_screen "generic-desktop";
+
     # Log out and switch to icewm
     $self->switch_wm;
     assert_and_click "displaymanager-settings";
     assert_and_click "dm-icewm";
     send_key "ret";
-    assert_screen "desktop-icewm", 120;
+    assert_screen "desktop-icewm";
     # Smoke test: launch some applications
     send_key "super-spc";
     wait_still_screen;
@@ -58,7 +77,7 @@ sub run {
     send_key "alt-l";
     wait_still_screen;
     send_key "alt-o";
-    assert_screen "displaymanager";
+    assert_screen "displaymanager", 60;
     send_key "ret";
     assert_screen "originUser-login-dm";
     type_password;
@@ -66,6 +85,10 @@ sub run {
     assert_and_click "dm-gnome";
     send_key "ret";
     assert_screen "generic-desktop", 120;
+
+    # Log out and switch to SLE classic
+    $self->prepare_sle_classic;
+    $self->application_test;
 }
 
 1;


### PR DESCRIPTION
Update gdm_session_switch test to include a reboot and IceWM. The test runs successfully on SLE 12SP2 and newer. SLE 12SP1 fails due to minor regression in IceWM but it's probably not worth fixing at this point in its lifecycle...

- Related ticket: https://progress.opensuse.org/issues/55706
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1207
- Verification run:
https://openqa.suse.de/tests/3294106
https://openqa.suse.de/tests/3294107