### PR TITLE
HPC: add accounting slurm cluster configuration

### DIFF
--- a/lib/hpc/configs.pm
+++ b/lib/hpc/configs.pm
@@ -28,6 +28,18 @@ sed -i "/^NodeName.*/c\\NodeName=$cluster_ctl_nodes,$cluster_compute_nodes Socke
 sed -i "/^PartitionName.*/c\\PartitionName=normal Nodes=$cluster_ctl_nodes,$cluster_compute_nodes Default=YES MaxTime=24:00:00 State=UP" /etc/slurm/slurm.conf
 EOF
         assert_script_run($_) foreach (split /\n/, $config);
+    } elsif ($slurm_conf eq "accounting") {
+        my $config = << "EOF";
+sed -i "/^ControlMachine.*/c\\ControlMachine=$cluster_ctl_nodes[0]" /etc/slurm/slurm.conf
+sed -i "/^NodeName.*/c\\NodeName=$cluster_ctl_nodes,$cluster_compute_nodes Sockets=1 CoresPerSocket=1 ThreadsPerCore=1 State=unknown" /etc/slurm/slurm.conf
+sed -i "/^PartitionName.*/c\\PartitionName=normal Nodes=$cluster_ctl_nodes,$cluster_compute_nodes Default=YES MaxTime=24:00:00 State=UP" /etc/slurm/slurm.conf
+sed -i "/^#JobAcctGatherType.*/c\\JobAcctGatherType=jobacct_gather/linux" /etc/slurm/slurm.conf
+sed -i "/^#JobAcctGatherFrequency.*/c\\JobAcctGatherFrequency=12" /etc/slurm/slurm.conf
+sed -i "/^#AccountingStorageType.*/c\\AccountingStorageType=accounting_storage/slurmdbd" /etc/slurm/slurm.conf
+sed -i "/^#AccountingStorageHost.*/c\\AccountingStorageHost=$cluster_compute_nodes[-1]" /etc/slurm/slurm.conf
+sed -i "/^#AccountingStorageUser.*/c\\AccountingStoragePort=20088" /etc/slurm/slurm.conf
+EOF
+        assert_script_run($_) foreach (split /\n/, $config);
     } elsif ($slurm_conf eq "ha") {
         my $config = << "EOF";
 sed -i "/^ControlMachine.*/c\\ControlMachine=$cluster_ctl_nodes[0]" /etc/slurm/slurm.conf

--- a/tests/hpc/barrier_init.pm
+++ b/tests/hpc/barrier_init.pm
@@ -19,66 +19,67 @@ use utils;
 
 sub run {
     # Get number of nodes
-    my $nodes = get_required_var("CLUSTER_NODES");
+    my $nodes = get_required_var('CLUSTER_NODES');
 
     # Initialize barriers
-    if (check_var("HPC", "slurm")) {
-        barrier_create("SLURM_MASTER_SERVICE_ENABLED", $nodes);
-        barrier_create("SLURM_SLAVE_SERVICE_ENABLED",  $nodes);
-        barrier_create("SLURM_SETUP_DONE",             $nodes);
+    if (check_var('HPC', 'slurm')) {
+        barrier_create('SLURM_MASTER_SERVICE_ENABLED', $nodes);
+        barrier_create('SLURM_SLAVE_SERVICE_ENABLED',  $nodes);
+        barrier_create('SLURM_SETUP_DONE',             $nodes);
         barrier_create('SLURM_MASTER_RUN_TESTS',       $nodes);
+        barrier_create('SLURM_SETUP_DBD',              $nodes);
     }
-    elsif (check_var("HPC", "mrsh")) {
-        barrier_create("MRSH_INSTALLATION_FINISHED", $nodes);
-        barrier_create("MRSH_KEY_COPIED",            $nodes);
-        barrier_create("MRSH_MUNGE_ENABLED",         $nodes);
-        barrier_create("SLAVE_MRLOGIN_STARTED",      $nodes);
-        barrier_create("MRSH_MASTER_DONE",           $nodes);
+    elsif (check_var('HPC', 'mrsh')) {
+        barrier_create('MRSH_INSTALLATION_FINISHED', $nodes);
+        barrier_create('MRSH_KEY_COPIED',            $nodes);
+        barrier_create('MRSH_MUNGE_ENABLED',         $nodes);
+        barrier_create('SLAVE_MRLOGIN_STARTED',      $nodes);
+        barrier_create('MRSH_MASTER_DONE',           $nodes);
     }
-    elsif (check_var("HPC", "munge")) {
-        barrier_create("MUNGE_INSTALLATION_FINISHED", $nodes);
+    elsif (check_var('HPC', 'munge')) {
+        barrier_create('MUNGE_INSTALLATION_FINISHED', $nodes);
         barrier_create('MUNGE_KEY_COPIED',            $nodes);
-        barrier_create("MUNGE_SERVICE_ENABLED",       $nodes);
+        barrier_create('MUNGE_SERVICE_ENABLED',       $nodes);
         barrier_create('MUNGE_DONE',                  $nodes);
     }
-    elsif (check_var("HPC", "pdsh")) {
-        barrier_create("PDSH_INSTALLATION_FINISHED", $nodes);
-        barrier_create("PDSH_KEY_COPIED",            $nodes);
-        barrier_create("PDSH_MUNGE_ENABLED",         $nodes);
-        barrier_create("MRSH_SOCKET_STARTED",        $nodes);
-        barrier_create("PDSH_SLAVE_DONE",            $nodes);
+    elsif (check_var('HPC', 'pdsh')) {
+        barrier_create('PDSH_INSTALLATION_FINISHED', $nodes);
+        barrier_create('PDSH_KEY_COPIED',            $nodes);
+        barrier_create('PDSH_MUNGE_ENABLED',         $nodes);
+        barrier_create('MRSH_SOCKET_STARTED',        $nodes);
+        barrier_create('PDSH_SLAVE_DONE',            $nodes);
     }
-    elsif (check_var("HPC", "ganglia")) {
-        barrier_create("GANGLIA_INSTALLED",      $nodes);
-        barrier_create("GANGLIA_SERVER_DONE",    $nodes);
-        barrier_create("GANGLIA_CLIENT_DONE",    $nodes);
-        barrier_create("GANGLIA_GMETAD_STARTED", $nodes);
-        barrier_create("GANGLIA_GMOND_STARTED",  $nodes);
+    elsif (check_var('HPC', 'ganglia')) {
+        barrier_create('GANGLIA_INSTALLED',      $nodes);
+        barrier_create('GANGLIA_SERVER_DONE',    $nodes);
+        barrier_create('GANGLIA_CLIENT_DONE',    $nodes);
+        barrier_create('GANGLIA_GMETAD_STARTED', $nodes);
+        barrier_create('GANGLIA_GMOND_STARTED',  $nodes);
     }
-    elsif (check_var("HPC", "mpi")) {
-        barrier_create("MPI_SETUP_READY",    $nodes);
-        barrier_create("MPI_BINARIES_READY", $nodes);
-        barrier_create("MPI_RUN_TEST",       $nodes);
+    elsif (check_var('HPC', 'mpi')) {
+        barrier_create('MPI_SETUP_READY',    $nodes);
+        barrier_create('MPI_BINARIES_READY', $nodes);
+        barrier_create('MPI_RUN_TEST',       $nodes);
     }
-    elsif (check_var("HPC", "hpc_comprehensive")) {
-        if (get_var("HPC_MIGRATION")) {
-            barrier_create("HPC_PRE_MIGRATION", $nodes);
+    elsif (check_var('HPC', 'hpc_comprehensive')) {
+        if (get_var('HPC_MIGRATION')) {
+            barrier_create('HPC_PRE_MIGRATION', $nodes);
         }
-        barrier_create("HPC_MASTER_SERVICES_ENABLED", $nodes);
-        barrier_create("HPC_SLAVE_SERVICES_ENABLED",  $nodes);
-        barrier_create("HPC_SETUPS_DONE",             $nodes);
-        barrier_create("HPC_MASTER_RUN_TESTS",        $nodes);
-        if (get_var("HPC_MIGRATION")) {
-            barrier_create("HPC_MIGRATION_START",          $nodes);
-            barrier_create("HPC_MIGRATION_TESTS",          $nodes);
-            barrier_create("HPC_POST_MIGRATION_TESTS",     $nodes);
-            barrier_create("HPC_POST_MIGRATION_TESTS_RUN", $nodes);
+        barrier_create('HPC_MASTER_SERVICES_ENABLED', $nodes);
+        barrier_create('HPC_SLAVE_SERVICES_ENABLED',  $nodes);
+        barrier_create('HPC_SETUPS_DONE',             $nodes);
+        barrier_create('HPC_MASTER_RUN_TESTS',        $nodes);
+        if (get_var('HPC_MIGRATION')) {
+            barrier_create('HPC_MIGRATION_START',          $nodes);
+            barrier_create('HPC_MIGRATION_TESTS',          $nodes);
+            barrier_create('HPC_POST_MIGRATION_TESTS',     $nodes);
+            barrier_create('HPC_POST_MIGRATION_TESTS_RUN', $nodes);
         }
     }
     else {
-        die("Unsupported test, check content of HPC variable");
+        die('Unsupported test, check content of HPC variable');
     }
-    record_info("barriers initialized");
+    record_info('barriers initialized');
 }
 
 sub test_flags {

--- a/tests/hpc/slurm_master_backup.pm
+++ b/tests/hpc/slurm_master_backup.pm
@@ -26,6 +26,7 @@ sub run {
 
     $self->mount_nfs();
     barrier_wait("SLURM_SETUP_DONE");
+    barrier_wait('SLURM_SETUP_DBD');
     barrier_wait("SLURM_MASTER_SERVICE_ENABLED");
 
     # enable and start munge

--- a/tests/hpc/slurm_master_backup_db.pm
+++ b/tests/hpc/slurm_master_backup_db.pm
@@ -31,6 +31,7 @@ sub run {
     $self->mount_nfs();
 
     barrier_wait("SLURM_SETUP_DONE");
+    barrier_wait('SLURM_SETUP_DBD');
     barrier_wait("SLURM_MASTER_SERVICE_ENABLED");
     record_info('slurm conf', script_output('cat /etc/slurm/slurm.conf'));
     $self->enable_and_start('munge');

--- a/tests/hpc/slurm_slave.pm
+++ b/tests/hpc/slurm_slave.pm
@@ -30,6 +30,7 @@ sub run {
     zypper_call('in slurm-node') if is_sle '15+';
 
     barrier_wait("SLURM_SETUP_DONE");
+    barrier_wait('SLURM_SETUP_DBD');
     barrier_wait("SLURM_MASTER_SERVICE_ENABLED");
 
     # enable and start munge


### PR DESCRIPTION
Current slurm tests consists of 3 types of clusters: basic, ha and
ha with accounting enabled. This patch is aiming at adding another
slurm cluster configuration with basic accounting enabled but with
no ha (so single slurmctl only)

- Verification run:
http://10.160.65.14/tests/13446
http://10.160.65.14/tests/13467
http://10.160.65.14/tests/13457
