### PR TITLE
Revert "Use get_available_compression and prefer .xz compression"

### DIFF
--- a/lib/opensusebasetest.pm
+++ b/lib/opensusebasetest.pm
@@ -12,7 +12,6 @@ use version_utils qw(is_sle is_leap is_upgrade is_aarch64_uefi_boot_hdd is_tumbl
 use main_common 'opensuse_welcome_applicable';
 use isotovideo;
 use IO::Socket::INET;
-use y2_logs_helper 'get_available_compression';
 
 # Base class for all openSUSE tests
 
@@ -418,8 +417,9 @@ sub export_logs {
     $self->save_and_upload_log('systemctl status',          '/tmp/systemctl_status.log');
     $self->save_and_upload_log('systemctl',                 '/tmp/systemctl.log', {screenshot => 1});
 
-    script_run "save_y2logs /tmp/y2logs_clone.tar" . get_available_compression;
-    upload_logs "/tmp/y2logs_clone.tar" . get_available_compression;
+    my $compression = is_sle('=12-sp1') ? 'bz2' : 'xz';
+    script_run "save_y2logs /tmp/y2logs_clone.tar.$compression";
+    upload_logs "/tmp/y2logs_clone.tar.$compression";
     $self->investigate_yast2_failure();
 }
 

--- a/lib/qam.pm
+++ b/lib/qam.pm
@@ -18,7 +18,7 @@ use Exporter;
 use testapi;
 use utils;
 use List::Util 'max';
-use y2_logs_helper 'get_available_compression';
+use version_utils 'is_sle';
 
 our @EXPORT
   = qw(capture_state check_automounter is_patch_needed add_test_repositories ssh_add_test_repositories remove_test_repositories advance_installer_window get_patches check_patch_variables);
@@ -29,8 +29,9 @@ use constant ZYPPER_STATUS_COL  => 5;
 sub capture_state {
     my ($state, $y2logs) = @_;
     if ($y2logs) {    #save y2logs if needed
-        assert_script_run "save_y2logs /tmp/y2logs_$state.tar" . get_available_compression;
-        upload_logs "/tmp/y2logs_$state.tar" . get_available_compression;
+        my $compression = is_sle('=12-sp1') ? 'bz2' : 'xz';
+        assert_script_run "save_y2logs /tmp/y2logs_$state.tar.$compression";
+        upload_logs "/tmp/y2logs_$state.tar.$compression";
         save_screenshot();
     }
     #upload ip status

--- a/lib/y2_logs_helper.pm
+++ b/lib/y2_logs_helper.pm
@@ -114,9 +114,9 @@ sub verify_license_translations {
     }
 }
 
-sub get_available_compression {    # prefer .xz compression
+sub get_available_compression {
     my %extensions = (bzip2 => '.bz2', gzip => '.gz', xz => '.xz');
-    foreach my $binary (reverse sort keys %extensions) {
+    foreach my $binary (sort keys %extensions) {
         return $extensions{$binary} unless script_run("type $binary");
     }
     return "";


### PR DESCRIPTION
Use the previous way, bz2 compression on 12sp1

Reverts os-autoinst/os-autoinst-distri-opensuse#8838