### PR TITLE
install_ltp: retry git-clone without --depth on failure

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -199,7 +199,10 @@ sub install_from_git {
     if ($rel) {
         $rel = ' -b ' . $rel;
     }
-    assert_script_run("git clone -q --depth 1 $url" . $rel, timeout => 360);
+    my $ret = script_run("git clone -q --depth 1 $url" . $rel, timeout => 360);
+    if (!defined($ret) || $ret) {
+        assert_script_run("git clone -q $url" . $rel, timeout => 360);
+    }
     assert_script_run 'cd ltp';
     # It is a shallow clone so 'git describe' won't work
     script_run 'git log -1 --pretty=format:"git-%h" | tee /opt/ltp_version';


### PR DESCRIPTION
This is a convenience patch for LTP testcase debugging. When installing LTP from a repo hosted on localhost via HTTP, `git clone --depth 1` will fail with the following error message:

    fatal: dumb http transport does not support shallow capabilities

Retry `git clone` without `--depth` if the first attempt fails.

- Related ticket: N/A
- Needles: N/A
- Verification run: N/A
