### PR TITLE
Improve the ssh_interactive PC scenario

### DIFF
--- a/lib/publiccloud/ssh_interactive.pm
+++ b/lib/publiccloud/ssh_interactive.pm
@@ -50,15 +50,14 @@ sub ssh_interactive_join {
 
     # Open SSH interactive session and check the serial console works
     type_string("ssh -t sut\n");
-    wait_serial("ssh_serial_ready", 10);
+    wait_serial("ssh_serial_ready", 90);
 
     $testapi::distri->set_standard_prompt('root');
 }
 
 sub ssh_interactive_leave {
     # Check if the SSH tunnel is still up and leave the SSH interactive session
-    assert_script_run("if [[ -p /dev/$serialdev ]]; then true; else false; fi");
-    type_string("exit\n");
+    script_run("test -p /dev/sshserial && exit", timeout => 0);
 
     # Restore the environment to not use the SSH tunnel for upload/download from the worker
     #set_var('SUT_HOSTNAME',          testapi::host_ip());

--- a/tests/publiccloud/instance_overview.pm
+++ b/tests/publiccloud/instance_overview.pm
@@ -31,8 +31,6 @@ sub run {
 
     assert_script_run("ps aux | nl");
 
-    register_product();
-
     assert_script_run("ip a s");
     assert_script_run("ip -6 a s");
     assert_script_run("ip r s");
@@ -41,7 +39,7 @@ sub run {
     assert_script_run("cat /etc/hosts");
     assert_script_run("cat /etc/resolv.conf");
 
-    zypper_call("in traceroute");
+    zypper_call("in traceroute bzip2");
     assert_script_run("traceroute -I gate.suse.cz", 90);
 }
 

--- a/tests/publiccloud/ssh_interactive_init.pm
+++ b/tests/publiccloud/ssh_interactive_init.pm
@@ -45,10 +45,13 @@ sub run {
 
     # configure ssh server, allow root and password login
     $instance->run_ssh_command(cmd => 'hostname -f');
+    $instance->run_ssh_command(cmd => 'sudo sed -i "s/PasswordAuthentication/#PasswordAuthentication/" /etc/ssh/sshd_config; echo "PasswordAuthentication no" >> /etc/ssh/sshd_config');
+    $instance->run_ssh_command(cmd => 'sudo sed -i "s/ChallengeResponseAuthentication/#ChallengeResponseAuthentication/" /etc/ssh/sshd_config; echo "ChallengeResponseAuthentication no" >> /etc/ssh/sshd_config');
     $instance->run_ssh_command(cmd => 'echo -e "' . $testapi::password . '\n' . $testapi::password . '" | sudo passwd root');
     $instance->run_ssh_command(cmd => 'sudo sed -i "s/PermitRootLogin no/PermitRootLogin yes/g" /etc/ssh/sshd_config');
-    $instance->run_ssh_command(cmd => 'sudo sed -i "s/PasswordAuthentication no/PasswordAuthentication yes/g" /etc/ssh/sshd_config');
-    $instance->run_ssh_command(cmd => 'sudo cp /home/ec2-user/.ssh/authorized_keys /root/.ssh/');
+    $instance->run_ssh_command(cmd => "sudo mkdir -p /root/.ssh");
+    $instance->run_ssh_command(cmd => "sudo chmod -R 700 /root/.ssh");
+    $instance->run_ssh_command(cmd => 'sudo cp /home/' . $instance->username() . '/.ssh/authorized_keys /root/.ssh/');
     $instance->run_ssh_command(cmd => 'sudo chmod 644 /root/.ssh/authorized_keys');
     $instance->run_ssh_command(cmd => 'sudo chown root /root/.ssh/authorized_keys');
     $instance->run_ssh_command(cmd => 'sudo systemctl reload sshd');
@@ -60,7 +63,7 @@ sub run {
     $instance->run_ssh_command(cmd => 'echo -e "' . $testapi::password . '\n' . $testapi::password . '" | sudo passwd ' . $testapi::username);
     $instance->run_ssh_command(cmd => "sudo mkdir /home/" . $testapi::username . "/.ssh");
     $instance->run_ssh_command(cmd => "sudo chmod -R 700 /home/" . $testapi::username . "/.ssh");
-    $instance->run_ssh_command(cmd => 'sudo cp /home/ec2-user/.ssh/authorized_keys /home/' . $testapi::username . '/.ssh/');
+    $instance->run_ssh_command(cmd => 'sudo cp /home/' . $instance->username() . '/.ssh/authorized_keys /home/' . $testapi::username . '/.ssh/');
     $instance->run_ssh_command(cmd => "sudo chmod 644 /home/" . $testapi::username . "/.ssh/authorized_keys");
     $instance->run_ssh_command(cmd => "sudo chown -R " . $testapi::username . " /home/" . $testapi::username . "/.ssh/");
 

--- a/tests/publiccloud/transfer_repos.pm
+++ b/tests/publiccloud/transfer_repos.pm
@@ -22,10 +22,12 @@ sub run {
     my ($self, $args) = @_;
     select_console 'tunnel-console';
 
+    $args->{my_instance}->run_ssh_command(cmd => "sudo SUSEConnect -r " . get_required_var('SCC_REGCODE'), timeout => 180) unless (get_var('FLAVOR') =~ 'On-Demand');
+
     assert_script_run("rsync -va -e ssh ~/repos root@" . $args->{my_instance}->public_ip . ":'/tmp/repos'", timeout => 900);
     $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec sed -i 's,http://,/tmp/repos/repos/,g' '{}' \\;");
     $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec zypper ar '{}' \\;");
-    $args->{my_instance}->run_ssh_command(cmd => "sudo find /tmp/repos/ -name *.repo -exec echo '{}' \\;");
+    $args->{my_instance}->run_ssh_command(cmd => "sudo ls /tmp/repos/*.repo");
 }
 
 sub test_flags {


### PR DESCRIPTION
Here I:
 * Increased some timeouts
 * Improved the `if [[ -p /dev/sshserial ]]` statement
 * Moved the registration before maintenance repositories added
 * Disabled the root password and made the setup username-independent

This was before #8781.

- Related ticket: [poo#54842](https://progress.opensuse.org/issues/54842)
- Needles: No new needles needed
- Verification runs:
   * [mau-extratests@SLES12SP1](http://pdostal-server.suse.cz/tests/5352)
   * [mau-extratests@SLES12SP2](http://pdostal-server.suse.cz/tests/5351)
   * [mau-extratests@SLES12SP3](http://pdostal-server.suse.cz/tests/5361)
   * [mau-extratests@SLES12SP4](http://pdostal-server.suse.cz/tests/5372)
   * [mau-extratests-publiccloud@SLES12SP4](http://pdostal-server.suse.cz/tests/5330)
   * [extra_tests_in_textmode@SLES12SP5](http://pdostal-server.suse.cz/tests/5356#)
   * [max-extratests@SLES15](http://pdostal-server.suse.cz/tests/5355)
   * [mau-extratests@SLES15SP1](http://pdostal-server.suse.cz/tests/5371)
   * [mau-extratests-publiccloud@SLES15SP1](http://pdostal-server.suse.cz/tests/5329)
   * [extra_tests_in_textmode@SLES15SP2](http://pdostal-server.suse.cz/tests/5354#)
- Errors: [SLES12SP4](https://openqa.suse.de/tests/3509823) [SLES15SP1](https://openqa.suse.de/tests/3511328)