### PR TITLE
Fix double appearance of bootloader_zkvm module

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -1111,7 +1111,6 @@ else {
         }
     }
     elsif (get_var("BOOT_HDD_IMAGE") && !is_jeos) {
-        load_bootloader_s390x();
         boot_hdd_image;
         if (get_var("ADDONS")) {
             loadtest "installation/addon_products_yast2";


### PR DESCRIPTION
bootloader_zkvm appeared twice in https://openqa.suse.de/tests/3556348

The commit removes extra load_bootloader_s390x function call as it is
already called in 'boot_hdd_image' for s390x.

- Verification run: https://openqa.suse.de/tests/3557418
