### PR TITLE
opensuse_welcome: set as a milestone

### DIFF
--- a/tests/installation/opensuse_welcome.pm
+++ b/tests/installation/opensuse_welcome.pm
@@ -35,4 +35,8 @@ sub run {
     }
 }
 
+sub test_flags {
+    return {milestone => 1};
+}
+
 1;


### PR DESCRIPTION
It will allow to restore the desktop without the welcome screen.