### PR TITLE
Add kmod tests

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1644,7 +1644,8 @@ sub load_extra_tests_console {
     loadtest 'console/timezone';
     loadtest 'console/ntp' if is_sle('<15');
     loadtest 'console/procps';
-    loadtest "console/lshw"      if ((is_sle('15+') && (is_ppc64le || is_x86_64)) || is_opensuse);
+    loadtest "console/lshw" if ((is_sle('15+') && (is_ppc64le || is_x86_64)) || is_opensuse);
+    loadtest 'console/kmod';
     loadtest 'console/zziplib'   if (is_sle('12-SP4+') && !is_jeos);
     loadtest 'console/firewalld' if is_sle('15+') || is_leap('15.0+') || is_tumbleweed;
     loadtest 'console/aaa_base' unless is_jeos;

--- a/tests/console/kmod.pm
+++ b/tests/console/kmod.pm
@@ -1,0 +1,59 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test common commands: modinfo, lsmod, modprobe, rmmod,
+# depmod. Tests the commands and their output for common words that
+# should appear independently of the individual modules loaded in
+# each system.
+# * modinfo: 'filename ... .ko', 'license ... GPL', 'author ... Qumranet'
+# * lsmod: 'Module', 'Size', 'Used by'
+# * modprobe: We make sure arc4 module is not active and then we activate it
+# * rmmod: We check the exit status and then we enable the disabled module again
+# * depmod: 'lib/modules', '.ko', 'kernel'.
+# Maintainer: Vasilios Anastasiadis <vasilios.anastasiadis@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+
+sub run {
+    select_console 'root-console';
+
+    #test modinfo command
+    assert_script_run('OUT="$(modinfo kvm)"');
+    #test the output for common words that should always appear
+    assert_script_run('grep -o -m 1 \'^filename:.*kvm.ko\' <<< "$OUT"');
+    assert_script_run('grep -o -m 1 \'^license:.*GPL\' <<< "$OUT"');
+    assert_script_run('grep -o -m 1 \'^author:.*Qumranet\' <<< "$OUT"');
+    assert_script_run('grep -o -m 1 \'^parm:.*ignore_msrs:bool\' <<< "$OUT"');
+
+    #test lsmod command
+    #test that the output has the expected correct format
+    assert_script_run('lsmod | grep \'^Module.*Size.*Used by$\'');
+
+    #test modprobe -v arc4 command
+    script_run('rmmod arc4');
+    assert_script_run('modprobe -v arc4 | grep \'^insmod.*arc4.ko\'');
+
+    #test rmmod arc4 command
+    assert_script_run('rmmod arc4');
+    #make sure the command terminated the module by starting it again
+    assert_script_run('modprobe -v arc4 | grep \'^insmod.*arc4.ko\'');
+
+    #test depmod
+    assert_script_run('OUT="$(depmod -av)"');
+    #test the output for common words that should always appear
+    assert_script_run('grep -o -m 1 .ko <<< "$OUT"');
+    assert_script_run('grep -o -m 1 lib/modules <<< "$OUT"');
+    assert_script_run('grep -o -m 1 kernel <<< "$OUT"');
+}
+
+1;


### PR DESCRIPTION
Add tests for kmod. Tests common commands: modinfo, lsmod, modprobe, rmmod, depmod. Tests the commands and their output for common words that should appear independently of the individual modules loaded in each system.

-Related issue: https://progress.opensuse.org/issues/55778
-Verification runs:
http://10.161.229.247/tests/47
http://10.161.229.247/tests/48
http://10.161.229.247/tests/49
http://10.161.229.247/tests/50
http://10.161.229.247/tests/51
http://10.161.229.247/tests/52
http://10.161.229.247/tests/56

