### PR TITLE
Fix false positive in validate_raid

### DIFF
--- a/tests/console/validate_raid.pm
+++ b/tests/console/validate_raid.pm
@@ -14,7 +14,7 @@ use strict;
 use warnings;
 use base "opensusebasetest";
 use testapi;
-use version_utils 'is_sle';
+use version_utils qw(is_sle is_leap is_tumbleweed);
 use Test::Assert ':all';
 
 #
@@ -52,8 +52,10 @@ my $raid_level = qr/\/dev\/md0:.*?Raid Level : raid$level/s;
 # RAID array always with level 0
 my $raid0 = qr/\/dev\/md(1|2):.*?Raid Level : raid0/s;
 # RAID array always with level 1? why?
-my $raid1       = qr/\/dev\/md1:.*?Raid Level : raid1/s;
-my @raid_detail = (
+my $raid1 = qr/\/dev\/md1:.*?Raid Level : raid1/s;
+# RAID arrays both with the same level
+my $raid_both_same_level = qr/(\/dev\/md(0|1):.*?Raid Level : raid$level.*){2}/s;
+my @raid_detail          = (
     # 4 RAID devices per RAID array
     /(Raid Devices : 4.*){$num_raid_arrays}/s,
     # 4 active RAID devices per RAID array
@@ -93,6 +95,13 @@ sub prepare_test_data {
             $vfat_efi,
             $btrfs, $swap,
         );
+        if (is_sle('>=15-SP2') || is_sle('=12-SP5')) {
+            @raid = ($raid_both_same_level, @raid_detail);
+        }
+        else {
+            # raid0 for swap is required in some products
+            @raid = (($raid_level, $raid0), @raid_detail);
+        }
     }
     elsif (check_var('ARCH', 'x86_64')) {
         if (is_sle('<15')) {
@@ -105,13 +114,20 @@ sub prepare_test_data {
             $num_raid_arrays = @raid_arrays;
             @raid            = (($raid_level, $raid0, $raid1), @raid_detail);
         }
-    }
-    else {
-        @partitioning = (
-            $raid_partitions_2_arrays, $hard_disks, $linux_raid_member_2_arrays,
-            $btrfs, $swap,
-        );
-        @raid = (($raid_level, $raid0), @raid_detail);
+        else {
+            @partitioning = (
+                $raid_partitions_2_arrays, $hard_disks, $linux_raid_member_2_arrays,
+                $btrfs, $swap,
+            );
+            if (is_sle('<=15-SP1') || get_var('STAGING') ||
+                is_leap() || (is_tumbleweed() && check_var('FLAVOR', 'NET'))) {
+                # raid0 for swap is required in some products
+                @raid = (($raid_level, $raid0), @raid_detail);
+            }
+            else {
+                @raid = ($raid_both_same_level, @raid_detail);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fix false positive only in x86_64 when validating partitioning and raid in product different from SLE-12.
Fix false positive for aarch validating raid (only partitioning was validated)

- Related ticket: https://progress.opensuse.org/issues/56468
- Needles: n/a
- Verification runs:
  - [sle-15-SP2-Installer-DVD-x86_64-Build32.1-RAID0_gpt@64bit](https://openqa.suse.de/t3352494)
  - [sle-15-SP2-Installer-DVD-x86_64-Build32.1-RAID10_gpt@64bit](https://openqa.suse.de/t3352495)
  - [sle-15-SP2-Installer-DVD-aarch64-Build32.1-RAID0_gpt@aarch64](https://openqa.suse.de/t3352496)
  - [sle-15-SP2-Installer-DVD-aarch64-Build32.1-RAID10_gpt@aarch64](https://openqa.suse.de/t3352497)
  - [sle-15-Installer-DVD-QR-x86_64-Build0051-RAID0@64bit](https://openqa.suse.de/t3352498)
  - [sle-15-Installer-DVD-QR-x86_64-Build0051-RAID10@64bit](https://openqa.suse.de/t3352499)
  - [sle-15-SP1-Installer-DVD-QR-x86_64-Build3.22-RAID0@64bit](https://openqa.suse.de/t3352500)
  - [sle-15-SP1-Installer-DVD-QR-x86_64-Build3.22-RAID10@64bit](https://openqa.suse.de/t3352501)
  - [sle-12-SP5-Server-DVD-aarch64-Build0313-RAID0_gpt_uefi@aarch64](https://openqa.suse.de/t3352502)
  - [sle-12-SP5-Server-DVD-aarch64-Build0313-RAID10_gpt_uefi@aarch64](https://openqa.suse.de/t3352503)
  - [sle-15-SP2-Installer-DVD-Y-Staging-x86_64-BuildY.29.3-RAID1@64bit-staging](https://openqa.suse.de/t3352504)
  - [sle-12-SP5-Server-DVD-D-Staging-x86_64-BuildD.59.1-RAID1@64bit-staging](https://openqa.suse.de/t3352505)
  - [opensuse-Tumbleweed-DVD-x86_64-Build20190909-RAID0_gpt@64bit](https://openqa.opensuse.org/t1031395)
  - [opensuse-Tumbleweed-DVD-x86_64-Build20190909-RAID10_gpt@64bit](https://openqa.opensuse.org/t1031396)
  - [opensuse-Tumbleweed-NET-x86_64-Build20190911-RAID10@64bit](https://openqa.opensuse.org/t1031407)
  - [opensuse-15.2-DVD-x86_64-Build493.5-RAID0@64bit](https://openqa.opensuse.org/t1031398)
  - [opensuse-15.2-DVD-x86_64-Build493.5-RAID10@64bit](https://openqa.opensuse.org/t1031399)
  - [opensuse-Tumbleweed-NET-aarch64-Build20190907-RAID0@aarch64](https://openqa.opensuse.org/t1031400)
  - [opensuse-Tumbleweed-NET-aarch64-Build20190907-RAID10@aarch64](https://openqa.opensuse.org/t1031401)