### PR TITLE
Add spvm boot support to LTP

### DIFF
--- a/lib/main_ltp.pm
+++ b/lib/main_ltp.pm
@@ -25,6 +25,7 @@ use LTP::TestInfo 'testinfo';
 use File::Basename 'basename';
 use main_common qw(load_bootloader_s390x boot_hdd_image get_ltp_tag load_boot_tests load_inst_tests load_reboot_tests);
 use 5.018;
+use Utils::Backends 'is_spvm';
 # FIXME: Delete the "## no critic (Strict)" line and uncomment "use warnings;"
 # use warnings;
 
@@ -132,6 +133,7 @@ sub load_kernel_tests {
     load_bootloader_s390x();
 
     if (get_var('INSTALL_LTP')) {
+        loadtest "../installation/bootloader" if is_spvm;
         if (get_var('INSTALL_KOTD')) {
             loadtest 'install_kotd';
         }
@@ -150,6 +152,7 @@ sub load_kernel_tests {
         shutdown_ltp();
     }
     elsif (get_var('LTP_COMMAND_FILE')) {
+        loadtest "../installation/bootloader" if is_spvm;
         if (get_var('INSTALL_KOTD')) {
             loadtest 'install_kotd';
         }


### PR DESCRIPTION
Enhancement poo#44309: LTP has own independent boot procedure, this
change will allow to boot LTP tests on installed PowerVM systems.

- Related ticket: https://progress.opensuse.org/issues/44309
- Needles: none
- Verification run:  http://10.100.12.105/tests/3447