### PR TITLE
Remove hacks for support server in openSUSE

### DIFF
--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -541,7 +541,6 @@ sub run {
     }
 
     if (exists $server_roles{dhcp}) {
-        zypper_call("in -t pattern dhcp_dns_server") if is_opensuse;
         setup_dhcp_server((exists $server_roles{dns}), 0);
     }
     if (exists $server_roles{qemuproxy}) {
@@ -555,7 +554,6 @@ sub run {
         $setup_script .= "systemctl restart apache2\n";
     }
     if (exists $server_roles{dns}) {
-        zypper_call("in -t pattern dhcp_dns_server") if is_opensuse;
         setup_dns_server();
     }
 


### PR DESCRIPTION
Remove hacks for support server in openSUSE. Image already has `dhcp_dns_server"` pattern installed, firewall disabled and network configuration with Wicked.

- Related ticket: https://progress.opensuse.org/issues/56006
- Needles: n/a
- Verification run: [opensuse-Tumbleweed-DVD-x86_64-Build20190902-remote_ssh_controller@64bit](http://rivera-workstation.suse.cz/tests/148)
