### PR TITLE
Fix unlock of encrypted disk after kdump

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -246,7 +246,7 @@ sub check_function {
     else {
         power_action('reboot', observe => 1, keepconsole => 1);
     }
-
+    unlock_if_encrypted;
     # Wait for system's reboot; more time for Hyper-V as it's slow.
     $self->wait_boot(bootloader_time => check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 200 : undef);
     select_console 'root-console';


### PR DESCRIPTION
Fix poo#57224: PR https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8370  removed `unlock_if_encrypted` function after kdump.

- Related ticket: https://progress.opensuse.org/issues/57224
- Needles:
- Verification run: 
SLE12-SP5 ppc64le: https://openqa.suse.de/tests/3396308#
SLE12-SP5 x86_64: http://10.100.12.105/tests/3225

