### PR TITLE
Increase timeout for http wizard window to appear

### DIFF
--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -37,7 +37,7 @@ sub run {
     wait_still_screen 5;
 
     # check http server wizard (1/5) -- Network Device Selection
-    assert_screen 'http_server_wizard';
+    assert_screen 'http_server_wizard', 60;
     wait_still_screen(3);
     send_key 'alt-n';                       # go to http server wizard (1/5) -- Network Device Selection
     assert_screen 'http_server_modules';    # check modules and enable php, perl, python before go to next step


### PR DESCRIPTION
In background can run installation of apache2, apache2-prefork

- Fail: https://openqa.suse.de/tests/3481124#step/yast2_http/8
- Verification run: https://openqa.suse.de/tests/3482391
