### PR TITLE
Skip systemtap-headers in install_packages

### DIFF
--- a/data/lsmfip
+++ b/data/lsmfip
@@ -183,6 +183,8 @@ sub problem_can_be_skipped {
     return 1 if $pkg =~ /^dapl-debug(|-devel|-libs|-utils)/;
     # conflict with ghostscript,-devel
     return 1 if $pkg =~ /^ghostscript(-devel)?-mini/;
+    # conflict with systemtap-sdt-devel
+    return 1 if $pkg =~ /^systemtap-headers/;
 
     return;
 }


### PR DESCRIPTION
PCBS 'systemtap-sdt-devel-3.2-lp150.5.4.2.x86_64': 'package systemtap-sdt-devel-3.2-lp150.5.4.2.x86_64 conflicts with systemtap-headers provided by systemtap-headers-3.2-lp150.5.4.2.x86_64'
  + solution
    - do not ask to install systemtap-headers-3.2-lp150.5.4.2.x86_64
