### PR TITLE
Add zypper install for all unimplemented services

### DIFF
--- a/lib/service_check.pm
+++ b/lib/service_check.pm
@@ -162,6 +162,7 @@ sub install_services {
                 next;
             }
 
+            zypper_call "in $srv_pkg_name";
             systemctl 'enable ' . $srv_proc_name;
             systemctl 'start ' . $srv_proc_name;
             systemctl 'is-active ' . $srv_proc_name;


### PR DESCRIPTION
Add zypper install for all unimplemented services

- Related ticket: https://progress.opensuse.org/issues/57086
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/3384364
