### PR TITLE
Extend time of waiting for installation_overview

### DIFF
--- a/tests/installation/installation_overview.pm
+++ b/tests/installation/installation_overview.pm
@@ -72,7 +72,7 @@ sub run {
     }
     else {
         # Refer to: https://progress.opensuse.org/issues/47369
-        assert_screen "installation-settings-overview-loaded", 250;
+        assert_screen "installation-settings-overview-loaded", 420;
         assert_screen "inst-xen-pattern" if get_var('XEN');
         ensure_ssh_unblocked;
         # Check the systemd target, see poo#45020

--- a/tests/installation/resolve_dependency_issues.pm
+++ b/tests/installation/resolve_dependency_issues.pm
@@ -22,7 +22,7 @@ use testapi;
 
 sub run {
     my ($self) = @_;
-    assert_screen('installation-settings-overview-loaded', 250);
+    assert_screen('installation-settings-overview-loaded', 420);
 
     if (check_screen('manual-intervention', 0)) {
         $self->deal_with_dependency_issues;


### PR DESCRIPTION
For migration test cases, the test module of resolve_dependency_issues often fails with time out, especially the cases with more modules. So I extend the time of waiting for installation overview. 
- Related ticket: https://progress.opensuse.org/issues/55103
- Verification run: https://openqa.suse.de/tests/3509212/file/autoinst-log.txt
