### PR TITLE
btrfs-progs: Make test result with more detail and more accurate

### DIFF
--- a/tests/btrfs-progs/run.pm
+++ b/tests/btrfs-progs/run.pm
@@ -62,17 +62,21 @@ sub get_test_list {
 # Run a single test, return test result and copy log to file
 # test - test to run(e.g. 001)
 sub test_run {
-    my $num = shift;
+    my $num     = shift;
+    my $status  = 'PASSED';
+    my $logfile = CATEGORY . '-tests-results.txt';
+
     script_run("./clean-tests.sh");
-    my $ret    = script_output("TEST=$num\\* ./" . CATEGORY . '-tests.sh', 600, proceed_on_failure => 1);
-    my $status = 'PASSED';
-    if ($ret =~ /[Ff]ailed/) {
+    my $ret = script_output("TEST=$num\\* ./" . CATEGORY . '-tests.sh | tee output.log;', 600, proceed_on_failure => 1);
+
+    if ($ret =~ /test\s+failed\s+for\s+case/i) {
         $status = 'FAILED';
     }
-    elsif ($ret =~ /NOTRUN/) {
-        $status = 'SKIPPED';
+    elsif ($ret =~ /NOTRUN|[Ff]ailed\s+prerequisiti?es/) {
+        $status  = 'SKIPPED';
+        $logfile = 'output.log';
     }
-    script_run('cp ' . CATEGORY . '-tests-results.txt ' . LOG_DIR . CATEGORY . "/$num.txt");
+    script_run("cp $logfile " . LOG_DIR . CATEGORY . "/$num.txt");
     return $status;
 }
 


### PR DESCRIPTION
For 'SKIPPED' test, the exit code maybe 0 or 1, and no test log.
Need double check test results by more stable way and got more test logs.

- Related ticket: https://progress.opensuse.org/issues/53936
- Verification run:
http://10.67.133.10/tests/475 (result for NOTRUN)
http://10.67.133.10/tests/476 (result for Failed prerequisites )
