### PR TITLE
Check register WE status with zypper lr

### DIFF
--- a/lib/services/registered_addons.pm
+++ b/lib/services/registered_addons.pm
@@ -48,9 +48,14 @@ sub check_registered_addons {
         $addon =~ s/(^\s+|\s+$)//g;
         my $name = get_addon_fullname($addon);
         $name = 'LTSS' if ($name =~ /LTSS/);
+        # If has WE addon, zypper lr will list product-we when sle is 15+
+        # Need check nvidia repo
+        if ($name =~ /sle-we/) {
+            is_sle('15+') ? zypper_lr('product-we') : zypper_lr('sle-we');
+            zypper_lr('NVIDIA');
+            next;
+        }
         zypper_lr($name);
-        # If has WE addon, need check nvidia repo
-        zypper_lr('NVIDIA') if ($name =~ /sle-we/);
     }
 }
 


### PR DESCRIPTION
Check register WE status with zypper lr, if sle version >= 15, sle-we will be changed to product-we. This part is different with SUSEConnect command, If use SUSEConnect, WE still is sle-we. In case to impact others' case, we need change our code to match WE name.
- Related ticket: https://progress.opensuse.org/issues/58962
- Verification run: 
Before migration: http://10.161.8.44/tests/680#step/install_service/13
After migration: http://10.161.8.44/tests/680#step/check_upgraded_service/20
