### PR TITLE
Use ARCH instead of BACKEND

### DIFF
--- a/schedule/yast/modify_existing_partition_sle.yaml
+++ b/schedule/yast/modify_existing_partition_sle.yaml
@@ -42,7 +42,7 @@ test_data:
 
 conditional_schedule:
   reconnect_mgmt_console:
-    BACKEND:
+    ARCH:
       s390x:
         - boot/reconnect_mgmt_console
   grub_test:


### PR DESCRIPTION
Test is failing here https://openqa.suse.de/tests/3553002, because backend is actually svirt. With this modification, this test could also run on zVM.

- Verification run: https://openqa.suse.de/tests/3557476
