### PR TITLE
Public Cloud: add a way to create instances with UEFI parameters

### DIFF
--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -48,6 +48,10 @@ variable "create-extra-disk" {
     default=false
 }
 
+variable "uefi" {
+    default=false
+}
+
 resource "random_id" "service" {
     count = "${var.instance_count}"
     keepers = {
@@ -84,6 +88,12 @@ resource "google_compute_instance" "openqa" {
     service_account {
         email = "${data.external.gce_cred.result["client_email"]}"
         scopes = ["cloud-platform"]
+    }
+
+    shielded_instance_config {
+        enable_secure_boot = "${var.uefi}"
+        enable_vtpm = "${var.uefi}"
+        enable_integrity_monitoring = "${var.uefi}"
     }
 }
 

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -287,6 +287,10 @@ sub terraform_apply {
         $cmd .= "-var 'extra-disk-size=" . $args{use_extra_disk}->{size} . "' " if $args{use_extra_disk}->{size};
         $cmd .= "-var 'extra-disk-type=" . $args{use_extra_disk}->{type} . "' " if $args{use_extra_disk}->{type};
     }
+    if (get_var('FLAVOR') =~ 'UEFI') {
+        $cmd .= "-var 'uefi=true' ";
+    }
+
     $cmd .= "-out myplan";
     record_info('TFM cmd', $cmd);
 


### PR DESCRIPTION
UEFI parameters in GCE must include
--shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring
and according to the documentation [1] it is possible to
enable those parameters in Terraform.

[1] https://www.terraform.io/docs/providers/google/d/datasource_compute_instance.html#shielded_instance_config

- Related ticket: https://progress.opensuse.org/issues/55055
- VR: https://openqa.suse.de/tests/3323270
