### PR TITLE
Drop sle2docker

### DIFF
--- a/schedule/jeos/sle/hyperv/jeos-extratest.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-extratest.yaml
@@ -53,7 +53,6 @@ schedule:
   - console/procps
   - console/docker
   - console/docker_runc
-  - console/sle2docker
   - console/docker_image
   - console/zypper_docker
   - sysauth/sssd

--- a/schedule/jeos/sle/kvm/jeos-extratest.yaml
+++ b/schedule/jeos/sle/kvm/jeos-extratest.yaml
@@ -51,7 +51,6 @@ schedule:
   - console/procps
   - console/docker
   - console/docker_runc
-  - console/sle2docker
   - console/docker_image
   - console/zypper_docker
   - sysauth/sssd

--- a/schedule/jeos/sle/xen/hvm/jeos-extratest.yaml
+++ b/schedule/jeos/sle/xen/hvm/jeos-extratest.yaml
@@ -53,7 +53,6 @@ schedule:
   - console/procps
   - console/docker
   - console/docker_runc
-  - console/sle2docker
   - console/docker_image
   - console/zypper_docker
   - sysauth/sssd

--- a/schedule/jeos/sle/xen/pv/jeos-extratest.yaml
+++ b/schedule/jeos/sle/xen/pv/jeos-extratest.yaml
@@ -52,7 +52,6 @@ schedule:
   - console/procps
   - console/docker
   - console/docker_runc
-  - console/sle2docker
   - console/docker_image
   - sysauth/sssd
   - console/zypper_docker


### PR DESCRIPTION
- Related ticket: [[JeOS][sle] remove sle2docker openQA module](https://progress.opensuse.org/issues/57197)
- Verification run: []()
