### PR TITLE
Adapt yast2 lan gui tests for new UI

### DIFF
--- a/tests/yast2_gui/yast2_network_settings.pm
+++ b/tests/yast2_gui/yast2_network_settings.pm
@@ -19,6 +19,7 @@ use strict;
 use warnings;
 use testapi;
 use y2_module_basetest 'is_network_manager_default';
+use version_utils 'is_sle';
 
 sub run {
     my $self = shift;
@@ -59,7 +60,11 @@ sub run {
     assert_screen 'yast2-network-settings_overview';
     unless (is_network_manager_default) {
         send_key $cmd{add_device};
-        assert_and_click 'yast2-network-settings_overview_hardware-dialog_device-type';
+        # Older than 15-SP2 versions require two steps to select device type: expand the list and then select the option.
+        # On 15-SP2 it is a list of radio buttons, so only one step with selecting the radio is needed.
+        if (is_sle('<15-SP2')) {
+            assert_and_click 'yast2-network-settings_overview_hardware-dialog_device-type';
+        }
         assert_and_click 'yast2-network-settings_overview_hardware-dialog_device-type_bridge';
         send_key $cmd{next};
         assert_screen 'yast2-network-settings_overview_network-card-setup';


### PR DESCRIPTION
Dropdown list is changed to radio buttons. The commit removes dropdown
expanding step for sle 15 sp2, and keeps it only for lower versions.

- Related ticket: https://progress.opensuse.org/issues/56180
- Needles: Already created on osd.
- Verification run: http://oorlov-vm.qa.suse.de/tests/1059