### PR TITLE
Schedule yast2_nfs_server only on qemu backend

### DIFF
--- a/schedule/qam/15-SP1/qam-minimal-base@64bit.yaml
+++ b/schedule/qam/15-SP1/qam-minimal-base@64bit.yaml
@@ -47,7 +47,7 @@ schedule:
 - console/yast2_bootloader
 - console/yast2_i
 - console/yast2_lan
-- console/yast2_nfs_server
+- {{yast2_nfs_server}}
 - console/mtab
 - console/mysql_srv
 - console/rsync
@@ -79,4 +79,8 @@ conditional_schedule:
     ARCH:
       x86_64:
         - console/glibc_sanity
+  yast2_nfs_server:
+    BACKEND:
+      qemu:
+        - console/yast2_nfs_server
 ...


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/52859
- Verification run: https://openqa.suse.de/tests/3482636
