### PR TITLE
Add pam automated tests

### DIFF
--- a/data/pam_test/pam.sh
+++ b/data/pam_test/pam.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bats
+# pam-test tool from the url https://github.com/pbrezina/pam-test
+
+USER_NOR='pamtest'
+USER_NOR_PW='pamtest'
+USER_PAM_DES='tstpamunix_des'
+USER_PAM_DES_PW='0aXKZztA.d1KY'
+USER_PAM_BIG='tstpamunix_big'
+USER_PAM_BIG_PW='0aXKZztA.d1KYIuFXArmd2jU'
+USER_ERR='pamtestx'
+USER_ERR_PW='pamtestxx'
+ROOT='root'
+ROOT_PW='nots3cr3t'
+
+setup() {
+    # the dir /etc/pam.d/pam_test is static in the tool pam-test
+    cp ./pam_test /etc/pam.d/pam_test
+    cp /etc/security/access.conf /etc/security/access.conf.bak
+    cp /etc/security/time.conf /etc/security/time.conf.bak
+    cp /etc/security/group.conf /etc/security/group.conf.bak
+    cp /etc/security/limits.conf /etc/security/limits.conf.bak
+}
+
+teardown() {
+    rm -f /etc/pam.d/pam_test
+    mv /etc/security/access.conf.bak /etc/security/access.conf
+    mv /etc/security/time.conf.bak /etc/security/time.conf
+    mv /etc/security/group.conf.bak /etc/security/group.conf
+    mv /etc/security/limits.conf.bak /etc/security/limits.conf
+}
+
+@test "prepare for next cases" {
+    useradd -m -d /home/$USER_NOR -g users $USER_NOR
+    echo $USER_NOR:$USER_NOR_PW | chpasswd
+    # 'pamunix0' was encypted to '0aXKZztA.d1KY', '0a' is salt.
+    useradd -p "$USER_PAM_DES_PW" "$USER_PAM_DES"
+    # 'pamunix01' was encypted to '0aXKZztA.d1KYIuFXArmd2jU', '0a' is salt.
+    useradd -p "$USER_PAM_BIG_PW" "$USER_PAM_BIG"
+}
+
+# This part about "login"
+@test "general authentication -- with correct passwd" {       # case 01
+    echo "$USER_NOR_PW" | pam_test auth $USER_NOR
+}
+
+@test "general authentication -- with incorrect passwd" {     # case 02
+    run bash -c "echo -en '$USER_ERR_PW' | pam_test auth $USER_NOR"
+    [ "$status" -ne 0 ]
+}
+
+@test "general authentication -- with incorrect user" {       # case 03 
+    run bash -c "echo -en '$USER_NOR_PW' | pam_test auth $USER_ERR"
+    [ "$status" -ne 0 ]
+}
+
+@test "deny access if too many attempts fail" {               # case 04
+    sed -i '/^auth/i\auth required pam_tally2.so onerr=fail deny=1 unlock_time=10' /etc/pam.d/pam_test
+
+    run bash -c "echo -en '$USER_ERR_PW' | pam_test auth $USER_NOR" # error password triggers this case
+    [ "$status" -ne 0 ]
+    sleep 2 # this time is less that 10s
+    run bash -c "echo -en '$USER_NOR_PW' | pam_test auth $USER_NOR"
+    [ "$status" -ne 0 ]
+    sleep 12
+    echo -en "$USER_NOR_PW" | pam_test auth $USER_NOR
+}
+
+@test "check for valid login shell" {                       # case 05
+    sed -i '/^account/i\account required pam_shells.so' /etc/pam.d/pam_test
+
+    bash -c "echo -en '$USER_NOR_PW' | pam_test auth $USER_NOR"
+    mv /etc/shells /etc/shells.bak && touch /etc/shells
+    run bash -c "echo -en '$USER_NOR_PW' | pam_test auth $USER_NOR"
+    mv /etc/shells.bak /etc/shells
+    [ "$status" -ne 0 ]
+}
+
+# This part about "password"
+@test "set a short invalid password" {                      # case 06
+    run su - $USER_NOR -c "echo -ne '$USER_NOR_PW\nsuse\nsuse' | passwd"
+    [ "$status" -ne 0 ]
+}
+
+@test "set a simplistic/systematic invalid password" {      # case 07
+    run su - $USER_NOR -c "echo -ne '$USER_NOR_PW\nabcd1234\nabcd1234' | passwd"
+    [ "$status" -ne 0 ]
+}
+
+@test "set a specific password" {                           # case 08
+    run su - $USER_NOR -c "echo -ne '$USER_NOR_PW\n!!\n!!' | passwd"
+    [ "$status" -ne 0 ]
+}
+
+@test "encrypt a password with DES" {                       # case 09
+    echo -en 'pamunix0' | pam_test auth $USER_PAM_DES
+    run bash -c "echo -en 'pamunix' | pam_test auth $USER_PAM_DES"
+    [ "$status" -ne 0 ]
+    echo -en 'pamunix0_xxxx' | pam_test auth $USER_PAM_DES
+}
+
+@test "encrypt a password with bigcrypt" {                  # case 10
+    echo -en 'pamunix01' | pam_test auth $USER_PAM_BIG
+    run bash -c "echo -en 'pamunix0' | pam_test auth $USER_PAM_BIG"
+    [ "$status" -ne 0 ]
+    run bash -c "echo -en 'pamunix01_xxxx' | pam_test auth $USER_PAM_BIG"
+    [ "$status" -ne 0 ]
+}
+
+@test "check password change minimum days handling" {       # case 11
+    chage -m 10000 $USER_NOR
+    run su - $USER_NOR -c "echo -ne '$USER_NOR_PW\nSu135@se\nSu135@se' | passwd"
+    chage -m 0 $USER_NOR
+    [[ "$output" =~ "You must wait longer to change your password" ]]
+}
+
+@test "set a complex password" {                            # case 12
+    pam-config -a --cracklib --cracklib-retry=1 --cracklib-minlen=8 --cracklib-dcredit=-1 --cracklib-ucredit=-1 --cracklib-lcredit=-1 --cracklib-ocredit=-1
+    
+    # the length of password is less than 8
+    run su - $USER_NOR -c "echo -en '$USER_NOR_PW\nGe13r@n\nGe13r@n' | passwd"
+    output01="$output"
+
+    # the password is lack of uppercase
+    run su - $USER_NOR -c "echo -en '$USER_NOR_PW\nge135r@n\nge135r@n' | passwd"
+    output02="$output"
+
+    # the password is lack of lowercase 
+    run su - $USER_NOR -c "echo -en '$USER_NOR_PW\nGE135R@N\nGE135R@N' | passwd"
+    output03="$output"
+
+    # the password is lack of digits
+    run su - $USER_NOR -c "echo -en '$USER_NOR_PW\nGeaaar@n\nGeaaar@n' | passwd"
+    output04="$output"
+
+    # the password is lack of special characters
+    run su - $USER_NOR -c "echo -en '$USER_NOR_PW\nGe135r7n\nGe135r7n' | passwd"
+    output05="$output"
+
+    # the password is conform to rules
+    run su - $USER_NOR -c "echo -en '$USER_NOR_PW\nGe135r@n\nGe135r@n' | passwd"
+    output06="$output"
+
+    pam-config -a --cracklib --cracklib-retry --cracklib-minlen --cracklib-dcredit --cracklib-ucredit --cracklib-lcredit --cracklib-ocredit
+    echo $USER_NOR:$USER_NOR_PW | chpasswd
+    [[ "$output01" =~ "BAD PASSWORD" ]] && [[ "$output02" =~ "BAD PASSWORD" ]]
+    [[ "$output03" =~ "BAD PASSWORD" ]] && [[ "$output04" =~ "BAD PASSWORD" ]]
+    [[ "$output05" =~ "BAD PASSWORD" ]] && [[ "$output06" =~ "password updated successfully" ]]
+}
+
+
+# This part "invalid access"
+@test "deny services based on an arbitrary file" {          # case 13
+    sed -i '/^auth/i\auth requisite pam_listfile.so item=user sense=deny file=/etc/deny' /etc/pam.d/pam_test
+    touch /etc/deny
+    echo "$USER_NOR" >> /etc/deny
+
+    run bash -c "echo -en '$USER_NOR_PW' | pam_test auth $USER_NOR"
+    rm -f /etc/deny
+    [ "$status" -ne 0 ]
+}
+
+@test "prevent non-root users from login" {                 # case 14
+    sed -i '/^auth/i\auth requisite pam_nologin.so' /etc/pam.d/pam_test
+    touch /etc/nologin
+
+    bash -c "echo -en '$ROOT_PW' | pam_test auth $ROOT"
+    run bash -c "echo -en '$USER_NOR_PW' | pam_test auth $USER_NOR"
+    rm -f /etc/nologin
+    [ "$status" -ne 0 ]
+}
+
+@test "logdaemon style login access control" {              # case 15
+    echo "-:ALL EXCEPT $USER_NOR :LOCAL" >> /etc/security/access.conf
+    pam-config -a --access --access-nodefgroup
+
+    echo -en "$USER_NOR_PW" | pam_test auth $USER_NOR
+    run bash -c "echo -en '$ROOT_PW' | pam_test auth $ROOT"
+    pam-config -d --access
+    [ "$status" -ne 0 ]
+}
+
+@test "test account characteristics -- deny users in users group" {   # case 16
+    sed -i '/^auth/i\auth required pam_succeed_if.so user notingroup users' /etc/pam.d/pam_test
+    run bash -c "echo -en '$USER_NOR_PW' | pam_test auth $USER_NOR"
+    [ "$status" -ne 0 ]
+}
+
+@test "test account characteristics -- deny users with uid > 10000" { # case 17
+    sed -i '/^auth/i\auth required pam_succeed_if.so uid > 10000' /etc/pam.d/pam_test
+    run bash -c "echo -en '$USER_NOR_PW' | pam_test auth $USER_NOR"
+    [ "$status" -ne 0 ]
+}
+
+@test "time controled access" {                                       # case 18
+    sed -i '/^account/i\account required pam_time.so' /etc/pam.d/pam_test
+    echo "*;*;$USER_NOR;!Al0000-2400" >> /etc/security/time.conf
+    run bash -c "echo -en '$USER_NOR_PW' | pam_test auth $USER_NOR"
+    [ "$status" -ne 0 ]
+}
+
+# The extra tests
+@test "modify group access" {                                         # case 19
+    echo "*;*;$USER_NOR;Al0000-2400;wheel" >> /etc/security/group.conf
+    pam-config -a --group
+    run su - $USER_NOR -c "echo -ne '$USER_NOR_PW\n' | su - $USER_NOR -c 'id -Gn'"
+    pam-config -d --group
+    [[ "$output" =~ "wheel" ]]
+}
+
+@test "limit resources -- maximum number of processes" {              # case 20
+    echo "$USER_NOR hard nproc 0" >> /etc/security/limits.conf
+    run su - $USER_NOR
+    [[ "$output" =~ "Resource temporarily unavailable" ]]
+}
+
+@test "limit resources -- limits the core file size" {                # case 21
+    echo '* soft core 1' >> /etc/security/limits.conf
+    run su - $USER_NOR -c "echo -ne '$USER_NOR_PW\n' | su - $USER_NOR -c 'prlimit -c'"
+    [[ "$output" =~ "1024" ]]
+}
+
+@test "limit resources -- maximum number of open files" {             # case 22
+    echo '* hard nofile 512' >> /etc/security/limits.conf
+    run su - $USER_NOR -c "echo -ne '$USER_NOR_PW\n' | su - $USER_NOR -c 'prlimit -n'"
+    [[ "$output" =~ files[[:space:]]*512[[:space:]]*512 ]]
+}
+
+@test "limit resources -- maximum number of processes in users group" {  # case 23
+    echo '@users soft nproc 20' >> /etc/security/limits.conf
+    echo '@users hard nproc 50' >> /etc/security/limits.conf
+    run su - $USER_NOR -c "echo -ne '$USER_NOR_PW\n' | su - $USER_NOR -c 'prlimit -u'"
+    [[ "$output" =~ processes[[:space:]]*20[[:space:]]*50 ]]
+}
+
+@test "limit resources -- maximum number of logins" {                 # case 24
+    echo '@users - maxlogins 0' >> /etc/security/limits.conf
+    run bash -c "echo -ne '$USER_NOR_PW\n' | su - $USER_NOR -c 'prlimit' 2>&1"
+    [[ "$output" =~ "cannot open session: Permission denied" ]]
+}
+
+@test "limit resources -- maximum nice priority" {                    # case 25
+    echo '* soft nice 19' >> /etc/security/limits.conf
+    echo '* hard nice -20' >> /etc/security/limits.conf
+    run su - $USER_NOR -c "echo -ne '$USER_NOR_PW\n' | su - $USER_NOR -c 'prlimit -e'"
+    [[ "$output" =~ raise[[:space:]]*1[[:space:]]*40 ]]
+}
+
+@test "clean up" {
+    userdel -r $USER_NOR
+    userdel -r $USER_PAM_DES
+    userdel -r $USER_PAM_BIG
+}

--- a/data/pam_test/pam_test
+++ b/data/pam_test/pam_test
@@ -1,0 +1,7 @@
+#%PAM-1.0
+# System default configuration.
+
+auth       include      common-auth
+account    include      common-account
+password   include      common-password
+session    include      common-session

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1585,6 +1585,7 @@ sub load_extra_tests_console {
     loadtest "console/check_os_release";
     # JeOS kernel is missing 'openvswitch' kernel module
     loadtest "console/openvswitch" unless is_jeos;
+    loadtest "console/pam"         unless is_leap;
     # dependency of git test
     loadtest "console/sshd";
     loadtest "console/update_alternatives";

--- a/schedule/qam/12-SP1/mau-extratests.yaml
+++ b/schedule/qam/12-SP1/mau-extratests.yaml
@@ -6,6 +6,7 @@ schedule:
 - console/consoletest_setup
 - console/check_os_release
 - console/openvswitch
+- console/pam
 - console/sshd
 - console/update_alternatives
 - console/rpm

--- a/schedule/qam/12-SP2/mau-extratests.yaml
+++ b/schedule/qam/12-SP2/mau-extratests.yaml
@@ -6,6 +6,7 @@ schedule:
 - console/consoletest_setup
 - console/check_os_release
 - console/openvswitch
+- console/pam
 - console/sshd
 - console/update_alternatives
 - console/rpm

--- a/schedule/qam/12-SP3/mau-extratests.yaml
+++ b/schedule/qam/12-SP3/mau-extratests.yaml
@@ -6,6 +6,7 @@ schedule:
 - console/consoletest_setup
 - console/check_os_release
 - console/openvswitch
+- console/pam
 - console/sshd
 - console/update_alternatives
 - console/rpm

--- a/schedule/qam/12-SP4/mau-extratests.yaml
+++ b/schedule/qam/12-SP4/mau-extratests.yaml
@@ -6,6 +6,7 @@ schedule:
 - console/consoletest_setup
 - console/check_os_release
 - console/openvswitch
+- console/pam
 - console/sshd
 - console/update_alternatives
 - console/rpm

--- a/schedule/qam/12-SP5/mau-extratests.yaml
+++ b/schedule/qam/12-SP5/mau-extratests.yaml
@@ -6,6 +6,7 @@ schedule:
 - console/consoletest_setup
 - console/check_os_release
 - console/openvswitch
+- console/pam
 - console/sshd
 - console/update_alternatives
 - console/rpm

--- a/schedule/qam/15-SP1/mau-extratests.yaml
+++ b/schedule/qam/15-SP1/mau-extratests.yaml
@@ -7,6 +7,7 @@ schedule:
 - console/consoletest_setup
 - console/check_os_release
 - console/openvswitch
+- console/pam
 - console/sshd
 - console/update_alternatives
 - console/rpm

--- a/schedule/qam/15/mau-extratests.yaml
+++ b/schedule/qam/15/mau-extratests.yaml
@@ -6,6 +6,7 @@ schedule:
 - console/consoletest_setup
 - console/check_os_release
 - console/openvswitch
+- console/pam
 - console/sshd
 - console/update_alternatives
 - console/rpm

--- a/tests/console/pam.pm
+++ b/tests/console/pam.pm
@@ -1,0 +1,66 @@
+# SUSE's openQA tests
+#
+# Copyright © 2019 SUSE LLC
+#
+# Copying and distribution of this file, with or without modification,
+# are permitted in any medium without royalty provided the copyright
+# notice and this notice are preserved.  This file is offered as-is,
+# without any warranty.
+#
+# Summary: This PM is to run a suite of tests about PAM, and gets a TAP
+#          format result. Four files(pam.sh, pam_test, pam_test.sh,
+#          system-default) are included. pam.sh is a "bats" script, and
+#          includes 25 tests for PAM. The other files are from the project
+#          "pam_test" which can be used to test a PAM stack for authentication
+#          and password change. The link: https://github.com/pbrezina/pam-test
+#   Steps:
+#       - add qa-head repo and install the tool "bats" from qa-head repo.
+#         Bats is a TAP-compliant testing framework for Bash.
+#       - download "pam_test" dir(automated tests of PAM) from "data" dir
+#         on openqa host if "prepare_test_data" perl module desn't run.
+#       - run the suite of tests in SUT.
+# Maintainer: Jun Wang <jgwang@suse.com>
+
+use base 'consoletest';
+use strict;
+use warnings;
+use testapi;
+use utils;
+use version_utils qw(is_leap is_sle);
+
+sub run {
+    select_console 'root-console';
+
+    die "This test module is not enabled for openSUSE Leap yet" if is_leap();
+    my $version = get_required_var('VERSION');
+    if (is_sle()) {
+        my $qa_head_repo = "http://download.suse.de/ibs/QA:/Head/" . 'SLE-' . $version;
+        zypper_ar("$qa_head_repo", name => 'qa-head-repo');
+    }
+    zypper_call('install bats pam-test pam pam-config snapper');
+
+    # create a snapshot for rollback
+    assert_script_run("snapbf=\$(snapper create -p -d 'before pam test')");
+
+    my $pamdir = "/home/bernhard/data/pam_test";
+    if (script_run("test -d $pamdir"))
+    {
+        my $archive = "pam-tests.data";
+        assert_script_run("cd; curl -L -v " . autoinst_url . "/data/pam_test > $archive && cpio -id < $archive && mv data pam_test && rm -f $archive");
+        $pamdir = "./pam_test";
+    }
+
+    my $tap_results = "results.tap";
+    my $ret         = script_run("cd $pamdir; prove -v pam.sh >$tap_results", timeout => 180);
+    parse_extra_log(TAP => $tap_results);
+
+    # restore the system after running pam.pm
+    assert_script_run("snapaf=\$(snapper create -p -d 'after pam test')");
+    assert_script_run("snapper -v undochange \$snapbf..\$snapaf");
+    assert_script_run("snapper delete \$snapaf \$snapbf");
+
+    die "pam.sh failed, see results.tap for details" if ($ret);
+}
+
+1;
+


### PR DESCRIPTION
This module is a suite of tests for PAM, and outputs
the TAP format result. It depends on "BATS"(a TAP-compliant
testing framework for Bash) and "pam-test"(to test a PAM stack
for authentication, https://github.com/pbrezina/pam-test)

- Related ticket: https://progress.opensuse.org/issues/51686
- Needles: no
- Verification run:
     - SLE12SP2: http://10.67.19.91/tests/867 :heavy_check_mark: 
     - SLE12SP3: http://10.67.19.91/tests/868 :heavy_check_mark: 
     - SLE12SP4: http://10.67.19.91/tests/869 :heavy_check_mark:
     - SLE12SP5: http://10.67.19.91/tests/871 :heavy_check_mark:
     - SLE15      : http://10.67.19.91/tests/870 :heavy_check_mark: 
     - SLE15SP1: http://10.67.19.91/tests/872 :heavy_check_mark:
     - Tumbleweed: http://10.67.19.91/tests/874 :heavy_check_mark: