### PR TITLE
Expand yast2_cmd test suite 

### DIFF
--- a/schedule/yast/yast2_cmd.yaml
+++ b/schedule/yast/yast2_cmd.yaml
@@ -1,6 +1,7 @@
 name:           yast2_cmd
 description:    >
     Yast2 cmd interface tests.
+
 conditional_schedule:
   bootloader_zkvm:
     ARCH:
@@ -10,5 +11,13 @@ schedule:
      # Called on ARCH: s390x
      - {{bootloader_zkvm}}
      - boot/boot_to_desktop
+     - yast2_cmd/yast_lan
      - yast2_cmd/yast_rdp
      - yast2_cmd/yast_timezone
+     - yast2_cmd/yast_tftp_server
+     - yast2_cmd/yast_ftp_server
+     - yast2_cmd/yast_users
+     - yast2_cmd/yast_sysconfig
+     - yast2_cmd/yast_keyboard
+     - yast2_cmd/yast_nfs_server
+     - yast2_cmd/yast_nfs_client

--- a/schedule/yast/yast2_cmd.yaml
+++ b/schedule/yast/yast2_cmd.yaml
@@ -7,17 +7,34 @@ conditional_schedule:
     ARCH:
       s390x:
         - installation/bootloader_zkvm
+  # The test modules are failed on s390x and aarch64 and excluded to do investigations
+  under_issues_investigation:
+    ARCH:
+      ppc64le:
+        - yast2_cmd/yast_lan
+        - yast2_cmd/yast_ftp_server
+        - yast2_cmd/yast_users
+        - yast2_cmd/yast_keyboard
+      x86_64:
+        - yast2_cmd/yast_lan
+        - yast2_cmd/yast_ftp_server
+        - yast2_cmd/yast_users
+        - yast2_cmd/yast_keyboard
+      aarch64:
+        - yast2_cmd/yast_keyboard
+      s390x:
+        - yast2_cmd/yast_lan
+        - yast2_cmd/yast_ftp_server
+        - yast2_cmd/yast_users
+
 schedule:
      # Called on ARCH: s390x
      - {{bootloader_zkvm}}
      - boot/boot_to_desktop
-     - yast2_cmd/yast_lan
      - yast2_cmd/yast_rdp
      - yast2_cmd/yast_timezone
      - yast2_cmd/yast_tftp_server
-     - yast2_cmd/yast_ftp_server
-     - yast2_cmd/yast_users
      - yast2_cmd/yast_sysconfig
-     - yast2_cmd/yast_keyboard
      - yast2_cmd/yast_nfs_server
      - yast2_cmd/yast_nfs_client
+     - {{under_issues_investigation}}

--- a/schedule/yast/yast2_cmd.yaml
+++ b/schedule/yast/yast2_cmd.yaml
@@ -1,8 +1,14 @@
 name:           yast2_cmd
 description:    >
     Yast2 cmd interface tests.
-
+conditional_schedule:
+  bootloader_zkvm:
+    ARCH:
+      s390x:
+        - installation/bootloader_zkvm
 schedule:
+     # Called on ARCH: s390x
+     - {{bootloader_zkvm}}
      - boot/boot_to_desktop
      - yast2_cmd/yast_rdp
      - yast2_cmd/yast_timezone

--- a/schedule/yast/yast2_cmd@s390x-kvm.yaml
+++ b/schedule/yast/yast2_cmd@s390x-kvm.yaml
@@ -1,9 +1,0 @@
-name:           yast2_cmd@yast-s390x-kvm
-description:    >
-    Yast2 cmd interface tests.
-
-schedule:
-     - installation/bootloader_zkvm
-     - boot/boot_to_desktop
-     - yast2_cmd/yast_rdp
-     - yast2_cmd/yast_timezone


### PR DESCRIPTION
The PR adds new test modules into the test suite.

Also, the PR removes additional scheduling file for s390x as it only
differs in one test module from yast2_cmd schedules for other
architectures and adds conditional_scheduling instead.

**For reviewers:** After merging it is required to change YAML_SCHEDULE=schedule/yast/yast2_cmd.yaml for s390x architecture as the old scheduling file is removed in the PR.

- Related ticket: https://progress.opensuse.org/issues/57755
- Verification runs: https://openqa.suse.de/tests/overview?distri=sle&groupid=96&version=15-SP2&build=58.1_oorlov