### PR TITLE
Reconnect only to novalink-ssh console

### DIFF
--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -1322,8 +1322,7 @@ sub reconnect_mgmt_console {
     }
     elsif (check_var('ARCH', 'ppc64le')) {
         if (check_var('BACKEND', 'spvm')) {
-            select_console 'novalink-ssh';
-            type_string " mkvterm --id " . get_required_var('NOVALINK_LPAR_ID') . "\n";
+            select_console 'novalink-ssh', await_console => 0;
         }
     }
     elsif (check_var('ARCH', 'x86_64')) {


### PR DESCRIPTION
Fix poo#57329: PowerVM console should be connected all the time during
the test execution without reset.

Related os-autoinst PR: https://github.com/os-autoinst/os-autoinst/pull/1232
**Must be merged when is autoinst PR deployed, otherwise it will break current test flow.**

- Related ticket: https://progress.opensuse.org/issues/57329
- Needles: none
- Verification run: http://10.100.12.105/tests/3348