### PR TITLE
Ensure sssd tests upload logs on failure

### DIFF
--- a/tests/sysauth/sssd.pm
+++ b/tests/sysauth/sssd.pm
@@ -22,7 +22,7 @@
 # testsuite", "junit success", "junit endsuite", otherwise record as failure
 # Maintainer: HouzuoGuo <guohouzuo@gmail.com>
 
-use base "opensusebasetest";
+use base "consoletest";
 
 use strict;
 use warnings;


### PR DESCRIPTION
opensusebasetest doesn't seem to collect also, logs from the SUT (like dmesg et al) for some reason. since this is basically a console test, using `consoletest` as base should be more than enough for sssd. In this cases, having those logs available, would help a lot when facing situations where a program is segfaulting. At some point working again on #6815 should be considered.

* Verification run: http://phobos.suse.de/tests/1748127
* related bug: https://bugzilla.suse.com/show_bug.cgi?id=1156306
* related progress ticket: https://progress.opensuse.org/issues/57215