### PR TITLE
btrfs-progs: Update partitioning step for create root/home partition

### DIFF
--- a/tests/installation/partitioning.pm
+++ b/tests/installation/partitioning.pm
@@ -25,9 +25,11 @@ sub run {
     if (check_var('PARTITION_EDIT', 'ext4_btrfs')) {
         send_key "alt-d";
         send_key "alt-f";
-        send_key "e";
+        send_key "down";
+        send_key "alt-r";
         send_key "alt-i";
-        send_key "b";
+        send_key "up";
+        send_key "up";
         assert_screen 'partitioning-ext4_root-btrfs_home';
         send_key "alt-o";
     }


### PR DESCRIPTION
create_hdd_minimal_base+sdk_withhome_ext4_btrfs failed due to partition step update
https://openqa.suse.de/tests/3509247#step/partitioning/1

- Verification run: https://openqa.suse.de/tests/3529275
