### PR TITLE
Fix new firefox behavior

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1973,10 +1973,6 @@ sub load_x11_webbrowser {
     loadtest "x11/firefox/firefox_passwd";
     loadtest "x11/firefox/firefox_html5";
     loadtest "x11/firefox/firefox_developertool";
-    ## RSS is removed since Firefox 64
-    if (is_sle('<=15-SP1') || is_leap('<=15.1')) {
-        loadtest "x11/firefox/firefox_rss";
-    }
     loadtest "x11/firefox/firefox_ssl";
     loadtest "x11/firefox/firefox_emaillink";
     loadtest "x11/firefox/firefox_plugins";

--- a/lib/x11test.pm
+++ b/lib/x11test.pm
@@ -509,11 +509,6 @@ sub setup_mail_account {
     assert_screen "evolution_mail-max-window";
 }
 
-# Firefox 60 is the current Extended Support Release.
-sub is_firefox_60 {
-    is_sle('<=15-SP1') || is_leap('<=15.1');
-}
-
 # start clean firefox with one suse.com tab, visit pages which trigger pop-up so they will not pop again
 # .mozilla is stored as .mozilla_first_run to be reference profile for following tests
 sub start_clean_firefox {
@@ -536,7 +531,7 @@ sub start_clean_firefox {
             assert_and_click 'firefox_trackinfo';
             last;
         }
-        # the needle match area has to be where trackinfo would pop-up
+        # the needle match area has to be where trackinfo does pop-up
         elsif (check_screen 'firefox-developertool-opensuse') {
             record_info 'Tracking protection', 'Track info pop-up did NOT show up';
             last;
@@ -678,7 +673,7 @@ sub firefox_open_url {
 
 sub exit_firefox_common {
     # Exit
-    send_key 'alt-f4';
+    send_key 'ctrl-q';
     send_key_until_needlematch([qw(firefox-save-and-quit xterm-left-open xterm-without-focus)], "alt-f4", 3, 30);
     if (match_has_tag 'firefox-save-and-quit') {
         # confirm "save&quit"

--- a/schedule/qam/15/qam-regression-firefox@64bit.yaml
+++ b/schedule/qam/15/qam-regression-firefox@64bit.yaml
@@ -1,0 +1,39 @@
+---
+description: Please write own description
+name: qam-regression-firefox-SLED
+schedule:
+- boot/boot_to_desktop
+- x11/window_system
+- x11/firefox/firefox_smoke
+- x11/firefox/firefox_urlsprotocols
+- x11/firefox/firefox_downloading
+- x11/firefox/firefox_changesaving
+- x11/firefox/firefox_fullscreen
+- x11/firefox/firefox_flashplayer
+- x11/firefox/firefox_localfiles
+- x11/firefox/firefox_headers
+- x11/firefox/firefox_pdf
+- x11/firefox/firefox_pagesaving
+- x11/firefox/firefox_private
+- x11/firefox/firefox_extensions
+- x11/firefox/firefox_appearance
+- x11/firefox/firefox_passwd
+- x11/firefox/firefox_html5
+- x11/firefox/firefox_developertool
+- x11/firefox/firefox_rss
+- x11/firefox/firefox_ssl
+- x11/firefox/firefox_emaillink
+- x11/firefox/firefox_plugins
+- x11/firefox/firefox_extcontent
+- x11/firefox/firefox_gnomeshell
+- x11/firefox_audio
+vars:
+  BOOT_HDD_IMAGE: '1'
+  HDD_1: SLED-12-SP4-20191001-2-x86_64@64bit_for_regression.qcow2
+  ISO: SLE-12-SP4-Desktop-DVD-x86_64-GM-DVD1.iso
+  MACHINE: 64bit
+  REGRESSION: firefox
+  START_AFTER_TEST: qam-regression-installation-SLED
+  TEST: qam-regression-firefox-SLED
+  VIRTIO_CONSOLE: '1'
+...

--- a/tests/x11/firefox/firefox_changesaving.pm
+++ b/tests/x11/firefox/firefox_changesaving.pm
@@ -33,10 +33,7 @@ use version_utils 'is_sle';
 sub run {
 
     my ($self) = @_;
-    my $profilename = '*.default-*';
-    $profilename = '*.default' if $self->is_firefox_60;
-
-    my $changesaving_checktimestamp = "ll --time-style=full-iso .mozilla/firefox/" . $profilename . "/prefs.js | cut -d' ' -f7";
+    my $changesaving_checktimestamp = "ll --time-style=full-iso .mozilla/firefox/*default*/prefs.js | cut -d' ' -f7";
 
     $self->start_firefox_with_profile;
 

--- a/tests/x11/firefox/firefox_extensions.pm
+++ b/tests/x11/firefox/firefox_extensions.pm
@@ -43,9 +43,13 @@ sub run {
         assert_and_click 'firefox-extensions-flagfox';
         wait_still_screen 3;
         assert_and_click 'firefox-extensions-add-to-firefox';
+        wait_still_screen 3;
         assert_screen 'firefox-extensions-confirm-add';
         send_key 'alt-a';
         wait_still_screen 3;
+        assert_and_click 'firefox-extensions-added';
+        wait_still_screen 3;
+        assert_and_click 'firefox-extensions-flagfox-tab';
         # close the flagfox relase notes tab and flagfox search tab
         send_key_until_needlematch 'firefox-addons-plugins', 'ctrl-w', 3, 3;
         # refresh the page to see addon buttons
@@ -58,13 +62,11 @@ sub run {
     assert_screen('firefox-extensions-show_flag');
 
     send_key "alt-2";
-    if ($self->is_firefox_60) {
-        assert_and_click('firefox-extensions-flagfox_installed');
+    assert_and_click('firefox-extensions-menu-icon') if check_screen('firefox-extensions-menu-icon');
+    assert_and_click('firefox-extensions-flagfox_installed');
 
-        send_key "alt-1";
-        assert_screen('firefox-extensions-no_flag', 90);
-    }
-    # for firefox 68, it needs much more to disable the extension
+    send_key "alt-1";
+    assert_screen('firefox-extensions-no_flag', 90);
 
     $self->exit_firefox;
 }

--- a/tests/x11/firefox/firefox_passwd.pm
+++ b/tests/x11/firefox/firefox_passwd.pm
@@ -52,16 +52,14 @@ sub run {
 
     send_key "alt-shift-u";
     wait_still_screen 3;
-    send_key 'spc' if $self->is_firefox_60;
+    send_key 'spc' unless check_screen('firefox-passwd-master_setting');
 
     assert_screen('firefox-passwd-master_setting');
 
-    type_string $masterpw;
+    type_string $masterpw, 150;
     send_key "tab";
-    type_string $masterpw;
-
-    # confirm password change
-    for (1 .. 2) { send_key 'tab'; }
+    type_string $masterpw, 150;
+    wait_still_screen 3;
     send_key 'ret';
     assert_and_click('firefox-passwd-success');
 
@@ -85,18 +83,12 @@ sub run {
     send_key "alt-e";
     send_key "n";    #Preferences
     assert_and_click('firefox-passwd-security');
-    if ($self->is_firefox_60) {
-        send_key "alt-shift-l";    #"Saved Logins"
-    } else {
-        ## tweak for firefox 68
-        send_key "alt-shift-l";    #"Clear Data"
-        send_key "alt-shift-l";    #"Saved Logins"
-    }
+    send_key_until_needlematch 'firefox-saved-logins-button', 'alt-shift-l', 5, 1;
     wait_still_screen 3;
     send_key 'spc';
     assert_screen('firefox-passwd-saved');
 
-    send_key "alt-shift-a";        #"Remove"
+    send_key "alt-shift-a";    #"Remove"
     wait_still_screen 3;
     send_key "alt-y";
     wait_still_screen 3;

--- a/tests/x11/firefox/firefox_ssl.pm
+++ b/tests/x11/firefox/firefox_ssl.pm
@@ -37,17 +37,11 @@ sub run {
 
     # go to advanced button and press it
     send_key "tab";
-    send_key "ret";
-    if ($self->is_firefox_60) {
-        for (1 .. 2) { send_key "tab"; }
-        send_key "ret";
-
-        assert_screen('firefox-ssl-addexception', 60);
-        send_key "alt-c";
-    } else {
-        ## This is new behavior for firefox 68
-        for (1 .. 4) { send_key "tab"; }
-        send_key "ret";
+    send_key 'spc';
+    send_key_until_needlematch 'firefox-ssl-risk-accept-and-continue-button-selected', 'tab', 7, 1;
+    send_key 'spc';
+    if (check_screen 'firefox-ssl-addexception', 5) {
+        send_key 'alt-c';
     }
 
     assert_screen('firefox-ssl-loadpage', 60);


### PR DESCRIPTION
- remove rss test as ess is gone
- remove is_firefox_60 as firefox version is not linked to SLE version
- close firefox with alt-q, this solve problem with multiple instances like
  with secure browsing
- fix default firefox directory
- handle new extension pop-up after extension is added
- to remove extension first click on hiden icon with three dots if present
- after setting master pw confirm with enter, no need to tab on OK button
- use needle to find saved logons button
- use needle to handle ssl exception

- Related ticket:
https://progress.opensuse.org/issues/57611
https://progress.opensuse.org/issues/57608
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1226
- Verification run:
http://10.100.12.155/tests