### PR TITLE
Set correct launch key for yast2_apparmor on SLE >=15

### DIFF
--- a/tests/console/yast2_apparmor.pm
+++ b/tests/console/yast2_apparmor.pm
@@ -42,7 +42,7 @@ sub run {
     } else {
         #SLES >=15 imediatelly asks for extra packages, not after main menu:
         install_extra_packages_requested;
-        send_key 'ret';
+        send_key 'alt-l';
     }
 
     assert_screen [qw(yast2_apparmor_disabled yast2_apparmor_enabled)];


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/56171
- Needles: None
- Verification run: 
SLE15.0: http://deathstar.suse.cz/tests/908
SLE15.1: http://deathstar.suse.cz/tests/909
