### PR TITLE
Ajust timeout of supportutils

### DIFF
--- a/tests/console/supportutils.pm
+++ b/tests/console/supportutils.pm
@@ -23,7 +23,7 @@ sub run {
     select_console 'root-console';
 
     assert_script_run "rm -rf nts_* ||:";
-    assert_script_run "supportconfig -t . -B test", 400;
+    assert_script_run "supportconfig -t . -B test", 800;
     assert_script_run "cd nts_test";
 
     # Check few file whether expected content is there.


### PR DESCRIPTION
We found the timeout not enough for some migration test case.

- Related ticket: https://progress.opensuse.org/issues/56210
- Needles: https: n/a
- Verification run: n/a
