### PR TITLE
Publiccloud: Add script to create instance logs

### DIFF
--- a/data/publiccloud/log_instance.sh
+++ b/data/publiccloud/log_instance.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+
+COMMAND=$1
+PROVIDER=$2
+INSTANCE_ID=$3
+HOST=$4
+ZONE=$5
+OUTPUT_DIR=/tmp/log_instance/"$INSTANCE_ID"
+LOCK=${OUTPUT_DIR}/.lock
+CNT_FILE=${OUTPUT_DIR}/.cnt
+PID_FILE=${OUTPUT_DIR}/pid
+SSH_OPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=ERROR"
+
+ec2_start_log()
+{
+    inc_unique_counter
+    set +e
+    aws ec2 get-console-output --instance-id "$INSTANCE_ID" --output text > "${OUTPUT_DIR}/${CNT}_get_console_output_start.log"
+    set -e
+    nohup ssh $SSH_OPTS "ec2-user@${HOST}" -- sudo dmesg -c -w > "${OUTPUT_DIR}/${CNT}_dmesg.log" 2>&1 &
+    echo "$!" >> "${OUTPUT_DIR}/pid"
+}
+
+ec2_stop_log()
+{
+    read_unique_counter
+    set +e
+    aws ec2 get-console-output --instance-id "$INSTANCE_ID" --output text > "${OUTPUT_DIR}/${CNT}_get_console_output_stop.log"
+    set -e
+    local pids=$( test -f "$PID_FILE" && cat "$PID_FILE")
+    rm "$PID_FILE"
+
+    for pid in $pids; do
+        kill -9 "$pid"
+    done
+}
+
+
+gce_read_serial()
+{
+    ( flock -w 10 -e 9 || exit 1;
+
+        rstart=0
+        tmpfile="${OUTPUT_DIR}/tmp.txt"
+        ofile="${OUTPUT_DIR}/serial_port_1.log"
+        errfile="${OUTPUT_DIR}/stderr"
+        max_loop=42
+
+        while [ $max_loop -gt 1 ] ; do
+            max_loop=$((max_loop -1))
+            [ -f "$errfile" ] &&
+                rstart=$( grep -oP -- '--start=\d+' "$errfile" | grep -oP '\d+' || echo 0)
+
+            gcloud compute instances get-serial-port-output "$INSTANCE_ID" --port 1 \
+                --zone "$ZONE" --start="$rstart" > "$tmpfile" 2> "$errfile"
+            grep 'WARNING:' "$errfile" >> "$ofile" || true
+            newstart=$(grep -oP -- '--start=\d+' "$errfile" | grep -oP '\d+')
+            if [ "$rstart" -eq "$newstart" ]; then
+                rm "$tmpfile"
+                break
+            else
+                cat "$tmpfile" >> "$ofile"
+                rm "$tmpfile"
+            fi
+        done
+    ) 9> "${LOCK}"
+}
+
+gce_is_running()
+{
+    if [ -f "$PID_FILE" ]; then
+        local pid=$( cat "$PID_FILE");
+        if kill -0 "$pid" > /dev/null 2>&1 ; then
+            return 0;
+        fi
+    fi
+    return 1
+}
+
+gce_start_log()
+{
+    gce_is_running && exit 2;
+    ( while true; do gce_read_serial; sleep 30; done; ) &
+    echo $! >> "$PID_FILE"
+}
+
+gce_stop_log()
+{
+    # Use flock to wait max 60s that gce_read_serial() is ready. And kill during
+    # the 30s sleep afterwards. If flock fail, just kill the bg process.
+    (flock -w 60 -e 9 || exit 1
+        gce_is_running && kill -9 $( cat "$PID_FILE" )
+        rm "$PID_FILE"
+    ) 9> "${LOCK}"
+}
+
+azure_start_log()
+{
+
+    inc_unique_counter
+    set +e
+    az vm boot-diagnostics get-boot-log --ids $(az vm list -g "$INSTANCE_ID" --query '[].id' -o tsv) > "${OUTPUT_DIR}/$CNT""_boot_log_start.txt" 2>&1
+    set -e
+    nohup ssh $SSH_OPTS "azureuser@${HOST}" -- sudo dmesg -c -w > "${OUTPUT_DIR}/${CNT}_dmesg.log" 2>&1 &
+    echo "$!" >> "$PID_FILE"
+
+    true;
+}
+
+azure_stop_log()
+{
+    read_unique_counter
+    set +e
+    # give some time for azure to write something
+    sleep 30
+    az vm boot-diagnostics get-boot-log --ids $(az vm list -g "$INSTANCE_ID" --query '[].id' -o tsv) > "${OUTPUT_DIR}/$CNT""_boot_log_stop.txt" 2>&1
+    set -e
+    local pids=$(test -f "$PID_FILE" && cat "$PID_FILE")
+    rm "$PID_FILE"
+
+    for pid in $pids; do
+        kill -9 "$pid"
+    done
+}
+
+read_unique_counter()
+{
+    CNT=$(printf "%03d" "$(cat "$CNT_FILE" 2> /dev/null)")
+}
+
+inc_unique_counter()
+{
+    if [ -f "$CNT_FILE" ]; then
+        CNT=$(( $(cat "$CNT_FILE") + 1 ))
+        echo $CNT > "$CNT_FILE"
+        CNT=$(printf "%03d" "$CNT")
+    else
+        CNT="000"
+        echo 0 > "$CNT_FILE"
+    fi
+}
+
+error() {
+    local parent_lineno=$1
+    local code=${2:-1}
+    echo "Error on line ${parent_lineno}"
+    exit "${code}"
+}
+
+trap 'error ${LINENO}' ERR
+set -e
+
+if [ $# -lt 4 ]; then
+    echo  "$0 (start|stop) (EC2|AZURE|GCE) <instance_id> <host> [zone]"
+    exit 2;
+fi
+mkdir -p "$OUTPUT_DIR"
+
+case $PROVIDER in
+    EC2)
+        ec2_"${COMMAND}"_log
+        ;;
+    AZURE|Azure)
+        azure_"${COMMAND}"_log
+        ;;
+    GCE)
+        gce_"${COMMAND}"_log
+        ;;
+    *)
+        echo "Unknown provider $PROVIDER given";
+        exit 2;
+        ;;
+esac
+

--- a/data/publiccloud/restart_instance.sh
+++ b/data/publiccloud/restart_instance.sh
@@ -43,16 +43,19 @@ INSTANCE_ID=$2
 HOST=$3
 ZONE=$4
 CNT=120;
+LOG_SCRIPT="./log_instance.sh"
+
+test -x $LOG_SCRIPT && $LOG_SCRIPT stop "$PROVIDER" "$INSTANCE_ID" "$HOST" "$ZONE"
 
 case $PROVIDER in
     EC2)
-        aws ec2 reboot-instances  --instance-ids $INSTANCE_ID
+        aws ec2 reboot-instances  --instance-ids "$INSTANCE_ID"
         ;;
     AZURE)
-        az vm restart -g $INSTANCE_ID -n $INSTANCE_ID --no-wait
+        az vm restart -g "$INSTANCE_ID" -n "$INSTANCE_ID" --no-wait
         ;;
     GCE)
-        gcloud compute instances reset $INSTANCE_ID --zone $ZONE
+        gcloud compute instances reset "$INSTANCE_ID" --zone "$ZONE"
         ;;
     *)
         echo "Unknown provider $PROVIDER given";
@@ -60,7 +63,8 @@ case $PROVIDER in
         ;;
 esac
 
-wait_for_power_off $HOST $CNT
-wait_for_power_on $HOST $CNT
+wait_for_power_off "$HOST" "$CNT"
+wait_for_power_on "$HOST" "$CNT"
 echo "Instance $INSTANCE_ID restarted";
+test -x $LOG_SCRIPT && $LOG_SCRIPT start "$PROVIDER" "$INSTANCE_ID" "$HOST" "$ZONE"
 

--- a/data/publiccloud/terraform/azure.tf
+++ b/data/publiccloud/terraform/azure.tf
@@ -34,6 +34,10 @@ variable "create-extra-disk" {
     default=false
 }
 
+variable "storage-account" {
+    default="openqa"
+}
+
 resource "random_id" "service" {
     count = "${var.instance_count}"
     keepers = {
@@ -158,6 +162,11 @@ resource "azurerm_virtual_machine" "openqa-vm" {
         openqa_created_by = "${var.name}"
         openqa_created_date = "${timestamp()}"
         openqa_created_id = "${element(random_id.service.*.hex, count.index)}"
+    }
+
+    boot_diagnostics {
+        enabled = true
+        storage_uri = "https://${var.storage-account}.blob.core.windows.net/"
     }
 }
 

--- a/tests/publiccloud/run_ltp.pm
+++ b/tests/publiccloud/run_ltp.pm
@@ -19,6 +19,8 @@ use utils;
 use repo_tools 'generate_version';
 use Mojo::UserAgent;
 
+our $root_dir = '/root';
+
 sub get_ltp_rpm
 {
     my ($url) = @_;
@@ -30,6 +32,16 @@ sub get_ltp_rpm
     die('Could not find LTP package in ' . $url);
 }
 
+sub instance_log_args
+{
+    my $self = shift;
+    return sprintf('"%s" "%s" "%s" "%s"',
+        get_required_var('PUBLIC_CLOUD_PROVIDER'),
+        $self->{my_instance}->instance_id,
+        $self->{my_instance}->public_ip,
+        $self->{provider}->region);
+}
+
 sub run {
     my ($self)   = @_;
     my $ltp_repo = get_var('LTP_REPO', 'http://download.suse.de/ibs/QA:/Head/' . generate_version("-") . '/x86_64/');
@@ -38,19 +50,22 @@ sub run {
     $self->select_serial_terminal;
 
     my $ltp_rpm         = get_ltp_rpm($ltp_repo);
-    my $source_rpm_path = '/root/' . $ltp_rpm;
+    my $source_rpm_path = $root_dir . '/' . $ltp_rpm;
     my $remote_rpm_path = '/tmp/' . $ltp_rpm;
     record_info('LTP RPM', $ltp_repo . $ltp_rpm);
     assert_script_run('wget ' . $ltp_repo . $ltp_rpm . ' -O ' . $source_rpm_path);
 
     my $provider = $self->provider_factory();
-    my $instance = $provider->create_instance();
+    my $instance = $self->{my_instance} = $provider->create_instance();
     $instance->wait_for_guestregister();
 
     $instance->scp($source_rpm_path, 'remote:' . $remote_rpm_path);
 
-    assert_script_run('curl ' . data_url('publiccloud/restart_instance.sh') . ' -o ~/restart_instance.sh');
-    assert_script_run('chmod +x ~/restart_instance.sh');
+    assert_script_run("cd $root_dir");
+    assert_script_run('curl ' . data_url('publiccloud/restart_instance.sh') . ' -o restart_instance.sh');
+    assert_script_run('curl ' . data_url('publiccloud/log_instance.sh') . ' -o log_instance.sh');
+    assert_script_run('chmod +x restart_instance.sh');
+    assert_script_run('chmod +x log_instance.sh');
 
     assert_script_run('git clone -q --single-branch -b runltp_ng_openqa --depth 1 https://github.com/cfconrad/ltp.git');
 
@@ -59,8 +74,10 @@ sub run {
     $instance->run_ssh_command(cmd => 'sudo zypper --no-gpg-checks --gpg-auto-import-keys -q in -y ' . $remote_rpm_path, timeout => 600);
     $instance->run_ssh_command(cmd => 'sudo CREATE_ENTRIES=1 /opt/ltp/IDcheck.sh', timeout => 300);
 
-    my $reset_cmd = sprintf('~/restart_instance.sh %s %s %s %s', get_required_var('PUBLIC_CLOUD_PROVIDER'), $instance->instance_id, $instance->public_ip,
-        $provider->region);
+    my $reset_cmd     = $root_dir . '/restart_instance.sh ' . $self->instance_log_args();
+    my $log_start_cmd = $root_dir . '/log_instance.sh start ' . $self->instance_log_args();
+
+    assert_script_run($log_start_cmd);
 
     my $cmd = 'perl -I ltp/tools/runltp-ng ltp/tools/runltp-ng/runltp-ng ';
     $cmd .= '--logname=ltp_log ';
@@ -85,7 +102,13 @@ sub cleanup {
     type_string('', terminate_with => 'ETX');
 
     upload_logs('ltp_log.raw', failok => 1);
-    parse_extra_log(LTP => 'ltp_log.json') if (script_run('test -f ltp_log.json') == 0);
+    parse_extra_log(LTP => "$root_dir/ltp_log.json") if (script_run("test -f $root_dir/ltp_log.json") == 0);
+
+    if ($self->{my_instance} && script_run("test -f $root_dir/log_instance.sh") == 0) {
+        assert_script_run($root_dir . '/log_instance.sh stop ' . $self->instance_log_args());
+        assert_script_run("(cd /tmp/log_instance && tar -zcf $root_dir/instance_log.tar.gz *)");
+        upload_logs("$root_dir/instance_log.tar.gz", failok => 1);
+    }
 }
 
 1;


### PR DESCRIPTION
For better debugging we need to create serial logs (if available) and
dmesg logs during ltp tests.

The logs will be uploaded as instance_log.tar.gz

- Related ticket: https://progress.opensuse.org/issues/58589
- Verification run: 
  - sle-12-SP5-Azure-Basic-On-Demand-x86_64-Build0.9.0-3.2-publiccloud_ltp_cve@az_Standard_A2_v2 -> https://openqa.suse.de/t3552740
  - sle-12-SP5-EC2-BYOS-x86_64-Build0.9.1-1.55-publiccloud_ltp_cve@ec2_t2 .large -> https://openqa.suse.de/t3552741
  - sle-12-SP5-GCE-BYOS-x86_64-Build0.9.1-1.55-publiccloud_ltp_cve@gce_n1_standard_2 -> https://openqa.suse.de/t3552742


