### PR TITLE
send_key_until_needlematch has an unexpected counter-effect, this change sends the key combination once and then asserts the screen.

### DIFF
--- a/tests/console/yast2_nis.pm
+++ b/tests/console/yast2_nis.pm
@@ -66,32 +66,38 @@ sub run() {
     assert_screen 'expert_settings';                                     # check the needle enable Broken server
     send_key 'alt-y';
     wait_screen_change { type_string "-c" };                             # only checks if the config file has syntax errors and exits
-    wait_screen_change { send_key 'alt-o' };
-    send_key_until_needlematch('nfs-client-configuration', 'alt-s', 2, 5);    # enter NFS configuration, sometimes fails, retry
-    send_key 'alt-a';                                                         # add nfs settings
-    assert_screen 'nfs-server-hostname';                                      # check that type string is sucessful
-    send_key 'alt-n';                                                         # from here enter some configurations...
+    wait_still_screen;
+    send_key 'alt-o';
+    wait_still_screen;
+    send_key 'alt-s';
+    wait_still_screen;
+    assert_screen 'nfs-client-configuration';                            # enter NFS configuration
+    send_key 'alt-a';                                                    # add nfs settings
+    assert_screen 'nfs-server-hostname';                                 # check that type string is sucessful
+    send_key 'alt-n';                                                    # from here enter some configurations...
     type_string "nis.suse.de";
     send_key 'alt-r';
     type_string "/mounts";
     send_key 'alt-m';
     type_string "/mounts_local";
     send_key 'alt-o';
-    assert_screen 'nfs_server_added';                                         # check Mount point
-    wait_screen_change { send_key 'alt-t' };                                  # go back to nfs configuration and delete configuration created before
-    assert_screen 'nis_server_delete';                                        # confirm to delete configuration
+    assert_screen 'nfs_server_added';                                    # check Mount point
+    wait_still_screen;
+    send_key 'alt-t';
+    wait_still_screen 1;
+    assert_screen 'nis_server_delete';                                   # confirm to delete configuration
     send_key 'alt-y';
     wait_still_screen 2;
     send_key 'alt-o';
     wait_still_screen 2;
-    send_key 'alt-f';                                                         # close the dialog...
+    send_key 'alt-f';                                                    # close the dialog...
     assert_screen([qw(nis_server_not_found ypbind_error)]);
     if (match_has_tag 'ypbind_error') {
         record_soft_failure 'bsc#1073281';
         send_key 'alt-o';
     }
     else {
-        send_key 'alt-o';                                                     # close it now even when config is not valid
+        send_key 'alt-o';                                                # close it now even when config is not valid
     }    # check error message for 'nis server not found'
 }
 1;


### PR DESCRIPTION
An improvement should be made to stop sending alt-s, this has a counter-effect of changing tab in the next yast screen on which this key combination is also accepted making the test fail. 
Now we send that combination once, and manually, then we check via check_screen and send it again if it was not 'read', then we wait a little and continue as usual.

- Related ticket: https://progress.opensuse.org/issues/57545
- Needles: None

- Verification run: 
12.2 http://deathstar.suse.cz/tests/1482
12.3 http://deathstar.suse.cz/tests/1483
12.4 http://deathstar.suse.cz/tests/1481
12.5 http://deathstar.suse.cz/tests/1478
15.0 http://deathstar.suse.cz/tests/1479
15.1 http://deathstar.suse.cz/tests/1480