### PR TITLE
Allow multiple runfiles in LTP_COMMAND_FILE

### DIFF
--- a/lib/LTP/TestInfo.pm
+++ b/lib/LTP/TestInfo.pm
@@ -18,6 +18,7 @@ use Mojo::Base 'OpenQA::Test::RunArgs';
 our @EXPORT_OK = qw(testinfo);
 use Exporter 'import';
 
+has 'runfile';
 has 'test';
 has test_result_export => sub { die 'Require test_result_export hashref'; };
 

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -41,21 +41,21 @@ sub shutdown_ltp {
 }
 
 sub parse_openposix_runfile {
-    my ($path, $cmd_pattern, $cmd_exclude, $test_result_export) = @_;
+    my ($path, $name, $cmd_pattern, $cmd_exclude, $test_result_export) = @_;
 
     open(my $rfile, $path) or die "Can not open runfile asset $path: $!";    ## no critic (InputOutput::ProhibitTwoArgOpen)
     while (my $line = <$rfile>) {
         chomp($line);
         if ($line =~ m/$cmd_pattern/ && !($line =~ m/$cmd_exclude/)) {
             my $test  = {name => basename($line, '.run-test'), command => $line};
-            my $tinfo = testinfo($test_result_export, test => $test);
+            my $tinfo = testinfo($test_result_export, test => $test, runfile => $name);
             loadtest('run_ltp', name => $test->{name}, run_args => $tinfo);
         }
     }
 }
 
 sub parse_runtest_file {
-    my ($path, $cmd_pattern, $cmd_exclude, $test_result_export) = @_;
+    my ($path, $name, $cmd_pattern, $cmd_exclude, $test_result_export) = @_;
 
     open(my $rfile, $path) or die "Can not open runtest asset $path: $!";    ## no critic (InputOutput::ProhibitTwoArgOpen)
     while (my $line = <$rfile>) {
@@ -65,7 +65,7 @@ sub parse_runtest_file {
         if ($line =~ /^\s* ([\w-]+) \s+ (\S.+) #?/gx) {
             next if (check_var('BACKEND', 'svirt') && ($1 eq 'dnsmasq' || $1 eq 'dhcpd'));    # poo#33850
             my $test  = {name => $1, command => $2};
-            my $tinfo = testinfo($test_result_export, test => $test);
+            my $tinfo = testinfo($test_result_export, test => $test, runfile => $name);
             if ($test->{name} =~ m/$cmd_pattern/ && !($test->{name} =~ m/$cmd_exclude/)) {
                 loadtest('run_ltp', name => $test->{name}, run_args => $tinfo);
             }
@@ -91,10 +91,10 @@ sub loadtest_from_runtest_file {
 
     for my $name (split(/,/, $namelist)) {
         if ($name eq 'openposix') {
-            parse_openposix_runfile($path . '/openposix-test-list-' . $tag, $cmd_pattern, $cmd_exclude, $test_result_export);
+            parse_openposix_runfile($path . '/openposix-test-list-' . $tag, $name, $cmd_pattern, $cmd_exclude, $test_result_export);
         }
         else {
-            parse_runtest_file($path . "/ltp-$name-" . $tag, $cmd_pattern, $cmd_exclude, $test_result_export);
+            parse_runtest_file($path . "/ltp-$name-" . $tag, $name, $cmd_pattern, $cmd_exclude, $test_result_export);
         }
     }
 

--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -74,7 +74,7 @@ sub parse_runtest_file {
 }
 
 sub loadtest_from_runtest_file {
-    my $name               = get_var('LTP_COMMAND_FILE');
+    my $namelist           = get_var('LTP_COMMAND_FILE');
     my $path               = get_var('ASSETDIR') . '/other';
     my $tag                = get_ltp_tag();
     my $cmd_pattern        = get_var('LTP_COMMAND_PATTERN') || '.*';
@@ -89,11 +89,13 @@ sub loadtest_from_runtest_file {
         loadtest 'create_junkfile_ltp';
     }
 
-    if ($name eq 'openposix') {
-        parse_openposix_runfile($path . '/openposix-test-list-' . $tag, $cmd_pattern, $cmd_exclude, $test_result_export);
-    }
-    else {
-        parse_runtest_file($path . "/ltp-$name-" . $tag, $cmd_pattern, $cmd_exclude, $test_result_export);
+    for my $name (split(/,/, $namelist)) {
+        if ($name eq 'openposix') {
+            parse_openposix_runfile($path . '/openposix-test-list-' . $tag, $cmd_pattern, $cmd_exclude, $test_result_export);
+        }
+        else {
+            parse_runtest_file($path . "/ltp-$name-" . $tag, $cmd_pattern, $cmd_exclude, $test_result_export);
+        }
     }
 
     shutdown_ltp(run_args => testinfo($test_result_export));

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -378,7 +378,8 @@ START_AFTER_TEST=install_ltp
 
 Either specifies the name of an LTP runfile from the runtest directory or
 'openposix'. When set to openposix it will load openposix_test_list.txt which
-is created by install_ltp.pm.
+is created by install_ltp.pm. Multiple runfiles separated by comma are also
+supported.
 
 =head2 LTP_COMMAND_PATTERN
 

--- a/tests/kernel/run_ltp.pm
+++ b/tests/kernel/run_ltp.pm
@@ -274,10 +274,10 @@ sub thetime {
 
 sub run {
     my ($self, $tinfo) = @_;
-    my $cmd_file = get_var 'LTP_COMMAND_FILE';
-    die 'Need LTP_COMMAND_FILE to know which tests to run' unless $cmd_file;
+    die 'Need LTP_COMMAND_FILE to know which tests to run' unless $tinfo && $tinfo->runfile;
+    my $runfile  = $tinfo->runfile;
     my $timeout  = get_var('LTP_TIMEOUT') || 900;
-    my $is_posix = $cmd_file =~ m/^\s*openposix\s*$/i;
+    my $is_posix = $runfile =~ m/^\s*openposix\s*$/i;
 
     unless (defined $tinfo) {
         die 'Require LTP::TestInfo object from loadtest with LTP test case name and command line';
@@ -307,9 +307,9 @@ sub run {
         type_string("($cmd_text) | tee /dev/$serialdev\n");
     }
     my $test_log = wait_serial(qr/$fin_msg\d+/, $timeout, 0, record_output => 1);
-    my ($timed_out, $result_export) = $self->record_ltp_result($cmd_file, $test, $test_log, $fin_msg, thetime() - $start_time, $is_posix);
+    my ($timed_out, $result_export) = $self->record_ltp_result($runfile, $test, $test_log, $fin_msg, thetime() - $start_time, $is_posix);
 
-    override_known_failures($self, $test_result_export->{environment}, $cmd_file, $test->{name}) if get_var('LTP_KNOWN_ISSUES') and $self->{result} eq 'fail';
+    override_known_failures($self, $test_result_export->{environment}, $runfile, $test->{name}) if get_var('LTP_KNOWN_ISSUES') and $self->{result} eq 'fail';
 
     push(@{$test_result_export->{results}}, $result_export);
     if ($timed_out) {


### PR DESCRIPTION
This patch enables running multiple LTP testsuites in a single OpenQA job.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/3338773

Verification run combines the following testsuites into a single job:
https://openqa.suse.de/tests/3331253
https://openqa.suse.de/tests/3331258
https://openqa.suse.de/tests/3331259