### PR TITLE
New test kernel_multipath_flakyserver

### DIFF
--- a/data/supportserver/iscsi/multipath_flaky_luns.sh
+++ b/data/supportserver/iscsi/multipath_flaky_luns.sh
@@ -1,0 +1,437 @@
+#!/bin/bash
+#
+#  iSCSI target for qa_sw_multipath:
+#
+#  randomly remove/re-add LUNs temporarily to enable an iSCSI/multipath client
+#  to test robustness of multipathing
+
+
+myname="$(basename "$0")"
+
+function usage() {
+	>&2 echo "
+Usage:  $myname [-D] [-m mode] [-t target]
+	$myname -h
+
+	to keep manipulating the LUNs of iSCSI target \"target\" in the way indicated
+	by \"mode\". Purpose is to assist in robustness tests.
+
+	Script ends by backgrounding its action and reporting its PID.
+	Terminate it by signaling. SIGINT SIGTERM trigger a proper
+	tidy-up of the target before exiting.
+
+Options:
+	-h   Print this help and exit successfully
+
+	-D   Activate debugging messages
+	-f   Waiting time (in seconds) between each action. Default: 15
+	-l   Just give a report about the iSCSI target's status, no further action
+	-m   specify the mode how to handle the LUNs: one of
+
+		\"addremove\" (default), \"onoffline\"
+
+	-t   specify the local iSCSI target to handle: one of
+
+	     iqn.2016-02.de.openqa		# (default) openQA supportserver standard target
+	     iqn.2010-06.de.suse:multipath	# standard qa_test_multipath target on galileo.qam.suse.de
+	     iqn.2012-09.de.suse:mpath2   	# secondary target on galileo.qam.suse.de, four paths
+"
+}
+# Global variables:
+# 	r/o:  $target
+# 	r/w:  $iscsi_server $trecord $tid
+#
+function detect_target() {
+	# FIXME: section for LIO iscsi target missing
+	if systemctl is-active tgtd >/dev/null 2>&1; then
+		iscsi_server="tgtd"
+		trecord="$(tgtadm --lld iscsi --op show --mode target | \
+			   sed -n -e "/^Target [1-9][0-9]*: $target/,/^Target [1-9]/ {
+				/^Target/ {
+					/$target/ ! q
+				}
+				p
+			}")"
+			tid="$(echo "$trecord" | sed -n -e "/^Target/ {
+				s/^Target \([1-9][0-9]*\):.*\$/\1/p
+				q
+			}")"
+	elif [ -f /proc/net/iet/volume ] ; then
+		iscsi_server="ietd"
+		trecord="$(sed -n -e "/^tid:[0-9]* name:$target/ {
+				p
+				:luns
+				n
+				/^[[:blank:]]*lun:/ {
+					p
+					b luns
+				}
+				q
+			}" /proc/net/iet/volume)"
+
+		tid="$(echo "$trecord" | sed -n -e "/^tid:.* name:$target/s,tid:\([0-9]*\) name:.*,\1,p")"
+	fi	# if [ -f /proc/net/iet/volume ]
+
+	if  [ "$tid" -gt 0 ] 2>/dev/null; then
+		[ -n "$DEBUG" ] && echo "DEBUG: detected TID: \"$tid\" for target: $target."
+	else
+		echo "ERROR: detect_target(): detected BAD TID: \"$tid\" for target: $target." >&2
+		return 1
+	fi
+
+	[ -n "$DEBUG" ] && echo "
+DEBUG: Target: $target: full record:
+
+$trecord
+
+\$tid: $tid
+"
+	return 0
+}
+
+# Global variables:
+#	r/o: $iscsi_server $trecord $tid
+#	r/w: $firstlun $lastlun $path[] $online[]
+#
+function detect_luns() {
+	local lun;
+
+	lastlun=0
+	# FIXME: section for LIO iscsi target missing
+	if [ "$iscsi_server" == "tgtd" ] ; then
+		firstlun=1
+		# Warning: DONT pipe here lest the result is just in a subshell!!
+		while read w1 w2 w3 w4 rest; do
+			case "$w1" in
+			    LUN:)	lun="$w2"
+					[ "$lun" -eq 0 ] && continue	# LUN 0: reserved, not a disk
+					# [ -n "$DEBUG" ] && echo -e "DEBUG: Evaluating trecord line: $w1 $w2 $w3 $w4 $rest"
+					online[lun]="online"
+					[ "$lun" -gt "$lastlun" ] && lastlun="$lun"
+					# [ -n "$DEBUG" ] && echo -e "DEBUG: LUN $lun: \$lastlun is $lastlun"
+					;;
+			    Backing)	[ "$lun" -eq 0 ] && continue	# LUN 0: reserved, not a disk
+					[ "$w1 $w2 $w3" != "Backing store path:" ] && continue;
+					# [ -n "$DEBUG" ] && echo -e "DEBUG: Evaluating trecord line: $w1 $w2 $w3 $w4 $rest"
+					path[lun]="$w4"
+					[ -n "$DEBUG" ] && echo -e "\tLUN: $lun\tpath: ${path[lun]}"
+					;;
+			esac
+		done < <(echo "$trecord")
+		no_luns="$lastlun"
+	elif [ "$iscsi_server" == "ietd" ] ; then
+		firstlun=0
+		# WARNING: the LUN IDs do not need to be monotonously increasing!
+		#          Need to find the max!
+		#          FIXME: there might even be gaps?! For now, let's assume "no gaps"
+		for lun in $(echo "$trecord" | sed -n -e's/^[[:blank:]]*lun:\([0-9]*\) .*$/\1/p') ; do
+			[ "$lun" -gt "$lastlun" ] && lastlun="$lun"
+		done
+
+		let "no_luns = lastlun + 1"
+		for lun in $(seq "$firstlun" "$lastlun") ; do
+			# For robustness, we keep track of *all* paths.
+			# They are identical for now, but this does not need to remain so.
+			path[lun]="$(echo "$trecord" | sed -n -e"/^[[:blank:]]*lun:$lun[[:blank:]]/s,^.*[[:blank:]]path:\(/.*\)\$,\1,p")"
+			[ -n "$DEBUG" ] && echo -e "\tLUN: $lun\tpath: ${path[lun]}"
+			online[lun]="online"
+		done
+	else
+		# unsupported $iscsi_server
+		return 1
+	fi	# if [ "$iscsi_server" == .....
+
+	if [ "$no_luns" -eq 0 ] ; then
+		echo "ERROR: detect_luns(): NO luns detected for tid: $tid" >&2
+		return 1
+	fi	# if [ "$no_luns" -eq 0 ]
+
+	[ -n "$DEBUG" ] && echo "DEBUG: Detected $no_luns LUNs: $firstlun,...,$lastlun:"
+	luns_online="$no_luns"
+	[ -n "$DEBUG" ] && echo ""
+	return 0
+}
+
+function report_lun_state() {
+	local lun;
+	echo -e "iSCSI target: $target (TID: $tid)\n"
+	for lun in $(seq -w "$firstlun" "$lastlun"); do
+		echo "LUN $lun: ${online[lun]}"
+	done
+}
+
+function add_lun {
+	local lun="$1"
+	# FIXME: section for LIO iscsi target missing
+	if [ "$iscsi_server" == "tgtd" ] ; then
+		# openQA supportserver, SLES-12 SP3
+		tgtadm --lld iscsi --mode logicalunit --op new \
+			--tid=$tid --lun=$lun \
+		--device-type disk --backing-store "${path[lun]}" \
+		&& tgtadm --lld iscsi --mode logicalunit --op update \
+			--tid=$tid --lun=$lun --params scsi_id="$ScsiId" \
+		|| return 1	# failure considered nonfatal, no action
+	elif [ "$iscsi_server" == "ietd" ] ; then
+		# galileo.qam.suse.de, SLES-11 SP3
+		ietadm --op new --tid=$tid --lun=$lun \
+			--params Type=blockio,ScsiId="$ScsiId",Path="${path[lun]:-$path_fallback}" \
+		|| return 1	# failure considered nonfatal, no action
+	else
+		return 1	# no action
+	fi
+	let "luns_online += 1"
+	online[lun]="online"
+}
+
+function remove_lun {
+	local lun="$1"
+	# FIXME: section for LIO iscsi target missing
+	if [ "$iscsi_server" == "tgtd" ] ; then
+		# openQA supportserver, SLES-12 SP3
+		tgtadm --lld iscsi --mode logicalunit --op delete \
+			--tid=$tid --lun=$lun \
+		|| return 1	# failure considered nonfatal, no action
+	elif [ "$iscsi_server" == "ietd" ] ; then
+		# galileo.qam.suse.de, SLES-11 SP3
+		ietadm --op delete --tid=$tid --lun=$lun \
+		|| return 1	# failure considered nonfatal, no action
+	else
+		return 1	# no action
+	fi
+	let "luns_online -= 1"
+	online[lun]="offline"
+}
+
+function online_lun {
+	local lun="$1"
+	# FIXME: section for LIO iscsi target missing
+	# only supported for the tgtd iSCSI server
+	if [ "$iscsi_server" == "tgtd" ] ; then
+		# openQA supportserver, SLES-12 SP3
+		tgtadm --lld iscsi --mode logicalunit --op update \
+			--tid=$tid --lun=$lun \
+			--params online=1 \
+		|| return 1	# failure considered nonfatal, no action
+	else
+		return 1	# no action
+	fi
+	let "luns_online += 1"
+	online[lun]="online"
+}
+
+function offline_lun {
+	local lun="$1"
+	# only supported for the tgtd iSCSI server
+
+	# FIXME: section for LIO iscsi target missing
+	if [ "$iscsi_server" == "tgtd" ] ; then
+		# openQA supportserver, SLES-12 SP3
+		tgtadm --lld iscsi --mode logicalunit --op update \
+			--tid=$tid --lun=$lun \
+			--params online=0 \
+		|| return 1	# failure considered nonfatal, no action
+	else
+		return 1	# no action
+	fi
+	let "luns_online -= 1"
+	online[lun]="offline"
+}
+
+# Global variables:
+#       r/o: $treat_lun $firstlun $lastlun $path[]
+#       r/w: $online[]
+#
+function toggle_lun {
+	local toggle_me
+	local fail
+
+	# we might need a few iterations for getting a suitable $RANDOM
+	local done=""
+	until [ -n "$done" ] ; do
+		toggle_me="$RANDOM"
+		# turn $RANDOM into a random index between $firstlun and $lastlun
+		let "toggle_me += -(toggle_me/no_luns)*no_luns + firstlun"
+		if [ "${online[toggle_me]}" == "online" ] ; then
+			# NO action if there is only one online LUN left. Rather repeat with a new $RANDOM.
+			# FIXME: if the paths vary, we want at least one LUN remain for each path.
+			if [ "$luns_online" -lt 2 ]; then
+				# wait a bit, then try with a new $RANDOM value
+				sleep 1
+				continue
+			fi
+			case "$treat_lun" in
+			    addremove)
+				remove_lun "$toggle_me" && fail="" || fail=" (nonfatal) NOT"
+				[ -n "$DEBUG" ] && echo "DEBUG:$fail deleted LUN $toggle_me"
+				[ -z "$fail" ] || echo "WARNING: remove_lun $toggle_me failed (probably nonfatal)" >&2
+				;;
+			    onoffline)
+				if offline_lun "$toggle_me"; then
+					[ -n "$DEBUG" ] && echo "DEBUG: taken offline: LUN $toggle_me"
+				else
+					echo "WARNING: offline_lun() failed (is iSCSI server $iscsi_server supported?)" >&2
+					continue
+				fi	# if offline_lun "$toggle_me"
+				;;
+			    *)		echo "Int ERROR: toggle_lun(): unknown \$action: $treat_lun. Doing nothing." >&2
+					continue
+				;;
+			esac
+			done="yes"
+		elif [ "${online[toggle_me]}" == "offline" ] ; then
+			case "$treat_lun" in
+			    addremove)
+				add_lun "$toggle_me" && fail="" || fail=" (nonfatal) NOT"
+				[ -n "$DEBUG" ] && echo "DEBUG:$fail Re-Added LUN $toggle_me"
+				[ -z "$fail" ] || echo "WARNING: add_lun $toggle_me failed (probably nonfatal)" >&2
+				;;
+			    onoffline)
+				if online_lun "$toggle_me"; then
+					[ -n "$DEBUG" ] && echo "DEBUG: brought online: LUN $toggle_me"
+				else
+					echo "WARNING: online_lun() failed (is iSCSI server $iscsi_server supported?)" >&2
+					continue
+				fi	# if online_lun "$toggle_me"
+				;;
+			    *)		echo "Int ERROR: toggle_lun(): unknown \$action: $treat_lun. Doing nothing." >&2
+					continue
+				;;
+			esac
+			done="yes"
+		else
+			echo "Int ERROR: toggle_lun(): Unexpected value: \${online[$toggle_me]} == ${online[toggle_me]}." >&2
+		fi
+	done
+	if [ -n "$DEBUG" ]; then
+		echo "
+DEBUG: result of invoking toggle_lun()
+--------------------------------------"
+		report_lun_state
+		echo
+	fi	# if [ -n "$DEBUG" ]
+	return 0
+}
+
+function tidyup_target {
+	local lun
+
+	# Add a temporary sentinel to have at least one LUN remaining throughout
+	let "tmplun = no_luns + 1"
+	path[tmplun]="${path[lastlun]}"
+	[ -n "$DEBUG" ] && echo "tidyup_target(): add_lun $tmplun"
+	add_lun $tmplun
+	sleep 1
+
+	for lun in $(seq $firstlun $lastlun); do
+		# FIXME: better check whether $lun is present in the first place
+		#        Fails here are likely nonfatal, just annoying
+		[ -n "$DEBUG" ] && echo "tidyup_target(): remove_lun $lun"
+		remove_lun "$lun" || echo "LUN $lun probably already absent; failure hopefully harmless" >&2
+	done
+	for lun in $(seq $firstlun $lastlun); do
+		[ -n "$DEBUG" ] && echo "tidyup_target(): add_lun $lun"
+		add_lun "$lun"
+	done
+	[ -n "$DEBUG" ] && echo "tidyup_target(): remove_lun $tmplun"
+	remove_lun $tmplun
+	[ -n "$DEBUG" ] && { echo -e "\nAfter final tidy-up:"; detect_target ; }
+	return 0
+}
+
+function tidyup_all {
+	tidyup_target
+	rm -f "$pidfile"
+	exit 0
+}
+
+# ACTION
+
+# Cmdline evaluation and sanity checks
+#
+
+# Defaults
+DEBUG=""
+wait_between=15
+just_report=""
+# FIXME: (clumsily) hardcoded to enable other processes to find the location
+#        (see openQA module tests/supportserver/flaky_mp_iscsi.pm)
+pidfile="/tmp/multipath_flaky_luns.pid"
+treat_lun="addremove"
+target="iqn.2016-02.de.openqa"
+
+while getopts hDf:lm:t: optchar ; do
+    case "$optchar" in
+	h)      usage ; exit 0            ;;
+	D)      DEBUG="yes"               ;;
+	f)      wait_between="$OPTARG"    ;;
+	l)      just_report="yes"         ;;
+	m)      treat_lun="$OPTARG"       ;;
+	t)      target="$OPTARG"          ;;
+	*)      usage ; exit 1            ;;
+    esac
+done
+
+if ! [ "$wait_between" -gt 0 ] >/dev/null 2>&1; then
+	echo "$myname: ERROR: option -f: invalid value $wait_between. Aborting...">&2
+	usage
+	exit 1
+fi
+
+if ! rm -rf "$pidfile" ; then
+	"$myname: ERROR: Unable to clean out needed PID file: $pidfile. Aborting...">&2
+	exit 1
+fi
+
+case "$target" in
+	iqn.2010-06.de.suse:multipath)	# standard qa_test_multipath target on galileo.qam.suse.de
+	    ScsiId=mpath1; path_fallback=/dev/qa/multipath
+	    ;;
+	iqn.2012-09.de.suse:mpath2)	# secondary target on galileo.qam.suse.de, four paths
+	    ScsiId=mpath2; path_fallback=/dev/qa/mpath2
+	    ;;
+	iqn.2016-02.de.openqa)		# openQA supportserver standard target
+	    ScsiId=mpatha; path_fallback=/dev/qa/mpatha
+	    ;;
+	* ) echo "$myname: ERROR: cmdline arg $target: unknown iSCSI target. Aborting...">&2
+	    exit 1
+	    ;;
+esac
+
+case "$treat_lun" in
+	addremove|onoffline)
+		: ;;
+	*)	echo "$myname: ERROR: cmdline arg $treat_lun: must be \"addremove\" or \"onoffline\". Aborting...">&2
+		exit 1
+		;;
+esac
+
+detect_target || {
+	echo "$myname: ERROR: detect_target() failed. Aborting...">&2
+	exit 1
+}
+detect_luns || {
+	echo "$myname: ERROR: detect_luns() failed for target: $target. Aborting...">&2
+	exit 1
+}
+#
+# Done: cmdline evaluation and sanity checks
+
+if [ "$just_report" == "yes" ] ; then
+	report_lun_state
+	exit 0
+fi
+
+# Main action in the background, expected to get
+# terminated by signaling
+#
+# Note: outputting $! to stdout and trying to capture it via
+# (subshelled) command substitution will hang. Therefore,
+# a hardcoded PIDfile is utilized.
+#
+{
+trap 'tidyup_all' SIGHUP SIGINT SIGTERM
+while true ; do
+	toggle_lun
+	sleep "$wait_between"
+done
+} & echo $! >"$pidfile"

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -676,8 +676,9 @@ elsif (get_var("SUPPORT_SERVER")) {
         loadtest "remote/remote_controller";
         load_inst_tests();
     }
-    loadtest "ha/barrier_init"  if get_var("HA_CLUSTER");
-    loadtest "hpc/barrier_init" if get_var("HPC");
+    loadtest "ha/barrier_init"               if get_var("HA_CLUSTER");
+    loadtest "hpc/barrier_init"              if get_var("HPC");
+    loadtest "support_server/flaky_mp_iscsi" if (get_var("ISCSI_MULTIPATH_FLAKY"));
     unless (load_slenkins_tests()) {
         loadtest "support_server/wait_children";
     }

--- a/tests/qa_automation/kernel_multipath.pm
+++ b/tests/qa_automation/kernel_multipath.pm
@@ -1,11 +1,22 @@
 # SUSE's openQA tests
 #
-# Copyright © 2018 SUSE LLC
+# Copyright © 2019 SUSE LLC
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
-# notice and this notice are preserved.  This file is offered as-is,
-# without any warranty.
+# notice and this notice are preserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
 
 # Summary: Use qa_test_multipath to test multipath over iscsi
 # - Install open-iscsi qa_test_multipath
@@ -14,17 +25,91 @@
 # - Configure test suite with proper iscsi iqn, target and wwid
 # - Run "/usr/share/qa/qaset/qaset reset"
 # - Run "/usr/share/qa/qaset/run/kernel-all-run.openqa"
-# Maintainer: Petr Cervinka <pcervinka@suse.com>
+
+# If ISCSI_MULTIPATH_FLAKY is set, modifications of the two I/O-intensive
+# qa_test_multipath tests are run which leave the disabling/re-enabling
+# of multipaths to the iSCSI server.
+
+# Maintainer: Petr Cervinka <pcervinka@suse.com>, Klaus G. Wagner <kgw@suse.com>
 
 use base 'qa_run';
 use strict;
 use warnings;
+use lockapi;
 use testapi;
+use mmapi;
 use utils;
 use iscsi;
 
+# FIXME: The status queries for qaset (pkg qa_testset_automation) in
+# the subsequent two subs are rather awkward "inofficial" workarounds:
+# the current qaset API does not seem to offer such queries.
+#
+# A request to implement API commands like, e.g.,
+#
+#     /usr/share/qa/qaset/qaset status		# clean/running/stopped/done
+#     /usr/share/qa/qaset/qaset waitstop	# wait until status is "stopped"
+#     /usr/share/qa/qaset/qaset waitdone	# wait until status is "done"
+#
+# is under way.
+#
+sub qaset_waitdone {
+    # qaset has been observed to create file /var/log/qaset/control/DONE
+    # as soon as
+    # -  no testsuite run is in progress anymore _and_
+    # -  there is no testsuite waiting for execution anymore
+    #    (file /var/log/qaset/control/NEXT_RUN)
+    #
+    my ($timeout) = @_;
+    assert_script_run(
+        "until [ -f /var/log/qaset/control/DONE ]; do sleep 5; done",
+        timeout      => $timeout,
+        fail_message => "qaset failed to announce overall completion within $timeout s");
+}
+
+# Invocation: qaset_waitstop(testname => $testname, timeout => $timeout [,prewait => $prewait]);
+#
+sub qaset_waitstop {
+    #
+    # FIXME: This sub is particularly awkward due to the need for $prewait.
+    # Observed: the following qaset behavior:
+    #
+    # qaset creates file /var/log/qaset/control/SYSTEM_DIRTY as soon
+    # as no testsuite run is in progress anymore (In contrast to
+    # DONE further testsuites-to-execute may be left waiting, like
+    # after a qaset stop).
+    #
+    # If some testsuite is left waiting for execution (file NEXT_RUN),
+    # starting another qaset run will delete an existing file SYSTEM_DIRTY:
+    # WARNING: but it has been observed to do so only after a delay of a few
+    # (FIXME: how many?) seconds. It is thus unsafe to start polling for
+    # SYSTEM_DIRTY immediately after such a restart. Hence $prewait.
+    #
+    my %args     = @_;
+    my $testname = $args{testname};
+    my $timeout  = $args{timeout};
+    my $prewait  = $args{prewait} // 15;    # 15 is guessed to be enough :-/
+    sleep $prewait if $prewait > 0;
+    assert_script_run(
+        "until [ -f /var/log/qaset/control/SYSTEM_DIRTY ]; do sleep 5; done",
+        timeout      => $timeout,
+        fail_message => "$testname: qaset run failed to complete in $timeout s");
+}
+
 sub start_testrun {
     my $self = shift;
+
+    # the mandatory parallel supportserver job which provides the
+    # multipathed test device.
+    my $jobid_server = get_parents();
+    $jobid_server = $jobid_server->[0];
+    # needed if 'ISCSI_MULTIPATH_FLAKY' is set
+    my $count = 1;
+    # qa_test_multipath RPM: when deployed for testsuites sw_multipath_s_aa
+    # resp. sw_multipath_s_ap, scripts active_active.sh, resp.,
+    # active_passive.sh configure a runtime of 180 s each.
+    # An openQA timeout of 360 s should therefore be plenty.
+    my $tc_timeout = 360;
 
     zypper_call("in open-iscsi qa_test_multipath");
 
@@ -58,12 +143,97 @@ sub start_testrun {
 
     $self->qaset_config();
     assert_script_run("/usr/share/qa/qaset/qaset reset");
+
+    if (get_var('ISCSI_MULTIPATH_FLAKY')) {
+        # The complication in this case is that the server must "tidy up"
+        # (restore all damaged multipaths) after the completion of each
+        # single testcase. Therefore
+        #
+        # -  client and supportserver need to keep communicating accordingly,
+        #
+        # -  each time a testcase is finished the client must take time out
+        #    from the qaset-controlled run for the sake of this tidy-up.
+        #
+        # Associated supportserver module: tests/support_server/flaky_mp_iscsi.pm
+
+        # iSCSI server and multipath export ready for action?
+        mutex_wait("flakyserver_tidied_up$count", $jobid_server);
+    }
+
     assert_script_run("/usr/share/qa/qaset/run/kernel-all-run.openqa");
+
+    if (get_var('ISCSI_MULTIPATH_FLAKY')) {
+        # The above qaset command above returns _immediately_ (the
+        # actual testrun takes place in detached screen sessions).
+        # So no significant time is lost before the ensuing communication.
+
+        # "supportserver: feel free to start meddling with the LUNs of the
+        # provided multipathed test device"
+        mutex_create "flakyserver_testcase_started$count";
+        record_info("start$count", "Mutex \"flakyserver_testcase_started$count\" created.");
+
+        # Wait a bit to make sure the first testsuite is under way, then
+        # set a stop mark for qaset (a kind of suspend, actually), to become
+        # effective after this testsuite (testcase sw_multipath_s_aa).
+        sleep 10;
+        assert_script_run("/usr/share/qa/qaset/qaset stop");
+        qaset_waitstop(testname => "sw_multipath_s_aa", timeout => $tc_timeout, prewait => 0);
+
+        # "supportserver: My first testcase is through. Please tidy up"
+        mutex_create "flakyserver_testcase_done$count";
+        record_info("done$count", "Mutex \"flakyserver_testcase_done$count\" created");
+        $count++;
+        # wait for server's ACK before taking up the next testsuite
+        mutex_wait("flakyserver_tidied_up$count", $jobid_server);
+        # The multipathed test device is now supposedly tidy again.
+
+        # Release stop file /var/log/qaset/control/STOP
+        script_run("/usr/share/qa/qaset/qaset resume");
+        # Only the following re-invocation actually resumes with the next
+        # one-testcase testsuite: sw_multipath_s_ap (found in file NEXT_RUN)
+        assert_script_run("/usr/share/qa/qaset/run/kernel-all-run.openqa");
+        # Notify the supportserver that it's time to re-commence LUN meddling...
+        mutex_create "flakyserver_testcase_started$count";
+        record_info("start$count", "Mutex \"flakyserver_testcase_started$count\" created.");
+
+        # It is a qaset restart: better leave parameter $prewait at its default.
+        # (see the function comment above).
+        # Test expected to run for about 180 s.
+        #
+        qaset_waitstop(testname => "sw_multipath_s_ap", timeout => $tc_timeout);
+
+        # "supportserver: please tidy up once more"
+        mutex_create "flakyserver_testcase_done$count";
+        record_info("done$count", "Mutex \"flakyserver_testcase_done$count\" created");
+        $count++;
+        mutex_wait("flakyserver_tidied_up$count", $jobid_server);
+        #
+        # _Note:_  For a potential future of more than two testsuites
+        # the above procedure could be iterated.
+        # TODO: write a proper loop for this.
+
+        # For now it's just the above two testcases: we are done
+        # The final wrap-up follows:
+
+        # After the second testcase finished, the overall completion is
+        # expected to be announced immediately.
+        qaset_waitdone(30);
+        # "supportserver: module flaky_mp_iscsi.pm may now terminate"
+        mutex_create "flakyserver_testcases_done_all";
+        record_info("done_all", "Mutex \"flakyserver_testcases_done_all\" created");
+        # wait for server's final ACK, then terminate
+        mutex_wait("flakyserver_ACK_done", $jobid_server);
+    }
 }
 
+# (supposedly overrides  sub test_run_list() in qa_run.pm)
 sub test_run_list {
-    return qw(_reboot_off sw_multipath);
+    if (get_var('ISCSI_MULTIPATH_FLAKY')) {
+        return qw(_reboot_off sw_multipath_s_aa sw_multipath_s_ap);
+    }
+    else {
+        return qw(_reboot_off sw_multipath);
+    }
 }
 
 1;
-

--- a/tests/support_server/flaky_mp_iscsi.pm
+++ b/tests/support_server/flaky_mp_iscsi.pm
@@ -1,0 +1,115 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <http://www.gnu.org/licenses/>.
+
+# Summary: collaborate with tests/qa_automation/kernel_multipath.pm for a
+#          multipath client robustness test. This supportserver module will
+#          keep disturbing the iSCSI LUNs of the multipathed test device.
+# Maintainer: Klaus G. Wagner <kgw@suse.com>
+
+use strict;
+use warnings;
+use base 'basetest';
+use lockapi;
+use testapi;
+use mmapi;
+use iscsi;
+
+sub run {
+    my $self  = shift;
+    my $count = 1;
+    # See: data/supportserver/iscsi/multipath_flaky_luns.sh
+    my $meddler_pidfile = "/tmp/multipath_flaky_luns.pid";
+    my $meddler_pid;
+
+    # This provides the job ID of the one parallel job (supposed to run
+    # kernel_multipath.pm)
+    # _NOTE_: the mutex_*() functions **need** this as second arg to work reliably.
+    my $jobid_client = get_children();
+    $jobid_client = (keys %$jobid_client)[0];
+
+    my $testcase_in_progress = 0;
+    my $done_all             = 0;
+    my $client_says_proceed  = 0;
+    # poll frequency in seconds :-/
+    my $poll_client_says_proceed = 5;
+    my $delay_meddling           = 10;
+
+    while (1) {
+        # check whether multipathed iSCSI target it is really tidied up, then
+        mutex_create "flakyserver_tidied_up$count";
+        record_info("tidy$count", "Mutex \"flakyserver_tidied_up$count\" created");
+        #
+        # Upon this the server supposedly will eventually receive
+        # notice by the client via
+        #     a) "flakyserver_testcase_started$count" or
+        #     b) "flakyserver_testcases_done_all"
+        # It is unknown which one, so we can't invoke mutex_wait() right away.
+        # FIXME: Instead, we resort to polling (except at the very start). UGLY!
+        # See os-autoinst-distri-opensuse/os-autoinst/lockapi.pm
+        # for mutex_try_lock(). Its advantage: it does not block!
+        #
+        unless ($count == 1) {
+            until ($client_says_proceed) {
+                sleep $poll_client_says_proceed;
+                $testcase_in_progress = mutex_try_lock("flakyserver_testcase_started$count", $jobid_client);
+                $done_all             = mutex_try_lock('flakyserver_testcases_done_all',     $jobid_client);
+                $client_says_proceed = $testcase_in_progress || $done_all;
+
+                # DEBUG: provide an idea of timing
+                record_info("Proceed?", "\$count =  $count: Received "
+                      . ($client_says_proceed ? "\"Go ahead\"" : "no notice yet")
+                      . " from client");
+            }
+            last if ($done_all);
+            # The subsequent mutex_wait() is now just a formality: expected to succeed immediately.
+        }
+        mutex_wait("flakyserver_testcase_started$count", $jobid_client);
+        # Test takes about 180 s. Wait a bit before starting to meddle with my LUNS
+        sleep $delay_meddling;
+        assert_script_run("/usr/local/bin/multipath_flaky_luns.sh", 30);
+        $meddler_pid = script_output("/bin/cat \"$meddler_pidfile\"", 30);
+        record_info("Meddling", "LUN meddling started: iteration $count (PID $meddler_pid)");
+
+        mutex_wait("flakyserver_testcase_done$count", $jobid_client);
+        # Client testcase run is done: terminate meddling (triggers tidy-up
+        # of LUNs and $meddler_pidfile along the way)
+        $client_says_proceed = 0;
+        script_run("kill -INT $meddler_pid");
+        record_info("SIGINT", "LUN meddling SIGINTed: iteration $count (PID $meddler_pid)");
+        # FIXME: ugly polling :-/
+        # wait for tidy-up action to complete ($meddler_pidfile will disappear)
+        assert_script_run("until ! [ -e \"$meddler_pidfile\" ] ; do sleep 5; done", 90);
+        # FIXME: then report (just for the record).
+        script_run("/usr/local/bin/multipath_flaky_luns.sh -l", 30);
+        $count++;
+    }
+
+    # Formality; expected to succeed immediately
+    mutex_wait('flakyserver_testcases_done_all', $jobid_client);
+    record_info("AllDone!", "Got mutex: flakyserver_testcases_done_all.");
+    # Let the client know that it's now OK to terminate.
+    mutex_create "flakyserver_ACK_done";
+}
+
+sub test_flags {
+    return {fatal => 1};
+}
+
+1;

--- a/tests/support_server/setup.pm
+++ b/tests/support_server/setup.pm
@@ -434,11 +434,17 @@ sub setup_iscsi_tgt_server {
     tgt_new_target(1, $iqn);
     # Add device lun 1 to target with id 1
     tgt_new_lun(1, 1, "$device");
-    # Export same device twice with same scsi_id for multipath test
+    # Export same device three times with same scsi_id for multipath test
     if (get_var('ISCSI_MULTIPATH')) {
         tgt_new_lun(1, 2, "$device");
+        tgt_new_lun(1, 3, "$device");
         tgt_update_lun_params(1, 1, "scsi_id=\"mpatha\"");
         tgt_update_lun_params(1, 2, "scsi_id=\"mpatha\"");
+        tgt_update_lun_params(1, 3, "scsi_id=\"mpatha\"");
+        # Download and prepare LUN disturber for later use (flaky_mp_iscsi.pm)
+        $setup_script .= "curl -f -v " . autoinst_url
+          . "/data/supportserver/iscsi/multipath_flaky_luns.sh >/usr/local/bin/multipath_flaky_luns.sh \n"
+          . "chmod +x /usr/local/bin/multipath_flaky_luns.sh";
     }
     # Authorize all clients
     tgt_auth_all(1);


### PR DESCRIPTION
A modification of two testcases from the standard `qa_sw_multipath` testsuite.

After importing one multipathed disk via iSCSI from the support server
the client runs modifications of the `active_active` and `active_passive` tests.
The difference is that it is the server rather than the client which will proceed to
(randomly) disable multipaths while the client is just doing heavy I/O.

Expected result is that the client is able to cope without any errors
(I/O or others).

Many extra comments and some debug statements and FIXMEs are left in.

- Related ticket: https://progress.opensuse.org/issues/46463
- Needles: (nothing new needed; new parts of tests are textmode-only)
- Verification run: client: http://polya.suse.de/tests/563, server: http://polya.suse.de/tests/562