### PR TITLE
no opensuse-welcome for ppc64/ppc64le

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -212,8 +212,9 @@ sub any_desktop_is_applicable {
 sub opensuse_welcome_applicable {
     # openSUSE-welcome is expected to show up on openSUSE Tumbleweed only (Leap possibly in the future)
     # since not all DEs honor xdg/autostart, we are filtering based on desktop environments
+    # except for ppc64/ppc64le because not built libqt5-qtwebengine sr#323144
     my $desktop = shift // get_var('DESKTOP', '');
-    return $desktop =~ /gnome|kde|lxde|lxqt|mate|xfce/ && is_tumbleweed;
+    return $desktop =~ /gnome|kde|lxde|lxqt|mate|xfce/ && is_tumbleweed && (get_var('ARCH') !~ /ppc64/);
 }
 
 sub logcurrentenv {


### PR DESCRIPTION
because opensuse-welcome not built for those arches as depends
on libqt5-qtwebengine not built either for them as per
https://build.opensuse.org/request/show/323144

pr validated with https://openqa.opensuse.org/tests/1028394