### PR TITLE
Apply workaround for shutdown on s390x backend

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -263,7 +263,14 @@ sub power_action {
                 reboot_x11;
             }
             elsif ($action eq 'poweroff') {
-                poweroff_x11;
+                if (check_var('BACKEND', 's390x')) {
+                    record_soft_failure('poo#58127 - Temporary workaround, because shutdown module is marked as failed on s390x backend when shutting down from GUI.');
+                    select_console 'root-console';
+                    type_string "$action\n";
+                }
+                else {
+                    poweroff_x11;
+                }
             }
         }
     }

--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -206,15 +206,6 @@ sub poweroff_x11 {
         assert_screen 'logout-confirm-dialog', 10;
         send_key "alt-o";              # _o_k
     }
-
-    if (check_var('BACKEND', 's390x')) {
-        # make sure SUT shut down correctly
-        console('x3270')->expect_3270(
-            output_delim => qr/.*SIGP stop.*/,
-            timeout      => 30
-        );
-
-    }
 }
 
 =head2 handle_livecd_reboot_failure


### PR DESCRIPTION
The PR removes assertion for shutdown on s390x backend from power_action_utils module.

Currently it makes test to be failed, though the system is actually shut down correctly. But what is more important, the code is located in `poweroff_x11`, where only powering off should be made, no additional assertions, as all the assertions are made further in `power_action` function

All other backends implement `is_shutdown` function in `os-autoinst/backend/{backend}.pm`, so it should be correctly implemented for s390x as well.

Also, the PR adds workaround to shut down from console, as the module is failed to shutdown from GUI.

- Related ticket: https://progress.opensuse.org/issues/57743
- Verification run: https://openqa.suse.de/tests/3475273