### PR TITLE
Bump timeout yast2_snapper

### DIFF
--- a/lib/y2snapper_common.pm
+++ b/lib/y2snapper_common.pm
@@ -163,7 +163,7 @@ sub y2snapper_clean_and_quit {
 
     # After deletion of snapshot sometimes the UI gets busy, delete button is even disabled
     # but the UI is unresponsive for a time
-    wait_still_screen 10;
+    wait_still_screen 30;
     # C'l'ose the snapper module
     wait_screen_change { send_key "alt-l"; };
 


### PR DESCRIPTION
Bump `wait_still_screen` in yast2_snapper to the original value once the snapshot is deleted. It is buggy but it should stabilize the test.

- Related ticket: https://progress.opensuse.org/issues/56255
- Needles: n/a
- Verification run: [sle-12-SP5-Server-DVD-x86_64-Build0369-cryptlvm@64bit](https://openqa.suse.de/t3556383)
