### PR TITLE
Add support for softfail messages in ltp_known_issues.json

### DIFF
--- a/lib/LTP/WhiteList.pm
+++ b/lib/LTP/WhiteList.pm
@@ -63,12 +63,13 @@ sub override_known_failures {
 
   ISSUE:
     foreach my $cond (@issues) {
-        foreach my $filter (qw(product ltp_version revision arch kernel)) {
+        foreach my $filter (qw(product ltp_version revision arch kernel backend retval)) {
             next ISSUE if exists $cond->{$filter} and $env->{$filter} !~ m/$cond->{$filter}/;
         }
 
         bmwqemu::diag("Failure in LTP:$suite:$test is known, overriding to softfail");
         $self->{result} = 'softfail';
+        record_soft_failure($cond->{message}) if exists $cond->{message};
         last;
     }
 }


### PR DESCRIPTION
This patch adds new features to the JSON list of known issues for LTP tests:
1. `backend` filter: soft-fail tests only if they run on specific backend
2. `retval` filter: soft-fail tests only if they return a specific error code
3. `message`: custom soft-fail message to be added to the failed test

- Related ticket: N/A
- Needles: N/A
- Verification runs:
https://openqa.suse.de/tests/3433283 (test not soft-failed because of wrong retval)
https://openqa.suse.de/tests/3433284 (test with custom soft-fail message)
See `dhcpd6` and `dnsmasq6` test modules in both jobs.