### PR TITLE
hexchat: avoid sending 'ctrl-a', as it is very unreliable

### DIFF
--- a/tests/x11/hexchat.pm
+++ b/tests/x11/hexchat.pm
@@ -28,9 +28,8 @@ sub run {
     x11_start_program($name, target_match => "$name-network-select");
     type_string "freenode\n";
     assert_and_click "hexchat-nick-$username";
-    send_key 'ctrl-a';
-    send_key 'delete';
-    assert_screen "hexchat-nick-empty";
+    send_key 'home';
+    send_key_until_needlematch 'hexchat-nick-empty', 'delete';
     type_string "openqa" . random_string(5);
     assert_and_click "$name-connect-button";
     assert_screen "$name-connection-complete-dialog";


### PR DESCRIPTION
Instead, move the cursor to the beginning of the field and press delete until it is empty.

- Related ticket: https://progress.opensuse.org/issues/54425
- Needles: N/A (hexchat-nick-empty was already in use before)
- Verification run: https://openqa.opensuse.org/tests/1026385