### PR TITLE
Add support for other architectures

### DIFF
--- a/schedule/yast/yast2_cmd@s390x-kvm.yaml
+++ b/schedule/yast/yast2_cmd@s390x-kvm.yaml
@@ -1,0 +1,9 @@
+name:           yast2_cmd@yast-s390x-kvm
+description:    >
+    Yast2 cmd interface tests.
+
+schedule:
+     - installation/bootloader_zkvm
+     - boot/boot_to_desktop
+     - yast2_cmd/yast_rdp
+     - yast2_cmd/yast_timezone


### PR DESCRIPTION
After https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8277 I think there is no reason not to test this on other architectures, hence this PR.

- Related ticket: https://progress.opensuse.org/issues/54746
- Verification runs
[aarch64](https://openqa.suse.de/tests/3310085)
[ppc64le](https://openqa.suse.de/tests/3310086)
[s390x-kvm](https://openqa.suse.de/tests/3310101)
