### PR TITLE
Set SELinux config file instead of using default

### DIFF
--- a/tests/security/selinux/sestatus.pm
+++ b/tests/security/selinux/sestatus.pm
@@ -35,6 +35,10 @@ sub run {
     # enable SELinux in grub
     add_grub_cmdline_settings('security=selinux selinux=1 enforcing=0', 1);
 
+    # control (enable) the status of SELinux on the system
+    assert_script_run("sed -i -e 's/^SELINUX=/#SELINUX=/' /etc/selinux/config");
+    assert_script_run("echo 'SELINUX=permissive' >> /etc/selinux/config");
+
     power_action("reboot", textmode => 1);
     $self->wait_boot;
     $self->select_serial_terminal;


### PR DESCRIPTION
Set SELinux config file to avoid using default values as the default value may introduce test fails.

- Related ticket: https://progress.opensuse.org/issues/56900
- Needles: NA
- Verification run: 
  SLE12-SP5-b330: http://10.67.19.62/tests/1230
  Tumbleweed-b20190921: http://10.67.19.62/tests/1235#
  SLE15-SP2-b38.6: http://10.67.19.62/tests/1238