### PR TITLE
Public Cloud: Fix Azure provider version lower than 1.33

### DIFF
--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -1,4 +1,6 @@
-provider "azurerm" {}
+provider "azurerm" {
+   version = "<= 1.33"
+}
 
 variable "instance_count" {
     default = "1"


### PR DESCRIPTION
Current Public Cloud Azure jobs are failing due to an unknown problem with latest Azure Terraform provider. Setting version <=1.33 fixes the problem. We can go back to latest version once the problem is fixed.

- Related ticket: https://github.com/SUSE/ha-sap-terraform-deployments/issues/188
- Verification run: http://fromm.arch.suse.de/tests/130#live
