### PR TITLE
Also match for opensuse-welcome in first_boot/finish_desktop

### DIFF
--- a/tests/installation/finish_desktop.pm
+++ b/tests/installation/finish_desktop.pm
@@ -15,6 +15,7 @@ use base "installbasetest";
 use testapi;
 use strict;
 use warnings;
+use main_common 'opensuse_welcome_applicable';
 
 # using this as base class means only run when an install is needed
 sub run {
@@ -22,8 +23,11 @@ sub run {
 
     # live may take ages to boot
     my $timeout = 600;
-    assert_screen "generic-desktop", $timeout;
 
+    my @tags = qw(generic-desktop);
+    push(@tags, qw(opensuse-welcome)) if opensuse_welcome_applicable;
+
+    assert_screen \@tags, $timeout;
 }
 
 sub post_fail_hook {

--- a/tests/installation/finish_desktop.pm
+++ b/tests/installation/finish_desktop.pm
@@ -24,11 +24,6 @@ sub run {
     my $timeout = 600;
     assert_screen "generic-desktop", $timeout;
 
-    ## duplicated from second stage, combine!
-    if (check_var('DESKTOP', 'kde')) {
-        send_key "esc";
-        assert_screen "generic-desktop", 25;
-    }
 }
 
 sub post_fail_hook {

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -22,6 +22,7 @@ use utils 'handle_emergency';
 use version_utils qw(is_sle is_leap is_desktop_installed is_upgrade is_sles4sap);
 use x11utils 'handle_login';
 use base 'opensusebasetest';
+use main_common 'opensuse_welcome_applicable';
 
 sub run {
     my ($self) = @_;
@@ -60,6 +61,7 @@ sub run {
     }
 
     my @tags = qw(generic-desktop);
+    push(@tags, qw(opensuse-welcome)) if opensuse_welcome_applicable;
     # boo#1102563 - autologin fails on aarch64 with GNOME on current Tumbleweed
     if (!is_sle('<=15') && !is_leap('<=15.0') && check_var('ARCH', 'aarch64') && check_var('DESKTOP', 'gnome')) {
         push(@tags, 'displaymanager');

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -60,9 +60,6 @@ sub run {
     }
 
     my @tags = qw(generic-desktop);
-    if (check_var('DESKTOP', 'kde') && get_var('VERSION', '') =~ /^1[23]/) {
-        push(@tags, 'kde-greeter');
-    }
     # boo#1102563 - autologin fails on aarch64 with GNOME on current Tumbleweed
     if (!is_sle('<=15') && !is_leap('<=15.0') && check_var('ARCH', 'aarch64') && check_var('DESKTOP', 'gnome')) {
         push(@tags, 'displaymanager');
@@ -90,10 +87,6 @@ sub run {
         wait_still_screen;
         script_sudo('sed -i s/#WaylandEnable=false/WaylandEnable=false/ /etc/gdm/custom.conf');
         wait_screen_change { send_key 'alt-f4' };
-    }
-    if (match_has_tag('kde-greeter')) {
-        send_key "esc";
-        assert_screen 'generic-desktop';
     }
 }
 


### PR DESCRIPTION
Currently, needles with the openSUSE Welcome dialog are duplicated, once
with the "generic-desktop" tag and once with "opensuse-welcome". This
also makes it difficult to differentiate between a "true" generic desktop
and one showing the dialog, i.e. in the opensuse_welcome module.

While at it, remove the long defunct 'kde-greeter' handling.

- Verification run: https://openqa.opensuse.org/tests/1028495