### PR TITLE
Don't need to install crash for kdump service test

### DIFF
--- a/lib/kdump_utils.pm
+++ b/lib/kdump_utils.pm
@@ -74,7 +74,12 @@ sub prepare_for_kdump {
 
     # disable packagekitd
     pkcon_quit;
-    zypper_call('in yast2-kdump kdump crash');
+    if ($test_type eq 'before') {
+        zypper_call('in yast2-kdump kdump');
+    }
+    else {
+        zypper_call('in yast2-kdump kdump crash');
+    }
 
     return if ($test_type eq 'before');
 


### PR DESCRIPTION
Don't need to install crash for kdump service test

- Related ticket: https://progress.opensuse.org/issues/57173
- Needles: N/A
- Verification run: SLES15SP2: https://openqa.suse.de/tests/3491890
                         : Function: https://openqa.suse.de/tests/3491891