### PR TITLE
Allow running LTP install and testcases in the same job

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -128,10 +128,15 @@ sub load_kernel_tests {
             loadtest 'update_kernel';
         }
         loadtest 'install_ltp';
-        if (get_var('LTP_INSTALL_REBOOT')) {
-            loadtest 'boot_ltp';
+        if (get_var('LTP_COMMAND_FILE')) {
+            loadtest_from_runtest_file();
         }
-        shutdown_ltp();
+        else {
+            if (get_var('LTP_INSTALL_REBOOT')) {
+                loadtest 'boot_ltp';
+            }
+            shutdown_ltp();
+        }
     }
     elsif (get_var('LTP_COMMAND_FILE')) {
         if (get_var('INSTALL_KOTD')) {

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -347,7 +347,8 @@ sub run {
 
     upload_runtest_files('/opt/ltp/runtest', $tag);
 
-    power_action('reboot', textmode => 1) if get_var('LTP_INSTALL_REBOOT');
+    power_action('reboot', textmode => 1) if get_var('LTP_INSTALL_REBOOT') ||
+        get_var('LTP_COMMAND_FILE');
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
This is a convenience patch for LTP testcase debugging. If both `INSTALL_LTP` and `LTP_COMMAND_FILE` variables are specified in the same job, the testcases specified in `LTP_COMMAND_FILE` will be executed immediately after `ltp_install` (and a VM reboot).

Currently, running a testcase bugfix check in openQA requires two separate jobs - one to install LTP and publish the HDD image, and second to actually run the tests. That's perfectly fine for running regression tests but somewhat inconvenient for testcase development/debugging on special hardware.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
