### PR TITLE
wicked: Improve upload and tcpdump handling

### DIFF
--- a/lib/serial_terminal.pm
+++ b/lib/serial_terminal.pm
@@ -178,7 +178,7 @@ sub upload_file {
     $dst = "ulogs/" . $dst;
     my ($fh, $tmpfilename) = tempfile(UNLINK => 1, SUFFIX => '.openqa.upload');
 
-    die("File $src doesn't exists on SUT") if (script_run("test -f $src", quiet => 1, timeout => $opts{timeout}) != 0);
+    die("File $src does not exist on SUT") if (script_run("test -f $src", quiet => 1, timeout => $opts{timeout}) != 0);
     die("File $dst already exists on worker") if (-f $dst);
 
     my $filesize = script_output("stat --printf='%s' $src", quiet => 1, timeout => $opts{timeout});


### PR DESCRIPTION
* wicked: Be strict about tcpdump presence to prevent alarm fatigue
* wicked: Ensure tcpdump is also installed for 'ref'
* serial_terminal: Fix grammar in die-message

Verification runs:
* ref: https://openqa.suse.de/tests/3552959
* sut: https://openqa.suse.de/tests/3552960