### PR TITLE
Attempt to cancell grub2 to on hyperv

### DIFF
--- a/tests/jeos/grub2.pm
+++ b/tests/jeos/grub2.pm
@@ -28,13 +28,11 @@ sub run {
     my $self = shift;
 
     # JeOS images GRUB2 timeout is set to 10s
-    my $counter = 0;
-    while ((!check_screen('grub2', 1)) && ($counter < 10)) {
-        wait_screen_change(sub {
-                send_key 'home';
-        }, 0.5);
+    my $counter = -1;
+    do {
+        send_key 'home' for (1 .. 3);
         $counter++;
-    }
+    } while ((!check_screen('grub2', 1)) && ($counter < 10));
     $self->wait_grub(in_grub => 1, bootloader_time => 10);
     uefi_bootmenu_params;
     if (check_var('VIRSH_VMM_FAMILY', 'hyperv')) {


### PR DESCRIPTION
- Related ticket: [[sle15sp1][JeOS] grub2 timeout was not cancelled](https://progress.opensuse.org/issues/57269)
- Verification run: [sle-15-SP2-JeOS-for-MS-HyperV-x86_64-Build36.2.5-jeos-filesystem_hyperv@svirt-hyperv](http://eris.suse.cz/tests/581#step/grub2/1)
