### PR TITLE
Wicked: Bugfix for t09 in basic suite

### DIFF
--- a/tests/wicked/basic/ref/t08_setup_second_card.pm
+++ b/tests/wicked/basic/ref/t08_setup_second_card.pm
@@ -33,4 +33,8 @@ sub run {
     die("Create mutex failed") unless mutex_create('t08_dhcpd_setup_complete');
 }
 
+sub test_flags {
+    return {always_rollback => 1};
+}
+
 1;


### PR DESCRIPTION
PR#8812 introduced a bug because t08 is changing the
dhcp server configuration which is needed by t09
and we don't roll back. The rollback in REF is enough
to keep the previous configuration we had.

VR: http://fromm.arch.suse.de/tests/229
