### PR TITLE
Implement YAML_TEST_DATA in declarative scheduler

### DIFF
--- a/t/02_yaml_schedule.t
+++ b/t/02_yaml_schedule.t
@@ -41,4 +41,17 @@ subtest 'do_not_allow_nested_imports' => sub {
     dies_ok { scheduler::parse_test_data($schedule) } "Error: test_data can only be defined in a dedicated file for data\n";
 };
 
+subtest 'parse_yaml_test_data_using_yaml_data_setting' => sub {
+    use scheduler;
+    use testapi 'set_var';
+
+    set_var('YAML_TEST_DATA', 't/data/test_data_yaml_data_setting.yaml');
+    # compare versions if possible
+    my $schedule = YAML::Tiny::LoadFile(dirname(__FILE__) . '/data/test_schedule_yaml_data_setting.yaml');
+    scheduler::parse_test_data($schedule);
+    my $testdata = scheduler::get_test_data();
+    ok $testdata->{test_in_yaml_data} eq 'test_in_yaml_data',               "Value from data file was overwritten by value from schedule or other imports";
+    ok $testdata->{test_in_yaml_import_3} eq 'test_in_yaml_import_value_3', "Value in data file was overwritten by value in schedule file";
+};
+
 done_testing;

--- a/t/data/test_data_3.yaml
+++ b/t/data/test_data_3.yaml
@@ -1,0 +1,2 @@
+test_in_yaml_data: test_in_yaml_import_value_3
+test_in_yaml_import_3: test_in_yaml_import_value_3

--- a/t/data/test_data_yaml_data_setting.yaml
+++ b/t/data/test_data_yaml_data_setting.yaml
@@ -1,0 +1,2 @@
+test_in_yaml_data: test_in_yaml_data
+!include: t/data/test_data_3.yaml

--- a/t/data/test_schedule_yaml_data_setting.yaml
+++ b/t/data/test_schedule_yaml_data_setting.yaml
@@ -1,0 +1,3 @@
+test_data:
+    test_in_yaml_data: test_in_yaml_schedule_value
+    test_in_yaml_import_3: test_in_yaml_schedule_value

--- a/variables.md
+++ b/variables.md
@@ -132,6 +132,7 @@ UNENCRYPTED_BOOT | boolean | false | Indicates/defines existence of unencrypted 
 WAYLAND | boolean | false | Enables wayland tests in the system.
 XDMUSED | boolean | false | Indicates availability of xdm.
 YAML_SCHEDULE | string | | Defines yaml file containing test suite schedule.
+YAML_TEST_DATA | string | | Defines yaml file containing test data.
 YAST2_FIRSTBOOT_USERNAME | string | | Defines username for the user to be created with YaST Firstboot
 ZDUP | boolean | false | Prescribes zypper dup scenario.
 ZDUPREPOS | string | | Comma separated list of repositories to be added/used for zypper dup call, defaults to SUSEMIRROR or attached media, e.g. ISO.


### PR DESCRIPTION
#### Related ticket: 
https://progress.opensuse.org/issues/59139
#### Description:
Implement `YAML_TEST_DATA` in declarative scheduler. When `YAML_TEST_DATA` is used we can have different combinations:
- Completely different data for the same test suite: test suite without `test_data` section + simple data file.
- Different data for the same test suite but still share some data in the test suite: test suite with `test_data` section + data file.
- Different data for the same test suite but still share some data in the test suite, which in turn it is shared with another test suite: test suite with `test_data` section containing `!include` tags (in different formats, list of `!includes` or only one, mixed with data or not) + data file.
- Different data for the same test suite which are shared with other scenarios, but still share some data in the test suite, which in turn it is shared with another test suites: test suite with `test_data` section containing `!include` tags (in different formats, list of `!includes` or only one, mixed with data or not) + data file containing `!include` tags.

Sometimes test data are more linked to a particular schedule and sometimes to other test data shared with other test suites. This enhancement give us the flexibility to avoid duplicate schedule files just because they have different data and due to we will be pointing to a test data file and at the moment we don't want to implement a recursive approach, we enable only for this case the possibility to use `!include` functionality in test data file, not cutting any path for the tester.