### PR TITLE
Use registration in autoyast for staging

### DIFF
--- a/data/autoyast_sle15/mini_staging.xml
+++ b/data/autoyast_sle15/mini_staging.xml
@@ -7,18 +7,20 @@
             <timeout config:type="integer">-1</timeout>
         </global>
     </bootloader>
-    <add-on>
-        <add_on_products config:type="list">
-             <listentry>
-                <media_url>{{ADDONURL_BASE}}</media_url>
-                <product>sle-module-basesystem</product>
-             </listentry>
-             <listentry>
-                <media_url>{{ADDONURL_SERVERAPP}}</media_url>
-                <product>sle-module-serverapplications</product>
-             </listentry>
-        </add_on_products>
-    </add-on>
+    <suse_register>
+      <do_registration config:type="boolean">true</do_registration>
+      <email/>
+      <reg_code>{{SCC_REGCODE}}</reg_code>
+      <install_updates config:type="boolean">true</install_updates>
+      <reg_server>{{SCC_URL}}</reg_server>
+      <addons config:type="list">
+        <addon>
+          <name>sle-module-basesystem</name>
+          <version>{{VERSION}}</version>
+          <arch>{{ARCH}}</arch>
+        </addon>
+      </addons>
+    </suse_register>
     <networking>
         <keep_install_network config:type="boolean">true</keep_install_network>
     </networking>


### PR DESCRIPTION
In staging we build only online installer, so only registered
installations are allowed.
Changing profile to use registration instead of using addons.

Fails with bug, as ay is still not working yet.

[Verification run(s)](https://openqa.suse.de/tests/overview?distri=sle&build=rwx788%2Fos-autoinst-distri-opensuse%238800&version=15-SP2).
