### PR TITLE
publiccloud: Add single quote to run_ssh_command()

### DIFF
--- a/tests/publiccloud/az_accelerated_net.pm
+++ b/tests/publiccloud/az_accelerated_net.pm
@@ -99,7 +99,7 @@ test on the client side. The test runs TEST_TIME seconds.
 sub run_test {
     my ($self, $client, $server) = @_;
     record_info('server', 'Start IPERF in server' . $server->public_ip);
-    $server->run_ssh_command(cmd => 'nohup iperf -s -D &');
+    $server->run_ssh_command(cmd => 'nohup iperf -s -D &', no_quote => 1);
     sleep 60;    # Wait 60 seconds so that the server starts up safely and the clinet can connect to it
     record_info('client', 'Start IPERF in client');
     my $output = $client->run_ssh_command(cmd => 'iperf -t ' . get_required_var('TEST_TIME') . ' -c ' . $server->public_ip);

--- a/tests/publiccloud/ipa.pm
+++ b/tests/publiccloud/ipa.pm
@@ -48,7 +48,7 @@ sub run {
             $instance->upload_log('/var/log/cloudregister');
             last;
         }
-        $instance->run_ssh_command(cmd => 'rpm -qa > /tmp/rpm_qa.txt');
+        $instance->run_ssh_command(cmd => 'rpm -qa > /tmp/rpm_qa.txt', no_quote => 1);
         upload_logs('/tmp/rpm_qa.txt');
     }
 }


### PR DESCRIPTION
The normal intention by this function is, that the given command is
executed on the remote side. So if I create a redirection, the file
will appear on the remote side. To do so, we need to avoid bash special
characters to be interpreted. This is now done by single quote the
given command.

- Verification run: https://openqa.suse.de/t3350890 https://openqa.suse.de/t3350891
