### PR TITLE
HPC: check for xor for test setting

### DIFF
--- a/tests/hpc/hpc_migration.pm
+++ b/tests/hpc/hpc_migration.pm
@@ -35,6 +35,10 @@ sub run {
     my @migration_targets;
     my $migration_target;
 
+    if (get_var('MIGRATE_TO_HPC_PRODUCT') and get_var('HPC_PRODUCT_MIGRATION')) {
+        die('Test setting MIGRATE_TO_HPC_PRODUCT and HPC_PRODUCT_MIGRATION are exclusive!');
+    }
+
     if (get_var('HPC_PRODUCT_MIGRATION')) {
         # run register_products() as preprepared images might require that
         $self->register_products();


### PR DESCRIPTION
MIGRATE_TO_HPC_PRODUCT setting is there to test experiment of migrating
SLE 12 Server to SLE 12 HPC. If the test is doing so, it should not
allow to set the test setting HPC_PRODUCT_MIGRATION, as this is to check
if SLE 12 HPC migrates to later SP of SLE 12 HPC. Those setting should
thus be exclusive and the test should fail if they are both true

additional comment: @jlausuch @frankenmichl 
I would still keep: MIGRATE_TO_HPC_PRODUCT despite the fact it won't be supported for now. In fact it is a valid uses case, so sooner or later it might be done and then this test code will be useful.

- Verification run: tbd
