### PR TITLE
xfstests: Add fsxops and xfs_info into filesystem log

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -263,6 +263,13 @@ sub copy_log {
     script_run($cmd);
 }
 
+# Copy junk.fsxops for fails fsx test included in subtests
+sub copy_fsxops {
+    my ($category, $num) = @_;
+    my $cmd = "if [ -e /mnt/test/junk.fsxops ]; then cp /mnt/test/junk.fsxops $LOG_DIR/$category/$num.junk.fsxops; fi";
+    script_run($cmd);
+}
+
 sub dump_btrfs_img {
     my ($category, $num) = @_;
     my $cmd = "echo \"no inconsistent error, skip btrfs image dump\"";
@@ -342,6 +349,7 @@ sub run {
                 copy_log($category, $num, 'out.bad');
                 copy_log($category, $num, 'full');
                 copy_log($category, $num, 'dmesg');
+                copy_fsxops($category, $num);
                 collect_fs_status($category, $num);
                 if (get_var('BTRFS_DUMP', 0) && (check_var 'XFSTESTS', 'btrfs')) { dump_btrfs_img($category, $num); }
             }


### PR DESCRIPTION
Add fsxops log during tests to debug fsx fails in each subtests. 
e.g. https://openqa.suse.de/tests/3402021#step/1_test_result/85

- Related ticket: https://progress.opensuse.org/issues/57389
- Verification run: http://10.67.133.102/tests/1115
It has only pass verification in this PR, the fail verification not tested, because it only happens in aarch64 and ppc64le. This PR is just try to use to debug those fails.