### PR TITLE
Install kernel-devel package in install_ltp

### DIFF
--- a/tests/kernel/qa_test_klp.pm
+++ b/tests/kernel/qa_test_klp.pm
@@ -35,7 +35,7 @@ sub run {
 
     add_suseconnect_product("sle-sdk") if (is_sle('<12-SP5'));
 
-    zypper_call('in -l git gcc kernel-devel make');
+    zypper_call('in -l git gcc make');
 
     assert_script_run('git clone ' . $git_repo);
 

--- a/tests/kernel/update_kernel.pm
+++ b/tests/kernel/update_kernel.pm
@@ -35,6 +35,7 @@ sub update_kernel {
     my ($repo, $incident_id) = @_;
 
     fully_patch_system;
+    zypper_call('in kernel-devel');
 
     my @repos = split(",", $repo);
     while (my ($i, $val) = each(@repos)) {
@@ -134,6 +135,8 @@ sub install_lock_kernel {
     if ($wk_ker == 1) {
         @packages = grep { $_ ne 'kernel-source-4.12.14-25.13.1' } @packages;
     }
+
+    push @packages, "kernel-devel=$version";
 
     # install and lock needed kernel
     zypper_call("in " . join(' ', @packages), exitcode => [0, 102, 103, 104], timeout => 1400);
@@ -257,7 +260,7 @@ sub install_kotd {
     fully_patch_system;
     remove_kernel_packages;
     zypper_ar($repo, name => 'KOTD', priority => 90, no_gpg_check => 1);
-    zypper_call("in -l kernel-default");
+    zypper_call("in -l kernel-default kernel-devel");
 }
 
 sub boot_to_console {


### PR DESCRIPTION
The KLP test requires kernel-devel package to work. Install it together with kernel in install_ltp job to prevent KLP test from failing due to cleared incident repository. KOTD tests in particular are prone to failing because their incident repo gets cleared more than once a day.

- Related ticket: https://progress.opensuse.org/issues/58601
- Needles: N/A
- Verification runs:
  - KOTD install: https://openqa.suse.de/tests/3544758
  - KOTD KLP: https://openqa.suse.de/tests/3546051
  - dtb-aarch64 install: https://openqa.suse.de/tests/3559521
  - dtb-aarch64 KLP: https://openqa.suse.de/tests/3559582
  - kgraft install: https://openqa.suse.de/tests/3604905
  - kgraft KLP: https://openqa.suse.de/tests/3604916
  - azure install: https://openqa.suse.de/tests/3580410

(This will take a while because there are currently no incident repos for some verification runs.)