### PR TITLE
Cleanup suggested NIS servers also on SLES12

### DIFF
--- a/tests/console/yast2_nis.pm
+++ b/tests/console/yast2_nis.pm
@@ -50,10 +50,8 @@ sub run() {
     send_key_until_needlematch 'nis-domain-empty-field', 'backspace';    # clear NIS Domain field if it is prefilled
     type_string "suse.de";
     send_key 'alt-a';
-    #clear suggested NIS server adresses on SLE15+
-    if (is_sle '15+') {
-        for (1 .. 15) { send_key 'backspace'; }
-    }
+    #clear suggested NIS server adress
+    for (1 .. 15) { send_key 'backspace'; }
     wait_screen_change { type_string "10.162.0.1" };
     wait_screen_change { send_key 'alt-p' };                             # check Netconfif NIS Policy
     send_key 'up';


### PR DESCRIPTION
This clears the changes of reappearance of the fail in bellow link:
https://openqa.suse.de/tests/3391679
This includes SLES 12 on a form clearance.

- Related ticket: https://progress.opensuse.org/issues/56639
- Needles: None
- Verification run:
12.2: http://deathstar.suse.cz/tests/1190
15.0: http://deathstar.suse.cz/tests/1188
15.1: http://deathstar.suse.cz/tests/1189
12.3: http://deathstar.suse.cz/tests/1191
12.5: http://deathstar.suse.cz/tests/1193
12.4: http://deathstar.suse.cz/tests/1192
