### PR TITLE
Fix the problem between xen-tools and xen-tools-domU during incidentinstall

### DIFF
--- a/tests/qam-updinstall/update_install.pm
+++ b/tests/qam-updinstall/update_install.pm
@@ -48,6 +48,8 @@ sub install_packages {
                 'kernel-rt-base'       => 'kernel-rt',
                 'kernel-xen'           => 'kernel-xen-base',
                 'kernel-xen-base'      => 'kernel-xen',
+                'xen-tools'            => 'xen-tools-domU',
+                'xen-tools-domU'       => 'xen-tools'
             );
             zypper_call("rm $conflict{$package}", exitcode => [0, 104]) if $conflict{$package};
             # install package


### PR DESCRIPTION
The packages `xen-tools` and `xen-tools-domU` are in conflict so one must by removed before the other gets installed and vice versa.

- Verification run: [xen-qam-incidentinstall](http://pdostal-server.suse.cz/tests/5250#)
