### PR TITLE
Enable extra tests for SDK module

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1666,6 +1666,10 @@ sub load_extra_tests_phub {
     loadtest 'sysauth/sssd';
 }
 
+sub load_extra_tests_sdk {
+    loadtest 'console/gdb';
+}
+
 sub load_extra_tests_docker {
     my ($image_names, $stable_names) = get_suse_container_urls();
     return unless @$image_names;


### PR DESCRIPTION
These changes allows to schedule sdk related test modules using the setting EXTRATEST=$EXTRATEST,sdk.
Valid for extra_tests_* and mau-extratests and any other test suite that needs to schedule these modules.

- Related ticket: https://progress.opensuse.org/issues/57101
- Verification runs:
  - Still scheduled on SLE mau-extratests: http://openqa.slindomansilla-vm.qa.suse.de/tests/1660/file/autoinst-log.txt
  - Not scheduled on SLE extra_tests_in_textmode: http://openqa.slindomansilla-vm.qa.suse.de/tests/1662/file/autoinst-log.txt
  - Scheduled on openSUSE extra_tests_in_textmode:
    - Tumbleweed: http://openqa.slindomansilla-vm.qa.suse.de/tests/1677/file/autoinst-log.txt
    - Leap 15.2: http://openqa.slindomansilla-vm.qa.suse.de/tests/1682/file/autoinst-log.txt
  - Scheduled on extra_tests_sdk: http://openqa.slindomansilla-vm.qa.suse.de/tests/1684