### PR TITLE
Publiccloud: Set corresponding project for gce.tf

### DIFF
--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -120,6 +120,12 @@ sub img_proof {
     return $self->run_img_proof(%args);
 }
 
+sub terraform_apply {
+    my ($self, %args) = @_;
+    $args{project} //= $self->project_id;
+    return $self->SUPER::terraform_apply(%args);
+}
+
 sub describe_instance
 {
     my ($self, $instance) = @_;

--- a/lib/publiccloud/provider.pm
+++ b/lib/publiccloud/provider.pm
@@ -282,6 +282,7 @@ sub terraform_apply {
     $cmd .= "-var 'type=" . $instance_type . "' ";
     $cmd .= "-var 'region=" . $self->region . "' ";
     $cmd .= "-var 'name=" . $name . "' ";
+    $cmd .= "-var 'project=" . $args{project} . "' " if $args{project};
     if ($args{use_extra_disk}) {
         $cmd .= "-var 'create-extra-disk=true' ";
         $cmd .= "-var 'extra-disk-size=" . $args{use_extra_disk}->{size} . "' " if $args{use_extra_disk}->{size};


### PR DESCRIPTION
With using different vault namespaces, we also get different
project-id's. So we need to reflect these when applying terraform
configs.

- Verification run: http://pdostal-server.suse.cz/tests/5403#step/ssh_interactive_init/32
