### PR TITLE
Enable EULA language in textmode and qt

### DIFF
--- a/lib/y2_logs_helper.pm
+++ b/lib/y2_logs_helper.pm
@@ -101,12 +101,19 @@ sub accept_license {
 }
 
 sub verify_license_translations {
-    return if (is_sle && get_var("BETA") || check_var('VIDEOMODE', 'text'));
+    return if (is_sle && get_var("BETA"));
     my $current_lang = 'english-us';
     for my $lang (split(/,/, get_var('EULA_LANGUAGES')), 'english-us') {
         wait_screen_change { send_key 'alt-l' };
-        assert_and_click "license-language-selected-$current_lang";
-        wait_screen_change { type_string(substr($lang, 0, 1)) };
+        # in textmode only arrow navigation is possible
+        if (get_var('VIDEOMODE') =~ 'text') {
+            send_key_until_needlematch("license-language-selected-english-us", 'up', 60);
+            send_key 'ret';
+        }
+        else {
+            assert_and_click "license-language-selected-$current_lang";
+        }
+        wait_screen_change { type_string(substr($lang, 0, 1)) } unless (check_var('VIDEOMODE', 'text'));
         send_key_until_needlematch("license-language-selected-dropbox-$lang", 'down', 60);
         send_key 'ret';
         assert_screen "license-content-$lang";

--- a/tests/installation/accept_license.pm
+++ b/tests/installation/accept_license.pm
@@ -36,7 +36,7 @@ sub run {
     # optional checks for the extended installation
     if (get_var('INSTALLER_EXTENDED_TEST')) {
         $self->verify_license_has_to_be_accepted;
-        $self->verify_license_translations unless is_sle('15+');
+        $self->verify_license_translations;
     }
     $self->accept_license;
     send_key $cmd{next};


### PR DESCRIPTION
The conditions for sle15 and textmode have been removed to allow
the verify_license_translations to be executed.

- Related ticket: https://progress.opensuse.org/issues/51854
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1243
- Verification run: display incorrect licenses in beta. verification needed to comment out condition for beta version
[installer_extended actual behavior in beta](http://aquarius.suse.cz/tests/796)
[installer_extended applying workaround for the needles](http://aquarius.suse.cz/tests/842)
[textmode PoC](http://aquarius.suse.cz/tests/841)
[opensuse-Tumbleweed](http://aquarius.suse.cz/tests/809)
---
[installer_extended latest with GUI](http://aquarius.suse.cz/tests/971)
[installer_extended latest textmode](http://aquarius.suse.cz/tests/970)
