### PR TITLE
Make swap partitions use RAID0 for RAID tests

### DIFF
--- a/schedule/yast/raid/raid10_opensuse_gpt.yaml
+++ b/schedule/yast/raid/raid10_opensuse_gpt.yaml
@@ -43,7 +43,7 @@ test_data:
           should_format: 1
         mounting_options:
           should_mount: 1
-    - raid_level: 10
+    - raid_level: 0
       chunk_size: 64
       device_selection_step: 1
       partition:

--- a/schedule/yast/raid/raid10_sle_gpt.yaml
+++ b/schedule/yast/raid/raid10_sle_gpt.yaml
@@ -43,7 +43,7 @@ test_data:
           should_format: 1
         mounting_options:
           should_mount: 1
-    - raid_level: 10
+    - raid_level: 0
       chunk_size: 64
       device_selection_step: 1
       partition:

--- a/schedule/yast/raid/raid1_opensuse_gpt.yaml
+++ b/schedule/yast/raid/raid1_opensuse_gpt.yaml
@@ -43,7 +43,7 @@ test_data:
           should_format: 1
         mounting_options:
           should_mount: 1
-    - raid_level: 1
+    - raid_level: 0
       chunk_size: 64
       device_selection_step: 1
       partition:

--- a/schedule/yast/raid/raid1_sle_gpt.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt.yaml
@@ -43,7 +43,7 @@ test_data:
           should_format: 1
         mounting_options:
           should_mount: 1
-    - raid_level: 1
+    - raid_level: 0
       chunk_size: 64
       device_selection_step: 1
       partition:

--- a/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid1_sle_gpt_uefi.yaml
@@ -93,7 +93,7 @@ test_data:
           should_format: 1
         mounting_options:
           should_mount: 1
-    - raid_level: 1
+    - raid_level: 0
       chunk_size: 64
       device_selection_step: 1
       partition:

--- a/schedule/yast/raid/raid5_opensuse_gpt.yaml
+++ b/schedule/yast/raid/raid5_opensuse_gpt.yaml
@@ -43,7 +43,7 @@ test_data:
           should_format: 1
         mounting_options:
           should_mount: 1
-    - raid_level: 5
+    - raid_level: 0
       chunk_size: 64
       device_selection_step: 1
       partition:

--- a/schedule/yast/raid/raid5_sle_gpt.yaml
+++ b/schedule/yast/raid/raid5_sle_gpt.yaml
@@ -43,7 +43,7 @@ test_data:
           should_format: 1
         mounting_options:
           should_mount: 1
-    - raid_level: 5
+    - raid_level: 0
       chunk_size: 64
       device_selection_step: 1
       partition:

--- a/schedule/yast/raid/raid6_sle_gpt.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt.yaml
@@ -43,7 +43,7 @@ test_data:
           should_format: 1
         mounting_options:
           should_mount: 1
-    - raid_level: 6
+    - raid_level: 0
       chunk_size: 64
       device_selection_step: 1
       partition:

--- a/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
+++ b/schedule/yast/raid/raid6_sle_gpt_uefi.yaml
@@ -93,7 +93,7 @@ test_data:
           should_format: 1
         mounting_options:
           should_mount: 1
-    - raid_level: 6
+    - raid_level: 0
       chunk_size: 64
       device_selection_step: 1
       partition:

--- a/test_data/yast/raid/raid10_gpt_uefi_test_data.yaml
+++ b/test_data/yast/raid/raid10_gpt_uefi_test_data.yaml
@@ -58,7 +58,7 @@ mds:
         should_format: 1
       mounting_options:
         should_mount: 1
-  - raid_level: 10
+  - raid_level: 0
     chunk_size: 64
     device_selection_step: 1
     partition:

--- a/test_data/yast/raid/raid1_gpt_uefi_test_data.yaml
+++ b/test_data/yast/raid/raid1_gpt_uefi_test_data.yaml
@@ -58,7 +58,7 @@ mds:
         should_format: 1
       mounting_options:
         should_mount: 1
-  - raid_level: 1
+  - raid_level: 0
     chunk_size: 64
     device_selection_step: 1
     partition:

--- a/test_data/yast/raid/raid5_gpt_uefi_test_data.yaml
+++ b/test_data/yast/raid/raid5_gpt_uefi_test_data.yaml
@@ -58,7 +58,7 @@ mds:
         should_format: 1
       mounting_options:
         should_mount: 1
-  - raid_level: 5
+  - raid_level: 0
     chunk_size: 64
     device_selection_step: 1
     partition:


### PR DESCRIPTION
RAID0 level is required to make all the RAID tests to be consistent and
to allow validation_raid to rely on that consistency, so that the
validation module will not fail if another RAID level is used.

- Related ticket: https://progress.opensuse.org/issues/56870
- Verification run: 
RAID1 (x86_64): https://openqa.suse.de/tests/3446069
RAID10 (ppc64le): https://openqa.suse.de/tests/3446068
RAID6 (aarch64): https://openqa.suse.de/tests/3446070

RAID10 (Tumbleweed-aarch64): https://openqa.opensuse.org/t1050993
RAID5 (Tumbleweed-ppc64le): https://openqa.opensuse.org/t1050382

VR for SLE12: https://openqa.suse.de/tests/3450402
VR for SLE15+: https://openqa.suse.de/t3450405