### PR TITLE
Allow access to EC2 PC instances only from SUSE IPs

### DIFF
--- a/data/publiccloud/terraform/ec2.tf
+++ b/data/publiccloud/terraform/ec2.tf
@@ -47,13 +47,13 @@ resource "aws_key_pair" "openqa-keypair" {
 
 resource "aws_security_group" "basic_sg" {
     name        = "openqa-${element(random_id.service.*.hex, 0)}"
-    description = "Allow all inbound traffic"
+    description = "Allow all inbound traffic from SUSE IP ranges"
 
     ingress {
         from_port   = 0
         to_port     = 0
         protocol    = "-1"
-        cidr_blocks = ["0.0.0.0/0"]
+        cidr_blocks = ["213.151.95.130/32", "195.135.220.0/22"]
     }
 
     egress {


### PR DESCRIPTION
The purpose of this PR is to increase the security of our EC2 Public Cloud instances by allowing only connections from SUSE IP ranges .This was a part of  #8781.

- Related ticket: [poo#54842](https://progress.opensuse.org/issues/54842)
- Needles: No new needles needed
- Verification runs:
   * [mau-extratests@SLES12SP1](http://pdostal-server.suse.cz/tests/5352)
   * [mau-extratests@SLES12SP2](http://pdostal-server.suse.cz/tests/5351)
   * [mau-extratests@SLES12SP3](http://pdostal-server.suse.cz/tests/5361)
   * [mau-extratests@SLES12SP4](http://pdostal-server.suse.cz/tests/5372)
   * [mau-extratests-publiccloud@SLES12SP4](http://pdostal-server.suse.cz/tests/5330)
   * [extra_tests_in_textmode@SLES12SP5](http://pdostal-server.suse.cz/tests/5356#)
   * [max-extratests@SLES15](http://pdostal-server.suse.cz/tests/5355)
   * [mau-extratests@SLES15SP1](http://pdostal-server.suse.cz/tests/5371)
   * [mau-extratests-publiccloud@SLES15SP1](http://pdostal-server.suse.cz/tests/5329)
   * [extra_tests_in_textmode@SLES15SP2](http://pdostal-server.suse.cz/tests/5354#)
- Errors: [SLES12SP4](https://openqa.suse.de/tests/3509823) [SLES15SP1](https://openqa.suse.de/tests/3511328)
