### PR TITLE
Remove 'fsid=0' option from nfs share as is valid for NFSv4 only

### DIFF
--- a/lib/nfs_common.pm
+++ b/lib/nfs_common.pm
@@ -83,12 +83,12 @@ sub add_shares {
     # Permissions dialog
     assert_screen 'nfs-share-host';
     send_key 'tab';
-    # Change 'ro,root_squash' to 'rw,fsid=0,no_root_squash,...'
+    # Change 'ro,root_squash' to 'rw,no_root_squash,...'
     send_key 'home';
     send_key 'delete';
     send_key 'delete';
     send_key 'delete';
-    type_string "rw,fsid=0,no_";
+    type_string "rw,no_";
     send_key 'alt-o';
 
     # Saved
@@ -264,4 +264,3 @@ sub check_y2_nfs_func {
 }
 
 1;
-


### PR DESCRIPTION
As per comment in
[bsc#1155653](https://bugzilla.suse.com/show_bug.cgi?id=1155653),
this option is valid only for NFSv4, and we have this option disabled in
YaST by default.

- Verification run: https://openqa.suse.de/t3557486
