### PR TITLE
wicked: don't use systemctl function but script_run

### DIFF
--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -34,7 +34,7 @@ sub run {
     assert_script_run($enable_command_logging);
     # image which we using for sle15 don't have firewall running.
     # QAM need another way to figure out firewall state due to wider set of images
-    if (is_sle('<15') || (is_updates_tests() && systemctl("is-active " . opensusebasetest::firewall))) {
+    if (is_sle('<15') || (is_updates_tests() && !script_run('systemctl is-active -q ' . opensusebasetest::firewall))) {
         systemctl("stop " . opensusebasetest::firewall);
         systemctl("disable " . opensusebasetest::firewall);
     }


### PR DESCRIPTION
systemctl function validates something while we simply want to know
if the service is active in the image or not (active == 0, inactive == 3)

Validation triggered: https://openqa.suse.de/tests/3472533