### PR TITLE
Accept openSUSE Welcome for secondary user accounts

### DIFF
--- a/tests/x11/multi_users_dm.pm
+++ b/tests/x11/multi_users_dm.pm
@@ -19,7 +19,8 @@ use strict;
 use warnings;
 use testapi;
 use utils;
-use x11utils qw(handle_login handle_logout);
+use x11utils qw(handle_login handle_logout untick_welcome_on_next_startup);
+use main_common 'opensuse_welcome_applicable';
 
 sub ensure_multi_user_target {
     type_string "systemctl isolate multi-user.target\n";
@@ -79,6 +80,11 @@ sub run {
     # Make sure screen changed before calling handle_login function (for slow workers)
     wait_still_screen;
     handle_login($user, 1);
+    if (opensuse_welcome_applicable) {
+        assert_screen 'opensuse-welcome', 120;
+        # Close welcome screen
+        untick_welcome_on_next_startup;
+    }
     assert_screen 'generic-desktop', 60;
     # verify correct user is logged in
     x11_start_program('xterm');


### PR DESCRIPTION
The multi_users_dm (Plasma) and change_password (Gnome) tests log in
as a secondary test user. The checks only test if login is working, the account
is discarded immediately after and not used for any further tests.

Just accept the desktop with the openSUSE Welcome dialog as a sign of
a successful login, and proceed.

- Related ticket: https://progress.opensuse.org/issues/56774
- Related ticket: https://progress.opensuse.org/issues/58577
- Verification run: https://openqa.opensuse.org/tests/1094655
