### PR TITLE
Fix f1c4edc7e (PR#7837) for JeOS

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -21,7 +21,6 @@ use version_utils
 use File::Find;
 use File::Basename;
 use LWP::Simple 'head';
-use repo_tools qw(add_qa_head_repo add_qa_web_repo);
 use scheduler 'load_yaml_schedule';
 use Utils::Backends qw(is_hyperv is_hyperv_in_gui);
 use Utils::Architectures;
@@ -730,8 +729,7 @@ elsif (get_var("QA_TESTSET")) {
 }
 elsif (get_var("QA_TESTSUITE")) {
     boot_hdd_image;
-    add_qa_head_repo;
-    add_qa_web_repo;
+    loadtest "qa_automation/prepare_qa_repo";
     loadtest "qa_automation/install_test_suite";
     loadtest "qa_automation/execute_test_run";
 }

--- a/tests/qa_automation/prepare_qa_repo.pm
+++ b/tests/qa_automation/prepare_qa_repo.pm
@@ -1,0 +1,31 @@
+# SUSE's openQA tests
+#
+# Copyright © 2017-2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: the step to prepare QA:Head repository
+# Maintainer: Yong Sun <yosun@suse.com>
+
+use strict;
+use warnings;
+use testapi;
+use utils;
+use base "opensusebasetest";
+use repo_tools qw(add_qa_head_repo add_qa_web_repo);
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    add_qa_head_repo;
+    add_qa_web_repo;
+}
+
+sub test_flags {
+    return {milestone => 1, fatal => 1};
+}
+
+1;


### PR DESCRIPTION
By putting add_qa_{head,web}_repo() helpers into
qa_automation/prepare_qa_repo.pm.

The problem wasn't with add_qa_{head,web}_repo() helpers itself, but
with the need to have select_console() call before (at least for JeOS).

This fixes JeOS testing
(sle-12-SP5-JeOS-for-kvm-and-xen-x86_64-Build4.61-jeos-fs_stress@64bit-virtio-vga)

Fixes: f1c4edc7e ("repo_tools: Add add_qa_{head,web}_repo() and use it")
Reported-by: Martin Loviska <mloviska@suse.com>

Verification run: http://quasar.suse.cz/tests/3624
