### PR TITLE
Remove 'disable_screensaver' on SLES4SAP

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2444,7 +2444,8 @@ sub load_system_prepare_tests {
     loadtest 'console/integration_services' if is_hyperv || is_vmware;
     loadtest 'console/hostname' unless is_bridged_networking;
     loadtest 'console/system_prepare';
-    loadtest "x11/disable_screensaver" if any_desktop_is_applicable();
+    # No need to test the screensaver on SLES4SAP
+    loadtest "x11/disable_screensaver" if any_desktop_is_applicable() && !is_sles4sap();
     loadtest 'console/force_scheduled_tasks' unless is_jeos;
     # Remove repos pointing to download.opensuse.org and add snaphot repo from o3
     replace_opensuse_repos_tests if is_repo_replacement_required;


### PR DESCRIPTION
`disable_screensaver` is not working on SLES4SAP, as there is only root user created. And there is also no need to test the screensaver on SLES4SAP.

So this commit removes this test for SLES4SAP.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/t3402565
- Regression test: https://openqa.suse.de/t3402567