### PR TITLE
Fix is_network_manager_default for non-desktop tests

### DIFF
--- a/lib/y2_module_basetest.pm
+++ b/lib/y2_module_basetest.pm
@@ -37,11 +37,13 @@ our @EXPORT = qw(is_network_manager_default
 
  is_network_manager_default();
 
-openSUSE has network manager as default except for older leap versions. The function returns 'is_opensuse' unless is_leap('<=15.0').
+openSUSE desktop roles have network manager as default except for older Leap versions.
 
 =cut
 sub is_network_manager_default {
-    return is_opensuse unless is_leap('<=15.0');
+    return 0 if !is_opensuse;
+    return 0 if is_leap('<=15.0');
+    return get_var('DESKTOP', '') =~ /gnome|kde|xfce/;
 }
 
 =head2 continue_info_network_manager_default


### PR DESCRIPTION
Currently many yast test suites run on GNOME, which is not ideal as they don't need a full desktop.
MinimalX or even textmode are sufficient, but `is_network_manager_default` was incompatible with that.

Verification runs:
yast2_ncurses with minimalx: http://10.160.67.86/tests/500
yast2_ncurses with gnome still works (well, as broken as before...): http://10.160.67.86/tests/507