### PR TITLE
Catch error in service check module

### DIFF
--- a/tests/console/check_upgraded_service.pm
+++ b/tests/console/check_upgraded_service.pm
@@ -22,6 +22,7 @@ use main_common 'is_desktop';
 sub run {
     select_console 'root-console';
     check_services($default_services) if (is_sle && !is_desktop && !is_sles4sap && !get_var('MEDIA_UPGRADE') && !get_var('ZDUP') && !get_var('INSTALLONLY'));
+    die "Service check after migration failed!" if $srv_check_results{'after_migration'} eq 'FAIL';
 }
 
 sub test_flags {

--- a/tests/installation/install_service.pm
+++ b/tests/installation/install_service.pm
@@ -38,6 +38,8 @@ sub run {
       && !get_var('MEDIA_UPGRADE')
       && !get_var('ZDUP')
       && !get_var('INSTALLONLY');
+
+    die "Service check before migration failed!" if $srv_check_results{'before_migration'} eq 'FAIL';
 }
 
 sub test_flags {


### PR DESCRIPTION
we need catch error during service check since we want get all the service check result even one service check failed.

- Related ticket: https://progress.opensuse.org/issues/59127
- Needles: na
- Verification run: https://openqa.suse.de/tests/3559374
