### PR TITLE
openqa: Fix missing qemu dependencies since change in os-autoinst deps

### DIFF
--- a/tests/openqa/install/openqa_bootstrap.pm
+++ b/tests/openqa/install/openqa_bootstrap.pm
@@ -24,7 +24,9 @@ sub run {
         record_info('No nested virt', 'No /dev/kvm found');
     }
 
-    zypper_call('in openQA-bootstrap');
+    # install qemu tools as we want to test using qemu and the bootstrap skips
+    # the "recommends"
+    zypper_call('in openQA-bootstrap qemu-tools');
     assert_script_run('/usr/share/openqa/script/openqa-bootstrap', 4000);
 }
 


### PR DESCRIPTION
Verification run: https://openqa.opensuse.org/tests/1080096

Related progress issue: https://progress.opensuse.org/issues/57014