### PR TITLE
Reorganize calls for assert_screen to avoid time waste

### DIFF
--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -38,8 +38,8 @@ sub run {
     assert_screen([qw(yast2_bootloader-missing_package yast2_console-finished)], $timeout);
     if (match_has_tag('yast2_bootloader-missing_package')) {
         wait_screen_change { send_key 'alt-i'; };
+        assert_screen 'yast2_console-finished', $timeout;
     }
-    assert_screen 'yast2_console-finished', $timeout;
     wait_serial("$module_name-0") || die "'yast2 bootloader' didn't finish";
 }
 

--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright

--- a/tests/console/yast2_bootloader.pm
+++ b/tests/console/yast2_bootloader.pm
@@ -21,6 +21,7 @@ use strict;
 use warnings;
 use testapi;
 use utils;
+use Utils::Backends 'is_hyperv';
 
 sub run {
     select_console 'root-console';
@@ -33,7 +34,7 @@ sub run {
     # OK => Close
     send_key "alt-o";
     # Our Hyper-V host is slow when initrd is being re-generated
-    my $timeout = check_var('VIRSH_VMM_FAMILY', 'hyperv') ? 600 : 200;
+    my $timeout = (is_hyperv) ? 600 : 200;
     assert_screen([qw(yast2_bootloader-missing_package yast2_console-finished)], $timeout);
     if (match_has_tag('yast2_bootloader-missing_package')) {
         wait_screen_change { send_key 'alt-i'; };


### PR DESCRIPTION
* ~~Bump timeout for aarch64~~
* https://progress.opensuse.org/issues/58586
* Verification run: https://openqa.suse.de/tests/3511238#