### PR TITLE
Mask PackageKit & run pkcon only if PackageKit is installed

### DIFF
--- a/tests/qam-minimal/update_minimal.pm
+++ b/tests/qam-minimal/update_minimal.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2016-2018 SUSE LLC
+# Copyright © 2016-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -29,7 +29,9 @@ sub run {
     my ($self) = @_;
     select_console 'root-console';
 
-    pkcon_quit;
+    if (script_run('rpm -q PackageKit') == 0) {
+        pkcon_quit;
+    }
 
     capture_state('between-after');
 

--- a/tests/update/prepare_system_for_update_tests.pm
+++ b/tests/update/prepare_system_for_update_tests.pm
@@ -1,4 +1,4 @@
-# Copyright (C) 2017-2018 SUSE LLC
+# Copyright (C) 2017-2019 SUSE LLC
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
 # Summary: Prepare system for actual desktop specific updates
 # - Disable delta rpms if system is not sle
 # - Unmask packagekit service
-# - Run "pkcon refresh"
+# - Run "pkcon refresh" if PackageKit is installed
 # Maintainer: Stephan Kulow <coolo@suse.de>
 
 use base "consoletest";
@@ -31,9 +31,11 @@ sub run {
     ensure_serialdev_permissions;
     # default is true, for legacy reasons we were running this on openSUSE only
     assert_script_run "echo \"download.use_deltarpm = false\" >> /etc/zypp/zypp.conf" if !is_sle;
-    systemctl 'unmask packagekit';
 
-    assert_script_run "pkcon refresh", 300;
+    if (script_run('rpm -q PackageKit') == 0) {
+        systemctl 'unmask packagekit';
+        assert_script_run "pkcon refresh", 300;
+    }
 }
 
 sub test_flags {


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/3500230#step/prepare_system_for_update_tests/14
- Verification run:
https://openqa.suse.de/tests/3509842 x86_64
https://openqa.suse.de/tests/3509843 ppc64le
https://openqa.suse.de/tests/3509844 aarch64