### PR TITLE
Select X11 console to avoid mismatched needles

### DIFF
--- a/tests/locale/keymap_or_locale_x11.pm
+++ b/tests/locale/keymap_or_locale_x11.pm
@@ -20,6 +20,7 @@ use testapi;
 
 sub run {
     my ($self) = @_;
+    select_console('x11');
     # uncomment in case of different keyboard than us is used during installation ( feature not ready yet )
     # my $expected   = get_var('INSTALL_KEYBOARD_LAYOUT','us');
     my $expected   = 'us';


### PR DESCRIPTION
The test schedule was changed, and keymap_or_locale_x11 was added instead of the previous one (which was executed on a console)

* See https://openqa.suse.de/tests/3417938#step/keymap_or_locale_x11/11
* VR: https://openqa.suse.de/tests/3422430

Created a verification run, but I think it's safe to merge. 