### PR TITLE
Update all calls to add/replace_grub_cmdline_settings

### DIFF
--- a/lib/bootloader_setup.pm
+++ b/lib/bootloader_setup.pm
@@ -1022,6 +1022,7 @@ sub grep_grub_cmdline_settings {
     change_grub_config($old, $new [, $search ] [, $modifiers ], [, $update_grub ]);
 
 Replace C<$old> with C<$new> in /etc/default/grub, using sed.
+C<$new>, default empty string
 C<$search> meant to be for changing only particular line for sed,
 C<$modifiers> for sed replacement, e.g. "g".
 C<$update_grub> if set, regenerate /boot/grub2/grub.cfg with grub2-mkconfig and upload configuration.
@@ -1031,6 +1032,7 @@ sub change_grub_config {
     my ($old, $new, $search, $modifiers, $update_grub) = @_;
     $modifiers   //= '';
     $update_grub //= 0;
+    $new         //= '';
     $search = "/$search/" if defined $search;
 
     assert_script_run("sed -ie '${search}s/${old}/${new}/${modifiers}' " . GRUB_DEFAULT_FILE);

--- a/tests/fips/fips_setup.pm
+++ b/tests/fips/fips_setup.pm
@@ -65,7 +65,7 @@ sub run {
     }
     else {
         zypper_call('in -t pattern fips');
-        add_grub_cmdline_settings('fips=1', 1);
+        add_grub_cmdline_settings('fips=1', update_grub => 1);
         record_info 'Kernel Mode', 'FIPS kernel mode configured!';
     }
 

--- a/tests/kernel/udev_no_symlink.pm
+++ b/tests/kernel/udev_no_symlink.pm
@@ -54,7 +54,7 @@ sub run {
     record_info('OK', 'No symlinks created for partitions with label "primary" and warning appeared');
 
     # Check that no symlinks are created at all with udev.no-partlabel-links kernel parameter
-    add_grub_cmdline_settings('udev.no-partlabel-links=1', 1);
+    add_grub_cmdline_settings('udev.no-partlabel-links=1', update_grub => 1);
     power_action('reboot');
     $self->wait_boot;
     $self->select_serial_terminal;

--- a/tests/security/ima/evm_protection_digital_signatures.pm
+++ b/tests/security/ima/evm_protection_digital_signatures.pm
@@ -68,7 +68,7 @@ sub run {
     assert_script_run "setfattr -x security.evm $sample_app";
     validate_script_output "getfattr -m security.evm -d $sample_app", sub { m/^$/ };
 
-    replace_grub_cmdline_settings('evm=fix ima_appraise=fix', '', 1);
+    replace_grub_cmdline_settings('evm=fix ima_appraise=fix', update_grub => 1);
 
     power_action('reboot', textmode => 1);
     $self->wait_boot(textmode => 1);

--- a/tests/security/ima/evm_protection_hmacs.pm
+++ b/tests/security/ima/evm_protection_hmacs.pm
@@ -50,7 +50,7 @@ sub run {
     assert_script_run "setfattr -x security.ima $sample_app";
     validate_script_output "getfattr -m security.evm -d $sample_app", sub { m/^$/ };
 
-    replace_grub_cmdline_settings('evm=fix ima_appraise=fix', '', 1);
+    replace_grub_cmdline_settings('evm=fix ima_appraise=fix', update_grub => 1);
 
     power_action('reboot', textmode => 1);
     $self->wait_boot(textmode => 1);

--- a/tests/security/ima/evm_setup.pm
+++ b/tests/security/ima/evm_setup.pm
@@ -48,7 +48,7 @@ sub run {
     assert_script_run "echo -e \"MASTERKEYTYPE='user'\\nMASTERKEY='$userkey_blob'\" > $masterkey_conf";
     assert_script_run "echo -e \"EVMKEY='$evmkey_blob'\" > $evm_conf";
 
-    add_grub_cmdline_settings("evm=fix ima_appraise=fix ima_appraise_tcb", 1);
+    add_grub_cmdline_settings("evm=fix ima_appraise=fix ima_appraise_tcb", update_grub => 1);
 
     power_action('reboot', textmode => 1);
     $self->wait_boot(textmode => 1);

--- a/tests/security/ima/ima_appraisal_audit.pm
+++ b/tests/security/ima/ima_appraisal_audit.pm
@@ -52,7 +52,7 @@ sub run {
     validate_script_output "ausearch -m INTEGRITY_DATA", sub { m/\Q$sample_app\E/ };
 
     # Test both default(no ima_apprais=) and ima_appraise=log situation
-    add_grub_cmdline_settings("ima_appraise=log", 1);
+    add_grub_cmdline_settings("ima_appraise=log", update_grub => 1);
     power_action('reboot', textmode => 1);
     $self->wait_boot(textmode => 1);
     $self->select_serial_terminal;

--- a/tests/security/ima/ima_appraisal_digital_signatures.pm
+++ b/tests/security/ima/ima_appraisal_digital_signatures.pm
@@ -37,7 +37,7 @@ sub run {
     my $cert_der = "/root/certs/ima_cert.der";
     my $mok_pass = "suse";
 
-    add_grub_cmdline_settings("ima_appraise=fix", 1);
+    add_grub_cmdline_settings("ima_appraise=fix", update_grub => 1);
 
     power_action('reboot', textmode => 1);
     $self->wait_boot(textmode => 1);
@@ -70,7 +70,7 @@ sub run {
 
     assert_script_run "wget --quiet " . data_url("ima/ima_appraisal_ds_policy" . " -O /etc/sysconfig/ima-policy");
 
-    replace_grub_cmdline_settings('ima_appraise=fix', '', 1);
+    replace_grub_cmdline_settings('ima_appraise=fix', update_grub => 1);
 
     power_action('reboot', textmode => 1);
     $self->wait_boot(textmode => 1);

--- a/tests/security/ima/ima_appraisal_hashes.pm
+++ b/tests/security/ima/ima_appraisal_hashes.pm
@@ -37,7 +37,7 @@ sub run {
     assert_script_run "echo $kver";
     my $tcb_cmdline = ($kver lt 4.13) ? 'ima_appraise_tcb' : 'ima_policy=appraise_tcb';
 
-    add_grub_cmdline_settings("ima_appraise=fix $tcb_cmdline", 1);
+    add_grub_cmdline_settings("ima_appraise=fix $tcb_cmdline", update_grub => 1);
 
     power_action('reboot', textmode => 1);
     $self->wait_boot(textmode => 1);
@@ -59,7 +59,7 @@ sub run {
     assert_script_run "setfattr -x security.ima $sample_app";
     validate_script_output "getfattr -m security.ima -d $sample_app", sub { m/^$/ };
 
-    replace_grub_cmdline_settings('ima_appraise=fix', '', 1);
+    replace_grub_cmdline_settings('ima_appraise=fix', update_grub => 1);
 
     power_action('reboot', textmode => 1);
     $self->wait_boot(textmode => 1);

--- a/tests/security/ima/ima_kernel_cmdline_hash.pm
+++ b/tests/security/ima/ima_kernel_cmdline_hash.pm
@@ -54,7 +54,7 @@ sub run {
     my $last_algo = "none";
 
     for my $i (@algo_list) {
-        replace_grub_cmdline_settings("ima_hash=$last_algo", "ima_hash=@$i{algo}", 1);
+        replace_grub_cmdline_settings("ima_hash=$last_algo", "ima_hash=@$i{algo}", update_grub => 1);
         $last_algo = @$i{algo};
 
         # Grep and output grub settings to the terminal for debugging

--- a/tests/security/ima/ima_kernel_cmdline_template.pm
+++ b/tests/security/ima/ima_kernel_cmdline_template.pm
@@ -60,7 +60,7 @@ sub run {
     my $last_cmdline = "ima_template";
 
     for my $k (@cmdline_list) {
-        replace_grub_cmdline_settings($last_cmdline, @$k{cmdline}, 1);
+        replace_grub_cmdline_settings($last_cmdline, @$k{cmdline}, update_grub => 1);
         $last_cmdline = @$k{cmdline};
 
         # Grep and output grub settings to the terminal for debugging

--- a/tests/security/ima/ima_measurement.pm
+++ b/tests/security/ima/ima_measurement.pm
@@ -33,7 +33,7 @@ sub run {
     my $meas_tmpfile = "/tmp/ascii_runtime_measurements";
     my $sample_file  = "/tmp/sample.txt";
 
-    add_grub_cmdline_settings('ima_policy=tcb', 1);
+    add_grub_cmdline_settings('ima_policy=tcb', update_grub => 1);
 
     # Reboot to make settings work
     power_action('reboot', textmode => 1);

--- a/tests/security/ima/ima_setup.pm
+++ b/tests/security/ima/ima_setup.pm
@@ -34,7 +34,7 @@ sub run {
     assert_script_run "awk -i inplace '{if(\$3 == \"ext4\") \$4=\$4\",iversion\"; print}' /etc/fstab";
 
     # Add 'rootflags=iversion' to grub2 boot menu
-    add_grub_cmdline_settings('rootflags=iversion', 1);
+    add_grub_cmdline_settings('rootflags=iversion', update_grub => 1);
 
     # Some necessary packages
     zypper_call('in evmctl dracut-ima');

--- a/tests/security/selinux/sestatus.pm
+++ b/tests/security/selinux/sestatus.pm
@@ -33,7 +33,7 @@ sub run {
     validate_script_output("sestatus", sub { m/SELinux status: .*disabled/ });
 
     # enable SELinux in grub
-    add_grub_cmdline_settings('security=selinux selinux=1 enforcing=0', 1);
+    add_grub_cmdline_settings('security=selinux selinux=1 enforcing=0', update_grub => 1);
 
     # control (enable) the status of SELinux on the system
     assert_script_run("sed -i -e 's/^SELINUX=/#SELINUX=/' /etc/selinux/config");


### PR DESCRIPTION
I modified all add/replace_grub_cmdline_settings function prototype.
It blocked some testings like 'security'. I update all 'calls' where that want to update
config in time.

@pevik @asmorodskyi @jouyingbin 

Signed-off-by: James Wang <jnwang@suse.com>
