### PR TITLE
HPC: zypper online migration

### DIFF
--- a/data/hpc/pars_migration.pl
+++ b/data/hpc/pars_migration.pl
@@ -5,7 +5,7 @@ use warnings;
 
 my @migration_targets;
 my $targets = '/tmp/migration_targets';
-my $pattern = "SUSE Linux Enterprise Server";
+my $pattern = "SUSE Linux Enterprise";
 
 open my $fd, '<', $targets or die "Could not open '$targets' $!\n";
 


### PR DESCRIPTION
New migration targets for SLE12 are added. If migration is attempted
from SLE12 SP4 with HPC as a module, two migration targets should be
present: SUSE Linux Enterprise Server 12 SP5 and SUSE Linux Enterprise
High Performance Computing 12 SP5. This initial patch ensures that
migration targets will be parsed in the way to include 'SUSE Linux
Enterprise High' targets and that test fail conditions accounts for
the change in number of migration targets. New test setting is added,
so that the module could server both SP migration: from SLE Server SPX
with HPC module to 1) SLE Server SPX+n with HPC module and 2) SLE HPC
SPX+n product

- Verification run:
Old way: SLE 12 SPx HPC module to SLE12 SPx+n HPC module: 
http://10.160.65.14/tests/12260#step/hpc_migration/69
SLE 12 SPx HPC Module to SLE 12 HPC product:
http://10.160.65.14/tests/12328#step/hpc_migration/90