### PR TITLE
Fix xfce4_appfinder for Leap 15.2

### DIFF
--- a/tests/x11/xfce4_appfinder.pm
+++ b/tests/x11/xfce4_appfinder.pm
@@ -15,7 +15,7 @@ use base 'x11test';
 use strict;
 use warnings;
 use testapi;
-use version_utils 'is_tumbleweed';
+use version_utils qw(is_tumbleweed is_leap);
 use x11utils 'desktop_runner_hotkey';
 
 
@@ -23,7 +23,7 @@ sub run {
     wait_screen_change { send_key desktop_runner_hotkey };
     send_key "down";
     # In XFCE 4.14+, a dynamic search is performed - poo#56111
-    if (is_tumbleweed) {
+    if (is_tumbleweed || is_leap(">=15.2")) {
         type_string "about";
     } else {
         type_string "about\n";


### PR DESCRIPTION
Leap 15.2 got an Xfce version update.

Verification run: http://10.160.67.86/tests/570
