### PR TITLE
Try harder to cancel GRUB TO on uefi

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -318,7 +318,9 @@ sub get_bootmenu_console_params {
 sub uefi_bootmenu_params {
     # assume bios+grub+anim already waited in start.sh
     # in grub2 it's tricky to set the screen resolution
-    send_key "e";
+    #send_key_until_needlematch('grub2-enter-edit-mode', 'e', 5, 0.5);
+    (is_jeos) ? send_key_until_needlematch('grub2-enter-edit-mode', 'e', 5, 0.5)
+      :         send_key 'e';
     for (1 .. 2) { send_key "down"; }
     send_key "end";
     # delete "keep" word

--- a/tests/jeos/grub2.pm
+++ b/tests/jeos/grub2.pm
@@ -1,0 +1,46 @@
+# SUSE's openQA tests
+#
+# Copyright © 2016-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# JeOS with kernel-default-base doesn't use kms, so the default mode
+# 1024x768 of the cirrus kms driver doesn't help us. We need to
+# manually configure grub to tell the kernel what mode to use.
+
+# Summary:  Reach GRUB2 menu
+#			Cancel time out counter
+#			Set gfxpayload to 1024x768
+#			Boot deployed image
+# Maintainer: Martin Loviska <mloviska@suse.com>
+
+use base "opensusebasetest";
+use strict;
+use warnings;
+use testapi;
+use bootloader_setup 'uefi_bootmenu_params';
+
+sub run {
+    my $self = shift;
+
+    # JeOS images GRUB2 timeout is set to 10s
+    my $counter = 0;
+    while ((!check_screen('grub2', 1)) && ($counter < 10)) {
+        wait_screen_change(sub {
+                send_key 'home';
+        }, 0.5);
+        $counter++;
+    }
+    $self->wait_grub(in_grub => 1, bootloader_time => 10);
+    uefi_bootmenu_params;
+    send_key "f10";
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;


### PR DESCRIPTION
JeOS images have reduced GRUB2 time out.

- Related ticket: [[jeos] openQA should try harder to stop GRUB timeout
](https://progress.opensuse.org/issues/42116)
- Needles: 
   * [OSD](https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1211)
- Verification runs:
   * [sle-12-SP5-JeOS-for-kvm-and-xen-x86_64-Build4.75-jeos-filesystem@svirt-xen-hvm](http://eris.suse.cz/tests/274) && [its history](http://eris.suse.cz/tests/274#next_previous)
   * [sle-12-SP5-JeOS-for-MS-HyperV-x86_64-Build4.75-jeos-filesystem@svirt-hyperv-uefi](http://eris.suse.cz/tests/305)
   * [sle-12-SP5-JeOS-for-kvm-and-xen-x86_64-Build4.75-jeos-main_intel_image@64bit-virtio-vga](http://eris.suse.cz/tests/172) && [its history](http://eris.suse.cz/tests/172#next_previous)