### PR TITLE
Add missing ':' in password literal

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -86,7 +86,7 @@ sub login {
     type_string("\n");
     wait_serial(qr/login:\s*$/i);
     type_string("$user\n");
-    wait_serial(qr/Password\s*$/i);
+    wait_serial(qr/Password:\s*$/i);
     type_password;
     type_string("\n");
     wait_serial(qr/$escseq* \w+:~\s\# $escseq* \s*$/x);


### PR DESCRIPTION
Uncomplete regression fix [#8607](https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8607), causes issue with log consoles on serial_terminal.

E.g.
https://openqa.suse.de/tests/3450723#step/login/6
