### PR TITLE
boot_into_snapshot moved to boot_into_snapshot

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -429,7 +429,7 @@ sub load_reboot_tests {
         # test makes no sense on s390 because grub2 can't be captured
         if (!(is_s390x or (check_var('VIRSH_VMM_FAMILY', 'xen') and check_var('VIRSH_VMM_TYPE', 'linux')))) {
             # exclude this scenario for autoyast test with switched keyboard layaout. also exclude on ipmi as installation/first_boot will call wait_grub
-            loadtest "installation/grub_test" unless get_var('INSTALL_KEYBOARD_LAYOUT') || get_var('KEEP_GRUB_TIMEOUT') || check_var('BACKEND', 'ipmi');
+            loadtest "installation/grub_test" unless get_var('INSTALL_KEYBOARD_LAYOUT') || get_var('KEEP_GRUB_TIMEOUT') || check_var('BACKEND', 'ipmi') || check_var('BOOT_TO_SNAPSHOT');
             if ((snapper_is_applicable()) && get_var("BOOT_TO_SNAPSHOT")) {
                 loadtest "installation/boot_into_snapshot";
             }

--- a/schedule/boot_to_snapshot.yaml
+++ b/schedule/boot_to_snapshot.yaml
@@ -4,6 +4,5 @@ description:    >
 vars:
     BOOT_TO_SNAPSHOT: 1
 schedule:
-    - installation/grub_test
     - installation/boot_into_snapshot
     - installation/first_boot

--- a/tests/installation/boot_into_snapshot.pm
+++ b/tests/installation/boot_into_snapshot.pm
@@ -20,9 +20,12 @@ use strict;
 use warnings;
 use testapi;
 use base "opensusebasetest";
+use bootloader_setup qw(stop_grub_timeout boot_into_snapshot);
 
 sub run {
     my ($self) = @_;
+    stop_grub_timeout;
+    boot_into_snapshot;
     assert_screen 'linux-login', 200;
     select_console 'root-console';
     # 1)

--- a/tests/installation/grub_test.pm
+++ b/tests/installation/grub_test.pm
@@ -11,7 +11,7 @@
 # Summary: Handle grub menu after reboot
 # - Handle grub2 to boot from hard disk (opposed to installation)
 # - Handle passphrase for encrypted disks
-# - Handle booting of snapshot or XEN, acconding to BOOT_TO_SNAPSHOT or XEN
+# - Handle booting of XEN, acconding to XEN
 # - Enable plymouth debug if product if GRUB_KERNEL_OPTION_APPEND is set,
 # or product is sle, aarch64 and PLYMOUTH_DEBUG is set
 # Tags: poo#9716, poo#10286, poo#10164
@@ -77,12 +77,11 @@ sub run {
     # 90 as a workaround due to the qemu backend fallout
     assert_screen_with_soft_timeout('grub2', timeout => 2 * $timeout, soft_timeout => $timeout, bugref => 'boo#1120256');
     stop_grub_timeout;
-    boot_into_snapshot if get_var("BOOT_TO_SNAPSHOT");
     send_key_until_needlematch("bootmenu-xen-kernel", 'down', 10, 5) if get_var('XEN');
     if ((check_var('ARCH', 'aarch64') && is_sle && get_var('PLYMOUTH_DEBUG'))
         || get_var('GRUB_KERNEL_OPTION_APPEND'))
     {
-        $self->bug_workaround_bsc1005313 unless get_var("BOOT_TO_SNAPSHOT");
+        $self->bug_workaround_bsc1005313;
     }
     else {
         # avoid timeout for booting to HDD


### PR DESCRIPTION
The boot_into_snapshot has separated from grub_test. This mean that
jobs that used the 'start bootloader from read-only snapshot' make
use of boot_into_snapshot. Apparently we could get rid of the BOOT_TO_SNAPSHOT
variable as well.

- Related ticket: https://progress.opensuse.org/issues/53801
- Needles: 
- Verification run:

boot_to_snapshot 
[opensuse-Tumbleweed-DVD.x86_64](http://aquarius.suse.cz/tests/792)
[sle-12-SP5-Server-DVD.x86_64](http://aquarius.suse.cz/tests/788)

using grub_test
[sle-12-SP5-Server-DVD.x86_64](http://aquarius.suse.cz/tests/789)
