### PR TITLE
Remove redundant assert_screeen. Increase timeout for SLE >15

### DIFF
--- a/tests/console/yast2_apparmor.pm
+++ b/tests/console/yast2_apparmor.pm
@@ -18,8 +18,7 @@ use utils qw(zypper_call systemctl);
 use version_utils qw(is_pre_15 is_sle is_opensuse is_leap);
 
 sub install_extra_packages_requested {
-    check_screen([qw(yast2_apparmor_extra_packages_requested yast2_apparmor)], 30);
-    if (match_has_tag 'yast2_apparmor_extra_packages_requested') {
+    if (check_screen 'yast2_apparmor_extra_packages_requested', 15) {
         send_key 'alt-i';
         save_screenshot;
         wait_still_screen 5;
@@ -43,11 +42,11 @@ sub run {
     } else {
         #SLES >=15 imediatelly asks for extra packages, not after main menu:
         install_extra_packages_requested;
-        send_key 'alt-l';
         assert_screen 'yast2_apparmor';
+        send_key 'alt-l';
     }
 
-    assert_screen [qw(yast2_apparmor_disabled yast2_apparmor_enabled)];
+    assert_screen([qw(yast2_apparmor_disabled yast2_apparmor_enabled)], 10);
     if (match_has_tag 'yast2_apparmor_disabled') {
         send_key 'alt-e';
         assert_screen 'yast2_apparmor_enabled';


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/56792
- Needles: None

- Verification runs:
12-SP2 - http://deathstar.suse.cz/tests/1163
12-SP3 - http://deathstar.suse.cz/tests/1164
12-SP4 - http://deathstar.suse.cz/tests/1165
12-SP5 - http://deathstar.suse.cz/tests/1166
SLE 15.0 - http://deathstar.suse.cz/tests/1170
SLE 15.1 - http://deathstar.suse.cz/tests/1171
Opensuse - 15.0 - http://deathstar.suse.cz/tests/1167
Opensuse 15.1 - http://deathstar.suse.cz/tests/1168
TW - http://deathstar.suse.cz/tests/1169

Change overview:
- Remove a redundant check screen for yast2_apparmor;

- Only on SLE 15+: 
First assert the screen(assert_screen 'yast2_apparmor';), then launch the application(alt-l), timeout incremented as SLE15 load screen sometimes is slower.