### PR TITLE
Adjust AY profiles for SLE 15 SP2 as per bsc#1153617 and bsc#1153746

### DIFF
--- a/data/autoyast_sle15/autoyast_multipath.xml
+++ b/data/autoyast_sle15/autoyast_multipath.xml
@@ -271,7 +271,7 @@ pre init scripts feature. See poo#20818.
           <crypt_fs config:type="boolean">false</crypt_fs>
           <filesystem config:type="symbol">xfs</filesystem>
           <format config:type="boolean">true</format>
-          <fstopt>noatime,nobarrier,inode64</fstopt>
+          <fstopt>noatime,inode64</fstopt>
           <loop_fs config:type="boolean">false</loop_fs>
           <lv_name>lvroot</lv_name>
           <mount>/</mount>
@@ -285,7 +285,7 @@ pre init scripts feature. See poo#20818.
           <crypt_fs config:type="boolean">false</crypt_fs>
           <filesystem config:type="symbol">xfs</filesystem>
           <format config:type="boolean">true</format>
-          <fstopt>noatime,nobarrier,inode64</fstopt>
+          <fstopt>noatime,inode64</fstopt>
           <loop_fs config:type="boolean">false</loop_fs>
           <lv_name>lvopt</lv_name>
           <mount>/opt</mount>
@@ -299,7 +299,7 @@ pre init scripts feature. See poo#20818.
           <crypt_fs config:type="boolean">false</crypt_fs>
           <filesystem config:type="symbol">xfs</filesystem>
           <format config:type="boolean">true</format>
-          <fstopt>noatime,nobarrier,inode64</fstopt>
+          <fstopt>noatime,inode64</fstopt>
           <loop_fs config:type="boolean">false</loop_fs>
           <lv_name>lvvar</lv_name>
           <mount>/var</mount>
@@ -313,7 +313,7 @@ pre init scripts feature. See poo#20818.
           <crypt_fs config:type="boolean">false</crypt_fs>
           <filesystem config:type="symbol">xfs</filesystem>
           <format config:type="boolean">true</format>
-          <fstopt>noatime,nobarrier,nodev,inode64</fstopt>
+          <fstopt>noatime,nodev,inode64</fstopt>
           <loop_fs config:type="boolean">false</loop_fs>
           <lv_name>lvhome</lv_name>
           <mount>/home</mount>
@@ -327,7 +327,7 @@ pre init scripts feature. See poo#20818.
           <crypt_fs config:type="boolean">false</crypt_fs>
           <filesystem config:type="symbol">xfs</filesystem>
           <format config:type="boolean">true</format>
-          <fstopt>noatime,nobarrier,nodev,nosuid,noexec,inode64</fstopt>
+          <fstopt>noatime,nodev,nosuid,noexec,inode64</fstopt>
           <loop_fs config:type="boolean">false</loop_fs>
           <lv_name>lvtmp</lv_name>
           <mount>/tmp</mount>
@@ -581,7 +581,7 @@ if [ -e /sys/firmware/efi ]; then
 else
       sed -i -e 's/BOOTFSTYPE/xfs/g' \
              -e 's/BOOTMOUNTP/\/boot/g' \
-             -e 's/BOOTMOUNTO/nobarrier,nodev,nosuid/g' \
+             -e 's/BOOTMOUNTO/nodev,nosuid/g' \
              -e 's/6878/131/g' /tmp/profile/modified.xml
 fi
 ]]>

--- a/data/autoyast_sle15/bug-872532_ix64ph1069.xml
+++ b/data/autoyast_sle15/bug-872532_ix64ph1069.xml
@@ -682,6 +682,8 @@
       <package>snapper-zypp-plugin</package>
       <package>ucode-intel</package>
       <package>xbitmaps</package>
+      <package>yast2-nis-client</package>
+      <package>yast2-printer</package>
       <package>yast2-snapper</package>
       <package>yast2-trans-en_US</package>
     </packages>

--- a/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
+++ b/data/autoyast_sle15/bug-876411_btrfs_h5_autoinst.xml
@@ -774,6 +774,8 @@ find / -name YaST2-Second-Stage.service
       <package>snapper-zypp-plugin</package>
       <package>ucode-amd</package>
       <package>xbitmaps</package>
+      <package>yast2-nis-client</package>
+      <package>yast2-printer</package>
       <package>yast2-snapper</package>
       <package>yast2-trans-en_US</package>
     </packages>

--- a/data/autoyast_sle15/bug-887126_autoinst.xml
+++ b/data/autoyast_sle15/bug-887126_autoinst.xml
@@ -446,6 +446,8 @@
       <package>ucode-intel</package>
       <package>xf86-input-evdev</package>
       <package>xf86-input-wacom</package>
+      <package>yast2-nis-client</package>
+      <package>yast2-printer</package>
       <package>yast2-snapper</package>
       <package>yast2-trans-en_US</package>
       <package>yast2-x11</package>


### PR DESCRIPTION
In short, previously if package was missing, sections in AY were silently ignored.
`nobarrier` fs option is no longer supported by xfs, so removing it from the profile.

[Verification runs](https://openqa.suse.de/tests/overview?version=15-SP2&distri=sle&build=rwx788%2Fos-autoinst-distri-opensuse%238696)