### PR TITLE
Add condition to load system_role for zVM base system installation

### DIFF
--- a/lib/version_utils.pm
+++ b/lib/version_utils.pm
@@ -476,7 +476,7 @@ sub is_using_system_role {
       && (install_this_version() || install_to_other_at_least('12-SP2'))
       || (is_sles4sap() && main_common::is_updates_test_repo())
       || is_sle('=15')
-      || (is_sle('>15') && (check_var('SCC_REGISTER', 'installation') || get_var('ADDONS') || get_var('ADDONURL')))
+      || (is_sle('>15') && (check_var('SCC_REGISTER', 'installation') || get_var('ADDONS') || get_var('ADDONURL') || get_var('BASE_VERSION')))
       || (is_opensuse && !is_leap('<15.1'))    # Also on leap 15.1, TW, MicroOS
 }
 


### PR DESCRIPTION
We have two jobs in SLE15SP2 job group to test migration from SLE15GA to SLE15SP2 on zVM. The first job is to install the base system SLE15GA on zVM, since current condition doesn't consider such situation that VERSION=15-SP2 but install SLE15GA. Add BASE_VERSION in condition for such migration test to install base system to prepare for migration test.

- Related ticket: https://progress.opensuse.org/issues/58034
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/3471372
