### PR TITLE
btrfs-progs: Fix report issue when only 1 line in log file

### DIFF
--- a/lib/ctcs2_to_junit.pm
+++ b/lib/ctcs2_to_junit.pm
@@ -127,7 +127,7 @@ sub generateXML {
             $test_path = '/opt/logs/' . $test_path . '.txt';
             my $test_out_content = script_output("
                 if [ -f $test_path ];
-                    then sed -n -e \"s/'//g\" -e 's/[^[:print:]\\r\\t\\n]//g' -e '1!H;/====== RUN /h;\${g;p;}' $test_path | head -n 100;
+                    then sed -n -e \"s/'//g\" -e 's/[^[:print:]\\r\\t\\n]//g' -e 'H;/====== RUN /h;\${g;p;}' $test_path | head -n 100;
                 else echo 'Test Crashed, find log in serial0.txt';
                 fi
             ", 600);


### PR DESCRIPTION
The bug is that no any output when there is only one line in log file.

- Related ticket: https://progress.opensuse.org/issues/56960
- Verification run: 
http://10.67.133.10/tests/501  (reproduced bug)
http://10.67.133.10/tests/500  (Fix: 1 line in log file)
http://10.67.133.10/tests/498
