### PR TITLE
 Exclude yast_lan cmd test from yast cmd schedule 

### DIFF
--- a/schedule/yast/yast2_cmd.yaml
+++ b/schedule/yast/yast2_cmd.yaml
@@ -16,7 +16,6 @@ conditional_schedule:
         - yast2_cmd/yast_users
         - yast2_cmd/yast_keyboard
       x86_64:
-        - yast2_cmd/yast_lan
         - yast2_cmd/yast_ftp_server
         - yast2_cmd/yast_users
         - yast2_cmd/yast_keyboard


### PR DESCRIPTION
We exclude not working tests to investigate failure and act accordingly.

See [poo#57755](https://progress.opensuse.org/issues/57755).

