### PR TITLE
To register product and addons by commands instead of YAST

### DIFF
--- a/lib/migration.pm
+++ b/lib/migration.pm
@@ -87,7 +87,14 @@ sub register_system_in_textmode {
     # that do not show license agreement during installation but do when registering
     # after install
     set_var('IN_PATCH_SLE', 1);
-    yast_scc_registration;
+    # To register the product and addons via commands, only for sle 12+
+    if (get_var('ADDON_REGBYCMD') && is_sle('12+')) {
+        register_product();
+        register_addons_cmd();
+    }
+    else {
+        yast_scc_registration();
+    }
     # Once SCC registration is done, disable IN_PATCH_SLE so it does not interfere
     # with further calls to accept_addons_license (in upgrade for example)
     set_var('IN_PATCH_SLE', 0);

--- a/tests/update/patch_sle.pm
+++ b/tests/update/patch_sle.pm
@@ -235,7 +235,14 @@ sub sle_register {
             # that do not show license agreement during installation but do when registering
             # after install
             set_var('IN_PATCH_SLE', 1);
-            yast_scc_registration();
+            # To register the product and addons via commands, only for sle 12+
+            if (get_var('ADDON_REGBYCMD') && is_sle('12+')) {
+                register_product();
+                register_addons_cmd();
+            }
+            else {
+                yast_scc_registration();
+            }
             # Once SCC registration is done, disable IN_PATCH_SLE so it does not interfere
             # with further calls to accept_addons_license (in upgrade for example)
             set_var('IN_PATCH_SLE', 0);


### PR DESCRIPTION
For all extensions testing, it need spend one hour to finish add addons at patch_sle part. If we use commands instead of YAST to add addons, it can save 45 mins only at patch_sle part. For some cases, we can set 'ADDON_REGBYCMD' to control use YAST  or command to add addons.

- Related ticket: https://progress.opensuse.org/issues/51347
- Verification run: 
http://10.161.8.44/tests/666#step/patch_sle_min/20