### PR TITLE
Rework thunderbird tests

### DIFF
--- a/tests/x11/thunderbird/thunderbird_imap.pm
+++ b/tests/x11/thunderbird/thunderbird_imap.pm
@@ -30,7 +30,7 @@ sub run {
     mouse_hide(1);
     # clean up and start thunderbird
     x11_start_program("xterm -e \"killall -9 thunderbird; find ~ -name *thunderbird | xargs rm -rf;\"", valid => 0);
-    my $success = eval { x11_start_program("thunderbird", match_timeout => 120); 1 };
+    my $success = eval { x11_start_program("thunderbird", match_timeout => 300); 1 };
     unless ($success) {
         force_soft_failure "bsc#1131306";
     } else {


### PR DESCRIPTION
The handling of self signed certificates requires much more work arounds than appears feasible. So switch to unencrypted connections

Validation run: https://openqa.suse.de/tests/3492734
Ticket: https://progress.opensuse.org/issues/57929