### PR TITLE
evince: save state of 1st test to open evince in maximized mode in next tests

### DIFF
--- a/tests/x11/evince/evince_open.pm
+++ b/tests/x11/evince/evince_open.pm
@@ -29,4 +29,9 @@ sub run {
     send_key "ctrl-w";     # close evince
 }
 
+# add milestone flag to open in maximized window mode by default
+sub test_flags {
+    return {milestone => 1};
+}
+
 1;


### PR DESCRIPTION
- Verification run: https://openqa.opensuse.org/t1056639