### PR TITLE
Revert "serial_terminal: die in case unsuccessful login"

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -84,12 +84,12 @@ sub login {
     # newline nudges the guest to display the login prompt, if this behaviour
     # changes then remove it
     type_string("\n");
-    die 'Failed to wait for login prompt' unless wait_serial(qr/login:\s*$/i);
+    wait_serial(qr/login:\s*$/i);
     type_string("$user\n");
-    die 'Failed to wait for password prompt' unless wait_serial(qr/Password:\s*$/i);
+    wait_serial(qr/Password:\s*$/i);
     type_password;
     type_string("\n");
-    die 'Failed to confirm that login was successful' unless wait_serial(qr/$escseq* \w+:~\s\# $escseq* \s*$/x);
+    wait_serial(qr/$escseq* \w+:~\s\# $escseq* \s*$/x);
     type_string(qq/PS1="$serial_term_prompt"\n/);
     wait_serial(qr/PS1="$serial_term_prompt"/);
     # TODO: Send 'tput rmam' instead/also


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#8659

Breaks https://openqa.opensuse.org/tests/1057088#step/sshd/17