### PR TITLE
Do not run cron jobs when cron dir tree is missing

### DIFF
--- a/tests/console/force_scheduled_tasks.pm
+++ b/tests/console/force_scheduled_tasks.pm
@@ -45,7 +45,10 @@ sub run {
     settle_load;
     my $before = time;
     # run cron jobs or systemd timers which can affect system performance and mask systemd timers later
-    assert_script_run('find /etc/cron.{hourly,daily,weekly,monthly} -type f -executable -exec echo cron job: {} \; -exec {} \;', 1000);
+    # if cron directories exist, try to run present cron jobs
+    if (script_run('ls -a /etc/cron.{hourly,daily,weekly,monthly}') == 0) {
+        assert_script_run('find /etc/cron.{hourly,daily,weekly,monthly} -type f -executable -exec echo cron job: {} \; -exec {} \;', 1000);
+    }
     my $systemd_tasks_cmd = 'echo "Triggering systemd timed service $i" && systemctl start $i';
     $systemd_tasks_cmd .= ' && systemctl mask $i.{service,timer}' unless get_var('SOFTFAIL_BSC1063638');
     assert_script_run(


### PR DESCRIPTION
- Related ticket: [[JeOS][oS] test fails in force_scheduled_tasks: Can't cope with /etc/cron* not existing](https://progress.opensuse.org/issues/56621)
- Verification runs: 
   * [opensuse-Tumbleweed-JeOS-for-kvm-and-xen-x86_64-Build20190907-jeos@64bit_virtio](http://eris.suse.cz/tests/136#step/force_scheduled_tasks/8)
   * [sle-12-SP5-Server-DVD-x86_64-Build0307-default@64bit](http://eris.suse.cz/tests/141#step/force_scheduled_tasks/8)
   * [opensuse-15.2-DVD-x86_64-Build492.5-kde@64bit-2G](http://eris.suse.cz/tests/139#step/force_scheduled_tasks/8)
   * [opensuse-Tumbleweed-DVD-x86_64-Build20190907-gnome@64bit](http://eris.suse.cz/tests/139#step/force_scheduled_tasks/8)
   * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build3.7-jeos-main_intel_image@64bit-virtio-vga](http://eris.suse.cz/tests/149#step/force_scheduled_tasks/8)
   * [sle-12-SP5-JeOS-for-kvm-and-xen-x86_64-Build4.71-jeos-main_intel_image@64bit-virtio-vga](http://eris.suse.cz/tests/148#step/force_scheduled_tasks/8)