### PR TITLE
Add support for SLES+HA migration tests in s390x

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2743,7 +2743,7 @@ sub load_ha_cluster_tests {
     set_var('USE_LVMLOCKD', 0) if (get_var('USE_LVMLOCKD') and is_sle('<15'));
 
     # When not using a support server, node 1 setups barriers and mutex
-    loadtest 'ha/barrier_init' if (get_var('HA_CLUSTER_INIT') and !get_var('USE_SUPPORT_SERVER'));
+    loadtest 'ha/barrier_init' if (get_var('HOSTNAME') =~ /node01$/ and !get_var('USE_SUPPORT_SERVER'));
 
     # Wait for barriers to be initialized except when testing HAWK as a client
     # or Pacemaker CTS regression tests

--- a/tests/ha/barrier_init.pm
+++ b/tests/ha/barrier_init.pm
@@ -19,7 +19,7 @@ use mmapi;
 
 # This tells the module whether the test is running in a supportserver or in node1
 sub is_not_supportserver_scenario {
-    return (get_var('HA_CLUSTER_INIT') and !get_var('USE_SUPPORT_SERVER'));
+    return (get_var('HOSTNAME') =~ /node01$/ and !get_var('USE_SUPPORT_SERVER'));
 }
 
 sub run {


### PR DESCRIPTION
Currently SLES+HA tests on aarch64, ppc64le and x86_64 over qemu rely on an extra job with a support server supplying DNS, DHCP, NTP and iSCSI services. As a consequence, mutex and barriers initialization is centralized in the support server job as well.

On the other hand, SLES+HA tests for s390x are run over svirt, so these network services are provided outside of the openqa infrastructure and there is no need for a support server. For this reason, barriers and mutex initialization was moved to whichever job has the `HA_CLUSTER_INIT` variable, i.e., the node starting the cluster with `ha-cluster-init`.

This approach works only for cluster installation and setup, but not for migration scenarios, as in those the cluster initialization was performed on a previous system (usually, in an older OS version).

This PR moves the barriers and mutex initialization from the job with `HA_CLUSTER_INIT` to whichever job with has the node identified as `node01` based on its hostname; as a consecuence existing installation and cluster setup tests for s390x should continue working as usually `node01` also has the `HA_CLUSTER_INIT` variable set, and migration tests can be also scheduled as long as one of the cluster nodes is currently identified as `node01`.

- Related ticket: N/A
- Needles: https://gitlab.suse.de/openqa/os-autoinst-needles-sles/merge_requests/1242
- Verification runs:

12-SP4 to 12-SP5 migration: [node01](http://mango.suse.de/tests/1928) & [node02](http://mango.suse.de/tests/1919)
Cluster Verification in Upgraded Cluster: [node01](http://mango.suse.de/tests/1931) & [node02](http://mango.suse.de/tests/1932)

- Regression:

Full Cluster Stack test: [node01](http://mango.suse.de/tests/1807) & [node02](http://mango.suse.de/tests/1808)

