### PR TITLE
Signal installation_done in MM for vnc/ssh

### DIFF
--- a/tests/remote/remote_target.pm
+++ b/tests/remote/remote_target.pm
@@ -11,12 +11,11 @@
 # Tags: poo#9576
 # Maintainer: Martin Loviska <mloviska@suse.com>
 
-use base "opensusebasetest";
+use base "y2_installbase";
 use strict;
 use warnings;
 use testapi;
 use lockapi;
-use mmapi;
 use mm_network;
 
 # poo#9576
@@ -25,11 +24,9 @@ sub run {
     assert_screen("remote_slave_ready", 350);
     mutex_create("installation_ready");
     # wait while whole installation process finishes
-    $self->wait_boot(bootloader_time => 1800);
+    mutex_wait("installation_done");
+    $self->wait_boot(bootloader_time => 120);
 }
 
-sub test_flags {
-    return {fatal => 1};
-}
 1;
 

--- a/tests/support_server/wait_children.pm
+++ b/tests/support_server/wait_children.pm
@@ -24,6 +24,7 @@ use strict;
 use warnings;
 use base 'basetest';
 use testapi;
+use lockapi;
 use mmapi;
 
 sub run {
@@ -33,6 +34,9 @@ sub run {
     # We don't need any logs from support server when running on REMOTE_CONTROLLER for remote SLE installation tests
     type_string("journalctl -f |tee /dev/$serialdev\n") unless (get_var('REMOTE_CONTROLLER'));
 
+    if (check_var("REMOTE_CONTROLLER", "ssh") || check_var("REMOTE_CONTROLLER", "vnc")) {
+        mutex_create("installation_done");
+    }
     wait_for_children;
 
     unless (get_var('REMOTE_CONTROLLER')) {


### PR DESCRIPTION
Signal installation_done in MM for vnc/ssh to be able to retrieve logs.

- Related ticket: https://progress.opensuse.org/issues/50111
- Verification runs:
  - Simulating failure:
    - [remote_ssh_controller](https://openqa.suse.de/tests/3482399) & [remote_ssh_target_ftp](https://openqa.suse.de/tests/3482400)
    - [remote_vnc_controller](https://openqa.suse.de/tests/3482457) & [remote_vnc_target_nfs](https://openqa.suse.de/tests/3482458)
  - Normal execution:
    - [remote_ssh_controller](https://openqa.suse.de/tests/3482445) & [remote_ssh_target_ftp](https://openqa.suse.de/tests/3482446)
    - [remote_vnc_controller](https://openqa.suse.de/tests/3483176) & [remote_vnc_target_nfs](https://openqa.suse.de/tests/3483177)    