### PR TITLE
Add retry on another exit codes due to bsc#1145521

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -503,8 +503,13 @@ sub zypper_call {
             }
             next unless get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/;
         }
-        if (get_var('FLAVOR', '') =~ /-(Updates|Incidents)$/ && ($ret == 4 || $ret == 8 || $ret == 105 || $ret == 106)) {
-            record_soft_failure 'Retry due to network problems poo#52319';
+        if (get_var('FLAVOR', '') =~ /-(Updates|Incidents)/ && ($ret == 4 || $ret == 8 || $ret == 105 || $ret == 106 || $ret == 139 || $ret == 141)) {
+            if (script_run('grep "Exiting on SIGPIPE" /var/log/zypper.log') == 0) {
+                record_soft_failure 'Zypper exiting on SIGPIPE received during package download bsc#1145521';
+            }
+            else {
+                record_soft_failure 'Retry due to network problems poo#52319';
+            }
             next;
         }
         last;


### PR DESCRIPTION
And remove end of string anchor as there is also Incidents-Minimal flavor
- Fail: [139](https://openqa.suse.de/tests/3310443#step/glibc_sanity/7) [141](https://openqa.suse.de/tests/3311838#step/glibc_sanity/7)
- Verification run:
https://openqa.suse.de/tests/3335660
https://openqa.suse.de/tests/3335704#step/update_kernel/12