### PR TITLE
Add kernel source verification

### DIFF
--- a/data/kernel/module/Makefile
+++ b/data/kernel/module/Makefile
@@ -1,0 +1,6 @@
+#  Example from http://www.tldp.org/LDP/lkmpg/2.6/html/x181.html
+obj-m += hello.o
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+clean:
+	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean  

--- a/data/kernel/module/hello.c
+++ b/data/kernel/module/hello.c
@@ -1,0 +1,13 @@
+/* Example from http://www.tldp.org/LDP/lkmpg/2.6/html/x121.html */
+
+#include <linux/module.h>
+#include <linux/kernel.h>
+int init_module(void)
+{
+ printk(KERN_INFO "Hello world.\n");
+ return 0;
+}
+void cleanup_module(void)
+{
+ printk(KERN_INFO "Goodbye world.\n");
+}

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -122,6 +122,7 @@ our @EXPORT = qw(
   updates_is_applicable
   we_is_applicable
   load_extra_tests_y2uitest_gui
+  load_extra_tests_kernel
 );
 
 sub init_main {
@@ -2602,6 +2603,11 @@ sub load_toolchain_tests {
     loadtest "toolchain/gcc_fortran_compilation";
     loadtest "toolchain/gcc_compilation";
     loadtest "console/kdump_and_crash" if is_sle && kdump_is_applicable;
+}
+
+sub load_extra_tests_kernel {
+    loadtest "kernel/module_build";
+    loadtest "kernel/tuned";
 }
 
 sub load_publiccloud_tests {

--- a/tests/kernel/module_build.pm
+++ b/tests/kernel/module_build.pm
@@ -1,0 +1,43 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test kernel module build
+#          Example http://www.tldp.org/LDP/lkmpg/2.6/html/x121.html
+# Maintainer: Petr Cervinka <pcervinka@suse.com>
+# Tags: https://progress.opensuse.org/issues/49031
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    zypper_call "in kernel-default-devel";
+    # Prepare module sources
+    assert_script_run("curl -L -v " . autoinst_url . "/data/kernel/module > module.data && cpio -id < module.data && rm module.data");
+    assert_script_run "cd data";
+    # Build module
+    assert_script_run "make";
+    # Insert module
+    assert_script_run "insmod hello.ko";
+    # Verify that module was inserted
+    assert_script_run "dmesg | grep 'Hello world'";
+    # Remove module
+    assert_script_run "rmmod hello";
+    # Verify that module was removed
+    assert_script_run "dmesg | grep 'Goodbye world'";
+    # Do cleanup
+    assert_script_run "make clean";
+    assert_script_run "cd .. && rm -rf data";
+}
+
+1;


### PR DESCRIPTION
New test poo#49031: Kernel source is verified against current
kernel by compiling kernel module. Kernel module is inserted
and removed to check correct behavior.

New extra tests kernel group was created to bundle more non LTP tests together
to avoid one test = one job configuration.
New test suite extra_tests_kernel was created on OSD:
```
BOOT_HDD_IMAGE=1
DESKTOP=textmode
EXTRATEST=kernel
HDDSIZEGB=20
HDD_1=SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed.qcow2
START_AFTER_TEST=create_hdd_minimal_base+sdk
UEFI_PFLASH_VARS=SLES-%VERSION%-%ARCH%-%BUILD%@%MACHINE%-minimal_with_sdk%BUILD_SDK%_installed-uefi-vars.qcow2
```

- Related ticket: https://progress.opensuse.org/issues/49031
- Needles: none
- Verification run: 
SLE12-SP5: http://10.100.12.105/tests/3174
Tumbleweed: http://10.100.12.105/tests/3175 (tuned error is not related)
