### PR TITLE
Add support for graphical installer when using ipxe_install

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -538,6 +538,7 @@ sub load_baremetal_tests {
     loadtest "autoyast/prepare_profile" if get_var "AUTOYAST_PREPARE_PROFILE";
     if (get_var('IPXE')) {
         loadtest 'installation/ipxe_install';
+        load_inst_tests() if !get_var('AUTOYAST');
         loadtest "console/suseconnect_scc";
     } else {
         load_boot_tests();

--- a/tests/installation/ipxe_install.pm
+++ b/tests/installation/ipxe_install.pm
@@ -74,8 +74,14 @@ sub set_bootscript {
     my $ip          = inet_ntoa(inet_aton($host));
     my $http_server = get_required_var('IPXE_HTTPSERVER');
     my $url         = "$http_server/$ip/script.ipxe";
+    my $instparm;
 
-    my $autoyast = get_required_var('AUTOYAST');
+    if (get_var('AUTOYAST')) {
+        my $autoyast = get_var('AUTOYAST');
+        $instparm = "autoyast=$autoyast";
+    } else {
+        $instparm = "sshd=1 vnc=1 VNCPassword=$testapi::password sshpassword=$testapi::password";
+    }
 
     my $kernel  = get_required_var('MIRROR_HTTP') . '/boot/x86_64/loader/linux';
     my $initrd  = get_required_var('MIRROR_HTTP') . '/boot/x86_64/loader/initrd';
@@ -88,7 +94,7 @@ echo ++++++++++++ openQA ipxe boot ++++++++++++
 echo +    Host: $host
 echo ++++++++++++++++++++++++++++++++++++++++++
 
-kernel $kernel install=$install autoyast=$autoyast console=tty0 console=ttyS1,115200
+kernel $kernel install=$install console=tty0 console=ttyS1,115200 $instparm
 initrd $initrd
 boot
 END_BOOTSCRIPT


### PR DESCRIPTION
Sometimes, for a machine there is no autoyast profile available yet,
autoyast is broken or we just want to make sure the installer is working
on bare metal.
In this case, we should start the installer as we would for the
traditional installations over IPMI so we can use the graphical
installer with all that comes with it.

This change will allow to use ipxe installations without autoyast by
unsetting the AUTOYAST variable.
