### PR TITLE
btrfs-progs: add two utilities for testing

### DIFF
--- a/data/btrfs-progs/install.sh
+++ b/data/btrfs-progs/install.sh
@@ -2,6 +2,18 @@
 
 # The first parameter is the git url
 # The second parameter is the install folder
+btrfs_bin='
+btrfs
+btrfs-convert
+btrfs-find-root
+btrfs-image
+btrfs-select-super
+btrfstune
+btrfs-corrupt-block
+mkfs.btrfs
+Documentation
+'
+
 git clone -q --depth 1 $1
 cd btrfs-progs
 ./autogen.sh
@@ -10,7 +22,7 @@ make
 make testsuite
 mkdir -p $2
 tar zxf tests/btrfs-progs-tests.tar.gz -C $2
-cp btrfs btrfs-convert btrfs-find-root btrfs-image btrfs-select-super btrfstune /sbin/
+cp -r $btrfs_bin /sbin/
 cp tests/clean-tests.sh $2
 if [ "$3" == "misc" ];then
     sed -ie '/check_min_kernel_version/,+2 s/^/#/' $2/misc-tests/034*/test.sh


### PR DESCRIPTION
btrfs-progs: add two utilities for testing
lack of btrfs-corrupt-block for fsck testing
lack of mkfs.btrfs for mkfs testing

- Related ticket: https://progress.opensuse.org/issues/56780
- Verification run:
http://10.67.133.10/tests/487
http://10.67.133.10/tests/485
http://10.67.133.10/tests/486
