### PR TITLE
Fix validate_raid in tw aarch

### DIFF
--- a/tests/console/validate_raid.pm
+++ b/tests/console/validate_raid.pm
@@ -95,7 +95,7 @@ sub prepare_test_data {
             $vfat_efi,
             $btrfs, $swap,
         );
-        if (is_sle('>=15-SP2') || is_sle('=12-SP5')) {
+        if (is_sle('>=15-SP2') || is_sle('=12-SP5') || is_tumbleweed) {
             @raid = ($raid_both_same_level, @raid_detail);
         }
         else {


### PR DESCRIPTION
Fix validate_raid in tw aarch

- Related ticket: https://progress.opensuse.org/issues/56468
- Needles: n/a
- Verification run: 
  - [opensuse-Tumbleweed-DVD-aarch64-Build20190913-RAID10_gpt_uefi@aarch64]( https://openqa.opensuse.org/t1036485)
