### PR TITLE
Add no-pager option to systemctl call in HA test

### DIFF
--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -71,8 +71,8 @@ sub run {
         assert_screen 'root-console',                    $default_timeout;
         assert_script_run 'systemctl restart pacemaker', $default_timeout;
     }
-    assert_script_run 'systemctl list-units | grep iscsi', $default_timeout;
-    assert_script_run 'systemctl status pacemaker',        $default_timeout;
+    assert_script_run 'systemctl list-units | grep iscsi',     $default_timeout;
+    assert_script_run 'systemctl --no-pager status pacemaker', $default_timeout;
 
     # Wait for resources to be started
     if (is_sles4sap) {


### PR DESCRIPTION
Add `--no-pager `option to `systemctl status pacemaker`

Issue found [here](http://1a102.qa.suse.de/tests/1405#step/check_after_reboot/9)

- Related ticket: N/A
- Needles: N/A
- Verification run: http://1a102.qa.suse.de/tests/1453
