### PR TITLE
 Use common post-fail hook for yast module tests 

### DIFF
--- a/lib/y2_module_consoletest.pm
+++ b/lib/y2_module_consoletest.pm
@@ -2,11 +2,9 @@
 
 package y2_module_consoletest;
 use parent 'y2_module_basetest';
-use y2_installbase;
 use strict;
 use warnings;
 use testapi;
-use utils 'show_tasks_in_blocked_state';
 use Utils::Backends 'is_hyperv';
 
 sub yast2_console_exec {
@@ -29,24 +27,6 @@ sub yast2_console_exec {
     } else {
         die "Yast2 module failed to execute!\n";
     }
-}
-
-sub post_fail_hook {
-    my $self = shift;
-
-    my $defer_blocked_task_info = testapi::is_serial_terminal();
-    show_tasks_in_blocked_state unless ($defer_blocked_task_info);
-
-    select_console 'log-console';
-    save_screenshot;
-
-    show_tasks_in_blocked_state if ($defer_blocked_task_info);
-
-    $self->remount_tmp_if_ro;
-    y2_installbase::save_upload_y2logs($self);
-    upload_logs('/var/log/zypper.log', failok => 1);
-    y2_installbase::save_system_logs($self);
-    y2_installbase::save_strace_gdb_output($self, 'yast');
 }
 
 sub post_run_hook {

--- a/lib/y2_module_guitest.pm
+++ b/lib/y2_module_guitest.pm
@@ -56,13 +56,6 @@ sub launch_yast2_module_x11 {
     send_key 'alt-f10' if $args{maximize_window};
 }
 
-sub post_fail_hook {
-    my ($self) = shift;
-    show_tasks_in_blocked_state;
-    $self->export_logs;
-    save_screenshot;
-}
-
 sub post_run_hook {
     assert_screen('generic-desktop');
 }


### PR DESCRIPTION
Verification run: https://openqa.suse.de/tests/3429763# ( we were not able to recover network connection there, so `post_fail_hook` fails to upload logs.

