### PR TITLE
Use script_retry instead of script_run to avoid silent fail

### DIFF
--- a/tests/console/java.pm
+++ b/tests/console/java.pm
@@ -30,7 +30,7 @@ sub run {
     pkcon_quit;
 
     if (check_var("DISTRI", "sle")) {
-        if (script_run('zypper -n in --auto-agree-with-licenses java-*', 500) == 4) {
+        if (script_retry('zypper -n in --auto-agree-with-licenses java-*', timeout => 500, expect => 4, retry => 5) == 4) {
             record_soft_failure 'bsc#1137466';
             # install only java-11-openjdk* & java-*-ibm*
             zypper_call('in --auto-agree-with-licenses java-11-openjdk* java-*-ibm*');


### PR DESCRIPTION
- Silent fail: https://openqa.suse.de/tests/3350064#step/java/4
- Verification run:
http://10.100.12.155/tests/13291
http://10.100.12.155/tests/13292
