### PR TITLE
Add tomcat regression test

### DIFF
--- a/lib/Tomcat/JspTest.pm
+++ b/lib/Tomcat/JspTest.pm
@@ -1,0 +1,266 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test the tomcat JSP examples
+# Maintainer: George Gkioulis <ggkioulis@suse.com>
+
+package Tomcat::JspTest;
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use Tomcat::Utils;
+
+# allow a 60 second timeout for asserting needles
+use constant TIMEOUT => 60;
+
+# test all JSP examples
+sub test_all_examples() {
+    my ($self) = shift;
+
+    # array with example test function and number of tabs required to select the example
+    # shuffle example is skipped
+    my @jsp_examples = ([\&basic_arithmetics, 2], [\&basic_comparisons, 4], [\&implicit_objects, 4], [\&functions, 4], [\&composite_expressions, 4], [\&hello_world_tag, 4], [\&repeat_simple_tag, 4], [\&book_tag, 4], [\&tag_file, 4], [\&panel_tag, 4], [\&display_product, 4], [\&xhtml_basic, 4], [\&attribute_body, 8], [\&dynamic_attributes, 8], [\&jsp_configuration, 4], [\&number_guess, 4], [\&date, 4], [\&snoop, 4], [\&error, 4], [\&carts, 4], [\&checkbox, 4], [\&color, 4], [\&calendar, 4], [\&include, 4], [\&forward, 4], [\&plugin, 4], [\&servlet_jsp, 4], [\&simple_tag, 4], [\&jsp_xml, 4], [\&if, 4], [\&foreach, 4], [\&choose, 4], [\&form, 4]);
+
+    # access the tomcat jsp examples page
+    $self->firefox_open_url('localhost:8080/examples/jsp');
+    send_key_until_needlematch('tomcat-jsp-examples', 'ret');
+
+    # Navigate with keyboard to each example and test it
+    for my $i (0 .. $#jsp_examples) {
+        Tomcat::Utils->browse_with_keyboard('tomcat-jsp-fallback', $jsp_examples[$i][0], $jsp_examples[$i][1]);
+    }
+
+    # test xhtml svg example
+    $self->firefox_open_url('localhost:8080/examples/jsp/jsp2/jspx/textRotate.jspx?name=testing');
+    send_key_until_needlematch('tomcat-xhtml-svg', 'ret');
+}
+
+
+# test basic arithmetics example
+sub basic_arithmetics() {
+    assert_screen('tomcat-jsp-basic-arithmetics', TIMEOUT);
+}
+
+# test basic comparisons example
+sub basic_comparisons() {
+    assert_screen('tomcat-jsp-basic-comparisons', TIMEOUT);
+}
+
+# test implicit objects example
+sub implicit_objects() {
+    assert_screen('tomcat-jsp-implicit-objects', TIMEOUT);
+    send_key('tab');
+    type_string('test');
+    send_key('ret');
+    assert_screen('tomcat-jsp-implicit-objects-result', TIMEOUT);
+}
+
+# test functions example
+sub functions() {
+    assert_screen('tomcat-jsp-functions', TIMEOUT);
+    send_key('tab');
+    type_string('test');
+    send_key('ret');
+    assert_screen('tomcat-jsp-fuctions-result', TIMEOUT);
+}
+
+# test composite expressions example
+sub composite_expressions() {
+    assert_screen('tomcat-jsp-composite-expressions', TIMEOUT);
+}
+
+# test composite hello world tag example
+sub hello_world_tag() {
+    assert_screen('tomcat-hello-world-tag', TIMEOUT);
+}
+
+# test repeate simple tag example
+sub repeat_simple_tag() {
+    assert_screen('tomcat-repeat-simple-tag', TIMEOUT);
+}
+
+# test book tag example
+sub book_tag() {
+    assert_screen('tomcat-book-tag', TIMEOUT);
+}
+
+# test world tag file example
+sub tag_file() {
+    assert_screen('tomcat-hello-world-tag-file', TIMEOUT);
+}
+
+# test panels using tag files example
+sub panel_tag() {
+    assert_screen('tomcat-panels-using-tag-files', TIMEOUT);
+}
+
+# test display products tag file example
+sub display_product() {
+    assert_screen('tomcat-display-products-tag-file', TIMEOUT);
+}
+
+# test xhtml basic example
+sub xhtml_basic() {
+    assert_screen('tomcat-xhtml-basic', TIMEOUT);
+}
+
+# test attribute body example
+sub attribute_body() {
+    assert_screen('tomcat-attribute-body', TIMEOUT);
+}
+
+# test dynamic attributes example
+sub dynamic_attributes() {
+    assert_screen('tomcat-dynamic-attributes', TIMEOUT);
+}
+
+# test jsp configuration example
+sub jsp_configuration() {
+    assert_screen('tomcat-jsp-configuration', TIMEOUT);
+}
+
+# test number guess example
+sub number_guess() {
+    assert_screen('tomcat-number-guess', TIMEOUT);
+    send_key('tab');
+    type_string('0');
+    send_key('ret');
+    assert_screen('tomcat-number-guess-result', TIMEOUT);
+}
+
+# test date example
+sub date() {
+    assert_screen('tomcat-date-example', TIMEOUT);
+}
+
+# test snoop example
+sub snoop() {
+    assert_screen('tomcat-snoop-example', TIMEOUT);
+}
+
+# test error example
+sub error() {
+    assert_screen('tomcat-error-example', TIMEOUT);
+    send_key('tab');
+    for (1 .. 4) { send_key('down'); }
+    send_key('tab');
+    send_key('ret');
+    assert_screen('tomcat-error-example-result', TIMEOUT);
+}
+
+# test carts example
+sub carts() {
+    assert_screen('tomcat-carts-example', TIMEOUT);
+    send_key('tab');
+    for (1 .. 4) { send_key('down'); }
+    send_key('tab');
+    send_key('ret');
+    assert_screen('tomcat-carts-example-result', TIMEOUT);
+}
+
+# test checkbox example
+sub checkbox() {
+    assert_screen('tomcat-checkbox-example', TIMEOUT);
+    for (1 .. 4) { send_key('tab'); }
+    send_key('spc');
+    send_key('ret');
+    assert_screen('tomcat-checkbox-example-result', TIMEOUT);
+}
+
+# test color example
+sub color() {
+    assert_screen('tomcat-color-example', TIMEOUT);
+    send_key('tab');
+    type_string('red');
+    send_key('ret');
+    assert_screen('tomcat-color-example-result', TIMEOUT);
+}
+
+# test calendar example
+sub calendar() {
+    assert_screen('tomcat-calendar-example', TIMEOUT);
+    send_key('tab');
+    type_string('George');
+    send_key('tab');
+    type_string('test@test.test');
+    send_key('ret');
+    assert_screen('tomcat-calendar-example-result1', TIMEOUT);
+    assert_and_click('tomcat-calendar-time');
+    assert_screen('tomcat-calendar-event-confirmation', TIMEOUT);
+    send_key('tab');
+    type_string('test');
+    send_key('ret');
+    assert_screen('tomcat-calendar-example-result2', TIMEOUT);
+}
+
+# test include example
+sub include() {
+    assert_screen('tomcat-include-example', TIMEOUT);
+}
+
+# test forward example
+sub forward() {
+    assert_screen('tomcat-forward-example', TIMEOUT);
+}
+
+# test plugin example
+sub plugin() {
+    assert_screen('tomcat-plugin-example', TIMEOUT);
+}
+
+# test servlet-to-jsp example
+sub servlet_jsp() {
+    assert_screen('tomcat-servlet-to-sjp', TIMEOUT);
+}
+
+# test simple tag example
+sub simple_tag() {
+    assert_screen('tomcat-simple-tag', TIMEOUT);
+}
+
+# test jsp in xml example
+sub jsp_xml() {
+    assert_screen('tomcat-jsp-in-xml', TIMEOUT);
+}
+
+# test if example
+sub if() {
+    assert_screen('tomcat-if-example', TIMEOUT);
+}
+
+# test foreach example
+sub foreach() {
+    assert_screen('tomcat-foreach-example', TIMEOUT);
+}
+
+# test choose example
+sub choose() {
+    assert_screen('tomcat-choose-example', TIMEOUT);
+}
+
+# test form example
+sub form() {
+    assert_screen('tomcat-form-example', TIMEOUT);
+    send_key('tab');
+    send_key('down');
+    for (1 .. 2) { send_key('ret'); }
+
+    if (check_screen('tomcat-click-save-login', 10)) {
+        assert_and_click('tomcat-click-save-login', TIMEOUT);
+    }
+
+    send_key('tab');
+    type_string('tomcat');
+    send_key('ret');
+    assert_screen('tomcat-form-example-result', TIMEOUT);
+}
+
+1;

--- a/lib/Tomcat/ServletTest.pm
+++ b/lib/Tomcat/ServletTest.pm
@@ -1,0 +1,142 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test the tomcat Servlet examples
+# Maintainer: George Gkioulis <ggkioulis@suse.com>
+
+package Tomcat::ServletTest;
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use Tomcat::Utils;
+use version_utils 'is_sle';
+
+# allow a TIMEOUT second timeout for asserting needles
+use constant TIMEOUT => 60;
+
+# test all Servlet examples
+sub test_all_examples() {
+    my ($self) = shift;
+
+    # array with example test function and number of tabs required to select the example
+    # the two servlet 4.0 examples are skipped
+    my @servlet_examples = ([\&hello, 2], [\&request_information, 4], [\&request_header, 4], [\&request_parameters, 4], [\&cookies, 4], [\&sessions, 4], [\&async0, 3], [\&async1, 1], [\&async2, 1], [\&async3, 1], [\&stocksticker, 1], [\&byte_counter, is_sle('<12-sp4') ? 2 : 1], [\&number_writer, 1]);
+
+    # access the tomcat servlets examples page
+    $self->firefox_open_url('localhost:8080/examples/servlets');
+    send_key_until_needlematch('tomcat-servlet-examples-page', 'ret');
+
+    # Navigate with keyboard to each example and test it
+    for my $i (0 .. $#servlet_examples) {
+        Tomcat::Utils->browse_with_keyboard('tomcat-servlet-fallback', $servlet_examples[$i][0], $servlet_examples[$i][1]);
+    }
+}
+
+
+# test hello example
+sub hello() {
+    assert_screen('tomcat-hello-world-example', TIMEOUT);
+}
+
+# test request information example
+sub request_information() {
+    assert_screen('tomcat-request-information-example', TIMEOUT);
+}
+
+# test request header example
+sub request_header() {
+    assert_screen('tomcat-request-header-example', TIMEOUT);
+}
+
+# test request parameters example
+sub request_parameters() {
+    assert_screen('tomcat-request-parameters-example-start', TIMEOUT);
+    assert_and_dclick('tomcat-request-parameters-example-1');
+    send_key('left');
+    type_string 'george';
+    send_key('tab');
+    type_string 'qam';
+    send_key('ret');
+    assert_screen('tomcat-request-parameters-example-2', TIMEOUT);
+}
+
+# test cookies example
+sub cookies() {
+    assert_screen('tomcat-cookies-example-start', TIMEOUT);
+    assert_and_dclick('tomcat-cookies-example-1');
+    send_key('left');
+    type_string 'biscuit';
+    send_key('tab');
+    type_string '5';
+    send_key('ret');
+    assert_screen('tomcat-cookies-example-2', TIMEOUT);
+}
+
+# test sessions example
+sub sessions() {
+    assert_screen('tomcat-sessions-example-start', TIMEOUT);
+    assert_and_dclick('tomcat-sessions-example-1');
+    send_key('left');
+    type_string('attr1');
+    send_key('tab');
+    type_string('1');
+    send_key('ret');
+    assert_screen('tomcat-sessions-example-result-1', TIMEOUT);
+    assert_and_dclick('tomcat-sessions-example-2');
+    type_string('attr2');
+    send_key('tab');
+    type_string('2');
+    send_key('ret');
+    assert_screen('tomcat-sessions-example-result-2', TIMEOUT);
+}
+
+# test async0 example
+sub async0() {
+    assert_screen('tomcat-async0-example', TIMEOUT);
+}
+
+# test async1 example
+sub async1() {
+    assert_screen('tomcat-async1-example', TIMEOUT);
+}
+
+# test async2 example
+sub async2() {
+    assert_screen('tomcat-async2-example', TIMEOUT);
+}
+
+# test async3 example
+sub async3() {
+    assert_screen('tomcat-async3-example', TIMEOUT);
+}
+
+# test stocksticker
+sub stocksticker() {
+    assert_screen('tomcat-stocksticker-example', TIMEOUT);
+}
+
+# test byte counter example
+sub byte_counter() {
+    assert_screen('tomcat-byte-counter-start', TIMEOUT);
+    assert_and_dclick('tomcat-byte-counter-example');
+    send_key('left');
+    type_string('test');
+    for (1 .. 2) { send_key('tab'); }
+    send_key('ret');
+    assert_screen('tomcat-byte-counter-example-result', TIMEOUT);
+}
+
+# test number writer example
+sub number_writer() {
+    assert_screen('tomcat-number-writer-example', TIMEOUT);
+}
+
+1;

--- a/lib/Tomcat/Utils.pm
+++ b/lib/Tomcat/Utils.pm
@@ -1,0 +1,92 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Provide functionality for tomcat installation and configuration,
+# accessing the tomcat manager page, and browsing tomcat examples using keyboard.
+# Maintainer: George Gkioulis <ggkioulis@suse.com>
+
+
+package Tomcat::Utils;
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils 'is_sle';
+use registration;
+
+# allow a 60 second timeout for asserting needles
+use constant TIMEOUT => 60;
+
+# Use keyboard to browse the examples faster
+sub browse_with_keyboard {
+    my ($self, $fallback_needle, $test_func, $tab_num) = @_;
+
+    assert_screen($fallback_needle, TIMEOUT);
+    for (1 .. $tab_num) { send_key('tab'); }
+    send_key('ctrl-ret');
+    send_key('ctrl-tab');
+
+    $test_func->();
+
+    send_key('ctrl-w');
+}
+
+# Install tomcat and set initial configuration
+sub tomcat_setup() {
+    my $tomcat_users_xml = <<'EOF';
+<?xml version="1.0" encoding="UTF-8"?>
+<tomcat-users xmlns="http://tomcat.apache.org/xml"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
+              version="1.0">
+<role rolename="manager-gui"/>
+<user name="admin" password="admin" roles="manager-gui,tomcat"/>
+</tomcat-users>
+EOF
+
+    # log in to root console
+    select_console('root-console');
+
+    record_info('Initial Setup');
+
+    zypper_call('in tomcat tomcat-webapps tomcat-admin-webapps');
+    assert_script_run('rpm -q tomcat');
+
+    # start the tomcat daemon and check that it is running
+    systemctl('start tomcat');
+    systemctl('status tomcat');
+
+    # check that tomcat is listening on port 8080
+    assert_script_run('lsof -i :8080 | grep tomcat');
+
+    # create manager-gui role
+    assert_script_run("echo '$tomcat_users_xml' > /etc/tomcat/tomcat-users.xml");
+
+    # restart tomcat in order to take into account new role
+    systemctl('restart tomcat');
+}
+
+
+# Access the tomcat web application manager
+sub tomcat_manager_test() {
+    my ($self) = shift;
+
+    $self->firefox_open_url('localhost:8080/manager');
+    send_key_until_needlematch('tomcat-manager-authentication', 'ret');
+    type_string('admin');
+    send_key('tab');
+    type_string('admin');
+    assert_and_click('tomcat-OK-autentication');
+    assert_and_click('tomcat-click-save-login');
+    assert_screen('tomcat-web-application-manager', TIMEOUT);
+}
+
+
+1;

--- a/lib/Tomcat/WebSocketsTest.pm
+++ b/lib/Tomcat/WebSocketsTest.pm
@@ -1,0 +1,79 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test the tomcat WebSocket examples
+# Maintainer: George Gkioulis <ggkioulis@suse.com>
+
+package Tomcat::WebSocketsTest;
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use utils;
+use Tomcat::Utils;
+
+# allow a 60 second timeout for asserting needles
+use constant TIMEOUT => 60;
+
+# test all WebSocket examples
+sub test_all_examples() {
+    my ($self) = shift;
+
+    # array with example test function and number of tabs required to select the example
+    my @websocket_examples = ([\&echo, 1], [\&chat, 1], [\&snake, 1], [\&drawboard, 1]);
+
+    # access the tomcat websocket examples page
+    $self->firefox_open_url('localhost:8080/examples/websocket');
+    send_key_until_needlematch('tomcat-websocket-examples', 'ret');
+
+    # Navigate with keyboard to each example and test it
+    for my $i (0 .. $#websocket_examples) {
+        Tomcat::Utils->browse_with_keyboard('tomcat-websocket-examples', $websocket_examples[$i][0], $websocket_examples[$i][1]);
+    }
+}
+
+
+# test echo example
+sub echo() {
+    assert_screen('tomcat-echo-example-loaded', TIMEOUT);
+    assert_and_click('tomcat-echo-example-select');
+    assert_and_click('tomcat-echo-example-connect');
+    assert_and_click('tomcat-echo-example-message');
+    assert_screen('tomcat-echo-example', TIMEOUT);
+}
+
+# test chat example
+sub chat() {
+    assert_screen('tomcat-chat-example-loaded', TIMEOUT);
+    send_key('tab');
+    type_string('test');
+    send_key('ret');
+    assert_screen('tomcat-chat-example', TIMEOUT);
+}
+
+# test snake example
+sub snake() {
+    assert_screen('tomcat-snake-example-loaded', TIMEOUT);
+    send_key('right');
+    send_key('down');
+    assert_screen('tomcat-snake-example', TIMEOUT);
+}
+
+# test multiplayer drawboard example
+sub drawboard() {
+    assert_screen('tomcat-multiplayer-drawboard-example', TIMEOUT);
+    assert_and_click('tomcat-multiplayer-drawboard-example-focus');
+    send_key('pgdn');
+    assert_and_click('tomcat-multiplayer-drawboard-example-thickness');
+    send_key('pgup');
+    assert_and_click('tomcat-multiplayer-drawboard-example-draw');
+    assert_screen('tomcat-multiplayer-drawboard-example-result', TIMEOUT);
+}
+
+1;

--- a/schedule/qam/common/qam-regression-tomcat.yaml
+++ b/schedule/qam/common/qam-regression-tomcat.yaml
@@ -1,0 +1,7 @@
+---
+name: qam-regression-tomcat
+description: tomcat regression test
+schedule:
+- boot/boot_to_desktop
+- x11/tomcat
+...

--- a/tests/x11/tomcat.pm
+++ b/tests/x11/tomcat.pm
@@ -1,0 +1,79 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Tomcat regression test
+# * install and configure tomcat
+# * access tomcat manager web page
+# * test all Servlet, JSP and WebSocket examples
+# Maintainer: George Gkioulis <ggkioulis@suse.com>
+
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use Tomcat::ServletTest;
+use Tomcat::JspTest;
+use Tomcat::WebSocketsTest;
+use Tomcat::Utils;
+use utils;
+use x11utils 'ensure_unlocked_desktop';
+
+sub run() {
+    my ($self) = shift;
+
+    # install and configure tomcat in console
+    Tomcat::Utils->tomcat_setup();
+
+    # switch to desktop
+    if (!check_var('DESKTOP', 'textmode')) {
+        select_console('x11', await_console => 0);
+        ensure_unlocked_desktop;
+    }
+
+    # start firefox
+    $self->start_firefox_with_profile();
+
+    # check that the tomcat web service works
+    $self->firefox_open_url('localhost:8080');
+    send_key_until_needlematch('tomcat-succesfully-installed', 'ret');
+
+    # verify that the tomcat manager page works
+    Tomcat::Utils->tomcat_manager_test($self);
+
+    # Servlet testing
+    record_info('Servlet Testing');
+    my $servlet_test = Tomcat::ServletTest->new();
+    $servlet_test->test_all_examples();
+
+    # JSP testing
+    record_info('JSP Testing');
+    my $jsp_test = Tomcat::JspTest->new();
+    $jsp_test->test_all_examples();
+
+    # WebSocket testing
+    record_info('WebSocket Testing');
+    my $websocket_test = Tomcat::WebSocketsTest->new();
+    $websocket_test->test_all_examples();
+
+
+    # close firefox
+    send_key('alt-f4');
+
+    # delete firefox.log and close xterm
+    send_key('alt-tab');
+    send_key('ret');
+    type_string_slow 'rm firefox.log';
+    send_key('ret');
+    type_string_slow 'killall xterm';
+    send_key('ret');
+
+    assert_screen('generic-desktop');
+}
+
+1;


### PR DESCRIPTION
Summary: Tomcat regression test
 * install and configure tomcat
 * access tomcat manager web page
 * test all Servlet, JSP and WebSocket examples

- Related ticket: https://progress.opensuse.org/issues/50060
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1215
- Verification run:
sle 12.sp2: http://10.161.229.232/tests/546#step/tomcat/1
sle 12.sp3: http://10.161.229.232/tests/542#step/tomcat/1
sle 12.sp4: http://10.161.229.232/tests/517#step/tomcat/1
sle 12.sp5: http://10.161.229.232/tests/708#step/tomcat/1
sle 15: http://10.161.229.232/tests/683#step/tomcat/1
sle 15.sp1: http://10.161.229.232/tests/689#step/tomcat/1
sle 15.sp2: http://10.161.229.232/tests/714#step/tomcat/1
