### PR TITLE
Workaround for hostname bsc#1153402

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -744,6 +744,12 @@ sub set_hostname {
     systemctl 'status network.service';
     save_screenshot;
     assert_script_run "if systemctl -q is-active network.service; then systemctl reload-or-restart network.service; fi";
+
+    # Workaround for HA MM test (hostname bug? in 15SP1/SP2)
+    if (script_run "hostname | grep $hostname") {
+        record_soft_failure('bsc#1153402 hostname not properly configured');
+        assert_script_run "hostnamectl set-hostname $hostname";
+    }
 }
 
 =head2 assert_and_click_until_screen_change


### PR DESCRIPTION
This PR add a workaround for hostname configuration. A bug was found during MM HA test.
Hostname is revert back by wicked after a `systemctl reload-or-restart network`
[bsc#1153402](https://bugzilla.suse.com/show_bug.cgi?id=1153402)

- Related ticket: N/A
- Needles: N/A
- Verification run:
[SLES15 SP1 node01](http://1a102.qa.suse.de/tests/1452)
[SLES15 SP1 node02](http://1a102.qa.suse.de/tests/1453)
- Regression test:
[SLES12 SP5 node01](http://1a102.qa.suse.de/tests/1458)
[SLES12 SP5 node02](http://1a102.qa.suse.de/tests/1459)