### PR TITLE
HPC: product migration for SLE 12 HPC

### DIFF
--- a/lib/hpc/migration.pm
+++ b/lib/hpc/migration.pm
@@ -4,6 +4,14 @@ use warnings;
 use testapi;
 use utils;
 
+## For SLE12 HPC exists as module and product
+sub switch_to_sle_hpc {
+    my $suseconnect_str = ' -e testing@suse.com -r ';
+
+    zypper_call('in switch_sles_sle-hpc');
+    assert_script_run('switch_to_sle-hpc' . $suseconnect_str . get_required_var('SCC_REGCODE_HPC_PRODUCT'), 600);
+}
+
 sub register_products {
     my $register = "register_installed_products.pl";
     my $reg_code = get_required_var('SCC_REGCODE');

--- a/tests/hpc/README.migration
+++ b/tests/hpc/README.migration
@@ -27,6 +27,8 @@ MIGRATION_A - single machine tests checking basics
 -- checking for zypper online (next: yast and offline migrations)
 -- checking for correct migration targets
 -- basic migration of a single machine
+-- migration from SLE 12 Server SPX with HPC Module, to SLE 12 Serever SPX+n with
+   HPC module
 
 MIGRATION_B - cluster tests checking HPC functionality upon migration
 -- focused on zypper online migration as relevant for multimachine set-ups
@@ -35,3 +37,13 @@ MIGRATION_B - cluster tests checking HPC functionality upon migration
 -- running online zypper migration
 -- restarting the cluster
 -- conducting HPC functional tests
+-- migration from SLE 12 Server SPX with HPC Module, to SLE 12 Serever SPX+n with
+   HPC module
+
+MIGRATION_C - single machine tests checking basics
+-- the same as MIGRATION_A but:
+-- migration from SLE 12 HPC SPX to SLE 12 HPC SPX+n
+
+MIGRATION_D - cluster tests checking HPC functionality upon migration
+-- the same as MIGRATION_B but:
+-- migration from SLE 12 HPC SPX to SLE 12 HPC SPX+n

--- a/tests/hpc/before_test.pm
+++ b/tests/hpc/before_test.pm
@@ -38,6 +38,9 @@ sub run {
         zypper_call 'up';
     }
 
+    my $out = script_output('SUSEConnect -s', 30, proceed_on_failure => 1);
+    assert_script_run('SUSEConnect --cleanup', 200) if $out =~ /Error: Invalid system credentials/s;
+
     # list registration status for ease of investigating in case the test fails
     record_info('INFO', script_output("SUSEConnect --status-text"));
 }


### PR DESCRIPTION
SLE 12 comes with HPC as the module, so that a customer can have SLE 12
Server with HPC module enabled but also the customer can have SLE 12 HPC
product registered. This patch enables testing migration from SLE 12 HPC
SPX to SLE 12 HPC SPX+n

Verification runs:
http://10.160.65.14/tests/12878#step/hpc_migration/79
http://10.160.65.14/tests/12877#step/hpc_migration/79

multimachine run:
SP4 -> SP5
http://10.160.65.14/tests/12887#step/post_migration/8
http://10.160.65.14/tests/12886#step/post_migration/8
SP3 -> SP5
http://10.160.65.14/tests/12884#step/post_migration/8
http://10.160.65.14/tests/12883#step/post_migration/8

SLE-HPC runs:
http://10.160.65.14/tests/12888#step/hpc_migration/102
http://10.160.65.14/tests/12889#step/hpc_migration/102