### PR TITLE
Extract package version from script_output output

### DIFF
--- a/tests/console/check_package_version.pm
+++ b/tests/console/check_package_version.pm
@@ -22,18 +22,18 @@ use warnings;
 use version;
 use testapi;
 use utils qw(systemctl zypper_call);
+use Mojo::Util 'trim';
 
 my %package = (
-    autofs              => ['5.1.5',   'jsc#5754'],
-    openscap            => ['1.3.0',   'jsc#5699'],
-    augeas              => ['1.0.0',   'jsc#5739'],
-    'freeradius-server' => ['3.0.18',  'jsc#5892'],
-    gpgme               => ['1.9.0',   'jsc#5953'],
-    'libgpg-error'      => ['1.17',    'jsc#5953'],
-    rsync               => ['3.1.3',   'jsc#5584'],
-    dpdk                => ['18.11.2', 'jsc#6820'],
-    python36            => ['3.6.0',   'jsc#7100'],
-    'python-daemon'     => ['1.6',     'jsc#5708']
+    autofs              => ['5.1.3',  'jsc#5754'],
+    openscap            => ['1.3.0',  'jsc#5699'],
+    augeas              => ['1.0.0',  'jsc#5739'],
+    'freeradius-server' => ['3.0.18', 'jsc#5892'],
+    gpgme               => ['1.5.1',  'jsc#5953'],
+    'libgpg-error'      => ['1.17',   'jsc#5953'],
+    rsync               => ['3.1.3',  'jsc#5584'],
+    python36            => ['3.6.0',  'jsc#7100'],
+    'python-daemon'     => ['1.6',    'jsc#5708']
 );
 
 my %package_s390x = (
@@ -52,8 +52,16 @@ sub cmp_packages {
     my ($pcks, $pckv, $jsc) = @_;
     record_info($pcks, "$pcks version check after migration");
     my $output = script_output("zypper se -s $pcks | grep -w $pcks | head -1 | awk -F '|' '{print \$4}'", proceed_on_failure => 1, 100);
-    record_soft_failure("$jsc, The $pcks is not existed") if ($output eq '');
-    record_soft_failure("$jsc, The $pcks version is $output, but request is $pckv") if ($output ne '' and !cmp_version($pckv, $output));
+    my $out    = '';
+    for my $line (split(/\r?\n/, $output)) {
+        if (trim($line) =~ m/^\d+\.\d+(\.\d+)?(-\d+\.\d+)?$/) {
+            $out = $line;
+            record_soft_failure("$jsc, The $pcks version is $out, but request is $pckv") if (!cmp_version($pckv, $out));
+        }
+    }
+    if ($out eq '') {
+        record_soft_failure("$jsc, The $pcks is not existed");
+    }
 }
 
 sub run {


### PR DESCRIPTION
Extract package version from script_output output, as script_output may output some dhcp information. We need extract package version from that output.

- Related ticket: https://progress.opensuse.org/issues/57194
- Verification run: 
https://openqa.suse.de/tests/3509210#step/check_package_version/24