### PR TITLE
Revert "evolution_prepare_servers: use 'consoletest' as base to upload logs on failure"

### DIFF
--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -12,7 +12,7 @@
 
 use strict;
 use warnings;
-use base "consoletest";
+use base "opensusebasetest";
 use testapi;
 use utils;
 use version_utils qw(is_sle is_jeos is_opensuse);


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#8314

https://openqa.suse.de/tests/3308513#step/evolution_prepare_servers/70