### PR TITLE
Ima

### DIFF
--- a/tests/security/ima/evm_protection_digital_signatures.pm
+++ b/tests/security/ima/evm_protection_digital_signatures.pm
@@ -68,7 +68,7 @@ sub run {
     assert_script_run "setfattr -x security.evm $sample_app";
     validate_script_output "getfattr -m security.evm -d $sample_app", sub { m/^$/ };
 
-    replace_grub_cmdline_settings('evm=fix ima_appraise=fix', update_grub => 1);
+    replace_grub_cmdline_settings('evm=fix ima_appraise=fix', '', update_grub => 1);
 
     power_action('reboot', textmode => 1);
     $self->wait_boot(textmode => 1);

--- a/tests/security/ima/evm_protection_hmacs.pm
+++ b/tests/security/ima/evm_protection_hmacs.pm
@@ -50,7 +50,7 @@ sub run {
     assert_script_run "setfattr -x security.ima $sample_app";
     validate_script_output "getfattr -m security.evm -d $sample_app", sub { m/^$/ };
 
-    replace_grub_cmdline_settings('evm=fix ima_appraise=fix', update_grub => 1);
+    replace_grub_cmdline_settings('evm=fix ima_appraise=fix', '', update_grub => 1);
 
     power_action('reboot', textmode => 1);
     $self->wait_boot(textmode => 1);

--- a/tests/security/ima/ima_appraisal_digital_signatures.pm
+++ b/tests/security/ima/ima_appraisal_digital_signatures.pm
@@ -70,7 +70,7 @@ sub run {
 
     assert_script_run "wget --quiet " . data_url("ima/ima_appraisal_ds_policy" . " -O /etc/sysconfig/ima-policy");
 
-    replace_grub_cmdline_settings('ima_appraise=fix', update_grub => 1);
+    replace_grub_cmdline_settings('ima_appraise=fix', '', update_grub => 1);
 
     power_action('reboot', textmode => 1);
     $self->wait_boot(textmode => 1);

--- a/tests/security/ima/ima_appraisal_hashes.pm
+++ b/tests/security/ima/ima_appraisal_hashes.pm
@@ -59,7 +59,7 @@ sub run {
     assert_script_run "setfattr -x security.ima $sample_app";
     validate_script_output "getfattr -m security.ima -d $sample_app", sub { m/^$/ };
 
-    replace_grub_cmdline_settings('ima_appraise=fix', update_grub => 1);
+    replace_grub_cmdline_settings('ima_appraise=fix', '', update_grub => 1);
 
     power_action('reboot', textmode => 1);
     $self->wait_boot(textmode => 1);


### PR DESCRIPTION
Fix IMA/EVM fails which failed on "kernel cmd line params mismatch settings"

- Related ticket: https://progress.opensuse.org/issues/58670
- Needles: NA
- Verification run:
   IMA/EVM is only supported on sle15+, verification run on sle15sp2_b72.1: 
   evm_protection: http://10.67.19.62/tests/1273
   ima_appraisal: http://10.67.19.62/tests/1272

NOTE: 
   The above runs are better than O.S.D runs and their logs show the issue of this poo describes has been fixed.
   There are still lots of fails but are not introduced by this fix, we are working on this and will file poo/bug(s) to track later.
