### PR TITLE
Download the vm disk files to the backup location instead of the libv…

### DIFF
--- a/tests/virt_autotest/download_guest_assets.pm
+++ b/tests/virt_autotest/download_guest_assets.pm
@@ -21,6 +21,7 @@ use virt_utils;
 sub run {
     # download vm image and xml file from NFS location to skip installing guest
     my $vm_xml_dir = "/tmp/download_vm_xml";
+    set_var("GUEST_LIST", get_var("GUEST")) if get_var("GUEST");
     handle_sp_in_settings_with_fcs("GUEST_LIST");
     my $guest_list = get_required_var("GUEST_LIST");
     if (download_guest_assets($guest_list, $vm_xml_dir)) {

--- a/tests/virt_autotest/guest_migration_src.pm
+++ b/tests/virt_autotest/guest_migration_src.pm
@@ -103,8 +103,8 @@ sub run {
     my $upload_log_name = "guest-migration-src-logs";
 
     # clean up logs from prevous tests
+    $self->execute_script_run('[ -d /tmp/prj3_guest_migration/ ] && rm -rf /tmp/prj3_guest_migration/',     30) if !get_var('SKIP_GUEST_INSTALL');
     $self->execute_script_run('[ -d /var/log/qa/ctcs2/ ] && rm -r /var/log/qa/ctcs2/*',                     30);
-    $self->execute_script_run('[ -d /tmp/prj3_guest_migration/ ] && rm -rf /tmp/prj3_guest_migration/',     30);
     $self->execute_script_run('[ -d /tmp/prj3_migrate_admin_log/ ] && rm -rf /tmp/prj3_migrate_admin_log/', 30);
 
     $self->run_test($timeout, "", "no", "yes", "$log_dirs", "$upload_log_name");


### PR DESCRIPTION
…irt image dir avoid of NFS flush
the NFS mounting from dest job flushed up the /var/lib/libvirt/image/ directory. Trying umount whatever from dest job or the src job all failed to recover the stuff. It seems that the umount command in different shell or openQA script are unable to restore the original files before NFS sharing. So have to download the disk files to the backup dir directly.

- Related ticket: https://github.com/SUSE/qa-automation/pull/714
- Verification run:
virt-guest-migration-sles15sp1-from-developing-to-developing-xen-src http://10.67.18.148/tests/1078
