### PR TITLE
Delete test.data in prepare_test_data after extracting

### DIFF
--- a/tests/console/prepare_test_data.pm
+++ b/tests/console/prepare_test_data.pm
@@ -10,6 +10,7 @@
 # Summary: prepare test data
 # - As user, get "test.data" from local autoinst service
 # - Run "cpio -id < test.data"
+# - Delete the downloaded CPIO archive again
 # - Run "ls -al data"
 # Maintainer: Zaoliang Luo <zluo@suse.de>
 
@@ -26,6 +27,7 @@ sub run {
     select_console 'user-console';
     assert_script_run "curl -L -v -f " . autoinst_url('/data') . " > test.data";
     assert_script_run " cpio -id < test.data";
+    assert_script_run "rm test.data";
     script_run "ls -al data";
 }
 


### PR DESCRIPTION
Wastes ~100MiB of disk space and in case of live systems, RAM.

Verification run:
- Tumbleweed KDE-Live: http://10.160.67.86/tests/567
