### PR TITLE
Pass textmode variable to the power_action 

### DIFF
--- a/schedule/yast/lvm_raid1/lvm+raid1_opensuse.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_opensuse.yaml
@@ -1,34 +1,33 @@
 ---
-name:           lvm+raid1@64bit
-description:    >
-  Validation of partitioning for raid1 on lvm
-  Installation of RAID1 using expert partitioner.
-vars:
-  RAIDLEVEL: 1
-  LVM: 1
-test_data:
-  !include: test_data/yast/lvm_raid1/lvm+raid1_opensuse.yaml
-schedule:
-  - installation/isosize
-  - installation/bootloader_start
-  - installation/welcome
-  - installation/online_repos
-  - installation/installation_mode
-  - installation/logpackages
-  - installation/system_role
-  - installation/partitioning
-  - installation/partitioning_raid
-  - installation/partitioning_finish
-  - installation/installer_timezone
-  - installation/user_settings
-  - installation/resolve_dependency_issues
-  - installation/installation_overview
-  - installation/disable_grub_timeout
-  - installation/start_install
-  - installation/await_install
-  - installation/logs_from_installation_system
-  - installation/reboot_after_installation
-  - installation/grub_test
-  - installation/first_boot
-  - installation/opensuse_welcome
-  - console/validate_lvm_raid1
+  name: lvm+raid1@64bit
+  description: >
+    Validation of partitioning for raid1 on lvm
+    Installation of RAID1 using expert partitioner.
+  vars:
+    RAIDLEVEL: 1
+    LVM: 1
+  test_data:
+    !include: test_data/yast/lvm_raid1/lvm+raid1_opensuse.yaml
+  schedule :
+    - installation/isosize
+    - installation/bootloader_start
+    - installation/welcome
+    - installation/online_repos
+    - installation/installation_mode
+    - installation/logpackages
+    - installation/system_role
+    - installation/partitioning
+    - installation/partitioning_raid
+    - installation/partitioning_finish
+    - installation/installer_timezone
+    - installation/user_settings
+    - installation/resolve_dependency_issues
+    - installation/installation_overview
+    - installation/disable_grub_timeout
+    - installation/start_install
+    - installation/await_install
+    - installation/logs_from_installation_system
+    - installation/reboot_after_installation
+    - installation/grub_test
+    - installation/first_boot
+    - console/validate_lvm_raid1

--- a/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
+++ b/schedule/yast/lvm_raid1/lvm+raid1_sle15_svirt-hyperv.yaml
@@ -11,6 +11,7 @@ test_data :
 schedule :
   - installation/isosize
   - installation/bootloader_hyperv
+  - installation/bootloader
   - installation/welcome
   - installation/accept_license
   - installation/scc_registration

--- a/tests/console/validate_lvm_raid1.pm
+++ b/tests/console/validate_lvm_raid1.pm
@@ -17,7 +17,7 @@ use testapi;
 use utils;
 use Test::Assert ':all';
 use scheduler 'get_test_data';
-use version_utils 'is_sle';
+use version_utils "is_sle";
 use power_action_utils 'power_action';
 
 sub run {
@@ -37,7 +37,6 @@ sub run {
     _remove_raid_disk($config, $actual_num_devs);
     _reboot();
     $self->wait_boot;
-
     _check_raid_disks_after_reboot($config, $actual_num_devs);
     _restore_raid_disk($config);
 }
@@ -80,7 +79,7 @@ sub _remove_raid_disk {
 
 sub _reboot {
     record_info('system reboots');
-    power_action('reboot');
+    power_action('reboot', textmode => 'textmode');
 }
 
 sub _check_raid_disks_after_reboot {


### PR DESCRIPTION
The Desktop variable is different than the expected. use of textmode as desktop which will trigger the reboot in power_action

- Related ticket: https://progress.opensuse.org/issues/52418
- Verification run: http://aquarius.suse.cz/tests/694#
http://aquarius.suse.cz/tests/695