### PR TITLE
Adjusted and enabled tests to work for QAM

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1420,6 +1420,13 @@ sub load_extra_tests_y2uitest_cmd {
     loadtest 'yast2_cmd/yast_sysconfig';
     loadtest 'yast2_cmd/yast_keyboard';
     loadtest 'yast2_cmd/yast_nfs_server';
+
+    #temporary runs for QAM while tests under y2uitest_ncurses are being ported
+    loadtest "console/yast2_apparmor";
+    loadtest "console/yast2_http";
+    loadtest "console/yast2_nis" if is_sle;
+    loadtest "console/yast2_ftp";
+    loadtest "console/yast2_tftp";
 }
 
 sub load_extra_tests_texlive {

--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -108,19 +108,17 @@ sub run {
     # make sure that apache2 server got started when booting
     if (is_sle('<=15') || is_leap('<=15.0')) {
         send_key 'alt-t';
-    }
-    else {
-        change_service_configuration(
-            after_writing => {start         => 'alt-t'},
-            after_reboot  => {start_on_boot => 'alt-a'}
-        );
+    } else {
+        send_key 'alt-a';                           #after rebooting the host, what should be apache status?
+        send_key 'up';
+        send_key 'ret';                             #we select to start apache when the host boots
     }
 
-    assert_screen 'http_start_apache2';    #confirm apache now starts on boot
-    send_key 'alt-f';                      # now finish the tests :)
+    assert_screen 'http_start_apache2';             #confirm apache now starts on boot
+    send_key 'alt-f';                               # now finish the tests :)
 
     check_screen 'http_install_apache2_mods', 60;
-    send_key 'alt-i';                      # confirm to install apache2_mod_perl, apache2_mod_php, apache2_mod_python
+    send_key 'alt-i';                               # confirm to install apache2_mod_perl, apache2_mod_php, apache2_mod_python
 
     # if popup, confirm to enable apache2 configuratuion
     if (check_screen('http_enable_apache2', 10)) {


### PR DESCRIPTION
Related ticked: https://progress.opensuse.org/issues/55940

needles SLES: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1209/
needle OpenSUSE: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/586

Test runs:

- SLES 15.1 -> http://deathstar.suse.cz/tests/610
- SLES 15.0 -> http://deathstar.suse.cz/tests/612
- SLES 12.4 -> http://deathstar.suse.cz/tests/608
- SLES 12.3 -> http://deathstar.suse.cz/tests/606
- TW: http://deathstar.suse.cz/tests/583
- Leap 15.0: http://deathstar.suse.cz/tests/611
- Leap 15.1: http://deathstar.suse.cz/tests/609