### PR TITLE
check_default_network: install systemd-networkd if available

### DIFF
--- a/tests/console/check_default_network_manager.pm
+++ b/tests/console/check_default_network_manager.pm
@@ -22,6 +22,8 @@ use version_utils;
 sub run {
     select_console 'root-console';
 
+    zypper_call('in systemd-network', exitcode => [0, 104]);
+
     assert_script_run 'ip a';
 
     if (is_opensuse) {


### PR DESCRIPTION
networkctl, which we use to query the default network management tool,
has been moved to the systemd-networkd package.

- Related ticket: https://progress.opensuse.org/issues/58694
- Needles: N/A
- Verification run: https://openqa.opensuse.org/tests/1065589
