### PR TITLE
Fix raid_validate tw aarch NET

### DIFF
--- a/tests/console/validate_raid.pm
+++ b/tests/console/validate_raid.pm
@@ -95,7 +95,8 @@ sub prepare_test_data {
             $vfat_efi,
             $btrfs, $swap,
         );
-        if (is_sle('>=15-SP2') || is_sle('=12-SP5') || is_tumbleweed) {
+        if (is_sle('>=15-SP2') || is_sle('=12-SP5') ||
+            (is_tumbleweed() && !check_var('FLAVOR', 'NET'))) {
             @raid = ($raid_both_same_level, @raid_detail);
         }
         else {


### PR DESCRIPTION
Fix raid_validate tw aarch NET

- Related ticket: https://progress.opensuse.org/issues/56468
- Needles: n/a
- Verification run:
  - [opensuse-Tumbleweed-NET-aarch64-Build20190920-RAID10@aarch64](https://openqa.opensuse.org/t1038696)
