### PR TITLE
Revert "Allow setting ram size for hyper-v"

### DIFF
--- a/tests/installation/bootloader_hyperv.pm
+++ b/tests/installation/bootloader_hyperv.pm
@@ -211,8 +211,6 @@ sub run {
 
     hyperv_cmd("$ps Set-VMProcessor $name -Count $cpucount");
 
-    # Set ram for the VM
-    hyperv_cmd("$ps Set-VMMemory $name -DynamicMemoryEnabled \$true -MinimumBytes 256MB -StartupBytes 512MB -MaximumBytes ${ramsize}MB");
     if (get_var('UEFI')) {
         hyperv_cmd("$ps Set-VMFirmware $name -EnableSecureBoot off")                                                        if $winserver eq '2012';
         hyperv_cmd("$ps Set-VMFirmware $name -EnableSecureBoot On -SecureBootTemplate 'MicrosoftUEFICertificateAuthority'") if $winserver eq '2016';


### PR DESCRIPTION
Reverts os-autoinst/os-autoinst-distri-opensuse#8628

See https://bugzilla.suse.com/show_bug.cgi?id=1153929
As original issue seems to be gone, reverting to come up with something which doesn't break existing tests.