### PR TITLE
Add HA tests for s390x on zKVM without support server

### DIFF
--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -61,10 +61,10 @@ our @EXPORT = qw(
 
 # Global variables
 our $crm_mon_cmd     = 'crm_mon -R -r -n -N -1';
-our $softdog_timeout = 60 * get_var('TIMEOUT_SCALE', 1);
+our $softdog_timeout = bmwqemu::scale_timeout(60);
 our $prev_console;
-our $join_timeout    = 60 * get_var('TIMEOUT_SCALE', 1);
-our $default_timeout = 30 * get_var('TIMEOUT_SCALE', 1);
+our $join_timeout    = bmwqemu::scale_timeout(60);
+our $default_timeout = bmwqemu::scale_timeout(30);
 
 sub exec_csync {
     # Sometimes we need to run csync2 twice to have all the files updated!
@@ -333,7 +333,7 @@ sub check_cluster_state {
 sub wait_until_resources_started {
     my %args    = @_;
     my @cmds    = ('crm cluster wait_for_startup');
-    my $timeout = ($args{timeout} // 120) * get_var('TIMEOUT_SCALE', 1);
+    my $timeout = bmwqemu::scale_timeout($args{timeout} // 120);
     my $ret     = undef;
 
     # Some CRM options can only been added on recent versions

--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -23,11 +23,14 @@ use x11utils 'ensure_unlocked_desktop';
 our @EXPORT = qw(
   $crm_mon_cmd
   $softdog_timeout
+  $join_timeout
+  $default_timeout
   exec_csync
   add_file_in_csync
   get_cluster_name
   get_hostname
   get_ip
+  get_my_ip
   get_node_to_join
   get_node_number
   is_node
@@ -58,8 +61,10 @@ our @EXPORT = qw(
 
 # Global variables
 our $crm_mon_cmd     = 'crm_mon -R -r -n -N -1';
-our $softdog_timeout = 60;
+our $softdog_timeout = 60 * get_var('TIMEOUT_SCALE', 1);
 our $prev_console;
+our $join_timeout    = 60 * get_var('TIMEOUT_SCALE', 1);
+our $default_timeout = 30 * get_var('TIMEOUT_SCALE', 1);
 
 sub exec_csync {
     # Sometimes we need to run csync2 twice to have all the files updated!
@@ -94,13 +99,25 @@ sub get_node_to_join {
     return get_required_var('HA_CLUSTER_JOIN');
 }
 
-sub get_ip {
-    my $node_hostname = shift;
-    my $node_ip       = script_output "host -t A $node_hostname";
+sub _just_the_ip {
+    my $node_ip = shift;
     if ($node_ip =~ /(\d+\.\d+\.\d+\.\d+)/) {
         return $1;
     }
     return 0;
+}
+
+sub get_ip {
+    my $node_hostname = shift;
+    my $node_ip       = get_var('USE_SUPPORT_SERVER') ? script_output "host -t A $node_hostname" :
+      script_output "awk 'BEGIN {RET=1} /$node_hostname/ {print \$1; RET=0; exit} END {exit RET}' /etc/hosts";
+    return _just_the_ip($node_ip);
+}
+
+sub get_my_ip {
+    my $netdevice = get_var('SUT_NETDEVICE', 'eth0');
+    my $node_ip   = script_output "ip -4 addr show dev $netdevice | sed -rne '/inet/s/[[:blank:]]*inet ([0-9\\.]*).*/\\1/p'";
+    return _just_the_ip($node_ip);
 }
 
 sub get_node_number {
@@ -140,8 +157,8 @@ sub choose_node {
 }
 
 sub save_state {
-    script_run 'yes | crm configure show';
-    assert_script_run "$crm_mon_cmd";
+    script_run 'yes | crm configure show', $default_timeout;
+    assert_script_run "$crm_mon_cmd",      $default_timeout;
     save_screenshot;
 }
 
@@ -161,17 +178,16 @@ sub check_rsc {
 
 sub ensure_process_running {
     my $process   = shift;
-    my $timeout   = 30 * get_var('TIMEOUT_SCALE', 1);
     my $starttime = time;
     my $ret       = undef;
 
     while ($ret = script_run "ps -A | grep -q '\\<$process\\>'") {
         my $timerun = time - $starttime;
-        if ($timerun < $timeout) {
+        if ($timerun < $default_timeout) {
             sleep 5;
         }
         else {
-            die "Process '$process' did not start within $timeout seconds";
+            die "Process '$process' did not start within $default_timeout seconds";
         }
     }
 
@@ -181,17 +197,16 @@ sub ensure_process_running {
 
 sub ensure_resource_running {
     my ($rsc, $regex) = @_;
-    my $timeout   = 30 * get_var('TIMEOUT_SCALE', 1);
     my $starttime = time;
     my $ret       = undef;
 
-    while ($ret = script_run "crm resource status $rsc | grep -E -q '$regex'") {
+    while ($ret = script_run("crm resource status $rsc | grep -E -q '$regex'", $default_timeout)) {
         my $timerun = time - $starttime;
-        if ($timerun < $timeout) {
+        if ($timerun < $default_timeout) {
             sleep 5;
         }
         else {
-            die "Resource '$rsc' did not start within $timeout seconds";
+            die "Resource '$rsc' did not start within $default_timeout seconds";
         }
     }
 
@@ -332,7 +347,7 @@ sub wait_until_resources_started {
         my $starttime = time;
 
         # Check for cluster/resources status and exit loop when needed
-        while ($ret = script_run "$cmd") {
+        while ($ret = script_run("$cmd", $default_timeout)) {
             # Otherwise wait a while if timeout is not reached
             my $timerun = time - $starttime;
             if ($timerun < $timeout) {
@@ -352,14 +367,21 @@ sub wait_until_resources_started {
 sub get_lun {
     my %args          = @_;
     my $hostname      = get_hostname;
-    my $lun_list_file = '/tmp/' . get_cluster_name . '-lun.list';
+    my $cluster_name  = get_cluster_name;
+    my $lun_list_file = '/tmp/' . $cluster_name . '-lun.list';
     my $use_once      = $args{use_once} // 1;
+    my $supportdir    = get_var('NFS_SUPPORT_DIR', '/mnt');
 
     # Use mutex to be sure that only *one* node at a time can access the file
     mutex_lock 'iscsi';
 
     # Get the LUN file from the support server to have an up-to-date version
-    exec_and_insert_password "scp -o StrictHostKeyChecking=no root\@ns:$lun_list_file $lun_list_file";
+    if (get_var('USE_SUPPORT_SERVER')) {
+        exec_and_insert_password "scp -o StrictHostKeyChecking=no root\@ns:$lun_list_file $lun_list_file";
+    }
+    else {
+        assert_script_run "cp $supportdir/$cluster_name-lun.list $lun_list_file";
+    }
 
     # Extract the first *free* line for this server
     my $lun = script_output "grep -Fv '$hostname' $lun_list_file | awk 'NR==1 { print \$1 }'";
@@ -380,7 +402,12 @@ sub get_lun {
     }
 
     # Copy the modified file on the support server (for the other nodes)
-    exec_and_insert_password "scp -o StrictHostKeyChecking=no $lun_list_file root\@ns:$lun_list_file";
+    if (get_var('USE_SUPPORT_SERVER')) {
+        exec_and_insert_password "scp -o StrictHostKeyChecking=no $lun_list_file root\@ns:$lun_list_file";
+    }
+    else {
+        assert_script_run "cp $lun_list_file $supportdir/$cluster_name-lun.list";
+    }
 
     mutex_unlock 'iscsi';
 

--- a/tests/ha/check_logs.pm
+++ b/tests/ha/check_logs.pm
@@ -27,7 +27,7 @@ sub run {
         record_soft_failure "bsc#1150704 - 'crm script run health' is known to crash the cluster on SLES+HA 12-SP5+ on s390x";
     }
     else {
-        assert_script_run 'crm script run health', 240 * get_var('TIMEOUT_SCALE', 1);
+        assert_script_run 'crm script run health', bmwqemu::scale_timeout(240);
     }
 
     barrier_wait("LOGS_CHECKED_$cluster_name");

--- a/tests/ha/cluster_md.pm
+++ b/tests/ha/cluster_md.pm
@@ -45,11 +45,11 @@ sub run {
     if (is_node(1)) {
         # Create cluster-md device
         assert_script_run
-"mdadm --create $clustermd_device $clustermd_name_opt --bitmap=clustered --metadata=1.2 --raid-devices=2 --level=mirror $clustermd_lun_01 $clustermd_lun_02";
+"mdadm --create $clustermd_device $clustermd_name_opt --bitmap=clustered --metadata=1.2 --raid-devices=2 --level=mirror $clustermd_lun_01 $clustermd_lun_02", $default_timeout;
 
         # We need to create the configuration file on all nodes
-        assert_script_run "echo DEVICE $clustermd_lun_01 $clustermd_lun_02 > $mdadm_conf";
-        assert_script_run "mdadm --detail --scan >> $mdadm_conf";
+        assert_script_run "echo DEVICE $clustermd_lun_01 $clustermd_lun_02 > $mdadm_conf", $default_timeout;
+        assert_script_run "mdadm --detail --scan >> $mdadm_conf",                          $default_timeout;
 
         # We need to add the configuration in csync2.conf
         add_file_in_csync(value => "$mdadm_conf");
@@ -63,7 +63,7 @@ sub run {
 
     # We need to start the cluster-md device on all nodes but node01, as it still has the device started
     if (!is_node(1)) {
-        assert_script_run "mdadm -A $clustermd_device $clustermd_lun_01 $clustermd_lun_02";
+        assert_script_run "mdadm -A $clustermd_device $clustermd_lun_01 $clustermd_lun_02", $default_timeout;
     }
 
     # Wait until cluster-md device is started
@@ -72,8 +72,8 @@ sub run {
     if (is_node(1)) {
         # Create cluster-md resource
         assert_script_run
-"EDITOR=\"sed -ie '\$ a primitive $clustermd_rsc ocf:heartbeat:Raid1 params raiddev=auto force_clones=true raidconf=$mdadm_conf'\" crm configure edit";
-        assert_script_run "EDITOR=\"sed -ie 's/^\\(group base-group.*\\)/\\1 $clustermd_rsc/'\" crm configure edit";
+"EDITOR=\"sed -ie '\$ a primitive $clustermd_rsc ocf:heartbeat:Raid1 params raiddev=auto force_clones=true raidconf=$mdadm_conf'\" crm configure edit", $default_timeout;
+        assert_script_run "EDITOR=\"sed -ie 's/^\\(group base-group.*\\)/\\1 $clustermd_rsc/'\" crm configure edit", $default_timeout;
     }
     else {
         diag 'Wait until cluster-md resource is created...';

--- a/tests/ha/dlm.pm
+++ b/tests/ha/dlm.pm
@@ -28,9 +28,9 @@ sub run {
 
     if (is_node(1)) {
         # Create DLM resource
-        assert_script_run 'EDITOR="sed -ie \'$ a primitive dlm ocf:pacemaker:controld\'" crm configure edit';
-        assert_script_run 'EDITOR="sed -ie \'$ a group base-group dlm\'" crm configure edit';
-        assert_script_run 'EDITOR="sed -ie \'$ a clone base-clone base-group\'" crm configure edit';
+        assert_script_run 'EDITOR="sed -ie \'$ a primitive dlm ocf:pacemaker:controld\'" crm configure edit', $default_timeout;
+        assert_script_run 'EDITOR="sed -ie \'$ a group base-group dlm\'" crm configure edit',                 $default_timeout;
+        assert_script_run 'EDITOR="sed -ie \'$ a clone base-clone base-group\'" crm configure edit',          $default_timeout;
     }
     else {
         diag 'Wait until DLM resource is created...';

--- a/tests/ha/drbd_passive.pm
+++ b/tests/ha/drbd_passive.pm
@@ -87,7 +87,8 @@ sub run {
     barrier_wait("DRBD_CREATE_CONF_$cluster_name");
 
     # Create the DRBD device
-    assert_script_run "drbdadm create-md $drbd_rsc";
+    my $force = get_var('USE_SUPPORT_SERVER') ? '' : '--force';    # force the md creation if reusing luns
+    assert_script_run "drbdadm create-md $force $drbd_rsc";
     assert_script_run "drbdadm up $drbd_rsc";
 
     # Wait for first node to complete its configuration

--- a/tests/ha/drbd_passive.pm
+++ b/tests/ha/drbd_passive.pm
@@ -87,8 +87,7 @@ sub run {
     barrier_wait("DRBD_CREATE_CONF_$cluster_name");
 
     # Create the DRBD device
-    my $force = get_var('USE_SUPPORT_SERVER') ? '' : '--force';    # force the md creation if reusing luns
-    assert_script_run "drbdadm create-md $force $drbd_rsc";
+    assert_script_run "drbdadm create-md --force $drbd_rsc";
     assert_script_run "drbdadm up $drbd_rsc";
 
     # Wait for first node to complete its configuration

--- a/tests/ha/ha_cluster_init.pm
+++ b/tests/ha/ha_cluster_init.pm
@@ -25,7 +25,6 @@ sub run {
     my $sbd_device    = get_lun;
     my $unicast_opt   = get_var("HA_UNICAST") ? '-u' : '';
     my $quorum_policy = 'stop';
-    my $join_timeout  = 60;
     my $fencing_opt   = "-s $sbd_device";
 
     # If we failed to initialize the cluster, trying again but in debug mode

--- a/tests/ha/ha_cluster_join.pm
+++ b/tests/ha/ha_cluster_join.pm
@@ -27,11 +27,11 @@ sub run {
 
     # Try to join the HA cluster through first node
     assert_script_run "ping -c1 $node_to_join";
-    type_string "ha-cluster-join -yc $node_to_join\n";
-    assert_screen 'ha-cluster-join-password';
+    type_string "ha-cluster-join -yc $node_to_join ; echo ha-cluster-join-finished-\$? > /dev/$serialdev\n";
+    assert_screen 'ha-cluster-join-password', $join_timeout;
     type_password;
     send_key 'ret';
-    wait_still_screen(stilltime => 10);
+    wait_serial("ha-cluster-join-finished-0", $join_timeout);
 
     # Indicate that the other nodes have joined the cluster
     barrier_wait("NODE_JOINED_$cluster_name");

--- a/tests/ha/iscsi_client.pm
+++ b/tests/ha/iscsi_client.pm
@@ -23,7 +23,7 @@ sub run {
 
     # Configuration of iSCSI client
     script_run("yast2 iscsi-client; echo yast2-iscsi-client-status-\$? > /dev/$serialdev", 0);
-    assert_screen 'iscsi-client-overview-service-tab';
+    assert_screen 'iscsi-client-overview-service-tab', $default_timeout;
     send_key 'alt-b';    # Start iscsi daemon on Boot
     wait_still_screen 3;
     send_key 'alt-i';    # Initiator name
@@ -35,13 +35,13 @@ sub run {
     wait_still_screen 3;
 
     # Go to Discovered Targets screen can take time
-    assert_screen 'iscsi-client-discovered-targets', 120;
-    send_key 'alt-d';    # Discovery
-    wait_still_screen 3;
+    assert_screen 'iscsi-client-discovered-targets',     120;
+    send_key_until_needlematch 'iscsi-client-discovery', 'alt-d';
     assert_screen 'iscsi-client-discovery';
     send_key 'alt-i';    # Ip address
     wait_still_screen 3;
-    type_string 'ns';
+    my $iscsi_server = get_var('USE_SUPPORT_SERVER') ? 'ns' : get_required_var('ISCSI_SERVER');
+    type_string $iscsi_server;
     wait_still_screen 3;
     send_key 'alt-n';    # Next
 
@@ -49,18 +49,16 @@ sub run {
     assert_screen 'iscsi-client-target-list';
     send_key 'alt-e';    # connEct
     assert_screen 'iscsi-client-target-startup';
-    wait_screen_change { send_key 'alt-s' };    # Startup
-    send_key 'down';
-    wait_still_screen 3;
-    send_key 'down';                            # Select 'automatic'
+    send_key_until_needlematch 'iscsi-client-target-startup-manual-selected',    'alt-s';
+    send_key_until_needlematch 'iscsi-client-target-startup-automatic-selected', 'down';
     assert_screen 'iscsi-client-target-startup-automatic-selected';
     send_key 'ret';
     wait_still_screen 3;
-    send_key 'alt-n';                           # Next
+    send_key 'alt-n';    # Next
 
     # Go to Discovered Targets screen can take time
     assert_screen 'iscsi-client-target-connected', 120;
-    send_key 'alt-o';                           # Ok
+    send_key 'alt-o';    # Ok
     wait_still_screen 3;
     wait_serial('yast2-iscsi-client-status-0', 90) || die "'yast2 iscsi-client' didn't finish";
 

--- a/tests/ha/remove_node.pm
+++ b/tests/ha/remove_node.pm
@@ -21,7 +21,7 @@ sub remove_state_join {
     my ($method, $cluster_name, $node_01, $node_02) = @_;
     my $remove_cmd = 'crm cluster remove -y -c';
     my $join_cmd   = 'crm cluster join -y -w /dev/watchdog -i ' . get_var('SUT_NETDEVICE', 'eth0') . ' -c';
-    my $timer      = 5 * get_var('TIMEOUT_SCALE', 1);
+    my $timer      = bmwqemu::scale_timeout(5);
 
     # Waiting for the other nodes to be ready
     barrier_wait("REMOVE_NODE_BY_" . "$method" . "_INIT_" . "$cluster_name");

--- a/tests/ha/remove_node.pm
+++ b/tests/ha/remove_node.pm
@@ -27,7 +27,7 @@ sub remove_state_join {
     barrier_wait("REMOVE_NODE_BY_" . "$method" . "_INIT_" . "$cluster_name");
 
     # Remove the second node
-    assert_script_run("$remove_cmd $node_02") if is_node(1);
+    assert_script_run("$remove_cmd $node_02", $default_timeout) if is_node(1);
     # Need to wait a bit for cluster configuration refresh
     sleep $timer;
 
@@ -35,10 +35,10 @@ sub remove_state_join {
     barrier_wait("REMOVE_NODE_BY_" . "$method" . "_DONE_" . "$cluster_name");
 
     # Show cluster status
-    is_node(2) ? script_run "$crm_mon_cmd" : save_state;
+    is_node(2) ? script_run("$crm_mon_cmd", $default_timeout) : save_state;
 
     # Second node needs to be reintegrated
-    assert_script_run("$join_cmd $node_01") if is_node(2);
+    assert_script_run("$join_cmd $node_01", 2 * $join_timeout) if is_node(2);
 
     # Synchronize all the nodes after the join
     barrier_wait("JOIN_NODE_BY_" . "$method" . "_DONE_" . "$cluster_name");

--- a/tests/ha/setup_hosts_and_luns.pm
+++ b/tests/ha/setup_hosts_and_luns.pm
@@ -16,7 +16,7 @@ use strict;
 use warnings;
 use testapi;
 use lockapi;
-use hacluster;
+use hacluster qw(get_cluster_name get_hostname get_my_ip is_node);
 
 sub run {
     my $nfs_share    = get_required_var('NFS_SUPPORT_SHARE');

--- a/tests/ha/setup_hosts_and_luns.pm
+++ b/tests/ha/setup_hosts_and_luns.pm
@@ -1,0 +1,84 @@
+# SUSE's openQA tests
+#
+# Copyright (c) 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Configure shared NFS mount point and /etc/hosts for HA
+#          tests with no supportserver
+# Maintainer: Alvaro Carvajal <acarvajal@suse.com>
+
+use base 'opensusebasetest';
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use hacluster;
+
+sub run {
+    my $nfs_share    = get_required_var('NFS_SUPPORT_SHARE');
+    my $mountpt      = '/support_fs';
+    my $cluster_name = get_cluster_name;
+    my $dir_id       = $cluster_name . '_' . get_required_var('ARCH');
+    my $time_to_wait;
+
+    set_var('NFS_SUPPORT_DIR', "$mountpt/$dir_id");
+    assert_script_run "mkdir -p $mountpt";
+    assert_script_run "mount -t nfs $nfs_share $mountpt";
+
+    if (is_node(1)) {
+        assert_script_run "rm -rf $mountpt/$dir_id";    # Remove info from previous test
+        assert_script_run "mkdir -p $mountpt/$dir_id";
+        barrier_wait("BARRIER_HA_NFS_SUPPORT_DIR_SETUP_$cluster_name");
+    }
+    else {
+        barrier_wait("BARRIER_HA_NFS_SUPPORT_DIR_SETUP_$cluster_name");
+    }
+
+    my $hostname = get_hostname;
+    my $ipaddr   = get_my_ip;
+    assert_script_run "echo \"$ipaddr  $hostname\" > $mountpt/$dir_id/$hostname.hosts";
+
+    barrier_wait("BARRIER_HA_HOSTS_FILES_READY_$cluster_name");
+    assert_script_run "sed -i '/$cluster_name/d' /etc/hosts";
+    assert_script_run "cat $mountpt/$dir_id/*.hosts >> /etc/hosts";
+    assert_script_run 'cat /etc/hosts';
+
+    # prepare LUN files. only node 1 does this
+    if (is_node(1)) {
+        my $cluster       = get_required_var('CLUSTER_INFOS');
+        my $iscsi_srv     = get_required_var('ISCSI_SERVER');
+        my $num_luns      = (split(/:/, $cluster))[2];
+        my $lun_list_file = "$mountpt/$dir_id/$cluster_name-lun.list";
+        my $index         = get_var('ISCSI_LUN_INDEX', 0);
+
+        assert_script_run "rm -f $lun_list_file ; touch $lun_list_file";
+
+        if (defined $num_luns) {
+            foreach my $i (0 .. ($num_luns - 1)) {
+                my $lun = "/dev/disk/by-path/ip-$iscsi_srv*-lun-" . ($i + $index);
+                assert_script_run "ls $lun >> $lun_list_file";
+                $lun = script_output 'echo \|$(ls ' . $lun . ')\|';
+                $lun =~ /\|([^\|]+)\|/;
+                $lun = $1;
+                assert_script_run "wipefs --all $lun";
+                assert_script_run "dd if=/dev/zero of=$lun bs=1M count=128";
+            }
+        }
+
+        assert_script_run "cat $lun_list_file";
+    }
+
+    barrier_wait("BARRIER_HA_LUNS_FILES_READY_$cluster_name");
+}
+
+# Override post_fail hook so it doesn't call ha_export_logs
+sub post_fail_hook {
+    my ($self) = @_;
+    save_screenshot;
+}
+
+1;


### PR DESCRIPTION
This moves several functions performed in the support server on HA tests such as the mutex and barrier creation, LUN list generation and name resolution from the support server to node 1 of the cluster setup when not using the support server.

As a result, HA test schedule is modified on such scenario.

Also included is:

- The definition of new default timeout values on `lib/hacluster` used to scale the timeout of several methods, and the creation of new variables `NFS_SUPPORT_DIR` and
`NFS_SUPPORT_SHARE` used as a shared communication method between nodes to share the LUN list file and the /etc/hosts.
- Verification of iSCSI configuration after reboot of cluster nodes.
- Soft fail on cluster health checkup on s390x with bsc#1150704.
- Use of `TIMEOUT_SCALE` in HA test modules.
- Use of external `ISCSI_SERVER` when not using support server.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1222
- Verification run on s390x/zKVM: [node 1](http://mango.suse.de/tests/1685) and [node 2](http://mango.suse.de/tests/1686).
- Regression tests on x86_64: [node 1](http://mango.suse.de/tests/1691), [node 2](http://mango.suse.de/tests/1692) and [support server](http://mango.suse.de/tests/1690)
