### PR TITLE
Allow "/[fingerprint]" fragment in prompt from new openssh

### DIFF
--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -66,7 +66,7 @@ sub run {
     if (is_serial_terminal()) {
         # Make interactive SSH connection as the new user
         type_string "ssh -v -l $ssh_testman localhost -t\n";
-        wait_serial('Are you sure you want to continue connecting (yes/no)?', undef, 0, no_regex => 1);
+        wait_serial('Are you sure you want to continue connecting \(yes/no(/\[fingerprint\])?\)\?', undef, 0, no_regex => 0);
         type_string "yes\n";
         wait_serial('Password:', undef, 0, no_regex => 1);
         type_string "$ssh_testman_passwd\n";


### PR DESCRIPTION
SSH changed the allowd answers from "(yes/no)" to "(yes/no/[fingerprint])",
also accept the new version.

- Related ticket: https://progress.opensuse.org/issues/58406
- Verification run: https://openqa.opensuse.org/t1061678#step/sshd/28
- Verification run: https://openqa.opensuse.org/t1061528#step/sshd/28

