### PR TITLE
Add missing import for zypper_call

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -8,6 +8,7 @@ use testapi;
 use network_utils;
 use version_utils qw(is_caasp is_sle);
 use y2_logs_helper 'get_available_compression';
+use utils 'zypper_call';
 
 sub use_wicked {
     script_run "cd /proc/sys/net/ipv4/conf";


### PR DESCRIPTION
See [poo#57110](https://progress.opensuse.org/issues/57110).

Fixes:
[2019-09-19T19:53:03.702 CEST] [debug] post_fail_hook failed: Undefined subroutine &y2_installbase::zypper_call called at /var/lib/openqa/cache/openqa.suse.de/tests/sle/lib/y2_installbase.pm line 273.
