### PR TITLE
HPC: Lower the number of pings

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -165,7 +165,7 @@ sub generate_and_distribute_ssh {
 sub check_nodes_availability {
     my @cluster_nodes = cluster_names();
     foreach (@cluster_nodes) {
-        assert_script_run("ping -c 5 $_");
+        assert_script_run("ping -c 3 $_");
     }
 }
 


### PR DESCRIPTION
As the function proved right for basic check if the created cluster
is having basing connectivity among all nodes, it make sense to
keep it, however the arbitrary number of pings=5 could be lowered
so that the test could save a few seconds form its run time
