### PR TITLE
Fix docker and docker_image timeout problems

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1414,14 +1414,14 @@ sub script_retry {
     my $ecode   = $args{expect}  // 0;
     my $retry   = $args{retry}   // 10;
     my $delay   = $args{delay}   // 30;
-    my $timeout = $args{timeout} // 25;
+    my $timeout = $args{timeout} // 30;
     my $die     = $args{die}     // 1;
 
     my $ret;
     for (1 .. $retry) {
         type_string "# Trying $_ of $retry:\n";
 
-        $ret = script_run "timeout $timeout $cmd";
+        $ret = script_run "timeout " . ($timeout - 3) . " $cmd", $timeout;
         last if defined($ret) && $ret == $ecode;
 
         die("Waiting for Godot: $cmd") if $retry == $_ && $die == 1;

--- a/tests/console/docker.pm
+++ b/tests/console/docker.pm
@@ -120,17 +120,17 @@ sub run {
     }
 
     # Try to stop container using ctrl+c
-    my $sleep_time = 30 * get_var('TIMEOUT_SCALE', 1);
+    my $sleep_time = 60 * get_var('TIMEOUT_SCALE', 1);
     type_string("docker run --rm opensuse/tumbleweed sleep $sleep_time\n");
-    type_string("# Let's press ctrl+c right now ... ");
+    type_string("#Press ctrl+c ");
     send_key 'ctrl-c';
-    type_string("# ... and we seem to be still in container\n");
+    type_string("#still in container\n");
     # If echo works then ctrl-c stopped sleep
     type_string "echo 'ctrlc_timeout' > /dev/$serialdev\n";
-    if (wait_serial('ctrlc_timeout', 10, 1) =~ 'ctrlc_timeout') {
-        die 'ctrl-c stopped container';
+    if (wait_serial('ctrlc_timeout', 10, 1)) {
+        die 'Sleep schould be still running so ctrl-c stopped container';
     }
-    die "Something went wrong" unless wait_serial('ctrlc_timeout', 40);
+    die "Sleep should already be finished but there is no output from the echo" unless wait_serial('ctrlc_timeout', $sleep_time + 30);
 
     # containers can be stopped
     assert_script_run("docker container stop $container_name");


### PR DESCRIPTION
This is fix for `console/docker` and `console/docker_image` test modules.
This also fixes `script_retry()` from `utils` library cc: @kravciak 

- Related ticket: [poo#47906](https://progress.opensuse.org/issues/47906)
- Verification run:
   * SLES: [12.3](http://pdostal-server.suse.cz/tests/4752) [12.4](http://pdostal-server.suse.cz/tests/4753) [15](http://pdostal-server.suse.cz/tests/4754) [15.1](http://pdostal-server.suse.cz/tests/4755)
  * `script_retry()`: [proof](http://pdostal-server.suse.cz/tests/4756#step/guest_management/22)