### PR TITLE
Add fix for suse-module-tools in sle15sp1

### DIFF
--- a/tests/console/suse_module_tools.pm
+++ b/tests/console/suse_module_tools.pm
@@ -31,7 +31,7 @@ sub run {
     my $pth = (split '\n', $mds)[0];
 
     # Test modhash command
-    if (!is_sle('=12-sp1') && !is_sle('=12-sp5') && !is_tumbleweed()) {
+    if (!is_sle('=12-sp1') && !is_sle('=12-sp5') && !is_sle('=15-sp1') && !is_tumbleweed()) {
         # Get the output and test it against correct output
         assert_script_run("modhash $pth | grep -E \"$pth: [0-9a-fA-F]+\"");
     }


### PR DESCRIPTION
Add fix for suse-module-tools on sle15sp1

- Related ticket: https://progress.opensuse.org/issues/55724
- Verification run: 
http://10.161.229.247/tests/254
http://10.161.229.247/tests/255
http://10.161.229.247/tests/256
http://10.161.229.247/tests/257
http://10.161.229.247/tests/258
http://10.161.229.247/tests/259
http://10.161.229.247/tests/260
