### PR TITLE
Use pattern to make vm name more flexible

### DIFF
--- a/data/virt_autotest/setup_dns_service.sh
+++ b/data/virt_autotest/setup_dns_service.sh
@@ -86,9 +86,10 @@ unset vm_hash_forward_ipaddr
 unset vm_hash_reverse_ipaddr
 declare -a vm_hash_forward_ipaddr=""
 declare -a vm_hash_reverse_ipaddr=""
-get_vm_guestnames_inactive=`virsh list --inactive | grep sles | awk '{print $2}'`
+vm_guestnames_types="sles|win"
+get_vm_guestnames_inactive=`virsh list --inactive | grep -E "${vm_guestnames_types}" | awk '{print $2}'`
 vm_guestnames_inactive_array=$(echo -e ${get_vm_guestnames_inactive})
-get_vm_guestnames=`virsh list  --all | grep sles | awk '{print $2}'`
+get_vm_guestnames=`virsh list  --all | grep -E "${vm_guestnames_types}" | awk '{print $2}'`
 vm_guestnames_array=$(echo -e ${get_vm_guestnames})
 get_vm_macaddress=""
 vm_macaddresses_array=""

--- a/tests/virt_autotest/set_config_as_glue.pm
+++ b/tests/virt_autotest/set_config_as_glue.pm
@@ -28,7 +28,8 @@ use testapi;
 
 sub fufill_guests_in_setting {
     my $wait_script        = "30";
-    my $get_vm_hostnames   = "virsh list  --all | grep sles | awk \'{print \$2}\'";
+    my $vm_types           = "sles|win";
+    my $get_vm_hostnames   = "virsh list --all | grep -E \"${vm_types}\" | awk \'{print \$2}\'";
     my $vm_hostnames       = script_output($get_vm_hostnames, $wait_script, type_command => 0, proceed_on_failure => 0);
     my @vm_hostnames_array = split(/\n+/, $vm_hostnames);
     foreach (@vm_hostnames_array) {

--- a/tests/virt_autotest/setup_dns_service.pm
+++ b/tests/virt_autotest/setup_dns_service.pm
@@ -60,7 +60,8 @@ sub post_fail_hook {
         script_run("service named stop");
     }
 
-    my $get_vm_hostnames   = "virsh list  --all | grep sles | awk \'{print \$2}\'";
+    my $vm_types           = "sles|win";
+    my $get_vm_hostnames   = "virsh list  --all | grep -E \"${vm_types}\" | awk \'{print \$2}\'";
     my $vm_hostnames       = script_output($get_vm_hostnames, 30, type_command => 0, proceed_on_failure => 0);
     my @vm_hostnames_array = split(/\n+/, $vm_hostnames);
     foreach (@vm_hostnames_array)


### PR DESCRIPTION
Now extend support to include windows vm guest:
1.Any future support for other types of vm guests can also be included very straightforward by add pattern into new perl variable vm_host_types in set_config_as_glue
2.Add vm_guestnames_types which serves the same purpose in data/setup_dns_service.sh

- Related automation run:https://openqa.suse.de/tests/3496567#step/set_config_as_glue/1
- Verificaiton run: Use the following perl script
#!/usr/bin/perl
my $vm_host_types = "sles|win";
system("virsh list --all | grep -E \"${vm_host_types}\" | awk \'{print \$2}\'");



