### PR TITLE
Fix LTP fail whitelisting on test timeout

### DIFF
--- a/lib/LTP/WhiteList.pm
+++ b/lib/LTP/WhiteList.pm
@@ -70,8 +70,10 @@ sub override_known_failures {
         bmwqemu::diag("Failure in LTP:$suite:$test is known, overriding to softfail");
         $self->{result} = 'softfail';
         record_soft_failure($cond->{message}) if exists $cond->{message};
-        last;
+        return 1;
     }
+
+    return 0;
 }
 
 1;


### PR DESCRIPTION
LTP whitelist (ltp_known_issues.yaml) is not applied correctly when a test times out because `$self->{result}` remains undefined when the whitelist checks for failure. This pull request fixes the problem.

- Related ticket: N/A
- Needles: N/A
- Verification run: https://openqa.suse.de/tests/3489382
(cloned from: https://openqa.suse.de/tests/3488924)
