### PR TITLE
HPC: add some checks for hpc migration

### DIFF
--- a/tests/hpc/changelog
+++ b/tests/hpc/changelog
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file
 
+## [1.0.13] - 2019-10-17
+### Added
+Add some simple checks for HPC migration tests
+
 ## [1.0.12] - 2019-10-16
 ### Changed
 hpc migration tests account for SLE Server to SLE HPC migration targets


### PR DESCRIPTION
Adding some validation for HPC migration tests. Checking if all
products and modules remain registered as expected. Also checking
if correct product if registered - High Performance Computing or
SUSE Linux Enterprise Server. Finally checking if both modules are
still registered as expected

- Verification run: 
positive run as it should be:
http://10.160.65.14/tests/12914
failed run as it should:
http://10.160.65.14/tests/12913#step/hpc_migration/86 
