### PR TITLE
[WIP] Remove statement which prevent logs in remote installation

### DIFF
--- a/lib/y2_installbase.pm
+++ b/lib/y2_installbase.pm
@@ -204,9 +204,10 @@ sub save_remote_upload_y2logs {
     type_string "save_y2logs $filename\n";
     my $uploadname = +(split('/', $filename))[2];
     my $upname     = ($args{log_name} || $autotest::current_test->{name}) . '-' . $uploadname;
-    type_string "curl --form upload=\@$filename --form upname=$upname " . autoinst_url("/uploadlog/$upname") . "\n";
+    type_string "curl --form upload=\@$filename --form upname=$upname " . autoinst_url("/uploadlog/$upname");
+    send_key 'ret';
+    sleep 60;
     save_screenshot();
-    $self->investigate_yast2_failure();
 }
 
 sub save_system_logs {

--- a/tests/installation/welcome.pm
+++ b/tests/installation/welcome.pm
@@ -87,7 +87,7 @@ sub get_product_shortcuts {
 sub run {
     my ($self) = @_;
     my $iterations;
-
+    assert_screen("foo");
     my @welcome_tags     = ('inst-welcome-confirm-self-update-server', 'scc-invalid-url');
     my $expect_beta_warn = get_var('BETA');
     if ($expect_beta_warn) {


### PR DESCRIPTION
Avoid code that goes through the serial console in remote installation

[type description here, PLEASE, REMOVE THIS LINE, PLACEHOLDER, BEFORE SUBMITTING THIS PULL REQUEST]

- Related ticket: https://progress.opensuse.org/issues/50111
- Needles: N/A
- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
