### PR TITLE
Enable apparmor for following check test

### DIFF
--- a/tests/security/apparmor/aa_prepare.pm
+++ b/tests/security/apparmor/aa_prepare.pm
@@ -18,11 +18,13 @@ use strict;
 use warnings;
 use testapi;
 use utils 'zypper_call';
+use services::apparmor;
 
 sub run {
     select_console 'root-console';
     zypper_call 'in -t pattern apparmor';
-    assert_script_run "systemctl start apparmor";
+    services::apparmor::start_service;
+    services::apparmor::enable_service;
 }
 
 sub test_flags {


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/3293802#step/aa_status/4
- Verification run:
http://10.100.12.155/tests/13075