### PR TITLE
Make desktop_mainmenu more reliable

### DIFF
--- a/tests/x11/desktop_mainmenu.pm
+++ b/tests/x11/desktop_mainmenu.pm
@@ -28,9 +28,8 @@ sub run {
     elsif (check_var("DESKTOP", "xfce")) {
         mouse_set(0, 0);
         sleep 1;
-        send_key "ctrl-esc";    # open menu
-        sleep 1;
-        send_key "up";          # go into Applications submenu
+        assert_screen_change { send_key "ctrl-esc" };    # open menu
+        send_key "up";                                   # go into Applications submenu
         mouse_hide(1);
     }
     else {


### PR DESCRIPTION
For some reason Ctrl-Esc can take more than a second to open the menu, but
sending the next keys too early breaks it, so has to be avoided.

Should fix failures like https://openqa.opensuse.org/tests/1061996#step/desktop_mainmenu/2

Verification run: http://10.160.67.86/tests/551#step/desktop_mainmenu/1