### PR TITLE
[WIP]Fix SUSEConnect failure by adding timeout

### DIFF
--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -25,8 +25,8 @@ use utils;
 sub run {
     select_console('root-console');
 
-    assert_script_run("SUSEConnect --list > /dev/$serialdev");
-    assert_script_run("SUSEConnect --status-text > /dev/$serialdev");
+    assert_script_run("time SUSEConnect --list > /dev/$serialdev", timeout => 180);
+    assert_script_run("time SUSEConnect --status-text > /dev/$serialdev", timeout => 180);
 
     if (!get_var('MILESTONE_VERSION')) {
         assert_script_run('cat /etc/issue');


### PR DESCRIPTION
Fix SUSEConnect failure by adding timeout like https://openqa.suse.de/tests/3397390#step/check_system_info/5

- Related ticket: https://progress.opensuse.org/issues/xyz
- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/xyz
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
