### PR TITLE
Change poo# number for saptune_v2 issues

### DIFF
--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -207,7 +207,7 @@ sub prepare_profile {
             $self->select_serial_terminal;
             $ret = script_run "saptune solution verify $profile";
         }
-        record_soft_failure("poo#54695: 'saptune solution verify' returned warnings or errors! Please check!")
+        record_soft_failure("poo#57464: 'saptune solution verify' returned warnings or errors! Please check!")
           if $ret;
 
         my $output = script_output "saptune daemon status", proceed_on_failure => 1;


### PR DESCRIPTION
In SLES4SAP tests there is some issues with the new saptune_v2 tuning tool (non blocking issues).

This commit change the poo# number to the good one (poo#57464).

- Related ticket: https://progress.opensuse.org/issues/57464
- Needles: N/A
- Verification run: I don't think that a verification run is really needed!
