### PR TITLE
Add a test for NVMe IRQ spreading on NUMA

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -254,7 +254,8 @@ sub is_kernel_test {
         || get_var('INSTALL_KOTD')
         || get_var('VIRTIO_CONSOLE_TEST')
         || get_var('NVMFTESTS')
-        || get_var('TRINITY'));
+        || get_var('TRINITY')
+        || get_var('NUMA_IRQBALANCE'));
 }
 
 sub get_ltp_tag {

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -172,6 +172,9 @@ sub load_kernel_tests {
             boot_hdd_image();
         }
         loadtest "trinity";
+    } elsif (get_var('NUMA_IRQBALANCE')) {
+        boot_hdd_image();
+        loadtest 'numa_irqbalance';
     }
 
     if (check_var('BACKEND', 'svirt') && get_var('PUBLISH_HDD_1')) {

--- a/tests/kernel/numa_irqbalance.pm
+++ b/tests/kernel/numa_irqbalance.pm
@@ -1,0 +1,113 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: This modules verifies we have correct spreading of NVMe
+# interrupts across all NUMA nodes, especially when the number of
+# nodes exceeds the number of queues the device has.
+# Maintainer: Michael Moese <mmoese@suse.de>
+
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $self   = shift;
+    my $numcpu = get_required_var('QEMUCPUS');
+    my @interrupts;
+    my @irqs;         # number of interrupts by cpu
+    my $numqueues;    # number of NVMe queues, each queue has it's own MSI
+    my $fail = 0;
+
+    $self->select_serial_terminal;
+
+    $numqueues = script_output('grep -c nvme /proc/interrupts');
+    record_info('INFO', "The VM has $numqueues NVMe queues and $numcpu CPUs");
+    if ($numcpu <= $numqueues || !check_var('QEMU_NUMA', 1)) {
+        die("This test requires the system to have more NUMA nodes than NVMe queues!");
+    }
+
+    # install and run fio to generate some interrupts
+    zypper_call('install fio');
+    assert_script_run("fio --randrepeat=1 --ioengine=libaio --direct=1 --gtod_reduce=1 --name=test --filename=random_read_write --bs=4k --iodepth=64 --size=4G --readwrite=randrw --rwmixread=75 --max-jobs=$numcpu");
+
+    my $fields = 3 + $numcpu - 1;    # calculete fields to select with cut
+    @interrupts = split('\n', script_output("grep nvme /proc/interrupts | sed -E -e \'s/[[:blank:]]+/ /g\' | cut -d \' \' -f 3-$fields"));
+
+    # ignore the first queue, this should be the admin queue. This doesn't
+    # do too much and propably will only be handled on node 0, so we skip it here.
+    for (my $queue = 1; $queue <= $numqueues; $queue++) {
+        my @thisqueue = split(' ', $interrupts[$queue]);
+        for (my $i = 0; $i <= $numcpu; $i++) {
+            $irqs[$i] += $thisqueue[$i];
+        }
+    }
+
+    for (my $j = 0; $j < $numcpu; $j++) {
+        # just report the number of IRQs handled per NUMA node
+        record_info("$irqs[$j]", "$irqs[$j] interrupts on CPU#$j");
+
+        # no need to check the first nodes. We are only interestesd if IRQs are
+        # also handled on the NUMA nodes with a higher number than the number of
+        # queues on the NVMe.
+        if ($j > $numqueues) {
+            if ($irqs[$j] == "0") {
+                die("IRQs don't get distributed equally");
+            }
+        }
+    }
+}
+
+sub post_fail_hook {
+    my $self = shift;
+
+    $self->select_serial_terminal;
+
+    script_run('cat /proc/interrupts > /tmp/interrupts.txt');
+    upload_logs('/tmp/interrupts.txt');
+    script_run('lscpu > /tmp/lscpu.txt');
+    upload_logs('/tmp/lscpu.txt');
+
+    $self->SUPER::post_fail_hook;
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;
+
+=head1 Configuration
+
+=head2 Requirements for runtime environment
+
+Basically, nothing much is needed on the SUT to run this test except fio.
+So if you are running SLE, you typically don't need any special modules.
+
+=head2 Requirements for QEMU configuration
+
+To run this testsuite, you need to have your disk configured as NVMe, with
+a number of queues that is smaller than the number of NUMA nodes in the SUT.
+In addition, you need to ensure you give the SUT enough memory, as it gets split
+among the NUMA nodes.
+
+=head2 Example testsuite
+
+Example testsuite to run the irq balancing tests:
+
+BOOT_HDD_IMAGE=1
+HDDMODEL_1=nvme
+HDDNUMQUEUES_1=4
+NUMA_IRQBALANCE=1
+QEMUCPUS=8
+QEMURAM =4096
+QEMU_NUMA=1
+


### PR DESCRIPTION
On NUMA-machines with more NUMA-nodes than NVMe queues, the irq
spreading code starts from node 0 and continues up to  the number
of interrupts requested for allocation. This leaves the nodes
past the last interrupt unused.

This test needs to be executed on a NUMA configuration, with more NUMA
nodes than NVMe queues.

Running this test requires https://github.com/os-autoinst/os-autoinst/pull/1203

- Related ticket: https://progress.opensuse.org/issues/55502
- Verification run: http://mmoese-vm.qa.suse.de/tests/79#

Please not this test is supposed to fail until this issue is resolved.