### PR TITLE
Use JeOS-specific grub2 module for JeOS

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -403,7 +403,12 @@ sub load_boot_tests {
     }
     if ((get_var("UEFI") || is_jeos()) && !check_var("BACKEND", "svirt")) {
         loadtest "installation/data_integrity" if data_integrity_is_applicable;
-        loadtest "installation/bootloader_uefi";
+        if (is_jeos() && is_x86_64) {
+            loadtest "jeos/grub2";
+        }
+        else {
+            loadtest "installation/bootloader_uefi";
+        }
     }
     elsif (is_svirt_except_s390x()) {
         load_svirt_vm_setup_tests;


### PR DESCRIPTION
jeos/grub2.pm was written specifically for JeOS, but apparently only used
on SLE. Add it to main_common.

Verification run: http://10.160.67.86/tests/549
