### PR TITLE
Adjust not check iscsi service for SLE-12-SP5

### DIFF
--- a/tests/iscsi/iscsi_client.pm
+++ b/tests/iscsi/iscsi_client.pm
@@ -116,7 +116,7 @@ sub run {
     record_info 'Systemd', 'Verify status of iscsi services and sockets';
     systemctl("is-active iscsid.service");
     systemctl("is-active iscsid.socket");
-    if (!is_sle('=12-SP4')) {
+    if (!is_sle('=12-SP4') && !is_sle('=12-SP5')) {
         systemctl("is-active iscsi.service");
     }
     record_info 'Display iSCSI session';


### PR DESCRIPTION
Checking recent failure in SLE-15-SP5 https://openqa.suse.de/tests/3369745, I guess we want to apply same exclusion than in #8299.