### PR TITLE
publiccloud: Get pkg list from image on failure

### DIFF
--- a/tests/publiccloud/ipa.pm
+++ b/tests/publiccloud/ipa.pm
@@ -48,6 +48,8 @@ sub run {
             $instance->upload_log('/var/log/cloudregister');
             last;
         }
+        $instance->run_ssh_command(cmd => 'rpm -qa > /tmp/rpm_qa.txt');
+        upload_logs('/tmp/rpm_qa.txt');
     }
 }
 


### PR DESCRIPTION
When IPA fail on certain tests. It might be nice to have the output
of `rpm -qa`.

- Verification run: https://openqa.suse.de/tests/3327034#downloads
