### PR TITLE
Publiccloud: Change GCE image name on upload

### DIFF
--- a/lib/publiccloud/gce.pm
+++ b/lib/publiccloud/gce.pm
@@ -76,8 +76,9 @@ sub file2name {
     my ($self, $file) = @_;
     my $name = $file;
     $name = lc $file;    # lower case
-    $name =~ s/[^a-z0-9]//g;    # only allowed characteres from Google Cloud
-    $name =~ s/targz$//;        # removes targz
+    $name =~ s/\.tar\.gz$//;     # removes tar.gz
+    $name =~ s/\./-/g;
+    $name =~ s/[^-a-z0-9]//g;    # only allowed characteres from Google Cloud
     return $name;
 }
 


### PR DESCRIPTION
We striped all '.' from the name. This has the result that it is not
possible to extract KIWI and BUILD number from that image later on.
But we need this info to automatic clean up such images.

`SLES12-SP5-GCE.x86_64-0.9.1-BYOS-Build1.55.tar.gz`
 => `sles12-sp5-gce-x8664-0-9-1-byos-build1-55`

- Related ticket: https://progress.opensuse.org/issues/54539
- Verification run: 
  - https://openqa.suse.de/t3542288
  - https://openqa.suse.de/t3542289
  - https://openqa.suse.de/t3542318 (when image already uploaded)
