### PR TITLE
Add yast2 packager to yast2ui extratests

### DIFF
--- a/tests/console/zypper_extend.pm
+++ b/tests/console/zypper_extend.pm
@@ -18,6 +18,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils 'is_sle';
 
 sub run {
     select_console 'root-console';
@@ -73,9 +74,20 @@ sub run {
 
     #Disable a specific repository
     zypper_call 'mr -d 1';
+    validate_script_output('zypper lr 1', sub { m/Enabled\s+:\sNo/ });
 
     #Enable a specific repository
     zypper_call 'mr -e 1';
+    validate_script_output('zypper lr 1', sub { m/Enabled\s+:\sYes/ });
+
+    #Autorefresh on repository on/off
+    my $refresh = is_sle('=12-sp1') ? '-r' : '-f';
+    zypper_call "mr $refresh 1";
+    my $autorefresh = is_sle('=12-sp1') ? 'Auto-refresh' : 'Autorefresh';
+    validate_script_output('zypper lr 1', sub { m/$autorefresh\s+:\sOn/ });
+    my $no_refresh = is_sle('=12-sp1') ? '-R' : '-F';
+    zypper_call "mr $no_refresh 1";
+    validate_script_output('zypper lr 1', sub { m/$autorefresh\s+:\sOff/ });
 
     #Disable rpm file caching for all the repositories.
     zypper_call 'mr -Ka';


### PR DESCRIPTION
And extend zypper_extend tests with autorefresh change on repo + verify

- Related ticket: https://progress.opensuse.org/issues/55727
- Verification run:
https://openqa.suse.de/tests/3346978
http://10.100.12.155/tests/13223#step/yast2_i/33
http://10.100.12.155/tests/13216 12sp4
http://10.100.12.155/tests/13219 12sp3
http://10.100.12.155/tests/13221 12sp2
http://10.100.12.155/tests/13220 12sp1
http://10.100.12.155/tests/13217 15sp1
http://10.100.12.155/tests/13218 15
