### PR TITLE
Fix sapconf test

### DIFF
--- a/tests/sles4sap/sapconf.pm
+++ b/tests/sles4sap/sapconf.pm
@@ -140,12 +140,14 @@ sub run {
     foreach my $p (@tuned_profiles) {
         assert_script_run "tuned-adm profile_info $p" if is_sle('>=15');
         assert_script_run "tuned-adm profile $p";
+        sleep 4;    # add a small sleep to ensure that tuned-adm has correctly switched profile
         check_profile($p);
     }
 
     unless (is_sle('>=15')) {
         foreach my $cmd ('start', keys %sapconf_profiles) {
             $output = script_output "sapconf $cmd";
+            sleep 4;    # add a small sleep to ensure that tuned-adm has correctly switched profile
             die "Command 'sapconf $cmd' output is not recognized"
               unless ($output =~ /Forwarding action to tuned\-adm\./);
             next if ($cmd eq 'start');


### PR DESCRIPTION
According to bsc#1146298 we have to wait a little between each `saptune` command.

This commit add this for sapconf test.

- Related ticket: N/A
- Needles: N/A
- Verification run: None, as this failure happens only in one case on o.s.d. it's easier to directly test on it. And as only 2 `sleep` commands are added nothing will be break with this PR.
