### PR TITLE
Fix perlcritic failure

### DIFF
--- a/tests/yast2_gui/yast2_bootloader.pm
+++ b/tests/yast2_gui/yast2_bootloader.pm
@@ -19,7 +19,7 @@ use base "y2_module_guitest";
 use strict;
 use warnings;
 use testapi;
-use utils qw(type_string_slow_extended);
+use utils "type_string_slow_extended";
 
 sub run {
     my $self = shift;


### PR DESCRIPTION
tests/yast2_gui/yast2_bootloader.pm: qw should be used as function at line 22, column 11.  use MODULE 'func' for single imports.  (Severity: 5)
