### PR TITLE
Use zypper_call instead of script_retry to pass on exit 0

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -498,6 +498,10 @@ sub zypper_call {
         $ret = script_run("zypper -n $command $printer; ( exit \${PIPESTATUS[0]} )", $timeout);
         die "zypper did not finish in $timeout seconds" unless defined($ret);
         if ($ret == 4) {
+            if ($command =~ /^in.*java-\*$/ && script_run('grep "do not install java-" /var/log/zypper.log') == 0) {
+                record_soft_failure 'bsc#1137466';
+                last;
+            }
             if (script_run('grep "Error code.*502" /var/log/zypper.log') == 0) {
                 record_soft_failure 'Retrying because of error 502 - bsc#1070851';
             }

--- a/tests/console/java.pm
+++ b/tests/console/java.pm
@@ -30,8 +30,7 @@ sub run {
     pkcon_quit;
 
     if (check_var("DISTRI", "sle")) {
-        if (script_retry('zypper -n in --auto-agree-with-licenses java-*', timeout => 500, expect => 4, retry => 5) == 4) {
-            record_soft_failure 'bsc#1137466';
+        if (zypper_call('in --auto-agree-with-licenses java-*', timeout => 500, exitcode => [0, 4])) {
             # install only java-11-openjdk* & java-*-ibm*
             zypper_call('in --auto-agree-with-licenses java-11-openjdk* java-*-ibm*');
         }


### PR DESCRIPTION
Move record_soft_failure into zypper_call as exception for this java bug is needed

- Verification run:
http://10.100.12.155/tests/13301
http://10.100.12.155/tests/13300
