### PR TITLE
Capture avalaible coredump data for consoletest modules

### DIFF
--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -56,6 +56,8 @@ sub post_fail_hook {
     $self->export_logs_basic;
     # Export extra log after failure for further check gdm issue 1127317, also poo#45236 used for tracking action on Openqa
     $self->export_logs_desktop;
+    # Export coredump data if present
+    $self->upload_coredumps;
 }
 
 sub test_flags {

--- a/tests/console/consoletest_setup.pm
+++ b/tests/console/consoletest_setup.pm
@@ -20,7 +20,7 @@
 
 use base "consoletest";
 use testapi;
-use utils qw(check_console_font disable_serial_getty);
+use utils qw(check_console_font disable_serial_getty zypper_call);
 use Utils::Backends qw(has_ttys use_ssh_serial_console);
 use Utils::Systemd 'disable_and_stop_service';
 use strict;
@@ -47,6 +47,9 @@ sub run {
     script_run 'echo "set -o pipefail" >> /etc/bash.bashrc.local';
     script_run '. /etc/bash.bashrc.local';
     disable_and_stop_service('packagekit.service', mask_service => 1);
+
+    # install coredumpctl for post_fail_hook consoletest.pm
+    zypper_call('in systemd-coredump');
 
     $self->clear_and_verify_console;
     select_console 'user-console';


### PR DESCRIPTION
Capture avalaible coredump data for consoletest modules

At least required to help investigation boo#1155583

- Related ticket: https://bugzilla.opensuse.org/show_bug.cgi?id=115558
