### PR TITLE
Workaround race condition in partitioning_full_lvm

### DIFF
--- a/lib/partition_setup.pm
+++ b/lib/partition_setup.pm
@@ -274,6 +274,8 @@ sub addlv {
     }, 5);
     send_key_until_needlematch('volume_management_feature', 'down');
     wait_still_screen(stilltime => 2, timeout => 4);
+    # Ensure Volume Management selected due to in slower archs sporadically root tree selection keys arrives with a delay
+    send_key_until_needlematch('volume_management_feature', 'down');
     # Expand collapsed list with VGs
     send_key_until_needlematch('lvm_uncollapse_vgs', 'right') if is_sle('<15');
     send_key_until_needlematch 'partition-select-vg-' . "$args{vg}", 'down';


### PR DESCRIPTION
Workaround for race condition in partitioning_full_lvm. what happens is `send_key 'home'` is sent before `send_key $cmd{system_view}` is received. We cannot simply use wait_screen_change nor wait_still_screen, nor even a needle because there is a *very subtle* screen change which is sometimes detected, sometimes not.

- Related ticket: https://progress.opensuse.org/issues/56441
- Verification runs: 
aarch64:
 https://openqa.suse.de/t3415768
 https://openqa.suse.de/t3415769
 https://openqa.suse.de/t3415770
 https://openqa.suse.de/t3415771
 https://openqa.suse.de/t3415772
s390:
 https://openqa.suse.de/t3415774
 https://openqa.suse.de/t3415775
 https://openqa.suse.de/t3415776
 https://openqa.suse.de/t3415777
 https://openqa.suse.de/t3415778



