### PR TITLE
xfstests: Setup NO_SHUFFLE=1 could disable shuffle

### DIFF
--- a/tests/xfstests/run.pm
+++ b/tests/xfstests/run.pm
@@ -326,7 +326,9 @@ sub run {
 
     # Get test list
     my @tests = tests_from_ranges($TEST_RANGES, $INST_DIR);
-    @tests = shuffle(@tests);
+    unless (get_var('NO_SHUFFLE')) {
+        @tests = shuffle(@tests);
+    }
 
     test_prepare;
     heartbeat_start;


### PR DESCRIPTION
Some time people don't want shuffle test order. This parameter NO_SHUFFLE give an option
to disable shuffle test order. But we recommend to keep shuffle open in default.
Coolo suggested to have this PR. He will ensure this configure setup in qam tests.

- Verification run: http://10.67.133.102/tests/1132
From this snapshot you could see test run in order. http://10.67.133.102/tests/1132#step/run/206
- Related ticket: https://progress.opensuse.org/issues/58556