### PR TITLE
Adjust the main* and console base tests for mau-extratests on public cloud

### DIFF
--- a/lib/consoletest.pm
+++ b/lib/consoletest.pm
@@ -49,17 +49,13 @@ Method executed when run() finishes and the module has result => 'fail'
 
 =cut
 sub post_fail_hook {
-    # On Public Cloud everything is done via SSH so the code below doesn't work
-    # TODO: Make some reasonable base post_fail_hook for Public Cloud
-    unless (get_var('PUBLIC_CLOUD')) {
-        my ($self) = shift;
-        select_console('log-console');
-        $self->SUPER::post_fail_hook;
-        $self->remount_tmp_if_ro;
-        $self->export_logs_basic;
-        # Export extra log after failure for further check gdm issue 1127317, also poo#45236 used for tracking action on Openqa
-        $self->export_logs_desktop;
-    }
+    my ($self) = shift;
+    select_console('log-console');
+    $self->SUPER::post_fail_hook;
+    $self->remount_tmp_if_ro;
+    $self->export_logs_basic;
+    # Export extra log after failure for further check gdm issue 1127317, also poo#45236 used for tracking action on Openqa
+    $self->export_logs_desktop;
 }
 
 sub test_flags {

--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -1700,7 +1700,7 @@ sub load_extra_tests_docker {
 sub load_extra_tests_prepare {
     # setup $serialdev permission and so on
     loadtest "console/prepare_test_data";
-    loadtest "console/consoletest_setup";
+    loadtest "console/consoletest_setup" unless get_var('PUBLIC_CLOUD');
     loadtest 'console/integration_services' if is_hyperv || is_vmware;
 }
 
@@ -2643,6 +2643,7 @@ sub load_publiccloud_tests {
         loadtest "publiccloud/patch_and_reboot",      run_args => $args;
         loadtest "publiccloud/ssh_interactive_start", run_args => $args;
         loadtest "publiccloud/instance_overview";
+        load_extra_tests_prepare();
         load_extra_tests_console();
         loadtest "publiccloud/ssh_interactive_end", run_args => $args;
     }

--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -1018,4 +1018,8 @@ sub post_fail_hook {
     send_key 'spc';
 }
 
+sub test_flags {
+    return get_var('PUBLIC_CLOUD') ? {no_rollback => 1} : {};
+}
+
 1;

--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1116,7 +1116,7 @@ else {
         if (get_var("ADDONS")) {
             loadtest "installation/addon_products_yast2";
         }
-        if (get_var('SCC_ADDONS') && !get_var('SLENKINS_NODE')) {
+        if (get_var('SCC_ADDONS') && !get_var('SLENKINS_NODE') && !get_var('PUBLIC_CLOUD')) {
             loadtest "installation/addon_products_via_SCC_yast2";
         }
         if (get_var("ISCSI_SERVER")) {


### PR DESCRIPTION
In  this PR I:
 * Add the `load_extra_tests_prepare()` to my scenario
 * Re-enable `post_fail_hook` from `consoletest.pm` because it actually works with `tunnel-console`
 * Add the `no_rollback => 1` tests flag to the `opensusebasetest.pm`
 * Disable the `"installation/addon_products_via_SCC_yast2.pm` because it makes no senso on PC

This was part of #8781.

- Related ticket: [poo#54842](https://progress.opensuse.org/issues/54842)
- Needles: No new needles needed
- Verification runs:
   * [mau-extratests@SLES12SP1](http://pdostal-server.suse.cz/tests/5352)
   * [mau-extratests@SLES12SP2](http://pdostal-server.suse.cz/tests/5351)
   * [mau-extratests@SLES12SP3](http://pdostal-server.suse.cz/tests/5361)
   * [mau-extratests@SLES12SP4](http://pdostal-server.suse.cz/tests/5372)
   * [mau-extratests-publiccloud@SLES12SP4](http://pdostal-server.suse.cz/tests/5330)
   * [extra_tests_in_textmode@SLES12SP5](http://pdostal-server.suse.cz/tests/5356#)
   * [max-extratests@SLES15](http://pdostal-server.suse.cz/tests/5355)
   * [mau-extratests@SLES15SP1](http://pdostal-server.suse.cz/tests/5371)
   * [mau-extratests-publiccloud@SLES15SP1](http://pdostal-server.suse.cz/tests/5329)
   * [extra_tests_in_textmode@SLES15SP2](http://pdostal-server.suse.cz/tests/5354#)
- Errors: [SLES12SP4](https://openqa.suse.de/tests/3509823) [SLES15SP1](https://openqa.suse.de/tests/3511328)