### PR TITLE
Reorder Post fail hooks calls for first_boot test

### DIFF
--- a/lib/bootbasetest.pm
+++ b/lib/bootbasetest.pm
@@ -12,11 +12,15 @@ sub post_fail_hook {
 
     # if we found a shell, we do not need the memory dump
     if (!(match_has_tag('emergency-shell') or match_has_tag('emergency-mode'))) {
-        die "save_memory_dump not implemented, no way to save memory_dump" unless check_var('BACKEND', 'qemu');
-        select_console 'root-console';
-        diag 'Save memory dump to debug bootup problems, e.g. for bsc#1005313';
-        save_memory_dump;
-        record_info('Sucessfuly saved memory dump');
+        if (check_var('BACKEND', 'qemu')) {
+            select_console 'root-console';
+            diag 'Save memory dump to debug bootup problems, e.g. for bsc#1005313';
+            save_memory_dump;
+            record_info('Memory dumo', 'Memory dump available for this module');
+        } else {
+            record_info('No memory dump', 'save_memory_dump not implemented for ' . get_var('BACKEND', 'NO-BACKEND')
+                  . ', no way to save memory_dump');
+        }
     }
 
     # crosscheck for text login on tty1

--- a/lib/bootbasetest.pm
+++ b/lib/bootbasetest.pm
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 
 sub post_fail_hook {
+    my ($self) = @_;
     # check for text login to check if X has failed
     if (check_screen('generic-login')) {
         record_info 'Seems that the display manager failed';
@@ -25,9 +26,11 @@ sub post_fail_hook {
 
     # crosscheck for text login on tty1
     select_console 'root-console';
-
     # collect and upload some stuff
-    export_logs();
+    $self->export_logs();
+    # call parent's post fail hook
+    $self->SUPER::post_fail_hook;
+
 }
 
 1;

--- a/lib/bootbasetest.pm
+++ b/lib/bootbasetest.pm
@@ -12,11 +12,11 @@ sub post_fail_hook {
 
     # if we found a shell, we do not need the memory dump
     if (!(match_has_tag('emergency-shell') or match_has_tag('emergency-mode'))) {
-        die "save_memory_dump not working correctly, disabled as per https://progress.opensuse.org/issues/48671 and https://progress.opensuse.org/issues/42683";
         die "save_memory_dump not implemented, no way to save memory_dump" unless check_var('BACKEND', 'qemu');
         select_console 'root-console';
         diag 'Save memory dump to debug bootup problems, e.g. for bsc#1005313';
         save_memory_dump;
+        record_info('Sucessfuly saved memory dump');
     }
 
     # crosscheck for text login on tty1

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -102,8 +102,4 @@ sub test_flags {
     return {fatal => 1, milestone => 1};
 }
 
-sub post_fail_hook {
-    bootbasetest->post_fail_hook();
-}
-
 1;

--- a/tests/installation/first_boot.pm
+++ b/tests/installation/first_boot.pm
@@ -19,15 +19,13 @@
 # - Disable wayland
 # Maintainer: Max Lin <mlin@suse.com>
 
-use base 'y2_installbase';
 use strict;
 use warnings;
-use bootbasetest;
+use base 'bootbasetest';
 use testapi;
 use utils 'handle_emergency';
 use version_utils qw(is_sle is_leap is_desktop_installed is_upgrade is_sles4sap);
 use x11utils 'handle_login';
-use base 'opensusebasetest';
 use main_common 'opensuse_welcome_applicable';
 
 sub run {


### PR DESCRIPTION
Bring back and call again save_memory_dump when needed, and don't die if it's not implemented.

This ensures that we really get the logs, that should be needed for further investigation (if needed)

Verification run: 

 * https://openqa.suse.de/tests/3393456
 * https://openqa.suse.de/tests/3393481
Progress ticket: https://progress.opensuse.org/issues/42683
Related tests: https://openqa.suse.de/tests/overview?arch=&machine=&modules=first_boot&modules_result=failed&distri=sle&version=15-SP2&build=38.6&groupid=110#