### PR TITLE
evolution_prepare_servers: use 'consoletest' as base to upload logs on failure

### DIFF
--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -12,7 +12,7 @@
 
 use strict;
 use warnings;
-use base "opensusebasetest";
+use base "consoletest";
 use testapi;
 use utils;
 use version_utils qw(is_sle is_jeos is_opensuse);


### PR DESCRIPTION
Upload logs on failure to help to debug by using `consoletest` as base.

- Verification run: 
  * aarch64: https://openqa.opensuse.org/t1019454
  * x86_64:   https://openqa.opensuse.org/t1019490
