### PR TITLE
Update search string for yast2-vm module in YaST control center

### DIFF
--- a/tests/yast2_gui/yast2_control_center.pm
+++ b/tests/yast2_gui/yast2_control_center.pm
@@ -243,9 +243,7 @@ sub start_user_and_group_management {
 }
 
 sub start_hypervisor {
-    # Module title got changed in SLE 15 SP2
-    my $search_string = is_sle('15-SP2+') ? 'install vm' : 'hypervisor';
-    search($search_string);
+    search('hypervisor');
     assert_and_click 'yast2_control-center_install-hypervisor-and-tools';
     assert_screen 'yast2-install-hypervisor-and-tools', timeout => 180;
     send_key 'alt-c';


### PR DESCRIPTION
There are changes in yast control center on SLE 15 SP2, so the test requires some adjustments.

There is a new title for the module, changed from "Install VM" back to
"Install hypervisor".

- Verification run: https://openqa.suse.de/tests/3415839
