### PR TITLE
Fix and enforce correct bugref kwarg

### DIFF
--- a/lib/power_action_utils.pm
+++ b/lib/power_action_utils.pm
@@ -124,7 +124,7 @@ sub poweroff_x11 {
 
     if (check_var("DESKTOP", "kde")) {
         send_key "ctrl-alt-delete";    # shutdown
-        assert_screen_with_soft_timeout('logoutdialog', timeout => 90, soft_timeout => 15, 'bsc#1091933');
+        assert_screen_with_soft_timeout('logoutdialog', timeout => 90, soft_timeout => 15, bugref => 'bsc#1091933');
         assert_and_click 'sddm_shutdown_option_btn';
     }
 

--- a/lib/utils.pm
+++ b/lib/utils.pm
@@ -800,14 +800,17 @@ sub handle_livecd_reboot_failure {
 
 =head2 assert_screen_with_soft_timeout
 
- assert_screen_with_soft_timeout($mustmatch [,timeout => $timeout] [, bugref => $bugref] [,soft_timeout => $soft_timeout] [,soft_failure_reason => $soft_failure_reason]);
+ assert_screen_with_soft_timeout($mustmatch, bugref => $bugref [,timeout => $timeout] [,soft_timeout => $soft_timeout] [,soft_failure_reason => $soft_failure_reason]);
 
 Extending assert_screen with a soft timeout. When C<$soft_timeout> is hit, a
 soft failure is recorded with the message C<$soft_failure_reason> but
-assert_screen continues until the (hard) timeout C<$timeout> is hit. This
+C<assert_screen> continues until the (hard) timeout C<$timeout> is hit. This
 makes sense when an assert screen should find a screen within a lower time but
 still should not fail and continue until the hard timeout, e.g. to discover
 performance issues.
+
+There MUST be a C<$bugref> set for the softfail.
+If it is not set this function will die.
 
 Example:
 
@@ -820,6 +823,7 @@ sub assert_screen_with_soft_timeout {
     $args{timeout}      //= 30;
     $args{soft_timeout} //= 0;
     my $needle_info = ref($mustmatch) eq "ARRAY" ? join(',', @$mustmatch) : $mustmatch;
+    die("\$args{bugref} is not set in assert_screen_with_soft_timeout") unless ($args{bugref});
     $args{soft_failure_reason} //= "$args{bugref}: needle(s) $needle_info not found within $args{soft_timeout}";
     if ($args{soft_timeout}) {
         die "soft timeout has to be smaller than timeout" unless ($args{soft_timeout} < $args{timeout});

--- a/tests/x11/dolphin.pm
+++ b/tests/x11/dolphin.pm
@@ -22,7 +22,7 @@ sub run {
 
     # Go to ~/Documents
     assert_and_click 'dolphin_icon_documents';
-    assert_screen_with_soft_timeout('dolphin_documents_empty', timeout => 90, soft_timeout => 30, 'boo#1112021');
+    assert_screen_with_soft_timeout('dolphin_documents_empty', timeout => 90, soft_timeout => 30, bugref => 'boo#1112021');
 
     # Create a new folder
     send_key 'f10';


### PR DESCRIPTION
for assert_screen_with_soft_timeout

Validation:

When called in wrong way: http://artemis.suse.de/tests/1701
When called in right way: http://artemis.suse.de/tests/1703