### PR TITLE
Allow installing in a different DASD path

### DIFF
--- a/tests/installation/bootloader_s390.pm
+++ b/tests/installation/bootloader_s390.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2017 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -218,22 +218,24 @@ sub show_debug {
 }
 
 sub create_encrypted_part_dasd {
-    my $self = shift;
+    my $self      = shift;
+    my $dasd_path = get_var('DASD_PATH', '0.0.0150');
     # activate install-shell to do pre-install dasd-format
     select_console('install-shell');
 
     # bring dasd online
     # exit status 0 -> everything ok
     # exit status 8 -> unformatted but still usable (e.g. from previous testrun)
-    my $r = script_run("dasd_configure 0.0.0150 1");
+    my $r = script_run("dasd_configure $dasd_path 1");
     die "DASD in undefined state" unless (defined($r) && ($r == 0 || $r == 8));
     create_encrypted_part('dasda');
-    assert_script_run("dasd_configure 0.0.0150 0");
+    assert_script_run("dasd_configure $dasd_path 0");
 }
 
 sub format_dasd {
     my $self = shift;
     my $r;
+    my $dasd_path = get_var('DASD_PATH', '0.0.0150');
 
     # activate install-shell to do pre-install dasd-format
     select_console('install-shell');
@@ -241,7 +243,7 @@ sub format_dasd {
     # bring dasd online
     # exit status 0 -> everything ok
     # exit status 8 -> unformatted but still usable (e.g. from previous testrun)
-    $r = script_run("dasd_configure 0.0.0150 1");
+    $r = script_run("dasd_configure $dasd_path 1");
     die "DASD in undefined state" unless (defined($r) && ($r == 0 || $r == 8));
 
     # make sure that there is a dasda device

--- a/tests/installation/disk_activation.pm
+++ b/tests/installation/disk_activation.pm
@@ -1,7 +1,7 @@
 # SUSE's openQA tests
 #
 # Copyright © 2009-2013 Bernhard M. Wiedemann
-# Copyright © 2012-2018 SUSE LLC
+# Copyright © 2012-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -39,6 +39,8 @@ sub add_zfcp_disk {
 }
 
 sub run {
+    my $dasd_path = get_var('DASD_PATH', '0.0.0150');
+
     # use zfcp as install disk
     if (check_var('S390_DISK', 'ZFCP')) {
         assert_screen 'disk-activation-zfcp';
@@ -60,10 +62,10 @@ sub run {
         if (check_var("VIDEOMODE", "text")) {
             send_key 'alt-m';    # minimum channel ID
             for (1 .. 9) { send_key "backspace"; }
-            type_string '0.0.0150';
+            type_string "$dasd_path";
             send_key 'alt-x';    # maximum channel ID
             for (1 .. 9) { send_key "backspace"; }
-            type_string '0.0.0150';
+            type_string "$dasd_path";
             send_key 'alt-f';    # filter button
             assert_screen 'dasd-unselected';
             send_key 'alt-s';    # select all
@@ -74,9 +76,9 @@ sub run {
         }
         else {
             send_key 'alt-m';    # minimum channel ID
-            type_string '0.0.0150';
+            type_string "$dasd_path";
             send_key 'alt-x';    # maximum channel ID
-            type_string '0.0.0150';
+            type_string "$dasd_path";
             send_key 'alt-f';    # filter button
             assert_screen 'dasd-unselected';
             send_key 'alt-s';    # select all

--- a/tests/installation/logs_from_installation_system.pm
+++ b/tests/installation/logs_from_installation_system.pm
@@ -1,6 +1,6 @@
 # SUSE's openQA tests
 #
-# Copyright © 2017-2018 SUSE LLC
+# Copyright © 2017-2019 SUSE LLC
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -9,7 +9,7 @@
 
 # Summary: Collect logs from the installation system just before we try to
 #   reboot into the installed system
-# - If BACKEND is s390x or S390_DISK is not ZFCP, run "lsreipl | grep 0.0.0150"
+# - If BACKEND is s390x or S390_DISK is not ZFCP, run "lsreipl | grep $dasd_path"
 # to check IPL device
 # - If BACKEND is ipmi or spvm, set serial console type depending, HYPERVISOR TYPE (xen,
 # kvm) or ARCH (aarch64)
@@ -31,11 +31,12 @@ use ipmi_backend_utils;
 
 sub run {
     my ($self) = @_;
+    my $dasd_path = get_var('DASD_PATH', '0.0.0150');
     select_console 'install-shell';
 
     # check for right boot-device on s390x (zVM, DASD ONLY)
     if (check_var('BACKEND', 's390x') && !check_var('S390_DISK', 'ZFCP')) {
-        if (script_run('lsreipl | grep 0.0.0150')) {
+        if (script_run("lsreipl | grep $dasd_path")) {
             die "IPL device was not set correctly";
         }
     }


### PR DESCRIPTION
os-autoinst-distri-opensuse expects by default an installation device on
path 0.0.0150. This change will allow to install the OS in a different
path by providing the job setting DASD_PATH.

- Motivation: http://openqa.slindomansilla-vm.qa.suse.de/tests/1821#step/bootloader_s390/40
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1241
- Verification run: http://openqa.slindomansilla-vm.qa.suse.de/tests/1814#step/disk_activation/2
