### PR TITLE
Increase timeout for dependencies installation

### DIFF
--- a/tests/console/yast2_http.pm
+++ b/tests/console/yast2_http.pm
@@ -34,7 +34,7 @@ sub run {
     }
 
     send_key 'alt-i';    # Confirm apache2 and apache2-prefork installation
-    wait_still_screen 5;
+    wait_still_screen 15;
 
     # check http server wizard (1/5) -- Network Device Selection
     assert_screen 'http_server_wizard';


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/57701
- Needles: None
- Verification run: 
SLE 12.1: http://deathstar.suse.cz/tests/1590
SLE 12.2: http://deathstar.suse.cz/tests/1584
SLE 12.3: http://deathstar.suse.cz/tests/1585
SLE 12.4: http://deathstar.suse.cz/tests/1586
SLE 15.0: http://deathstar.suse.cz/tests/1588
SLE 15.1: http://deathstar.suse.cz/tests/1591

OpenSUSE 15.1: http://deathstar.suse.cz/tests/1589
OpenSUSE TW: http://deathstar.suse.cz/tests/1587