### PR TITLE
Fix mau-extratests on public cloud #2

### DIFF
--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -47,13 +47,13 @@ resource "aws_key_pair" "openqa-keypair" {
 
 resource "aws_security_group" "basic_sg" {
     name        = "openqa-${element(random_id.service.*.hex, 0)}"
-    description = "Allow all inbound traffic"
+    description = "Allow all inbound traffic from SUSE IP ranges"
 
     ingress {
         from_port   = 0
         to_port     = 0
         protocol    = "-1"
-        cidr_blocks = ["0.0.0.0/0"]
+        cidr_blocks = ["213.151.95.130/32", "195.135.220.0/22"]
     }
 
     egress {

--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -49,17 +49,13 @@ Method executed when run() finishes and the module has result => 'fail'
 
 =cut
 sub post_fail_hook {
-    # On Public Cloud everything is done via SSH so the code below doesn't work
-    # TODO: Make some reasonable base post_fail_hook for Public Cloud
-    unless (get_var('PUBLIC_CLOUD')) {
-        my ($self) = shift;
-        select_console('log-console');
-        $self->SUPER::post_fail_hook;
-        $self->remount_tmp_if_ro;
-        $self->export_logs_basic;
-        # Export extra log after failure for further check gdm issue 1127317, also poo#45236 used for tracking action on Openqa
-        $self->export_logs_desktop;
-    }
+    my ($self) = shift;
+    select_console('log-console');
+    $self->SUPER::post_fail_hook;
+    $self->remount_tmp_if_ro;
+    $self->export_logs_basic;
+    # Export extra log after failure for further check gdm issue 1127317, also poo#45236 used for tracking action on Openqa
+    $self->export_logs_desktop;
 }
 
 sub test_flags {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1700,7 +1700,7 @@ sub load_extra_tests_docker {
 sub load_extra_tests_prepare {
     # setup $serialdev permission and so on
     loadtest "console/prepare_test_data";
-    loadtest "console/consoletest_setup";
+    loadtest "console/consoletest_setup" unless get_var('PUBLIC_CLOUD');
     loadtest 'console/integration_services' if is_hyperv || is_vmware;
 }
 
@@ -2643,6 +2643,7 @@ sub load_publiccloud_tests {
         loadtest "publiccloud/patch_and_reboot",      run_args => $args;
         loadtest "publiccloud/ssh_interactive_start", run_args => $args;
         loadtest "publiccloud/instance_overview";
+        load_extra_tests_prepare();
         load_extra_tests_console();
         loadtest "publiccloud/ssh_interactive_end", run_args => $args;
     }

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1018,4 +1018,8 @@ sub post_fail_hook {
     send_key 'spc';
 }
 
+sub test_flags {
+    return get_var('PUBLIC_CLOUD') ? {no_rollback => 1} : {};
+}
+
 1;

--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -35,7 +35,7 @@ sub init {
 
     $self->create_credentials_file();
     assert_script_run('source ~/.bashrc');
-    assert_script_run('ntpdate -s time.google.com');
+    #assert_script_run('ntpdate -s time.google.com');
     assert_script_run('gcloud config set account ' . $self->account);
     assert_script_run('gcloud auth activate-service-account --key-file=' . CREDENTIALS_FILE . ' --project=' . $self->project_id);
 }

--- a/lib/publiccloud/ssh_interactive.pm
+++ b/lib/publiccloud/ssh_interactive.pm
@@ -50,15 +50,14 @@ sub ssh_interactive_join {
 
     # Open SSH interactive session and check the serial console works
     type_string("ssh -t sut\n");
-    wait_serial("ssh_serial_ready", 10);
+    wait_serial("ssh_serial_ready", 90);
 
     $testapi::distri->set_standard_prompt('root');
 }
 
 sub ssh_interactive_leave {
     # Check if the SSH tunnel is still up and leave the SSH interactive session
-    assert_script_run("if [[ -p /dev/$serialdev ]]; then true; else false; fi");
-    type_string("exit\n");
+    script_run("if [[ -p /dev/sshserial ]]; then exit; fi", timeout => 0);
 
     # Restore the environment to not use the SSH tunnel for upload/download from the worker
     #set_var('SUT_HOSTNAME',          testapi::host_ip());

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1116,7 +1116,7 @@ else {
         if (get_var("ADDONS")) {
             loadtest "installation/addon_products_yast2";
         }
-        if (get_var('SCC_ADDONS') && !get_var('SLENKINS_NODE')) {
+        if (get_var('SCC_ADDONS') && !get_var('SLENKINS_NODE') && !get_var('PUBLIC_CLOUD')) {
             loadtest "installation/addon_products_via_SCC_yast2";
         }
         if (get_var("ISCSI_SERVER")) {

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -62,7 +62,7 @@ sub post_fail_hook {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 1};
+    return get_var('PUBLIC_CLOUD') ? {no_rollback => 1, milestone => 1, fatal => 1} : {milestone => 1, fatal => 1};
 }
 
 1;

--- a/tests/console/firewalld.pm
+++ b/tests/console/firewalld.pm
@@ -14,11 +14,12 @@ use strict;
 use warnings;
 use base "consoletest";
 use testapi;
-use utils 'systemctl';
+use utils qw(systemctl zypper_call);
 use version_utils 'is_tumbleweed';
 
 # Check Service State, enable it if necessary, set default zone to public
 sub pre_test {
+    zypper_call('in firewalld');
     record_info 'Check Service State';
     assert_script_run("if ! systemctl is-active -q firewalld; then systemctl start firewalld; fi");
     assert_script_run("firewall-cmd --set-default-zone=public");

--- a/tests/console/gdb.pm
+++ b/tests/console/gdb.pm
@@ -40,9 +40,9 @@ sub run {
     #Setup console for text feedback.
     my ($self) = @_;
     $self->select_serial_terminal();
-    if (is_sle('=12-SP5') && is_aarch64()) {
+    if ((is_sle('=12-SP5') && is_aarch64()) || get_var('PUBLIC_CLOUD')) {
         register_product;
-        add_suseconnect_product 'sle-sdk';
+        add_suseconnect_product(get_addon_fullname('sdk'));
     }
     zypper_call('in gcc glibc-devel gdb');    #Install test depedencies.
 

--- a/tests/console/lshw.pm
+++ b/tests/console/lshw.pm
@@ -23,7 +23,9 @@ sub run {
 
     # Check various output formats, -sanitize is used to not spill test machine serial numbers into public
     # On some architectures fields like "product" or "vendor" or section "*-pci" might not exist, so trying a common base.
-    validate_script_output("lshw -sanitize", sub { m/description.*\*-memory\n.*\*-network/s });
+    assert_script_run("lshw -sanitize | grep -A5 'description'");
+    assert_script_run("lshw -sanitize | grep -A5 '\\*-memory\$'");
+    assert_script_run("lshw -sanitize | grep -A5 '\\*-network'");
     assert_script_run("lshw -html -sanitize");
     assert_script_run("lshw -xml -sanitize");
     assert_script_run("lshw -json -sanitize");

--- a/tests/console/openldap2.pm
+++ b/tests/console/openldap2.pm
@@ -24,7 +24,7 @@ my @tests_sle = '';
 
 sub install_openldap2 {
     record_info 'Install OpenLDAP 2';
-    zypper_call('in openldap2-*');
+    zypper_call('in bzip2 openldap2-*');
 }
 
 sub prepare_test_suite {

--- a/tests/console/prepare_test_data.pm
+++ b/tests/console/prepare_test_data.pm
@@ -32,7 +32,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 1};
+    return get_var('PUBLIC_CLOUD') ? {no_rollback => 1, milestone => 1, fatal => 1} : {milestone => 1, fatal => 1};
 }
 
 1;

--- a/tests/console/soundtouch.pm
+++ b/tests/console/soundtouch.pm
@@ -30,7 +30,7 @@ sub run {
             zypper_ar 'http://' . get_var('OPENQA_URL') . "/assets/repo/$sdk_repo", name => 'SDK';
         }
         # maintenance updates are registered with sdk module
-        elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
+        elsif (get_var('FLAVOR') !~ /Updates|Incidents/ || get_var('PUBLIC_CLOUD')) {
             cleanup_registration;
             register_product;
             add_suseconnect_product('sle-module-desktop-applications') if is_sle('15+');
@@ -59,7 +59,7 @@ sub run {
         if (get_var('BETA')) {
             zypper_call "rr SDK";
         }
-        elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
+        elsif (get_var('FLAVOR') !~ /Updates|Incidents/ || get_var('PUBLIC_CLOUD')) {
             remove_suseconnect_product(get_addon_fullname('sdk'));
         }
     }

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -26,7 +26,7 @@ use base "consoletest";
 use strict;
 use testapi qw(is_serial_terminal :DEFAULT);
 use utils qw(systemctl exec_and_insert_password zypper_call);
-use version_utils qw(is_virtualization_server is_upgrade is_sle is_tumbleweed is_leap);
+use version_utils qw(is_upgrade is_sle is_tumbleweed is_leap);
 
 sub run {
     my $self = shift;
@@ -46,7 +46,7 @@ sub run {
         record_info("SuSEfirewall2 not available", "bsc#1090178: SuSEfirewall2 service is not available after upgrade from SLES11 SP4 to SLES15");
     }
     else {
-        systemctl 'stop ' . $self->firewall if !is_virtualization_server;
+        systemctl('stop ' . $self->firewall) if (script_run("which " . $self->firewall) == 0);
     }
 
     # Restart sshd and check it's status
@@ -129,7 +129,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1};
+    return get_var('PUBLIC_CLOUD') ? {milestone => 1, no_rollback => 1} : {milestone => 1};
 }
 
 1;

--- a/tests/console/wavpack.pm
+++ b/tests/console/wavpack.pm
@@ -39,7 +39,7 @@ sub run {
             zypper_ar 'http://' . get_var('OPENQA_URL') . "/assets/repo/$sdk_repo", name => "SDK";
         }
         # maintenance updates are registered with sdk module
-        elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
+        elsif (get_var('FLAVOR') !~ /Updates|Incidents/ || get_var('PUBLIC_CLOUD')) {
             cleanup_registration;
             register_product;
             add_suseconnect_product('sle-module-desktop-applications');
@@ -74,7 +74,7 @@ sub run {
         if (get_var('BETA')) {
             zypper_call "rr SDK";
         }
-        elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
+        elsif (get_var('FLAVOR') !~ /Updates|Incidents/ || get_var('PUBLIC_CLOUD')) {
             remove_suseconnect_product(get_addon_fullname('sdk'));
         }
     }

--- a/tests/console/zziplib.pm
+++ b/tests/console/zziplib.pm
@@ -36,7 +36,7 @@ sub run {
         zypper_ar 'http://' . get_var('OPENQA_URL') . "/assets/repo/$sdk_repo", name => 'SDK';
     }
     # maintenance updates are registered with sdk module
-    elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
+    elsif (get_var('FLAVOR') !~ /Updates|Incidents/ || get_var('PUBLIC_CLOUD')) {
         cleanup_registration;
         register_product;
         add_suseconnect_product('sle-module-desktop-applications');
@@ -73,7 +73,7 @@ sub run {
     if (get_var('BETA')) {
         zypper_call "rr SDK";
     }
-    elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
+    elsif (get_var('FLAVOR') !~ /Updates|Incidents/ || get_var('PUBLIC_CLOUD')) {
         remove_suseconnect_product(get_addon_fullname('sdk'));
     }
 }

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -31,8 +31,6 @@ sub run {
 
     assert_script_run("ps aux | nl");
 
-    register_product();
-
     assert_script_run("ip a s");
     assert_script_run("ip -6 a s");
     assert_script_run("ip r s");

--- a/tests/publiccloud/ssh_interactive_init.pm
+++ b/tests/publiccloud/ssh_interactive_init.pm
@@ -45,10 +45,12 @@ sub run {
 
     # configure ssh server, allow root and password login
     $instance->run_ssh_command(cmd => 'hostname -f');
+    $instance->run_ssh_command(cmd => 'sudo grep "^PasswordAuthentication no" /etc/ssh/sshd_config');
     $instance->run_ssh_command(cmd => 'echo -e "' . $testapi::password . '\n' . $testapi::password . '" | sudo passwd root');
     $instance->run_ssh_command(cmd => 'sudo sed -i "s/PermitRootLogin no/PermitRootLogin yes/g" /etc/ssh/sshd_config');
-    $instance->run_ssh_command(cmd => 'sudo sed -i "s/PasswordAuthentication no/PasswordAuthentication yes/g" /etc/ssh/sshd_config');
-    $instance->run_ssh_command(cmd => 'sudo cp /home/ec2-user/.ssh/authorized_keys /root/.ssh/');
+    $instance->run_ssh_command(cmd => "sudo mkdir -p /root/.ssh");
+    $instance->run_ssh_command(cmd => "sudo chmod -R 700 /root/.ssh");
+    $instance->run_ssh_command(cmd => 'sudo cp /home/' . $instance->username() . '/.ssh/authorized_keys /root/.ssh/');
     $instance->run_ssh_command(cmd => 'sudo chmod 644 /root/.ssh/authorized_keys');
     $instance->run_ssh_command(cmd => 'sudo chown root /root/.ssh/authorized_keys');
     $instance->run_ssh_command(cmd => 'sudo systemctl reload sshd');
@@ -60,7 +62,7 @@ sub run {
     $instance->run_ssh_command(cmd => 'echo -e "' . $testapi::password . '\n' . $testapi::password . '" | sudo passwd ' . $testapi::username);
     $instance->run_ssh_command(cmd => "sudo mkdir /home/" . $testapi::username . "/.ssh");
     $instance->run_ssh_command(cmd => "sudo chmod -R 700 /home/" . $testapi::username . "/.ssh");
-    $instance->run_ssh_command(cmd => 'sudo cp /home/ec2-user/.ssh/authorized_keys /home/' . $testapi::username . '/.ssh/');
+    $instance->run_ssh_command(cmd => 'sudo cp /home/' . $instance->username() . '/.ssh/authorized_keys /home/' . $testapi::username . '/.ssh/');
     $instance->run_ssh_command(cmd => "sudo chmod 644 /home/" . $testapi::username . "/.ssh/authorized_keys");
     $instance->run_ssh_command(cmd => "sudo chown -R " . $testapi::username . " /home/" . $testapi::username . "/.ssh/");
 

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -22,10 +22,12 @@ sub run {
     my ($self, $args) = @_;
     select_console 'tunnel-console';
 
+    $args->{my_instance}->run_ssh_command(cmd => "sudo SUSEConnect -r " . get_required_var('SCC_REGCODE'), timeout => 180) unless (get_var('FLAVOR') =~ 'On-Demand');
+
     assert_script_run("rsync -va -e ssh ~/repos root@" . $args->{my_instance}->public_ip . ":'/tmp/repos'", timeout => 900);
     $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");
-    $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar '{}' \\;");
     $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec echo '{}' \\;");
+    $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar '{}' \\;");
 }
 
 sub test_flags {

--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -116,7 +116,7 @@ sub run() {
 }
 
 sub test_flags() {
-    return {milestone => 1, fatal => 1};
+    return get_var('PUBLIC_CLOUD') ? {milestone => 1, fatal => 1, no_rollback => 1} : {milestone => 1, fatal => 1};
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
Hello, this is a follow-up for #8748 with some more small fixes for `mau-extratests-console` appearing on Public Cloud.


- Related ticket: [poo#54842](https://progress.opensuse.org/issues/54842)
- Needles: No new needles needed
- Verification runs:
   * [mau-extratests@SLES12SP1](http://pdostal-server.suse.cz/tests/5352)
   * [mau-extratests@SLES12SP2](http://pdostal-server.suse.cz/tests/5351)
   * [mau-extratests@SLES12SP3](http://pdostal-server.suse.cz/tests/5361)
   * [mau-extratests@SLES12SP4](http://pdostal-server.suse.cz/tests/5372)
   * [mau-extratests-publiccloud@SLES12SP4](http://pdostal-server.suse.cz/tests/5330)
   * [extra_tests_in_textmode@SLES12SP5](http://pdostal-server.suse.cz/tests/5356#)
   * [max-extratests@SLES15](http://pdostal-server.suse.cz/tests/5355)
   * [mau-extratests@SLES15SP1](http://pdostal-server.suse.cz/tests/5371)
   * [mau-extratests-publiccloud@SLES15SP1](http://pdostal-server.suse.cz/tests/5329)
   * [extra_tests_in_textmode@SLES15SP2](http://pdostal-server.suse.cz/tests/5354#)
- Errors: [SLES12SP4](https://openqa.suse.de/tests/3509823) [SLES15SP1](https://openqa.suse.de/tests/3511328)
