### PR TITLE
Fix expected description in snapper list

### DIFF
--- a/tests/console/installation_snapshots.pm
+++ b/tests/console/installation_snapshots.pm
@@ -18,7 +18,7 @@ use base 'consoletest';
 use strict;
 use warnings;
 use testapi;
-use version_utils "is_jeos";
+use version_utils qw(is_jeos is_sle);
 
 sub run {
     select_console 'root-console';
@@ -26,7 +26,7 @@ sub run {
     # Check if the corresponding snapshot is there
     my ($snapshot_desc, $snapshot_type);
     if (is_jeos) {
-        $snapshot_desc = 'Initial Status';
+        $snapshot_desc = (is_sle('<=15-sp1')) ? 'Initial Status' : 'After jeos-firstboot configuration';
         $snapshot_type = 'single';
     }
     elsif (get_var('AUTOUPGRADE')) {
@@ -41,7 +41,7 @@ sub run {
         $snapshot_desc = 'after installation';
         $snapshot_type = 'single';
     }
-    assert_script_run("snapper list --type $snapshot_type | grep '$snapshot_desc.*important=yes'");
+    assert_script_run("snapper list --type $snapshot_type | tee -a /dev/$serialdev | grep '$snapshot_desc.*important=yes'");
 }
 
 1;


### PR DESCRIPTION
- Related ticket: [[JeOS][sle15sp2] test fails in installation_snapshots - description has changed](https://progress.opensuse.org/issues/57827)
- Verification runs: 
   * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build2.20-jeos-extratest_kvm@uefi-virtio-vga](http://eris.suse.cz/tests/1280#step/installation_snapshots/2)
   * [sle-12-SP5-JeOS-for-kvm-and-xen-x86_64-Build4.108-jeos-main-de_DE_intel_image@64bit-virtio-vga](http://eris.suse.cz/tests/1281)
   * [sle-15-SP1-JeOS-for-kvm-and-xen-x86_64-Build36.2.6-jeos-main_intel_image@64bit-virtio-vga](http://eris.suse.cz/tests/1283)