### PR TITLE
Schedule ntp or chrony test case according to VERSION

### DIFF
--- a/schedule/jeos/sle/hyperv/jeos-extratest.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-extratest.yaml
@@ -1,6 +1,13 @@
 ---
 description: 'Extratest JeOS test suite. Maintainer: ccret.'
 name: 'jeos-extratest@svirt-hyperv ( svirt )'
+conditional_schedule:
+    ntp_test_module:
+        VERSION:
+            15-SP2:
+                - console/ntp_client
+            12-SP5:
+                - console/ntp
 schedule:
   - installation/bootloader_hyperv
   - jeos/grub2
@@ -20,7 +27,7 @@ schedule:
   - console/zypper_extend
   - console/check_os_release
   - console/timezone
-  - console/ntp
+  - {{ntp_test_module}}
   - console/sshd
   - console/update_alternatives
   - console/rpm

--- a/schedule/jeos/sle/kvm/jeos-extratest.yaml
+++ b/schedule/jeos/sle/kvm/jeos-extratest.yaml
@@ -1,6 +1,13 @@
 ---
 description: 'Extratest JeOS test suite. Maintainer: ccret.'
 name: 'jeos-extratest@uefi-virtio-vga ( qemu )'
+conditional_schedule:
+    ntp_test_module:
+        VERSION:
+            15-SP2:
+                - console/ntp_client
+            12-SP5:
+                - console/ntp
 schedule:
   - jeos/grub2
   - jeos/firstrun
@@ -18,7 +25,7 @@ schedule:
   - console/zypper_extend
   - console/check_os_release
   - console/timezone
-  - console/ntp
+  - {{ntp_test_module}}
   - console/sshd
   - console/update_alternatives
   - console/rpm

--- a/schedule/jeos/sle/xen/hvm/jeos-extratest.yaml
+++ b/schedule/jeos/sle/xen/hvm/jeos-extratest.yaml
@@ -1,6 +1,13 @@
 ---
 description: 'Extratest JeOS test suite. Maintainer: ccret.'
 name: 'jeos-extratest@svirt-xen-hvm ( svirt )'
+conditional_schedule:
+    ntp_test_module:
+        VERSION:
+            15-SP2:
+                - console/ntp_client
+            12-SP5:
+                - console/ntp
 schedule:
   - installation/bootloader_svirt
   - jeos/grub2
@@ -20,7 +27,7 @@ schedule:
   - console/zypper_extend
   - console/check_os_release
   - console/timezone
-  - console/ntp
+  - {{ntp_test_module}}
   - console/sshd
   - console/update_alternatives
   - console/rpm

--- a/schedule/jeos/sle/xen/pv/jeos-extratest.yaml
+++ b/schedule/jeos/sle/xen/pv/jeos-extratest.yaml
@@ -1,6 +1,13 @@
 ---
 description: 'Extratest JeOS test suite. Maintainer: ccret.'
 name: 'jeos-extratest@svirt-xen-pv ( svirt )'
+conditional_schedule:
+    ntp_test_module:
+        VERSION:
+            15-SP2:
+                - console/ntp_client
+            12-SP5:
+                - console/ntp
 schedule:
   - installation/bootloader_svirt
   - jeos/firstrun
@@ -19,7 +26,7 @@ schedule:
   - console/zypper_extend
   - console/check_os_release
   - console/timezone
-  - console/ntp
+  - {{ntp_test_module}}
   - console/sshd
   - console/update_alternatives
   - console/rpm


### PR DESCRIPTION
- Related ticket: [[jeos] schedule ntp on sle12 only, opensuse and sle15 have to use ntp_client](https://progress.opensuse.org/issues/54905)
- Verification runs: 
   * 15sp2:
     * [jeos-extratest_kvm@64bit-virtio-vga](http://eris.suse.cz/tests/2425)
     * [jeos-extratest_hyperv@svirt-hyperv-uefi](http://eris.suse.cz/tests/2420)
     * [jeos-main_xenpv_image@svirt-xen-pv](http://eris.suse.cz/tests/2422#)
     * [jeos-extratest_xenhvm@svirt-xen-hvm](http://eris.suse.cz/tests/2421#)
   * 12sp5:
     * [jeos-extratest_kvm@64bit-virtio-vga](http://eris.suse.cz/tests/2424)
     * [jeos-extratest_xenhvm@svirt-xen-hvm](http://eris.suse.cz/tests/2418)
     * [jeos-extratest_xenpv@svirt-xen-pv](http://eris.suse.cz/tests/2427#)
     * [jeos-extratest_hyperv@svirt-hyperv-uefi](http://eris.suse.cz/tests/2426#)
