### PR TITLE
publiccloud: Rename IPA to img-proof

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2623,8 +2623,8 @@ sub load_publiccloud_tests {
     if (get_var('PUBLIC_CLOUD_PREPARE_TOOLS')) {
         loadtest "publiccloud/prepare_tools";
     }
-    elsif (get_var('PUBLIC_CLOUD_IPA_TESTS')) {
-        loadtest "publiccloud/ipa";
+    elsif (get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS')) {
+        loadtest "publiccloud/img_proof";
     }
     elsif (get_var('PUBLIC_CLOUD_LTP')) {
         loadtest 'publiccloud/run_ltp';

--- a/lib/publiccloud/azure.pm
+++ b/lib/publiccloud/azure.pm
@@ -155,7 +155,7 @@ sub upload_img {
     return $img_name;
 }
 
-sub ipa {
+sub img_proof {
     my ($self, %args) = @_;
 
     my $credentials_file = 'azure_credentials.txt';
@@ -180,7 +180,7 @@ sub ipa {
     $args{user}          //= 'azureuser';
     $args{provider}      //= 'azure';
 
-    return $self->run_ipa(%args);
+    return $self->run_img_proof(%args);
 }
 
 sub on_terraform_timeout {

--- a/lib/publiccloud/ec2.pm
+++ b/lib/publiccloud/ec2.pm
@@ -139,7 +139,7 @@ sub upload_img {
     return $ami;
 }
 
-sub ipa {
+sub img_proof {
     my ($self, %args) = @_;
 
     $args{instance_type}        //= 't2.large';
@@ -150,7 +150,7 @@ sub ipa {
     $args{key_secret}           //= $self->key_secret;
     $args{key_name}             //= $self->ssh_key;
 
-    return $self->run_ipa(%args);
+    return $self->run_img_proof(%args);
 }
 
 sub cleanup {

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -109,7 +109,7 @@ sub upload_img {
     return $img_name;
 }
 
-sub ipa {
+sub img_proof {
     my ($self, %args) = @_;
 
     $args{credentials_file} = CREDENTIALS_FILE;
@@ -117,7 +117,7 @@ sub ipa {
     $args{user}          //= 'susetest';
     $args{provider}      //= 'gce';
 
-    return $self->run_ipa(%args);
+    return $self->run_img_proof(%args);
 }
 
 sub describe_instance

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -70,11 +70,11 @@ sub upload_image {
 }
 
 
-=head2 ipa
+=head2 img_proof
 
-  ipa(instance_type => <string>, cleanup => <bool>, tests => <string>, timeout => <seconds>, results_dir => <string>, distro => <string>);
+  img_proof(instance_type => <string>, cleanup => <bool>, tests => <string>, timeout => <seconds>, results_dir => <string>, distro => <string>);
 
-Call ipa tool and retrieves a hashref as result. Do not die if ipa call exit with error.
+Call img-proof tool and retrieves a hashref as result. Do not die if img-proof call exit with error.
   $result_hash = {
         instance    => <publiccloud:instance>,    # instance object
         logfile     => <string>,                  # the pytest logfile
@@ -87,16 +87,16 @@ Call ipa tool and retrieves a hashref as result. Do not die if ipa call exit wit
   };
 
 =cut
-sub ipa {
-    die('ipa() isn\'t implemented');
+sub img_proof {
+    die('img_proof() isn\'t implemented');
 }
 
-=head2 parse_ipa_output
+=head2 parse_img_proof_output
 
-Parse the output from ipa command and retrieves instance-id, ip and logfile names.
+Parse the output from img-proof command and retrieves instance-id, ip and logfile names.
 
 =cut
-sub parse_ipa_output {
+sub parse_img_proof_output {
     my ($self, $output) = @_;
     my $ret = {};
     my $instance_id;
@@ -147,23 +147,23 @@ sub create_ssh_key {
     }
 }
 
-=head2 run_ipa
+=head2 run_img_proof
 
-called by childs within ipa function
+called by childs within img-proof function
 
 =cut
-sub run_ipa {
+sub run_img_proof {
     my ($self, %args) = @_;
     die('Must provide an instance object') if (!$args{instance});
 
     $args{tests}       //= '';
     $args{timeout}     //= 60 * 30;
-    $args{results_dir} //= 'ipa_results';
+    $args{results_dir} //= 'img_proof_results';
     $args{distro}      //= 'sles';
     $args{tests} =~ s/,/ /g;
 
     my $version = script_output('img-proof --version', 300);
-    record_info("IPA version", $version);
+    record_info("img-proof version", $version);
 
     my $cmd = 'img-proof --no-color test ' . $args{provider};
     $cmd .= ' --debug ';
@@ -181,19 +181,19 @@ sub run_ipa {
     $cmd .= '--running-instance-id "' . $args{instance}->instance_id . '" ';
 
     $cmd .= $args{tests};
-    record_info("IPA cmd", $cmd);
+    record_info("img-proof cmd", $cmd);
 
     my $output = script_output($cmd . ' 2>&1', $args{timeout}, proceed_on_failure => 1);
-    record_info("IPA output", $output);
-    my $ipa = $self->parse_ipa_output($output);
-    record_info("IPA results", Dumper($ipa));
-    die($output) unless (defined($ipa));
+    record_info("img-proof output", $output);
+    my $img_proof = $self->parse_img_proof_output($output);
+    record_info("img-proof results", Dumper($img_proof));
+    die($output) unless (defined($img_proof));
 
-    $args{instance}->public_ip($ipa->{ip});
-    delete($ipa->{instance_id});
-    delete($ipa->{ip});
+    $args{instance}->public_ip($img_proof->{ip});
+    delete($img_proof->{instance_id});
+    delete($img_proof->{ip});
 
-    return $ipa;
+    return $img_proof;
 }
 
 =head2 get_image_id

--- a/tests/publiccloud/img_proof.pm
+++ b/tests/publiccloud/img_proof.pm
@@ -7,7 +7,7 @@
 # notice and this notice are preserved.  This file is offered as-is,
 # without any warranty.
 
-# Summary: Use IPA framework to test public cloud SUSE images
+# Summary: Use img-proof framework to test public cloud SUSE images
 #
 # Maintainer: Clemens Famulla-Conrad <cfamullaconrad@suse.de>
 
@@ -23,20 +23,20 @@ sub run {
 
     my $provider = $self->provider_factory();
     my $instance = $provider->create_instance();
-    my $tests    = get_var('PUBLIC_CLOUD_IPA_TESTS', '');
+    my $tests    = get_var('PUBLIC_CLOUD_IMG_PROOF_TESTS', '');
 
-    my $ipa = $provider->ipa(
+    my $img_proof = $provider->img_proof(
         instance    => $instance,
         tests       => $tests,
-        results_dir => 'ipa_results'
+        results_dir => 'img_proof_results'
     );
 
-    upload_logs($ipa->{logfile});
-    parse_extra_log(IPA => $ipa->{results});
-    assert_script_run('rm -rf ipa_results');
+    upload_logs($img_proof->{logfile});
+    parse_extra_log(IPA => $img_proof->{results});
+    assert_script_run('rm -rf img_proof_results');
 
     # fail, if at least one test failed
-    if ($ipa->{fail} > 0) {
+    if ($img_proof->{fail} > 0) {
 
         # Upload cloudregister log if corresponding test fails
         for my $t (@{$self->{extra_test_results}}) {
@@ -57,10 +57,10 @@ sub cleanup {
     my ($self) = @_;
 
     # upload logs on unexpected failure
-    my $ret = script_run('test -d ipa_results');
+    my $ret = script_run('test -d img_proof_results');
     if (defined($ret) && $ret == 0) {
-        assert_script_run('tar -zcvf ipa_results.tar.gz ipa_results');
-        upload_logs('ipa_results.tar.gz', failok => 1);
+        assert_script_run('tar -zcvf img_proof_results.tar.gz img_proof_results');
+        upload_logs('img_proof_results.tar.gz', failok => 1);
     }
 }
 
@@ -68,14 +68,14 @@ sub cleanup {
 
 =head1 Discussion
 
-This module use IPA tool to test public cloud SLE images.
+This module use img-proof tool to test public cloud SLE images.
 Logs are uploaded at the end.
 
-When running IPA from SLES, it must have a valid SCC registration to enable
+When running img-proof from SLES, it must have a valid SCC registration to enable
 public cloud module.
 
 The variables DISTRI, VERSION and ARCH must correspond to the system where
-IPA get installed in and not to the public cloud image.
+img-proof get installed in and not to the public cloud image.
 
 =head1 Configuration
 

--- a/tests/publiccloud/prepare_tools.pm
+++ b/tests/publiccloud/prepare_tools.pm
@@ -70,11 +70,8 @@ sub run {
     record_info('GCE', script_output('source ~/.bashrc && gcloud version'));
 
     # Create some directories, ipa will need them
-    assert_script_run("mkdir -p ~/ipa/tests/");
-    assert_script_run("mkdir -p .config/ipa");
-    assert_script_run("touch .config/ipa/config");
     assert_script_run("img-proof list");
-    record_info('IPA', script_output('img-proof --version'));
+    record_info('img-proof', script_output('img-proof --version'));
 
     # Install Terraform from repo
     zypper_call('ar https://download.opensuse.org/repositories/systemsmanagement:/terraform/SLE_15/systemsmanagement:terraform.repo');


### PR DESCRIPTION
Public Cloud tests using tool called img-proof.
Former name of this tool is IPA a lot of code
were refering to this old name. To avoid confusion
all variables/function/files containing "ipa" in their
names were renamed to "img_proof"

VR: http://10.160.67.22/tests/22 ( EC2 ) 
http://10.160.67.22/tests/25 ( GCE ) 
http://10.160.67.22/tests/26 ( Azure ) 