### PR TITLE
LTP: Fix NFS service name

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -273,7 +273,7 @@ sub setup_network {
     # echo/echoes, getaddrinfo_01
     assert_script_run('sed -i \'s/^\(hosts:\s+files\s\+dns$\)/\1 myhostname/\' /etc/nsswitch.conf');
 
-    foreach my $service (qw(auditd dnsmasq nfsserver rpcbind vsftpd)) {
+    foreach my $service (qw(auditd dnsmasq nfs-server rpcbind vsftpd)) {
         if (is_sle('12+') || is_opensuse || is_jeos) {
             systemctl("reenable $service");
             assert_script_run("systemctl start $service || { systemctl status --no-pager $service; journalctl -xe --no-pager; false; }");


### PR DESCRIPTION
Now NFS server service it's called as nfs-server only.

Fixes: poo#56783

Verification run:
* install_ltp+opensuse+DVD@64bit (Tumbleweed)
http://quasar.suse.cz/tests/3647
* install_ltp+sle+Server-DVD@64bit (SLE12-SP5)
http://quasar.suse.cz/tests/3646
* install_ltp+sle+Installer-DVD@64bit (SLE15-SP2)
http://quasar.suse.cz/tests/3645
