### PR TITLE
Add tuned regression test

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -255,7 +255,8 @@ sub is_kernel_test {
         || get_var('VIRTIO_CONSOLE_TEST')
         || get_var('NVMFTESTS')
         || get_var('TRINITY')
-        || get_var('NUMA_IRQBALANCE'));
+        || get_var('NUMA_IRQBALANCE')
+        || get_var('TUNED'));
 }
 
 sub get_ltp_tag {

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -23,7 +23,7 @@ use autotest;
 use utils;
 use LTP::TestInfo 'testinfo';
 use File::Basename 'basename';
-use main_common qw(load_bootloader_s390x boot_hdd_image get_ltp_tag);
+use main_common qw(load_bootloader_s390x boot_hdd_image get_ltp_tag load_boot_tests load_inst_tests load_reboot_tests);
 use 5.018;
 # FIXME: Delete the "## no critic (Strict)" line and uncomment "use warnings;"
 # use warnings;
@@ -112,6 +112,20 @@ sub stress_snapshots {
     }
 }
 
+sub prepare_target {
+    if (get_var("BOOT_HDD_IMAGE")) {
+        boot_hdd_image;
+    }
+    elsif (check_var('IPXE', '1')) {
+        return;
+    }
+    else {
+        load_boot_tests();
+        load_inst_tests();
+        load_reboot_tests();
+    }
+}
+
 sub load_kernel_tests {
     load_bootloader_s390x();
 
@@ -175,6 +189,10 @@ sub load_kernel_tests {
     } elsif (get_var('NUMA_IRQBALANCE')) {
         boot_hdd_image();
         loadtest 'numa_irqbalance';
+    }
+    elsif (get_var('TUNED')) {
+        prepare_target;
+        loadtest "tuned";
     }
 
     if (check_var('BACKEND', 'svirt') && get_var('PUBLISH_HDD_1')) {

--- a/tests/kernel/tuned.pm
+++ b/tests/kernel/tuned.pm
@@ -1,0 +1,67 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Regression test for tuned daemon
+# Maintainer: Petr Cervinka <pcervinka@suse.com>
+# Tags: https://jira.suse.com/browse/SLE-6514
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub tuned_set_profile {
+    my $tuned_profile = shift;
+    assert_script_run "tuned-adm profile $tuned_profile";
+    validate_script_output 'tuned-adm active', sub { m/${tuned_profile}/ };
+}
+
+sub run {
+    my $self      = shift;
+    my $tuned_log = '/var/log/tuned/tuned.log';
+    # Already known errors with bug reference
+    my %known_errors = (
+        bsc_1148789 => 'Executing cpupower error: Error setting perf-bias value on CPU'
+    );
+    select_console 'root-console';
+    # Install tuned package
+    zypper_call 'in tuned';
+    # Start daemon
+    systemctl 'start tuned';
+    # Check status
+    systemctl 'status tuned';
+    # Set virtual-guest profile for QEMU backends and throughput-performance for the rest
+    tuned_set_profile(check_var('BACKEND', 'qemu') ? 'virtual-guest' : 'throughput-performance');
+    # Stop tuned daemon
+    systemctl 'stop tuned';
+    # Delete and ignore logs from first run without proper profile set
+    assert_script_run "rm ${tuned_log}";
+    # Start daemon
+    systemctl 'start tuned';
+    # Check tuned log for errors
+    foreach my $error (split(/\n/, script_output "awk '/ERROR/ {\$1=\$2=\"\"; print \$0}' ${tuned_log} | uniq")) {
+        for (keys %known_errors) {
+            if ($error =~ /${known_errors{$_}}/) {
+                my $bugref = $_ =~ s/_/\#/r;
+                record_soft_failure "$bugref - ${known_errors{$_}}";
+                last;
+            }
+            record_info 'unknown error', $error, result => 'fail';
+            $self->result('fail');
+        }
+    }
+}
+
+sub post_fail_hook {
+    my $self = shift;
+    $self->SUPER::post_fail_hook;
+    upload_logs '/var/log/tuned/tuned.log';
+}
+1;


### PR DESCRIPTION
New test poo#55994: New test for tuned which covers installation,
change of profile, service start and check for errors in log file.

- Related ticket: https://progress.opensuse.org/issues/55994
- Needles: none
- Verification run:
x86_64: http://10.100.12.105/tests/3017#
ppc64le: http://10.100.12.105/tests/3018#
