### PR TITLE
Extracted the json string from the script_output output

### DIFF
--- a/lib/services/registered_addons.pm
+++ b/lib/services/registered_addons.pm
@@ -64,12 +64,18 @@ sub check_upgraded_addons {
 }
 
 sub check_suseconnect {
-    my $output = script_output("SUSEConnect -s");
-    my $json   = Mojo::JSON::decode_json($output);
-    foreach (@$json) {
-        my $iden   = $_->{identifier};
-        my $status = $_->{status};
-        die "$iden register status is: $status" if ($status ne 'Registered');
+    my $output = script_output("SUSEConnect -s", 120);
+    my @out = grep { $_ =~ /identifier/ } split(/\n/, $output);
+    if (@out) {
+        my $json = Mojo::JSON::decode_json($out[0]);
+        foreach (@$json) {
+            my $iden   = $_->{identifier};
+            my $status = $_->{status};
+            die "$iden register status is: $status" if ($status ne 'Registered');
+        }
+    }
+    else {
+        die "Cannot get register status: $output";
     }
 }
 


### PR DESCRIPTION
Extracted the json string from the script_output output. In case the output include unexpected information
It is related with SUSEConnect -s before and after migration check. Use script_output may get some dhcp information. But I only need the json string, so need parse the output information and get the exact return value.

- Related ticket: https://progress.opensuse.org/issues/58241
- Verification run: https://openqa.suse.de/tests/3487181#step/install_service/479
Please check the attachment
[serial0.txt](https://github.com/os-autoinst/os-autoinst-distri-opensuse/files/3742415/serial0.txt)
