### PR TITLE
Complete test flow with dependent desired modules

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -788,9 +788,13 @@ elsif (get_var("VIRT_AUTOTEST")) {
     }
     if (get_var("VIRT_PRJ1_GUEST_INSTALL")) {
         loadtest "virt_autotest/guest_installation_run";
-        loadtest "virt_autotest/set_config_as_glue";
-        loadtest "virt_autotest/virsh_internal_snapshot";
-        loadtest "virt_autotest/virsh_external_snapshot";
+        if (!(get_var("GUEST_PATTERN") =~ /win/img) && is_x86_64) {
+            loadtest "virt_autotest/setup_dns_service";
+            loadtest "virt_autotest/set_config_as_glue";
+            loadtest "virtualization/xen/hotplugging";
+            loadtest "virt_autotest/virsh_internal_snapshot";
+            loadtest "virt_autotest/virsh_external_snapshot";
+        }
     }
     elsif (get_var("VIRT_PRJ2_HOST_UPGRADE")) {
         loadtest "virt_autotest/host_upgrade_generate_run_file";


### PR DESCRIPTION
1) One module is inserted before set_config_as_glue: virt_autotest/setup_dns_service

2) One module is inserted before virsh_internal_snapshot: virtualization/xen/hotplugging

3) All five modules:
virt_autotest/setup_dns_service
virt_autotest/set_config_as_glue
virtualization/xen/hotplugging
virt_autotest/virsh_internal_snapshot
virt_autotest/virsh_external_snapshot
currently only run on x86_64 host with non-windows guests after guest_installation_run in VIRT_PRJ1_GUEST_INSTALL

Test run with desired order: http://10.67.19.99/tests/317
Verification with Perl online tool: https://www.tutorialspoint.com/execute_perl_online.php