### PR TITLE
Add timeout for messages in autoyast profile

### DIFF
--- a/data/autoyast_sle12/autoyast_mlx_con5.xml
+++ b/data/autoyast_sle12/autoyast_mlx_con5.xml
@@ -97,22 +97,22 @@
     <errors>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
+      <timeout config:type="integer">3</timeout>
     </errors>
     <messages>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
+      <timeout config:type="integer">3</timeout>
     </messages>
     <warnings>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
+      <timeout config:type="integer">3</timeout>
     </warnings>
     <yesno_messages>
       <log config:type="boolean">true</log>
       <show config:type="boolean">true</show>
-      <timeout config:type="integer">0</timeout>
+      <timeout config:type="integer">3</timeout>
     </yesno_messages>
   </report>
   <timezone>


### PR DESCRIPTION
In the autoyast file, set a timeout for warnings, errors, etc, so
we can continue installing even if an alpha/beta warning is shown.
Otherwise, we can be stalled until the test times out.