### PR TITLE
wicked: Add iputils so we will get ping installed

### DIFF
--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -72,7 +72,7 @@ sub run {
             assert_script_run('cd ./wicked ; ./autogen.sh ', timeout => 600);
             assert_script_run('make ; make install',         timeout => 600);
         }
-        my $package_list = 'openvswitch openvpn';
+        my $package_list = 'openvswitch openvpn iputils';
         $package_list .= ' libteam-tools libteamdctl0 python-libteam' if check_var('WICKED', 'advanced') || check_var('WICKED', 'aggregate');
         $package_list .= ' gcc' if check_var('WICKED', 'advanced');
         zypper_call('-q in ' . $package_list, timeout => 400);


### PR DESCRIPTION
Add iputils so we will get ping installed . Currently tests are failing because there is no ping installed on SLE 15 SP2 ... 

VR : https://openqa.suse.de/tests/3414084