### PR TITLE
Extend soft-failure to SLE-15+ and Tumbleweed

### DIFF
--- a/tests/kernel/tuned.pm
+++ b/tests/kernel/tuned.pm
@@ -16,6 +16,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use version_utils qw(is_sle is_tumbleweed);
 
 sub tuned_set_profile {
     my $tuned_profile = shift;
@@ -27,9 +28,10 @@ sub run {
     my $self      = shift;
     my $tuned_log = '/var/log/tuned/tuned.log';
     # Already known errors with bug reference
-    my %known_errors = (
-        bsc_1148789 => 'Executing cpupower error: Error setting perf-bias value on CPU'
-    );
+    my %known_errors;
+    $known_errors{bsc_1148789} = 'Executing cpupower error: Error setting perf-bias value on CPU' if is_sle '<15';
+    $known_errors{bsc_1148789} = 'Failed to set energy_perf_bias on cpu' if (is_sle('>=15') || is_tumbleweed);
+
     select_console 'root-console';
     # Install tuned package
     zypper_call 'in tuned';


### PR DESCRIPTION
Fix poo#56615: Soft-failure has different error on SLE-15+
and Tumbleweed. Added possibility to have same bug reference
for same error for different versions.

- Related ticket: https://progress.opensuse.org/issues/56615
- Needles: 
- Verification run: 
SLE12-SP5: http://10.100.12.105/tests/3203#step/tuned/27
SLE15-SP2: http://10.100.12.105/tests/3202#step/tuned/27
Tumbleweed: http://10.100.12.105/tests/3201#step/tuned/27
