### PR TITLE
curl test regression multimachine 

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1052,6 +1052,18 @@ else {
             loadtest 'console/rsync_client';
         }
     }
+    elsif (get_var('QAM_CURL')) {
+        set_var('INSTALLONLY', 1);
+        boot_hdd_image;
+        loadtest 'network/setup_multimachine';
+        if (check_var('HOSTNAME', 'server')) {
+            loadtest 'network/config_services';
+            loadtest 'network/curl_server';
+        }
+        else {
+            loadtest 'network/curl_client';
+        }
+    }
     elsif (get_var('AUTOFS')) {
         load_mm_autofs_tests;
     }

--- a/tests/network/config_services.pm
+++ b/tests/network/config_services.pm
@@ -1,0 +1,83 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Test preparing services to use with multimachine scenarios.
+#  At least confiugre:
+#   - http - A basic http support with apache2
+#   - ldap - A simple openladp with users.
+#   - ftp  - simple ftp server
+#  Use on test variables settings: SUPPORT_SERVER_ROLES=http,ldap
+#  The firewall was disable and network configuration used was provide by  tests/network/setup_multimachine.pm
+#  This script was based from tests/support_server/setup.pm, but not use serial
+#  console or neddles. This is to facilites to run on all SLES/OPensuse versions.
+#
+# Maintainer: Marcelo Martins <mmartins@suse.com>
+
+use base "consoletest";
+use strict;
+use warnings;
+use testapi;
+use lockapi;
+use mm_network 'setup_static_mm_network';
+use utils qw(systemctl zypper_call);
+
+my $http_server_set = 0;
+my $ldap_server_set = 0;
+my $ftp_server_set  = 0;
+my $setup_script;
+
+sub setup_http_server {
+    #install and configure simple apache2 if $http_server_set;
+    zypper_call('in  apache2');
+    systemctl('stop apache2');
+    assert_script_run 'curl -f -v ' . autoinst_url . "/data/supportserver/http/apache2  >/etc/sysconfig/apache";
+    systemctl('start apache2');
+    $http_server_set = 1;
+}
+
+sub setup_ldap_server {
+    #install and configure basic openldap2 if $ldap_server_set
+    zypper_call('in openldap2');
+    systemctl('stop slapd');
+    assert_script_run 'curl -f -v ' . autoinst_url . "/data/ldap/slapd.conf > /etc/openldap/slapd.conf";
+    assert_script_run 'curl -f -v ' . autoinst_url . "/data/ldap/test.ldif > /etc/openldap/test.ldif";
+    assert_script_run 'sudo -u ldap slapadd -l /etc/openldap/test.ldif';
+    systemctl('start slapd');
+    $ldap_server_set = 1;
+}
+
+sub setup_ftp_server {
+    #install and start default ftp server
+    zypper_call('in vsftpd');
+    systemctl('start vsftpd');
+    $ftp_server_set = 1;
+}
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+    my $hostname = get_var('HOSTNAME');
+    # Get variable SUPPORT_SERVER_ROLES from job settings.
+    my @server_roles = split(',|;', lc(get_var("SUPPORT_SERVER_ROLES")));
+    my %server_roles = map { $_ => 1 } @server_roles;
+
+    # Configure the services set in SUPPORT_SERVER_ROLES
+    if (exists $server_roles{http}) {
+        setup_http_server();
+    }
+
+    if (exists $server_roles{ldap}) {
+        setup_ldap_server();
+    }
+    if (exists $server_roles{ftp}) {
+        setup_ftp_server();
+    }
+}
+
+1;

--- a/tests/network/curl_client.pm
+++ b/tests/network/curl_client.pm
@@ -1,0 +1,39 @@
+# SUSE"s openQA tests
+# #
+# # Copyright © 2019 SUSE LLC
+# #
+# # Copying and distribution of this file, with or without modification,
+# # are permitted in any medium without royalty provided the copyright
+# # notice and this notice are preserved.  This file is offered as-is,
+# # without any warranty.
+#
+# Summary: Test regression to curl.
+#  this test curl with http, https, ldap, ftp and ntlm auth
+#  poo#51536
+# Maintainer: Marcelo Martins <mmartins@suse.cz>
+
+use base "consoletest";
+use warnings;
+use strict;
+use testapi;
+use lockapi;
+
+sub run {
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    #waiting curl server ready.
+    mutex_wait('curl_server_ready');
+    record_info 'Waiting Server', 'Waiting Curl-server to start tests.';
+
+    #start curl tests
+    assert_script_run('curl -f -v http://10.0.2.101/get 2>&1');
+    assert_script_run('curl -f -v https://httpbin.org/get 2>&1');
+    assert_script_run('curl "ldap://10.0.2.101/dc=example,dc=com??sub?(uid=bjensen)"');
+    assert_script_run('curl ftp://10.0.2.101');
+
+    #Tests dones. Curl server stop.
+    mutex_create('CURL_DONE');
+    record_info 'Curl Done', 'Curl done tests';
+}
+1;

--- a/tests/network/curl_server.pm
+++ b/tests/network/curl_server.pm
@@ -1,0 +1,39 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: Server configurations to test curl .
+# Maintainer: Marcelo Martins <mmartins@@suse.com>
+
+use base 'opensusebasetest';
+use warnings;
+use strict;
+use testapi;
+use mmapi;
+use lockapi;
+
+sub run {
+    #run on serial console.
+    my $self = shift;
+    $self->select_serial_terminal;
+
+    #preparing files will be use by client side.
+    assert_script_run(' echo "Hello World!!" > /srv/www/htdocs/get');
+    assert_script_run(' echo "Hello World!!" > /srv/ftp/file_test');
+
+    #Server ready, mutex to client continue....
+    mutex_create('curl_server_ready');
+    record_info 'Curl start', 'Curl client test start.';
+
+    # waiting Curl client end tests.
+    my $children = get_children();
+    my $child_id = (keys %$children)[0];
+    mutex_wait('CURL_DONE', $child_id);
+    record_info 'Curl test ends', 'Curl client test ends.';
+}
+1;


### PR DESCRIPTION
This fixes - poo#51536 [qam][urgent][blue] Extend curl test coverage

- Related ticket: https://progress.opensuse.org/issues/51536
- Verification run: 
SLES 15-SP1: 
http://10.161.228.111/tests/overview?distri=sle&version=15-P1&build=15-SP1&groupid=141
SLES 15: 
http://10.161.228.111/tests/overview?distri=sle&version=15&build=15&groupid=141
SLES 12-SP4: 
http://10.161.228.111/tests/overview?distri=sle&version=12-SP4&build=12-SP4&groupid=141
SLES 12-SP3: 
http://10.161.228.111/tests/overview?distri=sle&version=12-SP3&build=GM&groupid=141
SLES 12-SP2: 
http://10.161.228.111/tests/overview?distri=sle&version=12-SP2&build=GM&groupid=141
SLES 12-SP1: 
http://10.161.228.111/tests/overview?distri=sle&version=12-SP1&build=GM&groupid=141