### PR TITLE
Fix SUSEConnect failure by remove useless command

### DIFF
--- a/tests/console/check_system_info.pm
+++ b/tests/console/check_system_info.pm
@@ -25,8 +25,7 @@ use utils;
 sub run {
     select_console('root-console');
 
-    assert_script_run("SUSEConnect --list > /dev/$serialdev");
-    assert_script_run("SUSEConnect --status-text > /dev/$serialdev");
+    assert_script_run("SUSEConnect --status-text > /dev/$serialdev", timeout => 180);
 
     if (!get_var('MILESTONE_VERSION')) {
         assert_script_run('cat /etc/issue');


### PR DESCRIPTION
See title, fix https://openqa.suse.de/tests/3397390#step/check_system_info/3

- Related ticket: https://progress.opensuse.org/issues/57272
- Needles: n/a
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
