### PR TITLE
Enable running ltp_install and ltp_run in the same job

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -128,10 +128,15 @@ sub load_kernel_tests {
             loadtest 'update_kernel';
         }
         loadtest 'install_ltp';
-        if (get_var('LTP_INSTALL_REBOOT')) {
-            loadtest 'boot_ltp';
+        if (get_var('LTP_COMMAND_FILE')) {
+            loadtest_from_runtest_file();
         }
-        shutdown_ltp();
+        else {
+            if (get_var('LTP_INSTALL_REBOOT')) {
+                loadtest 'boot_ltp';
+            }
+            shutdown_ltp();
+        }
     }
     elsif (get_var('LTP_COMMAND_FILE')) {
         if (get_var('INSTALL_KOTD')) {

--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -347,7 +347,8 @@ sub run {
 
     upload_runtest_files('/opt/ltp/runtest', $tag);
 
-    power_action('reboot', textmode => 1) if get_var('LTP_INSTALL_REBOOT');
+    power_action('reboot', textmode => 1) if get_var('LTP_INSTALL_REBOOT') ||
+      get_var('LTP_COMMAND_FILE');
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
This is a convenience patch for LTP testcase debugging. When both `INSTALL_LTP` and `LTP_COMMAND_FILE` are specified in the same job, run the testcase immediately after `ltp_install` and VM reboot.

Currently, running an LTP testcase from fresh sources requires two separate jobs: One to install LTP from Git and publish the HDD image, second to actually run the testcase. This is perfectly fine for regression tests but it's too cumbersome for quick one-off debug runs on special hardware.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
