### PR TITLE
btrfs-progs: Update install steps

### DIFF
--- a/data/btrfs-progs/install.sh
+++ b/data/btrfs-progs/install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -x
+
+# The first parameter is the git url
+# The second parameter is the install folder
+git clone -q --depth 1 $1
+cd btrfs-progs
+./autogen.sh
+./configure --disable-documentation --disable-zstd --disable-python
+make
+make testsuite
+mkdir -p $2
+tar zxf tests/btrfs-progs-tests.tar.gz -C $2
+cp btrfs btrfs-convert btrfs-find-root btrfs-image btrfs-select-super btrfstune /sbin/
+cp tests/clean-tests.sh $2
+if [ "$3" == "misc" ];then
+    sed -ie '/check_min_kernel_version/,+2 s/^/#/' $2/misc-tests/034*/test.sh
+    umount /home
+fi
+

--- a/tests/btrfs-progs/install.pm
+++ b/tests/btrfs-progs/install.pm
@@ -35,6 +35,7 @@ sub install_dependencies {
       gcc
       libblkid-devel
       zlib-devel
+      libext2fs-devel
     );
     zypper_call('in ' . join(' ', @deps));
 }
@@ -45,15 +46,10 @@ sub run {
 
     # Install btrfs-progs
     install_dependencies;
-    assert_script_run('git clone -q --depth 1 ' . GIT_URL, timeout => 360);
-    assert_script_run 'cd btrfs-progs';
-    assert_script_run './autogen.sh';
-    assert_script_run './configure --disable-documentation --disable-convert --disable-zstd \
---disable-programs --disable-shared --disable-static --disable-python';
-    assert_script_run 'make testsuite', timeout => 300;
-    assert_script_run 'mkdir -p ' . INST_DIR;
-    assert_script_run 'tar zxf tests/btrfs-progs-tests.tar.gz -C ' . INST_DIR;
-    assert_script_run 'cp tests/clean-tests.sh ' . INST_DIR . ';cd ' . INST_DIR;
+    assert_script_run 'wget ' . autoinst_url('/data/btrfs-progs/install.sh');
+    assert_script_run 'chmod a+x install.sh';
+    assert_script_run './install.sh ' . GIT_URL . " " . INST_DIR . " " . get_var('CATEGORY'), timeout => 1200;
+    assert_script_run 'cd ' . INST_DIR;
 
     # Create log file
     log_create STATUS_LOG;


### PR DESCRIPTION
1. In SLE12 SP5, btrfs-progs version is lower than upstream. Need replace them with upstream version during testing, so that focus test on kernel but not btrfs user space utilities. 
2. Add workaround for misc/034 to run this test on kernel version before 5.0

- Related ticket: https://progress.opensuse.org/issues/55160
- Verification run:
http://10.67.133.10/tests/462  (cli test)
http://10.67.133.10/tests/461  (misc test)
