### PR TITLE
Fix NetWeaver cluster boot issue with Gnome

### DIFF
--- a/tests/boot/boot_to_desktop.pm
+++ b/tests/boot/boot_to_desktop.pm
@@ -32,7 +32,7 @@ sub run {
     # Do not attempt to log into the desktop of a system installed with SLES4SAP
     # being prepared for upgrade, as it does not have an unprivileged user to test
     # with other than the SAP Administrator
-    my $nologin = (get_var('HDDVERSION') and is_upgrade() and is_sles4sap());
+    my $nologin = (get_var('HDDVERSION') && is_upgrade() && is_sles4sap()) || get_var('HA_CLUSTER');
     if (check_var('VIRSH_VMM_TYPE', 'linux')) {
         wait_serial('Welcome to SUSE Linux', $timeout) || die "System did not boot in $timeout seconds.";
     }


### PR DESCRIPTION
If HA cluster is configured to boot with Gnome, reboot can fail after NetWeaver installation. This can occur if multiple account exist (root and sapadm in that case).

This commit fix this by disabling login in 'boot_to_desktop' on HA cluster.

- Related ticket: N/A
- Needles: N/A
- Verification runs: [NW cluster node01](http://1b210.qa.suse.de/tests/5854), [NW cluster node02](http://1b210.qa.suse.de/tests/5855)
