### PR TITLE
Fix regression in #8594

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -74,9 +74,8 @@ escape sequences (i.e. a single #) and changes the terminal width.
 =cut
 sub login {
     die 'Login expects two arguments' unless @_ == 2;
-    my $user        = shift;
-    my $escseq      = qr/(\e [\(\[] [\d\w]{1,2})/x;
-    my $pass_prompt = get_var('JEOSINSTLANG', '') =~ 'DE' ? 'Passwort:' : 'Password:';
+    my $user   = shift;
+    my $escseq = qr/(\e [\(\[] [\d\w]{1,2})/x;
 
     $serial_term_prompt = shift;
 
@@ -87,7 +86,7 @@ sub login {
     type_string("\n");
     wait_serial(qr/login:\s*$/i);
     type_string("$user\n");
-    wait_serial(qr/$pass_prompt\s*$/i);
+    wait_serial(qr/Password\s*$/i);
     type_password;
     type_string("\n");
     wait_serial(qr/$escseq* \w+:~\s\# $escseq* \s*$/x);

--- a/tests/jeos/glibc_locale.pm
+++ b/tests/jeos/glibc_locale.pm
@@ -177,9 +177,10 @@ sub run {
 
     ## Reboot and double check if the locale settings haven't changed
     power_action('reboot', textmode => 1);
+    record_info('Rebooting', "Expected locale set=$rc_lc_changed->{RC_LANG}");
     $self->wait_boot;
     select_console('root-console');
-    (test_users_locale($rc_lc_changed, $original_glibc_string) eq $updated_glibc_string) or die "Locale has changed after reboot!";
+    (test_users_locale($rc_lc_changed, $original_glibc_string) eq $updated_glibc_string) or die "Locale has changed after reboot!\n";
 
     ## Final check, is english locale set ?
     if (is_sle('15+')) {
@@ -189,6 +190,7 @@ sub run {
     } else {
         (/$updated_glibc_string/ eq /$test_lang_data{$lang_new}/) or die "Exit locale settings have not been changed to english!\n";
     }
+    reset_consoles;
 }
 
 1;


### PR DESCRIPTION
- Related ticket: [[JeOS][sle] test fails in glibc_locale - required module update](https://progress.opensuse.org/issues/57443)
- Verification runs:
   * [sle-12-SP5-JeOS-for-kvm-and-xen-x86_64-Build4.100-jeos-main-de_DE_intel_image@64bit-virtio-vga](http://eris.suse.cz/tests/1185#step/consoletest_setup/1)
   * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build3.19-jeos-main_intel_image@64bit-virtio-vga](http://eris.suse.cz/tests/1187#step/consoletest_setup/1)
   * [sle-15-SP1-JeOS-for-kvm-and-xen-x86_64-Build36.2.6-jeos-main-de_DE_intel_image@64bit-virtio-vga](http://eris.suse.cz/tests/1191#step/consoletest_setup/1)
   * [sle-12-SP5-JeOS-for-kvm-and-xen-x86_64-Build4.100-jeos-main_intel_image@64bit-virtio-vga](http://eris.suse.cz/tests/1195#step/consoletest_setup/1)
  * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build3.19-jeos-main-de_DE_intel_image@64bit-virtio-vga](http://eris.suse.cz/tests/1201)
  * [sle-15-SP1-JeOS-for-kvm-and-xen-x86_64-Build36.2.6-jeos-main_intel_image@64bit-virtio-vga](http://eris.suse.cz/tests/1206#)
