### PR TITLE
HA: Add fencing test from HAWK

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -319,7 +319,7 @@ sub check_cluster_state {
     assert_script_run "$crm_mon_cmd";
     assert_script_run "$crm_mon_cmd | grep -i 'no inactive resources'" if is_sle '12-sp3+';
     assert_script_run 'crm_mon -1 | grep \'partition with quorum\'';
-    assert_script_run 'crm_mon -s | grep "$(crm node list | wc -l) nodes online"';
+    assert_script_run q/crm_mon -s | grep "$(crm node list | grep -c ': member') nodes online"/;
     # As some options may be deprecated, test shouldn't die on 'crm_verify'
     if (get_var('HDDVERSION')) {
         script_run 'crm_verify -LV';

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2810,12 +2810,16 @@ sub load_ha_cluster_tests {
             return 1;
         }
 
-        # Test Haproxy
-        loadtest 'ha/haproxy' if (get_var('HA_CLUSTER_HAPROXY'));
-
         # If testing HAWK's GUI or HAPROXY, skip the rest of the cluster
         # setup tests and only check logs
         if (get_var('HAWKGUI_TEST_ROLE') or get_var('HA_CLUSTER_HAPROXY')) {
+            if (get_var('HAWKGUI_TEST_ROLE')) {
+                # Node1 will be fenced
+                boot_hdd_image if get_var('HA_CLUSTER_INIT');
+                loadtest 'ha/check_after_reboot';
+            }
+            # Test Haproxy
+            loadtest 'ha/haproxy' if (get_var('HA_CLUSTER_HAPROXY'));
             loadtest 'ha/check_logs' if !get_var('INSTALLONLY');
             return 1;
         }

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -106,6 +106,7 @@ sub run {
         # HAWK_GUI_ barriers also have to wait in the client
         barrier_create("HAWK_GUI_INIT_$cluster_name",    $num_nodes + 1);
         barrier_create("HAWK_GUI_CHECKED_$cluster_name", $num_nodes + 1);
+        barrier_create("HAWK_FENCE_$cluster_name",       $num_nodes + 1);
 
         # Create barriers for multiple tests
         foreach my $fs_tag ('LUN', 'CLUSTER_MD', 'DRBD_PASSIVE', 'DRBD_ACTIVE') {

--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -87,6 +87,8 @@ sub run {
 
     # Synchronize all nodes
     barrier_wait("CHECK_AFTER_REBOOT_END_$cluster_name");
+
+    barrier_wait("HAWK_FENCE_$cluster_name") if (check_var('HAWKGUI_TEST_ROLE', 'server'));
 }
 
 1;

--- a/tests/ha/hawk_gui.pm
+++ b/tests/ha/hawk_gui.pm
@@ -45,9 +45,9 @@ sub run {
     select_console 'root-console';
     install_docker;
 
-    # TODO: Use another namespace in DockerHub
-    my $docker_image = "registry.suse.de/home/rbranco/branches/opensuse.org/opensuse/templates/images/tumbleweed/containers/hawk_test";
-    assert_script_run("docker pull $docker_image", 120);
+    # TODO: Use another namespace using team group name
+    my $docker_image = "registry.opensuse.org/home/rbranco/branches/opensuse/templates/images/tumbleweed/containers/hawk_test";
+    assert_script_run("docker pull $docker_image", 240);
 
     select_console 'x11';
     x11_start_program('xterm');
@@ -59,17 +59,19 @@ sub run {
     # Run test
     my $browser    = 'firefox';
     my $version    = get_required_var('VERSION');
-    my $hostname   = choose_node(1);
+    my $node1      = choose_node(1);
+    my $node2      = choose_node(2);
     my $results    = "$path/$pyscr.results";
     my $retcode    = "$path/$pyscr.ret";
     my $logs       = "$path/$pyscr.log";
     my $virtual_ip = "10.0.2.222/24";
 
-    add_to_known_hosts($hostname);
+    add_to_known_hosts($node1);
+    add_to_known_hosts($node2);
     assert_script_run "mkdir -m 1777 $path";
     assert_script_run "xhost +";
     my $docker_cmd = "docker run --rm --name test --ipc=host -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=\$DISPLAY -v \$PWD/$path:/$path ";
-    $docker_cmd .= "$docker_image -b $browser -t $version -H $hostname -s $testapi::password -r /$results --virtual-ip $virtual_ip";
+    $docker_cmd .= "$docker_image -b $browser -t $version -H $node1 -S $node2 -s $testapi::password -r /$results --virtual-ip $virtual_ip";
     type_string "$docker_cmd | tee $logs; echo $pyscr-\$PIPESTATUS > $retcode\n";
     assert_screen "hawk-$browser", 60;
 
@@ -121,6 +123,9 @@ sub run {
 
     # Synchronize with the nodes
     barrier_wait("HAWK_GUI_CHECKED_$cluster_name");
+
+    # Wait for master node to reboot
+    barrier_wait("HAWK_FENCE_$cluster_name");
 }
 
 1;


### PR DESCRIPTION
This PR adds a fencing test from HAWK

A `--slave` (`-S`) option was added to hawk_test so Firefox connects to the slave instance to trigger the fencing.

Verification run: http://ix64hae1001.qa.suse.de./tests/996