### PR TITLE
Change test to use root-console

### DIFF
--- a/schedule/qam/15-SP1/mau-extratests.yaml
+++ b/schedule/qam/15-SP1/mau-extratests.yaml
@@ -26,7 +26,7 @@ schedule:
 - console/cups
 - console/java
 - console/sqlite3
-- {{gdb}}
+- console/gdb
 - console/sysctl
 - console/sysstat
 - console/curl_ipv6
@@ -69,10 +69,6 @@ conditional_schedule:
       x86_64:
         - console/aplay
         - console/wavpack
-  gdb:
-    ARCH:
-      x86_64:
-        - console/gdb
   yast2_lan_device_settings:
     ARCH:
       x86_64:

--- a/schedule/qam/15/mau-extratests.yaml
+++ b/schedule/qam/15/mau-extratests.yaml
@@ -27,7 +27,7 @@ schedule:
 - console/java
 - console/sqlite3
 - console/ant
-- {{gdb}}
+- console/gdb
 - console/perf
 - console/sysctl
 - console/sysstat
@@ -71,10 +71,6 @@ conditional_schedule:
       x86_64:
         - console/aplay
         - console/wavpack
-  gdb:
-    ARCH:
-      x86_64:
-        - console/gdb
   yast2_lan_device_settings:
     ARCH:
       x86_64:


### PR DESCRIPTION
- [Related ticket](https://progress.opensuse.org/issues/57698)
- Verification runs: 
mau-extratests
    - x86: 
     [SLE15SP0](https://openqa.suse.de/tests/3505192#step/gdb/1) [SLE15SP1](https://openqa.suse.de/tests/3501124#step/gdb/1) 
     [SLE12SP1](https://openqa.suse.de/tests/3505200#step/gdb/1) [SLE12SP2](https://openqa.suse.de/t3505201#step/gdb/1) [SLE12SP3](https://openqa.suse.de/t3505202#step/gdb/1) [SLE12SP4](https://openqa.suse.de/tests/3505203#step/gdb/1)
     - s390: [SLE15SP1](https://openqa.suse.de/tests/3501145#step/gdb/1)