### PR TITLE
Add select root-console for kdump_and_crash

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -259,8 +259,10 @@ sub check_function {
         my $crash_cmd = "echo exit | crash `ls -1t /var/crash/*/vmcore | head -n1` /boot/vmlinux-`uname -r`$suffix";
         validate_script_output "$crash_cmd", sub { m/PANIC:\s([^\s]+)/ }, 600;
     }
-
-    assert_script_run 'rm -fr /var/crash/*';
+    else {
+        # migration tests need remove core files before migration start
+        assert_script_run 'rm -fr /var/crash/*';
+    }
 }
 
 #

--- a/tests/console/kdump_and_crash.pm
+++ b/tests/console/kdump_and_crash.pm
@@ -18,6 +18,7 @@ use utils;
 use kdump_utils;
 
 sub run {
+    select_console('root-console');
     kdump_utils::configure_service('function');
     kdump_utils::check_function('function');
 }


### PR DESCRIPTION
We need to add select root console if the kdump_and crash is the first module in console test,
it will fail.

- Related ticket: https://progress.opensuse.org/issues/57074
- Needles: N/A
- Verification run: 
  https://openqa.suse.de/tests/3377329
  https://openqa.suse.de/tests/3377330
 Migration:
  https://openqa.suse.de/tests/3377331
