### PR TITLE
Fix namespace support in Public Cloud tests

### DIFF
--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -62,12 +62,12 @@ sub vault_create_credentials {
     my ($self) = @_;
 
     record_info('INFO', 'Get credentials from VAULT server.');
-    my $res = $self->vault_api('/azure/creds/openqa-role', method => 'get');
+    my $res = $self->vault_api('/v1/' . get_var('PUBLIC_CLOUD_VAULT_NAMESPACE', '') . '/azure/creds/openqa-role', method => 'get');
     $self->vault_lease_id($res->{lease_id});
     $self->key_id($res->{data}->{client_id});
     $self->key_secret($res->{data}->{client_secret});
 
-    $res = $self->vault_api('/secret/azure/openqa-role', method => 'get');
+    $res = $self->vault_api('/v1/' . get_var('PUBLIC_CLOUD_VAULT_NAMESPACE', '') . '/secret/azure/openqa-role', method => 'get');
     $self->tenantid($res->{data}->{tenant_id});
     $self->subscription($res->{data}->{subscription_id});
 

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -24,7 +24,7 @@ sub vault_create_credentials {
     my ($self) = @_;
 
     record_info('INFO', 'Get credentials from VAULT server.');
-    my $res = $self->vault_api('/aws/creds/openqa-role', method => 'get');
+    my $res = $self->vault_api('/v1/' . get_var('PUBLIC_CLOUD_VAULT_NAMESPACE', '') . '/aws/creds/openqa-role', method => 'get');
     $self->vault_lease_id($res->{lease_id});
     $self->key_id($res->{data}->{access_key});
     $self->key_secret($res->{data}->{secret_key});

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -59,7 +59,7 @@ sub create_credentials_file {
           . '}';
     } else {
         record_info('INFO', 'Get credentials from VAULT server.');
-        my $res = $self->vault_api('/gcp/key/openqa-role', method => 'get');
+        my $res = $self->vault_api('/v1/' . get_var('PUBLIC_CLOUD_VAULT_NAMESPACE', '') . '/gcp/key/openqa-role', method => 'get');
         $credentials_file = b64_decode($res->{data}->{private_key_data});
         my $cf_json = decode_json($credentials_file);
         $self->account($cf_json->{client_email});

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -379,13 +379,12 @@ sub vault_api {
     my $data   = $args{data}   // {};
     my $ua     = Mojo::UserAgent->new;
     my $url    = get_required_var('_SECRET_PUBLIC_CLOUD_REST_URL');
-    my $namespace = get_var('PUBLIC_CLOUD_VAULT_NAMESPACE', '');
     my $res;
 
     $self->vault_login() unless ($self->vault_token);
 
     $ua->insecure(get_var('_SECRET_PUBLIC_CLOUD_REST_SSL_INSECURE', 0));
-    $url = $url . '/v1/' . $namespace . $path;
+    $url = $url . $path;
     if ($method eq 'get') {
         $res = $ua->get($url =>
               {'X-Vault-Token' => $self->vault_token()})->result;
@@ -419,7 +418,7 @@ sub vault_revoke {
 
     return unless (defined($self->vault_lease_id));
 
-    $self->vault_api('/sys/leases/revoke', method => 'post', data => {lease_id => $self->vault_lease_id});
+    $self->vault_api('/v1/sys/leases/revoke', method => 'post', data => {lease_id => $self->vault_lease_id});
     $self->vault_lease_id(undef);
 }
 


### PR DESCRIPTION
Partial revert of PR #8345 because it breaks the 'revoke' part.

This commit add `PUBLIC_CLOUD_VAULT_NAMESPACE` only when needed.

- Related ticket: N/A
- Needles: N/A
- Verification run: To be done
