### PR TITLE
LTP: Use wicked workaround only when needed

### DIFF
--- a/tests/kernel/boot_ltp.pm
+++ b/tests/kernel/boot_ltp.pm
@@ -126,11 +126,6 @@ done
 EOF
         script_output($conf_nic_script);
 
-        # dhclient requires no wicked service not only running but also disabled
-        script_run(
-            'systemctl --no-pager -p Id show network.service | grep -q Id=wicked.service && { export ENABLE_WICKED=1; systemctl disable wicked; }'
-        );
-
         # emulate $LTPROOT/testscripts/network.sh
         assert_script_run('curl ' . data_url("ltp/net.sh") . ' -o net.sh', 60);
         assert_script_run('chmod 755 net.sh');

--- a/tests/kernel/shutdown_ltp.pm
+++ b/tests/kernel/shutdown_ltp.pm
@@ -41,7 +41,6 @@ sub run {
         upload_logs($ver_linux_log, failok => 1);
     }
 
-    script_run('[ "$ENABLE_WICKED" ] && systemctl enable wicked');
     upload_system_logs();
 
     power_action('poweroff');


### PR DESCRIPTION
LTP: Remove wicked workaround

This workaround has been lately moved to LTP as f5b28dbb0 ("net/dhcp:
Add support for wicked"), released in 20190115. Now it's not needed
(there have been 2 more LTP releases, so even QAM which uses stable LTP
release have this commit in LTP).

And this fix wasn't needed anyway. Original solution tests
dhclient-script from upstream - from dhcpd from ISC (besides
testing dhcpd from ISC and dnsmasq on IPv6). But we realized, that for
wicked users it's better actually test wicked client instead of dhclient
(as this is, what is actually used). That's why it was fixed in LTP
58f21cc86 ("net/dhcp: Don't start dhclient when wicked is running"),
thus no need to stop wicked during testing any more.

BTW testing dhclient found a bug bsc#1132280 (fixed in upstream [1]).
This was fixed just for wicked (on both SLE and openSUSE), because
that's what affects users. Fix for dhcp waits for updating the package.

Verification run (note failures are caused by still not fixed wicked, despite claiming it is in bsc#1132280)
- http://quasar.suse.cz/tests/3959
- http://quasar.suse.cz/tests/3960
- http://quasar.suse.cz/tests/3961

[1] https://source.isc.org/cgi-bin/gitweb.cgi?p=dhcp.git;a=commitdiff;h=140612c8cb51825fdf9e5723afb78c997117ab2c;hp=c2e5ee2882d6d9dba5e7227d432552a3ab75b9e2