### PR TITLE
Schedule qam-minimal+base via yaml

### DIFF
--- a/schedule/qam/15/qam-minimal-base@64bit.yaml
+++ b/schedule/qam/15/qam-minimal-base@64bit.yaml
@@ -1,0 +1,69 @@
+---
+name: qam-minimal-base
+vars:
+  COLLECT_COREDUMPS: 1
+  DESKTOP: textmode
+  PATTERNS: 'base,minimal'
+schedule:
+- installation/isosize
+- installation/bootloader
+- installation/welcome
+- installation/accept_license
+- installation/scc_registration
+- installation/add_update_test_repo
+- installation/addon_products_sle
+- installation/system_role
+- installation/partitioning
+- installation/partitioning_finish
+- installation/installer_timezone
+- installation/user_settings
+- installation/user_settings_root
+- installation/resolve_dependency_issues
+- installation/select_patterns_and_packages
+- installation/installation_overview
+- installation/disable_grub_timeout
+- installation/start_install
+- installation/await_install
+- installation/logs_from_installation_system
+- installation/reboot_after_installation
+- installation/grub_test
+- installation/first_boot
+- qa_automation/patch_and_reboot
+- locale/keymap_or_locale
+- console/system_prepare
+- console/check_network
+- console/system_state
+- console/prepare_test_data
+- console/consoletest_setup
+- console/force_scheduled_tasks
+- console/textinfo
+- console/hostname
+- console/installation_snapshots
+- console/zypper_in
+- console/zypper_lifecycle
+- console/zypper_lr
+- console/zypper_ref
+- console/firewall_enabled
+- console/glibc_sanity
+- console/salt
+- console/sshd
+- console/ssh_cleanup
+- console/ncurses
+- console/yast2_bootloader
+- console/yast2_i
+- console/yast2_lan
+- console/yast2_nfs_server
+- console/mtab
+- console/mysql_srv
+- console/rsync
+- console/curl_https
+- console/http_srv
+- console/dns_srv
+- console/apache
+- console/shibboleth
+- console/apache_ssl
+- console/apache_nss
+- console/postgresql_server
+- console/orphaned_packages_check
+- console/coredump_collect
+...


### PR DESCRIPTION
Remove zypper_up and add coredump_collect at the end fix duplicate of resolve_dependency_issues https://progress.opensuse.org/issues/57344

- Related ticket: 
https://progress.opensuse.org/issues/52859
https://progress.opensuse.org/issues/57344
- Verification run:
http://10.100.12.155/tests/13465
