### PR TITLE
vagrant: add aarch64 Tumbleweed box test

### DIFF
--- a/schedule/vagrant.yaml
+++ b/schedule/vagrant.yaml
@@ -5,6 +5,11 @@ vars:
     QEMUCPU: host
 schedule:
   - boot/boot_to_desktop
-  - virtualization/vagrant/add_box_virtualbox
+  - {{add_box_virtualbox}}
   - virtualization/vagrant/add_box_libvirt
   - virtualization/vagrant/boxes/tumbleweed
+conditional_schedule:
+  add_box_virtualbox:
+    ARCH:
+      x86_64:
+        - virtualization/vagrant/add_box_virtualbox

--- a/tests/virtualization/vagrant/add_box_libvirt.pm
+++ b/tests/virtualization/vagrant/add_box_libvirt.pm
@@ -35,7 +35,8 @@ sub run() {
 
     assert_script_run('echo "test" > testfile');
 
-    assert_script_run('vagrant init centos/7');
+    # Available from https://app.vagrantup.com/opensuse
+    assert_script_run("vagrant init opensuse/Tumbleweed." . get_required_var('ARCH'));
 
     assert_script_run('vagrant up', timeout => 1200);
 

--- a/tests/virtualization/vagrant/boxes/tumbleweed.pm
+++ b/tests/virtualization/vagrant/boxes/tumbleweed.pm
@@ -23,11 +23,14 @@ use testapi;
 use utils;
 use vagrant;
 use File::Basename;
+use Utils::Architectures 'is_x86_64';
 
 
 sub run() {
+    my $is_virtualbox_applicable = is_x86_64();
+
     setup_vagrant_libvirt();
-    setup_vagrant_virtualbox();
+    setup_vagrant_virtualbox() if $is_virtualbox_applicable;
 
     select_console('root-console');
     zypper_call('in ansible');
@@ -41,9 +44,10 @@ sub run() {
 
     my %boxes = (
         # Tumbleweed.x86_64-1.0-{libvirt|virtualbox}-Snapshot20190704.vagrant.{libvirt|virtualbox}.box
-        libvirt    => "$version.$arch-1.0-libvirt-Snapshot$build.vagrant.libvirt.box",
-        virtualbox => "$version.$arch-1.0-virtualbox-Snapshot$build.vagrant.virtualbox.box"
+        libvirt => "$version.$arch-1.0-libvirt-Snapshot$build.vagrant.libvirt.box",
     );
+    # virtualbox is supported only on x86_64
+    %boxes = (%boxes, virtualbox => "$version.$arch-1.0-virtualbox-Snapshot$build.vagrant.virtualbox.box") if $is_virtualbox_applicable;
 
     my @providers = keys %boxes;
 


### PR DESCRIPTION
- Verification run: 
  * aarch64: https://openqa.opensuse.org/t1079639 (expected failure as there is no nested virt for aarch64 on o3). Will be ok on real hardware tests with openQA (e.g. on RPi4)
  * x86_64: https://openqa.opensuse.org/tests/1117188
