### PR TITLE
set fips=1 in fips mode for the zkvm bootloader install

### DIFF
--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -37,6 +37,10 @@ sub set_svirt_domain_elements {
             $cmdline .= "upgrade=1 ";
         }
 
+        if (get_var('FIPS_ENABLED') || get_var('FIPS_INSTALLATION')) {
+            $cmdline .= "fips=1 ";
+        }
+
         if (my $autoyast = get_var('AUTOYAST')) {
             $autoyast = data_url($autoyast) if $autoyast !~ /^slp$|:\/\//;
             $cmdline .= " autoyast=" . $autoyast;


### PR DESCRIPTION
We need fips=1 during installation in fips mode to pull in the correct patterns.

- Related ticket: https://progress.opensuse.org/issues/56498
- bug https://bugzilla.suse.com/show_bug.cgi?id=1140169