### PR TITLE
Add SLES4SAP tests on Public Cloud

### DIFF
--- a/data/publiccloud/terraform/sap/azure.tfvars
+++ b/data/publiccloud/terraform/sap/azure.tfvars
@@ -1,0 +1,120 @@
+# Launch SLES-HAE of SLES4SAP cluster nodes
+
+# Instance type to use for the cluster nodes
+instancetype = "%MACHINE_TYPE%"
+
+# Disk type for HANA
+hana_data_disk_type = "StandardSSD_LRS"
+
+# Caching used for HANA disk
+hana_data_disk_caching = "ReadWrite"
+
+# Number of nodes in the cluster
+ninstances = "2"
+
+# Region where to deploy the configuration
+az_region = "%REGION%"
+
+# Installation type
+# Value can be all, skip-hana, skip-cluster
+init_type = "all"
+
+# SLES4SAP image information
+# If custom uris are enabled public information will be omitted
+# Custom sles4sap image
+sles4sap_uri = "%SLE_IMAGE%"
+
+# Custom iscsi server image
+# iscsi_srv_uri = "/path/to/your/iscsi/image"
+
+# Public SLES4SAP image
+hana_public_sku     = "15"
+hana_public_version = "latest"
+
+# Public iscsi server image
+iscsi_public_sku     = "15"
+iscsi_public_version = "latest"
+
+# Admin user
+admin_user = "ldevulder"
+
+# Private SSH Key location
+private_key_location = "~/.ssh/id_rsa"
+
+# SSH public key file
+public_key_location = "~/.ssh/id_rsa.pub"
+
+# Azure storage account name
+storage_account_name = "%STORAGE_ACCOUNT_NAME%"
+
+# Azure storage account secret key (key1 or key2)
+storage_account_key = "%STORAGE_ACCOUNT_KEY%"
+
+# Azure storage account path where HANA installation master is located
+hana_inst_master = "%HANA_BUCKET%"
+
+# Local folder where HANA installation master will be mounted
+hana_inst_folder = "/root/sap_inst/"
+
+# Device used by node where HANA will be installed
+hana_disk_device = "/dev/sdc"
+
+# Device used by the iSCSI server to provide LUNs
+iscsidev = "/dev/sdc"
+
+# Path to a custom ssh public key to upload to the nodes
+# Used for cluster communication for example
+cluster_ssh_pub = "salt://hana_node/files/sshkeys/cluster.id_rsa.pub"
+
+# Path to a custom ssh private key to upload to the nodes
+# Used for cluster communication for example
+cluster_ssh_key = "salt://hana_node/files/sshkeys/cluster.id_rsa"
+
+# Each host IP address (sequential order).
+# example : host_ips = ["10.0.1.0", "10.0.1.1"]
+host_ips = ["10.74.1.11", "10.74.1.12"]
+
+# Repository url used to install HA/SAP deployment packages
+# The latest RPM packages can be found at:
+# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
+ha_sap_deployment_repo = "https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_%SLE_VERSION%"
+
+# Optional SUSE Customer Center Registration parameters
+#reg_code = "<<REG_CODE>>"
+#reg_email = "<<your email>>"
+#reg_additional_modules = {
+#    "sle-module-adv-systems-management/12/x86_64" = ""
+#    "sle-module-containers/12/x86_64" = ""
+#    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
+#}
+reg_code = "%SCC_REGCODE_SLES4SAP%"
+
+# Cost optimized scenario
+#scenario_type: "cost-optimized"
+
+# To disable the provisioning process
+#provisioner = ""
+
+# Run provisioner execution in background
+#background = "true"
+
+# Monitoring variables
+
+# Enable the host to be monitored by exporters
+monitoring_enabled = "false"
+
+# IP address of the machine where prometheus and grafana are running
+#monitoring_srv_ip = "10.74.1.13"
+
+# QA variables
+
+# Define if the deployment is using for testing purpose
+# Disable all extra packages that do not come from the image
+# Except salt-minion (for the moment) and salt formulas
+# true or false
+qa_mode = "true"
+
+# Execute HANA Hardware Configuration Check Tool to bench filesystems
+# qa_mode must be set to true for executing hwcct
+# true or false (default)
+#hwcct = false

--- a/data/publiccloud/terraform/sap/ec2.tfvars
+++ b/data/publiccloud/terraform/sap/ec2.tfvars
@@ -1,0 +1,96 @@
+# Launch SLES-HAE of SLES4SAP cluster nodes
+
+# Instance type to use for the cluster nodes
+instancetype = "%MACHINE_TYPE%"
+
+# Disk type for HANA
+hana_data_disk_type = "gp2"
+
+# Number of nodes in the cluster
+ninstances = "2"
+
+# Region where to deploy the configuration
+aws_region = "%REGION%"
+
+# SSH private key file
+private_key_location = "~/.ssh/id_rsa"
+
+# SSH public key file
+public_key_location = "~/.ssh/id_rsa.pub"
+
+# Custom AMI for nodes
+sles4sap = {
+    "%REGION%" = "%SLE_IMAGE%"
+}
+
+# aws-cli credentials file. Located on ~/.aws/credentials on Linux, MacOS or Unix or at C:\Users\USERNAME\.aws\credentials on Windows
+aws_credentials = "/root/amazon_credentials"
+
+# Hostname, without the domain part
+name = "hana"
+
+# S3 bucket where HANA installation master is located
+hana_inst_master = "%HANA_BUCKET%"
+
+# Local folder where HANA installation master will be downloaded from S3
+hana_inst_folder = "/root/sap_inst/"
+
+# Device used by node where HANA will be installed
+hana_disk_device = "/dev/xvdd"
+
+# Variable for init-nodes.tpl script. Can be all, skip-hana or skip-cluster
+init_type = "all"
+
+# Device used by the iSCSI server to provide LUNs
+iscsidev = "/dev/xvdd"
+
+# Path to a custom ssh public key to upload to the nodes
+# Used for cluster communication for example
+cluster_ssh_pub = "salt://hana_node/files/sshkeys/cluster.id_rsa.pub"
+
+# Path to a custom ssh private key to upload to the nodes
+# Used for cluster communication for example
+cluster_ssh_key = "salt://hana_node/files/sshkeys/cluster.id_rsa"
+
+# Each host IP address (sequential order).
+# example : host_ips = ["10.0.1.0", "10.0.1.1"]
+host_ips = ["10.0.1.0", "10.0.1.1"]
+
+# Repository url used to install install HA/SAP deployment packages (OS version must be ommited)"
+# Contains the salt formulas
+ha_sap_deployment_repo = "https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_%SLE_VERSION%"
+
+# Optional SUSE Customer Center Registration parameters
+#reg_code = "<<REG_CODE>>"
+#reg_email = "<<your email>>"
+#reg_additional_modules = {
+#    "sle-module-adv-systems-management/12/x86_64" = ""
+#    "sle-module-containers/12/x86_64" = ""
+#    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
+#}
+reg_code = "%SCC_REGCODE_SLES4SAP%"
+
+# To disable the provisioning process
+#provisioner = ""
+
+# Run provisioner execution in background
+#background = "true"
+
+# Enable the host to be monitored by exporters
+monitoring_enabled = "false"
+
+# IP address of the machine where Prometheus and Grafana are running
+#monitoring_srv_ip = "10.0.1.2"
+
+# QA variables
+
+# Define if the deployement is using for testing purpose
+# Disable all extra packages that do not come from the image
+# Except salt-minion (for the moment) and salt formulas
+# true or false
+qa_mode = "true"
+
+# Execute HANA Hardware Configuration Check Tool to bench filesystems
+# qa_mode must be set to true for executing hwcct
+# true or false (default)
+#hwcct = false

--- a/data/publiccloud/terraform/sap/gce.tfvars
+++ b/data/publiccloud/terraform/sap/gce.tfvars
@@ -1,0 +1,99 @@
+# Launch SLES-HAE of SLES4SAP cluster nodes
+
+# Project name in GCP
+project = "suse-css-qa"
+
+# Credentials file for GCP
+gcp_credentials_file = "/root/google_credentials.json"
+
+# Internal IPv4 range
+ip_cidr_range = "10.0.0.0/24"
+
+# IP for iSCSI server
+iscsi_ip = "10.0.0.253"
+
+# Type of VM (vCPUs and RAM)
+machine_type = "%MACHINE_TYPE%"
+
+# Disk type for HANA
+hana_data_disk_type = "pd-ssd"
+
+# SSH private key file
+private_key_location = "~/.ssh/id_rsa"
+
+# SSH public key file
+public_key_location = "~/.ssh/id_rsa.pub"
+
+# Region where to deploy the configuration
+region = "%REGION%"
+
+# Variable for init-nodes.tpl script. Can be all, skip-hana or skip-all
+init_type = "all"
+
+# The name of the GCP storage bucket in your project that contains the SAP HANA installation files
+sap_hana_deployment_bucket = "%HANA_BUCKET%"
+
+# Custom sles4sap image
+sles4sap_os_image_file = "%SLE_IMAGE%"
+
+# Device used by the iSCSI server to provide LUNs
+iscsidev = "/dev/sdb"
+
+# Path to a custom ssh public key to upload to the nodes
+# Used for cluster communication for example
+cluster_ssh_pub = "salt://hana_node/files/sshkeys/cluster.id_rsa.pub"
+
+# Path to a custom ssh private key to upload to the nodes
+# Used for cluster communication for example
+cluster_ssh_key = "salt://hana_node/files/sshkeys/cluster.id_rsa"
+
+# Each host IP address (sequential order).
+# example : host_ips = ["10.0.0.2", "10.0.0.3"]
+host_ips = ["10.0.0.2", "10.0.0.3"]
+
+# Local folder where HANA installation master will be mounted
+hana_inst_folder = "/root/sap_inst/"
+
+# Device used by node where HANA will be installed
+hana_disk_device = "/dev/sdb"
+
+# Device used by node where HANA will be downloaded
+hana_inst_disk_device = "/dev/sdc"
+
+# HA packages Repository
+ha_sap_deployment_repo = "https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_%SLE_VERSION%"
+
+# Optional SUSE Customer Center Registration parameters
+#reg_code = "<<REG_CODE>>"
+#reg_email = "<<your email>>"
+#reg_additional_modules = {
+#    "sle-module-adv-systems-management/12/x86_64" = ""
+#    "sle-module-containers/12/x86_64" = ""
+#    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
+#}
+reg_code = "%SCC_REGCODE_SLES4SAP%"
+
+# To disable the provisioning process
+#provisioner = ""
+
+# Run provisioner execution in background
+#background = "true"
+
+# Enable the host to be monitored by exporters
+monitoring_enabled = "false"
+
+# IP address of the machine where Prometheus and Grafana are running
+#monitoring_srv_ip = "10.0.0.4"
+
+# QA variables
+
+# Define if the deployment is using for testing purpose
+# Disable all extra packages that do not come from the image
+# Except salt-minion (for the moment) and salt formulas
+# true or false
+qa_mode = "true"
+
+# Execute HANA Hardware Configuration Check Tool to bench filesystems
+# qa_mode must be set to true for executing hwcct
+# true or false (default)
+#hwcct = false

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2653,6 +2653,9 @@ sub load_publiccloud_tests {
     elsif (get_var('PUBLIC_CLOUD_LTP')) {
         loadtest 'publiccloud/run_ltp';
     }
+    elsif (get_var('PUBLIC_CLOUD_SLES4SAP')) {
+        loadtest 'publiccloud/sles4sap';
+    }
     elsif (get_var('PUBLIC_CLOUD_ACCNET')) {
         loadtest 'publiccloud/az_accelerated_net';
     }

--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -183,7 +183,7 @@ sub img_proof {
     return $self->run_img_proof(%args);
 }
 
-sub on_terraform_timeout {
+sub on_terraform_apply_timeout {
     my ($self) = @_;
     my $out = script_output('terraform state show azurerm_resource_group.openqa-group');
     if ($out !~ /name\s+=\s+(openqa-[a-z0-9]+)/m) {
@@ -209,6 +209,17 @@ sub on_terraform_timeout {
         }
     }
 
+    assert_script_run("az group delete --yes --no-wait --name $resgroup");
+}
+
+sub on_terraform_destroy_timeout {
+    my ($self) = @_;
+    my $out = script_output('terraform state show azurerm_resource_group.openqa-group');
+    if ($out !~ /name\s+=\s+(openqa-[a-z0-9]+)/m) {
+        record_info('ERROR', 'Unable to get resource-group:' . $/ . $out, result => 'fail');
+        return;
+    }
+    my $resgroup = $1;
     assert_script_run("az group delete --yes --no-wait --name $resgroup");
 }
 

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -194,5 +194,4 @@ sub start_instance
     $instance->public_ip($self->get_ip_from_instance($instance));
 }
 
-
 1;

--- a/lib/publiccloud/instance.pm
+++ b/lib/publiccloud/instance.pm
@@ -108,14 +108,12 @@ Upload a file from this instance to openqa using L<upload_logs()>.
 If the file doesn't exists on the instance, B<no> error is thrown.
 =cut
 sub upload_log {
-    my ($self, $remote_file) = @_;
+    my ($self, $remote_file, %args) = @_;
 
     my $tmpdir = script_output('mktemp -d');
     my $dest   = $tmpdir . '/' . basename($remote_file);
     my $ret    = $self->scp('remote:' . $remote_file, $dest);
-    if (defined($ret) && $ret == 0) {
-        upload_logs($dest);
-    }
+    upload_logs($dest, %args) if (defined($ret) && $ret == 0);
     assert_script_run("test -d '$tmpdir' && rm -rf '$tmpdir'");
 }
 

--- a/tests/publiccloud/sles4sap.pm
+++ b/tests/publiccloud/sles4sap.pm
@@ -1,0 +1,58 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test public cloud SLES4SAP images
+#
+# Maintainer: Loic Devulder <ldevulder@suse.de>
+
+use Mojo::Base 'publiccloud::basetest';
+use testapi;
+use Mojo::File 'path';
+use Mojo::JSON;
+
+sub upload_ha_sap_logs {
+    my ($self, $instance) = @_;
+    my @logfiles = qw(provisioning.log salt-deployment.log salt-formula.log salt-pre-installation.log);
+
+    # Upload logs from public cloud VM
+    $instance->run_ssh_command(cmd => 'sudo chmod o+r /tmp/*.log');
+    foreach my $file (@logfiles) {
+        $instance->upload_log("/tmp/$file", log_name => $instance->{instance_id});
+    }
+}
+
+sub run {
+    my ($self) = @_;
+
+    $self->select_serial_terminal;
+
+    my $provider = $self->provider_factory();
+    foreach my $instance ($provider->create_instances(check_connectivity => 1)) {
+        $self->upload_ha_sap_logs($instance);
+    }
+}
+
+1;
+
+=head1 Discussion
+
+This module is used to test public cloud SLES4SAP images.
+Logs are uploaded at the end.
+
+=head1 Configuration
+
+=head2 PUBLIC_CLOUD_SLES4SAP
+
+If set, this test module is added to the job.
+
+=head2 PUBLIC_CLOUD_VAULT_NAMESPACE
+
+Set the needed namespace, e.g. B<qa-shap>
+
+=cut

--- a/tests/publiccloud/upload_image.pm
+++ b/tests/publiccloud/upload_image.pm
@@ -43,7 +43,6 @@ sub test_flags {
     return {fatal => 1};
 }
 
-
 1;
 
 =head1 Discussion


### PR DESCRIPTION
This commit adds support for SLES4SAP images on Public Cloud tests.

This version has been tested on AWS. Other providers will follow.

- Related ticket: https://progress.opensuse.org/issues/57140
- Needles: N/A
- Verification run: http://1b210.qa.suse.de/tests/6124 (on AWS)
- Regression runs: [publiccloud_boottime@ec2_t2.large](http://1b210.qa.suse.de/tests/6125), [publiccloud_boottime@gce_n1_standard_2](http://1b210.qa.suse.de/tests/6122), [publiccloud_boottime@az_Standard_A2_v2](http://1b210.qa.suse.de/tests/6126)

GCP and Azure will do done in another PR if changes will be needed.