### PR TITLE
Remove soft-failure for bsc#1061051

### DIFF
--- a/tests/console/hostname.pm
+++ b/tests/console/hostname.pm
@@ -31,17 +31,6 @@ sub run {
     select_console 'root-console';
 
     set_hostname(get_var('HOSTNAME', 'susetest'));
-    if (script_run("ip addr show br0 | grep DOWN") == 0) {
-        record_soft_failure('bsc#1061051');
-        systemctl('reload network');
-        systemctl('status network');
-        save_screenshot;
-        systemctl('restart network');
-        systemctl('status network');
-        save_screenshot;
-        assert_script_run "ip addr show br0 | grep UP";
-        save_screenshot;
-    }
 }
 
 sub test_flags {


### PR DESCRIPTION
Bug is verified fixed. I've checked that even in QAM tests of SLE 12 SP1
test module doesn't fail.
Also, on openSUSE it causes issues as detection is wicked specific, as
well as check of the workaround.

- Related ticket: https://progress.opensuse.org/issues/57569
- Verification run: https://openqa.suse.de/t3433321
