### PR TITLE
s390x: workaround broken dasdconfigure

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -262,7 +262,8 @@ sub format_dasd {
     }
 
     # bring DASD down again to test the activation during the installation
-    assert_script_run("dasd_configure 0.0.0150 0");
+    # currently broken due to bsc#1151394, so just leave it activated to continue with testing
+    record_soft_failure('bsc#1151394');
 }
 
 sub run {


### PR DESCRIPTION
set of verification runs:
https://openqa.suse.de/tests/overview?build=Soulofdestiny%2Fos-autoinst-distri-opensuse%238738&distri=sle&version=12-SP5