### PR TITLE
Test only modified yaml schedules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test-compile-changed: os-autoinst/
 
 .PHONY: test-yaml-valid
 test-yaml-valid:
-	export PERL5LIB=${PERL5LIB_} ; tools/test_yaml_valid
+	export PERL5LIB=${PERL5LIB_} ; tools/test_yaml_valid `git --no-pager diff --name-only master | grep 'schedule.*\.yaml'`
 
 .PHONY: test-metadata
 test-metadata:

--- a/tools/test_yaml_valid
+++ b/tools/test_yaml_valid
@@ -1,20 +1,7 @@
 #!/usr/bin/env perl
 use Test::More;
 use Test::YAML::Valid qw(-Tiny);
-use File::Find;
 
-# The Unix find utility recursively searches through the directory hierarchy;
-# the Perl glob built-in does not, therefore we could use File::Find which is core module
-sub find_yaml_files {
-    my $dir = shift;
-    my @yaml_files;
-    my $yaml_finder = sub {
-        return if ! -f;
-        return if ! /\.yaml\z/;
-        push @yaml_files, $File::Find::name;
-    };
-    find( $yaml_finder, $dir );
-    return @yaml_files;
-}
-yaml_file_ok($_, $_) for find_yaml_files('./schedule/');
+pass("No yaml files modified") unless @ARGV;
+yaml_file_ok($_, $_) for @ARGV;
 done_testing();


### PR DESCRIPTION
Previously, we were executing this check for all yaml files under
schedule directory. This is not optimal as not every change modifies
yaml schedule. Introducing check only for modified yaml files.

Here is example of failed test: https://travis-ci.org/os-autoinst/os-autoinst-distri-opensuse/jobs/596541758