### PR TITLE
Use ARCH variable to differentiate s390x bootloader

### DIFF
--- a/schedule/qam/15-SP1/mau-extratests.yaml
+++ b/schedule/qam/15-SP1/mau-extratests.yaml
@@ -60,8 +60,8 @@ schedule:
 - console/coredump_collect
 conditional_schedule:
   zkvm_boot:
-    MACHINE:
-      zkvm:
+    ARCH:
+      s390x:
         - installation/bootloader_zkvm
   sound:
     ARCH:

--- a/schedule/qam/15-SP1/qam-minimal-base@64bit.yaml
+++ b/schedule/qam/15-SP1/qam-minimal-base@64bit.yaml
@@ -63,10 +63,10 @@ schedule:
 - console/coredump_collect
 conditional_schedule:
   boot:
-    MACHINE:
-      zkvm:
+    ARCH:
+      s390x:
         - installation/bootloader_zkvm
-      64bit:
+      x86_64:
         - installation/isosize
         - installation/bootloader
   grub:


### PR DESCRIPTION
- Fail: https://openqa.suse.de/tests/3517082
- Verification run: https://openqa.suse.de/tests/3517435
