### PR TITLE
Allow vagrant tests to run on aarch64 too

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2495,9 +2495,13 @@ sub load_virtualization_tests {
     # reboot the machine to kill the previously started virtual machines
     loadtest "console/console_reboot";
 
-    # the tests currently require x86 & Tumbleweed
+    # the virtualbox tests require x86_64 & Tumbleweed
     if (is_x86_64 && is_tumbleweed) {
         loadtest "virtualization/vagrant/add_box_virtualbox";
+    }
+
+    # libvirt works on aarch64 and x86_64
+    if ((is_aarch64 || is_x86_64) && is_tumbleweed) {
         loadtest "virtualization/vagrant/add_box_libvirt";
         loadtest "virtualization/vagrant/boxes/tumbleweed";
     }

--- a/tests/virtualization/vagrant/add_box_libvirt.pm
+++ b/tests/virtualization/vagrant/add_box_libvirt.pm
@@ -35,7 +35,7 @@ sub run() {
 
     assert_script_run('echo "test" > testfile');
 
-    assert_script_run('vagrant init centos/7');
+    assert_script_run('vagrant init dcermak/Tumbleweed.' . get_required_var('ARCH'));
 
     assert_script_run('vagrant up', timeout => 1200);
 

--- a/tests/virtualization/vagrant/boxes/tumbleweed.pm
+++ b/tests/virtualization/vagrant/boxes/tumbleweed.pm
@@ -26,24 +26,32 @@ use File::Basename;
 
 
 sub run() {
+    # version = Tumbleweed, Leap 15 etc
+    my $version = get_required_var('VERSION');
+    my $arch    = get_required_var('ARCH');
+    my $build   = get_required_var('BUILD');
+
     setup_vagrant_libvirt();
-    setup_vagrant_virtualbox();
+    if ($arch eq 'x86_64') {
+        setup_vagrant_virtualbox();
+    }
 
     select_console('root-console');
     zypper_call('in ansible');
 
     select_console('user-console');
 
-    # version = Tumbleweed, Leap 15 etc
-    my $version = get_required_var('VERSION');
-    my $arch    = get_required_var('ARCH');
-    my $build   = get_required_var('BUILD');
-
-    my %boxes = (
-        # openSUSE-Tumbleweed-Vagrant.x86_64-1.0-{libvirt|virtualbox}-Snapshot20190704.vagrant.{libvirt|virtualbox}.box
-        libvirt    => "openSUSE-$version-Vagrant.$arch-1.0-libvirt-Snapshot$build.vagrant.libvirt.box",
-        virtualbox => "openSUSE-$version-Vagrant.$arch-1.0-virtualbox-Snapshot$build.vagrant.virtualbox.box"
-    );
+    # for x86_64:
+    # Tumbleweed.x86_64-1.0-{libvirt|virtualbox}-Snapshot20190704.vagrant.{libvirt|virtualbox}.box
+    # for aarch64:
+    # Tumbleweed.aarch64-1.0-libvirt_aarch64-Snapshot20190920.vagrant.libvirt.box
+    my %boxes = ();
+    if ($arch eq 'x86_64') {
+        $boxes{libvirt}    = "$version.$arch-1.0-libvirt-Snapshot$build.vagrant.libvirt.box";
+        $boxes{virtualbox} = "$version.$arch-1.0-virtualbox-Snapshot$build.vagrant.virtualbox.box";
+    } elsif ($arch eq 'aarch64') {
+        $boxes{libvirt} = "$version.$arch.-1.0-libvirt_$arch-Snapshot$build.vagrant.libvirt.box";
+    }
 
     my @providers = keys %boxes;
 


### PR DESCRIPTION
Modify the current tests related to vagrant to allow to run on aarch64 too

- Related ticket: None
- Needles: no changes required
- Verification run: ~~https://openqa.opensuse.org/tests/1036715 (x86_64)~~ https://openqa.opensuse.org/tests/1039372 (x86_64), https://openqa.opensuse.org/tests/1039373 (aarch64)
