### PR TITLE
Fix common cryptlvm yaml schedule

### DIFF
--- a/schedule/yast/cryptlvm/cryptlvm_sle_15.yaml
+++ b/schedule/yast/cryptlvm/cryptlvm_sle_15.yaml
@@ -17,7 +17,6 @@ schedule:
   - installation/installer_timezone
   - installation/user_settings
   - installation/user_settings_root
-  - installation/resolve_dependency_issues
   - installation/installation_overview
   - installation/disable_grub_timeout
   - installation/start_install
@@ -29,6 +28,7 @@ schedule:
   - installation/first_boot
   - console/validate_lvm
   - console/validate_encrypt
+  - console/zypper_lr
   - console/yast2_i
   - shutdown/cleanup_before_shutdown
   - shutdown/shutdown


### PR DESCRIPTION
We already had yaml schedule for cryptlvm, but somehow we still use `main.pm` for it.
Running tests to confirm that it works and I will adjust settings to use it in prod.

* [Verification runs](https://openqa.suse.de/tests/overview?build=rwx788%2Fos-autoinst-distri-opensuse%238457&version=15-SP2&distri=sle)
