### PR TITLE
Add cluster nodes IPs to /etc/hosts on upgrade scenario

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -2752,6 +2752,7 @@ sub load_ha_cluster_tests {
 
     # Test HA after an upgrade, so no need to configure the HA stack
     if (get_var('HDDVERSION')) {
+        loadtest 'ha/setup_hosts_and_luns' unless get_var('USE_SUPPORT_SERVER');
         loadtest 'ha/upgrade_from_sle11sp4_workarounds' if check_var('HDDVERSION', '11-SP4');
         loadtest 'ha/check_after_reboot';
         loadtest 'ha/check_hawk';


### PR DESCRIPTION
Cluster migration from old OS versions saved in qcow2 images can result in cluster nodes which get a different IP address during verification than the ones used during cluster setup. In the svirt based tests for s390x, this information is stored locally in the `/etc/hosts` files of the cluster nodes. This PR calls `ha/setup_hosts_and_luns` in upgrage scenarios to update that information in the local files.

Also introduced here is the renaming of the support directory name in the NFS share to make it more unique.

- Related ticket: N/A
- Needles: N/A
- Verification run: [node01](http://mango.suse.de/tests/1933) & [node02](http://mango.suse.de/tests/1934)
