### PR TITLE
Workaround conflicting shortcuts in kde screenlocker configuration

### DIFF
--- a/lib/x11utils.pm
+++ b/lib/x11utils.pm
@@ -211,7 +211,8 @@ sub turn_off_kde_screensaver {
         assert_and_click('kde-disable-screenlock');
     }
     assert_screen 'screenlock-disabled';
-    send_key('alt-o');
+    # Was 'alt-o' before, but does not work in Plasma 5.17 due to kde#411758
+    send_key('ctrl-ret');
     assert_screen 'generic-desktop';
 }
 


### PR DESCRIPTION
Due to kde#411758 there's a conflict which can't be fixed easily.
Use Ctrl-Ret as a workaround.

Issue can be seen here:
TW Staging:K, with Plasma 5.17 Beta: https://openqa.opensuse.org/tests/1042324#step/updates_packagekit_kde/13
Argon, Plasma 5.17 Beta: https://openqa.opensuse.org/tests/1042702#step/live_installation/12

Verification runs:
TW Staging:K: http://10.160.67.86/tests/479
Leap 15.0 KDE live: http://10.160.67.86/tests/480
TW Live: http://10.160.67.86/tests/481
Argon: http://10.160.67.86/tests/482