### PR TITLE
Add system info check

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1126,6 +1126,7 @@ sub load_consoletests {
         loadtest "console/xorg_vt";
     }
     loadtest "console/zypper_lr";
+    loadtest "console/check_system_info" if (is_sle && (get_var('SCC_ADDONS') !~ /ha/) && !is_sles4sap && (is_upgrade || get_var('MEDIA_UPGRADE')));
     # Enable installation repo from the usb, unless we boot from USB, but don't use it
     # for the installation, like in case of LiveCDs and when using http/smb/ftp mirror
     if (check_var('USBBOOT', 1) && !is_livecd && !get_var('NETBOOT')) {

--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program; if not, see <http://www.gnu.org/licenses/>.
 #
-# Summary: Check system info like `/etc/issue` or `/etc/os-release`.
+# Summary: Verify milestone version and display some info.
 # Maintainer: Alynx Zhou <alynx.zhou@suse.com>
 
 use base "consoletest";

--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -1,0 +1,44 @@
+# Copyright (C) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+# Summary: Check system info like `/etc/issue` or `/etc/os-release`.
+# Maintainer: Alynx Zhou <alynx.zhou@suse.com>
+
+use base "basetest";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    select_console('root-console');
+
+    script_output("SUSEConnect --list");
+    script_output("SUSEConnect --status-text");
+
+    if (!get_var('MILESTONE_VERSION')) {
+        assert_script_run('cat /etc/issue');
+    } else {
+        my $milestone_version = get_var('MILESTONE_VERSION');
+        assert_script_run("grep $milestone_version /etc/issue");
+    }
+    assert_script_run('cat /etc/os-release');
+}
+
+sub test_flags {
+    return {fatal => 0};
+}
+
+1;

--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -25,8 +25,8 @@ use utils;
 sub run {
     select_console('root-console');
 
-    script_output("SUSEConnect --list");
-    script_output("SUSEConnect --status-text");
+    assert_script_run("SUSEConnect --list > /dev/$serialdev");
+    assert_script_run("SUSEConnect --status-text > /dev/$serialdev");
 
     if (!get_var('MILESTONE_VERSION')) {
         assert_script_run('cat /etc/issue');

--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -32,7 +32,7 @@ sub run {
         assert_script_run('cat /etc/issue');
     } else {
         my $milestone_version = get_var('MILESTONE_VERSION');
-        assert_script_run("grep $milestone_version /etc/issue");
+        assert_script_run("grep -w $milestone_version /etc/issue");
     }
     assert_script_run('cat /etc/os-release');
 }

--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -16,7 +16,7 @@
 # Summary: Check system info like `/etc/issue` or `/etc/os-release`.
 # Maintainer: Alynx Zhou <alynx.zhou@suse.com>
 
-use base "basetest";
+use base "consoletest";
 use strict;
 use warnings;
 use testapi;
@@ -35,10 +35,6 @@ sub run {
         assert_script_run("grep $milestone_version /etc/issue");
     }
     assert_script_run('cat /etc/os-release');
-}
-
-sub test_flags {
-    return {fatal => 0};
 }
 
 1;


### PR DESCRIPTION
Add check for `/etc/issue`, `/etc/os-release`, etc.

- Related ticket: https://progress.opensuse.org/issues/56396
- Needles: n/a
- Verification run:
  + http://openqa.suse.de/tests/3372732
  + http://openqa.suse.de/tests/3372733
  + (running) http://openqa.suse.de/tests/3385042