### PR TITLE
Fix SLES4SAP 'mr_test' on IPMI backend

### DIFF
--- a/tests/sles4sap/saptune/mr_test.pm
+++ b/tests/sles4sap/saptune/mr_test.pm
@@ -22,7 +22,7 @@ sub setup {
 
     my $tarball = get_var('MR_TEST_TARBALL', 'https://gitlab.suse.de/rbranco/mr_test/-/archive/master/mr_test-master.tar.gz');
 
-    select_console 'root-console';
+    $self->select_serial_terminal;
     # Disable packagekit
     pkcon_quit;
     # saptune is not installed by default on SLES4SAP 12 on ppc64le


### PR DESCRIPTION
Use `select_serial_terminal` instead of `select_console`.

- Related ticket: N/A
- Needles: N/A
- Verification run: None, small change already verified in PR #8253 , so should work and this will be tested ASAP after merge.
