### PR TITLE
Remove zypper_lifecycle from qam-minimal+base on 12sp1

### DIFF
--- a/schedule/qam/12-SP1/qam-minimal-base@64bit.yaml
+++ b/schedule/qam/12-SP1/qam-minimal-base@64bit.yaml
@@ -35,7 +35,6 @@ schedule:
 - console/hostname
 - console/installation_snapshots
 - console/zypper_in
-- console/zypper_lifecycle
 - console/zypper_lr
 - console/zypper_ref
 - console/firewall_enabled


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/3478633
- Related ticket: https://progress.opensuse.org/issues/52859