### PR TITLE
Look for HDD in worker cache directory too

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -896,11 +896,12 @@ sub tianocore_http_boot {
 sub zkvm_add_disk {
     my ($svirt) = @_;
     if (my $hdd = get_var('HDD_1')) {
-        my $basename = basename($hdd);
-        my $basedir  = svirt_host_basedir();
-        my $hdd_dir  = "$basedir/openqa/share/factory/hdd";
-        my $hdd_path = $svirt->get_cmd_output("find $hdd_dir -name $basename | head -n1 | tr -d '\n'");
-        die "Unable to find image $basename in $hdd_dir" unless $hdd_path;
+        my $basename      = basename($hdd);
+        my $basedir       = svirt_host_basedir();
+        my $hdd_share_dir = "$basedir/openqa/share/factory/hdd";
+        my $hdd_cache_dir = "$basedir/openqa/cache";
+        my $hdd_path      = $svirt->get_cmd_output("find $hdd_share_dir $hdd_cache_dir -name $basename | head -n1 | tr -d '\n'");
+        die "Unable to find image $basename in $hdd_share_dir nor $hdd_cache_dir" unless $hdd_path;
         diag("HDD path found: $hdd_path");
         if (get_var('PATCHED_SYSTEM')) {
             diag('in patched systems just load the patched image');


### PR DESCRIPTION
## Description

- Fix from:
  - https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6191
  - #6253
- Related tickets:
  - https://progress.opensuse.org/issues/44468
  - https://progress.opensuse.org/issues/36754
- Verification run: http://slindomansilla-vm.qa.suse.de/tests/955

## More info

When using **$svirt->get_cmd_output**, it is called on **s390p8.suse.de**

#### Understanding that

- Jump host is http://slindomansilla-vm.qa.suse.de/admin/workers/3
- remote machine is s390p8.suse.de
- SUT is a VM inside s390p8.suse.de