### PR TITLE
Allow the "Tip of the day" dialog to appear after a short delay

### DIFF
--- a/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
+++ b/tests/x11/libreoffice/libreoffice_mainmenu_components.pm
@@ -127,6 +127,12 @@ sub run {
     type_string "calc";                                                             #open calc
     assert_and_click 'overview-office-calc';
     assert_screen 'test-oocalc-1';
+    if (!match_has_tag('ooffice-tip-of-the-day')) {
+        # Sometimes the dialog does not appear immediately but after a short delay,
+        # or is fading in slowly - poo#56510
+        wait_still_screen 2;
+        assert_screen 'test-oocalc-1';
+    }
     if (match_has_tag('ooffice-tip-of-the-day')) {
         # Unselect "_S_how tips on startup", select "_O_k"
         send_key "alt-s";
@@ -135,17 +141,17 @@ sub run {
             assert_screen 'test-oocalc-1';
         }
     }
-    send_key "ctrl-q";                                                              #close calc
+    send_key "ctrl-q";    #close calc
 
     $self->open_overview();
-    type_string "draw";                                                             #open draw
+    type_string "draw";    #open draw
     assert_screen 'overview-office-draw';
     send_key "ret";
     assert_screen 'oodraw-launched';
-    send_key "ctrl-q";                                                              #close draw
+    send_key "ctrl-q";     #close draw
 
     $self->open_overview();
-    type_string "impress";                                                          #open impress
+    type_string "impress";    #open impress
     assert_screen 'overview-office-impress';
     send_key "ret";
     assert_screen [qw(ooimpress-select-a-template ooimpress-select-template-nofocus ooimpress-launched)];
@@ -155,18 +161,18 @@ sub run {
         assert_screen 'ooimpress-launched';
     }
     elsif (match_has_tag 'ooimpress-select-a-template') {
-        send_key 'alt-f4';                                                          # close impress template window
+        send_key 'alt-f4';    # close impress template window
         assert_screen 'ooimpress-launched';
     }
-    send_key "ctrl-q";                                                              #close impress
+    send_key "ctrl-q";        #close impress
 
     $self->open_overview();
-    type_string "writer";                                                           #open writer
+    type_string "writer";     #open writer
     assert_screen 'overview-office-writer';
     send_key "ret";
     assert_screen 'test-ooffice-1';
     assert_and_click('ooffice-writing-area', timeout => 10);
-    send_key "ctrl-q";                                                              #close writer
+    send_key "ctrl-q";        #close writer
 }
 
 1;


### PR DESCRIPTION
The dialog may appear a short time after the main window. In case it is
not there immediately, wait until everything has come to a rest and
check again.

- Related ticket: https://progress.opensuse.org/issues/56510
- Verification run: https://openqa.opensuse.org/tests/1025596
- Verification run: https://openqa.opensuse.org/tests/1025597
- Verification run: https://openqa.opensuse.org/tests/1025598
