### PR TITLE
Enlarge the timeout value for waiting scc registration screen for we and live

### DIFF
--- a/lib/registration.pm
+++ b/lib/registration.pm
@@ -248,7 +248,7 @@ sub register_addons {
             # skip addons which doesn't need to input scc code
             next unless grep { $addon eq $_ } @addons_with_code;
             if (check_var('VIDEOMODE', 'text')) {
-                send_key_until_needlematch "scc-code-field-$addon", 'tab';
+                send_key_until_needlematch("scc-code-field-$addon", 'tab', 60, 3);
             }
             else {
                 assert_and_click("scc-code-field-$addon", timeout => 240);


### PR DESCRIPTION
We need to enlarge the timeout value for waiting for scc registration screen for we and live.
the original wait time is 1 second for 20 times, which is too small for our regressional tests.

- Related ticket: https://progress.opensuse.org/issues/59133
- Needles: N/A
- Verification run: 
            https://openqa.suse.de/tests/3559525
            https://openqa.suse.de/tests/3559531