### PR TITLE
Fix validate_raid for staging openSUSE

### DIFF
--- a/tests/console/validate_raid.pm
+++ b/tests/console/validate_raid.pm
@@ -119,7 +119,7 @@ sub prepare_test_data {
                 $raid_partitions_2_arrays, $hard_disks, $linux_raid_member_2_arrays,
                 $btrfs, $swap,
             );
-            if (is_sle('<=15-SP1') || get_var('STAGING') ||
+            if (is_sle('<=15-SP1') || (is_sle() && get_var('STAGING')) ||
                 is_leap() || (is_tumbleweed() && check_var('FLAVOR', 'NET'))) {
                 # raid0 for swap is required in some products
                 @raid = (($raid_level, $raid0), @raid_detail);


### PR DESCRIPTION
Fix validate_raid for staging openSUSE.

- Related ticket: https://progress.opensuse.org/issues/56468
- Needles: n/a
- Verification run: [opensuse-Staging:J-Staging-DVD-x86_64-Build185.1-RAID1_gpt@64bit](https://openqa.opensuse.org/t1032925)
