### PR TITLE
[WIP] Fortify weak spots in console/yast2_lan_device_settings

### DIFF
--- a/tests/console/yast2_lan_device_settings.pm
+++ b/tests/console/yast2_lan_device_settings.pm
@@ -47,7 +47,7 @@ sub run {
     send_key "tab";
     type_string $static_ip;
     send_key "alt-n";    # next
-    assert_screen 'static-ip-address-set';
+    wait_screen_change { assert_screen 'static-ip-address-set' };
     close_yast2_lan();
 
     # verify that static IP has been set
@@ -60,7 +60,7 @@ sub run {
     assert_screen 'edit-network-card';
     send_key "alt-y";                  # select dynamic address option
     send_key "alt-n";                  # next
-    assert_screen 'dynamic-ip-address-set';
+    wait_screen_change { assert_screen 'dynamic-ip-address-set' };
     close_yast2_lan();
 
     # verify that dynamic IP address has been set


### PR DESCRIPTION
Add wait_screen_change to those parts of console/yast2_lan_device_settings where it has been known to sporadically fail.

- Related ticket: https://progress.opensuse.org/issues/56585
- Needles: N/A
- Verification run: TBA
