### PR TITLE
Use type_string_slow again in rrdtool_x11 for poo#51653

### DIFF
--- a/tests/x11/rrdtool_x11.pm
+++ b/tests/x11/rrdtool_x11.pm
@@ -65,7 +65,8 @@ sub run {
     verify_rrd_image 'speed-1';
 
     # make the graph 2.
-    assert_script_run "rrdtool graph speed-2.png --start 920804400 --end 920808000 --vertical-label m/s DEF:myspeed=test.rrd:speed:AVERAGE CDEF:realspeed=myspeed,1000,* LINE2:realspeed#FF0000";
+    type_string_slow "rrdtool graph speed-2.png --start 920804400 --end 920808000 --vertical-label m/s DEF:myspeed=test.rrd:speed:AVERAGE CDEF:realspeed=myspeed,1000,* LINE2:realspeed#FF0000";
+    send_key 'ret';
     #open image and verify if correct.
     verify_rrd_image 'speed-2';
 


### PR DESCRIPTION
Use type_string_slow again in rrdtool_x11 for poo#51653
in place of assert_script_run for graph 2 (already done for graph 3)
to avoid typing error, eg:
https://openqa.opensuse.org/tests/1035661#step/rrdtool_x11/38
https://openqa.opensuse.org/tests/1039842#step/rrdtool_x11/38

Related ticket: https://progress.opensuse.org/issues/51653

I am not able to run a verification job because of other issue
https://progress.opensuse.org/issues/57338