### PR TITLE
Add support for s390x for lvm test

### DIFF
--- a/schedule/qam/15-SP1/mau-filesystem.yaml
+++ b/schedule/qam/15-SP1/mau-filesystem.yaml
@@ -11,7 +11,7 @@ schedule:
 - console/system_prepare
 - console/lsof
 - console/autofs
-- {{lvm}}
+- console/lvm
 - console/btrfs_autocompletion
 - console/btrfs_qgroups
 - console/snapper_cleanup
@@ -26,8 +26,4 @@ conditional_schedule:
     ARCH:
       s390x:
         - installation/bootloader_zkvm
-  lvm:
-    ARCH:
-      x86_64:
-        - console/lvm
 ...

--- a/tests/console/lvm.pm
+++ b/tests/console/lvm.pm
@@ -62,6 +62,14 @@ sub run {
 
     select_console 'root-console';
 
+    if (check_var('ARCH', 's390x')) {
+        # bring dasd online
+        # exit status 0 -> everything ok
+        # exit status 8 -> unformatted but still usable (e.g. from previous testrun)
+        my $r =  script_run("dasd_configure 0.0.0200 1");
+        die "DASD in undefined state" unless (defined($r) && ($r == 0 || $r == 8));
+    }
+
     $self->set_playground_disk;
     my $disk = get_required_var('PLAYGROUNDDISK');
     record_info("Information", "The playground disk used by this test is: $disk");

--- a/tests/console/lvm.pm
+++ b/tests/console/lvm.pm
@@ -66,8 +66,8 @@ sub run {
         # bring dasd online
         # exit status 0 -> everything ok
         # exit status 8 -> unformatted but still usable (e.g. from previous testrun)
-        my $r =  script_run("dasd_configure 0.0.0200 1");
-        die "DASD in undefined state" unless (defined($r) && ($r == 0 || $r == 8));
+        my $r = script_run("dasd_configure 0.0.0200 1");
+        die "DASD in undefined state (exit code $r)" unless (defined($r) && ($r == 0 || $r == 8));
     }
 
     $self->set_playground_disk;


### PR DESCRIPTION
Add support for s390x for lvm test by configuring the second dasd disk

- Related ticket: https://progress.opensuse.org/issues/56837
- Verification runs:
  - 15.sp1:
    - x64: http://d250.qam.suse.de/tests/2211 :heavy_check_mark: 
    - s390x: https://openqa.suse.de/tests/3556501 :heavy_check_mark: 
  - 12.sp4: http://d250.qam.suse.de/tests/2213 :heavy_check_mark: 
