### PR TITLE
Tune testing by removing some wait_screen calls

### DIFF
--- a/tests/console/yast2_apparmor.pm
+++ b/tests/console/yast2_apparmor.pm
@@ -102,15 +102,13 @@ sub run {
         # try out with second element in the list
         wait_screen_change { send_key 'tab' };
         wait_screen_change { send_key 'down' };
-        save_screenshot;
         send_key(is_pre_15() ? 'alt-t' : 'alt-c');
+        # toggle takes some seconds:
         wait_still_screen(stilltime => 5);
         if (is_pre_15()) {
-            send_key 'tab';
-            wait_still_screen(stilltime => 5);
+            wait_screen_change { send_key 'tab' };
             send_key 'end';
         }
-        wait_still_screen(stilltime => 5);
         assert_screen 'yast2_apparmor_profile_mode_configuration_toggle';
     }
     wait_screen_change { send_key 'alt-b' } if is_pre_15();


### PR DESCRIPTION
This tunes this test removing some 'wait' calls.
Despite the 100runs of this branch in SLES12.3 I will keep an eye on this after (and if) this merge happens as is may somehow disrupt some other run.
This is not doing any relevant change, just removing the maybe redundat wai screen calls and it also removes one screenshot that is taken - we are asserting screen right after that anyway.

- Related ticket: https://progress.opensuse.org/issues/57704
- Needles: None
- Verification run: https://openqa.suse.de/tests/overview?build=srlemke%2Fos-autoinst-distri-opensuse%23yast_apparmor&version=12-SP3&distri=sle