### PR TITLE
Add slight timeout after reordering apparmor profiles list

### DIFF
--- a/tests/console/yast2_apparmor.pm
+++ b/tests/console/yast2_apparmor.pm
@@ -108,6 +108,7 @@ sub run {
             wait_screen_change { send_key 'tab' };
             wait_screen_change { send_key 'end' };    # we need to search for recent toggled element at the of the list
         }
+        wait_still_screen(stilltime => 2);
         assert_screen 'yast2_apparmor_profile_mode_configuration_toggle';
     }
     wait_screen_change { send_key 'alt-b' } if is_pre_15();


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/57704
- Needles: None
- Verification run:
SLE 12.1: http://deathstar.suse.cz/tests/1606
SLE 12.2: http://deathstar.suse.cz/tests/1600
SLE 12.3: http://deathstar.suse.cz/tests/1601
SLE 12.4: http://deathstar.suse.cz/tests/1602
SLE 15.0: http://deathstar.suse.cz/tests/1604
SLE 15.1: http://deathstar.suse.cz/tests/1607
OpenSUSE 15.1:  http://deathstar.suse.cz/tests/1605
OpenSUSE TW:   http://deathstar.suse.cz/tests/1603