### PR TITLE
Fix test failure in libreoffice_pyuno_bridge

### DIFF
--- a/tests/x11/libreoffice/libreoffice_pyuno_bridge.pm
+++ b/tests/x11/libreoffice/libreoffice_pyuno_bridge.pm
@@ -52,6 +52,8 @@ sub run {
     assert_screen('Server-setting', 30);
     send_key "alt-t";
     send_key "alt-u";
+    # use "ctrl-a" to select existing text, then use "type_string" to overwrite
+    send_key "ctrl-a";
     type_string "$mail_user";
     send_key "alt-p";
     type_string "$mail_passwd";


### PR DESCRIPTION
This is a simple fix for poo#58118.  The "libreoffice_pyuno_bridge" only runs on SLED12.

The fix is that before we type in the username, we use "ctrl-a" to select the existing default value, so that we can overwrite it.

- Related ticket: https://progress.opensuse.org/issues/58118
- Needles: None
- Verification run: http://147.2.212.139/tests/338#step/libreoffice_pyuno_bridge/24
