### PR TITLE
Set correct version on the installation of base system on zVM

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -197,6 +197,10 @@ sub setup_env {
         set_var('ORIGINAL_TARGET_VERSION', get_var('VERSION'));
         set_var('VERSION',                 get_var('UPGRADE_TARGET_VERSION'));
     }
+    # Set correct VERSION for the base system setup on z/VM
+    if (get_var('BASE_VERSION') && !is_upgrade() && check_var('ARCH', 's390x')) {
+        set_var('VERSION', get_var('BASE_VERSION'));
+    }
 }
 
 sub data_integrity_is_applicable {


### PR DESCRIPTION
For z/VM test, we have two jobs for it, one is installation for the base system, another is for migration. On base system it should have the correct VERSION = BASE_VERSION, while it will be set as the target version when trigger the job group for SLE15SP2.

- Related ticket: https://progress.opensuse.org/issues/58034
- Needles: 
- Verification run: http://openqa.suse.de/tests/3556319#
