### PR TITLE
btrfs-progs: Add execute time to status log

### DIFF
--- a/tests/btrfs-progs/run.pm
+++ b/tests/btrfs-progs/run.pm
@@ -102,10 +102,12 @@ sub run {
 
     foreach my $test (@tests) {
         # Run test and wait for it to finish
+        my $begin  = time();
         my $status = test_run($test);
+        my $delta  = time() - $begin;
 
         # Add test status to STATUS_LOG file
-        log_add(STATUS_LOG, CATEGORY . "-$test", $status, "10");
+        log_add(STATUS_LOG, CATEGORY . "-$test", $status, $delta);
     }
 }
 


### PR DESCRIPTION
Add execute time to test-status.log

- Related ticket: https://progress.opensuse.org/issues/58040
- Verification run: http://10.67.133.10/tests/511/file/test-status.log
