### PR TITLE
Fix boot_ltp failures in ltp_ima test jobs

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -16,6 +16,7 @@ use base 'opensusebasetest';
 use testapi;
 use bootloader_setup 'boot_grub_item';
 use LTP::WhiteList 'download_whitelist';
+use serial_terminal 'get_login_message';
 
 sub run {
     my ($self, $tinfo) = @_;
@@ -28,6 +29,7 @@ sub run {
         record_info('INFO', 'IMA boot');
         # boot kernel with IMA parameters
         boot_grub_item();
+        wait_serial(get_login_message(), 500);
     }
     elsif (check_var('BACKEND', 'ipmi')) {
         record_info('INFO', 'IPMI boot');


### PR DESCRIPTION
ltp_ima test jobs fail in boot_ltp on SLE-15GA because the wait for login prompt times out after 30 seconds. This patch gives the test system a little more time to boot up.

- Related ticket: https://progress.opensuse.org/issues/49571
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/3422304
