### PR TITLE
Re-enable VNC for s390x

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1128,8 +1128,7 @@ sub reconnect_mgmt_console {
             }
         }
 
-        # SLE >= 15 does not offer auto-started VNC server in SUT, only login prompt as in textmode
-        if (!check_var('DESKTOP', 'textmode') && is_sle('<15')) {
+        if (!check_var('DESKTOP', 'textmode')) {
             select_console('x11', await_console => 0);
         }
     }

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -137,12 +137,6 @@ if (is_sle('15+')) {
 }
 diag('default desktop: ' . default_desktop);
 set_var('DESKTOP', get_var('DESKTOP', default_desktop));
-if (is_sle('15+')) {
-    if (check_var('ARCH', 's390x') and get_var('DESKTOP', '') =~ /gnome|minimalx/) {
-        diag 'BUG: bsc#1058071 - No VNC server available in SUT, disabling X11 tests. Re-enable after bug is fixed';
-        set_var('DESKTOP', 'textmode');
-    }
-}
 
 # don't want updates, as we don't test it or rely on it in any tests, if is executed during installation
 # For released products we want install updates during installation, only in minimal workflow disable
@@ -1042,9 +1036,7 @@ else {
         load_mm_autofs_tests;
     }
     elsif (get_var('UPGRADE_ON_ZVM')) {
-        # Set 'DESKTOP' for origin system to avoid SLE15 s390x bug: bsc#1058071 - No VNC server available in SUT
         # Set origin and target version
-        set_var('DESKTOP',                'gnome');
         set_var('ORIGIN_SYSTEM_VERSION',  get_var('BASE_VERSION'));
         set_var('UPGRADE_TARGET_VERSION', get_var('VERSION')) if (!get_var('UPGRADE_TARGET_VERSION'));
         loadtest "migration/version_switch_origin_system";

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -34,8 +34,6 @@ sub run {
         select_console('x11');
     }
     my $boot_timeout = (check_var('VIRSH_VMM_FAMILY', 'hyperv') || check_var('BACKEND', 'ipmi')) ? 450 : 200;
-    # SLE >= 15 s390x does not offer auto-started VNC server in SUT, only login prompt as in textmode
-    return if check_var('ARCH', 's390x') && is_sle('15+');
     if (check_var('WORKER_CLASS', 'hornet')) {
         # hornet does not show the console output
         diag "waiting $boot_timeout seconds to let hornet boot and finish initial script";


### PR DESCRIPTION
Now that [bsc#1129412](https://bugzilla.suse.com/show_bug.cgi?id=1129412) is fixed, we can finally re-enable VNC for s390x.

- Related ticket: https://progress.opensuse.org/issues/50285
- Verification runs: 
[gnome](https://openqa.suse.de/t3308967)
[allpatterns-zKVM](https://openqa.suse.de/tests/3309724)
[allpatterns-zVM](https://openqa.suse.de/t3309155)
