### PR TITLE
kubeadm-cilium: Allow for changing upstream yaml names

### DIFF
--- a/tests/console/kubeadm.pm
+++ b/tests/console/kubeadm.pm
@@ -29,7 +29,7 @@ sub run {
 
     record_info 'Test #3', 'Test: Configure CNI';
     if (check_var('CNI', 'cilium')) {
-        assert_script_run('kubectl apply -f /usr/share/k8s-yaml/cilium/cilium.yaml');
+        assert_script_run('kubectl apply -f /usr/share/k8s-yaml/cilium/*.yaml');
     } elsif (check_var('CNI', 'flannel')) {
         assert_script_run('kubectl apply -f /usr/share/k8s-yaml/flannel/kube-flannel.yaml');
     } else {


### PR DESCRIPTION
Simple fix to handle the fact that new cilium versions use a different yaml name, but we still want to support the old ones.

We'll never package multiple yamls in the same dir.
