### PR TITLE
Introduce test suite option ENABLE_HOTPLUGGING to enbale/disable hotplugging test module

### DIFF
--- a/products/sle/main.pm
+++ b/products/sle/main.pm
@@ -802,7 +802,7 @@ elsif (get_var("VIRT_AUTOTEST")) {
         if (!(get_var("GUEST_PATTERN") =~ /win/img) && is_x86_64) {
             loadtest "virt_autotest/setup_dns_service";
             loadtest "virt_autotest/set_config_as_glue";
-            loadtest "virtualization/xen/hotplugging";
+            loadtest "virtualization/xen/hotplugging" if get_var("ENABLE_HOTPLUGGING");
             loadtest "virt_autotest/virsh_internal_snapshot";
             loadtest "virt_autotest/virsh_external_snapshot";
         }


### PR DESCRIPTION
The tests/virtualization/xen/hotlpugging test module needs more debugging and investigating work to validate its effectivenees and other aspects around hotplug stuff. So introducing test suite level option ENABLE_HOTPLUGGING to enable or disable it more freely.

- Related ticket: 
  - https://openqa.suse.de/tests/3569906#step/hotplugging/53
  - https://openqa.suse.de/tests/3569863#step/hotplugging/63
- Needles: n/a
- Verification run: https://10.67.19.99/tests/556
