### PR TITLE
Apply refactored RAID tests to SLE 15 SP0 version

### DIFF
--- a/lib/Distribution/Opensuse/Leap/15.pm
+++ b/lib/Distribution/Opensuse/Leap/15.pm
@@ -1,6 +1,6 @@
 package Distribution::Opensuse::Leap::15;
 use strict;
 use warnings FATAL => 'all';
-use parent 'Distribution::Sle::15';
+use parent 'Distribution::Sle::15_current';
 
 1;

--- a/lib/Distribution/Opensuse/Tumbleweed.pm
+++ b/lib/Distribution/Opensuse/Tumbleweed.pm
@@ -17,14 +17,14 @@ use strict;
 use warnings FATAL => 'all';
 use parent 'susedistribution';
 use Installation::Partitioner::LibstorageNG::GuidedSetupController;
-use Installation::Partitioner::LibstorageNG::ExpertPartitionerController;
+use Installation::Partitioner::LibstorageNG::v4::ExpertPartitionerController;
 
 sub get_partitioner {
     return Installation::Partitioner::LibstorageNG::GuidedSetupController->new();
 }
 
 sub get_expert_partitioner {
-    return Installation::Partitioner::LibstorageNG::ExpertPartitionerController->new();
+    return Installation::Partitioner::LibstorageNG::v4::ExpertPartitionerController->new();
 }
 
 1;

--- a/lib/Distribution/Sle/15_current.pm
+++ b/lib/Distribution/Sle/15_current.pm
@@ -7,15 +7,15 @@
 # notice and this notice are preserved. This file is offered as-is,
 # without any warranty.
 
-# Summary: The class represents Sle15 distribution and provides access to its
-# features.
+# Summary: The class represents current (i.e. latest) Sle15 distribution and
+# provides access to its features.
 # Follows the "Factory first" rule. So that the feature first appears in
 # Tumbleweed distribution, and only if it behaves different in Sle15 then it
 # should be overriden here.
 
 # Maintainer: Oleksandr Orlov <oorlov@suse.de>
 
-package Distribution::Sle::15;
+package Distribution::Sle::15_current;
 use strict;
 use warnings FATAL => 'all';
 use parent 'Distribution::Opensuse::Tumbleweed';

--- a/lib/Distribution/Sle/15sp0.pm
+++ b/lib/Distribution/Sle/15sp0.pm
@@ -1,0 +1,29 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class represents SLE15-SP0 distribution and provides access to its
+# features.
+# Follows the "Factory first" rule. So that the feature first appears in
+# Tumbleweed distribution, and only if it behaves different in Sle15-SP0 then it
+# should be overriden here.
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package Distribution::Sle::15sp0;
+use strict;
+use warnings;
+use Installation::Partitioner::LibstorageNG::v3::ExpertPartitionerController;
+use parent 'Distribution::Opensuse::Tumbleweed';
+
+# override
+sub get_expert_partitioner {
+    return Installation::Partitioner::LibstorageNG::v3::ExpertPartitionerController->new();
+}
+
+
+1;

--- a/lib/Distribution/Sle/15sp0.pm
+++ b/lib/Distribution/Sle/15sp0.pm
@@ -18,7 +18,7 @@ package Distribution::Sle::15sp0;
 use strict;
 use warnings;
 use Installation::Partitioner::LibstorageNG::v3::ExpertPartitionerController;
-use parent 'Distribution::Opensuse::Tumbleweed';
+use parent 'Distribution::Sle::15_current';
 
 # override
 sub get_expert_partitioner {

--- a/lib/DistributionProvider.pm
+++ b/lib/DistributionProvider.pm
@@ -17,6 +17,7 @@ use strict;
 use warnings FATAL => 'all';
 use version_utils;
 
+use Distribution::Sle::15sp0;
 use Distribution::Sle::15;
 use Distribution::Sle::12;
 use Distribution::Opensuse::Leap::42;
@@ -33,7 +34,8 @@ If there is no matched version, then returns Tumbleweed as the default one.
 
 =cut
 sub provide {
-    return Distribution::Sle::15->new()            if version_utils::is_sle('15+');
+    return Distribution::Sle::15sp0->new()         if version_utils::is_sle('=15');
+    return Distribution::Sle::15->new()            if version_utils::is_sle('>15');
     return Distribution::Sle::12->new()            if version_utils::is_sle('12+');
     return Distribution::Opensuse::Leap::15->new() if version_utils::is_leap('15.0+');
     return Distribution::Opensuse::Leap::42->new() if version_utils::is_leap('42.0+');

--- a/lib/DistributionProvider.pm
+++ b/lib/DistributionProvider.pm
@@ -18,7 +18,7 @@ use warnings FATAL => 'all';
 use version_utils;
 
 use Distribution::Sle::15sp0;
-use Distribution::Sle::15;
+use Distribution::Sle::15_current;
 use Distribution::Sle::12;
 use Distribution::Opensuse::Leap::42;
 use Distribution::Opensuse::Leap::15;
@@ -35,7 +35,7 @@ If there is no matched version, then returns Tumbleweed as the default one.
 =cut
 sub provide {
     return Distribution::Sle::15sp0->new()         if version_utils::is_sle('=15');
-    return Distribution::Sle::15->new()            if version_utils::is_sle('>15');
+    return Distribution::Sle::15_current->new()    if version_utils::is_sle('>15');
     return Distribution::Sle::12->new()            if version_utils::is_sle('12+');
     return Distribution::Opensuse::Leap::15->new() if version_utils::is_leap('15.0+');
     return Distribution::Opensuse::Leap::42->new() if version_utils::is_leap('42.0+');

--- a/lib/Installation/Partitioner/LibstorageNG/v3/ExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v3/ExpertPartitionerController.pm
@@ -1,0 +1,64 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved. This file is offered as-is,
+# without any warranty.
+
+# Summary: The class introduces business actions for Libstorage-NG (ver.3) Expert
+# Partitioner.
+#
+# Libstorage-NG (ver.3) introduces some different shortcuts comparing to Libstorage.
+# Also, it has some UI changes that causes some actions to be performed with the
+# different steps (e.g. Partitions Tab should be selected first for "Add" button
+# to be visible).
+#
+# Maintainer: Oleksandr Orlov <oorlov@suse.de>
+
+package Installation::Partitioner::LibstorageNG::v3::ExpertPartitionerController;
+use strict;
+use warnings;
+use testapi;
+use parent 'Installation::Partitioner::Libstorage::ExpertPartitionerController';
+use Installation::Partitioner::LibstorageNG::SuggestedPartitioningPage;
+use Installation::Partitioner::LibstorageNG::ExpertPartitionerPage;
+use Installation::Partitioner::NewPartitionSizePage;
+use Installation::Partitioner::RolePage;
+use Installation::Partitioner::LibstorageNG::FormattingOptionsPage;
+use Installation::Partitioner::RaidTypePage;
+use Installation::Partitioner::RaidOptionsPage;
+
+sub new {
+    my ($class, $args) = @_;
+    my $self = bless {
+        SuggestedPartitioningPage => Installation::Partitioner::LibstorageNG::SuggestedPartitioningPage->new(),
+        ExpertPartitionerPage => Installation::Partitioner::LibstorageNG::ExpertPartitionerPage->new({add_partition_shortcut => 'alt-d', add_raid_shortcut => 'alt-r'}),
+        NewPartitionSizePage => Installation::Partitioner::NewPartitionSizePage->new({custom_size_shortcut => 'alt-o'}),
+        RolePage             => Installation::Partitioner::RolePage->new({raw_volume_shortcut => 'alt-r'}),
+        FormattingOptionsPage => Installation::Partitioner::LibstorageNG::FormattingOptionsPage->new({do_not_format_shortcut => 'alt-t', format_shortcut => 'alt-r', filesystem_shortcut => 'alt-f', do_not_mount_shortcut => 'alt-d'}),
+        RaidTypePage    => Installation::Partitioner::RaidTypePage->new(),
+        RaidOptionsPage => Installation::Partitioner::RaidOptionsPage->new({chunk_size_shortcut => 'alt-u'})
+    }, $class;
+}
+
+sub run_expert_partitioner {
+    my ($self) = @_;
+    $self->get_suggested_partitioning_page()->select_start_with_existing_partitions();
+}
+
+sub add_partition_on_gpt_disk {
+    my ($self, $args) = @_;
+    $self->get_expert_partitioner_page()->select_item_in_system_view_table($args->{disk});
+    $self->get_expert_partitioner_page()->select_partitions_tab();
+    $self->get_expert_partitioner_page()->press_add_partition_button();
+    $self->_add_partition($args->{partition});
+}
+
+sub _finish_partition_creation {
+    my ($self) = @_;
+    $self->get_formatting_options_page()->press_next();
+}
+
+1;

--- a/lib/Installation/Partitioner/LibstorageNG/v4/ExpertPartitionerController.pm
+++ b/lib/Installation/Partitioner/LibstorageNG/v4/ExpertPartitionerController.pm
@@ -7,15 +7,18 @@
 # notice and this notice are preserved. This file is offered as-is,
 # without any warranty.
 
-# Summary: The class introduces business actions for Libstorage-NG Expert
-# Partitioner.
+# Summary: The class introduces business actions for Libstorage-NG (ver.4)
+# Expert Partitioner.
+# Libstorage-NG (ver.4) introduces some different shortcuts in comparing to the
+# ver.3. Also RAID creation wizard differs.
+#
 # Maintainer: Oleksandr Orlov <oorlov@suse.de>
 
-package Installation::Partitioner::LibstorageNG::ExpertPartitionerController;
+package Installation::Partitioner::LibstorageNG::v4::ExpertPartitionerController;
 use strict;
 use warnings;
 use testapi;
-use parent 'Installation::Partitioner::AbstractExpertPartitionerController';
+use parent 'Installation::Partitioner::LibstorageNG::v3::ExpertPartitionerController';
 use Installation::Partitioner::LibstorageNG::SuggestedPartitioningPage;
 use Installation::Partitioner::LibstorageNG::ExpertPartitionerPage;
 use Installation::Partitioner::NewPartitionSizePage;
@@ -37,59 +40,6 @@ sub new {
     }, $class;
 }
 
-sub get_suggested_partitioning_page {
-    my ($self) = @_;
-    return $self->{SuggestedPartitioningPage};
-}
-
-sub get_raid_options_page {
-    my ($self) = @_;
-    return $self->{RaidOptionsPage};
-}
-
-sub get_expert_partitioner_page {
-    my ($self) = @_;
-    return $self->{ExpertPartitionerPage};
-}
-
-sub get_formatting_options_page {
-    my ($self) = @_;
-    return $self->{FormattingOptionsPage};
-}
-
-sub get_rescan_devices_dialog {
-    my ($self) = @_;
-    return $self->{RescanDevicesDialog};
-}
-
-sub get_new_partition_size_page {
-    my ($self) = @_;
-    return $self->{NewPartitionSizePage};
-}
-
-sub get_raid_type_page {
-    my ($self) = @_;
-    return $self->{RaidTypePage};
-}
-
-sub get_role_page {
-    my ($self) = @_;
-    return $self->{RolePage};
-}
-
-sub run_expert_partitioner {
-    my ($self) = @_;
-    $self->get_suggested_partitioning_page()->select_start_with_existing_partitions();
-}
-
-sub add_partition_on_gpt_disk {
-    my ($self, $args) = @_;
-    $self->get_expert_partitioner_page()->select_item_in_system_view_table($args->{disk});
-    $self->get_expert_partitioner_page()->select_partitions_tab();
-    $self->get_expert_partitioner_page()->press_add_partition_button();
-    $self->_add_partition($args->{partition});
-}
-
 sub add_raid_partition {
     my ($self, $args) = @_;
     $self->get_expert_partitioner_page()->select_item_in_system_view_table('raid');
@@ -109,17 +59,5 @@ sub add_raid {
     $self->get_raid_options_page()->press_next();
     $self->add_raid_partition($args->{partition});
 }
-
-sub _finish_partition_creation {
-    my ($self) = @_;
-    $self->get_formatting_options_page()->press_next();
-}
-
-sub accept_changes {
-    my ($self) = @_;
-    $self->get_expert_partitioner_page()->press_accept_button();
-    $self->get_suggested_partitioning_page()->press_next();
-}
-
 
 1;


### PR DESCRIPTION
The PR adds the appropriate Controller and distribution to run the
tests on SLE 15 SP0.

- Related ticket: https://progress.opensuse.org/issues/54317
- Verification runs: 
   - SP0: https://openqa.suse.de/tests/overview?version=15&distri=sle&build=32.2_poo54317&groupid=96
   - SP2 (as I updated the files and it might affect the newer version): https://openqa.suse.de/tests/overview?build=32.3_poo54317&groupid=96&distri=sle&version=15-SP2
