### PR TITLE
Replace script_run by zypper_call, query 'apache2' package only

### DIFF
--- a/tests/console/apache.pm
+++ b/tests/console/apache.pm
@@ -28,14 +28,14 @@ sub run {
     # enable full package installation, and clean up previous apache2 deployment
     if (is_jeos) {
         assert_script_run('sed -ie \'s/rpm.install.excludedocs = yes/rpm.install.excludedocs = no/\' /etc/zypp/zypp.conf');
-        script_run('zypper rm apache2');
+        zypper_call('rm apache2', exitcode => [0, 104]);
     }
 
     # Even before the installation there should be htdocs so we can create the index
     assert_script_run 'echo "index" > /srv/www/htdocs/index.html';
 
-    # Ensure apache is installed and stopped
-    if (script_run('rpm -qa | grep apache2') == 0) {
+    # Ensure apache2 is installed and stopped
+    if (script_run('rpm -q apache2') == 0) {
         systemctl('stop apache2');
     } else {
         zypper_call 'in apache2';


### PR DESCRIPTION
- Related ticket: N/A fix regression introduced by https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8343
- Verification runs: 
  * [opensuse-15.1-JeOS-for-kvm-and-xen-x86_64-Build9.138-jeos@64bit_virtio-2G](http://eris.suse.cz/tests/17745#step/apache/8)
  * [opensuse-15.1-JeOS-for-kvm-and-xen-x86_64-Build9.138-jeos@64bit_virtio-2G - full schedule](http://eris.suse.cz/tests/17752#step/apache/8)

Thanks for the report, @Vogtinator !