### PR TITLE
Fix regression caused by #8867

### DIFF
--- a/lib/btrfs_test.pm
+++ b/lib/btrfs_test.pm
@@ -1,10 +1,12 @@
 package btrfs_test;
 use base 'consoletest';
-
 use strict;
 use warnings;
 use testapi;
 use utils 'get_root_console_tty';
+use Exporter 'import';
+
+our @EXPORT_OK = qw(set_playground_disk cleanup_partition_table);
 
 =head2 set_playground_disk
 
@@ -24,7 +26,7 @@ sub set_playground_disk {
         assert_script_run 'parted --script --machine -l';
         my $output = script_output 'parted --script --machine -l';
         # Parse playground disk
-        $output =~ m|(?<disk>/dev/$vd[ab]):.*unknown.*| || die "Failed to parse playground disk, got following output:\n$output";
+        $output =~ m|(?<disk>/dev/$vd[bc]):.*unknown.*| || die "Failed to parse playground disk, got following output:\n$output";
         set_var('PLAYGROUNDDISK', $+{disk});
     }
 }

--- a/schedule/jeos/sle/hyperv/jeos-filesystem.yaml
+++ b/schedule/jeos/sle/hyperv/jeos-filesystem.yaml
@@ -24,4 +24,3 @@ schedule:
   - console/btrfs_send_receive
   - console/snapper_undochange
   - console/snapper_create
-  - console/coredump_collect

--- a/tests/console/btrfs_qgroups.pm
+++ b/tests/console/btrfs_qgroups.pm
@@ -39,9 +39,11 @@ sub run {
     my $disk = get_required_var('PLAYGROUNDDISK');
 
     # forcing mkfs.btrfs yields no warning in case we are creating fs over drive with partitions
-    $self->cleanup_partition_table if (script_run "mkfs.btrfs $disk && mount $disk $dest && cd $dest");
+    if (script_run "mkfs.btrfs $disk && mount $disk $dest && cd $dest") {
+        $self->cleanup_partition_table;
+        assert_script_run "mkfs.btrfs $disk && mount $disk $dest && cd $dest", fail_message => 'Failed to create FS on the second attempt!';
+    }
 
-    assert_script_run "mkfs.btrfs $disk && mount $disk $dest && cd $dest";
     assert_script_run "btrfs quota enable .";
 
     # Create subvolumes, qgroups, assigns and limits

--- a/tests/console/lvm.pm
+++ b/tests/console/lvm.pm
@@ -39,23 +39,7 @@ use warnings;
 use testapi;
 use version_utils;
 use utils 'zypper_call';
-
-sub set_playground_disk {
-    # TODO check which vda is unpartitioned and use that one
-    unless (get_var('PLAYGROUNDDISK')) {
-        my $vd = 'vd';    # KVM
-        if (check_var('VIRSH_VMM_FAMILY', 'xen')) {
-            $vd = 'xvd';
-        }
-        elsif (check_var('VIRSH_VMM_FAMILY', 'hyperv') or check_var('VIRSH_VMM_FAMILY', 'vmware')) {
-            $vd = 'sd';
-        }
-        assert_script_run 'parted --script --machine -l';
-        my $unpartitioned_device = script_output("parted --script --machine -l 2>/dev/null | grep unknown | cut -f1 -d':' | grep /dev/$vd");
-        validate_script_output("echo $unpartitioned_device", sub { /\/dev\/$vd[ab]/ });
-        set_var('PLAYGROUNDDISK', $unpartitioned_device);
-    }
-}
+use btrfs_test 'set_playground_disk';
 
 sub run {
     my ($self) = @_;


### PR DESCRIPTION
- Related ticket: [[jeos][sle15sp2] test fails in btrfs_qgroups - /dev/sd[ab] device or resource is busy](https://progress.opensuse.org/issues/59181)
- Verification runs: 
   * [sle-12-SP5-JeOS-for-kvm-and-xen-x86_64-Build4.128-jeos-filesystem@uefi-virtio-vga](http://eris.suse.cz/tests/2466)
   * [sle-15-SP2-JeOS-for-MS-HyperV-x86_64-Build2.57-jeos-filesystem_hyperv@svirt-hyperv](http://eris.suse.cz/tests/2467#)
   * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build2.57-jeos-filesystem@64bit-virtio-vga](http://eris.suse.cz/tests/2468)
   * [sle-15-SP2-JeOS-for-kvm-and-xen-x86_64-Build2.57-jeos-filesystem@64bit-virtio-vga](http://eris.suse.cz/tests/2469)
   * [opensuse-Tumbleweed-DVD-x86_64-Build20191106-extra_tests_filesystem@64bit](http://eris.suse.cz/tests/2465#)
