### PR TITLE
Create snapshot after module kernel/create_junkfile_ltp

### DIFF
--- a/tests/kernel/create_junkfile_ltp.pm
+++ b/tests/kernel/create_junkfile_ltp.pm
@@ -32,7 +32,10 @@ sub run {
 }
 
 sub test_flags {
-    return {fatal => 1};
+    return {
+        fatal     => 1,
+        milestone => 1,
+    };
 }
 
 =head1 Configuration


### PR DESCRIPTION
If any of the aiodio tests crashes the system, the VM will be rolled back
to the last good snapshot. Since the snapshot created by boot_ltp lacks
the junkfile needed by aiodio tests, all remaining tests will fail.

Create new snapshot after kernel/create_junkfile_ltp to prevent false positive
failures in aiodio tests after VM rollback.

- Related ticket: N/A
- Needles: N/A
- Verification run: Pending
