### PR TITLE
Public Cloud: Install missing packages, add 'no_rollback => 1' flag, …

### DIFF
--- a/tests/console/firewalld.pm
+++ b/tests/console/firewalld.pm
@@ -14,11 +14,12 @@ use strict;
 use warnings;
 use base "consoletest";
 use testapi;
-use utils 'systemctl';
+use utils qw(systemctl zypper_call);
 use version_utils 'is_tumbleweed';
 
 # Check Service State, enable it if necessary, set default zone to public
 sub pre_test {
+    zypper_call('in firewalld');
     record_info 'Check Service State';
     assert_script_run("if ! systemctl is-active -q firewalld; then systemctl start firewalld; fi");
     assert_script_run("firewall-cmd --set-default-zone=public");

--- a/tests/console/gdb.pm
+++ b/tests/console/gdb.pm
@@ -43,6 +43,8 @@ sub run {
     if (is_sle('=12-SP5') && is_aarch64()) {
         register_product;
         add_suseconnect_product 'sle-sdk';
+    } elsif (get_var('PUBLIC_CLOUD')) {
+        add_suseconnect_product(get_addon_fullname('sdk'));
     }
     zypper_call('in gcc glibc-devel gdb');    #Install test depedencies.
 

--- a/tests/console/lshw.pm
+++ b/tests/console/lshw.pm
@@ -23,7 +23,9 @@ sub run {
 
     # Check various output formats, -sanitize is used to not spill test machine serial numbers into public
     # On some architectures fields like "product" or "vendor" or section "*-pci" might not exist, so trying a common base.
-    validate_script_output("lshw -sanitize", sub { m/description.*\*-memory\n.*\*-network/s });
+    assert_script_run("lshw -sanitize | grep -A5 'description'");
+    assert_script_run("lshw -sanitize | grep -A5 '\\*-memory\$'");
+    assert_script_run("lshw -sanitize | grep -A5 '\\*-network'");
     assert_script_run("lshw -html -sanitize");
     assert_script_run("lshw -xml -sanitize");
     assert_script_run("lshw -json -sanitize");

--- a/tests/console/openldap2.pm
+++ b/tests/console/openldap2.pm
@@ -24,7 +24,7 @@ my @tests_sle = '';
 
 sub install_openldap2 {
     record_info 'Install OpenLDAP 2';
-    zypper_call('in openldap2-*');
+    zypper_call('in bzip2 openldap2-*');
 }
 
 sub prepare_test_suite {

--- a/tests/console/prepare_test_data.pm
+++ b/tests/console/prepare_test_data.pm
@@ -32,7 +32,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1, fatal => 1};
+    return get_var('PUBLIC_CLOUD') ? {milestone => 0, fatal => 1, no_rollback => 1} : {milestone => 1, fatal => 1};
 }
 
 1;

--- a/tests/console/slp.pm
+++ b/tests/console/slp.pm
@@ -20,7 +20,7 @@ use base "consoletest";
 use testapi;
 use strict;
 use warnings;
-use utils qw(zypper_call systemctl);
+use utils qw(zypper_call systemctl script_retry);
 use Utils::Systemd 'disable_and_stop_service';
 
 sub run {
@@ -29,7 +29,9 @@ sub run {
 
     zypper_call 'in openslp openslp-server';
 
-    disable_and_stop_service($self->firewall);
+    disable_and_stop_service($self->firewall) if (script_run("which " . $self->firewall) == 0);
+
+    assert_script_run 'useradd -d /var/lib/empty/ -s /sbin/nologin openslp || true';
 
     systemctl 'enable slpd';
     systemctl 'start slpd';
@@ -53,11 +55,16 @@ sub run {
     # Register and find two NTP services
     assert_script_run 'slptool register ntp://tik.cesnet.cz:123,en,65535';
     assert_script_run 'slptool register ntp://tak.cesnet.cz:123,en,65535';
-    assert_script_run 'if [[ $(slptool findsrvs ntp | grep "tik\|tak" | wc -l) = "2" ]]; then echo "Both NTP announcements were found"; else false; fi';
+    script_retry('slptool findsrvs ntp | grep -A9 -B9 "tik" | grep -A9 -B9 "tak"', delay => 15, retry => 5);
 
     # Deregister one NTP service and find the other one
     assert_script_run 'slptool deregister ntp://tik.cesnet.cz:123,en,65535';
     assert_script_run 'if [[ $(slptool findsrvs ntp | grep "tik\|tak" | wc -l) = "1" ]]; then echo "One remaining NTP announcement was found"; else false; fi';
+}
+
+sub post_fail_hook {
+    select_console('log-console');
+    upload_logs '/var/log/slpd.log';
 }
 
 1;

--- a/tests/console/sshd.pm
+++ b/tests/console/sshd.pm
@@ -26,7 +26,7 @@ use base "consoletest";
 use strict;
 use testapi qw(is_serial_terminal :DEFAULT);
 use utils qw(systemctl exec_and_insert_password zypper_call);
-use version_utils qw(is_virtualization_server is_upgrade is_sle is_tumbleweed is_leap);
+use version_utils qw(is_upgrade is_sle is_tumbleweed is_leap);
 
 sub run {
     my $self = shift;
@@ -46,7 +46,7 @@ sub run {
         record_info("SuSEfirewall2 not available", "bsc#1090178: SuSEfirewall2 service is not available after upgrade from SLES11 SP4 to SLES15");
     }
     else {
-        systemctl 'stop ' . $self->firewall if !is_virtualization_server;
+        systemctl('stop ' . $self->firewall) if (script_run("which " . $self->firewall) == 0);
     }
 
     # Restart sshd and check it's status
@@ -129,7 +129,7 @@ sub run {
 }
 
 sub test_flags {
-    return {milestone => 1};
+    return get_var('PUBLIC_CLOUD') ? {milestone => 0, no_rollback => 1} : {milestone => 1};
 }
 
 1;

--- a/tests/console/zziplib.pm
+++ b/tests/console/zziplib.pm
@@ -36,7 +36,7 @@ sub run {
         zypper_ar 'http://' . get_var('OPENQA_URL') . "/assets/repo/$sdk_repo", name => 'SDK';
     }
     # maintenance updates are registered with sdk module
-    elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
+    elsif (get_var('FLAVOR') !~ /Updates|Incidents/ || get_var('PUBLIC_CLOUD')) {
         cleanup_registration;
         register_product;
         add_suseconnect_product('sle-module-desktop-applications');
@@ -73,7 +73,7 @@ sub run {
     if (get_var('BETA')) {
         zypper_call "rr SDK";
     }
-    elsif (get_var('FLAVOR') !~ /Updates|Incidents/) {
+    elsif (get_var('FLAVOR') !~ /Updates|Incidents/ || get_var('PUBLIC_CLOUD')) {
         remove_suseconnect_product(get_addon_fullname('sdk'));
     }
 }

--- a/tests/x11/evolution/evolution_prepare_servers.pm
+++ b/tests/x11/evolution/evolution_prepare_servers.pm
@@ -116,7 +116,7 @@ sub run() {
 }
 
 sub test_flags() {
-    return {milestone => 1, fatal => 1};
+    return get_var('PUBLIC_CLOUD') ? {milestone => 0, fatal => 1, no_rollback => 1} : {milestone => 1, fatal => 1};
 }
 
 sub post_fail_hook {


### PR DESCRIPTION
In this PR I:
 * Install some missing packages
 * Add `no_rollback => 1` test flags
 * Add `sdk` product
 * Add missing user

This was part of #8781 .

- Related ticket: [poo#54842](https://progress.opensuse.org/issues/54842)
- Needles: No new needles needed
- Verification runs new:
   * [mau-extratests@SLES12SP1](http://pdostal-server.suse.cz/tests/5500)
   * [mau-extratests@SLES12SP2](http://pdostal-server.suse.cz/tests/5501)
   * [mau-extratests@SLES12SP3](http://pdostal-server.suse.cz/tests/5495)
   * [mau-extratests@SLES12SP4](http://pdostal-server.suse.cz/tests/5505)
   * [max-extratests@SLES15](http://pdostal-server.suse.cz/tests/5496)
   * [mau-extratests@SLES15SP1](http://pdostal-server.suse.cz/tests/5502)
- Verification runs old:
   * [mau-extratests-publiccloud@SLES12SP4](http://pdostal-server.suse.cz/tests/5330)
   * [extra_tests_in_textmode@SLES12SP5](http://pdostal-server.suse.cz/tests/5356#)
   * [mau-extratests-publiccloud@SLES15SP1](http://pdostal-server.suse.cz/tests/5329)
   * [extra_tests_in_textmode@SLES15SP2](http://pdostal-server.suse.cz/tests/5354#)

