### PR TITLE
Use systemctl openQA function

### DIFF
--- a/tests/ha/check_after_reboot.pm
+++ b/tests/ha/check_after_reboot.pm
@@ -68,11 +68,11 @@ sub run {
         send_key 'alt-c';
         wait_still_screen 3;
         wait_serial('yast2-iscsi-client-status-0', 90) || die "'yast2 iscsi-client' didn't finish";
-        assert_screen 'root-console',                    $default_timeout;
-        assert_script_run 'systemctl restart pacemaker', $default_timeout;
+        assert_screen 'root-console', $default_timeout;
+        systemctl 'restart pacemaker', timeout => $default_timeout;
     }
-    assert_script_run 'systemctl list-units | grep iscsi',     $default_timeout;
-    assert_script_run 'systemctl --no-pager status pacemaker', $default_timeout;
+    systemctl 'list-units | grep iscsi', timeout => $default_timeout;
+    systemctl 'status pacemaker',        timeout => $default_timeout;
 
     # Wait for resources to be started
     if (is_sles4sap) {


### PR DESCRIPTION
Use systemctl openQA function instead of systemctl OS command
Suggested in #8638 

- Related ticket: N/A
- Needles: N/A
- Verification run: 
[SLES 15 SP1 node01](http://1a102.qa.suse.de/tests/1464)
[SLES 15 SP1 node02](http://1a102.qa.suse.de/tests/1465)
[SLES 12 SP5 node01](http://1a102.qa.suse.de/tests/1467)
[SLES 12 SP5 node01](http://1a102.qa.suse.de/tests/1468)