### PR TITLE
[WIP] Extend kubeadm init timeout to 300 seconds

### DIFF
--- a/tests/console/kubeadm.pm
+++ b/tests/console/kubeadm.pm
@@ -20,7 +20,7 @@ sub run {
     select_console("root-console");
 
     record_info 'Test #1', 'Test: Initialize kubeadm';
-    assert_script_run("kubeadm init --cri-socket=/var/run/crio/crio.sock --pod-network-cidr=10.244.0.0/16 --kubernetes-version=\$(kubelet --version|sed -e 's/Kubernetes v//g') | tee /dev/$serialdev", 180);
+    assert_script_run("kubeadm init --cri-socket=/var/run/crio/crio.sock --pod-network-cidr=10.244.0.0/16 --kubernetes-version=\$(kubelet --version|sed -e 's/Kubernetes v//g') | tee /dev/$serialdev", 300);
 
     record_info 'Test #2', 'Test: Configure kubectl';
     assert_script_run('mkdir -p ~/.kube');


### PR DESCRIPTION
180 seconds seems to be insufficent.

- Related ticket: https://progress.opensuse.org/issues/58982
- Verification run: https://openqa.opensuse.org/t1074710

