### PR TITLE
Increase zypper_call timeout for QAM updates

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -100,7 +100,7 @@ sub run {
 
     change_repos_state($repos, 'enable');
 
-    zypper_call("in -l -t patch ${patches}", exitcode => [0, 102, 103], log => 'zypper.log');
+    zypper_call("in -l -t patch ${patches}", exitcode => [0, 102, 103], log => 'zypper.log', timeout => 1500);
 
     prepare_system_shutdown;
     power_action("reboot");


### PR DESCRIPTION
There can be lot of packages for update, better wait longer than fail on running update

- Related ticket: https://progress.opensuse.org/issues/56804
- Verification run: https://openqa.suse.de/tests/3374764