### PR TITLE
Wicked: force install tcpdump

### DIFF
--- a/tests/wicked/before_test.pm
+++ b/tests/wicked/before_test.pm
@@ -78,6 +78,7 @@ sub run {
         my $package_list = 'openvswitch openvpn iputils';
         $package_list .= ' libteam-tools libteamdctl0 python-libteam' if check_var('WICKED', 'advanced') || check_var('WICKED', 'aggregate');
         $package_list .= ' gcc' if check_var('WICKED', 'advanced');
+        $package_list .= ' tcpdump' if get_var('WICKED_TCPDUMP');
         zypper_call('-q in ' . $package_list, timeout => 400);
         $self->reset_wicked();
     }


### PR DESCRIPTION
For some images, it might happen that tcpdump is not
installed and it will fail to upload some logs.

- Related ticket: https://progress.opensuse.org/issues/58664
- VR in failing job: https://openqa.suse.de/tests/3526037
- VR in non-failing job (no regression): http://fromm.arch.suse.de/tests/171 