### PR TITLE
Skip actions on Overview tab for yast_lan with NM

### DIFF
--- a/lib/y2_module_basetest.pm
+++ b/lib/y2_module_basetest.pm
@@ -68,13 +68,9 @@ Click on OK when appears a warning indicating that network interfaces are contro
 
 =cut
 sub accept_warning_network_manager_default {
-    if (is_network_manager_default) {
-        $cmd{overview_tab} = 'alt-v';
-        assert_screen 'yast2-lan-warning-network-manager';
-        send_key $cmd{ok};
-        assert_screen 'yast2_lan-global-tab';
-        send_key $cmd{overview_tab};
-    }
+    assert_screen 'yast2-lan-warning-network-manager';
+    send_key $cmd{ok};
+    assert_screen 'yast2_lan-global-tab';
 }
 
 =head2 workaround_suppress_lvm_warnings

--- a/lib/y2lan_restart_common.pm
+++ b/lib/y2lan_restart_common.pm
@@ -24,7 +24,7 @@ use Exporter 'import';
 use testapi;
 use utils 'systemctl';
 use version_utils qw(is_sle is_leap);
-use y2_module_basetest 'accept_warning_network_manager_default';
+use y2_module_basetest qw(accept_warning_network_manager_default is_network_manager_default);
 use y2_module_consoletest;
 
 our @EXPORT = qw(
@@ -78,10 +78,18 @@ Accept warning for Networkmanager controls network device.
 =cut
 sub open_network_settings {
     $module_name = y2_module_consoletest::yast2_console_exec(yast2_module => 'lan');
-    accept_warning_network_manager_default;
-    assert_screen 'yast2_lan', 180;    # yast2 lan overview tab
-    send_key 'home';                   # select first device
-    wait_still_screen 1, 1;
+    # 'Global Options' tab is opened after accepting the warning on the systems
+    # with Network Manager.
+    # Thus, there is no way to select device in Overview tab on such systems, so
+    # just skipping the selection.
+    if (is_network_manager_default()) {
+        accept_warning_network_manager_default();
+    }
+    else {
+        assert_screen 'yast2_lan', 180;    # yast2 lan overview tab
+        send_key 'home';                   # select first device
+        wait_still_screen 1, 1;
+    }
 }
 
 =head2 close_network_settings

--- a/tests/console/yast2_lan_hostname.pm
+++ b/tests/console/yast2_lan_hostname.pm
@@ -26,8 +26,14 @@ sub hostname_via_dhcp {
     $cmd{home}             = 'home';
     $cmd{spc}              = 'spc';
     y2_module_consoletest::yast2_console_exec(yast2_module => 'lan');
-    y2_module_basetest::accept_warning_network_manager_default;
-    assert_screen 'yast2_lan';
+    # 'Global Options' tab is opened after accepting the warning on the systems
+    # with Network Manager.
+    if (y2_module_basetest::is_network_manager_default) {
+        y2_module_basetest::accept_warning_network_manager_default;
+    }
+    else {
+        assert_screen 'yast2_lan';
+    }
 
     # Hostname/DNS tab
     send_key $cmd{hostname_dns_tab};


### PR DESCRIPTION
The commit adds conditional logic to skip all the actions on 'Overview'
tab on the systems with Network Manager.

'Global Options' tab is opened after accepting the warning on the systems
with Network Manager.

Thus, there is no way to perform any actions on 'Overview' tab.

Related ticket: https://progress.opensuse.org/issues/57833
Verification run: 
   - Leap 15: https://openqa.opensuse.org/tests/overview?version=15.2&build=poo57833_investigation&distri=opensuse
   - Tumbleweed: https://openqa.opensuse.org/tests/overview?distri=opensuse&build=poo57833_investigation&version=Tumbleweed
   - Sle15: https://openqa.suse.de/tests/overview?build=58.1_overview_tab&distri=sle&version=15-SP2&groupid=96
