### PR TITLE
Add post_fail_hook in lib/locale.pm

### DIFF
--- a/lib/locale.pm
+++ b/lib/locale.pm
@@ -75,4 +75,13 @@ sub get_keystroke_list {
     return $keystrokes{$layout};
 }
 
+# post_fail_hook for upload logs for test module which uses it as base
+# see https://progress.opensuse.org/issues/56636
+sub post_fail_hook {
+    my ($self) = shift;
+    select_console('log-console');
+    $self->SUPER::post_fail_hook;
+    $self->export_logs_basic;
+}
+
 1;


### PR DESCRIPTION
see https://progress.opensuse.org/issues/56636
The problem is that no logs collected and uploaded for test module
keymap_or_locale.

verification test:
http://f40.suse.de/tests/5167#step/keymap_or_locale/12
check uploaded logs at Logs& Assets.
