### PR TITLE
Change conditional to include SLES >15 when installing yast2-users is needed

### DIFF
--- a/tests/console/yast2_ftp.pm
+++ b/tests/console/yast2_ftp.pm
@@ -71,7 +71,7 @@ sub run {
     # install vsftps
     zypper_call("in vsftpd yast2-ftp-server", timeout => 180);
 
-    if (is_sle('=15')) {
+    if (is_sle('>=15')) {
         zypper_call("in yast2-users", timeout => 180);
         record_soft_failure 'bsc#1132116';
     }


### PR DESCRIPTION
https://progress.opensuse.org/issues/56177

Runs:
SLES 15.0:  http://deathstar.suse.cz/tests/762
SLES 15.1: http://deathstar.suse.cz/tests/763
SLES 12.4: http://deathstar.suse.cz/tests/764
SLES 12.3: http://deathstar.suse.cz/tests/765

No needles.