### PR TITLE
Add RDP remote desktop cases to TW(poo#57044)

### DIFF
--- a/tests/support_server/login.pm
+++ b/tests/support_server/login.pm
@@ -22,13 +22,14 @@ use base 'basetest';
 use base 'opensusebasetest';
 use testapi;
 use utils;
-use version_utils 'is_desktop_installed';
+use version_utils qw(is_desktop_installed is_tumbleweed);
 
 sub run {
     my ($self) = @_;
+    my $timeout = (is_tumbleweed) ? 180 : 80;
     # we have some tests that waits for dvd boot menu timeout and boot from hdd
     # - the timeout here must cover it
-    $self->wait_boot(bootloader_time => 80, textmode => !is_desktop_installed);
+    $self->wait_boot(bootloader_time => $timeout, textmode => !is_desktop_installed);
 
     # the supportserver image can be different version than the currently tested system
     # so try to login without use of needles

--- a/tests/x11/remote_desktop/xrdp_client.pm
+++ b/tests/x11/remote_desktop/xrdp_client.pm
@@ -15,20 +15,37 @@ use strict;
 use warnings;
 use base 'x11test';
 use testapi;
+use version_utils ':VERSION';
 use lockapi;
 use mmapi;
 use mm_tests;
 
 sub run {
     my $self = shift;
-
     # Setup static NETWORK
     $self->configure_static_ip_nm('10.0.2.17/24');
 
     mutex_lock 'win_server_ready';
 
+    ensure_installed('remmina');
+
+    # Disable Remmina news before launch Remmina
+    x11_start_program('xterm');
+    my $pref_dir  = '/home/bernhard/.config/remmina';
+    my $timestamp = script_output('date "+%s"', type_command => 1);
+    assert_script_run "mkdir $pref_dir";
+    assert_script_run "echo -e \'[remmina_news]\\nperiodic_rmnews_last_get='$timestamp'\' >> '$pref_dir'/remmina.pref";
+    type_string "exit\n";
+
     # Start Remmina and login the remote server
-    x11_start_program('remmina', target_match => 'remmina-launched');
+    x11_start_program('remmina', valid => 0);
+    check_screen 'enter-pwd-2-unlock-keyring';
+    if (match_has_tag 'enter-pwd-2-unlock-keyring') {
+        type_password;
+        assert_and_click "unlock-keyring";
+    }
+
+    assert_screen 'remmina-launched';
     type_string '10.0.2.18';
     send_key 'ret';
     assert_and_click 'accept-certificate-yes';
@@ -43,6 +60,7 @@ sub run {
 
     wait_still_screen 3;
     assert_screen [qw(connection-failed windows-desktop-on-remmina)];
+
     if (match_has_tag 'connection-failed') {
         record_soft_failure 'bsc#1117402 - Remmina is not able to connect to the windows server';
         send_key "alt-f4";


### PR DESCRIPTION
Add RDP remote desktop cases to TW(poo#57044)

- Related ticket
https://progress.opensuse.org/issues/57044

- Needles: 
https://github.com/os-autoinst/os-autoinst-needles-opensuse/pull/604

Verification Run:
http://10.67.19.11/tests/1410 (tw-remote-desktop-xrdp-server1)
http://10.67.19.11/tests/1411 (tw-remote-desktop-xrdp-client1)
http://10.67.19.11/tests/1414 (tw-remote-desktop-xrdp-server2)
http://10.67.19.11/tests/1415 (tw-remote-desktop-xrdp-client2)

Also verified the changes doesn't affect existing tests on SLE15SP2. See below verification run:
http://10.67.19.11/tests/1419 (desktopapps-remote-desktop-xrdp-server1)
http://10.67.19.11/tests/1421 (desktopapps-remote-desktop-xrdp-client1)