### PR TITLE
Clear suggested NIS servers on SLES 15+

### DIFF
--- a/tests/console/yast2_nis.pm
+++ b/tests/console/yast2_nis.pm
@@ -16,6 +16,7 @@ use base "y2_module_consoletest";
 
 use testapi;
 use utils 'zypper_call';
+use version_utils 'is_sle';
 
 sub run() {
     my ($self) = @_;
@@ -49,7 +50,11 @@ sub run() {
     send_key_until_needlematch 'nis-domain-empty-field', 'backspace';    # clear NIS Domain field if it is prefilled
     type_string "suse.de";
     send_key 'alt-a';
-    type_string "10.162.0.1";
+    #clear suggested NIS server adresses on SLE15+
+    if (is_sle '15+') {
+        for (1 .. 15) { send_key 'backspace'; }
+    }
+    wait_screen_change { type_string "10.162.0.1" };
     wait_screen_change { send_key 'alt-p' };                             # check Netconfif NIS Policy
     send_key 'up';
     wait_screen_change { send_key 'ret' };


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/56639

- Verification run: 
SLE 15.0 - http://deathstar.suse.cz/tests/1186
SLE 15.1 - http://deathstar.suse.cz/tests/1187

SLE 12.2 - http://deathstar.suse.cz/tests/1174
SLE 12.3 - http://deathstar.suse.cz/tests/1175
SLE 12.4 - http://deathstar.suse.cz/tests/1176
SLE 12.5 - http://deathstar.suse.cz/tests/1177

- No needles;
- yast2_nis doesn't run on Opensuse;