### PR TITLE
IB: grep for infiniband cards only

### DIFF
--- a/tests/kernel/mellanox_config.pm
+++ b/tests/kernel/mellanox_config.pm
@@ -44,7 +44,7 @@ sub run {
     # install dependencies
     zypper_call('--quiet in pciutils mstflint', timeout => 200);
 
-    my @devices = split(' ', script_output("lspci | grep -i mellanox |cut  -d ' ' -f 1"));
+    my @devices = split(' ', script_output("lspci | grep -i infiniband.*mellanox |cut  -d ' ' -f 1"));
 
     die "There is no Mellanox card here" if !@devices;
 


### PR DESCRIPTION
Some hardware available for IB tests includes Mellanox cards which
do not support IB, but Ethernet only and in such case the mstconfig
tool is failing while setting up LINK_TYPE_ protocol P1