### PR TITLE
Fix language selection in yast2_lan on aarch64

### DIFF
--- a/tests/yast2_gui/yast2_lang.pm
+++ b/tests/yast2_gui/yast2_lang.pm
@@ -26,9 +26,9 @@ sub run {
 
     # check language details and change detailed locale setting
     assert_and_click 'yast2-lang_details';
-    assert_and_click 'yast2-lang_detailed-locale-setting';
-    assert_and_click 'yast2-lang_detailed-locale-setting_en_GB';
-    assert_screen 'yast2-lang_detailed-locale-setting_changed';
+    assert_screen 'yast2-lang_detailed-locale-setting';
+    send_key 'alt-d';
+    send_key_until_needlematch 'yast2-lang_detailed-locale-setting_changed', 'up';
     send_key 'alt-o';
 
     # change adapt time zone to German


### PR DESCRIPTION
Select "Detailed Locale Settings" drop down and hit space until the list of languages will be appeared, as it sporadically failed to click the drop down with assert_and_click on aarch64.

- Related ticket: https://progress.opensuse.org/issues/56039
- Verification run: 
   Tumbleweed:
   - aarch64: https://openqa.opensuse.org/tests/1040830
   - 64bit: https://openqa.opensuse.org/t1040831

