### PR TITLE
Fixed wrong call of x11_start_program in gnucash

### DIFF
--- a/tests/x11/gnucash.pm
+++ b/tests/x11/gnucash.pm
@@ -21,7 +21,8 @@ sub run {
     select_console('x11');
 
     ensure_installed('gnucash gnucash-docs yelp');
-    x11_start_program('gnucash', target_match => [qw(gnucash gnucash-tip-close gnucash-assistant-close)]);
+    my @gnucash_tags = qw(gnucash gnucash-tip-close gnucash-assistant-close);
+    x11_start_program('gnucash', target_match => \@gnucash_tags);
     if (match_has_tag('gnucash-tip-close')) {
         send_key 'esc';
         assert_screen([qw(gnucash gnucash-assistant-close)]);


### PR DESCRIPTION
Removed the hashrefernce and replaced it with an array as expected by
the code in x11_start_program

This should fix the behaviour found in https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/8723

@Vogtinator @okurz @foursixnine 

Verification will follow soonish

- Verification run: openqa.mypersonalinstance.de/tests/xyz#step/module/x
