### PR TITLE
remove logs_from_installation_system lvm_raid1 scheduler

### DIFF
--- a/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv-uefi.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle12_svirt-hyperv-uefi.yaml
@@ -28,7 +28,6 @@ schedule :
   - installation/disable_grub_timeout
   - installation/start_install
   - installation/await_install
-  - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv-uefi.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv-uefi.yaml
@@ -28,7 +28,6 @@ schedule :
   - installation/disable_grub_timeout
   - installation/start_install
   - installation/await_install
-  - installation/logs_from_installation_system
   - installation/reboot_after_installation
   - installation/grub_test
   - installation/first_boot


### PR DESCRIPTION
remove logs_from_installation_system lvm_raid1 scheduler for svirt-hyperv-uefi
