### PR TITLE
Use regexp against STDOUT instead of screen check

### DIFF
--- a/lib/systemd_testsuite_test.pm
+++ b/lib/systemd_testsuite_test.pm
@@ -24,10 +24,10 @@ use version_utils qw(is_opensuse is_sle is_tumbleweed);
 
 
 sub testsuiteinstall {
-    # The isotovideo setting QA_HEAD_REPO is not mandatory.
-    # QA_HEAD_REPO is meant to override the default repos with a custom OBS repo to test changes on the test suite package.
-    my $qa_head_repo = get_var('QA_HEAD_REPO', '');
-    if (!$qa_head_repo) {
+    # The isotovideo setting QA_TESTSUITE_REPO is not mandatory.
+    # QA_TESTSUITE_REPO is meant to override the default repos with a custom OBS repo to test changes on the test suite package.
+    my $qa_testsuite_repo = get_var('QA_TESTSUITE_REPO', '');
+    if (!$qa_testsuite_repo) {
         if (is_opensuse()) {
             my $sub_project;
             if (is_tumbleweed()) {
@@ -37,13 +37,14 @@ sub testsuiteinstall {
                 (my $version, my $service_pack) = split('\.', get_required_var('VERSION'));
                 $sub_project = "Leap:/$version/openSUSE_Leap_$version.$service_pack/";
             }
-            $qa_head_repo = 'https://download.opensuse.org/repositories/devel:/openSUSE:/QA:/' . $sub_project;
+            $qa_testsuite_repo = 'https://download.opensuse.org/repositories/devel:/openSUSE:/QA:/' . $sub_project;
         }
         else {
-            (my $version, my $service_pack) = split('-', get_required_var('VERSION'));
-            $qa_head_repo = "http://download.suse.de/ibs/QA:/$version$service_pack/standard/";
+            my $version_with_service_pack    = get_required_var('VERSION');
+            my $version_without_service_pack = substr($version_with_service_pack, 0, index($version_with_service_pack, '-'));
+            $qa_testsuite_repo = "http://download.suse.de/ibs/QA:/Head:/SLE$version_without_service_pack/SLE-$version_with_service_pack/";
         }
-        die '$qa_head_repo is not set' unless ($qa_head_repo);
+        die '$qa_testsuite_repo is not set' unless ($qa_testsuite_repo);
     }
 
     select_console 'root-console';
@@ -57,7 +58,7 @@ sub testsuiteinstall {
     zypper_call 'in strace';
 
     # install systemd testsuite
-    zypper_call "ar $qa_head_repo systemd-testrepo";
+    zypper_call "ar $qa_testsuite_repo systemd-testrepo";
     zypper_call '--gpg-auto-import-keys ref';
     zypper_call 'in systemd-qa-testsuite';
 }

--- a/tests/systemd_testsuite/binary_tests.pm
+++ b/tests/systemd_testsuite/binary_tests.pm
@@ -19,15 +19,13 @@ sub run {
     my ($self) = @_;
     $self->testsuiteinstall;
 
-    #run binary tests
-    assert_script_run 'cd /var/opt/systemd-tests';
-    assert_script_run './run-tests.sh | tee /tmp/testsuite.log', 600;
-    assert_screen("systemd-testsuite-binary-tests-summary");
+    # run binary tests
+    assert_script_run('cd /var/opt/systemd-tests');
+    validate_script_output('./run-tests.sh | tee /tmp/testsuite.log', sub { m/# FAIL:\s*0/ }, timeout => 600);
 }
 
 sub test_flags {
     return {fatal => 1, milestone => 1};
 }
-
 
 1;


### PR DESCRIPTION
## Information
STDOUT is just text and a screen check is not as reliable because a font
change, a resolution change would need a new needle.
Furthermore, different needles have to be maintained for each product.
script_output and validate_script_output should be used instead of
check_screen and assert_screen if possible.

## Related ticket
- https://progress.opensuse.org/issues/56543

## Requirements
- SR: https://build.suse.de/request/show/204195 (accepted)

## Verification runs

#### Tumbleweed
- Test suite package broken, not possible to test.

#### SLE 15-SP2
- [x86_64 Build 80.5](http://openqa.slindomansilla-vm.qa.suse.de/tests/1872)

####  openSUSE Leap 15.2
- [x86_64 Build 509.3](http://openqa.slindomansilla-vm.qa.suse.de/tests/1774#step/binary_tests/20)

#### SLE 12-SP5
- Test suite outdated. Not possible to test.