### PR TITLE
Fix 'hide beta version' checkbox deselection

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -337,8 +337,11 @@ sub process_scc_register_addons {
     #   wsm - Web and Scripting Module
     if (get_var('SCC_ADDONS')) {
         if (check_screen('scc-beta-filter-checkbox', 5)) {
-            if (get_var('SP3ORLATER')) {
-                send_key 'alt-i';    # uncheck 'Hide Beta Versions'
+            if (is_sle('12-SP3+')) {
+                # Uncheck 'Hide Beta Versions'
+                # The workaround with send_key_until_needlematch is added,
+                # because on ppc64le the shortcut key does not reach VM sporadically.
+                send_key_until_needlematch('scc-beta-filter-unchecked', 'alt-i', 3, 5);
             }
             else {
                 send_key 'alt-f';    # uncheck 'Filter Out Beta Version'


### PR DESCRIPTION
The [test](https://openqa.suse.de/tests/3557442) is failed sporadically because sometimes 'alt-i' is sent to the SUT, but checkbox is not actually got selected.

The commit also changes SLE12 version check from get_var usage to is_sle
function, as it is currently more clear way to check the version.

- Verification run: https://openqa.suse.de/tests/3559456