### PR TITLE
Adjust addon_products_sle to workaround Full Flavor

### DIFF
--- a/lib/main_common.pm
+++ b/lib/main_common.pm
@@ -863,7 +863,7 @@ sub load_inst_tests {
     }
     if (is_sle) {
         loadtest 'installation/network_configuration' if get_var('NETWORK_CONFIGURATION');
-        loadtest "installation/scc_registration";
+        loadtest "installation/scc_registration" unless check_var('FLAVOR', 'Full');
         if (is_sles4sap and is_sle('<15') and !is_upgrade()) {
             loadtest "installation/sles4sap_product_installation_mode";
         }

--- a/schedule/yast/skip_registration/offline_install+skip_registration.yaml
+++ b/schedule/yast/skip_registration/offline_install+skip_registration.yaml
@@ -1,0 +1,26 @@
+---
+name:           offline_install+skip_registration
+description:    >
+  Offline installation. Skipping registration for SLE 15, as requires network connection.
+  This is default behavior for SLE 12.
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/network_configuration
+  - installation/addon_products_sle
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot

--- a/schedule/yast/skip_registration/releasenotes_origin+unregistered.yaml
+++ b/schedule/yast/skip_registration/releasenotes_origin+unregistered.yaml
@@ -1,0 +1,20 @@
+---
+name:           releasenotes_origin+unregistered
+description:    >
+  Test fate#323273 - Check the origin (rpm or url) of the showed release notes.
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/addon_products_sle
+  - installation/releasenotes_origin
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install

--- a/schedule/yast/skip_registration/skip_registration.yaml
+++ b/schedule/yast/skip_registration/skip_registration.yaml
@@ -1,0 +1,35 @@
+---
+name:           skip_registration
+description:    >
+  Like a standard scenario with explicit skipping of SCC registration
+  in case where we register by default, e.g. for SLE >= 15
+  See https://progress.opensuse.org/issues/25264 for details.
+
+schedule:
+  - installation/bootloader_start
+  - installation/welcome
+  - installation/accept_license
+  - installation/addon_products_sle
+  - installation/system_role
+  - installation/partitioning
+  - installation/partitioning_finish
+  - installation/installer_timezone
+  - installation/hostname_inst
+  - installation/user_settings
+  - installation/user_settings_root
+  - installation/resolve_dependency_issues
+  - installation/installation_overview
+  - installation/disable_grub_timeout
+  - installation/start_install
+  - installation/await_install
+  - installation/logs_from_installation_system
+  - installation/reboot_after_installation
+  - installation/grub_test
+  - installation/first_boot
+  - console/sle15_workarounds
+  - console/hostname
+  - console/system_prepare
+  - console/force_scheduled_tasks
+  - shutdown/grub_set_bootargs
+  - shutdown/cleanup_before_shutdown
+  - shutdown/shutdown


### PR DESCRIPTION
- create schedulers and remove scc_registration
- throw a soft_failure for bsc#1156568
- no handling for second betawarning, leaving to fail

ADDONS=all-packages should be set for that group of test suites

- Related ticket: https://progress.opensuse.org/issues/58691
- Needles: 
- Verification run: 
[releasenotes_origin+unregistered@64bit](http://aquarius.suse.cz/tests/880)
[offline_install+skip_registration@64bit](http://aquarius.suse.cz/tests/879)
[skip_registration@64bit](http://aquarius.suse.cz/tests/876)