### PR TITLE
Public Cloud: Skip UEFI configuration for non-UEFI images

### DIFF
--- a/data/publiccloud/terraform/gce.tf
+++ b/data/publiccloud/terraform/gce.tf
@@ -90,10 +90,13 @@ resource "google_compute_instance" "openqa" {
         scopes = ["cloud-platform"]
     }
 
-    shielded_instance_config {
-        enable_secure_boot = "${var.uefi}"
-        enable_vtpm = "${var.uefi}"
-        enable_integrity_monitoring = "${var.uefi}"
+    dynamic "shielded_instance_config" {
+        for_each = "${var.uefi}" ? [ "UEFI" ] : []
+        content {
+            enable_secure_boot = "true"
+            enable_vtpm = "true"
+            enable_integrity_monitoring = "true"
+        }
     }
 }
 


### PR DESCRIPTION
Although the parameters in the new UEFI block are disabled for non-uefi images, Terraform complains that this block shouldn't be there:

`Error: Error creating instance: googleapi: Error 400: Invalid value for field 'resource.shieldedVmConfig': '{  "enableSecureBoot": false,  "enableVtpm": false,  "enableIntegrityMonitoring": false}'. A Shielded VM Config can only be set when using a UEFI-compatible disk., invalid`

Using dynamic blocks in terraform version >0.12 avoids this using some syntax "magic".

- Related ticket: https://progress.opensuse.org/issues/55055
- Verification runs:

Normal: http://fromm.arch.suse.de/tests/37
UEFI: http://fromm.arch.suse.de/tests/36

