### PR TITLE
virtualization: fix the name of the Tumbleweed vagrant box

### DIFF
--- a/tests/virtualization/vagrant/boxes/tumbleweed.pm
+++ b/tests/virtualization/vagrant/boxes/tumbleweed.pm
@@ -40,9 +40,9 @@ sub run() {
     my $build   = get_required_var('BUILD');
 
     my %boxes = (
-        # openSUSE-Tumbleweed-Vagrant.x86_64-1.0-{libvirt|virtualbox}-Snapshot20190704.vagrant.{libvirt|virtualbox}.box
-        libvirt    => "openSUSE-$version-Vagrant.$arch-1.0-libvirt-Snapshot$build.vagrant.libvirt.box",
-        virtualbox => "openSUSE-$version-Vagrant.$arch-1.0-virtualbox-Snapshot$build.vagrant.virtualbox.box"
+        # Tumbleweed.x86_64-1.0-{libvirt|virtualbox}-Snapshot20190704.vagrant.{libvirt|virtualbox}.box
+        libvirt    => "$version.$arch-1.0-libvirt-Snapshot$build.vagrant.libvirt.box",
+        virtualbox => "$version.$arch-1.0-virtualbox-Snapshot$build.vagrant.virtualbox.box"
     );
 
     my @providers = keys %boxes;


### PR DESCRIPTION
The image got renamed due to the newly relaxed image naming rules from `openSUSE-Tumbleweed-Vagrant` to `Tumbleweed`.

- Related ticket: None
- Needles: not required
- Verification run: https://openqa.opensuse.org/tests/1051802
