### PR TITLE
Add new test for plasma-browser-integration

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1294,6 +1294,7 @@ sub load_x11tests {
         }
     }
     if (kdestep_is_applicable()) {
+        loadtest "x11/plasma_browser_integration" if (is_tumbleweed || is_leap("15.1+"));
         loadtest "x11/khelpcenter";
         if (get_var("PLASMA5")) {
             loadtest "x11/systemsettings5";

--- a/tests/x11/plasma_browser_integration.pm
+++ b/tests/x11/plasma_browser_integration.pm
@@ -1,0 +1,75 @@
+# SUSE's openQA tests
+#
+# Copyright © 2009-2013 Bernhard M. Wiedemann
+# Copyright © 2012-2018 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+
+# Summary: Test plasma-browser-integration in firefox
+# Maintainer: Fabian Vogt <fvogt@suse.de>
+
+use base "x11test";
+use strict;
+use warnings;
+use testapi;
+use utils;
+
+sub run {
+    my ($self) = @_;
+
+    ensure_installed 'plasma-browser-integration';
+
+    # If the host was just installed, a logout would be necessary. Work around that.
+    x11_start_program('qdbus-qt5 org.kde.kded5 /kded org.kde.kded5.loadModule browserintegrationreminder', valid => 0);
+
+    # Start without parameters, otherwise the reminder does not trigger. Add a space to avoid autocomplete.
+    x11_start_program(' firefox', valid => 0);
+    # Unfortunately that would result in a 100s delay waiting for a still screen here as
+    # the default start page is animated, so skip handling the dialog. It's not expected here anyway.
+    # $self->firefox_check_default();
+    $self->firefox_check_popups();
+
+    # Click on the reminder, it might take a while to appear
+    assert_and_click('plasma-browser-integration-reminder', 30);
+    # Click "Add to Firefox"
+    assert_and_click('plasma-browser-integration-install');
+    # Confirm installation
+    assert_and_click('plasma-browser-integration-install-confirm');
+    # Ack the "has been added" popup
+    assert_and_click('plasma-browser-integration-install-gotit');
+
+    # Open just the YT player, the whole /watch page is too big and dynamic
+    $self->firefox_open_url('https://www.youtube.com/embed/A3FjpB4JdvM');
+
+    # Play the video
+    assert_and_click('plasma-browser-integration-video-play');
+
+    # Open the MPRIS dialog, needs some tries as the video causes load
+    my $counter = 3;
+    while ($counter-- > 0) {
+        assert_and_click('plasma-mpris-playing');
+        last if check_screen('plasma-mpris-pause', 20);
+    }
+
+    # Pause using the button in the applet
+    assert_and_click('plasma-mpris-pause');
+    # Verify that the applet noticed that
+    assert_screen('plasma-mpris-paused');
+    # Verify that the video is paused and unpause it
+    assert_and_click('plasma-browser-integration-video-unpause');
+    # Verify that the applet noticed that
+    assert_screen('plasma-mpris-playing');
+
+    # Close firefox again. Can't use exit_firefox_common here as it expects xterm.
+    send_key_until_needlematch([qw(firefox-save-and-quit generic-desktop)], 'alt-f4', 3, 30);
+    if (match_has_tag('firefox-save-and-quit')) {
+        # confirm "save&quit"
+        send_key('ret');
+        assert_screen('generic-desktop');
+    }
+}
+
+1;


### PR DESCRIPTION
- Currently tests the MPRIS integration only

- Needles: https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/603
- Verification runs:
Tumbleweed: http://10.160.67.86/tests/606
Leap 15.1: http://10.160.67.86/tests/608

~Depends on https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8774~ (got merged)