### PR TITLE
Mitigate opensuse-welcome race, let screen content settle before checking

### DIFF
--- a/tests/installation/opensuse_welcome.pm
+++ b/tests/installation/opensuse_welcome.pm
@@ -23,14 +23,15 @@ sub run {
     # Untick box - (Retries may be needed: poo#56024)
     for my $retry (1 .. 5) {
         assert_and_click_until_screen_change("opensuse-welcome-show-on-boot", 5, 5);
-        last unless check_screen("opensuse-welcome-show-on-boot");
+        # Moving the cursor already causes screen changes - do not fail the check
+        # immediately but allow some time to reach the final state
+        last if check_screen("opensuse-welcome-show-on-boot-unselected", timeout => 5);
         die "Unable to untick 'Show on next startup'" if $retry == 5;
     }
 
-    # Close welcome screen - (Retries may be needed: poo#56024)
     for my $retry (1 .. 5) {
-        assert_and_click_until_screen_change("opensuse-welcome-close-btn", 5, 5);
-        last unless check_screen("opensuse-welcome");
+        wait_screen_change { send_key 'alt-f4' };
+        last unless check_screen("opensuse-welcome", timeout => 2);
         die "Unable to close openSUSE Welcome screen" if $retry == 5;
     }
 }


### PR DESCRIPTION
After each click, the mouse is move back to its previous location,
which is registered as a screen change, especially for Plasma were it
causes a popup in the lower right corner.

Without the delay, the check_screen may still see the old contents and
the assert_screen of the next round will bail out.

- Related ticket: https://progress.opensuse.org/issues/55661
- Verification run: https://openqa.opensuse.org/t1026573
- Verification run: https://openqa.opensuse.org/t1026574
- Verification run: https://openqa.opensuse.org/t1026575