### PR TITLE
regproxy: Performance improvements, necessary for cri-o

### DIFF
--- a/data/regproxy/regproxy.py
+++ b/data/regproxy/regproxy.py
@@ -61,7 +61,7 @@ class RegProxy(socketserver.StreamRequestHandler):
 			with context.wrap_socket(sock, server_hostname="hydra.opensuse.org") as ssock:
 				self.relayHttp(ssock, requestline)
 
-class TcpServer(socketserver.TCPServer):
+class TcpServer(socketserver.ThreadingTCPServer):
 	allow_reuse_address = True # Makes testing quicker
 
 try:

--- a/data/regproxy/regproxy.py
+++ b/data/regproxy/regproxy.py
@@ -24,6 +24,9 @@ class RegProxy(socketserver.StreamRequestHandler):
 		# Send request line
 		sock.write(requestline)
 
+		# No keepalive
+		sock.write(b"Connection: close\r\n")
+
 		# Send all headers from client to server
 		while True:
 			line = self.rfile.readline(65537)


### PR DESCRIPTION
This avoids a random ~15s delay on some requests.

Docker can handle it, but podman and apparently kubeadm don't take it too well: https://openqa.opensuse.org/tests/1051941

Verification run (hotpatched): http://10.160.67.86/tests/489