### PR TITLE
Fix NetWeaver tests on ppc64le

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -346,7 +346,7 @@ sub check_service_state {
         last if ((@olines == 0) && ($uc_state eq 'STOP'));
 
         if (($output =~ /sapstartsrv/) && ($uc_state eq 'START')) {
-            die "sapcontrol: wrong number of processes running after a StartService\n\n" . @olines unless (@olines == 1);
+            die "sapcontrol: wrong number of processes running after a StartService\n\n" . @olines unless ((@olines == 1) || ($time_to_wait > 10));
 
             # Exit if service is started
             last;


### PR DESCRIPTION
Increase check time in 'check_service_state' to ensure that the correct number of processes are started for NetWeaver on ppc64le.

- Related ticket: N/A
- Needles: N/A
- Failing test: https://openqa.suse.de/t3360591
- Verification run: https://openqa.suse.de/t3367475, https://openqa.suse.de/t3368037