### PR TITLE
Migrate fs_stress and fs test suites to YAML

### DIFF
--- a/schedule/jeos/sle/hyperv/jeos-extratest.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-extratest.yaml
@@ -6,6 +6,7 @@ schedule:
   - jeos/grub2
   - jeos/firstrun
   - jeos/record_machine_id
+  - console/system_prepare
   - console/force_scheduled_tasks
   - jeos/grub2_gfxmode
   - jeos/diskusage

--- a/schedule/jeos/sle/hyperv/jeos-filesystem.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-filesystem.yaml
@@ -1,0 +1,28 @@
+---
+description: 'Filesystems JeOS test suite.'
+name: 'jeos-filesystem@svirt-hyperv ( svirt )'
+schedule:
+  - installation/bootloader_hyperv
+  - jeos/grub2
+  - jeos/firstrun
+  - jeos/record_machine_id
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - jeos/grub2_gfxmode
+  - jeos/diskusage
+  - jeos/root_fs_size
+  - jeos/build_key
+  - console/suseconnect_scc
+  - console/consoletest_setup
+  - console/integration_services
+  - console/lsof
+  - console/autofs
+  - console/lvm
+  - console/snapper_jeos_cli
+  - console/btrfs_autocompletion
+  - console/btrfs_qgroups
+  - console/snapper_cleanup
+  - console/btrfs_send_receive
+  - console/snapper_undochange
+  - console/snapper_create
+  - console/coredump_collect

--- a/schedule/jeos/sle/hyperv/jeos-fs_stress.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-fs_stress.yaml
@@ -1,0 +1,17 @@
+---
+description: 'Filesystem stress test for JeOS. Maintainer: ccret'
+name: 'jeos-fs_stress@64bit-virtio-vga ( qemu )'
+schedule:
+  - installation/bootloader_svirt
+  - jeos/grub2
+  - jeos/firstrun
+  - jeos/record_machine_id
+  - console/force_scheduled_tasks
+  - jeos/grub2_gfxmode
+  - jeos/diskusage
+  - jeos/root_fs_size
+  - jeos/build_key
+  - console/suseconnect_scc
+  - qa_automation/prepare_qa_repo
+  - qa_automation/install_test_suite
+  - qa_automation/execute_test_run

--- a/schedule/jeos/sle/hyperv/jeos-main.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-main.yaml
@@ -6,16 +6,15 @@ schedule:
   - jeos/grub2
   - jeos/firstrun
   - jeos/record_machine_id
+  - console/system_prepare
   - console/force_scheduled_tasks
   - jeos/grub2_gfxmode
   - jeos/diskusage
   - jeos/root_fs_size
   - jeos/build_key
   - console/suseconnect_scc
-  - console/system_prepare
   - console/check_network
   - console/system_state
-  - console/prepare_test_data
   - console/consoletest_setup
   - console/integration_services
   - locale/keymap_or_locale

--- a/schedule/jeos/sle/kvm/jeos-extratest.yaml
+++ b/schedule/jeos/sle/kvm/jeos-extratest.yaml
@@ -5,6 +5,7 @@ schedule:
   - jeos/grub2
   - jeos/firstrun
   - jeos/record_machine_id
+  - console/system_prepare
   - console/force_scheduled_tasks
   - jeos/grub2_gfxmode
   - jeos/diskusage

--- a/schedule/jeos/sle/kvm/jeos-filesystem.yaml
+++ b/schedule/jeos/sle/kvm/jeos-filesystem.yaml
@@ -1,0 +1,25 @@
+---
+description: 'Filesystems JeOS test suite. Maintainer: ccret'
+name: 'jeos-filesystem@64bit-virtio-vga ( qemu )'
+schedule:
+  - jeos/grub2
+  - jeos/firstrun
+  - jeos/record_machine_id
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - jeos/grub2_gfxmode
+  - jeos/diskusage
+  - jeos/root_fs_size
+  - jeos/build_key
+  - console/suseconnect_scc
+  - console/consoletest_setup
+  - console/lsof
+  - console/autofs
+  - console/lvm
+  - console/snapper_jeos_cli
+  - console/btrfs_autocompletion
+  - console/btrfs_qgroups
+  - console/snapper_cleanup
+  - console/btrfs_send_receive
+  - console/snapper_undochange
+  - console/snapper_create

--- a/schedule/jeos/sle/kvm/jeos-fs_stress.yaml
+++ b/schedule/jeos/sle/kvm/jeos-fs_stress.yaml
@@ -1,0 +1,16 @@
+---
+description: 'Filesystem stress test for JeOS. Maintainer: ccret'
+name: 'jeos-fs_stress@64bit-virtio-vga ( qemu )'
+schedule:
+  - jeos/grub2
+  - jeos/firstrun
+  - jeos/record_machine_id
+  - console/force_scheduled_tasks
+  - jeos/grub2_gfxmode
+  - jeos/diskusage
+  - jeos/root_fs_size
+  - jeos/build_key
+  - console/suseconnect_scc
+  - qa_automation/prepare_qa_repo
+  - qa_automation/install_test_suite
+  - qa_automation/execute_test_run

--- a/schedule/jeos/sle/kvm/jeos-main.yaml
+++ b/schedule/jeos/sle/kvm/jeos-main.yaml
@@ -5,16 +5,15 @@ schedule:
   - jeos/grub2
   - jeos/firstrun
   - jeos/record_machine_id
+  - console/system_prepare
   - console/force_scheduled_tasks
   - jeos/grub2_gfxmode
   - jeos/diskusage
   - jeos/root_fs_size
   - jeos/build_key
   - console/suseconnect_scc
-  - console/system_prepare
   - console/check_network
   - console/system_state
-  - console/prepare_test_data
   - console/consoletest_setup
   - locale/keymap_or_locale
   - console/apache

--- a/schedule/jeos/sle/xen/hvm/jeos-extratest.yaml
+++ b/schedule/jeos/sle/xen/hvm/jeos-extratest.yaml
@@ -6,6 +6,7 @@ schedule:
   - jeos/grub2
   - jeos/firstrun
   - jeos/record_machine_id
+  - console/system_prepare
   - console/force_scheduled_tasks
   - jeos/grub2_gfxmode
   - jeos/revive_xen_domain

--- a/schedule/jeos/sle/xen/hvm/jeos-filesystem.yaml
+++ b/schedule/jeos/sle/xen/hvm/jeos-filesystem.yaml
@@ -1,0 +1,27 @@
+---
+description: 'Filesystems JeOS test suite. Maintainer: ccret'
+name: 'jeos-filesystem@svirt-xen-hvm ( svirt )'
+schedule:
+  - installation/bootloader_svirt
+  - jeos/grub2
+  - jeos/firstrun
+  - jeos/record_machine_id
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - jeos/grub2_gfxmode
+  - jeos/revive_xen_domain
+  - jeos/diskusage
+  - jeos/root_fs_size
+  - jeos/build_key
+  - console/suseconnect_scc
+  - console/consoletest_setup
+  - console/lsof
+  - console/autofs
+  - console/lvm
+  - console/snapper_jeos_cli
+  - console/btrfs_autocompletion
+  - console/btrfs_qgroups
+  - console/snapper_cleanup
+  - console/btrfs_send_receive
+  - console/snapper_undochange
+  - console/snapper_create

--- a/schedule/jeos/sle/xen/hvm/jeos-fs_stress.yaml
+++ b/schedule/jeos/sle/xen/hvm/jeos-fs_stress.yaml
@@ -1,0 +1,18 @@
+---
+description: 'Filesystem stress test for JeOS. Maintainer: ccret'
+name: 'jeos-fs_stress@svirt-xen-hvm ( svirt )'
+schedule:
+  - installation/bootloader_svirt
+  - jeos/grub2
+  - jeos/firstrun
+  - jeos/record_machine_id
+  - console/force_scheduled_tasks
+  - jeos/grub2_gfxmode
+  - jeos/revive_xen_domain
+  - jeos/diskusage
+  - jeos/root_fs_size
+  - jeos/build_key
+  - console/suseconnect_scc
+  - qa_automation/prepare_qa_repo
+  - qa_automation/install_test_suite
+  - qa_automation/execute_test_run

--- a/schedule/jeos/sle/xen/hvm/jeos-main.yaml
+++ b/schedule/jeos/sle/xen/hvm/jeos-main.yaml
@@ -6,6 +6,7 @@ schedule:
   - jeos/grub2
   - jeos/firstrun
   - jeos/record_machine_id
+  - console/system_prepare
   - console/force_scheduled_tasks
   - jeos/grub2_gfxmode
   - jeos/revive_xen_domain
@@ -13,10 +14,8 @@ schedule:
   - jeos/root_fs_size
   - jeos/build_key
   - console/suseconnect_scc
-  - console/system_prepare
   - console/check_network
   - console/system_state
-  - console/prepare_test_data
   - console/consoletest_setup
   - locale/keymap_or_locale
   - console/apache

--- a/schedule/jeos/sle/xen/pv/jeos-extratest.yaml
+++ b/schedule/jeos/sle/xen/pv/jeos-extratest.yaml
@@ -5,6 +5,7 @@ schedule:
   - installation/bootloader_svirt
   - jeos/firstrun
   - jeos/record_machine_id
+  - console/system_prepare
   - console/force_scheduled_tasks
   - jeos/grub2_gfxmode
   - jeos/revive_xen_domain

--- a/schedule/jeos/sle/xen/pv/jeos-filesystem.yaml
+++ b/schedule/jeos/sle/xen/pv/jeos-filesystem.yaml
@@ -1,0 +1,26 @@
+---
+description: 'Filesystems JeOS test suite. Maintainer: ccret'
+name: 'jeos-filesystem@svirt-xen-pv ( svirt )'
+schedule:
+  - installation/bootloader_svirt
+  - jeos/firstrun
+  - jeos/record_machine_id
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - jeos/grub2_gfxmode
+  - jeos/revive_xen_domain
+  - jeos/diskusage
+  - jeos/root_fs_size
+  - jeos/build_key
+  - console/suseconnect_scc
+  - console/consoletest_setup
+  - console/lsof
+  - console/autofs
+  - console/lvm
+  - console/snapper_jeos_cli
+  - console/btrfs_autocompletion
+  - console/btrfs_qgroups
+  - console/snapper_cleanup
+  - console/btrfs_send_receive
+  - console/snapper_undochange
+  - console/snapper_create

--- a/schedule/jeos/sle/xen/pv/jeos-fs_stress.yaml
+++ b/schedule/jeos/sle/xen/pv/jeos-fs_stress.yaml
@@ -1,0 +1,17 @@
+---
+description: 'Filesystem stress test for JeOS. Maintainer: ccret'
+name: 'jeos-fs_stress@svirt-xen-pv ( svirt )'
+schedule:
+  - installation/bootloader_svirt
+  - jeos/firstrun
+  - jeos/record_machine_id
+  - console/force_scheduled_tasks
+  - jeos/grub2_gfxmode
+  - jeos/revive_xen_domain
+  - jeos/diskusage
+  - jeos/root_fs_size
+  - jeos/build_key
+  - console/suseconnect_scc
+  - qa_automation/prepare_qa_repo
+  - qa_automation/install_test_suite
+  - qa_automation/execute_test_run

--- a/schedule/jeos/sle/xen/pv/jeos-main.yaml
+++ b/schedule/jeos/sle/xen/pv/jeos-main.yaml
@@ -5,6 +5,7 @@ schedule:
   - installation/bootloader_svirt
   - jeos/firstrun
   - jeos/record_machine_id
+  - console/system_prepare
   - console/force_scheduled_tasks
   - jeos/grub2_gfxmode
   - jeos/revive_xen_domain
@@ -12,10 +13,8 @@ schedule:
   - jeos/root_fs_size
   - jeos/build_key
   - console/suseconnect_scc
-  - console/system_prepare
   - console/check_network
   - console/system_state
-  - console/prepare_test_data
   - console/consoletest_setup
   - locale/keymap_or_locale
   - console/apache


### PR DESCRIPTION
- Related ticket: [[JeOS][sle] replace bootloader_uefi by grub2 module and migrate test suites to YAML](https://progress.opensuse.org/issues/57203)