### PR TITLE
Turn on debug for libvirtd & enable journal with previous reboot

### DIFF
--- a/tests/virt_autotest/update_package.pm
+++ b/tests/virt_autotest/update_package.pm
@@ -18,6 +18,7 @@ use base "virt_autotest_base";
 use virt_utils;
 use ipmi_backend_utils;
 use Utils::Backends 'is_remote_backend';
+use Utils::Architectures;
 
 sub update_package {
     my $self           = shift;
@@ -59,6 +60,10 @@ sub run {
         my $ipmi_console = get_var('LINUX_CONSOLE_OVERRIDE', 'ttyAMA0');
         assert_script_run("sed -irn \"s/console=ttyAMA0/console=$ipmi_console/g\" /usr/share/qa/virtautolib/lib/vh-update-lib.sh");
     }
+
+    # turn on debug for libvirtd & enable journal with previous reboot
+    enable_debug_logging if is_x86_64;
+
 }
 
 sub test_flags {


### PR DESCRIPTION
To implement:
log_level=1 in libvirtd.conf
create /var/log/libvirtd.log
keep previous boots logs in  journal log

refer to the existing function to enable libvirtd logging in virtlib

background: 
there is an existing func in virtlib, and prj1&prj4 support this function with -d options in the command line. But the option is not used in openqa tests.
Rather than enable other tests to support the debug option and pass the option to openqa tests, we would like to implement it in openqa test scripts directly for all tests.

- Related ticket: https://trello.com/c/m4mkX7pQ/495-p3openqaenable-debug-logging-of-libvirtd-journal-in-openqa
- Verification run: http://10.67.18.253/tests/1347#step/update_package/32

@alice-suse @xguo @waynechen55
