### PR TITLE
Fix installation for textmode on spvm backend

### DIFF
--- a/lib/bootloader_spvm.pm
+++ b/lib/bootloader_spvm.pm
@@ -129,7 +129,7 @@ sub boot_spvm {
     # Switch to installation console (ssh or vnc)
     select_console('installation');
     # We need to start installer only if it's pure ssh installation
-    type_string("yast.ssh\n") if check_var('VIDEOMODE', 'ssh-x');
+    type_string("yast.ssh\n") if get_var('VIDEOMODE', '') =~ /ssh-x|text/;
     wait_still_screen;
 }
 


### PR DESCRIPTION
Fix poo#56924: Installation was not started in textmode.
Extend VIDEOMODE condition with textmode.

- Related ticket: https://progress.opensuse.org/issues/56924
- Needles: none:
- Verification run SLE12-SP5: 
vnc: https://openqa.suse.de/tests/3393717#step/welcome/1
text: https://openqa.suse.de/tests/3393719#step/welcome/1
ssh-x: https://openqa.suse.de/tests/3394033