### PR TITLE
Increment timeout for extra packages installation

### DIFF
--- a/tests/console/yast2_apparmor.pm
+++ b/tests/console/yast2_apparmor.pm
@@ -21,7 +21,7 @@ sub install_extra_packages_requested {
     if (check_screen 'yast2_apparmor_extra_packages_requested', 15) {
         send_key 'alt-i';
         save_screenshot;
-        wait_still_screen 5;
+        wait_still_screen 15;
     }
 }
 


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/57704
- Needles: none
- Verification run: 
OpenSUSE Leap 15.1: http://deathstar.suse.cz/tests/1527
OpenSUSE TW: http://deathstar.suse.cz/tests/1526

SLE 12.1: http://deathstar.suse.cz/tests/1523
SLE 12.2: http://deathstar.suse.cz/tests/1516
SLE 12.3: http://deathstar.suse.cz/tests/1517
SLE 12.4: http://deathstar.suse.cz/tests/1518
SLE 15.0: http://deathstar.suse.cz/tests/1522
SLE 15.1: http://deathstar.suse.cz/tests/1521
