### PR TITLE
Add testcase for suse-module-tools

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1647,6 +1647,7 @@ sub load_extra_tests_console {
     loadtest 'console/procps';
     loadtest "console/lshw" if ((is_sle('15+') && (is_ppc64le || is_x86_64)) || is_opensuse);
     loadtest 'console/kmod';
+    loadtest 'console/suse_module_tools';
     loadtest 'console/zziplib'   if (is_sle('12-SP4+') && !is_jeos);
     loadtest 'console/firewalld' if is_sle('15+') || is_leap('15.0+') || is_tumbleweed;
     loadtest 'console/aaa_base' unless is_jeos;

--- a/tests/console/suse_module_tools.pm
+++ b/tests/console/suse_module_tools.pm
@@ -1,0 +1,45 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Testing functionality of modhash and modsign-verify commands.
+# A random module from available loadable modules on the system is picked
+# for testing purposes.
+# * modhash: the output is checked for correct format
+# * modsign-verify: the output is checked for correct format
+# Maintainer: Vasileios Anastasiadis <vasilios.anastasiadis@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use utils 'zypper_call';
+use version_utils qw(is_sle is_tumbleweed);
+
+sub run {
+    select_console 'root-console';
+
+    # Find a random module available on the system
+    # Get a list of all modules
+    my $mds = script_output("find /lib/modules/\$(uname -r) -type f -name '*.ko'");
+    # Get the first module on the list
+    my $pth = (split '\n', $mds)[0];
+
+    # Test modhash command
+    if (!is_sle('=12-sp1') && !is_sle('=12-sp5') && !is_tumbleweed()) {
+        # Get the output and test it against correct output
+        assert_script_run("modhash $pth | grep -E \"$pth: [0-9a-fA-F]+\"");
+    }
+    # testing modsign-verify command
+    if (is_sle('<15-sp1')) {
+        # Run command and grep correct output
+        assert_script_run("modsign-verify $pth | grep 'good signature\\|bad signature\\|certificate not found\\|module not signed\\|other error'");
+    }
+}
+
+1;


### PR DESCRIPTION
Add testcase for suse-module-tools

- Related ticket: https://progress.opensuse.org/issues/55724
- Verification run: 
http://10.161.229.247/tests/226
http://10.161.229.247/tests/227
http://10.161.229.247/tests/228
http://10.161.229.247/tests/229
http://10.161.229.247/tests/230
http://10.161.229.247/tests/231
http://10.161.229.247/tests/232
