### PR TITLE
Exclude yast2_lan_device_settings on s390x

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1597,7 +1597,8 @@ sub load_extra_tests_console {
     loadtest "console/syslog";
     loadtest "console/ntp_client" if (!is_sle || is_jeos);
     loadtest "console/mta" unless is_jeos;
-    loadtest "console/yast2_lan_device_settings";
+    # We cannot change network device settings as rely on ssh/vnc connection to the machine
+    loadtest "console/yast2_lan_device_settings" unless is_s390x();
     loadtest "console/check_default_network_manager";
     loadtest "console/ipsec_tools_h2h" if get_var("IPSEC");
     loadtest "console/git";


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/3348384#step/yast2_lan_device_settings/18
- Verification run: https://openqa.suse.de/tests/3350265