### PR TITLE
Schedule glibc_locale in JeOS

### DIFF
--- a/schedule/jeos/sle/hyperv/jeos-main.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-main.yaml
@@ -13,6 +13,7 @@ schedule:
   - jeos/root_fs_size
   - jeos/build_key
   - console/suseconnect_scc
+  - jeos/glibc_locale
   - console/check_network
   - console/system_state
   - console/consoletest_setup

--- a/schedule/jeos/sle/kvm/jeos-main.yaml
+++ b/schedule/jeos/sle/kvm/jeos-main.yaml
@@ -12,6 +12,7 @@ schedule:
   - jeos/root_fs_size
   - jeos/build_key
   - console/suseconnect_scc
+  - jeos/glibc_locale
   - console/check_network
   - console/system_state
   - console/consoletest_setup

--- a/schedule/jeos/sle/xen/hvm/jeos-main.yaml
+++ b/schedule/jeos/sle/xen/hvm/jeos-main.yaml
@@ -14,6 +14,7 @@ schedule:
   - jeos/root_fs_size
   - jeos/build_key
   - console/suseconnect_scc
+  - jeos/glibc_locale
   - console/check_network
   - console/system_state
   - console/consoletest_setup

--- a/schedule/jeos/sle/xen/pv/jeos-main.yaml
+++ b/schedule/jeos/sle/xen/pv/jeos-main.yaml
@@ -13,6 +13,7 @@ schedule:
   - jeos/root_fs_size
   - jeos/build_key
   - console/suseconnect_scc
+  - jeos/glibc_locale
   - console/check_network
   - console/system_state
   - console/consoletest_setup


### PR DESCRIPTION
- Related ticket: [[sle][JeOS] jeos-main-de_DE is missing jeos/glibc_locale.pm module](https://progress.opensuse.org/issues/57317)
- Verification runs: 
   * [sle-12-SP5-JeOS-for-kvm-and-xen-x86_64-Build4.94-jeos-main-de_DE_intel_image@64bit-virtio-vga](http://eris.suse.cz/tests/608#step/glibc_locale/1)
   * [sle-15-SP1-JeOS-for-kvm-and-xen-x86_64-Build36.2.6-jeos-main_intel_image@64bit-virtio-vga](http://eris.suse.cz/tests/612#step/glibc_locale/28)
   * [sle-12-SP5-JeOS-for-kvm-and-xen-x86_64-Build4.94-jeos-main_intel_image@64bit-virtio-vga](http://eris.suse.cz/tests/614#step/glibc_locale/28)