### PR TITLE
Adapt yast2_lan_device_settings test module for 15-SP2

### DIFF
--- a/tests/console/yast2_lan_device_settings.pm
+++ b/tests/console/yast2_lan_device_settings.pm
@@ -96,7 +96,7 @@ sub run {
     send_key "tab";
 
     # open device type drop down and select vlan
-    if (is_tumbleweed || is_leap('15.2+')) {
+    if (is_tumbleweed || is_leap('15.2+') || is_sle('15-SP2+')) {
         send_key "alt-v";
     }
     else {


### PR DESCRIPTION
This just brings the behaviour of Leap 15.2 to SLES 15.2 (And reasons why factory first works!)

* Ticket: https://progress.opensuse.org/issues/57146
* Verification run: https://openqa.suse.de/tests/3386984
* Fixes: https://openqa.suse.de/tests/3380425
* Needle: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/commit/2ebe031f02f60e83f31522f51c2b906170e64a72