### PR TITLE
Do not force mkfs.btrfs

### DIFF
--- a/tests/console/btrfs_qgroups.pm
+++ b/tests/console/btrfs_qgroups.pm
@@ -37,7 +37,11 @@ sub run {
     assert_script_run "mkdir $dest";
     $self->set_playground_disk;
     my $disk = get_required_var('PLAYGROUNDDISK');
-    assert_script_run "mkfs.btrfs -f $disk && mount $disk $dest && cd $dest";
+
+    # forcing mkfs.btrfs yields no warning in case we are creating fs over drive with partitions
+    $self->cleanup_partition_table if (script_run "mkfs.btrfs $disk && mount $disk $dest && cd $dest");
+
+    assert_script_run "mkfs.btrfs $disk && mount $disk $dest && cd $dest";
     assert_script_run "btrfs quota enable .";
 
     # Create subvolumes, qgroups, assigns and limits


### PR DESCRIPTION
- Related ticket: [[jeos][sle15sp2] test fails in btrfs_qgroups - /dev/sd[ab] device or resource is busy](https://progress.opensuse.org/issues/59181)
- Verification runs: 
  * [sle-15-SP2-JeOS-for-MS-HyperV-x86_64-Build2.57-jeos-filesystem_hyperv@svirt-hyperv](http://eris.suse.cz/tests/2430#step/btrfs_qgroups/9)
  * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build2.57-jeos-filesystem@64bit-virtio-vga]()
  * [sle-12-SP5-JeOS-for-kvm-and-xen-x86_64-Build4.128-jeos-filesystem@uefi-virtio-vga]()
