### PR TITLE
Add fix for sle15sp2

### DIFF
--- a/tests/console/suse_module_tools.pm
+++ b/tests/console/suse_module_tools.pm
@@ -31,7 +31,7 @@ sub run {
     my $pth = (split '\n', $mds)[0];
 
     # Test modhash command
-    if (!is_sle('=12-sp1') && !is_sle('=12-sp5') && !is_sle('=15-sp1') && !is_tumbleweed()) {
+    if (!is_sle('=12-sp1') && !is_sle('=12-sp5') && !is_sle('>=15-sp1') && !is_tumbleweed()) {
         # Get the output and test it against correct output
         assert_script_run("modhash $pth | grep -E \"$pth: [0-9a-fA-F]+\"");
     }


### PR DESCRIPTION
Add fix for sle15sp2 and onwards - no modhash on suse-module-tools anymore

- Related ticket: https://progress.opensuse.org/issues/57341
- Verification run: http://10.161.229.247/tests/267
(change too minor, no other verification runs provided)