### PR TITLE
Remove test variable WORKAROUND_MODULES

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -338,8 +338,7 @@ sub is_desktop_module_selected {
     # same is true for sles4sap
     return
       get_var('ADDONS', '') =~ /all-packages|desktop|we/
-      || get_var('WORKAROUND_MODULES', '') =~ /desktop|we/
-      || get_var('ADDONURL',           '') =~ /desktop|we/
+      || get_var('ADDONURL', '') =~ /desktop|we/
       || (!is_sle('15+') && get_var('SCC_ADDONS', '') =~ /desktop|we|productivity|ha/)
       || (is_sle('15+')  && get_var('SCC_ADDONS', '') =~ /desktop|we/)
       || is_sles4sap;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -116,7 +116,7 @@ sub cleanup_needles {
 }
 
 sub is_desktop_module_available {
-    return check_var('SCC_REGISTER', 'installation') || check_var_array('ADDONS', 'all-packages') || check_var_array('WORKAROUND_MODULES', 'desktop');
+    return check_var('SCC_REGISTER', 'installation') || check_var_array('ADDONS', 'all-packages') || check_var_array('ADDONURL', 'desktop');
 }
 
 # SLE specific variables
@@ -266,10 +266,7 @@ if (is_sle('15+') && !check_var('SCC_REGISTER', 'installation')) {
         # By default add all modules
         @modules = qw(base sdk desktop legacy script serverapp);
     }
-    # If WORKAROUND_MODULES contains a list of modules, add only them
-    if (get_var('WORKAROUND_MODULES')) {
-        @modules = split(/,/, get_var('WORKAROUND_MODULES'));
-    }
+
     if (@modules) {
         my $arch    = get_required_var("ARCH");
         my $build   = get_required_var("BUILD");

--- a/schedule/staging/sles4sap_offline_gnome@64bit-staging.yaml
+++ b/schedule/staging/sles4sap_offline_gnome@64bit-staging.yaml
@@ -15,7 +15,12 @@ vars:
   SLES4SAP_MODE: sles4sap
   SLE_PRODUCT: sles4sap
   SYSTEM_ROLE: default
-  WORKAROUND_MODULES: base,desktop,sapapp,serverapp,ha
+  ADDONURL: base,desktop,sapapp,serverapp,ha
+  ADDONURL_BASE: ftp://openqa.suse.de/%REPO_SLE_MODULE_BASESYSTEM%
+  ADDONURL_DESKTOP: ftp://openqa.suse.de/%REPO_SLE_MODULE_DESKTOP_APPLICATIONS%
+  ADDONURL_SERVERAPP: ftp://openqa.suse.de/%REPO_SLE_MODULE_SERVER_APPLICATIONS%
+  ADDONURL_SAPAPP: ftp://openqa.suse.de/%REPO_SLE_MODULE_SAP_APPLICATIONS%
+  ADDONURL_HA: ftp://openqa.suse.de/%REPO_SLE_PRODUCT_HA%
 schedule:
   - installation/bootloader_start
   - installation/welcome

--- a/tests/installation/addon_products_sle.pm
+++ b/tests/installation/addon_products_sle.pm
@@ -135,18 +135,11 @@ sub handle_addon {
 }
 
 sub test_addonurl {
-    my $testvalue = get_var('ADDONURL');
-    my @missing_modules;
-    my @test_modules = split(/,/, get_var('WORKAROUND_MODULES'));
+    die('ADDONURL is required') unless get_var('ADDONURL');
+    my @test_modules = split(/,/, get_var('ADDONURL'));
 
     foreach (@test_modules) {
-        push @missing_modules, $_ unless ($testvalue =~ $_);
         die('URL ADDONURL_' . uc $_ . ' could not be accessed') unless head(get_var('ADDONURL_' . uc $_));
-    }
-
-    if (@missing_modules) {
-        my $str_missed_mod = join(',', @missing_modules);
-        die "Missing modules in ADDONURL which are set in WORKAROUND_MODULES: $str_missed_mod";
     }
 }
 
@@ -183,11 +176,7 @@ sub run {
             }
         }
     }
-    test_addonurl
-      if is_sle('>=15')
-      and !check_var('SCC_REGISTER', 'installation')
-      and (get_var('ALL_MODULES') || get_var('WORKAROUND_MODULES'));
-
+    test_addonurl if is_sle('>=15');
     if (get_var("ADDONURL")) {
         if (match_has_tag('inst-addon')) {
             send_key 'alt-k';                                                   # install with addons


### PR DESCRIPTION
As the bsc#1054375 has been resolved  the WORKAROUND_MODULES test parameter
doesnt seem to be in any use. Any condition and the test_addonurl have been
removed as they are not serve in anything.

- Related ticket: https://progress.opensuse.org/issues/54770
- Needles: N/A
- Verification run: 
http://aquarius.suse.cz/tests/491
http://aquarius.suse.cz/tests/487
[sle-15-SP2 Y-Staging-x86_64 RAID1](https://openqa.suse.de/tests/3349620#)