### PR TITLE
Revert "set fips=1 in fips mode for the zkvm bootloader install"

### DIFF
--- a/tests/installation/bootloader_zkvm.pm
+++ b/tests/installation/bootloader_zkvm.pm
@@ -37,10 +37,6 @@ sub set_svirt_domain_elements {
             $cmdline .= "upgrade=1 ";
         }
 
-        if (get_var('FIPS_ENABLED') || get_var('FIPS_INSTALLATION')) {
-            $cmdline .= "fips=1 ";
-        }
-
         if (my $autoyast = get_var('AUTOYAST')) {
             $autoyast = data_url($autoyast) if $autoyast !~ /^slp$|:\/\//;
             $cmdline .= " autoyast=" . $autoyast;


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#8376 as the parameter
was already there, see https://progress.opensuse.org/issues/56498#note-3