### PR TITLE
Add test for HANA SR

### DIFF
--- a/data/sles4sap/hana_cluster.conf
+++ b/data/sles4sap/hana_cluster.conf
@@ -1,0 +1,35 @@
+primitive dlm ocf:pacemaker:controld \
+        op start timeout=90 interval=0 \
+        op stop timeout=100 interval=0 \
+        op monitor timeout=20 interval=10 \
+        op_params start_delay=0 \
+        meta target-role=Started
+primitive rsc_SAPHanaTopology_%SID%_HDB%HDB_INSTANCE% ocf:suse:SAPHanaTopology \
+        params SID=%SID% InstanceNumber=%HDB_INSTANCE% \
+        op monitor interval=10 timeout=600 \
+        op start interval=0 timeout=600 \
+        op stop interval=0 timeout=300
+primitive rsc_SAPHana_%SID%_HDB%HDB_INSTANCE% ocf:suse:SAPHana \
+        params SID=%SID% InstanceNumber=%HDB_INSTANCE% PREFER_SITE_TAKEOVER=true AUTOMATED_REGISTER=%AUTOMATED_REGISTER% DUPLICATE_PRIMARY_TIMEOUT=7200 DIR_EXECUTABLE="" DIR_PROFILE="" INSTANCE_PROFILE="" \
+        op start interval=0 timeout=3600 \
+        op stop interval=0 timeout=3600 \
+        op promote interval=0 timeout=3600 \
+        op monitor interval=60 role=Master timeout=700 \
+        op monitor interval=61 role=Slave timeout=700
+primitive rsc_ip_%SID%_HDB%HDB_INSTANCE% IPaddr2 \
+        params ip=%VIRTUAL_IP_ADDRESS% cidr_netmask=%VIRTUAL_IP_NETMASK% nic=eth0 \
+        op start timeout=20 interval=0 \
+        op stop timeout=20 interval=0 \
+        op monitor interval=10 timeout=20
+primitive rsc_stonith_sbd stonith:external/sbd \
+        params pcmk_delay_max=15
+group base-group dlm \
+        meta target-role=Started
+ms msl_SAPHana_%SID%_HDB%HDB_INSTANCE% rsc_SAPHana_%SID%_HDB%HDB_INSTANCE% \
+        meta clone-max=2 clone-node-max=1 interleave=true
+clone base-clone base-group \
+        meta target-role=Started
+clone cln_SAPHanaTopology_%SID%_HDB%HDB_INSTANCE% rsc_SAPHanaTopology_%SID%_HDB%HDB_INSTANCE% \
+        meta is-managed=true clone-node-max=1 interleave=true
+colocation col_saphana_ip_%SID%_HDB%HDB_INSTANCE% 2000: rsc_ip_%SID%_HDB%HDB_INSTANCE%:Started msl_SAPHana_%SID%_HDB%HDB_INSTANCE%:Master
+order ord_SAPHana_%SID%_HDB%HDB_INSTANCE% Optional: cln_SAPHanaTopology_%SID%_HDB%HDB_INSTANCE% msl_SAPHana_%SID%_HDB%HDB_INSTANCE%

--- a/lib/hacluster.pm
+++ b/lib/hacluster.pm
@@ -287,6 +287,9 @@ sub ha_export_logs {
     upload_logs("$bootstrap_log",  failok => 1);
     upload_logs("$hb_log.tar.bz2", failok => 1);
 
+    script_run "crm configure show > /tmp/crm.txt";
+    upload_logs('/tmp/crm.txt');
+
     # Extract YaST logs and upload them
     script_run 'save_y2logs /tmp/y2logs.tar.bz2', 120;
     upload_logs('/tmp/y2logs.tar.bz2', failok => 1);

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2737,6 +2737,9 @@ sub load_sles4sap_tests {
     if (get_var('NW')) {
         loadtest "sles4sap/netweaver_install" if (get_var('SLES4SAP_MODE') !~ /wizard/);
         loadtest "sles4sap/netweaver_test_instance";
+    } elsif (get_var('HANA')) {
+        loadtest "sles4sap/hana_install" if (get_var('SLES4SAP_MODE') !~ /wizard/);
+        loadtest "sles4sap/hana_test";
     }
 }
 
@@ -2830,6 +2833,9 @@ sub load_ha_cluster_tests {
             loadtest 'sles4sap/netweaver_install';
             loadtest 'sles4sap/netweaver_cluster';
             loadtest 'sles4sap/sap_suse_cluster_connector';
+        } elsif (get_var('HANA')) {
+            loadtest 'sles4sap/hana_install';
+            loadtest 'sles4sap/hana_cluster';
         }
     }
     else {

--- a/lib/sles4sap.pm
+++ b/lib/sles4sap.pm
@@ -242,6 +242,8 @@ sub copy_media {
     type_string "cd $target\n";
     assert_script_run "umount $mnt_path";
 
+    return 1 if get_var('DISABLE_CHECKSUM');
+
     # Then verify everything was copied correctly
     # NOTE: checksum is generated with this command: "find . -type f -exec md5sum {} \; > checksums.md5sum"
     my $chksum_file = 'checksum.md5sum';

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -127,13 +127,19 @@ sub run {
         # Create barriers for SAP cluster
         # Note: we always create these barries even if they are not used, mainly
         # because it's not easy to know at this stage that we are testing a SAP cluster...
-        barrier_create("ASCS_INSTALLED_$cluster_name",     $num_nodes);
-        barrier_create("ERS_INSTALLED_$cluster_name",      $num_nodes);
-        barrier_create("NW_CLUSTER_HOSTS_$cluster_name",   $num_nodes);
-        barrier_create("NW_CLUSTER_INSTALL_$cluster_name", $num_nodes);
-        barrier_create("NW_INIT_CONF_$cluster_name",       $num_nodes);
-        barrier_create("NW_CREATED_CONF_$cluster_name",    $num_nodes);
-        barrier_create("NW_LOADED_CONF_$cluster_name",     $num_nodes);
+        barrier_create("ASCS_INSTALLED_$cluster_name",       $num_nodes);
+        barrier_create("ERS_INSTALLED_$cluster_name",        $num_nodes);
+        barrier_create("NW_CLUSTER_HOSTS_$cluster_name",     $num_nodes);
+        barrier_create("NW_CLUSTER_INSTALL_$cluster_name",   $num_nodes);
+        barrier_create("NW_INIT_CONF_$cluster_name",         $num_nodes);
+        barrier_create("NW_CREATED_CONF_$cluster_name",      $num_nodes);
+        barrier_create("NW_LOADED_CONF_$cluster_name",       $num_nodes);
+        barrier_create("NW_RA_RESTART_$cluster_name",        $num_nodes);
+        barrier_create("HANA_CLUSTER_INSTALL_$cluster_name", $num_nodes);
+        barrier_create("HANA_INIT_CONF_$cluster_name",       $num_nodes);
+        barrier_create("HANA_CREATED_CONF_$cluster_name",    $num_nodes);
+        barrier_create("HANA_LOADED_CONF_$cluster_name",     $num_nodes);
+        barrier_create("HANA_RA_RESTART_$cluster_name",      $num_nodes);
     }
 
     # Wait for all children to start

--- a/tests/sles4sap/hana_cluster.pm
+++ b/tests/sles4sap/hana_cluster.pm
@@ -1,0 +1,98 @@
+# SUSE's SLES4SAP openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Configure HANA-SR cluster
+# Maintainer: Ricardo Branco <rbranco@suse.de>
+
+use base "sles4sap";
+use testapi;
+use lockapi;
+use hacluster;
+use utils qw(systemctl file_content_replace);
+use strict;
+use warnings;
+
+sub run {
+    my ($self)       = @_;
+    my $instance_id  = get_required_var('INSTANCE_ID');
+    my $sid          = get_required_var('INSTANCE_SID');
+    my $cluster_name = get_cluster_name;
+    my ($virtual_ip, $virtual_netmask) = split '/', get_required_var('VIRTUAL_IP_CIDR');
+
+    # Set SAP variables
+    my $pscmd  = $self->set_ps_cmd("HDB");
+    my $sapadm = $self->set_sap_info($sid, $instance_id);
+
+    # Synchronize the nodes
+    barrier_wait "HANA_CLUSTER_INSTALL_$cluster_name";
+
+    $self->select_serial_terminal;
+
+    # Create the resource configuration
+    my $cluster_conf = 'hana_cluster.conf';
+    assert_script_run "curl -f -v " . autoinst_url . "/data/sles4sap/$cluster_conf -o /tmp/$cluster_conf";
+    $cluster_conf = "/tmp/" . $cluster_conf;
+
+    # Initiate the template
+    file_content_replace($cluster_conf, '--sed-modifier' => 'g',
+        '%SID%'                => $sid,
+        '%HDB_INSTANCE%'       => $instance_id,
+        '%AUTOMATED_REGISTER%' => get_required_var('AUTOMATED_REGISTER'),
+        '%VIRTUAL_IP_ADDRESS%' => $virtual_ip,
+        '%VIRTUAL_IP_NETMASK%' => $virtual_netmask);
+
+    # Avoid hostname change on reboot.  See bsc#1153402
+    file_content_replace('/etc/sysconfig/network/dhcp', 'DHCLIENT_SET_HOSTNAME="yes"' => 'DHCLIENT_SET_HOSTNAME="no"');
+
+    my $node1 = choose_node(1);
+    my $node2 = choose_node(2);
+
+    if (is_node(1)) {
+        foreach ($node1, $node2) {
+            add_to_known_hosts($_);
+        }
+        assert_script_run "scp -qr /usr/sap/$sid/SYS/global/security/rsecssfs/* root\@$node2:/usr/sap/$sid/SYS/global/security/rsecssfs/";
+        my $password = get_required_var('PASSWORD');
+        assert_script_run qq(su - $sapadm -c "hdbsql -u system -p $password -i $instance_id -d SYSTEMDB \\"BACKUP DATA FOR FULL SYSTEM USING FILE ('backup')\\""), 300;
+        assert_script_run "su - $sapadm -c 'hdbnsutil -sr_enable --name=NODE1'";
+
+        # Synchronize the nodes
+        barrier_wait "HANA_INIT_CONF_$cluster_name";
+        barrier_wait "HANA_CREATED_CONF_$cluster_name";
+
+        # Upload the configuration into the cluster
+        assert_script_run 'crm configure property maintenance-mode=true';
+        assert_script_run "crm configure load update $cluster_conf";
+        assert_script_run 'crm configure property maintenance-mode=false';
+    }
+    else {
+        # Synchronize the nodes
+        barrier_wait "HANA_INIT_CONF_$cluster_name";
+
+        assert_script_run "su - $sapadm -c 'sapcontrol -nr $instance_id -function StopSystem HDB'";
+        sleep 10;
+        assert_script_run "su - $sapadm -c 'hdbnsutil -sr_register --remoteHost=$node1 -remoteInstance=$instance_id --replicationMode=sync --name=NODE2 --operationMode=logreplay'";
+        assert_script_run "su - $sapadm -c 'sapcontrol -nr $instance_id -function StartSystem HDB'";
+        sleep 10;
+
+        # Synchronize the nodes
+        barrier_wait "HANA_CREATED_CONF_$cluster_name";
+    }
+
+    # Synchronize the nodes
+    barrier_wait "HANA_LOADED_CONF_$cluster_name";
+
+    # Wait for resources to be started
+    wait_until_resources_started(timeout => 300);
+
+    # And check for the state of the whole cluster
+    check_cluster_state;
+}
+
+1;

--- a/tests/sles4sap/wizard_hana_install.pm
+++ b/tests/sles4sap/wizard_hana_install.pm
@@ -21,7 +21,7 @@ use version_utils 'is_sle';
 
 sub run {
     my ($self) = @_;
-    my ($proto, $path) = split m|://|, get_required_var('MEDIA');
+    my ($proto, $path) = split m|://|, get_required_var('HANA');
     die "Currently supported protocols are nfs and smb" unless $proto =~ /^(nfs|smb)$/;
 
     my $timeout  = 3600 * get_var('TIMEOUT_SCALE', 1);


### PR DESCRIPTION
This PR adds a HANA SR (System Replication) test.

For the cluster part I reused the code for the Netweaver cluster.

Main changes that impact other modules:
  - Variable **MEDIA** renamed to **HANA**

Verification run with `AUTOMATED_REGISTER=true` and `TIMEOUT_SCALE=4`:
- [node1](http://ix64hae1001.qa.suse.de/tests/1842) & [node2](http://ix64hae1001.qa.suse.de/tests/1843)

Verification run with `AUTOMATED_REGISTER=false`:
- [node1](http://ix64hae1001.qa.suse.de/tests/1879) & [node2](http://ix64hae1001.qa.suse.de/tests/1880)

Latest verification runs:
http://ix64hae1001.qa.suse.de/tests/1903
http://ix64hae1001.qa.suse.de./tests/1904

Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1244

Variables added with example values:
- `AUTOMATED_REGISTER=true|false`
- `DISABLE_CHECKSUM` (true if set)
- `VIRTUAL_IP_CIDR=10.0.2.222/24`