### PR TITLE
Ensure right pane of last node is refreshed in yast2 snapper

### DIFF
--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -104,13 +104,19 @@ sub y2snapper_show_changes_and_delete {
         # Select 1. subvolume (root) in the tree and expand it
         wait_screen_change { send_key "ret" };
         wait_screen_change { send_key "end" };
+        # Make sure it shows the new files from the unpacked tarball
+        send_key_until_needlematch 'yast2_snapper-show_testdata', 'up';
     }
     else {
         wait_screen_change { send_key "tab" };
         wait_screen_change { send_key "spc" };
+        save_screenshot;    # sporadically last item ticked on the tree is not refreshed in the right pane
+        wait_screen_change { send_key "home" };
+        wait_screen_change { send_key "end" };
+        # Make sure it shows the new files from the unpacked tarball
+        assert_screen 'yast2_snapper-show_testdata';
     }
-    # Make sure it shows the new files from the unpacked tarball
-    send_key_until_needlematch 'yast2_snapper-show_testdata', 'up';
+
     # Close the dialog and make sure it is closed
     send_key 'alt-c';
     # If snapshot list very long cannot show at one page, the 'yast2_snapper-new_snapshot' will never show up


### PR DESCRIPTION
Ensure right pane of last node is refreshed in yast2 snapper. UX is peculiar here, because expanding a node does not expand its nested nodes unless parent is ticked, so we are forced to test the ticking of the element as well in order to check that the whole tree is displayed, because going expanding one by one would also be a bad idea.

- Related ticket: https://progress.opensuse.org/issues/56255
- Verification run: [50 run - sle 12-SP5 build 20191017@jrivera_poo56255](https://openqa.suse.de/tests/overview?distri=sle&version=12-SP5&build=20191017%40jrivera_poo56255)
  - --> [Right pane is refreshed](https://openqa.suse.de/tests/3489314#step/yast2_snapper/52)
  - --> Right pane not refreshed: It's easy to spot even in the first run that works, when performing the [screenshot](https://openqa.suse.de/tests/3489310#step/yast2_snapper/52) the right pane is not refreshed and in the [next screenshot](https://openqa.suse.de/tests/3489310#step/yast2_snapper/53) the right pane shows correct info. The additional switch to home in the middle of these previous action is not visible, only in the video (which we don't have for ppc), but we can see here that really happened in my local verification in x86_64:
    - [screenshot](http://rivera-workstation.suse.cz/tests/168#step/yast2_snapper/58)
    - [frame of video switching home](http://rivera-workstation.suse.cz/tests/168/file/video.ogv#t=36.25,36.29) 

Note: I was not able to find any ncurses test case so I left the same original logic, ncurses climbing up in the tree to assert the needle and for graphic just we need one `assert_screen`.