### PR TITLE
Fix SLES4SAP XRDP test

### DIFF
--- a/tests/x11/remote_desktop/windows_client_remotelogin.pm
+++ b/tests/x11/remote_desktop/windows_client_remotelogin.pm
@@ -48,7 +48,7 @@ sub run {
         assert_and_click "close-xrdp-sharing-window";
         assert_and_click "confirm-close-remote-session";
     }
-    assert_and_click "close-remote-desktop-connection";
+    assert_and_click [qw(close-remote-desktop-connection remote-desktop-connection-ended)];
 
     send_key "c";
 }


### PR DESCRIPTION
Connection on SLES4SAP host through XRDP from a Windows machine can sometimes "fails" with a "RDP Services session has ended" error like on the Windows VM.
In that case, connection through XRDP is OK but the failure is only during the closing and only on the Windows side.

So this commit fix this by "simply" ack the "error" and continue.

- Failing test: https://openqa.suse.de/tests/3323446
- Related ticket: N/A
- Needles: already created
- Verification run: [XRDP Windows client](https://openqa.suse.de/tests/3324330), [XRDP server](https://openqa.suse.de/tests/3324329)
