### PR TITLE
bootloader is not needed before setup_zdup, so drop it

### DIFF
--- a/products/opensuse/main.pm
+++ b/products/opensuse/main.pm
@@ -396,7 +396,6 @@ else {
         load_reboot_tests();
     }
     elsif (installzdupstep_is_applicable()) {
-        load_boot_tests() unless is_jeos;
         load_zdup_tests();
     }
     elsif (get_var("BOOT_HDD_IMAGE")) {


### PR DESCRIPTION
Currently bootloader is scheduled before setup_zdup, which introduces
a race condition as both try to select the "Boot from HDD" option on
the install media. So only when grub2 loaded quickly enough before
setup_zdup checked for the bootloader needle, it worked.

Example of a failed run is here: https://openqa.opensuse.org/tests/1057368

Verification runs:
That run cloned with this patch: http://10.160.67.86/tests/513
That run with EXCLUDE_MODULES=bootloader on o3: https://openqa.opensuse.org/tests/1057376