### PR TITLE
Fix validation_raid for TW on aarch64

### DIFF
--- a/tests/console/validate_raid.pm
+++ b/tests/console/validate_raid.pm
@@ -95,7 +95,7 @@ sub prepare_test_data {
             $vfat_efi,
             $btrfs, $swap,
         );
-        if (is_sle('>=15-SP2') || is_sle('=12-SP5')) {
+        if (is_tumbleweed || is_sle('>=15-SP2') || is_sle('=12-SP5')) {
             @raid = ($raid_both_same_level, @raid_detail);
         }
         else {


### PR DESCRIPTION
The PR fixes failed validation_raid on Tumbleweed (aarch64).

- Verification run: https://openqa.opensuse.org/tests/1035795
https://openqa.opensuse.org/t1035818