### PR TITLE
Tolerate different number of significant digits in fdisk output

### DIFF
--- a/data/qam/mdadm.sh
+++ b/data/qam/mdadm.sh
@@ -136,7 +136,8 @@ run mdadm --create --verbose $MD_DEVICE --level=0 --raid-devices=3 --size=522240
 
 rungrep "active raid0" cat /proc/mdstat
 
-rungrep "1.5 GiB" fdisk -l $MD_DEVICE
+# Different fdisk versions either report "1.5 GiB" or "1.51 GiB"
+rungrep "1.51\? GiB" fdisk -l $MD_DEVICE
 
 rungrep "Creating filesystem with" mkfs.ext4 $MD_DEVICE
 


### PR DESCRIPTION
Newer versions of fdisk report one more significant digit, accept both
variants.

- Related ticket: https://progress.opensuse.org/issues/56069
- Verification run: https://openqa.opensuse.org/tests/1020124
- Verification run: https://openqa.opensuse.org/tests/1020149
