### PR TITLE
Call tidy with --changed-only by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ tidy-check: check-links
 
 .PHONY: tidy
 tidy: tools/tidy
+	$< --only-changed
+	@echo "[make] Tidy called over modified/new files only. For a full run use make tidy-full"
+
+.PHONY: tidy-full
+tidy-full: tools/tidy
 	$<
 
 .PHONY: unit-test


### PR DESCRIPTION
While we have already the tidy target, it still takes quite some time
when running it locally, as it does not differentiate over old vs new
files. With os-autoinst/os-autoinst#1240 we'd gain the possibility to
only do checks over files that have been just changed, reducing that
time.