### PR TITLE
Add test module to disable screensaver

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -444,6 +444,7 @@ sub load_reboot_tests {
         # exclude this scenario for autoyast test with switched keyboard layaout
         loadtest "installation/first_boot" unless get_var('INSTALL_KEYBOARD_LAYOUT');
         loadtest "installation/opensuse_welcome" if opensuse_welcome_applicable();
+        load_system_prepare_tests();
         if (is_aarch64 && !get_var('INSTALLONLY') && !get_var('LIVE_INSTALLATION') && !get_var('LIVE_UPGRADE')) {
             loadtest "installation/system_workarounds";
         }
@@ -1077,7 +1078,6 @@ sub load_console_server_tests {
 sub load_consoletests {
     return unless consolestep_is_applicable();
     loadtest 'qa_automation/patch_and_reboot' if is_updates_tests && !get_var('QAM_MINIMAL');
-    loadtest "console/system_prepare";
     loadtest "console/check_network";
     loadtest "console/system_state";
     loadtest "console/prepare_test_data";
@@ -1102,13 +1102,11 @@ sub load_consoletests {
         loadtest "console/supportutils";
         loadtest "console/check_package_version" if check_var('UPGRADE_TARGET_VERSION', '12-SP5');
     }
-    loadtest "console/force_scheduled_tasks" unless is_jeos;
     if (get_var("LOCK_PACKAGE")) {
         loadtest "console/check_locked_package";
     }
     loadtest "console/textinfo";
     loadtest "console/rmt" if is_rmt;
-    loadtest "console/hostname" unless is_bridged_networking;
     # Add non-oss and debug repos for o3 and remove other by default
     replace_opensuse_repos_tests if is_repo_replacement_required;
     if (get_var('SYSTEM_ROLE', '') =~ /kvm|xen/) {
@@ -2436,12 +2434,12 @@ sub load_systemd_patches_tests {
 
 sub load_system_prepare_tests {
     loadtest 'ses/install_ses' if check_var_array('ADDONS', 'ses') || check_var_array('SCC_ADDONS', 'ses');
-    loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
     # temporary adding test modules which applies hacks for missing parts in sle15
     loadtest 'console/sle15_workarounds' if is_sle('15+');
     loadtest 'console/integration_services' if is_hyperv || is_vmware;
     loadtest 'console/hostname' unless is_bridged_networking;
     loadtest 'console/system_prepare';
+    loadtest "x11/disable_screensaver" if any_desktop_is_applicable();
     loadtest 'console/force_scheduled_tasks' unless is_jeos;
     # Remove repos pointing to download.opensuse.org and add snaphot repo from o3
     replace_opensuse_repos_tests if is_repo_replacement_required;
@@ -2452,7 +2450,7 @@ sub load_system_prepare_tests {
 sub load_create_hdd_tests {
     return unless get_var('INSTALLONLY');
     # install SES packages and deepsea testsuites
-    load_system_prepare_tests;
+    loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
     load_shutdown_tests;
     if (check_var('BACKEND', 'svirt')) {
         if (is_hyperv) {

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1158,6 +1158,9 @@ sub disable_serial_getty {
     # Mask if is qemu backend as use serial in remote installations e.g. during reboot
     systemctl "mask $service_name", ignore_failure => 1 if check_var('BACKEND', 'qemu');
     record_info 'serial-getty', "Serial getty mask for $testapi::serialdev";
+    # agetty changed the group from "dialout" to "tty". This won't happen again on next boot,
+    # but we need to manually change it back for now.
+    assert_script_run "chown :dialout /dev/$testapi::serialdev";
 }
 
 =head2 exec_and_insert_password

--- a/tests/console/system_prepare.pm
+++ b/tests/console/system_prepare.pm
@@ -29,6 +29,7 @@ sub run {
     my ($self) = @_;
     select_console 'root-console';
 
+    disable_serial_getty;
     ensure_serialdev_permissions;
 
     # Configure serial consoles for virtio support

--- a/tests/x11/disable_screensaver.pm
+++ b/tests/x11/disable_screensaver.pm
@@ -1,0 +1,41 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Ensure screensaver is working and then disable it
+# Maintainer: Dominik Heidler <dheidler@suse.de>
+
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use x11utils;
+
+sub run {
+    my ($self) = @_;
+
+    select_console 'x11';
+    ensure_unlocked_desktop;
+    assert_screen "generic-desktop";
+
+    # set screensaver timeout to one minute
+    set_screensaver_timeout(1);
+
+    # wait for screensaver to start
+    assert_screen [qw(screenlock screenlock-password)], 70;
+    ensure_unlocked_desktop;
+    mouse_hide(1);
+
+    turn_off_screensaver;
+
+    # ensure that the screensaver will not start anymore
+    sleep 70;
+    assert_screen "generic-desktop";
+}
+
+1;


### PR DESCRIPTION
New try with fix for some issues regarding maint:

```patch
diff --git a/lib/main_common.pm b/lib/main_common.pm
index 286ee0952..1c0f094ed 100644
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2434,7 +2434,6 @@ sub load_systemd_patches_tests {

 sub load_system_prepare_tests {
     loadtest 'ses/install_ses' if check_var_array('ADDONS', 'ses') || check_var_array('SCC_ADDONS', 'ses');
-    loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
     # temporary adding test modules which applies hacks for missing parts in sle15
     loadtest 'console/sle15_workarounds' if is_sle('15+');
     loadtest 'console/integration_services' if is_hyperv || is_vmware;
@@ -2451,6 +2450,7 @@ sub load_system_prepare_tests {
 sub load_create_hdd_tests {
     return unless get_var('INSTALLONLY');
     # install SES packages and deepsea testsuites
+    loadtest 'qa_automation/patch_and_reboot' if is_updates_tests;
     load_shutdown_tests;
     if (check_var('BACKEND', 'svirt')) {
         if (is_hyperv) {
```

Verification:
http://artemis.suse.de/tests/1669
http://artemis.suse.de/tests/1667