### PR TITLE
HPC: use mount_nfs sub

### DIFF
--- a/lib/hpcbase.pm
+++ b/lib/hpcbase.pm
@@ -116,6 +116,7 @@ sub check_nodes_availability {
 
 sub mount_nfs {
     my ($self) = @_;
+    zypper_call('in nfs-client rpcbind');
     ## TODO: get rid of hardcoded name for the NFS-dir
     systemctl("start nfs");
     systemctl("start rpcbind");

--- a/tests/hpc/slurm_master_adv.pm
+++ b/tests/hpc/slurm_master_adv.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2019 SUSE LLC
+# Copyright © 2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -27,14 +27,8 @@ sub run {
     $self->prepare_user_and_group();
 
     zypper_call('in slurm slurm-munge');
-    zypper_call('in nfs-client rpcbind');
 
-    systemctl 'start nfs';
-    systemctl 'start rpcbind';
-    assert_script_run("showmount -e 10.0.2.1");
-    assert_script_run("mkdir -p /shared/slurm");
-    assert_script_run("chown -Rcv slurm:slurm /shared/slurm");
-    assert_script_run("mount -t nfs -o nfsvers=3 10.0.2.1:/nfs/shared /shared/slurm");
+    $self->mount_nfs();
     $self->prepare_slurm_conf();
     barrier_wait("SLURM_SETUP_DONE");
     record_info('slurmctl conf', script_output('cat /etc/slurm/slurm.conf'));

--- a/tests/hpc/slurm_master_backup.pm
+++ b/tests/hpc/slurm_master_backup.pm
@@ -22,19 +22,9 @@ sub run {
     my $nodes = get_required_var("CLUSTER_NODES");
 
     $self->prepare_user_and_group();
-    zypper_call('in nfs-client rpcbind');
-
-    systemctl 'start nfs';
-    systemctl 'start rpcbind';
-
-    assert_script_run("showmount -e 10.0.2.1");
-
-    assert_script_run("mkdir -p /shared/slurm");
-    assert_script_run("chown -Rcv slurm:slurm /shared/slurm");
-    assert_script_run("mount -t nfs -o nfsvers=3 10.0.2.1:/nfs/shared /shared/slurm");
-
     zypper_call('in slurm slurm-munge');
 
+    $self->mount_nfs();
     barrier_wait("SLURM_SETUP_DONE");
     barrier_wait("SLURM_MASTER_SERVICE_ENABLED");
 

--- a/tests/hpc/slurm_master_db.pm
+++ b/tests/hpc/slurm_master_db.pm
@@ -222,16 +222,9 @@ sub run {
     # provision HPC cluster, so the proper rpms are installed,
     # munge key is distributed to all nodes, so is slurm.conf
     # and proper services are enabled and started
-    zypper_call('in slurm slurm-munge slurm-torque');
+    zypper_call('in slurm slurm-munge slurm-torque mariadb');
 
-    zypper_call('in nfs-client rpcbind mariadb');
-    systemctl 'start nfs';
-    systemctl 'start rpcbind';
-    record_info('show mounts aviable on the supportserver', script_output('showmount -e 10.0.2.1'));
-    assert_script_run("mkdir -p /shared/slurm");
-    assert_script_run("chown -Rcv slurm:slurm /shared/slurm");
-    assert_script_run("mount -t nfs -o nfsvers=3 10.0.2.1:/nfs/shared /shared/slurm");
-
+    $self->mount_nfs();
     $self->prepare_slurm_conf();
     record_info('slurmctl conf', script_output('cat /etc/slurm/slurm.conf'));
     barrier_wait("SLURM_SETUP_DONE");


### PR DESCRIPTION
Replace direct mount of the NFS and use sub provided by the hpcbase

Verification run: http://10.160.65.14/tests/11465
http://10.160.65.14/tests/11465#step/slurm_master_adv/26