### PR TITLE
Increase the memory account of dom0

### DIFF
--- a/lib/ipmi_backend_utils.pm
+++ b/lib/ipmi_backend_utils.pm
@@ -108,7 +108,7 @@ sub setup_console_in_grub {
             $cmd
               = "sed -ri '/multiboot/ "
               . "{s/(console|loglevel|log_lvl|guest_loglvl)=[^ ]*//g; "
-              . "/multiboot/ s/\$/ dom0_mem=1024M,max:1024M console=com2,115200 log_lvl=all guest_loglvl=all sync_console $com_settings/;}; "
+              . "/multiboot/ s/\$/ dom0_mem=4096M,max:4096M console=com2,115200 log_lvl=all guest_loglvl=all sync_console $com_settings/;}; "
               . "' $grub_cfg_file";
             assert_script_run($cmd);
             save_screenshot;


### PR DESCRIPTION
Numerous tests on XEN host failed due to SUT unknown reboot. The inefficiency of dom0 memory is the most likely the culprit. We increase the dom0 to 4G from 1G.

- Related ticket: https://bugzilla.suse.com/show_bug.cgi?id=1153713
- Verification run: 
minor change, will verify it on OSD

@alice-suse @xguo @waynechen55