### PR TITLE
Add postfix service check

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -26,6 +26,7 @@ use services::ntpd;
 use services::cups;
 use services::rpcbind;
 use autofs_utils;
+use services::postfix;
 
 our @EXPORT = qw(
   $hdd_base_version
@@ -58,9 +59,10 @@ our $default_services = {
         support_ver   => '15,15-SP1'
     },
     postfix => {
-        srv_pkg_name  => 'postfix',
-        srv_proc_name => 'postfix',
-        support_ver   => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1'
+        srv_pkg_name       => 'postfix',
+        srv_proc_name      => 'postfix',
+        support_ver        => '12-SP2,12-SP3,12-SP4,12-SP5,15,15-SP1',
+        service_check_func => \&services::postfix::full_postfix_check
     },
     # Quick hack for poo 50576, we need this workround before full solution
     apache => {

--- a/lib/services/postfix.pm
+++ b/lib/services/postfix.pm
@@ -40,7 +40,7 @@ sub check_service {
 # check postfix function
 sub check_function {
     # Clear mailbox
-    assert_script_run("rm /var/spool/mail/$testapi::username");
+    type_string("rm /var/spool/mail/$testapi::username\n");
     # Send testing mail
     assert_script_run("echo 'Mail body' | mailx -v -s 'openQA Testing' $testapi::username\@localhost");
     # Flush mail queue to ensure mail has been sent

--- a/lib/services/postfix.pm
+++ b/lib/services/postfix.pm
@@ -39,10 +39,14 @@ sub check_service {
 
 # check postfix function
 sub check_function {
+    # Clear mailbox
+    assert_script_run("rm /var/spool/mail/$testapi::username");
     # Send testing mail
     assert_script_run("echo 'Mail body' | mailx -v -s 'openQA Testing' $testapi::username\@localhost");
+    # Flush mail queue to ensure mail has been sent
+    assert_script_run("postfix flush");
     # Verify mail received
-    assert_script_run("postfix flush; grep 'openQA Testing' /var/spool/mail/$testapi::username");
+    assert_script_run("grep 'openQA Testing' /var/spool/mail/$testapi::username");
 }
 
 # check postfix service before and after migration

--- a/lib/services/postfix.pm
+++ b/lib/services/postfix.pm
@@ -1,0 +1,63 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Package for postfix service tests
+#
+# Maintainer: Alynx Zhou <alynx.zhou@suse.com>
+
+package services::postfix;
+use base 'opensusebasetest';
+use testapi;
+use utils;
+use strict;
+use warnings;
+
+sub install_service {
+    # mailx is used to send mail
+    zypper_call('in postfix mailx');
+}
+
+sub enable_service {
+    systemctl('enable postfix');
+}
+
+sub start_service {
+    systemctl('start postfix');
+}
+
+# check service is running and enabled
+sub check_service {
+    systemctl('is-enabled postfix');
+    systemctl('is-active postfix');
+}
+
+# check postfix function
+sub check_function {
+    # Send testing mail
+    assert_script_run("echo 'Mail body' | mailx -v -s 'openQA Testing' $testapi::username\@localhost");
+    # Verify mail received
+    assert_script_run("postfix flush; grep 'openQA Testing' /var/spool/mail/$testapi::username");
+}
+
+# check postfix service before and after migration
+# stage is 'before' or 'after' system migration.
+sub full_postfix_check {
+    my ($stage) = @_;
+    $stage //= '';
+    if ($stage eq 'before') {
+        install_service();
+        enable_service();
+        start_service();
+    }
+    check_service();
+    check_function();
+}
+
+1;
+


### PR DESCRIPTION
Add postfix service check

- Related ticket: https://progress.opensuse.org/issues/55001
- Needles: n/a
- Verification run: http://openqa.suse.de/tests/3345978
