### PR TITLE
Enable download and restore guests in prj3

### DIFF
--- a/tests/virt_autotest/guest_migration_dst.pm
+++ b/tests/virt_autotest/guest_migration_dst.pm
@@ -41,8 +41,12 @@ sub run {
     save_screenshot;
     #workaround end
 
+    # clean up logs from prevous tests
+    $self->execute_script_run('[ -d /var/log/qa/ctcs2/ ] && rm -r /var/log/qa/ctcs2/*',                     30);
+    $self->execute_script_run('[ -d /tmp/prj3_guest_migration/ ] && rm -rf /tmp/prj3_guest_migration/',     30);
+    $self->execute_script_run('[ -d /tmp/prj3_migrate_admin_log/ ] && rm -rf /tmp/prj3_migrate_admin_log/', 30);
+
     #mark ready state
-    $self->execute_script_run("rm -r /var/log/qa/ctcs2/* /tmp/prj3* -r", 30);
     mutex_create('DST_READY_TO_START');
 
     #wait for src host core test finish to upload dst log

--- a/tests/virt_autotest/guest_migration_src.pm
+++ b/tests/virt_autotest/guest_migration_src.pm
@@ -19,6 +19,7 @@ use lockapi;
 use mmapi;
 use virt_utils;
 use Data::Dumper;
+use Utils::Architectures;
 
 sub get_script_run {
     my ($self) = @_;
@@ -32,6 +33,10 @@ sub get_script_run {
     my $test_time  = get_var("MAX_MIGRATE_TIME", "10800") - 90;
     my $args       = "-d $dst_ip -v $hypervisor -u $dst_user -p $dst_pass -i \"$guests\" -t $test_time";
     my $pre_test_cmd = "/usr/share/qa/tools/test_virtualization-guest-migrate-run " . $args;
+    my $vm_xml_dir   = "/tmp/download_vm_xml";
+    if (get_var("SKIP_GUEST_INSTALL") && is_x86_64) {
+        $pre_test_cmd .= " -k $vm_xml_dir";
+    }
 
     return "$pre_test_cmd";
 }
@@ -62,15 +67,16 @@ sub analyzeResult {
         $result->{$testcase_name}->{error}  = $error;
     }
 
-    #parse the reported guest installation failures at the end of log
-    unless ($text =~ /Congratulations! No guest failed in installation/) {
-        $text =~ /The guests failed in guest installation phase before core test are:(.*)Installation failed guest list done/s;
+    #parse the reported guest installation or restoration failures at the end of log
+    unless ($text =~ /Congratulations! No guest failed in (\w+)/) {
+        $text =~ /The guests failed in guest \w+ phase before core test are:(.*)\n(\w+) failed guest list done/s;
         my $installation_failed_guests = $1;
+        my $failing_phase              = $2;
         foreach my $guest (split('\n', $installation_failed_guests)) {
             next unless $guest !~ /^\s*$/;
             #add the installation failed guest into junit log
             $result->{$guest}->{status} = 'FAILED';
-            $result->{$guest}->{error}  = "Guest $guest installation failed before guest migration test.";
+            $result->{$guest}->{error}  = "Guest $failing_phase failed so the guest migration tests did not run.";
         }
     }
 
@@ -95,7 +101,12 @@ sub run {
     my $timeout         = get_var("MAX_MIGRATE_TIME", "10800") - 30;
     my $log_dirs        = "/var/log/qa";
     my $upload_log_name = "guest-migration-src-logs";
-    $self->execute_script_run("rm -r /var/log/qa/ctcs2/* /tmp/prj3* -r", 30);
+
+    # clean up logs from prevous tests
+    $self->execute_script_run('[ -d /var/log/qa/ctcs2/ ] && rm -r /var/log/qa/ctcs2/*',                     30);
+    $self->execute_script_run('[ -d /tmp/prj3_guest_migration/ ] && rm -rf /tmp/prj3_guest_migration/',     30);
+    $self->execute_script_run('[ -d /tmp/prj3_migrate_admin_log/ ] && rm -rf /tmp/prj3_migrate_admin_log/', 30);
+
     $self->run_test($timeout, "", "no", "yes", "$log_dirs", "$upload_log_name");
 
     #display test result

--- a/tests/virt_autotest/virt_utils.pm
+++ b/tests/virt_autotest/virt_utils.pm
@@ -329,8 +329,9 @@ sub download_guest_assets {
     my $remote_export_dir = "/var/lib/openqa/factory/other/";
     my $mount_point       = "/tmp/remote_guest";
 
-    assert_script_run "if [ ! -d $mount_point ];then mkdir -p $mount_point;fi";
+    script_run "if [ -d $mount_point ]; then if findmnt $mount_point; then umount $mount_point; fi; else mkdir -p $mount_point; fi";
     save_screenshot;
+
     # tip: nfs4 is not supported on sles12sp4
     assert_script_run("mount -t nfs $openqa_server:$remote_export_dir $mount_point", 120);
     save_screenshot;
@@ -352,6 +353,7 @@ sub download_guest_assets {
         script_run("ls -l $vm_xml_dir", 10);
         save_screenshot;
         my $local_guest_image = script_output "grep '<source file=' $vm_xml_dir/$guest.xml | sed \"s/^\\s*<source file='\\([^']*\\)'.*\$/\\1/\"";
+        script_run "if [ ! -d `dirname $local_guest_image` ]; then mkdir -p `dirname $local_guest_image`; fi";
         $rc = script_run("cp $mount_point/$remote_guest_disk $local_guest_image", 300);    #it took 75 seconds copy from vh016 to vh001
         script_run "ls -l $local_guest_image";
         save_screenshot;


### PR DESCRIPTION
Several commits in this PR together with other two PRs(https://github.com/SUSE/qa-testsuites/pull/784, https://github.com/SUSE/qa-automation/pull/711 ):

#1 improve the codes to reuse the guests in prj4
including fixing some minor issues, passing and setting the default downloaded xml directory which was left in previous commits, publish logs

#2 fix infinite loop between cleanupEnv() and restartService() in prj3

#3 fix default image location for sles11sp4 host

#4 enable reusing guest images in prj3

Only basic tests have been done for these commits. More through tests will be performed when the edits are more stable.

verify tests:

- about commit #1 improve prj4:

successful ones: 
prj4_guest_upgrade_developing_to_sles15sp1_on_developing-xen  http://10.67.17.153/tests/946  pass
prj4_guest_upgrade_developing_to_sles15sp1_on_developing-kvm  http://10.67.17.153/tests/949  running 

suppose to fail in restoration & publish report: 
prj4_guest_upgrade_sles11sp4_to_developing_on_developing-xen http://10.67.17.153/tests/947  as expected

- about #2 infinite loop issues:
http://10.67.17.153/tests/933#step/guest_migration_src/30 

- about #4 reuse guests in prj3
prj3 successful tests:
virt-guest-migration-developing-from-developing-to-developing-xen
http://10.67.17.153/tests/939#
virt-guest-migration-developing-from-developing-to-developing-kvm
http://10.67.17.153/tests/925


@alice-suse  @guoxuguang @waynechen55
