### PR TITLE
online_repos: increase timeout for initial screen

### DIFF
--- a/tests/installation/online_repos.pm
+++ b/tests/installation/online_repos.pm
@@ -55,7 +55,7 @@ sub run {
     ## Do not enable online repos by default
     ## List possible screens if pop-up is not there as a fallback
     my @needles = qw(online-repos-popup before-role-selection inst-networksettings partitioning-edit-proposal-button inst-instmode network-not-configured list-of-online-repositories);
-    assert_screen(\@needles);
+    assert_screen(\@needles, timeout => 60);
 
     # Do nothing if pop-up is not found
     return unless match_has_tag('online-repos-popup');


### PR DESCRIPTION
- Related ticket: https://progress.opensuse.org/issues/58769
- Verification run: https://openqa.opensuse.org/t1069224
