### PR TITLE
Adapt Win10 test suite to build 1903

### DIFF
--- a/tests/installation/win10_firstboot.pm
+++ b/tests/installation/win10_firstboot.pm
@@ -17,48 +17,82 @@ use warnings;
 use testapi;
 
 sub run {
-    assert_screen 'windows-start-with-region', 1000;
+    assert_screen 'windows-start-with-region', 360;
     assert_and_click 'windows-yes';
-    assert_screen 'windows-keyboard-layout';
+    assert_screen 'windows-keyboard-layout', 180;
     assert_and_click 'windows-yes';
+    assert_screen 'windows-second-keyboard';
     assert_and_click 'windows-skip-second-keyboard';
-    assert_screen 'windows-signin-with-ms', 1000;
+    # Network setup takes ages
+    # Coffee time!
+    assert_screen 'windows-account-setup', 360;
+    assert_and_click 'windows-select-personal-use', dclick => 1;
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
+    assert_and_click 'windows-next';
+    assert_screen 'windows-signin-with-ms';
     assert_and_click 'windows-offline';
-    assert_and_click 'windows-no-signin-ms-instead';
-    sleep 3;
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
+    assert_and_click 'windows-no-signin-ms-instead', timeout => 60;
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
+    assert_and_click 'windows-create-account';
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
     type_string $realname;    # input account name
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
+    save_screenshot;
     assert_and_click 'windows-next';
-    type_password;            # input password
-    assert_and_click 'windows-next';
-    type_password;            # confirm password
-    assert_and_click 'windows-next';
+    for (1 .. 2) {
+        sleep 3;
+        type_password;        # input password
+        save_screenshot;
+        assert_and_click 'windows-next';
+    }
     for (1 .. 3) {
         sleep 3;
         assert_and_click 'windows-security-question';
         send_key 'down';
         send_key 'ret';
         send_key 'tab';
+        sleep 1;
         type_string 'security';
         sleep 3;
         assert_and_click 'windows-next';
     }
-    assert_screen 'windows-make-cortana-personal-assistant';
+    assert_screen 'windows-enable-more-devices';
     assert_and_click 'windows-no';
+    assert_screen 'windows-make-cortana-personal-assistant';
+    assert_and_click 'windows-accept';
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
     assert_and_click 'windows-dont-use-speech-recognition';
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
     assert_and_click 'windows-accept';
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
     assert_and_click 'windows-dont-user-my-location';
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
     assert_and_click 'windows-accept';
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
     assert_and_click 'windows-turn-off-find-device';
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
     assert_and_click 'windows-accept';
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
     assert_and_click 'windows-send-full-diagnostic-data';
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
     assert_and_click 'windows-accept';
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
     assert_and_click 'windows-dont-improve-inking&typing';
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
     assert_and_click 'windows-accept';
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
     assert_and_click 'windows-dont-get-tailored-experiences';
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
     assert_and_click 'windows-accept';
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
     assert_and_click 'windows-dont-use-adID';
+    wait_still_screen stilltime => 10, timeout => 1, similarity_level => 43;
     assert_and_click 'windows-accept';
-    assert_screen 'windows-first-boot', 600;
+}
+
+sub test_flags {
+    return {fatal => 1};
 }
 
 1;

--- a/tests/installation/win10_installation.pm
+++ b/tests/installation/win10_installation.pm
@@ -20,37 +20,43 @@ use testapi;
 
 sub run {
     # This test works onlywith CDMODEL=ide-cd due to windows missing scsi drivers which are installed via scsi iso
-    if (get_var('UEFI')) {
-        assert_screen 'windows-boot';
-        send_key 'spc';    # boot from CD or DVD
-    }
-    assert_screen 'windows-setup', 60;
-    send_key 'alt-n';      # next
-    send_key 'alt-i';      # install Now
-    send_key 'alt-n';      # next
+    assert_screen 'windows-setup', 1000;
+    send_key 'alt-n';    # next
+    save_screenshot;
+    send_key 'alt-i';    # install Now
+    save_screenshot;
+    send_key 'alt-n';    # next
     assert_screen 'windows-activate';
-    send_key 'alt-i';      # I dont have the product key
+    send_key 'alt-i';    # I dont have the product key
     assert_screen 'windows-select-system';
-    send_key 'alt-n';      # select OS (Win 10 Pro)
+    send_key_until_needlematch('windows-10-pro', 'down');
+    send_key 'alt-n';    # select OS (Win 10 Pro)
     assert_screen 'windows-license';
-    send_key 'alt-a';      # accept eula
-    send_key 'alt-n';      # next
+    send_key 'alt-a';    # accept eula
+    send_key 'alt-n';    # next
     assert_screen 'windows-installation-type';
-    send_key 'alt-c';      # custom
+    send_key 'alt-c';    # custom
     assert_screen 'windows-disk-partitioning';
-    send_key 'alt-l';      # load driver
+    send_key 'alt-l';    # load driver
     assert_screen 'windows-load-driver';
-    send_key 'alt-b';      # browse button
+    send_key 'alt-b';    # browse button
     send_key 'c';
-    send_key 'c';          # go to second CD drive with drivers
-    send_key 'ret';        # ok
+    save_screenshot;
+    send_key 'c';        # go to second CD drive with drivers
+    send_key 'right';    # ok
+    sleep 0.5;
+    send_key 'ret';
     send_key_until_needlematch 'windows-all-drivers-selected', 'shift-down', 5;    # select all drivers
-    wait_still_screen;
+    sleep 0.5;
     send_key 'alt-n';                                                              # next
     wait_still_screen;
     send_key 'alt-n';                                                              # next ->Installing windows!
     assert_screen 'windows-restart', 600;
     send_key 'alt-r';                                                              # restart
+}
+
+sub test_flags {
+    return {fatal => 1};
 }
 
 1;

--- a/tests/installation/win10_reboot.pm
+++ b/tests/installation/win10_reboot.pm
@@ -18,12 +18,21 @@ use testapi;
 use windows_utils;
 
 sub run {
+    assert_screen 'windows-first-boot', 600;
+    assert_and_click 'windows-target-edge';
+    sleep 0.5;
     assert_and_click 'windows-close-edge';
+    #assert_and_click 'windows-close-network-discoverablepc';
+    assert_and_click 'windows-desktop';
     send_key 'alt-f4';
     assert_screen 'windows-shutdown';
     send_key 'down';    # switch from 'Shut down' to 'Restart'
     send_key 'ret';     # press ok to restart
     wait_boot_windows;
+}
+
+sub test_flags {
+    return {fatal => 1};
 }
 
 1;

--- a/tests/installation/win10_shutdown.pm
+++ b/tests/installation/win10_shutdown.pm
@@ -17,10 +17,15 @@ use warnings;
 use testapi;
 
 sub run {
+    assert_and_click 'windows-desktop';
     send_key 'alt-f4';
     assert_screen 'windows-shutdown';
     send_key 'ret';    # press ok to shutdown the os
     assert_shutdown;
+}
+
+sub test_flags {
+    return {fatal => 1};
 }
 
 1;


### PR DESCRIPTION
- Related ticket:[upgrade windows 10 image in openQA](https://progress.opensuse.org/issues/51221)
- Needles: [o3](https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/589)
- Verification runs: 
   * [bios_boot](http://eris.suse.cz/tests/101)
   * [uefi](http://eris.suse.cz/tests/104)

BUILD=1903
ISO=Win10_1903_V1_EnglishInternational_x64.iso
ISO_1=virtio-win-0.1.172_netkvm_viostor_only.iso