### PR TITLE
Disable firewall for LTP network tests

### DIFF
--- a/tests/kernel/install_ltp.pm
+++ b/tests/kernel/install_ltp.pm
@@ -28,6 +28,7 @@ use serial_terminal 'add_serial_console';
 use upload_system_log;
 use version_utils qw(is_jeos is_opensuse is_released is_sle);
 use Utils::Architectures qw(is_aarch64 is_ppc64le is_s390x is_x86_64);
+use Utils::Systemd qw(systemctl disable_and_stop_service);
 
 sub add_we_repo_if_available {
     # opensuse doesn't have extensions
@@ -283,6 +284,8 @@ sub setup_network {
             script_run("rc$service start");
         }
     }
+
+    disable_and_stop_service(opensusebasetest::firewall);
 }
 
 sub run {


### PR DESCRIPTION
boot_ltp clears all firewall rules from iptables for network tests but the firewall demon seems to load them back in after a while. This breaks some network tests.

- Related ticket: https://progress.opensuse.org/issues/38345
- Needles: N/A
- Verification runs:
  - 12SP1: https://openqa.suse.de/tests/3568322
  - 15GA: https://openqa.suse.de/tests/3568323