### PR TITLE
Fix iscsi_client.pm for 12.4 and 15.1

### DIFF
--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -100,14 +100,16 @@ sub run {
     initiator_service_tab;
     initiator_discovered_targets_tab;
     initiator_connected_targets_tab;
-    wait_serial("$module_name-0", 180) || die "'yast2 iscsi-client ' didn't finish or exited with non-zero code";
+    wait_serial("yast2-iscsi-client-status-0", 180) || die "'yast2 iscsi-client ' didn't finish or exited with non-zero code";
     # logging in to a target will create a local disc device
     # it takes a moment, since udev actually handles it
     sleep 5;
     record_info 'Systemd', 'Verify status of iscsi services and sockets';
     systemctl("is-active iscsid.service");
     systemctl("is-active iscsid.socket");
-    systemctl("is-active iscsi.service");
+    if (!is_sle('=12-SP4')) {
+        systemctl("is-active iscsi.service");
+    }
     record_info 'Display iSCSI session';
     assert_script_run 'iscsiadm --mode session -P 3 | tee -a ' . "/dev/$serialdev | grep LOGGED_IN";
     record_info 'Verify LUN availability';


### PR DESCRIPTION
Hello, those are two small fixes for
* SLES12sp4: Here, the `iscsi.service` isn't active but `iscsid.service` and `iscsid.socket` are and everything works.
* SLES15sp1: Here, the `$module_name` variable is empty but on serial we are waiting for `yast2-iscsi-client-status-0`.

- Related ticket: [poo#55265](https://progress.opensuse.org/issues/55265)
- Verification run: [pdostal-server.suse.cz](http://pdostal-server.suse.cz/tests)
